### PR TITLE
Adjointable seaice thermodynamics

### DIFF
--- a/pkg/seaice/seaice_growth_adjointable.F
+++ b/pkg/seaice/seaice_growth_adjointable.F
@@ -1,17 +1,29 @@
-C     $Header: /home/ubuntu/mnt/e9_copy/MITgcm_contrib/ifenty/Fenty_Thermo_Code_Updates/code_updates_20130122/seaice_growth_if.F,v 1.1 2013/01/22 21:53:56 ifenty Exp $
-C     $Name:  $
+C SEAICE GROWTH REBORN v02 2015/01/15
 
 #include "SEAICE_OPTIONS.h"
+#ifdef ALLOW_EXF
+# include "EXF_OPTIONS.h"
+#endif
+#ifdef ALLOW_SALT_PLUME
+# include "SALT_PLUME_OPTIONS.h"
+#endif
+#ifdef ALLOW_AUTODIFF
+# include "AUTODIFF_OPTIONS.h"
+#endif
 
-C     StartOfInterface
-      SUBROUTINE SEAICE_GROWTH_IF( myTime, myIter, myThid )
-C     /==========================================================\
-C     | SUBROUTINE seaice_growth_if                              |
-C     | o Updata ice thickness and snow depth                    |
-C     |==========================================================|
-C     \==========================================================/
+CBOP
+C     !ROUTINE: SEAICE_GROWTH
+C     !INTERFACE:
+      SUBROUTINE SEAICE_GROWTH( myTime, myIter, myThid )
+C     !DESCRIPTION: \bv
+C     *==========================================================*
+C     | SUBROUTINE seaice_growth
+C     | o rebirth of seaice_growth_if
+C     *==========================================================*
+C     \ev
+
+C     !USES:
       IMPLICIT NONE
-
 C     === Global variables ===
 #include "SIZE.h"
 #include "EEPARAMS.h"
@@ -19,12 +31,13 @@ C     === Global variables ===
 #include "DYNVARS.h"
 #include "GRID.h"
 #include "FFIELDS.h"
+#include "SEAICE_SIZE.h"
 #include "SEAICE_PARAMS.h"
 #include "SEAICE.h"
+#include "SEAICE_TRACER.h"
 #ifdef ALLOW_EXF
-# include "EXF_OPTIONS.h"
-# include "EXF_FIELDS.h"
 # include "EXF_PARAM.h"
+# include "EXF_FIELDS.h"
 #endif
 #ifdef ALLOW_SALT_PLUME
 # include "SALT_PLUME.h"
@@ -32,111 +45,152 @@ C     === Global variables ===
 #ifdef ALLOW_AUTODIFF_TAMC
 # include "tamc.h"
 #endif
+
+C     !INPUT/OUTPUT PARAMETERS:
 C     === Routine arguments ===
-C     myTime - Simulation time
-C     myIter - Simulation timestep number
-C     myThid - Thread no. that called this routine.
+C     myTime :: Simulation time
+C     myIter :: Simulation timestep number
+C     myThid :: Thread no. that called this routine.
       _RL myTime
       INTEGER myIter, myThid
-C     EndOfInterface(global-font-lock-mode 1)
+CEOP
 
+#if (defined ALLOW_EXF) && (defined ALLOW_ATM_TEMP)
+C     !FUNCTIONS:
+#ifdef ALLOW_DIAGNOSTICS
+      LOGICAL  DIAGNOSTICS_IS_ON
+      EXTERNAL DIAGNOSTICS_IS_ON
+#endif
+
+C     !LOCAL VARIABLES:
 C     === Local variables ===
-C     i,j,bi,bj - Loop counters
+C
+C unit/sign convention:
 
+
+C HEFF is effective Hice thickness (m3/m2)
+C HSNOW is Heffective snow thickness (m3/m2)
+C HSALT is Heffective salt content (g/m2)
+C AREA is the seaice cover fraction (0<=AREA<=1)
+
+
+
+C     i,j,bi,bj :: Loop counters
       INTEGER i, j, bi, bj
 C     number of surface interface layer
       INTEGER kSurface
-
+C     IT :: ice thickness category index (MULTICATEGORIES and ITD code)
+      INTEGER IT
+C     msgBuf      :: Informational/error message buffer
+#ifdef ALLOW_BALANCE_FLUXES
+      CHARACTER*(MAX_LEN_MBUF) msgBuf
+#elif (defined (SEAICE_DEBUG))
+      CHARACTER*(MAX_LEN_MBUF) msgBuf
+      CHARACTER*12 msgBufForm
+#endif
 C     constants
-      _RL TBC, SDF, ICE2SNOW,TMELT
-      _RL STANTON_NUMBER, USTAR_BASE
+      _RL tempFrz, ICE2SNOW, SNOW2ICE, surf_theta
+      _RL QI, QS, recip_QI
+      _RL RHOSW
+      _RL lhSublim
 
-#ifdef ALLOW_SEAICE_FLOODING
-      _RL hDraft, hFlood
-#endif /* ALLOW_SEAICE_FLOODING */
+C conversion factors to go from Q (W/m2) to HEFF (ice meters)
+      _RL convertQ2HI, convertHI2Q
+C conversion factors to go from precip (m/s) unit to HEFF (ice meters)
+      _RL convertPRECIP2HI, convertHI2PRECIP
 
-C     QSWO   - short wave heat flux over ocean (W/m^2)
-C     QSWI   - short wave heat flux under ice  (W/m^2)
-
-      _RL QSWO                         (1:sNx,1:sNy)
-      _RL QSWI                         (1:sNx,1:sNy)
-
-C     The shortwave heat flux in the open water fraction of the 
-C     grid cell converging within the uppermost ocean grid cell (W/m^2)
-      _RL QSWO_IN_FIRST_LAYER          (1:sNx,1:sNy)
-
-C     (1 - QSWO_IN_FIRST_LAYER) (W/m^2)
-      _RL QSWO_BELOW_FIRST_LAYER        (1:sNx,1:sNy)
-
-C     The total shortwave heat flux (into open water and through the ice)
-C     converging within the uppermost ocean grid cell (W/m^2)
-      _RL QSW_absorb_in_first_layer     (1:sNx,1:sNy)
-
-C     ( 1 - QSW_absorb_in_first_layer)  (W/m^2) 
-      _RL QSW_absorb_below_first_layer  (1:sNx,1:sNy)
-
-C     The actual ice thickness (i.e., mean ice thickness / ice concentration) (m) 
-      _RL HICE_ACTUAL                   (1:sNx,1:sNy)
-
-C     The actual snow thickness (i.e., mean snow thickness / ice concentration) (m) 
-      _RL HSNOW_ACTUAL                  (1:sNx,1:sNy)
-
-C     wind speed (m/s)
-      _RL UG                            (1:sNx,1:sNy)
-
+      _RL heffTooHeavy
+C     wind speed square
       _RL SPEED_SQ
-      _RL RHOFW,CPW,LI,QI,QS,RHOSW
 
-C     Helper Variables for snow flooding
-      _RL EnergyToMeltSnowAndIce        (1:sNx,1:sNy)
-      _RL EnergyToMeltSnowAndIce2       (1:sNx,1:sNy)
-      _RL FL_C1,FL_C2,FL_C3,FL_C4,deltaHS,deltaHI
+C     Regularization values squared
+      _RL area_reg_sq, hice_reg_sq
 
+C     Helper variables: reciprocal of some constants
+      _RL recip_multDim
 
-#ifdef SEAICE_USE_ORIGINAL_HEAT_FLUX
-      _RL GAMMA
+#ifndef SEAICE_ITD
+C     facilitate multi-category snow implementation
+      _RL pFac, pFacSnow
 #endif
 
-C     Factor by which we increase the u* (friction velocity) when ice is not 
-C     present (dimensionless)
-      _RL MixedLayerTurbulenceFactor
+C     temporary variables available for the various computations
+      _RL tmpscal0, tmpscal1, tmpscal2, tmpscal3, tmpscal4
+
+#ifdef ALLOW_SITRACER
+      INTEGER iTr
+#ifdef ALLOW_DIAGNOSTICS
+      CHARACTER*8   diagName
+#endif
+
+
+#endif /* ALLOW_SITRACER */
+#ifdef ALLOW_AUTODIFF_TAMC
+      INTEGER ilockey
+#endif
+
+C==   local arrays ==
+C--   TmixLoc        :: ocean surface/mixed-layer temperature (in K)
+      _RL TmixLoc       (1:sNx,1:sNy)
+
+#ifndef SEAICE_ITD
+C     actual ice thickness (with upper and lower limit)
+      _RL hiceActual          (1:sNx,1:sNy)
+C     actual snow thickness
+      _RL hsnowActual         (1:sNx,1:sNy)
+#endif
+C     actual ice thickness (with lower limit only) Reciprocal
+      _RL recip_hiceActual    (1:sNx,1:sNy)
+
+C     AREA_PRE :: hold sea-ice fraction field before any seaice-thermo update
+      _RL AREApreTH           (1:sNx,1:sNy)
+      _RL HEFFpreTH           (1:sNx,1:sNy)
+      _RL HSNWpreTH           (1:sNx,1:sNy)
+
+C     wind speed
+      _RL UG                  (1:sNx,1:sNy)
+
+C     temporary variables available for the various computations
+      _RL tmparr1             (1:sNx,1:sNy)
+
+      _RL ticeInMult          (1:sNx,1:sNy,nITD)
+      _RL ticeOutMult         (1:sNx,1:sNy,nITD)
+      _RL hiceActualMult      (1:sNx,1:sNy,nITD)
+      _RL hsnowActualMult     (1:sNx,1:sNy,nITD)
+
+      _RL F_io_net_mult     (1:sNx,1:sNy,nITD)
+      _RL F_ia_net_mult     (1:sNx,1:sNy,nITD)
+      _RL F_ia_mult     (1:sNx,1:sNy,nITD)
+      _RL QSWI_mult     (1:sNx,1:sNy,nITD)
+      _RL FWsublim_mult     (1:sNx,1:sNy,nITD)
+
+#ifdef ALLOW_DIAGNOSTICS
+C     Helper variables for diagnostics
+      _RL DIAGarrayA    (1:sNx,1:sNy)
+      _RL DIAGarrayB    (1:sNx,1:sNy)
+      _RL DIAGarrayC    (1:sNx,1:sNy)
+      _RL DIAGarrayD    (1:sNx,1:sNy)
+#endif /* ALLOW_DIAGNOSTICS */
+
+
+      _RL QSWO_BELOW_FIRST_LAYER (1:sNx,1:sNy)
+      _RL QSWO_IN_FIRST_LAYER (1:sNx,1:sNy)
+      _RL QSWO (1:sNx,1:sNy)
+      _RL QSWI (1:sNx,1:sNy)
 
 C     Sea ice growth rates (m/s)
+      _RL ActualNewTotalVolumeChange     (1:sNx,1:sNy)
+      _RL ActualNewTotalSnowMelt     (1:sNx,1:sNy)
+
       _RL NetExistingIceGrowthRate      (1:sNx,1:sNy)
       _RL IceGrowthRateUnderExistingIce (1:sNx,1:sNy)
       _RL IceGrowthRateFromSurface      (1:sNx,1:sNy)
       _RL IceGrowthRateOpenWater        (1:sNx,1:sNy)
       _RL IceGrowthRateMixedLayer       (1:sNx,1:sNy)
 
-#ifdef ALLOW_SALT_PLUME
-c     d(HEFF)/dt from heat fluxes in the open water fraction of the grid cell
-      _RL IceGrowthRateInLeads          (1:sNx,1:sNy)
-
-c     The fraction of salt released in leads by new ice production there
-c     which is to be sent to the salt plume package
-      _RL leadPlumeFraction             (1:sNx,1:sNy)
-#endif
-
-c     The minimum value of HEFF to be divided by during the calculation of d(AREA)/dt
-      _RL HEFF_MIN
- 
-c      Variables for debugging (predicted temperature change from various sources)
-      _RL PredTempChange                (1:sNx,1:sNy)
-      _RL PredTempChangeFromQSW         (1:sNx,1:sNy)
-      _RL PredTempChangeFromOA_MQNET    (1:sNx,1:sNy)
-      _RL PredTempChangeFromFIA         (1:sNx,1:sNy)
-      _RL PredTempChangeFromNewIceVol   (1:sNx,1:sNy)
-      _RL PredTempChangeFromF_IA_NET    (1:sNx,1:sNy)
-      _RL PredTempChangeFromF_IO_NET    (1:sNx,1:sNy)
-
-      _RL ExpectedIceVolumeChange       (1:sNx,1:sNy)
-      _RL ExpectedSnowVolumeChange      (1:sNx,1:sNy)
-      _RL ActualNewTotalVolumeChange    (1:sNx,1:sNy)
-      _RL ActualNewTotalSnowMelt        (1:sNx,1:sNy)
-
       _RL EnergyInNewTotalIceVolume     (1:sNx,1:sNy)
       _RL NetEnergyFluxOutOfOcean       (1:sNx,1:sNy)
-
+c
 C     The energy taken out of the ocean which is not converted
 C     to sea ice (Joules)
       _RL ResidualEnergyOutOfOcean      (1:sNx,1:sNy)
@@ -177,18 +231,12 @@ C     The freshwater contribution to (from) the ocean from melting (growing) ice
 C     S_a : d(AREA)/dt
       _RL S_a                           (1:sNx,1:sNy)
 
-C     S_a_from_IGROW : d(AREA)/dt [from ice growth rate from open water fluxes]
-      _RL S_a_from_IGROW                (1:sNx,1:sNy)
-
 C     S_h : d(HEFF)/dt
       _RL S_h                           (1:sNx,1:sNy)
 
 C     S_hsnow : d(HSNOW)/dt
       _RL S_hsnow                       (1:sNx,1:sNy)
 
-C     HSNOW_ORIG : The mean snow thickness before any accumulation, 
-C                  melt, or flooding (m)
-      _RL HSNOW_ORIG                    (1:sNx,1:sNy)
 
 C     F_ia  - sea ice/snow surface heat flux with atmosphere (W/m^2)
 C       F_ia > 0, heat loss to atmosphere
@@ -199,20 +247,20 @@ C     F_ia_net - the net heat flux divergence at the sea ice/snow surface
 C                including sea ice conductive fluxes and atmospheric fluxes (W/m^2)
 C       F_ia_net = 0, sea ice/snow surface energy balance condition met
 C                     upward conductive fluxes balance surface heat loss
-C       F_ia_net < 0, net heat flux convergence at ice/snow surface 
+C       F_ia_net < 0, net heat flux convergence at ice/snow surface
 C                     zero conductive fluxes and net atmospheric convergence
       _RL F_ia_net                      (1:sNx,1:sNy)
 
-C     F_ia_net - the net heat flux divergence at the sea ice/snow surface 
+C     F_ia_net - the net heat flux divergence at the sea ice/snow surface
 C                before snow is melted with any convergence (W/m^2)
-C        F_ia_net < 0, some snow, if present, will melt 
+C        F_ia_net < 0, some snow, if present, will melt
       _RL F_ia_net_before_snow          (1:sNx,1:sNy)
 
 C     F_io_net - the net upward conductive heat flux through the ice+snow system
 C                realized at the sea ice/snow surface
 C        F_io_net > 0, heat conducting upward from ice base --> basal thickening
-C        F_io_net = 0, no upward heat conduction 
-C                      ice/snow surface temperature > SEAICE_freeze)  
+C        F_io_net = 0, no upward heat conduction
+C                      ice/snow surface temperature > SEAICE_freeze)
       _RL F_io_net                      (1:sNx,1:sNy)
 
 C     F_ao  - heat flux from atmosphere to ocean (W/m^2)
@@ -221,973 +269,900 @@ C        F_ao > 0
 
 C     F_mi - heat flux from ocean to the ice (W/m^2)
       _RL F_mi                          (1:sNx,1:sNy)
- 
 
-c     The ocean temperature used for the calculation of turbulent ocean-ice heat fluxes
-      _RL surf_theta
+      _RL FWsublim                      (1:sNx,1:sNy)
 
-C     Helper variables for debugging
-      _RL FLUX_TO_DELTA_TEMP,ENERGY_TO_DELTA_TEMP
+C     S_a_from_IGROW : d(AREA)/dt [from ice growth rate from open water fluxes]
+      _RL S_a_IGROW                     (1:sNx,1:sNy)
 
-      if ( buoyancyRelation .eq. 'OCEANICP' ) then
-         kSurface        = Nr 
-      else
-         kSurface        = 1
-      endif
+C     S_a_from_IGROW : d(AREA)/dt [from ice growth rate from ocean-ice fluxes]
+      _RL S_a_IGRML                     (1:sNx,1:sNy)
 
-c    For debugging
-      FLUX_TO_DELTA_TEMP = SEAICE_deltaTtherm*
-     &            recip_Cp*recip_rhoConst * recip_drF(1)
+C     S_a_from_IGROW : d(AREA)/dt [from ice growth rate from ice-atm fluxes]
+      _RL S_a_IGRNE                     (1:sNx,1:sNy)
 
-      ENERGY_TO_DELTA_TEMP = recip_Cp*recip_rhoConst*recip_drF(1)
+C     Factor by which we increase the upper ocean friction velocity (u*) when
 
-C     TBC : The freezing point of seawater (deg C)
-      TBC          = SEAICE_freeze
+C     ice is absent in a grid cell  (dimensionless)
+      _RL MLTF                          (1:sNx,1:sNy)
 
-C     TMELT : The freezing point of fresh water (deg K)
-      TMELT = 273.15 _d 0 
+C---+----1----+----2----+----3----+----4----+----5----+----6----+----7-|--+----|
+
+C ===================================================================
+C =================PART 0: constants and initializations=============
+C ===================================================================
+
+      IF ( buoyancyRelation .EQ. 'OCEANICP' ) THEN
+       kSurface        = Nr
+      ELSE
+       kSurface        = 1
+      ENDIF
+
+C     avoid unnecessary divisions in loops
+      recip_multDim        = SEAICE_multDim
+      recip_multDim        = ONE / recip_multDim
+
+C     Cutoff for iceload
+      heffTooHeavy=drF(kSurface) / 5. _d 0
+
+C     RATIO OF SEA ICE DENSITY to SNOW DENSITY
+      ICE2SNOW     = SEAICE_rhoIce/SEAICE_rhoSnow
+      SNOW2ICE     = ONE / ICE2SNOW
+
+C  Heat Flux * QI = [W] [m^3/kg] [kg/J] = [m^3/s] or [m/s] per unit area
+      QI           = ONE/(SEAICE_rhoIce*SEAICE_lhFusion)
+C  Heat Flux * QS = [W] [m^3/kg] [kg/J] = [m^3/s] or [m/s] per unit area
+      QS           = ONE/(SEAICE_rhoSnow*SEAICE_lhFusion)
 
 c     A reference seawater density (kg m^-3)
       RHOSW = 1026. _d 0
+C     ICE LATENT HEAT CONSTANT
+      lhSublim = SEAICE_lhEvap + SEAICE_lhFusion
 
-c     Freshwater density (kg m^-3)
-      RHOFW = rhoConstFresh
+C     regularization constants
+      area_reg_sq = SEAICE_area_reg * SEAICE_area_reg
+      hice_reg_sq = SEAICE_hice_reg * SEAICE_hice_reg
 
-c     The Stanton number for the McPhee 
-c     ocean-ice heat flux parameterization (dimensionless)
-      STANTON_NUMBER = 0.0056 _d 0 
 
-c     USTAR_BASE : A typical friction velocity beneath sea 
-c                  ice for the McPhee heat flux parameterization (m/s)
-      USTAR_BASE = 0.0125 _d 0
-
-C     CPW : Seawater heat capacity   (J m^-3 K^-1)
-      CPW = 4010. _d 0
-
-c     Li : Ice latent heat of fusion (J kg^-1)
-      Li = 3.34 _d 5 
-
-c     Factors used to to map between energy fluxes and snow/ice melt or growth
-      QI = ONE/SEAICE_rhoIce/Li
-      QS = ONE/SEAICE_rhoSnow/Li
-
-c     Helper terms for snow flooding
-      FL_C2 = SEAICE_rhoIce/RHOSW
-      FL_C3 = (RHOSW-SEAICE_rhoIce)/SEAICE_rhoSnow
-      FL_C4 = SEAICE_rhoSnow/SEAICE_rhoIce
-
-#ifdef SEAICE_USE_ORIGINAL_HEAT_FLUX
-c     GAMMA is used to calculate ocean-ice heat fluxes from
-c     a user-specified flux timescale (SEAICE_gamma_t).  
-c     Originally, 3 days in seconds was suggested as useful.
-c     To keep this timescale up to date given advances in
-c     the parameterization, GAMMA is specified as follows, 
-c     
-      GAMMA =  10. _d 0/SEAICE_gamma_t
-
-c     n.b., changed from drF(1)/SEAICE_gamma_t to make 
-c     a more robust form in setups with a higher vertical resolution.
-#endif
-
+C---+----1----+----2----+----3----+----4----+----5----+----6----+----7-|--+----|
       DO bj=myByLo(myThid),myByHi(myThid)
-         DO bi=myBxLo(myThid),myBxHi(myThid)
-c     
+       DO bi=myBxLo(myThid),myBxHi(myThid)
+
 #ifdef ALLOW_AUTODIFF_TAMC
-            act1 = bi - myBxLo(myThid)
-            max1 = myBxHi(myThid) - myBxLo(myThid) + 1
-            act2 = bj - myByLo(myThid)
-            max2 = myByHi(myThid) - myByLo(myThid) + 1
-            act3 = myThid - 1
-            max3 = nTx*nTy
-            act4 = ikey_dynamics - 1
-            iicekey = (act1 + 1) + act2*max1
-     &           + act3*max1*max2
-     &           + act4*max1*max2*max3
-#endif /* ALLOW_AUTODIFF_TAMC */
-C     
-C     initialise a few fields
-C     
-#ifdef ALLOW_AUTODIFF_TAMC
-CADJ STORE area(:,:,bi,bj) = comlev1_bibj, 
-CADJ &                       key = iicekey, byte = isbyte
+        act1 = bi - myBxLo(myThid)
+        max1 = myBxHi(myThid) - myBxLo(myThid) + 1
+        act2 = bj - myByLo(myThid)
+        max2 = myByHi(myThid) - myByLo(myThid) + 1
+        act3 = myThid - 1
+        max3 = nTx*nTy
+        act4 = ikey_dynamics - 1
+        iicekey = (act1 + 1) + act2*max1
+     &                       + act3*max1*max2
+     &                       + act4*max1*max2*max3
 #endif /* ALLOW_AUTODIFF_TAMC */
 
-#ifdef SEAICE_SIMULATE_CONVERGENCE_IN_1D_MODEL
-c           simulate total convergence from dynamics
-            DO J=1,sNy
-               DO I=1,sNx
-                  IF (HEFF(I,J,bi,bj) .GT. ZERO) THEN
-                     AREA(I,J,bi,bj) = ONE
-                  ENDIF
-               ENDDO
-            ENDDO
+
+#ifdef ALLOW_AUTODIFF_TAMC
+CADJ STORE area = comlev1_bibj, key = iicekey, byte = isbyte
+CADJ STORE heff = comlev1_bibj, key = iicekey, byte = isbyte
+CADJ STORE hsnow = comlev1_bibj, key = iicekey, byte = isbyte
+CADJ STORE qnet = comlev1_bibj, key = iicekey, byte = isbyte
+CADJ STORE qsw = comlev1_bibj, key = iicekey, byte = isbyte
+CADJ STORE tices = comlev1_bibj, key = iicekey, byte = isbyte
 #endif
 
-#ifdef ALLOW_AUTODIFF_TAMC
-CADJ STORE area(:,:,bi,bj) = comlev1_bibj, 
-CADJ &                       key = iicekey, byte = isbyte
-CADJ STORE qnet(:,:,bi,bj) = comlev1_bibj, 
-CADJ &                       key = iicekey, byte = isbyte
-CADJ STORE qsw(:,:,bi,bj)  = comlev1_bibj, 
-CADJ &                       key = iicekey, byte = isbyte
-#endif /* ALLOW_AUTODIFF_TAMC */
-c
-            DO J=1,sNy
-               DO I=1,sNx
-c                 Bound area, heff, and hsnow 
-                  AREA(I,J,bi,bj) = MIN(ONE,AREA(I,J,bi,bj))
-                  AREA(I,J,bi,bj) = MAX(ZERO,AREA(I,J,bi,bj))
-                  HEFF(I,J,bi,bj) = MAX(ZERO, HEFF(I,J,bi,bj))
-                  HSNOW(I,J,bi,bj)  = MAX(ZERO, HSNOW(I,J,bi,bj))
+C array initializations
+C =====================
 
-c                 Sanity checks 
-                  IF (HEFF(I,J,bi,bj) .LE. ZERO .OR.
-     &                AREA(I,J,bi,bj) .LE. ZERO) THEN
-                    
-                    AREA(I,J,bi,bj)       = 0. _d 0
-                    HEFF(I,J,bi,bj)       = 0. _d 0
-                    HSNOW(I,J,bi,bj)      = 0. _d 0
-                  ENDIF
-               ENDDO
-            ENDDO
-
-
-            DO J=1,sNy
-               DO I=1,sNx
-                  F_ia_net                        (I,J) = 0. _d 0
-                  F_ia_net_before_snow            (I,J) = 0. _d 0
-                  F_io_net                        (I,J) = 0. _d 0
-
-                  F_ia                            (I,J) = 0. _d 0
-                  F_ao                            (I,J) = 0. _d 0
-                  F_mi                            (I,J) = 0. _d 0
-
-                  QSWO                            (I,J) = 0. _d 0
-                  QSWI                            (I,J) = 0. _d 0
-
-                  QSWO_BELOW_FIRST_LAYER          (I,J) = 0. _d 0
-                  QSWO_IN_FIRST_LAYER             (I,J) = 0. _d 0
-
-                  S_a                             (I,J) = 0. _d 0
-                  S_h                             (I,J) = 0. _d 0
-
-                  IceGrowthRateUnderExistingIce   (I,J) = 0. _d 0
-                  IceGrowthRateFromSurface        (I,J) = 0. _d 0
-                  NetExistingIceGrowthRate        (I,J) = 0. _d 0
-                  S_a_from_IGROW                  (I,J) = 0. _d 0
-
-                  PredTempChange                  (I,J) = 0. _d 0
-                  PredTempChangeFromQSW           (I,J) = 0. _d 0
-                  PredTempChangeFromOA_MQNET      (I,J) = 0. _d 0
-                  PredTempChangeFromFIA           (I,J) = 0. _d 0
-                  PredTempChangeFromF_IA_NET      (I,J) = 0. _d 0
-                  PredTempChangeFromF_IO_NET      (I,J) = 0. _d 0
-                  PredTempChangeFromNewIceVol     (I,J) = 0. _d 0
-
-                  IceGrowthRateOpenWater          (I,J) = 0. _d 0
-                  IceGrowthRateMixedLayer         (I,J) = 0. _d 0
-
-#ifdef ALLOW_SALT_PLUME
-                  IceGrowthRateInLeads            (I,J) = 0. _d 0
-                  leadPlumeFraction               (I,J) = 0. _d 0
-                  saltPlumeFlux             (I,J,bi,bj) = 0. _d 0
-#endif
-
-                  ExpectedIceVolumeChange         (I,J) = 0. _d 0
-                  ExpectedSnowVolumeChange        (I,J) = 0. _d 0
-                  ActualNewTotalVolumeChange      (I,J) = 0. _d 0
-                  ActualNewTotalSnowMelt          (I,J) = 0. _d 0
-
-                  EnergyInNewTotalIceVolume       (I,J) = 0. _d 0
-                  NetEnergyFluxOutOfOcean         (I,J) = 0. _d 0
-                  ResidualEnergyOutOfOcean          (I,J) = 0. _d 0
-                  QSW_absorb_in_first_layer       (I,J) = 0. _d 0
-                  QSW_absorb_below_first_layer    (I,J) = 0. _d 0
-
-                  SnowAccRateOverIce              (I,J) = 0. _d 0
-                  SnowAccOverIce                  (I,J) = 0. _d 0
-                  PrecipRateOverIceSurfaceToSea   (I,J) = 0. _d 0
-
-                  PotSnowMeltRateFromSurf         (I,J) = 0. _d 0
-                  PotSnowMeltFromSurf             (I,J) = 0. _d 0
-                  SnowMeltFromSurface             (I,J) = 0. _d 0
-                  SnowMeltRateFromSurface         (I,J) = 0. _d 0
-                  SurfHeatFluxConvergToSnowMelt   (I,J) = 0. _d 0
-
-                  FreshwaterContribFromSnowMelt   (I,J) = 0. _d 0
-                  FreshwaterContribFromIce        (I,J) = 0. _d 0
-
-c the post sea ice advection and diffusion ice state are in time level 1.  
-c move these to the time level 2 before thermo.  after this routine 
-c the updated ice state will be in time level 1 again. (except for snow 
-c which does not have 3 time levels for some reason) 
-                  HEFFNm1(I,J,bi,bj) = HEFF(I,J,bi,bj) 
-                  AREANm1(I,J,bi,bj) = AREA(I,J,bi,bj) 
-
-#ifdef SEAICE_SIMULATE_DIVERGENCE_IN_1D_MODEL
-c Sometimes it's nice to run a 1-D setup but how then to simulate
-c the effect of mechanical divergence?.  To simulate the effect of 
-c having regular lead openings, each time step remove a fraction
-c of the ice area while maintaining the actual thickness of ice
-c and snow.
-
-                  IF (AREANm1(I,J,bi,bj) .GT. ZERO) THEN
-                     HICE_ACTUAL(I,J)  = 
-     &                  HEFFNm1(I,J,bi,bj)/AREANm1(I,J,bi,bj)
-
-                     HSNOW_ACTUAL(I,J) = HSNOW(I,J,bi,bj)/
-     &                  AREANm1(I,J,bi,bj)
-
-c                    Removes about 1.2% of the concentration in 48 hours.
-                     AREANm1(I,J,bi,bj) = AREANm1(I,J,bi,bj)*0.99975 _d 0
-
-c                    Maintain the same snow and ice thickness
-                     HEFFNm1(I,J,bi,bj) = 
-     &                     HICE_ACTUAL(I,J)*AREANm1(I,J,bi,bj)
-
-                     HSNOW(I,J,bi,bj) = 
-     &                     HSNOW_ACTUAL(I,J)*AREANm1(I,J,bi,bj)
-
-                   ENDIF
-#endif            
-
-               ENDDO
-            ENDDO
-
-#ifdef ALLOW_AUTODIFF_TAMC
-CADJ STORE area(:,:,bi,bj)   = comlev1_bibj, 
-CADJ &                         key = iicekey, byte = isbyte
-CADJ STORE heff(:,:,bi,bj)   = comlev1_bibj, 
-CADJ &                         key = iicekey, byte = isbyte
-CADJ STORE hsnow(:,:,bi,bj)  = comlev1_bibj, 
-CADJ &                         key = iicekey, byte = isbyte
-CADJ STORE tice(:,:,bi,bj)   = comlev1_bibj, 
-CADJ &                         key = iicekey, byte = isbyte
-CADJ STORE precip(:,:,bi,bj) = comlev1_bibj, 
-CADJ &                         key = iicekey, byte = isbyte
-#endif /* ALLOW_AUTODIFF_TAMC */
-
-            DO J=1,sNy
-               DO I=1,sNx
-C WE HAVE TO BE CAREFUL HERE SINCE ADVECTION/DIFFUSION COULD HAVE 
-C MAKE EITHER (BUT NOT BOTH) HEFF OR AREA ZERO OR NEGATIVE 
-C HSNOW COULD ALSO BECOME NEGATIVE 
-                  HEFFNm1(I,J,bi,bj) = MAX(ZERO,HEFFNm1(I,J,bi,bj)) 
-                  HSNOW(I,J,bi,bj)   = MAX(ZERO,HSNOW(I,J,bi,bj)  ) 
-                  AREANm1(I,J,bi,bj) = MAX(ZERO,AREANm1(I,J,bi,bj)) 
-cif this is hack to prevent negative precip.  somehow negative precips  
-cif escapes my exf_checkrange hack
-cph-checkthis
-                  IF (PRECIP(I,J,bi,bj) .LT. ZERO) THEN 
-                     PRECIP(I,J,bi,bj) = ZERO 
-                  ENDIF 
-               ENDDO
-            ENDDO
-            
-#ifdef ALLOW_AUTODIFF_TAMC
-CADJ STORE area(:,:,bi,bj)   = comlev1_bibj, 
-CADJ &                         key = iicekey, byte = isbyte
-CADJ STORE heff(:,:,bi,bj)   = comlev1_bibj, 
-CADJ &                         key = iicekey, byte = isbyte
-CADJ STORE hsnow(:,:,bi,bj)  = comlev1_bibj, 
-CADJ &                         key = iicekey, byte = isbyte
-CADJ STORE precip(:,:,bi,bj) = comlev1_bibj, 
-CADJ &                         key = iicekey, byte = isbyte
-#endif
-            DO J=1,sNy
-               DO I=1,sNx
-
-                  IF (HEFFNm1(I,J,bi,bj) .LE. ZERO) THEN 
-                      AREANm1(I,J,bi,bj) = 0. _d 0
-                      HSNOW(I,J,bi,bj)   = 0. _d 0
-                  ENDIF 
- 
-                  IF (AREANm1(I,J,bi,bj) .LE. ZERO) THEN 
-                     HEFFNm1(I,J,bi,bj)  = 0. _d 0
-                     HSNOW(I,J,bi,bj)    = 0. _d 0
-                  ENDIF 
- 
-C PROCEED ONLY IF WE ARE CERTAIN TO HAVE ICE (AREA > 0) 
-
-                  IF (AREANm1(I,J,bi,bj) .GT. ZERO) THEN
-                     HICE_ACTUAL(I,J)  = 
-     &                  HEFFNm1(I,J,bi,bj)/AREANm1(I,J,bi,bj)
-
-                     HSNOW_ACTUAL(I,J) = HSNOW(I,J,bi,bj)/
-     &                  AREANm1(I,J,bi,bj)
-
-c                   ACCUMULATE SNOW
-c                   Is the ice/surface below freezing or at the freezing 
-c                   point (melting).  If it is freezing the precip is 
-c                   felt as snow and will accumulate over the ice. Else,
-c                   precip makes its way, like all things in time, to the sea.
-                    IF (TICE(I,J,bi,bj) .LT. TMELT) THEN
-c                     Snow falls onto freezing surface remaining as snow
-                      SnowAccRateOverIce(I,J) = 
-     &                  PRECIP(I,J,bi,bj)*RHOFW/SEAICE_rhoSnow
-
-c                     None of the precipitation falls into the sea 
-                      PrecipRateOverIceSurfaceToSea(I,J) = 0. _d 0
-  
-                    ELSE 
-c                     The snow melts on impact is is considered 
-c                     nothing more than rain.  Since meltponds are
-c                     not explicitly represented,this rain runs
-c                     immediately into the sea
-
-                      SnowAccRateOverIce(I,J) = 0. _d 0
-C                     The rate of rainfall over melting ice.
-                      PrecipRateOverIceSurfaceToSea(I,J)=
-     &                  PRECIP(I,J,bi,bj)
-                   ENDIF
-
-c                  In m of mean snow thickness.
-                   SnowAccOverIce(I,J) = 
-     &                  SnowAccRateOverIce(I,J)
-     &                  *SEAICE_deltaTtherm*AreaNm1(I,J,bi,bj)
-
-                ELSE
-                   HEFFNm1(I,J,bi,bj) = 0. _d 0
-                   HICE_ACTUAL(I,J)   = 0. _d 0
-                   HSNOW_ACTUAL(I,J)  = 0. _d 0
-                   HSNOW(I,J,bi,bj)   = 0. _d 0
-                ENDIF
-                HSNOW_ORIG(I,J) = HSNOW(I,J,bi,bj)
-             ENDDO
-          ENDDO
-            
-C     FIND ATM. WIND SPEED
         DO J=1,sNy
          DO I=1,sNx
-C         copy the wind speed computed in exf_wind.F to UG
-          UG(I,J) = MAX(SEAICE_EPS,wspeed(I,J,bi,bj))
+
+C NEW VARIABLE NAMES
+          NetExistingIceGrowthRate(I,J) = 0.0 _d 0
+          IceGrowthRateOpenWater(I,J)   = 0.0 _d 0
+          IceGrowthRateFromSurface(I,J) = 0.0 _d 0
+          IceGrowthRateMixedLayer(I,J)  = 0.0 _d 0
+
+          EnergyInNewTotalIceVolume(I,J) = 0.0 _d 0
+          NetEnergyFluxOutOfOcean(I,J)   = 0.0 _d 0
+          ResidualEnergyOutOfOcean(I,J)  = 0.0 _d 0
+
+          PrecipRateOverIceSurfaceToSea(I,J) = 0.0 _d 0
+
+          DO IT=1,SEAICE_multDim
+            ticeInMult(I,J,IT)            = 0.0 _d 0
+            ticeOutMult(I,J,IT)           = 0.0 _d 0
+
+            F_io_net_mult(I,J,IT)  = 0.0 _d 0
+            F_ia_net_mult(I,J,IT)  = 0.0 _d 0
+            F_ia_mult(I,J,IT)      = 0.0 _d 0
+
+            QSWI_mult(I,J,IT)      = 0.0 _d 0
+            FWsublim_mult(I,J,IT)  = 0.0 _d 0
+          ENDDO
+
+          F_io_net(I,J) = 0.0 _d 0
+          F_ia_net(I,J) = 0.0 _d 0
+          F_ia(I,J)     = 0.0 _d 0
+
+          QSWI(I,J) = 0.0 _d 0
+          FWsublim(I,J) = 0.0 _d 0
+
+          QSWO_BELOW_FIRST_LAYER (I,J) = 0.0 _d 0
+          QSWO_IN_FIRST_LAYER (I,J) = 0.0 _d 0
+          QSWO(I,J) = 0.0 _d 0
+
+          ActualNewTotalVolumeChange(I,J) = 0.0 _d 0
+          ActualNewTotalSnowMelt(I,J)     = 0.0 _d 0
+
+          SnowAccOverIce(I,J) = 0.0 _d 0
+          SnowAccRateOverIce(I,J) = 0.0 _d 0
+
+          PotSnowMeltRateFromSurf(I,J)    = 0.0 _d 0
+          PotSnowMeltFromSurf(I,J)        = 0.0 _d 0
+          SnowMeltRateFromSurface(I,J)    = 0.0 _d 0
+          SurfHeatFluxConvergToSnowMelt(I,J) = 0.0 _d 0
+          SnowMeltFromSurface(I,J)       = 0.0 _d 0
+
+          FreshwaterContribFromSnowMelt(I,J) = 0.0 _d 0
+          FreshwaterContribFromIce(I,J) = 0.0 _d 0
+
+          S_a(I,J)       = 0.0 _d 0
+          S_a_IGROW(I,J) = 0.0 _d 0
+          S_a_IGRML(I,J) = 0.0 _d 0
+          S_a_IGRNE(I,J) = 0.0 _d 0
+
+          S_h(I,J)       = 0.0 _d 0
+          S_hsnow(I,J)   = 0.0 _d 0
+
+          MLTF(I,J)      = 0.0 _d 0
          ENDDO
         ENDDO
 
+#if (defined (ALLOW_MEAN_SFLUX_COST_CONTRIBUTION) || defined (ALLOW_SSH_GLOBMEAN_COST_CONTRIBUTION))
+        DO J=1-oLy,sNy+oLy
+         DO I=1-oLx,sNx+oLx
+          frWtrAtm(I,J,bi,bj)        = 0.0 _d 0
+         ENDDO
+        ENDDO
+#endif
+
+C =====================================================================
+C  PART 1: Store ice and snow state on onset + regularize actual
+C               snow and ice thickness
+C =====================================================================
+
+        DO J=1,sNy
+         DO I=1,sNx
+
+          HEFF(I,J,bi,bj) = MAX(ZERO, HEFF(I,J,bi,bj))
+          AREA(I,J,bi,bj) = MAX(ZERO, AREA(I,J,bi,bj))
+
+          IF (HEFF(I,J,bi,bj) .LE. ZERO) then
+             AREA(I,J, bi,bj)  = ZERO
+             HSNOW(I,J, bi,bj) = ZERO
+          ELSEIF (AREA(I,J,bi,bj) .LE. ZERO) then
+             HEFF(I,J,bi,bj)  = ZERO
+             HSNOW(I,J,bi,bj) = ZERO
+          ENDIF
+
+          HEFFpreTH(I,J) = HEFF(I,J,bi,bj)
+          HSNWpreTH(I,J) = HSNOW(I,J,bi,bj)
+          AREApreTH(I,J) = AREA(I,J,bi,bj)
+
+#ifdef ALLOW_DIAGNOSTICS
+          DIAGarrayB(I,J) = AREA(I,J,bi,bj)
+          DIAGarrayC(I,J) = HEFF(I,J,bi,bj)
+          DIAGarrayD(I,J) = HSNOW(I,J,bi,bj)
+#endif
+         ENDDO
+        ENDDO
+
+#ifdef ALLOW_DIAGNOSTICS
+        IF ( useDiagnostics ) THEN
+         CALL DIAGNOSTICS_FILL(DIAGarrayB,'SIareaPT',0,1,3,bi,bj,myThid)
+         CALL DIAGNOSTICS_FILL(DIAGarrayC,'SIheffPT',0,1,3,bi,bj,myThid)
+         CALL DIAGNOSTICS_FILL(DIAGarrayD,'SIhsnoPT',0,1,3,bi,bj,myThid)
+        ENDIF
+#endif /* ALLOW_DIAGNOSTICS */
+
+C---+----1----+----2----+----3----+----4----+----5----+----6----+----7-|--+----|
 #ifdef ALLOW_AUTODIFF_TAMC
-cphCADJ STORE heff   = comlev1, key = ikey_dynamics
-cphCADJ STORE hsnow  = comlev1, key = ikey_dynamics
-cphCADJ STORE uwind  = comlev1, key = ikey_dynamics
-cphCADJ STORE vwind  = comlev1, key = ikey_dynamics
-CADJ STORE tice   = comlev1, key = ikey_dynamics
+CADJ STORE AREApreTH = comlev1_bibj, key = iicekey, byte = isbyte
+CADJ STORE HEFFpreTH = comlev1_bibj, key = iicekey, byte = isbyte
+CADJ STORE HSNWpreTH = comlev1_bibj, key = iicekey, byte = isbyte
 #endif /* ALLOW_AUTODIFF_TAMC */
+C---+----1----+----2----+----3----+----4----+----5----+----6----+----7-|--+----|
 
-C           SET LAYER TEMPERATURE IN KELVIN
-            DO J=1,sNy
-               DO I=1,sNx
-                  TMIX(I,J,bi,bj)=
-     &                 theta(I,J,kSurface,bi,bj) + TMELT
-               ENDDO
-            ENDDO
+C     COMPUTE ACTUAL ICE/SNOW THICKNESS; USE MIN/MAX VALUES
+C     TO REGULARIZE SEAICE_SOLVE4TEMP/d_AREA COMPUTATIONS
 
-C           CALCULATE THE THERMODYNAMIC FLUXES WITHIN THE SNOW/ICE SYSTEM
-            CALL SEAICE_BUDGET_ICE_IF(
-     I           UG, HICE_ACTUAL, HSNOW_ACTUAL, 
-     U           TICE, 
-     O           F_io_net,F_ia_net,F_ia, QSWI, 
-     I           bi, bj, myThid)
+        DO J=1,sNy
+         DO I=1,sNx
+          IF (HEFFpreTH(I,J) .GT. ZERO) THEN
+c          regularize AREA with SEAICE_area_reg
+           tmpscal1 = SQRT(AREApreTH(I,J)* AREApreTH(I,J) + area_reg_sq)
 
-C Sometimes it is nice to have a setup without ice-atmosphere heat
-C fluxes.  This flag turns those fluxes to zero but leaves the 
-C Ice ocean fluxes intact.  Thus, the first oceanic cell can transfer
-C heat to the ice leading to melting in F_ml and it can release 
-C heat to the atmosphere through leads and open area thus growing it in
-C F_ao
+c          hiceActual calculated with the regularized AREA
+           tmpscal2 = HEFFpreTH(I,J) / tmpscal1
 
-#ifdef FORBID_ICE_SURFACE_ATMOSPHERE_HEAT_FLUXES
-            DO J=1,sNy
-               DO I=1,sNx
-                  F_ia_net (I,J)  = 0. _d 0
-                  F_ia (I,J)      = 0. _d 0
-                  F_io_net(I,J)   = 0. _d 0
-                  QSWI(I,J)       = 0. _d 0
-               ENDDO
-            ENDDO
-#endif
+c          regularize hiceActual with SEAICE_hice_reg (add lower bound)
+c           hiceActual(I,J) = SQRT(tmpscal2 * tmpscal2 + hice_reg_sq)
+           hiceActual(I,J) = MAX(0.05 _d 0, tmpscal2)
 
-            DO J=1,sNy
-               DO I=1,sNx
+c          hsnowActual calculated with the regularized AREA (no lower bound)
+c          hsnowActual(I,J) = HSNWpreTH(I,J) / tmpscal1
+c          actually I don't think we need to regularize this.
+           hsnowActual(I,J) = HSNWpreTH(I,J) / AREApreTH(I,J)
 
-#ifdef SEAICE_DEBUG
-               IF ( (I .EQ. SEAICE_debugPointX)   .and.
-     &              (J .EQ. SEAICE_debugPointY) ) THEN
+c          regularize the inverse of hiceActual by hice_reg
+           recip_hiceActual(I,J)  = AREApreTH(I,J) /
+     &         sqrt(HEFFpreTH(I,J)*HEFFpreTH(I,J) + hice_reg_sq)
 
-                 print *,'sig: I,J,F_ia,F_ia_net',I,J,F_ia(I,J),
-     &              F_ia_net(I,J)
+c         Do not regularize when HEFFpreTH = 0
+          ELSE
+           hiceActual (I,J)       = ZERO
+           hsnowActual(I,J)       = ZERO
+           recip_hiceActual(I,J)  = ZERO
+          ENDIF
 
-               ENDIF
-#endif
+         ENDDO
+        ENDDO
 
-c                 If there is heat flux convergence at the snow surface,
-c                 use that energy to melt snow before melting ice.  It's
-c                 possible that some snow will remain after melting, 
-c                 which will drive F_ia_net to zero, or that all of the 
-c                 snow will be melted, leaving a nonzero F_ia_net to melt
-c                 some ice.  
-                  F_ia_net_before_snow(I,J) = F_ia_net(I,J)
 
-c                 Only continue if there is snow and ice in the cell
-                  IF (AreaNm1(I,J,bi,bj)*HEFFNm1(I,J,bi,bj)
-     &                .LE. ZERO                            ) THEN
-                     IceGrowthRateUnderExistingIce(I,J) = 0. _d 0
-                     IceGrowthRateFromSurface(I,J)      = 0. _d 0
-                     NetExistingIceGrowthRate(I,J)      = 0. _d 0
-                  ELSE
-c                    The growth rate (m/s) beneath existing ice is given by the upward
-c                    ocean-ice conductive flux, F_io_net, and QI.
-                     IceGrowthRateUnderExistingIce(I,J)=F_io_net(I,J)*QI
+C =============================================================================
+C Part 2: Precipitation as snow or rain over ice
+C =============================================================================
 
-c                    The rate at which snow is melted (m/s) because of surface 
-c                    heat flux convergence.  Note, during snow melt, F_ia_net must 
-c                    be negative (implying convergence) to make PSMRFW is positive
-                     PotSnowMeltRateFromSurf(I,J)= - F_ia_net(I,J)*QS
+C---+----1----+----2----+----3----+----4----+----5----+----6----+----7-|--+----|
+#ifdef ALLOW_AUTODIFF_TAMC
+CADJ STORE SnowAccRateOverIce = comlev1_bibj,key=iicekey,byte=isbyte
+CADJ STORE SnowAccOverIce     = comlev1_bibj,key=iicekey,byte=isbyte
+CADJ STORE PrecipRateOverIceSurfaceToSea   =
+CADJ &     comlev1_bibj, key = iicekey, byte = isbyte
+CADJ STORE PRECIP(:,:,bi,bj) = comlev1_bibj,key=iicekey,byte=isbyte
+CADJ STORE AREApreTH = comlev1_bibj, key = iicekey, byte = isbyte
+#endif /* ALLOW_AUTODIFF_TAMC */
+C---+----1----+----2----+----3----+----4----+----5----+----6----+----7-|--+----|
 
-c                    This is the depth of snow (m) that would be melted over one time step.
-                     PotSnowMeltFromSurf(I,J) =
-     &                  PotSnowMeltRateFromSurf(I,J)* SEAICE_deltaTtherm
+        DO J=1,sNy
+         DO I=1,sNx
+c        if we have ice and the temperature of the ice is below the freezing point
+c        then the precip falls and accumulates as snow
+          IF (( AREApreTH(I,J)     .GT. ZERO) .AND.
+     &        ( TICES(I,J,1,bi,bj) .LT. celsius2k) ) THEN
 
-c                    If we can melt MORE than is actually there, then the melt 
-c                    rate is reduced so that only that which is there 
-c                    is melted during the time step.  In this case, not all of the 
-c                    heat flux convergence at the surface is used to melt snow.
-c                    Any remaining energy will melt ice.  
+c use either prescribed snowfall or PRECIP rate
+           IF ( snowPrecipFile .NE. ' ' ) THEN
+c    rate of snow accumulation in m/s over ice
+c                      y [m/s] \approx 1.0 [kg/m^3] / 0.9 [m^3/kg] * x [m/s]
+             SnowAccRateOverIce(I,J) = rhoConstFresh/SEAICE_rhoSnow *
+     &               snowPrecip(i,j,bi,bj)
 
-c                    SurfHeatFluxConvergToSnowMelt is the part of the total heat 
-c                    flux convergence which melts snow.
+           ELSE
+             SnowAccRateOverIce(I,J) = rhoConstFresh/SEAICE_rhoSnow *
+     &           PRECIP(i,j,bi,bj)
 
-                     IF (PotSnowMeltFromSurf(I,J) .GE. 
-     &                   HSNOW_ACTUAL(I,J)) THEN
+           ENDIF
 
-c                      Snow melt and melt rate (actual not mean snow thickness)
-                       SnowMeltFromSurface(I,J)     = HSNOW_ACTUAL(I,J)
+           PrecipRateOverIceSurfaceToSea(I,J) = ZERO
 
-                       SnowMeltRateFromSurface(I,J) = 
-     &                   SnowMeltFromSurface(I,J)/ SEAICE_deltaTtherm
+          ELSE
+c            The snow/ice surface is not frozen (wet) so the precipitation
+c            remains wet and runs into the ocean
+             SnowAccRateOverIce(I,J) = ZERO
+             PrecipRateOverIceSurfaceToSea(I,J) = PRECIP(i,j,bi,bj)
+          ENDIF
 
-                       SurfHeatFluxConvergToSnowMelt(I,J) =
-     &                   -HSNOW_ACTUAL(I,J)/QS/SEAICE_deltaTtherm
-                     ELSE
-c                      In this case there will be snow remaining after melting.
-c                      All of the surface heat convergence will be redirected to 
-c                      this effort.
-                       SnowMeltFromSurface(I,J)=PotSnowMeltFromSurf(I,J)
+c  actual change in snow thickness due to precipitation in units of
+c  mean snow thickness
+          SnowAccOverIce(I,J) =
+     &     SnowAccRateOverIce(I,J) * SEAICE_deltaTtherm * AREApreTH(I,J)
 
-                       SnowMeltRateFromSurface(I,J) = 
-     &                    PotSnowMeltRateFromSurf(I,J)
+c I,J
+         ENDDO
+        ENDDO
 
-                       SurfHeatFluxConvergToSnowMelt(I,J) =F_ia_net(I,J)
-                     ENDIF
+C =============================================================================
+C FIND WIND SPEED
+C =============================================================================
 
-c                    Reduce the heat flux convergence available to melt surface
-c                    ice by the amount used to melt snow
-                     F_ia_net(I,J) = 
-     &                  F_ia_net(I,J)-SurfHeatFluxConvergToSnowMelt(I,J)
+        DO j=1,sNy
+         DO i=1,sNx
+C ocean surface/mixed layer temperature
+          TmixLoc(i,j) = theta(i,j,kSurface,bi,bj) + celsius2K
+C wind speed from exf
+          UG(I,J) = MAX(SEAICE_EPS, wspeed(I,J,bi,bj))
+         ENDDO
+        ENDDO
 
-                     IceGrowthRateFromSurface(I,J) = F_ia_net(I,J)*QI
 
-c                    The total growth rate (m/s) of the existing ice - the rate of
-c                    new ice accretion at the base less the rate due to surface melt
-                     NetExistingIceGrowthRate(I,J) = 
-     &                 IceGrowthRateUnderExistingIce(I,J) +
-     &                 IceGrowthRateFromSurface(I,J)
-                  ENDIF
-               ENDDO
-            ENDDO
-
+C =============================================================================
 c           Retrieve the air-sea heat and shortwave radiative fluxes
-            CALL SEAICE_BUDGET_OCEAN(
-     I           UG, 
-     U           TMIX, 
-     O           F_ao, QSWO, 
-     I           bi, bj, myTime, myIter, myThid )
- 
-#ifdef SEAICE_DEBUG
-        print *,'myiter', myIter
-        print '(A,2i4,2(1x,1P2E15.3))',
-     &       'ifice sigr, dbgx,dby, (netHF, SWHeatFlux)',
-     &        SEAICE_debugPointX,   SEAICE_debugPointY,
-     &        F_ao(SEAICE_debugPointX, SEAICE_debugPointY),
-     &        QSWO(SEAICE_debugPointX, SEAICE_debugPointY)
-#endif
+C =============================================================================
 
+C---+----1----+----2----+----3----+----4----+----5----+----6----+----7-|--+----|
+#ifdef ALLOW_AUTODIFF_TAMC
+CADJ STORE qnet(:,:,bi,bj) = comlev1_bibj, key = iicekey,byte=isbyte
+CADJ STORE qsw(:,:,bi,bj)  = comlev1_bibj, key = iicekey,byte=isbyte
+cCADJ STORE UG = comlev1_bibj, key = iicekey,byte=isbyte
+cCADJ STORE TmixLoc = comlev1_bibj, key = iicekey,byte=isbyte
+#endif /* ALLOW_AUTODIFF_TAMC */
+C---+----1----+----2----+----3----+----4----+----5----+----6----+----7-|--+----|
+
+        CALL SEAICE_BUDGET_OCEAN(
+     I       UG,
+     I       TmixLoc,
+     O       F_ao, QSWO,
+     I       bi, bj, myTime, myIter, myThid )
+
+
+C =============================================================================
+C      Calc air-sea fluxes in the uppermost grid cell
+C =============================================================================
 
 c--   Not all of the sw radiation is absorbed in the uppermost ocean grid cell layer.
 c     Only that fraction which converges in the uppermost ocean grid cell is used to
 c     melt ice.
-c           SWFRACB - the fraction of incoming sw radiation absorbed in the 
+c           SWFRACB - the fraction of incoming sw radiation absorbed in the
 c                     uppermost ocean grid cell (calculated in seaice_init_vari.F)
-            DO J=1,sNy
-               DO I=1,sNx
-
-c The contribution of shortwave heating is 
-c not included without #define SHORTWAVE_HEATING
-#ifdef SHORTWAVE_HEATING
-                  QSWO_BELOW_FIRST_LAYER(i,j)= QSWO(I,J)*SWFRACB
-                  QSWO_IN_FIRST_LAYER(I,J)   = QSWO(I,J)*(ONE - SWFRACB)
-#else 
-                  QSWO_BELOW_FIRST_LAYER(i,j)= 0. _d 0
-                  QSWO_IN_FIRST_LAYER(I,J)   = 0. _d 0
-#endif
-                  IceGrowthRateOpenWater(I,J)= QI*
-     &              (F_ao(I,J) - QSWO(I,J) + QSWO_IN_FIRST_LAYER(I,J))
-
-             ENDDO
-            ENDDO        
-            
-
-#ifdef ALLOW_AUTODIFF_TAMC
-CADJ STORE theta(:,:,:,bi,bj)= comlev1_bibj, 
-CADJ &                         key = iicekey, byte = isbyte
-CADJ STORE heff(:,:,bi,bj)   = comlev1_bibj, 
-CADJ &                         key = iicekey, byte = isbyte
-#endif /* ALLOW_AUTODIFF_TAMC */
-
-
-C--   Calcuate the heat fluxes from the ocean to the sea ice
-            DO J=1,sNy
-               DO I=1,sNx
-
-C     Calculate the seawater freezing point
-#ifdef SEAICE_VARIABLE_FREEZING_POINT
-                  TBC = -0.0575 _d 0*salt(I,J,kSurface,bi,bj) + 
-     &                 0.0901 _d 0
-#endif /* SEAICE_VARIABLE_FREEZING_POINT */
-                  
-c     Bound the ocean temperature to be at or above the freezing point.
-      surf_theta = max(theta(I,J,kSurface,bi,bj), TBC)
-
-c     This model has two alternative schemes to calculate turbulent ocean-ice
-c     heat fluxes.  Each is described in turn
-c
-c     ==== METHOD 1 ====
-c
-c     The first uses an empircal relationship between the 
-c     'far-field' ocean temperature and ocean to sea ice turbulent heat fluxes 
-c     given by McPhee:
-c
-c     Flux  = rho_sw * cp_sw * <w'T'> 
-c     <w'T'>= S_t *  u_star * (T_o - T_f)
-c
-c          Where,
-c             rho_sw : seawater density (kg m^-3)
-c             cp_sw  : seawater heat capcity (J kg^-1 K^-1)
-c             S_t    : Stanton Number ~ 0.0056 (dimensionless)
-c             u_star : friction velocity beneath ice ~ 0.015 m s^-1
-c             T_o, T_f : The 'far-field' ocean temperature and ice
-c                        freezing point (deg C)
-c
-c     Using typical values, ice advected over waters warmer by 1 degree
-c     will be subjected to a basal heat flux of ~ 345 W m^-2.  
-c
-c     In the model, the criteria for ice growth is that the air-sea
-c     heat loss must exceed the potential ocean-ice heat flux (i.e., more 
-c     potential ice production over one time step than melt).  
-c     Using the above parameterization, ice will form in waters which 
-c     are much warmer than its salinity-determined freezing point
-c     using typical wintertime conditions in, say, the North Atlantic.
-c
-c     Therefore, when no ice is present, an additional factor is applied
-c     to the above <w'T'> (mixedLayerTurbulenceFactor) to represent the idea that 
-c     turbulent mixing at and near the surface of an ice-free ocean
-c     is much greater than mixing beneath an ice-covered one.
-c
-c     A factor of 12.5 is chosen for mixedLayerTurbulenceFactor.  Consequently,
-c     for each 0.1 degree above freezing of the upper ocean grid cell,
-c     the air-sea heat losses must exceed ~ 515 W m^-2 before ice forms.
-c    
-c     Once ice gains a foothold in a grid cell, the McPhee parameterization
-c     is immediately invoked.
-c   
-c     ==== METHOD 2 ====
-c
-c     The second scheme (the original and now outdated version)
-c     subsumes (S_t * u_star) into a single variable (SEAICE_gamma_t)
-c      in the following way:
-c
-c     Flux  = rho_sw * cp_sw * GAMMA 
-c     GAMMA = dRf(1)/SEAICE_gamma_t * (T_o - T_f)
-c    
-c           Where,
-c               dRf(1)  : depth of surface level grid cell (originally 
-c                         assumed to be 10 m)
-c               SEAICE_gamma_t : an empirical parameter (~ 3 days in seconds)
-c
-c     Using typical values, ice advected into a grid cell 
-c     that is warmer than the sea ice freezing point by 1 degree
-c     will be subjected to a basal heat flux of ~ 160 W m^-2.   Therefore,
-c     as written, one should choose a SEAICE_gamma_t = 1.4 days in seconds
-c     to have flux magnitudes match those of the McPhee parameterization.
-c    
-c     The original scheme is accessed by defining  #SEAICE_USE_ORIGINAL_HEAT FLUX
-
-#ifndef SEAICE_USE_ORIGINAL_HEAT_FLUX
-c                 If ice is present, MixedLayerTurbulenceFactor = 1.0, else 12.50
-                  IF (AREANm1(I,J,bi,bj) .GT. 0. _d 0) THEN
-                     MixedLayerTurbulenceFactor = ONE
-                  ELSE
-                     MixedLayerTurbulenceFactor = 12.5 _d 0
-                  ENDIF
-
-                  F_mi(I,J) = -STANTON_NUMBER * USTAR_BASE * RHOSW *
-     &                CPW *(surf_theta - TBC)*MixedLayerTurbulenceFactor
-#else
-c                 no turbulence factor using original_heat_flux scheme
-                  F_mi(I,J) = -GAMMA*RHOSW*CPW *(surf_theta - TBC)
-
-#endif /* SEAICE_USE_ORIGINAL_HEAT_FLUX */
-
-                  IceGrowthRateMixedLayer(I,J) = F_mi(I,J)*QI;
-               ENDDO
-            ENDDO 
-
-#ifdef ALLOW_AUTODIFF_TAMC
-CADJ STORE S_h(:,:)         = comlev1_bibj, 
-CADJ &                        key = iicekey, byte = isbyte
-#endif /* ALLOW_AUTODIFF_TAMC */
-
-
-
-C           CALCULATE THICKNESS DERIVATIVE (S_h)
-            DO J=1,sNy
-               DO I=1,sNx
-                  S_h(I,J) = 
-     &                 NetExistingIceGrowthRate(I,J)*AREANm1(I,J,bi,bj)+
-     &                 (ONE -AREANm1(I,J,bi,bj))*
-     &                 IceGrowthRateOpenWater(I,J) +
-     &                 IceGrowthRateMixedLayer(I,J)
-
-c                  Both the accumulation and melt rates are in terms
-c                  of actual snow thickness.  As with ice, multiplying
-c                  with area converts to mean snow thickness.
-                   S_hsnow(I,J) =     AREANm1(I,J,bi,bj)* (
-     &                  SnowAccRateOverIce(I,J) - 
-     &                  SnowMeltRateFromSurface(I,J)     ) 
-               ENDDO
-            ENDDO
-
-#ifdef ALLOW_SALT_PLUME
-C       Now that we know the thickness tendency terms, we can calculate the saltPlumeFlux
         DO J=1,sNy
          DO I=1,sNx
 
-c            It is assumed that ice production in leads can generate
-c            salt plumes.  The fraction of the salt sent to the plume package
-c            from ice produced in leads (defined as the open water
-c            fraction) is a nonlinear function of ice concentration, AREA.
-c
-c            Specifically, function is a logistic curve (sigmoid) with a range and 
-c            domain {0,1}.  The function, f(AREA), has a single free parameter,
-c            SEAICE_plumeInflectionPoint, the inflection point of the curve.  
-c            By construction, the function has the following properties:
-c            f(1) \approx 1.0
-c            f(SEAICE_plumeInflectionPoint) = 0.5
-c            f(0) \approx 0.0 (when SEAICE_plumeInflectionPoint \geq 0.5)
-c            f(0) > 0.0 (when SEAICE_plumeInflectionPoint < 0.5)
-c
-c            As AREA --> 1, the open water fraction occurs
-c            in narrow leads, new ice production become spatially non-uniform,
-c            and the assumptions motivating KPP no longer hold.  To treat
-c            overturning in a more physically realistic way, the salt produced
-c            in the leads should be sent to depth via the plume package.  To assure 
-c            only narrow leads generate plumes, choose a SEAICE_plumeInflectionPoint 
-c            of > 0.8.
-
-c            Ensure that there is already ice present or that the total ice
-c            ice tendency term is positive.  We don't want to release 
-c            salt if sea ice is not established in the cell.
-
-             IF ((AREANm1(I,J,bi,bj) .GT. ZERO) .OR. 
-     &           (S_h(I,J)           .GT. ZERO)) THEN
- 
-              leadPlumeFraction(I,J) = 
-     &         (ONE + EXP( ( SEAICE_plumeInflectionPoint - 
-     &                       AREANm1(I,J,bi,bj)
-     &                     ) * 5._d 0/
-     &                     (ONE - SEAICE_plumeInflectionPoint)
-     &                   )
-     &         )**(-ONE) 
- 
-c             Only consider positive ice growth rate in leads for salt production
-              IceGrowthRateInLeads(I,J) = max( ZERO,
-     &         (ONE - AREANm1(I,J,bi,bj)) * IceGrowthRateOpenWater(I,J))
-
-              saltPlumeFlux(I,J,bi,bj) = leadPlumeFraction(I,J) * 
-     &            HEFFM(I,J,bi,bj)*IceGrowthRateInLeads(I,J)*
-     &            ICE2WATR*rhoConstFresh*
-     &            (salt(I,J,kSurface,bi,bj) - SEAICE_salinity_fixed)
-             ELSE 
-
-              saltPlumeFlux(I,J,bi,bj) = ZERO 
-
-             ENDIF
+c The contribution of shortwave heating is
+c not included without #define SHORTWAVE_HEATING
+#ifdef SHORTWAVE_HEATING
+           QSWO_BELOW_FIRST_LAYER(I,J)= QSWO(I,J)*SWFRACB
+           QSWO_IN_FIRST_LAYER(I,J)   = QSWO(I,J)*(ONE - SWFRACB)
+#else
+           QSWO_BELOW_FIRST_LAYER(I,J)= ZERO
+           QSWO_IN_FIRST_LAYER(I,J)   = ZERO
+#endif
+           IceGrowthRateOpenWater(I,J) = QI *
+     &        (F_ao(I,J) - QSWO(I,J) + QSWO_IN_FIRST_LAYER(I,J))
 
          ENDDO
         ENDDO
-#endif /* ALLOW_SALT_PLUME */
 
+
+
+C---+----1----+----2----+----3----+----4----+----5----+----6----+----7-|--+----|
 #ifdef ALLOW_AUTODIFF_TAMC
-CADJ STORE area(:,:,bi,bj)  = comlev1_bibj, 
-CADJ &                        key = iicekey, byte = isbyte
-CADJ STORE heff(:,:,bi,bj)  = comlev1_bibj, 
-CADJ &                        key = iicekey, byte = isbyte
-CADJ STORE hsnow(:,:,bi,bj) = comlev1_bibj, 
-CADJ &                        key = iicekey, byte = isbyte
-CADJ STORE S_h(:,:)         = comlev1_bibj, 
-CADJ &                        key = iicekey, byte = isbyte
-CADJ STORE S_hsnow(:,:)     = comlev1_bibj, 
-CADJ &                        key = iicekey, byte = isbyte
+CADJ STORE hsnowActual = comlev1_bibj, key = iicekey, byte = isbyte
+CADJ STORE hiceActual  = comlev1_bibj, key = iicekey, byte = isbyte
+CADJ STORE UG          = comlev1_bibj, key = iicekey, byte = isbyte
+CADJ STORE tices(:,:,:,bi,bj)
+CADJ &     = comlev1_bibj, key = iicekey, byte = isbyte
+CADJ STORE salt(:,:,kSurface,bi,bj) = comlev1_bibj,
+CADJ &                     key = iicekey, byte = isbyte
 #endif /* ALLOW_AUTODIFF_TAMC */
+C---+----1----+----2----+----3----+----4----+----5----+----6----+----7-|--+----|
 
+C =============================================================================
+c  calculate heat fluxes within ice (conduction), F_io, and across the
+c  ice/atmosphere interface, F_ia
+C =============================================================================
 
+C--   Start loop over multi-categories
+        DO IT=1,SEAICE_multDim
 
-c           Caculate dA/dt (S_a)
-            DO J=1,sNy
-               DO I=1,sNx
-                  S_a(I,J) =  0. _d 0 
+         DO J=1,sNy
+          DO I=1,sNx
+c record prior ice surface temperatures
+           ticeInMult(I,J,IT)  = TICES(I,J,IT,bi,bj)
+           ticeOutMult(I,J,IT) = TICES(I,J,IT,bi,bj)
+           TICES(I,J,IT,bi,bj) = ZERO
+          ENDDO
+         ENDDO
 
-c                 In the following, time derivatives of AREA require
-c                 divisions by HEFF. To prevent sensitivity blow up when
-c                 HEFF --> 0, we divide by an approximation to HEFF, HEFF*:
-c
-c                 HEFF* = sqrt(HEFF^2 + heff_min^2)
-c                      Where heff_min is implicitly defined as 0.1 m. 
-c
-c                 HEFF* is defined as a hyperbola with slope = 1 and 
-c                 y-intercept of heff_min.  The gradient of 1/HEFF* is 
-c                 well-behaved (correct sign) and deviates from 1/HEFF 
-c                 significantly only when HEFF --> 0.
+c set relative thickness of ice categories
+         pFac = (2.0 _d 0*IT - 1.0 _d 0)*recip_multDim
+         pFacSnow = 1. _d 0
 
-                 IF ( (HEFFNm1(I,J,bi,bj).GT. ZERO) .AND.
-     &                (AREANm1(I,J,bi,bj).NE. ZERO)) THEN
-                     HEFF_MIN = SQRT( 0.01 _d 0 + 
-     &                   HEFFNm1(I,J,bi,bj) * HEFFNm1(I,J,bi,bj) )
-                 ELSE
-c                        Just in case somehow we miss a case, we want to divide
-c                        by a sensible number, here 10 cm.
-                         HEFF_MIN = max(HEFFNm1(I,J,bi,bj), 0.1 _d 0)
-                 ENDIF
+c find actual snow and ice thickness within categories categories
+         IF ( SEAICE_useMultDimSnow ) pFacSnow=pFac
 
-c                 Caculate the ice area growth rate from the open water fluxes.
-c                 First, determine whether the open water growth rate is positive or
-c                 negative.  If positive, make sure that ice is present or that the 
-c                 net ice thickness growth rate is positive before extending ice cover 
+         DO J=1,sNy
+          DO I=1,sNx
+            hiceActualMult(I,J,IT)   = hiceActual(I,J) *pFac
+            hsnowActualMult(I,J,IT)  = hsnowActual(I,J)*pFacSnow
+          ENDDO
+         ENDDO
 
-                  IF (IceGrowthRateOpenWater(I,J) .GT. ZERO) THEN
+       ENDDO /* multDim */
 
-c                    Determine which hemisphere for hemisphere-dependent
-c                    "lead closing variable", HO
-
-                     IF ( YC(I,J,bi,bj) .LT. ZERO ) THEN
-                        S_a_from_IGROW(I,J) = (ONE-AREANm1(I,J,bi,bj))*
-     &                     IceGrowthRateOpenWater(I,J)/HO_south
-                     ELSE
-                        S_a_from_IGROW(I,J) = (ONE-AREANm1(I,J,bi,bj))*
-     &                     IceGrowthRateOpenWater(I,J)/HO
-                     ENDIF
-
-c                    If there is already ice, add to S_a
-                     IF (AREANm1(I,J,bi,bj) .GT. ZERO) THEN
-                        S_a(I,J) = S_a(I,J) + S_a_from_IGROW(I,J)
-c                    otherwise, add to S_a only if the net ice growth rate
-c                    is positive
-                     ELSE
-                        IF (S_h(I,J) .GT. ZERO) THEN
-                           S_a(I,J) = S_a(I,J) + S_a_from_IGROW(I,J)
-                        ENDIF
-                     ENDIF
-                  ELSE  
-
-c                    The open water growth rate is negative - contract the ice cover.
-                     IF ( (AREANm1(I,J,bi,bj).GT. ZERO) .AND.
-     &                  (HEFFNm1(I,J,bi,bj).GT. ZERO) ) THEN
-
-                       S_a(I,J) = S_a(I,J) 
-     &                    + AREANm1(I,J,bi,bj)/(2. _d 0*HEFF_MIN)*
-     &                    IceGrowthRateOpenWater(I,J)*
-     &                    (ONE - AREANm1(I,J,bi,bj))
-                     ELSE
-                       S_a(I,J) = S_a(I,J) +  0. _d 0
-                     ENDIF
-                  ENDIF
-
-C                 Melt ice if the IceGrowthRateMixedLayer is negative
-                  IF ( (IceGrowthRateMixedLayer(I,J) .LE. ZERO) .AND. 
-     &                 (AREANm1(I,J,bi,bj).GT. ZERO) .AND.
-     &                 (HEFFNm1(I,J,bi,bj).NE. ZERO) ) THEN
-
-                     S_a(I,J) = S_a(I,J) 
-     &                    + AREANm1(I,J,bi,bj)/(2. _d 0 *HEFF_MIN)*
-     &                    IceGrowthRateMixedLayer(I,J)
-
-                  ELSE
-                     S_a(I,J) = S_a(I,J) +  0. _d 0
-                  ENDIF
-
-C                 Melt ice if the NetExistingIceGrowthRate is negative
-                  IF ( (NetExistingIceGrowthRate(I,J) .LE. ZERO) .AND. 
-     &                 (AREANm1(I,J,bi,bj).GT. ZERO) .AND.
-     &                 (HEFFNm1(I,J,bi,bj).NE. ZERO) ) THEN
-
-                     S_a(I,J) = S_a(I,J) 
-     &                   + AREANm1(I,J,bi,bj)/(2. _d 0 * HEFF_MIN)*
-     &                  NetExistingIceGrowthRate(I,J)*AREANm1(I,J,bi,bj)
-
-                  ELSE
-                     S_a(I,J) = S_a(I,J) +  0. _d 0
-                  ENDIF
-                  
-               ENDDO
-            ENDDO
-                 
-
+C---+----1----+----2----+----3----+----4----+----5----+----6----+----7-|--+----|
 #ifdef ALLOW_AUTODIFF_TAMC
-CADJ STORE heff(:,:,bi,bj)   = comlev1_bibj, 
-CADJ &                         key = iicekey, byte = isbyte
-CADJ STORE hsnow(:,:,bi,bj)  = comlev1_bibj, 
-CADJ &                         key = iicekey, byte = isbyte
-CADJ STORE S_a(:,:)          = comlev1_bibj, 
-CADJ &                         key = iicekey, byte = isbyte
-CADJ STORE S_h(:,:)          = comlev1_bibj, 
-CADJ &                         key = iicekey, byte = isbyte
-CADJ STORE f_ao(:,:)         = comlev1_bibj, 
-CADJ &                         key = iicekey, byte = isbyte
-CADJ STORE qswi(:,:)         = comlev1_bibj, 
-CADJ &                         key = iicekey, byte = isbyte
-CADJ STORE qswo(:,:)         = comlev1_bibj, 
-CADJ &                         key = iicekey, byte = isbyte
-CADJ STORE area(:,:,bi,bj)   = comlev1_bibj, 
-CADJ &                         key = iicekey, byte = isbyte
-#endif
+CADJ STORE hiceActualMult = comlev1_bibj, key = iicekey, byte = isbyte
+CADJ STORE hsnowActualMult= comlev1_bibj, key = iicekey, byte = isbyte
+CADJ STORE ticeOutMult    = comlev1_bibj, key = iicekey, byte = isbyte
+CADJ STORE F_io_net_mult   =
+CADJ &     comlev1_bibj, key = iicekey, byte = isbyte
+CADJ STORE F_ia_net_mult   =
+CADJ &     comlev1_bibj, key = iicekey, byte = isbyte
+CADJ STORE F_ia_mult       =
+CADJ &     comlev1_bibj, key = iicekey, byte = isbyte
+CADJ STORE QSWI_mult       =
+CADJ &     comlev1_bibj, key = iicekey, byte = isbyte
+CADJ STORE FWsublim_mult   =
+CADJ &     comlev1_bibj, key = iicekey, byte = isbyte
+#endif /* ALLOW_AUTODIFF_TAMC */
+C---+----1----+----2----+----3----+----4----+----5----+----6----+----7-|--+----|
 
-C           Update the area, heff, and hsnow 
-            DO J=1,sNy
-               DO I=1,sNx
-                  AREA(I,J,bi,bj) = AREANm1(I,J,bi,bj) + 
-     &                 SEAICE_deltaTtherm * S_a(I,J)
-                  HEFF(I,J,bi,bj) = HEFFNm1(I,J,bi,bj) +
-     &                 SEAICE_deltaTTherm * S_h(I,J)
-                  HSNOW(I,J,bi,bj) = HSNOW(I,J,bi,bj) +
-     &                 SEAICE_deltaTTherm * S_hsnow(I,J)
-               ENDDO
-            ENDDO
-            
+c =======================================================================
+c  find calculate heat fluxes within ice (conduction) and across the
+c  ice/atmosphere interface for each thickness category
+c =======================================================================
+
+        DO IT=1,SEAICE_multDim
+         CALL SEAICE_SOLVE4TEMP(
+     I        UG, hiceActualMult(1,1,IT), hsnowActualMult(1,1,IT),
+     U        ticeInMult(1,1,IT), ticeOutMult(1,1,IT),
+     O        F_io_net_mult(1,1,IT),
+     O        F_ia_net_mult(1,1,IT),
+     O        F_ia_mult(1,1,IT),
+     O        QSWI_mult(1,1,IT),
+     O        FWsublim_mult(1,1,IT),
+     I        bi, bj, myTime, myIter, myThid )
+        ENDDO
+
+C---+----1----+----2----+----3----+----4----+----5----+----6----+----7-|--+----|
 #ifdef ALLOW_AUTODIFF_TAMC
-CADJ STORE area(:,:,bi,bj)  = comlev1_bibj, 
-CADJ &                        key = iicekey, byte = isbyte
-CADJ STORE heff(:,:,bi,bj)  = comlev1_bibj, 
-CADJ &                        key = iicekey, byte = isbyte
-CADJ STORE hsnow(:,:,bi,bj) = comlev1_bibj, 
-CADJ &                        key = iicekey, byte = isbyte
-#endif
+CADJ STORE hiceActualMult = comlev1_bibj, key = iicekey, byte = isbyte
+CADJ STORE hsnowActualMult= comlev1_bibj, key = iicekey, byte = isbyte
+CADJ STORE ticeOutMult    = comlev1_bibj, key = iicekey, byte = isbyte
+CADJ STORE F_io_net_mult  =
+CADJ &     comlev1_bibj, key = iicekey, byte = isbyte
+CADJ STORE F_ia_net_mult   =
+CADJ &     comlev1_bibj, key = iicekey, byte = isbyte
+CADJ STORE F_ia_mult       =
+CADJ &     comlev1_bibj, key = iicekey, byte = isbyte
+CADJ STORE QSWI_mult       =
+CADJ &     comlev1_bibj, key = iicekey, byte = isbyte
+CADJ STORE FWsublim_mult   =
+CADJ &     comlev1_bibj, key = iicekey, byte = isbyte
+#endif /* ALLOW_AUTODIFF_TAMC */
+C---+----1----+----2----+----3----+----4----+----5----+----6----+----7-|--+----|
 
-            DO J=1,sNy
-               DO I=1,sNx
-c                 Bound area, heff, and hsnow 
-                  AREA(I,J,bi,bj) = MIN(ONE,AREA(I,J,bi,bj))
-                  AREA(I,J,bi,bj) = MAX(ZERO,AREA(I,J,bi,bj))
-                  HEFF(I,J,bi,bj) = MAX(ZERO, HEFF(I,J,bi,bj))
-                  HSNOW(I,J,bi,bj)  = MAX(ZERO, HSNOW(I,J,bi,bj))
 
-c                 Sanity checks 
-                  IF (HEFF(I,J,bi,bj) .LE. ZERO .OR.
-     &                AREA(I,J,bi,bj) .LE. ZERO) THEN
-                    
-                    AREA(I,J,bi,bj)       = 0. _d 0
-                    HEFF(I,J,bi,bj)       = 0. _d 0
-                    HICE_ACTUAL(I,J)      = 0. _d 0
-                    HSNOW(I,J,bi,bj)      = 0. _d 0
-                    HSNOW_ACTUAL(I,J)     = 0. _d 0
+c =======================================================================
+c  record the ice surface temperature in each category
+c  and find the average of fluxes across each category
 
-                  ELSE
-c                 Calcuate the actual ice and snow thicknesses
-                    HICE_ACTUAL(I,J)  =  HEFF(I,J,bi,bj)/AREA(I,J,bi,bj)
-                    HSNOW_ACTUAL(I,J) = HSNOW(I,J,bi,bj)/AREA(I,J,bi,bj)
-                  ENDIF
+        DO IT=1,SEAICE_multDim
+         DO J=1,sNy
+          DO I=1,sNx
 
-               ENDDO
-            ENDDO
-            
+C     update TICES
+            TICES(I,J,IT,bi,bj) = ticeOutMult(I,J,IT)
+
+            F_io_net(I,J) = F_io_net(I,J) +
+     &        F_io_net_mult(I,J,IT)*recip_multDim
+
+            F_ia_net(I,J) = F_ia_net(I,J) +
+     &        F_ia_net_mult(I,J,IT)*recip_multDim
+
+            F_ia(I,J)  = F_ia(I,J)     +
+     &        F_ia_mult(I,J,IT)*recip_multDim
+
+            QSWI(I,J)  = QSWI(I,J) + QSWI_mult(I,J,IT)*recip_multDim
+
+            FWsublim(I,J) = FWsublim(I,J) +
+     &         FWsublim_mult(I,J,IT)*recip_multDim
+
+          ENDDO
+         ENDDO
+        ENDDO
+
+C---+----1----+----2----+----3----+----4----+----5----+----6----+----7-|--+----|
 #ifdef ALLOW_AUTODIFF_TAMC
-CADJ STORE area(:,:,bi,bj) = comlev1_bibj, 
+CADJ STORE AREApreTH = comlev1_bibj, key = iicekey, byte = isbyte
+CADJ STORE F_io_net  = comlev1_bibj, key = iicekey, byte = isbyte
+CADJ STORE F_ia_net  = comlev1_bibj, key = iicekey, byte = isbyte
+CADJ STORE F_ia      = comlev1_bibj, key = iicekey, byte = isbyte
+CADJ STORE QSWI      = comlev1_bibj, key = iicekey, byte = isbyte
+CADJ STORE FWSublim  = comlev1_bibj, key = iicekey, byte = isbyte
+#endif /* ALLOW_AUTODIFF_TAMC */
+C---+----1----+----2----+----3----+----4----+----5----+----6----+----7-|--+----|
+
+        DO J=1,sNy
+         DO I=1,sNx
+c          If there is heat flux convergence at the snow surface,
+c          use that energy to melt snow before melting ice.  It's
+c          possible that some snow will remain after melting,
+c          which will drive F_ia_net to zero, or that all of the
+c          snow will be melted, leaving a nonzero F_ia_net to melt
+c          some ice.
+          F_ia_net_before_snow(I,J) = F_ia_net(I,J)
+
+c         Only continue if there is snow and ice in the cell
+          IF (AREApreTH(I,J) .LE. ZERO) THEN
+            IceGrowthRateUnderExistingIce(I,J) = 0. _d 0
+            IceGrowthRateFromSurface(I,J)      = 0. _d 0
+            NetExistingIceGrowthRate(I,J)      = 0. _d 0
+          ELSE
+c           The growth rate (m/s) beneath existing ice is given by the upward
+c           ocean-ice conductive flux, F_io_net, and QI.
+            IceGrowthRateUnderExistingIce(I,J) = F_io_net(I,J)*QI
+
+c           The rate at which snow is melted (m/s) because of surface
+c           heat flux convergence.  Note, during snow melt, F_ia_net must
+c           be negative (implying convergence) to make PSMRFW is positive
+            PotSnowMeltRateFromSurf(I,J) = - F_ia_net(I,J)*QS
+
+c           This is the depth of snow (m) that would be melted in one dt
+            PotSnowMeltFromSurf(I,J)  =
+     &        PotSnowMeltRateFromSurf(I,J) * SEAICE_deltaTtherm
+
+c           If we can melt MORE than is actually there, then the melt
+c           rate is reduced so that only that which is there
+c           is melted during the time step.  In this case, not all of the
+c           heat flux convergence at the surface is used to melt snow.
+c           Any remaining energy will melt ice.
+
+c           SurfHeatFluxConvergToSnowMelt is the part of the total heat
+c           flux convergence which melts snow.
+
+C---+----1----+----2----+----3----+----4----+----5----+----6----+----7-|--+----|
+CCHECK: HSNOW ACTUAL SHOULDN'T BE REGULARIZED FOR THIS
+            IF (PotSnowMeltFromSurf(I,J) .GE. hsnowActual(I,J)) THEN
+
+c           Snow melt and melt rate [m] (actual snow thickness)
+              SnowMeltFromSurface(I,J)     = hsnowActual(I,J)
+
+c             SnowMeltRateFromSurface(I,J) =
+              SnowMeltRateFromSurface(I,J) =
+     &           SnowMeltFromSurface(I,J) / SEAICE_deltaTtherm
+
+              SurfHeatFluxConvergToSnowMelt(I,J) =
+     &          - hsnowActual(I,J)/QS/SEAICE_deltaTtherm
+           ELSE
+c             In this case there will be snow remaining after melting.
+c             All of the surface heat convergence will be redirected to
+c             this effort.
+              SnowMeltFromSurface(I,J) = PotSnowMeltFromSurf(I,J)
+
+              SnowMeltRateFromSurface(I,J) =PotSnowMeltRateFromSurf(I,J)
+
+              SurfHeatFluxConvergToSnowMelt(I,J) = F_ia_net(I,J)
+
+           ENDIF
+
+c          Reduce the heat flux convergence available to melt surface
+c          ice by the amount used to melt snow
+           F_ia_net(I,J) = F_ia_net(I,J) -
+     &         SurfHeatFluxConvergToSnowMelt(I,J)
+
+           IceGrowthRateFromSurface(I,J) = F_ia_net(I,J) * QI
+
+c          The total growth rate (m/s) of the existing ice - the rate of
+c          new ice accretion at the base less the rate due to surface melt
+           NetExistingIceGrowthRate(I,J) =
+     &            IceGrowthRateUnderExistingIce(I,J) +
+     &            IceGrowthRateFromSurface(I,J)
+          ENDIF
+
+         ENDDO
+        ENDDO
+
+C---+----1----+----2----+----3----+----4----+----5----+----6----+----7-|--+----|
+#ifdef ALLOW_AUTODIFF_TAMC
+CADJ STORE AREApreTH = comlev1_bibj, key = iicekey, byte = isbyte
+CADJ STORE SnowMeltRateFromSurface   = comlev1_bibj,
 CADJ &                       key = iicekey, byte = isbyte
-CADJ STORE heff(:,:,bi,bj) = comlev1_bibj, 
+CADJ STORE IceGrowthRateUnderExistingIce  = comlev1_bibj,
+CADJ &                       key = iicekey, byte = isbyte
+CADJ STORE IceGrowthRateFromSurface = comlev1_bibj,
+CADJ &                       key = iicekey, byte = isbyte
+CADJ STORE NetExistingIceGrowthRate  = comlev1_bibj,
 CADJ &                       key = iicekey, byte = isbyte
 #endif /* ALLOW_AUTODIFF_TAMC */
+C---+----1----+----2----+----3----+----4----+----5----+----6----+----7-|--+----|
 
-            DO J=1,sNy
-               DO I=1,sNx
 
-c                 The amount of new mean ice thickness we expect to grow
-                  ExpectedIceVolumeChange(I,J)  = S_h(I,J) *
-     &                 SEAICE_deltaTtherm
+C---+----1----+----2----+----3----+----4----+----5----+----6----+----7-|--+----|
+#ifdef ALLOW_AUTODIFF_TAMC
+CADJ STORE AREApreTH = comlev1_bibj, key = iicekey, byte = isbyte
+CADJ STORE theta(:,:,kSurface,bi,bj) = comlev1_bibj,
+CADJ &                       key = iicekey, byte = isbyte
+CADJ STORE salt(:,:,kSurface,bi,bj) = comlev1_bibj,
+CADJ &                       key = iicekey, byte = isbyte
+#endif
+C---+----1----+----2----+----3----+----4----+----5----+----6----+----7-|--+----|
 
-c                 The amount of new mean snow thickness we expect to grow
-                  ExpectedSnowVolumeChange(I,J) = S_hsnow(I,J)*
-     &                 SEAICE_deltaTtherm
+C       Calcuate the heat fluxes from the ocean to the sea ice
+        DO J=1,sNy
+         DO I=1,sNx
+c
+c         Bound the ocean temperature to be at or above the freezing point.
+          tempFrz = SEAICE_tempFrz0 +
+     &              SEAICE_dTempFrz_dS * salt(I,J,kSurface,bi,bj)
 
-c                 THE EFFECTIVE SHORTWAVE HEATING RATE
+          surf_theta = max(theta(I,J,kSurface,bi,bj), tempFrz)
+
+c         inflection point
+          tmpscal0 = 0.4 _d 0
+
+c         steepness
+          tmpscal1 = 7.0 _d 0
+
+          MLTF(I,J) = ONE + (12.5 - ONE) *
+     &         (ONE + EXP(  (AREApreTH(I,J) - tmpscal0)
+     &                     * tmpscal1/tmpscal0))**(-ONE)
+
+c          IF (AREApreTH(I,J) .GT. ZERO) THEN
+c
+c           If ice is present, MixedLayerTurbulenceFactor = 1.0, else 12.50
+c            MLTF = ONE
+c          ELSE
+c            MLTF = 12.5 _d 0
+c          ENDIF
+
+          F_mi(I,J) = -STANTON_NUMBER * USTAR_BASE * RHOSW *
+     &      HeatCapacity_Cp * (surf_theta - tempFrz) * MLTF(I,J)
+
+          IceGrowthRateMixedLayer (I,J) = F_mi(I,J) * QI
+
+         ENDDO
+        ENDDO
+
+
+C---+----1----+----2----+----3----+----4----+----5----+----6----+----7-|--+----|
+#ifdef ALLOW_AUTODIFF_TAMC
+CADJ STORE AREApreTH   = comlev1_bibj, key = iicekey, byte = isbyte
+CADJ STORE F_mi        = comlev1_bibj, key = iicekey, byte = isbyte
+CADJ STORE IceGrowthRateMixedLayer =
+CADJ &     comlev1_bibj,key = iicekey, byte = isbyte
+#endif /* ALLOW_AUTODIFF_TAMC */
+C---+----1----+----2----+----3----+----4----+----5----+----6----+----7-|--+----|
+
+C       CALCULATE THICKNESS DERIVATIVES of ice (dhdt) and snow (dhsdt)
+        DO J=1,sNy
+         DO I=1,sNx
+
+          S_h(I,J) =
+     &       NetExistingIceGrowthRate(I,J) *  AREApreTH(I,J)
+     &     + IceGrowthRateOpenWater(I,J)   * (ONE - AREApreTH(I,J))
+     &     + IceGrowthRateMixedLayer(I,J)
+
+c         Both the accumulation and melt rates are in terms
+c         of actual snow thickness.  As with ice, multiplying
+c         with area converts to mean snow thickness.
+          S_hsnow(I,J) =  AREApreTH(I,J) *
+     &      ( SnowAccRateOverIce(I,J) - SnowMeltRateFromSurface(I,J))
+
+         ENDDO
+        ENDDO
+
+C---+----1----+----2----+----3----+----4----+----5----+----6----+----7-|--+----|
+#ifdef ALLOW_AUTODIFF_TAMC
+CADJ STORE AREApreTH = comlev1_bibj, key = iicekey, byte = isbyte
+CADJ STORE HEFFpreTH = comlev1_bibj, key = iicekey, byte = isbyte
+CADJ STORE S_a       = comlev1_bibj, key = iicekey, byte = isbyte
+CADJ STORE S_h       = comlev1_bibj, key = iicekey, byte = isbyte
+CADJ STORE S_hsnow   = comlev1_bibj, key = iicekey, byte = isbyte
+#endif /* ALLOW_AUTODIFF_TAMC */
+C---+----1----+----2----+----3----+----4----+----5----+----6----+----7-|--+----|
+
+c       Caculate dA/dt (S_a)
+        DO J=1,sNy
+         DO I=1,sNx
+
+          S_a(I,J) =  0. _d 0
+
+c         Caculate the ice area growth rate from the open water fluxes.
+c         First, determine whether the open water growth rate is positive or
+c         negative.  If positive, make sure that ice is present or that the
+c         net ice thickness growth rate is positive before extending ice cover
+
+c         this is the geometric term: Area/(2*Heff),
+c         with Area/Heff regularized as Area/(Heff^2 + epsilon^2)
+c         Area/(Heff^2 + ep^2) = recip_hiceActual
+c         epsilon = SEAICE_hice_reg
+
+          tmpscal0 = recip_hiceActual(I,J) / 2.0 _d 0
+
+C    -=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=
+C         /* IceGrowthRateOpenWater */
+
+          S_a_IGROW(I,J) = ZERO
+
+c         Expand ice cover if the open water growth rate is positive
+          IF ( IceGrowthRateOpenWater(I,J) .GT. ZERO) THEN
+            IF ((AREApreTH(I,J) .GT. ZERO)   .OR.
+     &          (S_h(I,J)       .GT. ZERO))  THEN
+c           Determine which hemisphere for hemisphere-dependent
+c           "lead closing variable", HO
+              IF ( YC(I,J,bi,bj) .LT. ZERO ) THEN
+                S_a_IGROW(I,J) = (ONE - AREApreTH(I,J)) *
+     &             IceGrowthRateOpenWater(I,J)/HO_south
+              ELSE
+                S_a_IGROW(I,J) = (ONE - AREApreTH(I,J)) *
+     &             IceGrowthRateOpenWater(I,J)/HO
+              ENDIF
+            ENDIF
+
+C    -=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=
+c         Contract ice cover if the open water growth rate is negative
+          ELSE
+             S_a_IGROW(I,J) = tmpscal0 *
+     &          IceGrowthRateOpenWater(I,J) * (ONE - AREApreTH(I,J))
+          ENDIF
+
+          S_a(I,J) = S_a(I,J) + S_a_IGROW(I,J)
+
+
+C    -=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=
+c         /* IceGrowthRateMixedLayer */
+C         Contract ice if the IceGrowthRateMixedLayer is negative
+          S_a_IGRML(I,J) = ZERO
+
+          IF ( IceGrowthRateMixedLayer(I,J) .LE. ZERO)  THEN
+             S_a_IGRML(I,J) = tmpscal0 * IceGrowthRateMixedLayer(I,J)
+          ENDIF
+
+          S_a(I,J) = S_a(I,J) + S_a_IGRML(I,J)
+
+c
+C    -=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=
+C         Contract ice if the NetExistingIceGrowthRate is negative
+C         /* NetExistingIceGrowthRate */
+          S_a_IGRNE(I,J) = ZERO
+          IF ( (NetExistingIceGrowthRate(I,J) .LE. ZERO) .AND.
+     &         (HEFFpreTH(I,J)                .GT. ZERO) ) THEN
+
+            S_a_IGRNE(I,J) =
+     &       tmpscal0 * NetExistingIceGrowthRate(I,J) * AREApreTH(I,J)
+
+          ENDIF
+
+          S_a(I,J) = S_a(I,J) + S_a_IGRNE(I,J)
+
+         ENDDO /* I,J */
+        ENDDO /* I,J */
+
+
+C---+----1----+----2----+----3----+----4----+----5----+----6----+----7-|--+----|
+#ifdef ALLOW_AUTODIFF_TAMC
+CADJ STORE AREApreTH    = comlev1_bibj, key = iicekey, byte = isbyte
+CADJ STORE HEFFpreTH    = comlev1_bibj, key = iicekey, byte = isbyte
+CADJ STORE HSNWpreTH    = comlev1_bibj, key = iicekey, byte = isbyte
+CADJ STORE S_a          = comlev1_bibj, key = iicekey, byte = isbyte
+CADJ STORE S_h          = comlev1_bibj, key = iicekey, byte = isbyte
+CADJ STORE S_hsnow      = comlev1_bibj, key = iicekey, byte = isbyte
+#endif /* ALLOW_AUTODIFF_TAMC */
+C---+----1----+----2----+----3----+----4----+----5----+----6----+----7-|--+----|
+
+C       Update the area, heff, and hsnow
+        DO J=1,sNy
+         DO I=1,sNx
+           HEFF(I,J,bi,bj)  = HEFFpreTH(I,J) +
+     &           SEAICE_deltaTtherm * S_h(I,J)
+
+           AREA(I,J,bi,bj)  = AREApreTH(I,J) +
+     &           SEAICE_deltaTtherm * S_a(I,J)
+
+           HSNOW(I,J,bi,bj) = HSNWpreTH(I,J) +
+     &           SEAICE_deltaTtherm * S_hsnow(I,J)
+         ENDDO
+        ENDDO
+
+C---+----1----+----2----+----3----+----4----+----5----+----6----+----7-|--+----|
+#ifdef ALLOW_AUTODIFF_TAMC
+CADJ STORE AREApreTH        = comlev1_bibj,key=iicekey,byte=isbyte
+CADJ STORE HEFFpreTH        = comlev1_bibj,key=iicekey,byte=isbyte
+CADJ STORE HSNWpreTH        = comlev1_bibj,key=iicekey,byte=isbyte
+CADJ STORE AREA (:,:,bi,bj) = comlev1_bibj,key=iicekey,byte=isbyte
+CADJ STORE HEFF (:,:,bi,bj) = comlev1_bibj,key=iicekey,byte=isbyte
+CADJ STORE HSNOW(:,:,bi,bj) = comlev1_bibj,key=iicekey,byte=isbyte
+#endif /* ALLOW_AUTODIFF_TAMC */
+C---+----1----+----2----+----3----+----4----+----5----+----6----+----7-|--+----|
+
+
+        DO J=1,sNy
+          DO I=1,sNx
+c           Bound area, heff, and hsnow
+             AREA(I,J,bi,bj)  = MIN(ONE,  AREA(I,J,bi,bj))
+             AREA(I,J,bi,bj)  = MAX(ZERO, AREA(I,J,bi,bj))
+             HEFF(I,J,bi,bj)  = MAX(ZERO, HEFF(I,J,bi,bj))
+             HSNOW(I,J,bi,bj) = MAX(ZERO, HSNOW(I,J,bi,bj))
+
+c            Sanity checks
+             IF (HEFF(I,J,bi,bj) .LE. ZERO .OR.
+     &           AREA(I,J,bi,bj) .LE. ZERO) THEN
+
+                  AREA(I,J,bi,bj)       = 0. _d 0
+                  HEFF(I,J,bi,bj)       = 0. _d 0
+                  hiceActual(I,J)       = 0. _d 0
+                  HSNOW(I,J,bi,bj)      = 0. _d 0
+                  hsnowActual(I,J)      = 0. _d 0
+
+             ELSE
+c                 recalcuate the actual ice and snow thicknesses
+                  hiceActual(I,J)  =  HEFF(I,J,bi,bj)/AREA(I,J,bi,bj)
+                  hsnowActual(I,J) = HSNOW(I,J,bi,bj)/AREA(I,J,bi,bj)
+             ENDIF
+
+          ENDDO
+        ENDDO
+
+
+C---+----1----+----2----+----3----+----4----+----5----+----6----+----7-|--+----|
+#ifdef ALLOW_AUTODIFF_TAMC
+CADJ STORE AREA (:,:,bi,bj) = comlev1_bibj,key=iicekey,byte=isbyte
+CADJ STORE HEFF (:,:,bi,bj) = comlev1_bibj,key=iicekey,byte=isbyte
+CADJ STORE HSNOW(:,:,bi,bj) = comlev1_bibj,key=iicekey,byte=isbyte
+CADJ STORE salt(:,:,kSurface,bi,bj) = comlev1_bibj,
+CADJ &                       key = iicekey, byte = isbyte
+#endif /* ALLOW_AUTODIFF_TAMC */
+C---+----1----+----2----+----3----+----4----+----5----+----6----+----7-|--+----|
+
+        DO J=1,sNy
+          DO I=1,sNx
+
+c         THE EFFECTIVE SHORTWAVE HEATING RATE
 #ifdef SHORTWAVE_HEATING
-                  QSW(I,J,bi,bj)  =
-     &                 QSWI(I,J)  * (      AREANm1(I,J,bi,bj)) +
-     &                 QSWO(I,J)  * (ONE - AREANm1(I,J,bi,bj))
+            QSW(I,J,bi,bj)  =
+     &         QSWI(I,J)  * (      AREApreTH(I,J)) +
+     &         QSWO(I,J)  * (ONE - AREApreTH(I,J))
 #else
-                  QSW(I,J,bi,bj) = 0. _d 0
+            QSW(I,J,bi,bj) = 0. _d 0
 #endif
 
-c                 The actual ice volume change over the time step
-                  ActualNewTotalVolumeChange(I,J) = 
-     &                 HEFF(I,J,bi,bj) - HEFFNm1(I,J,bi,bj)
+c           The actual ice volume change over the time step
+            ActualNewTotalVolumeChange(I,J) =
+     &        HEFF(I,J,bi,bj) - HEFFpreTH(I,J)
 
-c     The net average snow thickness melt that is actually realized. e.g.
-c     hsnow_orig  = 0.25 m (e.g. 1 m of ice over a cell 1/4 covered in snow)
-c     hsnow_new   = 0.20 m
-c     snow accum  = 0.05 m
-c            melt = 0.25 + 0.05 - 0.2 = 0.1 m 
+c           The net average snow thickness melt that is actually realized. e.g.
+c           hsnow_orig  = 0.25 m (e.g. 1 m of ice over a cell 1/4 covered in snow)
+c           hsnow_new   = 0.20 m
+c           snow accum  = 0.05 m
+c           melt = 0.25 + 0.05 - 0.2 = 0.1 m
 
-c     since this is in mean snow thickness it might have been  0.4 of actual 
-c     snow thickness over the 1/4 of the cell which is ice covered.
-                  ActualNewTotalSnowMelt(I,J) = 
-     &                 HSNOW_ORIG(I,J) +
+c           since this is in mean snow thickness it might have been  0.4 of actual
+c           snow thickness over the 1/4 of the cell which is ice covered.
+            ActualNewTotalSnowMelt(I,J) =
+     &                 HSNWpreTH(I,J) +
      &                 SnowAccOverIce(I,J) -
      &                 HSNOW(I,J,bi,bj)
 
-c                 The energy required to melt or form the new ice volume
-                  EnergyInNewTotalIceVolume(I,J) = 
-     &                 ActualNewTotalVolumeChange(I,J)/QI
+c           The energy required to melt or form the new ice volume
+            EnergyInNewTotalIceVolume(I,J) =
+     &          ActualNewTotalVolumeChange(I,J)/QI
 
 c     This is the net energy flux out of the ice+ocean system
 c     Remember -----
-c     F_ia_net : Under ice/snow surface freezing conditions, 
+c     F_ia_net : Under ice/snow surface freezing conditions,
 c                vertical conductive heat flux convergence (F_c < 0) balances
-c                heat flux divergence to atmosphere (F_ia > 0)  
+c                heat flux divergence to atmosphere (F_ia > 0)
 c                Otherwise, F_ia_net = F_ia (pos)
 c
 c     F_io_net : Under ice/snow surface freezing conditions, F_c < 0.
-c                Under ice surface melting conditions, F_c = 0 (no energy flux 
+c                Under ice surface melting conditions, F_c = 0 (no energy flux
 c                from the ice to ocean)
 c
-c     So if we are freezing, F_io_net = the conductive flux and there 
+c     So if we are freezing, F_io_net = the conductive flux and there
 c     is energy balance at ice surface, F_ia_net =0.  If we are melting,
 c     there is a convergence of energy into the ice from above
-                  NetEnergyFluxOutOfOcean(I,J) = SEAICE_deltaTtherm *
-     &               (AREANm1(I,J,bi,bj) * 
-     &               (F_ia_net(I,J) + F_io_net(I,J) + QSWI(I,J))
-     &         +     (ONE - AREANm1(I,J,bi,bj)) *  F_ao(I,J))
+            NetEnergyFluxOutOfOcean(I,J) = SEAICE_deltaTtherm *
+     &               ( AREApreTH(I,J) *
+     &                 (F_ia_net(I,J) + F_io_net(I,J) + QSWI(I,J))
+     &         +     ( ONE - AREApreTH(I,J)) *  F_ao(I,J))
 
-c     THE QUANTITY OF HEAT WHICH IS THE RESIDUAL TO THE QUANTITY OF 
-c     ML temperature.  If the net energy flux is exactly balanced by the 
-c     latent energy of fusion in the new ice created then we will not 
+c     THE QUANTITY OF HEAT WHICH IS THE RESIDUAL TO THE QUANTITY OF
+c     ML temperature.  If the net energy flux is exactly balanced by the
+c     latent energy of fusion in the new ice created then we will not
 c     change the ML temperature at all.
 
-                  ResidualEnergyOutOfOcean(I,J) = 
+            ResidualEnergyOutOfOcean(I,J) =
      &             NetEnergyFluxOutOfOcean(I,J) -
      &             EnergyInNewTotalIceVolume(I,J)
 
-C     NOW FORMULATE QNET, which time LEVEL, ORIG 2.
-C     THIS QNET WILL DETERMINE THE TEMPERATURE CHANGE OF THE MIXED LAYER
+C     NOW FORMULATE QNET
+C     THIS QNET DETERMINES THE TEMPERATURE CHANGE
 C     QNET IS A DEPTH AVERAGED HEAT FLUX FOR THE OCEAN COLUMN
-C     BECAUSE OF THE 
-                  QNET(I,J,bi,bj) =
+
+            QNET(I,J,bi,bj) =
      &             ResidualEnergyOutOfOcean(I,J) / SEAICE_deltaTtherm
 
 
@@ -1198,342 +1173,272 @@ c    to calculate freshwater fluxes for the purpose of changing the
 c    salinity of the liquid cell.  In the case of non-zero ice salinity,
 c    the amount of freshwater is reduced by the ratio of ice salinity
 c    to water cell salinity.
-           IF  ( (salt(I,J,kSurface,bi,bj) .GT. ZERO) .AND.
-     &           (salt(I,J,kSurface,bi,bj) .GE. 
-     &                         SEAICE_salinity_fixed))  THEN 
+            IF  (salt(I,J,kSurface,bi,bj) .GE. SEAICE_salt0) THEN
 
                  FreshwaterContribFromIce(I,J) =
-     &            - ActualNewTotalVolumeChange(I,J)*SEAICE_rhoICE/RHOFW*
-     &            (ONE - SEAICE_salinity_fixed/salt(I,J,kSurface,bi,bj))
+     &            - ActualNewTotalVolumeChange(I,J) *
+     &              SEAICE_rhoICE/rhoConstFresh *
+     &             (ONE - SEAICE_salt0/salt(I,J,kSurface,bi,bj))
 
-           ELSE
+            ELSE
 C    If the liquid cell has a lower salinity than the specified
 c    salinity of sea ice then assume the sea ice is completely fresh
                  FreshwaterContribFromIce(I,J) =
-     &             -ActualNewTotalVolumeChange(I,J)*SEAICE_rhoIce/RHOFW
-           ENDIF
+     &             -ActualNewTotalVolumeChange(I,J) *
+     &              SEAICE_rhoIce/rhoConstFresh
+            ENDIF
 
 
 c    The freshwater contribution from snow comes only in the form of melt
 c    unlike ice, which takes freshwater upon growth and yields freshwater
 c    upon melt.  This is why the the actual new average snow melt was determined.
 c    In m/m^2 over the entire cell.
-                  FreshwaterContribFromSnowMelt(I,J) =
-     &                 ActualNewTotalSnowMelt(I,J)*SEAICE_rhoSnow/RHOFW
+             FreshwaterContribFromSnowMelt(I,J) =
+     &          ActualNewTotalSnowMelt(I,J)*SEAICE_rhoSnow/rhoConstFresh
 
 c    This seems to be in m/s, original time level 2 for area
 c    Only the precip and evap need to be area weighted.  The runoff
 c    and freshwater contribs from ice and snow melt are already mean
 c    weighted
-                  EmPmR(I,J,bi,bj)  = maskC(I,J,kSurface,bi,bj)*(
-     &                 ( EVAP(I,J,bi,bj)-PRECIP(I,J,bi,bj) )
-     &                 * ( ONE - AREANm1(I,J,bi,bj) )
-     &                 - PrecipRateOverIceSurfaceToSea(I,J)*
-     &                     AREANm1(I,J,bi,bj)
+             EmPmR(I,J,bi,bj)  = maskC(I,J,kSurface,bi,bj)*(
+     &       ( EVAP(I,J,bi,bj) - PRECIP(I,J,bi,bj) )
+     &          * ( ONE - AREApreTH(I,J) )
+     &          - PrecipRateOverIceSurfaceToSea(I,J)*AREApreTH(I,J)
 #ifdef ALLOW_RUNOFF
-     &                 - RUNOFF(I,J,bi,bj)
+     &          - RUNOFF(I,J,bi,bj)
 #endif
-     &                 - (FreshwaterContribFromIce(I,J) +
-     &                    FreshwaterContribFromSnowMelt(I,J))/
-     &                    SEAICE_deltaTtherm )*rhoConstFresh
+     &          - (FreshwaterContribFromIce(I,J) +
+     &             FreshwaterContribFromSnowMelt(I,J)) /
+     &             SEAICE_deltaTtherm ) * rhoConstFresh
 
-C                 DO SOME DEBUGGING CALCULATIONS.  MAKE SURE SUMS ALL ADD UP.
-#ifdef SEAICE_DEBUG
+         ENDDO
+        ENDDO
 
-C                 Calcuate the shortwave flux absorbed in the upper ocean
-c                 grid cell
-#ifdef SHORTWAVE_HEATING
-                  QSW_absorb_in_first_layer(I,J) = QSW(I,J,bi,bj)*
-     &              (ONE - SWFRACB)
-#else 
 
-                  QSW_absorb_in_first_layer(I,J) = 0. _d 0
-#endif
-
-C                 Calcuate the sw flux beneath the upper ocean grid cell
-                  QSW_absorb_below_first_layer(I,J) = 
-     &                 QSW(I,J,bi,bj) -  QSW_absorb_in_first_layer(I,J)
-
-                  PredTempChangeFromQSW(I,J) = 
-     &             - QSW_absorb_in_first_layer(I,J) * FLUX_TO_DELTA_TEMP
-
-                  PredTempChangeFromOA_MQNET(I,J) = 
-     &            -(QNET(I,J,bi,bj)-QSWO(I,J))*(ONE -AREANm1(I,J,bi,bj))
-     &             * FLUX_TO_DELTA_TEMP
-
-                  PredTempChangeFromF_IO_NET(I,J) = 
-     &             -F_io_net(I,J)*AREANm1(I,J,bi,bj)*FLUX_TO_DELTA_TEMP
-
-                  PredTempChangeFromF_IA_NET(I,J) = 
-     &             -F_ia_net(I,J)*AREANm1(I,J,bi,bj)*FLUX_TO_DELTA_TEMP
-
-                  PredTempChangeFromNewIceVol(I,J) = 
-     &              EnergyInNewTotalIceVolume(I,J)*ENERGY_TO_DELTA_TEMP
-
-                  PredTempChange(I,J) = 
-     &              PredTempChangeFromQSW(I,J) +
-     &              PredTempChangeFromOA_MQNET(I,J) +
-     &              PredTempChangeFromF_IO_NET(I,J) +
-     &              PredTempChangeFromF_IA_NET(I,J) +
-     &              PredTempChangeFromNewIceVol(I,J)
-#endif    
-
-               ENDDO
-            ENDDO
-
+C---+----1----+----2----+----3----+----4----+----5----+----6----+----7-|--+----|
 #ifdef ALLOW_AUTODIFF_TAMC
-CADJ STORE area(:,:,bi,bj)  = comlev1_bibj, 
-CADJ &                        key = iicekey, byte = isbyte
-CADJ STORE hsnow(:,:,bi,bj) = comlev1_bibj, 
-CADJ &                        key = iicekey, byte = isbyte
-CADJ STORE heff(:,:,bi,bj)  = comlev1_bibj, 
-CADJ &                        key = iicekey, byte = isbyte
+CADJ STORE hiceActual       = comlev1_bibj,key=iicekey,byte=isbyte
+CADJ STORE hsnowActual      = comlev1_bibj,key=iicekey,byte=isbyte
+CADJ STORE AREApreTH        = comlev1_bibj,key=iicekey,byte=isbyte
+CADJ STORE HEFF(:,:,bi,bj)  = comlev1_bibj,key=iicekey,byte=isbyte
+CADJ STORE HSNOW(:,:,bi,bj) = comlev1_bibj,key=iicekey,byte=isbyte
+CADJ STORE AREA(:,:,bi,bj)  = comlev1_bibj,key=iicekey,byte=isbyte
+CADJ STORE salt(:,:,kSurface,bi,bj) = comlev1_bibj,
+CADJ &                       key = iicekey, byte = isbyte
 #endif /* ALLOW_AUTODIFF_TAMC */
-            
-            DO J=1,sNy
-               DO I=1,sNx
-                  AREA(I,J,bi,bj) = AREA(I,J,bi,bj)*HEFFM(I,J,bi,bj)
-                  HEFF(I,J,bi,bj) = HEFF(I,J,bi,bj)*HEFFM(I,J,bi,bj)
-                  HSNOW(I,J,bi,bj)  = HSNOW(I,J,bi,bj)*HEFFM(I,J,bi,bj)
-               ENDDO
-            ENDDO
-
-#ifdef ALLOW_AUTODIFF_TAMC
-CADJ STORE area(:,:,bi,bj)  = comlev1_bibj, 
-CADJ &                        key = iicekey, byte = isbyte
-CADJ STORE hsnow(:,:,bi,bj) = comlev1_bibj, 
-CADJ &                        key = iicekey, byte = isbyte
-CADJ STORE heff(:,:,bi,bj)  = comlev1_bibj, 
-CADJ &                        key = iicekey, byte = isbyte
-#endif /* ALLOW_AUTODIFF_TAMC */
-
+C---+----1----+----2----+----3----+----4----+----5----+----6----+----7-|--+----|
 
 #ifdef ALLOW_SEAICE_FLOODING
-           IF(SEAICEuseFlooding) THEN
+        IF(SEAICEuseFlooding) THEN
 
             DO J = 1,sNy
                DO I = 1,sNx
-                  EnergyToMeltSnowAndIce(I,J) = 
-     &                 HEFF(I,J,bi,bj)/QI +
-     &                 HSNOW(I,J,bi,bj)/QS
-                  
-                  deltaHS = FL_C2*( HSNOW_ACTUAL(I,J) -
-     &                 HICE_ACTUAL(I,J)*FL_C3 )
-                  
-                  IF (deltaHS .GT. ZERO) THEN
-                     deltaHI = FL_C4*deltaHS
-                     
-                     HICE_ACTUAL(I,J) = HICE_ACTUAL(I,J)  
-     &                    + deltaHI
+                  tmpscal0 = FL_C2*( hsnowActual(I,J) -
+     &                 hiceActual(I,J)*FL_C3 )
 
-                     HSNOW_ACTUAL(I,J)= HSNOW_ACTUAL(I,J) 
-     &                    - deltaHS
+                  IF (tmpscal0 .GT. ZERO) THEN
+                     tmpscal1 = FL_C4*tmpscal0
 
-                     HEFF(I,J,bi,bj)= HICE_ACTUAL(I,J) *
+                     hiceActual(I,J) = hiceActual(I,J)
+     &                    + tmpscal1
+
+                     hsnowActual(I,J) = hsnowActual(I,J)
+     &                    - tmpscal0
+
+                     HEFF(I,J,bi,bj)= hiceActual(I,J) *
      &                    AREA(I,J,bi,bj)
 
-                     HSNOW(I,J,bi,bj) = HSNOW_ACTUAL(I,J)*
+                     HSNOW(I,J,bi,bj) = hsnowActual(I,J)*
      &                    AREA(I,J,bi,bj)
-                     
-                     EnergyToMeltSnowAndIce2(I,J) = 
-     &                    HEFF(I,J,bi,bj)/QI +
-     &                    HSNOW(I,J,bi,bj)/QS
-                     
-#ifdef SEAICE_DEBUG
-               IF ( (I .EQ. SEAICE_debugPointX)   .and.
-     &              (J .EQ. SEAICE_debugPointY) ) THEN
 
-                     print *,'Energy to melt snow+ice: pre,post,delta', 
-     &                    EnergyToMeltSnowAndIce(I,J),  
-     &                    EnergyToMeltSnowAndIce2(I,J),
-     &                    EnergyToMeltSnowAndIce(I,J) - 
-     &                    EnergyToMeltSnowAndIce2(I,J)
-               ENDIF
-c SEAICE DEBUG
-#endif
-c there is any flooding to be had                 
-                  ENDIF
+                  ENDIF /* flooding */
                ENDDO
             ENDDO
-
 c SEAICEuseFlooding
-           ENDIF 
+           ENDIF
 c ALLOW_SEAICE_FLOODING
-#endif 
-
-#ifdef ALLOW_AUTODIFF_TAMC
-CADJ STORE area(:,:,bi,bj)  = comlev1_bibj, 
-CADJ &                        key = iicekey, byte = isbyte
-CADJ STORE hsnow(:,:,bi,bj) = comlev1_bibj, 
-CADJ &                        key = iicekey, byte = isbyte
-CADJ STORE heff(:,:,bi,bj)  = comlev1_bibj, 
-CADJ &                        key = iicekey, byte = isbyte
-#endif /* ALLOW_AUTODIFF_TAMC */
-
-
-#ifdef ATMOSPHERIC_LOADING
-            IF ( useRealFreshWaterFlux ) THEN
-               DO J=1,sNy
-                  DO I=1,sNx
-                     sIceLoad(i,j,bi,bj) = HEFF(I,J,bi,bj)*
-     &                 SEAICE_rhoIce + HSNOW(I,J,bi,bj)*SEAICE_rhoSnow
-                  ENDDO
-               ENDDO
-            ENDIF
 #endif
+
+C---+----1----+----2----+----3----+----4----+----5----+----6----+----7-|--+----|
+#ifdef ALLOW_AUTODIFF_TAMC
+CADJ STORE hiceActual       = comlev1_bibj,key=iicekey,byte=isbyte
+CADJ STORE hsnowActual      = comlev1_bibj,key=iicekey,byte=isbyte
+CADJ STORE heff(:,:,bi,bj) = comlev1_bibj,key=iicekey,byte=isbyte
+CADJ STORE hsnow(:,:,bi,bj) = comlev1_bibj,key=iicekey,byte=isbyte
+#endif /* ALLOW_AUTODIFF_TAMC */
+C---+----1----+----2----+----3----+----4----+----5----+----6----+----7-|--+----|
+
+C Sea Ice Load on the sea surface.
+C =================================
+        IF ( useRealFreshWaterFlux ) THEN
+         DO J=1,sNy
+          DO I=1,sNx
+#ifdef SEAICE_CAP_ICELOAD
+           tmpscal1 = HEFF(I,J,bi,bj)*SEAICE_rhoIce
+     &              + HSNOW(I,J,bi,bj)*SEAICE_rhoSnow
+           tmpscal2 = MIN(tmpscal1,heffTooHeavy*rhoConst)
+#else
+           tmpscal2 = HEFF(I,J,bi,bj)*SEAICE_rhoIce
+     &              + HSNOW(I,J,bi,bj)*SEAICE_rhoSnow
+#endif
+           sIceLoad(i,j,bi,bj) = tmpscal2
+          ENDDO
+         ENDDO
+        ENDIF
+
 
 #ifdef SEAICE_DEBUG
             DO j=1,sNy
                DO i=1,sNx
 
-               IF ( (i .EQ. SEAICE_debugPointX)   .and.  
-     &              (j .EQ. SEAICE_debugPointY) ) THEN
+               IF ( (i .EQ. SEAICE_debugPointI)   .and.
+     &              (j .EQ. SEAICE_debugPointJ) ) THEN
 
-                  print *,'ifsig: myTime,myIter:',myTime,myIter
+                  print *,'ifice: myTime,myIter:',myTime,myIter
 
-                  print '(A,2i4,2(1x,1P3E15.4))',
+                  print  '(A,2i4,2(1x,1P3E15.4))',
      &                 'ifice i j --------------  ',i,j
 
-                  print '(A,2i4,2(1x,1P3E15.4))',
-     &                 'ifice i j IGR(ML OW ICE)  ',i,j,
-     &                 IceGrowthRateMixedLayer(i,j),
-     &                 IceGrowthRateOpenWater(i,j),
-     &                 NetExistingIceGrowthRate(i,j),
-     &                 SEAICE_deltaTtherm
-                  
-                  print '(A,2i4,2(1x,1P3E15.4))',
-     &                 'ifice i j F(mi ao)        ',
-     &                 i,j,F_mi(i,j), F_ao(i,j)
-                  
-                  print '(A,2i4,2(1x,1P3E15.4))',
+                  print  '(A,2i4,2(1x,1P3E15.4))',
+     &                 'ifice i j F(mi ao), rHIA  ',
+     &                 i,j, F_mi(i,j), F_ao(i,j),
+     &                 recip_hiceActual(i,j)
+
+                  print  '(A,2i4,2(1x,1P3E15.4))',
      &                 'ifice i j Fi(a,ant2/1 ont)',
-     &                 i,j,F_ia(i,j),
-     &                 F_ia_net_before_snow(i,j), 
-     &                 F_ia_net(i,j), 
+     &                 i,j, F_ia(i,j),
+     &                 F_ia_net_before_snow(i,j),
+     &                 F_ia_net(i,j),
      &                 F_io_net(i,j)
-                 
-                  print '(A,2i4,2(1x,1P3E15.4))',
+
+                  print  '(A,2i4,2(1x,1P3E15.4))',
      &                 'ifice i j AREA2/1 HEFF2/1 ',i,j,
-     &                 AREANm1(I,J,bi,bj),
+     &                 AREApreTH(I,J),
      &                 AREA(i,j,bi,bj),
-     &                 HEFFNm1(I,J,bi,bj),
+     &                 HEFFpreTH(I,J),
      &                 HEFF(i,j,bi,bj)
 
-
-#ifdef ALLOW_SALT_PLUME
-                  print '(A,2i4,2(1x,1P3E15.4))',
-     &                 'ifice i j A,IGLEA,LPF,SPF ',i,j,
-     &                 AREANm1(I,J,bi,bj),
-     &                 IceGrowthRateInLeads(I,J),
-     &                 leadPlumeFraction(I,J),
-     &                 saltPlumeFlux(i,j,bi,bj)
-#endif
-                  
-                  print '(A,2i4,2(1x,1P3E15.4))',
-     &                 'ifice i j HSNOW2/1 TMX TBC',i,j,
-     &                 HSNOW_ORIG(I,J),
+                  print  '(A,2i4,2(1x,1P3E15.4))',
+     &                 'ifice i j HSNOW2/1 TMX    ',i,j,
+     &                 HSNWpreTH(I,J),
      &                 HSNOW(I,J,bi,bj),
-     &                 TMIX(i,j,bi,bj)- TMELT, 
-     &                 TBC
+     &                 theta(I,J,kSurface,bi,bj)
 
-                  print '(A,2i4,2(1x,1P3E15.4))',
+                  print  '(A,2i4,2(1x,1P3E15.4))',
      &                 'ifice i j TI ATP LWD      ',i,j,
-     &                 TICE(i,j,bi,bj) - TMELT,
-     &                 ATEMP(i,j,bi,bj) -TMELT,
+     &                 TICES(i,j,1, bi,bj) - celsius2k,
+     &                 ATEMP(i,j,bi,bj) - celsius2k,
      &                 LWDOWN(i,j,bi,bj)
 
+                  print  '(A,2i4,2(1x,1P3E15.4))',
+     &                 'ifice i j S_a(tot,OW,ML,NE',i,j,
+     &                 S_a(i,j),
+     &                 S_a_IGROW(I,J),
+     &                 S_a_IGRML(I,J),
+     &                 S_a_IGRNE(I,J)
 
-                  print '(A,2i4,2(1x,1P3E15.4))',
+                  print  '(A,2i4,2(1x,1P3E15.4))',
      &                 'ifice i j S_a S_h S_hsnow ',i,j,
      &                 S_a(i,j),
      &                 S_h(i,j),
      &                 S_hsnow(i,j)
 
-                  print '(A,2i4,2(1x,1P3E15.4))',
-     &                 'ifice i j IVC(E A ENIN)   ',i,j,
-     &                 ExpectedIceVolumeChange(i,j),
+                  print  '(A,2i4,2(1x,1P3E15.4))',
+     &                 'ifice i j IGR(ML OW ICE)  ',i,j,
+     &                 IceGrowthRateMixedLayer(i,j),
+     &                 IceGrowthRateOpenWater(i,j),
+     &                 NetExistingIceGrowthRate(i,j)
+
+
+                  print  '(A,2i4,2(1x,1P3E15.4))',
+     &                 'ifice i j IVC(A ENIN)     ',i,j,
      &                 ActualNewTotalVolumeChange(i,j),
      &                 EnergyInNewTotalIceVolume(i,j)
-                  
-                  print '(A,2i4,2(1x,1P3E15.4))',
+c     &                 ExpectedIceVolumeChange(i,j),
+
+                  print  '(A,2i4,2(1x,1P3E15.4))',
      &                 'ifice i j EF(NOS RE) QNET ',i,j,
      &                 NetEnergyFluxOutOfOcean(i,j),
      &                 ResidualEnergyOutOfOcean(i,j),
      &                 QNET(I,J,bi,bj)
 
-                  print '(A,2i4,3(1x,1P3E15.4))',
+                  print  '(A,2i4,3(1x,1P3E15.4))',
      &                 'ifice i j QSW QSWO QSWI   ',i,j,
      &                 QSW(i,j,bi,bj),
      &                 QSWO(i,j),
      &                 QSWI(i,j)
 
-                  print '(A,2i4,3(1x,1P3E15.4))',
-     &                 'ifice i j SW(BML IML SW)  ',i,j,
-     &                 QSW_absorb_below_first_layer(i,j),
-     &                 QSW_absorb_in_first_layer(i,j),
-     &                 SWFRACB
+c                  print  '(A,2i4,3(1x,1P3E15.4))',
+c     &                 'ifice i j SW(BML IML SW)  ',i,j,
+c     &                 QSW_absorb_below_first_layer(i,j),
+c     &                 QSW_absorb_in_first_layer(i,j),
+c     &                 SWFRACB
 
-                  print '(A,2i4,3(1x,1P3E15.4))',
-     &                 'ifice i j ptc(to, qsw, oa)',i,j,
-     &                 PredTempChange(i,j),
-     &                 PredTempChangeFromQSW (i,j),
-     &                 PredTempChangeFromOA_MQNET(i,j)
-
-
-                  print '(A,2i4,3(1x,1P3E15.4))',
-     &                 'ifice i j ptc(fion,ian,ia)',i,j,
-     &                 PredTempChangeFromF_IO_NET(i,j),
-     &                 PredTempChangeFromF_IA_NET(i,j),
-     &                 PredTempChangeFromFIA(i,j)
-
-                  print '(A,2i4,3(1x,1P3E15.4))',
-     &                 'ifice i j ptc(niv)        ',i,j,
-     &                 PredTempChangeFromNewIceVol(i,j)
+c                  print  '(A,2i4,3(1x,1P3E15.4))',
+c     &                 'ifice i j ptc(to, qsw, oa)',i,j,
+c     &                 PredTempChange(i,j),
+c     &                 PredTempChangeFromQSW (i,j),
+c     &                 PredTempChangeFromOA_MQNET(i,j)
 
 
-                  print '(A,2i4,3(1x,1P3E15.4))',
+c                  print  '(A,2i4,3(1x,1P3E15.4))',
+c     &                 'ifice i j ptc(fion,ian,ia)',i,j,
+c     &                 PredTempChangeFromF_IO_NET(i,j),
+c     &                 PredTempChangeFromF_IA_NET(i,j),
+c     &                 PredTempChangeFromFIA(i,j)
+
+c                  print  '(A,2i4,3(1x,1P3E15.4))',
+c     &                 'ifice i j ptc(niv)        ',i,j,
+c     &                 PredTempChangeFromNewIceVol(i,j)
+
+
+                  print  '(A,2i4,3(1x,1P3E15.4))',
      &                 'ifice i j EmPmR EVP PRE RU',i,j,
      &                 EmPmR(I,J,bi,bj),
      &                 EVAP(I,J,bi,bj),
      &                 PRECIP(I,J,bi,bj),
      &                 RUNOFF(I,J,bi,bj)
 
-                  print '(A,2i4,3(1x,1P3E15.4))',
+                  print  '(A,2i4,3(1x,1P3E15.4))',
      &                 'ifice i j PRROIS,SAOI(R .)',i,j,
      &                 PrecipRateOverIceSurfaceToSea(I,J),
      &                 SnowAccRateOverIce(I,J),
      &                 SnowAccOverIce(I,J)
 
-                  print '(A,2i4,4(1x,1P3E15.4))',
+                  print  '(A,2i4,4(1x,1P3E15.4))',
      &                 'ifice i j SM(PM PMR . .R) ',i,j,
      &                 PotSnowMeltFromSurf(I,J),
      &                 PotSnowMeltRateFromSurf(I,J),
      &                 SnowMeltFromSurface(I,J),
      &                 SnowMeltRateFromSurface(I,J)
 
-                  print '(A,2i4,4(1x,1P3E15.4))',
-     &                 'ifice i j TotSnwMlt ExSnVC',i,j,
-     &                 ActualNewTotalSnowMelt(I,J),
-     &                 ExpectedSnowVolumeChange(I,J)
+                  print  '(A,2i4,4(1x,1P3E15.4))',
+     &                 'ifice i j TotSnwMlt       ',i,j,
+     &                 ActualNewTotalSnowMelt(I,J)
+c     &                 ExpectedSnowVolumeChange(I,J)
 
-
-                  print '(A,2i4,4(1x,1P3E15.4))',
+                  print  '(A,2i4,4(1x,1P3E15.4))',
      &                 'ifice i j fw(CFICE, CFSM) ',i,j,
      &                 FreshwaterContribFromIce(I,J),
      &                 FreshwaterContribFromSnowMelt(I,J)
 
-                  print '(A,2i4,2(1x,1P3E15.4))',
+                  print  '(A,2i4,2(1x,1P3E15.4))',
      &                 'ifice i j --------------  ',i,j
 
                ENDIF
+
                ENDDO
             ENDDO
 #endif /* SEAICE_DEBUG */
-            
-            
-C     end bi,bj loops
-         ENDDO
+
+
+C close bi,bj loops
+       ENDDO
       ENDDO
-      
+
+#else  /* ALLOW_EXF and ALLOW_ATM_TEMP */
+      STOP 'SEAICE_GROWTH not compiled without EXF and ALLOW_ATM_TEMP'
+#endif /* ALLOW_EXF and ALLOW_ATM_TEMP */
+
       RETURN
       END

--- a/pkg/seaice/seaice_growth_adjointable.F
+++ b/pkg/seaice/seaice_growth_adjointable.F
@@ -99,15 +99,27 @@ C conversion factors to go from Q (W/m2) to HEFF (ice meters)
 C conversion factors to go from precip (m/s) unit to HEFF (ice meters)
       _RL convertPRECIP2HI, convertHI2PRECIP
 
-      _RL heffTooHeavy
+
+
 C     wind speed square
       _RL SPEED_SQ
 
 C     Regularization values squared
       _RL area_reg_sq, hice_reg_sq
 
+C     pathological cases thresholds
+      _RL heffTooHeavy
+
 C     Helper variables: reciprocal of some constants
       _RL recip_multDim
+      _RL recip_deltaTtherm
+      _RL recip_rhoIce
+
+C     local value (=1/HO or 1/HO_south)
+      _RL recip_HO
+
+C     local value (=1/ice thickness)
+      _RL recip_HH
 
 #ifndef SEAICE_ITD
 C     facilitate multi-category snow implementation
@@ -146,6 +158,7 @@ C     AREA_PRE :: hold sea-ice fraction field before any seaice-thermo update
       _RL AREApreTH           (1:sNx,1:sNy)
       _RL HEFFpreTH           (1:sNx,1:sNy)
       _RL HSNWpreTH           (1:sNx,1:sNy)
+
 
 C     wind speed
       _RL UG                  (1:sNx,1:sNy)
@@ -269,7 +282,7 @@ C        F_ao > 0
 
 C     F_mi - heat flux from ocean to the ice (W/m^2)
       _RL F_mi                          (1:sNx,1:sNy)
-
+      
       _RL FWsublim                      (1:sNx,1:sNy)
 
 C     S_a_from_IGROW : d(AREA)/dt [from ice growth rate from open water fluxes]
@@ -301,6 +314,10 @@ C ===================================================================
 C     avoid unnecessary divisions in loops
       recip_multDim        = SEAICE_multDim
       recip_multDim        = ONE / recip_multDim
+C     above/below: double/single precision calculation of recip_multDim
+c     recip_multDim        = 1./float(SEAICE_multDim)
+      recip_deltaTtherm = ONE / SEAICE_deltaTtherm
+      recip_rhoIce      = ONE / SEAICE_rhoIce
 
 C     Cutoff for iceload
       heffTooHeavy=drF(kSurface) / 5. _d 0
@@ -341,7 +358,7 @@ C---+----1----+----2----+----3----+----4----+----5----+----6----+----7-|--+----|
      &                       + act4*max1*max2*max3
 #endif /* ALLOW_AUTODIFF_TAMC */
 
-
+cph-test(
 #ifdef ALLOW_AUTODIFF_TAMC
 CADJ STORE area = comlev1_bibj, key = iicekey, byte = isbyte
 CADJ STORE heff = comlev1_bibj, key = iicekey, byte = isbyte
@@ -350,6 +367,7 @@ CADJ STORE qnet = comlev1_bibj, key = iicekey, byte = isbyte
 CADJ STORE qsw = comlev1_bibj, key = iicekey, byte = isbyte
 CADJ STORE tices = comlev1_bibj, key = iicekey, byte = isbyte
 #endif
+cph-test)
 
 C array initializations
 C =====================
@@ -1173,7 +1191,8 @@ c    to calculate freshwater fluxes for the purpose of changing the
 c    salinity of the liquid cell.  In the case of non-zero ice salinity,
 c    the amount of freshwater is reduced by the ratio of ice salinity
 c    to water cell salinity.
-            IF  (salt(I,J,kSurface,bi,bj) .GE. SEAICE_salt0) THEN
+            IF  (salt(I,J,kSurface,bi,bj) .GE. SEAICE_salt0 .AND.
+     &           salt(I,J,kSurface,bi,bj) .GT. 0. _d 0) THEN
 
                  FreshwaterContribFromIce(I,J) =
      &            - ActualNewTotalVolumeChange(I,J) *

--- a/pkg/seaice/seaice_growth_adjointable.F
+++ b/pkg/seaice/seaice_growth_adjointable.F
@@ -1,12 +1,12 @@
-C     $Header: /u/gcmpack/MITgcm/pkg/seaice/seaice_growth_if.F,v 1.10 2010/03/16 19:09:51 gforget Exp $
+C     $Header: /u/gcmpack/MITgcm/pkg/seaice/seaice_growth.F,v 1.10 2007/01/09 13:33:49 mlosch Exp $
 C     $Name:  $
 
 #include "SEAICE_OPTIONS.h"
 
 C     StartOfInterface
-      SUBROUTINE SEAICE_GROWTH_IF( myTime, myIter, myThid )
+      SUBROUTINE SEAICE_GROWTH( myTime, myIter, myThid )
 C     /==========================================================\
-C     | SUBROUTINE seaice_growth_if                              |
+C     | SUBROUTINE seaice_growth                                 |
 C     | o Updata ice thickness and snow depth                    |
 C     |==========================================================|
 C     \==========================================================/
@@ -21,14 +21,9 @@ C     === Global variables ===
 #include "FFIELDS.h"
 #include "SEAICE_PARAMS.h"
 #include "SEAICE.h"
-#ifdef ALLOW_EXF
-# include "EXF_OPTIONS.h"
-# include "EXF_FIELDS.h"
-# include "EXF_PARAM.h"
-#endif
-#ifdef ALLOW_SALT_PLUME
-# include "SALT_PLUME.h"
-#endif
+#include "SEAICE_FFIELDS.h"
+#include "SEAICE_DIAGS.h"
+
 #ifdef ALLOW_AUTODIFF_TAMC
 # include "tamc.h"
 #endif
@@ -48,185 +43,124 @@ C     number of surface interface layer
       INTEGER kSurface
 
 C     constants
-      _RL TBC, SDF, ICE2SNOW,TMELT
-      _RL STANTON_NUMBER, USTAR_BASE
+      _RL TBC, SDF, ICE2WATR, ICE2SNOW,TMELT
 
 #ifdef ALLOW_SEAICE_FLOODING
       _RL hDraft, hFlood
+      INTEGER flood_flag
 #endif /* ALLOW_SEAICE_FLOODING */
 
-C     QSWO   - short wave heat flux over ocean (W/m^2)
-C     QSWI   - short wave heat flux under ice  (W/m^2)
+C     QNETI  - net surface heat flux under ice in W/m^2
+C     QSWO   - short wave heat flux over ocean in W/m^2
+C     QSWI   - short wave heat flux under ice in W/m^2
 
-      _RL QSWO                         (1:sNx,1:sNy)
-      _RL QSWI                         (1:sNx,1:sNy)
+      _RL QNETI               (1-OLx:sNx+OLx,1-OLy:sNy+OLy)
+      _RL QSWO                (1-OLx:sNx+OLx,1-OLy:sNy+OLy)
+      _RL QSWI                (1-OLx:sNx+OLx,1-OLy:sNy+OLy)
 
-C     The shortwave heat flux in the open water fraction of the 
-C     grid cell converging within the uppermost ocean grid cell (W/m^2)
-      _RL QSWO_IN_FIRST_LAYER          (1:sNx,1:sNy)
+      _RL QSWO_IN_FIRST_LAYER
+     &      (1-OLx:sNx+OLx,1-OLy:sNy+OLy)
+      _RL QSWO_BELOW_FIRST_LAYER
+     &      (1-OLx:sNx+OLx,1-OLy:sNy+OLy)
 
-C     (1 - QSWO_IN_FIRST_LAYER) (W/m^2)
-      _RL QSWO_BELOW_FIRST_LAYER        (1:sNx,1:sNy)
+      _RL QSW_absorb_in_ML    (1-OLx:sNx+OLx,1-OLy:sNy+OLy)
+      _RL QSW_absorb_below_ML (1-OLx:sNx+OLx,1-OLy:sNy+OLy)
 
-C     The total shortwave heat flux (into open water and through the ice)
-C     converging within the uppermost ocean grid cell (W/m^2)
-      _RL QSW_absorb_in_first_layer     (1:sNx,1:sNy)
+C     actual ice thickness with upper and lower limit
+      _RL HICE_ACTUAL   (1-OLx:sNx+OLx, 1-OLy:sNy+OLy)
 
-C     ( 1 - QSW_absorb_in_first_layer)  (W/m^2) 
-      _RL QSW_absorb_below_first_layer  (1:sNx,1:sNy)
+C     actual snow thickness
+      _RL HSNOW_ACTUAL(1-OLx:sNx+OLx, 1-OLy:sNy+OLy)
 
-C     The actual ice thickness (i.e., mean ice thickness / ice concentration) (m) 
-      _RL HICE_ACTUAL                   (1:sNx,1:sNy)
-
-C     The actual snow thickness (i.e., mean snow thickness / ice concentration) (m) 
-      _RL HSNOW_ACTUAL                  (1:sNx,1:sNy)
-
-C     wind speed (m/s)
-      _RL UG                            (1:sNx,1:sNy)
-
+C     wind speed
+      _RL UG     (1-OLx:sNx+OLx, 1-OLy:sNy+OLy)
       _RL SPEED_SQ
-      _RL RHOFW,CPW,LI,QI,QS,RHOSW
 
-C     Helper Variables for snow flooding
-      _RL EnergyToMeltSnowAndIce        (1:sNx,1:sNy)
-      _RL EnergyToMeltSnowAndIce2       (1:sNx,1:sNy)
+C     IAN
+      _RL RHOI, RHOFW,CPW,LI,QI,QS,GAMMAT,GAMMA,RHOSW,RHOSN
       _RL FL_C1,FL_C2,FL_C3,FL_C4,deltaHS,deltaHI
 
-
-#ifdef SEAICE_USE_ORIGINAL_HEAT_FLUX
-      _RL GAMMA
-#endif
-
-C     Factor by which we increase the u* (friction velocity) when ice is not 
-C     present (dimensionless)
-      _RL MixedLayerTurbulenceFactor
-
-C     Sea ice growth rates (m/s)
-      _RL NetExistingIceGrowthRate      (1:sNx,1:sNy)
-      _RL IceGrowthRateUnderExistingIce (1:sNx,1:sNy)
-      _RL IceGrowthRateFromSurface      (1:sNx,1:sNy)
-      _RL IceGrowthRateOpenWater        (1:sNx,1:sNy)
-      _RL IceGrowthRateMixedLayer       (1:sNx,1:sNy)
-
-#ifdef ALLOW_SALT_PLUME
-c     d(HEFF)/dt from heat fluxes in the open water fraction of the grid cell
-      _RL IceGrowthRateInLeads          (1:sNx,1:sNy)
-
-c     The fraction of salt released in leads by new ice production there
-c     which is to be sent to the salt plume package
-      _RL leadPlumeFraction             (1:sNx,1:sNy)
-#endif
-
-c     The minimum value of HEFF to be divided by during the calculation of d(AREA)/dt
-      _RL HEFF_MIN
+      _RL NetExistingIceGrowthRate      (1-OLx:sNx+OLx,1-OLy:sNy+OLy)
+      _RL IceGrowthRateUnderExistingIce (1-OLx:sNx+OLx,1-OLy:sNy+OLy)
+      _RL IceGrowthRateFromSurface      (1-OLx:sNx+OLx,1-OLy:sNy+OLy)
+      _RL IceGrowthRateOpenWater        (1-OLx:sNx+OLx,1-OLy:sNy+OLy)
+      _RL IceGrowthRateMixedLayer       (1-OLx:sNx+OLx,1-OLy:sNy+OLy)
+      _RL S_a_from_IGROW                (1-OLx:sNx+OLx,1-OLy:sNy+OLy)
  
-c      Variables for debugging (predicted temperature change from various sources)
-      _RL PredTempChange                (1:sNx,1:sNy)
-      _RL PredTempChangeFromQSW         (1:sNx,1:sNy)
-      _RL PredTempChangeFromOA_MQNET    (1:sNx,1:sNy)
-      _RL PredTempChangeFromFIA         (1:sNx,1:sNy)
-      _RL PredTempChangeFromNewIceVol   (1:sNx,1:sNy)
-      _RL PredTempChangeFromF_IA_NET    (1:sNx,1:sNy)
-      _RL PredTempChangeFromF_IO_NET    (1:sNx,1:sNy)
+      _RL PredictTempChg
+     &      (1-OLx:sNx+OLx,1-OLy:sNy+OLy)
+      _RL  PredictTempChgFromQSW
+     &      (1-OLx:sNx+OLx,1-OLy:sNy+OLy)
+      _RL  PredictTempChgFromOA_MQNET
+     &      (1-OLx:sNx+OLx,1-OLy:sNy+OLy)
+      _RL  PredictTempChgFromFIA
+     &      (1-OLx:sNx+OLx,1-OLy:sNy+OLy)
+      _RL  PredictTempChgFromNewIceVol
+     &      (1-OLx:sNx+OLx,1-OLy:sNy+OLy)
+      _RL  PredictTempChgFromF_IA_NET
+     &      (1-OLx:sNx+OLx,1-OLy:sNy+OLy)
+      _RL  PredictTempChgFromF_IO_NET
+     &      (1-OLx:sNx+OLx,1-OLy:sNy+OLy)
 
-      _RL ExpectedIceVolumeChange       (1:sNx,1:sNy)
-      _RL ExpectedSnowVolumeChange      (1:sNx,1:sNy)
-      _RL ActualNewTotalVolumeChange    (1:sNx,1:sNy)
-      _RL ActualNewTotalSnowMelt        (1:sNx,1:sNy)
+      _RL ExpectedIceVolumeChange   (1-OLx:sNx+OLx,1-OLy:sNy+OLy)
+      _RL ExpectedSnowVolumeChange   (1-OLx:sNx+OLx,1-OLy:sNy+OLy)
+      _RL ActualNewTotalVolumeChange(1-OLx:sNx+OLx,1-OLy:sNy+OLy)
+      _RL ActualNewTotalSnowMelt(1-OLx:sNx+OLx,1-OLy:sNy+OLy)
 
-      _RL EnergyInNewTotalIceVolume     (1:sNx,1:sNy)
-      _RL NetEnergyFluxOutOfOcean       (1:sNx,1:sNy)
+      _RL EnergyInNewTotalIceVolume (1-OLx:sNx+OLx,1-OLy:sNy+OLy)
+      _RL NetEnergyFluxOutOfSystem   (1-OLx:sNx+OLx,1-OLy:sNy+OLy)
 
-C     The energy taken out of the ocean which is not converted
-C     to sea ice (Joules)
-      _RL ResidualEnergyOutOfOcean      (1:sNx,1:sNy)
+      _RL ResidualHeatOutOfSystem    (1-OLx:sNx+OLx,1-OLy:sNy+OLy)
 
-C     Snow accumulation rate over ice (m/s)
-      _RL SnowAccRateOverIce            (1:sNx,1:sNy)
+      _RL SnowAccumulationRateOverIce   (1-OLx:sNx+OLx,1-OLy:sNy+OLy)
+      _RL SnowAccumulationOverIce   (1-OLx:sNx+OLx,1-OLy:sNy+OLy)
+      _RL PrecipRateOverIceSurfaceToSea (1-OLx:sNx+OLx,1-OLy:sNy+OLy)
 
-C     Total snow accumulation over ice (m)
-      _RL SnowAccOverIce                (1:sNx,1:sNy)
+      _RL PotSnowMeltRateFromSurf       (1-OLx:sNx+OLx,1-OLy:sNy+OLy)
+      _RL PotSnowMeltFromSurf           (1-OLx:sNx+OLx,1-OLy:sNy+OLy)
+      _RL SnowMeltFromSurface           (1-OLx:sNx+OLx,1-OLy:sNy+OLy)
+      _RL SnowMeltRateFromSurface       (1-OLx:sNx+OLx,1-OLy:sNy+OLy)
 
-C     The precipitation rate over the ice which goes immediately into the ocean
-      _RL PrecipRateOverIceSurfaceToSea (1:sNx,1:sNy)
+      _RL FreshwaterContribFromSnowMelt (1-OLx:sNx+OLx,1-OLy:sNy+OLy)
+      _RL FreshwaterContribFromIce      (1-OLx:sNx+OLx,1-OLy:sNy+OLy)
 
-C     The potential snow melt rate if all snow surface heat flux convergences
-C     goes to melting snow (m/s)
-      _RL PotSnowMeltRateFromSurf       (1:sNx,1:sNy)
+      _RL SurfHeatFluxConvergToSnowMelt (1-OLx:sNx+OLx,1-OLy:sNy+OLy)
+      _RL EnergyToMeltSnowAndIce        (1-OLx:sNx+OLx,1-OLy:sNy+OLy)
+      _RL EnergyToMeltSnowAndIce2       (1-OLx:sNx+OLx,1-OLy:sNy+OLy)
 
-C     The potential thickness of snow which could be melted by snow surface
-C     heat flux convergence (m)
-      _RL PotSnowMeltFromSurf           (1:sNx,1:sNy)
+C     dA/dt = S_a
+      _RL S_a (1-OLx:sNx+OLx,1-OLy:sNy+OLy)
+C     dh/dt = S_h
+      _RL S_h (1-OLx:sNx+OLx,1-OLy:sNy+OLy)
+      _RL S_hsnow (1-OLx:sNx+OLx,1-OLy:sNy+OLy)
+      _RL HSNOW_ORIG (1-OLx:sNx+OLx,1-OLy:sNy+OLy)
 
-C     The actual snow melt rate due to snow surface  heat flux convergence
-      _RL SnowMeltRateFromSurface       (1:sNx,1:sNy)
-
-C     The actual surface heat flux convergence used to melt snow (W/m^2)
-      _RL SurfHeatFluxConvergToSnowMelt (1:sNx,1:sNy)
-
-C     The actual thickness of snow to be melted by snow surface
-C     heat flux convergence (m)
-      _RL SnowMeltFromSurface           (1:sNx,1:sNy)
-
-C     The freshwater contribution to the ocean from melting snow (m)
-      _RL FreshwaterContribFromSnowMelt (1:sNx,1:sNy)
-
-C     The freshwater contribution to (from) the ocean from melting (growing) ice (m)
-      _RL FreshwaterContribFromIce      (1:sNx,1:sNy)
-
-C     S_a : d(AREA)/dt
-      _RL S_a                           (1:sNx,1:sNy)
-
-C     S_a_from_IGROW : d(AREA)/dt [from ice growth rate from open water fluxes]
-      _RL S_a_from_IGROW                (1:sNx,1:sNy)
-
-C     S_h : d(HEFF)/dt
-      _RL S_h                           (1:sNx,1:sNy)
-
-C     S_hsnow : d(HSNOW)/dt
-      _RL S_hsnow                       (1:sNx,1:sNy)
-
-C     HSNOW_ORIG : The mean snow thickness before any accumulation, 
-C                  melt, or flooding (m)
-      _RL HSNOW_ORIG                    (1:sNx,1:sNy)
-
-C     F_ia  - sea ice/snow surface heat flux with atmosphere (W/m^2)
-C       F_ia > 0, heat loss to atmosphere
-C       F_ia < 0, atmospheric heat flux convergence (ice/snow surface melt)
-      _RL F_ia                          (1:sNx,1:sNy)
-
-C     F_ia_net - the net heat flux divergence at the sea ice/snow surface
-C                including sea ice conductive fluxes and atmospheric fluxes (W/m^2)
-C       F_ia_net = 0, sea ice/snow surface energy balance condition met
-C                     upward conductive fluxes balance surface heat loss
-C       F_ia_net < 0, net heat flux convergence at ice/snow surface 
-C                     zero conductive fluxes and net atmospheric convergence
-      _RL F_ia_net                      (1:sNx,1:sNy)
-
-C     F_ia_net - the net heat flux divergence at the sea ice/snow surface 
-C                before snow is melted with any convergence (W/m^2)
-C        F_ia_net < 0, some snow, if present, will melt 
-      _RL F_ia_net_before_snow          (1:sNx,1:sNy)
-
-C     F_io_net - the net upward conductive heat flux through the ice+snow system
-C                realized at the sea ice/snow surface
-C        F_io_net > 0, heat conducting upward from ice base --> basal thickening
-C        F_io_net = 0, no upward heat conduction 
-C                      ice/snow surface temperature > SEAICE_freeze)  
-      _RL F_io_net                      (1:sNx,1:sNy)
+C     F_ia  - heat flux from ice to atmosphere (W/m^2)
+C     >0 causes ice growth, <0 causes snow and sea ice melt
+      _RL F_ia     (1-OLx:sNx+OLx,1-OLy:sNy+OLy)
+      _RL F_ia_net (1-OLx:sNx+OLx,1-OLy:sNy+OLy)
+      _RL F_ia_net_before_snow (1-OLx:sNx+OLx,1-OLy:sNy+OLy)
+      _RL F_io_net (1-OLx:sNx+OLx,1-OLy:sNy+OLy)
 
 C     F_ao  - heat flux from atmosphere to ocean (W/m^2)
-C        F_ao > 0
-      _RL F_ao                          (1:sNx,1:sNy)
+      _RL F_ao (1-OLx:sNx+OLx,1-OLy:sNy+OLy)
 
-C     F_mi - heat flux from ocean to the ice (W/m^2)
-      _RL F_mi                          (1:sNx,1:sNy)
- 
+C     F_mi - heat flux from mixed layer to ice (W/m^2)
+      _RL F_mi (1-OLx:sNx+OLx,1-OLy:sNy+OLy)
+      _RL F_mi_act (1-OLx:sNx+OLx,1-OLy:sNy+OLy)
 
-c     The ocean temperature used for the calculation of turbulent ocean-ice heat fluxes
+c     the theta to use for the calculation of mixed layer-> ice heat fluxes 
       _RL surf_theta
+      _RL HEFF_MIN,SNET_ICE,SNET_TOT,MixedLayerTurbulenceFactor
+      _RL HEFFO,HSNOWO
 
-C     Helper variables for debugging
+c     buoyancy flux related
+      _RL ALPHAZ (1-OLx:sNx+OLx,1-OLy:sNy+OLy)
+      _RL BETAZ  (1-OLx:sNx+OLx,1-OLy:sNy+OLy)
+      _RL RHOP0 (1-OLx:sNx+OLx,1-OLy:sNy+OLy)
+
+
+
       _RL FLUX_TO_DELTA_TEMP,ENERGY_TO_DELTA_TEMP
 
       if ( buoyancyRelation .eq. 'OCEANICP' ) then
@@ -235,59 +169,50 @@ C     Helper variables for debugging
          kSurface        = 1
       endif
 
-c    For debugging
       FLUX_TO_DELTA_TEMP = SEAICE_deltaTtherm*
      &            recip_Cp*recip_rhoConst * recip_drF(1)
 
       ENERGY_TO_DELTA_TEMP = recip_Cp*recip_rhoConst*recip_drF(1)
 
-C     TBC : The freezing point of seawater (deg C)
+C     FREEZING TEMP. OF SEA WATER (deg C)
       TBC          = SEAICE_freeze
 
-C     TMELT : The freezing point of fresh water (deg K)
-      TMELT = 273.15 _d 0 
+C     FREEZING POINT OF FRESHWATER 
+      TMELT = 273.15
 
-c     A reference seawater density (kg m^-3)
-      RHOSW = 1026. _d 0
+C     IAN
 
-c     Freshwater density (kg m^-3)
-      RHOFW = rhoConstFresh
+c     Freshwater ice density (kg m^-3) (not salty ice density)
+      RHOI = 917.0
 
-c     The Stanton number for the McPhee 
-c     ocean-ice heat flux parameterization (dimensionless)
-      STANTON_NUMBER = 0.0056 _d 0 
+c     Seawater density (kg m^-3)
+      RHOSW = 1026.0
 
-c     USTAR_BASE : A typical friction velocity beneath sea 
-c                  ice for the McPhee heat flux parameterization (m/s)
-      USTAR_BASE = 0.0125 _d 0
+c     Freshwater density (KG M^-3)
+      RHOFW = 1000.0
 
-C     CPW : Seawater heat capacity   (J m^-3 K^-1)
-      CPW = 4010. _d 0
+C     Snow density
+      RHOSN = 330.0
 
-c     Li : Ice latent heat of fusion (J kg^-1)
-      Li = 3.34 _d 5 
+C     Heat capacity of seawater (J  kg^-1 K^-1)
+      CPW = 4010.0
 
-c     Factors used to to map between energy fluxes and snow/ice melt or growth
-      QI = ONE/SEAICE_rhoIce/Li
-      QS = ONE/SEAICE_rhoSnow/Li
+c     latent heat of fusion for ice (J kg^-1)
+      LI = 3.340e5 
+c     conversion between Joules and m^3 of ice  (m^3)
+      QI = 1/rhoi/Li
+      QS = 1/RHOSN/Li
 
-c     Helper terms for snow flooding
-      FL_C2 = SEAICE_rhoIce/RHOSW
-      FL_C3 = (RHOSW-SEAICE_rhoIce)/SEAICE_rhoSnow
-      FL_C4 = SEAICE_rhoSnow/SEAICE_rhoIce
+c     FOR FLOODING
+      FL_C2 = RHOI/RHOSW
+      FL_C3 = (RHOSW-RHOI)/RHOSN
+      FL_C4 = RHOSN/RHOI
 
-#ifdef SEAICE_USE_ORIGINAL_HEAT_FLUX
-c     GAMMA is used to calculate ocean-ice heat fluxes from
-c     a user-specified flux timescale (SEAICE_gamma_t).  
-c     Originally, 3 days in seconds was suggested as useful.
-c     To keep this timescale up to date given advances in
-c     the parameterization, GAMMA is specified as follows, 
-c     
-      GAMMA =  10. _d 0/SEAICE_gamma_t
+     
 
-c     n.b., changed from drF(1)/SEAICE_gamma_t to make 
-c     a more robust form in setups with a higher vertical resolution.
-#endif
+c     Timescale for melting of ice from a warm ML (3 days in seconds)     
+c     Damping term for mixed layer heat to melt existing ice
+      GAMMA =  dRf(1)/SEAICE_gamma_t
 
       DO bj=myByLo(myThid),myByHi(myThid)
          DO bi=myBxLo(myThid),myBxHi(myThid)
@@ -308,226 +233,213 @@ C
 C     initialise a few fields
 C     
 #ifdef ALLOW_AUTODIFF_TAMC
-CADJ STORE area(:,:,bi,bj) = comlev1_bibj, 
-CADJ &                       key = iicekey, byte = isbyte
+CADJ STORE area(:,:,:,bi,bj) = comlev1_bibj, 
+CADJ &                         key = iicekey, byte = isbyte
+CADJ STORE qnet(:,:,bi,bj)   = comlev1_bibj, 
+CADJ &                         key = iicekey, byte = isbyte
+CADJ STORE qsw(:,:,bi,bj)    = comlev1_bibj, 
+CADJ &                         key = iicekey, byte = isbyte
 #endif /* ALLOW_AUTODIFF_TAMC */
-
-#ifdef SEAICE_SIMULATE_CONVERGENCE_IN_1D_MODEL
-c           simulate total convergence from dynamics
             DO J=1,sNy
                DO I=1,sNx
-                  IF (HEFF(I,J,bi,bj) .GT. ZERO) THEN
-                     AREA(I,J,bi,bj) = ONE
-                  ENDIF
-               ENDDO
-            ENDDO
-#endif
+                  F_ia_net (I,J)      = 0.0 
+                  F_ia_net_before_snow(I,J)      = 0.0 
+                  F_io_net (I,J)      = 0.0 
 
-#ifdef ALLOW_AUTODIFF_TAMC
-CADJ STORE area(:,:,bi,bj) = comlev1_bibj, 
-CADJ &                       key = iicekey, byte = isbyte
-CADJ STORE qnet(:,:,bi,bj) = comlev1_bibj, 
-CADJ &                       key = iicekey, byte = isbyte
-CADJ STORE qsw(:,:,bi,bj)  = comlev1_bibj, 
-CADJ &                       key = iicekey, byte = isbyte
-#endif /* ALLOW_AUTODIFF_TAMC */
-c
-            DO J=1,sNy
-               DO I=1,sNx
-c                 Bound area, heff, and hsnow 
-                  AREA(I,J,bi,bj) = MIN(ONE,AREA(I,J,bi,bj))
-                  AREA(I,J,bi,bj) = MAX(ZERO,AREA(I,J,bi,bj))
-                  HEFF(I,J,bi,bj) = MAX(ZERO, HEFF(I,J,bi,bj))
-                  HSNOW(I,J,bi,bj)  = MAX(ZERO, HSNOW(I,J,bi,bj))
+                  F_ia (I,J)      = 0.0 
+                  F_ao (I,J)      = 0.0 
+                  F_mi (I,J)      = 0.0 
+                  F_mi_act (I,J)      = 0.0 
 
-c                 Sanity checks 
-                  IF (HEFF(I,J,bi,bj) .LE. ZERO .OR.
-     &                AREA(I,J,bi,bj) .LE. ZERO) THEN
-                    
-                    AREA(I,J,bi,bj)       = 0. _d 0
-                    HEFF(I,J,bi,bj)       = 0. _d 0
-                    HSNOW(I,J,bi,bj)      = 0. _d 0
-                  ENDIF
-               ENDDO
-            ENDDO
+                  QNETI(I,J)      = 0.0 
+                  QSWO (I,J)      = 0.0 
+                  QSWI (I,J)      = 0.0 
 
+                  QSWO_BELOW_FIRST_LAYER (I,J) = 0.0 
+                  QSWO_IN_FIRST_LAYER    (I,J) = 0.0 
 
-            DO J=1,sNy
-               DO I=1,sNx
-                  F_ia_net                        (I,J) = 0. _d 0
-                  F_ia_net_before_snow            (I,J) = 0. _d 0
-                  F_io_net                        (I,J) = 0. _d 0
+C---+----1----+----2----+----3----+----4----+----5----+----6----+----7-|--+----|
+                  flux_MLI  (I,J,bi,bj) = 0.0 
+                  flux_AOS  (I,J,bi,bj) = 0.0 
+                  flux_AOZ  (I,J,bi,bj) = 0.0 
 
-                  F_ia                            (I,J) = 0. _d 0
-                  F_ao                            (I,J) = 0. _d 0
-                  F_mi                            (I,J) = 0. _d 0
+                  SID_SAML (I,J,bi,bj) = 0.0
+                  SID_SAEI (I,J,bi,bj) = 0.0
+                  SID_SAOW (I,J,bi,bj) = 0.0
 
-                  QSWO                            (I,J) = 0. _d 0
-                  QSWI                            (I,J) = 0. _d 0
+                  SID_Sh   (I,J,bi,bj) = 0.0
+                  SID_Shs  (I,J,bi,bj) = 0.0
+                  SID_Sa   (I,J,bi,bj) = 0.0
 
-                  QSWO_BELOW_FIRST_LAYER          (I,J) = 0. _d 0
-                  QSWO_IN_FIRST_LAYER             (I,J) = 0. _d 0
+                  SID_FC_S (I,J,bi,bj) = 0.0
+                  SID_FC_I (I,J,bi,bj) = 0.0
 
-                  S_a                             (I,J) = 0. _d 0
-                  S_h                             (I,J) = 0. _d 0
+                  SID_SHML(I,J,bi,bj) =  0.0 
+                  SID_SHEI(I,J,bi,bj) =  0.0 
+                  SID_SHOW(I,J,bi,bj) =  0.0
 
-                  IceGrowthRateUnderExistingIce   (I,J) = 0. _d 0
-                  IceGrowthRateFromSurface        (I,J) = 0. _d 0
-                  NetExistingIceGrowthRate        (I,J) = 0. _d 0
-                  S_a_from_IGROW                  (I,J) = 0. _d 0
+                  SID_SBFI(I,J,bi,bj)  = 0.0
+                  SID_SBFT(I,J,bi,bj)  = 0.0
+                  SID_EBFT(I,J,bi,bj)  = 0.0
+                  SID_EBFI(I,J,bi,bj)  = 0.0
 
-                  PredTempChange                  (I,J) = 0. _d 0
-                  PredTempChangeFromQSW           (I,J) = 0. _d 0
-                  PredTempChangeFromOA_MQNET      (I,J) = 0. _d 0
-                  PredTempChangeFromFIA           (I,J) = 0. _d 0
-                  PredTempChangeFromF_IA_NET      (I,J) = 0. _d 0
-                  PredTempChangeFromF_IO_NET      (I,J) = 0. _d 0
-                  PredTempChangeFromNewIceVol     (I,J) = 0. _d 0
+                  SID_DUM1 (I,J,bi,bj) = 0.0
+                  SID_DUM2 (I,J,bi,bj) = 0.0
+                  SID_DUM3 (I,J,bi,bj) = 0.0
+                  SID_DUM4 (I,J,bi,bj) = 0.0
+                  SID_DUM5 (I,J,bi,bj) = 0.0
+                  SID_DUM6 (I,J,bi,bj) = 0.0
+                  SID_DUM7 (I,J,bi,bj) = 0.0
+                  SID_DUM8 (I,J,bi,bj) = 0.0
+C---+----1----+----2----+----3----+----4----+----5----+----6----+----7-|--+----|
 
-                  IceGrowthRateOpenWater          (I,J) = 0. _d 0
-                  IceGrowthRateMixedLayer         (I,J) = 0. _d 0
+                  S_a                             (I,J) = 0.0 
+                  S_h                             (I,J) = 0.0 
 
-#ifdef ALLOW_SALT_PLUME
-                  IceGrowthRateInLeads            (I,J) = 0. _d 0
-                  leadPlumeFraction               (I,J) = 0. _d 0
-                  saltPlumeFlux             (I,J,bi,bj) = 0. _d 0
-#endif
+                  IceGrowthRateUnderExistingIce   (I,J) = 0.0 
+                  IceGrowthRateFromSurface        (I,J) = 0.0 
+                  NetExistingIceGrowthRate        (I,J) = 0.0 
+                  S_a_from_IGROW                  (I,J) = 0.0
 
-                  ExpectedIceVolumeChange         (I,J) = 0. _d 0
-                  ExpectedSnowVolumeChange        (I,J) = 0. _d 0
-                  ActualNewTotalVolumeChange      (I,J) = 0. _d 0
-                  ActualNewTotalSnowMelt          (I,J) = 0. _d 0
+                  PredictTempChg              (I,J) = 0.0
+                  PredictTempChgFromQSW       (I,J) = 0.0
+                  PredictTempChgFromOA_MQNET  (I,J) = 0.0
+                  PredictTempChgFromFIA       (I,J) = 0.0
+                  PredictTempChgFromF_IA_NET  (I,J) = 0.0
+                  PredictTempChgFromF_IO_NET  (I,J) = 0.0
+                  PredictTempChgFromNewIceVol (I,J) = 0.0
 
-                  EnergyInNewTotalIceVolume       (I,J) = 0. _d 0
-                  NetEnergyFluxOutOfOcean         (I,J) = 0. _d 0
-                  ResidualEnergyOutOfOcean          (I,J) = 0. _d 0
-                  QSW_absorb_in_first_layer       (I,J) = 0. _d 0
-                  QSW_absorb_below_first_layer    (I,J) = 0. _d 0
+                  IceGrowthRateOpenWater          (I,J) = 0.0 
+                  IceGrowthRateMixedLayer         (I,J) = 0.0 
 
-                  SnowAccRateOverIce              (I,J) = 0. _d 0
-                  SnowAccOverIce                  (I,J) = 0. _d 0
-                  PrecipRateOverIceSurfaceToSea   (I,J) = 0. _d 0
+                  ExpectedIceVolumeChange         (I,J) = 0.0 
+                  ExpectedSnowVolumeChange        (I,J) = 0.0 
+                  ActualNewTotalVolumeChange      (I,J) = 0.0 
+                  ActualNewTotalSnowMelt          (I,J) = 0.0 
 
-                  PotSnowMeltRateFromSurf         (I,J) = 0. _d 0
-                  PotSnowMeltFromSurf             (I,J) = 0. _d 0
-                  SnowMeltFromSurface             (I,J) = 0. _d 0
-                  SnowMeltRateFromSurface         (I,J) = 0. _d 0
-                  SurfHeatFluxConvergToSnowMelt   (I,J) = 0. _d 0
+                  EnergyInNewTotalIceVolume       (I,J) = 0.0 
+                  NetEnergyFluxOutOfSystem        (I,J) = 0.0 
+                  ResidualHeatOutOfSystem         (I,J) = 0.0 
+                  QSW_absorb_in_ML                (I,J) = 0.0 
+                  QSW_absorb_below_ML             (I,J) = 0.0 
 
-                  FreshwaterContribFromSnowMelt   (I,J) = 0. _d 0
-                  FreshwaterContribFromIce        (I,J) = 0. _d 0
+                  SnowAccumulationRateOverIce     (I,J) = 0.0
+                  SnowAccumulationOverIce         (I,J) = 0.0
+                  PrecipRateOverIceSurfaceToSea   (I,J) = 0.0
+
+                  PotSnowMeltRateFromSurf         (I,J) = 0.0
+                  PotSnowMeltFromSurf             (I,J) = 0.0
+                  SnowMeltFromSurface             (I,J) = 0.0
+                  SnowMeltRateFromSurface         (I,J) = 0.0
+                  SurfHeatFluxConvergToSnowMelt   (I,J) = 0.0 
+
+                  FreshwaterContribFromSnowMelt   (I,J) = 0.0
+                  FreshwaterContribFromIce        (I,J) = 0.0
 
 c the post sea ice advection and diffusion ice state are in time level 1.  
 c move these to the time level 2 before thermo.  after this routine 
 c the updated ice state will be in time level 1 again. (except for snow 
 c which does not have 3 time levels for some reason) 
-                  HEFFNm1(I,J,bi,bj) = HEFF(I,J,bi,bj) 
-                  AREANm1(I,J,bi,bj) = AREA(I,J,bi,bj) 
+                  HSNOW(I,J,bi,bj) =  max(0.0, HSNOW(I,J,bi,bj))
+                  HEFF(I,J,1,bi,bj) = max(0.0, HEFF(I,J,1,bi,bj))
+                  AREA(I,J,1,bi,bj) = min(1.0, AREA(I,J,1,bi,bj))
+                  AREA(I,J,1,bi,bj) = max(0.0, AREA(I,J,1,bi,bj))
 
-#ifdef SEAICE_SIMULATE_DIVERGENCE_IN_1D_MODEL
-c Sometimes it's nice to run a 1-D setup but how then to simulate
-c the effect of mechanical divergence?.  To simulate the effect of 
-c having regular lead openings, each time step remove a fraction
-c of the ice area while maintaining the actual thickness of ice
-c and snow.
+c                 I hope this is the advective/diffusive tendency
+c                 it is the difference between what just comes
+c                 back from advection and what we left with 
+                  SID_DUM1(I,J,bi,bj) = (AREA(I,J,1,bi,bj) - 
+     &               AREA_POST_THERMO(I,J,bi,bj))/SEAICE_deltaTtherm
 
-                  IF (AREANm1(I,J,bi,bj) .GT. ZERO) THEN
-                     HICE_ACTUAL(I,J)  = 
-     &                  HEFFNm1(I,J,bi,bj)/AREANm1(I,J,bi,bj)
+                  SID_DUM2(I,J,bi,bj) = (HEFF(I,J,1,bi,bj) - 
+     &               HEFF_POST_THERMO(I,J,bi,bj))/SEAICE_deltaTtherm
 
-                     HSNOW_ACTUAL(I,J) = HSNOW(I,J,bi,bj)/
-     &                  AREANm1(I,J,bi,bj)
-
-c                    Removes about 1.2% of the concentration in 48 hours.
-                     AREANm1(I,J,bi,bj) = AREANm1(I,J,bi,bj)*0.99975 _d 0
-
-c                    Maintain the same snow and ice thickness
-                     HEFFNm1(I,J,bi,bj) = 
-     &                     HICE_ACTUAL(I,J)*AREANm1(I,J,bi,bj)
-
-                     HSNOW(I,J,bi,bj) = 
-     &                     HSNOW_ACTUAL(I,J)*AREANm1(I,J,bi,bj)
-
-                   ENDIF
-#endif            
+                  HEFF(I,J,2,bi,bj) = HEFF(I,J,1,bi,bj) 
+                  AREA(I,J,2,bi,bj) = AREA(I,J,1,bi,bj) 
 
                ENDDO
             ENDDO
 
+C---+----1----+----2----+----3----+----4----+----5----+----6----+----7-|--+----|
+           call FIND_ALPHA(
+     &        bi, bj, 1-OLx, sNx+OLx, 1-OLy, sNy+OLy, 1, 1,
+     &        ALPHAZ)
+
+           call FIND_BETA(
+     &        bi, bj, 1-OLx, sNx+OLx, 1-OLy, sNy+OLy, 1, 1,
+     &        BETAZ )
+
+           CALL FIND_RHOP0(
+     &        bi, bj, 1-OLx, snx+OLx, 1-OLy, sNy+OLy, 1,
+     &        theta, salt,
+     &        RHOP0,
+     &        myThid )
+C---+----1----+----2----+----3----+----4----+----5----+----6----+----7-|--+----|
+
+
+
 #ifdef ALLOW_AUTODIFF_TAMC
-CADJ STORE area(:,:,bi,bj)   = comlev1_bibj, 
+CADJ STORE area(:,:,:,bi,bj) = comlev1_bibj, 
 CADJ &                         key = iicekey, byte = isbyte
-CADJ STORE heff(:,:,bi,bj)   = comlev1_bibj, 
+CADJ STORE heff(:,:,:,bi,bj) = comlev1_bibj, 
 CADJ &                         key = iicekey, byte = isbyte
 CADJ STORE hsnow(:,:,bi,bj)  = comlev1_bibj, 
-CADJ &                         key = iicekey, byte = isbyte
-CADJ STORE tice(:,:,bi,bj)   = comlev1_bibj, 
-CADJ &                         key = iicekey, byte = isbyte
-CADJ STORE precip(:,:,bi,bj) = comlev1_bibj, 
 CADJ &                         key = iicekey, byte = isbyte
 #endif /* ALLOW_AUTODIFF_TAMC */
 
             DO J=1,sNy
                DO I=1,sNx
+
+cif this is hack to prevent negative precip.  somehow negative precips  
+cif escapes my exf_checkrange hack
+#ifndef FORBID_OCEAN_SURFACE_ATMOSPHERE_WATER_FLUXES
+                  IF (PRECIP(I,J,bi,bj) .LT. 0.0 _d 0) THEN 
+                     PRECIP(I,J,bi,bj) = 0.0 _d 0 
+                  ENDIF 
+#else
+                  PRECIP(I,J,bi,bj) = 0.0 _d 0 
+                  EVAP(I,J,bi,bj) = 0.0 _d 0 
+#endif
+
 C WE HAVE TO BE CAREFUL HERE SINCE ADVECTION/DIFFUSION COULD HAVE 
 C MAKE EITHER (BUT NOT BOTH) HEFF OR AREA ZERO OR NEGATIVE 
 C HSNOW COULD ALSO BECOME NEGATIVE 
-                  HEFFNm1(I,J,bi,bj) = MAX(ZERO,HEFFNm1(I,J,bi,bj)) 
-                  HSNOW(I,J,bi,bj)   = MAX(ZERO,HSNOW(I,J,bi,bj)  ) 
-                  AREANm1(I,J,bi,bj) = MAX(ZERO,AREANm1(I,J,bi,bj)) 
-cif this is hack to prevent negative precip.  somehow negative precips  
-cif escapes my exf_checkrange hack
-cph-checkthis
-                  IF (PRECIP(I,J,bi,bj) .LT. ZERO) THEN 
-                     PRECIP(I,J,bi,bj) = ZERO 
-                  ENDIF 
-               ENDDO
-            ENDDO
-            
-#ifdef ALLOW_AUTODIFF_TAMC
-CADJ STORE area(:,:,bi,bj)   = comlev1_bibj, 
-CADJ &                         key = iicekey, byte = isbyte
-CADJ STORE heff(:,:,bi,bj)   = comlev1_bibj, 
-CADJ &                         key = iicekey, byte = isbyte
-CADJ STORE hsnow(:,:,bi,bj)  = comlev1_bibj, 
-CADJ &                         key = iicekey, byte = isbyte
-CADJ STORE precip(:,:,bi,bj) = comlev1_bibj, 
-CADJ &                         key = iicekey, byte = isbyte
-#endif
-            DO J=1,sNy
-               DO I=1,sNx
-
-                  IF (HEFFNm1(I,J,bi,bj) .LE. ZERO) THEN 
-                      AREANm1(I,J,bi,bj) = 0. _d 0
-                      HSNOW(I,J,bi,bj)   = 0. _d 0
+                  HEFF(I,J,2,bi,bj)  = MAX(0.0, HEFF(I,J,2,bi,bj)  ) 
+                  HSNOW(I,J,bi,bj)   = MAX(0.0, HSNOW(I,J,bi,bj)   ) 
+                  AREA(I,J,2,bi,bj)  = MAX(0.0, AREA(I,J,2,bi,bj)  ) 
+ 
+                  IF (HEFF(I,J,2,bi,bj) .LE. 0.0 _d 0) THEN 
+                      AREA(I,J,2,bi,bj) = 0.0 _d 0 
+                      HSNOW(I,J,bi,bj)  = 0.0 _d 0 
                   ENDIF 
  
-                  IF (AREANm1(I,J,bi,bj) .LE. ZERO) THEN 
-                     HEFFNm1(I,J,bi,bj)  = 0. _d 0
-                     HSNOW(I,J,bi,bj)    = 0. _d 0
+                  IF (AREA(I,J,2,bi,bj) .LE. 0.0 _d 0) THEN 
+                     HEFF(I,J,2,bi,bj)  = 0.0 _d 0 
+                     HSNOW(I,J,bi,bj)   = 0.0 _d 0 
                   ENDIF 
  
 C PROCEED ONLY IF WE ARE CERTAIN TO HAVE ICE (AREA > 0) 
 
-                  IF (AREANm1(I,J,bi,bj) .GT. ZERO) THEN
+                  IF (AREA(I,J,2,bi,bj) .GT. 0.0 _d 0) THEN
                      HICE_ACTUAL(I,J)  = 
-     &                  HEFFNm1(I,J,bi,bj)/AREANm1(I,J,bi,bj)
+     &                  HEFF(I,J,2,bi,bj)/AREA(I,J,2,bi,bj)
 
                      HSNOW_ACTUAL(I,J) = HSNOW(I,J,bi,bj)/
-     &                  AREANm1(I,J,bi,bj)
+     &                  AREA(I,J,2,bi,bj)
 
 c                   ACCUMULATE SNOW
 c                   Is the ice/surface below freezing or at the freezing 
 c                   point (melting).  If it is freezing the precip is 
 c                   felt as snow and will accumulate over the ice. Else,
-c                   precip makes its way, like all things in time, to the sea.
+c                   precip makes its way, like all things in time, to the sea.            
+
                     IF (TICE(I,J,bi,bj) .LT. TMELT) THEN
 c                     Snow falls onto freezing surface remaining as snow
-                      SnowAccRateOverIce(I,J) = 
-     &                  PRECIP(I,J,bi,bj)*RHOFW/SEAICE_rhoSnow
+                      SnowAccumulationRateOverIce(I,J) = 
+     &                  PRECIP(I,J,bi,bj)*RHOFW/RHOSN
 
 c                     None of the precipitation falls into the sea 
-                      PrecipRateOverIceSurfaceToSea(I,J) = 0. _d 0
+                      PrecipRateOverIceSurfaceToSea(I,J) = 0.0
   
                     ELSE 
 c                     The snow melts on impact is is considered 
@@ -535,34 +447,44 @@ c                     nothing more than rain.  Since meltponds are
 c                     not explicitly represented,this rain runs
 c                     immediately into the sea
 
-                      SnowAccRateOverIce(I,J) = 0. _d 0
+                      SnowAccumulationRateOverIce(I,J) = 0.0
 C                     The rate of rainfall over melting ice.
                       PrecipRateOverIceSurfaceToSea(I,J)=
      &                  PRECIP(I,J,bi,bj)
                    ENDIF
 
 c                  In m of mean snow thickness.
-                   SnowAccOverIce(I,J) = 
-     &                  SnowAccRateOverIce(I,J)
-     &                  *SEAICE_deltaTtherm*AreaNm1(I,J,bi,bj)
+                   SnowAccumulationOverIce(I,J) = 
+     &                  SnowAccumulationRateOverIce(I,J)
+     &                  *SEAICE_deltaTtherm*Area(I,J,2,bi,bj)
 
                 ELSE
-                   HEFFNm1(I,J,bi,bj) = 0. _d 0
-                   HICE_ACTUAL(I,J)   = 0. _d 0
-                   HSNOW_ACTUAL(I,J)  = 0. _d 0
-                   HSNOW(I,J,bi,bj)   = 0. _d 0
+                   HEFF(I,J,2,bi,bj) = 0.0
+                   HICE_ACTUAL(I,J)  = 0.0 
+                   HSNOW_ACTUAL(I,J) = 0.0
+                   HSNOW(I,J,bi,bj)  = 0.0
                 ENDIF
                 HSNOW_ORIG(I,J) = HSNOW(I,J,bi,bj)
              ENDDO
           ENDDO
             
 C     FIND ATM. WIND SPEED
-        DO J=1,sNy
-         DO I=1,sNx
-C         copy the wind speed computed in exf_wind.F to UG
-          UG(I,J) = MAX(SEAICE_EPS,wspeed(I,J,bi,bj))
-         ENDDO
-        ENDDO
+            DO J=1,sNy
+               DO I=1,sNx
+#ifdef SEAICE_EXTERNAL_FORCING
+c     USE EXF PACKAGE
+                  UG(I,J) = MAX(SEAICE_EPS,wspeed(I,J,bi,bj))
+#else 
+C     CALCULATE IT HERE
+                  SPEED_SQ = UWIND(I,J,bi,bj)**2 + VWIND(I,J,bi,bj)**2
+                  IF ( SPEED_SQ .LE. SEAICE_EPS_SQ ) THEN
+                     UG(I,J)=SEAICE_EPS
+                  ELSE
+                     UG(I,J)=SQRT(SPEED_SQ)
+                  ENDIF
+#endif /* SEAICE_EXTERNAL_FORCING */
+               ENDDO
+            ENDDO
 
 #ifdef ALLOW_AUTODIFF_TAMC
 cphCADJ STORE heff   = comlev1, key = ikey_dynamics
@@ -572,7 +494,7 @@ cphCADJ STORE vwind  = comlev1, key = ikey_dynamics
 CADJ STORE tice   = comlev1, key = ikey_dynamics
 #endif /* ALLOW_AUTODIFF_TAMC */
 
-C           SET LAYER TEMPERATURE IN KELVIN
+C     SET LAYER TEMPERATURE IN KELVIN
             DO J=1,sNy
                DO I=1,sNx
                   TMIX(I,J,bi,bj)=
@@ -580,14 +502,15 @@ C           SET LAYER TEMPERATURE IN KELVIN
                ENDDO
             ENDDO
 
-C           CALCULATE THE THERMODYNAMIC FLUXES WITHIN THE SNOW/ICE SYSTEM
-            CALL SEAICE_BUDGET_ICE_IF(
+C     NOW DO ICE
+
+            CALL SEAICE_BUDGET_ICE(
      I           UG, HICE_ACTUAL, HSNOW_ACTUAL, 
      U           TICE, 
      O           F_io_net,F_ia_net,F_ia, QSWI, 
-     I           bi, bj, myThid)
+     I           bi, bj)
 
-C Sometimes it is nice to have a setup without ice-atmosphere heat
+C Sometimes it's nice to have a setup without ice-atmosphere heat
 C fluxes.  This flag turns those fluxes to zero but leaves the 
 C Ice ocean fluxes intact.  Thus, the first oceanic cell can transfer
 C heat to the ice leading to melting in F_ml and it can release 
@@ -597,14 +520,14 @@ C F_ao
 #ifdef FORBID_ICE_SURFACE_ATMOSPHERE_HEAT_FLUXES
             DO J=1,sNy
                DO I=1,sNx
-                  F_ia_net (I,J)  = 0. _d 0
-                  F_ia (I,J)      = 0. _d 0
-                  F_io_net(I,J)   = 0. _d 0
-                  QSWI(I,J)       = 0. _d 0
+                  F_ia_net (I,J)  = 0.0 
+                  F_ia (I,J)      = 0.0
+                  F_io_net(I,J)   = 0.0 
                ENDDO
             ENDDO
 #endif
 
+C--   NET HEAT FLUX TO ICE FROM MIXED LAYER (POSITIVE MEANS NET OUT)
             DO J=1,sNy
                DO I=1,sNx
 
@@ -618,52 +541,51 @@ C F_ao
                ENDIF
 #endif
 
-c                 If there is heat flux convergence at the snow surface,
-c                 use that energy to melt snow before melting ice.  It's
-c                 possible that some snow will remain after melting, 
-c                 which will drive F_ia_net to zero, or that all of the 
-c                 snow will be melted, leaving a nonzero F_ia_net to melt
-c                 some ice.  
+#ifdef FORBID_ICE_SURFACE_ATMOSPHERE_HEAT_FLUXES
+                  NetExistingIceGrowthRate(I,J) = 0.0 
+#else
                   F_ia_net_before_snow(I,J) = F_ia_net(I,J)
 
-c                 Only continue if there is snow and ice in the cell
-                  IF (AreaNm1(I,J,bi,bj)*HEFFNm1(I,J,bi,bj)
-     &                .LE. ZERO                            ) THEN
-                     IceGrowthRateUnderExistingIce(I,J) = 0. _d 0
-                     IceGrowthRateFromSurface(I,J)      = 0. _d 0
-                     NetExistingIceGrowthRate(I,J)      = 0. _d 0
+                  IF (Area(I,J,2,bi,bj)*HEFF(I,J,2,bi,bj) .LE. 0.) THEN
+                     IceGrowthRateUnderExistingIce(I,J) = 0.0
+                     IceGrowthRateFromSurface(I,J)      = 0.0
+                     NetExistingIceGrowthRate(I,J)      = 0.0 
                   ELSE
-c                    The growth rate (m/s) beneath existing ice is given by the upward
-c                    ocean-ice conductive flux, F_io_net, and QI.
+c                    The growth rate under existing ice is given by the upward
+c                    ocean-ice conductive flux, F_io_net, and QI, which converts
+c                    Joules to meters of ice.  This quantity has units of meters
+c                    of ice per second.
                      IceGrowthRateUnderExistingIce(I,J)=F_io_net(I,J)*QI
 
-c                    The rate at which snow is melted (m/s) because of surface 
-c                    heat flux convergence.  Note, during snow melt, F_ia_net must 
-c                    be negative (implying convergence) to make PSMRFW is positive
+c                    Snow/Ice surface heat convergence is first used to melt 
+c                    snow.  If all of this heat convergence went into melting
+c                    snow, this is the rate at which it would do it
+c                    F_ia_net must be negative, -> PSMRFW is positive for melting
                      PotSnowMeltRateFromSurf(I,J)= - F_ia_net(I,J)*QS
 
-c                    This is the depth of snow (m) that would be melted over one time step.
+c                    This is the depth of snow that would be melted at this rate
+c                    and the seaice delta t. In meters of snow.
                      PotSnowMeltFromSurf(I,J) =
      &                  PotSnowMeltRateFromSurf(I,J)* SEAICE_deltaTtherm
 
-c                    If we can melt MORE than is actually there, then the melt 
-c                    rate is reduced so that only that which is there 
-c                    is melted during the time step.  In this case, not all of the 
-c                    heat flux convergence at the surface is used to melt snow.
-c                    Any remaining energy will melt ice.  
-
+c                    If we can melt MORE than is actually there, then we will 
+c                    reduce the melt rate so that only that which is there 
+c                    is melted in one time step.  In this case not all of the 
+c                    heat flux convergence at the surface is used to melt snow,
+c                    The leftover energy is going to melt ice.  
 c                    SurfHeatFluxConvergToSnowMelt is the part of the total heat 
-c                    flux convergence which melts snow.
+c                    flux convergence going to melt snow. 
 
                      IF (PotSnowMeltFromSurf(I,J) .GE. 
-     &                   HSNOW_ACTUAL(I,J)) THEN
-
-c                      Snow melt and melt rate (actual not mean snow thickness)
+     &                 HSNOW_ACTUAL(I,J)) THEN
+c                      Snow melt and melt rate in actual snow thickness.
                        SnowMeltFromSurface(I,J)     = HSNOW_ACTUAL(I,J)
 
                        SnowMeltRateFromSurface(I,J) = 
      &                   SnowMeltFromSurface(I,J)/ SEAICE_deltaTtherm
 
+c                      Since F_ia_net is focused only over ice, its reduction 
+c                      requires knowing how much snow is actually melted
                        SurfHeatFluxConvergToSnowMelt(I,J) =
      &                   -HSNOW_ACTUAL(I,J)/QS/SEAICE_deltaTtherm
                      ELSE
@@ -685,22 +607,35 @@ c                    ice by the amount used to melt snow
 
                      IceGrowthRateFromSurface(I,J) = F_ia_net(I,J)*QI
 
-c                    The total growth rate (m/s) of the existing ice - the rate of
-c                    new ice accretion at the base less the rate due to surface melt
                      NetExistingIceGrowthRate(I,J) = 
      &                 IceGrowthRateUnderExistingIce(I,J) +
      &                 IceGrowthRateFromSurface(I,J)
                   ENDIF
+c forbid ice surface - atmosphere heat fluxes
+#endif
                ENDDO
             ENDDO
 
-c           Retrieve the air-sea heat and shortwave radiative fluxes
+c     HERE WE WILL MELT SNOW AND ADJUST NET EXISTING ICE GROWTH RATE 
+C     TO REFLECT REDUCTION IN SEA ICE MELT.
+
+C     NOW DETERMINE GROWTH RATES
+C     FIRST DO OPEN WATER
             CALL SEAICE_BUDGET_OCEAN(
      I           UG, 
      U           TMIX, 
      O           F_ao, QSWO, 
-     I           bi, bj, myTime, myIter, myThid )
+     I           bi, bj)
  
+#ifdef FORBID_OCEAN_SURFACE_ATMOSPHERE_HEAT_FLUXES
+            DO J=1,sNy
+               DO I=1,sNx
+                  QSWO (I,J)  = 0.0 
+                  F_ao (I,J)  = 0.0
+               ENDDO
+            ENDDO
+#endif
+
 #ifdef SEAICE_DEBUG
         print *,'myiter', myIter
         print '(A,2i4,2(1x,1P2E15.3))',
@@ -711,337 +646,302 @@ c           Retrieve the air-sea heat and shortwave radiative fluxes
 #endif
 
 
-c--   Not all of the sw radiation is absorbed in the uppermost ocean grid cell layer.
-c     Only that fraction which converges in the uppermost ocean grid cell is used to
-c     melt ice.
-c           SWFRACB - the fraction of incoming sw radiation absorbed in the 
-c                     uppermost ocean grid cell (calculated in seaice_init_vari.F)
+C--   NET HEAT FLUX TO ICE FROM MIXED LAYER (POSITIVE MEANS NET OUT)
+c--   not all of the sw radiation is absorbed in the first layer, only that
+c     which is absorbed melts ice.   SWFRACB is calculated in seaice_init_vari.F 
             DO J=1,sNy
                DO I=1,sNx
+                IF (maskC(I,J,kSurface,bi,bj).NE.0.) THEN
+                  IceGrowthRateOpenWater(I,J) = 0.0
 
-c The contribution of shortwave heating is 
-c not included without #define SHORTWAVE_HEATING
+#ifndef FORBID_OCEAN_SURFACE_ATMOSPHERE_HEAT_FLUXES
+
+c     The contribution of shortwave heating is 
+c     not included without SHORTWAVE_HEATING
 #ifdef SHORTWAVE_HEATING
                   QSWO_BELOW_FIRST_LAYER(i,j)= QSWO(I,J)*SWFRACB
-                  QSWO_IN_FIRST_LAYER(I,J)   = QSWO(I,J)*(ONE - SWFRACB)
+                  QSWO_IN_FIRST_LAYER(I,J)   = QSWO(I,J)*(1.0 - SWFRACB)
 #else 
                   QSWO_BELOW_FIRST_LAYER(i,j)= 0. _d 0
                   QSWO_IN_FIRST_LAYER(I,J)   = 0. _d 0
 #endif
                   IceGrowthRateOpenWater(I,J)= QI*
      &              (F_ao(I,J) - QSWO(I,J) + QSWO_IN_FIRST_LAYER(I,J))
+#endif
+C---+----1----+----2----+----3----+----4----+----5----+----6----+----7-|--+----|
+C   BEGIN DIAGNOSTICS
+c                 air-sea turb +  radiation only in the first layer
+                  flux_AOS(I,J,bi,bj) = 
+     &                     F_ao(I,J) - QSWO(I,J) 
+     &                       + QSWO_IN_FIRST_LAYER(I,J)
+          
+c                 air-sea turb +  radiation throughout 
+                  flux_AOZ(I,J,bi,bj) = F_ao(I,J) 
+C   END DIAGNOSTICS
+C---+----1----+----2----+----3----+----4----+----5----+----6----+----7-|--+----|
 
-             ENDDO
+
+                ENDIF !/MASK
+              ENDDO
             ENDDO        
             
 
 #ifdef ALLOW_AUTODIFF_TAMC
 CADJ STORE theta(:,:,:,bi,bj)= comlev1_bibj, 
 CADJ &                         key = iicekey, byte = isbyte
-CADJ STORE heff(:,:,bi,bj)   = comlev1_bibj, 
+CADJ STORE heff(:,:,:,bi,bj) = comlev1_bibj, 
 CADJ &                         key = iicekey, byte = isbyte
 #endif /* ALLOW_AUTODIFF_TAMC */
 
 
-C--   Calcuate the heat fluxes from the ocean to the sea ice
+C--   NET HEAT FLUX TO ICE FROM MIXED LAYER (POSITIVE MEANS FLUX INTO ICE
+C     AND MELTING)
             DO J=1,sNy
                DO I=1,sNx
-
-C     Calculate the seawater freezing point
+                IF (maskC(I,J,kSurface,bi,bj).NE.0.) THEN
+C     FIND THE FREEZING POINT OF SEAWATER IN THIS CELL
 #ifdef SEAICE_VARIABLE_FREEZING_POINT
                   TBC = -0.0575 _d 0*salt(I,J,kSurface,bi,bj) + 
      &                 0.0901 _d 0
 #endif /* SEAICE_VARIABLE_FREEZING_POINT */
                   
-c     Bound the ocean temperature to be at or above the freezing point.
-      surf_theta = max(theta(I,J,kSurface,bi,bj), TBC)
+c     example: theta(i,j,ksurf)  = 0, tbc = -2, 
+c     fmi = -gamm*rhocpw * (0-(-2)) = - 2 * gamm * rhocpw, 
+c     a NEGATIVE number.  Heat flux INTO ice.
 
-c     This model has two alternative schemes to calculate turbulent ocean-ice
-c     heat fluxes.  Each is described in turn
-c
-c     ==== METHOD 1 ====
-c
-c     The first uses an empircal relationship between the 
-c     'far-field' ocean temperature and ocean to sea ice turbulent heat fluxes 
-c     given by McPhee:
-c
-c     Flux  = rho_sw * cp_sw * <w'T'> 
-c     <w'T'>= S_t *  u_star * (T_o - T_f)
-c
-c          Where,
-c             rho_sw : seawater density (kg m^-3)
-c             cp_sw  : seawater heat capcity (J kg^-1 K^-1)
-c             S_t    : Stanton Number ~ 0.0056 (dimensionless)
-c             u_star : friction velocity beneath ice ~ 0.015 m s^-1
-c             T_o, T_f : The 'far-field' ocean temperature and ice
-c                        freezing point (deg C)
-c
-c     Using typical values, ice advected over waters warmer by 1 degree
-c     will be subjected to a basal heat flux of ~ 345 W m^-2.  
-c
-c     In the model, the criteria for ice growth is that the air-sea
-c     heat loss must exceed the potential ocean-ice heat flux (i.e., more 
-c     potential ice production over one time step than melt).  
-c     Using the above parameterization, ice will form in waters which 
-c     are much warmer than its salinity-determined freezing point
-c     using typical wintertime conditions in, say, the North Atlantic.
-c
-c     Therefore, when no ice is present, an additional factor is applied
-c     to the above <w'T'> (mixedLayerTurbulenceFactor) to represent the idea that 
-c     turbulent mixing at and near the surface of an ice-free ocean
-c     is much greater than mixing beneath an ice-covered one.
-c
-c     A factor of 12.5 is chosen for mixedLayerTurbulenceFactor.  Consequently,
-c     for each 0.1 degree above freezing of the upper ocean grid cell,
-c     the air-sea heat losses must exceed ~ 515 W m^-2 before ice forms.
-c    
-c     Once ice gains a foothold in a grid cell, the McPhee parameterization
-c     is immediately invoked.
-c   
-c     ==== METHOD 2 ====
-c
-c     The second scheme (the original and now outdated version)
-c     subsumes (S_t * u_star) into a single variable (SEAICE_gamma_t)
-c      in the following way:
-c
-c     Flux  = rho_sw * cp_sw * GAMMA 
-c     GAMMA = dRf(1)/SEAICE_gamma_t * (T_o - T_f)
-c    
-c           Where,
-c               dRf(1)  : depth of surface level grid cell (originally 
-c                         assumed to be 10 m)
-c               SEAICE_gamma_t : an empirical parameter (~ 3 days in seconds)
-c
-c     Using typical values, ice advected into a grid cell 
-c     that is warmer than the sea ice freezing point by 1 degree
-c     will be subjected to a basal heat flux of ~ 160 W m^-2.   Therefore,
-c     as written, one should choose a SEAICE_gamma_t = 1.4 days in seconds
-c     to have flux magnitudes match those of the McPhee parameterization.
-c    
-c     The original scheme is accessed by defining  #SEAICE_USE_ORIGINAL_HEAT FLUX
+c     It is fantastic that the model frequently generates thetas less 
+c     then the freezing point.  Just fantastic.  When this happens, 
+c     throw your hands up into the air, shut off the mixed layer 
+c     heat flux, and hope for the best.
+                  surf_theta = max(theta(I,J,kSurface,bi,bj), TBC)
 
-#ifndef SEAICE_USE_ORIGINAL_HEAT_FLUX
-c                 If ice is present, MixedLayerTurbulenceFactor = 1.0, else 12.50
-                  IF (AREANm1(I,J,bi,bj) .GT. 0. _d 0) THEN
-                     MixedLayerTurbulenceFactor = ONE
+C                 Seaice_gamma_t should be chosen so as to give
+c                 GAMMA \approx 5.6e-5 based on the McPhee Stanton number
+c                 closure for <w'T'> of turbulent ocean-ice heat fluxes.
+c
+c                 F_mi   = <w'T'> rho_sw cp_sw
+c
+c                 and 
+c
+c                 <w'T'> = St u_* (T_o - T_frz)
+c
+C                 St     = Stanton number 0.0056
+C                 u_*    = friction velocity, about 1 cm/s beneath ice
+c                 rho_sw = seawater density
+c                 cp_sw  = seawater heat capacity
+c                 T_o    = ocean model grid cell temperature
+c                 T_frz  = ocean model freezing point
+c
+c                 St u_* in the model is parameterized in the GAMMA term
+c
+c                 F_mi = GAMMA * rho_sw cp_sw (T_o - T_frz) *
+c                             MixedLayerTurbulenceFactor
+c
+c                 GAMMA = dR(1) / Seaice_gamma_t
+c
+c                 So seaice_gamma_t must be 1.78e5 or so (about 2 days) 
+c                 to give heat flux values which are similar to data.
+c
+c                 However, F_mi also determines the new ice coalesence criteria
+c                 (new ice forms when F_ao > F_mi) and without ice the u_* value
+c                 can be much larger (by a factor of 3-5). see:
+c
+C                 Monthly Climatologies of Oceanic Friction Velocity Cubed
+C                 Barry A. Klinger, Bohua Huang, Ben Kirtman, Paul Schopf, Jiande Wang
+C                 Journal of Climate 2006 19:21, 5700-5708 
+c               
+c                 Therefore, when ice is not present we bump up the MixedLayerTurbulenceFactor
+c                 to 5.   By doing so, the initial growth of ice
+c                 begins at a lower ocean surface temperature.  Using 
+c                 St=0.0056, u* = 0.05 cm/s, new ice growth require 
+c                 atm fluxes exceeding 8614*(T_o- T_frz) W/m^2
+c
+c                 For example, with atm heat losses at  500 W/m^s, ocean temperatures 
+c                 need to get to 0.0580 degrees 
+c                 above the freezing point before ice forms.
+
+                  IF (AREA(I,J,2,bi,bj) .GT. 0.0 _d 0) THEN
+                     MixedLayerTurbulenceFactor=1.0
                   ELSE
-                     MixedLayerTurbulenceFactor = 12.5 _d 0
+C                    If we don't actually have ice here yet, then 
+C                    u* is going to be 3-5 cms, 
+                     MixedLayerTurbulenceFactor=5.0
                   ENDIF
+                   
+                  F_mi(I,J) = -GAMMA*RHOSW*CPW *(surf_theta - TBC)*
+     &                  MixedLayerTurbulenceFactor
 
-                  F_mi(I,J) = -STANTON_NUMBER * USTAR_BASE * RHOSW *
-     &                CPW *(surf_theta - TBC)*MixedLayerTurbulenceFactor
-#else
-c                 no turbulence factor using original_heat_flux scheme
-                  F_mi(I,J) = -GAMMA*RHOSW*CPW *(surf_theta - TBC)
+                  IceGrowthRateMixedLayer(I,J) = F_mi(I,J)*QI
 
-#endif /* SEAICE_USE_ORIGINAL_HEAT_FLUX */
-
-                  IceGrowthRateMixedLayer(I,J) = F_mi(I,J)*QI;
+C---+----1----+----2----+----3----+----4----+----5----+----6----+----7-|--+----|
+                  flux_MLI(I,J,bi,bj) = F_mi(I,J)
+C---+----1----+----2----+----3----+----4----+----5----+----6----+----7-|--+----|
+                 ENDIF !/ MASK
                ENDDO
-            ENDDO 
+            ENDDO
 
 #ifdef ALLOW_AUTODIFF_TAMC
 CADJ STORE S_h(:,:)         = comlev1_bibj, 
-CADJ &                        key = iicekey, byte = isbyte
+CADJ &                         key = iicekey, byte = isbyte
 #endif /* ALLOW_AUTODIFF_TAMC */
 
-
-
-C           CALCULATE THICKNESS DERIVATIVE (S_h)
+C     CALCULATE THICKNESS DERIVATIVE (S_h)
             DO J=1,sNy
                DO I=1,sNx
+                 
                   S_h(I,J) = 
-     &                 NetExistingIceGrowthRate(I,J)*AREANm1(I,J,bi,bj)+
-     &                 (ONE -AREANm1(I,J,bi,bj))*
+     &                 NetExistingIceGrowthRate(I,J)*AREA(I,J,2,bi,bj)+
+     &                 (1. -AREA(I,J,2,bi,bj))*
      &                 IceGrowthRateOpenWater(I,J) +
      &                 IceGrowthRateMixedLayer(I,J)
 
 c                  Both the accumulation and melt rates are in terms
 c                  of actual snow thickness.  As with ice, multiplying
 c                  with area converts to mean snow thickness.
-                   S_hsnow(I,J) =     AREANm1(I,J,bi,bj)* (
-     &                  SnowAccRateOverIce(I,J) - 
+                   S_hsnow(I,J) =     AREA(I,J,2,bi,bj)* (
+     &                  SnowAccumulationRateOverIce(I,J) - 
      &                  SnowMeltRateFromSurface(I,J)     ) 
+
+C---+----1----+----2----+----3----+----4----+----5----+----6----+----7-|--+----|
+                  IF ((AREA(I,J,2,bi,bj) .GT. 0.0 _d 0) .OR. 
+     &                (S_h(I,J)          .GT. 0.0 _d 0)       ) THEN
+
+                      SID_Shs(I,J,bi,bj) = S_hsnow(I,J)
+
+                      SID_SHML(I,J,bi,bj) = IceGrowthRateMixedLayer(I,J)
+
+                      SID_SHEI(I,J,bi,bj) = 
+     &                  NetExistingIceGrowthRate(I,J)*AREA(I,J,2,bi,bj)
+
+                      SID_SHOW(I,J,bi,bj) = 
+     &                  (1. -AREA(I,J,2,bi,bj))*
+     &                  IceGrowthRateOpenWater(I,J)
+                  ENDIF
+C---+----1----+----2----+----3----+----4----+----5----+----6----+----7-|--+----|
+
                ENDDO
             ENDDO
 
-#ifdef ALLOW_SALT_PLUME
-C       Now that we know the thickness tendency terms, we can calculate the saltPlumeFlux
-        DO J=1,sNy
-         DO I=1,sNx
-
-c            It is assumed that ice production in leads can generate
-c            salt plumes.  The fraction of the salt sent to the plume package
-c            from ice produced in leads (defined as the open water
-c            fraction) is a nonlinear function of ice concentration, AREA.
-c
-c            Specifically, function is a logistic curve (sigmoid) with a range and 
-c            domain {0,1}.  The function, f(AREA), has a single free parameter,
-c            SEAICE_plumeInflectionPoint, the inflection point of the curve.  
-c            By construction, the function has the following properties:
-c            f(1) \approx 1.0
-c            f(SEAICE_plumeInflectionPoint) = 0.5
-c            f(0) \approx 0.0 (when SEAICE_plumeInflectionPoint \geq 0.5)
-c            f(0) > 0.0 (when SEAICE_plumeInflectionPoint < 0.5)
-c
-c            As AREA --> 1, the open water fraction occurs
-c            in narrow leads, new ice production become spatially non-uniform,
-c            and the assumptions motivating KPP no longer hold.  To treat
-c            overturning in a more physically realistic way, the salt produced
-c            in the leads should be sent to depth via the plume package.  To assure 
-c            only narrow leads generate plumes, choose a SEAICE_plumeInflectionPoint 
-c            of > 0.8.
-
-c            Ensure that there is already ice present or that the total ice
-c            ice tendency term is positive.  We don't want to release 
-c            salt if sea ice is not established in the cell.
-
-             IF ((AREANm1(I,J,bi,bj) .GT. ZERO) .OR. 
-     &           (S_h(I,J)           .GT. ZERO)) THEN
- 
-              leadPlumeFraction(I,J) = 
-     &         (ONE + EXP( ( SEAICE_plumeInflectionPoint - 
-     &                       AREANm1(I,J,bi,bj)
-     &                     ) * 5._d 0/
-     &                     (ONE - SEAICE_plumeInflectionPoint)
-     &                   )
-     &         )**(-ONE) 
- 
-c             Only consider positive ice growth rate in leads for salt production
-              IceGrowthRateInLeads(I,J) = max( ZERO,
-     &         (ONE - AREANm1(I,J,bi,bj)) * IceGrowthRateOpenWater(I,J))
-
-              saltPlumeFlux(I,J,bi,bj) = leadPlumeFraction(I,J) * 
-     &            HEFFM(I,J,bi,bj)*IceGrowthRateInLeads(I,J)*
-     &            ICE2WATR*rhoConstFresh*
-     &            (salt(I,J,kSurface,bi,bj) - SEAICE_salinity_fixed)
-             ELSE 
-
-              saltPlumeFlux(I,J,bi,bj) = ZERO 
-
-             ENDIF
-
-         ENDDO
-        ENDDO
-#endif /* ALLOW_SALT_PLUME */
-
 #ifdef ALLOW_AUTODIFF_TAMC
-CADJ STORE area(:,:,bi,bj)  = comlev1_bibj, 
-CADJ &                        key = iicekey, byte = isbyte
-CADJ STORE heff(:,:,bi,bj)  = comlev1_bibj, 
-CADJ &                        key = iicekey, byte = isbyte
-CADJ STORE hsnow(:,:,bi,bj) = comlev1_bibj, 
-CADJ &                        key = iicekey, byte = isbyte
+CADJ STORE area(:,:,:,bi,bj) = comlev1_bibj, 
+CADJ &                         key = iicekey, byte = isbyte
+CADJ STORE heff(:,:,:,bi,bj) = comlev1_bibj, 
+CADJ &                         key = iicekey, byte = isbyte
+CADJ STORE hsnow(:,:,bi,bj)  = comlev1_bibj, 
+CADJ &                         key = iicekey, byte = isbyte
 CADJ STORE S_h(:,:)         = comlev1_bibj, 
-CADJ &                        key = iicekey, byte = isbyte
-CADJ STORE S_hsnow(:,:)     = comlev1_bibj, 
-CADJ &                        key = iicekey, byte = isbyte
+CADJ &                         key = iicekey, byte = isbyte
+CADJ STORE S_hsnow(:,:)      = comlev1_bibj, 
+CADJ &                         key = iicekey, byte = isbyte
 #endif /* ALLOW_AUTODIFF_TAMC */
 
-
-
-c           Caculate dA/dt (S_a)
             DO J=1,sNy
                DO I=1,sNx
-                  S_a(I,J) =  0. _d 0 
+                IF (maskC(I,J,kSurface,bi,bj).NE.0.) THEN
+                  S_a(I,J) =  0.0 
 
-c                 In the following, time derivatives of AREA require
-c                 divisions by HEFF. To prevent sensitivity blow up when
-c                 HEFF --> 0, we divide by an approximation to HEFF, HEFF*:
-c
-c                 HEFF* = sqrt(HEFF^2 + heff_min^2)
-c                      Where heff_min is implicitly defined as 0.1 m. 
-c
-c                 HEFF* is defined as a hyperbola with slope = 1 and 
-c                 y-intercept of heff_min.  The gradient of 1/HEFF* is 
-c                 well-behaved (correct sign) and deviates from 1/HEFF 
-c                 significantly only when HEFF --> 0.
+C                 If I need to divide by heff, divide by this
+                  HEFF_MIN = MAX(0.01, HEFF(I,J,2,bi,bj))
 
-                 IF ( (HEFFNm1(I,J,bi,bj).GT. ZERO) .AND.
-     &                (AREANm1(I,J,bi,bj).NE. ZERO)) THEN
-                     HEFF_MIN = SQRT( 0.01 _d 0 + 
-     &                   HEFFNm1(I,J,bi,bj) * HEFFNm1(I,J,bi,bj) )
-                 ELSE
-c                        Just in case somehow we miss a case, we want to divide
-c                        by a sensible number, here 10 cm.
-                         HEFF_MIN = max(HEFFNm1(I,J,bi,bj), 0.1 _d 0)
-                 ENDIF
+C     IF THE OPEN WATER GROWTH RATE IS POSITIVE 
+C     THEN EXTEND ICE AREAL COVER, S_a > 0
 
-c                 Caculate the ice area growth rate from the open water fluxes.
-c                 First, determine whether the open water growth rate is positive or
-c                 negative.  If positive, make sure that ice is present or that the 
-c                 net ice thickness growth rate is positive before extending ice cover 
+C     TWO CASES, IF THERE IS ALREADY ICE PRESENT THEN EXTEND THE AREA USING THE 
+C     OPEN WATER GROWTH RATE.  IF THERE IS NO ICE PRESENT DO NOT EXTEND THE ICE
+C     UNTIL THE NET ICE THICKNESS RATE IS POSITIVE.  I.E. IF OVERALL THE ICE 
+C     WOULD BE THINNING THEN THE NEW ICE WILL IMMEDIATLEY BE LOST. DO NOT GROW IT
 
-                  IF (IceGrowthRateOpenWater(I,J) .GT. ZERO) THEN
+                  IF (IceGrowthRateOpenWater(I,J) .GT. 0.0 _d 0) THEN
 
-c                    Determine which hemisphere for hemisphere-dependent
-c                    "lead closing variable", HO
+                     S_a_from_IGROW(I,J) = (ONE - AREA(I,J,2,bi,bj))*
+     &                      IceGrowthRateOpenWater(I,J)/HO
 
-                     IF ( YC(I,J,bi,bj) .LT. ZERO ) THEN
-                        S_a_from_IGROW(I,J) = (ONE-AREANm1(I,J,bi,bj))*
-     &                     IceGrowthRateOpenWater(I,J)/HO_south
-                     ELSE
-                        S_a_from_IGROW(I,J) = (ONE-AREANm1(I,J,bi,bj))*
-     &                     IceGrowthRateOpenWater(I,J)/HO
-                     ENDIF
-
-c                    If there is already ice, add to S_a
-                     IF (AREANm1(I,J,bi,bj) .GT. ZERO) THEN
+                     IF (AREA(I,J,2,bi,bj) .GT. 0.0 _d 0 )THEN
+C                       If there is some ice already then we just extend it
                         S_a(I,J) = S_a(I,J) + S_a_from_IGROW(I,J)
-c                    otherwise, add to S_a only if the net ice growth rate
-c                    is positive
                      ELSE
-                        IF (S_h(I,J) .GT. ZERO) THEN
+C                       Make sure the total ice growth rate is positive before
+C                       creating new ice area for the first time....
+                        IF (S_h(I,J) .GT. 0) THEN
                            S_a(I,J) = S_a(I,J) + S_a_from_IGROW(I,J)
                         ENDIF
                      ENDIF
-                  ELSE  
+                  ELSE !* THE OPEN WATER GROWTH RATE IS NEGATIVE !*
+C                   Only melt through the open water if we have some 
+C                   exisiting ice (A>0, H>0),  we already know that the
+C                   growth rate here is negative.
+                    IF ( (AREA(I,J,2,bi,bj).GT. 0. _d 0 ) .AND.
+     &                   (HEFF(I,J,2,bi,bj).GT. 0. _d 0 ) ) THEN
 
-c                    The open water growth rate is negative - contract the ice cover.
-                     IF ( (AREANm1(I,J,bi,bj).GT. ZERO) .AND.
-     &                  (HEFFNm1(I,J,bi,bj).GT. ZERO) ) THEN
-
-                       S_a(I,J) = S_a(I,J) 
-     &                    + AREANm1(I,J,bi,bj)/(2. _d 0*HEFF_MIN)*
+                     S_a(I,J) = S_a(I,J) +
+     &                    AREA(I,J,2,bi,bj)/(2.0*HEFF_MIN)*
      &                    IceGrowthRateOpenWater(I,J)*
-     &                    (ONE - AREANm1(I,J,bi,bj))
-                     ELSE
-                       S_a(I,J) = S_a(I,J) +  0. _d 0
-                     ENDIF
+     &                    (1-AREA(I,J,2,bi,bj))
+
+c     &                   AREA(I,J,2,bi,bj)/(2.0*HEFF(I,J,2,bi,bj))*
+c     &                   IceGrowthRateOpenWater(I,J)*
+c     &                   (1-AREA(I,J,2,bi,bj))
+                    ELSE
+                       S_a(I,J) = S_a(I,J) +  0.0 _d 0
+                    ENDIF
                   ENDIF
 
-C                 Melt ice if the IceGrowthRateMixedLayer is negative
-                  IF ( (IceGrowthRateMixedLayer(I,J) .LE. ZERO) .AND. 
-     &                 (AREANm1(I,J,bi,bj).GT. ZERO) .AND.
-     &                 (HEFFNm1(I,J,bi,bj).NE. ZERO) ) THEN
+C---+----1----+----2----+----3----+----4----+----5----+----6----+----7-|--+----|
+                  SID_SAOW(I,J,bi,bj) = S_a(I,J)
+C---+----1----+----2----+----3----+----4----+----5----+----6----+----7-|--+----|
 
-                     S_a(I,J) = S_a(I,J) 
-     &                    + AREANm1(I,J,bi,bj)/(2. _d 0 *HEFF_MIN)*
+
+C     REDUCE THE ICE COVER IF ICE IS PRESENT
+                  IF ( (IceGrowthRateMixedLayer(I,J) .LE. 0. _d 0) .AND.
+     &                 (AREA(I,J,2,bi,bj).GT. 0. _d 0) .AND.
+     &                 (HEFF(I,J,2,bi,bj).GT. 0. _d 0) ) THEN
+
+                     S_a(I,J) = S_a(I,J) + 
+     &                    AREA(I,J,2,bi,bj)/(2.0*HEFF_MIN)*
      &                    IceGrowthRateMixedLayer(I,J)
 
-                  ELSE
-                     S_a(I,J) = S_a(I,J) +  0. _d 0
-                  ENDIF
+c     &                   AREA(I,J,2,bi,bj)/(2.0*HEFF(I,J,2,bi,bj))*
 
-C                 Melt ice if the NetExistingIceGrowthRate is negative
-                  IF ( (NetExistingIceGrowthRate(I,J) .LE. ZERO) .AND. 
-     &                 (AREANm1(I,J,bi,bj).GT. ZERO) .AND.
-     &                 (HEFFNm1(I,J,bi,bj).NE. ZERO) ) THEN
+C---+----1----+----2----+----3----+----4----+----5----+----6----+----7-|--+----|
+                     SID_SAML(I,J,bi,bj) =
+     &                    AREA(I,J,2,bi,bj)/(2.0*HEFF_MIN)*
+     &                    IceGrowthRateMixedLayer(I,J)
 
-                     S_a(I,J) = S_a(I,J) 
-     &                   + AREANm1(I,J,bi,bj)/(2. _d 0 * HEFF_MIN)*
-     &                  NetExistingIceGrowthRate(I,J)*AREANm1(I,J,bi,bj)
+c     &                   AREA(I,J,2,bi,bj)/(2.0*HEFF(I,J,2,bi,bj))*
+C---+----1----+----2----+----3----+----4----+----5----+----6----+----7-|--+----|
 
                   ELSE
-                     S_a(I,J) = S_a(I,J) +  0. _d 0
+                     S_a(I,J) = S_a(I,J) +  0.0 _d 0 
                   ENDIF
-                  
+
+C     REDUCE THE ICE COVER IF ICE IS PRESENT
+                  IF ( (NetExistingIceGrowthRate(I,J) .LE. 0. _d 0).AND.
+     &                 (AREA(I,J,2,bi,bj).GT. 0. _d 0) .AND.
+     &                 (HEFF(I,J,2,bi,bj).GT. 0. _d 0) ) THEN
+
+                     S_a(I,J) = S_a(I,J) +
+     &                   AREA(I,J,2,bi,bj)/(2.0*HEFF_MIN)*
+     &                   NetExistingIceGrowthRate(I,J)*AREA(I,J,2,bi,bj)
+
+C---+----1----+----2----+----3----+----4----+----5----+----6----+----7-|--+----|
+                     SID_SAEI(I,J,bi,bj) =
+     &                   AREA(I,J,2,bi,bj)/(2.0*HEFF_MIN)*
+     &                   NetExistingIceGrowthRate(I,J)*AREA(I,J,2,bi,bj)
+C---+----1----+----2----+----3----+----4----+----5----+----6----+----7-|--+----|
+
+                  ELSE
+                     S_a(I,J) = S_a(I,J) +  0.0 _d 0
+                  ENDIF
+
+
+                ENDIF !/ MASK  
                ENDDO
             ENDDO
+       
                  
 
 #ifdef ALLOW_AUTODIFF_TAMC
-CADJ STORE heff(:,:,bi,bj)   = comlev1_bibj, 
+CADJ STORE heff(:,:,:,bi,bj) = comlev1_bibj, 
 CADJ &                         key = iicekey, byte = isbyte
 CADJ STORE hsnow(:,:,bi,bj)  = comlev1_bibj, 
 CADJ &                         key = iicekey, byte = isbyte
@@ -1055,88 +955,127 @@ CADJ STORE qswi(:,:)         = comlev1_bibj,
 CADJ &                         key = iicekey, byte = isbyte
 CADJ STORE qswo(:,:)         = comlev1_bibj, 
 CADJ &                         key = iicekey, byte = isbyte
-CADJ STORE area(:,:,bi,bj)   = comlev1_bibj, 
+CADJ STORE area(:,:,:,bi,bj) = comlev1_bibj, 
 CADJ &                         key = iicekey, byte = isbyte
 #endif
 
-C           Update the area, heff, and hsnow 
+C     ACTUALLY CHANGE THE AREA AND THICKNESS
             DO J=1,sNy
                DO I=1,sNx
-                  AREA(I,J,bi,bj) = AREANm1(I,J,bi,bj) + 
+                  AREA(I,J,1,bi,bj) = AREA(I,J,2,bi,bj) + 
      &                 SEAICE_deltaTtherm * S_a(I,J)
-                  HEFF(I,J,bi,bj) = HEFFNm1(I,J,bi,bj) +
-     &                 SEAICE_deltaTTherm * S_h(I,J)
-                  HSNOW(I,J,bi,bj) = HSNOW(I,J,bi,bj) +
-     &                 SEAICE_deltaTTherm * S_hsnow(I,J)
+C     SET LIMIT ON AREA
+                  AREA(I,J,1,bi,bj) = MIN(1.,AREA(I,J,1,bi,bj))
+                  AREA(I,J,1,bi,bj) = MAX(0.,AREA(I,J,1,bi,bj))
+
                ENDDO
             ENDDO
             
 #ifdef ALLOW_AUTODIFF_TAMC
-CADJ STORE area(:,:,bi,bj)  = comlev1_bibj, 
-CADJ &                        key = iicekey, byte = isbyte
-CADJ STORE heff(:,:,bi,bj)  = comlev1_bibj, 
-CADJ &                        key = iicekey, byte = isbyte
-CADJ STORE hsnow(:,:,bi,bj) = comlev1_bibj, 
-CADJ &                        key = iicekey, byte = isbyte
+CADJ STORE area(:,:,:,bi,bj) = comlev1_bibj, 
+CADJ &                         key = iicekey, byte = isbyte
 #endif
-
             DO J=1,sNy
                DO I=1,sNx
-c                 Bound area, heff, and hsnow 
-                  AREA(I,J,bi,bj) = MIN(ONE,AREA(I,J,bi,bj))
-                  AREA(I,J,bi,bj) = MAX(ZERO,AREA(I,J,bi,bj))
-                  HEFF(I,J,bi,bj) = MAX(ZERO, HEFF(I,J,bi,bj))
-                  HSNOW(I,J,bi,bj)  = MAX(ZERO, HSNOW(I,J,bi,bj))
+                IF (maskC(I,J,kSurface,bi,bj).NE.0.) THEN
+                  HEFF(I,J,1,bi,bj) = HEFF(I,J,2,bi,bj) +
+     &                 SEAICE_deltaTTherm * S_h(I,J)
+c                 if we end up with negative ice volume, we 
+c                 need to recalculate f_mi.  It needs a little
+c                 bit put back...
 
-c                 Sanity checks 
-                  IF (HEFF(I,J,bi,bj) .LE. ZERO .OR.
-     &                AREA(I,J,bi,bj) .LE. ZERO) THEN
-                    
-                    AREA(I,J,bi,bj)       = 0. _d 0
-                    HEFF(I,J,bi,bj)       = 0. _d 0
-                    HICE_ACTUAL(I,J)      = 0. _d 0
-                    HSNOW(I,J,bi,bj)      = 0. _d 0
-                    HSNOW_ACTUAL(I,J)     = 0. _d 0
+                  F_mi_act(I,J) = F_mi(I,J)
+C---+----1----+----2----+----3----+----4----+----5----+----6----+----7-|--+----|
+                  IF (HEFF(I,J,1,bi,bj) .LT. 0.0) THEN
+                      F_mi_act(I,J) = F_mi(I,J) - 
+     &                        HEFF(I,J,1,bi,bj)/SEAICE_deltaTTherm /QI
+                  ENDIF
+C---+----1----+----2----+----3----+----4----+----5----+----6----+----7-|--+----|
 
+                  HEFF(I,J,1,bi,bj) = MAX(0.0, HEFF(I,J,1,bi,bj))
+
+                  HSNOW(I,J,bi,bj) = HSNOW(I,J,bi,bj) +
+     &                 SEAICE_deltaTTherm * S_hsnow(I,J)
+                  HSNOW(I,J,bi,bj)  = MAX(0.0, HSNOW(I,J,bi,bj))
+
+                  IF (AREA(I,J,1,bi,bj) .GT. 0.0) THEN
+                      HICE_ACTUAL(I,J) = 
+     &                   HEFF(I,J,1,bi,bj)/AREA(I,J,1,bi,bj)
+                      HSNOW_ACTUAL(I,J) = 
+     &                    HSNOW(I,J,bi,bj)/AREA(I,J,1,bi,bj)
                   ELSE
-c                 Calcuate the actual ice and snow thicknesses
-                    HICE_ACTUAL(I,J)  =  HEFF(I,J,bi,bj)/AREA(I,J,bi,bj)
-                    HSNOW_ACTUAL(I,J) = HSNOW(I,J,bi,bj)/AREA(I,J,bi,bj)
+                      HICE_ACTUAL(I,J) = 0.0
+                      HSNOW_ACTUAL(I,J) = 0.0
+                  ENDIF
+                 ENDIF !/MASK 
+               ENDDO
+            ENDDO
+
+#ifdef ALLOW_AUTODIFF_TAMC
+CADJ STORE area(:,:,:,bi,bj) = comlev1_bibj, 
+CADJ &                         key = iicekey, byte = isbyte
+CADJ STORE heff(:,:,:,bi,bj) = comlev1_bibj, 
+CADJ &                         key = iicekey, byte = isbyte
+#endif /* ALLOW_AUTODIFF_TAMC */
+
+c     constrain area is no thickness and vice versa.
+            DO J=1,sNy
+               DO I=1,sNx
+                  IF (HEFF(I,J,1,bi,bj)  .LE. 0.0 .OR.
+     &                 AREA(I,J,1,bi,bj) .LE. 0.0) THEN
+
+C---+----1----+----2----+----3----+----4----+----5----+----6----+----7-|--+----|
+c                    the area that we are losing because the thickness
+c                    has gone to zero         
+                     SID_DUM3(I,J,bi,bj) =
+     &                   MIN(-AREA(I,J,1,bi,bj)/SEAICE_deltaTtherm, 0.0)
+
+c                    the heff we are losing because the area has gone
+c                    to zero
+                     SID_DUM4(I,J,bi,bj) = 
+     &                   MIN(-HEFF(I,J,1,bi,bj)/SEAICE_deltaTtherm, 0.0)
+C---+----1----+----2----+----3----+----4----+----5----+----6----+----7-|--+----|
+                     
+                     AREA(I,J,1,bi,bj)       = 0.0
+                     HEFF(I,J,1,bi,bj)       = 0.0
+                     HICE_ACTUAL(I,J)        = 0.0
+                     HSNOW(I,J,bi,bj)        = 0.0
+                     HSNOW_ACTUAL(I,J)       = 0.0
+
                   ENDIF
 
                ENDDO
             ENDDO
-            
+ 
+           
 #ifdef ALLOW_AUTODIFF_TAMC
-CADJ STORE area(:,:,bi,bj) = comlev1_bibj, 
-CADJ &                       key = iicekey, byte = isbyte
-CADJ STORE heff(:,:,bi,bj) = comlev1_bibj, 
-CADJ &                       key = iicekey, byte = isbyte
+CADJ STORE area(:,:,:,bi,bj) = comlev1_bibj, 
+CADJ &                         key = iicekey, byte = isbyte
+CADJ STORE heff(:,:,:,bi,bj) = comlev1_bibj, 
+CADJ &                         key = iicekey, byte = isbyte
 #endif /* ALLOW_AUTODIFF_TAMC */
 
             DO J=1,sNy
                DO I=1,sNx
-
-c                 The amount of new mean ice thickness we expect to grow
+                IF (maskC(I,J,kSurface,bi,bj).NE.0.) THEN
+c     The amount of new mean thickness we expect to grow
                   ExpectedIceVolumeChange(I,J)  = S_h(I,J) *
      &                 SEAICE_deltaTtherm
 
-c                 The amount of new mean snow thickness we expect to grow
                   ExpectedSnowVolumeChange(I,J) = S_hsnow(I,J)*
      &                 SEAICE_deltaTtherm
 
-c                 THE EFFECTIVE SHORTWAVE HEATING RATE
+c     THE EFFECTIVE SHORTWAVE HEATING RATE
 #ifdef SHORTWAVE_HEATING
                   QSW(I,J,bi,bj)  =
-     &                 QSWI(I,J)  * (      AREANm1(I,J,bi,bj)) +
-     &                 QSWO(I,J)  * (ONE - AREANm1(I,J,bi,bj))
+     &                 QSWI(I,J)  * (     AREA(I,J,2,bi,bj)) +
+     &                 QSWO(I,J)  * (1. - AREA(I,J,2,bi,bj))
 #else
                   QSW(I,J,bi,bj) = 0. _d 0
 #endif
 
-c                 The actual ice volume change over the time step
                   ActualNewTotalVolumeChange(I,J) = 
-     &                 HEFF(I,J,bi,bj) - HEFFNm1(I,J,bi,bj)
+     &                 HEFF(I,J,1,bi,bj) - HEFF(I,J,2,bi,bj)
 
 c     The net average snow thickness melt that is actually realized. e.g.
 c     hsnow_orig  = 0.25 m (e.g. 1 m of ice over a cell 1/4 covered in snow)
@@ -1148,39 +1087,38 @@ c     since this is in mean snow thickness it might have been  0.4 of actual
 c     snow thickness over the 1/4 of the cell which is ice covered.
                   ActualNewTotalSnowMelt(I,J) = 
      &                 HSNOW_ORIG(I,J) +
-     &                 SnowAccOverIce(I,J) -
+     &                 SnowAccumulationOverIce(I,J) -
      &                 HSNOW(I,J,bi,bj)
 
-c                 The energy required to melt or form the new ice volume
+c     The latent heat of fusion of the new ice
                   EnergyInNewTotalIceVolume(I,J) = 
      &                 ActualNewTotalVolumeChange(I,J)/QI
 
 c     This is the net energy flux out of the ice+ocean system
 c     Remember -----
-c     F_ia_net : Under ice/snow surface freezing conditions, 
-c                vertical conductive heat flux convergence (F_c < 0) balances
-c                heat flux divergence to atmosphere (F_ia > 0)  
-c                Otherwise, F_ia_net = F_ia (pos)
+c     F_ia_net : 0 if under freezing conditions (F_c < 0)
+c                The sum of the non-conductive surfice ice fluxes otherwise
 c
-c     F_io_net : Under ice/snow surface freezing conditions, F_c < 0.
-c                Under ice surface melting conditions, F_c = 0 (no energy flux 
-c                from the ice to ocean)
+c     F_io_net : The conductive fluxes under freezing conditions (F_c < 0)
+c                0 under melting conditions (no energy flux from ice to
+c                ocean)
 c
-c     So if we are freezing, F_io_net = the conductive flux and there 
-c     is energy balance at ice surface, F_ia_net =0.  If we are melting,
-c     there is a convergence of energy into the ice from above
-                  NetEnergyFluxOutOfOcean(I,J) = SEAICE_deltaTtherm *
-     &               (AREANm1(I,J,bi,bj) * 
+c     So if we are freezing, F_io_net is the conductive flux and there 
+c     is energy balance at ice surface, F_ia_net =0.  If we are melting
+c     There is a convergence of energy into the ice from above
+                  NetEnergyFluxOutOfSystem(I,J) = SEAICE_deltaTtherm *
+     &               (AREA(I,J,2,bi,bj) * 
      &               (F_ia_net(I,J) + F_io_net(I,J) + QSWI(I,J))
-     &         +     (ONE - AREANm1(I,J,bi,bj)) *  F_ao(I,J))
+     &         +     (1.0 - AREA(I,J,2,bi,bj)) * 
+     &                F_ao(I,J))
 
 c     THE QUANTITY OF HEAT WHICH IS THE RESIDUAL TO THE QUANTITY OF 
 c     ML temperature.  If the net energy flux is exactly balanced by the 
-c     latent energy of fusion in the new ice created then we will not 
+c     latent energy of fusion in the new ice created then we won't 
 c     change the ML temperature at all.
 
-                  ResidualEnergyOutOfOcean(I,J) = 
-     &             NetEnergyFluxOutOfOcean(I,J) -
+                  ResidualHeatOutOfSystem(I,J) = 
+     &             NetEnergyFluxOutOfSystem(I,J) -
      &             EnergyInNewTotalIceVolume(I,J)
 
 C     NOW FORMULATE QNET, which time LEVEL, ORIG 2.
@@ -1188,29 +1126,45 @@ C     THIS QNET WILL DETERMINE THE TEMPERATURE CHANGE OF THE MIXED LAYER
 C     QNET IS A DEPTH AVERAGED HEAT FLUX FOR THE OCEAN COLUMN
 C     BECAUSE OF THE 
                   QNET(I,J,bi,bj) =
-     &             ResidualEnergyOutOfOcean(I,J) / SEAICE_deltaTtherm
+     &             ResidualHeatOutOfSystem(I,J) / SEAICE_deltaTtherm
 
 
 c    Like snow melt, if there is melting, this quantity is positive.
-c    The change of freshwater content is per unit area over the entire
+c    The change of freshwater content is per unit area over the entire 
 c    cell, not just over the ice covered bits.  This term is only used
-c    to calculate freshwater fluxes for the purpose of changing the
+c    to calculate freshwater fluxes for the purpose of changing the 
 c    salinity of the liquid cell.  In the case of non-zero ice salinity,
 c    the amount of freshwater is reduced by the ratio of ice salinity
-c    to water cell salinity.
-           IF  ( (salt(I,J,kSurface,bi,bj) .GT. ZERO) .AND.
-     &           (salt(I,J,kSurface,bi,bj) .GE. 
-     &                         SEAICE_salinity_fixed))  THEN 
+c    to water cell salinity. 
+           IF  (salt(I,J,kSurface,bi,bj) .GE. SEAICE_salinity ) THEN
 
-                 FreshwaterContribFromIce(I,J) =
-     &            - ActualNewTotalVolumeChange(I,J)*SEAICE_rhoICE/RHOFW*
-     &            (ONE - SEAICE_salinity_fixed/salt(I,J,kSurface,bi,bj))
+#ifdef FORBID_SEAICE_MELTWATER_ENHANCEMENT_MECHANISM
+c            if we have lost volume, for whatever reason, do not count
+c            the loss as a positive freshwater flux to the surface
+c            when this FORBID flag is operational
+c
+c            note : S_h(I,J) may be positive but we may still lose volume
+c            from a loss of area
+c
+             IF (ActualNewTotalVolumeChange(I,J) .LE. 0.0) THEN
+                 FreshwaterContribFromIce(I,J) = 0.0
+             ELSE
+                 FreshwaterContribFromIce(I,J) = 
+     &             -ActualNewTotalVolumeChange(I,J)*RHOI/RHOFW*
+     &             (1.0 - SEAICE_salinity/salt(I,J,kSurface,bi,bj))
+             ENDIF
+#else
 
-           ELSE
+                 FreshwaterContribFromIce(I,J) = 
+     &             -ActualNewTotalVolumeChange(I,J)*RHOI/RHOFW*
+     &             (1.0 - SEAICE_salinity/salt(I,J,kSurface,bi,bj))
+#endif
+
+           ELSE 
 C    If the liquid cell has a lower salinity than the specified
 c    salinity of sea ice then assume the sea ice is completely fresh
-                 FreshwaterContribFromIce(I,J) =
-     &             -ActualNewTotalVolumeChange(I,J)*SEAICE_rhoIce/RHOFW
+                 FreshwaterContribFromIce(I,J) = 
+     &             -ActualNewTotalVolumeChange(I,J)*RHOI/RHOFW
            ENDIF
 
 
@@ -1218,126 +1172,208 @@ c    The freshwater contribution from snow comes only in the form of melt
 c    unlike ice, which takes freshwater upon growth and yields freshwater
 c    upon melt.  This is why the the actual new average snow melt was determined.
 c    In m/m^2 over the entire cell.
+
+#ifdef FORBID_SEAICE_MELTWATER_ENHANCEMENT_MECHANISM
+c          if we have actually melt any snow for any reason,
+c          do not count the loss as a positive freshwater flux to
+c          the surface when this FORBID flag is operational
+c       
+c          note: S_hsnow could be positive but because of loss
+c                of ice area or ice thickness we may still have
+c                to lose the snow.
+          
+           IF (ActualNewTotalSnowMelt(I,J) .GE. 0.0) THEN
+                  FreshwaterContribFromSnowMelt(I,J) = 0.0
+           ELSE
                   FreshwaterContribFromSnowMelt(I,J) =
-     &                 ActualNewTotalSnowMelt(I,J)*SEAICE_rhoSnow/RHOFW
+     &                 ActualNewTotalSnowMelt(I,J)*RHOSN/RHOFW
+           ENDIF
+#else
+                  FreshwaterContribFromSnowMelt(I,J) =
+     &                 ActualNewTotalSnowMelt(I,J)*RHOSN/RHOFW
+#endif
+
+     
 
 c    This seems to be in m/s, original time level 2 for area
 c    Only the precip and evap need to be area weighted.  The runoff
 c    and freshwater contribs from ice and snow melt are already mean
 c    weighted
+
                   EmPmR(I,J,bi,bj)  = maskC(I,J,kSurface,bi,bj)*(
      &                 ( EVAP(I,J,bi,bj)-PRECIP(I,J,bi,bj) )
-     &                 * ( ONE - AREANm1(I,J,bi,bj) )
+     &                 * ( ONE - AREA(I,J,2,bi,bj) )
      &                 - PrecipRateOverIceSurfaceToSea(I,J)*
-     &                     AREANm1(I,J,bi,bj)
-#ifdef ALLOW_RUNOFF
-     &                 - RUNOFF(I,J,bi,bj)
-#endif
+     &                     AREA(I,J,2,bi,bj)
+     &                 - RUNOFF(I,J,bi,bj) 
      &                 - (FreshwaterContribFromIce(I,J) +
      &                    FreshwaterContribFromSnowMelt(I,J))/
-     &                    SEAICE_deltaTtherm )*rhoConstFresh
+     &                    SEAICE_deltaTtherm) 
 
-C                 DO SOME DEBUGGING CALCULATIONS.  MAKE SURE SUMS ALL ADD UP.
+
+C---+----1----+----2----+----3----+----4----+----5----+----6----+----7-|--+----|
+C   BEGIN DIAGNOSTICS
+c          freshwater fluxes, ice snow (m/s)
+           SID_FC_I(I,J,bi,bj) =  
+     &          FreshwaterContribFromIce(I,J)/SEAICE_deltaTtherm
+
+           SID_FC_S(I,J,bi,bj) =  
+     &          FreshwaterContribFromSnowMelt(I,J)/SEAICE_deltaTtherm
+
+c          buoyancy fluxes, snet must be [PSU.m.s^-1]
+c          in EmPmR format. SID_FC_I > 0, must be made negative
+           SNET_ICE = -salt(I,J,kSurface,bi,bj)*(SID_FC_I(I,J,bi,bj) + 
+     &           SID_FC_S(I,J,bi,bj))
+
+           SNET_TOT = salt(I,J,kSurface,bi,bj)*EmPmR(I,J,bi,bj)
+
+c          this is the buoyancy flux associated with the 
+c          salinity fuxes from everything
+
+c          P > 0, EmPmR < 0, snet=salt*EmPmR < 0
+c          beta > 0, (drho/dS > 0), so 
+c          snet* beta  (-1)*(1) = -1.  so in order for a positive P
+c          to increase buoyancy, must multiply by -1, 
+           SID_SBFT(I,J,bi,bj)  =  -SNET_TOT*BETAZ(I,J)*Gravity
+
+c          this is the buoyancy flux associated with the 
+c          total temperature changing heat flux
+c          alpha < 0 (drho/dt < 0),
+c          qnet < 0 implies warming.  when qnet < 0,
+c          qnet * alpha  (-1)(-1) = 1, so buoyancy goes up
+           SID_EBFT(I,J,bi,bj)  =  QNET(I,J,bi,bj)*ALPHAZ(I,J)
+     &              /RHOP0(I,J)*Gravity/CPW
+
+c          only if there is ice can there be a buoyancy flux
+c          associated with ice.  F_mi is nonzero even with no 
+c          ice.  SNET_ICE shouldn't be, but this is just to 
+c          be safe
+           IF (AREA(I,J,2,bi,bj) .GT. 0.0) THEN
+c             this is the buoyancy flux associated with the 
+c             reducing the temperature from melting ice in the ML
+
+c             Note: IceGrowthRateMixedLayer(I,J) = F_mi(I,J)*QI
+c             ergo: f_mi always < 0, which implies cooling
+c             alpha < 0 (drho/dt < 0),
+c             so f_mi * alpha  (-1)*(-1) > 0
+c             ergo: must multipy by -1 for negative buoyancy
+c             flux when f_mi < 0
+              SID_EBFI(I,J,bi,bj)  = -F_mi(I,J)
+     &               * ALPHAZ(I,J)/RHOP0(I,J)*Gravity/CPW
+
+              SID_DUM8(I,J,bi,bj)  = -F_mi_act(I,J)
+     &               * ALPHAZ(I,J)/RHOP0(I,J)*Gravity/CPW
+
+c             this is the buoyancy flux associated with the 
+c             salinity fuxes from ice and snow
+              SID_SBFI(I,J,bi,bj)  = -SNET_ICE*BETAZ(I,J)*Gravity
+           ENDIF
+
+c          total ice related buoyancy flux
+
+           SID_DUM6(I,J,bi,bj) = SID_SBFT(I,J,bi,bj) + 
+     &                  SID_EBFT(I,J,bi,bj)
+
+           SID_DUM5(I,J,bi,bj) = SID_DUM8(I,J,bi,bj) +
+     &                  SID_SBFI(I,J,bi,bj)
+
+C   END DIAGNOSTICS
+C---+----1----+----2----+----3----+----4----+----5----+----6----+----7-|--+----|
+
+
+C     DO SOME DEBUGGING CALCULATIONS.  MAKE SURE SUMS ALL ADD UP.
 #ifdef SEAICE_DEBUG
 
-C                 Calcuate the shortwave flux absorbed in the upper ocean
-c                 grid cell
+C     THE SHORTWAVE ENERGY FLUX ABSORBED IN THE SURFACE LAYER
 #ifdef SHORTWAVE_HEATING
-                  QSW_absorb_in_first_layer(I,J) = QSW(I,J,bi,bj)*
-     &              (ONE - SWFRACB)
+                  QSW_absorb_in_ML(I,J) = QSW(I,J,bi,bj)*
+     &              (1.0 - SWFRACB)
 #else 
 
-                  QSW_absorb_in_first_layer(I,J) = 0. _d 0
+                  QSW_absorb_in_ML(I,J) = 0. _d 0
 #endif
 
-C                 Calcuate the sw flux beneath the upper ocean grid cell
-                  QSW_absorb_below_first_layer(I,J) = 
-     &                 QSW(I,J,bi,bj) -  QSW_absorb_in_first_layer(I,J)
+C     THE SHORTWAVE ENERGY FLUX PENETRATING BELOW THE SURFACE LAYER
+                  QSW_absorb_below_ML(I,J) = 
+     &                 QSW(I,J,bi,bj) -  QSW_absorb_in_ML(I,J);
 
-                  PredTempChangeFromQSW(I,J) = 
-     &             - QSW_absorb_in_first_layer(I,J) * FLUX_TO_DELTA_TEMP
+                  PredictTempChgFromQSW(I,J) = 
+     &             - QSW_absorb_in_ML(I,J) * FLUX_TO_DELTA_TEMP
 
-                  PredTempChangeFromOA_MQNET(I,J) = 
-     &            -(QNET(I,J,bi,bj)-QSWO(I,J))*(ONE -AREANm1(I,J,bi,bj))
+                  PredictTempChgFromOA_MQNET(I,J) = 
+     &            -(QNET(I,J,bi,bj) - QSWO(I,J))*(1. -AREA(I,J,2,bi,bj))
      &             * FLUX_TO_DELTA_TEMP
 
-                  PredTempChangeFromF_IO_NET(I,J) = 
-     &             -F_io_net(I,J)*AREANm1(I,J,bi,bj)*FLUX_TO_DELTA_TEMP
+                  PredictTempChgFromF_IO_NET(I,J) = 
+     &             -F_io_net(I,J)*AREA(I,J,2,bi,bj)*FLUX_TO_DELTA_TEMP
 
-                  PredTempChangeFromF_IA_NET(I,J) = 
-     &             -F_ia_net(I,J)*AREANm1(I,J,bi,bj)*FLUX_TO_DELTA_TEMP
+                  PredictTempChgFromF_IA_NET(I,J) = 
+     &             -F_ia_net(I,J)*AREA(I,J,2,bi,bj)*FLUX_TO_DELTA_TEMP
 
-                  PredTempChangeFromNewIceVol(I,J) = 
+                  PredictTempChgFromNewIceVol(I,J) = 
      &              EnergyInNewTotalIceVolume(I,J)*ENERGY_TO_DELTA_TEMP
 
-                  PredTempChange(I,J) = 
-     &              PredTempChangeFromQSW(I,J) +
-     &              PredTempChangeFromOA_MQNET(I,J) +
-     &              PredTempChangeFromF_IO_NET(I,J) +
-     &              PredTempChangeFromF_IA_NET(I,J) +
-     &              PredTempChangeFromNewIceVol(I,J)
+                  PredictTempChg(I,J) = 
+     &              PredictTempChgFromQSW(I,J) +
+     &              PredictTempChgFromOA_MQNET(I,J) +
+     &              PredictTempChgFromF_IO_NET(I,J) +
+     &              PredictTempChgFromF_IA_NET(I,J) +
+     &              PredictTempChgFromNewIceVol(I,J)
 #endif    
-
+                 ENDIF !/ MASKC
                ENDDO
             ENDDO
 
+
 #ifdef ALLOW_AUTODIFF_TAMC
-CADJ STORE area(:,:,bi,bj)  = comlev1_bibj, 
-CADJ &                        key = iicekey, byte = isbyte
+CADJ STORE area(:,:,:,bi,bj) = comlev1_bibj, 
+CADJ &                         key = iicekey, byte = isbyte
 CADJ STORE hsnow(:,:,bi,bj) = comlev1_bibj, 
-CADJ &                        key = iicekey, byte = isbyte
-CADJ STORE heff(:,:,bi,bj)  = comlev1_bibj, 
-CADJ &                        key = iicekey, byte = isbyte
+CADJ &                         key = iicekey, byte = isbyte
+CADJ STORE heff(:,:,:,bi,bj) = comlev1_bibj, 
+CADJ &                         key = iicekey, byte = isbyte
 #endif /* ALLOW_AUTODIFF_TAMC */
             
-            DO J=1,sNy
-               DO I=1,sNx
-                  AREA(I,J,bi,bj) = AREA(I,J,bi,bj)*HEFFM(I,J,bi,bj)
-                  HEFF(I,J,bi,bj) = HEFF(I,J,bi,bj)*HEFFM(I,J,bi,bj)
-                  HSNOW(I,J,bi,bj)  = HSNOW(I,J,bi,bj)*HEFFM(I,J,bi,bj)
-               ENDDO
-            ENDDO
-
-#ifdef ALLOW_AUTODIFF_TAMC
-CADJ STORE area(:,:,bi,bj)  = comlev1_bibj, 
-CADJ &                        key = iicekey, byte = isbyte
-CADJ STORE hsnow(:,:,bi,bj) = comlev1_bibj, 
-CADJ &                        key = iicekey, byte = isbyte
-CADJ STORE heff(:,:,bi,bj)  = comlev1_bibj, 
-CADJ &                        key = iicekey, byte = isbyte
-#endif /* ALLOW_AUTODIFF_TAMC */
-
 
 #ifdef ALLOW_SEAICE_FLOODING
-           IF(SEAICEuseFlooding) THEN
-
+          IF(SEAICEuseFlooding) THEN
             DO J = 1,sNy
-               DO I = 1,sNx
-                  EnergyToMeltSnowAndIce(I,J) = 
-     &                 HEFF(I,J,bi,bj)/QI +
+              DO I = 1,sNx
+
+                IF (HSNOW(I,J,bi,bj) .GT. 0.0) THEN
+
+                  deltaHS = FL_C2*( 
+     &               HSNOW(I,J,bi,bj) - HEFF(I,J,1,bi,bj)*FL_C3 )
+
+                  deltaHI = FL_C4*deltaHS
+
+                  IF (deltaHS .GT. 0.0 _d 0) THEN
+
+c                    total latent heat enthalpy in ice/snow 
+                     EnergyToMeltSnowAndIce(I,J) = 
+     &                 HEFF(I,J,1,bi,bj)/QI +
      &                 HSNOW(I,J,bi,bj)/QS
-                  
-                  deltaHS = FL_C2*( HSNOW_ACTUAL(I,J) -
-     &                 HICE_ACTUAL(I,J)*FL_C3 )
-                  
-                  IF (deltaHS .GT. ZERO) THEN
-                     deltaHI = FL_C4*deltaHS
+
+                     HEFFO = HEFF(I,J,1,bi,bj)
+                     HSNOWO = HSNOW(I,J,bi,bj)
                      
-                     HICE_ACTUAL(I,J) = HICE_ACTUAL(I,J)  
-     &                    + deltaHI
+                     HEFF(I,J,1,bi,bj) = HEFF(I,J,1,bi,bj) + deltaHI
+                     HSNOW(I,J,bi,bj)  = HSNOW(I,J,bi,bj)  - deltaHS
 
-                     HSNOW_ACTUAL(I,J)= HSNOW_ACTUAL(I,J) 
-     &                    - deltaHS
-
-                     HEFF(I,J,bi,bj)= HICE_ACTUAL(I,J) *
-     &                    AREA(I,J,bi,bj)
-
-                     HSNOW(I,J,bi,bj) = HSNOW_ACTUAL(I,J)*
-     &                    AREA(I,J,bi,bj)
-                     
+c                    total latent heat enthalpy in ice/snow, post adjustment 
                      EnergyToMeltSnowAndIce2(I,J) = 
-     &                    HEFF(I,J,bi,bj)/QI +
+     &                    HEFF(I,J,1,bi,bj)/QI +
      &                    HSNOW(I,J,bi,bj)/QS
+
+C---+----1----+----2----+----3----+----4----+----5----+----6----+----7-|--+----|
+c                    diagnostics of the tendencies of heff and hsnow 
+c                    from flooding.
+                     SID_DUM7(I,J,bi,bj) = 
+     &                 (HEFF(I,J,1,bi,bj) - HEFFO)/ SEAICE_deltaTtherm
+
+c                     SID_DUM8(I,J,bi,bj) = 
+c     &                 (HSNOW(I,J,bi,bj) - HSNOWO)/ SEAICE_deltaTtherm
+C---+----1----+----2----+----3----+----4----+----5----+----6----+----7-|--+----|
                      
 #ifdef SEAICE_DEBUG
                IF ( (I .EQ. SEAICE_debugPointX)   .and.
@@ -1351,40 +1387,81 @@ CADJ &                        key = iicekey, byte = isbyte
                ENDIF
 c SEAICE DEBUG
 #endif
-c there is any flooding to be had                 
-                  ENDIF
-               ENDDO
-            ENDDO
 
-c SEAICEuseFlooding
-           ENDIF 
-c ALLOW_SEAICE_FLOODING
-#endif 
+C                 NOT FLOODING, deltaHS !.GT. 0
+                  ELSE  
+                   deltaHS = 0.0  !/FLOODING CONDITIONS
+                   deltaHI = 0.0
+                  ENDIF
+ 
+                ENDIF !/ no snow
+
+               ENDDO !/ i,j
+             ENDDO !/ i,j
+          ENDIF !/useFlooding
+
+!/ allow flooding
+#endif  
+
+
+c one last cleanup
+          DO J=1,sNy
+            DO I=1,sNx
+              AREA(I,J,1,bi,bj) = AREA(I,J,1,bi,bj)*HEFFM(I,J,bi,bj)
+              HEFF(I,J,1,bi,bj) = HEFF(I,J,1,bi,bj)*HEFFM(I,J,bi,bj)
+              HSNOW(I,J,bi,bj)  = HSNOW(I,J,bi,bj)*HEFFM(I,J,bi,bj)
+            ENDDO
+         ENDDO
 
 #ifdef ALLOW_AUTODIFF_TAMC
-CADJ STORE area(:,:,bi,bj)  = comlev1_bibj, 
-CADJ &                        key = iicekey, byte = isbyte
+CADJ STORE area(:,:,:,bi,bj) = comlev1_bibj, 
+CADJ &                         key = iicekey, byte = isbyte
 CADJ STORE hsnow(:,:,bi,bj) = comlev1_bibj, 
-CADJ &                        key = iicekey, byte = isbyte
-CADJ STORE heff(:,:,bi,bj)  = comlev1_bibj, 
-CADJ &                        key = iicekey, byte = isbyte
+CADJ &                         key = iicekey, byte = isbyte
+CADJ STORE heff(:,:,:,bi,bj) = comlev1_bibj, 
+CADJ &                         key = iicekey, byte = isbyte
 #endif /* ALLOW_AUTODIFF_TAMC */
+
+
+
+C---+----1----+----2----+----3----+----4----+----5----+----6----+----7-|--+----|
+c diagnostics
+           DO J = 1,sNy
+             DO I = 1,sNx
+c              the actual dA/dt realized by the model
+               SID_Sa(I,J,bi,bj) = ( AREA(I,J,1,bi,bj) -
+     &              AREA(I,J,2,bi,bj) ) / SEAICE_deltaTtherm
+
+c                 the actual dheff/dt realized by the model
+               SID_Sh(I,J,bi,bj) =  ( HEFF(I,J,1,bi,bj) -
+     &              HEFF(I,J,2,bi,bj)) / SEAICE_deltaTtherm
+
+c          hackish way to take account of what is changed in advection
+c          this is the last information we have about area and
+c          heff when thermodynamics ends.  anything changing from this
+c          point on, until we get to thermo ice again must be advection
+               AREA_POST_THERMO(I,J,bi,bj) = AREA(I,J,1,bi,bj)
+               HEFF_POST_THERMO(I,J,bi,bj) = HEFF(I,J,1,bi,bj)
+
+            ENDDO
+           ENDDO
+C---+----1----+----2----+----3----+----4----+----5----+----6----+----7-|--+----|
 
 
 #ifdef ATMOSPHERIC_LOADING
             IF ( useRealFreshWaterFlux ) THEN
                DO J=1,sNy
                   DO I=1,sNx
-                     sIceLoad(i,j,bi,bj) = HEFF(I,J,bi,bj)*
-     &                 SEAICE_rhoIce + HSNOW(I,J,bi,bj)*SEAICE_rhoSnow
+                     sIceLoad(i,j,bi,bj) = HEFF(I,J,1,bi,bj)*
+     &                    SEAICE_rhoIce + HSNOW(I,J,bi,bj)* 330. _d 0
                   ENDDO
                ENDDO
             ENDIF
 #endif
 
 #ifdef SEAICE_DEBUG
-            DO j=1,sNy
-               DO i=1,sNx
+            DO j=1-OLy,sNy+OLy
+               DO i=1-OLx,sNx+OLx
 
                IF ( (i .EQ. SEAICE_debugPointX)   .and.  
      &              (j .EQ. SEAICE_debugPointY) ) THEN
@@ -1414,20 +1491,10 @@ CADJ &                        key = iicekey, byte = isbyte
                  
                   print '(A,2i4,2(1x,1P3E15.4))',
      &                 'ifice i j AREA2/1 HEFF2/1 ',i,j,
-     &                 AREANm1(I,J,bi,bj),
-     &                 AREA(i,j,bi,bj),
-     &                 HEFFNm1(I,J,bi,bj),
-     &                 HEFF(i,j,bi,bj)
-
-
-#ifdef ALLOW_SALT_PLUME
-                  print '(A,2i4,2(1x,1P3E15.4))',
-     &                 'ifice i j A,IGLEA,LPF,SPF ',i,j,
-     &                 AREANm1(I,J,bi,bj),
-     &                 IceGrowthRateInLeads(I,J),
-     &                 leadPlumeFraction(I,J),
-     &                 saltPlumeFlux(i,j,bi,bj)
-#endif
+     &                 AREA(i,j,2,bi,bj),
+     &                 AREA(i,j,1,bi,bj),
+     &                 HEFF(i,j,2,bi,bj),
+     &                 HEFF(i,j,1,bi,bj)
                   
                   print '(A,2i4,2(1x,1P3E15.4))',
      &                 'ifice i j HSNOW2/1 TMX TBC',i,j,
@@ -1457,8 +1524,8 @@ CADJ &                        key = iicekey, byte = isbyte
                   
                   print '(A,2i4,2(1x,1P3E15.4))',
      &                 'ifice i j EF(NOS RE) QNET ',i,j,
-     &                 NetEnergyFluxOutOfOcean(i,j),
-     &                 ResidualEnergyOutOfOcean(i,j),
+     &                 NetEnergyFluxOutOfSystem(i,j),
+     &                 ResidualHeatOutOfSystem(i,j),
      &                 QNET(I,J,bi,bj)
 
                   print '(A,2i4,3(1x,1P3E15.4))',
@@ -1469,26 +1536,26 @@ CADJ &                        key = iicekey, byte = isbyte
 
                   print '(A,2i4,3(1x,1P3E15.4))',
      &                 'ifice i j SW(BML IML SW)  ',i,j,
-     &                 QSW_absorb_below_first_layer(i,j),
-     &                 QSW_absorb_in_first_layer(i,j),
+     &                 QSW_absorb_below_ML(i,j),
+     &                 QSW_absorb_in_ML(i,j),
      &                 SWFRACB
 
                   print '(A,2i4,3(1x,1P3E15.4))',
      &                 'ifice i j ptc(to, qsw, oa)',i,j,
-     &                 PredTempChange(i,j),
-     &                 PredTempChangeFromQSW (i,j),
-     &                 PredTempChangeFromOA_MQNET(i,j)
+     &                 PredictTempChg(i,j),
+     &                 PredictTempChgFromQSW (i,j),
+     &                 PredictTempChgFromOA_MQNET(i,j)
 
 
                   print '(A,2i4,3(1x,1P3E15.4))',
      &                 'ifice i j ptc(fion,ian,ia)',i,j,
-     &                 PredTempChangeFromF_IO_NET(i,j),
-     &                 PredTempChangeFromF_IA_NET(i,j),
-     &                 PredTempChangeFromFIA(i,j)
+     &                 PredictTempChgFromF_IO_NET(i,j),
+     &                 PredictTempChgFromF_IA_NET(i,j),
+     &                 PredictTempChgFromFIA(i,j)
 
                   print '(A,2i4,3(1x,1P3E15.4))',
      &                 'ifice i j ptc(niv)        ',i,j,
-     &                 PredTempChangeFromNewIceVol(i,j)
+     &                 PredictTempChgFromNewIceVol(i,j)
 
 
                   print '(A,2i4,3(1x,1P3E15.4))',
@@ -1501,8 +1568,8 @@ CADJ &                        key = iicekey, byte = isbyte
                   print '(A,2i4,3(1x,1P3E15.4))',
      &                 'ifice i j PRROIS,SAOI(R .)',i,j,
      &                 PrecipRateOverIceSurfaceToSea(I,J),
-     &                 SnowAccRateOverIce(I,J),
-     &                 SnowAccOverIce(I,J)
+     &                 SnowAccumulationRateOverIce(I,J),
+     &                 SnowAccumulationOverIce(I,J)
 
                   print '(A,2i4,4(1x,1P3E15.4))',
      &                 'ifice i j SM(PM PMR . .R) ',i,j,
@@ -1531,7 +1598,7 @@ CADJ &                        key = iicekey, byte = isbyte
 #endif /* SEAICE_DEBUG */
             
             
-C     end bi,bj loops
+C     BI,BJ'S
          ENDDO
       ENDDO
       

--- a/pkg/seaice/seaice_growth_adjointable.F
+++ b/pkg/seaice/seaice_growth_adjointable.F
@@ -1,4 +1,4 @@
-C     $Header: /home/ubuntu/mnt/e9_copy/MITgcm_contrib/ifenty/Fenty_Thermo_Code_Updates/code_updates/seaice_growth_if.F,v 1.4 2010/09/25 16:41:06 ifenty Exp $
+C     $Header: /home/ubuntu/mnt/e9_copy/MITgcm_contrib/ifenty/Fenty_Thermo_Code_Updates/code_updates_20130122/seaice_growth_if.F,v 1.1 2013/01/22 21:53:56 ifenty Exp $
 C     $Name:  $
 
 #include "SEAICE_OPTIONS.h"
@@ -47,9 +47,9 @@ C     i,j,bi,bj - Loop counters
 C     number of surface interface layer
       INTEGER kSurface
 
-C     TBC   : The freezing point of seawater (deg C)
-C     TMELT : The freezing point of fresh water (deg K)
-      _RL TBC, TMELT
+C     constants
+      _RL TBC, SDF, ICE2SNOW,TMELT
+      _RL STANTON_NUMBER, USTAR_BASE
 
 #ifdef ALLOW_SEAICE_FLOODING
       _RL hDraft, hFlood
@@ -57,6 +57,7 @@ C     TMELT : The freezing point of fresh water (deg K)
 
 C     QSWO   - short wave heat flux over ocean (W/m^2)
 C     QSWI   - short wave heat flux under ice  (W/m^2)
+
       _RL QSWO                         (1:sNx,1:sNy)
       _RL QSWI                         (1:sNx,1:sNy)
 
@@ -64,18 +65,15 @@ C     The shortwave heat flux in the open water fraction of the
 C     grid cell converging within the uppermost ocean grid cell (W/m^2)
       _RL QSWO_IN_FIRST_LAYER          (1:sNx,1:sNy)
 
-
 C     (1 - QSWO_IN_FIRST_LAYER) (W/m^2)
       _RL QSWO_BELOW_FIRST_LAYER        (1:sNx,1:sNy)
 
-#ifdef SEAICE_DEBUG
 C     The total shortwave heat flux (into open water and through the ice)
 C     converging within the uppermost ocean grid cell (W/m^2)
       _RL QSW_absorb_in_first_layer     (1:sNx,1:sNy)
 
 C     ( 1 - QSW_absorb_in_first_layer)  (W/m^2) 
       _RL QSW_absorb_below_first_layer  (1:sNx,1:sNy)
-#endif
 
 C     The actual ice thickness (i.e., mean ice thickness / ice concentration) (m) 
       _RL HICE_ACTUAL                   (1:sNx,1:sNy)
@@ -86,12 +84,7 @@ C     The actual snow thickness (i.e., mean snow thickness / ice concentration) 
 C     wind speed (m/s)
       _RL UG                            (1:sNx,1:sNy)
 
-c     RHOFW  : Freshwater density (kg m^-3)
-C     CPW    : Seawater heat capacity   (J m^-3 K^-1)
-c     LI     : Ice latent heat of fusion (J kg^-1)
-c     QI, QS : Factors used to to map between energy fluxes 
-c     RHOSW  : A reference seawater density (kg m^-3)
-c     and snow/ice melt or growth
+      _RL SPEED_SQ
       _RL RHOFW,CPW,LI,QI,QS,RHOSW
 
 C     Helper Variables for snow flooding
@@ -104,22 +97,11 @@ C     Helper Variables for snow flooding
       _RL GAMMA
 #endif
 
-#ifndef SEAICE_USE_ORIGINAL_HEAT_FLUX
-C     Factor by which we increase the upper ocean friction velocity (u*) when 
-C     ice is absent in a grid cell  (dimensionless)
+C     Factor by which we increase the u* (friction velocity) when ice is not 
+C     present (dimensionless)
       _RL MixedLayerTurbulenceFactor
 
-c     The Stanton number for the McPhee 
-c     ocean-ice heat flux parameterization (dimensionless)
-      _RL STANTON_NUMBER
-
-c     A typical friction velocity beneath sea ice for the 
-c     McPhee heat flux parameterization (m/s)
-      _RL USTAR_BASE
-
-#endif /* SEAICE_USE_ORIGINAL_HEAT_FLUX */
-
-C     Sea ice thickness growth rates (m/s)
+C     Sea ice growth rates (m/s)
       _RL NetExistingIceGrowthRate      (1:sNx,1:sNy)
       _RL IceGrowthRateUnderExistingIce (1:sNx,1:sNy)
       _RL IceGrowthRateFromSurface      (1:sNx,1:sNy)
@@ -137,10 +119,8 @@ c     which is to be sent to the salt plume package
 
 c     The minimum value of HEFF to be divided by during the calculation of d(AREA)/dt
       _RL HEFF_MIN
-      
-#ifdef SEAICE_DEBUG
-c     Variables for debugging (predicted temperature change from 
-c     various sources)
+ 
+c      Variables for debugging (predicted temperature change from various sources)
       _RL PredTempChange                (1:sNx,1:sNy)
       _RL PredTempChangeFromQSW         (1:sNx,1:sNy)
       _RL PredTempChangeFromOA_MQNET    (1:sNx,1:sNy)
@@ -151,14 +131,11 @@ c     various sources)
 
       _RL ExpectedIceVolumeChange       (1:sNx,1:sNy)
       _RL ExpectedSnowVolumeChange      (1:sNx,1:sNy)
-#endif
-
-      _RL ActualIceVolumeChange         (1:sNx,1:sNy)
+      _RL ActualNewTotalVolumeChange    (1:sNx,1:sNy)
       _RL ActualNewTotalSnowMelt        (1:sNx,1:sNy)
 
-      _RL EnergyInNewIceVolume          (1:sNx,1:sNy)
-      _RL NetEnergyOutOfOcean           (1:sNx,1:sNy)
-      _RL NetEnergyOutOfIce             (1:sNx,1:sNy)
+      _RL EnergyInNewTotalIceVolume     (1:sNx,1:sNy)
+      _RL NetEnergyFluxOutOfOcean       (1:sNx,1:sNy)
 
 C     The energy taken out of the ocean which is not converted
 C     to sea ice (Joules)
@@ -210,54 +187,43 @@ C     S_hsnow : d(HSNOW)/dt
       _RL S_hsnow                       (1:sNx,1:sNy)
 
 C     HSNOW_ORIG : The mean snow thickness before any accumulation, 
-C     melt, or flooding (m)
+C                  melt, or flooding (m)
       _RL HSNOW_ORIG                    (1:sNx,1:sNy)
 
 C     F_ia  - sea ice/snow surface heat flux with atmosphere (W/m^2)
-
-C     F_ia > 0 implies heat loss to atmosphere
-
-C     F_ia < 0 implies atmospheric heat flux convergence (including
-c     ice/snow surface melt)
+C       F_ia > 0, heat loss to atmosphere
+C       F_ia < 0, atmospheric heat flux convergence (ice/snow surface melt)
       _RL F_ia                          (1:sNx,1:sNy)
 
-C     F_ia_net - the net heat flux divergence at the sea ice/snow 
-c     surface including sea ice conductive fluxes and atmospheric 
-c     fluxes (W/m^2)
-
-C     F_ia_net = 0 implies that at the sea ice/snow surface an energy 
-c     balance condition is met (upward conductive fluxes balance 
-c     surface heat loss to the atmosphere).
-
-C     F_ia_net < 0 implies a net heat flux convergence at the ice/snow
-c     surface, zero conductive fluxes, and net atmospheric convergence.
+C     F_ia_net - the net heat flux divergence at the sea ice/snow surface
+C                including sea ice conductive fluxes and atmospheric fluxes (W/m^2)
+C       F_ia_net = 0, sea ice/snow surface energy balance condition met
+C                     upward conductive fluxes balance surface heat loss
+C       F_ia_net < 0, net heat flux convergence at ice/snow surface 
+C                     zero conductive fluxes and net atmospheric convergence
       _RL F_ia_net                      (1:sNx,1:sNy)
 
-C     F_ia_net_before_snow - the net heat flux divergence at the 
-c     ice/snow surface before snow melts (W/m^2)
-
-C     F_ia_net_before_snow < 0 implies some snow, if present, will melt.
+C     F_ia_net - the net heat flux divergence at the sea ice/snow surface 
+C                before snow is melted with any convergence (W/m^2)
+C        F_ia_net < 0, some snow, if present, will melt 
       _RL F_ia_net_before_snow          (1:sNx,1:sNy)
 
-C     F_io_net - the net upward conductive heat flux through the 
-c     ice + snow realized at the sea ice/snow surface.
-
-C     F_io_net > 0 implies heat conducting upward from ice base,
-c     and basal thickening of the ice.
-
-c     F_io_net = 0 implies no upward heat conduction (i.e., the 
-C     ice/snow surface temperature > SEAICE_freeze).  
+C     F_io_net - the net upward conductive heat flux through the ice+snow system
+C                realized at the sea ice/snow surface
+C        F_io_net > 0, heat conducting upward from ice base --> basal thickening
+C        F_io_net = 0, no upward heat conduction 
+C                      ice/snow surface temperature > SEAICE_freeze)  
       _RL F_io_net                      (1:sNx,1:sNy)
 
 C     F_ao  - heat flux from atmosphere to ocean (W/m^2)
-C     F_ao > 0
+C        F_ao > 0
       _RL F_ao                          (1:sNx,1:sNy)
 
 C     F_mi - heat flux from ocean to the ice (W/m^2)
       _RL F_mi                          (1:sNx,1:sNy)
-      
-c     The ocean temperature used for the calculation of turbulent 
-c     ocean-ice heat fluxes (Celsius)
+ 
+
+c     The ocean temperature used for the calculation of turbulent ocean-ice heat fluxes
       _RL surf_theta
 
 C     Helper variables for debugging
@@ -269,25 +235,39 @@ C     Helper variables for debugging
          kSurface        = 1
       endif
 
-c     For debugging
+c    For debugging
       FLUX_TO_DELTA_TEMP = SEAICE_deltaTtherm*
-     &   recip_Cp*recip_rhoConst * recip_drF(1)
+     &            recip_Cp*recip_rhoConst * recip_drF(1)
 
       ENERGY_TO_DELTA_TEMP = recip_Cp*recip_rhoConst*recip_drF(1)
 
-      TBC   = SEAICE_freeze
+C     TBC : The freezing point of seawater (deg C)
+      TBC          = SEAICE_freeze
+
+C     TMELT : The freezing point of fresh water (deg K)
       TMELT = 273.15 _d 0 
+
+c     A reference seawater density (kg m^-3)
       RHOSW = 1026. _d 0
+
+c     Freshwater density (kg m^-3)
       RHOFW = rhoConstFresh
 
-#ifndef SEAICE_USE_ORIGINAL_HEAT_FLUX
+c     The Stanton number for the McPhee 
+c     ocean-ice heat flux parameterization (dimensionless)
       STANTON_NUMBER = 0.0056 _d 0 
-      USTAR_BASE = 0.0125 _d 0
-#endif
 
+c     USTAR_BASE : A typical friction velocity beneath sea 
+c                  ice for the McPhee heat flux parameterization (m/s)
+      USTAR_BASE = 0.0125 _d 0
+
+C     CPW : Seawater heat capacity   (J m^-3 K^-1)
       CPW = 4010. _d 0
+
+c     Li : Ice latent heat of fusion (J kg^-1)
       Li = 3.34 _d 5 
 
+c     Factors used to to map between energy fluxes and snow/ice melt or growth
       QI = ONE/SEAICE_rhoIce/Li
       QS = ONE/SEAICE_rhoSnow/Li
 
@@ -300,17 +280,15 @@ c     Helper terms for snow flooding
 c     GAMMA is used to calculate ocean-ice heat fluxes from
 c     a user-specified flux timescale (SEAICE_gamma_t).  
 c     Originally, 3 days in seconds was suggested as useful.
+c     To keep this timescale up to date given advances in
+c     the parameterization, GAMMA is specified as follows, 
 c     
-      GAMMA =  10. _d 0 / SEAICE_gamma_t
+      GAMMA =  10. _d 0/SEAICE_gamma_t
 
-c     (Note: this is changed from drF(1)/SEAICE_gamma_t for
-c     model setups with higher vertical resolutions.)
-c     
-c     GAMMA and SEAICE_gamma_t are not used with the default
-c     ocean-ice heat flux scheme of McPhee.
+c     n.b., changed from drF(1)/SEAICE_gamma_t to make 
+c     a more robust form in setups with a higher vertical resolution.
 #endif
 
-C---  +----1----+----2----+----3----+----4----+----5----+----6----+----7-|--+----|
       DO bj=myByLo(myThid),myByHi(myThid)
          DO bi=myBxLo(myThid),myBxHi(myThid)
 c     
@@ -323,22 +301,57 @@ c
             max3 = nTx*nTy
             act4 = ikey_dynamics - 1
             iicekey = (act1 + 1) + act2*max1
-     &         + act3*max1*max2
-     &         + act4*max1*max2*max3
+     &           + act3*max1*max2
+     &           + act4*max1*max2*max3
 #endif /* ALLOW_AUTODIFF_TAMC */
+C     
+C     initialise a few fields
+C     
+#ifdef ALLOW_AUTODIFF_TAMC
+CADJ STORE area(:,:,bi,bj) = comlev1_bibj, 
+CADJ &                       key = iicekey, byte = isbyte
+#endif /* ALLOW_AUTODIFF_TAMC */
+
+#ifdef SEAICE_SIMULATE_CONVERGENCE_IN_1D_MODEL
+c           simulate total convergence from dynamics
+            DO J=1,sNy
+               DO I=1,sNx
+                  IF (HEFF(I,J,bi,bj) .GT. ZERO) THEN
+                     AREA(I,J,bi,bj) = ONE
+                  ENDIF
+               ENDDO
+            ENDDO
+#endif
 
 #ifdef ALLOW_AUTODIFF_TAMC
-C     ADJ STORE area(:,:,bi,bj) = comlev1_bibj, 
-C     ADJ &                       key = iicekey, byte = isbyte
-C     ADJ STORE qnet(:,:,bi,bj) = comlev1_bibj, 
-C     ADJ &                       key = iicekey, byte = isbyte
-C     ADJ STORE qsw(:,:,bi,bj)  = comlev1_bibj, 
-C     ADJ &                       key = iicekey, byte = isbyte
+CADJ STORE area(:,:,bi,bj) = comlev1_bibj, 
+CADJ &                       key = iicekey, byte = isbyte
+CADJ STORE qnet(:,:,bi,bj) = comlev1_bibj, 
+CADJ &                       key = iicekey, byte = isbyte
+CADJ STORE qsw(:,:,bi,bj)  = comlev1_bibj, 
+CADJ &                       key = iicekey, byte = isbyte
 #endif /* ALLOW_AUTODIFF_TAMC */
+c
+            DO J=1,sNy
+               DO I=1,sNx
+c                 Bound area, heff, and hsnow 
+                  AREA(I,J,bi,bj) = MIN(ONE,AREA(I,J,bi,bj))
+                  AREA(I,J,bi,bj) = MAX(ZERO,AREA(I,J,bi,bj))
+                  HEFF(I,J,bi,bj) = MAX(ZERO, HEFF(I,J,bi,bj))
+                  HSNOW(I,J,bi,bj)  = MAX(ZERO, HSNOW(I,J,bi,bj))
 
-            
-C---  +----1----+----2----+----3----+----4----+----5----+----6----+----7-|--+----|
-C     Initialize variables
+c                 Sanity checks 
+                  IF (HEFF(I,J,bi,bj) .LE. ZERO .OR.
+     &                AREA(I,J,bi,bj) .LE. ZERO) THEN
+                    
+                    AREA(I,J,bi,bj)       = 0. _d 0
+                    HEFF(I,J,bi,bj)       = 0. _d 0
+                    HSNOW(I,J,bi,bj)      = 0. _d 0
+                  ENDIF
+               ENDDO
+            ENDDO
+
+
             DO J=1,sNy
                DO I=1,sNx
                   F_ia_net                        (I,J) = 0. _d 0
@@ -363,6 +376,14 @@ C     Initialize variables
                   NetExistingIceGrowthRate        (I,J) = 0. _d 0
                   S_a_from_IGROW                  (I,J) = 0. _d 0
 
+                  PredTempChange                  (I,J) = 0. _d 0
+                  PredTempChangeFromQSW           (I,J) = 0. _d 0
+                  PredTempChangeFromOA_MQNET      (I,J) = 0. _d 0
+                  PredTempChangeFromFIA           (I,J) = 0. _d 0
+                  PredTempChangeFromF_IA_NET      (I,J) = 0. _d 0
+                  PredTempChangeFromF_IO_NET      (I,J) = 0. _d 0
+                  PredTempChangeFromNewIceVol     (I,J) = 0. _d 0
+
                   IceGrowthRateOpenWater          (I,J) = 0. _d 0
                   IceGrowthRateMixedLayer         (I,J) = 0. _d 0
 
@@ -372,29 +393,16 @@ C     Initialize variables
                   saltPlumeFlux             (I,J,bi,bj) = 0. _d 0
 #endif
 
-                  ActualIceVolumeChange           (I,J) = 0. _d 0
-                  ActualNewTotalSnowMelt          (I,J) = 0. _d 0
-
-                  EnergyInNewIceVolume            (I,J) = 0. _d 0
-                  NetEnergyOutOfOcean             (I,J) = 0. _d 0
-                  NetEnergyOutOfIce               (I,J) = 0. _d 0
-                  ResidualEnergyOutOfOcean        (I,J) = 0. _d 0
-
-#ifdef SEAICE_DEBUG
                   ExpectedIceVolumeChange         (I,J) = 0. _d 0
                   ExpectedSnowVolumeChange        (I,J) = 0. _d 0
+                  ActualNewTotalVolumeChange      (I,J) = 0. _d 0
+                  ActualNewTotalSnowMelt          (I,J) = 0. _d 0
 
-                  PredTempChange                  (I,J) = 0. _d 0
-                  PredTempChangeFromQSW           (I,J) = 0. _d 0
-                  PredTempChangeFromOA_MQNET      (I,J) = 0. _d 0
-                  PredTempChangeFromFIA           (I,J) = 0. _d 0
-                  PredTempChangeFromF_IA_NET      (I,J) = 0. _d 0
-                  PredTempChangeFromF_IO_NET      (I,J) = 0. _d 0
-                  PredTempChangeFromNewIceVol     (I,J) = 0. _d 0
-
+                  EnergyInNewTotalIceVolume       (I,J) = 0. _d 0
+                  NetEnergyFluxOutOfOcean         (I,J) = 0. _d 0
+                  ResidualEnergyOutOfOcean          (I,J) = 0. _d 0
                   QSW_absorb_in_first_layer       (I,J) = 0. _d 0
                   QSW_absorb_below_first_layer    (I,J) = 0. _d 0
-#endif
 
                   SnowAccRateOverIce              (I,J) = 0. _d 0
                   SnowAccOverIce                  (I,J) = 0. _d 0
@@ -409,346 +417,310 @@ C     Initialize variables
                   FreshwaterContribFromSnowMelt   (I,J) = 0. _d 0
                   FreshwaterContribFromIce        (I,J) = 0. _d 0
 
-c     Following sea ice dynamics, the ice state (HEFF and 
-c     AREA) are stored in time level 1 (N).  The ice state 
-c     is moved to time level N minus 1 (Nm1) before 
-c     thermodynamical calulations.  Following this routine,
-c     the new ice state will be at time level N (except
-c     HSNOW which isn't stored at multiple time levels.)
+c the post sea ice advection and diffusion ice state are in time level 1.  
+c move these to the time level 2 before thermo.  after this routine 
+c the updated ice state will be in time level 1 again. (except for snow 
+c which does not have 3 time levels for some reason) 
                   HEFFNm1(I,J,bi,bj) = HEFF(I,J,bi,bj) 
-                  AREA(I,J,bi,bj) = MIN(1.0 _d 0, AREA(I,J,bi,bj)
                   AREANm1(I,J,bi,bj) = AREA(I,J,bi,bj) 
 
+#ifdef SEAICE_SIMULATE_DIVERGENCE_IN_1D_MODEL
+c Sometimes it's nice to run a 1-D setup but how then to simulate
+c the effect of mechanical divergence?.  To simulate the effect of 
+c having regular lead openings, each time step remove a fraction
+c of the ice area while maintaining the actual thickness of ice
+c and snow.
 
-
-               ENDDO
-            ENDDO
-
-
-#ifdef ALLOW_AUTODIFF_TAMC
-C     ADJ STORE area(:,:,bi,bj)   = comlev1_bibj, 
-C     ADJ &                         key = iicekey, byte = isbyte
-C     ADJ STORE heff(:,:,bi,bj)   = comlev1_bibj, 
-C     ADJ &                         key = iicekey, byte = isbyte
-C     ADJ STORE hsnow(:,:,bi,bj)  = comlev1_bibj, 
-C     ADJ &                         key = iicekey, byte = isbyte
-C     ADJ STORE tice(:,:,bi,bj)   = comlev1_bibj, 
-C     ADJ &                         key = iicekey, byte = isbyte
-C     ADJ STORE precip(:,:,bi,bj) = comlev1_bibj, 
-C     ADJ &                         key = iicekey, byte = isbyte
-#endif /* ALLOW_AUTODIFF_TAMC */
-
-
-C---  +----1----+----2----+----3----+----4----+----5----+----6----+----7-|--+----|
-C     Sanity check on HEFF, HSNOW, AREA, and PRECIP. The ice 
-c     dynamics subroutines could generate unphysical ice state 
-c     variables (e.g., zero/negative AREA with positive HEFF 
-c     and/or HSNOW)
-
-c     Note: the zeroing out negative HEFF and/or HSNOW here (due
-c     to ice dynamics) might violate mass/energy conservation.
-c     If this is a problem, choose a conservative ice advection
-c     and diffusion scheme. 
-            DO J=1,sNy
-               DO I=1,sNx
-
-#ifdef SEAICE_DEBUG
-                  IF ( (I .EQ. SEAICE_debugPointX)   .and.
-     &               (J .EQ. SEAICE_debugPointY) ) THEN
-
-                     print '(A,i6,4(1x,1PE24.15))',
-     &                  'beg iter, ANm1, HNm1, HSN',myIter,
-     &                  AREANm1(I,J,bi,bj), HEFFNm1(I,J,bi,bj), 
-     &                  HSNOW(I,J,bi,bj)
-
-                  ENDIF
-#endif
-
-                  HEFFNm1(I,J,bi,bj) = MAX(ZERO,HEFFNm1(I,J,bi,bj)) 
-                  HSNOW(I,J,bi,bj)   = MAX(ZERO,HSNOW(I,J,bi,bj)  ) 
-                  AREANm1(I,J,bi,bj) = MAX(ZERO,AREANm1(I,J,bi,bj)) 
-
-c     If either HEFF or AREA are zero, ensure all other ice
-c     state variables are also zero.
-                  IF ((HEFFNm1(I,J,bi,bj) .EQ. ZERO) .OR. 
-     &               (AREANm1(I,J,bi,bj) .EQ. ZERO)) THEN 
-
-                     AREANm1(I,J,bi,bj) = 0. _d 0
-                     HSNOW(I,J,bi,bj)   = 0. _d 0
-                     HEFFNm1(I,J,bi,bj) = 0. _d 0
-
-                     HICE_ACTUAL(I,J)   = 0. _d 0
-                     HSNOW_ACTUAL(I,J)  = 0. _d 0
-
-                  ELSE          !/ Heff and Area > 0
-
-c     Caclulate the actual (not mean) thicknesses 
-c     of the ice and any snow in the grid cell 
+                  IF (AREANm1(I,J,bi,bj) .GT. ZERO) THEN
                      HICE_ACTUAL(I,J)  = 
      &                  HEFFNm1(I,J,bi,bj)/AREANm1(I,J,bi,bj)
 
                      HSNOW_ACTUAL(I,J) = HSNOW(I,J,bi,bj)/
      &                  AREANm1(I,J,bi,bj)
 
-                  ENDIF 
+c                    Removes about 1.2% of the concentration in 48 hours.
+                     AREANm1(I,J,bi,bj) = AREANm1(I,J,bi,bj)*0.99975 _d 0
 
-                  HSNOW_ORIG(I,J) = HSNOW(I,J,bi,bj)
-                  
-c     This is to prevent (spurious) negative precipitation
-c     from decreasing snow depth.
+c                    Maintain the same snow and ice thickness
+                     HEFFNm1(I,J,bi,bj) = 
+     &                     HICE_ACTUAL(I,J)*AREANm1(I,J,bi,bj)
+
+                     HSNOW(I,J,bi,bj) = 
+     &                     HSNOW_ACTUAL(I,J)*AREANm1(I,J,bi,bj)
+
+                   ENDIF
+#endif            
+
+               ENDDO
+            ENDDO
+
+#ifdef ALLOW_AUTODIFF_TAMC
+CADJ STORE area(:,:,bi,bj)   = comlev1_bibj, 
+CADJ &                         key = iicekey, byte = isbyte
+CADJ STORE heff(:,:,bi,bj)   = comlev1_bibj, 
+CADJ &                         key = iicekey, byte = isbyte
+CADJ STORE hsnow(:,:,bi,bj)  = comlev1_bibj, 
+CADJ &                         key = iicekey, byte = isbyte
+CADJ STORE tice(:,:,bi,bj)   = comlev1_bibj, 
+CADJ &                         key = iicekey, byte = isbyte
+CADJ STORE precip(:,:,bi,bj) = comlev1_bibj, 
+CADJ &                         key = iicekey, byte = isbyte
+#endif /* ALLOW_AUTODIFF_TAMC */
+
+            DO J=1,sNy
+               DO I=1,sNx
+C WE HAVE TO BE CAREFUL HERE SINCE ADVECTION/DIFFUSION COULD HAVE 
+C MAKE EITHER (BUT NOT BOTH) HEFF OR AREA ZERO OR NEGATIVE 
+C HSNOW COULD ALSO BECOME NEGATIVE 
+                  HEFFNm1(I,J,bi,bj) = MAX(ZERO,HEFFNm1(I,J,bi,bj)) 
+                  HSNOW(I,J,bi,bj)   = MAX(ZERO,HSNOW(I,J,bi,bj)  ) 
+                  AREANm1(I,J,bi,bj) = MAX(ZERO,AREANm1(I,J,bi,bj)) 
+cif this is hack to prevent negative precip.  somehow negative precips  
+cif escapes my exf_checkrange hack
+cph-checkthis
                   IF (PRECIP(I,J,bi,bj) .LT. ZERO) THEN 
                      PRECIP(I,J,bi,bj) = ZERO 
                   ENDIF 
                ENDDO
             ENDDO
-
-
-#ifdef SEAICE_SIMULATE_DIVERGENCE_IN_1D_MONDEL
-C---  +----1----+----2----+----3----+----4----+----5----+----6----+----7-|--+----|
-c     Simulate unresolved dynamical convergence: This optional  
-c     code parameterizes unresolved small-scale mechanical 
-c     divergence of the ice pack.  To simulate regular lead 
-c     opening, a small fraction of the ice area is removed
-c     each time step while conserving ice and snow mass.
-
-            DO J=1,sNy
-               DO I=1,sNx
-c     Removes about 1.2% of the concentration in 48 hours.
-                  AREANm1(I,J,bi,bj) = AREANm1(I,J,bi,bj)*0.99975 _d 0
-               ENDDO
-            ENDDO
-#endif            
             
-
-C---  +----1----+----2----+----3----+----4----+----5----+----6----+----7-|--+----|
-c     Snow : Treat precipitation as snow and accumulate it onto 
-c     existing snow (or bare ice) it if the snow/ice surface 
-c     temperature is below the freshwater freezing point.  If the
-c     snow/ice surface temperature is at the freezing point, 
-c     assume  precipitation falls as rain and flows to the sea
+#ifdef ALLOW_AUTODIFF_TAMC
+CADJ STORE area(:,:,bi,bj)   = comlev1_bibj, 
+CADJ &                         key = iicekey, byte = isbyte
+CADJ STORE heff(:,:,bi,bj)   = comlev1_bibj, 
+CADJ &                         key = iicekey, byte = isbyte
+CADJ STORE hsnow(:,:,bi,bj)  = comlev1_bibj, 
+CADJ &                         key = iicekey, byte = isbyte
+CADJ STORE precip(:,:,bi,bj) = comlev1_bibj, 
+CADJ &                         key = iicekey, byte = isbyte
+#endif
             DO J=1,sNy
                DO I=1,sNx
+
+                  IF (HEFFNm1(I,J,bi,bj) .LE. ZERO) THEN 
+                      AREANm1(I,J,bi,bj) = 0. _d 0
+                      HSNOW(I,J,bi,bj)   = 0. _d 0
+                  ENDIF 
+ 
+                  IF (AREANm1(I,J,bi,bj) .LE. ZERO) THEN 
+                     HEFFNm1(I,J,bi,bj)  = 0. _d 0
+                     HSNOW(I,J,bi,bj)    = 0. _d 0
+                  ENDIF 
+ 
+C PROCEED ONLY IF WE ARE CERTAIN TO HAVE ICE (AREA > 0) 
+
                   IF (AREANm1(I,J,bi,bj) .GT. ZERO) THEN
+                     HICE_ACTUAL(I,J)  = 
+     &                  HEFFNm1(I,J,bi,bj)/AREANm1(I,J,bi,bj)
 
-                     IF (TICE(I,J,bi,bj) .LT. TMELT) THEN
-c     Snow falls onto freezing surface remaining
-                        SnowAccRateOverIce(I,J) = 
-     &                     PRECIP(I,J,bi,bj)*RHOFW/SEAICE_rhoSnow
+                     HSNOW_ACTUAL(I,J) = HSNOW(I,J,bi,bj)/
+     &                  AREANm1(I,J,bi,bj)
 
-                     ELSE 
-c     The snow melts on impact is is considered 
-c     nothing more than rain which runs to the sea
-                        PrecipRateOverIceSurfaceToSea(I,J)=
-     &                     PRECIP(I,J,bi,bj)
-                     ENDIF
+c                   ACCUMULATE SNOW
+c                   Is the ice/surface below freezing or at the freezing 
+c                   point (melting).  If it is freezing the precip is 
+c                   felt as snow and will accumulate over the ice. Else,
+c                   precip makes its way, like all things in time, to the sea.
+                    IF (TICE(I,J,bi,bj) .LT. TMELT) THEN
+c                     Snow falls onto freezing surface remaining as snow
+                      SnowAccRateOverIce(I,J) = 
+     &                  PRECIP(I,J,bi,bj)*RHOFW/SEAICE_rhoSnow
 
-c     The mean depth of new snow accumulation over the
-c     grid cell (m) 
-                     SnowAccOverIce(I,J) =   SnowAccRateOverIce(I,J)
-     &                  * SEAICE_deltaTtherm*AreaNm1(I,J,bi,bj)
+c                     None of the precipitation falls into the sea 
+                      PrecipRateOverIceSurfaceToSea(I,J) = 0. _d 0
+  
+                    ELSE 
+c                     The snow melts on impact is is considered 
+c                     nothing more than rain.  Since meltponds are
+c                     not explicitly represented,this rain runs
+c                     immediately into the sea
 
-                  ENDIF
-               ENDDO
-            ENDDO
+                      SnowAccRateOverIce(I,J) = 0. _d 0
+C                     The rate of rainfall over melting ice.
+                      PrecipRateOverIceSurfaceToSea(I,J)=
+     &                  PRECIP(I,J,bi,bj)
+                   ENDIF
+
+c                  In m of mean snow thickness.
+                   SnowAccOverIce(I,J) = 
+     &                  SnowAccRateOverIce(I,J)
+     &                  *SEAICE_deltaTtherm*AreaNm1(I,J,bi,bj)
+
+                ELSE
+                   HEFFNm1(I,J,bi,bj) = 0. _d 0
+                   HICE_ACTUAL(I,J)   = 0. _d 0
+                   HSNOW_ACTUAL(I,J)  = 0. _d 0
+                   HSNOW(I,J,bi,bj)   = 0. _d 0
+                ENDIF
+                HSNOW_ORIG(I,J) = HSNOW(I,J,bi,bj)
+             ENDDO
+          ENDDO
             
-
-C---  +----1----+----2----+----3----+----4----+----5----+----6----+----7-|--+----|
-C     Retrieve near-surface wind speed. 
-            DO J=1,sNy
-               DO I=1,sNx
-C     copy the wind speed computed in exf_wind.F to UG
-                  UG(I,J) = MAX(SEAICE_EPS,wspeed(I,J,bi,bj))
-               ENDDO
-            ENDDO
+C     FIND ATM. WIND SPEED
+        DO J=1,sNy
+         DO I=1,sNx
+C         copy the wind speed computed in exf_wind.F to UG
+          UG(I,J) = MAX(SEAICE_EPS,wspeed(I,J,bi,bj))
+         ENDDO
+        ENDDO
 
 #ifdef ALLOW_AUTODIFF_TAMC
-C     ADJ STORE tice   = comlev1, key = ikey_dynamics
+cphCADJ STORE heff   = comlev1, key = ikey_dynamics
+cphCADJ STORE hsnow  = comlev1, key = ikey_dynamics
+cphCADJ STORE uwind  = comlev1, key = ikey_dynamics
+cphCADJ STORE vwind  = comlev1, key = ikey_dynamics
+CADJ STORE tice   = comlev1, key = ikey_dynamics
 #endif /* ALLOW_AUTODIFF_TAMC */
 
+C           SET LAYER TEMPERATURE IN KELVIN
+            DO J=1,sNy
+               DO I=1,sNx
+                  TMIX(I,J,bi,bj)=
+     &                 theta(I,J,kSurface,bi,bj) + TMELT
+               ENDDO
+            ENDDO
 
-#ifndef FORBID_ICE_SURFACE_ATMOSPHERE_HEAT_FLUXES
-C---  +----1----+----2----+----3----+----4----+----5----+----6----+----7-|--+----|
-C     Calculate sea ice/snow thermodynamic fluxes within and out 
-c     of the snow and ice.
+C           CALCULATE THE THERMODYNAMIC FLUXES WITHIN THE SNOW/ICE SYSTEM
+            CALL SEAICE_BUDGET_ICE_IF(
+     I           UG, HICE_ACTUAL, HSNOW_ACTUAL, 
+     U           TICE, 
+     O           F_io_net,F_ia_net,F_ia, QSWI, 
+     I           bi, bj, myThid)
 
-            CALL SEAICE_BUDGET_ICE(
-     I         UG, HICE_ACTUAL, HSNOW_ACTUAL, 
-     U         TICE, 
-     O         F_io_net,F_ia_net,F_ia, QSWI, 
-     I         bi, bj, myTime, myIter, myThid )
+C Sometimes it is nice to have a setup without ice-atmosphere heat
+C fluxes.  This flag turns those fluxes to zero but leaves the 
+C Ice ocean fluxes intact.  Thus, the first oceanic cell can transfer
+C heat to the ice leading to melting in F_ml and it can release 
+C heat to the atmosphere through leads and open area thus growing it in
+C F_ao
 
-#else 
-
-c     Forbid ice surface atmosphere heat fluxes: Sometimes it is 
-c     useful to have a setup without ice-atmosphere heat fluxes. 
-C     This optional flag zeros fluxes at and through and snow/
-c     ice surface.  Sensible heat fluxes from the ocean to the 
-c     ice base and fluxes between the open water fraction of the 
-c     cell and the atmosphere are left intact.
-
+#ifdef FORBID_ICE_SURFACE_ATMOSPHERE_HEAT_FLUXES
             DO J=1,sNy
                DO I=1,sNx
                   F_ia_net (I,J)  = 0. _d 0
                   F_ia (I,J)      = 0. _d 0
                   F_io_net(I,J)   = 0. _d 0
                   QSWI(I,J)       = 0. _d 0
-                  TICE(I,J,bi,bj)   = TMELT
                ENDDO
             ENDDO
 #endif
 
-
-C---  +----1----+----2----+----3----+----4----+----5----+----6----+----7-|--+----|
-c     Debugging
-#ifdef SEAICE_DEBUG
-            print '(A,i6,4(1x,1PE24.15))',
-     &         'sig: iter, F_ia,F_ia_net ',myIter,
-     &         F_ia(SEAICE_debugPointX, SEAICE_debugPointY),
-     &         F_ia_net(SEAICE_debugPointX, SEAICE_debugPointY)
-
-            print '(A,i6,4(1x,1PE24.15))',
-     &         'sig: iter,_io_net,QSWI   ',myIter,
-     &         F_io_net(SEAICE_debugPointX, SEAICE_debugPointY),
-     &         QSWI(SEAICE_debugPointX, SEAICE_debugPointY)
-
-            print '(A,i6,4(1x,1PE24.15))',
-     &         'sig: iter, TICE     ',myIter,
-     &         TICE(SEAICE_debugPointX, SEAICE_debugPointY,bi,bj)
-
-#endif
-
-
-C---  +----1----+----2----+----3----+----4----+----5----+----6----+----7-|--+----|
-c     Calculate the snow and ice growth rates from 1) surface
-c     melt and 2) basal thickening:  Surface energy heat flux 
-c     convergence (F_ia_net) melts snow and ice.  Upward
-c     conductive heat fluxes drive basal thickening.
-
-c     If the surface energy heat flux convergence cannot melt all
-c     the snow, F_ia_net is driven to zero.  If all snow is
-c     melted, F_ia_net is reduced and the remaining energy melts
-c     ice.  
-
             DO J=1,sNy
                DO I=1,sNx
 
+#ifdef SEAICE_DEBUG
+               IF ( (I .EQ. SEAICE_debugPointX)   .and.
+     &              (J .EQ. SEAICE_debugPointY) ) THEN
+
+                 print *,'sig: I,J,F_ia,F_ia_net',I,J,F_ia(I,J),
+     &              F_ia_net(I,J)
+
+               ENDIF
+#endif
+
+c                 If there is heat flux convergence at the snow surface,
+c                 use that energy to melt snow before melting ice.  It's
+c                 possible that some snow will remain after melting, 
+c                 which will drive F_ia_net to zero, or that all of the 
+c                 snow will be melted, leaving a nonzero F_ia_net to melt
+c                 some ice.  
                   F_ia_net_before_snow(I,J) = F_ia_net(I,J)
 
-c     Continue if there is ice in the cell.
-                  IF (AreaNm1(I,J,bi,bj) .LE. ZERO) THEN 
+c                 Only continue if there is snow and ice in the cell
+                  IF (AreaNm1(I,J,bi,bj)*HEFFNm1(I,J,bi,bj)
+     &                .LE. ZERO                            ) THEN
                      IceGrowthRateUnderExistingIce(I,J) = 0. _d 0
                      IceGrowthRateFromSurface(I,J)      = 0. _d 0
                      NetExistingIceGrowthRate(I,J)      = 0. _d 0
                   ELSE
-c     The growth rate (m/s) beneath ice due to
-c     heat flux divergence at the ice base associated
-c     with upward conductive heat fluxes through the ice 
-c     (F_io_net)
+c                    The growth rate (m/s) beneath existing ice is given by the upward
+c                    ocean-ice conductive flux, F_io_net, and QI.
                      IceGrowthRateUnderExistingIce(I,J)=F_io_net(I,J)*QI
 
-c     The potential snow melt rate (m/s) due to surface
-c     heat flux convergence.  Note, snow melt requires a
-c     negative F_ia_net (implying convergence) for 
-c     a nonzero PSMRFW.
+c                    The rate at which snow is melted (m/s) because of surface 
+c                    heat flux convergence.  Note, during snow melt, F_ia_net must 
+c                    be negative (implying convergence) to make PSMRFW is positive
                      PotSnowMeltRateFromSurf(I,J)= - F_ia_net(I,J)*QS
 
-c     This is the depth of snow (m) that would be melted 
-c     over one time step.
+c                    This is the depth of snow (m) that would be melted over one time step.
                      PotSnowMeltFromSurf(I,J) =
      &                  PotSnowMeltRateFromSurf(I,J)* SEAICE_deltaTtherm
 
-c     If more can be melted than exists, the melt rate
-c     is reduced.  
+c                    If we can melt MORE than is actually there, then the melt 
+c                    rate is reduced so that only that which is there 
+c                    is melted during the time step.  In this case, not all of the 
+c                    heat flux convergence at the surface is used to melt snow.
+c                    Any remaining energy will melt ice.  
+
+c                    SurfHeatFluxConvergToSnowMelt is the part of the total heat 
+c                    flux convergence which melts snow.
 
                      IF (PotSnowMeltFromSurf(I,J) .GE. 
-     &                  HSNOW_ACTUAL(I,J)) THEN
+     &                   HSNOW_ACTUAL(I,J)) THEN
 
-c     Snow depth to be melted and the snow melt rate.
-                        SnowMeltFromSurface(I,J) = HSNOW_ACTUAL(I,J)
+c                      Snow melt and melt rate (actual not mean snow thickness)
+                       SnowMeltFromSurface(I,J)     = HSNOW_ACTUAL(I,J)
 
-                        SnowMeltRateFromSurface(I,J) = 
-     &                     SnowMeltFromSurface(I,J)/ SEAICE_deltaTtherm
+                       SnowMeltRateFromSurface(I,J) = 
+     &                   SnowMeltFromSurface(I,J)/ SEAICE_deltaTtherm
 
-c     SurfHeatFluxConvergToSnowMelt is the part of the 
-c     total heat flux convergence which melts snow.
-                        SurfHeatFluxConvergToSnowMelt(I,J) =
-     &                     -HSNOW_ACTUAL(I,J)/QS/SEAICE_deltaTtherm
+                       SurfHeatFluxConvergToSnowMelt(I,J) =
+     &                   -HSNOW_ACTUAL(I,J)/QS/SEAICE_deltaTtherm
                      ELSE
-c     Snow remains after melt.  
-                        SnowMeltFromSurface(I,J)=
-     &                     PotSnowMeltFromSurf(I,J)
+c                      In this case there will be snow remaining after melting.
+c                      All of the surface heat convergence will be redirected to 
+c                      this effort.
+                       SnowMeltFromSurface(I,J)=PotSnowMeltFromSurf(I,J)
 
-                        SnowMeltRateFromSurface(I,J) = 
-     &                     PotSnowMeltRateFromSurf(I,J)
+                       SnowMeltRateFromSurface(I,J) = 
+     &                    PotSnowMeltRateFromSurf(I,J)
 
-                        SurfHeatFluxConvergToSnowMelt(I,J) =
-     &                     F_ia_net(I,J)
+                       SurfHeatFluxConvergToSnowMelt(I,J) =F_ia_net(I,J)
                      ENDIF
 
-c     Reduce the heat flux convergence available to melt 
-c     ice by the amount used to melt snow.
+c                    Reduce the heat flux convergence available to melt surface
+c                    ice by the amount used to melt snow
                      F_ia_net(I,J) = 
      &                  F_ia_net(I,J)-SurfHeatFluxConvergToSnowMelt(I,J)
 
                      IceGrowthRateFromSurface(I,J) = F_ia_net(I,J)*QI
 
-c     The total growth rate (m/s) of the existing ice - 
-c     the rate of new ice accumulation less the rate of 
-c     surface melt.
+c                    The total growth rate (m/s) of the existing ice - the rate of
+c                    new ice accretion at the base less the rate due to surface melt
                      NetExistingIceGrowthRate(I,J) = 
-     &                  IceGrowthRateUnderExistingIce(I,J) +
-     &                  IceGrowthRateFromSurface(I,J)
+     &                 IceGrowthRateUnderExistingIce(I,J) +
+     &                 IceGrowthRateFromSurface(I,J)
                   ENDIF
-
-               ENDDO            !/ i
-            ENDDO               !/ j
-
-
-C---  +----1----+----2----+----3----+----4----+----5----+----6----+----7-|--+----|
-C     Retrieve upper ocean temp and store temporarily in TMIX.
-            DO J=1,sNy
-               DO I=1,sNx
-
-C     Set the upper ocean temperature in Kelvin
-                  TMIX(I,J,bi,bj)= theta(I,J,kSurface,bi,bj) + TMELT
-
                ENDDO
             ENDDO
-            
 
-C---  +----1----+----2----+----3----+----4----+----5----+----6----+----7-|--+----|
-c     Retrieve the air-sea heat and shortwave radiative fluxes
+c           Retrieve the air-sea heat and shortwave radiative fluxes
             CALL SEAICE_BUDGET_OCEAN(
-     I         UG, 
-     U         TMIX, 
-     O         F_ao, QSWO, 
-     I         bi, bj, myTime, myIter, myThid )
-
-            
+     I           UG, 
+     U           TMIX, 
+     O           F_ao, QSWO, 
+     I           bi, bj, myTime, myIter, myThid )
+ 
 #ifdef SEAICE_DEBUG
-C---  +----1----+----2----+----3----+----4----+----5----+----6----+----7-|--+----|
-c     Debugging
-            print '(A,i6,4(1x,1PE24.15))',
-     &         'myIter, Fao, QSWO ', myIter,
-     &         F_ao(SEAICE_debugPointX, SEAICE_debugPointY),
-     &         QSWO(SEAICE_debugPointX, SEAICE_debugPointY),
-     &         TMIX(SEAICE_debugPointX, SEAICE_debugPointY,bi,bj)
+        print *,'myiter', myIter
+        print '(A,2i4,2(1x,1P2E15.3))',
+     &       'ifice sigr, dbgx,dby, (netHF, SWHeatFlux)',
+     &        SEAICE_debugPointX,   SEAICE_debugPointY,
+     &        F_ao(SEAICE_debugPointX, SEAICE_debugPointY),
+     &        QSWO(SEAICE_debugPointX, SEAICE_debugPointY)
 #endif
 
 
-C---  +----1----+----2----+----3----+----4----+----5----+----6----+----7-|--+----|
-c     Calculate the ice growth rate from open water heat fluxes:
-c     Turbulent fluxes (F_ao) and shortwave energy convergence in
-c     the uppermost ocean grid cell contribute.
-c     
-c     SWFRACB - the fraction of incoming sw radiation absorbed in 
-c     the uppermost ocean grid cell 
+c--   Not all of the sw radiation is absorbed in the uppermost ocean grid cell layer.
+c     Only that fraction which converges in the uppermost ocean grid cell is used to
+c     melt ice.
+c           SWFRACB - the fraction of incoming sw radiation absorbed in the 
+c                     uppermost ocean grid cell (calculated in seaice_init_vari.F)
             DO J=1,sNy
                DO I=1,sNx
 
-c     The contribution of shortwave heating is 
-c     not included without #define SHORTWAVE_HEATING
-
+c The contribution of shortwave heating is 
+c not included without #define SHORTWAVE_HEATING
 #ifdef SHORTWAVE_HEATING
                   QSWO_BELOW_FIRST_LAYER(i,j)= QSWO(I,J)*SWFRACB
                   QSWO_IN_FIRST_LAYER(I,J)   = QSWO(I,J)*(ONE - SWFRACB)
@@ -756,106 +728,100 @@ c     not included without #define SHORTWAVE_HEATING
                   QSWO_BELOW_FIRST_LAYER(i,j)= 0. _d 0
                   QSWO_IN_FIRST_LAYER(I,J)   = 0. _d 0
 #endif
-
                   IceGrowthRateOpenWater(I,J)= QI*
-     &               (F_ao(I,J) - QSWO(I,J) + QSWO_IN_FIRST_LAYER(I,J))
+     &              (F_ao(I,J) - QSWO(I,J) + QSWO_IN_FIRST_LAYER(I,J))
 
-               ENDDO
+             ENDDO
             ENDDO        
             
 
 #ifdef ALLOW_AUTODIFF_TAMC
-C     ADJ STORE theta(:,:,:,bi,bj)= comlev1_bibj, 
-C     ADJ &                         key = iicekey, byte = isbyte
-C     ADJ STORE heff(:,:,bi,bj)   = comlev1_bibj, 
-C     ADJ &                         key = iicekey, byte = isbyte
+CADJ STORE theta(:,:,:,bi,bj)= comlev1_bibj, 
+CADJ &                         key = iicekey, byte = isbyte
+CADJ STORE heff(:,:,bi,bj)   = comlev1_bibj, 
+CADJ &                         key = iicekey, byte = isbyte
 #endif /* ALLOW_AUTODIFF_TAMC */
 
 
-C---  +----1----+----2----+----3----+----4----+----5----+----6----+----7-|--+----|
-C     Calcuate the ice growth rate from turbulent heat fluxes from
-c     the ocean.
-
+C--   Calcuate the heat fluxes from the ocean to the sea ice
             DO J=1,sNy
                DO I=1,sNx
 
-#ifdef SEAICE_VARIABLE_FREEZING_POINT
 C     Calculate the seawater freezing point
+#ifdef SEAICE_VARIABLE_FREEZING_POINT
                   TBC = -0.0575 _d 0*salt(I,J,kSurface,bi,bj) + 
-     &               0.0901 _d 0
+     &                 0.0901 _d 0
 #endif /* SEAICE_VARIABLE_FREEZING_POINT */
                   
 c     Bound the ocean temperature to be at or above the freezing point.
-                  surf_theta = max(theta(I,J,kSurface,bi,bj), TBC)
-
+      surf_theta = max(theta(I,J,kSurface,bi,bj), TBC)
 
 c     This model has two alternative schemes to calculate turbulent ocean-ice
 c     heat fluxes.  Each is described in turn
-c     
+c
 c     ==== METHOD 1 ====
-c     
+c
 c     The first uses an empircal relationship between the 
 c     'far-field' ocean temperature and ocean to sea ice turbulent heat fluxes 
 c     given by McPhee:
-c     
+c
 c     Flux  = rho_sw * cp_sw * <w'T'> 
 c     <w'T'>= S_t *  u_star * (T_o - T_f)
-c     
-c     Where,
-c     rho_sw : seawater density (kg m^-3)
-c     cp_sw  : seawater heat capcity (J kg^-1 K^-1)
-c     S_t    : Stanton Number ~ 0.0056 (dimensionless)
-c     u_star : friction velocity beneath ice ~ 0.015 m s^-1
-c     T_o, T_f : The 'far-field' ocean temperature and ice
-c     freezing point (deg C)
-c     
+c
+c          Where,
+c             rho_sw : seawater density (kg m^-3)
+c             cp_sw  : seawater heat capcity (J kg^-1 K^-1)
+c             S_t    : Stanton Number ~ 0.0056 (dimensionless)
+c             u_star : friction velocity beneath ice ~ 0.015 m s^-1
+c             T_o, T_f : The 'far-field' ocean temperature and ice
+c                        freezing point (deg C)
+c
 c     Using typical values, ice advected over waters warmer by 1 degree
 c     will be subjected to a basal heat flux of ~ 345 W m^-2.  
-c     
+c
 c     In the model, the criteria for ice growth is that the air-sea
 c     heat loss must exceed the potential ocean-ice heat flux (i.e., more 
 c     potential ice production over one time step than melt).  
 c     Using the above parameterization, ice will form in waters which 
 c     are much warmer than its salinity-determined freezing point
 c     using typical wintertime conditions in, say, the North Atlantic.
-c     
+c
 c     Therefore, when no ice is present, an additional factor is applied
 c     to the above <w'T'> (mixedLayerTurbulenceFactor) to represent the idea that 
 c     turbulent mixing at and near the surface of an ice-free ocean
 c     is much greater than mixing beneath an ice-covered one.
-c     
+c
 c     A factor of 12.5 is chosen for mixedLayerTurbulenceFactor.  Consequently,
 c     for each 0.1 degree above freezing of the upper ocean grid cell,
 c     the air-sea heat losses must exceed ~ 515 W m^-2 before ice forms.
-c     
+c    
 c     Once ice gains a foothold in a grid cell, the McPhee parameterization
 c     is immediately invoked.
-c     
+c   
 c     ==== METHOD 2 ====
-c     
+c
 c     The second scheme (the original and now outdated version)
 c     subsumes (S_t * u_star) into a single variable (SEAICE_gamma_t)
-c     in the following way:
-c     
+c      in the following way:
+c
 c     Flux  = rho_sw * cp_sw * GAMMA 
 c     GAMMA = dRf(1)/SEAICE_gamma_t * (T_o - T_f)
-c     
-c     Where,
-c     dRf(1)  : depth of surface level grid cell (originally 
-c     assumed to be 10 m)
-c     SEAICE_gamma_t : an empirical parameter (~ 3 days in seconds)
-c     
+c    
+c           Where,
+c               dRf(1)  : depth of surface level grid cell (originally 
+c                         assumed to be 10 m)
+c               SEAICE_gamma_t : an empirical parameter (~ 3 days in seconds)
+c
 c     Using typical values, ice advected into a grid cell 
 c     that is warmer than the sea ice freezing point by 1 degree
 c     will be subjected to a basal heat flux of ~ 160 W m^-2.   Therefore,
 c     as written, one should choose a SEAICE_gamma_t = 1.4 days in seconds
 c     to have flux magnitudes match those of the McPhee parameterization.
-c     
+c    
 c     The original scheme is accessed by defining  #SEAICE_USE_ORIGINAL_HEAT FLUX
 
 #ifndef SEAICE_USE_ORIGINAL_HEAT_FLUX
-
-c     If ice is present, MixedLayerTurbulenceFactor = 1.0, else 12.50
+c                 If ice is present, MixedLayerTurbulenceFactor = 1.0, else 12.50
                   IF (AREANm1(I,J,bi,bj) .GT. 0. _d 0) THEN
                      MixedLayerTurbulenceFactor = ONE
                   ELSE
@@ -863,160 +829,153 @@ c     If ice is present, MixedLayerTurbulenceFactor = 1.0, else 12.50
                   ENDIF
 
                   F_mi(I,J) = -STANTON_NUMBER * USTAR_BASE * RHOSW *
-     &               CPW *(surf_theta - TBC)*MixedLayerTurbulenceFactor
+     &                CPW *(surf_theta - TBC)*MixedLayerTurbulenceFactor
 #else
-
-c     no turbulence factor using original_heat_flux scheme
+c                 no turbulence factor using original_heat_flux scheme
                   F_mi(I,J) = -GAMMA*RHOSW*CPW *(surf_theta - TBC)
 
 #endif /* SEAICE_USE_ORIGINAL_HEAT_FLUX */
 
                   IceGrowthRateMixedLayer(I,J) = F_mi(I,J)*QI;
-
-               ENDDO            !/ i
-            ENDDO               !/ j
+               ENDDO
+            ENDDO 
 
 #ifdef ALLOW_AUTODIFF_TAMC
-C     ADJ STORE S_h(:,:)         = comlev1_bibj, 
-C     ADJ &                        key = iicekey, byte = isbyte
+CADJ STORE S_h(:,:)         = comlev1_bibj, 
+CADJ &                        key = iicekey, byte = isbyte
 #endif /* ALLOW_AUTODIFF_TAMC */
 
 
 
-C---  +----1----+----2----+----3----+----4----+----5----+----6----+----7-|--+----|
-C     Calculate the ice thickness derivative (S_h)
-
+C           CALCULATE THICKNESS DERIVATIVE (S_h)
             DO J=1,sNy
                DO I=1,sNx
                   S_h(I,J) = 
-     &               NetExistingIceGrowthRate(I,J)*AREANm1(I,J,bi,bj)+
-     &               (ONE -AREANm1(I,J,bi,bj))*
-     &               IceGrowthRateOpenWater(I,J) +
-     &               IceGrowthRateMixedLayer(I,J)
+     &                 NetExistingIceGrowthRate(I,J)*AREANm1(I,J,bi,bj)+
+     &                 (ONE -AREANm1(I,J,bi,bj))*
+     &                 IceGrowthRateOpenWater(I,J) +
+     &                 IceGrowthRateMixedLayer(I,J)
 
-c     Both the accumulation and melt rates are in terms
-c     of actual snow thickness.  As with HEFF,
-c     multiplying actual snow depth by AREA converts to
-c     mean snow thickness.
-                  S_hsnow(I,J) =     AREANm1(I,J,bi,bj)* (
-     &               SnowAccRateOverIce(I,J) - 
-     &               SnowMeltRateFromSurface(I,J)     ) 
-
+c                  Both the accumulation and melt rates are in terms
+c                  of actual snow thickness.  As with ice, multiplying
+c                  with area converts to mean snow thickness.
+                   S_hsnow(I,J) =     AREANm1(I,J,bi,bj)* (
+     &                  SnowAccRateOverIce(I,J) - 
+     &                  SnowMeltRateFromSurface(I,J)     ) 
                ENDDO
             ENDDO
 
-
 #ifdef ALLOW_SALT_PLUME
-C---  +----1----+----2----+----3----+----4----+----5----+----6----+----7-|--+----|
-C     Calculate the flux of salt to be treated with the salt plume
-c     parameterization.
-            IF (useSALT_PLUME) THEN
-               DO J=1,sNy
-                  DO I=1,sNx
+C       Now that we know the thickness tendency terms, we can calculate the saltPlumeFlux
+        DO J=1,sNy
+         DO I=1,sNx
 
-c     It is assumed that ice production in leads can generate
-c     salt plumes.  The fraction of the salt sent to the plume package
-c     from ice produced in leads (defined as the open water
-c     fraction) is a nonlinear function of ice concentration, AREA.
-c     
-c     Specifically, the function is a sigmoid with range and 
-c     domain {0,1}.  The function, f(AREA), has a single free parameter,
-c     SEAICE_plumeInflectionPoint, the inflection point of the curve.  
-c     By construction, the function has the following properties:
-c     f(1) \approx 1.0
-c     f(SEAICE_plumeInflectionPoint) = 0.5
-c     f(0) \approx 0.0 (when SEAICE_plumeInflectionPoint \geq 0.5)
-c     f(0) > 0.0 (when SEAICE_plumeInflectionPoint < 0.5)
-c     
-c     As AREA --> 1, the open water fraction occurs
-c     in narrow leads, new ice production become spatially non-uniform,
-c     and the assumptions motivating KPP no longer hold.  To treat
-c     overturning in a more physically realistic way, the salt produced
-c     in the leads should be sent to depth via the plume package.  To assure 
-c     only narrow leads generate plumes, choose a SEAICE_plumeInflectionPoint 
-c     of > 0.8.
+c            It is assumed that ice production in leads can generate
+c            salt plumes.  The fraction of the salt sent to the plume package
+c            from ice produced in leads (defined as the open water
+c            fraction) is a nonlinear function of ice concentration, AREA.
+c
+c            Specifically, function is a logistic curve (sigmoid) with a range and 
+c            domain {0,1}.  The function, f(AREA), has a single free parameter,
+c            SEAICE_plumeInflectionPoint, the inflection point of the curve.  
+c            By construction, the function has the following properties:
+c            f(1) \approx 1.0
+c            f(SEAICE_plumeInflectionPoint) = 0.5
+c            f(0) \approx 0.0 (when SEAICE_plumeInflectionPoint \geq 0.5)
+c            f(0) > 0.0 (when SEAICE_plumeInflectionPoint < 0.5)
+c
+c            As AREA --> 1, the open water fraction occurs
+c            in narrow leads, new ice production become spatially non-uniform,
+c            and the assumptions motivating KPP no longer hold.  To treat
+c            overturning in a more physically realistic way, the salt produced
+c            in the leads should be sent to depth via the plume package.  To assure 
+c            only narrow leads generate plumes, choose a SEAICE_plumeInflectionPoint 
+c            of > 0.8.
 
-c     Ensure that there is already ice present or that the total ice
-c     ice tendency term is positive.  We don't want to release 
-c     salt if sea ice is not established in the cell.
+c            Ensure that there is already ice present or that the total ice
+c            ice tendency term is positive.  We don't want to release 
+c            salt if sea ice is not established in the cell.
 
-                     IF ((AREANm1(I,J,bi,bj) .GT. ZERO) .OR. 
-     &                  (S_h(I,J)           .GT. ZERO)) THEN
-                        
-                        leadPlumeFraction(I,J) = 
-     &                     (ONE + EXP( ( SEAICE_plumeInflectionPoint- 
-     &                     AREANm1(I,J,bi,bj)
+             IF ((AREANm1(I,J,bi,bj) .GT. ZERO) .OR. 
+     &           (S_h(I,J)           .GT. ZERO)) THEN
+ 
+              leadPlumeFraction(I,J) = 
+     &         (ONE + EXP( ( SEAICE_plumeInflectionPoint - 
+     &                       AREANm1(I,J,bi,bj)
      &                     ) * 5._d 0/
      &                     (ONE - SEAICE_plumeInflectionPoint)
-     &                     )
-     &                     )**(-ONE) 
-                        
-c     Only consider positive ice growth rate in leads
-c     for the salt plume flux.
-                        IceGrowthRateInLeads(I,J) = max( ZERO,
-     &                     (ONE - AREANm1(I,J,bi,bj)) * 
-     &                     IceGrowthRateOpenWater(I,J))
+     &                   )
+     &         )**(-ONE) 
+ 
+c             Only consider positive ice growth rate in leads for salt production
+              IceGrowthRateInLeads(I,J) = max( ZERO,
+     &         (ONE - AREANm1(I,J,bi,bj)) * IceGrowthRateOpenWater(I,J))
 
-                        saltPlumeFlux(I,J,bi,bj) = 
-     &                     leadPlumeFraction(I,J) *
-     &                     HEFFM(I,J,bi,bj)*IceGrowthRateInLeads(I,J)*
-     &                     ICE2WATR*rhoConstFresh*
-     &                     (salt(I,J,kSurface,bi,bj) - 
-     &                     SEAICE_salinity_fixed)
-                        
-                     ENDIF
+              saltPlumeFlux(I,J,bi,bj) = leadPlumeFraction(I,J) * 
+     &            HEFFM(I,J,bi,bj)*IceGrowthRateInLeads(I,J)*
+     &            ICE2WATR*rhoConstFresh*
+     &            (salt(I,J,kSurface,bi,bj) - SEAICE_salinity_fixed)
+             ELSE 
 
-                  ENDDO         !/ Use plume 
-               ENDDO            !/ j
-            ENDIF               !/ i
+              saltPlumeFlux(I,J,bi,bj) = ZERO 
 
+             ENDIF
+
+         ENDDO
+        ENDDO
 #endif /* ALLOW_SALT_PLUME */
 
-
 #ifdef ALLOW_AUTODIFF_TAMC
-C     ADJ STORE S_h(:,:)         = comlev1_bibj, 
-C     ADJ &                        key = iicekey, byte = isbyte
-C     ADJ STORE S_hsnow(:,:)     = comlev1_bibj, 
-C     ADJ &                        key = iicekey, byte = isbyte
+CADJ STORE area(:,:,bi,bj)  = comlev1_bibj, 
+CADJ &                        key = iicekey, byte = isbyte
+CADJ STORE heff(:,:,bi,bj)  = comlev1_bibj, 
+CADJ &                        key = iicekey, byte = isbyte
+CADJ STORE hsnow(:,:,bi,bj) = comlev1_bibj, 
+CADJ &                        key = iicekey, byte = isbyte
+CADJ STORE S_h(:,:)         = comlev1_bibj, 
+CADJ &                        key = iicekey, byte = isbyte
+CADJ STORE S_hsnow(:,:)     = comlev1_bibj, 
+CADJ &                        key = iicekey, byte = isbyte
 #endif /* ALLOW_AUTODIFF_TAMC */
 
 
-C---  +----1----+----2----+----3----+----4----+----5----+----6----+----7-|--+----|
-C     Calculate the ice area derivative (S_a)
+
+c           Caculate dA/dt (S_a)
             DO J=1,sNy
                DO I=1,sNx
+                  S_a(I,J) =  0. _d 0 
 
-c     In the following, time derivatives of AREA require
-c     divisions by HEFF. To prevent sensitivity blow up when
-c     HEFF --> 0, we divide by an approximation to HEFF, HEFF*:
-c     
-c     HEFF* = sqrt(HEFF^2 + heff_min^2)
-c     Where heff_min is implicitly defined as 0.1 m. 
-c     
-c     HEFF* is defined as a hyperbola with slope = 1 and 
-c     y-intercept of heff_min.  The gradient of 1/HEFF* is 
-c     well-behaved (correct sign) and deviates from 1/HEFF 
-c     significantly only when HEFF --> 0.
+c                 In the following, time derivatives of AREA require
+c                 divisions by HEFF. To prevent sensitivity blow up when
+c                 HEFF --> 0, we divide by an approximation to HEFF, HEFF*:
+c
+c                 HEFF* = sqrt(HEFF^2 + heff_min^2)
+c                      Where heff_min is implicitly defined as 0.1 m. 
+c
+c                 HEFF* is defined as a hyperbola with slope = 1 and 
+c                 y-intercept of heff_min.  The gradient of 1/HEFF* is 
+c                 well-behaved (correct sign) and deviates from 1/HEFF 
+c                 significantly only when HEFF --> 0.
 
-                  IF (AREANm1(I,J,bi,bj) .GT. ZERO) THEN
+                 IF ( (HEFFNm1(I,J,bi,bj).GT. ZERO) .AND.
+     &                (AREANm1(I,J,bi,bj).NE. ZERO)) THEN
                      HEFF_MIN = SQRT( 0.01 _d 0 + 
-     &                  HEFFNm1(I,J,bi,bj) * HEFFNm1(I,J,bi,bj) )
-                  ELSE
-c     Just in case somehow we miss a case, we want to divide
-c     by a sensible number, here 10 cm.
-                     HEFF_MIN = max(HEFFNm1(I,J,bi,bj), 0.1 _d 0)
-                  ENDIF
+     &                   HEFFNm1(I,J,bi,bj) * HEFFNm1(I,J,bi,bj) )
+                 ELSE
+c                        Just in case somehow we miss a case, we want to divide
+c                        by a sensible number, here 10 cm.
+                         HEFF_MIN = max(HEFFNm1(I,J,bi,bj), 0.1 _d 0)
+                 ENDIF
 
-c     Caculate the ice area growth rate from the open water fluxes.
-c     First, determine whether the open water growth rate is positive or
-c     negative.  If positive, make sure that ice is present or that the 
-c     net ice thickness growth rate is positive before extending 
-c     the ice cover across the grid cell.
+c                 Caculate the ice area growth rate from the open water fluxes.
+c                 First, determine whether the open water growth rate is positive or
+c                 negative.  If positive, make sure that ice is present or that the 
+c                 net ice thickness growth rate is positive before extending ice cover 
 
                   IF (IceGrowthRateOpenWater(I,J) .GT. ZERO) THEN
 
-c     Determine which hemisphere for hemisphere-dependent so-called
-c     "lead closing variable", HO
+c                    Determine which hemisphere for hemisphere-dependent
+c                    "lead closing variable", HO
 
                      IF ( YC(I,J,bi,bj) .LT. ZERO ) THEN
                         S_a_from_IGROW(I,J) = (ONE-AREANm1(I,J,bi,bj))*
@@ -1026,418 +985,389 @@ c     "lead closing variable", HO
      &                     IceGrowthRateOpenWater(I,J)/HO
                      ENDIF
 
-c     If there is already ice, add to S_a
+c                    If there is already ice, add to S_a
                      IF (AREANm1(I,J,bi,bj) .GT. ZERO) THEN
                         S_a(I,J) = S_a(I,J) + S_a_from_IGROW(I,J)
-
-c     otherwise, add to S_a only if the net ice growth rate
-c     is positive
-                     ELSE IF (S_h(I,J) .GT. ZERO) THEN
-                        S_a(I,J) = S_a(I,J) + S_a_from_IGROW(I,J)
+c                    otherwise, add to S_a only if the net ice growth rate
+c                    is positive
+                     ELSE
+                        IF (S_h(I,J) .GT. ZERO) THEN
+                           S_a(I,J) = S_a(I,J) + S_a_from_IGROW(I,J)
+                        ENDIF
                      ENDIF
+                  ELSE  
 
-                  ELSE IF ( AREANm1(I,J,bi,bj) .GT. ZERO) THEN
-c     The open water growth rate is negative - contract the ice cover.
+c                    The open water growth rate is negative - contract the ice cover.
+                     IF ( (AREANm1(I,J,bi,bj).GT. ZERO) .AND.
+     &                  (HEFFNm1(I,J,bi,bj).GT. ZERO) ) THEN
 
-                     S_a(I,J) = S_a(I,J) +
-     &                  AREANm1(I,J,bi,bj)/(2. _d 0*HEFF_MIN)*
-     &                  IceGrowthRateOpenWater(I,J)*
-     &                  (ONE - AREANm1(I,J,bi,bj))
-
-                  ELSE
-                     S_a(I,J) = S_a(I,J) +  0. _d 0
+                       S_a(I,J) = S_a(I,J) 
+     &                    + AREANm1(I,J,bi,bj)/(2. _d 0*HEFF_MIN)*
+     &                    IceGrowthRateOpenWater(I,J)*
+     &                    (ONE - AREANm1(I,J,bi,bj))
+                     ELSE
+                       S_a(I,J) = S_a(I,J) +  0. _d 0
+                     ENDIF
                   ENDIF
 
-C     Contract ice area if IceGrowthRateMixedLayer is negative
-c     and ice is present
+C                 Melt ice if the IceGrowthRateMixedLayer is negative
                   IF ( (IceGrowthRateMixedLayer(I,J) .LE. ZERO) .AND. 
-     &               (AREANm1(I,J,bi,bj) .GT. ZERO) ) THEN
+     &                 (AREANm1(I,J,bi,bj).GT. ZERO) .AND.
+     &                 (HEFFNm1(I,J,bi,bj).NE. ZERO) ) THEN
 
-                     S_a(I,J) = S_a(I,J) +
-     &                  AREANm1(I,J,bi,bj)/(2. _d 0 *HEFF_MIN)*
-     &                  IceGrowthRateMixedLayer(I,J)
+                     S_a(I,J) = S_a(I,J) 
+     &                    + AREANm1(I,J,bi,bj)/(2. _d 0 *HEFF_MIN)*
+     &                    IceGrowthRateMixedLayer(I,J)
 
                   ELSE
                      S_a(I,J) = S_a(I,J) +  0. _d 0
                   ENDIF
 
-C     Contract ice area if NetExistingIceGrowthRate is negative
-c     and ice is present
+C                 Melt ice if the NetExistingIceGrowthRate is negative
                   IF ( (NetExistingIceGrowthRate(I,J) .LE. ZERO) .AND. 
-     &               (AREANm1(I,J,bi,bj) .GT. ZERO)) THEN
+     &                 (AREANm1(I,J,bi,bj).GT. ZERO) .AND.
+     &                 (HEFFNm1(I,J,bi,bj).NE. ZERO) ) THEN
 
-                     S_a(I,J) = S_a(I,J) +
-     &                  AREANm1(I,J,bi,bj)/(2. _d 0 * HEFF_MIN)*
+                     S_a(I,J) = S_a(I,J) 
+     &                   + AREANm1(I,J,bi,bj)/(2. _d 0 * HEFF_MIN)*
      &                  NetExistingIceGrowthRate(I,J)*AREANm1(I,J,bi,bj)
 
                   ELSE
                      S_a(I,J) = S_a(I,J) +  0. _d 0
                   ENDIF
                   
-               ENDDO            !/ i
-            ENDDO               !/ j
-            
+               ENDDO
+            ENDDO
+                 
 
 #ifdef ALLOW_AUTODIFF_TAMC
-C     ADJ STORE heff(:,:,bi,bj)   = comlev1_bibj, 
-C     ADJ &                         key = iicekey, byte = isbyte
-C     ADJ STORE hsnow(:,:,bi,bj)  = comlev1_bibj, 
-C     ADJ &                         key = iicekey, byte = isbyte
-C     ADJ STORE S_a(:,:)          = comlev1_bibj, 
-C     ADJ &                         key = iicekey, byte = isbyte
-C     ADJ STORE S_h(:,:)          = comlev1_bibj, 
-C     ADJ &                         key = iicekey, byte = isbyte
-C     ADJ STORE f_ao(:,:)         = comlev1_bibj, 
-C     ADJ &                         key = iicekey, byte = isbyte
-C     ADJ STORE qswi(:,:)         = comlev1_bibj, 
-C     ADJ &                         key = iicekey, byte = isbyte
-C     ADJ STORE qswo(:,:)         = comlev1_bibj, 
-C     ADJ &                         key = iicekey, byte = isbyte
-C     ADJ STORE area(:,:,bi,bj)   = comlev1_bibj, 
-C     ADJ &                         key = iicekey, byte = isbyte
+CADJ STORE heff(:,:,bi,bj)   = comlev1_bibj, 
+CADJ &                         key = iicekey, byte = isbyte
+CADJ STORE hsnow(:,:,bi,bj)  = comlev1_bibj, 
+CADJ &                         key = iicekey, byte = isbyte
+CADJ STORE S_a(:,:)          = comlev1_bibj, 
+CADJ &                         key = iicekey, byte = isbyte
+CADJ STORE S_h(:,:)          = comlev1_bibj, 
+CADJ &                         key = iicekey, byte = isbyte
+CADJ STORE f_ao(:,:)         = comlev1_bibj, 
+CADJ &                         key = iicekey, byte = isbyte
+CADJ STORE qswi(:,:)         = comlev1_bibj, 
+CADJ &                         key = iicekey, byte = isbyte
+CADJ STORE qswo(:,:)         = comlev1_bibj, 
+CADJ &                         key = iicekey, byte = isbyte
+CADJ STORE area(:,:,bi,bj)   = comlev1_bibj, 
+CADJ &                         key = iicekey, byte = isbyte
 #endif
 
-
-C---  +----1----+----2----+----3----+----4----+----5----+----6----+----7-|--+----|
-C     Update AREA, HEFF, and HSNOW using the time derivativees
-c     calculated above.
+C           Update the area, heff, and hsnow 
             DO J=1,sNy
                DO I=1,sNx
-
                   AREA(I,J,bi,bj) = AREANm1(I,J,bi,bj) + 
-     &               SEAICE_deltaTtherm * S_a(I,J)
-
+     &                 SEAICE_deltaTtherm * S_a(I,J)
                   HEFF(I,J,bi,bj) = HEFFNm1(I,J,bi,bj) +
-     &               SEAICE_deltaTTherm * S_h(I,J)
-
+     &                 SEAICE_deltaTTherm * S_h(I,J)
                   HSNOW(I,J,bi,bj) = HSNOW(I,J,bi,bj) +
-     &               SEAICE_deltaTTherm * S_hsnow(I,J)
+     &                 SEAICE_deltaTTherm * S_hsnow(I,J)
+               ENDDO
+            ENDDO
+            
+#ifdef ALLOW_AUTODIFF_TAMC
+CADJ STORE area(:,:,bi,bj)  = comlev1_bibj, 
+CADJ &                        key = iicekey, byte = isbyte
+CADJ STORE heff(:,:,bi,bj)  = comlev1_bibj, 
+CADJ &                        key = iicekey, byte = isbyte
+CADJ STORE hsnow(:,:,bi,bj) = comlev1_bibj, 
+CADJ &                        key = iicekey, byte = isbyte
+#endif
+
+            DO J=1,sNy
+               DO I=1,sNx
+c                 Bound area, heff, and hsnow 
+                  AREA(I,J,bi,bj) = MIN(ONE,AREA(I,J,bi,bj))
+                  AREA(I,J,bi,bj) = MAX(ZERO,AREA(I,J,bi,bj))
+                  HEFF(I,J,bi,bj) = MAX(ZERO, HEFF(I,J,bi,bj))
+                  HSNOW(I,J,bi,bj)  = MAX(ZERO, HSNOW(I,J,bi,bj))
+
+c                 Sanity checks 
+                  IF (HEFF(I,J,bi,bj) .LE. ZERO .OR.
+     &                AREA(I,J,bi,bj) .LE. ZERO) THEN
+                    
+                    AREA(I,J,bi,bj)       = 0. _d 0
+                    HEFF(I,J,bi,bj)       = 0. _d 0
+                    HICE_ACTUAL(I,J)      = 0. _d 0
+                    HSNOW(I,J,bi,bj)      = 0. _d 0
+                    HSNOW_ACTUAL(I,J)     = 0. _d 0
+
+                  ELSE
+c                 Calcuate the actual ice and snow thicknesses
+                    HICE_ACTUAL(I,J)  =  HEFF(I,J,bi,bj)/AREA(I,J,bi,bj)
+                    HSNOW_ACTUAL(I,J) = HSNOW(I,J,bi,bj)/AREA(I,J,bi,bj)
+                  ENDIF
 
                ENDDO
             ENDDO
             
-            
 #ifdef ALLOW_AUTODIFF_TAMC
-C     ADJ STORE area(:,:,bi,bj)  = comlev1_bibj, 
-C     ADJ &                        key = iicekey, byte = isbyte
-C     ADJ STORE heff(:,:,bi,bj)  = comlev1_bibj, 
-C     ADJ &                        key = iicekey, byte = isbyte
-C     ADJ STORE hsnow(:,:,bi,bj) = comlev1_bibj, 
-C     ADJ &                        key = iicekey, byte = isbyte
-#endif
+CADJ STORE area(:,:,bi,bj) = comlev1_bibj, 
+CADJ &                       key = iicekey, byte = isbyte
+CADJ STORE heff(:,:,bi,bj) = comlev1_bibj, 
+CADJ &                       key = iicekey, byte = isbyte
+#endif /* ALLOW_AUTODIFF_TAMC */
 
-
-C---  +----1----+----2----+----3----+----4----+----5----+----6----+----7-|--+----|
-C     Sanity check on HEFF, HSNOW, and AREA:  After updating
-c     the ice state with the time derivatives it is possible that
-c     an unphysical ice state occurs (e.g., zero/negative AREA 
-c     with positive HEFF and/or HSNOW).
-
-c     Note: the zeroing out negative HEFF and/or HSNOW here will
-c     not violate mass/energy conservation.  Energy and mass 
-c     fluxes are calculated based on the actual change in ice
-c     and snow volume between time levels N-1 and N.
             DO J=1,sNy
                DO I=1,sNx
 
-                  HEFF(I,J,bi,bj)  = HEFFM(I,J,bi,bj) *
-     &               MAX(ZERO,HEFF(I,J,bi,bj)) 
-
-                  HSNOW(I,J,bi,bj) = HEFFM(I,J,bi,bj) * 
-     &               MAX(ZERO,HSNOW(I,J,bi,bj)) 
-
-                  AREA(I,J,bi,bj) = MIN(1.0 _d 0, AREA(I,J,bi,bj)
-
-                  AREA(I,J,bi,bj)  = HEFFM(I,J,bi,bj) *
-     &               MAX(ZERO,AREA(I,J,bi,bj)) 
-
-c     If either HEFF or AREA are zero, make all other ice
-c     state variables zero.
-                  IF ((HEFF(I,J,bi,bj) .EQ. ZERO) .OR. 
-     &               (AREA(I,J,bi,bj) .EQ. ZERO)) THEN 
-
-                     AREA(I,J,bi,bj)  =  0. _d 0
-                     HSNOW(I,J,bi,bj) =  0. _d 0
-                     HEFF(I,J,bi,bj)  =  0. _d 0
-
-                     HICE_ACTUAL(I,J)   = 0. _d 0
-                     HSNOW_ACTUAL(I,J)  = 0. _d 0
-
-                  ELSE          !/ Heff and Area > 0
-
-c     Caclulate the actual (not mean) thicknesses of the 
-c     ice and any snow in the grid cell 
-                     HICE_ACTUAL(I,J)  = 
-     &                  HEFF(I,J,bi,bj)/AREA(I,J,bi,bj)
-
-                     HSNOW_ACTUAL(I,J) = HSNOW(I,J,bi,bj)/
-     &                  AREA(I,J,bi,bj)
-
-                  ENDIF 
-
-               ENDDO            !/ I
-            ENDDO               !/ J
-
-
-#ifdef ALLOW_AUTODIFF_TAMC
-C     ADJ STORE area(:,:,bi,bj)  = comlev1_bibj, 
-C     ADJ &                        key = iicekey, byte = isbyte
-C     ADJ STORE heff(:,:,bi,bj)  = comlev1_bibj, 
-C     ADJ &                        key = iicekey, byte = isbyte
-C     ADJ STORE hsnow(:,:,bi,bj) = comlev1_bibj, 
-C     ADJ &                        key = iicekey, byte = isbyte
-#endif
-
-
-C---  +----1----+----2----+----3----+----4----+----5----+----6----+----7-|--+----|
-            DO J=1,sNy
-               DO I=1,sNx
-
-
-#ifdef SEAICE_DEBUG
-c     The expected amount of new mean ice volume
+c                 The amount of new mean ice thickness we expect to grow
                   ExpectedIceVolumeChange(I,J)  = S_h(I,J) *
-     &               SEAICE_deltaTtherm
+     &                 SEAICE_deltaTtherm
 
-c     The expected amount of new mean snow volume
+c                 The amount of new mean snow thickness we expect to grow
                   ExpectedSnowVolumeChange(I,J) = S_hsnow(I,J)*
-     &               SEAICE_deltaTtherm
+     &                 SEAICE_deltaTtherm
 
-#endif
-
-c     The effective shortwave radiation (after modification
-c     by ice cover).
+c                 THE EFFECTIVE SHORTWAVE HEATING RATE
 #ifdef SHORTWAVE_HEATING
                   QSW(I,J,bi,bj)  =
-     &               QSWI(I,J)  * (      AREANm1(I,J,bi,bj)) +
-     &               QSWO(I,J)  * (ONE - AREANm1(I,J,bi,bj))
+     &                 QSWI(I,J)  * (      AREANm1(I,J,bi,bj)) +
+     &                 QSWO(I,J)  * (ONE - AREANm1(I,J,bi,bj))
 #else
                   QSW(I,J,bi,bj) = 0. _d 0
 #endif
 
-c     The change in mean ice thickness over the time step. 
-c     Note, this quantity may not equal S_h*SEAICE_deltaTtherm as
-c     AREA or HEFF may end up zero or negative which requires that both 
-c     be reset to ZERO.
-                  ActualIceVolumeChange(I,J) = 
-     &               HEFF(I,J,bi,bj) - HEFFNm1(I,J,bi,bj)
+c                 The actual ice volume change over the time step
+                  ActualNewTotalVolumeChange(I,J) = 
+     &                 HEFF(I,J,bi,bj) - HEFFNm1(I,J,bi,bj)
 
-c     The depth of lost mean snow thickness.
+c     The net average snow thickness melt that is actually realized. e.g.
+c     hsnow_orig  = 0.25 m (e.g. 1 m of ice over a cell 1/4 covered in snow)
+c     hsnow_new   = 0.20 m
+c     snow accum  = 0.05 m
+c            melt = 0.25 + 0.05 - 0.2 = 0.1 m 
+
+c     since this is in mean snow thickness it might have been  0.4 of actual 
+c     snow thickness over the 1/4 of the cell which is ice covered.
                   ActualNewTotalSnowMelt(I,J) = 
-     &               HSNOW_ORIG(I,J) +
-     &               SnowAccOverIce(I,J) -
-     &               HSNOW(I,J,bi,bj)
+     &                 HSNOW_ORIG(I,J) +
+     &                 SnowAccOverIce(I,J) -
+     &                 HSNOW(I,J,bi,bj)
 
-c     The energy required to melt or form the new ice.
-                  EnergyInNewIceVolume(I,J) = 
-     &               ActualIceVolumeChange(I,J)/QI
+c                 The energy required to melt or form the new ice volume
+                  EnergyInNewTotalIceVolume(I,J) = 
+     &                 ActualNewTotalVolumeChange(I,J)/QI
 
-c     The energy divergence (J/m^2) out of the ocean.  This
-c     includes the fluxes to the base of the seaice (F_io_net)
-c     and shortwave radiation penetrating through the ice (QSWI)
-c     weighted by ice-covered fraction, and the air-sea
-c     heat fluxes weighted by the open water fraction (F_ao).
-                  NetEnergyOutOfOcean(I,J) = SEAICE_deltaTtherm *
-     &               (AREANm1(I,J,bi,bj) * (F_io_net(I,J) + QSWI(I,J))
-     &               +     (ONE - AREANm1(I,J,bi,bj)) *  F_ao(I,J))
+c     This is the net energy flux out of the ice+ocean system
+c     Remember -----
+c     F_ia_net : Under ice/snow surface freezing conditions, 
+c                vertical conductive heat flux convergence (F_c < 0) balances
+c                heat flux divergence to atmosphere (F_ia > 0)  
+c                Otherwise, F_ia_net = F_ia (pos)
+c
+c     F_io_net : Under ice/snow surface freezing conditions, F_c < 0.
+c                Under ice surface melting conditions, F_c = 0 (no energy flux 
+c                from the ice to ocean)
+c
+c     So if we are freezing, F_io_net = the conductive flux and there 
+c     is energy balance at ice surface, F_ia_net =0.  If we are melting,
+c     there is a convergence of energy into the ice from above
+                  NetEnergyFluxOutOfOcean(I,J) = SEAICE_deltaTtherm *
+     &               (AREANm1(I,J,bi,bj) * 
+     &               (F_ia_net(I,J) + F_io_net(I,J) + QSWI(I,J))
+     &         +     (ONE - AREANm1(I,J,bi,bj)) *  F_ao(I,J))
 
-c     The net energy divergence from the snow/ice surface.
-c     Note, when TICE < TMELT, F_ia_net = 0 (i.e., an energy balance
-c     condition is achieved at the snow/ice surface.
-                  NetEnergyOutOfIce(I,J) = SEAICE_deltaTTherm *
-     &               AREANm1(I,J,bi,bj) * F_ia_net(I,J)
+c     THE QUANTITY OF HEAT WHICH IS THE RESIDUAL TO THE QUANTITY OF 
+c     ML temperature.  If the net energy flux is exactly balanced by the 
+c     latent energy of fusion in the new ice created then we will not 
+c     change the ML temperature at all.
 
-c     The energy divergence (J/m^2) from the ocean which is 
-c     not offset by the latent energy of fusion of any newly created
-c     or melted ice.  This residual energy loss will reduce the 
-c     seawater temperature. 
                   ResidualEnergyOutOfOcean(I,J) = 
-     &               NetEnergyOutOfIce(I,J) + 
-     &               NetEnergyOutOfOcean(I,J) -
-     &               EnergyInNewIceVolume(I,J)
+     &             NetEnergyFluxOutOfOcean(I,J) -
+     &             EnergyInNewTotalIceVolume(I,J)
 
-C     The energy flux (W/m^2) associated with the above residual 
-c     energy divgence.  
+C     NOW FORMULATE QNET, which time LEVEL, ORIG 2.
+C     THIS QNET WILL DETERMINE THE TEMPERATURE CHANGE OF THE MIXED LAYER
+C     QNET IS A DEPTH AVERAGED HEAT FLUX FOR THE OCEAN COLUMN
+C     BECAUSE OF THE 
                   QNET(I,J,bi,bj) =
-     &               ResidualEnergyOutOfOcean(I,J) / SEAICE_deltaTtherm
+     &             ResidualEnergyOutOfOcean(I,J) / SEAICE_deltaTtherm
 
 
-C---  +----1----+----2----+----3----+----4----+----5----+----6----+----7-|--+----|
-c     The change of freshwater content  per unit area over the entire
-c     cell, not just over the ice covered bits.  This term is only used
-c     to calculate freshwater fluxes for the purpose of changing the
-c     salinity of the liquid cell. 
+c    Like snow melt, if there is melting, this quantity is positive.
+c    The change of freshwater content is per unit area over the entire
+c    cell, not just over the ice covered bits.  This term is only used
+c    to calculate freshwater fluxes for the purpose of changing the
+c    salinity of the liquid cell.  In the case of non-zero ice salinity,
+c    the amount of freshwater is reduced by the ratio of ice salinity
+c    to water cell salinity.
+           IF  ( (salt(I,J,kSurface,bi,bj) .GT. ZERO) .AND.
+     &           (salt(I,J,kSurface,bi,bj) .GE. 
+     &                         SEAICE_salinity_fixed))  THEN 
 
-c                 If the seawater salinity is less than SEAICE_salinity_fixed
-c                 or zero, assume that ice is as saline as the seawater.
-c                 salinity
-                  IF  ((salt(I,J,kSurface,bi,bj) .EQ. ZERO) .OR. 
-     &                 (salt(I,J,kSurface,bi,bj) .LE. 
-     &                   SEAICE_salinity_fixed)) THEN
+                 FreshwaterContribFromIce(I,J) =
+     &            - ActualNewTotalVolumeChange(I,J)*SEAICE_rhoICE/RHOFW*
+     &            (ONE - SEAICE_salinity_fixed/salt(I,J,kSurface,bi,bj))
 
-                     FreshwaterContribFromIce(I,J) = ZERO 
-                 
-c                 If seawater salinity is greater than the specified
-c                 ice salinity, the freshwater contribution from ice is
-c                 the volume of freshwater required to mix with
-c                 seawater to yield sea ice having salinity
-c                 SEAICE_salinity_fixed.  Another way of looking at this
-c                 formulation is to assume that the sea ice is a mixture 
-c                 of a volume of freshwater and volume of water with 
-c                 salinity "salt".  When ice grows (or melts), only the 
-c                 extraction (release) of the freshwater volume 
-c                 alters the seawater salinity.
-                  ELSEIF ( salt(I,J,kSurface,bi,bj) .GT. 
-     &                     SEAICE_salinity_fixed   )  THEN 
+           ELSE
+C    If the liquid cell has a lower salinity than the specified
+c    salinity of sea ice then assume the sea ice is completely fresh
+                 FreshwaterContribFromIce(I,J) =
+     &             -ActualNewTotalVolumeChange(I,J)*SEAICE_rhoIce/RHOFW
+           ENDIF
 
-                       FreshwaterContribFromIce(I,J) =
-     &                   - ActualIceVolumeChange(I,J)*
-     &                   SEAICE_rhoICE/ RHOFW* (ONE - 
-     &                   SEAICE_salinity_fixed/salt(I,J,kSurface,bi,bj))
 
-                  ENDIF
-
-c     The freshwater contribution from snow comes from melt.
+c    The freshwater contribution from snow comes only in the form of melt
+c    unlike ice, which takes freshwater upon growth and yields freshwater
+c    upon melt.  This is why the the actual new average snow melt was determined.
+c    In m/m^2 over the entire cell.
                   FreshwaterContribFromSnowMelt(I,J) =
-     &               ActualNewTotalSnowMelt(I,J)*SEAICE_rhoSnow/RHOFW
+     &                 ActualNewTotalSnowMelt(I,J)*SEAICE_rhoSnow/RHOFW
 
+c    This seems to be in m/s, original time level 2 for area
+c    Only the precip and evap need to be area weighted.  The runoff
+c    and freshwater contribs from ice and snow melt are already mean
+c    weighted
                   EmPmR(I,J,bi,bj)  = maskC(I,J,kSurface,bi,bj)*(
-     &               ( EVAP(I,J,bi,bj)-PRECIP(I,J,bi,bj) )
-     &               * ( ONE - AREANm1(I,J,bi,bj) )
-     &               - PrecipRateOverIceSurfaceToSea(I,J)*
-     &               AREANm1(I,J,bi,bj)
+     &                 ( EVAP(I,J,bi,bj)-PRECIP(I,J,bi,bj) )
+     &                 * ( ONE - AREANm1(I,J,bi,bj) )
+     &                 - PrecipRateOverIceSurfaceToSea(I,J)*
+     &                     AREANm1(I,J,bi,bj)
 #ifdef ALLOW_RUNOFF
-     &               - RUNOFF(I,J,bi,bj)
+     &                 - RUNOFF(I,J,bi,bj)
 #endif
-     &               - (FreshwaterContribFromIce(I,J) +
-     &               FreshwaterContribFromSnowMelt(I,J))/
-     &               SEAICE_deltaTtherm )*rhoConstFresh
+     &                 - (FreshwaterContribFromIce(I,J) +
+     &                    FreshwaterContribFromSnowMelt(I,J))/
+     &                    SEAICE_deltaTtherm )*rhoConstFresh
 
-               ENDDO            !/ i
-            ENDDO               !/ j
-
-
+C                 DO SOME DEBUGGING CALCULATIONS.  MAKE SURE SUMS ALL ADD UP.
 #ifdef SEAICE_DEBUG
-C---  +----1----+----2----+----3----+----4----+----5----+----6----+----7-|--+----|
-c     Debugging calculations
 
-            DO J=1,sNy
-               DO I=1,sNx
-
-C     Calcuate the shortwave flux absorbed in the upper ocean
-c     grid cell
+C                 Calcuate the shortwave flux absorbed in the upper ocean
+c                 grid cell
 #ifdef SHORTWAVE_HEATING
                   QSW_absorb_in_first_layer(I,J) = QSW(I,J,bi,bj)*
-     &               (ONE - SWFRACB)
+     &              (ONE - SWFRACB)
 #else 
 
                   QSW_absorb_in_first_layer(I,J) = 0. _d 0
 #endif
 
-C     Calcuate the sw flux beneath the upper ocean grid cell
+C                 Calcuate the sw flux beneath the upper ocean grid cell
                   QSW_absorb_below_first_layer(I,J) = 
-     &               QSW(I,J,bi,bj) -  QSW_absorb_in_first_layer(I,J)
+     &                 QSW(I,J,bi,bj) -  QSW_absorb_in_first_layer(I,J)
 
-                  PredTempChangeFromQSW(I,J) =
-     &               - QSW_absorb_in_first_layer(I,J)*FLUX_TO_DELTA_TEMP
+                  PredTempChangeFromQSW(I,J) = 
+     &             - QSW_absorb_in_first_layer(I,J) * FLUX_TO_DELTA_TEMP
 
                   PredTempChangeFromOA_MQNET(I,J) = 
-     &               -(QNET(I,J,bi,bj)-QSWO(I,J)) * 
-     &               (ONE-AREANm1(I,J,bi,bj)) * FLUX_TO_DELTA_TEMP
+     &            -(QNET(I,J,bi,bj)-QSWO(I,J))*(ONE -AREANm1(I,J,bi,bj))
+     &             * FLUX_TO_DELTA_TEMP
 
-                  PredTempChangeFromF_IO_NET(I,J) = - F_io_net(I,J) *
-     &               AREANm1(I,J,bi,bj)*FLUX_TO_DELTA_TEMP
+                  PredTempChangeFromF_IO_NET(I,J) = 
+     &             -F_io_net(I,J)*AREANm1(I,J,bi,bj)*FLUX_TO_DELTA_TEMP
 
-                  PredTempChangeFromF_IA_NET(I,J) = - F_ia_net(I,J) *
-     &               AREANm1(I,J,bi,bj)*FLUX_TO_DELTA_TEMP
+                  PredTempChangeFromF_IA_NET(I,J) = 
+     &             -F_ia_net(I,J)*AREANm1(I,J,bi,bj)*FLUX_TO_DELTA_TEMP
 
                   PredTempChangeFromNewIceVol(I,J) = 
-     &               EnergyInNewIceVolume(I,J)*ENERGY_TO_DELTA_TEMP
+     &              EnergyInNewTotalIceVolume(I,J)*ENERGY_TO_DELTA_TEMP
 
                   PredTempChange(I,J) = 
-     &               PredTempChangeFromQSW(I,J) +
-     &               PredTempChangeFromOA_MQNET(I,J) +
-     &               PredTempChangeFromF_IO_NET(I,J) +
-     &               PredTempChangeFromF_IA_NET(I,J) +
-     &               PredTempChangeFromNewIceVol(I,J)
+     &              PredTempChangeFromQSW(I,J) +
+     &              PredTempChangeFromOA_MQNET(I,J) +
+     &              PredTempChangeFromF_IO_NET(I,J) +
+     &              PredTempChangeFromF_IA_NET(I,J) +
+     &              PredTempChangeFromNewIceVol(I,J)
+#endif    
 
                ENDDO
             ENDDO
-#endif /* seaice debug */   
-
 
 #ifdef ALLOW_AUTODIFF_TAMC
-C     ADJ STORE area(:,:,bi,bj)  = comlev1_bibj, 
-C     ADJ &                        key = iicekey, byte = isbyte
-C     ADJ STORE hsnow(:,:,bi,bj) = comlev1_bibj, 
-C     ADJ &                        key = iicekey, byte = isbyte
-C     ADJ STORE heff(:,:,bi,bj)  = comlev1_bibj, 
-C     ADJ &                        key = iicekey, byte = isbyte
+CADJ STORE area(:,:,bi,bj)  = comlev1_bibj, 
+CADJ &                        key = iicekey, byte = isbyte
+CADJ STORE hsnow(:,:,bi,bj) = comlev1_bibj, 
+CADJ &                        key = iicekey, byte = isbyte
+CADJ STORE heff(:,:,bi,bj)  = comlev1_bibj, 
+CADJ &                        key = iicekey, byte = isbyte
 #endif /* ALLOW_AUTODIFF_TAMC */
             
-
-#ifdef ALLOW_SEAICE_FLOODING
-C---  +----1----+----2----+----3----+----4----+----5----+----6----+----7-|--+----|
-c     Convert flooded snow to ice
-            IF(SEAICEuseFlooding) THEN
-
-               DO J = 1,sNy
-                  DO I = 1,sNx
-                     EnergyToMeltSnowAndIce(I,J) = 
-     &                  HEFF(I,J,bi,bj)/QI +
-     &                  HSNOW(I,J,bi,bj)/QS
-                     
-                     deltaHS = FL_C2*( HSNOW_ACTUAL(I,J) -
-     &                  HICE_ACTUAL(I,J)*FL_C3 )
-                     
-                     IF (deltaHS .GT. ZERO) THEN
-                        deltaHI = FL_C4*deltaHS
-                        
-                        HICE_ACTUAL(I,J) = HICE_ACTUAL(I,J)  
-     &                     + deltaHI
-
-                        HSNOW_ACTUAL(I,J)= HSNOW_ACTUAL(I,J) 
-     &                     - deltaHS
-
-                        HEFF(I,J,bi,bj)= HICE_ACTUAL(I,J) *
-     &                     AREA(I,J,bi,bj)
-
-                        HSNOW(I,J,bi,bj) = HSNOW_ACTUAL(I,J)*
-     &                     AREA(I,J,bi,bj)
-                        
-                        EnergyToMeltSnowAndIce2(I,J) = 
-     &                     HEFF(I,J,bi,bj)/QI +
-     &                     HSNOW(I,J,bi,bj)/QS
-                        
-#ifdef SEAICE_DEBUG
-
-                        IF ( (I .EQ. SEAICE_debugPointX)   .and.
-     &                     (J .EQ. SEAICE_debugPointY) ) THEN
-                           print '(A,4(1x,1PE24.15))',
-     &                        'Energy to melt snow+ice: pre,post,delta',
-     &                        EnergyToMeltSnowAndIce(I,J),  
-     &                        EnergyToMeltSnowAndIce2(I,J),
-     &                        EnergyToMeltSnowAndIce(I,J) - 
-     &                        EnergyToMeltSnowAndIce2(I,J)
-                        ENDIF
-#endif /* SEAICE DEBUG */
-
-                     ENDIF 
-
-                  ENDDO         !/ I
-               ENDDO            !/ J
-
-            ENDIF               !/ SEAICEuseFlooding
-#endif /* SEAICE_FLOODING
-
+            DO J=1,sNy
+               DO I=1,sNx
+                  AREA(I,J,bi,bj) = AREA(I,J,bi,bj)*HEFFM(I,J,bi,bj)
+                  HEFF(I,J,bi,bj) = HEFF(I,J,bi,bj)*HEFFM(I,J,bi,bj)
+                  HSNOW(I,J,bi,bj)  = HSNOW(I,J,bi,bj)*HEFFM(I,J,bi,bj)
+               ENDDO
+            ENDDO
 
 #ifdef ALLOW_AUTODIFF_TAMC
-C     ADJ STORE area(:,:,bi,bj)  = comlev1_bibj, 
-C     ADJ &                        key = iicekey, byte = isbyte
-C     ADJ STORE hsnow(:,:,bi,bj) = comlev1_bibj, 
-C     ADJ &                        key = iicekey, byte = isbyte
-C     ADJ STORE heff(:,:,bi,bj)  = comlev1_bibj, 
-C     ADJ &                        key = iicekey, byte = isbyte
+CADJ STORE area(:,:,bi,bj)  = comlev1_bibj, 
+CADJ &                        key = iicekey, byte = isbyte
+CADJ STORE hsnow(:,:,bi,bj) = comlev1_bibj, 
+CADJ &                        key = iicekey, byte = isbyte
+CADJ STORE heff(:,:,bi,bj)  = comlev1_bibj, 
+CADJ &                        key = iicekey, byte = isbyte
+#endif /* ALLOW_AUTODIFF_TAMC */
+
+
+#ifdef ALLOW_SEAICE_FLOODING
+           IF(SEAICEuseFlooding) THEN
+
+            DO J = 1,sNy
+               DO I = 1,sNx
+                  EnergyToMeltSnowAndIce(I,J) = 
+     &                 HEFF(I,J,bi,bj)/QI +
+     &                 HSNOW(I,J,bi,bj)/QS
+                  
+                  deltaHS = FL_C2*( HSNOW_ACTUAL(I,J) -
+     &                 HICE_ACTUAL(I,J)*FL_C3 )
+                  
+                  IF (deltaHS .GT. ZERO) THEN
+                     deltaHI = FL_C4*deltaHS
+                     
+                     HICE_ACTUAL(I,J) = HICE_ACTUAL(I,J)  
+     &                    + deltaHI
+
+                     HSNOW_ACTUAL(I,J)= HSNOW_ACTUAL(I,J) 
+     &                    - deltaHS
+
+                     HEFF(I,J,bi,bj)= HICE_ACTUAL(I,J) *
+     &                    AREA(I,J,bi,bj)
+
+                     HSNOW(I,J,bi,bj) = HSNOW_ACTUAL(I,J)*
+     &                    AREA(I,J,bi,bj)
+                     
+                     EnergyToMeltSnowAndIce2(I,J) = 
+     &                    HEFF(I,J,bi,bj)/QI +
+     &                    HSNOW(I,J,bi,bj)/QS
+                     
+#ifdef SEAICE_DEBUG
+               IF ( (I .EQ. SEAICE_debugPointX)   .and.
+     &              (J .EQ. SEAICE_debugPointY) ) THEN
+
+                     print *,'Energy to melt snow+ice: pre,post,delta', 
+     &                    EnergyToMeltSnowAndIce(I,J),  
+     &                    EnergyToMeltSnowAndIce2(I,J),
+     &                    EnergyToMeltSnowAndIce(I,J) - 
+     &                    EnergyToMeltSnowAndIce2(I,J)
+               ENDIF
+c SEAICE DEBUG
+#endif
+c there is any flooding to be had                 
+                  ENDIF
+               ENDDO
+            ENDDO
+
+c SEAICEuseFlooding
+           ENDIF 
+c ALLOW_SEAICE_FLOODING
+#endif 
+
+#ifdef ALLOW_AUTODIFF_TAMC
+CADJ STORE area(:,:,bi,bj)  = comlev1_bibj, 
+CADJ &                        key = iicekey, byte = isbyte
+CADJ STORE hsnow(:,:,bi,bj) = comlev1_bibj, 
+CADJ &                        key = iicekey, byte = isbyte
+CADJ STORE heff(:,:,bi,bj)  = comlev1_bibj, 
+CADJ &                        key = iicekey, byte = isbyte
 #endif /* ALLOW_AUTODIFF_TAMC */
 
 
@@ -1445,174 +1375,165 @@ C     ADJ &                        key = iicekey, byte = isbyte
             IF ( useRealFreshWaterFlux ) THEN
                DO J=1,sNy
                   DO I=1,sNx
-
                      sIceLoad(i,j,bi,bj) = HEFF(I,J,bi,bj)*
-     &                  SEAICE_rhoIce + HSNOW(I,J,bi,bj)*SEAICE_rhoSnow
-
+     &                 SEAICE_rhoIce + HSNOW(I,J,bi,bj)*SEAICE_rhoSnow
                   ENDDO
                ENDDO
             ENDIF
 #endif
 
-
 #ifdef SEAICE_DEBUG
-C---  +----1----+----2----+----3----+----4----+----5----+----6----+----7-|--+----|
-c     Debugging calculations
             DO j=1,sNy
                DO i=1,sNx
 
-                  IF ( (i .EQ. SEAICE_debugPointX)   .and.  
-     &               (j .EQ. SEAICE_debugPointY) ) THEN
+               IF ( (i .EQ. SEAICE_debugPointX)   .and.  
+     &              (j .EQ. SEAICE_debugPointY) ) THEN
 
-                     print *,'ifsig: myTime,myIter: ',myTime,myIter
+                  print *,'ifsig: myTime,myIter:',myTime,myIter
 
-                     print '(A,2i4)',
-     &                  'ifice i j -------------- ',i,j
+                  print '(A,2i4,2(1x,1P3E15.4))',
+     &                 'ifice i j --------------  ',i,j
 
-                     print '(A,4(1x,1PE24.15))',
-     &                  'ifice IGR(ML OW ICE)     ',
-     &                  IceGrowthRateMixedLayer(i,j),
-     &                  IceGrowthRateOpenWater(i,j),
-     &                  NetExistingIceGrowthRate(i,j),
-     &                  SEAICE_deltaTtherm
-                     
-                     print '(A,4(1x,1PE24.15))',
-     &                  'ifice F(mi ao)           ',
-     &                  F_mi(i,j), F_ao(i,j)
-                     
-                     print '(A,4(1x,1PE24.15))',
-     &                  'ifice Fi(a,ant2/1 ont)   ',
-     &                  F_ia(i,j),
-     &                  F_ia_net_before_snow(i,j), 
-     &                  F_ia_net(i,j), 
-     &                  F_io_net(i,j)
-                     
-                     print '(A,4(1x,1PE24.15))',
-     &                  'ifice AREA2/1 HEFF2/1    ',
-     &                  AREANm1(I,J,bi,bj),
-     &                  AREA(i,j,bi,bj),
-     &                  HEFFNm1(I,J,bi,bj),
-     &                  HEFF(i,j,bi,bj)
+                  print '(A,2i4,2(1x,1P3E15.4))',
+     &                 'ifice i j IGR(ML OW ICE)  ',i,j,
+     &                 IceGrowthRateMixedLayer(i,j),
+     &                 IceGrowthRateOpenWater(i,j),
+     &                 NetExistingIceGrowthRate(i,j),
+     &                 SEAICE_deltaTtherm
+                  
+                  print '(A,2i4,2(1x,1P3E15.4))',
+     &                 'ifice i j F(mi ao)        ',
+     &                 i,j,F_mi(i,j), F_ao(i,j)
+                  
+                  print '(A,2i4,2(1x,1P3E15.4))',
+     &                 'ifice i j Fi(a,ant2/1 ont)',
+     &                 i,j,F_ia(i,j),
+     &                 F_ia_net_before_snow(i,j), 
+     &                 F_ia_net(i,j), 
+     &                 F_io_net(i,j)
+                 
+                  print '(A,2i4,2(1x,1P3E15.4))',
+     &                 'ifice i j AREA2/1 HEFF2/1 ',i,j,
+     &                 AREANm1(I,J,bi,bj),
+     &                 AREA(i,j,bi,bj),
+     &                 HEFFNm1(I,J,bi,bj),
+     &                 HEFF(i,j,bi,bj)
 
 
 #ifdef ALLOW_SALT_PLUME
-                     print '(A,4(1x,1PE24.15))',
-     &                  'ifice A,IGLEA,LPF,SPF    ',
-     &                  AREANm1(I,J,bi,bj),
-     &                  IceGrowthRateInLeads(I,J),
-     &                  leadPlumeFraction(I,J),
-     &                  saltPlumeFlux(i,j,bi,bj)
+                  print '(A,2i4,2(1x,1P3E15.4))',
+     &                 'ifice i j A,IGLEA,LPF,SPF ',i,j,
+     &                 AREANm1(I,J,bi,bj),
+     &                 IceGrowthRateInLeads(I,J),
+     &                 leadPlumeFraction(I,J),
+     &                 saltPlumeFlux(i,j,bi,bj)
 #endif
-                     
-                     print '(A,4(1x,1PE24.15))',
-     &                  'ifice HSNOW2/1 TMX TBC   ',
-     &                  HSNOW_ORIG(I,J),
-     &                  HSNOW(I,J,bi,bj),
-     &                  TMIX(i,j,bi,bj)- TMELT, 
-     &                  TBC
+                  
+                  print '(A,2i4,2(1x,1P3E15.4))',
+     &                 'ifice i j HSNOW2/1 TMX TBC',i,j,
+     &                 HSNOW_ORIG(I,J),
+     &                 HSNOW(I,J,bi,bj),
+     &                 TMIX(i,j,bi,bj)- TMELT, 
+     &                 TBC
 
-                     print '(A,4(1x,1PE24.15))',
-     &                  'ifice TI ATP LWD         ',
-     &                  TICE(i,j,bi,bj) - TMELT,
-     &                  ATEMP(i,j,bi,bj) -TMELT,
-     &                  LWDOWN(i,j,bi,bj)
-
-
-                     print '(A,4(1x,1PE24.15))',
-     &                  'ifice S_a S_h S_hsnow    ',
-     &                  S_a(i,j),
-     &                  S_h(i,j),
-     &                  S_hsnow(i,j)
-
-                     print '(A,4(1x,1PE24.15))',
-     &                  'ifice IVC(E A ENIN)      ',
-     &                  ExpectedIceVolumeChange(i,j),
-     &                  ActualIceVolumeChange(i,j),
-     &                  EnergyInNewIceVolume(i,j)
-                     
-                     print '(A,4(1x,1PE24.15))',
-     &                  'ifice EF(NOS RE) QNET    ',
-     &                  NetEnergyOutOfOcean(i,j),
-     &                  ResidualEnergyOutOfOcean(i,j),
-     &                  QNET(I,J,bi,bj)
-
-                     print '(A,4(1x,1PE24.15))',
-     &                  'ifice QSW QSWO QSWI      ',
-     &                  QSW(i,j,bi,bj),
-     &                  QSWO(i,j),
-     &                  QSWI(i,j)
-
-                     print '(A,4(1x,1PE24.15))',
-     &                  'ifice SW(BML IML SW)     ',
-     &                  QSW_absorb_below_first_layer(i,j),
-     &                  QSW_absorb_in_first_layer(i,j),
-     &                  SWFRACB
-
-                     print '(A,4(1x,1PE24.15))',
-     &                  'ifice ptc(to, qsw, oa)   ',
-     &                  PredTempChange(i,j),
-     &                  PredTempChangeFromQSW (i,j),
-     &                  PredTempChangeFromOA_MQNET(i,j)
+                  print '(A,2i4,2(1x,1P3E15.4))',
+     &                 'ifice i j TI ATP LWD      ',i,j,
+     &                 TICE(i,j,bi,bj) - TMELT,
+     &                 ATEMP(i,j,bi,bj) -TMELT,
+     &                 LWDOWN(i,j,bi,bj)
 
 
-                     print '(A,4(1x,1PE24.15))',
-     &                  'ifice ptc(fion,ian,ia)   ',
-     &                  PredTempChangeFromF_IO_NET(i,j),
-     &                  PredTempChangeFromF_IA_NET(i,j),
-     &                  PredTempChangeFromFIA(i,j)
+                  print '(A,2i4,2(1x,1P3E15.4))',
+     &                 'ifice i j S_a S_h S_hsnow ',i,j,
+     &                 S_a(i,j),
+     &                 S_h(i,j),
+     &                 S_hsnow(i,j)
 
-                     print '(A,4(1x,1PE24.15))',
-     &                  'ifice ptc(niv)           ',
-     &                  PredTempChangeFromNewIceVol(i,j)
+                  print '(A,2i4,2(1x,1P3E15.4))',
+     &                 'ifice i j IVC(E A ENIN)   ',i,j,
+     &                 ExpectedIceVolumeChange(i,j),
+     &                 ActualNewTotalVolumeChange(i,j),
+     &                 EnergyInNewTotalIceVolume(i,j)
+                  
+                  print '(A,2i4,2(1x,1P3E15.4))',
+     &                 'ifice i j EF(NOS RE) QNET ',i,j,
+     &                 NetEnergyFluxOutOfOcean(i,j),
+     &                 ResidualEnergyOutOfOcean(i,j),
+     &                 QNET(I,J,bi,bj)
+
+                  print '(A,2i4,3(1x,1P3E15.4))',
+     &                 'ifice i j QSW QSWO QSWI   ',i,j,
+     &                 QSW(i,j,bi,bj),
+     &                 QSWO(i,j),
+     &                 QSWI(i,j)
+
+                  print '(A,2i4,3(1x,1P3E15.4))',
+     &                 'ifice i j SW(BML IML SW)  ',i,j,
+     &                 QSW_absorb_below_first_layer(i,j),
+     &                 QSW_absorb_in_first_layer(i,j),
+     &                 SWFRACB
+
+                  print '(A,2i4,3(1x,1P3E15.4))',
+     &                 'ifice i j ptc(to, qsw, oa)',i,j,
+     &                 PredTempChange(i,j),
+     &                 PredTempChangeFromQSW (i,j),
+     &                 PredTempChangeFromOA_MQNET(i,j)
 
 
-                     print '(A,4(1x,1PE24.15))',
-     &                  'ifice EmPmR EVP PRE RU   ',
-     &                  EmPmR(I,J,bi,bj),
-     &                  EVAP(I,J,bi,bj),
-     &                  PRECIP(I,J,bi,bj),
-     &                  RUNOFF(I,J,bi,bj)
+                  print '(A,2i4,3(1x,1P3E15.4))',
+     &                 'ifice i j ptc(fion,ian,ia)',i,j,
+     &                 PredTempChangeFromF_IO_NET(i,j),
+     &                 PredTempChangeFromF_IA_NET(i,j),
+     &                 PredTempChangeFromFIA(i,j)
 
-                     print '(A,4(1x,1PE24.15))',
-     &                  'ifice PRROIS,SAOI        ',
-     &                  PrecipRateOverIceSurfaceToSea(I,J),
-     &                  SnowAccRateOverIce(I,J),
-     &                  SnowAccOverIce(I,J)
-
-                     print '(A,4(1x,1PE24.15))',
-     &                  'ifice SM(PM PMS S MR)    ',
-     &                  PotSnowMeltFromSurf(I,J),
-     &                  PotSnowMeltRateFromSurf(I,J),
-     &                  SnowMeltFromSurface(I,J),
-     &                  SnowMeltRateFromSurface(I,J)
-
-                     print '(A,4(1x,1PE24.15))',
-     &                  'ifice TotSnwMlt ExSnVC   ',
-     &                  ActualNewTotalSnowMelt(I,J),
-     &                  ExpectedSnowVolumeChange(I,J)
+                  print '(A,2i4,3(1x,1P3E15.4))',
+     &                 'ifice i j ptc(niv)        ',i,j,
+     &                 PredTempChangeFromNewIceVol(i,j)
 
 
-                     print '(A,4(1x,1PE24.15))',
-     &                  'ifice fw(CFICE, CFSM)    ',
-     &                  FreshwaterContribFromIce(I,J),
-     &                  FreshwaterContribFromSnowMelt(I,J)
+                  print '(A,2i4,3(1x,1P3E15.4))',
+     &                 'ifice i j EmPmR EVP PRE RU',i,j,
+     &                 EmPmR(I,J,bi,bj),
+     &                 EVAP(I,J,bi,bj),
+     &                 PRECIP(I,J,bi,bj),
+     &                 RUNOFF(I,J,bi,bj)
 
-                     print '(A,2i5)',
-     &                  'ifice i j -------------- ',i,j
+                  print '(A,2i4,3(1x,1P3E15.4))',
+     &                 'ifice i j PRROIS,SAOI(R .)',i,j,
+     &                 PrecipRateOverIceSurfaceToSea(I,J),
+     &                 SnowAccRateOverIce(I,J),
+     &                 SnowAccOverIce(I,J)
 
-                     print '(A,4(1x,1PE24.15))',
-     &                  'end iter, ANm1, HNm1, HSN  ',myIter,
-     &                  AREANm1(I,J,bi,bj), HEFFNm1(I,J,bi,bj),
-     &                  HSNOW(I,J,bi,bj)
+                  print '(A,2i4,4(1x,1P3E15.4))',
+     &                 'ifice i j SM(PM PMR . .R) ',i,j,
+     &                 PotSnowMeltFromSurf(I,J),
+     &                 PotSnowMeltRateFromSurf(I,J),
+     &                 SnowMeltFromSurface(I,J),
+     &                 SnowMeltRateFromSurface(I,J)
 
-                  ENDIF
+                  print '(A,2i4,4(1x,1P3E15.4))',
+     &                 'ifice i j TotSnwMlt ExSnVC',i,j,
+     &                 ActualNewTotalSnowMelt(I,J),
+     &                 ExpectedSnowVolumeChange(I,J)
+
+
+                  print '(A,2i4,4(1x,1P3E15.4))',
+     &                 'ifice i j fw(CFICE, CFSM) ',i,j,
+     &                 FreshwaterContribFromIce(I,J),
+     &                 FreshwaterContribFromSnowMelt(I,J)
+
+                  print '(A,2i4,2(1x,1P3E15.4))',
+     &                 'ifice i j --------------  ',i,j
+
+               ENDIF
                ENDDO
             ENDDO
 #endif /* SEAICE_DEBUG */
             
             
-         ENDDO                  !/ bi
-      ENDDO                     !/ bj
+C     end bi,bj loops
+         ENDDO
+      ENDDO
       
       RETURN
       END

--- a/pkg/seaice/seaice_growth_adjointable.F
+++ b/pkg/seaice/seaice_growth_adjointable.F
@@ -1,12 +1,12 @@
-C     $Header: /u/gcmpack/MITgcm/pkg/seaice/seaice_growth.F,v 1.10 2007/01/09 13:33:49 mlosch Exp $
+C     $Header: /home/ubuntu/mnt/e9_copy/MITgcm_contrib/ifenty/Fenty_Thermo_Code_Updates/code_updates/seaice_growth_if.F,v 1.4 2010/09/25 16:41:06 ifenty Exp $
 C     $Name:  $
 
 #include "SEAICE_OPTIONS.h"
 
 C     StartOfInterface
-      SUBROUTINE SEAICE_GROWTH( myTime, myIter, myThid )
+      SUBROUTINE SEAICE_GROWTH_IF( myTime, myIter, myThid )
 C     /==========================================================\
-C     | SUBROUTINE seaice_growth                                 |
+C     | SUBROUTINE seaice_growth_if                              |
 C     | o Updata ice thickness and snow depth                    |
 C     |==========================================================|
 C     \==========================================================/
@@ -21,9 +21,14 @@ C     === Global variables ===
 #include "FFIELDS.h"
 #include "SEAICE_PARAMS.h"
 #include "SEAICE.h"
-#include "SEAICE_FFIELDS.h"
-#include "SEAICE_DIAGS.h"
-
+#ifdef ALLOW_EXF
+# include "EXF_OPTIONS.h"
+# include "EXF_FIELDS.h"
+# include "EXF_PARAM.h"
+#endif
+#ifdef ALLOW_SALT_PLUME
+# include "SALT_PLUME.h"
+#endif
 #ifdef ALLOW_AUTODIFF_TAMC
 # include "tamc.h"
 #endif
@@ -42,125 +47,220 @@ C     i,j,bi,bj - Loop counters
 C     number of surface interface layer
       INTEGER kSurface
 
-C     constants
-      _RL TBC, SDF, ICE2WATR, ICE2SNOW,TMELT
+C     TBC   : The freezing point of seawater (deg C)
+C     TMELT : The freezing point of fresh water (deg K)
+      _RL TBC, TMELT
 
 #ifdef ALLOW_SEAICE_FLOODING
       _RL hDraft, hFlood
-      INTEGER flood_flag
 #endif /* ALLOW_SEAICE_FLOODING */
 
-C     QNETI  - net surface heat flux under ice in W/m^2
-C     QSWO   - short wave heat flux over ocean in W/m^2
-C     QSWI   - short wave heat flux under ice in W/m^2
+C     QSWO   - short wave heat flux over ocean (W/m^2)
+C     QSWI   - short wave heat flux under ice  (W/m^2)
+      _RL QSWO                         (1:sNx,1:sNy)
+      _RL QSWI                         (1:sNx,1:sNy)
 
-      _RL QNETI               (1-OLx:sNx+OLx,1-OLy:sNy+OLy)
-      _RL QSWO                (1-OLx:sNx+OLx,1-OLy:sNy+OLy)
-      _RL QSWI                (1-OLx:sNx+OLx,1-OLy:sNy+OLy)
+C     The shortwave heat flux in the open water fraction of the 
+C     grid cell converging within the uppermost ocean grid cell (W/m^2)
+      _RL QSWO_IN_FIRST_LAYER          (1:sNx,1:sNy)
 
-      _RL QSWO_IN_FIRST_LAYER
-     &      (1-OLx:sNx+OLx,1-OLy:sNy+OLy)
-      _RL QSWO_BELOW_FIRST_LAYER
-     &      (1-OLx:sNx+OLx,1-OLy:sNy+OLy)
 
-      _RL QSW_absorb_in_ML    (1-OLx:sNx+OLx,1-OLy:sNy+OLy)
-      _RL QSW_absorb_below_ML (1-OLx:sNx+OLx,1-OLy:sNy+OLy)
+C     (1 - QSWO_IN_FIRST_LAYER) (W/m^2)
+      _RL QSWO_BELOW_FIRST_LAYER        (1:sNx,1:sNy)
 
-C     actual ice thickness with upper and lower limit
-      _RL HICE_ACTUAL   (1-OLx:sNx+OLx, 1-OLy:sNy+OLy)
+#ifdef SEAICE_DEBUG
+C     The total shortwave heat flux (into open water and through the ice)
+C     converging within the uppermost ocean grid cell (W/m^2)
+      _RL QSW_absorb_in_first_layer     (1:sNx,1:sNy)
 
-C     actual snow thickness
-      _RL HSNOW_ACTUAL(1-OLx:sNx+OLx, 1-OLy:sNy+OLy)
+C     ( 1 - QSW_absorb_in_first_layer)  (W/m^2) 
+      _RL QSW_absorb_below_first_layer  (1:sNx,1:sNy)
+#endif
 
-C     wind speed
-      _RL UG     (1-OLx:sNx+OLx, 1-OLy:sNy+OLy)
-      _RL SPEED_SQ
+C     The actual ice thickness (i.e., mean ice thickness / ice concentration) (m) 
+      _RL HICE_ACTUAL                   (1:sNx,1:sNy)
 
-C     IAN
-      _RL RHOI, RHOFW,CPW,LI,QI,QS,GAMMAT,GAMMA,RHOSW,RHOSN
+C     The actual snow thickness (i.e., mean snow thickness / ice concentration) (m) 
+      _RL HSNOW_ACTUAL                  (1:sNx,1:sNy)
+
+C     wind speed (m/s)
+      _RL UG                            (1:sNx,1:sNy)
+
+c     RHOFW  : Freshwater density (kg m^-3)
+C     CPW    : Seawater heat capacity   (J m^-3 K^-1)
+c     LI     : Ice latent heat of fusion (J kg^-1)
+c     QI, QS : Factors used to to map between energy fluxes 
+c     RHOSW  : A reference seawater density (kg m^-3)
+c     and snow/ice melt or growth
+      _RL RHOFW,CPW,LI,QI,QS,RHOSW
+
+C     Helper Variables for snow flooding
+      _RL EnergyToMeltSnowAndIce        (1:sNx,1:sNy)
+      _RL EnergyToMeltSnowAndIce2       (1:sNx,1:sNy)
       _RL FL_C1,FL_C2,FL_C3,FL_C4,deltaHS,deltaHI
 
-      _RL NetExistingIceGrowthRate      (1-OLx:sNx+OLx,1-OLy:sNy+OLy)
-      _RL IceGrowthRateUnderExistingIce (1-OLx:sNx+OLx,1-OLy:sNy+OLy)
-      _RL IceGrowthRateFromSurface      (1-OLx:sNx+OLx,1-OLy:sNy+OLy)
-      _RL IceGrowthRateOpenWater        (1-OLx:sNx+OLx,1-OLy:sNy+OLy)
-      _RL IceGrowthRateMixedLayer       (1-OLx:sNx+OLx,1-OLy:sNy+OLy)
-      _RL S_a_from_IGROW                (1-OLx:sNx+OLx,1-OLy:sNy+OLy)
- 
-      _RL PredictTempChg
-     &      (1-OLx:sNx+OLx,1-OLy:sNy+OLy)
-      _RL  PredictTempChgFromQSW
-     &      (1-OLx:sNx+OLx,1-OLy:sNy+OLy)
-      _RL  PredictTempChgFromOA_MQNET
-     &      (1-OLx:sNx+OLx,1-OLy:sNy+OLy)
-      _RL  PredictTempChgFromFIA
-     &      (1-OLx:sNx+OLx,1-OLy:sNy+OLy)
-      _RL  PredictTempChgFromNewIceVol
-     &      (1-OLx:sNx+OLx,1-OLy:sNy+OLy)
-      _RL  PredictTempChgFromF_IA_NET
-     &      (1-OLx:sNx+OLx,1-OLy:sNy+OLy)
-      _RL  PredictTempChgFromF_IO_NET
-     &      (1-OLx:sNx+OLx,1-OLy:sNy+OLy)
 
-      _RL ExpectedIceVolumeChange   (1-OLx:sNx+OLx,1-OLy:sNy+OLy)
-      _RL ExpectedSnowVolumeChange   (1-OLx:sNx+OLx,1-OLy:sNy+OLy)
-      _RL ActualNewTotalVolumeChange(1-OLx:sNx+OLx,1-OLy:sNy+OLy)
-      _RL ActualNewTotalSnowMelt(1-OLx:sNx+OLx,1-OLy:sNy+OLy)
+#ifdef SEAICE_USE_ORIGINAL_HEAT_FLUX
+      _RL GAMMA
+#endif
 
-      _RL EnergyInNewTotalIceVolume (1-OLx:sNx+OLx,1-OLy:sNy+OLy)
-      _RL NetEnergyFluxOutOfSystem   (1-OLx:sNx+OLx,1-OLy:sNy+OLy)
+#ifndef SEAICE_USE_ORIGINAL_HEAT_FLUX
+C     Factor by which we increase the upper ocean friction velocity (u*) when 
+C     ice is absent in a grid cell  (dimensionless)
+      _RL MixedLayerTurbulenceFactor
 
-      _RL ResidualHeatOutOfSystem    (1-OLx:sNx+OLx,1-OLy:sNy+OLy)
+c     The Stanton number for the McPhee 
+c     ocean-ice heat flux parameterization (dimensionless)
+      _RL STANTON_NUMBER
 
-      _RL SnowAccumulationRateOverIce   (1-OLx:sNx+OLx,1-OLy:sNy+OLy)
-      _RL SnowAccumulationOverIce   (1-OLx:sNx+OLx,1-OLy:sNy+OLy)
-      _RL PrecipRateOverIceSurfaceToSea (1-OLx:sNx+OLx,1-OLy:sNy+OLy)
+c     A typical friction velocity beneath sea ice for the 
+c     McPhee heat flux parameterization (m/s)
+      _RL USTAR_BASE
 
-      _RL PotSnowMeltRateFromSurf       (1-OLx:sNx+OLx,1-OLy:sNy+OLy)
-      _RL PotSnowMeltFromSurf           (1-OLx:sNx+OLx,1-OLy:sNy+OLy)
-      _RL SnowMeltFromSurface           (1-OLx:sNx+OLx,1-OLy:sNy+OLy)
-      _RL SnowMeltRateFromSurface       (1-OLx:sNx+OLx,1-OLy:sNy+OLy)
+#endif /* SEAICE_USE_ORIGINAL_HEAT_FLUX */
 
-      _RL FreshwaterContribFromSnowMelt (1-OLx:sNx+OLx,1-OLy:sNy+OLy)
-      _RL FreshwaterContribFromIce      (1-OLx:sNx+OLx,1-OLy:sNy+OLy)
+C     Sea ice thickness growth rates (m/s)
+      _RL NetExistingIceGrowthRate      (1:sNx,1:sNy)
+      _RL IceGrowthRateUnderExistingIce (1:sNx,1:sNy)
+      _RL IceGrowthRateFromSurface      (1:sNx,1:sNy)
+      _RL IceGrowthRateOpenWater        (1:sNx,1:sNy)
+      _RL IceGrowthRateMixedLayer       (1:sNx,1:sNy)
 
-      _RL SurfHeatFluxConvergToSnowMelt (1-OLx:sNx+OLx,1-OLy:sNy+OLy)
-      _RL EnergyToMeltSnowAndIce        (1-OLx:sNx+OLx,1-OLy:sNy+OLy)
-      _RL EnergyToMeltSnowAndIce2       (1-OLx:sNx+OLx,1-OLy:sNy+OLy)
+#ifdef ALLOW_SALT_PLUME
+c     d(HEFF)/dt from heat fluxes in the open water fraction of the grid cell
+      _RL IceGrowthRateInLeads          (1:sNx,1:sNy)
 
-C     dA/dt = S_a
-      _RL S_a (1-OLx:sNx+OLx,1-OLy:sNy+OLy)
-C     dh/dt = S_h
-      _RL S_h (1-OLx:sNx+OLx,1-OLy:sNy+OLy)
-      _RL S_hsnow (1-OLx:sNx+OLx,1-OLy:sNy+OLy)
-      _RL HSNOW_ORIG (1-OLx:sNx+OLx,1-OLy:sNy+OLy)
+c     The fraction of salt released in leads by new ice production there
+c     which is to be sent to the salt plume package
+      _RL leadPlumeFraction             (1:sNx,1:sNy)
+#endif
 
-C     F_ia  - heat flux from ice to atmosphere (W/m^2)
-C     >0 causes ice growth, <0 causes snow and sea ice melt
-      _RL F_ia     (1-OLx:sNx+OLx,1-OLy:sNy+OLy)
-      _RL F_ia_net (1-OLx:sNx+OLx,1-OLy:sNy+OLy)
-      _RL F_ia_net_before_snow (1-OLx:sNx+OLx,1-OLy:sNy+OLy)
-      _RL F_io_net (1-OLx:sNx+OLx,1-OLy:sNy+OLy)
+c     The minimum value of HEFF to be divided by during the calculation of d(AREA)/dt
+      _RL HEFF_MIN
+      
+#ifdef SEAICE_DEBUG
+c     Variables for debugging (predicted temperature change from 
+c     various sources)
+      _RL PredTempChange                (1:sNx,1:sNy)
+      _RL PredTempChangeFromQSW         (1:sNx,1:sNy)
+      _RL PredTempChangeFromOA_MQNET    (1:sNx,1:sNy)
+      _RL PredTempChangeFromFIA         (1:sNx,1:sNy)
+      _RL PredTempChangeFromNewIceVol   (1:sNx,1:sNy)
+      _RL PredTempChangeFromF_IA_NET    (1:sNx,1:sNy)
+      _RL PredTempChangeFromF_IO_NET    (1:sNx,1:sNy)
+
+      _RL ExpectedIceVolumeChange       (1:sNx,1:sNy)
+      _RL ExpectedSnowVolumeChange      (1:sNx,1:sNy)
+#endif
+
+      _RL ActualIceVolumeChange         (1:sNx,1:sNy)
+      _RL ActualNewTotalSnowMelt        (1:sNx,1:sNy)
+
+      _RL EnergyInNewIceVolume          (1:sNx,1:sNy)
+      _RL NetEnergyOutOfOcean           (1:sNx,1:sNy)
+      _RL NetEnergyOutOfIce             (1:sNx,1:sNy)
+
+C     The energy taken out of the ocean which is not converted
+C     to sea ice (Joules)
+      _RL ResidualEnergyOutOfOcean      (1:sNx,1:sNy)
+
+C     Snow accumulation rate over ice (m/s)
+      _RL SnowAccRateOverIce            (1:sNx,1:sNy)
+
+C     Total snow accumulation over ice (m)
+      _RL SnowAccOverIce                (1:sNx,1:sNy)
+
+C     The precipitation rate over the ice which goes immediately into the ocean
+      _RL PrecipRateOverIceSurfaceToSea (1:sNx,1:sNy)
+
+C     The potential snow melt rate if all snow surface heat flux convergences
+C     goes to melting snow (m/s)
+      _RL PotSnowMeltRateFromSurf       (1:sNx,1:sNy)
+
+C     The potential thickness of snow which could be melted by snow surface
+C     heat flux convergence (m)
+      _RL PotSnowMeltFromSurf           (1:sNx,1:sNy)
+
+C     The actual snow melt rate due to snow surface  heat flux convergence
+      _RL SnowMeltRateFromSurface       (1:sNx,1:sNy)
+
+C     The actual surface heat flux convergence used to melt snow (W/m^2)
+      _RL SurfHeatFluxConvergToSnowMelt (1:sNx,1:sNy)
+
+C     The actual thickness of snow to be melted by snow surface
+C     heat flux convergence (m)
+      _RL SnowMeltFromSurface           (1:sNx,1:sNy)
+
+C     The freshwater contribution to the ocean from melting snow (m)
+      _RL FreshwaterContribFromSnowMelt (1:sNx,1:sNy)
+
+C     The freshwater contribution to (from) the ocean from melting (growing) ice (m)
+      _RL FreshwaterContribFromIce      (1:sNx,1:sNy)
+
+C     S_a : d(AREA)/dt
+      _RL S_a                           (1:sNx,1:sNy)
+
+C     S_a_from_IGROW : d(AREA)/dt [from ice growth rate from open water fluxes]
+      _RL S_a_from_IGROW                (1:sNx,1:sNy)
+
+C     S_h : d(HEFF)/dt
+      _RL S_h                           (1:sNx,1:sNy)
+
+C     S_hsnow : d(HSNOW)/dt
+      _RL S_hsnow                       (1:sNx,1:sNy)
+
+C     HSNOW_ORIG : The mean snow thickness before any accumulation, 
+C     melt, or flooding (m)
+      _RL HSNOW_ORIG                    (1:sNx,1:sNy)
+
+C     F_ia  - sea ice/snow surface heat flux with atmosphere (W/m^2)
+
+C     F_ia > 0 implies heat loss to atmosphere
+
+C     F_ia < 0 implies atmospheric heat flux convergence (including
+c     ice/snow surface melt)
+      _RL F_ia                          (1:sNx,1:sNy)
+
+C     F_ia_net - the net heat flux divergence at the sea ice/snow 
+c     surface including sea ice conductive fluxes and atmospheric 
+c     fluxes (W/m^2)
+
+C     F_ia_net = 0 implies that at the sea ice/snow surface an energy 
+c     balance condition is met (upward conductive fluxes balance 
+c     surface heat loss to the atmosphere).
+
+C     F_ia_net < 0 implies a net heat flux convergence at the ice/snow
+c     surface, zero conductive fluxes, and net atmospheric convergence.
+      _RL F_ia_net                      (1:sNx,1:sNy)
+
+C     F_ia_net_before_snow - the net heat flux divergence at the 
+c     ice/snow surface before snow melts (W/m^2)
+
+C     F_ia_net_before_snow < 0 implies some snow, if present, will melt.
+      _RL F_ia_net_before_snow          (1:sNx,1:sNy)
+
+C     F_io_net - the net upward conductive heat flux through the 
+c     ice + snow realized at the sea ice/snow surface.
+
+C     F_io_net > 0 implies heat conducting upward from ice base,
+c     and basal thickening of the ice.
+
+c     F_io_net = 0 implies no upward heat conduction (i.e., the 
+C     ice/snow surface temperature > SEAICE_freeze).  
+      _RL F_io_net                      (1:sNx,1:sNy)
 
 C     F_ao  - heat flux from atmosphere to ocean (W/m^2)
-      _RL F_ao (1-OLx:sNx+OLx,1-OLy:sNy+OLy)
+C     F_ao > 0
+      _RL F_ao                          (1:sNx,1:sNy)
 
-C     F_mi - heat flux from mixed layer to ice (W/m^2)
-      _RL F_mi (1-OLx:sNx+OLx,1-OLy:sNy+OLy)
-      _RL F_mi_act (1-OLx:sNx+OLx,1-OLy:sNy+OLy)
-
-c     the theta to use for the calculation of mixed layer-> ice heat fluxes 
+C     F_mi - heat flux from ocean to the ice (W/m^2)
+      _RL F_mi                          (1:sNx,1:sNy)
+      
+c     The ocean temperature used for the calculation of turbulent 
+c     ocean-ice heat fluxes (Celsius)
       _RL surf_theta
-      _RL HEFF_MIN,SNET_ICE,SNET_TOT,MixedLayerTurbulenceFactor
-      _RL HEFFO,HSNOWO
 
-c     buoyancy flux related
-      _RL ALPHAZ (1-OLx:sNx+OLx,1-OLy:sNy+OLy)
-      _RL BETAZ  (1-OLx:sNx+OLx,1-OLy:sNy+OLy)
-      _RL RHOP0 (1-OLx:sNx+OLx,1-OLy:sNy+OLy)
-
-
-
+C     Helper variables for debugging
       _RL FLUX_TO_DELTA_TEMP,ENERGY_TO_DELTA_TEMP
 
       if ( buoyancyRelation .eq. 'OCEANICP' ) then
@@ -169,51 +269,48 @@ c     buoyancy flux related
          kSurface        = 1
       endif
 
+c     For debugging
       FLUX_TO_DELTA_TEMP = SEAICE_deltaTtherm*
-     &            recip_Cp*recip_rhoConst * recip_drF(1)
+     &   recip_Cp*recip_rhoConst * recip_drF(1)
 
       ENERGY_TO_DELTA_TEMP = recip_Cp*recip_rhoConst*recip_drF(1)
 
-C     FREEZING TEMP. OF SEA WATER (deg C)
-      TBC          = SEAICE_freeze
+      TBC   = SEAICE_freeze
+      TMELT = 273.15 _d 0 
+      RHOSW = 1026. _d 0
+      RHOFW = rhoConstFresh
 
-C     FREEZING POINT OF FRESHWATER 
-      TMELT = 273.15
+#ifndef SEAICE_USE_ORIGINAL_HEAT_FLUX
+      STANTON_NUMBER = 0.0056 _d 0 
+      USTAR_BASE = 0.0125 _d 0
+#endif
 
-C     IAN
+      CPW = 4010. _d 0
+      Li = 3.34 _d 5 
 
-c     Freshwater ice density (kg m^-3) (not salty ice density)
-      RHOI = 917.0
+      QI = ONE/SEAICE_rhoIce/Li
+      QS = ONE/SEAICE_rhoSnow/Li
 
-c     Seawater density (kg m^-3)
-      RHOSW = 1026.0
+c     Helper terms for snow flooding
+      FL_C2 = SEAICE_rhoIce/RHOSW
+      FL_C3 = (RHOSW-SEAICE_rhoIce)/SEAICE_rhoSnow
+      FL_C4 = SEAICE_rhoSnow/SEAICE_rhoIce
 
-c     Freshwater density (KG M^-3)
-      RHOFW = 1000.0
+#ifdef SEAICE_USE_ORIGINAL_HEAT_FLUX
+c     GAMMA is used to calculate ocean-ice heat fluxes from
+c     a user-specified flux timescale (SEAICE_gamma_t).  
+c     Originally, 3 days in seconds was suggested as useful.
+c     
+      GAMMA =  10. _d 0 / SEAICE_gamma_t
 
-C     Snow density
-      RHOSN = 330.0
+c     (Note: this is changed from drF(1)/SEAICE_gamma_t for
+c     model setups with higher vertical resolutions.)
+c     
+c     GAMMA and SEAICE_gamma_t are not used with the default
+c     ocean-ice heat flux scheme of McPhee.
+#endif
 
-C     Heat capacity of seawater (J  kg^-1 K^-1)
-      CPW = 4010.0
-
-c     latent heat of fusion for ice (J kg^-1)
-      LI = 3.340e5 
-c     conversion between Joules and m^3 of ice  (m^3)
-      QI = 1/rhoi/Li
-      QS = 1/RHOSN/Li
-
-c     FOR FLOODING
-      FL_C2 = RHOI/RHOSW
-      FL_C3 = (RHOSW-RHOI)/RHOSN
-      FL_C4 = RHOSN/RHOI
-
-     
-
-c     Timescale for melting of ice from a warm ML (3 days in seconds)     
-c     Damping term for mixed layer heat to melt existing ice
-      GAMMA =  dRf(1)/SEAICE_gamma_t
-
+C---  +----1----+----2----+----3----+----4----+----5----+----6----+----7-|--+----|
       DO bj=myByLo(myThid),myByHi(myThid)
          DO bi=myBxLo(myThid),myBxHi(myThid)
 c     
@@ -226,1381 +323,1296 @@ c
             max3 = nTx*nTy
             act4 = ikey_dynamics - 1
             iicekey = (act1 + 1) + act2*max1
-     &           + act3*max1*max2
-     &           + act4*max1*max2*max3
+     &         + act3*max1*max2
+     &         + act4*max1*max2*max3
 #endif /* ALLOW_AUTODIFF_TAMC */
-C     
-C     initialise a few fields
-C     
-#ifdef ALLOW_AUTODIFF_TAMC
-CADJ STORE area(:,:,:,bi,bj) = comlev1_bibj, 
-CADJ &                         key = iicekey, byte = isbyte
-CADJ STORE qnet(:,:,bi,bj)   = comlev1_bibj, 
-CADJ &                         key = iicekey, byte = isbyte
-CADJ STORE qsw(:,:,bi,bj)    = comlev1_bibj, 
-CADJ &                         key = iicekey, byte = isbyte
-#endif /* ALLOW_AUTODIFF_TAMC */
-            DO J=1,sNy
-               DO I=1,sNx
-                  F_ia_net (I,J)      = 0.0 
-                  F_ia_net_before_snow(I,J)      = 0.0 
-                  F_io_net (I,J)      = 0.0 
-
-                  F_ia (I,J)      = 0.0 
-                  F_ao (I,J)      = 0.0 
-                  F_mi (I,J)      = 0.0 
-                  F_mi_act (I,J)      = 0.0 
-
-                  QNETI(I,J)      = 0.0 
-                  QSWO (I,J)      = 0.0 
-                  QSWI (I,J)      = 0.0 
-
-                  QSWO_BELOW_FIRST_LAYER (I,J) = 0.0 
-                  QSWO_IN_FIRST_LAYER    (I,J) = 0.0 
-
-C---+----1----+----2----+----3----+----4----+----5----+----6----+----7-|--+----|
-                  flux_MLI  (I,J,bi,bj) = 0.0 
-                  flux_AOS  (I,J,bi,bj) = 0.0 
-                  flux_AOZ  (I,J,bi,bj) = 0.0 
-
-                  SID_SAML (I,J,bi,bj) = 0.0
-                  SID_SAEI (I,J,bi,bj) = 0.0
-                  SID_SAOW (I,J,bi,bj) = 0.0
-
-                  SID_Sh   (I,J,bi,bj) = 0.0
-                  SID_Shs  (I,J,bi,bj) = 0.0
-                  SID_Sa   (I,J,bi,bj) = 0.0
-
-                  SID_FC_S (I,J,bi,bj) = 0.0
-                  SID_FC_I (I,J,bi,bj) = 0.0
-
-                  SID_SHML(I,J,bi,bj) =  0.0 
-                  SID_SHEI(I,J,bi,bj) =  0.0 
-                  SID_SHOW(I,J,bi,bj) =  0.0
-
-                  SID_SBFI(I,J,bi,bj)  = 0.0
-                  SID_SBFT(I,J,bi,bj)  = 0.0
-                  SID_EBFT(I,J,bi,bj)  = 0.0
-                  SID_EBFI(I,J,bi,bj)  = 0.0
-
-                  SID_DUM1 (I,J,bi,bj) = 0.0
-                  SID_DUM2 (I,J,bi,bj) = 0.0
-                  SID_DUM3 (I,J,bi,bj) = 0.0
-                  SID_DUM4 (I,J,bi,bj) = 0.0
-                  SID_DUM5 (I,J,bi,bj) = 0.0
-                  SID_DUM6 (I,J,bi,bj) = 0.0
-                  SID_DUM7 (I,J,bi,bj) = 0.0
-                  SID_DUM8 (I,J,bi,bj) = 0.0
-C---+----1----+----2----+----3----+----4----+----5----+----6----+----7-|--+----|
-
-                  S_a                             (I,J) = 0.0 
-                  S_h                             (I,J) = 0.0 
-
-                  IceGrowthRateUnderExistingIce   (I,J) = 0.0 
-                  IceGrowthRateFromSurface        (I,J) = 0.0 
-                  NetExistingIceGrowthRate        (I,J) = 0.0 
-                  S_a_from_IGROW                  (I,J) = 0.0
-
-                  PredictTempChg              (I,J) = 0.0
-                  PredictTempChgFromQSW       (I,J) = 0.0
-                  PredictTempChgFromOA_MQNET  (I,J) = 0.0
-                  PredictTempChgFromFIA       (I,J) = 0.0
-                  PredictTempChgFromF_IA_NET  (I,J) = 0.0
-                  PredictTempChgFromF_IO_NET  (I,J) = 0.0
-                  PredictTempChgFromNewIceVol (I,J) = 0.0
-
-                  IceGrowthRateOpenWater          (I,J) = 0.0 
-                  IceGrowthRateMixedLayer         (I,J) = 0.0 
-
-                  ExpectedIceVolumeChange         (I,J) = 0.0 
-                  ExpectedSnowVolumeChange        (I,J) = 0.0 
-                  ActualNewTotalVolumeChange      (I,J) = 0.0 
-                  ActualNewTotalSnowMelt          (I,J) = 0.0 
-
-                  EnergyInNewTotalIceVolume       (I,J) = 0.0 
-                  NetEnergyFluxOutOfSystem        (I,J) = 0.0 
-                  ResidualHeatOutOfSystem         (I,J) = 0.0 
-                  QSW_absorb_in_ML                (I,J) = 0.0 
-                  QSW_absorb_below_ML             (I,J) = 0.0 
-
-                  SnowAccumulationRateOverIce     (I,J) = 0.0
-                  SnowAccumulationOverIce         (I,J) = 0.0
-                  PrecipRateOverIceSurfaceToSea   (I,J) = 0.0
-
-                  PotSnowMeltRateFromSurf         (I,J) = 0.0
-                  PotSnowMeltFromSurf             (I,J) = 0.0
-                  SnowMeltFromSurface             (I,J) = 0.0
-                  SnowMeltRateFromSurface         (I,J) = 0.0
-                  SurfHeatFluxConvergToSnowMelt   (I,J) = 0.0 
-
-                  FreshwaterContribFromSnowMelt   (I,J) = 0.0
-                  FreshwaterContribFromIce        (I,J) = 0.0
-
-c the post sea ice advection and diffusion ice state are in time level 1.  
-c move these to the time level 2 before thermo.  after this routine 
-c the updated ice state will be in time level 1 again. (except for snow 
-c which does not have 3 time levels for some reason) 
-                  HSNOW(I,J,bi,bj) =  max(0.0, HSNOW(I,J,bi,bj))
-                  HEFF(I,J,1,bi,bj) = max(0.0, HEFF(I,J,1,bi,bj))
-                  AREA(I,J,1,bi,bj) = min(1.0, AREA(I,J,1,bi,bj))
-                  AREA(I,J,1,bi,bj) = max(0.0, AREA(I,J,1,bi,bj))
-
-c                 I hope this is the advective/diffusive tendency
-c                 it is the difference between what just comes
-c                 back from advection and what we left with 
-                  SID_DUM1(I,J,bi,bj) = (AREA(I,J,1,bi,bj) - 
-     &               AREA_POST_THERMO(I,J,bi,bj))/SEAICE_deltaTtherm
-
-                  SID_DUM2(I,J,bi,bj) = (HEFF(I,J,1,bi,bj) - 
-     &               HEFF_POST_THERMO(I,J,bi,bj))/SEAICE_deltaTtherm
-
-                  HEFF(I,J,2,bi,bj) = HEFF(I,J,1,bi,bj) 
-                  AREA(I,J,2,bi,bj) = AREA(I,J,1,bi,bj) 
-
-               ENDDO
-            ENDDO
-
-C---+----1----+----2----+----3----+----4----+----5----+----6----+----7-|--+----|
-           call FIND_ALPHA(
-     &        bi, bj, 1-OLx, sNx+OLx, 1-OLy, sNy+OLy, 1, 1,
-     &        ALPHAZ)
-
-           call FIND_BETA(
-     &        bi, bj, 1-OLx, sNx+OLx, 1-OLy, sNy+OLy, 1, 1,
-     &        BETAZ )
-
-           CALL FIND_RHOP0(
-     &        bi, bj, 1-OLx, snx+OLx, 1-OLy, sNy+OLy, 1,
-     &        theta, salt,
-     &        RHOP0,
-     &        myThid )
-C---+----1----+----2----+----3----+----4----+----5----+----6----+----7-|--+----|
-
-
 
 #ifdef ALLOW_AUTODIFF_TAMC
-CADJ STORE area(:,:,:,bi,bj) = comlev1_bibj, 
-CADJ &                         key = iicekey, byte = isbyte
-CADJ STORE heff(:,:,:,bi,bj) = comlev1_bibj, 
-CADJ &                         key = iicekey, byte = isbyte
-CADJ STORE hsnow(:,:,bi,bj)  = comlev1_bibj, 
-CADJ &                         key = iicekey, byte = isbyte
+C     ADJ STORE area(:,:,bi,bj) = comlev1_bibj, 
+C     ADJ &                       key = iicekey, byte = isbyte
+C     ADJ STORE qnet(:,:,bi,bj) = comlev1_bibj, 
+C     ADJ &                       key = iicekey, byte = isbyte
+C     ADJ STORE qsw(:,:,bi,bj)  = comlev1_bibj, 
+C     ADJ &                       key = iicekey, byte = isbyte
 #endif /* ALLOW_AUTODIFF_TAMC */
 
-            DO J=1,sNy
-               DO I=1,sNx
-
-cif this is hack to prevent negative precip.  somehow negative precips  
-cif escapes my exf_checkrange hack
-#ifndef FORBID_OCEAN_SURFACE_ATMOSPHERE_WATER_FLUXES
-                  IF (PRECIP(I,J,bi,bj) .LT. 0.0 _d 0) THEN 
-                     PRECIP(I,J,bi,bj) = 0.0 _d 0 
-                  ENDIF 
-#else
-                  PRECIP(I,J,bi,bj) = 0.0 _d 0 
-                  EVAP(I,J,bi,bj) = 0.0 _d 0 
-#endif
-
-C WE HAVE TO BE CAREFUL HERE SINCE ADVECTION/DIFFUSION COULD HAVE 
-C MAKE EITHER (BUT NOT BOTH) HEFF OR AREA ZERO OR NEGATIVE 
-C HSNOW COULD ALSO BECOME NEGATIVE 
-                  HEFF(I,J,2,bi,bj)  = MAX(0.0, HEFF(I,J,2,bi,bj)  ) 
-                  HSNOW(I,J,bi,bj)   = MAX(0.0, HSNOW(I,J,bi,bj)   ) 
-                  AREA(I,J,2,bi,bj)  = MAX(0.0, AREA(I,J,2,bi,bj)  ) 
- 
-                  IF (HEFF(I,J,2,bi,bj) .LE. 0.0 _d 0) THEN 
-                      AREA(I,J,2,bi,bj) = 0.0 _d 0 
-                      HSNOW(I,J,bi,bj)  = 0.0 _d 0 
-                  ENDIF 
- 
-                  IF (AREA(I,J,2,bi,bj) .LE. 0.0 _d 0) THEN 
-                     HEFF(I,J,2,bi,bj)  = 0.0 _d 0 
-                     HSNOW(I,J,bi,bj)   = 0.0 _d 0 
-                  ENDIF 
- 
-C PROCEED ONLY IF WE ARE CERTAIN TO HAVE ICE (AREA > 0) 
-
-                  IF (AREA(I,J,2,bi,bj) .GT. 0.0 _d 0) THEN
-                     HICE_ACTUAL(I,J)  = 
-     &                  HEFF(I,J,2,bi,bj)/AREA(I,J,2,bi,bj)
-
-                     HSNOW_ACTUAL(I,J) = HSNOW(I,J,bi,bj)/
-     &                  AREA(I,J,2,bi,bj)
-
-c                   ACCUMULATE SNOW
-c                   Is the ice/surface below freezing or at the freezing 
-c                   point (melting).  If it is freezing the precip is 
-c                   felt as snow and will accumulate over the ice. Else,
-c                   precip makes its way, like all things in time, to the sea.            
-
-                    IF (TICE(I,J,bi,bj) .LT. TMELT) THEN
-c                     Snow falls onto freezing surface remaining as snow
-                      SnowAccumulationRateOverIce(I,J) = 
-     &                  PRECIP(I,J,bi,bj)*RHOFW/RHOSN
-
-c                     None of the precipitation falls into the sea 
-                      PrecipRateOverIceSurfaceToSea(I,J) = 0.0
-  
-                    ELSE 
-c                     The snow melts on impact is is considered 
-c                     nothing more than rain.  Since meltponds are
-c                     not explicitly represented,this rain runs
-c                     immediately into the sea
-
-                      SnowAccumulationRateOverIce(I,J) = 0.0
-C                     The rate of rainfall over melting ice.
-                      PrecipRateOverIceSurfaceToSea(I,J)=
-     &                  PRECIP(I,J,bi,bj)
-                   ENDIF
-
-c                  In m of mean snow thickness.
-                   SnowAccumulationOverIce(I,J) = 
-     &                  SnowAccumulationRateOverIce(I,J)
-     &                  *SEAICE_deltaTtherm*Area(I,J,2,bi,bj)
-
-                ELSE
-                   HEFF(I,J,2,bi,bj) = 0.0
-                   HICE_ACTUAL(I,J)  = 0.0 
-                   HSNOW_ACTUAL(I,J) = 0.0
-                   HSNOW(I,J,bi,bj)  = 0.0
-                ENDIF
-                HSNOW_ORIG(I,J) = HSNOW(I,J,bi,bj)
-             ENDDO
-          ENDDO
             
-C     FIND ATM. WIND SPEED
+C---  +----1----+----2----+----3----+----4----+----5----+----6----+----7-|--+----|
+C     Initialize variables
             DO J=1,sNy
                DO I=1,sNx
-#ifdef SEAICE_EXTERNAL_FORCING
-c     USE EXF PACKAGE
-                  UG(I,J) = MAX(SEAICE_EPS,wspeed(I,J,bi,bj))
-#else 
-C     CALCULATE IT HERE
-                  SPEED_SQ = UWIND(I,J,bi,bj)**2 + VWIND(I,J,bi,bj)**2
-                  IF ( SPEED_SQ .LE. SEAICE_EPS_SQ ) THEN
-                     UG(I,J)=SEAICE_EPS
-                  ELSE
-                     UG(I,J)=SQRT(SPEED_SQ)
-                  ENDIF
-#endif /* SEAICE_EXTERNAL_FORCING */
-               ENDDO
-            ENDDO
+                  F_ia_net                        (I,J) = 0. _d 0
+                  F_ia_net_before_snow            (I,J) = 0. _d 0
+                  F_io_net                        (I,J) = 0. _d 0
 
-#ifdef ALLOW_AUTODIFF_TAMC
-cphCADJ STORE heff   = comlev1, key = ikey_dynamics
-cphCADJ STORE hsnow  = comlev1, key = ikey_dynamics
-cphCADJ STORE uwind  = comlev1, key = ikey_dynamics
-cphCADJ STORE vwind  = comlev1, key = ikey_dynamics
-CADJ STORE tice   = comlev1, key = ikey_dynamics
-#endif /* ALLOW_AUTODIFF_TAMC */
+                  F_ia                            (I,J) = 0. _d 0
+                  F_ao                            (I,J) = 0. _d 0
+                  F_mi                            (I,J) = 0. _d 0
 
-C     SET LAYER TEMPERATURE IN KELVIN
-            DO J=1,sNy
-               DO I=1,sNx
-                  TMIX(I,J,bi,bj)=
-     &                 theta(I,J,kSurface,bi,bj) + TMELT
-               ENDDO
-            ENDDO
+                  QSWO                            (I,J) = 0. _d 0
+                  QSWI                            (I,J) = 0. _d 0
 
-C     NOW DO ICE
+                  QSWO_BELOW_FIRST_LAYER          (I,J) = 0. _d 0
+                  QSWO_IN_FIRST_LAYER             (I,J) = 0. _d 0
 
-            CALL SEAICE_BUDGET_ICE(
-     I           UG, HICE_ACTUAL, HSNOW_ACTUAL, 
-     U           TICE, 
-     O           F_io_net,F_ia_net,F_ia, QSWI, 
-     I           bi, bj)
+                  S_a                             (I,J) = 0. _d 0
+                  S_h                             (I,J) = 0. _d 0
 
-C Sometimes it's nice to have a setup without ice-atmosphere heat
-C fluxes.  This flag turns those fluxes to zero but leaves the 
-C Ice ocean fluxes intact.  Thus, the first oceanic cell can transfer
-C heat to the ice leading to melting in F_ml and it can release 
-C heat to the atmosphere through leads and open area thus growing it in
-C F_ao
+                  IceGrowthRateUnderExistingIce   (I,J) = 0. _d 0
+                  IceGrowthRateFromSurface        (I,J) = 0. _d 0
+                  NetExistingIceGrowthRate        (I,J) = 0. _d 0
+                  S_a_from_IGROW                  (I,J) = 0. _d 0
 
-#ifdef FORBID_ICE_SURFACE_ATMOSPHERE_HEAT_FLUXES
-            DO J=1,sNy
-               DO I=1,sNx
-                  F_ia_net (I,J)  = 0.0 
-                  F_ia (I,J)      = 0.0
-                  F_io_net(I,J)   = 0.0 
-               ENDDO
-            ENDDO
+                  IceGrowthRateOpenWater          (I,J) = 0. _d 0
+                  IceGrowthRateMixedLayer         (I,J) = 0. _d 0
+
+#ifdef ALLOW_SALT_PLUME
+                  IceGrowthRateInLeads            (I,J) = 0. _d 0
+                  leadPlumeFraction               (I,J) = 0. _d 0
+                  saltPlumeFlux             (I,J,bi,bj) = 0. _d 0
 #endif
 
-C--   NET HEAT FLUX TO ICE FROM MIXED LAYER (POSITIVE MEANS NET OUT)
+                  ActualIceVolumeChange           (I,J) = 0. _d 0
+                  ActualNewTotalSnowMelt          (I,J) = 0. _d 0
+
+                  EnergyInNewIceVolume            (I,J) = 0. _d 0
+                  NetEnergyOutOfOcean             (I,J) = 0. _d 0
+                  NetEnergyOutOfIce               (I,J) = 0. _d 0
+                  ResidualEnergyOutOfOcean        (I,J) = 0. _d 0
+
+#ifdef SEAICE_DEBUG
+                  ExpectedIceVolumeChange         (I,J) = 0. _d 0
+                  ExpectedSnowVolumeChange        (I,J) = 0. _d 0
+
+                  PredTempChange                  (I,J) = 0. _d 0
+                  PredTempChangeFromQSW           (I,J) = 0. _d 0
+                  PredTempChangeFromOA_MQNET      (I,J) = 0. _d 0
+                  PredTempChangeFromFIA           (I,J) = 0. _d 0
+                  PredTempChangeFromF_IA_NET      (I,J) = 0. _d 0
+                  PredTempChangeFromF_IO_NET      (I,J) = 0. _d 0
+                  PredTempChangeFromNewIceVol     (I,J) = 0. _d 0
+
+                  QSW_absorb_in_first_layer       (I,J) = 0. _d 0
+                  QSW_absorb_below_first_layer    (I,J) = 0. _d 0
+#endif
+
+                  SnowAccRateOverIce              (I,J) = 0. _d 0
+                  SnowAccOverIce                  (I,J) = 0. _d 0
+                  PrecipRateOverIceSurfaceToSea   (I,J) = 0. _d 0
+
+                  PotSnowMeltRateFromSurf         (I,J) = 0. _d 0
+                  PotSnowMeltFromSurf             (I,J) = 0. _d 0
+                  SnowMeltFromSurface             (I,J) = 0. _d 0
+                  SnowMeltRateFromSurface         (I,J) = 0. _d 0
+                  SurfHeatFluxConvergToSnowMelt   (I,J) = 0. _d 0
+
+                  FreshwaterContribFromSnowMelt   (I,J) = 0. _d 0
+                  FreshwaterContribFromIce        (I,J) = 0. _d 0
+
+c     Following sea ice dynamics, the ice state (HEFF and 
+c     AREA) are stored in time level 1 (N).  The ice state 
+c     is moved to time level N minus 1 (Nm1) before 
+c     thermodynamical calulations.  Following this routine,
+c     the new ice state will be at time level N (except
+c     HSNOW which isn't stored at multiple time levels.)
+                  HEFFNm1(I,J,bi,bj) = HEFF(I,J,bi,bj) 
+                  AREA(I,J,bi,bj) = MIN(1.0 _d 0, AREA(I,J,bi,bj)
+                  AREANm1(I,J,bi,bj) = AREA(I,J,bi,bj) 
+
+
+
+               ENDDO
+            ENDDO
+
+
+#ifdef ALLOW_AUTODIFF_TAMC
+C     ADJ STORE area(:,:,bi,bj)   = comlev1_bibj, 
+C     ADJ &                         key = iicekey, byte = isbyte
+C     ADJ STORE heff(:,:,bi,bj)   = comlev1_bibj, 
+C     ADJ &                         key = iicekey, byte = isbyte
+C     ADJ STORE hsnow(:,:,bi,bj)  = comlev1_bibj, 
+C     ADJ &                         key = iicekey, byte = isbyte
+C     ADJ STORE tice(:,:,bi,bj)   = comlev1_bibj, 
+C     ADJ &                         key = iicekey, byte = isbyte
+C     ADJ STORE precip(:,:,bi,bj) = comlev1_bibj, 
+C     ADJ &                         key = iicekey, byte = isbyte
+#endif /* ALLOW_AUTODIFF_TAMC */
+
+
+C---  +----1----+----2----+----3----+----4----+----5----+----6----+----7-|--+----|
+C     Sanity check on HEFF, HSNOW, AREA, and PRECIP. The ice 
+c     dynamics subroutines could generate unphysical ice state 
+c     variables (e.g., zero/negative AREA with positive HEFF 
+c     and/or HSNOW)
+
+c     Note: the zeroing out negative HEFF and/or HSNOW here (due
+c     to ice dynamics) might violate mass/energy conservation.
+c     If this is a problem, choose a conservative ice advection
+c     and diffusion scheme. 
             DO J=1,sNy
                DO I=1,sNx
 
 #ifdef SEAICE_DEBUG
-               IF ( (I .EQ. SEAICE_debugPointX)   .and.
-     &              (J .EQ. SEAICE_debugPointY) ) THEN
+                  IF ( (I .EQ. SEAICE_debugPointX)   .and.
+     &               (J .EQ. SEAICE_debugPointY) ) THEN
 
-                 print *,'sig: I,J,F_ia,F_ia_net',I,J,F_ia(I,J),
-     &              F_ia_net(I,J)
+                     print '(A,i6,4(1x,1PE24.15))',
+     &                  'beg iter, ANm1, HNm1, HSN',myIter,
+     &                  AREANm1(I,J,bi,bj), HEFFNm1(I,J,bi,bj), 
+     &                  HSNOW(I,J,bi,bj)
 
-               ENDIF
+                  ENDIF
 #endif
 
-#ifdef FORBID_ICE_SURFACE_ATMOSPHERE_HEAT_FLUXES
-                  NetExistingIceGrowthRate(I,J) = 0.0 
-#else
+                  HEFFNm1(I,J,bi,bj) = MAX(ZERO,HEFFNm1(I,J,bi,bj)) 
+                  HSNOW(I,J,bi,bj)   = MAX(ZERO,HSNOW(I,J,bi,bj)  ) 
+                  AREANm1(I,J,bi,bj) = MAX(ZERO,AREANm1(I,J,bi,bj)) 
+
+c     If either HEFF or AREA are zero, ensure all other ice
+c     state variables are also zero.
+                  IF ((HEFFNm1(I,J,bi,bj) .EQ. ZERO) .OR. 
+     &               (AREANm1(I,J,bi,bj) .EQ. ZERO)) THEN 
+
+                     AREANm1(I,J,bi,bj) = 0. _d 0
+                     HSNOW(I,J,bi,bj)   = 0. _d 0
+                     HEFFNm1(I,J,bi,bj) = 0. _d 0
+
+                     HICE_ACTUAL(I,J)   = 0. _d 0
+                     HSNOW_ACTUAL(I,J)  = 0. _d 0
+
+                  ELSE          !/ Heff and Area > 0
+
+c     Caclulate the actual (not mean) thicknesses 
+c     of the ice and any snow in the grid cell 
+                     HICE_ACTUAL(I,J)  = 
+     &                  HEFFNm1(I,J,bi,bj)/AREANm1(I,J,bi,bj)
+
+                     HSNOW_ACTUAL(I,J) = HSNOW(I,J,bi,bj)/
+     &                  AREANm1(I,J,bi,bj)
+
+                  ENDIF 
+
+                  HSNOW_ORIG(I,J) = HSNOW(I,J,bi,bj)
+                  
+c     This is to prevent (spurious) negative precipitation
+c     from decreasing snow depth.
+                  IF (PRECIP(I,J,bi,bj) .LT. ZERO) THEN 
+                     PRECIP(I,J,bi,bj) = ZERO 
+                  ENDIF 
+               ENDDO
+            ENDDO
+
+
+#ifdef SEAICE_SIMULATE_DIVERGENCE_IN_1D_MONDEL
+C---  +----1----+----2----+----3----+----4----+----5----+----6----+----7-|--+----|
+c     Simulate unresolved dynamical convergence: This optional  
+c     code parameterizes unresolved small-scale mechanical 
+c     divergence of the ice pack.  To simulate regular lead 
+c     opening, a small fraction of the ice area is removed
+c     each time step while conserving ice and snow mass.
+
+            DO J=1,sNy
+               DO I=1,sNx
+c     Removes about 1.2% of the concentration in 48 hours.
+                  AREANm1(I,J,bi,bj) = AREANm1(I,J,bi,bj)*0.99975 _d 0
+               ENDDO
+            ENDDO
+#endif            
+            
+
+C---  +----1----+----2----+----3----+----4----+----5----+----6----+----7-|--+----|
+c     Snow : Treat precipitation as snow and accumulate it onto 
+c     existing snow (or bare ice) it if the snow/ice surface 
+c     temperature is below the freshwater freezing point.  If the
+c     snow/ice surface temperature is at the freezing point, 
+c     assume  precipitation falls as rain and flows to the sea
+            DO J=1,sNy
+               DO I=1,sNx
+                  IF (AREANm1(I,J,bi,bj) .GT. ZERO) THEN
+
+                     IF (TICE(I,J,bi,bj) .LT. TMELT) THEN
+c     Snow falls onto freezing surface remaining
+                        SnowAccRateOverIce(I,J) = 
+     &                     PRECIP(I,J,bi,bj)*RHOFW/SEAICE_rhoSnow
+
+                     ELSE 
+c     The snow melts on impact is is considered 
+c     nothing more than rain which runs to the sea
+                        PrecipRateOverIceSurfaceToSea(I,J)=
+     &                     PRECIP(I,J,bi,bj)
+                     ENDIF
+
+c     The mean depth of new snow accumulation over the
+c     grid cell (m) 
+                     SnowAccOverIce(I,J) =   SnowAccRateOverIce(I,J)
+     &                  * SEAICE_deltaTtherm*AreaNm1(I,J,bi,bj)
+
+                  ENDIF
+               ENDDO
+            ENDDO
+            
+
+C---  +----1----+----2----+----3----+----4----+----5----+----6----+----7-|--+----|
+C     Retrieve near-surface wind speed. 
+            DO J=1,sNy
+               DO I=1,sNx
+C     copy the wind speed computed in exf_wind.F to UG
+                  UG(I,J) = MAX(SEAICE_EPS,wspeed(I,J,bi,bj))
+               ENDDO
+            ENDDO
+
+#ifdef ALLOW_AUTODIFF_TAMC
+C     ADJ STORE tice   = comlev1, key = ikey_dynamics
+#endif /* ALLOW_AUTODIFF_TAMC */
+
+
+#ifndef FORBID_ICE_SURFACE_ATMOSPHERE_HEAT_FLUXES
+C---  +----1----+----2----+----3----+----4----+----5----+----6----+----7-|--+----|
+C     Calculate sea ice/snow thermodynamic fluxes within and out 
+c     of the snow and ice.
+
+            CALL SEAICE_BUDGET_ICE(
+     I         UG, HICE_ACTUAL, HSNOW_ACTUAL, 
+     U         TICE, 
+     O         F_io_net,F_ia_net,F_ia, QSWI, 
+     I         bi, bj, myTime, myIter, myThid )
+
+#else 
+
+c     Forbid ice surface atmosphere heat fluxes: Sometimes it is 
+c     useful to have a setup without ice-atmosphere heat fluxes. 
+C     This optional flag zeros fluxes at and through and snow/
+c     ice surface.  Sensible heat fluxes from the ocean to the 
+c     ice base and fluxes between the open water fraction of the 
+c     cell and the atmosphere are left intact.
+
+            DO J=1,sNy
+               DO I=1,sNx
+                  F_ia_net (I,J)  = 0. _d 0
+                  F_ia (I,J)      = 0. _d 0
+                  F_io_net(I,J)   = 0. _d 0
+                  QSWI(I,J)       = 0. _d 0
+                  TICE(I,J,bi,bj)   = TMELT
+               ENDDO
+            ENDDO
+#endif
+
+
+C---  +----1----+----2----+----3----+----4----+----5----+----6----+----7-|--+----|
+c     Debugging
+#ifdef SEAICE_DEBUG
+            print '(A,i6,4(1x,1PE24.15))',
+     &         'sig: iter, F_ia,F_ia_net ',myIter,
+     &         F_ia(SEAICE_debugPointX, SEAICE_debugPointY),
+     &         F_ia_net(SEAICE_debugPointX, SEAICE_debugPointY)
+
+            print '(A,i6,4(1x,1PE24.15))',
+     &         'sig: iter,_io_net,QSWI   ',myIter,
+     &         F_io_net(SEAICE_debugPointX, SEAICE_debugPointY),
+     &         QSWI(SEAICE_debugPointX, SEAICE_debugPointY)
+
+            print '(A,i6,4(1x,1PE24.15))',
+     &         'sig: iter, TICE     ',myIter,
+     &         TICE(SEAICE_debugPointX, SEAICE_debugPointY,bi,bj)
+
+#endif
+
+
+C---  +----1----+----2----+----3----+----4----+----5----+----6----+----7-|--+----|
+c     Calculate the snow and ice growth rates from 1) surface
+c     melt and 2) basal thickening:  Surface energy heat flux 
+c     convergence (F_ia_net) melts snow and ice.  Upward
+c     conductive heat fluxes drive basal thickening.
+
+c     If the surface energy heat flux convergence cannot melt all
+c     the snow, F_ia_net is driven to zero.  If all snow is
+c     melted, F_ia_net is reduced and the remaining energy melts
+c     ice.  
+
+            DO J=1,sNy
+               DO I=1,sNx
+
                   F_ia_net_before_snow(I,J) = F_ia_net(I,J)
 
-                  IF (Area(I,J,2,bi,bj)*HEFF(I,J,2,bi,bj) .LE. 0.) THEN
-                     IceGrowthRateUnderExistingIce(I,J) = 0.0
-                     IceGrowthRateFromSurface(I,J)      = 0.0
-                     NetExistingIceGrowthRate(I,J)      = 0.0 
+c     Continue if there is ice in the cell.
+                  IF (AreaNm1(I,J,bi,bj) .LE. ZERO) THEN 
+                     IceGrowthRateUnderExistingIce(I,J) = 0. _d 0
+                     IceGrowthRateFromSurface(I,J)      = 0. _d 0
+                     NetExistingIceGrowthRate(I,J)      = 0. _d 0
                   ELSE
-c                    The growth rate under existing ice is given by the upward
-c                    ocean-ice conductive flux, F_io_net, and QI, which converts
-c                    Joules to meters of ice.  This quantity has units of meters
-c                    of ice per second.
+c     The growth rate (m/s) beneath ice due to
+c     heat flux divergence at the ice base associated
+c     with upward conductive heat fluxes through the ice 
+c     (F_io_net)
                      IceGrowthRateUnderExistingIce(I,J)=F_io_net(I,J)*QI
 
-c                    Snow/Ice surface heat convergence is first used to melt 
-c                    snow.  If all of this heat convergence went into melting
-c                    snow, this is the rate at which it would do it
-c                    F_ia_net must be negative, -> PSMRFW is positive for melting
+c     The potential snow melt rate (m/s) due to surface
+c     heat flux convergence.  Note, snow melt requires a
+c     negative F_ia_net (implying convergence) for 
+c     a nonzero PSMRFW.
                      PotSnowMeltRateFromSurf(I,J)= - F_ia_net(I,J)*QS
 
-c                    This is the depth of snow that would be melted at this rate
-c                    and the seaice delta t. In meters of snow.
+c     This is the depth of snow (m) that would be melted 
+c     over one time step.
                      PotSnowMeltFromSurf(I,J) =
      &                  PotSnowMeltRateFromSurf(I,J)* SEAICE_deltaTtherm
 
-c                    If we can melt MORE than is actually there, then we will 
-c                    reduce the melt rate so that only that which is there 
-c                    is melted in one time step.  In this case not all of the 
-c                    heat flux convergence at the surface is used to melt snow,
-c                    The leftover energy is going to melt ice.  
-c                    SurfHeatFluxConvergToSnowMelt is the part of the total heat 
-c                    flux convergence going to melt snow. 
+c     If more can be melted than exists, the melt rate
+c     is reduced.  
 
                      IF (PotSnowMeltFromSurf(I,J) .GE. 
-     &                 HSNOW_ACTUAL(I,J)) THEN
-c                      Snow melt and melt rate in actual snow thickness.
-                       SnowMeltFromSurface(I,J)     = HSNOW_ACTUAL(I,J)
+     &                  HSNOW_ACTUAL(I,J)) THEN
 
-                       SnowMeltRateFromSurface(I,J) = 
-     &                   SnowMeltFromSurface(I,J)/ SEAICE_deltaTtherm
+c     Snow depth to be melted and the snow melt rate.
+                        SnowMeltFromSurface(I,J) = HSNOW_ACTUAL(I,J)
 
-c                      Since F_ia_net is focused only over ice, its reduction 
-c                      requires knowing how much snow is actually melted
-                       SurfHeatFluxConvergToSnowMelt(I,J) =
-     &                   -HSNOW_ACTUAL(I,J)/QS/SEAICE_deltaTtherm
+                        SnowMeltRateFromSurface(I,J) = 
+     &                     SnowMeltFromSurface(I,J)/ SEAICE_deltaTtherm
+
+c     SurfHeatFluxConvergToSnowMelt is the part of the 
+c     total heat flux convergence which melts snow.
+                        SurfHeatFluxConvergToSnowMelt(I,J) =
+     &                     -HSNOW_ACTUAL(I,J)/QS/SEAICE_deltaTtherm
                      ELSE
-c                      In this case there will be snow remaining after melting.
-c                      All of the surface heat convergence will be redirected to 
-c                      this effort.
-                       SnowMeltFromSurface(I,J)=PotSnowMeltFromSurf(I,J)
+c     Snow remains after melt.  
+                        SnowMeltFromSurface(I,J)=
+     &                     PotSnowMeltFromSurf(I,J)
 
-                       SnowMeltRateFromSurface(I,J) = 
-     &                    PotSnowMeltRateFromSurf(I,J)
+                        SnowMeltRateFromSurface(I,J) = 
+     &                     PotSnowMeltRateFromSurf(I,J)
 
-                       SurfHeatFluxConvergToSnowMelt(I,J) =F_ia_net(I,J)
+                        SurfHeatFluxConvergToSnowMelt(I,J) =
+     &                     F_ia_net(I,J)
                      ENDIF
 
-c                    Reduce the heat flux convergence available to melt surface
-c                    ice by the amount used to melt snow
+c     Reduce the heat flux convergence available to melt 
+c     ice by the amount used to melt snow.
                      F_ia_net(I,J) = 
      &                  F_ia_net(I,J)-SurfHeatFluxConvergToSnowMelt(I,J)
 
                      IceGrowthRateFromSurface(I,J) = F_ia_net(I,J)*QI
 
+c     The total growth rate (m/s) of the existing ice - 
+c     the rate of new ice accumulation less the rate of 
+c     surface melt.
                      NetExistingIceGrowthRate(I,J) = 
-     &                 IceGrowthRateUnderExistingIce(I,J) +
-     &                 IceGrowthRateFromSurface(I,J)
+     &                  IceGrowthRateUnderExistingIce(I,J) +
+     &                  IceGrowthRateFromSurface(I,J)
                   ENDIF
-c forbid ice surface - atmosphere heat fluxes
-#endif
+
+               ENDDO            !/ i
+            ENDDO               !/ j
+
+
+C---  +----1----+----2----+----3----+----4----+----5----+----6----+----7-|--+----|
+C     Retrieve upper ocean temp and store temporarily in TMIX.
+            DO J=1,sNy
+               DO I=1,sNx
+
+C     Set the upper ocean temperature in Kelvin
+                  TMIX(I,J,bi,bj)= theta(I,J,kSurface,bi,bj) + TMELT
+
                ENDDO
             ENDDO
+            
 
-c     HERE WE WILL MELT SNOW AND ADJUST NET EXISTING ICE GROWTH RATE 
-C     TO REFLECT REDUCTION IN SEA ICE MELT.
-
-C     NOW DETERMINE GROWTH RATES
-C     FIRST DO OPEN WATER
+C---  +----1----+----2----+----3----+----4----+----5----+----6----+----7-|--+----|
+c     Retrieve the air-sea heat and shortwave radiative fluxes
             CALL SEAICE_BUDGET_OCEAN(
-     I           UG, 
-     U           TMIX, 
-     O           F_ao, QSWO, 
-     I           bi, bj)
- 
-#ifdef FORBID_OCEAN_SURFACE_ATMOSPHERE_HEAT_FLUXES
-            DO J=1,sNy
-               DO I=1,sNx
-                  QSWO (I,J)  = 0.0 
-                  F_ao (I,J)  = 0.0
-               ENDDO
-            ENDDO
-#endif
+     I         UG, 
+     U         TMIX, 
+     O         F_ao, QSWO, 
+     I         bi, bj, myTime, myIter, myThid )
 
+            
 #ifdef SEAICE_DEBUG
-        print *,'myiter', myIter
-        print '(A,2i4,2(1x,1P2E15.3))',
-     &       'ifice sigr, dbgx,dby, (netHF, SWHeatFlux)',
-     &        SEAICE_debugPointX,   SEAICE_debugPointY,
-     &        F_ao(SEAICE_debugPointX, SEAICE_debugPointY),
-     &        QSWO(SEAICE_debugPointX, SEAICE_debugPointY)
+C---  +----1----+----2----+----3----+----4----+----5----+----6----+----7-|--+----|
+c     Debugging
+            print '(A,i6,4(1x,1PE24.15))',
+     &         'myIter, Fao, QSWO ', myIter,
+     &         F_ao(SEAICE_debugPointX, SEAICE_debugPointY),
+     &         QSWO(SEAICE_debugPointX, SEAICE_debugPointY),
+     &         TMIX(SEAICE_debugPointX, SEAICE_debugPointY,bi,bj)
 #endif
 
 
-C--   NET HEAT FLUX TO ICE FROM MIXED LAYER (POSITIVE MEANS NET OUT)
-c--   not all of the sw radiation is absorbed in the first layer, only that
-c     which is absorbed melts ice.   SWFRACB is calculated in seaice_init_vari.F 
+C---  +----1----+----2----+----3----+----4----+----5----+----6----+----7-|--+----|
+c     Calculate the ice growth rate from open water heat fluxes:
+c     Turbulent fluxes (F_ao) and shortwave energy convergence in
+c     the uppermost ocean grid cell contribute.
+c     
+c     SWFRACB - the fraction of incoming sw radiation absorbed in 
+c     the uppermost ocean grid cell 
             DO J=1,sNy
                DO I=1,sNx
-                IF (maskC(I,J,kSurface,bi,bj).NE.0.) THEN
-                  IceGrowthRateOpenWater(I,J) = 0.0
-
-#ifndef FORBID_OCEAN_SURFACE_ATMOSPHERE_HEAT_FLUXES
 
 c     The contribution of shortwave heating is 
-c     not included without SHORTWAVE_HEATING
+c     not included without #define SHORTWAVE_HEATING
+
 #ifdef SHORTWAVE_HEATING
                   QSWO_BELOW_FIRST_LAYER(i,j)= QSWO(I,J)*SWFRACB
-                  QSWO_IN_FIRST_LAYER(I,J)   = QSWO(I,J)*(1.0 - SWFRACB)
+                  QSWO_IN_FIRST_LAYER(I,J)   = QSWO(I,J)*(ONE - SWFRACB)
 #else 
                   QSWO_BELOW_FIRST_LAYER(i,j)= 0. _d 0
                   QSWO_IN_FIRST_LAYER(I,J)   = 0. _d 0
 #endif
+
                   IceGrowthRateOpenWater(I,J)= QI*
-     &              (F_ao(I,J) - QSWO(I,J) + QSWO_IN_FIRST_LAYER(I,J))
-#endif
-C---+----1----+----2----+----3----+----4----+----5----+----6----+----7-|--+----|
-C   BEGIN DIAGNOSTICS
-c                 air-sea turb +  radiation only in the first layer
-                  flux_AOS(I,J,bi,bj) = 
-     &                     F_ao(I,J) - QSWO(I,J) 
-     &                       + QSWO_IN_FIRST_LAYER(I,J)
-          
-c                 air-sea turb +  radiation throughout 
-                  flux_AOZ(I,J,bi,bj) = F_ao(I,J) 
-C   END DIAGNOSTICS
-C---+----1----+----2----+----3----+----4----+----5----+----6----+----7-|--+----|
+     &               (F_ao(I,J) - QSWO(I,J) + QSWO_IN_FIRST_LAYER(I,J))
 
-
-                ENDIF !/MASK
-              ENDDO
+               ENDDO
             ENDDO        
             
 
 #ifdef ALLOW_AUTODIFF_TAMC
-CADJ STORE theta(:,:,:,bi,bj)= comlev1_bibj, 
-CADJ &                         key = iicekey, byte = isbyte
-CADJ STORE heff(:,:,:,bi,bj) = comlev1_bibj, 
-CADJ &                         key = iicekey, byte = isbyte
+C     ADJ STORE theta(:,:,:,bi,bj)= comlev1_bibj, 
+C     ADJ &                         key = iicekey, byte = isbyte
+C     ADJ STORE heff(:,:,bi,bj)   = comlev1_bibj, 
+C     ADJ &                         key = iicekey, byte = isbyte
 #endif /* ALLOW_AUTODIFF_TAMC */
 
 
-C--   NET HEAT FLUX TO ICE FROM MIXED LAYER (POSITIVE MEANS FLUX INTO ICE
-C     AND MELTING)
+C---  +----1----+----2----+----3----+----4----+----5----+----6----+----7-|--+----|
+C     Calcuate the ice growth rate from turbulent heat fluxes from
+c     the ocean.
+
             DO J=1,sNy
                DO I=1,sNx
-                IF (maskC(I,J,kSurface,bi,bj).NE.0.) THEN
-C     FIND THE FREEZING POINT OF SEAWATER IN THIS CELL
+
 #ifdef SEAICE_VARIABLE_FREEZING_POINT
+C     Calculate the seawater freezing point
                   TBC = -0.0575 _d 0*salt(I,J,kSurface,bi,bj) + 
-     &                 0.0901 _d 0
+     &               0.0901 _d 0
 #endif /* SEAICE_VARIABLE_FREEZING_POINT */
                   
-c     example: theta(i,j,ksurf)  = 0, tbc = -2, 
-c     fmi = -gamm*rhocpw * (0-(-2)) = - 2 * gamm * rhocpw, 
-c     a NEGATIVE number.  Heat flux INTO ice.
-
-c     It is fantastic that the model frequently generates thetas less 
-c     then the freezing point.  Just fantastic.  When this happens, 
-c     throw your hands up into the air, shut off the mixed layer 
-c     heat flux, and hope for the best.
+c     Bound the ocean temperature to be at or above the freezing point.
                   surf_theta = max(theta(I,J,kSurface,bi,bj), TBC)
 
-C                 Seaice_gamma_t should be chosen so as to give
-c                 GAMMA \approx 5.6e-5 based on the McPhee Stanton number
-c                 closure for <w'T'> of turbulent ocean-ice heat fluxes.
-c
-c                 F_mi   = <w'T'> rho_sw cp_sw
-c
-c                 and 
-c
-c                 <w'T'> = St u_* (T_o - T_frz)
-c
-C                 St     = Stanton number 0.0056
-C                 u_*    = friction velocity, about 1 cm/s beneath ice
-c                 rho_sw = seawater density
-c                 cp_sw  = seawater heat capacity
-c                 T_o    = ocean model grid cell temperature
-c                 T_frz  = ocean model freezing point
-c
-c                 St u_* in the model is parameterized in the GAMMA term
-c
-c                 F_mi = GAMMA * rho_sw cp_sw (T_o - T_frz) *
-c                             MixedLayerTurbulenceFactor
-c
-c                 GAMMA = dR(1) / Seaice_gamma_t
-c
-c                 So seaice_gamma_t must be 1.78e5 or so (about 2 days) 
-c                 to give heat flux values which are similar to data.
-c
-c                 However, F_mi also determines the new ice coalesence criteria
-c                 (new ice forms when F_ao > F_mi) and without ice the u_* value
-c                 can be much larger (by a factor of 3-5). see:
-c
-C                 Monthly Climatologies of Oceanic Friction Velocity Cubed
-C                 Barry A. Klinger, Bohua Huang, Ben Kirtman, Paul Schopf, Jiande Wang
-C                 Journal of Climate 2006 19:21, 5700-5708 
-c               
-c                 Therefore, when ice is not present we bump up the MixedLayerTurbulenceFactor
-c                 to 5.   By doing so, the initial growth of ice
-c                 begins at a lower ocean surface temperature.  Using 
-c                 St=0.0056, u* = 0.05 cm/s, new ice growth require 
-c                 atm fluxes exceeding 8614*(T_o- T_frz) W/m^2
-c
-c                 For example, with atm heat losses at  500 W/m^s, ocean temperatures 
-c                 need to get to 0.0580 degrees 
-c                 above the freezing point before ice forms.
 
-                  IF (AREA(I,J,2,bi,bj) .GT. 0.0 _d 0) THEN
-                     MixedLayerTurbulenceFactor=1.0
+c     This model has two alternative schemes to calculate turbulent ocean-ice
+c     heat fluxes.  Each is described in turn
+c     
+c     ==== METHOD 1 ====
+c     
+c     The first uses an empircal relationship between the 
+c     'far-field' ocean temperature and ocean to sea ice turbulent heat fluxes 
+c     given by McPhee:
+c     
+c     Flux  = rho_sw * cp_sw * <w'T'> 
+c     <w'T'>= S_t *  u_star * (T_o - T_f)
+c     
+c     Where,
+c     rho_sw : seawater density (kg m^-3)
+c     cp_sw  : seawater heat capcity (J kg^-1 K^-1)
+c     S_t    : Stanton Number ~ 0.0056 (dimensionless)
+c     u_star : friction velocity beneath ice ~ 0.015 m s^-1
+c     T_o, T_f : The 'far-field' ocean temperature and ice
+c     freezing point (deg C)
+c     
+c     Using typical values, ice advected over waters warmer by 1 degree
+c     will be subjected to a basal heat flux of ~ 345 W m^-2.  
+c     
+c     In the model, the criteria for ice growth is that the air-sea
+c     heat loss must exceed the potential ocean-ice heat flux (i.e., more 
+c     potential ice production over one time step than melt).  
+c     Using the above parameterization, ice will form in waters which 
+c     are much warmer than its salinity-determined freezing point
+c     using typical wintertime conditions in, say, the North Atlantic.
+c     
+c     Therefore, when no ice is present, an additional factor is applied
+c     to the above <w'T'> (mixedLayerTurbulenceFactor) to represent the idea that 
+c     turbulent mixing at and near the surface of an ice-free ocean
+c     is much greater than mixing beneath an ice-covered one.
+c     
+c     A factor of 12.5 is chosen for mixedLayerTurbulenceFactor.  Consequently,
+c     for each 0.1 degree above freezing of the upper ocean grid cell,
+c     the air-sea heat losses must exceed ~ 515 W m^-2 before ice forms.
+c     
+c     Once ice gains a foothold in a grid cell, the McPhee parameterization
+c     is immediately invoked.
+c     
+c     ==== METHOD 2 ====
+c     
+c     The second scheme (the original and now outdated version)
+c     subsumes (S_t * u_star) into a single variable (SEAICE_gamma_t)
+c     in the following way:
+c     
+c     Flux  = rho_sw * cp_sw * GAMMA 
+c     GAMMA = dRf(1)/SEAICE_gamma_t * (T_o - T_f)
+c     
+c     Where,
+c     dRf(1)  : depth of surface level grid cell (originally 
+c     assumed to be 10 m)
+c     SEAICE_gamma_t : an empirical parameter (~ 3 days in seconds)
+c     
+c     Using typical values, ice advected into a grid cell 
+c     that is warmer than the sea ice freezing point by 1 degree
+c     will be subjected to a basal heat flux of ~ 160 W m^-2.   Therefore,
+c     as written, one should choose a SEAICE_gamma_t = 1.4 days in seconds
+c     to have flux magnitudes match those of the McPhee parameterization.
+c     
+c     The original scheme is accessed by defining  #SEAICE_USE_ORIGINAL_HEAT FLUX
+
+#ifndef SEAICE_USE_ORIGINAL_HEAT_FLUX
+
+c     If ice is present, MixedLayerTurbulenceFactor = 1.0, else 12.50
+                  IF (AREANm1(I,J,bi,bj) .GT. 0. _d 0) THEN
+                     MixedLayerTurbulenceFactor = ONE
                   ELSE
-C                    If we don't actually have ice here yet, then 
-C                    u* is going to be 3-5 cms, 
-                     MixedLayerTurbulenceFactor=5.0
+                     MixedLayerTurbulenceFactor = 12.5 _d 0
                   ENDIF
-                   
-                  F_mi(I,J) = -GAMMA*RHOSW*CPW *(surf_theta - TBC)*
-     &                  MixedLayerTurbulenceFactor
 
-                  IceGrowthRateMixedLayer(I,J) = F_mi(I,J)*QI
+                  F_mi(I,J) = -STANTON_NUMBER * USTAR_BASE * RHOSW *
+     &               CPW *(surf_theta - TBC)*MixedLayerTurbulenceFactor
+#else
 
-C---+----1----+----2----+----3----+----4----+----5----+----6----+----7-|--+----|
-                  flux_MLI(I,J,bi,bj) = F_mi(I,J)
-C---+----1----+----2----+----3----+----4----+----5----+----6----+----7-|--+----|
-                 ENDIF !/ MASK
-               ENDDO
-            ENDDO
+c     no turbulence factor using original_heat_flux scheme
+                  F_mi(I,J) = -GAMMA*RHOSW*CPW *(surf_theta - TBC)
+
+#endif /* SEAICE_USE_ORIGINAL_HEAT_FLUX */
+
+                  IceGrowthRateMixedLayer(I,J) = F_mi(I,J)*QI;
+
+               ENDDO            !/ i
+            ENDDO               !/ j
 
 #ifdef ALLOW_AUTODIFF_TAMC
-CADJ STORE S_h(:,:)         = comlev1_bibj, 
-CADJ &                         key = iicekey, byte = isbyte
+C     ADJ STORE S_h(:,:)         = comlev1_bibj, 
+C     ADJ &                        key = iicekey, byte = isbyte
 #endif /* ALLOW_AUTODIFF_TAMC */
 
-C     CALCULATE THICKNESS DERIVATIVE (S_h)
+
+
+C---  +----1----+----2----+----3----+----4----+----5----+----6----+----7-|--+----|
+C     Calculate the ice thickness derivative (S_h)
+
             DO J=1,sNy
                DO I=1,sNx
-                 
                   S_h(I,J) = 
-     &                 NetExistingIceGrowthRate(I,J)*AREA(I,J,2,bi,bj)+
-     &                 (1. -AREA(I,J,2,bi,bj))*
-     &                 IceGrowthRateOpenWater(I,J) +
-     &                 IceGrowthRateMixedLayer(I,J)
+     &               NetExistingIceGrowthRate(I,J)*AREANm1(I,J,bi,bj)+
+     &               (ONE -AREANm1(I,J,bi,bj))*
+     &               IceGrowthRateOpenWater(I,J) +
+     &               IceGrowthRateMixedLayer(I,J)
 
-c                  Both the accumulation and melt rates are in terms
-c                  of actual snow thickness.  As with ice, multiplying
-c                  with area converts to mean snow thickness.
-                   S_hsnow(I,J) =     AREA(I,J,2,bi,bj)* (
-     &                  SnowAccumulationRateOverIce(I,J) - 
-     &                  SnowMeltRateFromSurface(I,J)     ) 
-
-C---+----1----+----2----+----3----+----4----+----5----+----6----+----7-|--+----|
-                  IF ((AREA(I,J,2,bi,bj) .GT. 0.0 _d 0) .OR. 
-     &                (S_h(I,J)          .GT. 0.0 _d 0)       ) THEN
-
-                      SID_Shs(I,J,bi,bj) = S_hsnow(I,J)
-
-                      SID_SHML(I,J,bi,bj) = IceGrowthRateMixedLayer(I,J)
-
-                      SID_SHEI(I,J,bi,bj) = 
-     &                  NetExistingIceGrowthRate(I,J)*AREA(I,J,2,bi,bj)
-
-                      SID_SHOW(I,J,bi,bj) = 
-     &                  (1. -AREA(I,J,2,bi,bj))*
-     &                  IceGrowthRateOpenWater(I,J)
-                  ENDIF
-C---+----1----+----2----+----3----+----4----+----5----+----6----+----7-|--+----|
+c     Both the accumulation and melt rates are in terms
+c     of actual snow thickness.  As with HEFF,
+c     multiplying actual snow depth by AREA converts to
+c     mean snow thickness.
+                  S_hsnow(I,J) =     AREANm1(I,J,bi,bj)* (
+     &               SnowAccRateOverIce(I,J) - 
+     &               SnowMeltRateFromSurface(I,J)     ) 
 
                ENDDO
             ENDDO
 
+
+#ifdef ALLOW_SALT_PLUME
+C---  +----1----+----2----+----3----+----4----+----5----+----6----+----7-|--+----|
+C     Calculate the flux of salt to be treated with the salt plume
+c     parameterization.
+            IF (useSALT_PLUME) THEN
+               DO J=1,sNy
+                  DO I=1,sNx
+
+c     It is assumed that ice production in leads can generate
+c     salt plumes.  The fraction of the salt sent to the plume package
+c     from ice produced in leads (defined as the open water
+c     fraction) is a nonlinear function of ice concentration, AREA.
+c     
+c     Specifically, the function is a sigmoid with range and 
+c     domain {0,1}.  The function, f(AREA), has a single free parameter,
+c     SEAICE_plumeInflectionPoint, the inflection point of the curve.  
+c     By construction, the function has the following properties:
+c     f(1) \approx 1.0
+c     f(SEAICE_plumeInflectionPoint) = 0.5
+c     f(0) \approx 0.0 (when SEAICE_plumeInflectionPoint \geq 0.5)
+c     f(0) > 0.0 (when SEAICE_plumeInflectionPoint < 0.5)
+c     
+c     As AREA --> 1, the open water fraction occurs
+c     in narrow leads, new ice production become spatially non-uniform,
+c     and the assumptions motivating KPP no longer hold.  To treat
+c     overturning in a more physically realistic way, the salt produced
+c     in the leads should be sent to depth via the plume package.  To assure 
+c     only narrow leads generate plumes, choose a SEAICE_plumeInflectionPoint 
+c     of > 0.8.
+
+c     Ensure that there is already ice present or that the total ice
+c     ice tendency term is positive.  We don't want to release 
+c     salt if sea ice is not established in the cell.
+
+                     IF ((AREANm1(I,J,bi,bj) .GT. ZERO) .OR. 
+     &                  (S_h(I,J)           .GT. ZERO)) THEN
+                        
+                        leadPlumeFraction(I,J) = 
+     &                     (ONE + EXP( ( SEAICE_plumeInflectionPoint- 
+     &                     AREANm1(I,J,bi,bj)
+     &                     ) * 5._d 0/
+     &                     (ONE - SEAICE_plumeInflectionPoint)
+     &                     )
+     &                     )**(-ONE) 
+                        
+c     Only consider positive ice growth rate in leads
+c     for the salt plume flux.
+                        IceGrowthRateInLeads(I,J) = max( ZERO,
+     &                     (ONE - AREANm1(I,J,bi,bj)) * 
+     &                     IceGrowthRateOpenWater(I,J))
+
+                        saltPlumeFlux(I,J,bi,bj) = 
+     &                     leadPlumeFraction(I,J) *
+     &                     HEFFM(I,J,bi,bj)*IceGrowthRateInLeads(I,J)*
+     &                     ICE2WATR*rhoConstFresh*
+     &                     (salt(I,J,kSurface,bi,bj) - 
+     &                     SEAICE_salinity_fixed)
+                        
+                     ENDIF
+
+                  ENDDO         !/ Use plume 
+               ENDDO            !/ j
+            ENDIF               !/ i
+
+#endif /* ALLOW_SALT_PLUME */
+
+
 #ifdef ALLOW_AUTODIFF_TAMC
-CADJ STORE area(:,:,:,bi,bj) = comlev1_bibj, 
-CADJ &                         key = iicekey, byte = isbyte
-CADJ STORE heff(:,:,:,bi,bj) = comlev1_bibj, 
-CADJ &                         key = iicekey, byte = isbyte
-CADJ STORE hsnow(:,:,bi,bj)  = comlev1_bibj, 
-CADJ &                         key = iicekey, byte = isbyte
-CADJ STORE S_h(:,:)         = comlev1_bibj, 
-CADJ &                         key = iicekey, byte = isbyte
-CADJ STORE S_hsnow(:,:)      = comlev1_bibj, 
-CADJ &                         key = iicekey, byte = isbyte
+C     ADJ STORE S_h(:,:)         = comlev1_bibj, 
+C     ADJ &                        key = iicekey, byte = isbyte
+C     ADJ STORE S_hsnow(:,:)     = comlev1_bibj, 
+C     ADJ &                        key = iicekey, byte = isbyte
 #endif /* ALLOW_AUTODIFF_TAMC */
 
+
+C---  +----1----+----2----+----3----+----4----+----5----+----6----+----7-|--+----|
+C     Calculate the ice area derivative (S_a)
             DO J=1,sNy
                DO I=1,sNx
-                IF (maskC(I,J,kSurface,bi,bj).NE.0.) THEN
-                  S_a(I,J) =  0.0 
 
-C                 If I need to divide by heff, divide by this
-                  HEFF_MIN = MAX(0.01, HEFF(I,J,2,bi,bj))
+c     In the following, time derivatives of AREA require
+c     divisions by HEFF. To prevent sensitivity blow up when
+c     HEFF --> 0, we divide by an approximation to HEFF, HEFF*:
+c     
+c     HEFF* = sqrt(HEFF^2 + heff_min^2)
+c     Where heff_min is implicitly defined as 0.1 m. 
+c     
+c     HEFF* is defined as a hyperbola with slope = 1 and 
+c     y-intercept of heff_min.  The gradient of 1/HEFF* is 
+c     well-behaved (correct sign) and deviates from 1/HEFF 
+c     significantly only when HEFF --> 0.
 
-C     IF THE OPEN WATER GROWTH RATE IS POSITIVE 
-C     THEN EXTEND ICE AREAL COVER, S_a > 0
+                  IF (AREANm1(I,J,bi,bj) .GT. ZERO) THEN
+                     HEFF_MIN = SQRT( 0.01 _d 0 + 
+     &                  HEFFNm1(I,J,bi,bj) * HEFFNm1(I,J,bi,bj) )
+                  ELSE
+c     Just in case somehow we miss a case, we want to divide
+c     by a sensible number, here 10 cm.
+                     HEFF_MIN = max(HEFFNm1(I,J,bi,bj), 0.1 _d 0)
+                  ENDIF
 
-C     TWO CASES, IF THERE IS ALREADY ICE PRESENT THEN EXTEND THE AREA USING THE 
-C     OPEN WATER GROWTH RATE.  IF THERE IS NO ICE PRESENT DO NOT EXTEND THE ICE
-C     UNTIL THE NET ICE THICKNESS RATE IS POSITIVE.  I.E. IF OVERALL THE ICE 
-C     WOULD BE THINNING THEN THE NEW ICE WILL IMMEDIATLEY BE LOST. DO NOT GROW IT
+c     Caculate the ice area growth rate from the open water fluxes.
+c     First, determine whether the open water growth rate is positive or
+c     negative.  If positive, make sure that ice is present or that the 
+c     net ice thickness growth rate is positive before extending 
+c     the ice cover across the grid cell.
 
-                  IF (IceGrowthRateOpenWater(I,J) .GT. 0.0 _d 0) THEN
+                  IF (IceGrowthRateOpenWater(I,J) .GT. ZERO) THEN
 
-                     S_a_from_IGROW(I,J) = (ONE - AREA(I,J,2,bi,bj))*
-     &                      IceGrowthRateOpenWater(I,J)/HO
+c     Determine which hemisphere for hemisphere-dependent so-called
+c     "lead closing variable", HO
 
-                     IF (AREA(I,J,2,bi,bj) .GT. 0.0 _d 0 )THEN
-C                       If there is some ice already then we just extend it
-                        S_a(I,J) = S_a(I,J) + S_a_from_IGROW(I,J)
+                     IF ( YC(I,J,bi,bj) .LT. ZERO ) THEN
+                        S_a_from_IGROW(I,J) = (ONE-AREANm1(I,J,bi,bj))*
+     &                     IceGrowthRateOpenWater(I,J)/HO_south
                      ELSE
-C                       Make sure the total ice growth rate is positive before
-C                       creating new ice area for the first time....
-                        IF (S_h(I,J) .GT. 0) THEN
-                           S_a(I,J) = S_a(I,J) + S_a_from_IGROW(I,J)
-                        ENDIF
+                        S_a_from_IGROW(I,J) = (ONE-AREANm1(I,J,bi,bj))*
+     &                     IceGrowthRateOpenWater(I,J)/HO
                      ENDIF
-                  ELSE !* THE OPEN WATER GROWTH RATE IS NEGATIVE !*
-C                   Only melt through the open water if we have some 
-C                   exisiting ice (A>0, H>0),  we already know that the
-C                   growth rate here is negative.
-                    IF ( (AREA(I,J,2,bi,bj).GT. 0. _d 0 ) .AND.
-     &                   (HEFF(I,J,2,bi,bj).GT. 0. _d 0 ) ) THEN
+
+c     If there is already ice, add to S_a
+                     IF (AREANm1(I,J,bi,bj) .GT. ZERO) THEN
+                        S_a(I,J) = S_a(I,J) + S_a_from_IGROW(I,J)
+
+c     otherwise, add to S_a only if the net ice growth rate
+c     is positive
+                     ELSE IF (S_h(I,J) .GT. ZERO) THEN
+                        S_a(I,J) = S_a(I,J) + S_a_from_IGROW(I,J)
+                     ENDIF
+
+                  ELSE IF ( AREANm1(I,J,bi,bj) .GT. ZERO) THEN
+c     The open water growth rate is negative - contract the ice cover.
 
                      S_a(I,J) = S_a(I,J) +
-     &                    AREA(I,J,2,bi,bj)/(2.0*HEFF_MIN)*
-     &                    IceGrowthRateOpenWater(I,J)*
-     &                    (1-AREA(I,J,2,bi,bj))
-
-c     &                   AREA(I,J,2,bi,bj)/(2.0*HEFF(I,J,2,bi,bj))*
-c     &                   IceGrowthRateOpenWater(I,J)*
-c     &                   (1-AREA(I,J,2,bi,bj))
-                    ELSE
-                       S_a(I,J) = S_a(I,J) +  0.0 _d 0
-                    ENDIF
-                  ENDIF
-
-C---+----1----+----2----+----3----+----4----+----5----+----6----+----7-|--+----|
-                  SID_SAOW(I,J,bi,bj) = S_a(I,J)
-C---+----1----+----2----+----3----+----4----+----5----+----6----+----7-|--+----|
-
-
-C     REDUCE THE ICE COVER IF ICE IS PRESENT
-                  IF ( (IceGrowthRateMixedLayer(I,J) .LE. 0. _d 0) .AND.
-     &                 (AREA(I,J,2,bi,bj).GT. 0. _d 0) .AND.
-     &                 (HEFF(I,J,2,bi,bj).GT. 0. _d 0) ) THEN
-
-                     S_a(I,J) = S_a(I,J) + 
-     &                    AREA(I,J,2,bi,bj)/(2.0*HEFF_MIN)*
-     &                    IceGrowthRateMixedLayer(I,J)
-
-c     &                   AREA(I,J,2,bi,bj)/(2.0*HEFF(I,J,2,bi,bj))*
-
-C---+----1----+----2----+----3----+----4----+----5----+----6----+----7-|--+----|
-                     SID_SAML(I,J,bi,bj) =
-     &                    AREA(I,J,2,bi,bj)/(2.0*HEFF_MIN)*
-     &                    IceGrowthRateMixedLayer(I,J)
-
-c     &                   AREA(I,J,2,bi,bj)/(2.0*HEFF(I,J,2,bi,bj))*
-C---+----1----+----2----+----3----+----4----+----5----+----6----+----7-|--+----|
+     &                  AREANm1(I,J,bi,bj)/(2. _d 0*HEFF_MIN)*
+     &                  IceGrowthRateOpenWater(I,J)*
+     &                  (ONE - AREANm1(I,J,bi,bj))
 
                   ELSE
-                     S_a(I,J) = S_a(I,J) +  0.0 _d 0 
+                     S_a(I,J) = S_a(I,J) +  0. _d 0
                   ENDIF
 
-C     REDUCE THE ICE COVER IF ICE IS PRESENT
-                  IF ( (NetExistingIceGrowthRate(I,J) .LE. 0. _d 0).AND.
-     &                 (AREA(I,J,2,bi,bj).GT. 0. _d 0) .AND.
-     &                 (HEFF(I,J,2,bi,bj).GT. 0. _d 0) ) THEN
+C     Contract ice area if IceGrowthRateMixedLayer is negative
+c     and ice is present
+                  IF ( (IceGrowthRateMixedLayer(I,J) .LE. ZERO) .AND. 
+     &               (AREANm1(I,J,bi,bj) .GT. ZERO) ) THEN
 
                      S_a(I,J) = S_a(I,J) +
-     &                   AREA(I,J,2,bi,bj)/(2.0*HEFF_MIN)*
-     &                   NetExistingIceGrowthRate(I,J)*AREA(I,J,2,bi,bj)
-
-C---+----1----+----2----+----3----+----4----+----5----+----6----+----7-|--+----|
-                     SID_SAEI(I,J,bi,bj) =
-     &                   AREA(I,J,2,bi,bj)/(2.0*HEFF_MIN)*
-     &                   NetExistingIceGrowthRate(I,J)*AREA(I,J,2,bi,bj)
-C---+----1----+----2----+----3----+----4----+----5----+----6----+----7-|--+----|
+     &                  AREANm1(I,J,bi,bj)/(2. _d 0 *HEFF_MIN)*
+     &                  IceGrowthRateMixedLayer(I,J)
 
                   ELSE
-                     S_a(I,J) = S_a(I,J) +  0.0 _d 0
+                     S_a(I,J) = S_a(I,J) +  0. _d 0
                   ENDIF
 
+C     Contract ice area if NetExistingIceGrowthRate is negative
+c     and ice is present
+                  IF ( (NetExistingIceGrowthRate(I,J) .LE. ZERO) .AND. 
+     &               (AREANm1(I,J,bi,bj) .GT. ZERO)) THEN
 
-                ENDIF !/ MASK  
-               ENDDO
-            ENDDO
-       
-                 
+                     S_a(I,J) = S_a(I,J) +
+     &                  AREANm1(I,J,bi,bj)/(2. _d 0 * HEFF_MIN)*
+     &                  NetExistingIceGrowthRate(I,J)*AREANm1(I,J,bi,bj)
+
+                  ELSE
+                     S_a(I,J) = S_a(I,J) +  0. _d 0
+                  ENDIF
+                  
+               ENDDO            !/ i
+            ENDDO               !/ j
+            
 
 #ifdef ALLOW_AUTODIFF_TAMC
-CADJ STORE heff(:,:,:,bi,bj) = comlev1_bibj, 
-CADJ &                         key = iicekey, byte = isbyte
-CADJ STORE hsnow(:,:,bi,bj)  = comlev1_bibj, 
-CADJ &                         key = iicekey, byte = isbyte
-CADJ STORE S_a(:,:)          = comlev1_bibj, 
-CADJ &                         key = iicekey, byte = isbyte
-CADJ STORE S_h(:,:)          = comlev1_bibj, 
-CADJ &                         key = iicekey, byte = isbyte
-CADJ STORE f_ao(:,:)         = comlev1_bibj, 
-CADJ &                         key = iicekey, byte = isbyte
-CADJ STORE qswi(:,:)         = comlev1_bibj, 
-CADJ &                         key = iicekey, byte = isbyte
-CADJ STORE qswo(:,:)         = comlev1_bibj, 
-CADJ &                         key = iicekey, byte = isbyte
-CADJ STORE area(:,:,:,bi,bj) = comlev1_bibj, 
-CADJ &                         key = iicekey, byte = isbyte
+C     ADJ STORE heff(:,:,bi,bj)   = comlev1_bibj, 
+C     ADJ &                         key = iicekey, byte = isbyte
+C     ADJ STORE hsnow(:,:,bi,bj)  = comlev1_bibj, 
+C     ADJ &                         key = iicekey, byte = isbyte
+C     ADJ STORE S_a(:,:)          = comlev1_bibj, 
+C     ADJ &                         key = iicekey, byte = isbyte
+C     ADJ STORE S_h(:,:)          = comlev1_bibj, 
+C     ADJ &                         key = iicekey, byte = isbyte
+C     ADJ STORE f_ao(:,:)         = comlev1_bibj, 
+C     ADJ &                         key = iicekey, byte = isbyte
+C     ADJ STORE qswi(:,:)         = comlev1_bibj, 
+C     ADJ &                         key = iicekey, byte = isbyte
+C     ADJ STORE qswo(:,:)         = comlev1_bibj, 
+C     ADJ &                         key = iicekey, byte = isbyte
+C     ADJ STORE area(:,:,bi,bj)   = comlev1_bibj, 
+C     ADJ &                         key = iicekey, byte = isbyte
 #endif
 
-C     ACTUALLY CHANGE THE AREA AND THICKNESS
+
+C---  +----1----+----2----+----3----+----4----+----5----+----6----+----7-|--+----|
+C     Update AREA, HEFF, and HSNOW using the time derivativees
+c     calculated above.
             DO J=1,sNy
                DO I=1,sNx
-                  AREA(I,J,1,bi,bj) = AREA(I,J,2,bi,bj) + 
-     &                 SEAICE_deltaTtherm * S_a(I,J)
-C     SET LIMIT ON AREA
-                  AREA(I,J,1,bi,bj) = MIN(1.,AREA(I,J,1,bi,bj))
-                  AREA(I,J,1,bi,bj) = MAX(0.,AREA(I,J,1,bi,bj))
+
+                  AREA(I,J,bi,bj) = AREANm1(I,J,bi,bj) + 
+     &               SEAICE_deltaTtherm * S_a(I,J)
+
+                  HEFF(I,J,bi,bj) = HEFFNm1(I,J,bi,bj) +
+     &               SEAICE_deltaTTherm * S_h(I,J)
+
+                  HSNOW(I,J,bi,bj) = HSNOW(I,J,bi,bj) +
+     &               SEAICE_deltaTTherm * S_hsnow(I,J)
 
                ENDDO
             ENDDO
             
+            
 #ifdef ALLOW_AUTODIFF_TAMC
-CADJ STORE area(:,:,:,bi,bj) = comlev1_bibj, 
-CADJ &                         key = iicekey, byte = isbyte
+C     ADJ STORE area(:,:,bi,bj)  = comlev1_bibj, 
+C     ADJ &                        key = iicekey, byte = isbyte
+C     ADJ STORE heff(:,:,bi,bj)  = comlev1_bibj, 
+C     ADJ &                        key = iicekey, byte = isbyte
+C     ADJ STORE hsnow(:,:,bi,bj) = comlev1_bibj, 
+C     ADJ &                        key = iicekey, byte = isbyte
 #endif
+
+
+C---  +----1----+----2----+----3----+----4----+----5----+----6----+----7-|--+----|
+C     Sanity check on HEFF, HSNOW, and AREA:  After updating
+c     the ice state with the time derivatives it is possible that
+c     an unphysical ice state occurs (e.g., zero/negative AREA 
+c     with positive HEFF and/or HSNOW).
+
+c     Note: the zeroing out negative HEFF and/or HSNOW here will
+c     not violate mass/energy conservation.  Energy and mass 
+c     fluxes are calculated based on the actual change in ice
+c     and snow volume between time levels N-1 and N.
             DO J=1,sNy
                DO I=1,sNx
-                IF (maskC(I,J,kSurface,bi,bj).NE.0.) THEN
-                  HEFF(I,J,1,bi,bj) = HEFF(I,J,2,bi,bj) +
-     &                 SEAICE_deltaTTherm * S_h(I,J)
-c                 if we end up with negative ice volume, we 
-c                 need to recalculate f_mi.  It needs a little
-c                 bit put back...
 
-                  F_mi_act(I,J) = F_mi(I,J)
-C---+----1----+----2----+----3----+----4----+----5----+----6----+----7-|--+----|
-                  IF (HEFF(I,J,1,bi,bj) .LT. 0.0) THEN
-                      F_mi_act(I,J) = F_mi(I,J) - 
-     &                        HEFF(I,J,1,bi,bj)/SEAICE_deltaTTherm /QI
-                  ENDIF
-C---+----1----+----2----+----3----+----4----+----5----+----6----+----7-|--+----|
+                  HEFF(I,J,bi,bj)  = HEFFM(I,J,bi,bj) *
+     &               MAX(ZERO,HEFF(I,J,bi,bj)) 
 
-                  HEFF(I,J,1,bi,bj) = MAX(0.0, HEFF(I,J,1,bi,bj))
+                  HSNOW(I,J,bi,bj) = HEFFM(I,J,bi,bj) * 
+     &               MAX(ZERO,HSNOW(I,J,bi,bj)) 
 
-                  HSNOW(I,J,bi,bj) = HSNOW(I,J,bi,bj) +
-     &                 SEAICE_deltaTTherm * S_hsnow(I,J)
-                  HSNOW(I,J,bi,bj)  = MAX(0.0, HSNOW(I,J,bi,bj))
+                  AREA(I,J,bi,bj) = MIN(1.0 _d 0, AREA(I,J,bi,bj)
 
-                  IF (AREA(I,J,1,bi,bj) .GT. 0.0) THEN
-                      HICE_ACTUAL(I,J) = 
-     &                   HEFF(I,J,1,bi,bj)/AREA(I,J,1,bi,bj)
-                      HSNOW_ACTUAL(I,J) = 
-     &                    HSNOW(I,J,bi,bj)/AREA(I,J,1,bi,bj)
-                  ELSE
-                      HICE_ACTUAL(I,J) = 0.0
-                      HSNOW_ACTUAL(I,J) = 0.0
-                  ENDIF
-                 ENDIF !/MASK 
-               ENDDO
-            ENDDO
+                  AREA(I,J,bi,bj)  = HEFFM(I,J,bi,bj) *
+     &               MAX(ZERO,AREA(I,J,bi,bj)) 
+
+c     If either HEFF or AREA are zero, make all other ice
+c     state variables zero.
+                  IF ((HEFF(I,J,bi,bj) .EQ. ZERO) .OR. 
+     &               (AREA(I,J,bi,bj) .EQ. ZERO)) THEN 
+
+                     AREA(I,J,bi,bj)  =  0. _d 0
+                     HSNOW(I,J,bi,bj) =  0. _d 0
+                     HEFF(I,J,bi,bj)  =  0. _d 0
+
+                     HICE_ACTUAL(I,J)   = 0. _d 0
+                     HSNOW_ACTUAL(I,J)  = 0. _d 0
+
+                  ELSE          !/ Heff and Area > 0
+
+c     Caclulate the actual (not mean) thicknesses of the 
+c     ice and any snow in the grid cell 
+                     HICE_ACTUAL(I,J)  = 
+     &                  HEFF(I,J,bi,bj)/AREA(I,J,bi,bj)
+
+                     HSNOW_ACTUAL(I,J) = HSNOW(I,J,bi,bj)/
+     &                  AREA(I,J,bi,bj)
+
+                  ENDIF 
+
+               ENDDO            !/ I
+            ENDDO               !/ J
+
 
 #ifdef ALLOW_AUTODIFF_TAMC
-CADJ STORE area(:,:,:,bi,bj) = comlev1_bibj, 
-CADJ &                         key = iicekey, byte = isbyte
-CADJ STORE heff(:,:,:,bi,bj) = comlev1_bibj, 
-CADJ &                         key = iicekey, byte = isbyte
-#endif /* ALLOW_AUTODIFF_TAMC */
+C     ADJ STORE area(:,:,bi,bj)  = comlev1_bibj, 
+C     ADJ &                        key = iicekey, byte = isbyte
+C     ADJ STORE heff(:,:,bi,bj)  = comlev1_bibj, 
+C     ADJ &                        key = iicekey, byte = isbyte
+C     ADJ STORE hsnow(:,:,bi,bj) = comlev1_bibj, 
+C     ADJ &                        key = iicekey, byte = isbyte
+#endif
 
-c     constrain area is no thickness and vice versa.
+
+C---  +----1----+----2----+----3----+----4----+----5----+----6----+----7-|--+----|
             DO J=1,sNy
                DO I=1,sNx
-                  IF (HEFF(I,J,1,bi,bj)  .LE. 0.0 .OR.
-     &                 AREA(I,J,1,bi,bj) .LE. 0.0) THEN
 
-C---+----1----+----2----+----3----+----4----+----5----+----6----+----7-|--+----|
-c                    the area that we are losing because the thickness
-c                    has gone to zero         
-                     SID_DUM3(I,J,bi,bj) =
-     &                   MIN(-AREA(I,J,1,bi,bj)/SEAICE_deltaTtherm, 0.0)
 
-c                    the heff we are losing because the area has gone
-c                    to zero
-                     SID_DUM4(I,J,bi,bj) = 
-     &                   MIN(-HEFF(I,J,1,bi,bj)/SEAICE_deltaTtherm, 0.0)
-C---+----1----+----2----+----3----+----4----+----5----+----6----+----7-|--+----|
-                     
-                     AREA(I,J,1,bi,bj)       = 0.0
-                     HEFF(I,J,1,bi,bj)       = 0.0
-                     HICE_ACTUAL(I,J)        = 0.0
-                     HSNOW(I,J,bi,bj)        = 0.0
-                     HSNOW_ACTUAL(I,J)       = 0.0
-
-                  ENDIF
-
-               ENDDO
-            ENDDO
- 
-           
-#ifdef ALLOW_AUTODIFF_TAMC
-CADJ STORE area(:,:,:,bi,bj) = comlev1_bibj, 
-CADJ &                         key = iicekey, byte = isbyte
-CADJ STORE heff(:,:,:,bi,bj) = comlev1_bibj, 
-CADJ &                         key = iicekey, byte = isbyte
-#endif /* ALLOW_AUTODIFF_TAMC */
-
-            DO J=1,sNy
-               DO I=1,sNx
-                IF (maskC(I,J,kSurface,bi,bj).NE.0.) THEN
-c     The amount of new mean thickness we expect to grow
+#ifdef SEAICE_DEBUG
+c     The expected amount of new mean ice volume
                   ExpectedIceVolumeChange(I,J)  = S_h(I,J) *
-     &                 SEAICE_deltaTtherm
+     &               SEAICE_deltaTtherm
 
+c     The expected amount of new mean snow volume
                   ExpectedSnowVolumeChange(I,J) = S_hsnow(I,J)*
-     &                 SEAICE_deltaTtherm
+     &               SEAICE_deltaTtherm
 
-c     THE EFFECTIVE SHORTWAVE HEATING RATE
+#endif
+
+c     The effective shortwave radiation (after modification
+c     by ice cover).
 #ifdef SHORTWAVE_HEATING
                   QSW(I,J,bi,bj)  =
-     &                 QSWI(I,J)  * (     AREA(I,J,2,bi,bj)) +
-     &                 QSWO(I,J)  * (1. - AREA(I,J,2,bi,bj))
+     &               QSWI(I,J)  * (      AREANm1(I,J,bi,bj)) +
+     &               QSWO(I,J)  * (ONE - AREANm1(I,J,bi,bj))
 #else
                   QSW(I,J,bi,bj) = 0. _d 0
 #endif
 
-                  ActualNewTotalVolumeChange(I,J) = 
-     &                 HEFF(I,J,1,bi,bj) - HEFF(I,J,2,bi,bj)
+c     The change in mean ice thickness over the time step. 
+c     Note, this quantity may not equal S_h*SEAICE_deltaTtherm as
+c     AREA or HEFF may end up zero or negative which requires that both 
+c     be reset to ZERO.
+                  ActualIceVolumeChange(I,J) = 
+     &               HEFF(I,J,bi,bj) - HEFFNm1(I,J,bi,bj)
 
-c     The net average snow thickness melt that is actually realized. e.g.
-c     hsnow_orig  = 0.25 m (e.g. 1 m of ice over a cell 1/4 covered in snow)
-c     hsnow_new   = 0.20 m
-c     snow accum  = 0.05 m
-c            melt = 0.25 + 0.05 - 0.2 = 0.1 m 
-
-c     since this is in mean snow thickness it might have been  0.4 of actual 
-c     snow thickness over the 1/4 of the cell which is ice covered.
+c     The depth of lost mean snow thickness.
                   ActualNewTotalSnowMelt(I,J) = 
-     &                 HSNOW_ORIG(I,J) +
-     &                 SnowAccumulationOverIce(I,J) -
-     &                 HSNOW(I,J,bi,bj)
+     &               HSNOW_ORIG(I,J) +
+     &               SnowAccOverIce(I,J) -
+     &               HSNOW(I,J,bi,bj)
 
-c     The latent heat of fusion of the new ice
-                  EnergyInNewTotalIceVolume(I,J) = 
-     &                 ActualNewTotalVolumeChange(I,J)/QI
+c     The energy required to melt or form the new ice.
+                  EnergyInNewIceVolume(I,J) = 
+     &               ActualIceVolumeChange(I,J)/QI
 
-c     This is the net energy flux out of the ice+ocean system
-c     Remember -----
-c     F_ia_net : 0 if under freezing conditions (F_c < 0)
-c                The sum of the non-conductive surfice ice fluxes otherwise
-c
-c     F_io_net : The conductive fluxes under freezing conditions (F_c < 0)
-c                0 under melting conditions (no energy flux from ice to
-c                ocean)
-c
-c     So if we are freezing, F_io_net is the conductive flux and there 
-c     is energy balance at ice surface, F_ia_net =0.  If we are melting
-c     There is a convergence of energy into the ice from above
-                  NetEnergyFluxOutOfSystem(I,J) = SEAICE_deltaTtherm *
-     &               (AREA(I,J,2,bi,bj) * 
-     &               (F_ia_net(I,J) + F_io_net(I,J) + QSWI(I,J))
-     &         +     (1.0 - AREA(I,J,2,bi,bj)) * 
-     &                F_ao(I,J))
+c     The energy divergence (J/m^2) out of the ocean.  This
+c     includes the fluxes to the base of the seaice (F_io_net)
+c     and shortwave radiation penetrating through the ice (QSWI)
+c     weighted by ice-covered fraction, and the air-sea
+c     heat fluxes weighted by the open water fraction (F_ao).
+                  NetEnergyOutOfOcean(I,J) = SEAICE_deltaTtherm *
+     &               (AREANm1(I,J,bi,bj) * (F_io_net(I,J) + QSWI(I,J))
+     &               +     (ONE - AREANm1(I,J,bi,bj)) *  F_ao(I,J))
 
-c     THE QUANTITY OF HEAT WHICH IS THE RESIDUAL TO THE QUANTITY OF 
-c     ML temperature.  If the net energy flux is exactly balanced by the 
-c     latent energy of fusion in the new ice created then we won't 
-c     change the ML temperature at all.
+c     The net energy divergence from the snow/ice surface.
+c     Note, when TICE < TMELT, F_ia_net = 0 (i.e., an energy balance
+c     condition is achieved at the snow/ice surface.
+                  NetEnergyOutOfIce(I,J) = SEAICE_deltaTTherm *
+     &               AREANm1(I,J,bi,bj) * F_ia_net(I,J)
 
-                  ResidualHeatOutOfSystem(I,J) = 
-     &             NetEnergyFluxOutOfSystem(I,J) -
-     &             EnergyInNewTotalIceVolume(I,J)
+c     The energy divergence (J/m^2) from the ocean which is 
+c     not offset by the latent energy of fusion of any newly created
+c     or melted ice.  This residual energy loss will reduce the 
+c     seawater temperature. 
+                  ResidualEnergyOutOfOcean(I,J) = 
+     &               NetEnergyOutOfIce(I,J) + 
+     &               NetEnergyOutOfOcean(I,J) -
+     &               EnergyInNewIceVolume(I,J)
 
-C     NOW FORMULATE QNET, which time LEVEL, ORIG 2.
-C     THIS QNET WILL DETERMINE THE TEMPERATURE CHANGE OF THE MIXED LAYER
-C     QNET IS A DEPTH AVERAGED HEAT FLUX FOR THE OCEAN COLUMN
-C     BECAUSE OF THE 
+C     The energy flux (W/m^2) associated with the above residual 
+c     energy divgence.  
                   QNET(I,J,bi,bj) =
-     &             ResidualHeatOutOfSystem(I,J) / SEAICE_deltaTtherm
+     &               ResidualEnergyOutOfOcean(I,J) / SEAICE_deltaTtherm
 
 
-c    Like snow melt, if there is melting, this quantity is positive.
-c    The change of freshwater content is per unit area over the entire 
-c    cell, not just over the ice covered bits.  This term is only used
-c    to calculate freshwater fluxes for the purpose of changing the 
-c    salinity of the liquid cell.  In the case of non-zero ice salinity,
-c    the amount of freshwater is reduced by the ratio of ice salinity
-c    to water cell salinity. 
-           IF  (salt(I,J,kSurface,bi,bj) .GE. SEAICE_salinity ) THEN
+C---  +----1----+----2----+----3----+----4----+----5----+----6----+----7-|--+----|
+c     The change of freshwater content  per unit area over the entire
+c     cell, not just over the ice covered bits.  This term is only used
+c     to calculate freshwater fluxes for the purpose of changing the
+c     salinity of the liquid cell. 
 
-#ifdef FORBID_SEAICE_MELTWATER_ENHANCEMENT_MECHANISM
-c            if we have lost volume, for whatever reason, do not count
-c            the loss as a positive freshwater flux to the surface
-c            when this FORBID flag is operational
-c
-c            note : S_h(I,J) may be positive but we may still lose volume
-c            from a loss of area
-c
-             IF (ActualNewTotalVolumeChange(I,J) .LE. 0.0) THEN
-                 FreshwaterContribFromIce(I,J) = 0.0
-             ELSE
-                 FreshwaterContribFromIce(I,J) = 
-     &             -ActualNewTotalVolumeChange(I,J)*RHOI/RHOFW*
-     &             (1.0 - SEAICE_salinity/salt(I,J,kSurface,bi,bj))
-             ENDIF
-#else
+c                 If the seawater salinity is less than SEAICE_salinity_fixed
+c                 or zero, assume that ice is as saline as the seawater.
+c                 salinity
+                  IF  ((salt(I,J,kSurface,bi,bj) .EQ. ZERO) .OR. 
+     &                 (salt(I,J,kSurface,bi,bj) .LE. 
+     &                   SEAICE_salinity_fixed)) THEN
 
-                 FreshwaterContribFromIce(I,J) = 
-     &             -ActualNewTotalVolumeChange(I,J)*RHOI/RHOFW*
-     &             (1.0 - SEAICE_salinity/salt(I,J,kSurface,bi,bj))
-#endif
+                     FreshwaterContribFromIce(I,J) = ZERO 
+                 
+c                 If seawater salinity is greater than the specified
+c                 ice salinity, the freshwater contribution from ice is
+c                 the volume of freshwater required to mix with
+c                 seawater to yield sea ice having salinity
+c                 SEAICE_salinity_fixed.  Another way of looking at this
+c                 formulation is to assume that the sea ice is a mixture 
+c                 of a volume of freshwater and volume of water with 
+c                 salinity "salt".  When ice grows (or melts), only the 
+c                 extraction (release) of the freshwater volume 
+c                 alters the seawater salinity.
+                  ELSEIF ( salt(I,J,kSurface,bi,bj) .GT. 
+     &                     SEAICE_salinity_fixed   )  THEN 
 
-           ELSE 
-C    If the liquid cell has a lower salinity than the specified
-c    salinity of sea ice then assume the sea ice is completely fresh
-                 FreshwaterContribFromIce(I,J) = 
-     &             -ActualNewTotalVolumeChange(I,J)*RHOI/RHOFW
-           ENDIF
+                       FreshwaterContribFromIce(I,J) =
+     &                   - ActualIceVolumeChange(I,J)*
+     &                   SEAICE_rhoICE/ RHOFW* (ONE - 
+     &                   SEAICE_salinity_fixed/salt(I,J,kSurface,bi,bj))
 
+                  ENDIF
 
-c    The freshwater contribution from snow comes only in the form of melt
-c    unlike ice, which takes freshwater upon growth and yields freshwater
-c    upon melt.  This is why the the actual new average snow melt was determined.
-c    In m/m^2 over the entire cell.
-
-#ifdef FORBID_SEAICE_MELTWATER_ENHANCEMENT_MECHANISM
-c          if we have actually melt any snow for any reason,
-c          do not count the loss as a positive freshwater flux to
-c          the surface when this FORBID flag is operational
-c       
-c          note: S_hsnow could be positive but because of loss
-c                of ice area or ice thickness we may still have
-c                to lose the snow.
-          
-           IF (ActualNewTotalSnowMelt(I,J) .GE. 0.0) THEN
-                  FreshwaterContribFromSnowMelt(I,J) = 0.0
-           ELSE
+c     The freshwater contribution from snow comes from melt.
                   FreshwaterContribFromSnowMelt(I,J) =
-     &                 ActualNewTotalSnowMelt(I,J)*RHOSN/RHOFW
-           ENDIF
-#else
-                  FreshwaterContribFromSnowMelt(I,J) =
-     &                 ActualNewTotalSnowMelt(I,J)*RHOSN/RHOFW
-#endif
-
-     
-
-c    This seems to be in m/s, original time level 2 for area
-c    Only the precip and evap need to be area weighted.  The runoff
-c    and freshwater contribs from ice and snow melt are already mean
-c    weighted
+     &               ActualNewTotalSnowMelt(I,J)*SEAICE_rhoSnow/RHOFW
 
                   EmPmR(I,J,bi,bj)  = maskC(I,J,kSurface,bi,bj)*(
-     &                 ( EVAP(I,J,bi,bj)-PRECIP(I,J,bi,bj) )
-     &                 * ( ONE - AREA(I,J,2,bi,bj) )
-     &                 - PrecipRateOverIceSurfaceToSea(I,J)*
-     &                     AREA(I,J,2,bi,bj)
-     &                 - RUNOFF(I,J,bi,bj) 
-     &                 - (FreshwaterContribFromIce(I,J) +
-     &                    FreshwaterContribFromSnowMelt(I,J))/
-     &                    SEAICE_deltaTtherm) 
+     &               ( EVAP(I,J,bi,bj)-PRECIP(I,J,bi,bj) )
+     &               * ( ONE - AREANm1(I,J,bi,bj) )
+     &               - PrecipRateOverIceSurfaceToSea(I,J)*
+     &               AREANm1(I,J,bi,bj)
+#ifdef ALLOW_RUNOFF
+     &               - RUNOFF(I,J,bi,bj)
+#endif
+     &               - (FreshwaterContribFromIce(I,J) +
+     &               FreshwaterContribFromSnowMelt(I,J))/
+     &               SEAICE_deltaTtherm )*rhoConstFresh
+
+               ENDDO            !/ i
+            ENDDO               !/ j
 
 
-C---+----1----+----2----+----3----+----4----+----5----+----6----+----7-|--+----|
-C   BEGIN DIAGNOSTICS
-c          freshwater fluxes, ice snow (m/s)
-           SID_FC_I(I,J,bi,bj) =  
-     &          FreshwaterContribFromIce(I,J)/SEAICE_deltaTtherm
-
-           SID_FC_S(I,J,bi,bj) =  
-     &          FreshwaterContribFromSnowMelt(I,J)/SEAICE_deltaTtherm
-
-c          buoyancy fluxes, snet must be [PSU.m.s^-1]
-c          in EmPmR format. SID_FC_I > 0, must be made negative
-           SNET_ICE = -salt(I,J,kSurface,bi,bj)*(SID_FC_I(I,J,bi,bj) + 
-     &           SID_FC_S(I,J,bi,bj))
-
-           SNET_TOT = salt(I,J,kSurface,bi,bj)*EmPmR(I,J,bi,bj)
-
-c          this is the buoyancy flux associated with the 
-c          salinity fuxes from everything
-
-c          P > 0, EmPmR < 0, snet=salt*EmPmR < 0
-c          beta > 0, (drho/dS > 0), so 
-c          snet* beta  (-1)*(1) = -1.  so in order for a positive P
-c          to increase buoyancy, must multiply by -1, 
-           SID_SBFT(I,J,bi,bj)  =  -SNET_TOT*BETAZ(I,J)*Gravity
-
-c          this is the buoyancy flux associated with the 
-c          total temperature changing heat flux
-c          alpha < 0 (drho/dt < 0),
-c          qnet < 0 implies warming.  when qnet < 0,
-c          qnet * alpha  (-1)(-1) = 1, so buoyancy goes up
-           SID_EBFT(I,J,bi,bj)  =  QNET(I,J,bi,bj)*ALPHAZ(I,J)
-     &              /RHOP0(I,J)*Gravity/CPW
-
-c          only if there is ice can there be a buoyancy flux
-c          associated with ice.  F_mi is nonzero even with no 
-c          ice.  SNET_ICE shouldn't be, but this is just to 
-c          be safe
-           IF (AREA(I,J,2,bi,bj) .GT. 0.0) THEN
-c             this is the buoyancy flux associated with the 
-c             reducing the temperature from melting ice in the ML
-
-c             Note: IceGrowthRateMixedLayer(I,J) = F_mi(I,J)*QI
-c             ergo: f_mi always < 0, which implies cooling
-c             alpha < 0 (drho/dt < 0),
-c             so f_mi * alpha  (-1)*(-1) > 0
-c             ergo: must multipy by -1 for negative buoyancy
-c             flux when f_mi < 0
-              SID_EBFI(I,J,bi,bj)  = -F_mi(I,J)
-     &               * ALPHAZ(I,J)/RHOP0(I,J)*Gravity/CPW
-
-              SID_DUM8(I,J,bi,bj)  = -F_mi_act(I,J)
-     &               * ALPHAZ(I,J)/RHOP0(I,J)*Gravity/CPW
-
-c             this is the buoyancy flux associated with the 
-c             salinity fuxes from ice and snow
-              SID_SBFI(I,J,bi,bj)  = -SNET_ICE*BETAZ(I,J)*Gravity
-           ENDIF
-
-c          total ice related buoyancy flux
-
-           SID_DUM6(I,J,bi,bj) = SID_SBFT(I,J,bi,bj) + 
-     &                  SID_EBFT(I,J,bi,bj)
-
-           SID_DUM5(I,J,bi,bj) = SID_DUM8(I,J,bi,bj) +
-     &                  SID_SBFI(I,J,bi,bj)
-
-C   END DIAGNOSTICS
-C---+----1----+----2----+----3----+----4----+----5----+----6----+----7-|--+----|
-
-
-C     DO SOME DEBUGGING CALCULATIONS.  MAKE SURE SUMS ALL ADD UP.
 #ifdef SEAICE_DEBUG
+C---  +----1----+----2----+----3----+----4----+----5----+----6----+----7-|--+----|
+c     Debugging calculations
 
-C     THE SHORTWAVE ENERGY FLUX ABSORBED IN THE SURFACE LAYER
+            DO J=1,sNy
+               DO I=1,sNx
+
+C     Calcuate the shortwave flux absorbed in the upper ocean
+c     grid cell
 #ifdef SHORTWAVE_HEATING
-                  QSW_absorb_in_ML(I,J) = QSW(I,J,bi,bj)*
-     &              (1.0 - SWFRACB)
+                  QSW_absorb_in_first_layer(I,J) = QSW(I,J,bi,bj)*
+     &               (ONE - SWFRACB)
 #else 
 
-                  QSW_absorb_in_ML(I,J) = 0. _d 0
+                  QSW_absorb_in_first_layer(I,J) = 0. _d 0
 #endif
 
-C     THE SHORTWAVE ENERGY FLUX PENETRATING BELOW THE SURFACE LAYER
-                  QSW_absorb_below_ML(I,J) = 
-     &                 QSW(I,J,bi,bj) -  QSW_absorb_in_ML(I,J);
+C     Calcuate the sw flux beneath the upper ocean grid cell
+                  QSW_absorb_below_first_layer(I,J) = 
+     &               QSW(I,J,bi,bj) -  QSW_absorb_in_first_layer(I,J)
 
-                  PredictTempChgFromQSW(I,J) = 
-     &             - QSW_absorb_in_ML(I,J) * FLUX_TO_DELTA_TEMP
+                  PredTempChangeFromQSW(I,J) =
+     &               - QSW_absorb_in_first_layer(I,J)*FLUX_TO_DELTA_TEMP
 
-                  PredictTempChgFromOA_MQNET(I,J) = 
-     &            -(QNET(I,J,bi,bj) - QSWO(I,J))*(1. -AREA(I,J,2,bi,bj))
-     &             * FLUX_TO_DELTA_TEMP
+                  PredTempChangeFromOA_MQNET(I,J) = 
+     &               -(QNET(I,J,bi,bj)-QSWO(I,J)) * 
+     &               (ONE-AREANm1(I,J,bi,bj)) * FLUX_TO_DELTA_TEMP
 
-                  PredictTempChgFromF_IO_NET(I,J) = 
-     &             -F_io_net(I,J)*AREA(I,J,2,bi,bj)*FLUX_TO_DELTA_TEMP
+                  PredTempChangeFromF_IO_NET(I,J) = - F_io_net(I,J) *
+     &               AREANm1(I,J,bi,bj)*FLUX_TO_DELTA_TEMP
 
-                  PredictTempChgFromF_IA_NET(I,J) = 
-     &             -F_ia_net(I,J)*AREA(I,J,2,bi,bj)*FLUX_TO_DELTA_TEMP
+                  PredTempChangeFromF_IA_NET(I,J) = - F_ia_net(I,J) *
+     &               AREANm1(I,J,bi,bj)*FLUX_TO_DELTA_TEMP
 
-                  PredictTempChgFromNewIceVol(I,J) = 
-     &              EnergyInNewTotalIceVolume(I,J)*ENERGY_TO_DELTA_TEMP
+                  PredTempChangeFromNewIceVol(I,J) = 
+     &               EnergyInNewIceVolume(I,J)*ENERGY_TO_DELTA_TEMP
 
-                  PredictTempChg(I,J) = 
-     &              PredictTempChgFromQSW(I,J) +
-     &              PredictTempChgFromOA_MQNET(I,J) +
-     &              PredictTempChgFromF_IO_NET(I,J) +
-     &              PredictTempChgFromF_IA_NET(I,J) +
-     &              PredictTempChgFromNewIceVol(I,J)
-#endif    
-                 ENDIF !/ MASKC
+                  PredTempChange(I,J) = 
+     &               PredTempChangeFromQSW(I,J) +
+     &               PredTempChangeFromOA_MQNET(I,J) +
+     &               PredTempChangeFromF_IO_NET(I,J) +
+     &               PredTempChangeFromF_IA_NET(I,J) +
+     &               PredTempChangeFromNewIceVol(I,J)
+
                ENDDO
             ENDDO
+#endif /* seaice debug */   
 
 
 #ifdef ALLOW_AUTODIFF_TAMC
-CADJ STORE area(:,:,:,bi,bj) = comlev1_bibj, 
-CADJ &                         key = iicekey, byte = isbyte
-CADJ STORE hsnow(:,:,bi,bj) = comlev1_bibj, 
-CADJ &                         key = iicekey, byte = isbyte
-CADJ STORE heff(:,:,:,bi,bj) = comlev1_bibj, 
-CADJ &                         key = iicekey, byte = isbyte
+C     ADJ STORE area(:,:,bi,bj)  = comlev1_bibj, 
+C     ADJ &                        key = iicekey, byte = isbyte
+C     ADJ STORE hsnow(:,:,bi,bj) = comlev1_bibj, 
+C     ADJ &                        key = iicekey, byte = isbyte
+C     ADJ STORE heff(:,:,bi,bj)  = comlev1_bibj, 
+C     ADJ &                        key = iicekey, byte = isbyte
 #endif /* ALLOW_AUTODIFF_TAMC */
             
 
 #ifdef ALLOW_SEAICE_FLOODING
-          IF(SEAICEuseFlooding) THEN
-            DO J = 1,sNy
-              DO I = 1,sNx
+C---  +----1----+----2----+----3----+----4----+----5----+----6----+----7-|--+----|
+c     Convert flooded snow to ice
+            IF(SEAICEuseFlooding) THEN
 
-                IF (HSNOW(I,J,bi,bj) .GT. 0.0) THEN
-
-                  deltaHS = FL_C2*( 
-     &               HSNOW(I,J,bi,bj) - HEFF(I,J,1,bi,bj)*FL_C3 )
-
-                  deltaHI = FL_C4*deltaHS
-
-                  IF (deltaHS .GT. 0.0 _d 0) THEN
-
-c                    total latent heat enthalpy in ice/snow 
+               DO J = 1,sNy
+                  DO I = 1,sNx
                      EnergyToMeltSnowAndIce(I,J) = 
-     &                 HEFF(I,J,1,bi,bj)/QI +
-     &                 HSNOW(I,J,bi,bj)/QS
-
-                     HEFFO = HEFF(I,J,1,bi,bj)
-                     HSNOWO = HSNOW(I,J,bi,bj)
+     &                  HEFF(I,J,bi,bj)/QI +
+     &                  HSNOW(I,J,bi,bj)/QS
                      
-                     HEFF(I,J,1,bi,bj) = HEFF(I,J,1,bi,bj) + deltaHI
-                     HSNOW(I,J,bi,bj)  = HSNOW(I,J,bi,bj)  - deltaHS
-
-c                    total latent heat enthalpy in ice/snow, post adjustment 
-                     EnergyToMeltSnowAndIce2(I,J) = 
-     &                    HEFF(I,J,1,bi,bj)/QI +
-     &                    HSNOW(I,J,bi,bj)/QS
-
-C---+----1----+----2----+----3----+----4----+----5----+----6----+----7-|--+----|
-c                    diagnostics of the tendencies of heff and hsnow 
-c                    from flooding.
-                     SID_DUM7(I,J,bi,bj) = 
-     &                 (HEFF(I,J,1,bi,bj) - HEFFO)/ SEAICE_deltaTtherm
-
-c                     SID_DUM8(I,J,bi,bj) = 
-c     &                 (HSNOW(I,J,bi,bj) - HSNOWO)/ SEAICE_deltaTtherm
-C---+----1----+----2----+----3----+----4----+----5----+----6----+----7-|--+----|
+                     deltaHS = FL_C2*( HSNOW_ACTUAL(I,J) -
+     &                  HICE_ACTUAL(I,J)*FL_C3 )
                      
+                     IF (deltaHS .GT. ZERO) THEN
+                        deltaHI = FL_C4*deltaHS
+                        
+                        HICE_ACTUAL(I,J) = HICE_ACTUAL(I,J)  
+     &                     + deltaHI
+
+                        HSNOW_ACTUAL(I,J)= HSNOW_ACTUAL(I,J) 
+     &                     - deltaHS
+
+                        HEFF(I,J,bi,bj)= HICE_ACTUAL(I,J) *
+     &                     AREA(I,J,bi,bj)
+
+                        HSNOW(I,J,bi,bj) = HSNOW_ACTUAL(I,J)*
+     &                     AREA(I,J,bi,bj)
+                        
+                        EnergyToMeltSnowAndIce2(I,J) = 
+     &                     HEFF(I,J,bi,bj)/QI +
+     &                     HSNOW(I,J,bi,bj)/QS
+                        
 #ifdef SEAICE_DEBUG
-               IF ( (I .EQ. SEAICE_debugPointX)   .and.
-     &              (J .EQ. SEAICE_debugPointY) ) THEN
 
-                     print *,'Energy to melt snow+ice: pre,post,delta', 
-     &                    EnergyToMeltSnowAndIce(I,J),  
-     &                    EnergyToMeltSnowAndIce2(I,J),
-     &                    EnergyToMeltSnowAndIce(I,J) - 
-     &                    EnergyToMeltSnowAndIce2(I,J)
-               ENDIF
-c SEAICE DEBUG
-#endif
+                        IF ( (I .EQ. SEAICE_debugPointX)   .and.
+     &                     (J .EQ. SEAICE_debugPointY) ) THEN
+                           print '(A,4(1x,1PE24.15))',
+     &                        'Energy to melt snow+ice: pre,post,delta',
+     &                        EnergyToMeltSnowAndIce(I,J),  
+     &                        EnergyToMeltSnowAndIce2(I,J),
+     &                        EnergyToMeltSnowAndIce(I,J) - 
+     &                        EnergyToMeltSnowAndIce2(I,J)
+                        ENDIF
+#endif /* SEAICE DEBUG */
 
-C                 NOT FLOODING, deltaHS !.GT. 0
-                  ELSE  
-                   deltaHS = 0.0  !/FLOODING CONDITIONS
-                   deltaHI = 0.0
-                  ENDIF
- 
-                ENDIF !/ no snow
+                     ENDIF 
 
-               ENDDO !/ i,j
-             ENDDO !/ i,j
-          ENDIF !/useFlooding
+                  ENDDO         !/ I
+               ENDDO            !/ J
 
-!/ allow flooding
-#endif  
+            ENDIF               !/ SEAICEuseFlooding
+#endif /* SEAICE_FLOODING
 
-
-c one last cleanup
-          DO J=1,sNy
-            DO I=1,sNx
-              AREA(I,J,1,bi,bj) = AREA(I,J,1,bi,bj)*HEFFM(I,J,bi,bj)
-              HEFF(I,J,1,bi,bj) = HEFF(I,J,1,bi,bj)*HEFFM(I,J,bi,bj)
-              HSNOW(I,J,bi,bj)  = HSNOW(I,J,bi,bj)*HEFFM(I,J,bi,bj)
-            ENDDO
-         ENDDO
 
 #ifdef ALLOW_AUTODIFF_TAMC
-CADJ STORE area(:,:,:,bi,bj) = comlev1_bibj, 
-CADJ &                         key = iicekey, byte = isbyte
-CADJ STORE hsnow(:,:,bi,bj) = comlev1_bibj, 
-CADJ &                         key = iicekey, byte = isbyte
-CADJ STORE heff(:,:,:,bi,bj) = comlev1_bibj, 
-CADJ &                         key = iicekey, byte = isbyte
+C     ADJ STORE area(:,:,bi,bj)  = comlev1_bibj, 
+C     ADJ &                        key = iicekey, byte = isbyte
+C     ADJ STORE hsnow(:,:,bi,bj) = comlev1_bibj, 
+C     ADJ &                        key = iicekey, byte = isbyte
+C     ADJ STORE heff(:,:,bi,bj)  = comlev1_bibj, 
+C     ADJ &                        key = iicekey, byte = isbyte
 #endif /* ALLOW_AUTODIFF_TAMC */
-
-
-
-C---+----1----+----2----+----3----+----4----+----5----+----6----+----7-|--+----|
-c diagnostics
-           DO J = 1,sNy
-             DO I = 1,sNx
-c              the actual dA/dt realized by the model
-               SID_Sa(I,J,bi,bj) = ( AREA(I,J,1,bi,bj) -
-     &              AREA(I,J,2,bi,bj) ) / SEAICE_deltaTtherm
-
-c                 the actual dheff/dt realized by the model
-               SID_Sh(I,J,bi,bj) =  ( HEFF(I,J,1,bi,bj) -
-     &              HEFF(I,J,2,bi,bj)) / SEAICE_deltaTtherm
-
-c          hackish way to take account of what is changed in advection
-c          this is the last information we have about area and
-c          heff when thermodynamics ends.  anything changing from this
-c          point on, until we get to thermo ice again must be advection
-               AREA_POST_THERMO(I,J,bi,bj) = AREA(I,J,1,bi,bj)
-               HEFF_POST_THERMO(I,J,bi,bj) = HEFF(I,J,1,bi,bj)
-
-            ENDDO
-           ENDDO
-C---+----1----+----2----+----3----+----4----+----5----+----6----+----7-|--+----|
 
 
 #ifdef ATMOSPHERIC_LOADING
             IF ( useRealFreshWaterFlux ) THEN
                DO J=1,sNy
                   DO I=1,sNx
-                     sIceLoad(i,j,bi,bj) = HEFF(I,J,1,bi,bj)*
-     &                    SEAICE_rhoIce + HSNOW(I,J,bi,bj)* 330. _d 0
+
+                     sIceLoad(i,j,bi,bj) = HEFF(I,J,bi,bj)*
+     &                  SEAICE_rhoIce + HSNOW(I,J,bi,bj)*SEAICE_rhoSnow
+
                   ENDDO
                ENDDO
             ENDIF
 #endif
 
+
 #ifdef SEAICE_DEBUG
-            DO j=1-OLy,sNy+OLy
-               DO i=1-OLx,sNx+OLx
+C---  +----1----+----2----+----3----+----4----+----5----+----6----+----7-|--+----|
+c     Debugging calculations
+            DO j=1,sNy
+               DO i=1,sNx
 
-               IF ( (i .EQ. SEAICE_debugPointX)   .and.  
-     &              (j .EQ. SEAICE_debugPointY) ) THEN
+                  IF ( (i .EQ. SEAICE_debugPointX)   .and.  
+     &               (j .EQ. SEAICE_debugPointY) ) THEN
 
-                  print *,'ifsig: myTime,myIter:',myTime,myIter
+                     print *,'ifsig: myTime,myIter: ',myTime,myIter
 
-                  print '(A,2i4,2(1x,1P3E15.4))',
-     &                 'ifice i j --------------  ',i,j
+                     print '(A,2i4)',
+     &                  'ifice i j -------------- ',i,j
 
-                  print '(A,2i4,2(1x,1P3E15.4))',
-     &                 'ifice i j IGR(ML OW ICE)  ',i,j,
-     &                 IceGrowthRateMixedLayer(i,j),
-     &                 IceGrowthRateOpenWater(i,j),
-     &                 NetExistingIceGrowthRate(i,j),
-     &                 SEAICE_deltaTtherm
-                  
-                  print '(A,2i4,2(1x,1P3E15.4))',
-     &                 'ifice i j F(mi ao)        ',
-     &                 i,j,F_mi(i,j), F_ao(i,j)
-                  
-                  print '(A,2i4,2(1x,1P3E15.4))',
-     &                 'ifice i j Fi(a,ant2/1 ont)',
-     &                 i,j,F_ia(i,j),
-     &                 F_ia_net_before_snow(i,j), 
-     &                 F_ia_net(i,j), 
-     &                 F_io_net(i,j)
-                 
-                  print '(A,2i4,2(1x,1P3E15.4))',
-     &                 'ifice i j AREA2/1 HEFF2/1 ',i,j,
-     &                 AREA(i,j,2,bi,bj),
-     &                 AREA(i,j,1,bi,bj),
-     &                 HEFF(i,j,2,bi,bj),
-     &                 HEFF(i,j,1,bi,bj)
-                  
-                  print '(A,2i4,2(1x,1P3E15.4))',
-     &                 'ifice i j HSNOW2/1 TMX TBC',i,j,
-     &                 HSNOW_ORIG(I,J),
-     &                 HSNOW(I,J,bi,bj),
-     &                 TMIX(i,j,bi,bj)- TMELT, 
-     &                 TBC
-
-                  print '(A,2i4,2(1x,1P3E15.4))',
-     &                 'ifice i j TI ATP LWD      ',i,j,
-     &                 TICE(i,j,bi,bj) - TMELT,
-     &                 ATEMP(i,j,bi,bj) -TMELT,
-     &                 LWDOWN(i,j,bi,bj)
+                     print '(A,4(1x,1PE24.15))',
+     &                  'ifice IGR(ML OW ICE)     ',
+     &                  IceGrowthRateMixedLayer(i,j),
+     &                  IceGrowthRateOpenWater(i,j),
+     &                  NetExistingIceGrowthRate(i,j),
+     &                  SEAICE_deltaTtherm
+                     
+                     print '(A,4(1x,1PE24.15))',
+     &                  'ifice F(mi ao)           ',
+     &                  F_mi(i,j), F_ao(i,j)
+                     
+                     print '(A,4(1x,1PE24.15))',
+     &                  'ifice Fi(a,ant2/1 ont)   ',
+     &                  F_ia(i,j),
+     &                  F_ia_net_before_snow(i,j), 
+     &                  F_ia_net(i,j), 
+     &                  F_io_net(i,j)
+                     
+                     print '(A,4(1x,1PE24.15))',
+     &                  'ifice AREA2/1 HEFF2/1    ',
+     &                  AREANm1(I,J,bi,bj),
+     &                  AREA(i,j,bi,bj),
+     &                  HEFFNm1(I,J,bi,bj),
+     &                  HEFF(i,j,bi,bj)
 
 
-                  print '(A,2i4,2(1x,1P3E15.4))',
-     &                 'ifice i j S_a S_h S_hsnow ',i,j,
-     &                 S_a(i,j),
-     &                 S_h(i,j),
-     &                 S_hsnow(i,j)
+#ifdef ALLOW_SALT_PLUME
+                     print '(A,4(1x,1PE24.15))',
+     &                  'ifice A,IGLEA,LPF,SPF    ',
+     &                  AREANm1(I,J,bi,bj),
+     &                  IceGrowthRateInLeads(I,J),
+     &                  leadPlumeFraction(I,J),
+     &                  saltPlumeFlux(i,j,bi,bj)
+#endif
+                     
+                     print '(A,4(1x,1PE24.15))',
+     &                  'ifice HSNOW2/1 TMX TBC   ',
+     &                  HSNOW_ORIG(I,J),
+     &                  HSNOW(I,J,bi,bj),
+     &                  TMIX(i,j,bi,bj)- TMELT, 
+     &                  TBC
 
-                  print '(A,2i4,2(1x,1P3E15.4))',
-     &                 'ifice i j IVC(E A ENIN)   ',i,j,
-     &                 ExpectedIceVolumeChange(i,j),
-     &                 ActualNewTotalVolumeChange(i,j),
-     &                 EnergyInNewTotalIceVolume(i,j)
-                  
-                  print '(A,2i4,2(1x,1P3E15.4))',
-     &                 'ifice i j EF(NOS RE) QNET ',i,j,
-     &                 NetEnergyFluxOutOfSystem(i,j),
-     &                 ResidualHeatOutOfSystem(i,j),
-     &                 QNET(I,J,bi,bj)
-
-                  print '(A,2i4,3(1x,1P3E15.4))',
-     &                 'ifice i j QSW QSWO QSWI   ',i,j,
-     &                 QSW(i,j,bi,bj),
-     &                 QSWO(i,j),
-     &                 QSWI(i,j)
-
-                  print '(A,2i4,3(1x,1P3E15.4))',
-     &                 'ifice i j SW(BML IML SW)  ',i,j,
-     &                 QSW_absorb_below_ML(i,j),
-     &                 QSW_absorb_in_ML(i,j),
-     &                 SWFRACB
-
-                  print '(A,2i4,3(1x,1P3E15.4))',
-     &                 'ifice i j ptc(to, qsw, oa)',i,j,
-     &                 PredictTempChg(i,j),
-     &                 PredictTempChgFromQSW (i,j),
-     &                 PredictTempChgFromOA_MQNET(i,j)
+                     print '(A,4(1x,1PE24.15))',
+     &                  'ifice TI ATP LWD         ',
+     &                  TICE(i,j,bi,bj) - TMELT,
+     &                  ATEMP(i,j,bi,bj) -TMELT,
+     &                  LWDOWN(i,j,bi,bj)
 
 
-                  print '(A,2i4,3(1x,1P3E15.4))',
-     &                 'ifice i j ptc(fion,ian,ia)',i,j,
-     &                 PredictTempChgFromF_IO_NET(i,j),
-     &                 PredictTempChgFromF_IA_NET(i,j),
-     &                 PredictTempChgFromFIA(i,j)
+                     print '(A,4(1x,1PE24.15))',
+     &                  'ifice S_a S_h S_hsnow    ',
+     &                  S_a(i,j),
+     &                  S_h(i,j),
+     &                  S_hsnow(i,j)
 
-                  print '(A,2i4,3(1x,1P3E15.4))',
-     &                 'ifice i j ptc(niv)        ',i,j,
-     &                 PredictTempChgFromNewIceVol(i,j)
+                     print '(A,4(1x,1PE24.15))',
+     &                  'ifice IVC(E A ENIN)      ',
+     &                  ExpectedIceVolumeChange(i,j),
+     &                  ActualIceVolumeChange(i,j),
+     &                  EnergyInNewIceVolume(i,j)
+                     
+                     print '(A,4(1x,1PE24.15))',
+     &                  'ifice EF(NOS RE) QNET    ',
+     &                  NetEnergyOutOfOcean(i,j),
+     &                  ResidualEnergyOutOfOcean(i,j),
+     &                  QNET(I,J,bi,bj)
+
+                     print '(A,4(1x,1PE24.15))',
+     &                  'ifice QSW QSWO QSWI      ',
+     &                  QSW(i,j,bi,bj),
+     &                  QSWO(i,j),
+     &                  QSWI(i,j)
+
+                     print '(A,4(1x,1PE24.15))',
+     &                  'ifice SW(BML IML SW)     ',
+     &                  QSW_absorb_below_first_layer(i,j),
+     &                  QSW_absorb_in_first_layer(i,j),
+     &                  SWFRACB
+
+                     print '(A,4(1x,1PE24.15))',
+     &                  'ifice ptc(to, qsw, oa)   ',
+     &                  PredTempChange(i,j),
+     &                  PredTempChangeFromQSW (i,j),
+     &                  PredTempChangeFromOA_MQNET(i,j)
 
 
-                  print '(A,2i4,3(1x,1P3E15.4))',
-     &                 'ifice i j EmPmR EVP PRE RU',i,j,
-     &                 EmPmR(I,J,bi,bj),
-     &                 EVAP(I,J,bi,bj),
-     &                 PRECIP(I,J,bi,bj),
-     &                 RUNOFF(I,J,bi,bj)
+                     print '(A,4(1x,1PE24.15))',
+     &                  'ifice ptc(fion,ian,ia)   ',
+     &                  PredTempChangeFromF_IO_NET(i,j),
+     &                  PredTempChangeFromF_IA_NET(i,j),
+     &                  PredTempChangeFromFIA(i,j)
 
-                  print '(A,2i4,3(1x,1P3E15.4))',
-     &                 'ifice i j PRROIS,SAOI(R .)',i,j,
-     &                 PrecipRateOverIceSurfaceToSea(I,J),
-     &                 SnowAccumulationRateOverIce(I,J),
-     &                 SnowAccumulationOverIce(I,J)
-
-                  print '(A,2i4,4(1x,1P3E15.4))',
-     &                 'ifice i j SM(PM PMR . .R) ',i,j,
-     &                 PotSnowMeltFromSurf(I,J),
-     &                 PotSnowMeltRateFromSurf(I,J),
-     &                 SnowMeltFromSurface(I,J),
-     &                 SnowMeltRateFromSurface(I,J)
-
-                  print '(A,2i4,4(1x,1P3E15.4))',
-     &                 'ifice i j TotSnwMlt ExSnVC',i,j,
-     &                 ActualNewTotalSnowMelt(I,J),
-     &                 ExpectedSnowVolumeChange(I,J)
+                     print '(A,4(1x,1PE24.15))',
+     &                  'ifice ptc(niv)           ',
+     &                  PredTempChangeFromNewIceVol(i,j)
 
 
-                  print '(A,2i4,4(1x,1P3E15.4))',
-     &                 'ifice i j fw(CFICE, CFSM) ',i,j,
-     &                 FreshwaterContribFromIce(I,J),
-     &                 FreshwaterContribFromSnowMelt(I,J)
+                     print '(A,4(1x,1PE24.15))',
+     &                  'ifice EmPmR EVP PRE RU   ',
+     &                  EmPmR(I,J,bi,bj),
+     &                  EVAP(I,J,bi,bj),
+     &                  PRECIP(I,J,bi,bj),
+     &                  RUNOFF(I,J,bi,bj)
 
-                  print '(A,2i4,2(1x,1P3E15.4))',
-     &                 'ifice i j --------------  ',i,j
+                     print '(A,4(1x,1PE24.15))',
+     &                  'ifice PRROIS,SAOI        ',
+     &                  PrecipRateOverIceSurfaceToSea(I,J),
+     &                  SnowAccRateOverIce(I,J),
+     &                  SnowAccOverIce(I,J)
 
-               ENDIF
+                     print '(A,4(1x,1PE24.15))',
+     &                  'ifice SM(PM PMS S MR)    ',
+     &                  PotSnowMeltFromSurf(I,J),
+     &                  PotSnowMeltRateFromSurf(I,J),
+     &                  SnowMeltFromSurface(I,J),
+     &                  SnowMeltRateFromSurface(I,J)
+
+                     print '(A,4(1x,1PE24.15))',
+     &                  'ifice TotSnwMlt ExSnVC   ',
+     &                  ActualNewTotalSnowMelt(I,J),
+     &                  ExpectedSnowVolumeChange(I,J)
+
+
+                     print '(A,4(1x,1PE24.15))',
+     &                  'ifice fw(CFICE, CFSM)    ',
+     &                  FreshwaterContribFromIce(I,J),
+     &                  FreshwaterContribFromSnowMelt(I,J)
+
+                     print '(A,2i5)',
+     &                  'ifice i j -------------- ',i,j
+
+                     print '(A,4(1x,1PE24.15))',
+     &                  'end iter, ANm1, HNm1, HSN  ',myIter,
+     &                  AREANm1(I,J,bi,bj), HEFFNm1(I,J,bi,bj),
+     &                  HSNOW(I,J,bi,bj)
+
+                  ENDIF
                ENDDO
             ENDDO
 #endif /* SEAICE_DEBUG */
             
             
-C     BI,BJ'S
-         ENDDO
-      ENDDO
+         ENDDO                  !/ bi
+      ENDDO                     !/ bj
       
       RETURN
       END

--- a/pkg/seaice/seaice_growth_adjointable.F
+++ b/pkg/seaice/seaice_growth_adjointable.F
@@ -1,5 +1,3 @@
-C SEAICE GROWTH REBORN v02 2015/01/15
-
 #include "SEAICE_OPTIONS.h"
 #ifdef ALLOW_EXF
 # include "EXF_OPTIONS.h"
@@ -12,14 +10,12 @@ C SEAICE GROWTH REBORN v02 2015/01/15
 #endif
 
 CBOP
-C     !ROUTINE: SEAICE_GROWTH
+C     !ROUTINE: SEAICE_GROWTH_ADJOINTABLE
 C     !INTERFACE:
-      SUBROUTINE SEAICE_GROWTH( myTime, myIter, myThid )
+      SUBROUTINE SEAICE_GROWTH_ADJOINTABLE
+     I  ( myTime, myIter, myThid )
 C     !DESCRIPTION: \bv
-C     *==========================================================*
-C     | SUBROUTINE seaice_growth
-C     | o rebirth of seaice_growth_if
-C     *==========================================================*
+
 C     \ev
 
 C     !USES:
@@ -82,12 +78,8 @@ C     number of surface interface layer
 C     IT :: ice thickness category index (MULTICATEGORIES and ITD code)
       INTEGER IT
 C     msgBuf      :: Informational/error message buffer
-#ifdef ALLOW_BALANCE_FLUXES
-      CHARACTER*(MAX_LEN_MBUF) msgBuf
-#elif (defined (SEAICE_DEBUG))
       CHARACTER*(MAX_LEN_MBUF) msgBuf
       CHARACTER*12 msgBufForm
-#endif
 C     constants
       _RL tempFrz, ICE2SNOW, SNOW2ICE, surf_theta
       _RL QI, QS, recip_QI
@@ -184,6 +176,14 @@ C     Helper variables for diagnostics
       _RL DIAGarrayC    (1:sNx,1:sNy)
       _RL DIAGarrayD    (1:sNx,1:sNy)
 #endif /* ALLOW_DIAGNOSTICS */
+#ifdef ALLOW_SALT_PLUME
+c     d(HEFF)/dt from heat fluxes in the open water fraction of the grid cell
+      _RL IceGrowthRateInLeads          (1:sNx,1:sNy)
+
+c     The fraction of salt released in leads by new ice production there
+c     which is to be sent to the salt plume package
+      _RL leadPlumeFraction             (1:sNx,1:sNy)
+#endif
 
 
       _RL QSWO_BELOW_FIRST_LAYER (1:sNx,1:sNy)
@@ -203,7 +203,20 @@ C     Sea ice growth rates (m/s)
 
       _RL EnergyInNewTotalIceVolume     (1:sNx,1:sNy)
       _RL NetEnergyFluxOutOfOcean       (1:sNx,1:sNy)
-c
+
+CAB   Terms for closing the budget
+       _RL SItflux     (1-OLx:sNx+OLx,1-OLy:sNy+OLy,nSx,nSy)
+       _RL SIaaflux    (1-OLx:sNx+OLx,1-OLy:sNy+OLy,nSx,nSy)  
+       _RL SIatmFW     (1-OLx:sNx+OLx,1-OLy:sNy+OLy,nSx,nSy)
+CAB these two terms are placeholders for extra bits from advection, 
+C   used in budget
+       _RL SIheffNeg   (1-OLx:sNx+OLx,1-OLy:sNy+OLy,nSx,nSy)  
+       _RL SIhsnwNeg   (1-OLx:sNx+OLx,1-OLy:sNy+OLy,nSx,nSy)  
+
+CAB
+       _RL d_HEFFbyFlood                (1:sNx,1:sNy)
+
+
 C     The energy taken out of the ocean which is not converted
 C     to sea ice (Joules)
       _RL ResidualEnergyOutOfOcean      (1:sNx,1:sNy)
@@ -434,6 +447,16 @@ C NEW VARIABLE NAMES
           S_hsnow(I,J)   = 0.0 _d 0
 
           MLTF(I,J)      = 0.0 _d 0
+
+          d_HEFFbyFlood(I,J) = 0.0 _d 0
+
+#ifdef ALLOW_SALT_PLUME
+          IceGrowthRateInLeads            (I,J) = 0. _d 0
+          leadPlumeFraction               (I,J) = 0. _d 0
+          saltPlumeFlux             (I,J,bi,bj) = 0. _d 0
+#endif
+
+
          ENDDO
         ENDDO
 
@@ -449,6 +472,13 @@ C =====================================================================
 C  PART 1: Store ice and snow state on onset + regularize actual
 C               snow and ice thickness
 C =====================================================================
+CAB
+        DO J=1,sNy
+         DO I=1,sNx
+         SIheffNeg(I,J,bi,bj)=d_HEFFbyNEG(I,J,bi,bj)*SINegFac 
+         SIhsnwNeg(I,J,bi,bj)=d_HSNWbyNEG(I,J,bi,bj)*SINegFac 
+         ENDDO
+        ENDDO
 
         DO J=1,sNy
          DO I=1,sNx
@@ -713,7 +743,7 @@ c  ice/atmosphere interface for each thickness category
 c =======================================================================
 
         DO IT=1,SEAICE_multDim
-         CALL SEAICE_SOLVE4TEMP(
+         CALL SEAICE_SOLVE4TEMP_ADJOINTABLE(
      I        UG, hiceActualMult(1,1,IT), hsnowActualMult(1,1,IT),
      U        ticeInMult(1,1,IT), ticeOutMult(1,1,IT),
      O        F_io_net_mult(1,1,IT),
@@ -952,6 +982,72 @@ c         with area converts to mean snow thickness.
          ENDDO
         ENDDO
 
+#ifdef ALLOW_SALT_PLUME
+#ifdef SALT_PLUME_IN_LEADS
+C       Now that we know the thickness tendency terms, we can calculate the saltPlumeFlux
+        DO J=1,sNy
+         DO I=1,sNx
+
+c            It is assumed that ice production in leads can generate
+c            salt plumes.  The fraction of the salt sent to the plume package
+c            from ice produced in leads (defined as the open water
+c            fraction) is a nonlinear function of ice concentration, AREA.
+c
+c            Specifically, function is a logistic curve (sigmoid) with a range and 
+c            domain {0,1}.  The function, f(AREA), has a single free parameter,
+c            SEAICE_plumeInflectionPoint, the inflection point of the curve.  
+c            By construction, the function has the following properties:
+c            f(1) \approx 1.0
+c            f(SEAICE_plumeInflectionPoint) = 0.5
+c            f(0) \approx 0.0 (when SEAICE_plumeInflectionPoint \geq 0.5)
+c            f(0) > 0.0 (when SEAICE_plumeInflectionPoint < 0.5)
+c
+c            As AREA --> 1, the open water fraction occurs
+c            in narrow leads, new ice production become spatially non-uniform,
+c            and the assumptions motivating KPP no longer hold.  To treat
+c            overturning in a more physically realistic way, the salt produced
+c            in the leads should be sent to depth via the plume package.  To assure 
+c            only narrow leads generate plumes, choose a SEAICE_plumeInflectionPoint 
+c            of > 0.8.
+
+c            Ensure that there is already ice present or that the total ice
+c            ice tendency term is positive.  We don't want to release 
+c            salt if sea ice is not established in the cell.
+
+             IF ((AREApreTH(I,J) .GT. ZERO) .OR. 
+     &           (S_h(I,J)           .GT. ZERO)) THEN
+ 
+              leadPlumeFraction(I,J) = 
+     &         (ONE + EXP( ( SPinflectionPoint - 
+     &                       AREApreTH(I,J)
+     &                     ) * 5. _d 0/
+     &                     (ONE - SPinflectionPoint)
+     &                   )
+     &         )**(-ONE) 
+ 
+c            Only consider positive ice growth rate in leads for salt production
+             IceGrowthRateInLeads(I,J) = max( ZERO,
+     &      (ONE - AREApreTH(I,J)) * IceGrowthRateOpenWater(I,J))
+
+              saltPlumeFlux(I,J,bi,bj) = leadPlumeFraction(I,J) * 
+     &            HEFFM(I,J,bi,bj)*IceGrowthRateInLeads(I,J)*
+     &            ICE2WATR*rhoConstFresh*
+     &            (salt(I,J,kSurface,bi,bj) - SEAICE_salt0)
+             ELSE 
+
+              saltPlumeFlux(I,J,bi,bj) = ZERO 
+
+             ENDIF
+
+         ENDDO
+        ENDDO
+#endif /* SALT_PLUME_IN_LEADS */
+#endif /* ALLOW_SALT_PLUME */
+
+
+
+
+
 C---+----1----+----2----+----3----+----4----+----5----+----6----+----7-|--+----|
 #ifdef ALLOW_AUTODIFF_TAMC
 CADJ STORE AREApreTH = comlev1_bibj, key = iicekey, byte = isbyte
@@ -1126,6 +1222,20 @@ c         THE EFFECTIVE SHORTWAVE HEATING RATE
 #else
             QSW(I,J,bi,bj) = 0. _d 0
 #endif
+#ifdef ALLOW_SEAICE_FLOODING
+        IF(SEAICEuseFlooding) THEN
+
+
+           tmpscal0 = (HSNOW(I,J,bi,bj)*SEAICE_rhoSnow
+     &              +HEFF(I,J,bi,bj)*SEAICE_rhoIce)*recip_rhoConst
+          d_HEFFbyFlood(I,J) = MAX(tmpscal0 - HEFF(I,J,bi,bj), 0. _d 0)
+                      HEFF(I,J,bi,bj)=HEFF(I,J,bi,bj)+d_HEFFbyFlood(I,J)
+                      HSNOW(I,J,bi,bj) = HSNOW(I,J,bi,bj)-
+     &                 d_HEFFbyFlood(I,J)*ICE2SNOW
+c SEAICEuseFlooding
+           ENDIF
+c ALLOW_SEAICE_FLOODING
+#endif
 
 c           The actual ice volume change over the time step
             ActualNewTotalVolumeChange(I,J) =
@@ -1147,6 +1257,8 @@ c           snow thickness over the 1/4 of the cell which is ice covered.
 c           The energy required to melt or form the new ice volume
             EnergyInNewTotalIceVolume(I,J) =
      &          ActualNewTotalVolumeChange(I,J)/QI
+c
+           
 
 c     This is the net energy flux out of the ice+ocean system
 c     Remember -----
@@ -1196,8 +1308,8 @@ c    to water cell salinity.
 
                  FreshwaterContribFromIce(I,J) =
      &            - ActualNewTotalVolumeChange(I,J) *
-     &              SEAICE_rhoICE/rhoConstFresh *
-     &             (ONE - SEAICE_salt0/salt(I,J,kSurface,bi,bj))
+     &              SEAICE_rhoICE/rhoConstFresh 
+C     &             * (ONE - SEAICE_salt0/salt(I,J,kSurface,bi,bj))
 
             ELSE
 C    If the liquid cell has a lower salinity than the specified
@@ -1206,7 +1318,22 @@ c    salinity of sea ice then assume the sea ice is completely fresh
      &             -ActualNewTotalVolumeChange(I,J) *
      &              SEAICE_rhoIce/rhoConstFresh
             ENDIF
+CAB
+          tmpscal3 = max( 0. _d 0,
+     &                    min(SEAICE_salt0,salt(I,J,kSurface,bi,bj)) )
+CAB Salt in ice + ridgi - ice from snow flood
+         tmpscal2 = (ActualNewTotalVolumeChange(I,J)+
+     &                   SIheffNeg(I,J,bi,bj)+
+     &                  0.0 )
+     &                   * tmpscal3 
+     &                   * HEFFM(I,J,bi,bj)
+     &                   / SEAICE_deltaTtherm * SEAICE_rhoIce
 
+                
+CAB test for getting the lines
+ 
+             saltflux(I,J,bi,bj) = tmpscal2 
+CAB
 
 c    The freshwater contribution from snow comes only in the form of melt
 c    unlike ice, which takes freshwater upon growth and yields freshwater
@@ -1229,6 +1356,40 @@ c    weighted
      &          - (FreshwaterContribFromIce(I,J) +
      &             FreshwaterContribFromSnowMelt(I,J)) /
      &             SEAICE_deltaTtherm ) * rhoConstFresh
+     &            +( SIheffNeg(I,J,bi,bj)*SEAICE_rhoIce
+     &            + SIhsnwNeg(I,J,bi,bj)*SEAICE_rhoSnow)
+     &            /SEAICE_deltaTtherm * maskC(I,J,kSurface,bi,bj)
+
+
+
+CAB Budget test , adding the energy stored in snow melt to qnet
+CMoved bunch of these to line 780
+
+       SItflux(I,J,bi,bj) = 0.0 +
+     &   (AREApreTH(I,J)
+     &     *(F_ia_net(I,J)
+     &     + F_io_net(I,J) + QSWI(I,J))
+     &  +( ONE - AREApreTH(I,J)) *  F_ao(I,J))
+     &    *maskC(I,J,kSurface,bi,bj)
+     &  +(SIheffNeg(I,J,bi,bj)/QI
+     &  +(SIhsnwNeg(I,J,bi,bj)
+     &  -ActualNewTotalSnowMelt(I,J) +SnowAccOverIce(I,J))/QS)
+     &  / SEAICE_deltaTtherm * maskC(I,J,kSurface,bi,bj)
+
+       SIaaflux(I,J,bi,bj) =  -EmPmR(I,J,bi,bj)  
+     &     * HeatCapacity_Cp *theta(I,J,kSurface,bi,bj)
+
+      SIatmFW(I,J,bi,bj) = maskC(I,J,kSurface,bi,bj)*(
+     &          EVAP(I,J,bi,bj)*( ONE - AREApreTH(I,J) )
+     &          - PRECIP(I,J,bi,bj)
+#ifdef ALLOW_RUNOFF
+     &          - RUNOFF(I,J,bi,bj)
+#endif /* ALLOW_RUNOFF */
+     &           )*rhoConstFresh
+C     &     +    FWsublim(i,j)* SEAICE_rhoIce * recip_deltaTtherm
+C  a_FWbySublim(
+CAB
+
 
          ENDDO
         ENDDO
@@ -1246,37 +1407,6 @@ CADJ STORE salt(:,:,kSurface,bi,bj) = comlev1_bibj,
 CADJ &                       key = iicekey, byte = isbyte
 #endif /* ALLOW_AUTODIFF_TAMC */
 C---+----1----+----2----+----3----+----4----+----5----+----6----+----7-|--+----|
-
-#ifdef ALLOW_SEAICE_FLOODING
-        IF(SEAICEuseFlooding) THEN
-
-            DO J = 1,sNy
-               DO I = 1,sNx
-                  tmpscal0 = FL_C2*( hsnowActual(I,J) -
-     &                 hiceActual(I,J)*FL_C3 )
-
-                  IF (tmpscal0 .GT. ZERO) THEN
-                     tmpscal1 = FL_C4*tmpscal0
-
-                     hiceActual(I,J) = hiceActual(I,J)
-     &                    + tmpscal1
-
-                     hsnowActual(I,J) = hsnowActual(I,J)
-     &                    - tmpscal0
-
-                     HEFF(I,J,bi,bj)= hiceActual(I,J) *
-     &                    AREA(I,J,bi,bj)
-
-                     HSNOW(I,J,bi,bj) = hsnowActual(I,J)*
-     &                    AREA(I,J,bi,bj)
-
-                  ENDIF /* flooding */
-               ENDDO
-            ENDDO
-c SEAICEuseFlooding
-           ENDIF
-c ALLOW_SEAICE_FLOODING
-#endif
 
 C---+----1----+----2----+----3----+----4----+----5----+----6----+----7-|--+----|
 #ifdef ALLOW_AUTODIFF_TAMC
@@ -1454,6 +1584,42 @@ c     &                 ExpectedSnowVolumeChange(I,J)
 C close bi,bj loops
        ENDDO
       ENDDO
+
+        _BEGIN_MASTER( myThid )
+#ifdef ALLOW_DIAGNOSTICS
+      IF ( useDiagnostics ) THEN
+C these diags need to be done outside of the bi,bj loop so that
+C we may do potential global mean adjustement to them consistently.
+CAB
+CAB        CALL DIAGNOSTICS_FILL(SItflux,
+
+C        CALL DIAGNOSTICS_FILL(SIatmQnt,
+C     &        'SIatmQnt',0,1,0,1,1,myThid)
+C SIatmFW follows the same convention as empmr -- SIatmFW diag does not
+CAB
+C       CALL DIAGNOSTICS_FILL(SIacSubl,
+C     &        'SIacSubl',0,1,3,bi,bj,myThid)
+
+       CALL DIAGNOSTICS_FILL(SItflux,
+     &        'SItflux ',0,1,0,1,1,myThid)
+
+
+       CALL DIAGNOSTICS_FILL(SIaaflux,
+     &        'SIaaflux',0,1,0,1,1,myThid)
+
+
+        tmpscal1= - 1. _d 0
+        CALL DIAGNOSTICS_SCALE_FILL(SIatmFW,
+     &        tmpscal1,1,'SIatmFW ',0,1,0,1,1,myThid)
+      ENDIF
+#endif /* ALLOW_DIAGNOSTICS */
+
+C        WRITE(msgBuf,'(a,a,e24.17)') 'SINegFac ',
+C     &       ' = ', SINegFac
+C        CALL PRINT_MESSAGE( msgBuf, standardMessageUnit,
+C     &                      SQUEEZE_RIGHT, myThid )
+C
+        _END_MASTER( myThid )
 
 #else  /* ALLOW_EXF and ALLOW_ATM_TEMP */
       STOP 'SEAICE_GROWTH not compiled without EXF and ALLOW_ATM_TEMP'

--- a/pkg/seaice/seaice_growth_adjointable.F
+++ b/pkg/seaice/seaice_growth_adjointable.F
@@ -1,0 +1,1539 @@
+C     $Header: /u/gcmpack/MITgcm/pkg/seaice/seaice_growth_if.F,v 1.10 2010/03/16 19:09:51 gforget Exp $
+C     $Name:  $
+
+#include "SEAICE_OPTIONS.h"
+
+C     StartOfInterface
+      SUBROUTINE SEAICE_GROWTH_IF( myTime, myIter, myThid )
+C     /==========================================================\
+C     | SUBROUTINE seaice_growth_if                              |
+C     | o Updata ice thickness and snow depth                    |
+C     |==========================================================|
+C     \==========================================================/
+      IMPLICIT NONE
+
+C     === Global variables ===
+#include "SIZE.h"
+#include "EEPARAMS.h"
+#include "PARAMS.h"
+#include "DYNVARS.h"
+#include "GRID.h"
+#include "FFIELDS.h"
+#include "SEAICE_PARAMS.h"
+#include "SEAICE.h"
+#ifdef ALLOW_EXF
+# include "EXF_OPTIONS.h"
+# include "EXF_FIELDS.h"
+# include "EXF_PARAM.h"
+#endif
+#ifdef ALLOW_SALT_PLUME
+# include "SALT_PLUME.h"
+#endif
+#ifdef ALLOW_AUTODIFF_TAMC
+# include "tamc.h"
+#endif
+C     === Routine arguments ===
+C     myTime - Simulation time
+C     myIter - Simulation timestep number
+C     myThid - Thread no. that called this routine.
+      _RL myTime
+      INTEGER myIter, myThid
+C     EndOfInterface(global-font-lock-mode 1)
+
+C     === Local variables ===
+C     i,j,bi,bj - Loop counters
+
+      INTEGER i, j, bi, bj
+C     number of surface interface layer
+      INTEGER kSurface
+
+C     constants
+      _RL TBC, SDF, ICE2SNOW,TMELT
+      _RL STANTON_NUMBER, USTAR_BASE
+
+#ifdef ALLOW_SEAICE_FLOODING
+      _RL hDraft, hFlood
+#endif /* ALLOW_SEAICE_FLOODING */
+
+C     QSWO   - short wave heat flux over ocean (W/m^2)
+C     QSWI   - short wave heat flux under ice  (W/m^2)
+
+      _RL QSWO                         (1:sNx,1:sNy)
+      _RL QSWI                         (1:sNx,1:sNy)
+
+C     The shortwave heat flux in the open water fraction of the 
+C     grid cell converging within the uppermost ocean grid cell (W/m^2)
+      _RL QSWO_IN_FIRST_LAYER          (1:sNx,1:sNy)
+
+C     (1 - QSWO_IN_FIRST_LAYER) (W/m^2)
+      _RL QSWO_BELOW_FIRST_LAYER        (1:sNx,1:sNy)
+
+C     The total shortwave heat flux (into open water and through the ice)
+C     converging within the uppermost ocean grid cell (W/m^2)
+      _RL QSW_absorb_in_first_layer     (1:sNx,1:sNy)
+
+C     ( 1 - QSW_absorb_in_first_layer)  (W/m^2) 
+      _RL QSW_absorb_below_first_layer  (1:sNx,1:sNy)
+
+C     The actual ice thickness (i.e., mean ice thickness / ice concentration) (m) 
+      _RL HICE_ACTUAL                   (1:sNx,1:sNy)
+
+C     The actual snow thickness (i.e., mean snow thickness / ice concentration) (m) 
+      _RL HSNOW_ACTUAL                  (1:sNx,1:sNy)
+
+C     wind speed (m/s)
+      _RL UG                            (1:sNx,1:sNy)
+
+      _RL SPEED_SQ
+      _RL RHOFW,CPW,LI,QI,QS,RHOSW
+
+C     Helper Variables for snow flooding
+      _RL EnergyToMeltSnowAndIce        (1:sNx,1:sNy)
+      _RL EnergyToMeltSnowAndIce2       (1:sNx,1:sNy)
+      _RL FL_C1,FL_C2,FL_C3,FL_C4,deltaHS,deltaHI
+
+
+#ifdef SEAICE_USE_ORIGINAL_HEAT_FLUX
+      _RL GAMMA
+#endif
+
+C     Factor by which we increase the u* (friction velocity) when ice is not 
+C     present (dimensionless)
+      _RL MixedLayerTurbulenceFactor
+
+C     Sea ice growth rates (m/s)
+      _RL NetExistingIceGrowthRate      (1:sNx,1:sNy)
+      _RL IceGrowthRateUnderExistingIce (1:sNx,1:sNy)
+      _RL IceGrowthRateFromSurface      (1:sNx,1:sNy)
+      _RL IceGrowthRateOpenWater        (1:sNx,1:sNy)
+      _RL IceGrowthRateMixedLayer       (1:sNx,1:sNy)
+
+#ifdef ALLOW_SALT_PLUME
+c     d(HEFF)/dt from heat fluxes in the open water fraction of the grid cell
+      _RL IceGrowthRateInLeads          (1:sNx,1:sNy)
+
+c     The fraction of salt released in leads by new ice production there
+c     which is to be sent to the salt plume package
+      _RL leadPlumeFraction             (1:sNx,1:sNy)
+#endif
+
+c     The minimum value of HEFF to be divided by during the calculation of d(AREA)/dt
+      _RL HEFF_MIN
+ 
+c      Variables for debugging (predicted temperature change from various sources)
+      _RL PredTempChange                (1:sNx,1:sNy)
+      _RL PredTempChangeFromQSW         (1:sNx,1:sNy)
+      _RL PredTempChangeFromOA_MQNET    (1:sNx,1:sNy)
+      _RL PredTempChangeFromFIA         (1:sNx,1:sNy)
+      _RL PredTempChangeFromNewIceVol   (1:sNx,1:sNy)
+      _RL PredTempChangeFromF_IA_NET    (1:sNx,1:sNy)
+      _RL PredTempChangeFromF_IO_NET    (1:sNx,1:sNy)
+
+      _RL ExpectedIceVolumeChange       (1:sNx,1:sNy)
+      _RL ExpectedSnowVolumeChange      (1:sNx,1:sNy)
+      _RL ActualNewTotalVolumeChange    (1:sNx,1:sNy)
+      _RL ActualNewTotalSnowMelt        (1:sNx,1:sNy)
+
+      _RL EnergyInNewTotalIceVolume     (1:sNx,1:sNy)
+      _RL NetEnergyFluxOutOfOcean       (1:sNx,1:sNy)
+
+C     The energy taken out of the ocean which is not converted
+C     to sea ice (Joules)
+      _RL ResidualEnergyOutOfOcean      (1:sNx,1:sNy)
+
+C     Snow accumulation rate over ice (m/s)
+      _RL SnowAccRateOverIce            (1:sNx,1:sNy)
+
+C     Total snow accumulation over ice (m)
+      _RL SnowAccOverIce                (1:sNx,1:sNy)
+
+C     The precipitation rate over the ice which goes immediately into the ocean
+      _RL PrecipRateOverIceSurfaceToSea (1:sNx,1:sNy)
+
+C     The potential snow melt rate if all snow surface heat flux convergences
+C     goes to melting snow (m/s)
+      _RL PotSnowMeltRateFromSurf       (1:sNx,1:sNy)
+
+C     The potential thickness of snow which could be melted by snow surface
+C     heat flux convergence (m)
+      _RL PotSnowMeltFromSurf           (1:sNx,1:sNy)
+
+C     The actual snow melt rate due to snow surface  heat flux convergence
+      _RL SnowMeltRateFromSurface       (1:sNx,1:sNy)
+
+C     The actual surface heat flux convergence used to melt snow (W/m^2)
+      _RL SurfHeatFluxConvergToSnowMelt (1:sNx,1:sNy)
+
+C     The actual thickness of snow to be melted by snow surface
+C     heat flux convergence (m)
+      _RL SnowMeltFromSurface           (1:sNx,1:sNy)
+
+C     The freshwater contribution to the ocean from melting snow (m)
+      _RL FreshwaterContribFromSnowMelt (1:sNx,1:sNy)
+
+C     The freshwater contribution to (from) the ocean from melting (growing) ice (m)
+      _RL FreshwaterContribFromIce      (1:sNx,1:sNy)
+
+C     S_a : d(AREA)/dt
+      _RL S_a                           (1:sNx,1:sNy)
+
+C     S_a_from_IGROW : d(AREA)/dt [from ice growth rate from open water fluxes]
+      _RL S_a_from_IGROW                (1:sNx,1:sNy)
+
+C     S_h : d(HEFF)/dt
+      _RL S_h                           (1:sNx,1:sNy)
+
+C     S_hsnow : d(HSNOW)/dt
+      _RL S_hsnow                       (1:sNx,1:sNy)
+
+C     HSNOW_ORIG : The mean snow thickness before any accumulation, 
+C                  melt, or flooding (m)
+      _RL HSNOW_ORIG                    (1:sNx,1:sNy)
+
+C     F_ia  - sea ice/snow surface heat flux with atmosphere (W/m^2)
+C       F_ia > 0, heat loss to atmosphere
+C       F_ia < 0, atmospheric heat flux convergence (ice/snow surface melt)
+      _RL F_ia                          (1:sNx,1:sNy)
+
+C     F_ia_net - the net heat flux divergence at the sea ice/snow surface
+C                including sea ice conductive fluxes and atmospheric fluxes (W/m^2)
+C       F_ia_net = 0, sea ice/snow surface energy balance condition met
+C                     upward conductive fluxes balance surface heat loss
+C       F_ia_net < 0, net heat flux convergence at ice/snow surface 
+C                     zero conductive fluxes and net atmospheric convergence
+      _RL F_ia_net                      (1:sNx,1:sNy)
+
+C     F_ia_net - the net heat flux divergence at the sea ice/snow surface 
+C                before snow is melted with any convergence (W/m^2)
+C        F_ia_net < 0, some snow, if present, will melt 
+      _RL F_ia_net_before_snow          (1:sNx,1:sNy)
+
+C     F_io_net - the net upward conductive heat flux through the ice+snow system
+C                realized at the sea ice/snow surface
+C        F_io_net > 0, heat conducting upward from ice base --> basal thickening
+C        F_io_net = 0, no upward heat conduction 
+C                      ice/snow surface temperature > SEAICE_freeze)  
+      _RL F_io_net                      (1:sNx,1:sNy)
+
+C     F_ao  - heat flux from atmosphere to ocean (W/m^2)
+C        F_ao > 0
+      _RL F_ao                          (1:sNx,1:sNy)
+
+C     F_mi - heat flux from ocean to the ice (W/m^2)
+      _RL F_mi                          (1:sNx,1:sNy)
+ 
+
+c     The ocean temperature used for the calculation of turbulent ocean-ice heat fluxes
+      _RL surf_theta
+
+C     Helper variables for debugging
+      _RL FLUX_TO_DELTA_TEMP,ENERGY_TO_DELTA_TEMP
+
+      if ( buoyancyRelation .eq. 'OCEANICP' ) then
+         kSurface        = Nr 
+      else
+         kSurface        = 1
+      endif
+
+c    For debugging
+      FLUX_TO_DELTA_TEMP = SEAICE_deltaTtherm*
+     &            recip_Cp*recip_rhoConst * recip_drF(1)
+
+      ENERGY_TO_DELTA_TEMP = recip_Cp*recip_rhoConst*recip_drF(1)
+
+C     TBC : The freezing point of seawater (deg C)
+      TBC          = SEAICE_freeze
+
+C     TMELT : The freezing point of fresh water (deg K)
+      TMELT = 273.15 _d 0 
+
+c     A reference seawater density (kg m^-3)
+      RHOSW = 1026. _d 0
+
+c     Freshwater density (kg m^-3)
+      RHOFW = rhoConstFresh
+
+c     The Stanton number for the McPhee 
+c     ocean-ice heat flux parameterization (dimensionless)
+      STANTON_NUMBER = 0.0056 _d 0 
+
+c     USTAR_BASE : A typical friction velocity beneath sea 
+c                  ice for the McPhee heat flux parameterization (m/s)
+      USTAR_BASE = 0.0125 _d 0
+
+C     CPW : Seawater heat capacity   (J m^-3 K^-1)
+      CPW = 4010. _d 0
+
+c     Li : Ice latent heat of fusion (J kg^-1)
+      Li = 3.34 _d 5 
+
+c     Factors used to to map between energy fluxes and snow/ice melt or growth
+      QI = ONE/SEAICE_rhoIce/Li
+      QS = ONE/SEAICE_rhoSnow/Li
+
+c     Helper terms for snow flooding
+      FL_C2 = SEAICE_rhoIce/RHOSW
+      FL_C3 = (RHOSW-SEAICE_rhoIce)/SEAICE_rhoSnow
+      FL_C4 = SEAICE_rhoSnow/SEAICE_rhoIce
+
+#ifdef SEAICE_USE_ORIGINAL_HEAT_FLUX
+c     GAMMA is used to calculate ocean-ice heat fluxes from
+c     a user-specified flux timescale (SEAICE_gamma_t).  
+c     Originally, 3 days in seconds was suggested as useful.
+c     To keep this timescale up to date given advances in
+c     the parameterization, GAMMA is specified as follows, 
+c     
+      GAMMA =  10. _d 0/SEAICE_gamma_t
+
+c     n.b., changed from drF(1)/SEAICE_gamma_t to make 
+c     a more robust form in setups with a higher vertical resolution.
+#endif
+
+      DO bj=myByLo(myThid),myByHi(myThid)
+         DO bi=myBxLo(myThid),myBxHi(myThid)
+c     
+#ifdef ALLOW_AUTODIFF_TAMC
+            act1 = bi - myBxLo(myThid)
+            max1 = myBxHi(myThid) - myBxLo(myThid) + 1
+            act2 = bj - myByLo(myThid)
+            max2 = myByHi(myThid) - myByLo(myThid) + 1
+            act3 = myThid - 1
+            max3 = nTx*nTy
+            act4 = ikey_dynamics - 1
+            iicekey = (act1 + 1) + act2*max1
+     &           + act3*max1*max2
+     &           + act4*max1*max2*max3
+#endif /* ALLOW_AUTODIFF_TAMC */
+C     
+C     initialise a few fields
+C     
+#ifdef ALLOW_AUTODIFF_TAMC
+CADJ STORE area(:,:,bi,bj) = comlev1_bibj, 
+CADJ &                       key = iicekey, byte = isbyte
+#endif /* ALLOW_AUTODIFF_TAMC */
+
+#ifdef SEAICE_SIMULATE_CONVERGENCE_IN_1D_MODEL
+c           simulate total convergence from dynamics
+            DO J=1,sNy
+               DO I=1,sNx
+                  IF (HEFF(I,J,bi,bj) .GT. ZERO) THEN
+                     AREA(I,J,bi,bj) = ONE
+                  ENDIF
+               ENDDO
+            ENDDO
+#endif
+
+#ifdef ALLOW_AUTODIFF_TAMC
+CADJ STORE area(:,:,bi,bj) = comlev1_bibj, 
+CADJ &                       key = iicekey, byte = isbyte
+CADJ STORE qnet(:,:,bi,bj) = comlev1_bibj, 
+CADJ &                       key = iicekey, byte = isbyte
+CADJ STORE qsw(:,:,bi,bj)  = comlev1_bibj, 
+CADJ &                       key = iicekey, byte = isbyte
+#endif /* ALLOW_AUTODIFF_TAMC */
+c
+            DO J=1,sNy
+               DO I=1,sNx
+c                 Bound area, heff, and hsnow 
+                  AREA(I,J,bi,bj) = MIN(ONE,AREA(I,J,bi,bj))
+                  AREA(I,J,bi,bj) = MAX(ZERO,AREA(I,J,bi,bj))
+                  HEFF(I,J,bi,bj) = MAX(ZERO, HEFF(I,J,bi,bj))
+                  HSNOW(I,J,bi,bj)  = MAX(ZERO, HSNOW(I,J,bi,bj))
+
+c                 Sanity checks 
+                  IF (HEFF(I,J,bi,bj) .LE. ZERO .OR.
+     &                AREA(I,J,bi,bj) .LE. ZERO) THEN
+                    
+                    AREA(I,J,bi,bj)       = 0. _d 0
+                    HEFF(I,J,bi,bj)       = 0. _d 0
+                    HSNOW(I,J,bi,bj)      = 0. _d 0
+                  ENDIF
+               ENDDO
+            ENDDO
+
+
+            DO J=1,sNy
+               DO I=1,sNx
+                  F_ia_net                        (I,J) = 0. _d 0
+                  F_ia_net_before_snow            (I,J) = 0. _d 0
+                  F_io_net                        (I,J) = 0. _d 0
+
+                  F_ia                            (I,J) = 0. _d 0
+                  F_ao                            (I,J) = 0. _d 0
+                  F_mi                            (I,J) = 0. _d 0
+
+                  QSWO                            (I,J) = 0. _d 0
+                  QSWI                            (I,J) = 0. _d 0
+
+                  QSWO_BELOW_FIRST_LAYER          (I,J) = 0. _d 0
+                  QSWO_IN_FIRST_LAYER             (I,J) = 0. _d 0
+
+                  S_a                             (I,J) = 0. _d 0
+                  S_h                             (I,J) = 0. _d 0
+
+                  IceGrowthRateUnderExistingIce   (I,J) = 0. _d 0
+                  IceGrowthRateFromSurface        (I,J) = 0. _d 0
+                  NetExistingIceGrowthRate        (I,J) = 0. _d 0
+                  S_a_from_IGROW                  (I,J) = 0. _d 0
+
+                  PredTempChange                  (I,J) = 0. _d 0
+                  PredTempChangeFromQSW           (I,J) = 0. _d 0
+                  PredTempChangeFromOA_MQNET      (I,J) = 0. _d 0
+                  PredTempChangeFromFIA           (I,J) = 0. _d 0
+                  PredTempChangeFromF_IA_NET      (I,J) = 0. _d 0
+                  PredTempChangeFromF_IO_NET      (I,J) = 0. _d 0
+                  PredTempChangeFromNewIceVol     (I,J) = 0. _d 0
+
+                  IceGrowthRateOpenWater          (I,J) = 0. _d 0
+                  IceGrowthRateMixedLayer         (I,J) = 0. _d 0
+
+#ifdef ALLOW_SALT_PLUME
+                  IceGrowthRateInLeads            (I,J) = 0. _d 0
+                  leadPlumeFraction               (I,J) = 0. _d 0
+                  saltPlumeFlux             (I,J,bi,bj) = 0. _d 0
+#endif
+
+                  ExpectedIceVolumeChange         (I,J) = 0. _d 0
+                  ExpectedSnowVolumeChange        (I,J) = 0. _d 0
+                  ActualNewTotalVolumeChange      (I,J) = 0. _d 0
+                  ActualNewTotalSnowMelt          (I,J) = 0. _d 0
+
+                  EnergyInNewTotalIceVolume       (I,J) = 0. _d 0
+                  NetEnergyFluxOutOfOcean         (I,J) = 0. _d 0
+                  ResidualEnergyOutOfOcean          (I,J) = 0. _d 0
+                  QSW_absorb_in_first_layer       (I,J) = 0. _d 0
+                  QSW_absorb_below_first_layer    (I,J) = 0. _d 0
+
+                  SnowAccRateOverIce              (I,J) = 0. _d 0
+                  SnowAccOverIce                  (I,J) = 0. _d 0
+                  PrecipRateOverIceSurfaceToSea   (I,J) = 0. _d 0
+
+                  PotSnowMeltRateFromSurf         (I,J) = 0. _d 0
+                  PotSnowMeltFromSurf             (I,J) = 0. _d 0
+                  SnowMeltFromSurface             (I,J) = 0. _d 0
+                  SnowMeltRateFromSurface         (I,J) = 0. _d 0
+                  SurfHeatFluxConvergToSnowMelt   (I,J) = 0. _d 0
+
+                  FreshwaterContribFromSnowMelt   (I,J) = 0. _d 0
+                  FreshwaterContribFromIce        (I,J) = 0. _d 0
+
+c the post sea ice advection and diffusion ice state are in time level 1.  
+c move these to the time level 2 before thermo.  after this routine 
+c the updated ice state will be in time level 1 again. (except for snow 
+c which does not have 3 time levels for some reason) 
+                  HEFFNm1(I,J,bi,bj) = HEFF(I,J,bi,bj) 
+                  AREANm1(I,J,bi,bj) = AREA(I,J,bi,bj) 
+
+#ifdef SEAICE_SIMULATE_DIVERGENCE_IN_1D_MODEL
+c Sometimes it's nice to run a 1-D setup but how then to simulate
+c the effect of mechanical divergence?.  To simulate the effect of 
+c having regular lead openings, each time step remove a fraction
+c of the ice area while maintaining the actual thickness of ice
+c and snow.
+
+                  IF (AREANm1(I,J,bi,bj) .GT. ZERO) THEN
+                     HICE_ACTUAL(I,J)  = 
+     &                  HEFFNm1(I,J,bi,bj)/AREANm1(I,J,bi,bj)
+
+                     HSNOW_ACTUAL(I,J) = HSNOW(I,J,bi,bj)/
+     &                  AREANm1(I,J,bi,bj)
+
+c                    Removes about 1.2% of the concentration in 48 hours.
+                     AREANm1(I,J,bi,bj) = AREANm1(I,J,bi,bj)*0.99975 _d 0
+
+c                    Maintain the same snow and ice thickness
+                     HEFFNm1(I,J,bi,bj) = 
+     &                     HICE_ACTUAL(I,J)*AREANm1(I,J,bi,bj)
+
+                     HSNOW(I,J,bi,bj) = 
+     &                     HSNOW_ACTUAL(I,J)*AREANm1(I,J,bi,bj)
+
+                   ENDIF
+#endif            
+
+               ENDDO
+            ENDDO
+
+#ifdef ALLOW_AUTODIFF_TAMC
+CADJ STORE area(:,:,bi,bj)   = comlev1_bibj, 
+CADJ &                         key = iicekey, byte = isbyte
+CADJ STORE heff(:,:,bi,bj)   = comlev1_bibj, 
+CADJ &                         key = iicekey, byte = isbyte
+CADJ STORE hsnow(:,:,bi,bj)  = comlev1_bibj, 
+CADJ &                         key = iicekey, byte = isbyte
+CADJ STORE tice(:,:,bi,bj)   = comlev1_bibj, 
+CADJ &                         key = iicekey, byte = isbyte
+CADJ STORE precip(:,:,bi,bj) = comlev1_bibj, 
+CADJ &                         key = iicekey, byte = isbyte
+#endif /* ALLOW_AUTODIFF_TAMC */
+
+            DO J=1,sNy
+               DO I=1,sNx
+C WE HAVE TO BE CAREFUL HERE SINCE ADVECTION/DIFFUSION COULD HAVE 
+C MAKE EITHER (BUT NOT BOTH) HEFF OR AREA ZERO OR NEGATIVE 
+C HSNOW COULD ALSO BECOME NEGATIVE 
+                  HEFFNm1(I,J,bi,bj) = MAX(ZERO,HEFFNm1(I,J,bi,bj)) 
+                  HSNOW(I,J,bi,bj)   = MAX(ZERO,HSNOW(I,J,bi,bj)  ) 
+                  AREANm1(I,J,bi,bj) = MAX(ZERO,AREANm1(I,J,bi,bj)) 
+cif this is hack to prevent negative precip.  somehow negative precips  
+cif escapes my exf_checkrange hack
+cph-checkthis
+                  IF (PRECIP(I,J,bi,bj) .LT. ZERO) THEN 
+                     PRECIP(I,J,bi,bj) = ZERO 
+                  ENDIF 
+               ENDDO
+            ENDDO
+            
+#ifdef ALLOW_AUTODIFF_TAMC
+CADJ STORE area(:,:,bi,bj)   = comlev1_bibj, 
+CADJ &                         key = iicekey, byte = isbyte
+CADJ STORE heff(:,:,bi,bj)   = comlev1_bibj, 
+CADJ &                         key = iicekey, byte = isbyte
+CADJ STORE hsnow(:,:,bi,bj)  = comlev1_bibj, 
+CADJ &                         key = iicekey, byte = isbyte
+CADJ STORE precip(:,:,bi,bj) = comlev1_bibj, 
+CADJ &                         key = iicekey, byte = isbyte
+#endif
+            DO J=1,sNy
+               DO I=1,sNx
+
+                  IF (HEFFNm1(I,J,bi,bj) .LE. ZERO) THEN 
+                      AREANm1(I,J,bi,bj) = 0. _d 0
+                      HSNOW(I,J,bi,bj)   = 0. _d 0
+                  ENDIF 
+ 
+                  IF (AREANm1(I,J,bi,bj) .LE. ZERO) THEN 
+                     HEFFNm1(I,J,bi,bj)  = 0. _d 0
+                     HSNOW(I,J,bi,bj)    = 0. _d 0
+                  ENDIF 
+ 
+C PROCEED ONLY IF WE ARE CERTAIN TO HAVE ICE (AREA > 0) 
+
+                  IF (AREANm1(I,J,bi,bj) .GT. ZERO) THEN
+                     HICE_ACTUAL(I,J)  = 
+     &                  HEFFNm1(I,J,bi,bj)/AREANm1(I,J,bi,bj)
+
+                     HSNOW_ACTUAL(I,J) = HSNOW(I,J,bi,bj)/
+     &                  AREANm1(I,J,bi,bj)
+
+c                   ACCUMULATE SNOW
+c                   Is the ice/surface below freezing or at the freezing 
+c                   point (melting).  If it is freezing the precip is 
+c                   felt as snow and will accumulate over the ice. Else,
+c                   precip makes its way, like all things in time, to the sea.
+                    IF (TICE(I,J,bi,bj) .LT. TMELT) THEN
+c                     Snow falls onto freezing surface remaining as snow
+                      SnowAccRateOverIce(I,J) = 
+     &                  PRECIP(I,J,bi,bj)*RHOFW/SEAICE_rhoSnow
+
+c                     None of the precipitation falls into the sea 
+                      PrecipRateOverIceSurfaceToSea(I,J) = 0. _d 0
+  
+                    ELSE 
+c                     The snow melts on impact is is considered 
+c                     nothing more than rain.  Since meltponds are
+c                     not explicitly represented,this rain runs
+c                     immediately into the sea
+
+                      SnowAccRateOverIce(I,J) = 0. _d 0
+C                     The rate of rainfall over melting ice.
+                      PrecipRateOverIceSurfaceToSea(I,J)=
+     &                  PRECIP(I,J,bi,bj)
+                   ENDIF
+
+c                  In m of mean snow thickness.
+                   SnowAccOverIce(I,J) = 
+     &                  SnowAccRateOverIce(I,J)
+     &                  *SEAICE_deltaTtherm*AreaNm1(I,J,bi,bj)
+
+                ELSE
+                   HEFFNm1(I,J,bi,bj) = 0. _d 0
+                   HICE_ACTUAL(I,J)   = 0. _d 0
+                   HSNOW_ACTUAL(I,J)  = 0. _d 0
+                   HSNOW(I,J,bi,bj)   = 0. _d 0
+                ENDIF
+                HSNOW_ORIG(I,J) = HSNOW(I,J,bi,bj)
+             ENDDO
+          ENDDO
+            
+C     FIND ATM. WIND SPEED
+        DO J=1,sNy
+         DO I=1,sNx
+C         copy the wind speed computed in exf_wind.F to UG
+          UG(I,J) = MAX(SEAICE_EPS,wspeed(I,J,bi,bj))
+         ENDDO
+        ENDDO
+
+#ifdef ALLOW_AUTODIFF_TAMC
+cphCADJ STORE heff   = comlev1, key = ikey_dynamics
+cphCADJ STORE hsnow  = comlev1, key = ikey_dynamics
+cphCADJ STORE uwind  = comlev1, key = ikey_dynamics
+cphCADJ STORE vwind  = comlev1, key = ikey_dynamics
+CADJ STORE tice   = comlev1, key = ikey_dynamics
+#endif /* ALLOW_AUTODIFF_TAMC */
+
+C           SET LAYER TEMPERATURE IN KELVIN
+            DO J=1,sNy
+               DO I=1,sNx
+                  TMIX(I,J,bi,bj)=
+     &                 theta(I,J,kSurface,bi,bj) + TMELT
+               ENDDO
+            ENDDO
+
+C           CALCULATE THE THERMODYNAMIC FLUXES WITHIN THE SNOW/ICE SYSTEM
+            CALL SEAICE_BUDGET_ICE_IF(
+     I           UG, HICE_ACTUAL, HSNOW_ACTUAL, 
+     U           TICE, 
+     O           F_io_net,F_ia_net,F_ia, QSWI, 
+     I           bi, bj, myThid)
+
+C Sometimes it is nice to have a setup without ice-atmosphere heat
+C fluxes.  This flag turns those fluxes to zero but leaves the 
+C Ice ocean fluxes intact.  Thus, the first oceanic cell can transfer
+C heat to the ice leading to melting in F_ml and it can release 
+C heat to the atmosphere through leads and open area thus growing it in
+C F_ao
+
+#ifdef FORBID_ICE_SURFACE_ATMOSPHERE_HEAT_FLUXES
+            DO J=1,sNy
+               DO I=1,sNx
+                  F_ia_net (I,J)  = 0. _d 0
+                  F_ia (I,J)      = 0. _d 0
+                  F_io_net(I,J)   = 0. _d 0
+                  QSWI(I,J)       = 0. _d 0
+               ENDDO
+            ENDDO
+#endif
+
+            DO J=1,sNy
+               DO I=1,sNx
+
+#ifdef SEAICE_DEBUG
+               IF ( (I .EQ. SEAICE_debugPointX)   .and.
+     &              (J .EQ. SEAICE_debugPointY) ) THEN
+
+                 print *,'sig: I,J,F_ia,F_ia_net',I,J,F_ia(I,J),
+     &              F_ia_net(I,J)
+
+               ENDIF
+#endif
+
+c                 If there is heat flux convergence at the snow surface,
+c                 use that energy to melt snow before melting ice.  It's
+c                 possible that some snow will remain after melting, 
+c                 which will drive F_ia_net to zero, or that all of the 
+c                 snow will be melted, leaving a nonzero F_ia_net to melt
+c                 some ice.  
+                  F_ia_net_before_snow(I,J) = F_ia_net(I,J)
+
+c                 Only continue if there is snow and ice in the cell
+                  IF (AreaNm1(I,J,bi,bj)*HEFFNm1(I,J,bi,bj)
+     &                .LE. ZERO                            ) THEN
+                     IceGrowthRateUnderExistingIce(I,J) = 0. _d 0
+                     IceGrowthRateFromSurface(I,J)      = 0. _d 0
+                     NetExistingIceGrowthRate(I,J)      = 0. _d 0
+                  ELSE
+c                    The growth rate (m/s) beneath existing ice is given by the upward
+c                    ocean-ice conductive flux, F_io_net, and QI.
+                     IceGrowthRateUnderExistingIce(I,J)=F_io_net(I,J)*QI
+
+c                    The rate at which snow is melted (m/s) because of surface 
+c                    heat flux convergence.  Note, during snow melt, F_ia_net must 
+c                    be negative (implying convergence) to make PSMRFW is positive
+                     PotSnowMeltRateFromSurf(I,J)= - F_ia_net(I,J)*QS
+
+c                    This is the depth of snow (m) that would be melted over one time step.
+                     PotSnowMeltFromSurf(I,J) =
+     &                  PotSnowMeltRateFromSurf(I,J)* SEAICE_deltaTtherm
+
+c                    If we can melt MORE than is actually there, then the melt 
+c                    rate is reduced so that only that which is there 
+c                    is melted during the time step.  In this case, not all of the 
+c                    heat flux convergence at the surface is used to melt snow.
+c                    Any remaining energy will melt ice.  
+
+c                    SurfHeatFluxConvergToSnowMelt is the part of the total heat 
+c                    flux convergence which melts snow.
+
+                     IF (PotSnowMeltFromSurf(I,J) .GE. 
+     &                   HSNOW_ACTUAL(I,J)) THEN
+
+c                      Snow melt and melt rate (actual not mean snow thickness)
+                       SnowMeltFromSurface(I,J)     = HSNOW_ACTUAL(I,J)
+
+                       SnowMeltRateFromSurface(I,J) = 
+     &                   SnowMeltFromSurface(I,J)/ SEAICE_deltaTtherm
+
+                       SurfHeatFluxConvergToSnowMelt(I,J) =
+     &                   -HSNOW_ACTUAL(I,J)/QS/SEAICE_deltaTtherm
+                     ELSE
+c                      In this case there will be snow remaining after melting.
+c                      All of the surface heat convergence will be redirected to 
+c                      this effort.
+                       SnowMeltFromSurface(I,J)=PotSnowMeltFromSurf(I,J)
+
+                       SnowMeltRateFromSurface(I,J) = 
+     &                    PotSnowMeltRateFromSurf(I,J)
+
+                       SurfHeatFluxConvergToSnowMelt(I,J) =F_ia_net(I,J)
+                     ENDIF
+
+c                    Reduce the heat flux convergence available to melt surface
+c                    ice by the amount used to melt snow
+                     F_ia_net(I,J) = 
+     &                  F_ia_net(I,J)-SurfHeatFluxConvergToSnowMelt(I,J)
+
+                     IceGrowthRateFromSurface(I,J) = F_ia_net(I,J)*QI
+
+c                    The total growth rate (m/s) of the existing ice - the rate of
+c                    new ice accretion at the base less the rate due to surface melt
+                     NetExistingIceGrowthRate(I,J) = 
+     &                 IceGrowthRateUnderExistingIce(I,J) +
+     &                 IceGrowthRateFromSurface(I,J)
+                  ENDIF
+               ENDDO
+            ENDDO
+
+c           Retrieve the air-sea heat and shortwave radiative fluxes
+            CALL SEAICE_BUDGET_OCEAN(
+     I           UG, 
+     U           TMIX, 
+     O           F_ao, QSWO, 
+     I           bi, bj, myTime, myIter, myThid )
+ 
+#ifdef SEAICE_DEBUG
+        print *,'myiter', myIter
+        print '(A,2i4,2(1x,1P2E15.3))',
+     &       'ifice sigr, dbgx,dby, (netHF, SWHeatFlux)',
+     &        SEAICE_debugPointX,   SEAICE_debugPointY,
+     &        F_ao(SEAICE_debugPointX, SEAICE_debugPointY),
+     &        QSWO(SEAICE_debugPointX, SEAICE_debugPointY)
+#endif
+
+
+c--   Not all of the sw radiation is absorbed in the uppermost ocean grid cell layer.
+c     Only that fraction which converges in the uppermost ocean grid cell is used to
+c     melt ice.
+c           SWFRACB - the fraction of incoming sw radiation absorbed in the 
+c                     uppermost ocean grid cell (calculated in seaice_init_vari.F)
+            DO J=1,sNy
+               DO I=1,sNx
+
+c The contribution of shortwave heating is 
+c not included without #define SHORTWAVE_HEATING
+#ifdef SHORTWAVE_HEATING
+                  QSWO_BELOW_FIRST_LAYER(i,j)= QSWO(I,J)*SWFRACB
+                  QSWO_IN_FIRST_LAYER(I,J)   = QSWO(I,J)*(ONE - SWFRACB)
+#else 
+                  QSWO_BELOW_FIRST_LAYER(i,j)= 0. _d 0
+                  QSWO_IN_FIRST_LAYER(I,J)   = 0. _d 0
+#endif
+                  IceGrowthRateOpenWater(I,J)= QI*
+     &              (F_ao(I,J) - QSWO(I,J) + QSWO_IN_FIRST_LAYER(I,J))
+
+             ENDDO
+            ENDDO        
+            
+
+#ifdef ALLOW_AUTODIFF_TAMC
+CADJ STORE theta(:,:,:,bi,bj)= comlev1_bibj, 
+CADJ &                         key = iicekey, byte = isbyte
+CADJ STORE heff(:,:,bi,bj)   = comlev1_bibj, 
+CADJ &                         key = iicekey, byte = isbyte
+#endif /* ALLOW_AUTODIFF_TAMC */
+
+
+C--   Calcuate the heat fluxes from the ocean to the sea ice
+            DO J=1,sNy
+               DO I=1,sNx
+
+C     Calculate the seawater freezing point
+#ifdef SEAICE_VARIABLE_FREEZING_POINT
+                  TBC = -0.0575 _d 0*salt(I,J,kSurface,bi,bj) + 
+     &                 0.0901 _d 0
+#endif /* SEAICE_VARIABLE_FREEZING_POINT */
+                  
+c     Bound the ocean temperature to be at or above the freezing point.
+      surf_theta = max(theta(I,J,kSurface,bi,bj), TBC)
+
+c     This model has two alternative schemes to calculate turbulent ocean-ice
+c     heat fluxes.  Each is described in turn
+c
+c     ==== METHOD 1 ====
+c
+c     The first uses an empircal relationship between the 
+c     'far-field' ocean temperature and ocean to sea ice turbulent heat fluxes 
+c     given by McPhee:
+c
+c     Flux  = rho_sw * cp_sw * <w'T'> 
+c     <w'T'>= S_t *  u_star * (T_o - T_f)
+c
+c          Where,
+c             rho_sw : seawater density (kg m^-3)
+c             cp_sw  : seawater heat capcity (J kg^-1 K^-1)
+c             S_t    : Stanton Number ~ 0.0056 (dimensionless)
+c             u_star : friction velocity beneath ice ~ 0.015 m s^-1
+c             T_o, T_f : The 'far-field' ocean temperature and ice
+c                        freezing point (deg C)
+c
+c     Using typical values, ice advected over waters warmer by 1 degree
+c     will be subjected to a basal heat flux of ~ 345 W m^-2.  
+c
+c     In the model, the criteria for ice growth is that the air-sea
+c     heat loss must exceed the potential ocean-ice heat flux (i.e., more 
+c     potential ice production over one time step than melt).  
+c     Using the above parameterization, ice will form in waters which 
+c     are much warmer than its salinity-determined freezing point
+c     using typical wintertime conditions in, say, the North Atlantic.
+c
+c     Therefore, when no ice is present, an additional factor is applied
+c     to the above <w'T'> (mixedLayerTurbulenceFactor) to represent the idea that 
+c     turbulent mixing at and near the surface of an ice-free ocean
+c     is much greater than mixing beneath an ice-covered one.
+c
+c     A factor of 12.5 is chosen for mixedLayerTurbulenceFactor.  Consequently,
+c     for each 0.1 degree above freezing of the upper ocean grid cell,
+c     the air-sea heat losses must exceed ~ 515 W m^-2 before ice forms.
+c    
+c     Once ice gains a foothold in a grid cell, the McPhee parameterization
+c     is immediately invoked.
+c   
+c     ==== METHOD 2 ====
+c
+c     The second scheme (the original and now outdated version)
+c     subsumes (S_t * u_star) into a single variable (SEAICE_gamma_t)
+c      in the following way:
+c
+c     Flux  = rho_sw * cp_sw * GAMMA 
+c     GAMMA = dRf(1)/SEAICE_gamma_t * (T_o - T_f)
+c    
+c           Where,
+c               dRf(1)  : depth of surface level grid cell (originally 
+c                         assumed to be 10 m)
+c               SEAICE_gamma_t : an empirical parameter (~ 3 days in seconds)
+c
+c     Using typical values, ice advected into a grid cell 
+c     that is warmer than the sea ice freezing point by 1 degree
+c     will be subjected to a basal heat flux of ~ 160 W m^-2.   Therefore,
+c     as written, one should choose a SEAICE_gamma_t = 1.4 days in seconds
+c     to have flux magnitudes match those of the McPhee parameterization.
+c    
+c     The original scheme is accessed by defining  #SEAICE_USE_ORIGINAL_HEAT FLUX
+
+#ifndef SEAICE_USE_ORIGINAL_HEAT_FLUX
+c                 If ice is present, MixedLayerTurbulenceFactor = 1.0, else 12.50
+                  IF (AREANm1(I,J,bi,bj) .GT. 0. _d 0) THEN
+                     MixedLayerTurbulenceFactor = ONE
+                  ELSE
+                     MixedLayerTurbulenceFactor = 12.5 _d 0
+                  ENDIF
+
+                  F_mi(I,J) = -STANTON_NUMBER * USTAR_BASE * RHOSW *
+     &                CPW *(surf_theta - TBC)*MixedLayerTurbulenceFactor
+#else
+c                 no turbulence factor using original_heat_flux scheme
+                  F_mi(I,J) = -GAMMA*RHOSW*CPW *(surf_theta - TBC)
+
+#endif /* SEAICE_USE_ORIGINAL_HEAT_FLUX */
+
+                  IceGrowthRateMixedLayer(I,J) = F_mi(I,J)*QI;
+               ENDDO
+            ENDDO 
+
+#ifdef ALLOW_AUTODIFF_TAMC
+CADJ STORE S_h(:,:)         = comlev1_bibj, 
+CADJ &                        key = iicekey, byte = isbyte
+#endif /* ALLOW_AUTODIFF_TAMC */
+
+
+
+C           CALCULATE THICKNESS DERIVATIVE (S_h)
+            DO J=1,sNy
+               DO I=1,sNx
+                  S_h(I,J) = 
+     &                 NetExistingIceGrowthRate(I,J)*AREANm1(I,J,bi,bj)+
+     &                 (ONE -AREANm1(I,J,bi,bj))*
+     &                 IceGrowthRateOpenWater(I,J) +
+     &                 IceGrowthRateMixedLayer(I,J)
+
+c                  Both the accumulation and melt rates are in terms
+c                  of actual snow thickness.  As with ice, multiplying
+c                  with area converts to mean snow thickness.
+                   S_hsnow(I,J) =     AREANm1(I,J,bi,bj)* (
+     &                  SnowAccRateOverIce(I,J) - 
+     &                  SnowMeltRateFromSurface(I,J)     ) 
+               ENDDO
+            ENDDO
+
+#ifdef ALLOW_SALT_PLUME
+C       Now that we know the thickness tendency terms, we can calculate the saltPlumeFlux
+        DO J=1,sNy
+         DO I=1,sNx
+
+c            It is assumed that ice production in leads can generate
+c            salt plumes.  The fraction of the salt sent to the plume package
+c            from ice produced in leads (defined as the open water
+c            fraction) is a nonlinear function of ice concentration, AREA.
+c
+c            Specifically, function is a logistic curve (sigmoid) with a range and 
+c            domain {0,1}.  The function, f(AREA), has a single free parameter,
+c            SEAICE_plumeInflectionPoint, the inflection point of the curve.  
+c            By construction, the function has the following properties:
+c            f(1) \approx 1.0
+c            f(SEAICE_plumeInflectionPoint) = 0.5
+c            f(0) \approx 0.0 (when SEAICE_plumeInflectionPoint \geq 0.5)
+c            f(0) > 0.0 (when SEAICE_plumeInflectionPoint < 0.5)
+c
+c            As AREA --> 1, the open water fraction occurs
+c            in narrow leads, new ice production become spatially non-uniform,
+c            and the assumptions motivating KPP no longer hold.  To treat
+c            overturning in a more physically realistic way, the salt produced
+c            in the leads should be sent to depth via the plume package.  To assure 
+c            only narrow leads generate plumes, choose a SEAICE_plumeInflectionPoint 
+c            of > 0.8.
+
+c            Ensure that there is already ice present or that the total ice
+c            ice tendency term is positive.  We don't want to release 
+c            salt if sea ice is not established in the cell.
+
+             IF ((AREANm1(I,J,bi,bj) .GT. ZERO) .OR. 
+     &           (S_h(I,J)           .GT. ZERO)) THEN
+ 
+              leadPlumeFraction(I,J) = 
+     &         (ONE + EXP( ( SEAICE_plumeInflectionPoint - 
+     &                       AREANm1(I,J,bi,bj)
+     &                     ) * 5._d 0/
+     &                     (ONE - SEAICE_plumeInflectionPoint)
+     &                   )
+     &         )**(-ONE) 
+ 
+c             Only consider positive ice growth rate in leads for salt production
+              IceGrowthRateInLeads(I,J) = max( ZERO,
+     &         (ONE - AREANm1(I,J,bi,bj)) * IceGrowthRateOpenWater(I,J))
+
+              saltPlumeFlux(I,J,bi,bj) = leadPlumeFraction(I,J) * 
+     &            HEFFM(I,J,bi,bj)*IceGrowthRateInLeads(I,J)*
+     &            ICE2WATR*rhoConstFresh*
+     &            (salt(I,J,kSurface,bi,bj) - SEAICE_salinity_fixed)
+             ELSE 
+
+              saltPlumeFlux(I,J,bi,bj) = ZERO 
+
+             ENDIF
+
+         ENDDO
+        ENDDO
+#endif /* ALLOW_SALT_PLUME */
+
+#ifdef ALLOW_AUTODIFF_TAMC
+CADJ STORE area(:,:,bi,bj)  = comlev1_bibj, 
+CADJ &                        key = iicekey, byte = isbyte
+CADJ STORE heff(:,:,bi,bj)  = comlev1_bibj, 
+CADJ &                        key = iicekey, byte = isbyte
+CADJ STORE hsnow(:,:,bi,bj) = comlev1_bibj, 
+CADJ &                        key = iicekey, byte = isbyte
+CADJ STORE S_h(:,:)         = comlev1_bibj, 
+CADJ &                        key = iicekey, byte = isbyte
+CADJ STORE S_hsnow(:,:)     = comlev1_bibj, 
+CADJ &                        key = iicekey, byte = isbyte
+#endif /* ALLOW_AUTODIFF_TAMC */
+
+
+
+c           Caculate dA/dt (S_a)
+            DO J=1,sNy
+               DO I=1,sNx
+                  S_a(I,J) =  0. _d 0 
+
+c                 In the following, time derivatives of AREA require
+c                 divisions by HEFF. To prevent sensitivity blow up when
+c                 HEFF --> 0, we divide by an approximation to HEFF, HEFF*:
+c
+c                 HEFF* = sqrt(HEFF^2 + heff_min^2)
+c                      Where heff_min is implicitly defined as 0.1 m. 
+c
+c                 HEFF* is defined as a hyperbola with slope = 1 and 
+c                 y-intercept of heff_min.  The gradient of 1/HEFF* is 
+c                 well-behaved (correct sign) and deviates from 1/HEFF 
+c                 significantly only when HEFF --> 0.
+
+                 IF ( (HEFFNm1(I,J,bi,bj).GT. ZERO) .AND.
+     &                (AREANm1(I,J,bi,bj).NE. ZERO)) THEN
+                     HEFF_MIN = SQRT( 0.01 _d 0 + 
+     &                   HEFFNm1(I,J,bi,bj) * HEFFNm1(I,J,bi,bj) )
+                 ELSE
+c                        Just in case somehow we miss a case, we want to divide
+c                        by a sensible number, here 10 cm.
+                         HEFF_MIN = max(HEFFNm1(I,J,bi,bj), 0.1 _d 0)
+                 ENDIF
+
+c                 Caculate the ice area growth rate from the open water fluxes.
+c                 First, determine whether the open water growth rate is positive or
+c                 negative.  If positive, make sure that ice is present or that the 
+c                 net ice thickness growth rate is positive before extending ice cover 
+
+                  IF (IceGrowthRateOpenWater(I,J) .GT. ZERO) THEN
+
+c                    Determine which hemisphere for hemisphere-dependent
+c                    "lead closing variable", HO
+
+                     IF ( YC(I,J,bi,bj) .LT. ZERO ) THEN
+                        S_a_from_IGROW(I,J) = (ONE-AREANm1(I,J,bi,bj))*
+     &                     IceGrowthRateOpenWater(I,J)/HO_south
+                     ELSE
+                        S_a_from_IGROW(I,J) = (ONE-AREANm1(I,J,bi,bj))*
+     &                     IceGrowthRateOpenWater(I,J)/HO
+                     ENDIF
+
+c                    If there is already ice, add to S_a
+                     IF (AREANm1(I,J,bi,bj) .GT. ZERO) THEN
+                        S_a(I,J) = S_a(I,J) + S_a_from_IGROW(I,J)
+c                    otherwise, add to S_a only if the net ice growth rate
+c                    is positive
+                     ELSE
+                        IF (S_h(I,J) .GT. ZERO) THEN
+                           S_a(I,J) = S_a(I,J) + S_a_from_IGROW(I,J)
+                        ENDIF
+                     ENDIF
+                  ELSE  
+
+c                    The open water growth rate is negative - contract the ice cover.
+                     IF ( (AREANm1(I,J,bi,bj).GT. ZERO) .AND.
+     &                  (HEFFNm1(I,J,bi,bj).GT. ZERO) ) THEN
+
+                       S_a(I,J) = S_a(I,J) 
+     &                    + AREANm1(I,J,bi,bj)/(2. _d 0*HEFF_MIN)*
+     &                    IceGrowthRateOpenWater(I,J)*
+     &                    (ONE - AREANm1(I,J,bi,bj))
+                     ELSE
+                       S_a(I,J) = S_a(I,J) +  0. _d 0
+                     ENDIF
+                  ENDIF
+
+C                 Melt ice if the IceGrowthRateMixedLayer is negative
+                  IF ( (IceGrowthRateMixedLayer(I,J) .LE. ZERO) .AND. 
+     &                 (AREANm1(I,J,bi,bj).GT. ZERO) .AND.
+     &                 (HEFFNm1(I,J,bi,bj).NE. ZERO) ) THEN
+
+                     S_a(I,J) = S_a(I,J) 
+     &                    + AREANm1(I,J,bi,bj)/(2. _d 0 *HEFF_MIN)*
+     &                    IceGrowthRateMixedLayer(I,J)
+
+                  ELSE
+                     S_a(I,J) = S_a(I,J) +  0. _d 0
+                  ENDIF
+
+C                 Melt ice if the NetExistingIceGrowthRate is negative
+                  IF ( (NetExistingIceGrowthRate(I,J) .LE. ZERO) .AND. 
+     &                 (AREANm1(I,J,bi,bj).GT. ZERO) .AND.
+     &                 (HEFFNm1(I,J,bi,bj).NE. ZERO) ) THEN
+
+                     S_a(I,J) = S_a(I,J) 
+     &                   + AREANm1(I,J,bi,bj)/(2. _d 0 * HEFF_MIN)*
+     &                  NetExistingIceGrowthRate(I,J)*AREANm1(I,J,bi,bj)
+
+                  ELSE
+                     S_a(I,J) = S_a(I,J) +  0. _d 0
+                  ENDIF
+                  
+               ENDDO
+            ENDDO
+                 
+
+#ifdef ALLOW_AUTODIFF_TAMC
+CADJ STORE heff(:,:,bi,bj)   = comlev1_bibj, 
+CADJ &                         key = iicekey, byte = isbyte
+CADJ STORE hsnow(:,:,bi,bj)  = comlev1_bibj, 
+CADJ &                         key = iicekey, byte = isbyte
+CADJ STORE S_a(:,:)          = comlev1_bibj, 
+CADJ &                         key = iicekey, byte = isbyte
+CADJ STORE S_h(:,:)          = comlev1_bibj, 
+CADJ &                         key = iicekey, byte = isbyte
+CADJ STORE f_ao(:,:)         = comlev1_bibj, 
+CADJ &                         key = iicekey, byte = isbyte
+CADJ STORE qswi(:,:)         = comlev1_bibj, 
+CADJ &                         key = iicekey, byte = isbyte
+CADJ STORE qswo(:,:)         = comlev1_bibj, 
+CADJ &                         key = iicekey, byte = isbyte
+CADJ STORE area(:,:,bi,bj)   = comlev1_bibj, 
+CADJ &                         key = iicekey, byte = isbyte
+#endif
+
+C           Update the area, heff, and hsnow 
+            DO J=1,sNy
+               DO I=1,sNx
+                  AREA(I,J,bi,bj) = AREANm1(I,J,bi,bj) + 
+     &                 SEAICE_deltaTtherm * S_a(I,J)
+                  HEFF(I,J,bi,bj) = HEFFNm1(I,J,bi,bj) +
+     &                 SEAICE_deltaTTherm * S_h(I,J)
+                  HSNOW(I,J,bi,bj) = HSNOW(I,J,bi,bj) +
+     &                 SEAICE_deltaTTherm * S_hsnow(I,J)
+               ENDDO
+            ENDDO
+            
+#ifdef ALLOW_AUTODIFF_TAMC
+CADJ STORE area(:,:,bi,bj)  = comlev1_bibj, 
+CADJ &                        key = iicekey, byte = isbyte
+CADJ STORE heff(:,:,bi,bj)  = comlev1_bibj, 
+CADJ &                        key = iicekey, byte = isbyte
+CADJ STORE hsnow(:,:,bi,bj) = comlev1_bibj, 
+CADJ &                        key = iicekey, byte = isbyte
+#endif
+
+            DO J=1,sNy
+               DO I=1,sNx
+c                 Bound area, heff, and hsnow 
+                  AREA(I,J,bi,bj) = MIN(ONE,AREA(I,J,bi,bj))
+                  AREA(I,J,bi,bj) = MAX(ZERO,AREA(I,J,bi,bj))
+                  HEFF(I,J,bi,bj) = MAX(ZERO, HEFF(I,J,bi,bj))
+                  HSNOW(I,J,bi,bj)  = MAX(ZERO, HSNOW(I,J,bi,bj))
+
+c                 Sanity checks 
+                  IF (HEFF(I,J,bi,bj) .LE. ZERO .OR.
+     &                AREA(I,J,bi,bj) .LE. ZERO) THEN
+                    
+                    AREA(I,J,bi,bj)       = 0. _d 0
+                    HEFF(I,J,bi,bj)       = 0. _d 0
+                    HICE_ACTUAL(I,J)      = 0. _d 0
+                    HSNOW(I,J,bi,bj)      = 0. _d 0
+                    HSNOW_ACTUAL(I,J)     = 0. _d 0
+
+                  ELSE
+c                 Calcuate the actual ice and snow thicknesses
+                    HICE_ACTUAL(I,J)  =  HEFF(I,J,bi,bj)/AREA(I,J,bi,bj)
+                    HSNOW_ACTUAL(I,J) = HSNOW(I,J,bi,bj)/AREA(I,J,bi,bj)
+                  ENDIF
+
+               ENDDO
+            ENDDO
+            
+#ifdef ALLOW_AUTODIFF_TAMC
+CADJ STORE area(:,:,bi,bj) = comlev1_bibj, 
+CADJ &                       key = iicekey, byte = isbyte
+CADJ STORE heff(:,:,bi,bj) = comlev1_bibj, 
+CADJ &                       key = iicekey, byte = isbyte
+#endif /* ALLOW_AUTODIFF_TAMC */
+
+            DO J=1,sNy
+               DO I=1,sNx
+
+c                 The amount of new mean ice thickness we expect to grow
+                  ExpectedIceVolumeChange(I,J)  = S_h(I,J) *
+     &                 SEAICE_deltaTtherm
+
+c                 The amount of new mean snow thickness we expect to grow
+                  ExpectedSnowVolumeChange(I,J) = S_hsnow(I,J)*
+     &                 SEAICE_deltaTtherm
+
+c                 THE EFFECTIVE SHORTWAVE HEATING RATE
+#ifdef SHORTWAVE_HEATING
+                  QSW(I,J,bi,bj)  =
+     &                 QSWI(I,J)  * (      AREANm1(I,J,bi,bj)) +
+     &                 QSWO(I,J)  * (ONE - AREANm1(I,J,bi,bj))
+#else
+                  QSW(I,J,bi,bj) = 0. _d 0
+#endif
+
+c                 The actual ice volume change over the time step
+                  ActualNewTotalVolumeChange(I,J) = 
+     &                 HEFF(I,J,bi,bj) - HEFFNm1(I,J,bi,bj)
+
+c     The net average snow thickness melt that is actually realized. e.g.
+c     hsnow_orig  = 0.25 m (e.g. 1 m of ice over a cell 1/4 covered in snow)
+c     hsnow_new   = 0.20 m
+c     snow accum  = 0.05 m
+c            melt = 0.25 + 0.05 - 0.2 = 0.1 m 
+
+c     since this is in mean snow thickness it might have been  0.4 of actual 
+c     snow thickness over the 1/4 of the cell which is ice covered.
+                  ActualNewTotalSnowMelt(I,J) = 
+     &                 HSNOW_ORIG(I,J) +
+     &                 SnowAccOverIce(I,J) -
+     &                 HSNOW(I,J,bi,bj)
+
+c                 The energy required to melt or form the new ice volume
+                  EnergyInNewTotalIceVolume(I,J) = 
+     &                 ActualNewTotalVolumeChange(I,J)/QI
+
+c     This is the net energy flux out of the ice+ocean system
+c     Remember -----
+c     F_ia_net : Under ice/snow surface freezing conditions, 
+c                vertical conductive heat flux convergence (F_c < 0) balances
+c                heat flux divergence to atmosphere (F_ia > 0)  
+c                Otherwise, F_ia_net = F_ia (pos)
+c
+c     F_io_net : Under ice/snow surface freezing conditions, F_c < 0.
+c                Under ice surface melting conditions, F_c = 0 (no energy flux 
+c                from the ice to ocean)
+c
+c     So if we are freezing, F_io_net = the conductive flux and there 
+c     is energy balance at ice surface, F_ia_net =0.  If we are melting,
+c     there is a convergence of energy into the ice from above
+                  NetEnergyFluxOutOfOcean(I,J) = SEAICE_deltaTtherm *
+     &               (AREANm1(I,J,bi,bj) * 
+     &               (F_ia_net(I,J) + F_io_net(I,J) + QSWI(I,J))
+     &         +     (ONE - AREANm1(I,J,bi,bj)) *  F_ao(I,J))
+
+c     THE QUANTITY OF HEAT WHICH IS THE RESIDUAL TO THE QUANTITY OF 
+c     ML temperature.  If the net energy flux is exactly balanced by the 
+c     latent energy of fusion in the new ice created then we will not 
+c     change the ML temperature at all.
+
+                  ResidualEnergyOutOfOcean(I,J) = 
+     &             NetEnergyFluxOutOfOcean(I,J) -
+     &             EnergyInNewTotalIceVolume(I,J)
+
+C     NOW FORMULATE QNET, which time LEVEL, ORIG 2.
+C     THIS QNET WILL DETERMINE THE TEMPERATURE CHANGE OF THE MIXED LAYER
+C     QNET IS A DEPTH AVERAGED HEAT FLUX FOR THE OCEAN COLUMN
+C     BECAUSE OF THE 
+                  QNET(I,J,bi,bj) =
+     &             ResidualEnergyOutOfOcean(I,J) / SEAICE_deltaTtherm
+
+
+c    Like snow melt, if there is melting, this quantity is positive.
+c    The change of freshwater content is per unit area over the entire
+c    cell, not just over the ice covered bits.  This term is only used
+c    to calculate freshwater fluxes for the purpose of changing the
+c    salinity of the liquid cell.  In the case of non-zero ice salinity,
+c    the amount of freshwater is reduced by the ratio of ice salinity
+c    to water cell salinity.
+           IF  ( (salt(I,J,kSurface,bi,bj) .GT. ZERO) .AND.
+     &           (salt(I,J,kSurface,bi,bj) .GE. 
+     &                         SEAICE_salinity_fixed))  THEN 
+
+                 FreshwaterContribFromIce(I,J) =
+     &            - ActualNewTotalVolumeChange(I,J)*SEAICE_rhoICE/RHOFW*
+     &            (ONE - SEAICE_salinity_fixed/salt(I,J,kSurface,bi,bj))
+
+           ELSE
+C    If the liquid cell has a lower salinity than the specified
+c    salinity of sea ice then assume the sea ice is completely fresh
+                 FreshwaterContribFromIce(I,J) =
+     &             -ActualNewTotalVolumeChange(I,J)*SEAICE_rhoIce/RHOFW
+           ENDIF
+
+
+c    The freshwater contribution from snow comes only in the form of melt
+c    unlike ice, which takes freshwater upon growth and yields freshwater
+c    upon melt.  This is why the the actual new average snow melt was determined.
+c    In m/m^2 over the entire cell.
+                  FreshwaterContribFromSnowMelt(I,J) =
+     &                 ActualNewTotalSnowMelt(I,J)*SEAICE_rhoSnow/RHOFW
+
+c    This seems to be in m/s, original time level 2 for area
+c    Only the precip and evap need to be area weighted.  The runoff
+c    and freshwater contribs from ice and snow melt are already mean
+c    weighted
+                  EmPmR(I,J,bi,bj)  = maskC(I,J,kSurface,bi,bj)*(
+     &                 ( EVAP(I,J,bi,bj)-PRECIP(I,J,bi,bj) )
+     &                 * ( ONE - AREANm1(I,J,bi,bj) )
+     &                 - PrecipRateOverIceSurfaceToSea(I,J)*
+     &                     AREANm1(I,J,bi,bj)
+#ifdef ALLOW_RUNOFF
+     &                 - RUNOFF(I,J,bi,bj)
+#endif
+     &                 - (FreshwaterContribFromIce(I,J) +
+     &                    FreshwaterContribFromSnowMelt(I,J))/
+     &                    SEAICE_deltaTtherm )*rhoConstFresh
+
+C                 DO SOME DEBUGGING CALCULATIONS.  MAKE SURE SUMS ALL ADD UP.
+#ifdef SEAICE_DEBUG
+
+C                 Calcuate the shortwave flux absorbed in the upper ocean
+c                 grid cell
+#ifdef SHORTWAVE_HEATING
+                  QSW_absorb_in_first_layer(I,J) = QSW(I,J,bi,bj)*
+     &              (ONE - SWFRACB)
+#else 
+
+                  QSW_absorb_in_first_layer(I,J) = 0. _d 0
+#endif
+
+C                 Calcuate the sw flux beneath the upper ocean grid cell
+                  QSW_absorb_below_first_layer(I,J) = 
+     &                 QSW(I,J,bi,bj) -  QSW_absorb_in_first_layer(I,J)
+
+                  PredTempChangeFromQSW(I,J) = 
+     &             - QSW_absorb_in_first_layer(I,J) * FLUX_TO_DELTA_TEMP
+
+                  PredTempChangeFromOA_MQNET(I,J) = 
+     &            -(QNET(I,J,bi,bj)-QSWO(I,J))*(ONE -AREANm1(I,J,bi,bj))
+     &             * FLUX_TO_DELTA_TEMP
+
+                  PredTempChangeFromF_IO_NET(I,J) = 
+     &             -F_io_net(I,J)*AREANm1(I,J,bi,bj)*FLUX_TO_DELTA_TEMP
+
+                  PredTempChangeFromF_IA_NET(I,J) = 
+     &             -F_ia_net(I,J)*AREANm1(I,J,bi,bj)*FLUX_TO_DELTA_TEMP
+
+                  PredTempChangeFromNewIceVol(I,J) = 
+     &              EnergyInNewTotalIceVolume(I,J)*ENERGY_TO_DELTA_TEMP
+
+                  PredTempChange(I,J) = 
+     &              PredTempChangeFromQSW(I,J) +
+     &              PredTempChangeFromOA_MQNET(I,J) +
+     &              PredTempChangeFromF_IO_NET(I,J) +
+     &              PredTempChangeFromF_IA_NET(I,J) +
+     &              PredTempChangeFromNewIceVol(I,J)
+#endif    
+
+               ENDDO
+            ENDDO
+
+#ifdef ALLOW_AUTODIFF_TAMC
+CADJ STORE area(:,:,bi,bj)  = comlev1_bibj, 
+CADJ &                        key = iicekey, byte = isbyte
+CADJ STORE hsnow(:,:,bi,bj) = comlev1_bibj, 
+CADJ &                        key = iicekey, byte = isbyte
+CADJ STORE heff(:,:,bi,bj)  = comlev1_bibj, 
+CADJ &                        key = iicekey, byte = isbyte
+#endif /* ALLOW_AUTODIFF_TAMC */
+            
+            DO J=1,sNy
+               DO I=1,sNx
+                  AREA(I,J,bi,bj) = AREA(I,J,bi,bj)*HEFFM(I,J,bi,bj)
+                  HEFF(I,J,bi,bj) = HEFF(I,J,bi,bj)*HEFFM(I,J,bi,bj)
+                  HSNOW(I,J,bi,bj)  = HSNOW(I,J,bi,bj)*HEFFM(I,J,bi,bj)
+               ENDDO
+            ENDDO
+
+#ifdef ALLOW_AUTODIFF_TAMC
+CADJ STORE area(:,:,bi,bj)  = comlev1_bibj, 
+CADJ &                        key = iicekey, byte = isbyte
+CADJ STORE hsnow(:,:,bi,bj) = comlev1_bibj, 
+CADJ &                        key = iicekey, byte = isbyte
+CADJ STORE heff(:,:,bi,bj)  = comlev1_bibj, 
+CADJ &                        key = iicekey, byte = isbyte
+#endif /* ALLOW_AUTODIFF_TAMC */
+
+
+#ifdef ALLOW_SEAICE_FLOODING
+           IF(SEAICEuseFlooding) THEN
+
+            DO J = 1,sNy
+               DO I = 1,sNx
+                  EnergyToMeltSnowAndIce(I,J) = 
+     &                 HEFF(I,J,bi,bj)/QI +
+     &                 HSNOW(I,J,bi,bj)/QS
+                  
+                  deltaHS = FL_C2*( HSNOW_ACTUAL(I,J) -
+     &                 HICE_ACTUAL(I,J)*FL_C3 )
+                  
+                  IF (deltaHS .GT. ZERO) THEN
+                     deltaHI = FL_C4*deltaHS
+                     
+                     HICE_ACTUAL(I,J) = HICE_ACTUAL(I,J)  
+     &                    + deltaHI
+
+                     HSNOW_ACTUAL(I,J)= HSNOW_ACTUAL(I,J) 
+     &                    - deltaHS
+
+                     HEFF(I,J,bi,bj)= HICE_ACTUAL(I,J) *
+     &                    AREA(I,J,bi,bj)
+
+                     HSNOW(I,J,bi,bj) = HSNOW_ACTUAL(I,J)*
+     &                    AREA(I,J,bi,bj)
+                     
+                     EnergyToMeltSnowAndIce2(I,J) = 
+     &                    HEFF(I,J,bi,bj)/QI +
+     &                    HSNOW(I,J,bi,bj)/QS
+                     
+#ifdef SEAICE_DEBUG
+               IF ( (I .EQ. SEAICE_debugPointX)   .and.
+     &              (J .EQ. SEAICE_debugPointY) ) THEN
+
+                     print *,'Energy to melt snow+ice: pre,post,delta', 
+     &                    EnergyToMeltSnowAndIce(I,J),  
+     &                    EnergyToMeltSnowAndIce2(I,J),
+     &                    EnergyToMeltSnowAndIce(I,J) - 
+     &                    EnergyToMeltSnowAndIce2(I,J)
+               ENDIF
+c SEAICE DEBUG
+#endif
+c there is any flooding to be had                 
+                  ENDIF
+               ENDDO
+            ENDDO
+
+c SEAICEuseFlooding
+           ENDIF 
+c ALLOW_SEAICE_FLOODING
+#endif 
+
+#ifdef ALLOW_AUTODIFF_TAMC
+CADJ STORE area(:,:,bi,bj)  = comlev1_bibj, 
+CADJ &                        key = iicekey, byte = isbyte
+CADJ STORE hsnow(:,:,bi,bj) = comlev1_bibj, 
+CADJ &                        key = iicekey, byte = isbyte
+CADJ STORE heff(:,:,bi,bj)  = comlev1_bibj, 
+CADJ &                        key = iicekey, byte = isbyte
+#endif /* ALLOW_AUTODIFF_TAMC */
+
+
+#ifdef ATMOSPHERIC_LOADING
+            IF ( useRealFreshWaterFlux ) THEN
+               DO J=1,sNy
+                  DO I=1,sNx
+                     sIceLoad(i,j,bi,bj) = HEFF(I,J,bi,bj)*
+     &                 SEAICE_rhoIce + HSNOW(I,J,bi,bj)*SEAICE_rhoSnow
+                  ENDDO
+               ENDDO
+            ENDIF
+#endif
+
+#ifdef SEAICE_DEBUG
+            DO j=1,sNy
+               DO i=1,sNx
+
+               IF ( (i .EQ. SEAICE_debugPointX)   .and.  
+     &              (j .EQ. SEAICE_debugPointY) ) THEN
+
+                  print *,'ifsig: myTime,myIter:',myTime,myIter
+
+                  print '(A,2i4,2(1x,1P3E15.4))',
+     &                 'ifice i j --------------  ',i,j
+
+                  print '(A,2i4,2(1x,1P3E15.4))',
+     &                 'ifice i j IGR(ML OW ICE)  ',i,j,
+     &                 IceGrowthRateMixedLayer(i,j),
+     &                 IceGrowthRateOpenWater(i,j),
+     &                 NetExistingIceGrowthRate(i,j),
+     &                 SEAICE_deltaTtherm
+                  
+                  print '(A,2i4,2(1x,1P3E15.4))',
+     &                 'ifice i j F(mi ao)        ',
+     &                 i,j,F_mi(i,j), F_ao(i,j)
+                  
+                  print '(A,2i4,2(1x,1P3E15.4))',
+     &                 'ifice i j Fi(a,ant2/1 ont)',
+     &                 i,j,F_ia(i,j),
+     &                 F_ia_net_before_snow(i,j), 
+     &                 F_ia_net(i,j), 
+     &                 F_io_net(i,j)
+                 
+                  print '(A,2i4,2(1x,1P3E15.4))',
+     &                 'ifice i j AREA2/1 HEFF2/1 ',i,j,
+     &                 AREANm1(I,J,bi,bj),
+     &                 AREA(i,j,bi,bj),
+     &                 HEFFNm1(I,J,bi,bj),
+     &                 HEFF(i,j,bi,bj)
+
+
+#ifdef ALLOW_SALT_PLUME
+                  print '(A,2i4,2(1x,1P3E15.4))',
+     &                 'ifice i j A,IGLEA,LPF,SPF ',i,j,
+     &                 AREANm1(I,J,bi,bj),
+     &                 IceGrowthRateInLeads(I,J),
+     &                 leadPlumeFraction(I,J),
+     &                 saltPlumeFlux(i,j,bi,bj)
+#endif
+                  
+                  print '(A,2i4,2(1x,1P3E15.4))',
+     &                 'ifice i j HSNOW2/1 TMX TBC',i,j,
+     &                 HSNOW_ORIG(I,J),
+     &                 HSNOW(I,J,bi,bj),
+     &                 TMIX(i,j,bi,bj)- TMELT, 
+     &                 TBC
+
+                  print '(A,2i4,2(1x,1P3E15.4))',
+     &                 'ifice i j TI ATP LWD      ',i,j,
+     &                 TICE(i,j,bi,bj) - TMELT,
+     &                 ATEMP(i,j,bi,bj) -TMELT,
+     &                 LWDOWN(i,j,bi,bj)
+
+
+                  print '(A,2i4,2(1x,1P3E15.4))',
+     &                 'ifice i j S_a S_h S_hsnow ',i,j,
+     &                 S_a(i,j),
+     &                 S_h(i,j),
+     &                 S_hsnow(i,j)
+
+                  print '(A,2i4,2(1x,1P3E15.4))',
+     &                 'ifice i j IVC(E A ENIN)   ',i,j,
+     &                 ExpectedIceVolumeChange(i,j),
+     &                 ActualNewTotalVolumeChange(i,j),
+     &                 EnergyInNewTotalIceVolume(i,j)
+                  
+                  print '(A,2i4,2(1x,1P3E15.4))',
+     &                 'ifice i j EF(NOS RE) QNET ',i,j,
+     &                 NetEnergyFluxOutOfOcean(i,j),
+     &                 ResidualEnergyOutOfOcean(i,j),
+     &                 QNET(I,J,bi,bj)
+
+                  print '(A,2i4,3(1x,1P3E15.4))',
+     &                 'ifice i j QSW QSWO QSWI   ',i,j,
+     &                 QSW(i,j,bi,bj),
+     &                 QSWO(i,j),
+     &                 QSWI(i,j)
+
+                  print '(A,2i4,3(1x,1P3E15.4))',
+     &                 'ifice i j SW(BML IML SW)  ',i,j,
+     &                 QSW_absorb_below_first_layer(i,j),
+     &                 QSW_absorb_in_first_layer(i,j),
+     &                 SWFRACB
+
+                  print '(A,2i4,3(1x,1P3E15.4))',
+     &                 'ifice i j ptc(to, qsw, oa)',i,j,
+     &                 PredTempChange(i,j),
+     &                 PredTempChangeFromQSW (i,j),
+     &                 PredTempChangeFromOA_MQNET(i,j)
+
+
+                  print '(A,2i4,3(1x,1P3E15.4))',
+     &                 'ifice i j ptc(fion,ian,ia)',i,j,
+     &                 PredTempChangeFromF_IO_NET(i,j),
+     &                 PredTempChangeFromF_IA_NET(i,j),
+     &                 PredTempChangeFromFIA(i,j)
+
+                  print '(A,2i4,3(1x,1P3E15.4))',
+     &                 'ifice i j ptc(niv)        ',i,j,
+     &                 PredTempChangeFromNewIceVol(i,j)
+
+
+                  print '(A,2i4,3(1x,1P3E15.4))',
+     &                 'ifice i j EmPmR EVP PRE RU',i,j,
+     &                 EmPmR(I,J,bi,bj),
+     &                 EVAP(I,J,bi,bj),
+     &                 PRECIP(I,J,bi,bj),
+     &                 RUNOFF(I,J,bi,bj)
+
+                  print '(A,2i4,3(1x,1P3E15.4))',
+     &                 'ifice i j PRROIS,SAOI(R .)',i,j,
+     &                 PrecipRateOverIceSurfaceToSea(I,J),
+     &                 SnowAccRateOverIce(I,J),
+     &                 SnowAccOverIce(I,J)
+
+                  print '(A,2i4,4(1x,1P3E15.4))',
+     &                 'ifice i j SM(PM PMR . .R) ',i,j,
+     &                 PotSnowMeltFromSurf(I,J),
+     &                 PotSnowMeltRateFromSurf(I,J),
+     &                 SnowMeltFromSurface(I,J),
+     &                 SnowMeltRateFromSurface(I,J)
+
+                  print '(A,2i4,4(1x,1P3E15.4))',
+     &                 'ifice i j TotSnwMlt ExSnVC',i,j,
+     &                 ActualNewTotalSnowMelt(I,J),
+     &                 ExpectedSnowVolumeChange(I,J)
+
+
+                  print '(A,2i4,4(1x,1P3E15.4))',
+     &                 'ifice i j fw(CFICE, CFSM) ',i,j,
+     &                 FreshwaterContribFromIce(I,J),
+     &                 FreshwaterContribFromSnowMelt(I,J)
+
+                  print '(A,2i4,2(1x,1P3E15.4))',
+     &                 'ifice i j --------------  ',i,j
+
+               ENDIF
+               ENDDO
+            ENDDO
+#endif /* SEAICE_DEBUG */
+            
+            
+C     end bi,bj loops
+         ENDDO
+      ENDDO
+      
+      RETURN
+      END

--- a/pkg/seaice/seaice_solve4temp_adjointable.F
+++ b/pkg/seaice/seaice_solve4temp_adjointable.F
@@ -1,358 +1,589 @@
-C $Header: /home/ubuntu/mnt/e9_copy/MITgcm_contrib/ifenty/Fenty_Thermo_Code_Updates/code_updates_20130122/seaice_budget_ice_if.F,v 1.1 2013/01/22 21:53:56 ifenty Exp $
+C $Header: /u/gcmpack/MITgcm/pkg/seaice/seaice_solve4temp.F,v 1.37 2014/10/20 03:20:58 gforget Exp $
 C $Name:  $
 
 #include "SEAICE_OPTIONS.h"
+#ifdef ALLOW_EXF
+# include "EXF_OPTIONS.h"
+#endif
+#ifdef ALLOW_AUTODIFF
+# include "AUTODIFF_OPTIONS.h"
+#endif
 
-CStartOfInterface
-      SUBROUTINE SEAICE_BUDGET_ICE_IF(
-     I     UG, HICE_ACTUAL, HSNOW_ACTUAL,
-     U     TSURF,
-     O     F_io_net,F_ia_net,F_ia, IcePenetSWFlux,
-     I     bi, bj, myThid )
-C     /================================================================\
-C     | SUBROUTINE seaice_budget_ice_if                                |
-C     | o Calculate ice growth rate, surface fluxes and temperature of |
-C     |   ice surface.                                                 |
-C     |   see Hibler, MWR, 108, 1943-1973, 1980                        |
-C     |================================================================|
-C     \================================================================/
+CBOP
+C     !ROUTINE: SEAICE_SOLVE4TEMP
+C     !INTERFACE:
+      SUBROUTINE SEAICE_SOLVE4TEMP(
+     I   UG, HICE_ACTUAL, HSNOW_ACTUAL,
+#ifdef SEAICE_CAP_SUBLIM
+     I   F_lh_max,
+#endif
+     I   TSURFin,
+     O   TSURFout,
+     O   F_io_net, F_ia_net, F_ia, IcePenetSW,
+     O   FWsublim,
+     I   bi, bj, myTime, myIter, myThid )
+
+C     !DESCRIPTION: \bv
+C     *==========================================================*
+C     | SUBROUTINE SOLVE4TEMP
+C     | o Calculate ice growth rate, surface fluxes and
+C     |   temperature of ice surface.
+C     |   see Hibler, MWR, 108, 1943-1973, 1980
+C     *==========================================================*
+C     \ev
+
+C     !USES:
       IMPLICIT NONE
-
 C     === Global variables ===
 #include "SIZE.h"
 #include "GRID.h"
 #include "EEPARAMS.h"
+#include "PARAMS.h"
 #include "FFIELDS.h"
-#include "SEAICE.h"
+#include "SEAICE_SIZE.h"
 #include "SEAICE_PARAMS.h"
-#ifdef SEAICE_VARIABLE_FREEZING_POINT
+#include "SEAICE.h"
 #include "DYNVARS.h"
-#endif /* SEAICE_VARIABLE_FREEZING_POINT */
 #ifdef ALLOW_EXF
-# include "EXF_OPTIONS.h"
 # include "EXF_FIELDS.h"
 #endif
+#ifdef ALLOW_AUTODIFF_TAMC
+# include "tamc.h"
+#endif
 
-C     === Routine arguments ===
-C     INPUT:
-C     UG      :: thermal wind of atmosphere
-C     TSURF   :: surface temperature of ice in Kelvin, updated
-C     HICE_ACTUAL    :: (actual) ice thickness with upper and lower limit
+C     !INPUT PARAMETERS:
+C     UG           :: atmospheric wind speed (m/s)
+C     HICE_ACTUAL  :: actual ice thickness
 C     HSNOW_ACTUAL :: actual snow thickness
-C     bi,bj   :: loop indices
-C     OUTPUT:
-C     netHeatFlux :: net heat flux under ice = growth rate
-C     IcePenetSWFlux  :: short wave heat flux under ice
-      _RL TSURF      (1-OLx:sNx+OLx,1-OLy:sNy+OLy,nSx,nSy)
+C     TSURF      :: surface temperature of ice/snow in Kelvin
+C     bi,bj      :: tile indices
+C     myTime     :: current time in simulation
+C     myIter     :: iteration number in simulation
+C     myThid     :: my Thread Id number
+C     !OUTPUT PARAMETERS:
+C     TSURF      :: updated surface temperature of ice/snow in Kelvin
+C     F_ia       :: upward seaice/snow surface heat flux to atmosphere (W/m^2)
+C     IcePenetSW :: short wave heat flux transmitted through ice (+=upward)
+C     FWsublim   :: fresh water (mass) flux due to sublimation (+=up)(kg/m^2/s)
+C---- Notes:
+C     1) should add IcePenetSW to F_ia to get the net surface heat flux
+C        from the atmosphere (IcePenetSW not currently included in F_ia)
+C     2) since zero ice/snow heat capacity is assumed, all the absorbed Short
+C        -Wave is used to warm the ice/snow surface (heating profile ignored).
+C----------
+      _RL UG          (1:sNx,1:sNy)
+      _RL HICE_ACTUAL (1:sNx,1:sNy)
+      _RL HSNOW_ACTUAL(1:sNx,1:sNy)
+#ifdef SEAICE_CAP_SUBLIM
+      _RL F_lh_max    (1:sNx,1:sNy)
+#endif
+      _RL TSURFin     (1:sNx,1:sNy)
+      _RL TSURFout    (1:sNx,1:sNy)
+      _RL F_ia        (1:sNx,1:sNy)
+      _RL IcePenetSW  (1:sNx,1:sNy)
+      _RL FWsublim    (1:sNx,1:sNy)
+      INTEGER bi, bj
+      _RL     myTime
+      INTEGER myIter, myThid
+CEOP
 
-      _RL UG             (1:sNx,1:sNy)
-      _RL HICE_ACTUAL    (1:sNx,1:sNy)
-      _RL HSNOW_ACTUAL   (1:sNx,1:sNy)
+#if defined(ALLOW_ATM_TEMP) && defined(ALLOW_DOWNWARD_RADIATION)
+C     !LOCAL VARIABLES:
+C     === Local variables ===
+C     i, j  :: Loop counters
+C     kSurface  :: vertical index of surface layer
+      INTEGER i, j
+      INTEGER kSurface
+      INTEGER ITER
+C     tempFrz :: ocean temperature in contact with ice (=seawater freezing point) (K)
+      _RL tempFrz         (1:sNx,1:sNy)
+      _RL D1, D1I
+      _RL D3(1:sNx,1:sNy)
+      _RL TMELT, XKI, XKS, HCUT, recip_HCUT, XIO
+C     SurfMeltTemp :: Temp (K) above which wet-albedo values are used
+      _RL SurfMeltTemp
+C     effConduct :: effective conductivity of combined ice and snow
+      _RL effConduct(1:sNx,1:sNy)
+C     lhSublim :: latent heat of sublimation (SEAICE_lhEvap + SEAICE_lhFusion)
+      _RL lhSublim
+C     t1,t2,t3,t4 :: powers of temperature
+      _RL  t1, t2, t3, t4
 
-      _RL F_ia           (1:sNx,1:sNy)
-      _RL F_io_net       (1:sNx,1:sNy)
-      _RL F_ia_net       (1:sNx,1:sNy)
-      _RL IcePenetSWFlux (1:sNx,1:sNy)
+C-    Constants to calculate Saturation Vapor Pressure
+C     Maykut Polynomial Coeff. for Sat. Vapor Press
+      _RL C1, C2, C3, C4, C5, QS1
+C     Extended temp-range expon. relation Coeff. for Sat. Vapor Press
+      _RL lnTEN
+      _RL aa1,aa2,bb1,bb2,Ppascals,cc0,cc1,cc2,cc3t
+C     specific humidity at ice surface variables
+      _RL mm_pi,mm_log10pi
 
-      _RL F_swi      (1:sNx,1:sNy)
-      _RL F_lwd      (1:sNx,1:sNy)
-      _RL F_lwu      (1:sNx,1:sNy)
-      _RL F_lh       (1:sNx,1:sNy)
-      _RL F_sens     (1:sNx,1:sNy)
+C     F_c      :: conductive heat flux through seaice+snow (+=upward)
+C     F_lwu    :: upward long-wave surface heat flux (+=upward)
+C     F_sens   :: sensible surface heat flux         (+=upward)
+C     F_lh     :: latent heat flux (sublimation) (+=upward)
+C     qhice    :: saturation vapor pressure of snow/ice surface
+C     dqh_dTs  :: derivative of qhice w.r.t snow/ice surf. temp
+C     dFia_dTs :: derivative of surf heat flux (F_ia) w.r.t surf. temp
       _RL F_c        (1:sNx,1:sNy)
-      _RL qhice_mm   (1:sNx,1:sNy)
+      _RL F_lwu      (1:sNx,1:sNy)
+      _RL F_sens     (1:sNx,1:sNy)
+      _RL F_lh       (1:sNx,1:sNy)
 
-      _RL AbsorbedSWFlux       (1:sNx,1:sNy)
-      _RL IcePenetSWFluxFrac   (1:sNx,1:sNy)
+C     F_io_net :: upward conductive heat flux through seaice+snow
+C     F_ia_net :: net heat flux divergence at the sea ice/snow surface:
+C                 includes ice conductive fluxes and atmospheric fluxes (W/m^2)
+      _RL F_io_net   (1:sNx,1:sNy)
+      _RL F_ia_net   (1:sNx,1:sNy)
+
+      _RL qhice      (1:sNx,1:sNy)
+      _RL dqh_dTs    (1:sNx,1:sNy)
+      _RL dFia_dTs   (1:sNx,1:sNy)
+      _RL absorbedSW (1:sNx,1:sNy)
+      _RL penetSWFrac
+      _RL delTsurf
 
 C     local copies of global variables
       _RL tsurfLoc   (1:sNx,1:sNy)
+      _RL tsurfPrev  (1:sNx,1:sNy)
       _RL atempLoc   (1:sNx,1:sNy)
       _RL lwdownLoc  (1:sNx,1:sNy)
       _RL ALB        (1:sNx,1:sNy)
-      
-      _RL tsurfLocOld
+      _RL ALB_ICE    (1:sNx,1:sNy)
+      _RL ALB_SNOW   (1:sNx,1:sNy)
+C     iceOrNot :: this is HICE_ACTUAL.GT.0.
+      LOGICAL iceOrNot(1:sNx,1:sNy)
+#ifdef SEAICE_DEBUG
+#endif /* SEAICE_DEBUG */
 
-      INTEGER bi, bj, myThid
-      INTEGER KOPEN
+C---+----1----+----2----+----3----+----4----+----5----+----6----+----7-|--+----|
 
-C     === Local variables ===
-C     i,j - Loop counters
-      INTEGER i, j
-      INTEGER ITER
+#ifdef ALLOW_AUTODIFF_TAMC
+CADJ INIT comlev1_solve4temp = COMMON, sNx*sNy*NMAX_TICE
+#endif /* ALLOW_AUTODIFF_TAMC */
 
-      _RL  QS1, C1, C2, C3, C4, C5, TB, D1, D1I, D3
-      _RL  TMELT, TMELTP, XKI, XKS, HCUT, ASNOW, XIO
-
-C     effective conductivity of combined ice and snow
-      _RL  effConduct
-
-C     specific humidity at ice surface variables
-      _RL  mm_pi,mm_log10pi,dqhice_dTice
-     
-C     powers of temperature
-      _RL  t1, t2, t3, t4
-
-c     Ian Saturation Vapor Pressure 
-      _RL aa1,aa2,bb1,bb2,Ppascals,cc0,cc1,cc2,cc3t,dFiDTs1
-
+C-    MAYKUT CONSTANTS FOR SAT. VAP. PRESSURE TEMP. POLYNOMIAL
+      C1=    2.7798202  _d -06
+      C2=   -2.6913393  _d -03
+      C3=    0.97920849 _d +00
+      C4= -158.63779    _d +00
+      C5= 9653.1925     _d +00
+      QS1=0.622 _d +00/1013.0 _d +00
+C-    Extended temp-range expon. relation Coeff. for Sat. Vapor Press
+      lnTEN = LOG(10.0 _d 0)
       aa1 = 2663.5 _d 0
       aa2 = 12.537 _d 0
       bb1 = 0.622 _d 0
-      bb2 = ONE - bb1
-      Ppascals = 1000.*100. _d 0
-      cc0 = 10. _d 0**aa2
-      cc1 = cc0*aa1*bb1*Ppascals*log(10. _d 0)
+      bb2 = 1.0 _d 0 - bb1
+      Ppascals = 100000. _d 0
+C     cc0 = TEN ** aa2
+      cc0 = EXP(aa2*lnTEN)
+      cc1 = cc0*aa1*bb1*Ppascals*lnTEN
       cc2 = cc0*bb2
-       
-C FREEZING TEMPERATURE OF SEAWATER
-      TB=273.15 _d 0 + SEAICE_freeze 
-C SENSIBLE HEAT CONSTANT
-      D1=SEAICE_sensHeat
-C ICE LATENT HEAT CONSTANT
-      D1I=SEAICE_latentIce
-C STEFAN BOLTZMAN CONSTANT TIMES 0.97 EMISSIVITY
-      D3=SEAICE_emissivity
-C MELTING TEMPERATURE OF ICE
-      TMELT=273.15 _d 0 
 
-C ICE CONDUCTIVITY
+      IF ( buoyancyRelation .EQ. 'OCEANICP' ) THEN
+       kSurface        = Nr
+      ELSE
+       kSurface        = 1
+      ENDIF
+
+C     SENSIBLE HEAT CONSTANT
+      D1=SEAICE_dalton*SEAICE_cpAir*SEAICE_rhoAir
+
+C     ICE LATENT HEAT CONSTANT
+      lhSublim = SEAICE_lhEvap + SEAICE_lhFusion
+      D1I=SEAICE_dalton*lhSublim*SEAICE_rhoAir
+
+C     MELTING TEMPERATURE OF ICE
+      TMELT        = celsius2K
+
+C     ICE CONDUCTIVITY
       XKI=SEAICE_iceConduct
-C SNOW CONDUCTIVITY
+
+C     SNOW CONDUCTIVITY
       XKS=SEAICE_snowConduct
-C CUTOFF SNOW THICKNESS
-      HCUT=SEAICE_snowThick
-C PENETRATION SHORTWAVE RADIATION FACTOR
+
+C     CUTOFF SNOW THICKNESS
+C     Snow-Thickness above HCUT: SW optically thick snow (=> snow-albedo).
+C     Snow-Thickness below HCUT: linear transition to ice-albedo
+      HCUT = SEAICE_snowThick
+      recip_HCUT = 0. _d 0
+      IF ( HCUT.GT.0. _d 0 ) recip_HCUT = 1. _d 0 / HCUT
+
+C     PENETRATION SHORTWAVE RADIATION FACTOR
       XIO=SEAICE_shortwave
 
+C     Temperature Threshold for wet-albedo:
+      SurfMeltTemp = TMELT + SEAICE_wetAlbTemp
+C     old SOLVE4TEMP_LEGACY setting, consistent with former celsius2K value:
+c     TMELT        = 273.16  _d +00
+c     SurfMeltTemp = 273.159 _d +00
+
+C     Initialize variables
       DO J=1,sNy
        DO I=1,sNx
-        IcePenetSWFlux     (I,J) = 0. _d 0
-        IcePenetSWFluxFrac (I,J) = 0. _d 0
-        AbsorbedSWFlux (I,J) = 0. _d 0
-
-        qhice_mm (I,J) = 0. _d 0
-        F_ia     (I,J) = 0. _d 0 
-        F_io_net (I,J) = 0. _d 0
+C     initialise output arrays:
+        TSURFout (I,J) = TSURFin(I,J)
+        F_ia     (I,J) = 0. _d 0
         F_ia_net (I,J) = 0. _d 0
-
-        F_swi    (I,J) = 0. _d 0
-        F_lwd    (I,J) = 0. _d 0
-        F_lwu    (I,J) = 0. _d 0
+        F_io_net (I,J) = 0. _d 0
+        IcePenetSW(I,J)= 0. _d 0
+        FWsublim (I,J) = 0. _d 0
+C     HICE_ACTUAL is modified in this routine, but at the same time
+C     used to decided where there is ice, therefore we save this information
+C     here in a separate array
+        iceOrNot  (I,J) = HICE_ACTUAL(I,J) .GT. 0. _d 0
+        absorbedSW(I,J) = 0. _d 0
+        qhice    (I,J) = 0. _d 0
+        dqh_dTs  (I,J) = 0. _d 0
         F_lh     (I,J) = 0. _d 0
+        F_lwu    (I,J) = 0. _d 0
         F_sens   (I,J) = 0. _d 0
+C     Make a local copy of LW, surface & atmospheric temperatures
+        tsurfLoc (I,J) = TSURFin(I,J)
+c       tsurfLoc (I,J) = MIN( celsius2K+MAX_TICE, TSURFin(I,J) )
+        lwdownLoc(I,J) = MAX( MIN_LWDOWN, LWDOWN(I,J,bi,bj) )
+        atempLoc (I,J) = MAX( celsius2K+MIN_ATEMP, ATEMP(I,J,bi,bj) )
 
-c set the surface temperature to zero if there is no ice there.       
-c
-c        IF (HICE_ACTUAL(I,J) .GT. 0.0) THEN        
-c          tsurfLoc (I,J) = MIN(TMELT, TSURF(I,J,bi,bj))
-c        ELSE
-c          tsurfLoc(I,J) = TMELT
-c        ENDIF
+c     FREEZING TEMP. OF SEA WATER (K)
+        tempFrz(I,J) = SEAICE_dTempFrz_dS *salt(I,J,kSurface,bi,bj)
+     &     + SEAICE_tempFrz0 + celsius2K
 
-c reset the surface temperature to the freezing point each time around.
-        tsurfLoc(I,J) = TMELT
-        TSURF(I,J,bi,bj) = tsurfLoc(I,J)
+C     Now determine fixed (relative to tsurf) forcing term in heat budget
 
-        atempLoc (I,J) = MAX(TMELT + MIN_ATEMP,ATEMP(I,J,bi,bj))
-        lwdownLoc(I,J) = LWDOWN(I,J,bi,bj)
-
+        IF(HSNOW_ACTUAL(I,J).GT.0.0) THEN
+C     Stefan-Boltzmann constant times emissivity
+         D3(I,J)=SEAICE_snow_emiss*SEAICE_boltzmann
+#ifdef EXF_LWDOWN_WITH_EMISSIVITY
+C     This is now [(1-emiss)*lwdown - lwdown]
+         lwdownLoc(I,J) = SEAICE_snow_emiss*lwdownLoc(I,J)
+#else /* use the old hard wired inconsistent value  */
+         lwdownLoc(I,J) = 0.97 _d 0*lwdownLoc(I,J)
+#endif /* EXF_LWDOWN_WITH_EMISSIVITY */
+        ELSE
+C     Stefan-Boltzmann constant times emissivity
+         D3(I,J)=SEAICE_ice_emiss*SEAICE_boltzmann
+#ifdef EXF_LWDOWN_WITH_EMISSIVITY
+C     This is now [(1-emiss)*lwdown - lwdown]
+         lwdownLoc(I,J) = SEAICE_ice_emiss*lwdownLoc(I,J)
+#else /* use the old hard wired inconsistent value  */
+         lwdownLoc(I,J) = 0.97 _d 0*lwdownLoc(I,J)
+#endif /* EXF_LWDOWN_WITH_EMISSIVITY */
+        ENDIF
        ENDDO
       ENDDO
 
-C COME HERE AT START OF ITERATION
+      DO J=1,sNy
+       DO I=1,sNx
 
-       DO J=1,sNy
-        DO I=1,sNx
+C     DECIDE ON ALBEDO
+        IF ( iceOrNot(I,J) ) THEN
 
-         IF (HICE_ACTUAL(I,J) .GT. 0.0) THEN
-
-C         DECIDE ON ALBEDO
-          IF ( YC(I,J,bi,bj) .LT. ZERO ) THEN
-           IF (tsurfLoc(I,J) .GE. TMELT) THEN
-            IF (HSNOW_ACTUAL(I,J) .EQ. 0.0) THEN
-             ALB(I,J)   = SEAICE_wetIceAlb_south
-            ELSE                ! some snow
-             ALB(I,J)   = SEAICE_wetSnowAlb_south
-            ENDIF
-           ELSE                 ! no surface melting
-            IF (HSNOW_ACTUAL(I,J) .EQ. 0.0) THEN
-             ALB(I,J)   = SEAICE_dryIceAlb_south
-            ELSE                !  some snow
-             ALB(I,J)   = SEAICE_drySnowAlb_south
-            ENDIF 
-           ENDIF
-          ELSE
-           IF (tsurfLoc(I,J) .GE. TMELT) THEN
-            IF (HSNOW_ACTUAL(I,J) .EQ. 0.0) THEN
-             ALB(I,J)   = SEAICE_wetIceAlb
-            ELSE                ! some snow
-             ALB(I,J)   = SEAICE_wetSnowAlb
-            ENDIF
-           ELSE                 ! no surface melting
-            IF (HSNOW_ACTUAL(I,J) .EQ. 0.0) THEN
-             ALB(I,J)   = SEAICE_dryIceAlb
-            ELSE                !  some snow
-             ALB(I,J)   = SEAICE_drySnowAlb
-            ENDIF 
-           ENDIF
+         IF ( YC(I,J,bi,bj) .LT. 0.0 _d 0 ) THEN
+          IF (tsurfLoc(I,J) .GE. SurfMeltTemp) THEN
+           ALB_ICE (I,J)   = SEAICE_wetIceAlb_south
+           ALB_SNOW(I,J)   = SEAICE_wetSnowAlb_south
+          ELSE                  ! no surface melting
+           ALB_ICE (I,J)   = SEAICE_dryIceAlb_south
+           ALB_SNOW(I,J)   = SEAICE_drySnowAlb_south
           ENDIF
-
-          F_lwd(I,J) = - 0.97 _d 0 * lwdownLoc(I,J)
-
-          IF (HSNOW_ACTUAL(I,J) .GT. 0.0) THEN
-           IcePenetSWFluxFrac(I,J) = ZERO
-          ELSE
-           IcePenetSWFluxFrac(I,J) = 
-     &        XIO*EXP(-1.5 _d 0 * HICE_ACTUAL(I,J))
+         ELSE                   !/ Northern Hemisphere
+          IF (tsurfLoc(I,J) .GE. SurfMeltTemp) THEN
+           ALB_ICE (I,J)   = SEAICE_wetIceAlb
+           ALB_SNOW(I,J)   = SEAICE_wetSnowAlb
+          ELSE                  ! no surface melting
+           ALB_ICE (I,J)   = SEAICE_dryIceAlb
+           ALB_SNOW(I,J)   = SEAICE_drySnowAlb
           ENDIF
+         ENDIF                  !/ Albedo for snow and ice
 
-           AbsorbedSWFlux(I,J)       = -(ONE - ALB(I,J))*
-     &        (1.0 - IcePenetSWFluxFrac(I,J))
-     &         *SWDOWN(I,J,bi,bj)
+C     If actual snow thickness exceeds the cutoff thickness, use snow albedo
+         IF (HSNOW_ACTUAL(I,J) .GT. HCUT) THEN
+          ALB(I,J) = ALB_SNOW(I,J)
+         ELSEIF ( HCUT.LE.ZERO ) THEN
+          ALB(I,J) = ALB_ICE(I,J)
+         ELSE
+C     otherwise, use linear transition between ice and snow albedo
+          ALB(I,J) = MIN( ALB_ICE(I,J) + HSNOW_ACTUAL(I,J)*recip_HCUT
+     &                                 *(ALB_SNOW(I,J) -ALB_ICE(I,J))
+     &                  , ALB_SNOW(I,J) )
+         ENDIF
 
-           IcePenetSWFlux(I,J) = -(ONE - ALB(I,J))*
-     &        IcePenetSWFluxFrac(I,J)
-     &        *SWDOWN(I,J,bi,bj)
+C     Determine the fraction of shortwave radiative flux remaining
+C     at ocean interface after scattering through the snow and ice.
+C     If snow is present, no radiation penetrates through snow+ice
+         IF (HSNOW_ACTUAL(I,J) .GT. 0.0 _d 0) THEN
+          penetSWFrac = 0.0 _d 0
+         ELSE
+          penetSWFrac = XIO*EXP(-1.5 _d 0 * HICE_ACTUAL(I,J))
+         ENDIF
+C     The shortwave radiative flux leaving ocean beneath ice (+=up).
+         IcePenetSW(I,J) = -(1.0 _d 0 - ALB(I,J))
+     &                    *penetSWFrac * SWDOWN(I,J,bi,bj)
+C     The shortwave radiative flux convergence in the seaice.
+         absorbedSW(I,J) =  (1.0 _d 0 - ALB(I,J))
+     &        *(1.0 _d 0 - penetSWFrac)* SWDOWN(I,J,bi,bj)
 
-          F_swi(I,J) = AbsorbedSWFlux(I,J)
-
-c         set a min ice as 5 cm to limit arbitrarily large conduction.
-          HICE_ACTUAL(I,J) = max(HICE_ACTUAL(I,J),5. _d -2)
-
-          effConduct = XKI * XKS / 
+C     The effective conductivity of the two-layer snow/ice system.
+C     Set a minimum sea ice thickness of 5 cm to bound
+C     the magnitude of conductive heat fluxes.
+Cif   * now taken care of by SEAICE_hice_reg in seaice_growth
+c        hice_tmp = max(HICE_ACTUAL(I,J),5. _d -2)
+         effConduct(I,J) = XKI * XKS /
      &        (XKS * HICE_ACTUAL(I,J) + XKI * HSNOW_ACTUAL(I,J))
 
-          DO ITER=1,IMAX_TICE
-
-           t1 = tsurfLoc(I,J)
-           t2 = t1*t1
-           t3 = t2*t1
-           t4 = t2*t2
-
-           tsurfLocOld = t1
-
-c          log 10 of the sat vap pressure
-           mm_log10pi = -aa1 / t1 + aa2
-c          saturation vapor pressure
-           mm_pi = 10**(mm_log10pi)
-c          over ice specific humidity
-           qhice_mm(I,J) = bb1*mm_pi / (Ppascals - (1.0 - bb1) * mm_pi)
-
-c          constant for sat vap pressure derivative w.r.t tice        
-           cc3t = 10**(aa1 / t1)
-c          the actual derivative
-           dqhice_dTice = cc1 * cc3t /( (cc2-cc3t*Ppascals)**2 * t2)
-
-c          the full derivative 
-           dFiDTs1 = 4.0 * D3*t3 + effConduct + D1*UG(I,J) +
-     &        D1I*UG(I,J)*dqhice_dTice
-
-
-           F_lh(I,J)    = D1I * UG(I,J) * (qhice_mm(I,J)-AQH(I,J,bi,bj))
-           F_c(I,J)     = -effConduct * (TB - t1)
-           F_lwu(I,J)   = t4 * D3
-           F_sens(I,J)  = D1 * UG(I,J) * (t1 - atempLoc(I,J))
-
-           F_ia(I,J)    = F_lwd(I,J) + F_swi(I,J) + F_lwu(I,J) +
-     &         F_c(I,J) + F_sens(I,J) + F_lh(I,J)
-
-           tsurfLoc(I,J) = tsurfLoc(I,J) - F_ia(I,J) / dFiDTs1
-
-
-c    If the search falls below 50 Kelvin then kick the search back up to  
-c    TMELT.  Note that a solution to the equation is for a large negative
-c    value of ice surface temperature since the longwave outgoing radiation
-c    goes as the fourth power of temperature.
-
-           IF (tsurfLoc(I,J) .LT. 50.0 ) THEN 
-                tsurfLoc(I,J) = TMELT 
-           ENDIF 
-
 #ifdef SEAICE_DEBUG
-          IF ( (I .EQ. SEAICE_debugPointX)   .and.
-     &          (J .EQ. SEAICE_debugPointY) ) THEN
+         IF ( (I .EQ. SEAICE_debugPointI) .AND.
+     &        (J .EQ. SEAICE_debugPointJ) ) THEN
+          print '(A,i6)','-----------------------------------'
+          print '(A,i6)','ibi merged initialization ', myIter
+          print '(A,i6,4(1x,D24.15))',
+     &         'ibi iter, TSL, TS     ',myIter,
+     &         tsurfLoc(I,J), TSURFin(I,J)
+          print '(A,i6,4(1x,D24.15))',
+     &         'ibi iter, TMELT       ',myIter,TMELT
+          print '(A,i6,4(1x,D24.15))',
+     &         'ibi iter, HIA, EFKCON ',myIter,
+     &         HICE_ACTUAL(I,J), effConduct(I,J)
+          print '(A,i6,4(1x,D24.15))',
+     &         'ibi iter, HSNOW       ',myIter,
+     &         HSNOW_ACTUAL(I,J), ALB(I,J)
+          print '(A,i6)','-----------------------------------'
+          print '(A,i6)','ibi energy balance iterat ', myIter
+         ENDIF
+#endif /* SEAICE_DEBUG */
 
-            print *,'ice-iter tsurfLc,|dif|', I,J, ITER,tsurfLoc(I,J),
-     &           log10(abs(tsurfLoc(I,J) - tsurfLocOld))
-          ENDIF
-#endif   
-          ENDDO !/* Iterations */
+        ENDIF                   !/* iceOrNot */
+       ENDDO                    !/* i */
+      ENDDO                     !/* j */
 
-          tsurfLoc(I,J) = MIN(tsurfLoc(I,J),TMELT)
-          TSURF(I,J,bi,bj) = tsurfLoc(I,J)
+C---+----1----+----2----+----3----+----4----+----5----+----6----+----7-|--+----|
+      DO ITER=1,IMAX_TICE
+       DO J=1,sNy
+        DO I=1,sNx
+#ifdef ALLOW_AUTODIFF_TAMC
+         iicekey = I + sNx*(J-1) + (ITER-1)*sNx*sNy
+CADJ STORE tsurfLoc(i,j) = comlev1_solve4temp,
+CADJ &                     key = iicekey, byte = isbyte
+#endif /*  ALLOW_AUTODIFF_TAMC */
+
+C-    save tsurf from previous iter
+         tsurfPrev(I,J) = tsurfLoc(I,J)
+         IF ( iceOrNot(I,J) ) THEN
 
           t1 = tsurfLoc(I,J)
           t2 = t1*t1
           t3 = t2*t1
           t4 = t2*t2
 
-c         log 10 of the sat vap pressure
-          mm_log10pi = -aa1 / t1 + aa2
-c         saturation vapor pressure
-          mm_pi = 10**(mm_log10pi)
-c         over ice specific humidity
-          qhice_mm(I,J) = bb1*mm_pi / (Ppascals - (1.0 - bb1) * mm_pi)
-
-          F_lh(I,J)    = D1I * UG(I,J) * (qhice_mm(I,J)-AQH(I,J,bi,bj))
-          F_c(I,J)     = -effConduct * (TB - t1)
-          F_lwu(I,J)   = t4 * D3
-          F_sens(I,J)  = D1 * UG(I,J) * (t1 - atempLoc(I,J))
-
-c         exlude conductive flux, the actual flux with the atmosphere.
-          F_ia(I,J)    = F_lwd(I,J) + F_swi(I,J) + F_lwu(I,J) +
-     &         F_sens(I,J) + F_lh(I,J)
-
-          IF (F_c(I,J) .LT. 0.0) THEN
-            F_io_net(I,J) = -F_c(I,J)
-            F_ia_net(I,J) = 0.0
+C--   Calculate the specific humidity in the BL above the snow/ice
+          IF ( useMaykutSatVapPoly ) THEN
+C-    Use the Maykut polynomial
+           qhice(I,J)=QS1*(C1*t4+C2*t3 +C3*t2+C4*t1+C5)
+           dqh_dTs(I,J) = 0. _d 0
           ELSE
-            F_io_net(I,J) = 0.0
-            F_ia_net(I,J) = F_lwd(I,J) + F_swi(I,J) + F_lwu(I,J) +
-     &         F_sens(I,J) + F_lh(I,J)
-          ENDIF !/* conductive fluxes up or down */
+C-    Use exponential relation approx., more accurate at low temperatures
+C     log 10 of the sat vap pressure
+           mm_log10pi = -aa1 / t1 + aa2
+C     The saturation vapor pressure (SVP) in the surface
+C     boundary layer (BL) above the snow/ice.
+c          mm_pi = TEN **(mm_log10pi)
+C     The following form does the same, but is faster
+           mm_pi = EXP(mm_log10pi*lnTEN)
+           qhice(I,J) = bb1*mm_pi/( Ppascals -(1.0 _d 0 - bb1)*mm_pi )
+C     A constant for SVP derivative w.r.t TICE
+c          cc3t = TEN **(aa1 / t1)
+C     The following form does the same, but is faster
+           cc3t = EXP(aa1 / t1 * lnTEN)
+C     d(qh)/d(TICE)
+           dqh_dTs(I,J) = cc1*cc3t/((cc2-cc3t*Ppascals)**2 *t2)
+          ENDIF
 
+#ifdef ALLOW_AUTODIFF_TAMC
+CADJ STORE tsurfLoc(i,j) = comlev1_solve4temp,
+CADJ &                     key = iicekey, byte = isbyte
+#endif /*  ALLOW_AUTODIFF_TAMC */
+C     Calculate the flux terms based on the updated tsurfLoc
+          F_c(I,J)    = effConduct(I,J)*(tempFrz(I,J)-tsurfLoc(I,J))
+          F_lh(I,J)   = D1I*UG(I,J)*(qhice(I,J)-AQH(I,J,bi,bj))
+#ifdef SEAICE_CAP_SUBLIM
+C     if the latent heat flux implied by tsurfLoc exceeds
+C     F_lh_max, cap F_lh and decouple the flux magnitude from tIce (tsurfLoc)
+          IF (F_lh(I,J) .GT. F_lh_max(I,J)) THEN
+             F_lh(I,J)  = F_lh_max(I,J)
+             dqh_dTs(I,J) = ZERO
+          ENDIF
+#endif /* SEAICE_CAP_SUBLIM */
+
+          F_lwu(I,J) = t4 * D3(I,J)
+          F_sens(I,J)= D1 * UG(I,J) * (t1 - atempLoc(I,J))
+          F_ia(I,J) = -lwdownLoc(I,J) -absorbedSW(I,J) + F_lwu(I,J)
+     &              +  F_sens(I,J) + F_lh(I,J)
+C     d(F_ia)/d(Tsurf)
+          dFia_dTs(I,J) = 4.0 _d 0*D3(I,J)*t3 + D1*UG(I,J)
+     &                  + D1I*UG(I,J)*dqh_dTs(I,J)
 
 #ifdef SEAICE_DEBUG
-          IF ( (I .EQ. SEAICE_debugPointX)   .and.
-     &         (J .EQ. SEAICE_debugPointY) ) THEN
+          IF ( (I .EQ. SEAICE_debugPointI) .AND.
+     &         (J .EQ. SEAICE_debugPointJ) ) THEN
+           print '(A,i6,4(1x,D24.15))',
+     &          'ice-iter qhICE,       ', ITER,qhIce(I,J)
+           print '(A,i6,4(1x,D24.15))',
+     &          'ice-iter dFiDTs1 F_ia ', ITER,
+     &          dFia_dTs(I,J)+effConduct(I,J), F_ia(I,J)-F_c(I,J)
+          ENDIF
+#endif /* SEAICE_DEBUG */
 
-          print '(A,2i4,3(1x,1P2E15.3))',
-     &     'ibi i j T(SURF, surfLoc,atmos)',I,J, 
-     &     TSURF(I,J,bi,bj), tsurfLoc(I,J),atempLoc(I,J) 
+C-    Update tsurf as solution of : Fc = Fia + d/dT(Fia - Fc) *delta.tsurf
+          tsurfLoc(I,J) = tsurfLoc(I,J)
+     &    + ( F_c(I,J)-F_ia(I,J) ) / ( effConduct(I,J)+dFia_dTs(I,J) )
 
-          print '(A,2i4,3(1x,1P2E15.3))',
-     &     'ibi i j QSW(Tot, Abs, Pen)    ',I,J, 
-     &     SWDOWN(I,J,bi,bj), AbsorbedSWFlux(I,J),
-     &     IcePenetSWFlux(I,J)
+#ifdef ALLOW_AUTODIFF_TAMC
+CADJ STORE tsurfLoc(i,j) = comlev1_solve4temp,
+CADJ &                     key = iicekey, byte = isbyte
+#endif /*  ALLOW_AUTODIFF_TAMC */
+          IF ( useMaykutSatVapPoly ) THEN
+            tsurfLoc(I,J) = MAX( celsius2K+MIN_TICE, tsurfLoc(I,J) )
+          ENDIF
+C     If the search leads to tsurfLoc < 50 Kelvin, restart the search
+C     at tsurfLoc = TMELT.  Note that one solution to the energy balance problem
+C     is an extremely low temperature - a temperature far below realistic values.
+c         IF (tsurfLoc(I,J) .LT. 50.0 _d 0 ) tsurfLoc(I,J) = TMELT
+C   Comments & code above not relevant anymore (from older version, when
+C   trying Maykut-Polynomial & dqh_dTs > 0 ?): commented out
+          tsurfLoc(I,J) = MIN( tsurfLoc(I,J), TMELT )
 
-          print '(A,2i4,3(1x,1P2E15.3))',
-     &     'ibi i j IcePenSWFluxFrac, Alb ',I,J, 
-     ^      IcePenetSWFluxFrac(I,J), ALB(I,J)
- 
-          print '(A,2i4,3(1x,1P2E15.3))',
-     &     'ibi i j qh(ATM ICE)           ',I,J, 
-     &      AQH(I,J,bi,bj),qhice_mm(I,J)
- 
-          print '(A,2i4,3(1x,1P2E15.3))',
-     &     'ibi i j F(lwd,swi,lwu)        ',I,J, 
-     &      F_lwd(I,J), F_swi(I,J), F_lwu(I,J)
+#ifdef SEAICE_DEBUG
+          IF ( (I .EQ. SEAICE_debugPointI) .AND.
+     &         (J .EQ. SEAICE_debugPointJ) ) THEN
+           print '(A,i6,4(1x,D24.15))',
+     &          'ice-iter tsurfLc,|dif|', ITER,
+     &          tsurfLoc(I,J),
+     &          LOG10(ABS(tsurfLoc(I,J) - t1))
+          ENDIF
+#endif /* SEAICE_DEBUG */
 
-          print '(A,2i4,3(1x,1P2E15.3))',
-     &     'ibi i j F(c,lh,sens)          ',I,J, 
-     &      F_c(I,J), F_lh(I,J), F_sens(I,J)
+         ENDIF                  !/* iceOrNot */
+        ENDDO                   !/* i */
+       ENDDO                    !/* j */
+      ENDDO                     !/* Iterations */
+C---+----1----+----2----+----3----+----4----+----5----+----6----+----7-|--+----|
 
-          print '(A,2i4,3(1x,1P2E15.3))',
-     &     'ibi i j F(io_net,ia_net,ia)   ',I,J, 
-     &      F_io_net(I,J), F_ia_net(I,J), F_ia(I,J)
+      DO J=1,sNy
+       DO I=1,sNx
+        IF ( iceOrNot(I,J) ) THEN
+
+C     Save updated tsurf and finalize the flux terms
+         TSURFout(I,J) = tsurfLoc(I,J)
+
+         IF ( postSolvTempIter.EQ.2 ) THEN
+C     Recalculate the fluxes based on the (possibly) adjusted TSURF
+          t1 = tsurfLoc(I,J)
+          t2 = t1*t1
+          t3 = t2*t1
+          t4 = t2*t2
+
+          IF ( useMaykutSatVapPoly ) THEN
+           qhice(I,J)=QS1*(C1*t4+C2*t3 +C3*t2+C4*t1+C5)
+          ELSE
+C     log 10 of the sat vap pressure
+           mm_log10pi = -aa1 / t1 + aa2
+C     saturation vapor pressure
+c          mm_pi = TEN **(mm_log10pi)
+C     The following form does the same, but is faster
+           mm_pi = EXP(mm_log10pi*lnTEN)
+C     over ice specific humidity
+           qhice(I,J) = bb1*mm_pi/( Ppascals -(1.0 _d 0 - bb1)*mm_pi )
+          ENDIF
+          F_c(I,J)  = effConduct(I,J) * (tempFrz(I,J) - t1)
+          F_lh(I,J) = D1I * UG(I,J)*(qhice(I,J)-AQH(I,J,bi,bj))
+#ifdef SEAICE_CAP_SUBLIM
+          IF (F_lh(I,J) .GT. F_lh_max(I,J)) THEN
+             F_lh(I,J)  = F_lh_max(I,J)
+          ENDIF
+#endif /* SEAICE_CAP_SUBLIM */
+          F_lwu(I,J)  = t4 * D3(I,J)
+          F_sens(I,J) = D1 * UG(I,J) * (t1 - atempLoc(I,J))
+C     The flux between the ice/snow surface and the atmosphere.
+          F_ia(I,J) = -lwdownLoc(I,J) -absorbedSW(I,J) + F_lwu(I,J)
+     &              +  F_sens(I,J) + F_lh(I,J)
+
+C IGF_SIR-b		  
+          IF (-F_c(I,J) .LT. ZERO) THEN
+C note that F_c is flipped sign in this rewrite for some reason
+            F_io_net(I,J) = F_c(I,J)
+            F_ia_net(I,J) = ZERO
+          ELSE
+            F_io_net(I,J) = ZERO
+            F_ia_net(I,J) = F_ia(I,J)
+          ENDIF
+C IGF_SIR-e
+
+         ELSEIF ( postSolvTempIter.EQ.1 ) THEN
+C     Update fluxes (consistent with the linearized formulation)
+          delTsurf  = tsurfLoc(I,J)-tsurfPrev(I,J)
+          F_c(I,J)  = effConduct(I,J)*(tempFrz(I,J)-tsurfLoc(I,J))
+          F_ia(I,J) = F_ia(I,J) + dFia_dTs(I,J)*delTsurf
+          F_lh(I,J) = F_lh(I,J)
+     &              + D1I*UG(I,J)*dqh_dTs(I,J)*delTsurf
+
+c        ELSEIF ( postSolvTempIter.EQ.0 ) THEN
+C     Take fluxes from last iteration
 
          ENDIF
-#endif
 
-         ENDIF  !/* HICE_ACTUAL > 0 */
+C     Fresh water flux (kg/m^2/s) from latent heat of sublimation.
+C     F_lh is positive upward (sea ice looses heat) and FWsublim
+C     is also positive upward (atmosphere gains freshwater)
+         FWsublim(I,J) = F_lh(I,J)/lhSublim
 
-       ENDDO   !/* i */
-      ENDDO    !/* j */
+#ifdef SEAICE_DEBUG
+         IF ( (I .EQ. SEAICE_debugPointI) .AND.
+     &        (J .EQ. SEAICE_debugPointJ) ) THEN
+          print '(A)','----------------------------------------'
+          print '(A,i6)','ibi complete ', myIter
+          print '(A,4(1x,D24.15))',
+     &         'ibi T(SURF, surfLoc,atmos) ',
+     &         TSURFout(I,J), tsurfLoc(I,J),atempLoc(I,J)
+          print '(A,4(1x,D24.15))',
+     &         'ibi LWL                    ', lwdownLoc(I,J)
+          print '(A,4(1x,D24.15))',
+     &         'ibi QSW(Total, Penetrating)',
+     &         SWDOWN(I,J,bi,bj), IcePenetSW(I,J)
+          print '(A,4(1x,D24.15))',
+     &         'ibi qh(ATM ICE)            ',
+     &         AQH(I,J,bi,bj),qhice(I,J)
+         print '(A,4(1x,D24.15))',
+     &         'ibi F(lwd,swi,lwu)         ',
+     &         -lwdownLoc(I,J), -absorbedSW(I,J), F_lwu(I,J)
+         print '(A,4(1x,D24.15))',
+     &         'ibi F(c,lh,sens)           ',
+     &         F_c(I,J), F_lh(I,J), F_sens(I,J)
+#ifdef SEAICE_CAP_SUBLIM
+         IF (F_lh_max(I,J) .GT. ZERO) THEN
+             print '(A,4(1x,D24.15))',
+     &         'ibi F_lh_max,  F_lh/lhmax) ',
+     &         F_lh_max(I,J), F_lh(I,J)/ F_lh_max(I,J)
+         ELSE
+             print '(A,4(1x,D24.15))',
+     &         'ibi F_lh_max = ZERO! '
+         ENDIF
+         print '(A,4(1x,D24.15))',
+     &         'ibi FWsub, FWsubm*dT/rhoI  ',
+     &          FWsublim(I,J),
+     &          FWsublim(I,J)*SEAICE_deltaTtherm/SEAICE_rhoICE
+#endif /* SEAICE_CAP_SUBLIM */
+          print '(A,4(1x,D24.15))',
+     &         'ibi F_ia, F_ia_net, F_c    ',
+     &         F_ia(I,J), F_ia_net(I,J), F_c(I,J)
+          print '(A)','----------------------------------------'
+         ENDIF
+#endif /* SEAICE_DEBUG */
 
+        ENDIF                   !/* iceOrNot */
+       ENDDO                    !/* i */
+      ENDDO                     !/* j */
+
+#endif /* ALLOW_ATM_TEMP && ALLOW_DOWNWARD_RADIATION */
       RETURN
       END

--- a/pkg/seaice/seaice_solve4temp_adjointable.F
+++ b/pkg/seaice/seaice_solve4temp_adjointable.F
@@ -1,16 +1,17 @@
-C $Header: /u/gcmpack/MITgcm/pkg/seaice/seaice_budget_ice.F,v 1.3 2006/12/19 18:57:09 dimitri Exp $
-C $Name:  $
+C     $Header: /home/ubuntu/mnt/e9_copy/MITgcm_contrib/ifenty/Fenty_Thermo_Code_Updates/code_updates/seaice_budget_ice_if.F,v 1.1 2010/09/03 13:05:44 ifenty Exp $
+C     $Name:  $
 
 #include "SEAICE_OPTIONS.h"
 
-CStartOfInterface
-      SUBROUTINE SEAICE_BUDGET_ICE(
-     I     UG, HICE_ACTUAL, HSNOW_ACTUAL,
-     U     TSURF,
-     O     F_io_net,F_ia_net,F_ia, IcePenetratingShortwaveFlux,
-     I     bi, bj )
+C     StartOfInterface
+      SUBROUTINE SEAICE_BUDGET_ICE_IF(
+     I   UG, HICE_ACTUAL, HSNOW_ACTUAL,
+     U   TSURF,
+     O   F_io_net,F_ia_net,F_ia, IcePenetSWFlux,
+     I   bi, bj, myTime, myIter, myThid )
+
 C     /================================================================\
-C     | SUBROUTINE seaice_budget_ice                                   |
+C     | SUBROUTINE seaice_budget_ice_if                                |
 C     | o Calculate ice growth rate, surface fluxes and temperature of |
 C     |   ice surface.                                                 |
 C     |   see Hibler, MWR, 108, 1943-1973, 1980                        |
@@ -20,477 +21,399 @@ C     \================================================================/
 
 C     === Global variables ===
 #include "SIZE.h"
+#include "GRID.h"
 #include "EEPARAMS.h"
 #include "FFIELDS.h"
-#include "SEAICE_DIAGS.h"
+#include "SEAICE.h"
 #include "SEAICE_PARAMS.h"
-#include "SEAICE_FFIELDS.h"
 #ifdef SEAICE_VARIABLE_FREEZING_POINT
 #include "DYNVARS.h"
-#endif 
-C/* SEAICE_VARIABLE_FREEZING_POINT */
+#endif /* SEAICE_VARIABLE_FREEZING_POINT */
+#ifdef ALLOW_EXF
+# include "EXF_OPTIONS.h"
+# include "EXF_FIELDS.h"
+#endif
 
 C     === Routine arguments ===
 C     INPUT:
 C     UG      :: thermal wind of atmosphere
 C     TSURF   :: surface temperature of ice in Kelvin, updated
-C     HICE_ACTUAL    :: (actual) ice thickness with upper and lower limit
+C     HICE_ACTUAL    :: actual ice thickness
 C     HSNOW_ACTUAL :: actual snow thickness
 C     bi,bj   :: loop indices
+
 C     OUTPUT:
 C     netHeatFlux :: net heat flux under ice = growth rate
-C     IcePenetratingShortwaveFlux  :: short wave heat flux under ice
-      _RL UG         (1-OLx:sNx+OLx,1-OLy:sNy+OLy)
+C     IcePenetSWFlux  :: short wave heat flux under ice
+
       _RL TSURF      (1-OLx:sNx+OLx,1-OLy:sNy+OLy,nSx,nSy)
-      _RL HICE_ACTUAL  (1-OLx:sNx+OLx,1-OLy:sNy+OLy)
-      _RL HSNOW_ACTUAL (1-OLx:sNx+OLx,1-OLy:sNy+OLy)
 
-      _RL F_ia       (1-OLx:sNx+OLx,1-OLy:sNy+OLy)
-      _RL F_io_net   (1-OLx:sNx+OLx,1-OLy:sNy+OLy)
-      _RL F_ia_net   (1-OLx:sNx+OLx,1-OLy:sNy+OLy)
+      _RL UG             (1:sNx,1:sNy)
+      _RL HICE_ACTUAL    (1:sNx,1:sNy)
+      _RL HSNOW_ACTUAL   (1:sNx,1:sNy)
 
-      _RL F_swi      (1-OLx:sNx+OLx,1-OLy:sNy+OLy)
-      _RL F_lwd      (1-OLx:sNx+OLx,1-OLy:sNy+OLy)
-      _RL F_lwu      (1-OLx:sNx+OLx,1-OLy:sNy+OLy)
-      _RL F_lh       (1-OLx:sNx+OLx,1-OLy:sNy+OLy)
-      _RL F_sens     (1-OLx:sNx+OLx,1-OLy:sNy+OLy)
-      _RL F_c        (1-OLx:sNx+OLx,1-OLy:sNy+OLy)
-      _RL qhice_mm   (1-OLx:sNx+OLx,1-OLy:sNy+OLy)
+      _RL F_ia           (1:sNx,1:sNy)
+      _RL F_io_net       (1:sNx,1:sNy)
+      _RL F_ia_net       (1:sNx,1:sNy)
+      _RL IcePenetSWFlux (1:sNx,1:sNy)
 
-      _RL IcePenetratingShortwaveFlux (1-OLx:sNx+OLx,1-OLy:sNy+OLy)
-      _RL AbsorbedShortwaveFlux       (1-OLx:sNx+OLx,1-OLy:sNy+OLy)
-      _RL IcePenetratingShortwaveFluxFraction
-     &           (1-OLx:sNx+OLx,1-OLy:sNy+OLy)
+      _RL F_swi      (1:sNx,1:sNy)
+      _RL F_lwd      (1:sNx,1:sNy)
+      _RL F_lwu      (1:sNx,1:sNy)
+      _RL F_lh       (1:sNx,1:sNy)
+      _RL F_sens     (1:sNx,1:sNy)
+      _RL F_c        (1:sNx,1:sNy)
+      _RL qhice_mm   (1:sNx,1:sNy)
 
-      INTEGER bi, bj
+      _RL AbsorbedSWFlux       (1:sNx,1:sNy)
+      _RL IcePenetSWFluxFrac   (1:sNx,1:sNy)
+
+C     local copies of global variables
+      _RL tsurfLoc   (1:sNx,1:sNy)
+      _RL atempLoc   (1:sNx,1:sNy)
+      _RL lwdownLoc  (1:sNx,1:sNy)
+      _RL ALB        (1:sNx,1:sNy)
+      
+      _RL tsurfLocOld
+
+      INTEGER bi, bj, myIter, myThid
       INTEGER KOPEN
-
+      _RL myTime
 C     === Local variables ===
 C     i,j - Loop counters
       INTEGER i, j
       INTEGER ITER
-      _RL  QS1, C1, C2, C3, C4, C5, TB, D1, D1I, D3,IAN1
+
+      _RL  QS1, C1, C2, C3, C4, C5, TB, D1, D1I, D3
       _RL  TMELT, TMELTP, XKI, XKS, HCUT, ASNOW, XIO
+
 C     effective conductivity of combined ice and snow
       _RL  effConduct
-C     specific humidity at ice surface
+
+C     specific humidity at ice surface variables
       _RL  mm_pi,mm_log10pi,dqhice_dTice
-     
+      
 C     powers of temperature
       _RL  t1, t2, t3, t4
-
-C     local copies of global variables
-      _RL tsurfLoc   (1-OLx:sNx+OLx,1-OLy:sNy+OLy)
-      _RL atempLoc   (1-OLx:sNx+OLx,1-OLy:sNy+OLy)
-      _RL lwdownLoc  (1-OLx:sNx+OLx,1-OLy:sNy+OLy)
-      _RL ALB        (1-OLx:sNx+OLx,1-OLy:sNy+OLy)
-
-
+      _RL TEN
 c     Ian Saturation Vapor Pressure 
       _RL aa1,aa2,bb1,bb2,Ppascals,cc0,cc1,cc2,cc3t,dFiDTs1
-#ifdef SEAICE_DEBUG
-      _RL tsurfLocInitial   (1-OLx:sNx+OLx,1-OLy:sNy+OLy)
-      _RL tsurfLocOld
-      INTEGER CONV_IT
-      _RL TSURF_CONV
 
-      TSURF_CONV = 0.0 _d 0
-      CONV_IT = 0
-#endif 
-
-      aa1 = 2663.5
-      aa2 = 12.537
-      bb1 = 0.622
-      bb2 = 1.0 - bb1
-      Ppascals = 1000.*100.
-      cc0 = 10**aa2
-      cc1 = cc0*aa1*bb1*Ppascals*log(10.0)
+      TEN = 10.0 _d 0
+      aa1 = 2663.5 _d 0
+      aa2 = 12.537 _d 0
+      bb1 = 0.622 _d 0
+      bb2 = ONE - bb1
+      Ppascals = 100000. _d 0
+      cc0 = TEN ** aa2
+      cc1 = cc0*aa1*bb1*Ppascals*log(10. _d 0)
       cc2 = cc0*bb2
-       
-C FREEZING TEMPERATURE OF SEAWATER
-      TB=273.15 _d + 00 - 1.96 _d + 00
-C SENSIBLE HEAT CONSTANT
+      
+C     FREEZING TEMPERATURE OF SEAWATER
+      TB=273.15 _d 0 + SEAICE_freeze 
+
+C     SENSIBLE HEAT CONSTANT
       D1=SEAICE_sensHeat
-C ICE LATENT HEAT CONSTANT
+
+C     ICE LATENT HEAT CONSTANT
       D1I=SEAICE_latentIce
-C STEFAN BOLTZMAN CONSTANT TIMES 0.97 EMISSIVITY
+
+C     STEFAN BOLTZMAN CONSTANT TIMES 0.97 EMISSIVITY
       D3=SEAICE_emissivity
-C MELTING TEMPERATURE OF ICE
-      TMELT=273.15 _d +00
-C ICE CONDUCTIVITY
+
+C     MELTING TEMPERATURE OF ICE
+      TMELT = 273.15 _d 0 
+
+C     ICE CONDUCTIVITY
       XKI=SEAICE_iceConduct
-C SNOW CONDUCTIVITY
+
+C     SNOW CONDUCTIVITY
       XKS=SEAICE_snowConduct
-C PENETRATION SHORTWAVE RADIATION FACTOR
+
+C     CUTOFF SNOW THICKNESS
+      HCUT=SEAICE_snowThick
+
+C     PENETRATION SHORTWAVE RADIATION FACTOR
       XIO=SEAICE_shortwave
 
-c/* debug */
 
+c     Initialize variables
       DO J=1,sNy
-       DO I=1,sNx
+         DO I=1,sNx
+            IcePenetSWFlux     (I,J) = 0. _d 0
+            IcePenetSWFluxFrac (I,J) = 0. _d 0
+            AbsorbedSWFlux     (I,J) = 0. _d 0
 
-        IcePenetratingShortwaveFlux         (I,J) = 0. _d 0
-        IcePenetratingShortwaveFluxFraction (I,J) = 0. _d 0
-        AbsorbedShortwaveFlux               (I,J) = 0. _d 0
+            qhice_mm (I,J) = 0. _d 0
+            F_ia     (I,J) = 0. _d 0 
+            F_io_net (I,J) = 0. _d 0
+            F_ia_net (I,J) = 0. _d 0
 
-        qhice_mm (I,J) = 0.0 _d 0
-        F_ia     (I,J) = 0.0 _d 0 
-        F_io_net (I,J) = 0.0 _d 0
-        F_ia_net (I,J) = 0.0 _d 0
+            F_swi    (I,J) = 0. _d 0
+            F_lwd    (I,J) = 0. _d 0
+            F_lwu    (I,J) = 0. _d 0
+            F_lh     (I,J) = 0. _d 0
+            F_sens   (I,J) = 0. _d 0
 
-        F_swi    (I,J) = 0.0 _d 0
-        F_lwd    (I,J) = 0.0 _d 0
-        F_lwu    (I,J) = 0.0 _d 0
-        F_lh     (I,J) = 0.0 _d 0
-        F_sens   (I,J) = 0.0 _d 0
-
-        flux_LWI(I,J,bi,bj) = 0.0
-        flux_SWI(I,J,bi,bj) = 0.0
-        flux_LWU(I,J,bi,bj) = 0.0
-        flux_CON(I,J,bi,bj) = 0.0
-        flux_SEN(I,J,bi,bj) = 0.0
-        flux_LAT(I,J,bi,bj) = 0.0
-        flux_ION(I,J,bi,bj) = 0.0
-        flux_IAN(I,J,bi,bj) = 0.0
- 
-        atempLoc (I,J) = MAX(TMELT + MIN_ATEMP,ATEMP(I,J,bi,bj))
-        lwdownLoc(I,J) = LWDOWN(I,J,bi,bj)
-
-c Set the ice surface temperature to the melting point if there is 
-c no ice here, or to the minimum of the ice melting point or the
-c last ice surface temperature.  You never know what could have
-c happened to TMELT since it was last through this subroutine... 
-
-        IF (HICE_ACTUAL(I,J) .GT. 0.0) THEN       
-            tsurfLoc (I,J) = MIN(TMELT, TSURF(I,J,bi,bj))
-            TSURF(I,J,bi,bj) = tsurfLoc(I,J)
-        ELSE
+c     Reset the snow/ice surface to TMELT 
             tsurfLoc(I,J) = TMELT
-        ENDIF
+            TSURF(I,J,bi,bj) = tsurfLoc(I,J)
+
+c     Bound the atmospheric temperature
+            atempLoc (I,J) = MAX(TMELT + MIN_ATEMP,ATEMP(I,J,bi,bj))
+            lwdownLoc(I,J) = LWDOWN(I,J,bi,bj)
+         ENDDO
+      ENDDO
+
+      
+      DO J=1,sNy
+         DO I=1,sNx
+
+C     DECIDE ON ALBEDO
+            IF (HICE_ACTUAL(I,J) .GT. ZERO) THEN
+
+               IF ( YC(I,J,bi,bj) .LT. ZERO ) THEN
+                  IF (tsurfLoc(I,J) .GE. TMELT) THEN
+                     IF (HSNOW_ACTUAL(I,J) .EQ. ZERO) THEN
+                        ALB(I,J)   = SEAICE_wetIceAlb_south
+                     ELSE       ! some snow
+                        ALB(I,J)   = SEAICE_wetSnowAlb_south
+                     ENDIF
+                  ELSE          ! no surface melting
+                     IF (HSNOW_ACTUAL(I,J) .EQ. ZERO) THEN
+                        ALB(I,J)   = SEAICE_dryIceAlb_south
+                     ELSE       !  some snow
+                        ALB(I,J)   = SEAICE_drySnowAlb_south
+                     ENDIF 
+                  ENDIF         !/ The snow/ice surface temperature
+
+               ELSE             !/ Northern Hemisphere
+                  IF (tsurfLoc(I,J) .GE. TMELT) THEN
+                     IF (HSNOW_ACTUAL(I,J) .EQ. ZERO) THEN
+                        ALB(I,J)   = SEAICE_wetIceAlb
+                     ELSE       ! some snow
+                        ALB(I,J)   = SEAICE_wetSnowAlb
+                     ENDIF
+                  ELSE          ! no surface melting
+                     IF (HSNOW_ACTUAL(I,J) .EQ. ZERO) THEN
+                        ALB(I,J)   = SEAICE_dryIceAlb
+                     ELSE       !  some snow
+                        ALB(I,J)   = SEAICE_drySnowAlb
+                     ENDIF 
+                  ENDIF
+               ENDIF            !/ Albedo is determined
+
+c     The longwave radiative flux convergence
+               F_lwd(I,J) = - 0.97 _d 0 * lwdownLoc(I,J)
+
+c     Determine the fraction of shortwave radiative flux 
+c     remaining after scattering through the snow and ice at
+c     the ocean interface.  If snow is present, no radiation
+c     penetrates to the ocean.
+               IF (HSNOW_ACTUAL(I,J) .GT. ZERO) THEN
+                  IcePenetSWFluxFrac(I,J) = ZERO
+               ELSE
+                  IcePenetSWFluxFrac(I,J) = 
+     &               XIO*EXP(-1.5 _d 0 * HICE_ACTUAL(I,J))
+               ENDIF
+
+c     The shortwave radiative flux convergence in the
+c     seaice. 
+               AbsorbedSWFlux(I,J)       = -(ONE - ALB(I,J))*
+     &            (ONE - IcePenetSWFluxFrac(I,J))
+     &            *SWDOWN(I,J,bi,bj)
+
+c     The shortwave radiative flux convergence in the
+c     ocean beneath ice.
+               IcePenetSWFlux(I,J) = -(ONE - ALB(I,J))*
+     &            IcePenetSWFluxFrac(I,J)
+     &            *SWDOWN(I,J,bi,bj)
+
+               F_swi(I,J) = AbsorbedSWFlux(I,J)
+
+c     Set a mininum sea ice thickness of 5 cm to bound
+c     the magnitude of conductive heat fluxes.
+               HICE_ACTUAL(I,J) = max(HICE_ACTUAL(I,J),5. _d -2)
+
+c     The effective conductivity of the two-layer 
+c     snow/ice system.
+               effConduct = XKI * XKS / 
+     &            (XKS * HICE_ACTUAL(I,J) + XKI * HSNOW_ACTUAL(I,J))
+
 
 #ifdef SEAICE_DEBUG
-C       The snow/ice surface temperature when we enter the routine
-        tsurfLocInitial(I,J) = tsurfLoc(I,J)
-#endif
-       ENDDO !/* I */
-      ENDDO !/* J */
+               IF ( (I .EQ. SEAICE_debugPointX)   .and.
+     &            (J .EQ. SEAICE_debugPointY) ) THEN
 
+                  print '(A,i6)','-----------------------------------'
+                  print '(A,i6)','ibi initialization ', myIter
 
-c     GO THROUGH EACH POINT.... 
-       DO J=1,sNy
-        DO I=1,sNx
+                  print '(A,i6,4(1x,1PE33.26))',
+     &               'ibi iter, TSL, TS ',myIter,
+     &               tsurfLoc(I,J), TSURF(I,J,bi,bj)
 
-c     DON'T BOTHER DOING THE REST OF THIS SUBROUTINE
-c     IF THERE IS NO ICE HERE TO BEING WITH
-c     THERE CAN BE NO ICE-ATM OR ICE-OCEAN FLUX IN THAT CASE
-         IF (HICE_ACTUAL(I,J) .GT. 0.0) THEN
+                  print '(A,i6,4(1x,1PE33.26))',
+     &               'ibi iter, TMELT ',myIter,TMELT
 
-C         DECIDE ON ALBEDO BASED ON THE ICE SURFACE TEMPERATURE
-C         OF THE PREVIOUS ITERATION
-          IF (tsurfLoc(I,J) .GE. TMELT) THEN
-           IF (HSNOW_ACTUAL(I,J) .EQ. 0.0) THEN
-              ALB(I,J)   = SEAICE_wetIceAlb
-           ELSE  ! some snow
-              ALB(I,J)   = SEAICE_wetSnowAlb
-           ENDIF
-          ELSE   ! no surface melting
-            IF (HSNOW_ACTUAL(I,J) .EQ. 0.0) THEN
-              ALB(I,J)   = SEAICE_dryIceAlb
-            ELSE !  some snow
-              ALB(I,J)   = SEAICE_drySnowAlb
-            ENDIF 
-          ENDIF !/* Surf temp is below or at freezing */
+                  print '(A,i6,4(1x,1PE33.26))',
+     &               'ibi iter, HIA, EFKCON ',myIter,
+     &               HICE_ACTUAL(I,J), effConduct
 
-#ifdef SEAICE_DEBUG
-          IF ( (I .EQ. SEAICE_debugPointX)   .and.
-     &         (J .EQ. SEAICE_debugPointY) ) THEN
-
-            print '(A,2i4,3(1x,1P2E15.3))',
-     &      'ibi i j initial tsurfLoc ',I,J,tsurfLoc(I,J)
-
-            print '(A,2i4,3(1x,1P2E15.3))',
-     &      'ibi i j ALB/ATEMP/LWDOWN ',I,J,ALB(I,J),
-     &      atempLoc(I,J),lwdownLoc(I,J)
-    
-            print *,''
-          ENDIF !/* DEBUG POINT */
-#endif
-
-c THESE VARIABLES ARE INDEPENDENT OF THE ICE/SNOW SURFACE
-c TEMPERATURE. CALCULATE THEM FIRST BEFORE THE ICE/SNOW
-c SURFACE TEMPERATURE ITERATIVE LOOP
-          F_lwd(I,J) = - 0.97 _d 0 * lwdownLoc(I,J)
-
-          IF (HSNOW_ACTUAL(I,J) .GT. 0.0) THEN
-           IcePenetratingShortwaveFluxFraction(I,J) = ZERO
-          ELSE
-           IcePenetratingShortwaveFluxFraction(I,J) = 
-     &        XIO*EXP(-1.5 _d 0 * HICE_ACTUAL(I,J))
-          ENDIF
-
-          AbsorbedShortwaveFlux(I,J)       = -(ONE - ALB(I,J))*
-     &        (1.0 - IcePenetratingShortwaveFluxFraction(I,J))
-     &         *SWDOWN(I,J,bi,bj)
-
-          IcePenetratingShortwaveFlux(I,J) = -(ONE - ALB(I,J))*
-     &        IcePenetratingShortwaveFluxFraction(I,J)
-     &        *SWDOWN(I,J,bi,bj)
-
-          F_swi(I,J) = AbsorbedShortwaveFlux(I,J)
-
-c         set a min ice as 5 cm to limit arbitrarily large conduction.
-          HICE_ACTUAL(I,J) = max(HICE_ACTUAL(I,J),0.05)
-
-          effConduct = XKI * XKS / 
-     &        (XKS * HICE_ACTUAL(I,J) + XKI * HSNOW_ACTUAL(I,J))
-
-#ifdef SEAICE_DEBUG
-c         RESET THE ITERATION WHERE CONVERGENCE IS ACHIEVED
-          CONV_IT = 0
-#endif
-
-c Onset of iterative search --------------------
-          DO ITER=1,IMAX_TICE
-
-C          ONLY BOTHER REFINING THE SOLUTION IF AN ENERGY BALANCE 
-C          TO SPECIFICED PRECISION HAS NOT BEEN ACHIEVED.  ONE ITERATION
-C          IS REQUIRED TO CALCULATE F_IA.
-           IF ( (ITER .GT. 1 )                .AND. 
-     &          (ABS(F_ia(I,J)) .LT. SEAICE_heatFluxPrecision))  THEN
-c           We have achieved the precision required.  Be careful
-c           not to set this value higher than machine precision.
-c           1.0e-12 works well.  Convergence within 5 iterations is
-c           typical.
-
-#ifdef SEAICE_DEBUG
-c           Record the iteration where precision was first achieved.
-            IF (CONV_IT .EQ. 0) THEN
-                CONV_IT = ITER
-                print *,' convergence at it ',ITER-1 
-            ENDIF !/* First time hitting precision*/
-#endif         
-           ELSE !/*  Required precision not yet achieved.  Iterate */
-
-           t1 = tsurfLoc(I,J)
-           t2 = t1*t1
-           t3 = t2*t1
-           t4 = t2*t2
-
-#ifdef SEAICE_DEBUG
-           tsurfLocOld = t1
-#endif
-c          log 10 of the sat vap pressure
-           mm_log10pi = -aa1 / t1 + aa2
-c          saturation vapor pressure
-           mm_pi = 10**(mm_log10pi)
-c          over ice specific humidity
-           qhice_mm(I,J) = bb1*mm_pi / (Ppascals - (1.0 - bb1) * mm_pi)
-
-c          constant for sat vap pressure derivative w.r.t tice        
-           cc3t = 10**(aa1 / t1)
-c          the actual derivative
-           dqhice_dTice = cc1 * cc3t /( (cc2-cc3t*Ppascals)**2 * t2)
-
-c          the full derivative 
-           dFiDTs1 = 4.0 * D3*t3 + effConduct + D1*UG(I,J) +
-     &        D1I*UG(I,J)*dqhice_dTice
-
-
-c qhice_mm depends on t1 via mm_pi via mm_log10pi
-           F_lh(I,J)    = D1I * UG(I,J) * (qhice_mm(I,J)-AQH(I,J,bi,bj))
-
-c these depend on t1 directly
-           F_c(I,J)     = -effConduct * (TB - t1)
-           F_lwu(I,J)   = t4 * D3
-           F_sens(I,J)  = D1 * UG(I,J) * (t1 - atempLoc(I,J))
-
-#ifdef SEAICE_DEBUG                      
-           IF ( (I .EQ. SEAICE_debugPointX)   .and. 
-     &          (J .EQ. SEAICE_debugPointY) ) THEN
-
-            print '(A,2i4,4(1x,1P2E15.3))',
-     &      'ibi i j F_LH/F_C/F_LWU/F_SENS',I,J,
-     &       F_lh(I,J),F_c(I,J),F_lwu(I,J),F_sens(I,J)
-
-            print '(A,2i4,4(1x,1P2E15.3))',
-     &      'ibi i j UG,QHICE,AQH, t1     ', I,J,
-     &       UG(I,J),qhice_mm(I,J),AQH(I,J,bi,bj), t1
-           ENDIF !/* debug point */
-#endif 
-
-C       This is the net flux into the surface of the ice, it includes
-C       conductive heat fluxes.  This will be zero ultimately 
-C       if the search works.
-
-           F_ia(I,J)    = F_lwd(I,J) + F_swi(I,J) + F_lwu(I,J) +
-     &        F_c(I,J) + F_sens(I,J) + F_lh(I,J)
-
-C  Update the ice surface temperature to further reduce the 
-C  net heat flux at the ice surface.
-
-           tsurfLoc(I,J) = tsurfLoc(I,J) - F_ia(I,J) / dFiDTs1
-
-
-c    If the search falls below 50 Kelvin then reset the algorithm at
-c    TMELT - 10 K.  Hope that a slightly different starting point 
-c    will lead to a solution
-
-c    Note that a solution to the equation is for a large negative
-c    value of ice surface temperature since the longwave outgoing radiation
-c    goes as the fourth power of temperature.
-
-           IF (tsurfLoc(I,J) .LT. 50.0 ) THEN 
-                tsurfLoc(I,J) = TMELT  - 10.0 
-                print *,'ifice : had to wrap around i,j, iteration',
-     &                   i,j, ITER
-           ENDIF  !/* Tsurf too cold */
-
-#ifdef SEAICE_DEBUG
-c    Debug the difference in tsurf from iteration to  iteration
-            IF ( (I .EQ. SEAICE_debugPointX)   .and.
-     &          (J .EQ. SEAICE_debugPointY) ) THEN
-              TSURF_CONV= log10(abs(tsurfLoc(I,J) - tsurfLocOld))
-
-              print *,'0076',ITER,TSURF_CONV,
-     &          abs(tsurfLoc(I,J) - tsurfLocInitial(I,J))
-
-            ENDIF !/* Debug point */ 
-#endif     
- 
-           ENDIF !/* Not yet reached required precision */
-          ENDDO !/* End of iterations */
-c ---------------------------------------------------
-
-c At this point the iterations are over and we have 
-c an ice/snow surface temperature.
-
-c First, we take the final ice/snow surface temperature and
-c recalculate the fluxes.  The temperature that balanced heat 
-c fluxes may be above the freezing point of ice/snow.  In 
-c that case we limit the temperature to the freezing point.
-
-          tsurfLoc(I,J) = MIN(tsurfLoc(I,J),TMELT)
-          TSURF(I,J,bi,bj) = tsurfLoc(I,J)
-
-          t1 = tsurfLoc(I,J)
-          t2 = t1*t1
-          t3 = t2*t1
-          t4 = t2*t2
-
-c         log 10 of the sat vap pressure
-          mm_log10pi = -aa1 / t1 + aa2
-c         saturation vapor pressure
-          mm_pi = 10**(mm_log10pi)
-c         over ice specific humidity
-          qhice_mm(I,J) = bb1*mm_pi / (Ppascals - (1.0 - bb1) * mm_pi)
-
-          F_lh(I,J)    = D1I * UG(I,J) * (qhice_mm(I,J)-AQH(I,J,bi,bj))
-          F_c(I,J)     = -effConduct * (TB - t1)
-          F_lwu(I,J)   = t4 * D3
-          F_sens(I,J)  = D1 * UG(I,J) * (t1 - atempLoc(I,J))
-
-C   recalculate the total heat convergence at the ice surface with the 
-C   new perhaps bounded surface temperature.  If the surface ice temperature
-C   that balances heat fluxes is above the freezing point of seawater then
-C   there  will be conductive heat fluxes into the ice which will melt ice.
-           F_ia(I,J)    = F_lwd(I,J) + F_swi(I,J) + F_lwu(I,J) +
-     &        F_c(I,J) + F_sens(I,J) + F_lh(I,J)
-
-C   Determine whether the conductive fluxes indicate fluxes out of the ocean
-C   or into the ice.
-          IF (F_c(I,J) .LT. 0.0) THEN
-C           Conductive fluxes through the ice are negative this implies
-C           that we are taking the heat out of the ocean and there is no net
-C           convergence of heat at the ice surface.  F_ia should be zero.
-
-            F_io_net(I,J) = -F_c(I,J)
-            F_ia_net(I,J) = 0.0 _d 0
-          ELSE
-C           Conductive fluxes through the ice are positive.  This implies
-C           that heat has converged to the surface and is going to conduct
-C           into the ice, melting it.  The rate of convergence is given by
-C           F_ia_net.
-
-            F_io_net(I,J) = 0.0
-            F_ia_net(I,J) = F_lwd(I,J) + F_swi(I,J) + F_lwu(I,J) +
-     &         F_sens(I,J) + F_lh(I,J)
-
-          ENDIF !/* conductive fluxes up or down */
-
-
-          flux_LWI(I,J,bi,bj) = F_lwd(I,J)
-          flux_SWI(I,J,bi,bj) = F_swi(I,J)
-          flux_LWU(I,J,bi,bj) = F_lwu(I,J)
-          flux_CON(I,J,bi,bj) = F_c(I,J)
-          flux_SEN(I,J,bi,bj) = F_sens(I,J)
-          flux_LAT(I,J,bi,bj) = F_lh(I,J)
-          flux_ION(I,J,bi,bj) = F_io_net(I,J)
-          flux_IAN(I,J,bi,bj) = F_ia_net(I,J)
-
-c Next, do some more detailed debugging for this particular point
-
-#ifdef SEAICE_DEBUG
-          IF ( (I .EQ. SEAICE_debugPointX)   .and.
-     &         (J .EQ. SEAICE_debugPointY) ) THEN
-
-          print *,'------- IBI summary -------'
-          print *,''
-          print '(A,2i4,3(1x,1P2E15.6))',
-     &     'ibi i j T(SURF, surfLoc,atmos)',I,J, 
-     &     TSURF(I,J,bi,bj), tsurfLoc(I,J),atempLoc(I,J) 
-
-          print '(A,2i4,3(1x,1P2E15.6))',
-     &     'ibi i j QSW(Tot, Abs, Pen)    ',I,J, 
-     &     SWDOWN(I,J,bi,bj), AbsorbedShortwaveFlux(I,J),
-     &     IcePenetratingShortwaveFlux(I,J)
-
-          print '(A,2i4,3(1x,1P2E15.6))',
-     &     'ibi i j IcePenSWFluxFrac, Alb ',I,J, 
-     &      IcePenetratingShortwaveFluxFraction(I,J), ALB(I,J)
- 
-          print '(A,2i4,3(1x,1P2E15.6))',
-     &     'ibi i j qh(ATM ICE)           ',I,J, 
-     &      AQH(I,J,bi,bj),qhice_mm(I,J)
- 
-          print '(A,2i4,3(1x,1P2E15.6))',
-     &     'ibi i j F(lwd,swi,lwu)        ',I,J, 
-     &      F_lwd(I,J), F_swi(I,J), F_lwu(I,J)
-
-          print '(A,2i4,3(1x,1P2E15.6))',
-     &     'ibi i j F(c,lh,sens)          ',I,J, 
-     &      F_c(I,J), F_lh(I,J), F_sens(I,J)
-
-          print '(A,2i4,3(1x,1P2E15.6))',
-     &     'ibi i j F(io_net,ia_net,ia)   ',I,J, 
-     &      F_io_net(I,J), F_ia_net(I,J), F_ia(I,J)
-
-          ENDIF !/* Debug point */ 
+                  print '(A,i6)','-----------------------------------'
+                  print '(A,i6)','ibi energy balance iterat ', myIter
+                  
+               ENDIF
 #endif
 
+               
+               DO ITER=1,IMAX_TICE
+                  
+                  t1 = tsurfLoc(I,J)
+                  t2 = t1*t1
+                  t3 = t2*t1
+                  t4 = t2*t2
 
-c The whole point of this 
-c algorithm is to find the ice/snow surface temperature that achieves an
-c energy balance.  Here we do the oft-neglected task of checking that it 
-c actually has worked.  Tolerance is arbitrarly set at 0.0001 W/m^2
+                  tsurfLocOld = t1
 
-c If the surface temperature is greater than the freezing point of salt
-c water then we will not have an energy balance since the conductive flux
-c will be transferring heat into the ice from the atmosphere.  It is only
-c when the ice surface is cooler than the ocean surface that conductive 
-c fluxes ultimately balance the net heat loss at the surface.
+c     log 10 of the sat vap pressure
+                  mm_log10pi = -aa1 / t1 + aa2
 
-           IF (tsurfLoc(I,J) .LT. TB) THEN
-             IF (ABS(F_ia(I,J)) .GT. SEAICE_heatFluxPrecision) THEN
-                print *,'ifice : energy balance failure at i,j ',I,J
-                print *,'tsurfLoc, F_ia_net',tsurfLoc(I,J),F_ia_net(I,J)
-                print *,'tsurfLoc, F_ia',tsurfLoc(I,J),F_ia(I,J)
-                stop
-             ENDIF  !/* Heat flux imbalance too great */
-           ENDIF !/* surface temperature is less than freezing point */  
+c     The saturation vapor pressure (SVP) in the surface 
+c     boundary layer (BL) above the snow/ice.
+                  mm_pi = TEN **(mm_log10pi)
 
-        ENDIF  
-       ENDDO   !/* i */
-      ENDDO    !/* j */
+c     The specific humidity in the BL above the snow/ice
+                  qhice_mm(I,J) = bb1*mm_pi / (Ppascals - (ONE - bb1) *
+     &               mm_pi)
+
+c     A constant for SVP derivative w.r.t TICE
+                  cc3t = TEN **(aa1 / t1)
+
+c     d(qh)/d(TICE)
+                  dqhice_dTice = cc1*cc3t/((cc2-cc3t*Ppascals)**TWO *t2)
+
+c     d(F_ia)/d(TICE) 
+                  dFiDTs1 = 4.0 _d 0 * D3*t3 + effConduct + D1*UG(I,J) +
+     &               D1I*UG(I,J)*dqhice_dTice
+
+
+                  F_lh(I,J) = D1I*UG(I,J)*(qhice_mm(I,J)-AQH(I,J,bi,bj))
+                  F_c(I,J)  = -effConduct * (TB - t1)
+                  F_lwu(I,J)= t4 * D3
+                  F_sens(I,J)= D1 * UG(I,J) * (t1 - atempLoc(I,J))
+
+                  F_ia(I,J)  = F_lwd(I,J) + F_swi(I,J) + F_lwu(I,J) +
+     &               F_c(I,J) + F_sens(I,J) + F_lh(I,J)
+
+                  tsurfLoc(I,J) = tsurfLoc(I,J) - F_ia(I,J) / dFiDTs1
+
+
+c     If the search leads to tsurfLoc < 50 Kelvin,
+c     restart the search at tsurfLoc = TMELT.  Note that one
+c     solution to the energy balance problem is an 
+c     extremely low temperature - a temperature far below
+c     what is observed.
+
+                  IF (tsurfLoc(I,J) .LT. 50.0 _d 0 ) THEN 
+                     tsurfLoc(I,J) = TMELT 
+                  ENDIF 
+
+#ifdef SEAICE_DEBUG
+                  IF ( (I .EQ. SEAICE_debugPointX)   .and.
+     &               (J .EQ. SEAICE_debugPointY) ) THEN
+
+                     print '(A,i6,4(1x,1PE33.26))',
+     &                  'ice-iter tsurfLc,|dif|  ', ITER,
+     &                  tsurfLoc(I,J),
+     &                  log10(abs(tsurfLoc(I,J) - tsurfLocOld))
+                  ENDIF
+#endif  
+                  
+               ENDDO            !/* Iterations */
+
+
+               tsurfLoc(I,J) = MIN(tsurfLoc(I,J),TMELT)
+               TSURF(I,J,bi,bj) = tsurfLoc(I,J)
+
+               t1 = tsurfLoc(I,J)
+               t2 = t1*t1
+               t3 = t2*t1
+               t4 = t2*t2
+
+c     log 10 of the sat vap pressure
+               mm_log10pi = -aa1 / t1 + aa2
+c     saturation vapor pressure
+               mm_pi = TEN **(mm_log10pi)
+c     over ice specific humidity
+               qhice_mm(I,J) = bb1*mm_pi/(Ppascals- (ONE - bb1) * mm_pi)
+
+               F_lh(I,J) = D1I * UG(I,J)*(qhice_mm(I,J)-AQH(I,J,bi,bj))
+               F_c(I,J)  = -effConduct * (TB - t1)
+               F_lwu(I,J)   = t4 * D3
+               F_sens(I,J)  = D1 * UG(I,J) * (t1 - atempLoc(I,J))
+
+c     exlude conductive flux, the actual flux with the atmosphere.
+               F_ia(I,J)    = F_lwd(I,J) + F_swi(I,J) + F_lwu(I,J) +
+     &            F_sens(I,J) + F_lh(I,J)
+
+               IF (F_c(I,J) .LT. ZERO) THEN
+                  F_io_net(I,J) = -F_c(I,J)
+                  F_ia_net(I,J) = ZERO
+               ELSE
+                  F_io_net(I,J) = ZERO
+                  F_ia_net(I,J) = F_lwd(I,J) + F_swi(I,J) + F_lwu(I,J) +
+     &               F_sens(I,J) + F_lh(I,J)
+               ENDIF            !/* conductive fluxes up or down */
+
+
+#ifdef SEAICE_DEBUG
+               IF ( (I .EQ. SEAICE_debugPointX)   .and.
+     &            (J .EQ. SEAICE_debugPointY) ) THEN
+
+                  print '(A)','----------------------------------------'
+                  print '(A,i6)','ibi complete ', myIter
+
+                  print '(A,4(1x,1PE33.26))',
+     &               'ibi T(SURF, surfLoc,atmos) ',
+     &               TSURF(I,J,bi,bj), tsurfLoc(I,J),atempLoc(I,J) 
+
+                  print '(A,4(1x,1PE33.26))',
+     &               'ibi LWL               ', lwdownLoc(I,J)
+                  
+                  print '(A,4(1x,1PE33.26))',
+     &               'ibi QSW(Tot, Abs, Pen)     ', 
+     &               SWDOWN(I,J,bi,bj), AbsorbedSWFlux(I,J),
+     &               IcePenetSWFlux(I,J)
+
+                  print '(A,4(1x,1PE33.26))',
+     &               'ibi IcePenSWFluxFrac, Alb  ' , 
+     ^               IcePenetSWFluxFrac(I,J), ALB(I,J)
+                  
+                  print '(A,4(1x,1PE33.26))',
+     &               'ibi qh(ATM ICE)            ', 
+     &               AQH(I,J,bi,bj),qhice_mm(I,J)
+                  
+                  print '(A,4(1x,1PE33.26))',
+     &               'ibi F(lwd,swi,lwu)         ', 
+     &               F_lwd(I,J), F_swi(I,J), F_lwu(I,J)
+
+                  print '(A,4(1x,1PE33.26))',
+     &               'ibi F(c,lh,sens)           ', 
+     &               F_c(I,J), F_lh(I,J), F_sens(I,J)
+
+                  print '(A,4(1x,1PE33.26))',
+     &               'ibi F(io_net,ia_net,ia)    ', 
+     &               F_io_net(I,J), F_ia_net(I,J), F_ia(I,J)
+
+                  print '(A)','----------------------------------------'
+
+               ENDIF
+#endif
+
+            ENDIF               !/* HICE_ACTUAL > 0 */
+
+         ENDDO                  !/* i */
+      ENDDO                     !/* j */
 
       RETURN
       END

--- a/pkg/seaice/seaice_solve4temp_adjointable.F
+++ b/pkg/seaice/seaice_solve4temp_adjointable.F
@@ -1,6 +1,3 @@
-C $Header: /u/gcmpack/MITgcm/pkg/seaice/seaice_solve4temp.F,v 1.37 2014/10/20 03:20:58 gforget Exp $
-C $Name:  $
-
 #include "SEAICE_OPTIONS.h"
 #ifdef ALLOW_EXF
 # include "EXF_OPTIONS.h"
@@ -10,9 +7,9 @@ C $Name:  $
 #endif
 
 CBOP
-C     !ROUTINE: SEAICE_SOLVE4TEMP
+C     !ROUTINE: SEAICE_SIMPLESOLVE4TEMP
 C     !INTERFACE:
-      SUBROUTINE SEAICE_SOLVE4TEMP(
+      SUBROUTINE SEAICE_SIMPLESOLVE4TEMP(
      I   UG, HICE_ACTUAL, HSNOW_ACTUAL,
 #ifdef SEAICE_CAP_SUBLIM
      I   F_lh_max,
@@ -25,7 +22,7 @@ C     !INTERFACE:
 
 C     !DESCRIPTION: \bv
 C     *==========================================================*
-C     | SUBROUTINE SOLVE4TEMP
+C     | SUBROUTINE SIMPLESOLVE4TEMP
 C     | o Calculate ice growth rate, surface fluxes and
 C     |   temperature of ice surface.
 C     |   see Hibler, MWR, 108, 1943-1973, 1980
@@ -153,13 +150,19 @@ C     local copies of global variables
       _RL ALB_SNOW   (1:sNx,1:sNy)
 C     iceOrNot :: this is HICE_ACTUAL.GT.0.
       LOGICAL iceOrNot(1:sNx,1:sNy)
+
+CAB
+      _RL SItflux     (1:sNx,1:sNy)
+      _RL SIacSubl    (1:sNx,1:sNy)
+CAB
+
 #ifdef SEAICE_DEBUG
 #endif /* SEAICE_DEBUG */
 
 C---+----1----+----2----+----3----+----4----+----5----+----6----+----7-|--+----|
 
 #ifdef ALLOW_AUTODIFF_TAMC
-CADJ INIT comlev1_solve4temp = COMMON, sNx*sNy*NMAX_TICE
+CADJ INIT comlev1_simplesolve4temp = COMMON, sNx*sNy*NMAX_TICE
 #endif /* ALLOW_AUTODIFF_TAMC */
 
 C-    MAYKUT CONSTANTS FOR SAT. VAP. PRESSURE TEMP. POLYNOMIAL
@@ -363,7 +366,7 @@ C---+----1----+----2----+----3----+----4----+----5----+----6----+----7-|--+----|
         DO I=1,sNx
 #ifdef ALLOW_AUTODIFF_TAMC
          iicekey = I + sNx*(J-1) + (ITER-1)*sNx*sNy
-CADJ STORE tsurfLoc(i,j) = comlev1_solve4temp,
+CADJ STORE tsurfLoc(i,j) = comlev1_simplesolve4temp,
 CADJ &                     key = iicekey, byte = isbyte
 #endif /*  ALLOW_AUTODIFF_TAMC */
 
@@ -400,7 +403,7 @@ C     d(qh)/d(TICE)
           ENDIF
 
 #ifdef ALLOW_AUTODIFF_TAMC
-CADJ STORE tsurfLoc(i,j) = comlev1_solve4temp,
+CADJ STORE tsurfLoc(i,j) = comlev1_simplesolve4temp,
 CADJ &                     key = iicekey, byte = isbyte
 #endif /*  ALLOW_AUTODIFF_TAMC */
 C     Calculate the flux terms based on the updated tsurfLoc
@@ -439,7 +442,7 @@ C-    Update tsurf as solution of : Fc = Fia + d/dT(Fia - Fc) *delta.tsurf
      &    + ( F_c(I,J)-F_ia(I,J) ) / ( effConduct(I,J)+dFia_dTs(I,J) )
 
 #ifdef ALLOW_AUTODIFF_TAMC
-CADJ STORE tsurfLoc(i,j) = comlev1_solve4temp,
+CADJ STORE tsurfLoc(i,j) = comlev1_simplesolve4temp,
 CADJ &                     key = iicekey, byte = isbyte
 #endif /*  ALLOW_AUTODIFF_TAMC */
           IF ( useMaykutSatVapPoly ) THEN
@@ -536,6 +539,33 @@ C     Fresh water flux (kg/m^2/s) from latent heat of sublimation.
 C     F_lh is positive upward (sea ice looses heat) and FWsublim
 C     is also positive upward (atmosphere gains freshwater)
          FWsublim(I,J) = F_lh(I,J)/lhSublim
+
+CAB
+C     F_c      :: conductive heat flux through seaice+snow (+=upward)
+C     F_lwu    :: upward long-wave surface heat flux (+=upward)
+C     F_sens   :: sensible surface heat flux         (+=upward)
+C     F_lh     :: latent heat flux (sublimation) (+=upward)
+
+C       SItflux(I,J) =
+C     &    (F_c(I,J)+F_lwu(I,J)+F_lh(I,J) + F_sens(I,J))
+C     &   -lwdownLoc(I,J) -absorbedSW(I,J) + F_lwu(I,J))
+C     &    *  maskC(I,J,kSurface,bi,bj)
+
+C       SIacSubl(I,J) =  
+C     &   (-lwdownLoc(I,J) -absorbedSW(I,J) + F_lwu(I,J))
+C     &    *  maskC(I,J,kSurface,bi,bj)
+
+
+
+C       CALL DIAGNOSTICS_FILL(SItflux,
+C     &        'SItflux ',0,1,3,bi,bj,myThid)
+
+C       CALL DIAGNOSTICS_FILL(SIacSubl,
+C     &        'SIacSubl',0,1,3,bi,bj,myThid)
+
+CAB
+
+
 
 #ifdef SEAICE_DEBUG
          IF ( (I .EQ. SEAICE_debugPointI) .AND.

--- a/pkg/seaice/seaice_solve4temp_adjointable.F
+++ b/pkg/seaice/seaice_solve4temp_adjointable.F
@@ -1,16 +1,16 @@
-C $Header: /u/gcmpack/MITgcm/pkg/seaice/seaice_budget_ice_if.F,v 1.4 2009/05/23 15:39:12 dimitri Exp $
+C $Header: /u/gcmpack/MITgcm/pkg/seaice/seaice_budget_ice.F,v 1.3 2006/12/19 18:57:09 dimitri Exp $
 C $Name:  $
 
 #include "SEAICE_OPTIONS.h"
 
 CStartOfInterface
-      SUBROUTINE SEAICE_BUDGET_ICE_IF(
+      SUBROUTINE SEAICE_BUDGET_ICE(
      I     UG, HICE_ACTUAL, HSNOW_ACTUAL,
      U     TSURF,
-     O     F_io_net,F_ia_net,F_ia, IcePenetSWFlux,
-     I     bi, bj, myThid )
+     O     F_io_net,F_ia_net,F_ia, IcePenetratingShortwaveFlux,
+     I     bi, bj )
 C     /================================================================\
-C     | SUBROUTINE seaice_budget_ice_if                                |
+C     | SUBROUTINE seaice_budget_ice                                   |
 C     | o Calculate ice growth rate, surface fluxes and temperature of |
 C     |   ice surface.                                                 |
 C     |   see Hibler, MWR, 108, 1943-1973, 1980                        |
@@ -20,18 +20,15 @@ C     \================================================================/
 
 C     === Global variables ===
 #include "SIZE.h"
-#include "GRID.h"
 #include "EEPARAMS.h"
 #include "FFIELDS.h"
-#include "SEAICE.h"
+#include "SEAICE_DIAGS.h"
 #include "SEAICE_PARAMS.h"
+#include "SEAICE_FFIELDS.h"
 #ifdef SEAICE_VARIABLE_FREEZING_POINT
 #include "DYNVARS.h"
-#endif /* SEAICE_VARIABLE_FREEZING_POINT */
-#ifdef ALLOW_EXF
-# include "EXF_OPTIONS.h"
-# include "EXF_FIELDS.h"
-#endif
+#endif 
+C/* SEAICE_VARIABLE_FREEZING_POINT */
 
 C     === Routine arguments ===
 C     INPUT:
@@ -42,71 +39,76 @@ C     HSNOW_ACTUAL :: actual snow thickness
 C     bi,bj   :: loop indices
 C     OUTPUT:
 C     netHeatFlux :: net heat flux under ice = growth rate
-C     IcePenetSWFlux  :: short wave heat flux under ice
+C     IcePenetratingShortwaveFlux  :: short wave heat flux under ice
+      _RL UG         (1-OLx:sNx+OLx,1-OLy:sNy+OLy)
       _RL TSURF      (1-OLx:sNx+OLx,1-OLy:sNy+OLy,nSx,nSy)
+      _RL HICE_ACTUAL  (1-OLx:sNx+OLx,1-OLy:sNy+OLy)
+      _RL HSNOW_ACTUAL (1-OLx:sNx+OLx,1-OLy:sNy+OLy)
 
-      _RL UG             (1:sNx,1:sNy)
-      _RL HICE_ACTUAL    (1:sNx,1:sNy)
-      _RL HSNOW_ACTUAL   (1:sNx,1:sNy)
+      _RL F_ia       (1-OLx:sNx+OLx,1-OLy:sNy+OLy)
+      _RL F_io_net   (1-OLx:sNx+OLx,1-OLy:sNy+OLy)
+      _RL F_ia_net   (1-OLx:sNx+OLx,1-OLy:sNy+OLy)
 
-      _RL F_ia           (1:sNx,1:sNy)
-      _RL F_io_net       (1:sNx,1:sNy)
-      _RL F_ia_net       (1:sNx,1:sNy)
-      _RL IcePenetSWFlux (1:sNx,1:sNy)
+      _RL F_swi      (1-OLx:sNx+OLx,1-OLy:sNy+OLy)
+      _RL F_lwd      (1-OLx:sNx+OLx,1-OLy:sNy+OLy)
+      _RL F_lwu      (1-OLx:sNx+OLx,1-OLy:sNy+OLy)
+      _RL F_lh       (1-OLx:sNx+OLx,1-OLy:sNy+OLy)
+      _RL F_sens     (1-OLx:sNx+OLx,1-OLy:sNy+OLy)
+      _RL F_c        (1-OLx:sNx+OLx,1-OLy:sNy+OLy)
+      _RL qhice_mm   (1-OLx:sNx+OLx,1-OLy:sNy+OLy)
 
-      _RL F_swi      (1:sNx,1:sNy)
-      _RL F_lwd      (1:sNx,1:sNy)
-      _RL F_lwu      (1:sNx,1:sNy)
-      _RL F_lh       (1:sNx,1:sNy)
-      _RL F_sens     (1:sNx,1:sNy)
-      _RL F_c        (1:sNx,1:sNy)
-      _RL qhice_mm   (1:sNx,1:sNy)
+      _RL IcePenetratingShortwaveFlux (1-OLx:sNx+OLx,1-OLy:sNy+OLy)
+      _RL AbsorbedShortwaveFlux       (1-OLx:sNx+OLx,1-OLy:sNy+OLy)
+      _RL IcePenetratingShortwaveFluxFraction
+     &           (1-OLx:sNx+OLx,1-OLy:sNy+OLy)
 
-      _RL AbsorbedSWFlux       (1:sNx,1:sNy)
-      _RL IcePenetSWFluxFrac   (1:sNx,1:sNy)
-
-C     local copies of global variables
-      _RL tsurfLoc   (1:sNx,1:sNy)
-      _RL atempLoc   (1:sNx,1:sNy)
-      _RL lwdownLoc  (1:sNx,1:sNy)
-      _RL ALB        (1:sNx,1:sNy)
-      
-      _RL tsurfLocOld
-
-      INTEGER bi, bj, myThid
+      INTEGER bi, bj
       INTEGER KOPEN
 
 C     === Local variables ===
 C     i,j - Loop counters
       INTEGER i, j
       INTEGER ITER
-
-      _RL  QS1, C1, C2, C3, C4, C5, TB, D1, D1I, D3
+      _RL  QS1, C1, C2, C3, C4, C5, TB, D1, D1I, D3,IAN1
       _RL  TMELT, TMELTP, XKI, XKS, HCUT, ASNOW, XIO
-
 C     effective conductivity of combined ice and snow
       _RL  effConduct
-
-C     specific humidity at ice surface variables
+C     specific humidity at ice surface
       _RL  mm_pi,mm_log10pi,dqhice_dTice
      
 C     powers of temperature
       _RL  t1, t2, t3, t4
 
+C     local copies of global variables
+      _RL tsurfLoc   (1-OLx:sNx+OLx,1-OLy:sNy+OLy)
+      _RL atempLoc   (1-OLx:sNx+OLx,1-OLy:sNy+OLy)
+      _RL lwdownLoc  (1-OLx:sNx+OLx,1-OLy:sNy+OLy)
+      _RL ALB        (1-OLx:sNx+OLx,1-OLy:sNy+OLy)
+
+
 c     Ian Saturation Vapor Pressure 
       _RL aa1,aa2,bb1,bb2,Ppascals,cc0,cc1,cc2,cc3t,dFiDTs1
+#ifdef SEAICE_DEBUG
+      _RL tsurfLocInitial   (1-OLx:sNx+OLx,1-OLy:sNy+OLy)
+      _RL tsurfLocOld
+      INTEGER CONV_IT
+      _RL TSURF_CONV
 
-      aa1 = 2663.5 _d 0
-      aa2 = 12.537 _d 0
-      bb1 = 0.622 _d 0
-      bb2 = ONE - bb1
-      Ppascals = 1000.*100. _d 0
-      cc0 = 10. _d 0**aa2
-      cc1 = cc0*aa1*bb1*Ppascals*log(10. _d 0)
+      TSURF_CONV = 0.0 _d 0
+      CONV_IT = 0
+#endif 
+
+      aa1 = 2663.5
+      aa2 = 12.537
+      bb1 = 0.622
+      bb2 = 1.0 - bb1
+      Ppascals = 1000.*100.
+      cc0 = 10**aa2
+      cc1 = cc0*aa1*bb1*Ppascals*log(10.0)
       cc2 = cc0*bb2
        
 C FREEZING TEMPERATURE OF SEAWATER
-      TB=273.15 _d 0 + SEAICE_freeze 
+      TB=273.15 _d + 00 - 1.96 _d + 00
 C SENSIBLE HEAT CONSTANT
       D1=SEAICE_sensHeat
 C ICE LATENT HEAT CONSTANT
@@ -114,124 +116,169 @@ C ICE LATENT HEAT CONSTANT
 C STEFAN BOLTZMAN CONSTANT TIMES 0.97 EMISSIVITY
       D3=SEAICE_emissivity
 C MELTING TEMPERATURE OF ICE
-      TMELT=273.15 _d 0 
-
+      TMELT=273.15 _d +00
 C ICE CONDUCTIVITY
       XKI=SEAICE_iceConduct
 C SNOW CONDUCTIVITY
       XKS=SEAICE_snowConduct
-C CUTOFF SNOW THICKNESS
-      HCUT=SEAICE_snowThick
 C PENETRATION SHORTWAVE RADIATION FACTOR
       XIO=SEAICE_shortwave
 
+c/* debug */
+
       DO J=1,sNy
        DO I=1,sNx
-        IcePenetSWFlux     (I,J) = 0. _d 0
-        IcePenetSWFluxFrac (I,J) = 0. _d 0
-        AbsorbedSWFlux (I,J) = 0. _d 0
 
-        qhice_mm (I,J) = 0. _d 0
-        F_ia     (I,J) = 0. _d 0 
-        F_io_net (I,J) = 0. _d 0
-        F_ia_net (I,J) = 0. _d 0
+        IcePenetratingShortwaveFlux         (I,J) = 0. _d 0
+        IcePenetratingShortwaveFluxFraction (I,J) = 0. _d 0
+        AbsorbedShortwaveFlux               (I,J) = 0. _d 0
 
-        F_swi    (I,J) = 0. _d 0
-        F_lwd    (I,J) = 0. _d 0
-        F_lwu    (I,J) = 0. _d 0
-        F_lh     (I,J) = 0. _d 0
-        F_sens   (I,J) = 0. _d 0
+        qhice_mm (I,J) = 0.0 _d 0
+        F_ia     (I,J) = 0.0 _d 0 
+        F_io_net (I,J) = 0.0 _d 0
+        F_ia_net (I,J) = 0.0 _d 0
 
-c set the surface temperature to zero if there is no ice there.       
-c
-c        IF (HICE_ACTUAL(I,J) .GT. 0.0) THEN        
-c          tsurfLoc (I,J) = MIN(TMELT, TSURF(I,J,bi,bj))
-c        ELSE
-c          tsurfLoc(I,J) = TMELT
-c        ENDIF
+        F_swi    (I,J) = 0.0 _d 0
+        F_lwd    (I,J) = 0.0 _d 0
+        F_lwu    (I,J) = 0.0 _d 0
+        F_lh     (I,J) = 0.0 _d 0
+        F_sens   (I,J) = 0.0 _d 0
 
-c reset the surface temperature to the freezing point each time around.
-        tsurfLoc(I,J) = TMELT
-        TSURF(I,J,bi,bj) = tsurfLoc(I,J)
-
+        flux_LWI(I,J,bi,bj) = 0.0
+        flux_SWI(I,J,bi,bj) = 0.0
+        flux_LWU(I,J,bi,bj) = 0.0
+        flux_CON(I,J,bi,bj) = 0.0
+        flux_SEN(I,J,bi,bj) = 0.0
+        flux_LAT(I,J,bi,bj) = 0.0
+        flux_ION(I,J,bi,bj) = 0.0
+        flux_IAN(I,J,bi,bj) = 0.0
+ 
         atempLoc (I,J) = MAX(TMELT + MIN_ATEMP,ATEMP(I,J,bi,bj))
         lwdownLoc(I,J) = LWDOWN(I,J,bi,bj)
 
-       ENDDO
-      ENDDO
+c Set the ice surface temperature to the melting point if there is 
+c no ice here, or to the minimum of the ice melting point or the
+c last ice surface temperature.  You never know what could have
+c happened to TMELT since it was last through this subroutine... 
 
-C COME HERE AT START OF ITERATION
+        IF (HICE_ACTUAL(I,J) .GT. 0.0) THEN       
+            tsurfLoc (I,J) = MIN(TMELT, TSURF(I,J,bi,bj))
+            TSURF(I,J,bi,bj) = tsurfLoc(I,J)
+        ELSE
+            tsurfLoc(I,J) = TMELT
+        ENDIF
 
+#ifdef SEAICE_DEBUG
+C       The snow/ice surface temperature when we enter the routine
+        tsurfLocInitial(I,J) = tsurfLoc(I,J)
+#endif
+       ENDDO !/* I */
+      ENDDO !/* J */
+
+
+c     GO THROUGH EACH POINT.... 
        DO J=1,sNy
         DO I=1,sNx
 
+c     DON'T BOTHER DOING THE REST OF THIS SUBROUTINE
+c     IF THERE IS NO ICE HERE TO BEING WITH
+c     THERE CAN BE NO ICE-ATM OR ICE-OCEAN FLUX IN THAT CASE
          IF (HICE_ACTUAL(I,J) .GT. 0.0) THEN
 
-C         DECIDE ON ALBEDO
-          IF ( YC(I,J,bi,bj) .LT. ZERO ) THEN
-           IF (tsurfLoc(I,J) .GE. TMELT) THEN
-            IF (HSNOW_ACTUAL(I,J) .EQ. 0.0) THEN
-             ALB(I,J)   = SEAICE_wetIceAlb_south
-            ELSE                ! some snow
-             ALB(I,J)   = SEAICE_wetSnowAlb_south
-            ENDIF
-           ELSE                 ! no surface melting
-            IF (HSNOW_ACTUAL(I,J) .EQ. 0.0) THEN
-             ALB(I,J)   = SEAICE_dryIceAlb_south
-            ELSE                !  some snow
-             ALB(I,J)   = SEAICE_drySnowAlb_south
-            ENDIF 
+C         DECIDE ON ALBEDO BASED ON THE ICE SURFACE TEMPERATURE
+C         OF THE PREVIOUS ITERATION
+          IF (tsurfLoc(I,J) .GE. TMELT) THEN
+           IF (HSNOW_ACTUAL(I,J) .EQ. 0.0) THEN
+              ALB(I,J)   = SEAICE_wetIceAlb
+           ELSE  ! some snow
+              ALB(I,J)   = SEAICE_wetSnowAlb
            ENDIF
-          ELSE
-           IF (tsurfLoc(I,J) .GE. TMELT) THEN
+          ELSE   ! no surface melting
             IF (HSNOW_ACTUAL(I,J) .EQ. 0.0) THEN
-             ALB(I,J)   = SEAICE_wetIceAlb
-            ELSE                ! some snow
-             ALB(I,J)   = SEAICE_wetSnowAlb
-            ENDIF
-           ELSE                 ! no surface melting
-            IF (HSNOW_ACTUAL(I,J) .EQ. 0.0) THEN
-             ALB(I,J)   = SEAICE_dryIceAlb
-            ELSE                !  some snow
-             ALB(I,J)   = SEAICE_drySnowAlb
+              ALB(I,J)   = SEAICE_dryIceAlb
+            ELSE !  some snow
+              ALB(I,J)   = SEAICE_drySnowAlb
             ENDIF 
-           ENDIF
-          ENDIF
+          ENDIF !/* Surf temp is below or at freezing */
 
+#ifdef SEAICE_DEBUG
+          IF ( (I .EQ. SEAICE_debugPointX)   .and.
+     &         (J .EQ. SEAICE_debugPointY) ) THEN
+
+            print '(A,2i4,3(1x,1P2E15.3))',
+     &      'ibi i j initial tsurfLoc ',I,J,tsurfLoc(I,J)
+
+            print '(A,2i4,3(1x,1P2E15.3))',
+     &      'ibi i j ALB/ATEMP/LWDOWN ',I,J,ALB(I,J),
+     &      atempLoc(I,J),lwdownLoc(I,J)
+    
+            print *,''
+          ENDIF !/* DEBUG POINT */
+#endif
+
+c THESE VARIABLES ARE INDEPENDENT OF THE ICE/SNOW SURFACE
+c TEMPERATURE. CALCULATE THEM FIRST BEFORE THE ICE/SNOW
+c SURFACE TEMPERATURE ITERATIVE LOOP
           F_lwd(I,J) = - 0.97 _d 0 * lwdownLoc(I,J)
 
           IF (HSNOW_ACTUAL(I,J) .GT. 0.0) THEN
-           IcePenetSWFluxFrac(I,J) = ZERO
+           IcePenetratingShortwaveFluxFraction(I,J) = ZERO
           ELSE
-           IcePenetSWFluxFrac(I,J) = 
+           IcePenetratingShortwaveFluxFraction(I,J) = 
      &        XIO*EXP(-1.5 _d 0 * HICE_ACTUAL(I,J))
           ENDIF
 
-           AbsorbedSWFlux(I,J)       = -(ONE - ALB(I,J))*
-     &        (1.0 - IcePenetSWFluxFrac(I,J))
+          AbsorbedShortwaveFlux(I,J)       = -(ONE - ALB(I,J))*
+     &        (1.0 - IcePenetratingShortwaveFluxFraction(I,J))
      &         *SWDOWN(I,J,bi,bj)
 
-           IcePenetSWFlux(I,J) = -(ONE - ALB(I,J))*
-     &        IcePenetSWFluxFrac(I,J)
+          IcePenetratingShortwaveFlux(I,J) = -(ONE - ALB(I,J))*
+     &        IcePenetratingShortwaveFluxFraction(I,J)
      &        *SWDOWN(I,J,bi,bj)
 
-          F_swi(I,J) = AbsorbedSWFlux(I,J)
+          F_swi(I,J) = AbsorbedShortwaveFlux(I,J)
 
 c         set a min ice as 5 cm to limit arbitrarily large conduction.
-          HICE_ACTUAL(I,J) = max(HICE_ACTUAL(I,J),5. _d -2)
+          HICE_ACTUAL(I,J) = max(HICE_ACTUAL(I,J),0.05)
 
           effConduct = XKI * XKS / 
      &        (XKS * HICE_ACTUAL(I,J) + XKI * HSNOW_ACTUAL(I,J))
 
+#ifdef SEAICE_DEBUG
+c         RESET THE ITERATION WHERE CONVERGENCE IS ACHIEVED
+          CONV_IT = 0
+#endif
+
+c Onset of iterative search --------------------
           DO ITER=1,IMAX_TICE
+
+C          ONLY BOTHER REFINING THE SOLUTION IF AN ENERGY BALANCE 
+C          TO SPECIFICED PRECISION HAS NOT BEEN ACHIEVED.  ONE ITERATION
+C          IS REQUIRED TO CALCULATE F_IA.
+           IF ( (ITER .GT. 1 )                .AND. 
+     &          (ABS(F_ia(I,J)) .LT. SEAICE_heatFluxPrecision))  THEN
+c           We have achieved the precision required.  Be careful
+c           not to set this value higher than machine precision.
+c           1.0e-12 works well.  Convergence within 5 iterations is
+c           typical.
+
+#ifdef SEAICE_DEBUG
+c           Record the iteration where precision was first achieved.
+            IF (CONV_IT .EQ. 0) THEN
+                CONV_IT = ITER
+                print *,' convergence at it ',ITER-1 
+            ENDIF !/* First time hitting precision*/
+#endif         
+           ELSE !/*  Required precision not yet achieved.  Iterate */
 
            t1 = tsurfLoc(I,J)
            t2 = t1*t1
            t3 = t2*t1
            t4 = t2*t2
 
+#ifdef SEAICE_DEBUG
            tsurfLocOld = t1
-
+#endif
 c          log 10 of the sat vap pressure
            mm_log10pi = -aa1 / t1 + aa2
 c          saturation vapor pressure
@@ -249,35 +296,78 @@ c          the full derivative
      &        D1I*UG(I,J)*dqhice_dTice
 
 
+c qhice_mm depends on t1 via mm_pi via mm_log10pi
            F_lh(I,J)    = D1I * UG(I,J) * (qhice_mm(I,J)-AQH(I,J,bi,bj))
+
+c these depend on t1 directly
            F_c(I,J)     = -effConduct * (TB - t1)
            F_lwu(I,J)   = t4 * D3
            F_sens(I,J)  = D1 * UG(I,J) * (t1 - atempLoc(I,J))
 
+#ifdef SEAICE_DEBUG                      
+           IF ( (I .EQ. SEAICE_debugPointX)   .and. 
+     &          (J .EQ. SEAICE_debugPointY) ) THEN
+
+            print '(A,2i4,4(1x,1P2E15.3))',
+     &      'ibi i j F_LH/F_C/F_LWU/F_SENS',I,J,
+     &       F_lh(I,J),F_c(I,J),F_lwu(I,J),F_sens(I,J)
+
+            print '(A,2i4,4(1x,1P2E15.3))',
+     &      'ibi i j UG,QHICE,AQH, t1     ', I,J,
+     &       UG(I,J),qhice_mm(I,J),AQH(I,J,bi,bj), t1
+           ENDIF !/* debug point */
+#endif 
+
+C       This is the net flux into the surface of the ice, it includes
+C       conductive heat fluxes.  This will be zero ultimately 
+C       if the search works.
+
            F_ia(I,J)    = F_lwd(I,J) + F_swi(I,J) + F_lwu(I,J) +
-     &         F_c(I,J) + F_sens(I,J) + F_lh(I,J)
+     &        F_c(I,J) + F_sens(I,J) + F_lh(I,J)
+
+C  Update the ice surface temperature to further reduce the 
+C  net heat flux at the ice surface.
 
            tsurfLoc(I,J) = tsurfLoc(I,J) - F_ia(I,J) / dFiDTs1
 
 
-c    If the search falls below 50 Kelvin then kick the search back up to  
-c    TMELT.  Note that a solution to the equation is for a large negative
+c    If the search falls below 50 Kelvin then reset the algorithm at
+c    TMELT - 10 K.  Hope that a slightly different starting point 
+c    will lead to a solution
+
+c    Note that a solution to the equation is for a large negative
 c    value of ice surface temperature since the longwave outgoing radiation
 c    goes as the fourth power of temperature.
 
            IF (tsurfLoc(I,J) .LT. 50.0 ) THEN 
-                tsurfLoc(I,J) = TMELT 
-           ENDIF 
+                tsurfLoc(I,J) = TMELT  - 10.0 
+                print *,'ifice : had to wrap around i,j, iteration',
+     &                   i,j, ITER
+           ENDIF  !/* Tsurf too cold */
 
 #ifdef SEAICE_DEBUG
-          IF ( (I .EQ. SEAICE_debugPointX)   .and.
+c    Debug the difference in tsurf from iteration to  iteration
+            IF ( (I .EQ. SEAICE_debugPointX)   .and.
      &          (J .EQ. SEAICE_debugPointY) ) THEN
+              TSURF_CONV= log10(abs(tsurfLoc(I,J) - tsurfLocOld))
 
-            print *,'ice-iter tsurfLc,|dif|', I,J, ITER,tsurfLoc(I,J),
-     &           log10(abs(tsurfLoc(I,J) - tsurfLocOld))
-          ENDIF
-#endif   
-          ENDDO !/* Iterations */
+              print *,'0076',ITER,TSURF_CONV,
+     &          abs(tsurfLoc(I,J) - tsurfLocInitial(I,J))
+
+            ENDIF !/* Debug point */ 
+#endif     
+ 
+           ENDIF !/* Not yet reached required precision */
+          ENDDO !/* End of iterations */
+c ---------------------------------------------------
+
+c At this point the iterations are over and we have 
+c an ice/snow surface temperature.
+
+c First, we take the final ice/snow surface temperature and
+c recalculate the fluxes.  The temperature that balanced heat 
+c fluxes may be above the freezing point of ice/snow.  In 
+c that case we limit the temperature to the freezing point.
 
           tsurfLoc(I,J) = MIN(tsurfLoc(I,J),TMELT)
           TSURF(I,J,bi,bj) = tsurfLoc(I,J)
@@ -299,58 +389,106 @@ c         over ice specific humidity
           F_lwu(I,J)   = t4 * D3
           F_sens(I,J)  = D1 * UG(I,J) * (t1 - atempLoc(I,J))
 
-c         exlude conductive flux, the actual flux with the atmosphere.
-          F_ia(I,J)    = F_lwd(I,J) + F_swi(I,J) + F_lwu(I,J) +
-     &         F_sens(I,J) + F_lh(I,J)
+C   recalculate the total heat convergence at the ice surface with the 
+C   new perhaps bounded surface temperature.  If the surface ice temperature
+C   that balances heat fluxes is above the freezing point of seawater then
+C   there  will be conductive heat fluxes into the ice which will melt ice.
+           F_ia(I,J)    = F_lwd(I,J) + F_swi(I,J) + F_lwu(I,J) +
+     &        F_c(I,J) + F_sens(I,J) + F_lh(I,J)
 
+C   Determine whether the conductive fluxes indicate fluxes out of the ocean
+C   or into the ice.
           IF (F_c(I,J) .LT. 0.0) THEN
+C           Conductive fluxes through the ice are negative this implies
+C           that we are taking the heat out of the ocean and there is no net
+C           convergence of heat at the ice surface.  F_ia should be zero.
+
             F_io_net(I,J) = -F_c(I,J)
-            F_ia_net(I,J) = 0.0
+            F_ia_net(I,J) = 0.0 _d 0
           ELSE
+C           Conductive fluxes through the ice are positive.  This implies
+C           that heat has converged to the surface and is going to conduct
+C           into the ice, melting it.  The rate of convergence is given by
+C           F_ia_net.
+
             F_io_net(I,J) = 0.0
             F_ia_net(I,J) = F_lwd(I,J) + F_swi(I,J) + F_lwu(I,J) +
      &         F_sens(I,J) + F_lh(I,J)
+
           ENDIF !/* conductive fluxes up or down */
 
+
+          flux_LWI(I,J,bi,bj) = F_lwd(I,J)
+          flux_SWI(I,J,bi,bj) = F_swi(I,J)
+          flux_LWU(I,J,bi,bj) = F_lwu(I,J)
+          flux_CON(I,J,bi,bj) = F_c(I,J)
+          flux_SEN(I,J,bi,bj) = F_sens(I,J)
+          flux_LAT(I,J,bi,bj) = F_lh(I,J)
+          flux_ION(I,J,bi,bj) = F_io_net(I,J)
+          flux_IAN(I,J,bi,bj) = F_ia_net(I,J)
+
+c Next, do some more detailed debugging for this particular point
 
 #ifdef SEAICE_DEBUG
           IF ( (I .EQ. SEAICE_debugPointX)   .and.
      &         (J .EQ. SEAICE_debugPointY) ) THEN
 
-          print '(A,2i4,3(1x,1P2E15.3))',
+          print *,'------- IBI summary -------'
+          print *,''
+          print '(A,2i4,3(1x,1P2E15.6))',
      &     'ibi i j T(SURF, surfLoc,atmos)',I,J, 
      &     TSURF(I,J,bi,bj), tsurfLoc(I,J),atempLoc(I,J) 
 
-          print '(A,2i4,3(1x,1P2E15.3))',
+          print '(A,2i4,3(1x,1P2E15.6))',
      &     'ibi i j QSW(Tot, Abs, Pen)    ',I,J, 
-     &     SWDOWN(I,J,bi,bj), AbsorbedSWFlux(I,J),
-     &     IcePenetSWFlux(I,J)
+     &     SWDOWN(I,J,bi,bj), AbsorbedShortwaveFlux(I,J),
+     &     IcePenetratingShortwaveFlux(I,J)
 
-          print '(A,2i4,3(1x,1P2E15.3))',
+          print '(A,2i4,3(1x,1P2E15.6))',
      &     'ibi i j IcePenSWFluxFrac, Alb ',I,J, 
-     ^      IcePenetSWFluxFrac(I,J), ALB(I,J)
+     &      IcePenetratingShortwaveFluxFraction(I,J), ALB(I,J)
  
-          print '(A,2i4,3(1x,1P2E15.3))',
+          print '(A,2i4,3(1x,1P2E15.6))',
      &     'ibi i j qh(ATM ICE)           ',I,J, 
      &      AQH(I,J,bi,bj),qhice_mm(I,J)
  
-          print '(A,2i4,3(1x,1P2E15.3))',
+          print '(A,2i4,3(1x,1P2E15.6))',
      &     'ibi i j F(lwd,swi,lwu)        ',I,J, 
      &      F_lwd(I,J), F_swi(I,J), F_lwu(I,J)
 
-          print '(A,2i4,3(1x,1P2E15.3))',
+          print '(A,2i4,3(1x,1P2E15.6))',
      &     'ibi i j F(c,lh,sens)          ',I,J, 
      &      F_c(I,J), F_lh(I,J), F_sens(I,J)
 
-          print '(A,2i4,3(1x,1P2E15.3))',
+          print '(A,2i4,3(1x,1P2E15.6))',
      &     'ibi i j F(io_net,ia_net,ia)   ',I,J, 
      &      F_io_net(I,J), F_ia_net(I,J), F_ia(I,J)
 
-         ENDIF
+          ENDIF !/* Debug point */ 
 #endif
 
-         ENDIF  !/* HICE_ACTUAL > 0 */
 
+c The whole point of this 
+c algorithm is to find the ice/snow surface temperature that achieves an
+c energy balance.  Here we do the oft-neglected task of checking that it 
+c actually has worked.  Tolerance is arbitrarly set at 0.0001 W/m^2
+
+c If the surface temperature is greater than the freezing point of salt
+c water then we will not have an energy balance since the conductive flux
+c will be transferring heat into the ice from the atmosphere.  It is only
+c when the ice surface is cooler than the ocean surface that conductive 
+c fluxes ultimately balance the net heat loss at the surface.
+
+           IF (tsurfLoc(I,J) .LT. TB) THEN
+             IF (ABS(F_ia(I,J)) .GT. SEAICE_heatFluxPrecision) THEN
+                print *,'ifice : energy balance failure at i,j ',I,J
+                print *,'tsurfLoc, F_ia_net',tsurfLoc(I,J),F_ia_net(I,J)
+                print *,'tsurfLoc, F_ia',tsurfLoc(I,J),F_ia(I,J)
+                stop
+             ENDIF  !/* Heat flux imbalance too great */
+           ENDIF !/* surface temperature is less than freezing point */  
+
+        ENDIF  
        ENDDO   !/* i */
       ENDDO    !/* j */
 

--- a/pkg/seaice/seaice_solve4temp_adjointable.F
+++ b/pkg/seaice/seaice_solve4temp_adjointable.F
@@ -1,0 +1,358 @@
+C $Header: /u/gcmpack/MITgcm/pkg/seaice/seaice_budget_ice_if.F,v 1.4 2009/05/23 15:39:12 dimitri Exp $
+C $Name:  $
+
+#include "SEAICE_OPTIONS.h"
+
+CStartOfInterface
+      SUBROUTINE SEAICE_BUDGET_ICE_IF(
+     I     UG, HICE_ACTUAL, HSNOW_ACTUAL,
+     U     TSURF,
+     O     F_io_net,F_ia_net,F_ia, IcePenetSWFlux,
+     I     bi, bj, myThid )
+C     /================================================================\
+C     | SUBROUTINE seaice_budget_ice_if                                |
+C     | o Calculate ice growth rate, surface fluxes and temperature of |
+C     |   ice surface.                                                 |
+C     |   see Hibler, MWR, 108, 1943-1973, 1980                        |
+C     |================================================================|
+C     \================================================================/
+      IMPLICIT NONE
+
+C     === Global variables ===
+#include "SIZE.h"
+#include "GRID.h"
+#include "EEPARAMS.h"
+#include "FFIELDS.h"
+#include "SEAICE.h"
+#include "SEAICE_PARAMS.h"
+#ifdef SEAICE_VARIABLE_FREEZING_POINT
+#include "DYNVARS.h"
+#endif /* SEAICE_VARIABLE_FREEZING_POINT */
+#ifdef ALLOW_EXF
+# include "EXF_OPTIONS.h"
+# include "EXF_FIELDS.h"
+#endif
+
+C     === Routine arguments ===
+C     INPUT:
+C     UG      :: thermal wind of atmosphere
+C     TSURF   :: surface temperature of ice in Kelvin, updated
+C     HICE_ACTUAL    :: (actual) ice thickness with upper and lower limit
+C     HSNOW_ACTUAL :: actual snow thickness
+C     bi,bj   :: loop indices
+C     OUTPUT:
+C     netHeatFlux :: net heat flux under ice = growth rate
+C     IcePenetSWFlux  :: short wave heat flux under ice
+      _RL TSURF      (1-OLx:sNx+OLx,1-OLy:sNy+OLy,nSx,nSy)
+
+      _RL UG             (1:sNx,1:sNy)
+      _RL HICE_ACTUAL    (1:sNx,1:sNy)
+      _RL HSNOW_ACTUAL   (1:sNx,1:sNy)
+
+      _RL F_ia           (1:sNx,1:sNy)
+      _RL F_io_net       (1:sNx,1:sNy)
+      _RL F_ia_net       (1:sNx,1:sNy)
+      _RL IcePenetSWFlux (1:sNx,1:sNy)
+
+      _RL F_swi      (1:sNx,1:sNy)
+      _RL F_lwd      (1:sNx,1:sNy)
+      _RL F_lwu      (1:sNx,1:sNy)
+      _RL F_lh       (1:sNx,1:sNy)
+      _RL F_sens     (1:sNx,1:sNy)
+      _RL F_c        (1:sNx,1:sNy)
+      _RL qhice_mm   (1:sNx,1:sNy)
+
+      _RL AbsorbedSWFlux       (1:sNx,1:sNy)
+      _RL IcePenetSWFluxFrac   (1:sNx,1:sNy)
+
+C     local copies of global variables
+      _RL tsurfLoc   (1:sNx,1:sNy)
+      _RL atempLoc   (1:sNx,1:sNy)
+      _RL lwdownLoc  (1:sNx,1:sNy)
+      _RL ALB        (1:sNx,1:sNy)
+      
+      _RL tsurfLocOld
+
+      INTEGER bi, bj, myThid
+      INTEGER KOPEN
+
+C     === Local variables ===
+C     i,j - Loop counters
+      INTEGER i, j
+      INTEGER ITER
+
+      _RL  QS1, C1, C2, C3, C4, C5, TB, D1, D1I, D3
+      _RL  TMELT, TMELTP, XKI, XKS, HCUT, ASNOW, XIO
+
+C     effective conductivity of combined ice and snow
+      _RL  effConduct
+
+C     specific humidity at ice surface variables
+      _RL  mm_pi,mm_log10pi,dqhice_dTice
+     
+C     powers of temperature
+      _RL  t1, t2, t3, t4
+
+c     Ian Saturation Vapor Pressure 
+      _RL aa1,aa2,bb1,bb2,Ppascals,cc0,cc1,cc2,cc3t,dFiDTs1
+
+      aa1 = 2663.5 _d 0
+      aa2 = 12.537 _d 0
+      bb1 = 0.622 _d 0
+      bb2 = ONE - bb1
+      Ppascals = 1000.*100. _d 0
+      cc0 = 10. _d 0**aa2
+      cc1 = cc0*aa1*bb1*Ppascals*log(10. _d 0)
+      cc2 = cc0*bb2
+       
+C FREEZING TEMPERATURE OF SEAWATER
+      TB=273.15 _d 0 + SEAICE_freeze 
+C SENSIBLE HEAT CONSTANT
+      D1=SEAICE_sensHeat
+C ICE LATENT HEAT CONSTANT
+      D1I=SEAICE_latentIce
+C STEFAN BOLTZMAN CONSTANT TIMES 0.97 EMISSIVITY
+      D3=SEAICE_emissivity
+C MELTING TEMPERATURE OF ICE
+      TMELT=273.15 _d 0 
+
+C ICE CONDUCTIVITY
+      XKI=SEAICE_iceConduct
+C SNOW CONDUCTIVITY
+      XKS=SEAICE_snowConduct
+C CUTOFF SNOW THICKNESS
+      HCUT=SEAICE_snowThick
+C PENETRATION SHORTWAVE RADIATION FACTOR
+      XIO=SEAICE_shortwave
+
+      DO J=1,sNy
+       DO I=1,sNx
+        IcePenetSWFlux     (I,J) = 0. _d 0
+        IcePenetSWFluxFrac (I,J) = 0. _d 0
+        AbsorbedSWFlux (I,J) = 0. _d 0
+
+        qhice_mm (I,J) = 0. _d 0
+        F_ia     (I,J) = 0. _d 0 
+        F_io_net (I,J) = 0. _d 0
+        F_ia_net (I,J) = 0. _d 0
+
+        F_swi    (I,J) = 0. _d 0
+        F_lwd    (I,J) = 0. _d 0
+        F_lwu    (I,J) = 0. _d 0
+        F_lh     (I,J) = 0. _d 0
+        F_sens   (I,J) = 0. _d 0
+
+c set the surface temperature to zero if there is no ice there.       
+c
+c        IF (HICE_ACTUAL(I,J) .GT. 0.0) THEN        
+c          tsurfLoc (I,J) = MIN(TMELT, TSURF(I,J,bi,bj))
+c        ELSE
+c          tsurfLoc(I,J) = TMELT
+c        ENDIF
+
+c reset the surface temperature to the freezing point each time around.
+        tsurfLoc(I,J) = TMELT
+        TSURF(I,J,bi,bj) = tsurfLoc(I,J)
+
+        atempLoc (I,J) = MAX(TMELT + MIN_ATEMP,ATEMP(I,J,bi,bj))
+        lwdownLoc(I,J) = LWDOWN(I,J,bi,bj)
+
+       ENDDO
+      ENDDO
+
+C COME HERE AT START OF ITERATION
+
+       DO J=1,sNy
+        DO I=1,sNx
+
+         IF (HICE_ACTUAL(I,J) .GT. 0.0) THEN
+
+C         DECIDE ON ALBEDO
+          IF ( YC(I,J,bi,bj) .LT. ZERO ) THEN
+           IF (tsurfLoc(I,J) .GE. TMELT) THEN
+            IF (HSNOW_ACTUAL(I,J) .EQ. 0.0) THEN
+             ALB(I,J)   = SEAICE_wetIceAlb_south
+            ELSE                ! some snow
+             ALB(I,J)   = SEAICE_wetSnowAlb_south
+            ENDIF
+           ELSE                 ! no surface melting
+            IF (HSNOW_ACTUAL(I,J) .EQ. 0.0) THEN
+             ALB(I,J)   = SEAICE_dryIceAlb_south
+            ELSE                !  some snow
+             ALB(I,J)   = SEAICE_drySnowAlb_south
+            ENDIF 
+           ENDIF
+          ELSE
+           IF (tsurfLoc(I,J) .GE. TMELT) THEN
+            IF (HSNOW_ACTUAL(I,J) .EQ. 0.0) THEN
+             ALB(I,J)   = SEAICE_wetIceAlb
+            ELSE                ! some snow
+             ALB(I,J)   = SEAICE_wetSnowAlb
+            ENDIF
+           ELSE                 ! no surface melting
+            IF (HSNOW_ACTUAL(I,J) .EQ. 0.0) THEN
+             ALB(I,J)   = SEAICE_dryIceAlb
+            ELSE                !  some snow
+             ALB(I,J)   = SEAICE_drySnowAlb
+            ENDIF 
+           ENDIF
+          ENDIF
+
+          F_lwd(I,J) = - 0.97 _d 0 * lwdownLoc(I,J)
+
+          IF (HSNOW_ACTUAL(I,J) .GT. 0.0) THEN
+           IcePenetSWFluxFrac(I,J) = ZERO
+          ELSE
+           IcePenetSWFluxFrac(I,J) = 
+     &        XIO*EXP(-1.5 _d 0 * HICE_ACTUAL(I,J))
+          ENDIF
+
+           AbsorbedSWFlux(I,J)       = -(ONE - ALB(I,J))*
+     &        (1.0 - IcePenetSWFluxFrac(I,J))
+     &         *SWDOWN(I,J,bi,bj)
+
+           IcePenetSWFlux(I,J) = -(ONE - ALB(I,J))*
+     &        IcePenetSWFluxFrac(I,J)
+     &        *SWDOWN(I,J,bi,bj)
+
+          F_swi(I,J) = AbsorbedSWFlux(I,J)
+
+c         set a min ice as 5 cm to limit arbitrarily large conduction.
+          HICE_ACTUAL(I,J) = max(HICE_ACTUAL(I,J),5. _d -2)
+
+          effConduct = XKI * XKS / 
+     &        (XKS * HICE_ACTUAL(I,J) + XKI * HSNOW_ACTUAL(I,J))
+
+          DO ITER=1,IMAX_TICE
+
+           t1 = tsurfLoc(I,J)
+           t2 = t1*t1
+           t3 = t2*t1
+           t4 = t2*t2
+
+           tsurfLocOld = t1
+
+c          log 10 of the sat vap pressure
+           mm_log10pi = -aa1 / t1 + aa2
+c          saturation vapor pressure
+           mm_pi = 10**(mm_log10pi)
+c          over ice specific humidity
+           qhice_mm(I,J) = bb1*mm_pi / (Ppascals - (1.0 - bb1) * mm_pi)
+
+c          constant for sat vap pressure derivative w.r.t tice        
+           cc3t = 10**(aa1 / t1)
+c          the actual derivative
+           dqhice_dTice = cc1 * cc3t /( (cc2-cc3t*Ppascals)**2 * t2)
+
+c          the full derivative 
+           dFiDTs1 = 4.0 * D3*t3 + effConduct + D1*UG(I,J) +
+     &        D1I*UG(I,J)*dqhice_dTice
+
+
+           F_lh(I,J)    = D1I * UG(I,J) * (qhice_mm(I,J)-AQH(I,J,bi,bj))
+           F_c(I,J)     = -effConduct * (TB - t1)
+           F_lwu(I,J)   = t4 * D3
+           F_sens(I,J)  = D1 * UG(I,J) * (t1 - atempLoc(I,J))
+
+           F_ia(I,J)    = F_lwd(I,J) + F_swi(I,J) + F_lwu(I,J) +
+     &         F_c(I,J) + F_sens(I,J) + F_lh(I,J)
+
+           tsurfLoc(I,J) = tsurfLoc(I,J) - F_ia(I,J) / dFiDTs1
+
+
+c    If the search falls below 50 Kelvin then kick the search back up to  
+c    TMELT.  Note that a solution to the equation is for a large negative
+c    value of ice surface temperature since the longwave outgoing radiation
+c    goes as the fourth power of temperature.
+
+           IF (tsurfLoc(I,J) .LT. 50.0 ) THEN 
+                tsurfLoc(I,J) = TMELT 
+           ENDIF 
+
+#ifdef SEAICE_DEBUG
+          IF ( (I .EQ. SEAICE_debugPointX)   .and.
+     &          (J .EQ. SEAICE_debugPointY) ) THEN
+
+            print *,'ice-iter tsurfLc,|dif|', I,J, ITER,tsurfLoc(I,J),
+     &           log10(abs(tsurfLoc(I,J) - tsurfLocOld))
+          ENDIF
+#endif   
+          ENDDO !/* Iterations */
+
+          tsurfLoc(I,J) = MIN(tsurfLoc(I,J),TMELT)
+          TSURF(I,J,bi,bj) = tsurfLoc(I,J)
+
+          t1 = tsurfLoc(I,J)
+          t2 = t1*t1
+          t3 = t2*t1
+          t4 = t2*t2
+
+c         log 10 of the sat vap pressure
+          mm_log10pi = -aa1 / t1 + aa2
+c         saturation vapor pressure
+          mm_pi = 10**(mm_log10pi)
+c         over ice specific humidity
+          qhice_mm(I,J) = bb1*mm_pi / (Ppascals - (1.0 - bb1) * mm_pi)
+
+          F_lh(I,J)    = D1I * UG(I,J) * (qhice_mm(I,J)-AQH(I,J,bi,bj))
+          F_c(I,J)     = -effConduct * (TB - t1)
+          F_lwu(I,J)   = t4 * D3
+          F_sens(I,J)  = D1 * UG(I,J) * (t1 - atempLoc(I,J))
+
+c         exlude conductive flux, the actual flux with the atmosphere.
+          F_ia(I,J)    = F_lwd(I,J) + F_swi(I,J) + F_lwu(I,J) +
+     &         F_sens(I,J) + F_lh(I,J)
+
+          IF (F_c(I,J) .LT. 0.0) THEN
+            F_io_net(I,J) = -F_c(I,J)
+            F_ia_net(I,J) = 0.0
+          ELSE
+            F_io_net(I,J) = 0.0
+            F_ia_net(I,J) = F_lwd(I,J) + F_swi(I,J) + F_lwu(I,J) +
+     &         F_sens(I,J) + F_lh(I,J)
+          ENDIF !/* conductive fluxes up or down */
+
+
+#ifdef SEAICE_DEBUG
+          IF ( (I .EQ. SEAICE_debugPointX)   .and.
+     &         (J .EQ. SEAICE_debugPointY) ) THEN
+
+          print '(A,2i4,3(1x,1P2E15.3))',
+     &     'ibi i j T(SURF, surfLoc,atmos)',I,J, 
+     &     TSURF(I,J,bi,bj), tsurfLoc(I,J),atempLoc(I,J) 
+
+          print '(A,2i4,3(1x,1P2E15.3))',
+     &     'ibi i j QSW(Tot, Abs, Pen)    ',I,J, 
+     &     SWDOWN(I,J,bi,bj), AbsorbedSWFlux(I,J),
+     &     IcePenetSWFlux(I,J)
+
+          print '(A,2i4,3(1x,1P2E15.3))',
+     &     'ibi i j IcePenSWFluxFrac, Alb ',I,J, 
+     ^      IcePenetSWFluxFrac(I,J), ALB(I,J)
+ 
+          print '(A,2i4,3(1x,1P2E15.3))',
+     &     'ibi i j qh(ATM ICE)           ',I,J, 
+     &      AQH(I,J,bi,bj),qhice_mm(I,J)
+ 
+          print '(A,2i4,3(1x,1P2E15.3))',
+     &     'ibi i j F(lwd,swi,lwu)        ',I,J, 
+     &      F_lwd(I,J), F_swi(I,J), F_lwu(I,J)
+
+          print '(A,2i4,3(1x,1P2E15.3))',
+     &     'ibi i j F(c,lh,sens)          ',I,J, 
+     &      F_c(I,J), F_lh(I,J), F_sens(I,J)
+
+          print '(A,2i4,3(1x,1P2E15.3))',
+     &     'ibi i j F(io_net,ia_net,ia)   ',I,J, 
+     &      F_io_net(I,J), F_ia_net(I,J), F_ia(I,J)
+
+         ENDIF
+#endif
+
+         ENDIF  !/* HICE_ACTUAL > 0 */
+
+       ENDDO   !/* i */
+      ENDDO    !/* j */
+
+      RETURN
+      END

--- a/pkg/seaice/seaice_solve4temp_adjointable.F
+++ b/pkg/seaice/seaice_solve4temp_adjointable.F
@@ -1,15 +1,14 @@
-C     $Header: /home/ubuntu/mnt/e9_copy/MITgcm_contrib/ifenty/Fenty_Thermo_Code_Updates/code_updates/seaice_budget_ice_if.F,v 1.1 2010/09/03 13:05:44 ifenty Exp $
-C     $Name:  $
+C $Header: /home/ubuntu/mnt/e9_copy/MITgcm_contrib/ifenty/Fenty_Thermo_Code_Updates/code_updates_20130122/seaice_budget_ice_if.F,v 1.1 2013/01/22 21:53:56 ifenty Exp $
+C $Name:  $
 
 #include "SEAICE_OPTIONS.h"
 
-C     StartOfInterface
+CStartOfInterface
       SUBROUTINE SEAICE_BUDGET_ICE_IF(
-     I   UG, HICE_ACTUAL, HSNOW_ACTUAL,
-     U   TSURF,
-     O   F_io_net,F_ia_net,F_ia, IcePenetSWFlux,
-     I   bi, bj, myTime, myIter, myThid )
-
+     I     UG, HICE_ACTUAL, HSNOW_ACTUAL,
+     U     TSURF,
+     O     F_io_net,F_ia_net,F_ia, IcePenetSWFlux,
+     I     bi, bj, myThid )
 C     /================================================================\
 C     | SUBROUTINE seaice_budget_ice_if                                |
 C     | o Calculate ice growth rate, surface fluxes and temperature of |
@@ -38,14 +37,12 @@ C     === Routine arguments ===
 C     INPUT:
 C     UG      :: thermal wind of atmosphere
 C     TSURF   :: surface temperature of ice in Kelvin, updated
-C     HICE_ACTUAL    :: actual ice thickness
+C     HICE_ACTUAL    :: (actual) ice thickness with upper and lower limit
 C     HSNOW_ACTUAL :: actual snow thickness
 C     bi,bj   :: loop indices
-
 C     OUTPUT:
 C     netHeatFlux :: net heat flux under ice = growth rate
 C     IcePenetSWFlux  :: short wave heat flux under ice
-
       _RL TSURF      (1-OLx:sNx+OLx,1-OLy:sNy+OLy,nSx,nSy)
 
       _RL UG             (1:sNx,1:sNy)
@@ -76,9 +73,9 @@ C     local copies of global variables
       
       _RL tsurfLocOld
 
-      INTEGER bi, bj, myIter, myThid
+      INTEGER bi, bj, myThid
       INTEGER KOPEN
-      _RL myTime
+
 C     === Local variables ===
 C     i,j - Loop counters
       INTEGER i, j
@@ -92,328 +89,270 @@ C     effective conductivity of combined ice and snow
 
 C     specific humidity at ice surface variables
       _RL  mm_pi,mm_log10pi,dqhice_dTice
-      
+     
 C     powers of temperature
       _RL  t1, t2, t3, t4
-      _RL TEN
+
 c     Ian Saturation Vapor Pressure 
       _RL aa1,aa2,bb1,bb2,Ppascals,cc0,cc1,cc2,cc3t,dFiDTs1
 
-      TEN = 10.0 _d 0
       aa1 = 2663.5 _d 0
       aa2 = 12.537 _d 0
       bb1 = 0.622 _d 0
       bb2 = ONE - bb1
-      Ppascals = 100000. _d 0
-      cc0 = TEN ** aa2
+      Ppascals = 1000.*100. _d 0
+      cc0 = 10. _d 0**aa2
       cc1 = cc0*aa1*bb1*Ppascals*log(10. _d 0)
       cc2 = cc0*bb2
-      
-C     FREEZING TEMPERATURE OF SEAWATER
+       
+C FREEZING TEMPERATURE OF SEAWATER
       TB=273.15 _d 0 + SEAICE_freeze 
-
-C     SENSIBLE HEAT CONSTANT
+C SENSIBLE HEAT CONSTANT
       D1=SEAICE_sensHeat
-
-C     ICE LATENT HEAT CONSTANT
+C ICE LATENT HEAT CONSTANT
       D1I=SEAICE_latentIce
-
-C     STEFAN BOLTZMAN CONSTANT TIMES 0.97 EMISSIVITY
+C STEFAN BOLTZMAN CONSTANT TIMES 0.97 EMISSIVITY
       D3=SEAICE_emissivity
+C MELTING TEMPERATURE OF ICE
+      TMELT=273.15 _d 0 
 
-C     MELTING TEMPERATURE OF ICE
-      TMELT = 273.15 _d 0 
-
-C     ICE CONDUCTIVITY
+C ICE CONDUCTIVITY
       XKI=SEAICE_iceConduct
-
-C     SNOW CONDUCTIVITY
+C SNOW CONDUCTIVITY
       XKS=SEAICE_snowConduct
-
-C     CUTOFF SNOW THICKNESS
+C CUTOFF SNOW THICKNESS
       HCUT=SEAICE_snowThick
-
-C     PENETRATION SHORTWAVE RADIATION FACTOR
+C PENETRATION SHORTWAVE RADIATION FACTOR
       XIO=SEAICE_shortwave
 
-
-c     Initialize variables
       DO J=1,sNy
-         DO I=1,sNx
-            IcePenetSWFlux     (I,J) = 0. _d 0
-            IcePenetSWFluxFrac (I,J) = 0. _d 0
-            AbsorbedSWFlux     (I,J) = 0. _d 0
+       DO I=1,sNx
+        IcePenetSWFlux     (I,J) = 0. _d 0
+        IcePenetSWFluxFrac (I,J) = 0. _d 0
+        AbsorbedSWFlux (I,J) = 0. _d 0
 
-            qhice_mm (I,J) = 0. _d 0
-            F_ia     (I,J) = 0. _d 0 
-            F_io_net (I,J) = 0. _d 0
-            F_ia_net (I,J) = 0. _d 0
+        qhice_mm (I,J) = 0. _d 0
+        F_ia     (I,J) = 0. _d 0 
+        F_io_net (I,J) = 0. _d 0
+        F_ia_net (I,J) = 0. _d 0
 
-            F_swi    (I,J) = 0. _d 0
-            F_lwd    (I,J) = 0. _d 0
-            F_lwu    (I,J) = 0. _d 0
-            F_lh     (I,J) = 0. _d 0
-            F_sens   (I,J) = 0. _d 0
+        F_swi    (I,J) = 0. _d 0
+        F_lwd    (I,J) = 0. _d 0
+        F_lwu    (I,J) = 0. _d 0
+        F_lh     (I,J) = 0. _d 0
+        F_sens   (I,J) = 0. _d 0
 
-c     Reset the snow/ice surface to TMELT 
-            tsurfLoc(I,J) = TMELT
-            TSURF(I,J,bi,bj) = tsurfLoc(I,J)
+c set the surface temperature to zero if there is no ice there.       
+c
+c        IF (HICE_ACTUAL(I,J) .GT. 0.0) THEN        
+c          tsurfLoc (I,J) = MIN(TMELT, TSURF(I,J,bi,bj))
+c        ELSE
+c          tsurfLoc(I,J) = TMELT
+c        ENDIF
 
-c     Bound the atmospheric temperature
-            atempLoc (I,J) = MAX(TMELT + MIN_ATEMP,ATEMP(I,J,bi,bj))
-            lwdownLoc(I,J) = LWDOWN(I,J,bi,bj)
-         ENDDO
+c reset the surface temperature to the freezing point each time around.
+        tsurfLoc(I,J) = TMELT
+        TSURF(I,J,bi,bj) = tsurfLoc(I,J)
+
+        atempLoc (I,J) = MAX(TMELT + MIN_ATEMP,ATEMP(I,J,bi,bj))
+        lwdownLoc(I,J) = LWDOWN(I,J,bi,bj)
+
+       ENDDO
       ENDDO
 
-      
-      DO J=1,sNy
-         DO I=1,sNx
+C COME HERE AT START OF ITERATION
 
-C     DECIDE ON ALBEDO
-            IF (HICE_ACTUAL(I,J) .GT. ZERO) THEN
+       DO J=1,sNy
+        DO I=1,sNx
 
-               IF ( YC(I,J,bi,bj) .LT. ZERO ) THEN
-                  IF (tsurfLoc(I,J) .GE. TMELT) THEN
-                     IF (HSNOW_ACTUAL(I,J) .EQ. ZERO) THEN
-                        ALB(I,J)   = SEAICE_wetIceAlb_south
-                     ELSE       ! some snow
-                        ALB(I,J)   = SEAICE_wetSnowAlb_south
-                     ENDIF
-                  ELSE          ! no surface melting
-                     IF (HSNOW_ACTUAL(I,J) .EQ. ZERO) THEN
-                        ALB(I,J)   = SEAICE_dryIceAlb_south
-                     ELSE       !  some snow
-                        ALB(I,J)   = SEAICE_drySnowAlb_south
-                     ENDIF 
-                  ENDIF         !/ The snow/ice surface temperature
+         IF (HICE_ACTUAL(I,J) .GT. 0.0) THEN
 
-               ELSE             !/ Northern Hemisphere
-                  IF (tsurfLoc(I,J) .GE. TMELT) THEN
-                     IF (HSNOW_ACTUAL(I,J) .EQ. ZERO) THEN
-                        ALB(I,J)   = SEAICE_wetIceAlb
-                     ELSE       ! some snow
-                        ALB(I,J)   = SEAICE_wetSnowAlb
-                     ENDIF
-                  ELSE          ! no surface melting
-                     IF (HSNOW_ACTUAL(I,J) .EQ. ZERO) THEN
-                        ALB(I,J)   = SEAICE_dryIceAlb
-                     ELSE       !  some snow
-                        ALB(I,J)   = SEAICE_drySnowAlb
-                     ENDIF 
-                  ENDIF
-               ENDIF            !/ Albedo is determined
+C         DECIDE ON ALBEDO
+          IF ( YC(I,J,bi,bj) .LT. ZERO ) THEN
+           IF (tsurfLoc(I,J) .GE. TMELT) THEN
+            IF (HSNOW_ACTUAL(I,J) .EQ. 0.0) THEN
+             ALB(I,J)   = SEAICE_wetIceAlb_south
+            ELSE                ! some snow
+             ALB(I,J)   = SEAICE_wetSnowAlb_south
+            ENDIF
+           ELSE                 ! no surface melting
+            IF (HSNOW_ACTUAL(I,J) .EQ. 0.0) THEN
+             ALB(I,J)   = SEAICE_dryIceAlb_south
+            ELSE                !  some snow
+             ALB(I,J)   = SEAICE_drySnowAlb_south
+            ENDIF 
+           ENDIF
+          ELSE
+           IF (tsurfLoc(I,J) .GE. TMELT) THEN
+            IF (HSNOW_ACTUAL(I,J) .EQ. 0.0) THEN
+             ALB(I,J)   = SEAICE_wetIceAlb
+            ELSE                ! some snow
+             ALB(I,J)   = SEAICE_wetSnowAlb
+            ENDIF
+           ELSE                 ! no surface melting
+            IF (HSNOW_ACTUAL(I,J) .EQ. 0.0) THEN
+             ALB(I,J)   = SEAICE_dryIceAlb
+            ELSE                !  some snow
+             ALB(I,J)   = SEAICE_drySnowAlb
+            ENDIF 
+           ENDIF
+          ENDIF
 
-c     The longwave radiative flux convergence
-               F_lwd(I,J) = - 0.97 _d 0 * lwdownLoc(I,J)
+          F_lwd(I,J) = - 0.97 _d 0 * lwdownLoc(I,J)
 
-c     Determine the fraction of shortwave radiative flux 
-c     remaining after scattering through the snow and ice at
-c     the ocean interface.  If snow is present, no radiation
-c     penetrates to the ocean.
-               IF (HSNOW_ACTUAL(I,J) .GT. ZERO) THEN
-                  IcePenetSWFluxFrac(I,J) = ZERO
-               ELSE
-                  IcePenetSWFluxFrac(I,J) = 
-     &               XIO*EXP(-1.5 _d 0 * HICE_ACTUAL(I,J))
-               ENDIF
+          IF (HSNOW_ACTUAL(I,J) .GT. 0.0) THEN
+           IcePenetSWFluxFrac(I,J) = ZERO
+          ELSE
+           IcePenetSWFluxFrac(I,J) = 
+     &        XIO*EXP(-1.5 _d 0 * HICE_ACTUAL(I,J))
+          ENDIF
 
-c     The shortwave radiative flux convergence in the
-c     seaice. 
-               AbsorbedSWFlux(I,J)       = -(ONE - ALB(I,J))*
-     &            (ONE - IcePenetSWFluxFrac(I,J))
-     &            *SWDOWN(I,J,bi,bj)
+           AbsorbedSWFlux(I,J)       = -(ONE - ALB(I,J))*
+     &        (1.0 - IcePenetSWFluxFrac(I,J))
+     &         *SWDOWN(I,J,bi,bj)
 
-c     The shortwave radiative flux convergence in the
-c     ocean beneath ice.
-               IcePenetSWFlux(I,J) = -(ONE - ALB(I,J))*
-     &            IcePenetSWFluxFrac(I,J)
-     &            *SWDOWN(I,J,bi,bj)
+           IcePenetSWFlux(I,J) = -(ONE - ALB(I,J))*
+     &        IcePenetSWFluxFrac(I,J)
+     &        *SWDOWN(I,J,bi,bj)
 
-               F_swi(I,J) = AbsorbedSWFlux(I,J)
+          F_swi(I,J) = AbsorbedSWFlux(I,J)
 
-c     Set a mininum sea ice thickness of 5 cm to bound
-c     the magnitude of conductive heat fluxes.
-               HICE_ACTUAL(I,J) = max(HICE_ACTUAL(I,J),5. _d -2)
+c         set a min ice as 5 cm to limit arbitrarily large conduction.
+          HICE_ACTUAL(I,J) = max(HICE_ACTUAL(I,J),5. _d -2)
 
-c     The effective conductivity of the two-layer 
-c     snow/ice system.
-               effConduct = XKI * XKS / 
-     &            (XKS * HICE_ACTUAL(I,J) + XKI * HSNOW_ACTUAL(I,J))
+          effConduct = XKI * XKS / 
+     &        (XKS * HICE_ACTUAL(I,J) + XKI * HSNOW_ACTUAL(I,J))
+
+          DO ITER=1,IMAX_TICE
+
+           t1 = tsurfLoc(I,J)
+           t2 = t1*t1
+           t3 = t2*t1
+           t4 = t2*t2
+
+           tsurfLocOld = t1
+
+c          log 10 of the sat vap pressure
+           mm_log10pi = -aa1 / t1 + aa2
+c          saturation vapor pressure
+           mm_pi = 10**(mm_log10pi)
+c          over ice specific humidity
+           qhice_mm(I,J) = bb1*mm_pi / (Ppascals - (1.0 - bb1) * mm_pi)
+
+c          constant for sat vap pressure derivative w.r.t tice        
+           cc3t = 10**(aa1 / t1)
+c          the actual derivative
+           dqhice_dTice = cc1 * cc3t /( (cc2-cc3t*Ppascals)**2 * t2)
+
+c          the full derivative 
+           dFiDTs1 = 4.0 * D3*t3 + effConduct + D1*UG(I,J) +
+     &        D1I*UG(I,J)*dqhice_dTice
+
+
+           F_lh(I,J)    = D1I * UG(I,J) * (qhice_mm(I,J)-AQH(I,J,bi,bj))
+           F_c(I,J)     = -effConduct * (TB - t1)
+           F_lwu(I,J)   = t4 * D3
+           F_sens(I,J)  = D1 * UG(I,J) * (t1 - atempLoc(I,J))
+
+           F_ia(I,J)    = F_lwd(I,J) + F_swi(I,J) + F_lwu(I,J) +
+     &         F_c(I,J) + F_sens(I,J) + F_lh(I,J)
+
+           tsurfLoc(I,J) = tsurfLoc(I,J) - F_ia(I,J) / dFiDTs1
+
+
+c    If the search falls below 50 Kelvin then kick the search back up to  
+c    TMELT.  Note that a solution to the equation is for a large negative
+c    value of ice surface temperature since the longwave outgoing radiation
+c    goes as the fourth power of temperature.
+
+           IF (tsurfLoc(I,J) .LT. 50.0 ) THEN 
+                tsurfLoc(I,J) = TMELT 
+           ENDIF 
+
+#ifdef SEAICE_DEBUG
+          IF ( (I .EQ. SEAICE_debugPointX)   .and.
+     &          (J .EQ. SEAICE_debugPointY) ) THEN
+
+            print *,'ice-iter tsurfLc,|dif|', I,J, ITER,tsurfLoc(I,J),
+     &           log10(abs(tsurfLoc(I,J) - tsurfLocOld))
+          ENDIF
+#endif   
+          ENDDO !/* Iterations */
+
+          tsurfLoc(I,J) = MIN(tsurfLoc(I,J),TMELT)
+          TSURF(I,J,bi,bj) = tsurfLoc(I,J)
+
+          t1 = tsurfLoc(I,J)
+          t2 = t1*t1
+          t3 = t2*t1
+          t4 = t2*t2
+
+c         log 10 of the sat vap pressure
+          mm_log10pi = -aa1 / t1 + aa2
+c         saturation vapor pressure
+          mm_pi = 10**(mm_log10pi)
+c         over ice specific humidity
+          qhice_mm(I,J) = bb1*mm_pi / (Ppascals - (1.0 - bb1) * mm_pi)
+
+          F_lh(I,J)    = D1I * UG(I,J) * (qhice_mm(I,J)-AQH(I,J,bi,bj))
+          F_c(I,J)     = -effConduct * (TB - t1)
+          F_lwu(I,J)   = t4 * D3
+          F_sens(I,J)  = D1 * UG(I,J) * (t1 - atempLoc(I,J))
+
+c         exlude conductive flux, the actual flux with the atmosphere.
+          F_ia(I,J)    = F_lwd(I,J) + F_swi(I,J) + F_lwu(I,J) +
+     &         F_sens(I,J) + F_lh(I,J)
+
+          IF (F_c(I,J) .LT. 0.0) THEN
+            F_io_net(I,J) = -F_c(I,J)
+            F_ia_net(I,J) = 0.0
+          ELSE
+            F_io_net(I,J) = 0.0
+            F_ia_net(I,J) = F_lwd(I,J) + F_swi(I,J) + F_lwu(I,J) +
+     &         F_sens(I,J) + F_lh(I,J)
+          ENDIF !/* conductive fluxes up or down */
 
 
 #ifdef SEAICE_DEBUG
-               IF ( (I .EQ. SEAICE_debugPointX)   .and.
-     &            (J .EQ. SEAICE_debugPointY) ) THEN
+          IF ( (I .EQ. SEAICE_debugPointX)   .and.
+     &         (J .EQ. SEAICE_debugPointY) ) THEN
 
-                  print '(A,i6)','-----------------------------------'
-                  print '(A,i6)','ibi initialization ', myIter
+          print '(A,2i4,3(1x,1P2E15.3))',
+     &     'ibi i j T(SURF, surfLoc,atmos)',I,J, 
+     &     TSURF(I,J,bi,bj), tsurfLoc(I,J),atempLoc(I,J) 
 
-                  print '(A,i6,4(1x,1PE33.26))',
-     &               'ibi iter, TSL, TS ',myIter,
-     &               tsurfLoc(I,J), TSURF(I,J,bi,bj)
+          print '(A,2i4,3(1x,1P2E15.3))',
+     &     'ibi i j QSW(Tot, Abs, Pen)    ',I,J, 
+     &     SWDOWN(I,J,bi,bj), AbsorbedSWFlux(I,J),
+     &     IcePenetSWFlux(I,J)
 
-                  print '(A,i6,4(1x,1PE33.26))',
-     &               'ibi iter, TMELT ',myIter,TMELT
+          print '(A,2i4,3(1x,1P2E15.3))',
+     &     'ibi i j IcePenSWFluxFrac, Alb ',I,J, 
+     ^      IcePenetSWFluxFrac(I,J), ALB(I,J)
+ 
+          print '(A,2i4,3(1x,1P2E15.3))',
+     &     'ibi i j qh(ATM ICE)           ',I,J, 
+     &      AQH(I,J,bi,bj),qhice_mm(I,J)
+ 
+          print '(A,2i4,3(1x,1P2E15.3))',
+     &     'ibi i j F(lwd,swi,lwu)        ',I,J, 
+     &      F_lwd(I,J), F_swi(I,J), F_lwu(I,J)
 
-                  print '(A,i6,4(1x,1PE33.26))',
-     &               'ibi iter, HIA, EFKCON ',myIter,
-     &               HICE_ACTUAL(I,J), effConduct
+          print '(A,2i4,3(1x,1P2E15.3))',
+     &     'ibi i j F(c,lh,sens)          ',I,J, 
+     &      F_c(I,J), F_lh(I,J), F_sens(I,J)
 
-                  print '(A,i6)','-----------------------------------'
-                  print '(A,i6)','ibi energy balance iterat ', myIter
-                  
-               ENDIF
+          print '(A,2i4,3(1x,1P2E15.3))',
+     &     'ibi i j F(io_net,ia_net,ia)   ',I,J, 
+     &      F_io_net(I,J), F_ia_net(I,J), F_ia(I,J)
+
+         ENDIF
 #endif
 
-               
-               DO ITER=1,IMAX_TICE
-                  
-                  t1 = tsurfLoc(I,J)
-                  t2 = t1*t1
-                  t3 = t2*t1
-                  t4 = t2*t2
+         ENDIF  !/* HICE_ACTUAL > 0 */
 
-                  tsurfLocOld = t1
-
-c     log 10 of the sat vap pressure
-                  mm_log10pi = -aa1 / t1 + aa2
-
-c     The saturation vapor pressure (SVP) in the surface 
-c     boundary layer (BL) above the snow/ice.
-                  mm_pi = TEN **(mm_log10pi)
-
-c     The specific humidity in the BL above the snow/ice
-                  qhice_mm(I,J) = bb1*mm_pi / (Ppascals - (ONE - bb1) *
-     &               mm_pi)
-
-c     A constant for SVP derivative w.r.t TICE
-                  cc3t = TEN **(aa1 / t1)
-
-c     d(qh)/d(TICE)
-                  dqhice_dTice = cc1*cc3t/((cc2-cc3t*Ppascals)**TWO *t2)
-
-c     d(F_ia)/d(TICE) 
-                  dFiDTs1 = 4.0 _d 0 * D3*t3 + effConduct + D1*UG(I,J) +
-     &               D1I*UG(I,J)*dqhice_dTice
-
-
-                  F_lh(I,J) = D1I*UG(I,J)*(qhice_mm(I,J)-AQH(I,J,bi,bj))
-                  F_c(I,J)  = -effConduct * (TB - t1)
-                  F_lwu(I,J)= t4 * D3
-                  F_sens(I,J)= D1 * UG(I,J) * (t1 - atempLoc(I,J))
-
-                  F_ia(I,J)  = F_lwd(I,J) + F_swi(I,J) + F_lwu(I,J) +
-     &               F_c(I,J) + F_sens(I,J) + F_lh(I,J)
-
-                  tsurfLoc(I,J) = tsurfLoc(I,J) - F_ia(I,J) / dFiDTs1
-
-
-c     If the search leads to tsurfLoc < 50 Kelvin,
-c     restart the search at tsurfLoc = TMELT.  Note that one
-c     solution to the energy balance problem is an 
-c     extremely low temperature - a temperature far below
-c     what is observed.
-
-                  IF (tsurfLoc(I,J) .LT. 50.0 _d 0 ) THEN 
-                     tsurfLoc(I,J) = TMELT 
-                  ENDIF 
-
-#ifdef SEAICE_DEBUG
-                  IF ( (I .EQ. SEAICE_debugPointX)   .and.
-     &               (J .EQ. SEAICE_debugPointY) ) THEN
-
-                     print '(A,i6,4(1x,1PE33.26))',
-     &                  'ice-iter tsurfLc,|dif|  ', ITER,
-     &                  tsurfLoc(I,J),
-     &                  log10(abs(tsurfLoc(I,J) - tsurfLocOld))
-                  ENDIF
-#endif  
-                  
-               ENDDO            !/* Iterations */
-
-
-               tsurfLoc(I,J) = MIN(tsurfLoc(I,J),TMELT)
-               TSURF(I,J,bi,bj) = tsurfLoc(I,J)
-
-               t1 = tsurfLoc(I,J)
-               t2 = t1*t1
-               t3 = t2*t1
-               t4 = t2*t2
-
-c     log 10 of the sat vap pressure
-               mm_log10pi = -aa1 / t1 + aa2
-c     saturation vapor pressure
-               mm_pi = TEN **(mm_log10pi)
-c     over ice specific humidity
-               qhice_mm(I,J) = bb1*mm_pi/(Ppascals- (ONE - bb1) * mm_pi)
-
-               F_lh(I,J) = D1I * UG(I,J)*(qhice_mm(I,J)-AQH(I,J,bi,bj))
-               F_c(I,J)  = -effConduct * (TB - t1)
-               F_lwu(I,J)   = t4 * D3
-               F_sens(I,J)  = D1 * UG(I,J) * (t1 - atempLoc(I,J))
-
-c     exlude conductive flux, the actual flux with the atmosphere.
-               F_ia(I,J)    = F_lwd(I,J) + F_swi(I,J) + F_lwu(I,J) +
-     &            F_sens(I,J) + F_lh(I,J)
-
-               IF (F_c(I,J) .LT. ZERO) THEN
-                  F_io_net(I,J) = -F_c(I,J)
-                  F_ia_net(I,J) = ZERO
-               ELSE
-                  F_io_net(I,J) = ZERO
-                  F_ia_net(I,J) = F_lwd(I,J) + F_swi(I,J) + F_lwu(I,J) +
-     &               F_sens(I,J) + F_lh(I,J)
-               ENDIF            !/* conductive fluxes up or down */
-
-
-#ifdef SEAICE_DEBUG
-               IF ( (I .EQ. SEAICE_debugPointX)   .and.
-     &            (J .EQ. SEAICE_debugPointY) ) THEN
-
-                  print '(A)','----------------------------------------'
-                  print '(A,i6)','ibi complete ', myIter
-
-                  print '(A,4(1x,1PE33.26))',
-     &               'ibi T(SURF, surfLoc,atmos) ',
-     &               TSURF(I,J,bi,bj), tsurfLoc(I,J),atempLoc(I,J) 
-
-                  print '(A,4(1x,1PE33.26))',
-     &               'ibi LWL               ', lwdownLoc(I,J)
-                  
-                  print '(A,4(1x,1PE33.26))',
-     &               'ibi QSW(Tot, Abs, Pen)     ', 
-     &               SWDOWN(I,J,bi,bj), AbsorbedSWFlux(I,J),
-     &               IcePenetSWFlux(I,J)
-
-                  print '(A,4(1x,1PE33.26))',
-     &               'ibi IcePenSWFluxFrac, Alb  ' , 
-     ^               IcePenetSWFluxFrac(I,J), ALB(I,J)
-                  
-                  print '(A,4(1x,1PE33.26))',
-     &               'ibi qh(ATM ICE)            ', 
-     &               AQH(I,J,bi,bj),qhice_mm(I,J)
-                  
-                  print '(A,4(1x,1PE33.26))',
-     &               'ibi F(lwd,swi,lwu)         ', 
-     &               F_lwd(I,J), F_swi(I,J), F_lwu(I,J)
-
-                  print '(A,4(1x,1PE33.26))',
-     &               'ibi F(c,lh,sens)           ', 
-     &               F_c(I,J), F_lh(I,J), F_sens(I,J)
-
-                  print '(A,4(1x,1PE33.26))',
-     &               'ibi F(io_net,ia_net,ia)    ', 
-     &               F_io_net(I,J), F_ia_net(I,J), F_ia(I,J)
-
-                  print '(A)','----------------------------------------'
-
-               ENDIF
-#endif
-
-            ENDIF               !/* HICE_ACTUAL > 0 */
-
-         ENDDO                  !/* i */
-      ENDDO                     !/* j */
+       ENDDO   !/* i */
+      ENDDO    !/* j */
 
       RETURN
       END


### PR DESCRIPTION
This pull request will introduce two routines, _seaice_growth_adjointable.F_ and _seaice_solve4temp_adjointable.F_ which are adjointable thermodynamic sea ice routines based on the codes that I wrote for my thesis and which were modified several times over the years.  

The way I constructed this fork was to sequentially update and commit **seven** quasi-incremental versions of the routines dating from 2010 to 2018.  The final version includes edits by @ArashBigdeli to properly close budgets when the model is configured with a nonlinear free surface.  

Two notes
1. Earlier versions of seaice_solve4temp.F were called seaice_budget_ice.F  
2. @ArashBigdeli provided the seventh and last version of these these routines with the suffix _simple_ but because they are no more simple thermodynamically speaking than seaice_growth.F, I decided to use the suffix _adjointable_ instead.  

Additional routines will have to be added by @ArashBigdeli before these _adjointable_ routines can be run (i.e., called by seaice_model.F).  

## What is the new behaviour 
The sea ice thermodynamic adjoint will be stable.

## Does this PR introduce a breaking change? 
No.  However, a run time or compile time flag will have to be set to use the new routines (that flag is not introduced here).


## Other information:
Of particular interest to @menemenlis @heimbach @antnguyen13 @christophernhill @jm-c 

## Suggested addition to `tag-index`