### PR TITLE
Move docs dependencies to separate script

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,14 +5,6 @@ services:
  - docker
 
 before_install:
-    #  Set up environment needed for Sphinx to build docs
-  - sudo apt-get install texlive-latex-recommended
-  - sudo apt-get install texlive-latex-extra
-  - sudo apt-get install texlive-fonts-recommended
-  - sudo apt-get install latexmk
-  - pip install sphinx
-  - pip install sphinx_rtd_theme
-  - pip install sphinxcontrib-bibtex
     # Set up environment needed to run testreport code tests
   - docker pull mitgcm/testreport-images:fc11-base-20170715
   - docker run  -v `pwd`:/MITgcm --name fc11-testreport -t -d mitgcm/testreport-images:fc11-base-20170715 /bin/bash
@@ -77,19 +69,27 @@ jobs:
       - BUILD="html"
       python: "2.7"
       script:
+        - tools/ci/install_doc_dependencies.sh > /dev/null
         - cd doc
         - sphinx-build -nWa -b ${BUILD} -d _build/doctrees . _build/html
     - env:
       - BUILD="html"
       python: "3.6"
       script:
+        - tools/ci/install_doc_dependencies.sh > /dev/null
         - cd doc
         - sphinx-build -nWa -b ${BUILD} -d _build/doctrees . _build/html
     - env:
       - BUILD="latexpdf"
       python: "2.7"
-      script: cd doc; make clean ${BUILD} LATEXOPTS="-interaction=nonstopmode -halt-on-error"
+      script:
+        - tools/ci/install_doc_dependencies.sh > /dev/null
+        - cd doc
+        - make clean ${BUILD} LATEXOPTS="-interaction=nonstopmode -halt-on-error"
     - env:
       - BUILD="latexpdf"
       python: "3.6"
-      script: cd doc; make clean ${BUILD} LATEXOPTS="-interaction=nonstopmode -halt-on-error"
+      script:
+        - tools/ci/install_doc_dependencies.sh > /dev/null
+        - cd doc
+        - make clean ${BUILD} LATEXOPTS="-interaction=nonstopmode -halt-on-error"

--- a/.travis.yml
+++ b/.travis.yml
@@ -23,41 +23,41 @@ jobs:
   include:
     # run the tests
     - stage: code tests
-      env: 
-      - MITGCM_EXP="aim.5l_cs" MITGCM_PRECS="14 16"
+      env:
+      - MITGCM_EXP="offline_exf_seaice" MITGCM_PRECS="16 16 16 16 16"
       script: . tools/ci/runtr.sh
     - env:
       - MITGCM_EXP="global_ocean.cs32x15" MITGCM_PRECS="16 16 16 16 16"
       script: . tools/ci/runtr.sh
-    - env: 
-      - MITGCM_EXP="global_ocean.90x40x15" MITGCM_PRECS="16 16 16"
-      script: . tools/ci/runtr.sh
-    - env: 
-      - MITGCM_EXP="hs94.cs-32x32x5" MITGCM_PRECS="13 16"
-      script: . tools/ci/runtr.sh
-    - env: 
-      - MITGCM_EXP="isomip" MITGCM_PRECS="16 16 16"
-      script: . tools/ci/runtr.sh
-    - env: 
-      - MITGCM_EXP="offline_exf_seaice" MITGCM_PRECS="16 16 16 16 16"
-      script: . tools/ci/runtr.sh
-    - env: 
-      - MITGCM_EXP="tutorial_advection_in_gyre" MITGCM_PRECS="16"
-      script: . tools/ci/runtr.sh
-    - env: 
-      - MITGCM_EXP="tutorial_cfc_offline" MITGCM_PRECS="16"
-      script: . tools/ci/runtr.sh
-    - env: 
+    - env:
       - MITGCM_EXP="tutorial_deep_convection" MITGCM_PRECS="16 16"
       script: . tools/ci/runtr.sh
-    - env: 
+    - env:
+      - MITGCM_EXP="aim.5l_cs" MITGCM_PRECS="14 16"
+      script: . tools/ci/runtr.sh
+    - env:
+      - MITGCM_EXP="isomip" MITGCM_PRECS="16 16 16"
+      script: . tools/ci/runtr.sh
+    - env:
+      - MITGCM_EXP="global_ocean.90x40x15" MITGCM_PRECS="16 16 16"
+      script: . tools/ci/runtr.sh
+    - env:
+      - MITGCM_EXP="tutorial_plume_on_slope" MITGCM_PRECS="16"
+      script: . tools/ci/runtr.sh
+    - env:
+      - MITGCM_EXP="tutorial_advection_in_gyre" MITGCM_PRECS="16"
+      script: . tools/ci/runtr.sh
+    - env:
+      - MITGCM_EXP="hs94.cs-32x32x5" MITGCM_PRECS="13 16"
+      script: . tools/ci/runtr.sh
+    - env:
       - MITGCM_EXP="tutorial_global_oce_biogeo" MITGCM_PRECS="16"
       script: . tools/ci/runtr.sh
-    - env: 
+    - env:
       - MITGCM_EXP="tutorial_global_oce_in_p" MITGCM_PRECS="16"
       script: . tools/ci/runtr.sh
-    - env: 
-      - MITGCM_EXP="tutorial_plume_on_slope" MITGCM_PRECS="16"
+    - env:
+      - MITGCM_EXP="tutorial_cfc_offline" MITGCM_PRECS="16"
       script: . tools/ci/runtr.sh
     # - stage: summary of code tests
     # disabled because jobs do not share data

--- a/tools/ci/install_doc_dependencies.sh
+++ b/tools/ci/install_doc_dependencies.sh
@@ -1,0 +1,9 @@
+#  Set up environment needed for Sphinx to build docs
+sudo apt-get update
+sudo apt-get install texlive-latex-recommended
+sudo apt-get install texlive-latex-extra
+sudo apt-get install texlive-fonts-recommended
+sudo apt-get install latexmk
+pip install sphinx
+pip install sphinx_rtd_theme
+pip install sphinxcontrib-bibtex


### PR DESCRIPTION
This speeds up the test suite by about 8 minutes (23 -> 17 minutes), since it removes 2-3 minutes of installation from each code test. Most of this time is spent installing LaTeX, which is only required for the pdf docs build. However, I decided not to split the docs dependencies into multiple scripts, since all docs builds run simultaneously, which means it wouldn't save any time.

Thanks @jahn for the idea.

## What changes does this PR introduce?
Dependencies for the docs builds are installed via a script in each docs test, rather than in the `before_install` section of `.travis.yml`.

## What is the current behaviour? 
All tests spend 2-3 minutes installing LaTeX and other docs related modules, even when they are not required.

## What is the new behaviour 
Docs dependencies are only installed for the doc tests, and the output is piped to `/dev/null` to keep the build logs clean.

## Does this PR introduce a breaking change? 
No.

