### PR TITLE
Add a list of related projects

### DIFF
--- a/doc/index.rst
+++ b/doc/index.rst
@@ -32,5 +32,5 @@ Welcome to MITgcm's user manual
    outp_pkgs/outp_pkgs
    ocean_state_est/ocean_state_est.rst
    under_dev/under_dev.rst
-   prev_applications/prev_applications.rst
+   related_projects/related_projects.rst
    references

--- a/doc/prev_applications/prev_applications.rst
+++ b/doc/prev_applications/prev_applications.rst
@@ -1,4 +1,0 @@
-
-Previous Applications of MITgcm
-*******************************
-

--- a/doc/related_projects/related_projects.rst
+++ b/doc/related_projects/related_projects.rst
@@ -1,0 +1,43 @@
+Related Projects and Highlighted Papers
+***************************************
+
+
+Projects Related to MITgcm
+==========================
+
+Estimating the Circulation and Climate of the Ocean (ECCO)
+----------------------------------------------------------
+
+ECCO is an oceanic reanalysis product that makes use of MITgcm's adjoint capabilities to assimilate observations into a dynamically self-consistent state estimate. 
+
+website: https://ecco.jpl.nasa.gov/
+
+
+Octopus - Lagrangian Particle Tracker
+---------------------------------------
+
+Octopus is an offline Lagrangian particle tracker that uses saved velocity fields from MITgcm simulations.
+
+website: https://github.com/jinbow/Octopus
+
+
+Southern Ocean State Estimation (SOSE)
+--------------------------------------
+
+SOSE uses the same techniques as ECCO to produce an eddy-permitting state estimate of the Southern Ocean.
+
+website: http://sose.ucsd.edu/
+
+
+xmitgcm
+-------
+
+xmitgcm is a Python module that loads MITgcm MDS output files as `xarray <http://xarray.pydata.org/en/stable/>`_ arrays with the associated grid information. These can be easily exported as NetCDF files.
+
+website: http://xmitgcm.readthedocs.io/en/latest/
+
+
+
+Highlighted Papers
+==================
+

--- a/doc/related_projects/related_projects.rst
+++ b/doc/related_projects/related_projects.rst
@@ -37,10 +37,21 @@ SOSE uses the same techniques as ECCO to produce an eddy-permitting state estima
 website: http://sose.ucsd.edu/
 
 
-xmitgcm
+Xgcm: General Circulation Model Postprocessing with xarray
+----------------------------------------------------------
+
+Xgcm is a python packge for working with the datasets produced by numerical General Circulation Models
+(GCMs) and similar gridded datasets that are amenable to finite volume analysis. In these datasets, different
+variables are located at different positions with respect to a volume or area element (e.g. cell center, cell face,
+etc.) xgcm solves the problem of how to interpolate and difference these variables from one position to another.
+
+website: http://xgcm.readthedocs.io/en/latest/
+
+
+Xmitgcm
 -------
 
-xmitgcm is a Python module that loads MITgcm MDS output files as `xarray <http://xarray.pydata.org/en/stable/>`_ datasets with the associated grid information. These can be easily exported as NetCDF files.
+Xmitgcm is a Python module that loads MITgcm MDS output files as `xarray <http://xarray.pydata.org/en/stable/>`_ datasets with the associated grid information. These can be easily exported as NetCDF files.
 
 website: http://xmitgcm.readthedocs.io/en/latest/
 

--- a/doc/related_projects/related_projects.rst
+++ b/doc/related_projects/related_projects.rst
@@ -26,20 +26,12 @@ The MITprof toolbox handles unevenly distributed in-situ ocean observations. It 
 
 website: https://github.com/gaelforget/MITprof
 
-Octopus - Lagrangian Particle Tracker
----------------------------------------
-
-Octopus is an offline Lagrangian particle tracker that uses saved velocity fields from MITgcm simulations.
-
-website: https://github.com/jinbow/Octopus
-
 OceanParcels - Lagrangian Particle Tracker
 ------------------------------------------
 
 Parcels provides a set of Python classses and methods to create customizable particle tracking simulations, focussing on tracking of both passive water parcels as well as active plankton, plastic and fish.
 
 website: http://oceanparcels.org/
-
 
 Southern Ocean State Estimation (SOSE)
 --------------------------------------

--- a/doc/related_projects/related_projects.rst
+++ b/doc/related_projects/related_projects.rst
@@ -40,7 +40,7 @@ website: http://sose.ucsd.edu/
 xmitgcm
 -------
 
-xmitgcm is a Python module that loads MITgcm MDS output files as `xarray <http://xarray.pydata.org/en/stable/>`_ arrays with the associated grid information. These can be easily exported as NetCDF files.
+xmitgcm is a Python module that loads MITgcm MDS output files as `xarray <http://xarray.pydata.org/en/stable/>`_ datasets with the associated grid information. These can be easily exported as NetCDF files.
 
 website: http://xmitgcm.readthedocs.io/en/latest/
 


### PR DESCRIPTION
This is a work in progress, and I'd like to get feedback on:
- the list of projects included
- the description for each project

## What changes does this PR introduce?
Include a list of related projects in the documentation, as discussed in #37.

## What is the current behaviour? 
No related projects are discussed.

## Other information
The list of papers in the original manual under "[Previous applications of the MITgcm](http://mitgcm.org/public/r2_manual/final/online_documents/node312.html)" is quite long. I think it would be more useful to have a shorter list of highly influential papers. I will open an issue for this topic to be discussed.