### PR TITLE
Add docker image spec for centos

### DIFF
--- a/tools/ci/docker/centos/Dockerfile
+++ b/tools/ci/docker/centos/Dockerfile
@@ -1,0 +1,9 @@
+FROM centos:centos7
+LABEL maintainer=mitgcm-devel@mitgcm.org
+
+RUN yum -y update; yum clean all
+RUN yum -y install epel-release wget csh; yum clean all
+RUN yum -y groupinstall "Development Tools"
+RUN cd /root; wget http://www.mcs.anl.gov/%7Eutke/OpenAD_tars/493/OpenAD_2014-03-15.tgz; tar -xzvf OpenAD_2014-03-15.tgz
+COPY pfile /root/pfile
+RUN cd /root/OpenAD; patch openadConfig.py ../pfile; pwd ; export PATH=".":$PATH; source setenv.sh; make

--- a/tools/ci/docker/centos/README.md
+++ b/tools/ci/docker/centos/README.md
@@ -1,0 +1,7 @@
+Dockerfile that specifies container for testreport testing of MITgcm
+under centos and including OpenAD. The docker container build automatically
+in dockerhub. To fetch the container use the command
+
+```
+docker pull mitgcm/testreport-images:centos
+```

--- a/tools/ci/docker/centos/pfile
+++ b/tools/ci/docker/centos/pfile
@@ -1,0 +1,19 @@
+*** openadConfig.py.old	Thu Mar  7 04:57:39 2019
+--- openadConfig.py	Thu Mar  7 04:57:56 2019
+*************** class openadConfig:
+*** 67,73 ****
+      else:
+        self.OpenADRepos[name]=(Repository.SVNRepository('https://svn.code.sf.net/p/angellib/code',OpenADRoot,name,None,'trunk','ANGEL_BASE'),True)
+      name="boost";         self.orderedRepoList.append(name)
+!     self.OpenADRepos[name]=(Repository.SVNRepository('http://svn.boost.org/svn/boost',OpenADRoot,name,'boost','tags/release/Boost_1_45_0','BOOST_BASE'),True)
+      if includeExtras:
+        name="RevolveF9X"; self.orderedRepoList.append(name)
+        self.OpenADRepos[name]=(Repository.MercurialRepository(ANLMercurialUrl+name,OpenADRoot,name,None,None,None),False)
+--- 67,73 ----
+      else:
+        self.OpenADRepos[name]=(Repository.SVNRepository('https://svn.code.sf.net/p/angellib/code',OpenADRoot,name,None,'trunk','ANGEL_BASE'),True)
+      name="boost";         self.orderedRepoList.append(name)
+!     self.OpenADRepos[name]=(Repository.SVNRepository('https://svn.boost.org/svn/boost',OpenADRoot,name,'boost','tags/release/Boost_1_45_0','BOOST_BASE'),True)
+      if includeExtras:
+        name="RevolveF9X"; self.orderedRepoList.append(name)
+        self.OpenADRepos[name]=(Repository.MercurialRepository(ANLMercurialUrl+name,OpenADRoot,name,None,None,None),False)


### PR DESCRIPTION
## What changes does this PR introduce?
Adds a Docker specification for a Centos docker image that can be used under Travis
with testreport and OpenAD. The Dockerfile is tied to [docker hub](https://hub.docker.com/r/mitgcm/testreport-images ) so that the image is automatically
built at Docker hub.


## What is the current behaviour? 
Old docker hub image does not include OpenAD and the Dockerfile
is not in git.


## What is the new behaviour 
Allows Travis to use OpenAD 

## Does this PR introduce a breaking change? 
Not yet. Once Travis is updated to use the docker image generated by this Dockerfile
then a broken Dockerfile will break all testing!


## Other information:


## Suggested addition to `tag-index`
o Added centos Dockerfile that is automatically built in docker hub.