### PR TITLE
Update ctrl_get_gen.F

### DIFF
--- a/pkg/ctrl/CTRL_OPTIONS.h
+++ b/pkg/ctrl/CTRL_OPTIONS.h
@@ -74,6 +74,12 @@ C  o Rotation of wind/stress controls adjustments
 C    from Eastward/Northward to model grid directions
 #undef ALLOW_ROTATE_UV_CONTROLS
 
+C  o Originally the first two time-reccords of control
+C    variable tau u and tau v were skipped.
+C    The CTRL_SKIP_FIRST_TWO_ATM_REC_ALL option extends this
+C    to the other the time variable atmospheric controls.
+#undef CTRL_SKIP_FIRST_TWO_ATM_REC_ALL
+
 C  o use pkg/smooth correlation operator (incl. smoother) for 2D controls (Weaver, Courtier 01)
 C    This CPP option just sets the default for ctrlSmoothCorrel2D to .TRUE.
 #undef ALLOW_SMOOTH_CORREL2D

--- a/pkg/ctrl/ctrl_get_gen.F
+++ b/pkg/ctrl/ctrl_get_gen.F
@@ -1,6 +1,5 @@
 #include "CTRL_OPTIONS.h"
 
-
       subroutine ctrl_get_gen(
      I          xx_gen_file, xx_genstartdate, xx_genperiod,
      I          genmask, genfld, xx_gen0, xx_gen1, xx_gen_dummy,
@@ -34,15 +33,6 @@ c     == global variables ==
 #include "optim.h"
 #ifdef ALLOW_EXF
 # include "EXF_FIELDS.h"
-#endif
-#ifndef ECCO_CTRL_DEPRECATED
-      character*(MAX_LEN_FNAM) xx_tauu_file
-      character*(MAX_LEN_FNAM) xx_tauv_file
-      character*(MAX_LEN_FNAM) xx_aqh_file
-      character*(MAX_LEN_FNAM) xx_atemp_file
-      character*(MAX_LEN_FNAM) xx_precip_file      
-      character*(MAX_LEN_FNAM) xx_lwdown_file      
-      character*(MAX_LEN_FNAM) xx_swdown_file            
 #endif
 
 c     == routine arguments ==
@@ -91,12 +81,20 @@ c     == local variables ==
       _RS dummyRS(1)
 #endif
 #endif
+#ifndef ECCO_CTRL_DEPRECATED
+      character*(MAX_LEN_FNAM) xx_tauu_file
+      character*(MAX_LEN_FNAM) xx_tauv_file
+      character*(MAX_LEN_FNAM) xx_aqh_file
+      character*(MAX_LEN_FNAM) xx_atemp_file
+      character*(MAX_LEN_FNAM) xx_precip_file
+      character*(MAX_LEN_FNAM) xx_lwdown_file
+      character*(MAX_LEN_FNAM) xx_swdown_file
+#endif
 
 c     == external functions ==
 
       integer  ilnblnk
       external ilnblnk
-
 
 c     == end of interface ==
 
@@ -142,13 +140,13 @@ cc#else
         call active_read_xy( fnamegen, xx_gen1, gencount0,
      &                       doglobalread, ladinit, optimcycle,
      &                       mythid, xx_gen_dummy )
-        if (.false.) then
+       if (.false.) then
         call active_read_xy( fnamegen, xx_gen0, gencount0,
      &                       doglobalread, ladinit, optimcycle,
      &                       mythid, xx_gen_dummy )
-        endif
+       endif
 #else
-      CALL READ_REC_XY_RL( fnamegen, xx_gen1, gencount0, 1, myThid )
+        CALL READ_REC_XY_RL( fnamegen, xx_gen1, gencount0, 1, myThid )
 #endif
 cc#endif /* ALLOW_OPENAD */
 
@@ -162,11 +160,11 @@ cc#endif /* ALLOW_OPENAD */
 
 #ifdef ALLOW_SMOOTH
 #ifdef ALLOW_SMOOTH_CTRL2D
-      if (useSMOOTH) call smooth2D(xx_gen1,genmask,1,mythid)
-      write(fnamegeneric(1:80),'(2a,i10.10)')
-     & xx_gen_file(1:ilgen),'.smooth.',optimcycle
-      CALL MDS_WRITE_FIELD(fnamegeneric,ctrlprec,.FALSE.,.FALSE.,
-     & 'RL',1,1,1,xx_gen1,dummyRS,gencount1,optimcycle,mythid)
+        if (useSMOOTH) call smooth2D(xx_gen1,genmask,1,mythid)
+        write(fnamegeneric(1:80),'(2a,i10.10)')
+     &    xx_gen_file(1:ilgen),'.smooth.',optimcycle
+        CALL MDS_WRITE_FIELD(fnamegeneric,ctrlprec,.FALSE.,.FALSE.,
+     &   'RL',1,1,1,xx_gen1,dummyRS,gencount1,optimcycle,mythid)
 #endif /* ALLOW_SMOOTH_CTRL2D */
 #endif /* ALLOW_SMOOTH */
 
@@ -198,11 +196,11 @@ cc#endif /* ALLOW_OPENAD */
 
 #ifdef ALLOW_SMOOTH
 #ifdef ALLOW_SMOOTH_CTRL2D
-      if (useSMOOTH) call smooth2D(xx_gen1,genmask,1,mythid)
-      write(fnamegeneric(1:80),'(2a,i10.10)')
-     & xx_gen_file(1:ilgen),'.smooth.',optimcycle
-      CALL MDS_WRITE_FIELD(fnamegeneric,ctrlprec,.FALSE.,.FALSE.,
-     & 'RL',1,1,1,xx_gen1,dummyRS,gencount0,optimcycle,mythid)
+        if (useSMOOTH) call smooth2D(xx_gen1,genmask,1,mythid)
+        write(fnamegeneric(1:80),'(2a,i10.10)')
+     &     xx_gen_file(1:ilgen),'.smooth.',optimcycle
+        CALL MDS_WRITE_FIELD(fnamegeneric,ctrlprec,.FALSE.,.FALSE.,
+     &   'RL',1,1,1,xx_gen1,dummyRS,gencount0,optimcycle,mythid)
 #endif /* ALLOW_SMOOTH_CTRL2D */
 #endif /* ALLOW_SMOOTH */
 
@@ -213,51 +211,37 @@ cph(
 cph this flag ported from the SIO code
 cph Initial wind stress adjustments are too vigorous.
 
-#ifndef ECCO_CTRL_DEPRECATED
-      xx_tauu_file       = 'xx_tauu'
-      xx_tauv_file       = 'xx_tauv'
-      
-      
-      xx_aqh_file        = 'xx_aqh'
-      xx_atemp_file      = 'xx_atemp'
-      xx_precip_file     = 'xx_precip' 
-      xx_lwdown_file     = 'xx_lwdown' 
-      xx_swdown_file     = 'xx_swdown'
-      
-#endif
-
-CIGF Originally only the first two time variable 
+CIGF Originally only the first two time variable
 CIGF tau u and tau v control records were disabled
 CIGF The DISABLE_FIRST_TWO_ATM_CTRLS_XX flag extends
 CIGF that to the rest of the time variable atmospheric
 CIGF controls.
 
+#ifndef ECCO_CTRL_DEPRECATED
+      xx_tauu_file       = 'xx_tauu'
+      xx_tauv_file       = 'xx_tauv'
+      xx_aqh_file        = 'xx_aqh'
+      xx_atemp_file      = 'xx_atemp'
+      xx_precip_file     = 'xx_precip'
+      xx_lwdown_file     = 'xx_lwdown'
+      xx_swdown_file     = 'xx_swdown'
+#endif
 
-#ifndef DISABLE_FIRST_TWO_ATM_CTRLS_XX
       if ( gencount0 .LE. 2 .AND.
      &     ( xx_gen_file(1:7) .EQ. xx_tauu_file .OR.
+#ifdef DISABLE_FIRST_TWO_ATM_CTRLS_XX
+     &       xx_gen_file(1:6) .EQ. xx_aqh_file  .OR.
+     &       xx_gen_file(1:8) .EQ. xx_atemp_file .OR.
+     &       xx_gen_file(1:9) .EQ. xx_precip_file .OR.
+     &       xx_gen_file(1:9) .EQ. xx_lwdown_file .OR.
+     &       xx_gen_file(1:9) .EQ. xx_swdown_file .OR.
+#endif
      &       xx_gen_file(1:7) .EQ. xx_tauv_file ) .AND.
-     &     ( xx_genperiod .NE. 0 ) ) then
+     &     ( xx_genperiod .NE. zeroRL ) ) then
          doCtrlUpdate = .FALSE.
       else
          doCtrlUpdate = .TRUE.
       endif
-#else 
-      if ( gencount0 .LE. 2 .AND.
-     &     ( xx_gen_file(1:7) .EQ. xx_tauu_file .OR.
-     &       xx_gen_file(1:7) .EQ. xx_tauv_file .OR.
-     &       xx_gen_file(1:6) .EQ. xx_aqh_file .OR.     
-     &       xx_gen_file(1:8) .EQ. xx_atemp_file .OR.
-     &       xx_gen_file(1:9) .EQ. xx_precip_file .OR.
-     &       xx_gen_file(1:9) .EQ. xx_lwdown_file .OR.
-     &       xx_gen_file(1:9) .EQ. xx_swdown_file) .AND.
-     &     ( xx_genperiod .NE. 0 ) ) then
-         doCtrlUpdate = .FALSE.
-      else
-         doCtrlUpdate = .TRUE.
-      endif      
-#endif
-      
       if ( xx_gen_file(1:7) .EQ. xx_tauu_file .OR.
      &     xx_gen_file(1:7) .EQ. xx_tauv_file ) then
          gensign = -1.
@@ -265,11 +249,8 @@ CIGF controls.
          gensign = 1.
       endif
 
-
-c
 cph since the above is ECCO specific, we undo it here:
 cph      doCtrlUpdate = .TRUE.
-c
       if ( doCtrlUpdate ) then
 cph)
 CMLCML(

--- a/pkg/ctrl/ctrl_get_gen.F
+++ b/pkg/ctrl/ctrl_get_gen.F
@@ -211,12 +211,6 @@ cph(
 cph this flag ported from the SIO code
 cph Initial wind stress adjustments are too vigorous.
 
-CIGF Originally only the first two time variable
-CIGF tau u and tau v control records were disabled
-CIGF The DISABLE_FIRST_TWO_ATM_CTRLS_XX flag extends
-CIGF that to the rest of the time variable atmospheric
-CIGF controls.
-
 #ifndef ECCO_CTRL_DEPRECATED
       xx_tauu_file       = 'xx_tauu'
       xx_tauv_file       = 'xx_tauv'
@@ -227,8 +221,7 @@ CIGF controls.
       xx_swdown_file     = 'xx_swdown'
 #endif
 
-      if ( gencount0 .LE. 2 .AND.
-     &      (
+      if ( gencount0 .LE. 2 .AND. (
 #ifdef CTRL_SKIP_FIRST_TWO_ATM_REC_ALL
      &       xx_gen_file(1:6) .EQ. xx_aqh_file  .OR.
      &       xx_gen_file(1:8) .EQ. xx_atemp_file .OR.
@@ -237,7 +230,7 @@ CIGF controls.
      &       xx_gen_file(1:9) .EQ. xx_swdown_file .OR.
 #endif
      &       xx_gen_file(1:7) .EQ. xx_tauu_file .OR.
-     &       xx_gen_file(1:7) .EQ. xx_tauv_file ) .AND.     
+     &       xx_gen_file(1:7) .EQ. xx_tauv_file ) .AND.
      &     ( xx_genperiod .NE. zeroRL ) ) then
          doCtrlUpdate = .FALSE.
       else

--- a/pkg/ctrl/ctrl_get_gen.F
+++ b/pkg/ctrl/ctrl_get_gen.F
@@ -38,6 +38,11 @@ c     == global variables ==
 #ifndef ECCO_CTRL_DEPRECATED
       character*(MAX_LEN_FNAM) xx_tauu_file
       character*(MAX_LEN_FNAM) xx_tauv_file
+      character*(MAX_LEN_FNAM) xx_aqh_file
+      character*(MAX_LEN_FNAM) xx_atemp_file
+      character*(MAX_LEN_FNAM) xx_precip_file      
+      character*(MAX_LEN_FNAM) xx_lwdown_file      
+      character*(MAX_LEN_FNAM) xx_swdown_file            
 #endif
 
 c     == routine arguments ==
@@ -211,8 +216,24 @@ cph Initial wind stress adjustments are too vigorous.
 #ifndef ECCO_CTRL_DEPRECATED
       xx_tauu_file       = 'xx_tauu'
       xx_tauv_file       = 'xx_tauv'
+      
+      
+      xx_aqh_file        = 'xx_aqh'
+      xx_atemp_file      = 'xx_atemp'
+      xx_precip_file     = 'xx_precip' 
+      xx_lwdown_file     = 'xx_lwdown' 
+      xx_swdown_file     = 'xx_swdown'
+      
 #endif
 
+CIGF Originally only the first two time variable 
+CIGF tau u and tau v control records were disabled
+CIGF The DISABLE_FIRST_TWO_ATM_CTRLS_XX flag extends
+CIGF that to the rest of the time variable atmospheric
+CIGF controls.
+
+
+#ifndef DISABLE_FIRST_TWO_ATM_CTRLS_XX
       if ( gencount0 .LE. 2 .AND.
      &     ( xx_gen_file(1:7) .EQ. xx_tauu_file .OR.
      &       xx_gen_file(1:7) .EQ. xx_tauv_file ) .AND.
@@ -221,12 +242,29 @@ cph Initial wind stress adjustments are too vigorous.
       else
          doCtrlUpdate = .TRUE.
       endif
+#else 
+      if ( gencount0 .LE. 2 .AND.
+     &     ( xx_gen_file(1:7) .EQ. xx_tauu_file .OR.
+     &       xx_gen_file(1:7) .EQ. xx_tauv_file .OR.
+     &       xx_gen_file(1:6) .EQ. xx_aqh_file .OR.     
+     &       xx_gen_file(1:8) .EQ. xx_atemp_file .OR.
+     &       xx_gen_file(1:9) .EQ. xx_precip_file .OR.
+     &       xx_gen_file(1:9) .EQ. xx_lwdown_file .OR.
+     &       xx_gen_file(1:9) .EQ. xx_swdown_file) .AND.
+     &     ( xx_genperiod .NE. 0 ) ) then
+         doCtrlUpdate = .FALSE.
+      else
+         doCtrlUpdate = .TRUE.
+      endif      
+#endif
+      
       if ( xx_gen_file(1:7) .EQ. xx_tauu_file .OR.
      &     xx_gen_file(1:7) .EQ. xx_tauv_file ) then
          gensign = -1.
       else
          gensign = 1.
       endif
+
 
 c
 cph since the above is ECCO specific, we undo it here:

--- a/pkg/ctrl/ctrl_get_gen.F
+++ b/pkg/ctrl/ctrl_get_gen.F
@@ -228,15 +228,16 @@ CIGF controls.
 #endif
 
       if ( gencount0 .LE. 2 .AND.
-     &     ( xx_gen_file(1:7) .EQ. xx_tauu_file .OR.
-#ifdef DISABLE_FIRST_TWO_ATM_CTRLS_XX
+     &      (
+#ifdef CTRL_SKIP_FIRST_TWO_ATM_REC_ALL
      &       xx_gen_file(1:6) .EQ. xx_aqh_file  .OR.
      &       xx_gen_file(1:8) .EQ. xx_atemp_file .OR.
      &       xx_gen_file(1:9) .EQ. xx_precip_file .OR.
      &       xx_gen_file(1:9) .EQ. xx_lwdown_file .OR.
      &       xx_gen_file(1:9) .EQ. xx_swdown_file .OR.
 #endif
-     &       xx_gen_file(1:7) .EQ. xx_tauv_file ) .AND.
+     &       xx_gen_file(1:7) .EQ. xx_tauu_file .OR.
+     &       xx_gen_file(1:7) .EQ. xx_tauv_file ) .AND.     
      &     ( xx_genperiod .NE. zeroRL ) ) then
          doCtrlUpdate = .FALSE.
       else


### PR DESCRIPTION
Originally only the first two time variable tau u and tau v control records were disabled.  We think this is because the long ago someone noticed that the optimization tends to make very large adjustments to the first one or two records for reasons that are not entirely clear.  We recently found very large adjustments in the first two control records of all of the other atmospheric controls.  This 

The DISABLE_FIRST_TWO_ATM_CTRLS_XX flag simply extends the original logic applied to tau u and tau v fields to all the time variable atmospheric controls.

## What changes does this PR introduce?
(Bug fix, feature, docs update, ...)


## What is the current behaviour? 
(You can also link to an open issue here)


## What is the new behaviour 
(if this is a feature change)?


## Does this PR introduce a breaking change? 
(What changes might users need to make in their application due to this PR?)


## Other information:


## Suggested addition to `tag-index`
(To avoid unnecessary merge conflicts, please don't update `tag-index`. One of the admins will do that when merging your pull request.)