### PR TITLE
Separate ecco autodiff

### DIFF
--- a/pkg/ecco/cost_bp_read.F
+++ b/pkg/ecco/cost_bp_read.F
@@ -71,6 +71,8 @@ cnew(
       logical exst
 cnew)
 
+      _RS dummyRS(1)
+
 c     == external functions ==
 
       integer  ilnblnk
@@ -113,8 +115,10 @@ ce    --> there is certainly a better place for this.
       endif
 
       if ( (obsrec.GT.0).AND.(imonth.GT.0) ) then
-        call mdsreadfield( fnametmp, cost_iprec, cost_yftype, 1,
-     &                   localobs, imonth, mythid )
+       call MDS_READ_FIELD(fnametmp, cost_iprec, .FALSE., cost_yftype,
+     &                     1,1,1,localobs,dummyRS,imonth,mythid)
+c        call mdsreadfield( fnametmp, cost_iprec, cost_yftype, 1,
+c     &                   localobs, imonth, mythid )
       else
         do bj = jtlo,jthi
          do bi = itlo,ithi

--- a/pkg/ecco/cost_bp_read.F
+++ b/pkg/ecco/cost_bp_read.F
@@ -117,8 +117,6 @@ ce    --> there is certainly a better place for this.
       if ( (obsrec.GT.0).AND.(imonth.GT.0) ) then
        call MDS_READ_FIELD(fnametmp, cost_iprec, .FALSE., cost_yftype,
      &                     1,1,1,localobs,dummyRS,imonth,mythid)
-c        call mdsreadfield( fnametmp, cost_iprec, cost_yftype, 1,
-c     &                   localobs, imonth, mythid )
       else
         do bj = jtlo,jthi
          do bi = itlo,ithi

--- a/pkg/ecco/cost_gencost_bpv4.F
+++ b/pkg/ecco/cost_gencost_bpv4.F
@@ -72,6 +72,8 @@ c     == local variables ==
 
       integer k, kgen
 
+      _RS dummyRS(1)
+
 c     == external functions ==
 
       integer  ilnblnk
@@ -277,11 +279,11 @@ c--    Remove global mean value
 c--    Smooth field of anomalies
       if (gencost_outputlevel(kgen).GT.0) then
       write(fname4test(1:80),'(1a)') 'bpdifanom_raw'
-      call mdswritefield(fname4test,32,.false.,'RL',
-     & 1,bpdifanom,irec,1,mythid)
+      call MDS_WRITE_FIELD(fname4test,32,.FALSE.,.FALSE.,'RL',
+     & 1,1,1,bpdifanom,dummyRS,irec,1,mythid)
       write(fname4test(1:80),'(1a)') 'bpdatanom_raw'
-      call mdswritefield(fname4test,32,.false.,'RL',
-     & 1,bpdatanom,irec,1,mythid)
+      call MDS_WRITE_FIELD(fname4test,32,.FALSE.,.FALSE.,'RL',
+     & 1,1,1,bpdatanom,dummyRS,irec,1,mythid)
       endif
 
 #ifdef ALLOW_SMOOTH
@@ -296,11 +298,11 @@ c--    Smooth field of anomalies
 #endif
 
       write(fname4test(1:80),'(1a)') 'bpdifanom_smooth'
-      call mdswritefield(fname4test,32,.false.,'RL',
-     & 1,bpdifanom,irec,1,mythid)
+      call MDS_WRITE_FIELD(fname4test,32,.FALSE.,.FALSE.,'RL',
+     & 1,1,1,bpdifanom,dummyRS,irec,1,mythid)
       write(fname4test(1:80),'(1a)') 'bpdatanom_smooth'
-      call mdswritefield(fname4test,32,.false.,'RL',
-     & 1,bpdatanom,irec,1,mythid)
+      call MDS_WRITE_FIELD(fname4test,32,.FALSE.,.FALSE.,'RL',
+     & 1,1,1,bpdatanom,dummyRS,irec,1,mythid)
       endif
 
 c--    Compute cost function

--- a/pkg/ecco/cost_gencost_seaicev4.F
+++ b/pkg/ecco/cost_gencost_seaicev4.F
@@ -96,6 +96,8 @@ c old:heff -> model has excess of iceconc     -> new:exconc
       character*(MAX_LEN_FNAM) localobswfile
       logical exst
 
+      _RS dummyRS(1)
+
 c     == external functions ==
 
       integer  ilnblnk
@@ -263,8 +265,8 @@ c====================================================
 c-- initialize to spzerloc = -9999.
         call ecco_zero(localobs,nnzsiv4,spzeroloc,mythid)
         if ( (localrec .GT. 0).AND.(obsrec .GT. 0).AND.(exst) ) then
-          call mdsreadfield( fname0, cost_iprec, cost_yftype, nnzsiv4,
-     &         localobs, localrec, mythid )
+         call MDS_READ_FIELD( fname0, cost_iprec, .FALSE., cost_yftype,
+     &        nnzsiv4,1,nnzsiv4,localobs, dummyRS,localrec, mythid )
         else
           il=ilnblnk( fname0 )
           WRITE(standardMessageUnit,'(2A)')

--- a/pkg/ecco/cost_gencost_sshv4.F
+++ b/pkg/ecco/cost_gencost_sshv4.F
@@ -162,6 +162,8 @@ c for PART 4/5: compute smooth/raw anomalies
       LOGICAL doReference
       LOGICAL useEtaMean
 
+      _RS dummyRS(1)
+
 c     == external functions ==
 
       integer  ilnblnk
@@ -335,8 +337,8 @@ cgf =======================================================
 c--   Read mean field and mask
 
       if (using_mdt)
-     &call mdsreadfield( mdtfi, cost_iprec, cost_yftype, 1,
-     &                   mdtob, 1, mythid )
+     &call MDS_READ_FIELD( mdtfi, cost_iprec, .FALSE.,cost_yftype, 
+     &                     1,1,1,mdtob, dummyRS,1, mythid )
 
       factor =  0.01 _d 0
       spval  = -9990. _d 0
@@ -459,8 +461,8 @@ c--   smooth mean_slaobs_mdt:
 
       if (gencost_outputlevel(igen_mdt).GT.0) then
       write(fname4test(1:80),'(1a)') 'sla2mdt_raw'
-      call mdswritefield(fname4test,32,.false.,'RL',
-     & 1,mean_slaobs_mdt,1,1,mythid)
+      call MDS_WRITE_FIELD(fname4test,32,.FALSE.,.FALSE.,'RL',
+     & 1,1,1,mean_slaobs_mdt,dummyRS,1,1,mythid)
       endif
 
 #ifdef ALLOW_SMOOTH
@@ -472,8 +474,8 @@ c--   smooth mean_slaobs_mdt:
 
       if (gencost_outputlevel(igen_mdt).GT.0) then
       write(fname4test(1:80),'(1a)') 'sla2mdt_smooth'
-      call mdswritefield(fname4test,32,.false.,'RL',
-     & 1,mean_slaobs_mdt,1,1,mythid)
+      call MDS_WRITE_FIELD(fname4test,32,.FALSE.,.FALSE.,'RL',
+     & 1,1,1,mean_slaobs_mdt,dummyRS,1,1,mythid)
       endif
 
 c--   re-reference mdt:
@@ -803,8 +805,8 @@ c use the simpler approach
 c--    smooth mean_psMssh_all
       if (gencost_outputlevel(igen_mdt).GT.0) then
       write(fname4test(1:80),'(1a)') 'mdtdiff_raw'
-      call mdswritefield(fname4test,32,.false.,'RL',
-     &    1,mean_psMssh_all,1,1,mythid)
+      call MDS_WRITE_FIELD(fname4test,32,.FALSE.,.FALSE.,
+     &     'RL',1,1,1,mean_psMssh_all,dummyRS,1,1,mythid)
       endif
 
 #ifdef ALLOW_SMOOTH
@@ -816,14 +818,14 @@ c--    smooth mean_psMssh_all
 
       if (gencost_outputlevel(igen_mdt).GT.0) then
       write(fname4test(1:80),'(1a)') 'mdtdiff_smooth'
-      call mdswritefield(fname4test,32,.false.,'RL',
-     &    1,mean_psMssh_all,1,1,mythid)
+      call MDS_WRITE_FIELD(fname4test,32,.FALSE.,.FALSE.,
+     &     'RL',1,1,1,mean_psMssh_all,dummyRS,1,1,mythid)
       endif
 
       if (gencost_outputlevel(igen_mdt).GT.0) then
       write(fname4test(1:80),'(1a)') 'sla2model_raw'
-      call mdswritefield(fname4test,32,.false.,'RL',
-     &    1,mean_slaobs_model,1,1,mythid)
+      call MDS_WRITE_FIELD(fname4test,32,.FALSE.,.FALSE.,
+     &     'RL',1,1,1,mean_slaobs_model,dummyRS,1,1,mythid)
       endif
 
 #ifdef ALLOW_SMOOTH
@@ -835,8 +837,8 @@ c--    smooth mean_psMssh_all
 
       if (gencost_outputlevel(igen_mdt).GT.0) then
       write(fname4test(1:80),'(1a)') 'sla2model_smooth'
-      call mdswritefield(fname4test,32,.false.,'RL',
-     &    1,mean_slaobs_model,1,1,mythid)
+      call MDS_WRITE_FIELD(fname4test,32,.FALSE.,.FALSE.,
+     &    'RL',1,1,1,mean_slaobs_model,dummyRS,1,1,mythid)
       endif
 
 cgf at this point:
@@ -874,8 +876,8 @@ cgf =======================================================
 
       if (gencost_outputlevel(igen_mdt).GT.0) then
       write(fname4test(1:80),'(1a)') 'misfits_mdt'
-      call mdswritefield(fname4test,32,.false.,'RL',
-     & 1,diagnosfld,1,1,mythid)
+      call MDS_WRITE_FIELD(fname4test,32,.FALSE.,.FALSE.,
+     &     'RL',1,1,1,diagnosfld,dummyRS,1,1,mythid)
       endif
 
 cgf =======================================================
@@ -1124,12 +1126,12 @@ c ----------------------------------------
 
       if (gencost_outputlevel(igen_lsc).GT.0) then
       write(fname4test(1:80),'(1a)') 'sladiff_raw'
-      call mdswritefield(fname4test,32,.false.,'RL',
-     & 1,anom_psMslaobs,irec,1,mythid)
+      call MDS_WRITE_FIELD(fname4test,32,.FALSE.,.FALSE.,
+     &     'RL',1,1,1,anom_psMslaobs,dummyRS,irec,1,mythid)
 
       write(fname4test(1:80),'(1a)') 'slaobs_raw'
-      call mdswritefield(fname4test,32,.false.,'RL',
-     & 1,anom_slaobs,irec,1,mythid)
+      call MDS_WRITE_FIELD(fname4test,32,.FALSE.,.FALSE.,
+     &     'RL',1,1,1,anom_slaobs,dummyRS,irec,1,mythid)
       endif
 
 #ifdef ALLOW_SMOOTH
@@ -1148,12 +1150,12 @@ c ----------------------------------------
 #endif
 c
       write(fname4test(1:80),'(1a)') 'sladiff_smooth'
-      call mdswritefield(fname4test,32,.false.,'RL',
-     & 1,anom_psMslaobs,irec,1,mythid)
+      call MDS_WRITE_FIELD(fname4test,32,.FALSE.,.FALSE.,
+     &     'RL',1,1,1,anom_psMslaobs,dummyRS,irec,1,mythid)
 c
       write(fname4test(1:80),'(1a)') 'slaobs_smooth'
-      call mdswritefield(fname4test,32,.false.,'RL',
-     & 1,anom_slaobs,irec,1,mythid)
+      call MDS_WRITE_FIELD(fname4test,32,.FALSE.,.FALSE.,
+     &     'RL',1,1,1,anom_slaobs,dummyRS,irec,1,mythid)
       endif
 
 c PART 4.3: compute cost function term
@@ -1186,12 +1188,12 @@ c ------------------------------------
 
       if (gencost_outputlevel(igen_lsc).GT.0) then
       write(fname4test(1:80),'(1a)') 'sladiff_subsample'
-      call mdswritefield(fname4test,32,.false.,'RL',
-     & 1,anom_psMslaobs_SUB,irec,1,mythid)
+      call MDS_WRITE_FIELD(fname4test,32,.FALSE.,.FALSE.,
+     &     'RL',1,1,1,anom_psMslaobs_SUB,dummyRS,irec,1,mythid)
 c
       write(fname4test(1:80),'(1a)') 'slaobs_subsample'
-      call mdswritefield(fname4test,32,.false.,'RL',
-     & 1,anom_slaobs_SUB,irec,1,mythid)
+      call MDS_WRITE_FIELD(fname4test,32,.FALSE.,.FALSE.,
+     &     'RL',1,1,1,anom_slaobs_SUB,dummyRS,irec,1,mythid)
       endif
 
 c PART 4.4: compute cost function term for global mean sea level
@@ -1311,29 +1313,29 @@ c time associated with this ndaysrec mean
 
       if (gencost_outputlevel(igen_tp).GT.0) then
       write(fname4test(1:80),'(1a)') 'sladiff_tp_raw'
-      call mdswritefield(fname4test,32,.false.,'RL',
-     & 1,anom_psMtpobs,irec,1,mythid)
+      call MDS_WRITE_FIELD(fname4test,32,.FALSE.,.FALSE.,
+     &     'RL',1,1,1,anom_psMtpobs,dummyRS,irec,1,mythid)
       write(fname4test(1:80),'(1a)') 'slaobs_tp_raw'
-      call mdswritefield(fname4test,32,.false.,'RL',
-     & 1,anom_tpobs,irec,1,mythid)
+      call MDS_WRITE_FIELD(fname4test,32,.FALSE.,.FALSE.,
+     &     'RL',1,1,1,anom_tpobs,dummyRS,irec,1,mythid)
       endif
 
       if (gencost_outputlevel(igen_ers).GT.0) then
       write(fname4test(1:80),'(1a)') 'sladiff_ers_raw'
-      call mdswritefield(fname4test,32,.false.,'RL',
-     & 1,anom_psMersobs,irec,1,mythid)
+      call MDS_WRITE_FIELD(fname4test,32,.FALSE.,.FALSE.,
+     &     'RL',1,1,1,anom_psMersobs,dummyRS,irec,1,mythid)
       write(fname4test(1:80),'(1a)') 'slaobs_ers_raw'
-      call mdswritefield(fname4test,32,.false.,'RL',
-     & 1,anom_ersobs,irec,1,mythid)
+      call MDS_WRITE_FIELD(fname4test,32,.FALSE.,.FALSE.,
+     &     'RL',1,1,1,anom_ersobs,dummyRS,irec,1,mythid)
       endif
 
       if (gencost_outputlevel(igen_gfo).GT.0) then
       write(fname4test(1:80),'(1a)') 'sladiff_gfo_raw'
-      call mdswritefield(fname4test,32,.false.,'RL',
-     & 1,anom_psMgfoobs,irec,1,mythid)
+      call MDS_WRITE_FIELD(fname4test,32,.FALSE.,.FALSE.,
+     &     'RL',1,1,1,anom_psMgfoobs,dummyRS,irec,1,mythid)
       write(fname4test(1:80),'(1a)') 'slaobs_gfo_raw'
-      call mdswritefield(fname4test,32,.false.,'RL',
-     & 1,anom_gfoobs,irec,1,mythid)
+      call MDS_WRITE_FIELD(fname4test,32,.FALSE.,.FALSE.,
+     &     'RL',1,1,1,anom_gfoobs,dummyRS,irec,1,mythid)
       endif
 
        do bj = jtlo,jthi

--- a/pkg/ecco/cost_generic.F
+++ b/pkg/ecco/cost_generic.F
@@ -254,6 +254,8 @@ c     == local variables ==
 
       _RL fac
 
+      _RS dummyRS(1)
+
       character*(128) fname1, fname2, fname3
       character*200 msgbuf
 
@@ -353,8 +355,8 @@ c--     load model average and observed average
 
         call ecco_zero(localobs,nnzobs,spzeroloc,myThid)
         if ( (localrec .GT. 0).AND.(obsrec .GT. 0).AND.(exst) )
-     &  call mdsreadfield( fname2, cost_iprec, cost_yftype, nnzobs,
-     &         localobs, localrec, mythid )
+     &  call MDS_READ_FIELD( fname2, cost_iprec, .FALSE., cost_yftype, 
+     &        nnzobs, 1, nnzobs, localobs, dummyRS, localrec, mythid )
 
 c--     Compute masked model-data difference
         call ecco_diffmsk( localbar, nnzbar, localobs, nnzobs,

--- a/pkg/ecco/cost_sla_read.F
+++ b/pkg/ecco/cost_sla_read.F
@@ -71,6 +71,8 @@ cnew(
       logical exst
 cnew)
 
+      _RS dummyRS(1)
+
 c     == external functions ==
 
       integer  ilnblnk
@@ -116,8 +118,8 @@ c      sshrec = floor(diffsecs/sla_period) + 1
 
 c read data:
       if ( (sshrec .GT. 0).AND.(exst) ) then
-       call mdsreadfield( fnametmp, cost_iprec, cost_yftype,
-     &                          1, sla_obs, sshrec, mythid )
+       call MDS_READ_FIELD(fnametmp, cost_iprec,.FALSE.,cost_yftype,
+     &                     1,1,1,sla_obs,dummyRS,sshrec,mythid)
       else
        do bj = jtlo,jthi
         do bi = itlo,ithi

--- a/pkg/ecco/cost_sla_read_yd.F
+++ b/pkg/ecco/cost_sla_read_yd.F
@@ -71,6 +71,8 @@ cnew(
       logical exst
 cnew)
 
+      _RS dummyRS(1)
+
 c     == external functions ==
 
       integer  ilnblnk
@@ -106,8 +108,8 @@ c     == end of interface ==
          stop
       endif
 
-      call mdsreadfield( fnametmp, cost_iprec, cost_yftype, 1, sla_obs,
-     &                   day, mythid )
+      call MDS_READ_FIELD(fnametmp, cost_iprec,.FALSE.,cost_yftype,
+     &                    1,1,1,sla_obs,dummyRS,irec,mythid)
 
       do bj = jtlo,jthi
         do bi = itlo,ithi

--- a/pkg/ecco/cost_ssh.F
+++ b/pkg/ecco/cost_ssh.F
@@ -83,6 +83,7 @@ c     == local variables ==
 
       character*(80) fname
       character*(MAX_LEN_MBUF) msgbuf
+      _RS dummyRS(1)
 
 c     == external functions ==
 
@@ -137,8 +138,8 @@ c--   ============
 c--   Read mean field and generate mask
 c--   Convert mean ssh from cm to m
 #ifdef ALLOW_SSH_MEAN_COST_CONTRIBUTION
-      call mdsreadfield( mdtdatfile, cost_iprec, cost_yftype, 1,
-     &                   mdt, 1, mythid )
+      call MDS_READ_FIELD( mdtdatfile, cost_iprec,.FALSE.,cost_yftype,
+     &                    1, 1, 1, mdt, dummyRS, 1, mythid )
 
       do bj = jtlo,jthi
         do bi = itlo,ithi

--- a/pkg/ecco/ecco_check.F
+++ b/pkg/ecco/ecco_check.F
@@ -564,10 +564,10 @@ cgf (3) naming convention: m_heat_hadv rather than trHeat, etc?
 cgf     would help eventually distinguish, e.g., m_heat_hdif vs m_heat_vdif...
 cgf (4) generalization: specify type of transport (vol, heat, etc) via namelist?
              call ecco_zero(msktrVolW,1,zeroRL,mythid)
-             call mdsreadfield(tempfile,cost_iprec,'RL',1,
-     &            msktrVolW,1,mythid)
-             call mdsreadfield(tempfile,cost_iprec,'RL',1,
-     &            gencost_mskWsurf(1-olx,1-oly,1,1,k),1,mythid)
+             call MDS_READ_FIELD(tempfile,cost_iprec,.FALSE.,'RL',
+     &            1,1,1,msktrVolW,dummyRS,1,mythid)
+             call MDS_READ_FIELD(tempfile,cost_iprec,.FALSE.,'RL',
+     &       1,1,1,gencost_mskWsurf(1-olx,1-oly,1,1,k),dummyRS,1,mythid)
            endif
 c-- South --------------------
            il = ilnblnk(gencost_errfile(k))
@@ -592,10 +592,10 @@ c-- South --------------------
            else
 c-- will move to init perhaps, but leave here for now due to check exst
              call ecco_zero(msktrVolS,1,zeroRL,mythid)
-             call mdsreadfield(tempfile,cost_iprec,'RL',1,
-     &            msktrVolS,1,mythid)
-             call mdsreadfield(tempfile,cost_iprec,'RL',1,
-     &            gencost_mskSsurf(1-olx,1-oly,1,1,k),1,mythid)
+             call MDS_READ_FIELD(tempfile,cost_iprec,.FALSE.,'RL',
+     &            1,1,1,msktrVolS,dummyRS,1,mythid)
+             call MDS_READ_FIELD(tempfile,cost_iprec,.FALSE.,'RL',
+     &       1,1,1,gencost_mskSsurf(1-olx,1-oly,1,1,k),dummyRS,1,mythid)
            endif
           else
            using_gencost(k)=.FALSE.

--- a/pkg/ecco/ecco_cost_weights.F
+++ b/pkg/ecco/ecco_cost_weights.F
@@ -375,8 +375,8 @@ c--
       defined (ALLOW_WSALTLEV))
       lwsaltLevInUse = .true.
       if ( salt0errfile .NE. ' ' ) then
-         call mdsreadfield( salt0errfile, cost_iprec, cost_yftype, Nr,
-     &         wsaltLev, 1, mythid)
+       call MDS_READ_FIELD(salt0errfile,cost_iprec,.FALSE.,cost_yftype, 
+     &         Nr,1,Nr,wsaltLev,dummyRS, 1, mythid)
          do bj = jtlo,jthi
           do bi = itlo,ithi
            do k = 1,nr
@@ -418,8 +418,8 @@ c--           Test for missing values.
      defined (ALLOW_WTHETALEV))
       lwthetaLevInUse = .true.
       if ( temp0errfile .NE. ' ' ) then
-         call mdsreadfield( temp0errfile, cost_iprec, cost_yftype, Nr,
-     &         wthetaLev, 1, mythid)
+       call MDS_READ_FIELD(temp0errfile,cost_iprec,.FALSE.,cost_yftype, 
+     &         Nr,1,Nr,wthetaLev,dummyRS, 1, mythid)
          do bj = jtlo,jthi
           do bi = itlo,ithi
            do k = 1,nr
@@ -463,8 +463,8 @@ c--           Test for missing values.
 
       lwsalt2InUse = .true.
       if ( salterrfile .NE. ' ' ) then
-         call mdsreadfield( salterrfile, cost_iprec, cost_yftype, Nr,
-     &                      wsalt2, 1, mythid)
+       call MDS_READ_FIELD(salterrfile,cost_iprec,.FALSE.,cost_yftype, 
+     &                     Nr,1,Nr,wsalt2,dummyRS, 1, mythid)
 
          do bj = jtlo,jthi
           do bi = itlo,ithi
@@ -511,8 +511,8 @@ c--           Test for missing values.
 
       lwtheta2InUse = .true.
       if ( temperrfile .NE. ' ' ) then
-         call mdsreadfield( temperrfile, cost_iprec, cost_yftype, Nr,
-     &                      wtheta2, 1, mythid)
+       call MDS_READ_FIELD(temperrfile,cost_iprec,.FALSE.,cost_yftype, 
+     &                     Nr,1,Nr,wtheta2,dummyRS, 1, mythid)
          do bj = jtlo,jthi
           do bi = itlo,ithi
            do k = 1,nr
@@ -554,13 +554,13 @@ c--           Test for missing values.
 
 #if (defined (ALLOW_SST_COST_CONTRIBUTION) || defined (ALLOW_SST_CONTROL))
       if ( ( using_cost_sst ).AND.( ssterrfile .NE. ' ' ) )
-     &   call mdsreadfield( ssterrfile, cost_iprec, cost_yftype, 1,
-     &                      wsst, 1, mythid)
+     & call MDS_READ_FIELD(ssterrfile,cost_iprec,.FALSE.,cost_yftype, 
+     &                     1,1,1,wsst,dummyRS, 1, mythid)
 #endif
 #if (defined (ALLOW_SSS_COST_CONTRIBUTION) || defined (ALLOW_SSS_CONTROL))
       if ( ssserrfile .NE. ' ' )
-     &   call mdsreadfield( ssserrfile, cost_iprec, cost_yftype, 1,
-     &                      wsss, 1, mythid)
+     & call MDS_READ_FIELD(ssserrfile,cost_iprec,.FALSE.,cost_yftype,
+     &                     1,1,1,wsss,dummyRS, 1, mythid)
 #endif
 
       k = 1
@@ -633,8 +633,8 @@ c--   Read egm-96 geoid covariance. Data in units of meters.
       nnz   =  1
       irec  =  1
       if ( geoid_errfile .NE. ' ' ) then
-      call mdsreadfield( geoid_errfile, cost_iprec, cost_yftype,
-     &    nnz, wp, irec, mythid )
+      call MDS_READ_FIELD(geoid_errfile,cost_iprec,.FALSE.,cost_yftype,
+     &    nnz,1,nnz, wp, dummyRS,irec, mythid )
 c--   Set all tile edges to zero.
       do bj = jtlo,jthi
         do bi = itlo,ithi
@@ -672,8 +672,8 @@ c--   Read SSH anomaly rms field. Data in units of centimeters.
       nnz   =   1
       irec  =   1
       if ( ssh_errfile .NE. ' ' ) then
-         call mdsreadfield( ssh_errfile, cost_iprec, cost_yftype,
-     &      nnz, wtp, irec, mythid )
+        call MDS_READ_FIELD(ssh_errfile,cost_iprec,.FALSE.,cost_yftype,
+     &      nnz,1,nnz, wtp,dummyRS, irec, mythid )
 
          do bj = jtlo,jthi
           do bi = itlo,ithi
@@ -701,18 +701,18 @@ c--           T/P error + 5cm
 
 c-- overwrite T/P error field, if available:
       if ( tp_errfile .NE. ' ' )
-     &     call mdsreadfield( tp_errfile, cost_iprec, cost_yftype, nnz,
-     &     wtp, irec, mythid )
+     & call MDS_READ_FIELD(tp_errfile,cost_iprec,.FALSE.,cost_yftype, 
+     & nnz,1,nnz,wtp,dummyRS, irec, mythid )
 
 c-- overwrite ERS error field, if available:
       if ( ers_errfile .NE. ' ' )
-     &     call mdsreadfield( ers_errfile, cost_iprec, cost_yftype, nnz,
-     &     wers, irec, mythid )
+     & call MDS_READ_FIELD(ers_errfile,cost_iprec,.FALSE.,cost_yftype, 
+     & nnz,1,nnz,wers,dummyRS, irec, mythid )
 
 c-- overwrite GFO error field, if available:
       if ( gfo_errfile .NE. ' ' )
-     &     call mdsreadfield( gfo_errfile, cost_iprec, cost_yftype, nnz,
-     &     wgfo, irec, mythid )
+     & call MDS_READ_FIELD(gfo_errfile,cost_iprec,.FALSE.,cost_yftype, 
+     & nnz,1,nnz,wgfo,dummyRS, irec, mythid )
 
          do bj = jtlo,jthi
           do bi = itlo,ithi
@@ -778,8 +778,8 @@ cph-indonesian)
 
       if ( sshv4cost_errfile(num_var) .NE. ' ' ) then
 c--   read error standard deviation
-      call mdsreadfield( sshv4cost_errfile(num_var),
-     &    cost_iprec, cost_yftype, 1, wsshv4tmp, 1, mythid)
+      call MDS_READ_FIELD(sshv4cost_errfile(num_var),cost_iprec,.FALSE.,
+     &     cost_yftype,1,1,1, wsshv4tmp,dummyRS, 1, mythid)
 c--   convert to units of meters
       do bj = jtlo,jthi
         do bi = itlo,ithi
@@ -828,8 +828,8 @@ c--   convert to units of meters
 #ifdef ALLOW_BP_COST_CONTRIBUTION
       IF (using_cost_bp) THEN
       if ( bperrfile .NE. ' ' )
-     &   call mdsreadfield( bperrfile, cost_iprec, cost_yftype, 1,
-     &                      wbp, 1, mythid)
+     &   call MDS_READ_FIELD(bperrfile,cost_iprec,.FALSE.,cost_yftype, 
+     &                       1,1,1,wbp,dummyRS, 1, mythid)
 
       do bj = jtlo,jthi
         do bi = itlo,ithi
@@ -849,8 +849,8 @@ c--   convert to units of meters
 
 #ifdef ALLOW_IESTAU_COST_CONTRIBUTION
       if ( ieserrfile .NE. ' ' )
-     &   call mdsreadfield( ieserrfile, cost_iprec, cost_yftype, 1,
-     &                      wies, 1, mythid)
+     &   call MDS_READ_FIELD(ieserrfile,cost_iprec,.FALSE.,cost_yftype, 
+     &                       1,1,1,wies,dummyRS, 1, mythid)
 
       do bj = jtlo,jthi
         do bi = itlo,ithi
@@ -875,11 +875,11 @@ c--   Read zonal wind stress variance.
       nnz   =   1
       irec  =   1
       if ( scatx_errfile .NE. ' ' )
-     &call mdsreadfield( scatx_errfile, cost_iprec, cost_yftype, nnz,
-     &                   wscatx, irec, mythid )
+     &call MDS_READ_FIELD(scatx_errfile,cost_iprec,.FALSE.,cost_yftype, 
+     &                    nnz,1,nnz,wscatx,dummyRS, irec, mythid )
       if ( scaty_errfile .NE. ' ' )
-     &call mdsreadfield( scaty_errfile, cost_iprec, cost_yftype, nnz,
-     &                   wscaty, irec, mythid )
+     &call MDS_READ_FIELD(scaty_errfile,cost_iprec,.FALSE.,cost_yftype, 
+     &                    nnz,1,nnz,wscaty,dummyRS, irec, mythid )
 
       do bj = jtlo,jthi
         do bi = itlo,ithi
@@ -948,8 +948,8 @@ ce(   due to Patrick processing:
       irec  = 1
 ce)
       if ( tauu_errfile .NE. ' ' ) then
-         call mdsreadfield( tauu_errfile, cost_iprec, cost_yftype,
-     &      nnz, wtauu, irec, mythid )
+       call MDS_READ_FIELD(tauu_errfile,cost_iprec,.FALSE.,cost_yftype,
+     &      nnz, 1, nnz, wtauu, dummyRS, irec, mythid )
       endif
 
       do bj = jtlo,jthi
@@ -986,8 +986,8 @@ ce(   due to Patrick processing:
       irec  = 1
 ce)
       if ( uwind_errfile .NE. ' ' ) then
-         call mdsreadfield( uwind_errfile, cost_iprec, cost_yftype,
-     &      nnz, wuwind, irec, mythid )
+       call MDS_READ_FIELD(uwind_errfile,cost_iprec,.FALSE.,cost_yftype,
+     &      nnz, 1, nnz, wuwind, dummyRS, irec, mythid )
       endif
 
       do bj = jtlo,jthi
@@ -1018,8 +1018,8 @@ ce(   due to Patrick processing:
 ce)
 
       if ( tauv_errfile .NE. ' ' ) then
-         call mdsreadfield( tauv_errfile, cost_iprec, cost_yftype, nnz,
-     &        wtauv, irec, mythid )
+       call MDS_READ_FIELD(tauv_errfile,cost_iprec,.FALSE.,cost_yftype, 
+     &      nnz,1,nnz,wtauv,dummyRS, irec, mythid )
       endif
 
       do bj = jtlo,jthi
@@ -1056,8 +1056,8 @@ ce(   due to Patrick processing:
 ce)
 
       if ( vwind_errfile .NE. ' ' ) then
-         call mdsreadfield( vwind_errfile, cost_iprec, cost_yftype,
-     &      nnz, wvwind, irec, mythid )
+       call MDS_READ_FIELD(vwind_errfile,cost_iprec,.FALSE.,cost_yftype,
+     &      nnz, 1, nnz, wvwind, dummyRS, irec, mythid )
       endif
 
       do bj = jtlo,jthi
@@ -1088,8 +1088,8 @@ ce(   due to Patrick processing:
       irec  = 1
 ce)
       if ( hflux_errfile .NE. ' ' ) then
-         call mdsreadfield( hflux_errfile, cost_iprec, cost_yftype,
-     &      nnz, whflux, irec, mythid )
+       call MDS_READ_FIELD(hflux_errfile,cost_iprec,.FALSE.,cost_yftype,
+     &      nnz, 1, nnz, whflux, dummyRS, irec, mythid )
       endif
 
       do bj = jtlo,jthi
@@ -1123,8 +1123,8 @@ ce(   due to Patrick processing:
       irec  = 1
 ce)
       if ( atemp_errfile .NE. ' ' ) then
-         call mdsreadfield( atemp_errfile, cost_iprec, cost_yftype,
-     &      nnz, watemp, irec, mythid )
+       call MDS_READ_FIELD(atemp_errfile,cost_iprec,.FALSE.,cost_yftype,
+     &      nnz, 1, nnz, watemp, dummyRS, irec, mythid )
       endif
 
       do bj = jtlo,jthi
@@ -1156,8 +1156,8 @@ ce(   due to Patrick processing:
       irec  = 1
 ce)
       if ( sflux_errfile .NE. ' ' ) then
-         call mdsreadfield( sflux_errfile, cost_iprec, cost_yftype,
-     &      nnz, wsflux, irec, mythid )
+       call MDS_READ_FIELD(sflux_errfile,cost_iprec,.FALSE.,cost_yftype,
+     &      nnz, 1, nnz, wsflux, dummyRS, irec, mythid )
       endif
 
       do bj = jtlo,jthi
@@ -1191,8 +1191,8 @@ ce(   due to Patrick processing:
       irec  = 1
 ce)
       if ( aqh_errfile .NE. ' ' ) then
-         call mdsreadfield( aqh_errfile, cost_iprec, cost_yftype, nnz,
-     &        waqh, irec, mythid )
+       call MDS_READ_FIELD(aqh_errfile,cost_iprec,.FALSE.,cost_yftype, 
+     &      nnz,1,nnz,waqh, dummyRS, irec, mythid )
       endif
 
       do bj = jtlo,jthi
@@ -1223,8 +1223,8 @@ ce(   due to Patrick processing:
       irec  = 1
 ce)
       if ( precip_errfile .NE. ' ' ) then
-        call mdsreadfield( precip_errfile, cost_iprec, cost_yftype,
-     &      nnz, wprecip, irec, mythid )
+       call MDS_READ_FIELD(precip_errfile,cost_iprec,.FALSE.,
+     &      cost_yftype,nnz,1,nnz, wprecip, dummyRS, irec, mythid )
       endif
 
       do bj = jtlo,jthi
@@ -1255,8 +1255,8 @@ ce(   due to Patrick processing:
       irec  = 1
 ce)
       if ( swflux_errfile .NE. ' ' ) then
-        call mdsreadfield( swflux_errfile, cost_iprec, cost_yftype,
-     &      nnz, wswflux, irec, mythid )
+       call MDS_READ_FIELD(swflux_errfile,cost_iprec,.FALSE.,
+     &      cost_yftype,nnz,1,nnz, wswflux, dummyRS, irec, mythid )
       endif
 
       do bj = jtlo,jthi
@@ -1287,8 +1287,8 @@ ce(   due to Patrick processing:
       irec  = 1
 ce)
       if ( swdown_errfile .NE. ' ' ) then
-        call mdsreadfield( swdown_errfile, cost_iprec, cost_yftype,
-     &      nnz, wswdown, irec, mythid )
+       call MDS_READ_FIELD(swdown_errfile,cost_iprec,.FALSE.,
+     &      cost_yftype,nnz,1,nnz, wswdown, dummyRS, irec, mythid )
       endif
 
       do bj = jtlo,jthi
@@ -1319,8 +1319,8 @@ ce(   due to Patrick processing:
       irec  = 1
 ce)
       if ( lwflux_errfile .NE. ' ' ) then
-        call mdsreadfield( lwflux_errfile, cost_iprec, cost_yftype,
-     &      nnz, wlwflux, irec, mythid )
+        call MDS_READ_FIELD(lwflux_errfile,cost_iprec,.FALSE.,
+     &       cost_yftype,nnz,1,nnz, wlwflux, dummyRS, irec, mythid )
       endif
 
       do bj = jtlo,jthi
@@ -1351,8 +1351,8 @@ ce(   due to Patrick processing:
       irec  = 1
 ce)
       if ( lwdown_errfile .NE. ' ' ) then
-        call mdsreadfield( lwdown_errfile, cost_iprec, cost_yftype,
-     &      nnz, wlwdown, irec, mythid )
+        call MDS_READ_FIELD(lwdown_errfile,cost_iprec,.FALSE.,
+     &       cost_yftype,nnz,1,nnz,wlwdown,dummyRS,irec, mythid )
       endif
 
       do bj = jtlo,jthi
@@ -1383,8 +1383,8 @@ ce(   due to Patrick processing:
       irec  = 1
 ce)
       if ( snowprecip_errfile .NE. ' ' ) then
-        call mdsreadfield( snowprecip_errfile, cost_iprec, cost_yftype,
-     &      nnz, wsnowprecip, irec, mythid )
+        call MDS_READ_FIELD(snowprecip_errfile,cost_iprec,.FALSE.,
+     &       cost_yftype,nnz,1,nnz, wsnowprecip,dummyRS,irec, mythid )
       endif
 
       do bj = jtlo,jthi
@@ -1416,8 +1416,8 @@ ce(   due to Patrick processing:
       irec  = 1
 ce)
       if ( evap_errfile .NE. ' ' ) then
-        call mdsreadfield( evap_errfile, cost_iprec, cost_yftype,
-     &      nnz, wevap, irec, mythid )
+        call MDS_READ_FIELD(evap_errfile,cost_iprec,.FALSE.,cost_yftype,
+     &      nnz, 1, nnz, wevap, dummyRS, irec, mythid )
       endif
 
       do bj = jtlo,jthi
@@ -1448,8 +1448,8 @@ ce(   due to Patrick processing:
       irec  = 1
 ce)
       if ( apressure_errfile .NE. ' ' ) then
-        call mdsreadfield( apressure_errfile, cost_iprec, cost_yftype,
-     &      nnz, wapressure, irec, mythid )
+        call MDS_READ_FIELD(apressure_errfile,cost_iprec,.FALSE.,
+     &      cost_yftype,nnz,1,nnz, wapressure,dummyRS,irec, mythid )
       endif
 
       do bj = jtlo,jthi
@@ -1481,8 +1481,8 @@ ce(   due to Patrick processing:
       irec  = 1
 ce)
       if ( runoff_errfile .NE. ' ' ) then
-        call mdsreadfield( runoff_errfile, cost_iprec, cost_yftype,
-     &      nnz, wrunoff, irec, mythid )
+        call MDS_READ_FIELD(runoff_errfile,cost_iprec,.FALSE.,
+     &       cost_yftype,nnz,1,nnz, wrunoff,dummyRS,irec, mythid )
       endif
 
       do bj = jtlo,jthi
@@ -1506,8 +1506,8 @@ c--           Data are in units of m/s.
 #if (defined (ALLOW_BOTTOMDRAG_COST_CONTRIBUTION) || defined (ALLOW_BOTTOMDRAG_CONTROL))
       if ( bottomdrag_errfile .NE. ' ' ) then
 
-        call mdsreadfield( bottomdrag_errfile, cost_iprec, cost_yftype,
-     &      nnz, wbottomdrag, irec, mythid )
+        call MDS_READ_FIELD(bottomdrag_errfile,cost_iprec,.FALSE.,
+     &       cost_yftype,nnz,1,nnz, wbottomdrag,dummyRS,irec, mythid )
 
       do bj = jtlo,jthi
         do bi = itlo,ithi
@@ -1528,8 +1528,8 @@ c--           Test for missing values.
 #if (defined (ALLOW_DIFFKR_COST_CONTRIBUTION) || defined (ALLOW_DIFFKR_CONTROL))
       if ( diffkr_errfile .NE. ' ' ) then
 
-        call mdsreadfield( diffkr_errfile, cost_iprec, cost_yftype,
-     &      Nr, wdiffkr2, 1, mythid )
+        call MDS_READ_FIELD(diffkr_errfile,cost_iprec,.FALSE.,
+     &       cost_yftype,Nr,1,Nr,wdiffkr2,dummyRS, 1, mythid )
 
       do bj = jtlo,jthi
         do bi = itlo,ithi
@@ -1552,8 +1552,8 @@ c--           Test for missing values.
 #if (defined (ALLOW_KAPGM_COST_CONTRIBUTION) || defined (ALLOW_KAPGM_CONTROL))
       if ( kapgm_errfile .NE. ' ' ) then
 
-        call mdsreadfield( kapgm_errfile, cost_iprec, cost_yftype,
-     &      Nr, wkapgm2, 1, mythid )
+        call MDS_READ_FIELD(kapgm_errfile,cost_iprec,.FALSE.,
+     &       cost_yftype,Nr,1,Nr, wkapgm2,dummyRS,1, mythid )
 
       do bj = jtlo,jthi
         do bi = itlo,ithi
@@ -1576,8 +1576,8 @@ c--           Test for missing values.
 #if (defined (ALLOW_KAPREDI_COST_CONTRIBUTION) || defined (ALLOW_KAPREDI_CONTROL))
       if ( kapredi_errfile .NE. ' ' ) then
 
-        call mdsreadfield( kapredi_errfile, cost_iprec, cost_yftype,
-     &      Nr, wkapredi2, 1, mythid )
+        call MDS_READ_FIELD(kapredi_errfile,cost_iprec,.FALSE.,
+     &       cost_yftype,Nr,1,Nr, wkapredi2,dummyRS,1, mythid )
 
       do bj = jtlo,jthi
         do bi = itlo,ithi
@@ -1600,8 +1600,8 @@ c--           Test for missing values.
 #if ( defined (ALLOW_EDDYPSI_COST_CONTRIBUTION) || defined (ALLOW_EDDYPSI_CONTROL) )
       if ( edtau_errfile .NE. ' ' ) then
 
-        call mdsreadfield( edtau_errfile, cost_iprec, cost_yftype,
-     &      Nr, wedtaux2, 1, mythid )
+        call MDS_READ_FIELD(edtau_errfile,cost_iprec,.FALSE.,
+     &       cost_yftype,Nr,1,Nr, wedtaux2,dummyRS,1, mythid )
 
       do bj = jtlo,jthi
         do bi = itlo,ithi
@@ -1624,8 +1624,8 @@ c--           Test for missing values.
 
 #if (defined (ALLOW_ETAN0_COST_CONTRIBUTION) || defined (ALLOW_ETAN0_CONTROL))
       if ( etan0errfile .NE. ' ' ) then
-         call mdsreadfield( etan0errfile, cost_iprec, cost_yftype, 1,
-     &         wetan, 1, mythid)
+         call MDS_READ_FIELD(etan0errfile,cost_iprec,.FALSE.,
+     &         cost_yftype, 1,1,1,wetan,dummyRS,1, mythid)
          do bj = jtlo,jthi
           do bi = itlo,ithi
             do j = jmin,jmax
@@ -1662,10 +1662,10 @@ c--           Test for missing values.
 #if (defined (ALLOW_VVEL0_COST_CONTRIBUTION) || defined (ALLOW_VVEL0_CONTROL))
 
       if ( uvel0errfile .NE. ' ' .AND. vvel0errfile .NE. ' ' ) then
-         call mdsreadfield( uvel0errfile, cost_iprec, cost_yftype, Nr,
-     &         wuvel3d, 1, mythid)
-         call mdsreadfield( vvel0errfile, cost_iprec, cost_yftype, Nr,
-     &         wvvel3d, 1, mythid)
+         call MDS_READ_FIELD(uvel0errfile,cost_iprec,.FALSE.,
+     &         cost_yftype, Nr,1,Nr,wuvel3d,dummyRS, 1, mythid)
+         call MDS_READ_FIELD(vvel0errfile,cost_iprec,.FALSE.,
+     &         cost_yftype, Nr,1,Nr,wvvel3d,dummyRS, 1, mythid)
          do bj = jtlo,jthi
           do bi = itlo,ithi
            do k = 1,nr

--- a/pkg/ecco/ecco_readparms.F
+++ b/pkg/ecco/ecco_readparms.F
@@ -732,13 +732,13 @@ c
             write(tempfile(1:128),'(2A)') gencost_mask(k)(1:il),'C'
             inquire( file=tempfile(1:il+1), exist=exst )
             if (exst.AND.(.NOT.gencost_msk_is3d(k))) then
-             call mdsreadfield(tempfile,cost_iprec,'RL',1,
-     &            gencost_mskCsurf(1-olx,1-oly,1,1,k),1,mythid)
+             call MDS_READ_FIELD(tempfile,cost_iprec,.FALSE.,'RL',1,1,1,
+     &            gencost_mskCsurf(1-olx,1-oly,1,1,k),dummyRS,1,mythid)
 #ifdef ALLOW_GENCOST3D
             elseif (exst.AND.(gencost_msk_pointer3d(k).LE.
      &                        NGENCOST3D)) then
-             call mdsreadfield(tempfile,cost_iprec,'RL',Nr,
-     &            gencost_mskC(1-olx,1-oly,1,1,1,kk),1,mythid)
+             call MDS_READ_FIELD(tempfile,cost_iprec,.FALSE.,'RL',Nr,1,
+     &          Nr,gencost_mskC(1-olx,1-oly,1,1,1,kk),dummyRS,1,mythid)
 #endif
             endif
 c
@@ -746,13 +746,13 @@ c
             write(tempfile(1:128),'(2A)') gencost_mask(k)(1:il),'W'
             inquire( file=tempfile(1:il+1), exist=exst )
             if (exst.AND.(.NOT.gencost_msk_is3d(k))) then
-             call mdsreadfield(tempfile,cost_iprec,'RL',1,
-     &            gencost_mskWsurf(1-olx,1-oly,1,1,k),1,mythid)
+             call MDS_READ_FIELD(tempfile,cost_iprec,.FALSE.,'RL',1,1,1,
+     &            gencost_mskWsurf(1-olx,1-oly,1,1,k),dummyRS,1,mythid)
 #ifdef ALLOW_GENCOST3D
             elseif (exst.AND.(gencost_msk_pointer3d(k).LE.
      &                        NGENCOST3D)) then
-             call mdsreadfield(tempfile,cost_iprec,'RL',Nr,
-     &            gencost_mskW(1-olx,1-oly,1,1,1,kk),1,mythid)
+             call MDS_READ_FIELD(tempfile,cost_iprec,.FALSE.,'RL',Nr,1,
+     &         Nr,gencost_mskW(1-olx,1-oly,1,1,1,kk),dummyRS,1,mythid)
 #endif
             endif
 c
@@ -760,13 +760,13 @@ c
             write(tempfile(1:128),'(2A)') gencost_mask(k)(1:il),'S'
             inquire( file=tempfile(1:il+1), exist=exst )
             if (exst.AND.(.NOT.gencost_msk_is3d(k))) then
-             call mdsreadfield(tempfile,cost_iprec,'RL',1,
-     &            gencost_mskSsurf(1-olx,1-oly,1,1,k),1,mythid)
+             call MDS_READ_FIELD(tempfile,cost_iprec,.FALSE.,'RL',1,1,1,
+     &            gencost_mskSsurf(1-olx,1-oly,1,1,k),dummyRS,1,mythid)
 #ifdef ALLOW_GENCOST3D
             elseif (exst.AND.(gencost_msk_pointer3d(k).LE.
      &                        NGENCOST3D)) then
-             call mdsreadfield(tempfile,cost_iprec,'RL',Nr,
-     &            gencost_mskS(1-olx,1-oly,1,1,1,kk),1,mythid)
+             call MDS_READ_FIELD(tempfile,cost_iprec,.FALSE.,'RL',Nr,1,
+     &        Nr,gencost_mskS(1-olx,1-oly,1,1,1,kk),dummyRS,1,mythid)
 #endif
             endif
 c


### PR DESCRIPTION
## What changes does this PR introduce?
Replace retired mds[read,write]field with MDS_[READ,WRITE]_FIELD in pkg/ecco to enable compiling pkg/ecco independent of pkg/autodiff


## What is the current behaviour? 
Currently, various costs in pkg/ecco only works if pkg/autodiff is compiled.  Without pkg/autodiff, various files within pkg/ecco are read/write using retired subroutine mds[read,write]field, and because there is a STOP statement inside pkg/mdsio/mdsio_rw_field.F pkg/ecco can not be used.

## What is the new behaviour 
This change allows for read/write of files within pkg/ecco using more updated and widely used subroutine MDS_[READ,WRITE]_FIELD , see for example recent similar changes in ctrl_get_gen.F. More importantly, this allows users to use pkg/ecco to calculate misfits (cost) to observations in a forward run without needing to compile pkg/autodiff.

## Does this PR introduce a breaking change? 
I do not expect any break.  This is simply updating the code to use the more current  read/write subroutine.  In fact, the retired subroutine mds[read,write]field  calls the new syntax inside pkg/mdsio/mdsio_rw_field.F.  The only difference here is now these modifications call the new syntax directly, and bypassing the STOP statement inside pkg/mdsio/mdsio_rw_field.F .

## Other information: