### PR TITLE
Promote constants in S/R CARBON_COEFFS_PRESSURE_DEP and S/R CAR_FLUX_OMEGA_TOP to double precision

### DIFF
--- a/pkg/dic/car_flux_omega_top.F
+++ b/pkg/dic/car_flux_omega_top.F
@@ -72,22 +72,22 @@ c reaches bottom layer 0=bottom, 1=top
       iflx=1
 c set some nominal particulate sinking rate
 c try 100m/day
-       WsinkPIC = 100/86400.0
+       WsinkPIC = 100. _d 0/86400. _d 0
 c calculate carbonate flux from base of each nlev
        DO j=jmin,jmax
         DO i=imin,imax
 c        exp_tot=0
          do k=1,nR
-            cflux(i,j,k)=0.d0
+            cflux(i,j,k)=0. _d 0
          enddo
          DO k=1,nLev
-          if (hFacC(i,j,k,bi,bj).gt.0.d0) then
+          if (hFacC(i,j,k,bi,bj).gt.0. _d 0) then
            caexport(i,j)= R_CP*rain_ratio(i,j,bi,bj)*bioac(i,j,k)*
-     &           (1.0-DOPfraction)*drF(k)*hFacC(i,j,k,bi,bj)
+     &           (1. _d 0-DOPfraction)*drF(k)*hFacC(i,j,k,bi,bj)
 c          exp_tot=exp_tot+caexport(i,j)
 c calculate flux to each layer from base of k
            Do ko=k+1,Nr
-            if (hFacC(i,j,ko,bi,bj).gt.0.d0) then
+            if (hFacC(i,j,ko,bi,bj).gt.0. _d 0) then
               if (ko .eq. k+1) then
                 flux_u = caexport(i,j)
               else
@@ -97,11 +97,11 @@ c calculate flux to each layer from base of k
 
 
 C flux through lower face of cell
-              if (omegaC(i,j,ko,bi,bj) .gt. 1.0) then
+              if (omegaC(i,j,ko,bi,bj) .gt. 1. _d 0) then
                 flux_l = flux_u
 
 c if at bottom, remineralize remaining flux
-                if (ko.eq.Nr.or.hFacC(i,j,ko+1,bi,bj).eq.0.d0) then
+                if (ko.eq.Nr.or.hFacC(i,j,ko+1,bi,bj).eq.0. _d 0) then
                   if (iflx.eq.1) then
 c ... at surface
                      cflux(i,j,1)=cflux(i,j,1)+
@@ -109,23 +109,24 @@ c ... at surface
                   else
 
 c ... at bottom
-                     flux_l=0.d0
+                     flux_l=0. _d 0
                   endif
                 endif
               else
 c if dissolution, then use rate from Kier (1980) Geochem. Cosmochem. Acta
 c Kiers dissolution rate in %  per day
-                 KierRate = 7.177* ((1.0-omegaC(i,j,ko,bi,bj))**4.54)
+                 KierRate = 7.177 _d 0* 
+     &             ((1. _d 0-omegaC(i,j,ko,bi,bj))**4.54 _d 0)
 c convert to per s
 c Karsten finds Kier value not in 0/0 after all... therefore drop 100 factor
 c                DissolutionRate = KierRate/(100.0*86400.0)
-                 DissolutionRate = KierRate/(86400.0)
+                 DissolutionRate = KierRate/(86400. _d 0)
 c                flux_l = flux_u*(1.0-DissolutionRate*drF(k)/WsinkPIC)
 c Karstens version
 c - gives NaNs (because using kierrate, not dissolution rate)???
 c                flux_l = flux_u*(1.0-KierRate)**(drF(k)/WsinkPIC)
 c MICKS NEW VERSION... based on vertical sinking/remin balance
-                 dumrate = -1.0d0*DissolutionRate*drF(ko)*
+                 dumrate = -1. _d 0*DissolutionRate*drF(ko)*
      &                       hFacC(i,j,ko,bi,bj)/WsinkPIC
                  flux_l = flux_u*exp(dumrate)
 c TEST ............................
@@ -137,8 +138,8 @@ c    &            omegaC(i,j,ko,bi,bj)
 c           endif
 c TEST ............................
 c no flux to ocean bottom
-                 if (ko.eq.Nr.or.hFacC(i,j,ko+1,bi,bj).eq.0.d0)
-     &                      flux_l=0.d0
+                 if (ko.eq.Nr.or.hFacC(i,j,ko+1,bi,bj).eq.0. _d 0)
+     &                      flux_l=0. _d 0
               endif
 
 c flux divergence
@@ -153,17 +154,17 @@ c TEST ............................
            else
 c if no layer below initial layer, remineralize
                if (ko.eq.k+1) then
-                if (iflx.eq.1.and.omegaC(i,j,k,bi,bj) .gt. 1.d0) then
+                if (iflx.eq.1.and.omegaC(i,j,k,bi,bj) .gt. 1. _d 0) then
 c ... at surface
                    cflux(i,j,1)=cflux(i,j,1)
-     &                  +bioac(i,j,k)*(1.0-DOPfraction)*
+     &                  +bioac(i,j,k)*(1. _d 0-DOPfraction)*
      &                    R_CP*rain_ratio(i,j,bi,bj)
      &                   *drF(k)*hFacC(i,j,k,bi,bj)/
      &                    (drF(1)*hFacC(i,j,1,bi,bj) )
                 else
 c ... at bottom
                   cflux(i,j,k)=cflux(i,j,k)
-     &                  +bioac(i,j,k)*(1.0-DOPfraction)*
+     &                  +bioac(i,j,k)*(1. _d 0-DOPfraction)*
      &                    R_CP*rain_ratio(i,j,bi,bj)
                 endif
                endif
@@ -177,14 +178,14 @@ c        flx_tot=0
 c        k=0
 c        do k=1,nR
 c          flx_tot=flx_tot+cflux(i,j,k)*drF(k)*hFacC(i,j,k,bi,bj)
-c          if (hFacC(i,j,k,bi,bj).gt.0) then
+c          if (hFacC(i,j,k,bi,bj).gt.0 _d 0) then
 c             knum=k
 c             omeg_bot=omegaC(i,j,k,bi,bj)
 c          endif
 c        enddo
-c        if (hFacC(i,j,k,bi,bj).gt.0) then
+c        if (hFacC(i,j,k,bi,bj).gt. 0. _d 0) then
 c         tmp=abs(exp_tot-flx_tot)
-c         if (tmp>1e-20) then
+c         if (tmp>1 _d -20) then
 c          print*,'QQ car_flux', knum,
 c    &                 omeg_bot, exp_tot, flx_tot, exp_tot-flx_tot
 c         endif

--- a/pkg/dic/carbon_chem.F
+++ b/pkg/dic/carbon_chem.F
@@ -750,22 +750,22 @@ C aks, aksi and akf are in mol/kg-H20, so need extra unit conversion to mol/kg-S
 #endif
          else
 c add Bennington
-            fugf(i,j,bi,bj)=0. _d 0
-            ff(i,j,bi,bj)=0. _d 0
-            ak0(i,j,bi,bj)= 0. _d 0
-            ak1(i,j,bi,bj)= 0. _d 0
-            ak2(i,j,bi,bj)= 0. _d 0
-            akb(i,j,bi,bj)= 0. _d 0
-            ak1p(i,j,bi,bj) = 0. _d 0
-            ak2p(i,j,bi,bj) = 0. _d 0
-            ak3p(i,j,bi,bj) = 0. _d 0
-            aksi(i,j,bi,bj) = 0. _d 0
-            akw(i,j,bi,bj) = 0. _d 0
-            aks(i,j,bi,bj)= 0. _d 0
-            akf(i,j,bi,bj)= 0. _d 0
-            bt(i,j,bi,bj) = 0. _d 0
-            st(i,j,bi,bj) = 0. _d 0
-            ft(i,j,bi,bj) = 0. _d 0
+           fugf(i,j,bi,bj)=0. _d 0
+           ff(i,j,bi,bj)=0. _d 0
+           ak0(i,j,bi,bj)= 0. _d 0
+           ak1(i,j,bi,bj)= 0. _d 0
+           ak2(i,j,bi,bj)= 0. _d 0
+           akb(i,j,bi,bj)= 0. _d 0
+           ak1p(i,j,bi,bj) = 0. _d 0
+           ak2p(i,j,bi,bj) = 0. _d 0
+           ak3p(i,j,bi,bj) = 0. _d 0
+           aksi(i,j,bi,bj) = 0. _d 0
+           akw(i,j,bi,bj) = 0. _d 0
+           aks(i,j,bi,bj)= 0. _d 0
+           akf(i,j,bi,bj)= 0. _d 0
+           bt(i,j,bi,bj) = 0. _d 0
+           st(i,j,bi,bj) = 0. _d 0
+           ft(i,j,bi,bj) = 0. _d 0
          endif
          end do
         end do
@@ -903,86 +903,87 @@ c for surface exchange coeffs
 cmick..............................
 c        write(6,*)'Klevel ',klevel
 
-        bdepth = 0.0d0
-        cdepth = 0.0d0
-        pressc = 1.0d0
+        bdepth = 0. _d 0
+        cdepth = 0. _d 0
+        pressc = 1. _d 0
         do k = 1,Klevel
-            cdepth = bdepth + 0.5d0*drF(k)
+            cdepth = bdepth + 0.5 _d 0*drF(k)
             bdepth = bdepth + drF(k)
-            pressc = 1.0d0 + 0.1d0*cdepth
+            pressc = 1. _d 0 + 0.1 _d 0*cdepth
         end do
 cmick...................................................
 c        write(6,*)'depth,pressc ',cdepth,pressc
 cmick....................................................
 
-
-
         do i=imin,imax
          do j=jmin,jmax
-          if (hFacC(i,j,Klevel,bi,bj).gt.0.d0) then
+          if (hFacC(i,j,Klevel,bi,bj).gt.0. _d 0) then
            t = ttemp(i,j)
            s = stemp(i,j)
-C terms used more than once
-           tk = 273.15 + t
-           tk100 = tk/100.0
+C terms used more than once for:
+C temperature
+           tk = 273.15 _d 0 + t
+           tk100 = tk/100. _d 0
            tk1002=tk100*tk100
-           invtk=1.0/tk
+           invtk=1.0 _d 0/tk
            dlogtk=log(tk)
-           is=19.924*s/(1000.-1.005*s)
+C ionic strength
+           is=19.924 _d 0*s/(1000. _d 0-1.005 _d 0*s)
            is2=is*is
            sqrtis=sqrt(is)
+C salinity
            s2=s*s
            sqrts=sqrt(s)
-           s15=s**1.5
-           scl=s/1.80655
+           s15=s**1.5 _d 0
+           scl=s/1.80655 _d 0
 
-           bigR = 83.14472
+           bigR = 83.14472 _d 0
 C------------------------------------------------------------------------
 C f = k0(1-pH2O)*correction term for non-ideality
-C Weiss & Price (1980, Mar. Chem., 8, 347-359; Eq 13 with table 6 values)
-           ff(i,j,bi,bj) = exp(-162.8301 + 218.2968/tk100  +
-     &          90.9241*log(tk100) - 1.47696*tk1002 +
-     &          s * (.025695 - .025225*tk100 +
-     &          0.0049867*tk1002))
+C Weiss & Price (1980, Mar. Chem., 8, 347-359;  Eq 13 with table 6 values)
+           ff(i,j,bi,bj) = exp(-162.8301 _d 0 + 218.2968 _d 0/tk100  +
+     &          90.9241 _d 0*log(tk100) - 1.47696 _d 0*tk1002 +
+     &          s * (.025695 _d 0 - .025225 _d 0*tk100 +
+     &          0.0049867 _d 0*tk1002))
 C------------------------------------------------------------------------
 C K0 from Weiss 1974
 C Independent of pH scale
-           ak0(i,j,bi,bj) = exp(93.4517/tk100 - 60.2409 +
-     &        23.3585 * log(tk100) +
-     &        s * (0.023517 - 0.023656*tk100 +
-     &        0.0047036*tk1002))
+           ak0(i,j,bi,bj) = exp(93.4517 _d 0/tk100 - 60.2409 _d 0 +
+     &        23.3585 _d 0 * log(tk100) +
+     &        s * (0.023517 _d 0 - 0.023656 _d 0*tk100 +
+     &        0.0047036 _d 0*tk1002))
 C------------------------------------------------------------------------
 C k1 = [H][HCO3]/[H2CO3]
 C k2 = [H][CO3]/[HCO3]
 C Millero p.664 (1995) using Mehrbach et al. data 
 C Both on seawater pH scale
-           ak1(i,j,bi,bj)=10**(-1*(3670.7*invtk -
-     &          62.008 + 9.7944*dlogtk -
-     &          0.0118 * s + 0.000116*s2))
-           ak2(i,j,bi,bj)=10**(-1*(1394.7*invtk + 4.777 -
-     &          0.0184*s + 0.000118*s2))
+           ak1(i,j,bi,bj)=10**(-1 _d 0*(3670.7 _d 0*invtk -
+     &          62.008 _d 0 + 9.7944 _d 0*dlogtk -
+     &          0.0118 _d 0 * s + 0.000116 _d 0*s2))
+           ak2(i,j,bi,bj)=10**(-1*(1394.7 _d 0*invtk + 4.777 _d 0 -
+     &          0.0184 _d 0*s + 0.000118 _d 0*s2))
 C NOW PRESSURE DEPENDENCE:
 c Following Takahashi (1981) GEOSECS report - quoting Culberson and
 c Pytkowicz (1968)
 c pressc = pressure in bars
            ak1(i,j,bi,bj) = ak1(i,j,bi,bj)*
-     &             exp( (24.2-0.085*t)*(pressc-1.0)/(83.143*tk) )
+     &         exp( (24.2 _d 0-0.085 _d 0*t)*(pressc-1.0 _d 0)/(83.143 _d 0*tk) )
 c FIRST GO FOR K2: According to GEOSECS (1982) report
 c          ak2(i,j,bi,bj) = ak2(i,j,bi,bj)*
 c    &             exp( (26.4-0.040*t)*(pressc-1.0)/(83.143*tk) )
 c SECOND GO FOR K2: corrected coeff according to CO2sys documentation
 c                   E. Lewis and D. Wallace (1998) ORNL/CDIAC-105
            ak2(i,j,bi,bj) = ak2(i,j,bi,bj)*
-     &             exp( (16.4-0.040*t)*(pressc-1.0)/(83.143*tk) )
+     &         exp( (16.4 _d 0-0.040 _d 0*t)*(pressc-1.0 _d 0)/(83.143 _d 0*tk) )
 C------------------------------------------------------------------------
 C kb = [H][BO2]/[HBO2]
 C Millero p.669 (1995) using data from dickson (1990)
 C On total pH scale
-           akb(i,j,bi,bj)=exp((-8966.90 - 2890.53*sqrts - 77.942*s +
-     &          1.728*s15 - 0.0996*s2)*invtk +
-     &          (148.0248 + 137.1942*sqrts + 1.62142*s) +
-     &          (-24.4344 - 25.085*sqrts - 0.2474*s) *
-     &          dlogtk + 0.053105*sqrts*tk)
+           akb(i,j,bi,bj)=exp((-8966.90 _d 0- 2890.53 _d 0*sqrts -
+     &          77.942 _d 0*s + 1.728 _d 0*s15 - 0.0996 _d 0*s2)*invtk +
+     &          (148.0248 _d 0 + 137.1942 _d 0*sqrts + 1.62142 _d 0*s) +
+     &          (-24.4344 _d 0 - 25.085 _d 0*sqrts - 0.2474 _d 0*s) *
+     &          dlogtk + 0.053105 _d 0*sqrts*tk)
 #ifdef CARBONCHEM_TOTALPHSCALE
 C JML Not yet, need to account for pH scale conversions
 C    (pressure correct on the seawater scale, not the total scale)
@@ -1001,11 +1002,11 @@ C Mick and Karsten - Dec 04
 C ADDING pressure dependence based on Millero (1995), p675
 C with additional info from CO2sys documentation (E. Lewis and
 C D. Wallace, 1998 - see endnotes for commentary on Millero, 95)
-           bigR = 83.145
-           dv = -29.48 + 0.1622*t + 2.608d-3*t*t
-           dk = -2.84d-3
+           bigR = 83.145 _d 0
+           dv = -29.48 _d 0 + 0.1622 _d 0*t + 2.608 _d -3*t*t
+           dk = -2.84 _d -3
            pfactor = - (dv/(bigR*tk))*pressc
-     &               + (0.5*dk/(bigR*tk))*pressc*pressc
+     &               + (0.5 _d 0*dk/(bigR*tk))*pressc*pressc
            akb(i,j,bi,bj) = akb(i,j,bi,bj)*exp(pfactor)
 #endif
 C------------------------------------------------------------------------
@@ -1014,75 +1015,76 @@ C DOE(1994) eq 7.2.20 with footnote using data from Millero (1974)
 C The constant 115.525 is an approximation to convert to the total pH scale 
 C  (Dickson et al., 2007). Use Millero's 115.540 constant to stay on the seawater
 C  pH scale (everything else is the same).
-           ak1p(i,j,bi,bj) = exp(-4576.752*invtk + 115.525 -
-     &          18.453*dlogtk +
-     &          (-106.736*invtk + 0.69171)*sqrts +
-     &          (-0.65643*invtk - 0.01844)*s)
+           ak1p(i,j,bi,bj) = exp(-4576.752 _d 0*invtk + 115.525 _d 0 -
+     &          18.453 _d 0*dlogtk +
+     &          (-106.736 _d 0*invtk + 0.69171 _d 0)*sqrts +
+     &          (-0.65643 _d 0*invtk - 0.01844 _d 0)*s)
 C------------------------------------------------------------------------
 C k2p = [H][HPO4]/[H2PO4]
 C DOE(1994) eq 7.2.23 with footnote using data from Millero (1974)
 C The constant 172.0833 is an approximation to convert to the total pH scale 
 C  (Dickson et al., 2007). Use Millero's 172.1033 constant to stay on the seawater
 C  pH scale (everything else is the same).
-           ak2p(i,j,bi,bj) = exp(-8814.715*invtk + 172.0883 -
-     &          27.927*dlogtk +
-     &          (-160.340*invtk + 1.3566) * sqrts +
-     &          (0.37335*invtk - 0.05778) * s)
+           ak2p(i,j,bi,bj) = exp(-8814.715 _d 0*invtk + 172.0883 _d 0 -
+     &          27.927 _d 0*dlogtk +
+     &          (-160.34 _d 00*invtk + 1.3566 _d 0) * sqrts +
+     &          (0.37335 _d 0*invtk - 0.05778 _d 0) * s)
 C------------------------------------------------------------------------
 C k3p = [H][PO4]/[HPO4]
 C DOE(1994) eq 7.2.26 with footnote using data from Millero (1974)
 C The constant 18.141 is an approximation to convert to the total pH scale 
 C  (Dickson et al., 2007). Use Millero's 18.126 constant to stay on the seawater
 C  pH scale (everything else is the same).
-           ak3p(i,j,bi,bj) = exp(-3070.75*invtk - 18.141 +
-     &          (17.27039*invtk + 2.81197) *
-     &          sqrts + (-44.99486*invtk - 0.09984) * s)
+           ak3p(i,j,bi,bj) = exp(-3070.75 _d 0*invtk - 18.141 _d 0 +
+     &          (17.27039 _d 0*invtk + 2.81197 _d 0) *
+     &          sqrts + (-44.99486 _d 0*invtk - 0.09984 _d 0) * s)
 C------------------------------------------------------------------------
 C ksi = [H][SiO(OH)3]/[Si(OH)4]
 C Millero p.671 (1995) using data from Yao and Millero (1995)
 C The constant 117.385 is an approximation to convert to the total pH scale 
 C  (Dickson et al., 2007). Use Millero's 117.400 constant to stay on the seawater
 C  pH scale (everything else is the same).
-           aksi(i,j,bi,bj) = exp(-8904.2*invtk + 117.385 -
-     &          19.334*dlogtk +
-     &          (-458.79*invtk + 3.5913) * sqrtis +
-     &          (188.74*invtk - 1.5998) * is +
-     &          (-12.1652*invtk + 0.07871) * is2 +
-     &          log(1.0-0.001005*s))
+           aksi(i,j,bi,bj) = exp(-8904.2 _d 0*invtk + 117.385 _d 0 -
+     &          19.334 _d 0*dlogtk +
+     &          (-458.79 _d 0*invtk + 3.5913 _d 0) * sqrtis +
+     &          (188.74 _d 0*invtk - 1.5998 _d 0) * is +
+     &          (-12.1652 _d 0*invtk + 0.07871 _d 0) * is2 +
+     &          log(1.0 _d 0-0.001005 _d 0*s))
 C------------------------------------------------------------------------
 C kw = [H][OH]
 C Millero p.670 (1995) using composite data
 C The constant 148.9652 is an approximation to convert to the total pH scale 
 C  (Dickson et al., 2007). Use Millero's 148.9802 constant to stay on the seawater
 C  pH scale (everything else is the same).
-           akw(i,j,bi,bj) = exp(-13847.26*invtk + 148.9652 -
-     &          23.6521*dlogtk +
-     &          (118.67*invtk - 5.977 + 1.0495 * dlogtk) *
-     &          sqrts - 0.01615 * s)
+           akw(i,j,bi,bj) = exp(-13847.26 _d 0*invtk + 148.9652 _d 0 -
+     &          23.6521 _d 0*dlogtk +
+     &          (118.67 _d 0*invtk - 5.977 _d 0 + 1.0495 _d 0 * dlogtk) *
+     &          sqrts - 0.01615 _d 0 * s)
 C------------------------------------------------------------------------
 C ks = [H][SO4]/[HSO4]
 C dickson (1990, J. chem. Thermodynamics 22, 113)
 C On the free pH scale
-           aks(i,j,bi,bj)=exp(-4276.1*invtk + 141.328 -
-     &          23.093*dlogtk +
-     &          (-13856*invtk + 324.57 - 47.986*dlogtk)*sqrtis +
-     &          (35474*invtk - 771.54 + 114.723*dlogtk)*is -
-     &          2698*invtk*is**1.5 + 1776*invtk*is2 +
-     &          log(1.0 - 0.001005*s))
+           aks(i,j,bi,bj)=exp(-4276.1 _d 0*invtk + 141.328 _d 0 -
+     &          23.093 _d 0*dlogtk +
+     &          (-13856 _d 0*invtk + 324.57 _d 0 - 47.986 _d 0*dlogtk)*sqrtis +
+     &          (35474 _d 0*invtk - 771.54 _d 0 + 114.723 _d 0*dlogtk)*is -
+     &          2698 _d 0*invtk*is**1.5 _d 0 + 1776 _d 0*invtk*is2 +
+     &          log(1.0 _d 0 - 0.001005 _d 0*s))
 C------------------------------------------------------------------------
 C kf = [H][F]/[HF]
 C dickson and Riley (1979) -- change pH scale to total (following Dickson & Goyet, 1994)
-           akf(i,j,bi,bj)=exp(1590.2*invtk - 12.641 + 1.525*sqrtis +
-     &          log(1.0 - 0.001005*s) +
-     &          log(1.0 + (0.1400/96.062)*(scl)/aks(i,j,bi,bj)))
+           akf(i,j,bi,bj)=exp(1590.2 _d 0*invtk - 12.641 _d 0 
+     &          + 1.525 _d 0*sqrtis      
+     &          + log(1.0 _d 0 - 0.001005 _d 0*s)
+     &          + log(1.0 _d 0 + (0.1400 _d 0/96.062 _d 0)*(scl)/aks(i,j,bi,bj)))
 C------------------------------------------------------------------------
 C Calculate concentrations for borate, sulfate, and fluoride
 C Uppstrom (1974)
-           bt(i,j,bi,bj) = 0.000232 * scl/10.811
+           bt(i,j,bi,bj) = 0.000232 _d 0 * scl/10.811 _d 0
 C Morris & Riley (1966)
-           st(i,j,bi,bj) = 0.14 * scl/96.062
+           st(i,j,bi,bj) = 0.14 _d 0 * scl/96.062 _d 0
 C Riley (1965)
-           ft(i,j,bi,bj) = 0.000067 * scl/18.9984
+           ft(i,j,bi,bj) = 0.000067 _d 0 * scl/18.9984 _d 0
 C------------------------------------------------------------------------
 
 #ifdef CARBONCHEM_TOTALPHSCALE
@@ -1095,28 +1097,28 @@ C  scale before pressure correction, and then convert back to the total scale.
 
 C All the terms for pressure correction are from Table 9, Millero (1995), p675
 C Info about pH conversions from Munhoven (2013) and Orr and Epitalon (2015)
-           total2free_surf = 1.0/
-     &                 (1.0 + st(i,j,bi,bj)/aks(i,j,bi,bj)) 
+           total2free_surf = 1. _d 0/
+     &                 (1. _d 0 + st(i,j,bi,bj)/aks(i,j,bi,bj)) 
 
-           free2sw_surf = 1.0 
+           free2sw_surf = 1. _d 0 
      &                 + st(i,j,bi,bj)/ aks(i,j,bi,bj) 
      &                 + ft(i,j,bi,bj)/(akf(i,j,bi,bj)*total2free_surf) 
      
            total2sw_surf = total2free_surf * free2sw_surf    
            
-           kgfw2kgsw     = 1.0 - 0.001005*s
+           kgfw2kgsw     = 1. _d 0 - 0.001005 _d 0*s
 C------------------------------------------------------------------------         
 C Pressure correct aks on native free pH scale
-           dv=-18.03 + 0.0466*t + 0.316d-3 *t*t
-           dk=-4.53d-3 + 0.09d-3 *t
+           dv=-18.03 _d 0 + 0.0466 _d 0*t + 0.316 _d -3 *t*t
+           dk=-4.53 _d -3 + 0.09 _d -3 *t
            pfactor = -(dv/(bigR*tk))*pressc
      &            +(0.5*dk/(bigR*tk))*pressc*pressc
            aks(i,j,bi,bj) = kgfw2kgsw*aks(i,j,bi,bj)*exp(pfactor)
 
-           total2free = 1./
-     &                 (1. + st(i,j,bi,bj)/aks(i,j,bi,bj)) 
+           total2free = 1. _d 0/
+     &                 (1. _d 0 + st(i,j,bi,bj)/aks(i,j,bi,bj)) 
 C free2sw has an additional component from fluoride           
-           free2sw    = 1. 
+           free2sw    = 1. _d 0 
      &                 + st(i,j,bi,bj)/ aks(i,j,bi,bj) 
            
            aks(i,j,bi,bj) = aks(i,j,bi,bj)/total2free
@@ -1124,8 +1126,8 @@ C free2sw has an additional component from fluoride
 C------------------------------------------------------------------------
 C Pressure correct akf on the free scale before converting back to total
            akf(i,j,bi,bj) = akf(i,j,bi,bj) * total2free_surf
-           dv  =  -9.78 + -0.0090 *t -0.942d-3 *t*t
-           dk  =  -3.91d-3 + 0.054d-3 *t
+           dv  =  -9.78 _d 0 -0.0090 _d 0 *t -0.942 _d -3 *t*t
+           dk  =  -3.91 _d -3 + 0.054 _d -3 *t
            pfactor = -(dv/(bigR*tk))*pressc
      &               +(0.5*dk/(bigR*tk))*pressc*pressc
            akf(i,j,bi,bj) = akf(i,j,bi,bj) * exp(pfactor)
@@ -1143,8 +1145,8 @@ C Convert pressure corrected ak1 and ak2 from the seawater pH scale to the total
 
 C------------------------------------------------------------------------
 C Pressure correct akb on the seawater scale before converting back to total scale
-            dv = -29.48 + 0.1622*t + 2.608d-3*t*t
-            dk = -2.84d-3
+            dv = -29.48 _d 0 + 0.1622 _d 0*t + 2.608 _d -3*t*t
+            dk = -2.84 _d -3
             pfactor = - (dv/(bigR*tk))*pressc
      &                + (0.5*dk/(bigR*tk))*pressc*pressc
             akb(i,j,bi,bj) = total2sw_surf*akb(i,j,bi,bj)*exp(pfactor)
@@ -1152,8 +1154,8 @@ C Pressure correct akb on the seawater scale before converting back to total sca
 
 C------------------------------------------------------------------------
 C Pressure correct ak1p on the seawater scale before converting back to total scale
-            dv = -14.51 + 0.1211*t -0.321d-3*t*t
-            dk = -2.67d-3 + 0.0427d-3*t
+            dv = -14.51 _d 0 + 0.1211 _d 0*t -0.321 _d -3*t*t
+            dk = -2.67 _d -3 + 0.0427 _d -3*t
             pfactor = - (dv/(bigR*tk))*pressc
      &                + (0.5*dk/(bigR*tk))*pressc*pressc
             ak1p(i,j,bi,bj) = total2sw_surf*ak1p(i,j,bi,bj)*exp(pfactor)
@@ -1161,8 +1163,8 @@ C Pressure correct ak1p on the seawater scale before converting back to total sc
 
 C------------------------------------------------------------------------
 C Pressure correct ak2p on the seawater scale before converting back to total scale
-            dv = -23.12 + 0.1758*t -2.647d-3*t*t
-            dk = -5.15d-3 + 0.09d-3*t
+            dv = -23.12 _d 0 + 0.1758 _d 0*t -2.647 _d -3*t*t
+            dk = -5.15 _d -3 + 0.09 _d -3*t
             pfactor = - (dv/(bigR*tk))*pressc
      &                + (0.5*dk/(bigR*tk))*pressc*pressc
             ak2p(i,j,bi,bj) = total2sw_surf*ak2p(i,j,bi,bj)*exp(pfactor)
@@ -1170,8 +1172,8 @@ C Pressure correct ak2p on the seawater scale before converting back to total sc
             
 C------------------------------------------------------------------------
 C Pressure correct ak3p on the seawater scale before converting back to total scale
-            dv = -26.57 + 0.2020*t -3.042d-3*t*t
-            dk = -4.08d-3 + 0.0714d-3*t
+            dv = -26.57 _d 0 + 0.2020 _d 0*t -3.042 _d -3*t*t
+            dk = -4.08 _d -3 + 0.0714 _d -3*t
             pfactor = - (dv/(bigR*tk))*pressc
      &                + (0.5*dk/(bigR*tk))*pressc*pressc
             ak3p(i,j,bi,bj) = total2sw_surf*ak3p(i,j,bi,bj)*exp(pfactor)
@@ -1179,8 +1181,8 @@ C Pressure correct ak3p on the seawater scale before converting back to total sc
             
 C------------------------------------------------------------------------
 C Pressure correct akw on the seawater scale before converting back to total scale
-            dv = -20.02 + 0.1119*t -1.409d-3*t*t
-            dk = -5.13d-3 + 0.0794d-3 *t
+            dv = -20.02 _d 0 + 0.1119 _d 0*t -1.409 _d -3*t*t
+            dk = -5.13 _d -3 + 0.0794 _d -3 *t
             pfactor = - (dv/(bigR*tk))*pressc
      &                + (0.5*dk/(bigR*tk))*pressc*pressc
             akw(i,j,bi,bj) = total2sw_surf*akw(i,j,bi,bj)*exp(pfactor)
@@ -1189,8 +1191,8 @@ C Pressure correct akw on the seawater scale before converting back to total sca
 C------------------------------------------------------------------------
 C Pressure correct aksi on the seawater scale before converting back to total scale
 C Estimated from the effect on akb
-            dv = -29.48 + 0.1622*t + 2.608d-3*t*t
-            dk = -2.84d-3
+            dv = -29.48 _d 0 + 0.1622 _d 0*t + 2.608 _d -3*t*t
+            dk = -2.84 _d -3
             pfactor = - (dv/(bigR*tk))*pressc
      &                + (0.5*dk/(bigR*tk))*pressc*pressc
             aksi(i,j,bi,bj) = total2sw_surf*aksi(i,j,bi,bj)*exp(pfactor)
@@ -1212,12 +1214,13 @@ c          Ksp_TP_Calc(i,j,bi,bj) = Ksp_T_Calc*exp(xvalue)
 c
 c
 C Following Mucci (1983) - from Zeebe/Wolf-Gladrow equic.m
-         tmpa1 = - 171.9065 - (0.077993*tk) + (2839.319/tk)
-     &            + (71.595*log10(tk))
-         tmpa2 = +(-0.77712 + (0.0028426*tk) + (178.34/tk) )*sqrts
-         tmpa3 = -(0.07711*s) + (0.0041249*s15)
-         logKspc = tmpa1 + tmpa2 + tmpa3
-         Ksp_T_Calc = 10.0**logKspc
+            tmpa1 = - 171.9065 _d 0 - (0.077993 _d 0*tk) 
+     &            + (2839.319 _d 0/tk) + (71.595 _d 0*log10(tk))
+            tmpa2 = +(-0.77712 _d 0 + (0.0028426 _d 0*tk) 
+     &           + (178.34 _d 0/tk) )*sqrts
+            tmpa3 = -(0.07711 _d 0*s) + (0.0041249 _d 0*s15)
+            logKspc = tmpa1 + tmpa2 + tmpa3
+            Ksp_T_Calc = 10.0 _d 0**logKspc
 c        write(6,*)i,j,k,tmpa1,tmpa2,tmpa3,logkspc,Ksp_T_Calc
 c with pressure dependence Culberson and Pytkowicz (1968)
 c        xvalue  =  (36.0-0.20*t)*(pressc-1.0)/(83.143*tk)
@@ -1234,34 +1237,31 @@ c          Ksp_TP_Calc(i,j,bi,bj) = Ksp_T_Calc*exp(xvalue)
 
 c alternative pressure dependence from Ingle (1975)
 
-           zdum   = (pressc*10.0d0 - 10.0d0)/10.0d0
-           xvalue = ( (48.8d0 - 0.53d0*t)*zdum
-     &                 + (-0.00588d0 + 0.0001845d0*t)*zdum*zdum)
-     &            / (188.93d0*(t + 273.15d0))
+            zdum   = (pressc*10. _d 0 - 10. _d 0)/10. _d 0
+            xvalue = ( (48.8 _d 0 - 0.53 _d 0*t)*zdum
+     &                 + (-0.00588 _d 0 + 0.0001845 _d 0*t)*zdum*zdum)
+     &            / (188.93 _d 0*(t + 273.15 _d 0))
 
-           Ksp_TP_Calc(i,j,bi,bj) = Ksp_T_Calc*10**(xvalue)
-
-
-
+            Ksp_TP_Calc(i,j,bi,bj) = Ksp_T_Calc*10**(xvalue)
 
 C------------------------------------------------------------------------
          else
-            ff(i,j,bi,bj)=0.d0
-            ak0(i,j,bi,bj)= 0.d0
-            ak1(i,j,bi,bj)= 0.d0
-            ak2(i,j,bi,bj)= 0.d0
-            akb(i,j,bi,bj)= 0.d0
-            ak1p(i,j,bi,bj) = 0.d0
-            ak2p(i,j,bi,bj) = 0.d0
-            ak3p(i,j,bi,bj) = 0.d0
-            aksi(i,j,bi,bj) = 0.d0
-            akw(i,j,bi,bj) = 0.d0
-            aks(i,j,bi,bj)= 0.d0
-            akf(i,j,bi,bj)= 0.d0
-            bt(i,j,bi,bj) = 0.d0
-            st(i,j,bi,bj) = 0.d0
-            ft(i,j,bi,bj) = 0.d0
-            Ksp_TP_Calc(i,j,bi,bj) = 0.d0
+            ff(i,j,bi,bj)=0. _d 0
+            ak0(i,j,bi,bj)= 0. _d 0
+            ak1(i,j,bi,bj)= 0. _d 0
+            ak2(i,j,bi,bj)= 0. _d 0
+            akb(i,j,bi,bj)= 0. _d 0
+            ak1p(i,j,bi,bj) = 0. _d 0
+            ak2p(i,j,bi,bj) = 0. _d 0
+            ak3p(i,j,bi,bj) = 0. _d 0
+            aksi(i,j,bi,bj) = 0. _d 0
+            akw(i,j,bi,bj) = 0. _d 0
+            aks(i,j,bi,bj)= 0. _d 0
+            akf(i,j,bi,bj)= 0. _d 0
+            bt(i,j,bi,bj) = 0. _d 0
+            st(i,j,bi,bj) = 0. _d 0
+            ft(i,j,bi,bj) = 0. _d 0
+            Ksp_TP_Calc(i,j,bi,bj) = 0. _d 0
          endif
          end do
         end do


### PR DESCRIPTION
## What changes does this PR introduce?
Promotes constants in `S/R CARBON_COEFFS_PRESSURE_DEP` and `S/R CAR_FLUX_OMEGA_TOP` to double precision.

## What is the current behaviour? 
Unlike `S/R CARBON_COEFFS` with numerical values that are represented as double precision (e.g. 1. _d 0), many of the calculations in `S/R CARBON_COEFFS_PRESSURE_DEP` contain single precision coefficients (e.g. 1.0). These single precision coefficients are multiplied by double precision tracer concentrations, which probably results in larger round off errors. Likewise, with `S/R CAR_FLUX_OMEGA_TOP`.

## What is the new behaviour 
All calculations in `S/R CARBON_COEFFS_PRESSURE_DEP` and `S/R CAR_FLUX_OMEGA_TOP` are now done in double precision.

## Does this PR introduce a breaking change? 
Both `S/Rs` have to be enabled by the user with the cpp option `CAR_DISS` in `DIC_OPTIONS.h` - it is not the default. The carbon chemistry coefficients may change slightly. 