### PR TITLE
Hold sphinxcontrib-bibtex <2 to avoid conf change

### DIFF
--- a/doc/requirements.txt
+++ b/doc/requirements.txt
@@ -1,4 +1,4 @@
 sphinx>2
-sphinxcontrib-bibtex
+sphinxcontrib-bibtex<2
 sphinxcontrib-programoutput
 numpy


### PR DESCRIPTION
## What changes does this PR introduce?

Fix broken doc test

## What is the current behaviour? 

Docs don't build with latest sphinxcontrib-bibtex 2.0.0 installed from requirements file

## What is the new behaviour 

sphinxcontrib-bibtex is held < 2, so docs build

## Does this PR introduce a breaking change? 

No

## Other information:


## Suggested addition to `tag-index`
