### PR TITLE
mdsio_read_meta.F 

### DIFF
--- a/pkg/mdsio/mdsio_read_meta.F
+++ b/pkg/mdsio/mdsio_read_meta.F
@@ -303,7 +303,7 @@ C-    Read the number of records
           IF ( iL.GE.25 ) THEN
             READ(lineBuf(15:iL),'(I10)') nRecords
           ELSE
-            READ(lineBuf(15:iL),'(I5)') nRecords
+            READ(lineBuf(15:iL),'(I6)') nRecords
           ENDIF
           iL = 0
          ENDIF


### PR DESCRIPTION
Increase the format length for nrecords from I5 to I6 when reading a meta file. Otherwise, It cannot correctly read nrecords for a pickup file that was generated using checkpoint66g (maybe some other checkpoints as well).

## What changes does this PR introduce?
(Bug fix, feature, docs update, ...)
Bug fix of mdsio_read_meta.F 


## What is the current behaviour? 
(You can also link to an open issue here)
It cannot correctly read nrecords for a pickup file that was generated using checkpoint66g (maybe some other checkpoints as well). For checkpoint66g, mdsio_write_meta.F uses a format length of I6 for nrecords (line 160), while mdsio_read_meta.F uses a format length of I5 for nrecords (line 306). 

## What is the new behaviour 
(if this is a feature change)?
It can correctly read nrecords.

## Does this PR introduce a breaking change? 
(What changes might users need to make in their application due to this PR?)


## Other information:


## Suggested addition to `tag-index`
(To avoid unnecessary merge conflicts, please don't update `tag-index`. One of the admins will do that when merging your pull request.)