### PR TITLE
add badge pointing to latest checkpoint archive and its reference / DOI

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,6 @@
 [![Build Status](https://travis-ci.org/MITgcm/MITgcm.svg?branch=master)](https://travis-ci.org/MITgcm/MITgcm)
 [![Documentation Status](http://readthedocs.org/projects/mitgcm/badge/?version=latest)](http://mitgcm.readthedocs.io/en/latest/?badge=latest)
-
-
-
+[![DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.1409237.svg)](https://doi.org/10.5281/zenodo.1409237)
 
 # MITgcm
 


### PR DESCRIPTION
## What changes does this PR introduce?
(Bug fix, feature, docs update, ...)

Adds a zenodo badge pointing to latest checkpoint archive and its reference / DOI

## What is the current behaviour? 
(You can also link to an open issue here)

DOI is not evident

## What is the new behaviour 
(if this is a feature change)?

DOI is shown when entering the repo with a zenodo badge that forwards to the 
latest latest checkpoint archive and its reference / DOI

## Does this PR introduce a breaking change? 
(What changes might users need to make in their application due to this PR?)

no

## Other information:

Could be useful to add some text to the effect of "Latest checkpoint: " in front of the badge maybe?
