### PR TITLE
Make travis wait for OpenAd build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -27,7 +27,7 @@ jobs:
         MITGCM_DECMD="docker exec -i openad-testing bash -lc"
         MITGCM_TROPT="-oad -devel -of=../tools/build_options/linux_amd64_gfortran"
         MITGCM_INPUT_DIR_PAT='/input_oad.*'
-      script: . tools/ci/runtr.sh
+      script: travis_wait . tools/ci/runtr.sh
     - env:
       - MITGCM_EXP="offline_exf_seaice" MITGCM_PRECS="16 16 16 16 16"
       script: . tools/ci/runtr.sh


### PR DESCRIPTION
## What changes does this PR introduce?
(Bug fix, feature, docs update, ...)

Testing bug fix.

## What is the current behaviour? 
(You can also link to an open issue here)

Travis sometimes times out when make AdAll takes more than 10 minutes because it produces no output.

## What is the new behaviour 
(if this is a feature change)?

Travis will wait up to 20 minutes for the OpenAd testreport.

## Does this PR introduce a breaking change? 
(What changes might users need to make in their application due to this PR?)

No.

## Other information:


## Suggested addition to `tag-index`
(To avoid unnecessary merge conflicts, please don't update `tag-index`. One of the admins will do that when merging your pull request.)