### PR TITLE
Add readthedocs configuration file

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -1,0 +1,20 @@
+# .readthedocs.yml
+# Read the Docs configuration file
+# See https://docs.readthedocs.io/en/stable/config-file/v2.html for details
+
+# Required
+version: 2
+
+# Build documentation in the docs/ directory with Sphinx
+sphinx:
+  configuration: doc/conf.py
+  fail_on_warning: true
+
+# Optionally build your docs in additional formats such as PDF and ePub
+formats:
+  - pdf
+
+# Optionally set the version of Python and requirements required to build your docs
+python:
+  install:
+    - requirements: doc/requirements.txt

--- a/doc/tag-index
+++ b/doc/tag-index
@@ -1,6 +1,9 @@
     Notes on tags used in MITgcmUV
     ==============================
 
+o doc:
+  - add rtfd config file to control build behaviour and options.
+
 checkpoint67l (2019/08/29)
 o QG-Leith viscosity:
   - pkg/mom_common: bug fix for QG Leith viscosity


### PR DESCRIPTION
## What changes does this PR introduce?

Adding a Read the Docs configuration file to turn on the pdf build and fail-on-warning here rather than in settings on the Read the Docs web site.  This mainly affects the docs builds for pull requests (https://blog.readthedocs.com/building-docs-for-pull-requests/), but is also the recommended way for configuring Read the Docs in general.

## What is the current behaviour? 

Docs built for pull requests do not fail for warnings.

## What is the new behaviour 

Docs built for pull requests fail for warnings.

## Does this PR introduce a breaking change? 

No

## Other information:

- As a side effect, python 3.7 is now used for the build instead of python 2.7.
- pdf builds are not available for pull requests as of now, so this part does not change anything yet (but keeps pdfs for regular branch builds).

## Suggested addition to `tag-index`
