### PR TITLE
Minor bug fix in ctrl_init

### DIFF
--- a/pkg/ctrl/ctrl_init.F
+++ b/pkg/ctrl/ctrl_init.F
@@ -72,7 +72,7 @@ c     == local variables ==
 
 #ifdef ALLOW_GENTIM2D_CONTROL
       CHARACTER*(MAX_LEN_FNAM) fnamegen
-      INTEGER ilgen, k2, diffrecFull, endrecFull
+      INTEGER ilgen, ilfnam, k2, diffrecFull, endrecFull
 #endif
 
 c     == external ==
@@ -897,16 +897,18 @@ C
 C
         write(fnamegen(1:MAX_LEN_FNAM),'(2a)')
      &       xx_gentim2d_file(iarr)(1:ilgen),'.effective'
+        ilfnam=ilnblnk(fnamegen)
         call ctrl_init_ctrlvar (
-     &       fnamegen(1:ilgen+10),
+     &       fnamegen(1:ilfnam),
      &       300+iarr, 400+iarr,
      &       diffrecFull, startrec, endrecFull,
      &       snx, sny, 1, 'c', 'xy', myThid )
 C
         write(fnamegen(1:MAX_LEN_FNAM),'(2a)')
      &       xx_gentim2d_file(iarr)(1:ilgen),'.tmp'
+        ilfnam=ilnblnk(fnamegen)
         call ctrl_init_ctrlvar (
-     &       fnamegen(1:ilgen+4),
+     &       fnamegen(1:ilfnam),
      &       300+iarr, 400+iarr,
      &       diffrecFull, startrec, endrecFull,
      &       snx, sny, 1, 'c', 'xy', myThid )

--- a/pkg/ctrl/ctrl_init.F
+++ b/pkg/ctrl/ctrl_init.F
@@ -912,7 +912,7 @@ C
      &       snx, sny, 1, 'c', 'xy', myThid )
 C
         call ctrl_init_ctrlvar (
-     &       xx_gentim2d_file(iarr)(1:MAX_LEN_FNAM),
+     &       xx_gentim2d_file(iarr)(1:ilgen),
      &       300+iarr, 400+iarr,
      &       diffrec, startrec, endrec,
      &       snx, sny, 1, 'c', 'xy', myThid )

--- a/pkg/ctrl/ctrl_init.F
+++ b/pkg/ctrl/ctrl_init.F
@@ -819,13 +819,14 @@ c----------------------------------------------------------------------
 c--
 #ifdef ALLOW_GENARR2D_CONTROL
        do iarr = 1, maxCtrlArr2D
+        ilgen=ilnblnk( xx_genarr2d_file(iarr) )
 #ifndef ALLOW_OPENAD
         if (xx_genarr2d_weight(iarr).NE.' ')
      &  call ctrl_init_ctrlvar (
 #else
         call ctrl_init_ctrlvar (
 #endif
-     &       xx_genarr2d_file(iarr)(1:MAX_LEN_FNAM),
+     &       xx_genarr2d_file(iarr)(1:ilgen),
      &       100+iarr, 200+iarr, 1, 1, 1,
      &       snx, sny, 1, 'c', 'xy', myThid )
 
@@ -836,13 +837,14 @@ c----------------------------------------------------------------------
 c--
 #ifdef ALLOW_GENARR3D_CONTROL
        do iarr = 1, maxCtrlArr3D
+        ilgen=ilnblnk( xx_genarr3d_file(iarr) )
 #ifndef ALLOW_OPENAD
         if (xx_genarr3d_weight(iarr).NE.' ')
      &  call ctrl_init_ctrlvar (
 #else
         call ctrl_init_ctrlvar (
 #endif
-     &       xx_genarr3d_file(iarr)(1:MAX_LEN_FNAM),
+     &       xx_genarr3d_file(iarr)(1:ilgen),
      &       200+iarr, 300+iarr, 1, 1, 1,
      &       snx, sny, nr, 'c', '3d', myThid )
        enddo
@@ -859,8 +861,8 @@ c--
           xx_gentim2d_startdate2(iarr)=startdate_2
         endif
 #endif
-
-        call ctrl_init_rec ( xx_gentim2d_file(iarr)(1:MAX_LEN_FNAM),
+        ilgen=ilnblnk( xx_gentim2d_file(iarr) )
+        call ctrl_init_rec ( xx_gentim2d_file(iarr)(1:ilgen),
      I       xx_gentim2d_startdate1(iarr), 
      I       xx_gentim2d_startdate2(iarr), 
      I       xx_gentim2d_period(iarr), 
@@ -893,20 +895,18 @@ C
          endif
         enddo
 C
-        ilgen=ilnblnk( xx_gentim2d_file(iarr) )
         write(fnamegen(1:MAX_LEN_FNAM),'(2a)')
      &       xx_gentim2d_file(iarr)(1:ilgen),'.effective'
         call ctrl_init_ctrlvar (
-     &       fnamegen(1:MAX_LEN_FNAM),
+     &       fnamegen(1:ilgen+10),
      &       300+iarr, 400+iarr,
      &       diffrecFull, startrec, endrecFull,
      &       snx, sny, 1, 'c', 'xy', myThid )
 C
-        ilgen=ilnblnk( xx_gentim2d_file(iarr) )
         write(fnamegen(1:MAX_LEN_FNAM),'(2a)')
      &       xx_gentim2d_file(iarr)(1:ilgen),'.tmp'
         call ctrl_init_ctrlvar (
-     &       fnamegen(1:MAX_LEN_FNAM),
+     &       fnamegen(1:ilgen+4),
      &       300+iarr, 400+iarr,
      &       diffrecFull, startrec, endrecFull,
      &       snx, sny, 1, 'c', 'xy', myThid )


### PR DESCRIPTION
## What changes does this PR introduce?
(Bug fix, feature, docs update, ...)

A minor bug fix. One of the gentim2d names was specified as name(1:MAX_LEN_MBUF) rather than name(1:ilgen). Somehow, this never caused any problems for forward or adjoint runs, but creates an issue for the tangent linear model.

## What is the current behaviour? 
(You can also link to an open issue here)

This causes the TLM with gentim2d controls to break during initialization.

## What is the new behaviour 
(if this is a feature change)?


## Does this PR introduce a breaking change? 
(What changes might users need to make in their application due to this PR?)

Nope

## Other information:


## Suggested addition to `tag-index`
(To avoid unnecessary merge conflicts, please don't update `tag-index`. One of the admins will do that when merging your pull request.)

Not sure if this is necessary, but if so, perhaps:

- Minor bug fix for gentim2d controls fixes tangent linear model initialization