### PR TITLE
Fix adj etan

### DIFF
--- a/doc/tag-index
+++ b/doc/tag-index
@@ -1,6 +1,8 @@
     Notes on tags used in MITgcmUV
     ==============================
 
+o pkg/autodiff:
+  - created addummy_for_etan.F to correctly print adjoint variable for etaN
 o pkg/streamice:
   - fix bugs relating to ice front advance:
     streamice_advect_thickness.F -- overlap update of array passed to 

--- a/model/src/integr_continuity.F
+++ b/model/src/integr_continuity.F
@@ -1,5 +1,6 @@
 #include "PACKAGES_CONFIG.h"
 #include "CPP_OPTIONS.h"
+#include "AUTODIFF_OPTIONS.h"
 
 CBOP
 C     !ROUTINE: INTEGR_CONTINUITY
@@ -13,6 +14,8 @@ C     | SUBROUTINE INTEGR_CONTINUITY
 C     | o Integrate the continuity Eq : compute vertical velocity
 C     |   and free surface "r-anomaly" (etaN,etaH) to satisfy
 C     |   exactly the conservation of the Total Volume
+C     | o Routine dummy_for_etan located here in order to print the
+C     |   correct adjoint variable for etaN
 C     *==========================================================*
 C     \ev
 
@@ -294,6 +297,11 @@ C---+----1----+----2----+----3----+----4----+----5----+----6----+----7-|--+----|
 C--   End bi,bj loops
        ENDDO
       ENDDO
+
+#ifdef ALLOW_AUTODIFF_MONITOR
+C     In reverse, print adjoint variable for etaN
+      CALL DUMMY_FOR_ETAN( myTime, myIter, myThid )
+#endif
 
       IF ( exactConserv .AND. myIter.NE.nIter0
      &                  .AND. implicDiv2Dflow .NE. 0. _d 0 )

--- a/model/src/integr_continuity.F
+++ b/model/src/integr_continuity.F
@@ -1,6 +1,8 @@
 #include "PACKAGES_CONFIG.h"
 #include "CPP_OPTIONS.h"
-#include "AUTODIFF_OPTIONS.h"
+#ifdef ALLOW_AUTODIFF
+# include "AUTODIFF_OPTIONS.h"
+#endif
 
 CBOP
 C     !ROUTINE: INTEGR_CONTINUITY
@@ -299,17 +301,13 @@ C--   End bi,bj loops
       ENDDO
 
 #ifdef ALLOW_AUTODIFF_MONITOR
-
 C     In reverse, print adjoint variable for etaN
       CALL DUMMY_FOR_ETAN( myTime, myIter, myThid )
       _EXCH_XY_RL( etaN , myThid )
-
 #else /* ALLOW_AUTODIFF_MONITOR */
-
       IF ( exactConserv .AND. myIter.NE.nIter0
      &                  .AND. implicDiv2Dflow .NE. 0. _d 0 )
      &    _EXCH_XY_RL( etaN , myThid )
-
 #endif /* ALLOW_AUTODIFF_MONITOR */
 
       IF ( implicitIntGravWave .OR. myIter.EQ.nIter0 )

--- a/model/src/integr_continuity.F
+++ b/model/src/integr_continuity.F
@@ -299,13 +299,19 @@ C--   End bi,bj loops
       ENDDO
 
 #ifdef ALLOW_AUTODIFF_MONITOR
+
 C     In reverse, print adjoint variable for etaN
       CALL DUMMY_FOR_ETAN( myTime, myIter, myThid )
-#endif
+      _EXCH_XY_RL( etaN , myThid )
+
+#else /* ALLOW_AUTODIFF_MONITOR */
 
       IF ( exactConserv .AND. myIter.NE.nIter0
      &                  .AND. implicDiv2Dflow .NE. 0. _d 0 )
      &    _EXCH_XY_RL( etaN , myThid )
+
+#endif /* ALLOW_AUTODIFF_MONITOR */
+
       IF ( implicitIntGravWave .OR. myIter.EQ.nIter0 )
      &    _EXCH_XYZ_RL( wVel , myThid )
 

--- a/model/src/the_model_main.F
+++ b/model/src/the_model_main.F
@@ -166,6 +166,7 @@ C    | | |
 C    | | |-INTEGR_CONTINUITY :: Integrate the continuity Equation
 C    | | | |-INTEGRATE_FOR_W :: Integrate for vertical velocity
 C    | | | |-OBCS_APPLY_W    :: Open boundary package (see pkg/obcs).
+C    | | | |-DUMMY_FOR_ETAN  :: For printing adEtaN (see pkg/autodiff).
 C    | | | |-UPDATE_ETAH     :: Update Surface height/pressure
 C    | | |
 C    | | |-CALC_R_STAR    :: Calculate the new level thickness factor (r* coord)

--- a/pkg/autodiff/AUTODIFF.h
+++ b/pkg/autodiff/AUTODIFF.h
@@ -12,8 +12,10 @@ c ad dump record number (used only if dumpAdByRec is true)
       integer dumpAdRecMn
       integer dumpAdRecDy
       integer dumpAdRecSi
+      integer dumpAdRecEt
       COMMON /AUTODIFF_DUMP_AD_REC/ 
-     &       dumpAdRecMn, dumpAdRecDy, dumpAdRecSi
+     &       dumpAdRecMn, dumpAdRecDy, dumpAdRecSi,
+     &       dumpAdRecEt
 
       integer ilev_1
       integer ilev_2

--- a/pkg/autodiff/addummy_for_etan.F
+++ b/pkg/autodiff/addummy_for_etan.F
@@ -133,11 +133,6 @@ C--     Set suffix for this set of data files.
         ELSE
           CALL RW_GET_SUFFIX( suff, myTime, myIter, myThid )
         ENDIF
-C ==>> Resetting run-time parameter writeBinaryPrec in the middle of a run
-C ==>>  is very very very nasty !!!
-c       writeBinaryPrec = writeStatePrec
-C <<==  If you really want to mess-up with this at your own risk,
-C <<==  uncomment the line above
 
 C-----------------------------------------------------------------------
 #ifndef ALLOW_OPENAD

--- a/pkg/autodiff/addummy_for_etan.F
+++ b/pkg/autodiff/addummy_for_etan.F
@@ -94,26 +94,7 @@ C     msgBuf  :: Error message buffer
       _RL var2Dv(1-OLx:sNx+OLx,1-OLy:sNy+OLy,nSx,nSy)
       _RS dumRS(1)
       _RL dumRL(1)
-      LOGICAL doExch
 CEOP
-
-C--- Test for adexch based on dumpAdVarExch flag
-      doExch = DIFFERENT_MULTIPLE(adjDumpFreq,myTime,deltaTClock)
-      doExch = doExch .AND. ( dumpAdVarExch.EQ.1 )
-
-C--- If necessary, do the exchanges
-      IF ( doExch ) THEN
-#ifdef ALLOW_OPENAD
-C--   need to all the correct OpenAD EXCH S/R ; left empty for now
-#else /* ALLOW_OPENAD */
-
-#ifdef AUTODIFF_TAMC_COMPATIBILITY
-        call adexch_xy_rl( myThid,adEtaN)
-# else /* ndfef AUTODIFF_TAMC_COMPATIBILITY */
-        CALL ADEXCH_3D_RL( adEtaN, 1 , myThid )
-#endif /* AUTODIFF_TAMC_COMPATIBILITY */
-#endif /* ALLOW_OPENAD */
-      ENDIF
 
       IF (
      &  DIFFERENT_MULTIPLE(adjDumpFreq,myTime,deltaTClock)

--- a/pkg/autodiff/addummy_for_etan.F
+++ b/pkg/autodiff/addummy_for_etan.F
@@ -103,9 +103,9 @@ CEOP
         CALL TIMER_START('I/O (WRITE)        [ADJOINT LOOP]', myThid )
 
 c increment ad dump record number (used only if dumpAdByRec is true)
-        dumpAdRecMn=dumpAdRecMn+1
+        dumpAdRecEt=dumpAdRecEt+1
 c#ifdef ALLOW_DEBUG
-c      IF ( debugMode ) print*,'dumpAdRecMn',dumpAdRecMn
+c      IF ( debugMode ) print*,'dumpAdRecEt',dumpAdRecEt
 c#endif
 
 C--     Set suffix for this set of data files.
@@ -127,7 +127,7 @@ C-----------------------------------------------------------------------
         ELSEIF ( ( dumpAdVarExch.NE.2 ).AND.(dumpAdByRec) ) THEN
 
           CALL WRITE_REC_XY_RL ( 'ADJetan',
-     &                           adEtaN, dumpAdRecMn, myIter, myThid)
+     &                           adEtaN, dumpAdRecEt, myIter, myThid)
 
         ELSE
 C       case dumpAdVarExch = 2
@@ -135,7 +135,7 @@ C       case dumpAdVarExch = 2
           IF (.NOT.dumpAdByRec) CALL WRITE_FLD_XY_RL(  'ADJetan.',
      &                           suff, var2Du, myIter, myThid )
           IF (  dumpAdByRec   ) CALL WRITE_REC_XY_RL(  'ADJetan',
-     &                           var2Du, dumpAdRecMn, myIter, myThid)
+     &                           var2Du, dumpAdRecEt, myIter, myThid)
         ENDIF
 
 C-----------------------------------------------------------------------
@@ -151,7 +151,7 @@ C-----------------------------------------------------------------------
 
           var2Du = etaN%d
           CALL WRITE_REC_XY_RL ( 'ADJetan',
-     &                           var2Du, dumpAdRecMn, myIter, myThid)
+     &                           var2Du, dumpAdRecEt, myIter, myThid)
 
         ELSE
 C       case dumpAdVarExch = 2
@@ -159,7 +159,7 @@ C       case dumpAdVarExch = 2
           IF (.NOT.dumpAdByRec) CALL WRITE_FLD_XY_RL(  'ADJetan.',
      &                           suff, var2Du, myIter, myThid )
           IF (  dumpAdByRec   ) CALL WRITE_REC_XY_RL(  'ADJetan',
-     &                           var2Du, dumpAdRecMn, myIter, myThid)
+     &                           var2Du, dumpAdRecEt, myIter, myThid)
 
 
 C       end if dumpAdVarExch = 2

--- a/pkg/autodiff/addummy_for_etan.F
+++ b/pkg/autodiff/addummy_for_etan.F
@@ -1,0 +1,232 @@
+#include "AUTODIFF_OPTIONS.h"
+#ifdef ALLOW_OPENAD
+# include "OPENAD_OPTIONS.h"
+#endif
+#ifdef ALLOW_CTRL
+# include "CTRL_OPTIONS.h"
+#endif
+#include "AD_CONFIG.h"
+
+CBOP
+C     !ROUTINE: ADDUMMY_FOR_ETAN
+C     !INTERFACE:
+      SUBROUTINE ADDUMMY_FOR_ETAN( myTime, myIter, myThid )
+
+C     !DESCRIPTION: \bv
+C     *==========================================================*
+C     | SUBROUTINE ADDUMMY_FOR_ETAN                           |
+C     *==========================================================*
+C     Extract adjoint variable for sea level height 
+C     from TAMC/TAF-generated
+C     adjoint common blocks, contained in adcommon.h
+C     and write fields to file;
+C     Make sure common blocks in adcommon.h are up-to-date
+C     w.r.t. current adjoint code.
+C   
+C     This dummy routine is located inside integr_continuity
+C     to get the impact of rstar or surf_dr adjoint
+C     variables on adEtaN. 
+C
+C     This does not use the diagnostics package because adEtaN is a
+C     "half" time step away from the other adjoint variables, but would
+C     have to be written at the same time.
+C
+C     Created: Tim Smith, tsmith@ices.utexas.edu, Sept 12 2018
+C     *==========================================================*
+C     | SUBROUTINE ADDUMMY_FOR_ETAN                           |
+C     *==========================================================*
+C     \ev
+
+C     !USES:
+      IMPLICIT NONE
+
+C     == Global variables ===
+#ifdef ALLOW_OPENAD
+      use OAD_active
+      use OAD_rev
+      use OAD_tape
+      use OAD_cp
+#endif
+#include "SIZE.h"
+#include "EEPARAMS.h"
+#include "PARAMS.h"
+#ifdef ALLOW_OPENAD
+# include "DYNVARS.h"
+# include "FFIELDS.h"
+#endif
+#include "AUTODIFF_PARAMS.h"
+#ifdef ALLOW_AUTODIFF_MONITOR
+c#include "GRID.h"
+# include "AUTODIFF.h"
+# ifndef ALLOW_OPENAD
+#  include "adcommon.h"
+# endif /* ALLOW_OPENAD */
+# ifdef ALLOW_MNC
+#  include "MNC_PARAMS.h"
+# endif
+#endif /* ALLOW_AUTODIFF_MONITOR */
+
+C     !INPUT/OUTPUT PARAMETERS:
+C     == Routine arguments ==
+C     myTime  :: time counter for this thread
+C     myIter  :: iteration counter for this thread
+C     myThid  :: Thread number for this instance of the routine.
+      _RL myTime
+      INTEGER myIter
+C      _RL     myTime
+C      INTEGER myIter
+      INTEGER myThid
+
+#if (defined (ALLOW_ADJOINT_RUN) || defined (ALLOW_ADMTLM))
+#ifdef ALLOW_AUTODIFF_MONITOR
+
+C     !FUNCTIONS:
+      LOGICAL  DIFFERENT_MULTIPLE
+      EXTERNAL DIFFERENT_MULTIPLE
+
+C     !LOCAL VARIABLES:
+c     == local variables ==
+C     suff    :: Hold suffix part of a filename
+C     msgBuf  :: Error message buffer
+      CHARACTER*(10) suff
+      CHARACTER*(MAX_LEN_MBUF) msgBuf
+      _RL var2Du(1-OLx:sNx+OLx,1-OLy:sNy+OLy,nSx,nSy)
+      _RL var2Dv(1-OLx:sNx+OLx,1-OLy:sNy+OLy,nSx,nSy)
+      _RS dumRS(1)
+      _RL dumRL(1)
+      LOGICAL doExch
+CEOP
+
+C--- Test for adexch based on dumpAdVarExch flag
+      doExch = DIFFERENT_MULTIPLE(adjDumpFreq,myTime,deltaTClock)
+      doExch = doExch .AND. ( dumpAdVarExch.EQ.1 )
+
+C--- If necessary, do the exchanges
+      IF ( doExch ) THEN
+#ifdef ALLOW_OPENAD
+C--   need to all the correct OpenAD EXCH S/R ; left empty for now
+#else /* ALLOW_OPENAD */
+
+#ifdef AUTODIFF_TAMC_COMPATIBILITY
+        call adexch_xy_rl( myThid,adEtaN)
+# else /* ndfef AUTODIFF_TAMC_COMPATIBILITY */
+        CALL ADEXCH_3D_RL( adEtaN, 1 , myThid )
+#endif /* AUTODIFF_TAMC_COMPATIBILITY */
+#endif /* ALLOW_OPENAD */
+      ENDIF
+
+      IF (
+     &  DIFFERENT_MULTIPLE(adjDumpFreq,myTime,deltaTClock)
+     & ) THEN
+
+        CALL TIMER_START('I/O (WRITE)        [ADJOINT LOOP]', myThid )
+
+c increment ad dump record number (used only if dumpAdByRec is true)
+        dumpAdRecMn=dumpAdRecMn+1
+c#ifdef ALLOW_DEBUG
+c      IF ( debugMode ) print*,'dumpAdRecMn',dumpAdRecMn
+c#endif
+
+C--     Set suffix for this set of data files.
+        IF ( rwSuffixType.EQ.0 ) THEN
+          WRITE(suff,'(I10.10)') myIter
+        ELSE
+          CALL RW_GET_SUFFIX( suff, myTime, myIter, myThid )
+        ENDIF
+C ==>> Resetting run-time parameter writeBinaryPrec in the middle of a run
+C ==>>  is very very very nasty !!!
+c       writeBinaryPrec = writeStatePrec
+C <<==  If you really want to mess-up with this at your own risk,
+C <<==  uncomment the line above
+
+C-----------------------------------------------------------------------
+#ifndef ALLOW_OPENAD
+C-----------------------------------------------------------------------
+
+        IF ( ( dumpAdVarExch.NE.2 ).AND.(.NOT.dumpAdByRec) ) THEN
+          CALL WRITE_FLD_XY_RL ( 'ADJetan.', suff,
+     &                           adEtaN, myIter, myThid )
+
+
+        ELSEIF ( ( dumpAdVarExch.NE.2 ).AND.(dumpAdByRec) ) THEN
+
+          CALL WRITE_REC_XY_RL ( 'ADJetan',
+     &                           adEtaN, dumpAdRecMn, myIter, myThid)
+
+        ELSE
+C       case dumpAdVarExch = 2
+          CALL COPY_ADVAR_OUTP( dumRS, adEtaN, var2Du,1,12,myThid )
+          IF (.NOT.dumpAdByRec) CALL WRITE_FLD_XY_RL(  'ADJetan.',
+     &                           suff, var2Du, myIter, myThid )
+          IF (  dumpAdByRec   ) CALL WRITE_REC_XY_RL(  'ADJetan',
+     &                           var2Du, dumpAdRecMn, myIter, myThid)
+        ENDIF
+
+C-----------------------------------------------------------------------
+#else /* ndef ALLOW_OPENAD */
+C-----------------------------------------------------------------------
+
+        IF ( ( dumpAdVarExch.NE.2 ).AND.(.NOT.dumpAdByRec) ) THEN
+          var2Du = etaN%d
+          CALL WRITE_FLD_XY_RL ( 'ADJetan.', suff,
+     &                           var2Du, myIter, myThid )
+
+        ELSEIF ( ( dumpAdVarExch.NE.2 ).AND.(dumpAdByRec) ) THEN
+
+          var2Du = etaN%d
+          CALL WRITE_REC_XY_RL ( 'ADJetan',
+     &                           var2Du, dumpAdRecMn, myIter, myThid)
+
+        ELSE
+C       case dumpAdVarExch = 2
+          CALL COPY_ADVAR_OUTP( dumRS, etaN%d, var2Du,1,12,myThid )
+          IF (.NOT.dumpAdByRec) CALL WRITE_FLD_XY_RL(  'ADJetan.',
+     &                           suff, var2Du, myIter, myThid )
+          IF (  dumpAdByRec   ) CALL WRITE_REC_XY_RL(  'ADJetan',
+     &                           var2Du, dumpAdRecMn, myIter, myThid)
+
+
+C       end if dumpAdVarExch = 2
+        ENDIF
+
+C-----------------------------------------------------------------------
+#endif /* ndef ALLOW_OPENAD */
+C-----------------------------------------------------------------------
+
+C-- NOW NMC output
+
+#ifndef ALLOW_OPENAD
+#ifdef ALLOW_MNC
+        IF (useMNC .AND. autodiff_mnc) THEN
+         CALL MNC_CW_SET_UDIM('adstate', -1, myThid)
+         CALL MNC_CW_RL_W_S('D','adstate',0,0,'T',myTime,myThid)
+         CALL MNC_CW_SET_UDIM('adstate', 0, myThid)
+         CALL MNC_CW_I_W_S('I','adstate',0,0,'iter',myIter,myThid)
+         CALL MNC_CW_RL_W_S('D','adstate',0,0,'model_time',myTime,
+     &        myThid)
+
+         IF ( dumpAdVarExch.EQ.2 ) THEN
+          CALL COPY_ADVAR_OUTP( dumRS, adEtaN, var2Du, 1 , 12, myThid )
+          CALL MNC_CW_RL_W('D','adstate',0,0,'adEta', var2Du, myThid)
+         ELSE
+C     dumpAdVarExch.NE.2
+          CALL MNC_CW_RL_W('D','adstate',0,0,'adEta', adEtaN, myThid)
+         ENDIF
+C     endif mnc
+        ENDIF
+#endif /* ALLOW_MNC */
+#endif /* ALLOW_OPENAD */
+
+#ifdef ALLOW_EXF
+cph        IF ( useEXF ) CALL EXF_AD_DUMP( myTime, myIter, myThid )
+#endif
+
+        CALL TIMER_STOP( 'I/O (WRITE)        [ADJOINT LOOP]', myThid )
+
+      ENDIF
+
+#endif /* ALLOW_AUTODIFF_MONITOR */
+#endif /* ALLOW_ADJOINT_RUN */
+
+      RETURN
+      END

--- a/pkg/autodiff/addummy_for_etan.F
+++ b/pkg/autodiff/addummy_for_etan.F
@@ -16,16 +16,16 @@ C     !DESCRIPTION: \bv
 C     *==========================================================*
 C     | SUBROUTINE ADDUMMY_FOR_ETAN                           |
 C     *==========================================================*
-C     Extract adjoint variable for sea level height 
+C     Extract adjoint variable for sea level height
 C     from TAMC/TAF-generated
 C     adjoint common blocks, contained in adcommon.h
 C     and write fields to file;
 C     Make sure common blocks in adcommon.h are up-to-date
 C     w.r.t. current adjoint code.
-C   
+C
 C     This dummy routine is located inside integr_continuity
 C     to get the impact of rstar or surf_dr adjoint
-C     variables on adEtaN. 
+C     variables on adEtaN.
 C
 C     This does not use the diagnostics package because adEtaN is a
 C     "half" time step away from the other adjoint variables, but would
@@ -90,10 +90,9 @@ C     suff    :: Hold suffix part of a filename
 C     msgBuf  :: Error message buffer
       CHARACTER*(10) suff
       CHARACTER*(MAX_LEN_MBUF) msgBuf
+#ifdef ALLOW_OPENAD
       _RL var2Du(1-OLx:sNx+OLx,1-OLy:sNy+OLy,nSx,nSy)
-      _RL var2Dv(1-OLx:sNx+OLx,1-OLy:sNy+OLy,nSx,nSy)
-      _RS dumRS(1)
-      _RL dumRL(1)
+#endif
 CEOP
 
       IF (
@@ -119,50 +118,26 @@ C-----------------------------------------------------------------------
 #ifndef ALLOW_OPENAD
 C-----------------------------------------------------------------------
 
-        IF ( ( dumpAdVarExch.NE.2 ).AND.(.NOT.dumpAdByRec) ) THEN
-          CALL WRITE_FLD_XY_RL ( 'ADJetan.', suff,
-     &                           adEtaN, myIter, myThid )
-
-
-        ELSEIF ( ( dumpAdVarExch.NE.2 ).AND.(dumpAdByRec) ) THEN
-
+        IF ( dumpAdByRec ) THEN
           CALL WRITE_REC_XY_RL ( 'ADJetan',
      &                           adEtaN, dumpAdRecEt, myIter, myThid)
-
         ELSE
-C       case dumpAdVarExch = 2
-          CALL COPY_ADVAR_OUTP( dumRS, adEtaN, var2Du,1,12,myThid )
-          IF (.NOT.dumpAdByRec) CALL WRITE_FLD_XY_RL(  'ADJetan.',
-     &                           suff, var2Du, myIter, myThid )
-          IF (  dumpAdByRec   ) CALL WRITE_REC_XY_RL(  'ADJetan',
-     &                           var2Du, dumpAdRecEt, myIter, myThid)
+          CALL WRITE_FLD_XY_RL ( 'ADJetan.', suff,
+     &                           adEtaN, myIter, myThid )
         ENDIF
 
 C-----------------------------------------------------------------------
 #else /* ndef ALLOW_OPENAD */
 C-----------------------------------------------------------------------
 
-        IF ( ( dumpAdVarExch.NE.2 ).AND.(.NOT.dumpAdByRec) ) THEN
-          var2Du = etaN%d
-          CALL WRITE_FLD_XY_RL ( 'ADJetan.', suff,
-     &                           var2Du, myIter, myThid )
-
-        ELSEIF ( ( dumpAdVarExch.NE.2 ).AND.(dumpAdByRec) ) THEN
-
+        IF ( dumpAdByRec ) THEN
           var2Du = etaN%d
           CALL WRITE_REC_XY_RL ( 'ADJetan',
      &                           var2Du, dumpAdRecEt, myIter, myThid)
-
         ELSE
-C       case dumpAdVarExch = 2
-          CALL COPY_ADVAR_OUTP( dumRS, etaN%d, var2Du,1,12,myThid )
-          IF (.NOT.dumpAdByRec) CALL WRITE_FLD_XY_RL(  'ADJetan.',
-     &                           suff, var2Du, myIter, myThid )
-          IF (  dumpAdByRec   ) CALL WRITE_REC_XY_RL(  'ADJetan',
-     &                           var2Du, dumpAdRecEt, myIter, myThid)
-
-
-C       end if dumpAdVarExch = 2
+          var2Du = etaN%d
+          CALL WRITE_FLD_XY_RL ( 'ADJetan.', suff,
+     &                           var2Du, myIter, myThid )
         ENDIF
 
 C-----------------------------------------------------------------------
@@ -173,29 +148,18 @@ C-- NOW NMC output
 
 #ifndef ALLOW_OPENAD
 #ifdef ALLOW_MNC
-        IF (useMNC .AND. autodiff_mnc) THEN
+        IF ( useMNC .AND. autodiff_mnc ) THEN
          CALL MNC_CW_SET_UDIM('adstate', -1, myThid)
          CALL MNC_CW_RL_W_S('D','adstate',0,0,'T',myTime,myThid)
          CALL MNC_CW_SET_UDIM('adstate', 0, myThid)
          CALL MNC_CW_I_W_S('I','adstate',0,0,'iter',myIter,myThid)
          CALL MNC_CW_RL_W_S('D','adstate',0,0,'model_time',myTime,
      &        myThid)
-
-         IF ( dumpAdVarExch.EQ.2 ) THEN
-          CALL COPY_ADVAR_OUTP( dumRS, adEtaN, var2Du, 1 , 12, myThid )
-          CALL MNC_CW_RL_W('D','adstate',0,0,'adEta', var2Du, myThid)
-         ELSE
-C     dumpAdVarExch.NE.2
-          CALL MNC_CW_RL_W('D','adstate',0,0,'adEta', adEtaN, myThid)
-         ENDIF
+         CALL MNC_CW_RL_W('D','adstate',0,0,'adEta', adEtaN, myThid)
 C     endif mnc
         ENDIF
 #endif /* ALLOW_MNC */
 #endif /* ALLOW_OPENAD */
-
-#ifdef ALLOW_EXF
-cph        IF ( useEXF ) CALL EXF_AD_DUMP( myTime, myIter, myThid )
-#endif
 
         CALL TIMER_STOP( 'I/O (WRITE)        [ADJOINT LOOP]', myThid )
 

--- a/pkg/autodiff/addummy_in_stepping.F
+++ b/pkg/autodiff/addummy_in_stepping.F
@@ -252,8 +252,8 @@ C-----------------------------------------------------------------------
 
         CALL TIMER_START('I/O (WRITE)        [ADJOINT LOOP]', myThid )
 
-c increment ad dump record number (used only if dumpAdByRec is true)
-        dumpAdRecMn=dumpAdRecMn+1
+C Note: dumpAdRecMn is now incremented by addummy_for_etan.F as this is
+C       called first
 c#ifdef ALLOW_DEBUG
 c      IF ( debugMode ) print*,'dumpAdRecMn',dumpAdRecMn
 c#endif
@@ -264,11 +264,6 @@ C--     Set suffix for this set of data files.
         ELSE
           CALL RW_GET_SUFFIX( suff, myTime, myIter, myThid )
         ENDIF
-C ==>> Resetting run-time parameter writeBinaryPrec in the middle of a run
-C ==>>  is very very very nasty !!!
-c       writeBinaryPrec = writeStatePrec
-C <<==  If you really want to mess-up with this at your own risk,
-C <<==  uncomment the line above
 
 C-----------------------------------------------------------------------
 #ifndef ALLOW_OPENAD

--- a/pkg/autodiff/addummy_in_stepping.F
+++ b/pkg/autodiff/addummy_in_stepping.F
@@ -110,7 +110,6 @@ C--   need to all the correct OpenAD EXCH S/R ; left empty for now
 #else /* ALLOW_OPENAD */
 
 #ifdef AUTODIFF_TAMC_COMPATIBILITY
-        call adexch_xy_rl( myThid,adetan)
         call adexch_xyz_rl( myThid,adTheta)
         call adexch_xyz_rl( myThid,adSalt)
         call adexch_xyz_rl( myThid,adwVel )
@@ -142,7 +141,6 @@ C--   need to all the correct OpenAD EXCH S/R ; left empty for now
 # endif
 # else /* ndfef AUTODIFF_TAMC_COMPATIBILITY */
 
-        CALL ADEXCH_3D_RL( adEtaN, 1 , myThid )
 #  ifndef ALLOW_BULK_OFFLINE
         CALL ADEXCH_3D_RL( adTheta,Nr, myThid )
         CALL ADEXCH_3D_RL( adSalt, Nr, myThid )
@@ -192,13 +190,6 @@ C --- 1. Grab modelEnd, necessary input for diagnostics routines
 C --- 2. Fill up diagnostics from local copy (after exch)
 
 # ifdef ALLOW_OPENAD
-         CALL COPY_ADVAR_OUTP( dumRS, etaN%d, var2Du, 1 , 12, myThid )
-# else
-         CALL COPY_ADVAR_OUTP( dumRS, adEtaN, var2Du, 1 , 12, myThid )
-# endif
-         CALL DIAGNOSTICS_FILL( var2Du, 'ADJetan ', 0,1, 0,1,1,myThid )
-
-# ifdef ALLOW_OPENAD
          CALL COPY_ADVAR_OUTP( dumRS, theta%d,var3Du, Nr, 12, myThid )
 # else
          CALL COPY_ADVAR_OUTP( dumRS, adTheta,var3Du, Nr, 12, myThid )
@@ -233,7 +224,6 @@ C --- 3. Fill up diagnostics directly
 
 #  ifdef ALLOW_OPENAD
 C -     OpenAD
-         CALL DIAGNOSTICS_FILL( etaN%d, 'ADJetan ', 0,1, 0,1,1,myThid )
          CALL DIAGNOSTICS_FILL( theta%d,'ADJtheta', 0,Nr,0,1,1,myThid )
          CALL DIAGNOSTICS_FILL( salt%d, 'ADJsalt ', 0,Nr,0,1,1,myThid )
          CALL DIAGNOSTICS_FILL( wVel%d, 'ADJwvel ', 0,Nr,0,1,1,myThid )
@@ -241,7 +231,6 @@ C -     OpenAD
          CALL DIAGNOSTICS_FILL( vVel%d, 'ADJvvel ', 0,Nr,0,1,1,myThid )
 #  else /* ALLOW_OPENAD */
 C -     TAF
-         CALL DIAGNOSTICS_FILL( adEtaN, 'ADJetan ', 0,1, 0,1,1,myThid )
          CALL DIAGNOSTICS_FILL( adTheta,'ADJtheta', 0,Nr,0,1,1,myThid )
          CALL DIAGNOSTICS_FILL( adSalt, 'ADJsalt ', 0,Nr,0,1,1,myThid )
          CALL DIAGNOSTICS_FILL( adwVel, 'ADJwvel ', 0,Nr,0,1,1,myThid )
@@ -296,8 +285,6 @@ C-----------------------------------------------------------------------
      &                           advVel, myIter, myThid )
           CALL WRITE_FLD_XYZ_RL( 'ADJwvel.', suff,
      &                           adwVel, myIter, myThid )
-          CALL WRITE_FLD_XY_RL ( 'ADJetan.', suff,
-     &                           adEtaN, myIter, myThid )
 
           IF ( .NOT. useSEAICE .AND. .NOT. useEXF ) THEN
            CALL WRITE_FLD_XY_RS('ADJtaux.',suff, adFu, myIter, myThid )
@@ -356,8 +343,6 @@ c    &                             adGGL90DiffKr, myIter, myThid )
      &                           advVel, dumpAdRecMn, myIter, myThid )
           CALL WRITE_REC_XYZ_RL( 'ADJwvel',
      &                           adwVel, dumpAdRecMn, myIter, myThid )
-          CALL WRITE_REC_XY_RL ( 'ADJetan',
-     &                           adEtaN, dumpAdRecMn, myIter, myThid )
 
           IF ( .NOT. useSEAICE .AND. .NOT. useEXF ) THEN
            CALL WRITE_REC_XY_RS('ADJtaux',
@@ -438,11 +423,6 @@ C       case dumpAdVarExch = 2
      &                           suff, var3Du, myIter, myThid )
           IF (  dumpAdByRec   ) CALL WRITE_REC_XYZ_RL( 'ADJwvel',
      &                           var3Du, dumpAdRecMn, myIter, myThid )
-          CALL COPY_ADVAR_OUTP( dumRS, adEtaN, var2Du, 1 , 12, myThid )
-          IF (.NOT.dumpAdByRec) CALL WRITE_FLD_XY_RL(  'ADJetan.',
-     &                           suff, var2Du, myIter, myThid )
-          IF (  dumpAdByRec   ) CALL WRITE_REC_XY_RL(  'ADJetan',
-     &                           var2Du, dumpAdRecMn, myIter, myThid )
 
           IF ( .NOT. useSEAICE .AND. .NOT. useEXF ) THEN
            CALL COPY_AD_UV_OUTP( adFu, adFv, dumRL, dumRL,
@@ -558,9 +538,6 @@ C-----------------------------------------------------------------------
           var3Du = wVel%d
           CALL WRITE_FLD_XYZ_RL( 'ADJwvel.', suff,
      &                           var3Du, myIter, myThid )
-          var2Du = etaN%d
-          CALL WRITE_FLD_XY_RL ( 'ADJetan.', suff,
-     &                           var2Du, myIter, myThid )
 
           IF ( .NOT. useSEAICE .AND. .NOT. useEXF ) THEN
            var2Du = Fu%d
@@ -645,9 +622,6 @@ cc     &                           var3Du, myIter, myThid )
           var3Du = wVel%d
           CALL WRITE_REC_XYZ_RL( 'ADJwvel',
      &                           var3Du, dumpAdRecMn, myIter, myThid )
-          var2Du = etaN%d
-          CALL WRITE_REC_XY_RL ( 'ADJetan',
-     &                           var2Du, dumpAdRecMn, myIter, myThid )
 
           IF ( .NOT. useSEAICE .AND. .NOT. useEXF ) THEN
            var2Du = fu%d
@@ -743,11 +717,6 @@ C       case dumpAdVarExch = 2
      &                           suff, var3Du, myIter, myThid )
           IF (  dumpAdByRec   ) CALL WRITE_REC_XYZ_RL( 'ADJwvel',
      &                           var3Du, dumpAdRecMn, myIter, myThid )
-          CALL COPY_ADVAR_OUTP( dumRS, EtaN%d, var2Du, 1 , 12, myThid )
-          IF (.NOT.dumpAdByRec) CALL WRITE_FLD_XY_RL(  'ADJetan.',
-     &                           suff, var2Du, myIter, myThid )
-          IF (  dumpAdByRec   ) CALL WRITE_REC_XY_RL(  'ADJetan',
-     &                           var2Du, dumpAdRecMn, myIter, myThid )
 
           IF ( .NOT. useSEAICE .AND. .NOT. useEXF ) THEN
            CALL COPY_AD_UV_OUTP( Fu%d, Fv%d, dumRL, dumRL,
@@ -869,8 +838,6 @@ C-- NOW NMC output
           CALL MNC_CW_RL_W('D','adstate',0,0,'adT', var3Du, myThid)
           CALL COPY_ADVAR_OUTP( dumRS, adSalt,var3Du, Nr, 12, myThid )
           CALL MNC_CW_RL_W('D','adstate',0,0,'adS', var3Du, myThid)
-          CALL COPY_ADVAR_OUTP( dumRS, adEtaN, var2Du, 1 , 12, myThid )
-          CALL MNC_CW_RL_W('D','adstate',0,0,'adEta', var2Du, myThid)
           CALL COPY_ADVAR_OUTP( dumRS, adwVel, var3Du, Nr, 12, myThid )
           CALL MNC_CW_RL_W('D','adstate',0,0,'adW', var3Du, myThid)
 
@@ -918,7 +885,6 @@ C     dumpAdVarExch.NE.2
           CALL MNC_CW_RL_W('D','adstate',0,0,'adV', advVel, myThid)
           CALL MNC_CW_RL_W('D','adstate',0,0,'adT', adTheta, myThid)
           CALL MNC_CW_RL_W('D','adstate',0,0,'adS', adSalt, myThid)
-          CALL MNC_CW_RL_W('D','adstate',0,0,'adEta', adetaN, myThid)
           CALL MNC_CW_RL_W('D','adstate',0,0,'adW', adwVel, myThid)
 
           CALL MNC_CW_RS_W('D','adstate',0,0,'adQnet', adQnet, myThid)

--- a/pkg/autodiff/addummy_in_stepping.F
+++ b/pkg/autodiff/addummy_in_stepping.F
@@ -252,8 +252,8 @@ C-----------------------------------------------------------------------
 
         CALL TIMER_START('I/O (WRITE)        [ADJOINT LOOP]', myThid )
 
-C Note: dumpAdRecMn is now incremented by addummy_for_etan.F as this is
-C       called first
+c increment ad dump record number (used only if dumpAdByRec is true)
+        dumpAdRecMn=dumpAdRecMn+1
 c#ifdef ALLOW_DEBUG
 c      IF ( debugMode ) print*,'dumpAdRecMn',dumpAdRecMn
 c#endif

--- a/pkg/autodiff/autodiff_ini_model_io.F
+++ b/pkg/autodiff/autodiff_ini_model_io.F
@@ -56,6 +56,7 @@ c     initialize ad dump record number (used only if dumpAdByRec is true)
       dumpAdRecMn=0
       dumpAdRecDy=0
       dumpAdRecSi=0
+      dumpAdRecEt=0
 
       _BEGIN_MASTER( myThid )
 

--- a/pkg/autodiff/dummy_for_etan.F
+++ b/pkg/autodiff/dummy_for_etan.F
@@ -1,0 +1,34 @@
+#include "AUTODIFF_OPTIONS.h"
+
+CBOP
+C     !ROUTINE: DUMMY_FOR_ETAN
+C     !INTERFACE:
+      SUBROUTINE DUMMY_FOR_ETAN( myTime, myIter, myThid )
+
+C     !DESCRIPTION: \bv
+C     *==========================================================*
+C     | SUBROUTINE DUMMY_FOR_ETAN                                |
+C     *==========================================================*
+C     \ev
+
+C     !USES:
+      IMPLICIT NONE
+
+C     == Global variables ===
+#include "SIZE.h"
+#include "EEPARAMS.h"
+#include "PARAMS.h"
+
+C     !INPUT/OUTPUT PARAMETERS:
+C     myTime :: time counter for this thread
+C     myIter :: iteration counter for this thread
+C     myThid :: Thread number for this instance of the routine.
+      _RL     myTime
+      INTEGER myIter
+      INTEGER myThid
+
+C     !LOCAL VARIABLES:
+CEOP
+
+      RETURN
+      END

--- a/pkg/autodiff/dummy_for_etan.flow
+++ b/pkg/autodiff/dummy_for_etan.flow
@@ -1,0 +1,11 @@
+C     /==========================================================\
+C     | SUBROUTINE DUMMY_FOR_ETAN                                |
+C     \==========================================================/
+cadj SUBROUTINE dummy_for_etan INPUT   = 1, 2, 3
+cadj SUBROUTINE dummy_for_etan OUTPUT  =
+cadj SUBROUTINE dummy_for_etan ACTIVE  =
+cadj SUBROUTINE dummy_for_etan DEPEND  = 1, 2, 3
+cadj SUBROUTINE dummy_for_etan REQUIRED
+cadj SUBROUTINE dummy_for_etan INFLUENCED
+cadj SUBROUTINE dummy_for_etan ADNAME  = addummy_for_etan
+cadj SUBROUTINE dummy_for_etan FTLNAME = g_dummy_for_etan

--- a/pkg/autodiff/g_dummy_for_etan.F
+++ b/pkg/autodiff/g_dummy_for_etan.F
@@ -75,11 +75,6 @@ C--     Set suffix for this set of data files.
         ELSE
           CALL RW_GET_SUFFIX( suff, myTime, myIter, myThid )
         ENDIF
-C ==>> Resetting run-time parameter writeBinaryPrec in the middle of a run
-C ==>>  is very very very nasty !!!
-c       writeBinaryPrec = writeStatePrec
-C <<==  If you really want to mess-up with this at your own risk,
-C <<==  uncomment the line above
 
 C--     Read IO error counter
         beginIOErrCount = IO_ERRCOUNT(myThid)

--- a/pkg/autodiff/g_dummy_for_etan.F
+++ b/pkg/autodiff/g_dummy_for_etan.F
@@ -1,0 +1,120 @@
+#include "AUTODIFF_OPTIONS.h"
+#ifdef ALLOW_CTRL
+# include "CTRL_OPTIONS.h"
+#endif
+#include "AD_CONFIG.h"
+
+CBOP
+C     !ROUTINE: g_dummy_for_etan
+C     !INTERFACE:
+      subroutine g_dummy_for_etan( myTime, myIter, myThid )
+
+C     !DESCRIPTION: \bv
+C     *==========================================================*
+C     | SUBROUTINE g_dummy_for_etan                              |
+C     *==========================================================*
+C     Extract tangent linear variable from TAMC/TAF-generated
+C     tangent linear common blocks, contained in g_common.h
+C     and write fields to file;
+C     Make sure common blocks in g_common.h are up-to-date
+C     w.r.t. current adjoint code.
+C     *==========================================================*
+C     | SUBROUTINE g_dummy_for_etan                              |
+C     *==========================================================*
+C     \ev
+
+C     !USES:
+      IMPLICIT NONE
+
+C     == Global variables ===
+#include "SIZE.h"
+#include "EEPARAMS.h"
+#include "PARAMS.h"
+#ifdef ALLOW_AUTODIFF_MONITOR
+# include "g_common.h"
+#endif
+
+C     !INPUT/OUTPUT PARAMETERS:
+C     == Routine arguments ==
+C     myIter :: iteration counter for this thread
+C     myTime :: time counter for this thread
+C     myThid :: Thread number for this instance of the routine.
+      INTEGER myThid
+      INTEGER myIter
+      _RL     myTime
+
+#ifdef ALLOW_TANGENTLINEAR_RUN
+#ifdef ALLOW_AUTODIFF_MONITOR
+
+C     !FUNCTIONS:
+      LOGICAL  DIFFERENT_MULTIPLE
+      EXTERNAL DIFFERENT_MULTIPLE
+      INTEGER  IO_ERRCOUNT
+      EXTERNAL IO_ERRCOUNT
+
+C     !LOCAL VARIABLES:
+c     == local variables ==
+C     suff   :: Hold suffix part of a filename
+C     msgBuf :: Error message buffer
+      CHARACTER*(10) suff
+      INTEGER beginIOErrCount
+      INTEGER endIOErrCount
+      CHARACTER*(MAX_LEN_MBUF) msgBuf
+CEOP
+
+      IF (
+     &  DIFFERENT_MULTIPLE(adjDumpFreq,myTime,deltaTClock)
+     &   ) THEN
+
+        CALL TIMER_START('I/O (WRITE)        [ADJOINT LOOP]', myThid )
+c       write(*,*) 'myIter= ',myIter
+
+C--     Set suffix for this set of data files.
+        IF ( rwSuffixType.EQ.0 ) THEN
+          WRITE(suff,'(I10.10)') myIter
+        ELSE
+          CALL RW_GET_SUFFIX( suff, myTime, myIter, myThid )
+        ENDIF
+C ==>> Resetting run-time parameter writeBinaryPrec in the middle of a run
+C ==>>  is very very very nasty !!!
+c       writeBinaryPrec = writeStatePrec
+C <<==  If you really want to mess-up with this at your own risk,
+C <<==  uncomment the line above
+
+C--     Read IO error counter
+        beginIOErrCount = IO_ERRCOUNT(myThid)
+
+        CALL WRITE_FLD_XY_RL(
+     &       'G_Jetan.',suff, g_etan, myIter, myThid )
+
+
+C--     Reread IO error counter
+        endIOErrCount = IO_ERRCOUNT(myThid)
+
+C--     Check for IO errors
+        IF ( endIOErrCount .NE. beginIOErrCount ) THEN
+         WRITE(msgBuf,'(A)')  'S/R WRITE_STATE'
+         CALL PRINT_ERROR( msgBuf, myThid )
+         WRITE(msgBuf,'(A)')  'Error writing out G_Jetan'
+         CALL PRINT_ERROR( msgBuf, myThid )
+         WRITE(msgBuf,'(A,I10)') 'Timestep ',myIter
+         CALL PRINT_ERROR( msgBuf, myThid )
+        ELSE
+         WRITE(msgBuf,'(A,I10)')
+     &    '// g_JetaN written, timestep', myIter
+         CALL PRINT_MESSAGE( msgBuf, standardMessageUnit,
+     &                       SQUEEZE_RIGHT, myThid )
+         WRITE(msgBuf,'(A)')  ' '
+         CALL PRINT_MESSAGE( msgBuf, standardMessageUnit,
+     &                       SQUEEZE_RIGHT, myThid )
+        ENDIF
+
+        CALL TIMER_STOP( 'I/O (WRITE)        [ADJOINT LOOP]', myThid )
+
+      ENDIF
+
+#endif /* ALLOW_AUTODIFF_MONITOR */
+#endif /* ALLOW_TANGENTLINEAR_RUN */
+
+      RETURN
+      END

--- a/pkg/autodiff/g_dummy_in_stepping.F
+++ b/pkg/autodiff/g_dummy_in_stepping.F
@@ -75,11 +75,6 @@ C--     Set suffix for this set of data files.
         ELSE
           CALL RW_GET_SUFFIX( suff, myTime, myIter, myThid )
         ENDIF
-C ==>> Resetting run-time parameter writeBinaryPrec in the middle of a run
-C ==>>  is very very very nasty !!!
-c       writeBinaryPrec = writeStatePrec
-C <<==  If you really want to mess-up with this at your own risk,
-C <<==  uncomment the line above
 
 C--     Read IO error counter
         beginIOErrCount = IO_ERRCOUNT(myThid)


### PR DESCRIPTION
## What changes does this PR introduce?
This introduces a new dummy routine which is carefully placed to correctly output of adEtaN, the adjoint variable for etaN. 

## What is the current behaviour? 
Currently, adEtaN is printed from addummy_in_stepping, but is zero at this point in the adjoint code.

## What is the new behaviour 
adEtaN is dumped out.

## Does this PR introduce a breaking change? 
no

## Other information:
Output at initial time matches the adxx_etan output from the control package.
I tested this for the various configurations of the free surface that made sense to me: nonlinear and linear free surface, `exactConserv`=t/f,  various settings for `implicDiv2DFlow` & `implicSurfPress`  ... etc. and got consistent results between the control and dumped output no matter the configuration. 

The caveat here is that I could not get this to work with the diagnostics package, and this issue is a bit technical. I put the dummy routine in this particular location so that adEtaN gets the impact of adjoint variables from `calc_r_star_ad` or `calc_surf_dr_ad`, and before it is integrated through the adjoint model, where adEtaN is zero'd out as sensitivities are passed to other variables. However, at this particular spot adEtaN is a "half" time step off from the other variables, so it did not make sense to fill the diagnostic slots for `ADJetan` to be printed later via `addummy_in_stepping` because they would be inconsistent. I also could not think of a way to print individual diagnostic variables at different times. This could be fixed by placing `dummy_in_stepping` in a similar manner to `do_state_vars_diags` but for adjoint variables, but this seemed like overkill for a first step.  