### PR TITLE
Mdsio section

### DIFF
--- a/eesupp/src/gather_xz_r4.F
+++ b/eesupp/src/gather_xz_r4.F
@@ -75,20 +75,12 @@ C     safer to reset to zero to avoid unknown values in output file
           DO bj=1,nSy
            DO bi=1,nSx
              tN = W2_myTileList(bi,bj)
-             IF  ( exch2_tNx(tN) .GT. xSize ) THEN
-C-           tile y-size larger than glob-size : make a long line
-               iGjLoc = exch2_mydNx(tN)
-               !jGjLoc = 0
-             ELSE
-C-           default (face fit into global-IO-array)
-               iGjLoc = 0
-               !jGjLoc = 1
-             ENDIF
+             iGjLoc = 0
 
-             DO i=1,sNx
 #ifdef TARGET_NEC_SX
 !cdir novector
 #endif
+             DO i=1,sNx
                iG=exch2_txGlobalo(tN)+iGjLoc*(i-1)
                gloBuff(iG) = myField(i,bi,bj)
              ENDDO
@@ -105,10 +97,11 @@ C-           default (face fit into global-IO-array)
 
           DO bj=1,nSy
            DO bi=1,nSx
-            DO i=1,sNx
+
 #ifdef TARGET_NEC_SX
 !cdir novector
 #endif
+            DO i=1,sNx
                iG = iBase+(bi-1)*sNx+i
                gloBuff(iG) = myField(i,bi,bj)
             ENDDO
@@ -148,18 +141,12 @@ C--   Process 0 gathers the local arrays into the global buffer.
           DO bj=1,nSy
            DO bi=1,nSx
              tN = W2_procTileList(bi,bj,np)
-             IF  ( exch2_tNx(tN) .GT. xSize ) THEN
-C-           tile y-size larger than glob-size : make a long line
-               iGjLoc = 0
-             ELSE
-C-           default (face fit into global-IO-array)
-               iGjLoc = 1
-             ENDIF
+             iGjLoc = 0
 
-             DO i=1,sNx
 #ifdef TARGET_NEC_SX
 !cdir novector
 #endif
+             DO i=1,sNx
               iG=exch2_txGlobalo(tN)+iGjLoc*(i-1)
               gloBuff(iG) = temp(i,bi,bj)
              ENDDO

--- a/eesupp/src/gather_xz_r4.F
+++ b/eesupp/src/gather_xz_r4.F
@@ -2,12 +2,12 @@
 #include "CPP_EEOPTIONS.h"
 
 CBOP
-C !ROUTINE: GATHER_YZ_R8
+C !ROUTINE: GATHER_XZ_R4
 C !INTERFACE:
-      SUBROUTINE GATHER_YZ_R8(
+      SUBROUTINE GATHER_XZ_R4(
      O                  gloBuff,
      I                  myField,
-     I                  ySize,
+     I                  xSize,
      I                  useExch2GlobLayOut,
      I                  zeroBuff,
      I                  myThid )
@@ -27,16 +27,16 @@ C     !USES:
 #endif /* ALLOW_EXCH2 */
 
 C     !INPUT/OUTPUT PARAMETERS:
-C gloBuff   ( _R8 ) :: full-domain 2D IO-buffer array             (Output)
-C myField   ( _R8 ) :: tiled, local (i.e. my Proc. tiles) 2D array (Input)
-C ySize    (integer):: global buffer 1rst dim (y)
+C gloBuff   ( _R4 ) :: full-domain 2D IO-buffer array             (Output)
+C myField   ( _R4 ) :: tiled, local (i.e. my Proc. tiles) 2D array (Input)
+C xSize    (integer):: global buffer 1rst dim (y)
 C useExch2GlobLayOut:: =T: Use Exch2 global-map layout (only with EXCH2)
 C zeroBuff (logical):: =T: initialise the buffer to zero before copy
 C myThid   (integer):: my Thread Id number
 
-      INTEGER ySize
-      _R8     gloBuff(ySize)
-      _R8     myField(1:sNy,nSx,nSy)
+      INTEGER xSize
+      _R4     gloBuff(xSize)
+      _R4     myField(1:sNx,nSx,nSy)
       LOGICAL useExch2GlobLayOut
       LOGICAL zeroBuff
       INTEGER myThid
@@ -52,7 +52,7 @@ C !LOCAL VARIABLES:
 #endif /* ALLOW_EXCH2 */
 #ifdef ALLOW_USE_MPI
       INTEGER np, pId
-      _R8     temp(1:sNy,nSx,nSy)
+      _R4     temp(1:sNx,nSx,nSy)
       INTEGER istatus(MPI_STATUS_SIZE), ierr
       INTEGER lbuff, idest, itag, ready_to_receive
 #endif /* ALLOW_USE_MPI */
@@ -67,30 +67,30 @@ C--   Process 0 fills-in its local data
 C--   If using blank-tiles, buffer will not be completely filled;
 C     safer to reset to zero to avoid unknown values in output file
           IF ( zeroBuff ) THEN
-            DO j=1,ySize
-               gloBuff(j) = 0.
+            DO i=1,xSize
+               gloBuff(i) = 0.
             ENDDO
           ENDIF
 
           DO bj=1,nSy
            DO bi=1,nSx
              tN = W2_myTileList(bi,bj)
-             IF  ( exch2_tNy(tN) .GT. ySize ) THEN
+             IF  ( exch2_tNx(tN) .GT. xSize ) THEN
 C-           tile y-size larger than glob-size : make a long line
-               !iGjLoc = exch2_mydNx(tN)
-               jGjLoc = 0
+               iGjLoc = exch2_mydNx(tN)
+               !jGjLoc = 0
              ELSE
 C-           default (face fit into global-IO-array)
-               !iGjLoc = 0
-               jGjLoc = 1
+               iGjLoc = 0
+               !jGjLoc = 1
              ENDIF
 
-             DO j=1,sNy
+             DO i=1,sNx
 #ifdef TARGET_NEC_SX
 !cdir novector
 #endif
-               jG=exch2_tyGlobalo(tN)+jGjLoc*(j-1)
-               gloBuff(jG) = myField(j,bi,bj)
+               iG=exch2_txGlobalo(tN)+iGjLoc*(i-1)
+               gloBuff(iG) = myField(i,bi,bj)
              ENDDO
 
            ENDDO
@@ -101,16 +101,16 @@ C-           default (face fit into global-IO-array)
         IF (.TRUE.) THEN
 #endif /* ALLOW_EXCH2 */
 
-          jBase = myYGlobalLo-1
+          iBase = myXGlobalLo-1
 
           DO bj=1,nSy
            DO bi=1,nSx
-            DO j=1,sNy
+            DO i=1,sNx
 #ifdef TARGET_NEC_SX
 !cdir novector
 #endif
-               jG = jBase+(bj-1)*sNy+j
-               gloBuff(jG) = myField(j,bi,bj)
+               iG = iBase+(bi-1)*sNx+i
+               gloBuff(iG) = myField(i,bi,bj)
             ENDDO
            ENDDO
           ENDDO
@@ -124,7 +124,7 @@ C-    end if myProcId = 0
 #ifdef ALLOW_USE_MPI
       IF ( usingMPI ) THEN
 
-       lbuff = sNy*nSy
+       lbuff = sNx*nSx
        idest = 0
        itag  = 0
        ready_to_receive = 0
@@ -138,7 +138,7 @@ C--   Process 0 polls and receives data from each process in turn
          CALL MPI_SEND (ready_to_receive, 1, MPI_INTEGER,
      &           pId, itag, MPI_COMM_MODEL, ierr)
 #endif
-         CALL MPI_RECV (temp, lbuff, _MPI_TYPE_R8,
+         CALL MPI_RECV (temp, lbuff, _MPI_TYPE_R4,
      &           pId, itag, MPI_COMM_MODEL, istatus, ierr)
 
 C--   Process 0 gathers the local arrays into the global buffer.
@@ -148,20 +148,20 @@ C--   Process 0 gathers the local arrays into the global buffer.
           DO bj=1,nSy
            DO bi=1,nSx
              tN = W2_procTileList(bi,bj,np)
-             IF  ( exch2_tNy(tN) .GT. ySize ) THEN
+             IF  ( exch2_tNx(tN) .GT. xSize ) THEN
 C-           tile y-size larger than glob-size : make a long line
-               jGjLoc = 0
+               iGjLoc = 0
              ELSE
 C-           default (face fit into global-IO-array)
-               jGjLoc = 1
+               iGjLoc = 1
              ENDIF
 
-             DO j=1,sNy
+             DO i=1,sNx
 #ifdef TARGET_NEC_SX
 !cdir novector
 #endif
-              jG=exch2_tyGlobalo(tN)+jGjLoc*(j-1)
-              gloBuff(jG) = temp(j,bi,bj)
+              iG=exch2_txGlobalo(tN)+iGjLoc*(i-1)
+              gloBuff(iG) = temp(i,bi,bj)
              ENDDO
 
            ENDDO
@@ -172,17 +172,17 @@ C-           default (face fit into global-IO-array)
          IF (.TRUE.) THEN
 #endif /* ALLOW_EXCH2 */
 
-          jBase = mpi_myYGlobalLo(np)-1
+          iBase = mpi_myXGlobalLo(np)-1
 
           DO bj=1,nSy
            DO bi=1,nSx
-            DO j=1,sNy
+            DO i=1,sNx
 #ifdef TARGET_NEC_SX
 !cdir novector
 #endif
-             IF (ABS(temp(j,bi,bj)).gt.0. _d 0) THEN
-               jG = jBase+(bj-1)*sNy+j
-               gloBuff(jG) = temp(j,bi,bj)
+             IF (ABS(temp(i,bi,bj)).gt.0. _d 0) THEN
+               iG = iBase+(bi-1)*sNx+i
+               gloBuff(iG) = temp(i,bi,bj)
              ENDIF
             ENDDO
 
@@ -202,7 +202,7 @@ C--   All proceses except 0 wait to be polled then send local array
          CALL MPI_RECV (ready_to_receive, 1, MPI_INTEGER,
      &        idest, itag, MPI_COMM_MODEL, istatus, ierr)
 #endif
-         CALL MPI_SEND (myField, lbuff, _MPI_TYPE_R8,
+         CALL MPI_SEND (myField, lbuff, _MPI_TYPE_R4,
      &        idest, itag, MPI_COMM_MODEL, ierr)
 
        ENDIF

--- a/eesupp/src/gather_xz_r8.F
+++ b/eesupp/src/gather_xz_r8.F
@@ -75,20 +75,12 @@ C     safer to reset to zero to avoid unknown values in output file
           DO bj=1,nSy
            DO bi=1,nSx
              tN = W2_myTileList(bi,bj)
-             IF  ( exch2_tNx(tN) .GT. xSize ) THEN
-C-           tile y-size larger than glob-size : make a long line
-               iGjLoc = exch2_mydNx(tN)
-               !jGjLoc = 0
-             ELSE
-C-           default (face fit into global-IO-array)
-               iGjLoc = 0
-               !jGjLoc = 1
-             ENDIF
+             iGjLoc = 0
 
-             DO i=1,sNx
 #ifdef TARGET_NEC_SX
 !cdir novector
 #endif
+             DO i=1,sNx
                iG=exch2_txGlobalo(tN)+iGjLoc*(i-1)
                gloBuff(iG) = myField(i,bi,bj)
              ENDDO
@@ -105,10 +97,11 @@ C-           default (face fit into global-IO-array)
 
           DO bj=1,nSy
            DO bi=1,nSx
-            DO i=1,sNx
+
 #ifdef TARGET_NEC_SX
 !cdir novector
 #endif
+            DO i=1,sNx
                iG = iBase+(bi-1)*sNx+i
                gloBuff(iG) = myField(i,bi,bj)
             ENDDO
@@ -148,18 +141,12 @@ C--   Process 0 gathers the local arrays into the global buffer.
           DO bj=1,nSy
            DO bi=1,nSx
              tN = W2_procTileList(bi,bj,np)
-             IF  ( exch2_tNx(tN) .GT. xSize ) THEN
-C-           tile y-size larger than glob-size : make a long line
-               iGjLoc = 0
-             ELSE
-C-           default (face fit into global-IO-array)
-               iGjLoc = 1
-             ENDIF
+             iGjLoc = 0
 
-             DO i=1,sNx
 #ifdef TARGET_NEC_SX
 !cdir novector
 #endif
+             DO i=1,sNx
               iG=exch2_txGlobalo(tN)+iGjLoc*(i-1)
               gloBuff(iG) = temp(i,bi,bj)
              ENDDO

--- a/eesupp/src/gather_xz_r8.F
+++ b/eesupp/src/gather_xz_r8.F
@@ -2,12 +2,12 @@
 #include "CPP_EEOPTIONS.h"
 
 CBOP
-C !ROUTINE: GATHER_YZ_R8
+C !ROUTINE: GATHER_XZ_R8
 C !INTERFACE:
-      SUBROUTINE GATHER_YZ_R8(
+      SUBROUTINE GATHER_XZ_R8(
      O                  gloBuff,
      I                  myField,
-     I                  ySize,
+     I                  xSize,
      I                  useExch2GlobLayOut,
      I                  zeroBuff,
      I                  myThid )
@@ -29,14 +29,14 @@ C     !USES:
 C     !INPUT/OUTPUT PARAMETERS:
 C gloBuff   ( _R8 ) :: full-domain 2D IO-buffer array             (Output)
 C myField   ( _R8 ) :: tiled, local (i.e. my Proc. tiles) 2D array (Input)
-C ySize    (integer):: global buffer 1rst dim (y)
+C xSize    (integer):: global buffer 1rst dim (y)
 C useExch2GlobLayOut:: =T: Use Exch2 global-map layout (only with EXCH2)
 C zeroBuff (logical):: =T: initialise the buffer to zero before copy
 C myThid   (integer):: my Thread Id number
 
-      INTEGER ySize
-      _R8     gloBuff(ySize)
-      _R8     myField(1:sNy,nSx,nSy)
+      INTEGER xSize
+      _R8     gloBuff(xSize)
+      _R8     myField(1:sNx,nSx,nSy)
       LOGICAL useExch2GlobLayOut
       LOGICAL zeroBuff
       INTEGER myThid
@@ -52,7 +52,7 @@ C !LOCAL VARIABLES:
 #endif /* ALLOW_EXCH2 */
 #ifdef ALLOW_USE_MPI
       INTEGER np, pId
-      _R8     temp(1:sNy,nSx,nSy)
+      _R8     temp(1:sNx,nSx,nSy)
       INTEGER istatus(MPI_STATUS_SIZE), ierr
       INTEGER lbuff, idest, itag, ready_to_receive
 #endif /* ALLOW_USE_MPI */
@@ -67,30 +67,30 @@ C--   Process 0 fills-in its local data
 C--   If using blank-tiles, buffer will not be completely filled;
 C     safer to reset to zero to avoid unknown values in output file
           IF ( zeroBuff ) THEN
-            DO j=1,ySize
-               gloBuff(j) = 0.
+            DO i=1,xSize
+               gloBuff(i) = 0.
             ENDDO
           ENDIF
 
           DO bj=1,nSy
            DO bi=1,nSx
              tN = W2_myTileList(bi,bj)
-             IF  ( exch2_tNy(tN) .GT. ySize ) THEN
+             IF  ( exch2_tNx(tN) .GT. xSize ) THEN
 C-           tile y-size larger than glob-size : make a long line
-               !iGjLoc = exch2_mydNx(tN)
-               jGjLoc = 0
+               iGjLoc = exch2_mydNx(tN)
+               !jGjLoc = 0
              ELSE
 C-           default (face fit into global-IO-array)
-               !iGjLoc = 0
-               jGjLoc = 1
+               iGjLoc = 0
+               !jGjLoc = 1
              ENDIF
 
-             DO j=1,sNy
+             DO i=1,sNx
 #ifdef TARGET_NEC_SX
 !cdir novector
 #endif
-               jG=exch2_tyGlobalo(tN)+jGjLoc*(j-1)
-               gloBuff(jG) = myField(j,bi,bj)
+               iG=exch2_txGlobalo(tN)+iGjLoc*(i-1)
+               gloBuff(iG) = myField(i,bi,bj)
              ENDDO
 
            ENDDO
@@ -101,16 +101,16 @@ C-           default (face fit into global-IO-array)
         IF (.TRUE.) THEN
 #endif /* ALLOW_EXCH2 */
 
-          jBase = myYGlobalLo-1
+          iBase = myXGlobalLo-1
 
           DO bj=1,nSy
            DO bi=1,nSx
-            DO j=1,sNy
+            DO i=1,sNx
 #ifdef TARGET_NEC_SX
 !cdir novector
 #endif
-               jG = jBase+(bj-1)*sNy+j
-               gloBuff(jG) = myField(j,bi,bj)
+               iG = iBase+(bi-1)*sNx+i
+               gloBuff(iG) = myField(i,bi,bj)
             ENDDO
            ENDDO
           ENDDO
@@ -124,7 +124,7 @@ C-    end if myProcId = 0
 #ifdef ALLOW_USE_MPI
       IF ( usingMPI ) THEN
 
-       lbuff = sNy*nSy
+       lbuff = sNx*nSx
        idest = 0
        itag  = 0
        ready_to_receive = 0
@@ -148,20 +148,20 @@ C--   Process 0 gathers the local arrays into the global buffer.
           DO bj=1,nSy
            DO bi=1,nSx
              tN = W2_procTileList(bi,bj,np)
-             IF  ( exch2_tNy(tN) .GT. ySize ) THEN
+             IF  ( exch2_tNx(tN) .GT. xSize ) THEN
 C-           tile y-size larger than glob-size : make a long line
-               jGjLoc = 0
+               iGjLoc = 0
              ELSE
 C-           default (face fit into global-IO-array)
-               jGjLoc = 1
+               iGjLoc = 1
              ENDIF
 
-             DO j=1,sNy
+             DO i=1,sNx
 #ifdef TARGET_NEC_SX
 !cdir novector
 #endif
-              jG=exch2_tyGlobalo(tN)+jGjLoc*(j-1)
-              gloBuff(jG) = temp(j,bi,bj)
+              iG=exch2_txGlobalo(tN)+iGjLoc*(i-1)
+              gloBuff(iG) = temp(i,bi,bj)
              ENDDO
 
            ENDDO
@@ -172,17 +172,17 @@ C-           default (face fit into global-IO-array)
          IF (.TRUE.) THEN
 #endif /* ALLOW_EXCH2 */
 
-          jBase = mpi_myYGlobalLo(np)-1
+          iBase = mpi_myXGlobalLo(np)-1
 
           DO bj=1,nSy
            DO bi=1,nSx
-            DO j=1,sNy
+            DO i=1,sNx
 #ifdef TARGET_NEC_SX
 !cdir novector
 #endif
-             IF (ABS(temp(j,bi,bj)).gt.0. _d 0) THEN
-               jG = jBase+(bj-1)*sNy+j
-               gloBuff(jG) = temp(j,bi,bj)
+             IF (ABS(temp(i,bi,bj)).gt.0. _d 0) THEN
+               iG = iBase+(bi-1)*sNx+i
+               gloBuff(iG) = temp(i,bi,bj)
              ENDIF
             ENDDO
 

--- a/eesupp/src/gather_yz_r4.F
+++ b/eesupp/src/gather_yz_r4.F
@@ -1,97 +1,215 @@
-#include "CPP_OPTIONS.h"
+#include "PACKAGES_CONFIG.h"
+#include "CPP_EEOPTIONS.h"
 
-      SUBROUTINE GATHER_YZ_R4( global, local, myThid )
-C     Gather elements of a y-z array from all mpi processes to process 0.
+CBOP
+C !ROUTINE: GATHER_YZ_R4
+C !INTERFACE:
+      SUBROUTINE GATHER_YZ_R4(
+     O                  gloBuff,
+     I                  myField,
+     I                  ySize,
+     I                  useExch2GlobLayOut,
+     I                  zeroBuff,
+     I                  myThid )
+C !DESCRIPTION:
+C     Gather elements of a global 2-D array from all mpi processes to process 0.
+C     Note: done by Master-Thread ; might need barrier calls before and after
+C           this S/R call.
+
+C     !USES:
       IMPLICIT NONE
 #include "SIZE.h"
 #include "EEPARAMS.h"
 #include "EESUPPORT.h"
-C     mythid - thread number for this instance of the routine.
-C     global,local - working arrays used to transfer 2-D fields
-      INTEGER mythid 
-      _R4     global(Ny)
-      _R4     local(sNy,nSx,nSy)
+#ifdef ALLOW_EXCH2
+#include "W2_EXCH2_SIZE.h"
+#include "W2_EXCH2_TOPOLOGY.h"
+#endif /* ALLOW_EXCH2 */
 
-      INTEGER jG, j, bi, bj
+C     !INPUT/OUTPUT PARAMETERS:
+C gloBuff   ( _R4 ) :: full-domain 2D IO-buffer array             (Output)
+C myField   ( _R4 ) :: tiled, local (i.e. my Proc. tiles) 2D array (Input)
+C ySize    (integer):: global buffer 1rst dim (y)
+C useExch2GlobLayOut:: =T: Use Exch2 global-map layout (only with EXCH2)
+C zeroBuff (logical):: =T: initialise the buffer to zero before copy
+C myThid   (integer):: my Thread Id number
+
+      INTEGER ySize
+      _R4     gloBuff(ySize)
+      _R4     myField(1:sNy,nSx,nSy)
+      LOGICAL useExch2GlobLayOut
+      LOGICAL zeroBuff
+      INTEGER myThid
+CEOP
+
+C !LOCAL VARIABLES:
+      INTEGER i,j,bi,bj
+      INTEGER iG, jG
+      INTEGER iBase, jBase
+#ifdef ALLOW_EXCH2
+      INTEGER iGjLoc, jGjLoc
+      INTEGER tN
+#endif /* ALLOW_EXCH2 */
 #ifdef ALLOW_USE_MPI
-
-      _R4     temp(sNy,nSx,nSy)
-
+      INTEGER np, pId
+      _R4     temp(1:sNy,nSx,nSy)
       INTEGER istatus(MPI_STATUS_SIZE), ierr
-      INTEGER lbuff, idest, itag, npe, ready_to_receive
+      INTEGER lbuff, idest, itag, ready_to_receive
 #endif /* ALLOW_USE_MPI */
 
-C--   Make everyone wait except for master thread.
-      _BARRIER
       _BEGIN_MASTER( myThid )
 
-#ifndef ALLOW_USE_MPI
-
-      DO bj=1,nSy
-         DO bi=1,nSx
-               DO j=1,sNy
-                  jG = myYGlobalLo-1+(bi-1)*sNy+j
-                  global(jG) = local(j,bi,bj)
-               ENDDO
-         ENDDO
-      ENDDO
-
-#else /* ALLOW_USE_MPI */
-
-      lbuff = sNy*nSx*nSy
-      idest = 0
-      itag  = 0
-      ready_to_receive = 0
-
-      IF( mpiMyId .EQ. 0 ) THEN
-
+      IF( myProcId .EQ. 0 ) THEN
 C--   Process 0 fills-in its local data
-         npe = 0
-         DO bj=1,nSy
-            DO bi=1,nSx
-                  DO j=1,sNy
-                     jG = mpi_myYGlobalLo(npe+1)-1+(bi-1)*sNy+j
-                     global(jG) = local(j,bi,bj)
-                  ENDDO
+
+#ifdef ALLOW_EXCH2
+        IF ( useExch2GlobLayOut ) THEN
+C--   If using blank-tiles, buffer will not be completely filled;
+C     safer to reset to zero to avoid unknown values in output file
+          IF ( zeroBuff ) THEN
+            DO j=1,ySize
+               gloBuff(j) = 0.
             ENDDO
-         ENDDO
+          ENDIF
+
+          DO bj=1,nSy
+           DO bi=1,nSx
+             tN = W2_myTileList(bi,bj)
+             IF  ( exch2_tNy(tN) .GT. ySize ) THEN
+C-           tile y-size larger than glob-size : make a long line
+               !iGjLoc = exch2_mydNx(tN)
+               jGjLoc = 0
+             ELSE
+C-           default (face fit into global-IO-array)
+               !iGjLoc = 0
+               jGjLoc = 1
+             ENDIF
+
+             DO j=1,sNy
+#ifdef TARGET_NEC_SX
+!cdir novector
+#endif
+               jG=exch2_tyGlobalo(tN)+jGjLoc*(j-1)
+               gloBuff(jG) = myField(j,bi,bj)
+             ENDDO
+
+           ENDDO
+          ENDDO
+
+        ELSE
+#else /* ALLOW_EXCH2 */
+        IF (.TRUE.) THEN
+#endif /* ALLOW_EXCH2 */
+
+          jBase = myYGlobalLo-1
+
+          DO bj=1,nSy
+           DO bi=1,nSx
+            DO j=1,sNy
+#ifdef TARGET_NEC_SX
+!cdir novector
+#endif
+              jG = jBase+(bj-1)*sNy+j
+              gloBuff(jG) = myField(j,bi,bj)
+            ENDDO
+           ENDDO
+          ENDDO
+
+C       end if-else useExch2GlobLayOut
+        ENDIF
+
+C-    end if myProcId = 0
+      ENDIF
+
+#ifdef ALLOW_USE_MPI
+      IF ( usingMPI ) THEN
+
+       lbuff = sNy*nSx*nSy
+       idest = 0
+       itag  = 0
+       ready_to_receive = 0
+
+       IF( mpiMyId .EQ. 0 ) THEN
 
 C--   Process 0 polls and receives data from each process in turn
-         DO npe = 1, numberOfProcs-1
+        DO np = 2, nPx*nPy
+         pId = np - 1
 #ifndef DISABLE_MPI_READY_TO_RECEIVE
-            CALL MPI_SEND (ready_to_receive, 1, MPI_INTEGER,
-     &           npe, itag, MPI_COMM_MODEL, ierr)
+         CALL MPI_SEND (ready_to_receive, 1, MPI_INTEGER,
+     &           pId, itag, MPI_COMM_MODEL, ierr)
 #endif
-            CALL MPI_RECV (temp, lbuff, MPI_DOUBLE_PRECISION,
-     &           npe, itag, MPI_COMM_MODEL, istatus, ierr)
+         CALL MPI_RECV (temp, lbuff, _MPI_TYPE_R4,
+     &           pId, itag, MPI_COMM_MODEL, istatus, ierr)
 
-C--   Process 0 gathers the local arrays into a global array.
-            DO bj=1,nSy
-               DO bi=1,nSx
-                     DO j=1,sNy
-                        jG = mpi_myYGlobalLo(npe+1)-1+(bi-1)*sNy+j
-                        global(jG) = temp(j,bi,bj)
-                     ENDDO
-                  ENDDO
-            ENDDO
-         ENDDO
+C--   Process 0 gathers the local arrays into the global buffer.
+#ifdef ALLOW_EXCH2
+         IF ( useExch2GlobLayOut ) THEN
 
-      ELSE
+          DO bj=1,nSy
+           DO bi=1,nSx
+             tN = W2_procTileList(bi,bj,np)
+             IF  ( exch2_tNy(tN) .GT. ySize ) THEN
+C-           tile y-size larger than glob-size : make a long line
+               !iGjLoc = exch2_mydNx(tN)
+               jGjLoc = 0
+             ELSE
+C-           default (face fit into global-IO-array)
+               !iGjLoc = 0
+               jGjLoc = 1
+             ENDIF
+
+             DO j=1,sNy
+#ifdef TARGET_NEC_SX
+!cdir novector
+#endif
+              jG=exch2_tyGlobalo(tN)+jGjLoc*(j-1)
+              gloBuff(jG) = temp(j,bi,bj)
+             ENDDO
+
+           ENDDO
+          ENDDO
+
+         ELSE
+#else /* ALLOW_EXCH2 */
+         IF (.TRUE.) THEN
+#endif /* ALLOW_EXCH2 */
+
+          jBase = mpi_myYGlobalLo(np)-1
+
+          DO bj=1,nSy
+           DO bi=1,nSx
+             DO j=1,sNy
+#ifdef TARGET_NEC_SX
+!cdir novector
+#endif
+              jG = jBase+(bj-1)*sNy+j
+              gloBuff(jG) = temp(j,bi,bj)
+             ENDDO
+           ENDDO
+          ENDDO
+
+C        end if-else useExch2GlobLayOut
+         ENDIF
+
+C-      end loop on np
+        ENDDO
+
+       ELSE
 
 C--   All proceses except 0 wait to be polled then send local array
 #ifndef DISABLE_MPI_READY_TO_RECEIVE
          CALL MPI_RECV (ready_to_receive, 1, MPI_INTEGER,
      &        idest, itag, MPI_COMM_MODEL, istatus, ierr)
 #endif
-         CALL MPI_SEND (local, lbuff, MPI_DOUBLE_PRECISION,
+         CALL MPI_SEND (myField, lbuff, _MPI_TYPE_R4,
      &        idest, itag, MPI_COMM_MODEL, ierr)
 
-      ENDIF
+       ENDIF
 
+      ENDIF
 #endif /* ALLOW_USE_MPI */
 
       _END_MASTER( myThid )
-      _BARRIER
 
       RETURN
       END

--- a/eesupp/src/gather_yz_r4.F
+++ b/eesupp/src/gather_yz_r4.F
@@ -1,0 +1,97 @@
+#include "CPP_OPTIONS.h"
+
+      SUBROUTINE GATHER_YZ_R4( global, local, myThid )
+C     Gather elements of a y-z array from all mpi processes to process 0.
+      IMPLICIT NONE
+#include "SIZE.h"
+#include "EEPARAMS.h"
+#include "EESUPPORT.h"
+C     mythid - thread number for this instance of the routine.
+C     global,local - working arrays used to transfer 2-D fields
+      INTEGER mythid 
+      _R4     global(Ny)
+      _R4     local(sNy,nSx,nSy)
+
+      INTEGER jG, j, bi, bj
+#ifdef ALLOW_USE_MPI
+
+      _R4     temp(sNy,nSx,nSy)
+
+      INTEGER istatus(MPI_STATUS_SIZE), ierr
+      INTEGER lbuff, idest, itag, npe, ready_to_receive
+#endif /* ALLOW_USE_MPI */
+
+C--   Make everyone wait except for master thread.
+      _BARRIER
+      _BEGIN_MASTER( myThid )
+
+#ifndef ALLOW_USE_MPI
+
+      DO bj=1,nSy
+         DO bi=1,nSx
+               DO j=1,sNy
+                  jG = myYGlobalLo-1+(bi-1)*sNy+j
+                  global(jG) = local(j,bi,bj)
+               ENDDO
+         ENDDO
+      ENDDO
+
+#else /* ALLOW_USE_MPI */
+
+      lbuff = sNy*nSx*nSy
+      idest = 0
+      itag  = 0
+      ready_to_receive = 0
+
+      IF( mpiMyId .EQ. 0 ) THEN
+
+C--   Process 0 fills-in its local data
+         npe = 0
+         DO bj=1,nSy
+            DO bi=1,nSx
+                  DO j=1,sNy
+                     jG = mpi_myYGlobalLo(npe+1)-1+(bi-1)*sNy+j
+                     global(jG) = local(j,bi,bj)
+                  ENDDO
+            ENDDO
+         ENDDO
+
+C--   Process 0 polls and receives data from each process in turn
+         DO npe = 1, numberOfProcs-1
+#ifndef DISABLE_MPI_READY_TO_RECEIVE
+            CALL MPI_SEND (ready_to_receive, 1, MPI_INTEGER,
+     &           npe, itag, MPI_COMM_MODEL, ierr)
+#endif
+            CALL MPI_RECV (temp, lbuff, MPI_DOUBLE_PRECISION,
+     &           npe, itag, MPI_COMM_MODEL, istatus, ierr)
+
+C--   Process 0 gathers the local arrays into a global array.
+            DO bj=1,nSy
+               DO bi=1,nSx
+                     DO j=1,sNy
+                        jG = mpi_myYGlobalLo(npe+1)-1+(bi-1)*sNy+j
+                        global(jG) = temp(j,bi,bj)
+                     ENDDO
+                  ENDDO
+            ENDDO
+         ENDDO
+
+      ELSE
+
+C--   All proceses except 0 wait to be polled then send local array
+#ifndef DISABLE_MPI_READY_TO_RECEIVE
+         CALL MPI_RECV (ready_to_receive, 1, MPI_INTEGER,
+     &        idest, itag, MPI_COMM_MODEL, istatus, ierr)
+#endif
+         CALL MPI_SEND (local, lbuff, MPI_DOUBLE_PRECISION,
+     &        idest, itag, MPI_COMM_MODEL, ierr)
+
+      ENDIF
+
+#endif /* ALLOW_USE_MPI */
+
+      _END_MASTER( myThid )
+      _BARRIER
+
+      RETURN
+      END

--- a/eesupp/src/gather_yz_r4.F
+++ b/eesupp/src/gather_yz_r4.F
@@ -109,8 +109,8 @@ C-           default (face fit into global-IO-array)
 #ifdef TARGET_NEC_SX
 !cdir novector
 #endif
-              jG = jBase+(bj-1)*sNy+j
-              gloBuff(jG) = myField(j,bi,bj)
+               jG = jBase+(bj-1)*sNy+j
+               gloBuff(jG) = myField(j,bi,bj)
             ENDDO
            ENDDO
           ENDDO
@@ -124,7 +124,7 @@ C-    end if myProcId = 0
 #ifdef ALLOW_USE_MPI
       IF ( usingMPI ) THEN
 
-       lbuff = sNy*nSx*nSy
+       lbuff = sNy*nSy
        idest = 0
        itag  = 0
        ready_to_receive = 0
@@ -150,11 +150,9 @@ C--   Process 0 gathers the local arrays into the global buffer.
              tN = W2_procTileList(bi,bj,np)
              IF  ( exch2_tNy(tN) .GT. ySize ) THEN
 C-           tile y-size larger than glob-size : make a long line
-               !iGjLoc = exch2_mydNx(tN)
                jGjLoc = 0
              ELSE
 C-           default (face fit into global-IO-array)
-               !iGjLoc = 0
                jGjLoc = 1
              ENDIF
 
@@ -178,13 +176,16 @@ C-           default (face fit into global-IO-array)
 
           DO bj=1,nSy
            DO bi=1,nSx
-             DO j=1,sNy
+            DO j=1,sNy
 #ifdef TARGET_NEC_SX
 !cdir novector
 #endif
-              jG = jBase+(bj-1)*sNy+j
-              gloBuff(jG) = temp(j,bi,bj)
-             ENDDO
+             IF (ABS(temp(j,bi,bj)).gt.0. _d 0) THEN
+               jG = jBase+(bj-1)*sNy+j
+               gloBuff(jG) = temp(j,bi,bj)
+             ENDIF
+            ENDDO
+
            ENDDO
           ENDDO
 

--- a/eesupp/src/gather_yz_r8.F
+++ b/eesupp/src/gather_yz_r8.F
@@ -1,97 +1,215 @@
-#include "CPP_OPTIONS.h"
+#include "PACKAGES_CONFIG.h"
+#include "CPP_EEOPTIONS.h"
 
-      SUBROUTINE GATHER_YZ_R8( global, local, myThid )
-C     Gather elements of a y-z array from all mpi processes to process 0.
+CBOP
+C !ROUTINE: GATHER_YZ_R8
+C !INTERFACE:
+      SUBROUTINE GATHER_YZ_R8(
+     O                  gloBuff,
+     I                  myField,
+     I                  ySize,
+     I                  useExch2GlobLayOut,
+     I                  zeroBuff,
+     I                  myThid )
+C !DESCRIPTION:
+C     Gather elements of a global 2-D array from all mpi processes to process 0.
+C     Note: done by Master-Thread ; might need barrier calls before and after
+C           this S/R call.
+
+C     !USES:
       IMPLICIT NONE
 #include "SIZE.h"
 #include "EEPARAMS.h"
 #include "EESUPPORT.h"
-C     mythid - thread number for this instance of the routine.
-C     global,local - working arrays used to transfer 2-D fields
-      INTEGER mythid 
-      _R8     global(Ny)
-      _R8     local(sNy,nSx,nSy)
+#ifdef ALLOW_EXCH2
+#include "W2_EXCH2_SIZE.h"
+#include "W2_EXCH2_TOPOLOGY.h"
+#endif /* ALLOW_EXCH2 */
 
-      INTEGER jG, j, bi, bj
+C     !INPUT/OUTPUT PARAMETERS:
+C gloBuff   ( _R8 ) :: full-domain 2D IO-buffer array             (Output)
+C myField   ( _R8 ) :: tiled, local (i.e. my Proc. tiles) 2D array (Input)
+C ySize    (integer):: global buffer 1rst dim (y)
+C useExch2GlobLayOut:: =T: Use Exch2 global-map layout (only with EXCH2)
+C zeroBuff (logical):: =T: initialise the buffer to zero before copy
+C myThid   (integer):: my Thread Id number
+
+      INTEGER ySize
+      _R8     gloBuff(ySize)
+      _R8     myField(1:sNy,nSx,nSy)
+      LOGICAL useExch2GlobLayOut
+      LOGICAL zeroBuff
+      INTEGER myThid
+CEOP
+
+C !LOCAL VARIABLES:
+      INTEGER i,j,bi,bj
+      INTEGER iG, jG
+      INTEGER iBase, jBase
+#ifdef ALLOW_EXCH2
+      INTEGER iGjLoc, jGjLoc
+      INTEGER tN
+#endif /* ALLOW_EXCH2 */
 #ifdef ALLOW_USE_MPI
-
-      _R8     temp(sNy,nSx,nSy)
-
+      INTEGER np, pId
+      _R8     temp(1:sNy,nSx,nSy)
       INTEGER istatus(MPI_STATUS_SIZE), ierr
-      INTEGER lbuff, idest, itag, npe, ready_to_receive
+      INTEGER lbuff, idest, itag, ready_to_receive
 #endif /* ALLOW_USE_MPI */
 
-C--   Make everyone wait except for master thread.
-      _BARRIER
       _BEGIN_MASTER( myThid )
 
-#ifndef ALLOW_USE_MPI
-
-      DO bj=1,nSy
-         DO bi=1,nSx
-               DO j=1,sNy
-                  jG = myYGlobalLo-1+(bi-1)*sNy+j
-                  global(jG) = local(j,bi,bj)
-               ENDDO
-         ENDDO
-      ENDDO
-
-#else /* ALLOW_USE_MPI */
-
-      lbuff = sNy*nSx*nSy
-      idest = 0
-      itag  = 0
-      ready_to_receive = 0
-
-      IF( mpiMyId .EQ. 0 ) THEN
-
+      IF( myProcId .EQ. 0 ) THEN
 C--   Process 0 fills-in its local data
-         npe = 0
-         DO bj=1,nSy
-            DO bi=1,nSx
-                  DO j=1,sNy
-                     jG = mpi_myYGlobalLo(npe+1)-1+(bi-1)*sNy+j
-                     global(jG) = local(j,bi,bj)
-                  ENDDO
+
+#ifdef ALLOW_EXCH2
+        IF ( useExch2GlobLayOut ) THEN
+C--   If using blank-tiles, buffer will not be completely filled;
+C     safer to reset to zero to avoid unknown values in output file
+          IF ( zeroBuff ) THEN
+            DO j=1,ySize
+               gloBuff(j) = 0.
             ENDDO
-         ENDDO
+          ENDIF
+
+          DO bj=1,nSy
+           DO bi=1,nSx
+             tN = W2_myTileList(bi,bj)
+             IF  ( exch2_tNy(tN) .GT. ySize ) THEN
+C-           tile y-size larger than glob-size : make a long line
+               !iGjLoc = exch2_mydNx(tN)
+               jGjLoc = 0
+             ELSE
+C-           default (face fit into global-IO-array)
+               !iGjLoc = 0
+               jGjLoc = 1
+             ENDIF
+
+             DO j=1,sNy
+#ifdef TARGET_NEC_SX
+!cdir novector
+#endif
+               jG=exch2_tyGlobalo(tN)+jGjLoc*(j-1)
+               gloBuff(jG) = myField(j,bi,bj)
+             ENDDO
+
+           ENDDO
+          ENDDO
+
+        ELSE
+#else /* ALLOW_EXCH2 */
+        IF (.TRUE.) THEN
+#endif /* ALLOW_EXCH2 */
+
+          jBase = myYGlobalLo-1
+
+          DO bj=1,nSy
+           DO bi=1,nSx
+            DO j=1,sNy
+#ifdef TARGET_NEC_SX
+!cdir novector
+#endif
+              jG = jBase+(bj-1)*sNy+j
+              gloBuff(jG) = myField(j,bi,bj)
+            ENDDO
+           ENDDO
+          ENDDO
+
+C       end if-else useExch2GlobLayOut
+        ENDIF
+
+C-    end if myProcId = 0
+      ENDIF
+
+#ifdef ALLOW_USE_MPI
+      IF ( usingMPI ) THEN
+
+       lbuff = sNy*nSx*nSy
+       idest = 0
+       itag  = 0
+       ready_to_receive = 0
+
+       IF( mpiMyId .EQ. 0 ) THEN
 
 C--   Process 0 polls and receives data from each process in turn
-         DO npe = 1, numberOfProcs-1
+        DO np = 2, nPx*nPy
+         pId = np - 1
 #ifndef DISABLE_MPI_READY_TO_RECEIVE
-            CALL MPI_SEND (ready_to_receive, 1, MPI_INTEGER,
-     &           npe, itag, MPI_COMM_MODEL, ierr)
+         CALL MPI_SEND (ready_to_receive, 1, MPI_INTEGER,
+     &           pId, itag, MPI_COMM_MODEL, ierr)
 #endif
-            CALL MPI_RECV (temp, lbuff, MPI_DOUBLE_PRECISION,
-     &           npe, itag, MPI_COMM_MODEL, istatus, ierr)
+         CALL MPI_RECV (temp, lbuff, _MPI_TYPE_R4,
+     &           pId, itag, MPI_COMM_MODEL, istatus, ierr)
 
-C--   Process 0 gathers the local arrays into a global array.
-            DO bj=1,nSy
-               DO bi=1,nSx
-                     DO j=1,sNy
-                        jG = mpi_myYGlobalLo(npe+1)-1+(bi-1)*sNy+j
-                        global(jG) = temp(j,bi,bj)
-                     ENDDO
-                  ENDDO
-            ENDDO
-         ENDDO
+C--   Process 0 gathers the local arrays into the global buffer.
+#ifdef ALLOW_EXCH2
+         IF ( useExch2GlobLayOut ) THEN
 
-      ELSE
+          DO bj=1,nSy
+           DO bi=1,nSx
+             tN = W2_procTileList(bi,bj,np)
+             IF  ( exch2_tNy(tN) .GT. ySize ) THEN
+C-           tile y-size larger than glob-size : make a long line
+               !iGjLoc = exch2_mydNx(tN)
+               jGjLoc = 0
+             ELSE
+C-           default (face fit into global-IO-array)
+               !iGjLoc = 0
+               jGjLoc = 1
+             ENDIF
+
+             DO j=1,sNy
+#ifdef TARGET_NEC_SX
+!cdir novector
+#endif
+              jG=exch2_tyGlobalo(tN)+jGjLoc*(j-1)
+              gloBuff(jG) = temp(j,bi,bj)
+             ENDDO
+
+           ENDDO
+          ENDDO
+
+         ELSE
+#else /* ALLOW_EXCH2 */
+         IF (.TRUE.) THEN
+#endif /* ALLOW_EXCH2 */
+
+          jBase = mpi_myYGlobalLo(np)-1
+
+          DO bj=1,nSy
+           DO bi=1,nSx
+             DO j=1,sNy
+#ifdef TARGET_NEC_SX
+!cdir novector
+#endif
+              jG = jBase+(bj-1)*sNy+j
+              gloBuff(jG) = temp(j,bi,bj)
+             ENDDO
+           ENDDO
+          ENDDO
+
+C        end if-else useExch2GlobLayOut
+         ENDIF
+
+C-      end loop on np
+        ENDDO
+
+       ELSE
 
 C--   All proceses except 0 wait to be polled then send local array
 #ifndef DISABLE_MPI_READY_TO_RECEIVE
          CALL MPI_RECV (ready_to_receive, 1, MPI_INTEGER,
      &        idest, itag, MPI_COMM_MODEL, istatus, ierr)
 #endif
-         CALL MPI_SEND (local, lbuff, MPI_DOUBLE_PRECISION,
+         CALL MPI_SEND (myField, lbuff, _MPI_TYPE_R4,
      &        idest, itag, MPI_COMM_MODEL, ierr)
 
-      ENDIF
+       ENDIF
 
+      ENDIF
 #endif /* ALLOW_USE_MPI */
 
       _END_MASTER( myThid )
-      _BARRIER
 
       RETURN
       END

--- a/eesupp/src/gather_yz_r8.F
+++ b/eesupp/src/gather_yz_r8.F
@@ -51,13 +51,17 @@ C !LOCAL VARIABLES:
       INTEGER tN
 #endif /* ALLOW_EXCH2 */
 #ifdef ALLOW_USE_MPI
-      INTEGER np, pId
+      INTEGER np, pId, myProcRow
       _R8     temp(1:sNy,nSx,nSy)
       INTEGER istatus(MPI_STATUS_SIZE), ierr
       INTEGER lbuff, idest, itag, ready_to_receive
 #endif /* ALLOW_USE_MPI */
 
       _BEGIN_MASTER( myThid )
+
+      DO jG = 1,ySize
+        gloBuff(j)=0.
+      ENDDO
 
       IF( myProcId .EQ. 0 ) THEN
 C--   Process 0 fills-in its local data
@@ -109,8 +113,8 @@ C-           default (face fit into global-IO-array)
 #ifdef TARGET_NEC_SX
 !cdir novector
 #endif
-              jG = jBase+(bj-1)*sNy+j
-              gloBuff(jG) = myField(j,bi,bj)
+               jG = jBase+(bj-1)*sNy+j
+               gloBuff(jG) = myField(j,bi,bj)
             ENDDO
            ENDDO
           ENDDO
@@ -174,17 +178,23 @@ C-           default (face fit into global-IO-array)
          IF (.TRUE.) THEN
 #endif /* ALLOW_EXCH2 */
 
-          jBase = mpi_myYGlobalLo(np)-1
+          !myProcRow = INT((mpi_myXGlobalLo(np)-1)/(nSx*sNx))
+          jBase = (mpi_myYGlobalLo(np)-1)
+          !print *, jBase
 
           DO bj=1,nSy
            DO bi=1,nSx
-             DO j=1,sNy
+            DO j=1,sNy
 #ifdef TARGET_NEC_SX
 !cdir novector
 #endif
-              jG = jBase+(bj-1)*sNy+j
-              gloBuff(jG) = temp(j,bi,bj)
-             ENDDO
+             IF (ABS(temp(j,bi,bj)).gt.0. _d 0) THEN
+               jG = jBase+(bj-1)*sNy+j
+               gloBuff(jG) = temp(j,bi,bj)
+               print *, 'np, jG, globuff(jg): ',np, jG, gloBuff(jg)
+             ENDIF
+            ENDDO
+
            ENDDO
           ENDDO
 

--- a/eesupp/src/gather_yz_r8.F
+++ b/eesupp/src/gather_yz_r8.F
@@ -51,17 +51,13 @@ C !LOCAL VARIABLES:
       INTEGER tN
 #endif /* ALLOW_EXCH2 */
 #ifdef ALLOW_USE_MPI
-      INTEGER np, pId, myProcRow
+      INTEGER np, pId
       _R8     temp(1:sNy,nSx,nSy)
       INTEGER istatus(MPI_STATUS_SIZE), ierr
       INTEGER lbuff, idest, itag, ready_to_receive
 #endif /* ALLOW_USE_MPI */
 
       _BEGIN_MASTER( myThid )
-
-      DO jG = 1,ySize
-        gloBuff(j)=0.
-      ENDDO
 
       IF( myProcId .EQ. 0 ) THEN
 C--   Process 0 fills-in its local data
@@ -142,7 +138,7 @@ C--   Process 0 polls and receives data from each process in turn
          CALL MPI_SEND (ready_to_receive, 1, MPI_INTEGER,
      &           pId, itag, MPI_COMM_MODEL, ierr)
 #endif
-         CALL MPI_RECV (temp, lbuff, _MPI_TYPE_R4,
+         CALL MPI_RECV (temp, lbuff, _MPI_TYPE_R8,
      &           pId, itag, MPI_COMM_MODEL, istatus, ierr)
 
 C--   Process 0 gathers the local arrays into the global buffer.
@@ -154,11 +150,9 @@ C--   Process 0 gathers the local arrays into the global buffer.
              tN = W2_procTileList(bi,bj,np)
              IF  ( exch2_tNy(tN) .GT. ySize ) THEN
 C-           tile y-size larger than glob-size : make a long line
-               !iGjLoc = exch2_mydNx(tN)
                jGjLoc = 0
              ELSE
 C-           default (face fit into global-IO-array)
-               !iGjLoc = 0
                jGjLoc = 1
              ENDIF
 
@@ -179,8 +173,7 @@ C-           default (face fit into global-IO-array)
 #endif /* ALLOW_EXCH2 */
 
           !myProcRow = INT((mpi_myXGlobalLo(np)-1)/(nSx*sNx))
-          jBase = (mpi_myYGlobalLo(np)-1)
-          !print *, jBase
+          jBase = mpi_myYGlobalLo(np)-1
 
           DO bj=1,nSy
            DO bi=1,nSx
@@ -191,7 +184,6 @@ C-           default (face fit into global-IO-array)
              IF (ABS(temp(j,bi,bj)).gt.0. _d 0) THEN
                jG = jBase+(bj-1)*sNy+j
                gloBuff(jG) = temp(j,bi,bj)
-               print *, 'np, jG, globuff(jg): ',np, jG, gloBuff(jg)
              ENDIF
             ENDDO
 
@@ -211,7 +203,7 @@ C--   All proceses except 0 wait to be polled then send local array
          CALL MPI_RECV (ready_to_receive, 1, MPI_INTEGER,
      &        idest, itag, MPI_COMM_MODEL, istatus, ierr)
 #endif
-         CALL MPI_SEND (myField, lbuff, _MPI_TYPE_R4,
+         CALL MPI_SEND (myField, lbuff, _MPI_TYPE_R8,
      &        idest, itag, MPI_COMM_MODEL, ierr)
 
        ENDIF

--- a/eesupp/src/gather_yz_r8.F
+++ b/eesupp/src/gather_yz_r8.F
@@ -1,0 +1,97 @@
+#include "CPP_OPTIONS.h"
+
+      SUBROUTINE GATHER_YZ_R8( global, local, myThid )
+C     Gather elements of a y-z array from all mpi processes to process 0.
+      IMPLICIT NONE
+#include "SIZE.h"
+#include "EEPARAMS.h"
+#include "EESUPPORT.h"
+C     mythid - thread number for this instance of the routine.
+C     global,local - working arrays used to transfer 2-D fields
+      INTEGER mythid 
+      _R8     global(Ny)
+      _R8     local(sNy,nSx,nSy)
+
+      INTEGER jG, j, bi, bj
+#ifdef ALLOW_USE_MPI
+
+      _R8     temp(sNy,nSx,nSy)
+
+      INTEGER istatus(MPI_STATUS_SIZE), ierr
+      INTEGER lbuff, idest, itag, npe, ready_to_receive
+#endif /* ALLOW_USE_MPI */
+
+C--   Make everyone wait except for master thread.
+      _BARRIER
+      _BEGIN_MASTER( myThid )
+
+#ifndef ALLOW_USE_MPI
+
+      DO bj=1,nSy
+         DO bi=1,nSx
+               DO j=1,sNy
+                  jG = myYGlobalLo-1+(bi-1)*sNy+j
+                  global(jG) = local(j,bi,bj)
+               ENDDO
+         ENDDO
+      ENDDO
+
+#else /* ALLOW_USE_MPI */
+
+      lbuff = sNy*nSx*nSy
+      idest = 0
+      itag  = 0
+      ready_to_receive = 0
+
+      IF( mpiMyId .EQ. 0 ) THEN
+
+C--   Process 0 fills-in its local data
+         npe = 0
+         DO bj=1,nSy
+            DO bi=1,nSx
+                  DO j=1,sNy
+                     jG = mpi_myYGlobalLo(npe+1)-1+(bi-1)*sNy+j
+                     global(jG) = local(j,bi,bj)
+                  ENDDO
+            ENDDO
+         ENDDO
+
+C--   Process 0 polls and receives data from each process in turn
+         DO npe = 1, numberOfProcs-1
+#ifndef DISABLE_MPI_READY_TO_RECEIVE
+            CALL MPI_SEND (ready_to_receive, 1, MPI_INTEGER,
+     &           npe, itag, MPI_COMM_MODEL, ierr)
+#endif
+            CALL MPI_RECV (temp, lbuff, MPI_DOUBLE_PRECISION,
+     &           npe, itag, MPI_COMM_MODEL, istatus, ierr)
+
+C--   Process 0 gathers the local arrays into a global array.
+            DO bj=1,nSy
+               DO bi=1,nSx
+                     DO j=1,sNy
+                        jG = mpi_myYGlobalLo(npe+1)-1+(bi-1)*sNy+j
+                        global(jG) = temp(j,bi,bj)
+                     ENDDO
+                  ENDDO
+            ENDDO
+         ENDDO
+
+      ELSE
+
+C--   All proceses except 0 wait to be polled then send local array
+#ifndef DISABLE_MPI_READY_TO_RECEIVE
+         CALL MPI_RECV (ready_to_receive, 1, MPI_INTEGER,
+     &        idest, itag, MPI_COMM_MODEL, istatus, ierr)
+#endif
+         CALL MPI_SEND (local, lbuff, MPI_DOUBLE_PRECISION,
+     &        idest, itag, MPI_COMM_MODEL, ierr)
+
+      ENDIF
+
+#endif /* ALLOW_USE_MPI */
+
+      _END_MASTER( myThid )
+      _BARRIER
+
+      RETURN
+      END

--- a/eesupp/src/scatter_xz_r4.F
+++ b/eesupp/src/scatter_xz_r4.F
@@ -2,12 +2,12 @@
 #include "CPP_EEOPTIONS.h"
 
 CBOP
-C !ROUTINE: SCATTER_YZ_R4
+C !ROUTINE: SCATTER_XZ_R4
 C !INTERFACE:
-      SUBROUTINE SCATTER_YZ_R4(
+      SUBROUTINE SCATTER_XZ_R4(
      I                  gloBuff,
      O                  myField,
-     I                  ySize,
+     I                  xSize,
      I                  useExch2GlobLayOut,
      I                  zeroBuff,
      I                  myThid )
@@ -29,14 +29,14 @@ C     !USES:
 C     !INPUT/OUTPUT PARAMETERS:
 C gloBuff   ( _R4 ) :: full-domain 2D IO-buffer array              (Input)
 C myField   ( _R4 ) :: tiled, local (i.e. my Proc. tiles) 2D array (Output)
-C ySize    (integer):: global buffer 2nd  dim (y)
+C xSize    (integer):: global buffer 2nd  dim (y)
 C useExch2GlobLayOut:: =T: Use Exch2 global-map layout (only with EXCH2)
 C zeroBuff (logical):: =T: reset the buffer to zero after copy
 C myThid   (integer):: my Thread Id number
 
-      INTEGER ySize
-      _R4     gloBuff(ySize)
-      _R4     myField(1:sNy,nSx,nSy)
+      INTEGER xSize
+      _R4     gloBuff(xSize)
+      _R4     myField(1:sNx,nSx,nSy)
       LOGICAL useExch2GlobLayOut
       LOGICAL zeroBuff
       INTEGER myThid
@@ -52,7 +52,7 @@ C !LOCAL VARIABLES:
 #endif /* ALLOW_EXCH2 */
 #ifdef ALLOW_USE_MPI
       INTEGER np, pId
-      _R4     temp(1:sNy,nSx,nSy)
+      _R4     temp(1:sNx,nSx,nSy)
       INTEGER istatus(MPI_STATUS_SIZE), ierr
       INTEGER lbuff, isource, itag
 #endif /* ALLOW_USE_MPI */
@@ -62,7 +62,7 @@ C !LOCAL VARIABLES:
 #ifdef ALLOW_USE_MPI
       IF ( usingMPI ) THEN
 
-       lbuff = sNy*nSy
+       lbuff = sNx*nSx
        isource = 0
        itag  = 0
 
@@ -79,20 +79,14 @@ C--   Process 0 extract the local arrays from the global buffer.
           DO bj=1,nSy
            DO bi=1,nSx
              tN = W2_procTileList(bi,bj,np)
-             IF ( exch2_tNy(tN) .GT. ySize ) THEN
-C-           tile y-size larger than glob-size : make a long line
-               jGjLoc = 0
-             ELSE
-C-           default (face fit into global-IO-array)
-               jGjLoc = 1
-             ENDIF
+             iGjLoc=0
 
-             DO j=1,sNy
 #ifdef TARGET_NEC_SX
 !cdir novector
 #endif
-              jG=exch2_tyGlobalo(tN)+jGjLoc*(j-1)
-              temp(j,bi,bj) = gloBuff(jG)
+             DO i=1,sNx
+              iG=exch2_txGlobalo(tN)+iGjLoc*(i-1)
+              temp(i,bi,bj) = gloBuff(iG)
              ENDDO
 
            ENDDO
@@ -103,16 +97,17 @@ C-           default (face fit into global-IO-array)
          IF (.TRUE.) THEN
 #endif /* ALLOW_EXCH2 */
 
-          jBase = mpi_myYGlobalLo(np)-1
+          iBase = mpi_myXGlobalLo(np)-1
 
           DO bj=1,nSy
            DO bi=1,nSx
-             DO j=1,sNy
+
 #ifdef TARGET_NEC_SX
 !cdir novector
 #endif
-              jG = jBase+(bj-1)*sNy+j
-              temp(j,bi,bj) = gloBuff(jG)
+             DO i=1,sNx
+              iG = jBase+(bi-1)*sNx+i
+              temp(i,bi,bj) = gloBuff(iG)
              ENDDO
            ENDDO
           ENDDO
@@ -148,20 +143,14 @@ C--   Process 0 fills-in its local data
           DO bj=1,nSy
            DO bi=1,nSx
              tN = W2_myTileList(bi,bj)
-             IF ( exch2_tNy(tN) .GT. ySize ) THEN
-C-           tile y-size larger than glob-size : make a long line
-               jGjLoc = 0
-             ELSE
-C-           default (face fit into global-IO-array)
-               jGjLoc = 1
-             ENDIF
+             iGjLoc = 0
 
-             DO j=1,sNy
 #ifdef TARGET_NEC_SX
 !cdir novector
 #endif
-              jG=exch2_tyGlobalo(tN)+jGjLoc*(j-1)
-              myField(j,bi,bj) = gloBuff(jG)
+             DO i=1,sNx
+              iG=exch2_txGlobalo(tN)+iGjLoc*(i-1)
+              myField(i,bi,bj) = gloBuff(iG)
              ENDDO
 
            ENDDO
@@ -171,8 +160,8 @@ C--   After the copy from the buffer, reset to zero.
 C     An alternative to zeroBuff when writing to file,
 C     which could be faster if we do less read than write.
           IF ( zeroBuff ) THEN
-            DO j=1,ySize
-              gloBuff(j) = 0.
+            DO i=1,xSize
+              gloBuff(i) = 0.
             ENDDO
           ENDIF
 
@@ -181,16 +170,17 @@ C     which could be faster if we do less read than write.
         IF (.TRUE.) THEN
 #endif /* ALLOW_EXCH2 */
 
-          jBase = myYGlobalLo-1
+          iBase = myXGlobalLo-1
 
           DO bj=1,nSy
            DO bi=1,nSx
-             DO j=1,sNy
+
 #ifdef TARGET_NEC_SX
 !cdir novector
 #endif
-              jG = jBase+(bj-1)*sNy+j
-              myField(j,bi,bj) = gloBuff(jG)
+             DO i=1,sNx
+              iG = iBase+(bi-1)*sNx+i
+              myField(i,bi,bj) = gloBuff(iG)
              ENDDO
            ENDDO
           ENDDO

--- a/eesupp/src/scatter_xz_r8.F
+++ b/eesupp/src/scatter_xz_r8.F
@@ -2,12 +2,12 @@
 #include "CPP_EEOPTIONS.h"
 
 CBOP
-C !ROUTINE: SCATTER_YZ_R4
+C !ROUTINE: SCATTER_XZ_R8
 C !INTERFACE:
-      SUBROUTINE SCATTER_YZ_R4(
+      SUBROUTINE SCATTER_XZ_R8(
      I                  gloBuff,
      O                  myField,
-     I                  ySize,
+     I                  xSize,
      I                  useExch2GlobLayOut,
      I                  zeroBuff,
      I                  myThid )
@@ -27,16 +27,16 @@ C     !USES:
 #endif /* ALLOW_EXCH2 */
 
 C     !INPUT/OUTPUT PARAMETERS:
-C gloBuff   ( _R4 ) :: full-domain 2D IO-buffer array              (Input)
-C myField   ( _R4 ) :: tiled, local (i.e. my Proc. tiles) 2D array (Output)
-C ySize    (integer):: global buffer 2nd  dim (y)
+C gloBuff   ( _R8 ) :: full-domain 2D IO-buffer array              (Input)
+C myField   ( _R8 ) :: tiled, local (i.e. my Proc. tiles) 2D array (Output)
+C xSize    (integer):: global buffer 2nd  dim (y)
 C useExch2GlobLayOut:: =T: Use Exch2 global-map layout (only with EXCH2)
 C zeroBuff (logical):: =T: reset the buffer to zero after copy
 C myThid   (integer):: my Thread Id number
 
-      INTEGER ySize
-      _R4     gloBuff(ySize)
-      _R4     myField(1:sNy,nSx,nSy)
+      INTEGER xSize
+      _R8     gloBuff(xSize)
+      _R8     myField(1:sNx,nSx,nSy)
       LOGICAL useExch2GlobLayOut
       LOGICAL zeroBuff
       INTEGER myThid
@@ -52,7 +52,7 @@ C !LOCAL VARIABLES:
 #endif /* ALLOW_EXCH2 */
 #ifdef ALLOW_USE_MPI
       INTEGER np, pId
-      _R4     temp(1:sNy,nSx,nSy)
+      _R8     temp(1:sNx,nSx,nSy)
       INTEGER istatus(MPI_STATUS_SIZE), ierr
       INTEGER lbuff, isource, itag
 #endif /* ALLOW_USE_MPI */
@@ -62,7 +62,7 @@ C !LOCAL VARIABLES:
 #ifdef ALLOW_USE_MPI
       IF ( usingMPI ) THEN
 
-       lbuff = sNy*nSy
+       lbuff = sNx*nSx
        isource = 0
        itag  = 0
 
@@ -79,20 +79,14 @@ C--   Process 0 extract the local arrays from the global buffer.
           DO bj=1,nSy
            DO bi=1,nSx
              tN = W2_procTileList(bi,bj,np)
-             IF ( exch2_tNy(tN) .GT. ySize ) THEN
-C-           tile y-size larger than glob-size : make a long line
-               jGjLoc = 0
-             ELSE
-C-           default (face fit into global-IO-array)
-               jGjLoc = 1
-             ENDIF
+             iGjLoc=0
 
-             DO j=1,sNy
 #ifdef TARGET_NEC_SX
 !cdir novector
 #endif
-              jG=exch2_tyGlobalo(tN)+jGjLoc*(j-1)
-              temp(j,bi,bj) = gloBuff(jG)
+             DO i=1,sNx
+              iG=exch2_txGlobalo(tN)+iGjLoc*(i-1)
+              temp(i,bi,bj) = gloBuff(iG)
              ENDDO
 
            ENDDO
@@ -103,16 +97,17 @@ C-           default (face fit into global-IO-array)
          IF (.TRUE.) THEN
 #endif /* ALLOW_EXCH2 */
 
-          jBase = mpi_myYGlobalLo(np)-1
+          iBase = mpi_myXGlobalLo(np)-1
 
           DO bj=1,nSy
            DO bi=1,nSx
-             DO j=1,sNy
+
 #ifdef TARGET_NEC_SX
 !cdir novector
 #endif
-              jG = jBase+(bj-1)*sNy+j
-              temp(j,bi,bj) = gloBuff(jG)
+             DO i=1,sNx
+              iG = jBase+(bi-1)*sNx+i
+              temp(i,bi,bj) = gloBuff(iG)
              ENDDO
            ENDDO
           ENDDO
@@ -122,7 +117,7 @@ C        end if-else useExch2GlobLayOut
 
 C--   Process 0 sends local arrays to all other processes
          pId = np - 1
-         CALL MPI_SEND (temp, lbuff, _MPI_TYPE_R4,
+         CALL MPI_SEND (temp, lbuff, _MPI_TYPE_R8,
      &           pId, itag, MPI_COMM_MODEL, ierr)
 
 C-      end loop on np
@@ -131,7 +126,7 @@ C-      end loop on np
        ELSE
 
 C--   All proceses except 0 receive local array from process 0
-         CALL MPI_RECV (myField, lbuff, _MPI_TYPE_R4,
+         CALL MPI_RECV (myField, lbuff, _MPI_TYPE_R8,
      &        isource, itag, MPI_COMM_MODEL, istatus, ierr)
 
        ENDIF
@@ -148,20 +143,14 @@ C--   Process 0 fills-in its local data
           DO bj=1,nSy
            DO bi=1,nSx
              tN = W2_myTileList(bi,bj)
-             IF ( exch2_tNy(tN) .GT. ySize ) THEN
-C-           tile y-size larger than glob-size : make a long line
-               jGjLoc = 0
-             ELSE
-C-           default (face fit into global-IO-array)
-               jGjLoc = 1
-             ENDIF
+             iGjLoc = 0
 
-             DO j=1,sNy
 #ifdef TARGET_NEC_SX
 !cdir novector
 #endif
-              jG=exch2_tyGlobalo(tN)+jGjLoc*(j-1)
-              myField(j,bi,bj) = gloBuff(jG)
+             DO i=1,sNx
+              iG=exch2_txGlobalo(tN)+iGjLoc*(i-1)
+              myField(i,bi,bj) = gloBuff(iG)
              ENDDO
 
            ENDDO
@@ -171,8 +160,8 @@ C--   After the copy from the buffer, reset to zero.
 C     An alternative to zeroBuff when writing to file,
 C     which could be faster if we do less read than write.
           IF ( zeroBuff ) THEN
-            DO j=1,ySize
-              gloBuff(j) = 0.
+            DO i=1,xSize
+              gloBuff(i) = 0.
             ENDDO
           ENDIF
 
@@ -181,16 +170,17 @@ C     which could be faster if we do less read than write.
         IF (.TRUE.) THEN
 #endif /* ALLOW_EXCH2 */
 
-          jBase = myYGlobalLo-1
+          iBase = myXGlobalLo-1
 
           DO bj=1,nSy
            DO bi=1,nSx
-             DO j=1,sNy
+
 #ifdef TARGET_NEC_SX
 !cdir novector
 #endif
-              jG = jBase+(bj-1)*sNy+j
-              myField(j,bi,bj) = gloBuff(jG)
+             DO i=1,sNx
+              iG = iBase+(bi-1)*sNx+i
+              myField(i,bi,bj) = gloBuff(iG)
              ENDDO
            ENDDO
           ENDDO

--- a/eesupp/src/scatter_yz_r4.F
+++ b/eesupp/src/scatter_yz_r4.F
@@ -1,0 +1,90 @@
+#include "CPP_EEOPTIONS.h"
+
+      SUBROUTINE SCATTER_YZ_R4( global, local, myThid )
+C     Scatter elements of a y-z array from mpi process 0 to all processes.
+      IMPLICIT NONE
+#include "SIZE.h"
+#include "EEPARAMS.h"
+#include "EESUPPORT.h"
+C     mythid - thread number for this instance of the routine.
+C     global,local - working arrays used to transfer 2-D fields
+      INTEGER mythid
+      _R4 global(Ny)
+      _R4 local(sNy,nSx,nSy)
+
+      INTEGER jG, j, bi, bj
+#ifdef ALLOW_USE_MPI
+
+      _R4 temp(sNy,nSx,nSy)
+
+      INTEGER istatus(MPI_STATUS_SIZE), ierr
+      INTEGER isource, itag, npe
+      INTEGER lbuff
+#endif /* ALLOW_USE_MPI */
+
+C--   Make everyone wait except for master thread.
+      _BARRIER
+      _BEGIN_MASTER( myThid )
+
+#ifndef ALLOW_USE_MPI
+
+      DO bj=1,nSy
+         DO bi=1,nSx
+               DO j=1,sNy
+                  jG = myYGlobalLo-1+(bi-1)*sNy+j
+                  local(j,bi,bj) = global(jG)
+               ENDDO
+         ENDDO
+      ENDDO
+
+#else /* ALLOW_USE_MPI */
+
+      lbuff=sNy*nSx*nSy
+      isource = 0
+      itag = 0
+
+      IF( mpiMyId .EQ. 0 ) THEN
+
+C--   Process 0 fills-in its local data
+         npe = 0
+         DO bj=1,nSy
+            DO bi=1,nSx
+                  DO j=1,sNy
+                     jG = mpi_myYGlobalLo(npe+1)-1+(bi-1)*sNy+j
+                     local(j,bi,bj) = global(jG)
+                  ENDDO
+            ENDDO
+         ENDDO
+
+C--   Process 0 sends local arrays to all other processes
+         DO npe = 1, numberOfProcs-1
+            DO bj=1,nSy
+               DO bi=1,nSx
+                     DO j=1,sNy
+                        jG = mpi_myYGlobalLo(npe+1)-1+(bi-1)*sNy+j
+                        temp(j,bi,bj) = global(jG)
+                     ENDDO
+               ENDDO
+            ENDDO
+            CALL MPI_SEND (temp, lbuff, MPI_DOUBLE_PRECISION,
+     &           npe, itag, MPI_COMM_MODEL, ierr)
+         ENDDO
+
+      ELSE
+
+C--   All proceses except 0 receive local array from process 0
+         CALL MPI_RECV (local, lbuff, MPI_DOUBLE_PRECISION,
+     &        isource, itag, MPI_COMM_MODEL, istatus, ierr)
+
+      ENDIF
+
+#endif /* ALLOW_USE_MPI */
+
+      _END_MASTER( myThid )
+      _BARRIER
+
+C--   Fill in edges.
+CMM      _EXCH_XY_RL( local, myThid )
+
+      RETURN
+      END

--- a/eesupp/src/scatter_yz_r4.F
+++ b/eesupp/src/scatter_yz_r4.F
@@ -1,90 +1,212 @@
+#include "PACKAGES_CONFIG.h"
 #include "CPP_EEOPTIONS.h"
 
-      SUBROUTINE SCATTER_YZ_R4( global, local, myThid )
-C     Scatter elements of a y-z array from mpi process 0 to all processes.
+CBOP
+C !ROUTINE: SCATTER_YZ_R4
+C !INTERFACE:
+      SUBROUTINE SCATTER_YZ_R4(
+     I                  gloBuff,
+     O                  myField,
+     I                  ySize,
+     I                  useExch2GlobLayOut,
+     I                  zeroBuff,
+     I                  myThid )
+C !DESCRIPTION:
+C     Scatter elements of a global 2-D array from mpi process 0 to all processes.
+C     Note: done by Master-Thread ; might need barrier calls before and after
+C           this S/R call.
+
+C     !USES:
       IMPLICIT NONE
 #include "SIZE.h"
 #include "EEPARAMS.h"
 #include "EESUPPORT.h"
-C     mythid - thread number for this instance of the routine.
-C     global,local - working arrays used to transfer 2-D fields
-      INTEGER mythid
-      _R4 global(Ny)
-      _R4 local(sNy,nSx,nSy)
+#ifdef ALLOW_EXCH2
+#include "W2_EXCH2_SIZE.h"
+#include "W2_EXCH2_TOPOLOGY.h"
+#endif /* ALLOW_EXCH2 */
 
-      INTEGER jG, j, bi, bj
+C     !INPUT/OUTPUT PARAMETERS:
+C gloBuff   ( _R4 ) :: full-domain 2D IO-buffer array              (Input)
+C myField   ( _R4 ) :: tiled, local (i.e. my Proc. tiles) 2D array (Output)
+C ySize    (integer):: global buffer 1st  dim (y)
+C useExch2GlobLayOut:: =T: Use Exch2 global-map layout (only with EXCH2)
+C zeroBuff (logical):: =T: reset the buffer to zero after copy
+C myThid   (integer):: my Thread Id number
+
+      INTEGER ySize
+      _R4     gloBuff(ySize)
+      _R4     myField(1:sNy,nSx,nSy)
+      LOGICAL useExch2GlobLayOut
+      LOGICAL zeroBuff
+      INTEGER myThid
+CEOP
+
+C !LOCAL VARIABLES:
+      INTEGER i,j, bi,bj
+      INTEGER iG, jG
+      INTEGER iBase, jBase
+#ifdef ALLOW_EXCH2
+      INTEGER iGjLoc, jGjLoc
+      INTEGER tN
+#endif /* ALLOW_EXCH2 */
 #ifdef ALLOW_USE_MPI
-
-      _R4 temp(sNy,nSx,nSy)
-
+      INTEGER np, pId
+      _R4     temp(1:sNy,nSx,nSy)
       INTEGER istatus(MPI_STATUS_SIZE), ierr
-      INTEGER isource, itag, npe
-      INTEGER lbuff
+      INTEGER lbuff, isource, itag
 #endif /* ALLOW_USE_MPI */
 
-C--   Make everyone wait except for master thread.
-      _BARRIER
       _BEGIN_MASTER( myThid )
 
-#ifndef ALLOW_USE_MPI
+#ifdef ALLOW_USE_MPI
+      IF ( usingMPI ) THEN
 
-      DO bj=1,nSy
-         DO bi=1,nSx
-               DO j=1,sNy
-                  jG = myYGlobalLo-1+(bi-1)*sNy+j
-                  local(j,bi,bj) = global(jG)
-               ENDDO
-         ENDDO
-      ENDDO
+       lbuff = nSx*sNy*nSy
+       isource = 0
+       itag  = 0
 
-#else /* ALLOW_USE_MPI */
-
-      lbuff=sNy*nSx*nSy
-      isource = 0
-      itag = 0
-
-      IF( mpiMyId .EQ. 0 ) THEN
-
-C--   Process 0 fills-in its local data
-         npe = 0
-         DO bj=1,nSy
-            DO bi=1,nSx
-                  DO j=1,sNy
-                     jG = mpi_myYGlobalLo(npe+1)-1+(bi-1)*sNy+j
-                     local(j,bi,bj) = global(jG)
-                  ENDDO
-            ENDDO
-         ENDDO
+       IF( mpiMyId .EQ. 0 ) THEN
 
 C--   Process 0 sends local arrays to all other processes
-         DO npe = 1, numberOfProcs-1
-            DO bj=1,nSy
-               DO bi=1,nSx
-                     DO j=1,sNy
-                        jG = mpi_myYGlobalLo(npe+1)-1+(bi-1)*sNy+j
-                        temp(j,bi,bj) = global(jG)
-                     ENDDO
-               ENDDO
-            ENDDO
-            CALL MPI_SEND (temp, lbuff, MPI_DOUBLE_PRECISION,
-     &           npe, itag, MPI_COMM_MODEL, ierr)
-         ENDDO
+        DO np = 2, nPx*nPy
 
-      ELSE
+C--   Process 0 extract the local arrays from the global buffer.
+
+#ifdef ALLOW_EXCH2
+         IF ( useExch2GlobLayOut ) THEN
+
+          DO bj=1,nSy
+           DO bi=1,nSx
+             tN = W2_procTileList(bi,bj,np)
+             IF  ( exch2_tNy(tN) .GT. ySize ) THEN
+C-           tile y-size larger than glob-size : make a long line
+               !iGjLoc = exch2_mydNx(tN)
+               jGjLoc = 0
+             ELSE
+C-           default (face fit into global-IO-array)
+               !iGjLoc = 0
+               jGjLoc = 1
+             ENDIF
+
+             DO j=1,sNy
+#ifdef TARGET_NEC_SX
+!cdir novector
+#endif
+              jG=exch2_tyGlobalo(tN)+jGjLoc*(j-1)
+              temp(j,bi,bj) = gloBuff(jG)
+             ENDDO
+
+           ENDDO
+          ENDDO
+
+         ELSE
+#else /* ALLOW_EXCH2 */
+         IF (.TRUE.) THEN
+#endif /* ALLOW_EXCH2 */
+
+          jBase = mpi_myYGlobalLo(np)-1
+
+          DO bj=1,nSy
+           DO bi=1,nSx
+             DO j=1,sNy
+#ifdef TARGET_NEC_SX
+!cdir novector
+#endif
+              jG = jBase+(bj-1)*sNy+j
+              temp(j,bi,bj) = gloBuff(jG)
+             ENDDO
+           ENDDO
+          ENDDO
+
+C        end if-else useExch2GlobLayOut
+         ENDIF
+
+C--   Process 0 sends local arrays to all other processes
+         pId = np - 1
+         CALL MPI_SEND (temp, lbuff, _MPI_TYPE_R4,
+     &           pId, itag, MPI_COMM_MODEL, ierr)
+
+C-      end loop on np
+        ENDDO
+
+       ELSE
 
 C--   All proceses except 0 receive local array from process 0
-         CALL MPI_RECV (local, lbuff, MPI_DOUBLE_PRECISION,
+         CALL MPI_RECV (myField, lbuff, _MPI_TYPE_R4,
      &        isource, itag, MPI_COMM_MODEL, istatus, ierr)
 
-      ENDIF
+       ENDIF
 
+      ENDIF
 #endif /* ALLOW_USE_MPI */
 
-      _END_MASTER( myThid )
-      _BARRIER
+      IF( myProcId .EQ. 0 ) THEN
+C--   Process 0 fills-in its local data
 
-C--   Fill in edges.
-CMM      _EXCH_XY_RL( local, myThid )
+#ifdef ALLOW_EXCH2
+        IF ( useExch2GlobLayOut ) THEN
+
+          DO bj=1,nSy
+           DO bi=1,nSx
+             tN = W2_myTileList(bi,bj)
+             IF  ( exch2_tNy(tN) .GT. ySize ) THEN
+C-           tile y-size larger than glob-size : make a long line
+               !iGjLoc = exch2_mydNx(tN)
+               jGjLoc = 0
+             ELSE
+C-           default (face fit into global-IO-array)
+               !iGjLoc = 0
+               jGjLoc = 1
+             ENDIF
+
+             DO j=1,sNy
+#ifdef TARGET_NEC_SX
+!cdir novector
+#endif
+              jG=exch2_tyGlobalo(tN)+jGjLoc*(j-1)
+              myField(j,bi,bj) = gloBuff(jG)
+             ENDDO
+
+           ENDDO
+          ENDDO
+
+C--   After the copy from the buffer, reset to zero.
+C     An alternative to zeroBuff when writing to file,
+C     which could be faster if we do less read than write.
+          IF ( zeroBuff ) THEN
+            DO j=1,ySize
+             gloBuff(j) = 0.
+            ENDDO
+          ENDIF
+
+        ELSE
+#else /* ALLOW_EXCH2 */
+        IF (.TRUE.) THEN
+#endif /* ALLOW_EXCH2 */
+
+          jBase = myYGlobalLo-1
+
+          DO bj=1,nSy
+           DO bi=1,nSx
+             DO j=1,sNy
+#ifdef TARGET_NEC_SX
+!cdir novector
+#endif
+              jG = jBase+(bj-1)*sNy+j
+              myField(j,bi,bj) = gloBuff(jG)
+             ENDDO
+           ENDDO
+          ENDDO
+
+C       end if-else useExch2GlobLayOut
+        ENDIF
+
+C-    end if myProcId = 0
+      ENDIF
+
+      _END_MASTER( myThid )
 
       RETURN
       END
+C---+----1----+----2----+----3----+----4----+----5----+----6----+----7-|--+----|

--- a/eesupp/src/scatter_yz_r4.F
+++ b/eesupp/src/scatter_yz_r4.F
@@ -29,7 +29,7 @@ C     !USES:
 C     !INPUT/OUTPUT PARAMETERS:
 C gloBuff   ( _R4 ) :: full-domain 2D IO-buffer array              (Input)
 C myField   ( _R4 ) :: tiled, local (i.e. my Proc. tiles) 2D array (Output)
-C ySize    (integer):: global buffer 1st  dim (y)
+C ySize    (integer):: global buffer 2nd  dim (y)
 C useExch2GlobLayOut:: =T: Use Exch2 global-map layout (only with EXCH2)
 C zeroBuff (logical):: =T: reset the buffer to zero after copy
 C myThid   (integer):: my Thread Id number
@@ -62,7 +62,7 @@ C !LOCAL VARIABLES:
 #ifdef ALLOW_USE_MPI
       IF ( usingMPI ) THEN
 
-       lbuff = nSx*sNy*nSy
+       lbuff = sNy*nSy
        isource = 0
        itag  = 0
 
@@ -79,13 +79,17 @@ C--   Process 0 extract the local arrays from the global buffer.
           DO bj=1,nSy
            DO bi=1,nSx
              tN = W2_procTileList(bi,bj,np)
-             IF  ( exch2_tNy(tN) .GT. ySize ) THEN
+             IF   ( exch2_mydNx(tN) .GT. xSize ) THEN
+C-           face x-size larger than glob-size : fold it
+               iGjLoc = 0
+               jGjLoc = exch2_mydNx(tN) / xSize
+             ELSEIF ( exch2_tNy(tN) .GT. ySize ) THEN
 C-           tile y-size larger than glob-size : make a long line
-               !iGjLoc = exch2_mydNx(tN)
+               iGjLoc = exch2_mydNx(tN)
                jGjLoc = 0
              ELSE
 C-           default (face fit into global-IO-array)
-               !iGjLoc = 0
+               iGjLoc = 0
                jGjLoc = 1
              ENDIF
 
@@ -150,7 +154,7 @@ C--   Process 0 fills-in its local data
           DO bj=1,nSy
            DO bi=1,nSx
              tN = W2_myTileList(bi,bj)
-             IF  ( exch2_tNy(tN) .GT. ySize ) THEN
+             IF ( exch2_tNy(tN) .GT. ySize ) THEN
 C-           tile y-size larger than glob-size : make a long line
                !iGjLoc = exch2_mydNx(tN)
                jGjLoc = 0
@@ -176,7 +180,7 @@ C     An alternative to zeroBuff when writing to file,
 C     which could be faster if we do less read than write.
           IF ( zeroBuff ) THEN
             DO j=1,ySize
-             gloBuff(j) = 0.
+              gloBuff(j) = 0.
             ENDDO
           ENDIF
 

--- a/eesupp/src/scatter_yz_r8.F
+++ b/eesupp/src/scatter_yz_r8.F
@@ -79,17 +79,11 @@ C--   Process 0 extract the local arrays from the global buffer.
           DO bj=1,nSy
            DO bi=1,nSx
              tN = W2_procTileList(bi,bj,np)
-             IF   ( exch2_mydNx(tN) .GT. xSize ) THEN
-C-           face x-size larger than glob-size : fold it
-               iGjLoc = 0
-               jGjLoc = exch2_mydNx(tN) / xSize
-             ELSEIF ( exch2_tNy(tN) .GT. ySize ) THEN
+             IF ( exch2_tNy(tN) .GT. ySize ) THEN
 C-           tile y-size larger than glob-size : make a long line
-               iGjLoc = exch2_mydNx(tN)
                jGjLoc = 0
              ELSE
 C-           default (face fit into global-IO-array)
-               iGjLoc = 0
                jGjLoc = 1
              ENDIF
 
@@ -156,11 +150,9 @@ C--   Process 0 fills-in its local data
              tN = W2_myTileList(bi,bj)
              IF ( exch2_tNy(tN) .GT. ySize ) THEN
 C-           tile y-size larger than glob-size : make a long line
-               !iGjLoc = exch2_mydNx(tN)
                jGjLoc = 0
              ELSE
 C-           default (face fit into global-IO-array)
-               !iGjLoc = 0
                jGjLoc = 1
              ENDIF
 

--- a/eesupp/src/scatter_yz_r8.F
+++ b/eesupp/src/scatter_yz_r8.F
@@ -1,90 +1,212 @@
+#include "PACKAGES_CONFIG.h"
 #include "CPP_EEOPTIONS.h"
 
-      SUBROUTINE SCATTER_YZ_R8( global, local, myThid )
-C     Scatter elements of a y-z array from mpi process 0 to all processes.
+CBOP
+C !ROUTINE: SCATTER_YZ_R8
+C !INTERFACE:
+      SUBROUTINE SCATTER_YZ_R8(
+     I                  gloBuff,
+     O                  myField,
+     I                  ySize,
+     I                  useExch2GlobLayOut,
+     I                  zeroBuff,
+     I                  myThid )
+C !DESCRIPTION:
+C     Scatter elements of a global 2-D array from mpi process 0 to all processes.
+C     Note: done by Master-Thread ; might need barrier calls before and after
+C           this S/R call.
+
+C     !USES:
       IMPLICIT NONE
 #include "SIZE.h"
 #include "EEPARAMS.h"
 #include "EESUPPORT.h"
-C     mythid - thread number for this instance of the routine.
-C     global,local - working arrays used to transfer 2-D fields
-      INTEGER mythid
-      _R8 global(Ny)
-      _R8 local(sNy,nSx,nSy)
+#ifdef ALLOW_EXCH2
+#include "W2_EXCH2_SIZE.h"
+#include "W2_EXCH2_TOPOLOGY.h"
+#endif /* ALLOW_EXCH2 */
 
-      INTEGER jG, j, bi, bj
+C     !INPUT/OUTPUT PARAMETERS:
+C gloBuff   ( _R8 ) :: full-domain 2D IO-buffer array              (Input)
+C myField   ( _R8 ) :: tiled, local (i.e. my Proc. tiles) 2D array (Output)
+C ySize    (integer):: global buffer 1st  dim (y)
+C useExch2GlobLayOut:: =T: Use Exch2 global-map layout (only with EXCH2)
+C zeroBuff (logical):: =T: reset the buffer to zero after copy
+C myThid   (integer):: my Thread Id number
+
+      INTEGER ySize
+      _R8     gloBuff(ySize)
+      _R8     myField(1:sNy,nSx,nSy)
+      LOGICAL useExch2GlobLayOut
+      LOGICAL zeroBuff
+      INTEGER myThid
+CEOP
+
+C !LOCAL VARIABLES:
+      INTEGER i,j, bi,bj
+      INTEGER iG, jG
+      INTEGER iBase, jBase
+#ifdef ALLOW_EXCH2
+      INTEGER iGjLoc, jGjLoc
+      INTEGER tN
+#endif /* ALLOW_EXCH2 */
 #ifdef ALLOW_USE_MPI
-
-      _R8 temp(sNy,nSx,nSy)
-
+      INTEGER np, pId
+      _R8     temp(1:sNy,nSx,nSy)
       INTEGER istatus(MPI_STATUS_SIZE), ierr
-      INTEGER isource, itag, npe
-      INTEGER lbuff
+      INTEGER lbuff, isource, itag
 #endif /* ALLOW_USE_MPI */
 
-C--   Make everyone wait except for master thread.
-      _BARRIER
       _BEGIN_MASTER( myThid )
 
-#ifndef ALLOW_USE_MPI
+#ifdef ALLOW_USE_MPI
+      IF ( usingMPI ) THEN
 
-      DO bj=1,nSy
-         DO bi=1,nSx
-               DO j=1,sNy
-                  jG = myYGlobalLo-1+(bi-1)*sNy+j
-                  local(j,bi,bj) = global(jG)
-               ENDDO
-         ENDDO
-      ENDDO
+       lbuff = nSx*sNy*nSy
+       isource = 0
+       itag  = 0
 
-#else /* ALLOW_USE_MPI */
-
-      lbuff=sNy*nSx*nSy
-      isource = 0
-      itag = 0
-
-      IF( mpiMyId .EQ. 0 ) THEN
-
-C--   Process 0 fills-in its local data
-         npe = 0
-         DO bj=1,nSy
-            DO bi=1,nSx
-                  DO j=1,sNy
-                     jG = mpi_myYGlobalLo(npe+1)-1+(bi-1)*sNy+j
-                     local(j,bi,bj) = global(jG)
-                  ENDDO
-            ENDDO
-         ENDDO
+       IF( mpiMyId .EQ. 0 ) THEN
 
 C--   Process 0 sends local arrays to all other processes
-         DO npe = 1, numberOfProcs-1
-            DO bj=1,nSy
-               DO bi=1,nSx
-                     DO j=1,sNy
-                        jG = mpi_myYGlobalLo(npe+1)-1+(bi-1)*sNy+j
-                        temp(j,bi,bj) = global(jG)
-                     ENDDO
-               ENDDO
-            ENDDO
-            CALL MPI_SEND (temp, lbuff, MPI_DOUBLE_PRECISION,
-     &           npe, itag, MPI_COMM_MODEL, ierr)
-         ENDDO
+        DO np = 2, nPx*nPy
 
-      ELSE
+C--   Process 0 extract the local arrays from the global buffer.
+
+#ifdef ALLOW_EXCH2
+         IF ( useExch2GlobLayOut ) THEN
+
+          DO bj=1,nSy
+           DO bi=1,nSx
+             tN = W2_procTileList(bi,bj,np)
+             IF  ( exch2_tNy(tN) .GT. ySize ) THEN
+C-           tile y-size larger than glob-size : make a long line
+               !iGjLoc = exch2_mydNx(tN)
+               jGjLoc = 0
+             ELSE
+C-           default (face fit into global-IO-array)
+               !iGjLoc = 0
+               jGjLoc = 1
+             ENDIF
+
+             DO j=1,sNy
+#ifdef TARGET_NEC_SX
+!cdir novector
+#endif
+              jG=exch2_tyGlobalo(tN)+jGjLoc*(j-1)
+              temp(j,bi,bj) = gloBuff(jG)
+             ENDDO
+
+           ENDDO
+          ENDDO
+
+         ELSE
+#else /* ALLOW_EXCH2 */
+         IF (.TRUE.) THEN
+#endif /* ALLOW_EXCH2 */
+
+          jBase = mpi_myYGlobalLo(np)-1
+
+          DO bj=1,nSy
+           DO bi=1,nSx
+             DO j=1,sNy
+#ifdef TARGET_NEC_SX
+!cdir novector
+#endif
+              jG = jBase+(bj-1)*sNy+j
+              temp(j,bi,bj) = gloBuff(jG)
+             ENDDO
+           ENDDO
+          ENDDO
+
+C        end if-else useExch2GlobLayOut
+         ENDIF
+
+C--   Process 0 sends local arrays to all other processes
+         pId = np - 1
+         CALL MPI_SEND (temp, lbuff, _MPI_TYPE_R4,
+     &           pId, itag, MPI_COMM_MODEL, ierr)
+
+C-      end loop on np
+        ENDDO
+
+       ELSE
 
 C--   All proceses except 0 receive local array from process 0
-         CALL MPI_RECV (local, lbuff, MPI_DOUBLE_PRECISION,
+         CALL MPI_RECV (myField, lbuff, _MPI_TYPE_R4,
      &        isource, itag, MPI_COMM_MODEL, istatus, ierr)
 
-      ENDIF
+       ENDIF
 
+      ENDIF
 #endif /* ALLOW_USE_MPI */
 
-      _END_MASTER( myThid )
-      _BARRIER
+      IF( myProcId .EQ. 0 ) THEN
+C--   Process 0 fills-in its local data
 
-C--   Fill in edges.
-CMM      _EXCH_XY_RL( local, myThid )
+#ifdef ALLOW_EXCH2
+        IF ( useExch2GlobLayOut ) THEN
+
+          DO bj=1,nSy
+           DO bi=1,nSx
+             tN = W2_myTileList(bi,bj)
+             IF  ( exch2_tNy(tN) .GT. ySize ) THEN
+C-           tile y-size larger than glob-size : make a long line
+               !iGjLoc = exch2_mydNx(tN)
+               jGjLoc = 0
+             ELSE
+C-           default (face fit into global-IO-array)
+               !iGjLoc = 0
+               jGjLoc = 1
+             ENDIF
+
+             DO j=1,sNy
+#ifdef TARGET_NEC_SX
+!cdir novector
+#endif
+              jG=exch2_tyGlobalo(tN)+jGjLoc*(j-1)
+              myField(j,bi,bj) = gloBuff(jG)
+             ENDDO
+
+           ENDDO
+          ENDDO
+
+C--   After the copy from the buffer, reset to zero.
+C     An alternative to zeroBuff when writing to file,
+C     which could be faster if we do less read than write.
+          IF ( zeroBuff ) THEN
+            DO j=1,ySize
+             gloBuff(j) = 0.
+            ENDDO
+          ENDIF
+
+        ELSE
+#else /* ALLOW_EXCH2 */
+        IF (.TRUE.) THEN
+#endif /* ALLOW_EXCH2 */
+
+          jBase = myYGlobalLo-1
+
+          DO bj=1,nSy
+           DO bi=1,nSx
+             DO j=1,sNy
+#ifdef TARGET_NEC_SX
+!cdir novector
+#endif
+              jG = jBase+(bj-1)*sNy+j
+              myField(j,bi,bj) = gloBuff(jG)
+             ENDDO
+           ENDDO
+          ENDDO
+
+C       end if-else useExch2GlobLayOut
+        ENDIF
+
+C-    end if myProcId = 0
+      ENDIF
+
+      _END_MASTER( myThid )
 
       RETURN
       END
+C---+----1----+----2----+----3----+----4----+----5----+----6----+----7-|--+----|

--- a/eesupp/src/scatter_yz_r8.F
+++ b/eesupp/src/scatter_yz_r8.F
@@ -1,0 +1,90 @@
+#include "CPP_EEOPTIONS.h"
+
+      SUBROUTINE SCATTER_YZ_R8( global, local, myThid )
+C     Scatter elements of a y-z array from mpi process 0 to all processes.
+      IMPLICIT NONE
+#include "SIZE.h"
+#include "EEPARAMS.h"
+#include "EESUPPORT.h"
+C     mythid - thread number for this instance of the routine.
+C     global,local - working arrays used to transfer 2-D fields
+      INTEGER mythid
+      _R8 global(Ny)
+      _R8 local(sNy,nSx,nSy)
+
+      INTEGER jG, j, bi, bj
+#ifdef ALLOW_USE_MPI
+
+      _R8 temp(sNy,nSx,nSy)
+
+      INTEGER istatus(MPI_STATUS_SIZE), ierr
+      INTEGER isource, itag, npe
+      INTEGER lbuff
+#endif /* ALLOW_USE_MPI */
+
+C--   Make everyone wait except for master thread.
+      _BARRIER
+      _BEGIN_MASTER( myThid )
+
+#ifndef ALLOW_USE_MPI
+
+      DO bj=1,nSy
+         DO bi=1,nSx
+               DO j=1,sNy
+                  jG = myYGlobalLo-1+(bi-1)*sNy+j
+                  local(j,bi,bj) = global(jG)
+               ENDDO
+         ENDDO
+      ENDDO
+
+#else /* ALLOW_USE_MPI */
+
+      lbuff=sNy*nSx*nSy
+      isource = 0
+      itag = 0
+
+      IF( mpiMyId .EQ. 0 ) THEN
+
+C--   Process 0 fills-in its local data
+         npe = 0
+         DO bj=1,nSy
+            DO bi=1,nSx
+                  DO j=1,sNy
+                     jG = mpi_myYGlobalLo(npe+1)-1+(bi-1)*sNy+j
+                     local(j,bi,bj) = global(jG)
+                  ENDDO
+            ENDDO
+         ENDDO
+
+C--   Process 0 sends local arrays to all other processes
+         DO npe = 1, numberOfProcs-1
+            DO bj=1,nSy
+               DO bi=1,nSx
+                     DO j=1,sNy
+                        jG = mpi_myYGlobalLo(npe+1)-1+(bi-1)*sNy+j
+                        temp(j,bi,bj) = global(jG)
+                     ENDDO
+               ENDDO
+            ENDDO
+            CALL MPI_SEND (temp, lbuff, MPI_DOUBLE_PRECISION,
+     &           npe, itag, MPI_COMM_MODEL, ierr)
+         ENDDO
+
+      ELSE
+
+C--   All proceses except 0 receive local array from process 0
+         CALL MPI_RECV (local, lbuff, MPI_DOUBLE_PRECISION,
+     &        isource, itag, MPI_COMM_MODEL, istatus, ierr)
+
+      ENDIF
+
+#endif /* ALLOW_USE_MPI */
+
+      _END_MASTER( myThid )
+      _BARRIER
+
+C--   Fill in edges.
+CMM      _EXCH_XY_RL( local, myThid )
+
+      RETURN
+      END

--- a/eesupp/src/scatter_yz_r8.F
+++ b/eesupp/src/scatter_yz_r8.F
@@ -29,7 +29,7 @@ C     !USES:
 C     !INPUT/OUTPUT PARAMETERS:
 C gloBuff   ( _R8 ) :: full-domain 2D IO-buffer array              (Input)
 C myField   ( _R8 ) :: tiled, local (i.e. my Proc. tiles) 2D array (Output)
-C ySize    (integer):: global buffer 1st  dim (y)
+C ySize    (integer):: global buffer 2nd  dim (y)
 C useExch2GlobLayOut:: =T: Use Exch2 global-map layout (only with EXCH2)
 C zeroBuff (logical):: =T: reset the buffer to zero after copy
 C myThid   (integer):: my Thread Id number
@@ -62,7 +62,7 @@ C !LOCAL VARIABLES:
 #ifdef ALLOW_USE_MPI
       IF ( usingMPI ) THEN
 
-       lbuff = nSx*sNy*nSy
+       lbuff = sNy*nSy
        isource = 0
        itag  = 0
 
@@ -79,13 +79,17 @@ C--   Process 0 extract the local arrays from the global buffer.
           DO bj=1,nSy
            DO bi=1,nSx
              tN = W2_procTileList(bi,bj,np)
-             IF  ( exch2_tNy(tN) .GT. ySize ) THEN
+             IF   ( exch2_mydNx(tN) .GT. xSize ) THEN
+C-           face x-size larger than glob-size : fold it
+               iGjLoc = 0
+               jGjLoc = exch2_mydNx(tN) / xSize
+             ELSEIF ( exch2_tNy(tN) .GT. ySize ) THEN
 C-           tile y-size larger than glob-size : make a long line
-               !iGjLoc = exch2_mydNx(tN)
+               iGjLoc = exch2_mydNx(tN)
                jGjLoc = 0
              ELSE
 C-           default (face fit into global-IO-array)
-               !iGjLoc = 0
+               iGjLoc = 0
                jGjLoc = 1
              ENDIF
 
@@ -124,7 +128,7 @@ C        end if-else useExch2GlobLayOut
 
 C--   Process 0 sends local arrays to all other processes
          pId = np - 1
-         CALL MPI_SEND (temp, lbuff, _MPI_TYPE_R4,
+         CALL MPI_SEND (temp, lbuff, _MPI_TYPE_R8,
      &           pId, itag, MPI_COMM_MODEL, ierr)
 
 C-      end loop on np
@@ -133,7 +137,7 @@ C-      end loop on np
        ELSE
 
 C--   All proceses except 0 receive local array from process 0
-         CALL MPI_RECV (myField, lbuff, _MPI_TYPE_R4,
+         CALL MPI_RECV (myField, lbuff, _MPI_TYPE_R8,
      &        isource, itag, MPI_COMM_MODEL, istatus, ierr)
 
        ENDIF
@@ -150,7 +154,7 @@ C--   Process 0 fills-in its local data
           DO bj=1,nSy
            DO bi=1,nSx
              tN = W2_myTileList(bi,bj)
-             IF  ( exch2_tNy(tN) .GT. ySize ) THEN
+             IF ( exch2_tNy(tN) .GT. ySize ) THEN
 C-           tile y-size larger than glob-size : make a long line
                !iGjLoc = exch2_mydNx(tN)
                jGjLoc = 0
@@ -176,7 +180,7 @@ C     An alternative to zeroBuff when writing to file,
 C     which could be faster if we do less read than write.
           IF ( zeroBuff ) THEN
             DO j=1,ySize
-             gloBuff(j) = 0.
+              gloBuff(j) = 0.
             ENDDO
           ENDIF
 

--- a/pkg/autodiff/active_file_control_slice.F
+++ b/pkg/autodiff/active_file_control_slice.F
@@ -112,7 +112,7 @@ C     >>>>>>>>>>>>>>>>>>> FORWARD RUN <<<<<<<<<<<<<<<<<<<
 C     Read the active variable from file.
         CALL MDS_READ_SEC_XZ(
      I                activeVar_file, prec, useCurrentDir,
-     I                'RL', myNr,
+     I                'RL', myNr, 1, myNr,
      O                active_var, dummyRS,
      I                iRec, myThid )
 
@@ -145,7 +145,7 @@ C     >>>>>>>>>>>>>>>>>>> ADJOINT RUN <<<<<<<<<<<<<<<<<<<
 
         CALL MDS_READ_SEC_XZ(
      I                activeVar_file, prec, useCurrentDir,
-     I                'RL', myNr,
+     I                'RL', myNr, 1, myNr,
      O                active_data_t, dummyRS,
      I                iRec, myThid )
 
@@ -187,7 +187,7 @@ C     >>>>>>>>>>>>>>>>>>> TANGENT RUN <<<<<<<<<<<<<<<<<<<
 C     Read the active variable from file.
         CALL MDS_READ_SEC_XZ(
      I                activeVar_file, prec, useCurrentDir,
-     I                'RL', myNr,
+     I                'RL', myNr, 1, myNr,
      O                active_var, dummyRS,
      I                iRec, myThid )
       ENDIF
@@ -288,7 +288,7 @@ C     >>>>>>>>>>>>>>>>>>> FORWARD RUN <<<<<<<<<<<<<<<<<<<
 C     Read the active variable from file.
         CALL MDS_READ_SEC_XZ(
      I                activeVar_file, prec, useCurrentDir,
-     I                'RS', myNr,
+     I                'RS', myNr, 1, myNr,
      O                dummyRL, active_var,
      I                iRec, myThid )
 
@@ -321,7 +321,7 @@ C     >>>>>>>>>>>>>>>>>>> ADJOINT RUN <<<<<<<<<<<<<<<<<<<
 
         CALL MDS_READ_SEC_XZ(
      I                activeVar_file, prec, useCurrentDir,
-     I                'RS', myNr,
+     I                'RS', myNr, 1, myNr,
      O                dummyRL, active_data_t,
      I                iRec, myThid )
 
@@ -363,7 +363,7 @@ C     >>>>>>>>>>>>>>>>>>> TANGENT RUN <<<<<<<<<<<<<<<<<<<
 C     Read the active variable from file.
         CALL MDS_READ_SEC_XZ(
      I                activeVar_file, prec, useCurrentDir,
-     I                'RS', myNr,
+     I                'RS', myNr, 1, myNr,
      O                dummyRL, active_var,
      I                iRec, myThid )
       ENDIF
@@ -463,7 +463,7 @@ C     >>>>>>>>>>>>>>>>>>> FORWARD RUN <<<<<<<<<<<<<<<<<<<
 C     Read the active variable from file.
         CALL MDS_READ_SEC_YZ(
      I                activeVar_file, prec, useCurrentDir,
-     I                'RL', myNr,
+     I                'RL', myNr, 1, myNr,
      O                active_var, dummyRS,
      I                iRec, myThid )
 
@@ -496,7 +496,7 @@ C     >>>>>>>>>>>>>>>>>>> ADJOINT RUN <<<<<<<<<<<<<<<<<<<
 
         CALL MDS_READ_SEC_YZ(
      I                activeVar_file, prec, useCurrentDir,
-     I                'RL', myNr,
+     I                'RL', myNr, 1, myNr,
      O                active_data_t, dummyRS,
      I                iRec, myThid )
 
@@ -538,7 +538,7 @@ C     >>>>>>>>>>>>>>>>>>> TANGENT RUN <<<<<<<<<<<<<<<<<<<
 C     Read the active variable from file.
         CALL MDS_READ_SEC_YZ(
      I                activeVar_file, prec, useCurrentDir,
-     I                'RL', myNr,
+     I                'RL', myNr, 1, myNr,
      O                active_var, dummyRS,
      I                iRec, myThid )
       ENDIF
@@ -639,7 +639,7 @@ C     >>>>>>>>>>>>>>>>>>> FORWARD RUN <<<<<<<<<<<<<<<<<<<
 C     Read the active variable from file.
         CALL MDS_READ_SEC_YZ(
      I                activeVar_file, prec, useCurrentDir,
-     I                'RS', myNr,
+     I                'RS', myNr, 1, myNr,
      O                dummyRL, active_var,
      I                iRec, myThid )
 
@@ -672,7 +672,7 @@ C     >>>>>>>>>>>>>>>>>>> ADJOINT RUN <<<<<<<<<<<<<<<<<<<
 
         CALL MDS_READ_SEC_YZ(
      I                activeVar_file, prec, useCurrentDir,
-     I                'RS', myNr,
+     I                'RS', myNr, 1, myNr,
      O                dummyRL, active_data_t,
      I                iRec, myThid )
 
@@ -714,7 +714,7 @@ C     >>>>>>>>>>>>>>>>>>> TANGENT RUN <<<<<<<<<<<<<<<<<<<
 C     Read the active variable from file.
         CALL MDS_READ_SEC_YZ(
      I                activeVar_file, prec, useCurrentDir,
-     I                'RS', myNr,
+     I                'RS', myNr, 1, myNr,
      O                dummyRL, active_var,
      I                iRec, myThid )
       ENDIF
@@ -803,7 +803,7 @@ C     >>>>>>>>>>>>>>>>>>> ADJOINT RUN <<<<<<<<<<<<<<<<<<<
 
         CALL MDS_READ_SEC_XZ(
      I                activeVar_file, prec, useCurrentDir,
-     I                'RL', myNr,
+     I                'RL', myNr, 1, myNr,
      O                active_data_t, dummyRS,
      I                iRec, myThid )
 
@@ -920,7 +920,7 @@ C     >>>>>>>>>>>>>>>>>>> ADJOINT RUN <<<<<<<<<<<<<<<<<<<
 
         CALL MDS_READ_SEC_XZ(
      I                activeVar_file, prec, useCurrentDir,
-     I                'RS', myNr,
+     I                'RS', myNr, 1, myNr,
      O                dummyRL, active_data_t,
      I                iRec, myThid )
 
@@ -1037,7 +1037,7 @@ C     >>>>>>>>>>>>>>>>>>> ADJOINT RUN <<<<<<<<<<<<<<<<<<<
 
         CALL MDS_READ_SEC_YZ(
      I                activeVar_file, prec, useCurrentDir,
-     I                'RL', myNr,
+     I                'RL', myNr, 1, myNr,
      O                active_data_t, dummyRS,
      I                iRec, myThid )
 
@@ -1154,7 +1154,7 @@ C     >>>>>>>>>>>>>>>>>>> ADJOINT RUN <<<<<<<<<<<<<<<<<<<
 
         CALL MDS_READ_SEC_YZ(
      I                activeVar_file, prec, useCurrentDir,
-     I                'RS', myNr,
+     I                'RS', myNr, 1, myNr,
      O                dummyRL, active_data_t,
      I                iRec, myThid )
 

--- a/pkg/autodiff/active_file_control_slice.F
+++ b/pkg/autodiff/active_file_control_slice.F
@@ -132,7 +132,7 @@ C     adjoint variable file. These files are tiled.
 
           CALL MDS_WRITE_SEC_XZ(
      I                adfname, prec, globalFile, useCurrentDir,
-     I                'RL', myNr,
+     I                'RL', myNr, 1, myNr,
      I                active_data_t, dummyRS,
      I                iRec, myOptimIter, myThid )
 
@@ -165,7 +165,7 @@ C     Store the result on disk.
         w_globFile = .FALSE.
         CALL MDS_WRITE_SEC_XZ(
      I                activeVar_file, prec, w_globFile, useCurrentDir,
-     I                'RL', myNr,
+     I                'RL', myNr, 1, myNr,
      I                active_data_t, dummyRS,
      I                iRec, myOptimIter, myThid )
 
@@ -308,7 +308,7 @@ C     adjoint variable file. These files are tiled.
 
           CALL MDS_WRITE_SEC_XZ(
      I                adfname, prec, globalFile, useCurrentDir,
-     I                'RS', myNr,
+     I                'RS', myNr, 1, myNr,
      I                dummyRL, active_data_t,
      I                iRec, myOptimIter, myThid )
 
@@ -341,7 +341,7 @@ C     Store the result on disk.
         w_globFile = .FALSE.
         CALL MDS_WRITE_SEC_XZ(
      I                activeVar_file, prec, w_globFile, useCurrentDir,
-     I                'RS', myNr,
+     I                'RS', myNr, 1, myNr,
      I                dummyRL, active_data_t,
      I                iRec, myOptimIter, myThid )
 
@@ -483,7 +483,7 @@ C     adjoint variable file. These files are tiled.
 
           CALL MDS_WRITE_SEC_YZ(
      I                adfname, prec, globalFile, useCurrentDir,
-     I                'RL', myNr,
+     I                'RL', myNr, 1, myNr,
      I                active_data_t, dummyRS,
      I                iRec, myOptimIter, myThid )
 
@@ -516,7 +516,7 @@ C     Store the result on disk.
         w_globFile = .FALSE.
         CALL MDS_WRITE_SEC_YZ(
      I                activeVar_file, prec, w_globFile, useCurrentDir,
-     I                'RL', myNr,
+     I                'RL', myNr, 1, myNr,
      I                active_data_t, dummyRS,
      I                iRec, myOptimIter, myThid )
 
@@ -659,7 +659,7 @@ C     adjoint variable file. These files are tiled.
 
           CALL MDS_WRITE_SEC_YZ(
      I                adfname, prec, globalFile, useCurrentDir,
-     I                'RS', myNr,
+     I                'RS', myNr, 1, myNr,
      I                dummyRL, active_data_t,
      I                iRec, myOptimIter, myThid )
 
@@ -692,7 +692,7 @@ C     Store the result on disk.
         w_globFile = .FALSE.
         CALL MDS_WRITE_SEC_YZ(
      I                activeVar_file, prec, w_globFile, useCurrentDir,
-     I                'RS', myNr,
+     I                'RS', myNr, 1, myNr,
      I                dummyRL, active_data_t,
      I                iRec, myOptimIter, myThid )
 
@@ -793,7 +793,7 @@ C     >>>>>>>>>>>>>>>>>>> FORWARD RUN <<<<<<<<<<<<<<<<<<<
       IF (theSimulationMode .EQ. FORWARD_SIMULATION) THEN
         CALL MDS_WRITE_SEC_XZ(
      I                activeVar_file, prec, globalFile, useCurrentDir,
-     I                'RL', myNr,
+     I                'RL', myNr, 1, myNr,
      I                active_var, dummyRS,
      I                iRec, myOptimIter, myThid )
       ENDIF
@@ -821,7 +821,7 @@ C     Add active_var from appropriate location to data.
         ENDDO
         CALL MDS_WRITE_SEC_XZ(
      I                activeVar_file, prec, globalFile, useCurrentDir,
-     I                'RL', myNr,
+     I                'RL', myNr, 1, myNr,
      I                active_data_t, dummyRS,
      I                iRec, myOptimIter, myThid )
 
@@ -831,7 +831,7 @@ C     >>>>>>>>>>>>>>>>>>> TANGENT RUN <<<<<<<<<<<<<<<<<<<
       IF (theSimulationMode .EQ. TANGENT_SIMULATION) THEN
         CALL MDS_WRITE_SEC_XZ(
      I                activeVar_file, prec, globalFile, useCurrentDir,
-     I                'RL', myNr,
+     I                'RL', myNr, 1, myNr,
      I                active_var, dummyRS,
      I                iRec, myOptimIter, myThid )
       ENDIF
@@ -910,7 +910,7 @@ C     >>>>>>>>>>>>>>>>>>> FORWARD RUN <<<<<<<<<<<<<<<<<<<
       IF (theSimulationMode .EQ. FORWARD_SIMULATION) THEN
         CALL MDS_WRITE_SEC_XZ(
      I                activeVar_file, prec, globalFile, useCurrentDir,
-     I                'RS', myNr,
+     I                'RS', myNr, 1, myNr,
      I                dummyRL, active_var,
      I                iRec, myOptimIter, myThid )
       ENDIF
@@ -938,7 +938,7 @@ C     Add active_var from appropriate location to data.
         ENDDO
         CALL MDS_WRITE_SEC_XZ(
      I                activeVar_file, prec, globalFile, useCurrentDir,
-     I                'RS', myNr,
+     I                'RS', myNr, 1, myNr,
      I                dummyRL, active_data_t,
      I                iRec, myOptimIter, myThid )
 
@@ -948,7 +948,7 @@ C     >>>>>>>>>>>>>>>>>>> TANGENT RUN <<<<<<<<<<<<<<<<<<<
       IF (theSimulationMode .EQ. TANGENT_SIMULATION) THEN
         CALL MDS_WRITE_SEC_XZ(
      I                activeVar_file, prec, globalFile, useCurrentDir,
-     I                'RS', myNr,
+     I                'RS', myNr, 1, myNr,
      I                dummyRL, active_var,
      I                iRec, myOptimIter, myThid )
       ENDIF
@@ -1027,7 +1027,7 @@ C     >>>>>>>>>>>>>>>>>>> FORWARD RUN <<<<<<<<<<<<<<<<<<<
       IF (theSimulationMode .EQ. FORWARD_SIMULATION) THEN
         CALL MDS_WRITE_SEC_YZ(
      I                activeVar_file, prec, globalFile, useCurrentDir,
-     I                'RL', myNr,
+     I                'RL', myNr, 1, myNr,
      I                active_var, dummyRS,
      I                iRec, myOptimIter, myThid )
       ENDIF
@@ -1055,7 +1055,7 @@ C     Add active_var from appropriate location to data.
         ENDDO
         CALL MDS_WRITE_SEC_YZ(
      I                activeVar_file, prec, globalFile, useCurrentDir,
-     I                'RL', myNr,
+     I                'RL', myNr, 1, myNr,
      I                active_data_t, dummyRS,
      I                iRec, myOptimIter, myThid )
 
@@ -1065,7 +1065,7 @@ C     >>>>>>>>>>>>>>>>>>> TANGENT RUN <<<<<<<<<<<<<<<<<<<
       IF (theSimulationMode .EQ. TANGENT_SIMULATION) THEN
         CALL MDS_WRITE_SEC_YZ(
      I                activeVar_file, prec, globalFile, useCurrentDir,
-     I                'RL', myNr,
+     I                'RL', myNr, 1, myNr,
      I                active_var, dummyRS,
      I                iRec, myOptimIter, myThid )
       ENDIF
@@ -1144,7 +1144,7 @@ C     >>>>>>>>>>>>>>>>>>> FORWARD RUN <<<<<<<<<<<<<<<<<<<
       IF (theSimulationMode .EQ. FORWARD_SIMULATION) THEN
         CALL MDS_WRITE_SEC_YZ(
      I                activeVar_file, prec, globalFile, useCurrentDir,
-     I                'RS', myNr,
+     I                'RS', myNr, 1, myNr,
      I                dummyRL, active_var,
      I                iRec, myOptimIter, myThid )
       ENDIF
@@ -1172,7 +1172,7 @@ C     Add active_var from appropriate location to data.
         ENDDO
         CALL MDS_WRITE_SEC_YZ(
      I                activeVar_file, prec, globalFile, useCurrentDir,
-     I                'RS', myNr,
+     I                'RS', myNr, 1, myNr,
      I                dummyRL, active_data_t,
      I                iRec, myOptimIter, myThid )
 
@@ -1182,7 +1182,7 @@ C     >>>>>>>>>>>>>>>>>>> TANGENT RUN <<<<<<<<<<<<<<<<<<<
       IF (theSimulationMode .EQ. TANGENT_SIMULATION) THEN
         CALL MDS_WRITE_SEC_YZ(
      I                activeVar_file, prec, globalFile, useCurrentDir,
-     I                'RS', myNr,
+     I                'RS', myNr, 1, myNr,
      I                dummyRL, active_var,
      I                iRec, myOptimIter, myThid )
       ENDIF

--- a/pkg/mdsio/mdsio_ad.flow
+++ b/pkg/mdsio/mdsio_ad.flow
@@ -47,13 +47,13 @@ CADJ SUBROUTINE mds_read_sec_yz  REQUIRED
 C----------------------------------------
 C subroutine mds_write_sec_xz
 C----------------------------------------
-CADJ SUBROUTINE mds_write_sec_xz  INPUT  = 1,2,3,4,5,6,7,8,9,10,11
+CADJ SUBROUTINE mds_write_sec_xz  INPUT  = 1,2,3,4,5,6,7,8,9,10,11,12,13
 CADJ SUBROUTINE mds_write_sec_xz  OUTPUT =
 
 C----------------------------------------
 C subroutine mds_write_sec_yz
 C----------------------------------------
-CADJ SUBROUTINE mds_write_sec_yz  INPUT  = 1,2,3,4,5,6,7,8,9,10,11
+CADJ SUBROUTINE mds_write_sec_yz  INPUT  = 1,2,3,4,5,6,7,8,9,10,11,12,13
 CADJ SUBROUTINE mds_write_sec_yz  OUTPUT =
 
 C----------------------------------------

--- a/pkg/mdsio/mdsio_ad.flow
+++ b/pkg/mdsio/mdsio_ad.flow
@@ -31,17 +31,17 @@ cCADJ SUBROUTINE mds_read_rec_yz  REQUIRED
 C----------------------------------------
 C subroutine mds_read_sec_xz
 C----------------------------------------
-CADJ SUBROUTINE mds_read_sec_xz  INPUT  = 1,2,3,4,5,    8,9
-CADJ SUBROUTINE mds_read_sec_xz  OUTPUT =           6,7
-CADJ SUBROUTINE mds_read_sec_xz  DEPEND = 1,2,3,4,5,6,7,8,9
+CADJ SUBROUTINE mds_read_sec_xz  INPUT  = 1,2,3,4,5,6,7,    10,11
+CADJ SUBROUTINE mds_read_sec_xz  OUTPUT =               8,9
+CADJ SUBROUTINE mds_read_sec_xz  DEPEND = 1,2,3,4,5,6,7,8,9,10,11
 CADJ SUBROUTINE mds_read_sec_xz  REQUIRED
 
 C----------------------------------------
 C subroutine mds_read_sec_yz
 C----------------------------------------
-CADJ SUBROUTINE mds_read_sec_yz  INPUT  = 1,2,3,4,5,    8,9
-CADJ SUBROUTINE mds_read_sec_yz  OUTPUT =           6,7
-CADJ SUBROUTINE mds_read_sec_yz  DEPEND = 1,2,3,4,5,6,7,8,9
+CADJ SUBROUTINE mds_read_sec_yz  INPUT  = 1,2,3,4,5,6,7,    10,11
+CADJ SUBROUTINE mds_read_sec_yz  OUTPUT =               8,9
+CADJ SUBROUTINE mds_read_sec_yz  DEPEND = 1,2,3,4,5,6,7,8,9,10,11
 CADJ SUBROUTINE mds_read_sec_yz  REQUIRED
 
 C----------------------------------------

--- a/pkg/mdsio/mdsio_pass_r4torl.F
+++ b/pkg/mdsio/mdsio_pass_r4torl.F
@@ -41,7 +41,7 @@ C copyTo  (logical):: if =T, copy 2-D -> 3-D ; if =F: copy 2-D <- 3-D
 C myThid  (integer):: my Thread Id number
       INTEGER oLi, oLj
       INTEGER nNz, kSize
-      Real*4 buffer(1-oLi:sNx+oLi,1-oLj:sNy+oLj,nNz,nSx,nSy)
+      _R4 buffer(1-oLi:sNx+oLi,1-oLj:sNy+oLj,nNz,nSx,nSy)
       _RL    arrFld(1-OLx:sNx+OLx,1-OLy:sNy+OLy,kSize,nSx,nSy)
       INTEGER kLo
       INTEGER biArg
@@ -121,6 +121,109 @@ CEOP
 C---+----1----+----2----+----3----+----4----+----5----+----6----+----7-|--+----|
 
 CBOP
+C !ROUTINE: MDS_PASS_XZ_R4toRL
+C !INTERFACE:
+      SUBROUTINE MDS_PASS_XZ_R4toRL(
+     U                            buffer, arrFld,
+     I                            oL, nNz, kLo, kSize,
+     I                            biArg, bjArg, copyTo, myThid )
+
+C !DESCRIPTION:
+C     Transfert 2-D, yz slice real*4 buffer to 2-D RS model array, or the reverse,
+C      depending on "copyTo" value. Apply transfert to tile biArg,bjArg
+C      only or to all myThid tiles if called with biArg=bjArg=0.
+
+C     !USES:
+      IMPLICIT NONE
+
+C Global variables / common blocks
+#include "EEPARAMS.h"
+#include "SIZE.h"
+
+C     !INPUT/OUTPUT PARAMETERS:
+C Routine arguments
+C buffer  (real*4) :: buffer 2-D array (Input/Output if copyTo=T/F)
+C arrFld   ( RL )  :: model 2-D tiled array (Output/Input if copyTo=T/F)
+C oL     (integer):: Overlap size (dim-1) of buffer to copy - to/from - arrFld
+C nNz     (integer):: Number of levels to - fill in / extract from - arrFld
+C kLo     (integer):: 1rst level to - fill in / extract from - arrFld
+C kSize   (integer):: third dimension of 3-D array "arrFld"
+C biArg   (integer):: tile X-index to - fill in / extract from - tiled buffer
+C bjArg   (integer):: tile Y-index to - fill in / extract from - tiled buffer
+C copyTo  (logical):: if =T, copy 2-D -> 3-D ; if =F: copy 2-D <- 3-D
+C myThid  (integer):: my Thread Id number
+      INTEGER oL
+      INTEGER nNz, kSize
+      _R4 buffer(1-oL:sNx+oL,nNz,nSx,nSy)
+      _RL    arrFld(1-OLy:sNx+OLy,kSize,nSx,nSy)
+      INTEGER kLo
+      INTEGER biArg
+      INTEGER bjArg
+      LOGICAL copyTo
+      INTEGER myThid
+
+C !LOCAL VARIABLES:
+C   i,j,k :: loop indices
+C   bi,bj :: tile indices
+      INTEGER i,j,k,bi,bj
+      INTEGER kLev
+CEOP
+      IF ( oL.LT.0 .OR. oL.GT.OLy ) THEN
+        STOP 'ABNORMAL END: MDS_PASS_XZ_R4toRL invalid oL,oL Arg'
+      ENDIF
+
+      IF ( biArg.EQ.0 .AND. bjArg.EQ.0 ) THEN
+        IF ( copyTo ) THEN
+          DO bj = myByLo(myThid), myByHi(myThid)
+           DO bi = myBxLo(myThid), myBxHi(myThid)
+            DO k=1,nNz
+             kLev = kLo+k-1
+             DO i=1-oL,sNx+oL
+               arrFld(i,kLev,bi,bj) = buffer(i,k,bi,bj)
+             ENDDO
+            ENDDO
+           ENDDO
+          ENDDO
+        ELSE
+          DO bj = myByLo(myThid), myByHi(myThid)
+           DO bi = myBxLo(myThid), myBxHi(myThid)
+            DO k=1,nNz
+             kLev = kLo+k-1
+             DO i=1-oL,sNx+oL
+               buffer(i,k,bi,bj) = arrFld(i,kLev,bi,bj)
+             ENDDO
+            ENDDO
+           ENDDO
+          ENDDO
+        ENDIF
+      ELSEIF ( biArg.GE.1 .AND. biArg.LE.nSx
+     &   .AND. bjArg.GE.1 .AND. bjArg.LE.nSy ) THEN
+        bi = biArg
+        bj = bjArg
+        IF ( copyTo ) THEN
+          DO k=1,nNz
+            kLev = kLo+k-1
+            DO i=1-oL,sNx+oL
+              arrFld(i,kLev,1,1) = buffer(i,k,bi,bj)
+            ENDDO
+          ENDDO
+        ELSE
+          DO k=1,nNz
+            kLev = kLo+k-1
+            DO i=1-oL,sNx+oL
+              buffer(i,k,bi,bj) = arrFld(i,kLev,1,1)
+            ENDDO
+          ENDDO
+        ENDIF
+      ELSE
+        STOP 'ABNORMAL END: MDS_PASS_XZ_R4toRL invalid bi,bj Arg'
+      ENDIF
+
+      RETURN
+      END
+
+C---+----1----+----2----+----3----+----4----+----5----+----6----+----7-|--+----|
+CBOP
 C !ROUTINE: MDS_PASS_YZ_R4toRL
 C !INTERFACE:
       SUBROUTINE MDS_PASS_YZ_R4toRL(
@@ -154,7 +257,7 @@ C copyTo  (logical):: if =T, copy 2-D -> 3-D ; if =F: copy 2-D <- 3-D
 C myThid  (integer):: my Thread Id number
       INTEGER oL
       INTEGER nNz, kSize
-      Real*4 buffer(1-oL:sNy+oL,nNz,nSx,nSy)
+      _R4 buffer(1-oL:sNy+oL,nNz,nSx,nSy)
       _RL    arrFld(1-OLy:sNy+OLy,kSize,nSx,nSy)
       INTEGER kLo
       INTEGER biArg

--- a/pkg/mdsio/mdsio_pass_r4torl.F
+++ b/pkg/mdsio/mdsio_pass_r4torl.F
@@ -117,3 +117,107 @@ CEOP
 
       RETURN
       END
+
+C---+----1----+----2----+----3----+----4----+----5----+----6----+----7-|--+----|
+
+CBOP
+C !ROUTINE: MDS_PASS_YZ_R4toRL
+C !INTERFACE:
+      SUBROUTINE MDS_PASS_YZ_R4toRL(
+     U                            buffer, arrFld,
+     I                            oL, nNz, kLo, kSize,
+     I                            biArg, bjArg, copyTo, myThid )
+
+C !DESCRIPTION:
+C     Transfert 2-D, yz slice real*4 buffer to 2-D RL model array, or the reverse,
+C      depending on "copyTo" value. Apply transfert to tile biArg,bjArg
+C      only or to all myThid tiles if called with biArg=bjArg=0.
+
+C     !USES:
+      IMPLICIT NONE
+
+C Global variables / common blocks
+#include "EEPARAMS.h"
+#include "SIZE.h"
+
+C     !INPUT/OUTPUT PARAMETERS:
+C Routine arguments
+C buffer  (real*4) :: buffer 2-D array (Input/Output if copyTo=T/F)
+C arrFld   ( RL )  :: model 2-D tiled array (Output/Input if copyTo=T/F)
+C oL     (integer):: Overlap size (dim-1) of buffer to copy - to/from - arrFld
+C nNz     (integer):: Number of levels to - fill in / extract from - arrFld
+C kLo     (integer):: 1rst level to - fill in / extract from - arrFld
+C kSize   (integer):: third dimension of 3-D array "arrFld"
+C biArg   (integer):: tile X-index to - fill in / extract from - tiled buffer
+C bjArg   (integer):: tile Y-index to - fill in / extract from - tiled buffer
+C copyTo  (logical):: if =T, copy 2-D -> 3-D ; if =F: copy 2-D <- 3-D
+C myThid  (integer):: my Thread Id number
+      INTEGER oL
+      INTEGER nNz, kSize
+      Real*4 buffer(1-oL:sNy+oL,nNz,nSx,nSy)
+      _RL    arrFld(1-OLy:sNy+OLy,kSize,nSx,nSy)
+      INTEGER kLo
+      INTEGER biArg
+      INTEGER bjArg
+      LOGICAL copyTo
+      INTEGER myThid
+
+C !LOCAL VARIABLES:
+C   i,j,k :: loop indices
+C   bi,bj :: tile indices
+      INTEGER i,j,k,bi,bj
+      INTEGER kLev
+CEOP
+      IF ( oL.LT.0 .OR. oL.GT.OLy ) THEN
+        STOP 'ABNORMAL END: MDS_PASS_YZ_R4toRL invalid oL,oL Arg'
+      ENDIF
+
+      IF ( biArg.EQ.0 .AND. bjArg.EQ.0 ) THEN
+        IF ( copyTo ) THEN
+          DO bj = myByLo(myThid), myByHi(myThid)
+           DO bi = myBxLo(myThid), myBxHi(myThid)
+            DO k=1,nNz
+             kLev = kLo+k-1
+             DO j=1-oL,sNy+oL
+               arrFld(j,kLev,bi,bj) = buffer(j,k,bi,bj)
+             ENDDO
+            ENDDO
+           ENDDO
+          ENDDO
+        ELSE
+          DO bj = myByLo(myThid), myByHi(myThid)
+           DO bi = myBxLo(myThid), myBxHi(myThid)
+            DO k=1,nNz
+             kLev = kLo+k-1
+             DO j=1-oL,sNy+oL
+               buffer(j,k,bi,bj) = arrFld(j,kLev,bi,bj)
+             ENDDO
+            ENDDO
+           ENDDO
+          ENDDO
+        ENDIF
+      ELSEIF ( biArg.GE.1 .AND. biArg.LE.nSx
+     &   .AND. bjArg.GE.1 .AND. bjArg.LE.nSy ) THEN
+        bi = biArg
+        bj = bjArg
+        IF ( copyTo ) THEN
+          DO k=1,nNz
+            kLev = kLo+k-1
+            DO j=1-oL,sNy+oL
+              arrFld(j,kLev,1,1) = buffer(j,k,bi,bj)
+            ENDDO
+          ENDDO
+        ELSE
+          DO k=1,nNz
+            kLev = kLo+k-1
+            DO j=1-oL,sNy+oL
+              buffer(j,k,bi,bj) = arrFld(j,kLev,1,1)
+            ENDDO
+          ENDDO
+        ENDIF
+      ELSE
+        STOP 'ABNORMAL END: MDS_PASS_YZ_R4toRL invalid bi,bj Arg'
+      ENDIF
+
+      RETURN
+      END

--- a/pkg/mdsio/mdsio_pass_r4tors.F
+++ b/pkg/mdsio/mdsio_pass_r4tors.F
@@ -117,3 +117,107 @@ CEOP
 
       RETURN
       END
+
+C---+----1----+----2----+----3----+----4----+----5----+----6----+----7-|--+----|
+
+CBOP
+C !ROUTINE: MDS_PASS_YZ_R4toRS
+C !INTERFACE:
+      SUBROUTINE MDS_PASS_YZ_R4toRS(
+     U                            buffer, arrFld,
+     I                            oL, nNz, kLo, kSize,
+     I                            biArg, bjArg, copyTo, myThid )
+
+C !DESCRIPTION:
+C     Transfert 2-D, yz slice real*4 buffer to 2-D RS model array, or the reverse,
+C      depending on "copyTo" value. Apply transfert to tile biArg,bjArg
+C      only or to all myThid tiles if called with biArg=bjArg=0.
+
+C     !USES:
+      IMPLICIT NONE
+
+C Global variables / common blocks
+#include "EEPARAMS.h"
+#include "SIZE.h"
+
+C     !INPUT/OUTPUT PARAMETERS:
+C Routine arguments
+C buffer  (real*4) :: buffer 2-D array (Input/Output if copyTo=T/F)
+C arrFld   ( RS )  :: model 2-D tiled array (Output/Input if copyTo=T/F)
+C oL     (integer):: Overlap size (dim-1) of buffer to copy - to/from - arrFld
+C nNz     (integer):: Number of levels to - fill in / extract from - arrFld
+C kLo     (integer):: 1rst level to - fill in / extract from - arrFld
+C kSize   (integer):: third dimension of 3-D array "arrFld"
+C biArg   (integer):: tile X-index to - fill in / extract from - tiled buffer
+C bjArg   (integer):: tile Y-index to - fill in / extract from - tiled buffer
+C copyTo  (logical):: if =T, copy 2-D -> 3-D ; if =F: copy 2-D <- 3-D
+C myThid  (integer):: my Thread Id number
+      INTEGER oL
+      INTEGER nNz, kSize
+      Real*4 buffer(1-oL:sNy+oL,nNz,nSx,nSy)
+      _RS    arrFld(1-OLy:sNy+OLy,kSize,nSx,nSy)
+      INTEGER kLo
+      INTEGER biArg
+      INTEGER bjArg
+      LOGICAL copyTo
+      INTEGER myThid
+
+C !LOCAL VARIABLES:
+C   i,j,k :: loop indices
+C   bi,bj :: tile indices
+      INTEGER i,j,k,bi,bj
+      INTEGER kLev
+CEOP
+      IF ( oL.LT.0 .OR. oL.GT.OLy ) THEN
+        STOP 'ABNORMAL END: MDS_PASS_YZ_R4toRL invalid oL,oL Arg'
+      ENDIF
+
+      IF ( biArg.EQ.0 .AND. bjArg.EQ.0 ) THEN
+        IF ( copyTo ) THEN
+          DO bj = myByLo(myThid), myByHi(myThid)
+           DO bi = myBxLo(myThid), myBxHi(myThid)
+            DO k=1,nNz
+             kLev = kLo+k-1
+             DO j=1-oL,sNy+oL
+               arrFld(j,kLev,bi,bj) = buffer(j,k,bi,bj)
+             ENDDO
+            ENDDO
+           ENDDO
+          ENDDO
+        ELSE
+          DO bj = myByLo(myThid), myByHi(myThid)
+           DO bi = myBxLo(myThid), myBxHi(myThid)
+            DO k=1,nNz
+             kLev = kLo+k-1
+             DO j=1-oL,sNy+oL
+               buffer(j,k,bi,bj) = arrFld(j,kLev,bi,bj)
+             ENDDO
+            ENDDO
+           ENDDO
+          ENDDO
+        ENDIF
+      ELSEIF ( biArg.GE.1 .AND. biArg.LE.nSx
+     &   .AND. bjArg.GE.1 .AND. bjArg.LE.nSy ) THEN
+        bi = biArg
+        bj = bjArg
+        IF ( copyTo ) THEN
+          DO k=1,nNz
+            kLev = kLo+k-1
+            DO j=1-oL,sNy+oL
+              arrFld(j,kLev,1,1) = buffer(j,k,bi,bj)
+            ENDDO
+          ENDDO
+        ELSE
+          DO k=1,nNz
+            kLev = kLo+k-1
+            DO j=1-oL,sNy+oL
+              buffer(j,k,bi,bj) = arrFld(j,kLev,1,1)
+            ENDDO
+          ENDDO
+        ENDIF
+      ELSE
+        STOP 'ABNORMAL END: MDS_PASS_YZ_R4toRS invalid bi,bj Arg'
+      ENDIF
+
+      RETURN
+      END

--- a/pkg/mdsio/mdsio_pass_r4tors.F
+++ b/pkg/mdsio/mdsio_pass_r4tors.F
@@ -41,7 +41,7 @@ C copyTo  (logical):: if =T, copy 2-D -> 3-D ; if =F: copy 2-D <- 3-D
 C myThid  (integer):: my Thread Id number
       INTEGER oLi, oLj
       INTEGER nNz, kSize
-      Real*4 buffer(1-oLi:sNx+oLi,1-oLj:sNy+oLj,nNz,nSx,nSy)
+      _R4 buffer(1-oLi:sNx+oLi,1-oLj:sNy+oLj,nNz,nSx,nSy)
       _RS    arrFld(1-OLx:sNx+OLx,1-OLy:sNy+OLy,kSize,nSx,nSy)
       INTEGER kLo
       INTEGER biArg
@@ -121,6 +121,110 @@ CEOP
 C---+----1----+----2----+----3----+----4----+----5----+----6----+----7-|--+----|
 
 CBOP
+C !ROUTINE: MDS_PASS_XZ_R4toRS
+C !INTERFACE:
+      SUBROUTINE MDS_PASS_XZ_R4toRS(
+     U                            buffer, arrFld,
+     I                            oL, nNz, kLo, kSize,
+     I                            biArg, bjArg, copyTo, myThid )
+
+C !DESCRIPTION:
+C     Transfert 2-D, yz slice real*4 buffer to 2-D RS model array, or the reverse,
+C      depending on "copyTo" value. Apply transfert to tile biArg,bjArg
+C      only or to all myThid tiles if called with biArg=bjArg=0.
+
+C     !USES:
+      IMPLICIT NONE
+
+C Global variables / common blocks
+#include "EEPARAMS.h"
+#include "SIZE.h"
+
+C     !INPUT/OUTPUT PARAMETERS:
+C Routine arguments
+C buffer  (real*4) :: buffer 2-D array (Input/Output if copyTo=T/F)
+C arrFld   ( RS )  :: model 2-D tiled array (Output/Input if copyTo=T/F)
+C oL     (integer):: Overlap size (dim-1) of buffer to copy - to/from - arrFld
+C nNz     (integer):: Number of levels to - fill in / extract from - arrFld
+C kLo     (integer):: 1rst level to - fill in / extract from - arrFld
+C kSize   (integer):: third dimension of 3-D array "arrFld"
+C biArg   (integer):: tile X-index to - fill in / extract from - tiled buffer
+C bjArg   (integer):: tile Y-index to - fill in / extract from - tiled buffer
+C copyTo  (logical):: if =T, copy 2-D -> 3-D ; if =F: copy 2-D <- 3-D
+C myThid  (integer):: my Thread Id number
+      INTEGER oL
+      INTEGER nNz, kSize
+      _R4 buffer(1-oL:sNx+oL,nNz,nSx,nSy)
+      _RS    arrFld(1-OLy:sNx+OLy,kSize,nSx,nSy)
+      INTEGER kLo
+      INTEGER biArg
+      INTEGER bjArg
+      LOGICAL copyTo
+      INTEGER myThid
+
+C !LOCAL VARIABLES:
+C   i,j,k :: loop indices
+C   bi,bj :: tile indices
+      INTEGER i,j,k,bi,bj
+      INTEGER kLev
+CEOP
+      IF ( oL.LT.0 .OR. oL.GT.OLy ) THEN
+        STOP 'ABNORMAL END: MDS_PASS_XZ_R4toRL invalid oL,oL Arg'
+      ENDIF
+
+      IF ( biArg.EQ.0 .AND. bjArg.EQ.0 ) THEN
+        IF ( copyTo ) THEN
+          DO bj = myByLo(myThid), myByHi(myThid)
+           DO bi = myBxLo(myThid), myBxHi(myThid)
+            DO k=1,nNz
+             kLev = kLo+k-1
+             DO i=1-oL,sNx+oL
+               arrFld(i,kLev,bi,bj) = buffer(i,k,bi,bj)
+             ENDDO
+            ENDDO
+           ENDDO
+          ENDDO
+        ELSE
+          DO bj = myByLo(myThid), myByHi(myThid)
+           DO bi = myBxLo(myThid), myBxHi(myThid)
+            DO k=1,nNz
+             kLev = kLo+k-1
+             DO i=1-oL,sNx+oL
+               buffer(i,k,bi,bj) = arrFld(i,kLev,bi,bj)
+             ENDDO
+            ENDDO
+           ENDDO
+          ENDDO
+        ENDIF
+      ELSEIF ( biArg.GE.1 .AND. biArg.LE.nSx
+     &   .AND. bjArg.GE.1 .AND. bjArg.LE.nSy ) THEN
+        bi = biArg
+        bj = bjArg
+        IF ( copyTo ) THEN
+          DO k=1,nNz
+            kLev = kLo+k-1
+            DO i=1-oL,sNx+oL
+              arrFld(i,kLev,1,1) = buffer(i,k,bi,bj)
+            ENDDO
+          ENDDO
+        ELSE
+          DO k=1,nNz
+            kLev = kLo+k-1
+            DO i=1-oL,sNx+oL
+              buffer(i,k,bi,bj) = arrFld(i,kLev,1,1)
+            ENDDO
+          ENDDO
+        ENDIF
+      ELSE
+        STOP 'ABNORMAL END: MDS_PASS_XZ_R4toRS invalid bi,bj Arg'
+      ENDIF
+
+      RETURN
+      END
+
+C---+----1----+----2----+----3----+----4----+----5----+----6----+----7-|--+----|
+
+CBOP
 C !ROUTINE: MDS_PASS_YZ_R4toRS
 C !INTERFACE:
       SUBROUTINE MDS_PASS_YZ_R4toRS(
@@ -154,7 +258,7 @@ C copyTo  (logical):: if =T, copy 2-D -> 3-D ; if =F: copy 2-D <- 3-D
 C myThid  (integer):: my Thread Id number
       INTEGER oL
       INTEGER nNz, kSize
-      Real*4 buffer(1-oL:sNy+oL,nNz,nSx,nSy)
+      _R4 buffer(1-oL:sNy+oL,nNz,nSx,nSy)
       _RS    arrFld(1-OLy:sNy+OLy,kSize,nSx,nSy)
       INTEGER kLo
       INTEGER biArg
@@ -221,3 +325,5 @@ CEOP
 
       RETURN
       END
+
+

--- a/pkg/mdsio/mdsio_pass_r8torl.F
+++ b/pkg/mdsio/mdsio_pass_r8torl.F
@@ -121,6 +121,110 @@ CEOP
 C---+----1----+----2----+----3----+----4----+----5----+----6----+----7-|--+----|
 
 CBOP
+C !ROUTINE: MDS_PASS_XZ_R8toRL
+C !INTERFACE:
+      SUBROUTINE MDS_PASS_XZ_R8toRL(
+     U                            buffer, arrFld,
+     I                            oL, nNz, kLo, kSize,
+     I                            biArg, bjArg, copyTo, myThid )
+
+C !DESCRIPTION:
+C     Transfert 2-D, yz slice real*4 buffer to 2-D RS model array, or the reverse,
+C      depending on "copyTo" value. Apply transfert to tile biArg,bjArg
+C      only or to all myThid tiles if called with biArg=bjArg=0.
+
+C     !USES:
+      IMPLICIT NONE
+
+C Global variables / common blocks
+#include "EEPARAMS.h"
+#include "SIZE.h"
+
+C     !INPUT/OUTPUT PARAMETERS:
+C Routine arguments
+C buffer  (real*4) :: buffer 2-D array (Input/Output if copyTo=T/F)
+C arrFld   ( RL )  :: model 2-D tiled array (Output/Input if copyTo=T/F)
+C oL     (integer):: Overlap size (dim-1) of buffer to copy - to/from - arrFld
+C nNz     (integer):: Number of levels to - fill in / extract from - arrFld
+C kLo     (integer):: 1rst level to - fill in / extract from - arrFld
+C kSize   (integer):: third dimension of 3-D array "arrFld"
+C biArg   (integer):: tile X-index to - fill in / extract from - tiled buffer
+C bjArg   (integer):: tile Y-index to - fill in / extract from - tiled buffer
+C copyTo  (logical):: if =T, copy 2-D -> 3-D ; if =F: copy 2-D <- 3-D
+C myThid  (integer):: my Thread Id number
+      INTEGER oL
+      INTEGER nNz, kSize
+      _R8 buffer(1-oL:sNx+oL,nNz,nSx,nSy)
+      _RL    arrFld(1-OLy:sNx+OLy,kSize,nSx,nSy)
+      INTEGER kLo
+      INTEGER biArg
+      INTEGER bjArg
+      LOGICAL copyTo
+      INTEGER myThid
+
+C !LOCAL VARIABLES:
+C   i,j,k :: loop indices
+C   bi,bj :: tile indices
+      INTEGER i,j,k,bi,bj
+      INTEGER kLev
+CEOP
+      IF ( oL.LT.0 .OR. oL.GT.OLy ) THEN
+        STOP 'ABNORMAL END: MDS_PASS_XZ_R8toRL invalid oL,oL Arg'
+      ENDIF
+
+      IF ( biArg.EQ.0 .AND. bjArg.EQ.0 ) THEN
+        IF ( copyTo ) THEN
+          DO bj = myByLo(myThid), myByHi(myThid)
+           DO bi = myBxLo(myThid), myBxHi(myThid)
+            DO k=1,nNz
+             kLev = kLo+k-1
+             DO i=1-oL,sNx+oL
+               arrFld(i,kLev,bi,bj) = buffer(i,k,bi,bj)
+             ENDDO
+            ENDDO
+           ENDDO
+          ENDDO
+        ELSE
+          DO bj = myByLo(myThid), myByHi(myThid)
+           DO bi = myBxLo(myThid), myBxHi(myThid)
+            DO k=1,nNz
+             kLev = kLo+k-1
+             DO i=1-oL,sNx+oL
+               buffer(i,k,bi,bj) = arrFld(i,kLev,bi,bj)
+             ENDDO
+            ENDDO
+           ENDDO
+          ENDDO
+        ENDIF
+      ELSEIF ( biArg.GE.1 .AND. biArg.LE.nSx
+     &   .AND. bjArg.GE.1 .AND. bjArg.LE.nSy ) THEN
+        bi = biArg
+        bj = bjArg
+        IF ( copyTo ) THEN
+          DO k=1,nNz
+            kLev = kLo+k-1
+            DO i=1-oL,sNx+oL
+              arrFld(i,kLev,1,1) = buffer(i,k,bi,bj)
+            ENDDO
+          ENDDO
+        ELSE
+          DO k=1,nNz
+            kLev = kLo+k-1
+            DO i=1-oL,sNx+oL
+              buffer(i,k,bi,bj) = arrFld(i,kLev,1,1)
+            ENDDO
+          ENDDO
+        ENDIF
+      ELSE
+        STOP 'ABNORMAL END: MDS_PASS_XZ_R8toRL invalid bi,bj Arg'
+      ENDIF
+
+      RETURN
+      END
+
+C---+----1----+----2----+----3----+----4----+----5----+----6----+----7-|--+----|
+
+CBOP
 C !ROUTINE: MDS_PASS_YZ_R8toRL
 C !INTERFACE:
       SUBROUTINE MDS_PASS_YZ_R8toRL(
@@ -154,7 +258,7 @@ C copyTo  (logical):: if =T, copy 2-D -> 3-D ; if =F: copy 2-D <- 3-D
 C myThid  (integer):: my Thread Id number
       INTEGER oL
       INTEGER nNz, kSize
-      Real*8 buffer(1-oL:sNy+oL,nNz,nSx,nSy)
+      _R8 buffer(1-oL:sNy+oL,nNz,nSx,nSy)
       _RL    arrFld(1-OLy:sNy+OLy,kSize,nSx,nSy)
       INTEGER kLo
       INTEGER biArg

--- a/pkg/mdsio/mdsio_pass_r8torl.F
+++ b/pkg/mdsio/mdsio_pass_r8torl.F
@@ -117,3 +117,107 @@ CEOP
 
       RETURN
       END
+
+C---+----1----+----2----+----3----+----4----+----5----+----6----+----7-|--+----|
+
+CBOP
+C !ROUTINE: MDS_PASS_YZ_R8toRL
+C !INTERFACE:
+      SUBROUTINE MDS_PASS_YZ_R8toRL(
+     U                            buffer, arrFld,
+     I                            oL, nNz, kLo, kSize,
+     I                            biArg, bjArg, copyTo, myThid )
+
+C !DESCRIPTION:
+C     Transfert 2-D, yz slice real*8 buffer to 2-D RL model array, or the reverse,
+C      depending on "copyTo" value. Apply transfert to tile biArg,bjArg
+C      only or to all myThid tiles if called with biArg=bjArg=0.
+
+C     !USES:
+      IMPLICIT NONE
+
+C Global variables / common blocks
+#include "EEPARAMS.h"
+#include "SIZE.h"
+
+C     !INPUT/OUTPUT PARAMETERS:
+C Routine arguments
+C buffer  (real*8) :: buffer 2-D array (Input/Output if copyTo=T/F)
+C arrFld   ( RL )  :: model 2-D tiled array (Output/Input if copyTo=T/F)
+C oL     (integer):: Overlap size (dim-1) of buffer to copy - to/from - arrFld
+C nNz     (integer):: Number of levels to - fill in / extract from - arrFld
+C kLo     (integer):: 1rst level to - fill in / extract from - arrFld
+C kSize   (integer):: third dimension of 3-D array "arrFld"
+C biArg   (integer):: tile X-index to - fill in / extract from - tiled buffer
+C bjArg   (integer):: tile Y-index to - fill in / extract from - tiled buffer
+C copyTo  (logical):: if =T, copy 2-D -> 3-D ; if =F: copy 2-D <- 3-D
+C myThid  (integer):: my Thread Id number
+      INTEGER oL
+      INTEGER nNz, kSize
+      Real*8 buffer(1-oL:sNy+oL,nNz,nSx,nSy)
+      _RL    arrFld(1-OLy:sNy+OLy,kSize,nSx,nSy)
+      INTEGER kLo
+      INTEGER biArg
+      INTEGER bjArg
+      LOGICAL copyTo
+      INTEGER myThid
+
+C !LOCAL VARIABLES:
+C   i,j,k :: loop indices
+C   bi,bj :: tile indices
+      INTEGER i,j,k,bi,bj
+      INTEGER kLev
+CEOP
+      IF ( oL.LT.0 .OR. oL.GT.OLy ) THEN
+        STOP 'ABNORMAL END: MDS_PASS_YZ_R8toRL invalid oL,oL Arg'
+      ENDIF
+
+      IF ( biArg.EQ.0 .AND. bjArg.EQ.0 ) THEN
+        IF ( copyTo ) THEN
+          DO bj = myByLo(myThid), myByHi(myThid)
+           DO bi = myBxLo(myThid), myBxHi(myThid)
+            DO k=1,nNz
+             kLev = kLo+k-1
+             DO j=1-oL,sNy+oL
+               arrFld(j,kLev,bi,bj) = buffer(j,k,bi,bj)
+             ENDDO
+            ENDDO
+           ENDDO
+          ENDDO
+        ELSE
+          DO bj = myByLo(myThid), myByHi(myThid)
+           DO bi = myBxLo(myThid), myBxHi(myThid)
+            DO k=1,nNz
+             kLev = kLo+k-1
+             DO j=1-oL,sNy+oL
+               buffer(j,k,bi,bj) = arrFld(j,kLev,bi,bj)
+             ENDDO
+            ENDDO
+           ENDDO
+          ENDDO
+        ENDIF
+      ELSEIF ( biArg.GE.1 .AND. biArg.LE.nSx
+     &   .AND. bjArg.GE.1 .AND. bjArg.LE.nSy ) THEN
+        bi = biArg
+        bj = bjArg
+        IF ( copyTo ) THEN
+          DO k=1,nNz
+            kLev = kLo+k-1
+            DO j=1-oL,sNy+oL
+              arrFld(j,kLev,1,1) = buffer(j,k,bi,bj)
+            ENDDO
+          ENDDO
+        ELSE
+          DO k=1,nNz
+            kLev = kLo+k-1
+            DO j=1-oL,sNy+oL
+              buffer(j,k,bi,bj) = arrFld(j,kLev,1,1)
+            ENDDO
+          ENDDO
+        ENDIF
+      ELSE
+        STOP 'ABNORMAL END: MDS_PASS_YZ_R8toRL invalid bi,bj Arg'
+      ENDIF
+
+      RETURN
+      END

--- a/pkg/mdsio/mdsio_pass_r8tors.F
+++ b/pkg/mdsio/mdsio_pass_r8tors.F
@@ -41,7 +41,7 @@ C copyTo  (logical):: if =T, copy 2-D -> 3-D ; if =F: copy 2-D <- 3-D
 C myThid  (integer):: my Thread Id number
       INTEGER oLi, oLj
       INTEGER nNz, kSize
-      Real*8 buffer(1-oLi:sNx+oLi,1-oLj:sNy+oLj,nNz,nSx,nSy)
+      _R8 buffer(1-oLi:sNx+oLi,1-oLj:sNy+oLj,nNz,nSx,nSy)
       _RS    arrFld(1-OLx:sNx+OLx,1-OLy:sNy+OLy,kSize,nSx,nSy)
       INTEGER kLo
       INTEGER biArg
@@ -121,6 +121,110 @@ CEOP
 C---+----1----+----2----+----3----+----4----+----5----+----6----+----7-|--+----|
 
 CBOP
+C !ROUTINE: MDS_PASS_XZ_R8toRS
+C !INTERFACE:
+      SUBROUTINE MDS_PASS_XZ_R8toRS(
+     U                            buffer, arrFld,
+     I                            oL, nNz, kLo, kSize,
+     I                            biArg, bjArg, copyTo, myThid )
+
+C !DESCRIPTION:
+C     Transfert 2-D, yz slice real*4 buffer to 2-D RS model array, or the reverse,
+C      depending on "copyTo" value. Apply transfert to tile biArg,bjArg
+C      only or to all myThid tiles if called with biArg=bjArg=0.
+
+C     !USES:
+      IMPLICIT NONE
+
+C Global variables / common blocks
+#include "EEPARAMS.h"
+#include "SIZE.h"
+
+C     !INPUT/OUTPUT PARAMETERS:
+C Routine arguments
+C buffer  (real*4) :: buffer 2-D array (Input/Output if copyTo=T/F)
+C arrFld   ( RS )  :: model 2-D tiled array (Output/Input if copyTo=T/F)
+C oL     (integer):: Overlap size (dim-1) of buffer to copy - to/from - arrFld
+C nNz     (integer):: Number of levels to - fill in / extract from - arrFld
+C kLo     (integer):: 1rst level to - fill in / extract from - arrFld
+C kSize   (integer):: third dimension of 3-D array "arrFld"
+C biArg   (integer):: tile X-index to - fill in / extract from - tiled buffer
+C bjArg   (integer):: tile Y-index to - fill in / extract from - tiled buffer
+C copyTo  (logical):: if =T, copy 2-D -> 3-D ; if =F: copy 2-D <- 3-D
+C myThid  (integer):: my Thread Id number
+      INTEGER oL
+      INTEGER nNz, kSize
+      _R8 buffer(1-oL:sNx+oL,nNz,nSx,nSy)
+      _RS    arrFld(1-OLy:sNx+OLy,kSize,nSx,nSy)
+      INTEGER kLo
+      INTEGER biArg
+      INTEGER bjArg
+      LOGICAL copyTo
+      INTEGER myThid
+
+C !LOCAL VARIABLES:
+C   i,j,k :: loop indices
+C   bi,bj :: tile indices
+      INTEGER i,j,k,bi,bj
+      INTEGER kLev
+CEOP
+      IF ( oL.LT.0 .OR. oL.GT.OLy ) THEN
+        STOP 'ABNORMAL END: MDS_PASS_XZ_R8toRS invalid oL,oL Arg'
+      ENDIF
+
+      IF ( biArg.EQ.0 .AND. bjArg.EQ.0 ) THEN
+        IF ( copyTo ) THEN
+          DO bj = myByLo(myThid), myByHi(myThid)
+           DO bi = myBxLo(myThid), myBxHi(myThid)
+            DO k=1,nNz
+             kLev = kLo+k-1
+             DO i=1-oL,sNx+oL
+               arrFld(i,kLev,bi,bj) = buffer(i,k,bi,bj)
+             ENDDO
+            ENDDO
+           ENDDO
+          ENDDO
+        ELSE
+          DO bj = myByLo(myThid), myByHi(myThid)
+           DO bi = myBxLo(myThid), myBxHi(myThid)
+            DO k=1,nNz
+             kLev = kLo+k-1
+             DO i=1-oL,sNx+oL
+               buffer(i,k,bi,bj) = arrFld(i,kLev,bi,bj)
+             ENDDO
+            ENDDO
+           ENDDO
+          ENDDO
+        ENDIF
+      ELSEIF ( biArg.GE.1 .AND. biArg.LE.nSx
+     &   .AND. bjArg.GE.1 .AND. bjArg.LE.nSy ) THEN
+        bi = biArg
+        bj = bjArg
+        IF ( copyTo ) THEN
+          DO k=1,nNz
+            kLev = kLo+k-1
+            DO i=1-oL,sNx+oL
+              arrFld(i,kLev,1,1) = buffer(i,k,bi,bj)
+            ENDDO
+          ENDDO
+        ELSE
+          DO k=1,nNz
+            kLev = kLo+k-1
+            DO i=1-oL,sNx+oL
+              buffer(i,k,bi,bj) = arrFld(i,kLev,1,1)
+            ENDDO
+          ENDDO
+        ENDIF
+      ELSE
+        STOP 'ABNORMAL END: MDS_PASS_XZ_R8toRS invalid bi,bj Arg'
+      ENDIF
+
+      RETURN
+      END
+
+C---+----1----+----2----+----3----+----4----+----5----+----6----+----7-|--+----|
+
+CBOP
 C !ROUTINE: MDS_PASS_YZ_R8toRS
 C !INTERFACE:
       SUBROUTINE MDS_PASS_YZ_R8toRS(
@@ -154,7 +258,7 @@ C copyTo  (logical):: if =T, copy 2-D -> 3-D ; if =F: copy 2-D <- 3-D
 C myThid  (integer):: my Thread Id number
       INTEGER oL
       INTEGER nNz, kSize
-      Real*8 buffer(1-oL:sNy+oL,nNz,nSx,nSy)
+      _R8 buffer(1-oL:sNy+oL,nNz,nSx,nSy)
       _RS    arrFld(1-OLy:sNy+OLy,kSize,nSx,nSy)
       INTEGER kLo
       INTEGER biArg
@@ -169,7 +273,7 @@ C   bi,bj :: tile indices
       INTEGER kLev
 CEOP
       IF ( oL.LT.0 .OR. oL.GT.OLy ) THEN
-        STOP 'ABNORMAL END: MDS_PASS_YZ_R8toRL invalid oL,oL Arg'
+        STOP 'ABNORMAL END: MDS_PASS_YZ_R8toRS invalid oL,oL Arg'
       ENDIF
 
       IF ( biArg.EQ.0 .AND. bjArg.EQ.0 ) THEN

--- a/pkg/mdsio/mdsio_pass_r8tors.F
+++ b/pkg/mdsio/mdsio_pass_r8tors.F
@@ -117,3 +117,107 @@ CEOP
 
       RETURN
       END
+
+C---+----1----+----2----+----3----+----4----+----5----+----6----+----7-|--+----|
+
+CBOP
+C !ROUTINE: MDS_PASS_YZ_R8toRS
+C !INTERFACE:
+      SUBROUTINE MDS_PASS_YZ_R8toRS(
+     U                            buffer, arrFld,
+     I                            oL, nNz, kLo, kSize,
+     I                            biArg, bjArg, copyTo, myThid )
+
+C !DESCRIPTION:
+C     Transfert 2-D, yz slice real*8 buffer to 2-D RS model array, or the reverse,
+C      depending on "copyTo" value. Apply transfert to tile biArg,bjArg
+C      only or to all myThid tiles if called with biArg=bjArg=0.
+
+C     !USES:
+      IMPLICIT NONE
+
+C Global variables / common blocks
+#include "EEPARAMS.h"
+#include "SIZE.h"
+
+C     !INPUT/OUTPUT PARAMETERS:
+C Routine arguments
+C buffer  (real*8) :: buffer 2-D array (Input/Output if copyTo=T/F)
+C arrFld   ( RS )  :: model 2-D tiled array (Output/Input if copyTo=T/F)
+C oL     (integer):: Overlap size (dim-1) of buffer to copy - to/from - arrFld
+C nNz     (integer):: Number of levels to - fill in / extract from - arrFld
+C kLo     (integer):: 1rst level to - fill in / extract from - arrFld
+C kSize   (integer):: third dimension of 3-D array "arrFld"
+C biArg   (integer):: tile X-index to - fill in / extract from - tiled buffer
+C bjArg   (integer):: tile Y-index to - fill in / extract from - tiled buffer
+C copyTo  (logical):: if =T, copy 2-D -> 3-D ; if =F: copy 2-D <- 3-D
+C myThid  (integer):: my Thread Id number
+      INTEGER oL
+      INTEGER nNz, kSize
+      Real*8 buffer(1-oL:sNy+oL,nNz,nSx,nSy)
+      _RS    arrFld(1-OLy:sNy+OLy,kSize,nSx,nSy)
+      INTEGER kLo
+      INTEGER biArg
+      INTEGER bjArg
+      LOGICAL copyTo
+      INTEGER myThid
+
+C !LOCAL VARIABLES:
+C   i,j,k :: loop indices
+C   bi,bj :: tile indices
+      INTEGER i,j,k,bi,bj
+      INTEGER kLev
+CEOP
+      IF ( oL.LT.0 .OR. oL.GT.OLy ) THEN
+        STOP 'ABNORMAL END: MDS_PASS_YZ_R8toRL invalid oL,oL Arg'
+      ENDIF
+
+      IF ( biArg.EQ.0 .AND. bjArg.EQ.0 ) THEN
+        IF ( copyTo ) THEN
+          DO bj = myByLo(myThid), myByHi(myThid)
+           DO bi = myBxLo(myThid), myBxHi(myThid)
+            DO k=1,nNz
+             kLev = kLo+k-1
+             DO j=1-oL,sNy+oL
+               arrFld(j,kLev,bi,bj) = buffer(j,k,bi,bj)
+             ENDDO
+            ENDDO
+           ENDDO
+          ENDDO
+        ELSE
+          DO bj = myByLo(myThid), myByHi(myThid)
+           DO bi = myBxLo(myThid), myBxHi(myThid)
+            DO k=1,nNz
+             kLev = kLo+k-1
+             DO j=1-oL,sNy+oL
+               buffer(j,k,bi,bj) = arrFld(j,kLev,bi,bj)
+             ENDDO
+            ENDDO
+           ENDDO
+          ENDDO
+        ENDIF
+      ELSEIF ( biArg.GE.1 .AND. biArg.LE.nSx
+     &   .AND. bjArg.GE.1 .AND. bjArg.LE.nSy ) THEN
+        bi = biArg
+        bj = bjArg
+        IF ( copyTo ) THEN
+          DO k=1,nNz
+            kLev = kLo+k-1
+            DO j=1-oL,sNy+oL
+              arrFld(j,kLev,1,1) = buffer(j,k,bi,bj)
+            ENDDO
+          ENDDO
+        ELSE
+          DO k=1,nNz
+            kLev = kLo+k-1
+            DO j=1-oL,sNy+oL
+              buffer(j,k,bi,bj) = arrFld(j,kLev,1,1)
+            ENDDO
+          ENDDO
+        ENDIF
+      ELSE
+        STOP 'ABNORMAL END: MDS_PASS_YZ_R8toRS invalid bi,bj Arg'
+      ENDIF
+
+      RETURN
+      END

--- a/pkg/mdsio/mdsio_read_field.F
+++ b/pkg/mdsio/mdsio_read_field.F
@@ -159,7 +159,7 @@ C    and shorter enough to be written to msgBuf with other informations
       ENDIF
 C Record number must be >= 1
       IF (irecord .LT. 1) THEN
-        WRITE(msgBuf,'(3A,I10)')
+        WRITE(msgBuf,'(3A)')
      &    ' MDS_READ_FIELD: file="', fName(1:IL), '"'
         CALL PRINT_MESSAGE( msgBuf, errorMessageUnit,
      &                      SQUEEZE_RIGHT, myThid )

--- a/pkg/mdsio/mdsio_read_section.F
+++ b/pkg/mdsio/mdsio_read_section.F
@@ -245,7 +245,7 @@ C Check first for global file with simple name (ie. fName)
         IF (exst) THEN
           IF ( debugLevel .GE. debLevB ) THEN
             WRITE(msgBuf,'(A,A)')
-     &      ' MDS_READ_FIELD: opening global file: ',dataFName(1:IL)
+     &      ' MDS_READ_SEC_XZ: opening global file: ',dataFName(1:IL)
             CALL PRINT_MESSAGE( msgBuf, standardMessageUnit,
      &                          SQUEEZE_RIGHT, myThid)
           ENDIF
@@ -259,7 +259,7 @@ C If negative check for global file with MDS name (ie. fName.data)
           IF (exst) THEN
            IF ( debugLevel .GE. debLevB ) THEN
             WRITE(msgBuf,'(A,A)')
-     &      ' MDS_READ_FIELD: opening global file: ',dataFName(1:IL+5)
+     &      ' MDS_READ_SEC_XZ: opening global file: ',dataFName(1:IL+5)
             CALL PRINT_MESSAGE( msgBuf, standardMessageUnit,
      &                          SQUEEZE_RIGHT, myThid)
            ENDIF
@@ -854,7 +854,7 @@ C Check first for global file with simple name (ie. fName)
         IF (exst) THEN
           IF ( debugLevel .GE. debLevB ) THEN
             WRITE(msgBuf,'(A,A)')
-     &      ' MDS_READ_FIELD: opening global file: ',dataFName(1:IL)
+     &      ' MDS_READ_SEC_YZ: opening global file: ',dataFName(1:IL)
             CALL PRINT_MESSAGE( msgBuf, standardMessageUnit,
      &                          SQUEEZE_RIGHT, myThid)
           ENDIF
@@ -868,7 +868,7 @@ C If negative check for global file with MDS name (ie. fName.data)
           IF (exst) THEN
            IF ( debugLevel .GE. debLevB ) THEN
             WRITE(msgBuf,'(A,A)')
-     &      ' MDS_READ_FIELD: opening global file: ',dataFName(1:IL+5)
+     &      ' MDS_READ_SEC_YZ: opening global file: ',dataFName(1:IL+5)
             CALL PRINT_MESSAGE( msgBuf, standardMessageUnit,
      &                          SQUEEZE_RIGHT, myThid)
            ENDIF

--- a/pkg/mdsio/mdsio_read_section.F
+++ b/pkg/mdsio/mdsio_read_section.F
@@ -115,10 +115,11 @@ C     bBij  :: base shift in Buffer index for tile bi,bj
       INTEGER i1,i2,i,j,k,nNz
       INTEGER irec,dUnit,IL,pIL
       INTEGER length_of_rec
+      INTEGER bBij
       INTEGER tNx, global_nTx
       INTEGER tBx, iGjLoc, jGjLoc
-      REAL*4 r4seg(sNx*nSx)
-      REAL*8 r8seg(sNx*nSx)
+      REAL*4 r4seg(sNx)
+      REAL*8 r8seg(sNx)
       REAL*4 x_layer_buffer_r4(Nx)
       REAL*8 x_layer_buffer_r8(Nx)
 #ifdef ALLOW_EXCH2
@@ -276,7 +277,7 @@ C globalFile is too slow, then try using single-CPU I/O.
 C Master thread of process 0, only, opens a global file
        IF ( iAmDoingIO ) THEN
          WRITE(dataFName,'(2a)') fName(1:IL),'.data'
-         length_of_rec = MDS_RECLEN( filePrec, sNx*nSx, myThid )
+         length_of_rec = MDS_RECLEN( filePrec, sNx, myThid )
          OPEN( dUnit, file=dataFName, status=_OLD_STATUS,
      &       access='direct', recl=length_of_rec )
        ENDIF
@@ -334,26 +335,26 @@ C  to access shared buffer while master thread is loading data into
           IF ( .not.W2_useE2ioLayOut ) THEN
 #endif
             CALL SCATTER_VEC_R4( 
-     O                         x_layer_buffer_r4,
-     I                         r4seg, 
-     I                         xSize, myThid ) 
+     I                         x_layer_buffer_r4,
+     O                         r4seg, 
+     I                         sNx, myThid ) 
 #ifdef ALLOW_EXCH2
           ELSE
 
             CALL SCATTER_VEC_R4( 
-     O                         x_layer_buffer_exch2_r4,
-     I                         r4seg, 
-     I                         xSize, myThid ) 
+     I                         x_layer_buffer_exch2_r4,
+     O                         r4seg, 
+     I                         sNx, myThid ) 
           ENDIF
 #endif
           CALL BAR2( myThid )
           DO bj=1,sNy
           DO bi=1,sNx
           IF ( arrType.EQ.'RS' ) THEN
-            CALL MDS_SEG4toRS_2D( sNx*nSx, oLx, kSize, bi, bj, k,
+            CALL MDS_SEG4toRS_2D( sNx, oLx, kSize, bi, bj, k,
      &                            .TRUE., r4seg, fldRS )
           ELSEIF ( arrType.EQ.'RL' ) THEN
-            CALL MDS_SEG4toRS_2D( sNx*nSx, oLx, kSize, bi, bj, k,
+            CALL MDS_SEG4toRS_2D( sNx, oLx, kSize, bi, bj, k,
      &                            .TRUE., r4seg, fldRL )
           ELSE
             WRITE(msgBuf,'(2A)')
@@ -370,26 +371,26 @@ C  to access shared buffer while master thread is loading data into
           IF ( .not.W2_useE2ioLayOut ) THEN
 #endif
             CALL SCATTER_VEC_R8( 
-     O                         x_layer_buffer_r8,
-     I                         r8seg, 
-     I                         xSize, myThid ) 
+     I                         x_layer_buffer_r8,
+     O                         r8seg, 
+     I                         sNx, myThid ) 
 #ifdef ALLOW_EXCH2
           ELSE
 
             CALL SCATTER_VEC_R8( 
-     O                          x_layer_buffer_exch2_r8,
-     I                          r8seg, 
-     I                          xSize, myThid ) 
+     I                          x_layer_buffer_exch2_r8,
+     O                          r8seg, 
+     I                          sNx, myThid ) 
           ENDIF
 #endif
           CALL BAR2( myThid )
           DO bj=1,sNy
           DO bi=1,sNx
           IF ( arrType.EQ.'RS' ) THEN
-            CALL MDS_SEG8toRS_2D( sNx*nSx, oLx, kSize, bi, bj, k,
+            CALL MDS_SEG8toRS_2D( sNx, oLx, kSize, bi, bj, k,
      I                         .TRUE., r8seg, fldRS )
           ELSEIF ( arrType.EQ.'RL' ) THEN
-            CALL MDS_SEG8toRS_2D( sNx*nSx, oLx, kSize, bi, bj, k,
+            CALL MDS_SEG8toRS_2D( sNx, oLx, kSize, bi, bj, k,
      I                         .TRUE., r8seg, fldRL )
           ELSE
             WRITE(msgBuf,'(2A)')
@@ -427,7 +428,7 @@ C Only do I/O if I am the master thread
 
 C If we are reading from a global file then we open it here
         IF (globalFile) THEN
-          length_of_rec = MDS_RECLEN( filePrec, sNx*nSx, myThid )
+          length_of_rec = MDS_RECLEN( filePrec, sNx, myThid )
           OPEN( dUnit, file=dataFName, status=_OLD_STATUS,
      &            access='direct', recl=length_of_rec )
           fileIsOpen=.TRUE.
@@ -538,9 +539,9 @@ C If global file was opened then close it
 
 #ifdef _BYTESWAPIO
         IF ( filePrec.EQ.precFloat32 ) THEN
-          CALL MDS_BYTESWAPR4( sNx*nSx, r4seg )
+          CALL MDS_BYTESWAPR4( sNx, r4seg )
         ELSE
-          CALL MDS_BYTESWAPR8( sNx*nSx, r8seg )
+          CALL MDS_BYTESWAPR8( sNx, r8seg )
         ENDIF
 #endif
 
@@ -558,10 +559,10 @@ C Wait for all threads to finish filling shared buffer
 C-      copy from fldRL/RS(level=k) to 2-D "local":
         IF ( filePrec.EQ.precFloat32 ) THEN
           IF ( arrType.EQ.'RS' ) THEN
-            CALL MDS_SEG4toRS_2D( sNx*nSx, oLx, kSize, bi, bj, k,
+            CALL MDS_SEG4toRS_2D( sNx, oLx, kSize, bi, bj, k,
      &                            .TRUE., r4seg, fldRS )
           ELSEIF ( arrType.EQ.'RL' ) THEN
-            CALL MDS_SEG4toRS_2D( sNx*nSx, oLx, kSize, bi, bj, k,
+            CALL MDS_SEG4toRS_2D( sNx, oLx, kSize, bi, bj, k,
      &                            .TRUE., r4seg, fldRL )
           ELSE
             WRITE(msgBuf,'(2A)')
@@ -573,10 +574,10 @@ C-      copy from fldRL/RS(level=k) to 2-D "local":
 
         ELSEIF ( filePrec.EQ.precFloat64 ) THEN
           IF ( arrType.EQ.'RS' ) THEN
-            CALL MDS_SEG8toRS_2D( sNx*nSx, oLx, kSize, bi, bj, k,
+            CALL MDS_SEG8toRS_2D( sNx, oLx, kSize, bi, bj, k,
      I                         .TRUE., r8seg, fldRS )
           ELSEIF ( arrType.EQ.'RL' ) THEN
-            CALL MDS_SEG8toRS_2D( sNx*nSx, oLx, kSize, bi, bj, k,
+            CALL MDS_SEG8toRS_2D( sNx, oLx, kSize, bi, bj, k,
      I                         .TRUE., r8seg, fldRL )
           ELSE
             WRITE(msgBuf,'(2A)')
@@ -721,12 +722,15 @@ C     bBij  :: base shift in Buffer index for tile bi,bj
       INTEGER i1,i2,i,j,k,nNz
       INTEGER irec,dUnit,IL,pIL
       INTEGER length_of_rec
+      INTEGER bBij
       INTEGER tNy, global_nTy
       INTEGER tBy, iGjLoc, jGjLoc
-      REAL*4 r4seg(sNy*nSy)
-      REAL*8 r8seg(sNy*nSy)
+      REAL*4 r4seg(sNy,nSx,nSy)
+      REAL*8 r8seg(sNy,nSx,nSy)
       REAL*4 y_layer_buffer_r4(Ny)
       REAL*8 y_layer_buffer_r8(Ny)
+      REAL*4 yz_buffer_r4( sNy*Nr*nSx*nSy )
+      REAL*8 yz_buffer_r8( sNy*Nr*nSx*nSy )
 #ifdef ALLOW_EXCH2
       INTEGER tN
       REAL*4 y_layer_buffer_exch2_r4(exch2_global_Ny)
@@ -875,56 +879,71 @@ C If negative check for global file with MDS name (ie. fName.data)
 C- endif iAmDoingIO
       ENDIF
 
-C If option globalFile is desired but does not work or if
-C globalFile is too slow, then try using single-CPU I/O.
+C---+----1----+----2----+----3----+----4----+----5----+----6----+----7-|--+----|
+
       IF (useSingleCpuIO) THEN
 
 C Master thread of process 0, only, opens a global file
        IF ( iAmDoingIO ) THEN
-         WRITE(dataFName,'(2a)') fName(1:IL),'.data'
-         length_of_rec = MDS_RECLEN( filePrec, sNy*nSy, myThid )
-         OPEN( dUnit, file=dataFName, status=_OLD_STATUS,
-     &       access='direct', recl=length_of_rec )
+C If global file is visible to process 0, then open it here.
+C Otherwise stop program.
+         IF ( globalFile) THEN
+          length_of_rec = MDS_RECLEN( filePrec, ySize, myThid )
+          OPEN( dUnit, file=dataFName, status='old',
+     &         access='direct', recl=length_of_rec )
+         ELSE
+          WRITE(msgBuf,'(2A)')
+     &      ' MDS_READ_SEC_YZ: filename: ', dataFName(1:IL+5)
+          CALL PRINT_MESSAGE( msgBuf, standardMessageUnit,
+     &                        SQUEEZE_RIGHT, myThid)
+          CALL PRINT_ERROR( msgBuf, myThid )
+          WRITE(msgBuf,'(A)')
+     &      ' MDS_READ_SEC_YZ: File does not exist'
+          CALL PRINT_MESSAGE( msgBuf, standardMessageUnit,
+     &                        SQUEEZE_RIGHT, myThid)
+          CALL PRINT_ERROR( msgBuf, myThid )
+          STOP 'ABNORMAL END: S/R MDS_READ_SEC_YZ'
+         ENDIF
+C- endif iAmDoingIO
        ENDIF
 
-C master thread of process 0, only ,read from file
        DO k=kLo,kHi
 
+C master thread of process 0, only ,read from file
         IF ( iAmDoingIO ) THEN
           irec = 1 + k-kLo + (irecord-1)*kSize
           IF ( filePrec.EQ.precFloat32 ) THEN
-
 #ifdef ALLOW_EXCH2
-           IF ( .not.W2_useE2ioLayOut ) THEN
+            IF ( .not.W2_useE2ioLayOut ) THEN
 #endif
 # ifdef _BYTESWAPIO
-            CALL MDS_BYTESWAPR4( ySize, y_layer_buffer_r4 )
+              CALL MDS_BYTESWAPR4( ySize, y_layer_buffer_r4 )
 # endif
-            WRITE(dUnit,rec=irec) y_layer_buffer_r4
+              WRITE(dUnit,rec=irec) y_layer_buffer_r4
 #ifdef ALLOW_EXCH2
-           ELSE
+            ELSE
 # ifdef _BYTESWAPIO
-            CALL MDS_BYTESWAPR4( ySize, y_layer_buffer_exch2_r4 )
+              CALL MDS_BYTESWAPR4( ySize, y_layer_buffer_exch2_r4 )
 # endif
-            WRITE(dUnit,rec=irec) y_layer_buffer_exch2_r4
-           ENDIF
+             WRITE(dUnit,rec=irec) y_layer_buffer_exch2_r4
+            ENDIF
 #endif
           ELSE
 
 #ifdef ALLOW_EXCH2
-           IF ( .not.W2_useE2ioLayOut ) THEN
+            IF ( .not.W2_useE2ioLayOut ) THEN
 #endif
 # ifdef _BYTESWAPIO
-            CALL MDS_BYTESWAPR8( ySize, y_layer_buffer_r8 )
+              CALL MDS_BYTESWAPR8( ySize, y_layer_buffer_r8 )
 # endif
-            WRITE(dUnit,rec=irec) y_layer_buffer_r8
+              WRITE(dUnit,rec=irec) y_layer_buffer_r8
 #ifdef ALLOW_EXCH2
-           ELSE
+            ELSE
 # ifdef _BYTESWAPIO
-            CALL MDS_BYTESWAPR8( ySize, y_layer_buffer_exch2_r8 )
+              CALL MDS_BYTESWAPR8( ySize, y_layer_buffer_exch2_r8 )
 # endif
-            WRITE(dUnit,rec=irec) y_layer_buffer_exch2_r8
-           ENDIF
+              WRITE(dUnit,rec=irec) y_layer_buffer_exch2_r8
+            ENDIF
 #endif
           ENDIF
 C-      end if iAmDoingIO
@@ -939,28 +958,19 @@ C  to access shared buffer while master thread is loading data into
 #ifdef ALLOW_EXCH2
           IF ( .not.W2_useE2ioLayOut ) THEN
 #endif
-            CALL SCATTER_VEC_R4( 
-     O                         y_layer_buffer_r4,
-     I                         r4seg, 
-     I                         ySize, myThid ) 
+            CALL SCATTER_YZ_R4( y_layer_buffer_r4, r4seg, myThid )
 #ifdef ALLOW_EXCH2
           ELSE
-
-            CALL SCATTER_VEC_R4( 
-     O                         y_layer_buffer_exch2_r4,
-     I                         r4seg, 
-     I                         ySize, myThid ) 
+            CALL SCATTER_YZ_R4( y_layer_exch2_buffer_r4, r4seg, myThid )
           ENDIF
 #endif
           CALL BAR2( myThid )
-          DO bj=1,sNy
-          DO bi=1,sNx
           IF ( arrType.EQ.'RS' ) THEN
-            CALL MDS_SEG4toRS_2D( sNy*nSy, oLy, kSize, bi, bj, k,
-     &                            .TRUE., r4seg, fldRS )
+            CALL MDS_PASS_YZ_R4toRS( y_layer_buffer_r4, fldRS,
+     &              0, 1, k, kSize, 0, 0, .TRUE., myThid)
           ELSEIF ( arrType.EQ.'RL' ) THEN
-            CALL MDS_SEG4toRS_2D( sNy*nSy, oLy, kSize, bi, bj, k,
-     &                            .TRUE., r4seg, fldRL )
+            CALL MDS_PASS_YZ_R4toRL( y_layer_buffer_r4, fldRL,
+     &              0, 1, k, kSize, 0, 0, .TRUE., myThid)
           ELSE
             WRITE(msgBuf,'(2A)')
      &      ' MDS_READ_SEC_YZ: illegal value for arrType=', arrType
@@ -968,51 +978,31 @@ C  to access shared buffer while master thread is loading data into
             CALL ALL_PROC_DIE( myThid )
             STOP 'ABNORMAL END: S/R MDS_READ_SEC_YZ'
           ENDIF
-          ENDDO
-          ENDDO
-
         ELSEIF ( filePrec.EQ.precFloat64 ) THEN
 #ifdef ALLOW_EXCH2
           IF ( .not.W2_useE2ioLayOut ) THEN
 #endif
-            CALL SCATTER_VEC_R8( 
-     O                         y_layer_buffer_r8,
-     I                         r8seg, 
-     I                         ySize, myThid ) 
+            CALL SCATTER_YZ_R8( y_layer_buffer_r8, r8seg, myThid )
 #ifdef ALLOW_EXCH2
           ELSE
-
-            CALL SCATTER_VEC_R8( 
-     O                          y_layer_buffer_exch2_r8,
-     I                          r8seg, 
-     I                          ySize, myThid ) 
+            CALL SCATTER_YZ_R8( y_layer_exch2_buffer_r8, r8seg, myThid )
           ENDIF
 #endif
           CALL BAR2( myThid )
-          DO bj=1,sNy
-          DO bi=1,sNx
           IF ( arrType.EQ.'RS' ) THEN
-            CALL MDS_SEG8toRS_2D( sNy*nSy, oLy, kSize, bi, bj, k,
-     I                         .TRUE., r8seg, fldRS )
+            CALL MDS_PASS_YZ_R8toRS( y_layer_buffer_r8, fldRS,
+     &              0, 1, k, kSize, 0, 0, .TRUE., myThid)
           ELSEIF ( arrType.EQ.'RL' ) THEN
-            CALL MDS_SEG8toRS_2D( sNy*nSy, oLy, kSize, bi, bj, k,
-     I                         .TRUE., r8seg, fldRL )
+            CALL MDS_PASS_YZ_R8toRL( y_layer_buffer_r8, fldRL,
+     &              0, 1, k, kSize, 0, 0, .TRUE., myThid)
+
           ELSE
-            WRITE(msgBuf,'(2A)')
-     &      ' MDS_READ_SEC_YZ: illegal value for arrType=', arrType
+            WRITE(msgBuf,'(A,I6)')
+     &        ' MDS_READ_SEC_YZ: illegal value for filePrec=',filePrec
             CALL PRINT_ERROR( msgBuf, myThid )
             CALL ALL_PROC_DIE( myThid )
             STOP 'ABNORMAL END: S/R MDS_READ_SEC_YZ'
           ENDIF
-          ENDDO
-          ENDDO
-
-        ELSE
-          WRITE(msgBuf,'(A,I6)')
-     &      ' MDS_READ_SEC_YZ: illegal value for filePrec=',filePrec
-          CALL PRINT_ERROR( msgBuf, myThid )
-          CALL ALL_PROC_DIE( myThid )
-          STOP 'ABNORMAL END: S/R MDS_READ_SEC_YZ'
         ENDIF
 
 C-     end of k loop
@@ -1033,8 +1023,8 @@ C Only do I/O if I am the master thread
 
 C If we are reading from a global file then we open it here
         IF (globalFile) THEN
-          length_of_rec = MDS_RECLEN( filePrec, sNy*nSy, myThid )
-          OPEN( dUnit, file=dataFName, status=_OLD_STATUS,
+          length_of_rec = MDS_RECLEN( filePrec, sNy, myThid )
+          OPEN( dUnit, file=dataFName, status='old',
      &            access='direct', recl=length_of_rec )
           fileIsOpen=.TRUE.
         ENDIF
@@ -1042,10 +1032,16 @@ C If we are reading from a global file then we open it here
 C Loop over all tiles
         DO bj=1,nSy
          DO bi=1,nSx
+          bBij = sNy*nNz*( bi-1 + (bj-1)*nSx )
+
+          IF (globalFile) THEN
+C--- Case of 1 Global file:
 
           tNy = sNy
           global_nTy = ySize/sNy
           tBy = myYGlobalLo-1 + (bj-1)*sNy
+          iGjLoc = 0
+          jGjLoc = 1
 #ifdef ALLOW_EXCH2
           IF ( useExch2ioLayOut ) THEN
             tN = W2_myTileList(bi,bj)
@@ -1065,16 +1061,16 @@ C-          default (face fit into global-IO-array)
           ENDIF
 #endif /* ALLOW_EXCH2 */
 
-          IF (globalFile) THEN
-C--- Case of 1 Global file:
-
+Cts --- TODO: check this!
            DO k=kLo,kHi
             irec = 1 + tBy/tNy
      &           +( k-kLo + (irecord-1)*kSize )*global_nTy
+            i1 = bBij + 1 + (k-kLo)*sNx*sNy
+            i2 = bBij +           k*sNx*sNy
             IF ( filePrec.EQ.precFloat32 ) THEN
-             READ(dUnit,rec=irec) r4seg
+             READ(dUnit,rec=irec) (yz_buffer_r4(i),i=i1,i2)
             ELSE
-             READ(dUnit,rec=irec) r8seg
+             READ(dUnit,rec=irec) (yz_buffer_r8(i),i=i1,i2)
             ENDIF
 C End of k loop
            ENDDO
@@ -1095,7 +1091,7 @@ C If we are writing to a tiled MDS file then we open each one here
               CALL PRINT_MESSAGE( msgBuf, standardMessageUnit,
      &                  SQUEEZE_RIGHT, myThid)
             ENDIF
-            length_of_rec = MDS_RECLEN( filePrec, sNy, myThid )
+            length_of_rec = MDS_RECLEN( filePrec, sNy*nNz, myThid )
             OPEN( dUnit, file=dataFName, status=_OLD_STATUS,
      &            access='direct', recl=length_of_rec )
             fileIsOpen=.TRUE.
@@ -1114,14 +1110,12 @@ C If we are writing to a tiled MDS file then we open each one here
             STOP 'ABNORMAL END: S/R MDS_READ_SEC_YZ'
            ENDIF
 
-           DO k=kLo,kHi
-            irec = k+kSize*(irecord-1)
-            IF ( filePrec.EQ.precFloat32 ) THEN
-              READ(dUnit,rec=irec) r4seg
-            ELSE
-              READ(dUnit,rec=irec) r8seg
-            ENDIF
-           ENDDO
+           irec = irecord
+           IF ( filePrec.EQ.precFloat32 ) THEN
+             READ(dUnit,rec=irec) yz_buffer_r4
+           ELSE
+             READ(dUnit,rec=irec) yz_buffer_r8
+           ENDIF
 
 C here We close the tiled MDS file
            IF ( fileIsOpen ) THEN
@@ -1144,9 +1138,9 @@ C If global file was opened then close it
 
 #ifdef _BYTESWAPIO
         IF ( filePrec.EQ.precFloat32 ) THEN
-          CALL MDS_BYTESWAPR4( sNy*nSy, r4seg )
+          CALL MDS_BYTESWAPR4( sNy*nNz*nSx*nSy, yz_buffer_r4 )
         ELSE
-          CALL MDS_BYTESWAPR8( sNy*nSy, r8seg )
+          CALL MDS_BYTESWAPR8( sNy*nNz*nSx*nSy, yz_buffer_r8 )
         ENDIF
 #endif
 
@@ -1156,56 +1150,44 @@ C- endif iAmDoingIO
 C Wait for all threads to finish filling shared buffer
        CALL BAR2( myThid )
 
+C-     copy from fldRL/RS(level=k) to 2-D "local":
+       IF ( filePrec.EQ.precFloat32 ) THEN
+         IF ( arrType.EQ.'RS' ) THEN
+           CALL MDS_PASS_YZ_R4toRS( yz_buffer_r4, fldRS,
+     I              0, nNz, kLo, kSize, 0, 0, .TRUE., myThid )
+         ELSEIF ( arrType.EQ.'RL' ) THEN
+           CALL MDS_PASS_YZ_R4toRL( yz_buffer_r4, fldRL,
+     I              0, nNz, kLo, kSize, 0, 0, .TRUE., myThid )
+         ELSE
+           WRITE(msgBuf,'(2A)')
+     &     ' MDS_READ_SEC_YZ: illegal value for arrType=', arrType
+           CALL PRINT_ERROR( msgBuf, myThid )
+           CALL ALL_PROC_DIE( myThid )
+           STOP 'ABNORMAL END: S/R MDS_READ_SEC_YZ'
+         ENDIF
 
-       DO k=kLo,kHi
-        DO bj=1,nSy
-         DO bi=1,nSx
-C-      copy from fldRL/RS(level=k) to 2-D "local":
-        IF ( filePrec.EQ.precFloat32 ) THEN
-          IF ( arrType.EQ.'RS' ) THEN
-            CALL MDS_SEG4toRS_2D( sNy*nSy, oLy, kSize, bi, bj, k,
-     &                            .TRUE., r4seg, fldRS )
-          ELSEIF ( arrType.EQ.'RL' ) THEN
-            CALL MDS_SEG4toRS_2D( sNy*nSy, oLy, kSize, bi, bj, k,
-     &                            .TRUE., r4seg, fldRL )
-          ELSE
-            WRITE(msgBuf,'(2A)')
-     &      ' MDS_READ_SEC_YZ: illegal value for arrType=', arrType
-            CALL PRINT_ERROR( msgBuf, myThid )
-            CALL ALL_PROC_DIE( myThid )
-            STOP 'ABNORMAL END: S/R MDS_READ_SEC_YZ'
-          ENDIF
+       ELSEIF ( filePrec.EQ.precFloat64 ) THEN
+         IF ( arrType.EQ.'RS' ) THEN
+           CALL MDS_PASS_YZ_R8toRS( yz_buffer_r8, fldRS,
+     I              0, nNz, kLo, kSize, 0, 0, .TRUE., myThid )
+         ELSEIF ( arrType.EQ.'RL' ) THEN
+           CALL MDS_PASS_YZ_R8toRL( yz_buffer_r8, fldRL,
+     I              0, nNz, kLo, kSize, 0, 0, .TRUE., myThid )
+         ELSE
+           WRITE(msgBuf,'(2A)')
+     &     ' MDS_READ_SEC_YZ: illegal value for arrType=', arrType
+           CALL PRINT_ERROR( msgBuf, myThid )
+           CALL ALL_PROC_DIE( myThid )
+           STOP 'ABNORMAL END: S/R MDS_READ_SEC_YZ'
+         ENDIF
 
-        ELSEIF ( filePrec.EQ.precFloat64 ) THEN
-          IF ( arrType.EQ.'RS' ) THEN
-            CALL MDS_SEG8toRS_2D( sNy*nSy, oLy, kSize, bi, bj, k,
-     I                         .TRUE., r8seg, fldRS )
-          ELSEIF ( arrType.EQ.'RL' ) THEN
-            CALL MDS_SEG8toRS_2D( sNy*nSy, oLy, kSize, bi, bj, k,
-     I                         .TRUE., r8seg, fldRL )
-          ELSE
-            WRITE(msgBuf,'(2A)')
-     &      ' MDS_READ_SEC_YZ: illegal value for arrType=', arrType
-            CALL PRINT_ERROR( msgBuf, myThid )
-            CALL ALL_PROC_DIE( myThid )
-            STOP 'ABNORMAL END: S/R MDS_READ_SEC_YZ'
-          ENDIF
-
-        ELSE
-          WRITE(msgBuf,'(A,I6)')
-     &      ' MDS_READ_SEC_YZ: illegal value for filePrec=',filePrec
-          CALL PRINT_ERROR( msgBuf, myThid )
-          CALL ALL_PROC_DIE( myThid )
-          STOP 'ABNORMAL END: S/R MDS_READ_SEC_YZ'
-        ENDIF
-
-C End of bi,bj loops
-         ENDDO
-        ENDDO
-
-C End k loop
-          ENDDO
-
+       ELSE
+         WRITE(msgBuf,'(A,I6)')
+     &     ' MDS_READ_SEC_YZ: illegal value for filePrec=',filePrec
+         CALL PRINT_ERROR( msgBuf, myThid )
+         CALL ALL_PROC_DIE( myThid )
+         STOP 'ABNORMAL END: S/R MDS_READ_SEC_YZ'
+       ENDIF
 
       CALL BAR2( myThid )
 

--- a/pkg/mdsio/mdsio_read_section.F
+++ b/pkg/mdsio/mdsio_read_section.F
@@ -725,16 +725,14 @@ C     bBij  :: base shift in Buffer index for tile bi,bj
       INTEGER bBij
       INTEGER tNy, global_nTy
       INTEGER tBy, iGjLoc, jGjLoc
-      REAL*4 r4seg(sNy,nSx,nSy)
-      REAL*8 r8seg(sNy,nSx,nSy)
-      REAL*4 y_layer_buffer_r4(Ny)
-      REAL*8 y_layer_buffer_r8(Ny)
-      REAL*4 yz_buffer_r4( sNy*Nr*nSx*nSy )
-      REAL*8 yz_buffer_r8( sNy*Nr*nSx*nSy )
+      _R4 r4seg(sNy,nSx,nSy)
+      _R8 r8seg(sNy,nSx,nSy)
+      _R4 y_buffer_r4(Ny)
+      _R8 y_buffer_r8(Ny)
+      _R4 yz_buffer_r4( sNy*Nr*nSy )
+      _R8 yz_buffer_r8( sNy*Nr*nSy )
 #ifdef ALLOW_EXCH2
       INTEGER tN
-      REAL*4 y_layer_buffer_exch2_r4(exch2_global_Ny)
-      REAL*8 y_layer_buffer_exch2_r8(exch2_global_Ny)
 #endif /* ALLOW_EXCH2 */
 
 C---+----1----+----2----+----3----+----4----+----5----+----6----+----7-|--+----|
@@ -913,37 +911,14 @@ C master thread of process 0, only ,read from file
         IF ( iAmDoingIO ) THEN
           irec = 1 + k-kLo + (irecord-1)*kSize
           IF ( filePrec.EQ.precFloat32 ) THEN
-#ifdef ALLOW_EXCH2
-            IF ( .not.W2_useE2ioLayOut ) THEN
-#endif
-# ifdef _BYTESWAPIO
-              CALL MDS_BYTESWAPR4( ySize, y_layer_buffer_r4 )
-# endif
-              WRITE(dUnit,rec=irec) y_layer_buffer_r4
-#ifdef ALLOW_EXCH2
-            ELSE
-# ifdef _BYTESWAPIO
-              CALL MDS_BYTESWAPR4( ySize, y_layer_buffer_exch2_r4 )
-# endif
-             WRITE(dUnit,rec=irec) y_layer_buffer_exch2_r4
-            ENDIF
+            READ(dUnit,rec=irec) y_buffer_r4
+#ifdef _BYTESWAPIO
+            CALL MDS_BYTESWAPR4( ySize, y_buffer_r4 )
 #endif
           ELSE
-
-#ifdef ALLOW_EXCH2
-            IF ( .not.W2_useE2ioLayOut ) THEN
-#endif
-# ifdef _BYTESWAPIO
-              CALL MDS_BYTESWAPR8( ySize, y_layer_buffer_r8 )
-# endif
-              WRITE(dUnit,rec=irec) y_layer_buffer_r8
-#ifdef ALLOW_EXCH2
-            ELSE
-# ifdef _BYTESWAPIO
-              CALL MDS_BYTESWAPR8( ySize, y_layer_buffer_exch2_r8 )
-# endif
-              WRITE(dUnit,rec=irec) y_layer_buffer_exch2_r8
-            ENDIF
+            READ(dUnit,rec=irec) y_buffer_r8
+#ifdef _BYTESWAPIO
+            CALL MDS_BYTESWAPR8( ySize, y_buffer_r8 )
 #endif
           ENDIF
 C-      end if iAmDoingIO
@@ -955,21 +930,18 @@ C  to access shared buffer while master thread is loading data into
         CALL BAR2( myThid )
 
         IF ( filePrec.EQ.precFloat32 ) THEN
-#ifdef ALLOW_EXCH2
-          IF ( .not.W2_useE2ioLayOut ) THEN
-#endif
-            CALL SCATTER_YZ_R4( y_layer_buffer_r4, r4seg, myThid )
-#ifdef ALLOW_EXCH2
-          ELSE
-            CALL SCATTER_YZ_R4( y_layer_exch2_buffer_r4, r4seg, myThid )
-          ENDIF
-#endif
+          CALL SCATTER_YZ_R4( 
+     U                       y_buffer_r4,
+     O                       r4seg,
+     I                       ySize,
+     I                       useExch2ioLayOut, .FALSE., myThid )
+C All threads wait for Master to finish loading into shared buffer
           CALL BAR2( myThid )
           IF ( arrType.EQ.'RS' ) THEN
-            CALL MDS_PASS_YZ_R4toRS( y_layer_buffer_r4, fldRS,
+            CALL MDS_PASS_YZ_R4toRS( y_buffer_r4, fldRS,
      &              0, 1, k, kSize, 0, 0, .TRUE., myThid)
           ELSEIF ( arrType.EQ.'RL' ) THEN
-            CALL MDS_PASS_YZ_R4toRL( y_layer_buffer_r4, fldRL,
+            CALL MDS_PASS_YZ_R4toRL( y_buffer_r4, fldRL,
      &              0, 1, k, kSize, 0, 0, .TRUE., myThid)
           ELSE
             WRITE(msgBuf,'(2A)')
@@ -979,23 +951,19 @@ C  to access shared buffer while master thread is loading data into
             STOP 'ABNORMAL END: S/R MDS_READ_SEC_YZ'
           ENDIF
         ELSEIF ( filePrec.EQ.precFloat64 ) THEN
-#ifdef ALLOW_EXCH2
-          IF ( .not.W2_useE2ioLayOut ) THEN
-#endif
-            CALL SCATTER_YZ_R8( y_layer_buffer_r8, r8seg, myThid )
-#ifdef ALLOW_EXCH2
-          ELSE
-            CALL SCATTER_YZ_R8( y_layer_exch2_buffer_r8, r8seg, myThid )
-          ENDIF
-#endif
+          CALL SCATTER_YZ_R8( 
+     U                       y_buffer_r8,
+     O                       r8seg,
+     I                       ySize,
+     I                       useExch2ioLayOut, .FALSE., myThid )
+C All threads wait for Master to finish loading into shared buffer
           CALL BAR2( myThid )
           IF ( arrType.EQ.'RS' ) THEN
-            CALL MDS_PASS_YZ_R8toRS( y_layer_buffer_r8, fldRS,
+            CALL MDS_PASS_YZ_R8toRS( y_buffer_r8, fldRS,
      &              0, 1, k, kSize, 0, 0, .TRUE., myThid)
           ELSEIF ( arrType.EQ.'RL' ) THEN
-            CALL MDS_PASS_YZ_R8toRL( y_layer_buffer_r8, fldRL,
+            CALL MDS_PASS_YZ_R8toRL( y_buffer_r8, fldRL,
      &              0, 1, k, kSize, 0, 0, .TRUE., myThid)
-
           ELSE
             WRITE(msgBuf,'(A,I6)')
      &        ' MDS_READ_SEC_YZ: illegal value for filePrec=',filePrec
@@ -1061,12 +1029,11 @@ C-          default (face fit into global-IO-array)
           ENDIF
 #endif /* ALLOW_EXCH2 */
 
-Cts --- TODO: check this!
            DO k=kLo,kHi
             irec = 1 + tBy/tNy
      &           +( k-kLo + (irecord-1)*kSize )*global_nTy
-            i1 = bBij + 1 + (k-kLo)*sNx*sNy
-            i2 = bBij +           k*sNx*sNy
+            i1 = bBij + 1 + (k-kLo)*sNy
+            i2 = bBij +           k*sNy
             IF ( filePrec.EQ.precFloat32 ) THEN
              READ(dUnit,rec=irec) (yz_buffer_r4(i),i=i1,i2)
             ELSE
@@ -1138,9 +1105,9 @@ C If global file was opened then close it
 
 #ifdef _BYTESWAPIO
         IF ( filePrec.EQ.precFloat32 ) THEN
-          CALL MDS_BYTESWAPR4( sNy*nNz*nSx*nSy, yz_buffer_r4 )
+          CALL MDS_BYTESWAPR4( sNy*nNz*nSy, yz_buffer_r4 )
         ELSE
-          CALL MDS_BYTESWAPR8( sNy*nNz*nSx*nSy, yz_buffer_r8 )
+          CALL MDS_BYTESWAPR8( sNy*nNz*nSy, yz_buffer_r8 )
         ENDIF
 #endif
 

--- a/pkg/mdsio/mdsio_read_section.F
+++ b/pkg/mdsio/mdsio_read_section.F
@@ -938,10 +938,10 @@ C  to access shared buffer while master thread is loading data into
 C All threads wait for Master to finish loading into shared buffer
           CALL BAR2( myThid )
           IF ( arrType.EQ.'RS' ) THEN
-            CALL MDS_PASS_YZ_R4toRS( y_buffer_r4, fldRS,
+            CALL MDS_PASS_YZ_R4toRS( r4seg, fldRS,
      &              0, 1, k, kSize, 0, 0, .TRUE., myThid)
           ELSEIF ( arrType.EQ.'RL' ) THEN
-            CALL MDS_PASS_YZ_R4toRL( y_buffer_r4, fldRL,
+            CALL MDS_PASS_YZ_R4toRL( r4seg, fldRL,
      &              0, 1, k, kSize, 0, 0, .TRUE., myThid)
           ELSE
             WRITE(msgBuf,'(2A)')
@@ -959,10 +959,10 @@ C All threads wait for Master to finish loading into shared buffer
 C All threads wait for Master to finish loading into shared buffer
           CALL BAR2( myThid )
           IF ( arrType.EQ.'RS' ) THEN
-            CALL MDS_PASS_YZ_R8toRS( y_buffer_r8, fldRS,
+            CALL MDS_PASS_YZ_R8toRS( r8seg, fldRS,
      &              0, 1, k, kSize, 0, 0, .TRUE., myThid)
           ELSEIF ( arrType.EQ.'RL' ) THEN
-            CALL MDS_PASS_YZ_R8toRL( y_buffer_r8, fldRL,
+            CALL MDS_PASS_YZ_R8toRL( r8seg, fldRL,
      &              0, 1, k, kSize, 0, 0, .TRUE., myThid)
           ELSE
             WRITE(msgBuf,'(A,I6)')
@@ -972,7 +972,6 @@ C All threads wait for Master to finish loading into shared buffer
             STOP 'ABNORMAL END: S/R MDS_READ_SEC_YZ'
           ENDIF
         ENDIF
-
 C-     end of k loop
        ENDDO
 

--- a/pkg/mdsio/mdsio_read_section.F
+++ b/pkg/mdsio/mdsio_read_section.F
@@ -6,7 +6,6 @@ C--   o MDS_READ_SEC_XZ
 C--   o MDS_READ_SEC_YZ
 
 C---+----1----+----2----+----3----+----4----+----5----+----6----+----7-|--+----|
-
 CBOP
 C !ROUTINE: MDS_READ_SEC_XZ
 C !INTERFACE:
@@ -118,14 +117,14 @@ C     bBij  :: base shift in Buffer index for tile bi,bj
       INTEGER bBij
       INTEGER tNx, global_nTx
       INTEGER tBx, iGjLoc, jGjLoc
-      REAL*4 r4seg(sNx)
-      REAL*8 r8seg(sNx)
-      REAL*4 x_layer_buffer_r4(Nx)
-      REAL*8 x_layer_buffer_r8(Nx)
+      _R4 r4seg(sNx,nSx,nSy)
+      _R8 r8seg(sNx,nSx,nSy)
+      _R4 x_buffer_r4(Nx)
+      _R8 x_buffer_r8(Nx)
+      _R4 xz_buffer_r4( sNx*Nr*nSx )
+      _R8 xz_buffer_r8( sNx*Nr*nSx )
 #ifdef ALLOW_EXCH2
       INTEGER tN
-      REAL*4 x_layer_buffer_exch2_r4(exch2_global_Nx)
-      REAL*8 x_layer_buffer_exch2_r8(exch2_global_Nx)
 #endif /* ALLOW_EXCH2 */
 
 C---+----1----+----2----+----3----+----4----+----5----+----6----+----7-|--+----|
@@ -270,56 +269,48 @@ C If negative check for global file with MDS name (ie. fName.data)
 C- endif iAmDoingIO
       ENDIF
 
-C If option globalFile is desired but does not work or if
-C globalFile is too slow, then try using single-CPU I/O.
+C---+----1----+----2----+----3----+----4----+----5----+----6----+----7-|--+----|
+
       IF (useSingleCpuIO) THEN
 
 C Master thread of process 0, only, opens a global file
        IF ( iAmDoingIO ) THEN
-         WRITE(dataFName,'(2a)') fName(1:IL),'.data'
-         length_of_rec = MDS_RECLEN( filePrec, sNx, myThid )
-         OPEN( dUnit, file=dataFName, status=_OLD_STATUS,
-     &       access='direct', recl=length_of_rec )
+C If global file is visible to process 0, then open it here.
+C Otherwise stop program.
+         IF ( globalFile) THEN
+          length_of_rec = MDS_RECLEN( filePrec, xSize, myThid )
+          OPEN( dUnit, file=dataFName, status='old',
+     &         access='direct', recl=length_of_rec )
+         ELSE
+          WRITE(msgBuf,'(2A)')
+     &      ' MDS_READ_SEC_XZ: filename: ', dataFName(1:IL+5)
+          CALL PRINT_MESSAGE( msgBuf, standardMessageUnit,
+     &                        SQUEEZE_RIGHT, myThid)
+          CALL PRINT_ERROR( msgBuf, myThid )
+          WRITE(msgBuf,'(A)')
+     &      ' MDS_READ_SEC_XZ: File does not exist'
+          CALL PRINT_MESSAGE( msgBuf, standardMessageUnit,
+     &                        SQUEEZE_RIGHT, myThid)
+          CALL PRINT_ERROR( msgBuf, myThid )
+          STOP 'ABNORMAL END: S/R MDS_READ_SEC_XZ'
+         ENDIF
+C- endif iAmDoingIO
        ENDIF
 
-C master thread of process 0, only ,read from file
        DO k=kLo,kHi
 
+C master thread of process 0, only ,read from file
         IF ( iAmDoingIO ) THEN
           irec = 1 + k-kLo + (irecord-1)*kSize
           IF ( filePrec.EQ.precFloat32 ) THEN
-
-#ifdef ALLOW_EXCH2
-           IF ( .not.W2_useE2ioLayOut ) THEN
-#endif
-# ifdef _BYTESWAPIO
-            CALL MDS_BYTESWAPR4( xSize, x_layer_buffer_r4 )
-# endif
-            WRITE(dUnit,rec=irec) x_layer_buffer_r4
-#ifdef ALLOW_EXCH2
-           ELSE
-# ifdef _BYTESWAPIO
-            CALL MDS_BYTESWAPR4( xSize, x_layer_buffer_exch2_r4 )
-# endif
-            WRITE(dUnit,rec=irec) x_layer_buffer_exch2_r4
-           ENDIF
+            READ(dUnit,rec=irec) x_buffer_r4
+#ifdef _BYTESWAPIO
+            CALL MDS_BYTESWAPR4( xSize, x_buffer_r4 )
 #endif
           ELSE
-
-#ifdef ALLOW_EXCH2
-           IF ( .not.W2_useE2ioLayOut ) THEN
-#endif
-# ifdef _BYTESWAPIO
-            CALL MDS_BYTESWAPR8( xSize, x_layer_buffer_r8 )
-# endif
-            WRITE(dUnit,rec=irec) x_layer_buffer_r8
-#ifdef ALLOW_EXCH2
-           ELSE
-# ifdef _BYTESWAPIO
-            CALL MDS_BYTESWAPR8( xSize, x_layer_buffer_exch2_r8 )
-# endif
-            WRITE(dUnit,rec=irec) x_layer_buffer_exch2_r8
-           ENDIF
+            READ(dUnit,rec=irec) x_buffer_r8
+#ifdef _BYTESWAPIO
+            CALL MDS_BYTESWAPR8( xSize, x_buffer_r8 )
 #endif
           ENDIF
 C-      end if iAmDoingIO
@@ -331,31 +322,19 @@ C  to access shared buffer while master thread is loading data into
         CALL BAR2( myThid )
 
         IF ( filePrec.EQ.precFloat32 ) THEN
-#ifdef ALLOW_EXCH2
-          IF ( .not.W2_useE2ioLayOut ) THEN
-#endif
-            CALL SCATTER_VEC_R4( 
-     I                         x_layer_buffer_r4,
-     O                         r4seg, 
-     I                         sNx, myThid ) 
-#ifdef ALLOW_EXCH2
-          ELSE
-
-            CALL SCATTER_VEC_R4( 
-     I                         x_layer_buffer_exch2_r4,
-     O                         r4seg, 
-     I                         sNx, myThid ) 
-          ENDIF
-#endif
+          CALL SCATTER_XZ_R4( 
+     U                       x_buffer_r4,
+     O                       r4seg,
+     I                       xSize,
+     I                       useExch2ioLayOut, .FALSE., myThid )
+C All threads wait for Master to finish loading into shared buffer
           CALL BAR2( myThid )
-          DO bj=1,sNy
-          DO bi=1,sNx
           IF ( arrType.EQ.'RS' ) THEN
-            CALL MDS_SEG4toRS_2D( sNx, oLx, kSize, bi, bj, k,
-     &                            .TRUE., r4seg, fldRS )
+            CALL MDS_PASS_XZ_R4toRS( r4seg, fldRS,
+     &              0, 1, k, kSize, 0, 0, .TRUE., myThid)
           ELSEIF ( arrType.EQ.'RL' ) THEN
-            CALL MDS_SEG4toRS_2D( sNx, oLx, kSize, bi, bj, k,
-     &                            .TRUE., r4seg, fldRL )
+            CALL MDS_PASS_XZ_R4toRL( r4seg, fldRL,
+     &              0, 1, k, kSize, 0, 0, .TRUE., myThid)
           ELSE
             WRITE(msgBuf,'(2A)')
      &      ' MDS_READ_SEC_XZ: illegal value for arrType=', arrType
@@ -363,53 +342,28 @@ C  to access shared buffer while master thread is loading data into
             CALL ALL_PROC_DIE( myThid )
             STOP 'ABNORMAL END: S/R MDS_READ_SEC_XZ'
           ENDIF
-          ENDDO
-          ENDDO
-
         ELSEIF ( filePrec.EQ.precFloat64 ) THEN
-#ifdef ALLOW_EXCH2
-          IF ( .not.W2_useE2ioLayOut ) THEN
-#endif
-            CALL SCATTER_VEC_R8( 
-     I                         x_layer_buffer_r8,
-     O                         r8seg, 
-     I                         sNx, myThid ) 
-#ifdef ALLOW_EXCH2
-          ELSE
-
-            CALL SCATTER_VEC_R8( 
-     I                          x_layer_buffer_exch2_r8,
-     O                          r8seg, 
-     I                          sNx, myThid ) 
-          ENDIF
-#endif
+          CALL SCATTER_XZ_R8( 
+     U                       x_buffer_r8,
+     O                       r8seg,
+     I                       xSize,
+     I                       useExch2ioLayOut, .FALSE., myThid )
+C All threads wait for Master to finish loading into shared buffer
           CALL BAR2( myThid )
-          DO bj=1,sNy
-          DO bi=1,sNx
           IF ( arrType.EQ.'RS' ) THEN
-            CALL MDS_SEG8toRS_2D( sNx, oLx, kSize, bi, bj, k,
-     I                         .TRUE., r8seg, fldRS )
+            CALL MDS_PASS_XZ_R8toRS( r8seg, fldRS,
+     &              0, 1, k, kSize, 0, 0, .TRUE., myThid)
           ELSEIF ( arrType.EQ.'RL' ) THEN
-            CALL MDS_SEG8toRS_2D( sNx, oLx, kSize, bi, bj, k,
-     I                         .TRUE., r8seg, fldRL )
+            CALL MDS_PASS_XZ_R8toRL( r8seg, fldRL,
+     &              0, 1, k, kSize, 0, 0, .TRUE., myThid)
           ELSE
-            WRITE(msgBuf,'(2A)')
-     &      ' MDS_READ_SEC_XZ: illegal value for arrType=', arrType
+            WRITE(msgBuf,'(A,I6)')
+     &        ' MDS_READ_SEC_XZ: illegal value for filePrec=',filePrec
             CALL PRINT_ERROR( msgBuf, myThid )
             CALL ALL_PROC_DIE( myThid )
             STOP 'ABNORMAL END: S/R MDS_READ_SEC_XZ'
           ENDIF
-          ENDDO
-          ENDDO
-
-        ELSE
-          WRITE(msgBuf,'(A,I6)')
-     &      ' MDS_READ_SEC_XZ: illegal value for filePrec=',filePrec
-          CALL PRINT_ERROR( msgBuf, myThid )
-          CALL ALL_PROC_DIE( myThid )
-          STOP 'ABNORMAL END: S/R MDS_READ_SEC_XZ'
         ENDIF
-
 C-     end of k loop
        ENDDO
 
@@ -429,7 +383,7 @@ C Only do I/O if I am the master thread
 C If we are reading from a global file then we open it here
         IF (globalFile) THEN
           length_of_rec = MDS_RECLEN( filePrec, sNx, myThid )
-          OPEN( dUnit, file=dataFName, status=_OLD_STATUS,
+          OPEN( dUnit, file=dataFName, status='old',
      &            access='direct', recl=length_of_rec )
           fileIsOpen=.TRUE.
         ENDIF
@@ -437,10 +391,16 @@ C If we are reading from a global file then we open it here
 C Loop over all tiles
         DO bj=1,nSy
          DO bi=1,nSx
+          bBij = sNx*nNz*( bi-1 + (bj-1)*nSx )
+
+          IF (globalFile) THEN
+C--- Case of 1 Global file:
 
           tNx = sNx
           global_nTx = xSize/sNx
           tBx = myXGlobalLo-1 + (bi-1)*sNx
+          iGjLoc = 0
+          jGjLoc = 1
 #ifdef ALLOW_EXCH2
           IF ( useExch2ioLayOut ) THEN
             tN = W2_myTileList(bi,bj)
@@ -460,16 +420,15 @@ C-          default (face fit into global-IO-array)
           ENDIF
 #endif /* ALLOW_EXCH2 */
 
-          IF (globalFile) THEN
-C--- Case of 1 Global file:
-
            DO k=kLo,kHi
             irec = 1 + tBx/tNx
      &           +( k-kLo + (irecord-1)*kSize )*global_nTx
+            i1 = bBij + 1 + (k-kLo)*sNx
+            i2 = bBij +           k*sNx
             IF ( filePrec.EQ.precFloat32 ) THEN
-             READ(dUnit,rec=irec) r4seg
+             READ(dUnit,rec=irec) (xz_buffer_r4(i),i=i1,i2)
             ELSE
-             READ(dUnit,rec=irec) r8seg
+             READ(dUnit,rec=irec) (xz_buffer_r8(i),i=i1,i2)
             ENDIF
 C End of k loop
            ENDDO
@@ -490,7 +449,7 @@ C If we are writing to a tiled MDS file then we open each one here
               CALL PRINT_MESSAGE( msgBuf, standardMessageUnit,
      &                  SQUEEZE_RIGHT, myThid)
             ENDIF
-            length_of_rec = MDS_RECLEN( filePrec, sNx, myThid )
+            length_of_rec = MDS_RECLEN( filePrec, sNx*nNz, myThid )
             OPEN( dUnit, file=dataFName, status=_OLD_STATUS,
      &            access='direct', recl=length_of_rec )
             fileIsOpen=.TRUE.
@@ -509,14 +468,12 @@ C If we are writing to a tiled MDS file then we open each one here
             STOP 'ABNORMAL END: S/R MDS_READ_SEC_XZ'
            ENDIF
 
-           DO k=kLo,kHi
-            irec = k+kSize*(irecord-1)
-            IF ( filePrec.EQ.precFloat32 ) THEN
-              READ(dUnit,rec=irec) r4seg
-            ELSE
-              READ(dUnit,rec=irec) r8seg
-            ENDIF
-           ENDDO
+           irec = irecord
+           IF ( filePrec.EQ.precFloat32 ) THEN
+             READ(dUnit,rec=irec) xz_buffer_r4
+           ELSE
+             READ(dUnit,rec=irec) xz_buffer_r8
+           ENDIF
 
 C here We close the tiled MDS file
            IF ( fileIsOpen ) THEN
@@ -539,9 +496,9 @@ C If global file was opened then close it
 
 #ifdef _BYTESWAPIO
         IF ( filePrec.EQ.precFloat32 ) THEN
-          CALL MDS_BYTESWAPR4( sNx, r4seg )
+          CALL MDS_BYTESWAPR4( sNx*nNz*nSx, xz_buffer_r4 )
         ELSE
-          CALL MDS_BYTESWAPR8( sNx, r8seg )
+          CALL MDS_BYTESWAPR8( sNx*nNz*nSx, xz_buffer_r8 )
         ENDIF
 #endif
 
@@ -551,57 +508,44 @@ C- endif iAmDoingIO
 C Wait for all threads to finish filling shared buffer
        CALL BAR2( myThid )
 
+C-     copy from fldRL/RS(level=k) to 2-D "local":
+       IF ( filePrec.EQ.precFloat32 ) THEN
+         IF ( arrType.EQ.'RS' ) THEN
+           CALL MDS_PASS_XZ_R4toRS( xz_buffer_r4, fldRS,
+     I              0, nNz, kLo, kSize, 0, 0, .TRUE., myThid )
+         ELSEIF ( arrType.EQ.'RL' ) THEN
+           CALL MDS_PASS_XZ_R4toRL( xz_buffer_r4, fldRL,
+     I              0, nNz, kLo, kSize, 0, 0, .TRUE., myThid )
+         ELSE
+           WRITE(msgBuf,'(2A)')
+     &     ' MDS_READ_SEC_XZ: illegal value for arrType=', arrType
+           CALL PRINT_ERROR( msgBuf, myThid )
+           CALL ALL_PROC_DIE( myThid )
+           STOP 'ABNORMAL END: S/R MDS_READ_SEC_XZ'
+         ENDIF
 
+       ELSEIF ( filePrec.EQ.precFloat64 ) THEN
+         IF ( arrType.EQ.'RS' ) THEN
+           CALL MDS_PASS_XZ_R8toRS( xz_buffer_r8, fldRS,
+     I              0, nNz, kLo, kSize, 0, 0, .TRUE., myThid )
+         ELSEIF ( arrType.EQ.'RL' ) THEN
+           CALL MDS_PASS_XZ_R8toRL( xz_buffer_r8, fldRL,
+     I              0, nNz, kLo, kSize, 0, 0, .TRUE., myThid )
+         ELSE
+           WRITE(msgBuf,'(2A)')
+     &     ' MDS_READ_SEC_XZ: illegal value for arrType=', arrType
+           CALL PRINT_ERROR( msgBuf, myThid )
+           CALL ALL_PROC_DIE( myThid )
+           STOP 'ABNORMAL END: S/R MDS_READ_SEC_XZ'
+         ENDIF
 
-       DO k=kLo,kHi
-        DO bj=1,nSy
-         DO bi=1,nSx
-C-      copy from fldRL/RS(level=k) to 2-D "local":
-        IF ( filePrec.EQ.precFloat32 ) THEN
-          IF ( arrType.EQ.'RS' ) THEN
-            CALL MDS_SEG4toRS_2D( sNx, oLx, kSize, bi, bj, k,
-     &                            .TRUE., r4seg, fldRS )
-          ELSEIF ( arrType.EQ.'RL' ) THEN
-            CALL MDS_SEG4toRS_2D( sNx, oLx, kSize, bi, bj, k,
-     &                            .TRUE., r4seg, fldRL )
-          ELSE
-            WRITE(msgBuf,'(2A)')
-     &      ' MDS_READ_SEC_XZ: illegal value for arrType=', arrType
-            CALL PRINT_ERROR( msgBuf, myThid )
-            CALL ALL_PROC_DIE( myThid )
-            STOP 'ABNORMAL END: S/R MDS_READ_SEC_XZ'
-          ENDIF
-
-        ELSEIF ( filePrec.EQ.precFloat64 ) THEN
-          IF ( arrType.EQ.'RS' ) THEN
-            CALL MDS_SEG8toRS_2D( sNx, oLx, kSize, bi, bj, k,
-     I                         .TRUE., r8seg, fldRS )
-          ELSEIF ( arrType.EQ.'RL' ) THEN
-            CALL MDS_SEG8toRS_2D( sNx, oLx, kSize, bi, bj, k,
-     I                         .TRUE., r8seg, fldRL )
-          ELSE
-            WRITE(msgBuf,'(2A)')
-     &      ' MDS_READ_SEC_XZ: illegal value for arrType=', arrType
-            CALL PRINT_ERROR( msgBuf, myThid )
-            CALL ALL_PROC_DIE( myThid )
-            STOP 'ABNORMAL END: S/R MDS_READ_SEC_XZ'
-          ENDIF
-
-        ELSE
-          WRITE(msgBuf,'(A,I6)')
-     &      ' MDS_READ_SEC_XZ: illegal value for filePrec=',filePrec
-          CALL PRINT_ERROR( msgBuf, myThid )
-          CALL ALL_PROC_DIE( myThid )
-          STOP 'ABNORMAL END: S/R MDS_READ_SEC_XZ'
-        ENDIF
-
-
-C End of bi,bj loops
-         ENDDO
-        ENDDO
-
-C-     end of k loop
-       ENDDO
+       ELSE
+         WRITE(msgBuf,'(A,I6)')
+     &     ' MDS_READ_SEC_XZ: illegal value for filePrec=',filePrec
+         CALL PRINT_ERROR( msgBuf, myThid )
+         CALL ALL_PROC_DIE( myThid )
+         STOP 'ABNORMAL END: S/R MDS_READ_SEC_XZ'
+       ENDIF
 
       CALL BAR2( myThid )
 
@@ -612,7 +556,6 @@ C     if useSingleCpuIO / else / end
       END
 
 C---+----1----+----2----+----3----+----4----+----5----+----6----+----7-|--+----|
-
 
 CBOP
 C !ROUTINE: MDS_READ_SEC_YZ
@@ -1018,8 +961,8 @@ c           global_nTx = exch2_global_Nx/tNx
             tBy = exch2_tyGlobalo(tN) - 1
             IF   ( exch2_mydNy(tN) .GT. ySize ) THEN
 C-          face x-size larger than glob-size : fold it
-              iGjLoc = 0
-              jGjLoc = exch2_mydNy(tN) / ySize
+              iGjLoc = exch2_mydNx(tN)
+              jGjLoc = 0
             ELSE
 C-          default (face fit into global-IO-array)
               iGjLoc = 0

--- a/pkg/mdsio/mdsio_read_section.F
+++ b/pkg/mdsio/mdsio_read_section.F
@@ -15,36 +15,54 @@ C !INTERFACE:
      I   filePrec,
      I   useCurrentDir,
      I   arrType,
-     I   kSize,
+     I   kSize,kLo,kHi,
      O   fldRL, fldRS,
      I   irecord,
      I   myThid )
 
-C !DESCRIPTION
+C !DESCRIPTION:
 C Arguments:
 C
-C fName       string  :: base name for file to read
-C filePrec    integer :: number of bits per word in file (32 or 64)
-C useCurrentDir(logic):: always read from the current directory (even if
+C fName     (string)  :: base name for file to write
+C filePrec  (integer) :: number of bits per word in file (32 or 64)
+C useCurrentDir(logic):: always write to the current directory (even if
 C                        "mdsioLocalDir" is set)
-C arrType     char(2) :: which array (fldRL/RS) to read into, either "RL" or "RS"
-C kSize       integer :: size of third dimension, normally either 1 or Nr
-C fldRL         RL    :: array to read into if arrType="RL", fldRL(:,kSize,:,:)
-C fldRS         RS    :: array to read into if arrType="RS", fldRS(:,kSize,:,:)
-C irecord     integer :: record number to read
-C myThid      integer :: thread identifier
+C arrType   (char(2)) :: which array (fldRL/RS) to write, either "RL" or "RS"
+C kSize     (integer) :: size of third dimension: normally either 1 or Nr
+C kLo       (integer) :: 1rst vertical level (of array fldRL/RS) to write
+C kHi       (integer) :: last vertical level (of array fldRL/RS) to write
+C fldRL       ( RL )  :: array to write if arrType="RL", fldRL(:,:,kSize,:,:)
+C fldRS       ( RS )  :: array to write if arrType="RS", fldRS(:,:,kSize,:,:)
+C irecord   (integer) :: record number to write
+C myThid    (integer) :: thread identifier
 C
 C MDS_READ_SEC_XZ first checks to see IF the file "fName" exists, then
-C if the file "fName.data" exists and finally the tiled files of the
-C form "fName.xxx.yyy.data" exist.
+C  IF the file "fName.data" exists and finally the tiled files of the
+C  form "fName.xxx.yyy.data" exist. Currently, the meta-files are not
+C  read because it is difficult to parse files in fortran.
 C The precision of the file is decsribed by filePrec, set either
 C  to floatPrec32 or floatPrec64. The char*(2) string arrType, either "RL"
 C  or "RS", selects which array is filled in, either fldRL or fldRS.
-C This routine reads vertical slices (X-Z) including the overlap region.
+C (kSize,kLo,kHi) allows for both 2-D and 3-D arrays to be handled, with
+C  the option to only read and fill-in a sub-set of consecutive vertical
+C  levels (from kLo to kHi) ; (kSize,kLo,kHi)=(1,1,1) implies a 2-D model
+C  field and (kSize,kLo,kHi)=(Nr,1,Nr) implies a 3-D model field.
 C irecord is the record number to be read and must be >= 1.
-C The file data is stored in fldRL/RS *but* the overlaps are *not* updated.
+C The file data is stored in fldRL/RS *but* the overlaps are *not* updated,
+C  i.e., an exchange must be called.
 C
-C Created: 06/03/00 spk@ocean.mit.edu
+C- Multi-threaded: Only Master thread does IO (and MPI calls) and put data
+C   to a shared buffer that any thread can get access to.
+C- Convention regarding thread synchronisation (BARRIER):
+C  A per-thread (or per tile) partition of the 2-D shared-buffer (sharedLocBuf_r4/r8)
+C   is readily available => any access (e.g., by master-thread) to a portion
+C   owned by an other thread is put between BARRIER (protected).
+C  No thread partition exist for the 3-D shared buffer (shared3dBuf_r4/r8).
+C   Therefore, the 3-D buffer is considered to be owned by master-thread and
+C   any access by other than master thread is put between BARRIER (protected).
+C
+C Modified: 06/02/00 spk@ocean.mit.edu
+C Modified: 08/03/20 - style copied from mdsio_read_field timsmith204@utexas.edu 
 CEOP
 
 C !USES:
@@ -54,235 +72,546 @@ C Global variables / common blocks
 #include "EEPARAMS.h"
 #include "PARAMS.h"
 #ifdef ALLOW_EXCH2
-#include "W2_EXCH2_SIZE.h"
-#include "W2_EXCH2_TOPOLOGY.h"
-#include "W2_EXCH2_PARAMS.h"
+# include "W2_EXCH2_SIZE.h"
+# include "W2_EXCH2_TOPOLOGY.h"
+# include "W2_EXCH2_PARAMS.h"
 #endif /* ALLOW_EXCH2 */
+#include "EEBUFF_SCPU.h"
+#ifdef ALLOW_FIZHI
+# include "fizhi_SIZE.h"
+#endif /* ALLOW_FIZHI */
+#include "MDSIO_BUFF_3D.h"
 
 C !INPUT PARAMETERS:
       CHARACTER*(*) fName
       INTEGER filePrec
       LOGICAL useCurrentDir
       CHARACTER*(2) arrType
-      INTEGER kSize
+      INTEGER kSize, kLo, kHi
       INTEGER irecord
       INTEGER myThid
 C !OUTPUT PARAMETERS:
-      _RL  fldRL(*)
-      _RS  fldRS(*)
+      _RL fldRL(*)
+      _RS fldRS(*)
 
-C !FUNCTIONS:
-      INTEGER ILNBLNK
-      INTEGER MDS_RECLEN
-      EXTERNAL ILNBLNK, MDS_RECLEN
+C !FUNCTIONS
+      INTEGER  ILNBLNK
+      INTEGER  MDS_RECLEN
+      LOGICAL  MASTER_CPU_IO
+      EXTERNAL ILNBLNK
+      EXTERNAL MDS_RECLEN
+      EXTERNAL MASTER_CPU_IO
 
 C !LOCAL VARIABLES:
+C     bBij  :: base shift in Buffer index for tile bi,bj
       CHARACTER*(MAX_LEN_FNAM) dataFName,pfName
-      INTEGER iG,jG,irec,bi,bj,k,dUnit,IL,pIL
+      CHARACTER*(MAX_LEN_MBUF) msgBuf
       LOGICAL exst
-      Real*4 r4seg(sNx)
-      Real*8 r8seg(sNx)
-      LOGICAL globalFile,fileIsOpen
+      LOGICAL globalFile, fileIsOpen
+      LOGICAL iAmDoingIO
+      LOGICAL useExch2ioLayOut
+      INTEGER xSize, ySize
+      INTEGER iG,jG,bi,bj
+      INTEGER i1,i2,i,j,k,nNz
+      INTEGER irec,dUnit,IL,pIL
       INTEGER length_of_rec
-      CHARACTER*(max_len_mbuf) msgBuf
+      INTEGER tNx, global_nTx
+      INTEGER tBx, iGjLoc, jGjLoc
+      REAL*4 r4seg(sNx*nSx)
+      REAL*8 r8seg(sNx*nSx)
+      REAL*4 x_layer_buffer_r4(Nx)
+      REAL*8 x_layer_buffer_r8(Nx)
 #ifdef ALLOW_EXCH2
-      INTEGER tGx,tNx,tN
+      INTEGER tN
+      REAL*4 x_layer_buffer_exch2_r4(exch2_global_Nx)
+      REAL*8 x_layer_buffer_exch2_r8(exch2_global_Nx)
 #endif /* ALLOW_EXCH2 */
-C     ------------------------------------------------------------------
 
-C Only do I/O if I am the master thread
-      _BEGIN_MASTER( myThid )
-
-C Record number must be >= 1
-      IF (irecord .LT. 1) THEN
-       WRITE(msgBuf,'(A,I9.8)')
-     &   ' MDS_READ_SEC_XZ: argument irecord = ',irecord
-       CALL PRINT_MESSAGE( msgBuf, standardMessageUnit,
-     &                     SQUEEZE_RIGHT, myThid )
-       WRITE(msgBuf,'(A)')
-     &   ' MDS_READ_SEC_XZ: Invalid value for irecord'
-       CALL PRINT_ERROR( msgBuf, myThid )
-       STOP 'ABNORMAL END: S/R MDS_READ_SEC_XZ'
+C---+----1----+----2----+----3----+----4----+----5----+----6----+----7-|--+----|
+C Set dimensions:
+      xSize = Nx
+      ySize = 1
+      useExch2ioLayOut = .FALSE.
+#ifdef ALLOW_EXCH2
+      IF ( W2_useE2ioLayOut ) THEN
+        xSize = exch2_global_Nx
+        ySize = 1
+        useExch2ioLayOut = .TRUE.
       ENDIF
+#endif /* ALLOW_EXCH2 */
 
 C Assume nothing
       globalFile = .FALSE.
       fileIsOpen = .FALSE.
       IL  = ILNBLNK( fName )
       pIL = ILNBLNK( mdsioLocalDir )
+      nNz = 1 + kHi - kLo
+
+C Only do I/O if I am the master thread (and mpi process 0 IF useSingleCpuIO):
+      iAmDoingIO = MASTER_CPU_IO(myThid)
+
+C File name should not be too long:
+C    IL(+pIL if not useCurrentDir)(+5: '.data')(+8: bi,bj) =< MAX_LEN_FNAM
+C    and shorter enough to be written to msgBuf with other informations
+      IF ( useCurrentDir .AND. (90+IL).GT.MAX_LEN_MBUF ) THEN
+        WRITE(msgBuf,'(2A,2(I4,A))') 'MDS_READ_SEC_XZ: ',
+     &   'Too long (IL=',IL,') file name:'
+        CALL PRINT_ERROR( msgBuf, myThid )
+        WRITE(errorMessageUnit,'(3A)')'file: >',fName(1:IL),'<'
+        CALL ALL_PROC_DIE( myThid )
+        STOP 'ABNORMAL END: S/R MDS_READ_SEC_XZ'
+      ELSEIF ( (90+IL+pIL).GT.MAX_LEN_MBUF ) THEN
+        WRITE(msgBuf,'(2A,2(I4,A))') 'MDS_READ_SEC_XZ: ',
+     &   'Too long (pIL=',pIL,', IL=',IL,') pfix + file name:'
+        CALL PRINT_ERROR( msgBuf, myThid )
+        WRITE(errorMessageUnit,'(3A)')'pfix: >',mdsioLocalDir(1:pIL),'<'
+        WRITE(errorMessageUnit,'(3A)')'file: >',fName(1:IL),'<'
+        CALL ALL_PROC_DIE( myThid )
+        STOP 'ABNORMAL END: S/R MDS_READ_SEC_XZ'
+      ENDIF
+C Record number must be >= 1
+      IF (irecord .LT. 1) THEN
+        WRITE(msgBuf,'(3A)')
+     &    ' MDS_READ_SEC_XZ: file="', fName(1:IL), '"'
+        CALL PRINT_MESSAGE( msgBuf, errorMessageUnit,
+     &                      SQUEEZE_RIGHT, myThid )
+        WRITE(msgBuf,'(A,I9.8)')
+     &    ' MDS_READ_SEC_XZ: argument irecord = ',irecord
+        CALL PRINT_MESSAGE( msgBuf, errorMessageUnit,
+     &                      SQUEEZE_RIGHT, myThid )
+        WRITE(msgBuf,'(A)')
+     &    ' MDS_READ_SEC_XZ: invalid value for irecord'
+        CALL PRINT_ERROR( msgBuf, myThid )
+        CALL ALL_PROC_DIE( myThid )
+        STOP 'ABNORMAL END: S/R MDS_READ_SEC_XZ'
+      ENDIF
+C check for valid sub-set of levels:
+      IF ( kLo.LT.1 .OR. kHi.GT.kSize ) THEN
+        WRITE(msgBuf,'(3A)')
+     &    ' MDS_READ_SEC_XZ: file="', fName(1:IL), '"'
+        CALL PRINT_MESSAGE( msgBuf, errorMessageUnit,
+     &                      SQUEEZE_RIGHT, myThid )
+        WRITE(msgBuf,'(3(A,I6))')
+     &    ' MDS_READ_SEC_XZ: arguments kSize=', kSize,
+     &    ' , kLo=', kLo, ' , kHi=', kHi
+        CALL PRINT_MESSAGE( msgBuf, errorMessageUnit,
+     &                      SQUEEZE_RIGHT, myThid )
+        WRITE(msgBuf,'(A)')
+     &    ' MDS_READ_SEC_XZ: invalid sub-set of levels'
+        CALL PRINT_ERROR( msgBuf, myThid )
+        CALL ALL_PROC_DIE( myThid )
+        STOP 'ABNORMAL END: S/R MDS_READ_SEC_XZ'
+      ENDIF
+C check for 3-D Buffer size:
+      IF ( .NOT.useSingleCpuIO .AND. nNz.GT.size3dBuf ) THEN
+        WRITE(msgBuf,'(3A)')
+     &    ' MDS_READ_SEC_XZ: file="', fName(1:IL), '"'
+        CALL PRINT_MESSAGE( msgBuf, errorMessageUnit,
+     &                      SQUEEZE_RIGHT, myThid )
+        WRITE(msgBuf,'(3(A,I6))')
+     &    ' MDS_READ_SEC_XZ: Nb Lev to write =', nNz,
+     &    ' >', size3dBuf, ' = buffer 3rd Dim'
+        CALL PRINT_MESSAGE( msgBuf, errorMessageUnit,
+     &                      SQUEEZE_RIGHT, myThid )
+        WRITE(msgBuf,'(A)')
+     &    ' MDS_READ_SEC_XZ: buffer 3rd Dim. too small'
+        CALL PRINT_ERROR( msgBuf, myThid )
+        WRITE(msgBuf,'(A)')
+     &    ' increase "size3dBuf" in "MDSIO_BUFF_3D.h" and recompile'
+        CALL PRINT_MESSAGE( msgBuf, errorMessageUnit,
+     &                      SQUEEZE_RIGHT, myThid)
+        CALL ALL_PROC_DIE( myThid )
+        STOP 'ABNORMAL END: S/R MDS_READ_SEC_XZ'
+      ENDIF
+
+C Only do I/O if I am the master thread
+      IF ( iAmDoingIO ) THEN
 
 C Assign special directory
-      IF ( useCurrentDir .OR. pIL.EQ.0 ) THEN
-       pfName= fName
-      ELSE
-       WRITE(pfName,'(2a)') mdsioLocalDir(1:pIL), fName(1:IL)
-      ENDIF
-      pIL=ILNBLNK( pfName )
+        IF ( useCurrentDir .OR. pIL.EQ.0 ) THEN
+         pfName = fName
+        ELSE
+         WRITE(pfName,'(2A)') mdsioLocalDir(1:pIL), fName(1:IL)
+        ENDIF
+        pIL=ILNBLNK( pfName )
 
 C Assign a free unit number as the I/O channel for this routine
-      CALL MDSFINDUNIT( dUnit, myThid )
+        CALL MDSFINDUNIT( dUnit, myThid )
 
 C Check first for global file with simple name (ie. fName)
-      dataFName = fName
-      INQUIRE( file=dataFName, exist=exst )
-      IF (exst) THEN
-       IF ( debugLevel .GE. debLevB ) THEN
-        WRITE(msgBuf,'(A,A)')
-     &   ' MDS_READ_SEC_XZ: opening global file: ',dataFName(1:IL)
-        CALL PRINT_MESSAGE( msgBuf, standardMessageUnit,
-     &                      SQUEEZE_RIGHT, myThid )
-       ENDIF
-       globalFile = .TRUE.
-      ENDIF
+        dataFName = fName
+        INQUIRE( file=dataFName, exist=exst )
+        IF (exst) THEN
+          IF ( debugLevel .GE. debLevB ) THEN
+            WRITE(msgBuf,'(A,A)')
+     &      ' MDS_READ_FIELD: opening global file: ',dataFName(1:IL)
+            CALL PRINT_MESSAGE( msgBuf, standardMessageUnit,
+     &                          SQUEEZE_RIGHT, myThid)
+          ENDIF
+          globalFile = .TRUE.
+        ENDIF
 
 C If negative check for global file with MDS name (ie. fName.data)
-      IF (.NOT. globalFile) THEN
-       WRITE(dataFName,'(2A)') fName(1:IL),'.data'
-       INQUIRE( file=dataFName, exist=exst )
-       IF (exst) THEN
-        IF ( debugLevel .GE. debLevB ) THEN
-         WRITE(msgBuf,'(A,A)')
-     &    ' MDS_READ_SEC_XZ: opening global file: ',dataFName(1:IL+5)
-         CALL PRINT_MESSAGE( msgBuf, standardMessageUnit,
-     &                       SQUEEZE_RIGHT, myThid )
+        IF (.NOT. globalFile) THEN
+          WRITE(dataFName,'(2a)') fName(1:IL),'.data'
+          INQUIRE( file=dataFName, exist=exst )
+          IF (exst) THEN
+           IF ( debugLevel .GE. debLevB ) THEN
+            WRITE(msgBuf,'(A,A)')
+     &      ' MDS_READ_FIELD: opening global file: ',dataFName(1:IL+5)
+            CALL PRINT_MESSAGE( msgBuf, standardMessageUnit,
+     &                          SQUEEZE_RIGHT, myThid)
+           ENDIF
+           globalFile = .TRUE.
+          ENDIF
         ENDIF
-        globalFile = .TRUE.
-       ENDIF
+
+C- endif iAmDoingIO
       ENDIF
+
+C If option globalFile is desired but does not work or if
+C globalFile is too slow, then try using single-CPU I/O.
+      IF (useSingleCpuIO) THEN
+
+C Master thread of process 0, only, opens a global file
+       IF ( iAmDoingIO ) THEN
+         WRITE(dataFName,'(2a)') fName(1:IL),'.data'
+         length_of_rec = MDS_RECLEN( filePrec, sNx*nSx, myThid )
+         OPEN( dUnit, file=dataFName, status=_OLD_STATUS,
+     &       access='direct', recl=length_of_rec )
+       ENDIF
+
+C master thread of process 0, only ,read from file
+       DO k=kLo,kHi
+
+        IF ( iAmDoingIO ) THEN
+          irec = 1 + k-kLo + (irecord-1)*kSize
+          IF ( filePrec.EQ.precFloat32 ) THEN
+
+#ifdef ALLOW_EXCH2
+           IF ( .not.W2_useE2ioLayOut ) THEN
+#endif
+# ifdef _BYTESWAPIO
+            CALL MDS_BYTESWAPR4( xSize, x_layer_buffer_r4 )
+# endif
+            WRITE(dUnit,rec=irec) x_layer_buffer_r4
+#ifdef ALLOW_EXCH2
+           ELSE
+# ifdef _BYTESWAPIO
+            CALL MDS_BYTESWAPR4( xSize, x_layer_buffer_exch2_r4 )
+# endif
+            WRITE(dUnit,rec=irec) x_layer_buffer_exch2_r4
+           ENDIF
+#endif
+          ELSE
+
+#ifdef ALLOW_EXCH2
+           IF ( .not.W2_useE2ioLayOut ) THEN
+#endif
+# ifdef _BYTESWAPIO
+            CALL MDS_BYTESWAPR8( xSize, x_layer_buffer_r8 )
+# endif
+            WRITE(dUnit,rec=irec) x_layer_buffer_r8
+#ifdef ALLOW_EXCH2
+           ELSE
+# ifdef _BYTESWAPIO
+            CALL MDS_BYTESWAPR8( xSize, x_layer_buffer_exch2_r8 )
+# endif
+            WRITE(dUnit,rec=irec) x_layer_buffer_exch2_r8
+           ENDIF
+#endif
+          ENDIF
+C-      end if iAmDoingIO
+        ENDIF
+
+        
+C wait for all thread to finish. this prevents other threads to continue
+C  to access shared buffer while master thread is loading data into
+        CALL BAR2( myThid )
+
+        IF ( filePrec.EQ.precFloat32 ) THEN
+#ifdef ALLOW_EXCH2
+          IF ( .not.W2_useE2ioLayOut ) THEN
+#endif
+            CALL SCATTER_VEC_R4( 
+     O                         x_layer_buffer_r4,
+     I                         r4seg, 
+     I                         xSize, myThid ) 
+#ifdef ALLOW_EXCH2
+          ELSE
+
+            CALL SCATTER_VEC_R4( 
+     O                         x_layer_buffer_exch2_r4,
+     I                         r4seg, 
+     I                         xSize, myThid ) 
+          ENDIF
+#endif
+          CALL BAR2( myThid )
+          DO bj=1,sNy
+          DO bi=1,sNx
+          IF ( arrType.EQ.'RS' ) THEN
+            CALL MDS_SEG4toRS_2D( sNx*nSx, oLx, kSize, bi, bj, k,
+     &                            .TRUE., r4seg, fldRS )
+          ELSEIF ( arrType.EQ.'RL' ) THEN
+            CALL MDS_SEG4toRS_2D( sNx*nSx, oLx, kSize, bi, bj, k,
+     &                            .TRUE., r4seg, fldRL )
+          ELSE
+            WRITE(msgBuf,'(2A)')
+     &      ' MDS_READ_SEC_XZ: illegal value for arrType=', arrType
+            CALL PRINT_ERROR( msgBuf, myThid )
+            CALL ALL_PROC_DIE( myThid )
+            STOP 'ABNORMAL END: S/R MDS_READ_SEC_XZ'
+          ENDIF
+          ENDDO
+          ENDDO
+
+        ELSEIF ( filePrec.EQ.precFloat64 ) THEN
+#ifdef ALLOW_EXCH2
+          IF ( .not.W2_useE2ioLayOut ) THEN
+#endif
+            CALL SCATTER_VEC_R8( 
+     O                         x_layer_buffer_r8,
+     I                         r8seg, 
+     I                         xSize, myThid ) 
+#ifdef ALLOW_EXCH2
+          ELSE
+
+            CALL SCATTER_VEC_R8( 
+     O                          x_layer_buffer_exch2_r8,
+     I                          r8seg, 
+     I                          xSize, myThid ) 
+          ENDIF
+#endif
+          CALL BAR2( myThid )
+          DO bj=1,sNy
+          DO bi=1,sNx
+          IF ( arrType.EQ.'RS' ) THEN
+            CALL MDS_SEG8toRS_2D( sNx*nSx, oLx, kSize, bi, bj, k,
+     I                         .TRUE., r8seg, fldRS )
+          ELSEIF ( arrType.EQ.'RL' ) THEN
+            CALL MDS_SEG8toRS_2D( sNx*nSx, oLx, kSize, bi, bj, k,
+     I                         .TRUE., r8seg, fldRL )
+          ELSE
+            WRITE(msgBuf,'(2A)')
+     &      ' MDS_READ_SEC_XZ: illegal value for arrType=', arrType
+            CALL PRINT_ERROR( msgBuf, myThid )
+            CALL ALL_PROC_DIE( myThid )
+            STOP 'ABNORMAL END: S/R MDS_READ_SEC_XZ'
+          ENDIF
+          ENDDO
+          ENDDO
+
+        ELSE
+          WRITE(msgBuf,'(A,I6)')
+     &      ' MDS_READ_SEC_XZ: illegal value for filePrec=',filePrec
+          CALL PRINT_ERROR( msgBuf, myThid )
+          CALL ALL_PROC_DIE( myThid )
+          STOP 'ABNORMAL END: S/R MDS_READ_SEC_XZ'
+        ENDIF
+
+C-     end of k loop
+       ENDDO
+
+C Close data-file
+       IF ( iAmDoingIO ) THEN
+         CLOSE( dUnit )
+       ENDIF
+
+C---+----1----+----2----+----3----+----4----+----5----+----6----+----7-|--+----|
+C---  else .NOT.useSingleCpuIO
+      ELSE
+
+
+C Only do I/O if I am the master thread
+       IF ( iAmDoingIO ) THEN
 
 C If we are reading from a global file then we open it here
-      IF (globalFile) THEN
-       length_of_rec = MDS_RECLEN( filePrec, sNx, myThid )
-       OPEN( dUnit, file=dataFName, status='old',
-     &       access='direct', recl=length_of_rec )
-       fileIsOpen=.TRUE.
-      ENDIF
-
-C Loop over all tiles
-      DO bj=1,nSy
-       DO bi=1,nSx
-C If we are reading from a tiled MDS file then we open each one here
-        IF (.NOT. globalFile) THEN
-         iG=bi+(myXGlobalLo-1)/sNx
-         jG=bj+(myYGlobalLo-1)/sNy
-         WRITE(dataFName,'(2A,I3.3,A,I3.3,A)')
-     &              pfName(1:pIL),'.',iG,'.',jG,'.data'
-         INQUIRE( file=dataFName, exist=exst )
-C Of course, we only open the file IF the tile is "active"
-C (This is a place-holder for the active/passive mechanism
-         IF (exst) THEN
-          IF ( debugLevel .GE. debLevB ) THEN
-           WRITE(msgBuf,'(A,A)')
-     &      ' MDS_READ_SEC_XZ: opening file: ',dataFName(1:pIL+13)
-           CALL PRINT_MESSAGE( msgBuf, standardMessageUnit,
-     &                         SQUEEZE_RIGHT, myThid )
-          ENDIF
-          length_of_rec = MDS_RECLEN( filePrec, sNx, myThid )
-          OPEN( dUnit, file=dataFName, status='old',
-     &          access='direct', recl=length_of_rec )
+        IF (globalFile) THEN
+          length_of_rec = MDS_RECLEN( filePrec, sNx*nSx, myThid )
+          OPEN( dUnit, file=dataFName, status=_OLD_STATUS,
+     &            access='direct', recl=length_of_rec )
           fileIsOpen=.TRUE.
-         ELSE
-          fileIsOpen=.FALSE.
-          WRITE(msgBuf,'(4A)') ' MDS_READ_SEC_XZ: filename: ',
-     &             fName(1:IL),' , ', dataFName(1:pIL+13)
-          CALL PRINT_MESSAGE( msgBuf, standardMessageUnit,
-     &                        SQUEEZE_RIGHT, myThid )
-          WRITE(msgBuf,'(A)')
-     &      ' MDS_READ_SEC_XZ: Files DO not exist'
-          CALL PRINT_ERROR( msgBuf, myThid )
-          STOP 'ABNORMAL END: S/R MDS_READ_SEC_XZ'
-         ENDIF
         ENDIF
 
-        IF (fileIsOpen) THEN
+C Loop over all tiles
+        DO bj=1,nSy
+         DO bi=1,nSx
+
+          tNx = sNx
+          global_nTx = xSize/sNx
+          tBx = myXGlobalLo-1 + (bi-1)*sNx
 #ifdef ALLOW_EXCH2
-C layout of global x-z section files is "xStack"
-         tN = W2_myTileList(bi,bj)
-         tGx = exch2_txXStackLo(tN)
-         tNx = exch2_tNx(tN)
-#endif /* ALLOW_EXCH2 */
-         DO k=1,kSize
-           IF (globalFile) THEN
-#ifdef ALLOW_EXCH2
-C record length is sNx==tNx
-            irec = 1 + ( tGx-1
-     &                   + ( k-1 + (irecord-1)*kSize )*exch2_xStack_Nx
-     &                 )/tNx
-#else /* ALLOW_EXCH2 */
-            iG = myXGlobalLo-1 + (bi-1)*sNx
-            jG = (myYGlobalLo-1)/sNy + (bj-1)
-            irec=1 + INT(iG/sNx) + nSx*nPx*(k-1)
-     &           + nSx*nPx*kSize*(irecord-1)
-#endif /* ALLOW_EXCH2 */
-           ELSE
-            iG = 0
-            jG = 0
-            irec=k + kSize*(irecord-1)
-           ENDIF
-           IF (filePrec .EQ. precFloat32) THEN
-            READ(dUnit,rec=irec) r4seg
-#ifdef _BYTESWAPIO
-            CALL MDS_BYTESWAPR4(sNx,r4seg)
-#endif
-            IF (arrType .EQ. 'RS') THEN
-             CALL MDS_SEG4toRS_2D( sNx,oLx,kSize,bi,bj,k,.TRUE.,
-     &                             r4seg,fldRS )
-            ELSEIF (arrType .EQ. 'RL') THEN
-             CALL MDS_SEG4toRL_2D( sNx,oLx,kSize,bi,bj,k,.TRUE.,
-     &                             r4seg,fldRL )
+          IF ( useExch2ioLayOut ) THEN
+            tN = W2_myTileList(bi,bj)
+c           tNx = exch2_tNx(tN)
+c           tNy = exch2_tNy(tN)
+c           global_nTx = exch2_global_Nx/tNx
+            tBx = exch2_txGlobalo(tN) - 1
+            IF   ( exch2_mydNx(tN) .GT. xSize ) THEN
+C-          face x-size larger than glob-size : fold it
+              iGjLoc = 0
+              jGjLoc = exch2_mydNx(tN) / xSize
             ELSE
-             WRITE(msgBuf,'(A)')
-     &         ' MDS_READ_SEC_XZ: illegal value for arrType'
-             CALL PRINT_ERROR( msgBuf, myThid )
-             STOP 'ABNORMAL END: S/R MDS_READ_SEC_XZ'
+C-          default (face fit into global-IO-array)
+              iGjLoc = 0
+              jGjLoc = 1
             ENDIF
-           ELSEIF (filePrec .EQ. precFloat64) THEN
-            READ(dUnit,rec=irec) r8seg
-#ifdef _BYTESWAPIO
-            CALL MDS_BYTESWAPR8( sNx, r8seg )
-#endif
-            IF (arrType .EQ. 'RS') THEN
-             CALL MDS_SEG8toRS_2D(sNx,oLx,kSize,bi,bj,k,.TRUE.,
-     &                             r8seg,fldRS )
-            ELSEIF (arrType .EQ. 'RL') THEN
-             CALL MDS_SEG8toRL_2D(sNx,oLx,kSize,bi,bj,k,.TRUE.,
-     &                             r8seg,fldRL )
+          ENDIF
+#endif /* ALLOW_EXCH2 */
+
+          IF (globalFile) THEN
+C--- Case of 1 Global file:
+
+           DO k=kLo,kHi
+            irec = 1 + tBx/tNx
+     &           +( k-kLo + (irecord-1)*kSize )*global_nTx
+            IF ( filePrec.EQ.precFloat32 ) THEN
+             READ(dUnit,rec=irec) r4seg
             ELSE
-             WRITE(msgBuf,'(A)')
-     &         ' MDS_READ_SEC_XZ: illegal value for arrType'
-             CALL PRINT_ERROR( msgBuf, myThid )
-             STOP 'ABNORMAL END: S/R MDS_READ_SEC_XZ'
+             READ(dUnit,rec=irec) r8seg
             ENDIF
+C End of k loop
+           ENDDO
+
+          ELSE
+C--- Case of 1 file per tile (globalFile=F):
+
+C If we are writing to a tiled MDS file then we open each one here
+           iG=bi+(myXGlobalLo-1)/sNx
+           jG=bj+(myYGlobalLo-1)/sNy
+           WRITE(dataFName,'(2A,I3.3,A,I3.3,A)')
+     &            pfName(1:pIL),'.',iG,'.',jG,'.data'
+           INQUIRE( file=dataFName, exist=exst)
+           IF (exst) THEN
+            IF ( debugLevel .GE.debLevB ) THEN
+              WRITE(msgBuf,'(A,A)')
+     &        ' MDS_READ_SEC_XZ: opening file: ', dataFName(1:pIL+13)
+              CALL PRINT_MESSAGE( msgBuf, standardMessageUnit,
+     &                  SQUEEZE_RIGHT, myThid)
+            ENDIF
+            length_of_rec = MDS_RECLEN( filePrec, sNx, myThid )
+            OPEN( dUnit, file=dataFName, status=_OLD_STATUS,
+     &            access='direct', recl=length_of_rec )
+            fileIsOpen=.TRUE.
            ELSE
+            fileIsOpen=.FALSE.
+            WRITE(msgBuf,'(4A)') ' MDS_READ_SEC_XZ: filename: ',
+     &             fName(1:IL),' , ', dataFName(1:pIL+13)
+            CALL PRINT_MESSAGE( msgBuf, standardMessageUnit,
+     &                          SQUEEZE_RIGHT, myThid)
+            CALL PRINT_ERROR( msgBuf, myThid )
             WRITE(msgBuf,'(A)')
-     &        ' MDS_READ_SEC_XZ: illegal value for filePrec'
+     &      ' MDS_READ_SEC_XZ: Files DO not exist'
+            CALL PRINT_MESSAGE( msgBuf, standardMessageUnit,
+     &                          SQUEEZE_RIGHT, myThid)
             CALL PRINT_ERROR( msgBuf, myThid )
             STOP 'ABNORMAL END: S/R MDS_READ_SEC_XZ'
            ENDIF
-C End of k loop
-         ENDDO
-         IF (.NOT. globalFile) THEN
-          CLOSE( dUnit )
-          fileIsOpen = .FALSE.
-         ENDIF
-        ENDIF
+
+           DO k=kLo,kHi
+            irec = k+kSize*(irecord-1)
+            IF ( filePrec.EQ.precFloat32 ) THEN
+              READ(dUnit,rec=irec) r4seg
+            ELSE
+              READ(dUnit,rec=irec) r8seg
+            ENDIF
+           ENDDO
+
+C here We close the tiled MDS file
+           IF ( fileIsOpen ) THEN
+             CLOSE( dUnit )
+             fileIsOpen = .FALSE.
+           ENDIF
+
+C--- End Global File / tile-file cases
+          ENDIF
+
 C End of bi,bj loops
-       ENDDO
-      ENDDO
+         ENDDO
+        ENDDO
 
 C If global file was opened then close it
-      IF (fileIsOpen .AND. globalFile) THEN
-       CLOSE( dUnit )
-       fileIsOpen = .FALSE.
+        IF (fileIsOpen .AND. globalFile) THEN
+          CLOSE( dUnit )
+          fileIsOpen = .FALSE.
+        ENDIF
+
+#ifdef _BYTESWAPIO
+        IF ( filePrec.EQ.precFloat32 ) THEN
+          CALL MDS_BYTESWAPR4( sNx*nSx, r4seg )
+        ELSE
+          CALL MDS_BYTESWAPR8( sNx*nSx, r8seg )
+        ENDIF
+#endif
+
+C- endif iAmDoingIO
+       ENDIF
+
+C Wait for all threads to finish filling shared buffer
+       CALL BAR2( myThid )
+
+
+
+       DO k=kLo,kHi
+        DO bj=1,nSy
+         DO bi=1,nSx
+C-      copy from fldRL/RS(level=k) to 2-D "local":
+        IF ( filePrec.EQ.precFloat32 ) THEN
+          IF ( arrType.EQ.'RS' ) THEN
+            CALL MDS_SEG4toRS_2D( sNx*nSx, oLx, kSize, bi, bj, k,
+     &                            .TRUE., r4seg, fldRS )
+          ELSEIF ( arrType.EQ.'RL' ) THEN
+            CALL MDS_SEG4toRS_2D( sNx*nSx, oLx, kSize, bi, bj, k,
+     &                            .TRUE., r4seg, fldRL )
+          ELSE
+            WRITE(msgBuf,'(2A)')
+     &      ' MDS_READ_SEC_XZ: illegal value for arrType=', arrType
+            CALL PRINT_ERROR( msgBuf, myThid )
+            CALL ALL_PROC_DIE( myThid )
+            STOP 'ABNORMAL END: S/R MDS_READ_SEC_XZ'
+          ENDIF
+
+        ELSEIF ( filePrec.EQ.precFloat64 ) THEN
+          IF ( arrType.EQ.'RS' ) THEN
+            CALL MDS_SEG8toRS_2D( sNx*nSx, oLx, kSize, bi, bj, k,
+     I                         .TRUE., r8seg, fldRS )
+          ELSEIF ( arrType.EQ.'RL' ) THEN
+            CALL MDS_SEG8toRS_2D( sNx*nSx, oLx, kSize, bi, bj, k,
+     I                         .TRUE., r8seg, fldRL )
+          ELSE
+            WRITE(msgBuf,'(2A)')
+     &      ' MDS_READ_SEC_XZ: illegal value for arrType=', arrType
+            CALL PRINT_ERROR( msgBuf, myThid )
+            CALL ALL_PROC_DIE( myThid )
+            STOP 'ABNORMAL END: S/R MDS_READ_SEC_XZ'
+          ENDIF
+
+        ELSE
+          WRITE(msgBuf,'(A,I6)')
+     &      ' MDS_READ_SEC_XZ: illegal value for filePrec=',filePrec
+          CALL PRINT_ERROR( msgBuf, myThid )
+          CALL ALL_PROC_DIE( myThid )
+          STOP 'ABNORMAL END: S/R MDS_READ_SEC_XZ'
+        ENDIF
+
+
+C End of bi,bj loops
+         ENDDO
+        ENDDO
+
+C-     end of k loop
+       ENDDO
+
+      CALL BAR2( myThid )
+
+C     if useSingleCpuIO / else / end
       ENDIF
 
-      _END_MASTER( myThid )
-
-C     ------------------------------------------------------------------
       RETURN
       END
 
 C---+----1----+----2----+----3----+----4----+----5----+----6----+----7-|--+----|
+
 
 CBOP
 C !ROUTINE: MDS_READ_SEC_YZ
@@ -292,36 +621,54 @@ C !INTERFACE:
      I   filePrec,
      I   useCurrentDir,
      I   arrType,
-     I   kSize,
+     I   kSize,kLo,kHi,
      O   fldRL, fldRS,
      I   irecord,
      I   myThid )
 
-C !DESCRIPTION
+C !DESCRIPTION:
 C Arguments:
 C
-C fName       string  :: base name for file to read
-C filePrec    integer :: number of bits per word in file (32 or 64)
-C useCurrentDir(logic):: always read from the current directory (even if
+C fName     (string)  :: base name for file to write
+C filePrec  (integer) :: number of bits per word in file (32 or 64)
+C useCurrentDir(logic):: always write to the current directory (even if
 C                        "mdsioLocalDir" is set)
-C arrType     char(2) :: which array (fldRL/RS) to read into, either "RL" or "RS"
-C kSize       integer :: size of third dimension, normally either 1 or Nr
-C fldRL         RL    :: array to read into if arrType="RL", fldRL(:,kSize,:,:)
-C fldRS         RS    :: array to read into if arrType="RS", fldRS(:,kSize,:,:)
-C irecord     integer :: record number to read
-C myThid      integer :: thread identifier
+C arrType   (char(2)) :: which array (fldRL/RS) to write, either "RL" or "RS"
+C kSize     (integer) :: size of third dimension: normally either 1 or Nr
+C kLo       (integer) :: 1rst vertical level (of array fldRL/RS) to write
+C kHi       (integer) :: last vertical level (of array fldRL/RS) to write
+C fldRL       ( RL )  :: array to write if arrType="RL", fldRL(:,:,kSize,:,:)
+C fldRS       ( RS )  :: array to write if arrType="RS", fldRS(:,:,kSize,:,:)
+C irecord   (integer) :: record number to write
+C myThid    (integer) :: thread identifier
 C
 C MDS_READ_SEC_YZ first checks to see IF the file "fName" exists, then
-C if the file "fName.data" exists and finally the tiled files of the
-C form "fName.xxx.yyy.data" exist.
+C  IF the file "fName.data" exists and finally the tiled files of the
+C  form "fName.xxx.yyy.data" exist. Currently, the meta-files are not
+C  read because it is difficult to parse files in fortran.
 C The precision of the file is decsribed by filePrec, set either
 C  to floatPrec32 or floatPrec64. The char*(2) string arrType, either "RL"
 C  or "RS", selects which array is filled in, either fldRL or fldRS.
-C This routine reads vertical slices (Y-Z) including the overlap region.
+C (kSize,kLo,kHi) allows for both 2-D and 3-D arrays to be handled, with
+C  the option to only read and fill-in a sub-set of consecutive vertical
+C  levels (from kLo to kHi) ; (kSize,kLo,kHi)=(1,1,1) implies a 2-D model
+C  field and (kSize,kLo,kHi)=(Nr,1,Nr) implies a 3-D model field.
 C irecord is the record number to be read and must be >= 1.
-C The file data is stored in fldRL/RS *but* the overlaps are *not* updated.
+C The file data is stored in fldRL/RS *but* the overlaps are *not* updated,
+C  i.e., an exchange must be called.
 C
-C Created: 06/03/00 spk@ocean.mit.edu
+C- Multi-threaded: Only Master thread does IO (and MPI calls) and put data
+C   to a shared buffer that any thread can get access to.
+C- Convention regarding thread synchronisation (BARRIER):
+C  A per-thread (or per tile) partition of the 2-D shared-buffer (sharedLocBuf_r4/r8)
+C   is readily available => any access (e.g., by master-thread) to a portion
+C   owned by an other thread is put between BARRIER (protected).
+C  No thread partition exist for the 3-D shared buffer (shared3dBuf_r4/r8).
+C   Therefore, the 3-D buffer is considered to be owned by master-thread and
+C   any access by other than master thread is put between BARRIER (protected).
+C
+C Modified: 06/02/00 spk@ocean.mit.edu
+C Modified: 08/03/20 - style copied from mdsio_read_field timsmith204@utexas.edu 
 CEOP
 
 C !USES:
@@ -331,231 +678,539 @@ C Global variables / common blocks
 #include "EEPARAMS.h"
 #include "PARAMS.h"
 #ifdef ALLOW_EXCH2
-#include "W2_EXCH2_SIZE.h"
-#include "W2_EXCH2_TOPOLOGY.h"
-#include "W2_EXCH2_PARAMS.h"
+# include "W2_EXCH2_SIZE.h"
+# include "W2_EXCH2_TOPOLOGY.h"
+# include "W2_EXCH2_PARAMS.h"
 #endif /* ALLOW_EXCH2 */
+#include "EEBUFF_SCPU.h"
+#ifdef ALLOW_FIZHI
+# include "fizhi_SIZE.h"
+#endif /* ALLOW_FIZHI */
+#include "MDSIO_BUFF_3D.h"
 
 C !INPUT PARAMETERS:
       CHARACTER*(*) fName
       INTEGER filePrec
       LOGICAL useCurrentDir
       CHARACTER*(2) arrType
-      INTEGER kSize
+      INTEGER kSize, kLo, kHi
       INTEGER irecord
       INTEGER myThid
 C !OUTPUT PARAMETERS:
-      _RL  fldRL(*)
-      _RS  fldRS(*)
+      _RL fldRL(*)
+      _RS fldRS(*)
 
-C !FUNCTIONS:
-      INTEGER ILNBLNK
-      INTEGER MDS_RECLEN
-      EXTERNAL ILNBLNK, MDS_RECLEN
+C !FUNCTIONS
+      INTEGER  ILNBLNK
+      INTEGER  MDS_RECLEN
+      LOGICAL  MASTER_CPU_IO
+      EXTERNAL ILNBLNK
+      EXTERNAL MDS_RECLEN
+      EXTERNAL MASTER_CPU_IO
 
 C !LOCAL VARIABLES:
+C     bBij  :: base shift in Buffer index for tile bi,bj
       CHARACTER*(MAX_LEN_FNAM) dataFName,pfName
-      INTEGER iG,jG,irec,bi,bj,k,dUnit,IL,pIL
+      CHARACTER*(MAX_LEN_MBUF) msgBuf
       LOGICAL exst
-      Real*4 r4seg(sNy)
-      Real*8 r8seg(sNy)
-      LOGICAL globalFile,fileIsOpen
+      LOGICAL globalFile, fileIsOpen
+      LOGICAL iAmDoingIO
+      LOGICAL useExch2ioLayOut
+      INTEGER xSize, ySize
+      INTEGER iG,jG,bi,bj
+      INTEGER i1,i2,i,j,k,nNz
+      INTEGER irec,dUnit,IL,pIL
       INTEGER length_of_rec
-      CHARACTER*(max_len_mbuf) msgBuf
+      INTEGER tNy, global_nTy
+      INTEGER tBy, iGjLoc, jGjLoc
+      REAL*4 r4seg(sNy*nSy)
+      REAL*8 r8seg(sNy*nSy)
+      REAL*4 y_layer_buffer_r4(Ny)
+      REAL*8 y_layer_buffer_r8(Ny)
 #ifdef ALLOW_EXCH2
-      INTEGER tGy,tNy,tN
+      INTEGER tN
+      REAL*4 y_layer_buffer_exch2_r4(exch2_global_Ny)
+      REAL*8 y_layer_buffer_exch2_r8(exch2_global_Ny)
 #endif /* ALLOW_EXCH2 */
 
-C     ------------------------------------------------------------------
-
-C Only do I/O if I am the master thread
-      _BEGIN_MASTER( myThid )
-
-C Record number must be >= 1
-      IF (irecord .LT. 1) THEN
-       WRITE(msgBuf,'(A,I9.8)')
-     &   ' MDS_READ_SEC_YZ: argument irecord = ',irecord
-       CALL PRINT_MESSAGE( msgBuf, standardMessageUnit,
-     &                     SQUEEZE_RIGHT, myThid )
-       WRITE(msgBuf,'(A)')
-     &   ' MDS_READ_SEC_YZ: Invalid value for irecord'
-       CALL PRINT_ERROR( msgBuf, myThid )
-       STOP 'ABNORMAL END: S/R MDS_READ_SEC_YZ'
+C---+----1----+----2----+----3----+----4----+----5----+----6----+----7-|--+----|
+C Set dimensions:
+      xSize = 1
+      ySize = Ny
+      useExch2ioLayOut = .FALSE.
+#ifdef ALLOW_EXCH2
+      IF ( W2_useE2ioLayOut ) THEN
+        xSize = 1
+        ySize = exch2_global_Ny
+        useExch2ioLayOut = .TRUE.
       ENDIF
+#endif /* ALLOW_EXCH2 */
 
 C Assume nothing
       globalFile = .FALSE.
       fileIsOpen = .FALSE.
       IL  = ILNBLNK( fName )
       pIL = ILNBLNK( mdsioLocalDir )
+      nNz = 1 + kHi - kLo
+
+C Only do I/O if I am the master thread (and mpi process 0 IF useSingleCpuIO):
+      iAmDoingIO = MASTER_CPU_IO(myThid)
+
+C File name should not be too long:
+C    IL(+pIL if not useCurrentDir)(+5: '.data')(+8: bi,bj) =< MAX_LEN_FNAM
+C    and shorter enough to be written to msgBuf with other informations
+      IF ( useCurrentDir .AND. (90+IL).GT.MAX_LEN_MBUF ) THEN
+        WRITE(msgBuf,'(2A,2(I4,A))') 'MDS_READ_SEC_YZ: ',
+     &   'Too long (IL=',IL,') file name:'
+        CALL PRINT_ERROR( msgBuf, myThid )
+        WRITE(errorMessageUnit,'(3A)')'file: >',fName(1:IL),'<'
+        CALL ALL_PROC_DIE( myThid )
+        STOP 'ABNORMAL END: S/R MDS_READ_SEC_YZ'
+      ELSEIF ( (90+IL+pIL).GT.MAX_LEN_MBUF ) THEN
+        WRITE(msgBuf,'(2A,2(I4,A))') 'MDS_READ_SEC_YZ: ',
+     &   'Too long (pIL=',pIL,', IL=',IL,') pfix + file name:'
+        CALL PRINT_ERROR( msgBuf, myThid )
+        WRITE(errorMessageUnit,'(3A)')'pfix: >',mdsioLocalDir(1:pIL),'<'
+        WRITE(errorMessageUnit,'(3A)')'file: >',fName(1:IL),'<'
+        CALL ALL_PROC_DIE( myThid )
+        STOP 'ABNORMAL END: S/R MDS_READ_SEC_YZ'
+      ENDIF
+C Record number must be >= 1
+      IF (irecord .LT. 1) THEN
+        WRITE(msgBuf,'(3A)')
+     &    ' MDS_READ_SEC_YZ: file="', fName(1:IL), '"'
+        CALL PRINT_MESSAGE( msgBuf, errorMessageUnit,
+     &                      SQUEEZE_RIGHT, myThid )
+        WRITE(msgBuf,'(A,I9.8)')
+     &    ' MDS_READ_SEC_YZ: argument irecord = ',irecord
+        CALL PRINT_MESSAGE( msgBuf, errorMessageUnit,
+     &                      SQUEEZE_RIGHT, myThid )
+        WRITE(msgBuf,'(A)')
+     &    ' MDS_READ_SEC_YZ: invalid value for irecord'
+        CALL PRINT_ERROR( msgBuf, myThid )
+        CALL ALL_PROC_DIE( myThid )
+        STOP 'ABNORMAL END: S/R MDS_READ_SEC_YZ'
+      ENDIF
+C check for valid sub-set of levels:
+      IF ( kLo.LT.1 .OR. kHi.GT.kSize ) THEN
+        WRITE(msgBuf,'(3A)')
+     &    ' MDS_READ_SEC_YZ: file="', fName(1:IL), '"'
+        CALL PRINT_MESSAGE( msgBuf, errorMessageUnit,
+     &                      SQUEEZE_RIGHT, myThid )
+        WRITE(msgBuf,'(3(A,I6))')
+     &    ' MDS_READ_SEC_YZ: arguments kSize=', kSize,
+     &    ' , kLo=', kLo, ' , kHi=', kHi
+        CALL PRINT_MESSAGE( msgBuf, errorMessageUnit,
+     &                      SQUEEZE_RIGHT, myThid )
+        WRITE(msgBuf,'(A)')
+     &    ' MDS_READ_SEC_YZ: invalid sub-set of levels'
+        CALL PRINT_ERROR( msgBuf, myThid )
+        CALL ALL_PROC_DIE( myThid )
+        STOP 'ABNORMAL END: S/R MDS_READ_SEC_YZ'
+      ENDIF
+C check for 3-D Buffer size:
+      IF ( .NOT.useSingleCpuIO .AND. nNz.GT.size3dBuf ) THEN
+        WRITE(msgBuf,'(3A)')
+     &    ' MDS_READ_SEC_YZ: file="', fName(1:IL), '"'
+        CALL PRINT_MESSAGE( msgBuf, errorMessageUnit,
+     &                      SQUEEZE_RIGHT, myThid )
+        WRITE(msgBuf,'(3(A,I6))')
+     &    ' MDS_READ_SEC_YZ: Nb Lev to write =', nNz,
+     &    ' >', size3dBuf, ' = buffer 3rd Dim'
+        CALL PRINT_MESSAGE( msgBuf, errorMessageUnit,
+     &                      SQUEEZE_RIGHT, myThid )
+        WRITE(msgBuf,'(A)')
+     &    ' MDS_READ_SEC_YZ: buffer 3rd Dim. too small'
+        CALL PRINT_ERROR( msgBuf, myThid )
+        WRITE(msgBuf,'(A)')
+     &    ' increase "size3dBuf" in "MDSIO_BUFF_3D.h" and recompile'
+        CALL PRINT_MESSAGE( msgBuf, errorMessageUnit,
+     &                      SQUEEZE_RIGHT, myThid)
+        CALL ALL_PROC_DIE( myThid )
+        STOP 'ABNORMAL END: S/R MDS_READ_SEC_YZ'
+      ENDIF
+
+C Only do I/O if I am the master thread
+      IF ( iAmDoingIO ) THEN
 
 C Assign special directory
-      IF ( useCurrentDir .OR. pIL.EQ.0 ) THEN
-       pfName= fName
-      ELSE
-       WRITE(pfName,'(2A)') mdsioLocalDir(1:pIL), fName(1:IL)
-      ENDIF
-      pIL=ILNBLNK( pfName )
+        IF ( useCurrentDir .OR. pIL.EQ.0 ) THEN
+         pfName = fName
+        ELSE
+         WRITE(pfName,'(2A)') mdsioLocalDir(1:pIL), fName(1:IL)
+        ENDIF
+        pIL=ILNBLNK( pfName )
 
 C Assign a free unit number as the I/O channel for this routine
-      CALL MDSFINDUNIT( dUnit, myThid )
+        CALL MDSFINDUNIT( dUnit, myThid )
 
 C Check first for global file with simple name (ie. fName)
-      dataFName = fName
-      INQUIRE( file=dataFName, exist=exst )
-      IF (exst) THEN
-       IF ( debugLevel .GE. debLevB ) THEN
-        WRITE(msgBuf,'(A,A)')
-     &   ' MDS_READ_SEC_YZ: opening global file: ',dataFName(1:IL)
-        CALL PRINT_MESSAGE( msgBuf, standardMessageUnit,
-     &                      SQUEEZE_RIGHT, myThid )
-       ENDIF
-       globalFile = .TRUE.
-      ENDIF
+        dataFName = fName
+        INQUIRE( file=dataFName, exist=exst )
+        IF (exst) THEN
+          IF ( debugLevel .GE. debLevB ) THEN
+            WRITE(msgBuf,'(A,A)')
+     &      ' MDS_READ_FIELD: opening global file: ',dataFName(1:IL)
+            CALL PRINT_MESSAGE( msgBuf, standardMessageUnit,
+     &                          SQUEEZE_RIGHT, myThid)
+          ENDIF
+          globalFile = .TRUE.
+        ENDIF
 
 C If negative check for global file with MDS name (ie. fName.data)
-      IF (.NOT. globalFile) THEN
-       WRITE(dataFName,'(2A)') fName(1:IL),'.data'
-       INQUIRE( file=dataFName, exist=exst )
-       IF (exst) THEN
-        IF ( debugLevel .GE. debLevB ) THEN
-         WRITE(msgBuf,'(A,A)')
-     &    ' MDS_READ_SEC_YZ: opening global file: ',dataFName(1:IL+5)
-         CALL PRINT_MESSAGE( msgBuf, standardMessageUnit,
-     &                       SQUEEZE_RIGHT, myThid )
+        IF (.NOT. globalFile) THEN
+          WRITE(dataFName,'(2a)') fName(1:IL),'.data'
+          INQUIRE( file=dataFName, exist=exst )
+          IF (exst) THEN
+           IF ( debugLevel .GE. debLevB ) THEN
+            WRITE(msgBuf,'(A,A)')
+     &      ' MDS_READ_FIELD: opening global file: ',dataFName(1:IL+5)
+            CALL PRINT_MESSAGE( msgBuf, standardMessageUnit,
+     &                          SQUEEZE_RIGHT, myThid)
+           ENDIF
+           globalFile = .TRUE.
+          ENDIF
         ENDIF
-        globalFile = .TRUE.
-       ENDIF
+
+C- endif iAmDoingIO
       ENDIF
+
+C If option globalFile is desired but does not work or if
+C globalFile is too slow, then try using single-CPU I/O.
+      IF (useSingleCpuIO) THEN
+
+C Master thread of process 0, only, opens a global file
+       IF ( iAmDoingIO ) THEN
+         WRITE(dataFName,'(2a)') fName(1:IL),'.data'
+         length_of_rec = MDS_RECLEN( filePrec, sNy*nSy, myThid )
+         OPEN( dUnit, file=dataFName, status=_OLD_STATUS,
+     &       access='direct', recl=length_of_rec )
+       ENDIF
+
+C master thread of process 0, only ,read from file
+       DO k=kLo,kHi
+
+        IF ( iAmDoingIO ) THEN
+          irec = 1 + k-kLo + (irecord-1)*kSize
+          IF ( filePrec.EQ.precFloat32 ) THEN
+
+#ifdef ALLOW_EXCH2
+           IF ( .not.W2_useE2ioLayOut ) THEN
+#endif
+# ifdef _BYTESWAPIO
+            CALL MDS_BYTESWAPR4( ySize, y_layer_buffer_r4 )
+# endif
+            WRITE(dUnit,rec=irec) y_layer_buffer_r4
+#ifdef ALLOW_EXCH2
+           ELSE
+# ifdef _BYTESWAPIO
+            CALL MDS_BYTESWAPR4( ySize, y_layer_buffer_exch2_r4 )
+# endif
+            WRITE(dUnit,rec=irec) y_layer_buffer_exch2_r4
+           ENDIF
+#endif
+          ELSE
+
+#ifdef ALLOW_EXCH2
+           IF ( .not.W2_useE2ioLayOut ) THEN
+#endif
+# ifdef _BYTESWAPIO
+            CALL MDS_BYTESWAPR8( ySize, y_layer_buffer_r8 )
+# endif
+            WRITE(dUnit,rec=irec) y_layer_buffer_r8
+#ifdef ALLOW_EXCH2
+           ELSE
+# ifdef _BYTESWAPIO
+            CALL MDS_BYTESWAPR8( ySize, y_layer_buffer_exch2_r8 )
+# endif
+            WRITE(dUnit,rec=irec) y_layer_buffer_exch2_r8
+           ENDIF
+#endif
+          ENDIF
+C-      end if iAmDoingIO
+        ENDIF
+
+        
+C wait for all thread to finish. this prevents other threads to continue
+C  to access shared buffer while master thread is loading data into
+        CALL BAR2( myThid )
+
+        IF ( filePrec.EQ.precFloat32 ) THEN
+#ifdef ALLOW_EXCH2
+          IF ( .not.W2_useE2ioLayOut ) THEN
+#endif
+            CALL SCATTER_VEC_R4( 
+     O                         y_layer_buffer_r4,
+     I                         r4seg, 
+     I                         ySize, myThid ) 
+#ifdef ALLOW_EXCH2
+          ELSE
+
+            CALL SCATTER_VEC_R4( 
+     O                         y_layer_buffer_exch2_r4,
+     I                         r4seg, 
+     I                         ySize, myThid ) 
+          ENDIF
+#endif
+          CALL BAR2( myThid )
+          DO bj=1,sNy
+          DO bi=1,sNx
+          IF ( arrType.EQ.'RS' ) THEN
+            CALL MDS_SEG4toRS_2D( sNy*nSy, oLy, kSize, bi, bj, k,
+     &                            .TRUE., r4seg, fldRS )
+          ELSEIF ( arrType.EQ.'RL' ) THEN
+            CALL MDS_SEG4toRS_2D( sNy*nSy, oLy, kSize, bi, bj, k,
+     &                            .TRUE., r4seg, fldRL )
+          ELSE
+            WRITE(msgBuf,'(2A)')
+     &      ' MDS_READ_SEC_YZ: illegal value for arrType=', arrType
+            CALL PRINT_ERROR( msgBuf, myThid )
+            CALL ALL_PROC_DIE( myThid )
+            STOP 'ABNORMAL END: S/R MDS_READ_SEC_YZ'
+          ENDIF
+          ENDDO
+          ENDDO
+
+        ELSEIF ( filePrec.EQ.precFloat64 ) THEN
+#ifdef ALLOW_EXCH2
+          IF ( .not.W2_useE2ioLayOut ) THEN
+#endif
+            CALL SCATTER_VEC_R8( 
+     O                         y_layer_buffer_r8,
+     I                         r8seg, 
+     I                         ySize, myThid ) 
+#ifdef ALLOW_EXCH2
+          ELSE
+
+            CALL SCATTER_VEC_R8( 
+     O                          y_layer_buffer_exch2_r8,
+     I                          r8seg, 
+     I                          ySize, myThid ) 
+          ENDIF
+#endif
+          CALL BAR2( myThid )
+          DO bj=1,sNy
+          DO bi=1,sNx
+          IF ( arrType.EQ.'RS' ) THEN
+            CALL MDS_SEG8toRS_2D( sNy*nSy, oLy, kSize, bi, bj, k,
+     I                         .TRUE., r8seg, fldRS )
+          ELSEIF ( arrType.EQ.'RL' ) THEN
+            CALL MDS_SEG8toRS_2D( sNy*nSy, oLy, kSize, bi, bj, k,
+     I                         .TRUE., r8seg, fldRL )
+          ELSE
+            WRITE(msgBuf,'(2A)')
+     &      ' MDS_READ_SEC_YZ: illegal value for arrType=', arrType
+            CALL PRINT_ERROR( msgBuf, myThid )
+            CALL ALL_PROC_DIE( myThid )
+            STOP 'ABNORMAL END: S/R MDS_READ_SEC_YZ'
+          ENDIF
+          ENDDO
+          ENDDO
+
+        ELSE
+          WRITE(msgBuf,'(A,I6)')
+     &      ' MDS_READ_SEC_YZ: illegal value for filePrec=',filePrec
+          CALL PRINT_ERROR( msgBuf, myThid )
+          CALL ALL_PROC_DIE( myThid )
+          STOP 'ABNORMAL END: S/R MDS_READ_SEC_YZ'
+        ENDIF
+
+C-     end of k loop
+       ENDDO
+
+C Close data-file
+       IF ( iAmDoingIO ) THEN
+         CLOSE( dUnit )
+       ENDIF
+
+C---+----1----+----2----+----3----+----4----+----5----+----6----+----7-|--+----|
+C---  else .NOT.useSingleCpuIO
+      ELSE
+
+
+C Only do I/O if I am the master thread
+       IF ( iAmDoingIO ) THEN
 
 C If we are reading from a global file then we open it here
-      IF (globalFile) THEN
-       length_of_rec = MDS_RECLEN( filePrec, sNy, myThid )
-       OPEN( dUnit, file=dataFName, status='old',
-     &       access='direct', recl=length_of_rec )
-       fileIsOpen=.TRUE.
-      ENDIF
-
-C Loop over all tiles
-      DO bj=1,nSy
-       DO bi=1,nSx
-C If we are reading from a tiled MDS file then we open each one here
-        IF (.NOT. globalFile) THEN
-         iG=bi+(myXGlobalLo-1)/sNx
-         jG=bj+(myYGlobalLo-1)/sNy
-         WRITE(dataFName,'(2A,I3.3,A,I3.3,A)')
-     &              pfName(1:pIL),'.',iG,'.',jG,'.data'
-         INQUIRE( file=dataFName, exist=exst )
-C Of course, we only open the file IF the tile is "active"
-C (This is a place-holder for the active/passive mechanism
-         IF (exst) THEN
-          IF ( debugLevel .GE. debLevB ) THEN
-           WRITE(msgBuf,'(A,A)')
-     &      ' MDS_READ_SEC_YZ: opening file: ',dataFName(1:pIL+13)
-           CALL PRINT_MESSAGE( msgBuf, standardMessageUnit,
-     &                         SQUEEZE_RIGHT, myThid )
-          ENDIF
-          length_of_rec = MDS_RECLEN( filePrec, sNy, myThid )
-          OPEN( dUnit, file=dataFName, status='old',
-     &          access='direct', recl=length_of_rec )
+        IF (globalFile) THEN
+          length_of_rec = MDS_RECLEN( filePrec, sNy*nSy, myThid )
+          OPEN( dUnit, file=dataFName, status=_OLD_STATUS,
+     &            access='direct', recl=length_of_rec )
           fileIsOpen=.TRUE.
-         ELSE
-          fileIsOpen=.FALSE.
-          WRITE(msgBuf,'(4A)') ' MDS_READ_SEC_YZ: filename: ',
-     &             fName(1:IL),' , ', dataFName(1:pIL+13)
-          CALL PRINT_MESSAGE( msgBuf, standardMessageUnit,
-     &                        SQUEEZE_RIGHT, myThid )
-          WRITE(msgBuf,'(A)')
-     &      ' MDS_READ_SEC_YZ: Files DO not exist'
-          CALL PRINT_ERROR( msgBuf, myThid )
-          STOP 'ABNORMAL END: S/R MDS_READ_SEC_YZ'
-         ENDIF
         ENDIF
 
-        IF (fileIsOpen) THEN
+C Loop over all tiles
+        DO bj=1,nSy
+         DO bi=1,nSx
+
+          tNy = sNy
+          global_nTy = ySize/sNy
+          tBy = myYGlobalLo-1 + (bj-1)*sNy
 #ifdef ALLOW_EXCH2
-C layout of global y-z section files is "yStack"
-         tN = W2_myTileList(bi,bj)
-         tGy = exch2_tyYStackLo(tN)
-         tNy = exch2_tNy(tN)
-#endif /* ALLOW_EXCH2 */
-         DO k=1,kSize
-           IF (globalFile) THEN
-#ifdef ALLOW_EXCH2
-C record length is sNy==tNy
-            irec = 1 + ( tGy-1
-     &                   + ( k-1 + (irecord-1)*kSize )*exch2_yStack_Ny
-     &                 )/tNy
-#else /* ALLOW_EXCH2 */
-            iG = (myXGlobalLo-1)/sNx + (bi-1)
-            jG = myYGlobalLo-1 + (bj-1)*sNy
-            irec=1 + INT(jG/sNy) + nSy*nPy*(k-1)
-     &           + nSy*nPy*kSize*(irecord-1)
-#endif /* ALLOW_EXCH2 */
-           ELSE
-            iG = 0
-            jG = 0
-            irec=k + kSize*(irecord-1)
-           ENDIF
-           IF (filePrec .EQ. precFloat32) THEN
-            READ(dUnit,rec=irec) r4seg
-#ifdef _BYTESWAPIO
-            CALL MDS_BYTESWAPR4(sNy,r4seg)
-#endif
-            IF (arrType .EQ. 'RS') THEN
-             CALL MDS_SEG4toRS_2D( sNy,oLy,kSize,bi,bj,k,.TRUE.,
-     &                             r4seg,fldRS )
-            ELSEIF (arrType .EQ. 'RL') THEN
-             CALL MDS_SEG4toRL_2D( sNy,oLy,kSize,bi,bj,k,.TRUE.,
-     &                             r4seg,fldRL )
+          IF ( useExch2ioLayOut ) THEN
+            tN = W2_myTileList(bi,bj)
+c           tNx = exch2_tNx(tN)
+c           tNy = exch2_tNy(tN)
+c           global_nTx = exch2_global_Nx/tNx
+            tBy = exch2_tyGlobalo(tN) - 1
+            IF   ( exch2_mydNy(tN) .GT. ySize ) THEN
+C-          face x-size larger than glob-size : fold it
+              iGjLoc = 0
+              jGjLoc = exch2_mydNy(tN) / ySize
             ELSE
-             WRITE(msgBuf,'(A)')
-     &         ' MDS_READ_SEC_YZ: illegal value for arrType'
-             CALL PRINT_ERROR( msgBuf, myThid )
-             STOP 'ABNORMAL END: S/R MDS_READ_SEC_YZ'
+C-          default (face fit into global-IO-array)
+              iGjLoc = 0
+              jGjLoc = 1
             ENDIF
-           ELSEIF (filePrec .EQ. precFloat64) THEN
-            READ(dUnit,rec=irec) r8seg
-#ifdef _BYTESWAPIO
-            CALL MDS_BYTESWAPR8( sNy, r8seg )
-#endif
-            IF (arrType .EQ. 'RS') THEN
-             CALL MDS_SEG8toRS_2D( sNy,oLy,kSize,bi,bj,k,.TRUE.,
-     &                             r8seg,fldRS )
-            ELSEIF (arrType .EQ. 'RL') THEN
-             CALL MDS_SEG8toRL_2D( sNy,oLy,kSize,bi,bj,k,.TRUE.,
-     &                             r8seg,fldRL )
+          ENDIF
+#endif /* ALLOW_EXCH2 */
+
+          IF (globalFile) THEN
+C--- Case of 1 Global file:
+
+           DO k=kLo,kHi
+            irec = 1 + tBy/tNy
+     &           +( k-kLo + (irecord-1)*kSize )*global_nTy
+            IF ( filePrec.EQ.precFloat32 ) THEN
+             READ(dUnit,rec=irec) r4seg
             ELSE
-             WRITE(msgBuf,'(A)')
-     &         ' MDS_READ_SEC_YZ: illegal value for arrType'
-             CALL PRINT_ERROR( msgBuf, myThid )
-             STOP 'ABNORMAL END: S/R MDS_READ_SEC_YZ'
+             READ(dUnit,rec=irec) r8seg
             ENDIF
+C End of k loop
+           ENDDO
+
+          ELSE
+C--- Case of 1 file per tile (globalFile=F):
+
+C If we are writing to a tiled MDS file then we open each one here
+           iG=bi+(myXGlobalLo-1)/sNx
+           jG=bj+(myYGlobalLo-1)/sNy
+           WRITE(dataFName,'(2A,I3.3,A,I3.3,A)')
+     &            pfName(1:pIL),'.',iG,'.',jG,'.data'
+           INQUIRE( file=dataFName, exist=exst)
+           IF (exst) THEN
+            IF ( debugLevel .GE.debLevB ) THEN
+              WRITE(msgBuf,'(A,A)')
+     &        ' MDS_READ_SEC_YZ: opening file: ', dataFName(1:pIL+13)
+              CALL PRINT_MESSAGE( msgBuf, standardMessageUnit,
+     &                  SQUEEZE_RIGHT, myThid)
+            ENDIF
+            length_of_rec = MDS_RECLEN( filePrec, sNy, myThid )
+            OPEN( dUnit, file=dataFName, status=_OLD_STATUS,
+     &            access='direct', recl=length_of_rec )
+            fileIsOpen=.TRUE.
            ELSE
+            fileIsOpen=.FALSE.
+            WRITE(msgBuf,'(4A)') ' MDS_READ_SEC_YZ: filename: ',
+     &             fName(1:IL),' , ', dataFName(1:pIL+13)
+            CALL PRINT_MESSAGE( msgBuf, standardMessageUnit,
+     &                          SQUEEZE_RIGHT, myThid)
+            CALL PRINT_ERROR( msgBuf, myThid )
             WRITE(msgBuf,'(A)')
-     &        ' MDS_READ_SEC_YZ: illegal value for filePrec'
+     &      ' MDS_READ_SEC_YZ: Files DO not exist'
+            CALL PRINT_MESSAGE( msgBuf, standardMessageUnit,
+     &                          SQUEEZE_RIGHT, myThid)
             CALL PRINT_ERROR( msgBuf, myThid )
             STOP 'ABNORMAL END: S/R MDS_READ_SEC_YZ'
            ENDIF
-C End of k loop
-         ENDDO
-         IF (.NOT. globalFile) THEN
-          CLOSE( dUnit )
-          fileIsOpen = .FALSE.
-         ENDIF
-        ENDIF
+
+           DO k=kLo,kHi
+            irec = k+kSize*(irecord-1)
+            IF ( filePrec.EQ.precFloat32 ) THEN
+              READ(dUnit,rec=irec) r4seg
+            ELSE
+              READ(dUnit,rec=irec) r8seg
+            ENDIF
+           ENDDO
+
+C here We close the tiled MDS file
+           IF ( fileIsOpen ) THEN
+             CLOSE( dUnit )
+             fileIsOpen = .FALSE.
+           ENDIF
+
+C--- End Global File / tile-file cases
+          ENDIF
+
 C End of bi,bj loops
-       ENDDO
-      ENDDO
+         ENDDO
+        ENDDO
 
 C If global file was opened then close it
-      IF (fileIsOpen .AND. globalFile) THEN
-       CLOSE( dUnit )
-       fileIsOpen = .FALSE.
+        IF (fileIsOpen .AND. globalFile) THEN
+          CLOSE( dUnit )
+          fileIsOpen = .FALSE.
+        ENDIF
+
+#ifdef _BYTESWAPIO
+        IF ( filePrec.EQ.precFloat32 ) THEN
+          CALL MDS_BYTESWAPR4( sNy*nSy, r4seg )
+        ELSE
+          CALL MDS_BYTESWAPR8( sNy*nSy, r8seg )
+        ENDIF
+#endif
+
+C- endif iAmDoingIO
+       ENDIF
+
+C Wait for all threads to finish filling shared buffer
+       CALL BAR2( myThid )
+
+
+       DO k=kLo,kHi
+        DO bj=1,nSy
+         DO bi=1,nSx
+C-      copy from fldRL/RS(level=k) to 2-D "local":
+        IF ( filePrec.EQ.precFloat32 ) THEN
+          IF ( arrType.EQ.'RS' ) THEN
+            CALL MDS_SEG4toRS_2D( sNy*nSy, oLy, kSize, bi, bj, k,
+     &                            .TRUE., r4seg, fldRS )
+          ELSEIF ( arrType.EQ.'RL' ) THEN
+            CALL MDS_SEG4toRS_2D( sNy*nSy, oLy, kSize, bi, bj, k,
+     &                            .TRUE., r4seg, fldRL )
+          ELSE
+            WRITE(msgBuf,'(2A)')
+     &      ' MDS_READ_SEC_YZ: illegal value for arrType=', arrType
+            CALL PRINT_ERROR( msgBuf, myThid )
+            CALL ALL_PROC_DIE( myThid )
+            STOP 'ABNORMAL END: S/R MDS_READ_SEC_YZ'
+          ENDIF
+
+        ELSEIF ( filePrec.EQ.precFloat64 ) THEN
+          IF ( arrType.EQ.'RS' ) THEN
+            CALL MDS_SEG8toRS_2D( sNy*nSy, oLy, kSize, bi, bj, k,
+     I                         .TRUE., r8seg, fldRS )
+          ELSEIF ( arrType.EQ.'RL' ) THEN
+            CALL MDS_SEG8toRS_2D( sNy*nSy, oLy, kSize, bi, bj, k,
+     I                         .TRUE., r8seg, fldRL )
+          ELSE
+            WRITE(msgBuf,'(2A)')
+     &      ' MDS_READ_SEC_YZ: illegal value for arrType=', arrType
+            CALL PRINT_ERROR( msgBuf, myThid )
+            CALL ALL_PROC_DIE( myThid )
+            STOP 'ABNORMAL END: S/R MDS_READ_SEC_YZ'
+          ENDIF
+
+        ELSE
+          WRITE(msgBuf,'(A,I6)')
+     &      ' MDS_READ_SEC_YZ: illegal value for filePrec=',filePrec
+          CALL PRINT_ERROR( msgBuf, myThid )
+          CALL ALL_PROC_DIE( myThid )
+          STOP 'ABNORMAL END: S/R MDS_READ_SEC_YZ'
+        ENDIF
+
+C End of bi,bj loops
+         ENDDO
+        ENDDO
+
+C End k loop
+          ENDDO
+
+
+      CALL BAR2( myThid )
+
+C     if useSingleCpuIO / else / end
       ENDIF
 
-      _END_MASTER( myThid )
-
-C     ------------------------------------------------------------------
       RETURN
       END

--- a/pkg/mdsio/mdsio_rw_slice.F
+++ b/pkg/mdsio/mdsio_rw_slice.F
@@ -61,12 +61,12 @@ C Local variables
 
       IF ( arrType.EQ.'RL' ) THEN
         CALL MDS_READ_SEC_XZ(
-     I                fName, filePrec, .FALSE., arrType, nNz,
+     I                fName, filePrec, .FALSE., arrType, nNz, 1, nNz,
      O                arr, dummyRS,
      I                irecord, myThid )
       ELSE
         CALL MDS_READ_SEC_XZ(
-     I                fName, filePrec, .FALSE., arrType, nNz,
+     I                fName, filePrec, .FALSE., arrType, nNz, 1, nNz,
      O                dummyRL, arr,
      I                irecord, myThid )
       ENDIF
@@ -126,12 +126,12 @@ C Local variables
 
       IF ( arrType.EQ.'RL' ) THEN
         CALL MDS_READ_SEC_YZ(
-     I                fName, filePrec, .FALSE., arrType, nNz,
+     I                fName, filePrec, .FALSE., arrType, nNz, 1, nNz,
      O                arr, dummyRS,
      I                irecord, myThid )
       ELSE
         CALL MDS_READ_SEC_YZ(
-     I                fName, filePrec, .FALSE., arrType, nNz,
+     I                fName, filePrec, .FALSE., arrType, nNz, 1, nNz,
      O                dummyRL, arr,
      I                irecord, myThid )
       ENDIF
@@ -191,12 +191,12 @@ C Local variables
 
       IF ( arrType.EQ.'RL' ) THEN
         CALL MDS_READ_SEC_XZ(
-     I                fName, filePrec, .TRUE., arrType, nNz,
+     I                fName, filePrec, .TRUE., arrType, nNz, 1, nNz,
      O                arr, dummyRS,
      I                irecord, myThid )
       ELSE
         CALL MDS_READ_SEC_XZ(
-     I                fName, filePrec, .TRUE., arrType, nNz,
+     I                fName, filePrec, .TRUE., arrType, nNz, 1, nNz,
      O                dummyRL, arr,
      I                irecord, myThid )
       ENDIF
@@ -256,12 +256,12 @@ C Local variables
 
       IF ( arrType.EQ.'RL' ) THEN
         CALL MDS_READ_SEC_YZ(
-     I                fName, filePrec, .TRUE., arrType, nNz,
+     I                fName, filePrec, .TRUE., arrType, nNz, 1, nNz,
      O                arr, dummyRS,
      I                irecord, myThid )
       ELSE
         CALL MDS_READ_SEC_YZ(
-     I                fName, filePrec, .TRUE., arrType, nNz,
+     I                fName, filePrec, .TRUE., arrType, nNz, 1, nNz,
      O                dummyRL, arr,
      I                irecord, myThid )
       ENDIF
@@ -328,12 +328,12 @@ C Local variables
       IF ( arrType.EQ.'RL' ) THEN
         CALL MDS_WRITE_SEC_XZ(
      I                 fName, filePrec, globalFile, .FALSE.,
-     I                 arrType, nNz, arr, dummyRS,
+     I                 arrType, nNz, 1, nNz, arr, dummyRS,
      I                 irecord, myIter, myThid )
       ELSE
         CALL MDS_WRITE_SEC_XZ(
      I                 fName, filePrec, globalFile, .FALSE.,
-     I                 arrType, nNz, dummyRL, arr,
+     I                 arrType, nNz, 1, nNz, dummyRL, arr,
      I                 irecord, myIter, myThid )
       ENDIF
 
@@ -399,12 +399,12 @@ C Local variables
       IF ( arrType.EQ.'RL' ) THEN
         CALL MDS_WRITE_SEC_YZ(
      I                 fName, filePrec, globalFile, .FALSE.,
-     I                 arrType, nNz, arr, dummyRS,
+     I                 arrType, nNz, 1, nNz, arr, dummyRS,
      I                 irecord, myIter, myThid )
       ELSE
         CALL MDS_WRITE_SEC_YZ(
      I                 fName, filePrec, globalFile, .FALSE.,
-     I                 arrType, nNz, dummyRL, arr,
+     I                 arrType, nNz, 1, nNz, dummyRL, arr,
      I                 irecord, myIter, myThid )
       ENDIF
 
@@ -470,12 +470,12 @@ C Local variables
       IF ( arrType.EQ.'RL' ) THEN
         CALL MDS_WRITE_SEC_XZ(
      I                 fName, filePrec, globalFile, .TRUE.,
-     I                 arrType, nNz, arr, dummyRS,
+     I                 arrType, nNz, 1, nNz, arr, dummyRS,
      I                 irecord, myIter, myThid )
       ELSE
         CALL MDS_WRITE_SEC_XZ(
      I                 fName, filePrec, globalFile, .TRUE.,
-     I                 arrType, nNz, dummyRL, arr,
+     I                 arrType, nNz, 1, nNz, dummyRL, arr,
      I                 irecord, myIter, myThid )
       ENDIF
 
@@ -541,12 +541,12 @@ C Local variables
       IF ( arrType.EQ.'RL' ) THEN
         CALL MDS_WRITE_SEC_YZ(
      I                 fName, filePrec, globalFile, .TRUE.,
-     I                 arrType, nNz, arr, dummyRS,
+     I                 arrType, nNz, 1, nNz, arr, dummyRS,
      I                 irecord, myIter, myThid )
       ELSE
         CALL MDS_WRITE_SEC_YZ(
      I                 fName, filePrec, globalFile, .TRUE.,
-     I                 arrType, nNz, dummyRL, arr,
+     I                 arrType, nNz, 1, nNz, dummyRL, arr,
      I                 irecord, myIter, myThid )
       ENDIF
 

--- a/pkg/mdsio/mdsio_write_section.F
+++ b/pkg/mdsio/mdsio_write_section.F
@@ -926,20 +926,118 @@ C Assign a free unit number as the I/O channel for this routine
 C- endif iAmDoingIO
       ENDIF
 
-C If option globalFile is desired but does not work or if
-C globalFile is too slow, then try using single-CPU I/O.
-      IF (useSingleCpuIO) THEN
+C Gather array and write it to file, one vertical level at a time
 
-C Master thread of process 0, only, opens a global file
-       IF ( iAmDoingIO ) THEN
-         WRITE(dataFName,'(2a)') fName(1:IL),'.data'
-         length_of_rec = MDS_RECLEN( filePrec, ySize, myThid )
-         IF (irecord .EQ. 1) THEN
-          OPEN( dUnit, file=dataFName, status=_NEW_STATUS,
-     &        access='direct', recl=length_of_rec )
+      DO k=kLo,kHi
+       zeroBuff = k.EQ.kLo
+C-     copy from fldRL/RS(level=k) to 2-D "local":
+       IF ( filePrec.EQ.precFloat32 ) THEN
+         IF ( arrType.EQ.'RS' ) THEN
+           CALL MDS_PASS_YZ_R4toRS( r4seg, fldRS, 
+     I             0, 1, k, kSize, 0, 0, .FALSE., myThid )
+         ELSEIF ( arrType.EQ.'RL' ) THEN
+           CALL MDS_PASS_YZ_R4toRL( r4seg, fldRL, 
+     I             0, 1, k, kSize, 0, 0, .FALSE., myThid )
          ELSE
-          OPEN( dUnit, file=dataFName, status=_OLD_STATUS,
-     &        access='direct', recl=length_of_rec )
+           WRITE(msgBuf,'(2A)')
+     &     ' MDS_WRITE_SEC_YZ: illegal value for arrType=', arrType
+           CALL PRINT_ERROR( msgBuf, myThid )
+           CALL ALL_PROC_DIE( myThid )
+           STOP 'ABNORMAL END: S/R MDS_WRITE_SEC_YZ'
+         ENDIF
+C Wait for all threads to finish filling shared buffer
+          CALL BAR2( myThid )
+#ifdef ALLOW_EXCH2
+          IF ( .not.W2_useE2ioLayOut ) THEN
+#endif
+            CALL GATHER_YZ_R4(
+     O                        y_layer_buffer_r4,
+     I                        r4seg,
+     I                        ySize,
+     I                        useExch2ioLayout,
+     I                        zeroBuff,
+     I                        myThid )
+#ifdef ALLOW_EXCH2
+          ELSE
+            CALL GATHER_YZ_R4(
+     O                        y_layer_buffer_exch2_r4,
+     I                        r4seg,
+     I                        ySize,
+     I                        useExch2ioLayout,
+     I                        zeroBuff,
+     I                        myThid )
+          ENDIF
+#endif
+
+       ELSEIF ( filePrec.EQ.precFloat64 ) THEN
+         IF ( arrType.EQ.'RS' ) THEN
+           CALL MDS_PASS_YZ_R8toRS( r8seg, fldRS,
+     I            0, 1, k, kSize, 0, 0, .FALSE., myThid )
+         ELSEIF ( arrType.EQ.'RL' ) THEN
+           CALL MDS_PASS_YZ_R8toRL( r8seg, fldRL,
+     I            0, 1, k, kSize, 0, 0, .FALSE., myThid )
+         ELSE
+           WRITE(msgBuf,'(2A)')
+     &     ' MDS_WRITE_SEC_YZ: illegal value for arrType=', arrType
+           CALL PRINT_ERROR( msgBuf, myThid )
+           CALL ALL_PROC_DIE( myThid )
+           STOP 'ABNORMAL END: S/R MDS_WRITE_SEC_YZ'
+         ENDIF
+         IF ( debugLevel .GE. debLevC ) THEN
+           WRITE(msgBuf,'(A,I8)')
+     &       ' MDS_WRITE_SEC_YZ: SIZE(ylayerbuffer_r8): ', 
+     &          SIZE(y_layer_buffer_r8)
+           CALL PRINT_MESSAGE( msgBuf, standardMessageUnit,
+     &                         SQUEEZE_RIGHT, myThid )
+         ENDIF
+C Wait for all threads to finish filling shared buffer
+         CALL BAR2( myThid )
+#ifdef ALLOW_EXCH2
+          IF ( .not.W2_useE2ioLayOut ) THEN
+#endif
+            CALL GATHER_YZ_R8(
+     O                        y_layer_buffer_r8,
+     I                        r8seg,
+     I                        ySize,
+     I                        useExch2ioLayout,
+     I                        zeroBuff,
+     I                        myThid )
+#ifdef ALLOW_EXCH2
+          ELSE
+            CALL GATHER_YZ_R8(
+     O                        y_layer_buffer_exch2_r8,
+     I                        r8seg,
+     I                        ySize,
+     I                        useExch2ioLayout,
+     I                        zeroBuff,
+     I                        myThid )
+          ENDIF
+#endif
+       ELSE
+         WRITE(msgBuf,'(A,I6)')
+     &     ' MDS_WRITE_SEC_YZ: illegal value for filePrec=',filePrec
+         CALL PRINT_ERROR( msgBuf, myThid )
+         CALL ALL_PROC_DIE( myThid )
+         STOP 'ABNORMAL END: S/R MDS_WRITE_SEC_YZ'
+       ENDIF
+C Make other threads wait for "gather" completion so that after this,
+C  shared buffer can again be modified by any thread
+        CALL BAR2( myThid )
+
+       IF ( iAmDoingIO ) THEN
+         irec = 1 + k-kLo + (irecord-1)*kSize
+         IF ( debugLevel .GE. debLevC ) THEN
+           WRITE(msgBuf,'(A,I8,A,I8)')
+     &       ' MDS_WRITE_SEC_YZ: irec: ', irec,
+     &       ' SIZE(ylayerbuffer_r8): ', SIZE(y_layer_buffer_r8)
+           CALL PRINT_MESSAGE( msgBuf, standardMessageUnit,
+     &                         SQUEEZE_RIGHT, myThid )
+           do j=1,Ny
+           WRITE(msgBuf,'(A,F8.2)')
+     &       ' MDS_WRITE_SEC_YZ: : ybuffer(j): ',y_layer_buffer_r8(j)
+           CALL PRINT_MESSAGE( msgBuf, standardMessageUnit,
+     &                         SQUEEZE_RIGHT, myThid )
+           enddo
          ENDIF
        ENDIF
 

--- a/pkg/mdsio/mdsio_write_section.F
+++ b/pkg/mdsio/mdsio_write_section.F
@@ -130,16 +130,17 @@ C     bBij  :: base shift in Buffer index for tile bi,bj
       INTEGER irec,dUnit,IL,pIL
       INTEGER dimList(3,2), nDims, map2gl(2)
       INTEGER length_of_rec
+      INTEGER bBij
       INTEGER tNx, global_nTx
       INTEGER tBx, iGjLoc, jGjLoc
-      REAL*4 r4seg(sNx)
-      REAL*8 r8seg(sNx)
-      REAL*4 x_layer_buffer_r4(Nx)
-      REAL*8 x_layer_buffer_r8(Nx)
+      _R4 r4seg(sNx,nSx,nSy)
+      _R8 r8seg(sNx,nSx,nSy)
+      _R4 x_buffer_r4( Nx )
+      _R8 x_buffer_r8( Nx )
+      _R4 xz_buffer_r4( sNx*Nr*nSx )
+      _R8 xz_buffer_r8( sNx*Nr*nSx )
 #ifdef ALLOW_EXCH2
       INTEGER tN
-      REAL*4 x_layer_buffer_exch2_r4(exch2_global_Nx)
-      REAL*8 x_layer_buffer_exch2_r8(exch2_global_Nx)
 #endif /* ALLOW_EXCH2 */
       _RL dummyRL(1)
       CHARACTER*8 blank8c
@@ -280,7 +281,7 @@ C globalFile is too slow, then try using single-CPU I/O.
 C Master thread of process 0, only, opens a global file
        IF ( iAmDoingIO ) THEN
          WRITE(dataFName,'(2a)') fName(1:IL),'.data'
-         length_of_rec = MDS_RECLEN( filePrec, sNx, myThid )
+         length_of_rec = MDS_RECLEN( filePrec, xSize, myThid )
          IF (irecord .EQ. 1) THEN
           OPEN( dUnit, file=dataFName, status=_NEW_STATUS,
      &        access='direct', recl=length_of_rec )
@@ -292,131 +293,81 @@ C Master thread of process 0, only, opens a global file
 
 C Gather array and write it to file, one vertical level at a time
       DO k=kLo,kHi
+C Initialize buffer
+       DO j = 1,xSize
+        x_buffer_r4(j)=0.
+        x_buffer_r8(j)=0.
+       ENDDO
        zeroBuff = k.EQ.kLo
 C-     copy from fldRL/RS(level=k) to 2-D "local":
        IF ( filePrec.EQ.precFloat32 ) THEN
-         DO bj=1,nSy
-         DO bi=1,nSx
-          IF ( arrType.EQ.'RS' ) THEN
-            CALL MDS_SEG4toRS_2D( sNx, oLx, kSize, bi, bj, k,
-     &                            .FALSE., r4seg, fldRS )
-          ELSEIF ( arrType.EQ.'RL' ) THEN
-            CALL MDS_SEG4toRS_2D( sNx, oLx, kSize, bi, bj, k,
-     &                            .FALSE., r4seg, fldRL )
-          ELSE
-            WRITE(msgBuf,'(2A)')
-     &      ' MDS_WRITE_SEC_XZ: illegal value for arrType=', arrType
-            CALL PRINT_ERROR( msgBuf, myThid )
-            CALL ALL_PROC_DIE( myThid )
-            STOP 'ABNORMAL END: S/R MDS_WRITE_SEC_XZ'
-          ENDIF
-         ENDDO
-         ENDDO
+         IF ( arrType.EQ.'RS' ) THEN
+           CALL MDS_PASS_XZ_R4toRS( r4seg, fldRS, 
+     I             0, 1, k, kSize, 0, 0, .FALSE., myThid )
+         ELSEIF ( arrType.EQ.'RL' ) THEN
+           CALL MDS_PASS_XZ_R4toRL( r4seg, fldRL, 
+     I             0, 1, k, kSize, 0, 0, .FALSE., myThid )
+         ELSE
+           WRITE(msgBuf,'(2A)')
+     &     ' MDS_WRITE_SEC_XZ: illegal value for arrType=', arrType
+           CALL PRINT_ERROR( msgBuf, myThid )
+           CALL ALL_PROC_DIE( myThid )
+           STOP 'ABNORMAL END: S/R MDS_WRITE_SEC_XZ'
+         ENDIF
 C Wait for all threads to finish filling shared buffer
           CALL BAR2( myThid )
-#ifdef ALLOW_EXCH2
-          IF ( .not.W2_useE2ioLayOut ) THEN
-#endif
-            CALL GATHER_VEC_R4( 
-     O                         x_layer_buffer_r4,
-     I                         r4seg, 
-     I                         sNx, myThid ) 
-#ifdef ALLOW_EXCH2
-          ELSE
-
-            CALL GATHER_VEC_R4( 
-     O                         x_layer_buffer_exch2_r4,
-     I                         r4seg, 
-     I                         sNx, myThid ) 
-          ENDIF
-#endif
-
-        ELSEIF ( filePrec.EQ.precFloat64 ) THEN
-         DO bj=1,nSy
-         DO bi=1,nSx
-          IF ( arrType.EQ.'RS' ) THEN
-            CALL MDS_SEG8toRS_2D( sNx, oLx, kSize, bi, bj, k,
-     I                         .FALSE., r8seg, fldRS )
-          ELSEIF ( arrType.EQ.'RL' ) THEN
-            CALL MDS_SEG8toRS_2D( sNx, oLx, kSize, bi, bj, k,
-     I                         .FALSE., r8seg, fldRL )
-          ELSE
-            WRITE(msgBuf,'(2A)')
-     &      ' MDS_WRITE_SEC_XZ: illegal value for arrType=', arrType
-            CALL PRINT_ERROR( msgBuf, myThid )
-            CALL ALL_PROC_DIE( myThid )
-            STOP 'ABNORMAL END: S/R MDS_WRITE_SEC_XZ'
-          ENDIF
-         ENDDO
-         ENDDO
+          CALL GATHER_XZ_R4(
+     O                      x_buffer_r4,
+     I                      r4seg,
+     I                      xSize,
+     I                      useExch2ioLayout, zeroBuff, myThid )
+       ELSEIF ( filePrec.EQ.precFloat64 ) THEN
+         IF ( arrType.EQ.'RS' ) THEN
+           CALL MDS_PASS_XZ_R8toRS( r8seg, fldRS,
+     I            0, 1, k, kSize, 0, 0, .FALSE., myThid )
+         ELSEIF ( arrType.EQ.'RL' ) THEN
+           CALL MDS_PASS_XZ_R8toRL( r8seg, fldRL,
+     I            0, 1, k, kSize, 0, 0, .FALSE., myThid )
+         ELSE
+           WRITE(msgBuf,'(2A)')
+     &     ' MDS_WRITE_SEC_XZ: illegal value for arrType=', arrType
+           CALL PRINT_ERROR( msgBuf, myThid )
+           CALL ALL_PROC_DIE( myThid )
+           STOP 'ABNORMAL END: S/R MDS_WRITE_SEC_XZ'
+         ENDIF
 C Wait for all threads to finish filling shared buffer
-          CALL BAR2( myThid )
-#ifdef ALLOW_EXCH2
-          IF ( .not.W2_useE2ioLayOut ) THEN
-#endif
-            CALL GATHER_VEC_R8( 
-     O                         x_layer_buffer_r8,
-     I                         r8seg, 
-     I                         sNx, myThid ) 
-#ifdef ALLOW_EXCH2
-          ELSE
-
-            CALL GATHER_VEC_R8( 
-     O                          x_layer_buffer_exch2_r8,
-     I                          r8seg, 
-     I                          sNx, myThid ) 
-          ENDIF
-#endif
-        ELSE
-          WRITE(msgBuf,'(A,I6)')
-     &      ' MDS_WRITE_SEC_XZ: illegal value for filePrec=',filePrec
-          CALL PRINT_ERROR( msgBuf, myThid )
-          CALL ALL_PROC_DIE( myThid )
-          STOP 'ABNORMAL END: S/R MDS_WRITE_SEC_XZ'
-        ENDIF
+         CALL BAR2( myThid )
+         CALL GATHER_XZ_R8(
+     O                     x_buffer_r8,
+     I                     r8seg,
+     I                     xSize,
+     I                     useExch2ioLayout, zeroBuff, myThid )
+       ELSE
+         WRITE(msgBuf,'(A,I6)')
+     &     ' MDS_WRITE_SEC_XZ: illegal value for filePrec=',filePrec
+         CALL PRINT_ERROR( msgBuf, myThid )
+         CALL ALL_PROC_DIE( myThid )
+         STOP 'ABNORMAL END: S/R MDS_WRITE_SEC_XZ'
+       ENDIF
 C Make other threads wait for "gather" completion so that after this,
 C  shared buffer can again be modified by any thread
         CALL BAR2( myThid )
 
-        IF ( iAmDoingIO ) THEN
-          irec = 1 + k-kLo + (irecord-1)*kSize
-          IF ( filePrec.EQ.precFloat32 ) THEN
-
-#ifdef ALLOW_EXCH2
-           IF ( .not.W2_useE2ioLayOut ) THEN
-#endif
+       IF ( iAmDoingIO ) THEN
+         irec = 1 + (k-kLo) + (irecord-1)*nNz
+         IF ( filePrec.EQ.precFloat32 ) THEN
 # ifdef _BYTESWAPIO
-            CALL MDS_BYTESWAPR4( xSize, x_layer_buffer_r4 )
+           CALL MDS_BYTESWAPR4( xSize, x_buffer_r4 )
 # endif
-            WRITE(dUnit,rec=irec) x_layer_buffer_r4
-#ifdef ALLOW_EXCH2
-           ELSE
+           WRITE(dUnit,rec=irec) x_buffer_r4
+         ELSE
 # ifdef _BYTESWAPIO
-            CALL MDS_BYTESWAPR4( xSize, x_layer_buffer_exch2_r4 )
+           CALL MDS_BYTESWAPR8( xSize, x_buffer_r8 )
 # endif
-            WRITE(dUnit,rec=irec) x_layer_buffer_exch2_r4
-           ENDIF
-#endif
-          ELSE
-
-#ifdef ALLOW_EXCH2
-           IF ( .not.W2_useE2ioLayOut ) THEN
-#endif
-# ifdef _BYTESWAPIO
-            CALL MDS_BYTESWAPR8( xSize, x_layer_buffer_r8 )
-# endif
-            WRITE(dUnit,rec=irec) x_layer_buffer_r8
-#ifdef ALLOW_EXCH2
-           ELSE
-# ifdef _BYTESWAPIO
-            CALL MDS_BYTESWAPR8( xSize, x_layer_buffer_exch2_r8 )
-# endif
-            WRITE(dUnit,rec=irec) x_layer_buffer_exch2_r8
-           ENDIF
-#endif
-          ENDIF
+           WRITE(dUnit,rec=irec) x_buffer_r8
+         ENDIF
 C-      end if iAmDoingIO
-        ENDIF
+       ENDIF
 C-     end of k loop
        ENDDO
 
@@ -431,21 +382,16 @@ C---  else .NOT.useSingleCpuIO
 
 C Wait for all thread to finish. This prevents other threads (e.g., master)
 C  to continue to acces 3-D buffer while this thread is filling it.
-        CALL BAR2( myThid )
+       CALL BAR2( myThid )
 
-C---    Copy from fldRL/RS to 3-D buffer (multi-threads):
-       DO k=kLo,kHi
-        zeroBuff = k.EQ.kLo
-        DO bj=1,nSy
-        DO bi=1,nSx
-C-      copy from fldRL/RS(level=k) to 2-D "local":
+C---    Copy from fldRL/RS to 2-D buffer (multi-threads):
         IF ( filePrec.EQ.precFloat32 ) THEN
           IF ( arrType.EQ.'RS' ) THEN
-            CALL MDS_SEG4toRS_2D( sNx, oLx, kSize, bi, bj, k,
-     &                            .FALSE., r4seg, fldRS )
+            CALL MDS_PASS_XZ_R4toRS( xz_buffer_r4, fldRS,
+     I              0, nNz, kLo, kSize, 0, 0, .FALSE., myThid )
           ELSEIF ( arrType.EQ.'RL' ) THEN
-            CALL MDS_SEG4toRS_2D( sNx, oLx, kSize, bi, bj, k,
-     &                            .FALSE., r4seg, fldRL )
+            CALL MDS_PASS_XZ_R4toRL( xz_buffer_r4, fldRL,
+     I              0, nNz, kLo, kSize, 0, 0, .FALSE., myThid )
           ELSE
             WRITE(msgBuf,'(2A)')
      &      ' MDS_WRITE_SEC_XZ: illegal value for arrType=', arrType
@@ -456,11 +402,11 @@ C-      copy from fldRL/RS(level=k) to 2-D "local":
 
         ELSEIF ( filePrec.EQ.precFloat64 ) THEN
           IF ( arrType.EQ.'RS' ) THEN
-            CALL MDS_SEG8toRS_2D( sNx, oLx, kSize, bi, bj, k,
-     I                         .FALSE., r8seg, fldRS )
+            CALL MDS_PASS_XZ_R8toRS( xz_buffer_r8, fldRS,
+     I              0, nNz, kLo, kSize, 0, 0, .FALSE., myThid )
           ELSEIF ( arrType.EQ.'RL' ) THEN
-            CALL MDS_SEG8toRS_2D( sNx, oLx, kSize, bi, bj, k,
-     I                         .FALSE., r8seg, fldRL )
+            CALL MDS_PASS_XZ_R8toRL( xz_buffer_r8, fldRL,
+     I              0, nNz, kLo, kSize, 0, 0, .FALSE., myThid )
           ELSE
             WRITE(msgBuf,'(2A)')
      &      ' MDS_WRITE_SEC_XZ: illegal value for arrType=', arrType
@@ -468,7 +414,6 @@ C-      copy from fldRL/RS(level=k) to 2-D "local":
             CALL ALL_PROC_DIE( myThid )
             STOP 'ABNORMAL END: S/R MDS_WRITE_SEC_XZ'
           ENDIF
-
         ELSE
           WRITE(msgBuf,'(A,I6)')
      &      ' MDS_WRITE_SEC_XZ: illegal value for filePrec=',filePrec
@@ -476,10 +421,6 @@ C-      copy from fldRL/RS(level=k) to 2-D "local":
           CALL ALL_PROC_DIE( myThid )
           STOP 'ABNORMAL END: S/R MDS_WRITE_SEC_XZ'
         ENDIF
-        ENDDO
-        ENDDO
-C-     end of k loop
-       ENDDO
 
 C Wait for all threads to finish filling shared buffer
        CALL BAR2( myThid )
@@ -489,9 +430,9 @@ C Only do I/O if I am the master thread
 
 #ifdef _BYTESWAPIO
         IF ( filePrec.EQ.precFloat32 ) THEN
-          CALL MDS_BYTESWAPR4( sNx, r4seg )
+          CALL MDS_BYTESWAPR4( sNx*nNz*nSx, xz_buffer_r4 )
         ELSE
-          CALL MDS_BYTESWAPR8( sNx, r8seg )
+          CALL MDS_BYTESWAPR8( sNx*nNz*nSx, xz_buffer_r8 )
         ENDIF
 #endif
 
@@ -512,10 +453,11 @@ C If we are writing to a global file then we open it here
 C Loop over all tiles
         DO bj=1,nSy
          DO bi=1,nSx
+          bBij = sNx*nNz*( bi-1 + (bj-1)*nSx )
 
           tNx = sNx
           global_nTx = xSize/sNx
-          tBx = myXGlobalLo-1 + (bi-1)*sNx
+          tBx = myXGlobalLo-1 + (bj-1)*sNx
 #ifdef ALLOW_EXCH2
           IF ( useExch2ioLayOut ) THEN
             tN = W2_myTileList(bi,bj)
@@ -541,10 +483,12 @@ C--- Case of 1 Global file:
            DO k=kLo,kHi
             irec = 1 + tBx/tNx
      &           +( k-kLo + (irecord-1)*kSize )*global_nTx
+            i1 = bBij + 1 + (k-kLo)*sNx
+            i2 = bBij +           k*sNx
             IF ( filePrec.EQ.precFloat32 ) THEN
-             WRITE(dUnit,rec=irec) r4seg
+             WRITE(dUnit,rec=irec) (xz_buffer_r4(i),i=i1,i2)
             ELSE
-             WRITE(dUnit,rec=irec) r8seg
+             WRITE(dUnit,rec=irec) (xz_buffer_r8(i),i=i1,i2)
             ENDIF
 C End of k loop
            ENDDO
@@ -557,7 +501,7 @@ C If we are writing to a tiled MDS file then we open each one here
            jG=bj+(myYGlobalLo-1)/sNy
            WRITE(dataFName,'(2A,I3.3,A,I3.3,A)')
      &            pfName(1:pIL),'.',iG,'.',jG,'.data'
-           length_of_rec = MDS_RECLEN( filePrec, sNx, myThid )
+           length_of_rec = MDS_RECLEN( filePrec, sNx*nNz, myThid )
            IF (irecord .EQ. 1) THEN
             OPEN( dUnit, file=dataFName, status=_NEW_STATUS,
      &            access='direct', recl=length_of_rec )
@@ -567,15 +511,12 @@ C If we are writing to a tiled MDS file then we open each one here
            ENDIF
            fileIsOpen=.TRUE.
 
-           DO k=kLo,kHi
-            irec = k+kSize*(irecord-1)
-            IF ( filePrec.EQ.precFloat32 ) THEN
-              WRITE(dUnit,rec=irec) r4seg
-            ELSE
-              WRITE(dUnit,rec=irec) r8seg
-            ENDIF
-C End of k loop
-           ENDDO
+           irec = irecord
+           IF ( filePrec.EQ.precFloat32 ) THEN
+             WRITE(dUnit,rec=irec) xz_buffer_r4
+           ELSE
+             WRITE(dUnit,rec=irec) xz_buffer_r8
+           ENDIF
 
 C here We close the tiled MDS file
            IF ( fileIsOpen ) THEN
@@ -592,7 +533,7 @@ C Create meta-file for each tile if we are tiling
            jG=bj+(myYGlobalLo-1)/sNy
            WRITE(metaFname,'(2A,I3.3,A,I3.3,A)')
      &              pfName(1:pIL),'.',iG,'.',jG,'.meta'
-           dimList(1,1) = xSize
+           dimList(1,1) = Nx
            dimList(2,1) = tBx + 1
            dimList(3,1) = tBx + tNx
            dimList(1,2) = nNz
@@ -632,9 +573,9 @@ C Create meta-file for the global-file (also if useSingleCpuIO)
       IF ( writeMetaF .AND. iAmDoingIO .AND.
      &    (globalFile .OR. useSingleCpuIO) ) THEN
          WRITE(metaFName,'(2A)') fName(1:IL),'.meta'
-         dimList(1,1) = xSize
+         dimList(1,1) = Nx
          dimList(2,1) = 1
-         dimList(3,1) = xSize
+         dimList(3,1) = Nx
          dimList(1,2) = nNz
          dimList(2,2) = 1
          dimList(3,2) = nNz
@@ -776,7 +717,7 @@ C     bBij  :: base shift in Buffer index for tile bi,bj
       INTEGER xSize, ySize
       INTEGER irecord
       INTEGER iG,jG,bi,bj
-      INTEGER i1,i2,i,j,k,nNz,np
+      INTEGER i1,i2,i,j,k,nNz
       INTEGER irec,dUnit,IL,pIL
       INTEGER dimList(3,2), nDims, map2gl(2)
       INTEGER length_of_rec
@@ -785,14 +726,12 @@ C     bBij  :: base shift in Buffer index for tile bi,bj
       INTEGER tBy, iGjLoc, jGjLoc
       _R4 r4seg(sNy,nSx,nSy)
       _R8 r8seg(sNy,nSx,nSy)
-      _R4 y_layer_buffer_r4( Ny )
-      _R8 y_layer_buffer_r8( Ny )
-      _R4 yz_buffer_r4( sNy*Nr*nSx*nSy )
-      _R8 yz_buffer_r8( sNy*Nr*nSx*nSy )
+      _R4 y_buffer_r4( Ny )
+      _R8 y_buffer_r8( Ny )
+      _R4 yz_buffer_r4( sNy*Nr*nSy )
+      _R8 yz_buffer_r8( sNy*Nr*nSy )
 #ifdef ALLOW_EXCH2
       INTEGER tN
-      REAL*4 y_layer_buffer_exch2_r4(exch2_global_Ny)
-      REAL*8 y_layer_buffer_exch2_r8(exch2_global_Ny)
 #endif /* ALLOW_EXCH2 */
       _RL dummyRL(1)
       CHARACTER*8 blank8c
@@ -944,12 +883,11 @@ C Master thread of process 0, only, opens a global file
        ENDIF
 
 C Gather array and write it to file, one vertical level at a time
-
       DO k=kLo,kHi
 C Initialize buffer
        DO j = 1,ySize
-        y_layer_buffer_r4(j)=0.
-        y_layer_buffer_r8(j)=0.
+        y_buffer_r4(j)=0.
+        y_buffer_r8(j)=0.
        ENDDO
        zeroBuff = k.EQ.kLo
 C-     copy from fldRL/RS(level=k) to 2-D "local":
@@ -969,28 +907,11 @@ C-     copy from fldRL/RS(level=k) to 2-D "local":
          ENDIF
 C Wait for all threads to finish filling shared buffer
           CALL BAR2( myThid )
-#ifdef ALLOW_EXCH2
-          IF ( .not.W2_useE2ioLayOut ) THEN
-#endif
-            CALL GATHER_YZ_R4(
-     O                        y_layer_buffer_r4,
-     I                        r4seg,
-     I                        ySize,
-     I                        useExch2ioLayout,
-     I                        zeroBuff,
-     I                        myThid )
-#ifdef ALLOW_EXCH2
-          ELSE
-            CALL GATHER_YZ_R4(
-     O                        y_layer_buffer_exch2_r4,
-     I                        r4seg,
-     I                        ySize,
-     I                        useExch2ioLayout,
-     I                        zeroBuff,
-     I                        myThid )
-          ENDIF
-#endif
-
+          CALL GATHER_YZ_R4(
+     O                      y_buffer_r4,
+     I                      r4seg,
+     I                      ySize,
+     I                      useExch2ioLayout, zeroBuff, myThid )
        ELSEIF ( filePrec.EQ.precFloat64 ) THEN
          IF ( arrType.EQ.'RS' ) THEN
            CALL MDS_PASS_YZ_R8toRS( r8seg, fldRS,
@@ -1005,36 +926,13 @@ C Wait for all threads to finish filling shared buffer
            CALL ALL_PROC_DIE( myThid )
            STOP 'ABNORMAL END: S/R MDS_WRITE_SEC_YZ'
          ENDIF
-         IF ( debugLevel .GE. debLevC ) THEN
-           WRITE(msgBuf,'(A,I8)')
-     &       ' MDS_WRITE_SEC_YZ: SIZE(ylayerbuffer_r8): ', 
-     &          SIZE(y_layer_buffer_r8)
-           CALL PRINT_MESSAGE( msgBuf, standardMessageUnit,
-     &                         SQUEEZE_RIGHT, myThid )
-         ENDIF
 C Wait for all threads to finish filling shared buffer
          CALL BAR2( myThid )
-#ifdef ALLOW_EXCH2
-          IF ( .not.W2_useE2ioLayOut ) THEN
-#endif
-            CALL GATHER_YZ_R8(
-     O                        y_layer_buffer_r8,
-     I                        r8seg,
-     I                        ySize,
-     I                        useExch2ioLayout,
-     I                        zeroBuff,
-     I                        myThid )
-#ifdef ALLOW_EXCH2
-          ELSE
-            CALL GATHER_YZ_R8(
-     O                        y_layer_buffer_exch2_r8,
-     I                        r8seg,
-     I                        ySize,
-     I                        useExch2ioLayout,
-     I                        zeroBuff,
-     I                        myThid )
-          ENDIF
-#endif
+         CALL GATHER_YZ_R8(
+     O                     y_buffer_r8,
+     I                     r8seg,
+     I                     ySize,
+     I                     useExch2ioLayout, zeroBuff, myThid )
        ELSE
          WRITE(msgBuf,'(A,I6)')
      &     ' MDS_WRITE_SEC_YZ: illegal value for filePrec=',filePrec
@@ -1048,46 +946,16 @@ C  shared buffer can again be modified by any thread
 
        IF ( iAmDoingIO ) THEN
          irec = 1 + (k-kLo) + (irecord-1)*nNz
-         IF ( debugLevel .GE. debLevC ) THEN
-           WRITE(msgBuf,'(A,I8,A,I8)')
-     &       ' MDS_WRITE_SEC_YZ: irec: ', irec,
-     &       ' SIZE(ylayerbuffer_r8): ', SIZE(y_layer_buffer_r8)
-           CALL PRINT_MESSAGE( msgBuf, standardMessageUnit,
-     &                         SQUEEZE_RIGHT, myThid )
-         ENDIF
          IF ( filePrec.EQ.precFloat32 ) THEN
-#ifdef ALLOW_EXCH2
-           IF ( .not.W2_useE2ioLayOut ) THEN
-#endif
 # ifdef _BYTESWAPIO
-             CALL MDS_BYTESWAPR4( ySize, y_layer_buffer_r4 )
+           CALL MDS_BYTESWAPR4( ySize, y_buffer_r4 )
 # endif
-             WRITE(dUnit,rec=irec) y_layer_buffer_r4
-#ifdef ALLOW_EXCH2
-           ELSE
-# ifdef _BYTESWAPIO
-             CALL MDS_BYTESWAPR4( ySize, y_layer_buffer_exch2_r4 )
-# endif
-             WRITE(dUnit,rec=irec) y_layer_buffer_exch2_r4
-           ENDIF
-#endif
+           WRITE(dUnit,rec=irec) y_buffer_r4
          ELSE
-
-#ifdef ALLOW_EXCH2
-           IF ( .not.W2_useE2ioLayOut ) THEN
-#endif
 # ifdef _BYTESWAPIO
-             CALL MDS_BYTESWAPR8( ySize, y_layer_buffer_r8 )
+           CALL MDS_BYTESWAPR8( ySize, y_buffer_r8 )
 # endif
-             WRITE(dUnit,rec=irec) y_layer_buffer_r8
-#ifdef ALLOW_EXCH2
-           ELSE
-# ifdef _BYTESWAPIO
-             CALL MDS_BYTESWAPR8( ySize, y_layer_buffer_exch2_r8 )
-# endif
-             WRITE(dUnit,rec=irec) y_layer_buffer_exch2_r8
-           ENDIF
-#endif
+           WRITE(dUnit,rec=irec) y_buffer_r8
          ENDIF
 C-      end if iAmDoingIO
        ENDIF
@@ -1137,7 +1005,6 @@ C---    Copy from fldRL/RS to 2-D buffer (multi-threads):
             CALL ALL_PROC_DIE( myThid )
             STOP 'ABNORMAL END: S/R MDS_WRITE_SEC_YZ'
           ENDIF
-
         ELSE
           WRITE(msgBuf,'(A,I6)')
      &      ' MDS_WRITE_SEC_YZ: illegal value for filePrec=',filePrec
@@ -1204,12 +1071,11 @@ C-          default (face fit into global-IO-array)
           IF (globalFile) THEN
 C--- Case of 1 Global file:
 
-Cts --- TODO: check this!
            DO k=kLo,kHi
             irec = 1 + tBy/tNy
      &           +( k-kLo + (irecord-1)*kSize )*global_nTy
-            i1 = bBij + 1 + (k-kLo)*sNx*sNy
-            i2 = bBij +           k*sNx*sNy
+            i1 = bBij + 1 + (k-kLo)*sNy
+            i2 = bBij +           k*sNy
             IF ( filePrec.EQ.precFloat32 ) THEN
              WRITE(dUnit,rec=irec) (yz_buffer_r4(i),i=i1,i2)
             ELSE
@@ -1301,9 +1167,6 @@ C Create meta-file for the global-file (also if useSingleCpuIO)
          dimList(1,1) = Ny
          dimList(2,1) = 1
          dimList(3,1) = Ny
-         ! dimList(1,2) = nPx
-         ! dimList(2,2) = 1
-         ! dimList(3,2) = nPx
          dimList(1,2) = nNz
          dimList(2,2) = 1
          dimList(3,2) = nNz

--- a/pkg/mdsio/mdsio_write_section.F
+++ b/pkg/mdsio/mdsio_write_section.F
@@ -16,40 +16,63 @@ C !INTERFACE:
      I   globalFile,
      I   useCurrentDir,
      I   arrType,
-     I   kSize,
+     I   kSize,kLo,kHi,
      I   fldRL, fldRS,
-     I   irecord,
+     I   jrecord,
      I   myIter,
      I   myThid )
 
-C !DESCRIPTION
+C !DESCRIPTION:
 C Arguments:
 C
-C fName       string  :: base name for file to read
-C filePrec    integer :: number of bits per word in file (32 or 64)
-C globalFile  logical :: selects between writing a global or tiled file
-C useCurrentDir logic :: always write to the current directory (even if
+C fName     (string)  :: base name for file to write
+C filePrec  (integer) :: number of bits per word in file (32 or 64)
+C globalFile (logical):: selects between writing a global or tiled file
+C useCurrentDir(logic):: always write to the current directory (even if
 C                        "mdsioLocalDir" is set)
-C arrType     char(2) :: which array (fldRL/RS) to write, either "RL" or "RS"
-C kSize       integer :: size of third dimension, normally either 1 or Nr
-C fldRL         RL    :: array to write if arrType="RL", fldRL(:,kSize,:,:)
-C fldRS         RS    :: array to write if arrType="RS", fldRS(:,kSize,:,:)
-C irecord     integer :: record number to read
-C myIter      integer :: time step number
-C myThid      integer :: thread identifier
+C arrType   (char(2)) :: which array (fldRL/RS) to write, either "RL" or "RS"
+C kSize     (integer) :: size of third dimension: normally either 1 or Nr
+C kLo       (integer) :: 1rst vertical level (of array fldRL/RS) to write
+C kHi       (integer) :: last vertical level (of array fldRL/RS) to write
+C fldRL       ( RL )  :: array to write if arrType="RL", fldRL(:,:,kSize,:,:)
+C fldRS       ( RS )  :: array to write if arrType="RS", fldRS(:,:,kSize,:,:)
+C irecord   (integer) :: record number to write
+C myIter    (integer) :: time step number
+C myThid    (integer) :: thread identifier
 C
-C MDS_WRITE_SEC_XZ creates either a file of the form "fName.data"
-C if the logical flag "globalFile" is set true. Otherwise
-C it creates MDS tiled files of the form "fName.xxx.yyy.data".
-C The precision of the file is decsribed by filePrec, set either
-C  to floatPrec32 or floatPrec64. The char*(2) string arrType, either "RL"
-C  or "RS", selects which array is written, either fldRL or fldRS.
-C This routine writes vertical slices (X-Z) including overlap regions.
-C irecord is the record number to be read and must be >= 1.
-C NOTE: It is currently assumed that
-C the highest record number in the file was the last record written.
+C MDS_WRITE_SEC_XZ creates either a file of the form "fName.data" and
+C  "fName.meta" if the logical flag "globalFile" is set true. Otherwise
+C  it creates MDS tiled files of the form "fName.xxx.yyy.data" and
+C  "fName.xxx.yyy.meta". If jrecord > 0, a meta-file is created.
+C Currently, the meta-files are not read because it is difficult
+C  to parse files in fortran. We should read meta information before
+C  adding records to an existing multi-record file.
+C The precision of the file is described by filePrec, set either
+C  to floatPrec32 or floatPrec64. The char*(2) string arrType, either
+C  "RL" or "RS", selects which array is written, either fldRL or fldRS.
+C (kSize,kLo,kHi) allows for both 2-D and 3-D arrays to be handled, with
+C  the option to only write a sub-set of consecutive vertical levels (from
+C  kLo to kHi); (kSize,kLo,kHi)=(1,1,1) implies a 2-D model field and
+C  (kSize,kLo,kHi)=(Nr,1,Nr) implies a 3-D model field.
+C irecord=|jrecord| is the record number to be written and must be >= 1.
+C NOTE: It is currently assumed that the highest record number in the file
+C  was the last record written. Nor is there a consistency check between the
+C  routine arguments and file, i.e., if you write record 2 after record 4
+C  the meta information will record the number of records to be 2. This,
+C  again, is because we have read the meta information. To be fixed.
+C
+C- Multi-threaded: Only Master thread does IO (and MPI calls) and get data
+C   from a shared buffer that any thread can copy to.
+C- Convention regarding thread synchronisation (BARRIER):
+C  A per-thread (or per tile) partition of the 2-D shared-buffer (sharedLocBuf_r4/r8)
+C   is readily available => any access (e.g., by master-thread) to a portion
+C   owned by an other thread is put between BARRIER (protected).
+C  No thread partition exist for the 3-D shared buffer (shared3dBuf_r4/r8);
+C   Therefore, the 3-D buffer is considered to be owned by master-thread and
+C   any access by other than master thread is put between BARRIER (protected).
 C
 C Modified: 06/02/00 spk@ocean.mit.edu
+C Modified: 08/03/20 - style copied from mdsio_write_field timsmith204@utexas.edu 
 CEOP
 
 C !USES:
@@ -59,10 +82,15 @@ C Global variables / common blocks
 #include "EEPARAMS.h"
 #include "PARAMS.h"
 #ifdef ALLOW_EXCH2
-#include "W2_EXCH2_SIZE.h"
-#include "W2_EXCH2_TOPOLOGY.h"
-#include "W2_EXCH2_PARAMS.h"
+# include "W2_EXCH2_SIZE.h"
+# include "W2_EXCH2_TOPOLOGY.h"
+# include "W2_EXCH2_PARAMS.h"
 #endif /* ALLOW_EXCH2 */
+#include "EEBUFF_SCPU.h"
+#ifdef ALLOW_FIZHI
+# include "fizhi_SIZE.h"
+#endif /* ALLOW_FIZHI */
+#include "MDSIO_BUFF_3D.h"
 
 C !INPUT PARAMETERS:
       CHARACTER*(*) fName
@@ -70,192 +98,545 @@ C !INPUT PARAMETERS:
       LOGICAL globalFile
       LOGICAL useCurrentDir
       CHARACTER*(2) arrType
-      INTEGER kSize
-      _RL  fldRL(*)
-      _RS  fldRS(*)
-      INTEGER irecord
+      INTEGER kSize, kLo, kHi
+      _RL fldRL(*)
+      _RS fldRS(*)
+      INTEGER jrecord
       INTEGER myIter
       INTEGER myThid
 C !OUTPUT PARAMETERS:
 
-C !FUNCTIONS:
-      INTEGER ILNBLNK
-      INTEGER MDS_RECLEN
-      EXTERNAL ILNBLNK, MDS_RECLEN
+C !FUNCTIONS
+      INTEGER  ILNBLNK
+      INTEGER  MDS_RECLEN
+      LOGICAL  MASTER_CPU_IO
+      EXTERNAL ILNBLNK
+      EXTERNAL MDS_RECLEN
+      EXTERNAL MASTER_CPU_IO
 
 C !LOCAL VARIABLES:
-      CHARACTER*(MAX_LEN_FNAM) dataFName,pfName
-      INTEGER iG,jG,irec,bi,bj,k,dUnit,IL,pIL
-      Real*4 r4seg(sNx)
-      Real*8 r8seg(sNx)
-      INTEGER length_of_rec
+C     bBij  :: base shift in Buffer index for tile bi,bj
+      CHARACTER*(MAX_LEN_FNAM) dataFName,metaFName,pfName
+      CHARACTER*(MAX_LEN_MBUF) msgBuf
       LOGICAL fileIsOpen
-      CHARACTER*(max_len_mbuf) msgBuf
+      LOGICAL iAmDoingIO
+      LOGICAL writeMetaF
+      LOGICAL useExch2ioLayOut
+      LOGICAL zeroBuff
+      INTEGER xSize, ySize
+      INTEGER irecord
+      INTEGER iG,jG,bi,bj
+      INTEGER i1,i2,i,j,k,nNz
+      INTEGER irec,dUnit,IL,pIL
+      INTEGER dimList(3,2), nDims, map2gl(2)
+      INTEGER length_of_rec
+      INTEGER tNx, global_nTx
+      INTEGER tBx, iGjLoc, jGjLoc
+      REAL*4 r4seg(sNx*nSx)
+      REAL*8 r8seg(sNx*nSx)
+      REAL*4 x_layer_buffer_r4(Nx)
+      REAL*8 x_layer_buffer_r8(Nx)
 #ifdef ALLOW_EXCH2
-      INTEGER tGx,tNx,tN
+      INTEGER tN
+      REAL*4 x_layer_buffer_exch2_r4(exch2_global_Nx)
+      REAL*8 x_layer_buffer_exch2_r8(exch2_global_Nx)
+#endif /* ALLOW_EXCH2 */
+      _RL dummyRL(1)
+      CHARACTER*8 blank8c
+
+      DATA dummyRL(1) / 0. _d 0 /
+      DATA blank8c / '        ' /
+
+C---+----1----+----2----+----3----+----4----+----5----+----6----+----7-|--+----|
+C Set dimensions:
+      xSize = Nx
+      ySize = 1
+      useExch2ioLayOut = .FALSE.
+#ifdef ALLOW_EXCH2
+      IF ( W2_useE2ioLayOut ) THEN
+        xSize = exch2_global_Nx
+        ySize = 1
+        useExch2ioLayOut = .TRUE.
+      ENDIF
 #endif /* ALLOW_EXCH2 */
 
-C     ------------------------------------------------------------------
-
-C Only do I/O if I am the master thread
-      _BEGIN_MASTER( myThid )
-
-C Record number must be >= 1
-      IF (irecord .LT. 1) THEN
-       WRITE(msgBuf,'(A,I9.8)')
-     &   ' MDS_WRITE_SEC_XZ: argument irecord = ',irecord
-       CALL PRINT_MESSAGE( msgBuf, standardMessageUnit,
-     &                     SQUEEZE_RIGHT, myThid )
-       WRITE(msgBuf,'(A)')
-     &   ' MDS_WRITE_SEC_XZ: invalid value for irecord'
-       CALL PRINT_ERROR( msgBuf, myThid )
-       STOP 'ABNORMAL END: S/R MDS_WRITE_SEC_XZ'
-      ENDIF
+C-    default:
+      iGjLoc = 0
+      jGjLoc = 1
 
 C Assume nothing
-      fileIsOpen=.FALSE.
+      fileIsOpen = .FALSE.
       IL  = ILNBLNK( fName )
       pIL = ILNBLNK( mdsioLocalDir )
+      nNz = 1 + kHi - kLo
+      irecord = ABS(jrecord)
+      writeMetaF = jrecord.GT.0
+
+C Only do I/O if I am the master thread (and mpi process 0 IF useSingleCpuIO):
+      iAmDoingIO = MASTER_CPU_IO(myThid)
+
+C File name should not be too long:
+C    IL(+pIL if not useCurrentDir)(+5: '.data')(+8: bi,bj) =< MAX_LEN_FNAM
+C    and shorter enough to be written to msgBuf with other informations
+      IF ( useCurrentDir .AND. (90+IL).GT.MAX_LEN_MBUF ) THEN
+        WRITE(msgBuf,'(2A,2(I4,A))') 'MDS_WRITE_SEC_XZ: ',
+     &   'Too long (IL=',IL,') file name:'
+        CALL PRINT_ERROR( msgBuf, myThid )
+        WRITE(errorMessageUnit,'(3A)')'file: >',fName(1:IL),'<'
+        CALL ALL_PROC_DIE( myThid )
+        STOP 'ABNORMAL END: S/R MDS_WRITE_SEC_XZ'
+      ELSEIF ( (90+IL+pIL).GT.MAX_LEN_MBUF ) THEN
+        WRITE(msgBuf,'(2A,2(I4,A))') 'MDS_WRITE_SEC_XZ: ',
+     &   'Too long (pIL=',pIL,', IL=',IL,') pfix + file name:'
+        CALL PRINT_ERROR( msgBuf, myThid )
+        WRITE(errorMessageUnit,'(3A)')'pfix: >',mdsioLocalDir(1:pIL),'<'
+        WRITE(errorMessageUnit,'(3A)')'file: >',fName(1:IL),'<'
+        CALL ALL_PROC_DIE( myThid )
+        STOP 'ABNORMAL END: S/R MDS_WRITE_SEC_XZ'
+      ENDIF
+C Record number must be >= 1
+      IF (irecord .LT. 1) THEN
+        WRITE(msgBuf,'(3A,I10)')
+     &    ' MDS_WRITE_SEC_XZ: file="', fName(1:IL), '" , iter=', myIter
+        CALL PRINT_MESSAGE( msgBuf, errorMessageUnit,
+     &                      SQUEEZE_RIGHT, myThid )
+        WRITE(msgBuf,'(A,I9.8)')
+     &    ' MDS_WRITE_SEC_XZ: argument irecord = ',irecord
+        CALL PRINT_MESSAGE( msgBuf, errorMessageUnit,
+     &                      SQUEEZE_RIGHT, myThid )
+        WRITE(msgBuf,'(A)')
+     &    ' MDS_WRITE_SEC_XZ: invalid value for irecord'
+        CALL PRINT_ERROR( msgBuf, myThid )
+        CALL ALL_PROC_DIE( myThid )
+        STOP 'ABNORMAL END: S/R MDS_WRITE_SEC_XZ'
+      ENDIF
+C check for valid sub-set of levels:
+      IF ( kLo.LT.1 .OR. kHi.GT.kSize ) THEN
+        WRITE(msgBuf,'(3A,I10)')
+     &    ' MDS_WRITE_SEC_XZ: file="', fName(1:IL), '" , iter=', myIter
+        CALL PRINT_MESSAGE( msgBuf, errorMessageUnit,
+     &                      SQUEEZE_RIGHT, myThid )
+        WRITE(msgBuf,'(3(A,I6))')
+     &    ' MDS_WRITE_SEC_XZ: arguments kSize=', kSize,
+     &    ' , kLo=', kLo, ' , kHi=', kHi
+        CALL PRINT_MESSAGE( msgBuf, errorMessageUnit,
+     &                      SQUEEZE_RIGHT, myThid )
+        WRITE(msgBuf,'(A)')
+     &    ' MDS_WRITE_SEC_XZ: invalid sub-set of levels'
+        CALL PRINT_ERROR( msgBuf, myThid )
+        CALL ALL_PROC_DIE( myThid )
+        STOP 'ABNORMAL END: S/R MDS_WRITE_SEC_XZ'
+      ENDIF
+C check for 3-D Buffer size:
+      IF ( .NOT.useSingleCpuIO .AND. nNz.GT.size3dBuf ) THEN
+        WRITE(msgBuf,'(3A,I10)')
+     &    ' MDS_WRITE_SEC_XZ: file="', fName(1:IL), '" , iter=', myIter
+        CALL PRINT_MESSAGE( msgBuf, errorMessageUnit,
+     &                      SQUEEZE_RIGHT, myThid )
+        WRITE(msgBuf,'(3(A,I6))')
+     &    ' MDS_WRITE_SEC_XZ: Nb Lev to write =', nNz,
+     &    ' >', size3dBuf, ' = buffer 3rd Dim'
+        CALL PRINT_MESSAGE( msgBuf, errorMessageUnit,
+     &                      SQUEEZE_RIGHT, myThid )
+        WRITE(msgBuf,'(A)')
+     &    ' MDS_WRITE_SEC_XZ: buffer 3rd Dim. too small'
+        CALL PRINT_ERROR( msgBuf, myThid )
+        WRITE(msgBuf,'(A)')
+     &    ' increase "size3dBuf" in "MDSIO_BUFF_3D.h" and recompile'
+        CALL PRINT_MESSAGE( msgBuf, errorMessageUnit,
+     &                      SQUEEZE_RIGHT, myThid)
+        CALL ALL_PROC_DIE( myThid )
+        STOP 'ABNORMAL END: S/R MDS_WRITE_SEC_XZ'
+      ENDIF
+
+C Only do I/O if I am the master thread
+      IF ( iAmDoingIO ) THEN
 
 C Assign special directory
-      IF ( useCurrentDir .OR. pIL.EQ.0 ) THEN
-       pfName= fName
-      ELSE
-       WRITE(pfName,'(2A)') mdsioLocalDir(1:pIL), fName(1:IL)
-      ENDIF
-      pIL=ILNBLNK( pfName )
+        IF ( useCurrentDir .OR. pIL.EQ.0 ) THEN
+         pfName = fName
+        ELSE
+         WRITE(pfName,'(2A)') mdsioLocalDir(1:pIL), fName(1:IL)
+        ENDIF
+        pIL=ILNBLNK( pfName )
+        IF ( debugLevel .GE. debLevC ) THEN
+          WRITE(msgBuf,'(A,I8,I6,3I4,2A)')
+     &      ' MDS_WRITE_SEC_XZ: it,rec,kS,kL,kH=', myIter, jrecord,
+     &      kSize, kLo, kHi, ' file=', pfName(1:pIL)
+          CALL PRINT_MESSAGE( msgBuf, standardMessageUnit,
+     &                        SQUEEZE_RIGHT, myThid )
+        ENDIF
 
 C Assign a free unit number as the I/O channel for this routine
-      CALL MDSFINDUNIT( dUnit, myThid )
+        CALL MDSFINDUNIT( dUnit, myThid )
+
+C- endif iAmDoingIO
+      ENDIF
+
+C If option globalFile is desired but does not work or if
+C globalFile is too slow, then try using single-CPU I/O.
+      IF (useSingleCpuIO) THEN
+
+C Master thread of process 0, only, opens a global file
+       IF ( iAmDoingIO ) THEN
+         WRITE(dataFName,'(2a)') fName(1:IL),'.data'
+         length_of_rec = MDS_RECLEN( filePrec, sNx*nSx, myThid )
+         IF (irecord .EQ. 1) THEN
+          OPEN( dUnit, file=dataFName, status=_NEW_STATUS,
+     &        access='direct', recl=length_of_rec )
+         ELSE
+          OPEN( dUnit, file=dataFName, status=_OLD_STATUS,
+     &        access='direct', recl=length_of_rec )
+         ENDIF
+       ENDIF
+
+C Gather array and write it to file, one vertical level at a time
+       DO k=kLo,kHi
+        zeroBuff = k.EQ.kLo
+C-      copy from fldRL/RS(level=k) to 2-D "local":
+        IF ( filePrec.EQ.precFloat32 ) THEN
+          IF ( arrType.EQ.'RS' ) THEN
+            CALL MDS_SEG4toRS_2D( sNx*nSx, oLx, kSize, bi, bj, k,
+     &                            .FALSE., r4seg, fldRS )
+          ELSEIF ( arrType.EQ.'RL' ) THEN
+            CALL MDS_SEG4toRS_2D( sNx*nSx, oLx, kSize, bi, bj, k,
+     &                            .FALSE., r4seg, fldRL )
+          ELSE
+            WRITE(msgBuf,'(2A)')
+     &      ' MDS_WRITE_SEC_XZ: illegal value for arrType=', arrType
+            CALL PRINT_ERROR( msgBuf, myThid )
+            CALL ALL_PROC_DIE( myThid )
+            STOP 'ABNORMAL END: S/R MDS_WRITE_SEC_XZ'
+          ENDIF
+C Wait for all threads to finish filling shared buffer
+          CALL BAR2( myThid )
+#ifdef ALLOW_EXCH2
+          IF ( .not.W2_useE2ioLayOut ) THEN
+#endif
+            CALL GATHER_VEC_R4( 
+     O                         x_layer_buffer_r4,
+     I                         r4seg, 
+     I                         xSize, myThid ) 
+#ifdef ALLOW_EXCH2
+          ELSE
+
+            CALL GATHER_VEC_R4( 
+     O                         x_layer_buffer_exch2_r4,
+     I                         r4seg, 
+     I                         xSize, myThid ) 
+          ENDIF
+#endif
+
+        ELSEIF ( filePrec.EQ.precFloat64 ) THEN
+          IF ( arrType.EQ.'RS' ) THEN
+            CALL MDS_SEG8toRS_2D( sNx*nSx, oLx, kSize, bi, bj, k,
+     I                         .FALSE., r8seg, fldRS )
+          ELSEIF ( arrType.EQ.'RL' ) THEN
+            CALL MDS_SEG8toRS_2D( sNx*nSx, oLx, kSize, bi, bj, k,
+     I                         .FALSE., r8seg, fldRL )
+          ELSE
+            WRITE(msgBuf,'(2A)')
+     &      ' MDS_WRITE_SEC_XZ: illegal value for arrType=', arrType
+            CALL PRINT_ERROR( msgBuf, myThid )
+            CALL ALL_PROC_DIE( myThid )
+            STOP 'ABNORMAL END: S/R MDS_WRITE_SEC_XZ'
+          ENDIF
+C Wait for all threads to finish filling shared buffer
+          CALL BAR2( myThid )
+#ifdef ALLOW_EXCH2
+          IF ( .not.W2_useE2ioLayOut ) THEN
+#endif
+            CALL GATHER_VEC_R8( 
+     O                         x_layer_buffer_r8,
+     I                         r8seg, 
+     I                         xSize, myThid ) 
+#ifdef ALLOW_EXCH2
+          ELSE
+
+            CALL GATHER_VEC_R8( 
+     O                          x_layer_buffer_exch2_r8,
+     I                          r8seg, 
+     I                          xSize, myThid ) 
+          ENDIF
+#endif
+        ELSE
+          WRITE(msgBuf,'(A,I6)')
+     &      ' MDS_WRITE_SEC_XZ: illegal value for filePrec=',filePrec
+          CALL PRINT_ERROR( msgBuf, myThid )
+          CALL ALL_PROC_DIE( myThid )
+          STOP 'ABNORMAL END: S/R MDS_WRITE_SEC_XZ'
+        ENDIF
+C Make other threads wait for "gather" completion so that after this,
+C  shared buffer can again be modified by any thread
+        CALL BAR2( myThid )
+
+        IF ( iAmDoingIO ) THEN
+          irec = 1 + k-kLo + (irecord-1)*kSize
+          IF ( filePrec.EQ.precFloat32 ) THEN
+
+#ifdef ALLOW_EXCH2
+           IF ( .not.W2_useE2ioLayOut ) THEN
+#endif
+# ifdef _BYTESWAPIO
+            CALL MDS_BYTESWAPR4( xSize, x_layer_buffer_r4 )
+# endif
+            WRITE(dUnit,rec=irec) x_layer_buffer_r4
+#ifdef ALLOW_EXCH2
+           ELSE
+# ifdef _BYTESWAPIO
+            CALL MDS_BYTESWAPR4( xSize, x_layer_buffer_exch2_r4 )
+# endif
+            WRITE(dUnit,rec=irec) x_layer_buffer_exch2_r4
+           ENDIF
+#endif
+          ELSE
+
+#ifdef ALLOW_EXCH2
+           IF ( .not.W2_useE2ioLayOut ) THEN
+#endif
+# ifdef _BYTESWAPIO
+            CALL MDS_BYTESWAPR8( xSize, x_layer_buffer_r8 )
+# endif
+            WRITE(dUnit,rec=irec) x_layer_buffer_r8
+#ifdef ALLOW_EXCH2
+           ELSE
+# ifdef _BYTESWAPIO
+            CALL MDS_BYTESWAPR8( xSize, x_layer_buffer_exch2_r8 )
+# endif
+            WRITE(dUnit,rec=irec) x_layer_buffer_exch2_r8
+           ENDIF
+#endif
+          ENDIF
+C-      end if iAmDoingIO
+        ENDIF
+C-     end of k loop
+       ENDDO
+
+C Close data-file
+       IF ( iAmDoingIO ) THEN
+         CLOSE( dUnit )
+       ENDIF
+
+C---+----1----+----2----+----3----+----4----+----5----+----6----+----7-|--+----|
+C---  else .NOT.useSingleCpuIO
+      ELSE
+
+C Wait for all thread to finish. This prevents other threads (e.g., master)
+C  to continue to acces 3-D buffer while this thread is filling it.
+        CALL BAR2( myThid )
+
+C---    Copy from fldRL/RS to 3-D buffer (multi-threads):
+       DO k=kLo,kHi
+        zeroBuff = k.EQ.kLo
+C-      copy from fldRL/RS(level=k) to 2-D "local":
+        IF ( filePrec.EQ.precFloat32 ) THEN
+          IF ( arrType.EQ.'RS' ) THEN
+            CALL MDS_SEG4toRS_2D( sNx*nSx, oLx, kSize, bi, bj, k,
+     &                            .FALSE., r4seg, fldRS )
+          ELSEIF ( arrType.EQ.'RL' ) THEN
+            CALL MDS_SEG4toRS_2D( sNx*nSx, oLx, kSize, bi, bj, k,
+     &                            .FALSE., r4seg, fldRL )
+          ELSE
+            WRITE(msgBuf,'(2A)')
+     &      ' MDS_WRITE_SEC_XZ: illegal value for arrType=', arrType
+            CALL PRINT_ERROR( msgBuf, myThid )
+            CALL ALL_PROC_DIE( myThid )
+            STOP 'ABNORMAL END: S/R MDS_WRITE_SEC_XZ'
+          ENDIF
+
+        ELSEIF ( filePrec.EQ.precFloat64 ) THEN
+          IF ( arrType.EQ.'RS' ) THEN
+            CALL MDS_SEG8toRS_2D( sNx*nSx, oLx, kSize, bi, bj, k,
+     I                         .FALSE., r8seg, fldRS )
+          ELSEIF ( arrType.EQ.'RL' ) THEN
+            CALL MDS_SEG8toRS_2D( sNx*nSx, oLx, kSize, bi, bj, k,
+     I                         .FALSE., r8seg, fldRL )
+          ELSE
+            WRITE(msgBuf,'(2A)')
+     &      ' MDS_WRITE_SEC_XZ: illegal value for arrType=', arrType
+            CALL PRINT_ERROR( msgBuf, myThid )
+            CALL ALL_PROC_DIE( myThid )
+            STOP 'ABNORMAL END: S/R MDS_WRITE_SEC_XZ'
+          ENDIF
+
+        ELSE
+          WRITE(msgBuf,'(A,I6)')
+     &      ' MDS_WRITE_SEC_XZ: illegal value for filePrec=',filePrec
+          CALL PRINT_ERROR( msgBuf, myThid )
+          CALL ALL_PROC_DIE( myThid )
+          STOP 'ABNORMAL END: S/R MDS_WRITE_SEC_XZ'
+        ENDIF
+C-     end of k loop
+       ENDDO
+
+C Wait for all threads to finish filling shared buffer
+       CALL BAR2( myThid )
+
+C Only do I/O if I am the master thread
+       IF ( iAmDoingIO ) THEN
+
+#ifdef _BYTESWAPIO
+        IF ( filePrec.EQ.precFloat32 ) THEN
+          CALL MDS_BYTESWAPR4( sNx*nSx, r4seg )
+        ELSE
+          CALL MDS_BYTESWAPR8( sNx*nSx, r8seg )
+        ENDIF
+#endif
 
 C If we are writing to a global file then we open it here
-      IF (globalFile) THEN
-       WRITE(dataFName,'(2A)') fName(1:IL),'.data'
-       IF (irecord .EQ. 1) THEN
-        length_of_rec = MDS_RECLEN( filePrec, sNx, myThid )
-        OPEN( dUnit, file=dataFName, status=_NEW_STATUS,
-     &        access='direct', recl=length_of_rec )
-        fileIsOpen=.TRUE.
-       ELSE
-        length_of_rec = MDS_RECLEN( filePrec, sNx, myThid )
-        OPEN( dUnit, file=dataFName, status='old',
-     &        access='direct', recl=length_of_rec )
-        fileIsOpen=.TRUE.
-       ENDIF
-      ENDIF
+        IF (globalFile) THEN
+          WRITE(dataFName,'(2a)') fName(1:IL),'.data'
+          length_of_rec = MDS_RECLEN( filePrec, sNx*nSx, myThid )
+          IF (irecord .EQ. 1) THEN
+           OPEN( dUnit, file=dataFName, status=_NEW_STATUS,
+     &             access='direct', recl=length_of_rec )
+          ELSE
+           OPEN( dUnit, file=dataFName, status=_OLD_STATUS,
+     &             access='direct', recl=length_of_rec )
+          ENDIF
+          fileIsOpen=.TRUE.
+        ENDIF
 
 C Loop over all tiles
-      DO bj=1,nSy
-       DO bi=1,nSx
-C If we are writing to a tiled MDS file then we open each one here
-        IF (.NOT. globalFile) THEN
-         iG=bi+(myXGlobalLo-1)/sNx
-         jG=bj+(myYGlobalLo-1)/sNy
-         WRITE(dataFName,'(2A,I3.3,A,I3.3,A)')
-     &              pfName(1:pIL),'.',iG,'.',jG,'.data'
-         IF (irecord .EQ. 1) THEN
-          length_of_rec = MDS_RECLEN( filePrec, sNx, myThid )
-          OPEN( dUnit, file=dataFName, status=_NEW_STATUS,
-     &          access='direct', recl=length_of_rec )
-          fileIsOpen=.TRUE.
-         ELSE
-          length_of_rec = MDS_RECLEN( filePrec, sNx, myThid )
-          OPEN( dUnit, file=dataFName, status='old',
-     &          access='direct', recl=length_of_rec )
-          fileIsOpen=.TRUE.
-         ENDIF
-        ENDIF
-        IF (fileIsOpen) THEN
+        DO bj=1,nSy
+         DO bi=1,nSx
+
+          tNx = sNx
+          global_nTx = xSize/sNx
+          tBx = myXGlobalLo-1 + (bi-1)*sNx
 #ifdef ALLOW_EXCH2
-C layout of global x-z section files is "xStack"
-         tN = W2_myTileList(bi,bj)
-         tGx = exch2_txXStackLo(tN)
-         tNx = exch2_tNx(tN)
-#endif /* ALLOW_EXCH2 */
-         DO k=1,kSize
-           IF (globalFile) THEN
-#ifdef ALLOW_EXCH2
-C record length is sNx==tNx
-            irec = 1 + ( tGx-1
-     &                   + ( k-1 + (irecord-1)*kSize )*exch2_xStack_Nx
-     &                 )/tNx
-#else /* ALLOW_EXCH2 */
-            iG = myXGlobalLo-1 + (bi-1)*sNx
-            jG = (myYGlobalLo-1)/sNy + (bj-1)
-            irec=1 + INT(iG/sNx) + nSx*nPx*(k-1)
-     &           + nSx*nPx*kSize*(irecord-1)
-#endif /* ALLOW_EXCH2 */
-           ELSE
-            iG = 0
-            jG = 0
-            irec=k + kSize*(irecord-1)
-           ENDIF
-           IF (filePrec .EQ. precFloat32) THEN
-            IF (arrType .EQ. 'RS') THEN
-             CALL MDS_SEG4toRS_2D( sNx,oLx,kSize,bi,bj,k,.FALSE.,
-     &                             r4seg,fldRS )
-            ELSEIF (arrType .EQ. 'RL') THEN
-             CALL MDS_SEG4toRL_2D( sNx,oLx,kSize,bi,bj,k,.FALSE.,
-     &                             r4seg,fldRL )
+          IF ( useExch2ioLayOut ) THEN
+            tN = W2_myTileList(bi,bj)
+c           tNx = exch2_tNx(tN)
+c           tNy = exch2_tNy(tN)
+c           global_nTx = exch2_global_Nx/tNx
+            tBx = exch2_txGlobalo(tN) - 1
+            IF   ( exch2_mydNx(tN) .GT. xSize ) THEN
+C-          face x-size larger than glob-size : fold it
+              iGjLoc = 0
+              jGjLoc = exch2_mydNx(tN) / xSize
             ELSE
-             WRITE(msgBuf,'(A)')
-     &         ' MDS_WRITE_SEC_XZ: illegal value for arrType'
-             CALL PRINT_ERROR( msgBuf, myThid )
-             STOP 'ABNORMAL END: S/R MDS_WRITE_SEC_XZ'
+C-          default (face fit into global-IO-array)
+              iGjLoc = 0
+              jGjLoc = 1
             ENDIF
-#ifdef _BYTESWAPIO
-            CALL MDS_BYTESWAPR4(sNx,r4seg)
-#endif
-            WRITE(dUnit,rec=irec) r4seg
-           ELSEIF (filePrec .EQ. precFloat64) THEN
-            IF (arrType .EQ. 'RS') THEN
-             CALL MDS_SEG8toRS_2D( sNx,oLx,kSize,bi,bj,k,.FALSE.,
-     &                             r8seg,fldRS )
-            ELSEIF (arrType .EQ. 'RL') THEN
-             CALL MDS_SEG8toRL_2D( sNx,oLx,kSize,bi,bj,k,.FALSE.,
-     &                             r8seg,fldRL )
+          ENDIF
+#endif /* ALLOW_EXCH2 */
+
+          IF (globalFile) THEN
+C--- Case of 1 Global file:
+
+           DO k=kLo,kHi
+            irec = 1 + tBx/tNx
+     &           +( k-kLo + (irecord-1)*kSize )*global_nTx
+            IF ( filePrec.EQ.precFloat32 ) THEN
+             WRITE(dUnit,rec=irec) r4seg
             ELSE
-             WRITE(msgBuf,'(A)')
-     &         ' MDS_WRITE_SEC_XZ: illegal value for arrType'
-             CALL PRINT_ERROR( msgBuf, myThid )
-             STOP 'ABNORMAL END: S/R MDS_WRITE_SEC_XZ'
+             WRITE(dUnit,rec=irec) r8seg
             ENDIF
-#ifdef _BYTESWAPIO
-            CALL MDS_BYTESWAPR8( sNx, r8seg )
-#endif
-            WRITE(dUnit,rec=irec) r8seg
-           ELSE
-            WRITE(msgBuf,'(A)')
-     &        ' MDS_WRITE_SEC_XZ: illegal value for filePrec'
-            CALL PRINT_ERROR( msgBuf, myThid )
-            STOP 'ABNORMAL END: S/R MDS_WRITE_SEC_XZ'
-           ENDIF
 C End of k loop
-         ENDDO
-        ELSE
-         WRITE(msgBuf,'(A)')
-     &     ' MDS_WRITE_SEC_XZ: I should never get to this point'
-         CALL PRINT_ERROR( msgBuf, myThid )
-         STOP 'ABNORMAL END: S/R MDS_WRITE_SEC_XZ'
-        ENDIF
-C If we were writing to a tiled MDS file then we close it here
-        IF (fileIsOpen .AND. (.NOT. globalFile)) THEN
-         CLOSE( dUnit )
-         fileIsOpen = .FALSE.
-        ENDIF
+           ENDDO
+
+          ELSE
+C--- Case of 1 file per tile (globalFile=F):
+
+C If we are writing to a tiled MDS file then we open each one here
+           iG=bi+(myXGlobalLo-1)/sNx
+           jG=bj+(myYGlobalLo-1)/sNy
+           WRITE(dataFName,'(2A,I3.3,A,I3.3,A)')
+     &            pfName(1:pIL),'.',iG,'.',jG,'.data'
+           length_of_rec = MDS_RECLEN( filePrec, sNx, myThid )
+           IF (irecord .EQ. 1) THEN
+            OPEN( dUnit, file=dataFName, status=_NEW_STATUS,
+     &            access='direct', recl=length_of_rec )
+           ELSE
+            OPEN( dUnit, file=dataFName, status=_OLD_STATUS,
+     &            access='direct', recl=length_of_rec )
+           ENDIF
+           fileIsOpen=.TRUE.
+
+           irec = k+kSize*(irecord-1)
+           IF ( filePrec.EQ.precFloat32 ) THEN
+             WRITE(dUnit,rec=irec) r4seg
+           ELSE
+             WRITE(dUnit,rec=irec) r8seg
+           ENDIF
+
+C here We close the tiled MDS file
+           IF ( fileIsOpen ) THEN
+             CLOSE( dUnit )
+             fileIsOpen = .FALSE.
+           ENDIF
+
+C--- End Global File / tile-file cases
+          ENDIF
+
+C Create meta-file for each tile if we are tiling
+          IF ( .NOT.globalFile .AND. writeMetaF ) THEN
+           iG=bi+(myXGlobalLo-1)/sNx
+           jG=bj+(myYGlobalLo-1)/sNy
+           WRITE(metaFname,'(2A,I3.3,A,I3.3,A)')
+     &              pfName(1:pIL),'.',iG,'.',jG,'.meta'
+           dimList(1,1) = xSize
+           dimList(2,1) = tBx + 1
+           dimList(3,1) = tBx + tNx
+           dimList(1,2) = nNz
+           dimList(2,2) = 1
+           dimList(3,2) = nNz
+           nDims = 2
+           IF ( nNz.EQ.1 ) nDims = 1
+           map2gl(1) = iGjLoc
+           map2gl(2) = jGjLoc
+           CALL MDS_WRITE_META(
+     I              metaFName, dataFName, the_run_name, ' ',
+     I              filePrec, nDims, dimList, map2gl, 0, blank8c,
+     I              0, dummyRL, oneRL, irecord, myIter, myThid )
+          ENDIF
+
 C End of bi,bj loops
-       ENDDO
-      ENDDO
+         ENDDO
+        ENDDO
 
 C If global file was opened then close it
-      IF (fileIsOpen .AND. globalFile) THEN
-       CLOSE( dUnit )
-       fileIsOpen = .FALSE.
+        IF (fileIsOpen .AND. globalFile) THEN
+          CLOSE( dUnit )
+          fileIsOpen = .FALSE.
+        ENDIF
+
+C- endif iAmDoingIO
+       ENDIF
+
+C Make other threads wait for I/O completion so that after this,
+C  3-D buffer can again be modified by any thread
+c      CALL BAR2( myThid )
+
+C     if useSingleCpuIO / else / end
       ENDIF
 
-      _END_MASTER( myThid )
+C Create meta-file for the global-file (also if useSingleCpuIO)
+      IF ( writeMetaF .AND. iAmDoingIO .AND.
+     &    (globalFile .OR. useSingleCpuIO) ) THEN
+         WRITE(metaFName,'(2A)') fName(1:IL),'.meta'
+         dimList(1,1) = xSize
+         dimList(2,1) = 1
+         dimList(3,1) = xSize
+         dimList(1,2) = nNz
+         dimList(2,2) = 1
+         dimList(3,2) = nNz
+         nDims = 2
+         IF ( nNz.EQ.1 ) nDims = 1
+         map2gl(1) = 0
+         map2gl(2) = 1
+         CALL MDS_WRITE_META(
+     I              metaFName, dataFName, the_run_name, ' ',
+     I              filePrec, nDims, dimList, map2gl, 0, blank8c,
+     I              0, dummyRL, oneRL, irecord, myIter, myThid )
+c    I              metaFName, dataFName, the_run_name, titleLine,
+c    I              filePrec, nDims, dimList, map2gl, nFlds,  fldList,
+c    I              nTimRec, timList, misVal, irecord, myIter, myThid )
+      ENDIF
 
-C     ------------------------------------------------------------------
+C---+----1----+----2----+----3----+----4----+----5----+----6----+----7-|--+----|
       RETURN
       END
 
@@ -270,40 +651,63 @@ C !INTERFACE:
      I   globalFile,
      I   useCurrentDir,
      I   arrType,
-     I   kSize,
+     I   kSize,kLo,kHi,
      I   fldRL, fldRS,
-     I   irecord,
+     I   jrecord,
      I   myIter,
      I   myThid )
 
-C !DESCRIPTION
+C !DESCRIPTION:
 C Arguments:
 C
-C fName       string  :: base name for file to read
-C filePrec    integer :: number of bits per word in file (32 or 64)
-C globalFile  logical :: selects between writing a global or tiled file
-C useCurrentDir logic :: always write to the current directory (even if
+C fName     (string)  :: base name for file to write
+C filePrec  (integer) :: number of bits per word in file (32 or 64)
+C globalFile (logical):: selects between writing a global or tiled file
+C useCurrentDir(logic):: always write to the current directory (even if
 C                        "mdsioLocalDir" is set)
-C arrType     char(2) :: which array (fldRL/RS) to write, either "RL" or "RS"
-C kSize       integer :: size of third dimension, normally either 1 or Nr
-C fldRL         RL    :: array to write if arrType="RL", fldRL(:,kSize,:,:)
-C fldRS         RS    :: array to write if arrType="RS", fldRS(:,kSize,:,:)
-C irecord     integer :: record number to read
-C myIter      integer :: time step number
-C myThid      integer :: thread identifier
+C arrType   (char(2)) :: which array (fldRL/RS) to write, either "RL" or "RS"
+C kSize     (integer) :: size of third dimension: normally either 1 or Nr
+C kLo       (integer) :: 1rst vertical level (of array fldRL/RS) to write
+C kHi       (integer) :: last vertical level (of array fldRL/RS) to write
+C fldRL       ( RL )  :: array to write if arrType="RL", fldRL(:,:,kSize,:,:)
+C fldRS       ( RS )  :: array to write if arrType="RS", fldRS(:,:,kSize,:,:)
+C irecord   (integer) :: record number to write
+C myIter    (integer) :: time step number
+C myThid    (integer) :: thread identifier
 C
-C MDS_WRITE_SEC_YZ creates either a file of the form "fName.data"
-C if the logical flag "globalFile" is set true. Otherwise
-C it creates MDS tiled files of the form "fName.xxx.yyy.data".
-C The precision of the file is decsribed by filePrec, set either
-C  to floatPrec32 or floatPrec64. The char*(2) string arrType, either "RL"
-C  or "RS", selects which array is written, either fldRL or fldRS.
-C This routine writes vertical slices (Y-Z) including overlap regions.
-C irecord is the record number to be read and must be >= 1.
-C NOTE: It is currently assumed that
-C the highest record number in the file was the last record written.
+C MDS_WRITE_SEC_YZ creates either a file of the form "fName.data" and
+C  "fName.meta" if the logical flag "globalFile" is set true. Otherwise
+C  it creates MDS tiled files of the form "fName.xxx.yyy.data" and
+C  "fName.xxx.yyy.meta". If jrecord > 0, a meta-file is created.
+C Currently, the meta-files are not read because it is difficult
+C  to parse files in fortran. We should read meta information before
+C  adding records to an existing multi-record file.
+C The precision of the file is described by filePrec, set either
+C  to floatPrec32 or floatPrec64. The char*(2) string arrType, either
+C  "RL" or "RS", selects which array is written, either fldRL or fldRS.
+C (kSize,kLo,kHi) allows for both 2-D and 3-D arrays to be handled, with
+C  the option to only write a sub-set of consecutive vertical levels (from
+C  kLo to kHi); (kSize,kLo,kHi)=(1,1,1) implies a 2-D model field and
+C  (kSize,kLo,kHi)=(Nr,1,Nr) implies a 3-D model field.
+C irecord=|jrecord| is the record number to be written and must be >= 1.
+C NOTE: It is currently assumed that the highest record number in the file
+C  was the last record written. Nor is there a consistency check between the
+C  routine arguments and file, i.e., if you write record 2 after record 4
+C  the meta information will record the number of records to be 2. This,
+C  again, is because we have read the meta information. To be fixed.
+C
+C- Multi-threaded: Only Master thread does IO (and MPI calls) and get data
+C   from a shared buffer that any thread can copy to.
+C- Convention regarding thread synchronisation (BARRIER):
+C  A per-thread (or per tile) partition of the 2-D shared-buffer (sharedLocBuf_r4/r8)
+C   is readily available => any access (e.g., by master-thread) to a portion
+C   owned by an other thread is put between BARRIER (protected).
+C  No thread partition exist for the 3-D shared buffer (shared3dBuf_r4/r8);
+C   Therefore, the 3-D buffer is considered to be owned by master-thread and
+C   any access by other than master thread is put between BARRIER (protected).
 C
 C Modified: 06/02/00 spk@ocean.mit.edu
+C Modified: 08/03/20 - style copied from mdsio_write_field timsmith204@utexas.edu 
 CEOP
 
 C !USES:
@@ -313,10 +717,15 @@ C Global variables / common blocks
 #include "EEPARAMS.h"
 #include "PARAMS.h"
 #ifdef ALLOW_EXCH2
-#include "W2_EXCH2_SIZE.h"
-#include "W2_EXCH2_TOPOLOGY.h"
-#include "W2_EXCH2_PARAMS.h"
+# include "W2_EXCH2_SIZE.h"
+# include "W2_EXCH2_TOPOLOGY.h"
+# include "W2_EXCH2_PARAMS.h"
 #endif /* ALLOW_EXCH2 */
+#include "EEBUFF_SCPU.h"
+#ifdef ALLOW_FIZHI
+# include "fizhi_SIZE.h"
+#endif /* ALLOW_FIZHI */
+#include "MDSIO_BUFF_3D.h"
 
 C !INPUT PARAMETERS:
       CHARACTER*(*) fName
@@ -324,190 +733,544 @@ C !INPUT PARAMETERS:
       LOGICAL globalFile
       LOGICAL useCurrentDir
       CHARACTER*(2) arrType
-      INTEGER kSize
-      _RL  fldRL(*)
-      _RS  fldRS(*)
-      INTEGER irecord
+      INTEGER kSize, kLo, kHi
+      _RL fldRL(*)
+      _RS fldRS(*)
+      INTEGER jrecord
       INTEGER myIter
       INTEGER myThid
 C !OUTPUT PARAMETERS:
 
-C !FUNCTIONS:
-      INTEGER ILNBLNK
-      INTEGER MDS_RECLEN
-      EXTERNAL ILNBLNK, MDS_RECLEN
+C !FUNCTIONS
+      INTEGER  ILNBLNK
+      INTEGER  MDS_RECLEN
+      LOGICAL  MASTER_CPU_IO
+      EXTERNAL ILNBLNK
+      EXTERNAL MDS_RECLEN
+      EXTERNAL MASTER_CPU_IO
 
 C !LOCAL VARIABLES:
-      CHARACTER*(MAX_LEN_FNAM) dataFName,pfName
-      INTEGER iG,jG,irec,bi,bj,k,dUnit,IL,pIL
-      Real*4 r4seg(sNy)
-      Real*8 r8seg(sNy)
-      INTEGER length_of_rec
+C     bBij  :: base shift in Buffer index for tile bi,bj
+      CHARACTER*(MAX_LEN_FNAM) dataFName,metaFName,pfName
+      CHARACTER*(MAX_LEN_MBUF) msgBuf
       LOGICAL fileIsOpen
-      CHARACTER*(max_len_mbuf) msgBuf
+      LOGICAL iAmDoingIO
+      LOGICAL writeMetaF
+      LOGICAL useExch2ioLayOut
+      LOGICAL zeroBuff
+      INTEGER xSize, ySize
+      INTEGER irecord
+      INTEGER iG,jG,bi,bj
+      INTEGER i1,i2,i,j,k,nNz
+      INTEGER irec,dUnit,IL,pIL
+      INTEGER dimList(3,2), nDims, map2gl(2)
+      INTEGER length_of_rec
+      INTEGER tNy, global_nTy
+      INTEGER tBy, iGjLoc, jGjLoc
+      REAL*4 r4seg(sNy*nSy)
+      REAL*8 r8seg(sNy*nSy)
+      REAL*4 y_layer_buffer_r4(Ny)
+      REAL*8 y_layer_buffer_r8(Ny)
 #ifdef ALLOW_EXCH2
-      INTEGER tGy,tNy,tN
+      INTEGER tN
+      REAL*4 y_layer_buffer_exch2_r4(exch2_global_Ny)
+      REAL*8 y_layer_buffer_exch2_r8(exch2_global_Ny)
 #endif /* ALLOW_EXCH2 */
-C     ------------------------------------------------------------------
+      _RL dummyRL(1)
+      CHARACTER*8 blank8c
 
-C Only do I/O if I am the master thread
-      _BEGIN_MASTER( myThid )
+      DATA dummyRL(1) / 0. _d 0 /
+      DATA blank8c / '        ' /
 
-C Record number must be >= 1
-      IF (irecord .LT. 1) THEN
-       WRITE(msgBuf,'(A,I9.8)')
-     &   ' MDS_WRITE_SEC_YZ: argument irecord = ',irecord
-       CALL PRINT_MESSAGE( msgBuf, standardMessageUnit,
-     &                     SQUEEZE_RIGHT , myThid)
-       WRITE(msgBuf,'(A)')
-     &   ' MDS_WRITE_SEC_YZ: invalid value for irecord'
-       CALL PRINT_ERROR( msgBuf, myThid )
-       STOP 'ABNORMAL END: S/R MDS_WRITE_SEC_YZ'
+C---+----1----+----2----+----3----+----4----+----5----+----6----+----7-|--+----|
+C Set dimensions:
+      xSize = 1
+      ySize = Ny
+      useExch2ioLayOut = .FALSE.
+#ifdef ALLOW_EXCH2
+      IF ( W2_useE2ioLayOut ) THEN
+        xSize = 1
+        ySize = exch2_global_Ny
+        useExch2ioLayOut = .TRUE.
       ENDIF
+#endif /* ALLOW_EXCH2 */
+
+C-    default:
+      iGjLoc = 0
+      jGjLoc = 1
 
 C Assume nothing
-      fileIsOpen=.FALSE.
+      fileIsOpen = .FALSE.
       IL  = ILNBLNK( fName )
       pIL = ILNBLNK( mdsioLocalDir )
+      nNz = 1 + kHi - kLo
+      irecord = ABS(jrecord)
+      writeMetaF = jrecord.GT.0
+
+C Only do I/O if I am the master thread (and mpi process 0 IF useSingleCpuIO):
+      iAmDoingIO = MASTER_CPU_IO(myThid)
+
+C File name should not be too long:
+C    IL(+pIL if not useCurrentDir)(+5: '.data')(+8: bi,bj) =< MAX_LEN_FNAM
+C    and shorter enough to be written to msgBuf with other informations
+      IF ( useCurrentDir .AND. (90+IL).GT.MAX_LEN_MBUF ) THEN
+        WRITE(msgBuf,'(2A,2(I4,A))') 'MDS_WRITE_SEC_YZ: ',
+     &   'Too long (IL=',IL,') file name:'
+        CALL PRINT_ERROR( msgBuf, myThid )
+        WRITE(errorMessageUnit,'(3A)')'file: >',fName(1:IL),'<'
+        CALL ALL_PROC_DIE( myThid )
+        STOP 'ABNORMAL END: S/R MDS_WRITE_SEC_YZ'
+      ELSEIF ( (90+IL+pIL).GT.MAX_LEN_MBUF ) THEN
+        WRITE(msgBuf,'(2A,2(I4,A))') 'MDS_WRITE_SEC_YZ: ',
+     &   'Too long (pIL=',pIL,', IL=',IL,') pfix + file name:'
+        CALL PRINT_ERROR( msgBuf, myThid )
+        WRITE(errorMessageUnit,'(3A)')'pfix: >',mdsioLocalDir(1:pIL),'<'
+        WRITE(errorMessageUnit,'(3A)')'file: >',fName(1:IL),'<'
+        CALL ALL_PROC_DIE( myThid )
+        STOP 'ABNORMAL END: S/R MDS_WRITE_SEC_YZ'
+      ENDIF
+C Record number must be >= 1
+      IF (irecord .LT. 1) THEN
+        WRITE(msgBuf,'(3A,I10)')
+     &    ' MDS_WRITE_SEC_YZ: file="', fName(1:IL), '" , iter=', myIter
+        CALL PRINT_MESSAGE( msgBuf, errorMessageUnit,
+     &                      SQUEEZE_RIGHT, myThid )
+        WRITE(msgBuf,'(A,I9.8)')
+     &    ' MDS_WRITE_SEC_YZ: argument irecord = ',irecord
+        CALL PRINT_MESSAGE( msgBuf, errorMessageUnit,
+     &                      SQUEEZE_RIGHT, myThid )
+        WRITE(msgBuf,'(A)')
+     &    ' MDS_WRITE_SEC_YZ: invalid value for irecord'
+        CALL PRINT_ERROR( msgBuf, myThid )
+        CALL ALL_PROC_DIE( myThid )
+        STOP 'ABNORMAL END: S/R MDS_WRITE_SEC_YZ'
+      ENDIF
+C check for valid sub-set of levels:
+      IF ( kLo.LT.1 .OR. kHi.GT.kSize ) THEN
+        WRITE(msgBuf,'(3A,I10)')
+     &    ' MDS_WRITE_SEC_YZ: file="', fName(1:IL), '" , iter=', myIter
+        CALL PRINT_MESSAGE( msgBuf, errorMessageUnit,
+     &                      SQUEEZE_RIGHT, myThid )
+        WRITE(msgBuf,'(3(A,I6))')
+     &    ' MDS_WRITE_SEC_YZ: arguments kSize=', kSize,
+     &    ' , kLo=', kLo, ' , kHi=', kHi
+        CALL PRINT_MESSAGE( msgBuf, errorMessageUnit,
+     &                      SQUEEZE_RIGHT, myThid )
+        WRITE(msgBuf,'(A)')
+     &    ' MDS_WRITE_SEC_YZ: invalid sub-set of levels'
+        CALL PRINT_ERROR( msgBuf, myThid )
+        CALL ALL_PROC_DIE( myThid )
+        STOP 'ABNORMAL END: S/R MDS_WRITE_SEC_YZ'
+      ENDIF
+C check for 3-D Buffer size:
+      IF ( .NOT.useSingleCpuIO .AND. nNz.GT.size3dBuf ) THEN
+        WRITE(msgBuf,'(3A,I10)')
+     &    ' MDS_WRITE_SEC_YZ: file="', fName(1:IL), '" , iter=', myIter
+        CALL PRINT_MESSAGE( msgBuf, errorMessageUnit,
+     &                      SQUEEZE_RIGHT, myThid )
+        WRITE(msgBuf,'(3(A,I6))')
+     &    ' MDS_WRITE_SEC_YZ: Nb Lev to write =', nNz,
+     &    ' >', size3dBuf, ' = buffer 3rd Dim'
+        CALL PRINT_MESSAGE( msgBuf, errorMessageUnit,
+     &                      SQUEEZE_RIGHT, myThid )
+        WRITE(msgBuf,'(A)')
+     &    ' MDS_WRITE_SEC_YZ: buffer 3rd Dim. too small'
+        CALL PRINT_ERROR( msgBuf, myThid )
+        WRITE(msgBuf,'(A)')
+     &    ' increase "size3dBuf" in "MDSIO_BUFF_3D.h" and recompile'
+        CALL PRINT_MESSAGE( msgBuf, errorMessageUnit,
+     &                      SQUEEZE_RIGHT, myThid)
+        CALL ALL_PROC_DIE( myThid )
+        STOP 'ABNORMAL END: S/R MDS_WRITE_SEC_YZ'
+      ENDIF
+
+C Only do I/O if I am the master thread
+      IF ( iAmDoingIO ) THEN
 
 C Assign special directory
-      IF ( useCurrentDir .OR. pIL.EQ.0 ) THEN
-       pfName= fName
-      ELSE
-       WRITE(pfName,'(2a)') mdsioLocalDir(1:pIL), fName(1:IL)
-      ENDIF
-      pIL=ILNBLNK( pfName )
+        IF ( useCurrentDir .OR. pIL.EQ.0 ) THEN
+         pfName = fName
+        ELSE
+         WRITE(pfName,'(2A)') mdsioLocalDir(1:pIL), fName(1:IL)
+        ENDIF
+        pIL=ILNBLNK( pfName )
+        IF ( debugLevel .GE. debLevC ) THEN
+          WRITE(msgBuf,'(A,I8,I6,3I4,2A)')
+     &      ' MDS_WRITE_SEC_YZ: it,rec,kS,kL,kH=', myIter, jrecord,
+     &      kSize, kLo, kHi, ' file=', pfName(1:pIL)
+          CALL PRINT_MESSAGE( msgBuf, standardMessageUnit,
+     &                        SQUEEZE_RIGHT, myThid )
+        ENDIF
 
 C Assign a free unit number as the I/O channel for this routine
-      CALL MDSFINDUNIT( dUnit, myThid )
+        CALL MDSFINDUNIT( dUnit, myThid )
+
+C- endif iAmDoingIO
+      ENDIF
+
+C If option globalFile is desired but does not work or if
+C globalFile is too slow, then try using single-CPU I/O.
+      IF (useSingleCpuIO) THEN
+
+C Master thread of process 0, only, opens a global file
+       IF ( iAmDoingIO ) THEN
+         WRITE(dataFName,'(2a)') fName(1:IL),'.data'
+         length_of_rec = MDS_RECLEN( filePrec, sNy*nSy, myThid )
+         IF (irecord .EQ. 1) THEN
+          OPEN( dUnit, file=dataFName, status=_NEW_STATUS,
+     &        access='direct', recl=length_of_rec )
+         ELSE
+          OPEN( dUnit, file=dataFName, status=_OLD_STATUS,
+     &        access='direct', recl=length_of_rec )
+         ENDIF
+       ENDIF
+
+C Gather array and write it to file, one vertical level at a time
+       DO k=kLo,kHi
+        zeroBuff = k.EQ.kLo
+C-      copy from fldRL/RS(level=k) to 2-D "local":
+        IF ( filePrec.EQ.precFloat32 ) THEN
+          IF ( arrType.EQ.'RS' ) THEN
+            CALL MDS_SEG4toRS_2D( sNy*nSy, oLy, kSize, bi, bj, k,
+     &                            .FALSE., r4seg, fldRS )
+          ELSEIF ( arrType.EQ.'RL' ) THEN
+            CALL MDS_SEG4toRS_2D( sNy*nSy, oLy, kSize, bi, bj, k,
+     &                            .FALSE., r4seg, fldRL )
+          ELSE
+            WRITE(msgBuf,'(2A)')
+     &      ' MDS_WRITE_SEC_YZ: illegal value for arrType=', arrType
+            CALL PRINT_ERROR( msgBuf, myThid )
+            CALL ALL_PROC_DIE( myThid )
+            STOP 'ABNORMAL END: S/R MDS_WRITE_SEC_YZ'
+          ENDIF
+C Wait for all threads to finish filling shared buffer
+          CALL BAR2( myThid )
+#ifdef ALLOW_EXCH2
+          IF ( .not.W2_useE2ioLayOut ) THEN
+#endif
+            CALL GATHER_VEC_R4( 
+     O                         y_layer_buffer_r4,
+     I                         r4seg, 
+     I                         ySize, myThid ) 
+#ifdef ALLOW_EXCH2
+          ELSE
+
+            CALL GATHER_VEC_R4( 
+     O                         y_layer_buffer_exch2_r4,
+     I                         r4seg, 
+     I                         ySize, myThid ) 
+          ENDIF
+#endif
+
+        ELSEIF ( filePrec.EQ.precFloat64 ) THEN
+          IF ( arrType.EQ.'RS' ) THEN
+            CALL MDS_SEG8toRS_2D( sNy*nSy, oLy, kSize, bi, bj, k,
+     I                         .FALSE., r8seg, fldRS )
+          ELSEIF ( arrType.EQ.'RL' ) THEN
+            CALL MDS_SEG8toRS_2D( sNy*nSy, oLy, kSize, bi, bj, k,
+     I                         .FALSE., r8seg, fldRL )
+          ELSE
+            WRITE(msgBuf,'(2A)')
+     &      ' MDS_WRITE_SEC_YZ: illegal value for arrType=', arrType
+            CALL PRINT_ERROR( msgBuf, myThid )
+            CALL ALL_PROC_DIE( myThid )
+            STOP 'ABNORMAL END: S/R MDS_WRITE_SEC_YZ'
+          ENDIF
+C Wait for all threads to finish filling shared buffer
+          CALL BAR2( myThid )
+#ifdef ALLOW_EXCH2
+          IF ( .not.W2_useE2ioLayOut ) THEN
+#endif
+            CALL GATHER_VEC_R8( 
+     O                         y_layer_buffer_r8,
+     I                         r8seg, 
+     I                         ySize, myThid ) 
+#ifdef ALLOW_EXCH2
+          ELSE
+
+            CALL GATHER_VEC_R8( 
+     O                          y_layer_buffer_exch2_r8,
+     I                          r8seg, 
+     I                          ySize, myThid ) 
+          ENDIF
+#endif
+        ELSE
+          WRITE(msgBuf,'(A,I6)')
+     &      ' MDS_WRITE_SEC_YZ: illegal value for filePrec=',filePrec
+          CALL PRINT_ERROR( msgBuf, myThid )
+          CALL ALL_PROC_DIE( myThid )
+          STOP 'ABNORMAL END: S/R MDS_WRITE_SEC_YZ'
+        ENDIF
+C Make other threads wait for "gather" completion so that after this,
+C  shared buffer can again be modified by any thread
+        CALL BAR2( myThid )
+
+        IF ( iAmDoingIO ) THEN
+          irec = 1 + k-kLo + (irecord-1)*kSize
+          IF ( filePrec.EQ.precFloat32 ) THEN
+
+#ifdef ALLOW_EXCH2
+           IF ( .not.W2_useE2ioLayOut ) THEN
+#endif
+# ifdef _BYTESWAPIO
+            CALL MDS_BYTESWAPR4( ySize, y_layer_buffer_r4 )
+# endif
+            WRITE(dUnit,rec=irec) y_layer_buffer_r4
+#ifdef ALLOW_EXCH2
+           ELSE
+# ifdef _BYTESWAPIO
+            CALL MDS_BYTESWAPR4( ySize, y_layer_buffer_exch2_r4 )
+# endif
+            WRITE(dUnit,rec=irec) y_layer_buffer_exch2_r4
+           ENDIF
+#endif
+          ELSE
+
+#ifdef ALLOW_EXCH2
+           IF ( .not.W2_useE2ioLayOut ) THEN
+#endif
+# ifdef _BYTESWAPIO
+            CALL MDS_BYTESWAPR8( ySize, y_layer_buffer_r8 )
+# endif
+            WRITE(dUnit,rec=irec) y_layer_buffer_r8
+#ifdef ALLOW_EXCH2
+           ELSE
+# ifdef _BYTESWAPIO
+            CALL MDS_BYTESWAPR8( ySize, y_layer_buffer_exch2_r8 )
+# endif
+            WRITE(dUnit,rec=irec) y_layer_buffer_exch2_r8
+           ENDIF
+#endif
+          ENDIF
+C-      end if iAmDoingIO
+        ENDIF
+C-     end of k loop
+       ENDDO
+
+C Close data-file
+       IF ( iAmDoingIO ) THEN
+         CLOSE( dUnit )
+       ENDIF
+
+C---+----1----+----2----+----3----+----4----+----5----+----6----+----7-|--+----|
+C---  else .NOT.useSingleCpuIO
+      ELSE
+
+C Wait for all thread to finish. This prevents other threads (e.g., master)
+C  to continue to acces 3-D buffer while this thread is filling it.
+        CALL BAR2( myThid )
+
+C---    Copy from fldRL/RS to 3-D buffer (multi-threads):
+       DO k=kLo,kHi
+        zeroBuff = k.EQ.kLo
+C-      copy from fldRL/RS(level=k) to 2-D "local":
+        IF ( filePrec.EQ.precFloat32 ) THEN
+          IF ( arrType.EQ.'RS' ) THEN
+            CALL MDS_SEG4toRS_2D( sNy*nSy, oLy, kSize, bi, bj, k,
+     &                            .FALSE., r4seg, fldRS )
+          ELSEIF ( arrType.EQ.'RL' ) THEN
+            CALL MDS_SEG4toRS_2D( sNy*nSy, oLy, kSize, bi, bj, k,
+     &                            .FALSE., r4seg, fldRL )
+          ELSE
+            WRITE(msgBuf,'(2A)')
+     &      ' MDS_WRITE_SEC_YZ: illegal value for arrType=', arrType
+            CALL PRINT_ERROR( msgBuf, myThid )
+            CALL ALL_PROC_DIE( myThid )
+            STOP 'ABNORMAL END: S/R MDS_WRITE_SEC_YZ'
+          ENDIF
+
+        ELSEIF ( filePrec.EQ.precFloat64 ) THEN
+          IF ( arrType.EQ.'RS' ) THEN
+            CALL MDS_SEG8toRS_2D( sNy*nSy, oLy, kSize, bi, bj, k,
+     I                         .FALSE., r8seg, fldRS )
+          ELSEIF ( arrType.EQ.'RL' ) THEN
+            CALL MDS_SEG8toRS_2D( sNy*nSy, oLy, kSize, bi, bj, k,
+     I                         .FALSE., r8seg, fldRL )
+          ELSE
+            WRITE(msgBuf,'(2A)')
+     &      ' MDS_WRITE_SEC_YZ: illegal value for arrType=', arrType
+            CALL PRINT_ERROR( msgBuf, myThid )
+            CALL ALL_PROC_DIE( myThid )
+            STOP 'ABNORMAL END: S/R MDS_WRITE_SEC_YZ'
+          ENDIF
+
+        ELSE
+          WRITE(msgBuf,'(A,I6)')
+     &      ' MDS_WRITE_SEC_YZ: illegal value for filePrec=',filePrec
+          CALL PRINT_ERROR( msgBuf, myThid )
+          CALL ALL_PROC_DIE( myThid )
+          STOP 'ABNORMAL END: S/R MDS_WRITE_SEC_YZ'
+        ENDIF
+C-     end of k loop
+       ENDDO
+
+C Wait for all threads to finish filling shared buffer
+       CALL BAR2( myThid )
+
+C Only do I/O if I am the master thread
+       IF ( iAmDoingIO ) THEN
+
+#ifdef _BYTESWAPIO
+        IF ( filePrec.EQ.precFloat32 ) THEN
+          CALL MDS_BYTESWAPR4( sNy*nSy, r4seg )
+        ELSE
+          CALL MDS_BYTESWAPR8( sNy*nSy, r8seg )
+        ENDIF
+#endif
 
 C If we are writing to a global file then we open it here
-      IF (globalFile) THEN
-       WRITE(dataFName,'(2A)') fName(1:IL),'.data'
-       IF (irecord .EQ. 1) THEN
-        length_of_rec = MDS_RECLEN( filePrec, sNy, myThid )
-        OPEN( dUnit, file=dataFName, status=_NEW_STATUS,
-     &        access='direct', recl=length_of_rec )
-        fileIsOpen=.TRUE.
-       ELSE
-        length_of_rec = MDS_RECLEN( filePrec, sNy, myThid )
-        OPEN( dUnit, file=dataFName, status='old',
-     &        access='direct', recl=length_of_rec )
-        fileIsOpen=.TRUE.
-       ENDIF
-      ENDIF
+        IF (globalFile) THEN
+          WRITE(dataFName,'(2a)') fName(1:IL),'.data'
+          length_of_rec = MDS_RECLEN( filePrec, sNy*nSy, myThid )
+          IF (irecord .EQ. 1) THEN
+           OPEN( dUnit, file=dataFName, status=_NEW_STATUS,
+     &             access='direct', recl=length_of_rec )
+          ELSE
+           OPEN( dUnit, file=dataFName, status=_OLD_STATUS,
+     &             access='direct', recl=length_of_rec )
+          ENDIF
+          fileIsOpen=.TRUE.
+        ENDIF
 
 C Loop over all tiles
-      DO bj=1,nSy
-       DO bi=1,nSx
-C If we are writing to a tiled MDS file then we open each one here
-        IF (.NOT. globalFile) THEN
-         iG=bi+(myXGlobalLo-1)/sNx
-         jG=bj+(myYGlobalLo-1)/sNy
-         WRITE(dataFName,'(2A,I3.3,A,I3.3,A)')
-     &              pfName(1:pIL),'.',iG,'.',jG,'.data'
-         IF (irecord .EQ. 1) THEN
-          length_of_rec = MDS_RECLEN( filePrec, sNy, myThid )
-          OPEN( dUnit, file=dataFName, status=_NEW_STATUS,
-     &          access='direct', recl=length_of_rec )
-          fileIsOpen=.TRUE.
-         ELSE
-          length_of_rec = MDS_RECLEN( filePrec, sNy, myThid )
-          OPEN( dUnit, file=dataFName, status='old',
-     &          access='direct', recl=length_of_rec )
-          fileIsOpen=.TRUE.
-         ENDIF
-        ENDIF
-        IF (fileIsOpen) THEN
+        DO bj=1,nSx
+         DO bi=1,nSy
+
+          tNy = sNy
+          global_nTy = ySize/sNy
+          tBy = myYGlobalLo-1 + (bj-1)*sNy
 #ifdef ALLOW_EXCH2
-C layout of global y-z section files is "yStack"
-         tN = W2_myTileList(bi,bj)
-         tGy = exch2_tyYStackLo(tN)
-         tNy = exch2_tNy(tN)
-#endif /* ALLOW_EXCH2 */
-         DO k=1,kSize
-           IF (globalFile) THEN
-#ifdef ALLOW_EXCH2
-C record length is sNy==tNy
-            irec = 1 + ( tGy-1
-     &                   + ( k-1 + (irecord-1)*kSize )*exch2_yStack_Ny
-     &                 )/tNy
-#else /* ALLOW_EXCH2 */
-            iG = (myXGlobalLo-1)/sNx + (bi-1)
-            jG = myYGlobalLo-1 + (bj-1)*sNy
-            irec=1 + INT(jG/sNy) + nSy*nPy*(k-1)
-     &           + nSy*nPy*kSize*(irecord-1)
-#endif /* ALLOW_EXCH2 */
-           ELSE
-            iG = 0
-            jG = 0
-            irec=k + kSize*(irecord-1)
-           ENDIF
-           IF (filePrec .EQ. precFloat32) THEN
-            IF (arrType .EQ. 'RS') THEN
-             CALL MDS_SEG4toRS_2D( sNy,oLy,kSize,bi,bj,k,.FALSE.,
-     &                             r4seg,fldRS )
-            ELSEIF (arrType .EQ. 'RL') THEN
-             CALL MDS_SEG4toRL_2D( sNy,oLy,kSize,bi,bj,k,.FALSE.,
-     &                             r4seg,fldRL )
+          IF ( useExch2ioLayOut ) THEN
+            tN = W2_myTileList(bi,bj)
+c           tNx = exch2_tNx(tN)
+c           tNy = exch2_tNy(tN)
+c           global_nTx = exch2_global_Nx/tNx
+            tBy = exch2_tyGlobalo(tN) - 1
+            IF   ( exch2_mydNy(tN) .GT. ySize ) THEN
+C-          face x-size larger than glob-size : fold it
+              iGjLoc = 0
+              jGjLoc = exch2_mydNy(tN) / ySize
             ELSE
-             WRITE(msgBuf,'(A)')
-     &         ' MDS_WRITE_SEC_YZ: illegal value for arrType'
-             CALL PRINT_ERROR( msgBuf, myThid )
-             STOP 'ABNORMAL END: S/R MDS_WRITE_SEC_YZ'
+C-          default (face fit into global-IO-array)
+              iGjLoc = 0
+              jGjLoc = 1
             ENDIF
-#ifdef _BYTESWAPIO
-            CALL MDS_BYTESWAPR4(sNy,r4seg)
-#endif
-            WRITE(dUnit,rec=irec) r4seg
-           ELSEIF (filePrec .EQ. precFloat64) THEN
-            IF (arrType .EQ. 'RS') THEN
-             CALL MDS_SEG8toRS_2D( sNy,oLy,kSize,bi,bj,k,.FALSE.,
-     &                             r8seg,fldRS )
-            ELSEIF (arrType .EQ. 'RL') THEN
-             CALL MDS_SEG8toRL_2D( sNy,oLy,kSize,bi,bj,k,.FALSE.,
-     &                             r8seg,fldRL )
+          ENDIF
+#endif /* ALLOW_EXCH2 */
+
+          IF (globalFile) THEN
+C--- Case of 1 Global file:
+
+           DO k=kLo,kHi
+            irec = 1 + tBy/tNy
+     &           +( k-kLo + (irecord-1)*kSize )*global_nTy
+            IF ( filePrec.EQ.precFloat32 ) THEN
+             WRITE(dUnit,rec=irec) r4seg
             ELSE
-             WRITE(msgBuf,'(A)')
-     &         ' MDS_WRITE_SEC_YZ: illegal value for arrType'
-             CALL PRINT_ERROR( msgBuf, myThid )
-             STOP 'ABNORMAL END: S/R MDS_WRITE_SEC_YZ'
+             WRITE(dUnit,rec=irec) r8seg
             ENDIF
-#ifdef _BYTESWAPIO
-            CALL MDS_BYTESWAPR8( sNy, r8seg )
-#endif
-            WRITE(dUnit,rec=irec) r8seg
-           ELSE
-            WRITE(msgBuf,'(A)')
-     &        ' MDS_WRITE_SEC_YZ: illegal value for filePrec'
-            CALL PRINT_ERROR( msgBuf, myThid )
-            STOP 'ABNORMAL END: S/R MDS_WRITE_SEC_YZ'
-           ENDIF
 C End of k loop
-         ENDDO
-        ELSE
-         WRITE(msgBuf,'(A)')
-     &     ' MDS_WRITE_SEC_YZ: I should never get to this point'
-         CALL PRINT_ERROR( msgBuf, myThid )
-         STOP 'ABNORMAL END: S/R MDS_WRITE_SEC_YZ'
-        ENDIF
-C If we were writing to a tiled MDS file then we close it here
-        IF (fileIsOpen .AND. (.NOT. globalFile)) THEN
-         CLOSE( dUnit )
-         fileIsOpen = .FALSE.
-        ENDIF
+           ENDDO
+
+          ELSE
+C--- Case of 1 file per tile (globalFile=F):
+
+C If we are writing to a tiled MDS file then we open each one here
+           iG=bi+(myXGlobalLo-1)/sNx
+           jG=bj+(myYGlobalLo-1)/sNy
+           WRITE(dataFName,'(2A,I3.3,A,I3.3,A)')
+     &            pfName(1:pIL),'.',iG,'.',jG,'.data'
+           length_of_rec = MDS_RECLEN( filePrec, sNy, myThid )
+           IF (irecord .EQ. 1) THEN
+            OPEN( dUnit, file=dataFName, status=_NEW_STATUS,
+     &            access='direct', recl=length_of_rec )
+           ELSE
+            OPEN( dUnit, file=dataFName, status=_OLD_STATUS,
+     &            access='direct', recl=length_of_rec )
+           ENDIF
+           fileIsOpen=.TRUE.
+
+           irec = k+kSize*(irecord-1)
+           IF ( filePrec.EQ.precFloat32 ) THEN
+             WRITE(dUnit,rec=irec) r4seg
+           ELSE
+             WRITE(dUnit,rec=irec) r8seg
+           ENDIF
+
+C here We close the tiled MDS file
+           IF ( fileIsOpen ) THEN
+             CLOSE( dUnit )
+             fileIsOpen = .FALSE.
+           ENDIF
+
+C--- End Global File / tile-file cases
+          ENDIF
+
+C Create meta-file for each tile if we are tiling
+          IF ( .NOT.globalFile .AND. writeMetaF ) THEN
+           iG=bi+(myXGlobalLo-1)/sNx
+           jG=bj+(myYGlobalLo-1)/sNy
+           WRITE(metaFname,'(2A,I3.3,A,I3.3,A)')
+     &              pfName(1:pIL),'.',iG,'.',jG,'.meta'
+           dimList(1,1) = ySize
+           dimList(2,1) = tBy + 1
+           dimList(3,1) = tBy + tNy
+           dimList(1,2) = nNz
+           dimList(2,2) = 1
+           dimList(3,2) = nNz
+           nDims = 2
+           IF ( nNz.EQ.1 ) nDims = 1
+           map2gl(1) = iGjLoc
+           map2gl(2) = jGjLoc
+           CALL MDS_WRITE_META(
+     I              metaFName, dataFName, the_run_name, ' ',
+     I              filePrec, nDims, dimList, map2gl, 0, blank8c,
+     I              0, dummyRL, oneRL, irecord, myIter, myThid )
+          ENDIF
+
 C End of bi,bj loops
-       ENDDO
-      ENDDO
+         ENDDO
+        ENDDO
 
 C If global file was opened then close it
-      IF (fileIsOpen .AND. globalFile) THEN
-       CLOSE( dUnit )
-       fileIsOpen = .FALSE.
+        IF (fileIsOpen .AND. globalFile) THEN
+          CLOSE( dUnit )
+          fileIsOpen = .FALSE.
+        ENDIF
+
+C- endif iAmDoingIO
+       ENDIF
+
+C Make other threads wait for I/O completion so that after this,
+C  3-D buffer can again be modified by any thread
+c      CALL BAR2( myThid )
+
+C     if useSingleCpuIO / else / end
       ENDIF
 
-      _END_MASTER( myThid )
+C Create meta-file for the global-file (also if useSingleCpuIO)
+      IF ( writeMetaF .AND. iAmDoingIO .AND.
+     &    (globalFile .OR. useSingleCpuIO) ) THEN
+         WRITE(metaFName,'(2A)') fName(1:IL),'.meta'
+         dimList(1,1) = ySize
+         dimList(2,1) = 1
+         dimList(3,1) = ySize
+         dimList(1,2) = nNz
+         dimList(2,2) = 1
+         dimList(3,2) = nNz
+         nDims = 2
+         IF ( nNz.EQ.1 ) nDims = 1
+         map2gl(1) = 0
+         map2gl(2) = 1
+         CALL MDS_WRITE_META(
+     I              metaFName, dataFName, the_run_name, ' ',
+     I              filePrec, nDims, dimList, map2gl, 0, blank8c,
+     I              0, dummyRL, oneRL, irecord, myIter, myThid )
+c    I              metaFName, dataFName, the_run_name, titleLine,
+c    I              filePrec, nDims, dimList, map2gl, nFlds,  fldList,
+c    I              nTimRec, timList, misVal, irecord, myIter, myThid )
+      ENDIF
 
-C     ------------------------------------------------------------------
+C---+----1----+----2----+----3----+----4----+----5----+----6----+----7-|--+----|
       RETURN
       END

--- a/pkg/mdsio/mdsio_write_section.F
+++ b/pkg/mdsio/mdsio_write_section.F
@@ -132,8 +132,8 @@ C     bBij  :: base shift in Buffer index for tile bi,bj
       INTEGER length_of_rec
       INTEGER tNx, global_nTx
       INTEGER tBx, iGjLoc, jGjLoc
-      REAL*4 r4seg(sNx*nSx)
-      REAL*8 r8seg(sNx*nSx)
+      REAL*4 r4seg(sNx)
+      REAL*8 r8seg(sNx)
       REAL*4 x_layer_buffer_r4(Nx)
       REAL*8 x_layer_buffer_r8(Nx)
 #ifdef ALLOW_EXCH2
@@ -280,7 +280,7 @@ C globalFile is too slow, then try using single-CPU I/O.
 C Master thread of process 0, only, opens a global file
        IF ( iAmDoingIO ) THEN
          WRITE(dataFName,'(2a)') fName(1:IL),'.data'
-         length_of_rec = MDS_RECLEN( filePrec, sNx*nSx, myThid )
+         length_of_rec = MDS_RECLEN( filePrec, sNx, myThid )
          IF (irecord .EQ. 1) THEN
           OPEN( dUnit, file=dataFName, status=_NEW_STATUS,
      &        access='direct', recl=length_of_rec )
@@ -298,10 +298,10 @@ C-     copy from fldRL/RS(level=k) to 2-D "local":
          DO bj=1,nSy
          DO bi=1,nSx
           IF ( arrType.EQ.'RS' ) THEN
-            CALL MDS_SEG4toRS_2D( sNx*nSx, oLx, kSize, bi, bj, k,
+            CALL MDS_SEG4toRS_2D( sNx, oLx, kSize, bi, bj, k,
      &                            .FALSE., r4seg, fldRS )
           ELSEIF ( arrType.EQ.'RL' ) THEN
-            CALL MDS_SEG4toRS_2D( sNx*nSx, oLx, kSize, bi, bj, k,
+            CALL MDS_SEG4toRS_2D( sNx, oLx, kSize, bi, bj, k,
      &                            .FALSE., r4seg, fldRL )
           ELSE
             WRITE(msgBuf,'(2A)')
@@ -320,14 +320,14 @@ C Wait for all threads to finish filling shared buffer
             CALL GATHER_VEC_R4( 
      O                         x_layer_buffer_r4,
      I                         r4seg, 
-     I                         xSize, myThid ) 
+     I                         sNx, myThid ) 
 #ifdef ALLOW_EXCH2
           ELSE
 
             CALL GATHER_VEC_R4( 
      O                         x_layer_buffer_exch2_r4,
      I                         r4seg, 
-     I                         xSize, myThid ) 
+     I                         sNx, myThid ) 
           ENDIF
 #endif
 
@@ -335,10 +335,10 @@ C Wait for all threads to finish filling shared buffer
          DO bj=1,nSy
          DO bi=1,nSx
           IF ( arrType.EQ.'RS' ) THEN
-            CALL MDS_SEG8toRS_2D( sNx*nSx, oLx, kSize, bi, bj, k,
+            CALL MDS_SEG8toRS_2D( sNx, oLx, kSize, bi, bj, k,
      I                         .FALSE., r8seg, fldRS )
           ELSEIF ( arrType.EQ.'RL' ) THEN
-            CALL MDS_SEG8toRS_2D( sNx*nSx, oLx, kSize, bi, bj, k,
+            CALL MDS_SEG8toRS_2D( sNx, oLx, kSize, bi, bj, k,
      I                         .FALSE., r8seg, fldRL )
           ELSE
             WRITE(msgBuf,'(2A)')
@@ -357,14 +357,14 @@ C Wait for all threads to finish filling shared buffer
             CALL GATHER_VEC_R8( 
      O                         x_layer_buffer_r8,
      I                         r8seg, 
-     I                         xSize, myThid ) 
+     I                         sNx, myThid ) 
 #ifdef ALLOW_EXCH2
           ELSE
 
             CALL GATHER_VEC_R8( 
      O                          x_layer_buffer_exch2_r8,
      I                          r8seg, 
-     I                          xSize, myThid ) 
+     I                          sNx, myThid ) 
           ENDIF
 #endif
         ELSE
@@ -441,10 +441,10 @@ C---    Copy from fldRL/RS to 3-D buffer (multi-threads):
 C-      copy from fldRL/RS(level=k) to 2-D "local":
         IF ( filePrec.EQ.precFloat32 ) THEN
           IF ( arrType.EQ.'RS' ) THEN
-            CALL MDS_SEG4toRS_2D( sNx*nSx, oLx, kSize, bi, bj, k,
+            CALL MDS_SEG4toRS_2D( sNx, oLx, kSize, bi, bj, k,
      &                            .FALSE., r4seg, fldRS )
           ELSEIF ( arrType.EQ.'RL' ) THEN
-            CALL MDS_SEG4toRS_2D( sNx*nSx, oLx, kSize, bi, bj, k,
+            CALL MDS_SEG4toRS_2D( sNx, oLx, kSize, bi, bj, k,
      &                            .FALSE., r4seg, fldRL )
           ELSE
             WRITE(msgBuf,'(2A)')
@@ -456,10 +456,10 @@ C-      copy from fldRL/RS(level=k) to 2-D "local":
 
         ELSEIF ( filePrec.EQ.precFloat64 ) THEN
           IF ( arrType.EQ.'RS' ) THEN
-            CALL MDS_SEG8toRS_2D( sNx*nSx, oLx, kSize, bi, bj, k,
+            CALL MDS_SEG8toRS_2D( sNx, oLx, kSize, bi, bj, k,
      I                         .FALSE., r8seg, fldRS )
           ELSEIF ( arrType.EQ.'RL' ) THEN
-            CALL MDS_SEG8toRS_2D( sNx*nSx, oLx, kSize, bi, bj, k,
+            CALL MDS_SEG8toRS_2D( sNx, oLx, kSize, bi, bj, k,
      I                         .FALSE., r8seg, fldRL )
           ELSE
             WRITE(msgBuf,'(2A)')
@@ -489,16 +489,16 @@ C Only do I/O if I am the master thread
 
 #ifdef _BYTESWAPIO
         IF ( filePrec.EQ.precFloat32 ) THEN
-          CALL MDS_BYTESWAPR4( sNx*nSx, r4seg )
+          CALL MDS_BYTESWAPR4( sNx, r4seg )
         ELSE
-          CALL MDS_BYTESWAPR8( sNx*nSx, r8seg )
+          CALL MDS_BYTESWAPR8( sNx, r8seg )
         ENDIF
 #endif
 
 C If we are writing to a global file then we open it here
         IF (globalFile) THEN
           WRITE(dataFName,'(2a)') fName(1:IL),'.data'
-          length_of_rec = MDS_RECLEN( filePrec, sNx*nSx, myThid )
+          length_of_rec = MDS_RECLEN( filePrec, sNx, myThid )
           IF (irecord .EQ. 1) THEN
            OPEN( dUnit, file=dataFName, status=_NEW_STATUS,
      &             access='direct', recl=length_of_rec )
@@ -780,12 +780,15 @@ C     bBij  :: base shift in Buffer index for tile bi,bj
       INTEGER irec,dUnit,IL,pIL
       INTEGER dimList(3,2), nDims, map2gl(2)
       INTEGER length_of_rec
+      INTEGER bBij
       INTEGER tNy, global_nTy
       INTEGER tBy, iGjLoc, jGjLoc
-      REAL*4 r4seg(sNy*nSy)
-      REAL*8 r8seg(sNy*nSy)
-      REAL*4 y_layer_buffer_r4(Ny)
-      REAL*8 y_layer_buffer_r8(Ny)
+      REAL*4 r4seg(sNy,nSx,nSy)
+      REAL*8 r8seg(sNy,nSx,nSy)
+      REAL*4 y_layer_buffer_r4( Ny )
+      REAL*8 y_layer_buffer_r8( Ny )
+      REAL*4 yz_buffer_r4( sNy*Nr*nSx*nSy )
+      REAL*8 yz_buffer_r8( sNy*Nr*nSx*nSy )
 #ifdef ALLOW_EXCH2
       INTEGER tN
       REAL*4 y_layer_buffer_exch2_r4(exch2_global_Ny)
@@ -930,7 +933,7 @@ C globalFile is too slow, then try using single-CPU I/O.
 C Master thread of process 0, only, opens a global file
        IF ( iAmDoingIO ) THEN
          WRITE(dataFName,'(2a)') fName(1:IL),'.data'
-         length_of_rec = MDS_RECLEN( filePrec, sNy*nSy, myThid )
+         length_of_rec = MDS_RECLEN( filePrec, ySize, myThid )
          IF (irecord .EQ. 1) THEN
           OPEN( dUnit, file=dataFName, status=_NEW_STATUS,
      &        access='direct', recl=length_of_rec )
@@ -946,128 +949,119 @@ C Gather array and write it to file, one vertical level at a time
        zeroBuff = k.EQ.kLo
 C-     copy from fldRL/RS(level=k) to 2-D "local":
        IF ( filePrec.EQ.precFloat32 ) THEN
-         DO bj=1,nSy
-         DO bi=1,nSx
-          IF ( arrType.EQ.'RS' ) THEN
-            CALL MDS_SEG4toRS_2D( sNy*nSy, oLy, kSize, bi, bj, k,
-     &                            .FALSE., r4seg, fldRS )
-          ELSEIF ( arrType.EQ.'RL' ) THEN
-            CALL MDS_SEG4toRS_2D( sNy*nSy, oLy, kSize, bi, bj, k,
-     &                            .FALSE., r4seg, fldRL )
-          ELSE
-            WRITE(msgBuf,'(2A)')
-     &      ' MDS_WRITE_SEC_YZ: illegal value for arrType=', arrType
-            CALL PRINT_ERROR( msgBuf, myThid )
-            CALL ALL_PROC_DIE( myThid )
-            STOP 'ABNORMAL END: S/R MDS_WRITE_SEC_YZ'
-          ENDIF
-         ENDDO
-         ENDDO
+         IF ( arrType.EQ.'RS' ) THEN
+           CALL MDS_PASS_YZ_R4toRS( r4seg, fldRS, 
+     I             0, 1, k, kSize, 0, 0, .FALSE., myThid )
+         ELSEIF ( arrType.EQ.'RL' ) THEN
+           CALL MDS_PASS_YZ_R4toRL( r4seg, fldRL, 
+     I             0, 1, k, kSize, 0, 0, .FALSE., myThid )
+         ELSE
+           WRITE(msgBuf,'(2A)')
+     &     ' MDS_WRITE_SEC_YZ: illegal value for arrType=', arrType
+           CALL PRINT_ERROR( msgBuf, myThid )
+           CALL ALL_PROC_DIE( myThid )
+           STOP 'ABNORMAL END: S/R MDS_WRITE_SEC_YZ'
+         ENDIF
 C Wait for all threads to finish filling shared buffer
           CALL BAR2( myThid )
 #ifdef ALLOW_EXCH2
           IF ( .not.W2_useE2ioLayOut ) THEN
 #endif
-            CALL GATHER_VEC_R4( 
-     O                         y_layer_buffer_r4,
-     I                         r4seg, 
-     I                         ySize, myThid ) 
+            CALL GATHER_YZ_R4( y_layer_buffer_r4, r4seg, myThid )
 #ifdef ALLOW_EXCH2
           ELSE
-
-            CALL GATHER_VEC_R4( 
-     O                         y_layer_buffer_exch2_r4,
-     I                         r4seg, 
-     I                         ySize, myThid ) 
+            CALL GATHER_YZ_R4( y_layer_buffer_exch2_r4, r4seg, myThid )
           ENDIF
 #endif
 
-        ELSEIF ( filePrec.EQ.precFloat64 ) THEN
-         DO bj=1,nSy
-         DO bi=1,nSx
-          IF ( arrType.EQ.'RS' ) THEN
-            CALL MDS_SEG8toRS_2D( sNy*nSy, oLy, kSize, bi, bj, k,
-     I                         .FALSE., r8seg, fldRS )
-          ELSEIF ( arrType.EQ.'RL' ) THEN
-            CALL MDS_SEG8toRS_2D( sNy*nSy, oLy, kSize, bi, bj, k,
-     I                         .FALSE., r8seg, fldRL )
-          ELSE
-            WRITE(msgBuf,'(2A)')
-     &      ' MDS_WRITE_SEC_YZ: illegal value for arrType=', arrType
-            CALL PRINT_ERROR( msgBuf, myThid )
-            CALL ALL_PROC_DIE( myThid )
-            STOP 'ABNORMAL END: S/R MDS_WRITE_SEC_YZ'
-          ENDIF
-         ENDDO
-         ENDDO
+       ELSEIF ( filePrec.EQ.precFloat64 ) THEN
+         IF ( arrType.EQ.'RS' ) THEN
+           CALL MDS_PASS_YZ_R8toRS( r8seg, fldRS,
+     I            0, 1, k, kSize, 0, 0, .FALSE., myThid )
+         ELSEIF ( arrType.EQ.'RL' ) THEN
+           CALL MDS_PASS_YZ_R8toRL( r8seg, fldRL,
+     I            0, 1, k, kSize, 0, 0, .FALSE., myThid )
+         ELSE
+           WRITE(msgBuf,'(2A)')
+     &     ' MDS_WRITE_SEC_YZ: illegal value for arrType=', arrType
+           CALL PRINT_ERROR( msgBuf, myThid )
+           CALL ALL_PROC_DIE( myThid )
+           STOP 'ABNORMAL END: S/R MDS_WRITE_SEC_YZ'
+         ENDIF
+         IF ( debugLevel .GE. debLevC ) THEN
+           WRITE(msgBuf,'(A,I8)')
+     &       ' MDS_WRITE_SEC_YZ: SIZE(ylayerbuffer_r8): ', 
+     &          SIZE(y_layer_buffer_r8)
+           CALL PRINT_MESSAGE( msgBuf, standardMessageUnit,
+     &                         SQUEEZE_RIGHT, myThid )
+         ENDIF
 C Wait for all threads to finish filling shared buffer
-          CALL BAR2( myThid )
+         CALL BAR2( myThid )
 #ifdef ALLOW_EXCH2
-          IF ( .not.W2_useE2ioLayOut ) THEN
+         IF ( .not.W2_useE2ioLayOut ) THEN
 #endif
-            CALL GATHER_VEC_R8( 
-     O                         y_layer_buffer_r8,
-     I                         r8seg, 
-     I                         ySize, myThid ) 
+           CALL GATHER_YZ_R8( y_layer_buffer_r8, r8seg, myThid )
 #ifdef ALLOW_EXCH2
-          ELSE
-
-            CALL GATHER_VEC_R8( 
-     O                          y_layer_buffer_exch2_r8,
-     I                          r8seg, 
-     I                          ySize, myThid ) 
-          ENDIF
+         ELSE
+           CALL GATHER_YZ_R8( y_layer_buffer_exch2_r8, r8seg, myThid )
+         ENDIF
 #endif
-        ELSE
-          WRITE(msgBuf,'(A,I6)')
-     &      ' MDS_WRITE_SEC_YZ: illegal value for filePrec=',filePrec
-          CALL PRINT_ERROR( msgBuf, myThid )
-          CALL ALL_PROC_DIE( myThid )
-          STOP 'ABNORMAL END: S/R MDS_WRITE_SEC_YZ'
-        ENDIF
+       ELSE
+         WRITE(msgBuf,'(A,I6)')
+     &     ' MDS_WRITE_SEC_YZ: illegal value for filePrec=',filePrec
+         CALL PRINT_ERROR( msgBuf, myThid )
+         CALL ALL_PROC_DIE( myThid )
+         STOP 'ABNORMAL END: S/R MDS_WRITE_SEC_YZ'
+       ENDIF
 C Make other threads wait for "gather" completion so that after this,
 C  shared buffer can again be modified by any thread
         CALL BAR2( myThid )
 
-        IF ( iAmDoingIO ) THEN
-          irec = 1 + k-kLo + (irecord-1)*kSize
-          IF ( filePrec.EQ.precFloat32 ) THEN
+       IF ( iAmDoingIO ) THEN
+         irec = 1 + k-kLo + (irecord-1)*kSize
+         IF ( debugLevel .GE. debLevC ) THEN
+           WRITE(msgBuf,'(A,I8,A,I8)')
+     &       ' MDS_WRITE_SEC_YZ: irec: ', irec,
+     &       ' SIZE(ylayerbuffer_r8): ', SIZE(y_layer_buffer_r8)
+           CALL PRINT_MESSAGE( msgBuf, standardMessageUnit,
+     &                         SQUEEZE_RIGHT, myThid )
+         ENDIF
+         IF ( filePrec.EQ.precFloat32 ) THEN
+#ifdef ALLOW_EXCH2
+           IF ( .not.W2_useE2ioLayOut ) THEN
+#endif
+# ifdef _BYTESWAPIO
+             CALL MDS_BYTESWAPR4( ySize, y_layer_buffer_r4 )
+# endif
+             WRITE(dUnit,rec=irec) y_layer_buffer_r4
+#ifdef ALLOW_EXCH2
+           ELSE
+# ifdef _BYTESWAPIO
+             CALL MDS_BYTESWAPR4( ySize, y_layer_buffer_exch2_r4 )
+# endif
+             WRITE(dUnit,rec=irec) y_layer_buffer_exch2_r4
+           ENDIF
+#endif
+         ELSE
 
 #ifdef ALLOW_EXCH2
            IF ( .not.W2_useE2ioLayOut ) THEN
 #endif
 # ifdef _BYTESWAPIO
-            CALL MDS_BYTESWAPR4( ySize, y_layer_buffer_r4 )
+             CALL MDS_BYTESWAPR8( ySize, y_layer_buffer_r8 )
 # endif
-            WRITE(dUnit,rec=irec) y_layer_buffer_r4
+             WRITE(dUnit,rec=irec) y_layer_buffer_r8
 #ifdef ALLOW_EXCH2
            ELSE
 # ifdef _BYTESWAPIO
-            CALL MDS_BYTESWAPR4( ySize, y_layer_buffer_exch2_r4 )
+             CALL MDS_BYTESWAPR8( ySize, y_layer_buffer_exch2_r8 )
 # endif
-            WRITE(dUnit,rec=irec) y_layer_buffer_exch2_r4
+             WRITE(dUnit,rec=irec) y_layer_buffer_exch2_r8
            ENDIF
 #endif
-          ELSE
-
-#ifdef ALLOW_EXCH2
-           IF ( .not.W2_useE2ioLayOut ) THEN
-#endif
-# ifdef _BYTESWAPIO
-            CALL MDS_BYTESWAPR8( ySize, y_layer_buffer_r8 )
-# endif
-            WRITE(dUnit,rec=irec) y_layer_buffer_r8
-#ifdef ALLOW_EXCH2
-           ELSE
-# ifdef _BYTESWAPIO
-            CALL MDS_BYTESWAPR8( ySize, y_layer_buffer_exch2_r8 )
-# endif
-            WRITE(dUnit,rec=irec) y_layer_buffer_exch2_r8
-           ENDIF
-#endif
-          ENDIF
+         ENDIF
 C-      end if iAmDoingIO
-        ENDIF
+       ENDIF
 C-     end of k loop
        ENDDO
 
@@ -1082,22 +1076,16 @@ C---  else .NOT.useSingleCpuIO
 
 C Wait for all thread to finish. This prevents other threads (e.g., master)
 C  to continue to acces 3-D buffer while this thread is filling it.
-        CALL BAR2( myThid )
+       CALL BAR2( myThid )
 
-C---    Copy from fldRL/RS to 3-D buffer (multi-threads):
-       DO k=kLo,kHi
-        zeroBuff = k.EQ.kLo
-        DO bj=1,nSy
-        DO bi=1,nSx
-
-C-      copy from fldRL/RS(level=k) to 2-D "local":
+C---    Copy from fldRL/RS to 2-D buffer (multi-threads):
         IF ( filePrec.EQ.precFloat32 ) THEN
           IF ( arrType.EQ.'RS' ) THEN
-            CALL MDS_SEG4toRS_2D( sNy*nSy, oLy, kSize, bi, bj, k,
-     &                            .FALSE., r4seg, fldRS )
+            CALL MDS_PASS_YZ_R4toRS( yz_buffer_r4, fldRS,
+     I              0, nNz, kLo, kSize, 0, 0, .FALSE., myThid )
           ELSEIF ( arrType.EQ.'RL' ) THEN
-            CALL MDS_SEG4toRS_2D( sNy*nSy, oLy, kSize, bi, bj, k,
-     &                            .FALSE., r4seg, fldRL )
+            CALL MDS_PASS_YZ_R4toRL( yz_buffer_r4, fldRL,
+     I              0, nNz, kLo, kSize, 0, 0, .FALSE., myThid )
           ELSE
             WRITE(msgBuf,'(2A)')
      &      ' MDS_WRITE_SEC_YZ: illegal value for arrType=', arrType
@@ -1108,11 +1096,11 @@ C-      copy from fldRL/RS(level=k) to 2-D "local":
 
         ELSEIF ( filePrec.EQ.precFloat64 ) THEN
           IF ( arrType.EQ.'RS' ) THEN
-            CALL MDS_SEG8toRS_2D( sNy*nSy, oLy, kSize, bi, bj, k,
-     I                         .FALSE., r8seg, fldRS )
+            CALL MDS_PASS_YZ_R8toRS( yz_buffer_r8, fldRS,
+     I              0, nNz, kLo, kSize, 0, 0, .FALSE., myThid )
           ELSEIF ( arrType.EQ.'RL' ) THEN
-            CALL MDS_SEG8toRS_2D( sNy*nSy, oLy, kSize, bi, bj, k,
-     I                         .FALSE., r8seg, fldRL )
+            CALL MDS_PASS_YZ_R8toRL( yz_buffer_r8, fldRL,
+     I              0, nNz, kLo, kSize, 0, 0, .FALSE., myThid )
           ELSE
             WRITE(msgBuf,'(2A)')
      &      ' MDS_WRITE_SEC_YZ: illegal value for arrType=', arrType
@@ -1128,10 +1116,6 @@ C-      copy from fldRL/RS(level=k) to 2-D "local":
           CALL ALL_PROC_DIE( myThid )
           STOP 'ABNORMAL END: S/R MDS_WRITE_SEC_YZ'
         ENDIF
-        ENDDO
-        ENDDO
-C-     end of k loop
-       ENDDO
 
 C Wait for all threads to finish filling shared buffer
        CALL BAR2( myThid )
@@ -1141,16 +1125,16 @@ C Only do I/O if I am the master thread
 
 #ifdef _BYTESWAPIO
         IF ( filePrec.EQ.precFloat32 ) THEN
-          CALL MDS_BYTESWAPR4( sNy*nSy, r4seg )
+          CALL MDS_BYTESWAPR4( sNy*nNz*nSx, yz_buffer_r4 )
         ELSE
-          CALL MDS_BYTESWAPR8( sNy*nSy, r8seg )
+          CALL MDS_BYTESWAPR8( sNy*nNz*nSx, yz_buffer_r8 )
         ENDIF
 #endif
 
 C If we are writing to a global file then we open it here
         IF (globalFile) THEN
           WRITE(dataFName,'(2a)') fName(1:IL),'.data'
-          length_of_rec = MDS_RECLEN( filePrec, sNy*nSy, myThid )
+          length_of_rec = MDS_RECLEN( filePrec, sNy, myThid )
           IF (irecord .EQ. 1) THEN
            OPEN( dUnit, file=dataFName, status=_NEW_STATUS,
      &             access='direct', recl=length_of_rec )
@@ -1164,6 +1148,7 @@ C If we are writing to a global file then we open it here
 C Loop over all tiles
         DO bj=1,nSy
          DO bi=1,nSx
+          bBij = sNy*nNz*( bi-1 + (bj-1)*nSx )
 
           tNy = sNy
           global_nTy = ySize/sNy
@@ -1190,13 +1175,16 @@ C-          default (face fit into global-IO-array)
           IF (globalFile) THEN
 C--- Case of 1 Global file:
 
+Cts --- TODO: check this!
            DO k=kLo,kHi
             irec = 1 + tBy/tNy
      &           +( k-kLo + (irecord-1)*kSize )*global_nTy
+            i1 = bBij + 1 + (k-kLo)*sNx*sNy
+            i2 = bBij +           k*sNx*sNy
             IF ( filePrec.EQ.precFloat32 ) THEN
-             WRITE(dUnit,rec=irec) r4seg
+             WRITE(dUnit,rec=irec) (yz_buffer_r4(i),i=i1,i2)
             ELSE
-             WRITE(dUnit,rec=irec) r8seg
+             WRITE(dUnit,rec=irec) (yz_buffer_r8(i),i=i1,i2)
             ENDIF
 C End of k loop
            ENDDO
@@ -1209,7 +1197,7 @@ C If we are writing to a tiled MDS file then we open each one here
            jG=bj+(myYGlobalLo-1)/sNy
            WRITE(dataFName,'(2A,I3.3,A,I3.3,A)')
      &            pfName(1:pIL),'.',iG,'.',jG,'.data'
-           length_of_rec = MDS_RECLEN( filePrec, sNy, myThid )
+           length_of_rec = MDS_RECLEN( filePrec, sNy*nNz, myThid )
            IF (irecord .EQ. 1) THEN
             OPEN( dUnit, file=dataFName, status=_NEW_STATUS,
      &            access='direct', recl=length_of_rec )
@@ -1219,15 +1207,12 @@ C If we are writing to a tiled MDS file then we open each one here
            ENDIF
            fileIsOpen=.TRUE.
 
-           DO k=kLo,kHi
-            irec = k+kSize*(irecord-1)
-            IF ( filePrec.EQ.precFloat32 ) THEN
-              WRITE(dUnit,rec=irec) r4seg
-            ELSE
-              WRITE(dUnit,rec=irec) r8seg
-            ENDIF
-C End of k loop
-           ENDDO
+           irec = irecord
+           IF ( filePrec.EQ.precFloat32 ) THEN
+             WRITE(dUnit,rec=irec) yz_buffer_r4
+           ELSE
+             WRITE(dUnit,rec=irec) yz_buffer_r8
+           ENDIF
 
 C here We close the tiled MDS file
            IF ( fileIsOpen ) THEN

--- a/pkg/mdsio/mdsio_write_section.F
+++ b/pkg/mdsio/mdsio_write_section.F
@@ -1058,8 +1058,8 @@ c           global_nTx = exch2_global_Nx/tNx
             tBy = exch2_tyGlobalo(tN) - 1
             IF   ( exch2_mydNy(tN) .GT. ySize ) THEN
 C-          face x-size larger than glob-size : fold it
-              iGjLoc = 0
-              jGjLoc = exch2_mydNy(tN) / ySize
+              iGjLoc = exch2_mydNx(tN)
+              jGjLoc = 0
             ELSE
 C-          default (face fit into global-IO-array)
               iGjLoc = 0

--- a/pkg/mdsio/mdsio_write_section.F
+++ b/pkg/mdsio/mdsio_write_section.F
@@ -825,15 +825,6 @@ C Assume nothing
       irecord = ABS(jrecord)
       writeMetaF = jrecord.GT.0
 
-C Initialize buffer
-      DO bj = 1,nSy
-       DO bi = 1,nSx
-        DO j = 1,sNy
-         r8seg(j,bi,bj) = 0. _d 0
-        ENDDO
-       ENDDO
-      ENDDO
-
 C Only do I/O if I am the master thread (and mpi process 0 IF useSingleCpuIO):
       iAmDoingIO = MASTER_CPU_IO(myThid)
 
@@ -955,6 +946,11 @@ C Master thread of process 0, only, opens a global file
 C Gather array and write it to file, one vertical level at a time
 
       DO k=kLo,kHi
+C Initialize buffer
+       DO j = 1,ySize
+        y_layer_buffer_r4(j)=0.
+        y_layer_buffer_r8(j)=0.
+       ENDDO
        zeroBuff = k.EQ.kLo
 C-     copy from fldRL/RS(level=k) to 2-D "local":
        IF ( filePrec.EQ.precFloat32 ) THEN

--- a/pkg/mdsio/mdsio_write_section.F
+++ b/pkg/mdsio/mdsio_write_section.F
@@ -776,19 +776,19 @@ C     bBij  :: base shift in Buffer index for tile bi,bj
       INTEGER xSize, ySize
       INTEGER irecord
       INTEGER iG,jG,bi,bj
-      INTEGER i1,i2,i,j,k,nNz
+      INTEGER i1,i2,i,j,k,nNz,np
       INTEGER irec,dUnit,IL,pIL
       INTEGER dimList(3,2), nDims, map2gl(2)
       INTEGER length_of_rec
       INTEGER bBij
       INTEGER tNy, global_nTy
       INTEGER tBy, iGjLoc, jGjLoc
-      REAL*4 r4seg(sNy,nSx,nSy)
-      REAL*8 r8seg(sNy,nSx,nSy)
-      REAL*4 y_layer_buffer_r4( Ny )
-      REAL*8 y_layer_buffer_r8( Ny )
-      REAL*4 yz_buffer_r4( sNy*Nr*nSx*nSy )
-      REAL*8 yz_buffer_r8( sNy*Nr*nSx*nSy )
+      _R4 r4seg(sNy,nSx,nSy)
+      _R8 r8seg(sNy,nSx,nSy)
+      _R4 y_layer_buffer_r4( Ny )
+      _R8 y_layer_buffer_r8( Ny )
+      _R4 yz_buffer_r4( sNy*Nr*nSx*nSy )
+      _R8 yz_buffer_r8( sNy*Nr*nSx*nSy )
 #ifdef ALLOW_EXCH2
       INTEGER tN
       REAL*4 y_layer_buffer_exch2_r4(exch2_global_Ny)
@@ -824,6 +824,15 @@ C Assume nothing
       nNz = 1 + kHi - kLo
       irecord = ABS(jrecord)
       writeMetaF = jrecord.GT.0
+
+C Initialize buffer
+      DO bj = 1,nSy
+       DO bi = 1,nSx
+        DO j = 1,sNy
+         r8seg(j,bi,bj) = 0. _d 0
+        ENDDO
+       ENDDO
+      ENDDO
 
 C Only do I/O if I am the master thread (and mpi process 0 IF useSingleCpuIO):
       iAmDoingIO = MASTER_CPU_IO(myThid)
@@ -926,6 +935,23 @@ C Assign a free unit number as the I/O channel for this routine
 C- endif iAmDoingIO
       ENDIF
 
+C If option globalFile is desired but does not work or if
+C globalFile is too slow, then try using single-CPU I/O.
+      IF (useSingleCpuIO) THEN
+
+C Master thread of process 0, only, opens a global file
+       IF ( iAmDoingIO ) THEN
+         WRITE(dataFName,'(2a)') fName(1:IL),'.data'
+         length_of_rec = MDS_RECLEN( filePrec, ySize, myThid )
+         IF (irecord .EQ. 1) THEN
+          OPEN( dUnit, file=dataFName, status=_NEW_STATUS,
+     &        access='direct', recl=length_of_rec )
+         ELSE
+          OPEN( dUnit, file=dataFName, status=_OLD_STATUS,
+     &        access='direct', recl=length_of_rec )
+         ENDIF
+       ENDIF
+
 C Gather array and write it to file, one vertical level at a time
 
       DO k=kLo,kHi
@@ -1025,98 +1051,7 @@ C  shared buffer can again be modified by any thread
         CALL BAR2( myThid )
 
        IF ( iAmDoingIO ) THEN
-         irec = 1 + k-kLo + (irecord-1)*kSize
-         IF ( debugLevel .GE. debLevC ) THEN
-           WRITE(msgBuf,'(A,I8,A,I8)')
-     &       ' MDS_WRITE_SEC_YZ: irec: ', irec,
-     &       ' SIZE(ylayerbuffer_r8): ', SIZE(y_layer_buffer_r8)
-           CALL PRINT_MESSAGE( msgBuf, standardMessageUnit,
-     &                         SQUEEZE_RIGHT, myThid )
-           do j=1,Ny
-           WRITE(msgBuf,'(A,F8.2)')
-     &       ' MDS_WRITE_SEC_YZ: : ybuffer(j): ',y_layer_buffer_r8(j)
-           CALL PRINT_MESSAGE( msgBuf, standardMessageUnit,
-     &                         SQUEEZE_RIGHT, myThid )
-           enddo
-         ENDIF
-       ENDIF
-
-C Gather array and write it to file, one vertical level at a time
-
-      DO k=kLo,kHi
-       zeroBuff = k.EQ.kLo
-C-     copy from fldRL/RS(level=k) to 2-D "local":
-       IF ( filePrec.EQ.precFloat32 ) THEN
-         IF ( arrType.EQ.'RS' ) THEN
-           CALL MDS_PASS_YZ_R4toRS( r4seg, fldRS, 
-     I             0, 1, k, kSize, 0, 0, .FALSE., myThid )
-         ELSEIF ( arrType.EQ.'RL' ) THEN
-           CALL MDS_PASS_YZ_R4toRL( r4seg, fldRL, 
-     I             0, 1, k, kSize, 0, 0, .FALSE., myThid )
-         ELSE
-           WRITE(msgBuf,'(2A)')
-     &     ' MDS_WRITE_SEC_YZ: illegal value for arrType=', arrType
-           CALL PRINT_ERROR( msgBuf, myThid )
-           CALL ALL_PROC_DIE( myThid )
-           STOP 'ABNORMAL END: S/R MDS_WRITE_SEC_YZ'
-         ENDIF
-C Wait for all threads to finish filling shared buffer
-          CALL BAR2( myThid )
-#ifdef ALLOW_EXCH2
-          IF ( .not.W2_useE2ioLayOut ) THEN
-#endif
-            CALL GATHER_YZ_R4( y_layer_buffer_r4, r4seg, myThid )
-#ifdef ALLOW_EXCH2
-          ELSE
-            CALL GATHER_YZ_R4( y_layer_buffer_exch2_r4, r4seg, myThid )
-          ENDIF
-#endif
-
-       ELSEIF ( filePrec.EQ.precFloat64 ) THEN
-         IF ( arrType.EQ.'RS' ) THEN
-           CALL MDS_PASS_YZ_R8toRS( r8seg, fldRS,
-     I            0, 1, k, kSize, 0, 0, .FALSE., myThid )
-         ELSEIF ( arrType.EQ.'RL' ) THEN
-           CALL MDS_PASS_YZ_R8toRL( r8seg, fldRL,
-     I            0, 1, k, kSize, 0, 0, .FALSE., myThid )
-         ELSE
-           WRITE(msgBuf,'(2A)')
-     &     ' MDS_WRITE_SEC_YZ: illegal value for arrType=', arrType
-           CALL PRINT_ERROR( msgBuf, myThid )
-           CALL ALL_PROC_DIE( myThid )
-           STOP 'ABNORMAL END: S/R MDS_WRITE_SEC_YZ'
-         ENDIF
-         IF ( debugLevel .GE. debLevC ) THEN
-           WRITE(msgBuf,'(A,I8)')
-     &       ' MDS_WRITE_SEC_YZ: SIZE(ylayerbuffer_r8): ', 
-     &          SIZE(y_layer_buffer_r8)
-           CALL PRINT_MESSAGE( msgBuf, standardMessageUnit,
-     &                         SQUEEZE_RIGHT, myThid )
-         ENDIF
-C Wait for all threads to finish filling shared buffer
-         CALL BAR2( myThid )
-#ifdef ALLOW_EXCH2
-         IF ( .not.W2_useE2ioLayOut ) THEN
-#endif
-           CALL GATHER_YZ_R8( y_layer_buffer_r8, r8seg, myThid )
-#ifdef ALLOW_EXCH2
-         ELSE
-           CALL GATHER_YZ_R8( y_layer_buffer_exch2_r8, r8seg, myThid )
-         ENDIF
-#endif
-       ELSE
-         WRITE(msgBuf,'(A,I6)')
-     &     ' MDS_WRITE_SEC_YZ: illegal value for filePrec=',filePrec
-         CALL PRINT_ERROR( msgBuf, myThid )
-         CALL ALL_PROC_DIE( myThid )
-         STOP 'ABNORMAL END: S/R MDS_WRITE_SEC_YZ'
-       ENDIF
-C Make other threads wait for "gather" completion so that after this,
-C  shared buffer can again be modified by any thread
-        CALL BAR2( myThid )
-
-       IF ( iAmDoingIO ) THEN
-         irec = 1 + k-kLo + (irecord-1)*kSize
+         irec = 1 + (k-kLo) + (irecord-1)*nNz
          IF ( debugLevel .GE. debLevC ) THEN
            WRITE(msgBuf,'(A,I8,A,I8)')
      &       ' MDS_WRITE_SEC_YZ: irec: ', irec,
@@ -1327,7 +1262,7 @@ C Create meta-file for each tile if we are tiling
            jG=bj+(myYGlobalLo-1)/sNy
            WRITE(metaFname,'(2A,I3.3,A,I3.3,A)')
      &              pfName(1:pIL),'.',iG,'.',jG,'.meta'
-           dimList(1,1) = ySize
+           dimList(1,1) = Ny
            dimList(2,1) = tBy + 1
            dimList(3,1) = tBy + tNy
            dimList(1,2) = nNz
@@ -1367,9 +1302,12 @@ C Create meta-file for the global-file (also if useSingleCpuIO)
       IF ( writeMetaF .AND. iAmDoingIO .AND.
      &    (globalFile .OR. useSingleCpuIO) ) THEN
          WRITE(metaFName,'(2A)') fName(1:IL),'.meta'
-         dimList(1,1) = ySize
+         dimList(1,1) = Ny
          dimList(2,1) = 1
-         dimList(3,1) = ySize
+         dimList(3,1) = Ny
+         ! dimList(1,2) = nPx
+         ! dimList(2,2) = 1
+         ! dimList(3,2) = nPx
          dimList(1,2) = nNz
          dimList(2,2) = 1
          dimList(3,2) = nNz

--- a/pkg/mdsio/mdsio_write_section.F
+++ b/pkg/mdsio/mdsio_write_section.F
@@ -291,10 +291,12 @@ C Master thread of process 0, only, opens a global file
        ENDIF
 
 C Gather array and write it to file, one vertical level at a time
-       DO k=kLo,kHi
-        zeroBuff = k.EQ.kLo
-C-      copy from fldRL/RS(level=k) to 2-D "local":
-        IF ( filePrec.EQ.precFloat32 ) THEN
+      DO k=kLo,kHi
+       zeroBuff = k.EQ.kLo
+C-     copy from fldRL/RS(level=k) to 2-D "local":
+       IF ( filePrec.EQ.precFloat32 ) THEN
+         DO bj=1,nSy
+         DO bi=1,nSx
           IF ( arrType.EQ.'RS' ) THEN
             CALL MDS_SEG4toRS_2D( sNx*nSx, oLx, kSize, bi, bj, k,
      &                            .FALSE., r4seg, fldRS )
@@ -308,6 +310,8 @@ C-      copy from fldRL/RS(level=k) to 2-D "local":
             CALL ALL_PROC_DIE( myThid )
             STOP 'ABNORMAL END: S/R MDS_WRITE_SEC_XZ'
           ENDIF
+         ENDDO
+         ENDDO
 C Wait for all threads to finish filling shared buffer
           CALL BAR2( myThid )
 #ifdef ALLOW_EXCH2
@@ -328,6 +332,8 @@ C Wait for all threads to finish filling shared buffer
 #endif
 
         ELSEIF ( filePrec.EQ.precFloat64 ) THEN
+         DO bj=1,nSy
+         DO bi=1,nSx
           IF ( arrType.EQ.'RS' ) THEN
             CALL MDS_SEG8toRS_2D( sNx*nSx, oLx, kSize, bi, bj, k,
      I                         .FALSE., r8seg, fldRS )
@@ -341,6 +347,8 @@ C Wait for all threads to finish filling shared buffer
             CALL ALL_PROC_DIE( myThid )
             STOP 'ABNORMAL END: S/R MDS_WRITE_SEC_XZ'
           ENDIF
+         ENDDO
+         ENDDO
 C Wait for all threads to finish filling shared buffer
           CALL BAR2( myThid )
 #ifdef ALLOW_EXCH2
@@ -428,6 +436,8 @@ C  to continue to acces 3-D buffer while this thread is filling it.
 C---    Copy from fldRL/RS to 3-D buffer (multi-threads):
        DO k=kLo,kHi
         zeroBuff = k.EQ.kLo
+        DO bj=1,nSy
+        DO bi=1,nSx
 C-      copy from fldRL/RS(level=k) to 2-D "local":
         IF ( filePrec.EQ.precFloat32 ) THEN
           IF ( arrType.EQ.'RS' ) THEN
@@ -466,6 +476,8 @@ C-      copy from fldRL/RS(level=k) to 2-D "local":
           CALL ALL_PROC_DIE( myThid )
           STOP 'ABNORMAL END: S/R MDS_WRITE_SEC_XZ'
         ENDIF
+        ENDDO
+        ENDDO
 C-     end of k loop
        ENDDO
 
@@ -555,12 +567,15 @@ C If we are writing to a tiled MDS file then we open each one here
            ENDIF
            fileIsOpen=.TRUE.
 
-           irec = k+kSize*(irecord-1)
-           IF ( filePrec.EQ.precFloat32 ) THEN
-             WRITE(dUnit,rec=irec) r4seg
-           ELSE
-             WRITE(dUnit,rec=irec) r8seg
-           ENDIF
+           DO k=kLo,kHi
+            irec = k+kSize*(irecord-1)
+            IF ( filePrec.EQ.precFloat32 ) THEN
+              WRITE(dUnit,rec=irec) r4seg
+            ELSE
+              WRITE(dUnit,rec=irec) r8seg
+            ENDIF
+C End of k loop
+           ENDDO
 
 C here We close the tiled MDS file
            IF ( fileIsOpen ) THEN
@@ -926,10 +941,13 @@ C Master thread of process 0, only, opens a global file
        ENDIF
 
 C Gather array and write it to file, one vertical level at a time
-       DO k=kLo,kHi
-        zeroBuff = k.EQ.kLo
-C-      copy from fldRL/RS(level=k) to 2-D "local":
-        IF ( filePrec.EQ.precFloat32 ) THEN
+
+      DO k=kLo,kHi
+       zeroBuff = k.EQ.kLo
+C-     copy from fldRL/RS(level=k) to 2-D "local":
+       IF ( filePrec.EQ.precFloat32 ) THEN
+         DO bj=1,nSy
+         DO bi=1,nSx
           IF ( arrType.EQ.'RS' ) THEN
             CALL MDS_SEG4toRS_2D( sNy*nSy, oLy, kSize, bi, bj, k,
      &                            .FALSE., r4seg, fldRS )
@@ -943,6 +961,8 @@ C-      copy from fldRL/RS(level=k) to 2-D "local":
             CALL ALL_PROC_DIE( myThid )
             STOP 'ABNORMAL END: S/R MDS_WRITE_SEC_YZ'
           ENDIF
+         ENDDO
+         ENDDO
 C Wait for all threads to finish filling shared buffer
           CALL BAR2( myThid )
 #ifdef ALLOW_EXCH2
@@ -963,6 +983,8 @@ C Wait for all threads to finish filling shared buffer
 #endif
 
         ELSEIF ( filePrec.EQ.precFloat64 ) THEN
+         DO bj=1,nSy
+         DO bi=1,nSx
           IF ( arrType.EQ.'RS' ) THEN
             CALL MDS_SEG8toRS_2D( sNy*nSy, oLy, kSize, bi, bj, k,
      I                         .FALSE., r8seg, fldRS )
@@ -976,6 +998,8 @@ C Wait for all threads to finish filling shared buffer
             CALL ALL_PROC_DIE( myThid )
             STOP 'ABNORMAL END: S/R MDS_WRITE_SEC_YZ'
           ENDIF
+         ENDDO
+         ENDDO
 C Wait for all threads to finish filling shared buffer
           CALL BAR2( myThid )
 #ifdef ALLOW_EXCH2
@@ -1063,6 +1087,9 @@ C  to continue to acces 3-D buffer while this thread is filling it.
 C---    Copy from fldRL/RS to 3-D buffer (multi-threads):
        DO k=kLo,kHi
         zeroBuff = k.EQ.kLo
+        DO bj=1,nSy
+        DO bi=1,nSx
+
 C-      copy from fldRL/RS(level=k) to 2-D "local":
         IF ( filePrec.EQ.precFloat32 ) THEN
           IF ( arrType.EQ.'RS' ) THEN
@@ -1101,6 +1128,8 @@ C-      copy from fldRL/RS(level=k) to 2-D "local":
           CALL ALL_PROC_DIE( myThid )
           STOP 'ABNORMAL END: S/R MDS_WRITE_SEC_YZ'
         ENDIF
+        ENDDO
+        ENDDO
 C-     end of k loop
        ENDDO
 
@@ -1133,8 +1162,8 @@ C If we are writing to a global file then we open it here
         ENDIF
 
 C Loop over all tiles
-        DO bj=1,nSx
-         DO bi=1,nSy
+        DO bj=1,nSy
+         DO bi=1,nSx
 
           tNy = sNy
           global_nTy = ySize/sNy
@@ -1190,12 +1219,15 @@ C If we are writing to a tiled MDS file then we open each one here
            ENDIF
            fileIsOpen=.TRUE.
 
-           irec = k+kSize*(irecord-1)
-           IF ( filePrec.EQ.precFloat32 ) THEN
-             WRITE(dUnit,rec=irec) r4seg
-           ELSE
-             WRITE(dUnit,rec=irec) r8seg
-           ENDIF
+           DO k=kLo,kHi
+            irec = k+kSize*(irecord-1)
+            IF ( filePrec.EQ.precFloat32 ) THEN
+              WRITE(dUnit,rec=irec) r4seg
+            ELSE
+              WRITE(dUnit,rec=irec) r8seg
+            ENDIF
+C End of k loop
+           ENDDO
 
 C here We close the tiled MDS file
            IF ( fileIsOpen ) THEN

--- a/pkg/rw/read_rec.F
+++ b/pkg/rw/read_rec.F
@@ -562,7 +562,7 @@ c     ENDIF
 #ifdef ALLOW_MDSIO
       CALL MDS_READ_SEC_XZ(
      I                      fName, fPrec, useCurrentDir,
-     I                      fType, nNz,
+     I                      fType, nNz, 1, nNz,
      O                      dummyRL, field,
      I                      iRec, myThid )
 #endif
@@ -624,7 +624,7 @@ c     ENDIF
 #ifdef ALLOW_MDSIO
       CALL MDS_READ_SEC_XZ(
      I                      fName, fPrec, useCurrentDir,
-     I                      fType, nNz,
+     I                      fType, nNz, 1, nNz,
      O                      field, dummyRS,
      I                      iRec, myThid )
 #endif
@@ -687,7 +687,7 @@ c     ENDIF
 #ifdef ALLOW_MDSIO
       CALL MDS_READ_SEC_YZ(
      I                      fName, fPrec, useCurrentDir,
-     I                      fType, nNz,
+     I                      fType, nNz, 1, nNz,
      O                      dummyRL, field,
      I                      iRec, myThid )
 #endif
@@ -750,7 +750,7 @@ c     ENDIF
 #ifdef ALLOW_MDSIO
       CALL MDS_READ_SEC_YZ(
      I                      fName, fPrec, useCurrentDir,
-     I                      fType, nNz,
+     I                      fType, nNz, 1, nNz,
      O                      field, dummyRS,
      I                      iRec, myThid )
 #endif

--- a/pkg/rw/write_rec.F
+++ b/pkg/rw/write_rec.F
@@ -655,7 +655,7 @@ c     ENDIF
 #ifdef ALLOW_MDSIO
       CALL MDS_WRITE_SEC_XZ(
      I                       fName, fPrec, globalFile, useCurrentDir,
-     I                       fType, nNz,
+     I                       fType, nNz, 1, nNz,
      I                       dummyRL, field,
      I                       iRec, myIter, myThid )
 #endif
@@ -721,7 +721,7 @@ c     ENDIF
 #ifdef ALLOW_MDSIO
       CALL MDS_WRITE_SEC_XZ(
      I                       fName, fPrec, globalFile, useCurrentDir,
-     I                       fType, nNz,
+     I                       fType, nNz, 1, nNz,
      I                       field, dummyRS,
      I                       iRec, myIter, myThid )
 #endif
@@ -788,7 +788,7 @@ c     ENDIF
 #ifdef ALLOW_MDSIO
       CALL MDS_WRITE_SEC_YZ(
      I                       fName, fPrec, globalFile, useCurrentDir,
-     I                       fType, nNz,
+     I                       fType, nNz, 1, nNz,
      I                       dummyRL, field,
      I                       iRec, myIter, myThid )
 #endif
@@ -855,7 +855,7 @@ c     ENDIF
 #ifdef ALLOW_MDSIO
       CALL MDS_WRITE_SEC_YZ(
      I                       fName, fPrec, globalFile, useCurrentDir,
-     I                       fType, nNz,
+     I                       fType, nNz, 1, nNz,
      I                       field, dummyRS,
      I                       iRec, myIter, myThid )
 #endif


### PR DESCRIPTION
## What changes does this PR introduce?
(Bug fix, feature, docs update, ...)

The current mdsio read/write routines for YZ or XZ slices don't take `useSingleCPUIO` into account, and also mds_write_sec_[xz/yz] do not write meta files. This PR makes some additions so that both of these are addressed: the mdsio read/write routines follow the same single cpu io logic as mds_write_field, and prints meta files accordingly.

Perhaps the first issue, whether mds_[read/write]_sec uses singlecpuio logic or not, does not matter. I found it to be annoying that this was turned on, yet all the xx_obcs files always print out as tiled files (since pkg/autodiff always uses non global files). I dug into addressing this (which turned out to be more tedious than expected...) and figured I would open up the PR to see what people think. I think that at least writing meta files would be a useful addition, although relatively minor.

## What is the current behaviour? 
(You can also link to an open issue here)

It does not matter if singlecpuio is turned on for sliced fields. The time where I noticed this is with the autodiff+obcs+ctrl packages in use. 

## What is the new behaviour 
(if this is a feature change)?

Now if singlecpuio is turned on, xz or yz slices are read/written with the master process via some new scatter/gather routines. 

## Does this PR introduce a breaking change? 
(What changes might users need to make in their application due to this PR?)

Honestly, it might. I did not wade through the exch2 logic dutifully since it is very confusing and I'm not familiar with it. At least something that needs to change is the size of the `x_buffer` and `y_buffer` fields in `mdsio_[read/write]_section`, and the indexing that happens in the [scatter/gather]_[xz/yz] routines could be incorrect. However, I wanted to see if anyone thinks this is worth keeping before digging into that... 

Another catch is with the gather_[xz/yz] routines. In this routine it's not clear which processor has the sliced information. For instance, if the slice is on one of the boundaries, then it would live on all the processors (and tiles) that intersect with the boundary. This would be difficult and perhaps overly intrusive to determine or pass as an input to the gather routine, so I solved this by simply only passing values to the global buffer if they are nonzero. Presumably, the sliced data are zero on all processors and tiles except where that slice is "active", and nonzero only where it is active, and the gather routine would then successfully grab the nonzero information. This was just a first pass so could be faulty (and all of this not worth it at all), but I'd be curious what the gurus think...

## Other information:


## Suggested addition to `tag-index`
(To avoid unnecessary merge conflicts, please don't update `tag-index`. One of the admins will do that when merging your pull request.)

o mdsio_[read/write]_section rewritten to include useSingleCPUIO logic, mirroring mdsio_[read/write]_field
o [scatter/gather]_[xz/yz]_[r4/r8] routines added