### PR TITLE
Fix for _RS = real*4

### DIFF
--- a/doc/tag-index
+++ b/doc/tag-index
@@ -1,6 +1,9 @@
     Notes on tags used in MITgcmUV
     ==============================
 
+o pkg/seaice:
+  - fix diagnostics additions (from PR #348) for case _RS is real*4.
+
 checkpoint67s (2020/07/30)
 o eesupp/src:
   - Improve formatting of output for large grids and many processors:

--- a/pkg/seaice/seaice_dynsolver.F
+++ b/pkg/seaice/seaice_dynsolver.F
@@ -79,7 +79,8 @@ C     bi,bj  :: tile counters
       _RL sig2   (1-OLx:sNx+OLx,1-OLy:sNy+OLy)
       _RL sig12  (1-OLx:sNx+OLx,1-OLy:sNy+OLy)
       _RL sigp, sigm, sigTmp, recip_prs
-      _RL areaW, areaS, COSWAT, SINWAT
+      _RL areaW, areaS, COSWAT
+      _RS SINWAT
       INTEGER kSrf
       LOGICAL diag_SIsigma_isOn, diag_SIshear_isOn
       LOGICAL diag_SIenpi_isOn, diag_SIenpot_isOn


### PR DESCRIPTION
Since fCori is declared _RS, got compiler error in expression:
 SIGN(SINWAT, fCori) if SINWAT is not the same type as fCori.
Change declaration of SINWAT to be _RS (as in may other pkg/seaice S/R).

## What changes does this PR introduce?
Fix minor bug, responsible fro several experiment to fail when running testreport with
-ur4 & -devel, see: http://mitgcm.org/testing/results/2020_08/tr_jaures_20200801_6/summary.txt

## What is the current behaviour? 
The two arguments of intrinsic function SIGN (i.e., SINWAT & fCori) have different types when _RS is real*4

## What is the new behaviour 
Fixed the same way as in many other pkg/seaice S/R

## Does this PR introduce a breaking change? 
no

## Other information:

## Suggested addition to `tag-index`
o pkg/seaice:
 - fix diagnostics additions (from PR #348) for case _RS is real*4.