### PR TITLE
Thin ice-shelf fix01

### DIFF
--- a/doc/tag-index
+++ b/doc/tag-index
@@ -1,6 +1,11 @@
     Notes on tags used in MITgcmUV
     ==============================
 
+o pkg/shelfice:
+  - allow to include thin ice-shelf (i.e., such that hFacC(k=1) > 0 ) when
+    using pkg/thsice, by preventing seaice to form where there is an ice-shelf.
+  - prevent short-wave heating below an ice-shelf (previously still happening
+    below thin ice-shelf); also fix Qnet there (but only for diagnostics).
 o pkg/seaice:
   - move initialisation of masks and metric coefficients and KGEO from
     seaice_init_varia.F to seaice_init_fixed.F

--- a/pkg/shelfice/shelfice_forcing_surf.F
+++ b/pkg/shelfice/shelfice_forcing_surf.F
@@ -57,6 +57,9 @@ C--   Zero out surface forcing terms below ice-shelf
             surfaceForcingT(i,j,bi,bj) = 0.
             surfaceForcingS(i,j,bi,bj) = 0.
             EmPmR(i,j,bi,bj) = 0.
+            Qsw  (i,j,bi,bj) = 0.
+C-    just for consistent diagnostics, also reset Qnet:
+            Qnet (i,j,bi,bj) = 0.
           ENDIF
          ENDDO
         ENDDO

--- a/pkg/thsice/thsice_get_ocean.F
+++ b/pkg/thsice/thsice_get_ocean.F
@@ -2,6 +2,9 @@
 #ifdef ALLOW_SEAICE
 # include "SEAICE_OPTIONS.h"
 #endif /* ALLOW_SEAICE */
+#ifdef ALLOW_SHELFICE
+# include "SHELFICE_OPTIONS.h"
+#endif /* ALLOW_SHELFICE */
 
 CBOP
 C     !ROUTINE: THSICE_GET_OCEAN
@@ -33,6 +36,9 @@ c#include "THSICE_PARAMS.h"
 # include "SEAICE_SIZE.h"
 # include "SEAICE.h"
 #endif /* ALLOW_SEAICE */
+#ifdef ALLOW_SHELFICE
+# include "SHELFICE.h"
+#endif /* ALLOW_SHELFICE */
 
 C     !INPUT/OUTPUT PARAMETERS:
 C     === Routine arguments ===
@@ -87,6 +93,17 @@ C--     Mixed layer thickness: take the 1rst layer
            ENDDO
           ENDDO
         ENDIF
+
+#ifdef ALLOW_SHELFICE
+C--   Prevent seaice to form where Ice-Shelf is present
+        IF ( useShelfIce ) THEN
+          DO j=1-OLy,sNy+OLy
+           DO i=1-OLx,sNx+OLx
+             IF ( kTopC(i,j,bi,bj).NE.0 ) hOceMxL(i,j,bi,bj) = 0. _d 0
+           ENDDO
+          ENDDO
+        ENDIF
+#endif /* ALLOW_SHELFICE */
 
         DO j=1-OLy,sNy+OLy
          DO i=1-OLx,sNx+OLx

--- a/verification/offline_exf_seaice/code/SEAICE_SIZE.h
+++ b/verification/offline_exf_seaice/code/SEAICE_SIZE.h
@@ -16,12 +16,10 @@ C-    Maximum Number of categories
       INTEGER nITD
 C--
 #ifdef SEAICE_ITD
-CToM<<<
 C nITD defines number of ice thickness categories,
 C i.e. size of additional dimension to AREA, HEFF, HSNOW, etc.
 C Bitz et al. (2001, JGR) suggest a minimum of nITD = 5
       PARAMETER (nITD = 5)
-C>>>ToM
 #else
       PARAMETER (nITD = 1)
 #endif
@@ -30,7 +28,7 @@ C-    Maximum Number of tracers
       INTEGER SItrMaxNum
       PARAMETER(SItrMaxNum = 3 )
 
-#ifdef ALLOW_AUTODIFF_TAMC
+#ifdef ALLOW_AUTODIFF
       INTEGER iicekey
       INTEGER nEVPstepMax
       PARAMETER ( nEVPstepMax=180 )
@@ -40,7 +38,7 @@ C-    Maximum Number of tracers
       PARAMETER ( SOLV_MAX_FIXED=500 )
       INTEGER MPSEUDOTIMESTEPS
       PARAMETER (MPSEUDOTIMESTEPS=2)
-#endif
+#endif /* ALLOW_AUTODIFF */
 
 #endif /* ALLOW_SEAICE */
 


### PR DESCRIPTION
## What changes does this PR introduce?
fix 2 issues related to thin ice-shelf, i.e., thinner than surface level so that hFacC(k=1) > 0:
fist one is when using pkg/thsice and addresses part of issue #99 (also problem left aside by PR #113);
the second one is with ocean short-wave heating that should not apply below the ice-shelf.

## What is the current behaviour? 
pkg/thsice cannot be used if ice-shelf is too thin (i.e., hFacC(k=1) > 0), and where this happens,
shortwave heating is not turned off and will directly warm-up ocean below the ice-shelf 

## What is the new behaviour 
- with pkg/thsice, prevent seaice to form where there is an ice-shelf;
- prevent short-wave to warm-up ocean below the ice-shelf;
- also fix Qnet where ise-shelf is thin (but only used for diagnostics).

## Does this PR introduce a breaking change? 
pkg/thsice can now be used with pkg/shelfice, even when, in some places, an ice-shelf is thin.

## Other information:
Still need to fix similar problem with pkg/seaice before closing issue #99 

## Suggested addition to `tag-index`
o pkg/shelfice:
  - allow to include thin ice-shelf (i.e., such that hFacC(k=1) > 0 ) when
    using pkg/thsice, by preventing seaice to form where there is an ice-shelf.
  - prevent short-wave heating below an ice-shelf (previously still happening 
    below thin ice-shelf); also fix Qnet there (but only for diagnostics).