### PR TITLE
Add instructions for building pdf version of the manual

### DIFF
--- a/doc/contributing/contributing.rst
+++ b/doc/contributing/contributing.rst
@@ -659,7 +659,9 @@ Once you've made your changes to the manual, you should build it locally to veri
  - sphinxcontrib-bibtex
  - sphinx_rtd_theme
 
-Once these modules are installed you can build the html version of the manual by running ``make html`` in the ``doc`` directory. To build the pdf version of the manual you will also need a working version of LaTeX installed. The command to build the pdf version is ``make latexpdf``, which should also be run in the ``doc`` directory.
+Once these modules are installed you can build the html version of the manual by running ``make html`` in the ``doc`` directory. 
+
+To build the pdf version of the manual you will also need a working version of LaTeX that includes `several packages <http://www.sphinx-doc.org/en/master/usage/builders/index.html#sphinx.builders.latex.LaTeXBuilder>`_ that are not always found in minimal LaTeX installations. The command to build the pdf version is ``make latexpdf``, which should also be run in the ``doc`` directory.
 
 
 

--- a/doc/contributing/contributing.rst
+++ b/doc/contributing/contributing.rst
@@ -653,7 +653,7 @@ Alternatively, latex ``:math:`` directives (see :ref:`above <symbolic_notation>`
 Building the manual
 -------------------
 
-Once you've made your changes to the manual, you should build it locally to verify that it works as expected. To do this you will need a working python installation with the following modules installed (use ``pip install MODULE`` in the terminal):
+Once you've made your changes to the manual, you should build it locally to verify that it works as expected. To do this you will need a working python installation with the following modules installed (use ``pip install «MODULE»`` in the terminal):
 
  - sphinx
  - sphinxcontrib-bibtex

--- a/doc/contributing/contributing.rst
+++ b/doc/contributing/contributing.rst
@@ -659,7 +659,7 @@ Once you've made your changes to the manual, you should build it locally to veri
  - sphinxcontrib-bibtex
  - sphinx_rtd_theme
 
-Then, run :code:`make html` in the :code:`docs` directory.
+Once these modules are installed you can build the html version of the manual by running :code:`make html` in the :code:`doc` directory. To build the pdf version of the manual you will also need a working version of LaTeX installed. The command to build the pdf version is :code:`make latexpdf`, which should also be run in the :code:`doc` directory.
 
 
 

--- a/doc/contributing/contributing.rst
+++ b/doc/contributing/contributing.rst
@@ -653,13 +653,13 @@ Alternatively, latex ``:math:`` directives (see :ref:`above <symbolic_notation>`
 Building the manual
 -------------------
 
-Once you've made your changes to the manual, you should build it locally to verify that it works as expected. To do this you will need a working python installation with the following modules installed (use :code:`pip install MODULE` in the terminal):
+Once you've made your changes to the manual, you should build it locally to verify that it works as expected. To do this you will need a working python installation with the following modules installed (use ``pip install MODULE`` in the terminal):
 
  - sphinx
  - sphinxcontrib-bibtex
  - sphinx_rtd_theme
 
-Once these modules are installed you can build the html version of the manual by running :code:`make html` in the :code:`doc` directory. To build the pdf version of the manual you will also need a working version of LaTeX installed. The command to build the pdf version is :code:`make latexpdf`, which should also be run in the :code:`doc` directory.
+Once these modules are installed you can build the html version of the manual by running ``make html`` in the ``doc`` directory. To build the pdf version of the manual you will also need a working version of LaTeX installed. The command to build the pdf version is ``make latexpdf``, which should also be run in the ``doc`` directory.
 
 
 


### PR DESCRIPTION
As noted by @jm-c (https://github.com/MITgcm/MITgcm/pull/123#issuecomment-405416243) the manual doesn't describe how to build the pdf version of the manual. This very small PR rectifies that omission.

## What changes does this PR introduce?
Add the command to building the pdf version of the manual to chapter 5.

## What is the current behaviour? 
pdf build is not mentioned.


## Does this PR introduce a breaking change? 
No.