### PR TITLE
change "direct" access to "stream" to accommodate 2GiB+ record

### DIFF
--- a/lsopt/dostore.F
+++ b/lsopt/dostore.F
@@ -3,6 +3,7 @@ c
 c         arguments
 c
       integer n, i, j
+      integer*8 rectmp, tmp1, tmp2
       double precision    x(n)
       real*4 tmpx(n) 
       logical store
@@ -15,13 +16,17 @@ cph      print *, 'pathei in dostore ',
 cph     &   store, n, ntape, j
 cph)
 
+      tmp1 = n
+      tmp2 = isize
+      rectmp = tmp1*tmp2
+
       if (store) then
         do i = 1, n
           tmpx(i) = x(i)
         enddo
-        write( ntape, rec=j ) tmpx
+        write( ntape, POS=(j-1)*rectmp +1) tmpx
       else
-        read(  ntape, rec=j ) tmpx
+        read(  ntape, POS=(j-1)*rectmp +1) tmpx
 	do i = 1, n
           x(i) = tmpx(i)
         enddo

--- a/lsopt/instore.F
+++ b/lsopt/instore.F
@@ -52,8 +52,7 @@ cph)
      $    , file   = 'OPWARMD'
      $    , status = 'unknown'
      $    , form   = 'unformatted'
-     $    , access = 'direct'
-     $    , recl   = rectmp
+     $    , access = 'stream'
      $    )
 
       return


### PR DESCRIPTION
## What changes does this PR introduce?
(Bug fix, feature, docs update, ...)
change "direct" access to "stream" to accommodate 2GiB+ record

## What is the current behaviour? 
(You can also link to an open issue here)
run-time error for single record over 2GiB 

## What is the new behaviour 
(if this is a feature change)?
no more limit

## Does this PR introduce a breaking change? 
(What changes might users need to make in their application due to this PR?)
ifort is OK. not tested other compiler yet.

## Other information: