### PR TITLE
Add new Dockerfile for villon

### DIFF
--- a/tools/ci/docker/ubuntu_18_04_villon/Dockerfile
+++ b/tools/ci/docker/ubuntu_18_04_villon/Dockerfile
@@ -1,0 +1,5 @@
+FROM ubuntu:18.04
+
+RUN apt-get -y update  
+RUN apt-get -y install build-essential git gfortran
+

--- a/tools/ci/docker/ubuntu_18_04_villon/README.md
+++ b/tools/ci/docker/ubuntu_18_04_villon/README.md
@@ -1,0 +1,1 @@
+Dockerfile that is consistent with villon.mit.edu reference testing machine.


### PR DESCRIPTION
## What changes does this PR introduce?
Docker image for travis and villon reference machine


## What is the current behaviour? 
this docker image does not exist 


## What is the new behaviour 
adds a new image 


## Does this PR introduce a breaking change? 
no. This just triggers image creation for use in subsequent update. 


## Other information:


## Suggested addition to `tag-index`
- add new Dockerfile with spec compatible villon