### PR TITLE
Flush missing figure and implement more stringent docs testing

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -73,14 +73,20 @@ jobs:
     #  script: docker exec -i fc11-testreport bash -c "cd /MITgcm/verification; ./testreport ${MITGCM_TROPT} -q"
     # build documentation
     - stage: test documentation
-      env: 
+      env:
       - BUILD="html"
       python: "2.7"
-      script: cd doc; make clean ${BUILD}
+      script:
+        - cd doc
+        - sphinx-build -nWa -b html -d _build/doctrees . _build/html
+        - make clean ${BUILD}
     - env:
       - BUILD="html"
       python: "3.6"
-      script: cd doc; make clean ${BUILD}
+      script:
+        - cd doc
+        - sphinx-build -nWa -b html -d _build/doctrees . _build/html
+        - make clean ${BUILD}
     - env:
       - BUILD="latexpdf"
       python: "2.7"

--- a/doc/phys_pkgs/gmredi.rst
+++ b/doc/phys_pkgs/gmredi.rst
@@ -443,16 +443,6 @@ The LDD97 tapering scheme is activated in the model by setting
 **GM\_taper\_scheme = ’ldd97’** in *data.gmredi*.
 
 
-.. figure::
-    :width: 70%
-    :align: center
-    :alt: Mixed layer depth with GM
-    :name: mixed_layer
-
-    **Figure missing** Mixed layer depth using GM parameterization with a) Cox slope clipping and for comparison b) using horizontal constant diffusion.
-
-
-
 .. _ssub_phys_pkg_gmredi_diagnostics:
 
 Package Reference


### PR DESCRIPTION
## What changes does this PR introduce?
Remove the missing figure in the GMRedi chapter, and include a new build command in the Travis build that makes warnings become errors. This will prevent the test suite from passing if the docs build throws any warnings.

## What is the current behaviour? 
A figure file has been missing since before the conversion to .rst, and throws a warning every time the docs get built.

## Does this PR introduce a breaking change? 
No.

## Other information:
