### PR TITLE
New namelist parameter for data.seaice

### DIFF
--- a/doc/manual_references.bib
+++ b/doc/manual_references.bib
@@ -1570,3 +1570,77 @@ PAGES = {35--44},
 URL = {https://www.the-cryosphere.net/5/35/2011/},
 DOI = {10.5194/tc-5-35-2011}
 }
+
+@Article{bitz01,
+  author =	 {C. M. Bitz and M. M. Holland and A. J. Weaver and
+                  M. Eby},
+  title =	 {Simulating the ice-thickness distribution in a
+                  coupled climate model},
+  journal =	 jgr,
+  year =	 2001,
+  volume =	 106,
+  pages =	 2441,
+  doi =		 {10.1029/1999JC000113}}
+
+@Article{lip01,
+  author =	 {W. H. Lipscomb},
+  title =	 {Remapping the thickness distribution in sea ice
+                  models},
+  journal =	 jgr,
+  year =	 2001,
+  volume =	 106,
+  number =	 {C7},
+  pages =	 {13989--14000},
+  doi =		 {10.1029/2000JC000518}}
+
+@Article{lip07,
+  author =	 {W. H. Lipscomb and E. C. Hunke and W. Maslowski and
+                  J. Jakacki},
+  title =	 {Ridging, strength, and stability in high-resolution
+                  sea ice models},
+  journal =	 jgr,
+  year =	 2007,
+  volume =	 112,
+  pages =	 {1--18},
+  doi =		 {10.1029/2005JC003355}}
+
+@Article{rot75,
+  author =	 {D. A. Rothrock},
+  title =	 {The energetics of the plastic deformation of pack
+                  ice by ridging},
+  journal =	 jgr,
+  year =	 1975,
+  volume =	 80,
+  number =	 33,
+  pages =	 {4514--4519},
+  doi =		 {10.1029/JC080i033p04514}}
+
+@Article{tho75,
+  AUTHOR =	 "A. S. Thorndike and D. A. Rothrock and G. A. Maykut
+                  and R. Colony",
+  YEAR =	 1975,
+  TITLE =	 "The thickness distribution of sea ice",
+  JOURNAL =	 jgr,
+  VOLUME =	 80,
+  PAGES =	 "4501--4513"
+}
+
+@Article{ung17,
+  author =	 {Mischa Ungermann and L. Bruno Tremblay and Torge
+                  Martin and Martin Losch},
+  title =	 {Impact of the Ice Strength Formulation on the
+                  Performance of a Sea Ice Thickness Distribution
+                  Model in the {A}rctic},
+  year =	 2017,
+  journal =	 jgr,
+  volume =	 122,
+  number =	 3,
+  issn =	 {2169-9291},
+  url =		 {http://dx.doi.org/10.1002/2016JC012128},
+  doi =		 {10.1002/2016JC012128},
+  pages =	 {2090--2107},
+  keywords =	 {Sea ice, Modeling, Distribution, cost function,
+                  coupled sea ice-ocean model, Arctic, ice strength
+                  parameterization, MITgcm, Green's function approach},
+}
+

--- a/doc/phys_pkgs/seaice.rst
+++ b/doc/phys_pkgs/seaice.rst
@@ -272,6 +272,44 @@ General flags and parameters
   +------------------------------+------------------------------+-------------------------------------------------------------------------+
   | SEAICE_useMultDimSnow        | T                            | use SEAICE_multDim snow categories                                      |
   +------------------------------+------------------------------+-------------------------------------------------------------------------+
+  | dynamical ice thickness distribution and ridging parameters, only active with SEAICE_ITD defined:                                     |
+  +------------------------------+------------------------------+-------------------------------------------------------------------------+
+  | useHibler79IceStrength       | T                            | do not use :cite:`rot75` with ITD                                       |
+  +------------------------------+------------------------------+-------------------------------------------------------------------------+
+  | SEAICEsimpleRidging          | T                            | use simple ridging a la :cite:`hib79`                                   |
+  +------------------------------+------------------------------+-------------------------------------------------------------------------+
+  | SEAICE_cf                    | 17                           | scaling parameter of :cite:`rot75` ice strength parameterization        |
+  +------------------------------+------------------------------+-------------------------------------------------------------------------+
+  | SEAICEpartFunc               | 0                            | use partition function of :cite:`tho75`                                 |
+  +------------------------------+------------------------------+-------------------------------------------------------------------------+
+  | SEAICEredistFunc             | 0                            | use redistribution function of :cite:`hib80`                            |
+  +------------------------------+------------------------------+-------------------------------------------------------------------------+
+  | SEAICEridgingIterMax         | 10                           | maximum number of ridging sweeps                                        |
+  +------------------------------+------------------------------+-------------------------------------------------------------------------+
+  | SEAICEshearParm              | 0.5                          | fraction of shear to be used for ridging                                |
+  +------------------------------+------------------------------+-------------------------------------------------------------------------+
+  | SEAICEgStar                  | 0.15                         | max. ice conc. that participates in ridging :cite:`tho75`               |
+  +------------------------------+------------------------------+-------------------------------------------------------------------------+
+  | SEAICEhStar                  | 25.                          | ridging parameter for :cite:`tho75`, :cite:`lip07`                      |
+  +------------------------------+------------------------------+-------------------------------------------------------------------------+
+  | SEAICEaStar                  | 0.05                         | similar to gStar for :cite:`lip07` participation function               |
+  +------------------------------+------------------------------+-------------------------------------------------------------------------+
+  | SEAICEmuRidging              | 3.                           | similar to hStar for :cite:`lip07` ridging function                     |
+  +------------------------------+------------------------------+-------------------------------------------------------------------------+
+  | SEAICEmaxRaft                | 1.                           | regularization parameter for rafting                                    | 
+  +------------------------------+------------------------------+-------------------------------------------------------------------------+
+  | SEAICEsnowFracRidge          | 0.5                          | fraction of snow that remains on ridged ice                             |
+  +------------------------------+------------------------------+-------------------------------------------------------------------------+
+  | SEAICEuseLinRemapITD         | T                            | use linear remapping scheme of :cite:`lip01`                            |
+  +------------------------------+------------------------------+-------------------------------------------------------------------------+
+  | Hlimit(nITD+1)               | UNSET_RL                     | ice thickness category limits (m)                                       |
+  +------------------------------+------------------------------+-------------------------------------------------------------------------+
+  | Hlimit_c1                    | 3.0                          | when Hlimit is not set, then these parameters                           |
+  +------------------------------+------------------------------+-------------------------------------------------------------------------+
+  | Hlimit_c2                    | 15.0                         | determine Hlimit from a simple function                                 |
+  +------------------------------+------------------------------+-------------------------------------------------------------------------+
+  | Hlimit_c3                    | 3.0                          | following :cite:`lip01`                                                 |
+  +------------------------------+------------------------------+-------------------------------------------------------------------------+
 
 
 .. _para_phys_pkg_seaice_fields_units:
@@ -1106,7 +1144,7 @@ schemes to preserve sharp gradients and edges that are typical of sea
 ice distributions and to rule out unphysical over- and undershoots
 (negative thickness or concentration). These schemes conserve volume and
 horizontal area and are unconditionally stable, so that we can set
-:math:`D_{X}=0`. Run-timeflags: ``SEAICEadvScheme ``(default=77, is a
+:math:`D_{X}=0`. Run-timeflags: ``SEAICEadvScheme`` (default=77, is a
 2nd-order flux limited scheme), ``DIFF`` = :math:`D_{X}/\Delta{x}`
 (default=0).
 
@@ -1133,6 +1171,90 @@ can occur, which then leads to unrealistic ice temperature. In the
 currently implemented solution, the sea-ice mass flux is used to
 advect the enthalpy in order to ensure conservation of enthalpy and to
 prevent false enthalpy extrema.
+
+.. _para_phys_pkg_seaice_itd:
+
+Dynamical Ice Thickness Distribution (ITD)
+##########################################
+
+The ice thickness distribution model implemented in MITgcm follows the implementatin in the Los Alamos sea ice model CICE (https://github.com/CICE-Consortium/CICE).
+There are two parts to it that are closely connected: the participation and rigding functions that determine which thickness classes take part in ridging and which thickness classes recieve ice during ridging based on :cite:`tho75` and the ice strength parameterization by :cite:`rot75` which uses this information.
+The following description is sligthly modified from :cite:`ung17`. Verification experiment ``seaice_itd`` uses the ITD model.
+
+Distribution, participation and redistribution functions in ridging
+<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<
+
+When ``SEAICE_ITD`` is defined in ``SEAICE_OPTIONS.h``, the ice
+thickness is described by the ice thickness distribution :math:`g(h,\mathbf{x},t)` for the subgrid-scale :cite:`tho75`, a probability density function for thickness :math:`h` following the evolution
+equation
+
+
+.. math::
+   :label: eq_itd
+
+   \frac{\partial g}{\partial t} = - \nabla \cdot (\mathbf{u} g) - \frac{\partial}{\partial h}(fg) + \Psi.
+
+Here :math:`f=\frac{\mathrm{d} h}{\mathrm{d} t}` is the thermodynamic growth rate and :math:`\Psi` a function describing the mechanical redistribution of sea ice during ridging or lead opening. 
+
+The mechanical redistribution function :math:`\Psi` generates open water in divergent motion and creates ridged ice during convergent motion. The ridging process depends on total strain rate and on the ratio between shear (runtime parameter ``SEAICEshearParm``) and divergent strain.
+In the single category model, ridge formation is treated implicitly by limiting the ice concentration to a maximum of one :cite:`hib79`, so that further volume increase in convergent motion leads to thicker ice. (This is also the default for ITD models; to change that set runtime parameter ``SEAICEsimpleRidging=.FALSE.`` in ``data.seaice``).
+For the ITD model, the ridging mode in convergence
+
+.. math::
+
+   \omega_r(h)= \frac{-a(h)+n(h)}{N}
+   
+gives the effective change for the ice volume with thickness between :math:`h` and :math:`h+\textrm{d} h` as the normalized difference between the ice :math:`n(h)` generated by ridging and the ice :math:`a(h)` participating in ridging.
+
+The participation function :math:`a(h) = b(h)g(h)` can be computed either following :cite:`tho75` (runtime parameter ``SEAICEpartFunc=0``) or :cite:`lip07` (``SEAICEpartFunc=1``), and similarly the ridging function :math:`n(h)` can be computed following :cite:`hib80` (runtime parameter ``SEAICEredistFunc=0``) or :cite:`lip07` (``SEAICEredistFunc=1``). As an example, we show here the functions that :cite:`lip07` suggested to avoid noise in the solutions. These functions are smooth and avoid non-differentiable discontinuities, but so far we did not find any noise issues as in :cite:`lip07`.
+
+With ``SEAICEpartFunc=1`` in ``data.seaice``, the participation function with the relative amount of ice of thickness :math:`h` weighted by an exponential function
+
+.. math::
+
+   b(h) = b_0 \exp [ -G(h)/a^*]
+   
+where :math:`G(h)=\int_0^h g(h) \textrm{d} h` is the cumulative thickness distribution function, :math:`b_0` a normalization factor, and :math:`a^*` (``SEAICEaStar``) the exponential constant that determines which relative amount of thicker and thinner ice take part in ridging.
+
+With ``SEAICEredistFunc=1`` in ``data.seaice``, the ice generated by ridging is calculated as 
+
+.. math::
+
+   n(h) = \int_0^\infty  a(h_1)\gamma(h_1,h) \textrm{d} h_1
+
+where the density function :math:`\gamma(h_1,h)` of resulting thickness :math:`h` for ridged ice with an original thickness of :math:`h_1` is taken as
+
+.. math::
+   
+   \gamma(h_1, h) = \frac{1}{k \lambda} \exp\left[{\frac{-(h-h_{\min})}{\lambda}}\right] 
+
+for :math:`h \geq h_{\min}`, with :math:`\gamma(h_1,h)=0` for :math:`h < h_{\min}$`.
+In this parameterization, the normalization factor :math:`k=\frac{h_{\min} + \lambda}{h_1}`, the e-folding scale :math:`\lambda = \mu h_1^{1/2}` and the minimum ridge thickness :math:`h_{\min}=\min(2h_1,h_1 + h_{\textrm{raft}})` all depend on the original thickness :math:`h_1`.
+The maximal ice thickness allowed to raft :math:`h_{\textrm{raft}}` is constant (``SEAICEmaxRaft``, default 1~m) and :math:`\mu` (``SEAICEmuRidging``) is a tunable parameter. 
+
+In the numerical model these equations are discretized into a set of :math:`n` (``nITD`` defined in ``SEAICE_SIZE.h``) thickness categories employing the delta function scheme of :cite:`bitz01`.  For each thickness category in an ITD configuration, the volume conservation equation :eq:`eq_advection` is evaluated using
+the heat flux with the category-specific values for ice and snow thickness, so there are no conceptual differences in the
+thermodynamics between the single category and ITD configurations. The only difference is that only in the thinnest category the creation
+of new ice of thickness :math:`H_0` (runtime parameter ``HO``) is possible, all other categories are limited to basal growth.  The conservation of ice
+area is replaced by the evolution equation of the ITD :eq:`eq_itd` that is discretized in thickness space with :math:`n+1` category limits given by runtime parameter ``Hlimit``. If ``Hlimit`` is not set in ``data.seaice``, a simple recursive formula following :cite:`lip01` is used to compute ``Hlimit``:
+:math:`H_\mathrm{limit}(k) = H_\mathrm{limit}(k-1) + c_1 + c_2 [ 1 + \tanh c_3 (\frac{k-1}{n} - 1) ]`, with :math:`H_\mathrm{limit}(0)=0` and :math:`H_\mathrm{limit}(n)=999.9`. The three contants are the runtime parameters ``Hlimit_c1, Hlimit_c2, Hlimit_c3``.
+The total ice concentration and volume can then be calculated by summing up the values for each category.
+
+Ice strength parameterization
+<<<<<<<<<<<<<<<<<<<<<<<<<<<<<
+
+In the default approach of equation :eq:`eq_icestrength`, the ice strength is parameterized following :cite:`hib79` and :math:`P` depends only on average ice concentration and thickness per grid cell and the constant ice strength parameters :math:`P^{\ast}` (``SEAICE_strength``) and :math:`C^{\ast}` (``SEAICE_cStar``). With an ice thickness distribution, it is possibe to use a different parameterization following :cite:`rot75`
+
+.. math::
+   :label: eq_rothrock
+
+      P = C_f C_p \int_0^\infty h^2 \omega_r(h) \textrm{d}h
+
+following considerations about the production of potential energy and the frictional energy loss in ridging.
+The physical constant :math:`C_p = \rho_i (\rho_w - \rho_i) \hat{g} / (2 \rho_w)` is a combination of the gravitational acceleration :math:`\hat{g}` and the densities :math:`\rho_i`, :math:`\rho_w` of ice and water, and :math:`C_f` (``SEAICE_cf``) is a scaling factor relating the amount of work against gravity necessary for ridging to the amount of work against friction. 
+To calculate the integral, this parameterization needs information about the ITD in each grid cell, while the default parameterization :eq:`eq_icestrength` can be used with both for ITD and single thickness category models. 
+In contrast to :eq:`eq_icestrength`, which is based on the plausible assumption that thick and compact ice is stronger than thin and loose drifting ice, this parameterization :eq:`eq_rothrock` clearly contains the more physical assumptions about energy conservation.
+For that reason alone this parameterization is often considered to be more physically realistic than REF, but in practice, the success is not so clear :cite:`ung17`. That is why the default is to use :eq:`eq_icestrength` (set ``useHibler79IceStrength=.FALSE.`` in ``data.seaice`` to change this behavior).
 
 .. _ssub_phys_pkg_seaice_subroutines:
 
@@ -1292,8 +1414,9 @@ Experiments and tutorials that use seaice
 - ``lab_sea``: Labrador Sea experiment
 - ``seaice_obcs``, based on ``lab_sea``
 - ``offline_exf_seaice.dyn_jfnk``, ``offline_exf_seaice.dyn_lsr``, and ``offline_exf_seaice.thermo``, idealized topography in a zonally re-entrant channel
-- ``seaice_itd``, based on ``offline_exf_seaice``, test ice thickness distribution
+- ``seaice_itd``, based on ``offline_exf_seaice``, tests ice thickness distribution
 - ``global_ocean.cs32x15/input.icedyn`` and ``global_ocean.cs32x15/input.seaice``, global cubed-sphere-experiment with combinations of ``seaice`` and ``thsice``
 - ``1D_ocean_ice_column``, just thermodynamics
+
 
 

--- a/doc/phys_pkgs/seaice.rst
+++ b/doc/phys_pkgs/seaice.rst
@@ -1228,7 +1228,7 @@ where the density function :math:`\gamma(h_1,h)` of resulting thickness :math:`h
    
    \gamma(h_1, h) = \frac{1}{k \lambda} \exp\left[{\frac{-(h-h_{\min})}{\lambda}}\right] 
 
-for :math:`h \geq h_{\min}`, with :math:`\gamma(h_1,h)=0` for :math:`h < h_{\min}$`.
+for :math:`h \geq h_{\min}`, with :math:`\gamma(h_1,h)=0` for :math:`h < h_{\min}`.
 In this parameterization, the normalization factor :math:`k=\frac{h_{\min} + \lambda}{h_1}`, the e-folding scale :math:`\lambda = \mu h_1^{1/2}` and the minimum ridge thickness :math:`h_{\min}=\min(2h_1,h_1 + h_{\textrm{raft}})` all depend on the original thickness :math:`h_1`.
 The maximal ice thickness allowed to raft :math:`h_{\textrm{raft}}` is constant (``SEAICEmaxRaft``, default 1~m) and :math:`\mu` (``SEAICEmuRidging``) is a tunable parameter. 
 

--- a/doc/tag-index
+++ b/doc/tag-index
@@ -1,6 +1,11 @@
     Notes on tags used in MITgcmUV
     ==============================
 
+o pkg/seaice:
+  - add Hlimit to seaice namelist in data.seaice
+  - use verification seaice_itd.thermo to test this feature with default
+    values (experiment does not change)
+  - clean up related output in seaice_init_fixed.F a little
 o verification/testreport:
   - for file run_ADM_DIVA, fix sed search syntax so that it works with BSD-sed
 o model/src:

--- a/pkg/seaice/seaice_init_fixed.F
+++ b/pkg/seaice/seaice_init_fixed.F
@@ -29,7 +29,6 @@ C     === Local variables ===
 #ifdef SEAICE_ITD
 C     msgBuf      :: Informational/error message buffer
       CHARACTER*(MAX_LEN_MBUF) msgBuf
-      CHARACTER*15 HlimitMsgFormat
 C     k - loop counter for ITD categories
       INTEGER k
       _RL tmpVar
@@ -160,20 +159,17 @@ C     check if Hlimit contains useful values
        IF ( Hlimit(k).LE.Hlimit(k-1) ) computeHlimit=.TRUE.
       ENDDO
       IF ( computeHlimit ) THEN
-       WRITE(msgBuf,'(A,I2,A)') ' SEAICE_INIT_FIXED: Computing ',
+       WRITE(msgBuf,'(A,I2,A)') 'SEAICE_INIT_FIXED: Computing ',
      &      nITD, ' thickness category limits with'
        CALL PRINT_MESSAGE( msgBuf, standardMessageUnit,
      &                     SQUEEZE_RIGHT, myThid )
-       WRITE(msgBuf,'(A,F6.2)')
-     &      ' SEAICE_INIT_FIXED: Hlimit_c1 = ', Hlimit_c1
-       CALL PRINT_MESSAGE( msgBuf, standardMessageUnit,
-     &                     SQUEEZE_RIGHT, myThid )
-       WRITE(msgBuf,'(A,F6.2)')
-     &      ' SEAICE_INIT_FIXED: Hlimit_c2 = ', Hlimit_c2
-       CALL PRINT_MESSAGE( msgBuf, standardMessageUnit,
-     &                     SQUEEZE_RIGHT, myThid )
-       WRITE(msgBuf,'(A,F6.2)')
-     &      ' SEAICE_INIT_FIXED: Hlimit_c3 = ', Hlimit_c3
+       CALL WRITE_0D_RL( Hlimit_c1  ,INDEX_NONE,
+     &      'Hlimit_c1  =', ' /* ITD bin parameter */')
+       CALL WRITE_0D_RL( Hlimit_c2  ,INDEX_NONE,
+     &      'Hlimit_c2  =', ' /* ITD bin parameter */')
+       CALL WRITE_0D_RL( Hlimit_c3  ,INDEX_NONE,
+     &      'Hlimit_c3  =', ' /* ITD bin parameter */')
+       WRITE(msgBuf,'(A)') ' '
        CALL PRINT_MESSAGE( msgBuf, standardMessageUnit,
      &                     SQUEEZE_RIGHT, myThid )
 C     use Equ. 22 of Lipscomb et al. (2001, JGR) to generate ice
@@ -200,16 +196,6 @@ C       -> HINT: set parameters c1, c2 and c3 in seaice_readparms.F
 C     thickest category is unlimited
       Hlimit(nITD) = 999.9 _d 0
 
-      WRITE(msgBuf,'(A,I2,A)')
-     &     ' SEAICE_INIT_FIXED: There are ', nITD,
-     &     ' sea ice thickness categories'
-      CALL PRINT_MESSAGE( msgBuf, standardMessageUnit,
-     &                    SQUEEZE_RIGHT, myThid )
-      WRITE(HlimitMsgFormat,'(A,I2,A)') '(A,',nITD,'F6.2,F6.1)'
-      WRITE(msgBuf,HlimitMsgFormat)
-     &     ' SEAICE_INIT_FIXED: Hlimit = ', (Hlimit(k),k=0,nITD)
-      CALL PRINT_MESSAGE( msgBuf, standardMessageUnit,
-     &                    SQUEEZE_RIGHT, myThid )
 #endif /* SEAICE_ITD */
 
 C     Only Master Thread updates parameter in common block:

--- a/pkg/seaice/seaice_init_fixed.F
+++ b/pkg/seaice/seaice_init_fixed.F
@@ -33,6 +33,7 @@ C     msgBuf      :: Informational/error message buffer
 C     k - loop counter for ITD categories
       INTEGER k
       _RL tmpVar
+      LOGICAL computeHlimit
 #endif
 C     i,j, bi,bj  :: Loop counters
       INTEGER i, j, bi, bj
@@ -148,6 +149,33 @@ c     (Smedrud and Martin, 2014, Ann. Glac.)
 #endif /* ALLOW_SITRACER */
 
 #ifdef SEAICE_ITD
+C     zeroth category needs to be zero
+      Hlimit(0)    = 0. _d 0
+C     thickest category is unlimited
+      Hlimit(nITD) = 999.9 _d 0
+      computeHlimit=.FALSE.
+C     check if Hlimit contains useful values
+      DO k = 1, nITD
+       IF ( Hlimit(k).EQ.UNSET_RL )    computeHlimit=.TRUE.
+       IF ( Hlimit(k).LE.Hlimit(k-1) ) computeHlimit=.TRUE.
+      ENDDO
+      IF ( computeHlimit ) THEN
+       WRITE(msgBuf,'(A,I2,A)') ' SEAICE_INIT_FIXED: Computing ',
+     &      nITD, ' thickness category limits with'
+       CALL PRINT_MESSAGE( msgBuf, standardMessageUnit,
+     &                     SQUEEZE_RIGHT, myThid )
+       WRITE(msgBuf,'(A,F6.2)')
+     &      ' SEAICE_INIT_FIXED: Hlimit_c1 = ', Hlimit_c1
+       CALL PRINT_MESSAGE( msgBuf, standardMessageUnit,
+     &                     SQUEEZE_RIGHT, myThid )
+       WRITE(msgBuf,'(A,F6.2)')
+     &      ' SEAICE_INIT_FIXED: Hlimit_c2 = ', Hlimit_c2
+       CALL PRINT_MESSAGE( msgBuf, standardMessageUnit,
+     &                     SQUEEZE_RIGHT, myThid )
+       WRITE(msgBuf,'(A,F6.2)')
+     &      ' SEAICE_INIT_FIXED: Hlimit_c3 = ', Hlimit_c3
+       CALL PRINT_MESSAGE( msgBuf, standardMessageUnit,
+     &                     SQUEEZE_RIGHT, myThid )
 C     use Equ. 22 of Lipscomb et al. (2001, JGR) to generate ice
 C     thickness category limits:
 C     - dependends on given number of categories nITD
@@ -156,24 +184,24 @@ C       c1=3.0/N, c2=15*c1, c3=3.0
 C       or emphasize thin end of ITD (in order to enhance ice growth):
 C       c1=1.5/N, c2=42*c1, c3=3.3
 C       -> HINT: set parameters c1, c2 and c3 in seaice_readparms.F
-      Hlimit(0) = 0. _d 0
-      IF ( nITD.GT.1 ) THEN
-       tmpVar = nITD
-       tmpVar = oneRL / tmpVar
-       Hlimit_c1 = Hlimit_c1*tmpVar
-       Hlimit_c2 = Hlimit_c2*Hlimit_c1
-       DO k=1,nITD-1
-        Hlimit(k) = Hlimit(k-1)
-     &            + Hlimit_c1
-     &            + Hlimit_c2
-     &  *( oneRL + TANH( Hlimit_c3 *( FLOAT(k-1)*tmpVar - oneRL ) ) )
-       ENDDO
+       IF ( nITD.GT.1 ) THEN
+        tmpVar = nITD
+        tmpVar = oneRL / tmpVar
+        Hlimit_c1 = Hlimit_c1*tmpVar
+        Hlimit_c2 = Hlimit_c2*Hlimit_c1
+        DO k=1,nITD-1
+         Hlimit(k) = Hlimit(k-1)
+     &             + Hlimit_c1
+     &             + Hlimit_c2
+     &    *( oneRL + TANH( Hlimit_c3 *( FLOAT(k-1)*tmpVar - oneRL ) ) )
+        ENDDO
+       ENDIF
       ENDIF
 C     thickest category is unlimited
       Hlimit(nITD) = 999.9 _d 0
 
       WRITE(msgBuf,'(A,I2,A)')
-     &     ' SEAICE_INIT_FIXED: ', nITD,
+     &     ' SEAICE_INIT_FIXED: There are ', nITD,
      &     ' sea ice thickness categories'
       CALL PRINT_MESSAGE( msgBuf, standardMessageUnit,
      &                    SQUEEZE_RIGHT, myThid )

--- a/pkg/seaice/seaice_readparms.F
+++ b/pkg/seaice/seaice_readparms.F
@@ -171,7 +171,7 @@ C--   SEAICE parameters
      & SEAICE_monFreq, SEAICE_dumpFreq, SEAICE_taveFreq,
      & SEAICE_tave_mnc, SEAICE_dump_mnc, SEAICE_mon_mnc,
 #ifdef SEAICE_ITD
-     & Hlimit_c1, Hlimit_c2, Hlimit_c3,
+     & Hlimit_c1, Hlimit_c2, Hlimit_c3, Hlimit,
 #endif
      & SEAICE_debugPointI, SEAICE_debugPointJ
 
@@ -353,6 +353,9 @@ C      - original parameters of Lipscomb et al. (2001):
 C        c1=3.0/N, c2=15*c1, c3=3.0
 C      - and a higher resolution of thin end of ITD:
 C        c1=1.5/N, c2=42*c1, c3=3.3
+      DO l = 0, nITD
+       Hlimit(l) = UNSET_RL
+      ENDDO
       Hlimit_c1          = 3.0
       Hlimit_c2          = 15.
       Hlimit_c3          = 3.0

--- a/pkg/seaice/seaice_summary.F
+++ b/pkg/seaice/seaice_summary.F
@@ -379,7 +379,58 @@ C     end if SEAICEuseDYNAMICS bloc
 C     end if useThSIce bloc
       ENDIF
 
-C--  Thermodynamics parameters
+#ifdef SEAICE_ITD
+C--   ITD parameters
+      WRITE(msgBuf,'(A)') ' '
+      CALL PRINT_MESSAGE( msgBuf, standardMessageUnit,
+     &                    SQUEEZE_RIGHT, myThid )
+      WRITE(msgBuf,'(A)')
+     &'   Seaice ice thickness distribution configuration   > START <  '
+      CALL PRINT_MESSAGE( msgBuf, standardMessageUnit,
+     &                    SQUEEZE_RIGHT, myThid )
+      WRITE(msgBuf,'(A)')
+     &'   -----------------------------------------------------------'
+      CALL PRINT_MESSAGE( msgBuf, standardMessageUnit,
+     &                    SQUEEZE_RIGHT, myThid )
+      CALL WRITE_0D_I (SEAICE_multDim,INDEX_NONE,'nITD              ='
+     & , ' /* number of ice thickness categories */')
+      CALL WRITE_1D_RL( Hlimit, nITD, INDEX_K, 'Hlimit =',
+     & '   /* seaice thickness category bin limits ( meters ) */')
+      CALL WRITE_0D_L ( SEAICEuseLinRemapITD, INDEX_NONE,
+     & 'SEAICEuseLinRemapITD  =',
+     & ' /* select linear remapping scheme for ITD */')
+      CALL WRITE_0D_L ( useHibler79IceStrength, INDEX_NONE,
+     & 'useHibler79IceStrength  =',
+     & ' /* select ice strength parameterizationd */')
+      CALL WRITE_0D_L ( SEAICEsimpleRidging, INDEX_NONE,
+     & 'SEAICEsimpleRidging  =',
+     & ' /* select ridging scheme */')
+      CALL WRITE_0D_I (SEAICEpartFunc,INDEX_NONE,
+     &     'SEAICEpartFunc   ='
+     & , ' /* select ridging participation function */')
+      CALL WRITE_0D_I (SEAICEredistFunc,INDEX_NONE,
+     &     'SEAICEredistFunc ='
+     & , ' /* select ridging redistribution function */')
+      CALL WRITE_0D_RL( SEAICE_cf  ,INDEX_NONE,
+     & 'SEAICE_cf  =', ' /* ice strength parameter */')
+      CALL WRITE_0D_RL( SEAICEshearParm  ,INDEX_NONE,
+     & 'SEAICEshearParm  =', ' /* amount of energy lost to shear */')
+      CALL WRITE_0D_RL( SEAICEgStar  ,INDEX_NONE,
+     & 'SEAICEgStar  =', ' /* ridging parameter */')
+      CALL WRITE_0D_RL( SEAICEhStar  ,INDEX_NONE,
+     & 'SEAICEhStar  =', ' /* ridging parameter */')
+      CALL WRITE_0D_RL( SEAICEaStar  ,INDEX_NONE,
+     & 'SEAICEaStar  =', ' /* ridging parameter */')
+      CALL WRITE_0D_RL( SEAICEmuRidging  ,INDEX_NONE,
+     & 'SEAICEmuRidging  =', ' /* ridging parameter */')
+      CALL WRITE_0D_RL( SEAICEmaxRaft  ,INDEX_NONE,
+     & 'SEAICEmaxRaft  =', ' /* ridging parameter */')
+      CALL WRITE_0D_RL( SEAICEsnowFracRidge ,INDEX_NONE,
+     & 'SEAICEsnowFracRidge  =',
+     &     ' /* fraction of snow remaining on ridges */')
+#endif
+
+C--   Thermodynamics parameters
       WRITE(msgBuf,'(A)') ' '
       CALL PRINT_MESSAGE( msgBuf, standardMessageUnit,
      &                    SQUEEZE_RIGHT, myThid )
@@ -508,42 +559,7 @@ c
       CALL WRITE_0D_L ( SEAICEheatConsFix,  INDEX_NONE,
      & 'SEAICEheatConsFix  =',
      & ' /* accound for ocn<->seaice advect. heat flux */')
-#ifdef SEAICE_ITD
-      CALL WRITE_0D_I (SEAICE_multDim,INDEX_NONE,'nITD              ='
-     & , ' /* number of ice thickness categories */')
-      CALL WRITE_0D_L ( SEAICEuseLinRemapITD, INDEX_NONE,
-     & 'SEAICEuseLinRemapITD  =',
-     & ' /* select linear remapping scheme for ITD */')
-      CALL WRITE_0D_L ( useHibler79IceStrength, INDEX_NONE,
-     & 'useHibler79IceStrength  =',
-     & ' /* select ice strength parameterizationd */')
-      CALL WRITE_0D_L ( SEAICEsimpleRidging, INDEX_NONE,
-     & 'SEAICEsimpleRidging  =',
-     & ' /* select ridging scheme */')
-      CALL WRITE_0D_I (SEAICEpartFunc,INDEX_NONE,
-     &     'SEAICEpartFunc   ='
-     & , ' /* select ridging participation function */')
-      CALL WRITE_0D_I (SEAICEredistFunc,INDEX_NONE,
-     &     'SEAICEredistFunc ='
-     & , ' /* select ridging redistribution function */')
-      CALL WRITE_0D_RL( SEAICE_cf  ,INDEX_NONE,
-     & 'SEAICE_cf  =', ' /* ice strength parameter */')
-      CALL WRITE_0D_RL( SEAICEshearParm  ,INDEX_NONE,
-     & 'SEAICEshearParm  =', ' /* amount of energy lost to shear */')
-      CALL WRITE_0D_RL( SEAICEgStar  ,INDEX_NONE,
-     & 'SEAICEgStar  =', ' /* ridging parameter */')
-      CALL WRITE_0D_RL( SEAICEhStar  ,INDEX_NONE,
-     & 'SEAICEhStar  =', ' /* ridging parameter */')
-      CALL WRITE_0D_RL( SEAICEaStar  ,INDEX_NONE,
-     & 'SEAICEaStar  =', ' /* ridging parameter */')
-      CALL WRITE_0D_RL( SEAICEmuRidging  ,INDEX_NONE,
-     & 'SEAICEmuRidging  =', ' /* ridging parameter */')
-      CALL WRITE_0D_RL( SEAICEmaxRaft  ,INDEX_NONE,
-     & 'SEAICEmaxRaft  =', ' /* ridging parameter */')
-      CALL WRITE_0D_RL( SEAICEsnowFracRidge ,INDEX_NONE,
-     & 'SEAICEsnowFracRidge  =',
-     &     ' /* fraction of snow remaining on ridges */')
-#else
+#ifndef SEAICE_ITD
       CALL WRITE_0D_I (SEAICE_multDim,INDEX_NONE,'SEAICE_multDim    ='
      & , ' /* number of ice categories (1 or 7) */')
 #endif

--- a/pkg/seaice/seaice_summary.F
+++ b/pkg/seaice/seaice_summary.F
@@ -395,7 +395,7 @@ C--   ITD parameters
       CALL WRITE_0D_I (SEAICE_multDim,INDEX_NONE,'nITD              ='
      & , ' /* number of ice thickness categories */')
       CALL WRITE_1D_RL( Hlimit(1), nITD, INDEX_K, 'Hlimit =',
-     & ' /* seaice thickness category bin limits ( meters ) */')
+     & ' /* seaice thickness category bin limits ( m ), Hlimit(0)=0 */')
       CALL WRITE_0D_L ( SEAICEuseLinRemapITD, INDEX_NONE,
      & 'SEAICEuseLinRemapITD  =',
      & ' /* select linear remapping scheme for ITD */')

--- a/pkg/seaice/seaice_summary.F
+++ b/pkg/seaice/seaice_summary.F
@@ -394,8 +394,8 @@ C--   ITD parameters
      &                    SQUEEZE_RIGHT, myThid )
       CALL WRITE_0D_I (SEAICE_multDim,INDEX_NONE,'nITD              ='
      & , ' /* number of ice thickness categories */')
-      CALL WRITE_1D_RL( Hlimit, nITD, INDEX_K, 'Hlimit =',
-     & '   /* seaice thickness category bin limits ( meters ) */')
+      CALL WRITE_1D_RL( Hlimit(1), nITD, INDEX_K, 'Hlimit =',
+     & ' /* seaice thickness category bin limits ( meters ) */')
       CALL WRITE_0D_L ( SEAICEuseLinRemapITD, INDEX_NONE,
      & 'SEAICEuseLinRemapITD  =',
      & ' /* select linear remapping scheme for ITD */')

--- a/verification/seaice_itd/input.thermo/data.seaice
+++ b/verification/seaice_itd/input.thermo/data.seaice
@@ -19,6 +19,10 @@
  SEAICE_cf        = 2.,
  SEAICEredistFunc = 0,
  SEAICEpartFunc   = 0,
+# test parameter Hlimit with the default values
+ Hlimit =       0., 0.46036229772816128, 0.96359590632446723,
+ 1.5667276956011804, 2.3991981802927964, 3.7406269979459270,
+ 6.1313098316368961, 999.9,
 # old defaults
  SEAICEscaleSurfStress = .FALSE.,
  SEAICEetaZmethod = 0,


### PR DESCRIPTION
## What changes does this PR introduce?
As a new feature, `Hlimit` is added to the seaice-namelist. Related output in `seaice_init_fixed.F` is cleaned up a little.

## What is the current behaviour? 
`Hlimit` can only be modified by setting 3 parameter in a fixed formula

## What is the new behaviour 
`Hlimit` can be set explicitly in `data.seaice`

## Does this PR introduce a breaking change? 
No

## Other information:


## Suggested addition to `tag-index`
- add Hlimit to seaice namelist in data.seaice
- use verification seaice_itd.thermo to test this feature with default values (experiment does not change)
- clean up related output in seaice_init_fixed.F a little