### PR TITLE
update shelfice_remeshing to allow for thin ice shelf

### DIFF
--- a/pkg/shelfice/shelfice_remesh_c_mask.F
+++ b/pkg/shelfice/shelfice_remesh_c_mask.F
@@ -146,11 +146,15 @@ C     update cell-centered grid factors and mask: maskC, h0FacC, recip_hFacC
           ENDIF
 
 C-- MERGE CELLS
-          IF ( ks.NE.0 .AND. ks.LT.kLowC (i,j,bi,bj) ) THEN
+          IF ( (ks.NE.0 .OR. shelficeMass(i,j,bi,bj).GT.0.0) 
+     &         .AND. ks.LT.kLowC (i,j,bi,bj) ) THEN
            IF ( hFac_surfC(i,j,bi,bj).LT.SHELFICEmergeThreshold ) THEN
             IF ( (hFac_surfC(i,j,bi,bj)*drF(ks)*recip_drF(ks+1)+1)
      &           .LT.SHELFICEsplitThreshold ) THEN
 
+             IF (ks.eq.0) THEN
+              ks = 1
+             ENDIF
              k1 = ks
              k2 = ks+1
              kSurfC(i,j,bi,bj) = k2


### PR DESCRIPTION
## What changes does this PR introduce?

This addresses a recent change (Consistent masking of thin ice shelf draft #113) which sets kTopC to 0 in cells where R_shelfice is zero. 


## What is the current behaviour? 
In the shelfice_remeshing functionality (shelfice_remesh_c_mask.F), cells can only be "merged" with cells below when kTopC is nonzero for the column. However, it is possible to initialise the shelfice package such that shelficeicemass is nonzero in a column even though R_shelfice=0, as long as etainit is nonzero (negative) in the column. If shelfice_mass_stepping = .TRUE., then the ice in this cell can grow in mass and the ice-ocean interface will be lowered.

With shelfice_remeshing, when an affected cell becomes sufficiently thin, it should merge with the cell below. However, in the above scenario kTopC will be zero in the affected colum and merging will not take place. This is because merging can only occur where kTopC is greater than zero.


## What is the new behaviour 
Merging is allowed if *either* ktopC>0 *or* shelficemass>0 in a column. The only change is in shelfice_remesh_c_mask.F

## Does this PR introduce a breaking change? 
This does not affect shelice_2d_remesh (or any other verifications)


## Other information:


## Suggested addition to `tag-index`
shelfice_remesh_c_mask.F: allow cells to merge if *either* kTopC>0 *or* shelficemass>0.