### PR TITLE
Ozone in atm phys

### DIFF
--- a/pkg/atm_phys/ATM_PHYS_PARAMS.h
+++ b/pkg/atm_phys/ATM_PHYS_PARAMS.h
@@ -23,10 +23,12 @@ C     atmPhys_sstFile  :: name of initial SST [in K] file
 C     atmPhys_qFlxFile :: name of Q-flux file
 C     atmPhys_mxldFile :: name of Mixed-Layer Depth file
 C     atmPhys_albedoFile :: name of Albedo file
+C     atmPhys_ozoneFile  :: name of ozone concentration file
       CHARACTER*(MAX_LEN_FNAM) atmPhys_sstFile
       CHARACTER*(MAX_LEN_FNAM) atmPhys_qFlxFile
       CHARACTER*(MAX_LEN_FNAM) atmPhys_mxldFile
       CHARACTER*(MAX_LEN_FNAM) atmPhys_albedoFile
+      CHARACTER*(MAX_LEN_FNAM) atmPhys_ozoneFile
 
       COMMON /ATM_PHYS_PARAMS_L/
      &       atmPhys_addTendT, atmPhys_addTendS,
@@ -35,8 +37,8 @@ C     atmPhys_albedoFile :: name of Albedo file
       COMMON /ATM_PHYS_PARAMS_R/
      &       atmPhys_tauDampUV, atmPhys_dampUVfac
       COMMON /ATM_PHYS_PARAMS_C/
-     &       atmPhys_sstFile,  atmPhys_qFlxFile,
-     &       atmPhys_mxldFile, atmPhys_albedoFile
+     &       atmPhys_sstFile, atmPhys_qFlxFile, atmPhys_mxldFile,
+     &       atmPhys_albedoFile, atmPhys_ozoneFile
 
 C-- from driver-atmosphere module:
       logical  module_is_initialized

--- a/pkg/atm_phys/ATM_PHYS_PARAMS.h
+++ b/pkg/atm_phys/ATM_PHYS_PARAMS.h
@@ -23,7 +23,8 @@ C     atmPhys_sstFile  :: name of initial SST [in K] file
 C     atmPhys_qFlxFile :: name of Q-flux file
 C     atmPhys_mxldFile :: name of Mixed-Layer Depth file
 C     atmPhys_albedoFile :: name of Albedo file
-C     atmPhys_ozoneFile  :: name of ozone concentration file
+C     atmPhys_ozoneFile  :: name of annual mean ozone concentration file
+C                           (units: mol/mol i.e. volume mixing ratio)
       CHARACTER*(MAX_LEN_FNAM) atmPhys_sstFile
       CHARACTER*(MAX_LEN_FNAM) atmPhys_qFlxFile
       CHARACTER*(MAX_LEN_FNAM) atmPhys_mxldFile

--- a/pkg/atm_phys/ATM_PHYS_VARS.h
+++ b/pkg/atm_phys/ATM_PHYS_VARS.h
@@ -12,13 +12,16 @@ C-    AtmPhys 2-dim. fields
      &    atmPhys_Albedo
 
 C-    AtmPhys 3-dim. fields
+C     atmPhys_Ozone :: ozone concentration [volume mixing ratio]
       _RL atmPhys_dT(1-OLx:sNx+OLx,1-OLy:sNy+OLy,Nr,nSx,nSy)
       _RL atmPhys_dQ(1-OLx:sNx+OLx,1-OLy:sNy+OLy,Nr,nSx,nSy)
       _RL atmPhys_dU(1-OLx:sNx+OLx,1-OLy:sNy+OLy,Nr,nSx,nSy)
       _RL atmPhys_dV(1-OLx:sNx+OLx,1-OLy:sNy+OLy,Nr,nSx,nSy)
+      _RL atmPhys_Ozone(1-OLx:sNx+OLx,1-OLy:sNy+OLy,Nr,nSx,nSy)
       COMMON /ATMPHYS_3D_VARS/
      &    atmPhys_dT, atmPhys_dQ,
-     &    atmPhys_dU, atmPhys_dV
+     &    atmPhys_dU, atmPhys_dV,
+     &    atmPhys_Ozone
 
 #endif /* ALLOW_ATM_PHYS */
 

--- a/pkg/atm_phys/ATM_PHYS_VARS.h
+++ b/pkg/atm_phys/ATM_PHYS_VARS.h
@@ -12,7 +12,7 @@ C-    AtmPhys 2-dim. fields
      &    atmPhys_Albedo
 
 C-    AtmPhys 3-dim. fields
-C     atmPhys_Ozone :: ozone concentration [volume mixing ratio]
+C     atmPhys_Ozone :: ozone concentration [volume mixing ratio <-> mol/mol]
       _RL atmPhys_dT(1-OLx:sNx+OLx,1-OLy:sNy+OLy,Nr,nSx,nSy)
       _RL atmPhys_dQ(1-OLx:sNx+OLx,1-OLy:sNy+OLy,Nr,nSx,nSy)
       _RL atmPhys_dU(1-OLx:sNx+OLx,1-OLy:sNy+OLy,Nr,nSx,nSy)

--- a/pkg/atm_phys/atm_phys_driver.F
+++ b/pkg/atm_phys/atm_phys_driver.F
@@ -72,6 +72,8 @@ CEOP
       _RL t_surf  (sNx,sNy)
 C-- radiation fields:
       _RL albedo_2d (sNx,sNy)
+      _RL ozone_3d  (sNx,sNy,Nr)
+      _RL ozoneColmn(sNx,sNy,Nr+1)
       _RL dtrans_3d (sNx,sNy,Nr)
       _RL dtrans_win(sNx,sNy,Nr)
       _RL b_3d      (sNx,sNy,Nr)
@@ -178,6 +180,11 @@ c       ENDIF
         ocean_qflux(:,:) = atmPhys_Qflx(1:sNx,1:sNy,bi,bj)
         mixLayDepth(:,:) = atmPhys_MxLD(1:sNx,1:sNy,bi,bj)
         albedo_2d(:,:) = atmPhys_Albedo(1:sNx,1:sNy,bi,bj)
+C--   copy atmPhys_Ozone to ozone_3d for rad scheme
+        DO k=1,Nr
+          kc = Nr-k+1
+          ozone_3d(:,:,k) = atmPhys_Ozone(1:sNx,1:sNy,kc,bi,bj)
+        ENDDO
 
 C--   Get grid and dynamical fields from main model common blocks
         CALL ATM_PHYS_DYN2PHYS(
@@ -276,7 +283,7 @@ c    &                            0, 1, 3, bi, bj, myThid )
            CALL DIAGNOSTICS_FILL( rain2d , 'AtPhLscP',
      &                            0, 1, 3, bi, bj, myThid )
 C     Re-use "q_ref" array to calculate Relative Humidity (in %)
-           q_ref = 100. _d 0 * q3d_tmp/q_ref
+           q_ref = 100. _d 0 * q3d_tmp/MAX( q_ref, 1. _d -12 )
            CALL DIAGNOSTICS_FILL( q_ref , 'RELHUM  ',
      &                           -1, Nr, 3, bi, bj, myThid )
         ENDIF
@@ -285,8 +292,8 @@ C     Re-use "q_ref" array to calculate Relative Humidity (in %)
         IF ( two_stream ) THEN
           CALL RADIATION_DOWN(
      I                   sNx,sNy, myTime, lat2d, pHalf3d, t3d, q3d,
-     I                   albedo_2d,
-     O                   s_sw_dwn, s_lw_dwn,
+     I                   albedo_2d, ozone_3d,
+     O                   ozoneColmn, s_sw_dwn, s_lw_dwn,
      O                   dtrans_3d, dtrans_win, b_3d, b_win,
      O                   lw_down_3d, sw_down_3d, myThid )
 
@@ -325,7 +332,7 @@ c    &      lw_down_3d(1,1,15), lw_down_3d(1,sNy,15)
           CALL RADIATION_UP(
      I                   sNx,sNy, myTime, lat2d, pHalf3d, t_surf, t3d,
      U                   tdt3d, lw_net_3d, sw_net_3d,
-     I                   albedo_2d, dtrans_3d, dtrans_win,
+     I                   albedo_2d, ozoneColmn, dtrans_3d, dtrans_win,
      I                   b_3d, b_win, lw_down_3d, sw_down_3d, myThid )
 
 c         write(errorMessageUnit,'(A,I5,I3,4F9.3)')

--- a/pkg/atm_phys/atm_phys_init_fixed.F
+++ b/pkg/atm_phys/atm_phys_init_fixed.F
@@ -39,7 +39,7 @@ C     iUnit      :: Work variable for IO unit number
       CHARACTER*(MAX_LEN_MBUF) msgBuf
       INTEGER iUnit
       INTEGER axes(4)
-      INTEGER i,j,bi,bj
+      INTEGER i,j,k,bi,bj
       _RL cst_albedo, cst_mxlDepth
 
       namelist / atmosphere_nml /
@@ -131,6 +131,13 @@ c    I                        lat2d, ocean_qflux,
             atmPhys_Albedo(i,j,bi,bj) = cst_albedo
           ENDDO
          ENDDO
+         DO k=1,Nr
+          DO j=1-OLy,sNy+OLy
+           DO i=1-OLx,sNx+OLx
+            atmPhys_Ozone(i,j,k,bi,bj) = 0. _d 0
+           ENDDO
+          ENDDO
+         ENDDO
        ENDDO
       ENDDO
       IF ( atmPhys_qFlxFile .NE. ' ' ) THEN
@@ -147,6 +154,11 @@ c    I                        lat2d, ocean_qflux,
         CALL READ_FLD_XY_RL( atmPhys_albedoFile,' ',
      &                       atmPhys_Albedo, 0, myThid )
         CALL EXCH_XY_RL( atmPhys_Albedo, myThid )
+      ENDIF
+      IF ( atmPhys_ozoneFile .NE. ' ' ) THEN
+        CALL READ_FLD_XYZ_RL( atmPhys_ozoneFile,' ',
+     &                        atmPhys_Ozone, 0, myThid )
+        CALL EXCH_XYZ_RL( atmPhys_Ozone, myThid )
       ENDIF
 
 #ifdef ALLOW_MNC

--- a/pkg/atm_phys/atm_phys_readparms.F
+++ b/pkg/atm_phys/atm_phys_readparms.F
@@ -35,8 +35,8 @@ C     iUnit      :: Work variable for IO unit number
      &       atmPhys_addTendU, atmPhys_addTendV,
      &       atmPhys_tauDampUV, atmPhys_dampUVfac,
      &       atmPhys_stepSST,
-     &       atmPhys_sstFile,  atmPhys_qFlxFile,
-     &       atmPhys_mxldFile, atmPhys_albedoFile
+     &       atmPhys_sstFile, atmPhys_qFlxFile, atmPhys_mxldFile,
+     &       atmPhys_albedoFile, atmPhys_ozoneFile
 
       _BEGIN_MASTER(myThid)
 
@@ -65,6 +65,7 @@ C-    additional parameters:
       atmPhys_qFlxFile  = ' '
       atmPhys_mxldFile  = ' '
       atmPhys_albedoFile= ' '
+      atmPhys_ozoneFile = ' '
 
       WRITE(msgBuf,'(A)') 'ATM_PHYS_READPARMS: opening data.atm_phys'
       CALL PRINT_MESSAGE( msgBuf, standardMessageUnit,

--- a/pkg/atm_phys/radiation_mod.F90
+++ b/pkg/atm_phys/radiation_mod.F90
@@ -34,11 +34,17 @@ public :: radiation_init, radiation_down, radiation_up, radiation_end
 ! module variables
 ! select_incSW :: select expression for Incoming SW radiation @ the top
 !              :: =0 : no season ; =1 : circular orbit planet (obliquity only)
+! ozone_in_SW  :: =1 : account for Ozone in downward SW absorption ; =0: ignore it
+! two_stream_SW :: =1 : also accont for Ozone in upward SW absorption ; =0: ignore
+!                 Note: requires ozone_in_SW=1 to use two_stream_SW=1
 ! yearLength   :: length of solar year in seconds
 ! yearPhase    :: phase in solar year [0-1] relative to NH winter solstice
 ! obliquity    :: obliquity of Earth rotation axis in degre
 logical :: initialized =.false.
 integer :: select_incSW    = 0
+! MK added switches for O3 scheme (default off):
+integer :: ozone_in_SW     = 0
+integer :: two_stream_SW   = 0
 
 real    :: solar_constant  = 1360.0
 real    :: del_sol         = 1.4
@@ -75,7 +81,8 @@ namelist/radiation_nml/ select_incSW, solar_constant, del_sol, &
            ir_tau_eq, ir_tau_pole, linear_tau, ir_tau_co2, ir_tau_wv,   &
            ir_tau_wv2, atm_abs, sw_diff, del_sw, albedo_value, window,  &
            wv_exponent, solar_exponent, yearLength, yearPhase, obliquity, &
-           sw_co2, ir_tau_co2_win, ir_tau_wv_win1, ir_tau_wv_win2, carbon_conc
+           sw_co2, ir_tau_co2_win, ir_tau_wv_win1, ir_tau_wv_win2, &
+           carbon_conc, ozone_in_SW, two_stream_SW
 
 !==================================================================================
 !-------------------- diagnostics fields -------------------------------
@@ -212,7 +219,8 @@ end subroutine radiation_init
 ! ==================================================================================
 
 subroutine radiation_down (is, js, Time_diag, lat, p_half, t, q,      &
-                           albedo, net_surf_sw_down, surf_lw_down,    &
+                           albedo, o3conc, ozone_column,              &
+                           net_surf_sw_down, surf_lw_down,            &
                            dtrans, dtrans_win, b, b_win,              &
                            down, solar_down,                          &
                            myThid )
@@ -228,6 +236,8 @@ real, intent(out), dimension(:,:)   :: net_surf_sw_down
 real, intent(out), dimension(:,:)   :: surf_lw_down
 real, intent(in) , dimension(:,:,:) :: t, q, p_half
 real, intent(in) , dimension(:,:)   :: albedo
+real, intent(in) , dimension(:,:,:) :: o3conc
+real, intent(out), dimension(:,:,:) :: ozone_column
 real, intent(out), dimension(:,:,:) :: dtrans
 real, intent(out), dimension(:,:,:) :: dtrans_win
 real, intent(out), dimension(:,:,:) :: b
@@ -251,6 +261,10 @@ real, allocatable, dimension(:,:)   :: ss, solar, solar_tau_0, p2
 real, allocatable, dimension(:,:)   :: solar_tau_k, sw_wv, del_sol_tau, mag_fac
 real, allocatable, dimension(:,:,:) :: solar_tau, dtrans_sol, down_win
 real, allocatable, dimension(:,:)   :: del_tau, tau_0, tau_km, tau_kp, del_tau_win
+! MK: Variables for Lacis & Hansen ozone SW scheme
+real, allocatable, dimension(:,:,:) :: ozone_mag, ozone_dF0_down
+real, allocatable, dimension(:,:)   :: abs_uv_LH, abs_uv_LH_FS
+real, allocatable, dimension(:,:)   :: abs_vis_LH, abs_vis_LH_FS
 ! Variables for seasonal Incoming SW
 real, allocatable, dimension(:,:)   :: cLat, sLat, cos_H, HourAng
 ! -------------------------------------------------------------------------
@@ -265,12 +279,20 @@ allocate (ss               (im, jm))
 allocate (solar            (im, jm))
 if ( select_incSW .eq. 0 ) then
   allocate (p2             (im, jm))
-elseif ( select_incSW .eq. 1 ) then
+else
 ! Variables for seasonal Incoming SW
   allocate (cLat           (im, jm))
   allocate (sLat           (im, jm))
   allocate (cos_H          (im, jm))
   allocate (HourAng        (im, jm))
+endif
+if ( ozone_in_SW .eq. 1 ) then
+  allocate (ozone_mag      (im, jm, n+1))
+  allocate (ozone_dF0_down (im, jm, n+1))
+  allocate (abs_uv_LH      (im, jm))
+  allocate (abs_vis_LH     (im, jm))
+  allocate (abs_uv_LH_FS   (im, jm))
+  allocate (abs_vis_LH_FS  (im, jm))
 endif
 if ( solar_exponent .eq. 0. ) then
   allocate (solar_tau_k    (im, jm))
@@ -297,15 +319,9 @@ endif
 
 ss  = sin(lat)
 
-if ( select_incSW .eq. 0 ) then
-! Original Incoming SW (no seasonal cycle):
-   p2 = (1. - 3.*ss*ss)/4.
-   solar = 0.25*solar_constant*(1.0 + del_sol*p2 + del_sw * ss)
-
-elseif ( select_incSW .eq. 1 ) then
+if ( select_incSW .eq. 1 .or. ozone_in_SW .eq. 1 ) then
 ! daily-mean Incoming SW with simple seasonal cycle accounting
 !  only for obliquity (i.e., circular orbit planet)
-   largeTan = 1.e+16
 
 ! tYear = time in the solar year, in [0-1]
    tYear = MOD( Time_diag/yearLength + yearPhase , 1.0 )
@@ -313,10 +329,20 @@ elseif ( select_incSW .eq. 1 ) then
 ! Compute the declination angle
 ! a) approximate estimate of declination angle: relative error is less
 !    than 0.03 for current obliq but as large as 0.21 for obliq=60^o
-!  xDecl = - obliquity*deg_to_rad * cos(2.*pi*tYear)
+!    xDecl = - obliquity*deg_to_rad * cos(2.*pi*tYear)
 ! b) unapproximate expression:
-   sDecl = -sin(  obliquity*deg_to_rad ) * cos(2.*pi*tYear)
+   sDecl = -sin( obliquity*deg_to_rad ) * cos(2.*pi*tYear)
    cDecl =  cos( asin( sDecl ) )
+endif
+
+if ( select_incSW .eq. 0 ) then
+! Original Incoming SW (no seasonal cycle):
+   p2 = (1. - 3.*ss*ss)/4.
+   solar = 0.25*solar_constant*(1.0 + del_sol*p2 + del_sw * ss)
+
+elseif ( select_incSW .eq. 1 ) then
+
+   largeTan = 1.e+16
    if ( cDecl.EQ.0. ) then
     tanDecl = sign( largeTan, sDecl )
    else
@@ -382,6 +408,69 @@ else
 
   do k = 1,n+1
     solar_down(:,:,k) = solar(:,:)*exp(-solar_tau(:,:,k))
+  end do
+
+endif
+
+if ( ozone_in_SW .eq. 1 ) then
+!-------
+! MK 2017: Add Lacis and Hansen (JAS, 1974) absorption by ozone,
+! and apply Forster and Shine (JGR, 1997) correction.
+!-------
+! Computes broadband absorption, as fraction of total solar flux at TOA.
+! However, O3 band does not significantly overlap with water vapour SW absorption,
+! so can safely add O3 heating on top of water vapour heating without changing the
+! radiation seen by the water vapour optical depths in Ruth's scheme above.
+
+! o3conc = Ozone VMR on pressure levels.  Need to convert to centimetre of ozone
+! to use with Lacis and Hansen scheme.  Make ozone_column array containing
+! ozone amount in cm from TOA down to top of level k
+
+! ozone_column(:,:,1:n+1) = Column O3 in cm above level 1 <= k <= n+1
+
+  ozone_column(:,:,1) = 0.
+  do k = 1, n
+    ozone_column(:,:,k+1) = ozone_column(:,:,k) + (                            &
+                          ( 287.1 / (1.38065e-23 * grav) )                     &
+                          * ( p_half(:,:,k+1) - p_half(:,:,k) )                &
+                          * o3conc(:,:,k) / 2.687e+23                          &
+                                                  )
+  end do
+
+! Apply magnification factor:
+  ozone_mag(:,:,:) = ozone_column(:,:,:) * 35.                                  &
+                   / sqrt( 1224.*cDecl*cDecl + 1. )
+
+! Parameterization for fraction of total flux absorbed from LH74:
+  do k = 1, n+1
+
+    abs_vis_LH(:,:)   = ( 0.02118 * ozone_mag(:,:,k) ) / (                     &
+                          1. + 0.042 * ozone_mag(:,:,k)                        &
+                             + 0.000323*ozone_mag(:,:,k)*ozone_mag(:,:,k)      &
+                                                         )
+  ! FS97 correction:
+    abs_vis_LH_FS(:,:) = ( -0.002894 * ozone_mag(:,:,k) + 1.0663 )             &
+                       * abs_vis_LH(:,:)
+
+    abs_uv_LH(:,:)   = ( 1.082 * ozone_mag(:,:,k) ) / (                        &
+                         ( 1. + 138.6 * ozone_mag(:,:,k) )**0.805              &
+                                                      )                        &
+                     + ( 0.0658 * ozone_mag(:,:,k) ) / (                       &
+                         1. + ( 103.6 * ozone_mag(:,:,k) )**3                  &
+                                                       )
+  ! FS97 correction:
+    abs_uv_LH_FS(:,:) = ( -0.01632 * ozone_mag(:,:,k) + 1.08964 )              &
+                      * abs_uv_LH(:,:)
+
+  ! Total downward SW flux absorbed above level k due to ozone heating.
+  ! N.B. Flux absorbed in level k = ozone_dF0_down(:,:,k+1) - ozone_dF0_down(:,:,k)
+    ozone_dF0_down(:,:,k) = solar(:,:) * ( abs_vis_LH_FS(:,:)                  &
+                                         + abs_uv_LH_FS(:,:)                   &
+                                         )
+
+  ! Subtract off ozone absorption from total SW flux:
+    solar_down(:,:,k) = solar_down(:,:,k) - ozone_dF0_down(:,:,k)
+
   end do
 
 endif
@@ -474,14 +563,19 @@ net_surf_sw_down = solar_down(:,:,n+1)*(1. - albedo(:,:))
 deallocate (ss, solar)
 if ( select_incSW .eq. 0 ) then
   deallocate (p2)
-elseif ( select_incSW .eq. 1 ) then
+else
 ! Variables for seasonal Incoming SW
-  deallocate (cLat, sLat, cos_H, HourAng)
+  deallocate (cLat, sLat)
+  deallocate (cos_H, HourAng)
 endif
 if ( solar_exponent .eq. 0. ) then
   deallocate (solar_tau_k, sw_wv, del_sol_tau, mag_fac, dtrans_sol)
 else
   deallocate (solar_tau_0, solar_tau)
+endif
+if ( ozone_in_SW .eq. 1 ) then
+  deallocate (ozone_mag, ozone_dF0_down)
+  deallocate (abs_uv_LH, abs_vis_LH, abs_uv_LH_FS, abs_vis_LH_FS)
 endif
 if ( wv_exponent .eq. -1. ) then
   deallocate (del_tau, del_tau_win, down_win)
@@ -498,9 +592,9 @@ end subroutine radiation_down
 ! ==================================================================================
 
 !subroutine radiation_up (is, js, Time_diag, lat, p_half, t_surf, t, tdt)
-subroutine radiation_up ( is, js, Time_diag, lat, p_half, t_surf, t, tdt,  &
-                          net, flux_sw, albedo, dtrans, dtrans_win,        &
-                          b, b_win, down, solar_down,                      &
+subroutine radiation_up ( is, js, Time_diag, lat, p_half, t_surf, t, tdt,      &
+                          flux_lw, flux_sw, albedo, ozone_column,              &
+                          dtrans, dtrans_win, b, b_win, down, solar_down,      &
                           myThid )
 
 ! Now complete the radiation calculation by computing the upward and net fluxes.
@@ -512,9 +606,10 @@ real, intent(in) , dimension(:,:)   :: lat
 real, intent(in) , dimension(:,:)   :: t_surf
 real, intent(in) , dimension(:,:,:) :: t, p_half
 real, intent(inout), dimension(:,:,:) :: tdt
-real, intent(out), dimension(:,:,:) :: net
+real, intent(out), dimension(:,:,:) :: flux_lw
 real, intent(out), dimension(:,:,:) :: flux_sw
 real, intent(in),  dimension(:,:)   :: albedo
+real, intent(in) , dimension(:,:,:) :: ozone_column
 real, intent(in),  dimension(:,:,:) :: dtrans
 real, intent(in),  dimension(:,:,:) :: dtrans_win
 real, intent(in),  dimension(:,:,:) :: b
@@ -526,13 +621,20 @@ integer, intent(in)                 :: myThid
 !integer :: i, j
 integer :: k, n
 integer :: im, jm
+! Variables for seasonal Incoming SW
+real    :: tYear, cDecl, sDecl
 
 !logical :: used
 
 ! -------------------------------------------------------------------------
-real, allocatable, dimension(:,:)     :: b_surf
-real, allocatable, dimension(:,:,:)   :: tdt_rad, entrop_rad, tdt_sw
-real, allocatable, dimension(:,:,:) :: up, up_win, flux_rad
+real, allocatable, dimension(:,:)   :: solar, b_surf
+real, allocatable, dimension(:,:,:) :: tdt_rad, up, up_win, solar_up
+!real, allocatable, dimension(:,:,:) :: tdt_sw, flux_rad   ! not used
+! MK: Variables for Lacis & Hansen ozone SW scheme
+real, allocatable, dimension(:,:,:) :: ozone_mag_up, ozone_dF0_up
+real, allocatable, dimension(:,:)   :: abs_uv_LH_up, abs_uv_LH_FS_up
+real, allocatable, dimension(:,:)   :: abs_vis_LH_up, abs_vis_LH_FS_up
+real, allocatable, dimension(:,:)   :: r_bar
 ! -------------------------------------------------------------------------
 
 n = size(t,3)
@@ -540,14 +642,104 @@ im = size(t,1)
 jm = size(t,2)
 
 ! -------------------------------------------------------------------------
+if( two_stream_SW .eq. 1 ) then
+  allocate (solar            (im, jm))
+  if ( ozone_in_SW .eq. 1 ) then
+    allocate (ozone_mag_up    (im, jm, n+1))
+    allocate (ozone_dF0_up    (im, jm, n+1))
+    allocate (abs_uv_LH_up    (im, jm))
+    allocate (abs_vis_LH_up   (im, jm))
+    allocate (abs_uv_LH_FS_up (im, jm))
+    allocate (abs_vis_LH_FS_up(im, jm))
+    allocate (r_bar           (im, jm))
+  endif
+endif
 allocate (tdt_rad          (im, jm, n))
-allocate (tdt_sw           (im, jm, n))
-allocate (entrop_rad       (im, jm, n))
 allocate (up               (im, jm, n+1))
 allocate (up_win           (im, jm, n+1))
-allocate (flux_rad         (im, jm, n+1))
+allocate (solar_up         (im, jm, n+1))
+!allocate (tdt_sw           (im, jm, n))    ! not used
+!allocate (flux_rad         (im, jm, n+1))  ! not used
 allocate (b_surf           (im, jm))
 ! -------------------------------------------------------------------------
+
+! MK add in solar_up variables
+do k = 1,n+1
+  solar_up(:,:,k) = albedo(:,:) * solar_down(:,:,n+1)
+end do
+
+if ( two_stream_SW .eq. 1 ) then
+! MK do upward SW for ozone
+
+! Need solar variables again:
+  solar = solar_down(:,:,1)
+
+  if ( ozone_in_SW .eq. 1 ) then
+  ! tYear = time in the solar year, in [0-1]
+    tYear = MOD( Time_diag/yearLength + yearPhase , 1.0 )
+
+  ! Compute the declination angle
+  ! a) approximate estimate of declination angle: relative error is less
+  !    than 0.03 for current obliq but as large as 0.21 for obliq=60^o
+  !    xDecl = - obliquity*deg_to_rad * cos(2.*pi*tYear)
+  ! b) unapproximate expression:
+    sDecl = -sin(  obliquity*deg_to_rad ) * cos(2.*pi*tYear)
+    cDecl =  cos( asin( sDecl ) )
+
+  ! Lacis and Hansen scheme for absorption of upward SW flux by O3:
+  ! Apply magnification factor:
+
+    do k = n+1,1,-1
+      ozone_mag_up(:,:,k) = ozone_column(:,:,n+1) * 35. /                      &
+                            sqrt( 1224.*cDecl*cDecl + 1. )                     &
+                          + 1.9 * ( ozone_column(:,:,n+1)                      &
+                                    - ozone_column(:,:,k)                      &
+                                  )
+    end do
+
+    r_bar(:,:) = ( 0.291 / ( 1. + 0.816*cDecl ) ) + (                          &
+                   ( 1. - ( 0.291 / ( 1. + 0.816*cDecl ) ) )                   &
+                   * 0.856 * albedo(:,:) / ( 1. - 0.144*albedo(:,:) )          &
+                                                    )
+  ! LH74 parameterisation for fraction of total solar flux absorbed:
+
+    do k = n+1,1,-1
+
+      abs_vis_LH_up(:,:) = r_bar(:,:) * (0.02118 * ozone_mag_up(:,:,k)) / (    &
+                         1. + 0.042 * ozone_mag_up(:,:,k)                      &
+                            + 0.000323*ozone_mag_up(:,:,k)*ozone_mag_up(:,:,k) &
+                                                                          )
+    ! FS97 correction
+      abs_vis_LH_FS_up(:,:) = ( -0.002894 * ozone_mag_up(:,:,k) + 1.0663 )     &
+                              * abs_vis_LH_up(:,:)
+
+      abs_uv_LH_up(:,:) = r_bar(:,:) * (1.082 * ozone_mag_up(:,:,k)) / (       &
+                            ( 1. + 138.6 * ozone_mag_up(:,:,k) )**0.805        &
+                                                                       )       &
+                        + ( 0.0658 * ozone_mag_up(:,:,k) ) / (                 &
+                            1. + ( 103.6 * ozone_mag_up(:,:,k) )**3            &
+                                                             )
+    ! FS97 correction
+      abs_uv_LH_FS_up(:,:) = ( -0.01632 * ozone_mag_up(:,:,k) + 1.08964 )      &
+                             * abs_uv_LH_up(:,:)
+
+    ! Total SW flux absorbed along path by reflected radiation up till and including level k.
+    ! N.B. Flux absorbed in level k = ozone_dF0_up(:,:,k) - ozone_dF0_up(:,:,k+1)
+      ozone_dF0_up(:,:,k) = solar(:,:) * ( abs_vis_LH_FS_up(:,:)               &
+                                         + abs_uv_LH_FS_up(:,:)                &
+                                         )
+
+    end do
+
+    do k = n,1,-1
+    ! Subtract off ozone absorption from total SW flux:
+      solar_up(:,:,k) = solar_up(:,:,k)                                        &
+                      - ( ozone_dF0_up(:,:,k) - ozone_dF0_up(:,:,n+1) )
+    end do
+
+  endif   ! ozone_in_SW
+
+endif   ! two_stream_SW
 
 ! total flux from surface
 b_surf = stefan*t_surf*t_surf*t_surf*t_surf
@@ -564,22 +756,34 @@ end do
 ! add upward flux in spectral window
 up = up + up_win
 
+! MK Compute flux_sw in terms of solar_up, and use flux_sw in tdt calculation
 do k = 1,n+1
-  net(:,:,k) = up(:,:,k)-down(:,:,k)
-  flux_sw(:,:,k) = albedo(:,:)*solar_down(:,:,n+1) - solar_down(:,:,k)
-  flux_rad(:,:,k) = net(:,:,k) + flux_sw(:,:,k)
+  flux_lw(:,:,k) = up(:,:,k)-down(:,:,k)   ! LW only, upward +ve
+  flux_sw(:,:,k) = solar_down(:,:,k) - solar_up(:,:,k)  ! Net downward SW
+! flux_rad(:,:,k) = flux_lw(:,:,k) + flux_sw(:,:,k)   ! not used
 end do
+
+if ( two_stream_SW .eq. 1 ) then
+  do k = 1,n
+    tdt_rad(:,:,k) = ( flux_lw(:,:,k+1) - flux_lw(:,:,k)                  &
+                     - flux_sw(:,:,k+1) + flux_sw(:,:,k)                  &
+                     )                                                    &
+                   * grav / ( cp_air*( p_half(:,:,k+1)-p_half(:,:,k) ) )
+  end do
+else
+  do k = 1,n
+    tdt_rad(:,:,k) = ( flux_lw(:,:,k+1) - flux_lw(:,:,k)                  &
+                     - solar_down(:,:,k+1) + solar_down(:,:,k) )          &
+                   * grav / ( cp_air*( p_half(:,:,k+1)-p_half(:,:,k) ) )
+  end do
+endif
 
 do k = 1,n
-  tdt_rad(:,:,k) = (net(:,:,k+1) - net(:,:,k)                  &
-                 - solar_down(:,:,k+1) + solar_down(:,:,k))    &
-             *grav/(cp_air*(p_half(:,:,k+1)-p_half(:,:,k)))
-  tdt_sw(:,:,k) = (- solar_down(:,:,k+1) + solar_down(:,:,k))  &
-             *grav/(cp_air*(p_half(:,:,k+1)-p_half(:,:,k)))
+! tdt_sw is not used:
+! tdt_sw(:,:,k) = ( - flux_sw(:,:,k+1) + flux_sw(:,:,k) )                 &
+!                  * grav / ( cp_air*( p_half(:,:,k+1)-p_half(:,:,k) ) )
   tdt(:,:,k) = tdt(:,:,k) + tdt_rad(:,:,k)
 end do
-
-flux_sw = -flux_sw  ! change sign to get Net SW: +=down
 
 !------- outgoing lw flux toa (olr) -------
 !     if ( id_olr > 0 ) then
@@ -615,8 +819,16 @@ flux_sw = -flux_sw  ! change sign to get Net SW: +=down
 !     endif
 
 ! -------------------------------------------------------------------------
-deallocate (tdt_rad, tdt_sw, entrop_rad)
-deallocate (up, up_win, flux_rad)
+if ( two_stream_SW .eq. 1 ) then
+  deallocate (solar)
+  if ( ozone_in_SW .eq. 1 ) then
+    deallocate (ozone_mag_up, ozone_dF0_up)
+    deallocate (abs_uv_LH_up, abs_vis_LH_up)
+    deallocate (abs_uv_LH_FS_up, abs_vis_LH_FS_up, r_bar)
+  endif
+endif
+deallocate (tdt_rad, up, up_win, solar_up)
+!deallocate (tdt_sw, flux_rad)  ! not used
 deallocate (b_surf)
 ! -------------------------------------------------------------------------
 


### PR DESCRIPTION
## What changes does this PR introduce?
1) Add 3-D input file for stratospheric ozone in pkg/atm_phys
2) Add code from Matt Kasoar for SW absorption by stratospheric ozone in pkg/atm_phys ;
    also clean up S/R "radiation_up" (remove un-used local arrays)
    and fix potential division by zero in Rel-Humid diagnostics (atm_phys_driver.F)

## What is the current behaviour?
no SW absorption du to ozone ; atmosphere is transparent to upward SW

## What is the new behaviour ?
- new code for ozone effect on SW based on Lacis and Hansen (JAS, 1974) and 
  Forster and Shine (JGR, 1997).
 - turned on using 2 local run-time parameters: ozone_in_SW (downward) and 
    two_stream_SW (also in upward); default are off.
- fixed in-time 3-D distribution of ozone read-in from file

## Does this PR introduce a breaking change? 

## Other information:
to be added soon to verification_other, a new experiment that uses new code with enough 
vertical resolution in stratosphere.

## Suggested addition to `tag-index`
o pkg/atm_phys:
  - add 3-D input file for stratospheric ozone
  - add code from Matt Kasoar for SW absorption by stratospheric ozone,
    based on following papers:
     Lacis and Hansen (JAS, 1974) and Forster and Shine (JGR, 1997).
  - turned on using 2 local run-time parameter: ozone_in_SW (downward)
    and two_stream_SW (also in upward); default are off.
  - clean up S/R "radiation_up": rename "net" to "flux_lw" (better name)
    and remove un-used local (dyn-allocated) arrays.
  - also avoid division by zero in Rel-Humid diagnostics (atm_phys_driver.F)