### PR TITLE
Update bling_carbon_chem.F

### DIFF
--- a/pkg/bling/bling_carbon_chem.F
+++ b/pkg/bling/bling_carbon_chem.F
@@ -39,6 +39,10 @@ C     === Global variables ===
 #include "PARAMS.h"
 #include "GRID.h"
 #include "FFIELDS.h"
+#ifdef ALLOW_EXF
+# include "EXF_PARAM.h"
+# include "EXF_FIELDS.h"
+#endif
 #include "BLING_VARS.h"
 
 C     == Routine arguments ==
@@ -356,6 +360,10 @@ C     === Global variables ===
 #include "PARAMS.h"
 #include "GRID.h"
 #include "FFIELDS.h"
+#ifdef ALLOW_EXF
+# include "EXF_PARAM.h"
+# include "EXF_FIELDS.h"
+#endif
 #include "BLING_VARS.h"
 
 C     == Routine arguments ==
@@ -517,11 +525,11 @@ C     === Global variables ===
 #include "PARAMS.h"
 #include "GRID.h"
 #include "FFIELDS.h"
-#include "BLING_VARS.h"
 #ifdef ALLOW_EXF
 # include "EXF_PARAM.h"
 # include "EXF_FIELDS.h"
 #endif
+#include "BLING_VARS.h"
 
 C     == Routine arguments ==
 C ttemp and stemp are local theta and salt arrays
@@ -775,11 +783,12 @@ C     === Global variables ===
 #include "PARAMS.h"
 #include "GRID.h"
 #include "FFIELDS.h"
-#include "BLING_VARS.h"
 #ifdef ALLOW_EXF
 # include "EXF_PARAM.h"
 # include "EXF_FIELDS.h"
 #endif
+#include "BLING_VARS.h"
+
 C     == Routine arguments ==
 C ttemp and stemp are local theta and salt arrays
 C dont really need to pass T and S in, could use theta, salt in


### PR DESCRIPTION
## What changes does this PR introduce?
BLING_VARS needs MAX_LAT_INC, which is in EXF_PARAM.h
But was missing in some bling_carbon_chem.F subroutines.
Now ensure that this is order:

> #ifdef ALLOW_EXF
> #include "EXF_PARAM.h"
> #include "EXF_FIELDS.h"
> #endif
> #include "BLING_VARS.h"
> in bling_carbon_chem.F

## What is the current behaviour? 
bug - will kill compile if using 
>#ifdef USE_EXFCO2
>#ifdef USE_EXF_INTERPOLATION

## What is the new behaviour 
Works

## Does this PR introduce a breaking change? 
only improves things

## Other information: