### PR TITLE
Fix OpenAD error in shelfice pkg

### DIFF
--- a/model/src/the_main_loop.F
+++ b/model/src/the_main_loop.F
@@ -245,6 +245,10 @@ CEOP
 #ifdef ALLOW_AUTODIFF_TAMC
 c--   Initialize storage for the cost function evaluation.
 CADJ  INIT dummytape = common, 1
+c--
+#  ifdef ALLOW_GENTIM2D_CONTROL
+CADJ INIT ctrltape       = COMMON,1
+#  endif
 c--   Initialize storage for the outermost loop.
 # ifdef ALLOW_AUTODIFF_WHTAPEIO
 CADJ  INIT tapelev_init   = common, 1
@@ -442,10 +446,6 @@ c--
 CADJ INIT comlev1        = COMMON,nchklev_1
 CADJ INIT comlev1_bibj   = COMMON,nchklev_1*nSx*nSy*nthreads_chkpt
 CADJ INIT comlev1_bibj_k = COMMON,nchklev_1*nSx*nSy*Nr*nthreads_chkpt
-c--
-#  ifdef ALLOW_GENTIM2D_CONTROL
-CADJ INIT ctrltape       = COMMON,1
-#  endif
 c--
 #   ifdef ALLOW_KPP
 CADJ INIT comlev1_kpp    = COMMON,nchklev_1*nSx*nSy

--- a/pkg/shelfice/shelfice_init_fixed.F
+++ b/pkg/shelfice/shelfice_init_fixed.F
@@ -100,7 +100,7 @@ C     like ctrl_get_gen and ctrl_set_unpack_xy require 3D masks.
          DO j=1-OLy,sNy+OLy
           DO i=1-OLx,sNx+OLx
            IF ( Ro_surf(i,j,bi,bj).LT.rF(1)
-     &          .AND. hFacC(i,j,k,bi,bj).NE.zeroRS ) THEN
+     &          .AND. maskC(i,j,k,bi,bj).NE.zeroRS ) THEN
             maskSHI(i,j,k,bi,bj) = 1. _d 0
             maskSHI(i,j,1,bi,bj) = 1. _d 0
            ENDIF


### PR DESCRIPTION
## What changes does this PR introduce?

- Bug fix for OpenAD in pkg/shelfice
- Fix a TAF tape initialiation in the_main_loop.F (left from PR #406)

## What is the current behaviour? 

OpenAD throws an error in the shelfice package when the non-linear free surface is used because of a comparison between the active variable hFacC and a floating point parameter. This got exposed by changes in PR #406 (replacing some ALLOW_SHIFWFLX_CONTROL with simply ALLOW_CTRL).

## What is the new behaviour 

No error.  maskC is used for the comparison.

## Does this PR introduce a breaking change? 

No.

## Other information:

This has been tested with OpenAD and the isomip verification experiment.
