### PR TITLE
Build docs under different versions of python

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -75,7 +75,17 @@ jobs:
     - stage: test documentation
       env: 
       - BUILD="html"
+      python: "2.7"
+      script: cd doc; make clean ${BUILD}
+    - env:
+      - BUILD="html"
+      python: "3.6"
       script: cd doc; make clean ${BUILD}
     - env:
       - BUILD="latexpdf"
+      python: "2.7"
+      script: cd doc; make clean ${BUILD}
+    - env:
+      - BUILD="latexpdf"
+      python: "3.6"
       script: cd doc; make clean ${BUILD}

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -60,31 +60,27 @@ author = u'Alistair Adcroft, Jean-Michel Campin, Ed Doddridge, Stephanie Dutkiew
 # built documents.
 #
 
-from subprocess import Popen, PIPE
+from subprocess import check_output, CalledProcessError
 
 def get_version():
     """
-    Returns project version as string from 'git describe' command.
-    
-    Slightly modified from:
-    http://dreamiurg.net/2011/10/03/using-git-to-get-version-information/
+    Return the latest tag (checkpoint) and, if there have
+    been commits since the version was tagged, the commit hash.
 
     To get just the release tag use:
     version = version.split('-')[0]
     """
 
-    pipe = Popen('git describe --tags --always', stdout=PIPE, shell=True)
-    version = pipe.stdout.read()
+    try:
+        version = check_output(['git', 'describe', '--tags', '--always'],
+                               universal_newlines=True)
+    except CalledProcessError:
+        return 'unknown version'
 
-    if version:
-        return version
-    else:
-        return 'X.Y'
+    return version.rstrip()
 
-# The full version, including alpha/beta/rc tags and, if there have 
-# been commits since the version was tagged, the commit hash.
 # "version" is used for html build
-version = get_version().lstrip('v').rstrip()
+version = get_version()
 # "release" is used for LaTeX build
 release = version
 


### PR DESCRIPTION
## Please check that the PR fulfils our requirements
- [x] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## What changes does this PR introduce?
Make Travis build the documentation with Python versions 2.7 and 3.6. 

## What is the current behaviour? 
The docs are only tested under Python 2.7.

## Other information:
Currently, the docs build fails under Python 3.X because of the `get_version` function. @jahn has a fix and will add it to this PR.