### PR TITLE
adjust sed syntax so that it works with BSD Unix

### DIFF
--- a/doc/tag-index
+++ b/doc/tag-index
@@ -1,6 +1,8 @@
     Notes on tags used in MITgcmUV
     ==============================
 
+o verification/testreport:
+  - for file run_ADM_DIVA, fix sed search syntax so that it works with BSD-sed
 o model/src:
   - fix small bug (wrong balanceEmPmR report) in config_summary.F, spotted by
     Christopher Wolfe ; add report of balancePrintMean to summary.

--- a/verification/testreport
+++ b/verification/testreport
@@ -828,7 +828,7 @@ runmodel()
 	#- Divided Adjoint Run:
 	#  get the number of additional runs (add_DIVA_runs) from file "run_ADM_DIVA"
 	    if test $KIND = 2 -a -f run_ADM_DIVA ; then
-	      adm_diva_nb=`sed -n '/^ *add_DIVA_runs\>.*=/p' run_ADM_DIVA | sed 's/ //g'`
+	      adm_diva_nb=`sed -n '/^ *add_DIVA_runs *=/s/ //gp' run_ADM_DIVA`
 	      echo " Divided Adjoint Run: $adm_diva_nb" >> $RUNLOG
 	      eval "let $adm_diva_nb"
 	      if [ $add_DIVA_runs -ge 1 ] ; then

--- a/verification/testreport
+++ b/verification/testreport
@@ -828,7 +828,7 @@ runmodel()
 	#- Divided Adjoint Run:
 	#  get the number of additional runs (add_DIVA_runs) from file "run_ADM_DIVA"
 	    if test $KIND = 2 -a -f run_ADM_DIVA ; then
-	      adm_diva_nb=`sed -n '/^ *add_DIVA_runs *=/p' run_ADM_DIVA | sed s/ //g`
+	      adm_diva_nb=`sed -n '/^ *add_DIVA_runs *=/p' run_ADM_DIVA | sed 's/ //g'`
 	      echo " Divided Adjoint Run: $adm_diva_nb" >> $RUNLOG
 	      eval "let $adm_diva_nb"
 	      if [ $add_DIVA_runs -ge 1 ] ; then

--- a/verification/testreport
+++ b/verification/testreport
@@ -828,7 +828,7 @@ runmodel()
 	#- Divided Adjoint Run:
 	#  get the number of additional runs (add_DIVA_runs) from file "run_ADM_DIVA"
 	    if test $KIND = 2 -a -f run_ADM_DIVA ; then
-	      adm_diva_nb=`sed -n '/^ *add_DIVA_runs *=/s/ //gp' run_ADM_DIVA`
+	      adm_diva_nb=`sed -n '/^ *add_DIVA_runs *=/p' run_ADM_DIVA | sed s/ //g`
 	      echo " Divided Adjoint Run: $adm_diva_nb" >> $RUNLOG
 	      eval "let $adm_diva_nb"
 	      if [ $add_DIVA_runs -ge 1 ] ; then


### PR DESCRIPTION
## What changes does this PR introduce?
bug fix

## What is the current behaviour? 
`./testreport -adm -t lab_sea` does not work with BSD-sed (e.g. on MacOS X), line 831 is the culprit.

## What is the new behaviour 
`./testreport -adm -t lab_sea` also works with BSD-sed


## Does this PR introduce a breaking change? 
No

## Other information:
- replace GNU extension syntax "\>.*=" with " *=" in line 831
- make line 831 shorter by combining two sed commands into one
- this change only affects tests with divided adjoint (i.e. currently
  only lab_sea)

## Suggested addition to `tag-index`
fix sed search syntax in testreport, so that is works with BSD-sed