### PR TITLE
A hack to fix the "-nocat4d" option with new version of TAF

### DIFF
--- a/doc/tag-index
+++ b/doc/tag-index
@@ -1,6 +1,10 @@
     Notes on tags used in MITgcmUV
     ==============================
 
+o tools/genmake2:
+  - fix option "-nocat4ad" for latest version of TAF: now needs to add TAF
+    option "-fixed" to process *.flowdir files with newer (after 4.1.1) version
+    of TAF (otherwise assumed now to be in free format).
 o model/src:
   - remove argument tFld & dFld from S/R CALC_PHI_HYD and from 2 related S/R
 o tools/genmake2:

--- a/tools/genmake2
+++ b/tools/genmake2
@@ -1807,6 +1807,7 @@ if test "x${AD_OPTFILE}" != xNONE ; then
 	exit 1
     fi
 fi
+if test $CAT_SRC_FOR_TAF = 0 ; then TAF_EXTRA="${TAF_EXTRA} -fixed" ; fi
 
 #====================================================================
 # Initialize INCLUDEDIRSMK from and optfile INCLUDEDIRS


### PR DESCRIPTION
With new version of TAF (currently 4.2.7), *.flowdir files are now
assumed to be free-format source files (since they don't have either .f
or .F suffix); Up to version 4.1.1 they were assumed to be fixed format.

And when using "-nocat4d" option, we send all individual files to TAF
(instead of a single file: ad_input_code.f); so we need to explicitly
add the "-fixed" option to the TAF command to get the *.flowdir processed
correctly.

## What changes does this PR introduce?
fix for special (-nocat4d built) TAF adjoint makefile

## What is the current behaviour? 
Du to a change in TAF defaults, current *.flowdir files are no longer
processed correctly with current version (4.2.7) version of TAF, cf:
 http://mitgcm.org/testing/results/2019_03/tr_jaures_20190301_1/summary.txt

## What is the new behaviour 
fixed by adding "-fixed" option to TAF arguments, see:
 http://mitgcm.org/testing/results/2019_03/tr_jaures_20190304_1/summary.txt

## Does this PR introduce a breaking change? 
no, specific to "-nocat4ad" built

## Other information:
Details regarding TAF new defaults were provided by Ralf Geiring

## Suggested addition to `tag-index`
o tools/genmake2:
  - fix option "-nocat4ad" for latest version of TAF: now needs to add TAF
    option "-fixed" to process *.flowdir files with newer (after 4.1.1) version
    of TAF (otherwise assumed now to be in free format).
