### PR TITLE
Allows to skip check fc part in genmake2

### DIFF
--- a/doc/tag-index
+++ b/doc/tag-index
@@ -1,6 +1,9 @@
     Notes on tags used in MITgcmUV
     ==============================
 
+o tools/genmake2:
+  - allow to skip "check_fortran_compiler" part (as, e.g., in opt-file:
+     tools/build_options/linux_ia64_cray_archer).
 o verification/tutorial_barotropic_gyre:
   - add 1rst tutorial documentation to new manual and update corresponding setup
 o pkg/atm_phys:

--- a/tools/build_options/linux_ia64_cray_archer
+++ b/tools/build_options/linux_ia64_cray_archer
@@ -5,7 +5,6 @@
 # module load cray-hdf5-parallel/1.10.0.1
 # module load cray-netcdf-hdf5parallel/4.4.1.1
 
-
 CC='cc'
 FC='ftn'
 F90C='ftn'
@@ -15,6 +14,7 @@ CPP='cpp -traditional -P'
 EXTENDED_SRC_FLAG='-Mextend'
 GET_FC_VERSION="-V"
 CHECK_FOR_LAPACK=t
+FC_CHECK=f
 
 INCLUDES='-I/opt/cray/netcdf-hdf5parallel/4.4.1.1/cray/83/include -I/opt/cray/mpt/7.5.5/gni/mpich-cray/84/include'
 LIBS='-L/opt/cray/netcdf-hdf5parallel/4.4.1.1/cray/83/lib -L/opt/cray/mpt/7.5.5/gni/mpich-cray/84/lib'
@@ -23,8 +23,8 @@ NOOPTFLAGS='-O0'
 NOOPTFILES=''
 
 if test "x$IEEE" = x ; then   #- with optimisation:
-#   FOPTIM='-O2 -hfp3 -Oipa5' for less agressive optimization 
-#   Be aware not all experiments pass the restart test with optimization 
+#   FOPTIM='-O2 -hfp3 -Oipa5' for less agressive optimization
+#   Be aware not all experiments pass the restart test with optimization
     FOPTIM='-O3 -hfp3 -Oipa5'
 else
     if test "x$DEVEL" = x ; then  #- no optimisation + IEEE :

--- a/tools/genmake2
+++ b/tools/genmake2
@@ -1859,7 +1859,9 @@ if test "x$MAKE" = x ; then
 fi
 
 #- check for fortran compiler (for now, just for information, no consequence)
-check_fortran_compiler
+if test "x$FC_CHECK" = x -o "x$FC_CHECK" = xt ; then
+    check_fortran_compiler
+else FC_CHECK=-2 ; fi
 
 if test "x$CPP" = x ; then
     CPP="cpp -traditional -P"
@@ -3766,7 +3768,7 @@ if test $FC_CHECK = 5 ; then
 elif [ $FC_CHECK -ge 3 ] ; then
     echo "  original 'Makefile' generated but was unable to"
     echo "   run compiled test-program (please see '$LOGFILE')"
-else
+elif [ $FC_CHECK -ge 0 ] ; then
     echo "Warning: FORTRAN compiler test failed (please see '$LOGFILE')"
     echo "Warning: 'Makefile' might be unusable (check your optfile)"
 fi


### PR DESCRIPTION
## What changes does this PR introduce?
1) Allows to skip the  " "check_fortran_compiler" part by setting
   (e.g., in optfile) FC_CHECK to anything else than 't'. 
2) add "FC_CHECK=f" in Archer (cray) compiler optfile to skip this
   part which cause Pb when done on compute node.

## What is the current behaviour? 
always run this check

## What is the new behaviour 
can now skip this check and illustrate this in Archer optfile

## Does this PR introduce a breaking change? 
no

## Other information:

## Suggested addition to `tag-index`
o tools/genmake2
  - allow to skip "check_fortran_compiler" part
