### PR TITLE
Doc PDF link fixup

### DIFF
--- a/doc/manual_references.bib
+++ b/doc/manual_references.bib
@@ -1326,7 +1326,7 @@ in the Earth's atmosphere.  },
   number =   {C3},
   pages =  {5733-5752},
   doi   = {10.1029/96JC02776},
-  url      =     {http://mitgcm.org/pdfs/96JC02775.pdf},
+  url      =     {http://mitgcm.org/pdfs/96JC02776.pdf},
 }
 
 
@@ -1340,7 +1340,7 @@ in the Earth's atmosphere.  },
   number =   {C3},
   pages =  {5753-5766},
   doi   = {10.1029/96JC02775},
-  url      =     {http://mitgcm.org/pdfs/96JC02776.pdf},
+  url      =     {http://mitgcm.org/pdfs/96JC02775.pdf},
 }
 
 


### PR DESCRIPTION
These two PDF links were swapped; now fixed.

I assume this will propagate through to the readthedocs documentation next time it's rebuilt.