### PR TITLE
Update .gitignore to keep unwanted files out of the repo

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,7 +4,7 @@ TAGS
 .make.state
 .nse_depinfo
 *~
-#*
+\#*
 .#*
 ,*
 _$*
@@ -27,3 +27,9 @@ _$*
 core
 # CVS default ignores end
 notes
+build/
+run/
+# OSX system files
+.DS_store
+/doc/_build/
+*.pyc


### PR DESCRIPTION
This causes git to ignore build and run directories, OSX system files, and .pyc files by default. Also the `#` was being interpreted as a comment.