### PR TITLE
adjoint diagnostics: dumpAtLast = dumpAtStart 

### DIFF
--- a/pkg/diagnostics/diagnostics_write_adj.F
+++ b/pkg/diagnostics/diagnostics_write_adj.F
@@ -1,7 +1,7 @@
 #include "DIAG_OPTIONS.h"
 
       SUBROUTINE DIAGNOSTICS_WRITE_ADJ (
-     I                               modelEnd,
+     I                               modelStart,
      I                               myTime, myIter, myThid )
 C***********************************************************************
 C  Purpose
@@ -14,7 +14,8 @@ C          than forward model diagnostic convention.
 C
 C  Arguments  Description
 C  ----------------------
-C     modelEnd :: true if call at end of model run.
+C     modelStart :: true if call at start of model run.
+C              :: (this is the adjoint's modelEnd)
 C     myTime   :: Current time of simulation ( s )
 C     myIter   :: Current Iteration Number
 C     myThid   :: my Thread Id number
@@ -27,7 +28,7 @@ C***********************************************************************
 #include "DIAGNOSTICS.h"
 
 C     !INPUT PARAMETERS:
-      LOGICAL modelEnd
+      LOGICAL modelStart
       _RL     myTime
       INTEGER myIter, myThid
 
@@ -83,7 +84,7 @@ C   to mirror ADJdump
      I                          wrTime, myIter, myThid )
           ENDIF
 #endif /* ALLOW_CAL */
-          IF ( dumpAtLast .AND. modelEnd
+          IF ( dumpAtLast .AND. modelStart
      &                    .AND. freqSec.GE.0. ) dump2fileNow = .TRUE.
           IF ( dump2fileNow ) THEN
             write2file = .TRUE.


### PR DESCRIPTION
## What changes does this PR introduce?
(Bug fix, feature, docs update, ...)

Argument `modelEnd` -> `modelStart` for diagnostics_write_adj, so that if `dumpAtLast`=True, then adjoint variables are written at iteration 0. This makes more sense than dumping them at modelEnd, where sensitivities are 0...

## What is the current behaviour? 
(You can also link to an open issue here)

Currently if `dumpAtLast`=True, sensitivities will print for the final time step, where they are 0.

## What is the new behaviour 
(if this is a feature change)?

Sensitivities printed at iteration 0 of adjoint run (this is the end of the adjoint run).

## Does this PR introduce a breaking change? 
(What changes might users need to make in their application due to this PR?)

Nope, no change to the forward code, or anything other than diagnostics. 
## Other information:


## Suggested addition to `tag-index`
(To avoid unnecessary merge conflicts, please don't update `tag-index`. One of the admins will do that when merging your pull request.)