### PR TITLE
Post pr405 fix

### DIFF
--- a/doc/tag-index
+++ b/doc/tag-index
@@ -1,6 +1,8 @@
     Notes on tags used in MITgcmUV
     ==============================
 
+o pkg/ecco:
+  - fix type of argument in S/R MDS_READVEC_LOC call inside cost_gencost_moc.F
 o verification/lab_sea:
   - change lab_sea.hb87 from testing EVP to testing aEVP with some sensible
     parameters ; update reference output "output.hb87.txt"

--- a/pkg/ecco/cost_gencost_moc.F
+++ b/pkg/ecco/cost_gencost_moc.F
@@ -40,7 +40,8 @@ c      integer nnzobs, nnzbar
       integer nrecloc, localrec, ioUnit
 
       _RL mybar     (1-olx:snx+olx,1-oly:sny+oly,nr,nsx,nsy)
-      _RL dummyRL, gencost_mskTemporal
+      _RL gencost_mskTemporal
+      _RL tmpVar(1), dummyRL
       _RS dummyRS(1)
       _RL tmpCumSumTile(nr,nSx,nSy)
       _RL tmpNumTile(nSx,nSy)
@@ -175,8 +176,9 @@ c-- Temporal mask
      &          SQUEEZE_RIGHT, myThid )
 
            ioUnit = 0
-           call MDS_READVEC_LOC(fname0,cost_iprec,ioUnit,'RL',
-     &          1, gencost_mskTemporal, dummyRS, 0, 0, irec, myThid )
+           CALL MDS_READVEC_LOC( fname0, cost_iprec, ioUnit, 'RL',
+     &                      1, tmpVar, dummyRS, 0, 0, irec, myThid )
+           gencost_mskTemporal = tmpVar(1)
           endif
 
 c=============== PART 2: Cost Computation ===================


### PR DESCRIPTION
## What changes does this PR introduce?
Fix argument type issue in cost_gencost_moc.F (from PR #405) as described in issue #427

## What is the current behaviour? 
Problem to compile with intel compiler with  "-chek all" option (which check for argument consistency between
S/R and places where they are called).

## What is the new behaviour 
In call to S/R MDS_READVEC_LOC, use local vector "tmpVal" of length 1 instead, and copy value 
to relevant variable.

## Does this PR introduce a breaking change? 
No

## Other information:


## Suggested addition to `tag-index`
Already documented (expected to be the next PR to be merged).