### PR TITLE
Quick fix to PR #242

### DIFF
--- a/pkg/autodiff/AUTODIFF_PARAMS.h
+++ b/pkg/autodiff/AUTODIFF_PARAMS.h
@@ -52,9 +52,9 @@ C      - for both   :: =0 : no exch ; =1 : apply adexch ;
 C      *AdVarExch - :: =2 : do adexch on a local copy.
 C     SEAICEapproxLevInAd :: level of approximation in seaice adjoint
 C       -1 (and .NOT.useSEAICEinAdMode) : use seaice_fake adjoint
-C       0 (and .NOT.useSEAICEinAdMode)  : omit all of seaice thermo adjoint 
+C       0 (and .NOT.useSEAICEinAdMode)  : omit all of seaice thermo adjoint
 C       0 (and useSEAICEinAdMode)       : use all of seaice thermo adjoint
-C       >= 1 (and useSEAICEinAdMode)    : omit pieces of seaice thermo adjoint 
+C       >= 1 (and useSEAICEinAdMode)    : omit pieces of seaice thermo adjoint
       INTEGER dumpAdVarExch
       INTEGER mon_AdVarExch
       INTEGER SEAICEapproxLevInAd
@@ -63,13 +63,13 @@ C       >= 1 (and useSEAICEinAdMode)    : omit pieces of seaice thermo adjoint
 
 C--   COMMON /AUTODIFF_PARM_R/ "Real" valued parameters used by the pkg.
 C     viscFacInAd :: viscosity factor for adjoint
-C     SIregFacInAd :: Factor for over shoots in AD 
+C     SIregFacInAd :: Factor for over shoots in AD
 C     SIregFacInFw :: Factor for over shoots in FW
       _RL viscFacInAd
       _RL SIregFacInAd, SIregFacInFw
       COMMON /AUTODIFF_PARM_R/
      &  viscFacInAd, SIregFacInAd, SIregFacInFw
-      
+
 C--   COMMON /AUTODIFF_PARM_C/ Character valued parameters used by the pkg.
 
 CEH3 ;;; Local Variables: ***

--- a/pkg/autodiff/autodiff_readparms.F
+++ b/pkg/autodiff/autodiff_readparms.F
@@ -70,7 +70,7 @@ C--   default : write one file per record
       SEAICEapproxLevInAd = 0
       viscFacInAd        = 1. _d 0
       SIregFacInAd       = UNSET_RL
-      SIregFacInFw       = UNSET_RL 
+      SIregFacInFw       = UNSET_RL
 
 C-- pkg/seaice related switches
       SEAICEuseFREEDRIFTswitchInAd = .FALSE.

--- a/pkg/seaice/seaice_growth_adx.F
+++ b/pkg/seaice/seaice_growth_adx.F
@@ -80,21 +80,12 @@ C     number of surface interface layer
 C     IT :: ice thickness category index (MULTICATEGORIES and ITD code)
       INTEGER IT
 C     msgBuf      :: Informational/error message buffer
-      CHARACTER*(MAX_LEN_MBUF) msgBuf
-      CHARACTER*12 msgBufForm
+c     CHARACTER*(MAX_LEN_MBUF) msgBuf
 C     constants
       _RL tempFrz, ICE2SNOW, SNOW2ICE, surf_theta
-      _RL QI, QS, recip_QI
+      _RL QI, QS
       _RL RHOSW
       _RL lhSublim
-
-C conversion factors to go from Q (W/m2) to HEFF (ice meters)
-      _RL convertQ2HI, convertHI2Q
-C conversion factors to go from precip (m/s) unit to HEFF (ice meters)
-      _RL convertPRECIP2HI, convertHI2PRECIP
-
-C     wind speed square
-      _RL SPEED_SQ
 
 C     Regularization values squared
       _RL area_reg_sq, hice_reg_sq
@@ -107,25 +98,12 @@ C     Helper variables: reciprocal of some constants
       _RL recip_deltaTtherm
       _RL recip_rhoIce
 
-C     local value (=1/HO or 1/HO_south)
-      _RL recip_HO
-
-C     local value (=1/ice thickness)
-      _RL recip_HH
-
 C     facilitate multi-category snow implementation
       _RL pFac, pFacSnow
 
 C     temporary variables available for the various computations
-      _RL tmpscal0, tmpscal1, tmpscal2, tmpscal3, tmpscal4
+      _RL tmpscal0, tmpscal1, tmpscal2, tmpscal3
 
-#ifdef ALLOW_SITRACER
-      INTEGER iTr
-#ifdef ALLOW_DIAGNOSTICS
-      CHARACTER*8   diagName
-#endif
-
-#endif /* ALLOW_SITRACER */
 #ifdef ALLOW_AUTODIFF_TAMC
       INTEGER ilockey
 #endif
@@ -150,8 +128,6 @@ C     wind speed
       _RL UG                  (1:sNx,1:sNy)
 
 C     temporary variables available for the various computations
-      _RL tmparr1             (1:sNx,1:sNy)
-
       _RL ticeInMult          (1:sNx,1:sNy,nITD)
       _RL ticeOutMult         (1:sNx,1:sNy,nITD)
       _RL hiceActualMult      (1:sNx,1:sNy,nITD)
@@ -165,7 +141,7 @@ C     temporary variables available for the various computations
 
 #ifdef ALLOW_DIAGNOSTICS
 C     Helper variables for diagnostics
-      _RL DIAGarrayA    (1:sNx,1:sNy)
+c     _RL DIAGarrayA    (1:sNx,1:sNy)
       _RL DIAGarrayB    (1:sNx,1:sNy)
       _RL DIAGarrayC    (1:sNx,1:sNy)
       _RL DIAGarrayD    (1:sNx,1:sNy)

--- a/pkg/seaice/seaice_growth_adx.F
+++ b/pkg/seaice/seaice_growth_adx.F
@@ -113,10 +113,8 @@ C     local value (=1/HO or 1/HO_south)
 C     local value (=1/ice thickness)
       _RL recip_HH
 
-#ifndef SEAICE_ITD
 C     facilitate multi-category snow implementation
       _RL pFac, pFacSnow
-#endif
 
 C     temporary variables available for the various computations
       _RL tmpscal0, tmpscal1, tmpscal2, tmpscal3, tmpscal4
@@ -136,12 +134,10 @@ C==   local arrays ==
 C--   TmixLoc        :: ocean surface/mixed-layer temperature (in K)
       _RL TmixLoc       (1:sNx,1:sNy)
 
-#ifndef SEAICE_ITD
 C     actual ice thickness (with upper and lower limit)
       _RL hiceActual          (1:sNx,1:sNy)
 C     actual snow thickness
       _RL hsnowActual         (1:sNx,1:sNy)
-#endif
 C     actual ice thickness (with lower limit only) Reciprocal
       _RL recip_hiceActual    (1:sNx,1:sNy)
 

--- a/pkg/seaice/seaice_solve4temp_adx.F
+++ b/pkg/seaice/seaice_solve4temp_adx.F
@@ -52,13 +52,16 @@ C     !INPUT PARAMETERS:
 C     UG           :: atmospheric wind speed (m/s)
 C     HICE_ACTUAL  :: actual ice thickness
 C     HSNOW_ACTUAL :: actual snow thickness
-C     TSURF      :: surface temperature of ice/snow in Kelvin
+C     TSURFin    :: surface temperature of ice/snow in Kelvin
 C     bi,bj      :: tile indices
 C     myTime     :: current time in simulation
 C     myIter     :: iteration number in simulation
 C     myThid     :: my Thread Id number
 C     !OUTPUT PARAMETERS:
-C     TSURF      :: updated surface temperature of ice/snow in Kelvin
+C     TSURFout   :: updated surface temperature of ice/snow in Kelvin
+C     F_io_net   :: upward conductive heat flux through seaice+snow
+C     F_ia_net   :: net heat flux divergence at the sea ice/snow surface:
+C                   includes ice conductive fluxes and atmospheric fluxes (W/m^2)
 C     F_ia       :: upward seaice/snow surface heat flux to atmosphere (W/m^2)
 C     IcePenetSW :: short wave heat flux transmitted through ice (+=upward)
 C     FWsublim   :: fresh water (mass) flux due to sublimation (+=up)(kg/m^2/s)
@@ -76,6 +79,8 @@ C----------
 #endif
       _RL TSURFin     (1:sNx,1:sNy)
       _RL TSURFout    (1:sNx,1:sNy)
+      _RL F_io_net    (1:sNx,1:sNy)
+      _RL F_ia_net    (1:sNx,1:sNy)
       _RL F_ia        (1:sNx,1:sNy)
       _RL IcePenetSW  (1:sNx,1:sNy)
       _RL FWsublim    (1:sNx,1:sNy)
@@ -126,12 +131,6 @@ C     dFia_dTs :: derivative of surf heat flux (F_ia) w.r.t surf. temp
       _RL F_lwu      (1:sNx,1:sNy)
       _RL F_sens     (1:sNx,1:sNy)
       _RL F_lh       (1:sNx,1:sNy)
-
-C     F_io_net :: upward conductive heat flux through seaice+snow
-C     F_ia_net :: net heat flux divergence at the sea ice/snow surface:
-C                 includes ice conductive fluxes and atmospheric fluxes (W/m^2)
-      _RL F_io_net   (1:sNx,1:sNy)
-      _RL F_ia_net   (1:sNx,1:sNy)
 
       _RL qhice      (1:sNx,1:sNy)
       _RL dqh_dTs    (1:sNx,1:sNy)


### PR DESCRIPTION
## What changes does this PR introduce?
Fix PR #242 so that it compiles with SEAICE_ITD defined
and without pkg/exf (like in exp. offline_cheapaml).

## What is the current behaviour? 
Currently experiments seaice_itd and offline_cheapaml
are broken (not compiling).

## What is the new behaviour 
FIx compilation Pb.

## Does this PR introduce a breaking change? 
no

## Other information:

## Suggested addition to `tag-index`
No need to add comments there if it's merged quickly.