### PR TITLE
add TAF storage dir for geothermal-flux

### DIFF
--- a/pkg/autodiff/checkpoint_lev1_directives.h
+++ b/pkg/autodiff/checkpoint_lev1_directives.h
@@ -157,6 +157,10 @@ CADJ &     kind = isbyte
 CADJ STORE Qsw1    = comlev1, key = ikey_dynamics,
 CADJ &     kind = isbyte
 # endif
+# ifdef ALLOW_GEOTHERMAL_FLUX
+CADJ STORE geothFlux0 = comlev1, key = ikey_dynamics, kind = isbyte
+CADJ STORE geothFlux1 = comlev1, key = ikey_dynamics, kind = isbyte
+# endif
 # ifdef ATMOSPHERIC_LOADING
 CADJ STORE pload0  = comlev1, key = ikey_dynamics,
 CADJ &     kind = isbyte

--- a/pkg/autodiff/checkpoint_lev2_directives.h
+++ b/pkg/autodiff/checkpoint_lev2_directives.h
@@ -25,6 +25,10 @@ CADJ STORE saltflux1 = tapelev2, key = ilev_2
 CADJ STORE qsw0 = tapelev2, key = ilev_2
 CADJ STORE qsw1 = tapelev2, key = ilev_2
 #endif
+# ifdef ALLOW_GEOTHERMAL_FLUX
+CADJ STORE geothFlux0 = tapelev2, key = ilev_2
+CADJ STORE geothFlux1 = tapelev2, key = ilev_2
+# endif
 #ifdef ATMOSPHERIC_LOADING
 CADJ STORE pload0 = tapelev2, key = ilev_2
 CADJ STORE pload1 = tapelev2, key = ilev_2

--- a/pkg/autodiff/checkpoint_lev3_directives.h
+++ b/pkg/autodiff/checkpoint_lev3_directives.h
@@ -25,6 +25,10 @@ CADJ STORE saltflux1 = tapelev3, key = ilev_3
 CADJ STORE qsw0 = tapelev3, key = ilev_3
 CADJ STORE qsw1 = tapelev3, key = ilev_3
 #endif
+# ifdef ALLOW_GEOTHERMAL_FLUX
+CADJ STORE geothFlux0 = tapelev3, key = ilev_3
+CADJ STORE geothFlux1 = tapelev3, key = ilev_3
+# endif
 #ifdef ATMOSPHERIC_LOADING
 CADJ STORE pload0 = tapelev3, key = ilev_3
 CADJ STORE pload1 = tapelev3, key = ilev_3

--- a/pkg/autodiff/checkpoint_lev4_directives.h
+++ b/pkg/autodiff/checkpoint_lev4_directives.h
@@ -25,6 +25,10 @@ CADJ STORE saltflux1 = tapelev4, key = ilev_4
 CADJ STORE qsw0 = tapelev4, key = ilev_4
 CADJ STORE qsw1 = tapelev4, key = ilev_4
 #endif
+# ifdef ALLOW_GEOTHERMAL_FLUX
+CADJ STORE geothFlux0 = tapelev4, key = ilev_4
+CADJ STORE geothFlux1 = tapelev4, key = ilev_4
+# endif
 #ifdef ATMOSPHERIC_LOADING
 CADJ STORE pload0 = tapelev4, key = ilev_4
 CADJ STORE pload1 = tapelev4, key = ilev_4


### PR DESCRIPTION
- add TAF storage dir for time-dependent geothermal heat-flux
  that were missing in recently merged PR #299

## What changes does this PR introduce?
see above.

## What is the current behaviour?
Storage dir are missing since these 2 arrays were added in PR #299 ;
as a consequence, TAF-AD experiments that use #define ALLOW_GEOTHERMAL_FLUX
are now broken:
 http://mitgcm.org/testing/results/2019_11/tr_glacier3_20191109_3/summary.txt

## What is the new behaviour
fixed by adding correct storage dir.

## Does this PR introduce a breaking change? 
no changes except fix in conditions described above

## Other information:
Note: no intent to clean-up these checkpoint-lev-directive files here 
      since this cleaning is the purpose of currently opened PR #250

## Suggested addition to `tag-index`
none (minor fix to PR #299 that just follows it with nothing in between)