### PR TITLE
Update bling_readparms.F

### DIFF
--- a/pkg/bling/bling_readparms.F
+++ b/pkg/bling/bling_readparms.F
@@ -333,6 +333,7 @@ C     model grid cell-center position (leading to trivial interpolation)
         ENDIF
         apco2_lat_inc(j) = inp_dLat
       ENDDO
+      apco2_interpMethod = 1
 #endif /* USE_EXF_INTERPOLATION */
 #endif
 


### PR DESCRIPTION
## What changes does this PR introduce?
Bug fix:
apco2_interpMethod was not initiated. 

## What is the current behaviour? 
if apco2_interpMethod was not prescribed in data.bling no interpolation would be used

## What is the new behaviour 
if apco2_interpMethod is not prescribed in data.bling it will default to linear interpolation method

## Does this PR introduce a breaking change? 
benign

## Other information: