### PR TITLE
QG Leith bug fix

### DIFF
--- a/pkg/gmredi/gmredi_calc_qgleith.F
+++ b/pkg/gmredi/gmredi_calc_qgleith.F
@@ -238,7 +238,7 @@ C Using it in Leith serves to damp instabilities in w.
      &                     + (divDy(i,j+1)*divDy(i,j+1)
      &                        + divDy(i,j)*divDy(i,j) )  )
 
-              LeithQG_K(i,j,k) = leithQG2fac*SQRT(grdVrt+grdDiv)*L3
+              LeithQG_K(i,j,k) = SQRT(leithQG2fac*(grdVrt+grdDiv))*L3
 
             ELSE
 C but this approximation will work on cube (and differs by as much as 4X)

--- a/pkg/mom_common/mom_calc_visc.F
+++ b/pkg/mom_common/mom_calc_visc.F
@@ -546,7 +546,8 @@ C This is the vector magnitude of grad(div.v) squared
      &     SQRT(leithD2fac*grdDiv)*L3
           viscA4_ZLthD(i,j)=
      &     SQRT(leithD4fac*grdDiv)*L5
-          viscAh_ZLthQG(i,j)=leithQG2fac*(grdVrt + grdDiv)*L3
+          viscAh_ZLthQG(i,j)=
+     &     SQRT(leithQG2fac*(grdVrt + grdDiv))*L3
 
          ELSEIF (calcLeith) THEN
 C but this approximation will work on cube (and differs by 4X)


### PR DESCRIPTION
## What changes does this PR introduce?
Two minor bugs in the QG Leith code are fixed.

One involves moving the non-dimensional coefficient inside the square root (bug in `pkg/gmredi`).
The other involves adding a missing square root (bug in `pkg/mom_common`).

## What is the current behaviour? 
The QG Leith viscosity is calculated incorrectly. There is also an unrelated error in the QG Leith coefficient used by `pkg/gmredi`. 

## What is the new behaviour 
Two fewer bugs.

## Does this PR introduce a breaking change? 
No.

## Other information:
The reference output will need to be updated. Last time baudelaire gave different numbers to my machine, so I haven't provided updated reference outputs.

## Suggested addition to `tag-index`
- pkg/mom_common bug fix for QG Leith viscosity
- pkg/gmredi bug fix for QG Leith coefficient