### PR TITLE
Fix pr355, seaice growth adx

### DIFF
--- a/model/src/correction_step.F
+++ b/model/src/correction_step.F
@@ -66,7 +66,9 @@ C     gV_dpy       :: implicit part of pressure gradient tendency
       _RL     gV_dpy(1-OLx:sNx+OLx,1-OLy:sNy+OLy)
 #ifdef ALLOW_DIAGNOSTICS
       LOGICAL dPhiDiagIsOn, implDisDiagIsOn
+# ifdef ALLOW_SOLVE4_PS_AND_DRAG
       _RL tmpFac
+# endif
 #endif /* ALLOW_DIAGNOSTICS */
 CEOP
 

--- a/pkg/generic_advdiff/gad_calc_rhs.F
+++ b/pkg/generic_advdiff/gad_calc_rhs.F
@@ -142,7 +142,7 @@ C locABT           :: local copy of (AB-extrapolated) tracer field
       _RL locABT(1-OLx:sNx+OLx,1-OLy:sNy+OLy)
       _RL advFac, rAdvFac
 #ifdef GAD_SMOLARKIEWICZ_HACK
-      _RL outFlux, trac, fac, gTrFac
+      _RL outFlux, trac, gTrFac
 #endif
 #ifdef ALLOW_DIAGNOSTICS
       CHARACTER*8 diagName
@@ -732,14 +732,14 @@ coj   SmolarkiewiczMaxFrac, scale them down
          IF (outFlux.GT.0. _d 0 .AND.
      &       outFlux.GT.SmolarkiewiczMaxFrac*trac) THEN
 coj   If tracer is already negative, scale flux to zero
-           fac = MAX(0. _d 0,SmolarkiewiczMaxFrac*trac/outFlux)
+           gTrFac = MAX(0. _d 0,SmolarkiewiczMaxFrac*trac/outFlux)
 
-           IF (fZon(i+1,j).GT.0. _d 0) fZon(i+1,j)=fac*fZon(i+1,j)
-           IF (-fZon(i,j) .GT.0. _d 0) fZon(i,j)  =fac*fZon(i,j)
-           IF (fMer(i,j+1).GT.0. _d 0) fMer(i,j+1)=fac*fMer(i,j+1)
-           IF (-fMer(i,j) .GT.0. _d 0) fMer(i,j)  =fac*fMer(i,j)
+           IF (fZon(i+1,j).GT.0. _d 0) fZon(i+1,j)=gTrFac*fZon(i+1,j)
+           IF (-fZon(i,j) .GT.0. _d 0) fZon(i,j)  =gTrFac*fZon(i,j)
+           IF (fMer(i,j+1).GT.0. _d 0) fMer(i,j+1)=gTrFac*fMer(i,j+1)
+           IF (-fMer(i,j) .GT.0. _d 0) fMer(i,j)  =gTrFac*fMer(i,j)
            IF (-fVerT(i,j,kUp)*rkSign .GT.0. _d 0)
-     &       fVerT(i,j,kUp)=fac*fVerT(i,j,kUp)
+     &       fVerT(i,j,kUp)=gTrFac*fVerT(i,j,kUp)
 
            IF (k.LT.Nr .AND. fVerT(i,j,kDown)*rkSign.GT.0. _d 0) THEN
 coj   Down flux is special: it has already been applied in lower layer,
@@ -751,7 +751,7 @@ coj   undo down flux, ...
      &         *recip_rhoFacC(k+1)
      &         *( -fVerT(i,j,kDown)*rkSign )
 coj   ... scale ...
-             fVerT(i,j,kDown)=fac*fVerT(i,j,kDown)
+             fVerT(i,j,kDown)=gTrFac*fVerT(i,j,kDown)
 coj   ... and reapply
              gTracer(i,j,k+1) = gTracer(i,j,k+1)
      &        +_recip_hFacC(i,j,k+1,bi,bj)*recip_drF(k+1)

--- a/pkg/seaice/seaice_growth.F
+++ b/pkg/seaice/seaice_growth.F
@@ -2708,7 +2708,7 @@ C SIatmFW follows the same convention as empmr -- SIatmFW diag does not
 #else  /* ALLOW_EXF and ALLOW_ATM_TEMP */
       STOP 'SEAICE_GROWTH not compiled without EXF and ALLOW_ATM_TEMP'
 #endif /* ALLOW_EXF and ALLOW_ATM_TEMP */
-#endif /* SEAICE_USE_GROWTH_ADX */
+#endif /* ndef SEAICE_USE_GROWTH_ADX */
 
       RETURN
       END

--- a/pkg/seaice/seaice_growth_adx.F
+++ b/pkg/seaice/seaice_growth_adx.F
@@ -55,6 +55,7 @@ C     myThid :: Thread no. that called this routine.
       INTEGER myIter, myThid
 CEOP
 
+#ifdef SEAICE_USE_GROWTH_ADX
 #if (defined ALLOW_EXF) && (defined ALLOW_ATM_TEMP)
 C     !FUNCTIONS:
 #ifdef ALLOW_DIAGNOSTICS
@@ -1420,6 +1421,7 @@ C
 #else  /* ALLOW_EXF and ALLOW_ATM_TEMP */
       STOP 'SEAICE_GROWTH_ADX not compiled with EXF and ALLOW_ATM_TEMP'
 #endif /* ALLOW_EXF and ALLOW_ATM_TEMP */
+#endif /* SEAICE_USE_GROWTH_ADX */
 
       RETURN
       END


### PR DESCRIPTION
## What changes does this PR introduce?
Fix for recently merged PR #355, updated version of seaice_growth_adx.F

## What is the current behaviour? 
Although this S/R is only called when corresponding CPP option "SEAICE_USE_GROWTH_ADX"
is defined, the entire S/R is always compiled including an inconsistent call to SEAICE_SOLVE4TEMP
when option above is undef.

## What is the new behaviour 
Leave the S/R empty when above option is undef.

## Does this PR introduce a breaking change? 
No

## Other information:
Current version fails to compile when compiler checks for argument mis-match, e.g.:
 http://mitgcm.org/testing/results/2020_11/tr_engaging-ifcMpi_20201127_0/summary.txt
This PR does fix the problem.

## Suggested addition to `tag-index`
(To avoid unnecessary merge conflicts, please don't update `tag-index`. One of the admins will do that when merging your pull request.)