### PR TITLE
Fix bug in B-grid advection code (issue #134).

### DIFF
--- a/doc/tag-index
+++ b/doc/tag-index
@@ -1,6 +1,10 @@
     Notes on tags used in MITgcmUV
     ==============================
 
+o pkg/seaice:
+  - fix bug in seaice B-grid code (call to seaice_advdiff, see issue #134);
+    Note: B-grid code not tested in any verification exp. (only compiled in one)
+    so no need to update any output.txt
 o pkg/diagnostics:
   - Print adjoint variables for theta, salt, uvel, vvel, wvel, and etan
     through diagnostics package.

--- a/pkg/seaice/seaice_advdiff.F
+++ b/pkg/seaice/seaice_advdiff.F
@@ -8,7 +8,8 @@ C !ROUTINE: SEAICE_ADVDIFF
 
 C !INTERFACE: ==========================================================
       SUBROUTINE SEAICE_ADVDIFF(
-     I     uc, vc, myTime, myIter, myThid )
+     U                  uc, vc,
+     I                  myTime, myIter, myThid )
 
 C !DESCRIPTION: \bv
 C     *===========================================================*
@@ -23,9 +24,6 @@ C !USES: ===============================================================
       IMPLICIT NONE
 
 C     === Global variables ===
-C     UICE/VICE :: ice velocity
-C     HEFF      :: scalar field to be advected
-C     HEFFM     :: mask for scalar field
 #include "SIZE.h"
 #include "EEPARAMS.h"
 #include "PARAMS.h"
@@ -35,29 +33,28 @@ C     HEFFM     :: mask for scalar field
 #include "SEAICE_PARAMS.h"
 #include "SEAICE.h"
 #include "SEAICE_TRACER.h"
-
 #ifdef ALLOW_AUTODIFF_TAMC
 # include "tamc.h"
 #endif
 
-C !INPUT PARAMETERS: ===================================================
+C !INPUT/OUTPUT PARAMETERS: ===================================================
 C     === Routine arguments ===
-C     myTime    :: current time
-C     myIter    :: iteration number
-C     myThid    :: Thread no. that called this routine.
+C     uc/vc     :: current ice velocity on C-grid;
+C               :: C-Grid : Input only ; B-grid : Output only
+C     myTime    :: current time in simulation
+C     myIter    :: current iteration number in simulation
+C     myThid    :: my Thread Id number
+      _RL uc   (1-OLx:sNx+OLx,1-OLy:sNy+OLy,nSx,nSy)
+      _RL vc   (1-OLx:sNx+OLx,1-OLy:sNy+OLy,nSx,nSy)
       _RL myTime
       INTEGER myIter
       INTEGER myThid
-CEndOfInterface
 
 C !LOCAL VARIABLES: ====================================================
 C     === Local variables ===
 C     i,j,bi,bj :: Loop counters
-#ifdef SEAICE_ITD
 C     it        :: Loop counter for ice thickness categories
-#endif /* SEAICE_ITD */
 C     ks        :: surface level index
-C     uc/vc     :: current ice velocity on C-grid
 C     uTrans    :: volume transport, x direction
 C     vTrans    :: volume transport, y direction
 C     afx       :: horizontal advective flux, x direction
@@ -87,9 +84,6 @@ C     xA,yA     :: "areas" of X and Y face of tracer cells
       _RL DIAGarray (1-OLx:sNx+OLx,1-OLy:sNy+OLy,Nr)
 # endif
 #endif /* ALLOW_SITRACER */
-
-      _RL uc        (1-OLx:sNx+OLx,1-OLy:sNy+OLy,nSx,nSy)
-      _RL vc        (1-OLx:sNx+OLx,1-OLy:sNy+OLy,nSx,nSy)
       _RL fldNm1    (1-OLx:sNx+OLx,1-OLy:sNy+OLy,nSx,nSy)
       _RL uTrans    (1-OLx:sNx+OLx,1-OLy:sNy+OLy)
       _RL vTrans    (1-OLx:sNx+OLx,1-OLy:sNy+OLy)
@@ -110,7 +104,7 @@ C--   alternatively interpolate to C-points if necessary
       DO bj=myByLo(myThid),myByHi(myThid)
        DO bi=myBxLo(myThid),myBxHi(myThid)
 #ifndef SEAICE_CGRID /* not SEAICE_CGRID = BGRID */
-C--   hack to ensure backward compatibility: 
+C--   hack to ensure backward compatibility:
 C     average B-grid seaice velocity to C-grid
         DO j=1-OLy,sNy+OLy-1
          DO i=1-OLx,sNx+OLx-1

--- a/pkg/seaice/seaice_model.F
+++ b/pkg/seaice/seaice_model.F
@@ -45,13 +45,12 @@ C !USES: ===============================================================
 #endif
 
 C !INPUT PARAMETERS: ===================================================
-C     myTime - Simulation time
-C     myIter - Simulation timestep number
-C     myThid - Thread no. that called this routine.
+C     myTime :: Current time in simulation
+C     myIter :: Current iteration number in simulation
+C     myThid :: my Thread Id number
       _RL     myTime
       INTEGER myIter
       INTEGER myThid
-CEndOfInterface
 
 C !LOCAL VARIABLES: ====================================================
 C     i,j,bi,bj :: Loop counters
@@ -61,6 +60,10 @@ C     i,j,bi,bj :: Loop counters
 #endif
 #ifdef ALLOW_SITRACER
       INTEGER iTr
+#endif
+#ifndef SEAICE_CGRID
+      _RL uLoc(1-OLx:sNx+OLx,1-OLy:sNy+OLy,nSx,nSy)
+      _RL vLoc(1-OLx:sNx+OLx,1-OLy:sNy+OLy,nSx,nSy)
 #endif
 CEOP
 
@@ -176,7 +179,11 @@ C NOW DO ADVECTION and DIFFUSION
 #ifdef ALLOW_DEBUG
        IF (debugMode) CALL DEBUG_CALL( 'SEAICE_ADVDIFF', myThid )
 #endif
+#ifdef SEAICE_CGRID
        CALL SEAICE_ADVDIFF( uIce, vIce, myTime, myIter, myThid )
+#else /* SEAICE_CGRID */
+       CALL SEAICE_ADVDIFF( uLoc, vLoc, myTime, myIter, myThid )
+#endif /* SEAICE_CGRID */
       ENDIF
 #ifdef ALLOW_AUTODIFF_TAMC
 CADJ STORE heffm  = comlev1, key=ikey_dynamics, kind=isbyte


### PR DESCRIPTION
- fix call to SEAICE_ADVDIFF for B-grid case
- improve description of argument list within seaice_advdiff.F

## Other information:
currently, only 1 forward experiment (1D_ocean_ice_column) compiles B-grid code 
but does not really use it (1 grid point), so no output to update.