### PR TITLE
Minor tweak to "do_tst_2+2" script

### DIFF
--- a/doc/tag-index
+++ b/doc/tag-index
@@ -1,9 +1,13 @@
     Notes on tags used in MITgcmUV
     ==============================
 
-o model/src
-  - fix 2 missing TAF initialisation directives in file "the_main_loop.F"; this allows to use
-    TAF recent version 5.0.9 (that does check for missing initialisation).
+o tools/do_tst_2+2:
+  - for sending restart test output, add same hack in "send" option as in
+    testreport, allowing to use "scp" (instead of an email).
+o model/src:
+  - fix 2 missing TAF initialisation directives in file "the_main_loop.F";
+    this allows to use TAF recent version 5.0.9 (that does check for missing
+    initialisation).
 o pkg/seaice:
   - fix diagnostics additions (from PR #348) for case _RS is real*4.
 

--- a/tools/do_tst_2+2
+++ b/tools/do_tst_2+2
@@ -271,10 +271,12 @@ if test "x$ADDRESS" != xNONE -a "x$ADDRESS" != x ; then
       fi
     fi
     if test "x$SENDCMD" != x ; then
-        #echo " run: $SENDCMD -s MITgcm-test -m 3555000  ${SAVDIR}/${DRESULTS}".tar.gz" $ADDRESS"
+        SendOpt='' ; headCMD=`echo $SENDCMD | awk '{print $1}'`
+        if test $headCMD != 'scp' ; then SendOpt='-s MITgcm-test -m 3555000' ; fi
+        #echo " run: $SENDCMD $SendOpt ${SAVDIR}/${DRESULTS}".tar.gz" $ADDRESSES"
         tar -cf  ${SAVDIR}/${DRESULTS}".tar" $DRESULTS > /dev/null 2>&1 \
             && gzip  ${SAVDIR}/${DRESULTS}".tar" \
-            && $SENDCMD -s MITgcm-test -m 3555000  ${SAVDIR}/${DRESULTS}".tar.gz" $ADDRESS
+            && $SENDCMD $SendOpt ${SAVDIR}/${DRESULTS}".tar.gz" $ADDRESS
         out=$?
         if test "x$out" != x0 ; then
             echo


### PR DESCRIPTION
Import same hack in "send" option (for sending output) as in
testreport, allowing to use "scp" (instead of an email) for sending restart test output.

## What changes does this PR introduce?
Minor addition to test-script "do_tst_2+2" regarding sending test-results,
that was already available for "testreport" but not for do_tst_2+2.

## What is the current behaviour? 
Only allow to send output through email

## What is the new behaviour 
Also allow to send output via "scp"

## Does this PR introduce a breaking change? 
no

## Other information:
Not very useful for sending output to official testing results repository
since might run into permission problems. But still good for sending output to user own
output storage.

## Suggested addition to `tag-index`
o tools/do_tst_2+2
  - for sending restart test output, add same hack in "send" option as in
    testreport, allowing to use "scp" (instead of an email).

