### PR TITLE
Add missing cpp bling options

### DIFF
--- a/model/src/forward_step.F
+++ b/model/src/forward_step.F
@@ -31,6 +31,9 @@
 #ifdef ALLOW_DIC
 # include "DIC_OPTIONS.h"
 #endif
+#ifdef ALLOW_BLING
+# include "BLING_OPTIONS.h"
+#endif
 #ifdef ALLOW_EXF
 # include "EXF_OPTIONS.h"
 #endif

--- a/model/src/main_do_loop.F
+++ b/model/src/main_do_loop.F
@@ -27,6 +27,9 @@ c#endif
 #ifdef ALLOW_DIC
 # include "DIC_OPTIONS.h"
 #endif
+#ifdef ALLOW_BLING
+# include "BLING_OPTIONS.h"
+#endif
 #ifdef ALLOW_EXF
 # include "EXF_OPTIONS.h"
 #endif

--- a/model/src/main_do_loop.F
+++ b/model/src/main_do_loop.F
@@ -27,9 +27,6 @@ c#endif
 #ifdef ALLOW_DIC
 # include "DIC_OPTIONS.h"
 #endif
-#ifdef ALLOW_BLING
-# include "BLING_OPTIONS.h"
-#endif
 #ifdef ALLOW_EXF
 # include "EXF_OPTIONS.h"
 #endif
@@ -108,10 +105,6 @@ c**************************************
 #  include "DIC_ATMOS.h"
 #  include "DIC_CTRL.h"
 #  include "DIC_COST.h"
-# endif
-# ifdef ALLOW_BLING
-#  include "BLING_VARS.h"
-#  include "BLING_LOAD.h"
 # endif
 # ifdef ALLOW_OBCS
 #  include "OBCS_PARAMS.h"

--- a/model/src/the_main_loop.F
+++ b/model/src/the_main_loop.F
@@ -121,10 +121,6 @@ c They provide the fields to be stored.
 #   include "DIC_CTRL.h"
 #   include "DIC_COST.h"
 #  endif
-#  ifdef ALLOW_BLING
-#   include "BLING_VARS.h"
-#   include "BLING_LOAD.h"
-#  endif
 #  ifdef ALLOW_OBCS
 #   include "OBCS_PARAMS.h"
 #   include "OBCS_FIELDS.h"
@@ -135,10 +131,15 @@ c They provide the fields to be stored.
 #  endif
 #  ifdef ALLOW_EXF
 #   include "EXF_FIELDS.h"
+#   include "EXF_PARAM.h"
 #   ifdef ALLOW_BULKFORMULAE
 #    include "EXF_CONSTANTS.h"
 #   endif
 #  endif /* ALLOW_EXF */
+#  ifdef ALLOW_BLING
+#   include "BLING_VARS.h"
+#   include "BLING_LOAD.h"
+#  endif
 #  ifdef ALLOW_SEAICE
 #   include "SEAICE_SIZE.h"
 #   include "SEAICE.h"

--- a/model/src/the_main_loop.F
+++ b/model/src/the_main_loop.F
@@ -24,6 +24,9 @@
 #ifdef ALLOW_DIC
 # include "DIC_OPTIONS.h"
 #endif
+#ifdef ALLOW_BLING
+# include "BLING_OPTIONS.h"
+#endif
 #ifdef ALLOW_EXF
 # include "EXF_OPTIONS.h"
 #endif


### PR DESCRIPTION
## What changes does this PR introduce?
(Bug fix)
model src routines missing BLING_OPTIONS.h CPP option

## What is the current behaviour? 
Improper handling of EXF CO2, including writing of sensitivity to apco2

## What is the new behaviour 
fixes this issue

## Does this PR introduce a breaking change? 
This will not effect any testers as none define USE_EXFCO2 in BLING_OPTIONS 

## Other information: