### PR TITLE
Remove python 2.7 doc tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -73,25 +73,11 @@ jobs:
     - stage: test documentation
       env:
       - BUILD="html"
-      python: "2.7"
-      script:
-        - tools/ci/install_doc_dependencies.sh > /dev/null
-        - cd doc
-        - sphinx-build -nWa -b ${BUILD} -d _build/doctrees . _build/html
-    - env:
-      - BUILD="html"
       python: "3.6"
       script:
         - tools/ci/install_doc_dependencies.sh > /dev/null
         - cd doc
         - sphinx-build -nWa -b ${BUILD} -d _build/doctrees . _build/html
-    - env:
-      - BUILD="latexpdf"
-      python: "2.7"
-      script:
-        - tools/ci/install_doc_dependencies.sh > /dev/null
-        - cd doc
-        - make clean ${BUILD} LATEXOPTS="-interaction=nonstopmode -halt-on-error"
     - env:
       - BUILD="latexpdf"
       python: "3.6"


### PR DESCRIPTION
## What changes does this PR introduce?

Test update

## What is the current behaviour? 

Python 2.7 doc test on Travis fails.

## What is the new behaviour 

Docs are no longer tested with Python 2.7.

## Does this PR introduce a breaking change? 

No.

## Other information:

Neither current sphinxcontrib-bibtex nor recent Sphinx support Python 2.X which is approaching end of life.  Time to drop it!

## Suggested addition to `tag-index`
