### PR TITLE
Implement speed-at-all-cost global reduction using MPI_Allreduce on a…

### DIFF
--- a/eesupp/inc/CPP_EEOPTIONS.h
+++ b/eesupp/inc/CPP_EEOPTIONS.h
@@ -130,13 +130,31 @@ C--   disconnect tiles (no exchange between tiles, just fill-in edges
 C     assuming locally periodic subdomain)
 #undef DISCONNECTED_TILES
 
+C--   Always cumulate as fast a possible applying MPI allreduce on a single value
+#define GLOBAL_SUM_GIDDYUP
+
 C--   Always cumulate tile local-sum in the same order by applying MPI allreduce
 C     to array of tiles ; can get slower with large number of tiles (big set-up)
-#define GLOBAL_SUM_ORDER_TILES
+#undef GLOBAL_SUM_ORDER_TILES
 
 C--   Alternative way of doing global sum without MPI allreduce call
 C     but instead, explicit MPI send & recv calls. Expected to be slower.
 #undef GLOBAL_SUM_SEND_RECV
+
+#if defined(GLOBAL_SUM_GIDDYUP)
+#undef GLOBAL_SUM_ORDER_TILES
+#undef GLOBAL_SUM_SEND_RECV
+#endif
+
+#if defined(GLOBAL_SUM_ORDER_TILES)
+#undef GLOBAL_SUM_SEND_RECV
+#undef GLOBAL_SUM_GIDDYUP
+#endif
+
+#if defined (GLOBAL_SUM_SEND_RECV)
+#undef GLOBAL_SUM_ORDER_TILES
+#undef GLOBAL_SUM_GIDDYUP
+#endif
 
 C--   Alternative way of doing global sum on a single CPU
 C     to eliminate tiling-dependent roundoff errors. Note: This is slow.

--- a/eesupp/src/global_sum_tile.F
+++ b/eesupp/src/global_sum_tile.F
@@ -191,9 +191,17 @@ C--   Sum over all tiles:
          ENDDO
 
       ELSE
-#else /* not ((GLOBAL_SUM_SEND_RECV | GLOBAL_SUM_ORDER_TILES) & ALLOW_USE_MPI) */
+#elif (defined (GLOBAL_SUM_GIDDYUP) && defined (ALLOW_USE_MPI) )
+      IF ( usingMPI ) THEN
+
+C--   Collect data from all procs
+        sumAllP = sum(phiTile)
+        CALL MPI_Allreduce( MPI_IN_PLACE, sumAllP, 1,
+     &           MPI_DOUBLE_PRECISION, MPI_SUM, MPI_COMM_MODEL, mpiRC )
+      ELSE
+#else /* not ((GLOBAL_SUM_SEND_RECV | GLOBAL_SUM_ORDER_TILES | GLOBAL_SUM_GIDDYUP) & ALLOW_USE_MPI) */
       IF ( .TRUE. ) THEN
-#endif /* not ((GLOBAL_SUM_SEND_RECV | GLOBAL_SUM_ORDER_TILES) & ALLOW_USE_MPI) */
+#endif /* not ((GLOBAL_SUM_SEND_RECV | GLOBAL_SUM_ORDER_TILES | GLOBAL_SUM_GIDDYUP) & ALLOW_USE_MPI) */
 
 C--   Sum over all tiles (of the same process) first
         sumMyPr = 0.


### PR DESCRIPTION
… single value; controlled via GLOBAL_SUM_GIDDYP; See issue #385 at https://github.com/MITgcm/MITgcm.git for some background

## What changes does this PR introduce?
This change provides a significant performance improvement on the Pleiades system when running the llc_540 case (https://github.com/MITgcm-contrib/llc_hires/tree/master/llc_540)


## What is the current behaviour? 
The current default behavior is to compute a global sum in an orderly fashion and thus spends lots of time in MPI_Allreduce.
See issue #385 for details


## What is the new behaviour 
The new behavior is to not care about what order the global sum is computed.


## Does this PR introduce a breaking change? 
The GLOBAL_SUM_GIDDYP option is not appropriate for situations where a user requires strong reproducibility.


## Other information:
Tested and verified on Pleiades using the llc_540 case (5-day simulation)

## Suggested addition to `tag-index`
(To avoid unnecessary merge conflicts, please don't update `tag-index`. One of the admins will do that when merging your pull request.)