### PR TITLE
Fix a potential bug of using incorrect error filename

### DIFF
--- a/pkg/ecco/cost_gencost_seaicev4.F
+++ b/pkg/ecco/cost_gencost_seaicev4.F
@@ -202,16 +202,16 @@ c====================================================
      &     jrec, localstartdate, localperiod, fname1,
      &     fname0w, localrec, obsrec, exst, myThid)
         call ecco_zero(localweight,nnzsiv4,zeroRL,myThid)
+        fname0w=gencost_errfile(igen_conc)
 #ifdef SEAICECOST_JPL
-       fname0w=gencost_errfile(igen_conc)
-       call ecco_readwei(fname0w,localweight,localrec,
-     &      nnzsiv4,dosumsq,myThid)
-       call ecco_readwei(gencost_errfile(igen_deconc),
-     &      gencost_weight(1,1,1,1,igen_deconc),localrec,
-     &      nnzsiv4,dosumsq,myThid)
-       call ecco_readwei(gencost_errfile(igen_exconc),
-     &      gencost_weight(1,1,1,1,igen_exconc),localrec,
-     &      nnzsiv4,dosumsq,myThid)
+        call ecco_readwei(fname0w,localweight,localrec,
+     &       nnzsiv4,dosumsq,myThid)
+        call ecco_readwei(gencost_errfile(igen_deconc),
+     &       gencost_weight(1,1,1,1,igen_deconc),localrec,
+     &       nnzsiv4,dosumsq,myThid)
+        call ecco_readwei(gencost_errfile(igen_exconc),
+     &       gencost_weight(1,1,1,1,igen_exconc),localrec,
+     &       nnzsiv4,dosumsq,myThid)
 #else
         if ( (localrec. GT. 0).AND.(obsrec .GT. 0).AND.(exst) ) then
           call ecco_readwei(fname0w,localweight,localrec,


### PR DESCRIPTION
## What changes does this PR introduce?
(Bug fix, feature, docs update, ...)
Move "fname0w=gencost_errfile(igen_conc)" in cost_gencost_seaicev4.F out of a CPP ifdef block. 

## What is the current behaviour? 
(You can also link to an open issue here)
An incorrect error filename would be used if the CPP option SEAICECOST_JPL is *not* defined. 


## What is the new behaviour 
(if this is a feature change)?
A correct error filename will be used no matter if the CPP option SEAICECOST_JPL is undefined.


## Does this PR introduce a breaking change? 
(What changes might users need to make in their application due to this PR?)
It might if cost_gencost_seaicev4.F is used and the CPP option SEAICECOST_JPL is undefined. But I ran test report and all verification experiments passed the test. 


## Other information:


## Suggested addition to `tag-index`
(To avoid unnecessary merge conflicts, please don't update `tag-index`. One of the admins will do that when merging your pull request.)