### PR TITLE
Bump python version for docs test on Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -80,7 +80,7 @@ jobs:
         - sphinx-build -nWa -b ${BUILD} -d _build/doctrees . _build/html
     - env:
       - BUILD="html"
-      python: "3.6"
+      python: "3.7"
       script:
         - tools/ci/install_doc_dependencies.sh > /dev/null
         - cd doc
@@ -94,7 +94,7 @@ jobs:
         - make clean ${BUILD} LATEXOPTS="-interaction=nonstopmode -halt-on-error"
     - env:
       - BUILD="latexpdf"
-      python: "3.6"
+      python: "3.7"
       script:
         - tools/ci/install_doc_dependencies.sh > /dev/null
         - cd doc

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,6 @@
 # Travis file for running some basic set of testreport checks on each commit
+dist: xenial
+
 language: python
 
 services:


### PR DESCRIPTION
## What changes does this PR introduce?
(Bug fix, feature, docs update, ...)

Test update

## What is the current behaviour? 
(You can also link to an open issue here)

Travis builds docs using python 3.6

## What is the new behaviour 
(if this is a feature change)?

Travis builds docs using python 3.7

## Does this PR introduce a breaking change? 
(What changes might users need to make in their application due to this PR?)

No.

## Other information:


## Suggested addition to `tag-index`
(To avoid unnecessary merge conflicts, please don't update `tag-index`. One of the admins will do that when merging your pull request.)