### PR TITLE
OpenAD active_read_xy fix

### DIFF
--- a/tools/OAD_support/ad_template.active_read_xy.F
+++ b/tools/OAD_support/ad_template.active_read_xy.F
@@ -37,7 +37,7 @@ C     !FUNCTIONS
       if (our_rev_mode%plain) then
          our_orig_mode = our_rev_mode
 ! original function
-         active_var_p = active_var%v
+         active_var_p = active_var
 ! set up for plain execution
          our_rev_mode%arg_store=.FALSE.
          our_rev_mode%arg_restore=.FALSE.
@@ -51,14 +51,14 @@ C     !FUNCTIONS
 ! reset the mode
          our_rev_mode=our_orig_mode
 ! copy back
-         active_var%v = active_var_p
+         active_var = active_var_p
       end if
 
       if (our_rev_mode%tape) then
 ! taping
          our_orig_mode=our_rev_mode
 ! original function
-         active_var_p = active_var%v
+         active_var_p = active_var
          our_rev_mode%arg_store=.FALSE.
          our_rev_mode%arg_restore=.FALSE.
          our_rev_mode%plain=.TRUE.
@@ -76,7 +76,7 @@ C     !FUNCTIONS
      &        FORWARD_SIMULATION, myOptimIter, myThid )
          our_rev_mode=our_orig_mode
 ! copy back
-         active_var%v = active_var_p
+         active_var = active_var_p
       end if
 
       if (our_rev_mode%adjoint) then
@@ -90,7 +90,7 @@ C     !FUNCTIONS
          WRITE(fname(1:80),'(A)') ' '
          WRITE(fname(1:2+il),'(2A)') adpref, active_var_file(1:il)
 !         WRITE(fname(1:2+il),'(2A)') adpref, active_var_file
-         active_var_p = active_var%d
+         active_var_p = active_var
 ! set up for plain execution
          our_orig_mode=our_rev_mode
          our_rev_mode%arg_store=.FALSE.
@@ -105,7 +105,7 @@ C     !FUNCTIONS
 ! reset the mode
          our_rev_mode=our_orig_mode
 ! copy back
-         active_var%d = active_var_p
+         active_var = active_var_p
       end if
 
 #endif /* ALLOW_OPENAD_ACTIVE_READ_XY */


### PR DESCRIPTION
Note: this applies a fix to `ad_template.active_read_xy.F`.  Almost certainly the same changes should be applied to `ad_template.active_read_xyz.F`.  No idea about `ad_template.active_write_xy.F`, I don't know where that is used.

## What changes does this PR introduce?
(Bug fix, feature, docs update, ...)

Bug fix

## What is the current behaviour? 
(You can also link to an open issue here)

Without this change, the optimization increments are ignored (using OpenAD, not TAF), per http://mailman.mitgcm.org/pipermail/mitgcm-support/2018-June/011632.html, though I'm not sure why this works.

## What is the new behaviour 
(if this is a feature change)?

Together with #204 and #207 , the tutorial example now works with OpenAD (the optimization increment gets read in correctly)

## Does this PR introduce a breaking change? 
(What changes might users need to make in their application due to this PR?)

Hopefully not!

## Suggested addition to `tag-index`
(To avoid unnecessary merge conflicts, please don't update `tag-index`. One of the admins will do that when merging your pull request.)
Fix tutorial_global_oce_optim example with OpenAD