### PR TITLE
Active file read/write for 1d vectors

### DIFF
--- a/doc/tag-index
+++ b/doc/tag-index
@@ -1,6 +1,9 @@
     Notes on tags used in MITgcmUV
     ==============================
 
+o pkg/autodiff:
+  - add active read and write routines for global 1D vectors, to be used for
+    compressed cost function vectors (note: not used yet, example to come soon).
 o model/src & pkg/exf:
   - Reference atmospheric pressure for seawater EOS was assumed but was not
     explicitly set. New constant "eosRefP0" is added to make this more clear ;

--- a/pkg/autodiff/active_file.F
+++ b/pkg/autodiff/active_file.F
@@ -9,13 +9,13 @@ C    o  active_read_xy         - Read  an active 2D variable from file.
 C    o  active_read_xyz        - Read  an active 3D variable from file.
 C    o  active_read_xz         - Read  an active 2D xz-slice from file.
 C    o  active_read_yz         - Read  an active 2D yz-slice from file.
-C    o  active_read_1D         - Read  an active 1D vector from file.
+C    o  active_read_1d         - Read  an active 1D vector from file.
 C
 C    o  active_write_xy        - Write an active 2D variable to a file.
 C    o  active_write_xyz       - Write an active 3D variable to a file.
 C    o  active_write_xz        - Write an active 2D xz-slice to a file.
 C    o  active_write_yz        - Write an active 2D yz-slice to a file.
-C    o  active_write_1D        - Write an active 1D vector from file.
+C    o  active_write_1d        - Write an active 1D vector from file.
 C
 C        changed: Christian Eckert eckert@mit.edu 24-Apr-2000
 C                 - Added routines that do active writes on tiles
@@ -37,8 +37,8 @@ C     !INTERFACE:
      I                           doglobalread,
      I                           lAdInit,
      I                           myOptimIter,
-     I                           myThid
-     I                         , dummy
+     I                           myThid,
+     I                           dummy
      &                         )
 
 C     !DESCRIPTION: \bv
@@ -60,22 +60,22 @@ C     == global variables ==
 #include "SIZE.h"
 
 C     !INPUT/OUTPUT PARAMETERS:
-C     active_var_file: filename
-C     active_var:      array
-C     iRec:            record number
-C     myOptimIter:     number of optimization iteration (default: 0)
-C     myThid:          thread number for this instance
-C     doglobalread:    flag for global or local read/write
-C                      (default: .false.)
-C     lAdInit:         initialisation of corresponding adjoint
-C                      variable and write to active file
+C     active_var_file:: filename
+C     active_var     :: array
+C     iRec           :: record number
+C     doglobalread   :: flag for global or local read/write
+C                       (default: .false.)
+C     lAdInit        :: initialisation of corresponding adjoint
+C                       variable and write to active file
+C     myOptimIter    :: number of optimization iteration (default: 0)
+C     myThid         :: thread number for this instance
       CHARACTER*(*) active_var_file
       _RL     active_var(1-OLx:sNx+OLx,1-OLy:sNy+OLy,nSx,nSy)
       INTEGER iRec
-      INTEGER myOptimIter
-      INTEGER myThid
       LOGICAL doglobalread
       LOGICAL lAdInit
+      INTEGER myOptimIter
+      INTEGER myThid
       _RL     dummy
 
 C     !LOCAL VARIABLES:
@@ -104,8 +104,8 @@ C     !INTERFACE:
      I                            doglobalread,
      I                            lAdInit,
      I                            myOptimIter,
-     I                            myThid
-     I                         , dummy
+     I                            myThid,
+     I                            dummy
      &                           )
 
 C     !DESCRIPTION: \bv
@@ -127,22 +127,22 @@ C     == global variables ==
 #include "SIZE.h"
 
 C     !INPUT/OUTPUT PARAMETERS:
-C     active_var_file: filename
-C     active_var:      array
-C     iRec:            record number
-C     myOptimIter:     number of optimization iteration (default: 0)
-C     myThid:          thread number for this instance
-C     doglobalread:    flag for global or local read/write
-C                      (default: .false.)
-C     lAdInit:         initialisation of corresponding adjoint
-C                      variable and write to active file
+C     active_var_file:: filename
+C     active_var     :: array
+C     iRec           :: record number
+C     doglobalread   :: flag for global or local read/write
+C                       (default: .false.)
+C     lAdInit        :: initialisation of corresponding adjoint
+C                       variable and write to active file
+C     myOptimIter    :: number of optimization iteration (default: 0)
+C     myThid         :: thread number for this instance
       CHARACTER*(*) active_var_file
       _RL active_var(1-OLx:sNx+OLx,1-OLy:sNy+OLy,Nr,nSx,nSy)
       INTEGER iRec
-      INTEGER myOptimIter
-      INTEGER myThid
       LOGICAL doglobalread
       LOGICAL lAdInit
+      INTEGER myOptimIter
+      INTEGER myThid
       _RL     dummy
 
 C     !LOCAL VARIABLES:
@@ -171,8 +171,8 @@ C     !INTERFACE:
      I                           doglobalread,
      I                           lAdInit,
      I                           myOptimIter,
-     I                           myThid
-     I                         , dummy
+     I                           myThid,
+     I                           dummy
      &                         )
 
 C     !DESCRIPTION: \bv
@@ -194,22 +194,22 @@ C     == global variables ==
 #include "SIZE.h"
 
 C     !INPUT/OUTPUT PARAMETERS:
-C     active_var_file: filename
-C     active_var:      array
-C     iRec:            record number
-C     myOptimIter:     number of optimization iteration (default: 0)
-C     myThid:          thread number for this instance
-C     doglobalread:    flag for global or local read/write
-C                      (default: .false.)
-C     lAdInit:         initialisation of corresponding adjoint
-C                      variable and write to active file
+C     active_var_file:: filename
+C     active_var     :: array
+C     iRec           :: record number
+C     doglobalread   :: flag for global or local read/write
+C                       (default: .false.)
+C     lAdInit        :: initialisation of corresponding adjoint
+C                       variable and write to active file
+C     myOptimIter    :: number of optimization iteration (default: 0)
+C     myThid         :: thread number for this instance
       CHARACTER*(*) active_var_file
       _RL     active_var(1-OLx:sNx+OLx,nSx,nSy)
       INTEGER iRec
-      INTEGER myOptimIter
-      INTEGER myThid
       LOGICAL doglobalread
       LOGICAL lAdInit
+      INTEGER myOptimIter
+      INTEGER myThid
       _RL     dummy
 
 C     !LOCAL VARIABLES:
@@ -238,8 +238,8 @@ C     !INTERFACE:
      I                           doglobalread,
      I                           lAdInit,
      I                           myOptimIter,
-     I                           myThid
-     I                         , dummy
+     I                           myThid,
+     I                           dummy
      &                         )
 
 C     !DESCRIPTION: \bv
@@ -260,22 +260,22 @@ C     == global variables ==
 #include "SIZE.h"
 
 C     !INPUT/OUTPUT PARAMETERS:
-C     active_var_file: filename
-C     active_var:      array
-C     iRec:            record number
-C     myOptimIter:     number of optimization iteration (default: 0)
-C     myThid:          thread number for this instance
-C     doglobalread:    flag for global or local read/write
-C                      (default: .false.)
-C     lAdInit:         initialisation of corresponding adjoint
-C                      variable and write to active file
+C     active_var_file:: filename
+C     active_var     :: array
+C     iRec           :: record number
+C     doglobalread   :: flag for global or local read/write
+C                       (default: .false.)
+C     lAdInit        :: initialisation of corresponding adjoint
+C                       variable and write to active file
+C     myOptimIter    :: number of optimization iteration (default: 0)
+C     myThid         :: thread number for this instance
       CHARACTER*(*) active_var_file
       _RL     active_var(1-OLy:sNy+OLy,nSx,nSy)
       INTEGER iRec
-      INTEGER myOptimIter
-      INTEGER myThid
       LOGICAL doglobalread
       LOGICAL lAdInit
+      INTEGER myOptimIter
+      INTEGER myThid
       _RL     dummy
 
 C     !LOCAL VARIABLES:
@@ -327,27 +327,27 @@ C     == global variables ==
 #include "SIZE.h"
 
 C     !INPUT/OUTPUT PARAMETERS:
-C     active_var_file: filename
-C     active_var:      array
-C     iRec:            record number
-C     myOptimIter:     number of optimization iteration (default: 0)
-C     myThid:          thread number for this instance
-C     lAdInit:         initialisation of corresponding adjoint
-C                      variable and write to active file
+C     active_var_file:: filename
+C     active_var     :: array
+C     active_var_length :: number of elements in active variable
+C     iRec           :: record number
+C     lAdInit        :: initialisation of corresponding adjoint
+C                       variable and write to active file
+C     myOptimIter    :: number of optimization iteration (default: 0)
+C     myThid         :: thread number for this instance
       CHARACTER*(*) active_var_file
       _RL     active_var(*)
       INTEGER active_var_length
       INTEGER iRec
+      LOGICAL lAdInit
       INTEGER myOptimIter
       INTEGER myThid
-      LOGICAL lAdInit
       _RL     dummy
-
 CEOP
 
       CALL ACTIVE_READ_1D_RL(
      &                 active_var_file, active_var, active_var_length,
-     &                 lAdInit, iRec, 
+     &                 lAdInit, iRec,
      &                 FORWARD_SIMULATION, myOptimIter, myThid )
 
       RETURN
@@ -362,8 +362,8 @@ C     !INTERFACE:
      I                            active_var,
      I                            iRec,
      I                            myOptimIter,
-     I                            myThid
-     I                         , dummy
+     I                            myThid,
+     I                            dummy
      &                          )
 
 C     !DESCRIPTION: \bv
@@ -385,11 +385,11 @@ C     == global variables ==
 #include "SIZE.h"
 
 C     !INPUT/OUTPUT PARAMETERS:
-C     active_var_file: filename
-C     active_var:      array
-C     iRec:            record number
-C     myOptimIter:     number of optimization iteration (default: 0)
-C     myThid:          thread number for this instance
+C     active_var_file:: filename
+C     active_var     :: array
+C     iRec           :: record number
+C     myOptimIter    :: number of optimization iteration (default: 0)
+C     myThid         :: thread number for this instance
       CHARACTER*(*) active_var_file
       _RL     active_var(1-OLx:sNx+OLx,1-OLy:sNy+OLy,nSx,nSy)
       INTEGER iRec
@@ -423,8 +423,8 @@ C     !INTERFACE:
      I                             active_var,
      I                             iRec,
      I                             myOptimIter,
-     I                             myThid
-     I                         , dummy
+     I                             myThid,
+     I                             dummy
      &                           )
 
 C     !DESCRIPTION: \bv
@@ -446,11 +446,11 @@ C     == global variables ==
 #include "SIZE.h"
 
 C     !INPUT/OUTPUT PARAMETERS:
-C     active_var_file: filename
-C     active_var:      array
-C     iRec:            record number
-C     myOptimIter:     number of optimization iteration (default: 0)
-C     myThid:          thread number for this instance
+C     active_var_file:: filename
+C     active_var     :: array
+C     iRec           :: record number
+C     myOptimIter    :: number of optimization iteration (default: 0)
+C     myThid         :: thread number for this instance
       CHARACTER*(*) active_var_file
       _RL active_var(1-OLx:sNx+OLx,1-OLy:sNy+OLy,Nr,nSx,nSy)
       INTEGER iRec
@@ -484,8 +484,8 @@ C     !INTERFACE:
      I                            active_var,
      I                            iRec,
      I                            myOptimIter,
-     I                            myThid
-     I                         , dummy
+     I                            myThid,
+     I                            dummy
      &                          )
 
 C     !DESCRIPTION: \bv
@@ -507,11 +507,11 @@ C     == global variables ==
 #include "SIZE.h"
 
 C     !INPUT/OUTPUT PARAMETERS:
-C     active_var_file: filename
-C     active_var:      array
-C     iRec:            record number
-C     myOptimIter:     number of optimization iteration (default: 0)
-C     myThid:          thread number for this instance
+C     active_var_file:: filename
+C     active_var     :: array
+C     iRec           :: record number
+C     myOptimIter    :: number of optimization iteration (default: 0)
+C     myThid         :: thread number for this instance
       CHARACTER*(*) active_var_file
       _RL     active_var(1-OLx:sNx+OLx,nSx,nSy)
       INTEGER iRec
@@ -545,8 +545,8 @@ C     !INTERFACE:
      I                            active_var,
      I                            iRec,
      I                            myOptimIter,
-     I                            myThid
-     I                         , dummy
+     I                            myThid,
+     I                            dummy
      &                          )
 
 C     !DESCRIPTION: \bv
@@ -568,11 +568,11 @@ C     == global variables ==
 #include "SIZE.h"
 
 C     !INPUT/OUTPUT PARAMETERS:
-C     active_var_file: filename
-C     active_var:      array
-C     iRec:            record number
-C     myOptimIter:     number of optimization iteration (default: 0)
-C     myThid:          thread number for this instance
+C     active_var_file:: filename
+C     active_var     :: array
+C     iRec           :: record number
+C     myOptimIter    :: number of optimization iteration (default: 0)
+C     myThid         :: thread number for this instance
       CHARACTER*(*) active_var_file
       _RL     active_var(1-OLy:sNy+OLy,nSx,nSy)
       INTEGER iRec
@@ -630,11 +630,12 @@ C     == global variables ==
 #include "SIZE.h"
 
 C     !INPUT/OUTPUT PARAMETERS:
-C     active_var_file: filename
-C     active_var:      array
-C     iRec:            record number
-C     myOptimIter:     number of optimization iteration (default: 0)
-C     myThid:          thread number for this instance
+C     active_var_file:: filename
+C     active_var     :: array
+C     active_var_length :: number of elements in active variable
+C     iRec           :: record number
+C     myOptimIter    :: number of optimization iteration (default: 0)
+C     myThid         :: thread number for this instance
       CHARACTER*(*) active_var_file
       _RL     active_var(*)
       INTEGER active_var_length
@@ -642,7 +643,6 @@ C     myThid:          thread number for this instance
       INTEGER myOptimIter
       INTEGER myThid
       _RL     dummy
-
 CEOP
 
       CALL ACTIVE_WRITE_1D_RL(

--- a/pkg/autodiff/active_file.F
+++ b/pkg/autodiff/active_file.F
@@ -204,7 +204,7 @@ C                       variable and write to active file
 C     myOptimIter    :: number of optimization iteration (default: 0)
 C     myThid         :: thread number for this instance
       CHARACTER*(*) active_var_file
-      _RL     active_var(1-OLx:sNx+OLx,nSx,nSy)
+      _RL     active_var(1-OLx:sNx+OLx,Nr,nSx,nSy)
       INTEGER iRec
       LOGICAL doglobalread
       LOGICAL lAdInit
@@ -270,7 +270,7 @@ C                       variable and write to active file
 C     myOptimIter    :: number of optimization iteration (default: 0)
 C     myThid         :: thread number for this instance
       CHARACTER*(*) active_var_file
-      _RL     active_var(1-OLy:sNy+OLy,nSx,nSy)
+      _RL     active_var(1-OLy:sNy+OLy,Nr,nSx,nSy)
       INTEGER iRec
       LOGICAL doglobalread
       LOGICAL lAdInit
@@ -513,7 +513,7 @@ C     iRec           :: record number
 C     myOptimIter    :: number of optimization iteration (default: 0)
 C     myThid         :: thread number for this instance
       CHARACTER*(*) active_var_file
-      _RL     active_var(1-OLx:sNx+OLx,nSx,nSy)
+      _RL     active_var(1-OLx:sNx+OLx,Nr,nSx,nSy)
       INTEGER iRec
       INTEGER myOptimIter
       INTEGER myThid
@@ -574,7 +574,7 @@ C     iRec           :: record number
 C     myOptimIter    :: number of optimization iteration (default: 0)
 C     myThid         :: thread number for this instance
       CHARACTER*(*) active_var_file
-      _RL     active_var(1-OLy:sNy+OLy,nSx,nSy)
+      _RL     active_var(1-OLy:sNy+OLy,Nr,nSx,nSy)
       INTEGER iRec
       INTEGER myOptimIter
       INTEGER myThid

--- a/pkg/autodiff/active_file.F
+++ b/pkg/autodiff/active_file.F
@@ -9,17 +9,21 @@ C    o  active_read_xy         - Read  an active 2D variable from file.
 C    o  active_read_xyz        - Read  an active 3D variable from file.
 C    o  active_read_xz         - Read  an active 2D xz-slice from file.
 C    o  active_read_yz         - Read  an active 2D yz-slice from file.
+C    o  active_read_1D         - Read  an active 1D vector from file.
 C
 C    o  active_write_xy        - Write an active 2D variable to a file.
 C    o  active_write_xyz       - Write an active 3D variable to a file.
 C    o  active_write_xz        - Write an active 2D xz-slice to a file.
 C    o  active_write_yz        - Write an active 2D yz-slice to a file.
+C    o  active_write_1D        - Write an active 1D vector from file.
 C
 C        changed: Christian Eckert eckert@mit.edu 24-Apr-2000
 C                 - Added routines that do active writes on tiles
 C                   instead of a whole thread.
 C        changed: heimbach@mit.edu 05-Mar-2001
 C                 - added active file handling of xz-/yz-arrays
+C        changed: tsmith@oden.utexas.edu 22-Oct-2019
+C                 - added 1D vectors
 C     ==================================================================
 
 C---+----1----+----2----+----3----+----4----+----5----+----6----+----7-|--+----|
@@ -291,6 +295,66 @@ CEOP
 
 C---+----1----+----2----+----3----+----4----+----5----+----6----+----7-|--+----|
 CBOP
+C     !ROUTINE: active_read_1d
+C     !INTERFACE:
+      subroutine active_read_1d(
+     I                           active_var_file,
+     O                           active_var,
+     I                           active_var_length,
+     I                           iRec,
+     I                           lAdInit,
+     I                           myOptimIter,
+     I                           myThid,
+     I                           dummy
+     &                         )
+
+C     !DESCRIPTION: \bv
+C     ==================================================================
+C     SUBROUTINE active_read_1d
+C     ==================================================================
+C     o Read an active 1D vector from file.
+C     started: Tim Smith tsmith@oden.utexas.edu 22-Oct-2019
+C     ==================================================================
+C     SUBROUTINE active_read_1d
+C     ==================================================================
+C     \ev
+
+C     !USES:
+      IMPLICIT NONE
+
+C     == global variables ==
+#include "EEPARAMS.h"
+#include "SIZE.h"
+
+C     !INPUT/OUTPUT PARAMETERS:
+C     active_var_file: filename
+C     active_var:      array
+C     iRec:            record number
+C     myOptimIter:     number of optimization iteration (default: 0)
+C     myThid:          thread number for this instance
+C     lAdInit:         initialisation of corresponding adjoint
+C                      variable and write to active file
+      CHARACTER*(*) active_var_file
+      _RL     active_var(*)
+      INTEGER active_var_length
+      INTEGER iRec
+      INTEGER myOptimIter
+      INTEGER myThid
+      LOGICAL lAdInit
+      _RL     dummy
+
+CEOP
+
+      CALL ACTIVE_READ_1D_RL(
+     &                 active_var_file, active_var, active_var_length,
+     &                 lAdInit, iRec, 
+     &                 FORWARD_SIMULATION, myOptimIter, myThid )
+
+      RETURN
+      END
+
+C---+----1----+----2----+----3----+----4----+----5----+----6----+----7-|--+----|
+CBOP
 C     !ROUTINE: active_write_xy
 C     !INTERFACE:
       subroutine active_write_xy(
@@ -529,6 +593,61 @@ CEOP
      &                 active_var_file, active_var, globalFile,
      &                 useCurrentDir, iRec, myNr,
      &                 FORWARD_SIMULATION, myOptimIter, myThid )
+
+      RETURN
+      END
+
+C---+----1----+----2----+----3----+----4----+----5----+----6----+----7-|--+----|
+CBOP
+C     !ROUTINE: active_write_1d
+C     !INTERFACE:
+      subroutine active_write_1d(
+     I                           active_var_file,
+     O                           active_var,
+     I                           active_var_length,
+     I                           iRec,
+     I                           myOptimIter,
+     I                           myThid,
+     I                           dummy
+     &                         )
+
+C     !DESCRIPTION: \bv
+C     ==================================================================
+C     SUBROUTINE active_write_1d
+C     ==================================================================
+C     o Write an active 1D vector to file.
+C     started: Tim Smith tsmith@oden.utexas.edu 22-Oct-2019
+C     ==================================================================
+C     SUBROUTINE active_write_1d
+C     ==================================================================
+C     \ev
+
+C     !USES:
+      IMPLICIT NONE
+
+C     == global variables ==
+#include "EEPARAMS.h"
+#include "SIZE.h"
+
+C     !INPUT/OUTPUT PARAMETERS:
+C     active_var_file: filename
+C     active_var:      array
+C     iRec:            record number
+C     myOptimIter:     number of optimization iteration (default: 0)
+C     myThid:          thread number for this instance
+      CHARACTER*(*) active_var_file
+      _RL     active_var(*)
+      INTEGER active_var_length
+      INTEGER iRec
+      INTEGER myOptimIter
+      INTEGER myThid
+      _RL     dummy
+
+CEOP
+
+      CALL ACTIVE_WRITE_1D_RL(
+     &                 active_var_file, active_var, active_var_length,
+     &                 iRec, FORWARD_SIMULATION, myOptimIter, myThid )
 
       RETURN
       END

--- a/pkg/autodiff/active_file.flow
+++ b/pkg/autodiff/active_file.flow
@@ -11,10 +11,12 @@ c     * active_read_xy
 c     * active_read_xyz
 c     * active_read_xz
 c     * active_read_yz
+c     * active_read_1d
 c     * active_write_xy
 c     * active_write_xyz
 c     * active_write_xz
 c     * active_write_yz
+c     * active_write_1d
 c     ==================================================================
 c     active_file.flow
 c     ==================================================================
@@ -62,6 +64,16 @@ cadj SUBROUTINE active_read_yz ACTIVE  =    2,                8
 cadj SUBROUTINE active_read_yz DEPEND  = 1,    3, 4, 5, 6, 7, 8
 
 c----------------------------------------
+c subroutine active_read_yz
+c----------------------------------------
+cadj SUBROUTINE active_read_1d FTLNAME = g_active_read_1d
+cadj SUBROUTINE active_read_1d ADNAME  = adactive_read_1d
+cadj SUBROUTINE active_read_1d INPUT   = 1   , 3, 4, 5, 6, 7, 8
+cadj SUBROUTINE active_read_1d OUTPUT  =    2
+cadj SUBROUTINE active_read_1d ACTIVE  =    2,                8
+cadj SUBROUTINE active_read_1d DEPEND  = 1,    3, 4, 5, 6, 7, 8
+
+c----------------------------------------
 c subroutine active_write_xy
 c----------------------------------------
 cadj SUBROUTINE active_write_xy FTLNAME = g_active_write_xy
@@ -101,3 +113,12 @@ cadj SUBROUTINE active_write_yz OUTPUT  =                6
 cadj SUBROUTINE active_write_yz ACTIVE  =    2         , 6
 cadj SUBROUTINE active_write_yz DEPEND  = 1,    3, 4, 5
 
+c----------------------------------------
+c subroutine active_write_1d
+c----------------------------------------
+cadj SUBROUTINE active_write_1d FTLNAME = g_active_write_1d
+cadj SUBROUTINE active_write_1d ADNAME  = adactive_write_1d
+cadj SUBROUTINE active_write_1d INPUT   = 1, 2, 3, 4, 5, 6, 7
+cadj SUBROUTINE active_write_1d OUTPUT  =                   7
+cadj SUBROUTINE active_write_1d ACTIVE  =    2            , 7
+cadj SUBROUTINE active_write_1d DEPEND  = 1,    3, 4, 5, 6

--- a/pkg/autodiff/active_file_ad.F
+++ b/pkg/autodiff/active_file_ad.F
@@ -9,11 +9,13 @@ C     o  adactive_read_xy         - Adjoint of active_read_xy
 C     o  adactive_read_xyz        - Adjoint of active_read_xyz
 C     o  adactive_read_xz         - Adjoint of active_read_xz
 C     o  adactive_read_yz         - Adjoint of active_read_yz
+C     o  adactive_read_1d         - Adjoint of active_read_1d
 C
 C     o  adactive_write_xy        - Adjoint of active_write_xy
 C     o  adactive_write_xyz       - Adjoint of active_write_xyz
 C     o  adactive_write_xz        - Adjoint of active_write_xz
 C     o  adactive_write_yz        - Adjoint of active_write_yz
+C     o  adactive_write_1d        - Adjoint of active_write_1d
 C
 C        changed: Christian Eckert eckert@mit.edu 24-Apr-2000
 C                 - Added routines that do active writes on tiles
@@ -23,6 +25,8 @@ C                 - changed suboutine argument list:
 C                   dropped mycurrentiter, mycurrenttime
 C        changed: heimbach@mit.edu 25-Mar-2002
 C                 - added active file handling of xz-/yz-arrays
+C        changed: tsmith@oden.utexas.edu 22-Oct-2019
+C                 - added 1D vectors
 C     ==================================================================
 
 C---+----1----+----2----+----3----+----4----+----5----+----6----+----7-|--+----|
@@ -383,6 +387,90 @@ CEOP
 
 C---+----1----+----2----+----3----+----4----+----5----+----6----+----7-|--+----|
 CBOP
+C     !ROUTINE: adactive_read_1d
+C     !INTERFACE:
+#ifdef AUTODIFF_TAMC_COMPATIBILITY
+      subroutine adactive_read_1d(
+     I                             active_var_file,
+     I                             active_var_length,
+     I                             iRec,
+     I                             lAdInit,
+     I                             myIter,
+     I                             myThid,
+     I                             adactive_var
+     &                           )
+#else
+      subroutine adactive_read_1d(
+     I                             active_var_file,
+     I                             adactive_var,
+     I                             active_var_length,
+     I                             iRec,
+     I                             lAdInit,
+     I                             myIter,
+     I                             myThid,
+     I                             dummy,
+     O                             addummy
+     &                           )
+#endif
+
+C     !DESCRIPTION: \bv
+C     ==================================================================
+C     SUBROUTINE adactive_read_1d
+C     ==================================================================
+C     o Adjoint of active_read_1d.
+C     started: Tim Smith tsmith@oden.utexas.edu 22-Oct-2019
+C     ==================================================================
+C     \ev
+
+C     !USES:
+      IMPLICIT NONE
+
+C     == global variables ==
+#include "EEPARAMS.h"
+#include "SIZE.h"
+
+C     !INPUT/OUTPUT PARAMETERS:
+C     active_var_file: filename
+C     adactive_var:    array
+C     active_var_length:    length of array
+C     iRec:            record number
+C     myIter:          number of optimization iteration (default: 0)
+C     myThid:          thread number for this instance
+C     lAdInit:         initialisation of corresponding adjoint
+C                      variable and write to active file
+      CHARACTER*(*) active_var_file
+      _RL     adactive_var(*)
+      INTEGER active_var_length
+      INTEGER iRec
+      INTEGER myIter,myThid
+      LOGICAL lAdInit
+      _RL  dummy, addummy ! Tags for IO: ctrl input and adjoint (gradient) output
+
+C     !FUNCTIONS:
+      INTEGER  ILNBLNK
+      EXTERNAL ILNBLNK
+
+C     !LOCAL VARIABLES:
+      CHARACTER*(2) adpref
+      CHARACTER*(80) fname
+      INTEGER il
+CEOP
+
+      adpref = 'ad'
+      il   = ILNBLNK( active_var_file )
+      WRITE(fname(1:80),'(A)') ' '
+      WRITE(fname(1:2+il),'(2A)') adpref, active_var_file(1:il)
+
+      CALL ACTIVE_READ_1D_RL(
+     &                 fname, adactive_var, active_var_length,
+     &                 lAdInit, iRec,
+     &                 REVERSE_SIMULATION, myIter, myThid )
+
+      RETURN
+      END
+
+C---+----1----+----2----+----3----+----4----+----5----+----6----+----7-|--+----|
+CBOP
 C     !ROUTINE: adactive_write_xy
 C     !INTERFACE:
 #ifdef AUTODIFF_TAMC_COMPATIBILITY
@@ -704,6 +792,84 @@ CEOP
      &                 fname, adactive_var, globalFile,
      &                 useCurrentDir, iRec, myNr,
      &                 REVERSE_SIMULATION, myIter, myThid )
+
+      RETURN
+      END
+
+C---+----1----+----2----+----3----+----4----+----5----+----6----+----7-|--+----|
+CBOP
+C     !ROUTINE: adactive_write_1d
+C     !INTERFACE:
+#ifdef AUTODIFF_TAMC_COMPATIBILITY
+      subroutine adactive_write_1d(
+     I                               active_var_file,
+     I                               active_var_length,
+     I                               iRec,
+     I                               myIter,
+     I                               myThid,
+     U                               adactive_var,
+     I                               dummy
+     &                             )
+#else
+      subroutine adactive_write_1d(
+     I                               active_var_file,
+     U                               adactive_var,
+     U                               active_var_length,
+     I                               iRec,
+     I                               myIter,
+     I                               myThid,
+     I                               dummy
+     &                             )
+#endif
+
+
+C     !DESCRIPTION: \bv
+C     ==================================================================
+C     SUBROUTINE adactive_write_1d
+C     ==================================================================
+C     o Adjoint of active_write_1d.
+C     started: tsmith@oden.utexas.edu 22-Oct-2019
+C     ==================================================================
+C     \ev
+
+C     !USES:
+      IMPLICIT NONE
+
+C     == global variables ==
+#include "EEPARAMS.h"
+#include "SIZE.h"
+
+C     !INPUT/OUTPUT PARAMETERS:
+C     active_var_file: filename
+C     adactive_var:    array
+C     iRec:            record number
+C     myIter:          number of optimization iteration (default: 0)
+C     myThid:          thread number for this instance
+      CHARACTER*(*) active_var_file
+      _RL     adactive_var(*)
+      INTEGER active_var_length
+      INTEGER iRec
+      INTEGER myIter,myThid
+      _RL dummy
+
+C     !FUNCTIONS:
+      INTEGER  ILNBLNK
+      EXTERNAL ILNBLNK
+
+C     !LOCAL VARIABLES:
+      CHARACTER*(2) adpref
+      CHARACTER*(80) fname
+      INTEGER il
+CEOP
+
+      adpref = 'ad'
+      il   = ILNBLNK( active_var_file )
+      WRITE(fname(1:80),'(A)') ' '
+      WRITE(fname(1:2+il),'(2A)') adpref, active_var_file(1:il)
+
+      CALL ACTIVE_WRITE_1D_RL(
+     &                 fname, adactive_var, active_var_length,
+     &                 iRec, REVERSE_SIMULATION, myIter, myThid )
 
       RETURN
       END

--- a/pkg/autodiff/active_file_ad.F
+++ b/pkg/autodiff/active_file_ad.F
@@ -74,19 +74,19 @@ C     == global variables ==
 #include "SIZE.h"
 
 C     !INPUT/OUTPUT PARAMETERS:
-C     active_var_file: filename
-C     adactive_var:    array
-C     iRec:            record number
-C     myIter:          number of optimization iteration (default: 0)
-C     myThid:          thread number for this instance
-C     doglobalread:    flag for global or local read/write
-C                      (default: .false.)
-C     lAdInit:         initialisation of corresponding adjoint
-C                      variable and write to active file
+C     active_var_file:: filename
+C     adactive_var   :: array
+C     iRec           :: record number
+C     myIter         :: number of optimization iteration (default: 0)
+C     myThid         :: thread number for this instance
+C     doglobalread   :: flag for global or local read/write
+C                       (default: .false.)
+C     lAdInit        :: initialisation of corresponding adjoint
+C                       variable and write to active file
       CHARACTER*(*) active_var_file
       _RL     adactive_var(1-OLx:sNx+OLx,1-OLy:sNy+OLy,nSx,nSy)
       INTEGER iRec
-      INTEGER myIter,myThid
+      INTEGER myIter, myThid
       LOGICAL doglobalread
       LOGICAL lAdInit
       _RL  dummy, addummy ! Tags for IO: ctrl input and adjoint (gradient) output
@@ -163,19 +163,19 @@ C     == global variables ==
 #include "SIZE.h"
 
 C     !INPUT/OUTPUT PARAMETERS:
-C     active_var_file: filename
-C     adactive_var:    array
-C     iRec:            record number
-C     myIter:          number of optimization iteration (default: 0)
-C     myThid:          thread number for this instance
-C     doglobalread:    flag for global or local read/write
-C                      (default: .false.)
-C     lAdInit:         initialisation of corresponding adjoint
-C                      variable and write to active file
+C     active_var_file:: filename
+C     adactive_var   :: array
+C     iRec           :: record number
+C     myIter         :: number of optimization iteration (default: 0)
+C     myThid         :: thread number for this instance
+C     doglobalread   :: flag for global or local read/write
+C                       (default: .false.)
+C     lAdInit        :: initialisation of corresponding adjoint
+C                       variable and write to active file
       CHARACTER*(*) active_var_file
       _RL     adactive_var(1-OLx:sNx+OLx,1-OLy:sNy+OLy,Nr,nSx,nSy)
       INTEGER iRec
-      INTEGER myIter,myThid
+      INTEGER myIter, myThid
       LOGICAL doglobalread
       LOGICAL lAdInit
       _RL  dummy, addummy ! Tags for IO: ctrl input and adjoint (gradient) output
@@ -252,19 +252,19 @@ C     == global variables ==
 #include "SIZE.h"
 
 C     !INPUT/OUTPUT PARAMETERS:
-C     active_var_file: filename
-C     adactive_var:    array
-C     iRec:            record number
-C     myIter:          number of optimization iteration (default: 0)
-C     myThid:          thread number for this instance
-C     doglobalread:    flag for global or local read/write
-C                      (default: .false.)
-C     lAdInit:         initialisation of corresponding adjoint
-C                      variable and write to active file
+C     active_var_file:: filename
+C     adactive_var   :: array
+C     iRec           :: record number
+C     myIter         :: number of optimization iteration (default: 0)
+C     myThid         :: thread number for this instance
+C     doglobalread   :: flag for global or local read/write
+C                       (default: .false.)
+C     lAdInit        :: initialisation of corresponding adjoint
+C                       variable and write to active file
       CHARACTER*(*) active_var_file
       _RL     adactive_var(1-OLx:sNx+OLx,Nr,nSx,nSy)
       INTEGER iRec
-      INTEGER myIter,myThid
+      INTEGER myIter, myThid
       LOGICAL doglobalread
       LOGICAL lAdInit
       _RL  dummy, addummy ! Tags for IO: ctrl input and adjoint (gradient) output
@@ -341,19 +341,19 @@ C     == global variables ==
 #include "SIZE.h"
 
 C     !INPUT/OUTPUT PARAMETERS:
-C     active_var_file: filename
-C     adactive_var:    array
-C     iRec:            record number
-C     myIter:          number of optimization iteration (default: 0)
-C     myThid:          thread number for this instance
-C     doglobalread:    flag for global or local read/write
-C                      (default: .false.)
-C     lAdInit:         initialisation of corresponding adjoint
-C                      variable and write to active file
+C     active_var_file:: filename
+C     adactive_var   :: array
+C     iRec           :: record number
+C     myIter         :: number of optimization iteration (default: 0)
+C     myThid         :: thread number for this instance
+C     doglobalread   :: flag for global or local read/write
+C                       (default: .false.)
+C     lAdInit        :: initialisation of corresponding adjoint
+C                       variable and write to active file
       CHARACTER*(*) active_var_file
       _RL     adactive_var(1-OLy:sNy+OLy,Nr,nSx,nSy)
       INTEGER iRec
-      INTEGER myIter,myThid
+      INTEGER myIter, myThid
       LOGICAL doglobalread
       LOGICAL lAdInit
       _RL  dummy, addummy ! Tags for IO: ctrl input and adjoint (gradient) output
@@ -430,19 +430,19 @@ C     == global variables ==
 #include "SIZE.h"
 
 C     !INPUT/OUTPUT PARAMETERS:
-C     active_var_file: filename
-C     adactive_var:    array
-C     active_var_length:    length of array
-C     iRec:            record number
-C     myIter:          number of optimization iteration (default: 0)
-C     myThid:          thread number for this instance
-C     lAdInit:         initialisation of corresponding adjoint
-C                      variable and write to active file
+C     active_var_file:: filename
+C     adactive_var:  :: array
+C     active_var_length :: length of array
+C     iRec           :: record number
+C     myIter         :: number of optimization iteration (default: 0)
+C     myThid         :: thread number for this instance
+C     lAdInit        :: initialisation of corresponding adjoint
+C                       variable and write to active file
       CHARACTER*(*) active_var_file
       _RL     adactive_var(*)
       INTEGER active_var_length
       INTEGER iRec
-      INTEGER myIter,myThid
+      INTEGER myIter, myThid
       LOGICAL lAdInit
       _RL  dummy, addummy ! Tags for IO: ctrl input and adjoint (gradient) output
 
@@ -493,7 +493,6 @@ C     !INTERFACE:
      &                            )
 #endif
 
-
 C     !DESCRIPTION: \bv
 C     ==================================================================
 C     SUBROUTINE adactive_write_xy
@@ -511,15 +510,15 @@ C     == global variables ==
 #include "SIZE.h"
 
 C     !INPUT/OUTPUT PARAMETERS:
-C     active_var_file: filename
-C     adactive_var:    array
-C     iRec:            record number
-C     myIter:          number of optimization iteration (default: 0)
-C     myThid:          thread number for this instance
+C     active_var_file:: filename
+C     adactive_var   :: array
+C     iRec           :: record number
+C     myIter         :: number of optimization iteration (default: 0)
+C     myThid         :: thread number for this instance
       CHARACTER*(*) active_var_file
       _RL     adactive_var(1-OLx:sNx+OLx,1-OLy:sNy+OLy,nSx,nSy)
       INTEGER iRec
-      INTEGER myIter,myThid
+      INTEGER myIter, myThid
       _RL     dummy
 
 C     !FUNCTIONS:
@@ -575,7 +574,6 @@ C     !INTERFACE:
      &                             )
 #endif
 
-
 C     !DESCRIPTION: \bv
 C     ==================================================================
 C     SUBROUTINE adactive_write_xyz
@@ -593,15 +591,15 @@ C     == global variables ==
 #include "SIZE.h"
 
 C     !INPUT/OUTPUT PARAMETERS:
-C     active_var_file: filename
-C     adactive_var:    array
-C     iRec:            record number
-C     myIter:          number of optimization iteration (default: 0)
-C     myThid:          thread number for this instance
+C     active_var_file:: filename
+C     adactive_var   :: array
+C     iRec           :: record number
+C     myIter         :: number of optimization iteration (default: 0)
+C     myThid         :: thread number for this instance
       CHARACTER*(*) active_var_file
       _RL     adactive_var(1-OLx:sNx+OLx,1-OLy:sNy+OLy,Nr,nSx,nSy)
       INTEGER iRec
-      INTEGER myIter,myThid
+      INTEGER myIter, myThid
       _RL dummy
 
 C     !FUNCTIONS:
@@ -674,15 +672,15 @@ C     == global variables ==
 #include "SIZE.h"
 
 C     !INPUT/OUTPUT PARAMETERS:
-C     active_var_file: filename
-C     adactive_var:    array
-C     iRec:            record number
-C     myIter:          number of optimization iteration (default: 0)
-C     myThid:          thread number for this instance
+C     active_var_file:: filename
+C     adactive_var   :: array
+C     iRec           :: record number
+C     myIter         :: number of optimization iteration (default: 0)
+C     myThid         :: thread number for this instance
       CHARACTER*(*) active_var_file
       _RL     adactive_var(1-OLx:sNx+OLx,Nr,nSx,nSy)
       INTEGER iRec
-      INTEGER myIter,myThid
+      INTEGER myIter, myThid
       _RL dummy
 
 C     !FUNCTIONS:
@@ -738,7 +736,6 @@ C     !INTERFACE:
      &                             )
 #endif
 
-
 C     !DESCRIPTION: \bv
 C     ==================================================================
 C     SUBROUTINE adactive_write_yz
@@ -756,15 +753,15 @@ C     == global variables ==
 #include "SIZE.h"
 
 C     !INPUT/OUTPUT PARAMETERS:
-C     active_var_file: filename
-C     adactive_var:    array
-C     iRec:            record number
-C     myIter:          number of optimization iteration (default: 0)
-C     myThid:          thread number for this instance
+C     active_var_file:: filename
+C     adactive_var   :: array
+C     iRec           :: record number
+C     myIter         :: number of optimization iteration (default: 0)
+C     myThid         :: thread number for this instance
       CHARACTER*(*) active_var_file
       _RL     adactive_var(1-OLy:sNy+OLy,Nr,nSx,nSy)
       INTEGER iRec
-      INTEGER myIter,myThid
+      INTEGER myIter, myThid
       _RL dummy
 
 C     !FUNCTIONS:
@@ -822,7 +819,6 @@ C     !INTERFACE:
      &                             )
 #endif
 
-
 C     !DESCRIPTION: \bv
 C     ==================================================================
 C     SUBROUTINE adactive_write_1d
@@ -840,16 +836,17 @@ C     == global variables ==
 #include "SIZE.h"
 
 C     !INPUT/OUTPUT PARAMETERS:
-C     active_var_file: filename
-C     adactive_var:    array
-C     iRec:            record number
-C     myIter:          number of optimization iteration (default: 0)
-C     myThid:          thread number for this instance
+C     active_var_file:: filename
+C     adactive_var   :: array
+C     active_var_length :: length of array
+C     iRec           :: record number
+C     myIter         :: number of optimization iteration (default: 0)
+C     myThid         :: thread number for this instance
       CHARACTER*(*) active_var_file
       _RL     adactive_var(*)
       INTEGER active_var_length
       INTEGER iRec
-      INTEGER myIter,myThid
+      INTEGER myIter, myThid
       _RL dummy
 
 C     !FUNCTIONS:

--- a/pkg/autodiff/active_file_control.F
+++ b/pkg/autodiff/active_file_control.F
@@ -489,13 +489,15 @@ C     adjoint variable file. These files are tiled.
           DO i = 1, active_var_length
             active_data_t(i) = 0. _d 0
           ENDDO
-          CALL MDS_WRITEVEC_LOC(
+          IF ( myProcId.EQ.0 ) THEN
+            CALL MDS_WRITEVEC_LOC(
      I                adfname, prec, ioUnit,
      I                'RL', active_var_length,
      O                active_data_t, dummyRS,
      I                bi, bj,
      I                iRec, myOptimIter, myThid )
 
+          ENDIF
         ENDIF
 
       ENDIF
@@ -516,12 +518,14 @@ C     Add active_var from appropriate location to data.
         ENDDO
 
 C     Store the result on disk.
-        CALL MDS_WRITEVEC_LOC(
+        IF ( myProcId.EQ.0 ) THEN
+          CALL MDS_WRITEVEC_LOC(
      I                activeVar_file, prec, ioUnit,
      I                'RL', active_var_length,
      O                active_data_t, dummyRS,
      I                bi, bj,
      I                iRec, myOptimIter, myThid )
+        ENDIF
 
 C     Set active_var to zero.
         DO i = 1, active_var_length
@@ -648,13 +652,15 @@ C     adjoint variable file. These files are tiled.
           DO i = 1, active_var_length
             active_data_t(i) = 0. _d 0
           ENDDO
-          CALL MDS_WRITEVEC_LOC(
+          IF ( myProcId.EQ.0 ) THEN
+            CALL MDS_WRITEVEC_LOC(
      I                adfname, prec, ioUnit,
      I                'RS', active_var_length,
      O                dummyRL, active_data_t,
      I                bi, bj,
      I                iRec, myOptimIter, myThid )
 
+          ENDIF
         ENDIF
 
       ENDIF
@@ -675,13 +681,15 @@ C     Add active_var from appropriate location to data.
         ENDDO
 
 C     Store the result on disk.
-        CALL MDS_WRITEVEC_LOC(
+        IF ( myProcId.EQ.0 ) THEN
+          CALL MDS_WRITEVEC_LOC(
      I                activeVar_file, prec, ioUnit,
      I                'RS', active_var_length,
      O                dummyRL, active_data_t,
      I                bi, bj,
      I                iRec, myOptimIter, myThid )
 
+        ENDIF
 C     Set active_var to zero.
         DO i = 1, active_var_length
           active_data_t(i) = 0. _d 0
@@ -1014,13 +1022,15 @@ C     >>>>>>>>>>>>>>>>>>> FORWARD RUN <<<<<<<<<<<<<<<<<<<
       IF (theSimulationMode .EQ. FORWARD_SIMULATION) THEN
 
 C     Read the active variable from file.
-        CALL MDS_WRITEVEC_LOC(
+        IF ( myProcId.EQ.0 ) THEN
+          CALL MDS_WRITEVEC_LOC(
      I                activeVar_file, prec, ioUnit,
      I                'RL', active_var_length,
      O                active_var, dummyRS,
      I                bi, bj,
      I                iRec, myOptimIter, myThid )
 
+        ENDIF
       ENDIF
 
 C     >>>>>>>>>>>>>>>>>>> ADJOINT RUN <<<<<<<<<<<<<<<<<<<
@@ -1040,24 +1050,27 @@ C     Add active_var from appropriate location to data.
         ENDDO
 
 C     Store the result on disk.
-        CALL MDS_WRITEVEC_LOC(
+        IF ( myProcId.EQ.0 ) THEN
+          CALL MDS_WRITEVEC_LOC(
      I                activeVar_file, prec, ioUnit,
      I                'RL', active_var_length,
      O                active_data_t, dummyRS,
      I                bi, bj,
      I                iRec, myOptimIter, myThid )
-
+        ENDIF
       ENDIF
 
 C     >>>>>>>>>>>>>>>>>>> TANGENT RUN <<<<<<<<<<<<<<<<<<<
       IF (theSimulationMode .EQ. TANGENT_SIMULATION) THEN
 C     Read the active variable from file.
-        CALL MDS_WRITEVEC_LOC(
+        IF ( myProcId.EQ.0 ) THEN
+          CALL MDS_WRITEVEC_LOC(
      I                activeVar_file, prec, ioUnit,
      I                'RL', active_var_length,
      O                active_var, dummyRS,
      I                bi, bj,
      I                iRec, myOptimIter, myThid )
+        ENDIF
       ENDIF
 
       RETURN
@@ -1136,13 +1149,15 @@ C     >>>>>>>>>>>>>>>>>>> FORWARD RUN <<<<<<<<<<<<<<<<<<<
       IF (theSimulationMode .EQ. FORWARD_SIMULATION) THEN
 
 C     Read the active variable from file.
-        CALL MDS_WRITEVEC_LOC(
+        IF ( myProcId.EQ.0 ) THEN
+          CALL MDS_WRITEVEC_LOC(
      I                activeVar_file, prec, ioUnit,
      I                'RS', active_var_length,
      O                dummyRL, active_var,
      I                bi, bj,
      I                iRec, myOptimIter, myThid )
 
+        ENDIF
       ENDIF
 
 C     >>>>>>>>>>>>>>>>>>> ADJOINT RUN <<<<<<<<<<<<<<<<<<<
@@ -1162,24 +1177,28 @@ C     Add active_var from appropriate location to data.
         ENDDO
 
 C     Store the result on disk.
-        CALL MDS_WRITEVEC_LOC(
+        IF ( myProcId.EQ.0 ) THEN
+          CALL MDS_WRITEVEC_LOC(
      I                activeVar_file, prec, ioUnit,
      I                'RL', active_var_length,
      O                dummyRL, active_data_t,
      I                bi, bj,
      I                iRec, myOptimIter, myThid )
 
+        ENDIF
       ENDIF
 
 C     >>>>>>>>>>>>>>>>>>> TANGENT RUN <<<<<<<<<<<<<<<<<<<
       IF (theSimulationMode .EQ. TANGENT_SIMULATION) THEN
 C     Read the active variable from file.
-        CALL MDS_WRITEVEC_LOC(
+        IF ( myProcId.EQ.0 ) THEN
+          CALL MDS_WRITEVEC_LOC(
      I                activeVar_file, prec, ioUnit,
      I                'RL', active_var_length,
      O                dummyRL, active_var,
      I                bi, bj,
      I                iRec, myOptimIter, myThid )
+        ENDIF
       ENDIF
 
       RETURN

--- a/pkg/autodiff/active_file_control.F
+++ b/pkg/autodiff/active_file_control.F
@@ -474,7 +474,7 @@ C     >>>>>>>>>>>>>>>>>>> FORWARD RUN <<<<<<<<<<<<<<<<<<<
       IF (theSimulationMode .EQ. FORWARD_SIMULATION) THEN
 
 C     Read the active variable from file.
-      CALL mds_readvec_loc(
+        CALL MDS_READVEC_LOC(
      I                activeVar_file, prec, ioUnit,
      I                'RL', active_var_length,
      O                active_var, dummyRS,
@@ -485,10 +485,10 @@ C     Read the active variable from file.
 C     Initialise the corresponding adjoint variable on the
 C     adjoint variable file. These files are tiled.
 
-          do i = 1, active_var_length
+          DO i = 1, active_var_length
             active_data_t(i) = 0. _d 0
-          enddo
-          CALL mds_writevec_loc(
+          ENDDO
+          CALL MDS_WRITEVEC_LOC(
      I                adfname, prec, ioUnit,
      I                'RL', active_var_length,
      O                active_data_t, dummyRS,
@@ -502,7 +502,7 @@ C     adjoint variable file. These files are tiled.
 C     >>>>>>>>>>>>>>>>>>> ADJOINT RUN <<<<<<<<<<<<<<<<<<<
       IF (theSimulationMode .EQ. REVERSE_SIMULATION) THEN
 
-        CALL mds_readvec_loc(
+        CALL MDS_READVEC_LOC(
      I                activeVar_file, prec, ioUnit,
      I                'RL', active_var_length,
      O                active_data_t, dummyRS,
@@ -510,12 +510,12 @@ C     >>>>>>>>>>>>>>>>>>> ADJOINT RUN <<<<<<<<<<<<<<<<<<<
      I                iRec, myThid )
 
 C     Add active_var from appropriate location to data.
-        do i = 1, active_var_length
+        DO i = 1, active_var_length
           active_data_t(i) = active_data_t(i) + active_var(i)
-        enddo
+        ENDDO
 
 C     Store the result on disk.
-        CALL mds_writevec_loc(
+        CALL MDS_WRITEVEC_LOC(
      I                activeVar_file, prec, ioUnit,
      I                'RL', active_var_length,
      O                active_data_t, dummyRS,
@@ -523,16 +523,16 @@ C     Store the result on disk.
      I                iRec, myOptimIter, myThid )
 
 C     Set active_var to zero.
-        do i = 1, active_var_length
+        DO i = 1, active_var_length
           active_data_t(i) = 0. _d 0
-        enddo
+        ENDDO
 
       ENDIF
 
 C     >>>>>>>>>>>>>>>>>>> TANGENT RUN <<<<<<<<<<<<<<<<<<<
       IF (theSimulationMode .EQ. TANGENT_SIMULATION) THEN
 C     Read the active variable from file.
-      CALL mds_readvec_loc(
+        CALL MDS_READVEC_LOC(
      I                activeVar_file, prec, ioUnit,
      I                'RL', active_var_length,
      O                active_var, dummyRS,
@@ -632,7 +632,7 @@ C     >>>>>>>>>>>>>>>>>>> FORWARD RUN <<<<<<<<<<<<<<<<<<<
       IF (theSimulationMode .EQ. FORWARD_SIMULATION) THEN
 
 C     Read the active variable from file.
-      CALL mds_readvec_loc(
+        CALL MDS_READVEC_LOC(
      I                activeVar_file, prec, ioUnit,
      I                'RS', active_var_length,
      O                dummyRL, active_var,
@@ -643,10 +643,10 @@ C     Read the active variable from file.
 C     Initialise the corresponding adjoint variable on the
 C     adjoint variable file. These files are tiled.
 
-          do i = 1, active_var_length
+          DO i = 1, active_var_length
             active_data_t(i) = 0. _d 0
-          enddo
-          CALL mds_writevec_loc(
+          ENDDO
+          CALL MDS_WRITEVEC_LOC(
      I                adfname, prec, ioUnit,
      I                'RS', active_var_length,
      O                dummyRL, active_data_t,
@@ -660,7 +660,7 @@ C     adjoint variable file. These files are tiled.
 C     >>>>>>>>>>>>>>>>>>> ADJOINT RUN <<<<<<<<<<<<<<<<<<<
       IF (theSimulationMode .EQ. REVERSE_SIMULATION) THEN
 
-        CALL mds_readvec_loc(
+        CALL MDS_READVEC_LOC(
      I                activeVar_file, prec, ioUnit,
      I                'RS', active_var_length,
      O                dummyRL, active_data_t,
@@ -668,12 +668,12 @@ C     >>>>>>>>>>>>>>>>>>> ADJOINT RUN <<<<<<<<<<<<<<<<<<<
      I                iRec, myThid )
 
 C     Add active_var from appropriate location to data.
-        do i = 1, active_var_length
+        DO i = 1, active_var_length
           active_data_t(i) = active_data_t(i) + active_var(i)
-        enddo
+        ENDDO
 
 C     Store the result on disk.
-        CALL mds_writevec_loc(
+        CALL MDS_WRITEVEC_LOC(
      I                activeVar_file, prec, ioUnit,
      I                'RS', active_var_length,
      O                dummyRL, active_data_t,
@@ -681,16 +681,16 @@ C     Store the result on disk.
      I                iRec, myOptimIter, myThid )
 
 C     Set active_var to zero.
-        do i = 1, active_var_length
+        DO i = 1, active_var_length
           active_data_t(i) = 0. _d 0
-        enddo
+        ENDDO
 
       ENDIF
 
 C     >>>>>>>>>>>>>>>>>>> TANGENT RUN <<<<<<<<<<<<<<<<<<<
       IF (theSimulationMode .EQ. TANGENT_SIMULATION) THEN
 C     Read the active variable from file.
-      CALL mds_readvec_loc(
+        CALL MDS_READVEC_LOC(
      I                activeVar_file, prec, ioUnit,
      I                'RS', active_var_length,
      O                dummyRL, active_var,
@@ -1008,7 +1008,7 @@ CEOP
 C     force 64-bit io
       prec = ctrlprec
 
-C     set these to zero otherwise looks mdsio_read/writevec_loc 
+C     set these to zero otherwise looks mdsio_read/writevec_loc
 C     looks for tiled file
       bi=0
       bj=0
@@ -1025,7 +1025,7 @@ C     >>>>>>>>>>>>>>>>>>> FORWARD RUN <<<<<<<<<<<<<<<<<<<
       IF (theSimulationMode .EQ. FORWARD_SIMULATION) THEN
 
 C     Read the active variable from file.
-      CALL mds_writevec_loc(
+        CALL MDS_WRITEVEC_LOC(
      I                activeVar_file, prec, ioUnit,
      I                'RL', active_var_length,
      O                active_var, dummyRS,
@@ -1037,7 +1037,7 @@ C     Read the active variable from file.
 C     >>>>>>>>>>>>>>>>>>> ADJOINT RUN <<<<<<<<<<<<<<<<<<<
       IF (theSimulationMode .EQ. REVERSE_SIMULATION) THEN
 
-        CALL mds_readvec_loc(
+        CALL MDS_READVEC_LOC(
      I                activeVar_file, prec, ioUnit,
      I                'RL', active_var_length,
      O                active_data_t, dummyRS,
@@ -1045,13 +1045,13 @@ C     >>>>>>>>>>>>>>>>>>> ADJOINT RUN <<<<<<<<<<<<<<<<<<<
      I                iRec, myThid )
 
 C     Add active_var from appropriate location to data.
-        do i = 1, active_var_length
+        DO i = 1, active_var_length
           active_var(i) = active_var(i) + active_data_t(i)
           active_data_t(i) = 0. _d 0
-        enddo
+        ENDDO
 
 C     Store the result on disk.
-        CALL mds_writevec_loc(
+        CALL MDS_WRITEVEC_LOC(
      I                activeVar_file, prec, ioUnit,
      I                'RL', active_var_length,
      O                active_data_t, dummyRS,
@@ -1063,7 +1063,7 @@ C     Store the result on disk.
 C     >>>>>>>>>>>>>>>>>>> TANGENT RUN <<<<<<<<<<<<<<<<<<<
       IF (theSimulationMode .EQ. TANGENT_SIMULATION) THEN
 C     Read the active variable from file.
-      CALL mds_writevec_loc(
+        CALL MDS_WRITEVEC_LOC(
      I                activeVar_file, prec, ioUnit,
      I                'RL', active_var_length,
      O                active_var, dummyRS,
@@ -1143,7 +1143,7 @@ CEOP
 C     force 64-bit io
       prec = ctrlprec
 
-C     set these to zero otherwise looks mdsio_read/writevec_loc 
+C     set these to zero otherwise looks mdsio_read/writevec_loc
 C     looks for tiled file
       bi=0
       bj=0
@@ -1160,7 +1160,7 @@ C     >>>>>>>>>>>>>>>>>>> FORWARD RUN <<<<<<<<<<<<<<<<<<<
       IF (theSimulationMode .EQ. FORWARD_SIMULATION) THEN
 
 C     Read the active variable from file.
-      CALL mds_writevec_loc(
+        CALL MDS_WRITEVEC_LOC(
      I                activeVar_file, prec, ioUnit,
      I                'RS', active_var_length,
      O                dummyRL, active_var,
@@ -1172,7 +1172,7 @@ C     Read the active variable from file.
 C     >>>>>>>>>>>>>>>>>>> ADJOINT RUN <<<<<<<<<<<<<<<<<<<
       IF (theSimulationMode .EQ. REVERSE_SIMULATION) THEN
 
-        CALL mds_readvec_loc(
+        CALL MDS_READVEC_LOC(
      I                activeVar_file, prec, ioUnit,
      I                'RL', active_var_length,
      O                dummyRL, active_data_t,
@@ -1180,10 +1180,10 @@ C     >>>>>>>>>>>>>>>>>>> ADJOINT RUN <<<<<<<<<<<<<<<<<<<
      I                iRec, myThid )
 
 C     Add active_var from appropriate location to data.
-        do i = 1, active_var_length
+        DO i = 1, active_var_length
           active_var(i) = active_var(i) + active_data_t(i)
           active_data_t(i) = 0. _d 0
-        enddo
+        ENDDO
 
 C     Store the result on disk.
         CALL mds_writevec_loc(
@@ -1198,7 +1198,7 @@ C     Store the result on disk.
 C     >>>>>>>>>>>>>>>>>>> TANGENT RUN <<<<<<<<<<<<<<<<<<<
       IF (theSimulationMode .EQ. TANGENT_SIMULATION) THEN
 C     Read the active variable from file.
-      CALL mds_writevec_loc(
+        CALL MDS_WRITEVEC_LOC(
      I                activeVar_file, prec, ioUnit,
      I                'RL', active_var_length,
      O                dummyRL, active_var,

--- a/pkg/autodiff/active_file_control.F
+++ b/pkg/autodiff/active_file_control.F
@@ -520,7 +520,7 @@ C     Store the result on disk.
      I                'RL', active_var_length,
      O                active_data_t, dummyRS,
      I                bi, bj,
-     I                iRec, myOptimIter myThid )
+     I                iRec, myOptimIter, myThid )
 
 C     Set active_var to zero.
         do i = 1, active_var_length
@@ -678,7 +678,7 @@ C     Store the result on disk.
      I                'RS', active_var_length,
      O                dummyRL, active_data_t,
      I                bi, bj,
-     I                iRec, myOptimIter myThid )
+     I                iRec, myOptimIter, myThid )
 
 C     Set active_var to zero.
         do i = 1, active_var_length

--- a/pkg/autodiff/active_file_control.F
+++ b/pkg/autodiff/active_file_control.F
@@ -105,7 +105,7 @@ C     force 64-bit io
 
       adpref = 'ad'
       il = ILNBLNK( activeVar_file )
-      WRITE(adfname(1:80),'(80a)') ' '
+      WRITE(adfname,'(A)') ' '
       WRITE(adfname(1:il+2),'(2A)') adpref, activeVar_file(1:il)
 
 C     >>>>>>>>>>>>>>>>>>> FORWARD RUN <<<<<<<<<<<<<<<<<<<
@@ -287,7 +287,7 @@ C     force 64-bit io
 
       adpref = 'ad'
       il = ILNBLNK( activeVar_file )
-      WRITE(adfname(1:80),'(80a)') ' '
+      WRITE(adfname,'(A)') ' '
       WRITE(adfname(1:il+2),'(2A)') adpref, activeVar_file(1:il)
 
 C     >>>>>>>>>>>>>>>>>>> FORWARD RUN <<<<<<<<<<<<<<<<<<<
@@ -405,6 +405,8 @@ C     ==================================================================
 C     o Read an active 1D _RL vector from file.
 C     o Read the same 1D vector to all tiles/processes, so global by
 C       nature
+C     o Note: rely on implicit dynamical allocation (local array size
+C       is an argument of this S/R) for local array "active_data_t"
 C     Modified from 3D: Tim Smith tsmith@oden.utexas.edu Oct-2019
 C     ==================================================================
 C     SUBROUTINE ACTIVE_READ_1D_RL
@@ -462,12 +464,11 @@ C     set these to zero otherwise looks for tiled file
       bi=0
       bj=0
 
-C     ioUnit = 0 => open, read, and close the file... see
-C     mdsio_readvec_loc
+C     ioUnit = 0 => open, read, and close the file... see mdsio_readvec_loc
       ioUnit = 0
       adpref = 'ad'
       il = ILNBLNK( activeVar_file )
-      WRITE(adfname(1:80),'(80a)') ' '
+      WRITE(adfname,'(A)') ' '
       WRITE(adfname(1:il+2),'(2A)') adpref, activeVar_file(1:il)
 
 C     >>>>>>>>>>>>>>>>>>> FORWARD RUN <<<<<<<<<<<<<<<<<<<
@@ -563,6 +564,8 @@ C     ==================================================================
 C     o Read an active 1D _RS vector from file.
 C     o Read the same 1D vector to all tiles/processes, so global by
 C       nature
+C     o Note: rely on implicit dynamical allocation (local array size
+C       is an argument of this S/R) for local array "active_data_t"
 C     Modified from 3D: Tim Smith tsmith@oden.utexas.edu Oct-2019
 C     ==================================================================
 C     SUBROUTINE ACTIVE_READ_1D_RS
@@ -620,12 +623,11 @@ C     set these to zero otherwise looks for tiled file
       bi=0
       bj=0
 
-C     ioUnit = 0 => open, read, and close the file... see
-C     mdsio_readvec_loc
+C     ioUnit = 0 => open, read, and close the file... see mdsio_readvec_loc
       ioUnit = 0
       adpref = 'ad'
       il = ILNBLNK( activeVar_file )
-      WRITE(adfname(1:80),'(80a)') ' '
+      WRITE(adfname,'(A)') ' '
       WRITE(adfname(1:il+2),'(2A)') adpref, activeVar_file(1:il)
 
 C     >>>>>>>>>>>>>>>>>>> FORWARD RUN <<<<<<<<<<<<<<<<<<<
@@ -990,16 +992,9 @@ C     myThid         :: thread number for this instance
       INTEGER  myOptimIter
       INTEGER  myThid
 
-C     !FUNCTIONS:
-      INTEGER  ILNBLNK
-      EXTERNAL ILNBLNK
-
 C     !LOCAL VARIABLES:
-      CHARACTER*(2)  adpref
-      CHARACTER*(80) adfname
       INTEGER i, bi, bj
       INTEGER prec
-      INTEGER il
       INTEGER ioUnit
       _RS  dummyRS(1)
       _RL  active_data_t(active_var_length)
@@ -1008,18 +1003,12 @@ CEOP
 C     force 64-bit io
       prec = ctrlprec
 
-C     set these to zero otherwise looks mdsio_read/writevec_loc
-C     looks for tiled file
+C     set these to zero otherwise mdsio_read/writevec_loc looks for tiled file
       bi=0
       bj=0
 
-C     ioUnit = 0 => open, read, and close the file... see
-C     mdsio_readvec_loc
+C     ioUnit = 0 => open, read, and close the file... see mdsio_readvec_loc
       ioUnit = 0
-      adpref = 'ad'
-      il = ILNBLNK( activeVar_file )
-      WRITE(adfname(1:80),'(80a)') ' '
-      WRITE(adfname(1:il+2),'(2A)') adpref, activeVar_file(1:il)
 
 C     >>>>>>>>>>>>>>>>>>> FORWARD RUN <<<<<<<<<<<<<<<<<<<
       IF (theSimulationMode .EQ. FORWARD_SIMULATION) THEN
@@ -1125,36 +1114,23 @@ C     myThid         :: thread number for this instance
       INTEGER  myOptimIter
       INTEGER  myThid
 
-C     !FUNCTIONS:
-      INTEGER  ILNBLNK
-      EXTERNAL ILNBLNK
-
 C     !LOCAL VARIABLES:
-      CHARACTER*(2)  adpref
-      CHARACTER*(80) adfname
       INTEGER i, bi, bj
       INTEGER prec
-      INTEGER il
       INTEGER ioUnit
-      _RL  dummyRL(1)
       _RS  active_data_t(active_var_length)
+      _RL  dummyRL(1)
 CEOP
 
 C     force 64-bit io
       prec = ctrlprec
 
-C     set these to zero otherwise looks mdsio_read/writevec_loc
-C     looks for tiled file
+C     set these to zero otherwise mdsio_read/writevec_loc looks for tiled file
       bi=0
       bj=0
 
-C     ioUnit = 0 => open, read, and close the file... see
-C     mdsio_readvec_loc
+C     ioUnit = 0 => open, read, and close the file... see mdsio_readvec_loc
       ioUnit = 0
-      adpref = 'ad'
-      il = ILNBLNK( activeVar_file )
-      WRITE(adfname(1:80),'(80a)') ' '
-      WRITE(adfname(1:il+2),'(2A)') adpref, activeVar_file(1:il)
 
 C     >>>>>>>>>>>>>>>>>>> FORWARD RUN <<<<<<<<<<<<<<<<<<<
       IF (theSimulationMode .EQ. FORWARD_SIMULATION) THEN

--- a/pkg/autodiff/active_file_control.F
+++ b/pkg/autodiff/active_file_control.F
@@ -947,7 +947,6 @@ C     !INTERFACE:
      I                          activeVar_file,
      O                          active_var,
      I                          active_var_length,
-     I                          lAdInit,
      I                          iRec,
      I                          theSimulationMode,
      I                          myOptimIter,
@@ -980,15 +979,12 @@ C     active_var     :: vector
 C     active_var_length :: number of elements in active variable
 C     useCurrentDir  :: always read from the current directory
 C                        (even if "mdsioLocalDir" is set)
-C     lAdInit        :: initialisation of corresponding adjoint variable
-C                        and write to active file
 C     theSimulationMode :: forward, tangent linear, or reverse mode simulation
 C     myOptimIter    :: number of optimization iteration (default: 0)
 C     myThid         :: thread number for this instance
       CHARACTER*(*) activeVar_file
       _RL      active_var(*)
       INTEGER  active_var_length
-      LOGICAL  lAdInit
       INTEGER  iRec
       INTEGER  theSimulationMode
       INTEGER  myOptimIter
@@ -1086,7 +1082,6 @@ C     !INTERFACE:
      I                          activeVar_file,
      O                          active_var,
      I                          active_var_length,
-     I                          lAdInit,
      I                          iRec,
      I                          theSimulationMode,
      I                          myOptimIter,
@@ -1119,15 +1114,12 @@ C     active_var     :: vector
 C     active_var_length :: number of elements in active variable
 C     useCurrentDir  :: always read from the current directory
 C                        (even if "mdsioLocalDir" is set)
-C     lAdInit        :: initialisation of corresponding adjoint variable
-C                        and write to active file
 C     theSimulationMode :: forward, tangent linear, or reverse mode simulation
 C     myOptimIter    :: number of optimization iteration (default: 0)
 C     myThid         :: thread number for this instance
       CHARACTER*(*) activeVar_file
       _RS      active_var(*)
       INTEGER  active_var_length
-      LOGICAL  lAdInit
       INTEGER  iRec
       INTEGER  theSimulationMode
       INTEGER  myOptimIter

--- a/pkg/autodiff/active_file_control.F
+++ b/pkg/autodiff/active_file_control.F
@@ -1162,7 +1162,7 @@ C     Add active_var from appropriate location to data.
         ENDDO
 
 C     Store the result on disk.
-        CALL mds_writevec_loc(
+        CALL MDS_WRITEVEC_LOC(
      I                activeVar_file, prec, ioUnit,
      I                'RL', active_var_length,
      O                dummyRL, active_data_t,

--- a/pkg/autodiff/active_file_control.F
+++ b/pkg/autodiff/active_file_control.F
@@ -10,8 +10,12 @@ C                            All files are direct access files.
 C     Routines:
 C     o  ACTIVE_READ_3D_RL  : Basic routine to handle active 3D read operations
 C     o  ACTIVE_READ_3D_RS  : Basic routine to handle active 3D read operations
+C     o  ACTIVE_READ_1D_RL  : Basic routine to handle active 1D read operations
+C     o  ACTIVE_READ_1D_RS  : Basic routine to handle active 1D read operations
 C     o  ACTIVE_WRITE_3D_RL : Basic routine to handle active 3D write operations
 C     o  ACTIVE_WRITE_3D_RS : Basic routine to handle active 3D write operations
+C     o  ACTIVE_WRITE_1D_RL  : Basic routine to handle active 1D write operations
+C     o  ACTIVE_WRITE_1D_RS  : Basic routine to handle active 1D write operations
 C
 C        changed: Christian Eckert eckert@mit.edu 24-Apr-2000
 C        - Added routines that do active writes on tiles
@@ -383,6 +387,322 @@ C     Read the active variable from file.
 
 C---+----1----+----2----+----3----+----4----+----5----+----6----+----7-|--+----|
 CBOP
+C     !ROUTINE: ACTIVE_READ_1D_RL
+C     !INTERFACE:
+      SUBROUTINE ACTIVE_READ_1D_RL(
+     I                          activeVar_file,
+     O                          active_var,
+     I                          active_var_length,
+     I                          lAdInit,
+     I                          iRec,
+     I                          theSimulationMode,
+     I                          myOptimIter,
+     I                          myThid )
+C     !DESCRIPTION: \bv
+C     ==================================================================
+C     SUBROUTINE ACTIVE_READ_1D_RL
+C     ==================================================================
+C     o Read an active 1D _RL vector from file.
+C     o Read the same 1D vector to all tiles/processes, so global by
+C       nature
+C     Modified from 3D: Tim Smith tsmith@oden.utexas.edu Oct-2019
+C     ==================================================================
+C     SUBROUTINE ACTIVE_READ_1D_RL
+C     ==================================================================
+C     \ev
+
+C     !USES:
+      IMPLICIT NONE
+
+C     == global variables ==
+#include "EEPARAMS.h"
+#include "SIZE.h"
+#include "PARAMS.h"
+#include "ctrl.h"
+
+C     !INPUT/OUTPUT PARAMETERS:
+C     activeVar_file :: filename
+C     active_var     :: vector
+C     active_var_length :: number of elements in active variable
+C     useCurrentDir  :: always read from the current directory
+C                        (even if "mdsioLocalDir" is set)
+C     lAdInit        :: initialisation of corresponding adjoint variable
+C                        and write to active file
+C     theSimulationMode :: forward, tangent linear, or reverse mode simulation
+C     myOptimIter    :: number of optimization iteration (default: 0)
+C     myThid         :: thread number for this instance
+      CHARACTER*(*) activeVar_file
+      _RL      active_var(*)
+      INTEGER  active_var_length
+      LOGICAL  lAdInit
+      INTEGER  iRec
+      INTEGER  theSimulationMode
+      INTEGER  myOptimIter
+      INTEGER  myThid
+
+C     !FUNCTIONS:
+      INTEGER  ILNBLNK
+      EXTERNAL ILNBLNK
+
+C     !LOCAL VARIABLES:
+      CHARACTER*(2)  adpref
+      CHARACTER*(80) adfname
+      INTEGER i, bi, bj
+      INTEGER prec
+      INTEGER il
+      INTEGER ioUnit
+      _RS  dummyRS(1)
+      _RL  active_data_t(*)
+CEOP
+
+C     force 64-bit io
+      prec = ctrlprec
+
+C     set these to zero otherwise looks for tiled file
+      bi=0
+      bj=0
+
+C     ioUnit = 0 => open, read, and close the file... see
+C     mdsio_readvec_loc
+      ioUnit = 0
+      adpref = 'ad'
+      il = ILNBLNK( activeVar_file )
+      WRITE(adfname(1:80),'(80a)') ' '
+      WRITE(adfname(1:il+2),'(2A)') adpref, activeVar_file(1:il)
+
+C     >>>>>>>>>>>>>>>>>>> FORWARD RUN <<<<<<<<<<<<<<<<<<<
+      IF (theSimulationMode .EQ. FORWARD_SIMULATION) THEN
+
+C     Read the active variable from file.
+      CALL mds_readvec_loc(
+     I                activeVar_file, prec, ioUnit,
+     I                'RL', active_var_length,
+     O                active_var, dummyRS,
+     I                bi, bj,
+     I                iRec, myThid )
+
+        IF ( lAdInit ) THEN
+C     Initialise the corresponding adjoint variable on the
+C     adjoint variable file. These files are tiled.
+
+          do i = 1, active_var_length
+            active_data_t(i) = 0. _d 0
+          enddo
+          CALL mds_writevec_loc(
+     I                adfname, prec, ioUnit,
+     I                'RL', active_var_length,
+     O                active_data_t, dummyRS,
+     I                bi, bj,
+     I                iRec, myOptimIter, myThid )
+
+        ENDIF
+
+      ENDIF
+
+C     >>>>>>>>>>>>>>>>>>> ADJOINT RUN <<<<<<<<<<<<<<<<<<<
+      IF (theSimulationMode .EQ. REVERSE_SIMULATION) THEN
+
+        CALL mds_readvec_loc(
+     I                activeVar_file, prec, ioUnit,
+     I                'RL', active_var_length,
+     O                active_data_t, dummyRS,
+     I                bi, bj,
+     I                iRec, myThid )
+
+C     Add active_var from appropriate location to data.
+        do i = 1, active_var_length
+          active_data_t(i) = active_data_t(i) + active_var(i)
+        enddo
+
+C     Store the result on disk.
+        CALL mds_writevec_loc(
+     I                activeVar_file, prec, ioUnit,
+     I                'RL', active_var_length,
+     O                active_data_t, dummyRS,
+     I                bi, bj,
+     I                iRec, myOptimIter myThid )
+
+C     Set active_var to zero.
+        do i = 1, active_var_length
+          active_data_t(i) = 0. _d 0
+        enddo
+
+      ENDIF
+
+C     >>>>>>>>>>>>>>>>>>> TANGENT RUN <<<<<<<<<<<<<<<<<<<
+      IF (theSimulationMode .EQ. TANGENT_SIMULATION) THEN
+C     Read the active variable from file.
+      CALL mds_readvec_loc(
+     I                activeVar_file, prec, ioUnit,
+     I                'RL', active_var_length,
+     O                active_var, dummyRS,
+     I                bi, bj,
+     I                iRec, myThid )
+      ENDIF
+
+      RETURN
+      END
+
+C---+----1----+----2----+----3----+----4----+----5----+----6----+----7-|--+----|
+CBOP
+C     !ROUTINE: ACTIVE_READ_1D_RS
+C     !INTERFACE:
+      SUBROUTINE ACTIVE_READ_1D_RS(
+     I                          activeVar_file,
+     O                          active_var,
+     I                          active_var_length,
+     I                          lAdInit,
+     I                          iRec,
+     I                          theSimulationMode,
+     I                          myOptimIter,
+     I                          myThid )
+C     !DESCRIPTION: \bv
+C     ==================================================================
+C     SUBROUTINE ACTIVE_READ_1D_RS
+C     ==================================================================
+C     o Read an active 1D _RS vector from file.
+C     o Read the same 1D vector to all tiles/processes, so global by
+C       nature
+C     Modified from 3D: Tim Smith tsmith@oden.utexas.edu Oct-2019
+C     ==================================================================
+C     SUBROUTINE ACTIVE_READ_1D_RS
+C     ==================================================================
+C     \ev
+
+C     !USES:
+      IMPLICIT NONE
+
+C     == global variables ==
+#include "EEPARAMS.h"
+#include "SIZE.h"
+#include "PARAMS.h"
+#include "ctrl.h"
+
+C     !INPUT/OUTPUT PARAMETERS:
+C     activeVar_file :: filename
+C     active_var     :: vector
+C     active_var_length :: number of elements in active variable
+C     useCurrentDir  :: always read from the current directory
+C                        (even if "mdsioLocalDir" is set)
+C     lAdInit        :: initialisation of corresponding adjoint variable
+C                        and write to active file
+C     theSimulationMode :: forward, tangent linear, or reverse mode simulation
+C     myOptimIter    :: number of optimization iteration (default: 0)
+C     myThid         :: thread number for this instance
+      CHARACTER*(*) activeVar_file
+      _RS      active_var(*)
+      INTEGER  active_var_length
+      LOGICAL  lAdInit
+      INTEGER  iRec
+      INTEGER  theSimulationMode
+      INTEGER  myOptimIter
+      INTEGER  myThid
+
+C     !FUNCTIONS:
+      INTEGER  ILNBLNK
+      EXTERNAL ILNBLNK
+
+C     !LOCAL VARIABLES:
+      CHARACTER*(2)  adpref
+      CHARACTER*(80) adfname
+      INTEGER i, bi, bj
+      INTEGER prec
+      INTEGER il
+      INTEGER ioUnit
+      _RS  active_data_t(*)
+      _RL  dummyRL(1)
+CEOP
+
+C     force 64-bit io
+      prec = ctrlprec
+
+C     set these to zero otherwise looks for tiled file
+      bi=0
+      bj=0
+
+C     ioUnit = 0 => open, read, and close the file... see
+C     mdsio_readvec_loc
+      ioUnit = 0
+      adpref = 'ad'
+      il = ILNBLNK( activeVar_file )
+      WRITE(adfname(1:80),'(80a)') ' '
+      WRITE(adfname(1:il+2),'(2A)') adpref, activeVar_file(1:il)
+
+C     >>>>>>>>>>>>>>>>>>> FORWARD RUN <<<<<<<<<<<<<<<<<<<
+      IF (theSimulationMode .EQ. FORWARD_SIMULATION) THEN
+
+C     Read the active variable from file.
+      CALL mds_readvec_loc(
+     I                activeVar_file, prec, ioUnit,
+     I                'RS', active_var_length,
+     O                dummyRL, active_var,
+     I                bi, bj,
+     I                iRec, myThid )
+
+        IF ( lAdInit ) THEN
+C     Initialise the corresponding adjoint variable on the
+C     adjoint variable file. These files are tiled.
+
+          do i = 1, active_var_length
+            active_data_t(i) = 0. _d 0
+          enddo
+          CALL mds_writevec_loc(
+     I                adfname, prec, ioUnit,
+     I                'RS', active_var_length,
+     O                dummyRL, active_data_t,
+     I                bi, bj,
+     I                iRec, myOptimIter, myThid )
+
+        ENDIF
+
+      ENDIF
+
+C     >>>>>>>>>>>>>>>>>>> ADJOINT RUN <<<<<<<<<<<<<<<<<<<
+      IF (theSimulationMode .EQ. REVERSE_SIMULATION) THEN
+
+        CALL mds_readvec_loc(
+     I                activeVar_file, prec, ioUnit,
+     I                'RS', active_var_length,
+     O                dummyRL, active_data_t,
+     I                bi, bj,
+     I                iRec, myThid )
+
+C     Add active_var from appropriate location to data.
+        do i = 1, active_var_length
+          active_data_t(i) = active_data_t(i) + active_var(i)
+        enddo
+
+C     Store the result on disk.
+        CALL mds_writevec_loc(
+     I                activeVar_file, prec, ioUnit,
+     I                'RS', active_var_length,
+     O                dummyRL, active_data_t,
+     I                bi, bj,
+     I                iRec, myOptimIter myThid )
+
+C     Set active_var to zero.
+        do i = 1, active_var_length
+          active_data_t(i) = 0. _d 0
+        enddo
+
+      ENDIF
+
+C     >>>>>>>>>>>>>>>>>>> TANGENT RUN <<<<<<<<<<<<<<<<<<<
+      IF (theSimulationMode .EQ. TANGENT_SIMULATION) THEN
+C     Read the active variable from file.
+      CALL mds_readvec_loc(
+     I                activeVar_file, prec, ioUnit,
+     I                'RS', active_var_length,
+     O                dummyRL, active_var,
+     I                bi, bj,
+     I                iRec, myThid )
+      ENDIF
+
+      RETURN
+      END
+
+C---+----1----+----2----+----3----+----4----+----5----+----6----+----7-|--+----|
+CBOP
 C     !ROUTINE: ACTIVE_WRITE_3D_RL
 C     !INTERFACE:
       SUBROUTINE ACTIVE_WRITE_3D_RL(
@@ -618,3 +938,4 @@ C     >>>>>>>>>>>>>>>>>>> TANGENT RUN <<<<<<<<<<<<<<<<<<<
 
       RETURN
       END
+

--- a/pkg/autodiff/active_file_control.F
+++ b/pkg/autodiff/active_file_control.F
@@ -452,7 +452,7 @@ C     !LOCAL VARIABLES:
       INTEGER il
       INTEGER ioUnit
       _RS  dummyRS(1)
-      _RL  active_data_t(*)
+      _RL  active_data_t(active_var_length)
 CEOP
 
 C     force 64-bit io
@@ -609,7 +609,7 @@ C     !LOCAL VARIABLES:
       INTEGER prec
       INTEGER il
       INTEGER ioUnit
-      _RS  active_data_t(*)
+      _RS  active_data_t(active_var_length)
       _RL  dummyRL(1)
 CEOP
 
@@ -939,3 +939,280 @@ C     >>>>>>>>>>>>>>>>>>> TANGENT RUN <<<<<<<<<<<<<<<<<<<
       RETURN
       END
 
+C---+----1----+----2----+----3----+----4----+----5----+----6----+----7-|--+----|
+CBOP
+C     !ROUTINE: ACTIVE_WRITE_1D_RL
+C     !INTERFACE:
+      SUBROUTINE ACTIVE_WRITE_1D_RL(
+     I                          activeVar_file,
+     O                          active_var,
+     I                          active_var_length,
+     I                          lAdInit,
+     I                          iRec,
+     I                          theSimulationMode,
+     I                          myOptimIter,
+     I                          myThid )
+C     !DESCRIPTION: \bv
+C     ==================================================================
+C     SUBROUTINE ACTIVE_WRITE_1D_RL
+C     ==================================================================
+C     o Write an active 1D _RL vector from file.
+C     o Write the same 1D vector to all tiles/processes, so global by
+C       nature
+C     Modified from 3D: Tim Smith tsmith@oden.utexas.edu Oct-2019
+C     ==================================================================
+C     SUBROUTINE ACTIVE_WRITE_1D_RL
+C     ==================================================================
+C     \ev
+
+C     !USES:
+      IMPLICIT NONE
+
+C     == global variables ==
+#include "EEPARAMS.h"
+#include "SIZE.h"
+#include "PARAMS.h"
+#include "ctrl.h"
+
+C     !INPUT/OUTPUT PARAMETERS:
+C     activeVar_file :: filename
+C     active_var     :: vector
+C     active_var_length :: number of elements in active variable
+C     useCurrentDir  :: always read from the current directory
+C                        (even if "mdsioLocalDir" is set)
+C     lAdInit        :: initialisation of corresponding adjoint variable
+C                        and write to active file
+C     theSimulationMode :: forward, tangent linear, or reverse mode simulation
+C     myOptimIter    :: number of optimization iteration (default: 0)
+C     myThid         :: thread number for this instance
+      CHARACTER*(*) activeVar_file
+      _RL      active_var(*)
+      INTEGER  active_var_length
+      LOGICAL  lAdInit
+      INTEGER  iRec
+      INTEGER  theSimulationMode
+      INTEGER  myOptimIter
+      INTEGER  myThid
+
+C     !FUNCTIONS:
+      INTEGER  ILNBLNK
+      EXTERNAL ILNBLNK
+
+C     !LOCAL VARIABLES:
+      CHARACTER*(2)  adpref
+      CHARACTER*(80) adfname
+      INTEGER i, bi, bj
+      INTEGER prec
+      INTEGER il
+      INTEGER ioUnit
+      _RS  dummyRS(1)
+      _RL  active_data_t(active_var_length)
+CEOP
+
+C     force 64-bit io
+      prec = ctrlprec
+
+C     set these to zero otherwise looks mdsio_read/writevec_loc 
+C     looks for tiled file
+      bi=0
+      bj=0
+
+C     ioUnit = 0 => open, read, and close the file... see
+C     mdsio_readvec_loc
+      ioUnit = 0
+      adpref = 'ad'
+      il = ILNBLNK( activeVar_file )
+      WRITE(adfname(1:80),'(80a)') ' '
+      WRITE(adfname(1:il+2),'(2A)') adpref, activeVar_file(1:il)
+
+C     >>>>>>>>>>>>>>>>>>> FORWARD RUN <<<<<<<<<<<<<<<<<<<
+      IF (theSimulationMode .EQ. FORWARD_SIMULATION) THEN
+
+C     Read the active variable from file.
+      CALL mds_writevec_loc(
+     I                activeVar_file, prec, ioUnit,
+     I                'RL', active_var_length,
+     O                active_var, dummyRS,
+     I                bi, bj,
+     I                iRec, myOptimIter, myThid )
+
+      ENDIF
+
+C     >>>>>>>>>>>>>>>>>>> ADJOINT RUN <<<<<<<<<<<<<<<<<<<
+      IF (theSimulationMode .EQ. REVERSE_SIMULATION) THEN
+
+        CALL mds_readvec_loc(
+     I                activeVar_file, prec, ioUnit,
+     I                'RL', active_var_length,
+     O                active_data_t, dummyRS,
+     I                bi, bj,
+     I                iRec, myThid )
+
+C     Add active_var from appropriate location to data.
+        do i = 1, active_var_length
+          active_var(i) = active_var(i) + active_data_t(i)
+          active_data_t(i) = 0. _d 0
+        enddo
+
+C     Store the result on disk.
+        CALL mds_writevec_loc(
+     I                activeVar_file, prec, ioUnit,
+     I                'RL', active_var_length,
+     O                active_data_t, dummyRS,
+     I                bi, bj,
+     I                iRec, myOptimIter, myThid )
+
+      ENDIF
+
+C     >>>>>>>>>>>>>>>>>>> TANGENT RUN <<<<<<<<<<<<<<<<<<<
+      IF (theSimulationMode .EQ. TANGENT_SIMULATION) THEN
+C     Read the active variable from file.
+      CALL mds_writevec_loc(
+     I                activeVar_file, prec, ioUnit,
+     I                'RL', active_var_length,
+     O                active_var, dummyRS,
+     I                bi, bj,
+     I                iRec, myOptimIter, myThid )
+      ENDIF
+
+      RETURN
+      END
+
+C---+----1----+----2----+----3----+----4----+----5----+----6----+----7-|--+----|
+CBOP
+C     !ROUTINE: ACTIVE_WRITE_1D_RS
+C     !INTERFACE:
+      SUBROUTINE ACTIVE_WRITE_1D_RS(
+     I                          activeVar_file,
+     O                          active_var,
+     I                          active_var_length,
+     I                          lAdInit,
+     I                          iRec,
+     I                          theSimulationMode,
+     I                          myOptimIter,
+     I                          myThid )
+C     !DESCRIPTION: \bv
+C     ==================================================================
+C     SUBROUTINE ACTIVE_WRITE_1D_RS
+C     ==================================================================
+C     o Write an active 1D _RS vector from file.
+C     o Write the same 1D vector to all tiles/processes, so global by
+C       nature
+C     Modified from 3D: Tim Smith tsmith@oden.utexas.edu Oct-2019
+C     ==================================================================
+C     SUBROUTINE ACTIVE_WRITE_1D_RS
+C     ==================================================================
+C     \ev
+
+C     !USES:
+      IMPLICIT NONE
+
+C     == global variables ==
+#include "EEPARAMS.h"
+#include "SIZE.h"
+#include "PARAMS.h"
+#include "ctrl.h"
+
+C     !INPUT/OUTPUT PARAMETERS:
+C     activeVar_file :: filename
+C     active_var     :: vector
+C     active_var_length :: number of elements in active variable
+C     useCurrentDir  :: always read from the current directory
+C                        (even if "mdsioLocalDir" is set)
+C     lAdInit        :: initialisation of corresponding adjoint variable
+C                        and write to active file
+C     theSimulationMode :: forward, tangent linear, or reverse mode simulation
+C     myOptimIter    :: number of optimization iteration (default: 0)
+C     myThid         :: thread number for this instance
+      CHARACTER*(*) activeVar_file
+      _RS      active_var(*)
+      INTEGER  active_var_length
+      LOGICAL  lAdInit
+      INTEGER  iRec
+      INTEGER  theSimulationMode
+      INTEGER  myOptimIter
+      INTEGER  myThid
+
+C     !FUNCTIONS:
+      INTEGER  ILNBLNK
+      EXTERNAL ILNBLNK
+
+C     !LOCAL VARIABLES:
+      CHARACTER*(2)  adpref
+      CHARACTER*(80) adfname
+      INTEGER i, bi, bj
+      INTEGER prec
+      INTEGER il
+      INTEGER ioUnit
+      _RL  dummyRL(1)
+      _RS  active_data_t(active_var_length)
+CEOP
+
+C     force 64-bit io
+      prec = ctrlprec
+
+C     set these to zero otherwise looks mdsio_read/writevec_loc 
+C     looks for tiled file
+      bi=0
+      bj=0
+
+C     ioUnit = 0 => open, read, and close the file... see
+C     mdsio_readvec_loc
+      ioUnit = 0
+      adpref = 'ad'
+      il = ILNBLNK( activeVar_file )
+      WRITE(adfname(1:80),'(80a)') ' '
+      WRITE(adfname(1:il+2),'(2A)') adpref, activeVar_file(1:il)
+
+C     >>>>>>>>>>>>>>>>>>> FORWARD RUN <<<<<<<<<<<<<<<<<<<
+      IF (theSimulationMode .EQ. FORWARD_SIMULATION) THEN
+
+C     Read the active variable from file.
+      CALL mds_writevec_loc(
+     I                activeVar_file, prec, ioUnit,
+     I                'RS', active_var_length,
+     O                dummyRL, active_var,
+     I                bi, bj,
+     I                iRec, myOptimIter, myThid )
+
+      ENDIF
+
+C     >>>>>>>>>>>>>>>>>>> ADJOINT RUN <<<<<<<<<<<<<<<<<<<
+      IF (theSimulationMode .EQ. REVERSE_SIMULATION) THEN
+
+        CALL mds_readvec_loc(
+     I                activeVar_file, prec, ioUnit,
+     I                'RL', active_var_length,
+     O                dummyRL, active_data_t,
+     I                bi, bj,
+     I                iRec, myThid )
+
+C     Add active_var from appropriate location to data.
+        do i = 1, active_var_length
+          active_var(i) = active_var(i) + active_data_t(i)
+          active_data_t(i) = 0. _d 0
+        enddo
+
+C     Store the result on disk.
+        CALL mds_writevec_loc(
+     I                activeVar_file, prec, ioUnit,
+     I                'RL', active_var_length,
+     O                dummyRL, active_data_t,
+     I                bi, bj,
+     I                iRec, myOptimIter, myThid )
+
+      ENDIF
+
+C     >>>>>>>>>>>>>>>>>>> TANGENT RUN <<<<<<<<<<<<<<<<<<<
+      IF (theSimulationMode .EQ. TANGENT_SIMULATION) THEN
+C     Read the active variable from file.
+      CALL mds_writevec_loc(
+     I                activeVar_file, prec, ioUnit,
+     I                'RL', active_var_length,
+     O                dummyRL, active_var,
+     I                bi, bj,
+     I                iRec, myOptimIter, myThid )
+      ENDIF
+
+      RETURN
+      END

--- a/pkg/autodiff/active_file_control.flow
+++ b/pkg/autodiff/active_file_control.flow
@@ -27,10 +27,22 @@ cadj SUBROUTINE active_read_3d_rl INPUT   = 1, 2, 3, 4, 5, 6, 7, 8, 9, 10
 cadj SUBROUTINE active_read_3d_rl OUTPUT  =    2
 
 c----------------------------------------
+c subroutine active_read_1d_rl
+c----------------------------------------
+cadj SUBROUTINE active_read_1d_rl INPUT   = 1, 2, 3, 4, 5, 6, 7, 8
+cadj SUBROUTINE active_read_1d_rl OUTPUT  =    2
+
+c----------------------------------------
 c subroutine active_read_3d_rs
 c----------------------------------------
 cadj SUBROUTINE active_read_3d_rs INPUT   = 1, 2, 3, 4, 5, 6, 7, 8, 9, 10
 cadj SUBROUTINE active_read_3d_rs OUTPUT  =    2
+
+c----------------------------------------
+c subroutine active_read_1d_rs
+c----------------------------------------
+cadj SUBROUTINE active_read_1d_rs INPUT   = 1, 2, 3, 4, 5, 6, 7, 8
+cadj SUBROUTINE active_read_1d_rs OUTPUT  =    2
 
 c----------------------------------------
 c subroutine active_read_xz_rl
@@ -63,10 +75,22 @@ cadj SUBROUTINE active_write_3d_rl INPUT   = 1, 2, 3, 4, 5, 6, 7, 8, 9
 cadj SUBROUTINE active_write_3d_rl OUTPUT  =    2
 
 c----------------------------------------
+c subroutine active_write_1d_rl
+c----------------------------------------
+cadj SUBROUTINE active_write_1d_rl INPUT   = 1, 2, 3, 4, 5, 6, 7
+cadj SUBROUTINE active_write_1d_rl OUTPUT  =    2
+
+c----------------------------------------
 c subroutine active_write_3d_rs
 c----------------------------------------
 cadj SUBROUTINE active_write_3d_rs INPUT   = 1, 2, 3, 4, 5, 6, 7, 8, 9
 cadj SUBROUTINE active_write_3d_rs OUTPUT  =    2
+
+c----------------------------------------
+c subroutine active_write_1d_rs
+c----------------------------------------
+cadj SUBROUTINE active_write_1d_rs INPUT   = 1, 2, 3, 4, 5, 6, 7
+cadj SUBROUTINE active_write_1d_rs OUTPUT  =    2
 
 c----------------------------------------
 c subroutine active_write_xz_rl

--- a/pkg/autodiff/active_file_g.F
+++ b/pkg/autodiff/active_file_g.F
@@ -415,6 +415,8 @@ C     active_var:      array
 C     g_active_var:    tangent linear  array
 C     active_var_length: array length
 C     iRec:            record number
+C     lAdInit:         initialisation of corresponding adjoint
+C                      variable and write to active file
 C     myOptimIter:     number of optimization iteration (default: 0)
 C     myThid:          thread number for this instance
       CHARACTER*(*) active_var_file
@@ -424,6 +426,7 @@ C     myThid:          thread number for this instance
       INTEGER iRec
       INTEGER myOptimIter
       INTEGER myThid
+      LOGICAL lAdInit
       _RL     dummy
       _RL     g_dummy
 

--- a/pkg/autodiff/active_file_g.F
+++ b/pkg/autodiff/active_file_g.F
@@ -9,13 +9,13 @@ C    o  g_active_read_xy         - Read  an active 2D variable from file.
 C    o  g_active_read_xyz        - Read  an active 3D variable from file.
 C    o  g_active_read_xz         - Read  an active 2D xz-slice from file.
 C    o  g_active_read_yz         - Read  an active 2D yz-slice from file.
-C    o  g_active_read_1D         - Read  an active 1D vector from file.
+C    o  g_active_read_1d         - Read  an active 1D vector from file.
 C
 C    o  g_active_write_xy        - Write an active 2D variable to a file.
 C    o  g_active_write_xyz       - Write an active 3D variable to a file.
 C    o  g_active_write_xz        - Write an active 2D xz-slice to a file.
 C    o  g_active_write_yz        - Write an active 2D yz-slice to a file.
-C    o  g_active_write_1D        - Write an active 1D vector to a file.
+C    o  g_active_write_1d        - Write an active 1D vector to a file.
 C
 C        changed: Christian Eckert eckert@mit.edu 24-Apr-2000
 C                 - Added routines that do active writes on tiles
@@ -62,23 +62,24 @@ C     == global variables ==
 #include "SIZE.h"
 
 C     !INPUT/OUTPUT PARAMETERS:
-C     active_var_file: filename
-C     active_var:      array
-C     iRec:            record number
-C     myOptimIter:     number of optimization iteration (default: 0)
-C     myThid:          thread number for this instance
-C     doglobalread:    flag for global or local read/write
-C                      (default: .false.)
-C     lAdInit:         initialisation of corresponding adjoint
-C                      variable and write to active file
+C     active_var_file:: filename
+C     active_var     :: array
+C     g_active_var   :: tangent linear  array
+C     iRec           :: record number
+C     doglobalread   :: flag for global or local read/write
+C                       (default: .false.)
+C     lAdInit        :: initialisation of corresponding adjoint
+C                       variable and write to active file
+C     myOptimIter    :: number of optimization iteration (default: 0)
+C     myThid         :: thread number for this instance
       CHARACTER*(*) active_var_file
       _RL     active_var(1-OLx:sNx+OLx,1-OLy:sNy+OLy,nSx,nSy)
       _RL     g_active_var(1-OLx:sNx+OLx,1-OLy:sNy+OLy,nSx,nSy)
       INTEGER iRec
-      INTEGER myOptimIter
-      INTEGER myThid
       LOGICAL doglobalread
       LOGICAL lAdInit
+      INTEGER myOptimIter
+      INTEGER myThid
       _RL     dummy, g_dummy
 
 C     !FUNCTIONS:
@@ -149,23 +150,24 @@ C     == global variables ==
 #include "SIZE.h"
 
 C     !INPUT/OUTPUT PARAMETERS:
-C     active_var_file: filename
-C     active_var:      array
-C     iRec:            record number
-C     myOptimIter:     number of optimization iteration (default: 0)
-C     myThid:          thread number for this instance
-C     doglobalread:    flag for global or local read/write
-C                      (default: .false.)
-C     lAdInit:         initialisation of corresponding adjoint
-C                      variable and write to active file
+C     active_var_file:: filename
+C     active_var     :: array
+C     g_active_var   :: tangent linear  array
+C     iRec           :: record number
+C     doglobalread   :: flag for global or local read/write
+C                       (default: .false.)
+C     lAdInit        :: initialisation of corresponding adjoint
+C                       variable and write to active file
+C     myOptimIter    :: number of optimization iteration (default: 0)
+C     myThid         :: thread number for this instance
       CHARACTER*(*) active_var_file
       _RL active_var(1-OLx:sNx+OLx,1-OLy:sNy+OLy,Nr,nSx,nSy)
       _RL g_active_var(1-OLx:sNx+OLx,1-OLy:sNy+OLy,Nr,nSx,nSy)
       INTEGER iRec
-      INTEGER myOptimIter
-      INTEGER myThid
       LOGICAL doglobalread
       LOGICAL lAdInit
+      INTEGER myOptimIter
+      INTEGER myThid
       _RL     dummy, g_dummy
 
 C     !FUNCTIONS:
@@ -236,23 +238,24 @@ C     == global variables ==
 #include "SIZE.h"
 
 C     !INPUT/OUTPUT PARAMETERS:
-C     active_var_file: filename
-C     active_var:      array
-C     iRec:            record number
-C     myOptimIter:     number of optimization iteration (default: 0)
-C     myThid:          thread number for this instance
-C     doglobalread:    flag for global or local read/write
-C                      (default: .false.)
-C     lAdInit:         initialisation of corresponding adjoint
-C                      variable and write to active file
+C     active_var_file:: filename
+C     active_var     :: array
+C     g_active_var   :: tangent linear  array
+C     iRec           :: record number
+C     doglobalread   :: flag for global or local read/write
+C                       (default: .false.)
+C     lAdInit        :: initialisation of corresponding adjoint
+C                       variable and write to active file
+C     myOptimIter    :: number of optimization iteration (default: 0)
+C     myThid         :: thread number for this instance
       CHARACTER*(*) active_var_file
       _RL     active_var(1-OLx:sNx+OLx,nSx,nSy)
       _RL     g_active_var(1-OLx:sNx+OLx,nSx,nSy)
       INTEGER iRec
-      INTEGER myOptimIter
-      INTEGER myThid
       LOGICAL doglobalread
       LOGICAL lAdInit
+      INTEGER myOptimIter
+      INTEGER myThid
       _RL     dummy, g_dummy
 
 C     !FUNCTIONS:
@@ -323,23 +326,24 @@ C     == global variables ==
 #include "SIZE.h"
 
 C     !INPUT/OUTPUT PARAMETERS:
-C     active_var_file: filename
-C     active_var:      array
-C     iRec:            record number
-C     myOptimIter:     number of optimization iteration (default: 0)
-C     myThid:          thread number for this instance
-C     doglobalread:    flag for global or local read/write
-C                      (default: .false.)
-C     lAdInit:         initialisation of corresponding adjoint
-C                      variable and write to active file
+C     active_var_file:: filename
+C     active_var     :: array
+C     g_active_var   :: tangent linear  array
+C     iRec           :: record number
+C     doglobalread   :: flag for global or local read/write
+C                       (default: .false.)
+C     lAdInit        :: initialisation of corresponding adjoint
+C                       variable and write to active file
+C     myOptimIter    :: number of optimization iteration (default: 0)
+C     myThid         :: thread number for this instance
       CHARACTER*(*) active_var_file
       _RL     active_var(1-OLy:sNy+OLy,nSx,nSy)
       _RL     g_active_var(1-OLy:sNy+OLy,nSx,nSy)
       INTEGER iRec
-      INTEGER myOptimIter
-      INTEGER myThid
       LOGICAL doglobalread
       LOGICAL lAdInit
+      INTEGER myOptimIter
+      INTEGER myThid
       _RL     dummy, g_dummy
 
 C     !FUNCTIONS:
@@ -410,23 +414,23 @@ C     == global variables ==
 #include "SIZE.h"
 
 C     !INPUT/OUTPUT PARAMETERS:
-C     active_var_file: filename
-C     active_var:      array
-C     g_active_var:    tangent linear  array
-C     active_var_length: array length
-C     iRec:            record number
-C     lAdInit:         initialisation of corresponding adjoint
-C                      variable and write to active file
-C     myOptimIter:     number of optimization iteration (default: 0)
-C     myThid:          thread number for this instance
+C     active_var_file:: filename
+C     active_var     :: array
+C     g_active_var   :: tangent linear  array
+C     active_var_length :: array length
+C     iRec           :: record number
+C     lAdInit        :: initialisation of corresponding adjoint
+C                       variable and write to active file
+C     myOptimIter    :: number of optimization iteration (default: 0)
+C     myThid         :: thread number for this instance
       CHARACTER*(*) active_var_file
       _RL     active_var(*)
       _RL     g_active_var(*)
       INTEGER active_var_length
       INTEGER iRec
+      LOGICAL lAdInit
       INTEGER myOptimIter
       INTEGER myThid
-      LOGICAL lAdInit
       _RL     dummy
       _RL     g_dummy
 
@@ -438,7 +442,6 @@ C     !LOCAL VARIABLES:
       CHARACTER*(2) pref
       CHARACTER*(80) fname
       INTEGER il
-
 CEOP
 
       pref = 'g_'
@@ -493,11 +496,12 @@ C     == global variables ==
 #include "SIZE.h"
 
 C     !INPUT/OUTPUT PARAMETERS:
-C     active_var_file: filename
-C     active_var:      array
-C     iRec:            record number
-C     myOptimIter:     number of optimization iteration (default: 0)
-C     myThid:          thread number for this instance
+C     active_var_file:: filename
+C     active_var     :: array
+C     g_active_var   :: tangent linear  array
+C     iRec           :: record number
+C     myOptimIter    :: number of optimization iteration (default: 0)
+C     myThid         :: thread number for this instance
       CHARACTER*(*) active_var_file
       _RL     active_var(1-OLx:sNx+OLx,1-OLy:sNy+OLy,nSx,nSy)
       _RL     g_active_var(1-OLx:sNx+OLx,1-OLy:sNy+OLy,nSx,nSy)
@@ -575,11 +579,12 @@ C     == global variables ==
 #include "SIZE.h"
 
 C     !INPUT/OUTPUT PARAMETERS:
-C     active_var_file: filename
-C     active_var:      array
-C     iRec:            record number
-C     myOptimIter:     number of optimization iteration (default: 0)
-C     myThid:          thread number for this instance
+C     active_var_file:: filename
+C     active_var     :: array
+C     g_active_var   :: tangent linear  array
+C     iRec           :: record number
+C     myOptimIter    :: number of optimization iteration (default: 0)
+C     myThid         :: thread number for this instance
       CHARACTER*(*) active_var_file
       _RL active_var(1-OLx:sNx+OLx,1-OLy:sNy+OLy,Nr,nSx,nSy)
       _RL g_active_var(1-OLx:sNx+OLx,1-OLy:sNy+OLy,Nr,nSx,nSy)
@@ -657,11 +662,12 @@ C     == global variables ==
 #include "SIZE.h"
 
 C     !INPUT/OUTPUT PARAMETERS:
-C     active_var_file: filename
-C     active_var:      array
-C     iRec:            record number
-C     myOptimIter:     number of optimization iteration (default: 0)
-C     myThid:          thread number for this instance
+C     active_var_file:: filename
+C     active_var     :: array
+C     g_active_var   :: tangent linear  array
+C     iRec           :: record number
+C     myOptimIter    :: number of optimization iteration (default: 0)
+C     myThid         :: thread number for this instance
       CHARACTER*(*) active_var_file
       _RL     active_var(1-OLx:sNx+OLx,nSx,nSy)
       _RL     g_active_var(1-OLx:sNx+OLx,nSx,nSy)
@@ -739,11 +745,12 @@ C     == global variables ==
 #include "SIZE.h"
 
 C     !INPUT/OUTPUT PARAMETERS:
-C     active_var_file: filename
-C     active_var:      array
-C     iRec:            record number
-C     myOptimIter:     number of optimization iteration (default: 0)
-C     myThid:          thread number for this instance
+C     active_var_file:: filename
+C     active_var     :: array
+C     g_active_var   :: tangent linear  array
+C     iRec           :: record number
+C     myOptimIter    :: number of optimization iteration (default: 0)
+C     myThid         :: thread number for this instance
       CHARACTER*(*) active_var_file
       _RL     active_var(1-OLy:sNy+OLy,nSx,nSy)
       _RL     g_active_var(1-OLy:sNy+OLy,nSx,nSy)
@@ -822,13 +829,13 @@ C     == global variables ==
 #include "SIZE.h"
 
 C     !INPUT/OUTPUT PARAMETERS:
-C     active_var_file: filename
-C     active_var:      array
-C     g_active_var:    tangent linear  array
-C     active_var_length: array length
-C     iRec:            record number
-C     myOptimIter:     number of optimization iteration (default: 0)
-C     myThid:          thread number for this instance
+C     active_var_file:: filename
+C     active_var     :: array
+C     g_active_var   :: tangent linear  array
+C     active_var_length :: array length
+C     iRec           :: record number
+C     myOptimIter    :: number of optimization iteration (default: 0)
+C     myThid         :: thread number for this instance
       CHARACTER*(*) active_var_file
       _RL     active_var(*)
       _RL     g_active_var(*)
@@ -847,7 +854,6 @@ C     !LOCAL VARIABLES:
       CHARACTER*(2) pref
       CHARACTER*(80) fname
       INTEGER il
-
 CEOP
 
       pref = 'g_'

--- a/pkg/autodiff/active_file_g.F
+++ b/pkg/autodiff/active_file_g.F
@@ -96,7 +96,7 @@ CEOP
 
       pref = 'g_'
       il   = ILNBLNK( active_var_file )
-      WRITE(fname(1:80),'(A)') ' '
+      WRITE(fname,'(A)') ' '
       WRITE(fname(1:2+il),'(2A)') pref, active_var_file(1:il)
       myNr = 1
       useCurrentDir = .FALSE.
@@ -184,7 +184,7 @@ CEOP
 
       pref = 'g_'
       il   = ILNBLNK( active_var_file )
-      WRITE(fname(1:80),'(A)') ' '
+      WRITE(fname,'(A)') ' '
       WRITE(fname(1:2+il),'(2A)') pref, active_var_file(1:il)
       myNr = Nr
       useCurrentDir = .FALSE.
@@ -249,8 +249,8 @@ C                       variable and write to active file
 C     myOptimIter    :: number of optimization iteration (default: 0)
 C     myThid         :: thread number for this instance
       CHARACTER*(*) active_var_file
-      _RL     active_var(1-OLx:sNx+OLx,nSx,nSy)
-      _RL     g_active_var(1-OLx:sNx+OLx,nSx,nSy)
+      _RL     active_var(1-OLx:sNx+OLx,Nr,nSx,nSy)
+      _RL     g_active_var(1-OLx:sNx+OLx,Nr,nSx,nSy)
       INTEGER iRec
       LOGICAL doglobalread
       LOGICAL lAdInit
@@ -272,7 +272,7 @@ CEOP
 
       pref = 'g_'
       il   = ILNBLNK( active_var_file )
-      WRITE(fname(1:80),'(A)') ' '
+      WRITE(fname,'(A)') ' '
       WRITE(fname(1:2+il),'(2A)') pref, active_var_file(1:il)
       myNr = Nr
       useCurrentDir = .FALSE.
@@ -337,8 +337,8 @@ C                       variable and write to active file
 C     myOptimIter    :: number of optimization iteration (default: 0)
 C     myThid         :: thread number for this instance
       CHARACTER*(*) active_var_file
-      _RL     active_var(1-OLy:sNy+OLy,nSx,nSy)
-      _RL     g_active_var(1-OLy:sNy+OLy,nSx,nSy)
+      _RL     active_var(1-OLy:sNy+OLy,Nr,nSx,nSy)
+      _RL     g_active_var(1-OLy:sNy+OLy,Nr,nSx,nSy)
       INTEGER iRec
       LOGICAL doglobalread
       LOGICAL lAdInit
@@ -360,7 +360,7 @@ CEOP
 
       pref = 'g_'
       il   = ILNBLNK( active_var_file )
-      WRITE(fname(1:80),'(A)') ' '
+      WRITE(fname,'(A)') ' '
       WRITE(fname(1:2+il),'(2A)') pref, active_var_file(1:il)
       myNr = Nr
       useCurrentDir = .FALSE.
@@ -446,7 +446,7 @@ CEOP
 
       pref = 'g_'
       il   = ILNBLNK( active_var_file )
-      WRITE(fname(1:80),'(A)') ' '
+      WRITE(fname,'(A)') ' '
       WRITE(fname(1:2+il),'(2A)') pref, active_var_file(1:il)
 
       CALL ACTIVE_READ_1D_RL(
@@ -526,7 +526,7 @@ CEOP
 
       pref = 'g_'
       il   = ILNBLNK( active_var_file )
-      WRITE(fname(1:80),'(A)') ' '
+      WRITE(fname,'(A)') ' '
       WRITE(fname(1:2+il),'(2A)') pref, active_var_file(1:il)
       myNr = 1
       globalFile = .FALSE.
@@ -609,7 +609,7 @@ CEOP
 
       pref = 'g_'
       il   = ILNBLNK( active_var_file )
-      WRITE(fname(1:80),'(A)') ' '
+      WRITE(fname,'(A)') ' '
       WRITE(fname(1:2+il),'(2A)') pref, active_var_file(1:il)
       myNr = Nr
       globalFile = .FALSE.
@@ -669,8 +669,8 @@ C     iRec           :: record number
 C     myOptimIter    :: number of optimization iteration (default: 0)
 C     myThid         :: thread number for this instance
       CHARACTER*(*) active_var_file
-      _RL     active_var(1-OLx:sNx+OLx,nSx,nSy)
-      _RL     g_active_var(1-OLx:sNx+OLx,nSx,nSy)
+      _RL     active_var(1-OLx:sNx+OLx,Nr,nSx,nSy)
+      _RL     g_active_var(1-OLx:sNx+OLx,Nr,nSx,nSy)
       INTEGER iRec
       INTEGER myOptimIter
       INTEGER myThid
@@ -692,7 +692,7 @@ CEOP
 
       pref = 'g_'
       il   = ILNBLNK( active_var_file )
-      WRITE(fname(1:80),'(A)') ' '
+      WRITE(fname,'(A)') ' '
       WRITE(fname(1:2+il),'(2A)') pref, active_var_file(1:il)
       myNr = Nr
       globalFile = .FALSE.
@@ -752,8 +752,8 @@ C     iRec           :: record number
 C     myOptimIter    :: number of optimization iteration (default: 0)
 C     myThid         :: thread number for this instance
       CHARACTER*(*) active_var_file
-      _RL     active_var(1-OLy:sNy+OLy,nSx,nSy)
-      _RL     g_active_var(1-OLy:sNy+OLy,nSx,nSy)
+      _RL     active_var(1-OLy:sNy+OLy,Nr,nSx,nSy)
+      _RL     g_active_var(1-OLy:sNy+OLy,Nr,nSx,nSy)
       INTEGER iRec
       INTEGER myOptimIter
       INTEGER myThid
@@ -775,7 +775,7 @@ CEOP
 
       pref = 'g_'
       il   = ILNBLNK( active_var_file )
-      WRITE(fname(1:80),'(A)') ' '
+      WRITE(fname,'(A)') ' '
       WRITE(fname(1:2+il),'(2A)') pref, active_var_file(1:il)
       myNr = Nr
       globalFile = .FALSE.
@@ -858,7 +858,7 @@ CEOP
 
       pref = 'g_'
       il   = ILNBLNK( active_var_file )
-      WRITE(fname(1:80),'(A)') ' '
+      WRITE(fname,'(A)') ' '
       WRITE(fname(1:2+il),'(2A)') pref, active_var_file(1:il)
 
       CALL ACTIVE_WRITE_1D_RL(

--- a/pkg/autodiff/active_file_g.F
+++ b/pkg/autodiff/active_file_g.F
@@ -9,17 +9,21 @@ C    o  g_active_read_xy         - Read  an active 2D variable from file.
 C    o  g_active_read_xyz        - Read  an active 3D variable from file.
 C    o  g_active_read_xz         - Read  an active 2D xz-slice from file.
 C    o  g_active_read_yz         - Read  an active 2D yz-slice from file.
+C    o  g_active_read_1D         - Read  an active 1D vector from file.
 C
 C    o  g_active_write_xy        - Write an active 2D variable to a file.
 C    o  g_active_write_xyz       - Write an active 3D variable to a file.
 C    o  g_active_write_xz        - Write an active 2D xz-slice to a file.
 C    o  g_active_write_yz        - Write an active 2D yz-slice to a file.
+C    o  g_active_write_1D        - Write an active 1D vector to a file.
 C
 C        changed: Christian Eckert eckert@mit.edu 24-Apr-2000
 C                 - Added routines that do active writes on tiles
 C                   instead of a whole thread.
 C        changed: heimbach@mit.edu 05-Mar-2001
 C                 - added active file handling of xz-/yz-arrays
+C        changed: tsmith@oden.utexas.edu 22-Oct-2019
+C                 - added 1D vectors
 C     ==================================================================
 
 C---+----1----+----2----+----3----+----4----+----5----+----6----+----7-|--+----|
@@ -372,6 +376,88 @@ CEOP
 
 C---+----1----+----2----+----3----+----4----+----5----+----6----+----7-|--+----|
 CBOP
+C     !ROUTINE: g_active_read_1d
+C     !INTERFACE:
+      subroutine g_active_read_1d(
+     I                           active_var_file,
+     O                           active_var,
+     I                           g_active_var,
+     I                           active_var_length,
+     I                           iRec,
+     I                           lAdInit,
+     I                           myOptimIter,
+     I                           myThid,
+     I                           dummy,
+     I                           g_dummy
+     &                         )
+
+C     !DESCRIPTION: \bv
+C     ==================================================================
+C     SUBROUTINE g_active_read_1d
+C     ==================================================================
+C     o Read an active 1D vector from file.
+C     started: Tim Smith tsmith@oden.utexas.edu 22-Oct-2019
+C     ==================================================================
+C     SUBROUTINE active_read_1d
+C     ==================================================================
+C     \ev
+
+C     !USES:
+      IMPLICIT NONE
+
+C     == global variables ==
+#include "EEPARAMS.h"
+#include "SIZE.h"
+
+C     !INPUT/OUTPUT PARAMETERS:
+C     active_var_file: filename
+C     active_var:      array
+C     g_active_var:    tangent linear  array
+C     active_var_length: array length
+C     iRec:            record number
+C     myOptimIter:     number of optimization iteration (default: 0)
+C     myThid:          thread number for this instance
+      CHARACTER*(*) active_var_file
+      _RL     active_var(*)
+      _RL     g_active_var(*)
+      INTEGER active_var_length
+      INTEGER iRec
+      INTEGER myOptimIter
+      INTEGER myThid
+      _RL     dummy
+      _RL     g_dummy
+
+C     !FUNCTIONS:
+      INTEGER  ILNBLNK
+      EXTERNAL ILNBLNK
+
+C     !LOCAL VARIABLES:
+      CHARACTER*(2) pref
+      CHARACTER*(80) fname
+      INTEGER il
+
+CEOP
+
+      pref = 'g_'
+      il   = ILNBLNK( active_var_file )
+      WRITE(fname(1:80),'(A)') ' '
+      WRITE(fname(1:2+il),'(2A)') pref, active_var_file(1:il)
+
+      CALL ACTIVE_READ_1D_RL(
+     &                 active_var_file, active_var, active_var_length,
+     &                 lAdInit, iRec,
+     &                 FORWARD_SIMULATION, myOptimIter, myThid )
+
+      CALL ACTIVE_READ_1D_RL(
+     &                 fname, g_active_var, active_var_length,
+     &                 lAdInit, iRec,
+     &                 TANGENT_SIMULATION, myOptimIter, myThid )
+
+      RETURN
+      END
+
+C---+----1----+----2----+----3----+----4----+----5----+----6----+----7-|--+----|
+CBOP
 C     !ROUTINE: g_active_write_xy
 C     !INTERFACE:
       subroutine g_active_write_xy(
@@ -694,6 +780,85 @@ CEOP
      &                 fname, g_active_var, globalFile,
      &                 useCurrentDir, iRec, myNr,
      &                 TANGENT_SIMULATION, myOptimIter, myThid )
+
+      RETURN
+      END
+
+C---+----1----+----2----+----3----+----4----+----5----+----6----+----7-|--+----|
+CBOP
+C     !ROUTINE: g_active_write_1d
+C     !INTERFACE:
+      subroutine g_active_write_1d(
+     I                           active_var_file,
+     I                           active_var,
+     I                           g_active_var,
+     I                           active_var_length,
+     I                           iRec,
+     I                           myOptimIter,
+     I                           myThid,
+     I                           dummy,
+     I                           g_dummy
+     &                         )
+
+C     !DESCRIPTION: \bv
+C     ==================================================================
+C     SUBROUTINE g_active_write_1d
+C     ==================================================================
+C     o Write an active 1D vector to file.
+C     started: Tim Smith tsmith@oden.utexas.edu 22-Oct-2019
+C     ==================================================================
+C     SUBROUTINE active_write_1d
+C     ==================================================================
+C     \ev
+
+C     !USES:
+      IMPLICIT NONE
+
+C     == global variables ==
+#include "EEPARAMS.h"
+#include "SIZE.h"
+
+C     !INPUT/OUTPUT PARAMETERS:
+C     active_var_file: filename
+C     active_var:      array
+C     g_active_var:    tangent linear  array
+C     active_var_length: array length
+C     iRec:            record number
+C     myOptimIter:     number of optimization iteration (default: 0)
+C     myThid:          thread number for this instance
+      CHARACTER*(*) active_var_file
+      _RL     active_var(*)
+      _RL     g_active_var(*)
+      INTEGER active_var_length
+      INTEGER iRec
+      INTEGER myOptimIter
+      INTEGER myThid
+      _RL     dummy
+      _RL     g_dummy
+
+C     !FUNCTIONS:
+      INTEGER  ILNBLNK
+      EXTERNAL ILNBLNK
+
+C     !LOCAL VARIABLES:
+      CHARACTER*(2) pref
+      CHARACTER*(80) fname
+      INTEGER il
+
+CEOP
+
+      pref = 'g_'
+      il   = ILNBLNK( active_var_file )
+      WRITE(fname(1:80),'(A)') ' '
+      WRITE(fname(1:2+il),'(2A)') pref, active_var_file(1:il)
+
+      CALL ACTIVE_WRITE_1D_RL(
+     &                 active_var_file, active_var, active_var_length,
+     &                 iRec, FORWARD_SIMULATION, myOptimIter, myThid )
+
+      CALL ACTIVE_WRITE_1D_RL(
+     &                 fname, g_active_var, active_var_length,
+     &                 iRec, TANGENT_SIMULATION, myOptimIter, myThid )
 
       RETURN
       END


### PR DESCRIPTION
## What changes does this PR introduce?
(Bug fix, feature, docs update, ...)

This introduces the active read and write routines for simple 1D vectors. This should cover all flavors (forward, TLM, adjoint) of necessary read and write routines, as well as flow directives for TAF.

## What is the current behaviour? 
(You can also link to an open issue here)

There aren't any existing active read/write routines for 1D vectors, just fields of any other shape and form.

## What is the new behaviour 
(if this is a feature change)?


## Does this PR introduce a breaking change? 
(What changes might users need to make in their application due to this PR?)

It should not

## Other information:

This came up in conversation with @mmazloff, and is hopefully useful to someone. This would most likely be useful for letting one solve an optimization problem in observation space, corresponding to the dual formulation of the 4D Var problem.

If it is useful, I also have a branch which implements a 1D vector cost function. I realized that I didn't need any of this for my immediate purposes, but if that is useful at all I'd be happy to open another pull request. Interested parties (@mmazloff?) can check out [this branch](https://github.com/timothyas/MITgcm/tree/gencost_vector_costfunction), and specifically [these lines of ecco_cost_final](https://github.com/timothyas/MITgcm/blob/41c711582b838ae3c7ac3d12915631d11d831546/pkg/ecco/ecco_cost_final.F#L1633-L1650). Otherwise, it'll probably die slowly in the depths of my MITgcm history


## Suggested addition to `tag-index`
(To avoid unnecessary merge conflicts, please don't update `tag-index`. One of the admins will do that when merging your pull request.)

add active read and write routines for 1D vectors