### PR TITLE
Fix OpenAD data.ctrl/data.optim files in tutorial example

### DIFF
--- a/verification/tutorial_global_oce_optim/input_oad/data.ctrl
+++ b/verification/tutorial_global_oce_optim/input_oad/data.ctrl
@@ -5,11 +5,13 @@
 # *********************
  &CTRL_NML
  xx_hfluxm_file      = 'xx_hfluxm',
- &
+ &end
 #
 # *********************
 # names for ctrl_pack/unpack
 # *********************
  &CTRL_PACKNAMES
- &
+ ctrlname = 'ecco_ctrl',
+ costname = 'ecco_cost',
+ &end
 

--- a/verification/tutorial_global_oce_optim/input_oad/data.optim
+++ b/verification/tutorial_global_oce_optim/input_oad/data.optim
@@ -9,4 +9,4 @@
  fmin=5.74,
  iprint=10,
  nupdate=8,
- &
+ &end


### PR DESCRIPTION
Sorry for PR spam, last one for now...   Fixing some code rot, and replacing `&` by `&end` (is this a modern Fortran compiler thing?)

## What changes does this PR introduce?
(Bug fix, feature, docs update, ...)

Bug fix

## What is the new behaviour 
(if this is a feature change)?

With #204 and #205, tutorial example now runs with OpenAD