### PR TITLE
fix recent change to tst_2+2

### DIFF
--- a/doc/tag-index
+++ b/doc/tag-index
@@ -1,7 +1,9 @@
     Notes on tags used in MITgcmUV
     ==============================
-o tools/do_tst_2+2 and tst_2+2:
+
+o tools/do_tst_2+2 & tst_2+2:
   - bug fix: replace some non-standard sed command with POSIX compatible syntax
+  - remove second blank at beginning of 2 new lines in file "data".
 o doc:
   - add new SO channel tutorial
   - update pkg/shelfice documentation

--- a/tools/tst_2+2
+++ b/tools/tst_2+2
@@ -171,10 +171,10 @@ if [ $prt -ge 2 ] ; then echo ' ' ; fi
 # add nIter0 & nTimeSteps in namelist "PARM03":
 Dbl=`expr $Nit \* 2`
 sed -e "/^ *\&PARM03/a\\
- \ nTimeSteps=$Dbl," data.tst > data.tmp_$$
+\ nTimeSteps=$Dbl," data.tst > data.tmp_$$
 mv -f data.tmp_$$ data.tst
 sed -e "/^ *\&PARM03/a\\
- \ nIter0=$iter," data.tst > data.tmp_$$
+\ nIter0=$iter," data.tst > data.tmp_$$
 mv -f data.tmp_$$ data.tst
 echo "prepare file 'data.tst' : done"
 if  [ $prt -ge 1 ] ; then


### PR DESCRIPTION
## What changes does this PR introduce?
fixes the previous fix

## What is the current behaviour? 
an extra space makes the script trip and all tests pass

## What is the new behaviour 
Still POSIX, but now avoids extra space at the beginning of the lines with nIter0 and nTimsteps, so that later sed commands do the right thing.


## Does this PR introduce a breaking change? 
No

## Other information:


## Suggested addition to `tag-index`
