### PR TITLE
add TAF STORE for OB eta with shelfice or seaice + NLFS

### DIFF
--- a/pkg/autodiff/autodiff_restore.F
+++ b/pkg/autodiff/autodiff_restore.F
@@ -26,7 +26,7 @@ c     ==================================================================
 c     SUBROUTINE autodiff_restore
 c     ==================================================================
 
-      implicit none
+      IMPLICIT NONE
 
 c     == global variables ==
 
@@ -317,6 +317,7 @@ C-      2D arrays
           OBNv(I,K,bi,bj)    = StoreOBCSN(I,K,bi,bj,2)
           OBNt(I,K,bi,bj)    = StoreOBCSN(I,K,bi,bj,3)
           OBNs(I,K,bi,bj)    = StoreOBCSN(I,K,bi,bj,4)
+#  ifdef ALLOW_OBCS_PRESCRIBE
           OBNu0(I,K,bi,bj)   = StoreOBCSN(I,K,bi,bj,5)
           OBNv0(I,K,bi,bj)   = StoreOBCSN(I,K,bi,bj,6)
           OBNt0(I,K,bi,bj)   = StoreOBCSN(I,K,bi,bj,7)
@@ -325,6 +326,7 @@ C-      2D arrays
           OBNv1(I,K,bi,bj)   = StoreOBCSN(I,K,bi,bj,10)
           OBNt1(I,K,bi,bj)   = StoreOBCSN(I,K,bi,bj,11)
           OBNs1(I,K,bi,bj)   = StoreOBCSN(I,K,bi,bj,12)
+#  endif
 #  ifdef ALLOW_OBCSN_CONTROL
           xx_obcsn0(I,K,bi,bj,1)   = StoreOBCSN(I,K,bi,bj,13)
           xx_obcsn0(I,K,bi,bj,2)   = StoreOBCSN(I,K,bi,bj,14)
@@ -352,6 +354,7 @@ C-      2D arrays
           OBSv(I,K,bi,bj)       = StoreOBCSS(I,K,bi,bj,2)
           OBSt(I,K,bi,bj)       = StoreOBCSS(I,K,bi,bj,3)
           OBSs(I,K,bi,bj)       = StoreOBCSS(I,K,bi,bj,4)
+#  ifdef ALLOW_OBCS_PRESCRIBE
           OBSu0(I,K,bi,bj)      = StoreOBCSS(I,K,bi,bj,5)
           OBSv0(I,K,bi,bj)      = StoreOBCSS(I,K,bi,bj,6)
           OBSt0(I,K,bi,bj)      = StoreOBCSS(I,K,bi,bj,7)
@@ -360,6 +363,7 @@ C-      2D arrays
           OBSv1(I,K,bi,bj)      = StoreOBCSS(I,K,bi,bj,10)
           OBSt1(I,K,bi,bj)      = StoreOBCSS(I,K,bi,bj,11)
           OBSs1(I,K,bi,bj)      = StoreOBCSS(I,K,bi,bj,12)
+#  endif
 #  ifdef ALLOW_OBCSS_CONTROL
           xx_obcss0(I,K,bi,bj,1)   = StoreOBCSS(I,K,bi,bj,13)
           xx_obcss0(I,K,bi,bj,2)   = StoreOBCSS(I,K,bi,bj,14)
@@ -387,6 +391,7 @@ C-      2D arrays
           OBEv(J,K,bi,bj)      = StoreOBCSE(J,K,bi,bj,2)
           OBEt(J,K,bi,bj)      = StoreOBCSE(J,K,bi,bj,3)
           OBEs(J,K,bi,bj)      = StoreOBCSE(J,K,bi,bj,4)
+#  ifdef ALLOW_OBCS_PRESCRIBE
           OBEu0(J,K,bi,bj)     = StoreOBCSE(J,K,bi,bj,5)
           OBEv0(J,K,bi,bj)     = StoreOBCSE(J,K,bi,bj,6)
           OBEt0(J,K,bi,bj)     = StoreOBCSE(J,K,bi,bj,7)
@@ -395,6 +400,7 @@ C-      2D arrays
           OBEv1(J,K,bi,bj)     = StoreOBCSE(J,K,bi,bj,10)
           OBEt1(J,K,bi,bj)     = StoreOBCSE(J,K,bi,bj,11)
           OBEs1(J,K,bi,bj)     = StoreOBCSE(J,K,bi,bj,12)
+#  endif
 #  ifdef ALLOW_OBCSE_CONTROL
           xx_obcse0(J,K,bi,bj,1)     = StoreOBCSE(J,K,bi,bj,13)
           xx_obcse0(J,K,bi,bj,2)     = StoreOBCSE(J,K,bi,bj,14)
@@ -422,6 +428,7 @@ C-      2D arrays
           OBWv(J,K,bi,bj)      = StoreOBCSW(J,K,bi,bj,2)
           OBWt(J,K,bi,bj)      = StoreOBCSW(J,K,bi,bj,3)
           OBWs(J,K,bi,bj)      = StoreOBCSW(J,K,bi,bj,4)
+#  ifdef ALLOW_OBCS_PRESCRIBE
           OBWu0(J,K,bi,bj)     = StoreOBCSW(J,K,bi,bj,5)
           OBWv0(J,K,bi,bj)     = StoreOBCSW(J,K,bi,bj,6)
           OBWt0(J,K,bi,bj)     = StoreOBCSW(J,K,bi,bj,7)
@@ -430,6 +437,7 @@ C-      2D arrays
           OBWv1(J,K,bi,bj)     = StoreOBCSW(J,K,bi,bj,10)
           OBWt1(J,K,bi,bj)     = StoreOBCSW(J,K,bi,bj,11)
           OBWs1(J,K,bi,bj)     = StoreOBCSW(J,K,bi,bj,12)
+#  endif
 #  ifdef ALLOW_OBCSW_CONTROL
           xx_obcsw0(J,K,bi,bj,1) = StoreOBCSW(J,K,bi,bj,13)
           xx_obcsw0(J,K,bi,bj,2) = StoreOBCSW(J,K,bi,bj,14)

--- a/pkg/autodiff/autodiff_store.F
+++ b/pkg/autodiff/autodiff_store.F
@@ -387,6 +387,7 @@ C-      2D arrays
           StoreOBCSN(I,K,bi,bj,2)  = OBNv(I,K,bi,bj)
           StoreOBCSN(I,K,bi,bj,3)  = OBNt(I,K,bi,bj)
           StoreOBCSN(I,K,bi,bj,4)  = OBNs(I,K,bi,bj)
+#  ifdef ALLOW_OBCS_PRESCRIBE
           StoreOBCSN(I,K,bi,bj,5)  = OBNu0(I,K,bi,bj)
           StoreOBCSN(I,K,bi,bj,6)  = OBNv0(I,K,bi,bj)
           StoreOBCSN(I,K,bi,bj,7)  = OBNt0(I,K,bi,bj)
@@ -395,6 +396,7 @@ C-      2D arrays
           StoreOBCSN(I,K,bi,bj,10) = OBNv1(I,K,bi,bj)
           StoreOBCSN(I,K,bi,bj,11) = OBNt1(I,K,bi,bj)
           StoreOBCSN(I,K,bi,bj,12) = OBNs1(I,K,bi,bj)
+#  endif
 #  ifdef ALLOW_OBCSN_CONTROL
           StoreOBCSN(I,K,bi,bj,13) = xx_obcsn0(I,K,bi,bj,1)
           StoreOBCSN(I,K,bi,bj,14) = xx_obcsn0(I,K,bi,bj,2)
@@ -431,6 +433,7 @@ C-      2D arrays
           StoreOBCSS(I,K,bi,bj,2)  = OBSv(I,K,bi,bj)
           StoreOBCSS(I,K,bi,bj,3)  = OBSt(I,K,bi,bj)
           StoreOBCSS(I,K,bi,bj,4)  = OBSs(I,K,bi,bj)
+#  ifdef ALLOW_OBCS_PRESCRIBE
           StoreOBCSS(I,K,bi,bj,5)  = OBSu0(I,K,bi,bj)
           StoreOBCSS(I,K,bi,bj,6)  = OBSv0(I,K,bi,bj)
           StoreOBCSS(I,K,bi,bj,7)  = OBSt0(I,K,bi,bj)
@@ -439,6 +442,7 @@ C-      2D arrays
           StoreOBCSS(I,K,bi,bj,10) = OBSv1(I,K,bi,bj)
           StoreOBCSS(I,K,bi,bj,11) = OBSt1(I,K,bi,bj)
           StoreOBCSS(I,K,bi,bj,12) = OBSs1(I,K,bi,bj)
+#  endif
 #  ifdef ALLOW_OBCSS_CONTROL
           StoreOBCSS(I,K,bi,bj,13) = xx_obcss0(I,K,bi,bj,1)
           StoreOBCSS(I,K,bi,bj,14) = xx_obcss0(I,K,bi,bj,2)
@@ -475,6 +479,7 @@ C-      2D arrays
           StoreOBCSE(J,K,bi,bj,2)  = OBEv(J,K,bi,bj)
           StoreOBCSE(J,K,bi,bj,3)  = OBEt(J,K,bi,bj)
           StoreOBCSE(J,K,bi,bj,4)  = OBEs(J,K,bi,bj)
+#  ifdef ALLOW_OBCS_PRESCRIBE
           StoreOBCSE(J,K,bi,bj,5)  = OBEu0(J,K,bi,bj)
           StoreOBCSE(J,K,bi,bj,6)  = OBEv0(J,K,bi,bj)
           StoreOBCSE(J,K,bi,bj,7)  = OBEt0(J,K,bi,bj)
@@ -483,6 +488,7 @@ C-      2D arrays
           StoreOBCSE(J,K,bi,bj,10) = OBEv1(J,K,bi,bj)
           StoreOBCSE(J,K,bi,bj,11) = OBEt1(J,K,bi,bj)
           StoreOBCSE(J,K,bi,bj,12) = OBEs1(J,K,bi,bj)
+#  endif
 #  ifdef ALLOW_OBCSE_CONTROL
           StoreOBCSE(J,K,bi,bj,13) = xx_obcse0(J,K,bi,bj,1)
           StoreOBCSE(J,K,bi,bj,14) = xx_obcse0(J,K,bi,bj,2)
@@ -519,6 +525,7 @@ C-      2D arrays
           StoreOBCSW(J,K,bi,bj,2)  = OBWv(J,K,bi,bj)
           StoreOBCSW(J,K,bi,bj,3)  = OBWt(J,K,bi,bj)
           StoreOBCSW(J,K,bi,bj,4)  = OBWs(J,K,bi,bj)
+#  ifdef ALLOW_OBCS_PRESCRIBE
           StoreOBCSW(J,K,bi,bj,5)  = OBWu0(J,K,bi,bj)
           StoreOBCSW(J,K,bi,bj,6)  = OBWv0(J,K,bi,bj)
           StoreOBCSW(J,K,bi,bj,7)  = OBWt0(J,K,bi,bj)
@@ -527,6 +534,7 @@ C-      2D arrays
           StoreOBCSW(J,K,bi,bj,10) = OBWv1(J,K,bi,bj)
           StoreOBCSW(J,K,bi,bj,11) = OBWt1(J,K,bi,bj)
           StoreOBCSW(J,K,bi,bj,12) = OBWs1(J,K,bi,bj)
+#  endif
 #  ifdef ALLOW_OBCSW_CONTROL
           StoreOBCSW(J,K,bi,bj,13) = xx_obcsw0(J,K,bi,bj,1)
           StoreOBCSW(J,K,bi,bj,14) = xx_obcsw0(J,K,bi,bj,2)

--- a/pkg/obcs/obcs_ad_check_lev1_dir.h
+++ b/pkg/obcs/obcs_ad_check_lev1_dir.h
@@ -5,12 +5,14 @@ CADJ STORE OBNu    = comlev1, key = ikey_dynamics
 CADJ STORE OBNv    = comlev1, key = ikey_dynamics
 CADJ STORE OBNt    = comlev1, key = ikey_dynamics
 CADJ STORE OBNs    = comlev1, key = ikey_dynamics
+#ifdef ALLOW_OBCS_PRESCRIBE
 CADJ STORE obnu0,obnu1  = comlev1, key = ikey_dynamics
 CADJ STORE obnv0,obnv1  = comlev1, key = ikey_dynamics
 CADJ STORE obnt0,obnt1  = comlev1, key = ikey_dynamics
 CADJ STORE obns0,obns1  = comlev1, key = ikey_dynamics
 #ifdef NONLIN_FRSURF
 CADJ STORE obneta0,obneta1 = comlev1, key = ikey_dynamics
+#endif
 #endif
 # ifdef ALLOW_OBCS_STEVENS
 CADJ STORE OBNtStevens = comlev1, key = ikey_dynamics
@@ -27,12 +29,14 @@ CADJ STORE OBSu    = comlev1, key = ikey_dynamics
 CADJ STORE OBSv    = comlev1, key = ikey_dynamics
 CADJ STORE OBSt    = comlev1, key = ikey_dynamics
 CADJ STORE OBSs    = comlev1, key = ikey_dynamics
+#ifdef ALLOW_OBCS_PRESCRIBE
 CADJ STORE obsu0,obsu1  = comlev1, key = ikey_dynamics
 CADJ STORE obsv0,obsv1  = comlev1, key = ikey_dynamics
 CADJ STORE obst0,obst1  = comlev1, key = ikey_dynamics
 CADJ STORE obss0,obss1  = comlev1, key = ikey_dynamics
 #ifdef NONLIN_FRSURF
 CADJ STORE obseta0,obseta1 = comlev1, key = ikey_dynamics
+#endif
 #endif
 # ifdef ALLOW_OBCS_STEVENS
 CADJ STORE OBStStevens = comlev1, key = ikey_dynamics
@@ -49,12 +53,14 @@ CADJ STORE OBEu    = comlev1, key = ikey_dynamics
 CADJ STORE OBEv    = comlev1, key = ikey_dynamics
 CADJ STORE OBEt    = comlev1, key = ikey_dynamics
 CADJ STORE OBEs    = comlev1, key = ikey_dynamics
+#ifdef ALLOW_OBCS_PRESCRIBE
 CADJ STORE obeu0,obeu1  = comlev1, key = ikey_dynamics
 CADJ STORE obev0,obev1  = comlev1, key = ikey_dynamics
 CADJ STORE obet0,obet1  = comlev1, key = ikey_dynamics
 CADJ STORE obes0,obes1  = comlev1, key = ikey_dynamics
 #ifdef NONLIN_FRSURF
 CADJ STORE obeeta0,obeeta1 = comlev1, key = ikey_dynamics
+#endif
 #endif
 # ifdef ALLOW_OBCS_STEVENS
 CADJ STORE OBEtStevens = comlev1, key = ikey_dynamics
@@ -71,12 +77,14 @@ CADJ STORE OBWu    = comlev1, key = ikey_dynamics
 CADJ STORE OBWv    = comlev1, key = ikey_dynamics
 CADJ STORE OBWt    = comlev1, key = ikey_dynamics
 CADJ STORE OBWs    = comlev1, key = ikey_dynamics
+#ifdef ALLOW_OBCS_PRESCRIBE
 CADJ STORE obwu0,obwu1  = comlev1, key = ikey_dynamics
 CADJ STORE obwv0,obwv1  = comlev1, key = ikey_dynamics
 CADJ STORE obwt0,obwt1  = comlev1, key = ikey_dynamics
 CADJ STORE obws0,obws1  = comlev1, key = ikey_dynamics
 #ifdef NONLIN_FRSURF
 CADJ STORE obweta0,obweta1 = comlev1, key = ikey_dynamics
+#endif
 #endif
 # ifdef ALLOW_OBCS_STEVENS
 CADJ STORE OBWtStevens = comlev1, key = ikey_dynamics

--- a/pkg/obcs/obcs_ad_check_lev2_dir.h
+++ b/pkg/obcs/obcs_ad_check_lev2_dir.h
@@ -146,19 +146,13 @@ CADJ STORE OBWsn1 = tapelev2, key = ilev_2
 #
 # endif /* ALLOW_SEAICE */
 
-# if (defined ALLOW_SHELFICE || defined ALLOW_SEAICE) && (defined NONLIN_FRSURF)
-#  ifdef ALLOW_OBCS_NORTH
+# if (defined ALLOW_SEAICE || defined ALLOW_SHELFICE)
+#  if (defined NONLIN_FRSURF && defined ALLOW_OBCS_PRESCRIBE)
 CADJ STORE obneta0,obneta1 = tapelev2, key = ilev_2
-#  endif
-#  ifdef ALLOW_OBCS_SOUTH
 CADJ STORE obseta0,obseta1 = tapelev2, key = ilev_2
-#  endif
-#  ifdef ALLOW_OBCS_EAST
 CADJ STORE obeeta0,obeeta1 = tapelev2, key = ilev_2
-#  endif
-#  ifdef ALLOW_OBCS_WEST
 CADJ STORE obweta0,obweta1 = tapelev2, key = ilev_2
 #  endif
 # endif
-#
+
 #endif  /* ALLOW_OBCS */

--- a/pkg/obcs/obcs_ad_check_lev2_dir.h
+++ b/pkg/obcs/obcs_ad_check_lev2_dir.h
@@ -87,9 +87,6 @@ CADJ STORE OBNa0  = tapelev2, key = ilev_2
 CADJ STORE OBNa1  = tapelev2, key = ilev_2
 CADJ STORE OBNsn0 = tapelev2, key = ilev_2
 CADJ STORE OBNsn1 = tapelev2, key = ilev_2
-#ifdef NONLIN_FRSURF
-CADJ STORE obneta0,obneta1 = tapelev2, key = ilev_2
-#endif
 #endif /* ALLOW_OBCS_PRESCRIBE */
 #endif /* ALLOW_OBCS_NORTH */
 #ifdef ALLOW_OBCS_SOUTH
@@ -108,9 +105,6 @@ CADJ STORE OBSa0  = tapelev2, key = ilev_2
 CADJ STORE OBSa1  = tapelev2, key = ilev_2
 CADJ STORE OBSsn0 = tapelev2, key = ilev_2
 CADJ STORE OBSsn1 = tapelev2, key = ilev_2
-#ifdef NONLIN_FRSURF
-CADJ STORE obseta0,obseta1 = tapelev2, key = ilev_2
-#endif
 #endif /* ALLOW_OBCS_PRESCRIBE */
 #endif /* ALLOW_OBCS_SOUTH */
 #ifdef ALLOW_OBCS_EAST
@@ -129,9 +123,6 @@ CADJ STORE OBEa0  = tapelev2, key = ilev_2
 CADJ STORE OBEa1  = tapelev2, key = ilev_2
 CADJ STORE OBEsn0 = tapelev2, key = ilev_2
 CADJ STORE OBEsn1 = tapelev2, key = ilev_2
-#ifdef NONLIN_FRSURF
-CADJ STORE obeeta0,obeeta1 = tapelev2, key = ilev_2
-#endif
 #endif /* ALLOW_OBCS_PRESCRIBE */
 #endif /* ALLOW_OBCS_EAST */
 #ifdef ALLOW_OBCS_WEST
@@ -150,12 +141,24 @@ CADJ STORE OBWa0  = tapelev2, key = ilev_2
 CADJ STORE OBWa1  = tapelev2, key = ilev_2
 CADJ STORE OBWsn0 = tapelev2, key = ilev_2
 CADJ STORE OBWsn1 = tapelev2, key = ilev_2
-#ifdef NONLIN_FRSURF
-CADJ STORE obweta0,obweta1 = tapelev2, key = ilev_2
-#endif
 #endif /* ALLOW_OBCS_PRESCRIBE */
 #endif /* ALLOW_OBCS_WEST */
 #
 # endif /* ALLOW_SEAICE */
+
+# if (defined ALLOW_SHELFICE || defined ALLOW_SEAICE) && (defined NONLIN_FRSURF)
+#  ifdef ALLOW_OBCS_NORTH
+CADJ STORE obneta0,obneta1 = tapelev2, key = ilev_2
+#  endif
+#  ifdef ALLOW_OBCS_SOUTH
+CADJ STORE obseta0,obseta1 = tapelev2, key = ilev_2
+#  endif
+#  ifdef ALLOW_OBCS_EAST
+CADJ STORE obeeta0,obeeta1 = tapelev2, key = ilev_2
+#  endif
+#  ifdef ALLOW_OBCS_WEST
+CADJ STORE obweta0,obweta1 = tapelev2, key = ilev_2
+#  endif
+# endif
 #
 #endif  /* ALLOW_OBCS */

--- a/pkg/obcs/obcs_ad_check_lev3_dir.h
+++ b/pkg/obcs/obcs_ad_check_lev3_dir.h
@@ -87,9 +87,6 @@ CADJ STORE OBNa0  = tapelev3, key = ilev_3
 CADJ STORE OBNa1  = tapelev3, key = ilev_3
 CADJ STORE OBNsn0 = tapelev3, key = ilev_3
 CADJ STORE OBNsn1 = tapelev3, key = ilev_3
-#ifdef NONLIN_FRSURF
-CADJ STORE obneta0,obneta1 = tapelev3, key = ilev_3
-#endif
 #endif /* ALLOW_OBCS_PRESCRIBE */
 #endif /* ALLOW_OBCS_NORTH */
 #ifdef ALLOW_OBCS_SOUTH
@@ -108,9 +105,6 @@ CADJ STORE OBSa0  = tapelev3, key = ilev_3
 CADJ STORE OBSa1  = tapelev3, key = ilev_3
 CADJ STORE OBSsn0 = tapelev3, key = ilev_3
 CADJ STORE OBSsn1 = tapelev3, key = ilev_3
-#ifdef NONLIN_FRSURF
-CADJ STORE obseta0,obseta1 = tapelev3, key = ilev_3
-#endif
 #endif /* ALLOW_OBCS_PRESCRIBE */
 #endif /* ALLOW_OBCS_SOUTH */
 #ifdef ALLOW_OBCS_EAST
@@ -129,9 +123,6 @@ CADJ STORE OBEa0  = tapelev3, key = ilev_3
 CADJ STORE OBEa1  = tapelev3, key = ilev_3
 CADJ STORE OBEsn0 = tapelev3, key = ilev_3
 CADJ STORE OBEsn1 = tapelev3, key = ilev_3
-#ifdef NONLIN_FRSURF
-CADJ STORE obeeta0,obeeta1 = tapelev3, key = ilev_3
-#endif
 #endif /* ALLOW_OBCS_PRESCRIBE */
 #endif /* ALLOW_OBCS_EAST */
 #ifdef ALLOW_OBCS_WEST
@@ -150,12 +141,24 @@ CADJ STORE OBWa0  = tapelev3, key = ilev_3
 CADJ STORE OBWa1  = tapelev3, key = ilev_3
 CADJ STORE OBWsn0 = tapelev3, key = ilev_3
 CADJ STORE OBWsn1 = tapelev3, key = ilev_3
-#ifdef NONLIN_FRSURF
-CADJ STORE obweta0,obweta1 = tapelev3, key = ilev_3
-#endif
 #endif /* ALLOW_OBCS_PRESCRIBE */
 #endif /* ALLOW_OBCS_WEST */
 #
 # endif /* ALLOW_SEAICE */
+
+# if (defined ALLOW_SHELFICE || defined ALLOW_SEAICE) && (defined NONLIN_FRSURF)
+#  ifdef ALLOW_OBCS_NORTH
+CADJ STORE obneta0,obneta1 = tapelev3, key = ilev_3
+#  endif
+#  ifdef ALLOW_OBCS_SOUTH
+CADJ STORE obseta0,obseta1 = tapelev3, key = ilev_3
+#  endif
+#  ifdef ALLOW_OBCS_EAST
+CADJ STORE obeeta0,obeeta1 = tapelev3, key = ilev_3
+#  endif
+#  ifdef ALLOW_OBCS_WEST
+CADJ STORE obweta0,obweta1 = tapelev3, key = ilev_3
+#  endif
+# endif
 #
 #endif  /* ALLOW_OBCS */

--- a/pkg/obcs/obcs_ad_check_lev3_dir.h
+++ b/pkg/obcs/obcs_ad_check_lev3_dir.h
@@ -146,19 +146,13 @@ CADJ STORE OBWsn1 = tapelev3, key = ilev_3
 #
 # endif /* ALLOW_SEAICE */
 
-# if (defined ALLOW_SHELFICE || defined ALLOW_SEAICE) && (defined NONLIN_FRSURF)
-#  ifdef ALLOW_OBCS_NORTH
+# if (defined ALLOW_SEAICE || defined ALLOW_SHELFICE)
+#  if (defined NONLIN_FRSURF && defined ALLOW_OBCS_PRESCRIBE)
 CADJ STORE obneta0,obneta1 = tapelev3, key = ilev_3
-#  endif
-#  ifdef ALLOW_OBCS_SOUTH
 CADJ STORE obseta0,obseta1 = tapelev3, key = ilev_3
-#  endif
-#  ifdef ALLOW_OBCS_EAST
 CADJ STORE obeeta0,obeeta1 = tapelev3, key = ilev_3
-#  endif
-#  ifdef ALLOW_OBCS_WEST
 CADJ STORE obweta0,obweta1 = tapelev3, key = ilev_3
 #  endif
 # endif
-#
+
 #endif  /* ALLOW_OBCS */

--- a/pkg/obcs/obcs_ad_check_lev4_dir.h
+++ b/pkg/obcs/obcs_ad_check_lev4_dir.h
@@ -87,9 +87,6 @@ CADJ STORE OBNa0  = tapelev4, key = ilev_4
 CADJ STORE OBNa1  = tapelev4, key = ilev_4
 CADJ STORE OBNsn0 = tapelev4, key = ilev_4
 CADJ STORE OBNsn1 = tapelev4, key = ilev_4
-#ifdef NONLIN_FRSURF
-CADJ STORE obneta0,obneta1 = tapelev4, key = ilev_4
-#endif
 #endif /* ALLOW_OBCS_PRESCRIBE */
 #endif /* ALLOW_OBCS_NORTH */
 #ifdef ALLOW_OBCS_SOUTH
@@ -108,9 +105,6 @@ CADJ STORE OBSa0  = tapelev4, key = ilev_4
 CADJ STORE OBSa1  = tapelev4, key = ilev_4
 CADJ STORE OBSsn0 = tapelev4, key = ilev_4
 CADJ STORE OBSsn1 = tapelev4, key = ilev_4
-#ifdef NONLIN_FRSURF
-CADJ STORE obseta0,obseta1 = tapelev4, key = ilev_4
-#endif
 #endif /* ALLOW_OBCS_PRESCRIBE */
 #endif /* ALLOW_OBCS_SOUTH */
 #ifdef ALLOW_OBCS_EAST
@@ -129,9 +123,6 @@ CADJ STORE OBEa0  = tapelev4, key = ilev_4
 CADJ STORE OBEa1  = tapelev4, key = ilev_4
 CADJ STORE OBEsn0 = tapelev4, key = ilev_4
 CADJ STORE OBEsn1 = tapelev4, key = ilev_4
-#ifdef NONLIN_FRSURF
-CADJ STORE obeeta0,obeeta1 = tapelev4, key = ilev_4
-#endif
 #endif /* ALLOW_OBCS_PRESCRIBE */
 #endif /* ALLOW_OBCS_EAST */
 #ifdef ALLOW_OBCS_WEST
@@ -150,12 +141,24 @@ CADJ STORE OBWa0  = tapelev4, key = ilev_4
 CADJ STORE OBWa1  = tapelev4, key = ilev_4
 CADJ STORE OBWsn0 = tapelev4, key = ilev_4
 CADJ STORE OBWsn1 = tapelev4, key = ilev_4
-#ifdef NONLIN_FRSURF
-CADJ STORE obweta0,obweta1 = tapelev4, key = ilev_4
-#endif
 #endif /* ALLOW_OBCS_PRESCRIBE */
 #endif /* ALLOW_OBCS_WEST */
 #
 # endif /* ALLOW_SEAICE */
+
+# if (defined ALLOW_SHELFICE || defined ALLOW_SEAICE) && (defined NONLIN_FRSURF)
+#  ifdef ALLOW_OBCS_NORTH
+CADJ STORE obneta0,obneta1 = tapelev4, key = ilev_4
+#  endif
+#  ifdef ALLOW_OBCS_SOUTH
+CADJ STORE obseta0,obseta1 = tapelev4, key = ilev_4
+#  endif
+#  ifdef ALLOW_OBCS_EAST
+CADJ STORE obeeta0,obeeta1 = tapelev4, key = ilev_4
+#  endif
+#  ifdef ALLOW_OBCS_WEST
+CADJ STORE obweta0,obweta1 = tapelev4, key = ilev_4
+#  endif
+# endif
 #
 #endif  /* ALLOW_OBCS */

--- a/pkg/obcs/obcs_ad_check_lev4_dir.h
+++ b/pkg/obcs/obcs_ad_check_lev4_dir.h
@@ -146,19 +146,13 @@ CADJ STORE OBWsn1 = tapelev4, key = ilev_4
 #
 # endif /* ALLOW_SEAICE */
 
-# if (defined ALLOW_SHELFICE || defined ALLOW_SEAICE) && (defined NONLIN_FRSURF)
-#  ifdef ALLOW_OBCS_NORTH
+# if (defined ALLOW_SEAICE || defined ALLOW_SHELFICE)
+#  if (defined NONLIN_FRSURF && defined ALLOW_OBCS_PRESCRIBE)
 CADJ STORE obneta0,obneta1 = tapelev4, key = ilev_4
-#  endif
-#  ifdef ALLOW_OBCS_SOUTH
 CADJ STORE obseta0,obseta1 = tapelev4, key = ilev_4
-#  endif
-#  ifdef ALLOW_OBCS_EAST
 CADJ STORE obeeta0,obeeta1 = tapelev4, key = ilev_4
-#  endif
-#  ifdef ALLOW_OBCS_WEST
 CADJ STORE obweta0,obweta1 = tapelev4, key = ilev_4
 #  endif
 # endif
-#
+
 #endif  /* ALLOW_OBCS */


### PR DESCRIPTION
## What changes does this PR introduce?
(Bug fix, feature, docs update, ...)

Add storage directives at checkpoint level 2, 3, and 4 for eta on open boundaries when nonlinear free surface and shelfice package are in use, i.e. 

`#if (defined ALLOW_SHELFICE || defined ALLOW_SEAICE) && (defined NONLIN_FRSURF)`

## What is the current behaviour? 
(You can also link to an open issue here)

Currently at checkpoint levels 2, 3, and 4 open boundary eta (i.e. ob[n,s,e,w]eta) is only stored when `ALLOW_SEAICE` && `NONLIN_FRSURF` are defined. I'm using a domain with shelfice (no seaice) and have found that this also needs ob eta stored to avoid the dreaded Extensive Recomputation warning from TAF :scream: 

## What is the new behaviour 
(if this is a feature change)?

This speeds up my simulation by a factor of 3 :fireworks: 

## Does this PR introduce a breaking change? 
(What changes might users need to make in their application due to this PR?)


## Other information:

It could be necessary to simply always store open boundary eta when nonlinear surface is turned on, even without seaice and shelfice, but I don't have a setup to test this or I'm unaware of one in the verification suite.

## Suggested addition to `tag-index`
(To avoid unnecessary merge conflicts, please don't update `tag-index`. One of the admins will do that when merging your pull request.)