### PR TITLE
add missing OPENAD_OPTIONS to tutorial_global_oce_optim

### DIFF
--- a/verification/tutorial_global_oce_optim/code_oad/OPENAD_OPTIONS.h
+++ b/verification/tutorial_global_oce_optim/code_oad/OPENAD_OPTIONS.h
@@ -1,0 +1,25 @@
+CBOP
+C !ROUTINE: OPENAD_OPTIONS.h
+C !INTERFACE:
+C #include "OPENAD_OPTIONS.h"
+
+C !DESCRIPTION:
+C *==================================================================*
+C | CPP options file for OpenAD (openad) package:
+C | Control which optional features to compile in this package code.
+C *==================================================================*
+CEOP
+
+#ifndef OPENAD_OPTIONS_H
+#define OPENAD_OPTIONS_H
+#include "PACKAGES_CONFIG.h"
+#include "CPP_OPTIONS.h"
+
+#ifdef ALLOW_OPENAD
+
+#define ALLOW_OPENAD_ACTIVE_READ_XY
+#undef ALLOW_OPENAD_ACTIVE_READ_XYZ
+#undef ALLOW_OPENAD_ACTIVE_WRITE
+
+#endif /* ALLOW_OPENAD */
+#endif /* OPENAD_OPTIONS_H */


### PR DESCRIPTION
## What changes does this PR introduce?
(Bug fix, feature, docs update, ...)
Bug fix (uncontroversial)

## What is the current behaviour? 
(You can also link to an open issue here)
File currently missing, causing the wrong thing to happen in `pkg/openad/externalDummies.F`: subroutine `active_read_xy` became a no-op since `ALLOW_OPENAD_ACTIVE_READ_XY` wasn't defined in this example