### PR TITLE
Add request for tag-index text

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -15,3 +15,7 @@
 
 
 ## Other information:
+
+
+## Suggested addition to `tag-index`
+(To avoid unnecessary merge conflicts, please don't update `tag-index`. One of the admins will do that when merging your pull request.)


### PR DESCRIPTION
## What changes does this PR introduce?
Add a request for suggested additions to `tag-index` to the PR template. This was requested in https://github.com/MITgcm/MITgcm/pull/89#issuecomment-422578547

## What is the current behaviour? 
Users are not prompted to suggest an addition to `tag-index`.

## Does this PR introduce a breaking change? 
No.
