### PR TITLE
Add entry-point calls to pkg/spoil subroutines

### DIFF
--- a/pkg/gchem/gchem_calc_tendency.F
+++ b/pkg/gchem/gchem_calc_tendency.F
@@ -97,6 +97,13 @@ c       ENDDO
 C------------------------
 C chemical forcing      |
 C------------------------
+#ifdef ALLOW_SPOIL
+        IF ( useSPOIL ) THEN
+          CALL SPOIL_CALC_TENDENCY( bi, bj,
+     I                              myTime, myIter, myThid )
+        ENDIF
+#endif /* ALLOW_SPOIL */
+
 #ifdef ALLOW_CFC
         IF ( useCFC ) THEN
          iTr = CFC_pTr_i1

--- a/pkg/gchem/gchem_init_fixed.F
+++ b/pkg/gchem/gchem_init_fixed.F
@@ -57,6 +57,12 @@ c         _END_MASTER( myThid )
       ENDIF
 #endif
 
+#ifdef ALLOW_SPOIL
+      IF ( useSPOIL ) THEN
+         CALL SPOIL_INIT_FIXED( myThid )
+      ENDIF
+#endif
+
 #ifdef ALLOW_DIAGNOSTICS
 C     Define diagnostics Names :
       IF ( useDiagnostics ) THEN

--- a/pkg/gchem/gchem_init_vari.F
+++ b/pkg/gchem/gchem_init_vari.F
@@ -90,6 +90,12 @@ C--   Initialise other Geo-Chemistry pkg variables:
 # endif
 #endif /* ALLOW_BLING */
 
+#ifdef ALLOW_SPOIL
+      IF ( useSPOIL ) THEN
+         CALL SPOIL_INIT_VARIA( myThid )
+      ENDIF
+#endif /* ALLOW_SPOIL */
+
 #ifdef ALLOW_DARWIN
       IF ( useDARWIN ) THEN
          CALL DARWIN_INIT_VARI(myThid )


### PR DESCRIPTION
Add entry-point calls in pkg/gchem to pkg/spoil subroutines.
pkg/spoil is not yet ready for being added to main Git repos
but useful to have few calls already in place (easier to maintained)

## Does this PR introduce a breaking change? 
Since all the added calls are protected by CPP option "ALLOW_SPOIL",
the compiled code remain exactly unchanged.

## Other information:
useSPOIL (in GCHEM.h) and call to SPOIL_READPARMS were added earlier, in Dec 2017.