### PR TITLE
obcs_init_fixed.F added to NOOPTFILES

### DIFF
--- a/tools/build_options/linux_amd64_ifort+mpi_ice_nas
+++ b/tools/build_options/linux_amd64_ifort+mpi_ice_nas
@@ -36,6 +36,7 @@ FFLAGS="$FFLAGS -W0 -WB"
 if test "x$IEEE" = x ; then     #- with optimisation:
     FOPTIM='-O2 -ipo -fp-model precise -align -axCORE-AVX2 -xSSE4.2 -traceback -ftz'
     NOOPTFILES='seaice_growth.F calc_oce_mxlayer.F fizhi_lsm.F fizhi_clockstuff.F ini_parms.F'
+#   NOOPTFILES='seaice_growth.F calc_oce_mxlayer.F fizhi_lsm.F fizhi_clockstuff.F ini_parms.F obcs_init_fixed.F'
 else
   if test "x$DEVEL" = x ; then  #- no optimisation + IEEE :
     FOPTIM='-O0 -noalign'

--- a/tools/build_options/linux_amd64_ifort+mpi_ice_nas
+++ b/tools/build_options/linux_amd64_ifort+mpi_ice_nas
@@ -36,7 +36,7 @@ FFLAGS="$FFLAGS -W0 -WB"
 if test "x$IEEE" = x ; then     #- with optimisation:
     FOPTIM='-O2 -ipo -fp-model precise -align -axCORE-AVX2 -xSSE4.2 -traceback -ftz'
     NOOPTFILES='seaice_growth.F calc_oce_mxlayer.F fizhi_lsm.F fizhi_clockstuff.F ini_parms.F'
-#   NOOPTFILES='seaice_growth.F calc_oce_mxlayer.F fizhi_lsm.F fizhi_clockstuff.F ini_parms.F obcs_init_fixed.F'
+    NOOPTFILES="$NOOPTFILES obcs_init_fixed.F"
 else
   if test "x$DEVEL" = x ; then  #- no optimisation + IEEE :
     FOPTIM='-O0 -noalign'


### PR DESCRIPTION
## What changes does this PR introduce?
obcs_init_fixed.F added to NOOPTFILES for
MITgcm/tools/build_options/linux_amd64_ifort+mpi_ice_nas

## What is the current behaviour? 
I have run across a number of MITgcm configurations, e.g.,
https://github.com/joernc/NA/tree/master/experiments/ll1815_02
https://github.com/joernc/NA/tree/master/experiments/ll1815_04
that cause segmentation fault on pleiades.

## What is the new behaviour 
No segmentation fault for above configurations.

## Does this PR introduce a breaking change? 
No.

## Other information:
The obcs_init_fixed.F segfault issue reappeared.
It looks like this problem might be linked with specific processors on pleiades.

## Suggested addition to `tag-index`
obcs_init_fixed.F added to linux_amd64_ifort+mpi_ice_nas NOOPTFILES