### PR TITLE
small bug fixes to tst_2+2 scripts

### DIFF
--- a/doc/tag-index
+++ b/doc/tag-index
@@ -1,5 +1,7 @@
     Notes on tags used in MITgcmUV
     ==============================
+o 2+2 tests:
+ - bug fix: replace some non-standard sed command with POSIX compatible syntax
 o doc:
   - add new SO channel tutorial
 o optim:

--- a/tools/do_tst_2+2
+++ b/tools/do_tst_2+2
@@ -204,7 +204,7 @@ do
       if test "x$OPTFILE" = x -a -f $xx/$bldDir/Makefile ; then
         comm=`grep '^# OPTFILE=' $xx/$bldDir/Makefile 2>/dev/null | head -1 | sed 's/^# //'`
         echo "from '$xx/$bldDir/Makefile', extract:" > $DRESULTS/genmake_state
-	awk "/^# executed by:/ {print;getline;print}" $xx/$bldDir/Makefile >> $DRESULTS/genmake_state
+        awk "/^# executed by:/ {print;getline;print}" $xx/$bldDir/Makefile >> $DRESULTS/genmake_state
         echo " $comm" >> $DRESULTS/genmake_state
         eval $comm
         gmkLog=$xx/$bldDir/genmake.log

--- a/tools/do_tst_2+2
+++ b/tools/do_tst_2+2
@@ -204,7 +204,7 @@ do
       if test "x$OPTFILE" = x -a -f $xx/$bldDir/Makefile ; then
         comm=`grep '^# OPTFILE=' $xx/$bldDir/Makefile 2>/dev/null | head -1 | sed 's/^# //'`
         echo "from '$xx/$bldDir/Makefile', extract:" > $DRESULTS/genmake_state
-        sed -n '/^# executed by:/,+1 p' $xx/$bldDir/Makefile >> $DRESULTS/genmake_state
+	awk "/^# executed by:/ {print;getline;print}" $xx/$bldDir/Makefile >> $DRESULTS/genmake_state
         echo " $comm" >> $DRESULTS/genmake_state
         eval $comm
         gmkLog=$xx/$bldDir/genmake.log

--- a/tools/tst_2+2
+++ b/tools/tst_2+2
@@ -170,9 +170,13 @@ done
 if [ $prt -ge 2 ] ; then echo ' ' ; fi
 # add nIter0 & nTimeSteps in namelist "PARM03":
 Dbl=`expr $Nit \* 2`
-sed "/^ *\&PARM03/a \ nTimeSteps=$Dbl," data.tst > data.tmp_$$
+tmpstr="nTimeSteps=$Dbl,"
+sed -e "/^ *\&PARM03/a\\
+ \ $tmpstr" data.tst > data.tmp_$$
 mv -f data.tmp_$$ data.tst
-sed "/^ *\&PARM03/a \ nIter0=$iter," data.tst > data.tmp_$$
+tmpstr="nIter0=$iter,"
+sed -e "/^ *\&PARM03/a\\
+ \ $tmpstr" data.tst > data.tmp_$$
 mv -f data.tmp_$$ data.tst
 echo "prepare file 'data.tst' : done"
 if  [ $prt -ge 1 ] ; then

--- a/tools/tst_2+2
+++ b/tools/tst_2+2
@@ -170,13 +170,11 @@ done
 if [ $prt -ge 2 ] ; then echo ' ' ; fi
 # add nIter0 & nTimeSteps in namelist "PARM03":
 Dbl=`expr $Nit \* 2`
-tmpstr="nTimeSteps=$Dbl,"
 sed -e "/^ *\&PARM03/a\\
- \ $tmpstr" data.tst > data.tmp_$$
+ \ nTimeSteps=$Dbl," data.tst > data.tmp_$$
 mv -f data.tmp_$$ data.tst
-tmpstr="nIter0=$iter,"
 sed -e "/^ *\&PARM03/a\\
- \ $tmpstr" data.tst > data.tmp_$$
+ \ nIter0=$iter," data.tst > data.tmp_$$
 mv -f data.tmp_$$ data.tst
 echo "prepare file 'data.tst' : done"
 if  [ $prt -ge 1 ] ; then


### PR DESCRIPTION
## What changes does this PR introduce?
This is a bug fix to improve portability of the tst_2+2 restart tests. non-POSIX `sed` syntax is replaced by POSIX compatible solutions. In one case this involves replacing `sed` by `awk`.

## What is the current behaviour? 
2+2 tests do not work with POSIX `sed` (e.g. on a MacOS system)

## What is the new behaviour 
works with POSIX sed and awk

## Does this PR introduce a breaking change? 
No

## Other information:


## Suggested addition to `tag-index`
- 2+2 tests:
  o bug fix: replace some non-standard sed command with POSIX compatible syntax