### PR TITLE
Set default highlight language to 'none'

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -103,6 +103,9 @@ language = None
 # This patterns also effect to html_static_path and html_extra_path
 exclude_patterns = ['_build', 'Thumbs.db', '.DS_Store']
 
+# Do not highlight code blocks unless a language is specified explicitly.
+highlight_language = 'none'
+
 # The name of the Pygments (syntax highlighting) style to use.
 pygments_style = 'sphinx'
 


### PR DESCRIPTION
## Please check that the PR fulfils our requirements
- [x] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## What changes does this PR introduce?
Bug fix

## What is the current behaviour? 
Literal blocks are highlighted for python, which is not appropriate for most of the blocks we have.

## What is the new behaviour 
Literal blocks are only highlighted if a language is specified explicitly.

## Does this PR introduce a breaking change? 
No.

## Other information: