### PR TITLE
Fix a bug and add a CPP option in the Held Suarez temperature forcing.

### DIFF
--- a/verification/tutorial_held_suarez_cs/code/apply_forcing.F
+++ b/verification/tutorial_held_suarez_cs/code/apply_forcing.F
@@ -247,15 +247,30 @@ CEOP
 
 C--   Forcing term
       ka = 1. _d 0/(40. _d 0*86400. _d 0)
+#ifdef TOP_HEAVY_HEATING
+      ks = 1. _d 0/(20. _d 0 *86400. _d 0)
+#else
       ks = 1. _d 0/(4. _d 0 *86400. _d 0)
+#endif
+C--   Hing Ong, 23 Aug 2020
+#ifdef TOP_HEAVY_HEATING
+C--   Tropopause
+      sigma_b = 0.1 _d 0
+#else
+C--   Top of planetary boundary layer
       sigma_b = 0.7 _d 0
+#endif
+C--   Hing Ong, 23 Aug 2020
       rFullDepth = rF(1)-rF(Nr+1)
       DO j=0,sNy+1
        DO i=0,sNx+1
          term1 = 60. _d 0*(SIN(yC(i,j,bi,bj)*deg2rad)**2)
          termP = 0.5 _d 0*( rF(k) + rF(k+1) )
-         term2 = 10. _d 0*LOG(termP/atm_po)
+C--   Bug fix
+c         term2 = 10. _d 0*LOG(termP/atm_po)
+         term2 = 10. _d 0*LOG10(termP/atm_po)
      &            *(COS(yC(i,j,bi,bj)*deg2rad)**2)
+C--   Hing Ong, 23 Aug 2020
          thetaLim = 200. _d 0/ ((termP/atm_po)**atm_kappa)
          thetaEq = 315. _d 0 - term1 - term2
          thetaEq = MAX(thetaLim,thetaEq)
@@ -281,8 +296,13 @@ C-  which simplifies to:
      &          + bHybSigmC(k)
          ENDIF
          kT = ka+(ks-ka)
+#ifdef TOP_HEAVY_HEATING
+     &      *MAX(zeroRL,SIN(PI*(termP-sigma_b)/(1. _d 0-sigma_b))/termP)
+#else
      &      *MAX( zeroRL, (termP-sigma_b)/(1. _d 0-sigma_b) )
+#endif
      &      *COS((yC(i,j,bi,bj)*deg2rad))**4
+C--   Hing Ong, 23 Aug 2020
          gT_arr(i,j) = gT_arr(i,j)
      &               - kT*( theta(i,j,k,bi,bj)-thetaEq )
      &                *maskC(i,j,k,bi,bj)

--- a/verification/tutorial_held_suarez_cs/results/output.txt
+++ b/verification/tutorial_held_suarez_cs/results/output.txt
@@ -5,10 +5,10 @@
 (PID.TID 0000.0001) // ======================================================
 (PID.TID 0000.0001) // execution environment starting up...
 (PID.TID 0000.0001) 
-(PID.TID 0000.0001) // MITgcmUV version:  checkpoint64w
-(PID.TID 0000.0001) // Build user:        jmc
-(PID.TID 0000.0001) // Build host:        baudelaire
-(PID.TID 0000.0001) // Build date:        Sun May 11 21:51:26 EDT 2014
+(PID.TID 0000.0001) // MITgcmUV version:  checkpoint67s
+(PID.TID 0000.0001) // Build user:        hing5ong
+(PID.TID 0000.0001) // Build host:        cori11
+(PID.TID 0000.0001) // Build date:        Wed Aug 26 13:40:06 PDT 2020
 (PID.TID 0000.0001) 
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // Execution Environment parameter file "eedata"
@@ -23,7 +23,7 @@
 (PID.TID 0000.0001) >#nTx=2,
 (PID.TID 0000.0001) >#nTx=3,
 (PID.TID 0000.0001) >#nTx=6,
-(PID.TID 0000.0001) > /
+(PID.TID 0000.0001) > &
 (PID.TID 0000.0001) ># Note: Some systems use & as the
 (PID.TID 0000.0001) ># namelist terminator. Other systems
 (PID.TID 0000.0001) ># use a / character (as shown here).
@@ -52,8 +52,10 @@
 (PID.TID 0000.0001)                   /*  note: To execute a program with MPI calls */
 (PID.TID 0000.0001)                   /*  it must be launched appropriately e.g     */
 (PID.TID 0000.0001)                   /*  "mpirun -np 64 ......"                    */
-(PID.TID 0000.0001) useCoupler=    F ;/* Flag used to control communications with   */
+(PID.TID 0000.0001) useCoupler=   F ; /* Flag used to control communications with   */
 (PID.TID 0000.0001)                   /*  other model components, through a coupler */
+(PID.TID 0000.0001) useNest2W_parent =    F ;/* Control 2-W Nesting comm */
+(PID.TID 0000.0001) useNest2W_child  =    F ;/* Control 2-W Nesting comm */
 (PID.TID 0000.0001) debugMode =    F ; /* print debug msg. (sequence of S/R calls)  */
 (PID.TID 0000.0001) printMapIncludesZeros=    F ; /* print zeros in Std.Output maps */
 (PID.TID 0000.0001) maxLengthPrt1D=   65 /* maxLength of 1D array printed to StdOut */
@@ -105,14 +107,14 @@
 (PID.TID 0000.0001) > staggerTimeStep=.TRUE.,
 (PID.TID 0000.0001) > readBinaryPrec=64,
 (PID.TID 0000.0001) > writeBinaryPrec=64,
-(PID.TID 0000.0001) > /
+(PID.TID 0000.0001) > &
 (PID.TID 0000.0001) >
 (PID.TID 0000.0001) ># Elliptic solver parameters
 (PID.TID 0000.0001) > &PARM02
 (PID.TID 0000.0001) > cg2dMaxIters=200,
 (PID.TID 0000.0001) >#cg2dTargetResidual=1.E-12,
 (PID.TID 0000.0001) > cg2dTargetResWunit=1.E-17,
-(PID.TID 0000.0001) > /
+(PID.TID 0000.0001) > &
 (PID.TID 0000.0001) >
 (PID.TID 0000.0001) ># Time stepping parameters
 (PID.TID 0000.0001) > &PARM03
@@ -132,7 +134,7 @@
 (PID.TID 0000.0001) >#- to run a short test (2.h):
 (PID.TID 0000.0001) > nTimeSteps=16,
 (PID.TID 0000.0001) > monitorFreq=1.,
-(PID.TID 0000.0001) > /
+(PID.TID 0000.0001) > &
 (PID.TID 0000.0001) >
 (PID.TID 0000.0001) ># Gridding parameters
 (PID.TID 0000.0001) > &PARM04
@@ -140,13 +142,12 @@
 (PID.TID 0000.0001) > horizGridFile='grid_cs32',
 (PID.TID 0000.0001) > radius_fromHorizGrid=6370.E3,
 (PID.TID 0000.0001) > delR=20*50.E2,
-(PID.TID 0000.0001) > Ro_SeaLevel=1.E5,
-(PID.TID 0000.0001) > /
+(PID.TID 0000.0001) > &
 (PID.TID 0000.0001) >
 (PID.TID 0000.0001) ># Input datasets
 (PID.TID 0000.0001) > &PARM05
 (PID.TID 0000.0001) >#topoFile='topo.cs.bin',
-(PID.TID 0000.0001) > /
+(PID.TID 0000.0001) > &
 (PID.TID 0000.0001) 
 (PID.TID 0000.0001)  INI_PARMS ; starts to read PARM01
 (PID.TID 0000.0001)  INI_PARMS ; read PARM01 : OK
@@ -169,21 +170,19 @@
 (PID.TID 0000.0001) > useSHAP_FILT=.TRUE.,
 (PID.TID 0000.0001) > useDiagnostics=.TRUE.,
 (PID.TID 0000.0001) >#useMNC=.TRUE.,
-(PID.TID 0000.0001) > /
+(PID.TID 0000.0001) > &
 (PID.TID 0000.0001) 
 (PID.TID 0000.0001)  PACKAGES_BOOT: finished reading data.pkg
 (PID.TID 0000.0001)  PACKAGES_BOOT: On/Off package Summary
  --------  pkgs with a standard "usePKG" On/Off switch in "data.pkg":  --------
  pkg/shap_filt            compiled   and   used ( useSHAP_FILT             = T )
  pkg/diagnostics          compiled   and   used ( useDiagnostics           = T )
- pkg/mnc                  compiled but not used ( useMNC                   = F )
  -------- pkgs without standard "usePKG" On/Off switch in "data.pkg":  --------
  pkg/generic_advdiff      compiled   and   used ( useGAD                   = T )
  pkg/mom_common           compiled   and   used ( momStepping              = T )
  pkg/mom_vecinv           compiled   and   used ( +vectorInvariantMomentum = T )
  pkg/mom_fluxform         compiled but not used ( & not vectorInvariantMom = F )
  pkg/monitor              compiled   and   used ( monitorFreq > 0.         = T )
- pkg/timeave              compiled but not used ( taveFreq > 0.            = F )
  pkg/debug                compiled but not used ( debugMode                = F )
  pkg/exch2                compiled   and   used
  pkg/rw                   compiled   and   used
@@ -209,7 +208,7 @@
 (PID.TID 0000.0001) >#Shap_Trtau=5400.,
 (PID.TID 0000.0001) >#Shap_uvtau=1800.,
 (PID.TID 0000.0001) >#Shap_diagFreq=2592000.,
-(PID.TID 0000.0001) > /
+(PID.TID 0000.0001) > &
 (PID.TID 0000.0001) 
 (PID.TID 0000.0001)  SHAP_FILT_READPARMS: finished reading data.shap
 (PID.TID 0000.0001) Shap_funct =   /* select Shapiro filter function */
@@ -301,7 +300,7 @@
 (PID.TID 0000.0001) >   fileName(3) = 'secmomDiag',
 (PID.TID 0000.0001) ># frequency(3) = 2592000.,
 (PID.TID 0000.0001) >  frequency(3) = 86400.,
-(PID.TID 0000.0001) > /
+(PID.TID 0000.0001) > &
 (PID.TID 0000.0001) >
 (PID.TID 0000.0001) >#--------------------
 (PID.TID 0000.0001) ># Parameter for Diagnostics of per level statistics:
@@ -327,7 +326,7 @@
 (PID.TID 0000.0001) >#  stat_freq(1)= -864000.,
 (PID.TID 0000.0001) >   stat_freq(1)= -3600.,
 (PID.TID 0000.0001) ># stat_phase(1) = 0.,
-(PID.TID 0000.0001) > /
+(PID.TID 0000.0001) > &
 (PID.TID 0000.0001) >
 (PID.TID 0000.0001) 
 (PID.TID 0000.0001) S/R DIAGNOSTICS_READPARMS, read namelist "diagnostics_list": start
@@ -349,6 +348,9 @@
 (PID.TID 0000.0001)     ;
 (PID.TID 0000.0001)  diagCG_resTarget = /* residual target for diag_cg2d */
 (PID.TID 0000.0001)                 1.000000000000000E-07
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001)  diagCG_pcOffDFac = /* preconditioner off-diagonal factor */
+(PID.TID 0000.0001)                 9.611687812379854E-01
 (PID.TID 0000.0001)     ;
 (PID.TID 0000.0001) -----------------------------------------------------
 (PID.TID 0000.0001)  DIAGNOSTICS_READPARMS: active diagnostics summary:
@@ -628,7 +630,7 @@
 (PID.TID 0000.0001) // ===================================
 (PID.TID 0000.0001) ------------------------------------------------------------
 (PID.TID 0000.0001) DIAGNOSTICS_SET_LEVELS: done
-(PID.TID 0000.0001)  Total Nb of available Diagnostics: ndiagt=   187
+(PID.TID 0000.0001)  Total Nb of available Diagnostics: ndiagt=   196
 (PID.TID 0000.0001)  write list of available Diagnostics to file: available_diagnostics.log
 (PID.TID 0000.0001) SETDIAG: Allocate  1 x  1 Levels for Diagnostic #    23 ETAN
 (PID.TID 0000.0001) SETDIAG: Allocate  1 x  1 Levels for Diagnostic #    24 ETANSQ
@@ -637,7 +639,7 @@
 (PID.TID 0000.0001) SETDIAG: Allocate 20 x  1 Levels for Diagnostic #    30 VVEL
 (PID.TID 0000.0001) SETDIAG: Allocate 20 x  1 Levels for Diagnostic #    31 WVEL
 (PID.TID 0000.0001) SETDIAG: Allocate 20 x  1 Levels for Diagnostic #    26 THETA
-(PID.TID 0000.0001) SETDIAG: Allocate 20 x  1 Levels for Diagnostic #   185 SHAP_dU
+(PID.TID 0000.0001) SETDIAG: Allocate 20 x  1 Levels for Diagnostic #   194 SHAP_dU
 (PID.TID 0000.0001) SETDIAG: Allocate 20 x  1 Levels for Diagnostic #    34 UVELSQ
 (PID.TID 0000.0001) SETDIAG: Allocate 20 x  1 Levels for Diagnostic #    35 VVELSQ
 (PID.TID 0000.0001) SETDIAG: Allocate 20 x  1 Levels for Diagnostic #    36 WVELSQ
@@ -766,11 +768,17 @@
 (PID.TID 0000.0001) no_slip_bottom =  /* Viscous BCs: No-slip bottom */
 (PID.TID 0000.0001)                   F
 (PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) bottomVisc_pCell = /* Partial-cell in bottom Visc. BC */
+(PID.TID 0000.0001)                   F
+(PID.TID 0000.0001)     ;
 (PID.TID 0000.0001) bottomDragLinear = /* linear bottom-drag coefficient ( m/s ) */
 (PID.TID 0000.0001)                 0.000000000000000E+00
 (PID.TID 0000.0001)     ;
 (PID.TID 0000.0001) bottomDragQuadratic = /* quadratic bottom-drag coefficient (-) */
 (PID.TID 0000.0001)                 0.000000000000000E+00
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) selectBotDragQuadr = /* select quadratic bottom drag options */
+(PID.TID 0000.0001)                      -1
 (PID.TID 0000.0001)     ;
 (PID.TID 0000.0001) diffKhT =   /* Laplacian diffusion of heat laterally ( m^2/s ) */
 (PID.TID 0000.0001)                 0.000000000000000E+00
@@ -817,6 +825,9 @@
 (PID.TID 0000.0001) eosType =  /* Type of Equation of State */
 (PID.TID 0000.0001)               'IDEALG'
 (PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) surf_pRef = /* Surface reference pressure ( Pa ) */
+(PID.TID 0000.0001)                 1.013250000000000E+05
+(PID.TID 0000.0001)     ;
 (PID.TID 0000.0001) celsius2K = /* 0 degree Celsius converted to Kelvin ( K ) */
 (PID.TID 0000.0001)                 2.731500000000000E+02
 (PID.TID 0000.0001)     ;
@@ -862,6 +873,12 @@
 (PID.TID 0000.0001) gBaro =   /* Barotropic gravity ( m/s^2 ) */
 (PID.TID 0000.0001)                 9.810000000000000E+00
 (PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) gravFacC = /* gravity factor (vs surf.) @ cell-Center (-) */
+(PID.TID 0000.0001)    20 @  1.000000000000000E+00              /* K =  1: 20 */
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) gravFacF = /* gravity factor (vs surf.) @ W-Interface (-) */
+(PID.TID 0000.0001)    21 @  1.000000000000000E+00              /* K =  1: 21 */
+(PID.TID 0000.0001)     ;
 (PID.TID 0000.0001) rotationPeriod =   /* Rotation Period ( s ) */
 (PID.TID 0000.0001)                 8.640000000000000E+04
 (PID.TID 0000.0001)     ;
@@ -889,7 +906,7 @@
 (PID.TID 0000.0001) implicSurfPress =  /* Surface Pressure implicit factor (0-1)*/
 (PID.TID 0000.0001)                 1.000000000000000E+00
 (PID.TID 0000.0001)     ;
-(PID.TID 0000.0001) implicDiv2Dflow =  /* Barot. Flow Div. implicit factor (0-1)*/
+(PID.TID 0000.0001) implicDiv2DFlow =  /* Barot. Flow Div. implicit factor (0-1)*/
 (PID.TID 0000.0001)                 1.000000000000000E+00
 (PID.TID 0000.0001)     ;
 (PID.TID 0000.0001) uniformLin_PhiSurf = /* use uniform Bo_surf on/off flag*/
@@ -983,6 +1000,10 @@
 (PID.TID 0000.0001) implicitViscosity = /* Implicit viscosity on/off flag */
 (PID.TID 0000.0001)                   F
 (PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) selectImplicitDrag= /* Implicit bot Drag options (0,1,2)*/
+(PID.TID 0000.0001)                       0
+(PID.TID 0000.0001)     0= Expl. ; 1= Impl. on provis. Vel ; 2= Fully Impl (with surf.P)
+(PID.TID 0000.0001)     ;
 (PID.TID 0000.0001) metricTerms =  /* metric-Terms on/off flag */
 (PID.TID 0000.0001)                   F
 (PID.TID 0000.0001)     ;
@@ -1002,14 +1023,12 @@
 (PID.TID 0000.0001) useCDscheme =  /* CD scheme on/off flag */
 (PID.TID 0000.0001)                   F
 (PID.TID 0000.0001)     ;
-(PID.TID 0000.0001) useEnergyConservingCoriolis= /* Flx-Form Coriolis scheme flag */
-(PID.TID 0000.0001)                   F
-(PID.TID 0000.0001)     ;
-(PID.TID 0000.0001) useJamartWetPoints= /* Coriolis WetPoints method flag */
-(PID.TID 0000.0001)                   F
-(PID.TID 0000.0001)     ;
-(PID.TID 0000.0001) useJamartMomAdv= /* V.I Non-linear terms Jamart flag */
-(PID.TID 0000.0001)                   F
+(PID.TID 0000.0001) selectCoriScheme= /* Scheme selector for Coriolis-Term */
+(PID.TID 0000.0001)                       0
+(PID.TID 0000.0001)    = 0 : original discretization (simple averaging, no hFac)
+(PID.TID 0000.0001)    = 1 : Wet-point averaging (Jamar & Ozer 1986)
+(PID.TID 0000.0001)    = 2 : hFac weighted average (Angular Mom. conserving)
+(PID.TID 0000.0001)    = 3 : energy conserving scheme using hFac weighted average
 (PID.TID 0000.0001)     ;
 (PID.TID 0000.0001) useAbsVorticity= /* V.I Works with f+zeta in Coriolis */
 (PID.TID 0000.0001)                   F
@@ -1021,6 +1040,9 @@
 (PID.TID 0000.0001)    = 2 : energy conserving scheme (used by Sadourny in JAS 75 paper)
 (PID.TID 0000.0001)    = 3 : energy (general) and enstrophy (2D, nonDiv.) conserving scheme
 (PID.TID 0000.0001)          from Sadourny (Burridge & Haseler, ECMWF Rep.4, 1977)
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) useJamartMomAdv= /* V.I Non-linear terms Jamart flag */
+(PID.TID 0000.0001)                   F
 (PID.TID 0000.0001)     ;
 (PID.TID 0000.0001) upwindVorticity= /* V.I Upwind bias vorticity flag */
 (PID.TID 0000.0001)                   F
@@ -1035,6 +1057,9 @@
 (PID.TID 0000.0001)                       0
 (PID.TID 0000.0001)     ;
 (PID.TID 0000.0001) momForcing =  /* Momentum forcing on/off flag */
+(PID.TID 0000.0001)                   T
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) momTidalForcing = /* Momentum Tidal forcing on/off flag */
 (PID.TID 0000.0001)                   T
 (PID.TID 0000.0001)     ;
 (PID.TID 0000.0001) momPressureForcing =  /* Momentum pressure term on/off flag */
@@ -1100,6 +1125,12 @@
 (PID.TID 0000.0001) writeBinaryPrec = /* Precision used for writing binary files */
 (PID.TID 0000.0001)                      64
 (PID.TID 0000.0001)     ;
+(PID.TID 0000.0001)  rwSuffixType =   /* select format of mds file suffix */
+(PID.TID 0000.0001)                       0
+(PID.TID 0000.0001)    = 0 : myIter (I10.10) ;   = 1 : 100*myTime (100th sec) ;
+(PID.TID 0000.0001)    = 2 : myTime (seconds);   = 3 : myTime/360 (10th of hr);
+(PID.TID 0000.0001)    = 4 : myTime/3600 (hours)
+(PID.TID 0000.0001)     ;
 (PID.TID 0000.0001)  globalFiles = /* write "global" (=not per tile) files */
 (PID.TID 0000.0001)                   F
 (PID.TID 0000.0001)     ;
@@ -1117,6 +1148,9 @@
 (PID.TID 0000.0001)    debLevD =  4 ; /* level of enhanced debug prt (add DEBUG_STATS prt) */
 (PID.TID 0000.0001)    debLevE =  5 ; /* level of extensive debug printing */
 (PID.TID 0000.0001) debugLevel =  /* select debug printing level */
+(PID.TID 0000.0001)                       2
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001)  plotLevel =  /* select PLOT_FIELD printing level */
 (PID.TID 0000.0001)                       2
 (PID.TID 0000.0001)     ;
 (PID.TID 0000.0001) //
@@ -1179,6 +1213,9 @@
 (PID.TID 0000.0001) abEps =   /* Adams-Bashforth-2 stabilizing weight */
 (PID.TID 0000.0001)                 1.000000000000000E-01
 (PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) applyExchUV_early = /* Apply EXCH to U,V earlier in time-step */
+(PID.TID 0000.0001)                   F
+(PID.TID 0000.0001)     ;
 (PID.TID 0000.0001) pickupStrictlyMatch= /* stop if pickup do not strictly match */
 (PID.TID 0000.0001)                   T
 (PID.TID 0000.0001)     ;
@@ -1212,15 +1249,6 @@
 (PID.TID 0000.0001) pickup_read_mdsio =   /* Model IO flag. */
 (PID.TID 0000.0001)                   T
 (PID.TID 0000.0001)     ;
-(PID.TID 0000.0001) pickup_write_mnc =   /* Model IO flag. */
-(PID.TID 0000.0001)                   F
-(PID.TID 0000.0001)     ;
-(PID.TID 0000.0001) pickup_read_mnc =   /* Model IO flag. */
-(PID.TID 0000.0001)                   F
-(PID.TID 0000.0001)     ;
-(PID.TID 0000.0001) pickup_write_immed =   /* Model IO flag. */
-(PID.TID 0000.0001)                   F
-(PID.TID 0000.0001)     ;
 (PID.TID 0000.0001) writePickupAtEnd =   /* Model IO flag. */
 (PID.TID 0000.0001)                   T
 (PID.TID 0000.0001)     ;
@@ -1233,9 +1261,6 @@
 (PID.TID 0000.0001) snapshot_mdsio =   /* Model IO flag. */
 (PID.TID 0000.0001)                   T
 (PID.TID 0000.0001)     ;
-(PID.TID 0000.0001) snapshot_mnc =   /* Model IO flag. */
-(PID.TID 0000.0001)                   F
-(PID.TID 0000.0001)     ;
 (PID.TID 0000.0001) monitorFreq =   /* Monitor output interval ( s ). */
 (PID.TID 0000.0001)                 1.000000000000000E+00
 (PID.TID 0000.0001)     ;
@@ -1244,9 +1269,6 @@
 (PID.TID 0000.0001)     ;
 (PID.TID 0000.0001) monitor_stdio =   /* Model IO flag. */
 (PID.TID 0000.0001)                   T
-(PID.TID 0000.0001)     ;
-(PID.TID 0000.0001) monitor_mnc =   /* Model IO flag. */
-(PID.TID 0000.0001)                   F
 (PID.TID 0000.0001)     ;
 (PID.TID 0000.0001) externForcingPeriod =   /* forcing period (s) */
 (PID.TID 0000.0001)                 0.000000000000000E+00
@@ -1278,11 +1300,20 @@
 (PID.TID 0000.0001) usingCurvilinearGrid = /* Curvilinear coordinates flag ( True/False ) */
 (PID.TID 0000.0001)                   T
 (PID.TID 0000.0001)     ;
-(PID.TID 0000.0001) selectSigmaCoord = /* Hybrid-Sigma Vert. Coordinate option */
+(PID.TID 0000.0001) useMin4hFacEdges = /* set hFacW,S as minimum of adjacent hFacC factor */
+(PID.TID 0000.0001)                   F
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) interViscAr_pCell = /* account for partial-cell in interior vert. viscosity */
+(PID.TID 0000.0001)                   F
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) interDiffKr_pCell = /* account for partial-cell in interior vert. diffusion */
+(PID.TID 0000.0001)                   F
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) pCellMix_select = /* option to enhance mixing near surface & bottom */
 (PID.TID 0000.0001)                       0
 (PID.TID 0000.0001)     ;
-(PID.TID 0000.0001) Ro_SeaLevel = /* r(1) ( units of r == Pa ) */
-(PID.TID 0000.0001)                 1.000000000000000E+05
+(PID.TID 0000.0001) selectSigmaCoord = /* Hybrid-Sigma Vert. Coordinate option */
+(PID.TID 0000.0001)                       0
 (PID.TID 0000.0001)     ;
 (PID.TID 0000.0001) rSigmaBnd = /* r/sigma transition ( units of r == Pa ) */
 (PID.TID 0000.0001)                 1.234567000000000E+05
@@ -1292,6 +1323,12 @@
 (PID.TID 0000.0001)     ;
 (PID.TID 0000.0001) gravitySign = /* gravity orientation relative to vertical coordinate */
 (PID.TID 0000.0001)                 1.000000000000000E+00
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) seaLev_Z =  /* reference height of sea-level [m] */
+(PID.TID 0000.0001)                 0.000000000000000E+00
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) top_Pres =  /* pressure at the top (r-axis origin) [Pa] */
+(PID.TID 0000.0001)                 0.000000000000000E+00
 (PID.TID 0000.0001)     ;
 (PID.TID 0000.0001) mass2rUnit = /* convert mass per unit area [kg/m2] to r-units [Pa] */
 (PID.TID 0000.0001)                 9.810000000000000E+00
@@ -2280,7 +2317,7 @@ listId=    2 ; file name: dynDiag
     30 |VVEL    |     24 |      4 |  20 |       0 |       0 |
     31 |WVEL    |     44 |      0 |  20 |       0 |
     26 |THETA   |     64 |      0 |  20 |       0 |
-   185 |SHAP_dU |     84 |      0 |  20 |       0 |
+   194 |SHAP_dU |     84 |      0 |  20 |       0 |
 ------------------------------------------------------------------------
 listId=    3 ; file name: secmomDiag
  nFlds, nActive,       freq     &     phase        , nLev               
@@ -2348,6 +2385,9 @@ listId=   1 ; file name: dynStDiag
 (PID.TID 0000.0001) %MON dynstat_salt_mean            =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON dynstat_salt_sd              =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON dynstat_salt_del2            =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON trAdv_CFL_u_max              =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON trAdv_CFL_v_max              =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON trAdv_CFL_w_max              =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON advcfl_uvel_max              =   2.6821335333544E-01
 (PID.TID 0000.0001) %MON advcfl_vvel_max              =   2.2671784577986E-01
 (PID.TID 0000.0001) %MON advcfl_wvel_max              =   7.5004516848636E-02
@@ -2373,10 +2413,10 @@ listId=   1 ; file name: dynStDiag
 (PID.TID 0000.0001) // End MONITOR dynamic field statistics
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) SOLVE_FOR_PRESSURE: putPmEinXvector =    F
- cg2d: Sum(rhs),rhsMax =   3.72529029846191E-09  1.59775201135660E+04
+ cg2d: Sum(rhs),rhsMax =   3.49245965480804E-09  1.59775201135660E+04
 (PID.TID 0000.0001)      cg2d_init_res =   1.75956829843616E+03
 (PID.TID 0000.0001)      cg2d_iters(min,last) =      -1      16
-(PID.TID 0000.0001)      cg2d_last_res =   4.58207194232493E-11
+(PID.TID 0000.0001)      cg2d_last_res =   4.58207194232495E-11
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // Begin MONITOR dynamic field statistics
 (PID.TID 0000.0001) // =======================================================
@@ -2399,19 +2439,22 @@ listId=   1 ; file name: dynStDiag
 (PID.TID 0000.0001) %MON dynstat_vvel_del2            =   1.1017027456424E-02
 (PID.TID 0000.0001) %MON dynstat_wvel_max             =   8.2394353142281E-01
 (PID.TID 0000.0001) %MON dynstat_wvel_min             =  -6.5576433650088E-01
-(PID.TID 0000.0001) %MON dynstat_wvel_mean            =   1.2310000703603E-17
+(PID.TID 0000.0001) %MON dynstat_wvel_mean            =   1.2068628140787E-17
 (PID.TID 0000.0001) %MON dynstat_wvel_sd              =   6.5534529222795E-02
 (PID.TID 0000.0001) %MON dynstat_wvel_del2            =   2.0602523810001E-04
 (PID.TID 0000.0001) %MON dynstat_theta_max            =   5.9603047092135E+02
-(PID.TID 0000.0001) %MON dynstat_theta_min            =   2.6186139259701E+02
-(PID.TID 0000.0001) %MON dynstat_theta_mean           =   3.2766071549124E+02
-(PID.TID 0000.0001) %MON dynstat_theta_sd             =   6.3757543866062E+01
-(PID.TID 0000.0001) %MON dynstat_theta_del2           =   5.1661175620448E-03
+(PID.TID 0000.0001) %MON dynstat_theta_min            =   2.6186139014729E+02
+(PID.TID 0000.0001) %MON dynstat_theta_mean           =   3.2766044326158E+02
+(PID.TID 0000.0001) %MON dynstat_theta_sd             =   6.3757608643319E+01
+(PID.TID 0000.0001) %MON dynstat_theta_del2           =   5.1661173661045E-03
 (PID.TID 0000.0001) %MON dynstat_salt_max             =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON dynstat_salt_min             =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON dynstat_salt_mean            =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON dynstat_salt_sd              =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON dynstat_salt_del2            =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON trAdv_CFL_u_max              =   2.9316619048753E-01
+(PID.TID 0000.0001) %MON trAdv_CFL_v_max              =   3.0913720621363E-01
+(PID.TID 0000.0001) %MON trAdv_CFL_w_max              =   7.3328810522297E-02
 (PID.TID 0000.0001) %MON advcfl_uvel_max              =   2.6844154766907E-01
 (PID.TID 0000.0001) %MON advcfl_vvel_max              =   2.2658765997300E-01
 (PID.TID 0000.0001) %MON advcfl_wvel_max              =   7.4154917828053E-02
@@ -2429,262 +2472,274 @@ listId=   1 ; file name: dynStDiag
 (PID.TID 0000.0001) %MON vort_a_sd                    =   8.8618432802437E-05
 (PID.TID 0000.0001) %MON vort_p_mean                  =   5.8832487099273E-20
 (PID.TID 0000.0001) %MON vort_p_sd                    =   8.8693885783139E-05
-(PID.TID 0000.0001) %MON surfExpan_theta_mean         =   1.5795885946161E-04
+(PID.TID 0000.0001) %MON surfExpan_theta_mean         =   1.5798065647713E-04
 (PID.TID 0000.0001) %MON surfExpan_salt_mean          =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON surfExpan_Heat_mean          =  -8.8320096116155E-02
-(PID.TID 0000.0001) %MON En_Budget_T2PE_mean          =   1.0517434380477E+00
+(PID.TID 0000.0001) %MON surfExpan_Heat_mean          =  -8.8318361280271E-02
+(PID.TID 0000.0001) %MON En_Budget_T2PE_mean          =   1.0517449701690E+00
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // End MONITOR dynamic field statistics
 (PID.TID 0000.0001) // =======================================================
- cg2d: Sum(rhs),rhsMax =   6.28642737865448E-09  1.58944198268730E+04
-(PID.TID 0000.0001)      cg2d_init_res =   1.98604552297670E+03
+ cg2d: Sum(rhs),rhsMax =   5.58793544769287E-09  1.58944200122148E+04
+(PID.TID 0000.0001)      cg2d_init_res =   1.98604224681596E+03
 (PID.TID 0000.0001)      cg2d_iters(min,last) =      -1      16
-(PID.TID 0000.0001)      cg2d_last_res =   5.19547874393149E-11
+(PID.TID 0000.0001)      cg2d_last_res =   5.19547959549411E-11
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // Begin MONITOR dynamic field statistics
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) %MON time_tsnumber                =                276482
 (PID.TID 0000.0001) %MON time_secondsf                =   1.2441690000000E+08
-(PID.TID 0000.0001) %MON dynstat_eta_max              =   2.5476643099503E+03
-(PID.TID 0000.0001) %MON dynstat_eta_min              =  -3.4770900160088E+03
-(PID.TID 0000.0001) %MON dynstat_eta_mean             =  -1.6065757781016E-13
-(PID.TID 0000.0001) %MON dynstat_eta_sd               =   8.2042505052207E+02
-(PID.TID 0000.0001) %MON dynstat_eta_del2             =   2.0590042529597E+00
-(PID.TID 0000.0001) %MON dynstat_uvel_max             =   6.7208792255762E+01
-(PID.TID 0000.0001) %MON dynstat_uvel_min             =  -6.6521653735911E+01
-(PID.TID 0000.0001) %MON dynstat_uvel_mean            =   2.0477920935072E+00
-(PID.TID 0000.0001) %MON dynstat_uvel_sd              =   1.1158132832437E+01
-(PID.TID 0000.0001) %MON dynstat_uvel_del2            =   1.0720628300021E-02
-(PID.TID 0000.0001) %MON dynstat_vvel_max             =   7.1938450606442E+01
-(PID.TID 0000.0001) %MON dynstat_vvel_min             =  -6.8642442063224E+01
-(PID.TID 0000.0001) %MON dynstat_vvel_mean            =   2.0112357252184E+00
-(PID.TID 0000.0001) %MON dynstat_vvel_sd              =   1.1667346011034E+01
-(PID.TID 0000.0001) %MON dynstat_vvel_del2            =   1.1014317552942E-02
-(PID.TID 0000.0001) %MON dynstat_wvel_max             =   8.1390646323634E-01
-(PID.TID 0000.0001) %MON dynstat_wvel_min             =  -6.6779926200020E-01
-(PID.TID 0000.0001) %MON dynstat_wvel_mean            =   9.1721573869980E-18
-(PID.TID 0000.0001) %MON dynstat_wvel_sd              =   6.5120768256993E-02
-(PID.TID 0000.0001) %MON dynstat_wvel_del2            =   2.0583539620212E-04
-(PID.TID 0000.0001) %MON dynstat_theta_max            =   5.9603109841639E+02
-(PID.TID 0000.0001) %MON dynstat_theta_min            =   2.6186637206653E+02
-(PID.TID 0000.0001) %MON dynstat_theta_mean           =   3.2766072575728E+02
-(PID.TID 0000.0001) %MON dynstat_theta_sd             =   6.3757523919914E+01
-(PID.TID 0000.0001) %MON dynstat_theta_del2           =   5.1664445138609E-03
+(PID.TID 0000.0001) %MON dynstat_eta_max              =   2.5476642308447E+03
+(PID.TID 0000.0001) %MON dynstat_eta_min              =  -3.4770900477964E+03
+(PID.TID 0000.0001) %MON dynstat_eta_mean             =  -2.8918364005828E-13
+(PID.TID 0000.0001) %MON dynstat_eta_sd               =   8.2042507248139E+02
+(PID.TID 0000.0001) %MON dynstat_eta_del2             =   2.0590042472458E+00
+(PID.TID 0000.0001) %MON dynstat_uvel_max             =   6.7208795253020E+01
+(PID.TID 0000.0001) %MON dynstat_uvel_min             =  -6.6521641927417E+01
+(PID.TID 0000.0001) %MON dynstat_uvel_mean            =   2.0477920915857E+00
+(PID.TID 0000.0001) %MON dynstat_uvel_sd              =   1.1158132733784E+01
+(PID.TID 0000.0001) %MON dynstat_uvel_del2            =   1.0720628320335E-02
+(PID.TID 0000.0001) %MON dynstat_vvel_max             =   7.1938450687271E+01
+(PID.TID 0000.0001) %MON dynstat_vvel_min             =  -6.8642433724859E+01
+(PID.TID 0000.0001) %MON dynstat_vvel_mean            =   2.0112357270521E+00
+(PID.TID 0000.0001) %MON dynstat_vvel_sd              =   1.1667346104063E+01
+(PID.TID 0000.0001) %MON dynstat_vvel_del2            =   1.1014317692902E-02
+(PID.TID 0000.0001) %MON dynstat_wvel_max             =   8.1390681297548E-01
+(PID.TID 0000.0001) %MON dynstat_wvel_min             =  -6.6780009505372E-01
+(PID.TID 0000.0001) %MON dynstat_wvel_mean            =   5.5515689447620E-18
+(PID.TID 0000.0001) %MON dynstat_wvel_sd              =   6.5120773111998E-02
+(PID.TID 0000.0001) %MON dynstat_wvel_del2            =   2.0583541516667E-04
+(PID.TID 0000.0001) %MON dynstat_theta_max            =   5.9603109598008E+02
+(PID.TID 0000.0001) %MON dynstat_theta_min            =   2.6186636717834E+02
+(PID.TID 0000.0001) %MON dynstat_theta_mean           =   3.2766018135267E+02
+(PID.TID 0000.0001) %MON dynstat_theta_sd             =   6.3757653466893E+01
+(PID.TID 0000.0001) %MON dynstat_theta_del2           =   5.1664441439518E-03
 (PID.TID 0000.0001) %MON dynstat_salt_max             =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON dynstat_salt_min             =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON dynstat_salt_mean            =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON dynstat_salt_sd              =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON dynstat_salt_del2            =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON advcfl_uvel_max              =   2.6866504930100E-01
-(PID.TID 0000.0001) %MON advcfl_vvel_max              =   2.2652444711028E-01
-(PID.TID 0000.0001) %MON advcfl_wvel_max              =   7.3251581691271E-02
-(PID.TID 0000.0001) %MON advcfl_W_hf_max              =   7.2436616453319E-02
+(PID.TID 0000.0001) %MON trAdv_CFL_u_max              =   2.9320418191769E-01
+(PID.TID 0000.0001) %MON trAdv_CFL_v_max              =   3.0916439912781E-01
+(PID.TID 0000.0001) %MON trAdv_CFL_w_max              =   7.2436647579648E-02
+(PID.TID 0000.0001) %MON advcfl_uvel_max              =   2.6866500160932E-01
+(PID.TID 0000.0001) %MON advcfl_vvel_max              =   2.2652448812509E-01
+(PID.TID 0000.0001) %MON advcfl_wvel_max              =   7.3251613167794E-02
+(PID.TID 0000.0001) %MON advcfl_W_hf_max              =   7.2436647579648E-02
 (PID.TID 0000.0001) %MON am_eta_mean                  =  -2.9402103954415E+09
-(PID.TID 0000.0001) %MON am_uZo_mean                  =   2.8067482671362E+11
-(PID.TID 0000.0001) %MON am_tot_mean                  =   2.7773461631818E+11
-(PID.TID 0000.0001) %MON pe_b_mean                    =   2.8499015063013E+00
-(PID.TID 0000.0001) %MON ke_max                       =   3.2582692727147E+03
-(PID.TID 0000.0001) %MON ke_mean                      =   1.3439942620009E+02
+(PID.TID 0000.0001) %MON am_uZo_mean                  =   2.8067482671367E+11
+(PID.TID 0000.0001) %MON am_tot_mean                  =   2.7773461631823E+11
+(PID.TID 0000.0001) %MON pe_b_mean                    =   2.8499016588610E+00
+(PID.TID 0000.0001) %MON ke_max                       =   3.2582687343779E+03
+(PID.TID 0000.0001) %MON ke_mean                      =   1.3439942618221E+02
 (PID.TID 0000.0001) %MON ke_vol                       =   5.0990436378172E+19
-(PID.TID 0000.0001) %MON vort_r_min                   =  -1.7812864841170E-04
-(PID.TID 0000.0001) %MON vort_r_max                   =   2.2156201204636E-04
-(PID.TID 0000.0001) %MON vort_a_mean                  =   2.2062196564066E-20
-(PID.TID 0000.0001) %MON vort_a_sd                    =   8.8616677696222E-05
-(PID.TID 0000.0001) %MON vort_p_mean                  =   2.4513536362078E-20
-(PID.TID 0000.0001) %MON vort_p_sd                    =   8.8691873838187E-05
-(PID.TID 0000.0001) %MON surfExpan_theta_mean         =   1.4954781959309E-03
+(PID.TID 0000.0001) %MON vort_r_min                   =  -1.7812864835885E-04
+(PID.TID 0000.0001) %MON vort_r_max                   =   2.2156201194222E-04
+(PID.TID 0000.0001) %MON vort_a_mean                  =  -9.8054206951405E-21
+(PID.TID 0000.0001) %MON vort_a_sd                    =   8.8616677693075E-05
+(PID.TID 0000.0001) %MON vort_p_mean                  =  -9.8054145448311E-21
+(PID.TID 0000.0001) %MON vort_p_sd                    =   8.8691873835046E-05
+(PID.TID 0000.0001) %MON surfExpan_theta_mean         =   1.4969871253227E-03
 (PID.TID 0000.0001) %MON surfExpan_salt_mean          =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON surfExpan_Heat_mean          =  -8.1823579949301E-03
-(PID.TID 0000.0001) %MON En_Budget_T2PE_mean          =   9.5519075732637E-01
+(PID.TID 0000.0001) %MON surfExpan_Heat_mean          =  -8.0222790418584E-03
+(PID.TID 0000.0001) %MON En_Budget_T2PE_mean          =   9.5518491827962E-01
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // End MONITOR dynamic field statistics
 (PID.TID 0000.0001) // =======================================================
- cg2d: Sum(rhs),rhsMax =   2.56113708019257E-09  1.57936655035747E+04
-(PID.TID 0000.0001)      cg2d_init_res =   2.13807977741679E+03
+ cg2d: Sum(rhs),rhsMax =   5.58793544769287E-09  1.57936661363820E+04
+(PID.TID 0000.0001)      cg2d_init_res =   2.13806934622534E+03
 (PID.TID 0000.0001)      cg2d_iters(min,last) =      -1      16
-(PID.TID 0000.0001)      cg2d_last_res =   5.32675086165132E-11
+(PID.TID 0000.0001)      cg2d_last_res =   5.32674358044652E-11
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // Begin MONITOR dynamic field statistics
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) %MON time_tsnumber                =                276483
 (PID.TID 0000.0001) %MON time_secondsf                =   1.2441735000000E+08
-(PID.TID 0000.0001) %MON dynstat_eta_max              =   2.5340947845402E+03
-(PID.TID 0000.0001) %MON dynstat_eta_min              =  -3.4560009745348E+03
-(PID.TID 0000.0001) %MON dynstat_eta_mean             =  -1.2209975913572E-13
-(PID.TID 0000.0001) %MON dynstat_eta_sd               =   8.1706314370713E+02
-(PID.TID 0000.0001) %MON dynstat_eta_del2             =   2.0353925911226E+00
-(PID.TID 0000.0001) %MON dynstat_uvel_max             =   6.7198802936008E+01
-(PID.TID 0000.0001) %MON dynstat_uvel_min             =  -6.6579589965013E+01
-(PID.TID 0000.0001) %MON dynstat_uvel_mean            =   2.0473709136343E+00
-(PID.TID 0000.0001) %MON dynstat_uvel_sd              =   1.1157268682651E+01
-(PID.TID 0000.0001) %MON dynstat_uvel_del2            =   1.0719821548695E-02
-(PID.TID 0000.0001) %MON dynstat_vvel_max             =   7.1973141962999E+01
-(PID.TID 0000.0001) %MON dynstat_vvel_min             =  -6.8647751639408E+01
-(PID.TID 0000.0001) %MON dynstat_vvel_mean            =   2.0102750707139E+00
-(PID.TID 0000.0001) %MON dynstat_vvel_sd              =   1.1666136419727E+01
-(PID.TID 0000.0001) %MON dynstat_vvel_del2            =   1.1011453877319E-02
-(PID.TID 0000.0001) %MON dynstat_wvel_max             =   8.0603951489307E-01
-(PID.TID 0000.0001) %MON dynstat_wvel_min             =  -6.7305518218898E-01
-(PID.TID 0000.0001) %MON dynstat_wvel_mean            =  -7.3216344054107E-18
-(PID.TID 0000.0001) %MON dynstat_wvel_sd              =   6.4787792035774E-02
-(PID.TID 0000.0001) %MON dynstat_wvel_del2            =   2.0562702394633E-04
-(PID.TID 0000.0001) %MON dynstat_theta_max            =   5.9603593681846E+02
-(PID.TID 0000.0001) %MON dynstat_theta_min            =   2.6187208570119E+02
-(PID.TID 0000.0001) %MON dynstat_theta_mean           =   3.2766074022485E+02
-(PID.TID 0000.0001) %MON dynstat_theta_sd             =   6.3757502950892E+01
-(PID.TID 0000.0001) %MON dynstat_theta_del2           =   5.1674062683620E-03
+(PID.TID 0000.0001) %MON dynstat_eta_max              =   2.5340944310496E+03
+(PID.TID 0000.0001) %MON dynstat_eta_min              =  -3.4560011423213E+03
+(PID.TID 0000.0001) %MON dynstat_eta_mean             =  -1.6065757781016E-13
+(PID.TID 0000.0001) %MON dynstat_eta_sd               =   8.1706323031894E+02
+(PID.TID 0000.0001) %MON dynstat_eta_del2             =   2.0353925940686E+00
+(PID.TID 0000.0001) %MON dynstat_uvel_max             =   6.7198811181336E+01
+(PID.TID 0000.0001) %MON dynstat_uvel_min             =  -6.6579555918939E+01
+(PID.TID 0000.0001) %MON dynstat_uvel_mean            =   2.0473708217563E+00
+(PID.TID 0000.0001) %MON dynstat_uvel_sd              =   1.1157268235702E+01
+(PID.TID 0000.0001) %MON dynstat_uvel_del2            =   1.0719821632106E-02
+(PID.TID 0000.0001) %MON dynstat_vvel_max             =   7.1973141103587E+01
+(PID.TID 0000.0001) %MON dynstat_vvel_min             =  -6.8647724747075E+01
+(PID.TID 0000.0001) %MON dynstat_vvel_mean            =   2.0102749909592E+00
+(PID.TID 0000.0001) %MON dynstat_vvel_sd              =   1.1666136529389E+01
+(PID.TID 0000.0001) %MON dynstat_vvel_del2            =   1.1011454275565E-02
+(PID.TID 0000.0001) %MON dynstat_wvel_max             =   8.0603981357430E-01
+(PID.TID 0000.0001) %MON dynstat_wvel_min             =  -6.7305865839239E-01
+(PID.TID 0000.0001) %MON dynstat_wvel_mean            =   5.0688238191305E-18
+(PID.TID 0000.0001) %MON dynstat_wvel_sd              =   6.4787808287849E-02
+(PID.TID 0000.0001) %MON dynstat_wvel_del2            =   2.0562719057777E-04
+(PID.TID 0000.0001) %MON dynstat_theta_max            =   5.9603592864567E+02
+(PID.TID 0000.0001) %MON dynstat_theta_min            =   2.6187207837074E+02
+(PID.TID 0000.0001) %MON dynstat_theta_mean           =   3.2765992370015E+02
+(PID.TID 0000.0001) %MON dynstat_theta_sd             =   6.3757697260459E+01
+(PID.TID 0000.0001) %MON dynstat_theta_del2           =   5.1674057329679E-03
 (PID.TID 0000.0001) %MON dynstat_salt_max             =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON dynstat_salt_min             =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON dynstat_salt_mean            =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON dynstat_salt_sd              =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON dynstat_salt_del2            =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON advcfl_uvel_max              =   2.6889903987360E-01
-(PID.TID 0000.0001) %MON advcfl_vvel_max              =   2.2646989653708E-01
-(PID.TID 0000.0001) %MON advcfl_wvel_max              =   7.2543556340377E-02
-(PID.TID 0000.0001) %MON advcfl_W_hf_max              =   7.1904284786951E-02
-(PID.TID 0000.0001) %MON am_eta_mean                  =  -2.9425411673745E+09
-(PID.TID 0000.0001) %MON am_uZo_mean                  =   2.8067049154543E+11
-(PID.TID 0000.0001) %MON am_tot_mean                  =   2.7772795037805E+11
-(PID.TID 0000.0001) %MON pe_b_mean                    =   2.8265929231515E+00
-(PID.TID 0000.0001) %MON ke_max                       =   3.2562335612551E+03
-(PID.TID 0000.0001) %MON ke_mean                      =   1.3437286733247E+02
-(PID.TID 0000.0001) %MON ke_vol                       =   5.0990436378173E+19
-(PID.TID 0000.0001) %MON vort_r_min                   =  -1.7828483099844E-04
-(PID.TID 0000.0001) %MON vort_r_max                   =   2.2158152210542E-04
-(PID.TID 0000.0001) %MON vort_a_mean                  =   9.8054206951405E-20
-(PID.TID 0000.0001) %MON vort_a_sd                    =   8.8614897566243E-05
-(PID.TID 0000.0001) %MON vort_p_mean                  =   9.5602792284466E-20
-(PID.TID 0000.0001) %MON vort_p_sd                    =   8.8689687251045E-05
-(PID.TID 0000.0001) %MON surfExpan_theta_mean         =   2.2347523417704E-03
+(PID.TID 0000.0001) %MON trAdv_CFL_u_max              =   2.9325433504052E-01
+(PID.TID 0000.0001) %MON trAdv_CFL_v_max              =   3.0919623660830E-01
+(PID.TID 0000.0001) %MON trAdv_CFL_w_max              =   7.1904311376773E-02
+(PID.TID 0000.0001) %MON advcfl_uvel_max              =   2.6889890236965E-01
+(PID.TID 0000.0001) %MON advcfl_vvel_max              =   2.2647001350790E-01
+(PID.TID 0000.0001) %MON advcfl_wvel_max              =   7.2543583221687E-02
+(PID.TID 0000.0001) %MON advcfl_W_hf_max              =   7.1904311376773E-02
+(PID.TID 0000.0001) %MON am_eta_mean                  =  -2.9425314486827E+09
+(PID.TID 0000.0001) %MON am_uZo_mean                  =   2.8067048181975E+11
+(PID.TID 0000.0001) %MON am_tot_mean                  =   2.7772795037107E+11
+(PID.TID 0000.0001) %MON pe_b_mean                    =   2.8265935224109E+00
+(PID.TID 0000.0001) %MON ke_max                       =   3.2562318603307E+03
+(PID.TID 0000.0001) %MON ke_mean                      =   1.3437286327110E+02
+(PID.TID 0000.0001) %MON ke_vol                       =   5.0990436378172E+19
+(PID.TID 0000.0001) %MON vort_r_min                   =  -1.7828483210179E-04
+(PID.TID 0000.0001) %MON vort_r_max                   =   2.2158152216107E-04
+(PID.TID 0000.0001) %MON vort_a_mean                  =   1.8875434838145E-19
+(PID.TID 0000.0001) %MON vort_a_sd                    =   8.8614897483014E-05
+(PID.TID 0000.0001) %MON vort_p_mean                  =   1.8630287727244E-19
+(PID.TID 0000.0001) %MON vort_p_sd                    =   8.8689687214915E-05
+(PID.TID 0000.0001) %MON surfExpan_theta_mean         =   2.2392042087083E-03
 (PID.TID 0000.0001) %MON surfExpan_salt_mean          =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON surfExpan_Heat_mean          =   1.9567066733240E-02
-(PID.TID 0000.0001) %MON En_Budget_T2PE_mean          =   8.5842105983634E-01
+(PID.TID 0000.0001) %MON surfExpan_Heat_mean          =   2.0040941957201E-02
+(PID.TID 0000.0001) %MON En_Budget_T2PE_mean          =   8.5839895550167E-01
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // End MONITOR dynamic field statistics
 (PID.TID 0000.0001) // =======================================================
- cg2d: Sum(rhs),rhsMax =   4.88944351673126E-09  1.56883433182849E+04
-(PID.TID 0000.0001)      cg2d_init_res =   2.21575698432898E+03
+ cg2d: Sum(rhs),rhsMax =   4.42378222942352E-09  1.56883451818050E+04
+(PID.TID 0000.0001)      cg2d_init_res =   2.21573402007867E+03
 (PID.TID 0000.0001)      cg2d_iters(min,last) =      -1      16
-(PID.TID 0000.0001)      cg2d_last_res =   5.39307883513930E-11
+(PID.TID 0000.0001)      cg2d_last_res =   5.39303441564551E-11
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // Begin MONITOR dynamic field statistics
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) %MON time_tsnumber                =                276484
 (PID.TID 0000.0001) %MON time_secondsf                =   1.2441780000000E+08
-(PID.TID 0000.0001) %MON dynstat_eta_max              =   2.5216824566150E+03
-(PID.TID 0000.0001) %MON dynstat_eta_min              =  -3.4334164428553E+03
-(PID.TID 0000.0001) %MON dynstat_eta_mean             =  -2.2492060893422E-13
-(PID.TID 0000.0001) %MON dynstat_eta_sd               =   8.1317575722287E+02
-(PID.TID 0000.0001) %MON dynstat_eta_del2             =   2.0191876543159E+00
-(PID.TID 0000.0001) %MON dynstat_uvel_max             =   6.7182787508627E+01
-(PID.TID 0000.0001) %MON dynstat_uvel_min             =  -6.6639104578934E+01
-(PID.TID 0000.0001) %MON dynstat_uvel_mean            =   2.0469401799882E+00
-(PID.TID 0000.0001) %MON dynstat_uvel_sd              =   1.1156477604961E+01
-(PID.TID 0000.0001) %MON dynstat_uvel_del2            =   1.0718761027832E-02
-(PID.TID 0000.0001) %MON dynstat_vvel_max             =   7.2013208722364E+01
-(PID.TID 0000.0001) %MON dynstat_vvel_min             =  -6.8657787474666E+01
-(PID.TID 0000.0001) %MON dynstat_vvel_mean            =   2.0093661901834E+00
-(PID.TID 0000.0001) %MON dynstat_vvel_sd              =   1.1665021707929E+01
-(PID.TID 0000.0001) %MON dynstat_vvel_del2            =   1.1008277321665E-02
-(PID.TID 0000.0001) %MON dynstat_wvel_max             =   8.0303444224713E-01
-(PID.TID 0000.0001) %MON dynstat_wvel_min             =  -6.7657191255943E-01
-(PID.TID 0000.0001) %MON dynstat_wvel_mean            =  -1.0861765326708E-18
-(PID.TID 0000.0001) %MON dynstat_wvel_sd              =   6.4528049501632E-02
-(PID.TID 0000.0001) %MON dynstat_wvel_del2            =   2.0546922134660E-04
-(PID.TID 0000.0001) %MON dynstat_theta_max            =   5.9604430134457E+02
-(PID.TID 0000.0001) %MON dynstat_theta_min            =   2.6187851431599E+02
-(PID.TID 0000.0001) %MON dynstat_theta_mean           =   3.2766075882864E+02
-(PID.TID 0000.0001) %MON dynstat_theta_sd             =   6.3757481415800E+01
-(PID.TID 0000.0001) %MON dynstat_theta_del2           =   5.1688753999835E-03
+(PID.TID 0000.0001) %MON dynstat_eta_max              =   2.5216815112370E+03
+(PID.TID 0000.0001) %MON dynstat_eta_min              =  -3.4334170198736E+03
+(PID.TID 0000.0001) %MON dynstat_eta_mean             =  -2.4419951827144E-13
+(PID.TID 0000.0001) %MON dynstat_eta_sd               =   8.1317597020261E+02
+(PID.TID 0000.0001) %MON dynstat_eta_del2             =   2.0191877231015E+00
+(PID.TID 0000.0001) %MON dynstat_uvel_max             =   6.7182802948675E+01
+(PID.TID 0000.0001) %MON dynstat_uvel_min             =  -6.6639038942688E+01
+(PID.TID 0000.0001) %MON dynstat_uvel_mean            =   2.0469398559924E+00
+(PID.TID 0000.0001) %MON dynstat_uvel_sd              =   1.1156476464771E+01
+(PID.TID 0000.0001) %MON dynstat_uvel_del2            =   1.0718761220559E-02
+(PID.TID 0000.0001) %MON dynstat_vvel_max             =   7.2013205157945E+01
+(PID.TID 0000.0001) %MON dynstat_vvel_min             =  -6.8657731703036E+01
+(PID.TID 0000.0001) %MON dynstat_vvel_mean            =   2.0093658920961E+00
+(PID.TID 0000.0001) %MON dynstat_vvel_sd              =   1.1665021652059E+01
+(PID.TID 0000.0001) %MON dynstat_vvel_del2            =   1.1008278091321E-02
+(PID.TID 0000.0001) %MON dynstat_wvel_max             =   8.0303526779348E-01
+(PID.TID 0000.0001) %MON dynstat_wvel_min             =  -6.7657942837898E-01
+(PID.TID 0000.0001) %MON dynstat_wvel_mean            =   2.1723530653416E-18
+(PID.TID 0000.0001) %MON dynstat_wvel_sd              =   6.4528083529395E-02
+(PID.TID 0000.0001) %MON dynstat_wvel_del2            =   2.0546965982661E-04
+(PID.TID 0000.0001) %MON dynstat_theta_max            =   5.9604428404420E+02
+(PID.TID 0000.0001) %MON dynstat_theta_min            =   2.6187850453564E+02
+(PID.TID 0000.0001) %MON dynstat_theta_mean           =   3.2765967023883E+02
+(PID.TID 0000.0001) %MON dynstat_theta_sd             =   6.3757740480672E+01
+(PID.TID 0000.0001) %MON dynstat_theta_del2           =   5.1688747176027E-03
 (PID.TID 0000.0001) %MON dynstat_salt_max             =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON dynstat_salt_min             =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON dynstat_salt_mean            =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON dynstat_salt_sd              =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON dynstat_salt_del2            =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON advcfl_uvel_max              =   2.6913940516497E-01
-(PID.TID 0000.0001) %MON advcfl_vvel_max              =   2.2640600928197E-01
-(PID.TID 0000.0001) %MON advcfl_wvel_max              =   7.2273099802242E-02
-(PID.TID 0000.0001) %MON advcfl_W_hf_max              =   7.1638243945414E-02
-(PID.TID 0000.0001) %MON am_eta_mean                  =  -2.9444544639733E+09
-(PID.TID 0000.0001) %MON am_uZo_mean                  =   2.8066574699087E+11
-(PID.TID 0000.0001) %MON am_tot_mean                  =   2.7772129252690E+11
-(PID.TID 0000.0001) %MON pe_b_mean                    =   2.7997604317774E+00
-(PID.TID 0000.0001) %MON ke_max                       =   3.2533473086033E+03
-(PID.TID 0000.0001) %MON ke_mean                      =   1.3434831979124E+02
+(PID.TID 0000.0001) %MON trAdv_CFL_u_max              =   2.9331763591895E-01
+(PID.TID 0000.0001) %MON trAdv_CFL_v_max              =   3.0925059614899E-01
+(PID.TID 0000.0001) %MON trAdv_CFL_w_max              =   7.1638317301307E-02
+(PID.TID 0000.0001) %MON advcfl_uvel_max              =   2.6913914007588E-01
+(PID.TID 0000.0001) %MON advcfl_vvel_max              =   2.2640623398396E-01
+(PID.TID 0000.0001) %MON advcfl_wvel_max              =   7.2273174101414E-02
+(PID.TID 0000.0001) %MON advcfl_W_hf_max              =   7.1638317301307E-02
+(PID.TID 0000.0001) %MON am_eta_mean                  =  -2.9444156476321E+09
+(PID.TID 0000.0001) %MON am_uZo_mean                  =   2.8066570814931E+11
+(PID.TID 0000.0001) %MON am_tot_mean                  =   2.7772129250168E+11
+(PID.TID 0000.0001) %MON pe_b_mean                    =   2.7997618983541E+00
+(PID.TID 0000.0001) %MON ke_max                       =   3.2533437581314E+03
+(PID.TID 0000.0001) %MON ke_mean                      =   1.3434830514780E+02
 (PID.TID 0000.0001) %MON ke_vol                       =   5.0990436378172E+19
-(PID.TID 0000.0001) %MON vort_r_min                   =  -1.7839853897958E-04
-(PID.TID 0000.0001) %MON vort_r_max                   =   2.2157705255847E-04
-(PID.TID 0000.0001) %MON vort_a_mean                  =   3.1867617259207E-20
-(PID.TID 0000.0001) %MON vort_a_sd                    =   8.8613055835206E-05
-(PID.TID 0000.0001) %MON vort_p_mean                  =   3.1867597616592E-20
-(PID.TID 0000.0001) %MON vort_p_sd                    =   8.8687341826351E-05
-(PID.TID 0000.0001) %MON surfExpan_theta_mean         =   2.3820334812641E-03
+(PID.TID 0000.0001) %MON vort_r_min                   =  -1.7839854383663E-04
+(PID.TID 0000.0001) %MON vort_r_max                   =   2.2157705323801E-04
+(PID.TID 0000.0001) %MON vort_a_mean                  =   1.9610841390281E-20
+(PID.TID 0000.0001) %MON vort_a_sd                    =   8.8613055549850E-05
+(PID.TID 0000.0001) %MON vort_p_mean                  =   1.9610829302574E-20
+(PID.TID 0000.0001) %MON vort_p_sd                    =   8.8687341728934E-05
+(PID.TID 0000.0001) %MON surfExpan_theta_mean         =   2.3908622025271E-03
 (PID.TID 0000.0001) %MON surfExpan_salt_mean          =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON surfExpan_Heat_mean          =  -2.1609231490710E-03
-(PID.TID 0000.0001) %MON En_Budget_T2PE_mean          =   7.6303907444916E-01
+(PID.TID 0000.0001) %MON surfExpan_Heat_mean          =  -1.2202368108224E-03
+(PID.TID 0000.0001) %MON En_Budget_T2PE_mean          =   7.6299181573451E-01
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // End MONITOR dynamic field statistics
 (PID.TID 0000.0001) // =======================================================
- cg2d: Sum(rhs),rhsMax =   5.58793544769287E-09  1.55883268830575E+04
-(PID.TID 0000.0001)      cg2d_init_res =   2.24861804947162E+03
+ cg2d: Sum(rhs),rhsMax =   3.02679836750031E-09  1.55883319686291E+04
+(PID.TID 0000.0001)      cg2d_init_res =   2.24857834308078E+03
 (PID.TID 0000.0001)      cg2d_iters(min,last) =      -1      16
-(PID.TID 0000.0001)      cg2d_last_res =   5.50083175387044E-11
+(PID.TID 0000.0001)      cg2d_last_res =   5.50081256906430E-11
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // Begin MONITOR dynamic field statistics
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) %MON time_tsnumber                =                276485
 (PID.TID 0000.0001) %MON time_secondsf                =   1.2441825000000E+08
-(PID.TID 0000.0001) %MON dynstat_eta_max              =   2.5076652294399E+03
-(PID.TID 0000.0001) %MON dynstat_eta_min              =  -3.4115861568786E+03
-(PID.TID 0000.0001) %MON dynstat_eta_mean             =  -9.6394546686094E-14
-(PID.TID 0000.0001) %MON dynstat_eta_sd               =   8.0898980037808E+02
-(PID.TID 0000.0001) %MON dynstat_eta_del2             =   2.0123281787431E+00
-(PID.TID 0000.0001) %MON dynstat_uvel_max             =   6.7161549795167E+01
-(PID.TID 0000.0001) %MON dynstat_uvel_min             =  -6.6697129351009E+01
-(PID.TID 0000.0001) %MON dynstat_uvel_mean            =   2.0464950155534E+00
-(PID.TID 0000.0001) %MON dynstat_uvel_sd              =   1.1155693470606E+01
-(PID.TID 0000.0001) %MON dynstat_uvel_del2            =   1.0717399227239E-02
-(PID.TID 0000.0001) %MON dynstat_vvel_max             =   7.2057689633907E+01
-(PID.TID 0000.0001) %MON dynstat_vvel_min             =  -6.8674462074132E+01
-(PID.TID 0000.0001) %MON dynstat_vvel_mean            =   2.0085058573065E+00
-(PID.TID 0000.0001) %MON dynstat_vvel_sd              =   1.1663956104581E+01
-(PID.TID 0000.0001) %MON dynstat_vvel_del2            =   1.1004751544861E-02
-(PID.TID 0000.0001) %MON dynstat_wvel_max             =   7.9989854639926E-01
-(PID.TID 0000.0001) %MON dynstat_wvel_min             =  -6.7938311335854E-01
-(PID.TID 0000.0001) %MON dynstat_wvel_mean            =   8.8503273032437E-19
-(PID.TID 0000.0001) %MON dynstat_wvel_sd              =   6.4332856708892E-02
-(PID.TID 0000.0001) %MON dynstat_wvel_del2            =   2.0541143495149E-04
-(PID.TID 0000.0001) %MON dynstat_theta_max            =   5.9605712249930E+02
-(PID.TID 0000.0001) %MON dynstat_theta_min            =   2.6188563742274E+02
-(PID.TID 0000.0001) %MON dynstat_theta_mean           =   3.2766078098208E+02
-(PID.TID 0000.0001) %MON dynstat_theta_sd             =   6.3757460069516E+01
-(PID.TID 0000.0001) %MON dynstat_theta_del2           =   5.1706620915775E-03
+(PID.TID 0000.0001) %MON dynstat_eta_max              =   2.5076632382356E+03
+(PID.TID 0000.0001) %MON dynstat_eta_min              =  -3.4115876896128E+03
+(PID.TID 0000.0001) %MON dynstat_eta_mean             =  -1.4780497158534E-13
+(PID.TID 0000.0001) %MON dynstat_eta_sd               =   8.0899021826054E+02
+(PID.TID 0000.0001) %MON dynstat_eta_del2             =   2.0123284279163E+00
+(PID.TID 0000.0001) %MON dynstat_uvel_max             =   6.7161574099892E+01
+(PID.TID 0000.0001) %MON dynstat_uvel_min             =  -6.6697023984854E+01
+(PID.TID 0000.0001) %MON dynstat_uvel_mean            =   2.0464942638220E+00
+(PID.TID 0000.0001) %MON dynstat_uvel_sd              =   1.1155691200341E+01
+(PID.TID 0000.0001) %MON dynstat_uvel_del2            =   1.0717399565294E-02
+(PID.TID 0000.0001) %MON dynstat_vvel_max             =   7.2057680838771E+01
+(PID.TID 0000.0001) %MON dynstat_vvel_min             =  -6.8674367372578E+01
+(PID.TID 0000.0001) %MON dynstat_vvel_mean            =   2.0085051520069E+00
+(PID.TID 0000.0001) %MON dynstat_vvel_sd              =   1.1663955597031E+01
+(PID.TID 0000.0001) %MON dynstat_vvel_del2            =   1.1004752794220E-02
+(PID.TID 0000.0001) %MON dynstat_wvel_max             =   7.9990023743468E-01
+(PID.TID 0000.0001) %MON dynstat_wvel_min             =  -6.7939589078042E-01
+(PID.TID 0000.0001) %MON dynstat_wvel_mean            =   1.1223824170932E-17
+(PID.TID 0000.0001) %MON dynstat_wvel_sd              =   6.4332913968894E-02
+(PID.TID 0000.0001) %MON dynstat_wvel_del2            =   2.0541226504153E-04
+(PID.TID 0000.0001) %MON dynstat_theta_max            =   5.9605711729272E+02
+(PID.TID 0000.0001) %MON dynstat_theta_min            =   2.6188562518148E+02
+(PID.TID 0000.0001) %MON dynstat_theta_mean           =   3.2765942038236E+02
+(PID.TID 0000.0001) %MON dynstat_theta_sd             =   6.3757783882205E+01
+(PID.TID 0000.0001) %MON dynstat_theta_del2           =   5.1706612869047E-03
 (PID.TID 0000.0001) %MON dynstat_salt_max             =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON dynstat_salt_min             =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON dynstat_salt_mean            =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON dynstat_salt_sd              =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON dynstat_salt_del2            =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON advcfl_uvel_max              =   2.6937375334147E-01
-(PID.TID 0000.0001) %MON advcfl_vvel_max              =   2.2633168011950E-01
-(PID.TID 0000.0001) %MON advcfl_wvel_max              =   7.1990869175933E-02
-(PID.TID 0000.0001) %MON advcfl_W_hf_max              =   7.1361097062113E-02
-(PID.TID 0000.0001) %MON am_eta_mean                  =  -2.9459804569148E+09
-(PID.TID 0000.0001) %MON am_uZo_mean                  =   2.8066063287791E+11
-(PID.TID 0000.0001) %MON am_tot_mean                  =   2.7771465242100E+11
-(PID.TID 0000.0001) %MON pe_b_mean                    =   2.7710101603824E+00
-(PID.TID 0000.0001) %MON ke_max                       =   3.2495652018669E+03
-(PID.TID 0000.0001) %MON ke_mean                      =   1.3432449544426E+02
+(PID.TID 0000.0001) %MON trAdv_CFL_u_max              =   2.9340107277505E-01
+(PID.TID 0000.0001) %MON trAdv_CFL_v_max              =   3.0933364670081E-01
+(PID.TID 0000.0001) %MON trAdv_CFL_w_max              =   7.1361247074753E-02
+(PID.TID 0000.0001) %MON advcfl_uvel_max              =   2.6937332779277E-01
+(PID.TID 0000.0001) %MON advcfl_vvel_max              =   2.2633204142276E-01
+(PID.TID 0000.0001) %MON advcfl_wvel_max              =   7.1991021369121E-02
+(PID.TID 0000.0001) %MON advcfl_W_hf_max              =   7.1361247074753E-02
+(PID.TID 0000.0001) %MON am_eta_mean                  =  -2.9458836296746E+09
+(PID.TID 0000.0001) %MON am_uZo_mean                  =   2.8066053599396E+11
+(PID.TID 0000.0001) %MON am_tot_mean                  =   2.7771465236428E+11
+(PID.TID 0000.0001) %MON pe_b_mean                    =   2.7710130231054E+00
+(PID.TID 0000.0001) %MON ke_max                       =   3.2495590570804E+03
+(PID.TID 0000.0001) %MON ke_mean                      =   1.3432446123073E+02
 (PID.TID 0000.0001) %MON ke_vol                       =   5.0990436378172E+19
-(PID.TID 0000.0001) %MON vort_r_min                   =  -1.7847041898710E-04
-(PID.TID 0000.0001) %MON vort_r_max                   =   2.2154777275390E-04
-(PID.TID 0000.0001) %MON vort_a_mean                  =   8.0894720734909E-20
-(PID.TID 0000.0001) %MON vort_a_sd                    =   8.8611125562487E-05
-(PID.TID 0000.0001) %MON vort_p_mean                  =   8.3346025025791E-20
-(PID.TID 0000.0001) %MON vort_p_sd                    =   8.8684862095823E-05
-(PID.TID 0000.0001) %MON surfExpan_theta_mean         =   2.0180504737353E-03
+(PID.TID 0000.0001) %MON vort_r_min                   =  -1.7847043174685E-04
+(PID.TID 0000.0001) %MON vort_r_max                   =   2.2154777444429E-04
+(PID.TID 0000.0001) %MON vort_a_mean                  =   1.2256775868926E-20
+(PID.TID 0000.0001) %MON vort_a_sd                    =   8.8611124909039E-05
+(PID.TID 0000.0001) %MON vort_p_mean                  =   1.2256768386224E-20
+(PID.TID 0000.0001) %MON vort_p_sd                    =   8.8684861910592E-05
+(PID.TID 0000.0001) %MON surfExpan_theta_mean         =   2.0326612323539E-03
 (PID.TID 0000.0001) %MON surfExpan_salt_mean          =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON surfExpan_Heat_mean          =  -6.3896561749832E-02
-(PID.TID 0000.0001) %MON En_Budget_T2PE_mean          =   6.7111003776556E-01
+(PID.TID 0000.0001) %MON surfExpan_Heat_mean          =  -6.2339199098272E-02
+(PID.TID 0000.0001) %MON En_Budget_T2PE_mean          =   6.7102877776178E-01
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // End MONITOR dynamic field statistics
 (PID.TID 0000.0001) // =======================================================
@@ -2693,507 +2748,531 @@ listId=   1 ; file name: dynStDiag
  Compute Stats, Diag. #     30  VVEL      vol(   0 ): 5.099E+19  Parms: VVR     MR      
  Compute Stats, Diag. #     31  WVEL      vol(   0 ): 4.972E+19  Parms: WM      LR      
  Compute Stats, Diag. #     26  THETA     vol(   0 ): 5.099E+19  Parms: SMR     MR      
- cg2d: Sum(rhs),rhsMax =   5.12227416038513E-09  1.55009887822930E+04
-(PID.TID 0000.0001)      cg2d_init_res =   2.26621044355940E+03
+ cg2d: Sum(rhs),rhsMax =   4.65661287307739E-09  1.55010007698855E+04
+(PID.TID 0000.0001)      cg2d_init_res =   2.26615255934685E+03
 (PID.TID 0000.0001)      cg2d_iters(min,last) =      -1      16
-(PID.TID 0000.0001)      cg2d_last_res =   5.56224150459197E-11
+(PID.TID 0000.0001)      cg2d_last_res =   5.56220165221364E-11
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // Begin MONITOR dynamic field statistics
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) %MON time_tsnumber                =                276486
 (PID.TID 0000.0001) %MON time_secondsf                =   1.2441870000000E+08
-(PID.TID 0000.0001) %MON dynstat_eta_max              =   2.4928771406250E+03
-(PID.TID 0000.0001) %MON dynstat_eta_min              =  -3.3922514824842E+03
-(PID.TID 0000.0001) %MON dynstat_eta_mean             =  -1.5423127469775E-13
-(PID.TID 0000.0001) %MON dynstat_eta_sd               =   8.0470592038710E+02
-(PID.TID 0000.0001) %MON dynstat_eta_del2             =   2.0143367144148E+00
-(PID.TID 0000.0001) %MON dynstat_uvel_max             =   6.7136766158251E+01
-(PID.TID 0000.0001) %MON dynstat_uvel_min             =  -6.6752918837671E+01
-(PID.TID 0000.0001) %MON dynstat_uvel_mean            =   2.0460339453726E+00
-(PID.TID 0000.0001) %MON dynstat_uvel_sd              =   1.1154856222698E+01
-(PID.TID 0000.0001) %MON dynstat_uvel_del2            =   1.0715753092806E-02
-(PID.TID 0000.0001) %MON dynstat_vvel_max             =   7.2104699406311E+01
-(PID.TID 0000.0001) %MON dynstat_vvel_min             =  -6.8698060131538E+01
-(PID.TID 0000.0001) %MON dynstat_vvel_mean            =   2.0076874712293E+00
-(PID.TID 0000.0001) %MON dynstat_vvel_sd              =   1.1662898037438E+01
-(PID.TID 0000.0001) %MON dynstat_vvel_del2            =   1.1000915143070E-02
-(PID.TID 0000.0001) %MON dynstat_wvel_max             =   7.9669308420312E-01
-(PID.TID 0000.0001) %MON dynstat_wvel_min             =  -6.8154087657145E-01
-(PID.TID 0000.0001) %MON dynstat_wvel_mean            =  -5.0285950586612E-18
-(PID.TID 0000.0001) %MON dynstat_wvel_sd              =   6.4193808767511E-02
-(PID.TID 0000.0001) %MON dynstat_wvel_del2            =   2.0543397960148E-04
-(PID.TID 0000.0001) %MON dynstat_theta_max            =   5.9622993018189E+02
-(PID.TID 0000.0001) %MON dynstat_theta_min            =   2.6189343972558E+02
-(PID.TID 0000.0001) %MON dynstat_theta_mean           =   3.2766080575934E+02
-(PID.TID 0000.0001) %MON dynstat_theta_sd             =   6.3757439693535E+01
-(PID.TID 0000.0001) %MON dynstat_theta_del2           =   5.1725727260736E-03
+(PID.TID 0000.0001) %MON dynstat_eta_max              =   2.4928737749944E+03
+(PID.TID 0000.0001) %MON dynstat_eta_min              =  -3.3922548483630E+03
+(PID.TID 0000.0001) %MON dynstat_eta_mean             =  -1.2852606224812E-13
+(PID.TID 0000.0001) %MON dynstat_eta_sd               =   8.0470663595302E+02
+(PID.TID 0000.0001) %MON dynstat_eta_del2             =   2.0143373152866E+00
+(PID.TID 0000.0001) %MON dynstat_uvel_max             =   6.7136800619623E+01
+(PID.TID 0000.0001) %MON dynstat_uvel_min             =  -6.6752766811995E+01
+(PID.TID 0000.0001) %MON dynstat_uvel_mean            =   2.0460325180060E+00
+(PID.TID 0000.0001) %MON dynstat_uvel_sd              =   1.1154852297533E+01
+(PID.TID 0000.0001) %MON dynstat_uvel_del2            =   1.0715753596619E-02
+(PID.TID 0000.0001) %MON dynstat_vvel_max             =   7.2104682101350E+01
+(PID.TID 0000.0001) %MON dynstat_vvel_min             =  -6.8697917292608E+01
+(PID.TID 0000.0001) %MON dynstat_vvel_mean            =   2.0076861189868E+00
+(PID.TID 0000.0001) %MON dynstat_vvel_sd              =   1.1662896689836E+01
+(PID.TID 0000.0001) %MON dynstat_vvel_del2            =   1.1000916975965E-02
+(PID.TID 0000.0001) %MON dynstat_wvel_max             =   7.9669603286232E-01
+(PID.TID 0000.0001) %MON dynstat_wvel_min             =  -6.8155983035135E-01
+(PID.TID 0000.0001) %MON dynstat_wvel_mean            =   2.2930393467495E-18
+(PID.TID 0000.0001) %MON dynstat_wvel_sd              =   6.4193893320115E-02
+(PID.TID 0000.0001) %MON dynstat_wvel_del2            =   2.0543530935841E-04
+(PID.TID 0000.0001) %MON dynstat_theta_max            =   5.9622993590844E+02
+(PID.TID 0000.0001) %MON dynstat_theta_min            =   2.6189342500899E+02
+(PID.TID 0000.0001) %MON dynstat_theta_mean           =   3.2765917320515E+02
+(PID.TID 0000.0001) %MON dynstat_theta_sd             =   6.3757828246285E+01
+(PID.TID 0000.0001) %MON dynstat_theta_del2           =   5.1725718263818E-03
 (PID.TID 0000.0001) %MON dynstat_salt_max             =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON dynstat_salt_min             =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON dynstat_salt_mean            =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON dynstat_salt_sd              =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON dynstat_salt_del2            =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON advcfl_uvel_max              =   2.6959907373479E-01
-(PID.TID 0000.0001) %MON advcfl_vvel_max              =   2.2624655887457E-01
-(PID.TID 0000.0001) %MON advcfl_wvel_max              =   7.1702377578281E-02
-(PID.TID 0000.0001) %MON advcfl_W_hf_max              =   7.1078096929506E-02
-(PID.TID 0000.0001) %MON am_eta_mean                  =  -2.9471544085227E+09
-(PID.TID 0000.0001) %MON am_uZo_mean                  =   2.8065518831597E+11
-(PID.TID 0000.0001) %MON am_tot_mean                  =   2.7770803390744E+11
-(PID.TID 0000.0001) %MON pe_b_mean                    =   2.7417409524978E+00
-(PID.TID 0000.0001) %MON ke_max                       =   3.2449303682381E+03
-(PID.TID 0000.0001) %MON ke_mean                      =   1.3430022306713E+02
+(PID.TID 0000.0001) %MON trAdv_CFL_u_max              =   2.9351056831840E-01
+(PID.TID 0000.0001) %MON trAdv_CFL_v_max              =   3.0944655274371E-01
+(PID.TID 0000.0001) %MON trAdv_CFL_w_max              =   7.1078358125217E-02
+(PID.TID 0000.0001) %MON advcfl_uvel_max              =   2.6959845973945E-01
+(PID.TID 0000.0001) %MON advcfl_vvel_max              =   2.2624708224607E-01
+(PID.TID 0000.0001) %MON advcfl_wvel_max              =   7.1702642957609E-02
+(PID.TID 0000.0001) %MON advcfl_W_hf_max              =   7.1078358125217E-02
+(PID.TID 0000.0001) %MON am_eta_mean                  =  -2.9469612863911E+09
+(PID.TID 0000.0001) %MON am_uZo_mean                  =   2.8065499509185E+11
+(PID.TID 0000.0001) %MON am_tot_mean                  =   2.7770803380545E+11
+(PID.TID 0000.0001) %MON pe_b_mean                    =   2.7417458285580E+00
+(PID.TID 0000.0001) %MON ke_max                       =   3.2449208380692E+03
+(PID.TID 0000.0001) %MON ke_mean                      =   1.3430015791623E+02
 (PID.TID 0000.0001) %MON ke_vol                       =   5.0990436378172E+19
-(PID.TID 0000.0001) %MON vort_r_min                   =  -1.7850081703487E-04
-(PID.TID 0000.0001) %MON vort_r_max                   =   2.2149321796243E-04
-(PID.TID 0000.0001) %MON vort_a_mean                  =   9.5602851777620E-20
-(PID.TID 0000.0001) %MON vort_a_sd                    =   8.8609092180624E-05
-(PID.TID 0000.0001) %MON vort_p_mean                  =   1.0050550128780E-19
-(PID.TID 0000.0001) %MON vort_p_sd                    =   8.8682277706820E-05
-(PID.TID 0000.0001) %MON surfExpan_theta_mean         =   1.2719184698384E-03
+(PID.TID 0000.0001) %MON vort_r_min                   =  -1.7850084339973E-04
+(PID.TID 0000.0001) %MON vort_r_max                   =   2.2149322060065E-04
+(PID.TID 0000.0001) %MON vort_a_mean                  =  -1.5688673112225E-19
+(PID.TID 0000.0001) %MON vort_a_sd                    =   8.8609090950583E-05
+(PID.TID 0000.0001) %MON vort_p_mean                  =  -1.5688663615836E-19
+(PID.TID 0000.0001) %MON vort_p_sd                    =   8.8682277409165E-05
+(PID.TID 0000.0001) %MON surfExpan_theta_mean         =   1.2936811591957E-03
 (PID.TID 0000.0001) %MON surfExpan_salt_mean          =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON surfExpan_Heat_mean          =  -1.5244266096219E-01
-(PID.TID 0000.0001) %MON En_Budget_T2PE_mean          =   5.8474248056115E-01
+(PID.TID 0000.0001) %MON surfExpan_Heat_mean          =  -1.5012259798669E-01
+(PID.TID 0000.0001) %MON En_Budget_T2PE_mean          =   5.8461846808875E-01
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // End MONITOR dynamic field statistics
 (PID.TID 0000.0001) // =======================================================
- cg2d: Sum(rhs),rhsMax =   4.42378222942352E-09  1.54315753983993E+04
-(PID.TID 0000.0001)      cg2d_init_res =   2.28474923297801E+03
+ cg2d: Sum(rhs),rhsMax =   3.49245965480804E-09  1.54315996828956E+04
+(PID.TID 0000.0001)      cg2d_init_res =   2.28467437877334E+03
 (PID.TID 0000.0001)      cg2d_iters(min,last) =      -1      16
-(PID.TID 0000.0001)      cg2d_last_res =   5.59336761524876E-11
+(PID.TID 0000.0001)      cg2d_last_res =   5.59324181082938E-11
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // Begin MONITOR dynamic field statistics
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) %MON time_tsnumber                =                276487
 (PID.TID 0000.0001) %MON time_secondsf                =   1.2441915000000E+08
-(PID.TID 0000.0001) %MON dynstat_eta_max              =   2.4807192996344E+03
-(PID.TID 0000.0001) %MON dynstat_eta_min              =  -3.3766620405554E+03
-(PID.TID 0000.0001) %MON dynstat_eta_mean             =  -2.1206800270941E-13
-(PID.TID 0000.0001) %MON dynstat_eta_sd               =   8.0049233021787E+02
-(PID.TID 0000.0001) %MON dynstat_eta_del2             =   2.0232910776547E+00
-(PID.TID 0000.0001) %MON dynstat_uvel_max             =   6.7110495738380E+01
-(PID.TID 0000.0001) %MON dynstat_uvel_min             =  -6.6807014621190E+01
-(PID.TID 0000.0001) %MON dynstat_uvel_mean            =   2.0455587506923E+00
-(PID.TID 0000.0001) %MON dynstat_uvel_sd              =   1.1153915489971E+01
-(PID.TID 0000.0001) %MON dynstat_uvel_del2            =   1.0713880972029E-02
-(PID.TID 0000.0001) %MON dynstat_vvel_max             =   7.2151878379303E+01
-(PID.TID 0000.0001) %MON dynstat_vvel_min             =  -6.8728633548612E+01
-(PID.TID 0000.0001) %MON dynstat_vvel_mean            =   2.0069013130909E+00
-(PID.TID 0000.0001) %MON dynstat_vvel_sd              =   1.1661810438966E+01
-(PID.TID 0000.0001) %MON dynstat_vvel_del2            =   1.0996855301698E-02
-(PID.TID 0000.0001) %MON dynstat_wvel_max             =   7.9346755732326E-01
-(PID.TID 0000.0001) %MON dynstat_wvel_min             =  -6.8300576514441E-01
-(PID.TID 0000.0001) %MON dynstat_wvel_mean            =   2.0918955444031E-18
-(PID.TID 0000.0001) %MON dynstat_wvel_sd              =   6.4103793478942E-02
-(PID.TID 0000.0001) %MON dynstat_wvel_del2            =   2.0552248740352E-04
-(PID.TID 0000.0001) %MON dynstat_theta_max            =   5.9640595645570E+02
-(PID.TID 0000.0001) %MON dynstat_theta_min            =   2.6190191316679E+02
-(PID.TID 0000.0001) %MON dynstat_theta_mean           =   3.2766083209116E+02
-(PID.TID 0000.0001) %MON dynstat_theta_sd             =   6.3757420944976E+01
-(PID.TID 0000.0001) %MON dynstat_theta_del2           =   5.1744284965490E-03
+(PID.TID 0000.0001) %MON dynstat_eta_max              =   2.4807137252690E+03
+(PID.TID 0000.0001) %MON dynstat_eta_min              =  -3.3766684323505E+03
+(PID.TID 0000.0001) %MON dynstat_eta_mean             =  -2.4419951827144E-13
+(PID.TID 0000.0001) %MON dynstat_eta_sd               =   8.0049344767712E+02
+(PID.TID 0000.0001) %MON dynstat_eta_del2             =   2.0232922460439E+00
+(PID.TID 0000.0001) %MON dynstat_uvel_max             =   6.7110541120471E+01
+(PID.TID 0000.0001) %MON dynstat_uvel_min             =  -6.6806809766589E+01
+(PID.TID 0000.0001) %MON dynstat_uvel_mean            =   2.0455563492704E+00
+(PID.TID 0000.0001) %MON dynstat_uvel_sd              =   1.1153909301230E+01
+(PID.TID 0000.0001) %MON dynstat_uvel_del2            =   1.0713881645212E-02
+(PID.TID 0000.0001) %MON dynstat_vvel_max             =   7.2151848563725E+01
+(PID.TID 0000.0001) %MON dynstat_vvel_min             =  -6.8728434420908E+01
+(PID.TID 0000.0001) %MON dynstat_vvel_mean            =   2.0068990248103E+00
+(PID.TID 0000.0001) %MON dynstat_vvel_sd              =   1.1661807763122E+01
+(PID.TID 0000.0001) %MON dynstat_vvel_del2            =   1.0996857816187E-02
+(PID.TID 0000.0001) %MON dynstat_wvel_max             =   7.9347220248615E-01
+(PID.TID 0000.0001) %MON dynstat_wvel_min             =  -6.8303146090585E-01
+(PID.TID 0000.0001) %MON dynstat_wvel_mean            =   4.1837910888061E-18
+(PID.TID 0000.0001) %MON dynstat_wvel_sd              =   6.4103907832830E-02
+(PID.TID 0000.0001) %MON dynstat_wvel_del2            =   2.0552440715271E-04
+(PID.TID 0000.0001) %MON dynstat_theta_max            =   5.9640596344034E+02
+(PID.TID 0000.0001) %MON dynstat_theta_min            =   2.6190189595680E+02
+(PID.TID 0000.0001) %MON dynstat_theta_mean           =   3.2765892763826E+02
+(PID.TID 0000.0001) %MON dynstat_theta_sd             =   6.3757874229706E+01
+(PID.TID 0000.0001) %MON dynstat_theta_del2           =   5.1744275286005E-03
 (PID.TID 0000.0001) %MON dynstat_salt_max             =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON dynstat_salt_min             =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON dynstat_salt_mean            =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON dynstat_salt_sd              =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON dynstat_salt_del2            =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON advcfl_uvel_max              =   2.6981755366621E-01
-(PID.TID 0000.0001) %MON advcfl_vvel_max              =   2.2614946031782E-01
-(PID.TID 0000.0001) %MON advcfl_wvel_max              =   7.1412080159093E-02
-(PID.TID 0000.0001) %MON advcfl_W_hf_max              =   7.0793468155148E-02
-(PID.TID 0000.0001) %MON am_eta_mean                  =  -2.9480157666407E+09
-(PID.TID 0000.0001) %MON am_uZo_mean                  =   2.8064945060968E+11
-(PID.TID 0000.0001) %MON am_tot_mean                  =   2.7770143484304E+11
-(PID.TID 0000.0001) %MON pe_b_mean                    =   2.7131035913942E+00
-(PID.TID 0000.0001) %MON ke_max                       =   3.2395625282307E+03
-(PID.TID 0000.0001) %MON ke_mean                      =   1.3427449254238E+02
+(PID.TID 0000.0001) %MON trAdv_CFL_u_max              =   2.9365071298822E-01
+(PID.TID 0000.0001) %MON trAdv_CFL_v_max              =   3.0959000336009E-01
+(PID.TID 0000.0001) %MON trAdv_CFL_w_max              =   7.0793879108983E-02
+(PID.TID 0000.0001) %MON advcfl_uvel_max              =   2.6981672630747E-01
+(PID.TID 0000.0001) %MON advcfl_vvel_max              =   2.2615016842784E-01
+(PID.TID 0000.0001) %MON advcfl_wvel_max              =   7.1412498223754E-02
+(PID.TID 0000.0001) %MON advcfl_W_hf_max              =   7.0793879108983E-02
+(PID.TID 0000.0001) %MON am_eta_mean                  =  -2.9476789006839E+09
+(PID.TID 0000.0001) %MON am_uZo_mean                  =   2.8064911358310E+11
+(PID.TID 0000.0001) %MON am_tot_mean                  =   2.7770143468241E+11
+(PID.TID 0000.0001) %MON pe_b_mean                    =   2.7131111661947E+00
+(PID.TID 0000.0001) %MON ke_max                       =   3.2395487893647E+03
+(PID.TID 0000.0001) %MON ke_mean                      =   1.3427438278981E+02
 (PID.TID 0000.0001) %MON ke_vol                       =   5.0990436378172E+19
-(PID.TID 0000.0001) %MON vort_r_min                   =  -1.7848961932193E-04
-(PID.TID 0000.0001) %MON vort_r_max                   =   2.2141328755333E-04
-(PID.TID 0000.0001) %MON vort_a_mean                  =   4.9027103475702E-20
-(PID.TID 0000.0001) %MON vort_a_sd                    =   8.8606953170410E-05
-(PID.TID 0000.0001) %MON vort_p_mean                  =   4.9027074004704E-20
-(PID.TID 0000.0001) %MON vort_p_sd                    =   8.8679619769397E-05
-(PID.TID 0000.0001) %MON surfExpan_theta_mean         =   2.9315492276889E-04
+(PID.TID 0000.0001) %MON vort_r_min                   =  -1.7848966644062E-04
+(PID.TID 0000.0001) %MON vort_r_max                   =   2.2141329028475E-04
+(PID.TID 0000.0001) %MON vort_a_mean                  =   2.2062196564066E-19
+(PID.TID 0000.0001) %MON vort_a_sd                    =   8.8606951114351E-05
+(PID.TID 0000.0001) %MON vort_p_mean                  =   2.2062183302510E-19
+(PID.TID 0000.0001) %MON vort_p_sd                    =   8.8679619336751E-05
+(PID.TID 0000.0001) %MON surfExpan_theta_mean         =   3.2339861165312E-04
 (PID.TID 0000.0001) %MON surfExpan_salt_mean          =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON surfExpan_Heat_mean          =  -2.5353568033412E-01
-(PID.TID 0000.0001) %MON En_Budget_T2PE_mean          =   5.0582033523283E-01
+(PID.TID 0000.0001) %MON surfExpan_Heat_mean          =  -2.5031133812821E-01
+(PID.TID 0000.0001) %MON En_Budget_T2PE_mean          =   5.0564496455728E-01
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // End MONITOR dynamic field statistics
 (PID.TID 0000.0001) // =======================================================
- cg2d: Sum(rhs),rhsMax =   4.65661287307739E-09  1.53833310895626E+04
-(PID.TID 0000.0001)      cg2d_init_res =   2.30768695893434E+03
+ cg2d: Sum(rhs),rhsMax =   3.25962901115417E-09  1.53833743701375E+04
+(PID.TID 0000.0001)      cg2d_init_res =   2.30759731454881E+03
 (PID.TID 0000.0001)      cg2d_iters(min,last) =      -1      16
-(PID.TID 0000.0001)      cg2d_last_res =   5.54248816665247E-11
+(PID.TID 0000.0001)      cg2d_last_res =   5.54227703315717E-11
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // Begin MONITOR dynamic field statistics
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) %MON time_tsnumber                =                276488
 (PID.TID 0000.0001) %MON time_secondsf                =   1.2441960000000E+08
-(PID.TID 0000.0001) %MON dynstat_eta_max              =   2.4695239603681E+03
-(PID.TID 0000.0001) %MON dynstat_eta_min              =  -3.3655931465712E+03
-(PID.TID 0000.0001) %MON dynstat_eta_mean             =  -1.8636279025978E-13
-(PID.TID 0000.0001) %MON dynstat_eta_sd               =   7.9648304823719E+02
-(PID.TID 0000.0001) %MON dynstat_eta_del2             =   2.0366831087294E+00
-(PID.TID 0000.0001) %MON dynstat_uvel_max             =   6.7084721378238E+01
-(PID.TID 0000.0001) %MON dynstat_uvel_min             =  -6.6859514805556E+01
-(PID.TID 0000.0001) %MON dynstat_uvel_mean            =   2.0450735851084E+00
-(PID.TID 0000.0001) %MON dynstat_uvel_sd              =   1.1152832118014E+01
-(PID.TID 0000.0001) %MON dynstat_uvel_del2            =   1.0711853467733E-02
-(PID.TID 0000.0001) %MON dynstat_vvel_max             =   7.2196851004233E+01
-(PID.TID 0000.0001) %MON dynstat_vvel_min             =  -6.8766098382016E+01
-(PID.TID 0000.0001) %MON dynstat_vvel_mean            =   2.0061354334721E+00
-(PID.TID 0000.0001) %MON dynstat_vvel_sd              =   1.1660660592163E+01
-(PID.TID 0000.0001) %MON dynstat_vvel_del2            =   1.0992670635288E-02
-(PID.TID 0000.0001) %MON dynstat_wvel_max             =   7.9025566997718E-01
-(PID.TID 0000.0001) %MON dynstat_wvel_min             =  -6.8367672292732E-01
-(PID.TID 0000.0001) %MON dynstat_wvel_mean            =   7.0802618425950E-18
-(PID.TID 0000.0001) %MON dynstat_wvel_sd              =   6.4056873087374E-02
-(PID.TID 0000.0001) %MON dynstat_wvel_del2            =   2.0566587759920E-04
-(PID.TID 0000.0001) %MON dynstat_theta_max            =   5.9656939183109E+02
-(PID.TID 0000.0001) %MON dynstat_theta_min            =   2.6191105622766E+02
-(PID.TID 0000.0001) %MON dynstat_theta_mean           =   3.2766085893312E+02
-(PID.TID 0000.0001) %MON dynstat_theta_sd             =   6.3757404283620E+01
-(PID.TID 0000.0001) %MON dynstat_theta_del2           =   5.1760839644947E-03
+(PID.TID 0000.0001) %MON dynstat_eta_max              =   2.4695153911204E+03
+(PID.TID 0000.0001) %MON dynstat_eta_min              =  -3.3656039923283E+03
+(PID.TID 0000.0001) %MON dynstat_eta_mean             =  -1.7351018403497E-13
+(PID.TID 0000.0001) %MON dynstat_eta_sd               =   7.9648468023135E+02
+(PID.TID 0000.0001) %MON dynstat_eta_del2             =   2.0366850826743E+00
+(PID.TID 0000.0001) %MON dynstat_uvel_max             =   6.7084777797759E+01
+(PID.TID 0000.0001) %MON dynstat_uvel_min             =  -6.6859251233434E+01
+(PID.TID 0000.0001) %MON dynstat_uvel_mean            =   2.0450698629392E+00
+(PID.TID 0000.0001) %MON dynstat_uvel_sd              =   1.1152822977219E+01
+(PID.TID 0000.0001) %MON dynstat_uvel_del2            =   1.0711854300366E-02
+(PID.TID 0000.0001) %MON dynstat_vvel_max             =   7.2196804012004E+01
+(PID.TID 0000.0001) %MON dynstat_vvel_min             =  -6.8765835670048E+01
+(PID.TID 0000.0001) %MON dynstat_vvel_mean            =   2.0061318723942E+00
+(PID.TID 0000.0001) %MON dynstat_vvel_sd              =   1.1660656003172E+01
+(PID.TID 0000.0001) %MON dynstat_vvel_del2            =   1.0992673919971E-02
+(PID.TID 0000.0001) %MON dynstat_wvel_max             =   7.9026249098221E-01
+(PID.TID 0000.0001) %MON dynstat_wvel_min             =  -6.8370942498038E-01
+(PID.TID 0000.0001) %MON dynstat_wvel_mean            =   3.7815034841132E-18
+(PID.TID 0000.0001) %MON dynstat_wvel_sd              =   6.4057018335507E-02
+(PID.TID 0000.0001) %MON dynstat_wvel_del2            =   2.0566846018854E-04
+(PID.TID 0000.0001) %MON dynstat_theta_max            =   5.9656939874722E+02
+(PID.TID 0000.0001) %MON dynstat_theta_min            =   2.6191103650239E+02
+(PID.TID 0000.0001) %MON dynstat_theta_mean           =   3.2765868263758E+02
+(PID.TID 0000.0001) %MON dynstat_theta_sd             =   6.3757922291873E+01
+(PID.TID 0000.0001) %MON dynstat_theta_del2           =   5.1760829513624E-03
 (PID.TID 0000.0001) %MON dynstat_salt_max             =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON dynstat_salt_min             =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON dynstat_salt_mean            =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON dynstat_salt_sd              =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON dynstat_salt_del2            =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON advcfl_uvel_max              =   2.7002958935428E-01
-(PID.TID 0000.0001) %MON advcfl_vvel_max              =   2.2603996230151E-01
-(PID.TID 0000.0001) %MON advcfl_wvel_max              =   7.1123010297946E-02
-(PID.TID 0000.0001) %MON advcfl_W_hf_max              =   7.0510072190076E-02
-(PID.TID 0000.0001) %MON am_eta_mean                  =  -2.9486074192870E+09
-(PID.TID 0000.0001) %MON am_uZo_mean                  =   2.8064345582102E+11
-(PID.TID 0000.0001) %MON am_tot_mean                  =   2.7769484840173E+11
-(PID.TID 0000.0001) %MON pe_b_mean                    =   2.6859943822281E+00
-(PID.TID 0000.0001) %MON ke_max                       =   3.2382963763531E+03
-(PID.TID 0000.0001) %MON ke_mean                      =   1.3424647036130E+02
+(PID.TID 0000.0001) %MON trAdv_CFL_u_max              =   2.9382371260560E-01
+(PID.TID 0000.0001) %MON trAdv_CFL_v_max              =   3.0976373676385E-01
+(PID.TID 0000.0001) %MON trAdv_CFL_w_max              =   7.0510675005126E-02
+(PID.TID 0000.0001) %MON advcfl_uvel_max              =   2.7002852484952E-01
+(PID.TID 0000.0001) %MON advcfl_vvel_max              =   2.2604087592956E-01
+(PID.TID 0000.0001) %MON advcfl_wvel_max              =   7.1123624188399E-02
+(PID.TID 0000.0001) %MON advcfl_W_hf_max              =   7.0510675005126E-02
+(PID.TID 0000.0001) %MON am_eta_mean                  =  -2.9480704427062E+09
+(PID.TID 0000.0001) %MON am_uZo_mean                  =   2.8064291861267E+11
+(PID.TID 0000.0001) %MON am_tot_mean                  =   2.7769484816996E+11
+(PID.TID 0000.0001) %MON pe_b_mean                    =   2.6860053894470E+00
+(PID.TID 0000.0001) %MON ke_max                       =   3.2382744547436E+03
+(PID.TID 0000.0001) %MON ke_mean                      =   1.3424630013708E+02
 (PID.TID 0000.0001) %MON ke_vol                       =   5.0990436378172E+19
-(PID.TID 0000.0001) %MON vort_r_min                   =  -1.7843621420202E-04
-(PID.TID 0000.0001) %MON vort_r_max                   =   2.2130823290835E-04
-(PID.TID 0000.0001) %MON vort_a_mean                  =   7.3540655213554E-21
-(PID.TID 0000.0001) %MON vort_a_sd                    =   8.8604715771865E-05
-(PID.TID 0000.0001) %MON vort_p_mean                  =   7.3540611239748E-21
-(PID.TID 0000.0001) %MON vort_p_sd                    =   8.8676917940668E-05
-(PID.TID 0000.0001) %MON surfExpan_theta_mean         =  -7.7220631407141E-04
+(PID.TID 0000.0001) %MON vort_r_min                   =  -1.7843629051690E-04
+(PID.TID 0000.0001) %MON vort_r_max                   =   2.2130823387874E-04
+(PID.TID 0000.0001) %MON vort_a_mean                  =  -3.6770327606777E-20
+(PID.TID 0000.0001) %MON vort_a_sd                    =   8.8604712601212E-05
+(PID.TID 0000.0001) %MON vort_p_mean                  =  -3.9221659328856E-20
+(PID.TID 0000.0001) %MON vort_p_sd                    =   8.8676917352576E-05
+(PID.TID 0000.0001) %MON surfExpan_theta_mean         =  -7.3219823022779E-04
 (PID.TID 0000.0001) %MON surfExpan_salt_mean          =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON surfExpan_Heat_mean          =  -3.5392982391147E-01
-(PID.TID 0000.0001) %MON En_Budget_T2PE_mean          =   4.3583725830790E-01
+(PID.TID 0000.0001) %MON surfExpan_Heat_mean          =  -3.4966461391403E-01
+(PID.TID 0000.0001) %MON En_Budget_T2PE_mean          =   4.3560210661518E-01
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // End MONITOR dynamic field statistics
 (PID.TID 0000.0001) // =======================================================
- cg2d: Sum(rhs),rhsMax =   4.19095158576965E-09  1.53848562144830E+04
-(PID.TID 0000.0001)      cg2d_init_res =   2.33168257692452E+03
+ cg2d: Sum(rhs),rhsMax =   1.86264514923096E-09  1.53849184027061E+04
+(PID.TID 0000.0001)      cg2d_init_res =   2.33157976295755E+03
 (PID.TID 0000.0001)      cg2d_iters(min,last) =      -1      16
-(PID.TID 0000.0001)      cg2d_last_res =   5.45684811603873E-11
+(PID.TID 0000.0001)      cg2d_last_res =   5.45655644627986E-11
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // Begin MONITOR dynamic field statistics
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) %MON time_tsnumber                =                276489
 (PID.TID 0000.0001) %MON time_secondsf                =   1.2442005000000E+08
-(PID.TID 0000.0001) %MON dynstat_eta_max              =   2.4592991606615E+03
-(PID.TID 0000.0001) %MON dynstat_eta_min              =  -3.3593673559241E+03
-(PID.TID 0000.0001) %MON dynstat_eta_mean             =  -1.9278909337219E-14
-(PID.TID 0000.0001) %MON dynstat_eta_sd               =   7.9277914892970E+02
-(PID.TID 0000.0001) %MON dynstat_eta_del2             =   2.0520452833325E+00
-(PID.TID 0000.0001) %MON dynstat_uvel_max             =   6.7061029105123E+01
-(PID.TID 0000.0001) %MON dynstat_uvel_min             =  -6.6909521999294E+01
-(PID.TID 0000.0001) %MON dynstat_uvel_mean            =   2.0445837572477E+00
-(PID.TID 0000.0001) %MON dynstat_uvel_sd              =   1.1151578393241E+01
-(PID.TID 0000.0001) %MON dynstat_uvel_del2            =   1.0709737784675E-02
-(PID.TID 0000.0001) %MON dynstat_vvel_max             =   7.2237580172599E+01
-(PID.TID 0000.0001) %MON dynstat_vvel_min             =  -6.8809705818946E+01
-(PID.TID 0000.0001) %MON dynstat_vvel_mean            =   2.0053769059235E+00
-(PID.TID 0000.0001) %MON dynstat_vvel_sd              =   1.1659419900135E+01
-(PID.TID 0000.0001) %MON dynstat_vvel_del2            =   1.0988444969010E-02
-(PID.TID 0000.0001) %MON dynstat_wvel_max             =   7.8707523187391E-01
-(PID.TID 0000.0001) %MON dynstat_wvel_min             =  -6.8352281192785E-01
-(PID.TID 0000.0001) %MON dynstat_wvel_mean            =  -1.1143366649993E-17
-(PID.TID 0000.0001) %MON dynstat_wvel_sd              =   6.4047851374445E-02
-(PID.TID 0000.0001) %MON dynstat_wvel_del2            =   2.0584848520699E-04
-(PID.TID 0000.0001) %MON dynstat_theta_max            =   5.9671754484288E+02
-(PID.TID 0000.0001) %MON dynstat_theta_min            =   2.6192087149431E+02
-(PID.TID 0000.0001) %MON dynstat_theta_mean           =   3.2766088538718E+02
-(PID.TID 0000.0001) %MON dynstat_theta_sd             =   6.3757389955032E+01
-(PID.TID 0000.0001) %MON dynstat_theta_del2           =   5.1774370110976E-03
+(PID.TID 0000.0001) %MON dynstat_eta_max              =   2.4592867273844E+03
+(PID.TID 0000.0001) %MON dynstat_eta_min              =  -3.3593842076894E+03
+(PID.TID 0000.0001) %MON dynstat_eta_mean             =  -1.1567345602331E-13
+(PID.TID 0000.0001) %MON dynstat_eta_sd               =   7.9278141340887E+02
+(PID.TID 0000.0001) %MON dynstat_eta_del2             =   2.0520482931190E+00
+(PID.TID 0000.0001) %MON dynstat_uvel_max             =   6.7061095973785E+01
+(PID.TID 0000.0001) %MON dynstat_uvel_min             =  -6.6909193831305E+01
+(PID.TID 0000.0001) %MON dynstat_uvel_mean            =   2.0445783219784E+00
+(PID.TID 0000.0001) %MON dynstat_uvel_sd              =   1.1151565535992E+01
+(PID.TID 0000.0001) %MON dynstat_uvel_del2            =   1.0709738758993E-02
+(PID.TID 0000.0001) %MON dynstat_vvel_max             =   7.2237510740833E+01
+(PID.TID 0000.0001) %MON dynstat_vvel_min             =  -6.8809372752612E+01
+(PID.TID 0000.0001) %MON dynstat_vvel_mean            =   2.0053716895619E+00
+(PID.TID 0000.0001) %MON dynstat_vvel_sd              =   1.1659412720164E+01
+(PID.TID 0000.0001) %MON dynstat_vvel_del2            =   1.0988449098614E-02
+(PID.TID 0000.0001) %MON dynstat_wvel_max             =   7.8708474218569E-01
+(PID.TID 0000.0001) %MON dynstat_wvel_min             =  -6.8356257333394E-01
+(PID.TID 0000.0001) %MON dynstat_wvel_mean            =  -8.7698697823051E-18
+(PID.TID 0000.0001) %MON dynstat_wvel_sd              =   6.4048027522049E-02
+(PID.TID 0000.0001) %MON dynstat_wvel_del2            =   2.0585179011576E-04
+(PID.TID 0000.0001) %MON dynstat_theta_max            =   5.9671754947006E+02
+(PID.TID 0000.0001) %MON dynstat_theta_min            =   2.6192084922795E+02
+(PID.TID 0000.0001) %MON dynstat_theta_mean           =   3.2765843730545E+02
+(PID.TID 0000.0001) %MON dynstat_theta_sd             =   6.3757972677932E+01
+(PID.TID 0000.0001) %MON dynstat_theta_del2           =   5.1774359694394E-03
 (PID.TID 0000.0001) %MON dynstat_salt_max             =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON dynstat_salt_min             =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON dynstat_salt_mean            =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON dynstat_salt_sd              =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON dynstat_salt_del2            =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON advcfl_uvel_max              =   2.7023155644945E-01
-(PID.TID 0000.0001) %MON advcfl_vvel_max              =   2.2591924608172E-01
-(PID.TID 0000.0001) %MON advcfl_wvel_max              =   7.0836770868652E-02
-(PID.TID 0000.0001) %MON advcfl_W_hf_max              =   7.0229390112613E-02
-(PID.TID 0000.0001) %MON am_eta_mean                  =  -2.9489751629789E+09
-(PID.TID 0000.0001) %MON am_uZo_mean                  =   2.8063724041769E+11
-(PID.TID 0000.0001) %MON am_tot_mean                  =   2.7768826525472E+11
-(PID.TID 0000.0001) %MON pe_b_mean                    =   2.6610710130347E+00
-(PID.TID 0000.0001) %MON ke_max                       =   3.2365622483806E+03
-(PID.TID 0000.0001) %MON ke_mean                      =   1.3421549955459E+02
+(PID.TID 0000.0001) %MON trAdv_CFL_u_max              =   2.9402787657991E-01
+(PID.TID 0000.0001) %MON trAdv_CFL_v_max              =   3.0996464225463E-01
+(PID.TID 0000.0001) %MON trAdv_CFL_w_max              =   7.0230229915787E-02
+(PID.TID 0000.0001) %MON advcfl_uvel_max              =   2.7023023105743E-01
+(PID.TID 0000.0001) %MON advcfl_vvel_max              =   2.2592038473855E-01
+(PID.TID 0000.0001) %MON advcfl_wvel_max              =   7.0837626796713E-02
+(PID.TID 0000.0001) %MON advcfl_W_hf_max              =   7.0230229915787E-02
+(PID.TID 0000.0001) %MON am_eta_mean                  =  -2.9481730782568E+09
+(PID.TID 0000.0001) %MON am_uZo_mean                  =   2.8063643801855E+11
+(PID.TID 0000.0001) %MON am_tot_mean                  =   2.7768826494029E+11
+(PID.TID 0000.0001) %MON pe_b_mean                    =   2.6610862151210E+00
+(PID.TID 0000.0001) %MON ke_max                       =   3.2365335081763E+03
+(PID.TID 0000.0001) %MON ke_mean                      =   1.3421525088195E+02
 (PID.TID 0000.0001) %MON ke_vol                       =   5.0990436378172E+19
-(PID.TID 0000.0001) %MON vort_r_min                   =  -1.7833955651597E-04
-(PID.TID 0000.0001) %MON vort_r_max                   =   2.2117861354319E-04
-(PID.TID 0000.0001) %MON vort_a_mean                  =  -6.6186589692198E-20
-(PID.TID 0000.0001) %MON vort_a_sd                    =   8.8602393812720E-05
-(PID.TID 0000.0001) %MON vort_p_mean                  =  -5.8832489123507E-20
-(PID.TID 0000.0001) %MON vort_p_sd                    =   8.8674198505616E-05
-(PID.TID 0000.0001) %MON surfExpan_theta_mean         =  -1.7987388808830E-03
+(PID.TID 0000.0001) %MON vort_r_min                   =  -1.7833967163269E-04
+(PID.TID 0000.0001) %MON vort_r_max                   =   2.2117860985876E-04
+(PID.TID 0000.0001) %MON vort_a_mean                  =  -7.3540655213554E-20
+(PID.TID 0000.0001) %MON vort_a_sd                    =   8.8602389201620E-05
+(PID.TID 0000.0001) %MON vort_p_mean                  =  -7.5991965120412E-20
+(PID.TID 0000.0001) %MON vort_p_sd                    =   8.8674197743776E-05
+(PID.TID 0000.0001) %MON surfExpan_theta_mean         =  -1.7477333120891E-03
 (PID.TID 0000.0001) %MON surfExpan_salt_mean          =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON surfExpan_Heat_mean          =  -4.4277381348688E-01
-(PID.TID 0000.0001) %MON En_Budget_T2PE_mean          =   3.7582894176947E-01
+(PID.TID 0000.0001) %MON surfExpan_Heat_mean          =  -4.3733665960170E-01
+(PID.TID 0000.0001) %MON En_Budget_T2PE_mean          =   3.7552579073202E-01
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // End MONITOR dynamic field statistics
 (PID.TID 0000.0001) // =======================================================
- cg2d: Sum(rhs),rhsMax =   5.58793544769287E-09  1.54315115256822E+04
-(PID.TID 0000.0001)      cg2d_init_res =   2.35199883434116E+03
+ cg2d: Sum(rhs),rhsMax =   4.65661287307739E-09  1.54316048037388E+04
+(PID.TID 0000.0001)      cg2d_init_res =   2.35188356171727E+03
 (PID.TID 0000.0001)      cg2d_iters(min,last) =      -1      16
-(PID.TID 0000.0001)      cg2d_last_res =   5.34550077374318E-11
+(PID.TID 0000.0001)      cg2d_last_res =   5.34513721450550E-11
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // Begin MONITOR dynamic field statistics
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) %MON time_tsnumber                =                276490
 (PID.TID 0000.0001) %MON time_secondsf                =   1.2442050000000E+08
-(PID.TID 0000.0001) %MON dynstat_eta_max              =   2.4500590401370E+03
-(PID.TID 0000.0001) %MON dynstat_eta_min              =  -3.3578918204922E+03
-(PID.TID 0000.0001) %MON dynstat_eta_mean             =  -2.6990473072106E-13
-(PID.TID 0000.0001) %MON dynstat_eta_sd               =   7.8945200238442E+02
-(PID.TID 0000.0001) %MON dynstat_eta_del2             =   2.0673219499250E+00
-(PID.TID 0000.0001) %MON dynstat_uvel_max             =   6.7040469469898E+01
-(PID.TID 0000.0001) %MON dynstat_uvel_min             =  -6.6955471832993E+01
-(PID.TID 0000.0001) %MON dynstat_uvel_mean            =   2.0440945268557E+00
-(PID.TID 0000.0001) %MON dynstat_uvel_sd              =   1.1150137345539E+01
-(PID.TID 0000.0001) %MON dynstat_uvel_del2            =   1.0707592387478E-02
-(PID.TID 0000.0001) %MON dynstat_vvel_max             =   7.2272563021240E+01
-(PID.TID 0000.0001) %MON dynstat_vvel_min             =  -6.8857876201283E+01
-(PID.TID 0000.0001) %MON dynstat_vvel_mean            =   2.0046131232292E+00
-(PID.TID 0000.0001) %MON dynstat_vvel_sd              =   1.1658063777873E+01
-(PID.TID 0000.0001) %MON dynstat_vvel_del2            =   1.0984236056897E-02
-(PID.TID 0000.0001) %MON dynstat_wvel_max             =   7.8392961706758E-01
-(PID.TID 0000.0001) %MON dynstat_wvel_min             =  -6.8444622840983E-01
-(PID.TID 0000.0001) %MON dynstat_wvel_mean            =   6.5170591960249E-18
-(PID.TID 0000.0001) %MON dynstat_wvel_sd              =   6.4071896074044E-02
-(PID.TID 0000.0001) %MON dynstat_wvel_del2            =   2.0605140575160E-04
-(PID.TID 0000.0001) %MON dynstat_theta_max            =   5.9684944644284E+02
-(PID.TID 0000.0001) %MON dynstat_theta_min            =   2.6193136269371E+02
-(PID.TID 0000.0001) %MON dynstat_theta_mean           =   3.2766091077191E+02
-(PID.TID 0000.0001) %MON dynstat_theta_sd             =   6.3757378007170E+01
-(PID.TID 0000.0001) %MON dynstat_theta_del2           =   5.1784289892575E-03
+(PID.TID 0000.0001) %MON dynstat_eta_max              =   2.4500418018200E+03
+(PID.TID 0000.0001) %MON dynstat_eta_min              =  -3.3579162506718E+03
+(PID.TID 0000.0001) %MON dynstat_eta_mean             =  -2.1206800270941E-13
+(PID.TID 0000.0001) %MON dynstat_eta_sd               =   7.8945501946786E+02
+(PID.TID 0000.0001) %MON dynstat_eta_del2             =   2.0673261874713E+00
+(PID.TID 0000.0001) %MON dynstat_uvel_max             =   6.7040545516343E+01
+(PID.TID 0000.0001) %MON dynstat_uvel_min             =  -6.6955073154870E+01
+(PID.TID 0000.0001) %MON dynstat_uvel_mean            =   2.0440869433033E+00
+(PID.TID 0000.0001) %MON dynstat_uvel_sd              =   1.1150119935290E+01
+(PID.TID 0000.0001) %MON dynstat_uvel_del2            =   1.0707593483276E-02
+(PID.TID 0000.0001) %MON dynstat_vvel_max             =   7.2272465363453E+01
+(PID.TID 0000.0001) %MON dynstat_vvel_min             =  -6.8857466275586E+01
+(PID.TID 0000.0001) %MON dynstat_vvel_mean            =   2.0046058255705E+00
+(PID.TID 0000.0001) %MON dynstat_vvel_sd              =   1.1658053240469E+01
+(PID.TID 0000.0001) %MON dynstat_vvel_del2            =   1.0984241089037E-02
+(PID.TID 0000.0001) %MON dynstat_wvel_max             =   7.8394235776929E-01
+(PID.TID 0000.0001) %MON dynstat_wvel_min             =  -6.8447675358852E-01
+(PID.TID 0000.0001) %MON dynstat_wvel_mean            =   3.2183008375432E-18
+(PID.TID 0000.0001) %MON dynstat_wvel_sd              =   6.4072102455836E-02
+(PID.TID 0000.0001) %MON dynstat_wvel_del2            =   2.0605548442957E-04
+(PID.TID 0000.0001) %MON dynstat_theta_max            =   5.9684944568185E+02
+(PID.TID 0000.0001) %MON dynstat_theta_min            =   2.6193133785680E+02
+(PID.TID 0000.0001) %MON dynstat_theta_mean           =   3.2765819096081E+02
+(PID.TID 0000.0001) %MON dynstat_theta_sd             =   6.3758025435382E+01
+(PID.TID 0000.0001) %MON dynstat_theta_del2           =   5.1784279278699E-03
 (PID.TID 0000.0001) %MON dynstat_salt_max             =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON dynstat_salt_min             =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON dynstat_salt_mean            =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON dynstat_salt_sd              =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON dynstat_salt_del2            =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON advcfl_uvel_max              =   2.7041713683783E-01
-(PID.TID 0000.0001) %MON advcfl_vvel_max              =   2.2579019842025E-01
-(PID.TID 0000.0001) %MON advcfl_wvel_max              =   7.0553665536082E-02
-(PID.TID 0000.0001) %MON advcfl_W_hf_max              =   6.9951630511850E-02
-(PID.TID 0000.0001) %MON am_eta_mean                  =  -2.9491673145763E+09
-(PID.TID 0000.0001) %MON am_uZo_mean                  =   2.8063084308620E+11
-(PID.TID 0000.0001) %MON am_tot_mean                  =   2.7768167577162E+11
-(PID.TID 0000.0001) %MON pe_b_mean                    =   2.6387818435467E+00
-(PID.TID 0000.0001) %MON ke_max                       =   3.2344768232627E+03
-(PID.TID 0000.0001) %MON ke_mean                      =   1.3418109072178E+02
+(PID.TID 0000.0001) %MON trAdv_CFL_u_max              =   2.9425727034816E-01
+(PID.TID 0000.0001) %MON trAdv_CFL_v_max              =   3.1018617595540E-01
+(PID.TID 0000.0001) %MON trAdv_CFL_w_max              =   6.9952754940525E-02
+(PID.TID 0000.0001) %MON advcfl_uvel_max              =   2.7041552667224E-01
+(PID.TID 0000.0001) %MON advcfl_vvel_max              =   2.2579158063294E-01
+(PID.TID 0000.0001) %MON advcfl_wvel_max              =   7.0554812199236E-02
+(PID.TID 0000.0001) %MON advcfl_W_hf_max              =   6.9952754940525E-02
+(PID.TID 0000.0001) %MON am_eta_mean                  =  -2.9480268193191E+09
+(PID.TID 0000.0001) %MON am_uZo_mean                  =   2.8062970218333E+11
+(PID.TID 0000.0001) %MON am_tot_mean                  =   2.7768167536402E+11
+(PID.TID 0000.0001) %MON pe_b_mean                    =   2.6388020130826E+00
+(PID.TID 0000.0001) %MON ke_max                       =   3.2344403033590E+03
+(PID.TID 0000.0001) %MON ke_mean                      =   1.3418074362227E+02
 (PID.TID 0000.0001) %MON ke_vol                       =   5.0990436378172E+19
-(PID.TID 0000.0001) %MON vort_r_min                   =  -1.7819826612589E-04
-(PID.TID 0000.0001) %MON vort_r_max                   =   2.2152079562771E-04
-(PID.TID 0000.0001) %MON vort_a_mean                  =  -7.8443365561124E-20
-(PID.TID 0000.0001) %MON vort_a_sd                    =   8.8600004507074E-05
-(PID.TID 0000.0001) %MON vort_p_mean                  =  -7.8443318947901E-20
-(PID.TID 0000.0001) %MON vort_p_sd                    =   8.8671483396186E-05
-(PID.TID 0000.0001) %MON surfExpan_theta_mean         =  -2.6913976112482E-03
+(PID.TID 0000.0001) %MON vort_r_min                   =  -1.7819843070967E-04
+(PID.TID 0000.0001) %MON vort_r_max                   =   2.2152090715622E-04
+(PID.TID 0000.0001) %MON vort_a_mean                  =  -1.7159486216496E-19
+(PID.TID 0000.0001) %MON vort_a_sd                    =   8.8599998094356E-05
+(PID.TID 0000.0001) %MON vort_p_mean                  =  -1.6669205277140E-19
+(PID.TID 0000.0001) %MON vort_p_sd                    =   8.8671482444431E-05
+(PID.TID 0000.0001) %MON surfExpan_theta_mean         =  -2.6282164968846E-03
 (PID.TID 0000.0001) %MON surfExpan_salt_mean          =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON surfExpan_Heat_mean          =  -5.1230886329167E-01
-(PID.TID 0000.0001) %MON En_Budget_T2PE_mean          =   3.2637990860775E-01
+(PID.TID 0000.0001) %MON surfExpan_Heat_mean          =  -5.0557472311819E-01
+(PID.TID 0000.0001) %MON En_Budget_T2PE_mean          =   3.2600075080806E-01
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // End MONITOR dynamic field statistics
 (PID.TID 0000.0001) // =======================================================
- cg2d: Sum(rhs),rhsMax =   4.65661287307739E-09  1.54891973463696E+04
-(PID.TID 0000.0001)      cg2d_init_res =   2.36506136203981E+03
+ cg2d: Sum(rhs),rhsMax =   6.75208866596222E-09  1.54893285424991E+04
+(PID.TID 0000.0001)      cg2d_init_res =   2.36493389045508E+03
 (PID.TID 0000.0001)      cg2d_iters(min,last) =      -1      16
-(PID.TID 0000.0001)      cg2d_last_res =   5.22012117617344E-11
+(PID.TID 0000.0001)      cg2d_last_res =   5.21972068846105E-11
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // Begin MONITOR dynamic field statistics
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) %MON time_tsnumber                =                276491
 (PID.TID 0000.0001) %MON time_secondsf                =   1.2442095000000E+08
-(PID.TID 0000.0001) %MON dynstat_eta_max              =   2.4418469415165E+03
-(PID.TID 0000.0001) %MON dynstat_eta_min              =  -3.3607186141319E+03
-(PID.TID 0000.0001) %MON dynstat_eta_mean             =  -1.3495236536053E-13
-(PID.TID 0000.0001) %MON dynstat_eta_sd               =   7.8654763508442E+02
-(PID.TID 0000.0001) %MON dynstat_eta_del2             =   2.0810256700198E+00
-(PID.TID 0000.0001) %MON dynstat_uvel_max             =   6.7023554593668E+01
-(PID.TID 0000.0001) %MON dynstat_uvel_min             =  -6.6995695910676E+01
-(PID.TID 0000.0001) %MON dynstat_uvel_mean            =   2.0436101214447E+00
-(PID.TID 0000.0001) %MON dynstat_uvel_sd              =   1.1148501426740E+01
-(PID.TID 0000.0001) %MON dynstat_uvel_del2            =   1.0705466056283E-02
-(PID.TID 0000.0001) %MON dynstat_vvel_max             =   7.2300872109063E+01
-(PID.TID 0000.0001) %MON dynstat_vvel_min             =  -6.8908522693870E+01
-(PID.TID 0000.0001) %MON dynstat_vvel_mean            =   2.0038329012739E+00
-(PID.TID 0000.0001) %MON dynstat_vvel_sd              =   1.1656571750197E+01
-(PID.TID 0000.0001) %MON dynstat_vvel_del2            =   1.0980074486911E-02
-(PID.TID 0000.0001) %MON dynstat_wvel_max             =   7.8080972950117E-01
-(PID.TID 0000.0001) %MON dynstat_wvel_min             =  -6.8544040316493E-01
-(PID.TID 0000.0001) %MON dynstat_wvel_mean            =   7.2210625042375E-18
-(PID.TID 0000.0001) %MON dynstat_wvel_sd              =   6.4124304520164E-02
-(PID.TID 0000.0001) %MON dynstat_wvel_del2            =   2.0625618222020E-04
-(PID.TID 0000.0001) %MON dynstat_theta_max            =   5.9696549416099E+02
-(PID.TID 0000.0001) %MON dynstat_theta_min            =   2.6194253215156E+02
-(PID.TID 0000.0001) %MON dynstat_theta_mean           =   3.2766093464679E+02
-(PID.TID 0000.0001) %MON dynstat_theta_sd             =   6.3757368323434E+01
-(PID.TID 0000.0001) %MON dynstat_theta_del2           =   5.1790389801710E-03
+(PID.TID 0000.0001) %MON dynstat_eta_max              =   2.4418238848877E+03
+(PID.TID 0000.0001) %MON dynstat_eta_min              =  -3.3607521479662E+03
+(PID.TID 0000.0001) %MON dynstat_eta_mean             =  -1.8636279025978E-13
+(PID.TID 0000.0001) %MON dynstat_eta_sd               =   7.8655152406330E+02
+(PID.TID 0000.0001) %MON dynstat_eta_del2             =   2.0810312674185E+00
+(PID.TID 0000.0001) %MON dynstat_uvel_max             =   6.7023637933232E+01
+(PID.TID 0000.0001) %MON dynstat_uvel_min             =  -6.6995220876787E+01
+(PID.TID 0000.0001) %MON dynstat_uvel_mean            =   2.0435999145242E+00
+(PID.TID 0000.0001) %MON dynstat_uvel_sd              =   1.1148478558630E+01
+(PID.TID 0000.0001) %MON dynstat_uvel_del2            =   1.0705467254476E-02
+(PID.TID 0000.0001) %MON dynstat_vvel_max             =   7.2300739953929E+01
+(PID.TID 0000.0001) %MON dynstat_vvel_min             =  -6.8908029534584E+01
+(PID.TID 0000.0001) %MON dynstat_vvel_mean            =   2.0038230552439E+00
+(PID.TID 0000.0001) %MON dynstat_vvel_sd              =   1.1656557004863E+01
+(PID.TID 0000.0001) %MON dynstat_vvel_del2            =   1.0980080461125E-02
+(PID.TID 0000.0001) %MON dynstat_wvel_max             =   7.8082626236256E-01
+(PID.TID 0000.0001) %MON dynstat_wvel_min             =  -6.8547565808277E-01
+(PID.TID 0000.0001) %MON dynstat_wvel_mean            =  -4.0228760469290E-19
+(PID.TID 0000.0001) %MON dynstat_wvel_sd              =   6.4124540228137E-02
+(PID.TID 0000.0001) %MON dynstat_wvel_del2            =   2.0626108327128E-04
+(PID.TID 0000.0001) %MON dynstat_theta_max            =   5.9696548414307E+02
+(PID.TID 0000.0001) %MON dynstat_theta_min            =   2.6194250471138E+02
+(PID.TID 0000.0001) %MON dynstat_theta_mean           =   3.2765794316356E+02
+(PID.TID 0000.0001) %MON dynstat_theta_sd             =   6.3758080447133E+01
+(PID.TID 0000.0001) %MON dynstat_theta_del2           =   5.1790379001553E-03
 (PID.TID 0000.0001) %MON dynstat_salt_max             =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON dynstat_salt_min             =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON dynstat_salt_mean            =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON dynstat_salt_sd              =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON dynstat_salt_del2            =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON advcfl_uvel_max              =   2.7057959226711E-01
-(PID.TID 0000.0001) %MON advcfl_vvel_max              =   2.2565707592424E-01
-(PID.TID 0000.0001) %MON advcfl_wvel_max              =   7.0272875655105E-02
-(PID.TID 0000.0001) %MON advcfl_W_hf_max              =   6.9675888930066E-02
-(PID.TID 0000.0001) %MON am_eta_mean                  =  -2.9492343954137E+09
-(PID.TID 0000.0001) %MON am_uZo_mean                  =   2.8062430607355E+11
-(PID.TID 0000.0001) %MON am_tot_mean                  =   2.7767507167814E+11
-(PID.TID 0000.0001) %MON pe_b_mean                    =   2.6194015800435E+00
-(PID.TID 0000.0001) %MON ke_max                       =   3.2321295871324E+03
-(PID.TID 0000.0001) %MON ke_mean                      =   1.3414290850674E+02
-(PID.TID 0000.0001) %MON ke_vol                       =   5.0990436378172E+19
-(PID.TID 0000.0001) %MON vort_r_min                   =  -1.7801079995860E-04
-(PID.TID 0000.0001) %MON vort_r_max                   =   2.2226415748753E-04
-(PID.TID 0000.0001) %MON vort_a_mean                  =   4.6575748301917E-20
-(PID.TID 0000.0001) %MON vort_a_sd                    =   8.8597565778678E-05
-(PID.TID 0000.0001) %MON vort_p_mean                  =   4.9027074387038E-20
-(PID.TID 0000.0001) %MON vort_p_sd                    =   8.8668789945174E-05
-(PID.TID 0000.0001) %MON surfExpan_theta_mean         =  -3.3888262427969E-03
+(PID.TID 0000.0001) %MON trAdv_CFL_u_max              =   2.9450275652755E-01
+(PID.TID 0000.0001) %MON trAdv_CFL_v_max              =   3.1041953150037E-01
+(PID.TID 0000.0001) %MON trAdv_CFL_w_max              =   6.9677347568711E-02
+(PID.TID 0000.0001) %MON advcfl_uvel_max              =   2.7057767371884E-01
+(PID.TID 0000.0001) %MON advcfl_vvel_max              =   2.2565871934303E-01
+(PID.TID 0000.0001) %MON advcfl_wvel_max              =   7.0274363612631E-02
+(PID.TID 0000.0001) %MON advcfl_W_hf_max              =   6.9677347568711E-02
+(PID.TID 0000.0001) %MON am_eta_mean                  =  -2.9476742453523E+09
+(PID.TID 0000.0001) %MON am_uZo_mean                  =   2.8062274541311E+11
+(PID.TID 0000.0001) %MON am_tot_mean                  =   2.7767507116776E+11
+(PID.TID 0000.0001) %MON pe_b_mean                    =   2.6194274826644E+00
+(PID.TID 0000.0001) %MON ke_max                       =   3.2320843428222E+03
+(PID.TID 0000.0001) %MON ke_mean                      =   1.3414244111020E+02
+(PID.TID 0000.0001) %MON ke_vol                       =   5.0990436378173E+19
+(PID.TID 0000.0001) %MON vort_r_min                   =  -1.7801102571071E-04
+(PID.TID 0000.0001) %MON vort_r_max                   =   2.2226430235840E-04
+(PID.TID 0000.0001) %MON vort_a_mean                  =   8.0894720734909E-20
+(PID.TID 0000.0001) %MON vort_a_sd                    =   8.8597557169865E-05
+(PID.TID 0000.0001) %MON vort_p_mean                  =   8.3346026462347E-20
+(PID.TID 0000.0001) %MON vort_p_sd                    =   8.8668788789448E-05
+(PID.TID 0000.0001) %MON surfExpan_theta_mean         =  -3.3123514357496E-03
 (PID.TID 0000.0001) %MON surfExpan_salt_mean          =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON surfExpan_Heat_mean          =  -5.5801143498925E-01
-(PID.TID 0000.0001) %MON En_Budget_T2PE_mean          =   2.8767640274055E-01
+(PID.TID 0000.0001) %MON surfExpan_Heat_mean          =  -5.4986182468901E-01
+(PID.TID 0000.0001) %MON En_Budget_T2PE_mean          =   2.8721343663572E-01
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // End MONITOR dynamic field statistics
 (PID.TID 0000.0001) // =======================================================
- cg2d: Sum(rhs),rhsMax =   7.91624188423157E-09  1.55532776651648E+04
-(PID.TID 0000.0001)      cg2d_init_res =   2.36887322032630E+03
+ cg2d: Sum(rhs),rhsMax =   2.79396772384644E-09  1.55534536877922E+04
+(PID.TID 0000.0001)      cg2d_init_res =   2.36873378985929E+03
 (PID.TID 0000.0001)      cg2d_iters(min,last) =      -1      16
-(PID.TID 0000.0001)      cg2d_last_res =   5.10745505809370E-11
+(PID.TID 0000.0001)      cg2d_last_res =   5.10708429568849E-11
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // Begin MONITOR dynamic field statistics
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) %MON time_tsnumber                =                276492
 (PID.TID 0000.0001) %MON time_secondsf                =   1.2442140000000E+08
-(PID.TID 0000.0001) %MON dynstat_eta_max              =   2.4347364592132E+03
-(PID.TID 0000.0001) %MON dynstat_eta_min              =  -3.3671274463275E+03
-(PID.TID 0000.0001) %MON dynstat_eta_mean             =  -1.7993648714737E-13
-(PID.TID 0000.0001) %MON dynstat_eta_sd               =   7.8409146966764E+02
-(PID.TID 0000.0001) %MON dynstat_eta_del2             =   2.0922453337972E+00
-(PID.TID 0000.0001) %MON dynstat_uvel_max             =   6.7010339296033E+01
-(PID.TID 0000.0001) %MON dynstat_uvel_min             =  -6.7028847753031E+01
-(PID.TID 0000.0001) %MON dynstat_uvel_mean            =   2.0431330749985E+00
-(PID.TID 0000.0001) %MON dynstat_uvel_sd              =   1.1146670859388E+01
-(PID.TID 0000.0001) %MON dynstat_uvel_del2            =   1.0703397707333E-02
-(PID.TID 0000.0001) %MON dynstat_vvel_max             =   7.2322077642442E+01
-(PID.TID 0000.0001) %MON dynstat_vvel_min             =  -6.8959544340098E+01
-(PID.TID 0000.0001) %MON dynstat_vvel_mean            =   2.0030272603084E+00
-(PID.TID 0000.0001) %MON dynstat_vvel_sd              =   1.1654927727637E+01
-(PID.TID 0000.0001) %MON dynstat_vvel_del2            =   1.0975968376969E-02
-(PID.TID 0000.0001) %MON dynstat_wvel_max             =   7.7769656416534E-01
-(PID.TID 0000.0001) %MON dynstat_wvel_min             =  -6.8610301254267E-01
-(PID.TID 0000.0001) %MON dynstat_wvel_mean            =  -2.2125818258109E-19
-(PID.TID 0000.0001) %MON dynstat_wvel_sd              =   6.4200410659078E-02
-(PID.TID 0000.0001) %MON dynstat_wvel_del2            =   2.0644784986577E-04
-(PID.TID 0000.0001) %MON dynstat_theta_max            =   5.9706708224532E+02
-(PID.TID 0000.0001) %MON dynstat_theta_min            =   2.6195437917966E+02
-(PID.TID 0000.0001) %MON dynstat_theta_mean           =   3.2766095680173E+02
-(PID.TID 0000.0001) %MON dynstat_theta_sd             =   6.3757360661540E+01
-(PID.TID 0000.0001) %MON dynstat_theta_del2           =   5.1792755474959E-03
+(PID.TID 0000.0001) %MON dynstat_eta_max              =   2.4347064887616E+03
+(PID.TID 0000.0001) %MON dynstat_eta_min              =  -3.3671715411655E+03
+(PID.TID 0000.0001) %MON dynstat_eta_mean             =  -1.6708388092256E-13
+(PID.TID 0000.0001) %MON dynstat_eta_sd               =   7.8409634629898E+02
+(PID.TID 0000.0001) %MON dynstat_eta_del2             =   2.0922523571987E+00
+(PID.TID 0000.0001) %MON dynstat_uvel_max             =   6.7010427522000E+01
+(PID.TID 0000.0001) %MON dynstat_uvel_min             =  -6.7028290761674E+01
+(PID.TID 0000.0001) %MON dynstat_uvel_mean            =   2.0431197326639E+00
+(PID.TID 0000.0001) %MON dynstat_uvel_sd              =   1.1146641564300E+01
+(PID.TID 0000.0001) %MON dynstat_uvel_del2            =   1.0703398991568E-02
+(PID.TID 0000.0001) %MON dynstat_vvel_max             =   7.2321904303866E+01
+(PID.TID 0000.0001) %MON dynstat_vvel_min             =  -6.8958961668992E+01
+(PID.TID 0000.0001) %MON dynstat_vvel_mean            =   2.0030143604884E+00
+(PID.TID 0000.0001) %MON dynstat_vvel_sd              =   1.1654907844468E+01
+(PID.TID 0000.0001) %MON dynstat_vvel_del2            =   1.0975975316128E-02
+(PID.TID 0000.0001) %MON dynstat_wvel_max             =   7.7771746384500E-01
+(PID.TID 0000.0001) %MON dynstat_wvel_min             =  -6.8614307396695E-01
+(PID.TID 0000.0001) %MON dynstat_wvel_mean            =   1.2149085661725E-17
+(PID.TID 0000.0001) %MON dynstat_wvel_sd              =   6.4200674928435E-02
+(PID.TID 0000.0001) %MON dynstat_wvel_del2            =   2.0645362337395E-04
+(PID.TID 0000.0001) %MON dynstat_theta_max            =   5.9706705851357E+02
+(PID.TID 0000.0001) %MON dynstat_theta_min            =   2.6195434910092E+02
+(PID.TID 0000.0001) %MON dynstat_theta_mean           =   3.2765769370408E+02
+(PID.TID 0000.0001) %MON dynstat_theta_sd             =   6.3758137470384E+01
+(PID.TID 0000.0001) %MON dynstat_theta_del2           =   5.1792744438069E-03
 (PID.TID 0000.0001) %MON dynstat_salt_max             =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON dynstat_salt_min             =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON dynstat_salt_mean            =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON dynstat_salt_sd              =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON dynstat_salt_del2            =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON advcfl_uvel_max              =   2.7071348462937E-01
-(PID.TID 0000.0001) %MON advcfl_vvel_max              =   2.2552495824548E-01
-(PID.TID 0000.0001) %MON advcfl_wvel_max              =   6.9992690774880E-02
-(PID.TID 0000.0001) %MON advcfl_W_hf_max              =   6.9400376746852E-02
-(PID.TID 0000.0001) %MON am_eta_mean                  =  -2.9492288246617E+09
-(PID.TID 0000.0001) %MON am_uZo_mean                  =   2.8061767577495E+11
-(PID.TID 0000.0001) %MON am_tot_mean                  =   2.7766844695028E+11
-(PID.TID 0000.0001) %MON pe_b_mean                    =   2.6030678247780E+00
-(PID.TID 0000.0001) %MON ke_max                       =   3.2295690470928E+03
-(PID.TID 0000.0001) %MON ke_mean                      =   1.3410075649475E+02
+(PID.TID 0000.0001) %MON trAdv_CFL_u_max              =   2.9475376330975E-01
+(PID.TID 0000.0001) %MON trAdv_CFL_v_max              =   3.1065555813598E-01
+(PID.TID 0000.0001) %MON trAdv_CFL_w_max              =   6.9402220459778E-02
+(PID.TID 0000.0001) %MON advcfl_uvel_max              =   2.7071123507450E-01
+(PID.TID 0000.0001) %MON advcfl_vvel_max              =   2.2552687975330E-01
+(PID.TID 0000.0001) %MON advcfl_wvel_max              =   6.9994571746050E-02
+(PID.TID 0000.0001) %MON advcfl_W_hf_max              =   6.9402220459778E-02
+(PID.TID 0000.0001) %MON am_eta_mean                  =  -2.9471602321226E+09
+(PID.TID 0000.0001) %MON am_uZo_mean                  =   2.8061560656051E+11
+(PID.TID 0000.0001) %MON am_tot_mean                  =   2.7766844632839E+11
+(PID.TID 0000.0001) %MON pe_b_mean                    =   2.6031002042697E+00
+(PID.TID 0000.0001) %MON ke_max                       =   3.2295141567133E+03
+(PID.TID 0000.0001) %MON ke_mean                      =   1.3410014515303E+02
 (PID.TID 0000.0001) %MON ke_vol                       =   5.0990436378172E+19
-(PID.TID 0000.0001) %MON vort_r_min                   =  -1.7787612073335E-04
-(PID.TID 0000.0001) %MON vort_r_max                   =   2.2298157381346E-04
-(PID.TID 0000.0001) %MON vort_a_mean                  =   3.4318972432992E-20
-(PID.TID 0000.0001) %MON vort_a_sd                    =   8.8595094377880E-05
-(PID.TID 0000.0001) %MON vort_p_mean                  =   3.6770305807884E-20
-(PID.TID 0000.0001) %MON vort_p_sd                    =   8.8666131140393E-05
-(PID.TID 0000.0001) %MON surfExpan_theta_mean         =  -3.8618115435832E-03
+(PID.TID 0000.0001) %MON vort_r_min                   =  -1.7787620496020E-04
+(PID.TID 0000.0001) %MON vort_r_max                   =   2.2298175536379E-04
+(PID.TID 0000.0001) %MON vort_a_mean                  =  -5.6381168997058E-20
+(PID.TID 0000.0001) %MON vort_a_sd                    =   8.8595083147284E-05
+(PID.TID 0000.0001) %MON vort_p_mean                  =  -5.3929781854990E-20
+(PID.TID 0000.0001) %MON vort_p_sd                    =   8.8666129768718E-05
+(PID.TID 0000.0001) %MON surfExpan_theta_mean         =  -3.7709897132536E-03
 (PID.TID 0000.0001) %MON surfExpan_salt_mean          =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON surfExpan_Heat_mean          =  -5.7834001886262E-01
-(PID.TID 0000.0001) %MON En_Budget_T2PE_mean          =   2.5958101035491E-01
+(PID.TID 0000.0001) %MON surfExpan_Heat_mean          =  -5.6866353067110E-01
+(PID.TID 0000.0001) %MON En_Budget_T2PE_mean          =   2.5902662858126E-01
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // End MONITOR dynamic field statistics
 (PID.TID 0000.0001) // =======================================================
- cg2d: Sum(rhs),rhsMax =   5.82076609134674E-09  1.56198395067995E+04
-(PID.TID 0000.0001)      cg2d_init_res =   2.36278233297671E+03
+ cg2d: Sum(rhs),rhsMax =   6.05359673500061E-09  1.56200672764254E+04
+(PID.TID 0000.0001)      cg2d_init_res =   2.36263117479675E+03
 (PID.TID 0000.0001)      cg2d_iters(min,last) =      -1      16
-(PID.TID 0000.0001)      cg2d_last_res =   5.04144330127309E-11
+(PID.TID 0000.0001)      cg2d_last_res =   5.04117578895699E-11
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // Begin MONITOR dynamic field statistics
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) %MON time_tsnumber                =                276493
 (PID.TID 0000.0001) %MON time_secondsf                =   1.2442185000000E+08
-(PID.TID 0000.0001) %MON dynstat_eta_max              =   2.4288136566504E+03
-(PID.TID 0000.0001) %MON dynstat_eta_min              =  -3.3762240459266E+03
-(PID.TID 0000.0001) %MON dynstat_eta_mean             =  -1.6065757781016E-13
-(PID.TID 0000.0001) %MON dynstat_eta_sd               =   7.8209288355533E+02
-(PID.TID 0000.0001) %MON dynstat_eta_del2             =   2.1005691000004E+00
-(PID.TID 0000.0001) %MON dynstat_uvel_max             =   6.7000533679034E+01
-(PID.TID 0000.0001) %MON dynstat_uvel_min             =  -6.7054096696111E+01
-(PID.TID 0000.0001) %MON dynstat_uvel_mean            =   2.0426639150111E+00
-(PID.TID 0000.0001) %MON dynstat_uvel_sd              =   1.1144651942566E+01
-(PID.TID 0000.0001) %MON dynstat_uvel_del2            =   1.0701415770597E-02
-(PID.TID 0000.0001) %MON dynstat_vvel_max             =   7.2336133150140E+01
-(PID.TID 0000.0001) %MON dynstat_vvel_min             =  -6.9009192482653E+01
-(PID.TID 0000.0001) %MON dynstat_vvel_mean            =   2.0021898353554E+00
-(PID.TID 0000.0001) %MON dynstat_vvel_sd              =   1.1653120331470E+01
-(PID.TID 0000.0001) %MON dynstat_vvel_del2            =   1.0971910533966E-02
-(PID.TID 0000.0001) %MON dynstat_wvel_max             =   7.7456469602031E-01
-(PID.TID 0000.0001) %MON dynstat_wvel_min             =  -6.8649973039464E-01
-(PID.TID 0000.0001) %MON dynstat_wvel_mean            =  -9.2325005277019E-18
-(PID.TID 0000.0001) %MON dynstat_wvel_sd              =   6.4295592322200E-02
-(PID.TID 0000.0001) %MON dynstat_wvel_del2            =   2.0661643924239E-04
-(PID.TID 0000.0001) %MON dynstat_theta_max            =   5.9715847890502E+02
-(PID.TID 0000.0001) %MON dynstat_theta_min            =   2.6196689950070E+02
-(PID.TID 0000.0001) %MON dynstat_theta_mean           =   3.2766097722421E+02
-(PID.TID 0000.0001) %MON dynstat_theta_sd             =   6.3757354692375E+01
-(PID.TID 0000.0001) %MON dynstat_theta_del2           =   5.1791682135954E-03
+(PID.TID 0000.0001) %MON dynstat_eta_max              =   2.4287755801409E+03
+(PID.TID 0000.0001) %MON dynstat_eta_min              =  -3.3762801113417E+03
+(PID.TID 0000.0001) %MON dynstat_eta_mean             =  -2.5705212449625E-13
+(PID.TID 0000.0001) %MON dynstat_eta_sd               =   7.8209885773573E+02
+(PID.TID 0000.0001) %MON dynstat_eta_del2             =   2.1005775582423E+00
+(PID.TID 0000.0001) %MON dynstat_uvel_max             =   6.7000623952193E+01
+(PID.TID 0000.0001) %MON dynstat_uvel_min             =  -6.7053452568248E+01
+(PID.TID 0000.0001) %MON dynstat_uvel_mean            =   2.0426468911718E+00
+(PID.TID 0000.0001) %MON dynstat_uvel_sd              =   1.1144615191536E+01
+(PID.TID 0000.0001) %MON dynstat_uvel_del2            =   1.0701417127324E-02
+(PID.TID 0000.0001) %MON dynstat_vvel_max             =   7.2335911565354E+01
+(PID.TID 0000.0001) %MON dynstat_vvel_min             =  -6.9008514149171E+01
+(PID.TID 0000.0001) %MON dynstat_vvel_mean            =   2.0021733408998E+00
+(PID.TID 0000.0001) %MON dynstat_vvel_sd              =   1.1653094305659E+01
+(PID.TID 0000.0001) %MON dynstat_vvel_del2            =   1.0971918447378E-02
+(PID.TID 0000.0001) %MON dynstat_wvel_max             =   7.7459054108818E-01
+(PID.TID 0000.0001) %MON dynstat_wvel_min             =  -6.8654473797155E-01
+(PID.TID 0000.0001) %MON dynstat_wvel_mean            =  -1.1947941859379E-17
+(PID.TID 0000.0001) %MON dynstat_wvel_sd              =   6.4295884840779E-02
+(PID.TID 0000.0001) %MON dynstat_wvel_del2            =   2.0662313974548E-04
+(PID.TID 0000.0001) %MON dynstat_theta_max            =   5.9715838894844E+02
+(PID.TID 0000.0001) %MON dynstat_theta_min            =   2.6196686674633E+02
+(PID.TID 0000.0001) %MON dynstat_theta_mean           =   3.2765744257033E+02
+(PID.TID 0000.0001) %MON dynstat_theta_sd             =   6.3758196175475E+01
+(PID.TID 0000.0001) %MON dynstat_theta_del2           =   5.1791670774060E-03
 (PID.TID 0000.0001) %MON dynstat_salt_max             =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON dynstat_salt_min             =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON dynstat_salt_mean            =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON dynstat_salt_sd              =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON dynstat_salt_del2            =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON advcfl_uvel_max              =   2.7081545907162E-01
-(PID.TID 0000.0001) %MON advcfl_vvel_max              =   2.2539917045146E-01
-(PID.TID 0000.0001) %MON advcfl_wvel_max              =   6.9710822641828E-02
-(PID.TID 0000.0001) %MON advcfl_W_hf_max              =   6.9122747565718E-02
-(PID.TID 0000.0001) %MON am_eta_mean                  =  -2.9492045690923E+09
-(PID.TID 0000.0001) %MON am_uZo_mean                  =   2.8061100255567E+11
-(PID.TID 0000.0001) %MON am_tot_mean                  =   2.7766179798658E+11
-(PID.TID 0000.0001) %MON pe_b_mean                    =   2.5898147157085E+00
-(PID.TID 0000.0001) %MON ke_max                       =   3.2268054006048E+03
-(PID.TID 0000.0001) %MON ke_mean                      =   1.3405456221204E+02
+(PID.TID 0000.0001) %MON trAdv_CFL_u_max              =   2.9499996488215E-01
+(PID.TID 0000.0001) %MON trAdv_CFL_v_max              =   3.1088633199084E-01
+(PID.TID 0000.0001) %MON trAdv_CFL_w_max              =   6.9125027693292E-02
+(PID.TID 0000.0001) %MON advcfl_uvel_max              =   2.7081285759324E-01
+(PID.TID 0000.0001) %MON advcfl_vvel_max              =   2.2540138630626E-01
+(PID.TID 0000.0001) %MON advcfl_wvel_max              =   6.9713148697936E-02
+(PID.TID 0000.0001) %MON advcfl_W_hf_max              =   6.9125027693292E-02
+(PID.TID 0000.0001) %MON am_eta_mean                  =  -2.9465316350990E+09
+(PID.TID 0000.0001) %MON am_uZo_mean                  =   2.8060832888031E+11
+(PID.TID 0000.0001) %MON am_tot_mean                  =   2.7766179724521E+11
+(PID.TID 0000.0001) %MON pe_b_mean                    =   2.5898542815445E+00
+(PID.TID 0000.0001) %MON ke_max                       =   3.2267399696612E+03
+(PID.TID 0000.0001) %MON ke_mean                      =   1.3405378161566E+02
 (PID.TID 0000.0001) %MON ke_vol                       =   5.0990436378172E+19
-(PID.TID 0000.0001) %MON vort_r_min                   =  -1.7771405806522E-04
-(PID.TID 0000.0001) %MON vort_r_max                   =   2.2367293315523E-04
+(PID.TID 0000.0001) %MON vort_r_min                   =  -1.7771417004336E-04
+(PID.TID 0000.0001) %MON vort_r_max                   =   2.2367315423748E-04
 (PID.TID 0000.0001) %MON vort_a_mean                  =  -8.5797431082479E-20
-(PID.TID 0000.0001) %MON vort_a_sd                    =   8.8592604812743E-05
-(PID.TID 0000.0001) %MON vort_p_mean                  =  -8.5797380231083E-20
-(PID.TID 0000.0001) %MON vort_p_sd                    =   8.8663516151447E-05
-(PID.TID 0000.0001) %MON surfExpan_theta_mean         =  -4.1086382428786E-03
+(PID.TID 0000.0001) %MON vort_a_sd                    =   8.8592590505621E-05
+(PID.TID 0000.0001) %MON vort_p_mean                  =  -8.8248733958651E-20
+(PID.TID 0000.0001) %MON vort_p_sd                    =   8.8663514553887E-05
+(PID.TID 0000.0001) %MON surfExpan_theta_mean         =  -4.0024855769383E-03
 (PID.TID 0000.0001) %MON surfExpan_salt_mean          =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON surfExpan_Heat_mean          =  -5.7424081732967E-01
-(PID.TID 0000.0001) %MON En_Budget_T2PE_mean          =   2.4171183486121E-01
+(PID.TID 0000.0001) %MON surfExpan_Heat_mean          =  -5.6293361232753E-01
+(PID.TID 0000.0001) %MON En_Budget_T2PE_mean          =   2.4105861051210E-01
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // End MONITOR dynamic field statistics
 (PID.TID 0000.0001) // =======================================================
@@ -3202,363 +3281,360 @@ listId=   1 ; file name: dynStDiag
  Compute Stats, Diag. #     30  VVEL      vol(   0 ): 5.099E+19  Parms: VVR     MR      
  Compute Stats, Diag. #     31  WVEL      vol(   0 ): 4.972E+19  Parms: WM      LR      
  Compute Stats, Diag. #     26  THETA     vol(   0 ): 5.099E+19  Parms: SMR     MR      
- cg2d: Sum(rhs),rhsMax =   1.74622982740402E-09  1.56858146987304E+04
-(PID.TID 0000.0001)      cg2d_init_res =   2.34738867799929E+03
+ cg2d: Sum(rhs),rhsMax =   7.79982656240463E-09  1.56861011351516E+04
+(PID.TID 0000.0001)      cg2d_init_res =   2.34722573117702E+03
 (PID.TID 0000.0001)      cg2d_iters(min,last) =      -1      16
-(PID.TID 0000.0001)      cg2d_last_res =   4.98457113689144E-11
+(PID.TID 0000.0001)      cg2d_last_res =   4.98419636076138E-11
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // Begin MONITOR dynamic field statistics
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) %MON time_tsnumber                =                276494
 (PID.TID 0000.0001) %MON time_secondsf                =   1.2442230000000E+08
-(PID.TID 0000.0001) %MON dynstat_eta_max              =   2.4241459541414E+03
-(PID.TID 0000.0001) %MON dynstat_eta_min              =  -3.3870439744461E+03
-(PID.TID 0000.0001) %MON dynstat_eta_mean             =  -1.9921539648459E-13
-(PID.TID 0000.0001) %MON dynstat_eta_sd               =   7.8054924548879E+02
-(PID.TID 0000.0001) %MON dynstat_eta_del2             =   2.1059697821481E+00
-(PID.TID 0000.0001) %MON dynstat_uvel_max             =   6.6993613648056E+01
-(PID.TID 0000.0001) %MON dynstat_uvel_min             =  -6.7071133767847E+01
-(PID.TID 0000.0001) %MON dynstat_uvel_mean            =   2.0422011631816E+00
-(PID.TID 0000.0001) %MON dynstat_uvel_sd              =   1.1142455557901E+01
-(PID.TID 0000.0001) %MON dynstat_uvel_del2            =   1.0699537353491E-02
-(PID.TID 0000.0001) %MON dynstat_vvel_max             =   7.2343244474309E+01
-(PID.TID 0000.0001) %MON dynstat_vvel_min             =  -6.9056204176054E+01
-(PID.TID 0000.0001) %MON dynstat_vvel_mean            =   2.0013169435274E+00
-(PID.TID 0000.0001) %MON dynstat_vvel_sd              =   1.1651143096323E+01
-(PID.TID 0000.0001) %MON dynstat_vvel_del2            =   1.0967885675494E-02
-(PID.TID 0000.0001) %MON dynstat_wvel_max             =   7.7138665947711E-01
-(PID.TID 0000.0001) %MON dynstat_wvel_min             =  -6.8667114223275E-01
-(PID.TID 0000.0001) %MON dynstat_wvel_mean            =   3.6407028224707E-18
-(PID.TID 0000.0001) %MON dynstat_wvel_sd              =   6.4405333065242E-02
-(PID.TID 0000.0001) %MON dynstat_wvel_del2            =   2.0675672913409E-04
-(PID.TID 0000.0001) %MON dynstat_theta_max            =   5.9728004764243E+02
-(PID.TID 0000.0001) %MON dynstat_theta_min            =   2.6198008555334E+02
-(PID.TID 0000.0001) %MON dynstat_theta_mean           =   3.2766099605492E+02
-(PID.TID 0000.0001) %MON dynstat_theta_sd             =   6.3757350035903E+01
-(PID.TID 0000.0001) %MON dynstat_theta_del2           =   5.1787599011212E-03
+(PID.TID 0000.0001) %MON dynstat_eta_max              =   2.4240984694064E+03
+(PID.TID 0000.0001) %MON dynstat_eta_min              =  -3.3871134169733E+03
+(PID.TID 0000.0001) %MON dynstat_eta_mean             =  -9.6394546686094E-14
+(PID.TID 0000.0001) %MON dynstat_eta_sd               =   7.8055641932677E+02
+(PID.TID 0000.0001) %MON dynstat_eta_del2             =   2.1059796445131E+00
+(PID.TID 0000.0001) %MON dynstat_uvel_max             =   6.6993702774843E+01
+(PID.TID 0000.0001) %MON dynstat_uvel_min             =  -6.7070397888947E+01
+(PID.TID 0000.0001) %MON dynstat_uvel_mean            =   2.0421798806036E+00
+(PID.TID 0000.0001) %MON dynstat_uvel_sd              =   1.1142410266939E+01
+(PID.TID 0000.0001) %MON dynstat_uvel_del2            =   1.0699538771406E-02
+(PID.TID 0000.0001) %MON dynstat_vvel_max             =   7.2342967221159E+01
+(PID.TID 0000.0001) %MON dynstat_vvel_min             =  -6.9055424227067E+01
+(PID.TID 0000.0001) %MON dynstat_vvel_mean            =   2.0012962812367E+00
+(PID.TID 0000.0001) %MON dynstat_vvel_sd              =   1.1651109852496E+01
+(PID.TID 0000.0001) %MON dynstat_vvel_del2            =   1.0967894562598E-02
+(PID.TID 0000.0001) %MON dynstat_wvel_max             =   7.7141802245690E-01
+(PID.TID 0000.0001) %MON dynstat_wvel_min             =  -6.8672131345020E-01
+(PID.TID 0000.0001) %MON dynstat_wvel_mean            =  -4.1033335678675E-18
+(PID.TID 0000.0001) %MON dynstat_wvel_sd              =   6.4405654188446E-02
+(PID.TID 0000.0001) %MON dynstat_wvel_del2            =   2.0676441695517E-04
+(PID.TID 0000.0001) %MON dynstat_theta_max            =   5.9727994013463E+02
+(PID.TID 0000.0001) %MON dynstat_theta_min            =   2.6198005008522E+02
+(PID.TID 0000.0001) %MON dynstat_theta_mean           =   3.2765718990351E+02
+(PID.TID 0000.0001) %MON dynstat_theta_sd             =   6.3758256181800E+01
+(PID.TID 0000.0001) %MON dynstat_theta_del2           =   5.1787587223272E-03
 (PID.TID 0000.0001) %MON dynstat_salt_max             =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON dynstat_salt_min             =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON dynstat_salt_mean            =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON dynstat_salt_sd              =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON dynstat_salt_del2            =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON advcfl_uvel_max              =   2.7088426772957E-01
-(PID.TID 0000.0001) %MON advcfl_vvel_max              =   2.2528477328755E-01
-(PID.TID 0000.0001) %MON advcfl_wvel_max              =   6.9424799352940E-02
-(PID.TID 0000.0001) %MON advcfl_W_hf_max              =   6.8840508728815E-02
-(PID.TID 0000.0001) %MON am_eta_mean                  =  -2.9492167194426E+09
-(PID.TID 0000.0001) %MON am_uZo_mean                  =   2.8060433995829E+11
-(PID.TID 0000.0001) %MON am_tot_mean                  =   2.7765512323885E+11
-(PID.TID 0000.0001) %MON pe_b_mean                    =   2.5796016286352E+00
-(PID.TID 0000.0001) %MON ke_max                       =   3.2238205140387E+03
-(PID.TID 0000.0001) %MON ke_mean                      =   1.3400436291874E+02
+(PID.TID 0000.0001) %MON trAdv_CFL_u_max              =   2.9523237737790E-01
+(PID.TID 0000.0001) %MON trAdv_CFL_v_max              =   3.1110587534662E-01
+(PID.TID 0000.0001) %MON trAdv_CFL_w_max              =   6.8843276170440E-02
+(PID.TID 0000.0001) %MON advcfl_uvel_max              =   2.7088129569070E-01
+(PID.TID 0000.0001) %MON advcfl_vvel_max              =   2.2528729929146E-01
+(PID.TID 0000.0001) %MON advcfl_wvel_max              =   6.9427622021121E-02
+(PID.TID 0000.0001) %MON advcfl_W_hf_max              =   6.8843276170440E-02
+(PID.TID 0000.0001) %MON am_eta_mean                  =  -2.9458368974800E+09
+(PID.TID 0000.0001) %MON am_uZo_mean                  =   2.8060095926802E+11
+(PID.TID 0000.0001) %MON am_tot_mean                  =   2.7765512237054E+11
+(PID.TID 0000.0001) %MON pe_b_mean                    =   2.5796490458335E+00
+(PID.TID 0000.0001) %MON ke_max                       =   3.2237436771762E+03
+(PID.TID 0000.0001) %MON ke_mean                      =   1.3400338621627E+02
 (PID.TID 0000.0001) %MON ke_vol                       =   5.0990436378172E+19
-(PID.TID 0000.0001) %MON vort_r_min                   =  -1.7748737541224E-04
-(PID.TID 0000.0001) %MON vort_r_max                   =   2.2433835609521E-04
-(PID.TID 0000.0001) %MON vort_a_mean                  =   9.8054206951405E-20
-(PID.TID 0000.0001) %MON vort_a_sd                    =   8.8590108980550E-05
-(PID.TID 0000.0001) %MON vort_p_mean                  =   1.0050550254344E-19
-(PID.TID 0000.0001) %MON vort_p_sd                    =   8.8660950970930E-05
-(PID.TID 0000.0001) %MON surfExpan_theta_mean         =  -4.1488779482508E-03
+(PID.TID 0000.0001) %MON vort_r_min                   =  -1.7748752321961E-04
+(PID.TID 0000.0001) %MON vort_r_max                   =   2.2433861923838E-04
+(PID.TID 0000.0001) %MON vort_a_mean                  =  -2.9416262085421E-20
+(PID.TID 0000.0001) %MON vort_a_sd                    =   8.8590091115353E-05
+(PID.TID 0000.0001) %MON vort_p_mean                  =  -3.9221659532648E-20
+(PID.TID 0000.0001) %MON vort_p_sd                    =   8.8660949139570E-05
+(PID.TID 0000.0001) %MON surfExpan_theta_mean         =  -4.0264844711729E-03
 (PID.TID 0000.0001) %MON surfExpan_salt_mean          =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON surfExpan_Heat_mean          =  -5.4854060875391E-01
-(PID.TID 0000.0001) %MON En_Budget_T2PE_mean          =   2.3351603921502E-01
+(PID.TID 0000.0001) %MON surfExpan_Heat_mean          =  -5.3550686944998E-01
+(PID.TID 0000.0001) %MON En_Budget_T2PE_mean          =   2.3275671361503E-01
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // End MONITOR dynamic field statistics
 (PID.TID 0000.0001) // =======================================================
- cg2d: Sum(rhs),rhsMax =   3.49245965480804E-09  1.57489749368835E+04
-(PID.TID 0000.0001)      cg2d_init_res =   2.32453725776117E+03
+ cg2d: Sum(rhs),rhsMax =   4.19095158576965E-09  1.57493270036939E+04
+(PID.TID 0000.0001)      cg2d_init_res =   2.32436193440324E+03
 (PID.TID 0000.0001)      cg2d_iters(min,last) =      -1      16
-(PID.TID 0000.0001)      cg2d_last_res =   4.94468425536083E-11
+(PID.TID 0000.0001)      cg2d_last_res =   4.94428860148717E-11
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // Begin MONITOR dynamic field statistics
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) %MON time_tsnumber                =                276495
 (PID.TID 0000.0001) %MON time_secondsf                =   1.2442275000000E+08
-(PID.TID 0000.0001) %MON dynstat_eta_max              =   2.4207461048893E+03
-(PID.TID 0000.0001) %MON dynstat_eta_min              =  -3.3986503556293E+03
-(PID.TID 0000.0001) %MON dynstat_eta_mean             =  -1.0282084979850E-13
-(PID.TID 0000.0001) %MON dynstat_eta_sd               =   7.7944928172584E+02
-(PID.TID 0000.0001) %MON dynstat_eta_del2             =   2.1086846663994E+00
-(PID.TID 0000.0001) %MON dynstat_uvel_max             =   6.6988912477208E+01
-(PID.TID 0000.0001) %MON dynstat_uvel_min             =  -6.7080069941544E+01
-(PID.TID 0000.0001) %MON dynstat_uvel_mean            =   2.0417415735316E+00
-(PID.TID 0000.0001) %MON dynstat_uvel_sd              =   1.1140096004533E+01
-(PID.TID 0000.0001) %MON dynstat_uvel_del2            =   1.0697767940787E-02
-(PID.TID 0000.0001) %MON dynstat_vvel_max             =   7.2343771025297E+01
-(PID.TID 0000.0001) %MON dynstat_vvel_min             =  -6.9099749365629E+01
-(PID.TID 0000.0001) %MON dynstat_vvel_mean            =   2.0004073793126E+00
-(PID.TID 0000.0001) %MON dynstat_vvel_sd              =   1.1648994425718E+01
-(PID.TID 0000.0001) %MON dynstat_vvel_del2            =   1.0963875775350E-02
-(PID.TID 0000.0001) %MON dynstat_wvel_max             =   7.7062520087525E-01
-(PID.TID 0000.0001) %MON dynstat_wvel_min             =  -6.8663470272855E-01
-(PID.TID 0000.0001) %MON dynstat_wvel_mean            =  -1.0318677060373E-17
-(PID.TID 0000.0001) %MON dynstat_wvel_sd              =   6.4525307183380E-02
-(PID.TID 0000.0001) %MON dynstat_wvel_del2            =   2.0686689331037E-04
-(PID.TID 0000.0001) %MON dynstat_theta_max            =   5.9739419971407E+02
-(PID.TID 0000.0001) %MON dynstat_theta_min            =   2.6199392739613E+02
-(PID.TID 0000.0001) %MON dynstat_theta_mean           =   3.2766101354029E+02
-(PID.TID 0000.0001) %MON dynstat_theta_sd             =   6.3757346292744E+01
-(PID.TID 0000.0001) %MON dynstat_theta_del2           =   5.1781007329933E-03
+(PID.TID 0000.0001) %MON dynstat_eta_max              =   2.4206877922998E+03
+(PID.TID 0000.0001) %MON dynstat_eta_min              =  -3.3987346292877E+03
+(PID.TID 0000.0001) %MON dynstat_eta_mean             =  -2.3134691204662E-13
+(PID.TID 0000.0001) %MON dynstat_eta_sd               =   7.7945774798844E+02
+(PID.TID 0000.0001) %MON dynstat_eta_del2             =   2.1086958821991E+00
+(PID.TID 0000.0001) %MON dynstat_uvel_max             =   6.6988996970015E+01
+(PID.TID 0000.0001) %MON dynstat_uvel_min             =  -6.7079238345051E+01
+(PID.TID 0000.0001) %MON dynstat_uvel_mean            =   2.0417154267468E+00
+(PID.TID 0000.0001) %MON dynstat_uvel_sd              =   1.1140041039836E+01
+(PID.TID 0000.0001) %MON dynstat_uvel_del2            =   1.0697769410110E-02
+(PID.TID 0000.0001) %MON dynstat_vvel_max             =   7.2343430350840E+01
+(PID.TID 0000.0001) %MON dynstat_vvel_min             =  -6.9098862137638E+01
+(PID.TID 0000.0001) %MON dynstat_vvel_mean            =   2.0003819467892E+00
+(PID.TID 0000.0001) %MON dynstat_vvel_sd              =   1.1648952822090E+01
+(PID.TID 0000.0001) %MON dynstat_vvel_del2            =   1.0963885629509E-02
+(PID.TID 0000.0001) %MON dynstat_wvel_max             =   7.7068112553044E-01
+(PID.TID 0000.0001) %MON dynstat_wvel_min             =  -6.8669033818349E-01
+(PID.TID 0000.0001) %MON dynstat_wvel_mean            =  -1.4884641373637E-18
+(PID.TID 0000.0001) %MON dynstat_wvel_sd              =   6.4525658047886E-02
+(PID.TID 0000.0001) %MON dynstat_wvel_del2            =   2.0687563430040E-04
+(PID.TID 0000.0001) %MON dynstat_theta_max            =   5.9739407400900E+02
+(PID.TID 0000.0001) %MON dynstat_theta_min            =   2.6199388917577E+02
+(PID.TID 0000.0001) %MON dynstat_theta_mean           =   3.2765693595059E+02
+(PID.TID 0000.0001) %MON dynstat_theta_sd             =   6.3758317089385E+01
+(PID.TID 0000.0001) %MON dynstat_theta_del2           =   5.1780995022539E-03
 (PID.TID 0000.0001) %MON dynstat_salt_max             =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON dynstat_salt_min             =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON dynstat_salt_mean            =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON dynstat_salt_sd              =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON dynstat_salt_del2            =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON advcfl_uvel_max              =   2.7092035879785E-01
-(PID.TID 0000.0001) %MON advcfl_vvel_max              =   2.2518615367877E-01
-(PID.TID 0000.0001) %MON advcfl_wvel_max              =   6.9356268078773E-02
-(PID.TID 0000.0001) %MON advcfl_W_hf_max              =   6.8559170237938E-02
-(PID.TID 0000.0001) %MON am_eta_mean                  =  -2.9493209755179E+09
-(PID.TID 0000.0001) %MON am_uZo_mean                  =   2.8059774352368E+11
-(PID.TID 0000.0001) %MON am_tot_mean                  =   2.7764842254816E+11
-(PID.TID 0000.0001) %MON pe_b_mean                    =   2.5723363112307E+00
-(PID.TID 0000.0001) %MON ke_max                       =   3.2205808640203E+03
-(PID.TID 0000.0001) %MON ke_mean                      =   1.3395029214615E+02
+(PID.TID 0000.0001) %MON trAdv_CFL_u_max              =   2.9544379799418E-01
+(PID.TID 0000.0001) %MON trAdv_CFL_v_max              =   3.1131010270834E-01
+(PID.TID 0000.0001) %MON trAdv_CFL_w_max              =   6.8564128627313E-02
+(PID.TID 0000.0001) %MON advcfl_uvel_max              =   2.7091700017851E-01
+(PID.TID 0000.0001) %MON advcfl_vvel_max              =   2.2518900528618E-01
+(PID.TID 0000.0001) %MON advcfl_wvel_max              =   6.9361301297740E-02
+(PID.TID 0000.0001) %MON advcfl_W_hf_max              =   6.8564128627313E-02
+(PID.TID 0000.0001) %MON am_eta_mean                  =  -2.9451255648436E+09
+(PID.TID 0000.0001) %MON am_uZo_mean                  =   2.8059354711039E+11
+(PID.TID 0000.0001) %MON am_tot_mean                  =   2.7764842154555E+11
+(PID.TID 0000.0001) %MON pe_b_mean                    =   2.5723921922059E+00
+(PID.TID 0000.0001) %MON ke_max                       =   3.2204917853430E+03
+(PID.TID 0000.0001) %MON ke_mean                      =   1.3394909106596E+02
 (PID.TID 0000.0001) %MON ke_vol                       =   5.0990436378172E+19
-(PID.TID 0000.0001) %MON vort_r_min                   =  -1.7719416772948E-04
-(PID.TID 0000.0001) %MON vort_r_max                   =   2.2497808663607E-04
-(PID.TID 0000.0001) %MON vort_a_mean                  =   1.0540827247276E-19
-(PID.TID 0000.0001) %MON vort_a_sd                    =   8.8587616294455E-05
-(PID.TID 0000.0001) %MON vort_p_mean                  =   1.0540820994326E-19
-(PID.TID 0000.0001) %MON vort_p_sd                    =   8.8658439051427E-05
-(PID.TID 0000.0001) %MON surfExpan_theta_mean         =  -4.0167730555374E-03
+(PID.TID 0000.0001) %MON vort_r_min                   =  -1.7719436122126E-04
+(PID.TID 0000.0001) %MON vort_r_max                   =   2.2497839427394E-04
+(PID.TID 0000.0001) %MON vort_a_mean                  =  -1.8140028286010E-19
+(PID.TID 0000.0001) %MON vort_a_sd                    =   8.8587594365176E-05
+(PID.TID 0000.0001) %MON vort_p_mean                  =  -1.7894882155029E-19
+(PID.TID 0000.0001) %MON vort_p_sd                    =   8.8658436980365E-05
+(PID.TID 0000.0001) %MON surfExpan_theta_mean         =  -3.8773064707866E-03
 (PID.TID 0000.0001) %MON surfExpan_salt_mean          =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON surfExpan_Heat_mean          =  -5.0532150454852E-01
-(PID.TID 0000.0001) %MON En_Budget_T2PE_mean          =   2.3433280031345E-01
+(PID.TID 0000.0001) %MON surfExpan_Heat_mean          =  -4.9047383809284E-01
+(PID.TID 0000.0001) %MON En_Budget_T2PE_mean          =   2.3346027456821E-01
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // End MONITOR dynamic field statistics
 (PID.TID 0000.0001) // =======================================================
- cg2d: Sum(rhs),rhsMax =   5.23868948221207E-09  1.58078604513157E+04
-(PID.TID 0000.0001)      cg2d_init_res =   2.29708710655123E+03
+ cg2d: Sum(rhs),rhsMax =   4.30736690759659E-09  1.58082852392885E+04
+(PID.TID 0000.0001)      cg2d_init_res =   2.29689832987077E+03
 (PID.TID 0000.0001)      cg2d_iters(min,last) =      -1      16
-(PID.TID 0000.0001)      cg2d_last_res =   4.93739854399662E-11
+(PID.TID 0000.0001)      cg2d_last_res =   4.93697066946099E-11
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // Begin MONITOR dynamic field statistics
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) %MON time_tsnumber                =                276496
 (PID.TID 0000.0001) %MON time_secondsf                =   1.2442320000000E+08
-(PID.TID 0000.0001) %MON dynstat_eta_max              =   2.4185412426419E+03
-(PID.TID 0000.0001) %MON dynstat_eta_min              =  -3.4102146830230E+03
-(PID.TID 0000.0001) %MON dynstat_eta_mean             =  -1.0282084979850E-13
-(PID.TID 0000.0001) %MON dynstat_eta_sd               =   7.7877574859093E+02
-(PID.TID 0000.0001) %MON dynstat_eta_del2             =   2.1091084566734E+00
-(PID.TID 0000.0001) %MON dynstat_uvel_max             =   6.6985690616549E+01
-(PID.TID 0000.0001) %MON dynstat_uvel_min             =  -6.7081297695395E+01
-(PID.TID 0000.0001) %MON dynstat_uvel_mean            =   2.0412805119019E+00
-(PID.TID 0000.0001) %MON dynstat_uvel_sd              =   1.1137590197564E+01
-(PID.TID 0000.0001) %MON dynstat_uvel_del2            =   1.0696101985718E-02
-(PID.TID 0000.0001) %MON dynstat_vvel_max             =   7.2338160200940E+01
-(PID.TID 0000.0001) %MON dynstat_vvel_min             =  -6.9139295965464E+01
-(PID.TID 0000.0001) %MON dynstat_vvel_mean            =   1.9994620302297E+00
-(PID.TID 0000.0001) %MON dynstat_vvel_sd              =   1.1646677244780E+01
-(PID.TID 0000.0001) %MON dynstat_vvel_del2            =   1.0959863575417E-02
-(PID.TID 0000.0001) %MON dynstat_wvel_max             =   7.7623796401281E-01
-(PID.TID 0000.0001) %MON dynstat_wvel_min             =  -6.8638934016306E-01
-(PID.TID 0000.0001) %MON dynstat_wvel_mean            =  -2.1321243048723E-18
-(PID.TID 0000.0001) %MON dynstat_wvel_sd              =   6.4651471987945E-02
-(PID.TID 0000.0001) %MON dynstat_wvel_del2            =   2.0694695990329E-04
-(PID.TID 0000.0001) %MON dynstat_theta_max            =   5.9750297901353E+02
-(PID.TID 0000.0001) %MON dynstat_theta_min            =   2.6200841390611E+02
-(PID.TID 0000.0001) %MON dynstat_theta_mean           =   3.2766102998757E+02
-(PID.TID 0000.0001) %MON dynstat_theta_sd             =   6.3757343070653E+01
-(PID.TID 0000.0001) %MON dynstat_theta_del2           =   5.1772430679403E-03
+(PID.TID 0000.0001) %MON dynstat_eta_max              =   2.4184705651201E+03
+(PID.TID 0000.0001) %MON dynstat_eta_min              =  -3.4103153301293E+03
+(PID.TID 0000.0001) %MON dynstat_eta_mean             =  -1.6708388092256E-13
+(PID.TID 0000.0001) %MON dynstat_eta_sd               =   7.7878558949305E+02
+(PID.TID 0000.0001) %MON dynstat_eta_del2             =   2.1091209713910E+00
+(PID.TID 0000.0001) %MON dynstat_uvel_max             =   6.6985766743360E+01
+(PID.TID 0000.0001) %MON dynstat_uvel_min             =  -6.7080367082126E+01
+(PID.TID 0000.0001) %MON dynstat_uvel_mean            =   2.0412488701730E+00
+(PID.TID 0000.0001) %MON dynstat_uvel_sd              =   1.1137524381062E+01
+(PID.TID 0000.0001) %MON dynstat_uvel_del2            =   1.0696103497645E-02
+(PID.TID 0000.0001) %MON dynstat_vvel_max             =   7.2337748048309E+01
+(PID.TID 0000.0001) %MON dynstat_vvel_min             =  -6.9138296188618E+01
+(PID.TID 0000.0001) %MON dynstat_vvel_mean            =   1.9994311990899E+00
+(PID.TID 0000.0001) %MON dynstat_vvel_sd              =   1.1646626077216E+01
+(PID.TID 0000.0001) %MON dynstat_vvel_del2            =   1.0959874386662E-02
+(PID.TID 0000.0001) %MON dynstat_wvel_max             =   7.7630124502649E-01
+(PID.TID 0000.0001) %MON dynstat_wvel_min             =  -6.8645081920789E-01
+(PID.TID 0000.0001) %MON dynstat_wvel_mean            =  -4.6263074539683E-19
+(PID.TID 0000.0001) %MON dynstat_wvel_sd              =   6.4651854531250E-02
+(PID.TID 0000.0001) %MON dynstat_wvel_del2            =   2.0695682400880E-04
+(PID.TID 0000.0001) %MON dynstat_theta_max            =   5.9750283462421E+02
+(PID.TID 0000.0001) %MON dynstat_theta_min            =   2.6200837289517E+02
+(PID.TID 0000.0001) %MON dynstat_theta_mean           =   3.2765668101939E+02
+(PID.TID 0000.0001) %MON dynstat_theta_sd             =   6.3758378505372E+01
+(PID.TID 0000.0001) %MON dynstat_theta_del2           =   5.1772417778822E-03
 (PID.TID 0000.0001) %MON dynstat_salt_max             =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON dynstat_salt_min             =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON dynstat_salt_mean            =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON dynstat_salt_sd              =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON dynstat_salt_del2            =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON advcfl_uvel_max              =   2.7092531740201E-01
-(PID.TID 0000.0001) %MON advcfl_vvel_max              =   2.2510671989510E-01
-(PID.TID 0000.0001) %MON advcfl_wvel_max              =   6.9861416761153E-02
-(PID.TID 0000.0001) %MON advcfl_W_hf_max              =   6.9056597954559E-02
-(PID.TID 0000.0001) %MON am_eta_mean                  =  -2.9495730405756E+09
-(PID.TID 0000.0001) %MON am_uZo_mean                  =   2.8059126946055E+11
-(PID.TID 0000.0001) %MON am_tot_mean                  =   2.7764169641997E+11
-(PID.TID 0000.0001) %MON pe_b_mean                    =   2.5678926476896E+00
-(PID.TID 0000.0001) %MON ke_max                       =   3.2170498723138E+03
-(PID.TID 0000.0001) %MON ke_mean                      =   1.3389256668173E+02
+(PID.TID 0000.0001) %MON trAdv_CFL_u_max              =   2.9562878578288E-01
+(PID.TID 0000.0001) %MON trAdv_CFL_v_max              =   3.1149635218365E-01
+(PID.TID 0000.0001) %MON trAdv_CFL_w_max              =   6.9062209155478E-02
+(PID.TID 0000.0001) %MON advcfl_uvel_max              =   2.7092155887759E-01
+(PID.TID 0000.0001) %MON advcfl_vvel_max              =   2.2510991222629E-01
+(PID.TID 0000.0001) %MON advcfl_wvel_max              =   6.9867112052384E-02
+(PID.TID 0000.0001) %MON advcfl_W_hf_max              =   6.9062209155478E-02
+(PID.TID 0000.0001) %MON am_eta_mean                  =  -2.9444477068591E+09
+(PID.TID 0000.0001) %MON am_uZo_mean                  =   2.8058614298194E+11
+(PID.TID 0000.0001) %MON am_tot_mean                  =   2.7764169527508E+11
+(PID.TID 0000.0001) %MON pe_b_mean                    =   2.5679575458067E+00
+(PID.TID 0000.0001) %MON ke_max                       =   3.2169477445343E+03
+(PID.TID 0000.0001) %MON ke_mean                      =   1.3389111165612E+02
 (PID.TID 0000.0001) %MON ke_vol                       =   5.0990436378172E+19
-(PID.TID 0000.0001) %MON vort_r_min                   =  -1.7683274759604E-04
-(PID.TID 0000.0001) %MON vort_r_max                   =   2.2559238171284E-04
-(PID.TID 0000.0001) %MON vort_a_mean                  =   1.7404621733874E-19
-(PID.TID 0000.0001) %MON vort_a_sd                    =   8.8585134097068E-05
-(PID.TID 0000.0001) %MON vort_p_mean                  =   1.7404611397537E-19
-(PID.TID 0000.0001) %MON vort_p_sd                    =   8.8655981878673E-05
-(PID.TID 0000.0001) %MON surfExpan_theta_mean         =  -3.7549883810933E-03
+(PID.TID 0000.0001) %MON vort_r_min                   =  -1.7683299859603E-04
+(PID.TID 0000.0001) %MON vort_r_max                   =   2.2559273635603E-04
+(PID.TID 0000.0001) %MON vort_a_mean                  =   4.4124393128132E-20
+(PID.TID 0000.0001) %MON vort_a_sd                    =   8.8585107575669E-05
+(PID.TID 0000.0001) %MON vort_p_mean                  =   4.6575720646966E-20
+(PID.TID 0000.0001) %MON vort_p_sd                    =   8.8655979564008E-05
+(PID.TID 0000.0001) %MON surfExpan_theta_mean         =  -3.5976974505032E-03
 (PID.TID 0000.0001) %MON surfExpan_salt_mean          =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON surfExpan_Heat_mean          =  -4.4934018990211E-01
-(PID.TID 0000.0001) %MON En_Budget_T2PE_mean          =   2.4344384043441E-01
+(PID.TID 0000.0001) %MON surfExpan_Heat_mean          =  -4.3259998107941E-01
+(PID.TID 0000.0001) %MON En_Budget_T2PE_mean          =   2.4245117139394E-01
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // End MONITOR dynamic field statistics
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) DIAGSTATS_CLOSE_IO: close file: dynStDiag.0000276480.txt , unit=     9
 (PID.TID 0000.0001) %CHECKPOINT    276496 ckptA
 (PID.TID 0000.0001)   Seconds in section "ALL                    [THE_MODEL_MAIN]":
-(PID.TID 0000.0001)           User time:   25.370000000000001
-(PID.TID 0000.0001)         System time:  8.99999999999999967E-002
-(PID.TID 0000.0001)     Wall clock time:   25.663639068603516
+(PID.TID 0000.0001)           User time:   12.8491426771507
+(PID.TID 0000.0001)         System time:  0.000000000000000E+000
+(PID.TID 0000.0001)     Wall clock time:   13.5841898918152
 (PID.TID 0000.0001)          No. starts:           1
 (PID.TID 0000.0001)           No. stops:           1
 (PID.TID 0000.0001)   Seconds in section "INITIALISE_FIXED       [THE_MODEL_MAIN]":
-(PID.TID 0000.0001)           User time:  0.20999999999999999
-(PID.TID 0000.0001)         System time:  1.00000000000000002E-002
-(PID.TID 0000.0001)     Wall clock time:  0.28174996376037598
+(PID.TID 0000.0001)           User time:  0.217233993113041
+(PID.TID 0000.0001)         System time:  0.000000000000000E+000
+(PID.TID 0000.0001)     Wall clock time:  0.391651868820190
 (PID.TID 0000.0001)          No. starts:           1
 (PID.TID 0000.0001)           No. stops:           1
 (PID.TID 0000.0001)   Seconds in section "THE_MAIN_LOOP          [THE_MODEL_MAIN]":
-(PID.TID 0000.0001)           User time:   25.160000000000000
-(PID.TID 0000.0001)         System time:  8.00000000000000017E-002
-(PID.TID 0000.0001)     Wall clock time:   25.381845951080322
+(PID.TID 0000.0001)           User time:   12.6318641901016
+(PID.TID 0000.0001)         System time:  0.000000000000000E+000
+(PID.TID 0000.0001)     Wall clock time:   13.1924889087677
 (PID.TID 0000.0001)          No. starts:           1
 (PID.TID 0000.0001)           No. stops:           1
 (PID.TID 0000.0001)   Seconds in section "INITIALISE_VARIA    [THE_MAIN_LOOP]":
-(PID.TID 0000.0001)           User time:  0.62000000000000011
-(PID.TID 0000.0001)         System time:  4.99999999999999958E-002
-(PID.TID 0000.0001)     Wall clock time:  0.75407600402832031
+(PID.TID 0000.0001)           User time:  0.460703015327454
+(PID.TID 0000.0001)         System time:  0.000000000000000E+000
+(PID.TID 0000.0001)     Wall clock time:  0.650363922119141
 (PID.TID 0000.0001)          No. starts:           1
 (PID.TID 0000.0001)           No. stops:           1
 (PID.TID 0000.0001)   Seconds in section "MAIN LOOP           [THE_MAIN_LOOP]":
-(PID.TID 0000.0001)           User time:   24.539999999999999
-(PID.TID 0000.0001)         System time:  2.99999999999999989E-002
-(PID.TID 0000.0001)     Wall clock time:   24.627732992172241
+(PID.TID 0000.0001)           User time:   12.1711348891258
+(PID.TID 0000.0001)         System time:  0.000000000000000E+000
+(PID.TID 0000.0001)     Wall clock time:   12.5420970916748
 (PID.TID 0000.0001)          No. starts:           1
 (PID.TID 0000.0001)           No. stops:           1
 (PID.TID 0000.0001)   Seconds in section "MAIN_DO_LOOP        [THE_MAIN_LOOP]":
-(PID.TID 0000.0001)           User time:   24.540000000000006
-(PID.TID 0000.0001)         System time:  2.99999999999999989E-002
-(PID.TID 0000.0001)     Wall clock time:   24.627579450607300
+(PID.TID 0000.0001)           User time:   12.1709832549095
+(PID.TID 0000.0001)         System time:  0.000000000000000E+000
+(PID.TID 0000.0001)     Wall clock time:   12.5419363975525
 (PID.TID 0000.0001)          No. starts:          16
 (PID.TID 0000.0001)           No. stops:          16
 (PID.TID 0000.0001)   Seconds in section "FORWARD_STEP        [MAIN_DO_LOOP]":
-(PID.TID 0000.0001)           User time:   24.540000000000006
-(PID.TID 0000.0001)         System time:  2.99999999999999989E-002
-(PID.TID 0000.0001)     Wall clock time:   24.627276897430420
+(PID.TID 0000.0001)           User time:   12.1706945896149
+(PID.TID 0000.0001)         System time:  0.000000000000000E+000
+(PID.TID 0000.0001)     Wall clock time:   12.5416266918182
 (PID.TID 0000.0001)          No. starts:          16
 (PID.TID 0000.0001)           No. stops:          16
 (PID.TID 0000.0001)   Seconds in section "DO_STATEVARS_DIAGS  [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:   1.2600000000000016
-(PID.TID 0000.0001)         System time:   0.0000000000000000
-(PID.TID 0000.0001)     Wall clock time:   1.2790248394012451
+(PID.TID 0000.0001)           User time:   1.01350659132004
+(PID.TID 0000.0001)         System time:  0.000000000000000E+000
+(PID.TID 0000.0001)     Wall clock time:   1.03708434104919
 (PID.TID 0000.0001)          No. starts:          48
 (PID.TID 0000.0001)           No. stops:          48
 (PID.TID 0000.0001)   Seconds in section "LOAD_FIELDS_DRIVER  [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:  9.99999999999801048E-003
-(PID.TID 0000.0001)         System time:   0.0000000000000000
-(PID.TID 0000.0001)     Wall clock time:  4.66346740722656250E-004
-(PID.TID 0000.0001)          No. starts:          16
-(PID.TID 0000.0001)           No. stops:          16
-(PID.TID 0000.0001)   Seconds in section "EXTERNAL_FLDS_LOAD [LOAD_FLDS_DRIVER]":
-(PID.TID 0000.0001)           User time:  9.99999999999801048E-003
-(PID.TID 0000.0001)         System time:   0.0000000000000000
-(PID.TID 0000.0001)     Wall clock time:  1.58309936523437500E-004
+(PID.TID 0000.0001)           User time:  1.372694969177246E-004
+(PID.TID 0000.0001)         System time:  0.000000000000000E+000
+(PID.TID 0000.0001)     Wall clock time:  1.354217529296875E-004
 (PID.TID 0000.0001)          No. starts:          16
 (PID.TID 0000.0001)           No. stops:          16
 (PID.TID 0000.0001)   Seconds in section "DO_ATMOSPHERIC_PHYS [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:   0.0000000000000000
-(PID.TID 0000.0001)         System time:   0.0000000000000000
-(PID.TID 0000.0001)     Wall clock time:  1.50680541992187500E-004
+(PID.TID 0000.0001)           User time:  4.633802175521851E-002
+(PID.TID 0000.0001)         System time:  0.000000000000000E+000
+(PID.TID 0000.0001)     Wall clock time:  4.708909988403320E-002
 (PID.TID 0000.0001)          No. starts:          16
 (PID.TID 0000.0001)           No. stops:          16
 (PID.TID 0000.0001)   Seconds in section "DO_OCEANIC_PHYS     [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:   0.0000000000000000
-(PID.TID 0000.0001)         System time:   0.0000000000000000
-(PID.TID 0000.0001)     Wall clock time:  2.67672538757324219E-003
+(PID.TID 0000.0001)           User time:  2.854466438293457E-004
+(PID.TID 0000.0001)         System time:  0.000000000000000E+000
+(PID.TID 0000.0001)     Wall clock time:  3.056526184082031E-004
 (PID.TID 0000.0001)          No. starts:          16
 (PID.TID 0000.0001)           No. stops:          16
 (PID.TID 0000.0001)   Seconds in section "DYNAMICS            [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:   6.1400000000000041
-(PID.TID 0000.0001)         System time:   0.0000000000000000
-(PID.TID 0000.0001)     Wall clock time:   6.1600482463836670
+(PID.TID 0000.0001)           User time:   2.62896692752838
+(PID.TID 0000.0001)         System time:  0.000000000000000E+000
+(PID.TID 0000.0001)     Wall clock time:   2.65821981430054
 (PID.TID 0000.0001)          No. starts:          16
 (PID.TID 0000.0001)           No. stops:          16
 (PID.TID 0000.0001)   Seconds in section "UPDATE_R_STAR       [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:  0.51999999999999957
-(PID.TID 0000.0001)         System time:   0.0000000000000000
-(PID.TID 0000.0001)     Wall clock time:  0.50531625747680664
+(PID.TID 0000.0001)           User time:  0.249868690967560
+(PID.TID 0000.0001)         System time:  0.000000000000000E+000
+(PID.TID 0000.0001)     Wall clock time:  0.249988079071045
 (PID.TID 0000.0001)          No. starts:          16
 (PID.TID 0000.0001)           No. stops:          16
 (PID.TID 0000.0001)   Seconds in section "UPDATE_CG2D         [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:  0.26000000000000156
-(PID.TID 0000.0001)         System time:   0.0000000000000000
-(PID.TID 0000.0001)     Wall clock time:  0.24038410186767578
+(PID.TID 0000.0001)           User time:  0.103121340274811
+(PID.TID 0000.0001)         System time:  0.000000000000000E+000
+(PID.TID 0000.0001)     Wall clock time:  0.104638576507568
 (PID.TID 0000.0001)          No. starts:          16
 (PID.TID 0000.0001)           No. stops:          16
 (PID.TID 0000.0001)   Seconds in section "SOLVE_FOR_PRESSURE  [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:  0.99000000000000199
-(PID.TID 0000.0001)         System time:   0.0000000000000000
-(PID.TID 0000.0001)     Wall clock time:   1.0284917354583740
+(PID.TID 0000.0001)           User time:  0.426168859004974
+(PID.TID 0000.0001)         System time:  0.000000000000000E+000
+(PID.TID 0000.0001)     Wall clock time:  0.428936004638672
 (PID.TID 0000.0001)          No. starts:          16
 (PID.TID 0000.0001)           No. stops:          16
 (PID.TID 0000.0001)   Seconds in section "MOM_CORRECTION_STEP [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:   6.5400000000000027
-(PID.TID 0000.0001)         System time:   0.0000000000000000
-(PID.TID 0000.0001)     Wall clock time:   6.5352544784545898
+(PID.TID 0000.0001)           User time:   2.98420572280884
+(PID.TID 0000.0001)         System time:  0.000000000000000E+000
+(PID.TID 0000.0001)     Wall clock time:   3.00955295562744
 (PID.TID 0000.0001)          No. starts:          16
 (PID.TID 0000.0001)           No. stops:          16
 (PID.TID 0000.0001)   Seconds in section "SHAP_FILT_UV       [MOM_CORR_STEP]":
-(PID.TID 0000.0001)           User time:   6.3300000000000125
-(PID.TID 0000.0001)         System time:   0.0000000000000000
-(PID.TID 0000.0001)     Wall clock time:   6.3096084594726563
+(PID.TID 0000.0001)           User time:   2.84808290004730
+(PID.TID 0000.0001)         System time:  0.000000000000000E+000
+(PID.TID 0000.0001)     Wall clock time:   2.86965608596802
 (PID.TID 0000.0001)          No. starts:          16
 (PID.TID 0000.0001)           No. stops:          16
 (PID.TID 0000.0001)   Seconds in section "INTEGR_CONTINUITY   [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:  0.69999999999999574
-(PID.TID 0000.0001)         System time:   0.0000000000000000
-(PID.TID 0000.0001)     Wall clock time:  0.73426580429077148
+(PID.TID 0000.0001)           User time:  0.290857076644897
+(PID.TID 0000.0001)         System time:  0.000000000000000E+000
+(PID.TID 0000.0001)     Wall clock time:  0.311199665069580
 (PID.TID 0000.0001)          No. starts:          16
 (PID.TID 0000.0001)           No. stops:          16
 (PID.TID 0000.0001)   Seconds in section "CALC_R_STAR         [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:  9.99999999999978684E-002
-(PID.TID 0000.0001)         System time:   0.0000000000000000
-(PID.TID 0000.0001)     Wall clock time:  8.80432128906250000E-002
+(PID.TID 0000.0001)           User time:  4.239869117736816E-002
+(PID.TID 0000.0001)         System time:  0.000000000000000E+000
+(PID.TID 0000.0001)     Wall clock time:  4.655337333679199E-002
 (PID.TID 0000.0001)          No. starts:          16
 (PID.TID 0000.0001)           No. stops:          16
 (PID.TID 0000.0001)   Seconds in section "BLOCKING_EXCHANGES  [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:  0.25999999999999446
-(PID.TID 0000.0001)         System time:   0.0000000000000000
-(PID.TID 0000.0001)     Wall clock time:  0.24471998214721680
+(PID.TID 0000.0001)           User time:  0.402749419212341
+(PID.TID 0000.0001)         System time:  0.000000000000000E+000
+(PID.TID 0000.0001)     Wall clock time:  0.407253265380859
 (PID.TID 0000.0001)          No. starts:          32
 (PID.TID 0000.0001)           No. stops:          32
 (PID.TID 0000.0001)   Seconds in section "THERMODYNAMICS      [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:   3.2000000000000064
-(PID.TID 0000.0001)         System time:   0.0000000000000000
-(PID.TID 0000.0001)     Wall clock time:   3.1872220039367676
+(PID.TID 0000.0001)           User time:   1.63692092895508
+(PID.TID 0000.0001)         System time:  0.000000000000000E+000
+(PID.TID 0000.0001)     Wall clock time:   1.64630985260010
 (PID.TID 0000.0001)          No. starts:          16
 (PID.TID 0000.0001)           No. stops:          16
 (PID.TID 0000.0001)   Seconds in section "TRC_CORRECTION_STEP [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:  5.99999999999987210E-002
-(PID.TID 0000.0001)         System time:   0.0000000000000000
-(PID.TID 0000.0001)     Wall clock time:  5.79326152801513672E-002
+(PID.TID 0000.0001)           User time:  4.587173461914062E-004
+(PID.TID 0000.0001)         System time:  0.000000000000000E+000
+(PID.TID 0000.0001)     Wall clock time:  4.444122314453125E-004
 (PID.TID 0000.0001)          No. starts:          16
 (PID.TID 0000.0001)           No. stops:          16
 (PID.TID 0000.0001)   Seconds in section "SHAP_FILT_TS       [TRC_CORR_STEP]":
-(PID.TID 0000.0001)           User time:   0.0000000000000000
-(PID.TID 0000.0001)         System time:   0.0000000000000000
-(PID.TID 0000.0001)     Wall clock time:  1.59978866577148438E-004
-(PID.TID 0000.0001)          No. starts:          16
-(PID.TID 0000.0001)           No. stops:          16
-(PID.TID 0000.0001)   Seconds in section "DO_STATEVARS_TAVE   [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:   0.0000000000000000
-(PID.TID 0000.0001)         System time:   0.0000000000000000
-(PID.TID 0000.0001)     Wall clock time:  1.57833099365234375E-004
+(PID.TID 0000.0001)           User time:  1.521110534667969E-004
+(PID.TID 0000.0001)         System time:  0.000000000000000E+000
+(PID.TID 0000.0001)     Wall clock time:  1.480579376220703E-004
 (PID.TID 0000.0001)          No. starts:          16
 (PID.TID 0000.0001)           No. stops:          16
 (PID.TID 0000.0001)   Seconds in section "MONITOR             [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:   4.4000000000000021
-(PID.TID 0000.0001)         System time:  1.00000000000000089E-002
-(PID.TID 0000.0001)     Wall clock time:   4.4353113174438477
+(PID.TID 0000.0001)           User time:   2.17403054237366
+(PID.TID 0000.0001)         System time:  0.000000000000000E+000
+(PID.TID 0000.0001)     Wall clock time:   2.25683307647705
 (PID.TID 0000.0001)          No. starts:          16
 (PID.TID 0000.0001)           No. stops:          16
 (PID.TID 0000.0001)   Seconds in section "DO_THE_MODEL_IO     [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:  5.00000000000007105E-002
-(PID.TID 0000.0001)         System time:  9.99999999999999500E-003
-(PID.TID 0000.0001)     Wall clock time:  5.94422817230224609E-002
+(PID.TID 0000.0001)           User time:  6.336557865142822E-002
+(PID.TID 0000.0001)         System time:  0.000000000000000E+000
+(PID.TID 0000.0001)     Wall clock time:  0.109786272048950
 (PID.TID 0000.0001)          No. starts:          16
 (PID.TID 0000.0001)           No. stops:          16
 (PID.TID 0000.0001)   Seconds in section "DO_WRITE_PICKUP     [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:  5.00000000000007105E-002
-(PID.TID 0000.0001)         System time:  9.99999999999999500E-003
-(PID.TID 0000.0001)     Wall clock time:  6.48188591003417969E-002
+(PID.TID 0000.0001)           User time:  0.102427840232849
+(PID.TID 0000.0001)         System time:  0.000000000000000E+000
+(PID.TID 0000.0001)     Wall clock time:  0.223593711853027
 (PID.TID 0000.0001)          No. starts:          16
 (PID.TID 0000.0001)           No. stops:          16
 (PID.TID 0000.0001) // ======================================================
@@ -3631,9 +3707,9 @@ listId=   1 ; file name: dynStDiag
 (PID.TID 0000.0001) //          Total. Y spins =              0
 (PID.TID 0000.0001) //            Avg. Y spins =       0.00E+00
 (PID.TID 0000.0001) // o Thread number: 000001
-(PID.TID 0000.0001) //            No. barriers =           8020
+(PID.TID 0000.0001) //            No. barriers =           8354
 (PID.TID 0000.0001) //      Max. barrier spins =              1
 (PID.TID 0000.0001) //      Min. barrier spins =              1
-(PID.TID 0000.0001) //     Total barrier spins =           8020
+(PID.TID 0000.0001) //     Total barrier spins =           8354
 (PID.TID 0000.0001) //      Avg. barrier spins =       1.00E+00
 PROGRAM MAIN: Execution ended Normally


### PR DESCRIPTION
## What changes does this PR introduce?
(Bug fix, feature, docs update, ...)
1. The bug fix makes the code conform to the equilibrium temperature formula in Held and Suarez (1994); 10-based log (Fortran function LOG10) is used instead of natural log (Fortran function LOG).
2. The CPP option TOP_HEAVY_HEATING, if true, changes the temperature relaxation timescale to make the tropical heating profile more top-heavy.

## What is the current behaviour? 
(You can also link to an open issue here)
1. The bug over-stratifies the atmosphere than in Held Suarez (1994).
2. Even with the bug fix, the mean vertical motion in the tropical mid-upper troposphere (~ 400 hPa) is weaker than the observed annual zonal mean.

## What is the new behaviour 
(if this is a feature change)?
1. The bug fix makes the simulation conform to Held Suarez (1994).
2. The CPP option TOP_HEAVY_HEATING, if true, makes the mean vertical motion in the tropical mid-upper troposphere (~ 400 hPa) better conform to the observed annual zonal mean, while other features like the mean zonal wind field still roughly conforms to Held Suarez (1994).

## Does this PR introduce a breaking change? 
(What changes might users need to make in their application due to this PR?)
No.

## Other information:


## Suggested addition to `tag-index`
(To avoid unnecessary merge conflicts, please don't update `tag-index`. One of the admins will do that when merging your pull request.)