### PR TITLE
Make sure dissociation constants are on the same pH scale

### DIFF
--- a/pkg/dic/carbon_chem.F
+++ b/pkg/dic/carbon_chem.F
@@ -402,7 +402,6 @@ C     == Local variables ==
         _RL  siooh3g
         _RL  fco2
 
-
 c ---------------------------------------------------------------------
 C Change units from the input of mol/m^3 -> mol/kg:
 c (1 mol/m^3)  x (1 m^3/1024.5 kg)
@@ -566,6 +565,13 @@ c add Bennington
         _RL  delta
         _RL  B1
         _RL  B
+#ifdef CARBONCHEM_TOTALPHSCALE
+c pH scale converstions
+        _RL kgfw2kgsw
+        _RL total2free
+        _RL free2sw        
+        _RL total2sw
+#endif
         INTEGER i
         INTEGER j
 
@@ -585,15 +591,18 @@ C....................................................................
           if (hFacC(i,j,1,bi,bj).gt.0. _d 0) then
            t = ttemp(i,j)
            s = stemp(i,j)
-C terms used more than once
+C terms used more than once for:
+C temperature
            tk = 273.15 _d 0 + t
            tk100 = tk/100. _d 0
            tk1002=tk100*tk100
            invtk=1.0 _d 0/tk
            dlogtk=log(tk)
+C ionic strength
            is=19.924 _d 0*s/(1000. _d 0-1.005 _d 0*s)
            is2=is*is
            sqrtis=sqrt(is)
+C salinity
            s2=s*s
            sqrts=sqrt(s)
            s15=s**1.5 _d 0
@@ -619,6 +628,7 @@ C Weiss & Price (1980, Mar. Chem., 8, 347-359; Eq 13 with table 6 values)
      &          0.0049867 _d 0*tk1002))
 C------------------------------------------------------------------------
 C K0 from Weiss 1974
+C Independent of pH scale
            ak0(i,j,bi,bj) = exp(93.4517 _d 0/tk100 - 60.2409 _d 0 +
      &        23.3585 _d 0 * log(tk100) +
      &        s * (0.023517 _d 0 - 0.023656 _d 0*tk100 +
@@ -626,7 +636,8 @@ C K0 from Weiss 1974
 C------------------------------------------------------------------------
 C k1 = [H][HCO3]/[H2CO3]
 C k2 = [H][CO3]/[HCO3]
-C Millero p.664 (1995) using Mehrbach et al. data on seawater scale
+C Millero p.664 (1995) using Mehrbach et al. data 
+C Both on seawater pH scale
            ak1(i,j,bi,bj)=10.**(-1. _d 0*(3670.7 _d 0*invtk -
      &          62.008 _d 0 + 9.7944 _d 0*dlogtk -
      &          0.0118 _d 0 * s + 0.000116 _d 0*s2))
@@ -635,6 +646,7 @@ C Millero p.664 (1995) using Mehrbach et al. data on seawater scale
 C------------------------------------------------------------------------
 C kb = [H][BO2]/[HBO2]
 C Millero p.669 (1995) using data from dickson (1990)
+C On total pH scale
            akb(i,j,bi,bj)=exp((-8966.90 _d 0- 2890.53 _d 0*sqrts -
      &          77.942 _d 0*s + 1.728 _d 0*s15 - 0.0996 _d 0*s2)*invtk +
      &          (148.0248 _d 0 + 137.1942 _d 0*sqrts + 1.62142 _d 0*s) +
@@ -643,6 +655,9 @@ C Millero p.669 (1995) using data from dickson (1990)
 C------------------------------------------------------------------------
 C k1p = [H][H2PO4]/[H3PO4]
 C DOE(1994) eq 7.2.20 with footnote using data from Millero (1974)
+C The constant 115.525 is an approximation to convert to the total pH scale 
+C  (Dickson et al., 2007). Use Millero's 115.540 constant to stay on the seawater
+C  pH scale (everything else is the same).
            ak1p(i,j,bi,bj) = exp(-4576.752 _d 0*invtk + 115.525 _d 0 -
      &          18.453 _d 0*dlogtk +
      &          (-106.736 _d 0*invtk + 0.69171 _d 0)*sqrts +
@@ -650,6 +665,9 @@ C DOE(1994) eq 7.2.20 with footnote using data from Millero (1974)
 C------------------------------------------------------------------------
 C k2p = [H][HPO4]/[H2PO4]
 C DOE(1994) eq 7.2.23 with footnote using data from Millero (1974))
+C The constant 172.0833 is an approximation to convert to the total pH scale 
+C  (Dickson et al., 2007). Use Millero's 172.1033 constant to stay on the seawater
+C  pH scale (everything else is the same).
            ak2p(i,j,bi,bj) = exp(-8814.715 _d 0*invtk + 172.0883 _d 0 -
      &          27.927 _d 0*dlogtk +
      &          (-160.340 _d 0*invtk + 1.3566 _d 0) * sqrts +
@@ -657,12 +675,18 @@ C DOE(1994) eq 7.2.23 with footnote using data from Millero (1974))
 C------------------------------------------------------------------------
 C k3p = [H][PO4]/[HPO4]
 C DOE(1994) eq 7.2.26 with footnote using data from Millero (1974)
+C The constant 18.141 is an approximation to convert to the total pH scale 
+C  (Dickson et al., 2007). Use Millero's 18.126 constant to stay on the seawater
+C  pH scale (everything else is the same).
            ak3p(i,j,bi,bj) = exp(-3070.75 _d 0*invtk - 18.141 _d 0 +
      &          (17.27039 _d 0*invtk + 2.81197 _d 0) *
      &          sqrts + (-44.99486 _d 0*invtk - 0.09984 _d 0) * s)
 C------------------------------------------------------------------------
 C ksi = [H][SiO(OH)3]/[Si(OH)4]
 C Millero p.671 (1995) using data from Yao and Millero (1995)
+C The constant 117.385 is an approximation to convert to the total pH scale 
+C  (Dickson et al., 2007). Use Millero's 117.400 constant to stay on the seawater
+C  pH scale (everything else is the same).
            aksi(i,j,bi,bj) = exp(-8904.2 _d 0*invtk + 117.385 _d 0 -
      &          19.334 _d 0*dlogtk +
      &          (-458.79 _d 0*invtk + 3.5913 _d 0) * sqrtis +
@@ -672,6 +696,9 @@ C Millero p.671 (1995) using data from Yao and Millero (1995)
 C------------------------------------------------------------------------
 C kw = [H][OH]
 C Millero p.670 (1995) using composite data
+C The constant 148.9652 is an approximation to convert to the total pH scale 
+C  (Dickson et al., 2007). Use Millero's 148.9802 constant to stay on the seawater
+C  pH scale (everything else is the same).
            akw(i,j,bi,bj) = exp(-13847.26 _d 0*invtk + 148.9652 _d 0 -
      &          23.6521 _d 0*dlogtk +
      &          (118.67 _d 0*invtk - 5.977 _d 0 + 1.0495 _d 0 * dlogtk)
@@ -679,6 +706,7 @@ C Millero p.670 (1995) using composite data
 C------------------------------------------------------------------------
 C ks = [H][SO4]/[HSO4]
 C dickson (1990, J. chem. Thermodynamics 22, 113)
+C On the free pH scale
            aks(i,j,bi,bj)=exp(-4276.1 _d 0*invtk + 141.328 _d 0 -
      &          23.093 _d 0*dlogtk +
      &   (-13856. _d 0*invtk + 324.57 _d 0 - 47.986 _d 0*dlogtk)*sqrtis+
@@ -687,7 +715,7 @@ C dickson (1990, J. chem. Thermodynamics 22, 113)
      &          log(1.0 _d 0 - 0.001005 _d 0*s))
 C------------------------------------------------------------------------
 C kf = [H][F]/[HF]
-C dickson and Riley (1979) -- change pH scale to total
+C dickson and Riley (1979) -- change pH scale to total (following Dickson & Goyet, 1994)
            akf(i,j,bi,bj)=exp(1590.2 _d 0*invtk - 12.641 _d 0 +
      &   1.525 _d 0*sqrtis + log(1.0 _d 0 - 0.001005 _d 0*s) +
      &   log(1.0 _d 0 + (0.1400 _d 0/96.062 _d 0)*(scl)/aks(i,j,bi,bj)))
@@ -700,6 +728,26 @@ C Morris & Riley (1966)
 C Riley (1965)
            ft(i,j,bi,bj) = 0.000067 _d 0 * scl/18.9984 _d 0
 C------------------------------------------------------------------------
+#ifdef CARBONCHEM_TOTALPHSCALE
+C Convert between pH scales, we want everything to end up on the total scale
+C ak1 and ak2 are on seawater scale and aks is on the free scale
+           kgfw2kgsw     = 1. _d 0 - 0.001005 _d 0*s
+
+           total2free = 1. _d 0/
+     &                 (1. _d 0 + st(i,j,bi,bj)/aks(i,j,bi,bj)) 
+
+           free2sw = 1. _d 0 
+     &                 + st(i,j,bi,bj)/ aks(i,j,bi,bj) 
+     &                 + ft(i,j,bi,bj)/(akf(i,j,bi,bj)*total2free) 
+           total2sw = total2free * free2sw                         
+
+           ak1(i,j,bi,bj)  = ak1(i,j,bi,bj)/total2sw
+           ak2(i,j,bi,bj)  = ak2(i,j,bi,bj)/total2sw
+C aks, aksi and akf are in mol/kg-H20, so need extra unit conversion to mol/kg-SW
+           aks(i,j,bi,bj) = kgfw2kgsw*aks(i,j,bi,bj)/total2free
+           aksi(i,j,bi,bj)= kgfw2kgsw*aksi(i,j,bi,bj)
+           akf(i,j,bi,bj) = kgfw2kgsw*akf(i,j,bi,bj)      
+#endif
          else
 c add Bennington
             fugf(i,j,bi,bj)=0. _d 0
@@ -826,7 +874,16 @@ C LOCAL VARIABLES
         _RL  dk
         _RL  pfactor
         _RL  bigR
-
+#ifdef CARBONCHEM_TOTALPHSCALE
+c pH scale converstions
+        _RL kgfw2kgsw
+        _RL total2free_surf
+        _RL free2sw_surf       
+        _RL total2sw_surf
+        _RL total2free
+        _RL free2sw        
+        _RL total2sw
+#endif
 C.....................................................................
 C OCMIP note:
 C Calculate all constants needed to convert between various measured
@@ -879,6 +936,7 @@ C terms used more than once
            s15=s**1.5
            scl=s/1.80655
 
+           bigR = 83.14472
 C------------------------------------------------------------------------
 C f = k0(1-pH2O)*correction term for non-ideality
 C Weiss & Price (1980, Mar. Chem., 8, 347-359; Eq 13 with table 6 values)
@@ -888,6 +946,7 @@ C Weiss & Price (1980, Mar. Chem., 8, 347-359; Eq 13 with table 6 values)
      &          0.0049867*tk1002))
 C------------------------------------------------------------------------
 C K0 from Weiss 1974
+C Independent of pH scale
            ak0(i,j,bi,bj) = exp(93.4517/tk100 - 60.2409 +
      &        23.3585 * log(tk100) +
      &        s * (0.023517 - 0.023656*tk100 +
@@ -895,7 +954,8 @@ C K0 from Weiss 1974
 C------------------------------------------------------------------------
 C k1 = [H][HCO3]/[H2CO3]
 C k2 = [H][CO3]/[HCO3]
-C Millero p.664 (1995) using Mehrbach et al. data on seawater scale
+C Millero p.664 (1995) using Mehrbach et al. data 
+C Both on seawater pH scale
            ak1(i,j,bi,bj)=10**(-1*(3670.7*invtk -
      &          62.008 + 9.7944*dlogtk -
      &          0.0118 * s + 0.000116*s2))
@@ -917,11 +977,26 @@ c                   E. Lewis and D. Wallace (1998) ORNL/CDIAC-105
 C------------------------------------------------------------------------
 C kb = [H][BO2]/[HBO2]
 C Millero p.669 (1995) using data from dickson (1990)
+C On total pH scale
            akb(i,j,bi,bj)=exp((-8966.90 - 2890.53*sqrts - 77.942*s +
      &          1.728*s15 - 0.0996*s2)*invtk +
      &          (148.0248 + 137.1942*sqrts + 1.62142*s) +
      &          (-24.4344 - 25.085*sqrts - 0.2474*s) *
      &          dlogtk + 0.053105*sqrts*tk)
+#ifdef CARBONCHEM_TOTALPHSCALE
+C JML Not yet, need to account for pH scale conversions
+C    (pressure correct on the seawater scale, not the total scale)
+C Mick and Karsten - Dec 04
+C ADDING pressure dependence based on Millero (1995), p675
+C with additional info from CO2sys documentation (E. Lewis and
+C D. Wallace, 1998 - see endnotes for commentary on Millero, 95)
+C           bigR = 83.145
+C           dv = -29.48 + 0.1622*t + 2.608d-3*t*t
+C           dk = -2.84d-3
+C           pfactor = - (dv/(bigR*tk))*pressc
+C     &               + (0.5*dk/(bigR*tk))*pressc*pressc
+C           akb(i,j,bi,bj) = akb(i,j,bi,bj)*exp(pfactor)
+#else
 C Mick and Karsten - Dec 04
 C ADDING pressure dependence based on Millero (1995), p675
 C with additional info from CO2sys documentation (E. Lewis and
@@ -932,16 +1007,23 @@ C D. Wallace, 1998 - see endnotes for commentary on Millero, 95)
            pfactor = - (dv/(bigR*tk))*pressc
      &               + (0.5*dk/(bigR*tk))*pressc*pressc
            akb(i,j,bi,bj) = akb(i,j,bi,bj)*exp(pfactor)
+#endif
 C------------------------------------------------------------------------
 C k1p = [H][H2PO4]/[H3PO4]
 C DOE(1994) eq 7.2.20 with footnote using data from Millero (1974)
+C The constant 115.525 is an approximation to convert to the total pH scale 
+C  (Dickson et al., 2007). Use Millero's 115.540 constant to stay on the seawater
+C  pH scale (everything else is the same).
            ak1p(i,j,bi,bj) = exp(-4576.752*invtk + 115.525 -
      &          18.453*dlogtk +
      &          (-106.736*invtk + 0.69171)*sqrts +
      &          (-0.65643*invtk - 0.01844)*s)
 C------------------------------------------------------------------------
 C k2p = [H][HPO4]/[H2PO4]
-C DOE(1994) eq 7.2.23 with footnote using data from Millero (1974))
+C DOE(1994) eq 7.2.23 with footnote using data from Millero (1974)
+C The constant 172.0833 is an approximation to convert to the total pH scale 
+C  (Dickson et al., 2007). Use Millero's 172.1033 constant to stay on the seawater
+C  pH scale (everything else is the same).
            ak2p(i,j,bi,bj) = exp(-8814.715*invtk + 172.0883 -
      &          27.927*dlogtk +
      &          (-160.340*invtk + 1.3566) * sqrts +
@@ -949,12 +1031,18 @@ C DOE(1994) eq 7.2.23 with footnote using data from Millero (1974))
 C------------------------------------------------------------------------
 C k3p = [H][PO4]/[HPO4]
 C DOE(1994) eq 7.2.26 with footnote using data from Millero (1974)
+C The constant 18.141 is an approximation to convert to the total pH scale 
+C  (Dickson et al., 2007). Use Millero's 18.126 constant to stay on the seawater
+C  pH scale (everything else is the same).
            ak3p(i,j,bi,bj) = exp(-3070.75*invtk - 18.141 +
      &          (17.27039*invtk + 2.81197) *
      &          sqrts + (-44.99486*invtk - 0.09984) * s)
 C------------------------------------------------------------------------
 C ksi = [H][SiO(OH)3]/[Si(OH)4]
 C Millero p.671 (1995) using data from Yao and Millero (1995)
+C The constant 117.385 is an approximation to convert to the total pH scale 
+C  (Dickson et al., 2007). Use Millero's 117.400 constant to stay on the seawater
+C  pH scale (everything else is the same).
            aksi(i,j,bi,bj) = exp(-8904.2*invtk + 117.385 -
      &          19.334*dlogtk +
      &          (-458.79*invtk + 3.5913) * sqrtis +
@@ -964,6 +1052,9 @@ C Millero p.671 (1995) using data from Yao and Millero (1995)
 C------------------------------------------------------------------------
 C kw = [H][OH]
 C Millero p.670 (1995) using composite data
+C The constant 148.9652 is an approximation to convert to the total pH scale 
+C  (Dickson et al., 2007). Use Millero's 148.9802 constant to stay on the seawater
+C  pH scale (everything else is the same).
            akw(i,j,bi,bj) = exp(-13847.26*invtk + 148.9652 -
      &          23.6521*dlogtk +
      &          (118.67*invtk - 5.977 + 1.0495 * dlogtk) *
@@ -971,6 +1062,7 @@ C Millero p.670 (1995) using composite data
 C------------------------------------------------------------------------
 C ks = [H][SO4]/[HSO4]
 C dickson (1990, J. chem. Thermodynamics 22, 113)
+C On the free pH scale
            aks(i,j,bi,bj)=exp(-4276.1*invtk + 141.328 -
      &          23.093*dlogtk +
      &          (-13856*invtk + 324.57 - 47.986*dlogtk)*sqrtis +
@@ -979,7 +1071,7 @@ C dickson (1990, J. chem. Thermodynamics 22, 113)
      &          log(1.0 - 0.001005*s))
 C------------------------------------------------------------------------
 C kf = [H][F]/[HF]
-C dickson and Riley (1979) -- change pH scale to total
+C dickson and Riley (1979) -- change pH scale to total (following Dickson & Goyet, 1994)
            akf(i,j,bi,bj)=exp(1590.2*invtk - 12.641 + 1.525*sqrtis +
      &          log(1.0 - 0.001005*s) +
      &          log(1.0 + (0.1400/96.062)*(scl)/aks(i,j,bi,bj)))
@@ -992,7 +1084,121 @@ C Morris & Riley (1966)
 C Riley (1965)
            ft(i,j,bi,bj) = 0.000067 * scl/18.9984
 C------------------------------------------------------------------------
-C solubility product for calcite
+
+#ifdef CARBONCHEM_TOTALPHSCALE
+C JML Convert between pH scales, we want everything to end up on the total scale
+C ak1 and ak2 are on seawater scale and are pressure corrected, so they just need converting.
+C aks is on the free scale, it needs pressure correcting then converting to the total scale.
+C akf needs pressure correcting too, but is on the right (total) pH scale.
+C akb, ak1p, ak2p, ak3p, aksi and akw are on the total scale. Convert to the seawater
+C  scale before pressure correction, and then convert back to the total scale.
+
+C All the terms for pressure correction are from Table 9, Millero (1995), p675
+C Info about pH conversions from Munhoven (2013) and Orr and Epitalon (2015)
+           total2free_surf = 1.0/
+     &                 (1.0 + st(i,j,bi,bj)/aks(i,j,bi,bj)) 
+
+           free2sw_surf = 1.0 
+     &                 + st(i,j,bi,bj)/ aks(i,j,bi,bj) 
+     &                 + ft(i,j,bi,bj)/(akf(i,j,bi,bj)*total2free_surf) 
+     
+           total2sw_surf = total2free_surf * free2sw_surf    
+           
+           kgfw2kgsw     = 1.0 - 0.001005*s
+C------------------------------------------------------------------------         
+C Pressure correct aks on native free pH scale
+           dv=-18.03 + 0.0466*t + 0.316d-3 *t*t
+           dk=-4.53d-3 + 0.09d-3 *t
+           pfactor = -(dv/(bigR*tk))*pressc
+     &            +(0.5*dk/(bigR*tk))*pressc*pressc
+           aks(i,j,bi,bj) = kgfw2kgsw*aks(i,j,bi,bj)*exp(pfactor)
+
+           total2free = 1./
+     &                 (1. + st(i,j,bi,bj)/aks(i,j,bi,bj)) 
+C free2sw has an additional component from fluoride           
+           free2sw    = 1. 
+     &                 + st(i,j,bi,bj)/ aks(i,j,bi,bj) 
+           
+           aks(i,j,bi,bj) = aks(i,j,bi,bj)/total2free
+           
+C------------------------------------------------------------------------
+C Pressure correct akf on the free scale before converting back to total
+           akf(i,j,bi,bj) = akf(i,j,bi,bj) * total2free_surf
+           dv  =  -9.78 + -0.0090 *t -0.942d-3 *t*t
+           dk  =  -3.91d-3 + 0.054d-3 *t
+           pfactor = -(dv/(bigR*tk))*pressc
+     &               +(0.5*dk/(bigR*tk))*pressc*pressc
+           akf(i,j,bi,bj) = akf(i,j,bi,bj) * exp(pfactor)
+           akf(i,j,bi,bj) = akf(i,j,bi,bj)/total2free        
+        
+           free2sw = free2sw 
+     &               + ft(i,j,bi,bj)/(akf(i,j,bi,bj)*total2free) 
+           total2sw = total2free * free2sw                        
+
+           akf(i,j,bi,bj) = kgfw2kgsw*akf(i,j,bi,bj)
+C------------------------------------------------------------------------
+C Convert pressure corrected ak1 and ak2 from the seawater pH scale to the total scale
+           ak1(i,j,bi,bj)  = ak1(i,j,bi,bj)/total2sw
+           ak2(i,j,bi,bj)  = ak1(i,j,bi,bj)/total2sw
+
+C------------------------------------------------------------------------
+C Pressure correct akb on the seawater scale before converting back to total scale
+            dv = -29.48 + 0.1622*t + 2.608d-3*t*t
+            dk = -2.84d-3
+            pfactor = - (dv/(bigR*tk))*pressc
+     &                + (0.5*dk/(bigR*tk))*pressc*pressc
+            akb(i,j,bi,bj) = total2sw_surf*akb(i,j,bi,bj)*exp(pfactor)
+            akb(i,j,bi,bj) = akb(i,j,bi,bj)/total2sw
+
+C------------------------------------------------------------------------
+C Pressure correct ak1p on the seawater scale before converting back to total scale
+            dv = -14.51 + 0.1211*t -0.321d-3*t*t
+            dk = -2.67d-3 + 0.0427d-3*t
+            pfactor = - (dv/(bigR*tk))*pressc
+     &                + (0.5*dk/(bigR*tk))*pressc*pressc
+            ak1p(i,j,bi,bj) = total2sw_surf*ak1p(i,j,bi,bj)*exp(pfactor)
+            ak1p(i,j,bi,bj) = ak1p(i,j,bi,bj)/total2sw
+
+C------------------------------------------------------------------------
+C Pressure correct ak2p on the seawater scale before converting back to total scale
+            dv = -23.12 + 0.1758*t -2.647d-3*t*t
+            dk = -5.15d-3 + 0.09d-3*t
+            pfactor = - (dv/(bigR*tk))*pressc
+     &                + (0.5*dk/(bigR*tk))*pressc*pressc
+            ak2p(i,j,bi,bj) = total2sw_surf*ak2p(i,j,bi,bj)*exp(pfactor)
+            ak2p(i,j,bi,bj) = ak2p(i,j,bi,bj)/total2sw
+            
+C------------------------------------------------------------------------
+C Pressure correct ak3p on the seawater scale before converting back to total scale
+            dv = -26.57 + 0.2020*t -3.042d-3*t*t
+            dk = -4.08d-3 + 0.0714d-3*t
+            pfactor = - (dv/(bigR*tk))*pressc
+     &                + (0.5*dk/(bigR*tk))*pressc*pressc
+            ak3p(i,j,bi,bj) = total2sw_surf*ak3p(i,j,bi,bj)*exp(pfactor)
+            ak3p(i,j,bi,bj) = ak3p(i,j,bi,bj)/total2sw
+            
+C------------------------------------------------------------------------
+C Pressure correct akw on the seawater scale before converting back to total scale
+            dv = -20.02 + 0.1119*t -1.409d-3*t*t
+            dk = -5.13d-3 + 0.0794d-3 *t
+            pfactor = - (dv/(bigR*tk))*pressc
+     &                + (0.5*dk/(bigR*tk))*pressc*pressc
+            akw(i,j,bi,bj) = total2sw_surf*akw(i,j,bi,bj)*exp(pfactor)
+            akw(i,j,bi,bj) = akw(i,j,bi,bj)/total2sw
+
+C------------------------------------------------------------------------
+C Pressure correct aksi on the seawater scale before converting back to total scale
+C Estimated from the effect on akb
+            dv = -29.48 + 0.1622*t + 2.608d-3*t*t
+            dk = -2.84d-3
+            pfactor = - (dv/(bigR*tk))*pressc
+     &                + (0.5*dk/(bigR*tk))*pressc*pressc
+            aksi(i,j,bi,bj) = total2sw_surf*aksi(i,j,bi,bj)*exp(pfactor)
+            aksi(i,j,bi,bj) = kgfw2kgsw*aksi(i,j,bi,bj)/total2sw
+#endif
+
+C------------------------------------------------------------------------
+C Solubility product for calcite
 C
 c Following Takahashi (1982) GEOSECS handbook
 C NOT SURE THIS IS WORKING???


### PR DESCRIPTION
## What changes does this PR introduce?
Dissociation coefficients for carbonate chemistry should be on the same pH scale (either free, total or seawater) - I have checked and documented the "ak" constants in `S/R CARBON_COEFFS` (referring to [Munhoven (2013)](https://doi.org/10.5194/gmd-6-1367-2013) and [Orr & Epitalon (2015)](https://doi.org/doi:10.5194/gmd-8-485-2015), as well as the original source [Millero (1995)](https://doi.org/10.1016/0016-7037(94)00354-O)) and found that there was a bit of a mix. I have also completed the set of pressure dependencies using relationships consistent with those already included (ak1, ak2 and akb, again consulting [Millero (1995)](https://doi.org/10.1016/0016-7037(94)00354-O) - although this doesn't seem linked, there are pH scale conversions involved so it seemed right to do it all at once).

## What is the current behaviour? 
The majority of the dissociation coefficients were on the total pH scale, K1 and K2 were on the seawater scale and KS was on the free scale (although this one isn't used that often). This is important because the coefficients are used in combination to solve the alkalinity-pH equation and calculate surface ocean pCO2 (`S/R CALC_PCO2` and `S/R CALC_PCO2_APPROX`), which then affects air-sea CO2 fluxes.

Further, `S/R CARBON_COEFFS_PRESSURE_DEP` also required the same updates as `S/R CARBON_COEFFS`, plus only ak1, ak2 and akb were corrected for pressure dependence here. 

## What is the new behaviour 
(1) ak1, ak2 and aks are converted to the total pH scale, in common with the other coefficients in both subroutines where they are calculated.
(2) aks, akf, ak1p, ak2p, ak3p, akw and aksi now have pressure dependence (which involved some pH scale conversions).

## Does this PR introduce a breaking change? 
No, nothing changes by default because the new additions must be activated by defining `CARBONCHEM_TOTALPHSCALE` in `DIC_OPTIONS.h`, although it would make sense if it became the default at some point down the line.

## Other information:
Altered coefficients slightly increase pH over the whole ocean (left=default coefficients, right=modified coefficients)
![carbon_coeffs_mod_ph](https://user-images.githubusercontent.com/26678243/43292027-bd309816-9101-11e8-98d6-1ef25f8f5bea.png)

Greater pH results in a 1-2 ppm increase in oceanic pCO2 (on a baseline of between 200 and 400 ppm, depending where you are looking).
![carbon_coeffs_mod_pco2_anomaly](https://user-images.githubusercontent.com/26678243/43292107-061e97a8-9102-11e8-93bd-93183e43b8c9.png)

Thus, there is a slight increase in outgassing (-ve values for CO2 flux) at low latitudes, and a reduction in uptake (also -ve values for CO2 flux) at higher latitudes. The Southern Ocean and North Atlantic - regions of importance for anthropogenic CO2 uptake - are particularly affected.
![carbon_coeffs_mod_co2flux_anomaly](https://user-images.githubusercontent.com/26678243/43292180-3f30104e-9102-11e8-809c-6e560eca4eb8.png)
