### PR TITLE
don't subtract startrec from fldcount

### DIFF
--- a/doc/tag-index
+++ b/doc/tag-index
@@ -1,6 +1,9 @@
     Notes on tags used in MITgcmUV
     ==============================
 
+o pkg/ctrl:
+  - fix reccord number setting in S/R CTRL_GET_GEN_REC ("startrec" substracted
+    for no reason).
 o doc:
   - add a sub-section about optim_m1qn3
 o pkg/ctrl:

--- a/pkg/ctrl/ctrl_get_gen_rec.F
+++ b/pkg/ctrl/ctrl_get_gen_rec.F
@@ -162,10 +162,8 @@ c     Set switches for reading new records.
         endif
        endif
 
-c      count0 = fldcount
-c      count1 = fldcount + 1
-       count0 = fldcount - startrec + 1
-       count1 = fldcount - startrec + 2
+       count0 = fldcount
+       count1 = fldcount + 1
 
        call cal_TimeInterval( fldsecs, 'secs', difftime, mythid )
        call cal_AddTime( fldstartdate, difftime, flddate, mythid )

--- a/pkg/ctrl/ctrl_get_gen_rec.F
+++ b/pkg/ctrl/ctrl_get_gen_rec.F
@@ -29,13 +29,13 @@ c     ==================================================================
 
 c     == global variables ==
 
-#include "EEPARAMS.h"
 #include "SIZE.h"
+#include "EEPARAMS.h"
+#include "PARAMS.h"
 #include "ctrl.h"
 #ifdef ALLOW_CAL
 # include "cal.h"
 #endif
-#include "PARAMS.h"
 
 c     == routine arguments ==
 
@@ -67,7 +67,7 @@ c     == local variables ==
       integer fldstartdate(4)
       _RL     fldperiod
 
-      integer startrec
+c     integer startrec
 
       logical lArgErr
 #else
@@ -127,11 +127,11 @@ c--   Determine the current date.
        call cal_GetDate( myiter, mytime, mydate, mythid )
 
 c     Determine first record:
-       call cal_TimePassed( fldstartdate, modelstartdate,
-     &                      difftime, mythid )
-       call cal_ToSeconds ( difftime, fldsecs, mythid )
-       startrec = int((modelstart + startTime - fldsecs)/
-     &                fldperiod) + 1
+c      call cal_TimePassed( fldstartdate, modelstartdate,
+c    &                      difftime, mythid )
+c      call cal_ToSeconds ( difftime, fldsecs, mythid )
+c      startrec = int((modelstart + startTime - fldsecs)/
+c    &                fldperiod) + 1
 
 c     Determine the flux record just before mycurrentdate.
        call cal_TimePassed( fldstartdate, mydate, difftime,

--- a/pkg/ctrl/ctrl_get_gen_rec.F
+++ b/pkg/ctrl/ctrl_get_gen_rec.F
@@ -13,21 +13,21 @@
      I                        mythid
      &                      )
 
-c     ==================================================================
-c     SUBROUTINE ctrl_get_gen_rec
-c     ==================================================================
-c
-c     o Get flags, counters, and the linear interpolation factor for a
-c       given control vector contribution.
-c     o New, generic, for new routine ctrl_get_gen
-c
-c     ==================================================================
-c     SUBROUTINE ctrl_get_gen_rec
-c     ==================================================================
+C     ==================================================================
+C     SUBROUTINE ctrl_get_gen_rec
+C     ==================================================================
+C
+C     o Get flags, counters, and the linear interpolation factor for a
+C       given control vector contribution.
+C     o New, generic, for new routine ctrl_get_gen
+C
+C     ==================================================================
+C     SUBROUTINE ctrl_get_gen_rec
+C     ==================================================================
 
       implicit none
 
-c     == global variables ==
+C     == global variables ==
 
 #include "SIZE.h"
 #include "EEPARAMS.h"
@@ -37,7 +37,7 @@ c     == global variables ==
 # include "cal.h"
 #endif
 
-c     == routine arguments ==
+C     == routine arguments ==
 
       integer xx_genstartdate(4)
       _RL     xx_genperiod
@@ -50,7 +50,7 @@ c     == routine arguments ==
       integer myiter
       integer mythid
 
-c     == local variables ==
+C     == local variables ==
 
 #ifdef ALLOW_CAL
 
@@ -81,13 +81,13 @@ C     for simplied default model calendar without exf/cal
       character*(max_len_mbuf) msgbuf
 #endif
 
-c     == end of interface ==
+C     == end of interface ==
 
 #ifdef ALLOW_CAL
       lArgErr = .true.
       fldperiod = 0.
 
-c     Map the field parameters.
+C     Map the field parameters.
 
       call cal_CopyDate(
      I     xx_genstartdate,
@@ -97,7 +97,7 @@ c     Map the field parameters.
       fldperiod = xx_genperiod
       lArgErr = .false.
 
-c--   Check the field argument.
+C--   Check the field argument.
       if ( lArgErr ) then
          print*,' The subroutine *ctrl_get_gen_rec* has been called'
          print*,' with an illegal field specification.'
@@ -105,42 +105,42 @@ c--   Check the field argument.
       endif
 
       if ( xx_genperiod .eq. -12. _d 0 ) then
-c     record numbers are assumed 1 to 12 corresponding to
-c     Jan. through Dec.
+C     record numbers are assumed 1 to 12 corresponding to
+C     Jan. through Dec.
        call cal_GetMonthsRec(
      O      fac, first, changed,
      O      count0, count1,
      I      mytime, myiter, mythid
      &      )
       elseif ( fldperiod .eq. 0. _d 0 ) then
-c     Read field only once in the beginning. Hack: count1=count0 causes
-c     the model to read the first record twice, but since this this is
-c     done only the first time around it is not too much of an overhead.
+C     Read field only once in the beginning. Hack: count1=count0 causes
+C     the model to read the first record twice, but since this this is
+C     done only the first time around it is not too much of an overhead.
        first   = ((mytime - modelstart) .lt. 0.5*modelstep)
        changed = .false.
        fac     = 1. _d 0
        count0  = 1
        count1  = count0
       else
-c     fldperiod .ne. 0
-c--   Determine the current date.
+C     fldperiod .ne. 0
+C--   Determine the current date.
        call cal_GetDate( myiter, mytime, mydate, mythid )
 
-c     Determine first record:
+C     Determine first record:
 c      call cal_TimePassed( fldstartdate, modelstartdate,
 c    &                      difftime, mythid )
 c      call cal_ToSeconds ( difftime, fldsecs, mythid )
 c      startrec = int((modelstart + startTime - fldsecs)/
 c    &                fldperiod) + 1
 
-c     Determine the flux record just before mycurrentdate.
+C     Determine the flux record just before mycurrentdate.
        call cal_TimePassed( fldstartdate, mydate, difftime,
      &                      mythid )
        call cal_ToSeconds( difftime, fldsecs, mythid )
        fldsecs  = int((fldsecs+0.5)/fldperiod)*fldperiod
        fldcount = int((fldsecs+0.5)/fldperiod) + 1
 
-c     Set switches for reading new records.
+C     Set switches for reading new records.
        first = ((mytime - modelstart) .lt. 0.5*modelstep)
 
        if ( first) then
@@ -170,17 +170,17 @@ c     Set switches for reading new records.
        call cal_TimePassed( flddate, mydate, difftime, mythid )
        call cal_ToSeconds( difftime, fldsecs, mythid )
 
-c     Weight belonging to irec for linear interpolation purposes.
-c     Note: The weight as chosen here is 1. - fac of the "old"
-c           MITgcm estimation program.
+C     Weight belonging to irec for linear interpolation purposes.
+C     Note: The weight as chosen here is 1. - fac of the "old"
+C           MITgcm estimation program.
        fac = 1. - fldsecs/fldperiod
 
-c     fldperiod .ne. 0.
+C     fldperiod .ne. 0.
       endif
 #else /* not ALLOW_CAL */
 C     Code, adapted from external_fields_load, for simplied
 C     default model calendar without exf/cal, but
-C     based on myTime, myIter, deltaTclock, externForcingCycle, and startTime
+C     based on myTime, myIter, deltaTClock, externForcingCycle, and startTime
 
       myRelTime = myTime - startTime
       first = (myRelTime .lt. 0.5*deltaTClock)
@@ -198,7 +198,7 @@ C--   Now calculate whether it is time to update the forcing arrays
        CALL GET_PERIODIC_INTERVAL(
      O                   countP, count0, count1, tmpFac, fac,
      I                   externForcingCycle, xx_genperiod,
-     I                   deltaTclock, myTime, myThid )
+     I                   deltaTClock, myTime, myThid )
 
        IF ( count0.NE.countP ) THEN
         changed = .true.
@@ -212,7 +212,7 @@ C--   Now calculate whether it is time to update the forcing arrays
 #endif /* ALLOW_CAL */
 
 #ifdef ECCO_VERBOSE
-c     Do some printing for the protocol.
+C     Do some printing for the protocol.
       _BEGIN_MASTER( mythid )
         write(msgbuf,'(a)') ' '
         call print_message( msgbuf, standardmessageunit,


### PR DESCRIPTION
## What changes does this PR introduce?
(Bug fix, feature, docs update, ...)

Bug fix: this is a pretty subtle and small change to pkg/ctrl/ctrl_get_gen_rec

## What is the current behaviour? 
(You can also link to an open issue here)

In ctrl_get_gen_rec, count0 and count1 are the variables used to determine which records to read from xx_gentim2d_file.effective.## (e.g. xx_tauu.effective.##). These are currently computed as follows:

```
count0 = fldcount0 - startrec + 1
count1 = fldcount1 - startrec + 2
```

With this implementation, count0 ALWAYS starts at 1. This means that the "effective" file only has the minimum number of records for the current simulation.

## What is the new behaviour 
(if this is a feature change)?

It is quite convenient to run for a short time period, but use a control vector from a longer run. As a concrete example, consider running only during 2009 of ECCO. Here it would be ideal to provide the same control vector from ECCO, which has hundreds of entries, and only access the entries relevant to the current run (we'd only need ~52 or so control records from ECCO for a single year). It would be extremely difficult to line up the start of the 2009 simulation with the exact record number needed. However, the following simple change seems to do the trick (this is the entire PR):

```
count0 = fldcount0
count1 = fldcount1 
```

For this 2009 simulation, the ctrl package makes xx_gentim2d.effective files which have length: (number of records for start of ECCO to start of 2009) + (number of records for 2009 simulation), and only these last records are accessed. 
 
## Does this PR introduce a breaking change? 
(What changes might users need to make in their application due to this PR?)

This doesn't break anything, and I've even tested this with the adjoint everything seems to be cool. 

## Other information:

The funny thing is, this modification is commented out in the original code. I can't think of a reason for adding `-startrec+1` etc, but I would be interested if @gaelforget (or anyone else) knows why these lines were commented out. It seems to only make this more difficult! 

I know @raphaeldussin and @antnguyen13 found this useful, perhaps others will too. 

## Suggested addition to `tag-index`
(To avoid unnecessary merge conflicts, please don't update `tag-index`. One of the admins will do that when merging your pull request.)