### PR TITLE
Consistent masking of thin ice shelf draft

### DIFF
--- a/doc/tag-index
+++ b/doc/tag-index
@@ -1,6 +1,11 @@
     Notes on tags used in MITgcmUV
     ==============================
 
+o pkg/shelfice:
+  - fix ice shelf mask for very-thin ice shelf case, when hFacMin
+    and hFacMinDr criteria leave no room for ice (hFac(k=1)=1).
+    Note: thin ice-shelf that results in 0< hFac(k=1) <1 still need
+    to be fixed when using any seaice pkg.
 o pkg/ecco:
   - Replace "mskTrVol" and "gencost_errfile" with "gencost_mask" in
     "cost_gencost_transp", mirroring "m_horflux_vol".

--- a/pkg/shelfice/shelfice_init_fixed.F
+++ b/pkg/shelfice/shelfice_init_fixed.F
@@ -69,7 +69,7 @@ C-----------------------------------------------------------------------
         DO j = 1-OLy, sNy+OLy
          DO i = 1-OLx, sNx+OLx
           IF ( kSurfC(i,j,bi,bj).LE.Nr .AND.
-     &         Ro_surf(i,j,bi,bj).LT.zeroRS ) THEN
+     &         Ro_surf(i,j,bi,bj).LT.rF(1) ) THEN
             kTopC(i,j,bi,bj) = kSurfC(i,j,bi,bj)
           ELSE
             kTopC(i,j,bi,bj) = 0
@@ -99,7 +99,7 @@ C     like ctrl_get_gen and ctrl_set_unpack_xy require 3D masks.
         DO k=1,Nr
          DO j=1-OLy,sNy+OLy
           DO i=1-OLx,sNx+OLx
-           IF ( Ro_surf(i,j,bi,bj).LT.zeroRS
+           IF ( Ro_surf(i,j,bi,bj).LT.rF(1)
      &          .AND. hFacC(i,j,k,bi,bj).NE.zeroRS ) THEN
             maskSHI(i,j,k,bi,bj) = 1. _d 0
             maskSHI(i,j,1,bi,bj) = 1. _d 0

--- a/pkg/shelfice/shelfice_init_fixed.F
+++ b/pkg/shelfice/shelfice_init_fixed.F
@@ -69,7 +69,7 @@ C-----------------------------------------------------------------------
         DO j = 1-OLy, sNy+OLy
          DO i = 1-OLx, sNx+OLx
           IF ( kSurfC(i,j,bi,bj).LE.Nr .AND.
-     &         R_shelfIce(i,j,bi,bj).LT.zeroRS ) THEN
+     &         Ro_surf(i,j,bi,bj).LT.zeroRS ) THEN
             kTopC(i,j,bi,bj) = kSurfC(i,j,bi,bj)
           ELSE
             kTopC(i,j,bi,bj) = 0
@@ -99,7 +99,7 @@ C     like ctrl_get_gen and ctrl_set_unpack_xy require 3D masks.
         DO k=1,Nr
          DO j=1-OLy,sNy+OLy
           DO i=1-OLx,sNx+OLx
-           IF ( R_shelfIce(i,j,bi,bj).LT.zeroRS
+           IF ( Ro_surf(i,j,bi,bj).LT.zeroRS
      &          .AND. hFacC(i,j,k,bi,bj).NE.zeroRS ) THEN
             maskSHI(i,j,k,bi,bj) = 1. _d 0
             maskSHI(i,j,1,bi,bj) = 1. _d 0

--- a/pkg/shelfice/shelfice_thermodynamics.F
+++ b/pkg/shelfice/shelfice_thermodynamics.F
@@ -255,7 +255,7 @@ C--   underneath the ice
         DO J = 1, sNy
          DO I = 1, sNx
           K         = MAX(1,kTopC(I,J,bi,bj))
-          pLoc(I,J) = ABS(R_shelfIce(I,J,bi,bj))
+          pLoc(I,J) = ABS(Ro_surf(I,J,bi,bj))
 c         pLoc(I,J) = shelficeMass(I,J,bi,bj)*gravity*1. _d -4
           tLoc(I,J) = theta(I,J,K,bi,bj)
           sLoc(I,J) = MAX(salt(I,J,K,bi,bj), zeroRL)

--- a/pkg/shelfice/shelfice_thermodynamics.F
+++ b/pkg/shelfice/shelfice_thermodynamics.F
@@ -255,7 +255,7 @@ C--   underneath the ice
         DO J = 1, sNy
          DO I = 1, sNx
           K         = MAX(1,kTopC(I,J,bi,bj))
-          pLoc(I,J) = ABS(Ro_surf(I,J,bi,bj))
+          pLoc(I,J) = ABS(R_shelfIce(I,J,bi,bj))
 c         pLoc(I,J) = shelficeMass(I,J,bi,bj)*gravity*1. _d -4
           tLoc(I,J) = theta(I,J,K,bi,bj)
           sLoc(I,J) = MAX(salt(I,J,K,bi,bj), zeroRL)


### PR DESCRIPTION
## What changes does this PR introduce?
This ensures the ice shelf mask is consistent throughout all parts of the code, by replacing R_shelfice with Ro_surf in shelfice_thermodynamics and shelfice_init_fixed.


## What is the current behaviour? 
Issue #99 describes how cells with very thin ice draft (violating hFacMin and hFacMinDr) are treated as open ocean cells by most of the code, but the ice shelf thermodynamics still sees the original ice shelf draft in its mask. Therefore, the cells are simultaneously sea ice cells and ice shelf cells.


## What is the new behaviour 
Cells with sufficiently thin ice draft are now consistently treated as open ocean cells (hFac=1).


## Does this PR introduce a breaking change? 
Martin Losch has confirmed this fix changes the results of the isomip verification experiment, and suggests this experiment should be rerun.


## Other information: