### PR TITLE
Make sure mpirun finds executable for FC check

### DIFF
--- a/tools/genmake2
+++ b/tools/genmake2
@@ -646,7 +646,7 @@ EOF
     fi
     if test $FC_CHECK = '-1' -a -x genmake_tcomp ; then
 	if test "x$MPI" = 'xtrue' ; then
-	    COMM="mpirun -np 1 genmake_tcomp"
+	    COMM="mpirun -np 1 ./genmake_tcomp"
 	else
 	    COMM="./genmake_tcomp"
 	fi


### PR DESCRIPTION
## What changes does this PR introduce?

Fix bug where mpirun cannot find the executable during the test for a working fortran compiler in genmake2.


## What is the current behaviour? 

Some implementations of mpirun do not look for the executable in the current working directory (unless '.' is in $PATH).  In this case the compiler check fails even if the compiler works.


## What is the new behaviour 

The executable is found.


## Does this PR introduce a breaking change? 

No.


## Other information:


## Suggested addition to `tag-index`
(To avoid unnecessary merge conflicts, please don't update `tag-index`. One of the admins will do that when merging your pull request.)