### PR TITLE
Fix testreport option "-clean" (left from cvs to git conversion)

### DIFF
--- a/verification/testreport
+++ b/verification/testreport
@@ -1524,7 +1524,7 @@ for dir in $TESTDIRS ; do
 	    rm -f SIZE.h.mpi genmake.tr_log make.tr_log
 	    rm -rf mpi_headers
 	)
-	if test -d $dir/$rundir/CVS ; then
+	if test -d $dir/$rundir ; then
 	    echo -n '  --- dir:' $dir/$rundir ': '
 	    run_clean $dir/$rundir
 	fi


### PR DESCRIPTION
"run/" directory does not contain "CVS" directory anymore; remove
condition on run/CVS to just a test on existing run/ dir

## Please check that the PR fulfils our requirements
- [x] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## What changes does this PR introduce?
fix "testreport -clean" for a non CVS MITgcm repo.

## What is the current behaviour? 
'testreport -clean' currently skip the cleaning of all run/ dir 
because a test on existence of run/CVS dir always fail

## What is the new behaviour 
simplify the condition to enable again cleaning of run dir.

## Does this PR introduce a breaking change? 

## Other information: