### PR TITLE
Add in python for testreport check

### DIFF
--- a/tools/ci/docker/ubuntu_18_04_villon/Dockerfile
+++ b/tools/ci/docker/ubuntu_18_04_villon/Dockerfile
@@ -1,5 +1,6 @@
 FROM ubuntu:18.04
+LABEL maintainer=mitgcm-devel@mitgcm.org
 
 RUN apt-get -y update  
-RUN apt-get -y install build-essential git gfortran
+RUN apt-get -y install build-essential git gfortran python python3
 


### PR DESCRIPTION
## What changes does this PR introduce?
Include python in Docker for villon test report

## What is the current behaviour? 
python is missing so Travis test for pass fails

## What is the new behaviour 
hopefully Travis  test for pass works

## Does this PR introduce a breaking change? 
No

## Other information:


## Suggested addition to `tag-index`