### PR TITLE
Comment out OBCS_PARM02 (#undef ALLOW_ORLANSKI )

### DIFF
--- a/verification/shelfice_2d_remesh/input/data.obcs
+++ b/verification/shelfice_2d_remesh/input/data.obcs
@@ -18,11 +18,11 @@
  OBCSprintDiags = .FALSE.,
  &
 
-# Orlanski parameters
- &OBCS_PARM02
+# Orlanski parameters (skiipped with #undef ALLOW_ORLANSKI)
+#&OBCS_PARM02
 #Cmax=0.45,
 #cVelTimeScale=1000.,
- &
+#&
 
 # Sponge layer parameters
  &OBCS_PARM03

--- a/verification/shelfice_2d_remesh/input/data.obcs
+++ b/verification/shelfice_2d_remesh/input/data.obcs
@@ -18,7 +18,7 @@
  OBCSprintDiags = .FALSE.,
  &
 
-# Orlanski parameters (skiipped with #undef ALLOW_ORLANSKI)
+# Orlanski parameters (skipped with #undef ALLOW_ORLANSKI)
 #&OBCS_PARM02
 #Cmax=0.45,
 #cVelTimeScale=1000.,


### PR DESCRIPTION
This second namelist is only read-in when ALLOW_ORLANSKI is #define.
Generally, with most compilers, this does not pose a problem to read-in
the next namelist, ignoring this un-read namelist; However, with current
version of open64 compiler on engaging (v 4.5.2.1), it fails to skip the
un-read namelist when trying to read the next one.

## What changes does this PR introduce?
Fix new experiment "shelfice_2d_remesh" data.obcs file for some picky compilers
such as open64 on engaging.

## What is the current behaviour? 
Second namelist in data.obcs is listed (but empty) but not read-in since
ALLOW_ORLANSKI is #undef

## What is the new behaviour 
Comment out completely this second namelist.

## Does this PR introduce a breaking change? 
no

## Other information:
I did check that this allows to run this new experiment on engaging with open64 compiler.

## Suggested addition to `tag-index`
none.