### PR TITLE
fix #139: split pattern matches empty string

### DIFF
--- a/utils/python/MITgcmutils/MITgcmutils/mds.py
+++ b/utils/python/MITgcmutils/MITgcmutils/mds.py
@@ -123,7 +123,7 @@ def parsemeta(metafile):
 
         if opening == '[':
             # [] can contain any type of values, separated by commas
-            val = [ parse1(s) for s in re.split(r',? *',line) ]
+            val = [ parse1(s) for s in re.split(r'[, ] *',line) ]
         else:
             # {} can only contain single quote-delimited strings separated by space
             val = [ s.rstrip() for s in re.split(r"'  *'", line.strip("'")) ]


### PR DESCRIPTION
## What changes does this PR introduce?

fixes a bug in python function MITgcmutils.rdmds where a split pattern matches the empty string.


## What is the current behaviour? 

python 3.7 throws an error


## What is the new behaviour 

bug is fixed


## Does this PR introduce a breaking change? 

no


## Other information:

fixes #139 