### PR TITLE
fix PR #219 regarding _RS type new variables

### DIFF
--- a/model/src/correction_step.F
+++ b/model/src/correction_step.F
@@ -256,8 +256,8 @@ C         kSurfW = Nr+1 if dry column
            ENDDO
           ENDDO
          ENDIF
-         CALL DIAGNOSTICS_FILL( botDragU,
-     &                         'botTauX ', 0, 1, 1, bi, bj, myThid )
+         CALL DIAGNOSTICS_FILL_RS( botDragU, 'botTauX ',
+     &                             0, 1, 1, bi, bj, myThid )
        ENDIF
        IF ( DIAGNOSTICS_IS_ON( 'botTauY ', myThid ) ) THEN
          IF ( usingZCoords ) THEN
@@ -279,8 +279,8 @@ C         kSurfS = Nr+1 if dry column
            ENDDO
           ENDDO
          ENDIF
-         CALL DIAGNOSTICS_FILL( botDragV,
-     &                         'botTauY ', 0, 1, 1, bi, bj, myThid )
+         CALL DIAGNOSTICS_FILL_RS( botDragV, 'botTauY ',
+     &                             0, 1, 1, bi, bj, myThid )
        ENDIF
       ENDIF
 #endif /* ALLOW_DIAGNOSTICS */

--- a/model/src/dynamics.F
+++ b/model/src/dynamics.F
@@ -694,8 +694,10 @@ Cml)
      &      (  no_slip_bottom
      &    .OR. selectBotDragQuadr.GE.0
      &    .OR. bottomDragLinear.NE.0. ) ) THEN
-        CALL DIAGNOSTICS_FILL( botDragU,'botTauX ',0,1,0,1,1,myThid )
-        CALL DIAGNOSTICS_FILL( botDragV,'botTauY ',0,1,0,1,1,myThid )
+        CALL DIAGNOSTICS_FILL_RS( botDragU, 'botTauX ',
+     &                            0, 1, 1, bi, bj, myThid )
+        CALL DIAGNOSTICS_FILL_RS( botDragV, 'botTauY ',
+     &                            0, 1, 1, bi, bj, myThid )
        ENDIF
 
       ENDIF

--- a/model/src/dynamics.F
+++ b/model/src/dynamics.F
@@ -695,9 +695,9 @@ Cml)
      &    .OR. selectBotDragQuadr.GE.0
      &    .OR. bottomDragLinear.NE.0. ) ) THEN
         CALL DIAGNOSTICS_FILL_RS( botDragU, 'botTauX ',
-     &                            0, 1, 1, bi, bj, myThid )
+     &                            0, 1, 0, 1, 1, myThid )
         CALL DIAGNOSTICS_FILL_RS( botDragV, 'botTauY ',
-     &                            0, 1, 1, bi, bj, myThid )
+     &                            0, 1, 0, 1, 1, myThid )
        ENDIF
 
       ENDIF


### PR DESCRIPTION
fix filling of diagnostics 'botTauX ' &  'botTauY ' using the right
type of DIAGNOSATICS_FILL for _RS arrays botDragU & botDragV

## What changes does this PR introduce?
fix on PR #219 addition

## What is the current behaviour? 
wrong DIAGNOSATICS_FILL call, responsible for experiments to fail when
using "-ur4", see: 
http://mitgcm.org/testing/results/2019_08/tr_engaging-ifcMpi_20190819_0/summary.txt

## What is the new behaviour 
can the right S/R DIAGNOSATICS_FILL_RS, issue is fixed, see:
http://mitgcm.org/testing/results/2019_08/tr_engaging-ifcMpi_20190819_1/summary.txt

## Does this PR introduce a breaking change? 
no

## Other information:

## Suggested addition to `tag-index`
none (not significant enough)