### PR TITLE
Add issue and PR templates

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,0 +1,31 @@
+**Note: for general support questions, please use the mailing list mitgcm-support@mitgcm.org**. This repository's issues are intended for feature requests and bug reports.
+
+## I'm submitting a ... 
+  - [ ] bug report
+  - [ ] feature request
+  - [ ] support request => Please do not submit support request here, see note at the top of this template.
+
+
+## Do you want to request a *feature* or report a *bug*?
+
+
+## What is the current behaviour?
+
+
+**Feature requests**
+## What is the desired behaviour?
+
+
+**Bug reports**
+## Describe the steps to reproduce and if possible a minimal demo of the problem
+
+
+## What is the expected behaviour?
+
+
+## Please tell us about your environment:
+(e.g. HPC environment, compilers, model version, etc.)
+
+
+### Other information
+ (e.g. detailed explanation, stacktraces, related issues, suggestions how to fix, links for us to have context, eg. stackoverflow, gitter, etc)

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,27 @@
+## Please check that the PR fulfils our requirements
+- [ ] The commit message follows our guidelines
+- [ ] Tests for the changes have been added (for bug fixes / features)
+- [ ] Docs have been added / updated (for bug fixes / features)
+
+
+## What changes does this PR introduce?
+(Bug fix, feature, docs update, ...)
+
+
+
+## What is the current behaviour? 
+(You can also link to an open issue here)
+
+
+
+## What is the new behaviour 
+(if this is a feature change)?
+
+
+
+## Does this PR introduce a breaking change? 
+(What changes might users need to make in their application due to this PR?)
+
+
+
+## Other information:


### PR DESCRIPTION
Add templates that will automatically appear in the editing window whenever someone opens an issue or a pull request.

This means that we can gently steer people towards providing the information we want, rather than having to ask for it every time.

These templates were adapted from https://github.com/stevemao/github-issue-templates/tree/master/conversational