### PR TITLE
initialize igen_uvel/vvel = 0 in case they aren't used

### DIFF
--- a/doc/tag-index
+++ b/doc/tag-index
@@ -1,6 +1,9 @@
     Notes on tags used in MITgcmUV
     ==============================
 
+o pkg/ctrl:
+  - Fix bug in ctrl_map_ini_genarr.F regarding missing initialization of
+    igen_uvel & igen_vvel (just like all the other variables).
 o pkg/dic:
   - Implement SolveSAPHE (Munhoven, 2013), a robust algorithm to calculate
     oceanic pH/pCO2 ; compiled when CARBONCHEM_SOLVESAPHE is defined (in

--- a/pkg/ctrl/ctrl_map_ini_genarr.F
+++ b/pkg/ctrl/ctrl_map_ini_genarr.F
@@ -68,11 +68,11 @@ C--   generic 2D control variables
       igen_geoth=0
       DO iarr = 1, maxCtrlArr2D
       if (xx_genarr2d_weight(iarr).NE.' ') then
-        if (xx_genarr2d_file(iarr)(1:7).EQ.'xx_etan') 
+        if (xx_genarr2d_file(iarr)(1:7).EQ.'xx_etan')
      &     igen_etan=iarr
-        if (xx_genarr2d_file(iarr)(1:13).EQ.'xx_bottomdrag') 
+        if (xx_genarr2d_file(iarr)(1:13).EQ.'xx_bottomdrag')
      &     igen_bdrag=iarr
-        if (xx_genarr2d_file(iarr)(1:13).EQ.'xx_geothermal') 
+        if (xx_genarr2d_file(iarr)(1:13).EQ.'xx_geothermal')
      &     igen_geoth=iarr
       endif
       ENDDO
@@ -106,20 +106,20 @@ C--   generic 3D control variables
 #endif
       DO iarr = 1, maxCtrlArr3D
       if (xx_genarr3d_weight(iarr).NE.' ') then
-        if (xx_genarr3d_file(iarr)(1:8).EQ.'xx_theta') 
+        if (xx_genarr3d_file(iarr)(1:8).EQ.'xx_theta')
      &     igen_theta0=iarr
-        if (xx_genarr3d_file(iarr)(1:7).EQ.'xx_salt') 
+        if (xx_genarr3d_file(iarr)(1:7).EQ.'xx_salt')
      &     igen_salt0=iarr
-        if (xx_genarr3d_file(iarr)(1:8).EQ.'xx_kapgm') 
+        if (xx_genarr3d_file(iarr)(1:8).EQ.'xx_kapgm')
      &     igen_kapgm=iarr
-        if (xx_genarr3d_file(iarr)(1:10).EQ.'xx_kapredi') 
+        if (xx_genarr3d_file(iarr)(1:10).EQ.'xx_kapredi')
      &     igen_kapredi=iarr
-        if (xx_genarr3d_file(iarr)(1:9).EQ.'xx_diffkr') 
+        if (xx_genarr3d_file(iarr)(1:9).EQ.'xx_diffkr')
      &     igen_diffkr=iarr
 #if (defined (ALLOW_UVEL0_CONTROL) && defined (ALLOW_VVEL0_CONTROL))
-        if (xx_genarr3d_file(iarr)(1:7).EQ.'xx_uvel') 
+        if (xx_genarr3d_file(iarr)(1:7).EQ.'xx_uvel')
      &     igen_uvel0=iarr
-        if (xx_genarr3d_file(iarr)(1:7).EQ.'xx_vvel') 
+        if (xx_genarr3d_file(iarr)(1:7).EQ.'xx_vvel')
      &     igen_vvel0=iarr
 #endif
       endif
@@ -303,7 +303,6 @@ c avoid param out of [boundsVec(1) boundsVec(4)]
       CALL MDS_WRITE_FIELD(fnamegenOut,ctrlprec,.FALSE.,.FALSE.,
      & 'RL',1,1,1,fld,dummyRS,1,optimcycle,mythid)
 
-
 #endif /* ALLOW_GENARR2D_CONTROL */
 
       RETURN
@@ -433,13 +432,13 @@ c--   Now, read the control vector.
 #endif
 
 #if (defined (ALLOW_UVEL0_CONTROL) && defined (ALLOW_VVEL0_CONTROL))
-c--   set local mask 
+c--   set local mask
       call ecco_zero(localmask,Nr,zeroRL,myThid)
       if (xx_genarr3d_file(iarr)(1:7).EQ.'xx_uvel') then
         call ecco_cprsrl(maskW,nr,localmask,nr,myThid)
       else if (xx_genarr3d_file(iarr)(1:7).EQ.'xx_vvel') then
         call ecco_cprsrl(maskS,nr,localmask,nr,myThid)
-      else 
+      else
         call ecco_cprsrl(maskC,nr,localmask,nr,myThid)
       endif
 #endif
@@ -479,11 +478,11 @@ c avoid param out of [boundsVec(1) boundsVec(4)]
       CALL CTRL_BOUND_3D(fld,maskC,xx_genarr3d_bounds(1,iarr),myThid)
 #endif
 
-C The tile exchange for xx_uvel and xx_vvel will be 
-C  done in CTRL_MAP_INI_GENARR.F when both 
-C  xx_uvel and xx_vvel are read in. 
+C The tile exchange for xx_uvel and xx_vvel will be
+C  done in CTRL_MAP_INI_GENARR.F when both
+C  xx_uvel and xx_vvel are read in.
       if (xx_genarr3d_file(iarr)(1:7).NE.'xx_uvel'.AND.
-     &    xx_genarr3d_file(iarr)(1:7).NE.'xx_vvel') 
+     &    xx_genarr3d_file(iarr)(1:7).NE.'xx_vvel')
      &    CALL EXCH_XYZ_RL( fld, mythid )
 
       CALL MDS_WRITE_FIELD(fnamegenOut,ctrlprec,.FALSE.,.FALSE.,
@@ -493,5 +492,3 @@ C  xx_uvel and xx_vvel are read in.
 
       RETURN
       END
-
-

--- a/pkg/ctrl/ctrl_map_ini_genarr.F
+++ b/pkg/ctrl/ctrl_map_ini_genarr.F
@@ -100,6 +100,10 @@ C--   generic 3D control variables
       igen_kapgm=0
       igen_kapredi=0
       igen_diffkr=0
+#if (defined (ALLOW_UVEL0_CONTROL) && defined (ALLOW_VVEL0_CONTROL))
+      igen_uvel0=0
+      igen_vvel0=0
+#endif
       DO iarr = 1, maxCtrlArr3D
       if (xx_genarr3d_weight(iarr).NE.' ') then
         if (xx_genarr3d_file(iarr)(1:8).EQ.'xx_theta') 


### PR DESCRIPTION
## What changes does this PR introduce?
(Bug fix, feature, docs update, ...)

Fixes a bug in pkg/ctrl/ctrl_map_ini_genarr.F by initializing igen_uvel=0 and igen_vvel=0 just like all the other variables.


## What is the current behaviour? 
(You can also link to an open issue here)

if the CPP options ALLOW_UVEL0_CONTROL and ALLOW_VVEL0_CONTROL are defined, but the user does not include xx_uvel or xx_vvel as control variables in data.ctrl, the code will fail at this routine because igen_uvel0 and igen_vvel0 do not get initialized to 0 (igen_* should be zero for every control variable that is not used). Specifically the code fails at this block of code: 

https://github.com/MITgcm/MITgcm/blob/6acab690ae3f7d99a211a588eb0bc130f94927e7/pkg/ctrl/ctrl_map_ini_genarr.F#L140-L146

where it tries to map the ctrl variables even though the files xx_uvel.##.meta/data etc don't exist because the user never chose them.

## What is the new behaviour 
(if this is a feature change)?


## Does this PR introduce a breaking change? 
(What changes might users need to make in their application due to this PR?)
no

## Other information:


## Suggested addition to `tag-index`
(To avoid unnecessary merge conflicts, please don't update `tag-index`. One of the admins will do that when merging your pull request.)
if anything, I would say something like "bug fix for uvel,vvel control variables"