### PR TITLE
Build html and latex docs on Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,7 @@ services:
  - docker
  
 before_install:
+ #  Set up environment needed for Sphinx to build docs
  - sudo apt-get install texlive-latex-recommended
  - sudo apt-get install texlive-latex-extra
  - sudo apt-get install texlive-fonts-recommended
@@ -12,6 +13,7 @@ before_install:
  - pip install sphinx
  - pip install sphinx_rtd_theme
  - pip install sphinxcontrib-bibtex
+ # Set up environment needed to run testreport code tests
  - docker pull mitgcm/testreport-images:fc11-base-20170715
  - docker run  -v `pwd`:/MITgcm --name fc11-testreport -t -d mitgcm/testreport-images:fc11-base-20170715 /bin/bash
  - docker exec -i fc11-testreport rpm -vv --rebuilddb

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,17 @@
 # Travis file for running some basic set of testreport checks on each commit
+language: python
+
 services: 
  - docker
  
 before_install:
+ - sudo apt-get install texlive-latex-recommended
+ - sudo apt-get install texlive-latex-extra
+ - sudo apt-get install texlive-fonts-recommended
+ - sudo apt-get install latexmk
+ - pip install sphinx
+ - pip install sphinx_rtd_theme
+ - pip install sphinxcontrib-bibtex
  - docker pull mitgcm/testreport-images:fc11-base-20170715
  - docker run  -v `pwd`:/MITgcm --name fc11-testreport -t -d mitgcm/testreport-images:fc11-base-20170715 /bin/bash
  - docker exec -i fc11-testreport rpm -vv --rebuilddb
@@ -31,3 +40,7 @@ script:
  - MITGCM_EXP="tutorial_plume_on_slope";    MITGCM_PRECS="16";             . tools/ci/runtr.sh
  # Generate a summary
  - docker exec -i fc11-testreport bash -c "cd /MITgcm/verification; ./testreport ${MITGCM_TROPT} -q"
+ # build documentation
+ - cd doc
+ - make clean html
+ - make clean latexpdf


### PR DESCRIPTION
## What changes does this PR introduce?
This PR makes Travis-CI build latexpdf and html versions of the docs. This increases the Travis runtime by about 3 minutes, since it requires installing TeX, which takes a while. Furthermore, the latexpdf build is very verbose, which means the log is now much longer. I've made the doc tests the final commands, so we won't need to wade through this output very often.

## What is the current behaviour? 
Currently the documentation does not get tested automatically.

## Other information:
There is another option for testing the docs; Sphinx has an inbuilt test
`sphinx-build -nWT -b dummy . _build/html`
However, this doesn't catch things like nested tables, since they are legitimate Sphinx syntax but break the latexpdf build. It can however be configured to throw errors instead of warnings, which might be useful in the future, if we decide to purge the bits that currently generate warnings.