### PR TITLE
Fix region mask settings

### DIFF
--- a/verification/shelfice_2d_remesh/input/data.diagnostics
+++ b/verification/shelfice_2d_remesh/input/data.diagnostics
@@ -75,8 +75,8 @@
 #- regional mask: =1 : under-ice ; =2 : open-ocean
   diagSt_regMaskFile='under_Ice_mask.bin',
   nSetRegMskFile=1,
-  set_regMask(1)= 1,  1,
-  val_regMask(1)= 1., 2.,
+  set_regMask(1:2)= 1,  1,
+  val_regMask(1:2)= 1., 2.,
 #---
  stat_fields(1:6,1) = 'ETAN    ','THETA   ','SALT    ',
                       'UVEL    ','VVEL    ','WVEL    ',


### PR DESCRIPTION
Some version of open64 & gfortran compiler (e.g., on baudelaire)
are picky regarding vector setting in namelist.
Fix setting of set_regMask & val_regMask with:
  set_regMask(1:2)= 1,  1,
  val_regMask(1:2)= 1., 2.,

## What changes does this PR introduce?
fix new experiment "data.diagnostics" file regarding region mask setting (see above)

## What is the current behaviour? 
works with many compilers but not all.

## What is the new behaviour 
Fix. And note that for old compilers (e.g., g77), there is a special setting
in optfile (NML_EXTENDED_F77) that does the conversion back (in S/R NML_CHANGE_SYNTAX).

## Does this PR introduce a breaking change? 
no

## Other information:


## Suggested addition to `tag-index`
not significant enough to be documented there