### PR TITLE
Dkokron/reduce startup time

### DIFF
--- a/eesupp/src/eeset_parms.F
+++ b/eesupp/src/eeset_parms.F
@@ -139,8 +139,8 @@ C     Make scratch copies of input data file with and without comments
 C     Stop if called from eeboot_minimal.F before myProcId is set
       IF ( .NOT.doReport )
      &     STOP 'ABNORMAL END: S/R EESET_PARMS: myProcId unset'
-      WRITE(scratchFile1,'(A)') 'scratch1'
-      WRITE(scratchFile2,'(A)') 'scratch2'
+      WRITE(scratchFile1,'(A)') '/tmp/scratch1'
+      WRITE(scratchFile2,'(A)') '/tmp/scratch2'
       IF( myProcId .EQ. 0 ) THEN
        OPEN(UNIT=scrUnit1, FILE=scratchFile1, STATUS='UNKNOWN')
        OPEN(UNIT=scrUnit2, FILE=scratchFile2, STATUS='UNKNOWN')
@@ -155,8 +155,8 @@ C     multi-node/multi-processor systems
 C     this definition will go into CPP_EEMACROS.h, once this method is
 C     properly established
 C     After opening regular files here, they are closed with STATUS='DELETE'
-      WRITE(scratchFile1,'(A,'//FMT_PROC_ID//')') 'scratch1.', procId
-      WRITE(scratchFile2,'(A,'//FMT_PROC_ID//')') 'scratch2.', procId
+      WRITE(scratchFile1,'(A,'//FMT_PROC_ID//')') '/tmp/scratch1.', procId
+      WRITE(scratchFile2,'(A,'//FMT_PROC_ID//')') '/tmp/scratch2.', procId
       OPEN(UNIT=scrUnit1, FILE=scratchFile1, STATUS='UNKNOWN')
       OPEN(UNIT=scrUnit2, FILE=scratchFile2, STATUS='UNKNOWN')
 # endif
@@ -166,8 +166,8 @@ C     After opening regular files here, they are closed with STATUS='DELETE'
       IF( myProcId .EQ. 0 ) THEN
 #endif
 
-      OPEN(UNIT=eeDataUnit,FILE='eedata',STATUS='OLD',
-     &     err=1,IOSTAT=errIO)
+      OPEN(UNIT=eeDataUnit,FILE='/tmp/namelist/eedata',STATUS='OLD',
+     &     ACTION='read',err=1,IOSTAT=errIO)
       IF ( errIO .GE. 0 ) GOTO 2
     1 CONTINUE
       IF ( doReport ) THEN

--- a/eesupp/src/open_copy_data_file.F
+++ b/eesupp/src/open_copy_data_file.F
@@ -76,8 +76,8 @@ C--   Open the parameter file
 
 C     Make scratch copies of eedata with and without comments
 #ifdef SINGLE_DISK_IO
-      WRITE(scratchFile1,'(A,A)') 'scratch1_', data_file
-      WRITE(scratchFile2,'(A,A)') 'scratch2_', data_file
+      WRITE(scratchFile1,'(A,A)') '/tmp/scratch1_', data_file
+      WRITE(scratchFile2,'(A,A)') '/tmp/scratch2_', data_file
       IF ( myProcId .EQ. 0 ) THEN
        OPEN(UNIT=scrUnit1, FILE=scratchFile1, STATUS='UNKNOWN')
        OPEN(UNIT=scrUnit2, FILE=scratchFile2, STATUS='UNKNOWN')
@@ -90,8 +90,8 @@ C     multi-node/multi-processor systems
       OPEN(UNIT=scrUnit2,STATUS='SCRATCH')
 #else
 C     After opening regular files here, they are closed with STATUS='DELETE'
-      WRITE(scratchFile1,'(A,'//FMT_PROC_ID//')') 'scratch1.', myProcId
-      WRITE(scratchFile2,'(A,'//FMT_PROC_ID//')') 'scratch2.', myProcId
+      WRITE(scratchFile1,'(A,'//FMT_PROC_ID//')') '/tmp/scratch1.', myProcId
+      WRITE(scratchFile2,'(A,'//FMT_PROC_ID//')') '/tmp/scratch2.', myProcId
       OPEN(UNIT=scrUnit1, FILE=scratchFile1, STATUS='UNKNOWN')
       OPEN(UNIT=scrUnit2, FILE=scratchFile2, STATUS='UNKNOWN')
 #endif /* USE_FORTRAN_SCRATCH_FILES */
@@ -102,7 +102,7 @@ C     After opening regular files here, they are closed with STATUS='DELETE'
 #endif
 
       OPEN(UNIT=modelDataUnit,FILE=data_file,STATUS='OLD',
-     &     IOSTAT=errIO)
+     &     ACTION='READ', IOSTAT=errIO)
       IF ( errIO .LT. 0 ) THEN
        WRITE(msgBuf,'(A,A)')
      &  'Unable to open parameter file: ',data_file

--- a/model/src/ini_curvilinear_grid.F
+++ b/model/src/ini_curvilinear_grid.F
@@ -53,6 +53,11 @@ C     == Local variables ==
 #endif
 #ifndef OLD_GRID_IO
       INTEGER iG, jG, iL, iLen
+#if 1
+      INTEGER dUnit, length_of_rec, tN, dNx, dNy, tBx, tBy, tNx, tNY
+      INTEGER  MDS_RECLEN
+      EXTERNAL MDS_RECLEN
+#endif
       CHARACTER*(MAX_LEN_FNAM) fName
       CHARACTER*(MAX_LEN_MBUF) tmpBuf
       INTEGER  ILNBLNK
@@ -291,6 +296,99 @@ C-    Tile Id number = Bi + (Bj-1)*(nSx*nPx)  with tile global-indices Bi,Bj
         WRITE(msgBuf,'(A)') '  =>'
 
 #ifdef ALLOW_MDSIO
+#if 1
+        tN  = W2_myTileList(bi,bj)
+        dNx = exch2_mydnx(tN)
+        dNy = exch2_mydny(tN)
+        tBx = exch2_tbasex(tN)
+        tBy = exch2_tbasey(tN)
+        tNx = exch2_tnx(tN)
+        tNy = exch2_tny(tN)
+        CALL MDSFINDUNIT( dUnit, myThid )
+        length_of_rec = MDS_RECLEN( fp, (dNx+1), myThid )
+        OPEN( dUnit, file=trim(fName), status='old', action='read',
+     &             access='direct', recl=length_of_rec )
+
+        CALL MDS_FACEF_READ_RS2( dUnit, fp, 1, length_of_rec, xC,
+     &                  dNx, dNy, tBx, tBy, tNx, tNY, bi, bj, myThid )
+        iL = ILNBLNK(msgBuf)
+        WRITE(tmpBuf,'(A,1X,A)') msgBuf(1:iL),'xC'
+        CALL MDS_FACEF_READ_RS2( dUnit, fp, 2, length_of_rec, yC,
+     &                  dNx, dNy, tBx, tBy, tNx, tNY, bi, bj, myThid )
+        iL = ILNBLNK(tmpBuf)
+        WRITE(msgBuf,'(A,1X,A)') tmpBuf(1:iL),'yC'
+        CALL MDS_FACEF_READ_RS2( dUnit, fp, 3, length_of_rec, dxF,
+     &                  dNx, dNy, tBx, tBy, tNx, tNY, bi, bj, myThid )
+        iL = ILNBLNK(msgBuf)
+        WRITE(tmpBuf,'(A,1X,A)') msgBuf(1:iL),'dxF'
+        CALL MDS_FACEF_READ_RS2( dUnit, fp, 4, length_of_rec, dyF,
+     &                  dNx, dNy, tBx, tBy, tNx, tNY, bi, bj, myThid )
+        iL = ILNBLNK(tmpBuf)
+        WRITE(msgBuf,'(A,1X,A)') tmpBuf(1:iL),'dyF'
+        CALL MDS_FACEF_READ_RS2( dUnit, fp, 5,  length_of_rec, rA,
+     &                  dNx, dNy, tBx, tBy, tNx, tNY, bi, bj, myThid )
+        iL = ILNBLNK(msgBuf)
+        WRITE(tmpBuf,'(A,1X,A)') msgBuf(1:iL),'rA'
+        CALL MDS_FACEF_READ_RS2( dUnit, fp, 6,  length_of_rec, xG,
+     &                  dNx, dNy, tBx, tBy, tNx, tNY, bi, bj, myThid )
+        iL = ILNBLNK(tmpBuf)
+        WRITE(msgBuf,'(A,1X,A)') tmpBuf(1:iL),'xG'
+        CALL MDS_FACEF_READ_RS2( dUnit, fp, 7,  length_of_rec, yG,
+     &                  dNx, dNy, tBx, tBy, tNx, tNY, bi, bj, myThid )
+        iL = ILNBLNK(msgBuf)
+        WRITE(tmpBuf,'(A,1X,A)') msgBuf(1:iL),'yG'
+        CALL MDS_FACEF_READ_RS2( dUnit, fp, 8, length_of_rec, dxV,
+     &                  dNx, dNy, tBx, tBy, tNx, tNY, bi, bj, myThid )
+        iL = ILNBLNK(tmpBuf)
+        WRITE(msgBuf,'(A,1X,A)') tmpBuf(1:iL),'dxV'
+        CALL MDS_FACEF_READ_RS2( dUnit, fp, 9, length_of_rec, dyU,
+     &                  dNx, dNy, tBx, tBy, tNx, tNY, bi, bj, myThid )
+        iL = ILNBLNK(msgBuf)
+        WRITE(tmpBuf,'(A,1X,A)') msgBuf(1:iL),'dyU'
+        CALL MDS_FACEF_READ_RS2( dUnit, fp,10, length_of_rec, rAz,
+     &                  dNx, dNy, tBx, tBy, tNx, tNY, bi, bj, myThid )
+        iL = ILNBLNK(tmpBuf)
+        WRITE(msgBuf,'(A,1X,A)') tmpBuf(1:iL),'rAz'
+        CALL MDS_FACEF_READ_RS2( dUnit, fp,11, length_of_rec, dxC,
+     &                  dNx, dNy, tBx, tBy, tNx, tNY, bi, bj, myThid )
+        iL = ILNBLNK(msgBuf)
+        WRITE(tmpBuf,'(A,1X,A)') msgBuf(1:iL),'dxC'
+        CALL MDS_FACEF_READ_RS2( dUnit, fp,12, length_of_rec, dyC,
+     &                  dNx, dNy, tBx, tBy, tNx, tNY, bi, bj, myThid )
+        iL = ILNBLNK(tmpBuf)
+        WRITE(msgBuf,'(A,1X,A)') tmpBuf(1:iL),'dyC'
+        CALL MDS_FACEF_READ_RS2( dUnit, fp,13, length_of_rec, rAw,
+     &                  dNx, dNy, tBx, tBy, tNx, tNY, bi, bj, myThid )
+        iL = ILNBLNK(msgBuf)
+        WRITE(tmpBuf,'(A,1X,A)') msgBuf(1:iL),'rAw'
+        CALL MDS_FACEF_READ_RS2( dUnit, fp,14, length_of_rec, rAs,
+     &                  dNx, dNy, tBx, tBy, tNx, tNY, bi, bj, myThid )
+        iL = ILNBLNK(tmpBuf)
+        WRITE(msgBuf,'(A,1X,A)') tmpBuf(1:iL),'rAs'
+        CALL MDS_FACEF_READ_RS2( dUnit, fp,15, length_of_rec, dxG,
+     &                  dNx, dNy, tBx, tBy, tNx, tNY, bi, bj, myThid )
+        iL = ILNBLNK(msgBuf)
+        WRITE(tmpBuf,'(A,1X,A)') msgBuf(1:iL),'dxG'
+        CALL MDS_FACEF_READ_RS2( dUnit, fp,16, length_of_rec, dyG,
+     &                  dNx, dNy, tBx, tBy, tNx, tNY, bi, bj, myThid )
+        iL = ILNBLNK(tmpBuf)
+        WRITE(msgBuf,'(A,1X,A)') tmpBuf(1:iL),'dyG'
+
+        iLen = ILNBLNK(horizGridFile)
+        IF ( iLen.GT.0 ) THEN
+         CALL MDS_FACEF_READ_RS2(dUnit,fp,17,length_of_rec, angleCosC,
+     &                  dNx, dNy, tBx, tBy, tNx, tNY, bi, bj, myThid)
+         iL = ILNBLNK(msgBuf)
+         WRITE(tmpBuf,'(A,1X,A)') msgBuf(1:iL),'AngleCS'
+         CALL MDS_FACEF_READ_RS2(dUnit,fp,18,length_of_rec, angleSinC,
+     &                  dNx, dNy, tBx, tBy, tNx, tNY, bi, bj, myThid)
+         iL = ILNBLNK(tmpBuf)
+         WRITE(msgBuf,'(A,1X,A)') tmpBuf(1:iL),'AngleSN'
+         anglesAreSet = .TRUE.
+        ELSE
+         anglesAreSet = .FALSE.
+        ENDIF
+#else
         CALL MDS_FACEF_READ_RS( fName, fp, 1,  xC, bi, bj, myThid )
         iL = ILNBLNK(msgBuf)
         WRITE(tmpBuf,'(A,1X,A)') msgBuf(1:iL),'xC'
@@ -352,6 +450,7 @@ C-    Tile Id number = Bi + (Bj-1)*(nSx*nPx)  with tile global-indices Bi,Bj
         ELSE
          anglesAreSet = .FALSE.
         ENDIF
+#endif
 #else /* ALLOW_MDSIO */
         WRITE(msgBuf,'(2A)')
      &   'INI_CURVILINEAR_GRID: Needs to compile MDSIO pkg'

--- a/model/src/ini_parms.F
+++ b/model/src/ini_parms.F
@@ -360,7 +360,7 @@ C--   Open the parameter file
       CALL PRINT_MESSAGE( msgBuf, standardMessageUnit,
      &                    SQUEEZE_RIGHT, myThid )
 
-      CALL OPEN_COPY_DATA_FILE( 'data', 'INI_PARMS',
+      CALL OPEN_COPY_DATA_FILE( '/tmp/namelist/data', 'INI_PARMS',
      O                          iUnit, myThid )
 
 C--   Read settings from iUnit (= a copy of model parameter file "data").

--- a/model/src/packages_boot.F
+++ b/model/src/packages_boot.F
@@ -102,7 +102,7 @@ C     data.pkg namelists
      &                    SQUEEZE_RIGHT , myThid )
 
       CALL OPEN_COPY_DATA_FILE(
-     I                          'data.pkg', 'PACKAGES_BOOT',
+     I                       '/tmp/namelist/data.pkg', 'PACKAGES_BOOT',
      O                          iUnit,
      I                          myThid )
 

--- a/pkg/bbl/bbl_readparms.F
+++ b/pkg/bbl/bbl_readparms.F
@@ -61,7 +61,7 @@ C-    file names for initial conditions:
       CALL PRINT_MESSAGE( msgBuf, standardMessageUnit,
      &                    SQUEEZE_RIGHT , 1)
       CALL OPEN_COPY_DATA_FILE(
-     I                     'data.bbl', 'BBL_READPARMS',
+     I                     '/tmp/namelist/data.bbl', 'BBL_READPARMS',
      O                     iUnit,
      I                     myThid )
 

--- a/pkg/cal/cal_readparms.F
+++ b/pkg/cal/cal_readparms.F
@@ -91,7 +91,7 @@ C       Next, read the calendar data file.
      &                    SQUEEZE_RIGHT , 1)
 
         CALL OPEN_COPY_DATA_FILE(
-     I                          'data.cal', 'CAL_READPARMS',
+     I                      '/tmp/namelist/data.cal', 'CAL_READPARMS',
      O                          iUnit,
      I                          myThid )
         READ(unit = iUnit, nml = cal_nml)

--- a/pkg/diagnostics/diagnostics_readparms.F
+++ b/pkg/diagnostics/diagnostics_readparms.F
@@ -194,7 +194,7 @@ C-    Track diagnostics pkg activation status:
      &     ' DIAGNOSTICS_READPARMS: opening data.diagnostics'
       CALL PRINT_MESSAGE( msgBuf, standardMessageUnit,SQUEEZE_RIGHT,1)
 
-      CALL OPEN_COPY_DATA_FILE('data.diagnostics',
+      CALL OPEN_COPY_DATA_FILE('/tmp/namelist/data.diagnostics',
      &     'DIAGNOSTICS_READPARMS', ku, myThid )
 
       WRITE(msgBuf,'(2A)') 'S/R DIAGNOSTICS_READPARMS,',

--- a/pkg/exch2/w2_eeboot.F
+++ b/pkg/exch2/w2_eeboot.F
@@ -85,7 +85,7 @@ C     Open message output-file (if needed)
       IF ( W2_printMsg .LT. 0 ) THEN
         iTmp = MAX(4,1 + INT(LOG10(DFLOAT(nPx*nPy))))
         WRITE(fmtStr,'(2(A,I1),A)') '(A,I',iTmp,'.',iTmp,',A)'
-        WRITE(fName,fmtStr) 'w2_tile_topology.',myProcId,'.log'
+        WRITE(fName,fmtStr) '/tmp/w2_tile_topology.',myProcId,'.log'
         iLen = ILNBLNK(fName)
         CALL MDSFINDUNIT( W2_oUnit, myThid )
         OPEN( W2_oUnit, file=fName(1:iLen),

--- a/pkg/exch2/w2_readparms.F
+++ b/pkg/exch2/w2_readparms.F
@@ -111,7 +111,7 @@ C-    Check for file "data.ech2":
         WRITE(msgBuf,'(A)') 'W2_READPARMS: opening data.exch2'
         CALL PRINT_MESSAGE( msgBuf, stdUnit, SQUEEZE_RIGHT , myThid )
         CALL OPEN_COPY_DATA_FILE(
-     I                      'data.exch2', 'W2_READPARMS',
+     I                      '/tmp/namelist/data.exch2', 'W2_READPARMS',
      O                      iUnit,
      I                      myThid )
 

--- a/pkg/exf/exf_interp_read.F
+++ b/pkg/exf/exf_interp_read.F
@@ -131,7 +131,7 @@ C--   master thread of process 0, only, opens a global file
         CALL MDSFINDUNIT( ioUnit, myThid )
         length_of_rec=MDS_RECLEN( filePrec, nx_in*ny_in, myThid )
         OPEN( ioUnit, file=infile, status='old', access='direct',
-     &       recl=length_of_rec )
+     &       action='read', recl=length_of_rec )
         IF ( filePrec .EQ. 32 ) THEN
 #ifdef EXF_INTERP_USE_DYNALLOC
           READ(ioUnit,rec=irecord)  buffer_r4

--- a/pkg/exf/exf_readparms.F
+++ b/pkg/exf/exf_readparms.F
@@ -916,7 +916,7 @@ C--   Next, read pkg/exf parameter file.
      &                    SQUEEZE_RIGHT, myThid )
 
       CALL OPEN_COPY_DATA_FILE(
-     I                          'data.exf', 'EXF_READPARMS',
+     I                       '/tmp/namelist/data.exf', 'EXF_READPARMS',
      O                          iUnit,
      I                          myThid )
 

--- a/pkg/kpp/kpp_readparms.F
+++ b/pkg/kpp/kpp_readparms.F
@@ -72,7 +72,7 @@ C     print a (weak) warning if data.kpp is found
      &                    SQUEEZE_RIGHT, myThid )
       errIO = 0
       CALL OPEN_COPY_DATA_FILE(
-     I                          'data.kpp', 'KPP_READPARMS',
+     I                       '/tmp/namelist/data.kpp', 'KPP_READPARMS',
      O                          iUnit,
      I                          myThid )
 

--- a/pkg/mdsio/mdsio_facef_read.F
+++ b/pkg/mdsio/mdsio_facef_read.F
@@ -75,7 +75,7 @@ C     Figure out offset of tile within face
 
       CALL MDSFINDUNIT( dUnit, myThid )
       length_of_rec = MDS_RECLEN( fPrec, (dNx+1), myThid )
-      OPEN( dUnit, file=fName(1:iLen), status='old',
+      OPEN( dUnit, file=fName(1:iLen), status='old', action='read',
      &             access='direct', recl=length_of_rec )
       j = 0
       jBase=(irec-1)*(dNy+1)
@@ -113,7 +113,7 @@ C     Figure out offset of tile within face
 
       CALL MDSFINDUNIT( dUnit, myThid )
       length_of_rec = MDS_RECLEN( fPrec, (sNx+1)*(sNy+1), myThid )
-      OPEN( dUnit, file=fName(1:iLen), status='old',
+      OPEN( dUnit, file=fName(1:iLen), status='old',  action='read',
      &             access='direct', recl=length_of_rec )
       IF ( fPrec.EQ.precFloat32 ) THEN
         READ(dUnit, rec=irec) ioBuf4
@@ -142,6 +142,148 @@ C     Figure out offset of tile within face
         STOP 'ABNORMAL END: S/R MDS_FACEF_READ_RS'
       ENDIF
       CLOSE( dUnit )
+
+#endif /* ALLOW_EXCH2 */
+
+C---+----1----+----2----+----3----+----4----+----5----+----6----+----7-|--+----|
+
+      RETURN
+      END
+
+CBOP
+C     !ROUTINE:  MDS_FACEF_READ_RS2
+C     !INTERFACE:
+      SUBROUTINE MDS_FACEF_READ_RS2(
+     I               fUnit, fPrec, irec, length_of_rec,
+     U                    array,
+     I  dNx, dNy, tBx, tBy, tNx, tNY, bi,bj, myThid )
+C     !DESCRIPTION: \bv
+C     *==========================================================*
+C     | SUBROUTINE MDS_FACEF_READ_RS
+C     *==========================================================*
+C     | Read 1 field from a file which contains all the data from
+C     |  1 "face" (= piece of domain with rectangular topology)
+C     *==========================================================*
+C     \ev
+
+C     !USES:
+      IMPLICIT NONE
+C     === Global variables ===
+#include "SIZE.h"
+#include "EEPARAMS.h"
+#ifdef ALLOW_EXCH2
+#include "W2_EXCH2_SIZE.h"
+#include "W2_EXCH2_TOPOLOGY.h"
+#endif /* ALLOW_EXCH2 */
+
+C     !INPUT/OUTPUT PARAMETERS:
+C     == Routine arguments ==
+      INTEGER fUnit
+      INTEGER fPrec
+      INTEGER irec
+      _RS array(1-Olx:sNx+Olx,1-Oly:sNy+Oly,nSx,nSy)
+      INTEGER bi,bj, myThid
+CEOP
+
+C     !FUNCTIONS:
+!      INTEGER  MDS_RECLEN
+!      EXTERNAL MDS_RECLEN
+      INTEGER  ILNBLNK
+      EXTERNAL ILNBLNK
+
+C     !LOCAL VARIABLES:
+C     == Local variables ==
+      INTEGER i,j
+      INTEGER length_of_rec
+      CHARACTER*(MAX_LEN_MBUF) msgBuf
+#ifdef ALLOW_EXCH2
+      INTEGER tN, dNx, dNy, tBx, tBy, tNx, tNY, jj, jBase
+      Real*4 ioBuf4(1:sNx*nSx*nPx+1)
+      Real*8 ioBuf8(1:sNx*nSx*nPx+1)
+#else
+      Real*4 ioBuf4(1:sNx+1,1:sNy+1)
+      Real*8 ioBuf8(1:sNx+1,1:sNy+1)
+#endif /* ALLOW_EXCH2 */
+
+#ifdef ALLOW_EXCH2
+C     Figure out offset of tile within face
+      !tN  = W2_myTileList(bi,bj)
+      !dNx = exch2_mydnx(tN)
+      !dNy = exch2_mydny(tN)
+      !tBx = exch2_tbasex(tN)
+      !tBy = exch2_tbasey(tN)
+      !tNx = exch2_tnx(tN)
+      !tNy = exch2_tny(tN)
+
+!      CALL MDSFINDUNIT( dUnit, myThid )
+!      length_of_rec = MDS_RECLEN( fPrec, (dNx+1), myThid )
+!      OPEN( dUnit, file=fName(1:iLen), status='old', action='read',
+!     &             access='direct', recl=length_of_rec )
+      j = 0
+      jBase=(irec-1)*(dNy+1)
+      IF ( fPrec.EQ.precFloat32 ) THEN
+        DO jj=1+tBy,sNy+1+tBy
+         READ(fUnit,rec=jj+jBase) (ioBuf4(i),i=1,dNx+1)
+#ifdef _BYTESWAPIO
+         CALL MDS_BYTESWAPR4( (dNx+1), ioBuf4 )
+#endif
+         j = j+1
+         DO i=1,sNx+1
+          array(i,j,bi,bj) = ioBuf4(i+tBx)
+         ENDDO
+        ENDDO
+      ELSEIF ( fPrec.EQ.precFloat64 ) THEN
+        DO jj=1+tBy,sNy+1+tBy
+         READ(fUnit,rec=jj+jBase) (ioBuf8(i),i=1,dNx+1)
+#ifdef _BYTESWAPIO
+         CALL MDS_BYTESWAPR8( (dNx+1), ioBuf8 )
+#endif
+         j = j+1
+         DO i=1,sNx+1
+          array(i,j,bi,bj) = ioBuf8(i+tBx)
+         ENDDO
+        ENDDO
+      ELSE
+        WRITE(msgBuf,'(A,I8,A)')  ' MDS_FACEF_READ_RS:',
+     &             fPrec, ' = illegal value for fPrec'
+        CALL PRINT_ERROR( msgBuf, myThid )
+        STOP 'ABNORMAL END: S/R MDS_FACEF_READ_RS'
+      ENDIF
+!      CLOSE( dUnit )
+
+#else /* ALLOW_EXCH2 */
+
+!      CALL MDSFINDUNIT( dUnit, myThid )
+!      length_of_rec = MDS_RECLEN( fPrec, (sNx+1)*(sNy+1), myThid )
+!      OPEN( dUnit, file=fName(1:iLen), status='old',  action='read',
+!     &             access='direct', recl=length_of_rec )
+      IF ( fPrec.EQ.precFloat32 ) THEN
+        READ(fUnit, rec=irec) ioBuf4
+#ifdef _BYTESWAPIO
+        CALL MDS_BYTESWAPR4( (sNx+1)*(sNy+1), ioBuf4 )
+#endif
+        DO j=1,sNy+1
+         DO i=1,sNx+1
+          array(i,j,bi,bj) = ioBuf4(i,j)
+         ENDDO
+        ENDDO
+      ELSEIF ( fPrec.EQ.precFloat64 ) THEN
+        READ(fUnit, rec=irec) ioBuf8
+#ifdef _BYTESWAPIO
+        CALL MDS_BYTESWAPR8( (sNx+1)*(sNy+1), ioBuf8 )
+#endif
+        DO j=1,sNy+1
+         DO i=1,sNx+1
+          array(i,j,bi,bj) = ioBuf8(i,j)
+         ENDDO
+        ENDDO
+      ELSE
+        WRITE(msgBuf,'(A,I8,A)')  ' MDS_FACEF_READ_RS:',
+     &             fPrec, ' = illegal value for fPrec'
+        CALL PRINT_ERROR( msgBuf, myThid )
+        STOP 'ABNORMAL END: S/R MDS_FACEF_READ_RS'
+      ENDIF
+!      CLOSE( dUnit )
 
 #endif /* ALLOW_EXCH2 */
 

--- a/pkg/mdsio/mdsio_read_field.F
+++ b/pkg/mdsio/mdsio_read_field.F
@@ -267,7 +267,7 @@ C If global file is visible to process 0, then open it here.
 C Otherwise stop program.
          IF ( globalFile) THEN
           length_of_rec = MDS_RECLEN( filePrec, xSize*ySize, myThid )
-          OPEN( dUnit, file=dataFName, status='old',
+          OPEN( dUnit, file=dataFName, status='old', ACTION='read',
      &         access='direct', recl=length_of_rec )
          ELSE
           WRITE(msgBuf,'(2A)')
@@ -379,7 +379,7 @@ C Only do I/O if I am the master thread
 C If we are reading from a global file then we open it here
         IF (globalFile) THEN
          length_of_rec = MDS_RECLEN( filePrec, sNx, myThid )
-         OPEN( dUnit, file=dataFName, status='old',
+         OPEN( dUnit, file=dataFName, status='old', ACTION='read',
      &        access='direct', recl=length_of_rec )
          fileIsOpen=.TRUE.
         ENDIF
@@ -462,7 +462,7 @@ C (This is a place-holder for the active/passive mechanism
      &                        SQUEEZE_RIGHT, myThid)
             ENDIF
             length_of_rec = MDS_RECLEN( filePrec, sNx*sNy*nNz, myThid )
-            OPEN( dUnit, file=dataFName, status='old',
+            OPEN( dUnit, file=dataFName, status='old', ACTION='read',
      &            access='direct', recl=length_of_rec )
             fileIsOpen=.TRUE.
            ELSE

--- a/pkg/mdsio/mdsio_read_meta.F
+++ b/pkg/mdsio/mdsio_read_meta.F
@@ -190,7 +190,8 @@ C-    Assign a free unit number as the I/O channel for this subroutine
         CALL MDSFINDUNIT( mUnit, myThid )
 
 C-    Open meta-file
-        OPEN( mUnit, FILE=mFileName, STATUS='old',
+        !mFileName = '/tmp/' // mFileName
+        OPEN( mUnit, FILE=mFileName, STATUS='old', ACTION='read',
      &        FORM='formatted', IOSTAT=errIO )
 c       write(0,*) 'errIO=',errIO
         IF ( errIO .NE. 0 ) THEN

--- a/pkg/salt_plume/salt_plume_readparms.F
+++ b/pkg/salt_plume/salt_plume_readparms.F
@@ -83,7 +83,7 @@ C--   Default values for SALT_PLUME
       CALL PRINT_MESSAGE( msgBuf, standardMessageUnit,
      &                    SQUEEZE_RIGHT , 1)
       CALL OPEN_COPY_DATA_FILE(
-     I                     'data.salt_plume', 'SALT_PLUME_READPARMS',
+     I         '/tmp/namelist/data.salt_plume', 'SALT_PLUME_READPARMS',
      O                     iUnit,
      I                     myThid )
 

--- a/pkg/seaice/seaice_readparms.F
+++ b/pkg/seaice/seaice_readparms.F
@@ -630,7 +630,7 @@ C     Open and read the data.seaice file
      &                    SQUEEZE_RIGHT , myThid)
 
       CALL OPEN_COPY_DATA_FILE(
-     I                          'data.seaice', 'SEAICE_READPARMS',
+     I              '/tmp/namelist/data.seaice', 'SEAICE_READPARMS',
      O                          iUnit,
      I                          myThid )
 


### PR DESCRIPTION
## What changes does this PR introduce?
Improved interaction with Pleiades Lustre file systems.  This PR addresses several issues in the current code resulting in a 200 second savings during startup (~300s -> ~90s) for the llc_540 case.
1) Each MPI process creates and reads numerous scratch files in the case directory.  I moved these to /tmp saving O(10^4) MDS hits

2) Each MPI process reads numerous small configuration files from the case directory.  I moved these to /tmp saving O(10^4) MDS hits.  Requires that the user pre-populate /tmp on each node.  I accomplish this on pleiades using
  pdsh -w `/u/scicon/tools/bin/pbs_nodes $PBS_JOBID` "cd $PWD; mkdir -p /tmp/namelist; /bin/cp data eedata data.{bbl,cal,diagnostics,exch2,exf,kpp,pkg,salt_plume,seaice} /tmp/namelist/"

3) The code uses the Fortran default action when opening files for read-only access.  Fortran defaults to action=' READWRITE ' when opening files.  If a user does not have write access (think shared boundary conditions), then the first attempt to access the file will fail.  The fortran runtime then attempts to open the file action='read' which then succeeds.  While this can be very fast, it depends greatly on how busy the Lustre meta-data server (MDS) is.  Considering the MDS is a shared resource, all these extra MDS hits really just contribute extra load on an already burdened resource.  I added action='read' to all of the open() statements where IOT indicated it would be useful.

Changed files
	modified:   eesupp/src/eeset_parms.F
	modified:   eesupp/src/open_copy_data_file.F
	modified:   model/src/ini_curvilinear_grid.F
	modified:   model/src/ini_parms.F
	modified:   model/src/packages_boot.F
	modified:   pkg/bbl/bbl_readparms.F
	modified:   pkg/cal/cal_readparms.F
	modified:   pkg/diagnostics/diagnostics_readparms.F
	modified:   pkg/exch2/w2_eeboot.F
	modified:   pkg/exch2/w2_readparms.F
	modified:   pkg/exf/exf_interp_read.F
	modified:   pkg/exf/exf_readparms.F
	modified:   pkg/kpp/kpp_readparms.F
	modified:   pkg/mdsio/mdsio_facef_read.F
	modified:   pkg/mdsio/mdsio_read_field.F
	modified:   pkg/mdsio/mdsio_read_meta.F
	modified:   pkg/salt_plume/salt_plume_readparms.F
	modified:   pkg/seaice/seaice_readparms.F


## What is the current behaviour? 
See above


## What is the new behaviour 
Avoid Lustre interactions wherever possible by usign node-local /tmp, opening files with action='read' whenever read-only access is intended.


## Does this PR introduce a breaking change? 
The user needs to prepopulate /tmp on each compute node with various configuration and meta-data files.  Might be better to test for the existence of a given file under /tmp instead of forcing users to comply.  Let me know how you would like this to be implemented.


## Other information:


## Suggested addition to `tag-index`
(To avoid unnecessary merge conflicts, please don't update `tag-index`. One of the admins will do that when merging your pull request.)