### PR TITLE
gencost_transp: gencost_errfile -> gencost_mask

### DIFF
--- a/doc/ocean_state_est/ocean_state_est.rst
+++ b/doc/ocean_state_est/ocean_state_est.rst
@@ -465,6 +465,18 @@ section (non quadratic cost function). To this end one sets
 with ``‘_’``, and set ``gencost_barfile`` to one of ``m_trVol``,
 ``m_trHeat``, and ``m_trSalt``.
 
+Note: the functionality in ``cost_gencost_transp.F`` is not regularly tested.
+Users interested in computing volumetric transports through a section
+are recommended to use the ``m_horflux_vol`` capabilities described above as 
+it is regularly tested. Users interested in computing heat and salt transport 
+should note the following about ``m_trHeat`` and ``m_trSalt``:
+
+    1. The associated advection scheme with transports may be inconsistent with
+       the model unless ``ENUM_CENTERED_2ND`` is implemented 
+    2. Bolus velocities are not included
+    3. Diffusion components are not included
+
+
 .. table:: Pre-defined ``gencost_name`` special cases (as of checkpoint
            65z; :numref:`v4custom`).
   :name: gencost_ecco_name

--- a/doc/tag-index
+++ b/doc/tag-index
@@ -1,6 +1,12 @@
     Notes on tags used in MITgcmUV
     ==============================
 
+o pkg/ecco:
+  - Replace "mskTrVol" and "gencost_errfile" with "gencost_mask" in
+    "cost_gencost_transp", mirroring "m_horflux_vol".
+  - Document and warn user (via STDERR) of potential issues with using
+    "cost_gencost_transp" to compute volume, heat, or salt transport.
+
 checkpoint67c (2018/06/26)
 o pkg/generic_advdiff:
   - Add per tracer run-time param to switch on/off Smolarkiewicz-Hack:
@@ -19,10 +25,6 @@ o pkg/ecco:
   - replace calls to (obsolete) MDSREADFIELD and MDSWRITEFIELD with calls to
     pkg/rw S/R: READ_REC_3D_RL and WRITE_REC_3D_RL ; this enable to use pkg/ecco
     without pkg/autodiff.
-  - Replace "mskTrVol" and "gencost_errfile" with "gencost_mask" in 
-    "cost_gencost_transp", mirroring "m_horflux_vol".
-  - Document and warn user (via STDERR) of potential issues with using 
-    "cost_gencost_transp" to compute volume, heat, or salt transport. 
 o verification exp:
   - update few (10) adm & tlm output after latest TAF update, from version 3.9.0
     to version 3.9.6 on May 16-18.

--- a/doc/tag-index
+++ b/doc/tag-index
@@ -19,6 +19,10 @@ o pkg/ecco:
   - replace calls to (obsolete) MDSREADFIELD and MDSWRITEFIELD with calls to
     pkg/rw S/R: READ_REC_3D_RL and WRITE_REC_3D_RL ; this enable to use pkg/ecco
     without pkg/autodiff.
+  - Replace "mskTrVol" and "gencost_errfile" with "gencost_mask" in 
+    "cost_gencost_transp", mirroring "m_horflux_vol".
+  - Document and warn user (via STDERR) of potential issues with using 
+    "cost_gencost_transp" to compute volume, heat, or salt transport. 
 o verification exp:
   - update few (10) adm & tlm output after latest TAF update, from version 3.9.0
     to version 3.9.6 on May 16-18.

--- a/pkg/ecco/cost_gencost_transp.F
+++ b/pkg/ecco/cost_gencost_transp.F
@@ -193,7 +193,7 @@ c model mask[W,S]: already included in transp calc in ecco_phys
 
 c--------- PART 0.1 read weights --------------------
 
-c-- read mask in errfile, already stored under msktrVol[W,S]
+c-- read mask in gencost_mask, already stored under msktrVol[W,S]
 c-- for now, assume non-time-variable mask
 
 c=============== PART 1: main loop ===================
@@ -204,10 +204,10 @@ c--------- PART 1.1 read barfiles ------------------
 c-- set all bars to zeros:
             call ecco_zero(mybar,Nr,zeroRL,myThid)
 
-c gencost_errfile and fname0 are dummy, get fname1 from mybarfile
+c gencost_mask and fname0 are dummy, get fname1 from mybarfile
             exst=.FALSE.
             call ecco_zero(localtmp,Nr,zeroRL,myThid)
-            call cost_gencal(mybarfile,gencost_errfile(kgen(icount)),
+            call cost_gencal(mybarfile,gencost_mask(kgen(icount)),
      &       irec,localstartdate,localperiod,fname1,
      &       fname0,localrec,obsrec,exst,mythid)
             call cost_genread(fname1,mybar,localtmp,irec,nnzbar,

--- a/pkg/ecco/cost_gencost_transp.F
+++ b/pkg/ecco/cost_gencost_transp.F
@@ -193,7 +193,7 @@ c model mask[W,S]: already included in transp calc in ecco_phys
 
 c--------- PART 0.1 read weights --------------------
 
-c-- read mask in gencost_mask, already stored under msktrVol[W,S]
+c-- read mask in gencost_mask
 c-- for now, assume non-time-variable mask
 
 c=============== PART 1: main loop ===================
@@ -264,7 +264,7 @@ c     O       tmpMeanTile,tmpNumTile,
 c     I       mythid)
 
 c global sums for display of time series
-c note tmpNumGlo is the constant total wet points in the msktrVol[W,S]
+c note tmpNumGlo is the constant total wet points in the gencost_mask[W,S]
             tmpMeanGlo = 0. _d 0
             tmpNumGlo = 0. _d 0
             il=ilnblnk(gencost_barfile(kgen(icount)))

--- a/pkg/ecco/ecco.h
+++ b/pkg/ecco/ecco.h
@@ -133,7 +133,6 @@ c                 the current model integration.
 #ifdef ALLOW_PSBAR_STERIC
      &                    sterGloH,
 #endif
-     &                    msktrVolW,msktrVolS,
      &                    trVol, trHeat, trSalt,
      &                    VOLsumGlob_0, VOLsumGlob,
      &                    RHOsumGlob_0, RHOsumGlob,
@@ -147,8 +146,6 @@ c                 the current model integration.
 #endif
       _RL m_UE (1-olx:snx+olx,1-oly:sny+oly,nr,nsx,nsy)
       _RL m_VN (1-olx:snx+olx,1-oly:sny+oly,nr,nsx,nsy)
-      _RL msktrVolW (1-OLx:sNx+OLx,1-OLy:sNy+OLy,   nSx,nSy)
-      _RL msktrVolS (1-OLx:sNx+OLx,1-OLy:sNy+OLy,   nSx,nSy)
       _RL trVol(1-OLx:sNx+OLx,1-OLy:sNy+OLy,Nr,nSx,nSy)
       _RL trHeat(1-OLx:sNx+OLx,1-OLy:sNy+OLy,Nr,nSx,nSy)
       _RL trSalt(1-OLx:sNx+OLx,1-OLy:sNy+OLy,Nr,nSx,nSy)

--- a/pkg/ecco/ecco_check.F
+++ b/pkg/ecco/ecco_check.F
@@ -590,7 +590,7 @@ c-- West ----------------------
            if (.NOT.exst) then
              using_gencost(k)=.FALSE.
              WRITE(msgBuf,'(2A)')
-     &         '** WARNING ** ECCO_CHECK_FILES: missing error file: ',
+     &         '** WARNING ** ECCO_CHECK_FILES: missing mask file: ',
      &         tempfile(1:il+1)
              CALL PRINT_MESSAGE( msgBuf, errorMessageUnit,
      &                  SQUEEZE_RIGHT , myThid)
@@ -599,19 +599,6 @@ c-- West ----------------------
      &         ' so ',gencost_name(k)(1:il),' gets switched off'
              CALL PRINT_MESSAGE( msgBuf, errorMessageUnit,
      &                  SQUEEZE_RIGHT , myThid)
-           else
-c-- will move to init perhaps, but leave here for now due to check exst
-cgf (1) should indeed be moved to init_fixed
-cgf (2) generalization: read in a 1D vertical mask and do the product
-cgf     of e.g. gencost_mskWsurf*gencost_mskZ in ecco_phys.F?
-cgf (3) naming convention: m_heat_hadv rather than trHeat, etc?
-cgf     would help eventually distinguish, e.g., m_heat_hdif vs m_heat_vdif...
-cgf (4) generalization: specify type of transport (vol, heat, etc) via namelist?
-             call ecco_zero(msktrVolW,1,zeroRL,myThid)
-             CALL READ_REC_3D_RL( tempfile, cost_iprec, 1,
-     &                            msktrVolW, 1, 1, myThid )
-             CALL READ_REC_3D_RL( tempfile, cost_iprec, 1,
-     &             gencost_mskWsurf(1-OLx,1-OLy,1,1,k), 1, 1, myThid )
            endif
 c-- South --------------------
            il = ilnblnk(gencost_mask(k))
@@ -624,7 +611,7 @@ c-- South --------------------
            if (.NOT.exst) then
              using_gencost(k)=.FALSE.
              WRITE(msgBuf,'(2A)')
-     &         '** WARNING ** ECCO_CHECK_FILES: missing error file: ',
+     &         '** WARNING ** ECCO_CHECK_FILES: missing mask file: ',
      &         tempfile(1:il+1)
              CALL PRINT_MESSAGE( msgBuf, errorMessageUnit,
      &                  SQUEEZE_RIGHT , myThid)
@@ -633,23 +620,7 @@ c-- South --------------------
      &         ' so ',gencost_name(k)(1:il),' gets switched off'
              CALL PRINT_MESSAGE( msgBuf, errorMessageUnit,
      &                  SQUEEZE_RIGHT , myThid)
-           else
-c-- will move to init perhaps, but leave here for now due to check exst
-             call ecco_zero(msktrVolS,1,zeroRL,myThid)
-             CALL READ_REC_3D_RL( tempfile, cost_iprec, 1,
-     &                            msktrVolS, 1, 1, myThid )
-             CALL READ_REC_3D_RL( tempfile, cost_iprec, 1,
-     &             gencost_mskSsurf(1-OLx,1-OLy,1,1,k), 1, 1, myThid )
            endif
-          else
-           using_gencost(k)=.FALSE.
-           il=ilnblnk(gencost_name(k))
-           WRITE(msgBuf,'(4A)')
-     &     '** WARNING ** ECCO_CHECKD: errfile not defined',
-     &     ' so ',gencost_name(k)(1:il),' gets switched off'
-           CALL PRINT_MESSAGE( msgBuf, errorMessageUnit,
-     &               SQUEEZE_RIGHT , myThid)
-           endif  
          endif ! gencost_mask.eq.' '
 
 c-- check barfile, make sure character m_tr[Vol,Heat,Salt] match exactly

--- a/pkg/ecco/ecco_check.F
+++ b/pkg/ecco/ecco_check.F
@@ -539,19 +539,30 @@ C TBD: Write a more consistent transport objective function
 C ---
 
           if (gencost_barfile(k)(1:7).eq.'m_trVol') then
-           WRITE(msgBuf,'(2A)') 
-     &   '** WARNING ** ECCO_CHECK: cost_gencost_transp.F not tested.',
-     &   ' See m_horflux_vol via
-     & cost_gencost_boxmean.F, which is regularly tested.'
+           WRITE(msgBuf,'(A)') 
+     &   '** WARNING ** ECCO_CHECK: cost_gencost_transp.F not tested.'
+           CALL PRINT_MESSAGE( msgBuf, errorMessageUnit,
+     &                         SQUEEZE_RIGHT, myThid )
+           WRITE(msgBuf,'(A)') 
+     &   ' See m_horflux_vol via cost_gencost_boxmean.F.'
            CALL PRINT_MESSAGE( msgBuf, errorMessageUnit,
      &                         SQUEEZE_RIGHT, myThid )
           elseif( (gencost_barfile(k)(1:8).eq.'m_trHeat').or.
      &            (gencost_barfile(k)(1:8).eq.'m_trSalt') ) then
-           WRITE(msgBuf,'(4A)') 
-     &   '** WARNING ** ECCO_CHECK: m_tr[Heat,Salt] to be used with
-     & caution because:',
-     &  '  (1) advection inconsistent unless ENUM_CENTERED_2ND is used',
-     &  '  (2) bolus velocities not included',
+           WRITE(msgBuf,'(2A)') 
+     &   '** WARNING ** ECCO_CHECK: m_tr[Heat,Salt] to be used with',
+     &   ' caution because:'
+           CALL PRINT_MESSAGE( msgBuf, errorMessageUnit,
+     &                         SQUEEZE_RIGHT, myThid )
+           WRITE(msgBuf,'(A)') 
+     &  '  (1) advection inconsistent unless ENUM_CENTERED_2ND is used'
+           CALL PRINT_MESSAGE( msgBuf, errorMessageUnit,
+     &                         SQUEEZE_RIGHT, myThid )
+           WRITE(msgBuf,'(A)') 
+     &  '  (2) bolus velocities not included'
+           CALL PRINT_MESSAGE( msgBuf, errorMessageUnit,
+     &                         SQUEEZE_RIGHT, myThid )
+           WRITE(msgBuf,'(A)') 
      &  '  (3) diffusion components not included'
            CALL PRINT_MESSAGE( msgBuf, errorMessageUnit,
      &                         SQUEEZE_RIGHT, myThid )

--- a/pkg/ecco/ecco_check.F
+++ b/pkg/ecco/ecco_check.F
@@ -533,6 +533,29 @@ c-- not checked here. also not checked for variwei at the moment
           CALL PRINT_MESSAGE( msgBuf, standardMessageUnit,
      &                        SQUEEZE_RIGHT , myThid)
 
+C ---
+C Warn the user that this is a less tested objective function
+C TBD: Write a more consistent transport objective function 
+C ---
+
+          if (gencost_barfile(k)(1:7).eq.'m_trVol') then
+           WRITE(msgBuf,'(2A)') 
+     &   '** WARNING ** ECCO_CHECK: cost_gencost_transp.F not tested.',
+     &   ' See m_horflux_vol via
+     & cost_gencost_boxmean.F, which is regularly tested.'
+           CALL PRINT_MESSAGE( msgBuf, errorMessageUnit,
+     &                         SQUEEZE_RIGHT, myThid )
+          elseif( (gencost_barfile(k)(1:8).eq.'m_trHeat').or.
+     &            (gencost_barfile(k)(1:8).eq.'m_trSalt') ) then
+           WRITE(msgBuf,'(4A)') 
+     &   '** WARNING ** ECCO_CHECK: m_tr[Heat,Salt] to be used with
+     & caution because:',
+     &  '  (1) advection inconsistent unless ENUM_CENTERED_2ND is used',
+     &  '  (2) bolus velocities not included',
+     &  '  (3) diffusion components not included'
+           CALL PRINT_MESSAGE( msgBuf, errorMessageUnit,
+     &                         SQUEEZE_RIGHT, myThid )
+         endif
 
 C ---
 C Note to user: use gencost_mask not errfile
@@ -658,6 +681,7 @@ c-- final report to make sure using_cost_transp is set correctly
      &     'using_cost_transp: ',icount_transp,using_cost_transp
           CALL PRINT_MESSAGE( msgBuf, standardMessageUnit,
      &                        SQUEEZE_RIGHT , myThid)
+
          endif  !gencost_flag
 
          endif !if ( gencost_datafile(k) .ne. ' ' ) then

--- a/pkg/ecco/ecco_check.F
+++ b/pkg/ecco/ecco_check.F
@@ -524,7 +524,7 @@ c-- (upper/lower-case matters) in cost_gencost_customize
            endif !barfile
 
 c---------------- block -4 ----------------------------
-c-- transs: require [err,bar][W,S]file, can have datafile, but
+c-- transs: require [mask,bar][W,S]file, can have datafile, but
 c-- not checked here. also not checked for variwei at the moment
          elseif ( gencost_flag(k).eq. -4 ) then
           WRITE(msgBuf,'(A,i3,L5)')
@@ -533,10 +533,32 @@ c-- not checked here. also not checked for variwei at the moment
           CALL PRINT_MESSAGE( msgBuf, standardMessageUnit,
      &                        SQUEEZE_RIGHT , myThid)
 
-          if ( gencost_errfile(k) .NE. ' ' ) then
+
+C ---
+C Note to user: use gencost_mask not errfile
+C ---
+          if(gencost_errfile(k) .ne. ' ') then
+            WRITE(msgBuf,'(3A)') 'S/R ECCO_CHECK: transp now ',
+     &        ' uses gencost_mask instead of gencost_errfile --',
+     &        ' please update data.ecco accordingly'
+            CALL PRINT_ERROR( msgBuf, myThid )
+            STOP 'ABNORMAL END: S/R ECCO_CHECK'
+          endif
+
+          if(gencost_mask(k) .eq. ' ') then
+            using_gencost(k)=.FALSE.
+            il = ilnblnk(gencost_name(k))
+            WRITE(msgBuf,'(4A)')
+     &        '** WARNING ** ECCO_CHECK_FILES: gencost_mask is',
+     &        ' undefined so ',gencost_name(k)(1:il),
+     &        ' gets switched off'
+            CALL PRINT_MESSAGE( msgBuf, errorMessageUnit,
+     &                 SQUEEZE_RIGHT , myThid)
+
+          else
 c-- West ----------------------
-           il = ilnblnk(gencost_errfile(k))
-           write(tempfile(1:128),'(2A)') gencost_errfile(k)(1:il),'W'
+           il = ilnblnk(gencost_mask(k))
+           write(tempfile(1:128),'(2A)') gencost_mask(k)(1:il),'W'
            inquire( file=tempfile(1:il+1), exist=exst )
            write(msgBuf,'(2A,L5)') 'ecco_check file, exst: ',
      &       tempfile(1:il+1),exst
@@ -569,8 +591,8 @@ cgf (4) generalization: specify type of transport (vol, heat, etc) via namelist?
      &             gencost_mskWsurf(1-OLx,1-OLy,1,1,k), 1, 1, myThid )
            endif
 c-- South --------------------
-           il = ilnblnk(gencost_errfile(k))
-           write(tempfile(1:128),'(2A)') gencost_errfile(k)(1:il),'S'
+           il = ilnblnk(gencost_mask(k))
+           write(tempfile(1:128),'(2A)') gencost_mask(k)(1:il),'S'
            inquire( file=tempfile(1:il+1), exist=exst )
            write(msgBuf,'(2A,L5)') 'ecco_check file, exst: ',
      &       tempfile(1:il+1),exst
@@ -604,8 +626,9 @@ c-- will move to init perhaps, but leave here for now due to check exst
      &     ' so ',gencost_name(k)(1:il),' gets switched off'
            CALL PRINT_MESSAGE( msgBuf, errorMessageUnit,
      &               SQUEEZE_RIGHT , myThid)
+           endif  
+         endif ! gencost_mask.eq.' '
 
-          endif!errfile
 c-- check barfile, make sure character m_tr[Vol,Heat,Salt] match exactly
 c-- (upper/lower-case matters) in cost_gencost_customize
           if(.not.( (gencost_barfile(k)(1:7).EQ.'m_trVol') .OR.

--- a/pkg/ecco/ecco_phys.F
+++ b/pkg/ecco/ecco_phys.F
@@ -168,58 +168,6 @@ c-- init
       call ecco_zero(trHeat,Nr,zeroRL,myThid)
       call ecco_zero(trSalt,Nr,zeroRL,myThid)
 
-      DO bj=myByLo(myThid),myByHi(myThid)
-       DO bi=myBxLo(myThid),myBxHi(myThid)
-c-- init: if done with overlap, more efficient. But since overwritten
-c immediately afterward, init is probably not needed.
-          do k = 1,nr
-            do j = 1-OLy,sNy+Oly
-              do i = 1-OLx,sNx+OLx
-                trVolW(i,j,k)=0. _d 0
-                trVolS(i,j,k)=0. _d 0
-                trHeatW(i,j,k)=0. _d 0
-                trHeatS(i,j,k)=0. _d 0
-                trSaltW(i,j,k)=0. _d 0
-                trSaltS(i,j,k)=0. _d 0
-              enddo
-            enddo
-          enddo
-          do k = 1,nr
-            do j = 1,sNy
-              do i =  1,sNx
-                trVolW(i,j,k) =
-     &                 uVel(i,j,k,bi,bj)*hFacW(i,j,k,bi,bj)
-     &                *dyG(i,j,bi,bj)*drF(k)*msktrVolW(i,j,bi,bj)
-     &                *maskInW(i,j,bi,bj)
-                trVolS(i,j,k) =
-     &                 vVel(i,j,k,bi,bj)*hFacS(i,j,k,bi,bj)
-     &                *dxG(i,j,bi,bj)*drF(k)*msktrVolS(i,j,bi,bj)
-     &                *maskInS(i,j,bi,bj)
-
-                trHeatW(i,j,k) = trVolW(i,j,k)
-     &                *(theta(i,j,k,bi,bj)+theta(i-1,j,k,bi,bj))*halfRL
-     &                *HeatCapacity_Cp*rhoConst
-                trHeatS(i,j,k) = trVolS(i,j,k)
-     &                *(theta(i,j,k,bi,bj)+theta(i,j-1,k,bi,bj))*halfRL
-     &                *HeatCapacity_Cp*rhoConst
-
-                trSaltW(i,j,k) = trVolW(i,j,k)
-     &                *(salt(i,j,k,bi,bj)+salt(i-1,j,k,bi,bj))*halfRL
-     &                *rhoConst/1000.
-                trSaltS(i,j,k) = trVolS(i,j,k)
-     &                *(salt(i,j,k,bi,bj)+salt(i,j-1,k,bi,bj))*halfRL
-     &                *rhoConst/1000.
-c now summing
-                trVol(i,j,k,bi,bj)=trVolW(i,j,k)+trVolS(i,j,k)
-                trHeat(i,j,k,bi,bj)=trHeatW(i,j,k)+trHeatS(i,j,k)
-                trSalt(i,j,k,bi,bj)=trSaltW(i,j,k)+trSaltS(i,j,k)
-                
-              enddo
-            enddo
-          enddo
-        enddo
-      enddo
-
 #ifdef ALLOW_GENCOST_CONTRIBUTION
 
       do kgen=1,NGENCOST
@@ -318,6 +266,38 @@ c
      &          gencost_storefld(i,j,bi,bj,kgen)
      &          +uVel(i,j,k,bi,bj)*tmpmskW
      &          +vVel(i,j,k,bi,bj)*tmpmskS
+
+            ! Only compute tr[Vol,Heat,Salt] if necessary, use
+            ! gencost_mask[W/S] rather than old msktrVol  
+            elseif ( gencost_barfile(kgen)(1:7).eq.'m_trVol' .or. 
+     &               gencost_barfile(kgen)(1:8).eq.'m_trHeat'.or.
+     &               gencost_barfile(kgen)(1:8).eq.'m_trSalt'    ) then
+
+                trVolW(i,j,k) =
+     &                 uVel(i,j,k,bi,bj)*tmpmskW
+     &                *maskInW(i,j,bi,bj)
+                trVolS(i,j,k) =
+     &                 vVel(i,j,k,bi,bj)*tmpmskS
+     &                *maskInS(i,j,bi,bj)
+
+                trHeatW(i,j,k) = trVolW(i,j,k)
+     &                *(theta(i,j,k,bi,bj)+theta(i-1,j,k,bi,bj))*halfRL
+     &                *HeatCapacity_Cp*rhoConst
+                trHeatS(i,j,k) = trVolS(i,j,k)
+     &                *(theta(i,j,k,bi,bj)+theta(i,j-1,k,bi,bj))*halfRL
+     &                *HeatCapacity_Cp*rhoConst
+
+                trSaltW(i,j,k) = trVolW(i,j,k)
+     &                *(salt(i,j,k,bi,bj)+salt(i-1,j,k,bi,bj))*halfRL
+     &                *rhoConst/1000.
+                trSaltS(i,j,k) = trVolS(i,j,k)
+     &                *(salt(i,j,k,bi,bj)+salt(i,j-1,k,bi,bj))*halfRL
+     &                *rhoConst/1000.
+c now summing
+                trVol(i,j,k,bi,bj)=trVolW(i,j,k)+trVolS(i,j,k)
+                trHeat(i,j,k,bi,bj)=trHeatW(i,j,k)+trHeatS(i,j,k)
+                trSalt(i,j,k,bi,bj)=trSaltW(i,j,k)+trSaltS(i,j,k)
+
             endif
           enddo
 c---------

--- a/pkg/ecco/ecco_readparms.F
+++ b/pkg/ecco/ecco_readparms.F
@@ -726,7 +726,8 @@ C--   load masks if needed:
       do k=1,NGENCOST
            kk=gencost_msk_pointer3d(k)
            if ( ( gencost_mask(k) .NE. ' ' ).AND.
-     &          (gencost_flag(k).EQ.-3) ) then
+     &          (gencost_flag(k).EQ.-3 .or. 
+     &           gencost_flag(k).eq.-4     ) ) then
 c
             il = ilnblnk(gencost_mask(k))
             write(tempfile(1:128),'(2A)') gencost_mask(k)(1:il),'C'


### PR DESCRIPTION
## What changes does this PR introduce?
In pkg/ecco, transp cost functions now use "gencost_mask" rather than "gencost_errfile", which is consistent with boxmean cost functions. 

## What is the new behaviour 
Now users specify masks with gencost_mask in data.ecco. If errfile is specified, a message is sent to STDERR to tell the user to use gencost_mask (just as with boxmean). 

## Does this PR introduce a breaking change? 
No, it passed a quick test run.