### PR TITLE
Add setting OpenAD environment in login profile

### DIFF
--- a/tools/ci/docker/centos/Dockerfile
+++ b/tools/ci/docker/centos/Dockerfile
@@ -7,3 +7,5 @@ RUN yum -y groupinstall "Development Tools"
 RUN cd /root; wget http://www.mcs.anl.gov/%7Eutke/OpenAD_tars/493/OpenAD_2014-03-15.tgz; tar -xzvf OpenAD_2014-03-15.tgz
 COPY pfile /root/pfile
 RUN cd /root/OpenAD; patch openadConfig.py ../pfile; pwd ; export PATH=".":$PATH; source setenv.sh; make
+RUN cd /root/OpenAD; export PATH=".:"${PATH}; ./tools/setenv/setenv.py --shell=sh > setenv.tmp
+RUN cd /root/OpenAD; cp setenv.tmp  /etc/profile.d/openad.sh


### PR DESCRIPTION
## What changes does this PR introduce?
Make Travis updates for OpenAD possible


## What is the current behaviour? 
Adding OpenAD in Travis is very awkward


## What is the new behaviour 
Adding OpenAD in Travis is easier

## Does this PR introduce a breaking change? 
No


## Other information:


## Suggested addition to `tag-index`
o Updated centos Dockerfile that is automatically built in docker hub.