### PR TITLE
Check that Fortran Compiler is usable

### DIFF
--- a/doc/getting_started/getting_started.rst
+++ b/doc/getting_started/getting_started.rst
@@ -455,9 +455,9 @@ In the above, notice:
   these error messages and/or the standard output from :filelink:`genmake2 <tools/genmake2>` or
   ``genmake.log`` may provide clues as to the problem. If instead you receive a
   warning message ``Warning: FORTRAN compiler test failed`` at the end of :filelink:`genmake2 <tools/genmake2>` output ,
-  :filelink:`genmake2 <tools/genmake2>` is unable
-  to locate the Fortran compiler or a pass a trivial “hello world” Fortran compilation & run test. See ``genmake.log``
-  for errors and/or seek assistance from your system administrator;
+  this means that :filelink:`genmake2 <tools/genmake2>` is unable
+  to locate the Fortran compiler or pass a trivial “hello world” Fortran compilation and run test. In this case, 
+  you should see ``genmake.log`` for errors and/or seek assistance from your system administrator;
   these tests need to pass in order to proceed to the ``make`` steps.
 
 

--- a/doc/getting_started/getting_started.rst
+++ b/doc/getting_started/getting_started.rst
@@ -416,6 +416,10 @@ When you run the :filelink:`genmake2 <tools/genmake2>` script, typical output mi
     Adding makedepend marker
   
   ===  Done  ===
+    original 'Makefile' generated successfully
+  => next steps:
+    > make depend
+    > make       (<-- to generate executable)
 
  
 
@@ -445,11 +449,17 @@ In the above, notice:
   overriding any MITgcm repository versions of files, if they exist.
 - a handful of packages are being used in this build; see :numref:`using_packages`
   for more detail about how to enable and disable packages.
-- :filelink:`genmake2 <tools/genmake2>` terminated without error,
+- :filelink:`genmake2 <tools/genmake2>` terminated without error (note output at end after ``===  Done  ===``),
   generating ``Makefile`` and a log file ``genmake.log``. As mentioned, this does not guarantee that
   your setup will compile properly, but if there are errors during ``make depend`` or ``make``, 
   these error messages and/or the standard output from :filelink:`genmake2 <tools/genmake2>` or
-  ``genmake.log`` may provide clues as to the problem.
+  ``genmake.log`` may provide clues as to the problem. If instead you receive a
+  warning message ``Warning: FORTRAN compiler test failed`` at the end of :filelink:`genmake2 <tools/genmake2>` output ,
+  :filelink:`genmake2 <tools/genmake2>` is unable
+  to locate the Fortran compiler or a pass a trivial “hello world” Fortran compilation & run test. See ``genmake.log``
+  for errors and/or seek assistance from your system administrator;
+  these tests need to pass in order to proceed to the ``make`` steps.
+
 
 .. _command_line_options:
 

--- a/tools/genmake2
+++ b/tools/genmake2
@@ -607,6 +607,69 @@ EOF
     fi
 }
 
+#  Just try to use FC, report failed attempt as a Warning
+check_fortran_compiler() {
+    echo -n "  check Fortran Compiler... "
+    echo "" >> $LOGFILE
+    echo "running: check_fortran_compiler" >> $LOGFILE
+    FC_CHECK=-1
+    rm -f ./genmake_tcomp.f
+    cat >> genmake_tcomp.f <<EOF
+      program hello
+      integer i
+      do i=1,3
+        print *, 'hello world : ', i
+      enddo
+      end
+EOF
+    COMM="$FC $FFLAGS $FOPTIM -c genmake_tcomp.f"
+    echo ' '$COMM >> $LOGFILE
+    $COMM >> $LOGFILE 2>&1
+    RETVAL=$?
+    if test "x$RETVAL" != x0 ; then
+	FC_CHECK=0
+	echo "" >> $LOGFILE
+	echo " Warning: FORTRAN compiler test fails to compile" >> $LOGFILE
+	echo -n " fail to compile"
+    fi
+    if test $FC_CHECK = '-1' ; then
+	COMM="$LINK $FFLAGS $FOPTIM -o genmake_tcomp genmake_tcomp.o $LIBS"
+	echo ' '$COMM >> $LOGFILE
+	$COMM >> $LOGFILE 2>&1
+	RETVAL=$?
+    else RETVAL=0 ; fi
+    if test "x$RETVAL" != x0 ; then
+	FC_CHECK=1
+	echo "" >> $LOGFILE
+	echo " Warning: FORTRAN compiler test fails to link" >> $LOGFILE
+	echo -n " fail to generate executable"
+    fi
+    if test $FC_CHECK = '-1' -a -x genmake_tcomp ; then
+	if test "x$MPI" = 'xtrue' ; then
+	    COMM="mpirun -np 1 genmake_tcomp"
+	else
+	    COMM="./genmake_tcomp"
+	fi
+	echo ' '$COMM >> $LOGFILE
+	$COMM >> $LOGFILE 2>&1
+	RETVAL=$?
+	if test "x$RETVAL" != x0 ; then
+	   FC_CHECK=3
+	  #echo -n " fail to run"
+	else
+	   FC_CHECK=4
+	   echo -n " pass"
+	fi
+    elif test $FC_CHECK = '-1' ; then
+	FC_CHECK=2
+	echo 'WARNING: missing executable from FORTRAN compiler test' >> $LOGFILE
+	echo -n " fail to generate executable"
+    fi
+    rm -f genmake_tcomp.* genmake_tcomp
+    echo " --> set FC_CHECK='$FC_CHECK'" >> $LOGFILE
+    echo "  (set FC_CHECK='$FC_CHECK')"
+}
+
 #  Do a local copy of MPI headers files (in local dir ./mpi_headers/) after
 #  checking for additional included headers (in case of chain of included header)
 mpi_headers_do_local_copy() {
@@ -1287,6 +1350,7 @@ CHECK_FOR_LAPACK=f
 # DEFINES checked by test compilation or command-line
 HAVE_SYSTEM=
 HAVE_FDATE=
+FC_CHECK=
 FC_NAMEMANGLE=
 HAVE_CLOC=
 # HAVE_SETRLSTK=
@@ -1357,7 +1421,7 @@ gm_s3="FEXTRAFLAGS IEEE DEVEL GSL TS PAPIS PCLS PAPI PCL HPMT DUMPSTATE"
 gm_s4="LN S64 LINK PACKAGES INCLUDES FFLAGS FOPTIM"
 gm_s5="CFLAGS LIBS KPP KFLAGS1 KFLAGS2 KPPFILES NOOPTFILES NOOPTFLAGS"
 gm_s6="PWD TOOLSDIR SOURCEDIRS INCLUDEDIRS EXEDIR EXECUTABLE EXEHOOK"
-gm_s7="TMP THISHOST THISUSER THISDATE THISVER MACHINE FC_NAMEMANGLE"
+gm_s7="TMP THISHOST THISUSER THISDATE THISVER MACHINE FC_CHECK FC_NAMEMANGLE"
 gm_s8="HAVE_NETCDF HAVE_SYSTEM HAVE_FDATE HAVE_ETIME HAVE_LAPACK HAVE_FLUSH"
 
 #  The following are all related to adjoint/tangent-linear stuff
@@ -1776,6 +1840,10 @@ fi
 if test "x$MAKE" = x ; then
     MAKE="make"
 fi
+
+#- check for fortran compiler (for now, just for information, no consequence)
+check_fortran_compiler
+
 if test "x$CPP" = x ; then
     CPP="cpp -traditional -P"
 fi
@@ -3650,4 +3718,26 @@ if test "x$DUMPSTATE" = xt ; then
 	eval $t1
 	echo "$i='$t2'" | sed -e 's/  */ /g' >> genmake_state
     done
+fi
+
+#  Conclude
+if test "x$FC_CHECK" = x4 ; then
+    echo "  original 'Makefile' generated successfully"
+    echo "=> next steps:"
+    ad=`echo $PACKAGES | grep -c autodiff`
+    if test "x$OPENAD" != x ; then
+	echo "  > make adAll    (<-- adjoint executable)"
+    elif test $ad != 0 ; then
+	echo "  > make depend"
+	echo "    > make adall  (<-- adjoint executable)"
+	echo " or > make tlm    (<-- tang-lin executable)"
+	echo " or > make        (<-- forward executable)"
+    else
+#	echo "  > make depend   (add dependencies to Makefile)"
+	echo "  > make depend"
+	echo "  > make       (<-- to generate executable)"
+    fi
+else
+	echo "Warning: FORTRAN compiler test failed (please see '$LOGFILE')"
+	echo "Warning: 'Makefile' might be unusable (check your optfile)"
 fi


### PR DESCRIPTION

## What changes does this PR introduce?
Check that FC compiler can be used to compile and run a simple hello world program.
For now, just reports the result (no changes in resulting Makefile).
Also, at the end, reports next command to type when FC test is successful.

## What is the current behaviour? 
No clear message when compiler is not usable.

## What is the new behaviour 
improve reports; also print next command to type.

## Does this PR introduce a breaking change? 
no

## Other information: