### PR TITLE
obcs_init_fixed.F added to NOOPTFILES as a comment

### DIFF
--- a/tools/build_options/linux_amd64_ifort+mpi_ice_nas
+++ b/tools/build_options/linux_amd64_ifort+mpi_ice_nas
@@ -36,6 +36,7 @@ FFLAGS="$FFLAGS -W0 -WB"
 if test "x$IEEE" = x ; then     #- with optimisation:
     FOPTIM='-O2 -ipo -fp-model precise -align -axCORE-AVX2 -xSSE4.2 -traceback -ftz'
     NOOPTFILES='seaice_growth.F calc_oce_mxlayer.F fizhi_lsm.F fizhi_clockstuff.F ini_parms.F'
+#   NOOPTFILES='seaice_growth.F calc_oce_mxlayer.F fizhi_lsm.F fizhi_clockstuff.F ini_parms.F obcs_init_fixed.F'
 else
   if test "x$DEVEL" = x ; then  #- no optimisation + IEEE :
     FOPTIM='-O0 -noalign'


### PR DESCRIPTION
I have run across a specific MITgcm configuration that requires that
obcs_init_fixed.F be added to linux_amd64_ifort+mpi_ice_nas NOOPTFILES in
order to integrate without segmentation fault on pleiades.

## What changes does this PR introduce?
a comment to linux_amd64_ifort+mpi_ice_nas


## What is the current behaviour? 
under specific compiler/environment options, obcs_init_fixed.F can cause segfault


## What is the new behaviour 
suggested addition to NOOPTFILES is added as a comment, so no change in behavior


## Does this PR introduce a breaking change? 
no

## Other information:


## Suggested addition to `tag-index`
obcs_init_fixed.F added to NOOPTFILES as a comment