### PR TITLE
add exch_rX_send_put_y.F to list of NOOPTFILES

### DIFF
--- a/tools/build_options/linux_ia64_cray_ollie
+++ b/tools/build_options/linux_ia64_cray_ollie
@@ -4,8 +4,6 @@
 # <https://swrepo1.awi.de/plugins/mediawiki/wiki/hpc/index.php/Main_Page>
 # module load craype-broadwell
 # module load PrgEnv-cray
-# module swap mvapich2_cce cray-impi
-# module load intel/impi-5.1.3
 
 FC='ftn'
 CC='cc'
@@ -25,7 +23,12 @@ NOOPTFLAGS="-O1"
 # with -fhp3 lead to wrong results of MOD(a,b) in the following function, so
 # we need to use a lower (default) value of -hfp2 implicit in the NOOPTFLAGS
 NOOPTFILES="exf_getffieldrec.F"
-
+# since the cray compiler update of April 2018, these routines break with -O3
+# for tutorial_barotropic_gyre; they work with -O2 and lower, so we include
+# them here to be compiled with NOOPTFLAGS.
+NOOPTFILES="${NOOPTFILES} exch_r4_send_put_y.F exch_r8_send_put_y.F"
+NOOPTFILES="${NOOPTFILES} exch_rl_send_put_y.F exch_rs_send_put_y.F"
+ 
 FFLAGS="$FFLAGS -h byteswapio" 
 if test "x$OMP" = xtrue ; then 
   # alternative if-statement: if test ! "x$OMP" = x ; then


### PR DESCRIPTION
These files break verification/tutorial_barotropic_gyre with agressive
optimization -O3 on ollie
Also adjust some comments in the build_options-file.

## What changes does this PR introduce?
Bug fix


## What is the current behaviour? 
verification/tutorial_barotropic_gyre breaks on CRAY CS400 with recent compiler (ollie at AWI)


## What is the new behaviour 
verification/tutorial_barotropic_gyre passes when exch_rX_send_put_y.F are compiled with -O2 or lower. The current value for NOOPTFILES is -O1.


## Does this PR introduce a breaking change? 
No

## Other information: