### PR TITLE
GitHub action to replace travis tests

### DIFF
--- a/.github/workflows/build_testing.yml
+++ b/.github/workflows/build_testing.yml
@@ -48,7 +48,7 @@ jobs:
          sudo apt-get update
          sudo apt-get -qq install gfortran
      
-     - name: Get a docker image and set it running (if this works!)
+     - name: Get a docker image and set it running
        run: |
          docker pull mitgcm/testreport-images:ubuntu_18_04_villon
          docker run  -v `pwd`:/MITgcm --name ubuntu_18_04-testreport -t -d mitgcm/testreport-images:ubuntu_18_04_villon /bin/bash

--- a/.github/workflows/simple_testing.yml
+++ b/.github/workflows/simple_testing.yml
@@ -1,5 +1,3 @@
-name: Initial testing of switching to github actions for CI
-
 # For testing do on every push
 on:
   push:
@@ -42,7 +40,7 @@ jobs:
    
      - name: Checkout
        uses: actions/checkout@v2.2.0
-   
+
      - name: Set up compilers
        run: |
          sudo apt-get update
@@ -95,3 +93,47 @@ jobs:
         MITGCM_INPUT_DIR_PAT: '/input_oad.*'
        run: |
          . tools/ci/runtr.sh
+
+ doc_test_html:
+   runs-on: ubuntu-latest
+
+   continue-on-error: true
+
+   steps:
+     - name: Checkout
+       uses: actions/checkout@v2.2.0
+
+     - name: Set up Python
+       uses: actions/setup-python@v2
+       with:
+         python-version: 3.6
+
+     - name: install dependencies
+       run: tools/ci/install_doc_dependencies.sh
+
+     - name: build docs
+       run: |
+         cd doc
+         sphinx-build -Wa -b html -d _build_doctrees . _build/html
+
+ doc_test_latex:
+   runs-on: ubuntu-latest
+
+   continue-on-error: true
+
+   steps:
+     - name: Checkout
+       uses: actions/checkout@v2.2.0
+
+     - name: Set up Python
+       uses: actions/setup-python@v2
+       with:
+         python-version: 3.6
+
+     - name: install dependencies
+       run: tools/ci/install_doc_dependencies.sh
+
+     - name: build docs
+       run: |
+         cd doc
+         make clean latexpdf LATEXOPTS="-interaction=nonstopmode -halt-on-error"

--- a/.github/workflows/simple_testing.yml
+++ b/.github/workflows/simple_testing.yml
@@ -59,3 +59,39 @@ jobs:
         MITGCM_PRECS: ${{ matrix.precs }}
        run: |
          . tools/ci/runtr.sh
+
+ test_openad:
+   runs-on: ubuntu-latest
+
+   strategy:
+     matrix:
+      include:
+        - exp: "global_ocean.90x40x15"
+          precs: "16"
+
+   continue-on-error: true
+
+   steps:
+
+     - name: Checkout
+       uses: actions/checkout@v2.2.0
+
+     - name: Set up compilers
+       run: |
+         sudo apt-get update
+         sudo apt-get -qq install gfortran
+
+     - name: Get a docker image and set it running
+       run: |
+         docker pull mitgcm/mitgcm-openad-test:centos-test
+         docker run -i -t -v `pwd`:/MITgcm -d --name openad-testing --ulimit stack=-1:-1 --rm mitgcm/mitgcm-openad-test:centos-test /bin/bash
+
+     - name: Run testreport
+       env:
+        MITGCM_EXP: ${{ matrix.exp }}
+        MITGCM_PRECS: ${{ matrix.precs }}
+        MITGCM_DECMD: "docker exec -i openad-testing bash -lc"
+        MITGCM_TROPT: "-oad -devel -of=../tools/build_options/linux_amd64_gfortran"
+        MITGCM_INPUT_DIR_PAT: '/input_oad.*'
+       run: |
+         . tools/ci/runtr.sh

--- a/.github/workflows/simple_testing.yml
+++ b/.github/workflows/simple_testing.yml
@@ -7,7 +7,37 @@ on:
 jobs:
  test_report:
    runs-on: ubuntu-latest
-   
+
+   strategy:
+     matrix:
+      include:
+        - exp: "offline_exf_seaice"
+          precs: "16 16 16 16 16"
+        - exp: "global_ocean.cs32x15"
+          precs: "16 16 16 16 16"
+        - exp: "tutorial_deep_convection"
+          precs: "16 16"
+        - exp: "aim.5l_cs"
+          precs: "14 16"
+        - exp: "isomip"
+          precs: "16 16 16 16"
+        - exp: "global_ocean.90x40x15"
+          precs: "16 16 16"
+        - exp: "tutorial_plume_on_slope"
+          precs: "16"
+        - exp: "tutorial_advection_in_gyre"
+          precs: "16"
+        - exp: "hs94.cs-32x32x5"
+          precs: "13 16"
+        - exp: "tutorial_global_oce_biogeo"
+          precs: "16"
+        - exp: "tutorial_global_oce_in_p"
+          precs: "16"
+        - exp: "tutorial_cfc_offline"
+          precs: "16"
+
+   continue-on-error: true
+
    steps:
    
      - name: Checkout
@@ -25,8 +55,7 @@ jobs:
          
      - name: Run a test
        env: 
-        MITGCM_EXP: "tutorial_deep_convection" 
-        MITGCM_PRECS: "16 16"
+        MITGCM_EXP: ${{ matrix.exp }}
+        MITGCM_PRECS: ${{ matrix.precs }}
        run: |
          . tools/ci/runtr.sh
-    

--- a/.github/workflows/simple_testing.yml
+++ b/.github/workflows/simple_testing.yml
@@ -1,6 +1,6 @@
-# For testing do on every push
 on:
   push:
+  pull_request:
 
 jobs:
  test_report:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,3 +1,5 @@
+name: build
+
 on:
   push:
   pull_request:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -3,7 +3,7 @@ on:
   pull_request:
 
 jobs:
- test_report:
+ forward:
    runs-on: ubuntu-latest
 
    strategy:
@@ -58,7 +58,7 @@ jobs:
        run: |
          . tools/ci/runtr.sh
 
- test_openad:
+ openad:
    runs-on: ubuntu-latest
 
    strategy:
@@ -94,7 +94,7 @@ jobs:
        run: |
          . tools/ci/runtr.sh
 
- doc_test_html:
+ doc_html:
    runs-on: ubuntu-latest
 
    continue-on-error: true
@@ -116,7 +116,7 @@ jobs:
          cd doc
          sphinx-build -Wa -b html -d _build_doctrees . _build/html
 
- doc_test_latex:
+ doc_latex:
    runs-on: ubuntu-latest
 
    continue-on-error: true

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-[![Build test](https://github.com/jahn/MITgcm/workflows/build/badge.svg)](https://github.com/jahn/MITgcm/actions)
+[![Build Status](https://github.com/jahn/MITgcm/workflows/build/badge.svg)](https://github.com/jahn/MITgcm/actions)
 [![Documentation Status](http://readthedocs.org/projects/mitgcm/badge/?version=latest)](http://mitgcm.readthedocs.io/en/latest/?badge=latest)
 [![DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.1409237.svg)](https://doi.org/10.5281/zenodo.1409237)
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-[![Build Status](https://travis-ci.org/MITgcm/MITgcm.svg?branch=master)](https://travis-ci.org/MITgcm/MITgcm)
+[![Build test](https://github.com/jahn/MITgcm/workflows/build/badge.svg)](https://github.com/jahn/MITgcm/actions)
 [![Documentation Status](http://readthedocs.org/projects/mitgcm/badge/?version=latest)](http://mitgcm.readthedocs.io/en/latest/?badge=latest)
 [![DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.1409237.svg)](https://doi.org/10.5281/zenodo.1409237)
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-[![Build Status](https://github.com/jahn/MITgcm/workflows/build/badge.svg)](https://github.com/jahn/MITgcm/actions)
+[![Build Status](https://github.com/MITgcm/MITgcm/workflows/build/badge.svg)](https://github.com/MITgcm/MITgcm/actions)
 [![Documentation Status](http://readthedocs.org/projects/mitgcm/badge/?version=latest)](http://mitgcm.readthedocs.io/en/latest/?badge=latest)
 [![DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.1409237.svg)](https://doi.org/10.5281/zenodo.1409237)
 


### PR DESCRIPTION
## What changes does this PR introduce?

Add more experiments, openad and doc tests to @christophernhill's testing workflow.

## What is the current behaviour? 

Only one experiment runs

## What is the new behaviour 

Same set of experiments as in travis run, including doc tests

## Does this PR introduce a breaking change? 

No.

## Other information:


## Suggested addition to `tag-index`
