### PR TITLE
Minor fix to previous update of testreport (from PR #190)

### DIFF
--- a/verification/testreport
+++ b/verification/testreport
@@ -1768,7 +1768,8 @@ for dir in $TESTDIRS ; do
     echo "-------------------------------------------------------------------------------"
 
 done
-grep '^HAVE_LAPACK' */$builddir/genmake_state | head -1 >> $DRESULTS/genmake_state
+grep '^HAVE_LAPACK' */$builddir/genmake_state 2> /dev/null \
+			| head -1 >> $DRESULTS/genmake_state
 
 printf "Start time:  " >> $SUMMARY
 echo "$start_date" >> $SUMMARY


### PR DESCRIPTION
In testreport, avoid error message when no file "*/$builddir/genmake_state" exists,
e.g., when running "testreport -clean".

## What changes does this PR introduce?
minor improvement to testreport modifications from PR #190

## What is the current behaviour? 
some testreport executions were reporting an error like:
"grep: */build/genmake_state: No such file or directory"
when no genmake_state file was found, e.g. when running
"testreport -clean"

## What is the new behaviour 
no more "fake" error message.

## Does this PR introduce a breaking change? 
no

## Other information:

## Suggested addition to `tag-index`
none (too small update to be reported in tag-index)