### PR TITLE
Update bling_production.F

### DIFF
--- a/pkg/bling/bling_production.F
+++ b/pkg/bling/bling_production.F
@@ -845,18 +845,18 @@ c ---------------------------------------------------------------------
       IF ( useDiagnostics ) THEN
 
 c 3d global variables
-        CALL DIAGNOSTICS_FILL(Phy_sm_local,'BLGPSM  ',0,Nr,1,bi,bj,
-     &       myThid)
-        CALL DIAGNOSTICS_FILL(Phy_lg_local,'BLGPLG  ',0,Nr,1,bi,bj,
-     &       myThid)
-        CALL DIAGNOSTICS_FILL(Phy_diaz_local,'BLGPDIA ',0,Nr,1,bi,bj,
-     &       myThid)
         CALL DIAGNOSTICS_FILL(chl,    'BLGCHL  ',0,Nr,1,bi,bj,myThid)
         CALL DIAGNOSTICS_FILL(irr_mem,'BLGIMEM ',0,Nr,1,bi,bj,myThid)
+        CALL DIAGNOSTICS_FILL(poc,     'BLGPOC  ',0,Nr,1,bi,bj,myThid)
 c 3d local variables
+        CALL DIAGNOSTICS_FILL(Phy_sm_local,'BLGPSM  ',0,Nr,2,bi,bj,
+     &       myThid)
+        CALL DIAGNOSTICS_FILL(Phy_lg_local,'BLGPLG  ',0,Nr,2,bi,bj,
+     &       myThid)
+        CALL DIAGNOSTICS_FILL(Phy_diaz_local,'BLGPDIA ',0,Nr,2,bi,bj,
+     &       myThid)
         CALL DIAGNOSTICS_FILL(irrk,    'BLGIRRK ',0,Nr,2,bi,bj,myThid)
         CALL DIAGNOSTICS_FILL(irr_eff, 'BLGIEFF ',0,Nr,2,bi,bj,myThid)
-        CALL DIAGNOSTICS_FILL(poc,     'BLGPOC  ',0,Nr,2,bi,bj,myThid)
         CALL DIAGNOSTICS_FILL(theta_Fe,'BLGCHL2C',0,Nr,2,bi,bj,myThid)
         CALL DIAGNOSTICS_FILL(thFe_inv,'BLGC2CHL',0,Nr,2,bi,bj,myThid)
         CALL DIAGNOSTICS_FILL(Fe_lim,  'BLGFELIM',0,Nr,2,bi,bj,myThid)


### PR DESCRIPTION
Fix diagnostic bibjFlg, updating correctly which variables have bi-bj dimensions

## What changes does this PR introduce?
Correctly identifies dimension of diagnostics to be written

## What is the current behaviour? 
Some are wrong, but only effects diagnostic output

## What is the new behaviour 
Wrong ones correct

## Does this PR introduce a breaking change? 
No. Only effects BLING diagnostics of POC and biomass

## Other information: