### PR TITLE
ECCO nosumsq preproc option

### DIFF
--- a/doc/tag-index
+++ b/doc/tag-index
@@ -1,6 +1,11 @@
     Notes on tags used in MITgcmUV
     ==============================
 
+o pkg/ecco:
+  - change S/R ECCO_READWEI to read in uncertainty file and compute weight
+    as 1/sigma if nosumsq is provided as a preprocessing option, or 1/sigma^2
+    if not. This is the expected behavior based on the "generic cost function"
+    section of the documentation.
 o verification:
   - new experiment "global_oce_biogeo_bling" move here from verification_other.
 o pkg/cheapaml:

--- a/pkg/ecco/cost_gencost_bpv4.F
+++ b/pkg/ecco/cost_gencost_bpv4.F
@@ -70,6 +70,7 @@ c     == local variables ==
       _RL offset_sum
 
       integer k, kgen
+      logical dosumsq
 
 c     == external functions ==
 
@@ -92,10 +93,11 @@ c     == end of interface ==
 
       if (kgen.GT.0) then
 
+       dosumsq=.TRUE.
        call ecco_zero(gencost_weight(:,:,1,1,kgen),1,zeroRL,myThid)
        if ( gencost_errfile(kgen) .NE. ' ' )
      &   call ecco_readwei(gencost_errfile(kgen),
-     &     gencost_weight(:,:,1,1,kgen),1,1,myThid)
+     &     gencost_weight(:,:,1,1,kgen),1,1,dosumsq,myThid)
 
 c-- initialise local variables
 cgf convert phibot from m2/s2 to cm

--- a/pkg/ecco/cost_gencost_seaicev4.F
+++ b/pkg/ecco/cost_gencost_seaicev4.F
@@ -204,14 +204,18 @@ c====================================================
         call ecco_zero(localweight,nnzsiv4,zeroRL,myThid)
 #ifdef SEAICECOST_JPL
        fname0w=gencost_errfile(igen_conc)
-       call ecco_readwei(fname0w,localweight,localrec,nnzsiv4,myThid)
+       call ecco_readwei(fname0w,localweight,localrec,
+     &      nnzsiv4,dosumsq,myThid)
        call ecco_readwei(gencost_errfile(igen_deconc),
-     &      gencost_weight(1,1,1,1,igen_deconc),localrec,nnzsiv4,myThid)
+     &      gencost_weight(1,1,1,1,igen_deconc),localrec,
+     &      nnzsiv4,dosumsq,myThid)
        call ecco_readwei(gencost_errfile(igen_exconc),
-     &      gencost_weight(1,1,1,1,igen_exconc),localrec,nnzsiv4,myThid)
+     &      gencost_weight(1,1,1,1,igen_exconc),localrec,
+     &      nnzsiv4,dosumsq,myThid)
 #else
         if ( (localrec. GT. 0).AND.(obsrec .GT. 0).AND.(exst) ) then
-          call ecco_readwei(fname0w,localweight,localrec,nnzsiv4,myThid)
+          call ecco_readwei(fname0w,localweight,localrec,
+     &      nnzsiv4,dosumsq,myThid)
         else
           WRITE(standardMessageUnit,'(A)')
      &     'siv4cost WARNING: ALL WEIGHTS ZEROS! NO CONTRIBUTION'

--- a/pkg/ecco/cost_gencost_sshv4.F
+++ b/pkg/ecco/cost_gencost_sshv4.F
@@ -153,6 +153,7 @@ c for PART 4/5: compute smooth/raw anomalies
       _RL ndaysaveRL
 
       integer k2, k2_mdt, k2_lsc
+      logical dosumsq
 
       character*(80) fname
       character*(80) fname4test
@@ -201,6 +202,7 @@ c-- detect the relevant gencost indices
         if (gencost_posproc(k2,igen_lsc).EQ.'smooth') k2_lsc=k2
       enddo
 
+      dosumsq = .TRUE.
       call ecco_zero(gencost_weight(:,:,1,1,igen_mdt),1,zeroRL,myThid)
       call ecco_zero(gencost_weight(:,:,1,1,igen_lsc),1,zeroRL,myThid)
       call ecco_zero(gencost_weight(:,:,1,1,igen_tp),1,zeroRL,myThid)
@@ -208,19 +210,19 @@ c-- detect the relevant gencost indices
       call ecco_zero(gencost_weight(:,:,1,1,igen_gfo),1,zeroRL,myThid)
       if ( gencost_errfile(igen_mdt) .NE. ' ' )
      &     call ecco_readwei(gencost_errfile(igen_mdt),
-     &     gencost_weight(:,:,1,1,igen_mdt),1,1,myThid)
+     &     gencost_weight(:,:,1,1,igen_mdt),1,1,dosumsq,myThid)
       if ( gencost_errfile(igen_lsc) .NE. ' ' )
      &     call ecco_readwei(gencost_errfile(igen_lsc),
-     &     gencost_weight(:,:,1,1,igen_lsc),1,1,myThid)
+     &     gencost_weight(:,:,1,1,igen_lsc),1,1,dosumsq,myThid)
       if ( gencost_errfile(igen_tp) .NE. ' ' )
      &     call ecco_readwei(gencost_errfile(igen_tp),
-     &     gencost_weight(:,:,1,1,igen_tp),1,1,myThid)
+     &     gencost_weight(:,:,1,1,igen_tp),1,1,dosumsq,myThid)
       if ( gencost_errfile(igen_ers) .NE. ' ' )
      &     call ecco_readwei(gencost_errfile(igen_ers),
-     &     gencost_weight(:,:,1,1,igen_ers),1,1,myThid)
+     &     gencost_weight(:,:,1,1,igen_ers),1,1,dosumsq,myThid)
       if ( gencost_errfile(igen_gfo) .NE. ' ' )
      &     call ecco_readwei(gencost_errfile(igen_gfo),
-     &     gencost_weight(:,:,1,1,igen_gfo),1,1,myThid)
+     &     gencost_weight(:,:,1,1,igen_gfo),1,1,dosumsq,myThid)
 
 c switch for excluding global mean
       useEtaMean=.TRUE.

--- a/pkg/ecco/cost_gencost_sstv4.F
+++ b/pkg/ecco/cost_gencost_sstv4.F
@@ -93,6 +93,7 @@ c     == local variables ==
       integer md, dd, sd, ld, wd
 
       integer kgen, kgen_lsc
+      logical dosumsq
 
 c     == external functions ==
 
@@ -131,14 +132,15 @@ c-- detect the relevant gencost indices
       if (kgen.NE.0) then
 c ------
 
+      dosumsq=.TRUE.
       call ecco_zero(gencost_weight(:,:,1,1,kgen),1,zeroRL,myThid)
       call ecco_zero(gencost_weight(:,:,1,1,kgen_lsc),1,zeroRL,myThid)
       if ( gencost_errfile(kgen) .NE. ' ' )
      &     call ecco_readwei(gencost_errfile(kgen),
-     &     gencost_weight(:,:,1,1,kgen),1,1,myThid)
+     &     gencost_weight(:,:,1,1,kgen),1,1,dosumsq,myThid)
       if ( gencost_errfile(kgen_lsc) .NE. ' ' )
      &     call ecco_readwei(gencost_errfile(kgen_lsc),
-     &     gencost_weight(:,:,1,1,kgen_lsc),1,1,myThid)
+     &     gencost_weight(:,:,1,1,kgen_lsc),1,1,dosumsq,myThid)
 
       call cal_FullDate(19920101,0,locstartdate,myThid)
 

--- a/pkg/ecco/cost_generic.F
+++ b/pkg/ecco/cost_generic.F
@@ -336,7 +336,8 @@ c--     load weights
      &     fname3, localrec, obsrec, exst, myThid )
         call ecco_zero(localweight,nnzobs,zeroRL,myThid)
         if ( (localrec .GT. 0).AND.(obsrec .GT. 0).AND.(exst) )
-     &  call ecco_readwei(fname3,localweight,localrec,nnzobs,myThid)
+     &  call ecco_readwei(fname3,localweight,
+     &                    localrec,nnzobs,dosumsq,myThid)
 
 c--     determine records and file names
         exst=.FALSE.

--- a/pkg/ecco/ecco_toolbox.F
+++ b/pkg/ecco/ecco_toolbox.F
@@ -1228,13 +1228,13 @@ CEOP
 c--        Test for missing values.
            if (localweight(i,j,k,bi,bj) .lt. -9900.) then
              localweight(i,j,k,bi,bj) = 0. _d 0
-           endif
 c--        Convert to weight
-           if (localweight(i,j,k,bi,bj) .ne. 0.) then
+           elseif ( localweight(i,j,k,bi,bj).ne.0. .AND. dosumsq ) then
               localweight(i,j,k,bi,bj) =
-     &             1./localweight(i,j,k,bi,bj)
-              if (dosumsq) localweight(i,j,k,bi,bj) =
-     &             localweight(i,j,k,bi,bj)*localweight(i,j,k,bi,bj)
+     &          oneRL/localweight(i,j,k,bi,bj)/localweight(i,j,k,bi,bj)
+           elseif ( localweight(i,j,k,bi,bj).ne.0. ) then
+              localweight(i,j,k,bi,bj) =
+     &           oneRL/localweight(i,j,k,bi,bj)
            endif
           enddo
          enddo

--- a/pkg/ecco/ecco_toolbox.F
+++ b/pkg/ecco/ecco_toolbox.F
@@ -1165,6 +1165,7 @@ C     !INTERFACE:
      O                           localweight,
      I                           iRec,
      I                           nnzbar,
+     I                           dosumsq,
      I                           myThid
      &                         )
 
@@ -1192,6 +1193,7 @@ C     iRec:            record number
       INTEGER iRec
       INTEGER myThid
       INTEGER nnzbar
+      LOGICAL dosumsq
 
 #ifdef ALLOW_ECCO
 
@@ -1230,8 +1232,9 @@ c--        Test for missing values.
 c--        Convert to weight
            if (localweight(i,j,k,bi,bj) .ne. 0.) then
               localweight(i,j,k,bi,bj) =
-     &             1./localweight(i,j,k,bi,bj)/
-     &                localweight(i,j,k,bi,bj)
+     &             1./localweight(i,j,k,bi,bj)
+              if (dosumsq) localweight(i,j,k,bi,bj) =
+     &             localweight(i,j,k,bi,bj)*localweight(i,j,k,bi,bj)
            endif
           enddo
          enddo


### PR DESCRIPTION
## What changes does this PR introduce?
(Bug fix, feature, docs update, ...)

Bug fix: this changes `ecco_readwei` to read in uncertainty file and compute weight as `1/sigma` if `nosumsq` is provided as a preprocessing option, or `1/sigma^2` if not. This is the expected behavior based on the following line in [the documentation](https://mitgcm.readthedocs.io/en/latest/ocean_state_est/ocean_state_est.html#generic-cost-function)

>By default cost functions are quadratic but 𝑑⃗ 𝑇𝑖𝑅−1𝑖𝑑⃗ 𝑖 can be replaced with 𝑅−1/2𝑖𝑑⃗ 𝑖 using the nosumsq option (Table 10.4).

## What is the current behaviour? 
(You can also link to an open issue here)

cost function weights are computed to be `1/sigma^2` no matter if `nosumsq` is provided as a preprocessing option or not

## What is the new behaviour 
(if this is a feature change)?

described above

## Does this PR introduce a breaking change? 
(What changes might users need to make in their application due to this PR?)


## Other information:

This modifies all functions which call `ecco_readwei`, providing the `dosumsq` flag. Note that `cost_gencost_sstv4`, `cost_gencost_sshv4`, and `cost_gencost_bpv4` are special in that the cost is hard coded to be quadratic, so I set `dosumsq=.TRUE.` in these subroutines, rather than taking in the user's input. 

All other instances of `ecco_readwei` take `dosumsq` flag based on user input.

## Suggested addition to `tag-index`
(To avoid unnecessary merge conflicts, please don't update `tag-index`. One of the admins will do that when merging your pull request.)