### PR TITLE
fix error in parameter reporting and add missing parameter

### DIFF
--- a/doc/tag-index
+++ b/doc/tag-index
@@ -1,6 +1,9 @@
     Notes on tags used in MITgcmUV
     ==============================
 
+o model/src:
+  - fix small bug (wrong balanceEmPmR report) in config_summary.F, spotted by
+    Christopher Wolfe ; add report of balancePrintMean to summary.
 o verification/verification_parser.py
   - ensure Travis test suite fails when a build or a run fails.
 

--- a/model/src/config_summary.F
+++ b/model/src/config_summary.F
@@ -565,7 +565,7 @@ c     CALL PRINT_MESSAGE( msgBuf, ioUnit, SQUEEZE_RIGHT, myThid )
       CALL WRITE_0D_L( saltForcing,  INDEX_NONE,
      & 'saltForcing  =', '  /* Salinity forcing on/off flag */')
 #ifdef ALLOW_BALANCE_FLUXES
-      CALL WRITE_0D_L( balanceQnet, INDEX_NONE, 'balanceEmPmR =',
+      CALL WRITE_0D_L( balanceEmPmR, INDEX_NONE, 'balanceEmPmR =',
      &             '  /* balance net fresh-water flux on/off flag */')
 #endif
       CALL WRITE_0D_L( doSaltClimRelax, INDEX_NONE,
@@ -581,6 +581,11 @@ c     CALL PRINT_MESSAGE( msgBuf, ioUnit, SQUEEZE_RIGHT, myThid )
      &  ' /* Precision used for reading binary files */')
       CALL WRITE_0D_I(writeBinaryPrec, INDEX_NONE, 'writeBinaryPrec =',
      &  ' /* Precision used for writing binary files */')
+#ifdef ALLOW_BALANCE_FLUXES
+      CALL WRITE_0D_L( balancePrintMean, INDEX_NONE,
+     &                 'balancePrintMean  =',
+     &  '  /* print means for balancing fluxes */')
+#endif
 C---
 c     CALL WRITE_0D_I(rwSuffixType, INDEX_NONE, 'rwSuffixType =',
 c    &  ' /* Select format of mds file suffix */')


### PR DESCRIPTION
## What changes does this PR introduce?
bug fix for issue #226

## What is the current behaviour? 
- #226 
- value of `balancePrintMean` is not report to STDOUT

## What is the new behaviour 
- value of `balanceEmRmR` is reported instead of `balanceQnet` in STDOUT
- value of `balancePrintMean` is reported to STDOUT

## Does this PR introduce a breaking change? 
No

## Other information:


## Suggested addition to `tag-index`
- fix small bug in config_summary.F reported by Christopher Wolfe
- print balancePrintMean to STDOUT