### PR TITLE
Clean-up argument list of S/R CALC_PHI_HYD and related S/R

### DIFF
--- a/doc/tag-index
+++ b/doc/tag-index
@@ -1,6 +1,8 @@
     Notes on tags used in MITgcmUV
     ==============================
 
+o model/src:
+  - remove argument tFld & dFld from S/R CALC_PHI_HYD and from 2 related S/R
 o tools/genmake2:
   - allow to skip "check_fortran_compiler" part (as, e.g., in opt-file:
      tools/build_options/linux_ia64_cray_archer).

--- a/model/src/calc_grad_phi_hyd.F
+++ b/model/src/calc_grad_phi_hyd.F
@@ -6,7 +6,7 @@ C     !ROUTINE: CALC_GRAD_PHI_HYD
 C     !INTERFACE:
       SUBROUTINE CALC_GRAD_PHI_HYD(
      I                       k, bi, bj, iMin,iMax, jMin,jMax,
-     I                       phiHydC, alphRho, tFld, sFld,
+     I                       phiHydC, alphRho,
      O                       dPhiHydX, dPhiHydY,
      I                       myTime, myIter, myThid)
 C     !DESCRIPTION: \bv
@@ -33,8 +33,6 @@ C     iMin,iMax,jMin,jMax :: Loop counters
 C     phiHydC    :: Hydrostatic Potential anomaly
 C                  (atmos: =Geopotential ; ocean-z: =Pressure/rho)
 C     alphRho    :: Density (z-coord) or specific volume (p-coord)
-C     tFld       :: Potential temp.
-C     sFld       :: Salinity
 C     dPhiHydX,Y :: Gradient (X & Y directions) of Hyd. Potential
 C     myTime :: Current time
 C     myIter :: Current iteration number
@@ -42,8 +40,6 @@ C     myThid :: Instance number for this call of the routine.
       INTEGER k, bi,bj, iMin,iMax, jMin,jMax
       _RL phiHydC(1-OLx:sNx+OLx,1-OLy:sNy+OLy)
       _RL alphRho(1-OLx:sNx+OLx,1-OLy:sNy+OLy)
-      _RL tFld(1-OLx:sNx+OLx,1-OLy:sNy+OLy,Nr,nSx,nSy)
-      _RL sFld(1-OLx:sNx+OLx,1-OLy:sNy+OLy,Nr,nSx,nSy)
       _RL dPhiHydX(1-OLx:sNx+OLx,1-OLy:sNy+OLy)
       _RL dPhiHydY(1-OLx:sNx+OLx,1-OLy:sNy+OLy)
       _RL myTime

--- a/model/src/calc_phi_hyd.F
+++ b/model/src/calc_phi_hyd.F
@@ -9,7 +9,6 @@ C     !ROUTINE: CALC_PHI_HYD
 C     !INTERFACE:
       SUBROUTINE CALC_PHI_HYD(
      I                         bi, bj, iMin, iMax, jMin, jMax, k,
-     I                         tFld, sFld,
      U                         phiHydF,
      O                         phiHydC, dPhiHydX, dPhiHydY,
      I                         myTime, myIter, myThid )
@@ -20,8 +19,6 @@ C     | o Integrate the hydrostatic relation to find the Hydros. |
 C     *==========================================================*
 C     |    Potential (ocean: Pressure/rho ; atmos = geopotential)
 C     | On entry:
-C     |   tFld,sFld     are the current thermodynamics quantities
-C     |                 (unchanged on exit)
 C     |   phiHydF(i,j) is the hydrostatic Potential anomaly
 C     |                at middle between tracer points k-1,k
 C     | On exit:
@@ -53,8 +50,6 @@ C     !INPUT/OUTPUT PARAMETERS:
 C     == Routine arguments ==
 C     bi, bj, k  :: tile and level indices
 C     iMin,iMax,jMin,jMax :: computational domain
-C     tFld       :: potential temperature
-C     sFld       :: salinity
 C     phiHydF    :: hydrostatic potential anomaly at middle between
 C                   2 centers (entry: Interf_k ; output: Interf_k+1)
 C     phiHydC    :: hydrostatic potential anomaly at cell center
@@ -63,8 +58,6 @@ C     myTime     :: current time
 C     myIter     :: current iteration number
 C     myThid     :: thread number for this instance of the routine.
       INTEGER bi,bj,iMin,iMax,jMin,jMax,k
-      _RL tFld(1-OLx:sNx+OLx,1-OLy:sNy+OLy,Nr,nSx,nSy)
-      _RL sFld(1-OLx:sNx+OLx,1-OLy:sNy+OLy,Nr,nSx,nSy)
       _RL phiHydF(1-OLx:sNx+OLx,1-OLy:sNy+OLy)
       _RL phiHydC(1-OLx:sNx+OLx,1-OLy:sNy+OLy)
       _RL dPhiHydX(1-OLx:sNx+OLx,1-OLy:sNy+OLy)
@@ -154,15 +147,15 @@ CADJ GENERAL
 C---    Calculate density
 #ifdef ALLOW_AUTODIFF_TAMC
           kkey = (ikey-1)*Nr + k
-CADJ STORE tFld (:,:,k,bi,bj) = comlev1_bibj_k, key=kkey, byte=isbyte,
+CADJ STORE theta(:,:,k,bi,bj) = comlev1_bibj_k, key=kkey, byte=isbyte,
 CADJ &     kind = isbyte
-CADJ STORE sFld (:,:,k,bi,bj) = comlev1_bibj_k, key=kkey, byte=isbyte,
+CADJ STORE salt (:,:,k,bi,bj) = comlev1_bibj_k, key=kkey, byte=isbyte,
 CADJ &     kind = isbyte
 #endif /* ALLOW_AUTODIFF_TAMC */
           CALL FIND_RHO_2D(
      I              iMin, iMax, jMin, jMax, k,
-     I              tFld(1-OLx,1-OLy,k,bi,bj),
-     I              sFld(1-OLx,1-OLy,k,bi,bj),
+     I              theta(1-OLx,1-OLy,k,bi,bj),
+     I              salt(1-OLx,1-OLy,k,bi,bj),
      O              alphaRho,
      I              k, bi, bj, myThid )
         ELSE
@@ -316,15 +309,15 @@ CADJ GENERAL
 C--     Calculate density
 #ifdef ALLOW_AUTODIFF_TAMC
           kkey = (ikey-1)*Nr + k
-CADJ STORE tFld (:,:,k,bi,bj) = comlev1_bibj_k, key=kkey, byte=isbyte,
+CADJ STORE theta(:,:,k,bi,bj) = comlev1_bibj_k, key=kkey, byte=isbyte,
 CADJ &     kind = isbyte
-CADJ STORE sFld (:,:,k,bi,bj) = comlev1_bibj_k, key=kkey, byte=isbyte,
+CADJ STORE salt (:,:,k,bi,bj) = comlev1_bibj_k, key=kkey, byte=isbyte,
 CADJ &     kind = isbyte
 #endif /* ALLOW_AUTODIFF_TAMC */
           CALL FIND_RHO_2D(
      I              iMin, iMax, jMin, jMax, k,
-     I              tFld(1-OLx,1-OLy,k,bi,bj),
-     I              sFld(1-OLx,1-OLy,k,bi,bj),
+     I              theta(1-OLx,1-OLy,k,bi,bj),
+     I              salt(1-OLx,1-OLy,k,bi,bj),
      O              alphaRho,
      I              k, bi, bj, myThid )
 #ifdef ALLOW_AUTODIFF_TAMC
@@ -441,8 +434,8 @@ C-      horizontally uniform (tRef) reference state
           ENDIF
           DO j=jMin,jMax
            DO i=iMin,iMax
-            alphaRho(i,j) = ( tFld(i,j,k,bi,bj)
-     &                        *( sFld(i,j,k,bi,bj)*atm_Rq + oneRL )
+            alphaRho(i,j) = ( theta(i,j,k,bi,bj)
+     &                        *( salt(i,j,k,bi,bj)*atm_Rq + oneRL )
      &                      - thetaRef )*maskC(i,j,k,bi,bj)
            ENDDO
           ENDDO
@@ -621,7 +614,7 @@ C--   r-coordinate and r*-coordinate cases:
        IF ( momPressureForcing ) THEN
         CALL CALC_GRAD_PHI_HYD(
      I                         k, bi, bj, iMin,iMax, jMin,jMax,
-     I                         phiHydC, alphaRho, tFld, sFld,
+     I                         phiHydC, alphaRho,
      O                         dPhiHydX, dPhiHydY,
      I                         myTime, myIter, myThid)
        ENDIF
@@ -657,7 +650,7 @@ C       = Top atmosphere height (Atmos, P-coord.)
       IF (useDiagPhiRlow) THEN
         CALL DIAGS_PHI_RLOW(
      I                      k, bi, bj, iMin,iMax, jMin,jMax,
-     I                      phiHydF, phiHydC, alphaRho, tFld, sFld,
+     I                      phiHydF, phiHydC, alphaRho,
      I                      myTime, myIter, myThid)
       ENDIF
 

--- a/model/src/diags_phi_rlow.F
+++ b/model/src/diags_phi_rlow.F
@@ -5,7 +5,7 @@ C     !ROUTINE: DIAGS_PHI_RLOW
 C     !INTERFACE:
       SUBROUTINE DIAGS_PHI_RLOW(
      I                       k, bi, bj, iMin,iMax, jMin,jMax,
-     I                       phiHydF, phiHydC, alphRho, tFld, sFld,
+     I                       phiHydF, phiHydC, alphRho,
      I                       myTime, myIter, myThid)
 C     !DESCRIPTION: \bv
 C     *==========================================================*
@@ -36,8 +36,6 @@ C                   2 centers k & k+1 (interface k+1)
 C     phiHydC    :: hydrostatic potential anomaly at cell center
 C                  (atmos: =Geopotential ; ocean-z: =Pressure/rho)
 C     alphRho    :: Density (z-coord) or specific volume (p-coord)
-C     tFld       :: Potential temp.
-C     sFld       :: Salinity
 C     myTime     :: Current time
 C     myIter     :: Current iteration number
 C     myThid     :: my Thread Id number
@@ -45,8 +43,6 @@ C     myThid     :: my Thread Id number
       _RL phiHydF(1-OLx:sNx+OLx,1-OLy:sNy+OLy)
       _RL phiHydC(1-OLx:sNx+OLx,1-OLy:sNy+OLy)
       _RL alphRho(1-OLx:sNx+OLx,1-OLy:sNy+OLy)
-      _RL tFld(1-OLx:sNx+OLx,1-OLy:sNy+OLy,Nr,nSx,nSy)
-      _RL sFld(1-OLx:sNx+OLx,1-OLy:sNy+OLy,Nr,nSx,nSy)
       _RL myTime
       INTEGER myIter, myThid
 

--- a/model/src/dynamics.F
+++ b/model/src/dynamics.F
@@ -477,7 +477,6 @@ CADJ &     = comlev1_bibj_k, key=kkey, byte=isbyte
 C--      Integrate hydrostatic balance for phiHyd with BC of phiHyd(z=0)=0
          CALL CALC_PHI_HYD(
      I        bi,bj,iMin,iMax,jMin,jMax,k,
-     I        theta, salt,
      U        phiHydF,
      O        phiHydC, dPhiHydX, dPhiHydY,
      I        myTime, myIter, myThid )

--- a/model/src/ini_pressure.F
+++ b/model/src/ini_pressure.F
@@ -110,7 +110,6 @@ C     for each level save old pressure and compute new pressure
             ENDDO
             CALL CALC_PHI_HYD(
      I           bi, bj, iMin, iMax, jMin, jMax, k,
-     I           theta, salt,
      U           phiHydF,
      O           phiHydC, dPhiHydX, dPhiHydY,
      I           startTime, -1, myThid )


### PR DESCRIPTION
- remove tFld,sFld from argument list of S/R CALC_GRAD_PHI_HYD
  and DIAGS_PHI_RLOW (not used at all anymore).
- remove tFld,sFld from argument list of S/R CALC_PHI_HYD and use
  instead theta & salt (directly available from common block in DYNARS.h)

## What changes does this PR introduce?
cleaning ; might help for OpenAD preformance, see:
 http://mailman.mitgcm.org/pipermail/mitgcm-devel/2019-March/007062.html

## What is the current behaviour? 
unused arguments or variables already available from common block

## What is the new behaviour 
argument tFld & sFld removed.

## Does this PR introduce a breaking change? 
no changes (pass all TAF adjoint test experiments)

## Suggested addition to `tag-index`
o model/src:
  - remove argument tFld & dFld from S/R CALC_PHI_HYD and from 2 related S/R