### PR TITLE
recognize (new) environment variable 'MITGCM_ROOTDIR'

### DIFF
--- a/tools/genmake2
+++ b/tools/genmake2
@@ -1379,6 +1379,18 @@ or for more detail see the Developer's HOWTO manual at:
 
 EOF
 
+if test "x$MITGCM_ROOTDIR" = x ; then
+  if test "x$ROOTDIR" != x ; then
+    echo "WARNING: Environement Variable 'ROOTDIR' getting retired soon ;"
+    echo "WARNING:  ==> has been replaced by Env. Var. 'MITGCM_ROOTDIR'"
+  # echo "WARNING: Environement Variable 'ROOTDIR' no longer recognized"
+  # echo "WARNING:  use instead 'MITGCM_ROOTDIR'" ; ROOTDIR=
+    echo ''
+  fi
+else
+  ROOTDIR=$MITGCM_ROOTDIR
+fi
+
 LOGFILE="genmake.log"
 #- clean-up previous genmake logfiles:
 rm -f genmake_state genmake_*optfile $LOGFILE
@@ -1633,8 +1645,8 @@ if test "x${ROOTDIR}" = x ; then
 fi
 if test "x${ROOTDIR}" = x ; then
     echo "Error: Cannot determine ROOTDIR for MITgcm code."
-    echo "  Please specify a ROOTDIR using either an options "
-    echo "  file or a command-line option."
+    echo "  Please specify a ROOTDIR using either the command line"
+    echo "   option '-rootdir' or the Env.Var. 'MITGCM_ROOTDIR'."
     exit 1
 fi
 if test ! -d ${ROOTDIR} ; then

--- a/tools/genmake2
+++ b/tools/genmake2
@@ -1381,9 +1381,9 @@ EOF
 
 if test "x$MITGCM_ROOTDIR" = x ; then
   if test "x$ROOTDIR" != x ; then
-    echo "WARNING: Environement Variable 'ROOTDIR' getting retired soon ;"
+    echo "WARNING: Environment Variable 'ROOTDIR' getting retired soon ;"
     echo "WARNING:  ==> has been replaced by Env. Var. 'MITGCM_ROOTDIR'"
-  # echo "WARNING: Environement Variable 'ROOTDIR' no longer recognized"
+  # echo "WARNING: Environment Variable 'ROOTDIR' no longer recognized"
   # echo "WARNING:  use instead 'MITGCM_ROOTDIR'" ; ROOTDIR=
     echo ''
   fi

--- a/tools/suggest_optfile_names
+++ b/tools/suggest_optfile_names
@@ -1,6 +1,4 @@
 #! /usr/bin/env bash
-#
-#
 
 look_for_makedepend()  {
 
@@ -37,7 +35,7 @@ EOF
 	    MAKEDEPEND=makedepend
 	else
 	    echo "    a system-default makedepend was not found."
-	    
+
 	    #  Try to build the cyrus implementation
 	    build_cyrus_makedepend
 	    RETVAL=$?
@@ -56,7 +54,6 @@ EOF
     fi
     rm -f genmake_tc*
 }
-
 
 build_cyrus_makedepend()  {
     rm -f ./genmake_cy_md
@@ -82,7 +79,6 @@ build_cyrus_makedepend()  {
     fi
 }
 
-
 find_possible_configs()  {
 
     tmp1=`uname`"_"`uname -m`
@@ -95,7 +91,7 @@ find_possible_configs()  {
     echo $PLATFORM | grep cygwin > /dev/null 2>&1  &&  PLATFORM=cygwin_ia32
     OFLIST=`(cd $ROOTDIR/tools/build_options; ls | grep "^$PLATFORM")`
     echo "  The platform appears to be:  $PLATFORM"
-    
+
     echo "test" > test
     ln -s ./test link
     RETVAL=$?
@@ -214,9 +210,18 @@ Error: No options file was found in:  $ROOTDIR/tools/build_options/
 EOF
 	exit 1
     fi
-    
+
 }
 
+#-- Sequential part of script starts here --------------------------------------
+if test "x$MITGCM_ROOTDIR" = x ; then
+  if test "x$ROOTDIR" != x ; then
+    echo "WARNING: Environement Variable 'ROOTDIR' no longer recognized"
+    echo "WARNING:  use instead 'MITGCM_ROOTDIR'" ; ROOTDIR=
+  fi
+else
+  ROOTDIR=$MITGCM_ROOTDIR
+fi
 
 AWK=awk
 

--- a/tools/suggest_optfile_names
+++ b/tools/suggest_optfile_names
@@ -216,7 +216,7 @@ EOF
 #-- Sequential part of script starts here --------------------------------------
 if test "x$MITGCM_ROOTDIR" = x ; then
   if test "x$ROOTDIR" != x ; then
-    echo "WARNING: Environement Variable 'ROOTDIR' no longer recognized"
+    echo "WARNING: Environment Variable 'ROOTDIR' no longer recognized"
     echo "WARNING:  use instead 'MITGCM_ROOTDIR'" ; ROOTDIR=
   fi
 else


### PR DESCRIPTION
- if set, use env.var. MITGCM_ROOTDIR to set genmake2 and Makefile internal
  variable "ROOTDIR".
- for now, can still use env.var. "ROOTDIR" (as previously) but issue a Warning.
Note: generated Makefile is not affected by this modification.

## Other information:
This is an alternative to PR #62 that involves less changes but address the main
issue which was related to the name of environment variable ROOTDIR ; This follows the
issue #63 discussion.