### PR TITLE
Thin iceshelf fix02

### DIFF
--- a/model/src/packages_init_fixed.F
+++ b/model/src/packages_init_fixed.F
@@ -77,17 +77,17 @@ C       |-- GCHEM_INIT_FIXED
 C       |
 C       |-- RBCS_INIT_FIXED
 C       |
+C       |-- STREAMICE_INIT_FIXED
+C       |
+C       |-- SHELFICE_INIT_FIXED
+C       |
+C       |-- ICEFRONT_INIT_FIXED
+C       |
 C       |-- FRAZIL_INIT_FIXED
 C       |
 C       |-- SEAICE_INIT_FIXED
 C       |
 C       |-- SALT_PLUME_INIT_FIXED
-C       |
-C       |-- SHELFICE_INIT_FIXED
-C       |
-C       |-- STREAMICE_INIT_FIXED
-C       |
-C       |-- ICEFRONT_INIT_FIXED
 C       |
 C       |-- THSICE_INIT_FIXED
 C       |
@@ -436,6 +436,37 @@ C--   Initialise fixed array for Float pkg
       ENDIF
 #endif
 
+#ifdef ALLOW_STREAMICE
+      IF (useStreamIce) THEN
+# ifdef ALLOW_DEBUG
+        IF (debugMode) CALL DEBUG_CALL('STREAMICE_INIT_FIXED',myThid)
+# endif
+#ifndef ALLOW_OPENAD
+       CALL STREAMICE_INIT_FIXED( myThid )
+#else
+       CALL OPENAD_STREAMICE_INIT_FIXED( myThid )
+#endif
+      ENDIF
+#endif /* ALLOW_STREAMICE */
+
+#ifdef ALLOW_SHELFICE
+      IF (useShelfIce) THEN
+# ifdef ALLOW_DEBUG
+        IF (debugMode) CALL DEBUG_CALL('SHELFICE_INIT_FIXED',myThid)
+# endif
+        CALL SHELFICE_INIT_FIXED( myThid )
+      ENDIF
+#endif /* ALLOW_SHELFICE */
+
+#ifdef ALLOW_ICEFRONT
+      IF (useICEFRONT) THEN
+# ifdef ALLOW_DEBUG
+        IF (debugMode) CALL DEBUG_CALL('ICEFRONT_INIT_FIXED',myThid)
+# endif
+        CALL ICEFRONT_INIT_FIXED( myThid )
+      ENDIF
+#endif /* ALLOW_ICEFRONT */
+
 #ifdef ALLOW_FRAZIL
       IF (useFRAZIL) THEN
 # ifdef ALLOW_DEBUG
@@ -462,37 +493,6 @@ C--   Initialise fixed array for Float pkg
         CALL SALT_PLUME_INIT_FIXED(myThid)
       ENDIF
 #endif
-
-#ifdef ALLOW_SHELFICE
-      IF (useShelfIce) THEN
-# ifdef ALLOW_DEBUG
-        IF (debugMode) CALL DEBUG_CALL('SHELFICE_INIT_FIXED',myThid)
-# endif
-        CALL SHELFICE_INIT_FIXED( myThid )
-      ENDIF
-#endif /* ALLOW_SHELFICE */
-
-#ifdef ALLOW_STREAMICE
-      IF (useStreamIce) THEN
-# ifdef ALLOW_DEBUG
-        IF (debugMode) CALL DEBUG_CALL('STREAMICE_INIT_FIXED',myThid)
-# endif
-#ifndef ALLOW_OPENAD
-       CALL STREAMICE_INIT_FIXED( myThid )
-#else
-       CALL OPENAD_STREAMICE_INIT_FIXED( myThid )
-#endif
-      ENDIF
-#endif /* ALLOW_STREAMICE */
-
-#ifdef ALLOW_ICEFRONT
-      IF (useICEFRONT) THEN
-# ifdef ALLOW_DEBUG
-        IF (debugMode) CALL DEBUG_CALL('ICEFRONT_INIT_FIXED',myThid)
-# endif
-        CALL ICEFRONT_INIT_FIXED( myThid )
-      ENDIF
-#endif /* ALLOW_ICEFRONT */
 
 #ifdef ALLOW_THSICE
       IF (useThSIce) THEN

--- a/model/src/packages_init_variables.F
+++ b/model/src/packages_init_variables.F
@@ -66,17 +66,17 @@ C       |-- RBCS_INIT_VARIA
 C       |
 C       |-- MATRIX_INIT_VARIA
 C       |
+C       |-- STREAMICE_INIT_VARIA
+C       |
+C       |-- SHELFICE_INIT_VARIA
+C       |
+C       |-- ICEFRONT_INIT_VARIA
+C       |
 C       |-- FRAZIL_INIT_VARIA
 C       |
 C       |-- SEAICE_INIT_VARIA
 C       |
 C       |-- SALT_PLUME_INIT_VARIA
-C       |
-C       |-- SHELFICE_INIT_VARIA
-C       |
-C       |-- STREAMICE_INIT_VARIA
-C       |
-C       |-- ICEFRONT_INIT_VARIA
 C       |
 C       |-- THSICE_INI_VARS
 C       |
@@ -317,6 +317,33 @@ C--   Initialise float position
       ENDIF
 #endif /* ALLOW_MATRIX */
 
+#ifdef ALLOW_STREAMICE
+      IF (useStreamIce) THEN
+# ifdef ALLOW_DEBUG
+       IF (debugMode) CALL DEBUG_CALL('STREAMICE_INIT_VARIA',myThid)
+# endif
+       CALL STREAMICE_INIT_VARIA( myThid )
+      ENDIF
+#endif /* ALLOW_STREAMICE */
+
+#ifdef ALLOW_SHELFICE
+      IF (useShelfIce) THEN
+# ifdef ALLOW_DEBUG
+       IF (debugMode) CALL DEBUG_CALL('SHELFICE_INIT_VARIA',myThid)
+# endif
+       CALL SHELFICE_INIT_VARIA( myThid )
+      ENDIF
+#endif /* ALLOW_SHELFICE */
+
+#ifdef ALLOW_ICEFRONT
+      IF (useICEFRONT) THEN
+# ifdef ALLOW_DEBUG
+       IF (debugMode) CALL DEBUG_CALL('ICEFRONT_INIT_VARIA',myThid)
+# endif
+       CALL ICEFRONT_INIT_VARIA( myThid )
+      ENDIF
+#endif /* ALLOW_ICEFRONT */
+
 #ifdef ALLOW_FRAZIL
       IF (useFRAZIL) THEN
 # ifdef ALLOW_DEBUG
@@ -341,33 +368,6 @@ C--   Initialize SEAICE model.
         CALL SALT_PLUME_INIT_VARIA( myThid )
       ENDIF
 #endif /* ALLOW_SALT_PLUME */
-
-#ifdef ALLOW_SHELFICE
-      IF (useShelfIce) THEN
-# ifdef ALLOW_DEBUG
-       IF (debugMode) CALL DEBUG_CALL('SHELFICE_INIT_VARIA',myThid)
-# endif
-       CALL SHELFICE_INIT_VARIA( myThid )
-      ENDIF
-#endif /* ALLOW_SHELFICE */
-
-#ifdef ALLOW_STREAMICE
-      IF (useStreamIce) THEN
-# ifdef ALLOW_DEBUG
-       IF (debugMode) CALL DEBUG_CALL('STREAMICE_INIT_VARIA',myThid)
-# endif
-       CALL STREAMICE_INIT_VARIA( myThid )
-      ENDIF
-#endif /* ALLOW_STREAMICE */
-
-#ifdef ALLOW_ICEFRONT
-      IF (useICEFRONT) THEN
-# ifdef ALLOW_DEBUG
-       IF (debugMode) CALL DEBUG_CALL('ICEFRONT_INIT_VARIA',myThid)
-# endif
-       CALL ICEFRONT_INIT_VARIA( myThid )
-      ENDIF
-#endif /* ALLOW_ICEFRONT */
 
 #ifdef ALLOW_THSICE
       IF (useThSIce) THEN

--- a/model/src/packages_readparms.F
+++ b/model/src/packages_readparms.F
@@ -74,15 +74,15 @@ C       |-- OFFLINE_READPARMS
 C       |
 C       |-- MATRIX_READPARMS
 C       |
-C       |-- SEAICE_READPARMS
-C       |
-C       |-- SALT_PLUME_READPARMS
+C       |-- STREAMICE_READPARMS
 C       |
 C       |-- SHELFICE_READPARMS
 C       |
-C       |-- STREAMICE_READPARMS
-C       |
 C       |-- ICEFRONT_READPARMS
+C       |
+C       |-- SEAICE_READPARMS
+C       |
+C       |-- SALT_PLUME_READPARMS
 C       |
 C       |-- THSICE_READPARMS
 C       |
@@ -267,6 +267,21 @@ C--   if useMATRIX=T, set MATRIX parameters; otherwise just return
       CALL MATRIX_READPARMS ( myThid )
 #endif
 
+#ifdef ALLOW_STREAMICE
+C--   if useStreamIce=T, set STREAMICE parameters; otherwise just return
+      CALL STREAMICE_READPARMS( myThid )
+#endif
+
+#ifdef ALLOW_SHELFICE
+C--   if useShelfIce=T, set SHELFICE parameters; otherwise just return
+      CALL SHELFICE_READPARMS( myThid )
+#endif
+
+#ifdef ALLOW_ICEFRONT
+C--   if useICEFRONT=T, set ICEFRONT parameters; otherwise just return
+      CALL ICEFRONT_READPARMS( myThid )
+#endif
+
 #ifdef ALLOW_SEAICE
 C--   if useSEAICE=T, set SEAICE parameters; otherwise just return
       CALL SEAICE_READPARMS( myThid )
@@ -275,21 +290,6 @@ C--   if useSEAICE=T, set SEAICE parameters; otherwise just return
 #ifdef ALLOW_SALT_PLUME
 C--   if useSALT_PLUME=T, set SALT_PLUME parameters; otherwise just return
       CALL SALT_PLUME_READPARMS( myThid )
-#endif
-
-#ifdef ALLOW_SHELFICE
-C--   if useShelfIce=T, set SHELFICE parameters; otherwise just return
-      CALL SHELFICE_READPARMS( myThid )
-#endif
-
-#ifdef ALLOW_STREAMICE
-C--   if useStreamIce=T, set STREAMICE parameters; otherwise just return
-      CALL STREAMICE_READPARMS( myThid )
-#endif
-
-#ifdef ALLOW_ICEFRONT
-C--   if useICEFRONT=T, set ICEFRONT parameters; otherwise just return
-      CALL ICEFRONT_READPARMS( myThid )
 #endif
 
 #ifdef ALLOW_THSICE

--- a/model/src/packages_write_pickup.F
+++ b/model/src/packages_write_pickup.F
@@ -39,9 +39,11 @@ C       |-- PTRACERS_WRITE_PICKUP
 C       |
 C       |-- GCHEM_WRITE_PICKUP
 C       |
-C       |-- SEAICE_WRITE_PICKUP
-C       |
 C       |-- STREAMICE_WRITE_PICKUP
+C       |
+C       |-- SHELFICE_WRITE_PICKUP
+C       |
+C       |-- SEAICE_WRITE_PICKUP
 C       |
 C       |-- THSICE_WRITE_PICKUP
 C       |
@@ -155,13 +157,6 @@ C     Write restart file for GCHEM pkg & GCHEM sub-packages
       ENDIF
 #endif
 
-#ifdef  ALLOW_SEAICE
-      IF ( useSEAICE ) THEN
-        CALL SEAICE_WRITE_PICKUP( permPickup,
-     I                    suffix, myTime, myIter, myThid )
-      ENDIF
-#endif  /* ALLOW_SEAICE */
-
 #ifdef ALLOW_STREAMICE
       IF (useStreamIce) THEN
         CALL STREAMICE_WRITE_PICKUP( permPickup,
@@ -175,6 +170,13 @@ C     Write restart file for GCHEM pkg & GCHEM sub-packages
      I                    suffix, myTime, myIter, myThid )
       ENDIF
 #endif
+
+#ifdef  ALLOW_SEAICE
+      IF ( useSEAICE ) THEN
+        CALL SEAICE_WRITE_PICKUP( permPickup,
+     I                    suffix, myTime, myIter, myThid )
+      ENDIF
+#endif  /* ALLOW_SEAICE */
 
 #ifdef ALLOW_THSICE
       IF (useThSIce) THEN

--- a/pkg/seaice/seaice_init_fixed.F
+++ b/pkg/seaice/seaice_init_fixed.F
@@ -233,6 +233,7 @@ C--   Initialise grid parameters that do no change during the integration
 C--   Initialise grid info
       DO bj=myByLo(myThid),myByHi(myThid)
        DO bi=myBxLo(myThid),myBxHi(myThid)
+C-    loops on tile indices bi,bj:
         DO j=1-OLy,sNy+OLy
          DO i=1-OLx,sNx+OLx
           HEFFM  (i,j,bi,bj) = 0. _d 0
@@ -385,8 +386,33 @@ C     approximation
          ENDDO
         ENDIF
 #endif /* not SEAICE_CGRID */
+C-    end bi,bj loops
        ENDDO
       ENDDO
+
+#ifdef ALLOW_SHELFICE
+      IF ( useShelfIce ) THEN
+       DO bj=myByLo(myThid),myByHi(myThid)
+        DO bi=myBxLo(myThid),myBxHi(myThid)
+C--   Prevent seaice to form where Ice-Shelf is present
+          CALL SHELFICE_MASK_SEAICE(
+     U                  HEFFM,
+     I                  bi, bj, -1, myThid )
+          DO j=2-OLy,sNy+OLy
+           DO i=2-OLx,sNx+OLx
+            IF ( HEFFM(i-1,j,bi,bj).EQ.zeroRL .OR.
+     &           HEFFM( i, j,bi,bj).EQ.zeroRL )
+     &           SIMaskU(i,j,bi,bj) = zeroRL
+            IF ( HEFFM(i,j-1,bi,bj).EQ.zeroRL .OR.
+     &           HEFFM(i, j, bi,bj).EQ.zeroRL )
+     &           SIMaskV(i,j,bi,bj) = zeroRL
+           ENDDO
+          ENDDO
+        ENDDO
+       ENDDO
+       CALL EXCH_UV_XY_RL( SIMaskU, SIMaskV, .FALSE., myThid )
+      ENDIF
+#endif /* ALLOW_SHELFICE */
 
 #ifndef SEAICE_CGRID
 C--   Choose a proxy level for geostrophic velocity,

--- a/pkg/shelfice/shelfice_mask_seaice.F
+++ b/pkg/shelfice/shelfice_mask_seaice.F
@@ -1,0 +1,52 @@
+#include "SHELFICE_OPTIONS.h"
+
+CBOP
+C !ROUTINE: SHELFICE_MASK_SEAICE
+
+C !INTERFACE: ==========================================================
+      SUBROUTINE SHELFICE_MASK_SEAICE(
+     U                    SIfield,
+     I                    bi, bj, myIter, myThid )
+
+C !DESCRIPTION:
+C  Mask seaice field (mask) to prevent seaice to spread
+C         in grid-cells that are occupied by ice-shelf
+
+C !USES: ===============================================================
+      IMPLICIT NONE
+#include "SIZE.h"
+#include "EEPARAMS.h"
+#include "PARAMS.h"
+#include "SHELFICE.h"
+
+C !INPUT/OUTPUT PARAMETERS: ============================================
+C     SIfield     :: seaice field @ grid-cell center
+C     bi, bj      :: Current tile indices
+C     myIter      :: Current iteration number in simulation
+C     myThid      :: my Thread Id number
+      _RL SIfield(1-OLx:sNx+OLx,1-OLy:sNy+OLy,nSx,nSy)
+      INTEGER bi, bj
+      INTEGER myIter
+      INTEGER myThid
+
+C !LOCAL VARIABLES: ====================================================
+C     i, j        :: Loop counters
+      INTEGER i, j
+CEOP
+C     msgBuf      :: Informational/error message buffer
+c     CHARACTER*(MAX_LEN_MBUF) msgBuf
+
+c     DO bj=myByLo(myThid),myByHi(myThid)
+c      DO bi=myBxLo(myThid),myBxHi(myThid)
+
+        DO j=1-OLy,sNy+OLy
+         DO i=1-OLx,sNx+OLx
+          IF ( kTopC(i,j,bi,bj).NE.0 ) SIfield(i,j,bi,bj) = zeroRL
+         ENDDO
+        ENDDO
+
+c      ENDDO
+c     ENDDO
+
+      RETURN
+      END

--- a/pkg/shelfice/shelfice_step_icemass.F
+++ b/pkg/shelfice/shelfice_step_icemass.F
@@ -4,13 +4,11 @@
 #endif
 
 CBOP
-C !ROUTINE: SHELFICE_U_DRAG
+C !ROUTINE: SHELFICE_STEP_ICEMASS
 
 C !INTERFACE: ==========================================================
       SUBROUTINE SHELFICE_STEP_ICEMASS(
      I                        myTime, myIter, myThid )
-
-!        myTime, myIter, myThid
 
 C !DESCRIPTION:
 C Serves as a "stub" for ice dynamics
@@ -28,10 +26,9 @@ C !USES: ===============================================================
 #endif
 
 C     !INPUT/OUTPUT PARAMETERS:
-C     === Routine arguments ===
-C     myIter :: iteration counter for this thread
-C     myTime :: time counter for this thread
-C     myThid :: thread number for this instance of the routine.
+C     myTime      :: current time in simulation
+C     myIter      :: current iteration number insimulation
+C     myThid      :: my thread Id number
       _RL  myTime
       INTEGER myIter
       INTEGER myThid
@@ -39,44 +36,43 @@ CEOP
 
 #ifdef ALLOW_SHELFICE
 C !LOCAL VARIABLES : ====================================================
-C  i,j                  :: loop indices
+C     i,j, bi,bj  :: loop indices
       INTEGER bi,bj,i,j
 
       IF ( SHELFICEMassStepping ) THEN
 
-#ifdef ALLOW_STREAMICE
        IF (useStreamIce) THEN
+
+#ifdef ALLOW_STREAMICE
         DO bj = myByLo(myThid), myByHi(myThid)
          DO bi = myBxLo(myThid), myBxHi(myThid)
           DO j=1-OLy,sNy+OLy-1
            DO i=1-OLx+1,sNx+OLx-1
-            if (streamice_hmask(i,j,bi,bj).eq.1 .or.
-     &          streamice_hmask(i,j,bi,bj).eq.2) then
-
+            IF ( streamice_hmask(i,j,bi,bj).EQ.1 .OR.
+     &           streamice_hmask(i,j,bi,bj).EQ.2 ) THEN
              shelficeMass(i,j,bi,bj) =
-     &        H_streamice(I,J,bi,bj) * streamice_density
-
-            endif
+     &        H_streamice(i,j,bi,bj) * streamice_density
+            ENDIF
            ENDDO
           ENDDO
          ENDDO
         ENDDO
-       ENDIF
 #endif /* ALLOW_STREAMICE */
 
-       IF (.NOT.useStreamIce) THEN
+       ELSE
+
         DO bj = myByLo(myThid), myByHi(myThid)
          DO bi = myBxLo(myThid), myBxHi(myThid)
           DO j=1-OLy,sNy+OLy
            DO i=1-OLx,sNx+OLx
 
-           IF (.NOT. SHELFICEDynMassOnly) then
-            shelficeMass(i,j,bi,bj) = shelficeMass(i,j,bi,bj)
-     &      + shelfIceFreshWaterFlux(I,J,bi,bj) * deltaT
-           ENDIF
+            IF ( .NOT.SHELFICEDynMassOnly ) THEN
+             shelficeMass(i,j,bi,bj) = shelficeMass(i,j,bi,bj)
+     &        + shelfIceFreshWaterFlux(i,j,bi,bj)*deltaT
+            ENDIF
 
             shelficeMass(i,j,bi,bj) = shelficeMass(i,j,bi,bj)
-     &      + shelfIceMassDynTendency(I,J,bi,bj)*deltaT
+     &        + shelfIceMassDynTendency(i,j,bi,bj)*deltaT
 
            ENDDO
           ENDDO

--- a/pkg/thsice/thsice_get_ocean.F
+++ b/pkg/thsice/thsice_get_ocean.F
@@ -2,9 +2,6 @@
 #ifdef ALLOW_SEAICE
 # include "SEAICE_OPTIONS.h"
 #endif /* ALLOW_SEAICE */
-#ifdef ALLOW_SHELFICE
-# include "SHELFICE_OPTIONS.h"
-#endif /* ALLOW_SHELFICE */
 
 CBOP
 C     !ROUTINE: THSICE_GET_OCEAN
@@ -36,9 +33,6 @@ c#include "THSICE_PARAMS.h"
 # include "SEAICE_SIZE.h"
 # include "SEAICE.h"
 #endif /* ALLOW_SEAICE */
-#ifdef ALLOW_SHELFICE
-# include "SHELFICE.h"
-#endif /* ALLOW_SHELFICE */
 
 C     !INPUT/OUTPUT PARAMETERS:
 C     === Routine arguments ===
@@ -97,11 +91,9 @@ C--     Mixed layer thickness: take the 1rst layer
 #ifdef ALLOW_SHELFICE
 C--   Prevent seaice to form where Ice-Shelf is present
         IF ( useShelfIce ) THEN
-          DO j=1-OLy,sNy+OLy
-           DO i=1-OLx,sNx+OLx
-             IF ( kTopC(i,j,bi,bj).NE.0 ) hOceMxL(i,j,bi,bj) = 0. _d 0
-           ENDDO
-          ENDDO
+          CALL SHELFICE_MASK_SEAICE(
+     U                  hOceMxL,
+     I                  bi, bj, myIter, myThid )
         ENDIF
 #endif /* ALLOW_SHELFICE */
 


### PR DESCRIPTION
## What changes does this PR introduce?
complement PR #187 by fixing the use of pkg/seaice with thin ice-shelf, i.e., thinner than surface level
so that hFacC(k=1) > 0. Will allow to close issue #99 (also fixing what was left aside by PR #113).

## What is the current behaviour? 
pkg/seaice cannot be used if ice-shelf is too thin (i.e., hFacC(k=1) > 0).

## What is the new behaviour 
with pkg/seaice. prevent seaice to form or spread where there is an ice-shelf.

## Does this PR introduce a breaking change? 
pkg/seaice can now be used with pkg/shelfice, even when, in some places, an ice-shelf is thin.

## Other information:
Implemented by updating seaice masks (recently added by PR #174); had to change
order of calls in initialisation (shelfice before seaice); for consistency, made this ordering change
in all init S/R (packages_readparms/init_fixed and init_variables).

## Suggested addition to `tag-index`
o model/src:
  - change ordering of pkg calls in initialisation: streamice / shelfice and 
    then seaice / salt_plume / thsice;
  - fix thin ice-shelf issue with pkg/seaice ; implemented by updating (recently
    added) seaice masks (requiring new ordering of calls).