### PR TITLE
Ref pressure in eos and p load

### DIFF
--- a/doc/phys_pkgs/exf.rst
+++ b/doc/phys_pkgs/exf.rst
@@ -19,14 +19,15 @@ to convert atmospheric fields to surface fluxes. An interpolation
 routine provides on-the-fly interpolation of forcing fields an arbitrary
 grid onto the model grid.
 
-CPP options enable or disable different aspects of the package (Section
-[sec:pkg:exf:config]). Runtime options, flags, filenames and
-field-related dates/times are set in ``data.exf`` (Section
-[sec:pkg:exf:runtime]). A description of key subroutines is given in
-Section [sec:pkg:exf:subroutines]. Input fields, units and sign
-conventions are summarized in Section
-[sec:pkg:exf:fields:sub:`u`\ nits], and available diagnostics output is
-listed in Section [sec:pkg:exf:diagnostics].
+CPP options enable or disable different aspects of the package
+(:numref:`ssub_phys_pkg_exf_config`). Runtime options, flags,
+filenames and field-related dates/times are set in ``data.exf``
+(:numref:`ssub_phys_pkg_exf_runtime`). A description of key subroutines
+is given in :numref:`ssub_phys_pkg_exf_subroutines`. Input fields,
+units and sign conventions are summarized in
+:numref:`ssub_phys_pkg_exf_inputs_units`, and available
+diagnostics output is listed in
+:numref:`ssub_phys_pkg_exf_diagnostics`.
 
 .. _ssub_phys_pkg_exf_config:
 
@@ -44,10 +45,11 @@ As with all MITgcm packages, EXF can be turned on or off at compile time
    switches
 
 -  *required packages and CPP options*:
-   EXF requires the calendar package ``cal`` to be enabled; no
+   EXF (only) requires the calendar package ``cal`` to be enabled if
+   the julian calendar will be used with the data ; no
    additional CPP options are required.
 
-(see Section [sec:buildingCode]).
+(see  :numref:`building_code`).
 
 Parts of the EXF code can be enabled or disabled at compile time via CPP
 preprocessor flags. These options are set in either ``EXF_OPTIONS.h`` or
@@ -212,10 +214,10 @@ General flags and parameters
 Field attributes
 ################
 
-All EXF fields are listed in Section
-[sec:pkg:exf:fields:sub:`u`\ nits]. Each field has a number of
-attributes which can be customized. They are summarized in Table
-[tab:pkg:exf:runtime:sub:`a`\ ttributes]. To obtain an attribute for a
+All EXF fields are listed in
+:numref:`ssub_phys_pkg_exf_inputs_units`. Each field has a number of
+attributes which can be customized. They are summarized in
+:numref:`tab_phys_pkg_exf_runtime_attributes`. To obtain an attribute for a
 specific field, e.g. ``uwind`` prepend the field name to the listed
 attribute, e.g. for attribute ``period`` this yields ``uwindperiod``:
 
@@ -228,7 +230,7 @@ attribute, e.g. for attribute ``period`` this yields ``uwindperiod``:
      \end{array}\end{aligned}
 
 
-.. table:: EXF runtime attributes 
+.. table:: EXF runtime attributes
            Note there is one exception for the default of ``atempconst`` = celsius2K = 273.16
     :name: tab_phys_pkg_exf_runtime_attributes
 
@@ -430,11 +432,9 @@ Output fields which EXF provides to the MITgcm are fields **fu**,
     c----------------------------------------------------------------------
     c     runoff    :: River and glacier runoff in m/s
     c               |  > 0 for decrease in salt (ocean salinity)
-    c               |  Typical range: 0 < runoff < ????
+    c               |  Typical range: 0 < runoff < 5e-7
     c               |  Southwest C-grid tracer point
     c               |  Input or input/output field
-    c               |  !!! WATCH OUT: Default exf_inscal_runoff !!!
-    c               |  !!! in exf_readparms.F is not 1.0        !!!
     c----------------------------------------------------------------------
     c     swdown    :: Downward shortwave radiation in W/m^2
     c               |  > 0 for increase in theta (ocean warming)
@@ -449,8 +449,7 @@ Output fields which EXF provides to the MITgcm are fields **fu**,
     c               |  Input/output field
     c----------------------------------------------------------------------
     c     apressure :: Atmospheric pressure field in N/m^2
-    c               |  > 0 for ????
-    c               |  Typical range: ???? < apressure < ????
+    c               |  Typical range: 88000 < apressure < 108000
     c               |  Southwest C-grid tracer point
     c               |  Input field
     c----------------------------------------------------------------------
@@ -545,8 +544,9 @@ Header routines
 EXF diagnostics
 +++++++++++++++
 
-Diagnostics output is available via the diagnostics package (see Section
-[sec:pkg:diagnostics]). Available output fields are summarized below.
+Diagnostics output is available via the diagnostics package (see
+:numref:`sub_outp_pkg_diagnostics`). Available output fields are
+summarized below.
 
 
 ::
@@ -585,6 +585,3 @@ Experiments and tutorials that use exf
 -  Global Ocean experiment, in global\_with\_exf verification directory
 
 -  Labrador Sea experiment, in lab\_sea verification directory
-
-
-

--- a/doc/tag-index
+++ b/doc/tag-index
@@ -1,6 +1,16 @@
     Notes on tags used in MITgcmUV
     ==============================
 
+o model/src & pkg/exf:
+  - Reference atmospheric pressure for seawater EOS was assumed but was not
+    explicitly set. New constant "eosRefP0" is added to make this more clear ;
+  - Add main model reference surface pressure (surf_pRef) so that pLoad
+    is now defined as the atmospheric pressure anomaly relative to surf_pRef ;
+  - Account for differences in 2 ref pressure in EOS S/R ;
+  - Fix few EOS references (in comments) ; fix and simplify S/R EOS_CHECK ;
+  - Keep exf "apressure" field unchanged (still full atmospheric surface
+    pressure) but now initialised to "surf_pRef" and fill "pLoad" with atmos.
+    pressure anomaly relative to surf_pRef.
 o pkg/streamice:
   - add option to specify "regularised coulomb" sliding law to better reflect
     dependence on subglacial water pressure close to the grounding line ;

--- a/model/inc/EOS.h
+++ b/model/inc/EOS.h
@@ -4,43 +4,49 @@ C    !INTERFACE:
 C    include EOS.h
 C    !DESCRIPTION: \bv
 C     *==========================================================*
-C     | EOS.h                                                  
+C     | EOS.h
 C     | o Header file defining coefficients for equation of state.
 C     *==========================================================*
-C     | The values from the model standard input file are         
-C     | stored into the variables held here.                   
+C     | The values from the model standard input file are
+C     | stored into the variables held here.
 C     *==========================================================*
 C     \ev
 CEOP
 
-C     PARAMETER SItoBar
+C     SItoBar  :: conversion factor for pressure, from Pa (SI Unit) to Bar
+C     SItodBar :: conversion factor for pressure, from Pa (SI Unit) to deci Bar
       _RL SItoBar, SItodBar
       PARAMETER ( SItoBar  = 1.D-05 )
       PARAMETER ( SItodBar = 1.D-04 )
 
+C Shared EOS Parameter
+C     eosRefP0  :: reference atmospheric pressure used in EOS formulation
+      COMMON /PARM_EOS_SHARED/ eosRefP0, equationOfState
+      _RL eosRefP0
+      CHARACTER*(6) equationOfState
+
 C Linear equation of state
 C     tAlpha    :: Linear EOS thermal expansion coefficient ( 1/degree ).
 C     sBeta     :: Linear EOS haline contraction coefficient.
-      COMMON /PARM_EOS_LIN/ tAlpha,sBeta,equationOfState
+      COMMON /PARM_EOS_LIN/ tAlpha, sBeta
       _RL tAlpha
       _RL sBeta
-      character*(6) equationOfState
 
 C Equation of State (polynomial coeffients)
-      COMMON /PARM_EOS_NL/ eosC,eosSig0,eosRefT,eosRefS
+      COMMON /PARM_EOS_POLY3/ eosC,eosSig0,eosRefT,eosRefS
       _RL eosC(9,Nr+1),eosSig0(Nr+1),eosRefT(Nr+1),eosRefS(Nr+1)
 
 C Full Equation of State
-C     eosType = 'JMD95' (Jackett and McDougall 1995, JPO)
+C     eosType = 'JMD95' (Jackett and McDougall 1995, JAOT)
 C     eosType = 'UNESCO' (Millero et al. 1980, DSR)
-C     COMMON /PARM_EOS_JMD95/ 
+C     COMMON /PARM_EOS_JMD95/
 C     eosJMDCFw  :: of fresh water at pressure 0
 C     eosJMDCSw  :: of sea water at pressure 0
 C     eosJMDCKFw :: of secant bulk modulus K of fresh water at pressure 0
 C     eosJMDCKSw :: of secant bulk modulus K of sea water at pressure 0
 C     eosJMDCKP  :: of secant bulk modulus K at pressure p
-C     eosType = 'MDJWF' (McDougall et al. 2002, JAOT, submitted)
-C     COMMON /PARM_EOS_MDJWF/ 
+C     eosType = 'MDJWF' (McDougall et al. 2003, JAOT)
+C     COMMON /PARM_EOS_MDJWF/
 C     eosMDJWFnum :: coefficients of numerator
 C     eosMDJWFden :: coefficients of denominator
 C     eosType = 'TEOS10' (McDougall et al. 2011, http://www.teos-10.org)
@@ -54,13 +60,8 @@ C     end nonlinear equation of state
       COMMON /PARM_EOS_JMD95/
      &     eosJMDCFw, eosJMDCSw, eosJMDCKFw, eosJMDCKSw, eosJMDCKP
       _RL eosMDJWFnum(0:11), eosMDJWFden(0:12)
-      COMMON /PARM_EOS_MDJWF/ 
+      COMMON /PARM_EOS_MDJWF/
      &     eosMDJWFnum, eosMDJWFden
       _RL teos(48)
       COMMON /PARM_TEOS10/
      &     teos
-
-C     pressure :: global absolute pressure variable needed for the 
-C                 nonlinear equation of state
-c     _RL pressure(1-OLx:sNx+OLx,1-OLy:sNy+OLy,1:Nr,nSx,nSy)
-c     COMMON /EOS_PRESSURE/ pressure

--- a/model/inc/FFIELDS.h
+++ b/model/inc/FFIELDS.h
@@ -67,10 +67,11 @@ C     lambdaSaltClimRelax :: Inverse time scale for relaxation ( 1/s ).
 
 C     phiTide2d :: vertically uniform (2d-map), time-dependent geopotential
 C                  anomaly (e.g., tidal forcing); Units are m^2/s^2
-C     pLoad :: for the ocean:      atmospheric pressure at z=eta
+C     pLoad :: for the ocean:      atmospheric pressure anomaly (relative to
+C                                   "surf_pRef") at z=eta
 C                Units are           Pa=N/m^2
-C              for the atmosphere: geopotential of the orography
-C                Units are           meters (converted)
+C              for the atmosphere (hack): geopotential anomaly of the orography
+C                Units are           m^2/s^2
 C     sIceLoad :: sea-ice loading, expressed in Mass of ice+snow / area unit
 C                Units are           kg/m^2
 C              Note: only used with Sea-Ice & RealFreshWater formulation

--- a/model/inc/PARAMS.h
+++ b/model/inc/PARAMS.h
@@ -604,6 +604,7 @@ C     rhoConstFresh :: Constant reference density for fresh water (rain)
 C     thetaConst :: Constant reference for potential temperature
 C     tRef       :: reference vertical profile for potential temperature
 C     sRef       :: reference vertical profile for salinity/specific humidity
+C     surf_pRef  :: surface reference pressure ( Pa )
 C     pRef4EOS   :: reference pressure used in EOS (case selectP_inEOS_Zc=1)
 C     phiRef     :: reference potential (press/rho, geopot) profile (m^2/s^2)
 C     dBdrRef    :: vertical gradient of reference buoyancy  [(m/s/r)^2]:
@@ -823,7 +824,7 @@ C     psiEuler      :: Euler angle, rotation about new z-axis
      & gravFacC, recip_gravFacC, gravFacF, recip_gravFacF,
      & rhoNil, rhoConst, recip_rhoConst, rho1Ref,
      & rhoFacC, recip_rhoFacC, rhoFacF, recip_rhoFacF, rhoConstFresh,
-     & thetaConst, tRef, sRef, pRef4EOS, phiRef, dBdrRef,
+     & thetaConst, tRef, sRef, surf_pRef, pRef4EOS, phiRef, dBdrRef,
      & rVel2wUnit, wUnit2rVel, mass2rUnit, rUnit2mass,
      & baseTime, startTime, endTime,
      & chkPtFreq, pChkPtFreq, dumpFreq, adjDumpFreq,
@@ -934,7 +935,7 @@ C     psiEuler      :: Euler angle, rotation about new z-axis
       _RL thetaConst
       _RL tRef(Nr)
       _RL sRef(Nr)
-      _RL pRef4EOS(Nr)
+      _RL surf_pRef, pRef4EOS(Nr)
       _RL phiRef(2*Nr+1)
       _RL dBdrRef(Nr)
       _RL rVel2wUnit(Nr+1), wUnit2rVel(Nr+1)

--- a/model/src/config_summary.F
+++ b/model/src/config_summary.F
@@ -253,8 +253,7 @@ C-----
      &  ' /* Linear EOS haline contraction coefficient ( 1/psu ) */')
         CALL WRITE_0D_RL( rhoNil,  INDEX_NONE, 'rhoNil    =',
      &  ' /* Reference density for Linear EOS ( kg/m^3 ) */')
-      ENDIF
-      IF ( eosType .EQ. 'POLY3 ' ) THEN
+      ELSEIF ( eosType .EQ. 'POLY3 ' ) THEN
         WRITE(msgBuf,'(A)')
      &   'Polynomial EQS parameters ( from POLY3.COEFFS ):'
         CALL PRINT_MESSAGE( msgBuf, ioUnit, SQUEEZE_RIGHT, myThid )
@@ -265,6 +264,9 @@ C-----
         ENDDO
         WRITE(msgBuf,'(A)') '    ;'
         CALL PRINT_MESSAGE( msgBuf, ioUnit, SQUEEZE_RIGHT, myThid )
+      ELSEIF ( eosType .NE. 'IDEALG' ) THEN
+        CALL WRITE_0D_RL( eosRefP0, INDEX_NONE, 'eosRefP0 =',
+     &  ' /* Reference atmospheric pressure for EOS ( Pa ) */')
       ENDIF
       IF ( usingZCoords ) THEN
        WRITE(msgBuf,'(2A)') 'selectP_inEOS_Zc =',
@@ -279,6 +281,8 @@ C-----
        CALL PRINT_MESSAGE(endList, ioUnit, SQUEEZE_RIGHT, myThid )
       ENDIF
 C-----
+      CALL WRITE_0D_RL( surf_pRef, INDEX_NONE, 'surf_pRef =',
+     &  ' /* Surface reference pressure ( Pa ) */')
       IF ( fluidIsWater ) THEN
        CALL WRITE_0D_RL( HeatCapacity_Cp, INDEX_NONE,
      &   'HeatCapacity_Cp =',

--- a/model/src/diags_oceanic_surf_flux.F
+++ b/model/src/diags_oceanic_surf_flux.F
@@ -89,7 +89,7 @@ C-    sea-ice loading (expressed in Mass of ice+snow / area unit, [kg/m2])
        CALL DIAGNOSTICS_FILL_RS( sIceLoad,'sIceLoad',0,1,0,1,1,myThid )
 
       IF ( fluidIsWater ) THEN
-C-    pLoad (Atmospheric pressure loading [Pa=N/m2])
+C-    pLoad (Atmospheric pressure anomaly relative to surf_pRef [Pa=N/m2])
        CALL DIAGNOSTICS_FILL_RS( pLoad,   'atmPload',0,1,0,1,1,myThid )
 
 C-    oceFreez (= heating from freezing of sea-water, if allowFreezing=T)

--- a/model/src/find_alpha.F
+++ b/model/src/find_alpha.F
@@ -52,7 +52,7 @@ c     myThid :: thread number for this instance of the routine
 C     !LOCAL VARIABLES:
 C     == Local variables ==
       INTEGER i,j
-      _RL refTemp,refSalt,tP,sP
+      _RL refTemp, refSalt, tP, sP, dp0
       _RL t1, t2, t3, s1, s3o2, p1, p2, sp5, p1t1
       _RL ct, sa, sqrtsa, p
       _RL drhoP0dtheta, drhoP0dthetaFresh, drhoP0dthetaSalt
@@ -112,9 +112,10 @@ c    I          k, bi, bj, myThid )
       ELSEIF ( equationOfState(1:5).EQ.'JMD95'
      &        .OR. equationOfState.EQ.'UNESCO' ) THEN
 C     nonlinear equation of state in pressure coordinates
+         dp0 = surf_pRef - eosRefP0
 
          CALL PRESSURE_FOR_EOS(
-     I        bi, bj, iMin, iMax, jMin, jMax,  kRef,
+     I        bi, bj, iMin, iMax, jMin, jMax,  kRef, dp0,
      O        locPres,
      I        myThid )
 
@@ -219,9 +220,10 @@ C     of sea water at p
             ENDDO
          ENDDO
       ELSEIF ( equationOfState.EQ.'MDJWF' ) THEN
+         dp0 = surf_pRef - eosRefP0
 
          CALL PRESSURE_FOR_EOS(
-     I        bi, bj, iMin, iMax, jMin, jMax,  kRef,
+     I        bi, bj, iMin, iMax, jMin, jMax,  kRef, dp0,
      O        locPres,
      I        myThid )
 
@@ -277,9 +279,10 @@ C     this line makes TAF create vectorizable code
       ENDDO
 
       ELSEIF ( equationOfState.EQ.'TEOS10' ) THEN
+       dp0 = surf_pRef - eosRefP0
 
        CALL PRESSURE_FOR_EOS(
-     I      bi, bj, iMin, iMax, jMin, jMax,  kRef,
+     I      bi, bj, iMin, iMax, jMin, jMax,  kRef, dp0,
      O      locPres,
      I      myThid )
 
@@ -382,7 +385,7 @@ c     myThid :: thread number for this instance of the routine
 C     !LOCAL VARIABLES:
 C     == Local variables ==
       INTEGER i,j
-      _RL refTemp,refSalt,tP,sP
+      _RL refTemp, refSalt, tP, sP, dp0
       _RL t1, t2, t3, s1, s3o2, p1, sp5, p1t1
       _RL ct, sa, sqrtsa, p
       _RL drhoP0dS
@@ -440,9 +443,10 @@ c    I          k, bi, bj, myThid )
       ELSEIF ( equationOfState(1:5).EQ.'JMD95'
      &        .OR. equationOfState.EQ.'UNESCO' ) THEN
 C     nonlinear equation of state in pressure coordinates
+         dp0 = surf_pRef - eosRefP0
 
          CALL PRESSURE_FOR_EOS(
-     I        bi, bj, iMin, iMax, jMin, jMax,  kRef,
+     I        bi, bj, iMin, iMax, jMin, jMax,  kRef, dp0,
      O        locPres,
      I        myThid )
 
@@ -533,9 +537,10 @@ C     of sea water at p
             ENDDO
          ENDDO
       ELSEIF ( equationOfState.EQ.'MDJWF' ) THEN
+         dp0 = surf_pRef - eosRefP0
 
          CALL PRESSURE_FOR_EOS(
-     I        bi, bj, iMin, iMax, jMin, jMax,  kRef,
+     I        bi, bj, iMin, iMax, jMin, jMax,  kRef, dp0,
      O        locPres,
      I        myThid )
 
@@ -584,9 +589,10 @@ C     this line makes TAF create vectorizable code
          ENDDO
 
       ELSEIF ( equationOfState.EQ.'TEOS10' ) THEN
+       dp0 = surf_pRef - eosRefP0
 
        CALL PRESSURE_FOR_EOS(
-     I      bi, bj, iMin, iMax, jMin, jMax,  kRef,
+     I      bi, bj, iMin, iMax, jMin, jMax,  kRef, dp0,
      O      locPres,
      I      myThid )
 

--- a/model/src/find_rho.F
+++ b/model/src/find_rho.F
@@ -61,8 +61,8 @@ C     kRef :: Pressure reference level
 C     !LOCAL VARIABLES:
 C     == Local variables ==
       INTEGER i,j
-      _RL refTemp,refSalt,sigRef,tP,sP,deltaSig,dRho
-      _RL oneMinusKap, facPres, theta_v
+      _RL refTemp, refSalt, sigRef, tP, sP, deltaSig, dRho
+      _RL dp0, oneMinusKap, facPres, theta_v
       _RL locPres(1-OLx:sNx+OLx,1-OLy:sNy+OLy)
       _RL rhoP0  (1-OLx:sNx+OLx,1-OLy:sNy+OLy)
       _RL bulkMod(1-OLx:sNx+OLx,1-OLy:sNy+OLy)
@@ -146,9 +146,10 @@ C **********
       ELSEIF ( equationOfState(1:5).EQ.'JMD95'
      &      .OR. equationOfState.EQ.'UNESCO' ) THEN
 C     nonlinear equation of state in pressure coordinates
+         dp0 = surf_pRef - eosRefP0
 
          CALL PRESSURE_FOR_EOS(
-     I             bi, bj, iMin, iMax, jMin, jMax, kRef,
+     I             bi, bj, iMin, iMax, jMin, jMax, kRef, dp0,
      O             locPres,
      I             myThid )
 
@@ -181,9 +182,10 @@ C     density of sea water at pressure p
          ENDDO
 
       ELSEIF ( equationOfState.EQ.'MDJWF' ) THEN
+         dp0 = surf_pRef - eosRefP0
 
          CALL PRESSURE_FOR_EOS(
-     I             bi, bj, iMin, iMax, jMin, jMax, kRef,
+     I             bi, bj, iMin, iMax, jMin, jMax, kRef, dp0,
      O             locPres,
      I             myThid )
 
@@ -210,9 +212,10 @@ c#endif /* ALLOW_AUTODIFF_TAMC */
          ENDDO
 
       ELSEIF ( equationOfState.EQ.'TEOS10' ) THEN
+         dp0 = surf_pRef - eosRefP0
 
          CALL PRESSURE_FOR_EOS(
-     I             bi, bj, iMin, iMax, jMin, jMax, kRef,
+     I             bi, bj, iMin, iMax, jMin, jMax, kRef, dp0,
      O             locPres,
      I             myThid )
 
@@ -235,7 +238,7 @@ c#endif /* ALLOW_AUTODIFF_TAMC */
       ELSEIF( equationOfState .EQ. 'IDEALG' ) THEN
 
          CALL PRESSURE_FOR_EOS(
-     I             bi, bj, iMin, iMax, jMin, jMax, kRef,
+     I             bi, bj, iMin, iMax, jMin, jMax, kRef, zeroRL,
      O             locPres,
      I             myThid )
 
@@ -836,6 +839,8 @@ C     !DESCRIPTION: \bv
 C     *==========================================================*
 C     | o SUBROUTINE FIND_RHO_SCALAR
 C     |   Calculates rho(S,T,p)
+C     | Note: for seawater EOS, p is pressure (Pa) relative to
+C     |   reference surface pressure "surf_pRef"
 C     *==========================================================*
 C     \ev
 
@@ -856,7 +861,7 @@ C     == Routine arguments ==
 C     !LOCAL VARIABLES:
 C     == Local variables ==
       _RL t1, t2, t3, t4, s1, s3o2, p1, p2, sp5, p1t1
-      _RL ct, sa, sqrtsa, p
+      _RL dp0, ct, sa, sqrtsa, p
       _RL rfresh, rsalt, rhoP0
       _RL bMfresh, bMsalt, bMpres, BulkMod
       _RL rhoNum, rhoDen, den, epsln
@@ -915,6 +920,7 @@ CEOP
       rhoNum  = 0. _d 0
       rhoDen  = 0. _d 0
       den     = 0. _d 0
+      dp0     = surf_pRef - eosRefP0
 
       t1 = tLoc
       t2 = t1*t1
@@ -959,7 +965,7 @@ C     nonlinear equation of state in pressure coordinates
 
          s3o2 = s1*SQRT(s1)
 
-         p1 = pLoc*SItoBar
+         p1 = ( pLoc + dp0 )*SItoBar
          p2 = p1*p1
 
 C     density of freshwater at the surface
@@ -1092,7 +1098,7 @@ C     density of sea water at pressure p
 
        sp5 = SQRT(s1)
 
-       p1   = pLoc*SItodBar
+       p1 = ( pLoc + dp0 )*SItodBar
        p1t1 = p1*t1
 
        rhoNum = eosMDJWFnum(0)
@@ -1129,7 +1135,7 @@ C     density of sea water at pressure p
         sa     = 0. _d 0
         sqrtsa = 0. _d 0
        ENDIF
-       p       = pLoc*SItodBar
+       p = ( pLoc + dp0 )*SItodBar
 
        rhoNum = teos(01)
      &   + ct*(teos(02) + ct*(teos(03) + teos(04)*ct))

--- a/model/src/ini_eos.F
+++ b/model/src/ini_eos.F
@@ -32,10 +32,14 @@ C     == Routine arguments ==
 C     myThid -  Number of this instance of INI_CORI
       INTEGER myThid
 
+C     !FUNCTIONS
+      INTEGER  ILNBLNK
+      EXTERNAL ILNBLNK
+
 C     !LOCAL VARIABLES:
 C     == Local variables ==
 C     i,k    :: Loop counters
-      INTEGER  i, k
+      INTEGER  i, k, iLen
       CHARACTER*(MAX_LEN_MBUF) msgBuf
 
       IF ( .NOT.fluidIsWater ) RETURN
@@ -44,6 +48,8 @@ C     i,k    :: Loop counters
       _BEGIN_MASTER(myThid)
 
       equationOfState = eosType
+      iLen = ILNBLNK(equationOfState)
+      iLen = MAX(iLen,1)
 
       DO k = 1,6
          eosJMDCFw(k) = 0. _d 0
@@ -70,6 +76,11 @@ C     i,k    :: Loop counters
          teos(k)        = 0. _d 0
       ENDDO
 
+C     For all current EOS that explicitly depend on pressure ('UNESCO',
+C     'JMD95','MDJWF' & 'TEOS10' ), the input pressure is assumed to be
+C     relative to reference atmospheric pressure of 1.atm = 101325 Pa
+      eosRefP0 = 101325. _d 0
+
       IF ( equationOfState .EQ. 'LINEAR' ) THEN
          IF ( tAlpha .EQ. UNSET_RL ) tAlpha = 2.  _d -4
          IF ( sBeta  .EQ. UNSET_RL ) sBeta  = 7.4 _d -4
@@ -79,10 +90,10 @@ C     i,k    :: Loop counters
          IF (k.NE.Nr) THEN
             WRITE(msgBuf,'(A)')
      &           'ini_eos: attempt to read POLY3.COEFFS failed'
-            CALL PRINT_ERROR( msgBuf , myThid )
+            CALL PRINT_ERROR( msgBuf, myThid )
             WRITE(msgBuf,'(A)')
      &           '           because bad # of levels in data'
-            CALL PRINT_ERROR( msgBuf , myThid )
+            CALL PRINT_ERROR( msgBuf, myThid )
             STOP 'Bad data in POLY3.COEFFS'
          ENDIF
          READ(37,*) (eosRefT(k),eosRefS(k),eosSig0(k),k=1,Nr)
@@ -94,22 +105,22 @@ C     i,k    :: Loop counters
       ELSEIF ( equationOfState .EQ. 'JMD95Z'
      &    .OR. equationOfState .EQ. 'JMD95P'
      &    .OR. equationOfState .EQ. 'UNESCO' ) THEN
-C
-C     Jackett & McDougall (1995, JPO) equation of state
+
+C     Jackett & McDougall (1995, JAOT) equation of state
 C     rho = R(salinity, potential temperature, pressure)
 C     pressure needs to be available (from the previous
 C     time step to linearize the problem)
-C
+
          IF ( equationOfState .EQ. 'JMD95Z' .AND. usingPCoords ) THEN
             WRITE(msgBuf,'(A)')
      &      'ini_eos: equation of state ''JMD95Z'' should not'
-            CALL PRINT_ERROR( msgBuf , myThid )
+            CALL PRINT_ERROR( msgBuf, myThid )
             WRITE(msgBuf,'(A)')
      &      '         be used together with pressure coordinates.'
-            CALL PRINT_ERROR( msgBuf , myThid )
+            CALL PRINT_ERROR( msgBuf, myThid )
             WRITE(msgBuf,'(A)')
      &      '         Use only ''JMD95P'' with ''OCEANICP''.'
-            CALL PRINT_ERROR( msgBuf , myThid )
+            CALL PRINT_ERROR( msgBuf, myThid )
             STOP 'ABNORMAL END: S/R INI_EOS'
          ENDIF
 
@@ -167,24 +178,24 @@ C     5. secant bulk modulus K of sea water at p
             WRITE(msgBuf,'(a)')
      &           'WARNING WARNING WARNING WARNING WARNING WARNING '
             CALL PRINT_MESSAGE( msgBuf, standardMessageUnit,
-     &           SQUEEZE_RIGHT , myThid )
+     &                          SQUEEZE_RIGHT, myThid )
             WRITE(msgBuf,'(a,a)')
      &           'WARNING: using the UNESCO formula with potential ',
      &           'temperature'
             CALL PRINT_MESSAGE( msgBuf, standardMessageUnit,
-     &           SQUEEZE_RIGHT , myThid )
+     &                          SQUEEZE_RIGHT, myThid )
             WRITE(msgBuf,'(a)')
      &           'WARNING: can result in density errors of up to 5%'
             CALL PRINT_MESSAGE( msgBuf, standardMessageUnit,
-     &           SQUEEZE_RIGHT , myThid )
+     &                          SQUEEZE_RIGHT, myThid )
             WRITE(msgBuf,'(a)')
      &           'WARNING: (see Jackett and McDougall 1995, JAOT)'
             CALL PRINT_MESSAGE( msgBuf, standardMessageUnit,
-     &           SQUEEZE_RIGHT , myThid )
+     &                          SQUEEZE_RIGHT, myThid )
             WRITE(msgBuf,'(a)')
      &           'WARNING WARNING WARNING WARNING WARNING WARNING '
             CALL PRINT_MESSAGE( msgBuf, standardMessageUnit,
-     &           SQUEEZE_RIGHT , myThid )
+     &                          SQUEEZE_RIGHT, myThid )
 
 C     3. secant bulk modulus K of fresh water at p = 0
             eosJMDCKFw(1) =   1.965221 _d +04
@@ -233,7 +244,6 @@ C     5. secant bulk modulus K of sea water at p
          eosMDJWFnum( 9) =  5.18761880 _d -06
          eosMDJWFnum(10) = -3.24041825 _d -08
          eosMDJWFnum(11) = -1.23869360 _d -11
-
 
          eosMDJWFden( 0) =  1.00000000 _d +00
          eosMDJWFden( 1) =  7.28606739 _d -03
@@ -298,14 +308,14 @@ C     5. secant bulk modulus K of sea water at p
        teos(45) = -1.864826425365600 _d -14
        teos(46) =  1.119522344879478 _d -14
        teos(47) = -1.200507748551599 _d -15
-       teos(48) =  6.057902487546866 _d -17 
+       teos(48) =  6.057902487546866 _d -17
 
       ELSEIF( equationOfState .EQ. 'IDEALG' ) THEN
 
       ELSE
 
-         WRITE(msgbuf,'(3A)') ' INI_EOS: equationOfState = "',
-     &        equationOfState,'"'
+         WRITE(msgBuf,'(3A)') 'INI_EOS: eosType= "',
+     &                     equationOfState(1:iLen), '" not valid'
          CALL PRINT_ERROR( msgbuf, myThid )
          STOP 'ABNORMAL END: S/R INI_EOS'
 
@@ -340,7 +350,6 @@ C     !USES:
 #include "PARAMS.h"
 #include "EOS.h"
 #include "GRID.h"
-#include "DYNVARS.h"
 
 C     !INPUT/OUTPUT PARAMETERS:
 C     == Routine arguments ==
@@ -358,17 +367,17 @@ C     i,j,k
       _RL tFld   (1-OLx:sNx+OLx,1-OLy:sNy+OLy)
       _RL sFld   (1-OLx:sNx+OLx,1-OLy:sNy+OLy)
       _RL pFld   (1-OLx:sNx+OLx,1-OLy:sNy+OLy)
-      _RL rhoLoc (1-Olx:sNx+Olx,1-Oly:sNy+Oly)
-      _RL bulkMod(1-Olx:sNx+Olx,1-Oly:sNy+Oly)
+      _RL rhoLoc (1-OLx:sNx+OLx,1-OLy:sNy+OLy)
+      _RL bulkMod(1-OLx:sNx+OLx,1-OLy:sNy+OLy)
 
-      INTEGER ncheck, kcheck
+      INTEGER ncheck, kcheck, k1c, k2c, iLen
       PARAMETER ( ncheck = 20 )
       _RL tLoc(ncheck), ptLoc(ncheck), sLoc(ncheck), pLoc(ncheck)
       _RL rLoc(ncheck), bLoc(ncheck)
-      _RS mskSave
-      _RS rC_Save
+      _RL surf_pRef_save, rhoDif
 
       CHARACTER*(MAX_LEN_MBUF) msgBuf
+      CHARACTER*(13) blkWrd
 
       DATA tLoc
      &     /3.25905152915860 _d 0, 20.38687090048638 _d 0,
@@ -403,7 +412,7 @@ C     i,j,k
      &       0.  _d 0,  0. _d 0,
      &      35.  _d 0, 35. _d 0,
      &      34.7392 _d 0, 34.4652 _d 0,
-     &      34.7738 _d 0, 34.8435 _d 0, 
+     &      34.7738 _d 0, 34.8435 _d 0,
      &      34.8637 _d 0, 34.8739 _d 0, 34.8776 _d 0/
      &     pLoc
      &     /300. _d 5,  200. _d 5,
@@ -442,6 +451,7 @@ C     i,j,k
      &         -1.00000 _d 0,    -1.00000 _d 0,
      &         -1.00000 _d 0/
 
+      blkWrd = '             '
       bi   = 1
       bj   = 1
       k    = 1
@@ -459,18 +469,44 @@ C     check nonlinear EOS
      &        'EOS_CHECK: Check the equation of state: Type ',
      &        equationOfState
         CALL PRINT_MESSAGE( msgBuf, standardMessageUnit,
-     &       SQUEEZE_RIGHT , myThid )
-C-    to get the right pressure out of S/R PRESSURE_FOR_EOS:
-        mskSave = maskC(i,j,k,bi,bj)
-        rC_Save = rC(k)
-        maskC(i,j,k,bi,bj) = 1.
-        totPhiHyd(i,j,k,bi,bj) = 0.
-C-    + set rC accordingly
-        DO kcheck = 1,ncheck
-          IF ( usingZCoords ) THEN
-            rC(k) = -pLoc(kcheck)*recip_rhoConst*recip_gravity
-          ELSE
-            rC(k) =  pLoc(kcheck)
+     &                      SQUEEZE_RIGHT, myThid )
+        IF ( equationOfState.EQ.'JMD95Z' .OR.
+     &       equationOfState.EQ.'JMD95P' ) THEN
+          WRITE(msgBuf,'(A)')
+     &         'EOS_CHECK: check Rho values for eosType=JMD95:'
+          k1c = 1
+          k2c = 1
+        ELSEIF ( equationOfState.EQ.'MDJWF' ) THEN
+          WRITE(msgBuf,'(A)')
+     &         'EOS_CHECK: check Rho values for eosType=MDJWF:'
+          k1c = 2
+          k2c = 5
+        ELSEIF ( equationOfState.EQ.'UNESCO' ) THEN
+          WRITE(msgBuf,'(A)')
+     &         'EOS_CHECK: check Rho & K values for eosType=UNESCO:'
+          k1c = 6
+          k2c = 13
+        ELSEIF ( equationOfState.EQ.'TEOS10' ) THEN
+          WRITE(msgBuf,'(A)')
+     &         'EOS_CHECK: check Rho values for eosType=TEOS10:'
+          k1c = 14
+          k2c = ncheck
+        ELSE
+          WRITE(msgBuf,'(3A)') 'EOS_CHECK: Invalid eosType= ',
+     &          equationOfState
+          CALL PRINT_ERROR( msgBuf, myThid )
+          STOP 'ABNORMAL END: S/R EOS_CHECK'
+        ENDIF
+        CALL PRINT_MESSAGE( msgBuf, standardMessageUnit,
+     &                      SQUEEZE_RIGHT, myThid )
+C-    Will use "surf_pRef" to get the right pressure out of S/R PRESSURE_FOR_EOS
+C     --> save current value into "surf_pRef_save"
+        surf_pRef_save = surf_pRef
+        DO kcheck = k1c, k2c
+
+          surf_pRef = eosRefP0 + pLoc(kcheck)
+          IF ( usingPCoords ) THEN
+            surf_pRef = surf_pRef - rC(k)
           ENDIF
           IF ( equationOfState.NE.'UNESCO' ) THEN
              tFld(i,j) = ptLoc(kcheck)
@@ -486,68 +522,60 @@ C-    + set rC accordingly
      I           tFld, sFld,
      O           rhoLoc,
      I           k, bi, bj, myThid )
+          rhoDif = rhoLoc(i,j) + rhoConst - rLoc(kcheck)
 
-          IF ( equationOfState.EQ.'MDJWF' .OR.
-     &         equationOfState.EQ.'TEOS10' ) THEN
-            bulkMod(i,j) = -1. _d 0
-          ELSE
+          IF ( equationOfState.EQ.'UNESCO' ) THEN
             CALL FIND_BULKMOD(
      I           iMin, iMax, jMin, jMax,
      I           pFld, tFld, sFld,
      O           bulkMod,
      I           myThid )
-          ENDIF
-
-          IF ( kcheck .EQ. 1 ) THEN
-           WRITE(msgBuf,'(A)') 
-     &          'EOS_CHECK: check values for eosType=JMD95:'
-           CALL PRINT_MESSAGE( msgBuf, standardMessageUnit,
-     &          SQUEEZE_RIGHT , myThid )
-          ELSEIF ( kcheck .EQ. 2 ) THEN
-           WRITE(msgBuf,'(A)') 
-     &          'EOS_CHECK: check values for eosType=MDJWF:'
-           CALL PRINT_MESSAGE( msgBuf, standardMessageUnit,
-     &          SQUEEZE_RIGHT , myThid )
-          ELSEIF ( kcheck .EQ. 6 ) THEN
-           WRITE(msgBuf,'(A)') 
-     &          'EOS_CHECK: check values for eosType=UNESCO:'
-           CALL PRINT_MESSAGE( msgBuf, standardMessageUnit,
-     &          SQUEEZE_RIGHT , myThid )
-          ELSEIF ( kcheck .EQ. 14 ) THEN
-           WRITE(msgBuf,'(A)') 
-     &          'EOS_CHECK: check values for eosType=TEOS10:'
-           CALL PRINT_MESSAGE( msgBuf, standardMessageUnit,
-     &          SQUEEZE_RIGHT , myThid )
-          ENDIF
-          WRITE(msgBuf,'(2(A,F4.1),A,F5.0,2A,F10.5,1X,F11.5)')
-     &         'rho(', sFld(i,j), ' PSU,',
-     &         tFld(i,j), ' degC,',
-     &         pLoc(kcheck)*SItoBar, ' bar)',
-     &         ' = ', rLoc(kcheck), bLoc(kcheck)
-          CALL PRINT_MESSAGE( msgBuf, standardMessageUnit,
-     &         SQUEEZE_RIGHT , myThid )
-          WRITE(msgBuf,'(A,F10.5,1X,F11.5)')
+C-    Reference value
+            WRITE(msgBuf,'(2(A,F4.1),A,F5.0,2A,F10.5,A,F11.5)')
+     &           'rho(', sFld(i,j), ' PSU,',
+     &           tFld(i,j), ' degC,',
+     &           pLoc(kcheck)*SItoBar, ' bar)',
+     &           ' = ', rLoc(kcheck), ' ', bLoc(kcheck)
+            CALL PRINT_MESSAGE( msgBuf, standardMessageUnit,
+     &                          SQUEEZE_RIGHT, myThid )
+            WRITE(msgBuf,'(A,F10.5,A,F11.5,A,1PE10.3)')
+     &           ' rho(find_rho_2d)                 = ',
+     &           rhoLoc(i,j)+rhoConst, ' ', bulkMod(i,j), ' ', rhoDif
+            iLen = LEN( blkWrd )
+          ELSE
+C-    Reference value
+            WRITE(msgBuf,'(2(A,F4.1),A,F5.0,2A,F10.5,A,F11.5)')
+     &           'rho(', sFld(i,j), ' PSU,',
+     &           tFld(i,j), ' degC,',
+     &           pLoc(kcheck)*SItoBar, ' bar)',
+     &           ' = ', rLoc(kcheck)
+            CALL PRINT_MESSAGE( msgBuf, standardMessageUnit,
+     &                          SQUEEZE_RIGHT, myThid )
+            WRITE(msgBuf,'(A,F10.5,A,1PE10.3)')
      &         ' rho(find_rho_2d)                 = ',
-     &         rhoLoc(i,j)+rhoConst, bulkMod(i,j)
+     &         rhoLoc(i,j)+rhoConst, ' ', rhoDif
+            iLen = 1
+          ENDIF
           CALL PRINT_MESSAGE( msgBuf, standardMessageUnit,
-     &         SQUEEZE_RIGHT , myThid )
+     &                        SQUEEZE_RIGHT, myThid )
 
+          surf_pRef = eosRefP0
           CALL FIND_RHO_SCALAR( tFld(i,j), sLoc(kcheck),
      &         pLoc(kcheck), rhoLoc(i,j), myThid )
-          WRITE(msgBuf,'(A,F10.5,1X,F11.5)')
+          rhoDif = rhoLoc(i,j) - rLoc(kcheck)
+          WRITE(msgBuf,'(A,F10.5,A,1PE10.3)')
      &         ' rho(find_rho_scalar)             = ',
-     &         rhoLoc(i,j)
+     &         rhoLoc(i,j), blkWrd(1:iLen), rhoDif
           CALL PRINT_MESSAGE( msgBuf, standardMessageUnit,
-     &         SQUEEZE_RIGHT , myThid )
+     &                        SQUEEZE_RIGHT, myThid )
 
         ENDDO
-C     end check nonlinear EOS
-        maskC(i,j,k,bi,bj) = mskSave
-        rC(k) = rC_Save
+C     end check nonlinear EOS ; restore surf_pRef value
+        surf_pRef = surf_pRef_save
 
         WRITE(msgBuf,'(A)') 'EOS_CHECK: Done'
         CALL PRINT_MESSAGE( msgBuf, standardMessageUnit,
-     &       SQUEEZE_RIGHT , myThid )
+     &                      SQUEEZE_RIGHT, myThid )
 
       ENDIF
 #endif /* INCLUDE_EOS_CHECK */

--- a/model/src/ini_parms.F
+++ b/model/src/ini_parms.F
@@ -193,7 +193,7 @@ C--   Continuous equation parameters
      & viscA4ReMax, viscAhReMax,
      & cosPower, viscAstrain, viscAtension,
      & diffKhT, diffK4T, diffKhS, diffK4S,
-     & tRef, sRef, tRefFile, sRefFile, rhoRefFile,
+     & surf_pRef, tRef, sRef, tRefFile, sRefFile, rhoRefFile,
      & eosType, selectP_inEOS_Zc, integr_GeoPot, selectFindRoSurf,
      & HeatCapacity_Cp, celsius2K, atm_Cp, atm_Rd, atm_Rq, atm_Po,
      & no_slip_sides, sideDragFactor, no_slip_bottom, bottomVisc_pCell,

--- a/model/src/pressure_for_eos.F
+++ b/model/src/pressure_for_eos.F
@@ -4,7 +4,7 @@ CBOP
 C     !ROUTINE: PRESSURE_FOR_EOS
 C     !INTERFACE:
       SUBROUTINE PRESSURE_FOR_EOS(
-     I        bi, bj, iMin, iMax, jMin, jMax,  k,
+     I        bi, bj, iMin, iMax, jMin, jMax,  k, dpRef,
      O        locPres,
      I        myThid )
 C     !DESCRIPTION: \bv
@@ -12,6 +12,11 @@ C     *==========================================================*
 C     | SUBROUTINE PRESSURE_FOR_EOS
 C     | o Provide a local copy of the total pressure
 C     |   at cell center (level k) for use in EOS funct. of P
+C     | Note: Since most seawater EOS are formulated as function
+C     |   of pressure anomaly relative to a reference P, this
+C     |   S/R allows to account for this reference Pressure (or
+C     |   different ref P) by adding a pressure shift "dpRef"
+C     |   to the output pressure.
 C     *==========================================================*
 C     \ev
 
@@ -30,11 +35,15 @@ C     == Global variables ==
 
 C     !INPUT/OUTPUT PARAMETERS:
 C     == Routine arguments ==
-C     bi,bj, k  :: tile and level indices
-C     iMin,iMax,jMin,jMax :: computational domain
-C     myThid - Thread number for this instance of the routine.
+C     bi, bj, k :: tile and level indices
+C     iMin,iMax :: computational domain, first index range
+C     jMin,jMax :: computational domain, second index range
+C     dpRef     :: shift applied to output pressure [Pa]
+C     locPres   :: total pressure for use in EOS [Pa]
+C     myThid    :: my Thread Id number
       INTEGER bi, bj, k
       INTEGER iMin,iMax,jMin,jMax
+      _RL dpRef
       _RL locPres(1-OLx:sNx+OLx,1-OLy:sNy+OLy)
       INTEGER myThid
 
@@ -44,9 +53,8 @@ C     i,j :: loop index
       INTEGER  i,j
 CEOP
 
-C
-C     provide the pressure for use in the equation of state
-C
+C     Provide the pressure for use in the equation of state
+
       IF ( usingZCoords ) THEN
 C     in Z coordinates the pressure is rho0 * (hydrostatic) Potential
 #ifdef ALLOW_NONHYDROSTATIC
@@ -57,8 +65,7 @@ C-     use full (hydrostatic+non-hydrostatic) dynamical pressure:
             locPres(i,j) = rhoConst*(
      &                   totPhiHyd(i,j,k,bi,bj)
      &                 +( phi_nh(i,j,k,bi,bj) - dPhiNH(i,j,bi,bj) )
-     &                 + phiRef(2*k) )
-c    &                             *maskC(i,j,k,bi,bj)
+     &                 + phiRef(2*k) ) + dpRef
           ENDDO
          ENDDO
        ELSEIF ( selectP_inEOS_Zc.EQ.2 ) THEN
@@ -74,8 +81,7 @@ C----------
           DO i=1-OLx,sNx+OLx
             locPres(i,j) = rhoConst*(
      &                   totPhiHyd(i,j,k,bi,bj)
-     &                 + phiRef(2*k) )
-c    &                             *maskC(i,j,k,bi,bj)
+     &                 + phiRef(2*k) ) + dpRef
           ENDDO
          ENDDO
 c      ELSEIF ( selectP_inEOS_Zc.EQ.1 ) THEN
@@ -86,16 +92,14 @@ C-     use horizontally uniform reference pressure pRef
 C      (solution of: pRef = integral{-g*rho(Tref,Sref,pRef)*dz} )
          DO j=1-OLy,sNy+OLy
           DO i=1-OLx,sNx+OLx
-            locPres(i,j) = pRef4EOS(k)
-c    &                              *maskC(i,j,k,bi,bj)
+            locPres(i,j) = pRef4EOS(k) + dpRef
           ENDDO
          ENDDO
        ELSE
 C-     simplest case: -g*rhoConst*z
          DO j=1-OLy,sNy+OLy
           DO i=1-OLx,sNx+OLx
-            locPres(i,j) = rhoConst*phiRef(2*k)
-c    &                              *maskC(i,j,k,bi,bj)
+            locPres(i,j) = rhoConst*phiRef(2*k) + dpRef
           ENDDO
          ENDDO
        ENDIF
@@ -104,8 +108,7 @@ C     in P coordinates the pressure is just the coordinate of
 C     the tracer point
          DO j=1-OLy,sNy+OLy
           DO i=1-OLx,sNx+OLx
-            locPres(i,j) = rC(k)
-c    &                   * maskC(i,j,k,bi,bj)
+            locPres(i,j) = rC(k) + dpRef
           ENDDO
          ENDDO
       ENDIF

--- a/model/src/set_defaults.F
+++ b/model/src/set_defaults.F
@@ -101,6 +101,7 @@ C--   Set default "physical" parameters
       nh_Am2              = 1. _d 0
       gravity             = 9.81 _d 0
       gBaro               = UNSET_RL
+      surf_pRef           = 101325. _d 0
       rhoNil              = 999.8 _d 0
       rhoConst            = UNSET_RL
 C-- jmc : the default is to set rhoConstFresh to rhoConst (=rhoNil by default)

--- a/pkg/diagnostics/diagnostics_main_init.F
+++ b/pkg/diagnostics/diagnostics_main_init.F
@@ -622,7 +622,7 @@ C--   surface fluxes:
      I   diagName, diagCode, diagUnits, diagTitle, diagMate, myThid )
 
       diagName  = 'atmPload'
-      diagTitle = 'Atmospheric pressure loading'
+      diagTitle = 'Atmospheric pressure loading anomaly (vs surf_pRef)'
       diagUnits = 'Pa              '
       diagCode  = 'SM      U1      '
       CALL DIAGNOSTICS_ADDTOLIST( diagNum,

--- a/pkg/dic/dic_readparms.F
+++ b/pkg/dic/dic_readparms.F
@@ -48,9 +48,9 @@ C---+----1----+----2----+----3----+----4----+----5----+----6----+----7-|--+----|
 C-- Abiotic dic parameters:
 C permil   :: set carbon mol/m3 <---> mol/kg conversion factor
 C             default permil = 1024.5 kg/m3
-C Pa2Atm   :: Conversion factor for atmospheric pressure pLoad (when coupled
-C             to atmospheric model) into Atm. Default assumes pLoad in Pascal
-C             1 Atm = 1.01325e5 Pa = 1013.25 mb
+C Pa2Atm   :: Conversion factor for atmospheric pressure anomaly pLoad (when
+C             coupled to atmospheric model) into Atm.
+C             Default assumes pLoad in Pascal: 1 Atm = 1.01325e5 Pa = 1013.25 mb
 C  selectBTconst :: estimates borate concentration from salinity:
 C     =1 :: use default formulation of Uppström (1974)(same as S/R CARBON_COEFFS)
 C     =2 :: use new formulation from Lee et al (2010)

--- a/pkg/dic/dic_surfforcing.F
+++ b/pkg/dic/dic_surfforcing.F
@@ -146,7 +146,7 @@ C to total pressure (in Atm)
 C Note: it is assumed the reference atmospheric pressure is 1Atm=1013mb
 C       rather than the actual ref. pressure from Atm. model so that on
 C       average AtmosP is about 1 Atm.
-                AtmosP(i,j,bi,bj)= 1. _d 0 + pLoad(i,j,bi,bj)/Pa2Atm
+          AtmosP(i,j,bi,bj)= ( surf_pRef + pLoad(i,j,bi,bj) )/Pa2Atm
 #endif
 
 C Pre-compute part of exchange coefficient: pisvel*(1-fice)

--- a/pkg/exf/EXF_FIELDS.h
+++ b/pkg/exf/EXF_FIELDS.h
@@ -121,13 +121,12 @@ C                  > 0 for increase in theta (ocean warming)
 C                  Typical range: 50 < lwdown < 450
 C                  Input/output field
 C
-C     apressure :: Atmospheric pressure field in N/m^2
-C                  > 0 for ????
-C                  Typical range: ???? < apressure < ????
+C     apressure :: Atmospheric surface pressure field in Pa
+C                  Typical range: 88000 < apressure < 108000
 C                  Input field
 C
 C     tidePot   :: Tidal geopotential forcing in m^2/s^2
-C                  Typical range: -10 < apressure < +10
+C                  Typical range: -10 < tidePot < +10
 C                  Input field
 
 C     NOTES:

--- a/pkg/exf/exf_mapfields.F
+++ b/pkg/exf/exf_mapfields.F
@@ -318,9 +318,11 @@ C             Short wave radiative flux.
 #endif
 
 #ifdef ATMOSPHERIC_LOADING
+C-    subtract "surf_pRef" to fill in atmos. pressure anomaly "pLoad"
           DO j = jmin,jmax
             DO i = imin,imax
-             pLoad(i,j,bi,bj)=exf_outscal_apressure*apressure(i,j,bi,bj)
+             pLoad(i,j,bi,bj) =
+     &          exf_outscal_apressure*apressure(i,j,bi,bj) - surf_pRef
             ENDDO
           ENDDO
 #endif

--- a/pkg/exf/exf_readparms.F
+++ b/pkg/exf/exf_readparms.F
@@ -506,7 +506,7 @@ C     Calendar data.
       apressurestartdate1    = 0
       apressurestartdate2    = 0
       apressureperiod        = 0.0 _d 0
-      apressureconst         = 0.0 _d 0
+      apressureconst         = surf_pRef
       apressure_exfremo_intercept = 0.0 _d 0
       apressure_exfremo_slope = 0.0 _d 0
 


### PR DESCRIPTION
## What changes does this PR introduce?
Address issue #199, defining clearly pLoad as atmospheric pressure anomaly relative
to new surface pressure reference value "surf_pRef".
Also explicitly set seawater EOS reference pressure (hold in EOS.h) and account for
potential differeces between the 2.
Fix and simplify S/R EOS_CHECK (which has been broken for a long time).

## What is the current behaviour? 
- seawater EOS assume pressure is defined relative to a relative pressure which does not
  appear anywhere.
- pLoad is documented as full atmospheric surface pressure but this is not consistent with 
  effects in EOS (when using  selectP_inEOS_Zc >= 2) and not consistent with coupling pkgs
  and dic pkgs.

## What is the new behaviour 
- set seawater EOS reference pressure explicitly (hard coded).
- new model parameter "surf_pRef" for model reference surface pressure, used for pLoad definition.
- account for potential difference between the 2 reference pressure.
- keep exf "apressure" field as full atmospheric surface pressure and fill-in pLoad accordingly.

## Does this PR introduce a breaking change? 
When using "apressure" field from pkg/exf, "surf_pref" is now subtracted from it to fill in pLoad.
This is likely to affect results:
 - at machine truncation level if selectP_inEOS_Z < 2 
 - larger differences but more consistent results with selectP_inEOS_Z >= 2

## Other information:

## Suggested addition to `tag-index`
o model/src & pkg/exf: 
  - Reference atmospheric pressure for seawater EOS was assumed but was not
    explicitly set. New constant "eosRefP0" is added to make this more clear ;
  - Add main model reference surface pressure (surf_pRef) so that pLoad
    is now defined as the atmospheric pressure anomaly relative to surf_pRef ;
  - account for differences in 2 ref pressure in EOS S/R ;
  - fix few EOS references (in comments) ; fix and simplify S/R EOS_CHECK ;
  - keep exf "apressure" field unchanged (still full atmospheric surface
    pressure) but now initialised to "surf_pRef" and fill "pLoad" with atmos. 
    pressure anomaly relative to surf_pRef.
