### PR TITLE
Fix small typos in ecco package

### DIFF
--- a/doc/tag-index
+++ b/doc/tag-index
@@ -1,6 +1,8 @@
     Notes on tags used in MITgcmUV
     ==============================
 
+o pkg/ecco:
+  - fix character length when checking for m_trHeat, m_trSalt & m_horflux_vol.
 o pkg/autodiff:
   - add active read and write routines for global 1D vectors, to be used for
     compressed cost function vectors (note: not used yet, example to come soon).

--- a/pkg/ecco/ecco_check.F
+++ b/pkg/ecco/ecco_check.F
@@ -535,34 +535,34 @@ c-- not checked here. also not checked for variwei at the moment
 
 C ---
 C Warn the user that this is a less tested objective function
-C TBD: Write a more consistent transport objective function 
+C TBD: Write a more consistent transport objective function
 C ---
 
           if (gencost_barfile(k)(1:7).eq.'m_trVol') then
-           WRITE(msgBuf,'(A)') 
+           WRITE(msgBuf,'(A)')
      &   '** WARNING ** ECCO_CHECK: cost_gencost_transp.F not tested.'
            CALL PRINT_MESSAGE( msgBuf, errorMessageUnit,
      &                         SQUEEZE_RIGHT, myThid )
-           WRITE(msgBuf,'(A)') 
+           WRITE(msgBuf,'(A)')
      &   ' See m_horflux_vol via cost_gencost_boxmean.F.'
            CALL PRINT_MESSAGE( msgBuf, errorMessageUnit,
      &                         SQUEEZE_RIGHT, myThid )
           elseif( (gencost_barfile(k)(1:8).eq.'m_trHeat').or.
      &            (gencost_barfile(k)(1:8).eq.'m_trSalt') ) then
-           WRITE(msgBuf,'(2A)') 
+           WRITE(msgBuf,'(2A)')
      &   '** WARNING ** ECCO_CHECK: m_tr[Heat,Salt] to be used with',
      &   ' caution because:'
            CALL PRINT_MESSAGE( msgBuf, errorMessageUnit,
      &                         SQUEEZE_RIGHT, myThid )
-           WRITE(msgBuf,'(A)') 
+           WRITE(msgBuf,'(A)')
      &  '  (1) advection inconsistent unless ENUM_CENTERED_2ND is used'
            CALL PRINT_MESSAGE( msgBuf, errorMessageUnit,
      &                         SQUEEZE_RIGHT, myThid )
-           WRITE(msgBuf,'(A)') 
+           WRITE(msgBuf,'(A)')
      &  '  (2) bolus velocities not included'
            CALL PRINT_MESSAGE( msgBuf, errorMessageUnit,
      &                         SQUEEZE_RIGHT, myThid )
-           WRITE(msgBuf,'(A)') 
+           WRITE(msgBuf,'(A)')
      &  '  (3) diffusion components not included'
            CALL PRINT_MESSAGE( msgBuf, errorMessageUnit,
      &                         SQUEEZE_RIGHT, myThid )

--- a/pkg/ecco/ecco_check.F
+++ b/pkg/ecco/ecco_check.F
@@ -505,7 +505,7 @@ c-- (upper/lower-case matters) in cost_gencost_customize
      &          (gencost_barfile(k)(1:13).EQ.'m_boxmean_eta').OR.
      &          (gencost_barfile(k)(1:14).EQ.'m_boxmean_salt').OR.
      &          (gencost_barfile(k)(1:17).EQ.'m_boxmean_ptracer').OR.
-     &          (gencost_barfile(k)(1:14).EQ.'m_horflux_vol')
+     &          (gencost_barfile(k)(1:13).EQ.'m_horflux_vol')
      &        )) then
             using_gencost(k)=.FALSE.
             il=ilnblnk(gencost_barfile(k))

--- a/pkg/ecco/ecco_readparms.F
+++ b/pkg/ecco/ecco_readparms.F
@@ -726,7 +726,7 @@ C--   load masks if needed:
       do k=1,NGENCOST
            kk=gencost_msk_pointer3d(k)
            if ( ( gencost_mask(k) .NE. ' ' ).AND.
-     &          (gencost_flag(k).EQ.-3 .or. 
+     &          (gencost_flag(k).EQ.-3 .or.
      &           gencost_flag(k).eq.-4     ) ) then
 c
             il = ilnblnk(gencost_mask(k))

--- a/pkg/ecco/ecco_readparms.F
+++ b/pkg/ecco/ecco_readparms.F
@@ -709,8 +709,8 @@ c identified three dimensional variables
      &        (gencost_barfile(k)(1:7).EQ.'m_kapgm').OR.
      &        (gencost_barfile(k)(1:9).EQ.'m_kapredi').OR.
      &        (gencost_barfile(k)(1:7).EQ.'m_trVol').OR.
-     &        (gencost_barfile(k)(1:9).EQ.'m_trHeat').OR.
-     &        (gencost_barfile(k)(1:9).EQ.'m_trSalt')
+     &        (gencost_barfile(k)(1:8).EQ.'m_trHeat').OR.
+     &        (gencost_barfile(k)(1:8).EQ.'m_trSalt')
      &       )
      &        gencost_is3d(k)=.TRUE.
 


### PR DESCRIPTION
* in ecco_check.F and ecco_readparms.F, correct character length when
  checking for m_tr[Heat/Salt] and m_horflux_vol

## What changes does this PR introduce?
Bug fix

## Does this PR introduce a breaking change? 
No
