### PR TITLE
more robust cleaning stage

### DIFF
--- a/tools/tst_2+2
+++ b/tools/tst_2+2
@@ -451,8 +451,8 @@ echo "== clean-up and reset :"
  echo ' rm -f' std_????.?i?
  rm -f std_????.?i?
  rm -f TTT.out.?i? 2> /dev/null
- echo ' rm -f' data.pkg data.tst
- rm -f data.pkg data.tst
+ echo ' rm -f' data data.pkg data.tst
+ rm -f data data.pkg data.tst
 #- move back files from temp_tst dir:
  if test -d $tmpDir ; then
   echo "--> move back files from 'temp_tst' dir."


### PR DESCRIPTION
explicitly remove file "data" (as done for "data.pkg") since relying
on moving back files from "temp_tst" is not very robust.

## Please check that the PR fulfils our requirements
- [x] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## What changes does this PR introduce?

## What is the current behaviour? 
during cleaning stage (tst_2+2 4), file "data" was not always removed (as it should) after some failed tst_2+2 run

## What is the new behaviour 
always remove file "data" during cleaning stage (as it should)

## Does this PR introduce a breaking change? 
No

## Other information: