### PR TITLE
Fix #18: Manual: Multiple use of label ```here``` in doc.

### DIFF
--- a/doc/contributing/contributing.rst
+++ b/doc/contributing/contributing.rst
@@ -300,6 +300,10 @@ Other embedded links
 **Hyperlinks:** to reference a (clickable) URL, simply enter the full URL. If you want to have a different,
 clickable text link instead of displaying the full URL, the syntax
 is ```clickable_text <URL>`_``  (the ‘<’ and ‘>’ are literal characters, and note the trailing underscore). 
+For this kind of link, the clickable text has to be unique for each URL.  If
+you would like to use a non-unique text (like ‘click here’), you should use
+an ‘anonymous reference’ with a double trailing underscore:
+```clickable_text <URL>`__``.
 
 **File references:** to create a link to pull up MITgcm code (or any file in the repo) in a code browser window, the syntax is ``:filelink:`path/filename```.
 If you want to have a different text link to click on (e.g., say you didn’t want to display the full path), the syntax is ``:filelink:`clickable_text <path/filename>```

--- a/doc/contributing/contributing.rst
+++ b/doc/contributing/contributing.rst
@@ -255,8 +255,8 @@ Contributing to the manual
 
 Whether you are simply correcting typos or describing undocumented packages, we welcome all contributions to the manual. The following information will help you make sure that your contribution is consistent with the style of the MITgcm documentation. (We know that not all of the current documentation follows these guidelines - we're working on it)
 
-The manual is written in **rst** format, which is short for ReStructuredText directives. rst offers many wonderful features: it automatically does much of the formatting for you, it is reasonably well documented on the web (e.g. primers available `here <http://www.sphinx-doc.org/en/stable/rest.html>`_ and
-`here <http://docutils.sourceforge.net/docs/user/rst/quickref.html>`_), it can accept raw latex syntax and track equation labelling for you, in addition to numerous other useful features. On the down side however, it can be very fussy about formatting, requiring exact spacing and indenting, and seemingly innocuous things such as blank spaces at ends of lines can wreak havoc. We suggest looking at the existing rst files in the manual to see exactly how something is formatted, along with the syntax guidelines specified in this section, prior to writing and formatting your own manual text.
+The manual is written in **rst** format, which is short for ReStructuredText directives. rst offers many wonderful features: it automatically does much of the formatting for you, it is reasonably well documented on the web (e.g. primers available `here <http://www.sphinx-doc.org/en/stable/rest.html>`__ and
+`here <http://docutils.sourceforge.net/docs/user/rst/quickref.html>`__), it can accept raw latex syntax and track equation labelling for you, in addition to numerous other useful features. On the down side however, it can be very fussy about formatting, requiring exact spacing and indenting, and seemingly innocuous things such as blank spaces at ends of lines can wreak havoc. We suggest looking at the existing rst files in the manual to see exactly how something is formatted, along with the syntax guidelines specified in this section, prior to writing and formatting your own manual text.
 
 The manual can be viewed either of two ways: interactively (i.e., web-based), as hosted by read-the-docs (https://readthedocs.org/),
 requiring an html format build, or downloaded as a pdf file. 
@@ -351,7 +351,7 @@ off each manual chapter subdirectory.
 The wild-card is used here so that different file formats can be used in the build process.
 For vector graphic images, save a ``pdf`` for the pdf build plus a ``svg`` file for the html build. 
 For bitmapped images, ``gif``, ``png``, or ``jpeg`` formats can be used for both builds, no wild-card necessary
-(see `here <http://www.sphinx-doc.org/en/stable/builders.html>`_ for more info
+(see `here <http://www.sphinx-doc.org/en/stable/builders.html>`__ for more info
 on compatible formats).
 
 ``:width:``:  used to scale the size of the figure, here specified as 80% scaling factor

--- a/doc/getting_started/getting_started.rst
+++ b/doc/getting_started/getting_started.rst
@@ -26,9 +26,9 @@ Where to find information
 There is a web-archived support mailing list for the model that you can
 email at MITgcm-support@mitgcm.org once you have subscribed.
 
-To sign up (subscribe) for the mailing list (highly recommended), click `here <http://mailman.mitgcm.org/mailman/listinfo/mitgcm-support/>`_ 
+To sign up (subscribe) for the mailing list (highly recommended), click `here <http://mailman.mitgcm.org/mailman/listinfo/mitgcm-support/>`__
 
-To browse through the support archive, click `here <http://mailman.mitgcm.org/pipermail/mitgcm-support/>`_
+To browse through the support archive, click `here <http://mailman.mitgcm.org/pipermail/mitgcm-support/>`__
 
 
 Obtaining the code


### PR DESCRIPTION
## Please check that the PR fulfils our requirements
- [x] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
       - Sphinx already warns about these.
- [x] Docs have been added / updated (for bug fixes / features)

## What changes does this PR introduce?
Bug fix

## What is the current behaviour? 
The html build warns about "Duplicate explicit target names".

## What is the new behaviour 
No more warnings.

## Does this PR introduce a breaking change? 
No.

## Other information:
The "named references" causing the problem are replaced by "anonymous references" which do not require unique explicit target names.  See comments in #18.