### PR TITLE
Fix local array declaration in pkg/monitor/mon_stats_latbnd_rl.F

### DIFF
--- a/pkg/monitor/mon_stats_latbnd_rl.F
+++ b/pkg/monitor/mon_stats_latbnd_rl.F
@@ -47,7 +47,6 @@ C     msgBuf :: Informational/error meesage buffer
       CHARACTER*(MAX_LEN_MBUF) msgBuf
       INTEGER bi,bj,i,j,k,n
       INTEGER km, k1, k2
-      LOGICAL noPnts(Ny)
       _RL tmpVal
       _RL tmpVol
       INTEGER nSepDim
@@ -55,6 +54,7 @@ C     msgBuf :: Informational/error meesage buffer
       _RL tileVol (nSx,nSy,nSepDim)
       _RL tileMean(nSx,nSy,nSepDim)
       _RL tileVar (nSx,nSy,nSepDim)
+      LOGICAL noPnts(nSepDim)
 
 C-    Check local Dim
       IF ( nSepBnd .GT. nSepDim ) THEN


### PR DESCRIPTION
Fix size of local array "noPnts":
change size from "Ny" to "nSepDim" (was causing out-of bounds error
in 2-D X-along set-up).

## What changes does this PR introduce?
fix a bug.

## What is the current behaviour? 
local array declaration is wrong, causing "out-of-bounds" error in
2-D set-up where Ny=1

## What is the new behaviour 
problem fixed

## Does this PR introduce a breaking change? 
no

## Other information:

## Suggested addition to `tag-index`
o pkg/monitor:
  - fix local array declaration in mon_stats_latbnd_rl.F