### PR TITLE
Update bling_readparms.F

### DIFF
--- a/pkg/bling/bling_readparms.F
+++ b/pkg/bling/bling_readparms.F
@@ -205,7 +205,8 @@ C   epsln            :: a very small number
      
       _RL secperday
       integer k
-#ifdef USE_EXF_INTERPOLATION
+#ifdef USE_EXFCO2
+# ifdef USE_EXF_INTERPOLATION
       INTEGER gridNx, gridNy
       INTEGER j
       _RL inp_lon0, inp_lat0, inp_dLon, inp_dLat
@@ -216,7 +217,8 @@ C   epsln            :: a very small number
       gridNx = Nx
       gridNy = Ny
 # endif /* ALLOW_EXCH2 */
-#endif /* USE_EXF_INTERPOLATION */
+# endif /* USE_EXF_INTERPOLATION */
+#endif /* USE_EXFCO2 */
 
       _BEGIN_MASTER(myThid)
       errCount = 0

--- a/pkg/bling/bling_readparms.F
+++ b/pkg/bling/bling_readparms.F
@@ -209,7 +209,14 @@ C   epsln            :: a very small number
       INTEGER gridNx, gridNy
       INTEGER j
       _RL inp_lon0, inp_lat0, inp_dLon, inp_dLat
-#endif
+# ifdef ALLOW_EXCH2
+      gridNx = exch2_mydNx(1)
+      gridNy = exch2_mydNy(1)
+# else /* ALLOW_EXCH2 */
+      gridNx = Nx
+      gridNy = Ny
+# endif /* ALLOW_EXCH2 */
+#endif /* USE_EXF_INTERPOLATION */
 
       _BEGIN_MASTER(myThid)
       errCount = 0


### PR DESCRIPTION
## What changes does this PR introduce?
Bug fix:
gridNx, gridNy not properly initialized

## What is the current behaviour? 
If using EXF_INTERP but don't wish to interpolate apco2 the model will crash

## What is the new behaviour 
Robust to using EXF_INTERP without interpolating apco2

## Does this PR introduce a breaking change? 
Only a fix. No harm done

## Other information: