### PR TITLE
fix missing update of sIceLoad when usePW79thermodynamics=F

### DIFF
--- a/doc/tag-index
+++ b/doc/tag-index
@@ -1,6 +1,8 @@
     Notes on tags used in MITgcmUV
     ==============================
 
+o pkg/seaice:
+  - fix missing update of sIceLoad in the case usePW79thermodynamics=F.
 o pkg/dic:
   - Adjust unit conversions for dissociation coefficients aks, aksi, and akf
     (#define CARBONCHEM_TOTALPHSCALE).

--- a/pkg/seaice/seaice_model.F
+++ b/pkg/seaice/seaice_model.F
@@ -54,10 +54,8 @@ C     myThid :: my Thread Id number
 
 C !LOCAL VARIABLES: ====================================================
 C     i,j,bi,bj :: Loop counters
-#ifdef ALLOW_AUTODIFF_TAMC
       INTEGER i, j
       INTEGER bi, bj
-#endif
 #ifdef ALLOW_SITRACER
       INTEGER iTr
 #endif
@@ -166,7 +164,7 @@ C--   Apply ice velocity open boundary conditions
         CALL THSICE_DO_ADVECT( 0, 0, myTime, myIter, myThid )
 #endif /* OLD_THSICE_CALL_SEQUENCE */
       ELSE
-#endif
+#endif /* ALLOW_THSICE */
 C--   Only call advection of heff, area, snow, and salt and
 C--   growth for the generic 0-layer thermodynamics of seaice
 C--   if useThSice=.false., otherwise the 3-layer Winton thermodynamics
@@ -191,7 +189,9 @@ C     may be > 1 in convergent motion and a ridging algorithm redistributes
 C     the ice to limit the concentration to 1.
       CALL SEAICE_REG_RIDGE( myTime, myIter, myThid )
 
-#ifndef DISABLE_SEAICE_GROWTH
+#ifdef DISABLE_SEAICE_GROWTH
+       IF ( .TRUE. ) THEN
+#else /* DISABLE_SEAICE_GROWTH */
 C     thermodynamics growth
 C     must call growth after calling advection
 C     because of ugly time level business
@@ -200,9 +200,28 @@ C     because of ugly time level business
         IF (debugMode) CALL DEBUG_CALL( 'SEAICE_GROWTH', myThid )
 #endif
         CALL SEAICE_GROWTH( myTime, myIter, myThid )
-C
-       ENDIF
+       ELSE
 #endif /* DISABLE_SEAICE_GROWTH */
+        DO bj=myByLo(myThid),myByHi(myThid)
+         DO bi=myBxLo(myThid),myBxHi(myThid)
+          DO j=1,sNy
+           DO i=1,sNx
+            sIceLoad(i,j,bi,bj) = HEFF(i,j,bi,bj)*SEAICE_rhoIce
+     &                         + HSNOW(i,j,bi,bj)*SEAICE_rhoSnow
+           ENDDO
+          ENDDO
+c#ifdef SEAICE_CAP_ICELOAD
+c         sIceTooHeavy = rhoConst*drF(1) / 5. _d 0
+c         DO j=1,sNy
+c          DO i=1,sNx
+c           sIceLoad(i,j,bi,bj) = MIN( sIceLoad(i,j,bi,bj),
+c    &                                 sIceTooHeavy )
+c          ENDDO
+c         ENDDO
+c#endif
+         ENDDO
+        ENDDO
+       ENDIF
 
 #ifdef ALLOW_SITRACER
 # ifdef ALLOW_AUTODIFF_TAMC


### PR DESCRIPTION
- Currently, sIceLoad is computed in S/R SEAICE_GROWTH but this call
  is skipped if usePW79thermodynamics=F ; in this case, sIceLoad
  was not updated after being initialised.
- This case is not very common (no issue with pkg/thsice that take care
  of sIceLoad update) but can happen (e.g, in offline_exf_seaice.dyn_lsr).
- Problem fixed by adding calculation of sIceLoad in SEAICE_MODEL for the
  case usePW79thermodynamics=F

## Does this PR introduce a breaking change? 
this rare case is not tested in any verification experiment ; checked that all AD
experiments are unaffected.
 
## Suggested addition to `tag-index`
o pkg/seaice:
  - fix missing update of sIceLoad in the case usePW79thermodynamics=F.