### PR TITLE
FIX: include stdio.h in setdir.c

### DIFF
--- a/doc/tag-index
+++ b/doc/tag-index
@@ -1,6 +1,8 @@
     Notes on tags used in MITgcmUV
     ==============================
 
+o eesupp/src:
+  - add missing "stdio.h" in src code setdir.c
 o tools/do_tst_2+2 & tst_2+2:
   - bug fix: replace some non-standard sed command with POSIX compatible syntax
   - remove second blank at beginning of 2 new lines in file "data".

--- a/eesupp/src/setdir.c
+++ b/eesupp/src/setdir.c
@@ -2,6 +2,7 @@
 */
 
 #include <stdlib.h>
+#include <stdio.h>
 #include <unistd.h>
 /*  Here, we get the definition of the FC_NAMEMANGLE() macro. */
 #include "FC_NAMEMANGLE.h"


### PR DESCRIPTION
## What changes does this PR introduce?

For gcc-10 (on macOS at least), MITgcm fails to compile with my flags, yielding:

```
mpicc  -DWORDLENGTH=4 -DALWAYS_USE_MPI -DALLOW_USE_MPI -DHAVE_SYSTEM -DHAVE_FDATE -DHAVE_ETIME_SBR -DHAVE_CLOC -DHAVE_SETRLSTK -DHAVE_STAT -DHAVE_FLUSH  -I/usr/local/include -c setdir.c
setdir.c:22:4: error: implicitly declaring library function 'sprintf' with type
      'int (char *, const char *, ...)' [-Werror,-Wimplicit-function-declaration]
   sprintf(RUN_DIR,"rank_%d",*myPEListId);
   ^
setdir.c:22:4: note: include the header <stdio.h> or explicitly provide a declaration for 'sprintf'
1 error generated.
```

This PR simply adds the include. 

Closes #389

## Does this PR introduce a breaking change? 

No

