### PR TITLE
Drop nitpicky option from travis docs build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -77,7 +77,7 @@ jobs:
       script:
         - tools/ci/install_doc_dependencies.sh > /dev/null
         - cd doc
-        - sphinx-build -nWa -b ${BUILD} -d _build/doctrees . _build/html
+        - sphinx-build -Wa -b ${BUILD} -d _build/doctrees . _build/html
     - env:
       - BUILD="latexpdf"
       python: "3.6"


### PR DESCRIPTION
## What changes does this PR introduce?

test options modification

## What is the current behaviour? 

Travis doc test fails when autodoc is used, see #285.

## What is the new behaviour 

Test doesn't fail.

## Does this PR introduce a breaking change? 

No

## Other information:

Turns out that we do not need the nitpicky option to catch all the kinds of undefined references we care about.  It produces an unmanageable number of spurious warnings when autodoc is used, so we are turning it off.