### PR TITLE
bring up-to-date this minimal (untested) setup

### DIFF
--- a/verification/adjustment.cs-32x32x1/code_min/CPP_OPTIONS.h
+++ b/verification/adjustment.cs-32x32x1/code_min/CPP_OPTIONS.h
@@ -15,12 +15,45 @@ CEOP
 
 C CPP flags controlling particular source code features
 
+C-- Forcing code options:
+
 C o Shortwave heating as extra term in external_forcing.F
 C Note: this should be a run-time option
 #undef SHORTWAVE_HEATING
 
+C o Include/exclude Geothermal Heat Flux at the bottom of the ocean
+#undef ALLOW_GEOTHERMAL_FLUX
+
+C o Allow to account for heating due to friction (and momentum dissipation)
+#undef ALLOW_FRICTION_HEATING
+
+C o Allow mass source or sink of Fluid in the interior
+C   (3-D generalisation of oceanic real-fresh water flux)
+#undef ALLOW_ADDFLUID
+
+C o Include pressure loading code
+#define ATMOSPHERIC_LOADING
+
+C o Include/exclude balancing surface forcing fluxes code
+#undef ALLOW_BALANCE_FLUXES
+
+C o Include/exclude balancing surface forcing relaxation code
+#undef ALLOW_BALANCE_RELAX
+
+C o Include/exclude checking for negative salinity
+#undef CHECK_SALINITY_FOR_NEGATIVE_VALUES
+
+C-- Options to discard parts of the main code:
+
+C o Exclude/allow external forcing-fields load
+C   this allows to read & do simple linear time interpolation of oceanic
+C   forcing fields, if no specific pkg (e.g., EXF) is used to compute them.
+#undef EXCLUDE_FFIELDS_LOAD
+
 C o Include/exclude phi_hyd calculation code
 #define INCLUDE_PHIHYD_CALCULATION_CODE
+
+C-- Vertical mixing code options:
 
 C o Include/exclude call to S/R CONVECT
 #define INCLUDE_CONVECT_CALL
@@ -34,46 +67,43 @@ C o Allow full 3D specification of vertical diffusivity
 C o Allow latitudinally varying BryanLewis79 vertical diffusivity
 #undef ALLOW_BL79_LAT_VARY
 
+C o Exclude/allow partial-cell effect (physical or enhanced) in vertical mixing
+C   this allows to account for partial-cell in vertical viscosity and diffusion,
+C   either from grid-spacing reduction effect or as artificially enhanced mixing
+C   near surface & bottom for too thin grid-cell
+#undef EXCLUDE_PCELL_MIX_CODE
+
+C-- Time-stepping code options:
+
+C o Include/exclude combined Surf.Pressure and Drag Implicit solver code
+#undef ALLOW_SOLVE4_PS_AND_DRAG
+
 C o Include/exclude Implicit vertical advection code
 #define INCLUDE_IMPLVERTADV_CODE
 
 C o Include/exclude AdamsBashforth-3rd-Order code
 #undef ALLOW_ADAMSBASHFORTH_3
 
+C-- Model formulation options:
+
+C o Allow/exclude "Exact Convervation" of fluid in Free-Surface formulation
+C   that ensures that d/dt(eta) is exactly equal to - Div.Transport
+#define EXACT_CONSERV
+
+C o Allow the use of Non-Linear Free-Surface formulation
+C   this implies that grid-cell thickness (hFactors) varies with time
+#undef NONLIN_FRSURF
+
 C o Include/exclude nonHydrostatic code
 #undef ALLOW_NONHYDROSTATIC
-
-C o Allow to account for heating due to friction (and momentum dissipation)
-#undef ALLOW_FRICTION_HEATING
-
-C o Allow mass source or sink of Fluid in the interior
-C   (3-D generalisation of oceanic real-fresh water flux)
-#undef ALLOW_ADDFLUID
-
-C o Include pressure loading code
-#define ATMOSPHERIC_LOADING
-
-C o exclude/allow external forcing-fields load
-C   this allows to read & do simple linear time interpolation of oceanic
-C   forcing fields, if no specific pkg (e.g., EXF) is used to compute them.
-#undef EXCLUDE_FFIELDS_LOAD
-
-C o Include/exclude balancing surface forcing fluxes code
-#undef ALLOW_BALANCE_FLUXES
-
-C o Include/exclude balancing surface forcing relaxation code
-#undef ALLOW_BALANCE_RELAX
 
 C o Include/exclude GM-like eddy stress in momentum code
 #undef ALLOW_EDDYPSI
 
-C o Use "Exact Convervation" of fluid in Free-Surface formulation
-C   so that d/dt(eta) is exactly equal to - Div.Transport
-#define EXACT_CONSERV
+C-- Algorithm options:
 
-C o Allow the use of Non-Linear Free-Surface formulation
-C   this implies that surface thickness (hFactors) vary with time
-#undef NONLIN_FRSURF
+C o Use Non Self-Adjoint (NSA) conjugate-gradient solver
+#undef ALLOW_CG2D_NSA
 
 C o Include/exclude code for single reduction Conjugate-Gradient solver
 #define ALLOW_SRCG
@@ -84,38 +114,14 @@ C   The following has low memory footprint, but not suitable for AD
 C   The following one suitable for AD but does not vectorize
 #undef SOLVE_DIAGONAL_KINNER
 
-C o ALLOW isotropic scaling of harmonic and bi-harmonic terms when
-C   using an locally isotropic spherical grid with (dlambda) x (dphi*cos(phi))
-C *only for use on a lat-lon grid*
-C   Setting this flag here affects both momentum and tracer equation unless
-C   it is set/unset again in other header fields (e.g., GAD_OPTIONS.h).
-C   The definition of the flag is commented to avoid interference with
-C   such other header files.
-C   The preferred method is specifying a value for viscAhGrid or viscA4Grid
-C   in data which is then automatically scaled by the grid size;
-C   the old method of specifying viscAh/viscA4 and this flag is provided
-C   for completeness only (and for use with the adjoint).
-C#define ISOTROPIC_COS_SCALING
-
-C o This flag selects the form of COSINE(lat) scaling of bi-harmonic term.
-C *only for use on a lat-lon grid*
-C   Has no effect if ISOTROPIC_COS_SCALING is undefined.
-C   Has no effect on vector invariant momentum equations.
-C   Setting this flag here affects both momentum and tracer equation unless
-C   it is set/unset again in other header fields (e.g., GAD_OPTIONS.h).
-C   The definition of the flag is commented to avoid interference with
-C   such other header files.
-C#define COSINEMETH_III
-
-C o Use "OLD" UV discretisation near boundaries (*not* recommended)
-C   Note - only works with  #undef NO_SLIP_LATERAL  in calc_mom_rhs.F
-C          because the old code did not have no-slip BCs
-#undef  OLD_ADV_BCS
+C-- Retired code options:
 
 C o Use LONG.bin, LATG.bin, etc., initialization for ini_curviliear_grid.F
 C   Default is to use "new" grid files (OLD_GRID_IO undef) but OLD_GRID_IO
 C   is still useful with, e.g., single-domain curvilinear configurations.
 #undef OLD_GRID_IO
+
+C-- Other option files:
 
 C o Execution environment support options
 #include "CPP_EEOPTIONS.h"

--- a/verification/adjustment.cs-32x32x1/code_min/main.F
+++ b/verification/adjustment.cs-32x32x1/code_min/main.F
@@ -109,6 +109,7 @@ C     myThid       :: thread Id number
       CHARACTER*(MAX_LEN_MBUF) msgBuf
       INTEGER myThid
       INTEGER I
+      INTEGER dummyComm
 
 #ifdef USE_OMP_THREADING
       INTEGER OMP_GET_THREAD_NUM
@@ -123,9 +124,9 @@ CEOP
 
 C--   Set up the execution environment
 C     EEBOOT loads a execution environment parameter file
-C     ( called "eedata" by default ) and sets variables
-C     accordingly.
-      CALL EEBOOT
+C     ( called "eedata" by default ) and sets variables accordingly.
+      dummyComm = -1
+      CALL EEBOOT( dummyComm )
 
 C--   Trap errors
       IF ( eeBootError ) THEN


### PR DESCRIPTION
was missing additional argument to S/R EEBOOT (added on Jan 28, 2017)

## What changes does this PR introduce?
Allow to compile and run a "minimal" set-up that got broken> 1 year ago.