### PR TITLE
refine build_options files for ollie

### DIFF
--- a/tools/build_options/linux_ia64_cray_ollie
+++ b/tools/build_options/linux_ia64_cray_ollie
@@ -75,20 +75,23 @@ F90OPTIM=$FOPTIM
 CFLAGS="-O0 $MCMODEL"
 
 
+# the extra -Wl,-rpath,${NETCDF_LIB} makes sure that the path to the
+# dynamics libraries is hardwired in the executable and does not depend
+# on which module you have loaded
 if [ "x$NETCDF_ROOT" != x ] ; then
     INCLUDEDIRS="${NETCDF_ROOT}/include"
     INCLUDES="-I${NETCDF_ROOT}/include"
-    LIBS="-L${NETCDF_ROOT}/lib"
+    LIBS="-L${NETCDF_ROOT}/lib -Wl,-rpath,${NETCDF_ROOT}/lib"
 elif [ "x$NETCDF_HOME" != x ]; then
     INCLUDEDIRS="${NETCDF_HOME}/include"
     INCLUDES="-I${NETCDF_HOME}/include"
-    LIBS="-L${NETCDF_HOME}/lib"
+    LIBS="-L${NETCDF_HOME}/lib -Wl,-rpath,${NETCDF_HOME}/lib"
 elif [ "x$NETCDF_INC" != x -a "x$NETCDF_LIB" != x ]; then
     NETCDF_INC=`echo $NETCDF_INC | sed 's/-I//g'`
     NETCDF_LIB=`echo $NETCDF_LIB | sed 's/-L//g'`
     INCLUDEDIRS="${NETCDF_INC}"
     INCLUDES="-I${NETCDF_INC}"
-    LIBS="-L${NETCDF_LIB}"
+    LIBS="-L${NETCDF_LIB} -Wl,-rpath,${NETCDF_LIB}"
 fi
 
 if [ -n "$MPI_ROOT" -a -z "$MPI_INC_DIR" ]; then

--- a/tools/build_options/linux_ia64_ifort_ollie
+++ b/tools/build_options/linux_ia64_ifort_ollie
@@ -77,20 +77,23 @@ INCLUDEDIRS=''
 INCLUDES=''
 LIBS=''
 
+# the extra -Wl,-rpath,${NETCDF_LIB} makes sure that the path to the
+# dynamics libraries is hardwired in the executable and does not depend
+# on which module you have loaded
 if [ "x$NETCDF_ROOT" != x ] ; then
     INCLUDEDIRS="${NETCDF_ROOT}/include"
     INCLUDES="-I${NETCDF_ROOT}/include"
-    LIBS="-L${NETCDF_ROOT}/lib"
+    LIBS="-L${NETCDF_ROOT}/lib -Wl,-rpath,${NETCDF_ROOT}/lib"
 elif [ "x$NETCDF_HOME" != x ]; then
     INCLUDEDIRS="${NETCDF_HOME}/include"
     INCLUDES="-I${NETCDF_HOME}/include"
-    LIBS="-L${NETCDF_HOME}/lib"
+    LIBS="-L${NETCDF_HOME}/lib -Wl,-rpath,${NETCDF_HOME}/lib"
 elif [ "x$NETCDF_INC" != x -a "x$NETCDF_LIB" != x ]; then
     NETCDF_INC=`echo $NETCDF_INC | sed 's/-I//g'`
     NETCDF_LIB=`echo $NETCDF_LIB | sed 's/-L//g'`
     INCLUDEDIRS="${NETCDF_INC}"
     INCLUDES="-I${NETCDF_INC}"
-    LIBS="-L${NETCDF_LIB}"
+    LIBS="-L${NETCDF_LIB} -Wl,-rpath,${NETCDF_LIB}"
 fi
 
 if [ -n "$MPI_INC_DIR" -a "x$MPI" = xtrue ] ; then


### PR DESCRIPTION
## What changes does this PR introduce?
additional flags hardwire paths to dynamic netcdf libraries 

## What is the current behaviour? 
paths to dynamic libraries depend on the loaded modules, which can cause the executable not to find dynamics libraries at runtime

## What is the new behaviour 
paths to dynamic libraries do not depend on the loaded modules

## Does this PR introduce a breaking change? 
No

## Other information:

## Suggested addition to `tag-index`
- additional flags hardwire paths to dynamic netcdf libraries, so that loading dynamic libraries at runtime does not depend on the loaded modules anymore