### PR TITLE
Fix bi loop range

### DIFF
--- a/doc/tag-index
+++ b/doc/tag-index
@@ -1,6 +1,10 @@
     Notes on tags used in MITgcmUV
     ==============================
 
+o compon_interf pkgs:
+  - fix bi loop range in few initialisation subroutines (2 in each pkg),
+    fixing issue #270
+
 checkpoint67k (2019/07/19)
 o model/src:
   - fix format in printing 1 error message from S/R SET_PARMS

--- a/pkg/atm_compon_interf/atm_import_ocnconfig.F
+++ b/pkg/atm_compon_interf/atm_import_ocnconfig.F
@@ -38,7 +38,7 @@ C     i,j,bi,bj :: Loop counters
 
 C-    Initialise mixed-layer depth
       DO bj=myByLo(myThid),myByHi(myThid)
-       DO bi=myBxLo(myThid),myByLo(myThid)
+       DO bi=myBxLo(myThid),myBxHi(myThid)
         DO j=1-OLy,sNy+OLy
          DO i=1-OLx,sNx+OLx
           ocMxlD (i,j,bi,bj) = 0.

--- a/pkg/atm_compon_interf/cpl_ini_vars.F
+++ b/pkg/atm_compon_interf/cpl_ini_vars.F
@@ -42,7 +42,7 @@ C     i,j,bi,bj :: Loop counters
       INTEGER i,j,bi,bj
 
       DO bj=myByLo(myThid),myByHi(myThid)
-       DO bi=myBxLo(myThid),myByLo(myThid)
+       DO bi=myBxLo(myThid),myBxHi(myThid)
         DO J=1-OLy,sNy+OLy
          DO I=1-OLx,sNx+OLx
 C-        Export field

--- a/pkg/ocn_compon_interf/cpl_ini_vars.F
+++ b/pkg/ocn_compon_interf/cpl_ini_vars.F
@@ -42,7 +42,7 @@ C     i,j,bi,bj :: Loop counters
       INTEGER i,j,bi,bj
 
       DO bj=myByLo(myThid),myByHi(myThid)
-       DO bi=myBxLo(myThid),myByLo(myThid)
+       DO bi=myBxLo(myThid),myBxHi(myThid)
         DO J=1-OLy,sNy+OLy
          DO I=1-OLx,sNx+OLx
 C.        Export fields

--- a/pkg/ocn_compon_interf/ocn_import_atmconfig.F
+++ b/pkg/ocn_compon_interf/ocn_import_atmconfig.F
@@ -37,7 +37,7 @@ C     i,j,bi,bj :: Loop counters
 
 C-    Initialise land-mask
       DO bj=myByLo(myThid),myByHi(myThid)
-       DO bi=myBxLo(myThid),myByLo(myThid)
+       DO bi=myBxLo(myThid),myBxHi(myThid)
         DO j=1-OLy,sNy+OLy
          DO i=1-OLx,sNx+OLx
           landMask(i,j,bi,bj) = 0.


### PR DESCRIPTION
## What changes does this PR introduce?
fix bi loop range in few initialisation S/R from coupling interface pkgs.
This addresses issue #270 

## What is the current behaviour? 
use wrong upper bound limit (=myByLo) for bi loop instead of the right one: myBxHi 

## What is the new behaviour 
fix this in 2 initialization S/R in pkg: atm_compon_interf and 2 other in ocn_compon_interf

## Does this PR introduce a breaking change? 
This bug was causing an  "out of bound" array index error only for some multi-threaded
config that have not been previously tried

## Other information:

## Suggested addition to `tag-index`
o compon_interf pkgs:
  - fix bi loop range in few initialisation subroutines (2 in each pkg), fixing issue #270 