### PR TITLE
Fix obcs stevens

### DIFF
--- a/pkg/obcs/obcs_apply_ts.F
+++ b/pkg/obcs/obcs_apply_ts.F
@@ -73,68 +73,30 @@ C     Set model variables to OB values on North/South Boundaries
 #ifdef ALLOW_OBCS_NORTH
         IF ( tileHasOBN(bi,bj) ) THEN
 C Northern boundary
-# ifdef ALLOW_OBCS_STEVENS
-         IF ( useStevensNorth ) THEN
-          DO i=1-OLx,sNx+OLx
-C     add tendency term instead of overwriting field with boundary value
-           Jobc = OB_Jn(i,bi,bj)
-           IF ( Jobc.NE.OB_indexNone ) THEN
-            DO k = kLo,kHi
-             tFld(i,Jobc,k,bi,bj) = tFld(i,Jobc,k,bi,bj)
-     &            + dTtracerLev(k)*OBNt(i,k,bi,bj)
-             sFld(i,Jobc,k,bi,bj) = sFld(i,Jobc,k,bi,bj)
-     &            + dTtracerLev(k)*OBNs(i,k,bi,bj)
-            ENDDO
-           ENDIF
-          ENDDO
-         ELSE
-# else
-         IF ( .TRUE. ) THEN
-# endif /* ALLOW_OBCS_STEVENS */
-          DO i=1-OLx,sNx+OLx
-           Jobc = OB_Jn(i,bi,bj)
-           IF ( Jobc.NE.OB_indexNone ) THEN
-            DO k = kLo,kHi
-             tFld(i,Jobc,k,bi,bj) = OBNt(i,k,bi,bj)
-             sFld(i,Jobc,k,bi,bj) = OBNs(i,k,bi,bj)
-            ENDDO
-           ENDIF
-          ENDDO
-         ENDIF
+         DO i=1-OLx,sNx+OLx
+          Jobc = OB_Jn(i,bi,bj)
+          IF ( Jobc.NE.OB_indexNone ) THEN
+           DO k = kLo,kHi
+            tFld(i,Jobc,k,bi,bj) = OBNt(i,k,bi,bj)
+            sFld(i,Jobc,k,bi,bj) = OBNs(i,k,bi,bj)
+           ENDDO
+          ENDIF
+         ENDDO
         ENDIF
 #endif /* ALLOW_OBCS_NORTH */
 
 #ifdef ALLOW_OBCS_SOUTH
         IF ( tileHasOBS(bi,bj) ) THEN
 C Southern boundary
-# ifdef ALLOW_OBCS_STEVENS
-         IF ( useStevensSouth ) THEN
-C     add tendency term instead of overwriting field with boundary value
-          DO i=1-OLx,sNx+OLx
-           Jobc = OB_Js(i,bi,bj)
-           IF ( Jobc.NE.OB_indexNone ) THEN
-            DO k = kLo,kHi
-             tFld(i,Jobc,k,bi,bj) = tFld(i,Jobc,k,bi,bj)
-     &            + dTtracerLev(k)*OBSt(i,k,bi,bj)
-             sFld(i,Jobc,k,bi,bj) = sFld(i,Jobc,k,bi,bj)
-     &            + dTtracerLev(k)*OBSs(i,k,bi,bj)
-            ENDDO
-           ENDIF
-          ENDDO
-         ELSE
-# else
-         IF ( .TRUE. ) THEN
-# endif /* ALLOW_OBCS_STEVENS */
-          DO i=1-OLx,sNx+OLx
-           Jobc = OB_Js(i,bi,bj)
-           IF ( Jobc.NE.OB_indexNone ) THEN
-            DO k = kLo,kHi
-             tFld(i,Jobc,k,bi,bj) = OBSt(i,k,bi,bj)
-             sFld(i,Jobc,k,bi,bj) = OBSs(i,k,bi,bj)
-            ENDDO
-           ENDIF
-          ENDDO
-         ENDIF
+         DO i=1-OLx,sNx+OLx
+          Jobc = OB_Js(i,bi,bj)
+          IF ( Jobc.NE.OB_indexNone ) THEN
+           DO k = kLo,kHi
+            tFld(i,Jobc,k,bi,bj) = OBSt(i,k,bi,bj)
+            sFld(i,Jobc,k,bi,bj) = OBSs(i,k,bi,bj)
+           ENDDO
+          ENDIF
+         ENDDO
         ENDIF
 #endif /* ALLOW_OBCS_SOUTH */
 
@@ -142,68 +104,30 @@ C     Set model variables to OB values on East/West Boundaries
 #ifdef ALLOW_OBCS_EAST
         IF ( tileHasOBE(bi,bj) ) THEN
 C Eastern boundary
-# ifdef ALLOW_OBCS_STEVENS
-         IF ( useStevensEast ) THEN
-C     add tendency term instead of overwriting field with boundary value
-          DO j=1-OLy,sNy+OLy
-           Iobc = OB_Ie(j,bi,bj)
-           IF ( Iobc.NE.OB_indexNone ) THEN
-            DO k = kLo,kHi
-             tFld(Iobc,j,k,bi,bj) = tFld(Iobc,j,k,bi,bj)
-     &            + dTtracerLev(k)*OBEt(j,k,bi,bj)
-             sFld(Iobc,j,k,bi,bj) = sFld(Iobc,j,k,bi,bj)
-     &            + dTtracerLev(k)*OBEs(j,k,bi,bj)
-            ENDDO
-           ENDIF
-          ENDDO
-         ELSE
-# else
-         IF ( .TRUE. ) THEN
-# endif /* ALLOW_OBCS_STEVENS */
-          DO j=1-OLy,sNy+OLy
-           Iobc = OB_Ie(j,bi,bj)
-           IF ( Iobc.NE.OB_indexNone ) THEN
-            DO k = kLo,kHi
-             tFld(Iobc,j,k,bi,bj) = OBEt(j,k,bi,bj)
-             sFld(Iobc,j,k,bi,bj) = OBEs(j,k,bi,bj)
-            ENDDO
-           ENDIF
-          ENDDO
-         ENDIF
+         DO j=1-OLy,sNy+OLy
+          Iobc = OB_Ie(j,bi,bj)
+          IF ( Iobc.NE.OB_indexNone ) THEN
+           DO k = kLo,kHi
+            tFld(Iobc,j,k,bi,bj) = OBEt(j,k,bi,bj)
+            sFld(Iobc,j,k,bi,bj) = OBEs(j,k,bi,bj)
+           ENDDO
+          ENDIF
+         ENDDO
         ENDIF
 #endif /* ALLOW_OBCS_EAST */
 
 #ifdef ALLOW_OBCS_WEST
         IF ( tileHasOBW(bi,bj) ) THEN
 C Western boundary
-# ifdef ALLOW_OBCS_STEVENS
-         IF ( useStevensWest ) THEN
-C     add tendency term instead of overwriting field with boundary value
-          DO j=1-OLy,sNy+OLy
-           Iobc = OB_Iw(j,bi,bj)
-           IF ( Iobc.NE.OB_indexNone ) THEN
-            DO k = kLo,kHi
-             tFld(Iobc,j,k,bi,bj) = tFld(Iobc,j,k,bi,bj)
-     &            + dTtracerLev(k)*OBWt(j,k,bi,bj)
-             sFld(Iobc,j,k,bi,bj) = sFld(Iobc,j,k,bi,bj)
-     &            + dTtracerLev(k)*OBWs(j,k,bi,bj)
-            ENDDO
-           ENDIF
-          ENDDO
-         ELSE
-# else
-         IF ( .TRUE. ) THEN
-# endif /* ALLOW_OBCS_STEVENS */
-          DO j=1-OLy,sNy+OLy
-           Iobc = OB_Iw(j,bi,bj)
-           IF ( Iobc.NE.OB_indexNone ) THEN
-            DO k = kLo,kHi
-             tFld(Iobc,j,k,bi,bj) = OBWt(j,k,bi,bj)
-             sFld(Iobc,j,k,bi,bj) = OBWs(j,k,bi,bj)
-            ENDDO
-           ENDIF
-          ENDDO
-         ENDIF
+         DO j=1-OLy,sNy+OLy
+          Iobc = OB_Iw(j,bi,bj)
+          IF ( Iobc.NE.OB_indexNone ) THEN
+           DO k = kLo,kHi
+            tFld(Iobc,j,k,bi,bj) = OBWt(j,k,bi,bj)
+            sFld(Iobc,j,k,bi,bj) = OBWs(j,k,bi,bj)
+           ENDDO
+          ENDIF
+         ENDDO
         ENDIF
 #endif /* ALLOW_OBCS_WEST */
 

--- a/pkg/obcs/obcs_calc_stevens.F
+++ b/pkg/obcs/obcs_calc_stevens.F
@@ -688,6 +688,8 @@ C     !USES:
       IMPLICIT NONE
 C     == Global variables ==
 #include "SIZE.h"
+#include "EEPARAMS.h"
+#include "PARAMS.h"
 #include "GRID.h"
 
 C     !INPUT/OUTPUT PARAMETERS:
@@ -708,7 +710,7 @@ C    bi, bj    :: indices of current tile
       _RL tracer (1-Olx:sNx+Olx,1-Oly:sNy+Oly,Nr,nSx,nSy)
       _RL uVel   (1-Olx:sNx+Olx,1-Oly:sNy+Oly,Nr,nSx,nSy)
 
-#ifdef ALLOW_OBCS_STEVENS
+#if (defined ALLOW_OBCS_NORTH & defined ALLOW_OBCS_STEVENS)
 C     !LOCAL VARIABLES:
 C     i,j,k        :: loop indices
 C     uPhase       :: estimate of phase velocity for radiation condition
@@ -732,14 +734,16 @@ CEOP
      &         MAX( 0.D0, -cflMer(J,K)*dTracTime/dTracSpace )
      &         ) * pFac
          ENDIF
-C     Compute the tracer tendency here, the tracer will be updated
-C     with a simple Euler forward step in S/R obcs_apply_ts
+C     Compute the tracer tendency ...
          OBEf(J,K,bi,bj) = _maskW(I,J,K,bi,bj) * (
      &        - ( aFac*MAX(0.D0,uVel(I,J,K,bi,bj)) + uPhase )
      &        *(tracer(I,J,K,bi,bj)-tracer(I-1,J,K,bi,bj))
      &        * _recip_dxC(I,J,bi,bj)
      &        - gFacM(J,K) * gammaf
      &        * (tracer(I,J,K,bi,bj)-OBEf(J,K,bi,bj)) )
+C     ... and update tracer with a simple Euler forward step
+         OBEf(J,K,bi,bj) = tracer(I,J,K,bi,bj)
+     &        + dTtracerLev(K) * OBEf(J,K,bi,bj) 
         ENDIF
        ENDDO
       ENDDO
@@ -769,6 +773,8 @@ C     !USES:
       IMPLICIT NONE
 C     == Global variables ==
 #include "SIZE.h"
+#include "EEPARAMS.h"
+#include "PARAMS.h"
 #include "GRID.h"
 
 C     !INPUT/OUTPUT PARAMETERS:
@@ -789,7 +795,7 @@ C    bi, bj    :: indices of current tile
       _RL tracer (1-Olx:sNx+Olx,1-Oly:sNy+Oly,Nr,nSx,nSy)
       _RL uVel   (1-Olx:sNx+Olx,1-Oly:sNy+Oly,Nr,nSx,nSy)
 
-#ifdef ALLOW_OBCS_STEVENS
+#if (defined ALLOW_OBCS_NORTH & defined ALLOW_OBCS_STEVENS)
 C     !LOCAL VARIABLES:
 C     i,j,k        :: loop indices
 C     uPhase       :: estimate of phase velocity for radiation condition
@@ -814,14 +820,16 @@ CEOP
      &         MIN( 0.D0, -cflMer(J,K)*dTracTime/dTracSpace )
      &         ) * pFac
          ENDIF
-C     Compute the tracer tendency here, the tracer will be updated
-C     with a simple Euler forward step in S/R obcs_apply_ts
+C     Compute the tracer tendency ...
          OBWf(J,K,bi,bj) = _maskW(I+1,J,K,bi,bj) * (
      &        - ( aFac*MIN(0.D0,uVel(I+1,J,K,bi,bj)) + uPhase )
      &        *(tracer(I+1,J,K,bi,bj)-tracer(I,J,K,bi,bj))
      &        * _recip_dxC(I+1,J,bi,bj)
      &        - gFacM(J,K) * gammaf
      &        * (tracer(I,J,K,bi,bj)-OBWf(J,K,bi,bj)) )
+C     ... and update tracer with a simple Euler forward step
+         OBWf(J,K,bi,bj) = tracer(I,J,K,bi,bj)
+     &        + dTtracerLev(K) * OBWf(J,K,bi,bj) 
         ENDIF
        ENDDO
       ENDDO
@@ -851,6 +859,8 @@ C     !USES:
       IMPLICIT NONE
 C     == Global variables ==
 #include "SIZE.h"
+#include "EEPARAMS.h"
+#include "PARAMS.h"
 #include "GRID.h"
 
 C     !INPUT/OUTPUT PARAMETERS:
@@ -871,7 +881,7 @@ C    bi, bj    :: indices of current tile
       _RL tracer (1-Olx:sNx+Olx,1-Oly:sNy+Oly,Nr,nSx,nSy)
       _RL vVel   (1-Olx:sNx+Olx,1-Oly:sNy+Oly,Nr,nSx,nSy)
 
-#ifdef ALLOW_OBCS_STEVENS
+#if (defined ALLOW_OBCS_NORTH & defined ALLOW_OBCS_STEVENS)
 C     !LOCAL VARIABLES:
 C     i,j,k        :: loop indices
 C     vPhase       :: estimate of phase velocity for radiation condition
@@ -896,14 +906,16 @@ C     Theta first:
      &         MAX( 0.D0, -cflZon(I,K)*dTracTime/dTracSpace )
      &         ) * pFac
          ENDIF
-C     Compute the tracer tendency here, the tracer will be updated
-C     with a simple Euler forward step in S/R obcs_apply_ts
+C     Compute the tracer tendency ...
          OBNf(I,K,bi,bj) = _maskS(I,J,K,bi,bj) * (
      &        - ( aFac*MAX(0.D0,vVel(I,J,K,bi,bj)) + vPhase )
      &        *(tracer(I,J,K,bi,bj)-tracer(I,J-1,K,bi,bj))
      &        * _recip_dyC(I,J,bi,bj)
      &        - gFacZ(I,K) * gammaf
      &        * (tracer(I,J,K,bi,bj)-OBNf(I,K,bi,bj)) )
+C     ... and update tracer with a simple Euler forward step
+         OBNf(I,K,bi,bj) = tracer(I,J,K,bi,bj)
+     &        + dTtracerLev(K) * OBNf(I,K,bi,bj) 
         ENDIF
        ENDDO
       ENDDO
@@ -933,6 +945,8 @@ C     !USES:
       IMPLICIT NONE
 C     == Global variables ==
 #include "SIZE.h"
+#include "EEPARAMS.h"
+#include "PARAMS.h"
 #include "GRID.h"
 
 C     !INPUT/OUTPUT PARAMETERS:
@@ -953,7 +967,7 @@ C    bi, bj    :: indices of current tile
       _RL tracer (1-Olx:sNx+Olx,1-Oly:sNy+Oly,Nr,nSx,nSy)
       _RL vVel   (1-Olx:sNx+Olx,1-Oly:sNy+Oly,Nr,nSx,nSy)
 
-#ifdef ALLOW_OBCS_STEVENS
+#if (defined ALLOW_OBCS_SOUTH & defined ALLOW_OBCS_STEVENS)
 C     !LOCAL VARIABLES:
 C     i,j,k        :: loop indices
 C     vPhase       :: estimate of phase velocity for radiation condition
@@ -977,14 +991,16 @@ CEOP
      &         MIN( 0.D0, -cflZon(I,K)*dTracTime/dTracSpace )
      &         ) * pFac
          ENDIF
-C     Compute the tracer tendency here, the tracer will be updated
-C     with a simple Euler forward step in S/R obcs_apply_ts
+C     Compute the tracer tendency ...
          OBSf(I,K,bi,bj) = _maskS(I,J+1,K,bi,bj) * (
      &        - ( aFac*MIN(0.D0,vVel(I,J+1,K,bi,bj)) + vPhase )
      &        *(tracer(I,J+1,K,bi,bj)-tracer(I,J,K,bi,bj))
      &        * _recip_dyC(I,J+1,bi,bj)
      &        - gFacZ(I,K) * gammaf
      &        * (tracer(I,J,K,bi,bj)-OBSf(I,K,bi,bj)) )
+C     ... and update tracer with a simple Euler forward step
+         OBSf(I,K,bi,bj) = tracer(I,J,K,bi,bj)
+     &        + dTtracerLev(K) * OBSf(I,K,bi,bj) 
         ENDIF
        ENDDO
       ENDDO

--- a/pkg/obcs/obcs_calc_stevens.F
+++ b/pkg/obcs/obcs_calc_stevens.F
@@ -710,7 +710,7 @@ C    bi, bj    :: indices of current tile
       _RL tracer (1-Olx:sNx+Olx,1-Oly:sNy+Oly,Nr,nSx,nSy)
       _RL uVel   (1-Olx:sNx+Olx,1-Oly:sNy+Oly,Nr,nSx,nSy)
 
-#if (defined ALLOW_OBCS_NORTH & defined ALLOW_OBCS_STEVENS)
+#if (defined ALLOW_OBCS_EAST && defined ALLOW_OBCS_STEVENS)
 C     !LOCAL VARIABLES:
 C     i,j,k        :: loop indices
 C     uPhase       :: estimate of phase velocity for radiation condition
@@ -795,7 +795,7 @@ C    bi, bj    :: indices of current tile
       _RL tracer (1-Olx:sNx+Olx,1-Oly:sNy+Oly,Nr,nSx,nSy)
       _RL uVel   (1-Olx:sNx+Olx,1-Oly:sNy+Oly,Nr,nSx,nSy)
 
-#if (defined ALLOW_OBCS_NORTH & defined ALLOW_OBCS_STEVENS)
+#if (defined ALLOW_OBCS_WEST && defined ALLOW_OBCS_STEVENS)
 C     !LOCAL VARIABLES:
 C     i,j,k        :: loop indices
 C     uPhase       :: estimate of phase velocity for radiation condition
@@ -881,7 +881,7 @@ C    bi, bj    :: indices of current tile
       _RL tracer (1-Olx:sNx+Olx,1-Oly:sNy+Oly,Nr,nSx,nSy)
       _RL vVel   (1-Olx:sNx+Olx,1-Oly:sNy+Oly,Nr,nSx,nSy)
 
-#if (defined ALLOW_OBCS_NORTH & defined ALLOW_OBCS_STEVENS)
+#if (defined ALLOW_OBCS_NORTH && defined ALLOW_OBCS_STEVENS)
 C     !LOCAL VARIABLES:
 C     i,j,k        :: loop indices
 C     vPhase       :: estimate of phase velocity for radiation condition
@@ -967,7 +967,7 @@ C    bi, bj    :: indices of current tile
       _RL tracer (1-Olx:sNx+Olx,1-Oly:sNy+Oly,Nr,nSx,nSy)
       _RL vVel   (1-Olx:sNx+Olx,1-Oly:sNy+Oly,Nr,nSx,nSy)
 
-#if (defined ALLOW_OBCS_SOUTH & defined ALLOW_OBCS_STEVENS)
+#if (defined ALLOW_OBCS_SOUTH && defined ALLOW_OBCS_STEVENS)
 C     !LOCAL VARIABLES:
 C     i,j,k        :: loop indices
 C     vPhase       :: estimate of phase velocity for radiation condition

--- a/verification/exp4/results/output.stevens.txt
+++ b/verification/exp4/results/output.stevens.txt
@@ -5,10 +5,10 @@
 (PID.TID 0000.0001) // ======================================================
 (PID.TID 0000.0001) // execution environment starting up...
 (PID.TID 0000.0001) 
-(PID.TID 0000.0001) // MITgcmUV version:  checkpoint65h
-(PID.TID 0000.0001) // Build user:        jmc
-(PID.TID 0000.0001) // Build host:        baudelaire
-(PID.TID 0000.0001) // Build date:        Sat Jan  3 19:06:56 EST 2015
+(PID.TID 0000.0001) // MITgcmUV version:  checkpoint67i
+(PID.TID 0000.0001) // Build user:        mlosch
+(PID.TID 0000.0001) // Build host:        bkli04l006
+(PID.TID 0000.0001) // Build date:        Wed May 22 14:32:08 CEST 2019
 (PID.TID 0000.0001) 
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // Execution Environment parameter file "eedata"
@@ -48,6 +48,8 @@
 (PID.TID 0000.0001)                   /*  "mpirun -np 64 ......"                    */
 (PID.TID 0000.0001) useCoupler=    F ;/* Flag used to control communications with   */
 (PID.TID 0000.0001)                   /*  other model components, through a coupler */
+(PID.TID 0000.0001) useNest2W_parent =    F ;/* Control 2-W Nesting comm */
+(PID.TID 0000.0001) useNest2W_child  =    F ;/* Control 2-W Nesting comm */
 (PID.TID 0000.0001) debugMode =    F ; /* print debug msg. (sequence of S/R calls)  */
 (PID.TID 0000.0001) printMapIncludesZeros=    F ; /* print zeros in Std.Output maps */
 (PID.TID 0000.0001) maxLengthPrt1D=   65 /* maxLength of 1D array printed to StdOut */
@@ -844,6 +846,10 @@
 (PID.TID 0000.0001) rhoNil    = /* Reference density for Linear EOS ( kg/m^3 ) */
 (PID.TID 0000.0001)                 9.998000000000000E+02
 (PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) selectP_inEOS_Zc = /* select pressure to use in EOS (0,1,2,3) */
+(PID.TID 0000.0001)                       0
+(PID.TID 0000.0001)     0= -g*rhoConst*z ; 1= pRef (from tRef,sRef); 2= Hyd P ; 3= Hyd+NH P
+(PID.TID 0000.0001)     ;
 (PID.TID 0000.0001) HeatCapacity_Cp =  /* Specific heat capacity ( J/kg/K ) */
 (PID.TID 0000.0001)                 3.994000000000000E+03
 (PID.TID 0000.0001)     ;
@@ -867,6 +873,12 @@
 (PID.TID 0000.0001)     ;
 (PID.TID 0000.0001) gBaro =   /* Barotropic gravity ( m/s^2 ) */
 (PID.TID 0000.0001)                 9.810000000000000E+00
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) gravFacC = /* gravity factor (vs surf.) @ cell-Center (-) */
+(PID.TID 0000.0001)     8 @  1.000000000000000E+00              /* K =  1:  8 */
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) gravFacF = /* gravity factor (vs surf.) @ W-Interface (-) */
+(PID.TID 0000.0001)     9 @  1.000000000000000E+00              /* K =  1:  9 */
 (PID.TID 0000.0001)     ;
 (PID.TID 0000.0001) rotationPeriod =   /* Rotation Period ( s ) */
 (PID.TID 0000.0001)                 8.616400000000000E+04
@@ -895,7 +907,7 @@
 (PID.TID 0000.0001) implicSurfPress =  /* Surface Pressure implicit factor (0-1)*/
 (PID.TID 0000.0001)                 1.000000000000000E+00
 (PID.TID 0000.0001)     ;
-(PID.TID 0000.0001) implicDiv2Dflow =  /* Barot. Flow Div. implicit factor (0-1)*/
+(PID.TID 0000.0001) implicDiv2DFlow =  /* Barot. Flow Div. implicit factor (0-1)*/
 (PID.TID 0000.0001)                 1.000000000000000E+00
 (PID.TID 0000.0001)     ;
 (PID.TID 0000.0001) uniformLin_PhiSurf = /* use uniform Bo_surf on/off flag*/
@@ -989,8 +1001,9 @@
 (PID.TID 0000.0001) implicitViscosity = /* Implicit viscosity on/off flag */
 (PID.TID 0000.0001)                   F
 (PID.TID 0000.0001)     ;
-(PID.TID 0000.0001) implBottomFriction= /* Implicit bottom friction on/off flag */
-(PID.TID 0000.0001)                   F
+(PID.TID 0000.0001) selectImplicitDrag= /* Implicit bot Drag options (0,1,2)*/
+(PID.TID 0000.0001)                       0
+(PID.TID 0000.0001)     0= Expl. ; 1= Impl. on provis. Vel ; 2= Fully Impl (with surf.P)
 (PID.TID 0000.0001)     ;
 (PID.TID 0000.0001) metricTerms =  /* metric-Terms on/off flag */
 (PID.TID 0000.0001)                   F
@@ -1044,6 +1057,9 @@
 (PID.TID 0000.0001)                       0
 (PID.TID 0000.0001)     ;
 (PID.TID 0000.0001) momForcing =  /* Momentum forcing on/off flag */
+(PID.TID 0000.0001)                   T
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) momTidalForcing = /* Momentum Tidal forcing on/off flag */
 (PID.TID 0000.0001)                   T
 (PID.TID 0000.0001)     ;
 (PID.TID 0000.0001) momPressureForcing =  /* Momentum pressure term on/off flag */
@@ -1109,6 +1125,12 @@
 (PID.TID 0000.0001) writeBinaryPrec = /* Precision used for writing binary files */
 (PID.TID 0000.0001)                      32
 (PID.TID 0000.0001)     ;
+(PID.TID 0000.0001)  rwSuffixType =   /* select format of mds file suffix */
+(PID.TID 0000.0001)                       0
+(PID.TID 0000.0001)    = 0 : myIter (I10.10) ;   = 1 : 100*myTime (100th sec) ;
+(PID.TID 0000.0001)    = 2 : myTime (seconds);   = 3 : myTime/360 (10th of hr);
+(PID.TID 0000.0001)    = 4 : myTime/3600 (hours)
+(PID.TID 0000.0001)     ;
 (PID.TID 0000.0001)  globalFiles = /* write "global" (=not per tile) files */
 (PID.TID 0000.0001)                   F
 (PID.TID 0000.0001)     ;
@@ -1126,6 +1148,9 @@
 (PID.TID 0000.0001)    debLevD =  4 ; /* level of enhanced debug prt (add DEBUG_STATS prt) */
 (PID.TID 0000.0001)    debLevE =  5 ; /* level of extensive debug printing */
 (PID.TID 0000.0001) debugLevel =  /* select debug printing level */
+(PID.TID 0000.0001)                       2
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001)  plotLevel =  /* select PLOT_FIELD printing level */
 (PID.TID 0000.0001)                       2
 (PID.TID 0000.0001)     ;
 (PID.TID 0000.0001) //
@@ -1188,6 +1213,9 @@
 (PID.TID 0000.0001) abEps =   /* Adams-Bashforth-2 stabilizing weight */
 (PID.TID 0000.0001)                 1.000000000000000E-01
 (PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) applyExchUV_early = /* Apply EXCH to U,V earlier in time-step */
+(PID.TID 0000.0001)                   F
+(PID.TID 0000.0001)     ;
 (PID.TID 0000.0001) pickupStrictlyMatch= /* stop if pickup do not strictly match */
 (PID.TID 0000.0001)                   T
 (PID.TID 0000.0001)     ;
@@ -1220,9 +1248,6 @@
 (PID.TID 0000.0001)     ;
 (PID.TID 0000.0001) pickup_read_mdsio =   /* Model IO flag. */
 (PID.TID 0000.0001)                   T
-(PID.TID 0000.0001)     ;
-(PID.TID 0000.0001) pickup_write_immed =   /* Model IO flag. */
-(PID.TID 0000.0001)                   F
 (PID.TID 0000.0001)     ;
 (PID.TID 0000.0001) writePickupAtEnd =   /* Model IO flag. */
 (PID.TID 0000.0001)                   T
@@ -1275,11 +1300,20 @@
 (PID.TID 0000.0001) usingCurvilinearGrid = /* Curvilinear coordinates flag ( True/False ) */
 (PID.TID 0000.0001)                   F
 (PID.TID 0000.0001)     ;
-(PID.TID 0000.0001) selectSigmaCoord = /* Hybrid-Sigma Vert. Coordinate option */
+(PID.TID 0000.0001) useMin4hFacEdges = /* set hFacW,S as minimum of adjacent hFacC factor */
+(PID.TID 0000.0001)                   F
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) interViscAr_pCell = /* account for partial-cell in interior vert. viscosity */
+(PID.TID 0000.0001)                   F
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) interDiffKr_pCell = /* account for partial-cell in interior vert. diffusion */
+(PID.TID 0000.0001)                   F
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) pCellMix_select = /* option to enhance mixing near surface & bottom */
 (PID.TID 0000.0001)                       0
 (PID.TID 0000.0001)     ;
-(PID.TID 0000.0001) Ro_SeaLevel = /* r(1) ( units of r ==  m ) */
-(PID.TID 0000.0001)                 0.000000000000000E+00
+(PID.TID 0000.0001) selectSigmaCoord = /* Hybrid-Sigma Vert. Coordinate option */
+(PID.TID 0000.0001)                       0
 (PID.TID 0000.0001)     ;
 (PID.TID 0000.0001) rSigmaBnd = /* r/sigma transition ( units of r ==  m ) */
 (PID.TID 0000.0001)                 1.234567000000000E+05
@@ -1289,6 +1323,12 @@
 (PID.TID 0000.0001)     ;
 (PID.TID 0000.0001) gravitySign = /* gravity orientation relative to vertical coordinate */
 (PID.TID 0000.0001)                -1.000000000000000E+00
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) seaLev_Z =  /* reference height of sea-level [m] */
+(PID.TID 0000.0001)                 0.000000000000000E+00
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) top_Pres =  /* reference pressure at the top [Pa] */
+(PID.TID 0000.0001)                 0.000000000000000E+00
 (PID.TID 0000.0001)     ;
 (PID.TID 0000.0001) mass2rUnit = /* convert mass per unit area [kg/m2] to r-units [m] */
 (PID.TID 0000.0001)                 1.000200040008002E-03
@@ -1659,6 +1699,9 @@
 (PID.TID 0000.0001) %MON dynstat_salt_mean            =   3.5000000000000E+01
 (PID.TID 0000.0001) %MON dynstat_salt_sd              =   1.1368683772162E-13
 (PID.TID 0000.0001) %MON dynstat_salt_del2            =   5.1588869912774E-06
+(PID.TID 0000.0001) %MON trAdv_CFL_u_max              =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON trAdv_CFL_v_max              =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON trAdv_CFL_w_max              =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON advcfl_uvel_max              =   3.0300000000000E-02
 (PID.TID 0000.0001) %MON advcfl_vvel_max              =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON advcfl_wvel_max              =   4.8480000000000E-01
@@ -1761,12 +1804,15 @@
 (PID.TID 0000.0001) %MON dynstat_theta_min            =  -6.9985030062455E-01
 (PID.TID 0000.0001) %MON dynstat_theta_mean           =   2.0284438739385E-02
 (PID.TID 0000.0001) %MON dynstat_theta_sd             =   4.5213405539759E-01
-(PID.TID 0000.0001) %MON dynstat_theta_del2           =   5.5965927425553E-05
+(PID.TID 0000.0001) %MON dynstat_theta_del2           =   5.5965927428889E-05
 (PID.TID 0000.0001) %MON dynstat_salt_max             =   3.5000271875000E+01
 (PID.TID 0000.0001) %MON dynstat_salt_min             =   3.5000000000000E+01
 (PID.TID 0000.0001) %MON dynstat_salt_mean            =   3.5000003651275E+01
 (PID.TID 0000.0001) %MON dynstat_salt_sd              =   3.1294706748909E-05
 (PID.TID 0000.0001) %MON dynstat_salt_del2            =   7.3014976940227E-06
+(PID.TID 0000.0001) %MON trAdv_CFL_u_max              =   3.0300000000000E-02
+(PID.TID 0000.0001) %MON trAdv_CFL_v_max              =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON trAdv_CFL_w_max              =   2.4240000000000E-01
 (PID.TID 0000.0001) %MON advcfl_uvel_max              =   3.0283333333333E-02
 (PID.TID 0000.0001) %MON advcfl_vvel_max              =   3.8465017557683E-03
 (PID.TID 0000.0001) %MON advcfl_wvel_max              =   1.7513813365337E-02
@@ -1817,16 +1863,19 @@
 (PID.TID 0000.0001) %MON dynstat_wvel_mean            =   2.8381869508585E-05
 (PID.TID 0000.0001) %MON dynstat_wvel_sd              =   2.1926381855743E-03
 (PID.TID 0000.0001) %MON dynstat_wvel_del2            =   1.6674764971226E-05
-(PID.TID 0000.0001) %MON dynstat_theta_max            =   7.0462888215804E-01
+(PID.TID 0000.0001) %MON dynstat_theta_max            =   7.0462888221327E-01
 (PID.TID 0000.0001) %MON dynstat_theta_min            =  -6.9888221186158E-01
 (PID.TID 0000.0001) %MON dynstat_theta_mean           =   2.0267043720748E-02
-(PID.TID 0000.0001) %MON dynstat_theta_sd             =   4.5211277176604E-01
-(PID.TID 0000.0001) %MON dynstat_theta_del2           =   1.7501791361736E-05
+(PID.TID 0000.0001) %MON dynstat_theta_sd             =   4.5211277176754E-01
+(PID.TID 0000.0001) %MON dynstat_theta_del2           =   1.7501791355877E-05
 (PID.TID 0000.0001) %MON dynstat_salt_max             =   3.5000777398941E+01
 (PID.TID 0000.0001) %MON dynstat_salt_min             =   3.4999977612180E+01
 (PID.TID 0000.0001) %MON dynstat_salt_mean            =   3.5000010130738E+01
 (PID.TID 0000.0001) %MON dynstat_salt_sd              =   8.9490027854635E-05
 (PID.TID 0000.0001) %MON dynstat_salt_del2            =   1.1654311857423E-05
+(PID.TID 0000.0001) %MON trAdv_CFL_u_max              =   3.0283333333333E-02
+(PID.TID 0000.0001) %MON trAdv_CFL_v_max              =   3.8465017557683E-03
+(PID.TID 0000.0001) %MON trAdv_CFL_w_max              =   1.9986381323987E-02
 (PID.TID 0000.0001) %MON advcfl_uvel_max              =   6.8594807397397E-02
 (PID.TID 0000.0001) %MON advcfl_vvel_max              =   1.0907443645892E-02
 (PID.TID 0000.0001) %MON advcfl_wvel_max              =   2.2295338924725E-02
@@ -1841,7 +1890,7 @@
 (PID.TID 0000.0001) %MON vort_a_sd                    =   6.1112250932683E-06
 (PID.TID 0000.0001) %MON vort_p_mean                  =   1.0161982423688E-04
 (PID.TID 0000.0001) %MON vort_p_sd                    =   3.4022071425820E-05
-(PID.TID 0000.0001) %MON surfExpan_theta_mean         =   3.6044559163639E-05
+(PID.TID 0000.0001) %MON surfExpan_theta_mean         =   3.6044559159438E-05
 (PID.TID 0000.0001) %MON surfExpan_salt_mean          =   1.7948540772385E-03
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // End MONITOR dynamic field statistics
@@ -1871,14 +1920,14 @@
 (PID.TID 0000.0001) %MON obc_S_vVel_mean              =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON obc_S_vVel_sd                =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON obc_S_vVel_Int               =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON obc_E_theta_max              =   6.9744900945016E-01
-(PID.TID 0000.0001) %MON obc_E_theta_min              =  -6.9674613287752E-01
-(PID.TID 0000.0001) %MON obc_E_theta_mean             =   6.1501523591539E-04
-(PID.TID 0000.0001) %MON obc_E_theta_sd               =   4.5645320744048E-01
-(PID.TID 0000.0001) %MON obc_W_theta_max              =   6.9683399247532E-01
-(PID.TID 0000.0001) %MON obc_W_theta_min              =  -6.9683399247532E-01
-(PID.TID 0000.0001) %MON obc_W_theta_mean             =   2.6274420734910E-14
-(PID.TID 0000.0001) %MON obc_W_theta_sd               =   4.5618475307088E-01
+(PID.TID 0000.0001) %MON obc_E_theta_max              =   6.9744901688887E-01
+(PID.TID 0000.0001) %MON obc_E_theta_min              =  -6.9674614031623E-01
+(PID.TID 0000.0001) %MON obc_E_theta_mean             =   6.1501523591511E-04
+(PID.TID 0000.0001) %MON obc_E_theta_sd               =   4.5645321028058E-01
+(PID.TID 0000.0001) %MON obc_W_theta_max              =   6.9683400000000E-01
+(PID.TID 0000.0001) %MON obc_W_theta_min              =  -6.9683400000000E-01
+(PID.TID 0000.0001) %MON obc_W_theta_mean             =   2.6226043701173E-14
+(PID.TID 0000.0001) %MON obc_W_theta_sd               =   4.5618475594441E-01
 (PID.TID 0000.0001) %MON obc_N_theta_max              =   6.9683400000000E-01
 (PID.TID 0000.0001) %MON obc_N_theta_min              =  -6.9683400000000E-01
 (PID.TID 0000.0001) %MON obc_N_theta_mean             =   5.0183265503355E-05
@@ -1892,120 +1941,126 @@
 (PID.TID 0000.0001) // =======================================================
  EXTERNAL_FIELDS_LOAD,         2 : iP,iLd,i0,i1=    1    2    1    2 ; Wght=  0.9444444444  0.0555555556
  OBCS_FIELDS_LOAD,         3 : iP,iLd,i0,i1=    1    2    1    2 ; Wght=  0.9166666667  0.0833333333
- cg2d: Sum(rhs),rhsMax =  -1.94073430460049E+01  2.29008393055596E-01
-(PID.TID 0000.0001)      cg2d_init_res =   1.54997923354951E+01
+ cg2d: Sum(rhs),rhsMax =  -1.94073430460048E+01  2.29008393055596E-01
+(PID.TID 0000.0001)      cg2d_init_res =   1.54997923411337E+01
 (PID.TID 0000.0001)      cg2d_iters(min,last) =      -1     202
-(PID.TID 0000.0001)      cg2d_last_res =   7.87828979761963E-14
+(PID.TID 0000.0001)      cg2d_last_res =   7.87842408748050E-14
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // Begin MONITOR dynamic field statistics
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) %MON time_tsnumber                =                     3
 (PID.TID 0000.0001) %MON time_secondsf                =   1.2600000000000E+04
-(PID.TID 0000.0001) %MON dynstat_eta_max              =   2.3415316830103E+00
-(PID.TID 0000.0001) %MON dynstat_eta_min              =  -2.1546594094821E+00
+(PID.TID 0000.0001) %MON dynstat_eta_max              =   2.3415316830442E+00
+(PID.TID 0000.0001) %MON dynstat_eta_min              =  -2.1546594094727E+00
 (PID.TID 0000.0001) %MON dynstat_eta_mean             =   9.2307692307689E-02
-(PID.TID 0000.0001) %MON dynstat_eta_sd               =   1.4635996818889E+00
-(PID.TID 0000.0001) %MON dynstat_eta_del2             =   8.9426106666821E-05
-(PID.TID 0000.0001) %MON dynstat_uvel_max             =   7.9272141952154E-01
-(PID.TID 0000.0001) %MON dynstat_uvel_min             =   2.3260922074141E-01
-(PID.TID 0000.0001) %MON dynstat_uvel_mean            =   3.1363350651270E-01
-(PID.TID 0000.0001) %MON dynstat_uvel_sd              =   5.5153619377167E-02
-(PID.TID 0000.0001) %MON dynstat_uvel_del2            =   1.5086081909295E-04
-(PID.TID 0000.0001) %MON dynstat_vvel_max             =   1.1002230788508E-01
+(PID.TID 0000.0001) %MON dynstat_eta_sd               =   1.4635996818891E+00
+(PID.TID 0000.0001) %MON dynstat_eta_del2             =   8.9426106669931E-05
+(PID.TID 0000.0001) %MON dynstat_uvel_max             =   7.9272141952152E-01
+(PID.TID 0000.0001) %MON dynstat_uvel_min             =   2.3260922073704E-01
+(PID.TID 0000.0001) %MON dynstat_uvel_mean            =   3.1363350651269E-01
+(PID.TID 0000.0001) %MON dynstat_uvel_sd              =   5.5153619377163E-02
+(PID.TID 0000.0001) %MON dynstat_uvel_del2            =   1.5086081908696E-04
+(PID.TID 0000.0001) %MON dynstat_vvel_max             =   1.1002230788507E-01
 (PID.TID 0000.0001) %MON dynstat_vvel_min             =  -1.4222596537280E-01
 (PID.TID 0000.0001) %MON dynstat_vvel_mean            =  -1.8349503854254E-03
 (PID.TID 0000.0001) %MON dynstat_vvel_sd              =   2.5249605030033E-02
 (PID.TID 0000.0001) %MON dynstat_vvel_del2            =   2.2475286893936E-05
-(PID.TID 0000.0001) %MON dynstat_wvel_max             =   2.7675243670425E-02
+(PID.TID 0000.0001) %MON dynstat_wvel_max             =   2.7675243670424E-02
 (PID.TID 0000.0001) %MON dynstat_wvel_min             =  -2.7376946136218E-02
-(PID.TID 0000.0001) %MON dynstat_wvel_mean            =   2.5793404753834E-05
-(PID.TID 0000.0001) %MON dynstat_wvel_sd              =   3.0248354192119E-03
-(PID.TID 0000.0001) %MON dynstat_wvel_del2            =   2.1843545643842E-05
-(PID.TID 0000.0001) %MON dynstat_theta_max            =   7.0373814845843E-01
+(PID.TID 0000.0001) %MON dynstat_wvel_mean            =   2.5793404753835E-05
+(PID.TID 0000.0001) %MON dynstat_wvel_sd              =   3.0248354192047E-03
+(PID.TID 0000.0001) %MON dynstat_wvel_del2            =   2.1843545643426E-05
+(PID.TID 0000.0001) %MON dynstat_theta_max            =   7.0373814859710E-01
 (PID.TID 0000.0001) %MON dynstat_theta_min            =  -7.0288006967436E-01
-(PID.TID 0000.0001) %MON dynstat_theta_mean           =   2.0261903100532E-02
-(PID.TID 0000.0001) %MON dynstat_theta_sd             =   4.5211070103324E-01
-(PID.TID 0000.0001) %MON dynstat_theta_del2           =   9.6153474314746E-06
+(PID.TID 0000.0001) %MON dynstat_theta_mean           =   2.0261903100533E-02
+(PID.TID 0000.0001) %MON dynstat_theta_sd             =   4.5211070103714E-01
+(PID.TID 0000.0001) %MON dynstat_theta_del2           =   9.6153473742743E-06
 (PID.TID 0000.0001) %MON dynstat_salt_max             =   3.5001621471611E+01
 (PID.TID 0000.0001) %MON dynstat_salt_min             =   3.4999969725851E+01
 (PID.TID 0000.0001) %MON dynstat_salt_mean            =   3.5000021257204E+01
 (PID.TID 0000.0001) %MON dynstat_salt_sd              =   1.8595520652836E-04
 (PID.TID 0000.0001) %MON dynstat_salt_del2            =   1.5510192750299E-05
-(PID.TID 0000.0001) %MON advcfl_uvel_max              =   9.5126570342585E-02
+(PID.TID 0000.0001) %MON trAdv_CFL_u_max              =   6.8518376808594E-02
+(PID.TID 0000.0001) %MON trAdv_CFL_v_max              =   1.0907443645892E-02
+(PID.TID 0000.0001) %MON trAdv_CFL_w_max              =   4.9184762576533E-02
+(PID.TID 0000.0001) %MON advcfl_uvel_max              =   9.5126570342582E-02
 (PID.TID 0000.0001) %MON advcfl_vvel_max              =   1.7067115844736E-02
-(PID.TID 0000.0001) %MON advcfl_wvel_max              =   2.9520259915120E-02
-(PID.TID 0000.0001) %MON advcfl_W_hf_max              =   6.6213593726667E-02
-(PID.TID 0000.0001) %MON pe_b_mean                    =   2.4556421876414E-03
-(PID.TID 0000.0001) %MON ke_max                       =   3.0811607468476E-01
-(PID.TID 0000.0001) %MON ke_mean                      =   5.1100668080967E-02
+(PID.TID 0000.0001) %MON advcfl_wvel_max              =   2.9520259915119E-02
+(PID.TID 0000.0001) %MON advcfl_W_hf_max              =   6.6213593726663E-02
+(PID.TID 0000.0001) %MON pe_b_mean                    =   2.4556421876421E-03
+(PID.TID 0000.0001) %MON ke_max                       =   3.0811607468474E-01
+(PID.TID 0000.0001) %MON ke_mean                      =   5.1100668080962E-02
 (PID.TID 0000.0001) %MON ke_vol                       =   3.3507127984312E+14
 (PID.TID 0000.0001) %MON vort_r_min                   =  -1.6341653255468E-04
 (PID.TID 0000.0001) %MON vort_r_max                   =   1.6284624799525E-04
 (PID.TID 0000.0001) %MON vort_a_mean                  =   1.0000000000000E-04
-(PID.TID 0000.0001) %MON vort_a_sd                    =   9.0309403981422E-06
+(PID.TID 0000.0001) %MON vort_a_sd                    =   9.0309403981431E-06
 (PID.TID 0000.0001) %MON vort_p_mean                  =   1.0161982423688E-04
 (PID.TID 0000.0001) %MON vort_p_sd                    =   3.7791452581473E-05
-(PID.TID 0000.0001) %MON surfExpan_theta_mean         =   3.4938340020790E-05
+(PID.TID 0000.0001) %MON surfExpan_theta_mean         =   3.4938340002628E-05
 (PID.TID 0000.0001) %MON surfExpan_salt_mean          =   1.6826315246875E-03
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // End MONITOR dynamic field statistics
 (PID.TID 0000.0001) // =======================================================
  EXTERNAL_FIELDS_LOAD,         3 : iP,iLd,i0,i1=    1    2    1    2 ; Wght=  0.9166666667  0.0833333333
  OBCS_FIELDS_LOAD,         4 : iP,iLd,i0,i1=    1    2    1    2 ; Wght=  0.8888888889  0.1111111111
- cg2d: Sum(rhs),rhsMax =  -2.36649262599794E+01  2.42584349415400E-01
-(PID.TID 0000.0001)      cg2d_init_res =   9.05023495367879E+00
+ cg2d: Sum(rhs),rhsMax =  -2.36649262599790E+01  2.42584349415405E-01
+(PID.TID 0000.0001)      cg2d_init_res =   9.05023495169662E+00
 (PID.TID 0000.0001)      cg2d_iters(min,last) =      -1     198
-(PID.TID 0000.0001)      cg2d_last_res =   8.19336255395881E-14
+(PID.TID 0000.0001)      cg2d_last_res =   8.19361920240511E-14
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // Begin MONITOR dynamic field statistics
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) %MON time_tsnumber                =                     4
 (PID.TID 0000.0001) %MON time_secondsf                =   1.3200000000000E+04
-(PID.TID 0000.0001) %MON dynstat_eta_max              =   6.5947763973701E-01
-(PID.TID 0000.0001) %MON dynstat_eta_min              =  -4.1734730792632E-01
+(PID.TID 0000.0001) %MON dynstat_eta_max              =   6.5947763973439E-01
+(PID.TID 0000.0001) %MON dynstat_eta_min              =  -4.1734730792781E-01
 (PID.TID 0000.0001) %MON dynstat_eta_mean             =   1.1923076923076E-01
-(PID.TID 0000.0001) %MON dynstat_eta_sd               =   2.6692710503626E-01
-(PID.TID 0000.0001) %MON dynstat_eta_del2             =   2.4382830610833E-05
-(PID.TID 0000.0001) %MON dynstat_uvel_max             =   8.1181777715730E-01
-(PID.TID 0000.0001) %MON dynstat_uvel_min             =   2.3233780391716E-01
-(PID.TID 0000.0001) %MON dynstat_uvel_mean            =   3.1794670311697E-01
-(PID.TID 0000.0001) %MON dynstat_uvel_sd              =   5.9942931180213E-02
-(PID.TID 0000.0001) %MON dynstat_uvel_del2            =   1.5141310916907E-04
-(PID.TID 0000.0001) %MON dynstat_vvel_max             =   1.1053419115770E-01
-(PID.TID 0000.0001) %MON dynstat_vvel_min             =  -1.7488295147043E-01
-(PID.TID 0000.0001) %MON dynstat_vvel_mean            =  -4.9464175327905E-04
-(PID.TID 0000.0001) %MON dynstat_vvel_sd              =   2.6670927300069E-02
-(PID.TID 0000.0001) %MON dynstat_vvel_del2            =   2.4597409903588E-05
-(PID.TID 0000.0001) %MON dynstat_wvel_max             =   2.7933879085796E-02
-(PID.TID 0000.0001) %MON dynstat_wvel_min             =  -2.7424245949120E-02
-(PID.TID 0000.0001) %MON dynstat_wvel_mean            =   2.1792828696503E-05
-(PID.TID 0000.0001) %MON dynstat_wvel_sd              =   2.9109813712745E-03
-(PID.TID 0000.0001) %MON dynstat_wvel_del2            =   1.4840169436484E-05
-(PID.TID 0000.0001) %MON dynstat_theta_max            =   7.0264578637712E-01
+(PID.TID 0000.0001) %MON dynstat_eta_sd               =   2.6692710503662E-01
+(PID.TID 0000.0001) %MON dynstat_eta_del2             =   2.4382830610045E-05
+(PID.TID 0000.0001) %MON dynstat_uvel_max             =   8.1181777715724E-01
+(PID.TID 0000.0001) %MON dynstat_uvel_min             =   2.3233780390415E-01
+(PID.TID 0000.0001) %MON dynstat_uvel_mean            =   3.1794670311694E-01
+(PID.TID 0000.0001) %MON dynstat_uvel_sd              =   5.9942931180193E-02
+(PID.TID 0000.0001) %MON dynstat_uvel_del2            =   1.5141310916249E-04
+(PID.TID 0000.0001) %MON dynstat_vvel_max             =   1.1053419115769E-01
+(PID.TID 0000.0001) %MON dynstat_vvel_min             =  -1.7488295147042E-01
+(PID.TID 0000.0001) %MON dynstat_vvel_mean            =  -4.9464175327882E-04
+(PID.TID 0000.0001) %MON dynstat_vvel_sd              =   2.6670927300067E-02
+(PID.TID 0000.0001) %MON dynstat_vvel_del2            =   2.4597409903601E-05
+(PID.TID 0000.0001) %MON dynstat_wvel_max             =   2.7933879085793E-02
+(PID.TID 0000.0001) %MON dynstat_wvel_min             =  -2.7424245949119E-02
+(PID.TID 0000.0001) %MON dynstat_wvel_mean            =   2.1792828696504E-05
+(PID.TID 0000.0001) %MON dynstat_wvel_sd              =   2.9109813712506E-03
+(PID.TID 0000.0001) %MON dynstat_wvel_del2            =   1.4840169434475E-05
+(PID.TID 0000.0001) %MON dynstat_theta_max            =   7.0264578656354E-01
 (PID.TID 0000.0001) %MON dynstat_theta_min            =  -7.0720251941573E-01
-(PID.TID 0000.0001) %MON dynstat_theta_mean           =   2.0252627664805E-02
-(PID.TID 0000.0001) %MON dynstat_theta_sd             =   4.5210635724825E-01
-(PID.TID 0000.0001) %MON dynstat_theta_del2           =   7.6718075724159E-06
+(PID.TID 0000.0001) %MON dynstat_theta_mean           =   2.0252627664815E-02
+(PID.TID 0000.0001) %MON dynstat_theta_sd             =   4.5210635725412E-01
+(PID.TID 0000.0001) %MON dynstat_theta_del2           =   7.6718074633009E-06
 (PID.TID 0000.0001) %MON dynstat_salt_max             =   3.5002722021623E+01
 (PID.TID 0000.0001) %MON dynstat_salt_min             =   3.4999987950315E+01
 (PID.TID 0000.0001) %MON dynstat_salt_mean            =   3.5000035852385E+01
-(PID.TID 0000.0001) %MON dynstat_salt_sd              =   3.0906582027802E-04
+(PID.TID 0000.0001) %MON dynstat_salt_sd              =   3.0906582027803E-04
 (PID.TID 0000.0001) %MON dynstat_salt_del2            =   1.9030584030912E-05
-(PID.TID 0000.0001) %MON advcfl_uvel_max              =   9.7418133258876E-02
-(PID.TID 0000.0001) %MON advcfl_vvel_max              =   2.0985954176451E-02
-(PID.TID 0000.0001) %MON advcfl_wvel_max              =   2.9796137691516E-02
-(PID.TID 0000.0001) %MON advcfl_W_hf_max              =   6.5534917903256E-02
-(PID.TID 0000.0001) %MON pe_b_mean                    =   9.7586574052935E-05
-(PID.TID 0000.0001) %MON ke_max                       =   3.2706619896990E-01
-(PID.TID 0000.0001) %MON ke_mean                      =   5.2791214882085E-02
+(PID.TID 0000.0001) %MON trAdv_CFL_u_max              =   9.5126570342582E-02
+(PID.TID 0000.0001) %MON trAdv_CFL_v_max              =   1.7067115844736E-02
+(PID.TID 0000.0001) %MON trAdv_CFL_w_max              =   6.6213593726663E-02
+(PID.TID 0000.0001) %MON advcfl_uvel_max              =   9.7418133258869E-02
+(PID.TID 0000.0001) %MON advcfl_vvel_max              =   2.0985954176450E-02
+(PID.TID 0000.0001) %MON advcfl_wvel_max              =   2.9796137691513E-02
+(PID.TID 0000.0001) %MON advcfl_W_hf_max              =   6.5534917903248E-02
+(PID.TID 0000.0001) %MON pe_b_mean                    =   9.7586574053157E-05
+(PID.TID 0000.0001) %MON ke_max                       =   3.2706619896985E-01
+(PID.TID 0000.0001) %MON ke_mean                      =   5.2791214882073E-02
 (PID.TID 0000.0001) %MON ke_vol                       =   3.3507127984312E+14
-(PID.TID 0000.0001) %MON vort_r_min                   =  -1.6715618290542E-04
-(PID.TID 0000.0001) %MON vort_r_max                   =   1.6564249921238E-04
+(PID.TID 0000.0001) %MON vort_r_min                   =  -1.6715618290540E-04
+(PID.TID 0000.0001) %MON vort_r_max                   =   1.6564249921236E-04
 (PID.TID 0000.0001) %MON vort_a_mean                  =   1.0000000000000E-04
-(PID.TID 0000.0001) %MON vort_a_sd                    =   9.1307311791736E-06
+(PID.TID 0000.0001) %MON vort_a_sd                    =   9.1307311791725E-06
 (PID.TID 0000.0001) %MON vort_p_mean                  =   1.0161982423688E-04
-(PID.TID 0000.0001) %MON vort_p_sd                    =   3.7736698096531E-05
-(PID.TID 0000.0001) %MON surfExpan_theta_mean         =   3.2176646714989E-05
+(PID.TID 0000.0001) %MON vort_p_sd                    =   3.7736698096529E-05
+(PID.TID 0000.0001) %MON surfExpan_theta_mean         =   3.2176646687999E-05
 (PID.TID 0000.0001) %MON surfExpan_salt_mean          =   1.5704131002607E-03
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // End MONITOR dynamic field statistics
@@ -2015,15 +2070,15 @@
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) %MON obc_time_tsnumber            =                     4
 (PID.TID 0000.0001) %MON obc_time_secondsf            =   1.3200000000000E+04
-(PID.TID 0000.0001) %MON obc_E_uVel_max               =   2.4998844415194E-01
-(PID.TID 0000.0001) %MON obc_E_uVel_min               =   2.4435553026367E-01
+(PID.TID 0000.0001) %MON obc_E_uVel_max               =   2.4998844431000E-01
+(PID.TID 0000.0001) %MON obc_E_uVel_min               =   2.4435552978948E-01
 (PID.TID 0000.0001) %MON obc_E_uVel_mean              =   2.4805555555556E-01
-(PID.TID 0000.0001) %MON obc_E_uVel_sd                =   1.5740219120249E-03
+(PID.TID 0000.0001) %MON obc_E_uVel_sd                =   1.5740221355762E-03
 (PID.TID 0000.0001) %MON obc_E_uVel_Int               =   2.2324999999999E+08
-(PID.TID 0000.0001) %MON obc_W_uVel_max               =   2.5302717021776E-01
-(PID.TID 0000.0001) %MON obc_W_uVel_min               =   2.4720627315589E-01
+(PID.TID 0000.0001) %MON obc_W_uVel_max               =   2.5302717006222E-01
+(PID.TID 0000.0001) %MON obc_W_uVel_min               =   2.4720627362251E-01
 (PID.TID 0000.0001) %MON obc_W_uVel_mean              =   2.5194444444444E-01
-(PID.TID 0000.0001) %MON obc_W_uVel_sd                =   1.7834301711099E-03
+(PID.TID 0000.0001) %MON obc_W_uVel_sd                =   1.7834299972242E-03
 (PID.TID 0000.0001) %MON obc_W_uVel_Int               =   2.2674999999999E+08
 (PID.TID 0000.0001) %MON obc_N_vVel_max               =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON obc_N_vVel_min               =   0.0000000000000E+00
@@ -2035,14 +2090,14 @@
 (PID.TID 0000.0001) %MON obc_S_vVel_mean              =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON obc_S_vVel_sd                =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON obc_S_vVel_Int               =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON obc_E_theta_max              =   7.0153993010255E-01
-(PID.TID 0000.0001) %MON obc_E_theta_min              =  -6.9620095611107E-01
-(PID.TID 0000.0001) %MON obc_E_theta_mean             =   4.8171608434915E-03
-(PID.TID 0000.0001) %MON obc_E_theta_sd               =   4.5823335666418E-01
-(PID.TID 0000.0001) %MON obc_W_theta_max              =   6.9288796632503E-01
-(PID.TID 0000.0001) %MON obc_W_theta_min              =  -6.9751748068732E-01
-(PID.TID 0000.0001) %MON obc_W_theta_mean             =  -4.5025258781025E-03
-(PID.TID 0000.0001) %MON obc_W_theta_sd               =   4.5432783209336E-01
+(PID.TID 0000.0001) %MON obc_E_theta_max              =   7.0153994016009E-01
+(PID.TID 0000.0001) %MON obc_E_theta_min              =  -6.9620096354144E-01
+(PID.TID 0000.0001) %MON obc_E_theta_mean             =   4.8171611259729E-03
+(PID.TID 0000.0001) %MON obc_E_theta_sd               =   4.5823336014133E-01
+(PID.TID 0000.0001) %MON obc_W_theta_max              =   6.9288797680910E-01
+(PID.TID 0000.0001) %MON obc_W_theta_min              =  -6.9751748847676E-01
+(PID.TID 0000.0001) %MON obc_W_theta_mean             =  -4.5025255620568E-03
+(PID.TID 0000.0001) %MON obc_W_theta_sd               =   4.5432783556459E-01
 (PID.TID 0000.0001) %MON obc_N_theta_max              =   6.9683400000000E-01
 (PID.TID 0000.0001) %MON obc_N_theta_min              =  -6.9683400000000E-01
 (PID.TID 0000.0001) %MON obc_N_theta_mean             =   5.0183265503355E-05
@@ -2056,120 +2111,126 @@
 (PID.TID 0000.0001) // =======================================================
  EXTERNAL_FIELDS_LOAD,         4 : iP,iLd,i0,i1=    1    2    1    2 ; Wght=  0.8888888889  0.1111111111
  OBCS_FIELDS_LOAD,         5 : iP,iLd,i0,i1=    1    2    1    2 ; Wght=  0.8611111111  0.1388888889
- cg2d: Sum(rhs),rhsMax =  -3.15533229850151E+01  2.20085993723772E-01
-(PID.TID 0000.0001)      cg2d_init_res =   5.70088023219849E+00
+ cg2d: Sum(rhs),rhsMax =  -3.15533229850174E+01  2.20085993723755E-01
+(PID.TID 0000.0001)      cg2d_init_res =   5.70088023249983E+00
 (PID.TID 0000.0001)      cg2d_iters(min,last) =      -1     196
-(PID.TID 0000.0001)      cg2d_last_res =   9.91946682390492E-14
+(PID.TID 0000.0001)      cg2d_last_res =   9.91949841455253E-14
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // Begin MONITOR dynamic field statistics
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) %MON time_tsnumber                =                     5
 (PID.TID 0000.0001) %MON time_secondsf                =   1.3800000000000E+04
-(PID.TID 0000.0001) %MON dynstat_eta_max              =   1.2528493347021E+00
-(PID.TID 0000.0001) %MON dynstat_eta_min              =  -9.6367989985312E-01
+(PID.TID 0000.0001) %MON dynstat_eta_max              =   1.2528493347212E+00
+(PID.TID 0000.0001) %MON dynstat_eta_min              =  -9.6367989975152E-01
 (PID.TID 0000.0001) %MON dynstat_eta_mean             =   1.4423076923076E-01
-(PID.TID 0000.0001) %MON dynstat_eta_sd               =   6.2329523098249E-01
-(PID.TID 0000.0001) %MON dynstat_eta_del2             =   3.4139725379645E-05
-(PID.TID 0000.0001) %MON dynstat_uvel_max             =   7.0884574599254E-01
-(PID.TID 0000.0001) %MON dynstat_uvel_min             =   1.9266710247682E-01
-(PID.TID 0000.0001) %MON dynstat_uvel_mean            =   2.9448780941349E-01
-(PID.TID 0000.0001) %MON dynstat_uvel_sd              =   4.7418105670257E-02
-(PID.TID 0000.0001) %MON dynstat_uvel_del2            =   1.1090837271111E-04
-(PID.TID 0000.0001) %MON dynstat_vvel_max             =   9.7393876548514E-02
-(PID.TID 0000.0001) %MON dynstat_vvel_min             =  -2.0199789887876E-01
-(PID.TID 0000.0001) %MON dynstat_vvel_mean            =   4.2953353933341E-04
-(PID.TID 0000.0001) %MON dynstat_vvel_sd              =   2.4646417301858E-02
-(PID.TID 0000.0001) %MON dynstat_vvel_del2            =   2.5819418313666E-05
-(PID.TID 0000.0001) %MON dynstat_wvel_max             =   2.4405392647130E-02
-(PID.TID 0000.0001) %MON dynstat_wvel_min             =  -2.5216998318045E-02
-(PID.TID 0000.0001) %MON dynstat_wvel_mean            =   1.8762638862364E-05
-(PID.TID 0000.0001) %MON dynstat_wvel_sd              =   2.6306394099857E-03
-(PID.TID 0000.0001) %MON dynstat_wvel_del2            =   1.9027959618959E-05
+(PID.TID 0000.0001) %MON dynstat_eta_sd               =   6.2329523098110E-01
+(PID.TID 0000.0001) %MON dynstat_eta_del2             =   3.4139725395140E-05
+(PID.TID 0000.0001) %MON dynstat_uvel_max             =   7.0884574599244E-01
+(PID.TID 0000.0001) %MON dynstat_uvel_min             =   1.9266710247680E-01
+(PID.TID 0000.0001) %MON dynstat_uvel_mean            =   2.9448780941346E-01
+(PID.TID 0000.0001) %MON dynstat_uvel_sd              =   4.7418105670191E-02
+(PID.TID 0000.0001) %MON dynstat_uvel_del2            =   1.1090837268611E-04
+(PID.TID 0000.0001) %MON dynstat_vvel_max             =   9.7393876548503E-02
+(PID.TID 0000.0001) %MON dynstat_vvel_min             =  -2.0199789887874E-01
+(PID.TID 0000.0001) %MON dynstat_vvel_mean            =   4.2953353933369E-04
+(PID.TID 0000.0001) %MON dynstat_vvel_sd              =   2.4646417301854E-02
+(PID.TID 0000.0001) %MON dynstat_vvel_del2            =   2.5819418313722E-05
+(PID.TID 0000.0001) %MON dynstat_wvel_max             =   2.4405392647126E-02
+(PID.TID 0000.0001) %MON dynstat_wvel_min             =  -2.5216998318043E-02
+(PID.TID 0000.0001) %MON dynstat_wvel_mean            =   1.8762638855559E-05
+(PID.TID 0000.0001) %MON dynstat_wvel_sd              =   2.6306394099244E-03
+(PID.TID 0000.0001) %MON dynstat_wvel_del2            =   1.9027959615322E-05
 (PID.TID 0000.0001) %MON dynstat_theta_max            =   7.0473972713694E-01
 (PID.TID 0000.0001) %MON dynstat_theta_min            =  -7.1065805514652E-01
-(PID.TID 0000.0001) %MON dynstat_theta_mean           =   2.0246177749184E-02
-(PID.TID 0000.0001) %MON dynstat_theta_sd             =   4.5210290220482E-01
-(PID.TID 0000.0001) %MON dynstat_theta_del2           =   8.3669862765730E-06
-(PID.TID 0000.0001) %MON dynstat_salt_max             =   3.5003991633995E+01
+(PID.TID 0000.0001) %MON dynstat_theta_mean           =   2.0246177749524E-02
+(PID.TID 0000.0001) %MON dynstat_theta_sd             =   4.5210290221325E-01
+(PID.TID 0000.0001) %MON dynstat_theta_del2           =   8.3669861946404E-06
+(PID.TID 0000.0001) %MON dynstat_salt_max             =   3.5003991633996E+01
 (PID.TID 0000.0001) %MON dynstat_salt_min             =   3.4999980399064E+01
 (PID.TID 0000.0001) %MON dynstat_salt_mean            =   3.5000053870450E+01
-(PID.TID 0000.0001) %MON dynstat_salt_sd              =   4.5769211760797E-04
-(PID.TID 0000.0001) %MON dynstat_salt_del2            =   2.2238788359487E-05
-(PID.TID 0000.0001) %MON advcfl_uvel_max              =   8.5061489519105E-02
-(PID.TID 0000.0001) %MON advcfl_vvel_max              =   2.4239747865451E-02
-(PID.TID 0000.0001) %MON advcfl_wvel_max              =   2.6898131539248E-02
-(PID.TID 0000.0001) %MON advcfl_W_hf_max              =   5.4294919068979E-02
-(PID.TID 0000.0001) %MON pe_b_mean                    =   4.6734497920050E-04
-(PID.TID 0000.0001) %MON ke_max                       =   2.5579273352193E-01
-(PID.TID 0000.0001) %MON ke_mean                      =   4.4805507097352E-02
+(PID.TID 0000.0001) %MON dynstat_salt_sd              =   4.5769211760785E-04
+(PID.TID 0000.0001) %MON dynstat_salt_del2            =   2.2238788359486E-05
+(PID.TID 0000.0001) %MON trAdv_CFL_u_max              =   9.7418133258869E-02
+(PID.TID 0000.0001) %MON trAdv_CFL_v_max              =   2.0985954176450E-02
+(PID.TID 0000.0001) %MON trAdv_CFL_w_max              =   6.5534917903248E-02
+(PID.TID 0000.0001) %MON advcfl_uvel_max              =   8.5061489519093E-02
+(PID.TID 0000.0001) %MON advcfl_vvel_max              =   2.4239747865449E-02
+(PID.TID 0000.0001) %MON advcfl_wvel_max              =   2.6898131539246E-02
+(PID.TID 0000.0001) %MON advcfl_W_hf_max              =   5.4294919068970E-02
+(PID.TID 0000.0001) %MON pe_b_mean                    =   4.6734497919853E-04
+(PID.TID 0000.0001) %MON ke_max                       =   2.5579273352187E-01
+(PID.TID 0000.0001) %MON ke_mean                      =   4.4805507097338E-02
 (PID.TID 0000.0001) %MON ke_vol                       =   3.3507127984312E+14
-(PID.TID 0000.0001) %MON vort_r_min                   =  -1.4543677620008E-04
-(PID.TID 0000.0001) %MON vort_r_max                   =   1.4319611151842E-04
+(PID.TID 0000.0001) %MON vort_r_min                   =  -1.4543677620006E-04
+(PID.TID 0000.0001) %MON vort_r_max                   =   1.4319611151840E-04
 (PID.TID 0000.0001) %MON vort_a_mean                  =   1.0000000000000E-04
-(PID.TID 0000.0001) %MON vort_a_sd                    =   7.5207195328049E-06
+(PID.TID 0000.0001) %MON vort_a_sd                    =   7.5207195328056E-06
 (PID.TID 0000.0001) %MON vort_p_mean                  =   1.0161982423688E-04
-(PID.TID 0000.0001) %MON vort_p_sd                    =   3.5417560671148E-05
-(PID.TID 0000.0001) %MON surfExpan_theta_mean         =   2.9332143092370E-05
+(PID.TID 0000.0001) %MON vort_p_sd                    =   3.5417560671147E-05
+(PID.TID 0000.0001) %MON surfExpan_theta_mean         =   2.9332143069919E-05
 (PID.TID 0000.0001) %MON surfExpan_salt_mean          =   1.4582495818380E-03
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // End MONITOR dynamic field statistics
 (PID.TID 0000.0001) // =======================================================
  EXTERNAL_FIELDS_LOAD,         5 : iP,iLd,i0,i1=    1    2    1    2 ; Wght=  0.8611111111  0.1388888889
  OBCS_FIELDS_LOAD,         6 : iP,iLd,i0,i1=    1    2    1    2 ; Wght=  0.8333333333  0.1666666667
- cg2d: Sum(rhs),rhsMax =  -4.45115477105028E+01  1.80976757041735E-01
-(PID.TID 0000.0001)      cg2d_init_res =   2.13675776677202E+00
+ cg2d: Sum(rhs),rhsMax =  -4.45115477105138E+01  1.80976757041691E-01
+(PID.TID 0000.0001)      cg2d_init_res =   2.13675776561102E+00
 (PID.TID 0000.0001)      cg2d_iters(min,last) =      -1     198
-(PID.TID 0000.0001)      cg2d_last_res =   7.75788825873846E-14
+(PID.TID 0000.0001)      cg2d_last_res =   7.75789492887883E-14
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // Begin MONITOR dynamic field statistics
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) %MON time_tsnumber                =                     6
 (PID.TID 0000.0001) %MON time_secondsf                =   1.4400000000000E+04
-(PID.TID 0000.0001) %MON dynstat_eta_max              =   1.3865760804496E+00
-(PID.TID 0000.0001) %MON dynstat_eta_min              =  -1.0535433060695E+00
+(PID.TID 0000.0001) %MON dynstat_eta_max              =   1.3865760804862E+00
+(PID.TID 0000.0001) %MON dynstat_eta_min              =  -1.0535433059213E+00
 (PID.TID 0000.0001) %MON dynstat_eta_mean             =   1.6730769230769E-01
-(PID.TID 0000.0001) %MON dynstat_eta_sd               =   7.1559524389264E-01
-(PID.TID 0000.0001) %MON dynstat_eta_del2             =   3.8640313178985E-05
-(PID.TID 0000.0001) %MON dynstat_uvel_max             =   5.8907113018079E-01
-(PID.TID 0000.0001) %MON dynstat_uvel_min             =   1.4817733390012E-01
-(PID.TID 0000.0001) %MON dynstat_uvel_mean            =   2.6717572347589E-01
-(PID.TID 0000.0001) %MON dynstat_uvel_sd              =   3.3906295515041E-02
-(PID.TID 0000.0001) %MON dynstat_uvel_del2            =   6.4519012208782E-05
-(PID.TID 0000.0001) %MON dynstat_vvel_max             =   8.8094085177315E-02
-(PID.TID 0000.0001) %MON dynstat_vvel_min             =  -2.2580540567632E-01
-(PID.TID 0000.0001) %MON dynstat_vvel_mean            =   6.9316419854500E-04
-(PID.TID 0000.0001) %MON dynstat_vvel_sd              =   2.2299922776732E-02
-(PID.TID 0000.0001) %MON dynstat_vvel_del2            =   2.6505383852186E-05
-(PID.TID 0000.0001) %MON dynstat_wvel_max             =   2.1672946763068E-02
-(PID.TID 0000.0001) %MON dynstat_wvel_min             =  -2.3220495185670E-02
-(PID.TID 0000.0001) %MON dynstat_wvel_mean            =   1.7330059737698E-05
-(PID.TID 0000.0001) %MON dynstat_wvel_sd              =   2.0779122365820E-03
-(PID.TID 0000.0001) %MON dynstat_wvel_del2            =   1.0965870295642E-05
+(PID.TID 0000.0001) %MON dynstat_eta_sd               =   7.1559524389050E-01
+(PID.TID 0000.0001) %MON dynstat_eta_del2             =   3.8640313198189E-05
+(PID.TID 0000.0001) %MON dynstat_uvel_max             =   5.8907113018068E-01
+(PID.TID 0000.0001) %MON dynstat_uvel_min             =   1.4817733390011E-01
+(PID.TID 0000.0001) %MON dynstat_uvel_mean            =   2.6717572347585E-01
+(PID.TID 0000.0001) %MON dynstat_uvel_sd              =   3.3906295514920E-02
+(PID.TID 0000.0001) %MON dynstat_uvel_del2            =   6.4519012156404E-05
+(PID.TID 0000.0001) %MON dynstat_vvel_max             =   8.8094085177301E-02
+(PID.TID 0000.0001) %MON dynstat_vvel_min             =  -2.2580540567630E-01
+(PID.TID 0000.0001) %MON dynstat_vvel_mean            =   6.9316419854502E-04
+(PID.TID 0000.0001) %MON dynstat_vvel_sd              =   2.2299922776726E-02
+(PID.TID 0000.0001) %MON dynstat_vvel_del2            =   2.6505383852350E-05
+(PID.TID 0000.0001) %MON dynstat_wvel_max             =   2.1672946763064E-02
+(PID.TID 0000.0001) %MON dynstat_wvel_min             =  -2.3220495185668E-02
+(PID.TID 0000.0001) %MON dynstat_wvel_mean            =   1.7330059373910E-05
+(PID.TID 0000.0001) %MON dynstat_wvel_sd              =   2.0779122364241E-03
+(PID.TID 0000.0001) %MON dynstat_wvel_del2            =   1.0965870282338E-05
 (PID.TID 0000.0001) %MON dynstat_theta_max            =   7.0642156564055E-01
 (PID.TID 0000.0001) %MON dynstat_theta_min            =  -7.1298621782004E-01
-(PID.TID 0000.0001) %MON dynstat_theta_mean           =   2.0240026640861E-02
-(PID.TID 0000.0001) %MON dynstat_theta_sd             =   4.5209951191646E-01
-(PID.TID 0000.0001) %MON dynstat_theta_del2           =   9.4642253581287E-06
-(PID.TID 0000.0001) %MON dynstat_salt_max             =   3.5005551766511E+01
+(PID.TID 0000.0001) %MON dynstat_theta_mean           =   2.0240026641344E-02
+(PID.TID 0000.0001) %MON dynstat_theta_sd             =   4.5209951192832E-01
+(PID.TID 0000.0001) %MON dynstat_theta_del2           =   9.4642253147435E-06
+(PID.TID 0000.0001) %MON dynstat_salt_max             =   3.5005551766514E+01
 (PID.TID 0000.0001) %MON dynstat_salt_min             =   3.4999972935502E+01
 (PID.TID 0000.0001) %MON dynstat_salt_mean            =   3.5000075249593E+01
-(PID.TID 0000.0001) %MON dynstat_salt_sd              =   6.3039529770827E-04
-(PID.TID 0000.0001) %MON dynstat_salt_del2            =   2.5163407457383E-05
-(PID.TID 0000.0001) %MON advcfl_uvel_max              =   7.0688535621695E-02
-(PID.TID 0000.0001) %MON advcfl_vvel_max              =   2.7096648681158E-02
-(PID.TID 0000.0001) %MON advcfl_wvel_max              =   2.4768528198048E-02
-(PID.TID 0000.0001) %MON advcfl_W_hf_max              =   4.1902705875856E-02
-(PID.TID 0000.0001) %MON pe_b_mean                    =   6.1665916503447E-04
-(PID.TID 0000.0001) %MON ke_max                       =   1.8518286745770E-01
-(PID.TID 0000.0001) %MON ke_mean                      =   3.6451254214078E-02
+(PID.TID 0000.0001) %MON dynstat_salt_sd              =   6.3039529770825E-04
+(PID.TID 0000.0001) %MON dynstat_salt_del2            =   2.5163407457380E-05
+(PID.TID 0000.0001) %MON trAdv_CFL_u_max              =   8.4919925033885E-02
+(PID.TID 0000.0001) %MON trAdv_CFL_v_max              =   2.4239747865449E-02
+(PID.TID 0000.0001) %MON trAdv_CFL_w_max              =   5.4294919068970E-02
+(PID.TID 0000.0001) %MON advcfl_uvel_max              =   7.0688535621682E-02
+(PID.TID 0000.0001) %MON advcfl_vvel_max              =   2.7096648681156E-02
+(PID.TID 0000.0001) %MON advcfl_wvel_max              =   2.4768528198046E-02
+(PID.TID 0000.0001) %MON advcfl_W_hf_max              =   4.1902705875846E-02
+(PID.TID 0000.0001) %MON pe_b_mean                    =   6.1665916503097E-04
+(PID.TID 0000.0001) %MON ke_max                       =   1.8518286745765E-01
+(PID.TID 0000.0001) %MON ke_mean                      =   3.6451254214061E-02
 (PID.TID 0000.0001) %MON ke_vol                       =   3.3507127984312E+14
-(PID.TID 0000.0001) %MON vort_r_min                   =  -1.2046495523440E-04
-(PID.TID 0000.0001) %MON vort_r_max                   =   1.1785917116913E-04
+(PID.TID 0000.0001) %MON vort_r_min                   =  -1.2046495523438E-04
+(PID.TID 0000.0001) %MON vort_r_max                   =   1.1785917116911E-04
 (PID.TID 0000.0001) %MON vort_a_mean                  =   1.0000000000000E-04
-(PID.TID 0000.0001) %MON vort_a_sd                    =   5.8837648247482E-06
+(PID.TID 0000.0001) %MON vort_a_sd                    =   5.8837648247460E-06
 (PID.TID 0000.0001) %MON vort_p_mean                  =   1.0161982423688E-04
-(PID.TID 0000.0001) %MON vort_p_sd                    =   3.3265544965491E-05
-(PID.TID 0000.0001) %MON surfExpan_theta_mean         =   2.6832648711472E-05
+(PID.TID 0000.0001) %MON vort_p_sd                    =   3.3265544965489E-05
+(PID.TID 0000.0001) %MON surfExpan_theta_mean         =   2.6832648707773E-05
 (PID.TID 0000.0001) %MON surfExpan_salt_mean          =   1.3461392586174E-03
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // End MONITOR dynamic field statistics
@@ -2179,15 +2240,15 @@
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) %MON obc_time_tsnumber            =                     6
 (PID.TID 0000.0001) %MON obc_time_secondsf            =   1.4400000000000E+04
-(PID.TID 0000.0001) %MON obc_E_uVel_max               =   2.5171659195439E-01
-(PID.TID 0000.0001) %MON obc_E_uVel_min               =   2.4357143137396E-01
+(PID.TID 0000.0001) %MON obc_E_uVel_max               =   2.5171659226348E-01
+(PID.TID 0000.0001) %MON obc_E_uVel_min               =   2.4357143054611E-01
 (PID.TID 0000.0001) %MON obc_E_uVel_mean              =   2.4833333333333E-01
-(PID.TID 0000.0001) %MON obc_E_uVel_sd                =   2.3789180223115E-03
+(PID.TID 0000.0001) %MON obc_E_uVel_sd                =   2.3789184404606E-03
 (PID.TID 0000.0001) %MON obc_E_uVel_Int               =   2.2349999999999E+08
-(PID.TID 0000.0001) %MON obc_W_uVel_max               =   2.5404960093816E-01
-(PID.TID 0000.0001) %MON obc_W_uVel_min               =   2.4564616924429E-01
+(PID.TID 0000.0001) %MON obc_W_uVel_max               =   2.5404960064326E-01
+(PID.TID 0000.0001) %MON obc_W_uVel_min               =   2.4564617001391E-01
 (PID.TID 0000.0001) %MON obc_W_uVel_mean              =   2.5166666666667E-01
-(PID.TID 0000.0001) %MON obc_W_uVel_sd                =   2.3342271329955E-03
+(PID.TID 0000.0001) %MON obc_W_uVel_sd                =   2.3342268056179E-03
 (PID.TID 0000.0001) %MON obc_W_uVel_Int               =   2.2649999999999E+08
 (PID.TID 0000.0001) %MON obc_N_vVel_max               =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON obc_N_vVel_min               =   0.0000000000000E+00
@@ -2199,14 +2260,14 @@
 (PID.TID 0000.0001) %MON obc_S_vVel_mean              =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON obc_S_vVel_sd                =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON obc_S_vVel_Int               =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON obc_E_theta_max              =   7.0172798856056E-01
-(PID.TID 0000.0001) %MON obc_E_theta_min              =  -6.9629687277693E-01
-(PID.TID 0000.0001) %MON obc_E_theta_mean             =   4.3699479724914E-03
-(PID.TID 0000.0001) %MON obc_E_theta_sd               =   4.5843758844173E-01
-(PID.TID 0000.0001) %MON obc_W_theta_max              =   6.9271245539376E-01
-(PID.TID 0000.0001) %MON obc_W_theta_min              =  -6.9750801339093E-01
-(PID.TID 0000.0001) %MON obc_W_theta_mean             =  -4.3940878002673E-03
-(PID.TID 0000.0001) %MON obc_W_theta_sd               =   4.5421593128033E-01
+(PID.TID 0000.0001) %MON obc_E_theta_max              =   7.0172800355825E-01
+(PID.TID 0000.0001) %MON obc_E_theta_min              =  -6.9629688404014E-01
+(PID.TID 0000.0001) %MON obc_E_theta_mean             =   4.3699484315582E-03
+(PID.TID 0000.0001) %MON obc_E_theta_sd               =   4.5843759355427E-01
+(PID.TID 0000.0001) %MON obc_W_theta_max              =   6.9271247104992E-01
+(PID.TID 0000.0001) %MON obc_W_theta_min              =  -6.9750802854269E-01
+(PID.TID 0000.0001) %MON obc_W_theta_mean             =  -4.3940877188396E-03
+(PID.TID 0000.0001) %MON obc_W_theta_sd               =   4.5421593719424E-01
 (PID.TID 0000.0001) %MON obc_N_theta_max              =   6.9683400000000E-01
 (PID.TID 0000.0001) %MON obc_N_theta_min              =  -6.9683400000000E-01
 (PID.TID 0000.0001) %MON obc_N_theta_mean             =   5.0183265503355E-05
@@ -2220,121 +2281,127 @@
 (PID.TID 0000.0001) // =======================================================
  EXTERNAL_FIELDS_LOAD,         6 : iP,iLd,i0,i1=    1    2    1    2 ; Wght=  0.8333333333  0.1666666667
  OBCS_FIELDS_LOAD,         7 : iP,iLd,i0,i1=    1    2    1    2 ; Wght=  0.8055555556  0.1944444444
- cg2d: Sum(rhs),rhsMax =  -5.87185510024954E+01  1.54535047598298E-01
-(PID.TID 0000.0001)      cg2d_init_res =   3.53131719539493E+00
+ cg2d: Sum(rhs),rhsMax =  -5.87185511604725E+01  1.54535047182535E-01
+(PID.TID 0000.0001)      cg2d_init_res =   3.53131720885111E+00
 (PID.TID 0000.0001)      cg2d_iters(min,last) =      -1     198
-(PID.TID 0000.0001)      cg2d_last_res =   8.11607677905880E-14
+(PID.TID 0000.0001)      cg2d_last_res =   8.11600100310504E-14
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // Begin MONITOR dynamic field statistics
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) %MON time_tsnumber                =                     7
 (PID.TID 0000.0001) %MON time_secondsf                =   1.5000000000000E+04
-(PID.TID 0000.0001) %MON dynstat_eta_max              =   9.9996012461838E-01
-(PID.TID 0000.0001) %MON dynstat_eta_min              =  -6.2758676684174E-01
+(PID.TID 0000.0001) %MON dynstat_eta_max              =   9.9996012465964E-01
+(PID.TID 0000.0001) %MON dynstat_eta_min              =  -6.2758676664184E-01
 (PID.TID 0000.0001) %MON dynstat_eta_mean             =   1.8846153846153E-01
-(PID.TID 0000.0001) %MON dynstat_eta_sd               =   4.3856926469300E-01
-(PID.TID 0000.0001) %MON dynstat_eta_del2             =   2.3965582014496E-05
-(PID.TID 0000.0001) %MON dynstat_uvel_max             =   5.2049132536479E-01
-(PID.TID 0000.0001) %MON dynstat_uvel_min             =   1.2068650223985E-01
-(PID.TID 0000.0001) %MON dynstat_uvel_mean            =   2.5069730476746E-01
-(PID.TID 0000.0001) %MON dynstat_uvel_sd              =   2.7664331514634E-02
-(PID.TID 0000.0001) %MON dynstat_uvel_del2            =   5.5358444446320E-05
-(PID.TID 0000.0001) %MON dynstat_vvel_max             =   8.3766724159065E-02
-(PID.TID 0000.0001) %MON dynstat_vvel_min             =  -2.4762891771808E-01
-(PID.TID 0000.0001) %MON dynstat_vvel_mean            =   5.0346036273096E-04
-(PID.TID 0000.0001) %MON dynstat_vvel_sd              =   2.1297875027657E-02
-(PID.TID 0000.0001) %MON dynstat_vvel_del2            =   2.7052618591497E-05
-(PID.TID 0000.0001) %MON dynstat_wvel_max             =   2.0455548621902E-02
-(PID.TID 0000.0001) %MON dynstat_wvel_min             =  -2.1783087347079E-02
-(PID.TID 0000.0001) %MON dynstat_wvel_mean            =   1.2197892361914E-05
-(PID.TID 0000.0001) %MON dynstat_wvel_sd              =   2.0464429043223E-03
-(PID.TID 0000.0001) %MON dynstat_wvel_del2            =   1.4618832239215E-05
+(PID.TID 0000.0001) %MON dynstat_eta_sd               =   4.3856926469003E-01
+(PID.TID 0000.0001) %MON dynstat_eta_del2             =   2.3965582069396E-05
+(PID.TID 0000.0001) %MON dynstat_uvel_max             =   5.2049132536467E-01
+(PID.TID 0000.0001) %MON dynstat_uvel_min             =   1.2068650223983E-01
+(PID.TID 0000.0001) %MON dynstat_uvel_mean            =   2.5069730476741E-01
+(PID.TID 0000.0001) %MON dynstat_uvel_sd              =   2.7664331513938E-02
+(PID.TID 0000.0001) %MON dynstat_uvel_del2            =   5.5358444310960E-05
+(PID.TID 0000.0001) %MON dynstat_vvel_max             =   8.3766724159049E-02
+(PID.TID 0000.0001) %MON dynstat_vvel_min             =  -2.4762891771805E-01
+(PID.TID 0000.0001) %MON dynstat_vvel_mean            =   5.0346036273124E-04
+(PID.TID 0000.0001) %MON dynstat_vvel_sd              =   2.1297875027648E-02
+(PID.TID 0000.0001) %MON dynstat_vvel_del2            =   2.7052618591915E-05
+(PID.TID 0000.0001) %MON dynstat_wvel_max             =   2.0455548621897E-02
+(PID.TID 0000.0001) %MON dynstat_wvel_min             =  -2.1783087347077E-02
+(PID.TID 0000.0001) %MON dynstat_wvel_mean            =   1.2197892061586E-05
+(PID.TID 0000.0001) %MON dynstat_wvel_sd              =   2.0464429034884E-03
+(PID.TID 0000.0001) %MON dynstat_wvel_del2            =   1.4618832206235E-05
 (PID.TID 0000.0001) %MON dynstat_theta_max            =   7.0770693446596E-01
 (PID.TID 0000.0001) %MON dynstat_theta_min            =  -7.1452410187308E-01
-(PID.TID 0000.0001) %MON dynstat_theta_mean           =   2.0235019339893E-02
-(PID.TID 0000.0001) %MON dynstat_theta_sd             =   4.5209664060135E-01
-(PID.TID 0000.0001) %MON dynstat_theta_del2           =   9.6419083278629E-06
-(PID.TID 0000.0001) %MON dynstat_salt_max             =   3.5007214330476E+01
+(PID.TID 0000.0001) %MON dynstat_theta_mean           =   2.0235019340553E-02
+(PID.TID 0000.0001) %MON dynstat_theta_sd             =   4.5209664061759E-01
+(PID.TID 0000.0001) %MON dynstat_theta_del2           =   9.6419082821846E-06
+(PID.TID 0000.0001) %MON dynstat_salt_max             =   3.5007214330483E+01
 (PID.TID 0000.0001) %MON dynstat_salt_min             =   3.4999967582296E+01
 (PID.TID 0000.0001) %MON dynstat_salt_mean            =   3.5000099933873E+01
-(PID.TID 0000.0001) %MON dynstat_salt_sd              =   8.2584924236850E-04
-(PID.TID 0000.0001) %MON dynstat_salt_del2            =   2.7828683539336E-05
-(PID.TID 0000.0001) %MON advcfl_uvel_max              =   6.2458959043774E-02
-(PID.TID 0000.0001) %MON advcfl_vvel_max              =   2.9715470126170E-02
-(PID.TID 0000.0001) %MON advcfl_wvel_max              =   2.3235293170218E-02
-(PID.TID 0000.0001) %MON advcfl_W_hf_max              =   3.3929941247041E-02
-(PID.TID 0000.0001) %MON pe_b_mean                    =   2.6017522278776E-04
-(PID.TID 0000.0001) %MON ke_max                       =   1.5181464033960E-01
-(PID.TID 0000.0001) %MON ke_mean                      =   3.1925916443544E-02
+(PID.TID 0000.0001) %MON dynstat_salt_sd              =   8.2584924236793E-04
+(PID.TID 0000.0001) %MON dynstat_salt_del2            =   2.7828683539328E-05
+(PID.TID 0000.0001) %MON trAdv_CFL_u_max              =   7.0554071748107E-02
+(PID.TID 0000.0001) %MON trAdv_CFL_v_max              =   2.7096648681156E-02
+(PID.TID 0000.0001) %MON trAdv_CFL_w_max              =   4.1902705875846E-02
+(PID.TID 0000.0001) %MON advcfl_uvel_max              =   6.2458959043760E-02
+(PID.TID 0000.0001) %MON advcfl_vvel_max              =   2.9715470126166E-02
+(PID.TID 0000.0001) %MON advcfl_wvel_max              =   2.3235293170215E-02
+(PID.TID 0000.0001) %MON advcfl_W_hf_max              =   3.3929941247030E-02
+(PID.TID 0000.0001) %MON pe_b_mean                    =   2.6017522278478E-04
+(PID.TID 0000.0001) %MON ke_max                       =   1.5181464033954E-01
+(PID.TID 0000.0001) %MON ke_mean                      =   3.1925916443516E-02
 (PID.TID 0000.0001) %MON ke_vol                       =   3.3507127984312E+14
-(PID.TID 0000.0001) %MON vort_r_min                   =  -1.0504314864533E-04
-(PID.TID 0000.0001) %MON vort_r_max                   =   1.0226197625643E-04
+(PID.TID 0000.0001) %MON vort_r_min                   =  -1.0504314864531E-04
+(PID.TID 0000.0001) %MON vort_r_max                   =   1.0226197625640E-04
 (PID.TID 0000.0001) %MON vort_a_mean                  =   1.0000000000000E-04
-(PID.TID 0000.0001) %MON vort_a_sd                    =   5.0311425135689E-06
+(PID.TID 0000.0001) %MON vort_a_sd                    =   5.0311425135729E-06
 (PID.TID 0000.0001) %MON vort_p_mean                  =   1.0161982423688E-04
-(PID.TID 0000.0001) %MON vort_p_sd                    =   3.2163328569838E-05
-(PID.TID 0000.0001) %MON surfExpan_theta_mean         =   2.4448519047924E-05
-(PID.TID 0000.0001) %MON surfExpan_salt_mean          =   1.2340389695924E-03
+(PID.TID 0000.0001) %MON vort_p_sd                    =   3.2163328569837E-05
+(PID.TID 0000.0001) %MON surfExpan_theta_mean         =   2.4448519066558E-05
+(PID.TID 0000.0001) %MON surfExpan_salt_mean          =   1.2340389695925E-03
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // End MONITOR dynamic field statistics
 (PID.TID 0000.0001) // =======================================================
  EXTERNAL_FIELDS_LOAD,         7 : iP,iLd,i0,i1=    1    2    1    2 ; Wght=  0.8055555556  0.1944444444
  OBCS_FIELDS_LOAD,         8 : iP,iLd,i0,i1=    1    2    1    2 ; Wght=  0.7777777778  0.2222222222
- cg2d: Sum(rhs),rhsMax =  -7.17406262833524E+01  1.39391032920494E-01
-(PID.TID 0000.0001)      cg2d_init_res =   4.18574098807250E+00
+ cg2d: Sum(rhs),rhsMax =  -7.17406262833793E+01  1.39391032920441E-01
+(PID.TID 0000.0001)      cg2d_init_res =   4.18574098627285E+00
 (PID.TID 0000.0001)      cg2d_iters(min,last) =      -1     196
-(PID.TID 0000.0001)      cg2d_last_res =   9.46958857453500E-14
+(PID.TID 0000.0001)      cg2d_last_res =   9.46956823929078E-14
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // Begin MONITOR dynamic field statistics
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) %MON time_tsnumber                =                     8
 (PID.TID 0000.0001) %MON time_secondsf                =   1.5600000000000E+04
-(PID.TID 0000.0001) %MON dynstat_eta_max              =   5.3194305508244E-01
-(PID.TID 0000.0001) %MON dynstat_eta_min              =  -1.2210450251462E-01
+(PID.TID 0000.0001) %MON dynstat_eta_max              =   5.3194305514615E-01
+(PID.TID 0000.0001) %MON dynstat_eta_min              =  -1.2210450225623E-01
 (PID.TID 0000.0001) %MON dynstat_eta_mean             =   2.0769230769230E-01
-(PID.TID 0000.0001) %MON dynstat_eta_sd               =   1.4874037864436E-01
-(PID.TID 0000.0001) %MON dynstat_eta_del2             =   1.0853290520762E-05
-(PID.TID 0000.0001) %MON dynstat_uvel_max             =   5.0147277535369E-01
-(PID.TID 0000.0001) %MON dynstat_uvel_min             =   1.1137271747759E-01
-(PID.TID 0000.0001) %MON dynstat_uvel_mean            =   2.4773355100482E-01
-(PID.TID 0000.0001) %MON dynstat_uvel_sd              =   2.6915149157527E-02
-(PID.TID 0000.0001) %MON dynstat_uvel_del2            =   4.8062712304167E-05
-(PID.TID 0000.0001) %MON dynstat_vvel_max             =   8.6307814836664E-02
-(PID.TID 0000.0001) %MON dynstat_vvel_min             =  -2.7169691892451E-01
-(PID.TID 0000.0001) %MON dynstat_vvel_mean            =   1.6864632496017E-04
-(PID.TID 0000.0001) %MON dynstat_vvel_sd              =   2.1802653687660E-02
-(PID.TID 0000.0001) %MON dynstat_vvel_del2            =   2.8051580136473E-05
-(PID.TID 0000.0001) %MON dynstat_wvel_max             =   2.0328712940468E-02
-(PID.TID 0000.0001) %MON dynstat_wvel_min             =  -2.1429391286829E-02
-(PID.TID 0000.0001) %MON dynstat_wvel_mean            =   1.3387099981901E-05
-(PID.TID 0000.0001) %MON dynstat_wvel_sd              =   1.8740736281830E-03
-(PID.TID 0000.0001) %MON dynstat_wvel_del2            =   7.9907298459099E-06
+(PID.TID 0000.0001) %MON dynstat_eta_sd               =   1.4874037864241E-01
+(PID.TID 0000.0001) %MON dynstat_eta_del2             =   1.0853290574306E-05
+(PID.TID 0000.0001) %MON dynstat_uvel_max             =   5.0147277535356E-01
+(PID.TID 0000.0001) %MON dynstat_uvel_min             =   1.1137271747757E-01
+(PID.TID 0000.0001) %MON dynstat_uvel_mean            =   2.4773355100477E-01
+(PID.TID 0000.0001) %MON dynstat_uvel_sd              =   2.6915149157036E-02
+(PID.TID 0000.0001) %MON dynstat_uvel_del2            =   4.8062712175843E-05
+(PID.TID 0000.0001) %MON dynstat_vvel_max             =   8.6307814836644E-02
+(PID.TID 0000.0001) %MON dynstat_vvel_min             =  -2.7169691892448E-01
+(PID.TID 0000.0001) %MON dynstat_vvel_mean            =   1.6864632496040E-04
+(PID.TID 0000.0001) %MON dynstat_vvel_sd              =   2.1802653687641E-02
+(PID.TID 0000.0001) %MON dynstat_vvel_del2            =   2.8051580136999E-05
+(PID.TID 0000.0001) %MON dynstat_wvel_max             =   2.0328712940462E-02
+(PID.TID 0000.0001) %MON dynstat_wvel_min             =  -2.1429391286826E-02
+(PID.TID 0000.0001) %MON dynstat_wvel_mean            =   1.3387099471318E-05
+(PID.TID 0000.0001) %MON dynstat_wvel_sd              =   1.8740736278919E-03
+(PID.TID 0000.0001) %MON dynstat_wvel_del2            =   7.9907298165482E-06
 (PID.TID 0000.0001) %MON dynstat_theta_max            =   7.0879362529554E-01
-(PID.TID 0000.0001) %MON dynstat_theta_min            =  -7.1575199150695E-01
-(PID.TID 0000.0001) %MON dynstat_theta_mean           =   2.0230967933795E-02
-(PID.TID 0000.0001) %MON dynstat_theta_sd             =   4.5209395518045E-01
-(PID.TID 0000.0001) %MON dynstat_theta_del2           =   1.0964537711291E-05
-(PID.TID 0000.0001) %MON dynstat_salt_max             =   3.5009178459440E+01
+(PID.TID 0000.0001) %MON dynstat_theta_min            =  -7.1575199150694E-01
+(PID.TID 0000.0001) %MON dynstat_theta_mean           =   2.0230967934387E-02
+(PID.TID 0000.0001) %MON dynstat_theta_sd             =   4.5209395520167E-01
+(PID.TID 0000.0001) %MON dynstat_theta_del2           =   1.0964537689360E-05
+(PID.TID 0000.0001) %MON dynstat_salt_max             =   3.5009178459451E+01
 (PID.TID 0000.0001) %MON dynstat_salt_min             =   3.4999965407250E+01
 (PID.TID 0000.0001) %MON dynstat_salt_mean            =   3.5000127878397E+01
-(PID.TID 0000.0001) %MON dynstat_salt_sd              =   1.0430013505065E-03
-(PID.TID 0000.0001) %MON dynstat_salt_del2            =   3.0256633333643E-05
-(PID.TID 0000.0001) %MON advcfl_uvel_max              =   6.0176733042443E-02
-(PID.TID 0000.0001) %MON advcfl_vvel_max              =   3.2603630270942E-02
-(PID.TID 0000.0001) %MON advcfl_wvel_max              =   2.2858017372617E-02
-(PID.TID 0000.0001) %MON advcfl_W_hf_max              =   3.1170495219494E-02
-(PID.TID 0000.0001) %MON pe_b_mean                    =   7.4514726979191E-05
-(PID.TID 0000.0001) %MON ke_max                       =   1.4684902265473E-01
-(PID.TID 0000.0001) %MON ke_mean                      =   3.1171303964706E-02
+(PID.TID 0000.0001) %MON dynstat_salt_sd              =   1.0430013505057E-03
+(PID.TID 0000.0001) %MON dynstat_salt_del2            =   3.0256633333632E-05
+(PID.TID 0000.0001) %MON trAdv_CFL_u_max              =   6.2458959043760E-02
+(PID.TID 0000.0001) %MON trAdv_CFL_v_max              =   2.9715470126166E-02
+(PID.TID 0000.0001) %MON trAdv_CFL_w_max              =   3.3929941247030E-02
+(PID.TID 0000.0001) %MON advcfl_uvel_max              =   6.0176733042427E-02
+(PID.TID 0000.0001) %MON advcfl_vvel_max              =   3.2603630270937E-02
+(PID.TID 0000.0001) %MON advcfl_wvel_max              =   2.2858017372614E-02
+(PID.TID 0000.0001) %MON advcfl_W_hf_max              =   3.1170495219481E-02
+(PID.TID 0000.0001) %MON pe_b_mean                    =   7.4514726978530E-05
+(PID.TID 0000.0001) %MON ke_max                       =   1.4684902265467E-01
+(PID.TID 0000.0001) %MON ke_mean                      =   3.1171303964676E-02
 (PID.TID 0000.0001) %MON ke_vol                       =   3.3507127984312E+14
-(PID.TID 0000.0001) %MON vort_r_min                   =  -1.0117352805471E-04
-(PID.TID 0000.0001) %MON vort_r_max                   =   9.8256527358909E-05
+(PID.TID 0000.0001) %MON vort_r_min                   =  -1.0117352805469E-04
+(PID.TID 0000.0001) %MON vort_r_max                   =   9.8256527358883E-05
 (PID.TID 0000.0001) %MON vort_a_mean                  =   1.0000000000000E-04
-(PID.TID 0000.0001) %MON vort_a_sd                    =   4.8585916702256E-06
+(PID.TID 0000.0001) %MON vort_a_sd                    =   4.8585916702215E-06
 (PID.TID 0000.0001) %MON vort_p_mean                  =   1.0161982423688E-04
-(PID.TID 0000.0001) %MON vort_p_sd                    =   3.1900894563701E-05
-(PID.TID 0000.0001) %MON surfExpan_theta_mean         =   2.2137645426869E-05
-(PID.TID 0000.0001) %MON surfExpan_salt_mean          =   1.1218974984835E-03
+(PID.TID 0000.0001) %MON vort_p_sd                    =   3.1900894563699E-05
+(PID.TID 0000.0001) %MON surfExpan_theta_mean         =   2.2137645456578E-05
+(PID.TID 0000.0001) %MON surfExpan_salt_mean          =   1.1218974984837E-03
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // End MONITOR dynamic field statistics
 (PID.TID 0000.0001) // =======================================================
@@ -2343,15 +2410,15 @@
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) %MON obc_time_tsnumber            =                     8
 (PID.TID 0000.0001) %MON obc_time_secondsf            =   1.5600000000000E+04
-(PID.TID 0000.0001) %MON obc_E_uVel_max               =   2.5357650479161E-01
-(PID.TID 0000.0001) %MON obc_E_uVel_min               =   2.4295555427723E-01
+(PID.TID 0000.0001) %MON obc_E_uVel_max               =   2.5357650533455E-01
+(PID.TID 0000.0001) %MON obc_E_uVel_min               =   2.4295555287917E-01
 (PID.TID 0000.0001) %MON obc_E_uVel_mean              =   2.4861111111111E-01
-(PID.TID 0000.0001) %MON obc_E_uVel_sd                =   3.3824621319585E-03
+(PID.TID 0000.0001) %MON obc_E_uVel_sd                =   3.3824628490911E-03
 (PID.TID 0000.0001) %MON obc_E_uVel_Int               =   2.2374999999999E+08
-(PID.TID 0000.0001) %MON obc_W_uVel_max               =   2.5531616980020E-01
-(PID.TID 0000.0001) %MON obc_W_uVel_min               =   2.4453491669424E-01
+(PID.TID 0000.0001) %MON obc_W_uVel_max               =   2.5531616929331E-01
+(PID.TID 0000.0001) %MON obc_W_uVel_min               =   2.4453491822236E-01
 (PID.TID 0000.0001) %MON obc_W_uVel_mean              =   2.5138888888889E-01
-(PID.TID 0000.0001) %MON obc_W_uVel_sd                =   2.9750058903665E-03
+(PID.TID 0000.0001) %MON obc_W_uVel_sd                =   2.9750052071422E-03
 (PID.TID 0000.0001) %MON obc_W_uVel_Int               =   2.2624999999999E+08
 (PID.TID 0000.0001) %MON obc_N_vVel_max               =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON obc_N_vVel_min               =   0.0000000000000E+00
@@ -2363,14 +2430,14 @@
 (PID.TID 0000.0001) %MON obc_S_vVel_mean              =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON obc_S_vVel_sd                =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON obc_S_vVel_Int               =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON obc_E_theta_max              =   7.0165331296413E-01
-(PID.TID 0000.0001) %MON obc_E_theta_min              =  -6.9635582554110E-01
-(PID.TID 0000.0001) %MON obc_E_theta_mean             =   3.9474368583092E-03
-(PID.TID 0000.0001) %MON obc_E_theta_sd               =   4.5826318325675E-01
-(PID.TID 0000.0001) %MON obc_W_theta_max              =   6.9278327068653E-01
-(PID.TID 0000.0001) %MON obc_W_theta_min              =  -6.9744105860752E-01
-(PID.TID 0000.0001) %MON obc_W_theta_mean             =  -4.0852569635916E-03
-(PID.TID 0000.0001) %MON obc_W_theta_sd               =   4.5429616999188E-01
+(PID.TID 0000.0001) %MON obc_E_theta_max              =   7.0165333251206E-01
+(PID.TID 0000.0001) %MON obc_E_theta_min              =  -6.9635584207542E-01
+(PID.TID 0000.0001) %MON obc_E_theta_mean             =   3.9474372557418E-03
+(PID.TID 0000.0001) %MON obc_E_theta_sd               =   4.5826319024517E-01
+(PID.TID 0000.0001) %MON obc_W_theta_max              =   6.9278329158550E-01
+(PID.TID 0000.0001) %MON obc_W_theta_min              =  -6.9744107809063E-01
+(PID.TID 0000.0001) %MON obc_W_theta_mean             =  -4.0852567221015E-03
+(PID.TID 0000.0001) %MON obc_W_theta_sd               =   4.5429617774386E-01
 (PID.TID 0000.0001) %MON obc_N_theta_max              =   6.9683400000000E-01
 (PID.TID 0000.0001) %MON obc_N_theta_min              =  -6.9683400000000E-01
 (PID.TID 0000.0001) %MON obc_N_theta_mean             =   5.0183265503355E-05
@@ -2384,121 +2451,127 @@
 (PID.TID 0000.0001) // =======================================================
  EXTERNAL_FIELDS_LOAD,         8 : iP,iLd,i0,i1=    1    2    1    2 ; Wght=  0.7777777778  0.2222222222
  OBCS_FIELDS_LOAD,         9 : iP,iLd,i0,i1=    1    2    1    2 ; Wght=  0.7500000000  0.2500000000
- cg2d: Sum(rhs),rhsMax =  -7.29666497764720E+01  1.48469655198917E-01
-(PID.TID 0000.0001)      cg2d_init_res =   2.59557012803489E+00
+ cg2d: Sum(rhs),rhsMax =  -7.29666485305536E+01  1.48469657734063E-01
+(PID.TID 0000.0001)      cg2d_init_res =   2.59557008892596E+00
 (PID.TID 0000.0001)      cg2d_iters(min,last) =      -1     193
-(PID.TID 0000.0001)      cg2d_last_res =   8.67473461761627E-14
+(PID.TID 0000.0001)      cg2d_last_res =   8.67472362497314E-14
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // Begin MONITOR dynamic field statistics
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) %MON time_tsnumber                =                     9
 (PID.TID 0000.0001) %MON time_secondsf                =   1.6200000000000E+04
-(PID.TID 0000.0001) %MON dynstat_eta_max              =   6.7545728909357E-01
-(PID.TID 0000.0001) %MON dynstat_eta_min              =  -2.2648873845042E-01
+(PID.TID 0000.0001) %MON dynstat_eta_max              =   6.7545728940788E-01
+(PID.TID 0000.0001) %MON dynstat_eta_min              =  -2.2648873838034E-01
 (PID.TID 0000.0001) %MON dynstat_eta_mean             =   2.2499999999999E-01
-(PID.TID 0000.0001) %MON dynstat_eta_sd               =   2.0854977090609E-01
-(PID.TID 0000.0001) %MON dynstat_eta_del2             =   1.6254626888189E-05
-(PID.TID 0000.0001) %MON dynstat_uvel_max             =   5.1255795081666E-01
-(PID.TID 0000.0001) %MON dynstat_uvel_min             =   1.1272232233294E-01
-(PID.TID 0000.0001) %MON dynstat_uvel_mean            =   2.5326956706792E-01
-(PID.TID 0000.0001) %MON dynstat_uvel_sd              =   2.9009612424357E-02
-(PID.TID 0000.0001) %MON dynstat_uvel_del2            =   5.4771572806765E-05
-(PID.TID 0000.0001) %MON dynstat_vvel_max             =   9.2738971252380E-02
-(PID.TID 0000.0001) %MON dynstat_vvel_min             =  -2.9892926803908E-01
-(PID.TID 0000.0001) %MON dynstat_vvel_mean            =  -8.5627066824141E-05
-(PID.TID 0000.0001) %MON dynstat_vvel_sd              =   2.3254681175029E-02
-(PID.TID 0000.0001) %MON dynstat_vvel_del2            =   2.9401110816237E-05
-(PID.TID 0000.0001) %MON dynstat_wvel_max             =   2.0938467163626E-02
-(PID.TID 0000.0001) %MON dynstat_wvel_min             =  -2.1855280375537E-02
-(PID.TID 0000.0001) %MON dynstat_wvel_mean            =   5.9621020367604E-06
-(PID.TID 0000.0001) %MON dynstat_wvel_sd              =   1.9709577100387E-03
-(PID.TID 0000.0001) %MON dynstat_wvel_del2            =   1.1431053795827E-05
+(PID.TID 0000.0001) %MON dynstat_eta_sd               =   2.0854977090985E-01
+(PID.TID 0000.0001) %MON dynstat_eta_del2             =   1.6254626950249E-05
+(PID.TID 0000.0001) %MON dynstat_uvel_max             =   5.1255795081651E-01
+(PID.TID 0000.0001) %MON dynstat_uvel_min             =   1.1272232233292E-01
+(PID.TID 0000.0001) %MON dynstat_uvel_mean            =   2.5326956706786E-01
+(PID.TID 0000.0001) %MON dynstat_uvel_sd              =   2.9009612423127E-02
+(PID.TID 0000.0001) %MON dynstat_uvel_del2            =   5.4771572601823E-05
+(PID.TID 0000.0001) %MON dynstat_vvel_max             =   9.2738971252354E-02
+(PID.TID 0000.0001) %MON dynstat_vvel_min             =  -2.9892926803904E-01
+(PID.TID 0000.0001) %MON dynstat_vvel_mean            =  -8.5627066823727E-05
+(PID.TID 0000.0001) %MON dynstat_vvel_sd              =   2.3254681174999E-02
+(PID.TID 0000.0001) %MON dynstat_vvel_del2            =   2.9401110817483E-05
+(PID.TID 0000.0001) %MON dynstat_wvel_max             =   2.0938467163620E-02
+(PID.TID 0000.0001) %MON dynstat_wvel_min             =  -2.1855280375534E-02
+(PID.TID 0000.0001) %MON dynstat_wvel_mean            =   5.9621018308450E-06
+(PID.TID 0000.0001) %MON dynstat_wvel_sd              =   1.9709577089568E-03
+(PID.TID 0000.0001) %MON dynstat_wvel_del2            =   1.1431053748471E-05
 (PID.TID 0000.0001) %MON dynstat_theta_max            =   7.0995721849774E-01
 (PID.TID 0000.0001) %MON dynstat_theta_min            =  -7.1700477149218E-01
-(PID.TID 0000.0001) %MON dynstat_theta_mean           =   2.0226778640910E-02
-(PID.TID 0000.0001) %MON dynstat_theta_sd             =   4.5209158506980E-01
-(PID.TID 0000.0001) %MON dynstat_theta_del2           =   1.0527207698448E-05
-(PID.TID 0000.0001) %MON dynstat_salt_max             =   3.5011189806858E+01
+(PID.TID 0000.0001) %MON dynstat_theta_mean           =   2.0226778641927E-02
+(PID.TID 0000.0001) %MON dynstat_theta_sd             =   4.5209158509656E-01
+(PID.TID 0000.0001) %MON dynstat_theta_del2           =   1.0527207673066E-05
+(PID.TID 0000.0001) %MON dynstat_salt_max             =   3.5011189806875E+01
 (PID.TID 0000.0001) %MON dynstat_salt_min             =   3.4999968957199E+01
 (PID.TID 0000.0001) %MON dynstat_salt_mean            =   3.5000159045839E+01
-(PID.TID 0000.0001) %MON dynstat_salt_sd              =   1.2807705074152E-03
-(PID.TID 0000.0001) %MON dynstat_salt_del2            =   3.2466250496555E-05
-(PID.TID 0000.0001) %MON advcfl_uvel_max              =   6.1506954097999E-02
-(PID.TID 0000.0001) %MON advcfl_vvel_max              =   3.5871512164689E-02
-(PID.TID 0000.0001) %MON advcfl_wvel_max              =   2.3312299067240E-02
-(PID.TID 0000.0001) %MON advcfl_W_hf_max              =   3.1601998179806E-02
-(PID.TID 0000.0001) %MON pe_b_mean                    =   1.0746551687133E-04
-(PID.TID 0000.0001) %MON ke_max                       =   1.5776895113442E-01
-(PID.TID 0000.0001) %MON ke_mean                      =   3.2663311353212E-02
+(PID.TID 0000.0001) %MON dynstat_salt_sd              =   1.2807705074124E-03
+(PID.TID 0000.0001) %MON dynstat_salt_del2            =   3.2466250496529E-05
+(PID.TID 0000.0001) %MON trAdv_CFL_u_max              =   6.0176733042427E-02
+(PID.TID 0000.0001) %MON trAdv_CFL_v_max              =   3.2603630270937E-02
+(PID.TID 0000.0001) %MON trAdv_CFL_w_max              =   3.1170495219481E-02
+(PID.TID 0000.0001) %MON advcfl_uvel_max              =   6.1506954097982E-02
+(PID.TID 0000.0001) %MON advcfl_vvel_max              =   3.5871512164685E-02
+(PID.TID 0000.0001) %MON advcfl_wvel_max              =   2.3312299067236E-02
+(PID.TID 0000.0001) %MON advcfl_W_hf_max              =   3.1601998179792E-02
+(PID.TID 0000.0001) %MON pe_b_mean                    =   1.0746551687312E-04
+(PID.TID 0000.0001) %MON ke_max                       =   1.5776895113435E-01
+(PID.TID 0000.0001) %MON ke_mean                      =   3.2663311353164E-02
 (PID.TID 0000.0001) %MON ke_vol                       =   3.3507127984312E+14
-(PID.TID 0000.0001) %MON vort_r_min                   =  -1.0450829676750E-04
-(PID.TID 0000.0001) %MON vort_r_max                   =   1.0141404422069E-04
+(PID.TID 0000.0001) %MON vort_r_min                   =  -1.0450829676747E-04
+(PID.TID 0000.0001) %MON vort_r_max                   =   1.0141404422066E-04
 (PID.TID 0000.0001) %MON vort_a_mean                  =   1.0000000000000E-04
-(PID.TID 0000.0001) %MON vort_a_sd                    =   5.0548964230891E-06
+(PID.TID 0000.0001) %MON vort_a_sd                    =   5.0548964230935E-06
 (PID.TID 0000.0001) %MON vort_p_mean                  =   1.0161982423688E-04
-(PID.TID 0000.0001) %MON vort_p_sd                    =   3.2080915364263E-05
-(PID.TID 0000.0001) %MON surfExpan_theta_mean         =   1.9944975726214E-05
-(PID.TID 0000.0001) %MON surfExpan_salt_mean          =   1.0096971461223E-03
+(PID.TID 0000.0001) %MON vort_p_sd                    =   3.2080915364262E-05
+(PID.TID 0000.0001) %MON surfExpan_theta_mean         =   1.9944975750437E-05
+(PID.TID 0000.0001) %MON surfExpan_salt_mean          =   1.0096971461225E-03
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // End MONITOR dynamic field statistics
 (PID.TID 0000.0001) // =======================================================
  EXTERNAL_FIELDS_LOAD,         9 : iP,iLd,i0,i1=    1    2    1    2 ; Wght=  0.7500000000  0.2500000000
  OBCS_FIELDS_LOAD,        10 : iP,iLd,i0,i1=    1    2    1    2 ; Wght=  0.7222222222  0.2777777778
- cg2d: Sum(rhs),rhsMax =  -7.44095797040351E+01  1.55545483795362E-01
-(PID.TID 0000.0001)      cg2d_init_res =   9.59703977399174E-01
+ cg2d: Sum(rhs),rhsMax =  -7.44095797041045E+01  1.55545483795217E-01
+(PID.TID 0000.0001)      cg2d_init_res =   9.59703966690771E-01
 (PID.TID 0000.0001)      cg2d_iters(min,last) =      -1     193
-(PID.TID 0000.0001)      cg2d_last_res =   8.24921495236236E-14
+(PID.TID 0000.0001)      cg2d_last_res =   8.24921952225330E-14
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // Begin MONITOR dynamic field statistics
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) %MON time_tsnumber                =                    10
 (PID.TID 0000.0001) %MON time_secondsf                =   1.6800000000000E+04
-(PID.TID 0000.0001) %MON dynstat_eta_max              =   7.6509256940934E-01
-(PID.TID 0000.0001) %MON dynstat_eta_min              =  -2.8481130535229E-01
+(PID.TID 0000.0001) %MON dynstat_eta_max              =   7.6509256980361E-01
+(PID.TID 0000.0001) %MON dynstat_eta_min              =  -2.8481130525272E-01
 (PID.TID 0000.0001) %MON dynstat_eta_mean             =   2.4038461538461E-01
-(PID.TID 0000.0001) %MON dynstat_eta_sd               =   2.5157136940309E-01
-(PID.TID 0000.0001) %MON dynstat_eta_del2             =   1.8338896433619E-05
-(PID.TID 0000.0001) %MON dynstat_uvel_max             =   5.2944839394510E-01
-(PID.TID 0000.0001) %MON dynstat_uvel_min             =   1.1609956595320E-01
-(PID.TID 0000.0001) %MON dynstat_uvel_mean            =   2.6063771006808E-01
-(PID.TID 0000.0001) %MON dynstat_uvel_sd              =   3.1983959309319E-02
-(PID.TID 0000.0001) %MON dynstat_uvel_del2            =   5.7237954515771E-05
-(PID.TID 0000.0001) %MON dynstat_vvel_max             =   1.0038496408679E-01
-(PID.TID 0000.0001) %MON dynstat_vvel_min             =  -3.2795930709536E-01
-(PID.TID 0000.0001) %MON dynstat_vvel_mean            =  -1.7777308102723E-04
-(PID.TID 0000.0001) %MON dynstat_vvel_sd              =   2.4984287049867E-02
-(PID.TID 0000.0001) %MON dynstat_vvel_del2            =   3.1104456518861E-05
-(PID.TID 0000.0001) %MON dynstat_wvel_max             =   2.1709936605400E-02
-(PID.TID 0000.0001) %MON dynstat_wvel_min             =  -2.2492861261579E-02
-(PID.TID 0000.0001) %MON dynstat_wvel_mean            =   9.9567615365416E-06
-(PID.TID 0000.0001) %MON dynstat_wvel_sd              =   1.9058805809394E-03
-(PID.TID 0000.0001) %MON dynstat_wvel_del2            =   7.6883933851887E-06
+(PID.TID 0000.0001) %MON dynstat_eta_sd               =   2.5157136940818E-01
+(PID.TID 0000.0001) %MON dynstat_eta_del2             =   1.8338896438608E-05
+(PID.TID 0000.0001) %MON dynstat_uvel_max             =   5.2944839394493E-01
+(PID.TID 0000.0001) %MON dynstat_uvel_min             =   1.1609956595319E-01
+(PID.TID 0000.0001) %MON dynstat_uvel_mean            =   2.6063771006801E-01
+(PID.TID 0000.0001) %MON dynstat_uvel_sd              =   3.1983959308472E-02
+(PID.TID 0000.0001) %MON dynstat_uvel_del2            =   5.7237954360203E-05
+(PID.TID 0000.0001) %MON dynstat_vvel_max             =   1.0038496408676E-01
+(PID.TID 0000.0001) %MON dynstat_vvel_min             =  -3.2795930709532E-01
+(PID.TID 0000.0001) %MON dynstat_vvel_mean            =  -1.7777308102689E-04
+(PID.TID 0000.0001) %MON dynstat_vvel_sd              =   2.4984287049813E-02
+(PID.TID 0000.0001) %MON dynstat_vvel_del2            =   3.1104456520525E-05
+(PID.TID 0000.0001) %MON dynstat_wvel_max             =   2.1709936605393E-02
+(PID.TID 0000.0001) %MON dynstat_wvel_min             =  -2.2492861261576E-02
+(PID.TID 0000.0001) %MON dynstat_wvel_mean            =   9.9567606815713E-06
+(PID.TID 0000.0001) %MON dynstat_wvel_sd              =   1.9058805806518E-03
+(PID.TID 0000.0001) %MON dynstat_wvel_del2            =   7.6883933521475E-06
 (PID.TID 0000.0001) %MON dynstat_theta_max            =   7.1138686233963E-01
 (PID.TID 0000.0001) %MON dynstat_theta_min            =  -7.1839283528410E-01
-(PID.TID 0000.0001) %MON dynstat_theta_mean           =   2.0224447799535E-02
-(PID.TID 0000.0001) %MON dynstat_theta_sd             =   4.5208935586383E-01
-(PID.TID 0000.0001) %MON dynstat_theta_del2           =   1.1678512002771E-05
-(PID.TID 0000.0001) %MON dynstat_salt_max             =   3.5013519453960E+01
+(PID.TID 0000.0001) %MON dynstat_theta_mean           =   2.0224447800486E-02
+(PID.TID 0000.0001) %MON dynstat_theta_sd             =   4.5208935589683E-01
+(PID.TID 0000.0001) %MON dynstat_theta_del2           =   1.1678511994696E-05
+(PID.TID 0000.0001) %MON dynstat_salt_max             =   3.5013519453984E+01
 (PID.TID 0000.0001) %MON dynstat_salt_min             =   3.4999977433489E+01
 (PID.TID 0000.0001) %MON dynstat_salt_mean            =   3.5000193401305E+01
-(PID.TID 0000.0001) %MON dynstat_salt_sd              =   1.5382969395575E-03
-(PID.TID 0000.0001) %MON dynstat_salt_del2            =   3.4476372096553E-05
-(PID.TID 0000.0001) %MON advcfl_uvel_max              =   6.3533807273412E-02
-(PID.TID 0000.0001) %MON advcfl_vvel_max              =   3.9355116851444E-02
-(PID.TID 0000.0001) %MON advcfl_wvel_max              =   2.3992385345684E-02
-(PID.TID 0000.0001) %MON advcfl_W_hf_max              =   3.2736225350300E-02
-(PID.TID 0000.0001) %MON pe_b_mean                    =   1.3824308493321E-04
-(PID.TID 0000.0001) %MON ke_max                       =   1.7260755854084E-01
-(PID.TID 0000.0001) %MON ke_mean                      =   3.4709810871049E-02
+(PID.TID 0000.0001) %MON dynstat_salt_sd              =   1.5382969395536E-03
+(PID.TID 0000.0001) %MON dynstat_salt_del2            =   3.4476372096513E-05
+(PID.TID 0000.0001) %MON trAdv_CFL_u_max              =   6.1506954097982E-02
+(PID.TID 0000.0001) %MON trAdv_CFL_v_max              =   3.5871512164685E-02
+(PID.TID 0000.0001) %MON trAdv_CFL_w_max              =   3.1601998179792E-02
+(PID.TID 0000.0001) %MON advcfl_uvel_max              =   6.3533807273391E-02
+(PID.TID 0000.0001) %MON advcfl_vvel_max              =   3.9355116851438E-02
+(PID.TID 0000.0001) %MON advcfl_wvel_max              =   2.3992385345681E-02
+(PID.TID 0000.0001) %MON advcfl_W_hf_max              =   3.2736225350285E-02
+(PID.TID 0000.0001) %MON pe_b_mean                    =   1.3824308493614E-04
+(PID.TID 0000.0001) %MON ke_max                       =   1.7260755854076E-01
+(PID.TID 0000.0001) %MON ke_mean                      =   3.4709810870997E-02
 (PID.TID 0000.0001) %MON ke_vol                       =   3.3507127984312E+14
-(PID.TID 0000.0001) %MON vort_r_min                   =  -1.0945305687258E-04
-(PID.TID 0000.0001) %MON vort_r_max                   =   1.0610852857307E-04
+(PID.TID 0000.0001) %MON vort_r_min                   =  -1.0945305687255E-04
+(PID.TID 0000.0001) %MON vort_r_max                   =   1.0610852857304E-04
 (PID.TID 0000.0001) %MON vort_a_mean                  =   1.0000000000000E-04
-(PID.TID 0000.0001) %MON vort_a_sd                    =   5.3530724352636E-06
+(PID.TID 0000.0001) %MON vort_a_sd                    =   5.3530724352571E-06
 (PID.TID 0000.0001) %MON vort_p_mean                  =   1.0161982423688E-04
-(PID.TID 0000.0001) %MON vort_p_sd                    =   3.2365733681326E-05
-(PID.TID 0000.0001) %MON surfExpan_theta_mean         =   1.7829159593412E-05
-(PID.TID 0000.0001) %MON surfExpan_salt_mean          =   8.9746129475479E-04
+(PID.TID 0000.0001) %MON vort_p_sd                    =   3.2365733681323E-05
+(PID.TID 0000.0001) %MON surfExpan_theta_mean         =   1.7829159601500E-05
+(PID.TID 0000.0001) %MON surfExpan_salt_mean          =   8.9746129475486E-04
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // End MONITOR dynamic field statistics
 (PID.TID 0000.0001) // =======================================================
@@ -2507,15 +2580,15 @@
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) %MON obc_time_tsnumber            =                    10
 (PID.TID 0000.0001) %MON obc_time_secondsf            =   1.6800000000000E+04
-(PID.TID 0000.0001) %MON obc_E_uVel_max               =   2.5534193198231E-01
-(PID.TID 0000.0001) %MON obc_E_uVel_min               =   2.4208018700878E-01
+(PID.TID 0000.0001) %MON obc_E_uVel_max               =   2.5534193288028E-01
+(PID.TID 0000.0001) %MON obc_E_uVel_min               =   2.4208018475031E-01
 (PID.TID 0000.0001) %MON obc_E_uVel_mean              =   2.4888888888889E-01
-(PID.TID 0000.0001) %MON obc_E_uVel_sd                =   4.4351333458226E-03
+(PID.TID 0000.0001) %MON obc_E_uVel_sd                =   4.4351344229434E-03
 (PID.TID 0000.0001) %MON obc_E_uVel_Int               =   2.2399999999999E+08
-(PID.TID 0000.0001) %MON obc_W_uVel_max               =   2.5653426467633E-01
-(PID.TID 0000.0001) %MON obc_W_uVel_min               =   2.4358068469282E-01
+(PID.TID 0000.0001) %MON obc_W_uVel_max               =   2.5653426384141E-01
+(PID.TID 0000.0001) %MON obc_W_uVel_min               =   2.4358068698390E-01
 (PID.TID 0000.0001) %MON obc_W_uVel_mean              =   2.5111111111111E-01
-(PID.TID 0000.0001) %MON obc_W_uVel_sd                =   3.7799306383793E-03
+(PID.TID 0000.0001) %MON obc_W_uVel_sd                =   3.7799296019335E-03
 (PID.TID 0000.0001) %MON obc_W_uVel_Int               =   2.2599999999999E+08
 (PID.TID 0000.0001) %MON obc_N_vVel_max               =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON obc_N_vVel_min               =   0.0000000000000E+00
@@ -2527,14 +2600,14 @@
 (PID.TID 0000.0001) %MON obc_S_vVel_mean              =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON obc_S_vVel_sd                =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON obc_S_vVel_Int               =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON obc_E_theta_max              =   7.0150584311379E-01
-(PID.TID 0000.0001) %MON obc_E_theta_min              =  -6.9644209102215E-01
-(PID.TID 0000.0001) %MON obc_E_theta_mean             =   3.5397862594590E-03
-(PID.TID 0000.0001) %MON obc_E_theta_sd               =   4.5814073715089E-01
-(PID.TID 0000.0001) %MON obc_W_theta_max              =   6.9290978674494E-01
-(PID.TID 0000.0001) %MON obc_W_theta_min              =  -6.9733555250752E-01
-(PID.TID 0000.0001) %MON obc_W_theta_mean             =  -3.7151152074424E-03
-(PID.TID 0000.0001) %MON obc_W_theta_sd               =   4.5435101472130E-01
+(PID.TID 0000.0001) %MON obc_E_theta_max              =   7.0150586696739E-01
+(PID.TID 0000.0001) %MON obc_E_theta_min              =  -6.9644210827696E-01
+(PID.TID 0000.0001) %MON obc_E_theta_mean             =   3.5397868316328E-03
+(PID.TID 0000.0001) %MON obc_E_theta_sd               =   4.5814074553434E-01
+(PID.TID 0000.0001) %MON obc_W_theta_max              =   6.9290981243083E-01
+(PID.TID 0000.0001) %MON obc_W_theta_min              =  -6.9733557301561E-01
+(PID.TID 0000.0001) %MON obc_W_theta_mean             =  -3.7151144388832E-03
+(PID.TID 0000.0001) %MON obc_W_theta_sd               =   4.5435102360688E-01
 (PID.TID 0000.0001) %MON obc_N_theta_max              =   6.9683400000000E-01
 (PID.TID 0000.0001) %MON obc_N_theta_min              =  -6.9683400000000E-01
 (PID.TID 0000.0001) %MON obc_N_theta_mean             =   5.0183265503355E-05
@@ -2548,135 +2621,135 @@
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) %CHECKPOINT        10 ckptA
 (PID.TID 0000.0001)   Seconds in section "ALL                    [THE_MODEL_MAIN]":
-(PID.TID 0000.0001)           User time:   5.6000000000000005
-(PID.TID 0000.0001)         System time:  2.00000000000000004E-002
-(PID.TID 0000.0001)     Wall clock time:   5.6415290832519531
+(PID.TID 0000.0001)           User time:   4.0240001678466797
+(PID.TID 0000.0001)         System time:   8.0000003799796104E-003
+(PID.TID 0000.0001)     Wall clock time:   4.0312108993530273
 (PID.TID 0000.0001)          No. starts:           1
 (PID.TID 0000.0001)           No. stops:           1
 (PID.TID 0000.0001)   Seconds in section "INITIALISE_FIXED       [THE_MODEL_MAIN]":
-(PID.TID 0000.0001)           User time:  8.00000000000000017E-002
-(PID.TID 0000.0001)         System time:  1.00000000000000002E-002
-(PID.TID 0000.0001)     Wall clock time:  9.41660404205322266E-002
+(PID.TID 0000.0001)           User time:   6.4000003039836884E-002
+(PID.TID 0000.0001)         System time:   4.0000001899898052E-003
+(PID.TID 0000.0001)     Wall clock time:   6.6485166549682617E-002
 (PID.TID 0000.0001)          No. starts:           1
 (PID.TID 0000.0001)           No. stops:           1
 (PID.TID 0000.0001)   Seconds in section "THE_MAIN_LOOP          [THE_MODEL_MAIN]":
-(PID.TID 0000.0001)           User time:   5.5200000000000005
-(PID.TID 0000.0001)         System time:  1.00000000000000002E-002
-(PID.TID 0000.0001)     Wall clock time:   5.5473210811614990
+(PID.TID 0000.0001)           User time:   3.9600001648068428
+(PID.TID 0000.0001)         System time:   4.0000001899898052E-003
+(PID.TID 0000.0001)     Wall clock time:   3.9646849632263184
 (PID.TID 0000.0001)          No. starts:           1
 (PID.TID 0000.0001)           No. stops:           1
 (PID.TID 0000.0001)   Seconds in section "INITIALISE_VARIA    [THE_MAIN_LOOP]":
-(PID.TID 0000.0001)           User time:  9.00000000000000105E-002
-(PID.TID 0000.0001)         System time:   0.0000000000000000
-(PID.TID 0000.0001)     Wall clock time:  0.10236501693725586
+(PID.TID 0000.0001)           User time:   6.7999996244907379E-002
+(PID.TID 0000.0001)         System time:   4.0000001899898052E-003
+(PID.TID 0000.0001)     Wall clock time:   7.3119163513183594E-002
 (PID.TID 0000.0001)          No. starts:           1
 (PID.TID 0000.0001)           No. stops:           1
 (PID.TID 0000.0001)   Seconds in section "MAIN LOOP           [THE_MAIN_LOOP]":
-(PID.TID 0000.0001)           User time:   5.4300000000000006
-(PID.TID 0000.0001)         System time:  1.00000000000000002E-002
-(PID.TID 0000.0001)     Wall clock time:   5.4449248313903809
+(PID.TID 0000.0001)           User time:   3.8920001685619354
+(PID.TID 0000.0001)         System time:   0.0000000000000000
+(PID.TID 0000.0001)     Wall clock time:   3.8915410041809082
 (PID.TID 0000.0001)          No. starts:           1
 (PID.TID 0000.0001)           No. stops:           1
 (PID.TID 0000.0001)   Seconds in section "MAIN_DO_LOOP        [THE_MAIN_LOOP]":
-(PID.TID 0000.0001)           User time:   5.4299999999999988
-(PID.TID 0000.0001)         System time:  1.00000000000000002E-002
-(PID.TID 0000.0001)     Wall clock time:   5.4448208808898926
+(PID.TID 0000.0001)           User time:   3.8920001685619354
+(PID.TID 0000.0001)         System time:   0.0000000000000000
+(PID.TID 0000.0001)     Wall clock time:   3.8914566040039062
 (PID.TID 0000.0001)          No. starts:          10
 (PID.TID 0000.0001)           No. stops:          10
 (PID.TID 0000.0001)   Seconds in section "FORWARD_STEP        [MAIN_DO_LOOP]":
-(PID.TID 0000.0001)           User time:   5.4299999999999988
-(PID.TID 0000.0001)         System time:  1.00000000000000002E-002
-(PID.TID 0000.0001)     Wall clock time:   5.4446387290954590
+(PID.TID 0000.0001)           User time:   3.8920001685619354
+(PID.TID 0000.0001)         System time:   0.0000000000000000
+(PID.TID 0000.0001)     Wall clock time:   3.8912885189056396
 (PID.TID 0000.0001)          No. starts:          10
 (PID.TID 0000.0001)           No. stops:          10
 (PID.TID 0000.0001)   Seconds in section "LOAD_FIELDS_DRIVER  [FORWARD_STEP]":
 (PID.TID 0000.0001)           User time:   0.0000000000000000
 (PID.TID 0000.0001)         System time:   0.0000000000000000
-(PID.TID 0000.0001)     Wall clock time:  1.70016288757324219E-003
+(PID.TID 0000.0001)     Wall clock time:   1.3666152954101562E-003
 (PID.TID 0000.0001)          No. starts:          10
 (PID.TID 0000.0001)           No. stops:          10
 (PID.TID 0000.0001)   Seconds in section "EXTERNAL_FLDS_LOAD [LOAD_FLDS_DRIVER]":
 (PID.TID 0000.0001)           User time:   0.0000000000000000
 (PID.TID 0000.0001)         System time:   0.0000000000000000
-(PID.TID 0000.0001)     Wall clock time:  1.52397155761718750E-003
+(PID.TID 0000.0001)     Wall clock time:   1.2152194976806641E-003
 (PID.TID 0000.0001)          No. starts:          10
 (PID.TID 0000.0001)           No. stops:          10
 (PID.TID 0000.0001)   Seconds in section "DO_ATMOSPHERIC_PHYS [FORWARD_STEP]":
 (PID.TID 0000.0001)           User time:   0.0000000000000000
 (PID.TID 0000.0001)         System time:   0.0000000000000000
-(PID.TID 0000.0001)     Wall clock time:  9.29832458496093750E-005
+(PID.TID 0000.0001)     Wall clock time:   7.8201293945312500E-005
 (PID.TID 0000.0001)          No. starts:          10
 (PID.TID 0000.0001)           No. stops:          10
 (PID.TID 0000.0001)   Seconds in section "DO_OCEANIC_PHYS     [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:  7.00000000000011724E-002
+(PID.TID 0000.0001)           User time:   3.5999894142150879E-002
 (PID.TID 0000.0001)         System time:   0.0000000000000000
-(PID.TID 0000.0001)     Wall clock time:  3.71499061584472656E-002
+(PID.TID 0000.0001)     Wall clock time:   2.6484727859497070E-002
 (PID.TID 0000.0001)          No. starts:          10
 (PID.TID 0000.0001)           No. stops:          10
 (PID.TID 0000.0001)   Seconds in section "THERMODYNAMICS      [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:  0.74000000000000021
+(PID.TID 0000.0001)           User time:  0.57600013911724091
 (PID.TID 0000.0001)         System time:   0.0000000000000000
-(PID.TID 0000.0001)     Wall clock time:  0.77500796318054199
+(PID.TID 0000.0001)     Wall clock time:  0.57961606979370117
 (PID.TID 0000.0001)          No. starts:          10
 (PID.TID 0000.0001)           No. stops:          10
 (PID.TID 0000.0001)   Seconds in section "DYNAMICS            [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:   1.1700000000000008
+(PID.TID 0000.0001)           User time:  0.83200009167194366
 (PID.TID 0000.0001)         System time:   0.0000000000000000
-(PID.TID 0000.0001)     Wall clock time:   1.1736876964569092
+(PID.TID 0000.0001)     Wall clock time:  0.83684349060058594
 (PID.TID 0000.0001)          No. starts:          10
 (PID.TID 0000.0001)           No. stops:          10
 (PID.TID 0000.0001)   Seconds in section "UPDATE_SURF_DR      [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:  1.99999999999995737E-002
+(PID.TID 0000.0001)           User time:   2.7999937534332275E-002
 (PID.TID 0000.0001)         System time:   0.0000000000000000
-(PID.TID 0000.0001)     Wall clock time:  2.16629505157470703E-002
+(PID.TID 0000.0001)     Wall clock time:   1.5131950378417969E-002
 (PID.TID 0000.0001)          No. starts:          10
 (PID.TID 0000.0001)           No. stops:          10
 (PID.TID 0000.0001)   Seconds in section "SOLVE_FOR_PRESSURE  [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:   2.6999999999999984
+(PID.TID 0000.0001)           User time:   1.8959996402263641
 (PID.TID 0000.0001)         System time:   0.0000000000000000
-(PID.TID 0000.0001)     Wall clock time:   2.7012615203857422
+(PID.TID 0000.0001)     Wall clock time:   1.9062407016754150
 (PID.TID 0000.0001)          No. starts:          10
 (PID.TID 0000.0001)           No. stops:          10
 (PID.TID 0000.0001)   Seconds in section "MOM_CORRECTION_STEP [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:  8.00000000000000711E-002
+(PID.TID 0000.0001)           User time:   6.0000360012054443E-002
 (PID.TID 0000.0001)         System time:   0.0000000000000000
-(PID.TID 0000.0001)     Wall clock time:  7.92400836944580078E-002
+(PID.TID 0000.0001)     Wall clock time:   6.1481714248657227E-002
 (PID.TID 0000.0001)          No. starts:          10
 (PID.TID 0000.0001)           No. stops:          10
 (PID.TID 0000.0001)   Seconds in section "INTEGR_CONTINUITY   [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:  0.11000000000000210
+(PID.TID 0000.0001)           User time:   7.9999953508377075E-002
 (PID.TID 0000.0001)         System time:   0.0000000000000000
-(PID.TID 0000.0001)     Wall clock time:  0.10302090644836426
+(PID.TID 0000.0001)     Wall clock time:   7.1711063385009766E-002
 (PID.TID 0000.0001)          No. starts:          10
 (PID.TID 0000.0001)           No. stops:          10
 (PID.TID 0000.0001)   Seconds in section "TRC_CORRECTION_STEP [FORWARD_STEP]":
 (PID.TID 0000.0001)           User time:   0.0000000000000000
 (PID.TID 0000.0001)         System time:   0.0000000000000000
-(PID.TID 0000.0001)     Wall clock time:  1.01804733276367188E-004
+(PID.TID 0000.0001)     Wall clock time:   8.2254409790039062E-005
 (PID.TID 0000.0001)          No. starts:          10
 (PID.TID 0000.0001)           No. stops:          10
 (PID.TID 0000.0001)   Seconds in section "BLOCKING_EXCHANGES  [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:  3.00000000000002487E-002
+(PID.TID 0000.0001)           User time:   1.5999853610992432E-002
 (PID.TID 0000.0001)         System time:   0.0000000000000000
-(PID.TID 0000.0001)     Wall clock time:  2.93822288513183594E-002
+(PID.TID 0000.0001)     Wall clock time:   2.0838022232055664E-002
 (PID.TID 0000.0001)          No. starts:          10
 (PID.TID 0000.0001)           No. stops:          10
 (PID.TID 0000.0001)   Seconds in section "MONITOR             [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:  0.47999999999999954
+(PID.TID 0000.0001)           User time:  0.34400013089179993
 (PID.TID 0000.0001)         System time:   0.0000000000000000
-(PID.TID 0000.0001)     Wall clock time:  0.48433113098144531
+(PID.TID 0000.0001)     Wall clock time:  0.34436941146850586
 (PID.TID 0000.0001)          No. starts:          10
 (PID.TID 0000.0001)           No. stops:          10
 (PID.TID 0000.0001)   Seconds in section "DO_THE_MODEL_IO     [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:  9.99999999999978684E-003
-(PID.TID 0000.0001)         System time:  1.00000000000000002E-002
-(PID.TID 0000.0001)     Wall clock time:  1.80780887603759766E-002
+(PID.TID 0000.0001)           User time:   7.9998970031738281E-003
+(PID.TID 0000.0001)         System time:   0.0000000000000000
+(PID.TID 0000.0001)     Wall clock time:   1.3006925582885742E-002
 (PID.TID 0000.0001)          No. starts:          10
 (PID.TID 0000.0001)           No. stops:          10
 (PID.TID 0000.0001)   Seconds in section "DO_WRITE_PICKUP     [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:  2.00000000000004619E-002
+(PID.TID 0000.0001)           User time:   1.6000270843505859E-002
 (PID.TID 0000.0001)         System time:   0.0000000000000000
-(PID.TID 0000.0001)     Wall clock time:  1.85015201568603516E-002
+(PID.TID 0000.0001)     Wall clock time:   1.2827634811401367E-002
 (PID.TID 0000.0001)          No. starts:          10
 (PID.TID 0000.0001)           No. stops:          10
 (PID.TID 0000.0001) // ======================================================
@@ -2727,9 +2800,9 @@
 (PID.TID 0000.0001) //          Total. Y spins =              0
 (PID.TID 0000.0001) //            Avg. Y spins =       0.00E+00
 (PID.TID 0000.0001) // o Thread number: 000001
-(PID.TID 0000.0001) //            No. barriers =          14188
+(PID.TID 0000.0001) //            No. barriers =          14402
 (PID.TID 0000.0001) //      Max. barrier spins =              1
 (PID.TID 0000.0001) //      Min. barrier spins =              1
-(PID.TID 0000.0001) //     Total barrier spins =          14188
+(PID.TID 0000.0001) //     Total barrier spins =          14402
 (PID.TID 0000.0001) //      Avg. barrier spins =       1.00E+00
 PROGRAM MAIN: Execution ended Normally


### PR DESCRIPTION
## What changes does this PR introduce?

simplify code by rearranging computations to remove code from non-stevens subroutines

## What is the new behaviour 
now new behaviour, but the changes modify the results

## Does this PR introduce a breaking change? 
No, but results change

## Suggested addition to `tag-index`
o pkg/obcs: rearrange computation of stevens bcs to make code simpler:
- revert obcs_apply_ts.F to version w/out extra code for Stevens boundary conditions
- in obcs_calc_stevens.F, update boundary tracer values instead of just computing tendency
- update reference experiment after modifying Stevens BC code