### PR TITLE
Add option for _oad, _ad, _tlm dirs

### DIFF
--- a/verification/verification_parser.py
+++ b/verification/verification_parser.py
@@ -4,12 +4,12 @@ import re
 import glob
 import os
 
-def verification_parser(filename, threshold, indirpat):
+def verification_parser(filename, threshold, input_dir_pat):
 
     # function should be given a threshold value for each sub test
     (directory, _) = os.path.split(filename)
     # how many additional tests are run with tweaks to this configuration
-    num_exps = len(glob.glob(directory+indirpat))+1
+    num_exps = len(glob.glob(directory+input_dir_pat))+1
 
     # check that the correct number of values for `threshold` have been given
     if len(threshold) != num_exps:
@@ -91,7 +91,7 @@ if __name__ == '__main__':
     parser.add_argument('-threshold',nargs='+', type=int, default=15, 
                         help='number of decimal places of similarity required for test to pass. Requires a value for each sub test. Separate values with a space.')
 
-    parser.add_argument('-indirpat', type=str, default='/input.*',
+    parser.add_argument('-input_dir_pat', type=str, default='/input.*',
                         help='Directory pattern for searching for sub-experiments for base, oad, adm, tlm. Default /input.*')
 
     args = parser.parse_args()

--- a/verification/verification_parser.py
+++ b/verification/verification_parser.py
@@ -4,12 +4,12 @@ import re
 import glob
 import os
 
-def verification_parser(filename, threshold):
+def verification_parser(filename, threshold, indirpat):
 
     # function should be given a threshold value for each sub test
     (directory, _) = os.path.split(filename)
     # how many additional tests are run with tweaks to this configuration
-    num_exps = len(glob.glob(directory+'/input.*'))+1
+    num_exps = len(glob.glob(directory+indirpat))+1
 
     # check that the correct number of values for `threshold` have been given
     if len(threshold) != num_exps:
@@ -90,6 +90,9 @@ if __name__ == '__main__':
 
     parser.add_argument('-threshold',nargs='+', type=int, default=15, 
                         help='number of decimal places of similarity required for test to pass. Requires a value for each sub test. Separate values with a space.')
+
+    parser.add_argument('-indirpat', type=str, default='/input.*',
+                        help='Directory pattern for searching for sub-experiments for base, oad, adm, tlm. Default /input.*')
 
     args = parser.parse_args()
 


### PR DESCRIPTION
Updated verfication_parser.py to support checking AD style experiments
in .travis. Previously verfication_parser.py counted directories named
'/input.*' to compute number of sub-experiemts to check. For AD experiments
pattern needs to be different (_oad, _ad, _tlm etc...).

## What changes does this PR introduce?
Will allow Travis with OpenAD


## What is the current behaviour? 
Travis with OpenAD not possible


## What is the new behaviour 
None yet, until Travis updated


## Does this PR introduce a breaking change? 
Hopefully not, but needs checking. New option has default
which is same as hard-coded value in previous.


## Other information:


## Suggested addition to `tag-index`
o verification_parser.py option to pattern match OAD input dirs