### PR TITLE
Update doc config for sphinxcontrib-bibtex changes

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -70,6 +70,7 @@ jobs:
       script:
         - tools/ci/install_doc_dependencies.sh > /dev/null
         - cd doc
+        - sphinx-build -a -b ${BUILD} -d _build/doctrees . _build/html
         - sphinx-build -Wa -b ${BUILD} -d _build/doctrees . _build/html
     - env:
       - BUILD="latexpdf"

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -39,6 +39,8 @@ extensions = ['sphinx.ext.autodoc',
     'sphinxcontrib.programoutput',
     'mitgcm']
 
+bibtex_bibfiles = ['manual_references.bib']
+
 autodoc_mock_imports = ['matplotlib', 'mpl_toolkits']
 
 # Add any paths that contain templates here, relative to this directory.

--- a/doc/references.rst
+++ b/doc/references.rst
@@ -7,5 +7,5 @@
 
    .. rubric:: References
 
-.. bibliography:: manual_references.bib
+.. bibliography::
    :all:


### PR DESCRIPTION
## What changes does this PR introduce?

Fix broken doc build with sphinxcontrib-bibtex 2.0.0.

## What is the current behaviour? 

sphinx-build complains about missing configuration setting "bibtex_bibfiles".

## What is the new behaviour 

Doc build succeeds.  sphinx-build warns that bibtex citations have changed and suggests rerunning sphinx.  This may not be necessary since we are using the :all: option and rerunning mainly seems to update the list of actually cited references (by file).  I did not see a problem with the bibliography or the citations in the built docs.

## Does this PR introduce a breaking change? 

No.

## Other information:

## Suggested addition to `tag-index`

Maybe not necessary.