### PR TITLE
Remove file: TSMo3.v02.gra from list of files to link (inexistent file).

### DIFF
--- a/verification/fizhi-gridalt-hs/input/prepare_run
+++ b/verification/fizhi-gridalt-hs/input/prepare_run
@@ -4,18 +4,18 @@
 #- from this dir:
 fromDir="../../fizhi-cs-32x32x40/input"
 
-fileList=`( cd $fromDir ; ls data.gcmo3 TSMo3.v02.gra dxC1_dXYa.face00?.bin )`
+fileList=`( cd $fromDir ; ls data.gcmo3 dxC1_dXYa.face00?.bin )`
 
 #echo 'fileList=' $fileList
 
-#- and do a symbolic link in the current directory 
+#- and do a symbolic link in the current directory
 #   (if the file does not already exist)
 if test -d $fromDir ; then
   lnkList='files:'
   for xx in $fileList
   do
-    if test -r ${fromDir}/$xx ; then 
-      if test ! -r $xx ; then 
+    if test -r ${fromDir}/$xx ; then
+      if test ! -r $xx ; then
         lnkList=${lnkList}" "$xx
         ln -sf ${fromDir}/$xx .
       fi


### PR DESCRIPTION
- This file was rever used by any fizhi experiment
- On dec 26, 2011, file TSMo3.v02.gra was removed from: fizhi-cs-32x32x40/input
- got removed from prepare_run of other fizhi experiment:fizhi-cs-aqualev20
  few months later (2012-03-11) but forgot to remove it from this prepare_run.

## Please check that the PR fulfils our requirements
- [x] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## What changes does this PR introduce?
minor bug fix that was triggering a harmless error message
when running this experiment.

## What is the current behaviour?
(You can also link to an open issue here)

## What is the new behaviour ?
running  experiment: fizhi-gridalt-hs is now cleaner 

## Does this PR introduce a breaking change? 
No

## Other information: