### PR TITLE
Add entry point for 2-Way Nesting pkgs

### DIFF
--- a/eesupp/inc/EEPARAMS.h
+++ b/eesupp/inc/EEPARAMS.h
@@ -174,13 +174,16 @@ C     useCubedSphereExchange :: use Cubed-Sphere topology domain.
 C     useCoupler     :: use Coupler for a multi-components set-up.
 C     useNEST_PARENT :: use Parent Nesting interface (pkg/nest_parent)
 C     useNEST_CHILD  :: use Child  Nesting interface (pkg/nest_child)
+C     useNest2W_parent :: use Parent 2-W Nesting interface (pkg/nest2w_parent)
+C     useNest2W_child  :: use Child  2-W Nesting interface (pkg/nest2w_child)
 C     useOASIS       :: use OASIS-coupler for a multi-components set-up.
       COMMON /EEPARAMS_L/
 c    &  eeBootError, fatalError, eeEndError,
      &  eeBootError, eeEndError, fatalError, debugMode,
      &  useSingleCpuIO, useSingleCpuInput, printMapIncludesZeros,
      &  useCubedSphereExchange, useCoupler,
-     &  useNEST_PARENT, useNEST_CHILD, useOASIS,
+     &  useNEST_PARENT, useNEST_CHILD,
+     &  useNest2W_parent, useNest2W_child, useOASIS,
      &  useSETRLSTK, useSIGREG
       LOGICAL eeBootError
       LOGICAL eeEndError
@@ -193,6 +196,8 @@ c    &  eeBootError, fatalError, eeEndError,
       LOGICAL useCoupler
       LOGICAL useNEST_PARENT
       LOGICAL useNEST_CHILD
+      LOGICAL useNest2W_parent
+      LOGICAL useNest2W_child
       LOGICAL useOASIS
       LOGICAL useSETRLSTK
       LOGICAL useSIGREG

--- a/eesupp/src/all_proc_die.F
+++ b/eesupp/src/all_proc_die.F
@@ -68,9 +68,9 @@ C        (even if usingMPI=F) --> comment out test on usingMPI
 c     IF ( usingMPI ) THEN
 C     better to avoid this call if multi-components set-up ; otherwise will
 C     hang here since procs of other comp. are not calling MPI_finalize now.
-       IF ( .NOT.( useCoupler
-     &        .OR. useNEST_PARENT
-     &        .OR. useNEST_CHILD )
+       IF ( .NOT.( useCoupler .OR.
+     &             useNEST_PARENT .OR. useNEST_CHILD .OR.
+     &             useNest2W_parent .OR. useNest2W_child )
      &    ) THEN
 #ifdef ALLOW_OASIS
          IF ( useOASIS ) CALL OASIS_ABORT

--- a/eesupp/src/eeboot_minimal.F
+++ b/eesupp/src/eeboot_minimal.F
@@ -57,10 +57,12 @@ C     mpiRC      :: Error code reporting variable used with MPI.
       INTEGER mpiIsInitialized
       LOGICAL doReport
 #if defined(ALLOW_OASIS) || defined(COMPONENT_MODULE)
-      INTEGER mpiMyWid
+      INTEGER mpiMyWId
+#elif defined(ALLOW_NEST2W_COMMON)
+      INTEGER mpiMyWId
 #endif
 #if defined(ALLOW_NEST_PARENT) || defined(ALLOW_NEST_CHILD)
-      INTEGER mpiMyWid, color
+      INTEGER mpiMyWId, color
 #endif
 #ifdef USE_PDAF
       INTEGER mpi_task_id
@@ -168,6 +170,17 @@ C--    Set the running directory
 C--    Setup Nesting Execution Environment
        CALL NEST_EEINIT( mpiMyWId, color )
 #endif /* ALLOW_NEST_PARENT | ALLOW_NEST_CHILD */
+
+#ifdef ALLOW_NEST2W_COMMON
+C--    Case with 2-Ways Nest(ing)
+C-     Set the running directory
+       CALL MPI_COMM_RANK( MPI_COMM_WORLD, mpiMyWId, mpiRC )
+       CALL SETDIR( mpiMyWId )
+
+C-     Setup Nesting Execution Environment
+       CALL NEST2W_EEINIT( mpiMyWId )
+       IF ( eeBootError ) GOTO 999
+#endif /* ALLOW_NEST2W_COMMON */
 
 C---+----1----+----2----+----3----+----4----+----5----+----6----+----7-|--+----|
 

--- a/eesupp/src/eeset_parms.F
+++ b/eesupp/src/eeset_parms.F
@@ -64,7 +64,8 @@ CEOP
       NAMELIST /EEPARMS/
      & nTx, nTy, usingMPI,
      & useCubedSphereExchange,
-     & useCoupler, useNEST_PARENT, useNEST_CHILD, useOASIS,
+     & useCoupler, useNEST_PARENT, useNEST_CHILD,
+     & useNest2W_parent, useNest2W_child, useOASIS,
      & useSETRLSTK, useSIGREG,
      & debugMode, printMapIncludesZeros, maxLengthPrt1D
 
@@ -109,6 +110,8 @@ C     which sets the stack size to "unlimited" using setrlimit()
       useCoupler                 = .FALSE.
       useNEST_PARENT             = .FALSE.
       useNEST_CHILD              = .FALSE.
+      useNest2W_parent           = .FALSE.
+      useNest2W_child            = .FALSE.
       useOASIS                   = .FALSE.
       nTx                        = 1
       nTy                        = 1

--- a/eesupp/src/eewrite_eeenv.F
+++ b/eesupp/src/eewrite_eeenv.F
@@ -160,6 +160,15 @@ CEOP
       CALL PRINT_MESSAGE( msgBuf, standardMessageUnit,
      &  SQUEEZE_RIGHT , 1)
 
+      WRITE(msgBuf,'(A,L5,A)') 'useNest2W_parent =', useNest2W_parent,
+     & ' ;/* Control 2-W Nesting comm */'
+      CALL PRINT_MESSAGE( msgBuf, standardMessageUnit,
+     &  SQUEEZE_RIGHT , 1)
+      WRITE(msgBuf,'(A,L5,A)') 'useNest2W_child  =', useNest2W_child,
+     & ' ;/* Control 2-W Nesting comm */'
+      CALL PRINT_MESSAGE( msgBuf, standardMessageUnit,
+     &  SQUEEZE_RIGHT , 1)
+
       WRITE(msgBuf,'(A,L5,A)') 'debugMode =', debugMode,
      & ' ; /* print debug msg. (sequence of S/R calls)  */'
       CALL PRINT_MESSAGE( msgBuf, standardMessageUnit,

--- a/model/src/packages_init_fixed.F
+++ b/model/src/packages_init_fixed.F
@@ -23,6 +23,8 @@ C       |
 C       |-- DIAGNOSTICS_INIT_EARLY
 C       |-- DIAGNOSTICS_MAIN_INIT
 C       |
+C       |-- NEST2W_INIT_FIXED
+C       |
 C       |-- GAD_INIT_FIXED
 C       |
 C       |-- MOM_INIT_FIXED
@@ -169,6 +171,16 @@ C-    needs to call DIAGNOSTICS_INIT_EARLY before all package-diag-init calls
         CALL DIAGNOSTICS_MAIN_INIT( myThid )
       ENDIF
 #endif
+
+#ifdef ALLOW_NEST2W_COMMON
+C--   Initialise the 2-Way Nesting packages
+      IF ( useNest2W_parent .OR. useNest2W_child ) THEN
+# ifdef ALLOW_DEBUG
+        IF (debugMode) CALL DEBUG_CALL('NEST2W_INIT_FIXED',myThid)
+# endif
+        CALL NEST2W_INIT_FIXED( myThid )
+      ENDIF
+#endif /* ALLOW_NEST2W_COMMON */
 
 #ifdef ALLOW_GENERIC_ADVDIFF
 C--   Initialize fixed params for GAD
@@ -358,7 +370,7 @@ C--   in order to provide the weight files
 
 #ifdef ALLOW_ECCO
       IF (useECCO) THEN
-C--   Initialise ecco-specific cost function. This needs to preceed 
+C--   Initialise ecco-specific cost function. This needs to preceed
 C     the call ctrl_init in order to provide the weight files
 # ifdef ALLOW_DEBUG
         IF (debugMode) CALL DEBUG_CALL('ECCO_COST_INIT_FIXED',myThid)
@@ -617,7 +629,7 @@ C--   needs to be called after the OASIS_INIT
 
 #ifdef ALLOW_CTRL
       IF (useCTRL) THEN
-C--   Initialise the control variables. Moved to the end of this S/R 
+C--   Initialise the control variables. Moved to the end of this S/R
 C     to allow other pkgs to set mask and weight fields.
 # ifdef ALLOW_DEBUG
         IF (debugMode) CALL DEBUG_CALL('CTRL_INIT',myThid)

--- a/model/src/packages_init_variables.F
+++ b/model/src/packages_init_variables.F
@@ -95,6 +95,8 @@ C       |
 C       |-- NEST_CHILD_INIT_VARIA
 C       |-- NEST_PARENT_INIT_VARIA
 C       |
+C       |-- NEST2W_INIT_VARIA
+C       |
 C       |-- CPL_INI_VARS
 C       |
 C       |-- MYPACKAGE_INIT_VARIA
@@ -446,6 +448,16 @@ C--   Initialize NEST in PARENT configuration
        CALL NEST_PARENT_INIT_VARIA( myThid )
       ENDIF
 #endif /* ALLOW_NEST_PARENT */
+
+#ifdef ALLOW_NEST2W_COMMON
+C--   Initialise the 2-Way Nesting packages variables
+      IF ( useNest2W_parent .OR. useNest2W_child ) THEN
+# ifdef ALLOW_DEBUG
+        IF (debugMode) CALL DEBUG_CALL('NEST2W_INIT_VARIA',myThid)
+# endif
+        CALL NEST2W_INIT_VARIA( myThid )
+      ENDIF
+#endif /* ALLOW_NEST2W_COMMON */
 
 #ifdef COMPONENT_MODULE
       IF (useCoupler) THEN

--- a/model/src/packages_readparms.F
+++ b/model/src/packages_readparms.F
@@ -119,6 +119,9 @@ C       |
 C       |-- NEST_CHILD_READPARMS
 C       |-- NEST_PARENT_READPARMS
 C       |
+C       |-- NEST2W_C_READPARMS
+C       |-- NEST2W_P_READPARMS
+C       |
 C       |-- CPL_READPARMS
 C       |
 C       |-- OASIS_READPARMS
@@ -376,6 +379,16 @@ C
 C--    Initialize nest(ing) package parameters x PARENT
        IF (useNEST_PARENT) CALL NEST_PARENT_READPARMS ( myThid )
 #endif /* ALLOW_NEST_PARENT */
+
+#ifdef ALLOW_NEST2W_CHILD
+C--    Initialize Child 2-way nest(ing) package parameters
+       IF (useNest2W_child) CALL NEST2W_C_READPARMS( myThid )
+#endif /* ALLOW_NEST2W_CHILD */
+C
+#ifdef ALLOW_NEST2W_PARENT
+C--    Initialize Parent 2-way nest(ing) package parameters
+       IF (useNest2W_parent) CALL NEST2W_P_READPARMS( myThid )
+#endif /* ALLOW_NEST2W_PARENT */
 
 #ifdef COMPONENT_MODULE
 C--   set Coupling parameters


### PR DESCRIPTION
## What changes does this PR introduce?
While nest-2way packages are still in development phase, the standard pkg calls
and switch on/off flags are ready to be merged; this would avoid the need to frequently update
this set of (modified) files every time the main code reference version changes.

## Does this PR introduce a breaking change? 
no change

## Suggested addition to `tag-index`
o eesupp & model:
 - add entry point for 2-way nesting pkgs.