### PR TITLE
Improve report of error/warning message

### DIFF
--- a/pkg/atm_phys/dargan_bettsmiller_mod.F90
+++ b/pkg/atm_phys/dargan_bettsmiller_mod.F90
@@ -760,15 +760,15 @@ contains
       if (value.lt.-23.0) then
           CALL PRINT_ERROR( 'In: dargan_bettsmiller '//  &
                             'lcltable: value too low', myThid)
-          WRITE(errorMessageUnit,'(A,3I4,I6,1PE14.6)')   &
-            'i,j,bj,myIter,value=',i,j,bj,myIter,value
+          WRITE(errorMessageUnit,'(A,4I4,I6,1PE14.6)')   &
+            'i,j,bi,bj,myIter,value=',i,j,bi,bj,myIter,value
 !         STOP 'ABNORMAL END: S/R LCLTABL (dargan_bettsmiller_mod)'
       endif
       if (value.gt.-10.4) then
           CALL PRINT_ERROR( 'In: dargan_bettsmiller '//  &
                             'lcltable: value too high', myThid)
-          WRITE(errorMessageUnit,'(A,3I4,I6,1PE14.6)')   &
-            'i,j,bj,myIter,value=',i,j,bj,myIter,value
+          WRITE(errorMessageUnit,'(A,4I4,I6,1PE14.6)')   &
+            'i,j,bi,bj,myIter,value=',i,j,bi,bj,myIter,value
 !         STOP 'ABNORMAL END: S/R LCLTABL (dargan_bettsmiller_mod)'
       endif
       ival = floor(10.*(v1 + 23.0))


### PR DESCRIPTION
print full location (including tile index "bi", previously missing)
where problem occurs.

## What changes does this PR introduce?
Minor fix to error/warning message.

## What is the current behaviour? 
already print a warning message when input value is beyond look-up table range,
but tile index "bi" was missing from the report. 

## What is the new behaviour 
add missing "bi" info to the warning message report.

## Does this PR introduce a breaking change? 
no

## Other information:

## Suggested addition to `tag-index`
none (not significant enough to be documented here)