### PR TITLE
Fix referencing error in dic/car_flux_omega_top

### DIFF
--- a/doc/tag-index
+++ b/doc/tag-index
@@ -1,6 +1,8 @@
     Notes on tags used in MITgcmUV
     ==============================
 
+o pkg/dic:
+  - fix out-of-bounds error in S/R CAR_FLUX_OMEGA_TOP (#define CAR_DISS)
 o pkg/streamice:
   - new implementation of grounding line smoothing by smoothing of basal
      traction in partly grounded cell, in streamice_upd_ffrac_uncoupled.F

--- a/pkg/dic/car_flux_omega_top.F
+++ b/pkg/dic/car_flux_omega_top.F
@@ -48,7 +48,7 @@ c                            layer
 c depth_u, depth_l        :: depths of upper and lower interfaces
 c flux_u, flux_l          :: flux through upper and lower interfaces
        _RL caexport(1-OLx:sNx+OLx,1-OLy:sNy+OLy)
-       INTEGER I,J,k, ko
+       INTEGER I,J,k, ko, kBottom
        _RL flux_u, flux_l
 c variables for calcium carbonate dissolution
        _RL KierRate
@@ -80,6 +80,9 @@ c        exp_tot=0
          do k=1,nR
             cflux(i,j,k)=0. _d 0
          enddo
+         
+         kBottom   = kLowC(i,j,bi,bj)
+         
          DO k=1,nLev
           if (hFacC(i,j,k,bi,bj).gt.0. _d 0) then
            caexport(i,j)= R_CP*rain_ratio(i,j,bi,bj)*bioac(i,j,k)*
@@ -101,7 +104,7 @@ C flux through lower face of cell
                 flux_l = flux_u
 
 c if at bottom, remineralize remaining flux
-                if (ko.eq.Nr.or.hFacC(i,j,ko+1,bi,bj).eq.0. _d 0) then
+                if (ko.eq.kBottom) then
                   if (iflx.eq.1) then
 c ... at surface
                      cflux(i,j,1)=cflux(i,j,1)+
@@ -138,7 +141,7 @@ c    &            omegaC(i,j,ko,bi,bj)
 c           endif
 c TEST ............................
 c no flux to ocean bottom
-                 if (ko.eq.Nr.or.hFacC(i,j,ko+1,bi,bj).eq.0. _d 0)
+                 if (ko.eq.kBottom)
      &                      flux_l=0. _d 0
               endif
 


### PR DESCRIPTION
## What changes does this PR introduce?
Fixes an out-of-bounds error in `pkg dic S/R car_flux_omega_top`

## What is the current behaviour? 
Compile verification/tutorial_global_oce_biogeo with `#define CAR_DISS` in `DIC_OPTIONS.h`

> 17:30:17 ~/G/M/v/t/run> ./mitgcmuv
At line 3539 of file car_flux_omega_top.for
Fortran runtime error: Index '16' of dimension 3 of array 'hfacc' above upper bound of 15

Narrowed it down to two lines where we test for the seafloor:
`if (ko.eq.Nr.or.hFacC(i,j,ko+1,bi,bj).eq.0. _d 0)`

If `ko` is `Nr` then `hFacC(i,j,Nr+1,bi,bj)` is illegal.

## What is the new behaviour 
Introduced `kBottom`, which is used to test `ko` against `kLowC`.

## Does this PR introduce a breaking change? 
Nope, only active when `#define CAR_DISS` is set (and it's probably ignored if not using strict compiler setting `-fbounds-check`).

## Suggested addition to `tag-index`
Fix out-of-bounds error in dic/car_flux_omega_top