### PR TITLE
corrected sign of Coriolis term

### DIFF
--- a/doc/overview/hydrostatic.rst
+++ b/doc/overview/hydrostatic.rst
@@ -50,7 +50,7 @@ form  [#]_ - see Marshall et al. (1997a) :cite:`marshall:97a` for a full discuss
  
    & -\left\{ \underline{\frac{v\dot{r}}{{r}}}-\frac{u^{2}\tan \varphi}{{r}}\right\} && \qquad \text{metric}    
 
-   & -\left\{ -2\Omega u\sin \varphi\right\} && \qquad \text{Coriolis}  
+   & -\left\{ 2\Omega u\sin \varphi\right\} && \qquad \text{Coriolis}  
 
    & +\mathcal{F}_{v} && \qquad \text{forcing/dissipation}
 


### PR DESCRIPTION
Corrected sign of the Coriolis term in the expression for the meridional momentum tendency. Note: the source code in cd_code_scheme has the correct sign – this is only a bug in the documentation.

## What changes does this PR introduce?
(Bug fix, feature, docs update, ...)


## What is the current behaviour? 
(You can also link to an open issue here)


## What is the new behaviour 
(if this is a feature change)?


## Does this PR introduce a breaking change? 
(What changes might users need to make in their application due to this PR?)


## Other information:


## Suggested addition to `tag-index`
(To avoid unnecessary merge conflicts, please don't update `tag-index`. One of the admins will do that when merging your pull request.)