### PR TITLE
Update this "prepare_run" (left from PR #447)

### DIFF
--- a/verification/tutorial_tracer_adjsens/input_oad/prepare_run
+++ b/verification/tutorial_tracer_adjsens/input_oad/prepare_run
@@ -2,20 +2,48 @@
 
 #- in order to save disc space, take *.bin files
 #- from this dir:
-fromDir="../input"
+fromDir="../../exp2/input"
 
 fileList=`( cd $fromDir ; echo *.bin )`
 
 #echo 'fileList=' $fileList
 
-#- and do a symbolic link in the current directory 
+#- and do a symbolic link in the current directory
 #   (if the file does not already exist)
 if test -d $fromDir ; then
   lnkList='files:'
   for xx in $fileList
   do
-    if test -r ${fromDir}/$xx ; then 
-      if test ! -r $xx ; then 
+    if test -r ${fromDir}/$xx ; then
+      if test ! -r $xx ; then
+        lnkList=${lnkList}" "$xx
+        ln -sf ${fromDir}/$xx .
+      fi
+    fi
+  done
+  echo ' link' $lnkList "from dir:" $fromDir
+else
+  echo " Error:" $fromDir "not a directory"
+fi
+
+#---------------------------------------------
+#-- for now, don't need this file ; stop here.
+exit
+#---------------------------------------------
+#- And take file 'ones_64b.bin'
+#- from this dir:
+fromDir="../../isomip/input_ad"
+
+fileList='ones_64b.bin'
+
+#- and do a symbolic link in the current directory
+#   (if the file does not already exist)
+if test -d $fromDir ; then
+  lnkList='files:'
+  for xx in $fileList
+  do
+    if test -r ${fromDir}/$xx ; then
+      if test ! -r $xx ; then
         lnkList=${lnkList}" "$xx
         ln -sf ${fromDir}/$xx .
       fi


### PR DESCRIPTION
All *.bin files are no longer in dir "input" but instead linked from exp2/input

## What changes does this PR introduce?
Forgot to update input_oad version of "prepare_run" (in experiment: tutorial_tracer_adjsens)
when removing *.bin files in dir input (as part of PR #447). Fix this.

## What is the current behaviour? 
tutorial_tracer_adjsens OpenAD test broken.

## What is the new behaviour 
Fixed

## Does this PR introduce a breaking change? 
no

## Other information:

## Suggested addition to `tag-index`
none if merged right after PR #447