### PR TITLE
testreport also check and report some AD-monitor

### DIFF
--- a/doc/tag-index
+++ b/doc/tag-index
@@ -1,6 +1,8 @@
     Notes on tags used in MITgcmUV
     ==============================
 
+o verification/testreport
+  - add ad-monitor of 3-D state variables to testreport summary output
 o pkg/ggl90:
   - avoid division by zero in adjoint of S/R GGL90_CALC (sqrt related)
 

--- a/verification/OpenAD/input_ad/data
+++ b/verification/OpenAD/input_ad/data
@@ -40,23 +40,12 @@
  nIter0 =     0,
  nTimeSteps = 4,
 # 100 years of integration will yield a reasonable flow field
-# startTime  =          0.,
-# endTime    = 3110400000.,
+# endTime   = 3110400000.,
  deltaTMom = 1200.0,
  tauCD =     321428.,
  deltaTtracer= 43200.0,
  deltaTClock = 43200.0,
-# if you are using a version later than checkpoint45d on the main branch
-# you can uncomment the following line and increase the time step
-# deltaTtracer and deltaTClock to 172800.0 as well to speed up the
-# asynchronous time stepping
-# deltaTfreesurf = 172800.0,
  abEps = 0.1,
- pChkptFreq= 311040000.,
- dumpFreq       = 2592000.,
- adjDumpFreq    = 2592000.,
- monitorFreq    = 2592000.,
- adjMonitorFreq = 2592000.,
 # 2 months restoring timescale for temperature
  tauThetaClimRelax =  5184000.0,
 # 6 months restoring timescale for salinity
@@ -64,6 +53,13 @@
  periodicExternalForcing=.TRUE.,
  externForcingPeriod=2592000.,
  externForcingCycle=31104000.,
+#- output:
+ pChkptFreq = 311040000.,
+ dumpFreq    =  2592000.,
+ adjDumpFreq =  2592000.,
+ monitorSelect = 2,
+ monitorFreq    = 86400.,
+ adjMonitorFreq = 86400.,
  &
 
 # Gridding parameters

--- a/verification/OpenAD/results/output_adm.txt
+++ b/verification/OpenAD/results/output_adm.txt
@@ -5,10 +5,10 @@
 (PID.TID 0000.0001) // ======================================================
 (PID.TID 0000.0001) // execution environment starting up...
 (PID.TID 0000.0001) 
-(PID.TID 0000.0001) // MITgcmUV version:  checkpoint65a
-(PID.TID 0000.0001) // Build user:        jmc
-(PID.TID 0000.0001) // Build host:        baudelaire
-(PID.TID 0000.0001) // Build date:        Tue Jul 29 13:06:16 EDT 2014
+(PID.TID 0000.0001) // MITgcmUV version:  checkpoint67w
+(PID.TID 0000.0001) // Build user:        jm_c
+(PID.TID 0000.0001) // Build host:        villon
+(PID.TID 0000.0001) // Build date:        Tue Apr 13 01:08:09 EDT 2021
 (PID.TID 0000.0001) 
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // Execution Environment parameter file "eedata"
@@ -21,9 +21,8 @@
 (PID.TID 0000.0001) > nTx=1,
 (PID.TID 0000.0001) > nTy=1,
 (PID.TID 0000.0001) > /
-(PID.TID 0000.0001) ># Note: Some systems use & as the
-(PID.TID 0000.0001) ># namelist terminator. Other systems
-(PID.TID 0000.0001) ># use a / character (as shown here).
+(PID.TID 0000.0001) ># Note: Some systems use & as the namelist terminator (as shown here).
+(PID.TID 0000.0001) >#       Other systems use a / character.
 (PID.TID 0000.0001) 
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // Computational Grid Specification ( see files "SIZE.h" )
@@ -49,8 +48,10 @@
 (PID.TID 0000.0001)                   /*  note: To execute a program with MPI calls */
 (PID.TID 0000.0001)                   /*  it must be launched appropriately e.g     */
 (PID.TID 0000.0001)                   /*  "mpirun -np 64 ......"                    */
-(PID.TID 0000.0001) useCoupler=    F ;/* Flag used to control communications with   */
+(PID.TID 0000.0001) useCoupler=   F ; /* Flag used to control communications with   */
 (PID.TID 0000.0001)                   /*  other model components, through a coupler */
+(PID.TID 0000.0001) useNest2W_parent =    F ;/* Control 2-W Nesting comm */
+(PID.TID 0000.0001) useNest2W_child  =    F ;/* Control 2-W Nesting comm */
 (PID.TID 0000.0001) debugMode =    F ; /* print debug msg. (sequence of S/R calls)  */
 (PID.TID 0000.0001) printMapIncludesZeros=    F ; /* print zeros in Std.Output maps */
 (PID.TID 0000.0001) maxLengthPrt1D=   65 /* maxLength of 1D array printed to StdOut */
@@ -89,10 +90,11 @@
 (PID.TID 0000.0001) > viscAr=1.E-3,
 (PID.TID 0000.0001) > viscAh=5.E5,
 (PID.TID 0000.0001) > diffKhT=0.0,
-(PID.TID 0000.0001) > diffKrT=3.E-5,
+(PID.TID 0000.0001) >#- diffKrT unused when compiled with ALLOW_3D_DIFFKR
+(PID.TID 0000.0001) >#diffKrT=3.E-5,
 (PID.TID 0000.0001) > diffKhS=0.0,
 (PID.TID 0000.0001) > diffKrS=3.E-5,
-(PID.TID 0000.0001) > rhonil=1035.,
+(PID.TID 0000.0001) > rhoConst=1035.,
 (PID.TID 0000.0001) > rotationPeriod=86400.,
 (PID.TID 0000.0001) > gravity=9.81,
 (PID.TID 0000.0001) > eosType = 'JMD95Z',
@@ -119,23 +121,12 @@
 (PID.TID 0000.0001) > nIter0 =     0,
 (PID.TID 0000.0001) > nTimeSteps = 4,
 (PID.TID 0000.0001) ># 100 years of integration will yield a reasonable flow field
-(PID.TID 0000.0001) ># startTime  =          0.,
-(PID.TID 0000.0001) ># endTime    = 3110400000.,
-(PID.TID 0000.0001) > deltaTmom = 1200.0,
+(PID.TID 0000.0001) ># endTime   = 3110400000.,
+(PID.TID 0000.0001) > deltaTMom = 1200.0,
 (PID.TID 0000.0001) > tauCD =     321428.,
 (PID.TID 0000.0001) > deltaTtracer= 43200.0,
 (PID.TID 0000.0001) > deltaTClock = 43200.0,
-(PID.TID 0000.0001) ># if you are using a version later than checkpoint45d on the main branch
-(PID.TID 0000.0001) ># you can uncomment the following line and increase the time step
-(PID.TID 0000.0001) ># deltaTtracer and deltaTClock to 172800.0 as well to speed up the
-(PID.TID 0000.0001) ># asynchronous time stepping
-(PID.TID 0000.0001) ># deltaTfreesurf = 172800.0,
 (PID.TID 0000.0001) > abEps = 0.1,
-(PID.TID 0000.0001) > pChkptFreq= 311040000.,
-(PID.TID 0000.0001) > dumpFreq       = 2592000.,
-(PID.TID 0000.0001) > adjDumpFreq    = 2592000.,
-(PID.TID 0000.0001) > monitorFreq    = 2592000.,
-(PID.TID 0000.0001) > adjMonitorFreq = 2592000.,
 (PID.TID 0000.0001) ># 2 months restoring timescale for temperature
 (PID.TID 0000.0001) > tauThetaClimRelax =  5184000.0,
 (PID.TID 0000.0001) ># 6 months restoring timescale for salinity
@@ -143,14 +134,21 @@
 (PID.TID 0000.0001) > periodicExternalForcing=.TRUE.,
 (PID.TID 0000.0001) > externForcingPeriod=2592000.,
 (PID.TID 0000.0001) > externForcingCycle=31104000.,
+(PID.TID 0000.0001) >#- output:
+(PID.TID 0000.0001) > pChkptFreq = 311040000.,
+(PID.TID 0000.0001) > dumpFreq    =  2592000.,
+(PID.TID 0000.0001) > adjDumpFreq =  2592000.,
+(PID.TID 0000.0001) > monitorSelect = 2,
+(PID.TID 0000.0001) > monitorFreq    = 86400.,
+(PID.TID 0000.0001) > adjMonitorFreq = 86400.,
 (PID.TID 0000.0001) > /
 (PID.TID 0000.0001) >
 (PID.TID 0000.0001) ># Gridding parameters
 (PID.TID 0000.0001) > &PARM04
 (PID.TID 0000.0001) > usingSphericalPolarGrid=.TRUE.,
-(PID.TID 0000.0001) > delR= 50., 70., 100., 140., 190.,
-(PID.TID 0000.0001) >       240., 290., 340., 390., 440.,
-(PID.TID 0000.0001) >       490., 540., 590., 640., 690.,
+(PID.TID 0000.0001) > delR= 50.,  70., 100., 140., 190.,
+(PID.TID 0000.0001) >      240., 290., 340., 390., 440.,
+(PID.TID 0000.0001) >      490., 540., 590., 640., 690.,
 (PID.TID 0000.0001) > ygOrigin=-80.,
 (PID.TID 0000.0001) > dySpacing=4.,
 (PID.TID 0000.0001) > dxSpacing=4.,
@@ -165,7 +163,7 @@
 (PID.TID 0000.0001) > meridWindFile=  'trenberth_tauy.bin',
 (PID.TID 0000.0001) > thetaClimFile=  'lev_sst.bin',
 (PID.TID 0000.0001) > saltClimFile=   'lev_sss.bin',
-(PID.TID 0000.0001) > surfQFile=      'ncep_qnet.bin',
+(PID.TID 0000.0001) > surfQnetFile=   'ncep_qnet.bin',
 (PID.TID 0000.0001) ># fresh water flux is turned off, uncomment next line to turn on
 (PID.TID 0000.0001) ># (not recommened together with surface salinity restoring)
 (PID.TID 0000.0001) ># EmPmRFile=      'ncep_emp.bin',
@@ -203,8 +201,11 @@
 (PID.TID 0000.0001)  PACKAGES_BOOT: finished reading data.pkg
 (PID.TID 0000.0001)  PACKAGES_BOOT: On/Off package Summary
  --------  pkgs with a standard "usePKG" On/Off switch in "data.pkg":  --------
+ pkg/kpp                  compiled but not used ( useKPP                   = F )
  pkg/gmredi               compiled   and   used ( useGMRedi                = T )
+ pkg/autodiff             compiled   and   used ( useAUTODIFF              = T )
  pkg/grdchk               compiled   and   used ( useGrdchk                = T )
+ pkg/ctrl                 compiled   and   used ( useCTRL                  = T )
  pkg/mnc                  compiled but not used ( useMNC                   = F )
  -------- pkgs without standard "usePKG" On/Off switch in "data.pkg":  --------
  pkg/generic_advdiff      compiled   and   used ( useGAD                   = T )
@@ -218,7 +219,6 @@
  pkg/mdsio                compiled   and   used
  pkg/autodiff             compiled   and   used
  pkg/cost                 compiled   and   used
- pkg/ctrl                 compiled   and   used
 (PID.TID 0000.0001)  PACKAGES_BOOT: End of package Summary
 (PID.TID 0000.0001) 
 (PID.TID 0000.0001)  GM_READPARMS: opening data.gmredi
@@ -284,6 +284,9 @@
 (PID.TID 0000.0001) inAdExact = /* get an exact adjoint (no approximation) */
 (PID.TID 0000.0001)                   T
 (PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) useApproxAdvectionInAdMode = /* approximate AD-advection */
+(PID.TID 0000.0001)                   F
+(PID.TID 0000.0001)     ;
 (PID.TID 0000.0001) useKPPinAdMode = /* use KPP in adjoint mode */
 (PID.TID 0000.0001)                   F
 (PID.TID 0000.0001)     ;
@@ -305,8 +308,17 @@
 (PID.TID 0000.0001) mon_AdVarExch = /* control adexch before monitor */
 (PID.TID 0000.0001)                       2
 (PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) viscFacInFw = /* viscosity factor for forward model */
+(PID.TID 0000.0001)                 1.000000000000000E+00
+(PID.TID 0000.0001)     ;
 (PID.TID 0000.0001) viscFacInAd = /* viscosity factor for adjoint */
 (PID.TID 0000.0001)                 1.000000000000000E+00
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) SIregFacInAd = /* sea ice factor for adjoint model */
+(PID.TID 0000.0001)                 1.234567000000000E+05
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) SIregFacInFw = /* sea ice factor for forward model */
+(PID.TID 0000.0001)                 1.234567000000000E+05
 (PID.TID 0000.0001)     ;
 (PID.TID 0000.0001) 
 (PID.TID 0000.0001) OPTIM_READPARMS: opening data.optim
@@ -353,9 +365,6 @@
 (PID.TID 0000.0001) >
 (PID.TID 0000.0001) 
 (PID.TID 0000.0001) CTRL_READPARMS: finished reading data.ctrl
-(PID.TID 0000.0001) useSmoothCorrel2DinAdMode = /* use ctrlSmoothCorrel2D in adjoint mode */
-(PID.TID 0000.0001)                   F
-(PID.TID 0000.0001)     ;
 (PID.TID 0000.0001) COST_READPARMS: opening data.cost
 (PID.TID 0000.0001)  OPEN_COPY_DATA_FILE: opening file data.cost
 (PID.TID 0000.0001) // =======================================================
@@ -400,6 +409,7 @@
 (PID.TID 0000.0001) // Gradient check configuration  >>> START <<<
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) 
+(PID.TID 0000.0001)   grdchkvarindex :                          1
 (PID.TID 0000.0001)   eps:                              0.100E-01
 (PID.TID 0000.0001)   First location:                           0
 (PID.TID 0000.0001)   Last location:                            7
@@ -616,8 +626,31 @@
 (PID.TID 0000.0001) ctrl-wet -------------------------------------------------
 (PID.TID 0000.0001) ctrl-wet -------------------------------------------------
 (PID.TID 0000.0001) ctrl-wet -------------------------------------------------
-(PID.TID 0000.0001) ctrl_init: no. of control variables:            4
-(PID.TID 0000.0001) ctrl_init: control vector length:          117236
+(PID.TID 0000.0001) ctrl_init_wet: no. of control variables:            4
+(PID.TID 0000.0001) ctrl_init_wet: control vector length:          117236
+(PID.TID 0000.0001) 
+(PID.TID 0000.0001) // =======================================================
+(PID.TID 0000.0001) // control vector configuration  >>> START <<<
+(PID.TID 0000.0001) // =======================================================
+(PID.TID 0000.0001) 
+(PID.TID 0000.0001)  Total number of ocean points per tile:
+(PID.TID 0000.0001)  --------------------------------------
+(PID.TID 0000.0001)  snx*sny*nr =    54000
+(PID.TID 0000.0001) 
+(PID.TID 0000.0001)  Number of ocean points per tile:
+(PID.TID 0000.0001)  --------------------------------
+(PID.TID 0000.0001)  bi,bj,#(c/s/w): 0001 0001 029309 026636 027324
+(PID.TID 0000.0001) 
+(PID.TID 0000.0001)  Initial state temperature contribution:
+(PID.TID 0000.0001)  Control variable index:    0101
+(PID.TID 0000.0001) 
+(PID.TID 0000.0001)  Initial state salinity contribution:
+(PID.TID 0000.0001)  Control variable index:    0102
+(PID.TID 0000.0001) 
+(PID.TID 0000.0001) // =======================================================
+(PID.TID 0000.0001) // control vector configuration  >>> END <<<
+(PID.TID 0000.0001) // =======================================================
+(PID.TID 0000.0001) 
 (PID.TID 0000.0001) %MON fCori_max                    =   1.4226580169407E-04
 (PID.TID 0000.0001) %MON fCori_min                    =  -1.4226580169407E-04
 (PID.TID 0000.0001) %MON fCori_mean                   =   7.5291817533716E-23
@@ -656,7 +689,7 @@
 (PID.TID 0000.0001) tRef =   /* Reference temperature profile ( oC or K ) */
 (PID.TID 0000.0001)    15 @  2.000000000000000E+01              /* K =  1: 15 */
 (PID.TID 0000.0001)     ;
-(PID.TID 0000.0001) sRef =   /* Reference salinity profile ( psu ) */
+(PID.TID 0000.0001) sRef =   /* Reference salinity profile ( g/kg ) */
 (PID.TID 0000.0001)    15 @  3.500000000000000E+01              /* K =  1: 15 */
 (PID.TID 0000.0001)     ;
 (PID.TID 0000.0001) useStrainTensionVisc= /* Use StrainTension Form of Viscous Operator */
@@ -692,11 +725,17 @@
 (PID.TID 0000.0001) no_slip_bottom =  /* Viscous BCs: No-slip bottom */
 (PID.TID 0000.0001)                   T
 (PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) bottomVisc_pCell = /* Partial-cell in bottom Visc. BC */
+(PID.TID 0000.0001)                   F
+(PID.TID 0000.0001)     ;
 (PID.TID 0000.0001) bottomDragLinear = /* linear bottom-drag coefficient ( m/s ) */
 (PID.TID 0000.0001)                 0.000000000000000E+00
 (PID.TID 0000.0001)     ;
 (PID.TID 0000.0001) bottomDragQuadratic = /* quadratic bottom-drag coefficient (-) */
 (PID.TID 0000.0001)                 0.000000000000000E+00
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) selectBotDragQuadr = /* select quadratic bottom drag options */
+(PID.TID 0000.0001)                      -1
 (PID.TID 0000.0001)     ;
 (PID.TID 0000.0001) diffKhT =   /* Laplacian diffusion of heat laterally ( m^2/s ) */
 (PID.TID 0000.0001)                 0.000000000000000E+00
@@ -711,7 +750,7 @@
 (PID.TID 0000.0001)                 0.000000000000000E+00
 (PID.TID 0000.0001)     ;
 (PID.TID 0000.0001) diffKrNrT = /* vertical profile of vertical diffusion of Temp ( m^2/s )*/
-(PID.TID 0000.0001)    15 @  3.000000000000000E-05              /* K =  1: 15 */
+(PID.TID 0000.0001)    15 @  0.000000000000000E+00              /* K =  1: 15 */
 (PID.TID 0000.0001)     ;
 (PID.TID 0000.0001) diffKrNrS = /* vertical profile of vertical diffusion of Salt ( m^2/s )*/
 (PID.TID 0000.0001)    15 @  3.000000000000000E-05              /* K =  1: 15 */
@@ -743,6 +782,16 @@
 (PID.TID 0000.0001) eosType =  /* Type of Equation of State */
 (PID.TID 0000.0001)               'JMD95Z'
 (PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) eosRefP0 = /* Reference atmospheric pressure for EOS ( Pa ) */
+(PID.TID 0000.0001)                 1.013250000000000E+05
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) selectP_inEOS_Zc = /* select pressure to use in EOS (0,1,2,3) */
+(PID.TID 0000.0001)                       0
+(PID.TID 0000.0001)     0= -g*rhoConst*z ; 1= pRef (from tRef,sRef); 2= Hyd P ; 3= Hyd+NH P
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) surf_pRef = /* Surface reference pressure ( Pa ) */
+(PID.TID 0000.0001)                 1.013250000000000E+05
+(PID.TID 0000.0001)     ;
 (PID.TID 0000.0001) HeatCapacity_Cp =  /* Specific heat capacity ( J/kg/K ) */
 (PID.TID 0000.0001)                 3.994000000000000E+03
 (PID.TID 0000.0001)     ;
@@ -766,6 +815,12 @@
 (PID.TID 0000.0001)     ;
 (PID.TID 0000.0001) gBaro =   /* Barotropic gravity ( m/s^2 ) */
 (PID.TID 0000.0001)                 9.810000000000000E+00
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) gravFacC = /* gravity factor (vs surf.) @ cell-Center (-) */
+(PID.TID 0000.0001)    15 @  1.000000000000000E+00              /* K =  1: 15 */
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) gravFacF = /* gravity factor (vs surf.) @ W-Interface (-) */
+(PID.TID 0000.0001)    16 @  1.000000000000000E+00              /* K =  1: 16 */
 (PID.TID 0000.0001)     ;
 (PID.TID 0000.0001) rotationPeriod =   /* Rotation Period ( s ) */
 (PID.TID 0000.0001)                 8.640000000000000E+04
@@ -794,7 +849,7 @@
 (PID.TID 0000.0001) implicSurfPress =  /* Surface Pressure implicit factor (0-1)*/
 (PID.TID 0000.0001)                 1.000000000000000E+00
 (PID.TID 0000.0001)     ;
-(PID.TID 0000.0001) implicDiv2Dflow =  /* Barot. Flow Div. implicit factor (0-1)*/
+(PID.TID 0000.0001) implicDiv2DFlow =  /* Barot. Flow Div. implicit factor (0-1)*/
 (PID.TID 0000.0001)                 1.000000000000000E+00
 (PID.TID 0000.0001)     ;
 (PID.TID 0000.0001) uniformLin_PhiSurf = /* use uniform Bo_surf on/off flag*/
@@ -834,7 +889,7 @@
 (PID.TID 0000.0001) temp_EvPrRn = /* Temp. of Evap/Prec/R (UNSET=use local T)(oC)*/
 (PID.TID 0000.0001)                 1.234567000000000E+05
 (PID.TID 0000.0001)     ;
-(PID.TID 0000.0001) salt_EvPrRn = /* Salin. of Evap/Prec/R (UNSET=use local S)(psu)*/
+(PID.TID 0000.0001) salt_EvPrRn = /* Salin. of Evap/Prec/R (UNSET=use local S)(g/kg)*/
 (PID.TID 0000.0001)                 0.000000000000000E+00
 (PID.TID 0000.0001)     ;
 (PID.TID 0000.0001) selectAddFluid = /* option for mass source/sink of fluid (=0: off) */
@@ -843,10 +898,10 @@
 (PID.TID 0000.0001) temp_addMass = /* Temp. of addMass array (UNSET=use local T)(oC)*/
 (PID.TID 0000.0001)                 1.234567000000000E+05
 (PID.TID 0000.0001)     ;
-(PID.TID 0000.0001) salt_addMass = /* Salin. of addMass array (UNSET=use local S)(psu)*/
+(PID.TID 0000.0001) salt_addMass = /* Salin. of addMass array (UNSET=use local S)(g/kg)*/
 (PID.TID 0000.0001)                 0.000000000000000E+00
 (PID.TID 0000.0001)     ;
-(PID.TID 0000.0001) convertFW2Salt = /* convert F.W. Flux to Salt Flux (-1=use local S)(psu)*/
+(PID.TID 0000.0001) convertFW2Salt = /* convert F.W. Flux to Salt Flux (-1=use local S)(g/kg)*/
 (PID.TID 0000.0001)                -1.000000000000000E+00
 (PID.TID 0000.0001)     ;
 (PID.TID 0000.0001) use3Dsolver = /* use 3-D pressure solver on/off flag */
@@ -888,6 +943,10 @@
 (PID.TID 0000.0001) implicitViscosity = /* Implicit viscosity on/off flag */
 (PID.TID 0000.0001)                   F
 (PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) selectImplicitDrag= /* Implicit bot Drag options (0,1,2)*/
+(PID.TID 0000.0001)                       0
+(PID.TID 0000.0001)     0= Expl. ; 1= Impl. on provis. Vel ; 2= Fully Impl (with surf.P)
+(PID.TID 0000.0001)     ;
 (PID.TID 0000.0001) metricTerms =  /* metric-Terms on/off flag */
 (PID.TID 0000.0001)                   T
 (PID.TID 0000.0001)     ;
@@ -907,39 +966,17 @@
 (PID.TID 0000.0001) useCDscheme =  /* CD scheme on/off flag */
 (PID.TID 0000.0001)                   T
 (PID.TID 0000.0001)     ;
-(PID.TID 0000.0001) useEnergyConservingCoriolis= /* Flx-Form Coriolis scheme flag */
-(PID.TID 0000.0001)                   F
-(PID.TID 0000.0001)     ;
-(PID.TID 0000.0001) useJamartWetPoints= /* Coriolis WetPoints method flag */
-(PID.TID 0000.0001)                   F
-(PID.TID 0000.0001)     ;
-(PID.TID 0000.0001) useJamartMomAdv= /* V.I Non-linear terms Jamart flag */
-(PID.TID 0000.0001)                   F
-(PID.TID 0000.0001)     ;
-(PID.TID 0000.0001) useAbsVorticity= /* V.I Works with f+zeta in Coriolis */
-(PID.TID 0000.0001)                   F
-(PID.TID 0000.0001)     ;
-(PID.TID 0000.0001) selectVortScheme= /* V.I Scheme selector for Vorticity-Term */
-(PID.TID 0000.0001)               123456789
-(PID.TID 0000.0001)    = 0 : enstrophy (Shallow-Water Eq.) conserving scheme by Sadourny, JAS 75
-(PID.TID 0000.0001)    = 1 : same as 0 with modified hFac
-(PID.TID 0000.0001)    = 2 : energy conserving scheme (used by Sadourny in JAS 75 paper)
-(PID.TID 0000.0001)    = 3 : energy (general) and enstrophy (2D, nonDiv.) conserving scheme
-(PID.TID 0000.0001)          from Sadourny (Burridge & Haseler, ECMWF Rep.4, 1977)
-(PID.TID 0000.0001)     ;
-(PID.TID 0000.0001) upwindVorticity= /* V.I Upwind bias vorticity flag */
-(PID.TID 0000.0001)                   F
-(PID.TID 0000.0001)     ;
-(PID.TID 0000.0001) highOrderVorticity= /* V.I High order vort. advect. flag */
-(PID.TID 0000.0001)                   F
-(PID.TID 0000.0001)     ;
-(PID.TID 0000.0001) upwindShear= /* V.I Upwind vertical Shear advection flag */
-(PID.TID 0000.0001)                   F
-(PID.TID 0000.0001)     ;
-(PID.TID 0000.0001) selectKEscheme= /* V.I Kinetic Energy scheme selector */
+(PID.TID 0000.0001) selectCoriScheme= /* Scheme selector for Coriolis-Term */
 (PID.TID 0000.0001)                       0
+(PID.TID 0000.0001)    = 0 : original discretization (simple averaging, no hFac)
+(PID.TID 0000.0001)    = 1 : Wet-point averaging (Jamar & Ozer 1986)
+(PID.TID 0000.0001)    = 2 : energy conserving scheme (no hFac weight)
+(PID.TID 0000.0001)    = 3 : energy conserving scheme using Wet-point averaging
 (PID.TID 0000.0001)     ;
 (PID.TID 0000.0001) momForcing =  /* Momentum forcing on/off flag */
+(PID.TID 0000.0001)                   T
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) momTidalForcing = /* Momentum Tidal forcing on/off flag */
 (PID.TID 0000.0001)                   T
 (PID.TID 0000.0001)     ;
 (PID.TID 0000.0001) momPressureForcing =  /* Momentum pressure term on/off flag */
@@ -1005,6 +1042,12 @@
 (PID.TID 0000.0001) writeBinaryPrec = /* Precision used for writing binary files */
 (PID.TID 0000.0001)                      32
 (PID.TID 0000.0001)     ;
+(PID.TID 0000.0001)  rwSuffixType =   /* select format of mds file suffix */
+(PID.TID 0000.0001)                       0
+(PID.TID 0000.0001)    = 0 : myIter (I10.10) ;   = 1 : 100*myTime (100th sec) ;
+(PID.TID 0000.0001)    = 2 : myTime (seconds);   = 3 : myTime/360 (10th of hr);
+(PID.TID 0000.0001)    = 4 : myTime/3600 (hours)
+(PID.TID 0000.0001)     ;
 (PID.TID 0000.0001)  globalFiles = /* write "global" (=not per tile) files */
 (PID.TID 0000.0001)                   F
 (PID.TID 0000.0001)     ;
@@ -1022,6 +1065,9 @@
 (PID.TID 0000.0001)    debLevD =  4 ; /* level of enhanced debug prt (add DEBUG_STATS prt) */
 (PID.TID 0000.0001)    debLevE =  5 ; /* level of extensive debug printing */
 (PID.TID 0000.0001) debugLevel =  /* select debug printing level */
+(PID.TID 0000.0001)                       1
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001)  plotLevel =  /* select PLOT_FIELD printing level */
 (PID.TID 0000.0001)                       1
 (PID.TID 0000.0001)     ;
 (PID.TID 0000.0001) //
@@ -1084,6 +1130,9 @@
 (PID.TID 0000.0001) abEps =   /* Adams-Bashforth-2 stabilizing weight */
 (PID.TID 0000.0001)                 1.000000000000000E-01
 (PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) applyExchUV_early = /* Apply EXCH to U,V earlier in time-step */
+(PID.TID 0000.0001)                   F
+(PID.TID 0000.0001)     ;
 (PID.TID 0000.0001) tauCD =   /* CD coupling time-scale ( s ) */
 (PID.TID 0000.0001)                 3.214280000000000E+05
 (PID.TID 0000.0001)     ;
@@ -1132,9 +1181,6 @@
 (PID.TID 0000.0001) pickup_read_mnc =   /* Model IO flag. */
 (PID.TID 0000.0001)                   F
 (PID.TID 0000.0001)     ;
-(PID.TID 0000.0001) pickup_write_immed =   /* Model IO flag. */
-(PID.TID 0000.0001)                   F
-(PID.TID 0000.0001)     ;
 (PID.TID 0000.0001) writePickupAtEnd =   /* Model IO flag. */
 (PID.TID 0000.0001)                   T
 (PID.TID 0000.0001)     ;
@@ -1151,10 +1197,10 @@
 (PID.TID 0000.0001)                   F
 (PID.TID 0000.0001)     ;
 (PID.TID 0000.0001) monitorFreq =   /* Monitor output interval ( s ). */
-(PID.TID 0000.0001)                 2.592000000000000E+06
+(PID.TID 0000.0001)                 8.640000000000000E+04
 (PID.TID 0000.0001)     ;
 (PID.TID 0000.0001) monitorSelect = /* select group of variables to monitor */
-(PID.TID 0000.0001)                       3
+(PID.TID 0000.0001)                       2
 (PID.TID 0000.0001)     ;
 (PID.TID 0000.0001) monitor_stdio =   /* Model IO flag. */
 (PID.TID 0000.0001)                   T
@@ -1192,11 +1238,20 @@
 (PID.TID 0000.0001) usingCurvilinearGrid = /* Curvilinear coordinates flag ( True/False ) */
 (PID.TID 0000.0001)                   F
 (PID.TID 0000.0001)     ;
-(PID.TID 0000.0001) selectSigmaCoord = /* Hybrid-Sigma Vert. Coordinate option */
+(PID.TID 0000.0001) useMin4hFacEdges = /* set hFacW,S as minimum of adjacent hFacC factor */
+(PID.TID 0000.0001)                   F
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) interViscAr_pCell = /* account for partial-cell in interior vert. viscosity */
+(PID.TID 0000.0001)                   F
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) interDiffKr_pCell = /* account for partial-cell in interior vert. diffusion */
+(PID.TID 0000.0001)                   F
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) pCellMix_select = /* option to enhance mixing near surface & bottom */
 (PID.TID 0000.0001)                       0
 (PID.TID 0000.0001)     ;
-(PID.TID 0000.0001) Ro_SeaLevel = /* r(1) ( units of r ==  m ) */
-(PID.TID 0000.0001)                 0.000000000000000E+00
+(PID.TID 0000.0001) selectSigmaCoord = /* Hybrid-Sigma Vert. Coordinate option */
+(PID.TID 0000.0001)                       0
 (PID.TID 0000.0001)     ;
 (PID.TID 0000.0001) rSigmaBnd = /* r/sigma transition ( units of r ==  m ) */
 (PID.TID 0000.0001)                 1.234567000000000E+05
@@ -1206,6 +1261,12 @@
 (PID.TID 0000.0001)     ;
 (PID.TID 0000.0001) gravitySign = /* gravity orientation relative to vertical coordinate */
 (PID.TID 0000.0001)                -1.000000000000000E+00
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) seaLev_Z =  /* reference height of sea-level [m] */
+(PID.TID 0000.0001)                 0.000000000000000E+00
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) top_Pres =  /* reference pressure at the top [Pa] */
+(PID.TID 0000.0001)                 0.000000000000000E+00
 (PID.TID 0000.0001)     ;
 (PID.TID 0000.0001) mass2rUnit = /* convert mass per unit area [kg/m2] to r-units [m] */
 (PID.TID 0000.0001)                 9.661835748792270E-04
@@ -1817,8 +1878,13 @@
 (PID.TID 0000.0001) subMeso_Lmax = /* maximum grid-scale length [m] */
 (PID.TID 0000.0001)                 1.100000000000000E+05
 (PID.TID 0000.0001)     ;
-(PID.TID 0000.0001) CTRL_CHECK: ctrl package
-(PID.TID 0000.0001) COST_CHECK: cost package
+(PID.TID 0000.0001) GM_useLeithQG = /* if TRUE => add QG Leith viscosity to GMRedi tensor */
+(PID.TID 0000.0001)                   F
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) CTRL_CHECK:  --> Starts to check CTRL set-up
+(PID.TID 0000.0001) CTRL_CHECK:  <-- Ends Normally
+(PID.TID 0000.0001) 
+(PID.TID 0000.0001) COST_CHECK: #define ALLOW_COST
 (PID.TID 0000.0001) GRDCHK_CHECK: grdchk package
 (PID.TID 0000.0001) GAD_CHECK: #define ALLOW_GENERIC_ADVDIFF
 (PID.TID 0000.0001) // =======================================================
@@ -1864,41 +1930,9 @@
 (PID.TID 0000.0001) %MON dynstat_salt_mean            =   3.4718006161475E+01
 (PID.TID 0000.0001) %MON dynstat_salt_sd              =   2.9628819587990E-01
 (PID.TID 0000.0001) %MON dynstat_salt_del2            =   1.0127003139695E-03
-(PID.TID 0000.0001) %MON dynstat_sst_max              =   2.9733388900757E+01
-(PID.TID 0000.0001) %MON dynstat_sst_min              =  -1.9000000000000E+00
-(PID.TID 0000.0001) %MON dynstat_sst_mean             =   1.8484768169451E+01
-(PID.TID 0000.0001) %MON dynstat_sst_sd               =   9.1795873467430E+00
-(PID.TID 0000.0001) %MON dynstat_sst_del2             =   2.7217991810411E-02
-(PID.TID 0000.0001) %MON dynstat_sss_max              =   3.7475627899170E+01
-(PID.TID 0000.0001) %MON dynstat_sss_min              =   2.9752769470215E+01
-(PID.TID 0000.0001) %MON dynstat_sss_mean             =   3.4849925275207E+01
-(PID.TID 0000.0001) %MON dynstat_sss_sd               =   9.6344930396289E-01
-(PID.TID 0000.0001) %MON dynstat_sss_del2             =   8.0490524880020E-03
-(PID.TID 0000.0001) %MON forcing_qnet_max             =   4.4161361694336E+02
-(PID.TID 0000.0001) %MON forcing_qnet_min             =  -1.8132531738281E+02
-(PID.TID 0000.0001) %MON forcing_qnet_mean            =  -1.6512526001044E+01
-(PID.TID 0000.0001) %MON forcing_qnet_sd              =   1.0987288293460E+02
-(PID.TID 0000.0001) %MON forcing_qnet_del2            =   1.0245701543512E+00
-(PID.TID 0000.0001) %MON forcing_qsw_max              =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON forcing_qsw_min              =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON forcing_qsw_mean             =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON forcing_qsw_sd               =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON forcing_qsw_del2             =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON forcing_empmr_max            =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON forcing_empmr_min            =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON forcing_empmr_mean           =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON forcing_empmr_sd             =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON forcing_empmr_del2           =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON forcing_fu_max               =   2.7877888083458E-01
-(PID.TID 0000.0001) %MON forcing_fu_min               =  -1.7088057100773E-01
-(PID.TID 0000.0001) %MON forcing_fu_mean              =   1.6001735152566E-02
-(PID.TID 0000.0001) %MON forcing_fu_sd                =   9.1062350670783E-02
-(PID.TID 0000.0001) %MON forcing_fu_del2              =   7.2483493833855E-04
-(PID.TID 0000.0001) %MON forcing_fv_max               =   2.3312132060528E-01
-(PID.TID 0000.0001) %MON forcing_fv_min               =  -1.7813690006733E-01
-(PID.TID 0000.0001) %MON forcing_fv_mean              =  -5.2588977395051E-03
-(PID.TID 0000.0001) %MON forcing_fv_sd                =   4.8248606070107E-02
-(PID.TID 0000.0001) %MON forcing_fv_del2              =   4.9948324922575E-04
+(PID.TID 0000.0001) %MON trAdv_CFL_u_max              =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON trAdv_CFL_v_max              =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON trAdv_CFL_w_max              =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON advcfl_uvel_max              =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON advcfl_vvel_max              =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON advcfl_wvel_max              =   0.0000000000000E+00
@@ -1921,40 +1955,238 @@
  EXTERNAL_FIELDS_LOAD, it=         0 : Reading new data, i0,i1=   12    1 (prev=   12    0 )
 (PID.TID 0000.0001) SOLVE_FOR_PRESSURE: putPmEinXvector =    F
  cg2d: Sum(rhs),rhsMax =   1.05956909912663E-14  2.53674886388737E+00
- cg2d: Sum(rhs),rhsMax =  -9.29811783123569E-16  5.04325900480939E+00
- cg2d: Sum(rhs),rhsMax =  -1.94913529760754E-14  6.29008403763971E+00
- cg2d: Sum(rhs),rhsMax =  -5.78946612872500E-14  6.70003306073551E+00
+ cg2d: Sum(rhs),rhsMax =  -1.15185638804860E-15  5.04325900480939E+00
+(PID.TID 0000.0001)      cg2d_init_res =   3.36819573987926E+00
+(PID.TID 0000.0001)      cg2d_iters(min,last) =      -1      36
+(PID.TID 0000.0001)      cg2d_last_res =   4.72603213756132E-20
+(PID.TID 0000.0001) // =======================================================
+(PID.TID 0000.0001) // Begin MONITOR dynamic field statistics
+(PID.TID 0000.0001) // =======================================================
+(PID.TID 0000.0001) %MON time_tsnumber                =                     2
+(PID.TID 0000.0001) %MON time_secondsf                =   8.6400000000000E+04
+(PID.TID 0000.0001) %MON dynstat_eta_max              =   3.7801774105274E-01
+(PID.TID 0000.0001) %MON dynstat_eta_min              =  -2.5442413411575E-01
+(PID.TID 0000.0001) %MON dynstat_eta_mean             =  -5.7690067231264E-18
+(PID.TID 0000.0001) %MON dynstat_eta_sd               =   6.0204479085973E-02
+(PID.TID 0000.0001) %MON dynstat_eta_del2             =   2.2874265953536E-03
+(PID.TID 0000.0001) %MON dynstat_uvel_max             =   1.8891126566953E-02
+(PID.TID 0000.0001) %MON dynstat_uvel_min             =  -1.7242415708016E-02
+(PID.TID 0000.0001) %MON dynstat_uvel_mean            =  -8.8944578754593E-04
+(PID.TID 0000.0001) %MON dynstat_uvel_sd              =   2.1243052636259E-03
+(PID.TID 0000.0001) %MON dynstat_uvel_del2            =   2.3141625125843E-05
+(PID.TID 0000.0001) %MON dynstat_vvel_max             =   3.3406292931411E-02
+(PID.TID 0000.0001) %MON dynstat_vvel_min             =  -1.7994571139087E-02
+(PID.TID 0000.0001) %MON dynstat_vvel_mean            =   1.7505325745996E-03
+(PID.TID 0000.0001) %MON dynstat_vvel_sd              =   6.1903921924015E-03
+(PID.TID 0000.0001) %MON dynstat_vvel_del2            =   2.8851036604616E-05
+(PID.TID 0000.0001) %MON dynstat_wvel_max             =   2.0881245119247E-04
+(PID.TID 0000.0001) %MON dynstat_wvel_min             =  -1.4685952519113E-04
+(PID.TID 0000.0001) %MON dynstat_wvel_mean            =  -1.1671338524540E-21
+(PID.TID 0000.0001) %MON dynstat_wvel_sd              =   2.4143621261042E-05
+(PID.TID 0000.0001) %MON dynstat_wvel_del2            =   2.9138609751269E-07
+(PID.TID 0000.0001) %MON dynstat_theta_max            =   2.9678646889493E+01
+(PID.TID 0000.0001) %MON dynstat_theta_min            =  -1.9016727707239E+00
+(PID.TID 0000.0001) %MON dynstat_theta_mean           =   3.6189381779999E+00
+(PID.TID 0000.0001) %MON dynstat_theta_sd             =   4.4154222862262E+00
+(PID.TID 0000.0001) %MON dynstat_theta_del2           =   5.5157879665219E-03
+(PID.TID 0000.0001) %MON dynstat_salt_max             =   3.7465356199095E+01
+(PID.TID 0000.0001) %MON dynstat_salt_min             =   2.9756623562822E+01
+(PID.TID 0000.0001) %MON dynstat_salt_mean            =   3.4717943185031E+01
+(PID.TID 0000.0001) %MON dynstat_salt_sd              =   2.9610617170209E-01
+(PID.TID 0000.0001) %MON dynstat_salt_del2            =   1.0206468323167E-03
+(PID.TID 0000.0001) %MON trAdv_CFL_u_max              =   2.7444977268794E-03
+(PID.TID 0000.0001) %MON trAdv_CFL_v_max              =   1.8885517877413E-03
+(PID.TID 0000.0001) %MON trAdv_CFL_w_max              =   1.2840985316018E-01
+(PID.TID 0000.0001) %MON advcfl_uvel_max              =   5.0226154859023E-03
+(PID.TID 0000.0001) %MON advcfl_vvel_max              =   3.2451534720241E-03
+(PID.TID 0000.0001) %MON advcfl_wvel_max              =   2.8752584079558E-01
+(PID.TID 0000.0001) %MON advcfl_W_hf_max              =   1.4915123266219E-01
+(PID.TID 0000.0001) %MON pe_b_mean                    =   4.6380860977297E-06
+(PID.TID 0000.0001) %MON ke_max                       =   3.9750126324262E-04
+(PID.TID 0000.0001) %MON ke_mean                      =   2.0989275005882E-05
+(PID.TID 0000.0001) %MON ke_vol                       =   1.3226782436723E+18
+(PID.TID 0000.0001) %MON vort_r_min                   =  -1.0400172285883E-07
+(PID.TID 0000.0001) %MON vort_r_max                   =   1.2612267171956E-07
+(PID.TID 0000.0001) %MON vort_a_mean                  =  -2.5205769283946E-05
+(PID.TID 0000.0001) %MON vort_a_sd                    =   7.3403114614120E-05
+(PID.TID 0000.0001) %MON vort_p_mean                  =  -3.1758669419511E-05
+(PID.TID 0000.0001) %MON vort_p_sd                    =   1.3126589427123E-04
+(PID.TID 0000.0001) %MON surfExpan_theta_mean         =   8.3024294304498E-05
+(PID.TID 0000.0001) %MON surfExpan_salt_mean          =   6.6180314817953E-06
+(PID.TID 0000.0001) // =======================================================
+(PID.TID 0000.0001) // End MONITOR dynamic field statistics
+(PID.TID 0000.0001) // =======================================================
+ cg2d: Sum(rhs),rhsMax =  -5.10043396406701E-14  6.29008403763954E+00
+ cg2d: Sum(rhs),rhsMax =   4.86659323950533E-14  6.70003306073569E+00
+(PID.TID 0000.0001)      cg2d_init_res =   1.87275603038141E+00
+(PID.TID 0000.0001)      cg2d_iters(min,last) =      -1      36
+(PID.TID 0000.0001)      cg2d_last_res =   5.46089734381062E-20
+(PID.TID 0000.0001) // =======================================================
+(PID.TID 0000.0001) // Begin MONITOR dynamic field statistics
+(PID.TID 0000.0001) // =======================================================
+(PID.TID 0000.0001) %MON time_tsnumber                =                     4
+(PID.TID 0000.0001) %MON time_secondsf                =   1.7280000000000E+05
+(PID.TID 0000.0001) %MON dynstat_eta_max              =   5.8496771725807E-01
+(PID.TID 0000.0001) %MON dynstat_eta_min              =  -4.8994750021282E-01
+(PID.TID 0000.0001) %MON dynstat_eta_mean             =   1.8252233404906E-17
+(PID.TID 0000.0001) %MON dynstat_eta_sd               =   1.2168470902780E-01
+(PID.TID 0000.0001) %MON dynstat_eta_del2             =   2.9494651408836E-03
+(PID.TID 0000.0001) %MON dynstat_uvel_max             =   4.2629915149354E-02
+(PID.TID 0000.0001) %MON dynstat_uvel_min             =  -4.2512701955552E-02
+(PID.TID 0000.0001) %MON dynstat_uvel_mean            =  -2.3370404210283E-03
+(PID.TID 0000.0001) %MON dynstat_uvel_sd              =   4.0261162313369E-03
+(PID.TID 0000.0001) %MON dynstat_uvel_del2            =   4.7406854803217E-05
+(PID.TID 0000.0001) %MON dynstat_vvel_max             =   5.1624397417113E-02
+(PID.TID 0000.0001) %MON dynstat_vvel_min             =  -3.5456974498627E-02
+(PID.TID 0000.0001) %MON dynstat_vvel_mean            =   3.1962471453806E-03
+(PID.TID 0000.0001) %MON dynstat_vvel_sd              =   1.0312808344268E-02
+(PID.TID 0000.0001) %MON dynstat_vvel_del2            =   5.9793773811553E-05
+(PID.TID 0000.0001) %MON dynstat_wvel_max             =   1.9706938614065E-04
+(PID.TID 0000.0001) %MON dynstat_wvel_min             =  -1.9619512296597E-04
+(PID.TID 0000.0001) %MON dynstat_wvel_mean            =   1.9540538027333E-21
+(PID.TID 0000.0001) %MON dynstat_wvel_sd              =   2.8047412065753E-05
+(PID.TID 0000.0001) %MON dynstat_wvel_del2            =   2.5108140951239E-07
+(PID.TID 0000.0001) %MON dynstat_theta_max            =   2.9645873194189E+01
+(PID.TID 0000.0001) %MON dynstat_theta_min            =  -1.9206080316285E+00
+(PID.TID 0000.0001) %MON dynstat_theta_mean           =   3.6163785043410E+00
+(PID.TID 0000.0001) %MON dynstat_theta_sd             =   4.4100884547553E+00
+(PID.TID 0000.0001) %MON dynstat_theta_del2           =   5.3743705803124E-03
+(PID.TID 0000.0001) %MON dynstat_salt_max             =   3.7457616070424E+01
+(PID.TID 0000.0001) %MON dynstat_salt_min             =   2.9762702431823E+01
+(PID.TID 0000.0001) %MON dynstat_salt_mean            =   3.4717726655502E+01
+(PID.TID 0000.0001) %MON dynstat_salt_sd              =   2.9612541609774E-01
+(PID.TID 0000.0001) %MON dynstat_salt_del2            =   1.0162880189411E-03
+(PID.TID 0000.0001) %MON trAdv_CFL_u_max              =   7.4439105816517E-03
+(PID.TID 0000.0001) %MON trAdv_CFL_v_max              =   4.5506406165286E-03
+(PID.TID 0000.0001) %MON trAdv_CFL_w_max              =   1.0480012906039E-01
+(PID.TID 0000.0001) %MON advcfl_uvel_max              =   8.7660980271049E-03
+(PID.TID 0000.0001) %MON advcfl_vvel_max              =   5.0148962311761E-03
+(PID.TID 0000.0001) %MON advcfl_wvel_max              =   2.3599463665017E-01
+(PID.TID 0000.0001) %MON advcfl_W_hf_max              =   1.1819181155376E-01
+(PID.TID 0000.0001) %MON pe_b_mean                    =   1.8947556732029E-05
+(PID.TID 0000.0001) %MON ke_max                       =   1.1655787739935E-03
+(PID.TID 0000.0001) %MON ke_mean                      =   6.2179020182627E-05
+(PID.TID 0000.0001) %MON ke_vol                       =   1.3226782436723E+18
+(PID.TID 0000.0001) %MON vort_r_min                   =  -2.0216007593326E-07
+(PID.TID 0000.0001) %MON vort_r_max                   =   2.2693374161035E-07
+(PID.TID 0000.0001) %MON vort_a_mean                  =  -2.5205769302465E-05
+(PID.TID 0000.0001) %MON vort_a_sd                    =   7.3402831168457E-05
+(PID.TID 0000.0001) %MON vort_p_mean                  =  -3.1758669442844E-05
+(PID.TID 0000.0001) %MON vort_p_sd                    =   1.3126526380848E-04
+(PID.TID 0000.0001) %MON surfExpan_theta_mean         =   1.3217658437323E-04
+(PID.TID 0000.0001) %MON surfExpan_salt_mean          =   1.1031313674778E-05
+(PID.TID 0000.0001) // =======================================================
+(PID.TID 0000.0001) // End MONITOR dynamic field statistics
+(PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) %CHECKPOINT         4 ckptA
-  early fc =  0.000000000000000D+00
+(PID.TID 0000.0001)   early fc =  0.000000000000000D+00
  --> objf_test(bi,bj)   =  0.804687744759401D+06
- --> objf_tracer(bi,bj) =  0.000000000000000D+00
- --> objf_atl(bi,bj)    =  0.000000000000000D+00
-  local fc =  0.804687744759401D+06
- global fc =  0.804687744759401D+06
+(PID.TID 0000.0001)   local fc =  0.804687744759401D+06
+(PID.TID 0000.0001)  global fc =  0.804687744759401D+06
  EXTERNAL_FIELDS_LOAD, it=         0 : Reading new data, i0,i1=   12    1 (prev=   12    1 )
 (PID.TID 0000.0001) SOLVE_FOR_PRESSURE: putPmEinXvector =    F
  cg2d: Sum(rhs),rhsMax =   1.05956909912663E-14  2.53674886388737E+00
- cg2d: Sum(rhs),rhsMax =  -9.29811783123569E-16  5.04325900480939E+00
- cg2d: Sum(rhs),rhsMax =  -1.94913529760754E-14  6.29008403763971E+00
- cg2d: Sum(rhs),rhsMax =  -5.78946612872500E-14  6.70003306073551E+00
+ cg2d: Sum(rhs),rhsMax =  -1.15185638804860E-15  5.04325900480939E+00
+ cg2d: Sum(rhs),rhsMax =  -5.10043396406701E-14  6.29008403763954E+00
+ cg2d: Sum(rhs),rhsMax =   4.86659323950533E-14  6.70003306073569E+00
 (PID.TID 0000.0001) Did not write pickup because writePickupAtEnd = FALSE
- cg2d: Sum(rhs),rhsMax =  -5.78946612872500E-14  6.70003306073551E+00
+ cg2d: Sum(rhs),rhsMax =   4.86659323950533E-14  6.70003306073569E+00
 (PID.TID 0000.0001) Did not write pickup because writePickupAtEnd = FALSE
 (PID.TID 0000.0001) Did not write pickup because writePickupAtEnd = FALSE
+(PID.TID 0000.0001) // =======================================================
+(PID.TID 0000.0001) // Begin AD_MONITOR dynamic field statistics
+(PID.TID 0000.0001) // =======================================================
+(PID.TID 0000.0001) %MON ad_time_tsnumber             =                     4
+(PID.TID 0000.0001) %MON ad_time_secondsf             =   1.7280000000000E+05
+(PID.TID 0000.0001) %MON ad_dynstat_adeta_max         =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON ad_dynstat_adeta_min         =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON ad_dynstat_adeta_mean        =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON ad_dynstat_adeta_sd          =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON ad_dynstat_adeta_del2        =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON ad_dynstat_aduvel_max        =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON ad_dynstat_aduvel_min        =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON ad_dynstat_aduvel_mean       =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON ad_dynstat_aduvel_sd         =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON ad_dynstat_aduvel_del2       =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON ad_dynstat_advvel_max        =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON ad_dynstat_advvel_min        =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON ad_dynstat_advvel_mean       =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON ad_dynstat_advvel_sd         =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON ad_dynstat_advvel_del2       =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON ad_dynstat_adwvel_max        =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON ad_dynstat_adwvel_min        =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON ad_dynstat_adwvel_mean       =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON ad_dynstat_adwvel_sd         =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON ad_dynstat_adwvel_del2       =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON ad_dynstat_adtheta_max       =   5.9291746388377E+01
+(PID.TID 0000.0001) %MON ad_dynstat_adtheta_min       =  -3.8024197906327E+00
+(PID.TID 0000.0001) %MON ad_dynstat_adtheta_mean      =   4.8245755940932E-01
+(PID.TID 0000.0001) %MON ad_dynstat_adtheta_sd        =   4.6884307335535E+00
+(PID.TID 0000.0001) %MON ad_dynstat_adtheta_del2      =   8.8096338546303E-03
+(PID.TID 0000.0001) %MON ad_dynstat_adsalt_max        =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON ad_dynstat_adsalt_min        =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON ad_dynstat_adsalt_mean       =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON ad_dynstat_adsalt_sd         =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON ad_dynstat_adsalt_del2       =   0.0000000000000E+00
+(PID.TID 0000.0001) // =======================================================
+(PID.TID 0000.0001) // End AD_MONITOR dynamic field statistics
+(PID.TID 0000.0001) // =======================================================
+ Calling cg2d from S/R CG2D_SAD
  cg2d: Sum(rhs),rhsMax =   0.00000000000000E+00  0.00000000000000E+00
  EXTERNAL_FIELDS_LOAD, it=         0 : Reading new data, i0,i1=   12    1 (prev=   12    1 )
 (PID.TID 0000.0001) SOLVE_FOR_PRESSURE: putPmEinXvector =    F
  cg2d: Sum(rhs),rhsMax =   1.05956909912663E-14  2.53674886388737E+00
- cg2d: Sum(rhs),rhsMax =  -9.29811783123569E-16  5.04325900480939E+00
- cg2d: Sum(rhs),rhsMax =  -1.94913529760754E-14  6.29008403763971E+00
- cg2d: Sum(rhs),rhsMax =   1.73456084565093E-15  7.86983807726851E-04
- cg2d: Sum(rhs),rhsMax =   1.30787308066926E-14  1.33029393421495E-03
- cg2d: Sum(rhs),rhsMax =  -1.37259995036665E-15  1.40191055720657E-03
+ cg2d: Sum(rhs),rhsMax =  -1.15185638804860E-15  5.04325900480939E+00
+ cg2d: Sum(rhs),rhsMax =  -5.10043396406701E-14  6.29008403763954E+00
+ Calling cg2d from S/R CG2D_SAD
+ cg2d: Sum(rhs),rhsMax =  -1.03261583311864E-14  7.86983807726830E-04
+(PID.TID 0000.0001) // =======================================================
+(PID.TID 0000.0001) // Begin AD_MONITOR dynamic field statistics
+(PID.TID 0000.0001) // =======================================================
+(PID.TID 0000.0001) %MON ad_time_tsnumber             =                     2
+(PID.TID 0000.0001) %MON ad_time_secondsf             =   8.6400000000000E+04
+(PID.TID 0000.0001) %MON ad_dynstat_adeta_max         =   6.3673953377848E+01
+(PID.TID 0000.0001) %MON ad_dynstat_adeta_min         =  -2.2878732433042E+01
+(PID.TID 0000.0001) %MON ad_dynstat_adeta_mean        =   6.8010820341981E-02
+(PID.TID 0000.0001) %MON ad_dynstat_adeta_sd          =   6.8233686763742E+00
+(PID.TID 0000.0001) %MON ad_dynstat_adeta_del2        =   2.8301420991010E-01
+(PID.TID 0000.0001) %MON ad_dynstat_aduvel_max        =   7.7653322362537E+01
+(PID.TID 0000.0001) %MON ad_dynstat_aduvel_min        =  -7.8753198967107E+01
+(PID.TID 0000.0001) %MON ad_dynstat_aduvel_mean       =  -1.5847448652989E+00
+(PID.TID 0000.0001) %MON ad_dynstat_aduvel_sd         =   1.0587610151857E+01
+(PID.TID 0000.0001) %MON ad_dynstat_aduvel_del2       =   6.4653246604227E-02
+(PID.TID 0000.0001) %MON ad_dynstat_advvel_max        =   1.5840779075806E+02
+(PID.TID 0000.0001) %MON ad_dynstat_advvel_min        =  -1.7191114512059E+02
+(PID.TID 0000.0001) %MON ad_dynstat_advvel_mean       =  -1.6241998514220E+00
+(PID.TID 0000.0001) %MON ad_dynstat_advvel_sd         =   2.6216739596418E+01
+(PID.TID 0000.0001) %MON ad_dynstat_advvel_del2       =   1.4915909728064E-01
+(PID.TID 0000.0001) %MON ad_dynstat_adwvel_max        =   1.7983938989145E+04
+(PID.TID 0000.0001) %MON ad_dynstat_adwvel_min        =  -2.2262847461829E+05
+(PID.TID 0000.0001) %MON ad_dynstat_adwvel_mean       =  -7.3033998585888E+02
+(PID.TID 0000.0001) %MON ad_dynstat_adwvel_sd         =   8.1341361286186E+03
+(PID.TID 0000.0001) %MON ad_dynstat_adwvel_del2       =   4.4695422301760E+01
+(PID.TID 0000.0001) %MON ad_dynstat_adtheta_max       =   7.5833391504053E+01
+(PID.TID 0000.0001) %MON ad_dynstat_adtheta_min       =  -4.1525354898429E+01
+(PID.TID 0000.0001) %MON ad_dynstat_adtheta_mean      =   4.7187967725433E-01
+(PID.TID 0000.0001) %MON ad_dynstat_adtheta_sd        =   4.5695083189871E+00
+(PID.TID 0000.0001) %MON ad_dynstat_adtheta_del2      =   1.6684315275265E-02
+(PID.TID 0000.0001) %MON ad_dynstat_adsalt_max        =   1.4448309853227E+02
+(PID.TID 0000.0001) %MON ad_dynstat_adsalt_min        =  -1.4320181175150E+02
+(PID.TID 0000.0001) %MON ad_dynstat_adsalt_mean       =   1.4162166902169E-02
+(PID.TID 0000.0001) %MON ad_dynstat_adsalt_sd         =   1.8817920709165E+00
+(PID.TID 0000.0001) %MON ad_dynstat_adsalt_del2       =   3.6516769974595E-02
+(PID.TID 0000.0001) // =======================================================
+(PID.TID 0000.0001) // End AD_MONITOR dynamic field statistics
+(PID.TID 0000.0001) // =======================================================
+ Calling cg2d from S/R CG2D_SAD
+ cg2d: Sum(rhs),rhsMax =  -6.61211536912010E-15  1.33029393421496E-03
+ Calling cg2d from S/R CG2D_SAD
+ cg2d: Sum(rhs),rhsMax =   5.01204980296599E-15  1.40191055720658E-03
 (PID.TID 0000.0001) Start initial hydrostatic pressure computation
 (PID.TID 0000.0001) Pressure is predetermined for buoyancyRelation OCEANIC
 (PID.TID 0000.0001) 
 (PID.TID 0000.0001) // =======================================================
-(PID.TID 0000.0001) // Begin MONITOR dynamic field statistics
+(PID.TID 0000.0001) // Begin AD_MONITOR dynamic field statistics
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) %MON ad_time_tsnumber             =                     0
 (PID.TID 0000.0001) %MON ad_time_secondsf             =   0.0000000000000E+00
@@ -1962,64 +2194,34 @@
 (PID.TID 0000.0001) %MON ad_dynstat_adeta_min         =  -4.3068281185577E+01
 (PID.TID 0000.0001) %MON ad_dynstat_adeta_mean        =   3.0864811552139E-01
 (PID.TID 0000.0001) %MON ad_dynstat_adeta_sd          =   1.6951595218077E+01
-(PID.TID 0000.0001) %MON ad_dynstat_adeta_del2        =   4.8323265865024E-01
-(PID.TID 0000.0001) %MON ad_dynstat_aduvel_max        =   5.5954280681864E+01
+(PID.TID 0000.0001) %MON ad_dynstat_adeta_del2        =   4.8323265865025E-01
+(PID.TID 0000.0001) %MON ad_dynstat_aduvel_max        =   5.5954280681837E+01
 (PID.TID 0000.0001) %MON ad_dynstat_aduvel_min        =  -1.0780668343557E+02
 (PID.TID 0000.0001) %MON ad_dynstat_aduvel_mean       =  -3.6363581261081E+00
 (PID.TID 0000.0001) %MON ad_dynstat_aduvel_sd         =   1.4356156918440E+01
-(PID.TID 0000.0001) %MON ad_dynstat_aduvel_del2       =   5.7258676444573E-02
+(PID.TID 0000.0001) %MON ad_dynstat_aduvel_del2       =   5.7258676444572E-02
 (PID.TID 0000.0001) %MON ad_dynstat_advvel_max        =   1.6191225597068E+02
 (PID.TID 0000.0001) %MON ad_dynstat_advvel_min        =  -1.5508690881795E+02
-(PID.TID 0000.0001) %MON ad_dynstat_advvel_mean       =  -3.5089813411514E+00
+(PID.TID 0000.0001) %MON ad_dynstat_advvel_mean       =  -3.5089813411513E+00
 (PID.TID 0000.0001) %MON ad_dynstat_advvel_sd         =   3.3429443019238E+01
 (PID.TID 0000.0001) %MON ad_dynstat_advvel_del2       =   1.0630213533164E-01
-(PID.TID 0000.0001) %MON ad_dynstat_adwvel_max        =   9.6291369464428E+03
-(PID.TID 0000.0001) %MON ad_dynstat_adwvel_min        =  -8.0212598087632E+04
+(PID.TID 0000.0001) %MON ad_dynstat_adwvel_max        =   9.6291369464420E+03
+(PID.TID 0000.0001) %MON ad_dynstat_adwvel_min        =  -8.0212598087631E+04
 (PID.TID 0000.0001) %MON ad_dynstat_adwvel_mean       =  -2.8566486397398E+02
 (PID.TID 0000.0001) %MON ad_dynstat_adwvel_sd         =   3.1351831455068E+03
 (PID.TID 0000.0001) %MON ad_dynstat_adwvel_del2       =   1.7209629792256E+01
-(PID.TID 0000.0001) %MON ad_dynstat_adtheta_max       =   8.2651719664676E+01
-(PID.TID 0000.0001) %MON ad_dynstat_adtheta_min       =  -4.8880614970974E+01
+(PID.TID 0000.0001) %MON ad_dynstat_adtheta_max       =   8.2651719664678E+01
+(PID.TID 0000.0001) %MON ad_dynstat_adtheta_min       =  -4.8880614970975E+01
 (PID.TID 0000.0001) %MON ad_dynstat_adtheta_mean      =   4.6180891894873E-01
 (PID.TID 0000.0001) %MON ad_dynstat_adtheta_sd        =   4.5299733854328E+00
 (PID.TID 0000.0001) %MON ad_dynstat_adtheta_del2      =   2.0428647971614E-02
-(PID.TID 0000.0001) %MON ad_dynstat_adsalt_max        =   1.7196765112889E+02
+(PID.TID 0000.0001) %MON ad_dynstat_adsalt_max        =   1.7196765112890E+02
 (PID.TID 0000.0001) %MON ad_dynstat_adsalt_min        =  -1.7060821975003E+02
 (PID.TID 0000.0001) %MON ad_dynstat_adsalt_mean       =   3.8434763110441E-02
 (PID.TID 0000.0001) %MON ad_dynstat_adsalt_sd         =   2.8167187528791E+00
-(PID.TID 0000.0001) %MON ad_dynstat_adsalt_del2       =   4.7705225892906E-02
-(PID.TID 0000.0001) %MON ad_dynstat_adsst_max         =   8.2651719664676E+01
-(PID.TID 0000.0001) %MON ad_dynstat_adsst_min         =  -3.6562234334533E+00
-(PID.TID 0000.0001) %MON ad_dynstat_adsst_mean        =   3.5225201180820E+01
-(PID.TID 0000.0001) %MON ad_dynstat_adsst_sd          =   1.7747800371256E+01
-(PID.TID 0000.0001) %MON ad_dynstat_adsst_del2        =   1.9384329002905E-01
-(PID.TID 0000.0001) %MON ad_dynstat_adsss_max         =   3.6292301866090E+01
-(PID.TID 0000.0001) %MON ad_dynstat_adsss_min         =  -1.7060821975003E+02
-(PID.TID 0000.0001) %MON ad_dynstat_adsss_mean        =  -3.4511622170179E-01
-(PID.TID 0000.0001) %MON ad_dynstat_adsss_sd          =   6.4015883269168E+00
-(PID.TID 0000.0001) %MON ad_dynstat_adsss_del2        =   3.8654377162560E-01
-(PID.TID 0000.0001) %MON ad_forcing_adqnet_max        =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON ad_forcing_adqnet_min        =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON ad_forcing_adqnet_mean       =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON ad_forcing_adqnet_sd         =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON ad_forcing_adqnet_del2       =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON ad_forcing_adempmr_max       =   2.5195521881915E+03
-(PID.TID 0000.0001) %MON ad_forcing_adempmr_min       =  -1.1738957059563E+04
-(PID.TID 0000.0001) %MON ad_forcing_adempmr_mean      =  -1.4265369061821E+01
-(PID.TID 0000.0001) %MON ad_forcing_adempmr_sd        =   4.3163518939887E+02
-(PID.TID 0000.0001) %MON ad_forcing_adempmr_del2      =   2.3357369077085E+01
-(PID.TID 0000.0001) %MON ad_forcing_adfu_max          =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON ad_forcing_adfu_min          =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON ad_forcing_adfu_mean         =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON ad_forcing_adfu_sd           =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON ad_forcing_adfu_del2         =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON ad_forcing_adfv_max          =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON ad_forcing_adfv_min          =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON ad_forcing_adfv_mean         =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON ad_forcing_adfv_sd           =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON ad_forcing_adfv_del2         =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON ad_dynstat_adsalt_del2       =   4.7705225892907E-02
 (PID.TID 0000.0001) // =======================================================
-(PID.TID 0000.0001) // End MONITOR dynamic field statistics
+(PID.TID 0000.0001) // End AD_MONITOR dynamic field statistics
 (PID.TID 0000.0001) // =======================================================
  ph-pack: packing ecco_cost
  ph-pack: packing ecco_ctrl
@@ -2047,16 +2249,14 @@ grad-res -------------------------------
  EXTERNAL_FIELDS_LOAD, it=         0 : Reading new data, i0,i1=   12    1 (prev=   12    0 )
 (PID.TID 0000.0001) SOLVE_FOR_PRESSURE: putPmEinXvector =    F
  cg2d: Sum(rhs),rhsMax =   1.06234465668820E-14  2.53674886388737E+00
- cg2d: Sum(rhs),rhsMax =   1.25732757538799E-14  5.04325900480939E+00
- cg2d: Sum(rhs),rhsMax =  -1.31734900765679E-14  6.29008403763971E+00
- cg2d: Sum(rhs),rhsMax =  -7.24940940610708E-14  6.70003306073551E+00
+ cg2d: Sum(rhs),rhsMax =  -4.85722573273506E-15  5.04325900480939E+00
+ cg2d: Sum(rhs),rhsMax =  -2.62220800628654E-14  6.29008403763954E+00
+ cg2d: Sum(rhs),rhsMax =   1.66290592407137E-14  6.70003306073569E+00
 (PID.TID 0000.0001) Did not write pickup because writePickupAtEnd = FALSE
-  early fc =  0.000000000000000D+00
+(PID.TID 0000.0001)   early fc =  0.000000000000000D+00
  --> objf_test(bi,bj)   =  0.804687708291728D+06
- --> objf_tracer(bi,bj) =  0.000000000000000D+00
- --> objf_atl(bi,bj)    =  0.000000000000000D+00
-  local fc =  0.804687708291728D+06
- global fc =  0.804687708291728D+06
+(PID.TID 0000.0001)   local fc =  0.804687708291728D+06
+(PID.TID 0000.0001)  global fc =  0.804687708291728D+06
 (PID.TID 0000.0001) grdchk perturb(+)fc: fcpertplus  =  8.04687708291728E+05
 (PID.TID 0000.0001) Start initial hydrostatic pressure computation
 (PID.TID 0000.0001) Pressure is predetermined for buoyancyRelation OCEANIC
@@ -2068,16 +2268,14 @@ grad-res -------------------------------
  EXTERNAL_FIELDS_LOAD, it=         0 : Reading new data, i0,i1=   12    1 (prev=   12    0 )
 (PID.TID 0000.0001) SOLVE_FOR_PRESSURE: putPmEinXvector =    F
  cg2d: Sum(rhs),rhsMax =   1.05956909912663E-14  2.53674886388737E+00
- cg2d: Sum(rhs),rhsMax =  -9.29811783123569E-16  5.04325900480939E+00
- cg2d: Sum(rhs),rhsMax =  -1.94913529760754E-14  6.29008403763971E+00
- cg2d: Sum(rhs),rhsMax =  -5.78946612872500E-14  6.70003306073551E+00
+ cg2d: Sum(rhs),rhsMax =  -1.15185638804860E-15  5.04325900480939E+00
+ cg2d: Sum(rhs),rhsMax =  -5.10043396406701E-14  6.29008403763954E+00
+ cg2d: Sum(rhs),rhsMax =   4.86659323950533E-14  6.70003306073569E+00
 (PID.TID 0000.0001) Did not write pickup because writePickupAtEnd = FALSE
-  early fc =  0.000000000000000D+00
+(PID.TID 0000.0001)   early fc =  0.000000000000000D+00
  --> objf_test(bi,bj)   =  0.804687744759401D+06
- --> objf_tracer(bi,bj) =  0.000000000000000D+00
- --> objf_atl(bi,bj)    =  0.000000000000000D+00
-  local fc =  0.804687744759401D+06
- global fc =  0.804687744759401D+06
+(PID.TID 0000.0001)   local fc =  0.804687744759401D+06
+(PID.TID 0000.0001)  global fc =  0.804687744759401D+06
 (PID.TID 0000.0001) grdchk perturb(-)fc: fcpertminus =  8.04687744759401E+05
 grad-res -------------------------------
  grad-res     0    1   73   39    1    1    1    1   8.04687744759E+05  8.04687708292E+05  8.04687744759E+05
@@ -2101,16 +2299,14 @@ grad-res -------------------------------
  EXTERNAL_FIELDS_LOAD, it=         0 : Reading new data, i0,i1=   12    1 (prev=   12    0 )
 (PID.TID 0000.0001) SOLVE_FOR_PRESSURE: putPmEinXvector =    F
  cg2d: Sum(rhs),rhsMax =   1.06234465668820E-14  2.53674886388737E+00
- cg2d: Sum(rhs),rhsMax =   1.29826704942104E-14  5.04325900480939E+00
- cg2d: Sum(rhs),rhsMax =  -1.90958360235527E-14  6.29008403763971E+00
- cg2d: Sum(rhs),rhsMax =  -6.09512440519211E-14  6.70003306073551E+00
+ cg2d: Sum(rhs),rhsMax =   8.04217803462848E-15  5.04325900480939E+00
+ cg2d: Sum(rhs),rhsMax =  -4.52346493595712E-14  6.29008403763954E+00
+ cg2d: Sum(rhs),rhsMax =   2.02199368359857E-14  6.70003306073569E+00
 (PID.TID 0000.0001) Did not write pickup because writePickupAtEnd = FALSE
-  early fc =  0.000000000000000D+00
+(PID.TID 0000.0001)   early fc =  0.000000000000000D+00
  --> objf_test(bi,bj)   =  0.804687708500864D+06
- --> objf_tracer(bi,bj) =  0.000000000000000D+00
- --> objf_atl(bi,bj)    =  0.000000000000000D+00
-  local fc =  0.804687708500864D+06
- global fc =  0.804687708500864D+06
+(PID.TID 0000.0001)   local fc =  0.804687708500864D+06
+(PID.TID 0000.0001)  global fc =  0.804687708500864D+06
 (PID.TID 0000.0001) grdchk perturb(+)fc: fcpertplus  =  8.04687708500864E+05
 (PID.TID 0000.0001) Start initial hydrostatic pressure computation
 (PID.TID 0000.0001) Pressure is predetermined for buoyancyRelation OCEANIC
@@ -2122,16 +2318,14 @@ grad-res -------------------------------
  EXTERNAL_FIELDS_LOAD, it=         0 : Reading new data, i0,i1=   12    1 (prev=   12    0 )
 (PID.TID 0000.0001) SOLVE_FOR_PRESSURE: putPmEinXvector =    F
  cg2d: Sum(rhs),rhsMax =   1.05956909912663E-14  2.53674886388737E+00
- cg2d: Sum(rhs),rhsMax =  -9.29811783123569E-16  5.04325900480939E+00
- cg2d: Sum(rhs),rhsMax =  -1.94913529760754E-14  6.29008403763971E+00
- cg2d: Sum(rhs),rhsMax =  -5.78946612872500E-14  6.70003306073551E+00
+ cg2d: Sum(rhs),rhsMax =  -1.15185638804860E-15  5.04325900480939E+00
+ cg2d: Sum(rhs),rhsMax =  -5.10043396406701E-14  6.29008403763954E+00
+ cg2d: Sum(rhs),rhsMax =   4.86659323950533E-14  6.70003306073569E+00
 (PID.TID 0000.0001) Did not write pickup because writePickupAtEnd = FALSE
-  early fc =  0.000000000000000D+00
+(PID.TID 0000.0001)   early fc =  0.000000000000000D+00
  --> objf_test(bi,bj)   =  0.804687744759401D+06
- --> objf_tracer(bi,bj) =  0.000000000000000D+00
- --> objf_atl(bi,bj)    =  0.000000000000000D+00
-  local fc =  0.804687744759401D+06
- global fc =  0.804687744759401D+06
+(PID.TID 0000.0001)   local fc =  0.804687744759401D+06
+(PID.TID 0000.0001)  global fc =  0.804687744759401D+06
 (PID.TID 0000.0001) grdchk perturb(-)fc: fcpertminus =  8.04687744759401E+05
 grad-res -------------------------------
  grad-res     0    2   74   39    1    1    1    1   8.04687744759E+05  8.04687708501E+05  8.04687744759E+05
@@ -2155,16 +2349,14 @@ grad-res -------------------------------
  EXTERNAL_FIELDS_LOAD, it=         0 : Reading new data, i0,i1=   12    1 (prev=   12    0 )
 (PID.TID 0000.0001) SOLVE_FOR_PRESSURE: putPmEinXvector =    F
  cg2d: Sum(rhs),rhsMax =   1.06234465668820E-14  2.53674886388737E+00
- cg2d: Sum(rhs),rhsMax =   1.34059430223488E-14  5.04325900480939E+00
- cg2d: Sum(rhs),rhsMax =  -2.10213790818869E-14  6.29008403763971E+00
- cg2d: Sum(rhs),rhsMax =  -5.99000016254791E-14  6.70003306073551E+00
+ cg2d: Sum(rhs),rhsMax =  -5.82867087928207E-16  5.04325900480939E+00
+ cg2d: Sum(rhs),rhsMax =  -1.62266033942871E-14  6.29008403763954E+00
+ cg2d: Sum(rhs),rhsMax =   1.70939651322755E-14  6.70003306073569E+00
 (PID.TID 0000.0001) Did not write pickup because writePickupAtEnd = FALSE
-  early fc =  0.000000000000000D+00
+(PID.TID 0000.0001)   early fc =  0.000000000000000D+00
  --> objf_test(bi,bj)   =  0.804687708506845D+06
- --> objf_tracer(bi,bj) =  0.000000000000000D+00
- --> objf_atl(bi,bj)    =  0.000000000000000D+00
-  local fc =  0.804687708506845D+06
- global fc =  0.804687708506845D+06
+(PID.TID 0000.0001)   local fc =  0.804687708506845D+06
+(PID.TID 0000.0001)  global fc =  0.804687708506845D+06
 (PID.TID 0000.0001) grdchk perturb(+)fc: fcpertplus  =  8.04687708506845E+05
 (PID.TID 0000.0001) Start initial hydrostatic pressure computation
 (PID.TID 0000.0001) Pressure is predetermined for buoyancyRelation OCEANIC
@@ -2176,16 +2368,14 @@ grad-res -------------------------------
  EXTERNAL_FIELDS_LOAD, it=         0 : Reading new data, i0,i1=   12    1 (prev=   12    0 )
 (PID.TID 0000.0001) SOLVE_FOR_PRESSURE: putPmEinXvector =    F
  cg2d: Sum(rhs),rhsMax =   1.05956909912663E-14  2.53674886388737E+00
- cg2d: Sum(rhs),rhsMax =  -9.29811783123569E-16  5.04325900480939E+00
- cg2d: Sum(rhs),rhsMax =  -1.94913529760754E-14  6.29008403763971E+00
- cg2d: Sum(rhs),rhsMax =  -5.78946612872500E-14  6.70003306073551E+00
+ cg2d: Sum(rhs),rhsMax =  -1.15185638804860E-15  5.04325900480939E+00
+ cg2d: Sum(rhs),rhsMax =  -5.10043396406701E-14  6.29008403763954E+00
+ cg2d: Sum(rhs),rhsMax =   4.86659323950533E-14  6.70003306073569E+00
 (PID.TID 0000.0001) Did not write pickup because writePickupAtEnd = FALSE
-  early fc =  0.000000000000000D+00
+(PID.TID 0000.0001)   early fc =  0.000000000000000D+00
  --> objf_test(bi,bj)   =  0.804687744759401D+06
- --> objf_tracer(bi,bj) =  0.000000000000000D+00
- --> objf_atl(bi,bj)    =  0.000000000000000D+00
-  local fc =  0.804687744759401D+06
- global fc =  0.804687744759401D+06
+(PID.TID 0000.0001)   local fc =  0.804687744759401D+06
+(PID.TID 0000.0001)  global fc =  0.804687744759401D+06
 (PID.TID 0000.0001) grdchk perturb(-)fc: fcpertminus =  8.04687744759401E+05
 grad-res -------------------------------
  grad-res     0    3   75   39    1    1    1    1   8.04687744759E+05  8.04687708507E+05  8.04687744759E+05
@@ -2209,16 +2399,14 @@ grad-res -------------------------------
  EXTERNAL_FIELDS_LOAD, it=         0 : Reading new data, i0,i1=   12    1 (prev=   12    0 )
 (PID.TID 0000.0001) SOLVE_FOR_PRESSURE: putPmEinXvector =    F
  cg2d: Sum(rhs),rhsMax =   1.06234465668820E-14  2.53674886388737E+00
- cg2d: Sum(rhs),rhsMax =  -8.32667268468867E-17  5.04325900480939E+00
- cg2d: Sum(rhs),rhsMax =  -2.22183382803109E-14  6.29008403763971E+00
- cg2d: Sum(rhs),rhsMax =  -5.94559124156291E-14  6.70003306073551E+00
+ cg2d: Sum(rhs),rhsMax =  -6.74460487459783E-15  5.04325900480939E+00
+ cg2d: Sum(rhs),rhsMax =  -3.15442116871623E-14  6.29008403763954E+00
+ cg2d: Sum(rhs),rhsMax =   2.85362011798185E-14  6.70003306073569E+00
 (PID.TID 0000.0001) Did not write pickup because writePickupAtEnd = FALSE
-  early fc =  0.000000000000000D+00
+(PID.TID 0000.0001)   early fc =  0.000000000000000D+00
  --> objf_test(bi,bj)   =  0.804687712788332D+06
- --> objf_tracer(bi,bj) =  0.000000000000000D+00
- --> objf_atl(bi,bj)    =  0.000000000000000D+00
-  local fc =  0.804687712788332D+06
- global fc =  0.804687712788332D+06
+(PID.TID 0000.0001)   local fc =  0.804687712788332D+06
+(PID.TID 0000.0001)  global fc =  0.804687712788332D+06
 (PID.TID 0000.0001) grdchk perturb(+)fc: fcpertplus  =  8.04687712788332E+05
 (PID.TID 0000.0001) Start initial hydrostatic pressure computation
 (PID.TID 0000.0001) Pressure is predetermined for buoyancyRelation OCEANIC
@@ -2230,16 +2418,14 @@ grad-res -------------------------------
  EXTERNAL_FIELDS_LOAD, it=         0 : Reading new data, i0,i1=   12    1 (prev=   12    0 )
 (PID.TID 0000.0001) SOLVE_FOR_PRESSURE: putPmEinXvector =    F
  cg2d: Sum(rhs),rhsMax =   1.05956909912663E-14  2.53674886388737E+00
- cg2d: Sum(rhs),rhsMax =  -9.29811783123569E-16  5.04325900480939E+00
- cg2d: Sum(rhs),rhsMax =  -1.94913529760754E-14  6.29008403763971E+00
- cg2d: Sum(rhs),rhsMax =  -5.78946612872500E-14  6.70003306073551E+00
+ cg2d: Sum(rhs),rhsMax =  -1.15185638804860E-15  5.04325900480939E+00
+ cg2d: Sum(rhs),rhsMax =  -5.10043396406701E-14  6.29008403763954E+00
+ cg2d: Sum(rhs),rhsMax =   4.86659323950533E-14  6.70003306073569E+00
 (PID.TID 0000.0001) Did not write pickup because writePickupAtEnd = FALSE
-  early fc =  0.000000000000000D+00
+(PID.TID 0000.0001)   early fc =  0.000000000000000D+00
  --> objf_test(bi,bj)   =  0.804687744759401D+06
- --> objf_tracer(bi,bj) =  0.000000000000000D+00
- --> objf_atl(bi,bj)    =  0.000000000000000D+00
-  local fc =  0.804687744759401D+06
- global fc =  0.804687744759401D+06
+(PID.TID 0000.0001)   local fc =  0.804687744759401D+06
+(PID.TID 0000.0001)  global fc =  0.804687744759401D+06
 (PID.TID 0000.0001) grdchk perturb(-)fc: fcpertminus =  8.04687744759401E+05
 grad-res -------------------------------
  grad-res     0    4   76   39    1    1    1    1   8.04687744759E+05  8.04687712788E+05  8.04687744759E+05
@@ -2263,16 +2449,14 @@ grad-res -------------------------------
  EXTERNAL_FIELDS_LOAD, it=         0 : Reading new data, i0,i1=   12    1 (prev=   12    0 )
 (PID.TID 0000.0001) SOLVE_FOR_PRESSURE: putPmEinXvector =    F
  cg2d: Sum(rhs),rhsMax =   1.05956909912663E-14  2.53674886388737E+00
- cg2d: Sum(rhs),rhsMax =   1.49602552568240E-14  5.04325900480939E+00
- cg2d: Sum(rhs),rhsMax =  -1.53939361258182E-14  6.29008403763971E+00
- cg2d: Sum(rhs),rhsMax =  -3.48401862915182E-14  6.70003306073551E+00
+ cg2d: Sum(rhs),rhsMax =  -1.13797860024079E-15  5.04325900480939E+00
+ cg2d: Sum(rhs),rhsMax =  -4.09151879043890E-14  6.29008403763954E+00
+ cg2d: Sum(rhs),rhsMax =   6.76160516466240E-14  6.70003306073569E+00
 (PID.TID 0000.0001) Did not write pickup because writePickupAtEnd = FALSE
-  early fc =  0.000000000000000D+00
+(PID.TID 0000.0001)   early fc =  0.000000000000000D+00
  --> objf_test(bi,bj)   =  0.804687749551412D+06
- --> objf_tracer(bi,bj) =  0.000000000000000D+00
- --> objf_atl(bi,bj)    =  0.000000000000000D+00
-  local fc =  0.804687749551412D+06
- global fc =  0.804687749551412D+06
+(PID.TID 0000.0001)   local fc =  0.804687749551412D+06
+(PID.TID 0000.0001)  global fc =  0.804687749551412D+06
 (PID.TID 0000.0001) grdchk perturb(+)fc: fcpertplus  =  8.04687749551412E+05
 (PID.TID 0000.0001) Start initial hydrostatic pressure computation
 (PID.TID 0000.0001) Pressure is predetermined for buoyancyRelation OCEANIC
@@ -2284,16 +2468,14 @@ grad-res -------------------------------
  EXTERNAL_FIELDS_LOAD, it=         0 : Reading new data, i0,i1=   12    1 (prev=   12    0 )
 (PID.TID 0000.0001) SOLVE_FOR_PRESSURE: putPmEinXvector =    F
  cg2d: Sum(rhs),rhsMax =   1.05956909912663E-14  2.53674886388737E+00
- cg2d: Sum(rhs),rhsMax =   1.18377530000657E-14  5.04325900480939E+00
- cg2d: Sum(rhs),rhsMax =  -1.20944920745103E-14  6.29008403763971E+00
- cg2d: Sum(rhs),rhsMax =  -4.83744988510892E-14  6.70003306073551E+00
+ cg2d: Sum(rhs),rhsMax =  -3.92741394961149E-15  5.04325900480939E+00
+ cg2d: Sum(rhs),rhsMax =  -1.54980195343768E-14  6.29008403763954E+00
+ cg2d: Sum(rhs),rhsMax =   3.43371164834849E-14  6.70003306073569E+00
 (PID.TID 0000.0001) Did not write pickup because writePickupAtEnd = FALSE
-  early fc =  0.000000000000000D+00
+(PID.TID 0000.0001)   early fc =  0.000000000000000D+00
  --> objf_test(bi,bj)   =  0.804687740147925D+06
- --> objf_tracer(bi,bj) =  0.000000000000000D+00
- --> objf_atl(bi,bj)    =  0.000000000000000D+00
-  local fc =  0.804687740147925D+06
- global fc =  0.804687740147925D+06
+(PID.TID 0000.0001)   local fc =  0.804687740147925D+06
+(PID.TID 0000.0001)  global fc =  0.804687740147925D+06
 (PID.TID 0000.0001) grdchk perturb(-)fc: fcpertminus =  8.04687740147925E+05
 grad-res -------------------------------
  grad-res     0    5   85   39    1    1    1    1   8.04687744759E+05  8.04687749551E+05  8.04687740148E+05
@@ -2317,16 +2499,14 @@ grad-res -------------------------------
  EXTERNAL_FIELDS_LOAD, it=         0 : Reading new data, i0,i1=   12    1 (prev=   12    0 )
 (PID.TID 0000.0001) SOLVE_FOR_PRESSURE: putPmEinXvector =    F
  cg2d: Sum(rhs),rhsMax =   1.06234465668820E-14  2.53674886388737E+00
- cg2d: Sum(rhs),rhsMax =   7.74380559676047E-15  5.04325900480939E+00
- cg2d: Sum(rhs),rhsMax =  -1.41796296926344E-14  6.29008403763971E+00
- cg2d: Sum(rhs),rhsMax =  -2.16354711923827E-14  6.70003306073551E+00
+ cg2d: Sum(rhs),rhsMax =   4.85722573273506E-15  5.04325900480939E+00
+ cg2d: Sum(rhs),rhsMax =  -3.17766646329432E-14  6.29008403763954E+00
+ cg2d: Sum(rhs),rhsMax =   6.47572273582142E-14  6.70003306073569E+00
 (PID.TID 0000.0001) Did not write pickup because writePickupAtEnd = FALSE
-  early fc =  0.000000000000000D+00
+(PID.TID 0000.0001)   early fc =  0.000000000000000D+00
  --> objf_test(bi,bj)   =  0.804687751308914D+06
- --> objf_tracer(bi,bj) =  0.000000000000000D+00
- --> objf_atl(bi,bj)    =  0.000000000000000D+00
-  local fc =  0.804687751308914D+06
- global fc =  0.804687751308914D+06
+(PID.TID 0000.0001)   local fc =  0.804687751308914D+06
+(PID.TID 0000.0001)  global fc =  0.804687751308914D+06
 (PID.TID 0000.0001) grdchk perturb(+)fc: fcpertplus  =  8.04687751308914E+05
 (PID.TID 0000.0001) Start initial hydrostatic pressure computation
 (PID.TID 0000.0001) Pressure is predetermined for buoyancyRelation OCEANIC
@@ -2338,16 +2518,14 @@ grad-res -------------------------------
  EXTERNAL_FIELDS_LOAD, it=         0 : Reading new data, i0,i1=   12    1 (prev=   12    0 )
 (PID.TID 0000.0001) SOLVE_FOR_PRESSURE: putPmEinXvector =    F
  cg2d: Sum(rhs),rhsMax =   1.05956909912663E-14  2.53674886388737E+00
- cg2d: Sum(rhs),rhsMax =   1.48769885299771E-14  5.04325900480939E+00
- cg2d: Sum(rhs),rhsMax =  -6.53643805748061E-15  6.29008403763971E+00
- cg2d: Sum(rhs),rhsMax =  -1.75866265994529E-14  6.70003306073551E+00
+ cg2d: Sum(rhs),rhsMax =   1.91513471747840E-14  5.04325900480939E+00
+ cg2d: Sum(rhs),rhsMax =  -1.32116539930394E-14  6.29008403763954E+00
+ cg2d: Sum(rhs),rhsMax =   2.99760216648792E-14  6.70003306073569E+00
 (PID.TID 0000.0001) Did not write pickup because writePickupAtEnd = FALSE
-  early fc =  0.000000000000000D+00
+(PID.TID 0000.0001)   early fc =  0.000000000000000D+00
  --> objf_test(bi,bj)   =  0.804687738384548D+06
- --> objf_tracer(bi,bj) =  0.000000000000000D+00
- --> objf_atl(bi,bj)    =  0.000000000000000D+00
-  local fc =  0.804687738384548D+06
- global fc =  0.804687738384548D+06
+(PID.TID 0000.0001)   local fc =  0.804687738384548D+06
+(PID.TID 0000.0001)  global fc =  0.804687738384548D+06
 (PID.TID 0000.0001) grdchk perturb(-)fc: fcpertminus =  8.04687738384548E+05
 grad-res -------------------------------
  grad-res     0    6   86   39    1    1    1    1   8.04687744759E+05  8.04687751309E+05  8.04687738385E+05
@@ -2371,16 +2549,14 @@ grad-res -------------------------------
  EXTERNAL_FIELDS_LOAD, it=         0 : Reading new data, i0,i1=   12    1 (prev=   12    0 )
 (PID.TID 0000.0001) SOLVE_FOR_PRESSURE: putPmEinXvector =    F
  cg2d: Sum(rhs),rhsMax =   1.06512021424976E-14  2.53674886388737E+00
- cg2d: Sum(rhs),rhsMax =   9.28424004342787E-15  5.04325900480939E+00
- cg2d: Sum(rhs),rhsMax =  -2.49869569479699E-14  6.29008403763971E+00
- cg2d: Sum(rhs),rhsMax =  -2.69367861349679E-14  6.70003306073551E+00
+ cg2d: Sum(rhs),rhsMax =   8.72912853111529E-15  5.04325900480939E+00
+ cg2d: Sum(rhs),rhsMax =  -2.72837308301632E-14  6.29008403763954E+00
+ cg2d: Sum(rhs),rhsMax =   5.75928194024300E-15  6.70003306073569E+00
 (PID.TID 0000.0001) Did not write pickup because writePickupAtEnd = FALSE
-  early fc =  0.000000000000000D+00
+(PID.TID 0000.0001)   early fc =  0.000000000000000D+00
  --> objf_test(bi,bj)   =  0.804687749828302D+06
- --> objf_tracer(bi,bj) =  0.000000000000000D+00
- --> objf_atl(bi,bj)    =  0.000000000000000D+00
-  local fc =  0.804687749828302D+06
- global fc =  0.804687749828302D+06
+(PID.TID 0000.0001)   local fc =  0.804687749828302D+06
+(PID.TID 0000.0001)  global fc =  0.804687749828302D+06
 (PID.TID 0000.0001) grdchk perturb(+)fc: fcpertplus  =  8.04687749828302E+05
 (PID.TID 0000.0001) Start initial hydrostatic pressure computation
 (PID.TID 0000.0001) Pressure is predetermined for buoyancyRelation OCEANIC
@@ -2392,20 +2568,18 @@ grad-res -------------------------------
  EXTERNAL_FIELDS_LOAD, it=         0 : Reading new data, i0,i1=   12    1 (prev=   12    0 )
 (PID.TID 0000.0001) SOLVE_FOR_PRESSURE: putPmEinXvector =    F
  cg2d: Sum(rhs),rhsMax =   1.06512021424976E-14  2.53674886388737E+00
- cg2d: Sum(rhs),rhsMax =   6.73766598069392E-15  5.04325900480939E+00
- cg2d: Sum(rhs),rhsMax =  -1.15185638804860E-14  6.29008403763971E+00
- cg2d: Sum(rhs),rhsMax =  -6.89726054048379E-14  6.70003306073551E+00
+ cg2d: Sum(rhs),rhsMax =   5.21110932183433E-15  5.04325900480939E+00
+ cg2d: Sum(rhs),rhsMax =  -2.32765196006568E-14  6.29008403763954E+00
+ cg2d: Sum(rhs),rhsMax =   3.08156278272520E-14  6.70003306073569E+00
 (PID.TID 0000.0001) Did not write pickup because writePickupAtEnd = FALSE
-  early fc =  0.000000000000000D+00
+(PID.TID 0000.0001)   early fc =  0.000000000000000D+00
  --> objf_test(bi,bj)   =  0.804687739866778D+06
- --> objf_tracer(bi,bj) =  0.000000000000000D+00
- --> objf_atl(bi,bj)    =  0.000000000000000D+00
-  local fc =  0.804687739866778D+06
- global fc =  0.804687739866778D+06
+(PID.TID 0000.0001)   local fc =  0.804687739866778D+06
+(PID.TID 0000.0001)  global fc =  0.804687739866778D+06
 (PID.TID 0000.0001) grdchk perturb(-)fc: fcpertminus =  8.04687739866778E+05
 grad-res -------------------------------
  grad-res     0    7   87   39    1    1    1    1   8.04687744759E+05  8.04687749828E+05  8.04687739867E+05
- grad-res     0    7    7 2289    0    1    1    1   4.98076169749E-01  4.98076213989E-01 -8.88226561191E-08
+ grad-res     0    7    7 2289    0    1    1    1   4.98076169749E-01  4.98076213989E-01 -8.88226556750E-08
 (PID.TID 0000.0001)  ADM  ref_cost_function      =  8.04687744759401E+05
 (PID.TID 0000.0001)  ADM  adjoint_gradient       =  4.98076169748959E-01
 (PID.TID 0000.0001)  ADM  finite-diff_grad       =  4.98076213989407E-01
@@ -2425,16 +2599,14 @@ grad-res -------------------------------
  EXTERNAL_FIELDS_LOAD, it=         0 : Reading new data, i0,i1=   12    1 (prev=   12    0 )
 (PID.TID 0000.0001) SOLVE_FOR_PRESSURE: putPmEinXvector =    F
  cg2d: Sum(rhs),rhsMax =   1.06373243546898E-14  2.53674886388737E+00
- cg2d: Sum(rhs),rhsMax =   1.77635683940025E-14  5.04325900480939E+00
- cg2d: Sum(rhs),rhsMax =  -3.35842464949110E-14  6.29008403763971E+00
- cg2d: Sum(rhs),rhsMax =  -3.34871019802563E-14  6.70003306073551E+00
+ cg2d: Sum(rhs),rhsMax =   5.44009282066327E-15  5.04325900480939E+00
+ cg2d: Sum(rhs),rhsMax =  -2.35055030994857E-14  6.29008403763954E+00
+ cg2d: Sum(rhs),rhsMax =   3.70814490224802E-14  6.70003306073569E+00
 (PID.TID 0000.0001) Did not write pickup because writePickupAtEnd = FALSE
-  early fc =  0.000000000000000D+00
+(PID.TID 0000.0001)   early fc =  0.000000000000000D+00
  --> objf_test(bi,bj)   =  0.804687750914794D+06
- --> objf_tracer(bi,bj) =  0.000000000000000D+00
- --> objf_atl(bi,bj)    =  0.000000000000000D+00
-  local fc =  0.804687750914794D+06
- global fc =  0.804687750914794D+06
+(PID.TID 0000.0001)   local fc =  0.804687750914794D+06
+(PID.TID 0000.0001)  global fc =  0.804687750914794D+06
 (PID.TID 0000.0001) grdchk perturb(+)fc: fcpertplus  =  8.04687750914794E+05
 (PID.TID 0000.0001) Start initial hydrostatic pressure computation
 (PID.TID 0000.0001) Pressure is predetermined for buoyancyRelation OCEANIC
@@ -2446,22 +2618,20 @@ grad-res -------------------------------
  EXTERNAL_FIELDS_LOAD, it=         0 : Reading new data, i0,i1=   12    1 (prev=   12    0 )
 (PID.TID 0000.0001) SOLVE_FOR_PRESSURE: putPmEinXvector =    F
  cg2d: Sum(rhs),rhsMax =   1.06095687790742E-14  2.53674886388737E+00
- cg2d: Sum(rhs),rhsMax =   2.23779328401008E-14  5.04325900480939E+00
- cg2d: Sum(rhs),rhsMax =  -1.94289029309402E-14  6.29008403763971E+00
- cg2d: Sum(rhs),rhsMax =  -7.71743779992562E-14  6.70003306073551E+00
+ cg2d: Sum(rhs),rhsMax =   3.03229663600746E-15  5.04325900480939E+00
+ cg2d: Sum(rhs),rhsMax =  -2.07785177952502E-14  6.29008403763954E+00
+ cg2d: Sum(rhs),rhsMax =   2.65065747129256E-14  6.70003306073569E+00
 (PID.TID 0000.0001) Did not write pickup because writePickupAtEnd = FALSE
-  early fc =  0.000000000000000D+00
+(PID.TID 0000.0001)   early fc =  0.000000000000000D+00
  --> objf_test(bi,bj)   =  0.804687738782400D+06
- --> objf_tracer(bi,bj) =  0.000000000000000D+00
- --> objf_atl(bi,bj)    =  0.000000000000000D+00
-  local fc =  0.804687738782400D+06
- global fc =  0.804687738782400D+06
+(PID.TID 0000.0001)   local fc =  0.804687738782400D+06
+(PID.TID 0000.0001)  global fc =  0.804687738782400D+06
 (PID.TID 0000.0001) grdchk perturb(-)fc: fcpertminus =  8.04687738782400E+05
 grad-res -------------------------------
  grad-res     0    8   88   39    1    1    1    1   8.04687744759E+05  8.04687750915E+05  8.04687738782E+05
- grad-res     0    8    8 2290    0    1    1    1   6.06619515888E-01  6.06619729660E-01 -3.52399837977E-07
+ grad-res     0    8    8 2290    0    1    1    1   6.06619515888E-01  6.06619729660E-01 -3.52399836867E-07
 (PID.TID 0000.0001)  ADM  ref_cost_function      =  8.04687744759401E+05
-(PID.TID 0000.0001)  ADM  adjoint_gradient       =  6.06619515887832E-01
+(PID.TID 0000.0001)  ADM  adjoint_gradient       =  6.06619515887833E-01
 (PID.TID 0000.0001)  ADM  finite-diff_grad       =  6.06619729660451E-01
 (PID.TID 0000.0001) ====== End of gradient-check number   8 (ierr=  0) =======
 (PID.TID 0000.0001) 
@@ -2501,11 +2671,11 @@ grad-res -------------------------------
 (PID.TID 0000.0001) 
 (PID.TID 0000.0001) grdchk output (p):   7    87    39     1    1    1   0.000000000E+00 -1.000000000E-02
 (PID.TID 0000.0001) grdchk output (c):   7  8.0468774475940E+05  8.0468774982830E+05  8.0468773986678E+05
-(PID.TID 0000.0001) grdchk output (g):   7     4.9807621398941E-01  4.9807616974896E-01 -8.8822656119092E-08
+(PID.TID 0000.0001) grdchk output (g):   7     4.9807621398941E-01  4.9807616974896E-01 -8.8822655675003E-08
 (PID.TID 0000.0001) 
 (PID.TID 0000.0001) grdchk output (p):   8    88    39     1    1    1   0.000000000E+00 -1.000000000E-02
 (PID.TID 0000.0001) grdchk output (c):   8  8.0468774475940E+05  8.0468775091479E+05  8.0468773878240E+05
-(PID.TID 0000.0001) grdchk output (g):   8     6.0661972966045E-01  6.0661951588783E-01 -3.5239983797730E-07
+(PID.TID 0000.0001) grdchk output (g):   8     6.0661972966045E-01  6.0661951588783E-01 -3.5239983686708E-07
 (PID.TID 0000.0001) 
 (PID.TID 0000.0001) grdchk  summary  :  RMS of    8 ratios =  3.3808379600181E+01
 (PID.TID 0000.0001) 
@@ -2514,165 +2684,171 @@ grad-res -------------------------------
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) 
 (PID.TID 0000.0001)   Seconds in section "ALL                    [THE_MODEL_MAIN]":
-(PID.TID 0000.0001)           User time:   67.030000000000001
-(PID.TID 0000.0001)         System time:  0.20999999999999999
-(PID.TID 0000.0001)     Wall clock time:   67.419028997421265
+(PID.TID 0000.0001)           User time:   41.969899772666395
+(PID.TID 0000.0001)         System time:  0.64759802818298340
+(PID.TID 0000.0001)     Wall clock time:   42.656092882156372
 (PID.TID 0000.0001)          No. starts:           1
 (PID.TID 0000.0001)           No. stops:           1
 (PID.TID 0000.0001)   Seconds in section "INITIALISE_FIXED       [THE_MODEL_MAIN]":
-(PID.TID 0000.0001)           User time:  0.17000000000000001
-(PID.TID 0000.0001)         System time:  2.00000000000000004E-002
-(PID.TID 0000.0001)     Wall clock time:  0.19813203811645508
+(PID.TID 0000.0001)           User time:  0.10250099934637547
+(PID.TID 0000.0001)         System time:   2.3496000096201897E-002
+(PID.TID 0000.0001)     Wall clock time:  0.12776184082031250
 (PID.TID 0000.0001)          No. starts:           1
 (PID.TID 0000.0001)           No. stops:           1
 (PID.TID 0000.0001)   Seconds in section "ADTHE_MAIN_LOOP          [ADJOINT RUN]":
-(PID.TID 0000.0001)           User time:   17.829999999999998
-(PID.TID 0000.0001)         System time:  0.15000000000000002
-(PID.TID 0000.0001)     Wall clock time:   18.029143095016479
+(PID.TID 0000.0001)           User time:   11.427078902721405
+(PID.TID 0000.0001)         System time:  0.44022000953555107
+(PID.TID 0000.0001)     Wall clock time:   11.881551027297974
 (PID.TID 0000.0001)          No. starts:           1
 (PID.TID 0000.0001)           No. stops:           1
 (PID.TID 0000.0001)   Seconds in section "FORWARD_STEP        [MAIN_DO_LOOP]":
-(PID.TID 0000.0001)           User time:   51.079999999999927
-(PID.TID 0000.0001)         System time:  2.00000000000000178E-002
-(PID.TID 0000.0001)     Wall clock time:   51.219977378845215
+(PID.TID 0000.0001)           User time:   31.876494675874710
+(PID.TID 0000.0001)         System time:  0.11299392580986023
+(PID.TID 0000.0001)     Wall clock time:   32.014313936233521
 (PID.TID 0000.0001)          No. starts:          72
 (PID.TID 0000.0001)           No. stops:          72
 (PID.TID 0000.0001)   Seconds in section "LOAD_FIELDS_DRIVER  [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:  9.99999999999943157E-002
-(PID.TID 0000.0001)         System time:   0.0000000000000000
-(PID.TID 0000.0001)     Wall clock time:  0.10257363319396973
+(PID.TID 0000.0001)           User time:   6.9492369890213013E-002
+(PID.TID 0000.0001)         System time:   4.7538802027702332E-003
+(PID.TID 0000.0001)     Wall clock time:   7.4993133544921875E-002
 (PID.TID 0000.0001)          No. starts:          72
 (PID.TID 0000.0001)           No. stops:          72
 (PID.TID 0000.0001)   Seconds in section "EXTERNAL_FLDS_LOAD [LOAD_FLDS_DRIVER]":
-(PID.TID 0000.0001)           User time:  9.99999999999943157E-002
-(PID.TID 0000.0001)         System time:   0.0000000000000000
-(PID.TID 0000.0001)     Wall clock time:  0.10687303543090820
+(PID.TID 0000.0001)           User time:   7.1116656064987183E-002
+(PID.TID 0000.0001)         System time:   8.7084621191024780E-004
+(PID.TID 0000.0001)     Wall clock time:   7.7203750610351562E-002
 (PID.TID 0000.0001)          No. starts:          76
 (PID.TID 0000.0001)           No. stops:          76
+(PID.TID 0000.0001)   Seconds in section "CTRL_MAP_FORCING  [FORWARD_STEP]":
+(PID.TID 0000.0001)           User time:   6.3678622245788574E-004
+(PID.TID 0000.0001)         System time:   5.9977173805236816E-006
+(PID.TID 0000.0001)     Wall clock time:   6.5326690673828125E-004
+(PID.TID 0000.0001)          No. starts:          72
+(PID.TID 0000.0001)           No. stops:          72
 (PID.TID 0000.0001)   Seconds in section "DO_ATMOSPHERIC_PHYS [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:  9.99999999999090505E-003
-(PID.TID 0000.0001)         System time:   0.0000000000000000
-(PID.TID 0000.0001)     Wall clock time:  6.55889511108398438E-004
+(PID.TID 0000.0001)           User time:   3.6983013153076172E-002
+(PID.TID 0000.0001)         System time:   2.8306990861892700E-004
+(PID.TID 0000.0001)     Wall clock time:   3.7329435348510742E-002
 (PID.TID 0000.0001)          No. starts:          72
 (PID.TID 0000.0001)           No. stops:          72
 (PID.TID 0000.0001)   Seconds in section "DO_OCEANIC_PHYS     [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:   8.1899999999999977
-(PID.TID 0000.0001)         System time:  1.00000000000000089E-002
-(PID.TID 0000.0001)     Wall clock time:   8.2164540290832520
+(PID.TID 0000.0001)           User time:   5.7128789424896240
+(PID.TID 0000.0001)         System time:   1.5854090452194214E-002
+(PID.TID 0000.0001)     Wall clock time:   5.7332389354705811
 (PID.TID 0000.0001)          No. starts:          72
 (PID.TID 0000.0001)           No. stops:          72
 (PID.TID 0000.0001)   Seconds in section "THERMODYNAMICS      [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:   16.469999999999970
-(PID.TID 0000.0001)         System time:   0.0000000000000000
-(PID.TID 0000.0001)     Wall clock time:   16.527510404586792
+(PID.TID 0000.0001)           User time:   9.5318860709667206
+(PID.TID 0000.0001)         System time:   3.9526984095573425E-002
+(PID.TID 0000.0001)     Wall clock time:   9.5786314010620117
 (PID.TID 0000.0001)          No. starts:          72
 (PID.TID 0000.0001)           No. stops:          72
 (PID.TID 0000.0001)   Seconds in section "DYNAMICS            [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:   19.130000000000010
-(PID.TID 0000.0001)         System time:  1.00000000000000089E-002
-(PID.TID 0000.0001)     Wall clock time:   19.160159349441528
+(PID.TID 0000.0001)           User time:   11.727683961391449
+(PID.TID 0000.0001)         System time:   2.4233058094978333E-002
+(PID.TID 0000.0001)     Wall clock time:   11.760771751403809
 (PID.TID 0000.0001)          No. starts:          72
 (PID.TID 0000.0001)           No. stops:          72
 (PID.TID 0000.0001)   Seconds in section "SOLVE_FOR_PRESSURE  [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:   4.3899999999999864
-(PID.TID 0000.0001)         System time:   0.0000000000000000
-(PID.TID 0000.0001)     Wall clock time:   4.3996253013610840
+(PID.TID 0000.0001)           User time:   2.7586901187896729
+(PID.TID 0000.0001)         System time:   8.0499649047851562E-003
+(PID.TID 0000.0001)     Wall clock time:   2.7703423500061035
 (PID.TID 0000.0001)          No. starts:          72
 (PID.TID 0000.0001)           No. stops:          72
 (PID.TID 0000.0001)   Seconds in section "MOM_CORRECTION_STEP [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:  0.39999999999999147
-(PID.TID 0000.0001)         System time:   0.0000000000000000
-(PID.TID 0000.0001)     Wall clock time:  0.42065262794494629
+(PID.TID 0000.0001)           User time:  0.35805779695510864
+(PID.TID 0000.0001)         System time:   1.6488134860992432E-004
+(PID.TID 0000.0001)     Wall clock time:  0.35837745666503906
 (PID.TID 0000.0001)          No. starts:          72
 (PID.TID 0000.0001)           No. stops:          72
 (PID.TID 0000.0001)   Seconds in section "INTEGR_CONTINUITY   [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:  0.72000000000004150
-(PID.TID 0000.0001)         System time:   0.0000000000000000
-(PID.TID 0000.0001)     Wall clock time:  0.71262645721435547
+(PID.TID 0000.0001)           User time:  0.45345473289489746
+(PID.TID 0000.0001)         System time:   9.3102455139160156E-005
+(PID.TID 0000.0001)     Wall clock time:  0.45371270179748535
 (PID.TID 0000.0001)          No. starts:          72
 (PID.TID 0000.0001)           No. stops:          72
 (PID.TID 0000.0001)   Seconds in section "TRC_CORRECTION_STEP [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:  0.21000000000000796
+(PID.TID 0000.0001)           User time:   7.0500373840332031E-004
 (PID.TID 0000.0001)         System time:   0.0000000000000000
-(PID.TID 0000.0001)     Wall clock time:  0.21013736724853516
+(PID.TID 0000.0001)     Wall clock time:   6.8020820617675781E-004
 (PID.TID 0000.0001)          No. starts:          72
 (PID.TID 0000.0001)           No. stops:          72
 (PID.TID 0000.0001)   Seconds in section "BLOCKING_EXCHANGES  [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:  0.28999999999997783
-(PID.TID 0000.0001)         System time:   0.0000000000000000
-(PID.TID 0000.0001)     Wall clock time:  0.27254319190979004
+(PID.TID 0000.0001)           User time:  0.19000786542892456
+(PID.TID 0000.0001)         System time:   8.2969665527343750E-005
+(PID.TID 0000.0001)     Wall clock time:  0.19027066230773926
 (PID.TID 0000.0001)          No. starts:          72
 (PID.TID 0000.0001)           No. stops:          72
 (PID.TID 0000.0001)   Seconds in section "MONITOR             [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:  1.00000000000051159E-002
-(PID.TID 0000.0001)         System time:   0.0000000000000000
-(PID.TID 0000.0001)     Wall clock time:  7.18832015991210938E-004
+(PID.TID 0000.0001)           User time:  0.11885583400726318
+(PID.TID 0000.0001)         System time:   1.0132789611816406E-006
+(PID.TID 0000.0001)     Wall clock time:  0.11887049674987793
 (PID.TID 0000.0001)          No. starts:          72
 (PID.TID 0000.0001)           No. stops:          72
 (PID.TID 0000.0001)   Seconds in section "COST_TILE           [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:   1.0799999999999557
-(PID.TID 0000.0001)         System time:   0.0000000000000000
-(PID.TID 0000.0001)     Wall clock time:   1.1138741970062256
+(PID.TID 0000.0001)           User time:  0.86268317699432373
+(PID.TID 0000.0001)         System time:   4.0610432624816895E-003
+(PID.TID 0000.0001)     Wall clock time:  0.86752462387084961
 (PID.TID 0000.0001)          No. starts:          72
 (PID.TID 0000.0001)           No. stops:          72
 (PID.TID 0000.0001)   Seconds in section "DO_THE_MODEL_IO     [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:  1.99999999999960210E-002
-(PID.TID 0000.0001)         System time:   0.0000000000000000
-(PID.TID 0000.0001)     Wall clock time:  2.31816768646240234E-002
+(PID.TID 0000.0001)           User time:   1.4082670211791992E-002
+(PID.TID 0000.0001)         System time:   3.8889795541763306E-003
+(PID.TID 0000.0001)     Wall clock time:   1.7976999282836914E-002
 (PID.TID 0000.0001)          No. starts:          72
 (PID.TID 0000.0001)           No. stops:          72
 (PID.TID 0000.0001)   Seconds in section "DO_WRITE_PICKUP     [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:  5.00000000000113687E-002
-(PID.TID 0000.0001)         System time:   0.0000000000000000
-(PID.TID 0000.0001)     Wall clock time:  4.88457679748535156E-002
+(PID.TID 0000.0001)           User time:   2.7841508388519287E-002
+(PID.TID 0000.0001)         System time:   1.1923998594284058E-002
+(PID.TID 0000.0001)     Wall clock time:   3.9765119552612305E-002
 (PID.TID 0000.0001)          No. starts:          72
 (PID.TID 0000.0001)           No. stops:          72
 (PID.TID 0000.0001)   Seconds in section "I/O (WRITE)        [ADJOINT LOOP]":
-(PID.TID 0000.0001)           User time:  4.00000000000027001E-002
-(PID.TID 0000.0001)         System time:   0.0000000000000000
-(PID.TID 0000.0001)     Wall clock time:  4.38201427459716797E-002
-(PID.TID 0000.0001)          No. starts:           1
-(PID.TID 0000.0001)           No. stops:           1
+(PID.TID 0000.0001)           User time:   2.9043197631835938E-002
+(PID.TID 0000.0001)         System time:   1.2033998966217041E-002
+(PID.TID 0000.0001)     Wall clock time:   4.1074037551879883E-002
+(PID.TID 0000.0001)          No. starts:           2
+(PID.TID 0000.0001)           No. stops:           2
 (PID.TID 0000.0001)   Seconds in section "CTRL_PACK           [THE_MODEL_MAIN]":
-(PID.TID 0000.0001)           User time:  5.00000000000007105E-002
-(PID.TID 0000.0001)         System time:  9.99999999999998113E-003
-(PID.TID 0000.0001)     Wall clock time:  5.79869747161865234E-002
+(PID.TID 0000.0001)           User time:   3.1980514526367188E-002
+(PID.TID 0000.0001)         System time:   7.9950094223022461E-003
+(PID.TID 0000.0001)     Wall clock time:   3.9978981018066406E-002
 (PID.TID 0000.0001)          No. starts:           1
 (PID.TID 0000.0001)           No. stops:           1
 (PID.TID 0000.0001)   Seconds in section "CTRL_PACK     [THE_MODEL_MAIN]":
-(PID.TID 0000.0001)           User time:  5.99999999999987210E-002
-(PID.TID 0000.0001)         System time:   0.0000000000000000
-(PID.TID 0000.0001)     Wall clock time:  5.73489665985107422E-002
+(PID.TID 0000.0001)           User time:   3.7089347839355469E-002
+(PID.TID 0000.0001)         System time:   4.5001506805419922E-005
+(PID.TID 0000.0001)     Wall clock time:   3.7137985229492188E-002
 (PID.TID 0000.0001)          No. starts:           1
 (PID.TID 0000.0001)           No. stops:           1
 (PID.TID 0000.0001)   Seconds in section "GRDCHK_MAIN         [THE_MODEL_MAIN]":
-(PID.TID 0000.0001)           User time:   48.920000000000002
-(PID.TID 0000.0001)         System time:  2.99999999999999989E-002
-(PID.TID 0000.0001)     Wall clock time:   49.076337099075317
+(PID.TID 0000.0001)           User time:   30.371159553527832
+(PID.TID 0000.0001)         System time:  0.17583703994750977
+(PID.TID 0000.0001)     Wall clock time:   30.569589138031006
 (PID.TID 0000.0001)          No. starts:           1
 (PID.TID 0000.0001)           No. stops:           1
 (PID.TID 0000.0001)   Seconds in section "INITIALISE_VARIA    [THE_MAIN_LOOP]":
-(PID.TID 0000.0001)           User time:   1.3499999999999943
-(PID.TID 0000.0001)         System time:  9.99999999999998113E-003
-(PID.TID 0000.0001)     Wall clock time:   1.3673486709594727
+(PID.TID 0000.0001)           User time:  0.96305751800537109
+(PID.TID 0000.0001)         System time:   5.5381059646606445E-002
+(PID.TID 0000.0001)     Wall clock time:   1.0228626728057861
 (PID.TID 0000.0001)          No. starts:          16
 (PID.TID 0000.0001)           No. stops:          16
 (PID.TID 0000.0001)   Seconds in section "MAIN LOOP           [THE_MAIN_LOOP]":
-(PID.TID 0000.0001)           User time:   47.329999999999998
-(PID.TID 0000.0001)         System time:   0.0000000000000000
-(PID.TID 0000.0001)     Wall clock time:   47.438304901123047
+(PID.TID 0000.0001)           User time:   29.224983215332031
+(PID.TID 0000.0001)         System time:   9.2540025711059570E-002
+(PID.TID 0000.0001)     Wall clock time:   29.335695505142212
 (PID.TID 0000.0001)          No. starts:          16
 (PID.TID 0000.0001)           No. stops:          16
 (PID.TID 0000.0001)   Seconds in section "MAIN_DO_LOOP        [THE_MAIN_LOOP]":
-(PID.TID 0000.0001)           User time:   45.339999999999961
-(PID.TID 0000.0001)         System time:   0.0000000000000000
-(PID.TID 0000.0001)     Wall clock time:   45.451010704040527
+(PID.TID 0000.0001)           User time:   27.965360641479492
+(PID.TID 0000.0001)         System time:   8.8449895381927490E-002
+(PID.TID 0000.0001)     Wall clock time:   28.071042537689209
 (PID.TID 0000.0001)          No. starts:          64
 (PID.TID 0000.0001)           No. stops:          64
 (PID.TID 0000.0001)   Seconds in section "COST_FINAL         [ADJOINT SPIN-DOWN]":
-(PID.TID 0000.0001)           User time:   0.0000000000000000
-(PID.TID 0000.0001)         System time:   0.0000000000000000
-(PID.TID 0000.0001)     Wall clock time:  1.77431106567382813E-003
+(PID.TID 0000.0001)           User time:   1.5869140625000000E-003
+(PID.TID 0000.0001)         System time:   1.9669532775878906E-006
+(PID.TID 0000.0001)     Wall clock time:   1.5935897827148438E-003
 (PID.TID 0000.0001)          No. starts:          16
 (PID.TID 0000.0001)           No. stops:          16
 (PID.TID 0000.0001) // ======================================================
@@ -2690,9 +2866,9 @@ grad-res -------------------------------
 (PID.TID 0000.0001) //          Total. Y spins =              0
 (PID.TID 0000.0001) //            Avg. Y spins =       0.00E+00
 (PID.TID 0000.0001) // o Thread number: 000001
-(PID.TID 0000.0001) //            No. barriers =          19380
+(PID.TID 0000.0001) //            No. barriers =          19762
 (PID.TID 0000.0001) //      Max. barrier spins =              1
 (PID.TID 0000.0001) //      Min. barrier spins =              1
-(PID.TID 0000.0001) //     Total barrier spins =          19380
+(PID.TID 0000.0001) //     Total barrier spins =          19762
 (PID.TID 0000.0001) //      Avg. barrier spins =       1.00E+00
 PROGRAM MAIN: Execution ended Normally

--- a/verification/global_oce_biogeo_bling/input_ad/data
+++ b/verification/global_oce_biogeo_bling/input_ad/data
@@ -42,31 +42,31 @@
 
 # Time stepping parameters
  &PARM03
- nIter0=0,
+ nIter0= 0,
  nTimeSteps = 4,
- deltaTmom  = 900.,
- tauCD =     321428.,
- deltaTtracer= 900.,
- deltaTClock = 900.,
+ deltaT =   900.,
+ tauCD = 321428.,
  abEps = 0.1,
  pChkptFreq = 216000.,
  chkptFreq  = 216000.,
  dumpFreq   = 216000.,
 # taveFreq   = 216000.,
+ monitorSelect= 2,
  monitorFreq= 86400.,
  tauThetaClimRelax = 5184000.,
  tauSaltClimRelax  = 7776000.,
  periodicExternalForcing=.TRUE.,
  externForcingPeriod=2592000.,
  externForcingCycle=31104000.,
- monitorFreq= 1.,
+ monitorFreq= 3600.,
+ adjMonitorFreq= 1.,
  &
 
 # Gridding parameters
  &PARM04
  usingSphericalPolarGrid=.TRUE.,
- delZ=  50., 70.,  100., 140., 190., 
-       240., 290., 340., 390., 440., 
+ delZ=  50., 70.,  100., 140., 190.,
+       240., 290., 340., 390., 440.,
        490., 540., 590., 640., 690.,
  ygOrigin=-90.,
  delX=128*2.8125,

--- a/verification/global_oce_biogeo_bling/input_ad/tr_checklist.adm
+++ b/verification/global_oce_biogeo_bling/input_ad/tr_checklist.adm
@@ -1,0 +1,1 @@
+admGrd admCst admGrd admFwd T+ S+ U+ V+ pt1+ pt2+

--- a/verification/global_oce_biogeo_bling/results/output_adm.txt
+++ b/verification/global_oce_biogeo_bling/results/output_adm.txt
@@ -5,10 +5,10 @@
 (PID.TID 0000.0001) // ======================================================
 (PID.TID 0000.0001) // execution environment starting up...
 (PID.TID 0000.0001) 
-(PID.TID 0000.0001) // MITgcmUV version:  checkpoint67r
-(PID.TID 0000.0001) // Build user:        jmc
-(PID.TID 0000.0001) // Build host:        jaures.mit.edu
-(PID.TID 0000.0001) // Build date:        Sun Jul 19 15:20:30 EDT 2020
+(PID.TID 0000.0001) // MITgcmUV version:  checkpoint67w
+(PID.TID 0000.0001) // Build user:        jm_c
+(PID.TID 0000.0001) // Build host:        villon
+(PID.TID 0000.0001) // Build date:        Tue Apr 13 00:29:33 EDT 2021
 (PID.TID 0000.0001) 
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // Execution Environment parameter file "eedata"
@@ -49,7 +49,7 @@
 (PID.TID 0000.0001)                   /*  note: To execute a program with MPI calls */
 (PID.TID 0000.0001)                   /*  it must be launched appropriately e.g     */
 (PID.TID 0000.0001)                   /*  "mpirun -np 64 ......"                    */
-(PID.TID 0000.0001) useCoupler=    F ;/* Flag used to control communications with   */
+(PID.TID 0000.0001) useCoupler=   F ; /* Flag used to control communications with   */
 (PID.TID 0000.0001)                   /*  other model components, through a coupler */
 (PID.TID 0000.0001) useNest2W_parent =    F ;/* Control 2-W Nesting comm */
 (PID.TID 0000.0001) useNest2W_child  =    F ;/* Control 2-W Nesting comm */
@@ -120,24 +120,24 @@
 (PID.TID 0000.0001) >
 (PID.TID 0000.0001) ># Time stepping parameters
 (PID.TID 0000.0001) > &PARM03
-(PID.TID 0000.0001) > nIter0=0,
+(PID.TID 0000.0001) > nIter0= 0,
 (PID.TID 0000.0001) > nTimeSteps = 4,
-(PID.TID 0000.0001) > deltaTmom  = 900.,
-(PID.TID 0000.0001) > tauCD =     321428.,
-(PID.TID 0000.0001) > deltaTtracer= 900.,
-(PID.TID 0000.0001) > deltaTClock = 900.,
+(PID.TID 0000.0001) > deltaT =   900.,
+(PID.TID 0000.0001) > tauCD = 321428.,
 (PID.TID 0000.0001) > abEps = 0.1,
 (PID.TID 0000.0001) > pChkptFreq = 216000.,
 (PID.TID 0000.0001) > chkptFreq  = 216000.,
 (PID.TID 0000.0001) > dumpFreq   = 216000.,
 (PID.TID 0000.0001) ># taveFreq   = 216000.,
+(PID.TID 0000.0001) > monitorSelect= 2,
 (PID.TID 0000.0001) > monitorFreq= 86400.,
 (PID.TID 0000.0001) > tauThetaClimRelax = 5184000.,
 (PID.TID 0000.0001) > tauSaltClimRelax  = 7776000.,
 (PID.TID 0000.0001) > periodicExternalForcing=.TRUE.,
 (PID.TID 0000.0001) > externForcingPeriod=2592000.,
 (PID.TID 0000.0001) > externForcingCycle=31104000.,
-(PID.TID 0000.0001) > monitorFreq= 1.,
+(PID.TID 0000.0001) > monitorFreq= 3600.,
+(PID.TID 0000.0001) > adjMonitorFreq= 1.,
 (PID.TID 0000.0001) > /
 (PID.TID 0000.0001) >
 (PID.TID 0000.0001) ># Gridding parameters
@@ -189,6 +189,7 @@
 (PID.TID 0000.0001) > useECCO        = .TRUE.,
 (PID.TID 0000.0001) > useGrdchk      = .TRUE.,
 (PID.TID 0000.0001) > usePROFILEs    = .TRUE.,
+(PID.TID 0000.0001) > useDIAGNOSTICS = .TRUE.,
 (PID.TID 0000.0001) > /
 (PID.TID 0000.0001) 
 (PID.TID 0000.0001)  PACKAGES_BOOT: finished reading data.pkg
@@ -203,6 +204,7 @@
  pkg/ctrl                 compiled   and   used ( useCTRL                  = T )
  pkg/ptracers             compiled   and   used ( usePTRACERS              = T )
  pkg/gchem                compiled   and   used ( useGCHEM                 = T )
+ pkg/diagnostics          compiled   and   used ( useDiagnostics           = T )
  -------- pkgs without standard "usePKG" On/Off switch in "data.pkg":  --------
  pkg/generic_advdiff      compiled   and   used ( useGAD                   = T )
  pkg/mom_common           compiled   and   used ( momStepping              = T )
@@ -423,6 +425,9 @@
 (PID.TID 0000.0001) inAdExact = /* get an exact adjoint (no approximation) */
 (PID.TID 0000.0001)                   T
 (PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) useApproxAdvectionInAdMode = /* approximate AD-advection */
+(PID.TID 0000.0001)                   F
+(PID.TID 0000.0001)     ;
 (PID.TID 0000.0001) useKPPinAdMode = /* use KPP in adjoint mode */
 (PID.TID 0000.0001)                   F
 (PID.TID 0000.0001)     ;
@@ -444,8 +449,17 @@
 (PID.TID 0000.0001) mon_AdVarExch = /* control adexch before monitor */
 (PID.TID 0000.0001)                       2
 (PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) viscFacInFw = /* viscosity factor for forward model */
+(PID.TID 0000.0001)                 1.000000000000000E+00
+(PID.TID 0000.0001)     ;
 (PID.TID 0000.0001) viscFacInAd = /* viscosity factor for adjoint */
 (PID.TID 0000.0001)                 1.000000000000000E+00
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) SIregFacInAd = /* sea ice factor for adjoint model */
+(PID.TID 0000.0001)                 1.234567000000000E+05
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) SIregFacInFw = /* sea ice factor for forward model */
+(PID.TID 0000.0001)                 1.234567000000000E+05
 (PID.TID 0000.0001)     ;
 (PID.TID 0000.0001) 
 (PID.TID 0000.0001) OPTIM_READPARMS: opening data.optim
@@ -495,51 +509,51 @@
 (PID.TID 0000.0001) > &CTRL_NML_GENARR
 (PID.TID 0000.0001) >#  Ini Cndtns
 (PID.TID 0000.0001) ># xx_genarr3d_weight(1) = 'wt_theta.bin',
-(PID.TID 0000.0001) > xx_genarr3d_weight(1) = 'wt_ones.bin',
+(PID.TID 0000.0001) > xx_genarr3d_weight(1) = 'ones_32b.bin',
 (PID.TID 0000.0001) > xx_genarr3d_file(1)='xx_theta',
 (PID.TID 0000.0001) ># xx_genarr3d_preproc(1,1)='smooth',
 (PID.TID 0000.0001) ># no bounds: xx_genarr3d_bounds(1:5,1)=-2.0,-1.9,39.,40.,0.,
 (PID.TID 0000.0001) > mult_genarr3d(1) = 1.0,
 (PID.TID 0000.0001) >#
 (PID.TID 0000.0001) ># xx_genarr3d_weight(2) = 'wt_salt.bin',
-(PID.TID 0000.0001) > xx_genarr3d_weight(2) = 'wt_ones.bin',
+(PID.TID 0000.0001) > xx_genarr3d_weight(2) = 'ones_32b.bin',
 (PID.TID 0000.0001) > xx_genarr3d_file(2)='xx_salt',
 (PID.TID 0000.0001) ># xx_genarr3d_preproc(1,2)='smooth',
 (PID.TID 0000.0001) ># xx_genarr3d_bounds(1:5,2)=29.,29.5,40.5,41.,0.,
 (PID.TID 0000.0001) > mult_genarr3d(2) = 1.0,
 (PID.TID 0000.0001) >#
 (PID.TID 0000.0001) ># xx_genarr3d_weight(3) = 'wt_DIC.bin',
-(PID.TID 0000.0001) > xx_genarr3d_weight(3) = 'wt_ones.bin',
+(PID.TID 0000.0001) > xx_genarr3d_weight(3) = 'ones_32b.bin',
 (PID.TID 0000.0001) > xx_genarr3d_file(3)='xx_ptr1',
 (PID.TID 0000.0001) ># xx_genarr3d_preproc(1,3)='smooth',
 (PID.TID 0000.0001) > mult_genarr3d(3) = 1.0,
 (PID.TID 0000.0001) >#
 (PID.TID 0000.0001) ># xx_genarr3d_weight(4) = 'wt_ALK.bin',
-(PID.TID 0000.0001) > xx_genarr3d_weight(4) = 'wt_ones.bin',
+(PID.TID 0000.0001) > xx_genarr3d_weight(4) = 'ones_32b.bin',
 (PID.TID 0000.0001) > xx_genarr3d_file(4)='xx_ptr2',
 (PID.TID 0000.0001) ># xx_genarr3d_preproc(1,4)='smooth',
 (PID.TID 0000.0001) > mult_genarr3d(4) = 1.0,
 (PID.TID 0000.0001) >#
 (PID.TID 0000.0001) ># xx_genarr3d_weight(5) = 'wt_O2.bin',
-(PID.TID 0000.0001) > xx_genarr3d_weight(5) = 'wt_ones.bin',
+(PID.TID 0000.0001) > xx_genarr3d_weight(5) = 'ones_32b.bin',
 (PID.TID 0000.0001) > xx_genarr3d_file(5)='xx_ptr3',
 (PID.TID 0000.0001) ># xx_genarr3d_preproc(1,5)='smooth',
 (PID.TID 0000.0001) > mult_genarr3d(5) = 1.0,
 (PID.TID 0000.0001) >#
 (PID.TID 0000.0001) ># xx_genarr3d_weight(6) = 'wt_NO3.bin',
-(PID.TID 0000.0001) > xx_genarr3d_weight(6) = 'wt_ones.bin',
+(PID.TID 0000.0001) > xx_genarr3d_weight(6) = 'ones_32b.bin',
 (PID.TID 0000.0001) > xx_genarr3d_file(6)='xx_ptr4',
 (PID.TID 0000.0001) ># xx_genarr3d_preproc(1,6)='smooth',
 (PID.TID 0000.0001) > mult_genarr3d(6) = 1.0,
 (PID.TID 0000.0001) >#
 (PID.TID 0000.0001) ># xx_genarr3d_weight(7) = 'wt_PO4.bin',
-(PID.TID 0000.0001) > xx_genarr3d_weight(7) = 'wt_ones.bin',
+(PID.TID 0000.0001) > xx_genarr3d_weight(7) = 'ones_32b.bin',
 (PID.TID 0000.0001) > xx_genarr3d_file(7)='xx_ptr5',
 (PID.TID 0000.0001) ># xx_genarr3d_preproc(1,7)='smooth',
 (PID.TID 0000.0001) > mult_genarr3d(7) = 1.0,
 (PID.TID 0000.0001) >#
 (PID.TID 0000.0001) ># xx_genarr3d_weight(8) = 'wt_FE.bin',
-(PID.TID 0000.0001) > xx_genarr3d_weight(8) = 'wt_ones.bin',
+(PID.TID 0000.0001) > xx_genarr3d_weight(8) = 'ones_32b.bin',
 (PID.TID 0000.0001) > xx_genarr3d_file(8)='xx_ptr6',
 (PID.TID 0000.0001) ># xx_genarr3d_preproc(1,8)='smooth',
 (PID.TID 0000.0001) > mult_genarr3d(8) = 1.0,
@@ -622,10 +636,10 @@
 (PID.TID 0000.0001) >
 (PID.TID 0000.0001) > &ECCO_GENCOST_NML
 (PID.TID 0000.0001) ># SST
-(PID.TID 0000.0001) > gencost_avgperiod(1)  = 'day',
+(PID.TID 0000.0001) > gencost_avgperiod(1) = 'day',
 (PID.TID 0000.0001) > gencost_barfile(1) = 'm_sst_day',
 (PID.TID 0000.0001) > gencost_datafile(1) = 'lev_clim_temp.bin',
-(PID.TID 0000.0001) > gencost_errfile(1) = 'wt_ones.bin',
+(PID.TID 0000.0001) > gencost_errfile(1) = 'ones_32b.bin',
 (PID.TID 0000.0001) > gencost_name(1) = 'sst-MW',
 (PID.TID 0000.0001) > gencost_spmin(1) = -1.8,
 (PID.TID 0000.0001) > gencost_spmax(1) = 40.,
@@ -656,6 +670,112 @@
 (PID.TID 0000.0001) > /
 (PID.TID 0000.0001) 
 (PID.TID 0000.0001) PROFILES_READPARMS: finished reading data.profiles
+(PID.TID 0000.0001)  DIAGNOSTICS_READPARMS: opening data.diagnostics
+(PID.TID 0000.0001)  OPEN_COPY_DATA_FILE: opening file data.diagnostics
+(PID.TID 0000.0001) // =======================================================
+(PID.TID 0000.0001) // Parameter file "data.diagnostics"
+(PID.TID 0000.0001) // =======================================================
+(PID.TID 0000.0001) ># Diagnostic Package Choices
+(PID.TID 0000.0001) >#--------------------
+(PID.TID 0000.0001) >#  dumpAtLast (logical): always write output at the end of simulation (default=F)
+(PID.TID 0000.0001) >#  diag_mnc   (logical): write to NetCDF files (default=useMNC)
+(PID.TID 0000.0001) >#--for each output-stream:
+(PID.TID 0000.0001) >#  fileName(n) : prefix of the output file name (max 80c long) for outp.stream n
+(PID.TID 0000.0001) >#  frequency(n):< 0 : write snap-shot output every |frequency| seconds
+(PID.TID 0000.0001) >#               > 0 : write time-average output every frequency seconds
+(PID.TID 0000.0001) >#  timePhase(n)     : write at time = timePhase + multiple of |frequency|
+(PID.TID 0000.0001) >#    averagingFreq  : frequency (in s) for periodic averaging interval
+(PID.TID 0000.0001) >#    averagingPhase : phase     (in s) for periodic averaging interval
+(PID.TID 0000.0001) >#    repeatCycle    : number of averaging intervals in 1 cycle
+(PID.TID 0000.0001) >#  levels(:,n) : list of levels to write to file (Notes: declared as REAL)
+(PID.TID 0000.0001) >#                when this entry is missing, select all common levels of this list
+(PID.TID 0000.0001) >#  fields(:,n) : list of selected diagnostics fields (8.c) in outp.stream n
+(PID.TID 0000.0001) >#                (see "available_diagnostics.log" file for the full list of diags)
+(PID.TID 0000.0001) >#  missing_value(n) : missing value for real-type fields in output file "n"
+(PID.TID 0000.0001) >#  fileFlags(n)     : specific code (8c string) for output file "n"
+(PID.TID 0000.0001) >#--------------------
+(PID.TID 0000.0001) > &DIAGNOSTICS_LIST
+(PID.TID 0000.0001) >  fileName(1)    = 'blingTracDiag',
+(PID.TID 0000.0001) >  fields(1:8,1)  = 'TRAC01  ','TRAC02  ','TRAC03  ',
+(PID.TID 0000.0001) >                   'TRAC04  ','TRAC05  ','TRAC06  ',
+(PID.TID 0000.0001) >                   'TRAC07  ','TRAC08  ',
+(PID.TID 0000.0001) >  frequency(1)   = 432000.,
+(PID.TID 0000.0001) ># ---
+(PID.TID 0000.0001) >  fileName(2)    = 'adjBlingTracDiag',
+(PID.TID 0000.0001) >  fields(1:8,2)  = 'ADJptr01','ADJptr02','ADJptr03',
+(PID.TID 0000.0001) >                   'ADJptr04','ADJptr05','ADJptr06',
+(PID.TID 0000.0001) >                   'ADJptr07','ADJptr08'
+(PID.TID 0000.0001) >  frequency(2)   = 432000.,
+(PID.TID 0000.0001) > /
+(PID.TID 0000.0001) >
+(PID.TID 0000.0001) >#--------------------
+(PID.TID 0000.0001) ># Parameter for Diagnostics of per level statistics:
+(PID.TID 0000.0001) >#--------------------
+(PID.TID 0000.0001) >#  diagSt_mnc (logical): write stat-diags to NetCDF files (default=diag_mnc)
+(PID.TID 0000.0001) >#  diagSt_regMaskFile : file containing the region-mask to read-in
+(PID.TID 0000.0001) >#  nSetRegMskFile   : number of region-mask sets within the region-mask file
+(PID.TID 0000.0001) >#  set_regMask(i)   : region-mask set-index that identifies the region "i"
+(PID.TID 0000.0001) >#  val_regMask(i)   : region "i" identifier value in the region mask
+(PID.TID 0000.0001) >#--for each output-stream:
+(PID.TID 0000.0001) >#  stat_fName(n) : prefix of the output file name (max 80c long) for outp.stream n
+(PID.TID 0000.0001) >#  stat_freq(n):< 0 : write snap-shot output every |stat_freq| seconds
+(PID.TID 0000.0001) >#               > 0 : write time-average output every stat_freq seconds
+(PID.TID 0000.0001) >#  stat_phase(n)    : write at time = stat_phase + multiple of |stat_freq|
+(PID.TID 0000.0001) >#  stat_region(:,n) : list of "regions" (default: 1 region only=global)
+(PID.TID 0000.0001) >#  stat_fields(:,n) : list of selected diagnostics fields (8.c) in outp.stream n
+(PID.TID 0000.0001) >#                (see "available_diagnostics.log" file for the full list of diags)
+(PID.TID 0000.0001) >#--------------------
+(PID.TID 0000.0001) > &DIAG_STATIS_PARMS
+(PID.TID 0000.0001) >#- an example just to check the agreement with MONITOR output:
+(PID.TID 0000.0001) >#stat_fields(1:5,1)  = 'ETAN    ','UVEL    ','VVEL    ','WVEL    ', 'THETA   ',
+(PID.TID 0000.0001) ># stat_fName(1) = 'dynStDiag',
+(PID.TID 0000.0001) >#  stat_freq(1) = -864000.,
+(PID.TID 0000.0001) ># stat_phase(1) = 0.,
+(PID.TID 0000.0001) > /
+(PID.TID 0000.0001) >
+(PID.TID 0000.0001) 
+(PID.TID 0000.0001) S/R DIAGNOSTICS_READPARMS, read namelist "diagnostics_list": start
+(PID.TID 0000.0001) S/R DIAGNOSTICS_READPARMS, read namelist "diagnostics_list": OK
+(PID.TID 0000.0001) S/R DIAGNOSTICS_READPARMS, read namelist "DIAG_STATIS_PARMS": start
+(PID.TID 0000.0001) S/R DIAGNOSTICS_READPARMS, read namelist "DIAG_STATIS_PARMS": OK
+(PID.TID 0000.0001)  DIAGNOSTICS_READPARMS: global parameter summary:
+(PID.TID 0000.0001)  dumpAtLast = /* always write time-ave diags at the end */
+(PID.TID 0000.0001)                   F
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001)  diag_mnc =   /* write NetCDF output files */
+(PID.TID 0000.0001)                   F
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001)  useMissingValue = /* put MissingValue where mask = 0 */
+(PID.TID 0000.0001)                   F
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001)  diagCG_maxIters = /* max number of iters in diag_cg2d */
+(PID.TID 0000.0001)                    1000
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001)  diagCG_resTarget = /* residual target for diag_cg2d */
+(PID.TID 0000.0001)                 1.000000000000000E-13
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001)  diagCG_pcOffDFac = /* preconditioner off-diagonal factor */
+(PID.TID 0000.0001)                 9.611687812379854E-01
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) -----------------------------------------------------
+(PID.TID 0000.0001)  DIAGNOSTICS_READPARMS: active diagnostics summary:
+(PID.TID 0000.0001) -----------------------------------------------------
+(PID.TID 0000.0001) Creating Output Stream: blingTracDiag
+(PID.TID 0000.0001) Output Frequency:     432000.000000 ; Phase:           0.000000
+(PID.TID 0000.0001)  Averaging Freq.:     432000.000000 , Phase:           0.000000 , Cycle:   1
+(PID.TID 0000.0001)  missing value: -9.990000000000E+02
+(PID.TID 0000.0001)  Levels:    will be set later
+(PID.TID 0000.0001)  Fields:    TRAC01   TRAC02   TRAC03   TRAC04   TRAC05   TRAC06   TRAC07   TRAC08
+(PID.TID 0000.0001) Creating Output Stream: adjBlingTracDiag
+(PID.TID 0000.0001) Output Frequency:     432000.000000 ; Phase:           0.000000
+(PID.TID 0000.0001)  Averaging Freq.:     432000.000000 , Phase:           0.000000 , Cycle:   1
+(PID.TID 0000.0001)  missing value: -9.990000000000E+02
+(PID.TID 0000.0001)  Levels:    will be set later
+(PID.TID 0000.0001)  Fields:    ADJptr01 ADJptr02 ADJptr03 ADJptr04 ADJptr05 ADJptr06 ADJptr07 ADJptr08
+(PID.TID 0000.0001) -----------------------------------------------------
+(PID.TID 0000.0001)  DIAGNOSTICS_READPARMS: statistics diags. summary:
+(PID.TID 0000.0001) -----------------------------------------------------
+(PID.TID 0000.0001) 
 (PID.TID 0000.0001) SET_PARMS: done
 (PID.TID 0000.0001) Enter INI_VERTICAL_GRID: setInterFDr=    T ; setCenterDr=    F
 (PID.TID 0000.0001) %MON XC_max                       =   3.5859375000000E+02
@@ -843,7 +963,7 @@
 (PID.TID 0000.0001) -------------
 (PID.TID 0000.0001)  data file = lev_clim_temp.bin
 (PID.TID 0000.0001)  model file = m_sst_day
-(PID.TID 0000.0001)  error file = wt_ones.bin
+(PID.TID 0000.0001)  error file = ones_32b.bin
 (PID.TID 0000.0001)  gencost_flag =  1
 (PID.TID 0000.0001)  gencost_outputlevel =  1
 (PID.TID 0000.0001) 
@@ -1338,8 +1458,8 @@
 (PID.TID 0000.0001) ctrl-wet -------------------------------------------------
 (PID.TID 0000.0001) ctrl-wet -------------------------------------------------
 (PID.TID 0000.0001) ctrl-wet -------------------------------------------------
-(PID.TID 0000.0001) ctrl_init: no. of control variables:            8
-(PID.TID 0000.0001) ctrl_init: control vector length:          445384
+(PID.TID 0000.0001) ctrl_init_wet: no. of control variables:            8
+(PID.TID 0000.0001) ctrl_init_wet: control vector length:          445384
 (PID.TID 0000.0001) 
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // control vector configuration  >>> START <<<
@@ -1362,33 +1482,81 @@
 (PID.TID 0000.0001)  ctrlUseGen  =     T /* use generic controls */
 (PID.TID 0000.0001)  -> 3d control, genarr3d no.  1 is in use
 (PID.TID 0000.0001)       file       = xx_theta
-(PID.TID 0000.0001)       weight     = wt_ones.bin
+(PID.TID 0000.0001)       weight     = ones_32b.bin
+(PID.TID 0000.0001)       index      =  0201
+(PID.TID 0000.0001)       ncvarindex =  0301
 (PID.TID 0000.0001)  -> 3d control, genarr3d no.  2 is in use
 (PID.TID 0000.0001)       file       = xx_salt
-(PID.TID 0000.0001)       weight     = wt_ones.bin
+(PID.TID 0000.0001)       weight     = ones_32b.bin
+(PID.TID 0000.0001)       index      =  0202
+(PID.TID 0000.0001)       ncvarindex =  0302
 (PID.TID 0000.0001)  -> 3d control, genarr3d no.  3 is in use
 (PID.TID 0000.0001)       file       = xx_ptr1
-(PID.TID 0000.0001)       weight     = wt_ones.bin
+(PID.TID 0000.0001)       weight     = ones_32b.bin
+(PID.TID 0000.0001)       index      =  0203
+(PID.TID 0000.0001)       ncvarindex =  0303
 (PID.TID 0000.0001)  -> 3d control, genarr3d no.  4 is in use
 (PID.TID 0000.0001)       file       = xx_ptr2
-(PID.TID 0000.0001)       weight     = wt_ones.bin
+(PID.TID 0000.0001)       weight     = ones_32b.bin
+(PID.TID 0000.0001)       index      =  0204
+(PID.TID 0000.0001)       ncvarindex =  0304
 (PID.TID 0000.0001)  -> 3d control, genarr3d no.  5 is in use
 (PID.TID 0000.0001)       file       = xx_ptr3
-(PID.TID 0000.0001)       weight     = wt_ones.bin
+(PID.TID 0000.0001)       weight     = ones_32b.bin
+(PID.TID 0000.0001)       index      =  0205
+(PID.TID 0000.0001)       ncvarindex =  0305
 (PID.TID 0000.0001)  -> 3d control, genarr3d no.  6 is in use
 (PID.TID 0000.0001)       file       = xx_ptr4
-(PID.TID 0000.0001)       weight     = wt_ones.bin
+(PID.TID 0000.0001)       weight     = ones_32b.bin
+(PID.TID 0000.0001)       index      =  0206
+(PID.TID 0000.0001)       ncvarindex =  0306
 (PID.TID 0000.0001)  -> 3d control, genarr3d no.  7 is in use
 (PID.TID 0000.0001)       file       = xx_ptr5
-(PID.TID 0000.0001)       weight     = wt_ones.bin
+(PID.TID 0000.0001)       weight     = ones_32b.bin
+(PID.TID 0000.0001)       index      =  0207
+(PID.TID 0000.0001)       ncvarindex =  0307
 (PID.TID 0000.0001)  -> 3d control, genarr3d no.  8 is in use
 (PID.TID 0000.0001)       file       = xx_ptr6
-(PID.TID 0000.0001)       weight     = wt_ones.bin
+(PID.TID 0000.0001)       weight     = ones_32b.bin
+(PID.TID 0000.0001)       index      =  0208
+(PID.TID 0000.0001)       ncvarindex =  0308
 (PID.TID 0000.0001) 
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // control vector configuration  >>> END <<<
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) 
+(PID.TID 0000.0001) ------------------------------------------------------------
+(PID.TID 0000.0001) DIAGNOSTICS_SET_LEVELS: done
+(PID.TID 0000.0001)  Total Nb of available Diagnostics: ndiagt=   427
+(PID.TID 0000.0001)  write list of available Diagnostics to file: available_diagnostics.log
+(PID.TID 0000.0001) SETDIAG: Allocate 15 x  1 Levels for Diagnostic #   227 TRAC01
+(PID.TID 0000.0001) SETDIAG: Allocate 15 x  1 Levels for Diagnostic #   242 TRAC02
+(PID.TID 0000.0001) SETDIAG: Allocate 15 x  1 Levels for Diagnostic #   257 TRAC03
+(PID.TID 0000.0001) SETDIAG: Allocate 15 x  1 Levels for Diagnostic #   272 TRAC04
+(PID.TID 0000.0001) SETDIAG: Allocate 15 x  1 Levels for Diagnostic #   287 TRAC05
+(PID.TID 0000.0001) SETDIAG: Allocate 15 x  1 Levels for Diagnostic #   302 TRAC06
+(PID.TID 0000.0001) SETDIAG: Allocate 15 x  1 Levels for Diagnostic #   317 TRAC07
+(PID.TID 0000.0001) SETDIAG: Allocate 15 x  1 Levels for Diagnostic #   332 TRAC08
+(PID.TID 0000.0001) SETDIAG: Allocate 15 x  1 Levels for Diagnostic #   241 ADJptr01
+(PID.TID 0000.0001) SETDIAG: Allocate 15 x  1 Levels for Diagnostic #   256 ADJptr02
+(PID.TID 0000.0001) SETDIAG: Allocate 15 x  1 Levels for Diagnostic #   271 ADJptr03
+(PID.TID 0000.0001) SETDIAG: Allocate 15 x  1 Levels for Diagnostic #   286 ADJptr04
+(PID.TID 0000.0001) SETDIAG: Allocate 15 x  1 Levels for Diagnostic #   301 ADJptr05
+(PID.TID 0000.0001) SETDIAG: Allocate 15 x  1 Levels for Diagnostic #   316 ADJptr06
+(PID.TID 0000.0001) SETDIAG: Allocate 15 x  1 Levels for Diagnostic #   331 ADJptr07
+(PID.TID 0000.0001) SETDIAG: Allocate 15 x  1 Levels for Diagnostic #   346 ADJptr08
+(PID.TID 0000.0001)   space allocated for all diagnostics:     240 levels
+(PID.TID 0000.0001) DIAGNOSTICS_SET_POINTERS: Set levels for Outp.Stream: blingTracDiag
+(PID.TID 0000.0001)  Levels:       1.   2.   3.   4.   5.   6.   7.   8.   9.  10.  11.  12.  13.  14.  15.
+(PID.TID 0000.0001) DIAGNOSTICS_SET_POINTERS: Set levels for Outp.Stream: adjBlingTracDiag
+(PID.TID 0000.0001)  Levels:       1.   2.   3.   4.   5.   6.   7.   8.   9.  10.  11.  12.  13.  14.  15.
+(PID.TID 0000.0001) DIAGNOSTICS_SET_POINTERS: done
+(PID.TID 0000.0001) ------------------------------------------------------------
+(PID.TID 0000.0001) DIAGSTATS_SET_REGIONS: define no region
+(PID.TID 0000.0001) ------------------------------------------------------------
+(PID.TID 0000.0001)   space allocated for all stats-diags:       0 levels
+(PID.TID 0000.0001) DIAGSTATS_SET_POINTERS: done
+(PID.TID 0000.0001) ------------------------------------------------------------
 (PID.TID 0000.0001) %MON fCori_max                    =   1.4579854531444E-04
 (PID.TID 0000.0001) %MON fCori_min                    =  -1.4579854531444E-04
 (PID.TID 0000.0001) %MON fCori_mean                   =   2.3039296165317E-19
@@ -1427,7 +1595,7 @@
 (PID.TID 0000.0001) tRef =   /* Reference temperature profile ( oC or K ) */
 (PID.TID 0000.0001)    15 @  2.000000000000000E+01              /* K =  1: 15 */
 (PID.TID 0000.0001)     ;
-(PID.TID 0000.0001) sRef =   /* Reference salinity profile ( psu ) */
+(PID.TID 0000.0001) sRef =   /* Reference salinity profile ( g/kg ) */
 (PID.TID 0000.0001)    15 @  3.500000000000000E+01              /* K =  1: 15 */
 (PID.TID 0000.0001)     ;
 (PID.TID 0000.0001) useStrainTensionVisc= /* Use StrainTension Form of Viscous Operator */
@@ -1627,7 +1795,7 @@
 (PID.TID 0000.0001) temp_EvPrRn = /* Temp. of Evap/Prec/R (UNSET=use local T)(oC)*/
 (PID.TID 0000.0001)                 1.234567000000000E+05
 (PID.TID 0000.0001)     ;
-(PID.TID 0000.0001) salt_EvPrRn = /* Salin. of Evap/Prec/R (UNSET=use local S)(psu)*/
+(PID.TID 0000.0001) salt_EvPrRn = /* Salin. of Evap/Prec/R (UNSET=use local S)(g/kg)*/
 (PID.TID 0000.0001)                 0.000000000000000E+00
 (PID.TID 0000.0001)     ;
 (PID.TID 0000.0001) selectAddFluid = /* option for mass source/sink of fluid (=0: off) */
@@ -1636,10 +1804,10 @@
 (PID.TID 0000.0001) temp_addMass = /* Temp. of addMass array (UNSET=use local T)(oC)*/
 (PID.TID 0000.0001)                 1.234567000000000E+05
 (PID.TID 0000.0001)     ;
-(PID.TID 0000.0001) salt_addMass = /* Salin. of addMass array (UNSET=use local S)(psu)*/
+(PID.TID 0000.0001) salt_addMass = /* Salin. of addMass array (UNSET=use local S)(g/kg)*/
 (PID.TID 0000.0001)                 0.000000000000000E+00
 (PID.TID 0000.0001)     ;
-(PID.TID 0000.0001) convertFW2Salt = /* convert F.W. Flux to Salt Flux (-1=use local S)(psu)*/
+(PID.TID 0000.0001) convertFW2Salt = /* convert F.W. Flux to Salt Flux (-1=use local S)(g/kg)*/
 (PID.TID 0000.0001)                 3.500000000000000E+01
 (PID.TID 0000.0001)     ;
 (PID.TID 0000.0001) use3Dsolver = /* use 3-D pressure solver on/off flag */
@@ -1935,10 +2103,10 @@
 (PID.TID 0000.0001)                   T
 (PID.TID 0000.0001)     ;
 (PID.TID 0000.0001) monitorFreq =   /* Monitor output interval ( s ). */
-(PID.TID 0000.0001)                 1.000000000000000E+00
+(PID.TID 0000.0001)                 3.600000000000000E+03
 (PID.TID 0000.0001)     ;
 (PID.TID 0000.0001) monitorSelect = /* select group of variables to monitor */
-(PID.TID 0000.0001)                       3
+(PID.TID 0000.0001)                       2
 (PID.TID 0000.0001)     ;
 (PID.TID 0000.0001) monitor_stdio =   /* Model IO flag. */
 (PID.TID 0000.0001)                   T
@@ -2834,7 +3002,7 @@
 (PID.TID 0000.0001)    15 @  9.000000000000000E+02              /* K =  1: 15 */
 (PID.TID 0000.0001)     ;
 (PID.TID 0000.0001) PTRACERS_monitorFreq = /* Frequency^-1 for monitor output (s) */
-(PID.TID 0000.0001)                 1.000000000000000E+00
+(PID.TID 0000.0001)                 3.600000000000000E+03
 (PID.TID 0000.0001)     ;
 (PID.TID 0000.0001) PTRACERS_dumpFreq = /* Frequency^-1 for snapshot output (s) */
 (PID.TID 0000.0001)                 2.160000000000000E+05
@@ -3285,7 +3453,15 @@
 (PID.TID 0000.0001) GCHEM_CHECK  --> Starts to check GCHEM set-up
 (PID.TID 0000.0001) GCHEM_CHECK  <-- Ends Normally
 (PID.TID 0000.0001) 
-(PID.TID 0000.0001) CTRL_CHECK: #define ALLOW_CTRL
+(PID.TID 0000.0001) CTRL_CHECK:  --> Starts to check CTRL set-up
+(PID.TID 0000.0001) CTRL_CHECK: pTracer #   1 in Gen-CTRL
+(PID.TID 0000.0001) CTRL_CHECK: pTracer #   2 in Gen-CTRL
+(PID.TID 0000.0001) CTRL_CHECK: pTracer #   3 in Gen-CTRL
+(PID.TID 0000.0001) CTRL_CHECK: pTracer #   4 in Gen-CTRL
+(PID.TID 0000.0001) CTRL_CHECK: pTracer #   5 in Gen-CTRL
+(PID.TID 0000.0001) CTRL_CHECK: pTracer #   6 in Gen-CTRL
+(PID.TID 0000.0001) CTRL_CHECK:  <-- Ends Normally
+(PID.TID 0000.0001) 
 (PID.TID 0000.0001) COST_CHECK: #define ALLOW_COST
 (PID.TID 0000.0001) GRDCHK_CHECK: grdchk package
 (PID.TID 0000.0001) etaday defined by gencost   0
@@ -3334,31 +3510,6 @@
 (PID.TID 0000.0001) %MON dynstat_salt_mean            =   3.4716565199218E+01
 (PID.TID 0000.0001) %MON dynstat_salt_sd              =   2.9642246219911E-01
 (PID.TID 0000.0001) %MON dynstat_salt_del2            =   3.3126046363364E-04
-(PID.TID 0000.0001) %MON forcing_qnet_max             =   4.4937911987305E+02
-(PID.TID 0000.0001) %MON forcing_qnet_min             =  -2.0417861938477E+02
-(PID.TID 0000.0001) %MON forcing_qnet_mean            =  -1.7498601459148E+01
-(PID.TID 0000.0001) %MON forcing_qnet_sd              =   1.1365585619929E+02
-(PID.TID 0000.0001) %MON forcing_qnet_del2            =   2.8640506155793E-01
-(PID.TID 0000.0001) %MON forcing_qsw_max              =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON forcing_qsw_min              =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON forcing_qsw_mean             =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON forcing_qsw_sd               =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON forcing_qsw_del2             =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON forcing_empmr_max            =   6.6865915471226E-05
-(PID.TID 0000.0001) %MON forcing_empmr_min            =  -1.5018765964214E-04
-(PID.TID 0000.0001) %MON forcing_empmr_mean           =   7.7320599494492E-09
-(PID.TID 0000.0001) %MON forcing_empmr_sd             =   2.3858729798697E-05
-(PID.TID 0000.0001) %MON forcing_empmr_del2           =   1.1192342175733E-07
-(PID.TID 0000.0001) %MON forcing_fu_max               =   2.8468748927116E-01
-(PID.TID 0000.0001) %MON forcing_fu_min               =  -1.5522694587708E-01
-(PID.TID 0000.0001) %MON forcing_fu_mean              =   1.7572056142629E-02
-(PID.TID 0000.0001) %MON forcing_fu_sd                =   8.9999224736116E-02
-(PID.TID 0000.0001) %MON forcing_fu_del2              =   2.6702947614548E-04
-(PID.TID 0000.0001) %MON forcing_fv_max               =   2.1343359351158E-01
-(PID.TID 0000.0001) %MON forcing_fv_min               =  -1.7404061555862E-01
-(PID.TID 0000.0001) %MON forcing_fv_mean              =  -5.8961451090369E-03
-(PID.TID 0000.0001) %MON forcing_fv_sd                =   4.6452039259649E-02
-(PID.TID 0000.0001) %MON forcing_fv_del2              =   1.8991860252817E-04
 (PID.TID 0000.0001) %MON trAdv_CFL_u_max              =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON trAdv_CFL_v_max              =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON trAdv_CFL_w_max              =   0.0000000000000E+00
@@ -3431,401 +3582,8 @@
  BLING_FIELDS_LOAD, it=         0 : Reading new data, i0,i1=   12    1 (prev=   12    0 )
 (PID.TID 0000.0001) SOLVE_FOR_PRESSURE: putPmEinXvector =    F
  cg2d: Sum(rhs),rhsMax =   1.86517468137026E-14  1.12640530997835E+00
-(PID.TID 0000.0001)      cg2d_init_res =   8.70945953329082E+00
-(PID.TID 0000.0001)      cg2d_iters(min,last) =      -1      28
-(PID.TID 0000.0001)      cg2d_last_res =   5.55689298144418E-14
-(PID.TID 0000.0001) // =======================================================
-(PID.TID 0000.0001) // Begin MONITOR dynamic field statistics
-(PID.TID 0000.0001) // =======================================================
-(PID.TID 0000.0001) %MON time_tsnumber                =                     1
-(PID.TID 0000.0001) %MON time_secondsf                =   9.0000000000000E+02
-(PID.TID 0000.0001) %MON dynstat_eta_max              =   9.4778091658998E-02
-(PID.TID 0000.0001) %MON dynstat_eta_min              =  -7.3377448006819E-02
-(PID.TID 0000.0001) %MON dynstat_eta_mean             =   5.7204479550494E-18
-(PID.TID 0000.0001) %MON dynstat_eta_sd               =   1.4841348483969E-02
-(PID.TID 0000.0001) %MON dynstat_eta_del2             =   3.6100821485323E-04
-(PID.TID 0000.0001) %MON dynstat_uvel_max             =   5.8983746437641E-03
-(PID.TID 0000.0001) %MON dynstat_uvel_min             =  -7.7886211737312E-03
-(PID.TID 0000.0001) %MON dynstat_uvel_mean            =  -2.5460695387493E-04
-(PID.TID 0000.0001) %MON dynstat_uvel_sd              =   7.4954516491236E-04
-(PID.TID 0000.0001) %MON dynstat_uvel_del2            =   2.8125105555196E-06
-(PID.TID 0000.0001) %MON dynstat_vvel_max             =   1.3530357005257E-02
-(PID.TID 0000.0001) %MON dynstat_vvel_min             =  -8.8220370709747E-03
-(PID.TID 0000.0001) %MON dynstat_vvel_mean            =   7.1275286104168E-04
-(PID.TID 0000.0001) %MON dynstat_vvel_sd              =   2.5645303783306E-03
-(PID.TID 0000.0001) %MON dynstat_vvel_del2            =   5.1892080721701E-06
-(PID.TID 0000.0001) %MON dynstat_wvel_max             =   1.1851616287534E-04
-(PID.TID 0000.0001) %MON dynstat_wvel_min             =  -8.4620678698462E-05
-(PID.TID 0000.0001) %MON dynstat_wvel_mean            =   3.0203333564733E-22
-(PID.TID 0000.0001) %MON dynstat_wvel_sd              =   1.2910274430925E-05
-(PID.TID 0000.0001) %MON dynstat_wvel_del2            =   1.0717471977224E-07
-(PID.TID 0000.0001) %MON dynstat_theta_max            =   2.9350966546296E+01
-(PID.TID 0000.0001) %MON dynstat_theta_min            =  -1.8999927703884E+00
-(PID.TID 0000.0001) %MON dynstat_theta_mean           =   3.7028405239627E+00
-(PID.TID 0000.0001) %MON dynstat_theta_sd             =   4.4919248721476E+00
-(PID.TID 0000.0001) %MON dynstat_theta_del2           =   1.9124211397397E-03
-(PID.TID 0000.0001) %MON dynstat_salt_max             =   3.7393091729613E+01
-(PID.TID 0000.0001) %MON dynstat_salt_min             =   3.1641560593787E+01
-(PID.TID 0000.0001) %MON dynstat_salt_mean            =   3.4716565220112E+01
-(PID.TID 0000.0001) %MON dynstat_salt_sd              =   2.9642125670149E-01
-(PID.TID 0000.0001) %MON dynstat_salt_del2            =   3.3133200397334E-04
-(PID.TID 0000.0001) %MON forcing_qnet_max             =   4.5173381042480E+02
-(PID.TID 0000.0001) %MON forcing_qnet_min             =  -2.1320401000977E+02
-(PID.TID 0000.0001) %MON forcing_qnet_mean            =  -1.7651133920904E+01
-(PID.TID 0000.0001) %MON forcing_qnet_sd              =   1.1600054643933E+02
-(PID.TID 0000.0001) %MON forcing_qnet_del2            =   2.7307867599176E-01
-(PID.TID 0000.0001) %MON forcing_qsw_max              =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON forcing_qsw_min              =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON forcing_qsw_mean             =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON forcing_qsw_sd               =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON forcing_qsw_del2             =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON forcing_empmr_max            =   6.6865915471226E-05
-(PID.TID 0000.0001) %MON forcing_empmr_min            =  -1.5018765964214E-04
-(PID.TID 0000.0001) %MON forcing_empmr_mean           =   7.7320599494492E-09
-(PID.TID 0000.0001) %MON forcing_empmr_sd             =   2.3858729798697E-05
-(PID.TID 0000.0001) %MON forcing_empmr_del2           =   1.1192342175733E-07
-(PID.TID 0000.0001) %MON forcing_fu_max               =   2.6936699450016E-01
-(PID.TID 0000.0001) %MON forcing_fu_min               =  -1.5727265179157E-01
-(PID.TID 0000.0001) %MON forcing_fu_mean              =   1.7848029829239E-02
-(PID.TID 0000.0001) %MON forcing_fu_sd                =   8.9618937726443E-02
-(PID.TID 0000.0001) %MON forcing_fu_del2              =   2.4788145916980E-04
-(PID.TID 0000.0001) %MON forcing_fv_max               =   1.9744335860014E-01
-(PID.TID 0000.0001) %MON forcing_fv_min               =  -1.5944199264050E-01
-(PID.TID 0000.0001) %MON forcing_fv_mean              =  -6.4503818001955E-03
-(PID.TID 0000.0001) %MON forcing_fv_sd                =   4.4276273939354E-02
-(PID.TID 0000.0001) %MON forcing_fv_del2              =   1.7990220506047E-04
-(PID.TID 0000.0001) %MON trAdv_CFL_u_max              =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON trAdv_CFL_v_max              =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON trAdv_CFL_w_max              =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON advcfl_uvel_max              =   1.3112770255519E-04
-(PID.TID 0000.0001) %MON advcfl_vvel_max              =   3.8944168374581E-05
-(PID.TID 0000.0001) %MON advcfl_wvel_max              =   3.7911236663599E-03
-(PID.TID 0000.0001) %MON advcfl_W_hf_max              =   1.9103770421145E-03
-(PID.TID 0000.0001) %MON pe_b_mean                    =   2.8389020658973E-07
-(PID.TID 0000.0001) %MON ke_max                       =   7.0576475330163E-05
-(PID.TID 0000.0001) %MON ke_mean                      =   3.5442321027997E-06
-(PID.TID 0000.0001) %MON ke_vol                       =   1.2571476858570E+18
-(PID.TID 0000.0001) %MON vort_r_min                   =  -7.1792501578575E-08
-(PID.TID 0000.0001) %MON vort_r_max                   =   7.7514160532054E-08
-(PID.TID 0000.0001) %MON vort_a_mean                  =  -2.4002453570026E-05
-(PID.TID 0000.0001) %MON vort_a_sd                    =   7.3137845726444E-05
-(PID.TID 0000.0001) %MON vort_p_mean                  =  -2.8585773838204E-05
-(PID.TID 0000.0001) %MON vort_p_sd                    =   1.1453370996464E-04
-(PID.TID 0000.0001) %MON surfExpan_theta_mean         =   3.4039938997955E-05
-(PID.TID 0000.0001) %MON surfExpan_salt_mean          =   2.9157001971032E-06
-(PID.TID 0000.0001) // =======================================================
-(PID.TID 0000.0001) // End MONITOR dynamic field statistics
-(PID.TID 0000.0001) // =======================================================
-(PID.TID 0000.0001) // =======================================================
-(PID.TID 0000.0001) // Begin MONITOR ptracer field statistics
-(PID.TID 0000.0001) // =======================================================
-(PID.TID 0000.0001) %MON trcstat_ptracer01_max        =   2.3453000070227E+00
-(PID.TID 0000.0001) %MON trcstat_ptracer01_min        =   1.8064643480366E+00
-(PID.TID 0000.0001) %MON trcstat_ptracer01_mean       =   2.2008880894528E+00
-(PID.TID 0000.0001) %MON trcstat_ptracer01_sd         =   7.6950849699869E-02
-(PID.TID 0000.0001) %MON trcstat_ptracer01_del2       =   4.2699802023500E-05
-(PID.TID 0000.0001) %MON trcstat_ptracer02_max        =   2.3977419966114E+00
-(PID.TID 0000.0001) %MON trcstat_ptracer02_min        =   2.1285226331205E+00
-(PID.TID 0000.0001) %MON trcstat_ptracer02_mean       =   2.3062094510413E+00
-(PID.TID 0000.0001) %MON trcstat_ptracer02_sd         =   4.1745000277287E-02
-(PID.TID 0000.0001) %MON trcstat_ptracer02_del2       =   2.3445207943327E-05
-(PID.TID 0000.0001) %MON trcstat_ptracer03_max        =   4.7902521565203E-01
-(PID.TID 0000.0001) %MON trcstat_ptracer03_min        =   1.7169304866271E-03
-(PID.TID 0000.0001) %MON trcstat_ptracer03_mean       =   1.7341063816078E-01
-(PID.TID 0000.0001) %MON trcstat_ptracer03_sd         =   6.3442830811169E-02
-(PID.TID 0000.0001) %MON trcstat_ptracer03_del2       =   4.9347099373290E-05
-(PID.TID 0000.0001) %MON trcstat_ptracer04_max        =   4.8773334992154E-02
-(PID.TID 0000.0001) %MON trcstat_ptracer04_min        =   3.1663746572035E-07
-(PID.TID 0000.0001) %MON trcstat_ptracer04_mean       =   3.1284105791854E-02
-(PID.TID 0000.0001) %MON trcstat_ptracer04_sd         =   9.0969278226196E-03
-(PID.TID 0000.0001) %MON trcstat_ptracer04_del2       =   6.6093736290645E-06
-(PID.TID 0000.0001) %MON trcstat_ptracer05_max        =   3.6434084491122E-03
-(PID.TID 0000.0001) %MON trcstat_ptracer05_min        =   4.3947602331920E-07
-(PID.TID 0000.0001) %MON trcstat_ptracer05_mean       =   2.1903153815539E-03
-(PID.TID 0000.0001) %MON trcstat_ptracer05_sd         =   6.4714639248499E-04
-(PID.TID 0000.0001) %MON trcstat_ptracer05_del2       =   5.2205500963868E-07
-(PID.TID 0000.0001) %MON trcstat_ptracer06_max        =   4.3130769162563E-06
-(PID.TID 0000.0001) %MON trcstat_ptracer06_min        =   4.5710730204061E-08
-(PID.TID 0000.0001) %MON trcstat_ptracer06_mean       =   4.3239715161377E-07
-(PID.TID 0000.0001) %MON trcstat_ptracer06_sd         =   1.4361483166243E-07
-(PID.TID 0000.0001) %MON trcstat_ptracer06_del2       =   3.2633112100636E-10
-(PID.TID 0000.0001) %MON trcstat_ptracer07_max        =   4.8014079222330E-03
-(PID.TID 0000.0001) %MON trcstat_ptracer07_min        =   9.9999287018024E-12
-(PID.TID 0000.0001) %MON trcstat_ptracer07_mean       =   9.5285650773983E-05
-(PID.TID 0000.0001) %MON trcstat_ptracer07_sd         =   4.2144100413660E-04
-(PID.TID 0000.0001) %MON trcstat_ptracer07_del2       =   5.2781400601383E-07
-(PID.TID 0000.0001) %MON trcstat_ptracer08_max        =   3.0008585555099E-04
-(PID.TID 0000.0001) %MON trcstat_ptracer08_min        =   9.9998574036048E-12
-(PID.TID 0000.0001) %MON trcstat_ptracer08_mean       =   5.9553168243656E-06
-(PID.TID 0000.0001) %MON trcstat_ptracer08_sd         =   2.6339873575433E-05
-(PID.TID 0000.0001) %MON trcstat_ptracer08_del2       =   3.2988140170681E-08
-(PID.TID 0000.0001) // =======================================================
-(PID.TID 0000.0001) // End MONITOR ptracer field statistics
-(PID.TID 0000.0001) // =======================================================
  cg2d: Sum(rhs),rhsMax =  -8.61533067109121E-14  2.39652939031455E+00
-(PID.TID 0000.0001)      cg2d_init_res =   5.22839285007465E+00
-(PID.TID 0000.0001)      cg2d_iters(min,last) =      -1      28
-(PID.TID 0000.0001)      cg2d_last_res =   4.04202872341439E-14
-(PID.TID 0000.0001) // =======================================================
-(PID.TID 0000.0001) // Begin MONITOR dynamic field statistics
-(PID.TID 0000.0001) // =======================================================
-(PID.TID 0000.0001) %MON time_tsnumber                =                     2
-(PID.TID 0000.0001) %MON time_secondsf                =   1.8000000000000E+03
-(PID.TID 0000.0001) %MON dynstat_eta_max              =   2.1727473311363E-01
-(PID.TID 0000.0001) %MON dynstat_eta_min              =  -1.7394236818337E-01
-(PID.TID 0000.0001) %MON dynstat_eta_mean             =   1.2889484797941E-17
-(PID.TID 0000.0001) %MON dynstat_eta_sd               =   3.6638572537488E-02
-(PID.TID 0000.0001) %MON dynstat_eta_del2             =   7.4058278663115E-04
-(PID.TID 0000.0001) %MON dynstat_uvel_max             =   1.2976949120471E-02
-(PID.TID 0000.0001) %MON dynstat_uvel_min             =  -1.3563183656646E-02
-(PID.TID 0000.0001) %MON dynstat_uvel_mean            =  -6.1761456238505E-04
-(PID.TID 0000.0001) %MON dynstat_uvel_sd              =   1.3831033860390E-03
-(PID.TID 0000.0001) %MON dynstat_uvel_del2            =   6.2332193994803E-06
-(PID.TID 0000.0001) %MON dynstat_vvel_max             =   2.4682744645608E-02
-(PID.TID 0000.0001) %MON dynstat_vvel_min             =  -1.5793931975390E-02
-(PID.TID 0000.0001) %MON dynstat_vvel_mean            =   1.3952090874177E-03
-(PID.TID 0000.0001) %MON dynstat_vvel_sd              =   4.8208805777858E-03
-(PID.TID 0000.0001) %MON dynstat_vvel_del2            =   1.0075983963790E-05
-(PID.TID 0000.0001) %MON dynstat_wvel_max             =   1.7115666416273E-04
-(PID.TID 0000.0001) %MON dynstat_wvel_min             =  -1.3382913898418E-04
-(PID.TID 0000.0001) %MON dynstat_wvel_mean            =   4.2473437825405E-22
-(PID.TID 0000.0001) %MON dynstat_wvel_sd              =   2.0318082170746E-05
-(PID.TID 0000.0001) %MON dynstat_wvel_del2            =   1.3442119337901E-07
-(PID.TID 0000.0001) %MON dynstat_theta_max            =   2.9351071561336E+01
-(PID.TID 0000.0001) %MON dynstat_theta_min            =  -1.8999848136924E+00
-(PID.TID 0000.0001) %MON dynstat_theta_mean           =   3.7028288884835E+00
-(PID.TID 0000.0001) %MON dynstat_theta_sd             =   4.4918991690884E+00
-(PID.TID 0000.0001) %MON dynstat_theta_del2           =   1.9126437972842E-03
-(PID.TID 0000.0001) %MON dynstat_salt_max             =   3.7393105087922E+01
-(PID.TID 0000.0001) %MON dynstat_salt_min             =   3.1641544724051E+01
-(PID.TID 0000.0001) %MON dynstat_salt_mean            =   3.4716564206711E+01
-(PID.TID 0000.0001) %MON dynstat_salt_sd              =   2.9642133393414E-01
-(PID.TID 0000.0001) %MON dynstat_salt_del2            =   3.3134950353305E-04
-(PID.TID 0000.0001) %MON forcing_qnet_max             =   4.5173217522303E+02
-(PID.TID 0000.0001) %MON forcing_qnet_min             =  -2.1319512013329E+02
-(PID.TID 0000.0001) %MON forcing_qnet_mean            =  -1.7651027995583E+01
-(PID.TID 0000.0001) %MON forcing_qnet_sd              =   1.1599840457558E+02
-(PID.TID 0000.0001) %MON forcing_qnet_del2            =   2.7308030971727E-01
-(PID.TID 0000.0001) %MON forcing_qsw_max              =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON forcing_qsw_min              =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON forcing_qsw_mean             =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON forcing_qsw_sd               =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON forcing_qsw_del2             =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON forcing_empmr_max            =   6.6865915471226E-05
-(PID.TID 0000.0001) %MON forcing_empmr_min            =  -1.5018765964214E-04
-(PID.TID 0000.0001) %MON forcing_empmr_mean           =   7.7320599494492E-09
-(PID.TID 0000.0001) %MON forcing_empmr_sd             =   2.3858729798697E-05
-(PID.TID 0000.0001) %MON forcing_empmr_del2           =   1.1192342175733E-07
-(PID.TID 0000.0001) %MON forcing_fu_max               =   2.6935862630813E-01
-(PID.TID 0000.0001) %MON forcing_fu_min               =  -1.5727123116247E-01
-(PID.TID 0000.0001) %MON forcing_fu_mean              =   1.7847838180846E-02
-(PID.TID 0000.0001) %MON forcing_fu_sd                =   8.9618742954684E-02
-(PID.TID 0000.0001) %MON forcing_fu_del2              =   2.4788672944513E-04
-(PID.TID 0000.0001) %MON forcing_fv_max               =   1.9745038334384E-01
-(PID.TID 0000.0001) %MON forcing_fv_min               =  -1.5944403406853E-01
-(PID.TID 0000.0001) %MON forcing_fv_mean              =  -6.4499969136044E-03
-(PID.TID 0000.0001) %MON forcing_fv_sd                =   4.4277257751380E-02
-(PID.TID 0000.0001) %MON forcing_fv_del2              =   1.7990161256993E-04
-(PID.TID 0000.0001) %MON trAdv_CFL_u_max              =   1.2208148765810E-04
-(PID.TID 0000.0001) %MON trAdv_CFL_v_max              =   3.9940291692279E-05
-(PID.TID 0000.0001) %MON trAdv_CFL_w_max              =   1.8955618331800E-03
-(PID.TID 0000.0001) %MON advcfl_uvel_max              =   2.2074786911314E-04
-(PID.TID 0000.0001) %MON advcfl_vvel_max              =   7.1043872903861E-05
-(PID.TID 0000.0001) %MON advcfl_wvel_max              =   4.8998656581852E-03
-(PID.TID 0000.0001) %MON advcfl_W_hf_max              =   2.4944380257340E-03
-(PID.TID 0000.0001) %MON pe_b_mean                    =   1.7301381211625E-06
-(PID.TID 0000.0001) %MON ke_max                       =   2.4005664395751E-04
-(PID.TID 0000.0001) %MON ke_mean                      =   1.2631131128923E-05
-(PID.TID 0000.0001) %MON ke_vol                       =   1.2571476858570E+18
-(PID.TID 0000.0001) %MON vort_r_min                   =  -1.2820964929996E-07
-(PID.TID 0000.0001) %MON vort_r_max                   =   1.4440478331118E-07
-(PID.TID 0000.0001) %MON vort_a_mean                  =  -2.4002453570025E-05
-(PID.TID 0000.0001) %MON vort_a_sd                    =   7.3137762484500E-05
-(PID.TID 0000.0001) %MON vort_p_mean                  =  -2.8585773838203E-05
-(PID.TID 0000.0001) %MON vort_p_sd                    =   1.1453350032438E-04
-(PID.TID 0000.0001) %MON surfExpan_theta_mean         =   6.4227388952837E-05
-(PID.TID 0000.0001) %MON surfExpan_salt_mean          =   5.5760715161222E-06
-(PID.TID 0000.0001) // =======================================================
-(PID.TID 0000.0001) // End MONITOR dynamic field statistics
-(PID.TID 0000.0001) // =======================================================
-(PID.TID 0000.0001) // =======================================================
-(PID.TID 0000.0001) // Begin MONITOR ptracer field statistics
-(PID.TID 0000.0001) // =======================================================
-(PID.TID 0000.0001) %MON trcstat_ptracer01_max        =   2.3452981269973E+00
-(PID.TID 0000.0001) %MON trcstat_ptracer01_min        =   1.8064680396481E+00
-(PID.TID 0000.0001) %MON trcstat_ptracer01_mean       =   2.2008881668617E+00
-(PID.TID 0000.0001) %MON trcstat_ptracer01_sd         =   7.6950152045912E-02
-(PID.TID 0000.0001) %MON trcstat_ptracer01_del2       =   4.2743826838336E-05
-(PID.TID 0000.0001) %MON trcstat_ptracer02_max        =   2.3977406904542E+00
-(PID.TID 0000.0001) %MON trcstat_ptracer02_min        =   2.1285231349315E+00
-(PID.TID 0000.0001) %MON trcstat_ptracer02_mean       =   2.3062094269140E+00
-(PID.TID 0000.0001) %MON trcstat_ptracer02_sd         =   4.1744726688719E-02
-(PID.TID 0000.0001) %MON trcstat_ptracer02_del2       =   2.3458189970664E-05
-(PID.TID 0000.0001) %MON trcstat_ptracer03_max        =   4.7901631990406E-01
-(PID.TID 0000.0001) %MON trcstat_ptracer03_min        =   1.7170347266136E-03
-(PID.TID 0000.0001) %MON trcstat_ptracer03_mean       =   1.7341062699669E-01
-(PID.TID 0000.0001) %MON trcstat_ptracer03_sd         =   6.3442555861475E-02
-(PID.TID 0000.0001) %MON trcstat_ptracer03_del2       =   4.9463052164476E-05
-(PID.TID 0000.0001) %MON trcstat_ptracer04_max        =   4.8773242228665E-02
-(PID.TID 0000.0001) %MON trcstat_ptracer04_min        =   2.9857816914167E-07
-(PID.TID 0000.0001) %MON trcstat_ptracer04_mean       =   3.1284116579925E-02
-(PID.TID 0000.0001) %MON trcstat_ptracer04_sd         =   9.0968590937021E-03
-(PID.TID 0000.0001) %MON trcstat_ptracer04_del2       =   6.6199624370194E-06
-(PID.TID 0000.0001) %MON trcstat_ptracer05_max        =   3.6434066643099E-03
-(PID.TID 0000.0001) %MON trcstat_ptracer05_min        =   4.4870958097944E-07
-(PID.TID 0000.0001) %MON trcstat_ptracer05_mean       =   2.1903161047134E-03
-(PID.TID 0000.0001) %MON trcstat_ptracer05_sd         =   6.4714152280254E-04
-(PID.TID 0000.0001) %MON trcstat_ptracer05_del2       =   5.2276946404717E-07
-(PID.TID 0000.0001) %MON trcstat_ptracer06_max        =   4.3116934624859E-06
-(PID.TID 0000.0001) %MON trcstat_ptracer06_min        =   4.5711437168894E-08
-(PID.TID 0000.0001) %MON trcstat_ptracer06_mean       =   4.3239692473185E-07
-(PID.TID 0000.0001) %MON trcstat_ptracer06_sd         =   1.4361117585938E-07
-(PID.TID 0000.0001) %MON trcstat_ptracer06_del2       =   3.2630489920205E-10
-(PID.TID 0000.0001) %MON trcstat_ptracer07_max        =   4.8012318532624E-03
-(PID.TID 0000.0001) %MON trcstat_ptracer07_min        =   9.9999287018024E-12
-(PID.TID 0000.0001) %MON trcstat_ptracer07_mean       =   9.5285362291346E-05
-(PID.TID 0000.0001) %MON trcstat_ptracer07_sd         =   4.2142359089311E-04
-(PID.TID 0000.0001) %MON trcstat_ptracer07_del2       =   5.3098557267641E-07
-(PID.TID 0000.0001) %MON trcstat_ptracer08_max        =   3.0007271182393E-04
-(PID.TID 0000.0001) %MON trcstat_ptracer08_min        =   9.9998574036048E-12
-(PID.TID 0000.0001) %MON trcstat_ptracer08_mean       =   5.9552563346901E-06
-(PID.TID 0000.0001) %MON trcstat_ptracer08_sd         =   2.6338597463093E-05
-(PID.TID 0000.0001) %MON trcstat_ptracer08_del2       =   3.3186125059316E-08
-(PID.TID 0000.0001) // =======================================================
-(PID.TID 0000.0001) // End MONITOR ptracer field statistics
-(PID.TID 0000.0001) // =======================================================
  cg2d: Sum(rhs),rhsMax =  -1.03916875104915E-13  3.40300341422513E+00
-(PID.TID 0000.0001)      cg2d_init_res =   3.68984249461652E+00
-(PID.TID 0000.0001)      cg2d_iters(min,last) =      -1      28
-(PID.TID 0000.0001)      cg2d_last_res =   3.51876920869430E-14
-(PID.TID 0000.0001) // =======================================================
-(PID.TID 0000.0001) // Begin MONITOR dynamic field statistics
-(PID.TID 0000.0001) // =======================================================
-(PID.TID 0000.0001) %MON time_tsnumber                =                     3
-(PID.TID 0000.0001) %MON time_secondsf                =   2.7000000000000E+03
-(PID.TID 0000.0001) %MON dynstat_eta_max              =   3.3253160948298E-01
-(PID.TID 0000.0001) %MON dynstat_eta_min              =  -2.9371922623078E-01
-(PID.TID 0000.0001) %MON dynstat_eta_mean             =   2.5586809845454E-17
-(PID.TID 0000.0001) %MON dynstat_eta_sd               =   6.0846095420267E-02
-(PID.TID 0000.0001) %MON dynstat_eta_del2             =   9.9967430707321E-04
-(PID.TID 0000.0001) %MON dynstat_uvel_max             =   2.2043473835155E-02
-(PID.TID 0000.0001) %MON dynstat_uvel_min             =  -2.0695517279181E-02
-(PID.TID 0000.0001) %MON dynstat_uvel_mean            =  -1.0768109473720E-03
-(PID.TID 0000.0001) %MON dynstat_uvel_sd              =   2.0033867993017E-03
-(PID.TID 0000.0001) %MON dynstat_uvel_del2            =   1.0133130580541E-05
-(PID.TID 0000.0001) %MON dynstat_vvel_max             =   3.3825267948200E-02
-(PID.TID 0000.0001) %MON dynstat_vvel_min             =  -2.0841850883679E-02
-(PID.TID 0000.0001) %MON dynstat_vvel_mean            =   2.0373757410587E-03
-(PID.TID 0000.0001) %MON dynstat_vvel_sd              =   6.7955346135223E-03
-(PID.TID 0000.0001) %MON dynstat_vvel_del2            =   1.5997940564315E-05
-(PID.TID 0000.0001) %MON dynstat_wvel_max             =   2.0578379546030E-04
-(PID.TID 0000.0001) %MON dynstat_wvel_min             =  -1.8104003956210E-04
-(PID.TID 0000.0001) %MON dynstat_wvel_mean            =  -2.7686389101005E-22
-(PID.TID 0000.0001) %MON dynstat_wvel_sd              =   2.4528739350504E-05
-(PID.TID 0000.0001) %MON dynstat_wvel_del2            =   1.3370642143665E-07
-(PID.TID 0000.0001) %MON dynstat_theta_max            =   2.9351175198093E+01
-(PID.TID 0000.0001) %MON dynstat_theta_min            =  -1.8999766875691E+00
-(PID.TID 0000.0001) %MON dynstat_theta_mean           =   3.7028109491916E+00
-(PID.TID 0000.0001) %MON dynstat_theta_sd             =   4.4918624263299E+00
-(PID.TID 0000.0001) %MON dynstat_theta_del2           =   1.9121197709680E-03
-(PID.TID 0000.0001) %MON dynstat_salt_max             =   3.7393118538522E+01
-(PID.TID 0000.0001) %MON dynstat_salt_min             =   3.1641526973171E+01
-(PID.TID 0000.0001) %MON dynstat_salt_mean            =   3.4716562619518E+01
-(PID.TID 0000.0001) %MON dynstat_salt_sd              =   2.9642199258599E-01
-(PID.TID 0000.0001) %MON dynstat_salt_del2            =   3.3133795337092E-04
-(PID.TID 0000.0001) %MON forcing_qnet_max             =   4.5173054002126E+02
-(PID.TID 0000.0001) %MON forcing_qnet_min             =  -2.1318623025682E+02
-(PID.TID 0000.0001) %MON forcing_qnet_mean            =  -1.7650922070262E+01
-(PID.TID 0000.0001) %MON forcing_qnet_sd              =   1.1599626340899E+02
-(PID.TID 0000.0001) %MON forcing_qnet_del2            =   2.7308195433838E-01
-(PID.TID 0000.0001) %MON forcing_qsw_max              =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON forcing_qsw_min              =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON forcing_qsw_mean             =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON forcing_qsw_sd               =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON forcing_qsw_del2             =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON forcing_empmr_max            =   6.6865915471226E-05
-(PID.TID 0000.0001) %MON forcing_empmr_min            =  -1.5018765964214E-04
-(PID.TID 0000.0001) %MON forcing_empmr_mean           =   7.7320599494492E-09
-(PID.TID 0000.0001) %MON forcing_empmr_sd             =   2.3858729798697E-05
-(PID.TID 0000.0001) %MON forcing_empmr_del2           =   1.1192342175733E-07
-(PID.TID 0000.0001) %MON forcing_fu_max               =   2.6935025811609E-01
-(PID.TID 0000.0001) %MON forcing_fu_min               =  -1.5726981053336E-01
-(PID.TID 0000.0001) %MON forcing_fu_mean              =   1.7847646532452E-02
-(PID.TID 0000.0001) %MON forcing_fu_sd                =   8.9618548821031E-02
-(PID.TID 0000.0001) %MON forcing_fu_del2              =   2.4789201147794E-04
-(PID.TID 0000.0001) %MON forcing_fv_max               =   1.9745740808754E-01
-(PID.TID 0000.0001) %MON forcing_fv_min               =  -1.5944607549657E-01
-(PID.TID 0000.0001) %MON forcing_fv_mean              =  -6.4496120270133E-03
-(PID.TID 0000.0001) %MON forcing_fv_sd                =   4.4278242325737E-02
-(PID.TID 0000.0001) %MON forcing_fv_del2              =   1.7990103083771E-04
-(PID.TID 0000.0001) %MON trAdv_CFL_u_max              =   2.1973719440204E-04
-(PID.TID 0000.0001) %MON trAdv_CFL_v_max              =   7.2861050194655E-05
-(PID.TID 0000.0001) %MON trAdv_CFL_w_max              =   2.4499328290926E-03
-(PID.TID 0000.0001) %MON advcfl_uvel_max              =   3.4842568067926E-04
-(PID.TID 0000.0001) %MON advcfl_vvel_max              =   9.7358623263095E-05
-(PID.TID 0000.0001) %MON advcfl_wvel_max              =   5.0334413773901E-03
-(PID.TID 0000.0001) %MON advcfl_W_hf_max              =   2.5553424280834E-03
-(PID.TID 0000.0001) %MON pe_b_mean                    =   4.7716558569138E-06
-(PID.TID 0000.0001) %MON ke_max                       =   4.6905861060657E-04
-(PID.TID 0000.0001) %MON ke_mean                      =   2.5512878252912E-05
-(PID.TID 0000.0001) %MON ke_vol                       =   1.2571476858570E+18
-(PID.TID 0000.0001) %MON vort_r_min                   =  -1.8687103030402E-07
-(PID.TID 0000.0001) %MON vort_r_max                   =   2.0838905916377E-07
-(PID.TID 0000.0001) %MON vort_a_mean                  =  -2.4002453570025E-05
-(PID.TID 0000.0001) %MON vort_a_sd                    =   7.3137662312030E-05
-(PID.TID 0000.0001) %MON vort_p_mean                  =  -2.8585773838203E-05
-(PID.TID 0000.0001) %MON vort_p_sd                    =   1.1453321474612E-04
-(PID.TID 0000.0001) %MON surfExpan_theta_mean         =   9.0241155515329E-05
-(PID.TID 0000.0001) %MON surfExpan_salt_mean          =   7.8941098766167E-06
-(PID.TID 0000.0001) // =======================================================
-(PID.TID 0000.0001) // End MONITOR dynamic field statistics
-(PID.TID 0000.0001) // =======================================================
-(PID.TID 0000.0001) // =======================================================
-(PID.TID 0000.0001) // Begin MONITOR ptracer field statistics
-(PID.TID 0000.0001) // =======================================================
-(PID.TID 0000.0001) %MON trcstat_ptracer01_max        =   2.3452964169860E+00
-(PID.TID 0000.0001) %MON trcstat_ptracer01_min        =   1.8064712486922E+00
-(PID.TID 0000.0001) %MON trcstat_ptracer01_mean       =   2.2008882851074E+00
-(PID.TID 0000.0001) %MON trcstat_ptracer01_sd         =   7.6949664833527E-02
-(PID.TID 0000.0001) %MON trcstat_ptracer01_del2       =   4.2748275627348E-05
-(PID.TID 0000.0001) %MON trcstat_ptracer02_max        =   2.3977392411021E+00
-(PID.TID 0000.0001) %MON trcstat_ptracer02_min        =   2.1285208113987E+00
-(PID.TID 0000.0001) %MON trcstat_ptracer02_mean       =   2.3062093819816E+00
-(PID.TID 0000.0001) %MON trcstat_ptracer02_sd         =   4.1744672292574E-02
-(PID.TID 0000.0001) %MON trcstat_ptracer02_del2       =   2.3462339106800E-05
-(PID.TID 0000.0001) %MON trcstat_ptracer03_max        =   4.7900767348166E-01
-(PID.TID 0000.0001) %MON trcstat_ptracer03_min        =   1.7171430172665E-03
-(PID.TID 0000.0001) %MON trcstat_ptracer03_mean       =   1.7341065854372E-01
-(PID.TID 0000.0001) %MON trcstat_ptracer03_sd         =   6.3442495078335E-02
-(PID.TID 0000.0001) %MON trcstat_ptracer03_del2       =   4.9487828322778E-05
-(PID.TID 0000.0001) %MON trcstat_ptracer04_max        =   4.8773144712737E-02
-(PID.TID 0000.0001) %MON trcstat_ptracer04_min        =   1.2327490349296E-07
-(PID.TID 0000.0001) %MON trcstat_ptracer04_mean       =   3.1284136297731E-02
-(PID.TID 0000.0001) %MON trcstat_ptracer04_sd         =   9.0968015021201E-03
-(PID.TID 0000.0001) %MON trcstat_ptracer04_del2       =   6.6221988242045E-06
-(PID.TID 0000.0001) %MON trcstat_ptracer05_max        =   3.6434049715374E-03
-(PID.TID 0000.0001) %MON trcstat_ptracer05_min        =   4.5715409031255E-07
-(PID.TID 0000.0001) %MON trcstat_ptracer05_mean       =   2.1903174008182E-03
-(PID.TID 0000.0001) %MON trcstat_ptracer05_sd         =   6.4713787764767E-04
-(PID.TID 0000.0001) %MON trcstat_ptracer05_del2       =   5.2291489607870E-07
-(PID.TID 0000.0001) %MON trcstat_ptracer06_max        =   4.3103131333307E-06
-(PID.TID 0000.0001) %MON trcstat_ptracer06_min        =   4.5712012956176E-08
-(PID.TID 0000.0001) %MON trcstat_ptracer06_mean       =   4.3239666710980E-07
-(PID.TID 0000.0001) %MON trcstat_ptracer06_sd         =   1.4360804837323E-07
-(PID.TID 0000.0001) %MON trcstat_ptracer06_del2       =   3.2626499137700E-10
-(PID.TID 0000.0001) %MON trcstat_ptracer07_max        =   4.8009368541099E-03
-(PID.TID 0000.0001) %MON trcstat_ptracer07_min        =   9.9999287018024E-12
-(PID.TID 0000.0001) %MON trcstat_ptracer07_mean       =   9.5285415776056E-05
-(PID.TID 0000.0001) %MON trcstat_ptracer07_sd         =   4.2142054544550E-04
-(PID.TID 0000.0001) %MON trcstat_ptracer07_del2       =   5.3181990992376E-07
-(PID.TID 0000.0001) %MON trcstat_ptracer08_max        =   3.0005213529166E-04
-(PID.TID 0000.0001) %MON trcstat_ptracer08_min        =   9.9998574036048E-12
-(PID.TID 0000.0001) %MON trcstat_ptracer08_mean       =   5.9552172184980E-06
-(PID.TID 0000.0001) %MON trcstat_ptracer08_sd         =   2.6338219335595E-05
-(PID.TID 0000.0001) %MON trcstat_ptracer08_del2       =   3.3238033409119E-08
-(PID.TID 0000.0001) // =======================================================
-(PID.TID 0000.0001) // End MONITOR ptracer field statistics
-(PID.TID 0000.0001) // =======================================================
  cg2d: Sum(rhs),rhsMax =  -1.18349774425042E-13  4.12647380987143E+00
 (PID.TID 0000.0001)      cg2d_init_res =   2.97840395365656E+00
 (PID.TID 0000.0001)      cg2d_iters(min,last) =      -1      28
@@ -3865,31 +3623,6 @@
 (PID.TID 0000.0001) %MON dynstat_salt_mean            =   3.4716560533193E+01
 (PID.TID 0000.0001) %MON dynstat_salt_sd              =   2.9642287051355E-01
 (PID.TID 0000.0001) %MON dynstat_salt_del2            =   3.3132484212418E-04
-(PID.TID 0000.0001) %MON forcing_qnet_max             =   4.5172890481949E+02
-(PID.TID 0000.0001) %MON forcing_qnet_min             =  -2.1317734038035E+02
-(PID.TID 0000.0001) %MON forcing_qnet_mean            =  -1.7650816144942E+01
-(PID.TID 0000.0001) %MON forcing_qnet_sd              =   1.1599412293960E+02
-(PID.TID 0000.0001) %MON forcing_qnet_del2            =   2.7308360985490E-01
-(PID.TID 0000.0001) %MON forcing_qsw_max              =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON forcing_qsw_min              =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON forcing_qsw_mean             =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON forcing_qsw_sd               =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON forcing_qsw_del2             =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON forcing_empmr_max            =   6.6865915471226E-05
-(PID.TID 0000.0001) %MON forcing_empmr_min            =  -1.5018765964214E-04
-(PID.TID 0000.0001) %MON forcing_empmr_mean           =   7.7320599494492E-09
-(PID.TID 0000.0001) %MON forcing_empmr_sd             =   2.3858729798697E-05
-(PID.TID 0000.0001) %MON forcing_empmr_del2           =   1.1192342175733E-07
-(PID.TID 0000.0001) %MON forcing_fu_max               =   2.6934188992406E-01
-(PID.TID 0000.0001) %MON forcing_fu_min               =  -1.5726838990425E-01
-(PID.TID 0000.0001) %MON forcing_fu_mean              =   1.7847454884059E-02
-(PID.TID 0000.0001) %MON forcing_fu_sd                =   8.9618355325489E-02
-(PID.TID 0000.0001) %MON forcing_fu_del2              =   2.4789730526748E-04
-(PID.TID 0000.0001) %MON forcing_fv_max               =   1.9746443283123E-01
-(PID.TID 0000.0001) %MON forcing_fv_min               =  -1.5944811692461E-01
-(PID.TID 0000.0001) %MON forcing_fv_mean              =  -6.4492271404222E-03
-(PID.TID 0000.0001) %MON forcing_fv_sd                =   4.4279227662373E-02
-(PID.TID 0000.0001) %MON forcing_fv_del2              =   1.7990045986391E-04
 (PID.TID 0000.0001) %MON trAdv_CFL_u_max              =   3.4846066466083E-04
 (PID.TID 0000.0001) %MON trAdv_CFL_v_max              =   9.9848885576019E-05
 (PID.TID 0000.0001) %MON trAdv_CFL_w_max              =   2.5553424280834E-03
@@ -3989,9 +3722,179 @@
 (PID.TID 0000.0001) Did not write pickup because writePickupAtEnd = FALSE
  cg2d: Sum(rhs),rhsMax =  -2.19598898065776E-07  4.12648249115271E+00
 (PID.TID 0000.0001) Did not write pickup because writePickupAtEnd = FALSE
+(PID.TID 0000.0001) // =======================================================
+(PID.TID 0000.0001) // Begin AD_MONITOR dynamic field statistics
+(PID.TID 0000.0001) // =======================================================
+(PID.TID 0000.0001) %MON ad_time_tsnumber             =                     4
+(PID.TID 0000.0001) %MON ad_time_secondsf             =   3.6000000000000E+03
+(PID.TID 0000.0001) %MON ad_dynstat_adeta_max         =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON ad_dynstat_adeta_min         =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON ad_dynstat_adeta_mean        =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON ad_dynstat_adeta_sd          =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON ad_dynstat_adeta_del2        =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON ad_dynstat_aduvel_max        =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON ad_dynstat_aduvel_min        =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON ad_dynstat_aduvel_mean       =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON ad_dynstat_aduvel_sd         =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON ad_dynstat_aduvel_del2       =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON ad_dynstat_advvel_max        =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON ad_dynstat_advvel_min        =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON ad_dynstat_advvel_mean       =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON ad_dynstat_advvel_sd         =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON ad_dynstat_advvel_del2       =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON ad_dynstat_adwvel_max        =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON ad_dynstat_adwvel_min        =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON ad_dynstat_adwvel_mean       =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON ad_dynstat_adwvel_sd         =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON ad_dynstat_adwvel_del2       =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON ad_dynstat_adtheta_max       =   1.3336181873456E-04
+(PID.TID 0000.0001) %MON ad_dynstat_adtheta_min       =  -2.5329589843750E-04
+(PID.TID 0000.0001) %MON ad_dynstat_adtheta_mean      =   4.6617470614945E-08
+(PID.TID 0000.0001) %MON ad_dynstat_adtheta_sd        =   6.1863825649512E-06
+(PID.TID 0000.0001) %MON ad_dynstat_adtheta_del2      =   3.8336508972263E-08
+(PID.TID 0000.0001) %MON ad_dynstat_adsalt_max        =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON ad_dynstat_adsalt_min        =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON ad_dynstat_adsalt_mean       =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON ad_dynstat_adsalt_sd         =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON ad_dynstat_adsalt_del2       =   0.0000000000000E+00
+(PID.TID 0000.0001) // =======================================================
+(PID.TID 0000.0001) // End AD_MONITOR dynamic field statistics
+(PID.TID 0000.0001) // =======================================================
+(PID.TID 0000.0001) // =======================================================
+(PID.TID 0000.0001) // Begin AD_MONITOR ptracer field statistics
+(PID.TID 0000.0001) // =======================================================
+(PID.TID 0000.0001) %MON ad_trcstat_adptracer01_max   =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON ad_trcstat_adptracer01_min   =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON ad_trcstat_adptracer01_mean  =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON ad_trcstat_adptracer01_sd    =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON ad_trcstat_adptracer01_del2  =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON ad_trcstat_adptracer02_max   =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON ad_trcstat_adptracer02_min   =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON ad_trcstat_adptracer02_mean  =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON ad_trcstat_adptracer02_sd    =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON ad_trcstat_adptracer02_del2  =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON ad_trcstat_adptracer03_max   =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON ad_trcstat_adptracer03_min   =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON ad_trcstat_adptracer03_mean  =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON ad_trcstat_adptracer03_sd    =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON ad_trcstat_adptracer03_del2  =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON ad_trcstat_adptracer04_max   =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON ad_trcstat_adptracer04_min   =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON ad_trcstat_adptracer04_mean  =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON ad_trcstat_adptracer04_sd    =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON ad_trcstat_adptracer04_del2  =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON ad_trcstat_adptracer05_max   =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON ad_trcstat_adptracer05_min   =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON ad_trcstat_adptracer05_mean  =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON ad_trcstat_adptracer05_sd    =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON ad_trcstat_adptracer05_del2  =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON ad_trcstat_adptracer06_max   =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON ad_trcstat_adptracer06_min   =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON ad_trcstat_adptracer06_mean  =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON ad_trcstat_adptracer06_sd    =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON ad_trcstat_adptracer06_del2  =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON ad_trcstat_adptracer07_max   =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON ad_trcstat_adptracer07_min   =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON ad_trcstat_adptracer07_mean  =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON ad_trcstat_adptracer07_sd    =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON ad_trcstat_adptracer07_del2  =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON ad_trcstat_adptracer08_max   =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON ad_trcstat_adptracer08_min   =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON ad_trcstat_adptracer08_mean  =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON ad_trcstat_adptracer08_sd    =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON ad_trcstat_adptracer08_del2  =   0.0000000000000E+00
+(PID.TID 0000.0001) // =======================================================
+(PID.TID 0000.0001) // End AD_MONITOR ptracer field statistics
+(PID.TID 0000.0001) // =======================================================
+ Calling cg2d from S/R CG2D_SAD
  cg2d: Sum(rhs),rhsMax =   0.00000000000000E+00  0.00000000000000E+00
  cg2d: Sum(rhs),rhsMax =  -1.47960689478310E-07  3.40300532400976E+00
  cg2d: Sum(rhs),rhsMax =  -1.47960689478310E-07  3.40300532400976E+00
+(PID.TID 0000.0001) // =======================================================
+(PID.TID 0000.0001) // Begin AD_MONITOR dynamic field statistics
+(PID.TID 0000.0001) // =======================================================
+(PID.TID 0000.0001) %MON ad_time_tsnumber             =                     3
+(PID.TID 0000.0001) %MON ad_time_secondsf             =   2.7000000000000E+03
+(PID.TID 0000.0001) %MON ad_dynstat_adeta_max         =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON ad_dynstat_adeta_min         =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON ad_dynstat_adeta_mean        =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON ad_dynstat_adeta_sd          =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON ad_dynstat_adeta_del2        =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON ad_dynstat_aduvel_max        =   3.4044801106696E-06
+(PID.TID 0000.0001) %MON ad_dynstat_aduvel_min        =  -7.3382331479668E-07
+(PID.TID 0000.0001) %MON ad_dynstat_aduvel_mean       =   2.4052767887769E-10
+(PID.TID 0000.0001) %MON ad_dynstat_aduvel_sd         =   1.9223824392142E-08
+(PID.TID 0000.0001) %MON ad_dynstat_aduvel_del2       =   1.9962856621217E-10
+(PID.TID 0000.0001) %MON ad_dynstat_advvel_max        =   1.0297373655446E-06
+(PID.TID 0000.0001) %MON ad_dynstat_advvel_min        =  -4.2289129385916E-06
+(PID.TID 0000.0001) %MON ad_dynstat_advvel_mean       =  -3.8555425647591E-09
+(PID.TID 0000.0001) %MON ad_dynstat_advvel_sd         =   5.6610397601293E-08
+(PID.TID 0000.0001) %MON ad_dynstat_advvel_del2       =   4.0492815552689E-10
+(PID.TID 0000.0001) %MON ad_dynstat_adwvel_max        =   1.3618606958794E-02
+(PID.TID 0000.0001) %MON ad_dynstat_adwvel_min        =  -1.6702241165980E-02
+(PID.TID 0000.0001) %MON ad_dynstat_adwvel_mean       =  -9.0108347666903E-07
+(PID.TID 0000.0001) %MON ad_dynstat_adwvel_sd         =   3.1179190181962E-04
+(PID.TID 0000.0001) %MON ad_dynstat_adwvel_del2       =   3.0190007531647E-06
+(PID.TID 0000.0001) %MON ad_dynstat_adtheta_max       =   2.6675450686988E-04
+(PID.TID 0000.0001) %MON ad_dynstat_adtheta_min       =  -5.0619614566291E-04
+(PID.TID 0000.0001) %MON ad_dynstat_adtheta_mean      =   9.3191972532440E-08
+(PID.TID 0000.0001) %MON ad_dynstat_adtheta_sd        =   1.2370142430461E-05
+(PID.TID 0000.0001) %MON ad_dynstat_adtheta_del2      =   7.6659308502612E-08
+(PID.TID 0000.0001) %MON ad_dynstat_adsalt_max        =   2.6426561487150E-06
+(PID.TID 0000.0001) %MON ad_dynstat_adsalt_min        =  -2.6654730015122E-06
+(PID.TID 0000.0001) %MON ad_dynstat_adsalt_mean       =  -6.0898958377160E-11
+(PID.TID 0000.0001) %MON ad_dynstat_adsalt_sd         =   1.1726205469853E-08
+(PID.TID 0000.0001) %MON ad_dynstat_adsalt_del2       =   2.1048465162908E-10
+(PID.TID 0000.0001) // =======================================================
+(PID.TID 0000.0001) // End AD_MONITOR dynamic field statistics
+(PID.TID 0000.0001) // =======================================================
+(PID.TID 0000.0001) // =======================================================
+(PID.TID 0000.0001) // Begin AD_MONITOR ptracer field statistics
+(PID.TID 0000.0001) // =======================================================
+(PID.TID 0000.0001) %MON ad_trcstat_adptracer01_max   =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON ad_trcstat_adptracer01_min   =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON ad_trcstat_adptracer01_mean  =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON ad_trcstat_adptracer01_sd    =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON ad_trcstat_adptracer01_del2  =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON ad_trcstat_adptracer02_max   =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON ad_trcstat_adptracer02_min   =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON ad_trcstat_adptracer02_mean  =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON ad_trcstat_adptracer02_sd    =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON ad_trcstat_adptracer02_del2  =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON ad_trcstat_adptracer03_max   =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON ad_trcstat_adptracer03_min   =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON ad_trcstat_adptracer03_mean  =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON ad_trcstat_adptracer03_sd    =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON ad_trcstat_adptracer03_del2  =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON ad_trcstat_adptracer04_max   =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON ad_trcstat_adptracer04_min   =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON ad_trcstat_adptracer04_mean  =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON ad_trcstat_adptracer04_sd    =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON ad_trcstat_adptracer04_del2  =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON ad_trcstat_adptracer05_max   =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON ad_trcstat_adptracer05_min   =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON ad_trcstat_adptracer05_mean  =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON ad_trcstat_adptracer05_sd    =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON ad_trcstat_adptracer05_del2  =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON ad_trcstat_adptracer06_max   =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON ad_trcstat_adptracer06_min   =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON ad_trcstat_adptracer06_mean  =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON ad_trcstat_adptracer06_sd    =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON ad_trcstat_adptracer06_del2  =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON ad_trcstat_adptracer07_max   =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON ad_trcstat_adptracer07_min   =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON ad_trcstat_adptracer07_mean  =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON ad_trcstat_adptracer07_sd    =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON ad_trcstat_adptracer07_del2  =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON ad_trcstat_adptracer08_max   =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON ad_trcstat_adptracer08_min   =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON ad_trcstat_adptracer08_mean  =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON ad_trcstat_adptracer08_sd    =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON ad_trcstat_adptracer08_del2  =   0.0000000000000E+00
+(PID.TID 0000.0001) // =======================================================
+(PID.TID 0000.0001) // End AD_MONITOR ptracer field statistics
+(PID.TID 0000.0001) // =======================================================
+ Calling cg2d from S/R CG2D_SAD
  cg2d: Sum(rhs),rhsMax =  -6.66133814775094E-15  8.94842829727029E-11
  EXTERNAL_FIELDS_LOAD, it=         0 : Reading new data, i0,i1=   12    1 (prev=   12    1 )
  BLING_FIELDS_LOAD, it=         0 : Reading new data, i0,i1=   12    1 (prev=   12    1 )
@@ -4000,6 +3903,91 @@
  cg2d: Sum(rhs),rhsMax =  -1.01696429055664E-13  2.39652939031455E+00
  cg2d: Sum(rhs),rhsMax =  -5.62424080641222E-08  2.39653793385382E+00
  cg2d: Sum(rhs),rhsMax =  -5.62424080641222E-08  2.39653793385382E+00
+(PID.TID 0000.0001) // =======================================================
+(PID.TID 0000.0001) // Begin AD_MONITOR dynamic field statistics
+(PID.TID 0000.0001) // =======================================================
+(PID.TID 0000.0001) %MON ad_time_tsnumber             =                     2
+(PID.TID 0000.0001) %MON ad_time_secondsf             =   1.8000000000000E+03
+(PID.TID 0000.0001) %MON ad_dynstat_adeta_max         =   6.3395720359212E-06
+(PID.TID 0000.0001) %MON ad_dynstat_adeta_min         =  -4.7885264695627E-06
+(PID.TID 0000.0001) %MON ad_dynstat_adeta_mean        =   4.4876476585256E-10
+(PID.TID 0000.0001) %MON ad_dynstat_adeta_sd          =   5.4780140198590E-07
+(PID.TID 0000.0001) %MON ad_dynstat_adeta_del2        =   1.6998224259818E-08
+(PID.TID 0000.0001) %MON ad_dynstat_aduvel_max        =   6.7273173812922E-04
+(PID.TID 0000.0001) %MON ad_dynstat_aduvel_min        =  -6.6501934130690E-04
+(PID.TID 0000.0001) %MON ad_dynstat_aduvel_mean       =  -1.2866148092501E-07
+(PID.TID 0000.0001) %MON ad_dynstat_aduvel_sd         =   5.5283213747785E-06
+(PID.TID 0000.0001) %MON ad_dynstat_aduvel_del2       =   9.2292064054600E-08
+(PID.TID 0000.0001) %MON ad_dynstat_advvel_max        =   1.6496274316665E-03
+(PID.TID 0000.0001) %MON ad_dynstat_advvel_min        =  -2.3679964004403E-03
+(PID.TID 0000.0001) %MON ad_dynstat_advvel_mean       =   1.5026680289700E-07
+(PID.TID 0000.0001) %MON ad_dynstat_advvel_sd         =   1.4532902098232E-05
+(PID.TID 0000.0001) %MON ad_dynstat_advvel_del2       =   2.6328749188216E-07
+(PID.TID 0000.0001) %MON ad_dynstat_adwvel_max        =   1.9469524627553E+00
+(PID.TID 0000.0001) %MON ad_dynstat_adwvel_min        =  -1.6433075486752E+01
+(PID.TID 0000.0001) %MON ad_dynstat_adwvel_mean       =  -2.0989517607266E-04
+(PID.TID 0000.0001) %MON ad_dynstat_adwvel_sd         =   5.3503140628278E-02
+(PID.TID 0000.0001) %MON ad_dynstat_adwvel_del2       =   1.5813046547897E-03
+(PID.TID 0000.0001) %MON ad_dynstat_adtheta_max       =   4.0006601694361E-04
+(PID.TID 0000.0001) %MON ad_dynstat_adtheta_min       =  -7.4829910730019E-01
+(PID.TID 0000.0001) %MON ad_dynstat_adtheta_mean      =  -4.8620403810177E-05
+(PID.TID 0000.0001) %MON ad_dynstat_adtheta_sd        =   4.3698751556551E-03
+(PID.TID 0000.0001) %MON ad_dynstat_adtheta_del2      =   8.3988783982069E-05
+(PID.TID 0000.0001) %MON ad_dynstat_adsalt_max        =   6.7425321981981E-05
+(PID.TID 0000.0001) %MON ad_dynstat_adsalt_min        =  -5.2898573254338E-01
+(PID.TID 0000.0001) %MON ad_dynstat_adsalt_mean       =  -3.4688832385057E-05
+(PID.TID 0000.0001) %MON ad_dynstat_adsalt_sd         =   3.0945988887126E-03
+(PID.TID 0000.0001) %MON ad_dynstat_adsalt_del2       =   5.9930784858397E-05
+(PID.TID 0000.0001) // =======================================================
+(PID.TID 0000.0001) // End AD_MONITOR dynamic field statistics
+(PID.TID 0000.0001) // =======================================================
+(PID.TID 0000.0001) // =======================================================
+(PID.TID 0000.0001) // Begin AD_MONITOR ptracer field statistics
+(PID.TID 0000.0001) // =======================================================
+(PID.TID 0000.0001) %MON ad_trcstat_adptracer01_max   =   5.6356047620543E-04
+(PID.TID 0000.0001) %MON ad_trcstat_adptracer01_min   =  -1.4739884041966E+02
+(PID.TID 0000.0001) %MON ad_trcstat_adptracer01_mean  =  -9.3724364074442E-03
+(PID.TID 0000.0001) %MON ad_trcstat_adptracer01_sd    =   8.4641740266065E-01
+(PID.TID 0000.0001) %MON ad_trcstat_adptracer01_del2  =   1.5699978472062E-02
+(PID.TID 0000.0001) %MON ad_trcstat_adptracer02_max   =   1.4449445813751E+02
+(PID.TID 0000.0001) %MON ad_trcstat_adptracer02_min   =  -5.5245594326738E-04
+(PID.TID 0000.0001) %MON ad_trcstat_adptracer02_mean  =   9.1675377421205E-03
+(PID.TID 0000.0001) %MON ad_trcstat_adptracer02_sd    =   8.2871009114870E-01
+(PID.TID 0000.0001) %MON ad_trcstat_adptracer02_del2  =   1.5328772125485E-02
+(PID.TID 0000.0001) %MON ad_trcstat_adptracer03_max   =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON ad_trcstat_adptracer03_min   =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON ad_trcstat_adptracer03_mean  =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON ad_trcstat_adptracer03_sd    =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON ad_trcstat_adptracer03_del2  =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON ad_trcstat_adptracer04_max   =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON ad_trcstat_adptracer04_min   =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON ad_trcstat_adptracer04_mean  =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON ad_trcstat_adptracer04_sd    =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON ad_trcstat_adptracer04_del2  =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON ad_trcstat_adptracer05_max   =   5.5907316674179E-04
+(PID.TID 0000.0001) %MON ad_trcstat_adptracer05_min   =  -1.4622518757474E+02
+(PID.TID 0000.0001) %MON ad_trcstat_adptracer05_mean  =  -9.3108828177317E-03
+(PID.TID 0000.0001) %MON ad_trcstat_adptracer05_sd    =   8.4077761730692E-01
+(PID.TID 0000.0001) %MON ad_trcstat_adptracer05_del2  =   1.5615666820603E-02
+(PID.TID 0000.0001) %MON ad_trcstat_adptracer06_max   =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON ad_trcstat_adptracer06_min   =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON ad_trcstat_adptracer06_mean  =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON ad_trcstat_adptracer06_sd    =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON ad_trcstat_adptracer06_del2  =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON ad_trcstat_adptracer07_max   =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON ad_trcstat_adptracer07_min   =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON ad_trcstat_adptracer07_mean  =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON ad_trcstat_adptracer07_sd    =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON ad_trcstat_adptracer07_del2  =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON ad_trcstat_adptracer08_max   =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON ad_trcstat_adptracer08_min   =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON ad_trcstat_adptracer08_mean  =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON ad_trcstat_adptracer08_sd    =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON ad_trcstat_adptracer08_del2  =   0.0000000000000E+00
+(PID.TID 0000.0001) // =======================================================
+(PID.TID 0000.0001) // End AD_MONITOR ptracer field statistics
+(PID.TID 0000.0001) // =======================================================
+ Calling cg2d from S/R CG2D_SAD
  cg2d: Sum(rhs),rhsMax =  -5.61616725347491E-17  1.46080023280902E-06
  EXTERNAL_FIELDS_LOAD, it=         0 : Reading new data, i0,i1=   12    1 (prev=   12    1 )
  BLING_FIELDS_LOAD, it=         0 : Reading new data, i0,i1=   12    1 (prev=   12    1 )
@@ -4009,11 +3997,180 @@
  BLING_FIELDS_LOAD, it=         0 : Reading new data, i0,i1=   12    1 (prev=   12    1 )
 (PID.TID 0000.0001) SOLVE_FOR_PRESSURE: putPmEinXvector =    F
  cg2d: Sum(rhs),rhsMax =   1.86517468137026E-14  1.12640530997835E+00
+(PID.TID 0000.0001) // =======================================================
+(PID.TID 0000.0001) // Begin AD_MONITOR dynamic field statistics
+(PID.TID 0000.0001) // =======================================================
+(PID.TID 0000.0001) %MON ad_time_tsnumber             =                     1
+(PID.TID 0000.0001) %MON ad_time_secondsf             =   9.0000000000000E+02
+(PID.TID 0000.0001) %MON ad_dynstat_adeta_max         =   3.7981436236293E-02
+(PID.TID 0000.0001) %MON ad_dynstat_adeta_min         =  -6.9228586370870E-03
+(PID.TID 0000.0001) %MON ad_dynstat_adeta_mean        =  -6.8980646035815E-08
+(PID.TID 0000.0001) %MON ad_dynstat_adeta_sd          =   4.5673951313236E-04
+(PID.TID 0000.0001) %MON ad_dynstat_adeta_del2        =   3.0712618057547E-05
+(PID.TID 0000.0001) %MON ad_dynstat_aduvel_max        =   3.7401749080058E-02
+(PID.TID 0000.0001) %MON ad_dynstat_aduvel_min        =  -2.7736270388969E-02
+(PID.TID 0000.0001) %MON ad_dynstat_aduvel_mean       =  -2.6139609641753E-06
+(PID.TID 0000.0001) %MON ad_dynstat_aduvel_sd         =   5.5395550015754E-04
+(PID.TID 0000.0001) %MON ad_dynstat_aduvel_del2       =   7.1775477304571E-06
+(PID.TID 0000.0001) %MON ad_dynstat_advvel_max        =   2.4020524786397E-02
+(PID.TID 0000.0001) %MON ad_dynstat_advvel_min        =  -2.2900089605233E-02
+(PID.TID 0000.0001) %MON ad_dynstat_advvel_mean       =   5.2473997229074E-06
+(PID.TID 0000.0001) %MON ad_dynstat_advvel_sd         =   4.0344300133930E-04
+(PID.TID 0000.0001) %MON ad_dynstat_advvel_del2       =   4.7935921138078E-06
+(PID.TID 0000.0001) %MON ad_dynstat_adwvel_max        =   7.7218670851751E-01
+(PID.TID 0000.0001) %MON ad_dynstat_adwvel_min        =  -1.9356368458827E+01
+(PID.TID 0000.0001) %MON ad_dynstat_adwvel_mean       =  -1.4128323315237E-04
+(PID.TID 0000.0001) %MON ad_dynstat_adwvel_sd         =   3.4752949974067E-02
+(PID.TID 0000.0001) %MON ad_dynstat_adwvel_del2       =   1.1741147408800E-03
+(PID.TID 0000.0001) %MON ad_dynstat_adtheta_max       =   5.3338480652394E-04
+(PID.TID 0000.0001) %MON ad_dynstat_adtheta_min       =  -5.2627884034990E-01
+(PID.TID 0000.0001) %MON ad_dynstat_adtheta_mean      =  -3.0801427544063E-05
+(PID.TID 0000.0001) %MON ad_dynstat_adtheta_sd        =   2.8134200800277E-03
+(PID.TID 0000.0001) %MON ad_dynstat_adtheta_del2      =   5.8047444292612E-05
+(PID.TID 0000.0001) %MON ad_dynstat_adsalt_max        =   9.5896219348462E-03
+(PID.TID 0000.0001) %MON ad_dynstat_adsalt_min        =  -3.9223205705286E-01
+(PID.TID 0000.0001) %MON ad_dynstat_adsalt_mean       =  -2.2075646587720E-05
+(PID.TID 0000.0001) %MON ad_dynstat_adsalt_sd         =   1.9136333721563E-03
+(PID.TID 0000.0001) %MON ad_dynstat_adsalt_del2       =   4.0223782032922E-05
+(PID.TID 0000.0001) // =======================================================
+(PID.TID 0000.0001) // End AD_MONITOR dynamic field statistics
+(PID.TID 0000.0001) // =======================================================
+(PID.TID 0000.0001) // =======================================================
+(PID.TID 0000.0001) // Begin AD_MONITOR ptracer field statistics
+(PID.TID 0000.0001) // =======================================================
+(PID.TID 0000.0001) %MON ad_trcstat_adptracer01_max   =   7.4947534194197E-04
+(PID.TID 0000.0001) %MON ad_trcstat_adptracer01_min   =  -9.2276295140043E+01
+(PID.TID 0000.0001) %MON ad_trcstat_adptracer01_mean  =  -5.9368893992141E-03
+(PID.TID 0000.0001) %MON ad_trcstat_adptracer01_sd    =   5.3866484291817E-01
+(PID.TID 0000.0001) %MON ad_trcstat_adptracer01_del2  =   1.0514310839184E-02
+(PID.TID 0000.0001) %MON ad_trcstat_adptracer02_max   =   9.0458070896682E+01
+(PID.TID 0000.0001) %MON ad_trcstat_adptracer02_min   =  -7.3470760107246E-04
+(PID.TID 0000.0001) %MON ad_trcstat_adptracer02_mean  =   5.8055090166055E-03
+(PID.TID 0000.0001) %MON ad_trcstat_adptracer02_sd    =   5.2710390985161E-01
+(PID.TID 0000.0001) %MON ad_trcstat_adptracer02_del2  =   1.0242387887091E-02
+(PID.TID 0000.0001) %MON ad_trcstat_adptracer03_max   =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON ad_trcstat_adptracer03_min   =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON ad_trcstat_adptracer03_mean  =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON ad_trcstat_adptracer03_sd    =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON ad_trcstat_adptracer03_del2  =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON ad_trcstat_adptracer04_max   =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON ad_trcstat_adptracer04_min   =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON ad_trcstat_adptracer04_mean  =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON ad_trcstat_adptracer04_sd    =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON ad_trcstat_adptracer04_del2  =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON ad_trcstat_adptracer05_max   =   7.4350788317980E-04
+(PID.TID 0000.0001) %MON ad_trcstat_adptracer05_min   =  -9.1541582702460E+01
+(PID.TID 0000.0001) %MON ad_trcstat_adptracer05_mean  =  -5.8986602335314E-03
+(PID.TID 0000.0001) %MON ad_trcstat_adptracer05_sd    =   5.3520272937464E-01
+(PID.TID 0000.0001) %MON ad_trcstat_adptracer05_del2  =   1.0466449913400E-02
+(PID.TID 0000.0001) %MON ad_trcstat_adptracer06_max   =   2.6008678918245E-34
+(PID.TID 0000.0001) %MON ad_trcstat_adptracer06_min   =  -9.5069392769900E-29
+(PID.TID 0000.0001) %MON ad_trcstat_adptracer06_mean  =  -2.4451361347326E-34
+(PID.TID 0000.0001) %MON ad_trcstat_adptracer06_sd    =   1.3073010665374E-31
+(PID.TID 0000.0001) %MON ad_trcstat_adptracer06_del2  =   5.3799189798037E-33
+(PID.TID 0000.0001) %MON ad_trcstat_adptracer07_max   =   4.7443788307518E-08
+(PID.TID 0000.0001) %MON ad_trcstat_adptracer07_min   =  -8.1227298955519E-03
+(PID.TID 0000.0001) %MON ad_trcstat_adptracer07_mean  =  -3.8120039424865E-07
+(PID.TID 0000.0001) %MON ad_trcstat_adptracer07_sd    =   3.7344592453394E-05
+(PID.TID 0000.0001) %MON ad_trcstat_adptracer07_del2  =   7.1578767045783E-07
+(PID.TID 0000.0001) %MON ad_trcstat_adptracer08_max   =   1.2177048970232E-08
+(PID.TID 0000.0001) %MON ad_trcstat_adptracer08_min   =  -2.0847981035269E-03
+(PID.TID 0000.0001) %MON ad_trcstat_adptracer08_mean  =  -9.8003680896332E-08
+(PID.TID 0000.0001) %MON ad_trcstat_adptracer08_sd    =   9.5977664333787E-06
+(PID.TID 0000.0001) %MON ad_trcstat_adptracer08_del2  =   1.8441176964659E-07
+(PID.TID 0000.0001) // =======================================================
+(PID.TID 0000.0001) // End AD_MONITOR ptracer field statistics
+(PID.TID 0000.0001) // =======================================================
+ Calling cg2d from S/R CG2D_SAD
  cg2d: Sum(rhs),rhsMax =   1.17016422593319E-13  1.47046439038471E-06
 (PID.TID 0000.0001) Start initial hydrostatic pressure computation
 (PID.TID 0000.0001) Pressure is predetermined for buoyancyRelation OCEANIC
 (PID.TID 0000.0001) 
  BLING_SURFFORCING_INIT, it=         0 : Reading new data, i0,i1=   12    1
+(PID.TID 0000.0001) // =======================================================
+(PID.TID 0000.0001) // Begin AD_MONITOR dynamic field statistics
+(PID.TID 0000.0001) // =======================================================
+(PID.TID 0000.0001) %MON ad_time_tsnumber             =                     0
+(PID.TID 0000.0001) %MON ad_time_secondsf             =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON ad_dynstat_adeta_max         =   4.2635472756233E-02
+(PID.TID 0000.0001) %MON ad_dynstat_adeta_min         =  -2.5248609519968E-03
+(PID.TID 0000.0001) %MON ad_dynstat_adeta_mean        =  -1.8939322281121E-07
+(PID.TID 0000.0001) %MON ad_dynstat_adeta_sd          =   5.1953441330201E-04
+(PID.TID 0000.0001) %MON ad_dynstat_adeta_del2        =   3.1004551694137E-05
+(PID.TID 0000.0001) %MON ad_dynstat_aduvel_max        =   2.0167695380198E-02
+(PID.TID 0000.0001) %MON ad_dynstat_aduvel_min        =  -2.6013095803896E-02
+(PID.TID 0000.0001) %MON ad_dynstat_aduvel_mean       =  -4.1632005455855E-06
+(PID.TID 0000.0001) %MON ad_dynstat_aduvel_sd         =   2.9528790615486E-04
+(PID.TID 0000.0001) %MON ad_dynstat_aduvel_del2       =   4.1062876281150E-06
+(PID.TID 0000.0001) %MON ad_dynstat_advvel_max        =   1.0233975560320E-02
+(PID.TID 0000.0001) %MON ad_dynstat_advvel_min        =  -1.3393597169996E-02
+(PID.TID 0000.0001) %MON ad_dynstat_advvel_mean       =   8.5854528542041E-06
+(PID.TID 0000.0001) %MON ad_dynstat_advvel_sd         =   2.6745833623741E-04
+(PID.TID 0000.0001) %MON ad_dynstat_advvel_del2       =   2.6952253659086E-06
+(PID.TID 0000.0001) %MON ad_dynstat_adwvel_max        =   1.2890351296836E+00
+(PID.TID 0000.0001) %MON ad_dynstat_adwvel_min        =  -1.7484062948568E+01
+(PID.TID 0000.0001) %MON ad_dynstat_adwvel_mean       =  -1.7433746055470E-04
+(PID.TID 0000.0001) %MON ad_dynstat_adwvel_sd         =   4.2181942196594E-02
+(PID.TID 0000.0001) %MON ad_dynstat_adwvel_del2       =   1.3269161406021E-03
+(PID.TID 0000.0001) %MON ad_dynstat_adtheta_max       =   6.6660803873769E-04
+(PID.TID 0000.0001) %MON ad_dynstat_adtheta_min       =  -5.7450530571819E-01
+(PID.TID 0000.0001) %MON ad_dynstat_adtheta_mean      =  -3.7574386872720E-05
+(PID.TID 0000.0001) %MON ad_dynstat_adtheta_sd        =   3.4053576702336E-03
+(PID.TID 0000.0001) %MON ad_dynstat_adtheta_del2      =   6.8522490051683E-05
+(PID.TID 0000.0001) %MON ad_dynstat_adsalt_max        =   7.8646041157381E-03
+(PID.TID 0000.0001) %MON ad_dynstat_adsalt_min        =  -4.0303757033970E-01
+(PID.TID 0000.0001) %MON ad_dynstat_adsalt_mean       =  -2.6945581431027E-05
+(PID.TID 0000.0001) %MON ad_dynstat_adsalt_sd         =   2.3406892720025E-03
+(PID.TID 0000.0001) %MON ad_dynstat_adsalt_del2       =   4.7876982225914E-05
+(PID.TID 0000.0001) // =======================================================
+(PID.TID 0000.0001) // End AD_MONITOR dynamic field statistics
+(PID.TID 0000.0001) // =======================================================
+(PID.TID 0000.0001) // =======================================================
+(PID.TID 0000.0001) // Begin AD_MONITOR ptracer field statistics
+(PID.TID 0000.0001) // =======================================================
+(PID.TID 0000.0001) %MON ad_trcstat_adptracer01_max   =   7.4879217787990E-04
+(PID.TID 0000.0001) %MON ad_trcstat_adptracer01_min   =  -1.1286326207305E+02
+(PID.TID 0000.0001) %MON ad_trcstat_adptracer01_mean  =  -7.2496814277386E-03
+(PID.TID 0000.0001) %MON ad_trcstat_adptracer01_sd    =   6.5435643922080E-01
+(PID.TID 0000.0001) %MON ad_trcstat_adptracer01_del2  =   1.2544264128155E-02
+(PID.TID 0000.0001) %MON ad_trcstat_adptracer02_max   =   1.1063938966654E+02
+(PID.TID 0000.0001) %MON ad_trcstat_adptracer02_min   =  -7.3403809135938E-04
+(PID.TID 0000.0001) %MON ad_trcstat_adptracer02_mean  =   7.0896697557238E-03
+(PID.TID 0000.0001) %MON ad_trcstat_adptracer02_sd    =   6.4042784548612E-01
+(PID.TID 0000.0001) %MON ad_trcstat_adptracer02_del2  =   1.2229424855743E-02
+(PID.TID 0000.0001) %MON ad_trcstat_adptracer03_max   =   8.2520646514219E-49
+(PID.TID 0000.0001) %MON ad_trcstat_adptracer03_min   =  -1.1482359312016E-43
+(PID.TID 0000.0001) %MON ad_trcstat_adptracer03_mean  =  -3.1084490514655E-49
+(PID.TID 0000.0001) %MON ad_trcstat_adptracer03_sd    =   1.5881838651091E-46
+(PID.TID 0000.0001) %MON ad_trcstat_adptracer03_del2  =   6.4543926748102E-48
+(PID.TID 0000.0001) %MON ad_trcstat_adptracer04_max   =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON ad_trcstat_adptracer04_min   =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON ad_trcstat_adptracer04_mean  =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON ad_trcstat_adptracer04_sd    =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON ad_trcstat_adptracer04_del2  =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON ad_trcstat_adptracer05_max   =   7.4283040885258E-04
+(PID.TID 0000.0001) %MON ad_trcstat_adptracer05_min   =  -1.1196464858774E+02
+(PID.TID 0000.0001) %MON ad_trcstat_adptracer05_mean  =  -7.2026897350031E-03
+(PID.TID 0000.0001) %MON ad_trcstat_adptracer05_sd    =   6.5009085570002E-01
+(PID.TID 0000.0001) %MON ad_trcstat_adptracer05_del2  =   1.2483502900547E-02
+(PID.TID 0000.0001) %MON ad_trcstat_adptracer06_max   =   9.4810635424274E-34
+(PID.TID 0000.0001) %MON ad_trcstat_adptracer06_min   =  -2.4478735300936E-28
+(PID.TID 0000.0001) %MON ad_trcstat_adptracer06_mean  =  -6.2009627125977E-34
+(PID.TID 0000.0001) %MON ad_trcstat_adptracer06_sd    =   3.3650236453918E-31
+(PID.TID 0000.0001) %MON ad_trcstat_adptracer06_del2  =   1.3845305782262E-32
+(PID.TID 0000.0001) %MON ad_trcstat_adptracer07_max   =   1.1968219507861E-07
+(PID.TID 0000.0001) %MON ad_trcstat_adptracer07_min   =  -8.2413754627673E-03
+(PID.TID 0000.0001) %MON ad_trcstat_adptracer07_mean  =  -4.7165733166787E-07
+(PID.TID 0000.0001) %MON ad_trcstat_adptracer07_sd    =   4.4622880799716E-05
+(PID.TID 0000.0001) %MON ad_trcstat_adptracer07_del2  =   1.0128962287257E-06
+(PID.TID 0000.0001) %MON ad_trcstat_adptracer08_max   =   3.0841726555078E-08
+(PID.TID 0000.0001) %MON ad_trcstat_adptracer08_min   =  -2.1409880030140E-03
+(PID.TID 0000.0001) %MON ad_trcstat_adptracer08_mean  =  -1.2136850848353E-07
+(PID.TID 0000.0001) %MON ad_trcstat_adptracer08_sd    =   1.1488006409021E-05
+(PID.TID 0000.0001) %MON ad_trcstat_adptracer08_del2  =   2.6156070967224E-07
+(PID.TID 0000.0001) // =======================================================
+(PID.TID 0000.0001) // End AD_MONITOR ptracer field statistics
+(PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) Start initial hydrostatic pressure computation
 (PID.TID 0000.0001) Pressure is predetermined for buoyancyRelation OCEANIC
 (PID.TID 0000.0001) 
@@ -4428,213 +4585,225 @@ grad-res -------------------------------
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) 
 (PID.TID 0000.0001)   Seconds in section "ALL                    [THE_MODEL_MAIN]":
-(PID.TID 0000.0001)           User time:   185.22853568196297
-(PID.TID 0000.0001)         System time:  0.57133800466544926
-(PID.TID 0000.0001)     Wall clock time:   186.09527778625488
+(PID.TID 0000.0001)           User time:   431.15993311163038
+(PID.TID 0000.0001)         System time:   7.2304811812937260
+(PID.TID 0000.0001)     Wall clock time:   491.69934296607971
 (PID.TID 0000.0001)          No. starts:           1
 (PID.TID 0000.0001)           No. stops:           1
 (PID.TID 0000.0001)   Seconds in section "INITIALISE_FIXED       [THE_MODEL_MAIN]":
-(PID.TID 0000.0001)           User time:  0.32332799490541220
-(PID.TID 0000.0001)         System time:   4.8945000860840082E-002
-(PID.TID 0000.0001)     Wall clock time:  0.37317299842834473
+(PID.TID 0000.0001)           User time:  0.98052399232983589
+(PID.TID 0000.0001)         System time:  0.20233100093901157
+(PID.TID 0000.0001)     Wall clock time:   1.4950819015502930
 (PID.TID 0000.0001)          No. starts:           1
 (PID.TID 0000.0001)           No. stops:           1
 (PID.TID 0000.0001)   Seconds in section "ADTHE_MAIN_LOOP          [ADJOINT RUN]":
-(PID.TID 0000.0001)           User time:   86.211873084306717
-(PID.TID 0000.0001)         System time:  0.47363302856683731
-(PID.TID 0000.0001)     Wall clock time:   86.830193996429443
+(PID.TID 0000.0001)           User time:   205.05874437093735
+(PID.TID 0000.0001)         System time:   6.3058750480413437
+(PID.TID 0000.0001)     Wall clock time:   237.58287715911865
 (PID.TID 0000.0001)          No. starts:           1
 (PID.TID 0000.0001)           No. stops:           1
 (PID.TID 0000.0001)   Seconds in section "FORWARD_STEP        [MAIN_DO_LOOP]":
-(PID.TID 0000.0001)           User time:   109.47491073608398
-(PID.TID 0000.0001)         System time:   4.3190017342567444E-002
-(PID.TID 0000.0001)     Wall clock time:   109.68205332756042
+(PID.TID 0000.0001)           User time:   254.50116252899170
+(PID.TID 0000.0001)         System time:   1.7560008764266968
+(PID.TID 0000.0001)     Wall clock time:   286.93847012519836
 (PID.TID 0000.0001)          No. starts:          40
 (PID.TID 0000.0001)           No. stops:          40
+(PID.TID 0000.0001)   Seconds in section "DO_STATEVARS_DIAGS  [FORWARD_STEP]":
+(PID.TID 0000.0001)           User time:   8.4229469299316406E-002
+(PID.TID 0000.0001)         System time:   4.0900707244873047E-004
+(PID.TID 0000.0001)     Wall clock time:   9.2684745788574219E-002
+(PID.TID 0000.0001)          No. starts:           8
+(PID.TID 0000.0001)           No. stops:           8
 (PID.TID 0000.0001)   Seconds in section "LOAD_FIELDS_DRIVER  [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:  0.13619530200958252
-(PID.TID 0000.0001)         System time:   4.0680021047592163E-003
-(PID.TID 0000.0001)     Wall clock time:  0.14057660102844238
+(PID.TID 0000.0001)           User time:  0.31698799133300781
+(PID.TID 0000.0001)         System time:   1.3876676559448242E-002
+(PID.TID 0000.0001)     Wall clock time:  0.74174070358276367
 (PID.TID 0000.0001)          No. starts:          40
 (PID.TID 0000.0001)           No. stops:          40
 (PID.TID 0000.0001)   Seconds in section "EXTERNAL_FLDS_LOAD [LOAD_FLDS_DRIVER]":
-(PID.TID 0000.0001)           User time:   9.8534584045410156E-002
-(PID.TID 0000.0001)         System time:   2.0080208778381348E-003
-(PID.TID 0000.0001)     Wall clock time:  0.10078430175781250
+(PID.TID 0000.0001)           User time:  0.21412324905395508
+(PID.TID 0000.0001)         System time:   9.8433494567871094E-003
+(PID.TID 0000.0001)     Wall clock time:  0.54704213142395020
 (PID.TID 0000.0001)          No. starts:          48
 (PID.TID 0000.0001)           No. stops:          48
 (PID.TID 0000.0001)   Seconds in section "CTRL_MAP_FORCING  [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:  0.11955237388610840
-(PID.TID 0000.0001)         System time:   9.3500316143035889E-004
-(PID.TID 0000.0001)     Wall clock time:  0.12071156501770020
+(PID.TID 0000.0001)           User time:  0.28029918670654297
+(PID.TID 0000.0001)         System time:   7.2538852691650391E-004
+(PID.TID 0000.0001)     Wall clock time:  0.32526969909667969
 (PID.TID 0000.0001)          No. starts:          40
 (PID.TID 0000.0001)           No. stops:          40
 (PID.TID 0000.0001)   Seconds in section "DO_ATMOSPHERIC_PHYS [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:   3.0526876449584961E-002
-(PID.TID 0000.0001)         System time:   6.0021877288818359E-005
-(PID.TID 0000.0001)     Wall clock time:   3.0686378479003906E-002
+(PID.TID 0000.0001)           User time:   8.8162899017333984E-002
+(PID.TID 0000.0001)         System time:   6.4849853515625000E-005
+(PID.TID 0000.0001)     Wall clock time:  0.10044741630554199
 (PID.TID 0000.0001)          No. starts:          40
 (PID.TID 0000.0001)           No. stops:          40
 (PID.TID 0000.0001)   Seconds in section "DO_OCEANIC_PHYS     [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:   4.5247528553009033
-(PID.TID 0000.0001)         System time:   2.9810070991516113E-003
-(PID.TID 0000.0001)     Wall clock time:   4.5345897674560547
+(PID.TID 0000.0001)           User time:   10.309710502624512
+(PID.TID 0000.0001)         System time:   1.6177773475646973E-002
+(PID.TID 0000.0001)     Wall clock time:   11.575847148895264
 (PID.TID 0000.0001)          No. starts:          40
 (PID.TID 0000.0001)           No. stops:          40
 (PID.TID 0000.0001)   Seconds in section "GCHEM_CALC_TENDENCY [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:   2.6726722717285156E-004
-(PID.TID 0000.0001)         System time:   9.9837779998779297E-007
-(PID.TID 0000.0001)     Wall clock time:   2.2578239440917969E-004
+(PID.TID 0000.0001)           User time:   4.8685073852539062E-004
+(PID.TID 0000.0001)         System time:   2.9802322387695312E-006
+(PID.TID 0000.0001)     Wall clock time:   4.5919418334960938E-004
 (PID.TID 0000.0001)          No. starts:          40
 (PID.TID 0000.0001)           No. stops:          40
 (PID.TID 0000.0001)   Seconds in section "THERMODYNAMICS      [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:   59.271099448204041
-(PID.TID 0000.0001)         System time:   5.6189894676208496E-003
-(PID.TID 0000.0001)     Wall clock time:   59.365509510040283
+(PID.TID 0000.0001)           User time:   135.95193147659302
+(PID.TID 0000.0001)         System time:  0.26647698879241943
+(PID.TID 0000.0001)     Wall clock time:   152.33208513259888
 (PID.TID 0000.0001)          No. starts:          40
 (PID.TID 0000.0001)           No. stops:          40
 (PID.TID 0000.0001)   Seconds in section "DYNAMICS            [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:   12.660955190658569
-(PID.TID 0000.0001)         System time:   2.9140114784240723E-003
-(PID.TID 0000.0001)     Wall clock time:   12.683148145675659
+(PID.TID 0000.0001)           User time:   29.417612075805664
+(PID.TID 0000.0001)         System time:   8.0897569656372070E-002
+(PID.TID 0000.0001)     Wall clock time:   33.031015396118164
 (PID.TID 0000.0001)          No. starts:          40
 (PID.TID 0000.0001)           No. stops:          40
 (PID.TID 0000.0001)   Seconds in section "SOLVE_FOR_PRESSURE  [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:   1.9338357448577881
-(PID.TID 0000.0001)         System time:   1.0130107402801514E-003
-(PID.TID 0000.0001)     Wall clock time:   1.9380683898925781
+(PID.TID 0000.0001)           User time:   4.3083753585815430
+(PID.TID 0000.0001)         System time:   2.0400881767272949E-002
+(PID.TID 0000.0001)     Wall clock time:   4.8147926330566406
 (PID.TID 0000.0001)          No. starts:          40
 (PID.TID 0000.0001)           No. stops:          40
 (PID.TID 0000.0001)   Seconds in section "MOM_CORRECTION_STEP [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:  0.33401107788085938
-(PID.TID 0000.0001)         System time:   2.4959444999694824E-005
-(PID.TID 0000.0001)     Wall clock time:  0.33452916145324707
+(PID.TID 0000.0001)           User time:  0.76507186889648438
+(PID.TID 0000.0001)         System time:   2.4867057800292969E-004
+(PID.TID 0000.0001)     Wall clock time:  0.84586334228515625
 (PID.TID 0000.0001)          No. starts:          40
 (PID.TID 0000.0001)           No. stops:          40
 (PID.TID 0000.0001)   Seconds in section "INTEGR_CONTINUITY   [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:  0.37294244766235352
-(PID.TID 0000.0001)         System time:   9.8504126071929932E-004
-(PID.TID 0000.0001)     Wall clock time:  0.37445759773254395
+(PID.TID 0000.0001)           User time:  0.83314228057861328
+(PID.TID 0000.0001)         System time:   2.2363662719726562E-004
+(PID.TID 0000.0001)     Wall clock time:  0.93382716178894043
 (PID.TID 0000.0001)          No. starts:          40
 (PID.TID 0000.0001)           No. stops:          40
 (PID.TID 0000.0001)   Seconds in section "TRC_CORRECTION_STEP [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:   2.8061866760253906E-004
-(PID.TID 0000.0001)         System time:   0.0000000000000000
-(PID.TID 0000.0001)     Wall clock time:   2.3794174194335938E-004
+(PID.TID 0000.0001)           User time:   6.2179565429687500E-004
+(PID.TID 0000.0001)         System time:   2.0265579223632812E-006
+(PID.TID 0000.0001)     Wall clock time:   5.2499771118164062E-004
 (PID.TID 0000.0001)          No. starts:          40
 (PID.TID 0000.0001)           No. stops:          40
 (PID.TID 0000.0001)   Seconds in section "GCHEM_FORCING_SEP  [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:   11.163873672485352
-(PID.TID 0000.0001)         System time:   1.2684017419815063E-002
-(PID.TID 0000.0001)     Wall clock time:   11.194773197174072
+(PID.TID 0000.0001)           User time:   26.350827217102051
+(PID.TID 0000.0001)         System time:  0.12736630439758301
+(PID.TID 0000.0001)     Wall clock time:   29.630918979644775
 (PID.TID 0000.0001)          No. starts:          40
 (PID.TID 0000.0001)           No. stops:          40
 (PID.TID 0000.0001)   Seconds in section "BLOCKING_EXCHANGES  [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:   1.0435919761657715
-(PID.TID 0000.0001)         System time:   9.1199576854705811E-004
-(PID.TID 0000.0001)     Wall clock time:   1.0468959808349609
+(PID.TID 0000.0001)           User time:   2.2757635116577148
+(PID.TID 0000.0001)         System time:   1.9598007202148438E-004
+(PID.TID 0000.0001)     Wall clock time:   2.5615472793579102
 (PID.TID 0000.0001)          No. starts:          40
 (PID.TID 0000.0001)           No. stops:          40
 (PID.TID 0000.0001)   Seconds in section "MONITOR             [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:  0.33547592163085938
-(PID.TID 0000.0001)         System time:   0.0000000000000000
-(PID.TID 0000.0001)     Wall clock time:  0.33597278594970703
-(PID.TID 0000.0001)          No. starts:           4
-(PID.TID 0000.0001)           No. stops:           4
+(PID.TID 0000.0001)           User time:  0.25712013244628906
+(PID.TID 0000.0001)         System time:   7.1525573730468750E-006
+(PID.TID 0000.0001)     Wall clock time:  0.28521037101745605
+(PID.TID 0000.0001)          No. starts:          40
+(PID.TID 0000.0001)           No. stops:          40
 (PID.TID 0000.0001)   Seconds in section "COST_TILE           [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:   2.3460388183593750E-004
-(PID.TID 0000.0001)         System time:   1.0132789611816406E-006
-(PID.TID 0000.0001)     Wall clock time:   2.3365020751953125E-004
+(PID.TID 0000.0001)           User time:   4.7588348388671875E-004
+(PID.TID 0000.0001)         System time:   9.5367431640625000E-007
+(PID.TID 0000.0001)     Wall clock time:   4.4345855712890625E-004
 (PID.TID 0000.0001)          No. starts:          40
 (PID.TID 0000.0001)           No. stops:          40
 (PID.TID 0000.0001)   Seconds in section "DO_THE_MODEL_IO     [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:  0.30270099639892578
-(PID.TID 0000.0001)         System time:   9.9299848079681396E-004
-(PID.TID 0000.0001)     Wall clock time:  0.30403327941894531
+(PID.TID 0000.0001)           User time:  0.29276752471923828
+(PID.TID 0000.0001)         System time:   2.7989625930786133E-002
+(PID.TID 0000.0001)     Wall clock time:  0.35674214363098145
 (PID.TID 0000.0001)          No. starts:          40
 (PID.TID 0000.0001)           No. stops:          40
 (PID.TID 0000.0001)   Seconds in section "PTRACERS_RESET      [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:   2.3746490478515625E-004
-(PID.TID 0000.0001)         System time:   9.5367431640625000E-007
-(PID.TID 0000.0001)     Wall clock time:   2.3484230041503906E-004
+(PID.TID 0000.0001)           User time:   4.0531158447265625E-004
+(PID.TID 0000.0001)         System time:   6.7949295043945312E-006
+(PID.TID 0000.0001)     Wall clock time:   4.9972534179687500E-004
 (PID.TID 0000.0001)          No. starts:          40
 (PID.TID 0000.0001)           No. stops:          40
 (PID.TID 0000.0001)   Seconds in section "DO_WRITE_PICKUP     [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:   9.5454692840576172E-002
-(PID.TID 0000.0001)         System time:   9.9810063838958740E-003
-(PID.TID 0000.0001)     Wall clock time:  0.10560774803161621
+(PID.TID 0000.0001)           User time:  0.24460411071777344
+(PID.TID 0000.0001)         System time:   1.1566466093063354
+(PID.TID 0000.0001)     Wall clock time:   1.4371771812438965
 (PID.TID 0000.0001)          No. starts:          40
 (PID.TID 0000.0001)           No. stops:          40
 (PID.TID 0000.0001)   Seconds in section "COST_GENCOST_ALL    [ECCO SPIN-DOWN]":
-(PID.TID 0000.0001)           User time:  0.13914585113525391
-(PID.TID 0000.0001)         System time:   4.9849599599838257E-003
-(PID.TID 0000.0001)     Wall clock time:  0.14454054832458496
+(PID.TID 0000.0001)           User time:  0.46461868286132812
+(PID.TID 0000.0001)         System time:  0.11223459243774414
+(PID.TID 0000.0001)     Wall clock time:  0.64338922500610352
 (PID.TID 0000.0001)          No. starts:           9
 (PID.TID 0000.0001)           No. stops:           9
 (PID.TID 0000.0001)   Seconds in section "CTRL_COST_DRIVER [ECCO SPIN-DOWN]":
-(PID.TID 0000.0001)           User time:  0.34684371948242188
-(PID.TID 0000.0001)         System time:   5.9850513935089111E-003
-(PID.TID 0000.0001)     Wall clock time:  0.35345911979675293
+(PID.TID 0000.0001)           User time:  0.82612228393554688
+(PID.TID 0000.0001)         System time:   6.3748121261596680E-002
+(PID.TID 0000.0001)     Wall clock time:   1.0185232162475586
 (PID.TID 0000.0001)          No. starts:           9
 (PID.TID 0000.0001)           No. stops:           9
+(PID.TID 0000.0001)   Seconds in section "I/O (WRITE)        [ADJOINT LOOP]":
+(PID.TID 0000.0001)           User time:  0.12077331542968750
+(PID.TID 0000.0001)         System time:   8.0232620239257812E-003
+(PID.TID 0000.0001)     Wall clock time:  0.14478921890258789
+(PID.TID 0000.0001)          No. starts:           4
+(PID.TID 0000.0001)           No. stops:           4
 (PID.TID 0000.0001)   Seconds in section "GRDCHK_MAIN         [THE_MODEL_MAIN]":
-(PID.TID 0000.0001)           User time:   98.693305969238281
-(PID.TID 0000.0001)         System time:   4.8753976821899414E-002
-(PID.TID 0000.0001)     Wall clock time:   98.891878843307495
+(PID.TID 0000.0001)           User time:   225.12060546875000
+(PID.TID 0000.0001)         System time:  0.72225713729858398
+(PID.TID 0000.0001)     Wall clock time:   252.62131094932556
 (PID.TID 0000.0001)          No. starts:           1
 (PID.TID 0000.0001)           No. stops:           1
 (PID.TID 0000.0001)   Seconds in section "INITIALISE_VARIA    [THE_MAIN_LOOP]":
-(PID.TID 0000.0001)           User time:   7.5004806518554688
-(PID.TID 0000.0001)         System time:   2.9873013496398926E-002
-(PID.TID 0000.0001)     Wall clock time:   7.5444560050964355
+(PID.TID 0000.0001)           User time:   16.701919555664062
+(PID.TID 0000.0001)         System time:  0.25634145736694336
+(PID.TID 0000.0001)     Wall clock time:   18.904108047485352
 (PID.TID 0000.0001)          No. starts:           8
 (PID.TID 0000.0001)           No. stops:           8
 (PID.TID 0000.0001)   Seconds in section "MAIN LOOP           [THE_MAIN_LOOP]":
-(PID.TID 0000.0001)           User time:   91.061187744140625
-(PID.TID 0000.0001)         System time:   9.9040865898132324E-003
-(PID.TID 0000.0001)     Wall clock time:   91.206538915634155
+(PID.TID 0000.0001)           User time:   208.09300231933594
+(PID.TID 0000.0001)         System time:  0.42203760147094727
+(PID.TID 0000.0001)     Wall clock time:   233.29532837867737
 (PID.TID 0000.0001)          No. starts:           8
 (PID.TID 0000.0001)           No. stops:           8
 (PID.TID 0000.0001)   Seconds in section "COST_AVERAGESFIELDS [MAIN_DO_LOOP]":
-(PID.TID 0000.0001)           User time:  0.45322418212890625
-(PID.TID 0000.0001)         System time:   1.9669532775878906E-006
-(PID.TID 0000.0001)     Wall clock time:  0.45360350608825684
+(PID.TID 0000.0001)           User time:   1.0591430664062500
+(PID.TID 0000.0001)         System time:   4.1246414184570312E-003
+(PID.TID 0000.0001)     Wall clock time:   1.1967020034790039
 (PID.TID 0000.0001)          No. starts:          32
 (PID.TID 0000.0001)           No. stops:          32
 (PID.TID 0000.0001)   Seconds in section "PROFILES_INLOOP    [MAIN_DO_LOOP]":
-(PID.TID 0000.0001)           User time:   4.6920776367187500E-003
-(PID.TID 0000.0001)         System time:   2.0265579223632812E-006
-(PID.TID 0000.0001)     Wall clock time:   4.7147274017333984E-003
+(PID.TID 0000.0001)           User time:   1.2100219726562500E-002
+(PID.TID 0000.0001)         System time:   5.0067901611328125E-005
+(PID.TID 0000.0001)     Wall clock time:   1.2223243713378906E-002
 (PID.TID 0000.0001)          No. starts:          32
 (PID.TID 0000.0001)           No. stops:          32
 (PID.TID 0000.0001)   Seconds in section "MAIN_DO_LOOP        [THE_MAIN_LOOP]":
-(PID.TID 0000.0001)           User time:   86.979843139648438
-(PID.TID 0000.0001)         System time:   4.9190521240234375E-003
-(PID.TID 0000.0001)     Wall clock time:   87.113657474517822
+(PID.TID 0000.0001)           User time:   199.07855224609375
+(PID.TID 0000.0001)         System time:  0.35804986953735352
+(PID.TID 0000.0001)     Wall clock time:   223.13108325004578
 (PID.TID 0000.0001)          No. starts:          32
 (PID.TID 0000.0001)           No. stops:          32
 (PID.TID 0000.0001)   Seconds in section "COST_AVERAGESFIELDS [THE_MAIN_LOOP]":
-(PID.TID 0000.0001)           User time:  0.11631774902343750
-(PID.TID 0000.0001)         System time:   9.9498033523559570E-004
-(PID.TID 0000.0001)     Wall clock time:  0.11744904518127441
+(PID.TID 0000.0001)           User time:  0.26220703125000000
+(PID.TID 0000.0001)         System time:   3.9467811584472656E-003
+(PID.TID 0000.0001)     Wall clock time:  0.29427003860473633
 (PID.TID 0000.0001)          No. starts:           8
 (PID.TID 0000.0001)           No. stops:           8
 (PID.TID 0000.0001)   Seconds in section "PROFILES_INLOOP    [THE_MAIN_LOOP]":
-(PID.TID 0000.0001)           User time:   1.0833740234375000E-003
-(PID.TID 0000.0001)         System time:   1.0132789611816406E-006
-(PID.TID 0000.0001)     Wall clock time:   1.1236667633056641E-003
+(PID.TID 0000.0001)           User time:   2.1667480468750000E-003
+(PID.TID 0000.0001)         System time:   8.1062316894531250E-006
+(PID.TID 0000.0001)     Wall clock time:   6.1690807342529297E-003
 (PID.TID 0000.0001)          No. starts:           8
 (PID.TID 0000.0001)           No. stops:           8
 (PID.TID 0000.0001)   Seconds in section "ECCO_COST_DRIVER   [THE_MAIN_LOOP]":
-(PID.TID 0000.0001)           User time:  0.43180847167968750
-(PID.TID 0000.0001)         System time:   3.9780139923095703E-003
-(PID.TID 0000.0001)     Wall clock time:  0.43660855293273926
+(PID.TID 0000.0001)           User time:   1.1490478515625000
+(PID.TID 0000.0001)         System time:   3.9663791656494141E-002
+(PID.TID 0000.0001)     Wall clock time:   1.3453035354614258
 (PID.TID 0000.0001)          No. starts:           8
 (PID.TID 0000.0001)           No. stops:           8
 (PID.TID 0000.0001)   Seconds in section "COST_FINAL         [ADJOINT SPIN-DOWN]":
-(PID.TID 0000.0001)           User time:   2.1057128906250000E-003
-(PID.TID 0000.0001)         System time:   3.9935111999511719E-006
-(PID.TID 0000.0001)     Wall clock time:   2.1171569824218750E-003
+(PID.TID 0000.0001)           User time:   5.3558349609375000E-003
+(PID.TID 0000.0001)         System time:   8.0108642578125000E-005
+(PID.TID 0000.0001)     Wall clock time:   5.4695606231689453E-003
 (PID.TID 0000.0001)          No. starts:           8
 (PID.TID 0000.0001)           No. stops:           8
 (PID.TID 0000.0001) // ======================================================
@@ -4685,9 +4854,9 @@ grad-res -------------------------------
 (PID.TID 0000.0001) //          Total. Y spins =              0
 (PID.TID 0000.0001) //            Avg. Y spins =       0.00E+00
 (PID.TID 0000.0001) // o Thread number: 000001
-(PID.TID 0000.0001) //            No. barriers =          53454
+(PID.TID 0000.0001) //            No. barriers =          53616
 (PID.TID 0000.0001) //      Max. barrier spins =              1
 (PID.TID 0000.0001) //      Min. barrier spins =              1
-(PID.TID 0000.0001) //     Total barrier spins =          53454
+(PID.TID 0000.0001) //     Total barrier spins =          53616
 (PID.TID 0000.0001) //      Avg. barrier spins =       1.00E+00
 PROGRAM MAIN: Execution ended Normally

--- a/verification/global_with_exf/input_ad/data
+++ b/verification/global_with_exf/input_ad/data
@@ -40,24 +40,20 @@
 
 # Time stepping parameters
  &PARM03
- nIter0 =      0,
- nTimeSteps = 20,
-# 100 years of integration will yield a reasonable flow field
-# startTime  =          0.,
-# endTime    = 3110400000.,
- deltaTmom = 1200.0,
+ nIter0 =     0,
+ nTimeSteps= 20,
+#- 100 years of integration will yield a reasonable flow field
+# endTime  = 3110400000.,
+ deltaTmom = 1200.,
  tauCD =     321428.,
- deltaTtracer= 43200.0,
- deltaTClock = 43200.0,
-# if you are using a version later than checkpoint45d on the main branch
-# you can uncomment the following line and increase the time step
-# deltaTtracer and deltaTClock to 172800.0 as well to speed up the
-# asynchronous time stepping
-# deltaTfreesurf = 172800.0,
+ deltaTtracer= 43200.,
+ deltaTClock = 43200.,
  abEps = 0.1,
  pChkptFreq= 311040000.,
- dumpFreq=   311040000.,
- monitorFreq=1.,
+ dumpFreq =  311040000.,
+ monitorSelect= 2,
+ monitorFreq =  432000.,
+ adjMonitorFreq=259200.,
  &
 
 # Gridding parameters

--- a/verification/global_with_exf/results/output_adm.txt
+++ b/verification/global_with_exf/results/output_adm.txt
@@ -5,10 +5,10 @@
 (PID.TID 0000.0001) // ======================================================
 (PID.TID 0000.0001) // execution environment starting up...
 (PID.TID 0000.0001) 
-(PID.TID 0000.0001) // MITgcmUV version:  checkpoint65z
-(PID.TID 0000.0001) // Build user:        jmc
-(PID.TID 0000.0001) // Build host:        baudelaire
-(PID.TID 0000.0001) // Build date:        Wed Oct  5 22:33:43 EDT 2016
+(PID.TID 0000.0001) // MITgcmUV version:  checkpoint67w
+(PID.TID 0000.0001) // Build user:        jm_c
+(PID.TID 0000.0001) // Build host:        villon
+(PID.TID 0000.0001) // Build date:        Tue Apr 13 00:44:31 EDT 2021
 (PID.TID 0000.0001) 
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // Execution Environment parameter file "eedata"
@@ -49,8 +49,10 @@
 (PID.TID 0000.0001)                   /*  note: To execute a program with MPI calls */
 (PID.TID 0000.0001)                   /*  it must be launched appropriately e.g     */
 (PID.TID 0000.0001)                   /*  "mpirun -np 64 ......"                    */
-(PID.TID 0000.0001) useCoupler=    F ;/* Flag used to control communications with   */
+(PID.TID 0000.0001) useCoupler=   F ; /* Flag used to control communications with   */
 (PID.TID 0000.0001)                   /*  other model components, through a coupler */
+(PID.TID 0000.0001) useNest2W_parent =    F ;/* Control 2-W Nesting comm */
+(PID.TID 0000.0001) useNest2W_child  =    F ;/* Control 2-W Nesting comm */
 (PID.TID 0000.0001) debugMode =    F ; /* print debug msg. (sequence of S/R calls)  */
 (PID.TID 0000.0001) printMapIncludesZeros=    F ; /* print zeros in Std.Output maps */
 (PID.TID 0000.0001) maxLengthPrt1D=   65 /* maxLength of 1D array printed to StdOut */
@@ -129,24 +131,20 @@
 (PID.TID 0000.0001) >
 (PID.TID 0000.0001) ># Time stepping parameters
 (PID.TID 0000.0001) > &PARM03
-(PID.TID 0000.0001) > nIter0 =      0,
-(PID.TID 0000.0001) > nTimeSteps = 20,
-(PID.TID 0000.0001) ># 100 years of integration will yield a reasonable flow field
-(PID.TID 0000.0001) ># startTime  =          0.,
-(PID.TID 0000.0001) ># endTime    = 3110400000.,
-(PID.TID 0000.0001) > deltaTmom = 1200.0,
+(PID.TID 0000.0001) > nIter0 =     0,
+(PID.TID 0000.0001) > nTimeSteps= 20,
+(PID.TID 0000.0001) >#- 100 years of integration will yield a reasonable flow field
+(PID.TID 0000.0001) ># endTime  = 3110400000.,
+(PID.TID 0000.0001) > deltaTmom = 1200.,
 (PID.TID 0000.0001) > tauCD =     321428.,
-(PID.TID 0000.0001) > deltaTtracer= 43200.0,
-(PID.TID 0000.0001) > deltaTClock = 43200.0,
-(PID.TID 0000.0001) ># if you are using a version later than checkpoint45d on the main branch
-(PID.TID 0000.0001) ># you can uncomment the following line and increase the time step
-(PID.TID 0000.0001) ># deltaTtracer and deltaTClock to 172800.0 as well to speed up the
-(PID.TID 0000.0001) ># asynchronous time stepping
-(PID.TID 0000.0001) ># deltaTfreesurf = 172800.0,
+(PID.TID 0000.0001) > deltaTtracer= 43200.,
+(PID.TID 0000.0001) > deltaTClock = 43200.,
 (PID.TID 0000.0001) > abEps = 0.1,
 (PID.TID 0000.0001) > pChkptFreq= 311040000.,
-(PID.TID 0000.0001) > dumpFreq=   311040000.,
-(PID.TID 0000.0001) > monitorFreq=1.,
+(PID.TID 0000.0001) > dumpFreq =  311040000.,
+(PID.TID 0000.0001) > monitorSelect= 2,
+(PID.TID 0000.0001) > monitorFreq =  432000.,
+(PID.TID 0000.0001) > adjMonitorFreq=259200.,
 (PID.TID 0000.0001) > /
 (PID.TID 0000.0001) >
 (PID.TID 0000.0001) ># Gridding parameters
@@ -188,11 +186,11 @@
 (PID.TID 0000.0001) ># Packages
 (PID.TID 0000.0001) > &PACKAGES
 (PID.TID 0000.0001) >  useEXF         = .TRUE.,
-(PID.TID 0000.0001) >  useGrdchk      = .TRUE.,
+(PID.TID 0000.0001) >  useCAL         = .TRUE.,
 (PID.TID 0000.0001) >  useGMRedi      = .TRUE.,
-(PID.TID 0000.0001) >##  useDiagnostics = .TRUE.,
+(PID.TID 0000.0001) >  useGrdchk      = .TRUE.,
+(PID.TID 0000.0001) ># useDiagnostics = .TRUE.,
 (PID.TID 0000.0001) > /
-(PID.TID 0000.0001) >
 (PID.TID 0000.0001) 
 (PID.TID 0000.0001)  PACKAGES_BOOT: finished reading data.pkg
 (PID.TID 0000.0001)  PACKAGES_BOOT: On/Off package Summary
@@ -245,7 +243,7 @@
 (PID.TID 0000.0001) > &EXF_NML_01
 (PID.TID 0000.0001) > exf_iprec         = 32,
 (PID.TID 0000.0001) > exf_debugLev      = 3,
-(PID.TID 0000.0001) > readStressOnAgrid = .TRUE.,
+(PID.TID 0000.0001) >#readStressOnAgrid = .TRUE.,
 (PID.TID 0000.0001) > /
 (PID.TID 0000.0001) >
 (PID.TID 0000.0001) ># *********************
@@ -307,7 +305,7 @@
 (PID.TID 0000.0001) > sflux_nlon    = 90,
 (PID.TID 0000.0001) > sflux_nlat    = 40,
 (PID.TID 0000.0001) >#
-(PID.TID 0000.0001) > ustress_lon0    = 0.,
+(PID.TID 0000.0001) > ustress_lon0    = 2.,
 (PID.TID 0000.0001) > ustress_lon_inc = 4.,
 (PID.TID 0000.0001) > ustress_lat0    = -78.,
 (PID.TID 0000.0001) > ustress_lat_inc = 39*4.,
@@ -316,11 +314,12 @@
 (PID.TID 0000.0001) >#
 (PID.TID 0000.0001) > vstress_lon0    = 2.,
 (PID.TID 0000.0001) > vstress_lon_inc = 4.,
-(PID.TID 0000.0001) > vstress_lat0    = -80.,
+(PID.TID 0000.0001) > vstress_lat0    = -78.,
 (PID.TID 0000.0001) > vstress_lat_inc = 39*4.,
 (PID.TID 0000.0001) > vstress_nlon    = 90,
 (PID.TID 0000.0001) > vstress_nlat    = 40,
 (PID.TID 0000.0001) >#
+(PID.TID 0000.0001) > climsst_interpMethod = 1,
 (PID.TID 0000.0001) > climsst_lon0    = 2.,
 (PID.TID 0000.0001) > climsst_lon_inc = 4.,
 (PID.TID 0000.0001) > climsst_lat0    = -78.,
@@ -328,6 +327,7 @@
 (PID.TID 0000.0001) > climsst_nlon    = 90,
 (PID.TID 0000.0001) > climsst_nlat    = 40,
 (PID.TID 0000.0001) >#
+(PID.TID 0000.0001) > climsss_interpMethod = 1,
 (PID.TID 0000.0001) > climsss_lon0    = 2.,
 (PID.TID 0000.0001) > climsss_lon_inc = 4.,
 (PID.TID 0000.0001) > climsss_lat0    = -78.,
@@ -340,6 +340,7 @@
 (PID.TID 0000.0001) EXF_READPARMS: reading EXF_NML_01
 (PID.TID 0000.0001) EXF_READPARMS: reading EXF_NML_02
 (PID.TID 0000.0001) EXF_READPARMS: reading EXF_NML_03
+(PID.TID 0000.0001) EXF_READPARMS: reading EXF_NML_04
 (PID.TID 0000.0001) EXF_READPARMS: finished reading data.exf
 (PID.TID 0000.0001)  GM_READPARMS: opening data.gmredi
 (PID.TID 0000.0001)  OPEN_COPY_DATA_FILE: opening file data.gmredi
@@ -399,6 +400,9 @@
 (PID.TID 0000.0001) inAdExact = /* get an exact adjoint (no approximation) */
 (PID.TID 0000.0001)                   T
 (PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) useApproxAdvectionInAdMode = /* approximate AD-advection */
+(PID.TID 0000.0001)                   F
+(PID.TID 0000.0001)     ;
 (PID.TID 0000.0001) useKPPinAdMode = /* use KPP in adjoint mode */
 (PID.TID 0000.0001)                   F
 (PID.TID 0000.0001)     ;
@@ -420,8 +424,17 @@
 (PID.TID 0000.0001) mon_AdVarExch = /* control adexch before monitor */
 (PID.TID 0000.0001)                       2
 (PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) viscFacInFw = /* viscosity factor for forward model */
+(PID.TID 0000.0001)                 1.000000000000000E+00
+(PID.TID 0000.0001)     ;
 (PID.TID 0000.0001) viscFacInAd = /* viscosity factor for adjoint */
 (PID.TID 0000.0001)                 1.000000000000000E+00
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) SIregFacInAd = /* sea ice factor for adjoint model */
+(PID.TID 0000.0001)                 1.234567000000000E+05
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) SIregFacInFw = /* sea ice factor for forward model */
+(PID.TID 0000.0001)                 1.234567000000000E+05
 (PID.TID 0000.0001)     ;
 (PID.TID 0000.0001) 
 (PID.TID 0000.0001) OPTIM_READPARMS: opening data.optim
@@ -781,11 +794,17 @@
 (PID.TID 0000.0001) useExfCheckRange = /* check for fields range */
 (PID.TID 0000.0001)                   T
 (PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) exf_output_interp = /* output directly interpolation result */
+(PID.TID 0000.0001)                   F
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) diags_opOceWeighted = /* weight flux diags by open-ocean fraction */
+(PID.TID 0000.0001)                   F
+(PID.TID 0000.0001)     ;
 (PID.TID 0000.0001) exf_debugLev = /* select EXF-debug printing level */
 (PID.TID 0000.0001)                       3
 (PID.TID 0000.0001)     ;
 (PID.TID 0000.0001) exf_monFreq  = /* EXF monitor frequency [ s ] */
-(PID.TID 0000.0001)                 1.000000000000000E+00
+(PID.TID 0000.0001)                 4.320000000000000E+05
 (PID.TID 0000.0001)     ;
 (PID.TID 0000.0001) repeatPeriod = /* period for cycling forcing dataset [ s ] */
 (PID.TID 0000.0001)                 0.000000000000000E+00
@@ -925,62 +944,57 @@
 (PID.TID 0000.0001) 
 (PID.TID 0000.0001)  EXF main CPP flags:
 (PID.TID 0000.0001) 
-(PID.TID 0000.0001) // USE_EXF_INTERPOLATION:          NOT defined
+(PID.TID 0000.0001) // USE_EXF_INTERPOLATION:              defined
 (PID.TID 0000.0001) // ALLOW_ATM_TEMP:                 NOT defined
 (PID.TID 0000.0001) // ALLOW_ATM_WIND (useAtmWind):    NOT defined
 (PID.TID 0000.0001) // ALLOW_DOWNWARD_RADIATION:       NOT defined
 (PID.TID 0000.0001) // ALLOW_BULKFORMULAE:             NOT defined
 (PID.TID 0000.0001) 
-(PID.TID 0000.0001)    Zonal wind stress forcing starts at                   0.
 (PID.TID 0000.0001)    Zonal wind stress forcing period is                 -12.
 (PID.TID 0000.0001)    Zonal wind stress forcing is read from file:
-(PID.TID 0000.0001)    >>  trenberth_taux.bin  <<
+(PID.TID 0000.0001)    >> trenberth_taux.bin <<
+(PID.TID 0000.0001)    interpolate "ustress" (method= 12 ):
+(PID.TID 0000.0001)    lon0=   2.00000, nlon=    90, lon_inc= 4.0000000
+(PID.TID 0000.0001)    lat0= -78.00000, nlat=    40, lat_inc= 4.0000000
 (PID.TID 0000.0001) 
-(PID.TID 0000.0001)    Meridional wind stress forcing starts at              0.
 (PID.TID 0000.0001)    Meridional wind stress forcing period is            -12.
 (PID.TID 0000.0001)    Meridional wind stress forcing is read from file:
-(PID.TID 0000.0001)    >>  trenberth_tauy.bin  <<
+(PID.TID 0000.0001)    >> trenberth_tauy.bin <<
+(PID.TID 0000.0001)    interpolate "vstress" (method= 22 ):
+(PID.TID 0000.0001)    lon0=   2.00000, nlon=    90, lon_inc= 4.0000000
+(PID.TID 0000.0001)    lat0= -78.00000, nlat=    40, lat_inc= 4.0000000
+(PID.TID 0000.0001)     Interp. U & V comp. together: uvInterp_stress =    T
 (PID.TID 0000.0001) 
-(PID.TID 0000.0001)    Heat flux forcing starts at                          0.
 (PID.TID 0000.0001)    Heat flux forcing period is                         -12.
 (PID.TID 0000.0001)    Heat flux forcing is read from file:
-(PID.TID 0000.0001)    >>  ncep_qnet.bin  <<
-(PID.TID 0000.0001) 
-(PID.TID 0000.0001)    Salt flux forcing starts at                           0.
-(PID.TID 0000.0001)    Salt flux forcing period is                         -12.
-(PID.TID 0000.0001)    Salt flux forcing is read from file:
-(PID.TID 0000.0001)    >>    <<
-(PID.TID 0000.0001) 
-(PID.TID 0000.0001)    Net shortwave flux forcing starts at                0.
-(PID.TID 0000.0001)    Net shortwave flux forcing period is                0.
-(PID.TID 0000.0001)    Net shortwave flux forcing is read from file:
-(PID.TID 0000.0001)    >>    <<
+(PID.TID 0000.0001)    >> ncep_qnet.bin <<
+(PID.TID 0000.0001)    interpolate "hflux" (method=  1 ):
+(PID.TID 0000.0001)    lon0=   2.00000, nlon=    90, lon_inc= 4.0000000
+(PID.TID 0000.0001)    lat0= -78.00000, nlat=    40, lat_inc= 4.0000000
 (PID.TID 0000.0001) 
 (PID.TID 0000.0001) // EXF_READ_EVAP:                  NOT defined
-(PID.TID 0000.0001) 
 (PID.TID 0000.0001) // ALLOW_RUNOFF:                   NOT defined
-(PID.TID 0000.0001) 
-(PID.TID 0000.0001)    Atmospheric pressure forcing starts at                0.
-(PID.TID 0000.0001)    Atmospheric pressure forcing period is                0.
-(PID.TID 0000.0001)    Atmospheric pressureforcing is read from file:
-(PID.TID 0000.0001)    >>    <<
+(PID.TID 0000.0001) // ALLOW_SALTFLX:                  NOT defined
 (PID.TID 0000.0001) 
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // External forcing (EXF) climatology configuration :
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) 
 (PID.TID 0000.0001) // ALLOW_CLIMSST_RELAXATION:           defined
-(PID.TID 0000.0001) // ALLOW_CLIMSSS_RELAXATION:           defined
-(PID.TID 0000.0001) 
-(PID.TID 0000.0001)    Climatological SST starts at                   0.
-(PID.TID 0000.0001)    Climatological SST period is                 -12.
+(PID.TID 0000.0001)    Climatological SST period is                        -12.
 (PID.TID 0000.0001)    Climatological SST is read from file:
-(PID.TID 0000.0001)    >>  lev_sst.bin  <<
+(PID.TID 0000.0001)    >> lev_sst.bin <<
+(PID.TID 0000.0001)    interpolate "climsst" (method=  1 ):
+(PID.TID 0000.0001)    lon0=   2.00000, nlon=    90, lon_inc= 4.0000000
+(PID.TID 0000.0001)    lat0= -78.00000, nlat=    40, lat_inc= 4.0000000
 (PID.TID 0000.0001) 
-(PID.TID 0000.0001)    Climatological SSS starts at                   0.
-(PID.TID 0000.0001)    Climatological SSS period is                 -12.
+(PID.TID 0000.0001) // ALLOW_CLIMSSS_RELAXATION:           defined
+(PID.TID 0000.0001)    Climatological SSS period is                        -12.
 (PID.TID 0000.0001)    Climatological SSS is read from file:
-(PID.TID 0000.0001)    >>  lev_sss.bin  <<
+(PID.TID 0000.0001)    >> lev_sss.bin <<
+(PID.TID 0000.0001)    interpolate "climsss" (method=  1 ):
+(PID.TID 0000.0001)    lon0=   2.00000, nlon=    90, lon_inc= 4.0000000
+(PID.TID 0000.0001)    lat0= -78.00000, nlat=    40, lat_inc= 4.0000000
 (PID.TID 0000.0001) 
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // External forcing (EXF) configuration  >>> END <<<
@@ -1075,8 +1089,8 @@
 (PID.TID 0000.0001) ctrl-wet -------------------------------------------------
 (PID.TID 0000.0001) ctrl-wet -------------------------------------------------
 (PID.TID 0000.0001) ctrl-wet -------------------------------------------------
-(PID.TID 0000.0001) ctrl_init: no. of control variables:            6
-(PID.TID 0000.0001) ctrl_init: control vector length:           85573
+(PID.TID 0000.0001) ctrl_init_wet: no. of control variables:            6
+(PID.TID 0000.0001) ctrl_init_wet: control vector length:           85573
 (PID.TID 0000.0001) 
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // control vector configuration  >>> START <<<
@@ -1171,7 +1185,7 @@
 (PID.TID 0000.0001) tRef =   /* Reference temperature profile ( oC or K ) */
 (PID.TID 0000.0001)    15 @  2.000000000000000E+01              /* K =  1: 15 */
 (PID.TID 0000.0001)     ;
-(PID.TID 0000.0001) sRef =   /* Reference salinity profile ( psu ) */
+(PID.TID 0000.0001) sRef =   /* Reference salinity profile ( g/kg ) */
 (PID.TID 0000.0001)    15 @  3.500000000000000E+01              /* K =  1: 15 */
 (PID.TID 0000.0001)     ;
 (PID.TID 0000.0001) useStrainTensionVisc= /* Use StrainTension Form of Viscous Operator */
@@ -1264,9 +1278,15 @@
 (PID.TID 0000.0001) eosType =  /* Type of Equation of State */
 (PID.TID 0000.0001)               'JMD95Z'
 (PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) eosRefP0 = /* Reference atmospheric pressure for EOS ( Pa ) */
+(PID.TID 0000.0001)                 1.013250000000000E+05
+(PID.TID 0000.0001)     ;
 (PID.TID 0000.0001) selectP_inEOS_Zc = /* select pressure to use in EOS (0,1,2,3) */
 (PID.TID 0000.0001)                       0
 (PID.TID 0000.0001)     0= -g*rhoConst*z ; 1= pRef (from tRef,sRef); 2= Hyd P ; 3= Hyd+NH P
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) surf_pRef = /* Surface reference pressure ( Pa ) */
+(PID.TID 0000.0001)                 1.013250000000000E+05
 (PID.TID 0000.0001)     ;
 (PID.TID 0000.0001) HeatCapacity_Cp =  /* Specific heat capacity ( J/kg/K ) */
 (PID.TID 0000.0001)                 3.994000000000000E+03
@@ -1325,7 +1345,7 @@
 (PID.TID 0000.0001) implicSurfPress =  /* Surface Pressure implicit factor (0-1)*/
 (PID.TID 0000.0001)                 1.000000000000000E+00
 (PID.TID 0000.0001)     ;
-(PID.TID 0000.0001) implicDiv2Dflow =  /* Barot. Flow Div. implicit factor (0-1)*/
+(PID.TID 0000.0001) implicDiv2DFlow =  /* Barot. Flow Div. implicit factor (0-1)*/
 (PID.TID 0000.0001)                 1.000000000000000E+00
 (PID.TID 0000.0001)     ;
 (PID.TID 0000.0001) uniformLin_PhiSurf = /* use uniform Bo_surf on/off flag*/
@@ -1365,7 +1385,7 @@
 (PID.TID 0000.0001) temp_EvPrRn = /* Temp. of Evap/Prec/R (UNSET=use local T)(oC)*/
 (PID.TID 0000.0001)                 1.234567000000000E+05
 (PID.TID 0000.0001)     ;
-(PID.TID 0000.0001) salt_EvPrRn = /* Salin. of Evap/Prec/R (UNSET=use local S)(psu)*/
+(PID.TID 0000.0001) salt_EvPrRn = /* Salin. of Evap/Prec/R (UNSET=use local S)(g/kg)*/
 (PID.TID 0000.0001)                 0.000000000000000E+00
 (PID.TID 0000.0001)     ;
 (PID.TID 0000.0001) selectAddFluid = /* option for mass source/sink of fluid (=0: off) */
@@ -1374,10 +1394,10 @@
 (PID.TID 0000.0001) temp_addMass = /* Temp. of addMass array (UNSET=use local T)(oC)*/
 (PID.TID 0000.0001)                 1.234567000000000E+05
 (PID.TID 0000.0001)     ;
-(PID.TID 0000.0001) salt_addMass = /* Salin. of addMass array (UNSET=use local S)(psu)*/
+(PID.TID 0000.0001) salt_addMass = /* Salin. of addMass array (UNSET=use local S)(g/kg)*/
 (PID.TID 0000.0001)                 0.000000000000000E+00
 (PID.TID 0000.0001)     ;
-(PID.TID 0000.0001) convertFW2Salt = /* convert F.W. Flux to Salt Flux (-1=use local S)(psu)*/
+(PID.TID 0000.0001) convertFW2Salt = /* convert F.W. Flux to Salt Flux (-1=use local S)(g/kg)*/
 (PID.TID 0000.0001)                -1.000000000000000E+00
 (PID.TID 0000.0001)     ;
 (PID.TID 0000.0001) use3Dsolver = /* use 3-D pressure solver on/off flag */
@@ -1419,8 +1439,9 @@
 (PID.TID 0000.0001) implicitViscosity = /* Implicit viscosity on/off flag */
 (PID.TID 0000.0001)                   F
 (PID.TID 0000.0001)     ;
-(PID.TID 0000.0001) implBottomFriction= /* Implicit bottom friction on/off flag */
-(PID.TID 0000.0001)                   F
+(PID.TID 0000.0001) selectImplicitDrag= /* Implicit bot Drag options (0,1,2)*/
+(PID.TID 0000.0001)                       0
+(PID.TID 0000.0001)     0= Expl. ; 1= Impl. on provis. Vel ; 2= Fully Impl (with surf.P)
 (PID.TID 0000.0001)     ;
 (PID.TID 0000.0001) metricTerms =  /* metric-Terms on/off flag */
 (PID.TID 0000.0001)                   T
@@ -1441,39 +1462,17 @@
 (PID.TID 0000.0001) useCDscheme =  /* CD scheme on/off flag */
 (PID.TID 0000.0001)                   T
 (PID.TID 0000.0001)     ;
-(PID.TID 0000.0001) useEnergyConservingCoriolis= /* Flx-Form Coriolis scheme flag */
-(PID.TID 0000.0001)                   F
-(PID.TID 0000.0001)     ;
-(PID.TID 0000.0001) useJamartWetPoints= /* Coriolis WetPoints method flag */
-(PID.TID 0000.0001)                   F
-(PID.TID 0000.0001)     ;
-(PID.TID 0000.0001) useJamartMomAdv= /* V.I Non-linear terms Jamart flag */
-(PID.TID 0000.0001)                   F
-(PID.TID 0000.0001)     ;
-(PID.TID 0000.0001) useAbsVorticity= /* V.I Works with f+zeta in Coriolis */
-(PID.TID 0000.0001)                   F
-(PID.TID 0000.0001)     ;
-(PID.TID 0000.0001) selectVortScheme= /* V.I Scheme selector for Vorticity-Term */
-(PID.TID 0000.0001)               123456789
-(PID.TID 0000.0001)    = 0 : enstrophy (Shallow-Water Eq.) conserving scheme by Sadourny, JAS 75
-(PID.TID 0000.0001)    = 1 : same as 0 with modified hFac
-(PID.TID 0000.0001)    = 2 : energy conserving scheme (used by Sadourny in JAS 75 paper)
-(PID.TID 0000.0001)    = 3 : energy (general) and enstrophy (2D, nonDiv.) conserving scheme
-(PID.TID 0000.0001)          from Sadourny (Burridge & Haseler, ECMWF Rep.4, 1977)
-(PID.TID 0000.0001)     ;
-(PID.TID 0000.0001) upwindVorticity= /* V.I Upwind bias vorticity flag */
-(PID.TID 0000.0001)                   F
-(PID.TID 0000.0001)     ;
-(PID.TID 0000.0001) highOrderVorticity= /* V.I High order vort. advect. flag */
-(PID.TID 0000.0001)                   F
-(PID.TID 0000.0001)     ;
-(PID.TID 0000.0001) upwindShear= /* V.I Upwind vertical Shear advection flag */
-(PID.TID 0000.0001)                   F
-(PID.TID 0000.0001)     ;
-(PID.TID 0000.0001) selectKEscheme= /* V.I Kinetic Energy scheme selector */
+(PID.TID 0000.0001) selectCoriScheme= /* Scheme selector for Coriolis-Term */
 (PID.TID 0000.0001)                       0
+(PID.TID 0000.0001)    = 0 : original discretization (simple averaging, no hFac)
+(PID.TID 0000.0001)    = 1 : Wet-point averaging (Jamar & Ozer 1986)
+(PID.TID 0000.0001)    = 2 : energy conserving scheme (no hFac weight)
+(PID.TID 0000.0001)    = 3 : energy conserving scheme using Wet-point averaging
 (PID.TID 0000.0001)     ;
 (PID.TID 0000.0001) momForcing =  /* Momentum forcing on/off flag */
+(PID.TID 0000.0001)                   T
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) momTidalForcing = /* Momentum Tidal forcing on/off flag */
 (PID.TID 0000.0001)                   T
 (PID.TID 0000.0001)     ;
 (PID.TID 0000.0001) momPressureForcing =  /* Momentum pressure term on/off flag */
@@ -1539,6 +1538,12 @@
 (PID.TID 0000.0001) writeBinaryPrec = /* Precision used for writing binary files */
 (PID.TID 0000.0001)                      32
 (PID.TID 0000.0001)     ;
+(PID.TID 0000.0001)  rwSuffixType =   /* select format of mds file suffix */
+(PID.TID 0000.0001)                       0
+(PID.TID 0000.0001)    = 0 : myIter (I10.10) ;   = 1 : 100*myTime (100th sec) ;
+(PID.TID 0000.0001)    = 2 : myTime (seconds);   = 3 : myTime/360 (10th of hr);
+(PID.TID 0000.0001)    = 4 : myTime/3600 (hours)
+(PID.TID 0000.0001)     ;
 (PID.TID 0000.0001)  globalFiles = /* write "global" (=not per tile) files */
 (PID.TID 0000.0001)                   F
 (PID.TID 0000.0001)     ;
@@ -1556,6 +1561,9 @@
 (PID.TID 0000.0001)    debLevD =  4 ; /* level of enhanced debug prt (add DEBUG_STATS prt) */
 (PID.TID 0000.0001)    debLevE =  5 ; /* level of extensive debug printing */
 (PID.TID 0000.0001) debugLevel =  /* select debug printing level */
+(PID.TID 0000.0001)                       1
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001)  plotLevel =  /* select PLOT_FIELD printing level */
 (PID.TID 0000.0001)                       1
 (PID.TID 0000.0001)     ;
 (PID.TID 0000.0001) //
@@ -1663,9 +1671,6 @@
 (PID.TID 0000.0001) pickup_read_mdsio =   /* Model IO flag. */
 (PID.TID 0000.0001)                   T
 (PID.TID 0000.0001)     ;
-(PID.TID 0000.0001) pickup_write_immed =   /* Model IO flag. */
-(PID.TID 0000.0001)                   F
-(PID.TID 0000.0001)     ;
 (PID.TID 0000.0001) writePickupAtEnd =   /* Model IO flag. */
 (PID.TID 0000.0001)                   T
 (PID.TID 0000.0001)     ;
@@ -1679,10 +1684,10 @@
 (PID.TID 0000.0001)                   T
 (PID.TID 0000.0001)     ;
 (PID.TID 0000.0001) monitorFreq =   /* Monitor output interval ( s ). */
-(PID.TID 0000.0001)                 1.000000000000000E+00
+(PID.TID 0000.0001)                 4.320000000000000E+05
 (PID.TID 0000.0001)     ;
 (PID.TID 0000.0001) monitorSelect = /* select group of variables to monitor */
-(PID.TID 0000.0001)                       3
+(PID.TID 0000.0001)                       2
 (PID.TID 0000.0001)     ;
 (PID.TID 0000.0001) monitor_stdio =   /* Model IO flag. */
 (PID.TID 0000.0001)                   T
@@ -1716,6 +1721,18 @@
 (PID.TID 0000.0001)     ;
 (PID.TID 0000.0001) usingCurvilinearGrid = /* Curvilinear coordinates flag ( True/False ) */
 (PID.TID 0000.0001)                   F
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) useMin4hFacEdges = /* set hFacW,S as minimum of adjacent hFacC factor */
+(PID.TID 0000.0001)                   F
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) interViscAr_pCell = /* account for partial-cell in interior vert. viscosity */
+(PID.TID 0000.0001)                   F
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) interDiffKr_pCell = /* account for partial-cell in interior vert. diffusion */
+(PID.TID 0000.0001)                   F
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) pCellMix_select = /* option to enhance mixing near surface & bottom */
+(PID.TID 0000.0001)                       0
 (PID.TID 0000.0001)     ;
 (PID.TID 0000.0001) selectSigmaCoord = /* Hybrid-Sigma Vert. Coordinate option */
 (PID.TID 0000.0001)                       0
@@ -2345,8 +2362,14 @@
 (PID.TID 0000.0001) subMeso_Lmax = /* maximum grid-scale length [m] */
 (PID.TID 0000.0001)                 1.100000000000000E+05
 (PID.TID 0000.0001)     ;
-(PID.TID 0000.0001) CTRL_CHECK: ctrl package
-(PID.TID 0000.0001) COST_CHECK: cost package
+(PID.TID 0000.0001) GM_useLeithQG = /* if TRUE => add QG Leith viscosity to GMRedi tensor */
+(PID.TID 0000.0001)                   F
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) EXF_CHECK: #define ALLOW_EXF
+(PID.TID 0000.0001) CTRL_CHECK:  --> Starts to check CTRL set-up
+(PID.TID 0000.0001) CTRL_CHECK:  <-- Ends Normally
+(PID.TID 0000.0001) 
+(PID.TID 0000.0001) COST_CHECK: #define ALLOW_COST
 (PID.TID 0000.0001) GRDCHK_CHECK: grdchk package
 (PID.TID 0000.0001) GAD_CHECK: #define ALLOW_GENERIC_ADVDIFF
 (PID.TID 0000.0001) // =======================================================
@@ -2392,31 +2415,6 @@
 (PID.TID 0000.0001) %MON dynstat_salt_mean            =   3.4718006161477E+01
 (PID.TID 0000.0001) %MON dynstat_salt_sd              =   2.9628819587991E-01
 (PID.TID 0000.0001) %MON dynstat_salt_del2            =   1.0127003139695E-03
-(PID.TID 0000.0001) %MON forcing_qnet_max             =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON forcing_qnet_min             =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON forcing_qnet_mean            =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON forcing_qnet_sd              =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON forcing_qnet_del2            =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON forcing_qsw_max              =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON forcing_qsw_min              =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON forcing_qsw_mean             =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON forcing_qsw_sd               =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON forcing_qsw_del2             =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON forcing_empmr_max            =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON forcing_empmr_min            =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON forcing_empmr_mean           =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON forcing_empmr_sd             =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON forcing_empmr_del2           =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON forcing_fu_max               =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON forcing_fu_min               =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON forcing_fu_mean              =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON forcing_fu_sd                =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON forcing_fu_del2              =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON forcing_fv_max               =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON forcing_fv_min               =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON forcing_fv_mean              =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON forcing_fv_sd                =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON forcing_fv_del2              =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON trAdv_CFL_u_max              =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON trAdv_CFL_v_max              =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON trAdv_CFL_w_max              =   0.0000000000000E+00
@@ -2439,16 +2437,48 @@
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // End MONITOR dynamic field statistics
 (PID.TID 0000.0001) // =======================================================
-(PID.TID 0000.0001)  EXF_SET_GEN: it=         0 loading rec=    12 from: lev_sst.bin
-(PID.TID 0000.0001)  EXF_SET_GEN: it=         0 loading rec=     1 from: lev_sst.bin
-(PID.TID 0000.0001)  EXF_SET_GEN: it=         0 loading rec=    12 from: lev_sss.bin
-(PID.TID 0000.0001)  EXF_SET_GEN: it=         0 loading rec=     1 from: lev_sss.bin
-(PID.TID 0000.0001)  EXF_SET_GEN: it=         0 loading rec=    12 from: trenberth_taux.bin
-(PID.TID 0000.0001)  EXF_SET_GEN: it=         0 loading rec=     1 from: trenberth_taux.bin
-(PID.TID 0000.0001)  EXF_SET_GEN: it=         0 loading rec=    12 from: trenberth_tauy.bin
-(PID.TID 0000.0001)  EXF_SET_GEN: it=         0 loading rec=     1 from: trenberth_tauy.bin
-(PID.TID 0000.0001)  EXF_SET_GEN: it=         0 loading rec=    12 from: ncep_qnet.bin
-(PID.TID 0000.0001)  EXF_SET_GEN: it=         0 loading rec=     1 from: ncep_qnet.bin
+(PID.TID 0000.0001) EXF_SET_FLD: field "climsst", it=         0, loading rec=    12
+(PID.TID 0000.0001) EXF_SET_FLD:   from file: "lev_sst.bin"
+(PID.TID 0000.0001)  EXF_INTERP: file="lev_sst.bin", rec=    12 , x-Per,P.Sym=    T    T
+(PID.TID 0000.0001)  S.edge (j=-1,0,1) : proc= 0.0 0.0 0.0, yIn=  -86.000000  -82.000000  -78.000000
+(PID.TID 0000.0001)  N.edge (j=+0,+1,+2) proc= 0.0 0.0 0.0, yIn=   78.000000   82.000000   86.000000
+(PID.TID 0000.0001) EXF_SET_FLD: field "climsst", it=         0, loading rec=     1
+(PID.TID 0000.0001) EXF_SET_FLD:   from file: "lev_sst.bin"
+(PID.TID 0000.0001)  EXF_INTERP: file="lev_sst.bin", rec=     1 , x-Per,P.Sym=    T    T
+(PID.TID 0000.0001)  S.edge (j=-1,0,1) : proc= 0.0 0.0 0.0, yIn=  -86.000000  -82.000000  -78.000000
+(PID.TID 0000.0001)  N.edge (j=+0,+1,+2) proc= 0.0 0.0 0.0, yIn=   78.000000   82.000000   86.000000
+(PID.TID 0000.0001) EXF_SET_FLD: field "climsss", it=         0, loading rec=    12
+(PID.TID 0000.0001) EXF_SET_FLD:   from file: "lev_sss.bin"
+(PID.TID 0000.0001)  EXF_INTERP: file="lev_sss.bin", rec=    12 , x-Per,P.Sym=    T    T
+(PID.TID 0000.0001)  S.edge (j=-1,0,1) : proc= 0.0 0.0 0.0, yIn=  -86.000000  -82.000000  -78.000000
+(PID.TID 0000.0001)  N.edge (j=+0,+1,+2) proc= 0.0 0.0 0.0, yIn=   78.000000   82.000000   86.000000
+(PID.TID 0000.0001) EXF_SET_FLD: field "climsss", it=         0, loading rec=     1
+(PID.TID 0000.0001) EXF_SET_FLD:   from file: "lev_sss.bin"
+(PID.TID 0000.0001)  EXF_INTERP: file="lev_sss.bin", rec=     1 , x-Per,P.Sym=    T    T
+(PID.TID 0000.0001)  S.edge (j=-1,0,1) : proc= 0.0 0.0 0.0, yIn=  -86.000000  -82.000000  -78.000000
+(PID.TID 0000.0001)  N.edge (j=+0,+1,+2) proc= 0.0 0.0 0.0, yIn=   78.000000   82.000000   86.000000
+(PID.TID 0000.0001) EXF_SET_UV: fields "ustress" & "vstress", it=         0
+(PID.TID 0000.0001) EXF_SET_UV:   loading rec=    12 from file: "trenberth_taux.bin"
+(PID.TID 0000.0001) EXF_SET_UV:   loading rec=    12 from file: "trenberth_tauy.bin"
+(PID.TID 0000.0001)  EXF_INTERP_UV: fileU="trenberth_taux.bin", rec=    12 , x-Per,P.Sym=    T    T
+(PID.TID 0000.0001)  S.edge (j=-1,0,1) : proc= 0.0 0.0 0.0, yIn=  -86.000000  -82.000000  -78.000000
+(PID.TID 0000.0001)  N.edge (j=+0,+1,+2) proc= 0.0 0.0 0.0, yIn=   78.000000   82.000000   86.000000
+(PID.TID 0000.0001) EXF_SET_UV: fields "ustress" & "vstress", it=         0
+(PID.TID 0000.0001) EXF_SET_UV:   loading rec=     1 from file: "trenberth_taux.bin"
+(PID.TID 0000.0001) EXF_SET_UV:   loading rec=     1 from file: "trenberth_tauy.bin"
+(PID.TID 0000.0001)  EXF_INTERP_UV: fileU="trenberth_taux.bin", rec=     1 , x-Per,P.Sym=    T    T
+(PID.TID 0000.0001)  S.edge (j=-1,0,1) : proc= 0.0 0.0 0.0, yIn=  -86.000000  -82.000000  -78.000000
+(PID.TID 0000.0001)  N.edge (j=+0,+1,+2) proc= 0.0 0.0 0.0, yIn=   78.000000   82.000000   86.000000
+(PID.TID 0000.0001) EXF_SET_FLD: field "hflux", it=         0, loading rec=    12
+(PID.TID 0000.0001) EXF_SET_FLD:   from file: "ncep_qnet.bin"
+(PID.TID 0000.0001)  EXF_INTERP: file="ncep_qnet.bin", rec=    12 , x-Per,P.Sym=    T    T
+(PID.TID 0000.0001)  S.edge (j=-1,0,1) : proc= 0.0 0.0 0.0, yIn=  -86.000000  -82.000000  -78.000000
+(PID.TID 0000.0001)  N.edge (j=+0,+1,+2) proc= 0.0 0.0 0.0, yIn=   78.000000   82.000000   86.000000
+(PID.TID 0000.0001) EXF_SET_FLD: field "hflux", it=         0, loading rec=     1
+(PID.TID 0000.0001) EXF_SET_FLD:   from file: "ncep_qnet.bin"
+(PID.TID 0000.0001)  EXF_INTERP: file="ncep_qnet.bin", rec=     1 , x-Per,P.Sym=    T    T
+(PID.TID 0000.0001)  S.edge (j=-1,0,1) : proc= 0.0 0.0 0.0, yIn=  -86.000000  -82.000000  -78.000000
+(PID.TID 0000.0001)  N.edge (j=+0,+1,+2) proc= 0.0 0.0 0.0, yIn=   78.000000   82.000000   86.000000
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // Begin MONITOR EXF statistics
 (PID.TID 0000.0001) // =======================================================
@@ -2474,7 +2504,7 @@
 (PID.TID 0000.0001) %MON exf_climsst_mean             =   1.8364821435178E+01
 (PID.TID 0000.0001) %MON exf_climsst_sd               =   9.2122803951938E+00
 (PID.TID 0000.0001) %MON exf_climsst_del2             =   2.4303814016692E-02
-(PID.TID 0000.0001) %MON exf_climsss_max              =   3.7451293945313E+01
+(PID.TID 0000.0001) %MON exf_climsss_max              =   3.7451293945312E+01
 (PID.TID 0000.0001) %MON exf_climsss_min              =   2.9661429405212E+01
 (PID.TID 0000.0001) %MON exf_climsss_mean             =   3.4846753273918E+01
 (PID.TID 0000.0001) %MON exf_climsss_sd               =   9.6901487505657E-01
@@ -2484,1076 +2514,14 @@
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) SOLVE_FOR_PRESSURE: putPmEinXvector =    F
  cg2d: Sum(rhs),rhsMax =  -2.77555756156289E-16  2.53662338005399E+00
-(PID.TID 0000.0001)      cg2d_init_res =   6.19025994173577E+00
-(PID.TID 0000.0001)      cg2d_iters(min,last) =      -1      26
-(PID.TID 0000.0001)      cg2d_last_res =   4.92999792731088E-14
-(PID.TID 0000.0001) // =======================================================
-(PID.TID 0000.0001) // Begin MONITOR dynamic field statistics
-(PID.TID 0000.0001) // =======================================================
-(PID.TID 0000.0001) %MON time_tsnumber                =                     1
-(PID.TID 0000.0001) %MON time_secondsf                =   4.3200000000000E+04
-(PID.TID 0000.0001) %MON dynstat_eta_max              =   1.7834036635760E-01
-(PID.TID 0000.0001) %MON dynstat_eta_min              =  -1.1524770868768E-01
-(PID.TID 0000.0001) %MON dynstat_eta_mean             =  -1.1608766249848E-17
-(PID.TID 0000.0001) %MON dynstat_eta_sd               =   2.6146441238634E-02
-(PID.TID 0000.0001) %MON dynstat_eta_del2             =   1.1687020304933E-03
-(PID.TID 0000.0001) %MON dynstat_uvel_max             =   8.2017065980870E-03
-(PID.TID 0000.0001) %MON dynstat_uvel_min             =  -8.7870205639833E-03
-(PID.TID 0000.0001) %MON dynstat_uvel_mean            =  -3.5949102412284E-04
-(PID.TID 0000.0001) %MON dynstat_uvel_sd              =   1.2232963218868E-03
-(PID.TID 0000.0001) %MON dynstat_uvel_del2            =   1.1645019871449E-05
-(PID.TID 0000.0001) %MON dynstat_vvel_max             =   1.8419534682980E-02
-(PID.TID 0000.0001) %MON dynstat_vvel_min             =  -1.1238599609055E-02
-(PID.TID 0000.0001) %MON dynstat_vvel_mean            =   9.0360644458204E-04
-(PID.TID 0000.0001) %MON dynstat_vvel_sd              =   3.3983679266188E-03
-(PID.TID 0000.0001) %MON dynstat_vvel_del2            =   1.5511830585828E-05
-(PID.TID 0000.0001) %MON dynstat_wvel_max             =   1.5968256233580E-04
-(PID.TID 0000.0001) %MON dynstat_wvel_min             =  -1.0328470054651E-04
-(PID.TID 0000.0001) %MON dynstat_wvel_mean            =   1.1156519290424E-22
-(PID.TID 0000.0001) %MON dynstat_wvel_sd              =   1.6738261935693E-05
-(PID.TID 0000.0001) %MON dynstat_wvel_del2            =   2.5271176229257E-07
-(PID.TID 0000.0001) %MON dynstat_theta_max            =   2.9730291024029E+01
-(PID.TID 0000.0001) %MON dynstat_theta_min            =  -1.9000461615150E+00
-(PID.TID 0000.0001) %MON dynstat_theta_mean           =   3.6197399585377E+00
-(PID.TID 0000.0001) %MON dynstat_theta_sd             =   4.4172006819825E+00
-(PID.TID 0000.0001) %MON dynstat_theta_del2           =   5.6287336378632E-03
-(PID.TID 0000.0001) %MON dynstat_salt_max             =   3.7470515688115E+01
-(PID.TID 0000.0001) %MON dynstat_salt_min             =   2.9754192248363E+01
-(PID.TID 0000.0001) %MON dynstat_salt_mean            =   3.4718006046545E+01
-(PID.TID 0000.0001) %MON dynstat_salt_sd              =   2.9615694173131E-01
-(PID.TID 0000.0001) %MON dynstat_salt_del2            =   1.0154236975332E-03
-(PID.TID 0000.0001) %MON forcing_qnet_max             =   4.2589080810547E+02
-(PID.TID 0000.0001) %MON forcing_qnet_min             =  -1.8702698516846E+02
-(PID.TID 0000.0001) %MON forcing_qnet_mean            =  -1.6700205338390E+01
-(PID.TID 0000.0001) %MON forcing_qnet_sd              =   1.1285666794876E+02
-(PID.TID 0000.0001) %MON forcing_qnet_del2            =   9.9079877721394E-01
-(PID.TID 0000.0001) %MON forcing_qsw_max              =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON forcing_qsw_min              =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON forcing_qsw_mean             =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON forcing_qsw_sd               =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON forcing_qsw_del2             =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON forcing_empmr_max            =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON forcing_empmr_min            =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON forcing_empmr_mean           =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON forcing_empmr_sd             =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON forcing_empmr_del2           =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON forcing_fu_max               =   2.7286743372679E-01
-(PID.TID 0000.0001) %MON forcing_fu_min               =  -1.5774825587869E-01
-(PID.TID 0000.0001) %MON forcing_fu_mean              =   1.6059009244638E-02
-(PID.TID 0000.0001) %MON forcing_fu_sd                =   8.9852225077625E-02
-(PID.TID 0000.0001) %MON forcing_fu_del2              =   6.4526464033158E-04
-(PID.TID 0000.0001) %MON forcing_fv_max               =   1.9885098189116E-01
-(PID.TID 0000.0001) %MON forcing_fv_min               =  -1.4956599846482E-01
-(PID.TID 0000.0001) %MON forcing_fv_mean              =  -5.8490268865938E-03
-(PID.TID 0000.0001) %MON forcing_fv_sd                =   4.3024380850966E-02
-(PID.TID 0000.0001) %MON forcing_fv_del2              =   3.4720178533248E-04
-(PID.TID 0000.0001) %MON trAdv_CFL_u_max              =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON trAdv_CFL_v_max              =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON trAdv_CFL_w_max              =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON advcfl_uvel_max              =   2.7953390747829E-03
-(PID.TID 0000.0001) %MON advcfl_vvel_max              =   1.7893100875415E-03
-(PID.TID 0000.0001) %MON advcfl_wvel_max              =   2.5681012755494E-01
-(PID.TID 0000.0001) %MON advcfl_W_hf_max              =   1.3027675391902E-01
-(PID.TID 0000.0001) %MON pe_b_mean                    =   8.7479516092465E-07
-(PID.TID 0000.0001) %MON ke_max                       =   1.1990109926456E-04
-(PID.TID 0000.0001) %MON ke_mean                      =   6.2899488174120E-06
-(PID.TID 0000.0001) %MON ke_vol                       =   1.3226782436723E+18
-(PID.TID 0000.0001) %MON vort_r_min                   =  -5.9383308332544E-08
-(PID.TID 0000.0001) %MON vort_r_max                   =   6.6673875971352E-08
-(PID.TID 0000.0001) %MON vort_a_mean                  =  -2.5205769368589E-05
-(PID.TID 0000.0001) %MON vort_a_sd                    =   7.3403223606589E-05
-(PID.TID 0000.0001) %MON vort_p_mean                  =  -3.1758669526158E-05
-(PID.TID 0000.0001) %MON vort_p_sd                    =   1.3126608365457E-04
-(PID.TID 0000.0001) %MON surfExpan_theta_mean         =   4.6288041828946E-05
-(PID.TID 0000.0001) %MON surfExpan_salt_mean          =   3.4812297697017E-06
-(PID.TID 0000.0001) // =======================================================
-(PID.TID 0000.0001) // End MONITOR dynamic field statistics
-(PID.TID 0000.0001) // =======================================================
-(PID.TID 0000.0001) // =======================================================
-(PID.TID 0000.0001) // Begin MONITOR EXF statistics
-(PID.TID 0000.0001) // =======================================================
-(PID.TID 0000.0001) %MON exf_tsnumber                 =                     1
-(PID.TID 0000.0001) %MON exf_time_sec                 =   4.3200000000000E+04
-(PID.TID 0000.0001) %MON exf_ustress_max              =   2.7447456409854E-01
-(PID.TID 0000.0001) %MON exf_ustress_min              =  -1.5923819378499E-01
-(PID.TID 0000.0001) %MON exf_ustress_mean             =   1.5027890504196E-02
-(PID.TID 0000.0001) %MON exf_ustress_sd               =   8.8622362583491E-02
-(PID.TID 0000.0001) %MON exf_ustress_del2             =   6.8886970054666E-04
-(PID.TID 0000.0001) %MON exf_vstress_max              =   2.0858214074566E-01
-(PID.TID 0000.0001) %MON exf_vstress_min              =  -1.8662386363552E-01
-(PID.TID 0000.0001) %MON exf_vstress_mean             =  -6.0060398708152E-03
-(PID.TID 0000.0001) %MON exf_vstress_sd               =   4.4511397903789E-02
-(PID.TID 0000.0001) %MON exf_vstress_del2             =   4.6453645043852E-04
-(PID.TID 0000.0001) %MON exf_hflux_max                =   4.2639799548734E+02
-(PID.TID 0000.0001) %MON exf_hflux_min                =  -1.8680093876008E+02
-(PID.TID 0000.0001) %MON exf_hflux_mean               =  -1.6694151166218E+01
-(PID.TID 0000.0001) %MON exf_hflux_sd                 =   1.1275125285539E+02
-(PID.TID 0000.0001) %MON exf_hflux_del2               =   1.1772929134667E+00
-(PID.TID 0000.0001) %MON exf_climsst_max              =   2.9553869616601E+01
-(PID.TID 0000.0001) %MON exf_climsst_min              =  -1.9000000000000E+00
-(PID.TID 0000.0001) %MON exf_climsst_mean             =   1.8368676314521E+01
-(PID.TID 0000.0001) %MON exf_climsst_sd               =   9.2103513767114E+00
-(PID.TID 0000.0001) %MON exf_climsst_del2             =   2.4267068693234E-02
-(PID.TID 0000.0001) %MON exf_climsss_max              =   3.7452078911566E+01
-(PID.TID 0000.0001) %MON exf_climsss_min              =   2.9664375858922E+01
-(PID.TID 0000.0001) %MON exf_climsss_mean             =   3.4846855596540E+01
-(PID.TID 0000.0001) %MON exf_climsss_sd               =   9.6852202071827E-01
-(PID.TID 0000.0001) %MON exf_climsss_del2             =   7.0276302495755E-03
-(PID.TID 0000.0001) // =======================================================
-(PID.TID 0000.0001) // End MONITOR EXF statistics
-(PID.TID 0000.0001) // =======================================================
  cg2d: Sum(rhs),rhsMax =   3.80251385934116E-14  5.04305351695056E+00
-(PID.TID 0000.0001)      cg2d_init_res =   3.36809689018778E+00
-(PID.TID 0000.0001)      cg2d_iters(min,last) =      -1      26
-(PID.TID 0000.0001)      cg2d_last_res =   3.21266665346924E-14
-(PID.TID 0000.0001) // =======================================================
-(PID.TID 0000.0001) // Begin MONITOR dynamic field statistics
-(PID.TID 0000.0001) // =======================================================
-(PID.TID 0000.0001) %MON time_tsnumber                =                     2
-(PID.TID 0000.0001) %MON time_secondsf                =   8.6400000000000E+04
-(PID.TID 0000.0001) %MON dynstat_eta_max              =   3.7801169392188E-01
-(PID.TID 0000.0001) %MON dynstat_eta_min              =  -2.5435453765636E-01
-(PID.TID 0000.0001) %MON dynstat_eta_mean             =  -3.1273623599030E-17
-(PID.TID 0000.0001) %MON dynstat_eta_sd               =   6.0203334244953E-02
-(PID.TID 0000.0001) %MON dynstat_eta_del2             =   2.2871697805663E-03
-(PID.TID 0000.0001) %MON dynstat_uvel_max             =   1.8770498727081E-02
-(PID.TID 0000.0001) %MON dynstat_uvel_min             =  -1.6972178694346E-02
-(PID.TID 0000.0001) %MON dynstat_uvel_mean            =  -8.8946159320443E-04
-(PID.TID 0000.0001) %MON dynstat_uvel_sd              =   2.1237463596591E-03
-(PID.TID 0000.0001) %MON dynstat_uvel_del2            =   2.3138623892522E-05
-(PID.TID 0000.0001) %MON dynstat_vvel_max             =   3.3412334787217E-02
-(PID.TID 0000.0001) %MON dynstat_vvel_min             =  -1.8001428607805E-02
-(PID.TID 0000.0001) %MON dynstat_vvel_mean            =   1.7508065930333E-03
-(PID.TID 0000.0001) %MON dynstat_vvel_sd              =   6.1900225861998E-03
-(PID.TID 0000.0001) %MON dynstat_vvel_del2            =   2.8871845159518E-05
-(PID.TID 0000.0001) %MON dynstat_wvel_max             =   2.0883680635556E-04
-(PID.TID 0000.0001) %MON dynstat_wvel_min             =  -1.4685960611897E-04
-(PID.TID 0000.0001) %MON dynstat_wvel_mean            =   3.2295187419648E-22
-(PID.TID 0000.0001) %MON dynstat_wvel_sd              =   2.4144442928680E-05
-(PID.TID 0000.0001) %MON dynstat_wvel_del2            =   2.9137302939727E-07
-(PID.TID 0000.0001) %MON dynstat_theta_max            =   2.9678636166842E+01
-(PID.TID 0000.0001) %MON dynstat_theta_min            =  -1.9016700561509E+00
-(PID.TID 0000.0001) %MON dynstat_theta_mean           =   3.6189382082763E+00
-(PID.TID 0000.0001) %MON dynstat_theta_sd             =   4.4154045467617E+00
-(PID.TID 0000.0001) %MON dynstat_theta_del2           =   5.5114085078002E-03
-(PID.TID 0000.0001) %MON dynstat_salt_max             =   3.7465158917311E+01
-(PID.TID 0000.0001) %MON dynstat_salt_min             =   2.9756646415705E+01
-(PID.TID 0000.0001) %MON dynstat_salt_mean            =   3.4717943191992E+01
-(PID.TID 0000.0001) %MON dynstat_salt_sd              =   2.9609789487842E-01
-(PID.TID 0000.0001) %MON dynstat_salt_del2            =   1.0200199142768E-03
-(PID.TID 0000.0001) %MON forcing_qnet_max             =   4.2639799548734E+02
-(PID.TID 0000.0001) %MON forcing_qnet_min             =  -1.8680093876008E+02
-(PID.TID 0000.0001) %MON forcing_qnet_mean            =  -1.6694151166218E+01
-(PID.TID 0000.0001) %MON forcing_qnet_sd              =   1.1275125285539E+02
-(PID.TID 0000.0001) %MON forcing_qnet_del2            =   9.9127884480556E-01
-(PID.TID 0000.0001) %MON forcing_qsw_max              =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON forcing_qsw_min              =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON forcing_qsw_mean             =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON forcing_qsw_sd               =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON forcing_qsw_del2             =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON forcing_empmr_max            =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON forcing_empmr_min            =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON forcing_empmr_mean           =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON forcing_empmr_sd             =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON forcing_empmr_del2           =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON forcing_fu_max               =   2.7227548581939E-01
-(PID.TID 0000.0001) %MON forcing_fu_min               =  -1.5805101394653E-01
-(PID.TID 0000.0001) %MON forcing_fu_mean              =   1.6055044233911E-02
-(PID.TID 0000.0001) %MON forcing_fu_sd                =   8.9841658841100E-02
-(PID.TID 0000.0001) %MON forcing_fu_del2              =   6.4565659499100E-04
-(PID.TID 0000.0001) %MON forcing_fv_max               =   1.9953677202425E-01
-(PID.TID 0000.0001) %MON forcing_fv_min               =  -1.4979143777201E-01
-(PID.TID 0000.0001) %MON forcing_fv_mean              =  -5.8156920579535E-03
-(PID.TID 0000.0001) %MON forcing_fv_sd                =   4.3070123215686E-02
-(PID.TID 0000.0001) %MON forcing_fv_del2              =   3.4720151576684E-04
-(PID.TID 0000.0001) %MON trAdv_CFL_u_max              =   2.7448576826639E-03
-(PID.TID 0000.0001) %MON trAdv_CFL_v_max              =   1.8885381102954E-03
-(PID.TID 0000.0001) %MON trAdv_CFL_w_max              =   1.2840506377747E-01
-(PID.TID 0000.0001) %MON advcfl_uvel_max              =   5.0236141916436E-03
-(PID.TID 0000.0001) %MON advcfl_vvel_max              =   3.2457403898658E-03
-(PID.TID 0000.0001) %MON advcfl_wvel_max              =   2.8752671169256E-01
-(PID.TID 0000.0001) %MON advcfl_W_hf_max              =   1.4917541193258E-01
-(PID.TID 0000.0001) %MON pe_b_mean                    =   4.6379097048499E-06
-(PID.TID 0000.0001) %MON ke_max                       =   3.9747850459151E-04
-(PID.TID 0000.0001) %MON ke_mean                      =   2.0986585539317E-05
-(PID.TID 0000.0001) %MON ke_vol                       =   1.3226782436723E+18
-(PID.TID 0000.0001) %MON vort_r_min                   =  -1.0401954146865E-07
-(PID.TID 0000.0001) %MON vort_r_max                   =   1.2611958532140E-07
-(PID.TID 0000.0001) %MON vort_a_mean                  =  -2.5205769288022E-05
-(PID.TID 0000.0001) %MON vort_a_sd                    =   7.3403114562114E-05
-(PID.TID 0000.0001) %MON vort_p_mean                  =  -3.1758669424646E-05
-(PID.TID 0000.0001) %MON vort_p_sd                    =   1.3126589494254E-04
-(PID.TID 0000.0001) %MON surfExpan_theta_mean         =   8.3020642153277E-05
-(PID.TID 0000.0001) %MON surfExpan_salt_mean          =   6.6168338288627E-06
-(PID.TID 0000.0001) // =======================================================
-(PID.TID 0000.0001) // End MONITOR dynamic field statistics
-(PID.TID 0000.0001) // =======================================================
-(PID.TID 0000.0001) // =======================================================
-(PID.TID 0000.0001) // Begin MONITOR EXF statistics
-(PID.TID 0000.0001) // =======================================================
-(PID.TID 0000.0001) %MON exf_tsnumber                 =                     2
-(PID.TID 0000.0001) %MON exf_time_sec                 =   8.6400000000000E+04
-(PID.TID 0000.0001) %MON exf_ustress_max              =   2.7405913750972E-01
-(PID.TID 0000.0001) %MON exf_ustress_min              =  -1.5946645001250E-01
-(PID.TID 0000.0001) %MON exf_ustress_mean             =   1.5025001692563E-02
-(PID.TID 0000.0001) %MON exf_ustress_sd               =   8.8615517327637E-02
-(PID.TID 0000.0001) %MON exf_ustress_del2             =   6.8908097172501E-04
-(PID.TID 0000.0001) %MON exf_vstress_max              =   2.0881129849342E-01
-(PID.TID 0000.0001) %MON exf_vstress_min              =  -1.8634096484992E-01
-(PID.TID 0000.0001) %MON exf_vstress_mean             =  -5.9750353300724E-03
-(PID.TID 0000.0001) %MON exf_vstress_sd               =   4.4554868446764E-02
-(PID.TID 0000.0001) %MON exf_vstress_del2             =   4.6416161428942E-04
-(PID.TID 0000.0001) %MON exf_hflux_max                =   4.2690518286920E+02
-(PID.TID 0000.0001) %MON exf_hflux_min                =  -1.8657489235170E+02
-(PID.TID 0000.0001) %MON exf_hflux_mean               =  -1.6688096994045E+01
-(PID.TID 0000.0001) %MON exf_hflux_sd                 =   1.1264643288199E+02
-(PID.TID 0000.0001) %MON exf_hflux_del2               =   1.1772850088224E+00
-(PID.TID 0000.0001) %MON exf_climsst_max              =   2.9546101354784E+01
-(PID.TID 0000.0001) %MON exf_climsst_min              =  -1.9000000000000E+00
-(PID.TID 0000.0001) %MON exf_climsst_mean             =   1.8372532126253E+01
-(PID.TID 0000.0001) %MON exf_climsst_sd               =   9.2084804498399E+00
-(PID.TID 0000.0001) %MON exf_climsst_del2             =   2.4239385550137E-02
-(PID.TID 0000.0001) %MON exf_climsss_max              =   3.7452863877819E+01
-(PID.TID 0000.0001) %MON exf_climsss_min              =   2.9667322312632E+01
-(PID.TID 0000.0001) %MON exf_climsss_mean             =   3.4846957919163E+01
-(PID.TID 0000.0001) %MON exf_climsss_sd               =   9.6804985052932E-01
-(PID.TID 0000.0001) %MON exf_climsss_del2             =   7.0234812904951E-03
-(PID.TID 0000.0001) // =======================================================
-(PID.TID 0000.0001) // End MONITOR EXF statistics
-(PID.TID 0000.0001) // =======================================================
  cg2d: Sum(rhs),rhsMax =   7.50562806350885E-14  6.28993178193994E+00
-(PID.TID 0000.0001)      cg2d_init_res =   2.18219763803565E+00
-(PID.TID 0000.0001)      cg2d_iters(min,last) =      -1      26
-(PID.TID 0000.0001)      cg2d_last_res =   2.84741877553292E-14
-(PID.TID 0000.0001) // =======================================================
-(PID.TID 0000.0001) // Begin MONITOR dynamic field statistics
-(PID.TID 0000.0001) // =======================================================
-(PID.TID 0000.0001) %MON time_tsnumber                =                     3
-(PID.TID 0000.0001) %MON time_secondsf                =   1.2960000000000E+05
-(PID.TID 0000.0001) %MON dynstat_eta_max              =   5.1071575764509E-01
-(PID.TID 0000.0001) %MON dynstat_eta_min              =  -3.7625182173429E-01
-(PID.TID 0000.0001) %MON dynstat_eta_mean             =  -5.0375996159633E-17
-(PID.TID 0000.0001) %MON dynstat_eta_sd               =   9.2315866547231E-02
-(PID.TID 0000.0001) %MON dynstat_eta_del2             =   2.8329221936343E-03
-(PID.TID 0000.0001) %MON dynstat_uvel_max             =   3.0447480313710E-02
-(PID.TID 0000.0001) %MON dynstat_uvel_min             =  -2.9831613068425E-02
-(PID.TID 0000.0001) %MON dynstat_uvel_mean            =  -1.5582538102367E-03
-(PID.TID 0000.0001) %MON dynstat_uvel_sd              =   3.0082249443120E-03
-(PID.TID 0000.0001) %MON dynstat_uvel_del2            =   3.5708181780679E-05
-(PID.TID 0000.0001) %MON dynstat_vvel_max             =   4.4399647946687E-02
-(PID.TID 0000.0001) %MON dynstat_vvel_min             =  -2.4384678511822E-02
-(PID.TID 0000.0001) %MON dynstat_vvel_mean            =   2.5206696020371E-03
-(PID.TID 0000.0001) %MON dynstat_vvel_sd              =   8.4514571736309E-03
-(PID.TID 0000.0001) %MON dynstat_vvel_del2            =   4.4138806105770E-05
-(PID.TID 0000.0001) %MON dynstat_wvel_max             =   1.9534476371336E-04
-(PID.TID 0000.0001) %MON dynstat_wvel_min             =  -1.6536425571330E-04
-(PID.TID 0000.0001) %MON dynstat_wvel_mean            =  -5.1745698024663E-23
-(PID.TID 0000.0001) %MON dynstat_wvel_sd              =   2.6512952877060E-05
-(PID.TID 0000.0001) %MON dynstat_wvel_del2            =   2.5370590173899E-07
-(PID.TID 0000.0001) %MON dynstat_theta_max            =   2.9641725692382E+01
-(PID.TID 0000.0001) %MON dynstat_theta_min            =  -1.9084756136719E+00
-(PID.TID 0000.0001) %MON dynstat_theta_mean           =   3.6177869163051E+00
-(PID.TID 0000.0001) %MON dynstat_theta_sd             =   4.4129865652935E+00
-(PID.TID 0000.0001) %MON dynstat_theta_del2           =   5.4129892198198E-03
-(PID.TID 0000.0001) %MON dynstat_salt_max             =   3.7460968154503E+01
-(PID.TID 0000.0001) %MON dynstat_salt_min             =   2.9759548989168E+01
-(PID.TID 0000.0001) %MON dynstat_salt_mean            =   3.4717847335819E+01
-(PID.TID 0000.0001) %MON dynstat_salt_sd              =   2.9610549689512E-01
-(PID.TID 0000.0001) %MON dynstat_salt_del2            =   1.0182424775760E-03
-(PID.TID 0000.0001) %MON forcing_qnet_max             =   4.2690518286920E+02
-(PID.TID 0000.0001) %MON forcing_qnet_min             =  -1.8657489235170E+02
-(PID.TID 0000.0001) %MON forcing_qnet_mean            =  -1.6688096994045E+01
-(PID.TID 0000.0001) %MON forcing_qnet_sd              =   1.1264643288199E+02
-(PID.TID 0000.0001) %MON forcing_qnet_del2            =   9.9180049072513E-01
-(PID.TID 0000.0001) %MON forcing_qsw_max              =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON forcing_qsw_min              =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON forcing_qsw_mean             =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON forcing_qsw_sd               =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON forcing_qsw_del2             =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON forcing_empmr_max            =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON forcing_empmr_min            =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON forcing_empmr_mean           =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON forcing_empmr_sd             =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON forcing_empmr_del2           =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON forcing_fu_max               =   2.7171199480372E-01
-(PID.TID 0000.0001) %MON forcing_fu_min               =  -1.5835377201438E-01
-(PID.TID 0000.0001) %MON forcing_fu_mean              =   1.6051079223184E-02
-(PID.TID 0000.0001) %MON forcing_fu_sd                =   8.9833555996941E-02
-(PID.TID 0000.0001) %MON forcing_fu_del2              =   6.4615745626553E-04
-(PID.TID 0000.0001) %MON forcing_fv_max               =   2.0022256215734E-01
-(PID.TID 0000.0001) %MON forcing_fv_min               =  -1.5001687707920E-01
-(PID.TID 0000.0001) %MON forcing_fv_mean              =  -5.7823572293133E-03
-(PID.TID 0000.0001) %MON forcing_fv_sd                =   4.3119132898368E-02
-(PID.TID 0000.0001) %MON forcing_fv_del2              =   3.4728273578110E-04
-(PID.TID 0000.0001) %MON trAdv_CFL_u_max              =   5.5971192499844E-03
-(PID.TID 0000.0001) %MON trAdv_CFL_v_max              =   3.4257362460907E-03
-(PID.TID 0000.0001) %MON trAdv_CFL_w_max              =   1.4376335584628E-01
-(PID.TID 0000.0001) %MON advcfl_uvel_max              =   5.8770988169963E-03
-(PID.TID 0000.0001) %MON advcfl_vvel_max              =   4.3130697556496E-03
-(PID.TID 0000.0001) %MON advcfl_wvel_max              =   2.0528005782173E-01
-(PID.TID 0000.0001) %MON advcfl_W_hf_max              =   1.0500963657762E-01
-(PID.TID 0000.0001) %MON pe_b_mean                    =   1.0905206694548E-05
-(PID.TID 0000.0001) %MON ke_max                       =   7.5943201389460E-04
-(PID.TID 0000.0001) %MON ke_mean                      =   4.0133692447050E-05
-(PID.TID 0000.0001) %MON ke_vol                       =   1.3226782436723E+18
-(PID.TID 0000.0001) %MON vort_r_min                   =  -1.5500399701616E-07
-(PID.TID 0000.0001) %MON vort_r_max                   =   1.7984300850151E-07
-(PID.TID 0000.0001) %MON vort_a_mean                  =  -2.5205769306073E-05
-(PID.TID 0000.0001) %MON vort_a_sd                    =   7.3402981729621E-05
-(PID.TID 0000.0001) %MON vort_p_mean                  =  -3.1758669447389E-05
-(PID.TID 0000.0001) %MON vort_p_sd                    =   1.3126562184712E-04
-(PID.TID 0000.0001) %MON surfExpan_theta_mean         =   1.1106290134462E-04
-(PID.TID 0000.0001) %MON surfExpan_salt_mean          =   9.1673889773474E-06
-(PID.TID 0000.0001) // =======================================================
-(PID.TID 0000.0001) // End MONITOR dynamic field statistics
-(PID.TID 0000.0001) // =======================================================
-(PID.TID 0000.0001) // =======================================================
-(PID.TID 0000.0001) // Begin MONITOR EXF statistics
-(PID.TID 0000.0001) // =======================================================
-(PID.TID 0000.0001) %MON exf_tsnumber                 =                     3
-(PID.TID 0000.0001) %MON exf_time_sec                 =   1.2960000000000E+05
-(PID.TID 0000.0001) %MON exf_ustress_max              =   2.7364371092089E-01
-(PID.TID 0000.0001) %MON exf_ustress_min              =  -1.5986004039165E-01
-(PID.TID 0000.0001) %MON exf_ustress_mean             =   1.5022112880929E-02
-(PID.TID 0000.0001) %MON exf_ustress_sd               =   8.8611175397966E-02
-(PID.TID 0000.0001) %MON exf_ustress_del2             =   6.8941330587844E-04
-(PID.TID 0000.0001) %MON exf_vstress_max              =   2.0904045624118E-01
-(PID.TID 0000.0001) %MON exf_vstress_min              =  -1.8605806606431E-01
-(PID.TID 0000.0001) %MON exf_vstress_mean             =  -5.9440307893297E-03
-(PID.TID 0000.0001) %MON exf_vstress_sd               =   4.4601833921357E-02
-(PID.TID 0000.0001) %MON exf_vstress_del2             =   4.6390552774395E-04
-(PID.TID 0000.0001) %MON exf_hflux_max                =   4.2741237025107E+02
-(PID.TID 0000.0001) %MON exf_hflux_min                =  -1.8634884594333E+02
-(PID.TID 0000.0001) %MON exf_hflux_mean               =  -1.6682042821873E+01
-(PID.TID 0000.0001) %MON exf_hflux_sd                 =   1.1254220969141E+02
-(PID.TID 0000.0001) %MON exf_hflux_del2               =   1.1773135251992E+00
-(PID.TID 0000.0001) %MON exf_climsst_max              =   2.9538333092966E+01
-(PID.TID 0000.0001) %MON exf_climsst_min              =  -1.9000000000000E+00
-(PID.TID 0000.0001) %MON exf_climsst_mean             =   1.8376391382744E+01
-(PID.TID 0000.0001) %MON exf_climsst_sd               =   9.2066621227687E+00
-(PID.TID 0000.0001) %MON exf_climsst_del2             =   2.4220813113014E-02
-(PID.TID 0000.0001) %MON exf_climsss_max              =   3.7453648844073E+01
-(PID.TID 0000.0001) %MON exf_climsss_min              =   2.9670268766342E+01
-(PID.TID 0000.0001) %MON exf_climsss_mean             =   3.4847060241785E+01
-(PID.TID 0000.0001) %MON exf_climsss_sd               =   9.6759839477018E-01
-(PID.TID 0000.0001) %MON exf_climsss_del2             =   7.0221374226415E-03
-(PID.TID 0000.0001) // =======================================================
-(PID.TID 0000.0001) // End MONITOR EXF statistics
-(PID.TID 0000.0001) // =======================================================
  cg2d: Sum(rhs),rhsMax =   1.00336405850499E-13  6.70007859133559E+00
-(PID.TID 0000.0001)      cg2d_init_res =   1.87291899336378E+00
-(PID.TID 0000.0001)      cg2d_iters(min,last) =      -1      26
-(PID.TID 0000.0001)      cg2d_last_res =   2.55376894289821E-14
-(PID.TID 0000.0001) // =======================================================
-(PID.TID 0000.0001) // Begin MONITOR dynamic field statistics
-(PID.TID 0000.0001) // =======================================================
-(PID.TID 0000.0001) %MON time_tsnumber                =                     4
-(PID.TID 0000.0001) %MON time_secondsf                =   1.7280000000000E+05
-(PID.TID 0000.0001) %MON dynstat_eta_max              =   5.8500921982248E-01
-(PID.TID 0000.0001) %MON dynstat_eta_min              =  -4.8988286928138E-01
-(PID.TID 0000.0001) %MON dynstat_eta_mean             =  -2.7055872094724E-17
-(PID.TID 0000.0001) %MON dynstat_eta_sd               =   1.2168962137718E-01
-(PID.TID 0000.0001) %MON dynstat_eta_del2             =   2.9488324633363E-03
-(PID.TID 0000.0001) %MON dynstat_uvel_max             =   4.2370151636811E-02
-(PID.TID 0000.0001) %MON dynstat_uvel_min             =  -4.1948031051454E-02
-(PID.TID 0000.0001) %MON dynstat_uvel_mean            =  -2.3370787767730E-03
-(PID.TID 0000.0001) %MON dynstat_uvel_sd              =   4.0243999945914E-03
-(PID.TID 0000.0001) %MON dynstat_uvel_del2            =   4.7390128397355E-05
-(PID.TID 0000.0001) %MON dynstat_vvel_max             =   5.1653281207328E-02
-(PID.TID 0000.0001) %MON dynstat_vvel_min             =  -3.5699668019646E-02
-(PID.TID 0000.0001) %MON dynstat_vvel_mean            =   3.1966229583161E-03
-(PID.TID 0000.0001) %MON dynstat_vvel_sd              =   1.0311940953639E-02
-(PID.TID 0000.0001) %MON dynstat_vvel_del2            =   5.9856869919493E-05
-(PID.TID 0000.0001) %MON dynstat_wvel_max             =   1.9707388146494E-04
-(PID.TID 0000.0001) %MON dynstat_wvel_min             =  -1.9617142940965E-04
-(PID.TID 0000.0001) %MON dynstat_wvel_mean            =   5.2846670323060E-22
-(PID.TID 0000.0001) %MON dynstat_wvel_sd              =   2.8047582170304E-05
-(PID.TID 0000.0001) %MON dynstat_wvel_del2            =   2.5097677936350E-07
-(PID.TID 0000.0001) %MON dynstat_theta_max            =   2.9645907915211E+01
-(PID.TID 0000.0001) %MON dynstat_theta_min            =  -1.9206067717715E+00
-(PID.TID 0000.0001) %MON dynstat_theta_mean           =   3.6163785382811E+00
-(PID.TID 0000.0001) %MON dynstat_theta_sd             =   4.4100702419848E+00
-(PID.TID 0000.0001) %MON dynstat_theta_del2           =   5.3694315397566E-03
-(PID.TID 0000.0001) %MON dynstat_salt_max             =   3.7457251412608E+01
-(PID.TID 0000.0001) %MON dynstat_salt_min             =   2.9762763460885E+01
-(PID.TID 0000.0001) %MON dynstat_salt_mean            =   3.4717726699092E+01
-(PID.TID 0000.0001) %MON dynstat_salt_sd              =   2.9611861757431E-01
-(PID.TID 0000.0001) %MON dynstat_salt_del2            =   1.0162135076969E-03
-(PID.TID 0000.0001) %MON forcing_qnet_max             =   4.2741237025107E+02
-(PID.TID 0000.0001) %MON forcing_qnet_min             =  -1.8634884594333E+02
-(PID.TID 0000.0001) %MON forcing_qnet_mean            =  -1.6682042821873E+01
-(PID.TID 0000.0001) %MON forcing_qnet_sd              =   1.1254220969141E+02
-(PID.TID 0000.0001) %MON forcing_qnet_del2            =   9.9236364940445E-01
-(PID.TID 0000.0001) %MON forcing_qsw_max              =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON forcing_qsw_min              =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON forcing_qsw_mean             =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON forcing_qsw_sd               =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON forcing_qsw_del2             =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON forcing_empmr_max            =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON forcing_empmr_min            =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON forcing_empmr_mean           =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON forcing_empmr_sd             =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON forcing_empmr_del2           =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON forcing_fu_max               =   2.7152394815799E-01
-(PID.TID 0000.0001) %MON forcing_fu_min               =  -1.5865653008223E-01
-(PID.TID 0000.0001) %MON forcing_fu_mean              =   1.6047114212457E-02
-(PID.TID 0000.0001) %MON forcing_fu_sd                =   8.9827917211772E-02
-(PID.TID 0000.0001) %MON forcing_fu_del2              =   6.4676697114089E-04
-(PID.TID 0000.0001) %MON forcing_fv_max               =   2.0090835229043E-01
-(PID.TID 0000.0001) %MON forcing_fv_min               =  -1.5024231638639E-01
-(PID.TID 0000.0001) %MON forcing_fv_mean              =  -5.7490224006730E-03
-(PID.TID 0000.0001) %MON forcing_fv_sd                =   4.3171398771493E-02
-(PID.TID 0000.0001) %MON forcing_fv_del2              =   3.4744538822742E-04
-(PID.TID 0000.0001) %MON trAdv_CFL_u_max              =   7.4037698692404E-03
-(PID.TID 0000.0001) %MON trAdv_CFL_v_max              =   4.5522554545582E-03
-(PID.TID 0000.0001) %MON trAdv_CFL_w_max              =   1.0481197963904E-01
-(PID.TID 0000.0001) %MON advcfl_uvel_max              =   8.7642298835647E-03
-(PID.TID 0000.0001) %MON advcfl_vvel_max              =   5.0177020597753E-03
-(PID.TID 0000.0001) %MON advcfl_wvel_max              =   2.3599014536236E-01
-(PID.TID 0000.0001) %MON advcfl_W_hf_max              =   1.1821091332057E-01
-(PID.TID 0000.0001) %MON pe_b_mean                    =   1.8949086569231E-05
-(PID.TID 0000.0001) %MON ke_max                       =   1.1667562983054E-03
-(PID.TID 0000.0001) %MON ke_mean                      =   6.2165871666209E-05
-(PID.TID 0000.0001) %MON ke_vol                       =   1.3226782436723E+18
-(PID.TID 0000.0001) %MON vort_r_min                   =  -2.0217204088273E-07
-(PID.TID 0000.0001) %MON vort_r_max                   =   2.2692083538479E-07
-(PID.TID 0000.0001) %MON vort_a_mean                  =  -2.5205769310605E-05
-(PID.TID 0000.0001) %MON vort_a_sd                    =   7.3402831071710E-05
-(PID.TID 0000.0001) %MON vort_p_mean                  =  -3.1758669453100E-05
-(PID.TID 0000.0001) %MON vort_p_sd                    =   1.3126526480389E-04
-(PID.TID 0000.0001) %MON surfExpan_theta_mean         =   1.3217262592197E-04
-(PID.TID 0000.0001) %MON surfExpan_salt_mean          =   1.1029391954923E-05
-(PID.TID 0000.0001) // =======================================================
-(PID.TID 0000.0001) // End MONITOR dynamic field statistics
-(PID.TID 0000.0001) // =======================================================
-(PID.TID 0000.0001) // =======================================================
-(PID.TID 0000.0001) // Begin MONITOR EXF statistics
-(PID.TID 0000.0001) // =======================================================
-(PID.TID 0000.0001) %MON exf_tsnumber                 =                     4
-(PID.TID 0000.0001) %MON exf_time_sec                 =   1.7280000000000E+05
-(PID.TID 0000.0001) %MON exf_ustress_max              =   2.7322828433206E-01
-(PID.TID 0000.0001) %MON exf_ustress_min              =  -1.6025363077079E-01
-(PID.TID 0000.0001) %MON exf_ustress_mean             =   1.5019224069296E-02
-(PID.TID 0000.0001) %MON exf_ustress_sd               =   8.8609337162474E-02
-(PID.TID 0000.0001) %MON exf_ustress_del2             =   6.8986652804546E-04
-(PID.TID 0000.0001) %MON exf_vstress_max              =   2.0926961398894E-01
-(PID.TID 0000.0001) %MON exf_vstress_min              =  -1.8577516727871E-01
-(PID.TID 0000.0001) %MON exf_vstress_mean             =  -5.9130262485869E-03
-(PID.TID 0000.0001) %MON exf_vstress_sd               =   4.4652283299615E-02
-(PID.TID 0000.0001) %MON exf_vstress_del2             =   4.6376838751787E-04
-(PID.TID 0000.0001) %MON exf_hflux_max                =   4.2791955763294E+02
-(PID.TID 0000.0001) %MON exf_hflux_min                =  -1.8612279953495E+02
-(PID.TID 0000.0001) %MON exf_hflux_mean               =  -1.6675988649700E+01
-(PID.TID 0000.0001) %MON exf_hflux_sd                 =   1.1243858494319E+02
-(PID.TID 0000.0001) %MON exf_hflux_del2               =   1.1773784599505E+00
-(PID.TID 0000.0001) %MON exf_climsst_max              =   2.9530564831149E+01
-(PID.TID 0000.0001) %MON exf_climsst_min              =  -1.9000000000000E+00
-(PID.TID 0000.0001) %MON exf_climsst_mean             =   1.8380250639236E+01
-(PID.TID 0000.0001) %MON exf_climsst_sd               =   9.2049040151256E+00
-(PID.TID 0000.0001) %MON exf_climsst_del2             =   2.4211345121699E-02
-(PID.TID 0000.0001) %MON exf_climsss_max              =   3.7454433810326E+01
-(PID.TID 0000.0001) %MON exf_climsss_min              =   2.9673215220051E+01
-(PID.TID 0000.0001) %MON exf_climsss_mean             =   3.4847162564407E+01
-(PID.TID 0000.0001) %MON exf_climsss_sd               =   9.6716768244817E-01
-(PID.TID 0000.0001) %MON exf_climsss_del2             =   7.0236002561602E-03
-(PID.TID 0000.0001) // =======================================================
-(PID.TID 0000.0001) // End MONITOR EXF statistics
-(PID.TID 0000.0001) // =======================================================
  cg2d: Sum(rhs),rhsMax =   5.93969318174459E-14  6.82703161607703E+00
-(PID.TID 0000.0001)      cg2d_init_res =   1.76875007905671E+00
-(PID.TID 0000.0001)      cg2d_iters(min,last) =      -1      26
-(PID.TID 0000.0001)      cg2d_last_res =   2.61696188215599E-14
-(PID.TID 0000.0001) // =======================================================
-(PID.TID 0000.0001) // Begin MONITOR dynamic field statistics
-(PID.TID 0000.0001) // =======================================================
-(PID.TID 0000.0001) %MON time_tsnumber                =                     5
-(PID.TID 0000.0001) %MON time_secondsf                =   2.1600000000000E+05
-(PID.TID 0000.0001) %MON dynstat_eta_max              =   6.2766141182721E-01
-(PID.TID 0000.0001) %MON dynstat_eta_min              =  -5.6627382790468E-01
-(PID.TID 0000.0001) %MON dynstat_eta_mean             =  -4.2112068699738E-17
-(PID.TID 0000.0001) %MON dynstat_eta_sd               =   1.4940426702770E-01
-(PID.TID 0000.0001) %MON dynstat_eta_del2             =   2.8718111514063E-03
-(PID.TID 0000.0001) %MON dynstat_uvel_max             =   5.4068160209257E-02
-(PID.TID 0000.0001) %MON dynstat_uvel_min             =  -5.2014178545460E-02
-(PID.TID 0000.0001) %MON dynstat_uvel_mean            =  -3.1957288726892E-03
-(PID.TID 0000.0001) %MON dynstat_uvel_sd              =   5.1485320886573E-03
-(PID.TID 0000.0001) %MON dynstat_uvel_del2            =   5.7374239618716E-05
-(PID.TID 0000.0001) %MON dynstat_vvel_max             =   5.5976684172092E-02
-(PID.TID 0000.0001) %MON dynstat_vvel_min             =  -4.6316936834306E-02
-(PID.TID 0000.0001) %MON dynstat_vvel_mean            =   3.7651826041186E-03
-(PID.TID 0000.0001) %MON dynstat_vvel_sd              =   1.1812183496344E-02
-(PID.TID 0000.0001) %MON dynstat_vvel_del2            =   7.3666829777064E-05
-(PID.TID 0000.0001) %MON dynstat_wvel_max             =   2.2270914484920E-04
-(PID.TID 0000.0001) %MON dynstat_wvel_min             =  -2.2597475020464E-04
-(PID.TID 0000.0001) %MON dynstat_wvel_mean            =   4.0515780581013E-22
-(PID.TID 0000.0001) %MON dynstat_wvel_sd              =   2.9602026208135E-05
-(PID.TID 0000.0001) %MON dynstat_wvel_del2            =   2.7642571540834E-07
-(PID.TID 0000.0001) %MON dynstat_theta_max            =   2.9675564257703E+01
-(PID.TID 0000.0001) %MON dynstat_theta_min            =  -1.9423274345336E+00
-(PID.TID 0000.0001) %MON dynstat_theta_mean           =   3.6147795010756E+00
-(PID.TID 0000.0001) %MON dynstat_theta_sd             =   4.4067543915320E+00
-(PID.TID 0000.0001) %MON dynstat_theta_del2           =   5.3538427693808E-03
-(PID.TID 0000.0001) %MON dynstat_salt_max             =   3.7453484254625E+01
-(PID.TID 0000.0001) %MON dynstat_salt_min             =   2.9766140785211E+01
-(PID.TID 0000.0001) %MON dynstat_salt_mean            =   3.4717589743257E+01
-(PID.TID 0000.0001) %MON dynstat_salt_sd              =   2.9613913290126E-01
-(PID.TID 0000.0001) %MON dynstat_salt_del2            =   1.0148695120426E-03
-(PID.TID 0000.0001) %MON forcing_qnet_max             =   4.2791955763294E+02
-(PID.TID 0000.0001) %MON forcing_qnet_min             =  -1.8612279953495E+02
-(PID.TID 0000.0001) %MON forcing_qnet_mean            =  -1.6675988649700E+01
-(PID.TID 0000.0001) %MON forcing_qnet_sd              =   1.1243858494319E+02
-(PID.TID 0000.0001) %MON forcing_qnet_del2            =   9.9296825021206E-01
-(PID.TID 0000.0001) %MON forcing_qsw_max              =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON forcing_qsw_min              =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON forcing_qsw_mean             =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON forcing_qsw_sd               =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON forcing_qsw_del2             =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON forcing_empmr_max            =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON forcing_empmr_min            =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON forcing_empmr_mean           =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON forcing_empmr_sd             =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON forcing_empmr_del2           =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON forcing_fu_max               =   2.7133590151225E-01
-(PID.TID 0000.0001) %MON forcing_fu_min               =  -1.5895928815007E-01
-(PID.TID 0000.0001) %MON forcing_fu_mean              =   1.6043149201730E-02
-(PID.TID 0000.0001) %MON forcing_fu_sd                =   8.9824742949640E-02
-(PID.TID 0000.0001) %MON forcing_fu_del2              =   6.4748483277140E-04
-(PID.TID 0000.0001) %MON forcing_fv_max               =   2.0159414242352E-01
-(PID.TID 0000.0001) %MON forcing_fv_min               =  -1.5046775569358E-01
-(PID.TID 0000.0001) %MON forcing_fv_mean              =  -5.7156875720328E-03
-(PID.TID 0000.0001) %MON forcing_fv_sd                =   4.3226909023834E-02
-(PID.TID 0000.0001) %MON forcing_fv_del2              =   3.4768935882117E-04
-(PID.TID 0000.0001) %MON trAdv_CFL_u_max              =   8.8627394206391E-03
-(PID.TID 0000.0001) %MON trAdv_CFL_v_max              =   6.6705200384998E-03
-(PID.TID 0000.0001) %MON trAdv_CFL_w_max              =   1.1799507268118E-01
-(PID.TID 0000.0001) %MON advcfl_uvel_max              =   1.1251643630403E-02
-(PID.TID 0000.0001) %MON advcfl_vvel_max              =   5.4376859882786E-03
-(PID.TID 0000.0001) %MON advcfl_wvel_max              =   2.4308705789312E-01
-(PID.TID 0000.0001) %MON advcfl_W_hf_max              =   1.2349709412839E-01
-(PID.TID 0000.0001) %MON pe_b_mean                    =   2.8563222480142E-05
-(PID.TID 0000.0001) %MON ke_max                       =   1.6439112411115E-03
-(PID.TID 0000.0001) %MON ke_mean                      =   8.5687071020763E-05
-(PID.TID 0000.0001) %MON ke_vol                       =   1.3226782436723E+18
-(PID.TID 0000.0001) %MON vort_r_min                   =  -2.4294974621374E-07
-(PID.TID 0000.0001) %MON vort_r_max                   =   2.6609316786230E-07
-(PID.TID 0000.0001) %MON vort_a_mean                  =  -2.5205769310456E-05
-(PID.TID 0000.0001) %MON vort_a_sd                    =   7.3402667498140E-05
-(PID.TID 0000.0001) %MON vort_p_mean                  =  -3.1758669452911E-05
-(PID.TID 0000.0001) %MON vort_p_sd                    =   1.3126483053568E-04
-(PID.TID 0000.0001) %MON surfExpan_theta_mean         =   1.4724553739534E-04
-(PID.TID 0000.0001) %MON surfExpan_salt_mean          =   1.2254956089683E-05
-(PID.TID 0000.0001) // =======================================================
-(PID.TID 0000.0001) // End MONITOR dynamic field statistics
-(PID.TID 0000.0001) // =======================================================
-(PID.TID 0000.0001) // =======================================================
-(PID.TID 0000.0001) // Begin MONITOR EXF statistics
-(PID.TID 0000.0001) // =======================================================
-(PID.TID 0000.0001) %MON exf_tsnumber                 =                     5
-(PID.TID 0000.0001) %MON exf_time_sec                 =   2.1600000000000E+05
-(PID.TID 0000.0001) %MON exf_ustress_max              =   2.7281285774323E-01
-(PID.TID 0000.0001) %MON exf_ustress_min              =  -1.6064722114994E-01
-(PID.TID 0000.0001) %MON exf_ustress_mean             =   1.5016335257663E-02
-(PID.TID 0000.0001) %MON exf_ustress_sd               =   8.8610002776980E-02
-(PID.TID 0000.0001) %MON exf_ustress_del2             =   6.9044040016445E-04
-(PID.TID 0000.0001) %MON exf_vstress_max              =   2.0949877173670E-01
-(PID.TID 0000.0001) %MON exf_vstress_min              =  -1.8549226849310E-01
-(PID.TID 0000.0001) %MON exf_vstress_mean             =  -5.8820217078441E-03
-(PID.TID 0000.0001) %MON exf_vstress_sd               =   4.4706204787150E-02
-(PID.TID 0000.0001) %MON exf_vstress_del2             =   4.6375029913561E-04
-(PID.TID 0000.0001) %MON exf_hflux_max                =   4.2842674501481E+02
-(PID.TID 0000.0001) %MON exf_hflux_min                =  -1.8589675312658E+02
-(PID.TID 0000.0001) %MON exf_hflux_mean               =  -1.6669934477528E+01
-(PID.TID 0000.0001) %MON exf_hflux_sd                 =   1.1233556029344E+02
-(PID.TID 0000.0001) %MON exf_hflux_del2               =   1.1774798070513E+00
-(PID.TID 0000.0001) %MON exf_climsst_max              =   2.9522796569332E+01
-(PID.TID 0000.0001) %MON exf_climsst_min              =  -1.9000000000000E+00
-(PID.TID 0000.0001) %MON exf_climsst_mean             =   1.8384109895727E+01
-(PID.TID 0000.0001) %MON exf_climsst_sd               =   9.2032061614223E+00
-(PID.TID 0000.0001) %MON exf_climsst_del2             =   2.4210992257393E-02
-(PID.TID 0000.0001) %MON exf_climsss_max              =   3.7455218776580E+01
-(PID.TID 0000.0001) %MON exf_climsss_min              =   2.9676161673761E+01
-(PID.TID 0000.0001) %MON exf_climsss_mean             =   3.4847264887029E+01
-(PID.TID 0000.0001) %MON exf_climsss_sd               =   9.6675774128830E-01
-(PID.TID 0000.0001) %MON exf_climsss_del2             =   7.0278680384274E-03
-(PID.TID 0000.0001) // =======================================================
-(PID.TID 0000.0001) // End MONITOR EXF statistics
-(PID.TID 0000.0001) // =======================================================
  cg2d: Sum(rhs),rhsMax =  -3.24185123190546E-14  6.85801094466119E+00
-(PID.TID 0000.0001)      cg2d_init_res =   1.69333738721926E+00
-(PID.TID 0000.0001)      cg2d_iters(min,last) =      -1      26
-(PID.TID 0000.0001)      cg2d_last_res =   2.67811984694815E-14
-(PID.TID 0000.0001) // =======================================================
-(PID.TID 0000.0001) // Begin MONITOR dynamic field statistics
-(PID.TID 0000.0001) // =======================================================
-(PID.TID 0000.0001) %MON time_tsnumber                =                     6
-(PID.TID 0000.0001) %MON time_secondsf                =   2.5920000000000E+05
-(PID.TID 0000.0001) %MON dynstat_eta_max              =   7.1824925854669E-01
-(PID.TID 0000.0001) %MON dynstat_eta_min              =  -6.2212514611702E-01
-(PID.TID 0000.0001) %MON dynstat_eta_mean             =  -3.9168752070186E-17
-(PID.TID 0000.0001) %MON dynstat_eta_sd               =   1.7603078972467E-01
-(PID.TID 0000.0001) %MON dynstat_eta_del2             =   2.7463213254284E-03
-(PID.TID 0000.0001) %MON dynstat_uvel_max             =   6.5244328836446E-02
-(PID.TID 0000.0001) %MON dynstat_uvel_min             =  -6.0113676952461E-02
-(PID.TID 0000.0001) %MON dynstat_uvel_mean            =  -4.1028747576667E-03
-(PID.TID 0000.0001) %MON dynstat_uvel_sd              =   6.3429248795664E-03
-(PID.TID 0000.0001) %MON dynstat_uvel_del2            =   6.5937570884115E-05
-(PID.TID 0000.0001) %MON dynstat_vvel_max             =   6.5077451238084E-02
-(PID.TID 0000.0001) %MON dynstat_vvel_min             =  -5.6002191963001E-02
-(PID.TID 0000.0001) %MON dynstat_vvel_mean            =   4.2163906061444E-03
-(PID.TID 0000.0001) %MON dynstat_vvel_sd              =   1.2974156272485E-02
-(PID.TID 0000.0001) %MON dynstat_vvel_del2            =   8.4972324212586E-05
-(PID.TID 0000.0001) %MON dynstat_wvel_max             =   2.4290572911784E-04
-(PID.TID 0000.0001) %MON dynstat_wvel_min             =  -2.5030067977368E-04
-(PID.TID 0000.0001) %MON dynstat_wvel_mean            =   4.1102965806824E-22
-(PID.TID 0000.0001) %MON dynstat_wvel_sd              =   3.1185150972352E-05
-(PID.TID 0000.0001) %MON dynstat_wvel_del2            =   3.0977356385367E-07
-(PID.TID 0000.0001) %MON dynstat_theta_max            =   2.9704136577208E+01
-(PID.TID 0000.0001) %MON dynstat_theta_min            =  -1.9694552177519E+00
-(PID.TID 0000.0001) %MON dynstat_theta_mean           =   3.6130519490663E+00
-(PID.TID 0000.0001) %MON dynstat_theta_sd             =   4.4031183165063E+00
-(PID.TID 0000.0001) %MON dynstat_theta_del2           =   5.3380897259235E-03
-(PID.TID 0000.0001) %MON dynstat_salt_max             =   3.7449713065833E+01
-(PID.TID 0000.0001) %MON dynstat_salt_min             =   2.9769535325110E+01
-(PID.TID 0000.0001) %MON dynstat_salt_mean            =   3.4717443293192E+01
-(PID.TID 0000.0001) %MON dynstat_salt_sd              =   2.9615523621216E-01
-(PID.TID 0000.0001) %MON dynstat_salt_del2            =   1.0133163408620E-03
-(PID.TID 0000.0001) %MON forcing_qnet_max             =   4.2842674501481E+02
-(PID.TID 0000.0001) %MON forcing_qnet_min             =  -1.8589675312658E+02
-(PID.TID 0000.0001) %MON forcing_qnet_mean            =  -1.6669934477528E+01
-(PID.TID 0000.0001) %MON forcing_qnet_sd              =   1.1233556029344E+02
-(PID.TID 0000.0001) %MON forcing_qnet_del2            =   9.9361421749702E-01
-(PID.TID 0000.0001) %MON forcing_qsw_max              =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON forcing_qsw_min              =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON forcing_qsw_mean             =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON forcing_qsw_sd               =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON forcing_qsw_del2             =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON forcing_empmr_max            =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON forcing_empmr_min            =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON forcing_empmr_mean           =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON forcing_empmr_sd             =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON forcing_empmr_del2           =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON forcing_fu_max               =   2.7114785486652E-01
-(PID.TID 0000.0001) %MON forcing_fu_min               =  -1.5926204621792E-01
-(PID.TID 0000.0001) %MON forcing_fu_mean              =   1.6039184191003E-02
-(PID.TID 0000.0001) %MON forcing_fu_sd                =   8.9824033471825E-02
-(PID.TID 0000.0001) %MON forcing_fu_del2              =   6.4831068124650E-04
-(PID.TID 0000.0001) %MON forcing_fv_max               =   2.0227993255661E-01
-(PID.TID 0000.0001) %MON forcing_fv_min               =  -1.5069319500077E-01
-(PID.TID 0000.0001) %MON forcing_fv_mean              =  -5.6823527433926E-03
-(PID.TID 0000.0001) %MON forcing_fv_sd                =   4.3285651173452E-02
-(PID.TID 0000.0001) %MON forcing_fv_del2              =   3.4801447654163E-04
-(PID.TID 0000.0001) %MON trAdv_CFL_u_max              =   1.1253928919698E-02
-(PID.TID 0000.0001) %MON trAdv_CFL_v_max              =   8.7063477140337E-03
-(PID.TID 0000.0001) %MON trAdv_CFL_w_max              =   1.2154352894656E-01
-(PID.TID 0000.0001) %MON advcfl_uvel_max              =   1.3672716983034E-02
-(PID.TID 0000.0001) %MON advcfl_vvel_max              =   6.3217525293618E-03
-(PID.TID 0000.0001) %MON advcfl_wvel_max              =   2.0746130230986E-01
-(PID.TID 0000.0001) %MON advcfl_W_hf_max              =   1.0808083381936E-01
-(PID.TID 0000.0001) %MON pe_b_mean                    =   3.9651395343749E-05
-(PID.TID 0000.0001) %MON ke_max                       =   2.1850452912594E-03
-(PID.TID 0000.0001) %MON ke_mean                      =   1.0947752154437E-04
-(PID.TID 0000.0001) %MON ke_vol                       =   1.3226782436723E+18
-(PID.TID 0000.0001) %MON vort_r_min                   =  -2.7552627535857E-07
-(PID.TID 0000.0001) %MON vort_r_max                   =   2.9726529731228E-07
-(PID.TID 0000.0001) %MON vort_a_mean                  =  -2.5205769328176E-05
-(PID.TID 0000.0001) %MON vort_a_sd                    =   7.3402495960100E-05
-(PID.TID 0000.0001) %MON vort_p_mean                  =  -3.1758669475238E-05
-(PID.TID 0000.0001) %MON vort_p_sd                    =   1.3126433377379E-04
-(PID.TID 0000.0001) %MON surfExpan_theta_mean         =   1.5692756042860E-04
-(PID.TID 0000.0001) %MON surfExpan_salt_mean          =   1.2943430382628E-05
-(PID.TID 0000.0001) // =======================================================
-(PID.TID 0000.0001) // End MONITOR dynamic field statistics
-(PID.TID 0000.0001) // =======================================================
-(PID.TID 0000.0001) // =======================================================
-(PID.TID 0000.0001) // Begin MONITOR EXF statistics
-(PID.TID 0000.0001) // =======================================================
-(PID.TID 0000.0001) %MON exf_tsnumber                 =                     6
-(PID.TID 0000.0001) %MON exf_time_sec                 =   2.5920000000000E+05
-(PID.TID 0000.0001) %MON exf_ustress_max              =   2.7239743115440E-01
-(PID.TID 0000.0001) %MON exf_ustress_min              =  -1.6104081152908E-01
-(PID.TID 0000.0001) %MON exf_ustress_mean             =   1.5013446446030E-02
-(PID.TID 0000.0001) %MON exf_ustress_sd               =   8.8613172185060E-02
-(PID.TID 0000.0001) %MON exf_ustress_del2             =   6.9113462169646E-04
-(PID.TID 0000.0001) %MON exf_vstress_max              =   2.1038053232816E-01
-(PID.TID 0000.0001) %MON exf_vstress_min              =  -1.8520936970749E-01
-(PID.TID 0000.0001) %MON exf_vstress_mean             =  -5.8510171671014E-03
-(PID.TID 0000.0001) %MON exf_vstress_sd               =   4.4763585836625E-02
-(PID.TID 0000.0001) %MON exf_vstress_del2             =   4.6385127652482E-04
-(PID.TID 0000.0001) %MON exf_hflux_max                =   4.2893393239667E+02
-(PID.TID 0000.0001) %MON exf_hflux_min                =  -1.8567070671820E+02
-(PID.TID 0000.0001) %MON exf_hflux_mean               =  -1.6663880305355E+01
-(PID.TID 0000.0001) %MON exf_hflux_sd                 =   1.1223313739475E+02
-(PID.TID 0000.0001) %MON exf_hflux_del2               =   1.1776175571006E+00
-(PID.TID 0000.0001) %MON exf_climsst_max              =   2.9515028307515E+01
-(PID.TID 0000.0001) %MON exf_climsst_min              =  -1.9000000000000E+00
-(PID.TID 0000.0001) %MON exf_climsst_mean             =   1.8387969152218E+01
-(PID.TID 0000.0001) %MON exf_climsst_sd               =   9.2015685950123E+00
-(PID.TID 0000.0001) %MON exf_climsst_del2             =   2.4219754918499E-02
-(PID.TID 0000.0001) %MON exf_climsss_max              =   3.7456003742833E+01
-(PID.TID 0000.0001) %MON exf_climsss_min              =   2.9679108127471E+01
-(PID.TID 0000.0001) %MON exf_climsss_mean             =   3.4847367209651E+01
-(PID.TID 0000.0001) %MON exf_climsss_sd               =   9.6636859772443E-01
-(PID.TID 0000.0001) %MON exf_climsss_del2             =   7.0349356645322E-03
-(PID.TID 0000.0001) // =======================================================
-(PID.TID 0000.0001) // End MONITOR EXF statistics
-(PID.TID 0000.0001) // =======================================================
  cg2d: Sum(rhs),rhsMax =  -4.99600361081320E-14  7.14243599153802E+00
-(PID.TID 0000.0001)      cg2d_init_res =   1.55876199121154E+00
-(PID.TID 0000.0001)      cg2d_iters(min,last) =      -1      26
-(PID.TID 0000.0001)      cg2d_last_res =   2.52069677615918E-14
-(PID.TID 0000.0001) // =======================================================
-(PID.TID 0000.0001) // Begin MONITOR dynamic field statistics
-(PID.TID 0000.0001) // =======================================================
-(PID.TID 0000.0001) %MON time_tsnumber                =                     7
-(PID.TID 0000.0001) %MON time_secondsf                =   3.0240000000000E+05
-(PID.TID 0000.0001) %MON dynstat_eta_max              =   8.1796008891401E-01
-(PID.TID 0000.0001) %MON dynstat_eta_min              =  -6.7400077955006E-01
-(PID.TID 0000.0001) %MON dynstat_eta_mean             =   4.4376158414777E-17
-(PID.TID 0000.0001) %MON dynstat_eta_sd               =   2.0163010732313E-01
-(PID.TID 0000.0001) %MON dynstat_eta_del2             =   2.6321618326268E-03
-(PID.TID 0000.0001) %MON dynstat_uvel_max             =   7.5733231759611E-02
-(PID.TID 0000.0001) %MON dynstat_uvel_min             =  -7.2791668094672E-02
-(PID.TID 0000.0001) %MON dynstat_uvel_mean            =  -5.0270467408806E-03
-(PID.TID 0000.0001) %MON dynstat_uvel_sd              =   7.5735992595014E-03
-(PID.TID 0000.0001) %MON dynstat_uvel_del2            =   7.3399570231258E-05
-(PID.TID 0000.0001) %MON dynstat_vvel_max             =   7.3645516990192E-02
-(PID.TID 0000.0001) %MON dynstat_vvel_min             =  -6.5730228411614E-02
-(PID.TID 0000.0001) %MON dynstat_vvel_mean            =   4.5446985990932E-03
-(PID.TID 0000.0001) %MON dynstat_vvel_sd              =   1.3820939972968E-02
-(PID.TID 0000.0001) %MON dynstat_vvel_del2            =   9.3997063608876E-05
-(PID.TID 0000.0001) %MON dynstat_wvel_max             =   2.5779566778365E-04
-(PID.TID 0000.0001) %MON dynstat_wvel_min             =  -2.6860876235709E-04
-(PID.TID 0000.0001) %MON dynstat_wvel_mean            =   8.9252154323390E-22
-(PID.TID 0000.0001) %MON dynstat_wvel_sd              =   3.2630791668706E-05
-(PID.TID 0000.0001) %MON dynstat_wvel_del2            =   3.3958132494968E-07
-(PID.TID 0000.0001) %MON dynstat_theta_max            =   2.9714371049330E+01
-(PID.TID 0000.0001) %MON dynstat_theta_min            =  -2.0000296041356E+00
-(PID.TID 0000.0001) %MON dynstat_theta_mean           =   3.6112523454260E+00
-(PID.TID 0000.0001) %MON dynstat_theta_sd             =   4.3992457614237E+00
-(PID.TID 0000.0001) %MON dynstat_theta_del2           =   5.3135557584413E-03
-(PID.TID 0000.0001) %MON dynstat_salt_max             =   3.7446198831492E+01
-(PID.TID 0000.0001) %MON dynstat_salt_min             =   2.9772812763492E+01
-(PID.TID 0000.0001) %MON dynstat_salt_mean            =   3.4717292732048E+01
-(PID.TID 0000.0001) %MON dynstat_salt_sd              =   2.9616417425610E-01
-(PID.TID 0000.0001) %MON dynstat_salt_del2            =   1.0117867955079E-03
-(PID.TID 0000.0001) %MON forcing_qnet_max             =   4.2893393239667E+02
-(PID.TID 0000.0001) %MON forcing_qnet_min             =  -1.8567070671820E+02
-(PID.TID 0000.0001) %MON forcing_qnet_mean            =  -1.6663880305355E+01
-(PID.TID 0000.0001) %MON forcing_qnet_sd              =   1.1223313739475E+02
-(PID.TID 0000.0001) %MON forcing_qnet_del2            =   9.9430147063573E-01
-(PID.TID 0000.0001) %MON forcing_qsw_max              =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON forcing_qsw_min              =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON forcing_qsw_mean             =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON forcing_qsw_sd               =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON forcing_qsw_del2             =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON forcing_empmr_max            =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON forcing_empmr_min            =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON forcing_empmr_mean           =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON forcing_empmr_sd             =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON forcing_empmr_del2           =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON forcing_fu_max               =   2.7095980822079E-01
-(PID.TID 0000.0001) %MON forcing_fu_min               =  -1.5956480428576E-01
-(PID.TID 0000.0001) %MON forcing_fu_mean              =   1.6035219180276E-02
-(PID.TID 0000.0001) %MON forcing_fu_sd                =   8.9825788836729E-02
-(PID.TID 0000.0001) %MON forcing_fu_del2              =   6.4924410448355E-04
-(PID.TID 0000.0001) %MON forcing_fv_max               =   2.0296572268971E-01
-(PID.TID 0000.0001) %MON forcing_fv_min               =  -1.5091863430796E-01
-(PID.TID 0000.0001) %MON forcing_fv_mean              =  -5.6490179147523E-03
-(PID.TID 0000.0001) %MON forcing_fv_sd                =   4.3347612081314E-02
-(PID.TID 0000.0001) %MON forcing_fv_del2              =   3.4842051422912E-04
-(PID.TID 0000.0001) %MON trAdv_CFL_u_max              =   1.3675494009642E-02
-(PID.TID 0000.0001) %MON trAdv_CFL_v_max              =   1.0505685341387E-02
-(PID.TID 0000.0001) %MON trAdv_CFL_w_max              =   1.0373065115493E-01
-(PID.TID 0000.0001) %MON advcfl_uvel_max              =   1.5755261626612E-02
-(PID.TID 0000.0001) %MON advcfl_vvel_max              =   7.1540714095522E-03
-(PID.TID 0000.0001) %MON advcfl_wvel_max              =   1.7417286108130E-01
-(PID.TID 0000.0001) %MON advcfl_W_hf_max              =   8.6668136060357E-02
-(PID.TID 0000.0001) %MON pe_b_mean                    =   5.2022589105306E-05
-(PID.TID 0000.0001) %MON ke_max                       =   2.9313384992331E-03
-(PID.TID 0000.0001) %MON ke_mean                      =   1.3256947443554E-04
-(PID.TID 0000.0001) %MON ke_vol                       =   1.3226782436723E+18
-(PID.TID 0000.0001) %MON vort_r_min                   =  -2.9932442409355E-07
-(PID.TID 0000.0001) %MON vort_r_max                   =   3.2156423178797E-07
-(PID.TID 0000.0001) %MON vort_a_mean                  =  -2.5205769374687E-05
-(PID.TID 0000.0001) %MON vort_a_sd                    =   7.3402321551960E-05
-(PID.TID 0000.0001) %MON vort_p_mean                  =  -3.1758669533841E-05
-(PID.TID 0000.0001) %MON vort_p_sd                    =   1.3126379177250E-04
-(PID.TID 0000.0001) %MON surfExpan_theta_mean         =   1.6175479964087E-04
-(PID.TID 0000.0001) %MON surfExpan_salt_mean          =   1.3177064435577E-05
-(PID.TID 0000.0001) // =======================================================
-(PID.TID 0000.0001) // End MONITOR dynamic field statistics
-(PID.TID 0000.0001) // =======================================================
-(PID.TID 0000.0001) // =======================================================
-(PID.TID 0000.0001) // Begin MONITOR EXF statistics
-(PID.TID 0000.0001) // =======================================================
-(PID.TID 0000.0001) %MON exf_tsnumber                 =                     7
-(PID.TID 0000.0001) %MON exf_time_sec                 =   3.0240000000000E+05
-(PID.TID 0000.0001) %MON exf_ustress_max              =   2.7198200456558E-01
-(PID.TID 0000.0001) %MON exf_ustress_min              =  -1.6143440190823E-01
-(PID.TID 0000.0001) %MON exf_ustress_mean             =   1.5010557634397E-02
-(PID.TID 0000.0001) %MON exf_ustress_sd               =   8.8618845118075E-02
-(PID.TID 0000.0001) %MON exf_ustress_del2             =   6.9194883040748E-04
-(PID.TID 0000.0001) %MON exf_vstress_max              =   2.1129016385924E-01
-(PID.TID 0000.0001) %MON exf_vstress_min              =  -1.8492647092189E-01
-(PID.TID 0000.0001) %MON exf_vstress_mean             =  -5.8200126263586E-03
-(PID.TID 0000.0001) %MON exf_vstress_sd               =   4.4824413161982E-02
-(PID.TID 0000.0001) %MON exf_vstress_del2             =   4.6407124196284E-04
-(PID.TID 0000.0001) %MON exf_hflux_max                =   4.2944111977854E+02
-(PID.TID 0000.0001) %MON exf_hflux_min                =  -1.8544466030982E+02
-(PID.TID 0000.0001) %MON exf_hflux_mean               =  -1.6657826133183E+01
-(PID.TID 0000.0001) %MON exf_hflux_sd                 =   1.1213131789607E+02
-(PID.TID 0000.0001) %MON exf_hflux_del2               =   1.1777916973255E+00
-(PID.TID 0000.0001) %MON exf_climsst_max              =   2.9507260045698E+01
-(PID.TID 0000.0001) %MON exf_climsst_min              =  -1.9000000000000E+00
-(PID.TID 0000.0001) %MON exf_climsst_mean             =   1.8391828408710E+01
-(PID.TID 0000.0001) %MON exf_climsst_sd               =   9.1999913480886E+00
-(PID.TID 0000.0001) %MON exf_climsst_del2             =   2.4237623218373E-02
-(PID.TID 0000.0001) %MON exf_climsss_max              =   3.7456788709087E+01
-(PID.TID 0000.0001) %MON exf_climsss_min              =   2.9682054581181E+01
-(PID.TID 0000.0001) %MON exf_climsss_mean             =   3.4847469532274E+01
-(PID.TID 0000.0001) %MON exf_climsss_sd               =   9.6600027689088E-01
-(PID.TID 0000.0001) %MON exf_climsss_del2             =   7.0447947077263E-03
-(PID.TID 0000.0001) // =======================================================
-(PID.TID 0000.0001) // End MONITOR EXF statistics
-(PID.TID 0000.0001) // =======================================================
  cg2d: Sum(rhs),rhsMax =  -4.26325641456060E-14  7.72291365607133E+00
-(PID.TID 0000.0001)      cg2d_init_res =   1.38193299224474E+00
-(PID.TID 0000.0001)      cg2d_iters(min,last) =      -1      26
-(PID.TID 0000.0001)      cg2d_last_res =   2.25062033038493E-14
-(PID.TID 0000.0001) // =======================================================
-(PID.TID 0000.0001) // Begin MONITOR dynamic field statistics
-(PID.TID 0000.0001) // =======================================================
-(PID.TID 0000.0001) %MON time_tsnumber                =                     8
-(PID.TID 0000.0001) %MON time_secondsf                =   3.4560000000000E+05
-(PID.TID 0000.0001) %MON dynstat_eta_max              =   8.8792655385350E-01
-(PID.TID 0000.0001) %MON dynstat_eta_min              =  -7.0258977686040E-01
-(PID.TID 0000.0001) %MON dynstat_eta_mean             =   6.5658601736150E-17
-(PID.TID 0000.0001) %MON dynstat_eta_sd               =   2.2602862760441E-01
-(PID.TID 0000.0001) %MON dynstat_eta_del2             =   2.5409774232031E-03
-(PID.TID 0000.0001) %MON dynstat_uvel_max             =   8.5496927453717E-02
-(PID.TID 0000.0001) %MON dynstat_uvel_min             =  -9.0968231282521E-02
-(PID.TID 0000.0001) %MON dynstat_uvel_mean            =  -5.9376248649071E-03
-(PID.TID 0000.0001) %MON dynstat_uvel_sd              =   8.8087123611174E-03
-(PID.TID 0000.0001) %MON dynstat_uvel_del2            =   7.9958090707749E-05
-(PID.TID 0000.0001) %MON dynstat_vvel_max             =   7.9110028403951E-02
-(PID.TID 0000.0001) %MON dynstat_vvel_min             =  -7.4403473350457E-02
-(PID.TID 0000.0001) %MON dynstat_vvel_mean            =   4.7493119303972E-03
-(PID.TID 0000.0001) %MON dynstat_vvel_sd              =   1.4380412812588E-02
-(PID.TID 0000.0001) %MON dynstat_vvel_del2            =   1.0112793738342E-04
-(PID.TID 0000.0001) %MON dynstat_wvel_max             =   2.6701898114157E-04
-(PID.TID 0000.0001) %MON dynstat_wvel_min             =  -2.8089686612740E-04
-(PID.TID 0000.0001) %MON dynstat_wvel_mean            =   2.1138668129224E-22
-(PID.TID 0000.0001) %MON dynstat_wvel_sd              =   3.3783328054735E-05
-(PID.TID 0000.0001) %MON dynstat_wvel_del2            =   3.6169030363118E-07
-(PID.TID 0000.0001) %MON dynstat_theta_max            =   2.9701258538497E+01
-(PID.TID 0000.0001) %MON dynstat_theta_min            =  -2.0317467000366E+00
-(PID.TID 0000.0001) %MON dynstat_theta_mean           =   3.6094317839801E+00
-(PID.TID 0000.0001) %MON dynstat_theta_sd             =   4.3952198050720E+00
-(PID.TID 0000.0001) %MON dynstat_theta_del2           =   5.2825669971528E-03
-(PID.TID 0000.0001) %MON dynstat_salt_max             =   3.7443065568935E+01
-(PID.TID 0000.0001) %MON dynstat_salt_min             =   2.9775856626500E+01
-(PID.TID 0000.0001) %MON dynstat_salt_mean            =   3.4717142629584E+01
-(PID.TID 0000.0001) %MON dynstat_salt_sd              =   2.9616514631683E-01
-(PID.TID 0000.0001) %MON dynstat_salt_del2            =   1.0102777023514E-03
-(PID.TID 0000.0001) %MON forcing_qnet_max             =   4.2944111977854E+02
-(PID.TID 0000.0001) %MON forcing_qnet_min             =  -1.8544466030982E+02
-(PID.TID 0000.0001) %MON forcing_qnet_mean            =  -1.6657826133183E+01
-(PID.TID 0000.0001) %MON forcing_qnet_sd              =   1.1213131789607E+02
-(PID.TID 0000.0001) %MON forcing_qnet_del2            =   9.9502992408153E-01
-(PID.TID 0000.0001) %MON forcing_qsw_max              =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON forcing_qsw_min              =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON forcing_qsw_mean             =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON forcing_qsw_sd               =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON forcing_qsw_del2             =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON forcing_empmr_max            =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON forcing_empmr_min            =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON forcing_empmr_mean           =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON forcing_empmr_sd             =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON forcing_empmr_del2           =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON forcing_fu_max               =   2.7077176157505E-01
-(PID.TID 0000.0001) %MON forcing_fu_min               =  -1.5986756235361E-01
-(PID.TID 0000.0001) %MON forcing_fu_mean              =   1.6031254169549E-02
-(PID.TID 0000.0001) %MON forcing_fu_sd                =   8.9830008899856E-02
-(PID.TID 0000.0001) %MON forcing_fu_del2              =   6.5028463924194E-04
-(PID.TID 0000.0001) %MON forcing_fv_max               =   2.0365151282280E-01
-(PID.TID 0000.0001) %MON forcing_fv_min               =  -1.5114407361515E-01
-(PID.TID 0000.0001) %MON forcing_fv_mean              =  -5.6156830861121E-03
-(PID.TID 0000.0001) %MON forcing_fv_sd                =   4.3412777965500E-02
-(PID.TID 0000.0001) %MON forcing_fv_del2              =   3.4890718937407E-04
-(PID.TID 0000.0001) %MON trAdv_CFL_u_max              =   1.5758461632932E-02
-(PID.TID 0000.0001) %MON trAdv_CFL_v_max              =   1.1978733303782E-02
-(PID.TID 0000.0001) %MON trAdv_CFL_w_max              =   8.6668136060357E-02
-(PID.TID 0000.0001) %MON advcfl_uvel_max              =   1.6701165779578E-02
-(PID.TID 0000.0001) %MON advcfl_vvel_max              =   7.6849048732857E-03
-(PID.TID 0000.0001) %MON advcfl_wvel_max              =   1.8625486461305E-01
-(PID.TID 0000.0001) %MON advcfl_W_hf_max              =   9.4009783201394E-02
-(PID.TID 0000.0001) %MON pe_b_mean                    =   6.5374457260192E-05
-(PID.TID 0000.0001) %MON ke_max                       =   3.7514769711189E-03
-(PID.TID 0000.0001) %MON ke_mean                      =   1.5423519274630E-04
-(PID.TID 0000.0001) %MON ke_vol                       =   1.3226782436723E+18
-(PID.TID 0000.0001) %MON vort_r_min                   =  -3.1494569609912E-07
-(PID.TID 0000.0001) %MON vort_r_max                   =   3.6410486047148E-07
-(PID.TID 0000.0001) %MON vort_a_mean                  =  -2.5205769446108E-05
-(PID.TID 0000.0001) %MON vort_a_sd                    =   7.3402149385451E-05
-(PID.TID 0000.0001) %MON vort_p_mean                  =  -3.1758669623830E-05
-(PID.TID 0000.0001) %MON vort_p_sd                    =   1.3126322243080E-04
-(PID.TID 0000.0001) %MON surfExpan_theta_mean         =   1.6227994247026E-04
-(PID.TID 0000.0001) %MON surfExpan_salt_mean          =   1.3014083010119E-05
-(PID.TID 0000.0001) // =======================================================
-(PID.TID 0000.0001) // End MONITOR dynamic field statistics
-(PID.TID 0000.0001) // =======================================================
-(PID.TID 0000.0001) // =======================================================
-(PID.TID 0000.0001) // Begin MONITOR EXF statistics
-(PID.TID 0000.0001) // =======================================================
-(PID.TID 0000.0001) %MON exf_tsnumber                 =                     8
-(PID.TID 0000.0001) %MON exf_time_sec                 =   3.4560000000000E+05
-(PID.TID 0000.0001) %MON exf_ustress_max              =   2.7156657797675E-01
-(PID.TID 0000.0001) %MON exf_ustress_min              =  -1.6182799228737E-01
-(PID.TID 0000.0001) %MON exf_ustress_mean             =   1.5007668822763E-02
-(PID.TID 0000.0001) %MON exf_ustress_sd               =   8.8627021095280E-02
-(PID.TID 0000.0001) %MON exf_ustress_del2             =   6.9288260330560E-04
-(PID.TID 0000.0001) %MON exf_vstress_max              =   2.1219979539033E-01
-(PID.TID 0000.0001) %MON exf_vstress_min              =  -1.8464357213628E-01
-(PID.TID 0000.0001) %MON exf_vstress_mean             =  -5.7890080856158E-03
-(PID.TID 0000.0001) %MON exf_vstress_sd               =   4.4888672753379E-02
-(PID.TID 0000.0001) %MON exf_vstress_del2             =   4.6441002637548E-04
-(PID.TID 0000.0001) %MON exf_hflux_max                =   4.2994830716041E+02
-(PID.TID 0000.0001) %MON exf_hflux_min                =  -1.8521861390145E+02
-(PID.TID 0000.0001) %MON exf_hflux_mean               =  -1.6651771961010E+01
-(PID.TID 0000.0001) %MON exf_hflux_sd                 =   1.1203010344261E+02
-(PID.TID 0000.0001) %MON exf_hflux_del2               =   1.1780022115880E+00
-(PID.TID 0000.0001) %MON exf_climsst_max              =   2.9499491783880E+01
-(PID.TID 0000.0001) %MON exf_climsst_min              =  -1.9000000000000E+00
-(PID.TID 0000.0001) %MON exf_climsst_mean             =   1.8395687883583E+01
-(PID.TID 0000.0001) %MON exf_climsst_sd               =   9.1984739698203E+00
-(PID.TID 0000.0001) %MON exf_climsst_del2             =   2.4264589313133E-02
-(PID.TID 0000.0001) %MON exf_climsss_max              =   3.7457573675340E+01
-(PID.TID 0000.0001) %MON exf_climsss_min              =   2.9685001034890E+01
-(PID.TID 0000.0001) %MON exf_climsss_mean             =   3.4847571854896E+01
-(PID.TID 0000.0001) %MON exf_climsss_sd               =   9.6565280261437E-01
-(PID.TID 0000.0001) %MON exf_climsss_del2             =   7.0574334694174E-03
-(PID.TID 0000.0001) // =======================================================
-(PID.TID 0000.0001) // End MONITOR EXF statistics
-(PID.TID 0000.0001) // =======================================================
  cg2d: Sum(rhs),rhsMax =  -7.90478793533111E-14  8.03387068208590E+00
-(PID.TID 0000.0001)      cg2d_init_res =   1.27491895664762E+00
-(PID.TID 0000.0001)      cg2d_iters(min,last) =      -1      25
-(PID.TID 0000.0001)      cg2d_last_res =   9.25700616520291E-14
-(PID.TID 0000.0001) // =======================================================
-(PID.TID 0000.0001) // Begin MONITOR dynamic field statistics
-(PID.TID 0000.0001) // =======================================================
-(PID.TID 0000.0001) %MON time_tsnumber                =                     9
-(PID.TID 0000.0001) %MON time_secondsf                =   3.8880000000000E+05
-(PID.TID 0000.0001) %MON dynstat_eta_max              =   9.2789787246412E-01
-(PID.TID 0000.0001) %MON dynstat_eta_min              =  -7.8230383597799E-01
-(PID.TID 0000.0001) %MON dynstat_eta_mean             =   1.5644859930924E-16
-(PID.TID 0000.0001) %MON dynstat_eta_sd               =   2.4897754053015E-01
-(PID.TID 0000.0001) %MON dynstat_eta_del2             =   2.4651205426938E-03
-(PID.TID 0000.0001) %MON dynstat_uvel_max             =   9.4571872966211E-02
-(PID.TID 0000.0001) %MON dynstat_uvel_min             =  -1.0650562898699E-01
-(PID.TID 0000.0001) %MON dynstat_uvel_mean            =  -6.8056901392599E-03
-(PID.TID 0000.0001) %MON dynstat_uvel_sd              =   1.0018411061909E-02
-(PID.TID 0000.0001) %MON dynstat_uvel_del2            =   8.5736513139562E-05
-(PID.TID 0000.0001) %MON dynstat_vvel_max             =   8.3622182914372E-02
-(PID.TID 0000.0001) %MON dynstat_vvel_min             =  -8.1931039543840E-02
-(PID.TID 0000.0001) %MON dynstat_vvel_mean            =   4.8341513686608E-03
-(PID.TID 0000.0001) %MON dynstat_vvel_sd              =   1.4686547870328E-02
-(PID.TID 0000.0001) %MON dynstat_vvel_del2            =   1.0667601833154E-04
-(PID.TID 0000.0001) %MON dynstat_wvel_max             =   2.6990204271131E-04
-(PID.TID 0000.0001) %MON dynstat_wvel_min             =  -2.8783763687168E-04
-(PID.TID 0000.0001) %MON dynstat_wvel_mean            =  -1.4092445419483E-22
-(PID.TID 0000.0001) %MON dynstat_wvel_sd              =   3.4549241603867E-05
-(PID.TID 0000.0001) %MON dynstat_wvel_del2            =   3.7548501955659E-07
-(PID.TID 0000.0001) %MON dynstat_theta_max            =   2.9669082897069E+01
-(PID.TID 0000.0001) %MON dynstat_theta_min            =  -2.0622657261404E+00
-(PID.TID 0000.0001) %MON dynstat_theta_mean           =   3.6076349907080E+00
-(PID.TID 0000.0001) %MON dynstat_theta_sd             =   4.3911172400540E+00
-(PID.TID 0000.0001) %MON dynstat_theta_del2           =   5.2489457673031E-03
-(PID.TID 0000.0001) %MON dynstat_salt_max             =   3.7440304257189E+01
-(PID.TID 0000.0001) %MON dynstat_salt_min             =   2.9778573221473E+01
-(PID.TID 0000.0001) %MON dynstat_salt_mean            =   3.4716997060646E+01
-(PID.TID 0000.0001) %MON dynstat_salt_sd              =   2.9615862835640E-01
-(PID.TID 0000.0001) %MON dynstat_salt_del2            =   1.0088083345020E-03
-(PID.TID 0000.0001) %MON forcing_qnet_max             =   4.2994830716041E+02
-(PID.TID 0000.0001) %MON forcing_qnet_min             =  -1.8521861390145E+02
-(PID.TID 0000.0001) %MON forcing_qnet_mean            =  -1.6651771961010E+01
-(PID.TID 0000.0001) %MON forcing_qnet_sd              =   1.1203010344261E+02
-(PID.TID 0000.0001) %MON forcing_qnet_del2            =   9.9579948741711E-01
-(PID.TID 0000.0001) %MON forcing_qsw_max              =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON forcing_qsw_min              =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON forcing_qsw_mean             =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON forcing_qsw_sd               =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON forcing_qsw_del2             =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON forcing_empmr_max            =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON forcing_empmr_min            =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON forcing_empmr_mean           =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON forcing_empmr_sd             =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON forcing_empmr_del2           =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON forcing_fu_max               =   2.7058371492932E-01
-(PID.TID 0000.0001) %MON forcing_fu_min               =  -1.6017032042146E-01
-(PID.TID 0000.0001) %MON forcing_fu_mean              =   1.6027289158822E-02
-(PID.TID 0000.0001) %MON forcing_fu_sd                =   8.9836693313870E-02
-(PID.TID 0000.0001) %MON forcing_fu_del2              =   6.5143177225281E-04
-(PID.TID 0000.0001) %MON forcing_fv_max               =   2.0433730295589E-01
-(PID.TID 0000.0001) %MON forcing_fv_min               =  -1.5136951292234E-01
-(PID.TID 0000.0001) %MON forcing_fv_mean              =  -5.5823482574718E-03
-(PID.TID 0000.0001) %MON forcing_fv_sd                =   4.3481134415961E-02
-(PID.TID 0000.0001) %MON forcing_fv_del2              =   3.4947416509125E-04
-(PID.TID 0000.0001) %MON trAdv_CFL_u_max              =   1.6704557905797E-02
-(PID.TID 0000.0001) %MON trAdv_CFL_v_max              =   1.3055624838411E-02
-(PID.TID 0000.0001) %MON trAdv_CFL_w_max              =   9.4009783201394E-02
-(PID.TID 0000.0001) %MON advcfl_uvel_max              =   1.6413400695281E-02
-(PID.TID 0000.0001) %MON advcfl_vvel_max              =   8.1232245008441E-03
-(PID.TID 0000.0001) %MON advcfl_wvel_max              =   1.9039063870886E-01
-(PID.TID 0000.0001) %MON advcfl_W_hf_max              =   9.8713778793038E-02
-(PID.TID 0000.0001) %MON pe_b_mean                    =   7.9323440981330E-05
-(PID.TID 0000.0001) %MON ke_max                       =   4.6100533766175E-03
-(PID.TID 0000.0001) %MON ke_mean                      =   1.7396783904258E-04
-(PID.TID 0000.0001) %MON ke_vol                       =   1.3226782436723E+18
-(PID.TID 0000.0001) %MON vort_r_min                   =  -3.2370221768309E-07
-(PID.TID 0000.0001) %MON vort_r_max                   =   4.2555132870248E-07
-(PID.TID 0000.0001) %MON vort_a_mean                  =  -2.5205769530901E-05
-(PID.TID 0000.0001) %MON vort_a_sd                    =   7.3401984401820E-05
-(PID.TID 0000.0001) %MON vort_p_mean                  =  -3.1758669730667E-05
-(PID.TID 0000.0001) %MON vort_p_sd                    =   1.3126264467269E-04
-(PID.TID 0000.0001) %MON surfExpan_theta_mean         =   1.5910486162160E-04
-(PID.TID 0000.0001) %MON surfExpan_salt_mean          =   1.2505231744378E-05
-(PID.TID 0000.0001) // =======================================================
-(PID.TID 0000.0001) // End MONITOR dynamic field statistics
-(PID.TID 0000.0001) // =======================================================
-(PID.TID 0000.0001) // =======================================================
-(PID.TID 0000.0001) // Begin MONITOR EXF statistics
-(PID.TID 0000.0001) // =======================================================
-(PID.TID 0000.0001) %MON exf_tsnumber                 =                     9
-(PID.TID 0000.0001) %MON exf_time_sec                 =   3.8880000000000E+05
-(PID.TID 0000.0001) %MON exf_ustress_max              =   2.7115115138792E-01
-(PID.TID 0000.0001) %MON exf_ustress_min              =  -1.6222158266652E-01
-(PID.TID 0000.0001) %MON exf_ustress_mean             =   1.5004780011130E-02
-(PID.TID 0000.0001) %MON exf_ustress_sd               =   8.8637699424028E-02
-(PID.TID 0000.0001) %MON exf_ustress_del2             =   6.9393545772739E-04
-(PID.TID 0000.0001) %MON exf_vstress_max              =   2.1310942692141E-01
-(PID.TID 0000.0001) %MON exf_vstress_min              =  -1.8436067335067E-01
-(PID.TID 0000.0001) %MON exf_vstress_mean             =  -5.7580035448731E-03
-(PID.TID 0000.0001) %MON exf_vstress_sd               =   4.4956349892810E-02
-(PID.TID 0000.0001) %MON exf_vstress_del2             =   4.6486736998536E-04
-(PID.TID 0000.0001) %MON exf_hflux_max                =   4.3045549454228E+02
-(PID.TID 0000.0001) %MON exf_hflux_min                =  -1.8499256749307E+02
-(PID.TID 0000.0001) %MON exf_hflux_mean               =  -1.6645717788838E+01
-(PID.TID 0000.0001) %MON exf_hflux_sd                 =   1.1192949567575E+02
-(PID.TID 0000.0001) %MON exf_hflux_del2               =   1.1782490803913E+00
-(PID.TID 0000.0001) %MON exf_climsst_max              =   2.9491723522063E+01
-(PID.TID 0000.0001) %MON exf_climsst_min              =  -1.9000000000000E+00
-(PID.TID 0000.0001) %MON exf_climsst_mean             =   1.8399550721214E+01
-(PID.TID 0000.0001) %MON exf_climsst_sd               =   9.1970095444163E+00
-(PID.TID 0000.0001) %MON exf_climsst_del2             =   2.4300802812195E-02
-(PID.TID 0000.0001) %MON exf_climsss_max              =   3.7458358641594E+01
-(PID.TID 0000.0001) %MON exf_climsss_min              =   2.9687947488600E+01
-(PID.TID 0000.0001) %MON exf_climsss_mean             =   3.4847674177518E+01
-(PID.TID 0000.0001) %MON exf_climsss_sd               =   9.6532619740638E-01
-(PID.TID 0000.0001) %MON exf_climsss_del2             =   7.0728370480198E-03
-(PID.TID 0000.0001) // =======================================================
-(PID.TID 0000.0001) // End MONITOR EXF statistics
-(PID.TID 0000.0001) // =======================================================
  cg2d: Sum(rhs),rhsMax =  -3.04645197957143E-13  8.11896831221745E+00
 (PID.TID 0000.0001)      cg2d_init_res =   1.21243316691704E+00
 (PID.TID 0000.0001)      cg2d_iters(min,last) =      -1      25
@@ -3593,31 +2561,6 @@
 (PID.TID 0000.0001) %MON dynstat_salt_mean            =   3.4716859577764E+01
 (PID.TID 0000.0001) %MON dynstat_salt_sd              =   2.9614565000130E-01
 (PID.TID 0000.0001) %MON dynstat_salt_del2            =   1.0074131526581E-03
-(PID.TID 0000.0001) %MON forcing_qnet_max             =   4.3045549454228E+02
-(PID.TID 0000.0001) %MON forcing_qnet_min             =  -1.8499256749307E+02
-(PID.TID 0000.0001) %MON forcing_qnet_mean            =  -1.6645717788838E+01
-(PID.TID 0000.0001) %MON forcing_qnet_sd              =   1.1192949567575E+02
-(PID.TID 0000.0001) %MON forcing_qnet_del2            =   9.9661006540964E-01
-(PID.TID 0000.0001) %MON forcing_qsw_max              =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON forcing_qsw_min              =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON forcing_qsw_mean             =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON forcing_qsw_sd               =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON forcing_qsw_del2             =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON forcing_empmr_max            =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON forcing_empmr_min            =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON forcing_empmr_mean           =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON forcing_empmr_sd             =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON forcing_empmr_del2           =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON forcing_fu_max               =   2.7039566828359E-01
-(PID.TID 0000.0001) %MON forcing_fu_min               =  -1.6047307848930E-01
-(PID.TID 0000.0001) %MON forcing_fu_mean              =   1.6023324148095E-02
-(PID.TID 0000.0001) %MON forcing_fu_sd                =   8.9845841528738E-02
-(PID.TID 0000.0001) %MON forcing_fu_del2              =   6.5268494145790E-04
-(PID.TID 0000.0001) %MON forcing_fv_max               =   2.0502309308898E-01
-(PID.TID 0000.0001) %MON forcing_fv_min               =  -1.5159495222953E-01
-(PID.TID 0000.0001) %MON forcing_fv_mean              =  -5.5490134288316E-03
-(PID.TID 0000.0001) %MON forcing_fv_sd                =   4.3552666409801E-02
-(PID.TID 0000.0001) %MON forcing_fv_del2              =   3.5012105127173E-04
 (PID.TID 0000.0001) %MON trAdv_CFL_u_max              =   1.6416734374353E-02
 (PID.TID 0000.0001) %MON trAdv_CFL_v_max              =   1.3688397015289E-02
 (PID.TID 0000.0001) %MON trAdv_CFL_w_max              =   9.8713778793038E-02
@@ -3674,1076 +2617,14 @@
 (PID.TID 0000.0001) // End MONITOR EXF statistics
 (PID.TID 0000.0001) // =======================================================
  cg2d: Sum(rhs),rhsMax =  -3.65929508916452E-13  8.04727754553643E+00
-(PID.TID 0000.0001)      cg2d_init_res =   1.17667485894329E+00
-(PID.TID 0000.0001)      cg2d_iters(min,last) =      -1      25
-(PID.TID 0000.0001)      cg2d_last_res =   8.19532054376992E-14
-(PID.TID 0000.0001) // =======================================================
-(PID.TID 0000.0001) // Begin MONITOR dynamic field statistics
-(PID.TID 0000.0001) // =======================================================
-(PID.TID 0000.0001) %MON time_tsnumber                =                    11
-(PID.TID 0000.0001) %MON time_secondsf                =   4.7520000000000E+05
-(PID.TID 0000.0001) %MON dynstat_eta_max              =   9.3932987350570E-01
-(PID.TID 0000.0001) %MON dynstat_eta_min              =  -8.5772363624083E-01
-(PID.TID 0000.0001) %MON dynstat_eta_mean             =   3.3599091371189E-16
-(PID.TID 0000.0001) %MON dynstat_eta_sd               =   2.8953421622212E-01
-(PID.TID 0000.0001) %MON dynstat_eta_del2             =   2.3268137948445E-03
-(PID.TID 0000.0001) %MON dynstat_uvel_max             =   1.1079930745731E-01
-(PID.TID 0000.0001) %MON dynstat_uvel_min             =  -1.2583010564927E-01
-(PID.TID 0000.0001) %MON dynstat_uvel_mean            =  -8.3114743574041E-03
-(PID.TID 0000.0001) %MON dynstat_uvel_sd              =   1.2259361186468E-02
-(PID.TID 0000.0001) %MON dynstat_uvel_del2            =   9.5206903652696E-05
-(PID.TID 0000.0001) %MON dynstat_vvel_max             =   9.9665276916285E-02
-(PID.TID 0000.0001) %MON dynstat_vvel_min             =  -9.2923192365132E-02
-(PID.TID 0000.0001) %MON dynstat_vvel_mean            =   4.6828204471885E-03
-(PID.TID 0000.0001) %MON dynstat_vvel_sd              =   1.4703841773913E-02
-(PID.TID 0000.0001) %MON dynstat_vvel_del2            =   1.1371125516212E-04
-(PID.TID 0000.0001) %MON dynstat_wvel_max             =   2.5860828887765E-04
-(PID.TID 0000.0001) %MON dynstat_wvel_min             =  -3.1448254807744E-04
-(PID.TID 0000.0001) %MON dynstat_wvel_mean            =  -1.0804208154937E-21
-(PID.TID 0000.0001) %MON dynstat_wvel_sd              =   3.4837386802024E-05
-(PID.TID 0000.0001) %MON dynstat_wvel_del2            =   3.8149974926559E-07
-(PID.TID 0000.0001) %MON dynstat_theta_max            =   2.9585494893119E+01
-(PID.TID 0000.0001) %MON dynstat_theta_min            =  -2.1118720649465E+00
-(PID.TID 0000.0001) %MON dynstat_theta_mean           =   3.6042557992332E+00
-(PID.TID 0000.0001) %MON dynstat_theta_sd             =   4.3829426691632E+00
-(PID.TID 0000.0001) %MON dynstat_theta_del2           =   5.1827231966140E-03
-(PID.TID 0000.0001) %MON dynstat_salt_max             =   3.7435688793104E+01
-(PID.TID 0000.0001) %MON dynstat_salt_min             =   2.9782781582552E+01
-(PID.TID 0000.0001) %MON dynstat_salt_mean            =   3.4716733061917E+01
-(PID.TID 0000.0001) %MON dynstat_salt_sd              =   2.9612732408421E-01
-(PID.TID 0000.0001) %MON dynstat_salt_del2            =   1.0061239693068E-03
-(PID.TID 0000.0001) %MON forcing_qnet_max             =   4.3096268192414E+02
-(PID.TID 0000.0001) %MON forcing_qnet_min             =  -1.8476652108469E+02
-(PID.TID 0000.0001) %MON forcing_qnet_mean            =  -1.6639663616666E+01
-(PID.TID 0000.0001) %MON forcing_qnet_sd              =   1.1182949623291E+02
-(PID.TID 0000.0001) %MON forcing_qnet_del2            =   9.9746155806858E-01
-(PID.TID 0000.0001) %MON forcing_qsw_max              =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON forcing_qsw_min              =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON forcing_qsw_mean             =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON forcing_qsw_sd               =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON forcing_qsw_del2             =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON forcing_empmr_max            =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON forcing_empmr_min            =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON forcing_empmr_mean           =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON forcing_empmr_sd             =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON forcing_empmr_del2           =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON forcing_fu_max               =   2.7020762163785E-01
-(PID.TID 0000.0001) %MON forcing_fu_min               =  -1.6077583655715E-01
-(PID.TID 0000.0001) %MON forcing_fu_mean              =   1.6019359137368E-02
-(PID.TID 0000.0001) %MON forcing_fu_sd                =   8.9857452791955E-02
-(PID.TID 0000.0001) %MON forcing_fu_del2              =   6.5404353735084E-04
-(PID.TID 0000.0001) %MON forcing_fv_max               =   2.0570888322207E-01
-(PID.TID 0000.0001) %MON forcing_fv_min               =  -1.5182039153672E-01
-(PID.TID 0000.0001) %MON forcing_fv_mean              =  -5.5156786001913E-03
-(PID.TID 0000.0001) %MON forcing_fv_sd                =   4.3627358327032E-02
-(PID.TID 0000.0001) %MON forcing_fv_del2              =   3.5084740590333E-04
-(PID.TID 0000.0001) %MON trAdv_CFL_u_max              =   1.5182370713585E-02
-(PID.TID 0000.0001) %MON trAdv_CFL_v_max              =   1.3850964385702E-02
-(PID.TID 0000.0001) %MON trAdv_CFL_w_max              =   9.4414613461562E-02
-(PID.TID 0000.0001) %MON advcfl_uvel_max              =   1.6281625441536E-02
-(PID.TID 0000.0001) %MON advcfl_vvel_max              =   9.6816824329831E-03
-(PID.TID 0000.0001) %MON advcfl_wvel_max              =   1.8150904005374E-01
-(PID.TID 0000.0001) %MON advcfl_W_hf_max              =   8.8193889428868E-02
-(PID.TID 0000.0001) %MON pe_b_mean                    =   1.0727066906865E-04
-(PID.TID 0000.0001) %MON ke_max                       =   6.4124396622991E-03
-(PID.TID 0000.0001) %MON ke_mean                      =   2.0657205737822E-04
-(PID.TID 0000.0001) %MON ke_vol                       =   1.3226782436723E+18
-(PID.TID 0000.0001) %MON vort_r_min                   =  -3.2620260750860E-07
-(PID.TID 0000.0001) %MON vort_r_max                   =   5.1812945204417E-07
-(PID.TID 0000.0001) %MON vort_a_mean                  =  -2.5205769691000E-05
-(PID.TID 0000.0001) %MON vort_a_sd                    =   7.3401694018845E-05
-(PID.TID 0000.0001) %MON vort_p_mean                  =  -3.1758669932388E-05
-(PID.TID 0000.0001) %MON vort_p_sd                    =   1.3126154847306E-04
-(PID.TID 0000.0001) %MON surfExpan_theta_mean         =   1.4416330228242E-04
-(PID.TID 0000.0001) %MON surfExpan_salt_mean          =   1.0682184656988E-05
-(PID.TID 0000.0001) // =======================================================
-(PID.TID 0000.0001) // End MONITOR dynamic field statistics
-(PID.TID 0000.0001) // =======================================================
-(PID.TID 0000.0001) // =======================================================
-(PID.TID 0000.0001) // Begin MONITOR EXF statistics
-(PID.TID 0000.0001) // =======================================================
-(PID.TID 0000.0001) %MON exf_tsnumber                 =                    11
-(PID.TID 0000.0001) %MON exf_time_sec                 =   4.7520000000000E+05
-(PID.TID 0000.0001) %MON exf_ustress_max              =   2.7032029821027E-01
-(PID.TID 0000.0001) %MON exf_ustress_min              =  -1.6300876342481E-01
-(PID.TID 0000.0001) %MON exf_ustress_mean             =   1.4999002387864E-02
-(PID.TID 0000.0001) %MON exf_ustress_sd               =   8.8666559307921E-02
-(PID.TID 0000.0001) %MON exf_ustress_del2             =   6.9639618964092E-04
-(PID.TID 0000.0001) %MON exf_vstress_max              =   2.1492868998358E-01
-(PID.TID 0000.0001) %MON exf_vstress_min              =  -1.8379487577946E-01
-(PID.TID 0000.0001) %MON exf_vstress_mean             =  -5.6959944633876E-03
-(PID.TID 0000.0001) %MON exf_vstress_sd               =   4.5101894500972E-02
-(PID.TID 0000.0001) %MON exf_vstress_del2             =   4.6613624846055E-04
-(PID.TID 0000.0001) %MON exf_hflux_max                =   4.3146986930601E+02
-(PID.TID 0000.0001) %MON exf_hflux_min                =  -1.8454047467632E+02
-(PID.TID 0000.0001) %MON exf_hflux_mean               =  -1.6633609444493E+01
-(PID.TID 0000.0001) %MON exf_hflux_sd                 =   1.1173010674746E+02
-(PID.TID 0000.0001) %MON exf_hflux_del2               =   1.1788517868992E+00
-(PID.TID 0000.0001) %MON exf_climsst_max              =   2.9480712890625E+01
-(PID.TID 0000.0001) %MON exf_climsst_min              =  -1.9000000000000E+00
-(PID.TID 0000.0001) %MON exf_climsst_mean             =   1.8407276396474E+01
-(PID.TID 0000.0001) %MON exf_climsst_sd               =   9.1942619057521E+00
-(PID.TID 0000.0001) %MON exf_climsst_del2             =   2.4400242208664E-02
-(PID.TID 0000.0001) %MON exf_climsss_max              =   3.7459928574101E+01
-(PID.TID 0000.0001) %MON exf_climsss_min              =   2.9693840396020E+01
-(PID.TID 0000.0001) %MON exf_climsss_mean             =   3.4847878822763E+01
-(PID.TID 0000.0001) %MON exf_climsss_sd               =   9.6473567762277E-01
-(PID.TID 0000.0001) %MON exf_climsss_del2             =   7.1118635720215E-03
-(PID.TID 0000.0001) // =======================================================
-(PID.TID 0000.0001) // End MONITOR EXF statistics
-(PID.TID 0000.0001) // =======================================================
  cg2d: Sum(rhs),rhsMax =  -6.36823926924990E-13  7.88895797898159E+00
-(PID.TID 0000.0001)      cg2d_init_res =   1.15540981532070E+00
-(PID.TID 0000.0001)      cg2d_iters(min,last) =      -1      25
-(PID.TID 0000.0001)      cg2d_last_res =   7.88267462814550E-14
-(PID.TID 0000.0001) // =======================================================
-(PID.TID 0000.0001) // Begin MONITOR dynamic field statistics
-(PID.TID 0000.0001) // =======================================================
-(PID.TID 0000.0001) %MON time_tsnumber                =                    12
-(PID.TID 0000.0001) %MON time_secondsf                =   5.1840000000000E+05
-(PID.TID 0000.0001) %MON dynstat_eta_max              =   9.6802418022627E-01
-(PID.TID 0000.0001) %MON dynstat_eta_min              =  -9.3321747320919E-01
-(PID.TID 0000.0001) %MON dynstat_eta_mean             =   4.0164951544804E-16
-(PID.TID 0000.0001) %MON dynstat_eta_sd               =   3.0673332854234E-01
-(PID.TID 0000.0001) %MON dynstat_eta_del2             =   2.2613432859870E-03
-(PID.TID 0000.0001) %MON dynstat_uvel_max             =   1.1795227157380E-01
-(PID.TID 0000.0001) %MON dynstat_uvel_min             =  -1.2898290680164E-01
-(PID.TID 0000.0001) %MON dynstat_uvel_mean            =  -8.9066632820647E-03
-(PID.TID 0000.0001) %MON dynstat_uvel_sd              =   1.3251870885034E-02
-(PID.TID 0000.0001) %MON dynstat_uvel_del2            =   9.8952761735038E-05
-(PID.TID 0000.0001) %MON dynstat_vvel_max             =   1.0406091146300E-01
-(PID.TID 0000.0001) %MON dynstat_vvel_min             =  -9.6030186766250E-02
-(PID.TID 0000.0001) %MON dynstat_vvel_mean            =   4.4760558443052E-03
-(PID.TID 0000.0001) %MON dynstat_vvel_sd              =   1.4507411814575E-02
-(PID.TID 0000.0001) %MON dynstat_vvel_del2            =   1.1541035218955E-04
-(PID.TID 0000.0001) %MON dynstat_wvel_max             =   2.5319570609300E-04
-(PID.TID 0000.0001) %MON dynstat_wvel_min             =  -3.2821034721661E-04
-(PID.TID 0000.0001) %MON dynstat_wvel_mean            =   5.6369781677931E-22
-(PID.TID 0000.0001) %MON dynstat_wvel_sd              =   3.4428327190420E-05
-(PID.TID 0000.0001) %MON dynstat_wvel_del2            =   3.7608696374724E-07
-(PID.TID 0000.0001) %MON dynstat_theta_max            =   2.9547912213252E+01
-(PID.TID 0000.0001) %MON dynstat_theta_min            =  -2.1282858771861E+00
-(PID.TID 0000.0001) %MON dynstat_theta_mean           =   3.6027270877202E+00
-(PID.TID 0000.0001) %MON dynstat_theta_sd             =   4.3789785398695E+00
-(PID.TID 0000.0001) %MON dynstat_theta_del2           =   5.1513482216612E-03
-(PID.TID 0000.0001) %MON dynstat_salt_max             =   3.7433720010797E+01
-(PID.TID 0000.0001) %MON dynstat_salt_min             =   2.9784220846676E+01
-(PID.TID 0000.0001) %MON dynstat_salt_mean            =   3.4716619628326E+01
-(PID.TID 0000.0001) %MON dynstat_salt_sd              =   2.9610456082395E-01
-(PID.TID 0000.0001) %MON dynstat_salt_del2            =   1.0049645835295E-03
-(PID.TID 0000.0001) %MON forcing_qnet_max             =   4.3146986930601E+02
-(PID.TID 0000.0001) %MON forcing_qnet_min             =  -1.8454047467632E+02
-(PID.TID 0000.0001) %MON forcing_qnet_mean            =  -1.6633609444493E+01
-(PID.TID 0000.0001) %MON forcing_qnet_sd              =   1.1173010674746E+02
-(PID.TID 0000.0001) %MON forcing_qnet_del2            =   9.9835386070598E-01
-(PID.TID 0000.0001) %MON forcing_qsw_max              =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON forcing_qsw_min              =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON forcing_qsw_mean             =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON forcing_qsw_sd               =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON forcing_qsw_del2             =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON forcing_empmr_max            =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON forcing_empmr_min            =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON forcing_empmr_mean           =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON forcing_empmr_sd             =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON forcing_empmr_del2           =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON forcing_fu_max               =   2.7001957499212E-01
-(PID.TID 0000.0001) %MON forcing_fu_min               =  -1.6107859462500E-01
-(PID.TID 0000.0001) %MON forcing_fu_mean              =   1.6015394126641E-02
-(PID.TID 0000.0001) %MON forcing_fu_sd                =   8.9871526148854E-02
-(PID.TID 0000.0001) %MON forcing_fu_del2              =   6.5550690441364E-04
-(PID.TID 0000.0001) %MON forcing_fv_max               =   2.0639467335516E-01
-(PID.TID 0000.0001) %MON forcing_fv_min               =  -1.5204583084391E-01
-(PID.TID 0000.0001) %MON forcing_fv_mean              =  -5.4823437715511E-03
-(PID.TID 0000.0001) %MON forcing_fv_sd                =   4.3705193966787E-02
-(PID.TID 0000.0001) %MON forcing_fv_del2              =   3.5165273654936E-04
-(PID.TID 0000.0001) %MON trAdv_CFL_u_max              =   1.6284932356111E-02
-(PID.TID 0000.0001) %MON trAdv_CFL_v_max              =   1.3547432811995E-02
-(PID.TID 0000.0001) %MON trAdv_CFL_w_max              =   8.8518750215531E-02
-(PID.TID 0000.0001) %MON advcfl_uvel_max              =   1.8564949384164E-02
-(PID.TID 0000.0001) %MON advcfl_vvel_max              =   1.0108683080445E-02
-(PID.TID 0000.0001) %MON advcfl_wvel_max              =   1.8492923380865E-01
-(PID.TID 0000.0001) %MON advcfl_W_hf_max              =   8.1756053989234E-02
-(PID.TID 0000.0001) %MON pe_b_mean                    =   1.2039352629782E-04
-(PID.TID 0000.0001) %MON ke_max                       =   7.3297181219692E-03
-(PID.TID 0000.0001) %MON ke_mean                      =   2.1930502105001E-04
-(PID.TID 0000.0001) %MON ke_vol                       =   1.3226782436723E+18
-(PID.TID 0000.0001) %MON vort_r_min                   =  -3.2197325335332E-07
-(PID.TID 0000.0001) %MON vort_r_max                   =   5.4497370580299E-07
-(PID.TID 0000.0001) %MON vort_a_mean                  =  -2.5205769747146E-05
-(PID.TID 0000.0001) %MON vort_a_sd                    =   7.3401576340243E-05
-(PID.TID 0000.0001) %MON vort_p_mean                  =  -3.1758670003131E-05
-(PID.TID 0000.0001) %MON vort_p_sd                    =   1.3126107483665E-04
-(PID.TID 0000.0001) %MON surfExpan_theta_mean         =   1.3360014646581E-04
-(PID.TID 0000.0001) %MON surfExpan_salt_mean          =   9.4976335705891E-06
-(PID.TID 0000.0001) // =======================================================
-(PID.TID 0000.0001) // End MONITOR dynamic field statistics
-(PID.TID 0000.0001) // =======================================================
-(PID.TID 0000.0001) // =======================================================
-(PID.TID 0000.0001) // Begin MONITOR EXF statistics
-(PID.TID 0000.0001) // =======================================================
-(PID.TID 0000.0001) %MON exf_tsnumber                 =                    12
-(PID.TID 0000.0001) %MON exf_time_sec                 =   5.1840000000000E+05
-(PID.TID 0000.0001) %MON exf_ustress_max              =   2.6990487162144E-01
-(PID.TID 0000.0001) %MON exf_ustress_min              =  -1.6340235380396E-01
-(PID.TID 0000.0001) %MON exf_ustress_mean             =   1.4996113576231E-02
-(PID.TID 0000.0001) %MON exf_ustress_sd               =   8.8684738421357E-02
-(PID.TID 0000.0001) %MON exf_ustress_del2             =   6.9780281518039E-04
-(PID.TID 0000.0001) %MON exf_vstress_max              =   2.1583832151467E-01
-(PID.TID 0000.0001) %MON exf_vstress_min              =  -1.8351197699385E-01
-(PID.TID 0000.0001) %MON exf_vstress_mean             =  -5.6649899226448E-03
-(PID.TID 0000.0001) %MON exf_vstress_sd               =   4.5179729141995E-02
-(PID.TID 0000.0001) %MON exf_vstress_del2             =   4.6694682084966E-04
-(PID.TID 0000.0001) %MON exf_hflux_max                =   4.3197705668788E+02
-(PID.TID 0000.0001) %MON exf_hflux_min                =  -1.8431442826794E+02
-(PID.TID 0000.0001) %MON exf_hflux_mean               =  -1.6627555272321E+01
-(PID.TID 0000.0001) %MON exf_hflux_sd                 =   1.1163132884860E+02
-(PID.TID 0000.0001) %MON exf_hflux_del2               =   1.1792075689085E+00
-(PID.TID 0000.0001) %MON exf_climsst_max              =   2.9478864669800E+01
-(PID.TID 0000.0001) %MON exf_climsst_min              =  -1.9000000000000E+00
-(PID.TID 0000.0001) %MON exf_climsst_mean             =   1.8411139234104E+01
-(PID.TID 0000.0001) %MON exf_climsst_sd               =   9.1929787466535E+00
-(PID.TID 0000.0001) %MON exf_climsst_del2             =   2.4463358305507E-02
-(PID.TID 0000.0001) %MON exf_climsss_max              =   3.7460713540354E+01
-(PID.TID 0000.0001) %MON exf_climsss_min              =   2.9696786849729E+01
-(PID.TID 0000.0001) %MON exf_climsss_mean             =   3.4847981145385E+01
-(PID.TID 0000.0001) %MON exf_climsss_sd               =   9.6447180143091E-01
-(PID.TID 0000.0001) %MON exf_climsss_del2             =   7.1354415626269E-03
-(PID.TID 0000.0001) // =======================================================
-(PID.TID 0000.0001) // End MONITOR EXF statistics
-(PID.TID 0000.0001) // =======================================================
  cg2d: Sum(rhs),rhsMax =  -8.44657677134819E-13  8.31754379147366E+00
-(PID.TID 0000.0001)      cg2d_init_res =   1.05639236129967E+00
-(PID.TID 0000.0001)      cg2d_iters(min,last) =      -1      25
-(PID.TID 0000.0001)      cg2d_last_res =   6.97416509688133E-14
-(PID.TID 0000.0001) // =======================================================
-(PID.TID 0000.0001) // Begin MONITOR dynamic field statistics
-(PID.TID 0000.0001) // =======================================================
-(PID.TID 0000.0001) %MON time_tsnumber                =                    13
-(PID.TID 0000.0001) %MON time_secondsf                =   5.6160000000000E+05
-(PID.TID 0000.0001) %MON dynstat_eta_max              =   1.0164868264484E+00
-(PID.TID 0000.0001) %MON dynstat_eta_min              =  -1.0078756140118E+00
-(PID.TID 0000.0001) %MON dynstat_eta_mean             =   5.0443918851084E-16
-(PID.TID 0000.0001) %MON dynstat_eta_sd               =   3.2170165748830E-01
-(PID.TID 0000.0001) %MON dynstat_eta_del2             =   2.2013776358950E-03
-(PID.TID 0000.0001) %MON dynstat_uvel_max             =   1.2443724746886E-01
-(PID.TID 0000.0001) %MON dynstat_uvel_min             =  -1.2804426639582E-01
-(PID.TID 0000.0001) %MON dynstat_uvel_mean            =  -9.3759963240945E-03
-(PID.TID 0000.0001) %MON dynstat_uvel_sd              =   1.4142488887130E-02
-(PID.TID 0000.0001) %MON dynstat_uvel_del2            =   1.0207300145990E-04
-(PID.TID 0000.0001) %MON dynstat_vvel_max             =   1.0912579012923E-01
-(PID.TID 0000.0001) %MON dynstat_vvel_min             =  -9.7342351499306E-02
-(PID.TID 0000.0001) %MON dynstat_vvel_mean            =   4.2069031798902E-03
-(PID.TID 0000.0001) %MON dynstat_vvel_sd              =   1.4237245909743E-02
-(PID.TID 0000.0001) %MON dynstat_vvel_del2            =   1.1605113326674E-04
-(PID.TID 0000.0001) %MON dynstat_wvel_max             =   2.5418765757461E-04
-(PID.TID 0000.0001) %MON dynstat_wvel_min             =  -3.3596511206596E-04
-(PID.TID 0000.0001) %MON dynstat_wvel_mean            =  -8.4554672516896E-22
-(PID.TID 0000.0001) %MON dynstat_wvel_sd              =   3.3737126903698E-05
-(PID.TID 0000.0001) %MON dynstat_wvel_del2            =   3.6655972856716E-07
-(PID.TID 0000.0001) %MON dynstat_theta_max            =   2.9557009089275E+01
-(PID.TID 0000.0001) %MON dynstat_theta_min            =  -2.1381892230463E+00
-(PID.TID 0000.0001) %MON dynstat_theta_mean           =   3.6013304770620E+00
-(PID.TID 0000.0001) %MON dynstat_theta_sd             =   4.3751567911511E+00
-(PID.TID 0000.0001) %MON dynstat_theta_del2           =   5.1215609783798E-03
-(PID.TID 0000.0001) %MON dynstat_salt_max             =   3.7431897315870E+01
-(PID.TID 0000.0001) %MON dynstat_salt_min             =   2.9785226394387E+01
-(PID.TID 0000.0001) %MON dynstat_salt_mean            =   3.4716520628721E+01
-(PID.TID 0000.0001) %MON dynstat_salt_sd              =   2.9607804474191E-01
-(PID.TID 0000.0001) %MON dynstat_salt_del2            =   1.0041339761161E-03
-(PID.TID 0000.0001) %MON forcing_qnet_max             =   4.3197705668788E+02
-(PID.TID 0000.0001) %MON forcing_qnet_min             =  -1.8431442826794E+02
-(PID.TID 0000.0001) %MON forcing_qnet_mean            =  -1.6627555272321E+01
-(PID.TID 0000.0001) %MON forcing_qnet_sd              =   1.1163132884860E+02
-(PID.TID 0000.0001) %MON forcing_qnet_del2            =   9.9928686399933E-01
-(PID.TID 0000.0001) %MON forcing_qsw_max              =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON forcing_qsw_min              =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON forcing_qsw_mean             =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON forcing_qsw_sd               =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON forcing_qsw_del2             =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON forcing_empmr_max            =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON forcing_empmr_min            =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON forcing_empmr_mean           =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON forcing_empmr_sd             =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON forcing_empmr_del2           =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON forcing_fu_max               =   2.6983152834638E-01
-(PID.TID 0000.0001) %MON forcing_fu_min               =  -1.6138135269284E-01
-(PID.TID 0000.0001) %MON forcing_fu_mean              =   1.6011429115913E-02
-(PID.TID 0000.0001) %MON forcing_fu_sd                =   8.9888060443000E-02
-(PID.TID 0000.0001) %MON forcing_fu_del2              =   6.5707434264057E-04
-(PID.TID 0000.0001) %MON forcing_fv_max               =   2.0708046348826E-01
-(PID.TID 0000.0001) %MON forcing_fv_min               =  -1.5227127015110E-01
-(PID.TID 0000.0001) %MON forcing_fv_mean              =  -5.4490089429109E-03
-(PID.TID 0000.0001) %MON forcing_fv_sd                =   4.3786156563931E-02
-(PID.TID 0000.0001) %MON forcing_fv_del2              =   3.5253650197433E-04
-(PID.TID 0000.0001) %MON trAdv_CFL_u_max              =   1.8568720058163E-02
-(PID.TID 0000.0001) %MON trAdv_CFL_v_max              =   1.2906519778705E-02
-(PID.TID 0000.0001) %MON trAdv_CFL_w_max              =   8.0602395038508E-02
-(PID.TID 0000.0001) %MON advcfl_uvel_max              =   2.1567857774055E-02
-(PID.TID 0000.0001) %MON advcfl_vvel_max              =   1.0600695427426E-02
-(PID.TID 0000.0001) %MON advcfl_wvel_max              =   1.8552955489445E-01
-(PID.TID 0000.0001) %MON advcfl_W_hf_max              =   8.0448951430200E-02
-(PID.TID 0000.0001) %MON pe_b_mean                    =   1.3243043243159E-04
-(PID.TID 0000.0001) %MON ke_max                       =   8.2315725322783E-03
-(PID.TID 0000.0001) %MON ke_mean                      =   2.2975206230399E-04
-(PID.TID 0000.0001) %MON ke_vol                       =   1.3226782436723E+18
-(PID.TID 0000.0001) %MON vort_r_min                   =  -3.1485976659845E-07
-(PID.TID 0000.0001) %MON vort_r_max                   =   5.5735994243955E-07
-(PID.TID 0000.0001) %MON vort_a_mean                  =  -2.5205769780005E-05
-(PID.TID 0000.0001) %MON vort_a_sd                    =   7.3401480961498E-05
-(PID.TID 0000.0001) %MON vort_p_mean                  =  -3.1758670044533E-05
-(PID.TID 0000.0001) %MON vort_p_sd                    =   1.3126067858455E-04
-(PID.TID 0000.0001) %MON surfExpan_theta_mean         =   1.2170433263791E-04
-(PID.TID 0000.0001) %MON surfExpan_salt_mean          =   8.2173974958424E-06
-(PID.TID 0000.0001) // =======================================================
-(PID.TID 0000.0001) // End MONITOR dynamic field statistics
-(PID.TID 0000.0001) // =======================================================
-(PID.TID 0000.0001) // =======================================================
-(PID.TID 0000.0001) // Begin MONITOR EXF statistics
-(PID.TID 0000.0001) // =======================================================
-(PID.TID 0000.0001) %MON exf_tsnumber                 =                    13
-(PID.TID 0000.0001) %MON exf_time_sec                 =   5.6160000000000E+05
-(PID.TID 0000.0001) %MON exf_ustress_max              =   2.6979751836869E-01
-(PID.TID 0000.0001) %MON exf_ustress_min              =  -1.6379594418310E-01
-(PID.TID 0000.0001) %MON exf_ustress_mean             =   1.4993224764597E-02
-(PID.TID 0000.0001) %MON exf_ustress_sd               =   8.8705415003953E-02
-(PID.TID 0000.0001) %MON exf_ustress_del2             =   6.9932602144313E-04
-(PID.TID 0000.0001) %MON exf_vstress_max              =   2.1674795304575E-01
-(PID.TID 0000.0001) %MON exf_vstress_min              =  -1.8322907820825E-01
-(PID.TID 0000.0001) %MON exf_vstress_mean             =  -5.6339853819020E-03
-(PID.TID 0000.0001) %MON exf_vstress_sd               =   4.5260915710932E-02
-(PID.TID 0000.0001) %MON exf_vstress_del2             =   4.6787403109410E-04
-(PID.TID 0000.0001) %MON exf_hflux_max                =   4.3248424406975E+02
-(PID.TID 0000.0001) %MON exf_hflux_min                =  -1.8408838185956E+02
-(PID.TID 0000.0001) %MON exf_hflux_mean               =  -1.6621501100148E+01
-(PID.TID 0000.0001) %MON exf_hflux_sd                 =   1.1153316416126E+02
-(PID.TID 0000.0001) %MON exf_hflux_del2               =   1.1795995940939E+00
-(PID.TID 0000.0001) %MON exf_climsst_max              =   2.9477016448975E+01
-(PID.TID 0000.0001) %MON exf_climsst_min              =  -1.9000000000000E+00
-(PID.TID 0000.0001) %MON exf_climsst_mean             =   1.8415002071734E+01
-(PID.TID 0000.0001) %MON exf_climsst_sd               =   9.1917560618574E+00
-(PID.TID 0000.0001) %MON exf_climsst_del2             =   2.4535316687973E-02
-(PID.TID 0000.0001) %MON exf_climsss_max              =   3.7461498506608E+01
-(PID.TID 0000.0001) %MON exf_climsss_min              =   2.9699733303439E+01
-(PID.TID 0000.0001) %MON exf_climsss_mean             =   3.4848083468007E+01
-(PID.TID 0000.0001) %MON exf_climsss_sd               =   9.6422887106270E-01
-(PID.TID 0000.0001) %MON exf_climsss_del2             =   7.1616947122608E-03
-(PID.TID 0000.0001) // =======================================================
-(PID.TID 0000.0001) // End MONITOR EXF statistics
-(PID.TID 0000.0001) // =======================================================
  cg2d: Sum(rhs),rhsMax =  -7.49622586226906E-13  8.97048397340147E+00
-(PID.TID 0000.0001)      cg2d_init_res =   9.46748120848987E-01
-(PID.TID 0000.0001)      cg2d_iters(min,last) =      -1      25
-(PID.TID 0000.0001)      cg2d_last_res =   5.94479987598542E-14
-(PID.TID 0000.0001) // =======================================================
-(PID.TID 0000.0001) // Begin MONITOR dynamic field statistics
-(PID.TID 0000.0001) // =======================================================
-(PID.TID 0000.0001) %MON time_tsnumber                =                    14
-(PID.TID 0000.0001) %MON time_secondsf                =   6.0480000000000E+05
-(PID.TID 0000.0001) %MON dynstat_eta_max              =   1.0840734733175E+00
-(PID.TID 0000.0001) %MON dynstat_eta_min              =  -1.0744503098657E+00
-(PID.TID 0000.0001) %MON dynstat_eta_mean             =   4.4738412769184E-16
-(PID.TID 0000.0001) %MON dynstat_eta_sd               =   3.3439342397955E-01
-(PID.TID 0000.0001) %MON dynstat_eta_del2             =   2.1487229988727E-03
-(PID.TID 0000.0001) %MON dynstat_uvel_max             =   1.3104892854536E-01
-(PID.TID 0000.0001) %MON dynstat_uvel_min             =  -1.2351608270490E-01
-(PID.TID 0000.0001) %MON dynstat_uvel_mean            =  -9.7106487507091E-03
-(PID.TID 0000.0001) %MON dynstat_uvel_sd              =   1.4925281210807E-02
-(PID.TID 0000.0001) %MON dynstat_uvel_del2            =   1.0461154622982E-04
-(PID.TID 0000.0001) %MON dynstat_vvel_max             =   1.1941741251222E-01
-(PID.TID 0000.0001) %MON dynstat_vvel_min             =  -9.9137404317920E-02
-(PID.TID 0000.0001) %MON dynstat_vvel_mean            =   3.8965745615581E-03
-(PID.TID 0000.0001) %MON dynstat_vvel_sd              =   1.3936933887658E-02
-(PID.TID 0000.0001) %MON dynstat_vvel_del2            =   1.1579766224139E-04
-(PID.TID 0000.0001) %MON dynstat_wvel_max             =   2.5177066190472E-04
-(PID.TID 0000.0001) %MON dynstat_wvel_min             =  -3.3757558455867E-04
-(PID.TID 0000.0001) %MON dynstat_wvel_mean            =   7.9857190710402E-22
-(PID.TID 0000.0001) %MON dynstat_wvel_sd              =   3.2837236952005E-05
-(PID.TID 0000.0001) %MON dynstat_wvel_del2            =   3.5391948026081E-07
-(PID.TID 0000.0001) %MON dynstat_theta_max            =   2.9558070463947E+01
-(PID.TID 0000.0001) %MON dynstat_theta_min            =  -2.1414394163928E+00
-(PID.TID 0000.0001) %MON dynstat_theta_mean           =   3.6000773550127E+00
-(PID.TID 0000.0001) %MON dynstat_theta_sd             =   4.3715165579771E+00
-(PID.TID 0000.0001) %MON dynstat_theta_del2           =   5.0927964545224E-03
-(PID.TID 0000.0001) %MON dynstat_salt_max             =   3.7430169534208E+01
-(PID.TID 0000.0001) %MON dynstat_salt_min             =   2.9785835461826E+01
-(PID.TID 0000.0001) %MON dynstat_salt_mean            =   3.4716436701883E+01
-(PID.TID 0000.0001) %MON dynstat_salt_sd              =   2.9604876854996E-01
-(PID.TID 0000.0001) %MON dynstat_salt_del2            =   1.0033360045504E-03
-(PID.TID 0000.0001) %MON forcing_qnet_max             =   4.3248424406975E+02
-(PID.TID 0000.0001) %MON forcing_qnet_min             =  -1.8408838185956E+02
-(PID.TID 0000.0001) %MON forcing_qnet_mean            =  -1.6621501100148E+01
-(PID.TID 0000.0001) %MON forcing_qnet_sd              =   1.1153316416126E+02
-(PID.TID 0000.0001) %MON forcing_qnet_del2            =   1.0002604540568E+00
-(PID.TID 0000.0001) %MON forcing_qsw_max              =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON forcing_qsw_min              =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON forcing_qsw_mean             =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON forcing_qsw_sd               =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON forcing_qsw_del2             =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON forcing_empmr_max            =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON forcing_empmr_min            =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON forcing_empmr_mean           =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON forcing_empmr_sd             =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON forcing_empmr_del2           =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON forcing_fu_max               =   2.6964348170065E-01
-(PID.TID 0000.0001) %MON forcing_fu_min               =  -1.6168411076069E-01
-(PID.TID 0000.0001) %MON forcing_fu_mean              =   1.6007464105186E-02
-(PID.TID 0000.0001) %MON forcing_fu_sd                =   8.9907054316662E-02
-(PID.TID 0000.0001) %MON forcing_fu_del2              =   6.5874510914174E-04
-(PID.TID 0000.0001) %MON forcing_fv_max               =   2.0776625362135E-01
-(PID.TID 0000.0001) %MON forcing_fv_min               =  -1.5249670945829E-01
-(PID.TID 0000.0001) %MON forcing_fv_mean              =  -5.4156741142706E-03
-(PID.TID 0000.0001) %MON forcing_fv_sd                =   4.3870228806050E-02
-(PID.TID 0000.0001) %MON forcing_fv_del2              =   3.5349811390448E-04
-(PID.TID 0000.0001) %MON trAdv_CFL_u_max              =   2.1572238360225E-02
-(PID.TID 0000.0001) %MON trAdv_CFL_v_max              =   1.1850901959328E-02
-(PID.TID 0000.0001) %MON trAdv_CFL_w_max              =   8.0448951430200E-02
-(PID.TID 0000.0001) %MON advcfl_uvel_max              =   2.3670221721789E-02
-(PID.TID 0000.0001) %MON advcfl_vvel_max              =   1.1600444013044E-02
-(PID.TID 0000.0001) %MON advcfl_wvel_max              =   1.7227040292092E-01
-(PID.TID 0000.0001) %MON advcfl_W_hf_max              =   7.5025453829750E-02
-(PID.TID 0000.0001) %MON pe_b_mean                    =   1.4308583973602E-04
-(PID.TID 0000.0001) %MON ke_max                       =   9.0967474867422E-03
-(PID.TID 0000.0001) %MON ke_mean                      =   2.3806393856029E-04
-(PID.TID 0000.0001) %MON ke_vol                       =   1.3226782436723E+18
-(PID.TID 0000.0001) %MON vort_r_min                   =  -3.3333806124691E-07
-(PID.TID 0000.0001) %MON vort_r_max                   =   5.5513934517039E-07
-(PID.TID 0000.0001) %MON vort_a_mean                  =  -2.5205769788322E-05
-(PID.TID 0000.0001) %MON vort_a_sd                    =   7.3401409747734E-05
-(PID.TID 0000.0001) %MON vort_p_mean                  =  -3.1758670055011E-05
-(PID.TID 0000.0001) %MON vort_p_sd                    =   1.3126037530654E-04
-(PID.TID 0000.0001) %MON surfExpan_theta_mean         =   1.0893600196592E-04
-(PID.TID 0000.0001) %MON surfExpan_salt_mean          =   6.8943289049915E-06
-(PID.TID 0000.0001) // =======================================================
-(PID.TID 0000.0001) // End MONITOR dynamic field statistics
-(PID.TID 0000.0001) // =======================================================
-(PID.TID 0000.0001) // =======================================================
-(PID.TID 0000.0001) // Begin MONITOR EXF statistics
-(PID.TID 0000.0001) // =======================================================
-(PID.TID 0000.0001) %MON exf_tsnumber                 =                    14
-(PID.TID 0000.0001) %MON exf_time_sec                 =   6.0480000000000E+05
-(PID.TID 0000.0001) %MON exf_ustress_max              =   2.6983685166605E-01
-(PID.TID 0000.0001) %MON exf_ustress_min              =  -1.6418953456225E-01
-(PID.TID 0000.0001) %MON exf_ustress_mean             =   1.4990335952964E-02
-(PID.TID 0000.0001) %MON exf_ustress_sd               =   8.8728587309739E-02
-(PID.TID 0000.0001) %MON exf_ustress_del2             =   7.0096504843521E-04
-(PID.TID 0000.0001) %MON exf_vstress_max              =   2.1765758457684E-01
-(PID.TID 0000.0001) %MON exf_vstress_min              =  -1.8294617942264E-01
-(PID.TID 0000.0001) %MON exf_vstress_mean             =  -5.6029808411593E-03
-(PID.TID 0000.0001) %MON exf_vstress_sd               =   4.5345436203889E-02
-(PID.TID 0000.0001) %MON exf_vstress_del2             =   4.6891718729513E-04
-(PID.TID 0000.0001) %MON exf_hflux_max                =   4.3299143145161E+02
-(PID.TID 0000.0001) %MON exf_hflux_min                =  -1.8386233545119E+02
-(PID.TID 0000.0001) %MON exf_hflux_mean               =  -1.6615446927976E+01
-(PID.TID 0000.0001) %MON exf_hflux_sd                 =   1.1143561430599E+02
-(PID.TID 0000.0001) %MON exf_hflux_del2               =   1.1800278263336E+00
-(PID.TID 0000.0001) %MON exf_climsst_max              =   2.9475168228149E+01
-(PID.TID 0000.0001) %MON exf_climsst_min              =  -1.9000000000000E+00
-(PID.TID 0000.0001) %MON exf_climsst_mean             =   1.8418864909364E+01
-(PID.TID 0000.0001) %MON exf_climsst_sd               =   9.1905938754998E+00
-(PID.TID 0000.0001) %MON exf_climsst_del2             =   2.4616039812039E-02
-(PID.TID 0000.0001) %MON exf_climsss_max              =   3.7462283472861E+01
-(PID.TID 0000.0001) %MON exf_climsss_min              =   2.9702679757149E+01
-(PID.TID 0000.0001) %MON exf_climsss_mean             =   3.4848185790629E+01
-(PID.TID 0000.0001) %MON exf_climsss_sd               =   9.6400690235322E-01
-(PID.TID 0000.0001) %MON exf_climsss_del2             =   7.1905937196401E-03
-(PID.TID 0000.0001) // =======================================================
-(PID.TID 0000.0001) // End MONITOR EXF statistics
-(PID.TID 0000.0001) // =======================================================
  cg2d: Sum(rhs),rhsMax =  -8.29558643999917E-13  9.43480072446720E+00
-(PID.TID 0000.0001)      cg2d_init_res =   8.73253184568476E-01
-(PID.TID 0000.0001)      cg2d_iters(min,last) =      -1      25
-(PID.TID 0000.0001)      cg2d_last_res =   5.11926766462723E-14
-(PID.TID 0000.0001) // =======================================================
-(PID.TID 0000.0001) // Begin MONITOR dynamic field statistics
-(PID.TID 0000.0001) // =======================================================
-(PID.TID 0000.0001) %MON time_tsnumber                =                    15
-(PID.TID 0000.0001) %MON time_secondsf                =   6.4800000000000E+05
-(PID.TID 0000.0001) %MON dynstat_eta_max              =   1.1385227374180E+00
-(PID.TID 0000.0001) %MON dynstat_eta_min              =  -1.1106410912446E+00
-(PID.TID 0000.0001) %MON dynstat_eta_mean             =   5.2979699331928E-16
-(PID.TID 0000.0001) %MON dynstat_eta_sd               =   3.4483635783033E-01
-(PID.TID 0000.0001) %MON dynstat_eta_del2             =   2.1036116531395E-03
-(PID.TID 0000.0001) %MON dynstat_uvel_max             =   1.3990717288610E-01
-(PID.TID 0000.0001) %MON dynstat_uvel_min             =  -1.2437447050950E-01
-(PID.TID 0000.0001) %MON dynstat_uvel_mean            =  -9.9074535422106E-03
-(PID.TID 0000.0001) %MON dynstat_uvel_sd              =   1.5598722289028E-02
-(PID.TID 0000.0001) %MON dynstat_uvel_del2            =   1.0662761379772E-04
-(PID.TID 0000.0001) %MON dynstat_vvel_max             =   1.3179553211793E-01
-(PID.TID 0000.0001) %MON dynstat_vvel_min             =  -1.0134292108900E-01
-(PID.TID 0000.0001) %MON dynstat_vvel_mean            =   3.5667119128291E-03
-(PID.TID 0000.0001) %MON dynstat_vvel_sd              =   1.3643419214572E-02
-(PID.TID 0000.0001) %MON dynstat_vvel_del2            =   1.1485783523499E-04
-(PID.TID 0000.0001) %MON dynstat_wvel_max             =   2.4637522693455E-04
-(PID.TID 0000.0001) %MON dynstat_wvel_min             =  -3.3359787053941E-04
-(PID.TID 0000.0001) %MON dynstat_wvel_mean            =   2.1138668129224E-21
-(PID.TID 0000.0001) %MON dynstat_wvel_sd              =   3.1799647012610E-05
-(PID.TID 0000.0001) %MON dynstat_wvel_del2            =   3.3918072029955E-07
-(PID.TID 0000.0001) %MON dynstat_theta_max            =   2.9548091059413E+01
-(PID.TID 0000.0001) %MON dynstat_theta_min            =  -2.1382350160259E+00
-(PID.TID 0000.0001) %MON dynstat_theta_mean           =   3.5989743663745E+00
-(PID.TID 0000.0001) %MON dynstat_theta_sd             =   4.3680935207106E+00
-(PID.TID 0000.0001) %MON dynstat_theta_del2           =   5.0657622628700E-03
-(PID.TID 0000.0001) %MON dynstat_salt_max             =   3.7428508488913E+01
-(PID.TID 0000.0001) %MON dynstat_salt_min             =   2.9786105212448E+01
-(PID.TID 0000.0001) %MON dynstat_salt_mean            =   3.4716367968625E+01
-(PID.TID 0000.0001) %MON dynstat_salt_sd              =   2.9601752879508E-01
-(PID.TID 0000.0001) %MON dynstat_salt_del2            =   1.0027872295241E-03
-(PID.TID 0000.0001) %MON forcing_qnet_max             =   4.3299143145161E+02
-(PID.TID 0000.0001) %MON forcing_qnet_min             =  -1.8386233545119E+02
-(PID.TID 0000.0001) %MON forcing_qnet_mean            =  -1.6615446927976E+01
-(PID.TID 0000.0001) %MON forcing_qnet_sd              =   1.1143561430599E+02
-(PID.TID 0000.0001) %MON forcing_qnet_del2            =   1.0012745124846E+00
-(PID.TID 0000.0001) %MON forcing_qsw_max              =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON forcing_qsw_min              =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON forcing_qsw_mean             =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON forcing_qsw_sd               =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON forcing_qsw_del2             =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON forcing_empmr_max            =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON forcing_empmr_min            =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON forcing_empmr_mean           =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON forcing_empmr_sd             =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON forcing_empmr_del2           =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON forcing_fu_max               =   2.6945543505492E-01
-(PID.TID 0000.0001) %MON forcing_fu_min               =  -1.6198686882854E-01
-(PID.TID 0000.0001) %MON forcing_fu_mean              =   1.6003499094459E-02
-(PID.TID 0000.0001) %MON forcing_fu_sd                =   8.9928506211371E-02
-(PID.TID 0000.0001) %MON forcing_fu_del2              =   6.6051841981797E-04
-(PID.TID 0000.0001) %MON forcing_fv_max               =   2.0845204375444E-01
-(PID.TID 0000.0001) %MON forcing_fv_min               =  -1.5272214876548E-01
-(PID.TID 0000.0001) %MON forcing_fv_mean              =  -5.3823392856304E-03
-(PID.TID 0000.0001) %MON forcing_fv_sd                =   4.3957392850766E-02
-(PID.TID 0000.0001) %MON forcing_fv_del2              =   3.5453693891022E-04
-(PID.TID 0000.0001) %MON trAdv_CFL_u_max              =   2.3675029313113E-02
-(PID.TID 0000.0001) %MON trAdv_CFL_v_max              =   1.1249708332951E-02
-(PID.TID 0000.0001) %MON trAdv_CFL_w_max              =   7.5025453829750E-02
-(PID.TID 0000.0001) %MON advcfl_uvel_max              =   2.4586996831953E-02
-(PID.TID 0000.0001) %MON advcfl_vvel_max              =   1.2802879072153E-02
-(PID.TID 0000.0001) %MON advcfl_wvel_max              =   1.4729696131473E-01
-(PID.TID 0000.0001) %MON advcfl_W_hf_max              =   6.5914473136934E-02
-(PID.TID 0000.0001) %MON pe_b_mean                    =   1.5216238226940E-04
-(PID.TID 0000.0001) %MON ke_max                       =   9.9071429545267E-03
-(PID.TID 0000.0001) %MON ke_mean                      =   2.4441743178202E-04
-(PID.TID 0000.0001) %MON ke_vol                       =   1.3226782436723E+18
-(PID.TID 0000.0001) %MON vort_r_min                   =  -3.5535136597336E-07
-(PID.TID 0000.0001) %MON vort_r_max                   =   5.3886202866405E-07
-(PID.TID 0000.0001) %MON vort_a_mean                  =  -2.5205769774005E-05
-(PID.TID 0000.0001) %MON vort_a_sd                    =   7.3401363593815E-05
-(PID.TID 0000.0001) %MON vort_p_mean                  =  -3.1758670036973E-05
-(PID.TID 0000.0001) %MON vort_p_sd                    =   1.3126017419751E-04
-(PID.TID 0000.0001) %MON surfExpan_theta_mean         =   9.5706242811607E-05
-(PID.TID 0000.0001) %MON surfExpan_salt_mean          =   5.5733001667361E-06
-(PID.TID 0000.0001) // =======================================================
-(PID.TID 0000.0001) // End MONITOR dynamic field statistics
-(PID.TID 0000.0001) // =======================================================
-(PID.TID 0000.0001) // =======================================================
-(PID.TID 0000.0001) // Begin MONITOR EXF statistics
-(PID.TID 0000.0001) // =======================================================
-(PID.TID 0000.0001) %MON exf_tsnumber                 =                    15
-(PID.TID 0000.0001) %MON exf_time_sec                 =   6.4800000000000E+05
-(PID.TID 0000.0001) %MON exf_ustress_max              =   2.6987618496341E-01
-(PID.TID 0000.0001) %MON exf_ustress_min              =  -1.6458312494140E-01
-(PID.TID 0000.0001) %MON exf_ustress_mean             =   1.4987447141331E-02
-(PID.TID 0000.0001) %MON exf_ustress_sd               =   8.8754253383936E-02
-(PID.TID 0000.0001) %MON exf_ustress_del2             =   7.0271908573382E-04
-(PID.TID 0000.0001) %MON exf_vstress_max              =   2.1856721610792E-01
-(PID.TID 0000.0001) %MON exf_vstress_min              =  -1.8266328063703E-01
-(PID.TID 0000.0001) %MON exf_vstress_mean             =  -5.5719763004165E-03
-(PID.TID 0000.0001) %MON exf_vstress_sd               =   4.5433272014359E-02
-(PID.TID 0000.0001) %MON exf_vstress_del2             =   4.7007551755777E-04
-(PID.TID 0000.0001) %MON exf_hflux_max                =   4.3349861883348E+02
-(PID.TID 0000.0001) %MON exf_hflux_min                =  -1.8363628904281E+02
-(PID.TID 0000.0001) %MON exf_hflux_mean               =  -1.6609392755803E+01
-(PID.TID 0000.0001) %MON exf_hflux_sd                 =   1.1133868089886E+02
-(PID.TID 0000.0001) %MON exf_hflux_del2               =   1.1804922262245E+00
-(PID.TID 0000.0001) %MON exf_climsst_max              =   2.9473320007324E+01
-(PID.TID 0000.0001) %MON exf_climsst_min              =  -1.9000000000000E+00
-(PID.TID 0000.0001) %MON exf_climsst_mean             =   1.8422727746995E+01
-(PID.TID 0000.0001) %MON exf_climsst_sd               =   9.1894922105341E+00
-(PID.TID 0000.0001) %MON exf_climsst_del2             =   2.4705441763507E-02
-(PID.TID 0000.0001) %MON exf_climsss_max              =   3.7463068439114E+01
-(PID.TID 0000.0001) %MON exf_climsss_min              =   2.9705626210859E+01
-(PID.TID 0000.0001) %MON exf_climsss_mean             =   3.4848288113252E+01
-(PID.TID 0000.0001) %MON exf_climsss_sd               =   9.6380590978517E-01
-(PID.TID 0000.0001) %MON exf_climsss_del2             =   7.2221068229136E-03
-(PID.TID 0000.0001) // =======================================================
-(PID.TID 0000.0001) // End MONITOR EXF statistics
-(PID.TID 0000.0001) // =======================================================
  cg2d: Sum(rhs),rhsMax =  -7.76267938817909E-13  9.69891950271935E+00
-(PID.TID 0000.0001)      cg2d_init_res =   8.27183783167458E-01
-(PID.TID 0000.0001)      cg2d_iters(min,last) =      -1      25
-(PID.TID 0000.0001)      cg2d_last_res =   4.41866743444745E-14
-(PID.TID 0000.0001) // =======================================================
-(PID.TID 0000.0001) // Begin MONITOR dynamic field statistics
-(PID.TID 0000.0001) // =======================================================
-(PID.TID 0000.0001) %MON time_tsnumber                =                    16
-(PID.TID 0000.0001) %MON time_secondsf                =   6.9120000000000E+05
-(PID.TID 0000.0001) %MON dynstat_eta_max              =   1.1695576084733E+00
-(PID.TID 0000.0001) %MON dynstat_eta_min              =  -1.1102259556999E+00
-(PID.TID 0000.0001) %MON dynstat_eta_mean             =   4.7545884015833E-16
-(PID.TID 0000.0001) %MON dynstat_eta_sd               =   3.5312590841245E-01
-(PID.TID 0000.0001) %MON dynstat_eta_del2             =   2.0652934797321E-03
-(PID.TID 0000.0001) %MON dynstat_uvel_max             =   1.4793125603484E-01
-(PID.TID 0000.0001) %MON dynstat_uvel_min             =  -1.2506658442845E-01
-(PID.TID 0000.0001) %MON dynstat_uvel_mean            =  -9.9686435824743E-03
-(PID.TID 0000.0001) %MON dynstat_uvel_sd              =   1.6164972464683E-02
-(PID.TID 0000.0001) %MON dynstat_uvel_del2            =   1.0819021083073E-04
-(PID.TID 0000.0001) %MON dynstat_vvel_max             =   1.4113087653410E-01
-(PID.TID 0000.0001) %MON dynstat_vvel_min             =  -1.0243768650641E-01
-(PID.TID 0000.0001) %MON dynstat_vvel_mean            =   3.2380917025483E-03
-(PID.TID 0000.0001) %MON dynstat_vvel_sd              =   1.3384461436338E-02
-(PID.TID 0000.0001) %MON dynstat_vvel_del2            =   1.1347239349132E-04
-(PID.TID 0000.0001) %MON dynstat_wvel_max             =   2.4883764585070E-04
-(PID.TID 0000.0001) %MON dynstat_wvel_min             =  -3.2761717020862E-04
-(PID.TID 0000.0001) %MON dynstat_wvel_mean            =   2.3487409032471E-22
-(PID.TID 0000.0001) %MON dynstat_wvel_sd              =   3.0690419534249E-05
-(PID.TID 0000.0001) %MON dynstat_wvel_del2            =   3.2342427194968E-07
-(PID.TID 0000.0001) %MON dynstat_theta_max            =   2.9525730380723E+01
-(PID.TID 0000.0001) %MON dynstat_theta_min            =  -2.1290729369709E+00
-(PID.TID 0000.0001) %MON dynstat_theta_mean           =   3.5980239077702E+00
-(PID.TID 0000.0001) %MON dynstat_theta_sd             =   4.3649202402056E+00
-(PID.TID 0000.0001) %MON dynstat_theta_del2           =   5.0405104445380E-03
-(PID.TID 0000.0001) %MON dynstat_salt_max             =   3.7426911032558E+01
-(PID.TID 0000.0001) %MON dynstat_salt_min             =   2.9786108451406E+01
-(PID.TID 0000.0001) %MON dynstat_salt_mean            =   3.4716314095940E+01
-(PID.TID 0000.0001) %MON dynstat_salt_sd              =   2.9598561856020E-01
-(PID.TID 0000.0001) %MON dynstat_salt_del2            =   1.0025618991793E-03
-(PID.TID 0000.0001) %MON forcing_qnet_max             =   4.3349861883348E+02
-(PID.TID 0000.0001) %MON forcing_qnet_min             =  -1.8363628904281E+02
-(PID.TID 0000.0001) %MON forcing_qnet_mean            =  -1.6609392755803E+01
-(PID.TID 0000.0001) %MON forcing_qnet_sd              =   1.1133868089886E+02
-(PID.TID 0000.0001) %MON forcing_qnet_del2            =   1.0023289164570E+00
-(PID.TID 0000.0001) %MON forcing_qsw_max              =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON forcing_qsw_min              =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON forcing_qsw_mean             =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON forcing_qsw_sd               =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON forcing_qsw_del2             =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON forcing_empmr_max            =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON forcing_empmr_min            =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON forcing_empmr_mean           =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON forcing_empmr_sd             =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON forcing_empmr_del2           =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON forcing_fu_max               =   2.6926738840918E-01
-(PID.TID 0000.0001) %MON forcing_fu_min               =  -1.6228962689638E-01
-(PID.TID 0000.0001) %MON forcing_fu_mean              =   1.5999534083732E-02
-(PID.TID 0000.0001) %MON forcing_fu_sd                =   8.9952414368557E-02
-(PID.TID 0000.0001) %MON forcing_fu_del2              =   6.6239345109877E-04
-(PID.TID 0000.0001) %MON forcing_fv_max               =   2.0913783388753E-01
-(PID.TID 0000.0001) %MON forcing_fv_min               =  -1.5294758807267E-01
-(PID.TID 0000.0001) %MON forcing_fv_mean              =  -5.3490044569901E-03
-(PID.TID 0000.0001) %MON forcing_fv_sd                =   4.4047630343360E-02
-(PID.TID 0000.0001) %MON forcing_fv_del2              =   3.5565230039706E-04
-(PID.TID 0000.0001) %MON trAdv_CFL_u_max              =   2.4591990626859E-02
-(PID.TID 0000.0001) %MON trAdv_CFL_v_max              =   1.2176846993789E-02
-(PID.TID 0000.0001) %MON trAdv_CFL_w_max              =   7.3648480657365E-02
-(PID.TID 0000.0001) %MON advcfl_uvel_max              =   2.4129201017193E-02
-(PID.TID 0000.0001) %MON advcfl_vvel_max              =   1.3709732921722E-02
-(PID.TID 0000.0001) %MON advcfl_wvel_max              =   1.5894952270890E-01
-(PID.TID 0000.0001) %MON advcfl_W_hf_max              =   6.4416764530919E-02
-(PID.TID 0000.0001) %MON pe_b_mean                    =   1.5956600244407E-04
-(PID.TID 0000.0001) %MON ke_max                       =   1.0650129146392E-02
-(PID.TID 0000.0001) %MON ke_mean                      =   2.4899526008967E-04
-(PID.TID 0000.0001) %MON ke_vol                       =   1.3226782436723E+18
-(PID.TID 0000.0001) %MON vort_r_min                   =  -3.7406075545048E-07
-(PID.TID 0000.0001) %MON vort_r_max                   =   5.0967426693043E-07
-(PID.TID 0000.0001) %MON vort_a_mean                  =  -2.5205769741443E-05
-(PID.TID 0000.0001) %MON vort_a_sd                    =   7.3401342442448E-05
-(PID.TID 0000.0001) %MON vort_p_mean                  =  -3.1758669995945E-05
-(PID.TID 0000.0001) %MON vort_p_sd                    =   1.3126007742951E-04
-(PID.TID 0000.0001) %MON surfExpan_theta_mean         =   8.2370462713945E-05
-(PID.TID 0000.0001) %MON surfExpan_salt_mean          =   4.2879052653176E-06
-(PID.TID 0000.0001) // =======================================================
-(PID.TID 0000.0001) // End MONITOR dynamic field statistics
-(PID.TID 0000.0001) // =======================================================
-(PID.TID 0000.0001) // =======================================================
-(PID.TID 0000.0001) // Begin MONITOR EXF statistics
-(PID.TID 0000.0001) // =======================================================
-(PID.TID 0000.0001) %MON exf_tsnumber                 =                    16
-(PID.TID 0000.0001) %MON exf_time_sec                 =   6.9120000000000E+05
-(PID.TID 0000.0001) %MON exf_ustress_max              =   2.6991551826077E-01
-(PID.TID 0000.0001) %MON exf_ustress_min              =  -1.6497671532054E-01
-(PID.TID 0000.0001) %MON exf_ustress_mean             =   1.4984558329698E-02
-(PID.TID 0000.0001) %MON exf_ustress_sd               =   8.8782411063776E-02
-(PID.TID 0000.0001) %MON exf_ustress_del2             =   7.0458727440104E-04
-(PID.TID 0000.0001) %MON exf_vstress_max              =   2.1947684763901E-01
-(PID.TID 0000.0001) %MON exf_vstress_min              =  -1.8238038185143E-01
-(PID.TID 0000.0001) %MON exf_vstress_mean             =  -5.5409717596737E-03
-(PID.TID 0000.0001) %MON exf_vstress_sd               =   4.5524403952399E-02
-(PID.TID 0000.0001) %MON exf_vstress_del2             =   4.7134817276780E-04
-(PID.TID 0000.0001) %MON exf_hflux_max                =   4.3400580621535E+02
-(PID.TID 0000.0001) %MON exf_hflux_min                =  -1.8341024263443E+02
-(PID.TID 0000.0001) %MON exf_hflux_mean               =  -1.6603338583631E+01
-(PID.TID 0000.0001) %MON exf_hflux_sd                 =   1.1124236555132E+02
-(PID.TID 0000.0001) %MON exf_hflux_del2               =   1.1809927511000E+00
-(PID.TID 0000.0001) %MON exf_climsst_max              =   2.9471471786499E+01
-(PID.TID 0000.0001) %MON exf_climsst_min              =  -1.9000000000000E+00
-(PID.TID 0000.0001) %MON exf_climsst_mean             =   1.8426590870872E+01
-(PID.TID 0000.0001) %MON exf_climsst_sd               =   9.1884504554686E+00
-(PID.TID 0000.0001) %MON exf_climsst_del2             =   2.4803452547448E-02
-(PID.TID 0000.0001) %MON exf_climsss_max              =   3.7463853405368E+01
-(PID.TID 0000.0001) %MON exf_climsss_min              =   2.9708572664568E+01
-(PID.TID 0000.0001) %MON exf_climsss_mean             =   3.4848390435874E+01
-(PID.TID 0000.0001) %MON exf_climsss_sd               =   9.6362590648411E-01
-(PID.TID 0000.0001) %MON exf_climsss_del2             =   7.2561999637252E-03
-(PID.TID 0000.0001) // =======================================================
-(PID.TID 0000.0001) // End MONITOR EXF statistics
-(PID.TID 0000.0001) // =======================================================
  cg2d: Sum(rhs),rhsMax =  -5.09814412907872E-13  9.76269586763470E+00
-(PID.TID 0000.0001)      cg2d_init_res =   8.02509446037038E-01
-(PID.TID 0000.0001)      cg2d_iters(min,last) =      -1      25
-(PID.TID 0000.0001)      cg2d_last_res =   3.57137725220627E-14
-(PID.TID 0000.0001) // =======================================================
-(PID.TID 0000.0001) // Begin MONITOR dynamic field statistics
-(PID.TID 0000.0001) // =======================================================
-(PID.TID 0000.0001) %MON time_tsnumber                =                    17
-(PID.TID 0000.0001) %MON time_secondsf                =   7.3440000000000E+05
-(PID.TID 0000.0001) %MON dynstat_eta_max              =   1.1772728614046E+00
-(PID.TID 0000.0001) %MON dynstat_eta_min              =  -1.0764021254033E+00
-(PID.TID 0000.0001) %MON dynstat_eta_mean             =   3.3327400605384E-16
-(PID.TID 0000.0001) %MON dynstat_eta_sd               =   3.5941403116181E-01
-(PID.TID 0000.0001) %MON dynstat_eta_del2             =   2.0327869912220E-03
-(PID.TID 0000.0001) %MON dynstat_uvel_max             =   1.5498015700183E-01
-(PID.TID 0000.0001) %MON dynstat_uvel_min             =  -1.2416045508993E-01
-(PID.TID 0000.0001) %MON dynstat_uvel_mean            =  -9.9012294004817E-03
-(PID.TID 0000.0001) %MON dynstat_uvel_sd              =   1.6629108405301E-02
-(PID.TID 0000.0001) %MON dynstat_uvel_del2            =   1.0937489987162E-04
-(PID.TID 0000.0001) %MON dynstat_vvel_max             =   1.4669062870165E-01
-(PID.TID 0000.0001) %MON dynstat_vvel_min             =  -1.0240099378866E-01
-(PID.TID 0000.0001) %MON dynstat_vvel_mean            =   2.9294598988406E-03
-(PID.TID 0000.0001) %MON dynstat_vvel_sd              =   1.3177224556626E-02
-(PID.TID 0000.0001) %MON dynstat_vvel_del2            =   1.1189339255538E-04
-(PID.TID 0000.0001) %MON dynstat_wvel_max             =   2.5456378778222E-04
-(PID.TID 0000.0001) %MON dynstat_wvel_min             =  -3.1872146295069E-04
-(PID.TID 0000.0001) %MON dynstat_wvel_mean            =  -1.1273956335586E-21
-(PID.TID 0000.0001) %MON dynstat_wvel_sd              =   2.9569907100045E-05
-(PID.TID 0000.0001) %MON dynstat_wvel_del2            =   3.0775796184967E-07
-(PID.TID 0000.0001) %MON dynstat_theta_max            =   2.9490883807972E+01
-(PID.TID 0000.0001) %MON dynstat_theta_min            =  -2.1147468662483E+00
-(PID.TID 0000.0001) %MON dynstat_theta_mean           =   3.5972247361150E+00
-(PID.TID 0000.0001) %MON dynstat_theta_sd             =   4.3620259416543E+00
-(PID.TID 0000.0001) %MON dynstat_theta_del2           =   5.0169900574568E-03
-(PID.TID 0000.0001) %MON dynstat_salt_max             =   3.7425386250468E+01
-(PID.TID 0000.0001) %MON dynstat_salt_min             =   2.9785928923027E+01
-(PID.TID 0000.0001) %MON dynstat_salt_mean            =   3.4716274449214E+01
-(PID.TID 0000.0001) %MON dynstat_salt_sd              =   2.9595457792758E-01
-(PID.TID 0000.0001) %MON dynstat_salt_del2            =   1.0023136024033E-03
-(PID.TID 0000.0001) %MON forcing_qnet_max             =   4.3400580621535E+02
-(PID.TID 0000.0001) %MON forcing_qnet_min             =  -1.8341024263443E+02
-(PID.TID 0000.0001) %MON forcing_qnet_mean            =  -1.6603338583631E+01
-(PID.TID 0000.0001) %MON forcing_qnet_sd              =   1.1124236555132E+02
-(PID.TID 0000.0001) %MON forcing_qnet_del2            =   1.0034235387878E+00
-(PID.TID 0000.0001) %MON forcing_qsw_max              =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON forcing_qsw_min              =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON forcing_qsw_mean             =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON forcing_qsw_sd               =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON forcing_qsw_del2             =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON forcing_empmr_max            =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON forcing_empmr_min            =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON forcing_empmr_mean           =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON forcing_empmr_sd             =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON forcing_empmr_del2           =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON forcing_fu_max               =   2.6907934176345E-01
-(PID.TID 0000.0001) %MON forcing_fu_min               =  -1.6259238496423E-01
-(PID.TID 0000.0001) %MON forcing_fu_mean              =   1.5995569073005E-02
-(PID.TID 0000.0001) %MON forcing_fu_sd                =   8.9978776830267E-02
-(PID.TID 0000.0001) %MON forcing_fu_del2              =   6.6436934173492E-04
-(PID.TID 0000.0001) %MON forcing_fv_max               =   2.0982362402062E-01
-(PID.TID 0000.0001) %MON forcing_fv_min               =  -1.5317302737986E-01
-(PID.TID 0000.0001) %MON forcing_fv_mean              =  -5.3156696283499E-03
-(PID.TID 0000.0001) %MON forcing_fv_sd                =   4.4140922434647E-02
-(PID.TID 0000.0001) %MON forcing_fv_del2              =   3.5684348069104E-04
-(PID.TID 0000.0001) %MON trAdv_CFL_u_max              =   2.4134101830494E-02
-(PID.TID 0000.0001) %MON trAdv_CFL_v_max              =   1.3045937751221E-02
-(PID.TID 0000.0001) %MON trAdv_CFL_w_max              =   7.9474761354452E-02
-(PID.TID 0000.0001) %MON advcfl_uvel_max              =   2.2230065759047E-02
-(PID.TID 0000.0001) %MON advcfl_vvel_max              =   1.4249818260947E-02
-(PID.TID 0000.0001) %MON advcfl_wvel_max              =   1.6632255547949E-01
-(PID.TID 0000.0001) %MON advcfl_W_hf_max              =   6.7597376324183E-02
-(PID.TID 0000.0001) %MON pe_b_mean                    =   1.6529939163971E-04
-(PID.TID 0000.0001) %MON ke_max                       =   1.1319225641521E-02
-(PID.TID 0000.0001) %MON ke_mean                      =   2.5197598581539E-04
-(PID.TID 0000.0001) %MON ke_vol                       =   1.3226782436723E+18
-(PID.TID 0000.0001) %MON vort_r_min                   =  -3.8985883742101E-07
-(PID.TID 0000.0001) %MON vort_r_max                   =   4.6921402866315E-07
-(PID.TID 0000.0001) %MON vort_a_mean                  =  -2.5205769696559E-05
-(PID.TID 0000.0001) %MON vort_a_sd                    =   7.3401345373982E-05
-(PID.TID 0000.0001) %MON vort_p_mean                  =  -3.1758669939393E-05
-(PID.TID 0000.0001) %MON vort_p_sd                    =   1.3126008060784E-04
-(PID.TID 0000.0001) %MON surfExpan_theta_mean         =   6.9237861292216E-05
-(PID.TID 0000.0001) %MON surfExpan_salt_mean          =   3.0622882695702E-06
-(PID.TID 0000.0001) // =======================================================
-(PID.TID 0000.0001) // End MONITOR dynamic field statistics
-(PID.TID 0000.0001) // =======================================================
-(PID.TID 0000.0001) // =======================================================
-(PID.TID 0000.0001) // Begin MONITOR EXF statistics
-(PID.TID 0000.0001) // =======================================================
-(PID.TID 0000.0001) %MON exf_tsnumber                 =                    17
-(PID.TID 0000.0001) %MON exf_time_sec                 =   7.3440000000000E+05
-(PID.TID 0000.0001) %MON exf_ustress_max              =   2.6995485155813E-01
-(PID.TID 0000.0001) %MON exf_ustress_min              =  -1.6537030569969E-01
-(PID.TID 0000.0001) %MON exf_ustress_mean             =   1.4981669518065E-02
-(PID.TID 0000.0001) %MON exf_ustress_sd               =   8.8813057979411E-02
-(PID.TID 0000.0001) %MON exf_ustress_del2             =   7.0656870897861E-04
-(PID.TID 0000.0001) %MON exf_vstress_max              =   2.2038647917009E-01
-(PID.TID 0000.0001) %MON exf_vstress_min              =  -1.8209748306582E-01
-(PID.TID 0000.0001) %MON exf_vstress_mean             =  -5.5099672189310E-03
-(PID.TID 0000.0001) %MON exf_vstress_sd               =   4.5618812264159E-02
-(PID.TID 0000.0001) %MON exf_vstress_del2             =   4.7273422959817E-04
-(PID.TID 0000.0001) %MON exf_hflux_max                =   4.3451299359722E+02
-(PID.TID 0000.0001) %MON exf_hflux_min                =  -1.8318419622606E+02
-(PID.TID 0000.0001) %MON exf_hflux_mean               =  -1.6597284411458E+01
-(PID.TID 0000.0001) %MON exf_hflux_sd                 =   1.1114666987015E+02
-(PID.TID 0000.0001) %MON exf_hflux_del2               =   1.1815293550499E+00
-(PID.TID 0000.0001) %MON exf_climsst_max              =   2.9469623565674E+01
-(PID.TID 0000.0001) %MON exf_climsst_min              =  -1.9000000000000E+00
-(PID.TID 0000.0001) %MON exf_climsst_mean             =   1.8430458021528E+01
-(PID.TID 0000.0001) %MON exf_climsst_sd               =   9.1874603458912E+00
-(PID.TID 0000.0001) %MON exf_climsst_del2             =   2.4910285815413E-02
-(PID.TID 0000.0001) %MON exf_climsss_max              =   3.7464638371621E+01
-(PID.TID 0000.0001) %MON exf_climsss_min              =   2.9711519118278E+01
-(PID.TID 0000.0001) %MON exf_climsss_mean             =   3.4848492758496E+01
-(PID.TID 0000.0001) %MON exf_climsss_sd               =   9.6346690421424E-01
-(PID.TID 0000.0001) %MON exf_climsss_del2             =   7.2928369580637E-03
-(PID.TID 0000.0001) // =======================================================
-(PID.TID 0000.0001) // End MONITOR EXF statistics
-(PID.TID 0000.0001) // =======================================================
  cg2d: Sum(rhs),rhsMax =  -7.60280727263307E-13  9.63804624662821E+00
-(PID.TID 0000.0001)      cg2d_init_res =   7.94966119063840E-01
-(PID.TID 0000.0001)      cg2d_iters(min,last) =      -1      25
-(PID.TID 0000.0001)      cg2d_last_res =   2.83414320012451E-14
-(PID.TID 0000.0001) // =======================================================
-(PID.TID 0000.0001) // Begin MONITOR dynamic field statistics
-(PID.TID 0000.0001) // =======================================================
-(PID.TID 0000.0001) %MON time_tsnumber                =                    18
-(PID.TID 0000.0001) %MON time_secondsf                =   7.7760000000000E+05
-(PID.TID 0000.0001) %MON dynstat_eta_max              =   1.1631571058304E+00
-(PID.TID 0000.0001) %MON dynstat_eta_min              =  -1.0857972297529E+00
-(PID.TID 0000.0001) %MON dynstat_eta_mean             =   4.4738412769184E-16
-(PID.TID 0000.0001) %MON dynstat_eta_sd               =   3.6389526330404E-01
-(PID.TID 0000.0001) %MON dynstat_eta_del2             =   2.0052032778688E-03
-(PID.TID 0000.0001) %MON dynstat_uvel_max             =   1.6093269830821E-01
-(PID.TID 0000.0001) %MON dynstat_uvel_min             =  -1.2984830272112E-01
-(PID.TID 0000.0001) %MON dynstat_uvel_mean            =  -9.7161234161005E-03
-(PID.TID 0000.0001) %MON dynstat_uvel_sd              =   1.6998238933409E-02
-(PID.TID 0000.0001) %MON dynstat_uvel_del2            =   1.1026100755046E-04
-(PID.TID 0000.0001) %MON dynstat_vvel_max             =   1.4791932289823E-01
-(PID.TID 0000.0001) %MON dynstat_vvel_min             =  -1.1093089782881E-01
-(PID.TID 0000.0001) %MON dynstat_vvel_mean            =   2.6566260891911E-03
-(PID.TID 0000.0001) %MON dynstat_vvel_sd              =   1.3028470300975E-02
-(PID.TID 0000.0001) %MON dynstat_vvel_del2            =   1.1035694784317E-04
-(PID.TID 0000.0001) %MON dynstat_wvel_max             =   2.5819487979362E-04
-(PID.TID 0000.0001) %MON dynstat_wvel_min             =  -3.0697719749123E-04
-(PID.TID 0000.0001) %MON dynstat_wvel_mean            =  -1.5971438142080E-21
-(PID.TID 0000.0001) %MON dynstat_wvel_sd              =   2.8492313526434E-05
-(PID.TID 0000.0001) %MON dynstat_wvel_del2            =   2.9322519817566E-07
-(PID.TID 0000.0001) %MON dynstat_theta_max            =   2.9452263303319E+01
-(PID.TID 0000.0001) %MON dynstat_theta_min            =  -2.0963607481362E+00
-(PID.TID 0000.0001) %MON dynstat_theta_mean           =   3.5965724773734E+00
-(PID.TID 0000.0001) %MON dynstat_theta_sd             =   4.3594353165817E+00
-(PID.TID 0000.0001) %MON dynstat_theta_del2           =   4.9953902303934E-03
-(PID.TID 0000.0001) %MON dynstat_salt_max             =   3.7423939793018E+01
-(PID.TID 0000.0001) %MON dynstat_salt_min             =   2.9785656454439E+01
-(PID.TID 0000.0001) %MON dynstat_salt_mean            =   3.4716248191282E+01
-(PID.TID 0000.0001) %MON dynstat_salt_sd              =   2.9592528196891E-01
-(PID.TID 0000.0001) %MON dynstat_salt_del2            =   1.0021367165520E-03
-(PID.TID 0000.0001) %MON forcing_qnet_max             =   4.3451299359722E+02
-(PID.TID 0000.0001) %MON forcing_qnet_min             =  -1.8318419622606E+02
-(PID.TID 0000.0001) %MON forcing_qnet_mean            =  -1.6597284411458E+01
-(PID.TID 0000.0001) %MON forcing_qnet_sd              =   1.1114666987015E+02
-(PID.TID 0000.0001) %MON forcing_qnet_del2            =   1.0045582480047E+00
-(PID.TID 0000.0001) %MON forcing_qsw_max              =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON forcing_qsw_min              =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON forcing_qsw_mean             =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON forcing_qsw_sd               =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON forcing_qsw_del2             =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON forcing_empmr_max            =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON forcing_empmr_min            =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON forcing_empmr_mean           =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON forcing_empmr_sd             =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON forcing_empmr_del2           =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON forcing_fu_max               =   2.6889129511772E-01
-(PID.TID 0000.0001) %MON forcing_fu_min               =  -1.6289514303207E-01
-(PID.TID 0000.0001) %MON forcing_fu_mean              =   1.5991604062278E-02
-(PID.TID 0000.0001) %MON forcing_fu_sd                =   9.0007591439967E-02
-(PID.TID 0000.0001) %MON forcing_fu_del2              =   6.6644519463725E-04
-(PID.TID 0000.0001) %MON forcing_fv_max               =   2.1050941415371E-01
-(PID.TID 0000.0001) %MON forcing_fv_min               =  -1.5339846668705E-01
-(PID.TID 0000.0001) %MON forcing_fv_mean              =  -5.2823347997097E-03
-(PID.TID 0000.0001) %MON forcing_fv_sd                =   4.4237249799067E-02
-(PID.TID 0000.0001) %MON forcing_fv_del2              =   3.5810972320471E-04
-(PID.TID 0000.0001) %MON trAdv_CFL_u_max              =   2.2234580844394E-02
-(PID.TID 0000.0001) %MON trAdv_CFL_v_max              =   1.3550619228519E-02
-(PID.TID 0000.0001) %MON trAdv_CFL_w_max              =   8.3161277739743E-02
-(PID.TID 0000.0001) %MON advcfl_uvel_max              =   2.2505049647968E-02
-(PID.TID 0000.0001) %MON advcfl_vvel_max              =   1.4369176049202E-02
-(PID.TID 0000.0001) %MON advcfl_wvel_max              =   1.6863265851279E-01
-(PID.TID 0000.0001) %MON advcfl_W_hf_max              =   6.8108672686215E-02
-(PID.TID 0000.0001) %MON pe_b_mean                    =   1.6944704724608E-04
-(PID.TID 0000.0001) %MON ke_max                       =   1.1913523545811E-02
-(PID.TID 0000.0001) %MON ke_mean                      =   2.5353129551497E-04
-(PID.TID 0000.0001) %MON ke_vol                       =   1.3226782436723E+18
-(PID.TID 0000.0001) %MON vort_r_min                   =  -4.1920797808649E-07
-(PID.TID 0000.0001) %MON vort_r_max                   =   4.1948484077210E-07
-(PID.TID 0000.0001) %MON vort_a_mean                  =  -2.5205769645784E-05
-(PID.TID 0000.0001) %MON vort_a_sd                    =   7.3401370746777E-05
-(PID.TID 0000.0001) %MON vort_p_mean                  =  -3.1758669875417E-05
-(PID.TID 0000.0001) %MON vort_p_sd                    =   1.3126017387140E-04
-(PID.TID 0000.0001) %MON surfExpan_theta_mean         =   5.6596701641485E-05
-(PID.TID 0000.0001) %MON surfExpan_salt_mean          =   1.9187666729073E-06
-(PID.TID 0000.0001) // =======================================================
-(PID.TID 0000.0001) // End MONITOR dynamic field statistics
-(PID.TID 0000.0001) // =======================================================
-(PID.TID 0000.0001) // =======================================================
-(PID.TID 0000.0001) // Begin MONITOR EXF statistics
-(PID.TID 0000.0001) // =======================================================
-(PID.TID 0000.0001) %MON exf_tsnumber                 =                    18
-(PID.TID 0000.0001) %MON exf_time_sec                 =   7.7760000000000E+05
-(PID.TID 0000.0001) %MON exf_ustress_max              =   2.6999418485549E-01
-(PID.TID 0000.0001) %MON exf_ustress_min              =  -1.6576389607883E-01
-(PID.TID 0000.0001) %MON exf_ustress_mean             =   1.4978780706431E-02
-(PID.TID 0000.0001) %MON exf_ustress_sd               =   8.8846191554903E-02
-(PID.TID 0000.0001) %MON exf_ustress_del2             =   7.0866243955356E-04
-(PID.TID 0000.0001) %MON exf_vstress_max              =   2.2129611070118E-01
-(PID.TID 0000.0001) %MON exf_vstress_min              =  -1.8181458428021E-01
-(PID.TID 0000.0001) %MON exf_vstress_mean             =  -5.4789626781882E-03
-(PID.TID 0000.0001) %MON exf_vstress_sd               =   4.5716476651692E-02
-(PID.TID 0000.0001) %MON exf_vstress_del2             =   4.7423269372103E-04
-(PID.TID 0000.0001) %MON exf_hflux_max                =   4.3502018097908E+02
-(PID.TID 0000.0001) %MON exf_hflux_min                =  -1.8295814981768E+02
-(PID.TID 0000.0001) %MON exf_hflux_mean               =  -1.6591230239286E+01
-(PID.TID 0000.0001) %MON exf_hflux_sd                 =   1.1105159545728E+02
-(PID.TID 0000.0001) %MON exf_hflux_del2               =   1.1821019889410E+00
-(PID.TID 0000.0001) %MON exf_climsst_max              =   2.9467775344849E+01
-(PID.TID 0000.0001) %MON exf_climsst_min              =  -1.9000000000000E+00
-(PID.TID 0000.0001) %MON exf_climsst_mean             =   1.8434328397312E+01
-(PID.TID 0000.0001) %MON exf_climsst_sd               =   9.1865236651676E+00
-(PID.TID 0000.0001) %MON exf_climsst_del2             =   2.5025225952218E-02
-(PID.TID 0000.0001) %MON exf_climsss_max              =   3.7465423337875E+01
-(PID.TID 0000.0001) %MON exf_climsss_min              =   2.9714465571988E+01
-(PID.TID 0000.0001) %MON exf_climsss_mean             =   3.4848595081118E+01
-(PID.TID 0000.0001) %MON exf_climsss_sd               =   9.6332891337454E-01
-(PID.TID 0000.0001) %MON exf_climsss_del2             =   7.3319796720651E-03
-(PID.TID 0000.0001) // =======================================================
-(PID.TID 0000.0001) // End MONITOR EXF statistics
-(PID.TID 0000.0001) // =======================================================
  cg2d: Sum(rhs),rhsMax =  -8.56203996590921E-13  9.34829007243764E+00
-(PID.TID 0000.0001)      cg2d_init_res =   8.01532798166213E-01
-(PID.TID 0000.0001)      cg2d_iters(min,last) =      -1      25
-(PID.TID 0000.0001)      cg2d_last_res =   2.81517474936486E-14
-(PID.TID 0000.0001) // =======================================================
-(PID.TID 0000.0001) // Begin MONITOR dynamic field statistics
-(PID.TID 0000.0001) // =======================================================
-(PID.TID 0000.0001) %MON time_tsnumber                =                    19
-(PID.TID 0000.0001) %MON time_secondsf                =   8.2080000000000E+05
-(PID.TID 0000.0001) %MON dynstat_eta_max              =   1.1299630630737E+00
-(PID.TID 0000.0001) %MON dynstat_eta_min              =  -1.0681489335293E+00
-(PID.TID 0000.0001) %MON dynstat_eta_mean             =   3.8217834389870E-16
-(PID.TID 0000.0001) %MON dynstat_eta_sd               =   3.6679233386134E-01
-(PID.TID 0000.0001) %MON dynstat_eta_del2             =   1.9817398563386E-03
-(PID.TID 0000.0001) %MON dynstat_uvel_max             =   1.6569156739136E-01
-(PID.TID 0000.0001) %MON dynstat_uvel_min             =  -1.3506325555774E-01
-(PID.TID 0000.0001) %MON dynstat_uvel_mean            =  -9.4271460061477E-03
-(PID.TID 0000.0001) %MON dynstat_uvel_sd              =   1.7280515783289E-02
-(PID.TID 0000.0001) %MON dynstat_uvel_del2            =   1.1092781356413E-04
-(PID.TID 0000.0001) %MON dynstat_vvel_max             =   1.4448120566965E-01
-(PID.TID 0000.0001) %MON dynstat_vvel_min             =  -1.2341758112904E-01
-(PID.TID 0000.0001) %MON dynstat_vvel_mean            =   2.4318721967849E-03
-(PID.TID 0000.0001) %MON dynstat_vvel_sd              =   1.2936421182828E-02
-(PID.TID 0000.0001) %MON dynstat_vvel_del2            =   1.0905652132684E-04
-(PID.TID 0000.0001) %MON dynstat_wvel_max             =   2.5985236969880E-04
-(PID.TID 0000.0001) %MON dynstat_wvel_min             =  -2.9293289932096E-04
-(PID.TID 0000.0001) %MON dynstat_wvel_mean            =   1.5971438142080E-21
-(PID.TID 0000.0001) %MON dynstat_wvel_sd              =   2.7504193065118E-05
-(PID.TID 0000.0001) %MON dynstat_wvel_del2            =   2.8072202551951E-07
-(PID.TID 0000.0001) %MON dynstat_theta_max            =   2.9443519616048E+01
-(PID.TID 0000.0001) %MON dynstat_theta_min            =  -2.0753104788214E+00
-(PID.TID 0000.0001) %MON dynstat_theta_mean           =   3.5960596232303E+00
-(PID.TID 0000.0001) %MON dynstat_theta_sd             =   4.3571669385418E+00
-(PID.TID 0000.0001) %MON dynstat_theta_del2           =   4.9758658879582E-03
-(PID.TID 0000.0001) %MON dynstat_salt_max             =   3.7422567330272E+01
-(PID.TID 0000.0001) %MON dynstat_salt_min             =   2.9785382189374E+01
-(PID.TID 0000.0001) %MON dynstat_salt_mean            =   3.4716234243018E+01
-(PID.TID 0000.0001) %MON dynstat_salt_sd              =   2.9589840059437E-01
-(PID.TID 0000.0001) %MON dynstat_salt_del2            =   1.0020097644606E-03
-(PID.TID 0000.0001) %MON forcing_qnet_max             =   4.3502018097908E+02
-(PID.TID 0000.0001) %MON forcing_qnet_min             =  -1.8295814981768E+02
-(PID.TID 0000.0001) %MON forcing_qnet_mean            =  -1.6591230239286E+01
-(PID.TID 0000.0001) %MON forcing_qnet_sd              =   1.1105159545728E+02
-(PID.TID 0000.0001) %MON forcing_qnet_del2            =   1.0057329084247E+00
-(PID.TID 0000.0001) %MON forcing_qsw_max              =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON forcing_qsw_min              =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON forcing_qsw_mean             =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON forcing_qsw_sd               =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON forcing_qsw_del2             =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON forcing_empmr_max            =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON forcing_empmr_min            =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON forcing_empmr_mean           =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON forcing_empmr_sd             =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON forcing_empmr_del2           =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON forcing_fu_max               =   2.6870324847198E-01
-(PID.TID 0000.0001) %MON forcing_fu_min               =  -1.6319790109992E-01
-(PID.TID 0000.0001) %MON forcing_fu_mean              =   1.5987639051551E-02
-(PID.TID 0000.0001) %MON forcing_fu_sd                =   9.0038855843416E-02
-(PID.TID 0000.0001) %MON forcing_fu_del2              =   6.6862007875319E-04
-(PID.TID 0000.0001) %MON forcing_fv_max               =   2.1119520428681E-01
-(PID.TID 0000.0001) %MON forcing_fv_min               =  -1.5362390599424E-01
-(PID.TID 0000.0001) %MON forcing_fv_mean              =  -5.2489999710694E-03
-(PID.TID 0000.0001) %MON forcing_fv_sd                =   4.4336592652977E-02
-(PID.TID 0000.0001) %MON forcing_fv_del2              =   3.5945023466941E-04
-(PID.TID 0000.0001) %MON trAdv_CFL_u_max              =   2.2509620584510E-02
-(PID.TID 0000.0001) %MON trAdv_CFL_v_max              =   1.3636492180126E-02
-(PID.TID 0000.0001) %MON trAdv_CFL_w_max              =   8.4316329256397E-02
-(PID.TID 0000.0001) %MON advcfl_uvel_max              =   2.3170536439096E-02
-(PID.TID 0000.0001) %MON advcfl_vvel_max              =   1.4035190530831E-02
-(PID.TID 0000.0001) %MON advcfl_wvel_max              =   1.6533374435215E-01
-(PID.TID 0000.0001) %MON advcfl_W_hf_max              =   6.7370657454075E-02
-(PID.TID 0000.0001) %MON pe_b_mean                    =   1.7215581648081E-04
-(PID.TID 0000.0001) %MON ke_max                       =   1.2490195998977E-02
-(PID.TID 0000.0001) %MON ke_mean                      =   2.5382759971072E-04
-(PID.TID 0000.0001) %MON ke_vol                       =   1.3226782436723E+18
-(PID.TID 0000.0001) %MON vort_r_min                   =  -4.3799151605105E-07
-(PID.TID 0000.0001) %MON vort_r_max                   =   3.7308410031324E-07
-(PID.TID 0000.0001) %MON vort_a_mean                  =  -2.5205769595171E-05
-(PID.TID 0000.0001) %MON vort_a_sd                    =   7.3401416363264E-05
-(PID.TID 0000.0001) %MON vort_p_mean                  =  -3.1758669811646E-05
-(PID.TID 0000.0001) %MON vort_p_sd                    =   1.3126034363904E-04
-(PID.TID 0000.0001) %MON surfExpan_theta_mean         =   4.4700183370964E-05
-(PID.TID 0000.0001) %MON surfExpan_salt_mean          =   8.7503836536159E-07
-(PID.TID 0000.0001) // =======================================================
-(PID.TID 0000.0001) // End MONITOR dynamic field statistics
-(PID.TID 0000.0001) // =======================================================
-(PID.TID 0000.0001) // =======================================================
-(PID.TID 0000.0001) // Begin MONITOR EXF statistics
-(PID.TID 0000.0001) // =======================================================
-(PID.TID 0000.0001) %MON exf_tsnumber                 =                    19
-(PID.TID 0000.0001) %MON exf_time_sec                 =   8.2080000000000E+05
-(PID.TID 0000.0001) %MON exf_ustress_max              =   2.7003351815285E-01
-(PID.TID 0000.0001) %MON exf_ustress_min              =  -1.6615748645798E-01
-(PID.TID 0000.0001) %MON exf_ustress_mean             =   1.4975891894798E-02
-(PID.TID 0000.0001) %MON exf_ustress_sd               =   8.8881809009303E-02
-(PID.TID 0000.0001) %MON exf_ustress_del2             =   7.1086747388443E-04
-(PID.TID 0000.0001) %MON exf_vstress_max              =   2.2220574223226E-01
-(PID.TID 0000.0001) %MON exf_vstress_min              =  -1.8153168549461E-01
-(PID.TID 0000.0001) %MON exf_vstress_mean             =  -5.4479581374455E-03
-(PID.TID 0000.0001) %MON exf_vstress_sd               =   4.5817376293037E-02
-(PID.TID 0000.0001) %MON exf_vstress_del2             =   4.7584250320031E-04
-(PID.TID 0000.0001) %MON exf_hflux_max                =   4.3552736836095E+02
-(PID.TID 0000.0001) %MON exf_hflux_min                =  -1.8273210340931E+02
-(PID.TID 0000.0001) %MON exf_hflux_mean               =  -1.6585176067114E+01
-(PID.TID 0000.0001) %MON exf_hflux_sd                 =   1.1095714390972E+02
-(PID.TID 0000.0001) %MON exf_hflux_del2               =   1.1827106004394E+00
-(PID.TID 0000.0001) %MON exf_climsst_max              =   2.9465927124023E+01
-(PID.TID 0000.0001) %MON exf_climsst_min              =  -1.9000000000000E+00
-(PID.TID 0000.0001) %MON exf_climsst_mean             =   1.8438200457355E+01
-(PID.TID 0000.0001) %MON exf_climsst_sd               =   9.1856438469628E+00
-(PID.TID 0000.0001) %MON exf_climsst_del2             =   2.5148271139989E-02
-(PID.TID 0000.0001) %MON exf_climsss_max              =   3.7466208304128E+01
-(PID.TID 0000.0001) %MON exf_climsss_min              =   2.9717412025698E+01
-(PID.TID 0000.0001) %MON exf_climsss_mean             =   3.4848697403740E+01
-(PID.TID 0000.0001) %MON exf_climsss_sd               =   9.6321194299537E-01
-(PID.TID 0000.0001) %MON exf_climsss_del2             =   7.3735882009776E-03
-(PID.TID 0000.0001) // =======================================================
-(PID.TID 0000.0001) // End MONITOR EXF statistics
-(PID.TID 0000.0001) // =======================================================
  cg2d: Sum(rhs),rhsMax =  -7.78044295657310E-13  9.12167905632681E+00
 (PID.TID 0000.0001)      cg2d_init_res =   8.02324513658737E-01
 (PID.TID 0000.0001)      cg2d_iters(min,last) =      -1      25
@@ -4783,31 +2664,6 @@
 (PID.TID 0000.0001) %MON dynstat_salt_mean            =   3.4716231358454E+01
 (PID.TID 0000.0001) %MON dynstat_salt_sd              =   2.9587429127505E-01
 (PID.TID 0000.0001) %MON dynstat_salt_del2            =   1.0019566199393E-03
-(PID.TID 0000.0001) %MON forcing_qnet_max             =   4.3552736836095E+02
-(PID.TID 0000.0001) %MON forcing_qnet_min             =  -1.8273210340931E+02
-(PID.TID 0000.0001) %MON forcing_qnet_mean            =  -1.6585176067114E+01
-(PID.TID 0000.0001) %MON forcing_qnet_sd              =   1.1095714390972E+02
-(PID.TID 0000.0001) %MON forcing_qnet_del2            =   1.0069473802317E+00
-(PID.TID 0000.0001) %MON forcing_qsw_max              =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON forcing_qsw_min              =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON forcing_qsw_mean             =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON forcing_qsw_sd               =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON forcing_qsw_del2             =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON forcing_empmr_max            =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON forcing_empmr_min            =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON forcing_empmr_mean           =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON forcing_empmr_sd             =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON forcing_empmr_del2           =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON forcing_fu_max               =   2.6851520182625E-01
-(PID.TID 0000.0001) %MON forcing_fu_min               =  -1.6350065916777E-01
-(PID.TID 0000.0001) %MON forcing_fu_mean              =   1.5983674040824E-02
-(PID.TID 0000.0001) %MON forcing_fu_sd                =   9.0072567489627E-02
-(PID.TID 0000.0001) %MON forcing_fu_del2              =   6.7089303097274E-04
-(PID.TID 0000.0001) %MON forcing_fv_max               =   2.1188099441990E-01
-(PID.TID 0000.0001) %MON forcing_fv_min               =  -1.5384934530143E-01
-(PID.TID 0000.0001) %MON forcing_fv_mean              =  -5.2156651424292E-03
-(PID.TID 0000.0001) %MON forcing_fv_sd                =   4.4438930773077E-02
-(PID.TID 0000.0001) %MON forcing_fv_del2              =   3.6086418741975E-04
 (PID.TID 0000.0001) %MON trAdv_CFL_u_max              =   2.3175242540765E-02
 (PID.TID 0000.0001) %MON trAdv_CFL_v_max              =   1.3270508470032E-02
 (PID.TID 0000.0001) %MON trAdv_CFL_w_max              =   8.2666872176075E-02
@@ -4831,11 +2687,11 @@
 (PID.TID 0000.0001) // End MONITOR dynamic field statistics
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) %CHECKPOINT        20 ckptA
-  early fc =  0.000000000000000D+00
+(PID.TID 0000.0001)   early fc =  0.000000000000000D+00
  --> objf_test(bi,bj)   =  0.354115231360145D+06
  --> objf_test(bi,bj)   =  0.444589534075227D+06
-  local fc =  0.798704765435371D+06
- global fc =  0.798704765435371D+06
+(PID.TID 0000.0001)   local fc =  0.798704765435371D+06
+(PID.TID 0000.0001)  global fc =  0.798704765435371D+06
  cg2d: Sum(rhs),rhsMax =  -8.56203996590921E-13  9.34829007243764E+00
  cg2d: Sum(rhs),rhsMax =  -7.78044295657310E-13  9.12167905632681E+00
 (PID.TID 0000.0001) Did not write pickup because writePickupAtEnd = FALSE
@@ -4843,50 +2699,383 @@
  cg2d: Sum(rhs),rhsMax =  -7.78044295657310E-13  9.12167905632681E+00
 (PID.TID 0000.0001) Did not write pickup because writePickupAtEnd = FALSE
 (PID.TID 0000.0001) Did not write pickup because writePickupAtEnd = FALSE
+ Calling cg2d from S/R CG2D_SAD
  cg2d: Sum(rhs),rhsMax =   0.00000000000000E+00  0.00000000000000E+00
- cg2d: Sum(rhs),rhsMax =  -2.69229083471600E-15  6.76966537085450E-04
+ Calling cg2d from S/R CG2D_SAD
+ cg2d: Sum(rhs),rhsMax =  -2.80331313717852E-15  6.76966537085450E-04
+(PID.TID 0000.0001) // =======================================================
+(PID.TID 0000.0001) // Begin AD_MONITOR EXF statistics for iwhen =  3
+(PID.TID 0000.0001) // =======================================================
+(PID.TID 0000.0001) %MON ad_exf_tsnumber              =                    18
+(PID.TID 0000.0001) %MON ad_exf_time_sec              =   7.7760000000000E+05
+(PID.TID 0000.0001) %MON ad_exf_adfu_max              =   6.3182847616768E-01
+(PID.TID 0000.0001) %MON ad_exf_adfu_min              =  -7.5281673064656E-01
+(PID.TID 0000.0001) %MON ad_exf_adfu_mean             =  -4.9097966315425E-03
+(PID.TID 0000.0001) %MON ad_exf_adfu_sd               =   1.1692914176228E-01
+(PID.TID 0000.0001) %MON ad_exf_adfu_del2             =   4.1972096721568E-03
+(PID.TID 0000.0001) %MON ad_exf_adfv_max              =   1.1084348879120E+00
+(PID.TID 0000.0001) %MON ad_exf_adfv_min              =  -9.8089001545166E-01
+(PID.TID 0000.0001) %MON ad_exf_adfv_mean             =  -6.1359706426882E-02
+(PID.TID 0000.0001) %MON ad_exf_adfv_sd               =   3.3086988998551E-01
+(PID.TID 0000.0001) %MON ad_exf_adfv_del2             =   5.9237049657449E-03
+(PID.TID 0000.0001) %MON ad_exf_adqnet_max            =   1.8693608664056E-02
+(PID.TID 0000.0001) %MON ad_exf_adqnet_min            =  -2.5195411236209E-02
+(PID.TID 0000.0001) %MON ad_exf_adqnet_mean           =  -7.2821129026237E-03
+(PID.TID 0000.0001) %MON ad_exf_adqnet_sd             =   3.8815356478080E-03
+(PID.TID 0000.0001) %MON ad_exf_adqnet_del2           =   7.0614044792077E-05
+(PID.TID 0000.0001) %MON ad_exf_adempmr_max           =   1.5437556494358E+04
+(PID.TID 0000.0001) %MON ad_exf_adempmr_min           =  -8.6576794888601E+03
+(PID.TID 0000.0001) %MON ad_exf_adempmr_mean          =   2.3369358831067E+01
+(PID.TID 0000.0001) %MON ad_exf_adempmr_sd            =   4.9233411077345E+02
+(PID.TID 0000.0001) %MON ad_exf_adempmr_del2          =   3.2544340749426E+01
+(PID.TID 0000.0001) // =======================================================
+(PID.TID 0000.0001) // End AD_MONITOR EXF statistics for iwhen =  3
+(PID.TID 0000.0001) // =======================================================
+(PID.TID 0000.0001) // =======================================================
+(PID.TID 0000.0001) // Begin AD_MONITOR EXF statistics for iwhen =  1
+(PID.TID 0000.0001) // =======================================================
+(PID.TID 0000.0001) %MON ad_exf_tsnumber              =                    18
+(PID.TID 0000.0001) %MON ad_exf_time_sec              =   7.7760000000000E+05
+(PID.TID 0000.0001) %MON ad_exf_adustress_max         =   4.9523245941170E-01
+(PID.TID 0000.0001) %MON ad_exf_adustress_min         =  -6.0226009196363E-01
+(PID.TID 0000.0001) %MON ad_exf_adustress_mean        =  -5.2847824865677E-03
+(PID.TID 0000.0001) %MON ad_exf_adustress_sd          =   9.8993701163881E-02
+(PID.TID 0000.0001) %MON ad_exf_adustress_del2        =   2.6012927473511E-03
+(PID.TID 0000.0001) %MON ad_exf_advstress_max         =   8.0451080880935E-01
+(PID.TID 0000.0001) %MON ad_exf_advstress_min         =  -9.0463339243562E-01
+(PID.TID 0000.0001) %MON ad_exf_advstress_mean        =  -5.6048104594660E-02
+(PID.TID 0000.0001) %MON ad_exf_advstress_sd          =   3.1263554068441E-01
+(PID.TID 0000.0001) %MON ad_exf_advstress_del2        =   3.7251611193295E-03
+(PID.TID 0000.0001) %MON ad_exf_adhflux_max           =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON ad_exf_adhflux_min           =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON ad_exf_adhflux_mean          =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON ad_exf_adhflux_sd            =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON ad_exf_adhflux_del2          =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON ad_exf_adsflux_max           =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON ad_exf_adsflux_min           =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON ad_exf_adsflux_mean          =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON ad_exf_adsflux_sd            =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON ad_exf_adsflux_del2          =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON ad_exf_adwspeed_max          =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON ad_exf_adwspeed_min          =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON ad_exf_adwspeed_mean         =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON ad_exf_adwspeed_sd           =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON ad_exf_adwspeed_del2         =   0.0000000000000E+00
+(PID.TID 0000.0001) // =======================================================
+(PID.TID 0000.0001) // End AD_MONITOR EXF statistics for iwhen =  1
+(PID.TID 0000.0001) // =======================================================
+(PID.TID 0000.0001) // =======================================================
+(PID.TID 0000.0001) // Begin AD_MONITOR EXF statistics for iwhen =  2
+(PID.TID 0000.0001) // =======================================================
+(PID.TID 0000.0001) %MON ad_exf_tsnumber              =                    18
+(PID.TID 0000.0001) %MON ad_exf_time_sec              =   7.7760000000000E+05
+(PID.TID 0000.0001) // =======================================================
+(PID.TID 0000.0001) // End AD_MONITOR EXF statistics for iwhen =  2
+(PID.TID 0000.0001) // =======================================================
  cg2d: Sum(rhs),rhsMax =  -8.44657677134819E-13  8.31754379147366E+00
  cg2d: Sum(rhs),rhsMax =  -7.49622586226906E-13  8.97048397340147E+00
  cg2d: Sum(rhs),rhsMax =  -8.29558643999917E-13  9.43480072446720E+00
  cg2d: Sum(rhs),rhsMax =  -7.76267938817909E-13  9.69891950271935E+00
  cg2d: Sum(rhs),rhsMax =  -5.09814412907872E-13  9.76269586763470E+00
  cg2d: Sum(rhs),rhsMax =  -7.60280727263307E-13  9.63804624662821E+00
- cg2d: Sum(rhs),rhsMax =   8.07132138902489E-14  1.12800176292508E-03
- cg2d: Sum(rhs),rhsMax =   1.78940195993960E-13  1.19230209700089E-03
+ cg2d: Sum(rhs),rhsMax =  -5.09814412907872E-13  9.76269586763470E+00
+ cg2d: Sum(rhs),rhsMax =  -7.60280727263307E-13  9.63804624662821E+00
+(PID.TID 0000.0001) // =======================================================
+(PID.TID 0000.0001) // Begin AD_MONITOR dynamic field statistics
+(PID.TID 0000.0001) // =======================================================
+(PID.TID 0000.0001) %MON ad_time_tsnumber             =                    18
+(PID.TID 0000.0001) %MON ad_time_secondsf             =   7.7760000000000E+05
+(PID.TID 0000.0001) %MON ad_dynstat_adeta_max         =   5.5611560230866E+01
+(PID.TID 0000.0001) %MON ad_dynstat_adeta_min         =  -1.9067315543213E+01
+(PID.TID 0000.0001) %MON ad_dynstat_adeta_mean        =   7.1587356262354E-02
+(PID.TID 0000.0001) %MON ad_dynstat_adeta_sd          =   6.1711284431743E+00
+(PID.TID 0000.0001) %MON ad_dynstat_adeta_del2        =   2.5009857692566E-01
+(PID.TID 0000.0001) %MON ad_dynstat_aduvel_max        =   5.9801533332417E+01
+(PID.TID 0000.0001) %MON ad_dynstat_aduvel_min        =  -7.5893524111402E+01
+(PID.TID 0000.0001) %MON ad_dynstat_aduvel_mean       =  -1.4728167379921E+00
+(PID.TID 0000.0001) %MON ad_dynstat_aduvel_sd         =   9.8090994620371E+00
+(PID.TID 0000.0001) %MON ad_dynstat_aduvel_del2       =   5.8494033240244E-02
+(PID.TID 0000.0001) %MON ad_dynstat_advvel_max        =   1.5193849838308E+02
+(PID.TID 0000.0001) %MON ad_dynstat_advvel_min        =  -1.4565694438304E+02
+(PID.TID 0000.0001) %MON ad_dynstat_advvel_mean       =  -1.1928655420993E+00
+(PID.TID 0000.0001) %MON ad_dynstat_advvel_sd         =   2.4736448871136E+01
+(PID.TID 0000.0001) %MON ad_dynstat_advvel_del2       =   1.3216270749287E-01
+(PID.TID 0000.0001) %MON ad_dynstat_adwvel_max        =   4.7750224482247E+04
+(PID.TID 0000.0001) %MON ad_dynstat_adwvel_min        =  -2.2596237627005E+05
+(PID.TID 0000.0001) %MON ad_dynstat_adwvel_mean       =  -7.7527431893141E+02
+(PID.TID 0000.0001) %MON ad_dynstat_adwvel_sd         =   8.3346256188021E+03
+(PID.TID 0000.0001) %MON ad_dynstat_adwvel_del2       =   4.1985876441056E+01
+(PID.TID 0000.0001) %MON ad_dynstat_adtheta_max       =   2.2864327422312E+02
+(PID.TID 0000.0001) %MON ad_dynstat_adtheta_min       =  -1.9840062446905E+02
+(PID.TID 0000.0001) %MON ad_dynstat_adtheta_mean      =   4.7235501513783E-01
+(PID.TID 0000.0001) %MON ad_dynstat_adtheta_sd        =   4.7445313453760E+00
+(PID.TID 0000.0001) %MON ad_dynstat_adtheta_del2      =   6.4844289927343E-02
+(PID.TID 0000.0001) %MON ad_dynstat_adsalt_max        =   7.8892054061718E+02
+(PID.TID 0000.0001) %MON ad_dynstat_adsalt_min        =  -8.0500698112699E+02
+(PID.TID 0000.0001) %MON ad_dynstat_adsalt_mean       =   2.3847583057498E-02
+(PID.TID 0000.0001) %MON ad_dynstat_adsalt_sd         =   5.2287288656231E+00
+(PID.TID 0000.0001) %MON ad_dynstat_adsalt_del2       =   2.1938078175498E-01
+(PID.TID 0000.0001) // =======================================================
+(PID.TID 0000.0001) // End AD_MONITOR dynamic field statistics
+(PID.TID 0000.0001) // =======================================================
+ Calling cg2d from S/R CG2D_SAD
+ cg2d: Sum(rhs),rhsMax =   7.87148124459236E-14  1.12800176292508E-03
+ Calling cg2d from S/R CG2D_SAD
+ cg2d: Sum(rhs),rhsMax =   1.94289029309402E-13  1.19230209700089E-03
  cg2d: Sum(rhs),rhsMax =  -8.29558643999917E-13  9.43480072446720E+00
  cg2d: Sum(rhs),rhsMax =  -7.76267938817909E-13  9.69891950271935E+00
- cg2d: Sum(rhs),rhsMax =   4.13225009765483E-13  1.12069397365533E-03
- cg2d: Sum(rhs),rhsMax =   4.74509320724792E-13  1.06839092629844E-03
+ Calling cg2d from S/R CG2D_SAD
+ cg2d: Sum(rhs),rhsMax =   4.28546087505310E-13  1.12069397365533E-03
+ Calling cg2d from S/R CG2D_SAD
+ cg2d: Sum(rhs),rhsMax =   4.86610751693206E-13  1.06839092629844E-03
  cg2d: Sum(rhs),rhsMax =  -8.44657677134819E-13  8.31754379147366E+00
  cg2d: Sum(rhs),rhsMax =  -7.49622586226906E-13  8.97048397340147E+00
- cg2d: Sum(rhs),rhsMax =   4.74620343027254E-13  1.04899306102913E-03
- cg2d: Sum(rhs),rhsMax =   5.94635451989234E-13  1.01928705835677E-03
+ Calling cg2d from S/R CG2D_SAD
+ cg2d: Sum(rhs),rhsMax =   5.36348743196413E-13  1.04899306102913E-03
+ Calling cg2d from S/R CG2D_SAD
+ cg2d: Sum(rhs),rhsMax =   6.03295191581310E-13  1.01928705835677E-03
+(PID.TID 0000.0001) // =======================================================
+(PID.TID 0000.0001) // Begin AD_MONITOR EXF statistics for iwhen =  3
+(PID.TID 0000.0001) // =======================================================
+(PID.TID 0000.0001) %MON ad_exf_tsnumber              =                    12
+(PID.TID 0000.0001) %MON ad_exf_time_sec              =   5.1840000000000E+05
+(PID.TID 0000.0001) %MON ad_exf_adfu_max              =   1.7002111151767E+00
+(PID.TID 0000.0001) %MON ad_exf_adfu_min              =  -2.3276244444537E+00
+(PID.TID 0000.0001) %MON ad_exf_adfu_mean             =  -2.0138302474450E-01
+(PID.TID 0000.0001) %MON ad_exf_adfu_sd               =   4.2574895847810E-01
+(PID.TID 0000.0001) %MON ad_exf_adfu_del2             =   1.1792683520050E-02
+(PID.TID 0000.0001) %MON ad_exf_adfv_max              =   2.1337891927380E+00
+(PID.TID 0000.0001) %MON ad_exf_adfv_min              =  -2.7958423975081E+00
+(PID.TID 0000.0001) %MON ad_exf_adfv_mean             =  -1.7638256597599E-01
+(PID.TID 0000.0001) %MON ad_exf_adfv_sd               =   9.0394139669387E-01
+(PID.TID 0000.0001) %MON ad_exf_adfv_del2             =   1.6843527043875E-02
+(PID.TID 0000.0001) %MON ad_exf_adqnet_max            =   8.7592036218591E-02
+(PID.TID 0000.0001) %MON ad_exf_adqnet_min            =  -1.4775837088883E-01
+(PID.TID 0000.0001) %MON ad_exf_adqnet_mean           =  -6.8899694299591E-03
+(PID.TID 0000.0001) %MON ad_exf_adqnet_sd             =   5.2675010731207E-03
+(PID.TID 0000.0001) %MON ad_exf_adqnet_del2           =   2.9508710424486E-04
+(PID.TID 0000.0001) %MON ad_exf_adempmr_max           =   5.7172806054019E+04
+(PID.TID 0000.0001) %MON ad_exf_adempmr_min           =  -7.6457060987036E+04
+(PID.TID 0000.0001) %MON ad_exf_adempmr_mean          =  -1.9259732537393E+01
+(PID.TID 0000.0001) %MON ad_exf_adempmr_sd            =   2.1290894406129E+03
+(PID.TID 0000.0001) %MON ad_exf_adempmr_del2          =   1.5843652426480E+02
+(PID.TID 0000.0001) // =======================================================
+(PID.TID 0000.0001) // End AD_MONITOR EXF statistics for iwhen =  3
+(PID.TID 0000.0001) // =======================================================
+(PID.TID 0000.0001) // =======================================================
+(PID.TID 0000.0001) // Begin AD_MONITOR EXF statistics for iwhen =  1
+(PID.TID 0000.0001) // =======================================================
+(PID.TID 0000.0001) %MON ad_exf_tsnumber              =                    12
+(PID.TID 0000.0001) %MON ad_exf_time_sec              =   5.1840000000000E+05
+(PID.TID 0000.0001) %MON ad_exf_adustress_max         =   1.2909079597558E+00
+(PID.TID 0000.0001) %MON ad_exf_adustress_min         =  -2.0681017258799E+00
+(PID.TID 0000.0001) %MON ad_exf_adustress_mean        =  -2.0285219477519E-01
+(PID.TID 0000.0001) %MON ad_exf_adustress_sd          =   3.8913860078546E-01
+(PID.TID 0000.0001) %MON ad_exf_adustress_del2        =   7.5952194229265E-03
+(PID.TID 0000.0001) %MON ad_exf_advstress_max         =   1.9231307585049E+00
+(PID.TID 0000.0001) %MON ad_exf_advstress_min         =  -2.4855484905225E+00
+(PID.TID 0000.0001) %MON ad_exf_advstress_mean        =  -1.6272912479704E-01
+(PID.TID 0000.0001) %MON ad_exf_advstress_sd          =   8.5290899247097E-01
+(PID.TID 0000.0001) %MON ad_exf_advstress_del2        =   1.0358976257488E-02
+(PID.TID 0000.0001) %MON ad_exf_adhflux_max           =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON ad_exf_adhflux_min           =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON ad_exf_adhflux_mean          =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON ad_exf_adhflux_sd            =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON ad_exf_adhflux_del2          =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON ad_exf_adsflux_max           =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON ad_exf_adsflux_min           =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON ad_exf_adsflux_mean          =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON ad_exf_adsflux_sd            =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON ad_exf_adsflux_del2          =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON ad_exf_adwspeed_max          =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON ad_exf_adwspeed_min          =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON ad_exf_adwspeed_mean         =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON ad_exf_adwspeed_sd           =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON ad_exf_adwspeed_del2         =   0.0000000000000E+00
+(PID.TID 0000.0001) // =======================================================
+(PID.TID 0000.0001) // End AD_MONITOR EXF statistics for iwhen =  1
+(PID.TID 0000.0001) // =======================================================
+(PID.TID 0000.0001) // =======================================================
+(PID.TID 0000.0001) // Begin AD_MONITOR EXF statistics for iwhen =  2
+(PID.TID 0000.0001) // =======================================================
+(PID.TID 0000.0001) %MON ad_exf_tsnumber              =                    12
+(PID.TID 0000.0001) %MON ad_exf_time_sec              =   5.1840000000000E+05
+(PID.TID 0000.0001) // =======================================================
+(PID.TID 0000.0001) // End AD_MONITOR EXF statistics for iwhen =  2
+(PID.TID 0000.0001) // =======================================================
  cg2d: Sum(rhs),rhsMax =  -4.99600361081320E-14  7.14243599153802E+00
  cg2d: Sum(rhs),rhsMax =  -4.26325641456060E-14  7.72291365607133E+00
  cg2d: Sum(rhs),rhsMax =  -7.90478793533111E-14  8.03387068208590E+00
  cg2d: Sum(rhs),rhsMax =  -3.04645197957143E-13  8.11896831221745E+00
  cg2d: Sum(rhs),rhsMax =  -3.65929508916452E-13  8.04727754553643E+00
  cg2d: Sum(rhs),rhsMax =  -6.36823926924990E-13  7.88895797898159E+00
- cg2d: Sum(rhs),rhsMax =   6.39488462184090E-13  9.85320725523901E-04
- cg2d: Sum(rhs),rhsMax =   6.81010803305071E-13  1.00868528908259E-03
+ cg2d: Sum(rhs),rhsMax =  -3.65929508916452E-13  8.04727754553643E+00
+ cg2d: Sum(rhs),rhsMax =  -6.36823926924990E-13  7.88895797898159E+00
+(PID.TID 0000.0001) // =======================================================
+(PID.TID 0000.0001) // Begin AD_MONITOR dynamic field statistics
+(PID.TID 0000.0001) // =======================================================
+(PID.TID 0000.0001) %MON ad_time_tsnumber             =                    12
+(PID.TID 0000.0001) %MON ad_time_secondsf             =   5.1840000000000E+05
+(PID.TID 0000.0001) %MON ad_dynstat_adeta_max         =   1.1145925571437E+02
+(PID.TID 0000.0001) %MON ad_dynstat_adeta_min         =  -7.2935139782744E+01
+(PID.TID 0000.0001) %MON ad_dynstat_adeta_mean        =   1.1320285340389E+00
+(PID.TID 0000.0001) %MON ad_dynstat_adeta_sd          =   2.2825220425312E+01
+(PID.TID 0000.0001) %MON ad_dynstat_adeta_del2        =   3.2314573763981E-01
+(PID.TID 0000.0001) %MON ad_dynstat_aduvel_max        =   7.7545864656475E+01
+(PID.TID 0000.0001) %MON ad_dynstat_aduvel_min        =  -1.5589331922963E+02
+(PID.TID 0000.0001) %MON ad_dynstat_aduvel_mean       =  -5.4417455010059E+00
+(PID.TID 0000.0001) %MON ad_dynstat_aduvel_sd         =   1.9783914975294E+01
+(PID.TID 0000.0001) %MON ad_dynstat_aduvel_del2       =   6.1685081337721E-02
+(PID.TID 0000.0001) %MON ad_dynstat_advvel_max        =   1.4578411770896E+02
+(PID.TID 0000.0001) %MON ad_dynstat_advvel_min        =  -1.3337286267997E+02
+(PID.TID 0000.0001) %MON ad_dynstat_advvel_mean       =  -2.6226895756593E+00
+(PID.TID 0000.0001) %MON ad_dynstat_advvel_sd         =   3.4192045453379E+01
+(PID.TID 0000.0001) %MON ad_dynstat_advvel_del2       =   1.0435763037548E-01
+(PID.TID 0000.0001) %MON ad_dynstat_adwvel_max        =   1.3126595073737E+05
+(PID.TID 0000.0001) %MON ad_dynstat_adwvel_min        =  -2.0119638113819E+05
+(PID.TID 0000.0001) %MON ad_dynstat_adwvel_mean       =  -7.3370596724115E+02
+(PID.TID 0000.0001) %MON ad_dynstat_adwvel_sd         =   7.6227256925042E+03
+(PID.TID 0000.0001) %MON ad_dynstat_adwvel_del2       =   4.0857955687246E+01
+(PID.TID 0000.0001) %MON ad_dynstat_adtheta_max       =   8.3140228195078E+02
+(PID.TID 0000.0001) %MON ad_dynstat_adtheta_min       =  -7.9061076581129E+02
+(PID.TID 0000.0001) %MON ad_dynstat_adtheta_mean      =   4.2872314808084E-01
+(PID.TID 0000.0001) %MON ad_dynstat_adtheta_sd        =   5.5469763379498E+00
+(PID.TID 0000.0001) %MON ad_dynstat_adtheta_del2      =   1.6500294331239E-01
+(PID.TID 0000.0001) %MON ad_dynstat_adsalt_max        =   2.9473372909205E+03
+(PID.TID 0000.0001) %MON ad_dynstat_adsalt_min        =  -3.0338027352097E+03
+(PID.TID 0000.0001) %MON ad_dynstat_adsalt_mean       =   1.4198446413120E-01
+(PID.TID 0000.0001) %MON ad_dynstat_adsalt_sd         =   1.4170334901642E+01
+(PID.TID 0000.0001) %MON ad_dynstat_adsalt_del2       =   6.3857573720501E-01
+(PID.TID 0000.0001) // =======================================================
+(PID.TID 0000.0001) // End AD_MONITOR dynamic field statistics
+(PID.TID 0000.0001) // =======================================================
+ Calling cg2d from S/R CG2D_SAD
+ cg2d: Sum(rhs),rhsMax =   6.26165785888588E-13  9.85320725523902E-04
+ Calling cg2d from S/R CG2D_SAD
+ cg2d: Sum(rhs),rhsMax =   7.22533144426052E-13  1.00868528908259E-03
  cg2d: Sum(rhs),rhsMax =  -7.90478793533111E-14  8.03387068208590E+00
  cg2d: Sum(rhs),rhsMax =  -3.04645197957143E-13  8.11896831221745E+00
- cg2d: Sum(rhs),rhsMax =   7.81152920126260E-13  1.01831017062021E-03
- cg2d: Sum(rhs),rhsMax =   8.51319015282570E-13  1.01730137453669E-03
+ Calling cg2d from S/R CG2D_SAD
+ cg2d: Sum(rhs),rhsMax =   7.54063478325406E-13  1.01831017062021E-03
+ Calling cg2d from S/R CG2D_SAD
+ cg2d: Sum(rhs),rhsMax =   8.53095372121970E-13  1.01730137453669E-03
  cg2d: Sum(rhs),rhsMax =  -4.99600361081320E-14  7.14243599153802E+00
  cg2d: Sum(rhs),rhsMax =  -4.26325641456060E-14  7.72291365607133E+00
- cg2d: Sum(rhs),rhsMax =   9.50794998288984E-13  1.01053671002043E-03
- cg2d: Sum(rhs),rhsMax =   1.10622622173651E-12  1.00342273311352E-03
-(PID.TID 0000.0001)  EXF_SET_GEN: it=         0 loading rec=    12 from: lev_sst.bin
-(PID.TID 0000.0001)  EXF_SET_GEN: it=         0 loading rec=     1 from: lev_sst.bin
-(PID.TID 0000.0001)  EXF_SET_GEN: it=         0 loading rec=    12 from: lev_sss.bin
-(PID.TID 0000.0001)  EXF_SET_GEN: it=         0 loading rec=     1 from: lev_sss.bin
-(PID.TID 0000.0001)  EXF_SET_GEN: it=         0 loading rec=    12 from: trenberth_taux.bin
-(PID.TID 0000.0001)  EXF_SET_GEN: it=         0 loading rec=     1 from: trenberth_taux.bin
-(PID.TID 0000.0001)  EXF_SET_GEN: it=         0 loading rec=    12 from: trenberth_tauy.bin
-(PID.TID 0000.0001)  EXF_SET_GEN: it=         0 loading rec=     1 from: trenberth_tauy.bin
-(PID.TID 0000.0001)  EXF_SET_GEN: it=         0 loading rec=    12 from: ncep_qnet.bin
-(PID.TID 0000.0001)  EXF_SET_GEN: it=         0 loading rec=     1 from: ncep_qnet.bin
+ Calling cg2d from S/R CG2D_SAD
+ cg2d: Sum(rhs),rhsMax =   1.00097707900204E-12  1.01053671002043E-03
+ Calling cg2d from S/R CG2D_SAD
+ cg2d: Sum(rhs),rhsMax =   1.16040510533821E-12  1.00342273311352E-03
+(PID.TID 0000.0001) // =======================================================
+(PID.TID 0000.0001) // Begin AD_MONITOR EXF statistics for iwhen =  3
+(PID.TID 0000.0001) // =======================================================
+(PID.TID 0000.0001) %MON ad_exf_tsnumber              =                     6
+(PID.TID 0000.0001) %MON ad_exf_time_sec              =   2.5920000000000E+05
+(PID.TID 0000.0001) %MON ad_exf_adfu_max              =   2.6118716985292E+00
+(PID.TID 0000.0001) %MON ad_exf_adfu_min              =  -3.5633383291876E+00
+(PID.TID 0000.0001) %MON ad_exf_adfu_mean             =  -5.2055585635097E-01
+(PID.TID 0000.0001) %MON ad_exf_adfu_sd               =   8.2191330440785E-01
+(PID.TID 0000.0001) %MON ad_exf_adfu_del2             =   1.7055725822053E-02
+(PID.TID 0000.0001) %MON ad_exf_adfv_max              =   3.3401411988339E+00
+(PID.TID 0000.0001) %MON ad_exf_adfv_min              =  -3.8422330822069E+00
+(PID.TID 0000.0001) %MON ad_exf_adfv_mean             =  -1.9614336431363E-01
+(PID.TID 0000.0001) %MON ad_exf_adfv_sd               =   1.2329524666891E+00
+(PID.TID 0000.0001) %MON ad_exf_adfv_del2             =   2.3682224464942E-02
+(PID.TID 0000.0001) %MON ad_exf_adqnet_max            =   5.6740276414860E-03
+(PID.TID 0000.0001) %MON ad_exf_adqnet_min            =  -1.1393930627606E-01
+(PID.TID 0000.0001) %MON ad_exf_adqnet_mean           =  -6.3700459704863E-03
+(PID.TID 0000.0001) %MON ad_exf_adqnet_sd             =   3.7894456223014E-03
+(PID.TID 0000.0001) %MON ad_exf_adqnet_del2           =   1.7829903299533E-04
+(PID.TID 0000.0001) %MON ad_exf_adempmr_max           =   4.2132164787598E+03
+(PID.TID 0000.0001) %MON ad_exf_adempmr_min           =  -7.7284579821215E+04
+(PID.TID 0000.0001) %MON ad_exf_adempmr_mean          =  -2.5621178603330E+01
+(PID.TID 0000.0001) %MON ad_exf_adempmr_sd            =   1.5144166737932E+03
+(PID.TID 0000.0001) %MON ad_exf_adempmr_del2          =   1.1867742922499E+02
+(PID.TID 0000.0001) // =======================================================
+(PID.TID 0000.0001) // End AD_MONITOR EXF statistics for iwhen =  3
+(PID.TID 0000.0001) // =======================================================
+(PID.TID 0000.0001) // =======================================================
+(PID.TID 0000.0001) // Begin AD_MONITOR EXF statistics for iwhen =  1
+(PID.TID 0000.0001) // =======================================================
+(PID.TID 0000.0001) %MON ad_exf_tsnumber              =                     6
+(PID.TID 0000.0001) %MON ad_exf_time_sec              =   2.5920000000000E+05
+(PID.TID 0000.0001) %MON ad_exf_adustress_max         =   2.0244331313762E+00
+(PID.TID 0000.0001) %MON ad_exf_adustress_min         =  -3.4402404038615E+00
+(PID.TID 0000.0001) %MON ad_exf_adustress_mean        =  -5.2298038298803E-01
+(PID.TID 0000.0001) %MON ad_exf_adustress_sd          =   7.8166892184559E-01
+(PID.TID 0000.0001) %MON ad_exf_adustress_del2        =   1.1900999495416E-02
+(PID.TID 0000.0001) %MON ad_exf_advstress_max         =   2.8293475179217E+00
+(PID.TID 0000.0001) %MON ad_exf_advstress_min         =  -3.3052640079750E+00
+(PID.TID 0000.0001) %MON ad_exf_advstress_mean        =  -1.8028825044500E-01
+(PID.TID 0000.0001) %MON ad_exf_advstress_sd          =   1.1601263475306E+00
+(PID.TID 0000.0001) %MON ad_exf_advstress_del2        =   1.4454317712746E-02
+(PID.TID 0000.0001) %MON ad_exf_adhflux_max           =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON ad_exf_adhflux_min           =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON ad_exf_adhflux_mean          =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON ad_exf_adhflux_sd            =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON ad_exf_adhflux_del2          =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON ad_exf_adsflux_max           =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON ad_exf_adsflux_min           =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON ad_exf_adsflux_mean          =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON ad_exf_adsflux_sd            =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON ad_exf_adsflux_del2          =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON ad_exf_adwspeed_max          =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON ad_exf_adwspeed_min          =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON ad_exf_adwspeed_mean         =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON ad_exf_adwspeed_sd           =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON ad_exf_adwspeed_del2         =   0.0000000000000E+00
+(PID.TID 0000.0001) // =======================================================
+(PID.TID 0000.0001) // End AD_MONITOR EXF statistics for iwhen =  1
+(PID.TID 0000.0001) // =======================================================
+(PID.TID 0000.0001) // =======================================================
+(PID.TID 0000.0001) // Begin AD_MONITOR EXF statistics for iwhen =  2
+(PID.TID 0000.0001) // =======================================================
+(PID.TID 0000.0001) %MON ad_exf_tsnumber              =                     6
+(PID.TID 0000.0001) %MON ad_exf_time_sec              =   2.5920000000000E+05
+(PID.TID 0000.0001) // =======================================================
+(PID.TID 0000.0001) // End AD_MONITOR EXF statistics for iwhen =  2
+(PID.TID 0000.0001) // =======================================================
+(PID.TID 0000.0001) EXF_SET_FLD: field "climsst", it=         0, loading rec=    12
+(PID.TID 0000.0001) EXF_SET_FLD:   from file: "lev_sst.bin"
+(PID.TID 0000.0001)  EXF_INTERP: file="lev_sst.bin", rec=    12 , x-Per,P.Sym=    T    T
+(PID.TID 0000.0001)  S.edge (j=-1,0,1) : proc= 0.0 0.0 0.0, yIn=  -86.000000  -82.000000  -78.000000
+(PID.TID 0000.0001)  N.edge (j=+0,+1,+2) proc= 0.0 0.0 0.0, yIn=   78.000000   82.000000   86.000000
+(PID.TID 0000.0001) EXF_SET_FLD: field "climsst", it=         0, loading rec=     1
+(PID.TID 0000.0001) EXF_SET_FLD:   from file: "lev_sst.bin"
+(PID.TID 0000.0001)  EXF_INTERP: file="lev_sst.bin", rec=     1 , x-Per,P.Sym=    T    T
+(PID.TID 0000.0001)  S.edge (j=-1,0,1) : proc= 0.0 0.0 0.0, yIn=  -86.000000  -82.000000  -78.000000
+(PID.TID 0000.0001)  N.edge (j=+0,+1,+2) proc= 0.0 0.0 0.0, yIn=   78.000000   82.000000   86.000000
+(PID.TID 0000.0001) EXF_SET_FLD: field "climsss", it=         0, loading rec=    12
+(PID.TID 0000.0001) EXF_SET_FLD:   from file: "lev_sss.bin"
+(PID.TID 0000.0001)  EXF_INTERP: file="lev_sss.bin", rec=    12 , x-Per,P.Sym=    T    T
+(PID.TID 0000.0001)  S.edge (j=-1,0,1) : proc= 0.0 0.0 0.0, yIn=  -86.000000  -82.000000  -78.000000
+(PID.TID 0000.0001)  N.edge (j=+0,+1,+2) proc= 0.0 0.0 0.0, yIn=   78.000000   82.000000   86.000000
+(PID.TID 0000.0001) EXF_SET_FLD: field "climsss", it=         0, loading rec=     1
+(PID.TID 0000.0001) EXF_SET_FLD:   from file: "lev_sss.bin"
+(PID.TID 0000.0001)  EXF_INTERP: file="lev_sss.bin", rec=     1 , x-Per,P.Sym=    T    T
+(PID.TID 0000.0001)  S.edge (j=-1,0,1) : proc= 0.0 0.0 0.0, yIn=  -86.000000  -82.000000  -78.000000
+(PID.TID 0000.0001)  N.edge (j=+0,+1,+2) proc= 0.0 0.0 0.0, yIn=   78.000000   82.000000   86.000000
+(PID.TID 0000.0001) EXF_SET_UV: fields "ustress" & "vstress", it=         0
+(PID.TID 0000.0001) EXF_SET_UV:   loading rec=    12 from file: "trenberth_taux.bin"
+(PID.TID 0000.0001) EXF_SET_UV:   loading rec=    12 from file: "trenberth_tauy.bin"
+(PID.TID 0000.0001)  EXF_INTERP_UV: fileU="trenberth_taux.bin", rec=    12 , x-Per,P.Sym=    T    T
+(PID.TID 0000.0001)  S.edge (j=-1,0,1) : proc= 0.0 0.0 0.0, yIn=  -86.000000  -82.000000  -78.000000
+(PID.TID 0000.0001)  N.edge (j=+0,+1,+2) proc= 0.0 0.0 0.0, yIn=   78.000000   82.000000   86.000000
+(PID.TID 0000.0001) EXF_SET_UV: fields "ustress" & "vstress", it=         0
+(PID.TID 0000.0001) EXF_SET_UV:   loading rec=     1 from file: "trenberth_taux.bin"
+(PID.TID 0000.0001) EXF_SET_UV:   loading rec=     1 from file: "trenberth_tauy.bin"
+(PID.TID 0000.0001)  EXF_INTERP_UV: fileU="trenberth_taux.bin", rec=     1 , x-Per,P.Sym=    T    T
+(PID.TID 0000.0001)  S.edge (j=-1,0,1) : proc= 0.0 0.0 0.0, yIn=  -86.000000  -82.000000  -78.000000
+(PID.TID 0000.0001)  N.edge (j=+0,+1,+2) proc= 0.0 0.0 0.0, yIn=   78.000000   82.000000   86.000000
+(PID.TID 0000.0001) EXF_SET_FLD: field "hflux", it=         0, loading rec=    12
+(PID.TID 0000.0001) EXF_SET_FLD:   from file: "ncep_qnet.bin"
+(PID.TID 0000.0001)  EXF_INTERP: file="ncep_qnet.bin", rec=    12 , x-Per,P.Sym=    T    T
+(PID.TID 0000.0001)  S.edge (j=-1,0,1) : proc= 0.0 0.0 0.0, yIn=  -86.000000  -82.000000  -78.000000
+(PID.TID 0000.0001)  N.edge (j=+0,+1,+2) proc= 0.0 0.0 0.0, yIn=   78.000000   82.000000   86.000000
+(PID.TID 0000.0001) EXF_SET_FLD: field "hflux", it=         0, loading rec=     1
+(PID.TID 0000.0001) EXF_SET_FLD:   from file: "ncep_qnet.bin"
+(PID.TID 0000.0001)  EXF_INTERP: file="ncep_qnet.bin", rec=     1 , x-Per,P.Sym=    T    T
+(PID.TID 0000.0001)  S.edge (j=-1,0,1) : proc= 0.0 0.0 0.0, yIn=  -86.000000  -82.000000  -78.000000
+(PID.TID 0000.0001)  N.edge (j=+0,+1,+2) proc= 0.0 0.0 0.0, yIn=   78.000000   82.000000   86.000000
 (PID.TID 0000.0001) SOLVE_FOR_PRESSURE: putPmEinXvector =    F
  cg2d: Sum(rhs),rhsMax =  -2.77555756156289E-16  2.53662338005399E+00
  cg2d: Sum(rhs),rhsMax =   3.80251385934116E-14  5.04305351695056E+00
@@ -4894,30 +3083,215 @@
  cg2d: Sum(rhs),rhsMax =   1.00336405850499E-13  6.70007859133559E+00
  cg2d: Sum(rhs),rhsMax =   5.93969318174459E-14  6.82703161607703E+00
  cg2d: Sum(rhs),rhsMax =  -3.24185123190546E-14  6.85801094466119E+00
- cg2d: Sum(rhs),rhsMax =   1.26521015886283E-12  1.00012240906901E-03
- cg2d: Sum(rhs),rhsMax =   1.37312383685639E-12  1.00294944830281E-03
+ cg2d: Sum(rhs),rhsMax =   5.93969318174459E-14  6.82703161607703E+00
+ cg2d: Sum(rhs),rhsMax =  -3.24185123190546E-14  6.85801094466119E+00
+(PID.TID 0000.0001) // =======================================================
+(PID.TID 0000.0001) // Begin AD_MONITOR dynamic field statistics
+(PID.TID 0000.0001) // =======================================================
+(PID.TID 0000.0001) %MON ad_time_tsnumber             =                     6
+(PID.TID 0000.0001) %MON ad_time_secondsf             =   2.5920000000000E+05
+(PID.TID 0000.0001) %MON ad_dynstat_adeta_max         =   1.3393264949430E+02
+(PID.TID 0000.0001) %MON ad_dynstat_adeta_min         =  -7.7076010868855E+01
+(PID.TID 0000.0001) %MON ad_dynstat_adeta_mean        =   2.5202171920913E+00
+(PID.TID 0000.0001) %MON ad_dynstat_adeta_sd          =   2.7053188808563E+01
+(PID.TID 0000.0001) %MON ad_dynstat_adeta_del2        =   3.2192143448046E-01
+(PID.TID 0000.0001) %MON ad_dynstat_aduvel_max        =   1.1488966276125E+02
+(PID.TID 0000.0001) %MON ad_dynstat_aduvel_min        =  -1.4583717802199E+02
+(PID.TID 0000.0001) %MON ad_dynstat_aduvel_mean       =  -4.8656787269310E+00
+(PID.TID 0000.0001) %MON ad_dynstat_aduvel_sd         =   2.3638824849553E+01
+(PID.TID 0000.0001) %MON ad_dynstat_aduvel_del2       =   7.4693314374533E-02
+(PID.TID 0000.0001) %MON ad_dynstat_advvel_max        =   2.0335874036776E+02
+(PID.TID 0000.0001) %MON ad_dynstat_advvel_min        =  -1.5300227713514E+02
+(PID.TID 0000.0001) %MON ad_dynstat_advvel_mean       =   1.2729215032779E+00
+(PID.TID 0000.0001) %MON ad_dynstat_advvel_sd         =   3.2191073098968E+01
+(PID.TID 0000.0001) %MON ad_dynstat_advvel_del2       =   1.1674178298204E-01
+(PID.TID 0000.0001) %MON ad_dynstat_adwvel_max        =   7.4403888571290E+04
+(PID.TID 0000.0001) %MON ad_dynstat_adwvel_min        =  -1.9434789360049E+05
+(PID.TID 0000.0001) %MON ad_dynstat_adwvel_mean       =  -6.9681693310515E+02
+(PID.TID 0000.0001) %MON ad_dynstat_adwvel_sd         =   7.0686159887736E+03
+(PID.TID 0000.0001) %MON ad_dynstat_adwvel_del2       =   3.6850782722298E+01
+(PID.TID 0000.0001) %MON ad_dynstat_adtheta_max       =   3.7085269952041E+02
+(PID.TID 0000.0001) %MON ad_dynstat_adtheta_min       =  -3.6479985472189E+02
+(PID.TID 0000.0001) %MON ad_dynstat_adtheta_mean      =   3.8076171464461E-01
+(PID.TID 0000.0001) %MON ad_dynstat_adtheta_sd        =   4.2514704141872E+00
+(PID.TID 0000.0001) %MON ad_dynstat_adtheta_del2      =   6.5916024697812E-02
+(PID.TID 0000.0001) %MON ad_dynstat_adsalt_max        =   1.8250421943346E+03
+(PID.TID 0000.0001) %MON ad_dynstat_adsalt_min        =  -1.8042753489733E+03
+(PID.TID 0000.0001) %MON ad_dynstat_adsalt_mean       =   2.8840083401771E-01
+(PID.TID 0000.0001) %MON ad_dynstat_adsalt_sd         =   8.3198011406403E+00
+(PID.TID 0000.0001) %MON ad_dynstat_adsalt_del2       =   3.1257953228542E-01
+(PID.TID 0000.0001) // =======================================================
+(PID.TID 0000.0001) // End AD_MONITOR dynamic field statistics
+(PID.TID 0000.0001) // =======================================================
+ Calling cg2d from S/R CG2D_SAD
+ cg2d: Sum(rhs),rhsMax =   1.26476606965298E-12  1.00012240906901E-03
+ Calling cg2d from S/R CG2D_SAD
+ cg2d: Sum(rhs),rhsMax =   1.34425803821614E-12  1.00294944830281E-03
  cg2d: Sum(rhs),rhsMax =   7.50562806350885E-14  6.28993178193994E+00
  cg2d: Sum(rhs),rhsMax =   1.00336405850499E-13  6.70007859133559E+00
- cg2d: Sum(rhs),rhsMax =   1.52278190057586E-12  1.01232637639743E-03
- cg2d: Sum(rhs),rhsMax =   1.58317803311547E-12  1.02695457066718E-03
-(PID.TID 0000.0001)  EXF_SET_GEN: it=         0 loading rec=    12 from: lev_sst.bin
-(PID.TID 0000.0001)  EXF_SET_GEN: it=         0 loading rec=     1 from: lev_sst.bin
-(PID.TID 0000.0001)  EXF_SET_GEN: it=         0 loading rec=    12 from: lev_sss.bin
-(PID.TID 0000.0001)  EXF_SET_GEN: it=         0 loading rec=     1 from: lev_sss.bin
-(PID.TID 0000.0001)  EXF_SET_GEN: it=         0 loading rec=    12 from: trenberth_taux.bin
-(PID.TID 0000.0001)  EXF_SET_GEN: it=         0 loading rec=     1 from: trenberth_taux.bin
-(PID.TID 0000.0001)  EXF_SET_GEN: it=         0 loading rec=    12 from: trenberth_tauy.bin
-(PID.TID 0000.0001)  EXF_SET_GEN: it=         0 loading rec=     1 from: trenberth_tauy.bin
-(PID.TID 0000.0001)  EXF_SET_GEN: it=         0 loading rec=    12 from: ncep_qnet.bin
-(PID.TID 0000.0001)  EXF_SET_GEN: it=         0 loading rec=     1 from: ncep_qnet.bin
+ Calling cg2d from S/R CG2D_SAD
+ cg2d: Sum(rhs),rhsMax =   1.60538249360798E-12  1.01232637639743E-03
+ Calling cg2d from S/R CG2D_SAD
+ cg2d: Sum(rhs),rhsMax =   1.55520041289492E-12  1.02695457066718E-03
+(PID.TID 0000.0001) EXF_SET_FLD: field "climsst", it=         0, loading rec=    12
+(PID.TID 0000.0001) EXF_SET_FLD:   from file: "lev_sst.bin"
+(PID.TID 0000.0001)  EXF_INTERP: file="lev_sst.bin", rec=    12 , x-Per,P.Sym=    T    T
+(PID.TID 0000.0001)  S.edge (j=-1,0,1) : proc= 0.0 0.0 0.0, yIn=  -86.000000  -82.000000  -78.000000
+(PID.TID 0000.0001)  N.edge (j=+0,+1,+2) proc= 0.0 0.0 0.0, yIn=   78.000000   82.000000   86.000000
+(PID.TID 0000.0001) EXF_SET_FLD: field "climsst", it=         0, loading rec=     1
+(PID.TID 0000.0001) EXF_SET_FLD:   from file: "lev_sst.bin"
+(PID.TID 0000.0001)  EXF_INTERP: file="lev_sst.bin", rec=     1 , x-Per,P.Sym=    T    T
+(PID.TID 0000.0001)  S.edge (j=-1,0,1) : proc= 0.0 0.0 0.0, yIn=  -86.000000  -82.000000  -78.000000
+(PID.TID 0000.0001)  N.edge (j=+0,+1,+2) proc= 0.0 0.0 0.0, yIn=   78.000000   82.000000   86.000000
+(PID.TID 0000.0001) EXF_SET_FLD: field "climsss", it=         0, loading rec=    12
+(PID.TID 0000.0001) EXF_SET_FLD:   from file: "lev_sss.bin"
+(PID.TID 0000.0001)  EXF_INTERP: file="lev_sss.bin", rec=    12 , x-Per,P.Sym=    T    T
+(PID.TID 0000.0001)  S.edge (j=-1,0,1) : proc= 0.0 0.0 0.0, yIn=  -86.000000  -82.000000  -78.000000
+(PID.TID 0000.0001)  N.edge (j=+0,+1,+2) proc= 0.0 0.0 0.0, yIn=   78.000000   82.000000   86.000000
+(PID.TID 0000.0001) EXF_SET_FLD: field "climsss", it=         0, loading rec=     1
+(PID.TID 0000.0001) EXF_SET_FLD:   from file: "lev_sss.bin"
+(PID.TID 0000.0001)  EXF_INTERP: file="lev_sss.bin", rec=     1 , x-Per,P.Sym=    T    T
+(PID.TID 0000.0001)  S.edge (j=-1,0,1) : proc= 0.0 0.0 0.0, yIn=  -86.000000  -82.000000  -78.000000
+(PID.TID 0000.0001)  N.edge (j=+0,+1,+2) proc= 0.0 0.0 0.0, yIn=   78.000000   82.000000   86.000000
+(PID.TID 0000.0001) EXF_SET_UV: fields "ustress" & "vstress", it=         0
+(PID.TID 0000.0001) EXF_SET_UV:   loading rec=    12 from file: "trenberth_taux.bin"
+(PID.TID 0000.0001) EXF_SET_UV:   loading rec=    12 from file: "trenberth_tauy.bin"
+(PID.TID 0000.0001)  EXF_INTERP_UV: fileU="trenberth_taux.bin", rec=    12 , x-Per,P.Sym=    T    T
+(PID.TID 0000.0001)  S.edge (j=-1,0,1) : proc= 0.0 0.0 0.0, yIn=  -86.000000  -82.000000  -78.000000
+(PID.TID 0000.0001)  N.edge (j=+0,+1,+2) proc= 0.0 0.0 0.0, yIn=   78.000000   82.000000   86.000000
+(PID.TID 0000.0001) EXF_SET_UV: fields "ustress" & "vstress", it=         0
+(PID.TID 0000.0001) EXF_SET_UV:   loading rec=     1 from file: "trenberth_taux.bin"
+(PID.TID 0000.0001) EXF_SET_UV:   loading rec=     1 from file: "trenberth_tauy.bin"
+(PID.TID 0000.0001)  EXF_INTERP_UV: fileU="trenberth_taux.bin", rec=     1 , x-Per,P.Sym=    T    T
+(PID.TID 0000.0001)  S.edge (j=-1,0,1) : proc= 0.0 0.0 0.0, yIn=  -86.000000  -82.000000  -78.000000
+(PID.TID 0000.0001)  N.edge (j=+0,+1,+2) proc= 0.0 0.0 0.0, yIn=   78.000000   82.000000   86.000000
+(PID.TID 0000.0001) EXF_SET_FLD: field "hflux", it=         0, loading rec=    12
+(PID.TID 0000.0001) EXF_SET_FLD:   from file: "ncep_qnet.bin"
+(PID.TID 0000.0001)  EXF_INTERP: file="ncep_qnet.bin", rec=    12 , x-Per,P.Sym=    T    T
+(PID.TID 0000.0001)  S.edge (j=-1,0,1) : proc= 0.0 0.0 0.0, yIn=  -86.000000  -82.000000  -78.000000
+(PID.TID 0000.0001)  N.edge (j=+0,+1,+2) proc= 0.0 0.0 0.0, yIn=   78.000000   82.000000   86.000000
+(PID.TID 0000.0001) EXF_SET_FLD: field "hflux", it=         0, loading rec=     1
+(PID.TID 0000.0001) EXF_SET_FLD:   from file: "ncep_qnet.bin"
+(PID.TID 0000.0001)  EXF_INTERP: file="ncep_qnet.bin", rec=     1 , x-Per,P.Sym=    T    T
+(PID.TID 0000.0001)  S.edge (j=-1,0,1) : proc= 0.0 0.0 0.0, yIn=  -86.000000  -82.000000  -78.000000
+(PID.TID 0000.0001)  N.edge (j=+0,+1,+2) proc= 0.0 0.0 0.0, yIn=   78.000000   82.000000   86.000000
 (PID.TID 0000.0001) SOLVE_FOR_PRESSURE: putPmEinXvector =    F
  cg2d: Sum(rhs),rhsMax =  -2.77555756156289E-16  2.53662338005399E+00
  cg2d: Sum(rhs),rhsMax =   3.80251385934116E-14  5.04305351695056E+00
- cg2d: Sum(rhs),rhsMax =   1.46993528460371E-12  1.04437188573638E-03
- cg2d: Sum(rhs),rhsMax =   1.39133149446025E-12  1.06189295162398E-03
+ Calling cg2d from S/R CG2D_SAD
+ cg2d: Sum(rhs),rhsMax =   1.44906309174075E-12  1.04437188573638E-03
+ Calling cg2d from S/R CG2D_SAD
+ cg2d: Sum(rhs),rhsMax =   1.32560629140244E-12  1.06189295162398E-03
+(PID.TID 0000.0001) // =======================================================
+(PID.TID 0000.0001) // Begin AD_MONITOR EXF statistics for iwhen =  3
+(PID.TID 0000.0001) // =======================================================
+(PID.TID 0000.0001) %MON ad_exf_tsnumber              =                     0
+(PID.TID 0000.0001) %MON ad_exf_time_sec              =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON ad_exf_adfu_max              =   1.4107165781771E+00
+(PID.TID 0000.0001) %MON ad_exf_adfu_min              =  -1.7981652077697E+00
+(PID.TID 0000.0001) %MON ad_exf_adfu_mean             =  -3.4383149838650E-01
+(PID.TID 0000.0001) %MON ad_exf_adfu_sd               =   4.9344858127448E-01
+(PID.TID 0000.0001) %MON ad_exf_adfu_del2             =   7.9922724570081E-03
+(PID.TID 0000.0001) %MON ad_exf_adfv_max              =   1.8137233244936E+00
+(PID.TID 0000.0001) %MON ad_exf_adfv_min              =  -1.6809421919177E+00
+(PID.TID 0000.0001) %MON ad_exf_adfv_mean             =  -3.3023974571601E-02
+(PID.TID 0000.0001) %MON ad_exf_adfv_sd               =   5.1060593608745E-01
+(PID.TID 0000.0001) %MON ad_exf_adfv_del2             =   1.1074286861285E-02
+(PID.TID 0000.0001) %MON ad_exf_adqnet_max            =   5.7076511053927E-03
+(PID.TID 0000.0001) %MON ad_exf_adqnet_min            =  -7.9634223516045E-03
+(PID.TID 0000.0001) %MON ad_exf_adqnet_mean           =  -2.3308236877899E-03
+(PID.TID 0000.0001) %MON ad_exf_adqnet_sd             =   1.1785964574523E-03
+(PID.TID 0000.0001) %MON ad_exf_adqnet_del2           =   1.9771086227144E-05
+(PID.TID 0000.0001) %MON ad_exf_adempmr_max           =   2.9230520564395E+03
+(PID.TID 0000.0001) %MON ad_exf_adempmr_min           =  -3.1306667453343E+03
+(PID.TID 0000.0001) %MON ad_exf_adempmr_mean          =  -8.1076052256074E-02
+(PID.TID 0000.0001) %MON ad_exf_adempmr_sd            =   1.3355864294094E+02
+(PID.TID 0000.0001) %MON ad_exf_adempmr_del2          =   7.4337135125516E+00
+(PID.TID 0000.0001) // =======================================================
+(PID.TID 0000.0001) // End AD_MONITOR EXF statistics for iwhen =  3
+(PID.TID 0000.0001) // =======================================================
+(PID.TID 0000.0001) // =======================================================
+(PID.TID 0000.0001) // Begin AD_MONITOR EXF statistics for iwhen =  1
+(PID.TID 0000.0001) // =======================================================
+(PID.TID 0000.0001) %MON ad_exf_tsnumber              =                     0
+(PID.TID 0000.0001) %MON ad_exf_time_sec              =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON ad_exf_adustress_max         =   1.1137379338634E+00
+(PID.TID 0000.0001) %MON ad_exf_adustress_min         =  -1.7660779077900E+00
+(PID.TID 0000.0001) %MON ad_exf_adustress_mean        =  -3.4485976493230E-01
+(PID.TID 0000.0001) %MON ad_exf_adustress_sd          =   4.7797628043931E-01
+(PID.TID 0000.0001) %MON ad_exf_adustress_del2        =   6.0957294046562E-03
+(PID.TID 0000.0001) %MON ad_exf_advstress_max         =   1.3128334985928E+00
+(PID.TID 0000.0001) %MON ad_exf_advstress_min         =  -1.3569652352123E+00
+(PID.TID 0000.0001) %MON ad_exf_advstress_mean        =  -2.8862409005447E-02
+(PID.TID 0000.0001) %MON ad_exf_advstress_sd          =   4.7295685314537E-01
+(PID.TID 0000.0001) %MON ad_exf_advstress_del2        =   6.6197888380823E-03
+(PID.TID 0000.0001) %MON ad_exf_adhflux_max           =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON ad_exf_adhflux_min           =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON ad_exf_adhflux_mean          =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON ad_exf_adhflux_sd            =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON ad_exf_adhflux_del2          =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON ad_exf_adsflux_max           =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON ad_exf_adsflux_min           =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON ad_exf_adsflux_mean          =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON ad_exf_adsflux_sd            =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON ad_exf_adsflux_del2          =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON ad_exf_adwspeed_max          =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON ad_exf_adwspeed_min          =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON ad_exf_adwspeed_mean         =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON ad_exf_adwspeed_sd           =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON ad_exf_adwspeed_del2         =   0.0000000000000E+00
+(PID.TID 0000.0001) // =======================================================
+(PID.TID 0000.0001) // End AD_MONITOR EXF statistics for iwhen =  1
+(PID.TID 0000.0001) // =======================================================
+(PID.TID 0000.0001) // =======================================================
+(PID.TID 0000.0001) // Begin AD_MONITOR EXF statistics for iwhen =  2
+(PID.TID 0000.0001) // =======================================================
+(PID.TID 0000.0001) %MON ad_exf_tsnumber              =                     0
+(PID.TID 0000.0001) %MON ad_exf_time_sec              =   0.0000000000000E+00
+(PID.TID 0000.0001) // =======================================================
+(PID.TID 0000.0001) // End AD_MONITOR EXF statistics for iwhen =  2
+(PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) Start initial hydrostatic pressure computation
 (PID.TID 0000.0001) Pressure is predetermined for buoyancyRelation OCEANIC
 (PID.TID 0000.0001) 
+(PID.TID 0000.0001) // =======================================================
+(PID.TID 0000.0001) // Begin AD_MONITOR dynamic field statistics
+(PID.TID 0000.0001) // =======================================================
+(PID.TID 0000.0001) %MON ad_time_tsnumber             =                     0
+(PID.TID 0000.0001) %MON ad_time_secondsf             =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON ad_dynstat_adeta_max         =   1.3115583351007E+02
+(PID.TID 0000.0001) %MON ad_dynstat_adeta_min         =  -9.1094202431826E+01
+(PID.TID 0000.0001) %MON ad_dynstat_adeta_mean        =   3.3673263020724E+00
+(PID.TID 0000.0001) %MON ad_dynstat_adeta_sd          =   3.1158255354386E+01
+(PID.TID 0000.0001) %MON ad_dynstat_adeta_del2        =   3.3443491783346E-01
+(PID.TID 0000.0001) %MON ad_dynstat_aduvel_max        =   1.4333715531695E+02
+(PID.TID 0000.0001) %MON ad_dynstat_aduvel_min        =  -1.1882829831584E+02
+(PID.TID 0000.0001) %MON ad_dynstat_aduvel_mean       =  -9.2110533641223E-01
+(PID.TID 0000.0001) %MON ad_dynstat_aduvel_sd         =   2.3168440931900E+01
+(PID.TID 0000.0001) %MON ad_dynstat_aduvel_del2       =   7.8765217532800E-02
+(PID.TID 0000.0001) %MON ad_dynstat_advvel_max        =   2.0244484936654E+02
+(PID.TID 0000.0001) %MON ad_dynstat_advvel_min        =  -1.8104790687155E+02
+(PID.TID 0000.0001) %MON ad_dynstat_advvel_mean       =   5.6908048819103E+00
+(PID.TID 0000.0001) %MON ad_dynstat_advvel_sd         =   2.7695472981194E+01
+(PID.TID 0000.0001) %MON ad_dynstat_advvel_del2       =   1.2032468891975E-01
+(PID.TID 0000.0001) %MON ad_dynstat_adwvel_max        =   6.2788438312848E+03
+(PID.TID 0000.0001) %MON ad_dynstat_adwvel_min        =  -7.1632031791888E+04
+(PID.TID 0000.0001) %MON ad_dynstat_adwvel_mean       =  -2.6558761195099E+02
+(PID.TID 0000.0001) %MON ad_dynstat_adwvel_sd         =   2.6489446164346E+03
+(PID.TID 0000.0001) %MON ad_dynstat_adwvel_del2       =   1.4552148063926E+01
+(PID.TID 0000.0001) %MON ad_dynstat_adtheta_max       =   9.8660885291789E+01
+(PID.TID 0000.0001) %MON ad_dynstat_adtheta_min       =  -7.8489631288868E+01
+(PID.TID 0000.0001) %MON ad_dynstat_adtheta_mean      =   3.5203658363174E-01
+(PID.TID 0000.0001) %MON ad_dynstat_adtheta_sd        =   3.9174825237978E+00
+(PID.TID 0000.0001) %MON ad_dynstat_adtheta_del2      =   2.3493166971375E-02
+(PID.TID 0000.0001) %MON ad_dynstat_adsalt_max        =   2.8182281437383E+02
+(PID.TID 0000.0001) %MON ad_dynstat_adsalt_min        =  -2.6664613257874E+02
+(PID.TID 0000.0001) %MON ad_dynstat_adsalt_mean       =   3.5911421837575E-01
+(PID.TID 0000.0001) %MON ad_dynstat_adsalt_sd         =   6.5582182270238E+00
+(PID.TID 0000.0001) %MON ad_dynstat_adsalt_del2       =   7.7901490754450E-02
+(PID.TID 0000.0001) // =======================================================
+(PID.TID 0000.0001) // End AD_MONITOR dynamic field statistics
+(PID.TID 0000.0001) // =======================================================
  ph-pack: packing ecco_cost
  ph-pack: packing ecco_ctrl
 (PID.TID 0000.0001) // =======================================================
@@ -4941,16 +3315,48 @@ grad-res -------------------------------
 (PID.TID 0000.0001) // Model current state
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) 
-(PID.TID 0000.0001)  EXF_SET_GEN: it=         0 loading rec=    12 from: lev_sst.bin
-(PID.TID 0000.0001)  EXF_SET_GEN: it=         0 loading rec=     1 from: lev_sst.bin
-(PID.TID 0000.0001)  EXF_SET_GEN: it=         0 loading rec=    12 from: lev_sss.bin
-(PID.TID 0000.0001)  EXF_SET_GEN: it=         0 loading rec=     1 from: lev_sss.bin
-(PID.TID 0000.0001)  EXF_SET_GEN: it=         0 loading rec=    12 from: trenberth_taux.bin
-(PID.TID 0000.0001)  EXF_SET_GEN: it=         0 loading rec=     1 from: trenberth_taux.bin
-(PID.TID 0000.0001)  EXF_SET_GEN: it=         0 loading rec=    12 from: trenberth_tauy.bin
-(PID.TID 0000.0001)  EXF_SET_GEN: it=         0 loading rec=     1 from: trenberth_tauy.bin
-(PID.TID 0000.0001)  EXF_SET_GEN: it=         0 loading rec=    12 from: ncep_qnet.bin
-(PID.TID 0000.0001)  EXF_SET_GEN: it=         0 loading rec=     1 from: ncep_qnet.bin
+(PID.TID 0000.0001) EXF_SET_FLD: field "climsst", it=         0, loading rec=    12
+(PID.TID 0000.0001) EXF_SET_FLD:   from file: "lev_sst.bin"
+(PID.TID 0000.0001)  EXF_INTERP: file="lev_sst.bin", rec=    12 , x-Per,P.Sym=    T    T
+(PID.TID 0000.0001)  S.edge (j=-1,0,1) : proc= 0.0 0.0 0.0, yIn=  -86.000000  -82.000000  -78.000000
+(PID.TID 0000.0001)  N.edge (j=+0,+1,+2) proc= 0.0 0.0 0.0, yIn=   78.000000   82.000000   86.000000
+(PID.TID 0000.0001) EXF_SET_FLD: field "climsst", it=         0, loading rec=     1
+(PID.TID 0000.0001) EXF_SET_FLD:   from file: "lev_sst.bin"
+(PID.TID 0000.0001)  EXF_INTERP: file="lev_sst.bin", rec=     1 , x-Per,P.Sym=    T    T
+(PID.TID 0000.0001)  S.edge (j=-1,0,1) : proc= 0.0 0.0 0.0, yIn=  -86.000000  -82.000000  -78.000000
+(PID.TID 0000.0001)  N.edge (j=+0,+1,+2) proc= 0.0 0.0 0.0, yIn=   78.000000   82.000000   86.000000
+(PID.TID 0000.0001) EXF_SET_FLD: field "climsss", it=         0, loading rec=    12
+(PID.TID 0000.0001) EXF_SET_FLD:   from file: "lev_sss.bin"
+(PID.TID 0000.0001)  EXF_INTERP: file="lev_sss.bin", rec=    12 , x-Per,P.Sym=    T    T
+(PID.TID 0000.0001)  S.edge (j=-1,0,1) : proc= 0.0 0.0 0.0, yIn=  -86.000000  -82.000000  -78.000000
+(PID.TID 0000.0001)  N.edge (j=+0,+1,+2) proc= 0.0 0.0 0.0, yIn=   78.000000   82.000000   86.000000
+(PID.TID 0000.0001) EXF_SET_FLD: field "climsss", it=         0, loading rec=     1
+(PID.TID 0000.0001) EXF_SET_FLD:   from file: "lev_sss.bin"
+(PID.TID 0000.0001)  EXF_INTERP: file="lev_sss.bin", rec=     1 , x-Per,P.Sym=    T    T
+(PID.TID 0000.0001)  S.edge (j=-1,0,1) : proc= 0.0 0.0 0.0, yIn=  -86.000000  -82.000000  -78.000000
+(PID.TID 0000.0001)  N.edge (j=+0,+1,+2) proc= 0.0 0.0 0.0, yIn=   78.000000   82.000000   86.000000
+(PID.TID 0000.0001) EXF_SET_UV: fields "ustress" & "vstress", it=         0
+(PID.TID 0000.0001) EXF_SET_UV:   loading rec=    12 from file: "trenberth_taux.bin"
+(PID.TID 0000.0001) EXF_SET_UV:   loading rec=    12 from file: "trenberth_tauy.bin"
+(PID.TID 0000.0001)  EXF_INTERP_UV: fileU="trenberth_taux.bin", rec=    12 , x-Per,P.Sym=    T    T
+(PID.TID 0000.0001)  S.edge (j=-1,0,1) : proc= 0.0 0.0 0.0, yIn=  -86.000000  -82.000000  -78.000000
+(PID.TID 0000.0001)  N.edge (j=+0,+1,+2) proc= 0.0 0.0 0.0, yIn=   78.000000   82.000000   86.000000
+(PID.TID 0000.0001) EXF_SET_UV: fields "ustress" & "vstress", it=         0
+(PID.TID 0000.0001) EXF_SET_UV:   loading rec=     1 from file: "trenberth_taux.bin"
+(PID.TID 0000.0001) EXF_SET_UV:   loading rec=     1 from file: "trenberth_tauy.bin"
+(PID.TID 0000.0001)  EXF_INTERP_UV: fileU="trenberth_taux.bin", rec=     1 , x-Per,P.Sym=    T    T
+(PID.TID 0000.0001)  S.edge (j=-1,0,1) : proc= 0.0 0.0 0.0, yIn=  -86.000000  -82.000000  -78.000000
+(PID.TID 0000.0001)  N.edge (j=+0,+1,+2) proc= 0.0 0.0 0.0, yIn=   78.000000   82.000000   86.000000
+(PID.TID 0000.0001) EXF_SET_FLD: field "hflux", it=         0, loading rec=    12
+(PID.TID 0000.0001) EXF_SET_FLD:   from file: "ncep_qnet.bin"
+(PID.TID 0000.0001)  EXF_INTERP: file="ncep_qnet.bin", rec=    12 , x-Per,P.Sym=    T    T
+(PID.TID 0000.0001)  S.edge (j=-1,0,1) : proc= 0.0 0.0 0.0, yIn=  -86.000000  -82.000000  -78.000000
+(PID.TID 0000.0001)  N.edge (j=+0,+1,+2) proc= 0.0 0.0 0.0, yIn=   78.000000   82.000000   86.000000
+(PID.TID 0000.0001) EXF_SET_FLD: field "hflux", it=         0, loading rec=     1
+(PID.TID 0000.0001) EXF_SET_FLD:   from file: "ncep_qnet.bin"
+(PID.TID 0000.0001)  EXF_INTERP: file="ncep_qnet.bin", rec=     1 , x-Per,P.Sym=    T    T
+(PID.TID 0000.0001)  S.edge (j=-1,0,1) : proc= 0.0 0.0 0.0, yIn=  -86.000000  -82.000000  -78.000000
+(PID.TID 0000.0001)  N.edge (j=+0,+1,+2) proc= 0.0 0.0 0.0, yIn=   78.000000   82.000000   86.000000
 (PID.TID 0000.0001) SOLVE_FOR_PRESSURE: putPmEinXvector =    F
  cg2d: Sum(rhs),rhsMax =  -2.77555756156289E-16  2.53662338005399E+00
  cg2d: Sum(rhs),rhsMax =   4.15778522722121E-14  5.04305351695056E+00
@@ -4965,19 +3371,19 @@ grad-res -------------------------------
  cg2d: Sum(rhs),rhsMax =  -5.01820807130571E-13  8.04727754560105E+00
  cg2d: Sum(rhs),rhsMax =  -7.05213665241899E-13  7.88895797900659E+00
  cg2d: Sum(rhs),rhsMax =  -8.19788681383216E-13  8.31754379149280E+00
- cg2d: Sum(rhs),rhsMax =  -9.11271058612328E-13  8.97048397342872E+00
- cg2d: Sum(rhs),rhsMax =  -8.66862137627322E-13  9.43480072450346E+00
- cg2d: Sum(rhs),rhsMax =  -8.15347789284715E-13  9.69891950276480E+00
- cg2d: Sum(rhs),rhsMax =  -8.63309423948522E-13  9.76269586768808E+00
- cg2d: Sum(rhs),rhsMax =  -8.45545855554519E-13  9.63804624668725E+00
- cg2d: Sum(rhs),rhsMax =  -8.27782287160517E-13  9.34829007249910E+00
- cg2d: Sum(rhs),rhsMax =  -8.91731133378926E-13  9.12167905635334E+00
+ cg2d: Sum(rhs),rhsMax =  -9.13047415451729E-13  8.97048397342872E+00
+ cg2d: Sum(rhs),rhsMax =  -8.45545855554519E-13  9.43480072450346E+00
+ cg2d: Sum(rhs),rhsMax =  -8.22453216642316E-13  9.69891950276479E+00
+ cg2d: Sum(rhs),rhsMax =  -8.38440428196918E-13  9.76269586768807E+00
+ cg2d: Sum(rhs),rhsMax =  -7.54951656745106E-13  9.63804624668725E+00
+ cg2d: Sum(rhs),rhsMax =  -7.56728013584507E-13  9.34829007249910E+00
+ cg2d: Sum(rhs),rhsMax =  -8.73967564984923E-13  9.12167905635334E+00
 (PID.TID 0000.0001) Did not write pickup because writePickupAtEnd = FALSE
-  early fc =  0.000000000000000D+00
- --> objf_test(bi,bj)   =  0.354115231358161D+06
+(PID.TID 0000.0001)   early fc =  0.000000000000000D+00
+ --> objf_test(bi,bj)   =  0.354115231358160D+06
  --> objf_test(bi,bj)   =  0.444589534075216D+06
-  local fc =  0.798704765433376D+06
- global fc =  0.798704765433376D+06
+(PID.TID 0000.0001)   local fc =  0.798704765433376D+06
+(PID.TID 0000.0001)  global fc =  0.798704765433376D+06
 (PID.TID 0000.0001) grdchk perturb(+)fc: fcpertplus  =  7.98704765433376E+05
 (PID.TID 0000.0001) Start initial hydrostatic pressure computation
 (PID.TID 0000.0001) Pressure is predetermined for buoyancyRelation OCEANIC
@@ -4986,16 +3392,48 @@ grad-res -------------------------------
 (PID.TID 0000.0001) // Model current state
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) 
-(PID.TID 0000.0001)  EXF_SET_GEN: it=         0 loading rec=    12 from: lev_sst.bin
-(PID.TID 0000.0001)  EXF_SET_GEN: it=         0 loading rec=     1 from: lev_sst.bin
-(PID.TID 0000.0001)  EXF_SET_GEN: it=         0 loading rec=    12 from: lev_sss.bin
-(PID.TID 0000.0001)  EXF_SET_GEN: it=         0 loading rec=     1 from: lev_sss.bin
-(PID.TID 0000.0001)  EXF_SET_GEN: it=         0 loading rec=    12 from: trenberth_taux.bin
-(PID.TID 0000.0001)  EXF_SET_GEN: it=         0 loading rec=     1 from: trenberth_taux.bin
-(PID.TID 0000.0001)  EXF_SET_GEN: it=         0 loading rec=    12 from: trenberth_tauy.bin
-(PID.TID 0000.0001)  EXF_SET_GEN: it=         0 loading rec=     1 from: trenberth_tauy.bin
-(PID.TID 0000.0001)  EXF_SET_GEN: it=         0 loading rec=    12 from: ncep_qnet.bin
-(PID.TID 0000.0001)  EXF_SET_GEN: it=         0 loading rec=     1 from: ncep_qnet.bin
+(PID.TID 0000.0001) EXF_SET_FLD: field "climsst", it=         0, loading rec=    12
+(PID.TID 0000.0001) EXF_SET_FLD:   from file: "lev_sst.bin"
+(PID.TID 0000.0001)  EXF_INTERP: file="lev_sst.bin", rec=    12 , x-Per,P.Sym=    T    T
+(PID.TID 0000.0001)  S.edge (j=-1,0,1) : proc= 0.0 0.0 0.0, yIn=  -86.000000  -82.000000  -78.000000
+(PID.TID 0000.0001)  N.edge (j=+0,+1,+2) proc= 0.0 0.0 0.0, yIn=   78.000000   82.000000   86.000000
+(PID.TID 0000.0001) EXF_SET_FLD: field "climsst", it=         0, loading rec=     1
+(PID.TID 0000.0001) EXF_SET_FLD:   from file: "lev_sst.bin"
+(PID.TID 0000.0001)  EXF_INTERP: file="lev_sst.bin", rec=     1 , x-Per,P.Sym=    T    T
+(PID.TID 0000.0001)  S.edge (j=-1,0,1) : proc= 0.0 0.0 0.0, yIn=  -86.000000  -82.000000  -78.000000
+(PID.TID 0000.0001)  N.edge (j=+0,+1,+2) proc= 0.0 0.0 0.0, yIn=   78.000000   82.000000   86.000000
+(PID.TID 0000.0001) EXF_SET_FLD: field "climsss", it=         0, loading rec=    12
+(PID.TID 0000.0001) EXF_SET_FLD:   from file: "lev_sss.bin"
+(PID.TID 0000.0001)  EXF_INTERP: file="lev_sss.bin", rec=    12 , x-Per,P.Sym=    T    T
+(PID.TID 0000.0001)  S.edge (j=-1,0,1) : proc= 0.0 0.0 0.0, yIn=  -86.000000  -82.000000  -78.000000
+(PID.TID 0000.0001)  N.edge (j=+0,+1,+2) proc= 0.0 0.0 0.0, yIn=   78.000000   82.000000   86.000000
+(PID.TID 0000.0001) EXF_SET_FLD: field "climsss", it=         0, loading rec=     1
+(PID.TID 0000.0001) EXF_SET_FLD:   from file: "lev_sss.bin"
+(PID.TID 0000.0001)  EXF_INTERP: file="lev_sss.bin", rec=     1 , x-Per,P.Sym=    T    T
+(PID.TID 0000.0001)  S.edge (j=-1,0,1) : proc= 0.0 0.0 0.0, yIn=  -86.000000  -82.000000  -78.000000
+(PID.TID 0000.0001)  N.edge (j=+0,+1,+2) proc= 0.0 0.0 0.0, yIn=   78.000000   82.000000   86.000000
+(PID.TID 0000.0001) EXF_SET_UV: fields "ustress" & "vstress", it=         0
+(PID.TID 0000.0001) EXF_SET_UV:   loading rec=    12 from file: "trenberth_taux.bin"
+(PID.TID 0000.0001) EXF_SET_UV:   loading rec=    12 from file: "trenberth_tauy.bin"
+(PID.TID 0000.0001)  EXF_INTERP_UV: fileU="trenberth_taux.bin", rec=    12 , x-Per,P.Sym=    T    T
+(PID.TID 0000.0001)  S.edge (j=-1,0,1) : proc= 0.0 0.0 0.0, yIn=  -86.000000  -82.000000  -78.000000
+(PID.TID 0000.0001)  N.edge (j=+0,+1,+2) proc= 0.0 0.0 0.0, yIn=   78.000000   82.000000   86.000000
+(PID.TID 0000.0001) EXF_SET_UV: fields "ustress" & "vstress", it=         0
+(PID.TID 0000.0001) EXF_SET_UV:   loading rec=     1 from file: "trenberth_taux.bin"
+(PID.TID 0000.0001) EXF_SET_UV:   loading rec=     1 from file: "trenberth_tauy.bin"
+(PID.TID 0000.0001)  EXF_INTERP_UV: fileU="trenberth_taux.bin", rec=     1 , x-Per,P.Sym=    T    T
+(PID.TID 0000.0001)  S.edge (j=-1,0,1) : proc= 0.0 0.0 0.0, yIn=  -86.000000  -82.000000  -78.000000
+(PID.TID 0000.0001)  N.edge (j=+0,+1,+2) proc= 0.0 0.0 0.0, yIn=   78.000000   82.000000   86.000000
+(PID.TID 0000.0001) EXF_SET_FLD: field "hflux", it=         0, loading rec=    12
+(PID.TID 0000.0001) EXF_SET_FLD:   from file: "ncep_qnet.bin"
+(PID.TID 0000.0001)  EXF_INTERP: file="ncep_qnet.bin", rec=    12 , x-Per,P.Sym=    T    T
+(PID.TID 0000.0001)  S.edge (j=-1,0,1) : proc= 0.0 0.0 0.0, yIn=  -86.000000  -82.000000  -78.000000
+(PID.TID 0000.0001)  N.edge (j=+0,+1,+2) proc= 0.0 0.0 0.0, yIn=   78.000000   82.000000   86.000000
+(PID.TID 0000.0001) EXF_SET_FLD: field "hflux", it=         0, loading rec=     1
+(PID.TID 0000.0001) EXF_SET_FLD:   from file: "ncep_qnet.bin"
+(PID.TID 0000.0001)  EXF_INTERP: file="ncep_qnet.bin", rec=     1 , x-Per,P.Sym=    T    T
+(PID.TID 0000.0001)  S.edge (j=-1,0,1) : proc= 0.0 0.0 0.0, yIn=  -86.000000  -82.000000  -78.000000
+(PID.TID 0000.0001)  N.edge (j=+0,+1,+2) proc= 0.0 0.0 0.0, yIn=   78.000000   82.000000   86.000000
 (PID.TID 0000.0001) SOLVE_FOR_PRESSURE: putPmEinXvector =    F
  cg2d: Sum(rhs),rhsMax =  -2.77555756156289E-16  2.53662338005399E+00
  cg2d: Sum(rhs),rhsMax =   3.80251385934116E-14  5.04305351695056E+00
@@ -5018,18 +3456,18 @@ grad-res -------------------------------
  cg2d: Sum(rhs),rhsMax =  -7.81597009336110E-13  9.34829007237633E+00
  cg2d: Sum(rhs),rhsMax =  -8.84625706021325E-13  9.12167905630036E+00
 (PID.TID 0000.0001) Did not write pickup because writePickupAtEnd = FALSE
-  early fc =  0.000000000000000D+00
+(PID.TID 0000.0001)   early fc =  0.000000000000000D+00
  --> objf_test(bi,bj)   =  0.354115231362129D+06
  --> objf_test(bi,bj)   =  0.444589534075239D+06
-  local fc =  0.798704765437369D+06
- global fc =  0.798704765437369D+06
+(PID.TID 0000.0001)   local fc =  0.798704765437369D+06
+(PID.TID 0000.0001)  global fc =  0.798704765437369D+06
 (PID.TID 0000.0001) grdchk perturb(-)fc: fcpertminus =  7.98704765437369E+05
 grad-res -------------------------------
  grad-res     0    1    4    8    1    1    1    1   7.98704765435E+05  7.98704765433E+05  7.98704765437E+05
- grad-res     0    1    1  204    0    1    1    1  -1.99545934416E-02 -1.99611531571E-02 -3.28732103763E-04
+ grad-res     0    1    1  204    0    1    1    1  -1.99545934416E-02 -1.99623173103E-02 -3.87072215862E-04
 (PID.TID 0000.0001)  ADM  ref_cost_function      =  7.98704765435371E+05
 (PID.TID 0000.0001)  ADM  adjoint_gradient       = -1.99545934415736E-02
-(PID.TID 0000.0001)  ADM  finite-diff_grad       = -1.99611531570554E-02
+(PID.TID 0000.0001)  ADM  finite-diff_grad       = -1.99623173102736E-02
 (PID.TID 0000.0001) ====== End of gradient-check number   1 (ierr=  0) =======
 (PID.TID 0000.0001) ====== Starts gradient-check number   2 (=ichknum) =======
  ph-test icomp, ncvarcomp, ichknum          205        6945           2
@@ -5043,16 +3481,48 @@ grad-res -------------------------------
 (PID.TID 0000.0001) // Model current state
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) 
-(PID.TID 0000.0001)  EXF_SET_GEN: it=         0 loading rec=    12 from: lev_sst.bin
-(PID.TID 0000.0001)  EXF_SET_GEN: it=         0 loading rec=     1 from: lev_sst.bin
-(PID.TID 0000.0001)  EXF_SET_GEN: it=         0 loading rec=    12 from: lev_sss.bin
-(PID.TID 0000.0001)  EXF_SET_GEN: it=         0 loading rec=     1 from: lev_sss.bin
-(PID.TID 0000.0001)  EXF_SET_GEN: it=         0 loading rec=    12 from: trenberth_taux.bin
-(PID.TID 0000.0001)  EXF_SET_GEN: it=         0 loading rec=     1 from: trenberth_taux.bin
-(PID.TID 0000.0001)  EXF_SET_GEN: it=         0 loading rec=    12 from: trenberth_tauy.bin
-(PID.TID 0000.0001)  EXF_SET_GEN: it=         0 loading rec=     1 from: trenberth_tauy.bin
-(PID.TID 0000.0001)  EXF_SET_GEN: it=         0 loading rec=    12 from: ncep_qnet.bin
-(PID.TID 0000.0001)  EXF_SET_GEN: it=         0 loading rec=     1 from: ncep_qnet.bin
+(PID.TID 0000.0001) EXF_SET_FLD: field "climsst", it=         0, loading rec=    12
+(PID.TID 0000.0001) EXF_SET_FLD:   from file: "lev_sst.bin"
+(PID.TID 0000.0001)  EXF_INTERP: file="lev_sst.bin", rec=    12 , x-Per,P.Sym=    T    T
+(PID.TID 0000.0001)  S.edge (j=-1,0,1) : proc= 0.0 0.0 0.0, yIn=  -86.000000  -82.000000  -78.000000
+(PID.TID 0000.0001)  N.edge (j=+0,+1,+2) proc= 0.0 0.0 0.0, yIn=   78.000000   82.000000   86.000000
+(PID.TID 0000.0001) EXF_SET_FLD: field "climsst", it=         0, loading rec=     1
+(PID.TID 0000.0001) EXF_SET_FLD:   from file: "lev_sst.bin"
+(PID.TID 0000.0001)  EXF_INTERP: file="lev_sst.bin", rec=     1 , x-Per,P.Sym=    T    T
+(PID.TID 0000.0001)  S.edge (j=-1,0,1) : proc= 0.0 0.0 0.0, yIn=  -86.000000  -82.000000  -78.000000
+(PID.TID 0000.0001)  N.edge (j=+0,+1,+2) proc= 0.0 0.0 0.0, yIn=   78.000000   82.000000   86.000000
+(PID.TID 0000.0001) EXF_SET_FLD: field "climsss", it=         0, loading rec=    12
+(PID.TID 0000.0001) EXF_SET_FLD:   from file: "lev_sss.bin"
+(PID.TID 0000.0001)  EXF_INTERP: file="lev_sss.bin", rec=    12 , x-Per,P.Sym=    T    T
+(PID.TID 0000.0001)  S.edge (j=-1,0,1) : proc= 0.0 0.0 0.0, yIn=  -86.000000  -82.000000  -78.000000
+(PID.TID 0000.0001)  N.edge (j=+0,+1,+2) proc= 0.0 0.0 0.0, yIn=   78.000000   82.000000   86.000000
+(PID.TID 0000.0001) EXF_SET_FLD: field "climsss", it=         0, loading rec=     1
+(PID.TID 0000.0001) EXF_SET_FLD:   from file: "lev_sss.bin"
+(PID.TID 0000.0001)  EXF_INTERP: file="lev_sss.bin", rec=     1 , x-Per,P.Sym=    T    T
+(PID.TID 0000.0001)  S.edge (j=-1,0,1) : proc= 0.0 0.0 0.0, yIn=  -86.000000  -82.000000  -78.000000
+(PID.TID 0000.0001)  N.edge (j=+0,+1,+2) proc= 0.0 0.0 0.0, yIn=   78.000000   82.000000   86.000000
+(PID.TID 0000.0001) EXF_SET_UV: fields "ustress" & "vstress", it=         0
+(PID.TID 0000.0001) EXF_SET_UV:   loading rec=    12 from file: "trenberth_taux.bin"
+(PID.TID 0000.0001) EXF_SET_UV:   loading rec=    12 from file: "trenberth_tauy.bin"
+(PID.TID 0000.0001)  EXF_INTERP_UV: fileU="trenberth_taux.bin", rec=    12 , x-Per,P.Sym=    T    T
+(PID.TID 0000.0001)  S.edge (j=-1,0,1) : proc= 0.0 0.0 0.0, yIn=  -86.000000  -82.000000  -78.000000
+(PID.TID 0000.0001)  N.edge (j=+0,+1,+2) proc= 0.0 0.0 0.0, yIn=   78.000000   82.000000   86.000000
+(PID.TID 0000.0001) EXF_SET_UV: fields "ustress" & "vstress", it=         0
+(PID.TID 0000.0001) EXF_SET_UV:   loading rec=     1 from file: "trenberth_taux.bin"
+(PID.TID 0000.0001) EXF_SET_UV:   loading rec=     1 from file: "trenberth_tauy.bin"
+(PID.TID 0000.0001)  EXF_INTERP_UV: fileU="trenberth_taux.bin", rec=     1 , x-Per,P.Sym=    T    T
+(PID.TID 0000.0001)  S.edge (j=-1,0,1) : proc= 0.0 0.0 0.0, yIn=  -86.000000  -82.000000  -78.000000
+(PID.TID 0000.0001)  N.edge (j=+0,+1,+2) proc= 0.0 0.0 0.0, yIn=   78.000000   82.000000   86.000000
+(PID.TID 0000.0001) EXF_SET_FLD: field "hflux", it=         0, loading rec=    12
+(PID.TID 0000.0001) EXF_SET_FLD:   from file: "ncep_qnet.bin"
+(PID.TID 0000.0001)  EXF_INTERP: file="ncep_qnet.bin", rec=    12 , x-Per,P.Sym=    T    T
+(PID.TID 0000.0001)  S.edge (j=-1,0,1) : proc= 0.0 0.0 0.0, yIn=  -86.000000  -82.000000  -78.000000
+(PID.TID 0000.0001)  N.edge (j=+0,+1,+2) proc= 0.0 0.0 0.0, yIn=   78.000000   82.000000   86.000000
+(PID.TID 0000.0001) EXF_SET_FLD: field "hflux", it=         0, loading rec=     1
+(PID.TID 0000.0001) EXF_SET_FLD:   from file: "ncep_qnet.bin"
+(PID.TID 0000.0001)  EXF_INTERP: file="ncep_qnet.bin", rec=     1 , x-Per,P.Sym=    T    T
+(PID.TID 0000.0001)  S.edge (j=-1,0,1) : proc= 0.0 0.0 0.0, yIn=  -86.000000  -82.000000  -78.000000
+(PID.TID 0000.0001)  N.edge (j=+0,+1,+2) proc= 0.0 0.0 0.0, yIn=   78.000000   82.000000   86.000000
 (PID.TID 0000.0001) SOLVE_FOR_PRESSURE: putPmEinXvector =    F
  cg2d: Sum(rhs),rhsMax =  -2.77555756156289E-16  2.53662338005399E+00
  cg2d: Sum(rhs),rhsMax =   4.15778522722121E-14  5.04305351695056E+00
@@ -5067,19 +3537,19 @@ grad-res -------------------------------
  cg2d: Sum(rhs),rhsMax =  -4.87609952415369E-13  8.04727754561625E+00
  cg2d: Sum(rhs),rhsMax =  -8.03801469828613E-13  7.88895797901699E+00
  cg2d: Sum(rhs),rhsMax =  -6.74127420552395E-13  8.31754379150284E+00
- cg2d: Sum(rhs),rhsMax =  -8.27782287160517E-13  8.97048397344084E+00
- cg2d: Sum(rhs),rhsMax =  -9.02389274415327E-13  9.43480072451688E+00
- cg2d: Sum(rhs),rhsMax =  -7.92255150372512E-13  9.69891950277832E+00
- cg2d: Sum(rhs),rhsMax =  -5.63105118089879E-13  9.76269586770021E+00
- cg2d: Sum(rhs),rhsMax =  -6.00408611717285E-13  9.63804624669669E+00
- cg2d: Sum(rhs),rhsMax =  -9.52127265918534E-13  9.34829007250513E+00
- cg2d: Sum(rhs),rhsMax =  -8.49098569233320E-13  9.12167905636223E+00
+ cg2d: Sum(rhs),rhsMax =  -8.36664071357518E-13  8.97048397344084E+00
+ cg2d: Sum(rhs),rhsMax =  -9.14823772291129E-13  9.43480072451688E+00
+ cg2d: Sum(rhs),rhsMax =  -8.17124146124115E-13  9.69891950277832E+00
+ cg2d: Sum(rhs),rhsMax =  -6.05737682235485E-13  9.76269586770022E+00
+ cg2d: Sum(rhs),rhsMax =  -5.79092329644482E-13  9.63804624669669E+00
+ cg2d: Sum(rhs),rhsMax =  -9.41469124882133E-13  9.34829007250513E+00
+ cg2d: Sum(rhs),rhsMax =  -9.05941988094128E-13  9.12167905636224E+00
 (PID.TID 0000.0001) Did not write pickup because writePickupAtEnd = FALSE
-  early fc =  0.000000000000000D+00
+(PID.TID 0000.0001)   early fc =  0.000000000000000D+00
  --> objf_test(bi,bj)   =  0.354115231358193D+06
  --> objf_test(bi,bj)   =  0.444589534075217D+06
-  local fc =  0.798704765433409D+06
- global fc =  0.798704765433409D+06
+(PID.TID 0000.0001)   local fc =  0.798704765433409D+06
+(PID.TID 0000.0001)  global fc =  0.798704765433409D+06
 (PID.TID 0000.0001) grdchk perturb(+)fc: fcpertplus  =  7.98704765433409E+05
 (PID.TID 0000.0001) Start initial hydrostatic pressure computation
 (PID.TID 0000.0001) Pressure is predetermined for buoyancyRelation OCEANIC
@@ -5088,16 +3558,48 @@ grad-res -------------------------------
 (PID.TID 0000.0001) // Model current state
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) 
-(PID.TID 0000.0001)  EXF_SET_GEN: it=         0 loading rec=    12 from: lev_sst.bin
-(PID.TID 0000.0001)  EXF_SET_GEN: it=         0 loading rec=     1 from: lev_sst.bin
-(PID.TID 0000.0001)  EXF_SET_GEN: it=         0 loading rec=    12 from: lev_sss.bin
-(PID.TID 0000.0001)  EXF_SET_GEN: it=         0 loading rec=     1 from: lev_sss.bin
-(PID.TID 0000.0001)  EXF_SET_GEN: it=         0 loading rec=    12 from: trenberth_taux.bin
-(PID.TID 0000.0001)  EXF_SET_GEN: it=         0 loading rec=     1 from: trenberth_taux.bin
-(PID.TID 0000.0001)  EXF_SET_GEN: it=         0 loading rec=    12 from: trenberth_tauy.bin
-(PID.TID 0000.0001)  EXF_SET_GEN: it=         0 loading rec=     1 from: trenberth_tauy.bin
-(PID.TID 0000.0001)  EXF_SET_GEN: it=         0 loading rec=    12 from: ncep_qnet.bin
-(PID.TID 0000.0001)  EXF_SET_GEN: it=         0 loading rec=     1 from: ncep_qnet.bin
+(PID.TID 0000.0001) EXF_SET_FLD: field "climsst", it=         0, loading rec=    12
+(PID.TID 0000.0001) EXF_SET_FLD:   from file: "lev_sst.bin"
+(PID.TID 0000.0001)  EXF_INTERP: file="lev_sst.bin", rec=    12 , x-Per,P.Sym=    T    T
+(PID.TID 0000.0001)  S.edge (j=-1,0,1) : proc= 0.0 0.0 0.0, yIn=  -86.000000  -82.000000  -78.000000
+(PID.TID 0000.0001)  N.edge (j=+0,+1,+2) proc= 0.0 0.0 0.0, yIn=   78.000000   82.000000   86.000000
+(PID.TID 0000.0001) EXF_SET_FLD: field "climsst", it=         0, loading rec=     1
+(PID.TID 0000.0001) EXF_SET_FLD:   from file: "lev_sst.bin"
+(PID.TID 0000.0001)  EXF_INTERP: file="lev_sst.bin", rec=     1 , x-Per,P.Sym=    T    T
+(PID.TID 0000.0001)  S.edge (j=-1,0,1) : proc= 0.0 0.0 0.0, yIn=  -86.000000  -82.000000  -78.000000
+(PID.TID 0000.0001)  N.edge (j=+0,+1,+2) proc= 0.0 0.0 0.0, yIn=   78.000000   82.000000   86.000000
+(PID.TID 0000.0001) EXF_SET_FLD: field "climsss", it=         0, loading rec=    12
+(PID.TID 0000.0001) EXF_SET_FLD:   from file: "lev_sss.bin"
+(PID.TID 0000.0001)  EXF_INTERP: file="lev_sss.bin", rec=    12 , x-Per,P.Sym=    T    T
+(PID.TID 0000.0001)  S.edge (j=-1,0,1) : proc= 0.0 0.0 0.0, yIn=  -86.000000  -82.000000  -78.000000
+(PID.TID 0000.0001)  N.edge (j=+0,+1,+2) proc= 0.0 0.0 0.0, yIn=   78.000000   82.000000   86.000000
+(PID.TID 0000.0001) EXF_SET_FLD: field "climsss", it=         0, loading rec=     1
+(PID.TID 0000.0001) EXF_SET_FLD:   from file: "lev_sss.bin"
+(PID.TID 0000.0001)  EXF_INTERP: file="lev_sss.bin", rec=     1 , x-Per,P.Sym=    T    T
+(PID.TID 0000.0001)  S.edge (j=-1,0,1) : proc= 0.0 0.0 0.0, yIn=  -86.000000  -82.000000  -78.000000
+(PID.TID 0000.0001)  N.edge (j=+0,+1,+2) proc= 0.0 0.0 0.0, yIn=   78.000000   82.000000   86.000000
+(PID.TID 0000.0001) EXF_SET_UV: fields "ustress" & "vstress", it=         0
+(PID.TID 0000.0001) EXF_SET_UV:   loading rec=    12 from file: "trenberth_taux.bin"
+(PID.TID 0000.0001) EXF_SET_UV:   loading rec=    12 from file: "trenberth_tauy.bin"
+(PID.TID 0000.0001)  EXF_INTERP_UV: fileU="trenberth_taux.bin", rec=    12 , x-Per,P.Sym=    T    T
+(PID.TID 0000.0001)  S.edge (j=-1,0,1) : proc= 0.0 0.0 0.0, yIn=  -86.000000  -82.000000  -78.000000
+(PID.TID 0000.0001)  N.edge (j=+0,+1,+2) proc= 0.0 0.0 0.0, yIn=   78.000000   82.000000   86.000000
+(PID.TID 0000.0001) EXF_SET_UV: fields "ustress" & "vstress", it=         0
+(PID.TID 0000.0001) EXF_SET_UV:   loading rec=     1 from file: "trenberth_taux.bin"
+(PID.TID 0000.0001) EXF_SET_UV:   loading rec=     1 from file: "trenberth_tauy.bin"
+(PID.TID 0000.0001)  EXF_INTERP_UV: fileU="trenberth_taux.bin", rec=     1 , x-Per,P.Sym=    T    T
+(PID.TID 0000.0001)  S.edge (j=-1,0,1) : proc= 0.0 0.0 0.0, yIn=  -86.000000  -82.000000  -78.000000
+(PID.TID 0000.0001)  N.edge (j=+0,+1,+2) proc= 0.0 0.0 0.0, yIn=   78.000000   82.000000   86.000000
+(PID.TID 0000.0001) EXF_SET_FLD: field "hflux", it=         0, loading rec=    12
+(PID.TID 0000.0001) EXF_SET_FLD:   from file: "ncep_qnet.bin"
+(PID.TID 0000.0001)  EXF_INTERP: file="ncep_qnet.bin", rec=    12 , x-Per,P.Sym=    T    T
+(PID.TID 0000.0001)  S.edge (j=-1,0,1) : proc= 0.0 0.0 0.0, yIn=  -86.000000  -82.000000  -78.000000
+(PID.TID 0000.0001)  N.edge (j=+0,+1,+2) proc= 0.0 0.0 0.0, yIn=   78.000000   82.000000   86.000000
+(PID.TID 0000.0001) EXF_SET_FLD: field "hflux", it=         0, loading rec=     1
+(PID.TID 0000.0001) EXF_SET_FLD:   from file: "ncep_qnet.bin"
+(PID.TID 0000.0001)  EXF_INTERP: file="ncep_qnet.bin", rec=     1 , x-Per,P.Sym=    T    T
+(PID.TID 0000.0001)  S.edge (j=-1,0,1) : proc= 0.0 0.0 0.0, yIn=  -86.000000  -82.000000  -78.000000
+(PID.TID 0000.0001)  N.edge (j=+0,+1,+2) proc= 0.0 0.0 0.0, yIn=   78.000000   82.000000   86.000000
 (PID.TID 0000.0001) SOLVE_FOR_PRESSURE: putPmEinXvector =    F
  cg2d: Sum(rhs),rhsMax =  -2.77555756156289E-16  2.53662338005399E+00
  cg2d: Sum(rhs),rhsMax =   3.80251385934116E-14  5.04305351695056E+00
@@ -5120,18 +3622,18 @@ grad-res -------------------------------
  cg2d: Sum(rhs),rhsMax =  -7.95807864051312E-13  9.34829007237082E+00
  cg2d: Sum(rhs),rhsMax =  -8.63309423948522E-13  9.12167905629137E+00
 (PID.TID 0000.0001) Did not write pickup because writePickupAtEnd = FALSE
-  early fc =  0.000000000000000D+00
+(PID.TID 0000.0001)   early fc =  0.000000000000000D+00
  --> objf_test(bi,bj)   =  0.354115231362097D+06
  --> objf_test(bi,bj)   =  0.444589534075237D+06
-  local fc =  0.798704765437333D+06
- global fc =  0.798704765437333D+06
+(PID.TID 0000.0001)   local fc =  0.798704765437333D+06
+(PID.TID 0000.0001)  global fc =  0.798704765437333D+06
 (PID.TID 0000.0001) grdchk perturb(-)fc: fcpertminus =  7.98704765437333E+05
 grad-res -------------------------------
  grad-res     0    2    5    8    1    1    1    1   7.98704765435E+05  7.98704765433E+05  7.98704765437E+05
- grad-res     0    2    2  205    0    1    1    1  -1.96210731004E-02 -1.96200562641E-02  5.18236861556E-05
+ grad-res     0    2    2  205    0    1    1    1  -1.96210731004E-02 -1.96188921109E-02  1.11155467466E-04
 (PID.TID 0000.0001)  ADM  ref_cost_function      =  7.98704765435371E+05
 (PID.TID 0000.0001)  ADM  adjoint_gradient       = -1.96210731004369E-02
-(PID.TID 0000.0001)  ADM  finite-diff_grad       = -1.96200562641025E-02
+(PID.TID 0000.0001)  ADM  finite-diff_grad       = -1.96188921108842E-02
 (PID.TID 0000.0001) ====== End of gradient-check number   2 (ierr=  0) =======
 (PID.TID 0000.0001) ====== Starts gradient-check number   3 (=ichknum) =======
  ph-test icomp, ncvarcomp, ichknum          206        6945           3
@@ -5145,16 +3647,48 @@ grad-res -------------------------------
 (PID.TID 0000.0001) // Model current state
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) 
-(PID.TID 0000.0001)  EXF_SET_GEN: it=         0 loading rec=    12 from: lev_sst.bin
-(PID.TID 0000.0001)  EXF_SET_GEN: it=         0 loading rec=     1 from: lev_sst.bin
-(PID.TID 0000.0001)  EXF_SET_GEN: it=         0 loading rec=    12 from: lev_sss.bin
-(PID.TID 0000.0001)  EXF_SET_GEN: it=         0 loading rec=     1 from: lev_sss.bin
-(PID.TID 0000.0001)  EXF_SET_GEN: it=         0 loading rec=    12 from: trenberth_taux.bin
-(PID.TID 0000.0001)  EXF_SET_GEN: it=         0 loading rec=     1 from: trenberth_taux.bin
-(PID.TID 0000.0001)  EXF_SET_GEN: it=         0 loading rec=    12 from: trenberth_tauy.bin
-(PID.TID 0000.0001)  EXF_SET_GEN: it=         0 loading rec=     1 from: trenberth_tauy.bin
-(PID.TID 0000.0001)  EXF_SET_GEN: it=         0 loading rec=    12 from: ncep_qnet.bin
-(PID.TID 0000.0001)  EXF_SET_GEN: it=         0 loading rec=     1 from: ncep_qnet.bin
+(PID.TID 0000.0001) EXF_SET_FLD: field "climsst", it=         0, loading rec=    12
+(PID.TID 0000.0001) EXF_SET_FLD:   from file: "lev_sst.bin"
+(PID.TID 0000.0001)  EXF_INTERP: file="lev_sst.bin", rec=    12 , x-Per,P.Sym=    T    T
+(PID.TID 0000.0001)  S.edge (j=-1,0,1) : proc= 0.0 0.0 0.0, yIn=  -86.000000  -82.000000  -78.000000
+(PID.TID 0000.0001)  N.edge (j=+0,+1,+2) proc= 0.0 0.0 0.0, yIn=   78.000000   82.000000   86.000000
+(PID.TID 0000.0001) EXF_SET_FLD: field "climsst", it=         0, loading rec=     1
+(PID.TID 0000.0001) EXF_SET_FLD:   from file: "lev_sst.bin"
+(PID.TID 0000.0001)  EXF_INTERP: file="lev_sst.bin", rec=     1 , x-Per,P.Sym=    T    T
+(PID.TID 0000.0001)  S.edge (j=-1,0,1) : proc= 0.0 0.0 0.0, yIn=  -86.000000  -82.000000  -78.000000
+(PID.TID 0000.0001)  N.edge (j=+0,+1,+2) proc= 0.0 0.0 0.0, yIn=   78.000000   82.000000   86.000000
+(PID.TID 0000.0001) EXF_SET_FLD: field "climsss", it=         0, loading rec=    12
+(PID.TID 0000.0001) EXF_SET_FLD:   from file: "lev_sss.bin"
+(PID.TID 0000.0001)  EXF_INTERP: file="lev_sss.bin", rec=    12 , x-Per,P.Sym=    T    T
+(PID.TID 0000.0001)  S.edge (j=-1,0,1) : proc= 0.0 0.0 0.0, yIn=  -86.000000  -82.000000  -78.000000
+(PID.TID 0000.0001)  N.edge (j=+0,+1,+2) proc= 0.0 0.0 0.0, yIn=   78.000000   82.000000   86.000000
+(PID.TID 0000.0001) EXF_SET_FLD: field "climsss", it=         0, loading rec=     1
+(PID.TID 0000.0001) EXF_SET_FLD:   from file: "lev_sss.bin"
+(PID.TID 0000.0001)  EXF_INTERP: file="lev_sss.bin", rec=     1 , x-Per,P.Sym=    T    T
+(PID.TID 0000.0001)  S.edge (j=-1,0,1) : proc= 0.0 0.0 0.0, yIn=  -86.000000  -82.000000  -78.000000
+(PID.TID 0000.0001)  N.edge (j=+0,+1,+2) proc= 0.0 0.0 0.0, yIn=   78.000000   82.000000   86.000000
+(PID.TID 0000.0001) EXF_SET_UV: fields "ustress" & "vstress", it=         0
+(PID.TID 0000.0001) EXF_SET_UV:   loading rec=    12 from file: "trenberth_taux.bin"
+(PID.TID 0000.0001) EXF_SET_UV:   loading rec=    12 from file: "trenberth_tauy.bin"
+(PID.TID 0000.0001)  EXF_INTERP_UV: fileU="trenberth_taux.bin", rec=    12 , x-Per,P.Sym=    T    T
+(PID.TID 0000.0001)  S.edge (j=-1,0,1) : proc= 0.0 0.0 0.0, yIn=  -86.000000  -82.000000  -78.000000
+(PID.TID 0000.0001)  N.edge (j=+0,+1,+2) proc= 0.0 0.0 0.0, yIn=   78.000000   82.000000   86.000000
+(PID.TID 0000.0001) EXF_SET_UV: fields "ustress" & "vstress", it=         0
+(PID.TID 0000.0001) EXF_SET_UV:   loading rec=     1 from file: "trenberth_taux.bin"
+(PID.TID 0000.0001) EXF_SET_UV:   loading rec=     1 from file: "trenberth_tauy.bin"
+(PID.TID 0000.0001)  EXF_INTERP_UV: fileU="trenberth_taux.bin", rec=     1 , x-Per,P.Sym=    T    T
+(PID.TID 0000.0001)  S.edge (j=-1,0,1) : proc= 0.0 0.0 0.0, yIn=  -86.000000  -82.000000  -78.000000
+(PID.TID 0000.0001)  N.edge (j=+0,+1,+2) proc= 0.0 0.0 0.0, yIn=   78.000000   82.000000   86.000000
+(PID.TID 0000.0001) EXF_SET_FLD: field "hflux", it=         0, loading rec=    12
+(PID.TID 0000.0001) EXF_SET_FLD:   from file: "ncep_qnet.bin"
+(PID.TID 0000.0001)  EXF_INTERP: file="ncep_qnet.bin", rec=    12 , x-Per,P.Sym=    T    T
+(PID.TID 0000.0001)  S.edge (j=-1,0,1) : proc= 0.0 0.0 0.0, yIn=  -86.000000  -82.000000  -78.000000
+(PID.TID 0000.0001)  N.edge (j=+0,+1,+2) proc= 0.0 0.0 0.0, yIn=   78.000000   82.000000   86.000000
+(PID.TID 0000.0001) EXF_SET_FLD: field "hflux", it=         0, loading rec=     1
+(PID.TID 0000.0001) EXF_SET_FLD:   from file: "ncep_qnet.bin"
+(PID.TID 0000.0001)  EXF_INTERP: file="ncep_qnet.bin", rec=     1 , x-Per,P.Sym=    T    T
+(PID.TID 0000.0001)  S.edge (j=-1,0,1) : proc= 0.0 0.0 0.0, yIn=  -86.000000  -82.000000  -78.000000
+(PID.TID 0000.0001)  N.edge (j=+0,+1,+2) proc= 0.0 0.0 0.0, yIn=   78.000000   82.000000   86.000000
 (PID.TID 0000.0001) SOLVE_FOR_PRESSURE: putPmEinXvector =    F
  cg2d: Sum(rhs),rhsMax =  -2.77555756156289E-16  2.53662338005399E+00
  cg2d: Sum(rhs),rhsMax =   4.15778522722121E-14  5.04305351695056E+00
@@ -5171,17 +3705,17 @@ grad-res -------------------------------
  cg2d: Sum(rhs),rhsMax =  -7.71827046719409E-13  8.31754379150922E+00
  cg2d: Sum(rhs),rhsMax =  -9.25481913327530E-13  8.97048397344763E+00
  cg2d: Sum(rhs),rhsMax =  -7.99360577730113E-13  9.43480072452314E+00
- cg2d: Sum(rhs),rhsMax =  -7.90478793533111E-13  9.69891950278317E+00
- cg2d: Sum(rhs),rhsMax =  -6.53699316899292E-13  9.76269586770301E+00
- cg2d: Sum(rhs),rhsMax =  -7.38964445190504E-13  9.63804624669697E+00
- cg2d: Sum(rhs),rhsMax =  -6.21724893790088E-13  9.34829007250260E+00
- cg2d: Sum(rhs),rhsMax =  -7.42517158869305E-13  9.12167905636660E+00
+ cg2d: Sum(rhs),rhsMax =  -7.88702436693711E-13  9.69891950278317E+00
+ cg2d: Sum(rhs),rhsMax =  -6.99884594723699E-13  9.76269586770301E+00
+ cg2d: Sum(rhs),rhsMax =  -7.33635374672303E-13  9.63804624669697E+00
+ cg2d: Sum(rhs),rhsMax =  -6.39488462184090E-13  9.34829007250261E+00
+ cg2d: Sum(rhs),rhsMax =  -8.02913291408913E-13  9.12167905636661E+00
 (PID.TID 0000.0001) Did not write pickup because writePickupAtEnd = FALSE
-  early fc =  0.000000000000000D+00
+(PID.TID 0000.0001)   early fc =  0.000000000000000D+00
  --> objf_test(bi,bj)   =  0.354115231358188D+06
  --> objf_test(bi,bj)   =  0.444589534075218D+06
-  local fc =  0.798704765433406D+06
- global fc =  0.798704765433406D+06
+(PID.TID 0000.0001)   local fc =  0.798704765433406D+06
+(PID.TID 0000.0001)  global fc =  0.798704765433406D+06
 (PID.TID 0000.0001) grdchk perturb(+)fc: fcpertplus  =  7.98704765433406E+05
 (PID.TID 0000.0001) Start initial hydrostatic pressure computation
 (PID.TID 0000.0001) Pressure is predetermined for buoyancyRelation OCEANIC
@@ -5190,16 +3724,48 @@ grad-res -------------------------------
 (PID.TID 0000.0001) // Model current state
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) 
-(PID.TID 0000.0001)  EXF_SET_GEN: it=         0 loading rec=    12 from: lev_sst.bin
-(PID.TID 0000.0001)  EXF_SET_GEN: it=         0 loading rec=     1 from: lev_sst.bin
-(PID.TID 0000.0001)  EXF_SET_GEN: it=         0 loading rec=    12 from: lev_sss.bin
-(PID.TID 0000.0001)  EXF_SET_GEN: it=         0 loading rec=     1 from: lev_sss.bin
-(PID.TID 0000.0001)  EXF_SET_GEN: it=         0 loading rec=    12 from: trenberth_taux.bin
-(PID.TID 0000.0001)  EXF_SET_GEN: it=         0 loading rec=     1 from: trenberth_taux.bin
-(PID.TID 0000.0001)  EXF_SET_GEN: it=         0 loading rec=    12 from: trenberth_tauy.bin
-(PID.TID 0000.0001)  EXF_SET_GEN: it=         0 loading rec=     1 from: trenberth_tauy.bin
-(PID.TID 0000.0001)  EXF_SET_GEN: it=         0 loading rec=    12 from: ncep_qnet.bin
-(PID.TID 0000.0001)  EXF_SET_GEN: it=         0 loading rec=     1 from: ncep_qnet.bin
+(PID.TID 0000.0001) EXF_SET_FLD: field "climsst", it=         0, loading rec=    12
+(PID.TID 0000.0001) EXF_SET_FLD:   from file: "lev_sst.bin"
+(PID.TID 0000.0001)  EXF_INTERP: file="lev_sst.bin", rec=    12 , x-Per,P.Sym=    T    T
+(PID.TID 0000.0001)  S.edge (j=-1,0,1) : proc= 0.0 0.0 0.0, yIn=  -86.000000  -82.000000  -78.000000
+(PID.TID 0000.0001)  N.edge (j=+0,+1,+2) proc= 0.0 0.0 0.0, yIn=   78.000000   82.000000   86.000000
+(PID.TID 0000.0001) EXF_SET_FLD: field "climsst", it=         0, loading rec=     1
+(PID.TID 0000.0001) EXF_SET_FLD:   from file: "lev_sst.bin"
+(PID.TID 0000.0001)  EXF_INTERP: file="lev_sst.bin", rec=     1 , x-Per,P.Sym=    T    T
+(PID.TID 0000.0001)  S.edge (j=-1,0,1) : proc= 0.0 0.0 0.0, yIn=  -86.000000  -82.000000  -78.000000
+(PID.TID 0000.0001)  N.edge (j=+0,+1,+2) proc= 0.0 0.0 0.0, yIn=   78.000000   82.000000   86.000000
+(PID.TID 0000.0001) EXF_SET_FLD: field "climsss", it=         0, loading rec=    12
+(PID.TID 0000.0001) EXF_SET_FLD:   from file: "lev_sss.bin"
+(PID.TID 0000.0001)  EXF_INTERP: file="lev_sss.bin", rec=    12 , x-Per,P.Sym=    T    T
+(PID.TID 0000.0001)  S.edge (j=-1,0,1) : proc= 0.0 0.0 0.0, yIn=  -86.000000  -82.000000  -78.000000
+(PID.TID 0000.0001)  N.edge (j=+0,+1,+2) proc= 0.0 0.0 0.0, yIn=   78.000000   82.000000   86.000000
+(PID.TID 0000.0001) EXF_SET_FLD: field "climsss", it=         0, loading rec=     1
+(PID.TID 0000.0001) EXF_SET_FLD:   from file: "lev_sss.bin"
+(PID.TID 0000.0001)  EXF_INTERP: file="lev_sss.bin", rec=     1 , x-Per,P.Sym=    T    T
+(PID.TID 0000.0001)  S.edge (j=-1,0,1) : proc= 0.0 0.0 0.0, yIn=  -86.000000  -82.000000  -78.000000
+(PID.TID 0000.0001)  N.edge (j=+0,+1,+2) proc= 0.0 0.0 0.0, yIn=   78.000000   82.000000   86.000000
+(PID.TID 0000.0001) EXF_SET_UV: fields "ustress" & "vstress", it=         0
+(PID.TID 0000.0001) EXF_SET_UV:   loading rec=    12 from file: "trenberth_taux.bin"
+(PID.TID 0000.0001) EXF_SET_UV:   loading rec=    12 from file: "trenberth_tauy.bin"
+(PID.TID 0000.0001)  EXF_INTERP_UV: fileU="trenberth_taux.bin", rec=    12 , x-Per,P.Sym=    T    T
+(PID.TID 0000.0001)  S.edge (j=-1,0,1) : proc= 0.0 0.0 0.0, yIn=  -86.000000  -82.000000  -78.000000
+(PID.TID 0000.0001)  N.edge (j=+0,+1,+2) proc= 0.0 0.0 0.0, yIn=   78.000000   82.000000   86.000000
+(PID.TID 0000.0001) EXF_SET_UV: fields "ustress" & "vstress", it=         0
+(PID.TID 0000.0001) EXF_SET_UV:   loading rec=     1 from file: "trenberth_taux.bin"
+(PID.TID 0000.0001) EXF_SET_UV:   loading rec=     1 from file: "trenberth_tauy.bin"
+(PID.TID 0000.0001)  EXF_INTERP_UV: fileU="trenberth_taux.bin", rec=     1 , x-Per,P.Sym=    T    T
+(PID.TID 0000.0001)  S.edge (j=-1,0,1) : proc= 0.0 0.0 0.0, yIn=  -86.000000  -82.000000  -78.000000
+(PID.TID 0000.0001)  N.edge (j=+0,+1,+2) proc= 0.0 0.0 0.0, yIn=   78.000000   82.000000   86.000000
+(PID.TID 0000.0001) EXF_SET_FLD: field "hflux", it=         0, loading rec=    12
+(PID.TID 0000.0001) EXF_SET_FLD:   from file: "ncep_qnet.bin"
+(PID.TID 0000.0001)  EXF_INTERP: file="ncep_qnet.bin", rec=    12 , x-Per,P.Sym=    T    T
+(PID.TID 0000.0001)  S.edge (j=-1,0,1) : proc= 0.0 0.0 0.0, yIn=  -86.000000  -82.000000  -78.000000
+(PID.TID 0000.0001)  N.edge (j=+0,+1,+2) proc= 0.0 0.0 0.0, yIn=   78.000000   82.000000   86.000000
+(PID.TID 0000.0001) EXF_SET_FLD: field "hflux", it=         0, loading rec=     1
+(PID.TID 0000.0001) EXF_SET_FLD:   from file: "ncep_qnet.bin"
+(PID.TID 0000.0001)  EXF_INTERP: file="ncep_qnet.bin", rec=     1 , x-Per,P.Sym=    T    T
+(PID.TID 0000.0001)  S.edge (j=-1,0,1) : proc= 0.0 0.0 0.0, yIn=  -86.000000  -82.000000  -78.000000
+(PID.TID 0000.0001)  N.edge (j=+0,+1,+2) proc= 0.0 0.0 0.0, yIn=   78.000000   82.000000   86.000000
 (PID.TID 0000.0001) SOLVE_FOR_PRESSURE: putPmEinXvector =    F
  cg2d: Sum(rhs),rhsMax =  -2.77555756156289E-16  2.53662338005399E+00
  cg2d: Sum(rhs),rhsMax =   4.51305659510126E-14  5.04305351695056E+00
@@ -5222,11 +3788,11 @@ grad-res -------------------------------
  cg2d: Sum(rhs),rhsMax =  -8.38440428196918E-13  9.34829007237321E+00
  cg2d: Sum(rhs),rhsMax =  -8.81072992342524E-13  9.12167905628693E+00
 (PID.TID 0000.0001) Did not write pickup because writePickupAtEnd = FALSE
-  early fc =  0.000000000000000D+00
+(PID.TID 0000.0001)   early fc =  0.000000000000000D+00
  --> objf_test(bi,bj)   =  0.354115231362102D+06
  --> objf_test(bi,bj)   =  0.444589534075236D+06
-  local fc =  0.798704765437337D+06
- global fc =  0.798704765437337D+06
+(PID.TID 0000.0001)   local fc =  0.798704765437337D+06
+(PID.TID 0000.0001)  global fc =  0.798704765437337D+06
 (PID.TID 0000.0001) grdchk perturb(-)fc: fcpertminus =  7.98704765437337E+05
 grad-res -------------------------------
  grad-res     0    3    6    8    1    1    1    1   7.98704765435E+05  7.98704765433E+05  7.98704765437E+05
@@ -5247,16 +3813,48 @@ grad-res -------------------------------
 (PID.TID 0000.0001) // Model current state
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) 
-(PID.TID 0000.0001)  EXF_SET_GEN: it=         0 loading rec=    12 from: lev_sst.bin
-(PID.TID 0000.0001)  EXF_SET_GEN: it=         0 loading rec=     1 from: lev_sst.bin
-(PID.TID 0000.0001)  EXF_SET_GEN: it=         0 loading rec=    12 from: lev_sss.bin
-(PID.TID 0000.0001)  EXF_SET_GEN: it=         0 loading rec=     1 from: lev_sss.bin
-(PID.TID 0000.0001)  EXF_SET_GEN: it=         0 loading rec=    12 from: trenberth_taux.bin
-(PID.TID 0000.0001)  EXF_SET_GEN: it=         0 loading rec=     1 from: trenberth_taux.bin
-(PID.TID 0000.0001)  EXF_SET_GEN: it=         0 loading rec=    12 from: trenberth_tauy.bin
-(PID.TID 0000.0001)  EXF_SET_GEN: it=         0 loading rec=     1 from: trenberth_tauy.bin
-(PID.TID 0000.0001)  EXF_SET_GEN: it=         0 loading rec=    12 from: ncep_qnet.bin
-(PID.TID 0000.0001)  EXF_SET_GEN: it=         0 loading rec=     1 from: ncep_qnet.bin
+(PID.TID 0000.0001) EXF_SET_FLD: field "climsst", it=         0, loading rec=    12
+(PID.TID 0000.0001) EXF_SET_FLD:   from file: "lev_sst.bin"
+(PID.TID 0000.0001)  EXF_INTERP: file="lev_sst.bin", rec=    12 , x-Per,P.Sym=    T    T
+(PID.TID 0000.0001)  S.edge (j=-1,0,1) : proc= 0.0 0.0 0.0, yIn=  -86.000000  -82.000000  -78.000000
+(PID.TID 0000.0001)  N.edge (j=+0,+1,+2) proc= 0.0 0.0 0.0, yIn=   78.000000   82.000000   86.000000
+(PID.TID 0000.0001) EXF_SET_FLD: field "climsst", it=         0, loading rec=     1
+(PID.TID 0000.0001) EXF_SET_FLD:   from file: "lev_sst.bin"
+(PID.TID 0000.0001)  EXF_INTERP: file="lev_sst.bin", rec=     1 , x-Per,P.Sym=    T    T
+(PID.TID 0000.0001)  S.edge (j=-1,0,1) : proc= 0.0 0.0 0.0, yIn=  -86.000000  -82.000000  -78.000000
+(PID.TID 0000.0001)  N.edge (j=+0,+1,+2) proc= 0.0 0.0 0.0, yIn=   78.000000   82.000000   86.000000
+(PID.TID 0000.0001) EXF_SET_FLD: field "climsss", it=         0, loading rec=    12
+(PID.TID 0000.0001) EXF_SET_FLD:   from file: "lev_sss.bin"
+(PID.TID 0000.0001)  EXF_INTERP: file="lev_sss.bin", rec=    12 , x-Per,P.Sym=    T    T
+(PID.TID 0000.0001)  S.edge (j=-1,0,1) : proc= 0.0 0.0 0.0, yIn=  -86.000000  -82.000000  -78.000000
+(PID.TID 0000.0001)  N.edge (j=+0,+1,+2) proc= 0.0 0.0 0.0, yIn=   78.000000   82.000000   86.000000
+(PID.TID 0000.0001) EXF_SET_FLD: field "climsss", it=         0, loading rec=     1
+(PID.TID 0000.0001) EXF_SET_FLD:   from file: "lev_sss.bin"
+(PID.TID 0000.0001)  EXF_INTERP: file="lev_sss.bin", rec=     1 , x-Per,P.Sym=    T    T
+(PID.TID 0000.0001)  S.edge (j=-1,0,1) : proc= 0.0 0.0 0.0, yIn=  -86.000000  -82.000000  -78.000000
+(PID.TID 0000.0001)  N.edge (j=+0,+1,+2) proc= 0.0 0.0 0.0, yIn=   78.000000   82.000000   86.000000
+(PID.TID 0000.0001) EXF_SET_UV: fields "ustress" & "vstress", it=         0
+(PID.TID 0000.0001) EXF_SET_UV:   loading rec=    12 from file: "trenberth_taux.bin"
+(PID.TID 0000.0001) EXF_SET_UV:   loading rec=    12 from file: "trenberth_tauy.bin"
+(PID.TID 0000.0001)  EXF_INTERP_UV: fileU="trenberth_taux.bin", rec=    12 , x-Per,P.Sym=    T    T
+(PID.TID 0000.0001)  S.edge (j=-1,0,1) : proc= 0.0 0.0 0.0, yIn=  -86.000000  -82.000000  -78.000000
+(PID.TID 0000.0001)  N.edge (j=+0,+1,+2) proc= 0.0 0.0 0.0, yIn=   78.000000   82.000000   86.000000
+(PID.TID 0000.0001) EXF_SET_UV: fields "ustress" & "vstress", it=         0
+(PID.TID 0000.0001) EXF_SET_UV:   loading rec=     1 from file: "trenberth_taux.bin"
+(PID.TID 0000.0001) EXF_SET_UV:   loading rec=     1 from file: "trenberth_tauy.bin"
+(PID.TID 0000.0001)  EXF_INTERP_UV: fileU="trenberth_taux.bin", rec=     1 , x-Per,P.Sym=    T    T
+(PID.TID 0000.0001)  S.edge (j=-1,0,1) : proc= 0.0 0.0 0.0, yIn=  -86.000000  -82.000000  -78.000000
+(PID.TID 0000.0001)  N.edge (j=+0,+1,+2) proc= 0.0 0.0 0.0, yIn=   78.000000   82.000000   86.000000
+(PID.TID 0000.0001) EXF_SET_FLD: field "hflux", it=         0, loading rec=    12
+(PID.TID 0000.0001) EXF_SET_FLD:   from file: "ncep_qnet.bin"
+(PID.TID 0000.0001)  EXF_INTERP: file="ncep_qnet.bin", rec=    12 , x-Per,P.Sym=    T    T
+(PID.TID 0000.0001)  S.edge (j=-1,0,1) : proc= 0.0 0.0 0.0, yIn=  -86.000000  -82.000000  -78.000000
+(PID.TID 0000.0001)  N.edge (j=+0,+1,+2) proc= 0.0 0.0 0.0, yIn=   78.000000   82.000000   86.000000
+(PID.TID 0000.0001) EXF_SET_FLD: field "hflux", it=         0, loading rec=     1
+(PID.TID 0000.0001) EXF_SET_FLD:   from file: "ncep_qnet.bin"
+(PID.TID 0000.0001)  EXF_INTERP: file="ncep_qnet.bin", rec=     1 , x-Per,P.Sym=    T    T
+(PID.TID 0000.0001)  S.edge (j=-1,0,1) : proc= 0.0 0.0 0.0, yIn=  -86.000000  -82.000000  -78.000000
+(PID.TID 0000.0001)  N.edge (j=+0,+1,+2) proc= 0.0 0.0 0.0, yIn=   78.000000   82.000000   86.000000
 (PID.TID 0000.0001) SOLVE_FOR_PRESSURE: putPmEinXvector =    F
  cg2d: Sum(rhs),rhsMax =  -2.77555756156289E-16  2.53662338005399E+00
  cg2d: Sum(rhs),rhsMax =   4.15778522722121E-14  5.04305351695056E+00
@@ -5276,14 +3874,14 @@ grad-res -------------------------------
  cg2d: Sum(rhs),rhsMax =  -7.88702436693711E-13  9.69891950278502E+00
  cg2d: Sum(rhs),rhsMax =  -6.69686528453894E-13  9.76269586770318E+00
  cg2d: Sum(rhs),rhsMax =  -7.22977233635902E-13  9.63804624669534E+00
- cg2d: Sum(rhs),rhsMax =  -6.50146603220492E-13  9.34829007249936E+00
+ cg2d: Sum(rhs),rhsMax =  -6.64357457935694E-13  9.34829007249936E+00
  cg2d: Sum(rhs),rhsMax =  -6.85673740008497E-13  9.12167905636955E+00
 (PID.TID 0000.0001) Did not write pickup because writePickupAtEnd = FALSE
-  early fc =  0.000000000000000D+00
+(PID.TID 0000.0001)   early fc =  0.000000000000000D+00
  --> objf_test(bi,bj)   =  0.354115231357987D+06
  --> objf_test(bi,bj)   =  0.444589534075221D+06
-  local fc =  0.798704765433208D+06
- global fc =  0.798704765433208D+06
+(PID.TID 0000.0001)   local fc =  0.798704765433208D+06
+(PID.TID 0000.0001)  global fc =  0.798704765433208D+06
 (PID.TID 0000.0001) grdchk perturb(+)fc: fcpertplus  =  7.98704765433208E+05
 (PID.TID 0000.0001) Start initial hydrostatic pressure computation
 (PID.TID 0000.0001) Pressure is predetermined for buoyancyRelation OCEANIC
@@ -5292,16 +3890,48 @@ grad-res -------------------------------
 (PID.TID 0000.0001) // Model current state
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) 
-(PID.TID 0000.0001)  EXF_SET_GEN: it=         0 loading rec=    12 from: lev_sst.bin
-(PID.TID 0000.0001)  EXF_SET_GEN: it=         0 loading rec=     1 from: lev_sst.bin
-(PID.TID 0000.0001)  EXF_SET_GEN: it=         0 loading rec=    12 from: lev_sss.bin
-(PID.TID 0000.0001)  EXF_SET_GEN: it=         0 loading rec=     1 from: lev_sss.bin
-(PID.TID 0000.0001)  EXF_SET_GEN: it=         0 loading rec=    12 from: trenberth_taux.bin
-(PID.TID 0000.0001)  EXF_SET_GEN: it=         0 loading rec=     1 from: trenberth_taux.bin
-(PID.TID 0000.0001)  EXF_SET_GEN: it=         0 loading rec=    12 from: trenberth_tauy.bin
-(PID.TID 0000.0001)  EXF_SET_GEN: it=         0 loading rec=     1 from: trenberth_tauy.bin
-(PID.TID 0000.0001)  EXF_SET_GEN: it=         0 loading rec=    12 from: ncep_qnet.bin
-(PID.TID 0000.0001)  EXF_SET_GEN: it=         0 loading rec=     1 from: ncep_qnet.bin
+(PID.TID 0000.0001) EXF_SET_FLD: field "climsst", it=         0, loading rec=    12
+(PID.TID 0000.0001) EXF_SET_FLD:   from file: "lev_sst.bin"
+(PID.TID 0000.0001)  EXF_INTERP: file="lev_sst.bin", rec=    12 , x-Per,P.Sym=    T    T
+(PID.TID 0000.0001)  S.edge (j=-1,0,1) : proc= 0.0 0.0 0.0, yIn=  -86.000000  -82.000000  -78.000000
+(PID.TID 0000.0001)  N.edge (j=+0,+1,+2) proc= 0.0 0.0 0.0, yIn=   78.000000   82.000000   86.000000
+(PID.TID 0000.0001) EXF_SET_FLD: field "climsst", it=         0, loading rec=     1
+(PID.TID 0000.0001) EXF_SET_FLD:   from file: "lev_sst.bin"
+(PID.TID 0000.0001)  EXF_INTERP: file="lev_sst.bin", rec=     1 , x-Per,P.Sym=    T    T
+(PID.TID 0000.0001)  S.edge (j=-1,0,1) : proc= 0.0 0.0 0.0, yIn=  -86.000000  -82.000000  -78.000000
+(PID.TID 0000.0001)  N.edge (j=+0,+1,+2) proc= 0.0 0.0 0.0, yIn=   78.000000   82.000000   86.000000
+(PID.TID 0000.0001) EXF_SET_FLD: field "climsss", it=         0, loading rec=    12
+(PID.TID 0000.0001) EXF_SET_FLD:   from file: "lev_sss.bin"
+(PID.TID 0000.0001)  EXF_INTERP: file="lev_sss.bin", rec=    12 , x-Per,P.Sym=    T    T
+(PID.TID 0000.0001)  S.edge (j=-1,0,1) : proc= 0.0 0.0 0.0, yIn=  -86.000000  -82.000000  -78.000000
+(PID.TID 0000.0001)  N.edge (j=+0,+1,+2) proc= 0.0 0.0 0.0, yIn=   78.000000   82.000000   86.000000
+(PID.TID 0000.0001) EXF_SET_FLD: field "climsss", it=         0, loading rec=     1
+(PID.TID 0000.0001) EXF_SET_FLD:   from file: "lev_sss.bin"
+(PID.TID 0000.0001)  EXF_INTERP: file="lev_sss.bin", rec=     1 , x-Per,P.Sym=    T    T
+(PID.TID 0000.0001)  S.edge (j=-1,0,1) : proc= 0.0 0.0 0.0, yIn=  -86.000000  -82.000000  -78.000000
+(PID.TID 0000.0001)  N.edge (j=+0,+1,+2) proc= 0.0 0.0 0.0, yIn=   78.000000   82.000000   86.000000
+(PID.TID 0000.0001) EXF_SET_UV: fields "ustress" & "vstress", it=         0
+(PID.TID 0000.0001) EXF_SET_UV:   loading rec=    12 from file: "trenberth_taux.bin"
+(PID.TID 0000.0001) EXF_SET_UV:   loading rec=    12 from file: "trenberth_tauy.bin"
+(PID.TID 0000.0001)  EXF_INTERP_UV: fileU="trenberth_taux.bin", rec=    12 , x-Per,P.Sym=    T    T
+(PID.TID 0000.0001)  S.edge (j=-1,0,1) : proc= 0.0 0.0 0.0, yIn=  -86.000000  -82.000000  -78.000000
+(PID.TID 0000.0001)  N.edge (j=+0,+1,+2) proc= 0.0 0.0 0.0, yIn=   78.000000   82.000000   86.000000
+(PID.TID 0000.0001) EXF_SET_UV: fields "ustress" & "vstress", it=         0
+(PID.TID 0000.0001) EXF_SET_UV:   loading rec=     1 from file: "trenberth_taux.bin"
+(PID.TID 0000.0001) EXF_SET_UV:   loading rec=     1 from file: "trenberth_tauy.bin"
+(PID.TID 0000.0001)  EXF_INTERP_UV: fileU="trenberth_taux.bin", rec=     1 , x-Per,P.Sym=    T    T
+(PID.TID 0000.0001)  S.edge (j=-1,0,1) : proc= 0.0 0.0 0.0, yIn=  -86.000000  -82.000000  -78.000000
+(PID.TID 0000.0001)  N.edge (j=+0,+1,+2) proc= 0.0 0.0 0.0, yIn=   78.000000   82.000000   86.000000
+(PID.TID 0000.0001) EXF_SET_FLD: field "hflux", it=         0, loading rec=    12
+(PID.TID 0000.0001) EXF_SET_FLD:   from file: "ncep_qnet.bin"
+(PID.TID 0000.0001)  EXF_INTERP: file="ncep_qnet.bin", rec=    12 , x-Per,P.Sym=    T    T
+(PID.TID 0000.0001)  S.edge (j=-1,0,1) : proc= 0.0 0.0 0.0, yIn=  -86.000000  -82.000000  -78.000000
+(PID.TID 0000.0001)  N.edge (j=+0,+1,+2) proc= 0.0 0.0 0.0, yIn=   78.000000   82.000000   86.000000
+(PID.TID 0000.0001) EXF_SET_FLD: field "hflux", it=         0, loading rec=     1
+(PID.TID 0000.0001) EXF_SET_FLD:   from file: "ncep_qnet.bin"
+(PID.TID 0000.0001)  EXF_INTERP: file="ncep_qnet.bin", rec=     1 , x-Per,P.Sym=    T    T
+(PID.TID 0000.0001)  S.edge (j=-1,0,1) : proc= 0.0 0.0 0.0, yIn=  -86.000000  -82.000000  -78.000000
+(PID.TID 0000.0001)  N.edge (j=+0,+1,+2) proc= 0.0 0.0 0.0, yIn=   78.000000   82.000000   86.000000
 (PID.TID 0000.0001) SOLVE_FOR_PRESSURE: putPmEinXvector =    F
  cg2d: Sum(rhs),rhsMax =  -2.77555756156289E-16  2.53662338005399E+00
  cg2d: Sum(rhs),rhsMax =   4.15778522722121E-14  5.04305351695056E+00
@@ -5310,32 +3940,32 @@ grad-res -------------------------------
  cg2d: Sum(rhs),rhsMax =   9.50350909079134E-14  6.82703161604641E+00
  cg2d: Sum(rhs),rhsMax =   5.58442181386454E-14  6.85801094461299E+00
  cg2d: Sum(rhs),rhsMax =   1.55431223447522E-14  7.14243599149923E+00
- cg2d: Sum(rhs),rhsMax =  -9.21485110438880E-14  7.72291365601715E+00
- cg2d: Sum(rhs),rhsMax =  -8.97060203897126E-14  8.03387068201753E+00
- cg2d: Sum(rhs),rhsMax =  -3.61044527608101E-13  8.11896831214255E+00
- cg2d: Sum(rhs),rhsMax =  -5.32018873400375E-13  8.04727754546010E+00
- cg2d: Sum(rhs),rhsMax =  -7.89590615113411E-13  7.88895797893534E+00
- cg2d: Sum(rhs),rhsMax =  -7.37188088351104E-13  8.31754379143366E+00
- cg2d: Sum(rhs),rhsMax =  -9.14823772291129E-13  8.97048397335082E+00
- cg2d: Sum(rhs),rhsMax =  -7.58504370423907E-13  9.43480072440762E+00
- cg2d: Sum(rhs),rhsMax =  -7.17648163117701E-13  9.69891950265375E+00
- cg2d: Sum(rhs),rhsMax =  -7.30082660993503E-13  9.76269586756682E+00
- cg2d: Sum(rhs),rhsMax =  -8.27782287160517E-13  9.63804624656201E+00
- cg2d: Sum(rhs),rhsMax =  -8.95283847057726E-13  9.34829007237653E+00
- cg2d: Sum(rhs),rhsMax =  -7.81597009336110E-13  9.12167905628406E+00
+ cg2d: Sum(rhs),rhsMax =  -9.19264664389630E-14  7.72291365601715E+00
+ cg2d: Sum(rhs),rhsMax =  -9.90318937965640E-14  8.03387068201753E+00
+ cg2d: Sum(rhs),rhsMax =  -3.86357612569554E-13  8.11896831214255E+00
+ cg2d: Sum(rhs),rhsMax =  -5.12478948166972E-13  8.04727754546010E+00
+ cg2d: Sum(rhs),rhsMax =  -7.68274333040608E-13  7.88895797893527E+00
+ cg2d: Sum(rhs),rhsMax =  -7.74491581978509E-13  8.31754379143366E+00
+ cg2d: Sum(rhs),rhsMax =  -9.84101689027739E-13  8.97048397335084E+00
+ cg2d: Sum(rhs),rhsMax =  -8.52651282912120E-13  9.43480072440763E+00
+ cg2d: Sum(rhs),rhsMax =  -7.33635374672303E-13  9.69891950265375E+00
+ cg2d: Sum(rhs),rhsMax =  -7.24753590475302E-13  9.76269586756687E+00
+ cg2d: Sum(rhs),rhsMax =  -8.75743921824323E-13  9.63804624656203E+00
+ cg2d: Sum(rhs),rhsMax =  -7.24753590475302E-13  9.34829007237654E+00
+ cg2d: Sum(rhs),rhsMax =  -7.49622586226906E-13  9.12167905628407E+00
 (PID.TID 0000.0001) Did not write pickup because writePickupAtEnd = FALSE
-  early fc =  0.000000000000000D+00
+(PID.TID 0000.0001)   early fc =  0.000000000000000D+00
  --> objf_test(bi,bj)   =  0.354115231362302D+06
- --> objf_test(bi,bj)   =  0.444589534075235D+06
-  local fc =  0.798704765437537D+06
- global fc =  0.798704765437537D+06
+ --> objf_test(bi,bj)   =  0.444589534075234D+06
+(PID.TID 0000.0001)   local fc =  0.798704765437537D+06
+(PID.TID 0000.0001)  global fc =  0.798704765437537D+06
 (PID.TID 0000.0001) grdchk perturb(-)fc: fcpertminus =  7.98704765437537E+05
 grad-res -------------------------------
  grad-res     0    4    7    8    1    1    1    1   7.98704765435E+05  7.98704765433E+05  7.98704765438E+05
- grad-res     0    4    4  207    0    1    1    1  -2.16533768328E-02 -2.16445187107E-02  4.09087329685E-04
+ grad-res     0    4    4  207    0    1    1    1  -2.16533768328E-02 -2.16439366341E-02  4.35968892484E-04
 (PID.TID 0000.0001)  ADM  ref_cost_function      =  7.98704765435371E+05
 (PID.TID 0000.0001)  ADM  adjoint_gradient       = -2.16533768327800E-02
-(PID.TID 0000.0001)  ADM  finite-diff_grad       = -2.16445187106729E-02
+(PID.TID 0000.0001)  ADM  finite-diff_grad       = -2.16439366340637E-02
 (PID.TID 0000.0001) ====== End of gradient-check number   4 (ierr=  0) =======
 (PID.TID 0000.0001) ====== Starts gradient-check number   5 (=ichknum) =======
  ph-test icomp, ncvarcomp, ichknum          208        6945           5
@@ -5349,16 +3979,48 @@ grad-res -------------------------------
 (PID.TID 0000.0001) // Model current state
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) 
-(PID.TID 0000.0001)  EXF_SET_GEN: it=         0 loading rec=    12 from: lev_sst.bin
-(PID.TID 0000.0001)  EXF_SET_GEN: it=         0 loading rec=     1 from: lev_sst.bin
-(PID.TID 0000.0001)  EXF_SET_GEN: it=         0 loading rec=    12 from: lev_sss.bin
-(PID.TID 0000.0001)  EXF_SET_GEN: it=         0 loading rec=     1 from: lev_sss.bin
-(PID.TID 0000.0001)  EXF_SET_GEN: it=         0 loading rec=    12 from: trenberth_taux.bin
-(PID.TID 0000.0001)  EXF_SET_GEN: it=         0 loading rec=     1 from: trenberth_taux.bin
-(PID.TID 0000.0001)  EXF_SET_GEN: it=         0 loading rec=    12 from: trenberth_tauy.bin
-(PID.TID 0000.0001)  EXF_SET_GEN: it=         0 loading rec=     1 from: trenberth_tauy.bin
-(PID.TID 0000.0001)  EXF_SET_GEN: it=         0 loading rec=    12 from: ncep_qnet.bin
-(PID.TID 0000.0001)  EXF_SET_GEN: it=         0 loading rec=     1 from: ncep_qnet.bin
+(PID.TID 0000.0001) EXF_SET_FLD: field "climsst", it=         0, loading rec=    12
+(PID.TID 0000.0001) EXF_SET_FLD:   from file: "lev_sst.bin"
+(PID.TID 0000.0001)  EXF_INTERP: file="lev_sst.bin", rec=    12 , x-Per,P.Sym=    T    T
+(PID.TID 0000.0001)  S.edge (j=-1,0,1) : proc= 0.0 0.0 0.0, yIn=  -86.000000  -82.000000  -78.000000
+(PID.TID 0000.0001)  N.edge (j=+0,+1,+2) proc= 0.0 0.0 0.0, yIn=   78.000000   82.000000   86.000000
+(PID.TID 0000.0001) EXF_SET_FLD: field "climsst", it=         0, loading rec=     1
+(PID.TID 0000.0001) EXF_SET_FLD:   from file: "lev_sst.bin"
+(PID.TID 0000.0001)  EXF_INTERP: file="lev_sst.bin", rec=     1 , x-Per,P.Sym=    T    T
+(PID.TID 0000.0001)  S.edge (j=-1,0,1) : proc= 0.0 0.0 0.0, yIn=  -86.000000  -82.000000  -78.000000
+(PID.TID 0000.0001)  N.edge (j=+0,+1,+2) proc= 0.0 0.0 0.0, yIn=   78.000000   82.000000   86.000000
+(PID.TID 0000.0001) EXF_SET_FLD: field "climsss", it=         0, loading rec=    12
+(PID.TID 0000.0001) EXF_SET_FLD:   from file: "lev_sss.bin"
+(PID.TID 0000.0001)  EXF_INTERP: file="lev_sss.bin", rec=    12 , x-Per,P.Sym=    T    T
+(PID.TID 0000.0001)  S.edge (j=-1,0,1) : proc= 0.0 0.0 0.0, yIn=  -86.000000  -82.000000  -78.000000
+(PID.TID 0000.0001)  N.edge (j=+0,+1,+2) proc= 0.0 0.0 0.0, yIn=   78.000000   82.000000   86.000000
+(PID.TID 0000.0001) EXF_SET_FLD: field "climsss", it=         0, loading rec=     1
+(PID.TID 0000.0001) EXF_SET_FLD:   from file: "lev_sss.bin"
+(PID.TID 0000.0001)  EXF_INTERP: file="lev_sss.bin", rec=     1 , x-Per,P.Sym=    T    T
+(PID.TID 0000.0001)  S.edge (j=-1,0,1) : proc= 0.0 0.0 0.0, yIn=  -86.000000  -82.000000  -78.000000
+(PID.TID 0000.0001)  N.edge (j=+0,+1,+2) proc= 0.0 0.0 0.0, yIn=   78.000000   82.000000   86.000000
+(PID.TID 0000.0001) EXF_SET_UV: fields "ustress" & "vstress", it=         0
+(PID.TID 0000.0001) EXF_SET_UV:   loading rec=    12 from file: "trenberth_taux.bin"
+(PID.TID 0000.0001) EXF_SET_UV:   loading rec=    12 from file: "trenberth_tauy.bin"
+(PID.TID 0000.0001)  EXF_INTERP_UV: fileU="trenberth_taux.bin", rec=    12 , x-Per,P.Sym=    T    T
+(PID.TID 0000.0001)  S.edge (j=-1,0,1) : proc= 0.0 0.0 0.0, yIn=  -86.000000  -82.000000  -78.000000
+(PID.TID 0000.0001)  N.edge (j=+0,+1,+2) proc= 0.0 0.0 0.0, yIn=   78.000000   82.000000   86.000000
+(PID.TID 0000.0001) EXF_SET_UV: fields "ustress" & "vstress", it=         0
+(PID.TID 0000.0001) EXF_SET_UV:   loading rec=     1 from file: "trenberth_taux.bin"
+(PID.TID 0000.0001) EXF_SET_UV:   loading rec=     1 from file: "trenberth_tauy.bin"
+(PID.TID 0000.0001)  EXF_INTERP_UV: fileU="trenberth_taux.bin", rec=     1 , x-Per,P.Sym=    T    T
+(PID.TID 0000.0001)  S.edge (j=-1,0,1) : proc= 0.0 0.0 0.0, yIn=  -86.000000  -82.000000  -78.000000
+(PID.TID 0000.0001)  N.edge (j=+0,+1,+2) proc= 0.0 0.0 0.0, yIn=   78.000000   82.000000   86.000000
+(PID.TID 0000.0001) EXF_SET_FLD: field "hflux", it=         0, loading rec=    12
+(PID.TID 0000.0001) EXF_SET_FLD:   from file: "ncep_qnet.bin"
+(PID.TID 0000.0001)  EXF_INTERP: file="ncep_qnet.bin", rec=    12 , x-Per,P.Sym=    T    T
+(PID.TID 0000.0001)  S.edge (j=-1,0,1) : proc= 0.0 0.0 0.0, yIn=  -86.000000  -82.000000  -78.000000
+(PID.TID 0000.0001)  N.edge (j=+0,+1,+2) proc= 0.0 0.0 0.0, yIn=   78.000000   82.000000   86.000000
+(PID.TID 0000.0001) EXF_SET_FLD: field "hflux", it=         0, loading rec=     1
+(PID.TID 0000.0001) EXF_SET_FLD:   from file: "ncep_qnet.bin"
+(PID.TID 0000.0001)  EXF_INTERP: file="ncep_qnet.bin", rec=     1 , x-Per,P.Sym=    T    T
+(PID.TID 0000.0001)  S.edge (j=-1,0,1) : proc= 0.0 0.0 0.0, yIn=  -86.000000  -82.000000  -78.000000
+(PID.TID 0000.0001)  N.edge (j=+0,+1,+2) proc= 0.0 0.0 0.0, yIn=   78.000000   82.000000   86.000000
 (PID.TID 0000.0001) SOLVE_FOR_PRESSURE: putPmEinXvector =    F
  cg2d: Sum(rhs),rhsMax =  -2.77555756156289E-16  2.53662338005399E+00
  cg2d: Sum(rhs),rhsMax =   3.80251385934116E-14  5.04305351695056E+00
@@ -5381,11 +4043,11 @@ grad-res -------------------------------
  cg2d: Sum(rhs),rhsMax =  -8.59756710269721E-13  9.34829007249099E+00
  cg2d: Sum(rhs),rhsMax =  -8.52651282912120E-13  9.12167905636606E+00
 (PID.TID 0000.0001) Did not write pickup because writePickupAtEnd = FALSE
-  early fc =  0.000000000000000D+00
+(PID.TID 0000.0001)   early fc =  0.000000000000000D+00
  --> objf_test(bi,bj)   =  0.354115231358061D+06
  --> objf_test(bi,bj)   =  0.444589534075221D+06
-  local fc =  0.798704765433282D+06
- global fc =  0.798704765433282D+06
+(PID.TID 0000.0001)   local fc =  0.798704765433282D+06
+(PID.TID 0000.0001)  global fc =  0.798704765433282D+06
 (PID.TID 0000.0001) grdchk perturb(+)fc: fcpertplus  =  7.98704765433282E+05
 (PID.TID 0000.0001) Start initial hydrostatic pressure computation
 (PID.TID 0000.0001) Pressure is predetermined for buoyancyRelation OCEANIC
@@ -5394,16 +4056,48 @@ grad-res -------------------------------
 (PID.TID 0000.0001) // Model current state
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) 
-(PID.TID 0000.0001)  EXF_SET_GEN: it=         0 loading rec=    12 from: lev_sst.bin
-(PID.TID 0000.0001)  EXF_SET_GEN: it=         0 loading rec=     1 from: lev_sst.bin
-(PID.TID 0000.0001)  EXF_SET_GEN: it=         0 loading rec=    12 from: lev_sss.bin
-(PID.TID 0000.0001)  EXF_SET_GEN: it=         0 loading rec=     1 from: lev_sss.bin
-(PID.TID 0000.0001)  EXF_SET_GEN: it=         0 loading rec=    12 from: trenberth_taux.bin
-(PID.TID 0000.0001)  EXF_SET_GEN: it=         0 loading rec=     1 from: trenberth_taux.bin
-(PID.TID 0000.0001)  EXF_SET_GEN: it=         0 loading rec=    12 from: trenberth_tauy.bin
-(PID.TID 0000.0001)  EXF_SET_GEN: it=         0 loading rec=     1 from: trenberth_tauy.bin
-(PID.TID 0000.0001)  EXF_SET_GEN: it=         0 loading rec=    12 from: ncep_qnet.bin
-(PID.TID 0000.0001)  EXF_SET_GEN: it=         0 loading rec=     1 from: ncep_qnet.bin
+(PID.TID 0000.0001) EXF_SET_FLD: field "climsst", it=         0, loading rec=    12
+(PID.TID 0000.0001) EXF_SET_FLD:   from file: "lev_sst.bin"
+(PID.TID 0000.0001)  EXF_INTERP: file="lev_sst.bin", rec=    12 , x-Per,P.Sym=    T    T
+(PID.TID 0000.0001)  S.edge (j=-1,0,1) : proc= 0.0 0.0 0.0, yIn=  -86.000000  -82.000000  -78.000000
+(PID.TID 0000.0001)  N.edge (j=+0,+1,+2) proc= 0.0 0.0 0.0, yIn=   78.000000   82.000000   86.000000
+(PID.TID 0000.0001) EXF_SET_FLD: field "climsst", it=         0, loading rec=     1
+(PID.TID 0000.0001) EXF_SET_FLD:   from file: "lev_sst.bin"
+(PID.TID 0000.0001)  EXF_INTERP: file="lev_sst.bin", rec=     1 , x-Per,P.Sym=    T    T
+(PID.TID 0000.0001)  S.edge (j=-1,0,1) : proc= 0.0 0.0 0.0, yIn=  -86.000000  -82.000000  -78.000000
+(PID.TID 0000.0001)  N.edge (j=+0,+1,+2) proc= 0.0 0.0 0.0, yIn=   78.000000   82.000000   86.000000
+(PID.TID 0000.0001) EXF_SET_FLD: field "climsss", it=         0, loading rec=    12
+(PID.TID 0000.0001) EXF_SET_FLD:   from file: "lev_sss.bin"
+(PID.TID 0000.0001)  EXF_INTERP: file="lev_sss.bin", rec=    12 , x-Per,P.Sym=    T    T
+(PID.TID 0000.0001)  S.edge (j=-1,0,1) : proc= 0.0 0.0 0.0, yIn=  -86.000000  -82.000000  -78.000000
+(PID.TID 0000.0001)  N.edge (j=+0,+1,+2) proc= 0.0 0.0 0.0, yIn=   78.000000   82.000000   86.000000
+(PID.TID 0000.0001) EXF_SET_FLD: field "climsss", it=         0, loading rec=     1
+(PID.TID 0000.0001) EXF_SET_FLD:   from file: "lev_sss.bin"
+(PID.TID 0000.0001)  EXF_INTERP: file="lev_sss.bin", rec=     1 , x-Per,P.Sym=    T    T
+(PID.TID 0000.0001)  S.edge (j=-1,0,1) : proc= 0.0 0.0 0.0, yIn=  -86.000000  -82.000000  -78.000000
+(PID.TID 0000.0001)  N.edge (j=+0,+1,+2) proc= 0.0 0.0 0.0, yIn=   78.000000   82.000000   86.000000
+(PID.TID 0000.0001) EXF_SET_UV: fields "ustress" & "vstress", it=         0
+(PID.TID 0000.0001) EXF_SET_UV:   loading rec=    12 from file: "trenberth_taux.bin"
+(PID.TID 0000.0001) EXF_SET_UV:   loading rec=    12 from file: "trenberth_tauy.bin"
+(PID.TID 0000.0001)  EXF_INTERP_UV: fileU="trenberth_taux.bin", rec=    12 , x-Per,P.Sym=    T    T
+(PID.TID 0000.0001)  S.edge (j=-1,0,1) : proc= 0.0 0.0 0.0, yIn=  -86.000000  -82.000000  -78.000000
+(PID.TID 0000.0001)  N.edge (j=+0,+1,+2) proc= 0.0 0.0 0.0, yIn=   78.000000   82.000000   86.000000
+(PID.TID 0000.0001) EXF_SET_UV: fields "ustress" & "vstress", it=         0
+(PID.TID 0000.0001) EXF_SET_UV:   loading rec=     1 from file: "trenberth_taux.bin"
+(PID.TID 0000.0001) EXF_SET_UV:   loading rec=     1 from file: "trenberth_tauy.bin"
+(PID.TID 0000.0001)  EXF_INTERP_UV: fileU="trenberth_taux.bin", rec=     1 , x-Per,P.Sym=    T    T
+(PID.TID 0000.0001)  S.edge (j=-1,0,1) : proc= 0.0 0.0 0.0, yIn=  -86.000000  -82.000000  -78.000000
+(PID.TID 0000.0001)  N.edge (j=+0,+1,+2) proc= 0.0 0.0 0.0, yIn=   78.000000   82.000000   86.000000
+(PID.TID 0000.0001) EXF_SET_FLD: field "hflux", it=         0, loading rec=    12
+(PID.TID 0000.0001) EXF_SET_FLD:   from file: "ncep_qnet.bin"
+(PID.TID 0000.0001)  EXF_INTERP: file="ncep_qnet.bin", rec=    12 , x-Per,P.Sym=    T    T
+(PID.TID 0000.0001)  S.edge (j=-1,0,1) : proc= 0.0 0.0 0.0, yIn=  -86.000000  -82.000000  -78.000000
+(PID.TID 0000.0001)  N.edge (j=+0,+1,+2) proc= 0.0 0.0 0.0, yIn=   78.000000   82.000000   86.000000
+(PID.TID 0000.0001) EXF_SET_FLD: field "hflux", it=         0, loading rec=     1
+(PID.TID 0000.0001) EXF_SET_FLD:   from file: "ncep_qnet.bin"
+(PID.TID 0000.0001)  EXF_INTERP: file="ncep_qnet.bin", rec=     1 , x-Per,P.Sym=    T    T
+(PID.TID 0000.0001)  S.edge (j=-1,0,1) : proc= 0.0 0.0 0.0, yIn=  -86.000000  -82.000000  -78.000000
+(PID.TID 0000.0001)  N.edge (j=+0,+1,+2) proc= 0.0 0.0 0.0, yIn=   78.000000   82.000000   86.000000
 (PID.TID 0000.0001) SOLVE_FOR_PRESSURE: putPmEinXvector =    F
  cg2d: Sum(rhs),rhsMax =  -2.77555756156289E-16  2.53662338005399E+00
  cg2d: Sum(rhs),rhsMax =   3.80251385934116E-14  5.04305351695056E+00
@@ -5420,17 +4114,17 @@ grad-res -------------------------------
  cg2d: Sum(rhs),rhsMax =  -8.75743921824323E-13  8.31754379143682E+00
  cg2d: Sum(rhs),rhsMax =  -7.76267938817909E-13  8.97048397335530E+00
  cg2d: Sum(rhs),rhsMax =  -7.31859017832903E-13  9.43480072441335E+00
- cg2d: Sum(rhs),rhsMax =  -8.63309423948522E-13  9.69891950266066E+00
- cg2d: Sum(rhs),rhsMax =  -7.53175299905706E-13  9.76269586757459E+00
- cg2d: Sum(rhs),rhsMax =  -5.59552404411079E-13  9.63804624657024E+00
- cg2d: Sum(rhs),rhsMax =  -8.63309423948522E-13  9.34829007238485E+00
- cg2d: Sum(rhs),rhsMax =  -7.88702436693711E-13  9.12167905628749E+00
+ cg2d: Sum(rhs),rhsMax =  -8.45545855554519E-13  9.69891950266066E+00
+ cg2d: Sum(rhs),rhsMax =  -7.47846229387505E-13  9.76269586757459E+00
+ cg2d: Sum(rhs),rhsMax =  -5.20472553944273E-13  9.63804624657024E+00
+ cg2d: Sum(rhs),rhsMax =  -8.81072992342524E-13  9.34829007238485E+00
+ cg2d: Sum(rhs),rhsMax =  -8.10018718766514E-13  9.12167905628749E+00
 (PID.TID 0000.0001) Did not write pickup because writePickupAtEnd = FALSE
-  early fc =  0.000000000000000D+00
+(PID.TID 0000.0001)   early fc =  0.000000000000000D+00
  --> objf_test(bi,bj)   =  0.354115231362228D+06
  --> objf_test(bi,bj)   =  0.444589534075233D+06
-  local fc =  0.798704765437461D+06
- global fc =  0.798704765437461D+06
+(PID.TID 0000.0001)   local fc =  0.798704765437461D+06
+(PID.TID 0000.0001)  global fc =  0.798704765437461D+06
 (PID.TID 0000.0001) grdchk perturb(-)fc: fcpertminus =  7.98704765437461E+05
 grad-res -------------------------------
  grad-res     0    5    8    8    1    1    1    1   7.98704765435E+05  7.98704765433E+05  7.98704765437E+05
@@ -5452,11 +4146,11 @@ grad-res -------------------------------
 (PID.TID 0000.0001) 
 (PID.TID 0000.0001) grdchk output (p):   1     4     8     1    1    1   0.000000000E+00 -1.000000000E-04
 (PID.TID 0000.0001) grdchk output (c):   1  7.9870476543537E+05  7.9870476543338E+05  7.9870476543737E+05
-(PID.TID 0000.0001) grdchk output (g):   1    -1.9961153157055E-02 -1.9954593441574E-02 -3.2873210376350E-04
+(PID.TID 0000.0001) grdchk output (g):   1    -1.9962317310274E-02 -1.9954593441574E-02 -3.8707221586232E-04
 (PID.TID 0000.0001) 
 (PID.TID 0000.0001) grdchk output (p):   2     5     8     1    1    1   0.000000000E+00 -1.000000000E-04
 (PID.TID 0000.0001) grdchk output (c):   2  7.9870476543537E+05  7.9870476543341E+05  7.9870476543733E+05
-(PID.TID 0000.0001) grdchk output (g):   2    -1.9620056264102E-02 -1.9621073100437E-02  5.1823686155639E-05
+(PID.TID 0000.0001) grdchk output (g):   2    -1.9618892110884E-02 -1.9621073100437E-02  1.1115546746598E-04
 (PID.TID 0000.0001) 
 (PID.TID 0000.0001) grdchk output (p):   3     6     8     1    1    1   0.000000000E+00 -1.000000000E-04
 (PID.TID 0000.0001) grdchk output (c):   3  7.9870476543537E+05  7.9870476543341E+05  7.9870476543734E+05
@@ -5464,184 +4158,190 @@ grad-res -------------------------------
 (PID.TID 0000.0001) 
 (PID.TID 0000.0001) grdchk output (p):   4     7     8     1    1    1   0.000000000E+00 -1.000000000E-04
 (PID.TID 0000.0001) grdchk output (c):   4  7.9870476543537E+05  7.9870476543321E+05  7.9870476543754E+05
-(PID.TID 0000.0001) grdchk output (g):   4    -2.1644518710673E-02 -2.1653376832780E-02  4.0908732968536E-04
+(PID.TID 0000.0001) grdchk output (g):   4    -2.1643936634064E-02 -2.1653376832780E-02  4.3596889248410E-04
 (PID.TID 0000.0001) 
 (PID.TID 0000.0001) grdchk output (p):   5     8     8     1    1    1   0.000000000E+00 -1.000000000E-04
 (PID.TID 0000.0001) grdchk output (c):   5  7.9870476543537E+05  7.9870476543328E+05  7.9870476543746E+05
 (PID.TID 0000.0001) grdchk output (g):   5    -2.0896550267935E-02 -2.0895261587307E-02 -6.1673342671043E-05
 (PID.TID 0000.0001) 
-(PID.TID 0000.0001) grdchk  summary  :  RMS of    5 ratios =  2.3785999501731E-04
+(PID.TID 0000.0001) grdchk  summary  :  RMS of    5 ratios =  2.6722023344107E-04
 (PID.TID 0000.0001) 
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // Gradient check results  >>> END <<<
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) 
 (PID.TID 0000.0001)   Seconds in section "ALL                    [THE_MODEL_MAIN]":
-(PID.TID 0000.0001)           User time:   230.39697963767685
-(PID.TID 0000.0001)         System time:  0.48392698529642075
-(PID.TID 0000.0001)     Wall clock time:   231.58339595794678
+(PID.TID 0000.0001)           User time:   204.44940704782493
+(PID.TID 0000.0001)         System time:   1.4140470027923584
+(PID.TID 0000.0001)     Wall clock time:   230.82279992103577
 (PID.TID 0000.0001)          No. starts:           1
 (PID.TID 0000.0001)           No. stops:           1
 (PID.TID 0000.0001)   Seconds in section "INITIALISE_FIXED       [THE_MODEL_MAIN]":
-(PID.TID 0000.0001)           User time:  0.13897899561561644
-(PID.TID 0000.0001)         System time:  1.59980001626536250E-002
-(PID.TID 0000.0001)     Wall clock time:  0.21055603027343750
+(PID.TID 0000.0001)           User time:  0.10705700214020908
+(PID.TID 0000.0001)         System time:   3.2735001295804977E-002
+(PID.TID 0000.0001)     Wall clock time:  0.19469881057739258
 (PID.TID 0000.0001)          No. starts:           1
 (PID.TID 0000.0001)           No. stops:           1
 (PID.TID 0000.0001)   Seconds in section "ADTHE_MAIN_LOOP          [ADJOINT RUN]":
-(PID.TID 0000.0001)           User time:   83.186352998018265
-(PID.TID 0000.0001)         System time:  0.37994200922548771
-(PID.TID 0000.0001)     Wall clock time:   83.859733104705811
+(PID.TID 0000.0001)           User time:   75.358791172504425
+(PID.TID 0000.0001)         System time:   1.2261389456689358
+(PID.TID 0000.0001)     Wall clock time:   86.757795095443726
 (PID.TID 0000.0001)          No. starts:           1
 (PID.TID 0000.0001)           No. stops:           1
 (PID.TID 0000.0001)   Seconds in section "FORWARD_STEP        [MAIN_DO_LOOP]":
-(PID.TID 0000.0001)           User time:   165.38583296537399
-(PID.TID 0000.0001)         System time:  9.69860590994358063E-002
-(PID.TID 0000.0001)     Wall clock time:   165.92188835144043
-(PID.TID 0000.0001)          No. starts:         234
-(PID.TID 0000.0001)           No. stops:         234
+(PID.TID 0000.0001)           User time:   144.73576980829239
+(PID.TID 0000.0001)         System time:  0.12413885444402695
+(PID.TID 0000.0001)     Wall clock time:   162.31060528755188
+(PID.TID 0000.0001)          No. starts:         240
+(PID.TID 0000.0001)           No. stops:         240
 (PID.TID 0000.0001)   Seconds in section "LOAD_FIELDS_DRIVER  [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:   1.1097114384174347
-(PID.TID 0000.0001)         System time:  1.49979852139949799E-002
-(PID.TID 0000.0001)     Wall clock time:   1.1626951694488525
-(PID.TID 0000.0001)          No. starts:         234
-(PID.TID 0000.0001)           No. stops:         234
+(PID.TID 0000.0001)           User time:   1.2519042789936066
+(PID.TID 0000.0001)         System time:   1.7357937991619110E-002
+(PID.TID 0000.0001)     Wall clock time:   2.1877427101135254
+(PID.TID 0000.0001)          No. starts:         240
+(PID.TID 0000.0001)           No. stops:         240
 (PID.TID 0000.0001)   Seconds in section "EXF_GETFORCING     [LOAD_FLDS_DRIVER]":
-(PID.TID 0000.0001)           User time:   1.1017158329486847
-(PID.TID 0000.0001)         System time:  1.39979980885982513E-002
-(PID.TID 0000.0001)     Wall clock time:   1.1541781425476074
-(PID.TID 0000.0001)          No. starts:         234
-(PID.TID 0000.0001)           No. stops:         234
+(PID.TID 0000.0001)           User time:   1.2422281503677368
+(PID.TID 0000.0001)         System time:   1.7263107001781464E-002
+(PID.TID 0000.0001)     Wall clock time:   2.1740207672119141
+(PID.TID 0000.0001)          No. starts:         240
+(PID.TID 0000.0001)           No. stops:         240
 (PID.TID 0000.0001)   Seconds in section "I/O (WRITE)        [ADJOINT LOOP]":
-(PID.TID 0000.0001)           User time:  7.99942016601562500E-003
-(PID.TID 0000.0001)         System time:   0.0000000000000000
-(PID.TID 0000.0001)     Wall clock time:  7.90572166442871094E-003
-(PID.TID 0000.0001)          No. starts:         862
-(PID.TID 0000.0001)           No. stops:         862
+(PID.TID 0000.0001)           User time:   9.0498626232147217E-003
+(PID.TID 0000.0001)         System time:   1.1873990297317505E-004
+(PID.TID 0000.0001)     Wall clock time:   8.0914497375488281E-003
+(PID.TID 0000.0001)          No. starts:         820
+(PID.TID 0000.0001)           No. stops:         820
 (PID.TID 0000.0001)   Seconds in section "EXTERNAL_FLDS_LOAD [LOAD_FLDS_DRIVER]":
-(PID.TID 0000.0001)           User time:  1.00708007812500000E-003
-(PID.TID 0000.0001)         System time:   0.0000000000000000
-(PID.TID 0000.0001)     Wall clock time:  2.19154357910156250E-003
-(PID.TID 0000.0001)          No. starts:         234
-(PID.TID 0000.0001)           No. stops:         234
+(PID.TID 0000.0001)           User time:   2.3000240325927734E-003
+(PID.TID 0000.0001)         System time:   2.8952956199645996E-005
+(PID.TID 0000.0001)     Wall clock time:   2.4783611297607422E-003
+(PID.TID 0000.0001)          No. starts:         240
+(PID.TID 0000.0001)           No. stops:         240
+(PID.TID 0000.0001)   Seconds in section "CTRL_MAP_FORCING  [FORWARD_STEP]":
+(PID.TID 0000.0001)           User time:   2.3527443408966064E-003
+(PID.TID 0000.0001)         System time:   3.4138560295104980E-005
+(PID.TID 0000.0001)     Wall clock time:   2.3305416107177734E-003
+(PID.TID 0000.0001)          No. starts:         240
+(PID.TID 0000.0001)           No. stops:         240
 (PID.TID 0000.0001)   Seconds in section "DO_ATMOSPHERIC_PHYS [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:  0.20287358760833740
-(PID.TID 0000.0001)         System time:   0.0000000000000000
-(PID.TID 0000.0001)     Wall clock time:  0.19924902915954590
-(PID.TID 0000.0001)          No. starts:         234
-(PID.TID 0000.0001)           No. stops:         234
+(PID.TID 0000.0001)           User time:  0.14730364084243774
+(PID.TID 0000.0001)         System time:   2.1918714046478271E-003
+(PID.TID 0000.0001)     Wall clock time:  0.16550970077514648
+(PID.TID 0000.0001)          No. starts:         240
+(PID.TID 0000.0001)           No. stops:         240
 (PID.TID 0000.0001)   Seconds in section "DO_OCEANIC_PHYS     [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:   25.533201068639755
-(PID.TID 0000.0001)         System time:  8.99798423051834106E-003
-(PID.TID 0000.0001)     Wall clock time:   25.611576080322266
-(PID.TID 0000.0001)          No. starts:         234
-(PID.TID 0000.0001)           No. stops:         234
+(PID.TID 0000.0001)           User time:   21.539048820734024
+(PID.TID 0000.0001)         System time:   1.1634126305580139E-002
+(PID.TID 0000.0001)     Wall clock time:   23.982547283172607
+(PID.TID 0000.0001)          No. starts:         240
+(PID.TID 0000.0001)           No. stops:         240
 (PID.TID 0000.0001)   Seconds in section "THERMODYNAMICS      [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:   50.727334260940552
-(PID.TID 0000.0001)         System time:  2.89960578083992004E-002
-(PID.TID 0000.0001)     Wall clock time:   50.870495319366455
-(PID.TID 0000.0001)          No. starts:         234
-(PID.TID 0000.0001)           No. stops:         234
+(PID.TID 0000.0001)           User time:   44.378943860530853
+(PID.TID 0000.0001)         System time:   1.6317948698997498E-002
+(PID.TID 0000.0001)     Wall clock time:   49.425491094589233
+(PID.TID 0000.0001)          No. starts:         240
+(PID.TID 0000.0001)           No. stops:         240
 (PID.TID 0000.0001)   Seconds in section "DYNAMICS            [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:   66.285884082317352
-(PID.TID 0000.0001)         System time:  1.89969912171363831E-002
-(PID.TID 0000.0001)     Wall clock time:   66.490280866622925
-(PID.TID 0000.0001)          No. starts:         234
-(PID.TID 0000.0001)           No. stops:         234
+(PID.TID 0000.0001)           User time:   57.844526886940002
+(PID.TID 0000.0001)         System time:   3.6507748067378998E-002
+(PID.TID 0000.0001)     Wall clock time:   64.671465158462524
+(PID.TID 0000.0001)          No. starts:         240
+(PID.TID 0000.0001)           No. stops:         240
 (PID.TID 0000.0001)   Seconds in section "SOLVE_FOR_PRESSURE  [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:   11.203293561935425
-(PID.TID 0000.0001)         System time:  1.09979733824729919E-002
-(PID.TID 0000.0001)     Wall clock time:   11.237483739852905
-(PID.TID 0000.0001)          No. starts:         234
-(PID.TID 0000.0001)           No. stops:         234
+(PID.TID 0000.0001)           User time:   10.512911379337311
+(PID.TID 0000.0001)         System time:   2.2663116455078125E-002
+(PID.TID 0000.0001)     Wall clock time:   11.768797159194946
+(PID.TID 0000.0001)          No. starts:         240
+(PID.TID 0000.0001)           No. stops:         240
 (PID.TID 0000.0001)   Seconds in section "MOM_CORRECTION_STEP [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:   1.3618136644363403
-(PID.TID 0000.0001)         System time:  1.00001692771911621E-003
-(PID.TID 0000.0001)     Wall clock time:   1.3616418838500977
-(PID.TID 0000.0001)          No. starts:         234
-(PID.TID 0000.0001)           No. stops:         234
+(PID.TID 0000.0001)           User time:   1.6746615767478943
+(PID.TID 0000.0001)         System time:   5.7603418827056885E-004
+(PID.TID 0000.0001)     Wall clock time:   1.8408973217010498
+(PID.TID 0000.0001)          No. starts:         240
+(PID.TID 0000.0001)           No. stops:         240
 (PID.TID 0000.0001)   Seconds in section "INTEGR_CONTINUITY   [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:   2.4135764837265015
-(PID.TID 0000.0001)         System time:  1.00001692771911621E-003
-(PID.TID 0000.0001)     Wall clock time:   2.4189317226409912
-(PID.TID 0000.0001)          No. starts:         234
-(PID.TID 0000.0001)           No. stops:         234
+(PID.TID 0000.0001)           User time:   2.1788600683212280
+(PID.TID 0000.0001)         System time:   4.4470429420471191E-003
+(PID.TID 0000.0001)     Wall clock time:   2.4730799198150635
+(PID.TID 0000.0001)          No. starts:         240
+(PID.TID 0000.0001)           No. stops:         240
 (PID.TID 0000.0001)   Seconds in section "TRC_CORRECTION_STEP [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:  1.99890136718750000E-003
-(PID.TID 0000.0001)         System time:   0.0000000000000000
-(PID.TID 0000.0001)     Wall clock time:  2.30407714843750000E-003
-(PID.TID 0000.0001)          No. starts:         234
-(PID.TID 0000.0001)           No. stops:         234
+(PID.TID 0000.0001)           User time:   2.6018619537353516E-003
+(PID.TID 0000.0001)         System time:   2.9504299163818359E-006
+(PID.TID 0000.0001)     Wall clock time:   2.5229454040527344E-003
+(PID.TID 0000.0001)          No. starts:         240
+(PID.TID 0000.0001)           No. stops:         240
 (PID.TID 0000.0001)   Seconds in section "BLOCKING_EXCHANGES  [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:  0.98883628845214844
-(PID.TID 0000.0001)         System time:   0.0000000000000000
-(PID.TID 0000.0001)     Wall clock time:  0.99307465553283691
-(PID.TID 0000.0001)          No. starts:         234
-(PID.TID 0000.0001)           No. stops:         234
+(PID.TID 0000.0001)           User time:  0.83714365959167480
+(PID.TID 0000.0001)         System time:   2.3302435874938965E-004
+(PID.TID 0000.0001)     Wall clock time:  0.93484854698181152
+(PID.TID 0000.0001)          No. starts:         240
+(PID.TID 0000.0001)           No. stops:         240
 (PID.TID 0000.0001)   Seconds in section "MONITOR             [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:   1.7437351942062378
-(PID.TID 0000.0001)         System time:  2.00000405311584473E-003
-(PID.TID 0000.0001)     Wall clock time:   1.7505931854248047
-(PID.TID 0000.0001)          No. starts:          20
-(PID.TID 0000.0001)           No. stops:          20
+(PID.TID 0000.0001)           User time:  0.14868205785751343
+(PID.TID 0000.0001)         System time:   2.1994113922119141E-005
+(PID.TID 0000.0001)     Wall clock time:  0.16475772857666016
+(PID.TID 0000.0001)          No. starts:         240
+(PID.TID 0000.0001)           No. stops:         240
 (PID.TID 0000.0001)   Seconds in section "COST_TILE           [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:   3.7155829668045044
-(PID.TID 0000.0001)         System time:   0.0000000000000000
-(PID.TID 0000.0001)     Wall clock time:   3.7097675800323486
-(PID.TID 0000.0001)          No. starts:         234
-(PID.TID 0000.0001)           No. stops:         234
+(PID.TID 0000.0001)           User time:   4.1007152199745178
+(PID.TID 0000.0001)         System time:   7.9747587442398071E-003
+(PID.TID 0000.0001)     Wall clock time:   4.5588421821594238
+(PID.TID 0000.0001)          No. starts:         240
+(PID.TID 0000.0001)           No. stops:         240
 (PID.TID 0000.0001)   Seconds in section "DO_THE_MODEL_IO     [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:  2.19898223876953125E-002
-(PID.TID 0000.0001)         System time:  3.99899482727050781E-003
-(PID.TID 0000.0001)     Wall clock time:  2.69167423248291016E-002
-(PID.TID 0000.0001)          No. starts:         234
-(PID.TID 0000.0001)           No. stops:         234
+(PID.TID 0000.0001)           User time:   2.2068202495574951E-002
+(PID.TID 0000.0001)         System time:   3.9689838886260986E-003
+(PID.TID 0000.0001)     Wall clock time:   3.0000686645507812E-002
+(PID.TID 0000.0001)          No. starts:         240
+(PID.TID 0000.0001)           No. stops:         240
 (PID.TID 0000.0001)   Seconds in section "DO_WRITE_PICKUP     [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:  5.19981384277343750E-002
-(PID.TID 0000.0001)         System time:  4.00000065565109253E-003
-(PID.TID 0000.0001)     Wall clock time:  5.47542572021484375E-002
-(PID.TID 0000.0001)          No. starts:         234
-(PID.TID 0000.0001)           No. stops:         234
+(PID.TID 0000.0001)           User time:   4.7981202602386475E-002
+(PID.TID 0000.0001)         System time:   2.9146671295166016E-005
+(PID.TID 0000.0001)     Wall clock time:   5.2205324172973633E-002
+(PID.TID 0000.0001)          No. starts:         240
+(PID.TID 0000.0001)           No. stops:         240
 (PID.TID 0000.0001)   Seconds in section "CTRL_PACK           [THE_MODEL_MAIN]":
-(PID.TID 0000.0001)           User time:  6.19888305664062500E-002
-(PID.TID 0000.0001)         System time:  6.99898600578308105E-003
-(PID.TID 0000.0001)     Wall clock time:  6.87141418457031250E-002
+(PID.TID 0000.0001)           User time:   5.2383422851562500E-002
+(PID.TID 0000.0001)         System time:   1.2001991271972656E-002
+(PID.TID 0000.0001)     Wall clock time:   6.8381071090698242E-002
 (PID.TID 0000.0001)          No. starts:           1
 (PID.TID 0000.0001)           No. stops:           1
 (PID.TID 0000.0001)   Seconds in section "CTRL_PACK     [THE_MODEL_MAIN]":
-(PID.TID 0000.0001)           User time:  6.59942626953125000E-002
-(PID.TID 0000.0001)         System time:  2.00000405311584473E-003
-(PID.TID 0000.0001)     Wall clock time:  6.96840286254882813E-002
+(PID.TID 0000.0001)           User time:   5.4412841796875000E-002
+(PID.TID 0000.0001)         System time:   7.9720020294189453E-003
+(PID.TID 0000.0001)     Wall clock time:   7.4369907379150391E-002
 (PID.TID 0000.0001)          No. starts:           1
 (PID.TID 0000.0001)           No. stops:           1
 (PID.TID 0000.0001)   Seconds in section "GRDCHK_MAIN         [THE_MODEL_MAIN]":
-(PID.TID 0000.0001)           User time:   146.94366455078125
-(PID.TID 0000.0001)         System time:  7.89879858493804932E-002
-(PID.TID 0000.0001)     Wall clock time:   147.37463402748108
+(PID.TID 0000.0001)           User time:   128.87667083740234
+(PID.TID 0000.0001)         System time:  0.13519299030303955
+(PID.TID 0000.0001)     Wall clock time:   143.72746706008911
 (PID.TID 0000.0001)          No. starts:           1
 (PID.TID 0000.0001)           No. stops:           1
 (PID.TID 0000.0001)   Seconds in section "INITIALISE_VARIA    [THE_MAIN_LOOP]":
-(PID.TID 0000.0001)           User time:  0.73190307617187500
-(PID.TID 0000.0001)         System time:  6.99996948242187500E-003
-(PID.TID 0000.0001)     Wall clock time:  0.74204063415527344
+(PID.TID 0000.0001)           User time:  0.74491882324218750
+(PID.TID 0000.0001)         System time:   1.9590973854064941E-002
+(PID.TID 0000.0001)     Wall clock time:  0.84836292266845703
 (PID.TID 0000.0001)          No. starts:          10
 (PID.TID 0000.0001)           No. stops:          10
 (PID.TID 0000.0001)   Seconds in section "MAIN LOOP           [THE_MAIN_LOOP]":
-(PID.TID 0000.0001)           User time:   146.17876434326172
-(PID.TID 0000.0001)         System time:  6.49900436401367188E-002
-(PID.TID 0000.0001)     Wall clock time:   146.59405207633972
+(PID.TID 0000.0001)           User time:   128.10452270507812
+(PID.TID 0000.0001)         System time:   9.9434971809387207E-002
+(PID.TID 0000.0001)     Wall clock time:   142.82770037651062
 (PID.TID 0000.0001)          No. starts:          10
 (PID.TID 0000.0001)           No. stops:          10
 (PID.TID 0000.0001)   Seconds in section "MAIN_DO_LOOP        [THE_MAIN_LOOP]":
-(PID.TID 0000.0001)           User time:   139.47177124023438
-(PID.TID 0000.0001)         System time:  6.49900436401367188E-002
-(PID.TID 0000.0001)     Wall clock time:   139.85805845260620
+(PID.TID 0000.0001)           User time:   121.53507995605469
+(PID.TID 0000.0001)         System time:   9.5375895500183105E-002
+(PID.TID 0000.0001)     Wall clock time:   135.52848172187805
 (PID.TID 0000.0001)          No. starts:         200
 (PID.TID 0000.0001)           No. stops:         200
 (PID.TID 0000.0001)   Seconds in section "COST_FINAL         [ADJOINT SPIN-DOWN]":
-(PID.TID 0000.0001)           User time:  1.00708007812500000E-003
+(PID.TID 0000.0001)           User time:   1.7013549804687500E-003
 (PID.TID 0000.0001)         System time:   0.0000000000000000
-(PID.TID 0000.0001)     Wall clock time:  1.38020515441894531E-003
+(PID.TID 0000.0001)     Wall clock time:   1.6679763793945312E-003
 (PID.TID 0000.0001)          No. starts:          10
 (PID.TID 0000.0001)           No. stops:          10
 (PID.TID 0000.0001) // ======================================================
@@ -5670,9 +4370,9 @@ grad-res -------------------------------
 (PID.TID 0000.0001) //          Total. Y spins =              0
 (PID.TID 0000.0001) //            Avg. Y spins =       0.00E+00
 (PID.TID 0000.0001) // o Thread number: 000001
-(PID.TID 0000.0001) //            No. barriers =          50526
+(PID.TID 0000.0001) //            No. barriers =          46630
 (PID.TID 0000.0001) //      Max. barrier spins =              1
 (PID.TID 0000.0001) //      Min. barrier spins =              1
-(PID.TID 0000.0001) //     Total barrier spins =          50526
+(PID.TID 0000.0001) //     Total barrier spins =          46630
 (PID.TID 0000.0001) //      Avg. barrier spins =       1.00E+00
 PROGRAM MAIN: Execution ended Normally

--- a/verification/obcs_ctrl/input_ad/data
+++ b/verification/obcs_ctrl/input_ad/data
@@ -39,14 +39,14 @@
  endTime=4800.,
  deltaTmom=1200.0,
  deltaTtracer=1200.0,
- dumpInitAndLast=.TRUE.,
  abEps=0.1,
+ dumpInitAndLast=.TRUE.,
  pChkptFreq=0.0,
  chkptFreq=0.0,
  dumpFreq=2628000.0,
-#monitorFreq=432000.,
- monitorFreq=3600.,
- monitorSelect=1,
+ monitorSelect= 1,
+ monitorFreq = 4800.,
+ adjMonitorFreq=3600.,
  &
 # Gridding parameters
  &PARM04

--- a/verification/obcs_ctrl/input_ad/tr_checklist.adm
+++ b/verification/obcs_ctrl/input_ad/tr_checklist.adm
@@ -1,0 +1,1 @@
+admGrd admCst admGrd admFwd T+ Eta+ U+ V+

--- a/verification/obcs_ctrl/results/output_adm.txt
+++ b/verification/obcs_ctrl/results/output_adm.txt
@@ -5,10 +5,10 @@
 (PID.TID 0000.0001) // ======================================================
 (PID.TID 0000.0001) // execution environment starting up...
 (PID.TID 0000.0001) 
-(PID.TID 0000.0001) // MITgcmUV version:  checkpoint65
-(PID.TID 0000.0001) // Build user:        jmc
-(PID.TID 0000.0001) // Build host:        baudelaire
-(PID.TID 0000.0001) // Build date:        Sat Jul 19 01:47:56 EDT 2014
+(PID.TID 0000.0001) // MITgcmUV version:  checkpoint67w
+(PID.TID 0000.0001) // Build user:        jm_c
+(PID.TID 0000.0001) // Build host:        villon
+(PID.TID 0000.0001) // Build date:        Tue Apr 13 00:55:02 EDT 2021
 (PID.TID 0000.0001) 
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // Execution Environment parameter file "eedata"
@@ -49,8 +49,10 @@
 (PID.TID 0000.0001)                   /*  note: To execute a program with MPI calls */
 (PID.TID 0000.0001)                   /*  it must be launched appropriately e.g     */
 (PID.TID 0000.0001)                   /*  "mpirun -np 64 ......"                    */
-(PID.TID 0000.0001) useCoupler=    F ;/* Flag used to control communications with   */
+(PID.TID 0000.0001) useCoupler=   F ; /* Flag used to control communications with   */
 (PID.TID 0000.0001)                   /*  other model components, through a coupler */
+(PID.TID 0000.0001) useNest2W_parent =    F ;/* Control 2-W Nesting comm */
+(PID.TID 0000.0001) useNest2W_child  =    F ;/* Control 2-W Nesting comm */
 (PID.TID 0000.0001) debugMode =    F ; /* print debug msg. (sequence of S/R calls)  */
 (PID.TID 0000.0001) printMapIncludesZeros=    F ; /* print zeros in Std.Output maps */
 (PID.TID 0000.0001) maxLengthPrt1D=   65 /* maxLength of 1D array printed to StdOut */
@@ -146,14 +148,14 @@
 (PID.TID 0000.0001) > endTime=4800.,
 (PID.TID 0000.0001) > deltaTmom=1200.0,
 (PID.TID 0000.0001) > deltaTtracer=1200.0,
-(PID.TID 0000.0001) > dumpInitAndLast=.TRUE.,
 (PID.TID 0000.0001) > abEps=0.1,
+(PID.TID 0000.0001) > dumpInitAndLast=.TRUE.,
 (PID.TID 0000.0001) > pChkptFreq=0.0,
 (PID.TID 0000.0001) > chkptFreq=0.0,
 (PID.TID 0000.0001) > dumpFreq=2628000.0,
-(PID.TID 0000.0001) >#monitorFreq=432000.,
-(PID.TID 0000.0001) > monitorFreq=3600.,
-(PID.TID 0000.0001) > monitorSelect=1,
+(PID.TID 0000.0001) > monitorSelect= 1,
+(PID.TID 0000.0001) > monitorFreq = 4800.,
+(PID.TID 0000.0001) > adjMonitorFreq=3600.,
 (PID.TID 0000.0001) > /
 (PID.TID 0000.0001) ># Gridding parameters
 (PID.TID 0000.0001) > &PARM04
@@ -204,21 +206,21 @@
  pkg/obcs                 compiled   and   used ( useOBCS                  = T )
  pkg/cal                  compiled   and   used ( useCAL                   = T )
  pkg/exf                  compiled   and   used ( useEXF                   = T )
+ pkg/autodiff             compiled   and   used ( useAUTODIFF              = T )
  pkg/grdchk               compiled   and   used ( useGrdchk                = T )
  pkg/ecco                 compiled   and   used ( useECCO                  = T )
+ pkg/ctrl                 compiled   and   used ( useCTRL                  = T )
  pkg/diagnostics          compiled   and   used ( useDiagnostics           = T )
  -------- pkgs without standard "usePKG" On/Off switch in "data.pkg":  --------
  pkg/generic_advdiff      compiled   and   used ( useGAD                   = T )
  pkg/mom_common           compiled   and   used ( momStepping              = T )
  pkg/mom_vecinv           compiled   and   used ( +vectorInvariantMomentum = T )
  pkg/monitor              compiled   and   used ( monitorFreq > 0.         = T )
- pkg/timeave              compiled but not used ( taveFreq > 0.            = F )
  pkg/debug                compiled but not used ( debugMode                = F )
  pkg/rw                   compiled   and   used
  pkg/mdsio                compiled   and   used
  pkg/autodiff             compiled   and   used
  pkg/cost                 compiled   and   used
- pkg/ctrl                 compiled   and   used
 (PID.TID 0000.0001)  PACKAGES_BOOT: End of package Summary
 (PID.TID 0000.0001) 
 (PID.TID 0000.0001) CAL_READPARMS: opening data.cal
@@ -378,6 +380,9 @@
 (PID.TID 0000.0001) inAdExact = /* get an exact adjoint (no approximation) */
 (PID.TID 0000.0001)                   T
 (PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) useApproxAdvectionInAdMode = /* approximate AD-advection */
+(PID.TID 0000.0001)                   F
+(PID.TID 0000.0001)     ;
 (PID.TID 0000.0001) useKPPinAdMode = /* use KPP in adjoint mode */
 (PID.TID 0000.0001)                   F
 (PID.TID 0000.0001)     ;
@@ -399,8 +404,17 @@
 (PID.TID 0000.0001) mon_AdVarExch = /* control adexch before monitor */
 (PID.TID 0000.0001)                       2
 (PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) viscFacInFw = /* viscosity factor for forward model */
+(PID.TID 0000.0001)                 1.000000000000000E+00
+(PID.TID 0000.0001)     ;
 (PID.TID 0000.0001) viscFacInAd = /* viscosity factor for adjoint */
 (PID.TID 0000.0001)                 1.000000000000000E+00
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) SIregFacInAd = /* sea ice factor for adjoint model */
+(PID.TID 0000.0001)                 1.234567000000000E+05
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) SIregFacInFw = /* sea ice factor for forward model */
+(PID.TID 0000.0001)                 1.234567000000000E+05
 (PID.TID 0000.0001)     ;
 (PID.TID 0000.0001) 
 (PID.TID 0000.0001) OPTIM_READPARMS: opening data.optim
@@ -466,11 +480,16 @@
 (PID.TID 0000.0001) > ctrlname = 'ecco_ctrl',
 (PID.TID 0000.0001) > costname = 'ecco_cost',
 (PID.TID 0000.0001) > /
+(PID.TID 0000.0001) >#
+(PID.TID 0000.0001) ># *********************
+(PID.TID 0000.0001) ># names for CTRL_GENARR, CTRL_GENTIM
+(PID.TID 0000.0001) ># *********************
+(PID.TID 0000.0001) > &CTRL_NML_GENARR
+(PID.TID 0000.0001) > xx_genarr3d_file(1)       = 'xx_theta',
+(PID.TID 0000.0001) > xx_genarr3d_weight(1)     = 'errorTtot.err64',
+(PID.TID 0000.0001) > /
 (PID.TID 0000.0001) 
 (PID.TID 0000.0001) CTRL_READPARMS: finished reading data.ctrl
-(PID.TID 0000.0001) useSmoothCorrel2DinAdMode = /* use ctrlSmoothCorrel2D in adjoint mode */
-(PID.TID 0000.0001)                   F
-(PID.TID 0000.0001)     ;
 (PID.TID 0000.0001) COST_READPARMS: opening data.cost
 (PID.TID 0000.0001)  OPEN_COPY_DATA_FILE: opening file data.cost
 (PID.TID 0000.0001) // =======================================================
@@ -513,6 +532,7 @@
 (PID.TID 0000.0001) // Gradient check configuration  >>> START <<<
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) 
+(PID.TID 0000.0001)   grdchkvarindex :                         13
 (PID.TID 0000.0001)   eps:                              0.100E-03
 (PID.TID 0000.0001)   First location:                           0
 (PID.TID 0000.0001)   Last location:                            4
@@ -537,7 +557,7 @@
 (PID.TID 0000.0001) > tbarfile        = 'tbar',
 (PID.TID 0000.0001) >#
 (PID.TID 0000.0001) > temp0errfile    = 'errorTtot.err',
-(PID.TID 0000.0001) >#  temperrfile     = 'errorTtot.err',
+(PID.TID 0000.0001) > temperrfile     = 'errorTtot.err',
 (PID.TID 0000.0001) > tdatfile        = 'FinalThetaObs.bin',
 (PID.TID 0000.0001) >#
 (PID.TID 0000.0001) >#
@@ -551,8 +571,26 @@
 (PID.TID 0000.0001) > cost_iprec  = 32,
 (PID.TID 0000.0001) > cost_yftype = 'RL',
 (PID.TID 0000.0001) > /
+(PID.TID 0000.0001) >
+(PID.TID 0000.0001) > &ECCO_GENCOST_NML
+(PID.TID 0000.0001) > gencost_avgperiod(1)  = 'month',
+(PID.TID 0000.0001) > gencost_barfile(1) = 'm_theta',
+(PID.TID 0000.0001) > gencost_datafile(1) = 'FinalThetaObs.bin',
+(PID.TID 0000.0001) > gencost_errfile(1) = 'errorTtot.err',
+(PID.TID 0000.0001) > gencost_name(1) = 'theta',
+(PID.TID 0000.0001) > gencost_is3d(1) = .TRUE.,
+(PID.TID 0000.0001) > gencost_preproc(1,1) = 'clim',
+(PID.TID 0000.0001) > gencost_preproc_i(1,1)=12,
+(PID.TID 0000.0001) > gencost_spmin(1) = -1.8,
+(PID.TID 0000.0001) > gencost_spmax(1) = 40.,
+(PID.TID 0000.0001) > gencost_spzero(1) = 0.,
+(PID.TID 0000.0001) ># this is default
+(PID.TID 0000.0001) > gencost_outputlevel(1)=0,
+(PID.TID 0000.0001) > mult_gencost(1) = 1.,
+(PID.TID 0000.0001) > /
 (PID.TID 0000.0001) 
 (PID.TID 0000.0001) ECCO_READPARMS: finished reading #1: ecco_cost_nml
+(PID.TID 0000.0001) ECCO_READPARMS: finished reading #2: ecco_gencost_nml
 (PID.TID 0000.0001) ECCO_READPARMS: done
 (PID.TID 0000.0001)  DIAGNOSTICS_READPARMS: opening data.diagnostics
 (PID.TID 0000.0001)  OPEN_COPY_DATA_FILE: opening file data.diagnostics
@@ -632,6 +670,9 @@
 (PID.TID 0000.0001)     ;
 (PID.TID 0000.0001)  diagCG_resTarget = /* residual target for diag_cg2d */
 (PID.TID 0000.0001)                 1.000000000000000E-08
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001)  diagCG_pcOffDFac = /* preconditioner off-diagonal factor */
+(PID.TID 0000.0001)                 9.611687812379854E-01
 (PID.TID 0000.0001)     ;
 (PID.TID 0000.0001) -----------------------------------------------------
 (PID.TID 0000.0001)  DIAGNOSTICS_READPARMS: active diagnostics summary:
@@ -836,6 +877,9 @@
 (PID.TID 0000.0001) useExfCheckRange = /* check for fields range */
 (PID.TID 0000.0001)                   F
 (PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) diags_opOceWeighted = /* weight flux diags by open-ocean fraction */
+(PID.TID 0000.0001)                   F
+(PID.TID 0000.0001)     ;
 (PID.TID 0000.0001) exf_debugLev = /* select EXF-debug printing level */
 (PID.TID 0000.0001)                       1
 (PID.TID 0000.0001)     ;
@@ -852,6 +896,9 @@
 (PID.TID 0000.0001)                 2.000000000000000E+00
 (PID.TID 0000.0001)     ;
 (PID.TID 0000.0001) stressIsOnCgrid = /* set u,v_stress on Arakawa C-grid */
+(PID.TID 0000.0001)                   F
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) rotateStressOnAgrid = /* rotate u,v_stress on Arakawa A-grid */
 (PID.TID 0000.0001)                   F
 (PID.TID 0000.0001)     ;
 (PID.TID 0000.0001) cen2kel = /* conversion of deg. Centigrade to Kelvin [K] */
@@ -982,52 +1029,23 @@
 (PID.TID 0000.0001) // ALLOW_ATM_WIND (useAtmWind):    NOT defined
 (PID.TID 0000.0001) // ALLOW_DOWNWARD_RADIATION:       NOT defined
 (PID.TID 0000.0001) // ALLOW_BULKFORMULAE:             NOT defined
-(PID.TID 0000.0001) 
-(PID.TID 0000.0001)    Zonal wind stress forcing starts at                   0.
-(PID.TID 0000.0001)    Zonal wind stress forcing period is                   0.
-(PID.TID 0000.0001)    Zonal wind stress forcing is read from file:
-(PID.TID 0000.0001)    >>    <<
-(PID.TID 0000.0001) 
-(PID.TID 0000.0001)    Meridional wind stress forcing starts at              0.
-(PID.TID 0000.0001)    Meridional wind stress forcing period is              0.
-(PID.TID 0000.0001)    Meridional wind stress forcing is read from file:
-(PID.TID 0000.0001)    >>    <<
-(PID.TID 0000.0001) 
-(PID.TID 0000.0001)    Heat flux forcing starts at                          0.
-(PID.TID 0000.0001)    Heat flux forcing period is                           0.
-(PID.TID 0000.0001)    Heat flux forcing is read from file:
-(PID.TID 0000.0001)    >>    <<
-(PID.TID 0000.0001) 
-(PID.TID 0000.0001)    Salt flux forcing starts at                           0.
-(PID.TID 0000.0001)    Salt flux forcing period is                           0.
-(PID.TID 0000.0001)    Salt flux forcing is read from file:
-(PID.TID 0000.0001)    >>    <<
-(PID.TID 0000.0001) 
-(PID.TID 0000.0001)    Net shortwave flux forcing starts at                0.
-(PID.TID 0000.0001)    Net shortwave flux forcing period is                0.
-(PID.TID 0000.0001)    Net shortwave flux forcing is read from file:
-(PID.TID 0000.0001)    >>    <<
-(PID.TID 0000.0001) 
 (PID.TID 0000.0001) // EXF_READ_EVAP:                  NOT defined
-(PID.TID 0000.0001) 
 (PID.TID 0000.0001) // ALLOW_RUNOFF:                   NOT defined
-(PID.TID 0000.0001) 
-(PID.TID 0000.0001)    Atmospheric pressure forcing starts at                0.
-(PID.TID 0000.0001)    Atmospheric pressure forcing period is                0.
-(PID.TID 0000.0001)    Atmospheric pressureforcing is read from file:
-(PID.TID 0000.0001)    >>    <<
+(PID.TID 0000.0001) // ALLOW_SALTFLX:                  NOT defined
 (PID.TID 0000.0001) 
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // External forcing (EXF) climatology configuration :
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) 
 (PID.TID 0000.0001) // ALLOW_CLIMSST_RELAXATION:       NOT defined
+(PID.TID 0000.0001) 
 (PID.TID 0000.0001) // ALLOW_CLIMSSS_RELAXATION:       NOT defined
 (PID.TID 0000.0001) 
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // External forcing (EXF) configuration  >>> END <<<
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) 
+(PID.TID 0000.0001) etaday defined by gencost   0
 (PID.TID 0000.0001)  OPEN_COPY_DATA_FILE: opening file data.err
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // Parameter file "data.err"
@@ -1044,53 +1062,32 @@
 (PID.TID 0000.0001) 
 (PID.TID 0000.0001) 
 (PID.TID 0000.0001) // =======================================================
-(PID.TID 0000.0001) // ECCO cost function configuration  >>> START <<<
+(PID.TID 0000.0001) // ECCO configuration >>> START <<<
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) 
-(PID.TID 0000.0001)   Multipliers for the indivdual cost function contributions:
-(PID.TID 0000.0001) 
-(PID.TID 0000.0001)   Net heat flux:                 0.000E+00
-(PID.TID 0000.0001)   Salt flux:                     0.000E+00
-(PID.TID 0000.0001)   Zonal wind stress:             0.000E+00
-(PID.TID 0000.0001)   Meridional wind stress:        0.000E+00
-(PID.TID 0000.0001)   Mean sea surface height:       0.000E+00
-(PID.TID 0000.0001)   Sea surface height anomalies:  0.100E+01
-(PID.TID 0000.0001)   Temperature Lev.:              0.100E+01
-(PID.TID 0000.0001)   Salinity Lev.:                 0.000E+00
-(PID.TID 0000.0001)   Temperature ini.:              0.100E+01
-(PID.TID 0000.0001)   Salinity ini.:                 0.000E+00
-(PID.TID 0000.0001)   Sea level ini.:                0.000E+00
-(PID.TID 0000.0001)   zonal velocity ini.:           0.000E+00
-(PID.TID 0000.0001)   merid velocity ini.:           0.000E+00
-(PID.TID 0000.0001)   TMI Sea surface temperature:   0.000E+00
-(PID.TID 0000.0001)   Sea surface temperature:       0.000E+00
-(PID.TID 0000.0001)   Sea surface salinity:         0.000E+00
-(PID.TID 0000.0001)   CTD temperature:               0.000E+00
-(PID.TID 0000.0001)   CTD salinity:                  0.000E+00
-(PID.TID 0000.0001)   CTD clim temperature:          0.000E+00
-(PID.TID 0000.0001)   CTD clim salinity:             0.000E+00
-(PID.TID 0000.0001)   XBT Temperature:               0.000E+00
-(PID.TID 0000.0001)   ARGO Temperature:               0.000E+00
-(PID.TID 0000.0001)   ARGO Salt:                      0.000E+00
-(PID.TID 0000.0001)   drifter velocities:            0.000E+00
-(PID.TID 0000.0001)   drift between last and 1st year: 0.000E+00
-(PID.TID 0000.0001)   drift between last and 1st year: 0.000E+00
-(PID.TID 0000.0001)   Ageostrophic bdy flow:         0.000E+00
-(PID.TID 0000.0001)   OB North:                      0.100E+01
-(PID.TID 0000.0001)   OB South:                      0.100E+01
-(PID.TID 0000.0001)   OB West:                       0.100E+01
-(PID.TID 0000.0001)   OB East:                       0.100E+01
+(PID.TID 0000.0001) gencost( 1) = theta
+(PID.TID 0000.0001) -------------
+(PID.TID 0000.0001)  data file = FinalThetaObs.bin
+(PID.TID 0000.0001)  model file = m_theta
+(PID.TID 0000.0001)  error file = errorTtot.err
+(PID.TID 0000.0001)  preprocess = clim
+(PID.TID 0000.0001)  gencost_flag =  1
+(PID.TID 0000.0001)  gencost_outputlevel =  0
+(PID.TID 0000.0001)  gencost_pointer3d =  1
 (PID.TID 0000.0001) 
 (PID.TID 0000.0001) 
-(PID.TID 0000.0001)   Temperature data are read from: FinalThetaObs.bin
-(PID.TID 0000.0001)   Salinity data are read from:
+(PID.TID 0000.0001) 
+(PID.TID 0000.0001) // =======================================================
+(PID.TID 0000.0001) // ECCO configuration  >>> END <<<
+(PID.TID 0000.0001) // =======================================================
+(PID.TID 0000.0001) 
 (PID.TID 0000.0001) ctrl-wet 1:    nvarlength =        40960
 (PID.TID 0000.0001) ctrl-wet 2: surface wet C =         1024
 (PID.TID 0000.0001) ctrl-wet 3: surface wet W =         1024
 (PID.TID 0000.0001) ctrl-wet 4: surface wet S =         1024
 (PID.TID 0000.0001) ctrl-wet 4a:surface wet V =            0
 (PID.TID 0000.0001) ctrl-wet 5: 3D wet points =         8192
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =     1           1
+(PID.TID 0000.0001) ctrl-wet 6: no recs for i =     1           0
 (PID.TID 0000.0001) ctrl-wet 6: no recs for i =     2           0
 (PID.TID 0000.0001) ctrl-wet 6: no recs for i =     3           0
 (PID.TID 0000.0001) ctrl-wet 6: no recs for i =     4           0
@@ -1150,6 +1147,346 @@
 (PID.TID 0000.0001) ctrl-wet 6: no recs for i =    58           0
 (PID.TID 0000.0001) ctrl-wet 6: no recs for i =    59           0
 (PID.TID 0000.0001) ctrl-wet 6: no recs for i =    60           0
+(PID.TID 0000.0001) ctrl-wet 6: no recs for i =    61           0
+(PID.TID 0000.0001) ctrl-wet 6: no recs for i =    62           0
+(PID.TID 0000.0001) ctrl-wet 6: no recs for i =    63           0
+(PID.TID 0000.0001) ctrl-wet 6: no recs for i =    64           0
+(PID.TID 0000.0001) ctrl-wet 6: no recs for i =    65           0
+(PID.TID 0000.0001) ctrl-wet 6: no recs for i =    66           0
+(PID.TID 0000.0001) ctrl-wet 6: no recs for i =    67           0
+(PID.TID 0000.0001) ctrl-wet 6: no recs for i =    68           0
+(PID.TID 0000.0001) ctrl-wet 6: no recs for i =    69           0
+(PID.TID 0000.0001) ctrl-wet 6: no recs for i =    70           0
+(PID.TID 0000.0001) ctrl-wet 6: no recs for i =    71           0
+(PID.TID 0000.0001) ctrl-wet 6: no recs for i =    72           0
+(PID.TID 0000.0001) ctrl-wet 6: no recs for i =    73           0
+(PID.TID 0000.0001) ctrl-wet 6: no recs for i =    74           0
+(PID.TID 0000.0001) ctrl-wet 6: no recs for i =    75           0
+(PID.TID 0000.0001) ctrl-wet 6: no recs for i =    76           0
+(PID.TID 0000.0001) ctrl-wet 6: no recs for i =    77           0
+(PID.TID 0000.0001) ctrl-wet 6: no recs for i =    78           0
+(PID.TID 0000.0001) ctrl-wet 6: no recs for i =    79           0
+(PID.TID 0000.0001) ctrl-wet 6: no recs for i =    80           0
+(PID.TID 0000.0001) ctrl-wet 6: no recs for i =    81           0
+(PID.TID 0000.0001) ctrl-wet 6: no recs for i =    82           0
+(PID.TID 0000.0001) ctrl-wet 6: no recs for i =    83           0
+(PID.TID 0000.0001) ctrl-wet 6: no recs for i =    84           0
+(PID.TID 0000.0001) ctrl-wet 6: no recs for i =    85           0
+(PID.TID 0000.0001) ctrl-wet 6: no recs for i =    86           0
+(PID.TID 0000.0001) ctrl-wet 6: no recs for i =    87           0
+(PID.TID 0000.0001) ctrl-wet 6: no recs for i =    88           0
+(PID.TID 0000.0001) ctrl-wet 6: no recs for i =    89           0
+(PID.TID 0000.0001) ctrl-wet 6: no recs for i =    90           0
+(PID.TID 0000.0001) ctrl-wet 6: no recs for i =    91           0
+(PID.TID 0000.0001) ctrl-wet 6: no recs for i =    92           0
+(PID.TID 0000.0001) ctrl-wet 6: no recs for i =    93           0
+(PID.TID 0000.0001) ctrl-wet 6: no recs for i =    94           0
+(PID.TID 0000.0001) ctrl-wet 6: no recs for i =    95           0
+(PID.TID 0000.0001) ctrl-wet 6: no recs for i =    96           0
+(PID.TID 0000.0001) ctrl-wet 6: no recs for i =    97           0
+(PID.TID 0000.0001) ctrl-wet 6: no recs for i =    98           0
+(PID.TID 0000.0001) ctrl-wet 6: no recs for i =    99           0
+(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   100           0
+(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   101           0
+(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   102           0
+(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   103           0
+(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   104           0
+(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   105           0
+(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   106           0
+(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   107           0
+(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   108           0
+(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   109           0
+(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   110           0
+(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   111           0
+(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   112           0
+(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   113           0
+(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   114           0
+(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   115           0
+(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   116           0
+(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   117           0
+(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   118           0
+(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   119           0
+(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   120           0
+(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   121           0
+(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   122           0
+(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   123           0
+(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   124           0
+(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   125           0
+(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   126           0
+(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   127           0
+(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   128           0
+(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   129           0
+(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   130           0
+(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   131           0
+(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   132           0
+(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   133           0
+(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   134           0
+(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   135           0
+(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   136           0
+(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   137           0
+(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   138           0
+(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   139           0
+(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   140           0
+(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   141           0
+(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   142           0
+(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   143           0
+(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   144           0
+(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   145           0
+(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   146           0
+(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   147           0
+(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   148           0
+(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   149           0
+(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   150           0
+(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   151           0
+(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   152           0
+(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   153           0
+(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   154           0
+(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   155           0
+(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   156           0
+(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   157           0
+(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   158           0
+(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   159           0
+(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   160           0
+(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   161           0
+(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   162           0
+(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   163           0
+(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   164           0
+(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   165           0
+(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   166           0
+(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   167           0
+(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   168           0
+(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   169           0
+(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   170           0
+(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   171           0
+(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   172           0
+(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   173           0
+(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   174           0
+(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   175           0
+(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   176           0
+(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   177           0
+(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   178           0
+(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   179           0
+(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   180           0
+(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   181           0
+(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   182           0
+(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   183           0
+(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   184           0
+(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   185           0
+(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   186           0
+(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   187           0
+(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   188           0
+(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   189           0
+(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   190           0
+(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   191           0
+(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   192           0
+(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   193           0
+(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   194           0
+(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   195           0
+(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   196           0
+(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   197           0
+(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   198           0
+(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   199           0
+(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   200           0
+(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   201           1
+(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   202           0
+(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   203           0
+(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   204           0
+(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   205           0
+(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   206           0
+(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   207           0
+(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   208           0
+(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   209           0
+(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   210           0
+(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   211           0
+(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   212           0
+(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   213           0
+(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   214           0
+(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   215           0
+(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   216           0
+(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   217           0
+(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   218           0
+(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   219           0
+(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   220           0
+(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   221           0
+(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   222           0
+(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   223           0
+(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   224           0
+(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   225           0
+(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   226           0
+(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   227           0
+(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   228           0
+(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   229           0
+(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   230           0
+(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   231           0
+(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   232           0
+(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   233           0
+(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   234           0
+(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   235           0
+(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   236           0
+(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   237           0
+(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   238           0
+(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   239           0
+(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   240           0
+(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   241           0
+(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   242           0
+(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   243           0
+(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   244           0
+(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   245           0
+(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   246           0
+(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   247           0
+(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   248           0
+(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   249           0
+(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   250           0
+(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   251           0
+(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   252           0
+(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   253           0
+(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   254           0
+(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   255           0
+(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   256           0
+(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   257           0
+(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   258           0
+(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   259           0
+(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   260           0
+(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   261           0
+(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   262           0
+(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   263           0
+(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   264           0
+(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   265           0
+(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   266           0
+(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   267           0
+(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   268           0
+(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   269           0
+(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   270           0
+(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   271           0
+(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   272           0
+(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   273           0
+(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   274           0
+(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   275           0
+(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   276           0
+(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   277           0
+(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   278           0
+(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   279           0
+(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   280           0
+(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   281           0
+(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   282           0
+(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   283           0
+(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   284           0
+(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   285           0
+(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   286           0
+(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   287           0
+(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   288           0
+(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   289           0
+(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   290           0
+(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   291           0
+(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   292           0
+(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   293           0
+(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   294           0
+(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   295           0
+(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   296           0
+(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   297           0
+(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   298           0
+(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   299           0
+(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   300           0
+(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   301           0
+(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   302           0
+(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   303           0
+(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   304           0
+(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   305           0
+(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   306           0
+(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   307           0
+(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   308           0
+(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   309           0
+(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   310           0
+(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   311           0
+(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   312           0
+(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   313           0
+(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   314           0
+(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   315           0
+(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   316           0
+(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   317           0
+(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   318           0
+(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   319           0
+(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   320           0
+(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   321           0
+(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   322           0
+(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   323           0
+(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   324           0
+(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   325           0
+(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   326           0
+(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   327           0
+(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   328           0
+(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   329           0
+(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   330           0
+(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   331           0
+(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   332           0
+(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   333           0
+(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   334           0
+(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   335           0
+(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   336           0
+(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   337           0
+(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   338           0
+(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   339           0
+(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   340           0
+(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   341           0
+(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   342           0
+(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   343           0
+(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   344           0
+(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   345           0
+(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   346           0
+(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   347           0
+(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   348           0
+(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   349           0
+(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   350           0
+(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   351           0
+(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   352           0
+(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   353           0
+(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   354           0
+(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   355           0
+(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   356           0
+(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   357           0
+(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   358           0
+(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   359           0
+(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   360           0
+(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   361           0
+(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   362           0
+(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   363           0
+(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   364           0
+(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   365           0
+(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   366           0
+(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   367           0
+(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   368           0
+(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   369           0
+(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   370           0
+(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   371           0
+(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   372           0
+(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   373           0
+(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   374           0
+(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   375           0
+(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   376           0
+(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   377           0
+(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   378           0
+(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   379           0
+(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   380           0
+(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   381           0
+(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   382           0
+(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   383           0
+(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   384           0
+(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   385           0
+(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   386           0
+(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   387           0
+(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   388           0
+(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   389           0
+(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   390           0
+(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   391           0
+(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   392           0
+(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   393           0
+(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   394           0
+(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   395           0
+(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   396           0
+(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   397           0
+(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   398           0
+(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   399           0
+(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   400           0
 (PID.TID 0000.0001) ctrl-wet 7: flux         16384
 (PID.TID 0000.0001) ctrl-wet 8: atmos        16384
 (PID.TID 0000.0001) ctrl-wet 9: surface wet obcsn =            0         0         0         0
@@ -1206,11 +1543,41 @@
 (PID.TID 0000.0001) ctrl-wet 16c: global SUM(K) obcsW T,S,U,V          512         512         512         512
 (PID.TID 0000.0001) ctrl-wet 16d: global SUM(K) obcsE T,S,U,V          512         512         512         512
 (PID.TID 0000.0001) ctrl-wet -------------------------------------------------
-(PID.TID 0000.0001) ctrl_init: no. of control variables:            5
-(PID.TID 0000.0001) ctrl_init: control vector length:           40960
+(PID.TID 0000.0001) ctrl_init_wet: no. of control variables:            5
+(PID.TID 0000.0001) ctrl_init_wet: control vector length:           40960
+(PID.TID 0000.0001) 
+(PID.TID 0000.0001) // =======================================================
+(PID.TID 0000.0001) // control vector configuration  >>> START <<<
+(PID.TID 0000.0001) // =======================================================
+(PID.TID 0000.0001) 
+(PID.TID 0000.0001)  Total number of ocean points per tile:
+(PID.TID 0000.0001)  --------------------------------------
+(PID.TID 0000.0001)  snx*sny*nr =     8192
+(PID.TID 0000.0001) 
+(PID.TID 0000.0001)  Number of ocean points per tile:
+(PID.TID 0000.0001)  --------------------------------
+(PID.TID 0000.0001)  bi,bj,#(c/s/w): 0001 0001 008192 008192 008192
+(PID.TID 0000.0001)  bi,bj,#(c/s/w): 0002 0001 008192 008192 008192
+(PID.TID 0000.0001)  bi,bj,#(c/s/w): 0001 0002 008192 008192 008192
+(PID.TID 0000.0001)  bi,bj,#(c/s/w): 0002 0002 008192 008192 008192
+(PID.TID 0000.0001) 
+(PID.TID 0000.0001)  Settings of generic controls:
+(PID.TID 0000.0001)  -----------------------------
+(PID.TID 0000.0001) 
+(PID.TID 0000.0001)  ctrlUseGen  =     T /* use generic controls */
+(PID.TID 0000.0001)  -> 3d control, genarr3d no.  1 is in use
+(PID.TID 0000.0001)       file       = xx_theta
+(PID.TID 0000.0001)       weight     = errorTtot.err64
+(PID.TID 0000.0001)       index      =  0201
+(PID.TID 0000.0001)       ncvarindex =  0301
+(PID.TID 0000.0001) 
+(PID.TID 0000.0001) // =======================================================
+(PID.TID 0000.0001) // control vector configuration  >>> END <<<
+(PID.TID 0000.0001) // =======================================================
+(PID.TID 0000.0001) 
 (PID.TID 0000.0001) ------------------------------------------------------------
 (PID.TID 0000.0001) DIAGNOSTICS_SET_LEVELS: done
-(PID.TID 0000.0001)  Total Nb of available Diagnostics: ndiagt=   194
+(PID.TID 0000.0001)  Total Nb of available Diagnostics: ndiagt=   229
 (PID.TID 0000.0001)  write list of available Diagnostics to file: available_diagnostics.log
 (PID.TID 0000.0001)   space allocated for all diagnostics:       0 levels
 (PID.TID 0000.0001) DIAGNOSTICS_SET_POINTERS: done
@@ -1265,7 +1632,7 @@
 (PID.TID 0000.0001)                 7.000000000000000E+00,      /* K =  7 */
 (PID.TID 0000.0001)                 6.000000000000000E+00       /* K =  8 */
 (PID.TID 0000.0001)     ;
-(PID.TID 0000.0001) sRef =   /* Reference salinity profile ( psu ) */
+(PID.TID 0000.0001) sRef =   /* Reference salinity profile ( g/kg ) */
 (PID.TID 0000.0001)     8 @  3.500000000000000E+01              /* K =  1:  8 */
 (PID.TID 0000.0001)     ;
 (PID.TID 0000.0001) useStrainTensionVisc= /* Use StrainTension Form of Viscous Operator */
@@ -1301,11 +1668,17 @@
 (PID.TID 0000.0001) no_slip_bottom =  /* Viscous BCs: No-slip bottom */
 (PID.TID 0000.0001)                   T
 (PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) bottomVisc_pCell = /* Partial-cell in bottom Visc. BC */
+(PID.TID 0000.0001)                   F
+(PID.TID 0000.0001)     ;
 (PID.TID 0000.0001) bottomDragLinear = /* linear bottom-drag coefficient ( m/s ) */
 (PID.TID 0000.0001)                 0.000000000000000E+00
 (PID.TID 0000.0001)     ;
 (PID.TID 0000.0001) bottomDragQuadratic = /* quadratic bottom-drag coefficient (-) */
 (PID.TID 0000.0001)                 0.000000000000000E+00
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) selectBotDragQuadr = /* select quadratic bottom drag options */
+(PID.TID 0000.0001)                      -1
 (PID.TID 0000.0001)     ;
 (PID.TID 0000.0001) diffKhT =   /* Laplacian diffusion of heat laterally ( m^2/s ) */
 (PID.TID 0000.0001)                 0.000000000000000E+00
@@ -1355,11 +1728,18 @@
 (PID.TID 0000.0001) tAlpha = /* Linear EOS thermal expansion coefficient ( 1/oC ) */
 (PID.TID 0000.0001)                 2.000000000000000E-04
 (PID.TID 0000.0001)     ;
-(PID.TID 0000.0001) sBeta  = /* Linear EOS haline contraction coefficient ( 1/psu ) */
+(PID.TID 0000.0001) sBeta  = /* Linear EOS haline contraction coefficient ( 1/(g/kg) ) */
 (PID.TID 0000.0001)                 0.000000000000000E+00
 (PID.TID 0000.0001)     ;
 (PID.TID 0000.0001) rhoNil    = /* Reference density for Linear EOS ( kg/m^3 ) */
 (PID.TID 0000.0001)                 9.998000000000000E+02
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) selectP_inEOS_Zc = /* select pressure to use in EOS (0,1,2,3) */
+(PID.TID 0000.0001)                       0
+(PID.TID 0000.0001)     0= -g*rhoConst*z ; 1= pRef (from tRef,sRef); 2= Hyd P ; 3= Hyd+NH P
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) surf_pRef = /* Surface reference pressure ( Pa ) */
+(PID.TID 0000.0001)                 1.013250000000000E+05
 (PID.TID 0000.0001)     ;
 (PID.TID 0000.0001) HeatCapacity_Cp =  /* Specific heat capacity ( J/kg/K ) */
 (PID.TID 0000.0001)                 3.994000000000000E+03
@@ -1384,6 +1764,12 @@
 (PID.TID 0000.0001)     ;
 (PID.TID 0000.0001) gBaro =   /* Barotropic gravity ( m/s^2 ) */
 (PID.TID 0000.0001)                 9.810000000000000E+00
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) gravFacC = /* gravity factor (vs surf.) @ cell-Center (-) */
+(PID.TID 0000.0001)     8 @  1.000000000000000E+00              /* K =  1:  8 */
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) gravFacF = /* gravity factor (vs surf.) @ W-Interface (-) */
+(PID.TID 0000.0001)     9 @  1.000000000000000E+00              /* K =  1:  9 */
 (PID.TID 0000.0001)     ;
 (PID.TID 0000.0001) rotationPeriod =   /* Rotation Period ( s ) */
 (PID.TID 0000.0001)                 8.640000000000000E+04
@@ -1412,7 +1798,7 @@
 (PID.TID 0000.0001) implicSurfPress =  /* Surface Pressure implicit factor (0-1)*/
 (PID.TID 0000.0001)                 1.000000000000000E+00
 (PID.TID 0000.0001)     ;
-(PID.TID 0000.0001) implicDiv2Dflow =  /* Barot. Flow Div. implicit factor (0-1)*/
+(PID.TID 0000.0001) implicDiv2DFlow =  /* Barot. Flow Div. implicit factor (0-1)*/
 (PID.TID 0000.0001)                 1.000000000000000E+00
 (PID.TID 0000.0001)     ;
 (PID.TID 0000.0001) uniformLin_PhiSurf = /* use uniform Bo_surf on/off flag*/
@@ -1452,7 +1838,7 @@
 (PID.TID 0000.0001) temp_EvPrRn = /* Temp. of Evap/Prec/R (UNSET=use local T)(oC)*/
 (PID.TID 0000.0001)                 1.234567000000000E+05
 (PID.TID 0000.0001)     ;
-(PID.TID 0000.0001) salt_EvPrRn = /* Salin. of Evap/Prec/R (UNSET=use local S)(psu)*/
+(PID.TID 0000.0001) salt_EvPrRn = /* Salin. of Evap/Prec/R (UNSET=use local S)(g/kg)*/
 (PID.TID 0000.0001)                 0.000000000000000E+00
 (PID.TID 0000.0001)     ;
 (PID.TID 0000.0001) selectAddFluid = /* option for mass source/sink of fluid (=0: off) */
@@ -1461,10 +1847,10 @@
 (PID.TID 0000.0001) temp_addMass = /* Temp. of addMass array (UNSET=use local T)(oC)*/
 (PID.TID 0000.0001)                 1.234567000000000E+05
 (PID.TID 0000.0001)     ;
-(PID.TID 0000.0001) salt_addMass = /* Salin. of addMass array (UNSET=use local S)(psu)*/
+(PID.TID 0000.0001) salt_addMass = /* Salin. of addMass array (UNSET=use local S)(g/kg)*/
 (PID.TID 0000.0001)                 0.000000000000000E+00
 (PID.TID 0000.0001)     ;
-(PID.TID 0000.0001) convertFW2Salt = /* convert F.W. Flux to Salt Flux (-1=use local S)(psu)*/
+(PID.TID 0000.0001) convertFW2Salt = /* convert F.W. Flux to Salt Flux (-1=use local S)(g/kg)*/
 (PID.TID 0000.0001)                 3.500000000000000E+01
 (PID.TID 0000.0001)     ;
 (PID.TID 0000.0001) use3Dsolver = /* use 3-D pressure solver on/off flag */
@@ -1506,6 +1892,10 @@
 (PID.TID 0000.0001) implicitViscosity = /* Implicit viscosity on/off flag */
 (PID.TID 0000.0001)                   T
 (PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) selectImplicitDrag= /* Implicit bot Drag options (0,1,2)*/
+(PID.TID 0000.0001)                       0
+(PID.TID 0000.0001)     0= Expl. ; 1= Impl. on provis. Vel ; 2= Fully Impl (with surf.P)
+(PID.TID 0000.0001)     ;
 (PID.TID 0000.0001) metricTerms =  /* metric-Terms on/off flag */
 (PID.TID 0000.0001)                   T
 (PID.TID 0000.0001)     ;
@@ -1525,14 +1915,12 @@
 (PID.TID 0000.0001) useCDscheme =  /* CD scheme on/off flag */
 (PID.TID 0000.0001)                   F
 (PID.TID 0000.0001)     ;
-(PID.TID 0000.0001) useEnergyConservingCoriolis= /* Flx-Form Coriolis scheme flag */
-(PID.TID 0000.0001)                   F
-(PID.TID 0000.0001)     ;
-(PID.TID 0000.0001) useJamartWetPoints= /* Coriolis WetPoints method flag */
-(PID.TID 0000.0001)                   F
-(PID.TID 0000.0001)     ;
-(PID.TID 0000.0001) useJamartMomAdv= /* V.I Non-linear terms Jamart flag */
-(PID.TID 0000.0001)                   F
+(PID.TID 0000.0001) selectCoriScheme= /* Scheme selector for Coriolis-Term */
+(PID.TID 0000.0001)                       0
+(PID.TID 0000.0001)    = 0 : original discretization (simple averaging, no hFac)
+(PID.TID 0000.0001)    = 1 : Wet-point averaging (Jamar & Ozer 1986)
+(PID.TID 0000.0001)    = 2 : hFac weighted average (Angular Mom. conserving)
+(PID.TID 0000.0001)    = 3 : energy conserving scheme using hFac weighted average
 (PID.TID 0000.0001)     ;
 (PID.TID 0000.0001) useAbsVorticity= /* V.I Works with f+zeta in Coriolis */
 (PID.TID 0000.0001)                   F
@@ -1544,6 +1932,9 @@
 (PID.TID 0000.0001)    = 2 : energy conserving scheme (used by Sadourny in JAS 75 paper)
 (PID.TID 0000.0001)    = 3 : energy (general) and enstrophy (2D, nonDiv.) conserving scheme
 (PID.TID 0000.0001)          from Sadourny (Burridge & Haseler, ECMWF Rep.4, 1977)
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) useJamartMomAdv= /* V.I Non-linear terms Jamart flag */
+(PID.TID 0000.0001)                   F
 (PID.TID 0000.0001)     ;
 (PID.TID 0000.0001) upwindVorticity= /* V.I Upwind bias vorticity flag */
 (PID.TID 0000.0001)                   F
@@ -1558,6 +1949,9 @@
 (PID.TID 0000.0001)                       0
 (PID.TID 0000.0001)     ;
 (PID.TID 0000.0001) momForcing =  /* Momentum forcing on/off flag */
+(PID.TID 0000.0001)                   T
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) momTidalForcing = /* Momentum Tidal forcing on/off flag */
 (PID.TID 0000.0001)                   T
 (PID.TID 0000.0001)     ;
 (PID.TID 0000.0001) momPressureForcing =  /* Momentum pressure term on/off flag */
@@ -1623,6 +2017,12 @@
 (PID.TID 0000.0001) writeBinaryPrec = /* Precision used for writing binary files */
 (PID.TID 0000.0001)                      32
 (PID.TID 0000.0001)     ;
+(PID.TID 0000.0001)  rwSuffixType =   /* select format of mds file suffix */
+(PID.TID 0000.0001)                       0
+(PID.TID 0000.0001)    = 0 : myIter (I10.10) ;   = 1 : 100*myTime (100th sec) ;
+(PID.TID 0000.0001)    = 2 : myTime (seconds);   = 3 : myTime/360 (10th of hr);
+(PID.TID 0000.0001)    = 4 : myTime/3600 (hours)
+(PID.TID 0000.0001)     ;
 (PID.TID 0000.0001)  globalFiles = /* write "global" (=not per tile) files */
 (PID.TID 0000.0001)                   F
 (PID.TID 0000.0001)     ;
@@ -1640,6 +2040,9 @@
 (PID.TID 0000.0001)    debLevD =  4 ; /* level of enhanced debug prt (add DEBUG_STATS prt) */
 (PID.TID 0000.0001)    debLevE =  5 ; /* level of extensive debug printing */
 (PID.TID 0000.0001) debugLevel =  /* select debug printing level */
+(PID.TID 0000.0001)                       1
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001)  plotLevel =  /* select PLOT_FIELD printing level */
 (PID.TID 0000.0001)                       1
 (PID.TID 0000.0001)     ;
 (PID.TID 0000.0001) //
@@ -1702,6 +2105,9 @@
 (PID.TID 0000.0001) abEps =   /* Adams-Bashforth-2 stabilizing weight */
 (PID.TID 0000.0001)                 1.000000000000000E-01
 (PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) applyExchUV_early = /* Apply EXCH to U,V earlier in time-step */
+(PID.TID 0000.0001)                   F
+(PID.TID 0000.0001)     ;
 (PID.TID 0000.0001) pickupStrictlyMatch= /* stop if pickup do not strictly match */
 (PID.TID 0000.0001)                   T
 (PID.TID 0000.0001)     ;
@@ -1735,9 +2141,6 @@
 (PID.TID 0000.0001) pickup_read_mdsio =   /* Model IO flag. */
 (PID.TID 0000.0001)                   T
 (PID.TID 0000.0001)     ;
-(PID.TID 0000.0001) pickup_write_immed =   /* Model IO flag. */
-(PID.TID 0000.0001)                   F
-(PID.TID 0000.0001)     ;
 (PID.TID 0000.0001) writePickupAtEnd =   /* Model IO flag. */
 (PID.TID 0000.0001)                   T
 (PID.TID 0000.0001)     ;
@@ -1751,7 +2154,7 @@
 (PID.TID 0000.0001)                   T
 (PID.TID 0000.0001)     ;
 (PID.TID 0000.0001) monitorFreq =   /* Monitor output interval ( s ). */
-(PID.TID 0000.0001)                 3.600000000000000E+03
+(PID.TID 0000.0001)                 4.800000000000000E+03
 (PID.TID 0000.0001)     ;
 (PID.TID 0000.0001) monitorSelect = /* select group of variables to monitor */
 (PID.TID 0000.0001)                       1
@@ -1789,11 +2192,20 @@
 (PID.TID 0000.0001) usingCurvilinearGrid = /* Curvilinear coordinates flag ( True/False ) */
 (PID.TID 0000.0001)                   F
 (PID.TID 0000.0001)     ;
-(PID.TID 0000.0001) selectSigmaCoord = /* Hybrid-Sigma Vert. Coordinate option */
+(PID.TID 0000.0001) useMin4hFacEdges = /* set hFacW,S as minimum of adjacent hFacC factor */
+(PID.TID 0000.0001)                   F
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) interViscAr_pCell = /* account for partial-cell in interior vert. viscosity */
+(PID.TID 0000.0001)                   F
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) interDiffKr_pCell = /* account for partial-cell in interior vert. diffusion */
+(PID.TID 0000.0001)                   F
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) pCellMix_select = /* option to enhance mixing near surface & bottom */
 (PID.TID 0000.0001)                       0
 (PID.TID 0000.0001)     ;
-(PID.TID 0000.0001) Ro_SeaLevel = /* r(1) ( units of r ==  m ) */
-(PID.TID 0000.0001)                 0.000000000000000E+00
+(PID.TID 0000.0001) selectSigmaCoord = /* Hybrid-Sigma Vert. Coordinate option */
+(PID.TID 0000.0001)                       0
 (PID.TID 0000.0001)     ;
 (PID.TID 0000.0001) rSigmaBnd = /* r/sigma transition ( units of r ==  m ) */
 (PID.TID 0000.0001)                 1.234567000000000E+05
@@ -1803,6 +2215,12 @@
 (PID.TID 0000.0001)     ;
 (PID.TID 0000.0001) gravitySign = /* gravity orientation relative to vertical coordinate */
 (PID.TID 0000.0001)                -1.000000000000000E+00
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) seaLev_Z =  /* reference height of sea-level [m] */
+(PID.TID 0000.0001)                 0.000000000000000E+00
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) top_Pres =  /* reference pressure at the top [Pa] */
+(PID.TID 0000.0001)                 0.000000000000000E+00
 (PID.TID 0000.0001)     ;
 (PID.TID 0000.0001) mass2rUnit = /* convert mass per unit area [kg/m2] to r-units [m] */
 (PID.TID 0000.0001)                 1.000200040008002E-03
@@ -2553,7 +2971,7 @@
 (PID.TID 0000.0001)                       0
 (PID.TID 0000.0001)     ;
 (PID.TID 0000.0001) OBCS_monitorFreq = /* monitor output frequency [s] */
-(PID.TID 0000.0001)                 3.600000000000000E+03
+(PID.TID 0000.0001)                 4.800000000000000E+03
 (PID.TID 0000.0001)     ;
 (PID.TID 0000.0001) OBCS_monSelect = /* select group of variables to monitor */
 (PID.TID 0000.0001)                       0
@@ -2606,9 +3024,13 @@
 (PID.TID 0000.0001) OBCS_CHECK: end summary.
 (PID.TID 0000.0001) OBCS_CHECK: set-up OK
 (PID.TID 0000.0001) OBCS_CHECK: check Inside Mask and OB locations: OK
-(PID.TID 0000.0001) CTRL_CHECK: ctrl package
-(PID.TID 0000.0001) COST_CHECK: cost package
+(PID.TID 0000.0001) EXF_CHECK: #define ALLOW_EXF
+(PID.TID 0000.0001) CTRL_CHECK:  --> Starts to check CTRL set-up
+(PID.TID 0000.0001) CTRL_CHECK:  <-- Ends Normally
+(PID.TID 0000.0001) 
+(PID.TID 0000.0001) COST_CHECK: #define ALLOW_COST
 (PID.TID 0000.0001) GRDCHK_CHECK: grdchk package
+(PID.TID 0000.0001) etaday defined by gencost   0
 (PID.TID 0000.0001) GAD_CHECK: #define ALLOW_GENERIC_ADVDIFF
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // Check Model config. (CONFIG_CHECK):
@@ -2694,51 +3116,52 @@
  cg2d: Sum(rhs),rhsMax =  -7.87435592178018E+00  1.37697984471785E+00
  cg2d: Sum(rhs),rhsMax =  -1.01791081157115E+02  2.13040853307022E-01
  cg2d: Sum(rhs),rhsMax =  -1.59112718349022E+02  2.04436757292323E-01
-(PID.TID 0000.0001)      cg2d_init_res =   1.07341835251457E+01
-(PID.TID 0000.0001)      cg2d_iters(min,last) =      -1     125
-(PID.TID 0000.0001)      cg2d_last_res =   8.69273657547353E-09
+ cg2d: Sum(rhs),rhsMax =  -2.24736325184813E+02  1.92987571287909E-01
+(PID.TID 0000.0001)      cg2d_init_res =   5.54624486165762E+00
+(PID.TID 0000.0001)      cg2d_iters(min,last) =      -1     124
+(PID.TID 0000.0001)      cg2d_last_res =   9.76732479760236E-09
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // Begin MONITOR dynamic field statistics
 (PID.TID 0000.0001) // =======================================================
-(PID.TID 0000.0001) %MON time_tsnumber                =                     3
-(PID.TID 0000.0001) %MON time_secondsf                =   3.6000000000000E+03
-(PID.TID 0000.0001) %MON dynstat_eta_max              =   7.8092398553590E-01
-(PID.TID 0000.0001) %MON dynstat_eta_min              =  -5.4968965087768E-01
-(PID.TID 0000.0001) %MON dynstat_eta_mean             =   9.9423395070582E-02
-(PID.TID 0000.0001) %MON dynstat_eta_sd               =   2.9439735896680E-01
-(PID.TID 0000.0001) %MON dynstat_eta_del2             =   1.8190879495240E-05
-(PID.TID 0000.0001) %MON dynstat_uvel_max             =   4.8537995003132E-02
-(PID.TID 0000.0001) %MON dynstat_uvel_min             =  -3.8997873814471E-02
-(PID.TID 0000.0001) %MON dynstat_uvel_mean            =   7.8610415895868E-03
-(PID.TID 0000.0001) %MON dynstat_uvel_sd              =   1.2961485949301E-02
-(PID.TID 0000.0001) %MON dynstat_uvel_del2            =   3.5150503690454E-05
+(PID.TID 0000.0001) %MON time_tsnumber                =                     4
+(PID.TID 0000.0001) %MON time_secondsf                =   4.8000000000000E+03
+(PID.TID 0000.0001) %MON dynstat_eta_max              =   9.2130392091931E-01
+(PID.TID 0000.0001) %MON dynstat_eta_min              =  -5.6255703983901E-01
+(PID.TID 0000.0001) %MON dynstat_eta_mean             =   1.3256452676073E-01
+(PID.TID 0000.0001) %MON dynstat_eta_sd               =   3.4455125785822E-01
+(PID.TID 0000.0001) %MON dynstat_eta_del2             =   1.4253272027794E-05
+(PID.TID 0000.0001) %MON dynstat_uvel_max             =   4.4546562415600E-02
+(PID.TID 0000.0001) %MON dynstat_uvel_min             =  -3.8670904988210E-02
+(PID.TID 0000.0001) %MON dynstat_uvel_mean            =   6.3213292834139E-03
+(PID.TID 0000.0001) %MON dynstat_uvel_sd              =   1.2365214002733E-02
+(PID.TID 0000.0001) %MON dynstat_uvel_del2            =   3.3192533216355E-05
 (PID.TID 0000.0001) %MON dynstat_vvel_max             =   9.9974803626537E-02
 (PID.TID 0000.0001) %MON dynstat_vvel_min             =   6.2484252266586E-03
-(PID.TID 0000.0001) %MON dynstat_vvel_mean            =   7.0253520401631E-02
-(PID.TID 0000.0001) %MON dynstat_vvel_sd              =   1.2000187955839E-02
-(PID.TID 0000.0001) %MON dynstat_vvel_del2            =   5.6726128973313E-05
-(PID.TID 0000.0001) %MON dynstat_wvel_max             =   4.0011921563865E-04
-(PID.TID 0000.0001) %MON dynstat_wvel_min             =  -3.2885885525852E-04
+(PID.TID 0000.0001) %MON dynstat_vvel_mean            =   6.5911248841545E-02
+(PID.TID 0000.0001) %MON dynstat_vvel_sd              =   1.1520767318869E-02
+(PID.TID 0000.0001) %MON dynstat_vvel_del2            =   5.2443710264333E-05
+(PID.TID 0000.0001) %MON dynstat_wvel_max             =   2.1316879708723E-04
+(PID.TID 0000.0001) %MON dynstat_wvel_min             =  -1.5012272074613E-04
 (PID.TID 0000.0001) %MON dynstat_wvel_mean            =   1.4729391862362E-05
-(PID.TID 0000.0001) %MON dynstat_wvel_sd              =   7.4772613147768E-05
-(PID.TID 0000.0001) %MON dynstat_wvel_del2            =   1.8938666481104E-07
-(PID.TID 0000.0001) %MON dynstat_theta_max            =   2.0001248819492E+01
-(PID.TID 0000.0001) %MON dynstat_theta_min            =   5.9999361694632E+00
-(PID.TID 0000.0001) %MON dynstat_theta_mean           =   1.0999776469027E+01
-(PID.TID 0000.0001) %MON dynstat_theta_sd             =   4.4997965691583E+00
-(PID.TID 0000.0001) %MON dynstat_theta_del2           =   1.9685540248354E-06
+(PID.TID 0000.0001) %MON dynstat_wvel_sd              =   5.1810336999194E-05
+(PID.TID 0000.0001) %MON dynstat_wvel_del2            =   1.0172580595088E-07
+(PID.TID 0000.0001) %MON dynstat_theta_max            =   2.0001260229520E+01
+(PID.TID 0000.0001) %MON dynstat_theta_min            =   5.9999253969875E+00
+(PID.TID 0000.0001) %MON dynstat_theta_mean           =   1.0999702246231E+01
+(PID.TID 0000.0001) %MON dynstat_theta_sd             =   4.4997341908325E+00
+(PID.TID 0000.0001) %MON dynstat_theta_del2           =   2.3209976472543E-06
 (PID.TID 0000.0001) %MON dynstat_salt_max             =   3.5000000000000E+01
 (PID.TID 0000.0001) %MON dynstat_salt_min             =   3.5000000000000E+01
 (PID.TID 0000.0001) %MON dynstat_salt_mean            =   3.4999999999999E+01
 (PID.TID 0000.0001) %MON dynstat_salt_sd              =   5.4711790653528E-13
 (PID.TID 0000.0001) %MON dynstat_salt_del2            =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON advcfl_uvel_max              =   2.7610341090195E-03
+(PID.TID 0000.0001) %MON advcfl_uvel_max              =   2.5339855562864E-03
 (PID.TID 0000.0001) %MON advcfl_vvel_max              =   4.3163335425681E-03
-(PID.TID 0000.0001) %MON advcfl_wvel_max              =   1.9205722350655E-03
-(PID.TID 0000.0001) %MON advcfl_W_hf_max              =   8.4492544279721E-04
-(PID.TID 0000.0001) %MON pe_b_mean                    =   1.1840034367670E-04
-(PID.TID 0000.0001) %MON ke_max                       =   5.0892057267744E-03
-(PID.TID 0000.0001) %MON ke_mean                      =   2.6538045909161E-03
+(PID.TID 0000.0001) %MON advcfl_wvel_max              =   1.0232102260187E-03
+(PID.TID 0000.0001) %MON advcfl_W_hf_max              =   4.4735815378683E-04
+(PID.TID 0000.0001) %MON pe_b_mean                    =   1.6712429188635E-04
+(PID.TID 0000.0001) %MON ke_max                       =   4.9317513107246E-03
+(PID.TID 0000.0001) %MON ke_mean                      =   2.3289380306233E-03
 (PID.TID 0000.0001) %MON ke_vol                       =   9.9316925415266E+15
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // End MONITOR dynamic field statistics
@@ -2769,114 +3192,17 @@
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // End OBCS MONITOR field statistics
 (PID.TID 0000.0001) // =======================================================
- cg2d: Sum(rhs),rhsMax =  -2.24736325184813E+02  1.92987571287909E-01
 (PID.TID 0000.0001) %CHECKPOINT         4 ckptA
-(PID.TID 0000.0001) ph-cost call cost_theta0
-(PID.TID 0000.0001) ph-cost call cost_theta
- --> f_temp    = 0.147701073786182D+01
- --> f_salt    = 0.000000000000000D+00
- --> f_temp0   = 0.000000000000000D+00
- --> f_salt0   = 0.000000000000000D+00
- --> f_temp0smoo = 0.000000000000000D+00
- --> f_salt0smoo = 0.000000000000000D+00
- --> f_etan0   = 0.000000000000000D+00
- --> f_uvel0   = 0.000000000000000D+00
- --> f_vvel0   = 0.000000000000000D+00
- --> f_sst     = 0.000000000000000D+00
- --> f_tmi     = 0.000000000000000D+00
- --> f_sss     = 0.000000000000000D+00
- --> f_bp      = 0.000000000000000D+00
- --> f_ies      = 0.000000000000000D+00
- --> f_ssh       = 0.000000000000000D+00
- --> f_tp        = 0.000000000000000D+00
- --> f_ers       = 0.000000000000000D+00
- --> f_gfo       = 0.000000000000000D+00
- --> f_tauu    = 0.000000000000000D+00
- --> f_tauum   = 0.000000000000000D+00
- --> f_tauusmoo = 0.000000000000000D+00
- --> f_tauv    = 0.000000000000000D+00
- --> f_tauvm   = 0.000000000000000D+00
- --> f_tauvsmoo = 0.000000000000000D+00
- --> f_hflux   = 0.000000000000000D+00
- --> f_hfluxmm = 0.000000000000000D+00
- --> f_hfluxsmoo = 0.000000000000000D+00
- --> f_sflux   = 0.000000000000000D+00
- --> f_sfluxmm = 0.000000000000000D+00
- --> f_sfluxsmoo = 0.000000000000000D+00
- --> f_uwind     = 0.000000000000000D+00
- --> f_vwind     = 0.000000000000000D+00
- --> f_atemp     = 0.000000000000000D+00
- --> f_aqh     = 0.000000000000000D+00
- --> f_precip  = 0.000000000000000D+00
- --> f_swflux  = 0.000000000000000D+00
- --> f_swdown  = 0.000000000000000D+00
- --> f_lwflux  = 0.000000000000000D+00
- --> f_lwdown  = 0.000000000000000D+00
- --> f_uwindm     = 0.000000000000000D+00
- --> f_vwindm     = 0.000000000000000D+00
- --> f_atempm     = 0.000000000000000D+00
- --> f_aqhm     = 0.000000000000000D+00
- --> f_precipm  = 0.000000000000000D+00
- --> f_swfluxm  = 0.000000000000000D+00
- --> f_lwfluxm  = 0.000000000000000D+00
- --> f_swdownm  = 0.000000000000000D+00
- --> f_lwdownm  = 0.000000000000000D+00
- --> f_uwindsmoo     = 0.000000000000000D+00
- --> f_vwindsmoo     = 0.000000000000000D+00
- --> f_atempsmoo     = 0.000000000000000D+00
- --> f_aqhsmoo     = 0.000000000000000D+00
- --> f_precipsmoo  = 0.000000000000000D+00
- --> f_swfluxsmoo  = 0.000000000000000D+00
- --> f_lwfluxsmoo  = 0.000000000000000D+00
- --> f_swdownsmoo  = 0.000000000000000D+00
- --> f_lwdownsmoo  = 0.000000000000000D+00
- --> f_atl     = 0.000000000000000D+00
- --> f_ctdt    = 0.000000000000000D+00
- --> f_ctds    = 0.000000000000000D+00
- --> f_ctdtclim= 0.000000000000000D+00
- --> f_ctdsclim= 0.000000000000000D+00
- --> f_xbt     = 0.000000000000000D+00
- --> f_argot   = 0.000000000000000D+00
- --> f_argos   = 0.000000000000000D+00
- --> f_drifter   = 0.000000000000000D+00
- --> f_tdrift  = 0.000000000000000D+00
- --> f_sdrift  = 0.000000000000000D+00
- --> f_wdrift  = 0.000000000000000D+00
- --> f_scatx   = 0.000000000000000D+00
- --> f_scaty   = 0.000000000000000D+00
- --> f_scatxm  = 0.000000000000000D+00
- --> f_scatym  = 0.000000000000000D+00
  --> f_obcsn   = 0.000000000000000D+00
  --> f_obcss   = 0.000000000000000D+00
  --> f_obcsw   = 0.000000000000000D+00
  --> f_obcse   = 0.000000000000000D+00
- --> f_ageos   = 0.000000000000000D+00
- --> f_curmtr  = 0.000000000000000D+00
- --> f_kapgm   = 0.000000000000000D+00
- --> f_kapredi   = 0.000000000000000D+00
- --> f_diffkr  = 0.000000000000000D+00
- --> f_eddytau = 0.000000000000000D+00
- --> f_bottomdrag = 0.000000000000000D+00
- --> f_hfluxmm2           = 0.000000000000000D+00
- --> f_sfluxmm2           = 0.000000000000000D+00
- --> f_transp             = 0.000000000000000D+00
- --> objf_hmean           = 0.000000000000000D+00
- --> fc               = 0.000000000000000D+00
-  early fc =  0.000000000000000D+00
- --> objf_test(bi,bj)   =  0.000000000000000D+00
- --> objf_tracer(bi,bj) =  0.000000000000000D+00
- --> objf_atl(bi,bj)    =  0.000000000000000D+00
- --> objf_test(bi,bj)   =  0.000000000000000D+00
- --> objf_tracer(bi,bj) =  0.000000000000000D+00
- --> objf_atl(bi,bj)    =  0.000000000000000D+00
- --> objf_test(bi,bj)   =  0.000000000000000D+00
- --> objf_tracer(bi,bj) =  0.000000000000000D+00
- --> objf_atl(bi,bj)    =  0.000000000000000D+00
- --> objf_test(bi,bj)   =  0.000000000000000D+00
- --> objf_tracer(bi,bj) =  0.000000000000000D+00
- --> objf_atl(bi,bj)    =  0.000000000000000D+00
-  local fc =  0.147701073786182D+01
- global fc =  0.147701073786182D+01
+(PID.TID 0000.0001)  --> f_gencost = 0.147701073786182D+01 1
+(PID.TID 0000.0001)  --> f_genarr3d = 0.000000000000000D+00 1
+(PID.TID 0000.0001)  --> fc               = 0.147701073786182D+01
+(PID.TID 0000.0001)   early fc =  0.000000000000000D+00
+(PID.TID 0000.0001)   local fc =  0.147701073786182D+01
+(PID.TID 0000.0001)  global fc =  0.147701073786182D+01
 (PID.TID 0000.0001) SOLVE_FOR_PRESSURE: putPmEinXvector =    F
  cg2d: Sum(rhs),rhsMax =  -7.87435592178018E+00  1.37697984471785E+00
  cg2d: Sum(rhs),rhsMax =  -1.01791081157115E+02  2.13040853307022E-01
@@ -2889,14 +3215,237 @@
  cg2d: Sum(rhs),rhsMax =  -1.59112718349022E+02  2.04436757292323E-01
  cg2d: Sum(rhs),rhsMax =  -2.24736325184813E+02  1.92987571287909E-01
 (PID.TID 0000.0001) Did not write pickup because writePickupAtEnd = FALSE
+ cg2d: Sum(rhs),rhsMax =  -2.24736307784685E+02  1.92987586350900E-01
 (PID.TID 0000.0001) Did not write pickup because writePickupAtEnd = FALSE
- cg2d: Sum(rhs),rhsMax =  -8.88178419700125E-15  3.51056614475562E-07
- cg2d: Sum(rhs),rhsMax =   1.31969102312723E-10  5.59388870055407E-07
- cg2d: Sum(rhs),rhsMax =   1.14482645585667E-10  6.28064934600198E-07
- cg2d: Sum(rhs),rhsMax =  -1.04449782156735E-12  9.25487177941239E-07
+ Calling cg2d from S/R CG2D_SAD
+ cg2d: Sum(rhs),rhsMax =   3.19744231092045E-14  3.51056614475562E-07
+(PID.TID 0000.0001) // =======================================================
+(PID.TID 0000.0001) // Begin AD_MONITOR EXF statistics for iwhen =  3
+(PID.TID 0000.0001) // =======================================================
+(PID.TID 0000.0001) %MON ad_exf_tsnumber              =                     3
+(PID.TID 0000.0001) %MON ad_exf_time_sec              =   3.6000000000000E+03
+(PID.TID 0000.0001) %MON ad_exf_adfu_max              =   5.8709717829351E-06
+(PID.TID 0000.0001) %MON ad_exf_adfu_min              =  -5.0431749928204E-06
+(PID.TID 0000.0001) %MON ad_exf_adfu_mean             =  -8.3540510599836E-07
+(PID.TID 0000.0001) %MON ad_exf_adfu_sd               =   1.2621909994194E-06
+(PID.TID 0000.0001) %MON ad_exf_adfu_del2             =   2.3130992997975E-08
+(PID.TID 0000.0001) %MON ad_exf_adfv_max              =   1.1246194862269E-05
+(PID.TID 0000.0001) %MON ad_exf_adfv_min              =  -5.4423141248595E-06
+(PID.TID 0000.0001) %MON ad_exf_adfv_mean             =   7.6127193119865E-07
+(PID.TID 0000.0001) %MON ad_exf_adfv_sd               =   2.6719796373446E-06
+(PID.TID 0000.0001) %MON ad_exf_adfv_del2             =   2.7390574716127E-08
+(PID.TID 0000.0001) %MON ad_exf_adqnet_max            =   4.6438701753071E-08
+(PID.TID 0000.0001) %MON ad_exf_adqnet_min            =  -2.2003352880324E-08
+(PID.TID 0000.0001) %MON ad_exf_adqnet_mean           =   8.8636803209616E-09
+(PID.TID 0000.0001) %MON ad_exf_adqnet_sd             =   1.4929044558236E-08
+(PID.TID 0000.0001) %MON ad_exf_adqnet_del2           =   5.4523809756612E-11
+(PID.TID 0000.0001) %MON ad_exf_adempmr_max           =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON ad_exf_adempmr_min           =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON ad_exf_adempmr_mean          =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON ad_exf_adempmr_sd            =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON ad_exf_adempmr_del2          =   0.0000000000000E+00
+(PID.TID 0000.0001) // =======================================================
+(PID.TID 0000.0001) // End AD_MONITOR EXF statistics for iwhen =  3
+(PID.TID 0000.0001) // =======================================================
+(PID.TID 0000.0001) // =======================================================
+(PID.TID 0000.0001) // Begin AD_MONITOR EXF statistics for iwhen =  1
+(PID.TID 0000.0001) // =======================================================
+(PID.TID 0000.0001) %MON ad_exf_tsnumber              =                     3
+(PID.TID 0000.0001) %MON ad_exf_time_sec              =   3.6000000000000E+03
+(PID.TID 0000.0001) %MON ad_exf_adustress_max         =   3.7274570918021E-06
+(PID.TID 0000.0001) %MON ad_exf_adustress_min         =  -5.0415844732947E-06
+(PID.TID 0000.0001) %MON ad_exf_adustress_mean        =  -8.3337873736786E-07
+(PID.TID 0000.0001) %MON ad_exf_adustress_sd          =   1.2094382236025E-06
+(PID.TID 0000.0001) %MON ad_exf_adustress_del2        =   1.2590199082228E-08
+(PID.TID 0000.0001) %MON ad_exf_advstress_max         =   1.1079375452446E-05
+(PID.TID 0000.0001) %MON ad_exf_advstress_min         =  -2.4343375629543E-06
+(PID.TID 0000.0001) %MON ad_exf_advstress_mean        =   7.7559128172213E-07
+(PID.TID 0000.0001) %MON ad_exf_advstress_sd          =   2.5646312323075E-06
+(PID.TID 0000.0001) %MON ad_exf_advstress_del2        =   1.8377587936728E-08
+(PID.TID 0000.0001) %MON ad_exf_adhflux_max           =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON ad_exf_adhflux_min           =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON ad_exf_adhflux_mean          =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON ad_exf_adhflux_sd            =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON ad_exf_adhflux_del2          =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON ad_exf_adsflux_max           =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON ad_exf_adsflux_min           =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON ad_exf_adsflux_mean          =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON ad_exf_adsflux_sd            =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON ad_exf_adsflux_del2          =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON ad_exf_adwspeed_max          =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON ad_exf_adwspeed_min          =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON ad_exf_adwspeed_mean         =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON ad_exf_adwspeed_sd           =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON ad_exf_adwspeed_del2         =   0.0000000000000E+00
+(PID.TID 0000.0001) // =======================================================
+(PID.TID 0000.0001) // End AD_MONITOR EXF statistics for iwhen =  1
+(PID.TID 0000.0001) // =======================================================
+(PID.TID 0000.0001) // =======================================================
+(PID.TID 0000.0001) // Begin AD_MONITOR EXF statistics for iwhen =  2
+(PID.TID 0000.0001) // =======================================================
+(PID.TID 0000.0001) %MON ad_exf_tsnumber              =                     3
+(PID.TID 0000.0001) %MON ad_exf_time_sec              =   3.6000000000000E+03
+(PID.TID 0000.0001) // =======================================================
+(PID.TID 0000.0001) // End AD_MONITOR EXF statistics for iwhen =  2
+(PID.TID 0000.0001) // =======================================================
+ cg2d: Sum(rhs),rhsMax =  -1.59112726246071E+02  2.04436747268914E-01
+(PID.TID 0000.0001) // =======================================================
+(PID.TID 0000.0001) // Begin AD_MONITOR dynamic field statistics
+(PID.TID 0000.0001) // =======================================================
+(PID.TID 0000.0001) %MON ad_time_tsnumber             =                     3
+(PID.TID 0000.0001) %MON ad_time_secondsf             =   3.6000000000000E+03
+(PID.TID 0000.0001) %MON ad_dynstat_adeta_max         =   6.9553714367739E-04
+(PID.TID 0000.0001) %MON ad_dynstat_adeta_min         =  -5.4177609226076E-04
+(PID.TID 0000.0001) %MON ad_dynstat_adeta_mean        =   2.3516835039517E-06
+(PID.TID 0000.0001) %MON ad_dynstat_adeta_sd          =   2.1084468100996E-04
+(PID.TID 0000.0001) %MON ad_dynstat_adeta_del2        =   7.1780902426021E-07
+(PID.TID 0000.0001) %MON ad_dynstat_aduvel_max        =   1.7242637004962E-03
+(PID.TID 0000.0001) %MON ad_dynstat_aduvel_min        =  -1.3997311137770E-03
+(PID.TID 0000.0001) %MON ad_dynstat_aduvel_mean       =   4.1597280631791E-04
+(PID.TID 0000.0001) %MON ad_dynstat_aduvel_sd         =   4.4753403135599E-04
+(PID.TID 0000.0001) %MON ad_dynstat_aduvel_del2       =   1.4726674745988E-06
+(PID.TID 0000.0001) %MON ad_dynstat_advvel_max        =   2.8832914124571E-03
+(PID.TID 0000.0001) %MON ad_dynstat_advvel_min        =  -1.4298100658402E-03
+(PID.TID 0000.0001) %MON ad_dynstat_advvel_mean       =   3.1593505821441E-04
+(PID.TID 0000.0001) %MON ad_dynstat_advvel_sd         =   6.0346002533507E-04
+(PID.TID 0000.0001) %MON ad_dynstat_advvel_del2       =   2.0214054920126E-06
+(PID.TID 0000.0001) %MON ad_dynstat_adwvel_max        =   3.6767199578452E-07
+(PID.TID 0000.0001) %MON ad_dynstat_adwvel_min        =  -8.7956852691803E-08
+(PID.TID 0000.0001) %MON ad_dynstat_adwvel_mean       =  -2.9155919432676E-09
+(PID.TID 0000.0001) %MON ad_dynstat_adwvel_sd         =   2.6595476741591E-08
+(PID.TID 0000.0001) %MON ad_dynstat_adwvel_del2       =   6.6766183266447E-11
+(PID.TID 0000.0001) %MON ad_dynstat_adtheta_max       =   2.4177848166771E-01
+(PID.TID 0000.0001) %MON ad_dynstat_adtheta_min       =  -3.0677830191700E-01
+(PID.TID 0000.0001) %MON ad_dynstat_adtheta_mean      =  -1.1911405043954E-02
+(PID.TID 0000.0001) %MON ad_dynstat_adtheta_sd        =   5.3573179769125E-02
+(PID.TID 0000.0001) %MON ad_dynstat_adtheta_del2      =   1.1593988690583E-04
+(PID.TID 0000.0001) %MON ad_dynstat_adsalt_max        =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON ad_dynstat_adsalt_min        =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON ad_dynstat_adsalt_mean       =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON ad_dynstat_adsalt_sd         =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON ad_dynstat_adsalt_del2       =   0.0000000000000E+00
+(PID.TID 0000.0001) // =======================================================
+(PID.TID 0000.0001) // End AD_MONITOR dynamic field statistics
+(PID.TID 0000.0001) // =======================================================
+ Calling cg2d from S/R CG2D_SAD
+ cg2d: Sum(rhs),rhsMax =   1.31858968188681E-10  5.59388870055983E-07
+ cg2d: Sum(rhs),rhsMax =  -1.01791052791247E+02  2.13040912211049E-01
+ Calling cg2d from S/R CG2D_SAD
+ cg2d: Sum(rhs),rhsMax =   1.14553699859243E-10  6.28064934587702E-07
+(PID.TID 0000.0001) SOLVE_FOR_PRESSURE: putPmEinXvector =    F
+ cg2d: Sum(rhs),rhsMax =  -7.87435592178018E+00  1.37697984471785E+00
+ Calling cg2d from S/R CG2D_SAD
+ cg2d: Sum(rhs),rhsMax =  -8.73967564984923E-13  9.25487177938092E-07
+(PID.TID 0000.0001) // =======================================================
+(PID.TID 0000.0001) // Begin AD_MONITOR EXF statistics for iwhen =  3
+(PID.TID 0000.0001) // =======================================================
+(PID.TID 0000.0001) %MON ad_exf_tsnumber              =                     0
+(PID.TID 0000.0001) %MON ad_exf_time_sec              =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON ad_exf_adfu_max              =   1.2552281362196E-05
+(PID.TID 0000.0001) %MON ad_exf_adfu_min              =  -3.5914552579897E-05
+(PID.TID 0000.0001) %MON ad_exf_adfu_mean             =  -7.0608941088644E-06
+(PID.TID 0000.0001) %MON ad_exf_adfu_sd               =   6.4556812168091E-06
+(PID.TID 0000.0001) %MON ad_exf_adfu_del2             =   5.1076688924702E-08
+(PID.TID 0000.0001) %MON ad_exf_adfv_max              =   4.8331863849915E-05
+(PID.TID 0000.0001) %MON ad_exf_adfv_min              =  -1.9839717090482E-05
+(PID.TID 0000.0001) %MON ad_exf_adfv_mean             =   1.0461566958412E-06
+(PID.TID 0000.0001) %MON ad_exf_adfv_sd               =   1.4072316049049E-05
+(PID.TID 0000.0001) %MON ad_exf_adfv_del2             =   8.5337991164083E-08
+(PID.TID 0000.0001) %MON ad_exf_adqnet_max            =   1.8225251536434E-07
+(PID.TID 0000.0001) %MON ad_exf_adqnet_min            =  -8.6236717737716E-08
+(PID.TID 0000.0001) %MON ad_exf_adqnet_mean           =   3.5330836684638E-08
+(PID.TID 0000.0001) %MON ad_exf_adqnet_sd             =   5.9371649204344E-08
+(PID.TID 0000.0001) %MON ad_exf_adqnet_del2           =   2.1725373829097E-10
+(PID.TID 0000.0001) %MON ad_exf_adempmr_max           =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON ad_exf_adempmr_min           =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON ad_exf_adempmr_mean          =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON ad_exf_adempmr_sd            =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON ad_exf_adempmr_del2          =   0.0000000000000E+00
+(PID.TID 0000.0001) // =======================================================
+(PID.TID 0000.0001) // End AD_MONITOR EXF statistics for iwhen =  3
+(PID.TID 0000.0001) // =======================================================
+(PID.TID 0000.0001) // =======================================================
+(PID.TID 0000.0001) // Begin AD_MONITOR EXF statistics for iwhen =  1
+(PID.TID 0000.0001) // =======================================================
+(PID.TID 0000.0001) %MON ad_exf_tsnumber              =                     0
+(PID.TID 0000.0001) %MON ad_exf_time_sec              =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON ad_exf_adustress_max         =   3.9245975748616E-05
+(PID.TID 0000.0001) %MON ad_exf_adustress_min         =  -8.6297830578121E-05
+(PID.TID 0000.0001) %MON ad_exf_adustress_mean        =  -1.8104262271548E-05
+(PID.TID 0000.0001) %MON ad_exf_adustress_sd          =   1.8139588477426E-05
+(PID.TID 0000.0001) %MON ad_exf_adustress_del2        =   8.9832517344424E-08
+(PID.TID 0000.0001) %MON ad_exf_advstress_max         =   1.4144123986796E-04
+(PID.TID 0000.0001) %MON ad_exf_advstress_min         =  -4.4657373904865E-05
+(PID.TID 0000.0001) %MON ad_exf_advstress_mean        =   6.2517738768625E-06
+(PID.TID 0000.0001) %MON ad_exf_advstress_sd          =   3.9642792228470E-05
+(PID.TID 0000.0001) %MON ad_exf_advstress_del2        =   2.1947505130906E-07
+(PID.TID 0000.0001) %MON ad_exf_adhflux_max           =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON ad_exf_adhflux_min           =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON ad_exf_adhflux_mean          =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON ad_exf_adhflux_sd            =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON ad_exf_adhflux_del2          =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON ad_exf_adsflux_max           =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON ad_exf_adsflux_min           =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON ad_exf_adsflux_mean          =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON ad_exf_adsflux_sd            =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON ad_exf_adsflux_del2          =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON ad_exf_adwspeed_max          =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON ad_exf_adwspeed_min          =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON ad_exf_adwspeed_mean         =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON ad_exf_adwspeed_sd           =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON ad_exf_adwspeed_del2         =   0.0000000000000E+00
+(PID.TID 0000.0001) // =======================================================
+(PID.TID 0000.0001) // End AD_MONITOR EXF statistics for iwhen =  1
+(PID.TID 0000.0001) // =======================================================
+(PID.TID 0000.0001) // =======================================================
+(PID.TID 0000.0001) // Begin AD_MONITOR EXF statistics for iwhen =  2
+(PID.TID 0000.0001) // =======================================================
+(PID.TID 0000.0001) %MON ad_exf_tsnumber              =                     0
+(PID.TID 0000.0001) %MON ad_exf_time_sec              =   0.0000000000000E+00
+(PID.TID 0000.0001) // =======================================================
+(PID.TID 0000.0001) // End AD_MONITOR EXF statistics for iwhen =  2
+(PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) Start initial hydrostatic pressure computation
 (PID.TID 0000.0001) Pressure is predetermined for buoyancyRelation OCEANIC
 (PID.TID 0000.0001) 
+(PID.TID 0000.0001) // =======================================================
+(PID.TID 0000.0001) // Begin AD_MONITOR dynamic field statistics
+(PID.TID 0000.0001) // =======================================================
+(PID.TID 0000.0001) %MON ad_time_tsnumber             =                     0
+(PID.TID 0000.0001) %MON ad_time_secondsf             =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON ad_dynstat_adeta_max         =   4.7869894365378E-03
+(PID.TID 0000.0001) %MON ad_dynstat_adeta_min         =  -4.7565576878087E-03
+(PID.TID 0000.0001) %MON ad_dynstat_adeta_mean        =   4.6799540815434E-05
+(PID.TID 0000.0001) %MON ad_dynstat_adeta_sd          =   1.9898151358336E-03
+(PID.TID 0000.0001) %MON ad_dynstat_adeta_del2        =   5.1648218116907E-06
+(PID.TID 0000.0001) %MON ad_dynstat_aduvel_max        =   1.1564982648546E-02
+(PID.TID 0000.0001) %MON ad_dynstat_aduvel_min        =  -2.0463784124876E-02
+(PID.TID 0000.0001) %MON ad_dynstat_aduvel_mean       =   2.2090930370914E-03
+(PID.TID 0000.0001) %MON ad_dynstat_aduvel_sd         =   3.7924004828758E-03
+(PID.TID 0000.0001) %MON ad_dynstat_aduvel_del2       =   9.5668717463669E-06
+(PID.TID 0000.0001) %MON ad_dynstat_advvel_max        =   3.0259205799804E-02
+(PID.TID 0000.0001) %MON ad_dynstat_advvel_min        =  -1.1599535100862E-02
+(PID.TID 0000.0001) %MON ad_dynstat_advvel_mean       =   2.3825090204143E-03
+(PID.TID 0000.0001) %MON ad_dynstat_advvel_sd         =   4.8975400333167E-03
+(PID.TID 0000.0001) %MON ad_dynstat_advvel_del2       =   1.5395027191477E-05
+(PID.TID 0000.0001) %MON ad_dynstat_adwvel_max        =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON ad_dynstat_adwvel_min        =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON ad_dynstat_adwvel_mean       =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON ad_dynstat_adwvel_sd         =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON ad_dynstat_adwvel_del2       =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON ad_dynstat_adtheta_max       =   5.9387883884850E-01
+(PID.TID 0000.0001) %MON ad_dynstat_adtheta_min       =  -7.5297906832602E-01
+(PID.TID 0000.0001) %MON ad_dynstat_adtheta_mean      =  -2.9718530630997E-02
+(PID.TID 0000.0001) %MON ad_dynstat_adtheta_sd        =   1.3326500128855E-01
+(PID.TID 0000.0001) %MON ad_dynstat_adtheta_del2      =   2.8325162781932E-04
+(PID.TID 0000.0001) %MON ad_dynstat_adsalt_max        =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON ad_dynstat_adsalt_min        =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON ad_dynstat_adsalt_mean       =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON ad_dynstat_adsalt_sd         =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON ad_dynstat_adsalt_del2       =   0.0000000000000E+00
+(PID.TID 0000.0001) // =======================================================
+(PID.TID 0000.0001) // End AD_MONITOR dynamic field statistics
+(PID.TID 0000.0001) // =======================================================
  ph-pack: packing ecco_cost
  ph-pack: packing ecco_ctrl
 (PID.TID 0000.0001) // =======================================================
@@ -2929,113 +3478,17 @@ grad-res -------------------------------
  cg2d: Sum(rhs),rhsMax =  -1.59112718349022E+02  2.04436757292323E-01
  cg2d: Sum(rhs),rhsMax =  -2.24736325184813E+02  1.92987571287909E-01
 (PID.TID 0000.0001) Did not write pickup because writePickupAtEnd = FALSE
-(PID.TID 0000.0001) ph-cost call cost_theta0
-(PID.TID 0000.0001) ph-cost call cost_theta
- --> f_temp    = 0.147701173786179D+01
- --> f_salt    = 0.000000000000000D+00
- --> f_temp0   = 0.000000000000000D+00
- --> f_salt0   = 0.000000000000000D+00
- --> f_temp0smoo = 0.000000000000000D+00
- --> f_salt0smoo = 0.000000000000000D+00
- --> f_etan0   = 0.000000000000000D+00
- --> f_uvel0   = 0.000000000000000D+00
- --> f_vvel0   = 0.000000000000000D+00
- --> f_sst     = 0.000000000000000D+00
- --> f_tmi     = 0.000000000000000D+00
- --> f_sss     = 0.000000000000000D+00
- --> f_bp      = 0.000000000000000D+00
- --> f_ies      = 0.000000000000000D+00
- --> f_ssh       = 0.000000000000000D+00
- --> f_tp        = 0.000000000000000D+00
- --> f_ers       = 0.000000000000000D+00
- --> f_gfo       = 0.000000000000000D+00
- --> f_tauu    = 0.000000000000000D+00
- --> f_tauum   = 0.000000000000000D+00
- --> f_tauusmoo = 0.000000000000000D+00
- --> f_tauv    = 0.000000000000000D+00
- --> f_tauvm   = 0.000000000000000D+00
- --> f_tauvsmoo = 0.000000000000000D+00
- --> f_hflux   = 0.000000000000000D+00
- --> f_hfluxmm = 0.000000000000000D+00
- --> f_hfluxsmoo = 0.000000000000000D+00
- --> f_sflux   = 0.000000000000000D+00
- --> f_sfluxmm = 0.000000000000000D+00
- --> f_sfluxsmoo = 0.000000000000000D+00
- --> f_uwind     = 0.000000000000000D+00
- --> f_vwind     = 0.000000000000000D+00
- --> f_atemp     = 0.000000000000000D+00
- --> f_aqh     = 0.000000000000000D+00
- --> f_precip  = 0.000000000000000D+00
- --> f_swflux  = 0.000000000000000D+00
- --> f_swdown  = 0.000000000000000D+00
- --> f_lwflux  = 0.000000000000000D+00
- --> f_lwdown  = 0.000000000000000D+00
- --> f_uwindm     = 0.000000000000000D+00
- --> f_vwindm     = 0.000000000000000D+00
- --> f_atempm     = 0.000000000000000D+00
- --> f_aqhm     = 0.000000000000000D+00
- --> f_precipm  = 0.000000000000000D+00
- --> f_swfluxm  = 0.000000000000000D+00
- --> f_lwfluxm  = 0.000000000000000D+00
- --> f_swdownm  = 0.000000000000000D+00
- --> f_lwdownm  = 0.000000000000000D+00
- --> f_uwindsmoo     = 0.000000000000000D+00
- --> f_vwindsmoo     = 0.000000000000000D+00
- --> f_atempsmoo     = 0.000000000000000D+00
- --> f_aqhsmoo     = 0.000000000000000D+00
- --> f_precipsmoo  = 0.000000000000000D+00
- --> f_swfluxsmoo  = 0.000000000000000D+00
- --> f_lwfluxsmoo  = 0.000000000000000D+00
- --> f_swdownsmoo  = 0.000000000000000D+00
- --> f_lwdownsmoo  = 0.000000000000000D+00
- --> f_atl     = 0.000000000000000D+00
- --> f_ctdt    = 0.000000000000000D+00
- --> f_ctds    = 0.000000000000000D+00
- --> f_ctdtclim= 0.000000000000000D+00
- --> f_ctdsclim= 0.000000000000000D+00
- --> f_xbt     = 0.000000000000000D+00
- --> f_argot   = 0.000000000000000D+00
- --> f_argos   = 0.000000000000000D+00
- --> f_drifter   = 0.000000000000000D+00
- --> f_tdrift  = 0.000000000000000D+00
- --> f_sdrift  = 0.000000000000000D+00
- --> f_wdrift  = 0.000000000000000D+00
- --> f_scatx   = 0.000000000000000D+00
- --> f_scaty   = 0.000000000000000D+00
- --> f_scatxm  = 0.000000000000000D+00
- --> f_scatym  = 0.000000000000000D+00
  --> f_obcsn   = 0.000000000000000D+00
  --> f_obcss   = 0.000000000000000D+00
- --> f_obcsw   = 0.152587890625000D-12
+ --> f_obcsw   = 0.500000000000000D-08
  --> f_obcse   = 0.000000000000000D+00
- --> f_ageos   = 0.000000000000000D+00
- --> f_curmtr  = 0.000000000000000D+00
- --> f_kapgm   = 0.000000000000000D+00
- --> f_kapredi   = 0.000000000000000D+00
- --> f_diffkr  = 0.000000000000000D+00
- --> f_eddytau = 0.000000000000000D+00
- --> f_bottomdrag = 0.000000000000000D+00
- --> f_hfluxmm2           = 0.000000000000000D+00
- --> f_sfluxmm2           = 0.000000000000000D+00
- --> f_transp             = 0.000000000000000D+00
- --> objf_hmean           = 0.000000000000000D+00
- --> fc               = 0.000000000000000D+00
-  early fc =  0.000000000000000D+00
- --> objf_test(bi,bj)   =  0.000000000000000D+00
- --> objf_tracer(bi,bj) =  0.000000000000000D+00
- --> objf_atl(bi,bj)    =  0.000000000000000D+00
- --> objf_test(bi,bj)   =  0.000000000000000D+00
- --> objf_tracer(bi,bj) =  0.000000000000000D+00
- --> objf_atl(bi,bj)    =  0.000000000000000D+00
- --> objf_test(bi,bj)   =  0.000000000000000D+00
- --> objf_tracer(bi,bj) =  0.000000000000000D+00
- --> objf_atl(bi,bj)    =  0.000000000000000D+00
- --> objf_test(bi,bj)   =  0.000000000000000D+00
- --> objf_tracer(bi,bj) =  0.000000000000000D+00
- --> objf_atl(bi,bj)    =  0.000000000000000D+00
-  local fc =  0.147701173786194D+01
- global fc =  0.147701173786194D+01
-(PID.TID 0000.0001) grdchk perturb(+)fc: fcpertplus  =  1.47701173786194E+00
+(PID.TID 0000.0001)  --> f_gencost = 0.147701173786179D+01 1
+(PID.TID 0000.0001)  --> f_genarr3d = 0.000000000000000D+00 1
+(PID.TID 0000.0001)  --> fc               = 0.147701174286179D+01
+(PID.TID 0000.0001)   early fc =  0.000000000000000D+00
+(PID.TID 0000.0001)   local fc =  0.147701174286179D+01
+(PID.TID 0000.0001)  global fc =  0.147701174286179D+01
+(PID.TID 0000.0001) grdchk perturb(+)fc: fcpertplus  =  1.47701174286179E+00
 (PID.TID 0000.0001) Start initial hydrostatic pressure computation
 (PID.TID 0000.0001) Pressure is predetermined for buoyancyRelation OCEANIC
 (PID.TID 0000.0001) 
@@ -3049,115 +3502,19 @@ grad-res -------------------------------
  cg2d: Sum(rhs),rhsMax =  -1.59112718349022E+02  2.04436757292323E-01
  cg2d: Sum(rhs),rhsMax =  -2.24736325184813E+02  1.92987571287909E-01
 (PID.TID 0000.0001) Did not write pickup because writePickupAtEnd = FALSE
-(PID.TID 0000.0001) ph-cost call cost_theta0
-(PID.TID 0000.0001) ph-cost call cost_theta
- --> f_temp    = 0.147701173786179D+01
- --> f_salt    = 0.000000000000000D+00
- --> f_temp0   = 0.000000000000000D+00
- --> f_salt0   = 0.000000000000000D+00
- --> f_temp0smoo = 0.000000000000000D+00
- --> f_salt0smoo = 0.000000000000000D+00
- --> f_etan0   = 0.000000000000000D+00
- --> f_uvel0   = 0.000000000000000D+00
- --> f_vvel0   = 0.000000000000000D+00
- --> f_sst     = 0.000000000000000D+00
- --> f_tmi     = 0.000000000000000D+00
- --> f_sss     = 0.000000000000000D+00
- --> f_bp      = 0.000000000000000D+00
- --> f_ies      = 0.000000000000000D+00
- --> f_ssh       = 0.000000000000000D+00
- --> f_tp        = 0.000000000000000D+00
- --> f_ers       = 0.000000000000000D+00
- --> f_gfo       = 0.000000000000000D+00
- --> f_tauu    = 0.000000000000000D+00
- --> f_tauum   = 0.000000000000000D+00
- --> f_tauusmoo = 0.000000000000000D+00
- --> f_tauv    = 0.000000000000000D+00
- --> f_tauvm   = 0.000000000000000D+00
- --> f_tauvsmoo = 0.000000000000000D+00
- --> f_hflux   = 0.000000000000000D+00
- --> f_hfluxmm = 0.000000000000000D+00
- --> f_hfluxsmoo = 0.000000000000000D+00
- --> f_sflux   = 0.000000000000000D+00
- --> f_sfluxmm = 0.000000000000000D+00
- --> f_sfluxsmoo = 0.000000000000000D+00
- --> f_uwind     = 0.000000000000000D+00
- --> f_vwind     = 0.000000000000000D+00
- --> f_atemp     = 0.000000000000000D+00
- --> f_aqh     = 0.000000000000000D+00
- --> f_precip  = 0.000000000000000D+00
- --> f_swflux  = 0.000000000000000D+00
- --> f_swdown  = 0.000000000000000D+00
- --> f_lwflux  = 0.000000000000000D+00
- --> f_lwdown  = 0.000000000000000D+00
- --> f_uwindm     = 0.000000000000000D+00
- --> f_vwindm     = 0.000000000000000D+00
- --> f_atempm     = 0.000000000000000D+00
- --> f_aqhm     = 0.000000000000000D+00
- --> f_precipm  = 0.000000000000000D+00
- --> f_swfluxm  = 0.000000000000000D+00
- --> f_lwfluxm  = 0.000000000000000D+00
- --> f_swdownm  = 0.000000000000000D+00
- --> f_lwdownm  = 0.000000000000000D+00
- --> f_uwindsmoo     = 0.000000000000000D+00
- --> f_vwindsmoo     = 0.000000000000000D+00
- --> f_atempsmoo     = 0.000000000000000D+00
- --> f_aqhsmoo     = 0.000000000000000D+00
- --> f_precipsmoo  = 0.000000000000000D+00
- --> f_swfluxsmoo  = 0.000000000000000D+00
- --> f_lwfluxsmoo  = 0.000000000000000D+00
- --> f_swdownsmoo  = 0.000000000000000D+00
- --> f_lwdownsmoo  = 0.000000000000000D+00
- --> f_atl     = 0.000000000000000D+00
- --> f_ctdt    = 0.000000000000000D+00
- --> f_ctds    = 0.000000000000000D+00
- --> f_ctdtclim= 0.000000000000000D+00
- --> f_ctdsclim= 0.000000000000000D+00
- --> f_xbt     = 0.000000000000000D+00
- --> f_argot   = 0.000000000000000D+00
- --> f_argos   = 0.000000000000000D+00
- --> f_drifter   = 0.000000000000000D+00
- --> f_tdrift  = 0.000000000000000D+00
- --> f_sdrift  = 0.000000000000000D+00
- --> f_wdrift  = 0.000000000000000D+00
- --> f_scatx   = 0.000000000000000D+00
- --> f_scaty   = 0.000000000000000D+00
- --> f_scatxm  = 0.000000000000000D+00
- --> f_scatym  = 0.000000000000000D+00
  --> f_obcsn   = 0.000000000000000D+00
  --> f_obcss   = 0.000000000000000D+00
- --> f_obcsw   = 0.152587890625000D-12
+ --> f_obcsw   = 0.500000000000000D-08
  --> f_obcse   = 0.000000000000000D+00
- --> f_ageos   = 0.000000000000000D+00
- --> f_curmtr  = 0.000000000000000D+00
- --> f_kapgm   = 0.000000000000000D+00
- --> f_kapredi   = 0.000000000000000D+00
- --> f_diffkr  = 0.000000000000000D+00
- --> f_eddytau = 0.000000000000000D+00
- --> f_bottomdrag = 0.000000000000000D+00
- --> f_hfluxmm2           = 0.000000000000000D+00
- --> f_sfluxmm2           = 0.000000000000000D+00
- --> f_transp             = 0.000000000000000D+00
- --> objf_hmean           = 0.000000000000000D+00
- --> fc               = 0.000000000000000D+00
-  early fc =  0.000000000000000D+00
- --> objf_test(bi,bj)   =  0.000000000000000D+00
- --> objf_tracer(bi,bj) =  0.000000000000000D+00
- --> objf_atl(bi,bj)    =  0.000000000000000D+00
- --> objf_test(bi,bj)   =  0.000000000000000D+00
- --> objf_tracer(bi,bj) =  0.000000000000000D+00
- --> objf_atl(bi,bj)    =  0.000000000000000D+00
- --> objf_test(bi,bj)   =  0.000000000000000D+00
- --> objf_tracer(bi,bj) =  0.000000000000000D+00
- --> objf_atl(bi,bj)    =  0.000000000000000D+00
- --> objf_test(bi,bj)   =  0.000000000000000D+00
- --> objf_tracer(bi,bj) =  0.000000000000000D+00
- --> objf_atl(bi,bj)    =  0.000000000000000D+00
-  local fc =  0.147701173786194D+01
- global fc =  0.147701173786194D+01
-(PID.TID 0000.0001) grdchk perturb(-)fc: fcpertminus =  1.47701173786194E+00
+(PID.TID 0000.0001)  --> f_gencost = 0.147701173786179D+01 1
+(PID.TID 0000.0001)  --> f_genarr3d = 0.000000000000000D+00 1
+(PID.TID 0000.0001)  --> fc               = 0.147701174286179D+01
+(PID.TID 0000.0001)   early fc =  0.000000000000000D+00
+(PID.TID 0000.0001)   local fc =  0.147701174286179D+01
+(PID.TID 0000.0001)  global fc =  0.147701174286179D+01
+(PID.TID 0000.0001) grdchk perturb(-)fc: fcpertminus =  1.47701174286179E+00
 grad-res -------------------------------
- grad-res     0    1    1    1    4    1    1    1   1.47701073786E+00  1.47701173786E+00  1.47701173786E+00
+ grad-res     0    1    1    1    4    1    1    1   1.47701073786E+00  1.47701174286E+00  1.47701174286E+00
  grad-res     0    1    1   97    0    1    1    1   0.00000000000E+00  0.00000000000E+00  0.00000000000E+00
 (PID.TID 0000.0001)  ADM  ref_cost_function      =  1.47701073786182E+00
 (PID.TID 0000.0001)  ADM  adjoint_gradient       =  0.00000000000000E+00
@@ -3181,113 +3538,17 @@ grad-res -------------------------------
  cg2d: Sum(rhs),rhsMax =  -1.59112718349077E+02  2.04436757292253E-01
  cg2d: Sum(rhs),rhsMax =  -2.24736325185377E+02  1.92987571287426E-01
 (PID.TID 0000.0001) Did not write pickup because writePickupAtEnd = FALSE
-(PID.TID 0000.0001) ph-cost call cost_theta0
-(PID.TID 0000.0001) ph-cost call cost_theta
- --> f_temp    = 0.147701229545064D+01
- --> f_salt    = 0.000000000000000D+00
- --> f_temp0   = 0.000000000000000D+00
- --> f_salt0   = 0.000000000000000D+00
- --> f_temp0smoo = 0.000000000000000D+00
- --> f_salt0smoo = 0.000000000000000D+00
- --> f_etan0   = 0.000000000000000D+00
- --> f_uvel0   = 0.000000000000000D+00
- --> f_vvel0   = 0.000000000000000D+00
- --> f_sst     = 0.000000000000000D+00
- --> f_tmi     = 0.000000000000000D+00
- --> f_sss     = 0.000000000000000D+00
- --> f_bp      = 0.000000000000000D+00
- --> f_ies      = 0.000000000000000D+00
- --> f_ssh       = 0.000000000000000D+00
- --> f_tp        = 0.000000000000000D+00
- --> f_ers       = 0.000000000000000D+00
- --> f_gfo       = 0.000000000000000D+00
- --> f_tauu    = 0.000000000000000D+00
- --> f_tauum   = 0.000000000000000D+00
- --> f_tauusmoo = 0.000000000000000D+00
- --> f_tauv    = 0.000000000000000D+00
- --> f_tauvm   = 0.000000000000000D+00
- --> f_tauvsmoo = 0.000000000000000D+00
- --> f_hflux   = 0.000000000000000D+00
- --> f_hfluxmm = 0.000000000000000D+00
- --> f_hfluxsmoo = 0.000000000000000D+00
- --> f_sflux   = 0.000000000000000D+00
- --> f_sfluxmm = 0.000000000000000D+00
- --> f_sfluxsmoo = 0.000000000000000D+00
- --> f_uwind     = 0.000000000000000D+00
- --> f_vwind     = 0.000000000000000D+00
- --> f_atemp     = 0.000000000000000D+00
- --> f_aqh     = 0.000000000000000D+00
- --> f_precip  = 0.000000000000000D+00
- --> f_swflux  = 0.000000000000000D+00
- --> f_swdown  = 0.000000000000000D+00
- --> f_lwflux  = 0.000000000000000D+00
- --> f_lwdown  = 0.000000000000000D+00
- --> f_uwindm     = 0.000000000000000D+00
- --> f_vwindm     = 0.000000000000000D+00
- --> f_atempm     = 0.000000000000000D+00
- --> f_aqhm     = 0.000000000000000D+00
- --> f_precipm  = 0.000000000000000D+00
- --> f_swfluxm  = 0.000000000000000D+00
- --> f_lwfluxm  = 0.000000000000000D+00
- --> f_swdownm  = 0.000000000000000D+00
- --> f_lwdownm  = 0.000000000000000D+00
- --> f_uwindsmoo     = 0.000000000000000D+00
- --> f_vwindsmoo     = 0.000000000000000D+00
- --> f_atempsmoo     = 0.000000000000000D+00
- --> f_aqhsmoo     = 0.000000000000000D+00
- --> f_precipsmoo  = 0.000000000000000D+00
- --> f_swfluxsmoo  = 0.000000000000000D+00
- --> f_lwfluxsmoo  = 0.000000000000000D+00
- --> f_swdownsmoo  = 0.000000000000000D+00
- --> f_lwdownsmoo  = 0.000000000000000D+00
- --> f_atl     = 0.000000000000000D+00
- --> f_ctdt    = 0.000000000000000D+00
- --> f_ctds    = 0.000000000000000D+00
- --> f_ctdtclim= 0.000000000000000D+00
- --> f_ctdsclim= 0.000000000000000D+00
- --> f_xbt     = 0.000000000000000D+00
- --> f_argot   = 0.000000000000000D+00
- --> f_argos   = 0.000000000000000D+00
- --> f_drifter   = 0.000000000000000D+00
- --> f_tdrift  = 0.000000000000000D+00
- --> f_sdrift  = 0.000000000000000D+00
- --> f_wdrift  = 0.000000000000000D+00
- --> f_scatx   = 0.000000000000000D+00
- --> f_scaty   = 0.000000000000000D+00
- --> f_scatxm  = 0.000000000000000D+00
- --> f_scatym  = 0.000000000000000D+00
  --> f_obcsn   = 0.000000000000000D+00
  --> f_obcss   = 0.000000000000000D+00
- --> f_obcsw   = 0.152587890625000D-12
+ --> f_obcsw   = 0.500000000000000D-08
  --> f_obcse   = 0.000000000000000D+00
- --> f_ageos   = 0.000000000000000D+00
- --> f_curmtr  = 0.000000000000000D+00
- --> f_kapgm   = 0.000000000000000D+00
- --> f_kapredi   = 0.000000000000000D+00
- --> f_diffkr  = 0.000000000000000D+00
- --> f_eddytau = 0.000000000000000D+00
- --> f_bottomdrag = 0.000000000000000D+00
- --> f_hfluxmm2           = 0.000000000000000D+00
- --> f_sfluxmm2           = 0.000000000000000D+00
- --> f_transp             = 0.000000000000000D+00
- --> objf_hmean           = 0.000000000000000D+00
- --> fc               = 0.000000000000000D+00
-  early fc =  0.000000000000000D+00
- --> objf_test(bi,bj)   =  0.000000000000000D+00
- --> objf_tracer(bi,bj) =  0.000000000000000D+00
- --> objf_atl(bi,bj)    =  0.000000000000000D+00
- --> objf_test(bi,bj)   =  0.000000000000000D+00
- --> objf_tracer(bi,bj) =  0.000000000000000D+00
- --> objf_atl(bi,bj)    =  0.000000000000000D+00
- --> objf_test(bi,bj)   =  0.000000000000000D+00
- --> objf_tracer(bi,bj) =  0.000000000000000D+00
- --> objf_atl(bi,bj)    =  0.000000000000000D+00
- --> objf_test(bi,bj)   =  0.000000000000000D+00
- --> objf_tracer(bi,bj) =  0.000000000000000D+00
- --> objf_atl(bi,bj)    =  0.000000000000000D+00
-  local fc =  0.147701229545079D+01
- global fc =  0.147701229545079D+01
-(PID.TID 0000.0001) grdchk perturb(+)fc: fcpertplus  =  1.47701229545079E+00
+(PID.TID 0000.0001)  --> f_gencost = 0.147701229545064D+01 1
+(PID.TID 0000.0001)  --> f_genarr3d = 0.000000000000000D+00 1
+(PID.TID 0000.0001)  --> fc               = 0.147701230045064D+01
+(PID.TID 0000.0001)   early fc =  0.000000000000000D+00
+(PID.TID 0000.0001)   local fc =  0.147701230045064D+01
+(PID.TID 0000.0001)  global fc =  0.147701230045064D+01
+(PID.TID 0000.0001) grdchk perturb(+)fc: fcpertplus  =  1.47701230045064E+00
 (PID.TID 0000.0001) Start initial hydrostatic pressure computation
 (PID.TID 0000.0001) Pressure is predetermined for buoyancyRelation OCEANIC
 (PID.TID 0000.0001) 
@@ -3301,118 +3562,22 @@ grad-res -------------------------------
  cg2d: Sum(rhs),rhsMax =  -1.59112718348959E+02  2.04436757292404E-01
  cg2d: Sum(rhs),rhsMax =  -2.24736325184243E+02  1.92987571288399E-01
 (PID.TID 0000.0001) Did not write pickup because writePickupAtEnd = FALSE
-(PID.TID 0000.0001) ph-cost call cost_theta0
-(PID.TID 0000.0001) ph-cost call cost_theta
- --> f_temp    = 0.147701118176573D+01
- --> f_salt    = 0.000000000000000D+00
- --> f_temp0   = 0.000000000000000D+00
- --> f_salt0   = 0.000000000000000D+00
- --> f_temp0smoo = 0.000000000000000D+00
- --> f_salt0smoo = 0.000000000000000D+00
- --> f_etan0   = 0.000000000000000D+00
- --> f_uvel0   = 0.000000000000000D+00
- --> f_vvel0   = 0.000000000000000D+00
- --> f_sst     = 0.000000000000000D+00
- --> f_tmi     = 0.000000000000000D+00
- --> f_sss     = 0.000000000000000D+00
- --> f_bp      = 0.000000000000000D+00
- --> f_ies      = 0.000000000000000D+00
- --> f_ssh       = 0.000000000000000D+00
- --> f_tp        = 0.000000000000000D+00
- --> f_ers       = 0.000000000000000D+00
- --> f_gfo       = 0.000000000000000D+00
- --> f_tauu    = 0.000000000000000D+00
- --> f_tauum   = 0.000000000000000D+00
- --> f_tauusmoo = 0.000000000000000D+00
- --> f_tauv    = 0.000000000000000D+00
- --> f_tauvm   = 0.000000000000000D+00
- --> f_tauvsmoo = 0.000000000000000D+00
- --> f_hflux   = 0.000000000000000D+00
- --> f_hfluxmm = 0.000000000000000D+00
- --> f_hfluxsmoo = 0.000000000000000D+00
- --> f_sflux   = 0.000000000000000D+00
- --> f_sfluxmm = 0.000000000000000D+00
- --> f_sfluxsmoo = 0.000000000000000D+00
- --> f_uwind     = 0.000000000000000D+00
- --> f_vwind     = 0.000000000000000D+00
- --> f_atemp     = 0.000000000000000D+00
- --> f_aqh     = 0.000000000000000D+00
- --> f_precip  = 0.000000000000000D+00
- --> f_swflux  = 0.000000000000000D+00
- --> f_swdown  = 0.000000000000000D+00
- --> f_lwflux  = 0.000000000000000D+00
- --> f_lwdown  = 0.000000000000000D+00
- --> f_uwindm     = 0.000000000000000D+00
- --> f_vwindm     = 0.000000000000000D+00
- --> f_atempm     = 0.000000000000000D+00
- --> f_aqhm     = 0.000000000000000D+00
- --> f_precipm  = 0.000000000000000D+00
- --> f_swfluxm  = 0.000000000000000D+00
- --> f_lwfluxm  = 0.000000000000000D+00
- --> f_swdownm  = 0.000000000000000D+00
- --> f_lwdownm  = 0.000000000000000D+00
- --> f_uwindsmoo     = 0.000000000000000D+00
- --> f_vwindsmoo     = 0.000000000000000D+00
- --> f_atempsmoo     = 0.000000000000000D+00
- --> f_aqhsmoo     = 0.000000000000000D+00
- --> f_precipsmoo  = 0.000000000000000D+00
- --> f_swfluxsmoo  = 0.000000000000000D+00
- --> f_lwfluxsmoo  = 0.000000000000000D+00
- --> f_swdownsmoo  = 0.000000000000000D+00
- --> f_lwdownsmoo  = 0.000000000000000D+00
- --> f_atl     = 0.000000000000000D+00
- --> f_ctdt    = 0.000000000000000D+00
- --> f_ctds    = 0.000000000000000D+00
- --> f_ctdtclim= 0.000000000000000D+00
- --> f_ctdsclim= 0.000000000000000D+00
- --> f_xbt     = 0.000000000000000D+00
- --> f_argot   = 0.000000000000000D+00
- --> f_argos   = 0.000000000000000D+00
- --> f_drifter   = 0.000000000000000D+00
- --> f_tdrift  = 0.000000000000000D+00
- --> f_sdrift  = 0.000000000000000D+00
- --> f_wdrift  = 0.000000000000000D+00
- --> f_scatx   = 0.000000000000000D+00
- --> f_scaty   = 0.000000000000000D+00
- --> f_scatxm  = 0.000000000000000D+00
- --> f_scatym  = 0.000000000000000D+00
  --> f_obcsn   = 0.000000000000000D+00
  --> f_obcss   = 0.000000000000000D+00
- --> f_obcsw   = 0.152587890625000D-12
+ --> f_obcsw   = 0.500000000000000D-08
  --> f_obcse   = 0.000000000000000D+00
- --> f_ageos   = 0.000000000000000D+00
- --> f_curmtr  = 0.000000000000000D+00
- --> f_kapgm   = 0.000000000000000D+00
- --> f_kapredi   = 0.000000000000000D+00
- --> f_diffkr  = 0.000000000000000D+00
- --> f_eddytau = 0.000000000000000D+00
- --> f_bottomdrag = 0.000000000000000D+00
- --> f_hfluxmm2           = 0.000000000000000D+00
- --> f_sfluxmm2           = 0.000000000000000D+00
- --> f_transp             = 0.000000000000000D+00
- --> objf_hmean           = 0.000000000000000D+00
- --> fc               = 0.000000000000000D+00
-  early fc =  0.000000000000000D+00
- --> objf_test(bi,bj)   =  0.000000000000000D+00
- --> objf_tracer(bi,bj) =  0.000000000000000D+00
- --> objf_atl(bi,bj)    =  0.000000000000000D+00
- --> objf_test(bi,bj)   =  0.000000000000000D+00
- --> objf_tracer(bi,bj) =  0.000000000000000D+00
- --> objf_atl(bi,bj)    =  0.000000000000000D+00
- --> objf_test(bi,bj)   =  0.000000000000000D+00
- --> objf_tracer(bi,bj) =  0.000000000000000D+00
- --> objf_atl(bi,bj)    =  0.000000000000000D+00
- --> objf_test(bi,bj)   =  0.000000000000000D+00
- --> objf_tracer(bi,bj) =  0.000000000000000D+00
- --> objf_atl(bi,bj)    =  0.000000000000000D+00
-  local fc =  0.147701118176588D+01
- global fc =  0.147701118176588D+01
-(PID.TID 0000.0001) grdchk perturb(-)fc: fcpertminus =  1.47701118176588E+00
+(PID.TID 0000.0001)  --> f_gencost = 0.147701118176573D+01 1
+(PID.TID 0000.0001)  --> f_genarr3d = 0.000000000000000D+00 1
+(PID.TID 0000.0001)  --> fc               = 0.147701118676573D+01
+(PID.TID 0000.0001)   early fc =  0.000000000000000D+00
+(PID.TID 0000.0001)   local fc =  0.147701118676573D+01
+(PID.TID 0000.0001)  global fc =  0.147701118676573D+01
+(PID.TID 0000.0001) grdchk perturb(-)fc: fcpertminus =  1.47701118676573E+00
 grad-res -------------------------------
- grad-res     0    2    1    2    4    1    1    1   1.47701073786E+00  1.47701229545E+00  1.47701118177E+00
- grad-res     0    2    2   98    0    1    1    1   5.56842434466E-03  5.56842455479E-03 -3.77366511373E-08
+ grad-res     0    2    1    2    4    1    1    1   1.47701073786E+00  1.47701230045E+00  1.47701118677E+00
+ grad-res     0    2    2   98    0    1    1    1   5.56842434466E-03  5.56842455479E-03 -3.77366475846E-08
 (PID.TID 0000.0001)  ADM  ref_cost_function      =  1.47701073786182E+00
-(PID.TID 0000.0001)  ADM  adjoint_gradient       =  5.56842434465787E-03
+(PID.TID 0000.0001)  ADM  adjoint_gradient       =  5.56842434465789E-03
 (PID.TID 0000.0001)  ADM  finite-diff_grad       =  5.56842455479156E-03
 (PID.TID 0000.0001) ====== End of gradient-check number   2 (ierr=  0) =======
 (PID.TID 0000.0001) ====== Starts gradient-check number   3 (=ichknum) =======
@@ -3433,113 +3598,17 @@ grad-res -------------------------------
  cg2d: Sum(rhs),rhsMax =  -1.59112718349075E+02  2.04436757292256E-01
  cg2d: Sum(rhs),rhsMax =  -2.24736325185393E+02  1.92987571287411E-01
 (PID.TID 0000.0001) Did not write pickup because writePickupAtEnd = FALSE
-(PID.TID 0000.0001) ph-cost call cost_theta0
-(PID.TID 0000.0001) ph-cost call cost_theta
- --> f_temp    = 0.147701230547671D+01
- --> f_salt    = 0.000000000000000D+00
- --> f_temp0   = 0.000000000000000D+00
- --> f_salt0   = 0.000000000000000D+00
- --> f_temp0smoo = 0.000000000000000D+00
- --> f_salt0smoo = 0.000000000000000D+00
- --> f_etan0   = 0.000000000000000D+00
- --> f_uvel0   = 0.000000000000000D+00
- --> f_vvel0   = 0.000000000000000D+00
- --> f_sst     = 0.000000000000000D+00
- --> f_tmi     = 0.000000000000000D+00
- --> f_sss     = 0.000000000000000D+00
- --> f_bp      = 0.000000000000000D+00
- --> f_ies      = 0.000000000000000D+00
- --> f_ssh       = 0.000000000000000D+00
- --> f_tp        = 0.000000000000000D+00
- --> f_ers       = 0.000000000000000D+00
- --> f_gfo       = 0.000000000000000D+00
- --> f_tauu    = 0.000000000000000D+00
- --> f_tauum   = 0.000000000000000D+00
- --> f_tauusmoo = 0.000000000000000D+00
- --> f_tauv    = 0.000000000000000D+00
- --> f_tauvm   = 0.000000000000000D+00
- --> f_tauvsmoo = 0.000000000000000D+00
- --> f_hflux   = 0.000000000000000D+00
- --> f_hfluxmm = 0.000000000000000D+00
- --> f_hfluxsmoo = 0.000000000000000D+00
- --> f_sflux   = 0.000000000000000D+00
- --> f_sfluxmm = 0.000000000000000D+00
- --> f_sfluxsmoo = 0.000000000000000D+00
- --> f_uwind     = 0.000000000000000D+00
- --> f_vwind     = 0.000000000000000D+00
- --> f_atemp     = 0.000000000000000D+00
- --> f_aqh     = 0.000000000000000D+00
- --> f_precip  = 0.000000000000000D+00
- --> f_swflux  = 0.000000000000000D+00
- --> f_swdown  = 0.000000000000000D+00
- --> f_lwflux  = 0.000000000000000D+00
- --> f_lwdown  = 0.000000000000000D+00
- --> f_uwindm     = 0.000000000000000D+00
- --> f_vwindm     = 0.000000000000000D+00
- --> f_atempm     = 0.000000000000000D+00
- --> f_aqhm     = 0.000000000000000D+00
- --> f_precipm  = 0.000000000000000D+00
- --> f_swfluxm  = 0.000000000000000D+00
- --> f_lwfluxm  = 0.000000000000000D+00
- --> f_swdownm  = 0.000000000000000D+00
- --> f_lwdownm  = 0.000000000000000D+00
- --> f_uwindsmoo     = 0.000000000000000D+00
- --> f_vwindsmoo     = 0.000000000000000D+00
- --> f_atempsmoo     = 0.000000000000000D+00
- --> f_aqhsmoo     = 0.000000000000000D+00
- --> f_precipsmoo  = 0.000000000000000D+00
- --> f_swfluxsmoo  = 0.000000000000000D+00
- --> f_lwfluxsmoo  = 0.000000000000000D+00
- --> f_swdownsmoo  = 0.000000000000000D+00
- --> f_lwdownsmoo  = 0.000000000000000D+00
- --> f_atl     = 0.000000000000000D+00
- --> f_ctdt    = 0.000000000000000D+00
- --> f_ctds    = 0.000000000000000D+00
- --> f_ctdtclim= 0.000000000000000D+00
- --> f_ctdsclim= 0.000000000000000D+00
- --> f_xbt     = 0.000000000000000D+00
- --> f_argot   = 0.000000000000000D+00
- --> f_argos   = 0.000000000000000D+00
- --> f_drifter   = 0.000000000000000D+00
- --> f_tdrift  = 0.000000000000000D+00
- --> f_sdrift  = 0.000000000000000D+00
- --> f_wdrift  = 0.000000000000000D+00
- --> f_scatx   = 0.000000000000000D+00
- --> f_scaty   = 0.000000000000000D+00
- --> f_scatxm  = 0.000000000000000D+00
- --> f_scatym  = 0.000000000000000D+00
  --> f_obcsn   = 0.000000000000000D+00
  --> f_obcss   = 0.000000000000000D+00
- --> f_obcsw   = 0.152587890625000D-12
+ --> f_obcsw   = 0.500000000000000D-08
  --> f_obcse   = 0.000000000000000D+00
- --> f_ageos   = 0.000000000000000D+00
- --> f_curmtr  = 0.000000000000000D+00
- --> f_kapgm   = 0.000000000000000D+00
- --> f_kapredi   = 0.000000000000000D+00
- --> f_diffkr  = 0.000000000000000D+00
- --> f_eddytau = 0.000000000000000D+00
- --> f_bottomdrag = 0.000000000000000D+00
- --> f_hfluxmm2           = 0.000000000000000D+00
- --> f_sfluxmm2           = 0.000000000000000D+00
- --> f_transp             = 0.000000000000000D+00
- --> objf_hmean           = 0.000000000000000D+00
- --> fc               = 0.000000000000000D+00
-  early fc =  0.000000000000000D+00
- --> objf_test(bi,bj)   =  0.000000000000000D+00
- --> objf_tracer(bi,bj) =  0.000000000000000D+00
- --> objf_atl(bi,bj)    =  0.000000000000000D+00
- --> objf_test(bi,bj)   =  0.000000000000000D+00
- --> objf_tracer(bi,bj) =  0.000000000000000D+00
- --> objf_atl(bi,bj)    =  0.000000000000000D+00
- --> objf_test(bi,bj)   =  0.000000000000000D+00
- --> objf_tracer(bi,bj) =  0.000000000000000D+00
- --> objf_atl(bi,bj)    =  0.000000000000000D+00
- --> objf_test(bi,bj)   =  0.000000000000000D+00
- --> objf_tracer(bi,bj) =  0.000000000000000D+00
- --> objf_atl(bi,bj)    =  0.000000000000000D+00
-  local fc =  0.147701230547687D+01
- global fc =  0.147701230547687D+01
-(PID.TID 0000.0001) grdchk perturb(+)fc: fcpertplus  =  1.47701230547687E+00
+(PID.TID 0000.0001)  --> f_gencost = 0.147701230547672D+01 1
+(PID.TID 0000.0001)  --> f_genarr3d = 0.000000000000000D+00 1
+(PID.TID 0000.0001)  --> fc               = 0.147701231047672D+01
+(PID.TID 0000.0001)   early fc =  0.000000000000000D+00
+(PID.TID 0000.0001)   local fc =  0.147701231047672D+01
+(PID.TID 0000.0001)  global fc =  0.147701231047672D+01
+(PID.TID 0000.0001) grdchk perturb(+)fc: fcpertplus  =  1.47701231047672E+00
 (PID.TID 0000.0001) Start initial hydrostatic pressure computation
 (PID.TID 0000.0001) Pressure is predetermined for buoyancyRelation OCEANIC
 (PID.TID 0000.0001) 
@@ -3553,119 +3622,23 @@ grad-res -------------------------------
  cg2d: Sum(rhs),rhsMax =  -1.59112718348955E+02  2.04436757292410E-01
  cg2d: Sum(rhs),rhsMax =  -2.24736325184253E+02  1.92987571288390E-01
 (PID.TID 0000.0001) Did not write pickup because writePickupAtEnd = FALSE
-(PID.TID 0000.0001) ph-cost call cost_theta0
-(PID.TID 0000.0001) ph-cost call cost_theta
- --> f_temp    = 0.147701117173774D+01
- --> f_salt    = 0.000000000000000D+00
- --> f_temp0   = 0.000000000000000D+00
- --> f_salt0   = 0.000000000000000D+00
- --> f_temp0smoo = 0.000000000000000D+00
- --> f_salt0smoo = 0.000000000000000D+00
- --> f_etan0   = 0.000000000000000D+00
- --> f_uvel0   = 0.000000000000000D+00
- --> f_vvel0   = 0.000000000000000D+00
- --> f_sst     = 0.000000000000000D+00
- --> f_tmi     = 0.000000000000000D+00
- --> f_sss     = 0.000000000000000D+00
- --> f_bp      = 0.000000000000000D+00
- --> f_ies      = 0.000000000000000D+00
- --> f_ssh       = 0.000000000000000D+00
- --> f_tp        = 0.000000000000000D+00
- --> f_ers       = 0.000000000000000D+00
- --> f_gfo       = 0.000000000000000D+00
- --> f_tauu    = 0.000000000000000D+00
- --> f_tauum   = 0.000000000000000D+00
- --> f_tauusmoo = 0.000000000000000D+00
- --> f_tauv    = 0.000000000000000D+00
- --> f_tauvm   = 0.000000000000000D+00
- --> f_tauvsmoo = 0.000000000000000D+00
- --> f_hflux   = 0.000000000000000D+00
- --> f_hfluxmm = 0.000000000000000D+00
- --> f_hfluxsmoo = 0.000000000000000D+00
- --> f_sflux   = 0.000000000000000D+00
- --> f_sfluxmm = 0.000000000000000D+00
- --> f_sfluxsmoo = 0.000000000000000D+00
- --> f_uwind     = 0.000000000000000D+00
- --> f_vwind     = 0.000000000000000D+00
- --> f_atemp     = 0.000000000000000D+00
- --> f_aqh     = 0.000000000000000D+00
- --> f_precip  = 0.000000000000000D+00
- --> f_swflux  = 0.000000000000000D+00
- --> f_swdown  = 0.000000000000000D+00
- --> f_lwflux  = 0.000000000000000D+00
- --> f_lwdown  = 0.000000000000000D+00
- --> f_uwindm     = 0.000000000000000D+00
- --> f_vwindm     = 0.000000000000000D+00
- --> f_atempm     = 0.000000000000000D+00
- --> f_aqhm     = 0.000000000000000D+00
- --> f_precipm  = 0.000000000000000D+00
- --> f_swfluxm  = 0.000000000000000D+00
- --> f_lwfluxm  = 0.000000000000000D+00
- --> f_swdownm  = 0.000000000000000D+00
- --> f_lwdownm  = 0.000000000000000D+00
- --> f_uwindsmoo     = 0.000000000000000D+00
- --> f_vwindsmoo     = 0.000000000000000D+00
- --> f_atempsmoo     = 0.000000000000000D+00
- --> f_aqhsmoo     = 0.000000000000000D+00
- --> f_precipsmoo  = 0.000000000000000D+00
- --> f_swfluxsmoo  = 0.000000000000000D+00
- --> f_lwfluxsmoo  = 0.000000000000000D+00
- --> f_swdownsmoo  = 0.000000000000000D+00
- --> f_lwdownsmoo  = 0.000000000000000D+00
- --> f_atl     = 0.000000000000000D+00
- --> f_ctdt    = 0.000000000000000D+00
- --> f_ctds    = 0.000000000000000D+00
- --> f_ctdtclim= 0.000000000000000D+00
- --> f_ctdsclim= 0.000000000000000D+00
- --> f_xbt     = 0.000000000000000D+00
- --> f_argot   = 0.000000000000000D+00
- --> f_argos   = 0.000000000000000D+00
- --> f_drifter   = 0.000000000000000D+00
- --> f_tdrift  = 0.000000000000000D+00
- --> f_sdrift  = 0.000000000000000D+00
- --> f_wdrift  = 0.000000000000000D+00
- --> f_scatx   = 0.000000000000000D+00
- --> f_scaty   = 0.000000000000000D+00
- --> f_scatxm  = 0.000000000000000D+00
- --> f_scatym  = 0.000000000000000D+00
  --> f_obcsn   = 0.000000000000000D+00
  --> f_obcss   = 0.000000000000000D+00
- --> f_obcsw   = 0.152587890625000D-12
+ --> f_obcsw   = 0.500000000000000D-08
  --> f_obcse   = 0.000000000000000D+00
- --> f_ageos   = 0.000000000000000D+00
- --> f_curmtr  = 0.000000000000000D+00
- --> f_kapgm   = 0.000000000000000D+00
- --> f_kapredi   = 0.000000000000000D+00
- --> f_diffkr  = 0.000000000000000D+00
- --> f_eddytau = 0.000000000000000D+00
- --> f_bottomdrag = 0.000000000000000D+00
- --> f_hfluxmm2           = 0.000000000000000D+00
- --> f_sfluxmm2           = 0.000000000000000D+00
- --> f_transp             = 0.000000000000000D+00
- --> objf_hmean           = 0.000000000000000D+00
- --> fc               = 0.000000000000000D+00
-  early fc =  0.000000000000000D+00
- --> objf_test(bi,bj)   =  0.000000000000000D+00
- --> objf_tracer(bi,bj) =  0.000000000000000D+00
- --> objf_atl(bi,bj)    =  0.000000000000000D+00
- --> objf_test(bi,bj)   =  0.000000000000000D+00
- --> objf_tracer(bi,bj) =  0.000000000000000D+00
- --> objf_atl(bi,bj)    =  0.000000000000000D+00
- --> objf_test(bi,bj)   =  0.000000000000000D+00
- --> objf_tracer(bi,bj) =  0.000000000000000D+00
- --> objf_atl(bi,bj)    =  0.000000000000000D+00
- --> objf_test(bi,bj)   =  0.000000000000000D+00
- --> objf_tracer(bi,bj) =  0.000000000000000D+00
- --> objf_atl(bi,bj)    =  0.000000000000000D+00
-  local fc =  0.147701117173790D+01
- global fc =  0.147701117173790D+01
-(PID.TID 0000.0001) grdchk perturb(-)fc: fcpertminus =  1.47701117173790E+00
+(PID.TID 0000.0001)  --> f_gencost = 0.147701117173774D+01 1
+(PID.TID 0000.0001)  --> f_genarr3d = 0.000000000000000D+00 1
+(PID.TID 0000.0001)  --> fc               = 0.147701117673774D+01
+(PID.TID 0000.0001)   early fc =  0.000000000000000D+00
+(PID.TID 0000.0001)   local fc =  0.147701117673774D+01
+(PID.TID 0000.0001)  global fc =  0.147701117673774D+01
+(PID.TID 0000.0001) grdchk perturb(-)fc: fcpertminus =  1.47701117673774E+00
 grad-res -------------------------------
- grad-res     0    3    1    3    4    1    1    1   1.47701073786E+00  1.47701230548E+00  1.47701117174E+00
- grad-res     0    3    3   99    0    1    1    1   5.66869450426E-03  5.66869484242E-03 -5.96533411557E-08
+ grad-res     0    3    1    3    4    1    1    1   1.47701073786E+00  1.47701231048E+00  1.47701117674E+00
+ grad-res     0    3    3   99    0    1    1    1   5.66869450426E-03  5.66869486684E-03 -6.39620780785E-08
 (PID.TID 0000.0001)  ADM  ref_cost_function      =  1.47701073786182E+00
-(PID.TID 0000.0001)  ADM  adjoint_gradient       =  5.66869450426349E-03
-(PID.TID 0000.0001)  ADM  finite-diff_grad       =  5.66869484242005E-03
+(PID.TID 0000.0001)  ADM  adjoint_gradient       =  5.66869450426348E-03
+(PID.TID 0000.0001)  ADM  finite-diff_grad       =  5.66869486684496E-03
 (PID.TID 0000.0001) ====== End of gradient-check number   3 (ierr=  0) =======
 (PID.TID 0000.0001) ====== Starts gradient-check number   4 (=ichknum) =======
  ph-test icomp, ncvarcomp, ichknum          100        8192           4
@@ -3685,113 +3658,17 @@ grad-res -------------------------------
  cg2d: Sum(rhs),rhsMax =  -1.59112718349076E+02  2.04436757292255E-01
  cg2d: Sum(rhs),rhsMax =  -2.24736325185376E+02  1.92987571287426E-01
 (PID.TID 0000.0001) Did not write pickup because writePickupAtEnd = FALSE
-(PID.TID 0000.0001) ph-cost call cost_theta0
-(PID.TID 0000.0001) ph-cost call cost_theta
- --> f_temp    = 0.147701231575998D+01
- --> f_salt    = 0.000000000000000D+00
- --> f_temp0   = 0.000000000000000D+00
- --> f_salt0   = 0.000000000000000D+00
- --> f_temp0smoo = 0.000000000000000D+00
- --> f_salt0smoo = 0.000000000000000D+00
- --> f_etan0   = 0.000000000000000D+00
- --> f_uvel0   = 0.000000000000000D+00
- --> f_vvel0   = 0.000000000000000D+00
- --> f_sst     = 0.000000000000000D+00
- --> f_tmi     = 0.000000000000000D+00
- --> f_sss     = 0.000000000000000D+00
- --> f_bp      = 0.000000000000000D+00
- --> f_ies      = 0.000000000000000D+00
- --> f_ssh       = 0.000000000000000D+00
- --> f_tp        = 0.000000000000000D+00
- --> f_ers       = 0.000000000000000D+00
- --> f_gfo       = 0.000000000000000D+00
- --> f_tauu    = 0.000000000000000D+00
- --> f_tauum   = 0.000000000000000D+00
- --> f_tauusmoo = 0.000000000000000D+00
- --> f_tauv    = 0.000000000000000D+00
- --> f_tauvm   = 0.000000000000000D+00
- --> f_tauvsmoo = 0.000000000000000D+00
- --> f_hflux   = 0.000000000000000D+00
- --> f_hfluxmm = 0.000000000000000D+00
- --> f_hfluxsmoo = 0.000000000000000D+00
- --> f_sflux   = 0.000000000000000D+00
- --> f_sfluxmm = 0.000000000000000D+00
- --> f_sfluxsmoo = 0.000000000000000D+00
- --> f_uwind     = 0.000000000000000D+00
- --> f_vwind     = 0.000000000000000D+00
- --> f_atemp     = 0.000000000000000D+00
- --> f_aqh     = 0.000000000000000D+00
- --> f_precip  = 0.000000000000000D+00
- --> f_swflux  = 0.000000000000000D+00
- --> f_swdown  = 0.000000000000000D+00
- --> f_lwflux  = 0.000000000000000D+00
- --> f_lwdown  = 0.000000000000000D+00
- --> f_uwindm     = 0.000000000000000D+00
- --> f_vwindm     = 0.000000000000000D+00
- --> f_atempm     = 0.000000000000000D+00
- --> f_aqhm     = 0.000000000000000D+00
- --> f_precipm  = 0.000000000000000D+00
- --> f_swfluxm  = 0.000000000000000D+00
- --> f_lwfluxm  = 0.000000000000000D+00
- --> f_swdownm  = 0.000000000000000D+00
- --> f_lwdownm  = 0.000000000000000D+00
- --> f_uwindsmoo     = 0.000000000000000D+00
- --> f_vwindsmoo     = 0.000000000000000D+00
- --> f_atempsmoo     = 0.000000000000000D+00
- --> f_aqhsmoo     = 0.000000000000000D+00
- --> f_precipsmoo  = 0.000000000000000D+00
- --> f_swfluxsmoo  = 0.000000000000000D+00
- --> f_lwfluxsmoo  = 0.000000000000000D+00
- --> f_swdownsmoo  = 0.000000000000000D+00
- --> f_lwdownsmoo  = 0.000000000000000D+00
- --> f_atl     = 0.000000000000000D+00
- --> f_ctdt    = 0.000000000000000D+00
- --> f_ctds    = 0.000000000000000D+00
- --> f_ctdtclim= 0.000000000000000D+00
- --> f_ctdsclim= 0.000000000000000D+00
- --> f_xbt     = 0.000000000000000D+00
- --> f_argot   = 0.000000000000000D+00
- --> f_argos   = 0.000000000000000D+00
- --> f_drifter   = 0.000000000000000D+00
- --> f_tdrift  = 0.000000000000000D+00
- --> f_sdrift  = 0.000000000000000D+00
- --> f_wdrift  = 0.000000000000000D+00
- --> f_scatx   = 0.000000000000000D+00
- --> f_scaty   = 0.000000000000000D+00
- --> f_scatxm  = 0.000000000000000D+00
- --> f_scatym  = 0.000000000000000D+00
  --> f_obcsn   = 0.000000000000000D+00
  --> f_obcss   = 0.000000000000000D+00
- --> f_obcsw   = 0.152587890625000D-12
+ --> f_obcsw   = 0.500000000000000D-08
  --> f_obcse   = 0.000000000000000D+00
- --> f_ageos   = 0.000000000000000D+00
- --> f_curmtr  = 0.000000000000000D+00
- --> f_kapgm   = 0.000000000000000D+00
- --> f_kapredi   = 0.000000000000000D+00
- --> f_diffkr  = 0.000000000000000D+00
- --> f_eddytau = 0.000000000000000D+00
- --> f_bottomdrag = 0.000000000000000D+00
- --> f_hfluxmm2           = 0.000000000000000D+00
- --> f_sfluxmm2           = 0.000000000000000D+00
- --> f_transp             = 0.000000000000000D+00
- --> objf_hmean           = 0.000000000000000D+00
- --> fc               = 0.000000000000000D+00
-  early fc =  0.000000000000000D+00
- --> objf_test(bi,bj)   =  0.000000000000000D+00
- --> objf_tracer(bi,bj) =  0.000000000000000D+00
- --> objf_atl(bi,bj)    =  0.000000000000000D+00
- --> objf_test(bi,bj)   =  0.000000000000000D+00
- --> objf_tracer(bi,bj) =  0.000000000000000D+00
- --> objf_atl(bi,bj)    =  0.000000000000000D+00
- --> objf_test(bi,bj)   =  0.000000000000000D+00
- --> objf_tracer(bi,bj) =  0.000000000000000D+00
- --> objf_atl(bi,bj)    =  0.000000000000000D+00
- --> objf_test(bi,bj)   =  0.000000000000000D+00
- --> objf_tracer(bi,bj) =  0.000000000000000D+00
- --> objf_atl(bi,bj)    =  0.000000000000000D+00
-  local fc =  0.147701231576013D+01
- global fc =  0.147701231576013D+01
-(PID.TID 0000.0001) grdchk perturb(+)fc: fcpertplus  =  1.47701231576013E+00
+(PID.TID 0000.0001)  --> f_gencost = 0.147701231575998D+01 1
+(PID.TID 0000.0001)  --> f_genarr3d = 0.000000000000000D+00 1
+(PID.TID 0000.0001)  --> fc               = 0.147701232075998D+01
+(PID.TID 0000.0001)   early fc =  0.000000000000000D+00
+(PID.TID 0000.0001)   local fc =  0.147701232075998D+01
+(PID.TID 0000.0001)  global fc =  0.147701232075998D+01
+(PID.TID 0000.0001) grdchk perturb(+)fc: fcpertplus  =  1.47701232075998E+00
 (PID.TID 0000.0001) Start initial hydrostatic pressure computation
 (PID.TID 0000.0001) Pressure is predetermined for buoyancyRelation OCEANIC
 (PID.TID 0000.0001) 
@@ -3805,119 +3682,23 @@ grad-res -------------------------------
  cg2d: Sum(rhs),rhsMax =  -1.59112718348958E+02  2.04436757292406E-01
  cg2d: Sum(rhs),rhsMax =  -2.24736325184256E+02  1.92987571288387E-01
 (PID.TID 0000.0001) Did not write pickup because writePickupAtEnd = FALSE
-(PID.TID 0000.0001) ph-cost call cost_theta0
-(PID.TID 0000.0001) ph-cost call cost_theta
- --> f_temp    = 0.147701116146135D+01
- --> f_salt    = 0.000000000000000D+00
- --> f_temp0   = 0.000000000000000D+00
- --> f_salt0   = 0.000000000000000D+00
- --> f_temp0smoo = 0.000000000000000D+00
- --> f_salt0smoo = 0.000000000000000D+00
- --> f_etan0   = 0.000000000000000D+00
- --> f_uvel0   = 0.000000000000000D+00
- --> f_vvel0   = 0.000000000000000D+00
- --> f_sst     = 0.000000000000000D+00
- --> f_tmi     = 0.000000000000000D+00
- --> f_sss     = 0.000000000000000D+00
- --> f_bp      = 0.000000000000000D+00
- --> f_ies      = 0.000000000000000D+00
- --> f_ssh       = 0.000000000000000D+00
- --> f_tp        = 0.000000000000000D+00
- --> f_ers       = 0.000000000000000D+00
- --> f_gfo       = 0.000000000000000D+00
- --> f_tauu    = 0.000000000000000D+00
- --> f_tauum   = 0.000000000000000D+00
- --> f_tauusmoo = 0.000000000000000D+00
- --> f_tauv    = 0.000000000000000D+00
- --> f_tauvm   = 0.000000000000000D+00
- --> f_tauvsmoo = 0.000000000000000D+00
- --> f_hflux   = 0.000000000000000D+00
- --> f_hfluxmm = 0.000000000000000D+00
- --> f_hfluxsmoo = 0.000000000000000D+00
- --> f_sflux   = 0.000000000000000D+00
- --> f_sfluxmm = 0.000000000000000D+00
- --> f_sfluxsmoo = 0.000000000000000D+00
- --> f_uwind     = 0.000000000000000D+00
- --> f_vwind     = 0.000000000000000D+00
- --> f_atemp     = 0.000000000000000D+00
- --> f_aqh     = 0.000000000000000D+00
- --> f_precip  = 0.000000000000000D+00
- --> f_swflux  = 0.000000000000000D+00
- --> f_swdown  = 0.000000000000000D+00
- --> f_lwflux  = 0.000000000000000D+00
- --> f_lwdown  = 0.000000000000000D+00
- --> f_uwindm     = 0.000000000000000D+00
- --> f_vwindm     = 0.000000000000000D+00
- --> f_atempm     = 0.000000000000000D+00
- --> f_aqhm     = 0.000000000000000D+00
- --> f_precipm  = 0.000000000000000D+00
- --> f_swfluxm  = 0.000000000000000D+00
- --> f_lwfluxm  = 0.000000000000000D+00
- --> f_swdownm  = 0.000000000000000D+00
- --> f_lwdownm  = 0.000000000000000D+00
- --> f_uwindsmoo     = 0.000000000000000D+00
- --> f_vwindsmoo     = 0.000000000000000D+00
- --> f_atempsmoo     = 0.000000000000000D+00
- --> f_aqhsmoo     = 0.000000000000000D+00
- --> f_precipsmoo  = 0.000000000000000D+00
- --> f_swfluxsmoo  = 0.000000000000000D+00
- --> f_lwfluxsmoo  = 0.000000000000000D+00
- --> f_swdownsmoo  = 0.000000000000000D+00
- --> f_lwdownsmoo  = 0.000000000000000D+00
- --> f_atl     = 0.000000000000000D+00
- --> f_ctdt    = 0.000000000000000D+00
- --> f_ctds    = 0.000000000000000D+00
- --> f_ctdtclim= 0.000000000000000D+00
- --> f_ctdsclim= 0.000000000000000D+00
- --> f_xbt     = 0.000000000000000D+00
- --> f_argot   = 0.000000000000000D+00
- --> f_argos   = 0.000000000000000D+00
- --> f_drifter   = 0.000000000000000D+00
- --> f_tdrift  = 0.000000000000000D+00
- --> f_sdrift  = 0.000000000000000D+00
- --> f_wdrift  = 0.000000000000000D+00
- --> f_scatx   = 0.000000000000000D+00
- --> f_scaty   = 0.000000000000000D+00
- --> f_scatxm  = 0.000000000000000D+00
- --> f_scatym  = 0.000000000000000D+00
  --> f_obcsn   = 0.000000000000000D+00
  --> f_obcss   = 0.000000000000000D+00
- --> f_obcsw   = 0.152587890625000D-12
+ --> f_obcsw   = 0.500000000000000D-08
  --> f_obcse   = 0.000000000000000D+00
- --> f_ageos   = 0.000000000000000D+00
- --> f_curmtr  = 0.000000000000000D+00
- --> f_kapgm   = 0.000000000000000D+00
- --> f_kapredi   = 0.000000000000000D+00
- --> f_diffkr  = 0.000000000000000D+00
- --> f_eddytau = 0.000000000000000D+00
- --> f_bottomdrag = 0.000000000000000D+00
- --> f_hfluxmm2           = 0.000000000000000D+00
- --> f_sfluxmm2           = 0.000000000000000D+00
- --> f_transp             = 0.000000000000000D+00
- --> objf_hmean           = 0.000000000000000D+00
- --> fc               = 0.000000000000000D+00
-  early fc =  0.000000000000000D+00
- --> objf_test(bi,bj)   =  0.000000000000000D+00
- --> objf_tracer(bi,bj) =  0.000000000000000D+00
- --> objf_atl(bi,bj)    =  0.000000000000000D+00
- --> objf_test(bi,bj)   =  0.000000000000000D+00
- --> objf_tracer(bi,bj) =  0.000000000000000D+00
- --> objf_atl(bi,bj)    =  0.000000000000000D+00
- --> objf_test(bi,bj)   =  0.000000000000000D+00
- --> objf_tracer(bi,bj) =  0.000000000000000D+00
- --> objf_atl(bi,bj)    =  0.000000000000000D+00
- --> objf_test(bi,bj)   =  0.000000000000000D+00
- --> objf_tracer(bi,bj) =  0.000000000000000D+00
- --> objf_atl(bi,bj)    =  0.000000000000000D+00
-  local fc =  0.147701116146150D+01
- global fc =  0.147701116146150D+01
-(PID.TID 0000.0001) grdchk perturb(-)fc: fcpertminus =  1.47701116146150E+00
+(PID.TID 0000.0001)  --> f_gencost = 0.147701116146135D+01 1
+(PID.TID 0000.0001)  --> f_genarr3d = 0.000000000000000D+00 1
+(PID.TID 0000.0001)  --> fc               = 0.147701116646135D+01
+(PID.TID 0000.0001)   early fc =  0.000000000000000D+00
+(PID.TID 0000.0001)   local fc =  0.147701116646135D+01
+(PID.TID 0000.0001)  global fc =  0.147701116646135D+01
+(PID.TID 0000.0001) grdchk perturb(-)fc: fcpertminus =  1.47701116646135E+00
 grad-res -------------------------------
- grad-res     0    4    1    4    4    1    1    1   1.47701073786E+00  1.47701231576E+00  1.47701116146E+00
- grad-res     0    4    4  100    0    1    1    1   5.77149324922E-03  5.77149313230E-03  2.02579585329E-08
+ grad-res     0    4    1    4    4    1    1    1   1.47701073786E+00  1.47701232076E+00  1.47701116646E+00
+ grad-res     0    4    4  100    0    1    1    1   5.77149324922E-03  5.77149313452E-03  1.98732276191E-08
 (PID.TID 0000.0001)  ADM  ref_cost_function      =  1.47701073786182E+00
-(PID.TID 0000.0001)  ADM  adjoint_gradient       =  5.77149324921919E-03
-(PID.TID 0000.0001)  ADM  finite-diff_grad       =  5.77149313230052E-03
+(PID.TID 0000.0001)  ADM  adjoint_gradient       =  5.77149324921917E-03
+(PID.TID 0000.0001)  ADM  finite-diff_grad       =  5.77149313452097E-03
 (PID.TID 0000.0001) ====== End of gradient-check number   4 (ierr=  0) =======
 (PID.TID 0000.0001) ====== Starts gradient-check number   5 (=ichknum) =======
  ph-test icomp, ncvarcomp, ichknum          101        8192           5
@@ -3937,113 +3718,17 @@ grad-res -------------------------------
  cg2d: Sum(rhs),rhsMax =  -1.59112718349079E+02  2.04436757292251E-01
  cg2d: Sum(rhs),rhsMax =  -2.24736325185391E+02  1.92987571287413E-01
 (PID.TID 0000.0001) Did not write pickup because writePickupAtEnd = FALSE
-(PID.TID 0000.0001) ph-cost call cost_theta0
-(PID.TID 0000.0001) ph-cost call cost_theta
- --> f_temp    = 0.147701232551278D+01
- --> f_salt    = 0.000000000000000D+00
- --> f_temp0   = 0.000000000000000D+00
- --> f_salt0   = 0.000000000000000D+00
- --> f_temp0smoo = 0.000000000000000D+00
- --> f_salt0smoo = 0.000000000000000D+00
- --> f_etan0   = 0.000000000000000D+00
- --> f_uvel0   = 0.000000000000000D+00
- --> f_vvel0   = 0.000000000000000D+00
- --> f_sst     = 0.000000000000000D+00
- --> f_tmi     = 0.000000000000000D+00
- --> f_sss     = 0.000000000000000D+00
- --> f_bp      = 0.000000000000000D+00
- --> f_ies      = 0.000000000000000D+00
- --> f_ssh       = 0.000000000000000D+00
- --> f_tp        = 0.000000000000000D+00
- --> f_ers       = 0.000000000000000D+00
- --> f_gfo       = 0.000000000000000D+00
- --> f_tauu    = 0.000000000000000D+00
- --> f_tauum   = 0.000000000000000D+00
- --> f_tauusmoo = 0.000000000000000D+00
- --> f_tauv    = 0.000000000000000D+00
- --> f_tauvm   = 0.000000000000000D+00
- --> f_tauvsmoo = 0.000000000000000D+00
- --> f_hflux   = 0.000000000000000D+00
- --> f_hfluxmm = 0.000000000000000D+00
- --> f_hfluxsmoo = 0.000000000000000D+00
- --> f_sflux   = 0.000000000000000D+00
- --> f_sfluxmm = 0.000000000000000D+00
- --> f_sfluxsmoo = 0.000000000000000D+00
- --> f_uwind     = 0.000000000000000D+00
- --> f_vwind     = 0.000000000000000D+00
- --> f_atemp     = 0.000000000000000D+00
- --> f_aqh     = 0.000000000000000D+00
- --> f_precip  = 0.000000000000000D+00
- --> f_swflux  = 0.000000000000000D+00
- --> f_swdown  = 0.000000000000000D+00
- --> f_lwflux  = 0.000000000000000D+00
- --> f_lwdown  = 0.000000000000000D+00
- --> f_uwindm     = 0.000000000000000D+00
- --> f_vwindm     = 0.000000000000000D+00
- --> f_atempm     = 0.000000000000000D+00
- --> f_aqhm     = 0.000000000000000D+00
- --> f_precipm  = 0.000000000000000D+00
- --> f_swfluxm  = 0.000000000000000D+00
- --> f_lwfluxm  = 0.000000000000000D+00
- --> f_swdownm  = 0.000000000000000D+00
- --> f_lwdownm  = 0.000000000000000D+00
- --> f_uwindsmoo     = 0.000000000000000D+00
- --> f_vwindsmoo     = 0.000000000000000D+00
- --> f_atempsmoo     = 0.000000000000000D+00
- --> f_aqhsmoo     = 0.000000000000000D+00
- --> f_precipsmoo  = 0.000000000000000D+00
- --> f_swfluxsmoo  = 0.000000000000000D+00
- --> f_lwfluxsmoo  = 0.000000000000000D+00
- --> f_swdownsmoo  = 0.000000000000000D+00
- --> f_lwdownsmoo  = 0.000000000000000D+00
- --> f_atl     = 0.000000000000000D+00
- --> f_ctdt    = 0.000000000000000D+00
- --> f_ctds    = 0.000000000000000D+00
- --> f_ctdtclim= 0.000000000000000D+00
- --> f_ctdsclim= 0.000000000000000D+00
- --> f_xbt     = 0.000000000000000D+00
- --> f_argot   = 0.000000000000000D+00
- --> f_argos   = 0.000000000000000D+00
- --> f_drifter   = 0.000000000000000D+00
- --> f_tdrift  = 0.000000000000000D+00
- --> f_sdrift  = 0.000000000000000D+00
- --> f_wdrift  = 0.000000000000000D+00
- --> f_scatx   = 0.000000000000000D+00
- --> f_scaty   = 0.000000000000000D+00
- --> f_scatxm  = 0.000000000000000D+00
- --> f_scatym  = 0.000000000000000D+00
  --> f_obcsn   = 0.000000000000000D+00
  --> f_obcss   = 0.000000000000000D+00
- --> f_obcsw   = 0.152587890625000D-12
+ --> f_obcsw   = 0.500000000000000D-08
  --> f_obcse   = 0.000000000000000D+00
- --> f_ageos   = 0.000000000000000D+00
- --> f_curmtr  = 0.000000000000000D+00
- --> f_kapgm   = 0.000000000000000D+00
- --> f_kapredi   = 0.000000000000000D+00
- --> f_diffkr  = 0.000000000000000D+00
- --> f_eddytau = 0.000000000000000D+00
- --> f_bottomdrag = 0.000000000000000D+00
- --> f_hfluxmm2           = 0.000000000000000D+00
- --> f_sfluxmm2           = 0.000000000000000D+00
- --> f_transp             = 0.000000000000000D+00
- --> objf_hmean           = 0.000000000000000D+00
- --> fc               = 0.000000000000000D+00
-  early fc =  0.000000000000000D+00
- --> objf_test(bi,bj)   =  0.000000000000000D+00
- --> objf_tracer(bi,bj) =  0.000000000000000D+00
- --> objf_atl(bi,bj)    =  0.000000000000000D+00
- --> objf_test(bi,bj)   =  0.000000000000000D+00
- --> objf_tracer(bi,bj) =  0.000000000000000D+00
- --> objf_atl(bi,bj)    =  0.000000000000000D+00
- --> objf_test(bi,bj)   =  0.000000000000000D+00
- --> objf_tracer(bi,bj) =  0.000000000000000D+00
- --> objf_atl(bi,bj)    =  0.000000000000000D+00
- --> objf_test(bi,bj)   =  0.000000000000000D+00
- --> objf_tracer(bi,bj) =  0.000000000000000D+00
- --> objf_atl(bi,bj)    =  0.000000000000000D+00
-  local fc =  0.147701232551293D+01
- global fc =  0.147701232551293D+01
-(PID.TID 0000.0001) grdchk perturb(+)fc: fcpertplus  =  1.47701232551293E+00
+(PID.TID 0000.0001)  --> f_gencost = 0.147701232551278D+01 1
+(PID.TID 0000.0001)  --> f_genarr3d = 0.000000000000000D+00 1
+(PID.TID 0000.0001)  --> fc               = 0.147701233051278D+01
+(PID.TID 0000.0001)   early fc =  0.000000000000000D+00
+(PID.TID 0000.0001)   local fc =  0.147701233051278D+01
+(PID.TID 0000.0001)  global fc =  0.147701233051278D+01
+(PID.TID 0000.0001) grdchk perturb(+)fc: fcpertplus  =  1.47701233051278E+00
 (PID.TID 0000.0001) Start initial hydrostatic pressure computation
 (PID.TID 0000.0001) Pressure is predetermined for buoyancyRelation OCEANIC
 (PID.TID 0000.0001) 
@@ -4057,116 +3742,20 @@ grad-res -------------------------------
  cg2d: Sum(rhs),rhsMax =  -1.59112718348971E+02  2.04436757292389E-01
  cg2d: Sum(rhs),rhsMax =  -2.24736325184247E+02  1.92987571288395E-01
 (PID.TID 0000.0001) Did not write pickup because writePickupAtEnd = FALSE
-(PID.TID 0000.0001) ph-cost call cost_theta0
-(PID.TID 0000.0001) ph-cost call cost_theta
- --> f_temp    = 0.147701115171239D+01
- --> f_salt    = 0.000000000000000D+00
- --> f_temp0   = 0.000000000000000D+00
- --> f_salt0   = 0.000000000000000D+00
- --> f_temp0smoo = 0.000000000000000D+00
- --> f_salt0smoo = 0.000000000000000D+00
- --> f_etan0   = 0.000000000000000D+00
- --> f_uvel0   = 0.000000000000000D+00
- --> f_vvel0   = 0.000000000000000D+00
- --> f_sst     = 0.000000000000000D+00
- --> f_tmi     = 0.000000000000000D+00
- --> f_sss     = 0.000000000000000D+00
- --> f_bp      = 0.000000000000000D+00
- --> f_ies      = 0.000000000000000D+00
- --> f_ssh       = 0.000000000000000D+00
- --> f_tp        = 0.000000000000000D+00
- --> f_ers       = 0.000000000000000D+00
- --> f_gfo       = 0.000000000000000D+00
- --> f_tauu    = 0.000000000000000D+00
- --> f_tauum   = 0.000000000000000D+00
- --> f_tauusmoo = 0.000000000000000D+00
- --> f_tauv    = 0.000000000000000D+00
- --> f_tauvm   = 0.000000000000000D+00
- --> f_tauvsmoo = 0.000000000000000D+00
- --> f_hflux   = 0.000000000000000D+00
- --> f_hfluxmm = 0.000000000000000D+00
- --> f_hfluxsmoo = 0.000000000000000D+00
- --> f_sflux   = 0.000000000000000D+00
- --> f_sfluxmm = 0.000000000000000D+00
- --> f_sfluxsmoo = 0.000000000000000D+00
- --> f_uwind     = 0.000000000000000D+00
- --> f_vwind     = 0.000000000000000D+00
- --> f_atemp     = 0.000000000000000D+00
- --> f_aqh     = 0.000000000000000D+00
- --> f_precip  = 0.000000000000000D+00
- --> f_swflux  = 0.000000000000000D+00
- --> f_swdown  = 0.000000000000000D+00
- --> f_lwflux  = 0.000000000000000D+00
- --> f_lwdown  = 0.000000000000000D+00
- --> f_uwindm     = 0.000000000000000D+00
- --> f_vwindm     = 0.000000000000000D+00
- --> f_atempm     = 0.000000000000000D+00
- --> f_aqhm     = 0.000000000000000D+00
- --> f_precipm  = 0.000000000000000D+00
- --> f_swfluxm  = 0.000000000000000D+00
- --> f_lwfluxm  = 0.000000000000000D+00
- --> f_swdownm  = 0.000000000000000D+00
- --> f_lwdownm  = 0.000000000000000D+00
- --> f_uwindsmoo     = 0.000000000000000D+00
- --> f_vwindsmoo     = 0.000000000000000D+00
- --> f_atempsmoo     = 0.000000000000000D+00
- --> f_aqhsmoo     = 0.000000000000000D+00
- --> f_precipsmoo  = 0.000000000000000D+00
- --> f_swfluxsmoo  = 0.000000000000000D+00
- --> f_lwfluxsmoo  = 0.000000000000000D+00
- --> f_swdownsmoo  = 0.000000000000000D+00
- --> f_lwdownsmoo  = 0.000000000000000D+00
- --> f_atl     = 0.000000000000000D+00
- --> f_ctdt    = 0.000000000000000D+00
- --> f_ctds    = 0.000000000000000D+00
- --> f_ctdtclim= 0.000000000000000D+00
- --> f_ctdsclim= 0.000000000000000D+00
- --> f_xbt     = 0.000000000000000D+00
- --> f_argot   = 0.000000000000000D+00
- --> f_argos   = 0.000000000000000D+00
- --> f_drifter   = 0.000000000000000D+00
- --> f_tdrift  = 0.000000000000000D+00
- --> f_sdrift  = 0.000000000000000D+00
- --> f_wdrift  = 0.000000000000000D+00
- --> f_scatx   = 0.000000000000000D+00
- --> f_scaty   = 0.000000000000000D+00
- --> f_scatxm  = 0.000000000000000D+00
- --> f_scatym  = 0.000000000000000D+00
  --> f_obcsn   = 0.000000000000000D+00
  --> f_obcss   = 0.000000000000000D+00
- --> f_obcsw   = 0.152587890625000D-12
+ --> f_obcsw   = 0.500000000000000D-08
  --> f_obcse   = 0.000000000000000D+00
- --> f_ageos   = 0.000000000000000D+00
- --> f_curmtr  = 0.000000000000000D+00
- --> f_kapgm   = 0.000000000000000D+00
- --> f_kapredi   = 0.000000000000000D+00
- --> f_diffkr  = 0.000000000000000D+00
- --> f_eddytau = 0.000000000000000D+00
- --> f_bottomdrag = 0.000000000000000D+00
- --> f_hfluxmm2           = 0.000000000000000D+00
- --> f_sfluxmm2           = 0.000000000000000D+00
- --> f_transp             = 0.000000000000000D+00
- --> objf_hmean           = 0.000000000000000D+00
- --> fc               = 0.000000000000000D+00
-  early fc =  0.000000000000000D+00
- --> objf_test(bi,bj)   =  0.000000000000000D+00
- --> objf_tracer(bi,bj) =  0.000000000000000D+00
- --> objf_atl(bi,bj)    =  0.000000000000000D+00
- --> objf_test(bi,bj)   =  0.000000000000000D+00
- --> objf_tracer(bi,bj) =  0.000000000000000D+00
- --> objf_atl(bi,bj)    =  0.000000000000000D+00
- --> objf_test(bi,bj)   =  0.000000000000000D+00
- --> objf_tracer(bi,bj) =  0.000000000000000D+00
- --> objf_atl(bi,bj)    =  0.000000000000000D+00
- --> objf_test(bi,bj)   =  0.000000000000000D+00
- --> objf_tracer(bi,bj) =  0.000000000000000D+00
- --> objf_atl(bi,bj)    =  0.000000000000000D+00
-  local fc =  0.147701115171255D+01
- global fc =  0.147701115171255D+01
-(PID.TID 0000.0001) grdchk perturb(-)fc: fcpertminus =  1.47701115171255E+00
+(PID.TID 0000.0001)  --> f_gencost = 0.147701115171239D+01 1
+(PID.TID 0000.0001)  --> f_genarr3d = 0.000000000000000D+00 1
+(PID.TID 0000.0001)  --> fc               = 0.147701115671239D+01
+(PID.TID 0000.0001)   early fc =  0.000000000000000D+00
+(PID.TID 0000.0001)   local fc =  0.147701115671239D+01
+(PID.TID 0000.0001)  global fc =  0.147701115671239D+01
+(PID.TID 0000.0001) grdchk perturb(-)fc: fcpertminus =  1.47701115671239E+00
 grad-res -------------------------------
- grad-res     0    5    1    5    4    1    1    1   1.47701073786E+00  1.47701232551E+00  1.47701115171E+00
- grad-res     0    5    5  101    0    1    1    1   5.86900146724E-03  5.86900191779E-03 -7.67675383262E-08
+ grad-res     0    5    1    5    4    1    1    1   1.47701073786E+00  1.47701233051E+00  1.47701115671E+00
+ grad-res     0    5    5  101    0    1    1    1   5.86900146724E-03  5.86900191779E-03 -7.67675387703E-08
 (PID.TID 0000.0001)  ADM  ref_cost_function      =  1.47701073786182E+00
 (PID.TID 0000.0001)  ADM  adjoint_gradient       =  5.86900146724214E-03
 (PID.TID 0000.0001)  ADM  finite-diff_grad       =  5.86900191779094E-03
@@ -4183,269 +3772,239 @@ grad-res -------------------------------
 (PID.TID 0000.0001) grdchk output h.g:  Id     FC1-FC2/(2*EPS)      ADJ GRAD(FC)         1-FDGRD/ADGRD
 (PID.TID 0000.0001) 
 (PID.TID 0000.0001) grdchk output (p):   1     1     1     4    1    1   0.000000000E+00 -1.000000000E-04
-(PID.TID 0000.0001) grdchk output (c):   1  1.4770107378618E+00  1.4770117378619E+00  1.4770117378619E+00
+(PID.TID 0000.0001) grdchk output (c):   1  1.4770107378618E+00  1.4770117428618E+00  1.4770117428618E+00
 (PID.TID 0000.0001) grdchk output (g):   1     0.0000000000000E+00  0.0000000000000E+00  0.0000000000000E+00
 (PID.TID 0000.0001) 
 (PID.TID 0000.0001) grdchk output (p):   2     1     2     4    1    1   0.000000000E+00 -1.000000000E-04
-(PID.TID 0000.0001) grdchk output (c):   2  1.4770107378618E+00  1.4770122954508E+00  1.4770111817659E+00
-(PID.TID 0000.0001) grdchk output (g):   2     5.5684245547916E-03  5.5684243446579E-03 -3.7736651137266E-08
+(PID.TID 0000.0001) grdchk output (c):   2  1.4770107378618E+00  1.4770123004506E+00  1.4770111867657E+00
+(PID.TID 0000.0001) grdchk output (g):   2     5.5684245547916E-03  5.5684243446579E-03 -3.7736647584552E-08
 (PID.TID 0000.0001) 
 (PID.TID 0000.0001) grdchk output (p):   3     1     3     4    1    1   0.000000000E+00 -1.000000000E-04
-(PID.TID 0000.0001) grdchk output (c):   3  1.4770107378618E+00  1.4770123054769E+00  1.4770111717379E+00
-(PID.TID 0000.0001) grdchk output (g):   3     5.6686948424201E-03  5.6686945042635E-03 -5.9653341155652E-08
+(PID.TID 0000.0001) grdchk output (c):   3  1.4770107378618E+00  1.4770123104767E+00  1.4770111767377E+00
+(PID.TID 0000.0001) grdchk output (g):   3     5.6686948668450E-03  5.6686945042635E-03 -6.3962078078461E-08
 (PID.TID 0000.0001) 
 (PID.TID 0000.0001) grdchk output (p):   4     1     4     4    1    1   0.000000000E+00 -1.000000000E-04
-(PID.TID 0000.0001) grdchk output (c):   4  1.4770107378618E+00  1.4770123157601E+00  1.4770111614615E+00
-(PID.TID 0000.0001) grdchk output (g):   4     5.7714931323005E-03  5.7714932492192E-03  2.0257958532888E-08
+(PID.TID 0000.0001) grdchk output (c):   4  1.4770107378618E+00  1.4770123207600E+00  1.4770111664613E+00
+(PID.TID 0000.0001) grdchk output (g):   4     5.7714931345210E-03  5.7714932492192E-03  1.9873227619094E-08
 (PID.TID 0000.0001) 
 (PID.TID 0000.0001) grdchk output (p):   5     1     5     4    1    1   0.000000000E+00 -1.000000000E-04
-(PID.TID 0000.0001) grdchk output (c):   5  1.4770107378618E+00  1.4770123255129E+00  1.4770111517125E+00
-(PID.TID 0000.0001) grdchk output (g):   5     5.8690019177909E-03  5.8690014672421E-03 -7.6767538326195E-08
+(PID.TID 0000.0001) grdchk output (c):   5  1.4770107378618E+00  1.4770123305128E+00  1.4770111567124E+00
+(PID.TID 0000.0001) grdchk output (g):   5     5.8690019177909E-03  5.8690014672421E-03 -7.6767538770284E-08
 (PID.TID 0000.0001) 
-(PID.TID 0000.0001) grdchk  summary  :  RMS of    5 ratios =  4.7510453112283E-08
+(PID.TID 0000.0001) grdchk  summary  :  RMS of    5 ratios =  4.8586833994166E-08
 (PID.TID 0000.0001) 
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // Gradient check results  >>> END <<<
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) 
 (PID.TID 0000.0001)   Seconds in section "ALL                    [THE_MODEL_MAIN]":
-(PID.TID 0000.0001)           User time:   34.369999999999997
-(PID.TID 0000.0001)         System time:  0.19000000000000000
-(PID.TID 0000.0001)     Wall clock time:   34.800395011901855
+(PID.TID 0000.0001)           User time:   38.262015249114484
+(PID.TID 0000.0001)         System time:  0.38001498579978943
+(PID.TID 0000.0001)     Wall clock time:   38.752650976181030
 (PID.TID 0000.0001)          No. starts:           1
 (PID.TID 0000.0001)           No. stops:           1
 (PID.TID 0000.0001)   Seconds in section "INITIALISE_FIXED       [THE_MODEL_MAIN]":
-(PID.TID 0000.0001)           User time:  0.20000000000000001
-(PID.TID 0000.0001)         System time:  4.00000000000000008E-002
-(PID.TID 0000.0001)     Wall clock time:  0.32605910301208496
+(PID.TID 0000.0001)           User time:  0.10044400254264474
+(PID.TID 0000.0001)         System time:   4.5416001230478287E-002
+(PID.TID 0000.0001)     Wall clock time:  0.20148611068725586
 (PID.TID 0000.0001)          No. starts:           1
 (PID.TID 0000.0001)           No. stops:           1
 (PID.TID 0000.0001)   Seconds in section "ADTHE_MAIN_LOOP          [ADJOINT RUN]":
-(PID.TID 0000.0001)           User time:   11.210000000000001
-(PID.TID 0000.0001)         System time:  8.99999999999999967E-002
-(PID.TID 0000.0001)     Wall clock time:   11.371971130371094
+(PID.TID 0000.0001)           User time:   12.228305250406265
+(PID.TID 0000.0001)         System time:  0.21082200482487679
+(PID.TID 0000.0001)     Wall clock time:   12.461027145385742
 (PID.TID 0000.0001)          No. starts:           1
 (PID.TID 0000.0001)           No. stops:           1
 (PID.TID 0000.0001)   Seconds in section "FORWARD_STEP        [MAIN_DO_LOOP]":
-(PID.TID 0000.0001)           User time:   25.120000000000005
-(PID.TID 0000.0001)         System time:  2.99999999999999989E-002
-(PID.TID 0000.0001)     Wall clock time:   25.194791316986084
+(PID.TID 0000.0001)           User time:   25.956096529960632
+(PID.TID 0000.0001)         System time:   1.1153995990753174E-002
+(PID.TID 0000.0001)     Wall clock time:   25.980992317199707
 (PID.TID 0000.0001)          No. starts:          48
 (PID.TID 0000.0001)           No. stops:          48
 (PID.TID 0000.0001)   Seconds in section "DO_STATEVARS_DIAGS  [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:   0.0000000000000000
-(PID.TID 0000.0001)         System time:   0.0000000000000000
-(PID.TID 0000.0001)     Wall clock time:  1.26910209655761719E-003
+(PID.TID 0000.0001)           User time:   2.3305416107177734E-004
+(PID.TID 0000.0001)         System time:   5.9977173805236816E-006
+(PID.TID 0000.0001)     Wall clock time:   2.3698806762695312E-004
 (PID.TID 0000.0001)          No. starts:          12
 (PID.TID 0000.0001)           No. stops:          12
 (PID.TID 0000.0001)   Seconds in section "LOAD_FIELDS_DRIVER  [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:  0.11999999999999744
-(PID.TID 0000.0001)         System time:   0.0000000000000000
-(PID.TID 0000.0001)     Wall clock time:  0.12186646461486816
+(PID.TID 0000.0001)           User time:   8.5981249809265137E-002
+(PID.TID 0000.0001)         System time:   1.1199712753295898E-004
+(PID.TID 0000.0001)     Wall clock time:   8.6102008819580078E-002
 (PID.TID 0000.0001)          No. starts:          48
 (PID.TID 0000.0001)           No. stops:          48
 (PID.TID 0000.0001)   Seconds in section "EXF_GETFORCING     [LOAD_FLDS_DRIVER]":
-(PID.TID 0000.0001)           User time:  0.13000000000000256
-(PID.TID 0000.0001)         System time:   0.0000000000000000
-(PID.TID 0000.0001)     Wall clock time:  0.12995076179504395
+(PID.TID 0000.0001)           User time:   9.1066420078277588E-002
+(PID.TID 0000.0001)         System time:   1.9899010658264160E-004
+(PID.TID 0000.0001)     Wall clock time:   9.1361284255981445E-002
 (PID.TID 0000.0001)          No. starts:          52
 (PID.TID 0000.0001)           No. stops:          52
-(PID.TID 0000.0001)   Seconds in section "I/O (WRITE)        [ADJOINT LOOP]":
-(PID.TID 0000.0001)           User time:   0.0000000000000000
-(PID.TID 0000.0001)         System time:   0.0000000000000000
-(PID.TID 0000.0001)     Wall clock time:  1.61075592041015625E-003
-(PID.TID 0000.0001)          No. starts:         176
-(PID.TID 0000.0001)           No. stops:         176
 (PID.TID 0000.0001)   Seconds in section "EXTERNAL_FLDS_LOAD [LOAD_FLDS_DRIVER]":
-(PID.TID 0000.0001)           User time:   0.0000000000000000
-(PID.TID 0000.0001)         System time:   0.0000000000000000
-(PID.TID 0000.0001)     Wall clock time:  4.89473342895507813E-004
+(PID.TID 0000.0001)           User time:   4.7731399536132812E-004
+(PID.TID 0000.0001)         System time:   1.9818544387817383E-006
+(PID.TID 0000.0001)     Wall clock time:   4.7969818115234375E-004
 (PID.TID 0000.0001)          No. starts:          52
 (PID.TID 0000.0001)           No. stops:          52
-(PID.TID 0000.0001)   Seconds in section "DO_ATMOSPHERIC_PHYS [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:   0.0000000000000000
+(PID.TID 0000.0001)   Seconds in section "CTRL_MAP_FORCING  [FORWARD_STEP]":
+(PID.TID 0000.0001)           User time:   4.0465593338012695E-004
 (PID.TID 0000.0001)         System time:   0.0000000000000000
-(PID.TID 0000.0001)     Wall clock time:  4.42028045654296875E-004
+(PID.TID 0000.0001)     Wall clock time:   3.9243698120117188E-004
+(PID.TID 0000.0001)          No. starts:          48
+(PID.TID 0000.0001)           No. stops:          48
+(PID.TID 0000.0001)   Seconds in section "DO_ATMOSPHERIC_PHYS [FORWARD_STEP]":
+(PID.TID 0000.0001)           User time:   1.9118428230285645E-002
+(PID.TID 0000.0001)         System time:   2.4989247322082520E-005
+(PID.TID 0000.0001)     Wall clock time:   1.9204616546630859E-002
 (PID.TID 0000.0001)          No. starts:          48
 (PID.TID 0000.0001)           No. stops:          48
 (PID.TID 0000.0001)   Seconds in section "DO_OCEANIC_PHYS     [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:  0.30999999999998806
-(PID.TID 0000.0001)         System time:   0.0000000000000000
-(PID.TID 0000.0001)     Wall clock time:  0.33052897453308105
+(PID.TID 0000.0001)           User time:  0.22669690847396851
+(PID.TID 0000.0001)         System time:   5.0067901611328125E-006
+(PID.TID 0000.0001)     Wall clock time:  0.22684502601623535
 (PID.TID 0000.0001)          No. starts:          48
 (PID.TID 0000.0001)           No. stops:          48
 (PID.TID 0000.0001)   Seconds in section "DYNAMICS            [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:   7.1500000000000270
-(PID.TID 0000.0001)         System time:  1.00000000000000089E-002
-(PID.TID 0000.0001)     Wall clock time:   7.1298437118530273
+(PID.TID 0000.0001)           User time:   4.9396277666091919
+(PID.TID 0000.0001)         System time:   9.9837779998779297E-006
+(PID.TID 0000.0001)     Wall clock time:   4.9408731460571289
 (PID.TID 0000.0001)          No. starts:          48
 (PID.TID 0000.0001)           No. stops:          48
 (PID.TID 0000.0001)   Seconds in section "SOLVE_FOR_PRESSURE  [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:   10.509999999999984
-(PID.TID 0000.0001)         System time:  9.99999999999998113E-003
-(PID.TID 0000.0001)     Wall clock time:   10.557406902313232
+(PID.TID 0000.0001)           User time:   7.2265335917472839
+(PID.TID 0000.0001)         System time:   4.0130019187927246E-003
+(PID.TID 0000.0001)     Wall clock time:   7.2319846153259277
 (PID.TID 0000.0001)          No. starts:          48
 (PID.TID 0000.0001)           No. stops:          48
 (PID.TID 0000.0001)   Seconds in section "MOM_CORRECTION_STEP [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:  0.27999999999999403
+(PID.TID 0000.0001)           User time:  0.22495180368423462
 (PID.TID 0000.0001)         System time:   0.0000000000000000
-(PID.TID 0000.0001)     Wall clock time:  0.28749465942382813
+(PID.TID 0000.0001)     Wall clock time:  0.22509980201721191
 (PID.TID 0000.0001)          No. starts:          48
 (PID.TID 0000.0001)           No. stops:          48
 (PID.TID 0000.0001)   Seconds in section "INTEGR_CONTINUITY   [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:  0.41000000000002501
+(PID.TID 0000.0001)           User time:  0.24052137136459351
 (PID.TID 0000.0001)         System time:   0.0000000000000000
-(PID.TID 0000.0001)     Wall clock time:  0.39425206184387207
+(PID.TID 0000.0001)     Wall clock time:  0.24067139625549316
 (PID.TID 0000.0001)          No. starts:          48
 (PID.TID 0000.0001)           No. stops:          48
 (PID.TID 0000.0001)   Seconds in section "BLOCKING_EXCHANGES  [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:  0.12999999999998835
+(PID.TID 0000.0001)           User time:   7.5146079063415527E-002
 (PID.TID 0000.0001)         System time:   0.0000000000000000
-(PID.TID 0000.0001)     Wall clock time:  0.11550259590148926
+(PID.TID 0000.0001)     Wall clock time:   7.5312852859497070E-002
 (PID.TID 0000.0001)          No. starts:          96
 (PID.TID 0000.0001)           No. stops:          96
 (PID.TID 0000.0001)   Seconds in section "THERMODYNAMICS      [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:   5.9999999999999716
-(PID.TID 0000.0001)         System time:   0.0000000000000000
-(PID.TID 0000.0001)     Wall clock time:   6.0317463874816895
+(PID.TID 0000.0001)           User time:   3.7270334959030151
+(PID.TID 0000.0001)         System time:   1.0013580322265625E-005
+(PID.TID 0000.0001)     Wall clock time:   3.7279376983642578
 (PID.TID 0000.0001)          No. starts:          48
 (PID.TID 0000.0001)           No. stops:          48
 (PID.TID 0000.0001)   Seconds in section "TRC_CORRECTION_STEP [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:  0.12000000000000455
+(PID.TID 0000.0001)           User time:   4.5478343963623047E-004
 (PID.TID 0000.0001)         System time:   0.0000000000000000
-(PID.TID 0000.0001)     Wall clock time:  0.10523819923400879
-(PID.TID 0000.0001)          No. starts:          48
-(PID.TID 0000.0001)           No. stops:          48
-(PID.TID 0000.0001)   Seconds in section "DO_STATEVARS_TAVE   [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:   0.0000000000000000
-(PID.TID 0000.0001)         System time:   0.0000000000000000
-(PID.TID 0000.0001)     Wall clock time:  4.83989715576171875E-004
+(PID.TID 0000.0001)     Wall clock time:   4.4584274291992188E-004
 (PID.TID 0000.0001)          No. starts:          48
 (PID.TID 0000.0001)           No. stops:          48
 (PID.TID 0000.0001)   Seconds in section "MONITOR             [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:  6.00000000000000533E-002
+(PID.TID 0000.0001)           User time:   4.2183637619018555E-002
 (PID.TID 0000.0001)         System time:   0.0000000000000000
-(PID.TID 0000.0001)     Wall clock time:  5.68330287933349609E-002
-(PID.TID 0000.0001)          No. starts:           4
-(PID.TID 0000.0001)           No. stops:           4
+(PID.TID 0000.0001)     Wall clock time:   4.2183637619018555E-002
+(PID.TID 0000.0001)          No. starts:          48
+(PID.TID 0000.0001)           No. stops:          48
 (PID.TID 0000.0001)   Seconds in section "COST_TILE           [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:   0.0000000000000000
+(PID.TID 0000.0001)           User time:   3.7544965744018555E-004
 (PID.TID 0000.0001)         System time:   0.0000000000000000
-(PID.TID 0000.0001)     Wall clock time:  4.76837158203125000E-004
+(PID.TID 0000.0001)     Wall clock time:   3.7860870361328125E-004
 (PID.TID 0000.0001)          No. starts:          48
 (PID.TID 0000.0001)           No. stops:          48
 (PID.TID 0000.0001)   Seconds in section "DO_THE_MODEL_IO     [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:  9.99999999999801048E-003
-(PID.TID 0000.0001)         System time:  1.00000000000000089E-002
-(PID.TID 0000.0001)     Wall clock time:  2.39498615264892578E-002
+(PID.TID 0000.0001)           User time:   1.1933922767639160E-002
+(PID.TID 0000.0001)         System time:   2.9700025916099548E-003
+(PID.TID 0000.0001)     Wall clock time:   1.4731407165527344E-002
 (PID.TID 0000.0001)          No. starts:          48
 (PID.TID 0000.0001)           No. stops:          48
 (PID.TID 0000.0001)   Seconds in section "DO_WRITE_PICKUP     [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:  9.99999999999801048E-003
-(PID.TID 0000.0001)         System time:   0.0000000000000000
-(PID.TID 0000.0001)     Wall clock time:  2.98545360565185547E-002
+(PID.TID 0000.0001)           User time:   8.4931850433349609E-003
+(PID.TID 0000.0001)         System time:   3.9959996938705444E-003
+(PID.TID 0000.0001)     Wall clock time:   1.2484312057495117E-002
 (PID.TID 0000.0001)          No. starts:          48
 (PID.TID 0000.0001)           No. stops:          48
-(PID.TID 0000.0001)   Seconds in section "COST_FORCING       [ECCO SPIN-DOWN]":
-(PID.TID 0000.0001)           User time:   0.0000000000000000
-(PID.TID 0000.0001)         System time:   0.0000000000000000
-(PID.TID 0000.0001)     Wall clock time:  1.13010406494140625E-004
-(PID.TID 0000.0001)          No. starts:          11
-(PID.TID 0000.0001)           No. stops:          11
-(PID.TID 0000.0001)   Seconds in section "COST_HYD           [ECCO SPIN-DOWN]":
-(PID.TID 0000.0001)           User time:  0.21999999999999886
-(PID.TID 0000.0001)         System time:  9.99999999999998113E-003
-(PID.TID 0000.0001)     Wall clock time:  0.21263599395751953
-(PID.TID 0000.0001)          No. starts:          11
-(PID.TID 0000.0001)           No. stops:          11
 (PID.TID 0000.0001)   Seconds in section "COST_OBCS          [ECCO SPIN-DOWN]":
-(PID.TID 0000.0001)           User time:  2.00000000000031264E-002
-(PID.TID 0000.0001)         System time:  1.00000000000000089E-002
-(PID.TID 0000.0001)     Wall clock time:  5.42600154876708984E-002
-(PID.TID 0000.0001)          No. starts:          11
-(PID.TID 0000.0001)           No. stops:          11
-(PID.TID 0000.0001)   Seconds in section "COST_INTERNAL_PARAMS  [ECCO SPIN-DOWN]":
-(PID.TID 0000.0001)           User time:   0.0000000000000000
-(PID.TID 0000.0001)         System time:   0.0000000000000000
-(PID.TID 0000.0001)     Wall clock time:  1.06811523437500000E-004
+(PID.TID 0000.0001)           User time:   1.7777919769287109E-002
+(PID.TID 0000.0001)         System time:   3.0029989778995514E-002
+(PID.TID 0000.0001)     Wall clock time:   4.7825098037719727E-002
 (PID.TID 0000.0001)          No. starts:          11
 (PID.TID 0000.0001)           No. stops:          11
 (PID.TID 0000.0001)   Seconds in section "COST_GENCOST_ALL    [ECCO SPIN-DOWN]":
-(PID.TID 0000.0001)           User time:   0.0000000000000000
-(PID.TID 0000.0001)         System time:   0.0000000000000000
-(PID.TID 0000.0001)     Wall clock time:  1.08003616333007813E-004
+(PID.TID 0000.0001)           User time:  0.22885274887084961
+(PID.TID 0000.0001)         System time:   2.5987990200519562E-002
+(PID.TID 0000.0001)     Wall clock time:  0.25745701789855957
 (PID.TID 0000.0001)          No. starts:          11
 (PID.TID 0000.0001)           No. stops:          11
-(PID.TID 0000.0001)   Seconds in section "COST_USERCOST_ALL    [ECCO SPIN-DOWN]":
-(PID.TID 0000.0001)           User time:   0.0000000000000000
-(PID.TID 0000.0001)         System time:   0.0000000000000000
-(PID.TID 0000.0001)     Wall clock time:  1.05142593383789063E-004
-(PID.TID 0000.0001)          No. starts:          11
-(PID.TID 0000.0001)           No. stops:          11
-(PID.TID 0000.0001)   Seconds in section "COST_GENCTRL       [ECCO SPIN-DOWN]":
-(PID.TID 0000.0001)           User time:   0.0000000000000000
-(PID.TID 0000.0001)         System time:   0.0000000000000000
-(PID.TID 0000.0001)     Wall clock time:  1.06573104858398438E-004
+(PID.TID 0000.0001)   Seconds in section "CTRL_COST_DRIVER [ECCO SPIN-DOWN]":
+(PID.TID 0000.0001)           User time:   2.8175115585327148E-002
+(PID.TID 0000.0001)         System time:   2.8380155563354492E-003
+(PID.TID 0000.0001)     Wall clock time:   3.1032562255859375E-002
 (PID.TID 0000.0001)          No. starts:          11
 (PID.TID 0000.0001)           No. stops:          11
 (PID.TID 0000.0001)   Seconds in section "CTRL_PACK           [THE_MODEL_MAIN]":
-(PID.TID 0000.0001)           User time:  1.99999999999995737E-002
-(PID.TID 0000.0001)         System time:   0.0000000000000000
-(PID.TID 0000.0001)     Wall clock time:  3.45079898834228516E-002
+(PID.TID 0000.0001)           User time:   9.2258453369140625E-003
+(PID.TID 0000.0001)         System time:   8.0330073833465576E-003
+(PID.TID 0000.0001)     Wall clock time:   1.7266035079956055E-002
 (PID.TID 0000.0001)          No. starts:           1
 (PID.TID 0000.0001)           No. stops:           1
 (PID.TID 0000.0001)   Seconds in section "CTRL_PACK     [THE_MODEL_MAIN]":
-(PID.TID 0000.0001)           User time:  2.00000000000013500E-002
-(PID.TID 0000.0001)         System time:  1.00000000000000089E-002
-(PID.TID 0000.0001)     Wall clock time:  2.06811428070068359E-002
+(PID.TID 0000.0001)           User time:   4.8122406005859375E-003
+(PID.TID 0000.0001)         System time:   8.0260038375854492E-003
+(PID.TID 0000.0001)     Wall clock time:   1.2844085693359375E-002
 (PID.TID 0000.0001)          No. starts:           1
 (PID.TID 0000.0001)           No. stops:           1
 (PID.TID 0000.0001)   Seconds in section "GRDCHK_MAIN         [THE_MODEL_MAIN]":
-(PID.TID 0000.0001)           User time:   22.919999999999995
-(PID.TID 0000.0001)         System time:  4.99999999999999889E-002
-(PID.TID 0000.0001)     Wall clock time:   23.047086954116821
+(PID.TID 0000.0001)           User time:   25.919136047363281
+(PID.TID 0000.0001)         System time:  0.10770997405052185
+(PID.TID 0000.0001)     Wall clock time:   26.059946060180664
 (PID.TID 0000.0001)          No. starts:           1
 (PID.TID 0000.0001)           No. stops:           1
 (PID.TID 0000.0001)   Seconds in section "INITIALISE_VARIA    [THE_MAIN_LOOP]":
-(PID.TID 0000.0001)           User time:  0.67999999999999972
-(PID.TID 0000.0001)         System time:  2.00000000000000178E-002
-(PID.TID 0000.0001)     Wall clock time:  0.70116829872131348
+(PID.TID 0000.0001)           User time:   2.4889745712280273
+(PID.TID 0000.0001)         System time:   4.0027976036071777E-002
+(PID.TID 0000.0001)     Wall clock time:   2.5296847820281982
 (PID.TID 0000.0001)          No. starts:          10
 (PID.TID 0000.0001)           No. stops:          10
 (PID.TID 0000.0001)   Seconds in section "MAIN LOOP           [THE_MAIN_LOOP]":
-(PID.TID 0000.0001)           User time:   22.219999999999999
-(PID.TID 0000.0001)         System time:  2.99999999999999711E-002
-(PID.TID 0000.0001)     Wall clock time:   22.308402061462402
+(PID.TID 0000.0001)           User time:   23.420961380004883
+(PID.TID 0000.0001)         System time:   5.8989942073822021E-002
+(PID.TID 0000.0001)     Wall clock time:   23.512380838394165
 (PID.TID 0000.0001)          No. starts:          10
 (PID.TID 0000.0001)           No. stops:          10
 (PID.TID 0000.0001)   Seconds in section "COST_AVERAGESFIELDS [MAIN_DO_LOOP]":
-(PID.TID 0000.0001)           User time:  0.19000000000000483
-(PID.TID 0000.0001)         System time:   0.0000000000000000
-(PID.TID 0000.0001)     Wall clock time:  0.18974518775939941
+(PID.TID 0000.0001)           User time:  0.71129608154296875
+(PID.TID 0000.0001)         System time:   5.9008598327636719E-005
+(PID.TID 0000.0001)     Wall clock time:  0.71154856681823730
 (PID.TID 0000.0001)          No. starts:          40
 (PID.TID 0000.0001)           No. stops:          40
 (PID.TID 0000.0001)   Seconds in section "MAIN_DO_LOOP        [THE_MAIN_LOOP]":
-(PID.TID 0000.0001)           User time:   20.900000000000006
-(PID.TID 0000.0001)         System time:  1.99999999999999900E-002
-(PID.TID 0000.0001)     Wall clock time:   20.960688352584839
+(PID.TID 0000.0001)           User time:   21.645304679870605
+(PID.TID 0000.0001)         System time:   4.0580034255981445E-003
+(PID.TID 0000.0001)     Wall clock time:   21.654401779174805
 (PID.TID 0000.0001)          No. starts:          40
 (PID.TID 0000.0001)           No. stops:          40
 (PID.TID 0000.0001)   Seconds in section "COST_AVERAGESFIELDS [THE_MAIN_LOOP]":
-(PID.TID 0000.0001)           User time:  0.14000000000000057
-(PID.TID 0000.0001)         System time:   0.0000000000000000
-(PID.TID 0000.0001)     Wall clock time:  0.15532040596008301
+(PID.TID 0000.0001)           User time:  0.19194126129150391
+(PID.TID 0000.0001)         System time:   1.1926949024200439E-002
+(PID.TID 0000.0001)     Wall clock time:  0.23081183433532715
 (PID.TID 0000.0001)          No. starts:          10
 (PID.TID 0000.0001)           No. stops:          10
 (PID.TID 0000.0001)   Seconds in section "ECCO_COST_DRIVER   [THE_MAIN_LOOP]":
-(PID.TID 0000.0001)           User time:  0.21999999999999886
-(PID.TID 0000.0001)         System time:  9.99999999999998113E-003
-(PID.TID 0000.0001)     Wall clock time:  0.23935008049011230
+(PID.TID 0000.0001)           User time:  0.25743865966796875
+(PID.TID 0000.0001)         System time:   4.2616009712219238E-002
+(PID.TID 0000.0001)     Wall clock time:  0.30019593238830566
 (PID.TID 0000.0001)          No. starts:          10
 (PID.TID 0000.0001)           No. stops:          10
 (PID.TID 0000.0001)   Seconds in section "COST_FINAL         [ADJOINT SPIN-DOWN]":
-(PID.TID 0000.0001)           User time:   0.0000000000000000
-(PID.TID 0000.0001)         System time:   0.0000000000000000
-(PID.TID 0000.0001)     Wall clock time:  6.52647018432617188E-003
+(PID.TID 0000.0001)           User time:   1.8711090087890625E-003
+(PID.TID 0000.0001)         System time:   2.5099515914916992E-004
+(PID.TID 0000.0001)     Wall clock time:   2.1207332611083984E-003
 (PID.TID 0000.0001)          No. starts:          10
 (PID.TID 0000.0001)           No. stops:          10
 (PID.TID 0000.0001) // ======================================================
@@ -4496,9 +4055,9 @@ grad-res -------------------------------
 (PID.TID 0000.0001) //          Total. Y spins =              0
 (PID.TID 0000.0001) //            Avg. Y spins =       0.00E+00
 (PID.TID 0000.0001) // o Thread number: 000001
-(PID.TID 0000.0001) //            No. barriers =          46366
+(PID.TID 0000.0001) //            No. barriers =          47988
 (PID.TID 0000.0001) //      Max. barrier spins =              1
 (PID.TID 0000.0001) //      Min. barrier spins =              1
-(PID.TID 0000.0001) //     Total barrier spins =          46366
+(PID.TID 0000.0001) //     Total barrier spins =          47988
 (PID.TID 0000.0001) //      Avg. barrier spins =       1.00E+00
 PROGRAM MAIN: Execution ended Normally

--- a/verification/offline_exf_seaice/input_ad.thsice/data
+++ b/verification/offline_exf_seaice/input_ad.thsice/data
@@ -56,6 +56,7 @@
  nTimeSteps=60,
 #monitorFreq=1.,
 #dumpFreq = 1.,
+ adjMonitorFreq= 86400.,
  &
 
 # Gridding parameters

--- a/verification/offline_exf_seaice/input_ad.thsice/tr_checklist.adm
+++ b/verification/offline_exf_seaice/input_ad.thsice/tr_checklist.adm
@@ -1,0 +1,1 @@
+admGrd admCst admGrd admFwd T+ S+ U+ V+

--- a/verification/offline_exf_seaice/input_ad/data
+++ b/verification/offline_exf_seaice/input_ad/data
@@ -46,16 +46,15 @@
  &PARM03
  startTime=0.0,
 #endTime=864000.,
+ nTimeSteps=120,
  deltaT=3600.0,
  abEps=0.1,
  forcing_In_AB = .FALSE.,
- pChkptFreq=3600000.,
- monitorFreq=432000.,
- monitorSelect=2,
-#dumpFreq = 86400.,
- nTimeSteps=120,
-#monitorFreq=1.,
-#dumpFreq = 1.,
+ pChkptFreq=5184000.,
+#dumpFreq = 864000.,
+ monitorSelect = 2,
+ monitorFreq =  216000.,
+ adjMonitorFreq= 86400.,
  &
 
 # Gridding parameters

--- a/verification/offline_exf_seaice/input_ad/data.diagnostics
+++ b/verification/offline_exf_seaice/input_ad/data.diagnostics
@@ -38,11 +38,12 @@
 #                  'SIflxAtm','SIfrwAtm',
 #                  'EXFqnet ','EXFempmr',
 #- with pkg/seaice:
-  fields(1:10,2) = 'SIarea  ','SIheff  ','THETA   ','SItices ',
+  fields(1:8,2)  = 'SIarea  ','SIheff  ','THETA   ','SItices ',
 #                  'SIuice  ','SIvice  ','SIhsnow ',
 #                  'oceQnet ','oceQsw  ','oceFWflx','oceSflux',
                    'SIqnet  ','SIqsw   ','SIempmr ','oceSflux',
-                   'SIatmQnt','SIatmFW ',
+#- comment out SIatmQnt (not filled in seaice_growth_adx.F):
+#                  'SIatmQnt','SIatmFW ',
    fileName(2) = 'iceDiag',
   frequency(2) =  86400.,
   missing_value(2) = -999.,
@@ -83,11 +84,12 @@
 #                      'SIflxAtm','SIfrwAtm',
 #- with pkg/seaice:
 #stat_fields(1:11,1) = 'SIarea  ','SIheff  ','SIhsnow ',
- stat_fields(1:10,1) = 'SIarea  ','SIheff  ',
+ stat_fields(1:8,1)  = 'SIarea  ','SIheff  ',
                        'THETA   ','SItices ',
 #                      'oceQnet ','oceQsw  ','oceFWflx','oceSflux',
                        'SIqnet  ','SIqsw   ','SIempmr ','oceSflux',
-                       'SIatmQnt','SIatmFW ',
+#- comment out SIatmQnt (not filled in seaice_growth_adx.F):
+#                      'SIatmQnt','SIatmFW ',
   stat_fName(1) = 'iceStDiag',
    stat_freq(1) = 43200.,
   stat_phase(1) = 3600.,

--- a/verification/offline_exf_seaice/input_ad/tr_checklist.adm
+++ b/verification/offline_exf_seaice/input_ad/tr_checklist.adm
@@ -1,0 +1,1 @@
+admGrd admCst admGrd admFwd T+ S+ aSI+ hSI+ uSI+ vSI+

--- a/verification/offline_exf_seaice/results/output_adm.thsice.txt
+++ b/verification/offline_exf_seaice/results/output_adm.thsice.txt
@@ -5,10 +5,10 @@
 (PID.TID 0000.0001) // ======================================================
 (PID.TID 0000.0001) // execution environment starting up...
 (PID.TID 0000.0001) 
-(PID.TID 0000.0001) // MITgcmUV version:  checkpoint64s
-(PID.TID 0000.0001) // Build user:        jmc
-(PID.TID 0000.0001) // Build host:        baudelaire
-(PID.TID 0000.0001) // Build date:        Fri Jan 31 10:23:12 EST 2014
+(PID.TID 0000.0001) // MITgcmUV version:  checkpoint67w
+(PID.TID 0000.0001) // Build user:        jm_c
+(PID.TID 0000.0001) // Build host:        villon
+(PID.TID 0000.0001) // Build date:        Tue Apr 13 00:59:56 EDT 2021
 (PID.TID 0000.0001) 
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // Execution Environment parameter file "eedata"
@@ -48,8 +48,10 @@
 (PID.TID 0000.0001)                   /*  note: To execute a program with MPI calls */
 (PID.TID 0000.0001)                   /*  it must be launched appropriately e.g     */
 (PID.TID 0000.0001)                   /*  "mpirun -np 64 ......"                    */
-(PID.TID 0000.0001) useCoupler=    F ;/* Flag used to control communications with   */
+(PID.TID 0000.0001) useCoupler=   F ; /* Flag used to control communications with   */
 (PID.TID 0000.0001)                   /*  other model components, through a coupler */
+(PID.TID 0000.0001) useNest2W_parent =    F ;/* Control 2-W Nesting comm */
+(PID.TID 0000.0001) useNest2W_child  =    F ;/* Control 2-W Nesting comm */
 (PID.TID 0000.0001) debugMode =    F ; /* print debug msg. (sequence of S/R calls)  */
 (PID.TID 0000.0001) printMapIncludesZeros=    F ; /* print zeros in Std.Output maps */
 (PID.TID 0000.0001) maxLengthPrt1D=   65 /* maxLength of 1D array printed to StdOut */
@@ -162,6 +164,7 @@
 (PID.TID 0000.0001) > nTimeSteps=60,
 (PID.TID 0000.0001) >#monitorFreq=1.,
 (PID.TID 0000.0001) >#dumpFreq = 1.,
+(PID.TID 0000.0001) > adjMonitorFreq= 86400.,
 (PID.TID 0000.0001) > /
 (PID.TID 0000.0001) >
 (PID.TID 0000.0001) ># Gridding parameters
@@ -207,6 +210,7 @@
 (PID.TID 0000.0001) ># Packages
 (PID.TID 0000.0001) > &PACKAGES
 (PID.TID 0000.0001) >  useEXF    = .TRUE.,
+(PID.TID 0000.0001) >  useCAL    = .TRUE.,
 (PID.TID 0000.0001) >  useSEAICE = .FALSE.,
 (PID.TID 0000.0001) >  useThSIce = .TRUE.,
 (PID.TID 0000.0001) ># useDiagnostics=.TRUE.,
@@ -218,7 +222,9 @@
  --------  pkgs with a standard "usePKG" On/Off switch in "data.pkg":  --------
  pkg/cal                  compiled   and   used ( useCAL                   = T )
  pkg/exf                  compiled   and   used ( useEXF                   = T )
+ pkg/autodiff             compiled   and   used ( useAUTODIFF              = T )
  pkg/grdchk               compiled   and   used ( useGrdchk                = T )
+ pkg/ctrl                 compiled   and   used ( useCTRL                  = T )
  pkg/seaice               compiled but not used ( useSEAICE                = F )
  pkg/thsice               compiled   and   used ( useThSIce                = T )
  pkg/diagnostics          compiled but not used ( useDiagnostics           = F )
@@ -233,7 +239,6 @@
  pkg/mdsio                compiled   and   used
  pkg/autodiff             compiled   and   used
  pkg/cost                 compiled   and   used
- pkg/ctrl                 compiled   and   used
 (PID.TID 0000.0001)  PACKAGES_BOOT: End of package Summary
 (PID.TID 0000.0001) 
 (PID.TID 0000.0001) CAL_READPARMS: opening data.cal
@@ -475,6 +480,9 @@
 (PID.TID 0000.0001) inAdExact = /* get an exact adjoint (no approximation) */
 (PID.TID 0000.0001)                   T
 (PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) useApproxAdvectionInAdMode = /* approximate AD-advection */
+(PID.TID 0000.0001)                   F
+(PID.TID 0000.0001)     ;
 (PID.TID 0000.0001) useKPPinAdMode = /* use KPP in adjoint mode */
 (PID.TID 0000.0001)                   F
 (PID.TID 0000.0001)     ;
@@ -496,11 +504,26 @@
 (PID.TID 0000.0001) SEAICEuseFREEDRIFTswitchInAd= /* switch On/Off Free-Drift in AD mode */
 (PID.TID 0000.0001)                   F
 (PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) SEAICEapproxLevInAd = /* -1:SEAICE_FAKE, >0:other adjoint approximation */
+(PID.TID 0000.0001)                       0
+(PID.TID 0000.0001)     ;
 (PID.TID 0000.0001) dumpAdVarExch = /* control adexch before dumpinp */
 (PID.TID 0000.0001)                       2
 (PID.TID 0000.0001)     ;
 (PID.TID 0000.0001) mon_AdVarExch = /* control adexch before monitor */
 (PID.TID 0000.0001)                       2
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) viscFacInFw = /* viscosity factor for forward model */
+(PID.TID 0000.0001)                 1.000000000000000E+00
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) viscFacInAd = /* viscosity factor for adjoint */
+(PID.TID 0000.0001)                 1.000000000000000E+00
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) SIregFacInAd = /* sea ice factor for adjoint model */
+(PID.TID 0000.0001)                 1.234567000000000E+05
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) SIregFacInFw = /* sea ice factor for forward model */
+(PID.TID 0000.0001)                 1.234567000000000E+05
 (PID.TID 0000.0001)     ;
 (PID.TID 0000.0001) 
 (PID.TID 0000.0001) OPTIM_READPARMS: opening data.optim
@@ -522,14 +545,35 @@
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // Parameter file "data.ctrl"
 (PID.TID 0000.0001) // =======================================================
-(PID.TID 0000.0001) > &ctrl_nml
+(PID.TID 0000.0001) ># *********************
+(PID.TID 0000.0001) ># general parameters and
+(PID.TID 0000.0001) ># non-default ECCO legacy control variables
+(PID.TID 0000.0001) ># *********************
+(PID.TID 0000.0001) > &CTRL_NML
 (PID.TID 0000.0001) >  doMainUnpack=.FALSE.,
 (PID.TID 0000.0001) >  doMainPack=.FALSE.,
+(PID.TID 0000.0001) >  ctrlprec = 32,
 (PID.TID 0000.0001) > /
 (PID.TID 0000.0001) >#
-(PID.TID 0000.0001) > &ctrl_packnames
+(PID.TID 0000.0001) ># *********************
+(PID.TID 0000.0001) ># names for ctrl_pack/unpack
+(PID.TID 0000.0001) ># *********************
+(PID.TID 0000.0001) > &CTRL_PACKNAMES
 (PID.TID 0000.0001) > /
-(PID.TID 0000.0001) >
+(PID.TID 0000.0001) >#
+(PID.TID 0000.0001) ># *********************
+(PID.TID 0000.0001) ># names for CTRL_GENARR, CTRL_GENTIM
+(PID.TID 0000.0001) ># *********************
+(PID.TID 0000.0001) > &CTRL_NML_GENARR
+(PID.TID 0000.0001) > xx_gentim2d_file(1)       = 'xx_atemp',
+(PID.TID 0000.0001) > xx_gentim2d_weight(1)     = 'ones_32b.bin',
+(PID.TID 0000.0001) >#
+(PID.TID 0000.0001) > xx_gentim2d_file(2)       = 'xx_swdown',
+(PID.TID 0000.0001) > xx_gentim2d_weight(2)     = 'ones_32b.bin',
+(PID.TID 0000.0001) >#
+(PID.TID 0000.0001) > xx_genarr3d_file(1)       = 'xx_theta',
+(PID.TID 0000.0001) > xx_genarr3d_weight(1)     = 'ones_32b.bin',
+(PID.TID 0000.0001) > /
 (PID.TID 0000.0001) 
 (PID.TID 0000.0001) CTRL_READPARMS: finished reading data.ctrl
 (PID.TID 0000.0001) COST_READPARMS: opening data.cost
@@ -557,8 +601,11 @@
 (PID.TID 0000.0001) > nend             = 4,
 (PID.TID 0000.0001) >#(grdchkvarindex   = 1 fails at freezing point)
 (PID.TID 0000.0001) >#grdchkvarindex   = 1,
-(PID.TID 0000.0001) > grdchkvarindex   = 7,
-(PID.TID 0000.0001) >#grdchkvarindex   = 34,
+(PID.TID 0000.0001) ># this is xx_atemp
+(PID.TID 0000.0001) ># grdchkvarindex   = 7,
+(PID.TID 0000.0001) ># to test this with xx_gentim2d set 301, because xx_atemp is
+(PID.TID 0000.0001) ># our first control variable (see data.ctrl)
+(PID.TID 0000.0001) > grdchkvarindex   = 301,
 (PID.TID 0000.0001) > /
 (PID.TID 0000.0001) 
 (PID.TID 0000.0001) GRDCHK_READPARMS: finished reading data.grdchk
@@ -567,6 +614,7 @@
 (PID.TID 0000.0001) // Gradient check configuration  >>> START <<<
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) 
+(PID.TID 0000.0001)   grdchkvarindex :                        301
 (PID.TID 0000.0001)   eps:                              0.100E-01
 (PID.TID 0000.0001)   First location:                           1
 (PID.TID 0000.0001)   Last location:                            4
@@ -663,7 +711,7 @@
 (PID.TID 0000.0001) modelend  = /* End time of the model integration [s] */
 (PID.TID 0000.0001)                 2.160000000000000E+05
 (PID.TID 0000.0001)     ;
-(PID.TID 0000.0001) modelstep = /* Time interval for a model forward step [s] */
+(PID.TID 0000.0001) modelStep = /* Time interval for a model forward step [s] */
 (PID.TID 0000.0001)                 3.600000000000000E+03
 (PID.TID 0000.0001)     ;
 (PID.TID 0000.0001) usingGregorianCalendar= /* Calendar Type: Gregorian Calendar */
@@ -672,19 +720,22 @@
 (PID.TID 0000.0001) usingJulianCalendar = /* Calendar Type: Julian Calendar */
 (PID.TID 0000.0001)                   F
 (PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) usingNoLeapYearCal  = /* Calendar Type: without Leap Year */
+(PID.TID 0000.0001)                   F
+(PID.TID 0000.0001)     ;
 (PID.TID 0000.0001) usingModelCalendar  = /* Calendar Type: Model Calendar */
 (PID.TID 0000.0001)                   F
 (PID.TID 0000.0001)     ;
-(PID.TID 0000.0001) modelstartdate YYYYMMDD = /* Model start date YYYY-MM-DD */
+(PID.TID 0000.0001) modelStartDate YYYYMMDD = /* Model start date YYYY-MM-DD */
 (PID.TID 0000.0001)                19790101
 (PID.TID 0000.0001)     ;
-(PID.TID 0000.0001)   modelstartdate HHMMSS = /* Model start date HH-MM-SS  */
+(PID.TID 0000.0001)   modelStartDate HHMMSS = /* Model start date HH-MM-SS  */
 (PID.TID 0000.0001)                       0
 (PID.TID 0000.0001)     ;
-(PID.TID 0000.0001) modelenddate   YYYYMMDD = /* Model end date YYYY-MM-DD */
+(PID.TID 0000.0001) modelEndDate   YYYYMMDD = /* Model end date YYYY-MM-DD */
 (PID.TID 0000.0001)                19790103
 (PID.TID 0000.0001)     ;
-(PID.TID 0000.0001)   modelenddate   HHMMSS = /* Model end date HH-MM-SS  */
+(PID.TID 0000.0001)   modelEndDate   HHMMSS = /* Model end date HH-MM-SS  */
 (PID.TID 0000.0001)                  120000
 (PID.TID 0000.0001)     ;
 (PID.TID 0000.0001) intyears = /* Number of calendar years affected by the integration */
@@ -696,13 +747,13 @@
 (PID.TID 0000.0001) intdays = /* Number of calendar days affected by the integration */
 (PID.TID 0000.0001)                       3
 (PID.TID 0000.0001)     ;
-(PID.TID 0000.0001) modeliter0 = /* Base timestep number  */
+(PID.TID 0000.0001) modelIter0 = /* Base timestep number  */
 (PID.TID 0000.0001)                       0
 (PID.TID 0000.0001)     ;
-(PID.TID 0000.0001) modeliterend = /* Final timestep number  */
+(PID.TID 0000.0001) modelIterEnd = /* Final timestep number  */
 (PID.TID 0000.0001)                      60
 (PID.TID 0000.0001)     ;
-(PID.TID 0000.0001) modelintsteps= /* Number of model timesteps  */
+(PID.TID 0000.0001) modelIntSteps= /* Number of model timesteps  */
 (PID.TID 0000.0001)                      60
 (PID.TID 0000.0001)     ;
 (PID.TID 0000.0001) 
@@ -768,13 +819,16 @@
 (PID.TID 0000.0001) twoDigitYear = /* use 2-digit year extension */
 (PID.TID 0000.0001)                   F
 (PID.TID 0000.0001)     ;
-(PID.TID 0000.0001) exf_verbose = /* print more messages to STDOUT */
-(PID.TID 0000.0001)                   F
-(PID.TID 0000.0001)     ;
 (PID.TID 0000.0001) useExfCheckRange = /* check for fields range */
 (PID.TID 0000.0001)                   T
 (PID.TID 0000.0001)     ;
-(PID.TID 0000.0001) exf_monFreq = /* EXF monitor frequency [ s ] */
+(PID.TID 0000.0001) diags_opOceWeighted = /* weight flux diags by open-ocean fraction */
+(PID.TID 0000.0001)                   T
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) exf_debugLev = /* select EXF-debug printing level */
+(PID.TID 0000.0001)                       1
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) exf_monFreq  = /* EXF monitor frequency [ s ] */
 (PID.TID 0000.0001)                 8.640000000000000E+07
 (PID.TID 0000.0001)     ;
 (PID.TID 0000.0001) repeatPeriod = /* period for cycling forcing dataset [ s ] */
@@ -787,6 +841,9 @@
 (PID.TID 0000.0001)                 2.000000000000000E+00
 (PID.TID 0000.0001)     ;
 (PID.TID 0000.0001) stressIsOnCgrid = /* set u,v_stress on Arakawa C-grid */
+(PID.TID 0000.0001)                   F
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) rotateStressOnAgrid = /* rotate u,v_stress on Arakawa A-grid */
 (PID.TID 0000.0001)                   F
 (PID.TID 0000.0001)     ;
 (PID.TID 0000.0001) cen2kel = /* conversion of deg. Centigrade to Kelvin [K] */
@@ -918,81 +975,62 @@
 (PID.TID 0000.0001) // ALLOW_DOWNWARD_RADIATION:           defined
 (PID.TID 0000.0001) // ALLOW_BULKFORMULAE:                 defined
 (PID.TID 0000.0001) 
-(PID.TID 0000.0001)    Net shortwave flux forcing starts at                0.
-(PID.TID 0000.0001)    Net shortwave flux forcing period is                0.
-(PID.TID 0000.0001)    Net shortwave flux forcing is read from file:
-(PID.TID 0000.0001)    >>    <<
-(PID.TID 0000.0001) 
 (PID.TID 0000.0001)    Zonal wind forcing starts at                   -1317600.
 (PID.TID 0000.0001)    Zonal wind forcing period is                    2635200.
+(PID.TID 0000.0001)    Zonal wind forcing repeat-cycle is              2635200.
 (PID.TID 0000.0001)    Zonal wind forcing is read from file:
-(PID.TID 0000.0001)    >>  windx.bin  <<
-(PID.TID 0000.0001) 
-(PID.TID 0000.0001)    Meridional wind forcing starts at                     0.
-(PID.TID 0000.0001)    Meridional wind forcing period is               2635200.
-(PID.TID 0000.0001)    Meridional wind forcing is read from file:
-(PID.TID 0000.0001)    >>    <<
+(PID.TID 0000.0001)    >> windx.bin <<
 (PID.TID 0000.0001) 
 (PID.TID 0000.0001)    Atmospheric temperature starts at              -1317600.
 (PID.TID 0000.0001)    Atmospheric temperature period is               2635200.
+(PID.TID 0000.0001)    Atmospheric temperature repeat-cycle is         2635200.
 (PID.TID 0000.0001)    Atmospheric temperature is read from file:
-(PID.TID 0000.0001)    >>  tair_4x.bin  <<
+(PID.TID 0000.0001)    >> tair_4x.bin <<
 (PID.TID 0000.0001) 
 (PID.TID 0000.0001)    Atmospheric specific humidity starts at        -1317600.
 (PID.TID 0000.0001)    Atmospheric specific humidity period is         2635200.
+(PID.TID 0000.0001)    Atmospheric specific humidity rep-cycle is      2635200.
 (PID.TID 0000.0001)    Atmospheric specific humidity is read from file:
-(PID.TID 0000.0001)    >>  qa70_4x.bin  <<
+(PID.TID 0000.0001)    >> qa70_4x.bin <<
 (PID.TID 0000.0001) 
-(PID.TID 0000.0001)    Net longwave flux forcing starts at                 0.
-(PID.TID 0000.0001)    Net longwave flux forcing period is                 0.
-(PID.TID 0000.0001)    Net longwave flux forcing is read from file:
-(PID.TID 0000.0001)    >>    <<
-(PID.TID 0000.0001) 
-(PID.TID 0000.0001)    Precipitation data set starts at               -1317600.
-(PID.TID 0000.0001)    Precipitation data period is                    2635200.
-(PID.TID 0000.0001)    Precipitation data is read from file:
-(PID.TID 0000.0001)    >>  const_00.bin  <<
-(PID.TID 0000.0001) 
+(PID.TID 0000.0001) // ALLOW_READ_TURBFLUXES:          NOT defined
 (PID.TID 0000.0001) // EXF_READ_EVAP:                  NOT defined
 (PID.TID 0000.0001) 
+(PID.TID 0000.0001)    Precipitation data starts at                   -1317600.
+(PID.TID 0000.0001)    Precipitation data period is                    2635200.
+(PID.TID 0000.0001)    Precipitation data repeat-cycle is              2635200.
+(PID.TID 0000.0001)    Precipitation data is read from file:
+(PID.TID 0000.0001)    >> const_00.bin <<
+(PID.TID 0000.0001) 
 (PID.TID 0000.0001) // ALLOW_RUNOFF:                       defined
-(PID.TID 0000.0001)    Runoff starts at               0.
-(PID.TID 0000.0001)    Runoff period is               0.
-(PID.TID 0000.0001)    Runoff is read from file:
-(PID.TID 0000.0001)    >>    <<
 (PID.TID 0000.0001) // ALLOW_RUNOFTEMP:                NOT defined
+(PID.TID 0000.0001) // ALLOW_SALTFLX:                  NOT defined
 (PID.TID 0000.0001) 
-(PID.TID 0000.0001)    Downward shortwave flux forcing starts at         -1317600.
-(PID.TID 0000.0001)    Downward shortwave flux forcing period is          2635200.
-(PID.TID 0000.0001)    Downward shortwave flux forcing is read from file:
-(PID.TID 0000.0001)    >>  dsw_100.bin  <<
+(PID.TID 0000.0001)    Downward shortwave flux starts at              -1317600.
+(PID.TID 0000.0001)    Downward shortwave flux period is               2635200.
+(PID.TID 0000.0001)    Downward shortwave flux repeat-cycle is         2635200.
+(PID.TID 0000.0001)    Downward shortwave flux is read from file:
+(PID.TID 0000.0001)    >> dsw_100.bin <<
 (PID.TID 0000.0001) 
-(PID.TID 0000.0001)    Downward longwave flux forcing starts at          -1317600.
-(PID.TID 0000.0001)    Downward longwave flux forcing period is           2635200.
-(PID.TID 0000.0001)    Downward longwave flux forcing is read from file:
-(PID.TID 0000.0001)    >>  dlw_250.bin  <<
-(PID.TID 0000.0001) 
-(PID.TID 0000.0001)    Atmospheric pressure forcing starts at                0.
-(PID.TID 0000.0001)    Atmospheric pressure forcing period is                0.
-(PID.TID 0000.0001)    Atmospheric pressureforcing is read from file:
-(PID.TID 0000.0001)    >>    <<
+(PID.TID 0000.0001)    Downward longwave flux starts at               -1317600.
+(PID.TID 0000.0001)    Downward longwave flux period is                2635200.
+(PID.TID 0000.0001)    Downward longwave flux repeat-cycle is          2635200.
+(PID.TID 0000.0001)    Downward longwave flux is read from file:
+(PID.TID 0000.0001)    >> dlw_250.bin <<
 (PID.TID 0000.0001) 
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // External forcing (EXF) climatology configuration :
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) 
 (PID.TID 0000.0001) // ALLOW_CLIMSST_RELAXATION:           defined
-(PID.TID 0000.0001) // ALLOW_CLIMSSS_RELAXATION:           defined
-(PID.TID 0000.0001) 
-(PID.TID 0000.0001)    Climatological SST starts at            -1317600.
-(PID.TID 0000.0001)    Climatological SST period is             2635200.
+(PID.TID 0000.0001)    Climatological SST starts at                   -1317600.
+(PID.TID 0000.0001)    Climatological SST period is                    2635200.
+(PID.TID 0000.0001)    Climatological SST repeat-cycle is              2635200.
 (PID.TID 0000.0001)    Climatological SST is read from file:
-(PID.TID 0000.0001)    >>  tocn.bin  <<
+(PID.TID 0000.0001)    >> tocn.bin <<
 (PID.TID 0000.0001) 
-(PID.TID 0000.0001)    Climatological SSS starts at                   0.
-(PID.TID 0000.0001)    Climatological SSS period is             2635200.
-(PID.TID 0000.0001)    Climatological SSS is read from file:
-(PID.TID 0000.0001)    >>    <<
+(PID.TID 0000.0001) // ALLOW_CLIMSSS_RELAXATION:           defined
+(PID.TID 0000.0001)    climsss relaxation is NOT used
 (PID.TID 0000.0001) 
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // External forcing (EXF) configuration  >>> END <<<
@@ -1004,13 +1042,13 @@
 (PID.TID 0000.0001) ctrl-wet 4: surface wet S =          760
 (PID.TID 0000.0001) ctrl-wet 4a:surface wet V =            0
 (PID.TID 0000.0001) ctrl-wet 5: 3D wet points =          800
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =     1           1
+(PID.TID 0000.0001) ctrl-wet 6: no recs for i =     1           0
 (PID.TID 0000.0001) ctrl-wet 6: no recs for i =     2           0
 (PID.TID 0000.0001) ctrl-wet 6: no recs for i =     3           0
 (PID.TID 0000.0001) ctrl-wet 6: no recs for i =     4           0
 (PID.TID 0000.0001) ctrl-wet 6: no recs for i =     5           0
 (PID.TID 0000.0001) ctrl-wet 6: no recs for i =     6           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =     7           1
+(PID.TID 0000.0001) ctrl-wet 6: no recs for i =     7           0
 (PID.TID 0000.0001) ctrl-wet 6: no recs for i =     8           0
 (PID.TID 0000.0001) ctrl-wet 6: no recs for i =     9           0
 (PID.TID 0000.0001) ctrl-wet 6: no recs for i =    10           0
@@ -1037,7 +1075,7 @@
 (PID.TID 0000.0001) ctrl-wet 6: no recs for i =    31           0
 (PID.TID 0000.0001) ctrl-wet 6: no recs for i =    32           0
 (PID.TID 0000.0001) ctrl-wet 6: no recs for i =    33           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =    34           1
+(PID.TID 0000.0001) ctrl-wet 6: no recs for i =    34           0
 (PID.TID 0000.0001) ctrl-wet 6: no recs for i =    35           0
 (PID.TID 0000.0001) ctrl-wet 6: no recs for i =    36           0
 (PID.TID 0000.0001) ctrl-wet 6: no recs for i =    37           0
@@ -1064,8 +1102,348 @@
 (PID.TID 0000.0001) ctrl-wet 6: no recs for i =    58           0
 (PID.TID 0000.0001) ctrl-wet 6: no recs for i =    59           0
 (PID.TID 0000.0001) ctrl-wet 6: no recs for i =    60           0
+(PID.TID 0000.0001) ctrl-wet 6: no recs for i =    61           0
+(PID.TID 0000.0001) ctrl-wet 6: no recs for i =    62           0
+(PID.TID 0000.0001) ctrl-wet 6: no recs for i =    63           0
+(PID.TID 0000.0001) ctrl-wet 6: no recs for i =    64           0
+(PID.TID 0000.0001) ctrl-wet 6: no recs for i =    65           0
+(PID.TID 0000.0001) ctrl-wet 6: no recs for i =    66           0
+(PID.TID 0000.0001) ctrl-wet 6: no recs for i =    67           0
+(PID.TID 0000.0001) ctrl-wet 6: no recs for i =    68           0
+(PID.TID 0000.0001) ctrl-wet 6: no recs for i =    69           0
+(PID.TID 0000.0001) ctrl-wet 6: no recs for i =    70           0
+(PID.TID 0000.0001) ctrl-wet 6: no recs for i =    71           0
+(PID.TID 0000.0001) ctrl-wet 6: no recs for i =    72           0
+(PID.TID 0000.0001) ctrl-wet 6: no recs for i =    73           0
+(PID.TID 0000.0001) ctrl-wet 6: no recs for i =    74           0
+(PID.TID 0000.0001) ctrl-wet 6: no recs for i =    75           0
+(PID.TID 0000.0001) ctrl-wet 6: no recs for i =    76           0
+(PID.TID 0000.0001) ctrl-wet 6: no recs for i =    77           0
+(PID.TID 0000.0001) ctrl-wet 6: no recs for i =    78           0
+(PID.TID 0000.0001) ctrl-wet 6: no recs for i =    79           0
+(PID.TID 0000.0001) ctrl-wet 6: no recs for i =    80           0
+(PID.TID 0000.0001) ctrl-wet 6: no recs for i =    81           0
+(PID.TID 0000.0001) ctrl-wet 6: no recs for i =    82           0
+(PID.TID 0000.0001) ctrl-wet 6: no recs for i =    83           0
+(PID.TID 0000.0001) ctrl-wet 6: no recs for i =    84           0
+(PID.TID 0000.0001) ctrl-wet 6: no recs for i =    85           0
+(PID.TID 0000.0001) ctrl-wet 6: no recs for i =    86           0
+(PID.TID 0000.0001) ctrl-wet 6: no recs for i =    87           0
+(PID.TID 0000.0001) ctrl-wet 6: no recs for i =    88           0
+(PID.TID 0000.0001) ctrl-wet 6: no recs for i =    89           0
+(PID.TID 0000.0001) ctrl-wet 6: no recs for i =    90           0
+(PID.TID 0000.0001) ctrl-wet 6: no recs for i =    91           0
+(PID.TID 0000.0001) ctrl-wet 6: no recs for i =    92           0
+(PID.TID 0000.0001) ctrl-wet 6: no recs for i =    93           0
+(PID.TID 0000.0001) ctrl-wet 6: no recs for i =    94           0
+(PID.TID 0000.0001) ctrl-wet 6: no recs for i =    95           0
+(PID.TID 0000.0001) ctrl-wet 6: no recs for i =    96           0
+(PID.TID 0000.0001) ctrl-wet 6: no recs for i =    97           0
+(PID.TID 0000.0001) ctrl-wet 6: no recs for i =    98           0
+(PID.TID 0000.0001) ctrl-wet 6: no recs for i =    99           0
+(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   100           0
+(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   101           0
+(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   102           0
+(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   103           0
+(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   104           0
+(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   105           0
+(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   106           0
+(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   107           0
+(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   108           0
+(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   109           0
+(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   110           0
+(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   111           0
+(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   112           0
+(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   113           0
+(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   114           0
+(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   115           0
+(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   116           0
+(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   117           0
+(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   118           0
+(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   119           0
+(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   120           0
+(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   121           0
+(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   122           0
+(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   123           0
+(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   124           0
+(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   125           0
+(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   126           0
+(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   127           0
+(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   128           0
+(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   129           0
+(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   130           0
+(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   131           0
+(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   132           0
+(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   133           0
+(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   134           0
+(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   135           0
+(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   136           0
+(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   137           0
+(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   138           0
+(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   139           0
+(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   140           0
+(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   141           0
+(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   142           0
+(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   143           0
+(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   144           0
+(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   145           0
+(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   146           0
+(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   147           0
+(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   148           0
+(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   149           0
+(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   150           0
+(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   151           0
+(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   152           0
+(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   153           0
+(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   154           0
+(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   155           0
+(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   156           0
+(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   157           0
+(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   158           0
+(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   159           0
+(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   160           0
+(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   161           0
+(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   162           0
+(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   163           0
+(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   164           0
+(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   165           0
+(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   166           0
+(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   167           0
+(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   168           0
+(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   169           0
+(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   170           0
+(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   171           0
+(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   172           0
+(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   173           0
+(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   174           0
+(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   175           0
+(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   176           0
+(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   177           0
+(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   178           0
+(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   179           0
+(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   180           0
+(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   181           0
+(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   182           0
+(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   183           0
+(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   184           0
+(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   185           0
+(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   186           0
+(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   187           0
+(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   188           0
+(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   189           0
+(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   190           0
+(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   191           0
+(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   192           0
+(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   193           0
+(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   194           0
+(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   195           0
+(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   196           0
+(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   197           0
+(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   198           0
+(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   199           0
+(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   200           0
+(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   201           1
+(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   202           0
+(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   203           0
+(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   204           0
+(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   205           0
+(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   206           0
+(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   207           0
+(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   208           0
+(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   209           0
+(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   210           0
+(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   211           0
+(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   212           0
+(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   213           0
+(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   214           0
+(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   215           0
+(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   216           0
+(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   217           0
+(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   218           0
+(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   219           0
+(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   220           0
+(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   221           0
+(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   222           0
+(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   223           0
+(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   224           0
+(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   225           0
+(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   226           0
+(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   227           0
+(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   228           0
+(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   229           0
+(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   230           0
+(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   231           0
+(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   232           0
+(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   233           0
+(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   234           0
+(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   235           0
+(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   236           0
+(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   237           0
+(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   238           0
+(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   239           0
+(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   240           0
+(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   241           0
+(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   242           0
+(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   243           0
+(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   244           0
+(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   245           0
+(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   246           0
+(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   247           0
+(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   248           0
+(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   249           0
+(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   250           0
+(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   251           0
+(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   252           0
+(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   253           0
+(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   254           0
+(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   255           0
+(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   256           0
+(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   257           0
+(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   258           0
+(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   259           0
+(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   260           0
+(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   261           0
+(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   262           0
+(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   263           0
+(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   264           0
+(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   265           0
+(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   266           0
+(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   267           0
+(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   268           0
+(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   269           0
+(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   270           0
+(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   271           0
+(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   272           0
+(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   273           0
+(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   274           0
+(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   275           0
+(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   276           0
+(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   277           0
+(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   278           0
+(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   279           0
+(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   280           0
+(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   281           0
+(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   282           0
+(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   283           0
+(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   284           0
+(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   285           0
+(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   286           0
+(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   287           0
+(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   288           0
+(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   289           0
+(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   290           0
+(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   291           0
+(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   292           0
+(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   293           0
+(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   294           0
+(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   295           0
+(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   296           0
+(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   297           0
+(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   298           0
+(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   299           0
+(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   300           0
+(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   301           1
+(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   302           1
+(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   303           0
+(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   304           0
+(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   305           0
+(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   306           0
+(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   307           0
+(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   308           0
+(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   309           0
+(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   310           0
+(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   311           0
+(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   312           0
+(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   313           0
+(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   314           0
+(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   315           0
+(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   316           0
+(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   317           0
+(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   318           0
+(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   319           0
+(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   320           0
+(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   321           0
+(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   322           0
+(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   323           0
+(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   324           0
+(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   325           0
+(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   326           0
+(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   327           0
+(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   328           0
+(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   329           0
+(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   330           0
+(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   331           0
+(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   332           0
+(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   333           0
+(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   334           0
+(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   335           0
+(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   336           0
+(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   337           0
+(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   338           0
+(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   339           0
+(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   340           0
+(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   341           0
+(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   342           0
+(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   343           0
+(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   344           0
+(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   345           0
+(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   346           0
+(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   347           0
+(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   348           0
+(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   349           0
+(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   350           0
+(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   351           0
+(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   352           0
+(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   353           0
+(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   354           0
+(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   355           0
+(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   356           0
+(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   357           0
+(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   358           0
+(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   359           0
+(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   360           0
+(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   361           0
+(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   362           0
+(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   363           0
+(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   364           0
+(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   365           0
+(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   366           0
+(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   367           0
+(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   368           0
+(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   369           0
+(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   370           0
+(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   371           0
+(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   372           0
+(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   373           0
+(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   374           0
+(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   375           0
+(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   376           0
+(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   377           0
+(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   378           0
+(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   379           0
+(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   380           0
+(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   381           0
+(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   382           0
+(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   383           0
+(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   384           0
+(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   385           0
+(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   386           0
+(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   387           0
+(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   388           0
+(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   389           0
+(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   390           0
+(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   391           0
+(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   392           0
+(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   393           0
+(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   394           0
+(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   395           0
+(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   396           0
+(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   397           0
+(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   398           0
+(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   399           0
+(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   400           0
 (PID.TID 0000.0001) ctrl-wet 7: flux          1600
-(PID.TID 0000.0001) ctrl-wet 8: atmos         2400
+(PID.TID 0000.0001) ctrl-wet 8: atmos         1600
 (PID.TID 0000.0001) ctrl-wet -------------------------------------------------
 (PID.TID 0000.0001) ctrl-wet 13: global nvarlength for Nr =    1        9840
 (PID.TID 0000.0001) ctrl-wet -------------------------------------------------
@@ -1073,8 +1451,50 @@
 (PID.TID 0000.0001) ctrl-wet -------------------------------------------------
 (PID.TID 0000.0001) ctrl-wet -------------------------------------------------
 (PID.TID 0000.0001) ctrl-wet -------------------------------------------------
-(PID.TID 0000.0001) ctrl_init: no. of control variables:            3
-(PID.TID 0000.0001) ctrl_init: control vector length:            9840
+(PID.TID 0000.0001) ctrl_init_wet: no. of control variables:            3
+(PID.TID 0000.0001) ctrl_init_wet: control vector length:            9840
+(PID.TID 0000.0001) 
+(PID.TID 0000.0001) // =======================================================
+(PID.TID 0000.0001) // control vector configuration  >>> START <<<
+(PID.TID 0000.0001) // =======================================================
+(PID.TID 0000.0001) 
+(PID.TID 0000.0001)  Total number of ocean points per tile:
+(PID.TID 0000.0001)  --------------------------------------
+(PID.TID 0000.0001)  snx*sny*nr =      840
+(PID.TID 0000.0001) 
+(PID.TID 0000.0001)  Number of ocean points per tile:
+(PID.TID 0000.0001)  --------------------------------
+(PID.TID 0000.0001)  bi,bj,#(c/s/w): 0001 0001 000800 000760 000800
+(PID.TID 0000.0001)  bi,bj,#(c/s/w): 0002 0001 000800 000760 000800
+(PID.TID 0000.0001)  bi,bj,#(c/s/w): 0001 0002 000840 000840 000840
+(PID.TID 0000.0001)  bi,bj,#(c/s/w): 0002 0002 000840 000840 000840
+(PID.TID 0000.0001) 
+(PID.TID 0000.0001)  Settings of generic controls:
+(PID.TID 0000.0001)  -----------------------------
+(PID.TID 0000.0001) 
+(PID.TID 0000.0001)  ctrlUseGen  =     T /* use generic controls */
+(PID.TID 0000.0001)  -> 3d control, genarr3d no.  1 is in use
+(PID.TID 0000.0001)       file       = xx_theta
+(PID.TID 0000.0001)       weight     = ones_32b.bin
+(PID.TID 0000.0001)       index      =  0201
+(PID.TID 0000.0001)       ncvarindex =  0301
+(PID.TID 0000.0001)  -> time variable 2D control, gentim2d no.  1 is in use
+(PID.TID 0000.0001)       file       = xx_atemp
+(PID.TID 0000.0001)       weight     = ones_32b.bin
+(PID.TID 0000.0001)       index      =  0301
+(PID.TID 0000.0001)       ncvarindex =  0401
+(PID.TID 0000.0001)       period     =  00000000 000000
+(PID.TID 0000.0001)  -> time variable 2D control, gentim2d no.  2 is in use
+(PID.TID 0000.0001)       file       = xx_swdown
+(PID.TID 0000.0001)       weight     = ones_32b.bin
+(PID.TID 0000.0001)       index      =  0302
+(PID.TID 0000.0001)       ncvarindex =  0402
+(PID.TID 0000.0001)       period     =  00000000 000000
+(PID.TID 0000.0001) 
+(PID.TID 0000.0001) // =======================================================
+(PID.TID 0000.0001) // control vector configuration  >>> END <<<
+(PID.TID 0000.0001) // =======================================================
+(PID.TID 0000.0001) 
 (PID.TID 0000.0001) %MON fCori_max                    =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON fCori_min                    =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON fCori_mean                   =   0.0000000000000E+00
@@ -1113,7 +1533,7 @@
 (PID.TID 0000.0001) tRef =   /* Reference temperature profile ( oC or K ) */
 (PID.TID 0000.0001)                -1.620000000000000E+00       /* K =  1 */
 (PID.TID 0000.0001)     ;
-(PID.TID 0000.0001) sRef =   /* Reference salinity profile ( psu ) */
+(PID.TID 0000.0001) sRef =   /* Reference salinity profile ( g/kg ) */
 (PID.TID 0000.0001)                 3.000000000000000E+01       /* K =  1 */
 (PID.TID 0000.0001)     ;
 (PID.TID 0000.0001) useStrainTensionVisc= /* Use StrainTension Form of Viscous Operator */
@@ -1149,11 +1569,17 @@
 (PID.TID 0000.0001) no_slip_bottom =  /* Viscous BCs: No-slip bottom */
 (PID.TID 0000.0001)                   T
 (PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) bottomVisc_pCell = /* Partial-cell in bottom Visc. BC */
+(PID.TID 0000.0001)                   F
+(PID.TID 0000.0001)     ;
 (PID.TID 0000.0001) bottomDragLinear = /* linear bottom-drag coefficient ( m/s ) */
 (PID.TID 0000.0001)                 0.000000000000000E+00
 (PID.TID 0000.0001)     ;
 (PID.TID 0000.0001) bottomDragQuadratic = /* quadratic bottom-drag coefficient (-) */
 (PID.TID 0000.0001)                 5.000000000000000E-03
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) selectBotDragQuadr = /* select quadratic bottom drag options */
+(PID.TID 0000.0001)                      -1
 (PID.TID 0000.0001)     ;
 (PID.TID 0000.0001) diffKhT =   /* Laplacian diffusion of heat laterally ( m^2/s ) */
 (PID.TID 0000.0001)                 0.000000000000000E+00
@@ -1203,11 +1629,21 @@
 (PID.TID 0000.0001) tAlpha = /* Linear EOS thermal expansion coefficient ( 1/oC ) */
 (PID.TID 0000.0001)                 2.000000000000000E-04
 (PID.TID 0000.0001)     ;
-(PID.TID 0000.0001) sBeta  = /* Linear EOS haline contraction coefficient ( 1/psu ) */
+(PID.TID 0000.0001) sBeta  = /* Linear EOS haline contraction coefficient ( 1/(g/kg) ) */
 (PID.TID 0000.0001)                 0.000000000000000E+00
 (PID.TID 0000.0001)     ;
 (PID.TID 0000.0001) rhoNil    = /* Reference density for Linear EOS ( kg/m^3 ) */
 (PID.TID 0000.0001)                 1.030000000000000E+03
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) selectP_inEOS_Zc = /* select pressure to use in EOS (0,1,2,3) */
+(PID.TID 0000.0001)                       0
+(PID.TID 0000.0001)     0= -g*rhoConst*z ; 1= pRef (from tRef,sRef); 2= Hyd P ; 3= Hyd+NH P
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) surf_pRef = /* Surface reference pressure ( Pa ) */
+(PID.TID 0000.0001)                 1.013250000000000E+05
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) HeatCapacity_Cp =  /* Specific heat capacity ( J/kg/K ) */
+(PID.TID 0000.0001)                 3.986000000000000E+03
 (PID.TID 0000.0001)     ;
 (PID.TID 0000.0001) celsius2K = /* 0 degree Celsius converted to Kelvin ( K ) */
 (PID.TID 0000.0001)                 2.731500000000000E+02
@@ -1229,6 +1665,12 @@
 (PID.TID 0000.0001)     ;
 (PID.TID 0000.0001) gBaro =   /* Barotropic gravity ( m/s^2 ) */
 (PID.TID 0000.0001)                 9.810000000000000E+00
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) gravFacC = /* gravity factor (vs surf.) @ cell-Center (-) */
+(PID.TID 0000.0001)                 1.000000000000000E+00       /* K =  1 */
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) gravFacF = /* gravity factor (vs surf.) @ W-Interface (-) */
+(PID.TID 0000.0001)     2 @  1.000000000000000E+00              /* K =  1:  2 */
 (PID.TID 0000.0001)     ;
 (PID.TID 0000.0001) rotationPeriod =   /* Rotation Period ( s ) */
 (PID.TID 0000.0001)                 8.616400000000000E+04
@@ -1257,7 +1699,7 @@
 (PID.TID 0000.0001) implicSurfPress =  /* Surface Pressure implicit factor (0-1)*/
 (PID.TID 0000.0001)                 1.000000000000000E+00
 (PID.TID 0000.0001)     ;
-(PID.TID 0000.0001) implicDiv2Dflow =  /* Barot. Flow Div. implicit factor (0-1)*/
+(PID.TID 0000.0001) implicDiv2DFlow =  /* Barot. Flow Div. implicit factor (0-1)*/
 (PID.TID 0000.0001)                 1.000000000000000E+00
 (PID.TID 0000.0001)     ;
 (PID.TID 0000.0001) uniformLin_PhiSurf = /* use uniform Bo_surf on/off flag*/
@@ -1270,7 +1712,7 @@
 (PID.TID 0000.0001)                 1.000000000000000E+00
 (PID.TID 0000.0001)     ;
 (PID.TID 0000.0001) hFacMinDr = /* minimum partial cell thickness ( m) */
-(PID.TID 0000.0001)                 1.000000000000000E+00
+(PID.TID 0000.0001)                 0.000000000000000E+00
 (PID.TID 0000.0001)     ;
 (PID.TID 0000.0001) exactConserv =  /* Exact Volume Conservation on/off flag*/
 (PID.TID 0000.0001)                   F
@@ -1297,7 +1739,7 @@
 (PID.TID 0000.0001) temp_EvPrRn = /* Temp. of Evap/Prec/R (UNSET=use local T)(oC)*/
 (PID.TID 0000.0001)                 1.234567000000000E+05
 (PID.TID 0000.0001)     ;
-(PID.TID 0000.0001) salt_EvPrRn = /* Salin. of Evap/Prec/R (UNSET=use local S)(psu)*/
+(PID.TID 0000.0001) salt_EvPrRn = /* Salin. of Evap/Prec/R (UNSET=use local S)(g/kg)*/
 (PID.TID 0000.0001)                 0.000000000000000E+00
 (PID.TID 0000.0001)     ;
 (PID.TID 0000.0001) selectAddFluid = /* option for mass source/sink of fluid (=0: off) */
@@ -1306,10 +1748,10 @@
 (PID.TID 0000.0001) temp_addMass = /* Temp. of addMass array (UNSET=use local T)(oC)*/
 (PID.TID 0000.0001)                 1.234567000000000E+05
 (PID.TID 0000.0001)     ;
-(PID.TID 0000.0001) salt_addMass = /* Salin. of addMass array (UNSET=use local S)(psu)*/
+(PID.TID 0000.0001) salt_addMass = /* Salin. of addMass array (UNSET=use local S)(g/kg)*/
 (PID.TID 0000.0001)                 0.000000000000000E+00
 (PID.TID 0000.0001)     ;
-(PID.TID 0000.0001) convertFW2Salt = /* convert F.W. Flux to Salt Flux (-1=use local S)(psu)*/
+(PID.TID 0000.0001) convertFW2Salt = /* convert F.W. Flux to Salt Flux (-1=use local S)(g/kg)*/
 (PID.TID 0000.0001)                -1.000000000000000E+00
 (PID.TID 0000.0001)     ;
 (PID.TID 0000.0001) use3Dsolver = /* use 3-D pressure solver on/off flag */
@@ -1351,6 +1793,10 @@
 (PID.TID 0000.0001) implicitViscosity = /* Implicit viscosity on/off flag */
 (PID.TID 0000.0001)                   F
 (PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) selectImplicitDrag= /* Implicit bot Drag options (0,1,2)*/
+(PID.TID 0000.0001)                       0
+(PID.TID 0000.0001)     0= Expl. ; 1= Impl. on provis. Vel ; 2= Fully Impl (with surf.P)
+(PID.TID 0000.0001)     ;
 (PID.TID 0000.0001) metricTerms =  /* metric-Terms on/off flag */
 (PID.TID 0000.0001)                   F
 (PID.TID 0000.0001)     ;
@@ -1370,37 +1816,12 @@
 (PID.TID 0000.0001) useCDscheme =  /* CD scheme on/off flag */
 (PID.TID 0000.0001)                   F
 (PID.TID 0000.0001)     ;
-(PID.TID 0000.0001) useEnergyConservingCoriolis= /* Flx-Form Coriolis scheme flag */
-(PID.TID 0000.0001)                   F
-(PID.TID 0000.0001)     ;
-(PID.TID 0000.0001) useJamartWetPoints= /* Coriolis WetPoints method flag */
-(PID.TID 0000.0001)                   T
-(PID.TID 0000.0001)     ;
-(PID.TID 0000.0001) useJamartMomAdv= /* V.I Non-linear terms Jamart flag */
-(PID.TID 0000.0001)                   F
-(PID.TID 0000.0001)     ;
-(PID.TID 0000.0001) useAbsVorticity= /* V.I Works with f+zeta in Coriolis */
-(PID.TID 0000.0001)                   F
-(PID.TID 0000.0001)     ;
-(PID.TID 0000.0001) selectVortScheme= /* V.I Scheme selector for Vorticity-Term */
-(PID.TID 0000.0001)               123456789
-(PID.TID 0000.0001)    = 0 : enstrophy (Shallow-Water Eq.) conserving scheme by Sadourny, JAS 75
-(PID.TID 0000.0001)    = 1 : same as 0 with modified hFac
-(PID.TID 0000.0001)    = 2 : energy conserving scheme (used by Sadourny in JAS 75 paper)
-(PID.TID 0000.0001)    = 3 : energy (general) and enstrophy (2D, nonDiv.) conserving scheme
-(PID.TID 0000.0001)          from Sadourny (Burridge & Haseler, ECMWF Rep.4, 1977)
-(PID.TID 0000.0001)     ;
-(PID.TID 0000.0001) upwindVorticity= /* V.I Upwind bias vorticity flag */
-(PID.TID 0000.0001)                   F
-(PID.TID 0000.0001)     ;
-(PID.TID 0000.0001) highOrderVorticity= /* V.I High order vort. advect. flag */
-(PID.TID 0000.0001)                   F
-(PID.TID 0000.0001)     ;
-(PID.TID 0000.0001) upwindShear= /* V.I Upwind vertical Shear advection flag */
-(PID.TID 0000.0001)                   F
-(PID.TID 0000.0001)     ;
-(PID.TID 0000.0001) selectKEscheme= /* V.I Kinetic Energy scheme selector */
-(PID.TID 0000.0001)                       0
+(PID.TID 0000.0001) selectCoriScheme= /* Scheme selector for Coriolis-Term */
+(PID.TID 0000.0001)                       1
+(PID.TID 0000.0001)    = 0 : original discretization (simple averaging, no hFac)
+(PID.TID 0000.0001)    = 1 : Wet-point averaging (Jamar & Ozer 1986)
+(PID.TID 0000.0001)    = 2 : energy conserving scheme (no hFac weight)
+(PID.TID 0000.0001)    = 3 : energy conserving scheme using Wet-point averaging
 (PID.TID 0000.0001)     ;
 (PID.TID 0000.0001) momForcing =  /* Momentum forcing on/off flag */
 (PID.TID 0000.0001)                   F
@@ -1468,6 +1889,12 @@
 (PID.TID 0000.0001) writeBinaryPrec = /* Precision used for writing binary files */
 (PID.TID 0000.0001)                      64
 (PID.TID 0000.0001)     ;
+(PID.TID 0000.0001)  rwSuffixType =   /* select format of mds file suffix */
+(PID.TID 0000.0001)                       0
+(PID.TID 0000.0001)    = 0 : myIter (I10.10) ;   = 1 : 100*myTime (100th sec) ;
+(PID.TID 0000.0001)    = 2 : myTime (seconds);   = 3 : myTime/360 (10th of hr);
+(PID.TID 0000.0001)    = 4 : myTime/3600 (hours)
+(PID.TID 0000.0001)     ;
 (PID.TID 0000.0001)  globalFiles = /* write "global" (=not per tile) files */
 (PID.TID 0000.0001)                   F
 (PID.TID 0000.0001)     ;
@@ -1485,6 +1912,9 @@
 (PID.TID 0000.0001)    debLevD =  4 ; /* level of enhanced debug prt (add DEBUG_STATS prt) */
 (PID.TID 0000.0001)    debLevE =  5 ; /* level of extensive debug printing */
 (PID.TID 0000.0001) debugLevel =  /* select debug printing level */
+(PID.TID 0000.0001)                       1
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001)  plotLevel =  /* select PLOT_FIELD printing level */
 (PID.TID 0000.0001)                       1
 (PID.TID 0000.0001)     ;
 (PID.TID 0000.0001) //
@@ -1547,6 +1977,9 @@
 (PID.TID 0000.0001) abEps =   /* Adams-Bashforth-2 stabilizing weight */
 (PID.TID 0000.0001)                 1.000000000000000E-01
 (PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) applyExchUV_early = /* Apply EXCH to U,V earlier in time-step */
+(PID.TID 0000.0001)                   F
+(PID.TID 0000.0001)     ;
 (PID.TID 0000.0001) pickupStrictlyMatch= /* stop if pickup do not strictly match */
 (PID.TID 0000.0001)                   T
 (PID.TID 0000.0001)     ;
@@ -1579,9 +2012,6 @@
 (PID.TID 0000.0001)     ;
 (PID.TID 0000.0001) pickup_read_mdsio =   /* Model IO flag. */
 (PID.TID 0000.0001)                   T
-(PID.TID 0000.0001)     ;
-(PID.TID 0000.0001) pickup_write_immed =   /* Model IO flag. */
-(PID.TID 0000.0001)                   F
 (PID.TID 0000.0001)     ;
 (PID.TID 0000.0001) writePickupAtEnd =   /* Model IO flag. */
 (PID.TID 0000.0001)                   T
@@ -1634,11 +2064,20 @@
 (PID.TID 0000.0001) usingCurvilinearGrid = /* Curvilinear coordinates flag ( True/False ) */
 (PID.TID 0000.0001)                   F
 (PID.TID 0000.0001)     ;
-(PID.TID 0000.0001) selectSigmaCoord = /* Hybrid-Sigma Vert. Coordinate option */
+(PID.TID 0000.0001) useMin4hFacEdges = /* set hFacW,S as minimum of adjacent hFacC factor */
+(PID.TID 0000.0001)                   F
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) interViscAr_pCell = /* account for partial-cell in interior vert. viscosity */
+(PID.TID 0000.0001)                   F
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) interDiffKr_pCell = /* account for partial-cell in interior vert. diffusion */
+(PID.TID 0000.0001)                   F
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) pCellMix_select = /* option to enhance mixing near surface & bottom */
 (PID.TID 0000.0001)                       0
 (PID.TID 0000.0001)     ;
-(PID.TID 0000.0001) Ro_SeaLevel = /* r(1) ( units of r ==  m ) */
-(PID.TID 0000.0001)                 0.000000000000000E+00
+(PID.TID 0000.0001) selectSigmaCoord = /* Hybrid-Sigma Vert. Coordinate option */
+(PID.TID 0000.0001)                       0
 (PID.TID 0000.0001)     ;
 (PID.TID 0000.0001) rSigmaBnd = /* r/sigma transition ( units of r ==  m ) */
 (PID.TID 0000.0001)                 1.234567000000000E+05
@@ -1648,6 +2087,12 @@
 (PID.TID 0000.0001)     ;
 (PID.TID 0000.0001) gravitySign = /* gravity orientation relative to vertical coordinate */
 (PID.TID 0000.0001)                -1.000000000000000E+00
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) seaLev_Z =  /* reference height of sea-level [m] */
+(PID.TID 0000.0001)                 0.000000000000000E+00
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) top_Pres =  /* reference pressure at the top [Pa] */
+(PID.TID 0000.0001)                 0.000000000000000E+00
 (PID.TID 0000.0001)     ;
 (PID.TID 0000.0001) mass2rUnit = /* convert mass per unit area [kg/m2] to r-units [m] */
 (PID.TID 0000.0001)                 9.708737864077669E-04
@@ -1862,9 +2307,12 @@
 (PID.TID 0000.0001) 
 (PID.TID 0000.0001) == Packages configuration : Check & print summary ==
 (PID.TID 0000.0001) 
+(PID.TID 0000.0001) EXF_CHECK: #define ALLOW_EXF
 (PID.TID 0000.0001) THSICE_CHECK: #define THSICE
-(PID.TID 0000.0001) CTRL_CHECK: ctrl package
-(PID.TID 0000.0001) COST_CHECK: cost package
+(PID.TID 0000.0001) CTRL_CHECK:  --> Starts to check CTRL set-up
+(PID.TID 0000.0001) CTRL_CHECK:  <-- Ends Normally
+(PID.TID 0000.0001) 
+(PID.TID 0000.0001) COST_CHECK: #define ALLOW_COST
 (PID.TID 0000.0001) GRDCHK_CHECK: grdchk package
 (PID.TID 0000.0001) GAD_CHECK: #define ALLOW_GENERIC_ADVDIFF
 (PID.TID 0000.0001) // =======================================================
@@ -1910,6 +2358,9 @@
 (PID.TID 0000.0001) %MON dynstat_salt_mean            =   3.0000000000000E+01
 (PID.TID 0000.0001) %MON dynstat_salt_sd              =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON dynstat_salt_del2            =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON trAdv_CFL_u_max              =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON trAdv_CFL_v_max              =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON trAdv_CFL_w_max              =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON advcfl_uvel_max              =   1.4400000000000E-01
 (PID.TID 0000.0001) %MON advcfl_vvel_max              =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON advcfl_wvel_max              =   0.0000000000000E+00
@@ -2026,6 +2477,11 @@
 (PID.TID 0000.0001) %MON exf_lwflux_mean              =   5.6469966707288E+01
 (PID.TID 0000.0001) %MON exf_lwflux_sd                =   8.7396756498492E-13
 (PID.TID 0000.0001) %MON exf_lwflux_del2              =   3.0989615875950E-01
+(PID.TID 0000.0001) %MON exf_evap_max                 =   2.4349220321116E-08
+(PID.TID 0000.0001) %MON exf_evap_min                 =  -2.4559554123212E-09
+(PID.TID 0000.0001) %MON exf_evap_mean                =   1.1256492036177E-08
+(PID.TID 0000.0001) %MON exf_evap_sd                  =   9.4794636747833E-09
+(PID.TID 0000.0001) %MON exf_evap_del2                =   7.2578500983819E-11
 (PID.TID 0000.0001) %MON exf_precip_max               =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON exf_precip_min               =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON exf_precip_mean              =   0.0000000000000E+00
@@ -2036,11 +2492,6 @@
 (PID.TID 0000.0001) %MON exf_swflux_mean              =  -9.0000000000000E+01
 (PID.TID 0000.0001) %MON exf_swflux_sd                =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON exf_swflux_del2              =   4.9390243902439E-01
-(PID.TID 0000.0001) %MON exf_evap_max                 =   2.4349220321116E-08
-(PID.TID 0000.0001) %MON exf_evap_min                 =  -2.4559554123212E-09
-(PID.TID 0000.0001) %MON exf_evap_mean                =   1.1256492036177E-08
-(PID.TID 0000.0001) %MON exf_evap_sd                  =   9.4794636747833E-09
-(PID.TID 0000.0001) %MON exf_evap_del2                =   7.2578500983819E-11
 (PID.TID 0000.0001) %MON exf_swdown_max               =   1.0000000000000E+02
 (PID.TID 0000.0001) %MON exf_swdown_min               =   1.0000000000000E+02
 (PID.TID 0000.0001) %MON exf_swdown_mean              =   1.0000000000000E+02
@@ -2313,27 +2764,471 @@
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) %CHECKPOINT        60 ckptA
  --> f_thsice     =  0.160336971132022D+11
-  early fc =  0.000000000000000D+00
- --> objf_test(bi,bj)   =  0.000000000000000D+00
- --> objf_tracer(bi,bj) =  0.000000000000000D+00
- --> objf_atl(bi,bj)    =  0.000000000000000D+00
- --> objf_test(bi,bj)   =  0.000000000000000D+00
- --> objf_tracer(bi,bj) =  0.000000000000000D+00
- --> objf_atl(bi,bj)    =  0.000000000000000D+00
- --> objf_test(bi,bj)   =  0.000000000000000D+00
- --> objf_tracer(bi,bj) =  0.000000000000000D+00
- --> objf_atl(bi,bj)    =  0.000000000000000D+00
- --> objf_test(bi,bj)   =  0.000000000000000D+00
- --> objf_tracer(bi,bj) =  0.000000000000000D+00
- --> objf_atl(bi,bj)    =  0.000000000000000D+00
-  local fc =  0.160336971132022D+11
- global fc =  0.160336971132022D+11
+(PID.TID 0000.0001)   early fc =  0.000000000000000D+00
+(PID.TID 0000.0001)   local fc =  0.160336971132022D+11
+(PID.TID 0000.0001)  global fc =  0.160336971132022D+11
 (PID.TID 0000.0001) Did not write pickup because writePickupAtEnd = FALSE
 (PID.TID 0000.0001) Did not write pickup because writePickupAtEnd = FALSE
 (PID.TID 0000.0001) Did not write pickup because writePickupAtEnd = FALSE
+(PID.TID 0000.0001) // =======================================================
+(PID.TID 0000.0001) // Begin AD_MONITOR EXF statistics for iwhen =  3
+(PID.TID 0000.0001) // =======================================================
+(PID.TID 0000.0001) %MON ad_exf_tsnumber              =                    48
+(PID.TID 0000.0001) %MON ad_exf_time_sec              =   1.7280000000000E+05
+(PID.TID 0000.0001) %MON ad_exf_adfu_max              =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON ad_exf_adfu_min              =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON ad_exf_adfu_mean             =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON ad_exf_adfu_sd               =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON ad_exf_adfu_del2             =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON ad_exf_adfv_max              =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON ad_exf_adfv_min              =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON ad_exf_adfv_mean             =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON ad_exf_adfv_sd               =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON ad_exf_adfv_del2             =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON ad_exf_adqnet_max            =   5.3217768362976E+01
+(PID.TID 0000.0001) %MON ad_exf_adqnet_min            =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON ad_exf_adqnet_mean           =   1.7146679914646E+00
+(PID.TID 0000.0001) %MON ad_exf_adqnet_sd             =   8.4876620624783E+00
+(PID.TID 0000.0001) %MON ad_exf_adqnet_del2           =   1.5553228234191E-01
+(PID.TID 0000.0001) %MON ad_exf_adempmr_max           =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON ad_exf_adempmr_min           =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON ad_exf_adempmr_mean          =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON ad_exf_adempmr_sd            =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON ad_exf_adempmr_del2          =   0.0000000000000E+00
+(PID.TID 0000.0001) // =======================================================
+(PID.TID 0000.0001) // End AD_MONITOR EXF statistics for iwhen =  3
+(PID.TID 0000.0001) // =======================================================
+(PID.TID 0000.0001) // =======================================================
+(PID.TID 0000.0001) // Begin AD_MONITOR EXF statistics for iwhen =  1
+(PID.TID 0000.0001) // =======================================================
+(PID.TID 0000.0001) %MON ad_exf_tsnumber              =                    48
+(PID.TID 0000.0001) %MON ad_exf_time_sec              =   1.7280000000000E+05
+(PID.TID 0000.0001) %MON ad_exf_adustress_max         =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON ad_exf_adustress_min         =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON ad_exf_adustress_mean        =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON ad_exf_adustress_sd          =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON ad_exf_adustress_del2        =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON ad_exf_advstress_max         =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON ad_exf_advstress_min         =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON ad_exf_advstress_mean        =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON ad_exf_advstress_sd          =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON ad_exf_advstress_del2        =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON ad_exf_adhflux_max           =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON ad_exf_adhflux_min           =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON ad_exf_adhflux_mean          =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON ad_exf_adhflux_sd            =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON ad_exf_adhflux_del2          =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON ad_exf_adsflux_max           =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON ad_exf_adsflux_min           =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON ad_exf_adsflux_mean          =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON ad_exf_adsflux_sd            =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON ad_exf_adsflux_del2          =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON ad_exf_adwspeed_max          =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON ad_exf_adwspeed_min          =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON ad_exf_adwspeed_mean         =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON ad_exf_adwspeed_sd           =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON ad_exf_adwspeed_del2         =   0.0000000000000E+00
+(PID.TID 0000.0001) // =======================================================
+(PID.TID 0000.0001) // End AD_MONITOR EXF statistics for iwhen =  1
+(PID.TID 0000.0001) // =======================================================
+(PID.TID 0000.0001) // =======================================================
+(PID.TID 0000.0001) // Begin AD_MONITOR EXF statistics for iwhen =  2
+(PID.TID 0000.0001) // =======================================================
+(PID.TID 0000.0001) %MON ad_exf_tsnumber              =                    48
+(PID.TID 0000.0001) %MON ad_exf_time_sec              =   1.7280000000000E+05
+(PID.TID 0000.0001) %MON ad_exf_aduwind_max           =   4.5673215823266E+02
+(PID.TID 0000.0001) %MON ad_exf_aduwind_min           =  -3.6759459351602E+01
+(PID.TID 0000.0001) %MON ad_exf_aduwind_mean          =  -3.2620189393150E+00
+(PID.TID 0000.0001) %MON ad_exf_aduwind_sd            =   7.4236122476072E+01
+(PID.TID 0000.0001) %MON ad_exf_aduwind_del2          =   1.3053658455010E+00
+(PID.TID 0000.0001) %MON ad_exf_advwind_max           =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON ad_exf_advwind_min           =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON ad_exf_advwind_mean          =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON ad_exf_advwind_sd            =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON ad_exf_advwind_del2          =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON ad_exf_adatemp_max           =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON ad_exf_adatemp_min           =  -9.1688863591894E+02
+(PID.TID 0000.0001) %MON ad_exf_adatemp_mean          =  -7.7370205768247E+01
+(PID.TID 0000.0001) %MON ad_exf_adatemp_sd            =   1.6973575956933E+02
+(PID.TID 0000.0001) %MON ad_exf_adatemp_del2          =   4.1909771513588E+00
+(PID.TID 0000.0001) %MON ad_exf_adaqh_max             =   3.9119818889727E+05
+(PID.TID 0000.0001) %MON ad_exf_adaqh_min             =  -1.9395663588760E+06
+(PID.TID 0000.0001) %MON ad_exf_adaqh_mean            =   1.6614723278305E+05
+(PID.TID 0000.0001) %MON ad_exf_adaqh_sd              =   4.4418523686527E+05
+(PID.TID 0000.0001) %MON ad_exf_adaqh_del2            =   1.1542035286428E+04
+(PID.TID 0000.0001) %MON ad_exf_adlwflux_max          =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON ad_exf_adlwflux_min          =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON ad_exf_adlwflux_mean         =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON ad_exf_adlwflux_sd           =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON ad_exf_adlwflux_del2         =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON ad_exf_adprecip_max          =   1.5817657488391E+09
+(PID.TID 0000.0001) %MON ad_exf_adprecip_min          =  -1.2044402128633E+08
+(PID.TID 0000.0001) %MON ad_exf_adprecip_mean         =   3.5309286670828E+08
+(PID.TID 0000.0001) %MON ad_exf_adprecip_sd           =   4.3755690036537E+08
+(PID.TID 0000.0001) %MON ad_exf_adprecip_del2         =   7.7553888163321E+06
+(PID.TID 0000.0001) %MON ad_exf_adswdown_max          =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON ad_exf_adswdown_min          =  -4.8413321706703E+01
+(PID.TID 0000.0001) %MON ad_exf_adswdown_mean         =  -2.5907519867559E+00
+(PID.TID 0000.0001) %MON ad_exf_adswdown_sd           =   7.9083588923378E+00
+(PID.TID 0000.0001) %MON ad_exf_adswdown_del2         =   1.4864139747581E-01
+(PID.TID 0000.0001) %MON ad_exf_adlwdown_max          =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON ad_exf_adlwdown_min          =  -5.2971565805117E+01
+(PID.TID 0000.0001) %MON ad_exf_adlwdown_mean         =  -4.0201020949533E+00
+(PID.TID 0000.0001) %MON ad_exf_adlwdown_sd           =   9.3924815148638E+00
+(PID.TID 0000.0001) %MON ad_exf_adlwdown_del2         =   2.2081879183868E-01
+(PID.TID 0000.0001) %MON ad_exf_adrunoff_max          =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON ad_exf_adrunoff_min          =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON ad_exf_adrunoff_mean         =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON ad_exf_adrunoff_sd           =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON ad_exf_adrunoff_del2         =   0.0000000000000E+00
+(PID.TID 0000.0001) // =======================================================
+(PID.TID 0000.0001) // End AD_MONITOR EXF statistics for iwhen =  2
+(PID.TID 0000.0001) // =======================================================
+(PID.TID 0000.0001) // =======================================================
+(PID.TID 0000.0001) // Begin AD_MONITOR dynamic field statistics
+(PID.TID 0000.0001) // =======================================================
+(PID.TID 0000.0001) %MON ad_time_tsnumber             =                    48
+(PID.TID 0000.0001) %MON ad_time_secondsf             =   1.7280000000000E+05
+(PID.TID 0000.0001) %MON ad_dynstat_adeta_max         =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON ad_dynstat_adeta_min         =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON ad_dynstat_adeta_mean        =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON ad_dynstat_adeta_sd          =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON ad_dynstat_adeta_del2        =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON ad_dynstat_aduvel_max        =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON ad_dynstat_aduvel_min        =  -2.2760795667402E+04
+(PID.TID 0000.0001) %MON ad_dynstat_aduvel_mean       =  -6.5325535699592E+03
+(PID.TID 0000.0001) %MON ad_dynstat_aduvel_sd         =   8.4720706467918E+03
+(PID.TID 0000.0001) %MON ad_dynstat_aduvel_del2       =   8.0712327506269E+01
+(PID.TID 0000.0001) %MON ad_dynstat_advvel_max        =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON ad_dynstat_advvel_min        =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON ad_dynstat_advvel_mean       =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON ad_dynstat_advvel_sd         =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON ad_dynstat_advvel_del2       =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON ad_dynstat_adwvel_max        =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON ad_dynstat_adwvel_min        =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON ad_dynstat_adwvel_mean       =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON ad_dynstat_adwvel_sd         =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON ad_dynstat_adwvel_del2       =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON ad_dynstat_adtheta_max       =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON ad_dynstat_adtheta_min       =  -6.8092755233148E+05
+(PID.TID 0000.0001) %MON ad_dynstat_adtheta_mean      =  -7.4802092795902E+04
+(PID.TID 0000.0001) %MON ad_dynstat_adtheta_sd        =   1.2365186171131E+05
+(PID.TID 0000.0001) %MON ad_dynstat_adtheta_del2      =   1.9377858451443E+03
+(PID.TID 0000.0001) %MON ad_dynstat_adsalt_max        =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON ad_dynstat_adsalt_min        =  -3.8673612201196E+04
+(PID.TID 0000.0001) %MON ad_dynstat_adsalt_mean       =  -4.2374738700734E+03
+(PID.TID 0000.0001) %MON ad_dynstat_adsalt_sd         =   6.9169691141174E+03
+(PID.TID 0000.0001) %MON ad_dynstat_adsalt_del2       =   1.0776858614611E+02
+(PID.TID 0000.0001) // =======================================================
+(PID.TID 0000.0001) // End AD_MONITOR dynamic field statistics
+(PID.TID 0000.0001) // =======================================================
+(PID.TID 0000.0001) // =======================================================
+(PID.TID 0000.0001) // Begin AD_MONITOR EXF statistics for iwhen =  3
+(PID.TID 0000.0001) // =======================================================
+(PID.TID 0000.0001) %MON ad_exf_tsnumber              =                    24
+(PID.TID 0000.0001) %MON ad_exf_time_sec              =   8.6400000000000E+04
+(PID.TID 0000.0001) %MON ad_exf_adfu_max              =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON ad_exf_adfu_min              =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON ad_exf_adfu_mean             =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON ad_exf_adfu_sd               =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON ad_exf_adfu_del2             =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON ad_exf_adfv_max              =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON ad_exf_adfv_min              =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON ad_exf_adfv_mean             =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON ad_exf_adfv_sd               =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON ad_exf_adfv_del2             =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON ad_exf_adqnet_max            =   1.8266180650238E+02
+(PID.TID 0000.0001) %MON ad_exf_adqnet_min            =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON ad_exf_adqnet_mean           =   5.8215505211317E+00
+(PID.TID 0000.0001) %MON ad_exf_adqnet_sd             =   2.8208129713018E+01
+(PID.TID 0000.0001) %MON ad_exf_adqnet_del2           =   5.3170655081510E-01
+(PID.TID 0000.0001) %MON ad_exf_adempmr_max           =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON ad_exf_adempmr_min           =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON ad_exf_adempmr_mean          =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON ad_exf_adempmr_sd            =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON ad_exf_adempmr_del2          =   0.0000000000000E+00
+(PID.TID 0000.0001) // =======================================================
+(PID.TID 0000.0001) // End AD_MONITOR EXF statistics for iwhen =  3
+(PID.TID 0000.0001) // =======================================================
+(PID.TID 0000.0001) // =======================================================
+(PID.TID 0000.0001) // Begin AD_MONITOR EXF statistics for iwhen =  1
+(PID.TID 0000.0001) // =======================================================
+(PID.TID 0000.0001) %MON ad_exf_tsnumber              =                    24
+(PID.TID 0000.0001) %MON ad_exf_time_sec              =   8.6400000000000E+04
+(PID.TID 0000.0001) %MON ad_exf_adustress_max         =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON ad_exf_adustress_min         =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON ad_exf_adustress_mean        =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON ad_exf_adustress_sd          =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON ad_exf_adustress_del2        =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON ad_exf_advstress_max         =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON ad_exf_advstress_min         =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON ad_exf_advstress_mean        =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON ad_exf_advstress_sd          =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON ad_exf_advstress_del2        =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON ad_exf_adhflux_max           =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON ad_exf_adhflux_min           =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON ad_exf_adhflux_mean          =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON ad_exf_adhflux_sd            =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON ad_exf_adhflux_del2          =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON ad_exf_adsflux_max           =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON ad_exf_adsflux_min           =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON ad_exf_adsflux_mean          =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON ad_exf_adsflux_sd            =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON ad_exf_adsflux_del2          =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON ad_exf_adwspeed_max          =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON ad_exf_adwspeed_min          =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON ad_exf_adwspeed_mean         =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON ad_exf_adwspeed_sd           =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON ad_exf_adwspeed_del2         =   0.0000000000000E+00
+(PID.TID 0000.0001) // =======================================================
+(PID.TID 0000.0001) // End AD_MONITOR EXF statistics for iwhen =  1
+(PID.TID 0000.0001) // =======================================================
+(PID.TID 0000.0001) // =======================================================
+(PID.TID 0000.0001) // Begin AD_MONITOR EXF statistics for iwhen =  2
+(PID.TID 0000.0001) // =======================================================
+(PID.TID 0000.0001) %MON ad_exf_tsnumber              =                    24
+(PID.TID 0000.0001) %MON ad_exf_time_sec              =   8.6400000000000E+04
+(PID.TID 0000.0001) %MON ad_exf_aduwind_max           =   1.5064609438148E+03
+(PID.TID 0000.0001) %MON ad_exf_aduwind_min           =  -1.8056939681274E+02
+(PID.TID 0000.0001) %MON ad_exf_aduwind_mean          =   6.1395866887983E+00
+(PID.TID 0000.0001) %MON ad_exf_aduwind_sd            =   2.4526056475953E+02
+(PID.TID 0000.0001) %MON ad_exf_aduwind_del2          =   4.4482128240851E+00
+(PID.TID 0000.0001) %MON ad_exf_advwind_max           =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON ad_exf_advwind_min           =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON ad_exf_advwind_mean          =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON ad_exf_advwind_sd            =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON ad_exf_advwind_del2          =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON ad_exf_adatemp_max           =   2.5000813828191E+01
+(PID.TID 0000.0001) %MON ad_exf_adatemp_min           =  -3.0464292351517E+03
+(PID.TID 0000.0001) %MON ad_exf_adatemp_mean          =  -4.5730746067731E+02
+(PID.TID 0000.0001) %MON ad_exf_adatemp_sd            =   7.3174769073636E+02
+(PID.TID 0000.0001) %MON ad_exf_adatemp_del2          =   2.7114878212421E+01
+(PID.TID 0000.0001) %MON ad_exf_adaqh_max             =   1.1735945666918E+06
+(PID.TID 0000.0001) %MON ad_exf_adaqh_min             =  -6.9493714405113E+06
+(PID.TID 0000.0001) %MON ad_exf_adaqh_mean            =  -1.5745137582575E+05
+(PID.TID 0000.0001) %MON ad_exf_adaqh_sd              =   2.0016203882750E+06
+(PID.TID 0000.0001) %MON ad_exf_adaqh_del2            =   7.6157001822614E+04
+(PID.TID 0000.0001) %MON ad_exf_adlwflux_max          =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON ad_exf_adlwflux_min          =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON ad_exf_adlwflux_mean         =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON ad_exf_adlwflux_sd           =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON ad_exf_adlwflux_del2         =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON ad_exf_adprecip_max          =   3.5540046633244E+10
+(PID.TID 0000.0001) %MON ad_exf_adprecip_min          =  -4.6658694105038E+08
+(PID.TID 0000.0001) %MON ad_exf_adprecip_mean         =   8.3971060271877E+09
+(PID.TID 0000.0001) %MON ad_exf_adprecip_sd           =   1.0229268452419E+10
+(PID.TID 0000.0001) %MON ad_exf_adprecip_del2         =   1.5039430826684E+08
+(PID.TID 0000.0001) %MON ad_exf_adswdown_max          =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON ad_exf_adswdown_min          =  -1.6462894219346E+02
+(PID.TID 0000.0001) %MON ad_exf_adswdown_mean         =  -1.3088107615463E+01
+(PID.TID 0000.0001) %MON ad_exf_adswdown_sd           =   2.6623619712098E+01
+(PID.TID 0000.0001) %MON ad_exf_adswdown_del2         =   5.7447545805709E-01
+(PID.TID 0000.0001) %MON ad_exf_adlwdown_max          =   1.2082111496089E+00
+(PID.TID 0000.0001) %MON ad_exf_adlwdown_min          =  -1.7686055865178E+02
+(PID.TID 0000.0001) %MON ad_exf_adlwdown_mean         =  -2.3111576699806E+01
+(PID.TID 0000.0001) %MON ad_exf_adlwdown_sd           =   3.8160473273135E+01
+(PID.TID 0000.0001) %MON ad_exf_adlwdown_del2         =   1.3396770568578E+00
+(PID.TID 0000.0001) %MON ad_exf_adrunoff_max          =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON ad_exf_adrunoff_min          =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON ad_exf_adrunoff_mean         =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON ad_exf_adrunoff_sd           =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON ad_exf_adrunoff_del2         =   0.0000000000000E+00
+(PID.TID 0000.0001) // =======================================================
+(PID.TID 0000.0001) // End AD_MONITOR EXF statistics for iwhen =  2
+(PID.TID 0000.0001) // =======================================================
+(PID.TID 0000.0001) // =======================================================
+(PID.TID 0000.0001) // Begin AD_MONITOR dynamic field statistics
+(PID.TID 0000.0001) // =======================================================
+(PID.TID 0000.0001) %MON ad_time_tsnumber             =                    24
+(PID.TID 0000.0001) %MON ad_time_secondsf             =   8.6400000000000E+04
+(PID.TID 0000.0001) %MON ad_dynstat_adeta_max         =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON ad_dynstat_adeta_min         =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON ad_dynstat_adeta_mean        =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON ad_dynstat_adeta_sd          =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON ad_dynstat_adeta_del2        =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON ad_dynstat_aduvel_max        =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON ad_dynstat_aduvel_min        =  -1.3229249340179E+05
+(PID.TID 0000.0001) %MON ad_dynstat_aduvel_mean       =  -3.9859491319153E+04
+(PID.TID 0000.0001) %MON ad_dynstat_aduvel_sd         =   4.9361286340832E+04
+(PID.TID 0000.0001) %MON ad_dynstat_aduvel_del2       =   4.5792340798357E+02
+(PID.TID 0000.0001) %MON ad_dynstat_advvel_max        =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON ad_dynstat_advvel_min        =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON ad_dynstat_advvel_mean       =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON ad_dynstat_advvel_sd         =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON ad_dynstat_advvel_del2       =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON ad_dynstat_adwvel_max        =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON ad_dynstat_adwvel_min        =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON ad_dynstat_adwvel_mean       =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON ad_dynstat_adwvel_sd         =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON ad_dynstat_adwvel_del2       =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON ad_dynstat_adtheta_max       =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON ad_dynstat_adtheta_min       =  -2.1869696084045E+06
+(PID.TID 0000.0001) %MON ad_dynstat_adtheta_mean      =  -4.3405603512834E+05
+(PID.TID 0000.0001) %MON ad_dynstat_adtheta_sd        =   4.8847952667343E+05
+(PID.TID 0000.0001) %MON ad_dynstat_adtheta_del2      =   5.4666463714912E+03
+(PID.TID 0000.0001) %MON ad_dynstat_adsalt_max        =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON ad_dynstat_adsalt_min        =  -1.3922034599037E+05
+(PID.TID 0000.0001) %MON ad_dynstat_adsalt_mean       =  -2.5264743222103E+04
+(PID.TID 0000.0001) %MON ad_dynstat_adsalt_sd         =   2.8592304538801E+04
+(PID.TID 0000.0001) %MON ad_dynstat_adsalt_del2       =   3.2459588626128E+02
+(PID.TID 0000.0001) // =======================================================
+(PID.TID 0000.0001) // End AD_MONITOR dynamic field statistics
+(PID.TID 0000.0001) // =======================================================
+(PID.TID 0000.0001) // =======================================================
+(PID.TID 0000.0001) // Begin AD_MONITOR EXF statistics for iwhen =  3
+(PID.TID 0000.0001) // =======================================================
+(PID.TID 0000.0001) %MON ad_exf_tsnumber              =                     0
+(PID.TID 0000.0001) %MON ad_exf_time_sec              =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON ad_exf_adfu_max              =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON ad_exf_adfu_min              =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON ad_exf_adfu_mean             =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON ad_exf_adfu_sd               =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON ad_exf_adfu_del2             =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON ad_exf_adfv_max              =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON ad_exf_adfv_min              =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON ad_exf_adfv_mean             =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON ad_exf_adfv_sd               =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON ad_exf_adfv_del2             =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON ad_exf_adqnet_max            =   2.8674154035755E+05
+(PID.TID 0000.0001) %MON ad_exf_adqnet_min            =  -2.5223425135767E+05
+(PID.TID 0000.0001) %MON ad_exf_adqnet_mean           =   6.6759013095264E+02
+(PID.TID 0000.0001) %MON ad_exf_adqnet_sd             =   1.6078921224389E+04
+(PID.TID 0000.0001) %MON ad_exf_adqnet_del2           =   5.7270455753670E+02
+(PID.TID 0000.0001) %MON ad_exf_adempmr_max           =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON ad_exf_adempmr_min           =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON ad_exf_adempmr_mean          =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON ad_exf_adempmr_sd            =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON ad_exf_adempmr_del2          =   0.0000000000000E+00
+(PID.TID 0000.0001) // =======================================================
+(PID.TID 0000.0001) // End AD_MONITOR EXF statistics for iwhen =  3
+(PID.TID 0000.0001) // =======================================================
+(PID.TID 0000.0001) // =======================================================
+(PID.TID 0000.0001) // Begin AD_MONITOR EXF statistics for iwhen =  1
+(PID.TID 0000.0001) // =======================================================
+(PID.TID 0000.0001) %MON ad_exf_tsnumber              =                     0
+(PID.TID 0000.0001) %MON ad_exf_time_sec              =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON ad_exf_adustress_max         =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON ad_exf_adustress_min         =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON ad_exf_adustress_mean        =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON ad_exf_adustress_sd          =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON ad_exf_adustress_del2        =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON ad_exf_advstress_max         =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON ad_exf_advstress_min         =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON ad_exf_advstress_mean        =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON ad_exf_advstress_sd          =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON ad_exf_advstress_del2        =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON ad_exf_adhflux_max           =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON ad_exf_adhflux_min           =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON ad_exf_adhflux_mean          =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON ad_exf_adhflux_sd            =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON ad_exf_adhflux_del2          =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON ad_exf_adsflux_max           =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON ad_exf_adsflux_min           =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON ad_exf_adsflux_mean          =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON ad_exf_adsflux_sd            =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON ad_exf_adsflux_del2          =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON ad_exf_adwspeed_max          =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON ad_exf_adwspeed_min          =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON ad_exf_adwspeed_mean         =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON ad_exf_adwspeed_sd           =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON ad_exf_adwspeed_del2         =   0.0000000000000E+00
+(PID.TID 0000.0001) // =======================================================
+(PID.TID 0000.0001) // End AD_MONITOR EXF statistics for iwhen =  1
+(PID.TID 0000.0001) // =======================================================
+(PID.TID 0000.0001) // =======================================================
+(PID.TID 0000.0001) // Begin AD_MONITOR EXF statistics for iwhen =  2
+(PID.TID 0000.0001) // =======================================================
+(PID.TID 0000.0001) %MON ad_exf_tsnumber              =                     0
+(PID.TID 0000.0001) %MON ad_exf_time_sec              =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON ad_exf_aduwind_max           =   1.8984562261640E+06
+(PID.TID 0000.0001) %MON ad_exf_aduwind_min           =  -1.3021013836359E+06
+(PID.TID 0000.0001) %MON ad_exf_aduwind_mean          =   3.6538554414927E+03
+(PID.TID 0000.0001) %MON ad_exf_aduwind_sd            =   8.6996179372758E+04
+(PID.TID 0000.0001) %MON ad_exf_aduwind_del2          =   3.1391242839214E+03
+(PID.TID 0000.0001) %MON ad_exf_advwind_max           =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON ad_exf_advwind_min           =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON ad_exf_advwind_mean          =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON ad_exf_advwind_sd            =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON ad_exf_advwind_del2          =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON ad_exf_adatemp_max           =   4.2160522911427E+06
+(PID.TID 0000.0001) %MON ad_exf_adatemp_min           =  -4.8816480043731E+06
+(PID.TID 0000.0001) %MON ad_exf_adatemp_mean          =  -9.9202264433309E+03
+(PID.TID 0000.0001) %MON ad_exf_adatemp_sd            =   2.4041836263328E+05
+(PID.TID 0000.0001) %MON ad_exf_adatemp_del2          =   9.4843043694832E+03
+(PID.TID 0000.0001) %MON ad_exf_adaqh_max             =   1.0534803363949E+10
+(PID.TID 0000.0001) %MON ad_exf_adaqh_min             =  -1.2134579670905E+10
+(PID.TID 0000.0001) %MON ad_exf_adaqh_mean            =  -2.9101926881582E+07
+(PID.TID 0000.0001) %MON ad_exf_adaqh_sd              =   6.7242197657827E+08
+(PID.TID 0000.0001) %MON ad_exf_adaqh_del2            =   2.3984933378930E+07
+(PID.TID 0000.0001) %MON ad_exf_adlwflux_max          =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON ad_exf_adlwflux_min          =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON ad_exf_adlwflux_mean         =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON ad_exf_adlwflux_sd           =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON ad_exf_adlwflux_del2         =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON ad_exf_adprecip_max          =   1.5617007233769E+11
+(PID.TID 0000.0001) %MON ad_exf_adprecip_min          =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON ad_exf_adprecip_mean         =   4.0719992198543E+10
+(PID.TID 0000.0001) %MON ad_exf_adprecip_sd           =   4.8996197203954E+10
+(PID.TID 0000.0001) %MON ad_exf_adprecip_del2         =   6.2519481442548E+08
+(PID.TID 0000.0001) %MON ad_exf_adswdown_max          =   2.2701082622191E+05
+(PID.TID 0000.0001) %MON ad_exf_adswdown_min          =  -2.5806738632180E+05
+(PID.TID 0000.0001) %MON ad_exf_adswdown_mean         =  -6.2296401490341E+02
+(PID.TID 0000.0001) %MON ad_exf_adswdown_sd           =   1.4470134582206E+04
+(PID.TID 0000.0001) %MON ad_exf_adswdown_del2         =   5.1544773174194E+02
+(PID.TID 0000.0001) %MON ad_exf_adlwdown_max          =   2.4467167239281E+05
+(PID.TID 0000.0001) %MON ad_exf_adlwdown_min          =  -2.7814435131685E+05
+(PID.TID 0000.0001) %MON ad_exf_adlwdown_mean         =  -6.9940718262277E+02
+(PID.TID 0000.0001) %MON ad_exf_adlwdown_sd           =   1.5594843917507E+04
+(PID.TID 0000.0001) %MON ad_exf_adlwdown_del2         =   5.5556763303153E+02
+(PID.TID 0000.0001) %MON ad_exf_adrunoff_max          =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON ad_exf_adrunoff_min          =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON ad_exf_adrunoff_mean         =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON ad_exf_adrunoff_sd           =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON ad_exf_adrunoff_del2         =   0.0000000000000E+00
+(PID.TID 0000.0001) // =======================================================
+(PID.TID 0000.0001) // End AD_MONITOR EXF statistics for iwhen =  2
+(PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) Start initial hydrostatic pressure computation
 (PID.TID 0000.0001) Pressure is predetermined for buoyancyRelation OCEANIC
 (PID.TID 0000.0001) 
+(PID.TID 0000.0001) // =======================================================
+(PID.TID 0000.0001) // Begin AD_MONITOR dynamic field statistics
+(PID.TID 0000.0001) // =======================================================
+(PID.TID 0000.0001) %MON ad_time_tsnumber             =                     0
+(PID.TID 0000.0001) %MON ad_time_secondsf             =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON ad_dynstat_adeta_max         =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON ad_dynstat_adeta_min         =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON ad_dynstat_adeta_mean        =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON ad_dynstat_adeta_sd          =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON ad_dynstat_adeta_del2        =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON ad_dynstat_aduvel_max        =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON ad_dynstat_aduvel_min        =  -2.0403845681102E+05
+(PID.TID 0000.0001) %MON ad_dynstat_aduvel_mean       =  -6.4698274609567E+04
+(PID.TID 0000.0001) %MON ad_dynstat_aduvel_sd         =   7.5616272819974E+04
+(PID.TID 0000.0001) %MON ad_dynstat_aduvel_del2       =   7.2642480517249E+02
+(PID.TID 0000.0001) %MON ad_dynstat_advvel_max        =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON ad_dynstat_advvel_min        =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON ad_dynstat_advvel_mean       =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON ad_dynstat_advvel_sd         =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON ad_dynstat_advvel_del2       =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON ad_dynstat_adwvel_max        =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON ad_dynstat_adwvel_min        =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON ad_dynstat_adwvel_mean       =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON ad_dynstat_adwvel_sd         =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON ad_dynstat_adwvel_del2       =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON ad_dynstat_adtheta_max       =   2.8646687738786E+09
+(PID.TID 0000.0001) %MON ad_dynstat_adtheta_min       =  -3.2564470978114E+09
+(PID.TID 0000.0001) %MON ad_dynstat_adtheta_mean      =  -1.0769505358314E+07
+(PID.TID 0000.0001) %MON ad_dynstat_adtheta_sd        =   1.8251632299361E+08
+(PID.TID 0000.0001) %MON ad_dynstat_adtheta_del2      =   6.5058075087841E+06
+(PID.TID 0000.0001) %MON ad_dynstat_adsalt_max        =   1.5531710375020E+08
+(PID.TID 0000.0001) %MON ad_dynstat_adsalt_min        =  -1.7661042640747E+08
+(PID.TID 0000.0001) %MON ad_dynstat_adsalt_mean       =  -5.8886872247176E+05
+(PID.TID 0000.0001) %MON ad_dynstat_adsalt_sd         =   9.8956579914632E+06
+(PID.TID 0000.0001) %MON ad_dynstat_adsalt_del2       =   3.5274977250485E+05
+(PID.TID 0000.0001) // =======================================================
+(PID.TID 0000.0001) // End AD_MONITOR dynamic field statistics
+(PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // Gradient-check starts (grdchk_main)
 (PID.TID 0000.0001) // =======================================================
@@ -2355,21 +3250,9 @@ grad-res -------------------------------
 (PID.TID 0000.0001) 
 (PID.TID 0000.0001) Did not write pickup because writePickupAtEnd = FALSE
  --> f_thsice     =  0.160336968734131D+11
-  early fc =  0.000000000000000D+00
- --> objf_test(bi,bj)   =  0.000000000000000D+00
- --> objf_tracer(bi,bj) =  0.000000000000000D+00
- --> objf_atl(bi,bj)    =  0.000000000000000D+00
- --> objf_test(bi,bj)   =  0.000000000000000D+00
- --> objf_tracer(bi,bj) =  0.000000000000000D+00
- --> objf_atl(bi,bj)    =  0.000000000000000D+00
- --> objf_test(bi,bj)   =  0.000000000000000D+00
- --> objf_tracer(bi,bj) =  0.000000000000000D+00
- --> objf_atl(bi,bj)    =  0.000000000000000D+00
- --> objf_test(bi,bj)   =  0.000000000000000D+00
- --> objf_tracer(bi,bj) =  0.000000000000000D+00
- --> objf_atl(bi,bj)    =  0.000000000000000D+00
-  local fc =  0.160336968734131D+11
- global fc =  0.160336968734131D+11
+(PID.TID 0000.0001)   early fc =  0.000000000000000D+00
+(PID.TID 0000.0001)   local fc =  0.160336968734131D+11
+(PID.TID 0000.0001)  global fc =  0.160336968734131D+11
 (PID.TID 0000.0001) grdchk perturb(+)fc: fcpertplus  =  1.60336968734131E+10
 (PID.TID 0000.0001) Start initial hydrostatic pressure computation
 (PID.TID 0000.0001) Pressure is predetermined for buoyancyRelation OCEANIC
@@ -2380,21 +3263,9 @@ grad-res -------------------------------
 (PID.TID 0000.0001) 
 (PID.TID 0000.0001) Did not write pickup because writePickupAtEnd = FALSE
  --> f_thsice     =  0.160336973530640D+11
-  early fc =  0.000000000000000D+00
- --> objf_test(bi,bj)   =  0.000000000000000D+00
- --> objf_tracer(bi,bj) =  0.000000000000000D+00
- --> objf_atl(bi,bj)    =  0.000000000000000D+00
- --> objf_test(bi,bj)   =  0.000000000000000D+00
- --> objf_tracer(bi,bj) =  0.000000000000000D+00
- --> objf_atl(bi,bj)    =  0.000000000000000D+00
- --> objf_test(bi,bj)   =  0.000000000000000D+00
- --> objf_tracer(bi,bj) =  0.000000000000000D+00
- --> objf_atl(bi,bj)    =  0.000000000000000D+00
- --> objf_test(bi,bj)   =  0.000000000000000D+00
- --> objf_tracer(bi,bj) =  0.000000000000000D+00
- --> objf_atl(bi,bj)    =  0.000000000000000D+00
-  local fc =  0.160336973530640D+11
- global fc =  0.160336973530640D+11
+(PID.TID 0000.0001)   early fc =  0.000000000000000D+00
+(PID.TID 0000.0001)   local fc =  0.160336973530640D+11
+(PID.TID 0000.0001)  global fc =  0.160336973530640D+11
 (PID.TID 0000.0001) grdchk perturb(-)fc: fcpertminus =  1.60336973530640E+10
 grad-res -------------------------------
  grad-res     0    1    1    1    1    2    2    1   1.60336971132E+10  1.60336968734E+10  1.60336973531E+10
@@ -2417,21 +3288,9 @@ grad-res -------------------------------
 (PID.TID 0000.0001) 
 (PID.TID 0000.0001) Did not write pickup because writePickupAtEnd = FALSE
  --> f_thsice     =  0.160336967917381D+11
-  early fc =  0.000000000000000D+00
- --> objf_test(bi,bj)   =  0.000000000000000D+00
- --> objf_tracer(bi,bj) =  0.000000000000000D+00
- --> objf_atl(bi,bj)    =  0.000000000000000D+00
- --> objf_test(bi,bj)   =  0.000000000000000D+00
- --> objf_tracer(bi,bj) =  0.000000000000000D+00
- --> objf_atl(bi,bj)    =  0.000000000000000D+00
- --> objf_test(bi,bj)   =  0.000000000000000D+00
- --> objf_tracer(bi,bj) =  0.000000000000000D+00
- --> objf_atl(bi,bj)    =  0.000000000000000D+00
- --> objf_test(bi,bj)   =  0.000000000000000D+00
- --> objf_tracer(bi,bj) =  0.000000000000000D+00
- --> objf_atl(bi,bj)    =  0.000000000000000D+00
-  local fc =  0.160336967917381D+11
- global fc =  0.160336967917381D+11
+(PID.TID 0000.0001)   early fc =  0.000000000000000D+00
+(PID.TID 0000.0001)   local fc =  0.160336967917381D+11
+(PID.TID 0000.0001)  global fc =  0.160336967917381D+11
 (PID.TID 0000.0001) grdchk perturb(+)fc: fcpertplus  =  1.60336967917381E+10
 (PID.TID 0000.0001) Start initial hydrostatic pressure computation
 (PID.TID 0000.0001) Pressure is predetermined for buoyancyRelation OCEANIC
@@ -2442,21 +3301,9 @@ grad-res -------------------------------
 (PID.TID 0000.0001) 
 (PID.TID 0000.0001) Did not write pickup because writePickupAtEnd = FALSE
  --> f_thsice     =  0.160336974361304D+11
-  early fc =  0.000000000000000D+00
- --> objf_test(bi,bj)   =  0.000000000000000D+00
- --> objf_tracer(bi,bj) =  0.000000000000000D+00
- --> objf_atl(bi,bj)    =  0.000000000000000D+00
- --> objf_test(bi,bj)   =  0.000000000000000D+00
- --> objf_tracer(bi,bj) =  0.000000000000000D+00
- --> objf_atl(bi,bj)    =  0.000000000000000D+00
- --> objf_test(bi,bj)   =  0.000000000000000D+00
- --> objf_tracer(bi,bj) =  0.000000000000000D+00
- --> objf_atl(bi,bj)    =  0.000000000000000D+00
- --> objf_test(bi,bj)   =  0.000000000000000D+00
- --> objf_tracer(bi,bj) =  0.000000000000000D+00
- --> objf_atl(bi,bj)    =  0.000000000000000D+00
-  local fc =  0.160336974361304D+11
- global fc =  0.160336974361304D+11
+(PID.TID 0000.0001)   early fc =  0.000000000000000D+00
+(PID.TID 0000.0001)   local fc =  0.160336974361304D+11
+(PID.TID 0000.0001)  global fc =  0.160336974361304D+11
 (PID.TID 0000.0001) grdchk perturb(-)fc: fcpertminus =  1.60336974361304E+10
 grad-res -------------------------------
  grad-res     0    2    2    1    1    2    2    1   1.60336971132E+10  1.60336967917E+10  1.60336974361E+10
@@ -2479,21 +3326,9 @@ grad-res -------------------------------
 (PID.TID 0000.0001) 
 (PID.TID 0000.0001) Did not write pickup because writePickupAtEnd = FALSE
  --> f_thsice     =  0.160336967420046D+11
-  early fc =  0.000000000000000D+00
- --> objf_test(bi,bj)   =  0.000000000000000D+00
- --> objf_tracer(bi,bj) =  0.000000000000000D+00
- --> objf_atl(bi,bj)    =  0.000000000000000D+00
- --> objf_test(bi,bj)   =  0.000000000000000D+00
- --> objf_tracer(bi,bj) =  0.000000000000000D+00
- --> objf_atl(bi,bj)    =  0.000000000000000D+00
- --> objf_test(bi,bj)   =  0.000000000000000D+00
- --> objf_tracer(bi,bj) =  0.000000000000000D+00
- --> objf_atl(bi,bj)    =  0.000000000000000D+00
- --> objf_test(bi,bj)   =  0.000000000000000D+00
- --> objf_tracer(bi,bj) =  0.000000000000000D+00
- --> objf_atl(bi,bj)    =  0.000000000000000D+00
-  local fc =  0.160336967420046D+11
- global fc =  0.160336967420046D+11
+(PID.TID 0000.0001)   early fc =  0.000000000000000D+00
+(PID.TID 0000.0001)   local fc =  0.160336967420046D+11
+(PID.TID 0000.0001)  global fc =  0.160336967420046D+11
 (PID.TID 0000.0001) grdchk perturb(+)fc: fcpertplus  =  1.60336967420046E+10
 (PID.TID 0000.0001) Start initial hydrostatic pressure computation
 (PID.TID 0000.0001) Pressure is predetermined for buoyancyRelation OCEANIC
@@ -2504,21 +3339,9 @@ grad-res -------------------------------
 (PID.TID 0000.0001) 
 (PID.TID 0000.0001) Did not write pickup because writePickupAtEnd = FALSE
  --> f_thsice     =  0.160336974844416D+11
-  early fc =  0.000000000000000D+00
- --> objf_test(bi,bj)   =  0.000000000000000D+00
- --> objf_tracer(bi,bj) =  0.000000000000000D+00
- --> objf_atl(bi,bj)    =  0.000000000000000D+00
- --> objf_test(bi,bj)   =  0.000000000000000D+00
- --> objf_tracer(bi,bj) =  0.000000000000000D+00
- --> objf_atl(bi,bj)    =  0.000000000000000D+00
- --> objf_test(bi,bj)   =  0.000000000000000D+00
- --> objf_tracer(bi,bj) =  0.000000000000000D+00
- --> objf_atl(bi,bj)    =  0.000000000000000D+00
- --> objf_test(bi,bj)   =  0.000000000000000D+00
- --> objf_tracer(bi,bj) =  0.000000000000000D+00
- --> objf_atl(bi,bj)    =  0.000000000000000D+00
-  local fc =  0.160336974844416D+11
- global fc =  0.160336974844416D+11
+(PID.TID 0000.0001)   early fc =  0.000000000000000D+00
+(PID.TID 0000.0001)   local fc =  0.160336974844416D+11
+(PID.TID 0000.0001)  global fc =  0.160336974844416D+11
 (PID.TID 0000.0001) grdchk perturb(-)fc: fcpertminus =  1.60336974844416E+10
 grad-res -------------------------------
  grad-res     0    3    3    1    1    2    2    1   1.60336971132E+10  1.60336967420E+10  1.60336974844E+10
@@ -2541,21 +3364,9 @@ grad-res -------------------------------
 (PID.TID 0000.0001) 
 (PID.TID 0000.0001) Did not write pickup because writePickupAtEnd = FALSE
  --> f_thsice     =  0.160336967400952D+11
-  early fc =  0.000000000000000D+00
- --> objf_test(bi,bj)   =  0.000000000000000D+00
- --> objf_tracer(bi,bj) =  0.000000000000000D+00
- --> objf_atl(bi,bj)    =  0.000000000000000D+00
- --> objf_test(bi,bj)   =  0.000000000000000D+00
- --> objf_tracer(bi,bj) =  0.000000000000000D+00
- --> objf_atl(bi,bj)    =  0.000000000000000D+00
- --> objf_test(bi,bj)   =  0.000000000000000D+00
- --> objf_tracer(bi,bj) =  0.000000000000000D+00
- --> objf_atl(bi,bj)    =  0.000000000000000D+00
- --> objf_test(bi,bj)   =  0.000000000000000D+00
- --> objf_tracer(bi,bj) =  0.000000000000000D+00
- --> objf_atl(bi,bj)    =  0.000000000000000D+00
-  local fc =  0.160336967400952D+11
- global fc =  0.160336967400952D+11
+(PID.TID 0000.0001)   early fc =  0.000000000000000D+00
+(PID.TID 0000.0001)   local fc =  0.160336967400952D+11
+(PID.TID 0000.0001)  global fc =  0.160336967400952D+11
 (PID.TID 0000.0001) grdchk perturb(+)fc: fcpertplus  =  1.60336967400952E+10
 (PID.TID 0000.0001) Start initial hydrostatic pressure computation
 (PID.TID 0000.0001) Pressure is predetermined for buoyancyRelation OCEANIC
@@ -2566,21 +3377,9 @@ grad-res -------------------------------
 (PID.TID 0000.0001) 
 (PID.TID 0000.0001) Did not write pickup because writePickupAtEnd = FALSE
  --> f_thsice     =  0.160336974863433D+11
-  early fc =  0.000000000000000D+00
- --> objf_test(bi,bj)   =  0.000000000000000D+00
- --> objf_tracer(bi,bj) =  0.000000000000000D+00
- --> objf_atl(bi,bj)    =  0.000000000000000D+00
- --> objf_test(bi,bj)   =  0.000000000000000D+00
- --> objf_tracer(bi,bj) =  0.000000000000000D+00
- --> objf_atl(bi,bj)    =  0.000000000000000D+00
- --> objf_test(bi,bj)   =  0.000000000000000D+00
- --> objf_tracer(bi,bj) =  0.000000000000000D+00
- --> objf_atl(bi,bj)    =  0.000000000000000D+00
- --> objf_test(bi,bj)   =  0.000000000000000D+00
- --> objf_tracer(bi,bj) =  0.000000000000000D+00
- --> objf_atl(bi,bj)    =  0.000000000000000D+00
-  local fc =  0.160336974863433D+11
- global fc =  0.160336974863433D+11
+(PID.TID 0000.0001)   early fc =  0.000000000000000D+00
+(PID.TID 0000.0001)   local fc =  0.160336974863433D+11
+(PID.TID 0000.0001)  global fc =  0.160336974863433D+11
 (PID.TID 0000.0001) grdchk perturb(-)fc: fcpertminus =  1.60336974863433E+10
 grad-res -------------------------------
  grad-res     0    4    4    1    1    2    2    1   1.60336971132E+10  1.60336967401E+10  1.60336974863E+10
@@ -2623,153 +3422,153 @@ grad-res -------------------------------
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) 
 (PID.TID 0000.0001)   Seconds in section "ALL                    [THE_MODEL_MAIN]":
-(PID.TID 0000.0001)           User time:   249.01000000000002
-(PID.TID 0000.0001)         System time:  0.27000000000000002
-(PID.TID 0000.0001)     Wall clock time:   249.86228299140930
+(PID.TID 0000.0001)           User time:   94.108497466892004
+(PID.TID 0000.0001)         System time:   1.2073169611394405
+(PID.TID 0000.0001)     Wall clock time:   99.900910139083862
 (PID.TID 0000.0001)          No. starts:           1
 (PID.TID 0000.0001)           No. stops:           1
 (PID.TID 0000.0001)   Seconds in section "INITIALISE_FIXED       [THE_MODEL_MAIN]":
-(PID.TID 0000.0001)           User time:  5.00000000000000028E-002
-(PID.TID 0000.0001)         System time:   0.0000000000000000
-(PID.TID 0000.0001)     Wall clock time:  8.15119743347167969E-002
+(PID.TID 0000.0001)           User time:   3.7963001290336251E-002
+(PID.TID 0000.0001)         System time:   7.1118002990260720E-002
+(PID.TID 0000.0001)     Wall clock time:  0.40559697151184082
 (PID.TID 0000.0001)          No. starts:           1
 (PID.TID 0000.0001)           No. stops:           1
 (PID.TID 0000.0001)   Seconds in section "ADTHE_MAIN_LOOP          [ADJOINT RUN]":
-(PID.TID 0000.0001)           User time:   227.84999999999999
-(PID.TID 0000.0001)         System time:  0.23999999999999999
-(PID.TID 0000.0001)     Wall clock time:   228.57661104202271
+(PID.TID 0000.0001)           User time:   79.804975017905235
+(PID.TID 0000.0001)         System time:   1.0800200104713440
+(PID.TID 0000.0001)     Wall clock time:   85.091937065124512
 (PID.TID 0000.0001)          No. starts:           1
 (PID.TID 0000.0001)           No. stops:           1
 (PID.TID 0000.0001)   Seconds in section "FORWARD_STEP        [MAIN_DO_LOOP]":
-(PID.TID 0000.0001)           User time:   23.650000000001484
-(PID.TID 0000.0001)         System time:  4.00000000000000355E-002
-(PID.TID 0000.0001)     Wall clock time:   23.817140340805054
+(PID.TID 0000.0001)           User time:   15.819585248827934
+(PID.TID 0000.0001)         System time:   8.8170781731605530E-002
+(PID.TID 0000.0001)     Wall clock time:   16.157036066055298
 (PID.TID 0000.0001)          No. starts:         600
 (PID.TID 0000.0001)           No. stops:         600
 (PID.TID 0000.0001)   Seconds in section "LOAD_FIELDS_DRIVER  [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:   5.4199999999998170
-(PID.TID 0000.0001)         System time:  1.00000000000000089E-002
-(PID.TID 0000.0001)     Wall clock time:   5.5488939285278320
+(PID.TID 0000.0001)           User time:   3.8990386575460434
+(PID.TID 0000.0001)         System time:   3.7472620606422424E-002
+(PID.TID 0000.0001)     Wall clock time:   4.0198245048522949
 (PID.TID 0000.0001)          No. starts:         600
 (PID.TID 0000.0001)           No. stops:         600
 (PID.TID 0000.0001)   Seconds in section "EXF_GETFORCING     [LOAD_FLDS_DRIVER]":
-(PID.TID 0000.0001)           User time:   5.9099999999997976
-(PID.TID 0000.0001)         System time:  1.00000000000000089E-002
-(PID.TID 0000.0001)     Wall clock time:   6.0726137161254883
+(PID.TID 0000.0001)           User time:   3.9442929625511169
+(PID.TID 0000.0001)         System time:   3.4800589084625244E-002
+(PID.TID 0000.0001)     Wall clock time:   3.9955053329467773
 (PID.TID 0000.0001)          No. starts:         660
 (PID.TID 0000.0001)           No. stops:         660
-(PID.TID 0000.0001)   Seconds in section "I/O (WRITE)        [ADJOINT LOOP]":
-(PID.TID 0000.0001)           User time:  9.99999999999090505E-003
-(PID.TID 0000.0001)         System time:   0.0000000000000000
-(PID.TID 0000.0001)     Wall clock time:  2.26125717163085938E-002
-(PID.TID 0000.0001)          No. starts:        2460
-(PID.TID 0000.0001)           No. stops:        2460
 (PID.TID 0000.0001)   Seconds in section "EXTERNAL_FLDS_LOAD [LOAD_FLDS_DRIVER]":
-(PID.TID 0000.0001)           User time:   0.0000000000000000
-(PID.TID 0000.0001)         System time:   0.0000000000000000
-(PID.TID 0000.0001)     Wall clock time:  6.02364540100097656E-003
+(PID.TID 0000.0001)           User time:   6.3064694404602051E-003
+(PID.TID 0000.0001)         System time:   1.7009675502777100E-004
+(PID.TID 0000.0001)     Wall clock time:   2.6661634445190430E-002
 (PID.TID 0000.0001)          No. starts:         660
 (PID.TID 0000.0001)           No. stops:         660
+(PID.TID 0000.0001)   Seconds in section "CTRL_MAP_FORCING  [FORWARD_STEP]":
+(PID.TID 0000.0001)           User time:   1.0960880219936371
+(PID.TID 0000.0001)         System time:   3.5001039505004883E-003
+(PID.TID 0000.0001)     Wall clock time:   1.1238946914672852
+(PID.TID 0000.0001)          No. starts:         600
+(PID.TID 0000.0001)           No. stops:         600
 (PID.TID 0000.0001)   Seconds in section "DO_ATMOSPHERIC_PHYS [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:  9.99999999999090505E-003
-(PID.TID 0000.0001)         System time:   0.0000000000000000
-(PID.TID 0000.0001)     Wall clock time:  5.36346435546875000E-003
+(PID.TID 0000.0001)           User time:   2.7503624558448792E-002
+(PID.TID 0000.0001)         System time:   1.7890334129333496E-004
+(PID.TID 0000.0001)     Wall clock time:   2.7649879455566406E-002
 (PID.TID 0000.0001)          No. starts:         600
 (PID.TID 0000.0001)           No. stops:         600
 (PID.TID 0000.0001)   Seconds in section "DO_OCEANIC_PHYS     [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:   14.440000000000708
-(PID.TID 0000.0001)         System time:   0.0000000000000000
-(PID.TID 0000.0001)     Wall clock time:   14.492702007293701
+(PID.TID 0000.0001)           User time:   8.7292360067367554
+(PID.TID 0000.0001)         System time:   1.5920013189315796E-002
+(PID.TID 0000.0001)     Wall clock time:   8.7922492027282715
 (PID.TID 0000.0001)          No. starts:         600
 (PID.TID 0000.0001)           No. stops:         600
 (PID.TID 0000.0001)   Seconds in section "THSICE_MAIN     [DO_OCEANIC_PHYS]":
-(PID.TID 0000.0001)           User time:   13.340000000000515
-(PID.TID 0000.0001)         System time:   0.0000000000000000
-(PID.TID 0000.0001)     Wall clock time:   13.333601474761963
+(PID.TID 0000.0001)           User time:   7.9982690960168839
+(PID.TID 0000.0001)         System time:   1.3991862535476685E-002
+(PID.TID 0000.0001)     Wall clock time:   8.0498819351196289
 (PID.TID 0000.0001)          No. starts:         600
 (PID.TID 0000.0001)           No. stops:         600
 (PID.TID 0000.0001)   Seconds in section "DYNAMICS            [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:  0.71999999999999886
-(PID.TID 0000.0001)         System time:   0.0000000000000000
-(PID.TID 0000.0001)     Wall clock time:  0.77188372611999512
+(PID.TID 0000.0001)           User time:  0.46845538914203644
+(PID.TID 0000.0001)         System time:   2.8321444988250732E-003
+(PID.TID 0000.0001)     Wall clock time:  0.47743201255798340
 (PID.TID 0000.0001)          No. starts:         600
 (PID.TID 0000.0001)           No. stops:         600
 (PID.TID 0000.0001)   Seconds in section "MOM_CORRECTION_STEP [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:  0.41999999999987381
-(PID.TID 0000.0001)         System time:   0.0000000000000000
-(PID.TID 0000.0001)     Wall clock time:  0.33982634544372559
+(PID.TID 0000.0001)           User time:   7.0851147174835205E-003
+(PID.TID 0000.0001)         System time:   2.3809075355529785E-004
+(PID.TID 0000.0001)     Wall clock time:   8.0184936523437500E-003
 (PID.TID 0000.0001)          No. starts:         600
 (PID.TID 0000.0001)           No. stops:         600
 (PID.TID 0000.0001)   Seconds in section "BLOCKING_EXCHANGES  [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:  0.21999999999997044
-(PID.TID 0000.0001)         System time:  1.00000000000000089E-002
-(PID.TID 0000.0001)     Wall clock time:  0.22803783416748047
+(PID.TID 0000.0001)           User time:  0.15252964198589325
+(PID.TID 0000.0001)         System time:   1.3277977705001831E-003
+(PID.TID 0000.0001)     Wall clock time:  0.15436172485351562
 (PID.TID 0000.0001)          No. starts:        1200
 (PID.TID 0000.0001)           No. stops:        1200
 (PID.TID 0000.0001)   Seconds in section "THERMODYNAMICS      [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:   2.0900000000000034
-(PID.TID 0000.0001)         System time:   0.0000000000000000
-(PID.TID 0000.0001)     Wall clock time:   2.1698293685913086
+(PID.TID 0000.0001)           User time:   1.2635070681571960
+(PID.TID 0000.0001)         System time:   1.7852932214736938E-003
+(PID.TID 0000.0001)     Wall clock time:   1.2834281921386719
 (PID.TID 0000.0001)          No. starts:         600
 (PID.TID 0000.0001)           No. stops:         600
 (PID.TID 0000.0001)   Seconds in section "TRC_CORRECTION_STEP [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:  0.11000000000001364
-(PID.TID 0000.0001)         System time:   0.0000000000000000
-(PID.TID 0000.0001)     Wall clock time:  7.12795257568359375E-002
+(PID.TID 0000.0001)           User time:   5.6730359792709351E-003
+(PID.TID 0000.0001)         System time:   3.0115246772766113E-005
+(PID.TID 0000.0001)     Wall clock time:   5.7094097137451172E-003
 (PID.TID 0000.0001)          No. starts:         600
 (PID.TID 0000.0001)           No. stops:         600
 (PID.TID 0000.0001)   Seconds in section "MONITOR             [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:   0.0000000000000000
-(PID.TID 0000.0001)         System time:   0.0000000000000000
-(PID.TID 0000.0001)     Wall clock time:  5.78403472900390625E-004
-(PID.TID 0000.0001)          No. starts:          60
-(PID.TID 0000.0001)           No. stops:          60
+(PID.TID 0000.0001)           User time:   5.8840662240982056E-003
+(PID.TID 0000.0001)         System time:   3.9860606193542480E-005
+(PID.TID 0000.0001)     Wall clock time:   5.8305263519287109E-003
+(PID.TID 0000.0001)          No. starts:         600
+(PID.TID 0000.0001)           No. stops:         600
 (PID.TID 0000.0001)   Seconds in section "COST_TILE           [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:  7.99999999999556621E-002
-(PID.TID 0000.0001)         System time:  1.00000000000000089E-002
-(PID.TID 0000.0001)     Wall clock time:  6.00881576538085938E-002
+(PID.TID 0000.0001)           User time:   3.8049295544624329E-002
+(PID.TID 0000.0001)         System time:   2.9170513153076172E-004
+(PID.TID 0000.0001)     Wall clock time:   3.8315296173095703E-002
 (PID.TID 0000.0001)          No. starts:         600
 (PID.TID 0000.0001)           No. stops:         600
 (PID.TID 0000.0001)   Seconds in section "DO_THE_MODEL_IO     [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:  1.99999999999818101E-002
-(PID.TID 0000.0001)         System time:  1.00000000000000089E-002
-(PID.TID 0000.0001)     Wall clock time:  4.31833267211914063E-002
+(PID.TID 0000.0001)           User time:   3.4829199314117432E-002
+(PID.TID 0000.0001)         System time:   1.5301972627639771E-002
+(PID.TID 0000.0001)     Wall clock time:   9.7441911697387695E-002
 (PID.TID 0000.0001)          No. starts:         600
 (PID.TID 0000.0001)           No. stops:         600
 (PID.TID 0000.0001)   Seconds in section "DO_WRITE_PICKUP     [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:  9.99999999999090505E-003
-(PID.TID 0000.0001)         System time:   0.0000000000000000
-(PID.TID 0000.0001)     Wall clock time:  1.31235122680664063E-002
+(PID.TID 0000.0001)           User time:   9.4543546438217163E-003
+(PID.TID 0000.0001)         System time:   8.3940029144287109E-003
+(PID.TID 0000.0001)     Wall clock time:   3.5941362380981445E-002
 (PID.TID 0000.0001)          No. starts:         600
 (PID.TID 0000.0001)           No. stops:         600
 (PID.TID 0000.0001)   Seconds in section "GRDCHK_MAIN         [THE_MODEL_MAIN]":
-(PID.TID 0000.0001)           User time:   21.110000000000014
-(PID.TID 0000.0001)         System time:  3.00000000000000266E-002
-(PID.TID 0000.0001)     Wall clock time:   21.204101800918579
+(PID.TID 0000.0001)           User time:   14.265480041503906
+(PID.TID 0000.0001)         System time:   5.6143999099731445E-002
+(PID.TID 0000.0001)     Wall clock time:   14.403275012969971
 (PID.TID 0000.0001)          No. starts:           1
 (PID.TID 0000.0001)           No. stops:           1
 (PID.TID 0000.0001)   Seconds in section "INITIALISE_VARIA    [THE_MAIN_LOOP]":
-(PID.TID 0000.0001)           User time:  0.10000000000002274
-(PID.TID 0000.0001)         System time:   0.0000000000000000
-(PID.TID 0000.0001)     Wall clock time:  0.10244297981262207
+(PID.TID 0000.0001)           User time:   9.8114013671875000E-002
+(PID.TID 0000.0001)         System time:   1.7078042030334473E-002
+(PID.TID 0000.0001)     Wall clock time:  0.11521100997924805
 (PID.TID 0000.0001)          No. starts:           8
 (PID.TID 0000.0001)           No. stops:           8
 (PID.TID 0000.0001)   Seconds in section "MAIN LOOP           [THE_MAIN_LOOP]":
-(PID.TID 0000.0001)           User time:   21.009999999999962
-(PID.TID 0000.0001)         System time:  3.00000000000000266E-002
-(PID.TID 0000.0001)     Wall clock time:   21.070705175399780
+(PID.TID 0000.0001)           User time:   14.152626037597656
+(PID.TID 0000.0001)         System time:   2.8172969818115234E-002
+(PID.TID 0000.0001)     Wall clock time:   14.183200359344482
 (PID.TID 0000.0001)          No. starts:           8
 (PID.TID 0000.0001)           No. stops:           8
 (PID.TID 0000.0001)   Seconds in section "MAIN_DO_LOOP        [THE_MAIN_LOOP]":
-(PID.TID 0000.0001)           User time:   18.940000000001106
-(PID.TID 0000.0001)         System time:  3.00000000000000266E-002
-(PID.TID 0000.0001)     Wall clock time:   19.057034969329834
+(PID.TID 0000.0001)           User time:   12.452026367187500
+(PID.TID 0000.0001)         System time:   2.8108119964599609E-002
+(PID.TID 0000.0001)     Wall clock time:   12.481823921203613
 (PID.TID 0000.0001)          No. starts:         480
 (PID.TID 0000.0001)           No. stops:         480
 (PID.TID 0000.0001)   Seconds in section "COST_FINAL         [ADJOINT SPIN-DOWN]":
-(PID.TID 0000.0001)           User time:   0.0000000000000000
+(PID.TID 0000.0001)           User time:   9.2315673828125000E-004
 (PID.TID 0000.0001)         System time:   0.0000000000000000
-(PID.TID 0000.0001)     Wall clock time:  7.65800476074218750E-004
+(PID.TID 0000.0001)     Wall clock time:   9.0456008911132812E-004
 (PID.TID 0000.0001)          No. starts:           8
 (PID.TID 0000.0001)           No. stops:           8
 (PID.TID 0000.0001) // ======================================================
@@ -2820,9 +3619,9 @@ grad-res -------------------------------
 (PID.TID 0000.0001) //          Total. Y spins =              0
 (PID.TID 0000.0001) //            Avg. Y spins =       0.00E+00
 (PID.TID 0000.0001) // o Thread number: 000001
-(PID.TID 0000.0001) //            No. barriers =           2316
+(PID.TID 0000.0001) //            No. barriers =           3926
 (PID.TID 0000.0001) //      Max. barrier spins =              1
 (PID.TID 0000.0001) //      Min. barrier spins =              1
-(PID.TID 0000.0001) //     Total barrier spins =           2316
+(PID.TID 0000.0001) //     Total barrier spins =           3926
 (PID.TID 0000.0001) //      Avg. barrier spins =       1.00E+00
 PROGRAM MAIN: Execution ended Normally

--- a/verification/offline_exf_seaice/results/output_adm.txt
+++ b/verification/offline_exf_seaice/results/output_adm.txt
@@ -5,10 +5,10 @@
 (PID.TID 0000.0001) // ======================================================
 (PID.TID 0000.0001) // execution environment starting up...
 (PID.TID 0000.0001) 
-(PID.TID 0000.0001) // MITgcmUV version:  checkpoint67r
-(PID.TID 0000.0001) // Build user:        mlosch
-(PID.TID 0000.0001) // Build host:        bkli04l006
-(PID.TID 0000.0001) // Build date:        Thu Jul 30 07:12:20 CEST 2020
+(PID.TID 0000.0001) // MITgcmUV version:  checkpoint67w
+(PID.TID 0000.0001) // Build user:        jm_c
+(PID.TID 0000.0001) // Build host:        villon
+(PID.TID 0000.0001) // Build date:        Tue Apr 13 00:59:56 EDT 2021
 (PID.TID 0000.0001) 
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // Execution Environment parameter file "eedata"
@@ -48,7 +48,7 @@
 (PID.TID 0000.0001)                   /*  note: To execute a program with MPI calls */
 (PID.TID 0000.0001)                   /*  it must be launched appropriately e.g     */
 (PID.TID 0000.0001)                   /*  "mpirun -np 64 ......"                    */
-(PID.TID 0000.0001) useCoupler=    F ;/* Flag used to control communications with   */
+(PID.TID 0000.0001) useCoupler=   F ; /* Flag used to control communications with   */
 (PID.TID 0000.0001)                   /*  other model components, through a coupler */
 (PID.TID 0000.0001) useNest2W_parent =    F ;/* Control 2-W Nesting comm */
 (PID.TID 0000.0001) useNest2W_child  =    F ;/* Control 2-W Nesting comm */
@@ -154,16 +154,15 @@
 (PID.TID 0000.0001) > &PARM03
 (PID.TID 0000.0001) > startTime=0.0,
 (PID.TID 0000.0001) >#endTime=864000.,
+(PID.TID 0000.0001) > nTimeSteps=120,
 (PID.TID 0000.0001) > deltaT=3600.0,
 (PID.TID 0000.0001) > abEps=0.1,
 (PID.TID 0000.0001) > forcing_In_AB = .FALSE.,
-(PID.TID 0000.0001) > pChkptFreq=3600000.,
-(PID.TID 0000.0001) > monitorFreq=432000.,
-(PID.TID 0000.0001) > monitorSelect=2,
-(PID.TID 0000.0001) >#dumpFreq = 86400.,
-(PID.TID 0000.0001) > nTimeSteps=120,
-(PID.TID 0000.0001) >#monitorFreq=1.,
-(PID.TID 0000.0001) >#dumpFreq = 1.,
+(PID.TID 0000.0001) > pChkptFreq=5184000.,
+(PID.TID 0000.0001) >#dumpFreq = 864000.,
+(PID.TID 0000.0001) > monitorSelect = 2,
+(PID.TID 0000.0001) > monitorFreq =  216000.,
+(PID.TID 0000.0001) > adjMonitorFreq= 86400.,
 (PID.TID 0000.0001) > /
 (PID.TID 0000.0001) >
 (PID.TID 0000.0001) ># Gridding parameters
@@ -372,31 +371,31 @@
 (PID.TID 0000.0001) > SEAICE_dTempFrz_dS = -5.4e-02,
 (PID.TID 0000.0001) >#seaice growth parameters
 (PID.TID 0000.0001) > HO = 0.2,
-(PID.TID 0000.0001) ># these have no effect in seaice_growth_adx
+(PID.TID 0000.0001) ># these have no effect in seaice_growth_adx, so we comment it out
 (PID.TID 0000.0001) >#SEAICE_frazilFrac  = 1.,
 (PID.TID 0000.0001) >#SEAICE_areaLossFormula = 2,
 (PID.TID 0000.0001) >#SEAICE_growMeltByConv = .TRUE.,
 (PID.TID 0000.0001) >#SEAICE_doOpenWaterMelt = .TRUE.,
 (PID.TID 0000.0001) >#- same mcPheePiston value as in thsice with surf-current=0.2 m/s
 (PID.TID 0000.0001) >#SEAICE_mcPheePiston= 8.7854425e-5,
-(PID.TID 0000.0001) >#SEAICEuseFlooding  = .TRUE.,
-(PID.TID 0000.0001) > SEAICE_salt0       = 4.,
 (PID.TID 0000.0001) >#SEAICE_saltFrac    = 0.3,
+(PID.TID 0000.0001) > SEAICE_salt0       = 4.,
 (PID.TID 0000.0001) >#simplest (constant) albedo scheme
 (PID.TID 0000.0001) > SEAICE_dryIceAlb   = 0.6,
 (PID.TID 0000.0001) > SEAICE_wetIceAlb   = 0.6,
 (PID.TID 0000.0001) > SEAICE_drySnowAlb  = 0.6,
 (PID.TID 0000.0001) > SEAICE_wetSnowAlb  = 0.6,
-(PID.TID 0000.0001) >#SEAICE_waterAlbedo = 0.1,
 (PID.TID 0000.0001) >#
 (PID.TID 0000.0001) > SEAICE_strength    = 2.6780e+04,
 (PID.TID 0000.0001) > OCEAN_drag         = 8.1541e-04,
 (PID.TID 0000.0001) > SEAICE_waterDrag   = 5.3508E-03,
 (PID.TID 0000.0001) > SEAICEuseDYNAMICS  =.FALSE.,
 (PID.TID 0000.0001) > LSR_ERROR          = 1.E-12,
-(PID.TID 0000.0001) > SEAICElinearIterMax= 1500,
+(PID.TID 0000.0001) > SEAICElinearIterMax= 500,
 (PID.TID 0000.0001) > LSR_mixIniGuess    = 1,
-(PID.TID 0000.0001) > SEAICEadvScheme    = 77,
+(PID.TID 0000.0001) ># this is default anyway, so we comment it out
+(PID.TID 0000.0001) >#SEAICEuseFlooding  = .TRUE.,
+(PID.TID 0000.0001) >#SEAICEadvScheme    = 77,
 (PID.TID 0000.0001) >#SEAICEadvSnow      = .TRUE.,
 (PID.TID 0000.0001) >#SEAICEadvSalt      = .TRUE.,
 (PID.TID 0000.0001) > SEAICE_no_Slip     = .FALSE.,
@@ -405,8 +404,6 @@
 (PID.TID 0000.0001) > HsaltFile          = 'const_00.bin',
 (PID.TID 0000.0001) > AreaFile           = 'ice0_area.bin',
 (PID.TID 0000.0001) > HeffFile           = 'ice0_heff.bin',
-(PID.TID 0000.0001) >#SEAICE_initialHEFF = 0.2,
-(PID.TID 0000.0001) >#uIceFile           = 'const_00.bin',
 (PID.TID 0000.0001) > SEAICEwriteState   = .TRUE.,
 (PID.TID 0000.0001) > SEAICE_monFreq = 43200.,
 (PID.TID 0000.0001) > /
@@ -434,6 +431,9 @@
 (PID.TID 0000.0001) // ===================================
 (PID.TID 0000.0001) inAdExact = /* get an exact adjoint (no approximation) */
 (PID.TID 0000.0001)                   T
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) useApproxAdvectionInAdMode = /* approximate AD-advection */
+(PID.TID 0000.0001)                   F
 (PID.TID 0000.0001)     ;
 (PID.TID 0000.0001) useKPPinAdMode = /* use KPP in adjoint mode */
 (PID.TID 0000.0001)                   F
@@ -465,8 +465,17 @@
 (PID.TID 0000.0001) mon_AdVarExch = /* control adexch before monitor */
 (PID.TID 0000.0001)                       2
 (PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) viscFacInFw = /* viscosity factor for forward model */
+(PID.TID 0000.0001)                 1.000000000000000E+00
+(PID.TID 0000.0001)     ;
 (PID.TID 0000.0001) viscFacInAd = /* viscosity factor for adjoint */
 (PID.TID 0000.0001)                 1.000000000000000E+00
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) SIregFacInAd = /* sea ice factor for adjoint model */
+(PID.TID 0000.0001)                 1.234567000000000E+05
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) SIregFacInFw = /* sea ice factor for forward model */
+(PID.TID 0000.0001)                 1.234567000000000E+05
 (PID.TID 0000.0001)     ;
 (PID.TID 0000.0001) 
 (PID.TID 0000.0001) OPTIM_READPARMS: opening data.optim
@@ -488,14 +497,35 @@
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // Parameter file "data.ctrl"
 (PID.TID 0000.0001) // =======================================================
-(PID.TID 0000.0001) > &ctrl_nml
+(PID.TID 0000.0001) ># *********************
+(PID.TID 0000.0001) ># general parameters and
+(PID.TID 0000.0001) ># non-default ECCO legacy control variables
+(PID.TID 0000.0001) ># *********************
+(PID.TID 0000.0001) > &CTRL_NML
 (PID.TID 0000.0001) >  doMainUnpack=.FALSE.,
 (PID.TID 0000.0001) >  doMainPack=.FALSE.,
+(PID.TID 0000.0001) >  ctrlprec = 32,
 (PID.TID 0000.0001) > /
 (PID.TID 0000.0001) >#
-(PID.TID 0000.0001) > &ctrl_packnames
+(PID.TID 0000.0001) ># *********************
+(PID.TID 0000.0001) ># names for ctrl_pack/unpack
+(PID.TID 0000.0001) ># *********************
+(PID.TID 0000.0001) > &CTRL_PACKNAMES
 (PID.TID 0000.0001) > /
-(PID.TID 0000.0001) >
+(PID.TID 0000.0001) >#
+(PID.TID 0000.0001) ># *********************
+(PID.TID 0000.0001) ># names for CTRL_GENARR, CTRL_GENTIM
+(PID.TID 0000.0001) ># *********************
+(PID.TID 0000.0001) > &CTRL_NML_GENARR
+(PID.TID 0000.0001) > xx_gentim2d_file(1)       = 'xx_atemp',
+(PID.TID 0000.0001) > xx_gentim2d_weight(1)     = 'ones_32b.bin',
+(PID.TID 0000.0001) >#
+(PID.TID 0000.0001) > xx_gentim2d_file(2)       = 'xx_swdown',
+(PID.TID 0000.0001) > xx_gentim2d_weight(2)     = 'ones_32b.bin',
+(PID.TID 0000.0001) >#
+(PID.TID 0000.0001) > xx_genarr3d_file(1)       = 'xx_theta',
+(PID.TID 0000.0001) > xx_genarr3d_weight(1)     = 'ones_32b.bin',
+(PID.TID 0000.0001) > /
 (PID.TID 0000.0001) 
 (PID.TID 0000.0001) CTRL_READPARMS: finished reading data.ctrl
 (PID.TID 0000.0001) COST_READPARMS: opening data.cost
@@ -523,8 +553,11 @@
 (PID.TID 0000.0001) > nend             = 4,
 (PID.TID 0000.0001) >#(grdchkvarindex   = 1 fails at freezing point)
 (PID.TID 0000.0001) >#grdchkvarindex   = 1,
-(PID.TID 0000.0001) > grdchkvarindex   = 7,
-(PID.TID 0000.0001) >#grdchkvarindex   = 34,
+(PID.TID 0000.0001) ># this is xx_atemp
+(PID.TID 0000.0001) ># grdchkvarindex   = 7,
+(PID.TID 0000.0001) ># to test this with xx_gentim2d set 301, because xx_atemp is
+(PID.TID 0000.0001) ># our first control variable (see data.ctrl)
+(PID.TID 0000.0001) > grdchkvarindex   = 301,
 (PID.TID 0000.0001) > /
 (PID.TID 0000.0001) 
 (PID.TID 0000.0001) GRDCHK_READPARMS: finished reading data.grdchk
@@ -533,7 +566,7 @@
 (PID.TID 0000.0001) // Gradient check configuration  >>> START <<<
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) 
-(PID.TID 0000.0001)   grdchkvarindex :                          7
+(PID.TID 0000.0001)   grdchkvarindex :                        301
 (PID.TID 0000.0001)   eps:                              0.100E-01
 (PID.TID 0000.0001)   First location:                           1
 (PID.TID 0000.0001)   Last location:                            4
@@ -590,11 +623,12 @@
 (PID.TID 0000.0001) >#                  'SIflxAtm','SIfrwAtm',
 (PID.TID 0000.0001) >#                  'EXFqnet ','EXFempmr',
 (PID.TID 0000.0001) >#- with pkg/seaice:
-(PID.TID 0000.0001) >  fields(1:10,2) = 'SIarea  ','SIheff  ','THETA   ','SItices ',
+(PID.TID 0000.0001) >  fields(1:8,2)  = 'SIarea  ','SIheff  ','THETA   ','SItices ',
 (PID.TID 0000.0001) >#                  'SIuice  ','SIvice  ','SIhsnow ',
 (PID.TID 0000.0001) >#                  'oceQnet ','oceQsw  ','oceFWflx','oceSflux',
 (PID.TID 0000.0001) >                   'SIqnet  ','SIqsw   ','SIempmr ','oceSflux',
-(PID.TID 0000.0001) >                   'SIatmQnt','SIatmFW ',
+(PID.TID 0000.0001) >#- comment out SIatmQnt (not filled in seaice_growth_adx.F):
+(PID.TID 0000.0001) >#                  'SIatmQnt','SIatmFW ',
 (PID.TID 0000.0001) >   fileName(2) = 'iceDiag',
 (PID.TID 0000.0001) >  frequency(2) =  86400.,
 (PID.TID 0000.0001) >  missing_value(2) = -999.,
@@ -635,11 +669,12 @@
 (PID.TID 0000.0001) >#                      'SIflxAtm','SIfrwAtm',
 (PID.TID 0000.0001) >#- with pkg/seaice:
 (PID.TID 0000.0001) >#stat_fields(1:11,1) = 'SIarea  ','SIheff  ','SIhsnow ',
-(PID.TID 0000.0001) > stat_fields(1:10,1) = 'SIarea  ','SIheff  ',
+(PID.TID 0000.0001) > stat_fields(1:8,1)  = 'SIarea  ','SIheff  ',
 (PID.TID 0000.0001) >                       'THETA   ','SItices ',
 (PID.TID 0000.0001) >#                      'oceQnet ','oceQsw  ','oceFWflx','oceSflux',
 (PID.TID 0000.0001) >                       'SIqnet  ','SIqsw   ','SIempmr ','oceSflux',
-(PID.TID 0000.0001) >                       'SIatmQnt','SIatmFW ',
+(PID.TID 0000.0001) >#- comment out SIatmQnt (not filled in seaice_growth_adx.F):
+(PID.TID 0000.0001) >#                      'SIatmQnt','SIatmFW ',
 (PID.TID 0000.0001) >  stat_fName(1) = 'iceStDiag',
 (PID.TID 0000.0001) >   stat_freq(1) = 43200.,
 (PID.TID 0000.0001) >  stat_phase(1) = 3600.,
@@ -676,7 +711,7 @@
 (PID.TID 0000.0001)  Averaging Freq.:      86400.000000 , Phase:           0.000000 , Cycle:   1
 (PID.TID 0000.0001)  missing value: -9.990000000000E+02
 (PID.TID 0000.0001)  Levels:    will be set later
-(PID.TID 0000.0001)  Fields:    SIarea   SIheff   THETA    SItices  SIqnet   SIqsw    SIempmr  oceSflux SIatmQnt SIatmFW
+(PID.TID 0000.0001)  Fields:    SIarea   SIheff   THETA    SItices  SIqnet   SIqsw    SIempmr  oceSflux
 (PID.TID 0000.0001) Creating Output Stream: snapshot
 (PID.TID 0000.0001) Output Frequency:     -86400.000000 ; Phase:       -3600.000000
 (PID.TID 0000.0001)  Averaging Freq.:          0.000000 , Phase:           0.000000 , Cycle:   1
@@ -688,7 +723,7 @@
 (PID.TID 0000.0001) Creating Stats. Output Stream: iceStDiag
 (PID.TID 0000.0001) Output Frequency:      43200.000000 ; Phase:        3600.000000
 (PID.TID 0000.0001)  Regions:   0
-(PID.TID 0000.0001)  Fields:    SIarea   SIheff   THETA    SItices  SIqnet   SIqsw    SIempmr  oceSflux SIatmQnt SIatmFW
+(PID.TID 0000.0001)  Fields:    SIarea   SIheff   THETA    SItices  SIqnet   SIqsw    SIempmr  oceSflux
 (PID.TID 0000.0001) -----------------------------------------------------
 (PID.TID 0000.0001) 
 (PID.TID 0000.0001) SET_PARMS: done
@@ -1405,13 +1440,13 @@
 (PID.TID 0000.0001) ctrl-wet 4: surface wet S =          760
 (PID.TID 0000.0001) ctrl-wet 4a:surface wet V =            0
 (PID.TID 0000.0001) ctrl-wet 5: 3D wet points =          800
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =     1           1
+(PID.TID 0000.0001) ctrl-wet 6: no recs for i =     1           0
 (PID.TID 0000.0001) ctrl-wet 6: no recs for i =     2           0
 (PID.TID 0000.0001) ctrl-wet 6: no recs for i =     3           0
 (PID.TID 0000.0001) ctrl-wet 6: no recs for i =     4           0
 (PID.TID 0000.0001) ctrl-wet 6: no recs for i =     5           0
 (PID.TID 0000.0001) ctrl-wet 6: no recs for i =     6           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =     7           1
+(PID.TID 0000.0001) ctrl-wet 6: no recs for i =     7           0
 (PID.TID 0000.0001) ctrl-wet 6: no recs for i =     8           0
 (PID.TID 0000.0001) ctrl-wet 6: no recs for i =     9           0
 (PID.TID 0000.0001) ctrl-wet 6: no recs for i =    10           0
@@ -1438,7 +1473,7 @@
 (PID.TID 0000.0001) ctrl-wet 6: no recs for i =    31           0
 (PID.TID 0000.0001) ctrl-wet 6: no recs for i =    32           0
 (PID.TID 0000.0001) ctrl-wet 6: no recs for i =    33           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =    34           1
+(PID.TID 0000.0001) ctrl-wet 6: no recs for i =    34           0
 (PID.TID 0000.0001) ctrl-wet 6: no recs for i =    35           0
 (PID.TID 0000.0001) ctrl-wet 6: no recs for i =    36           0
 (PID.TID 0000.0001) ctrl-wet 6: no recs for i =    37           0
@@ -1465,8 +1500,348 @@
 (PID.TID 0000.0001) ctrl-wet 6: no recs for i =    58           0
 (PID.TID 0000.0001) ctrl-wet 6: no recs for i =    59           0
 (PID.TID 0000.0001) ctrl-wet 6: no recs for i =    60           0
+(PID.TID 0000.0001) ctrl-wet 6: no recs for i =    61           0
+(PID.TID 0000.0001) ctrl-wet 6: no recs for i =    62           0
+(PID.TID 0000.0001) ctrl-wet 6: no recs for i =    63           0
+(PID.TID 0000.0001) ctrl-wet 6: no recs for i =    64           0
+(PID.TID 0000.0001) ctrl-wet 6: no recs for i =    65           0
+(PID.TID 0000.0001) ctrl-wet 6: no recs for i =    66           0
+(PID.TID 0000.0001) ctrl-wet 6: no recs for i =    67           0
+(PID.TID 0000.0001) ctrl-wet 6: no recs for i =    68           0
+(PID.TID 0000.0001) ctrl-wet 6: no recs for i =    69           0
+(PID.TID 0000.0001) ctrl-wet 6: no recs for i =    70           0
+(PID.TID 0000.0001) ctrl-wet 6: no recs for i =    71           0
+(PID.TID 0000.0001) ctrl-wet 6: no recs for i =    72           0
+(PID.TID 0000.0001) ctrl-wet 6: no recs for i =    73           0
+(PID.TID 0000.0001) ctrl-wet 6: no recs for i =    74           0
+(PID.TID 0000.0001) ctrl-wet 6: no recs for i =    75           0
+(PID.TID 0000.0001) ctrl-wet 6: no recs for i =    76           0
+(PID.TID 0000.0001) ctrl-wet 6: no recs for i =    77           0
+(PID.TID 0000.0001) ctrl-wet 6: no recs for i =    78           0
+(PID.TID 0000.0001) ctrl-wet 6: no recs for i =    79           0
+(PID.TID 0000.0001) ctrl-wet 6: no recs for i =    80           0
+(PID.TID 0000.0001) ctrl-wet 6: no recs for i =    81           0
+(PID.TID 0000.0001) ctrl-wet 6: no recs for i =    82           0
+(PID.TID 0000.0001) ctrl-wet 6: no recs for i =    83           0
+(PID.TID 0000.0001) ctrl-wet 6: no recs for i =    84           0
+(PID.TID 0000.0001) ctrl-wet 6: no recs for i =    85           0
+(PID.TID 0000.0001) ctrl-wet 6: no recs for i =    86           0
+(PID.TID 0000.0001) ctrl-wet 6: no recs for i =    87           0
+(PID.TID 0000.0001) ctrl-wet 6: no recs for i =    88           0
+(PID.TID 0000.0001) ctrl-wet 6: no recs for i =    89           0
+(PID.TID 0000.0001) ctrl-wet 6: no recs for i =    90           0
+(PID.TID 0000.0001) ctrl-wet 6: no recs for i =    91           0
+(PID.TID 0000.0001) ctrl-wet 6: no recs for i =    92           0
+(PID.TID 0000.0001) ctrl-wet 6: no recs for i =    93           0
+(PID.TID 0000.0001) ctrl-wet 6: no recs for i =    94           0
+(PID.TID 0000.0001) ctrl-wet 6: no recs for i =    95           0
+(PID.TID 0000.0001) ctrl-wet 6: no recs for i =    96           0
+(PID.TID 0000.0001) ctrl-wet 6: no recs for i =    97           0
+(PID.TID 0000.0001) ctrl-wet 6: no recs for i =    98           0
+(PID.TID 0000.0001) ctrl-wet 6: no recs for i =    99           0
+(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   100           0
+(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   101           0
+(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   102           0
+(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   103           0
+(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   104           0
+(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   105           0
+(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   106           0
+(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   107           0
+(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   108           0
+(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   109           0
+(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   110           0
+(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   111           0
+(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   112           0
+(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   113           0
+(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   114           0
+(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   115           0
+(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   116           0
+(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   117           0
+(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   118           0
+(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   119           0
+(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   120           0
+(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   121           0
+(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   122           0
+(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   123           0
+(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   124           0
+(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   125           0
+(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   126           0
+(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   127           0
+(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   128           0
+(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   129           0
+(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   130           0
+(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   131           0
+(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   132           0
+(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   133           0
+(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   134           0
+(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   135           0
+(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   136           0
+(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   137           0
+(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   138           0
+(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   139           0
+(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   140           0
+(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   141           0
+(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   142           0
+(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   143           0
+(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   144           0
+(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   145           0
+(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   146           0
+(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   147           0
+(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   148           0
+(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   149           0
+(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   150           0
+(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   151           0
+(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   152           0
+(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   153           0
+(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   154           0
+(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   155           0
+(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   156           0
+(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   157           0
+(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   158           0
+(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   159           0
+(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   160           0
+(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   161           0
+(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   162           0
+(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   163           0
+(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   164           0
+(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   165           0
+(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   166           0
+(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   167           0
+(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   168           0
+(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   169           0
+(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   170           0
+(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   171           0
+(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   172           0
+(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   173           0
+(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   174           0
+(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   175           0
+(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   176           0
+(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   177           0
+(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   178           0
+(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   179           0
+(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   180           0
+(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   181           0
+(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   182           0
+(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   183           0
+(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   184           0
+(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   185           0
+(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   186           0
+(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   187           0
+(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   188           0
+(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   189           0
+(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   190           0
+(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   191           0
+(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   192           0
+(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   193           0
+(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   194           0
+(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   195           0
+(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   196           0
+(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   197           0
+(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   198           0
+(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   199           0
+(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   200           0
+(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   201           1
+(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   202           0
+(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   203           0
+(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   204           0
+(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   205           0
+(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   206           0
+(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   207           0
+(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   208           0
+(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   209           0
+(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   210           0
+(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   211           0
+(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   212           0
+(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   213           0
+(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   214           0
+(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   215           0
+(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   216           0
+(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   217           0
+(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   218           0
+(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   219           0
+(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   220           0
+(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   221           0
+(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   222           0
+(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   223           0
+(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   224           0
+(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   225           0
+(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   226           0
+(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   227           0
+(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   228           0
+(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   229           0
+(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   230           0
+(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   231           0
+(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   232           0
+(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   233           0
+(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   234           0
+(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   235           0
+(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   236           0
+(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   237           0
+(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   238           0
+(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   239           0
+(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   240           0
+(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   241           0
+(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   242           0
+(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   243           0
+(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   244           0
+(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   245           0
+(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   246           0
+(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   247           0
+(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   248           0
+(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   249           0
+(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   250           0
+(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   251           0
+(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   252           0
+(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   253           0
+(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   254           0
+(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   255           0
+(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   256           0
+(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   257           0
+(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   258           0
+(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   259           0
+(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   260           0
+(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   261           0
+(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   262           0
+(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   263           0
+(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   264           0
+(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   265           0
+(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   266           0
+(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   267           0
+(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   268           0
+(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   269           0
+(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   270           0
+(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   271           0
+(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   272           0
+(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   273           0
+(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   274           0
+(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   275           0
+(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   276           0
+(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   277           0
+(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   278           0
+(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   279           0
+(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   280           0
+(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   281           0
+(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   282           0
+(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   283           0
+(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   284           0
+(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   285           0
+(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   286           0
+(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   287           0
+(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   288           0
+(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   289           0
+(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   290           0
+(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   291           0
+(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   292           0
+(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   293           0
+(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   294           0
+(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   295           0
+(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   296           0
+(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   297           0
+(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   298           0
+(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   299           0
+(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   300           0
+(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   301           1
+(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   302           1
+(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   303           0
+(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   304           0
+(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   305           0
+(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   306           0
+(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   307           0
+(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   308           0
+(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   309           0
+(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   310           0
+(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   311           0
+(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   312           0
+(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   313           0
+(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   314           0
+(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   315           0
+(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   316           0
+(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   317           0
+(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   318           0
+(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   319           0
+(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   320           0
+(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   321           0
+(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   322           0
+(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   323           0
+(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   324           0
+(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   325           0
+(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   326           0
+(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   327           0
+(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   328           0
+(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   329           0
+(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   330           0
+(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   331           0
+(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   332           0
+(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   333           0
+(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   334           0
+(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   335           0
+(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   336           0
+(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   337           0
+(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   338           0
+(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   339           0
+(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   340           0
+(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   341           0
+(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   342           0
+(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   343           0
+(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   344           0
+(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   345           0
+(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   346           0
+(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   347           0
+(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   348           0
+(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   349           0
+(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   350           0
+(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   351           0
+(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   352           0
+(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   353           0
+(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   354           0
+(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   355           0
+(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   356           0
+(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   357           0
+(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   358           0
+(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   359           0
+(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   360           0
+(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   361           0
+(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   362           0
+(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   363           0
+(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   364           0
+(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   365           0
+(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   366           0
+(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   367           0
+(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   368           0
+(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   369           0
+(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   370           0
+(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   371           0
+(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   372           0
+(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   373           0
+(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   374           0
+(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   375           0
+(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   376           0
+(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   377           0
+(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   378           0
+(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   379           0
+(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   380           0
+(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   381           0
+(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   382           0
+(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   383           0
+(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   384           0
+(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   385           0
+(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   386           0
+(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   387           0
+(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   388           0
+(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   389           0
+(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   390           0
+(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   391           0
+(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   392           0
+(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   393           0
+(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   394           0
+(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   395           0
+(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   396           0
+(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   397           0
+(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   398           0
+(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   399           0
+(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   400           0
 (PID.TID 0000.0001) ctrl-wet 7: flux          1600
-(PID.TID 0000.0001) ctrl-wet 8: atmos         2400
+(PID.TID 0000.0001) ctrl-wet 8: atmos         1600
 (PID.TID 0000.0001) ctrl-wet -------------------------------------------------
 (PID.TID 0000.0001) ctrl-wet 13: global nvarlength for Nr =    1        9840
 (PID.TID 0000.0001) ctrl-wet -------------------------------------------------
@@ -1474,8 +1849,8 @@
 (PID.TID 0000.0001) ctrl-wet -------------------------------------------------
 (PID.TID 0000.0001) ctrl-wet -------------------------------------------------
 (PID.TID 0000.0001) ctrl-wet -------------------------------------------------
-(PID.TID 0000.0001) ctrl_init: no. of control variables:            3
-(PID.TID 0000.0001) ctrl_init: control vector length:            9840
+(PID.TID 0000.0001) ctrl_init_wet: no. of control variables:            3
+(PID.TID 0000.0001) ctrl_init_wet: control vector length:            9840
 (PID.TID 0000.0001) 
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // control vector configuration  >>> START <<<
@@ -1492,8 +1867,27 @@
 (PID.TID 0000.0001)  bi,bj,#(c/s/w): 0001 0002 000840 000840 000840
 (PID.TID 0000.0001)  bi,bj,#(c/s/w): 0002 0002 000840 000840 000840
 (PID.TID 0000.0001) 
-(PID.TID 0000.0001)  Initial state temperature contribution:
-(PID.TID 0000.0001)  Control variable index:    0101
+(PID.TID 0000.0001)  Settings of generic controls:
+(PID.TID 0000.0001)  -----------------------------
+(PID.TID 0000.0001) 
+(PID.TID 0000.0001)  ctrlUseGen  =     T /* use generic controls */
+(PID.TID 0000.0001)  -> 3d control, genarr3d no.  1 is in use
+(PID.TID 0000.0001)       file       = xx_theta
+(PID.TID 0000.0001)       weight     = ones_32b.bin
+(PID.TID 0000.0001)       index      =  0201
+(PID.TID 0000.0001)       ncvarindex =  0301
+(PID.TID 0000.0001)  -> time variable 2D control, gentim2d no.  1 is in use
+(PID.TID 0000.0001)       file       = xx_atemp
+(PID.TID 0000.0001)       weight     = ones_32b.bin
+(PID.TID 0000.0001)       index      =  0301
+(PID.TID 0000.0001)       ncvarindex =  0401
+(PID.TID 0000.0001)       period     =  00000000 000000
+(PID.TID 0000.0001)  -> time variable 2D control, gentim2d no.  2 is in use
+(PID.TID 0000.0001)       file       = xx_swdown
+(PID.TID 0000.0001)       weight     = ones_32b.bin
+(PID.TID 0000.0001)       index      =  0302
+(PID.TID 0000.0001)       ncvarindex =  0402
+(PID.TID 0000.0001)       period     =  00000000 000000
 (PID.TID 0000.0001) 
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // control vector configuration  >>> END <<<
@@ -1501,31 +1895,29 @@
 (PID.TID 0000.0001) 
 (PID.TID 0000.0001) ------------------------------------------------------------
 (PID.TID 0000.0001) DIAGNOSTICS_SET_LEVELS: done
-(PID.TID 0000.0001)  Total Nb of available Diagnostics: ndiagt=   221
+(PID.TID 0000.0001)  Total Nb of available Diagnostics: ndiagt=   258
 (PID.TID 0000.0001)  write list of available Diagnostics to file: available_diagnostics.log
-(PID.TID 0000.0001) SETDIAG: Allocate  1 x  1 Levels for Diagnostic #   152 SIarea
-(PID.TID 0000.0001) SETDIAG: Allocate  1 x  1 Levels for Diagnostic #   155 SIheff
+(PID.TID 0000.0001) SETDIAG: Allocate  1 x  1 Levels for Diagnostic #   176 SIarea
+(PID.TID 0000.0001) SETDIAG: Allocate  1 x  1 Levels for Diagnostic #   179 SIheff
 (PID.TID 0000.0001) SETDIAG: Allocate  1 x  1 Levels for Diagnostic #    26 THETA
-(PID.TID 0000.0001) SETDIAG: Allocate  1 x  1 Levels for Diagnostic #   160 SItices
-(PID.TID 0000.0001) - NOTE - SETDIAG: Counter-mate #   152 SIarea   is already set
-(PID.TID 0000.0001) SETDIAG: Allocate  1 x  1 Levels for Diagnostic #   167 SIqnet
-(PID.TID 0000.0001) SETDIAG: Allocate  1 x  1 Levels for Diagnostic #   168 SIqsw
-(PID.TID 0000.0001) SETDIAG: Allocate  1 x  1 Levels for Diagnostic #   175 SIempmr
+(PID.TID 0000.0001) SETDIAG: Allocate  1 x  1 Levels for Diagnostic #   192 SItices
+(PID.TID 0000.0001) - NOTE - SETDIAG: Counter-mate #   176 SIarea   is already set
+(PID.TID 0000.0001) SETDIAG: Allocate  1 x  1 Levels for Diagnostic #   199 SIqnet
+(PID.TID 0000.0001) SETDIAG: Allocate  1 x  1 Levels for Diagnostic #   200 SIqsw
+(PID.TID 0000.0001) SETDIAG: Allocate  1 x  1 Levels for Diagnostic #   207 SIempmr
 (PID.TID 0000.0001) SETDIAG: Allocate  1 x  1 Levels for Diagnostic #    84 oceSflux
-(PID.TID 0000.0001) SETDIAG: Allocate  1 x  1 Levels for Diagnostic #   169 SIatmQnt
-(PID.TID 0000.0001) SETDIAG: Allocate  1 x  1 Levels for Diagnostic #   176 SIatmFW
-(PID.TID 0000.0001) SETDIAG: Allocate  1 x  1 Levels for Diagnostic #   152 SIarea
-(PID.TID 0000.0001) SETDIAG: Allocate  1 x  1 Levels for Diagnostic #   155 SIheff
+(PID.TID 0000.0001) SETDIAG: Allocate  1 x  1 Levels for Diagnostic #   176 SIarea
+(PID.TID 0000.0001) SETDIAG: Allocate  1 x  1 Levels for Diagnostic #   179 SIheff
 (PID.TID 0000.0001) SETDIAG: Allocate  1 x  1 Levels for Diagnostic #    26 THETA
-(PID.TID 0000.0001) SETDIAG: Allocate  1 x  1 Levels for Diagnostic #   160 SItices
-(PID.TID 0000.0001) - NOTE - SETDIAG: Counter-mate #   152 SIarea   is already set
-(PID.TID 0000.0001) SETDIAG: Allocate  1 x  1 Levels for Diagnostic #   167 SIqnet
-(PID.TID 0000.0001) SETDIAG: Allocate  1 x  1 Levels for Diagnostic #   168 SIqsw
-(PID.TID 0000.0001) SETDIAG: Allocate  1 x  1 Levels for Diagnostic #   175 SIempmr
+(PID.TID 0000.0001) SETDIAG: Allocate  1 x  1 Levels for Diagnostic #   192 SItices
+(PID.TID 0000.0001) - NOTE - SETDIAG: Counter-mate #   176 SIarea   is already set
+(PID.TID 0000.0001) SETDIAG: Allocate  1 x  1 Levels for Diagnostic #   199 SIqnet
+(PID.TID 0000.0001) SETDIAG: Allocate  1 x  1 Levels for Diagnostic #   200 SIqsw
+(PID.TID 0000.0001) SETDIAG: Allocate  1 x  1 Levels for Diagnostic #   207 SIempmr
 (PID.TID 0000.0001) SETDIAG: Allocate  1 x  1 Levels for Diagnostic #    84 oceSflux
-(PID.TID 0000.0001) SETDIAG: Allocate  1 x  1 Levels for Diagnostic #   169 SIatmQnt
-(PID.TID 0000.0001) SETDIAG: Allocate  1 x  1 Levels for Diagnostic #   176 SIatmFW
-(PID.TID 0000.0001)   space allocated for all diagnostics:      20 levels
+(PID.TID 0000.0001) SETDIAG: Allocate  1 x  1 Levels for Diagnostic #   201 SIatmQnt
+(PID.TID 0000.0001) SETDIAG: Allocate  1 x  1 Levels for Diagnostic #   208 SIatmFW
+(PID.TID 0000.0001)   space allocated for all diagnostics:      18 levels
 (PID.TID 0000.0001) DIAGNOSTICS_SET_POINTERS: Set levels for Outp.Stream: iceDiag
 (PID.TID 0000.0001)  Levels:       1.
 (PID.TID 0000.0001) DIAGNOSTICS_SET_POINTERS: Set levels for Outp.Stream: snapshot
@@ -1534,18 +1926,16 @@
 (PID.TID 0000.0001) ------------------------------------------------------------
 (PID.TID 0000.0001) DIAGSTATS_SET_REGIONS: define no region
 (PID.TID 0000.0001) ------------------------------------------------------------
-(PID.TID 0000.0001) SETDIAG: Allocate  1 Levels for Stats-Diag #   152 SIarea
-(PID.TID 0000.0001) SETDIAG: Allocate  1 Levels for Stats-Diag #   155 SIheff
+(PID.TID 0000.0001) SETDIAG: Allocate  1 Levels for Stats-Diag #   176 SIarea
+(PID.TID 0000.0001) SETDIAG: Allocate  1 Levels for Stats-Diag #   179 SIheff
 (PID.TID 0000.0001) SETDIAG: Allocate  1 Levels for Stats-Diag #    26 THETA
-(PID.TID 0000.0001) SETDIAG: Allocate  1 Levels for Stats-Diag #   160 SItices
-(PID.TID 0000.0001) - NOTE - SETDIAG: Counter Diagnostic #   152 SIarea   has already been set
-(PID.TID 0000.0001) SETDIAG: Allocate  1 Levels for Stats-Diag #   167 SIqnet
-(PID.TID 0000.0001) SETDIAG: Allocate  1 Levels for Stats-Diag #   168 SIqsw
-(PID.TID 0000.0001) SETDIAG: Allocate  1 Levels for Stats-Diag #   175 SIempmr
+(PID.TID 0000.0001) SETDIAG: Allocate  1 Levels for Stats-Diag #   192 SItices
+(PID.TID 0000.0001) - NOTE - SETDIAG: Counter Diagnostic #   176 SIarea   has already been set
+(PID.TID 0000.0001) SETDIAG: Allocate  1 Levels for Stats-Diag #   199 SIqnet
+(PID.TID 0000.0001) SETDIAG: Allocate  1 Levels for Stats-Diag #   200 SIqsw
+(PID.TID 0000.0001) SETDIAG: Allocate  1 Levels for Stats-Diag #   207 SIempmr
 (PID.TID 0000.0001) SETDIAG: Allocate  1 Levels for Stats-Diag #    84 oceSflux
-(PID.TID 0000.0001) SETDIAG: Allocate  1 Levels for Stats-Diag #   169 SIatmQnt
-(PID.TID 0000.0001) SETDIAG: Allocate  1 Levels for Stats-Diag #   176 SIatmFW
-(PID.TID 0000.0001)   space allocated for all stats-diags:      10 levels
+(PID.TID 0000.0001)   space allocated for all stats-diags:       8 levels
 (PID.TID 0000.0001) DIAGSTATS_SET_POINTERS: done
 (PID.TID 0000.0001) ------------------------------------------------------------
 (PID.TID 0000.0001) DIAGSTATS_INI_IO: open file: iceStDiag.0000000000.txt , unit=     9
@@ -1587,7 +1977,7 @@
 (PID.TID 0000.0001) tRef =   /* Reference temperature profile ( oC or K ) */
 (PID.TID 0000.0001)                -1.620000000000000E+00       /* K =  1 */
 (PID.TID 0000.0001)     ;
-(PID.TID 0000.0001) sRef =   /* Reference salinity profile ( psu ) */
+(PID.TID 0000.0001) sRef =   /* Reference salinity profile ( g/kg ) */
 (PID.TID 0000.0001)                 3.000000000000000E+01       /* K =  1 */
 (PID.TID 0000.0001)     ;
 (PID.TID 0000.0001) useStrainTensionVisc= /* Use StrainTension Form of Viscous Operator */
@@ -1683,7 +2073,7 @@
 (PID.TID 0000.0001) tAlpha = /* Linear EOS thermal expansion coefficient ( 1/oC ) */
 (PID.TID 0000.0001)                 2.000000000000000E-04
 (PID.TID 0000.0001)     ;
-(PID.TID 0000.0001) sBeta  = /* Linear EOS haline contraction coefficient ( 1/psu ) */
+(PID.TID 0000.0001) sBeta  = /* Linear EOS haline contraction coefficient ( 1/(g/kg) ) */
 (PID.TID 0000.0001)                 0.000000000000000E+00
 (PID.TID 0000.0001)     ;
 (PID.TID 0000.0001) rhoNil    = /* Reference density for Linear EOS ( kg/m^3 ) */
@@ -1793,7 +2183,7 @@
 (PID.TID 0000.0001) temp_EvPrRn = /* Temp. of Evap/Prec/R (UNSET=use local T)(oC)*/
 (PID.TID 0000.0001)                 1.234567000000000E+05
 (PID.TID 0000.0001)     ;
-(PID.TID 0000.0001) salt_EvPrRn = /* Salin. of Evap/Prec/R (UNSET=use local S)(psu)*/
+(PID.TID 0000.0001) salt_EvPrRn = /* Salin. of Evap/Prec/R (UNSET=use local S)(g/kg)*/
 (PID.TID 0000.0001)                 0.000000000000000E+00
 (PID.TID 0000.0001)     ;
 (PID.TID 0000.0001) selectAddFluid = /* option for mass source/sink of fluid (=0: off) */
@@ -1802,10 +2192,10 @@
 (PID.TID 0000.0001) temp_addMass = /* Temp. of addMass array (UNSET=use local T)(oC)*/
 (PID.TID 0000.0001)                 1.234567000000000E+05
 (PID.TID 0000.0001)     ;
-(PID.TID 0000.0001) salt_addMass = /* Salin. of addMass array (UNSET=use local S)(psu)*/
+(PID.TID 0000.0001) salt_addMass = /* Salin. of addMass array (UNSET=use local S)(g/kg)*/
 (PID.TID 0000.0001)                 0.000000000000000E+00
 (PID.TID 0000.0001)     ;
-(PID.TID 0000.0001) convertFW2Salt = /* convert F.W. Flux to Salt Flux (-1=use local S)(psu)*/
+(PID.TID 0000.0001) convertFW2Salt = /* convert F.W. Flux to Salt Flux (-1=use local S)(g/kg)*/
 (PID.TID 0000.0001)                -1.000000000000000E+00
 (PID.TID 0000.0001)     ;
 (PID.TID 0000.0001) use3Dsolver = /* use 3-D pressure solver on/off flag */
@@ -2056,7 +2446,7 @@
 (PID.TID 0000.0001)                 4.320000000000000E+05
 (PID.TID 0000.0001)     ;
 (PID.TID 0000.0001) pChkPtFreq = /* Permanent restart/pickup file interval ( s ) */
-(PID.TID 0000.0001)                 3.600000000000000E+06
+(PID.TID 0000.0001)                 5.184000000000000E+06
 (PID.TID 0000.0001)     ;
 (PID.TID 0000.0001) chkPtFreq  = /* Rolling restart/pickup file interval ( s ) */
 (PID.TID 0000.0001)                 0.000000000000000E+00
@@ -2080,7 +2470,7 @@
 (PID.TID 0000.0001)                   T
 (PID.TID 0000.0001)     ;
 (PID.TID 0000.0001) monitorFreq =   /* Monitor output interval ( s ). */
-(PID.TID 0000.0001)                 4.320000000000000E+05
+(PID.TID 0000.0001)                 2.160000000000000E+05
 (PID.TID 0000.0001)     ;
 (PID.TID 0000.0001) monitorSelect = /* select group of variables to monitor */
 (PID.TID 0000.0001)                       2
@@ -2363,7 +2753,9 @@
 (PID.TID 0000.0001) 
 (PID.TID 0000.0001) EXF_CHECK: #define ALLOW_EXF
 (PID.TID 0000.0001) SEAICE_CHECK: #define ALLOW_SEAICE
-(PID.TID 0000.0001) CTRL_CHECK: #define ALLOW_CTRL
+(PID.TID 0000.0001) CTRL_CHECK:  --> Starts to check CTRL set-up
+(PID.TID 0000.0001) CTRL_CHECK:  <-- Ends Normally
+(PID.TID 0000.0001) 
 (PID.TID 0000.0001) COST_CHECK: #define ALLOW_COST
 (PID.TID 0000.0001) GRDCHK_CHECK: grdchk package
 (PID.TID 0000.0001) GAD_CHECK: #define ALLOW_GENERIC_ADVDIFF
@@ -2805,6 +3197,63 @@
  ph-ice C           58   1694757520.7312348     
  ph-ice B           59  -1.5737498275105886       0.98162212455183684       0.19218410451932219     
  ph-ice C           59   1721898629.1440599     
+(PID.TID 0000.0001) // =======================================================
+(PID.TID 0000.0001) // Begin MONITOR dynamic field statistics
+(PID.TID 0000.0001) // =======================================================
+(PID.TID 0000.0001) %MON time_tsnumber                =                    60
+(PID.TID 0000.0001) %MON time_secondsf                =   2.1600000000000E+05
+(PID.TID 0000.0001) %MON dynstat_eta_max              =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON dynstat_eta_min              =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON dynstat_eta_mean             =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON dynstat_eta_sd               =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON dynstat_eta_del2             =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON dynstat_uvel_max             =   2.0000000000000E-01
+(PID.TID 0000.0001) %MON dynstat_uvel_min             =   2.0000000000000E-01
+(PID.TID 0000.0001) %MON dynstat_uvel_mean            =   2.0000000000000E-01
+(PID.TID 0000.0001) %MON dynstat_uvel_sd              =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON dynstat_uvel_del2            =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON dynstat_vvel_max             =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON dynstat_vvel_min             =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON dynstat_vvel_mean            =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON dynstat_vvel_sd              =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON dynstat_vvel_del2            =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON dynstat_wvel_max             =  -0.0000000000000E+00
+(PID.TID 0000.0001) %MON dynstat_wvel_min             =  -0.0000000000000E+00
+(PID.TID 0000.0001) %MON dynstat_wvel_mean            =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON dynstat_wvel_sd              =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON dynstat_wvel_del2            =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON dynstat_theta_max            =  -1.1918289050661E+00
+(PID.TID 0000.0001) %MON dynstat_theta_min            =  -1.6083565301653E+00
+(PID.TID 0000.0001) %MON dynstat_theta_mean           =  -1.5747989276423E+00
+(PID.TID 0000.0001) %MON dynstat_theta_sd             =   5.3385989004639E-02
+(PID.TID 0000.0001) %MON dynstat_theta_del2           =   7.5005005311126E-04
+(PID.TID 0000.0001) %MON dynstat_salt_max             =   3.0000000000000E+01
+(PID.TID 0000.0001) %MON dynstat_salt_min             =   3.0000000000000E+01
+(PID.TID 0000.0001) %MON dynstat_salt_mean            =   3.0000000000000E+01
+(PID.TID 0000.0001) %MON dynstat_salt_sd              =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON dynstat_salt_del2            =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON trAdv_CFL_u_max              =   1.4400000000000E-01
+(PID.TID 0000.0001) %MON trAdv_CFL_v_max              =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON trAdv_CFL_w_max              =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON advcfl_uvel_max              =   1.4400000000000E-01
+(PID.TID 0000.0001) %MON advcfl_vvel_max              =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON advcfl_wvel_max              =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON advcfl_W_hf_max              =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON pe_b_mean                    =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON ke_max                       =   2.0000000000000E-02
+(PID.TID 0000.0001) %MON ke_mean                      =   2.0000000000000E-02
+(PID.TID 0000.0001) %MON ke_vol                       =   8.2000000000000E+11
+(PID.TID 0000.0001) %MON vort_r_min                   =  -4.0000000000000E-05
+(PID.TID 0000.0001) %MON vort_r_max                   =   4.0000000000000E-05
+(PID.TID 0000.0001) %MON vort_a_mean                  =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON vort_a_sd                    =   8.7287156094397E-06
+(PID.TID 0000.0001) %MON vort_p_mean                  =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON vort_p_sd                    =   1.7777777777778E-05
+(PID.TID 0000.0001) %MON surfExpan_theta_mean         =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON surfExpan_salt_mean          =   0.0000000000000E+00
+(PID.TID 0000.0001) // =======================================================
+(PID.TID 0000.0001) // End MONITOR dynamic field statistics
+(PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // Begin MONITOR SEAICE statistics
 (PID.TID 0000.0001) // =======================================================
@@ -3442,6 +3891,77 @@
  ph-ice C          119   3244366142.1855283     
 (PID.TID 0000.0001) Did not write pickup because writePickupAtEnd = FALSE
 (PID.TID 0000.0001) Did not write pickup because writePickupAtEnd = FALSE
+(PID.TID 0000.0001) // =======================================================
+(PID.TID 0000.0001) // Begin AD_MONITOR dynamic field statistics
+(PID.TID 0000.0001) // =======================================================
+(PID.TID 0000.0001) %MON ad_time_tsnumber             =                   120
+(PID.TID 0000.0001) %MON ad_time_secondsf             =   4.3200000000000E+05
+(PID.TID 0000.0001) %MON ad_dynstat_adeta_max         =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON ad_dynstat_adeta_min         =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON ad_dynstat_adeta_mean        =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON ad_dynstat_adeta_sd          =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON ad_dynstat_adeta_del2        =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON ad_dynstat_aduvel_max        =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON ad_dynstat_aduvel_min        =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON ad_dynstat_aduvel_mean       =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON ad_dynstat_aduvel_sd         =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON ad_dynstat_aduvel_del2       =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON ad_dynstat_advvel_max        =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON ad_dynstat_advvel_min        =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON ad_dynstat_advvel_mean       =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON ad_dynstat_advvel_sd         =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON ad_dynstat_advvel_del2       =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON ad_dynstat_adwvel_max        =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON ad_dynstat_adwvel_min        =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON ad_dynstat_adwvel_mean       =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON ad_dynstat_adwvel_sd         =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON ad_dynstat_adwvel_del2       =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON ad_dynstat_adtheta_max       =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON ad_dynstat_adtheta_min       =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON ad_dynstat_adtheta_mean      =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON ad_dynstat_adtheta_sd        =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON ad_dynstat_adtheta_del2      =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON ad_dynstat_adsalt_max        =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON ad_dynstat_adsalt_min        =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON ad_dynstat_adsalt_mean       =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON ad_dynstat_adsalt_sd         =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON ad_dynstat_adsalt_del2       =   0.0000000000000E+00
+(PID.TID 0000.0001) // =======================================================
+(PID.TID 0000.0001) // End AD_MONITOR dynamic field statistics
+(PID.TID 0000.0001) // =======================================================
+(PID.TID 0000.0001) // =======================================================
+(PID.TID 0000.0001) // Begin AD_MONITOR SEAICE statistics
+(PID.TID 0000.0001) // =======================================================
+(PID.TID 0000.0001) %MON ad_seaice_tsnumber           =                   120
+(PID.TID 0000.0001) %MON ad_seaice_time_sec           =   4.3200000000000E+05
+(PID.TID 0000.0001) %MON ad_seaice_aduice_max         =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON ad_seaice_aduice_min         =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON ad_seaice_aduice_mean        =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON ad_seaice_aduice_sd          =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON ad_seaice_aduice_del2        =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON ad_seaice_advice_max         =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON ad_seaice_advice_min         =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON ad_seaice_advice_mean        =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON ad_seaice_advice_sd          =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON ad_seaice_advice_del2        =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON ad_seaice_adarea_max         =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON ad_seaice_adarea_min         =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON ad_seaice_adarea_mean        =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON ad_seaice_adarea_sd          =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON ad_seaice_adarea_del2        =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON ad_seaice_adheff_max         =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON ad_seaice_adheff_min         =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON ad_seaice_adheff_mean        =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON ad_seaice_adheff_sd          =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON ad_seaice_adheff_del2        =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON ad_seaice_adhsnow_max        =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON ad_seaice_adhsnow_min        =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON ad_seaice_adhsnow_mean       =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON ad_seaice_adhsnow_sd         =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON ad_seaice_adhsnow_del2       =   0.0000000000000E+00
+(PID.TID 0000.0001) // =======================================================
+(PID.TID 0000.0001) // End AD_MONITOR SEAICE statistics
+(PID.TID 0000.0001) // =======================================================
  ph-ice B          110  -1.5603215291267247       0.95827144042976076       0.18185865275628374     
  ph-ice C          110   3029658625.3316388     
  ph-ice B          111  -1.5601305473156073       0.95779456511698902       0.18164393756979080     
@@ -3482,6 +4002,191 @@
  ph-ice C           98   2735745011.7420526     
  ph-ice B           99  -1.5625393944989743       0.96348691648055784       0.18419749009571190     
  ph-ice C           99   2760568439.1643796     
+(PID.TID 0000.0001) // =======================================================
+(PID.TID 0000.0001) // Begin AD_MONITOR EXF statistics for iwhen =  3
+(PID.TID 0000.0001) // =======================================================
+(PID.TID 0000.0001) %MON ad_exf_tsnumber              =                    96
+(PID.TID 0000.0001) %MON ad_exf_time_sec              =   3.4560000000000E+05
+(PID.TID 0000.0001) %MON ad_exf_adfu_max              =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON ad_exf_adfu_min              =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON ad_exf_adfu_mean             =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON ad_exf_adfu_sd               =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON ad_exf_adfu_del2             =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON ad_exf_adfv_max              =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON ad_exf_adfv_min              =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON ad_exf_adfv_mean             =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON ad_exf_adfv_sd               =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON ad_exf_adfv_del2             =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON ad_exf_adqnet_max            =   5.0634774162520E-14
+(PID.TID 0000.0001) %MON ad_exf_adqnet_min            =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON ad_exf_adqnet_mean           =   1.4344912575391E-14
+(PID.TID 0000.0001) %MON ad_exf_adqnet_sd             =   6.4642295776161E-15
+(PID.TID 0000.0001) %MON ad_exf_adqnet_del2           =   1.5637647852900E-16
+(PID.TID 0000.0001) %MON ad_exf_adempmr_max           =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON ad_exf_adempmr_min           =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON ad_exf_adempmr_mean          =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON ad_exf_adempmr_sd            =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON ad_exf_adempmr_del2          =   0.0000000000000E+00
+(PID.TID 0000.0001) // =======================================================
+(PID.TID 0000.0001) // End AD_MONITOR EXF statistics for iwhen =  3
+(PID.TID 0000.0001) // =======================================================
+(PID.TID 0000.0001) // =======================================================
+(PID.TID 0000.0001) // Begin AD_MONITOR EXF statistics for iwhen =  1
+(PID.TID 0000.0001) // =======================================================
+(PID.TID 0000.0001) %MON ad_exf_tsnumber              =                    96
+(PID.TID 0000.0001) %MON ad_exf_time_sec              =   3.4560000000000E+05
+(PID.TID 0000.0001) %MON ad_exf_adustress_max         =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON ad_exf_adustress_min         =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON ad_exf_adustress_mean        =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON ad_exf_adustress_sd          =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON ad_exf_adustress_del2        =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON ad_exf_advstress_max         =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON ad_exf_advstress_min         =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON ad_exf_advstress_mean        =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON ad_exf_advstress_sd          =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON ad_exf_advstress_del2        =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON ad_exf_adhflux_max           =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON ad_exf_adhflux_min           =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON ad_exf_adhflux_mean          =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON ad_exf_adhflux_sd            =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON ad_exf_adhflux_del2          =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON ad_exf_adsflux_max           =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON ad_exf_adsflux_min           =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON ad_exf_adsflux_mean          =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON ad_exf_adsflux_sd            =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON ad_exf_adsflux_del2          =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON ad_exf_adwspeed_max          =   2.2383642385942E-14
+(PID.TID 0000.0001) %MON ad_exf_adwspeed_min          =  -3.9138863052746E-13
+(PID.TID 0000.0001) %MON ad_exf_adwspeed_mean         =  -7.2117620614939E-14
+(PID.TID 0000.0001) %MON ad_exf_adwspeed_sd           =   1.3341352489460E-13
+(PID.TID 0000.0001) %MON ad_exf_adwspeed_del2         =   1.3484704673669E-15
+(PID.TID 0000.0001) // =======================================================
+(PID.TID 0000.0001) // End AD_MONITOR EXF statistics for iwhen =  1
+(PID.TID 0000.0001) // =======================================================
+(PID.TID 0000.0001) // =======================================================
+(PID.TID 0000.0001) // Begin AD_MONITOR EXF statistics for iwhen =  2
+(PID.TID 0000.0001) // =======================================================
+(PID.TID 0000.0001) %MON ad_exf_tsnumber              =                    96
+(PID.TID 0000.0001) %MON ad_exf_time_sec              =   3.4560000000000E+05
+(PID.TID 0000.0001) %MON ad_exf_aduwind_max           =   4.1428227949941E-13
+(PID.TID 0000.0001) %MON ad_exf_aduwind_min           =  -4.4435438335535E-13
+(PID.TID 0000.0001) %MON ad_exf_aduwind_mean          =  -6.5660596032606E-14
+(PID.TID 0000.0001) %MON ad_exf_aduwind_sd            =   1.7180879915172E-13
+(PID.TID 0000.0001) %MON ad_exf_aduwind_del2          =   1.8231491989692E-15
+(PID.TID 0000.0001) %MON ad_exf_advwind_max           =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON ad_exf_advwind_min           =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON ad_exf_advwind_mean          =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON ad_exf_advwind_sd            =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON ad_exf_advwind_del2          =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON ad_exf_adatemp_max           =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON ad_exf_adatemp_min           =  -1.1762161138076E-12
+(PID.TID 0000.0001) %MON ad_exf_adatemp_mean          =  -4.2442470333845E-13
+(PID.TID 0000.0001) %MON ad_exf_adatemp_sd            =   3.4981854042792E-13
+(PID.TID 0000.0001) %MON ad_exf_adatemp_del2          =   5.3634952381680E-15
+(PID.TID 0000.0001) %MON ad_exf_adaqh_max             =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON ad_exf_adaqh_min             =  -3.3937354656610E-09
+(PID.TID 0000.0001) %MON ad_exf_adaqh_mean            =  -1.2316716019916E-09
+(PID.TID 0000.0001) %MON ad_exf_adaqh_sd              =   1.0277245116677E-09
+(PID.TID 0000.0001) %MON ad_exf_adaqh_del2            =   1.5624339494003E-11
+(PID.TID 0000.0001) %MON ad_exf_adlwflux_max          =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON ad_exf_adlwflux_min          =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON ad_exf_adlwflux_mean         =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON ad_exf_adlwflux_sd           =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON ad_exf_adlwflux_del2         =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON ad_exf_adprecip_max          =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON ad_exf_adprecip_min          =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON ad_exf_adprecip_mean         =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON ad_exf_adprecip_sd           =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON ad_exf_adprecip_del2         =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON ad_exf_adswdown_max          =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON ad_exf_adswdown_min          =  -3.7372928400188E-14
+(PID.TID 0000.0001) %MON ad_exf_adswdown_mean         =  -8.1582006839259E-15
+(PID.TID 0000.0001) %MON ad_exf_adswdown_sd           =   6.6761867693230E-15
+(PID.TID 0000.0001) %MON ad_exf_adswdown_del2         =   1.2667657971778E-16
+(PID.TID 0000.0001) %MON ad_exf_adlwdown_max          =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON ad_exf_adlwdown_min          =  -5.5672153269191E-14
+(PID.TID 0000.0001) %MON ad_exf_adlwdown_mean         =  -2.0967774990448E-14
+(PID.TID 0000.0001) %MON ad_exf_adlwdown_sd           =   1.7743563766416E-14
+(PID.TID 0000.0001) %MON ad_exf_adlwdown_del2         =   2.7611005350800E-16
+(PID.TID 0000.0001) %MON ad_exf_adrunoff_max          =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON ad_exf_adrunoff_min          =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON ad_exf_adrunoff_mean         =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON ad_exf_adrunoff_sd           =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON ad_exf_adrunoff_del2         =   0.0000000000000E+00
+(PID.TID 0000.0001) // =======================================================
+(PID.TID 0000.0001) // End AD_MONITOR EXF statistics for iwhen =  2
+(PID.TID 0000.0001) // =======================================================
+(PID.TID 0000.0001) // =======================================================
+(PID.TID 0000.0001) // Begin AD_MONITOR dynamic field statistics
+(PID.TID 0000.0001) // =======================================================
+(PID.TID 0000.0001) %MON ad_time_tsnumber             =                    96
+(PID.TID 0000.0001) %MON ad_time_secondsf             =   3.4560000000000E+05
+(PID.TID 0000.0001) %MON ad_dynstat_adeta_max         =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON ad_dynstat_adeta_min         =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON ad_dynstat_adeta_mean        =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON ad_dynstat_adeta_sd          =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON ad_dynstat_adeta_del2        =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON ad_dynstat_aduvel_max        =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON ad_dynstat_aduvel_min        =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON ad_dynstat_aduvel_mean       =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON ad_dynstat_aduvel_sd         =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON ad_dynstat_aduvel_del2       =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON ad_dynstat_advvel_max        =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON ad_dynstat_advvel_min        =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON ad_dynstat_advvel_mean       =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON ad_dynstat_advvel_sd         =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON ad_dynstat_advvel_del2       =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON ad_dynstat_adwvel_max        =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON ad_dynstat_adwvel_min        =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON ad_dynstat_adwvel_mean       =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON ad_dynstat_adwvel_sd         =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON ad_dynstat_adwvel_del2       =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON ad_dynstat_adtheta_max       =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON ad_dynstat_adtheta_min       =  -6.0610545110377E-10
+(PID.TID 0000.0001) %MON ad_dynstat_adtheta_mean      =  -1.7605282354626E-10
+(PID.TID 0000.0001) %MON ad_dynstat_adtheta_sd        =   7.8022050492162E-11
+(PID.TID 0000.0001) %MON ad_dynstat_adtheta_del2      =   1.8879232580786E-12
+(PID.TID 0000.0001) %MON ad_dynstat_adsalt_max        =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON ad_dynstat_adsalt_min        =  -3.4269563950896E-11
+(PID.TID 0000.0001) %MON ad_dynstat_adsalt_mean       =  -9.9291034896884E-12
+(PID.TID 0000.0001) %MON ad_dynstat_adsalt_sd         =   4.4184232649909E-12
+(PID.TID 0000.0001) %MON ad_dynstat_adsalt_del2       =   1.0653218688991E-13
+(PID.TID 0000.0001) // =======================================================
+(PID.TID 0000.0001) // End AD_MONITOR dynamic field statistics
+(PID.TID 0000.0001) // =======================================================
+(PID.TID 0000.0001) // =======================================================
+(PID.TID 0000.0001) // Begin AD_MONITOR SEAICE statistics
+(PID.TID 0000.0001) // =======================================================
+(PID.TID 0000.0001) %MON ad_seaice_tsnumber           =                    96
+(PID.TID 0000.0001) %MON ad_seaice_time_sec           =   3.4560000000000E+05
+(PID.TID 0000.0001) %MON ad_seaice_aduice_max         =   8.8196839742197E-09
+(PID.TID 0000.0001) %MON ad_seaice_aduice_min         =  -2.8494566746339E-10
+(PID.TID 0000.0001) %MON ad_seaice_aduice_mean        =   1.9305910501572E-10
+(PID.TID 0000.0001) %MON ad_seaice_aduice_sd          =   1.2715968485503E-09
+(PID.TID 0000.0001) %MON ad_seaice_aduice_del2        =   5.5748671509504E-11
+(PID.TID 0000.0001) %MON ad_seaice_advice_max         =   9.6622993247832E-09
+(PID.TID 0000.0001) %MON ad_seaice_advice_min         =  -8.8653864956993E-09
+(PID.TID 0000.0001) %MON ad_seaice_advice_mean        =   1.1155372223471E-10
+(PID.TID 0000.0001) %MON ad_seaice_advice_sd          =   1.5896773613202E-09
+(PID.TID 0000.0001) %MON ad_seaice_advice_del2        =   6.8103681846039E-11
+(PID.TID 0000.0001) %MON ad_seaice_adarea_max         =   1.7426136025123E-10
+(PID.TID 0000.0001) %MON ad_seaice_adarea_min         =  -6.4075542206535E-11
+(PID.TID 0000.0001) %MON ad_seaice_adarea_mean        =  -3.2698712241122E-11
+(PID.TID 0000.0001) %MON ad_seaice_adarea_sd          =   3.3306699538957E-11
+(PID.TID 0000.0001) %MON ad_seaice_adarea_del2        =   6.4453596782994E-13
+(PID.TID 0000.0001) %MON ad_seaice_adheff_max         =   5.0582477923286E-09
+(PID.TID 0000.0001) %MON ad_seaice_adheff_min         =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON ad_seaice_adheff_mean        =   4.7118350608186E-09
+(PID.TID 0000.0001) %MON ad_seaice_adheff_sd          =   1.1126320760293E-09
+(PID.TID 0000.0001) %MON ad_seaice_adheff_del2        =   3.3782816405761E-11
+(PID.TID 0000.0001) %MON ad_seaice_adhsnow_max        =   1.8379912493913E-09
+(PID.TID 0000.0001) %MON ad_seaice_adhsnow_min        =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON ad_seaice_adhsnow_mean       =   1.6857317248962E-09
+(PID.TID 0000.0001) %MON ad_seaice_adhsnow_sd         =   3.9898616969475E-10
+(PID.TID 0000.0001) %MON ad_seaice_adhsnow_del2       =   1.2133298253645E-11
+(PID.TID 0000.0001) // =======================================================
+(PID.TID 0000.0001) // End AD_MONITOR SEAICE statistics
+(PID.TID 0000.0001) // =======================================================
  ph-ice B           90  -1.5645503684093980       0.96770339816767470       0.18607522337701074     
  ph-ice C           90   2535012703.7948956     
  ph-ice B           91  -1.5643164940117751       0.96723761219559112       0.18586838732449140     
@@ -3532,6 +4237,191 @@
  ph-ice C           73   2095958977.6661813     
  ph-ice B           74  -1.5687464279132974       0.97503617971188872       0.18931129152199933     
  ph-ice C           74   2122250322.0738361     
+(PID.TID 0000.0001) // =======================================================
+(PID.TID 0000.0001) // Begin AD_MONITOR EXF statistics for iwhen =  3
+(PID.TID 0000.0001) // =======================================================
+(PID.TID 0000.0001) %MON ad_exf_tsnumber              =                    72
+(PID.TID 0000.0001) %MON ad_exf_time_sec              =   2.5920000000000E+05
+(PID.TID 0000.0001) %MON ad_exf_adfu_max              =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON ad_exf_adfu_min              =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON ad_exf_adfu_mean             =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON ad_exf_adfu_sd               =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON ad_exf_adfu_del2             =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON ad_exf_adfv_max              =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON ad_exf_adfv_min              =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON ad_exf_adfv_mean             =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON ad_exf_adfv_sd               =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON ad_exf_adfv_del2             =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON ad_exf_adqnet_max            =   1.1083632397549E-13
+(PID.TID 0000.0001) %MON ad_exf_adqnet_min            =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON ad_exf_adqnet_mean           =   4.7056182285067E-14
+(PID.TID 0000.0001) %MON ad_exf_adqnet_sd             =   1.6265321196383E-14
+(PID.TID 0000.0001) %MON ad_exf_adqnet_del2           =   4.1562141863003E-16
+(PID.TID 0000.0001) %MON ad_exf_adempmr_max           =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON ad_exf_adempmr_min           =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON ad_exf_adempmr_mean          =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON ad_exf_adempmr_sd            =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON ad_exf_adempmr_del2          =   0.0000000000000E+00
+(PID.TID 0000.0001) // =======================================================
+(PID.TID 0000.0001) // End AD_MONITOR EXF statistics for iwhen =  3
+(PID.TID 0000.0001) // =======================================================
+(PID.TID 0000.0001) // =======================================================
+(PID.TID 0000.0001) // Begin AD_MONITOR EXF statistics for iwhen =  1
+(PID.TID 0000.0001) // =======================================================
+(PID.TID 0000.0001) %MON ad_exf_tsnumber              =                    72
+(PID.TID 0000.0001) %MON ad_exf_time_sec              =   2.5920000000000E+05
+(PID.TID 0000.0001) %MON ad_exf_adustress_max         =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON ad_exf_adustress_min         =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON ad_exf_adustress_mean        =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON ad_exf_adustress_sd          =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON ad_exf_adustress_del2        =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON ad_exf_advstress_max         =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON ad_exf_advstress_min         =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON ad_exf_advstress_mean        =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON ad_exf_advstress_sd          =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON ad_exf_advstress_del2        =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON ad_exf_adhflux_max           =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON ad_exf_adhflux_min           =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON ad_exf_adhflux_mean          =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON ad_exf_adhflux_sd            =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON ad_exf_adhflux_del2          =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON ad_exf_adsflux_max           =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON ad_exf_adsflux_min           =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON ad_exf_adsflux_mean          =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON ad_exf_adsflux_sd            =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON ad_exf_adsflux_del2          =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON ad_exf_adwspeed_max          =   4.1486984960606E-14
+(PID.TID 0000.0001) %MON ad_exf_adwspeed_min          =  -8.1007279695144E-13
+(PID.TID 0000.0001) %MON ad_exf_adwspeed_mean         =  -1.4825337277920E-13
+(PID.TID 0000.0001) %MON ad_exf_adwspeed_sd           =   2.7640263730036E-13
+(PID.TID 0000.0001) %MON ad_exf_adwspeed_del2         =   2.7795486789675E-15
+(PID.TID 0000.0001) // =======================================================
+(PID.TID 0000.0001) // End AD_MONITOR EXF statistics for iwhen =  1
+(PID.TID 0000.0001) // =======================================================
+(PID.TID 0000.0001) // =======================================================
+(PID.TID 0000.0001) // Begin AD_MONITOR EXF statistics for iwhen =  2
+(PID.TID 0000.0001) // =======================================================
+(PID.TID 0000.0001) %MON ad_exf_tsnumber              =                    72
+(PID.TID 0000.0001) %MON ad_exf_time_sec              =   2.5920000000000E+05
+(PID.TID 0000.0001) %MON ad_exf_aduwind_max           =   9.4807058330358E-13
+(PID.TID 0000.0001) %MON ad_exf_aduwind_min           =  -8.8678610146780E-13
+(PID.TID 0000.0001) %MON ad_exf_aduwind_mean          =  -1.2871509711993E-13
+(PID.TID 0000.0001) %MON ad_exf_aduwind_sd            =   3.5019142673104E-13
+(PID.TID 0000.0001) %MON ad_exf_aduwind_del2          =   3.8672881918320E-15
+(PID.TID 0000.0001) %MON ad_exf_advwind_max           =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON ad_exf_advwind_min           =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON ad_exf_advwind_mean          =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON ad_exf_advwind_sd            =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON ad_exf_advwind_del2          =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON ad_exf_adatemp_max           =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON ad_exf_adatemp_min           =  -2.3753868208349E-12
+(PID.TID 0000.0001) %MON ad_exf_adatemp_mean          =  -8.5546061042474E-13
+(PID.TID 0000.0001) %MON ad_exf_adatemp_sd            =   7.2089114096878E-13
+(PID.TID 0000.0001) %MON ad_exf_adatemp_del2          =   1.1022860831278E-14
+(PID.TID 0000.0001) %MON ad_exf_adaqh_max             =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON ad_exf_adaqh_min             =  -6.8106077216460E-09
+(PID.TID 0000.0001) %MON ad_exf_adaqh_mean            =  -2.4595076165545E-09
+(PID.TID 0000.0001) %MON ad_exf_adaqh_sd              =   2.0861989577823E-09
+(PID.TID 0000.0001) %MON ad_exf_adaqh_del2            =   3.1835174309735E-11
+(PID.TID 0000.0001) %MON ad_exf_adlwflux_max          =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON ad_exf_adlwflux_min          =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON ad_exf_adlwflux_mean         =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON ad_exf_adlwflux_sd           =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON ad_exf_adlwflux_del2         =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON ad_exf_adprecip_max          =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON ad_exf_adprecip_min          =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON ad_exf_adprecip_mean         =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON ad_exf_adprecip_sd           =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON ad_exf_adprecip_del2         =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON ad_exf_adswdown_max          =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON ad_exf_adswdown_min          =  -8.3836104133895E-14
+(PID.TID 0000.0001) %MON ad_exf_adswdown_mean         =  -1.9141459475064E-14
+(PID.TID 0000.0001) %MON ad_exf_adswdown_sd           =   1.5864122414963E-14
+(PID.TID 0000.0001) %MON ad_exf_adswdown_del2         =   3.0499757765530E-16
+(PID.TID 0000.0001) %MON ad_exf_adlwdown_max          =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON ad_exf_adlwdown_min          =  -1.1090320589643E-13
+(PID.TID 0000.0001) %MON ad_exf_adlwdown_mean         =  -4.1487244737004E-14
+(PID.TID 0000.0001) %MON ad_exf_adlwdown_sd           =   3.5704900299356E-14
+(PID.TID 0000.0001) %MON ad_exf_adlwdown_del2         =   5.6476148721831E-16
+(PID.TID 0000.0001) %MON ad_exf_adrunoff_max          =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON ad_exf_adrunoff_min          =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON ad_exf_adrunoff_mean         =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON ad_exf_adrunoff_sd           =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON ad_exf_adrunoff_del2         =   0.0000000000000E+00
+(PID.TID 0000.0001) // =======================================================
+(PID.TID 0000.0001) // End AD_MONITOR EXF statistics for iwhen =  2
+(PID.TID 0000.0001) // =======================================================
+(PID.TID 0000.0001) // =======================================================
+(PID.TID 0000.0001) // Begin AD_MONITOR dynamic field statistics
+(PID.TID 0000.0001) // =======================================================
+(PID.TID 0000.0001) %MON ad_time_tsnumber             =                    72
+(PID.TID 0000.0001) %MON ad_time_secondsf             =   2.5920000000000E+05
+(PID.TID 0000.0001) %MON ad_dynstat_adeta_max         =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON ad_dynstat_adeta_min         =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON ad_dynstat_adeta_mean        =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON ad_dynstat_adeta_sd          =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON ad_dynstat_adeta_del2        =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON ad_dynstat_aduvel_max        =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON ad_dynstat_aduvel_min        =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON ad_dynstat_aduvel_mean       =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON ad_dynstat_aduvel_sd         =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON ad_dynstat_aduvel_del2       =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON ad_dynstat_advvel_max        =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON ad_dynstat_advvel_min        =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON ad_dynstat_advvel_mean       =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON ad_dynstat_advvel_sd         =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON ad_dynstat_advvel_del2       =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON ad_dynstat_adwvel_max        =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON ad_dynstat_adwvel_min        =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON ad_dynstat_adwvel_mean       =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON ad_dynstat_adwvel_sd         =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON ad_dynstat_adwvel_del2       =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON ad_dynstat_adtheta_max       =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON ad_dynstat_adtheta_min       =  -1.2924751169758E-09
+(PID.TID 0000.0001) %MON ad_dynstat_adtheta_mean      =  -5.5475134976649E-10
+(PID.TID 0000.0001) %MON ad_dynstat_adtheta_sd        =   1.9018556935608E-10
+(PID.TID 0000.0001) %MON ad_dynstat_adtheta_del2      =   4.8771858857922E-12
+(PID.TID 0000.0001) %MON ad_dynstat_adsalt_max        =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON ad_dynstat_adsalt_min        =  -7.6522678776471E-11
+(PID.TID 0000.0001) %MON ad_dynstat_adsalt_mean       =  -3.1899739939598E-11
+(PID.TID 0000.0001) %MON ad_dynstat_adsalt_sd         =   1.1170261033609E-11
+(PID.TID 0000.0001) %MON ad_dynstat_adsalt_del2       =   2.8338988474674E-13
+(PID.TID 0000.0001) // =======================================================
+(PID.TID 0000.0001) // End AD_MONITOR dynamic field statistics
+(PID.TID 0000.0001) // =======================================================
+(PID.TID 0000.0001) // =======================================================
+(PID.TID 0000.0001) // Begin AD_MONITOR SEAICE statistics
+(PID.TID 0000.0001) // =======================================================
+(PID.TID 0000.0001) %MON ad_seaice_tsnumber           =                    72
+(PID.TID 0000.0001) %MON ad_seaice_time_sec           =   2.5920000000000E+05
+(PID.TID 0000.0001) %MON ad_seaice_aduice_max         =   3.3967570171712E-08
+(PID.TID 0000.0001) %MON ad_seaice_aduice_min         =  -9.1878646342695E-10
+(PID.TID 0000.0001) %MON ad_seaice_aduice_mean        =   7.4745395985736E-10
+(PID.TID 0000.0001) %MON ad_seaice_aduice_sd          =   4.9223579269956E-09
+(PID.TID 0000.0001) %MON ad_seaice_aduice_del2        =   2.1577333535223E-10
+(PID.TID 0000.0001) %MON ad_seaice_advice_max         =   3.5881096973323E-08
+(PID.TID 0000.0001) %MON ad_seaice_advice_min         =  -3.4069327852611E-08
+(PID.TID 0000.0001) %MON ad_seaice_advice_mean        =   4.3551195910026E-10
+(PID.TID 0000.0001) %MON ad_seaice_advice_sd          =   6.2018311065202E-09
+(PID.TID 0000.0001) %MON ad_seaice_advice_del2        =   2.6536889654403E-10
+(PID.TID 0000.0001) %MON ad_seaice_adarea_max         =   3.7797621607949E-10
+(PID.TID 0000.0001) %MON ad_seaice_adarea_min         =  -2.0391544477136E-10
+(PID.TID 0000.0001) %MON ad_seaice_adarea_mean        =  -1.0354187358246E-10
+(PID.TID 0000.0001) %MON ad_seaice_adarea_sd          =   8.7586188934956E-11
+(PID.TID 0000.0001) %MON ad_seaice_adarea_del2        =   1.7936291447065E-12
+(PID.TID 0000.0001) %MON ad_seaice_adheff_max         =   1.0223284171438E-08
+(PID.TID 0000.0001) %MON ad_seaice_adheff_min         =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON ad_seaice_adheff_mean        =   9.3824446022242E-09
+(PID.TID 0000.0001) %MON ad_seaice_adheff_sd          =   2.2106897379998E-09
+(PID.TID 0000.0001) %MON ad_seaice_adheff_del2        =   6.7254218392797E-11
+(PID.TID 0000.0001) %MON ad_seaice_adhsnow_max        =   3.6857198443149E-09
+(PID.TID 0000.0001) %MON ad_seaice_adhsnow_min        =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON ad_seaice_adhsnow_mean       =   3.3453724770407E-09
+(PID.TID 0000.0001) %MON ad_seaice_adhsnow_sd         =   7.9044907771524E-10
+(PID.TID 0000.0001) %MON ad_seaice_adhsnow_del2       =   2.4084609568170E-11
+(PID.TID 0000.0001) // =======================================================
+(PID.TID 0000.0001) // End AD_MONITOR SEAICE statistics
+(PID.TID 0000.0001) // =======================================================
  ph-ice B           65  -1.5715921939801123       0.97903052703036886       0.19105757676389984     
  ph-ice C           65   1883569082.7733924     
  ph-ice B           66  -1.5712544168047180       0.97859258992511056       0.19086670171917006     
@@ -3582,6 +4472,191 @@
  ph-ice C           48   1420310189.7948878     
  ph-ice B           49  -1.5779365538141876       0.98577720132379532       0.19397916313116059     
  ph-ice C           49   1448001119.7934864     
+(PID.TID 0000.0001) // =======================================================
+(PID.TID 0000.0001) // Begin AD_MONITOR EXF statistics for iwhen =  3
+(PID.TID 0000.0001) // =======================================================
+(PID.TID 0000.0001) %MON ad_exf_tsnumber              =                    48
+(PID.TID 0000.0001) %MON ad_exf_time_sec              =   1.7280000000000E+05
+(PID.TID 0000.0001) %MON ad_exf_adfu_max              =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON ad_exf_adfu_min              =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON ad_exf_adfu_mean             =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON ad_exf_adfu_sd               =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON ad_exf_adfu_del2             =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON ad_exf_adfv_max              =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON ad_exf_adfv_min              =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON ad_exf_adfv_mean             =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON ad_exf_adfv_sd               =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON ad_exf_adfv_del2             =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON ad_exf_adqnet_max            =   1.7025707496674E-13
+(PID.TID 0000.0001) %MON ad_exf_adqnet_min            =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON ad_exf_adqnet_mean           =   8.8017425305442E-14
+(PID.TID 0000.0001) %MON ad_exf_adqnet_sd             =   2.5555419522151E-14
+(PID.TID 0000.0001) %MON ad_exf_adqnet_del2           =   7.1004861205869E-16
+(PID.TID 0000.0001) %MON ad_exf_adempmr_max           =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON ad_exf_adempmr_min           =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON ad_exf_adempmr_mean          =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON ad_exf_adempmr_sd            =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON ad_exf_adempmr_del2          =   0.0000000000000E+00
+(PID.TID 0000.0001) // =======================================================
+(PID.TID 0000.0001) // End AD_MONITOR EXF statistics for iwhen =  3
+(PID.TID 0000.0001) // =======================================================
+(PID.TID 0000.0001) // =======================================================
+(PID.TID 0000.0001) // Begin AD_MONITOR EXF statistics for iwhen =  1
+(PID.TID 0000.0001) // =======================================================
+(PID.TID 0000.0001) %MON ad_exf_tsnumber              =                    48
+(PID.TID 0000.0001) %MON ad_exf_time_sec              =   1.7280000000000E+05
+(PID.TID 0000.0001) %MON ad_exf_adustress_max         =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON ad_exf_adustress_min         =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON ad_exf_adustress_mean        =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON ad_exf_adustress_sd          =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON ad_exf_adustress_del2        =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON ad_exf_advstress_max         =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON ad_exf_advstress_min         =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON ad_exf_advstress_mean        =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON ad_exf_advstress_sd          =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON ad_exf_advstress_del2        =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON ad_exf_adhflux_max           =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON ad_exf_adhflux_min           =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON ad_exf_adhflux_mean          =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON ad_exf_adhflux_sd            =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON ad_exf_adhflux_del2          =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON ad_exf_adsflux_max           =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON ad_exf_adsflux_min           =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON ad_exf_adsflux_mean          =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON ad_exf_adsflux_sd            =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON ad_exf_adsflux_del2          =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON ad_exf_adwspeed_max          =   6.0417818592205E-14
+(PID.TID 0000.0001) %MON ad_exf_adwspeed_min          =  -1.2600794248465E-12
+(PID.TID 0000.0001) %MON ad_exf_adwspeed_mean         =  -2.2922163194463E-13
+(PID.TID 0000.0001) %MON ad_exf_adwspeed_sd           =   4.3007006537903E-13
+(PID.TID 0000.0001) %MON ad_exf_adwspeed_del2         =   4.3059590312775E-15
+(PID.TID 0000.0001) // =======================================================
+(PID.TID 0000.0001) // End AD_MONITOR EXF statistics for iwhen =  1
+(PID.TID 0000.0001) // =======================================================
+(PID.TID 0000.0001) // =======================================================
+(PID.TID 0000.0001) // Begin AD_MONITOR EXF statistics for iwhen =  2
+(PID.TID 0000.0001) // =======================================================
+(PID.TID 0000.0001) %MON ad_exf_tsnumber              =                    48
+(PID.TID 0000.0001) %MON ad_exf_time_sec              =   1.7280000000000E+05
+(PID.TID 0000.0001) %MON ad_exf_aduwind_max           =   1.4930411391897E-12
+(PID.TID 0000.0001) %MON ad_exf_aduwind_min           =  -1.3349576222988E-12
+(PID.TID 0000.0001) %MON ad_exf_aduwind_mean          =  -1.9200169275279E-13
+(PID.TID 0000.0001) %MON ad_exf_aduwind_sd            =   5.3334606759721E-13
+(PID.TID 0000.0001) %MON ad_exf_aduwind_del2          =   6.0308729602899E-15
+(PID.TID 0000.0001) %MON ad_exf_advwind_max           =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON ad_exf_advwind_min           =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON ad_exf_advwind_mean          =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON ad_exf_advwind_sd            =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON ad_exf_advwind_del2          =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON ad_exf_adatemp_max           =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON ad_exf_adatemp_min           =  -3.6142091823497E-12
+(PID.TID 0000.0001) %MON ad_exf_adatemp_mean          =  -1.2944976133027E-12
+(PID.TID 0000.0001) %MON ad_exf_adatemp_sd            =   1.1133042867842E-12
+(PID.TID 0000.0001) %MON ad_exf_adatemp_del2          =   1.6890516851291E-14
+(PID.TID 0000.0001) %MON ad_exf_adaqh_max             =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON ad_exf_adaqh_min             =  -1.0301702492996E-08
+(PID.TID 0000.0001) %MON ad_exf_adaqh_mean            =  -3.6924698073987E-09
+(PID.TID 0000.0001) %MON ad_exf_adaqh_sd              =   3.1828577259064E-09
+(PID.TID 0000.0001) %MON ad_exf_adaqh_del2            =   4.8497148222970E-11
+(PID.TID 0000.0001) %MON ad_exf_adlwflux_max          =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON ad_exf_adlwflux_min          =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON ad_exf_adlwflux_mean         =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON ad_exf_adlwflux_sd           =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON ad_exf_adlwflux_del2         =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON ad_exf_adprecip_max          =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON ad_exf_adprecip_min          =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON ad_exf_adprecip_mean         =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON ad_exf_adprecip_sd           =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON ad_exf_adprecip_del2         =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON ad_exf_adswdown_max          =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON ad_exf_adswdown_min          =  -1.3450615257311E-13
+(PID.TID 0000.0001) %MON ad_exf_adswdown_mean         =  -3.0867014738389E-14
+(PID.TID 0000.0001) %MON ad_exf_adswdown_sd           =   2.5619017267895E-14
+(PID.TID 0000.0001) %MON ad_exf_adswdown_del2         =   5.0340158003779E-16
+(PID.TID 0000.0001) %MON ad_exf_adlwdown_max          =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON ad_exf_adlwdown_min          =  -1.6658640639378E-13
+(PID.TID 0000.0001) %MON ad_exf_adlwdown_mean         =  -6.1744268273598E-14
+(PID.TID 0000.0001) %MON ad_exf_adlwdown_sd           =   5.3971970586521E-14
+(PID.TID 0000.0001) %MON ad_exf_adlwdown_del2         =   8.6155742123445E-16
+(PID.TID 0000.0001) %MON ad_exf_adrunoff_max          =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON ad_exf_adrunoff_min          =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON ad_exf_adrunoff_mean         =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON ad_exf_adrunoff_sd           =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON ad_exf_adrunoff_del2         =   0.0000000000000E+00
+(PID.TID 0000.0001) // =======================================================
+(PID.TID 0000.0001) // End AD_MONITOR EXF statistics for iwhen =  2
+(PID.TID 0000.0001) // =======================================================
+(PID.TID 0000.0001) // =======================================================
+(PID.TID 0000.0001) // Begin AD_MONITOR dynamic field statistics
+(PID.TID 0000.0001) // =======================================================
+(PID.TID 0000.0001) %MON ad_time_tsnumber             =                    48
+(PID.TID 0000.0001) %MON ad_time_secondsf             =   1.7280000000000E+05
+(PID.TID 0000.0001) %MON ad_dynstat_adeta_max         =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON ad_dynstat_adeta_min         =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON ad_dynstat_adeta_mean        =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON ad_dynstat_adeta_sd          =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON ad_dynstat_adeta_del2        =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON ad_dynstat_aduvel_max        =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON ad_dynstat_aduvel_min        =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON ad_dynstat_aduvel_mean       =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON ad_dynstat_aduvel_sd         =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON ad_dynstat_aduvel_del2       =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON ad_dynstat_advvel_max        =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON ad_dynstat_advvel_min        =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON ad_dynstat_advvel_mean       =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON ad_dynstat_advvel_sd         =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON ad_dynstat_advvel_del2       =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON ad_dynstat_adwvel_max        =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON ad_dynstat_adwvel_min        =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON ad_dynstat_adwvel_mean       =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON ad_dynstat_adwvel_sd         =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON ad_dynstat_adwvel_del2       =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON ad_dynstat_adtheta_max       =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON ad_dynstat_adtheta_min       =  -1.9696627316459E-09
+(PID.TID 0000.0001) %MON ad_dynstat_adtheta_mean      =  -1.0244318147158E-09
+(PID.TID 0000.0001) %MON ad_dynstat_adtheta_sd        =   2.9560672338239E-10
+(PID.TID 0000.0001) %MON ad_dynstat_adtheta_del2      =   8.2352915128606E-12
+(PID.TID 0000.0001) %MON ad_dynstat_adsalt_max        =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON ad_dynstat_adsalt_min        =  -1.2179383846752E-10
+(PID.TID 0000.0001) %MON ad_dynstat_adsalt_mean       =  -6.0110835063752E-11
+(PID.TID 0000.0001) %MON ad_dynstat_adsalt_sd         =   1.7976435942528E-11
+(PID.TID 0000.0001) %MON ad_dynstat_adsalt_del2       =   4.9099825413588E-13
+(PID.TID 0000.0001) // =======================================================
+(PID.TID 0000.0001) // End AD_MONITOR dynamic field statistics
+(PID.TID 0000.0001) // =======================================================
+(PID.TID 0000.0001) // =======================================================
+(PID.TID 0000.0001) // Begin AD_MONITOR SEAICE statistics
+(PID.TID 0000.0001) // =======================================================
+(PID.TID 0000.0001) %MON ad_seaice_tsnumber           =                    48
+(PID.TID 0000.0001) %MON ad_seaice_time_sec           =   1.7280000000000E+05
+(PID.TID 0000.0001) %MON ad_seaice_aduice_max         =   7.5000909360277E-08
+(PID.TID 0000.0001) %MON ad_seaice_aduice_min         =  -1.8377616535322E-09
+(PID.TID 0000.0001) %MON ad_seaice_aduice_mean        =   1.6589374274047E-09
+(PID.TID 0000.0001) %MON ad_seaice_aduice_sd          =   1.0922771647001E-08
+(PID.TID 0000.0001) %MON ad_seaice_aduice_del2        =   4.7867057949535E-10
+(PID.TID 0000.0001) %MON ad_seaice_advice_max         =   7.6322698296057E-08
+(PID.TID 0000.0001) %MON ad_seaice_advice_min         =  -7.5077321531689E-08
+(PID.TID 0000.0001) %MON ad_seaice_advice_mean        =   9.6128900835882E-10
+(PID.TID 0000.0001) %MON ad_seaice_advice_sd          =   1.3859402168398E-08
+(PID.TID 0000.0001) %MON ad_seaice_advice_del2        =   5.9238745890943E-10
+(PID.TID 0000.0001) %MON ad_seaice_adarea_max         =   4.0286805982004E-10
+(PID.TID 0000.0001) %MON ad_seaice_adarea_min         =  -3.7665638271267E-10
+(PID.TID 0000.0001) %MON ad_seaice_adarea_mean        =  -1.8887414080508E-10
+(PID.TID 0000.0001) %MON ad_seaice_adarea_sd          =   1.3556846238028E-10
+(PID.TID 0000.0001) %MON ad_seaice_adarea_del2        =   2.6331774210896E-12
+(PID.TID 0000.0001) %MON ad_seaice_adheff_max         =   1.5492979768857E-08
+(PID.TID 0000.0001) %MON ad_seaice_adheff_min         =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON ad_seaice_adheff_mean        =   1.4014372212897E-08
+(PID.TID 0000.0001) %MON ad_seaice_adheff_sd          =   3.2876701423394E-09
+(PID.TID 0000.0001) %MON ad_seaice_adheff_del2        =   1.0019425501080E-10
+(PID.TID 0000.0001) %MON ad_seaice_adhsnow_max        =   5.5732372431082E-09
+(PID.TID 0000.0001) %MON ad_seaice_adhsnow_min        =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON ad_seaice_adhsnow_mean       =   4.9911400371595E-09
+(PID.TID 0000.0001) %MON ad_seaice_adhsnow_sd         =   1.1751201223658E-09
+(PID.TID 0000.0001) %MON ad_seaice_adhsnow_del2       =   3.5859695693125E-11
+(PID.TID 0000.0001) // =======================================================
+(PID.TID 0000.0001) // End AD_MONITOR SEAICE statistics
+(PID.TID 0000.0001) // =======================================================
  ph-ice B           40  -1.5825109512112714       0.98928928553040774       0.19548525057908156     
  ph-ice C           40   1196845881.2896149     
  ph-ice B           41  -1.5819579524866192       0.98891178762854004       0.19532388175446985     
@@ -3632,6 +4707,191 @@
  ph-ice C           23   710856909.21532667     
  ph-ice B           24  -1.5933084516320595       0.99476749531402342       0.19781186127280898     
  ph-ice C           24   739854574.21137202     
+(PID.TID 0000.0001) // =======================================================
+(PID.TID 0000.0001) // Begin AD_MONITOR EXF statistics for iwhen =  3
+(PID.TID 0000.0001) // =======================================================
+(PID.TID 0000.0001) %MON ad_exf_tsnumber              =                    24
+(PID.TID 0000.0001) %MON ad_exf_time_sec              =   8.6400000000000E+04
+(PID.TID 0000.0001) %MON ad_exf_adfu_max              =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON ad_exf_adfu_min              =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON ad_exf_adfu_mean             =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON ad_exf_adfu_sd               =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON ad_exf_adfu_del2             =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON ad_exf_adfv_max              =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON ad_exf_adfv_min              =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON ad_exf_adfv_mean             =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON ad_exf_adfv_sd               =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON ad_exf_adfv_del2             =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON ad_exf_adqnet_max            =   2.2876816178592E-13
+(PID.TID 0000.0001) %MON ad_exf_adqnet_min            =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON ad_exf_adqnet_mean           =   1.3303095122467E-13
+(PID.TID 0000.0001) %MON ad_exf_adqnet_sd             =   3.4080338435624E-14
+(PID.TID 0000.0001) %MON ad_exf_adqnet_del2           =   9.9312074102538E-16
+(PID.TID 0000.0001) %MON ad_exf_adempmr_max           =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON ad_exf_adempmr_min           =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON ad_exf_adempmr_mean          =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON ad_exf_adempmr_sd            =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON ad_exf_adempmr_del2          =   0.0000000000000E+00
+(PID.TID 0000.0001) // =======================================================
+(PID.TID 0000.0001) // End AD_MONITOR EXF statistics for iwhen =  3
+(PID.TID 0000.0001) // =======================================================
+(PID.TID 0000.0001) // =======================================================
+(PID.TID 0000.0001) // Begin AD_MONITOR EXF statistics for iwhen =  1
+(PID.TID 0000.0001) // =======================================================
+(PID.TID 0000.0001) %MON ad_exf_tsnumber              =                    24
+(PID.TID 0000.0001) %MON ad_exf_time_sec              =   8.6400000000000E+04
+(PID.TID 0000.0001) %MON ad_exf_adustress_max         =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON ad_exf_adustress_min         =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON ad_exf_adustress_mean        =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON ad_exf_adustress_sd          =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON ad_exf_adustress_del2        =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON ad_exf_advstress_max         =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON ad_exf_advstress_min         =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON ad_exf_advstress_mean        =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON ad_exf_advstress_sd          =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON ad_exf_advstress_del2        =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON ad_exf_adhflux_max           =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON ad_exf_adhflux_min           =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON ad_exf_adhflux_mean          =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON ad_exf_adhflux_sd            =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON ad_exf_adhflux_del2          =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON ad_exf_adsflux_max           =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON ad_exf_adsflux_min           =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON ad_exf_adsflux_mean          =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON ad_exf_adsflux_sd            =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON ad_exf_adsflux_del2          =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON ad_exf_adwspeed_max          =   8.4685594187811E-14
+(PID.TID 0000.0001) %MON ad_exf_adwspeed_min          =  -1.7428964939953E-12
+(PID.TID 0000.0001) %MON ad_exf_adwspeed_mean         =  -3.1535812549441E-13
+(PID.TID 0000.0001) %MON ad_exf_adwspeed_sd           =   5.9438773172882E-13
+(PID.TID 0000.0001) %MON ad_exf_adwspeed_del2         =   5.9283317148278E-15
+(PID.TID 0000.0001) // =======================================================
+(PID.TID 0000.0001) // End AD_MONITOR EXF statistics for iwhen =  1
+(PID.TID 0000.0001) // =======================================================
+(PID.TID 0000.0001) // =======================================================
+(PID.TID 0000.0001) // Begin AD_MONITOR EXF statistics for iwhen =  2
+(PID.TID 0000.0001) // =======================================================
+(PID.TID 0000.0001) %MON ad_exf_tsnumber              =                    24
+(PID.TID 0000.0001) %MON ad_exf_time_sec              =   8.6400000000000E+04
+(PID.TID 0000.0001) %MON ad_exf_aduwind_max           =   2.1119476280755E-12
+(PID.TID 0000.0001) %MON ad_exf_aduwind_min           =  -1.7919699675170E-12
+(PID.TID 0000.0001) %MON ad_exf_aduwind_mean          =  -2.5426809343843E-13
+(PID.TID 0000.0001) %MON ad_exf_aduwind_sd            =   7.2598715327635E-13
+(PID.TID 0000.0001) %MON ad_exf_aduwind_del2          =   8.3474032861003E-15
+(PID.TID 0000.0001) %MON ad_exf_advwind_max           =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON ad_exf_advwind_min           =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON ad_exf_advwind_mean          =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON ad_exf_advwind_sd            =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON ad_exf_advwind_del2          =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON ad_exf_adatemp_max           =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON ad_exf_adatemp_min           =  -4.8998413504905E-12
+(PID.TID 0000.0001) %MON ad_exf_adatemp_mean          =  -1.7472502528840E-12
+(PID.TID 0000.0001) %MON ad_exf_adatemp_sd            =   1.5270881391468E-12
+(PID.TID 0000.0001) %MON ad_exf_adatemp_del2          =   2.2925518867358E-14
+(PID.TID 0000.0001) %MON ad_exf_adaqh_max             =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON ad_exf_adaqh_min             =  -1.3889014075250E-08
+(PID.TID 0000.0001) %MON ad_exf_adaqh_mean            =  -4.9522334229952E-09
+(PID.TID 0000.0001) %MON ad_exf_adaqh_sd              =   4.3161614140655E-09
+(PID.TID 0000.0001) %MON ad_exf_adaqh_del2            =   6.5271176985237E-11
+(PID.TID 0000.0001) %MON ad_exf_adlwflux_max          =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON ad_exf_adlwflux_min          =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON ad_exf_adlwflux_mean         =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON ad_exf_adlwflux_sd           =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON ad_exf_adlwflux_del2         =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON ad_exf_adprecip_max          =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON ad_exf_adprecip_min          =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON ad_exf_adprecip_mean         =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON ad_exf_adprecip_sd           =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON ad_exf_adprecip_del2         =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON ad_exf_adswdown_max          =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON ad_exf_adswdown_min          =  -1.9119461087181E-13
+(PID.TID 0000.0001) %MON ad_exf_adswdown_mean         =  -4.2903305945393E-14
+(PID.TID 0000.0001) %MON ad_exf_adswdown_sd           =   3.5585923733040E-14
+(PID.TID 0000.0001) %MON ad_exf_adswdown_del2         =   7.0074297665166E-16
+(PID.TID 0000.0001) %MON ad_exf_adlwdown_max          =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON ad_exf_adlwdown_min          =  -2.2476876066103E-13
+(PID.TID 0000.0001) %MON ad_exf_adlwdown_mean         =  -8.2273156209362E-14
+(PID.TID 0000.0001) %MON ad_exf_adlwdown_sd           =   7.2622136637184E-14
+(PID.TID 0000.0001) %MON ad_exf_adlwdown_del2         =   1.1601069831674E-15
+(PID.TID 0000.0001) %MON ad_exf_adrunoff_max          =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON ad_exf_adrunoff_min          =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON ad_exf_adrunoff_mean         =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON ad_exf_adrunoff_sd           =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON ad_exf_adrunoff_del2         =   0.0000000000000E+00
+(PID.TID 0000.0001) // =======================================================
+(PID.TID 0000.0001) // End AD_MONITOR EXF statistics for iwhen =  2
+(PID.TID 0000.0001) // =======================================================
+(PID.TID 0000.0001) // =======================================================
+(PID.TID 0000.0001) // Begin AD_MONITOR dynamic field statistics
+(PID.TID 0000.0001) // =======================================================
+(PID.TID 0000.0001) %MON ad_time_tsnumber             =                    24
+(PID.TID 0000.0001) %MON ad_time_secondsf             =   8.6400000000000E+04
+(PID.TID 0000.0001) %MON ad_dynstat_adeta_max         =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON ad_dynstat_adeta_min         =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON ad_dynstat_adeta_mean        =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON ad_dynstat_adeta_sd          =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON ad_dynstat_adeta_del2        =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON ad_dynstat_aduvel_max        =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON ad_dynstat_aduvel_min        =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON ad_dynstat_aduvel_mean       =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON ad_dynstat_aduvel_sd         =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON ad_dynstat_aduvel_del2       =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON ad_dynstat_advvel_max        =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON ad_dynstat_advvel_min        =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON ad_dynstat_advvel_mean       =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON ad_dynstat_advvel_sd         =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON ad_dynstat_advvel_del2       =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON ad_dynstat_adwvel_max        =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON ad_dynstat_adwvel_min        =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON ad_dynstat_adwvel_mean       =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON ad_dynstat_adwvel_sd         =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON ad_dynstat_adwvel_del2       =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON ad_dynstat_adtheta_max       =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON ad_dynstat_adtheta_min       =  -2.6364795479773E-09
+(PID.TID 0000.0001) %MON ad_dynstat_adtheta_mean      =  -1.5392411555948E-09
+(PID.TID 0000.0001) %MON ad_dynstat_adtheta_sd        =   3.9243534326186E-10
+(PID.TID 0000.0001) %MON ad_dynstat_adtheta_del2      =   1.1453252916893E-11
+(PID.TID 0000.0001) %MON ad_dynstat_adsalt_max        =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON ad_dynstat_adsalt_min        =  -1.7009081027943E-10
+(PID.TID 0000.0001) %MON ad_dynstat_adsalt_mean       =  -9.2185460098295E-11
+(PID.TID 0000.0001) %MON ad_dynstat_adsalt_sd         =   2.4590135461795E-11
+(PID.TID 0000.0001) %MON ad_dynstat_adsalt_del2       =   6.9961928868037E-13
+(PID.TID 0000.0001) // =======================================================
+(PID.TID 0000.0001) // End AD_MONITOR dynamic field statistics
+(PID.TID 0000.0001) // =======================================================
+(PID.TID 0000.0001) // =======================================================
+(PID.TID 0000.0001) // Begin AD_MONITOR SEAICE statistics
+(PID.TID 0000.0001) // =======================================================
+(PID.TID 0000.0001) %MON ad_seaice_tsnumber           =                    24
+(PID.TID 0000.0001) %MON ad_seaice_time_sec           =   8.6400000000000E+04
+(PID.TID 0000.0001) %MON ad_seaice_aduice_max         =   1.3178560176004E-07
+(PID.TID 0000.0001) %MON ad_seaice_aduice_min         =  -2.7395025912206E-09
+(PID.TID 0000.0001) %MON ad_seaice_aduice_mean        =   2.9293093270836E-09
+(PID.TID 0000.0001) %MON ad_seaice_aduice_sd          =   1.9279520380914E-08
+(PID.TID 0000.0001) %MON ad_seaice_aduice_del2        =   8.4457269198022E-10
+(PID.TID 0000.0001) %MON ad_seaice_advice_max         =   1.3090584962064E-07
+(PID.TID 0000.0001) %MON ad_seaice_advice_min         =  -1.3099982269551E-07
+(PID.TID 0000.0001) %MON ad_seaice_advice_mean        =   1.6844081689985E-09
+(PID.TID 0000.0001) %MON ad_seaice_advice_sd          =   2.4609604499922E-08
+(PID.TID 0000.0001) %MON ad_seaice_advice_del2        =   1.0496979135997E-09
+(PID.TID 0000.0001) %MON ad_seaice_adarea_max         =   2.8165862185731E-10
+(PID.TID 0000.0001) %MON ad_seaice_adarea_min         =  -5.5961031432592E-10
+(PID.TID 0000.0001) %MON ad_seaice_adarea_mean        =  -2.7141693278208E-10
+(PID.TID 0000.0001) %MON ad_seaice_adarea_sd          =   1.8839913026313E-10
+(PID.TID 0000.0001) %MON ad_seaice_adarea_del2        =   3.2502451147344E-12
+(PID.TID 0000.0001) %MON ad_seaice_adheff_max         =   2.0869357013827E-08
+(PID.TID 0000.0001) %MON ad_seaice_adheff_min         =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON ad_seaice_adheff_mean        =   1.8622764443494E-08
+(PID.TID 0000.0001) %MON ad_seaice_adheff_sd          =   4.2882024171998E-09
+(PID.TID 0000.0001) %MON ad_seaice_adheff_del2        =   1.3042653155265E-10
+(PID.TID 0000.0001) %MON ad_seaice_adhsnow_max        =   7.5140227369778E-09
+(PID.TID 0000.0001) %MON ad_seaice_adhsnow_min        =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON ad_seaice_adhsnow_mean       =   6.6345721830151E-09
+(PID.TID 0000.0001) %MON ad_seaice_adhsnow_sd         =   1.5344719475883E-09
+(PID.TID 0000.0001) %MON ad_seaice_adhsnow_del2       =   4.6710983423296E-11
+(PID.TID 0000.0001) // =======================================================
+(PID.TID 0000.0001) // End AD_MONITOR SEAICE statistics
+(PID.TID 0000.0001) // =======================================================
  ph-ice B           15  -1.6014692775250958       0.99724077783438014       0.19885165024142812     
  ph-ice C           15   477013810.52470720     
  ph-ice B           16  -1.6004696366477322       0.99699326412734279       0.19874795163593029     
@@ -3672,9 +4932,194 @@
  ph-ice C            3   120321046.77355954     
  ph-ice B            4  -1.6143308073584433       0.99941130480019769       0.19975659048163302     
  ph-ice C            4   150299134.02091029     
+(PID.TID 0000.0001) // =======================================================
+(PID.TID 0000.0001) // Begin AD_MONITOR EXF statistics for iwhen =  3
+(PID.TID 0000.0001) // =======================================================
+(PID.TID 0000.0001) %MON ad_exf_tsnumber              =                     0
+(PID.TID 0000.0001) %MON ad_exf_time_sec              =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON ad_exf_adfu_max              =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON ad_exf_adfu_min              =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON ad_exf_adfu_mean             =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON ad_exf_adfu_sd               =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON ad_exf_adfu_del2             =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON ad_exf_adfv_max              =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON ad_exf_adfv_min              =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON ad_exf_adfv_mean             =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON ad_exf_adfv_sd               =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON ad_exf_adfv_del2             =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON ad_exf_adqnet_max            =   2.8274181744831E-13
+(PID.TID 0000.0001) %MON ad_exf_adqnet_min            =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON ad_exf_adqnet_mean           =   1.8089805661447E-13
+(PID.TID 0000.0001) %MON ad_exf_adqnet_sd             =   4.0317917514716E-14
+(PID.TID 0000.0001) %MON ad_exf_adqnet_del2           =   1.2310728507197E-15
+(PID.TID 0000.0001) %MON ad_exf_adempmr_max           =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON ad_exf_adempmr_min           =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON ad_exf_adempmr_mean          =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON ad_exf_adempmr_sd            =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON ad_exf_adempmr_del2          =   0.0000000000000E+00
+(PID.TID 0000.0001) // =======================================================
+(PID.TID 0000.0001) // End AD_MONITOR EXF statistics for iwhen =  3
+(PID.TID 0000.0001) // =======================================================
+(PID.TID 0000.0001) // =======================================================
+(PID.TID 0000.0001) // Begin AD_MONITOR EXF statistics for iwhen =  1
+(PID.TID 0000.0001) // =======================================================
+(PID.TID 0000.0001) %MON ad_exf_tsnumber              =                     0
+(PID.TID 0000.0001) %MON ad_exf_time_sec              =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON ad_exf_adustress_max         =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON ad_exf_adustress_min         =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON ad_exf_adustress_mean        =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON ad_exf_adustress_sd          =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON ad_exf_adustress_del2        =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON ad_exf_advstress_max         =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON ad_exf_advstress_min         =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON ad_exf_advstress_mean        =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON ad_exf_advstress_sd          =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON ad_exf_advstress_del2        =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON ad_exf_adhflux_max           =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON ad_exf_adhflux_min           =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON ad_exf_adhflux_mean          =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON ad_exf_adhflux_sd            =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON ad_exf_adhflux_del2          =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON ad_exf_adsflux_max           =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON ad_exf_adsflux_min           =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON ad_exf_adsflux_mean          =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON ad_exf_adsflux_sd            =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON ad_exf_adsflux_del2          =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON ad_exf_adwspeed_max          =   1.1237018897886E-13
+(PID.TID 0000.0001) %MON ad_exf_adwspeed_min          =  -2.2587253285922E-12
+(PID.TID 0000.0001) %MON ad_exf_adwspeed_mean         =  -4.0641515640297E-13
+(PID.TID 0000.0001) %MON ad_exf_adwspeed_sd           =   7.6843242438864E-13
+(PID.TID 0000.0001) %MON ad_exf_adwspeed_del2         =   7.5932150449808E-15
+(PID.TID 0000.0001) // =======================================================
+(PID.TID 0000.0001) // End AD_MONITOR EXF statistics for iwhen =  1
+(PID.TID 0000.0001) // =======================================================
+(PID.TID 0000.0001) // =======================================================
+(PID.TID 0000.0001) // Begin AD_MONITOR EXF statistics for iwhen =  2
+(PID.TID 0000.0001) // =======================================================
+(PID.TID 0000.0001) %MON ad_exf_tsnumber              =                     0
+(PID.TID 0000.0001) %MON ad_exf_time_sec              =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON ad_exf_aduwind_max           =   2.9453549965331E-12
+(PID.TID 0000.0001) %MON ad_exf_aduwind_min           =  -2.2587253285922E-12
+(PID.TID 0000.0001) %MON ad_exf_aduwind_mean          =  -3.1377409903131E-13
+(PID.TID 0000.0001) %MON ad_exf_aduwind_sd            =   9.3751151848232E-13
+(PID.TID 0000.0001) %MON ad_exf_aduwind_del2          =   1.0711831342100E-14
+(PID.TID 0000.0001) %MON ad_exf_advwind_max           =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON ad_exf_advwind_min           =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON ad_exf_advwind_mean          =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON ad_exf_advwind_sd            =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON ad_exf_advwind_del2          =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON ad_exf_adatemp_max           =  -1.6507601563330E-14
+(PID.TID 0000.0001) %MON ad_exf_adatemp_min           =  -6.2341656920223E-12
+(PID.TID 0000.0001) %MON ad_exf_adatemp_mean          =  -2.2289728197628E-12
+(PID.TID 0000.0001) %MON ad_exf_adatemp_sd            =   1.9582830040031E-12
+(PID.TID 0000.0001) %MON ad_exf_adatemp_del2          =   2.8854798800252E-14
+(PID.TID 0000.0001) %MON ad_exf_adaqh_max             =  -9.2806080530529E-11
+(PID.TID 0000.0001) %MON ad_exf_adaqh_min             =  -1.7579726936509E-08
+(PID.TID 0000.0001) %MON ad_exf_adaqh_mean            =  -6.2997700140314E-09
+(PID.TID 0000.0001) %MON ad_exf_adaqh_sd              =   5.4593867251015E-09
+(PID.TID 0000.0001) %MON ad_exf_adaqh_del2            =   8.0516098721770E-11
+(PID.TID 0000.0001) %MON ad_exf_adlwflux_max          =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON ad_exf_adlwflux_min          =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON ad_exf_adlwflux_mean         =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON ad_exf_adlwflux_sd           =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON ad_exf_adlwflux_del2         =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON ad_exf_adprecip_max          =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON ad_exf_adprecip_min          =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON ad_exf_adprecip_mean         =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON ad_exf_adprecip_sd           =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON ad_exf_adprecip_del2         =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON ad_exf_adswdown_max          =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON ad_exf_adswdown_min          =  -2.5446763570348E-13
+(PID.TID 0000.0001) %MON ad_exf_adswdown_mean         =  -5.6185811993889E-14
+(PID.TID 0000.0001) %MON ad_exf_adswdown_sd           =   4.6590885714131E-14
+(PID.TID 0000.0001) %MON ad_exf_adswdown_del2         =   9.1406376001034E-16
+(PID.TID 0000.0001) %MON ad_exf_adlwdown_max          =  -2.3936024987127E-15
+(PID.TID 0000.0001) %MON ad_exf_adlwdown_min          =  -2.9404974362334E-13
+(PID.TID 0000.0001) %MON ad_exf_adlwdown_mean         =  -1.0461210462081E-13
+(PID.TID 0000.0001) %MON ad_exf_adlwdown_sd           =   9.1418921696644E-14
+(PID.TID 0000.0001) %MON ad_exf_adlwdown_del2         =   1.4361958161081E-15
+(PID.TID 0000.0001) %MON ad_exf_adrunoff_max          =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON ad_exf_adrunoff_min          =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON ad_exf_adrunoff_mean         =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON ad_exf_adrunoff_sd           =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON ad_exf_adrunoff_del2         =   0.0000000000000E+00
+(PID.TID 0000.0001) // =======================================================
+(PID.TID 0000.0001) // End AD_MONITOR EXF statistics for iwhen =  2
+(PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) Start initial hydrostatic pressure computation
 (PID.TID 0000.0001) Pressure is predetermined for buoyancyRelation OCEANIC
 (PID.TID 0000.0001) 
+(PID.TID 0000.0001) // =======================================================
+(PID.TID 0000.0001) // Begin AD_MONITOR dynamic field statistics
+(PID.TID 0000.0001) // =======================================================
+(PID.TID 0000.0001) %MON ad_time_tsnumber             =                     0
+(PID.TID 0000.0001) %MON ad_time_secondsf             =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON ad_dynstat_adeta_max         =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON ad_dynstat_adeta_min         =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON ad_dynstat_adeta_mean        =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON ad_dynstat_adeta_sd          =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON ad_dynstat_adeta_del2        =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON ad_dynstat_aduvel_max        =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON ad_dynstat_aduvel_min        =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON ad_dynstat_aduvel_mean       =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON ad_dynstat_aduvel_sd         =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON ad_dynstat_aduvel_del2       =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON ad_dynstat_advvel_max        =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON ad_dynstat_advvel_min        =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON ad_dynstat_advvel_mean       =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON ad_dynstat_advvel_sd         =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON ad_dynstat_advvel_del2       =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON ad_dynstat_adwvel_max        =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON ad_dynstat_adwvel_min        =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON ad_dynstat_adwvel_mean       =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON ad_dynstat_adwvel_sd         =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON ad_dynstat_adwvel_del2       =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON ad_dynstat_adtheta_max       =   5.0633984252775E-14
+(PID.TID 0000.0001) %MON ad_dynstat_adtheta_min       =  -3.2131232964311E-09
+(PID.TID 0000.0001) %MON ad_dynstat_adtheta_mean      =  -2.0597633238223E-09
+(PID.TID 0000.0001) %MON ad_dynstat_adtheta_sd        =   4.5860802115156E-10
+(PID.TID 0000.0001) %MON ad_dynstat_adtheta_del2      =   1.4011333069838E-11
+(PID.TID 0000.0001) %MON ad_dynstat_adsalt_max        =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON ad_dynstat_adsalt_min        =  -2.1352179667030E-10
+(PID.TID 0000.0001) %MON ad_dynstat_adsalt_mean       =  -1.2607293649994E-10
+(PID.TID 0000.0001) %MON ad_dynstat_adsalt_sd         =   2.9773092956455E-11
+(PID.TID 0000.0001) %MON ad_dynstat_adsalt_del2       =   8.8082297342071E-13
+(PID.TID 0000.0001) // =======================================================
+(PID.TID 0000.0001) // End AD_MONITOR dynamic field statistics
+(PID.TID 0000.0001) // =======================================================
+(PID.TID 0000.0001) // =======================================================
+(PID.TID 0000.0001) // Begin AD_MONITOR SEAICE statistics
+(PID.TID 0000.0001) // =======================================================
+(PID.TID 0000.0001) %MON ad_seaice_tsnumber           =                     0
+(PID.TID 0000.0001) %MON ad_seaice_time_sec           =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON ad_seaice_aduice_max         =   2.0450863371678E-07
+(PID.TID 0000.0001) %MON ad_seaice_aduice_min         =  -3.9635129411056E-09
+(PID.TID 0000.0001) %MON ad_seaice_aduice_mean        =   4.5640176465299E-09
+(PID.TID 0000.0001) %MON ad_seaice_aduice_sd          =   3.0025849079108E-08
+(PID.TID 0000.0001) %MON ad_seaice_aduice_del2        =   1.3145313792358E-09
+(PID.TID 0000.0001) %MON ad_seaice_advice_max         =   2.0371330096262E-07
+(PID.TID 0000.0001) %MON ad_seaice_advice_min         =  -2.0515682010583E-07
+(PID.TID 0000.0001) %MON ad_seaice_advice_mean        =   2.6771965135477E-09
+(PID.TID 0000.0001) %MON ad_seaice_advice_sd          =   3.8422076281828E-08
+(PID.TID 0000.0001) %MON ad_seaice_advice_del2        =   1.6354685080819E-09
+(PID.TID 0000.0001) %MON ad_seaice_adarea_max         =   2.4990428782726E-10
+(PID.TID 0000.0001) %MON ad_seaice_adarea_min         =  -3.2237227183331E-10
+(PID.TID 0000.0001) %MON ad_seaice_adarea_mean        =  -7.9100343725940E-11
+(PID.TID 0000.0001) %MON ad_seaice_adarea_sd          =   1.1427591058305E-10
+(PID.TID 0000.0001) %MON ad_seaice_adarea_del2        =   2.0670862120541E-12
+(PID.TID 0000.0001) %MON ad_seaice_adheff_max         =   2.6358690449262E-08
+(PID.TID 0000.0001) %MON ad_seaice_adheff_min         =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON ad_seaice_adheff_mean        =   2.2781868198820E-08
+(PID.TID 0000.0001) %MON ad_seaice_adheff_sd          =   6.1004121696713E-09
+(PID.TID 0000.0001) %MON ad_seaice_adheff_del2        =   1.6290616789187E-10
+(PID.TID 0000.0001) %MON ad_seaice_adhsnow_max        =   9.5158896995915E-09
+(PID.TID 0000.0001) %MON ad_seaice_adhsnow_min        =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON ad_seaice_adhsnow_mean       =   8.1371370275440E-09
+(PID.TID 0000.0001) %MON ad_seaice_adhsnow_sd         =   2.1828502692774E-09
+(PID.TID 0000.0001) %MON ad_seaice_adhsnow_del2       =   5.8371063544916E-11
+(PID.TID 0000.0001) // =======================================================
+(PID.TID 0000.0001) // End AD_MONITOR SEAICE statistics
+(PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // Gradient-check starts (grdchk_main)
 (PID.TID 0000.0001) // =======================================================
@@ -5812,171 +7257,165 @@ grad-res -------------------------------
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) 
 (PID.TID 0000.0001)   Seconds in section "ALL                    [THE_MODEL_MAIN]":
-(PID.TID 0000.0001)           User time:   70.424003601074219
-(PID.TID 0000.0001)         System time:  0.44800001382827759
-(PID.TID 0000.0001)     Wall clock time:   70.927305936813354
+(PID.TID 0000.0001)           User time:   67.834487915039062
+(PID.TID 0000.0001)         System time:  0.77294697798788548
+(PID.TID 0000.0001)     Wall clock time:   68.921129941940308
 (PID.TID 0000.0001)          No. starts:           1
 (PID.TID 0000.0001)           No. stops:           1
 (PID.TID 0000.0001)   Seconds in section "INITIALISE_FIXED       [THE_MODEL_MAIN]":
-(PID.TID 0000.0001)           User time:   4.3999999761581421E-002
-(PID.TID 0000.0001)         System time:   4.0000001899898052E-003
-(PID.TID 0000.0001)     Wall clock time:   4.9685001373291016E-002
+(PID.TID 0000.0001)           User time:   4.2488999664783478E-002
+(PID.TID 0000.0001)         System time:   1.8313000677153468E-002
+(PID.TID 0000.0001)     Wall clock time:  0.13366198539733887
 (PID.TID 0000.0001)          No. starts:           1
 (PID.TID 0000.0001)           No. stops:           1
 (PID.TID 0000.0001)   Seconds in section "ADTHE_MAIN_LOOP          [ADJOINT RUN]":
-(PID.TID 0000.0001)           User time:   36.207998901605606
-(PID.TID 0000.0001)         System time:  0.32799998717382550
-(PID.TID 0000.0001)     Wall clock time:   36.568407058715820
+(PID.TID 0000.0001)           User time:   34.606531593948603
+(PID.TID 0000.0001)         System time:  0.68246800638735294
+(PID.TID 0000.0001)     Wall clock time:   35.526963949203491
 (PID.TID 0000.0001)          No. starts:           1
 (PID.TID 0000.0001)           No. stops:           1
 (PID.TID 0000.0001)   Seconds in section "FORWARD_STEP        [MAIN_DO_LOOP]":
-(PID.TID 0000.0001)           User time:   39.979948908090591
-(PID.TID 0000.0001)         System time:  0.11200002953410149
-(PID.TID 0000.0001)     Wall clock time:   40.100943326950073
+(PID.TID 0000.0001)           User time:   38.253896877169609
+(PID.TID 0000.0001)         System time:   8.6411125957965851E-002
+(PID.TID 0000.0001)     Wall clock time:   38.370883464813232
 (PID.TID 0000.0001)          No. starts:        1200
 (PID.TID 0000.0001)           No. stops:        1200
 (PID.TID 0000.0001)   Seconds in section "DO_STATEVARS_DIAGS  [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:  0.21600104868412018
-(PID.TID 0000.0001)         System time:   0.0000000000000000
-(PID.TID 0000.0001)     Wall clock time:  0.18325495719909668
+(PID.TID 0000.0001)           User time:  0.14147941023111343
+(PID.TID 0000.0001)         System time:   5.3298473358154297E-004
+(PID.TID 0000.0001)     Wall clock time:  0.14216995239257812
 (PID.TID 0000.0001)          No. starts:         360
 (PID.TID 0000.0001)           No. stops:         360
 (PID.TID 0000.0001)   Seconds in section "LOAD_FIELDS_DRIVER  [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:   7.5079888254404068
-(PID.TID 0000.0001)         System time:   2.4000011384487152E-002
-(PID.TID 0000.0001)     Wall clock time:   7.5324959754943848
+(PID.TID 0000.0001)           User time:   7.3639771938323975
+(PID.TID 0000.0001)         System time:   2.4776026606559753E-002
+(PID.TID 0000.0001)     Wall clock time:   7.4116289615631104
 (PID.TID 0000.0001)          No. starts:        1200
 (PID.TID 0000.0001)           No. stops:        1200
 (PID.TID 0000.0001)   Seconds in section "EXF_GETFORCING     [LOAD_FLDS_DRIVER]":
-(PID.TID 0000.0001)           User time:   8.2120156437158585
-(PID.TID 0000.0001)         System time:   2.4000011384487152E-002
-(PID.TID 0000.0001)     Wall clock time:   8.2388019561767578
+(PID.TID 0000.0001)           User time:   7.5136665627360344
+(PID.TID 0000.0001)         System time:   2.0455069839954376E-002
+(PID.TID 0000.0001)     Wall clock time:   7.5579242706298828
 (PID.TID 0000.0001)          No. starts:        1320
 (PID.TID 0000.0001)           No. stops:        1320
-(PID.TID 0000.0001)   Seconds in section "I/O (WRITE)        [ADJOINT LOOP]":
-(PID.TID 0000.0001)           User time:   3.5991907119750977E-002
-(PID.TID 0000.0001)         System time:   0.0000000000000000
-(PID.TID 0000.0001)     Wall clock time:   3.8858890533447266E-002
-(PID.TID 0000.0001)          No. starts:        4920
-(PID.TID 0000.0001)           No. stops:        4920
 (PID.TID 0000.0001)   Seconds in section "EXTERNAL_FLDS_LOAD [LOAD_FLDS_DRIVER]":
-(PID.TID 0000.0001)           User time:   1.5995025634765625E-002
-(PID.TID 0000.0001)         System time:   0.0000000000000000
-(PID.TID 0000.0001)     Wall clock time:   1.0476827621459961E-002
+(PID.TID 0000.0001)           User time:   1.2063473463058472E-002
+(PID.TID 0000.0001)         System time:   4.9807131290435791E-005
+(PID.TID 0000.0001)     Wall clock time:   1.2048721313476562E-002
 (PID.TID 0000.0001)          No. starts:        1320
 (PID.TID 0000.0001)           No. stops:        1320
 (PID.TID 0000.0001)   Seconds in section "CTRL_MAP_FORCING  [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:   1.6005039215087891E-002
-(PID.TID 0000.0001)         System time:   0.0000000000000000
-(PID.TID 0000.0001)     Wall clock time:   9.6566677093505859E-003
+(PID.TID 0000.0001)           User time:   2.0806136727333069
+(PID.TID 0000.0001)         System time:   7.3290094733238220E-003
+(PID.TID 0000.0001)     Wall clock time:   2.0900723934173584
 (PID.TID 0000.0001)          No. starts:        1200
 (PID.TID 0000.0001)           No. stops:        1200
 (PID.TID 0000.0001)   Seconds in section "DO_ATMOSPHERIC_PHYS [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:   4.7995567321777344E-002
-(PID.TID 0000.0001)         System time:   0.0000000000000000
-(PID.TID 0000.0001)     Wall clock time:   6.1588764190673828E-002
+(PID.TID 0000.0001)           User time:   5.3439229726791382E-002
+(PID.TID 0000.0001)         System time:   2.8692930936813354E-004
+(PID.TID 0000.0001)     Wall clock time:   5.3714036941528320E-002
 (PID.TID 0000.0001)          No. starts:        1200
 (PID.TID 0000.0001)           No. stops:        1200
 (PID.TID 0000.0001)   Seconds in section "DO_OCEANIC_PHYS     [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:   27.528042212128639
-(PID.TID 0000.0001)         System time:   6.0000002384185791E-002
-(PID.TID 0000.0001)     Wall clock time:   27.628920793533325
+(PID.TID 0000.0001)           User time:   24.683019056916237
+(PID.TID 0000.0001)         System time:   1.9665002822875977E-002
+(PID.TID 0000.0001)     Wall clock time:   24.717600107192993
 (PID.TID 0000.0001)          No. starts:        1200
 (PID.TID 0000.0001)           No. stops:        1200
 (PID.TID 0000.0001)   Seconds in section "SEAICE_MODEL    [DO_OCEANIC_PHYS]":
-(PID.TID 0000.0001)           User time:   25.788031369447708
-(PID.TID 0000.0001)         System time:   6.0000002384185791E-002
-(PID.TID 0000.0001)     Wall clock time:   25.822838783264160
+(PID.TID 0000.0001)           User time:   23.153767585754395
+(PID.TID 0000.0001)         System time:   1.8785007297992706E-002
+(PID.TID 0000.0001)     Wall clock time:   23.180456876754761
 (PID.TID 0000.0001)          No. starts:        1200
 (PID.TID 0000.0001)           No. stops:        1200
 (PID.TID 0000.0001)   Seconds in section "SEAICE_DYNSOLVER   [SEAICE_MODEL]":
-(PID.TID 0000.0001)           User time:   5.4399553984403610
-(PID.TID 0000.0001)         System time:   2.0000010728836060E-002
-(PID.TID 0000.0001)     Wall clock time:   5.4431660175323486
+(PID.TID 0000.0001)           User time:   5.2780015170574188
+(PID.TID 0000.0001)         System time:   1.7547935247421265E-002
+(PID.TID 0000.0001)     Wall clock time:   5.3010849952697754
 (PID.TID 0000.0001)          No. starts:        1320
 (PID.TID 0000.0001)           No. stops:        1320
 (PID.TID 0000.0001)   Seconds in section "DYNAMICS            [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:   1.1919701099395752
-(PID.TID 0000.0001)         System time:   7.9999864101409912E-003
-(PID.TID 0000.0001)     Wall clock time:   1.1483542919158936
+(PID.TID 0000.0001)           User time:  0.90167613327503204
+(PID.TID 0000.0001)         System time:   2.9061138629913330E-003
+(PID.TID 0000.0001)     Wall clock time:  0.90513849258422852
 (PID.TID 0000.0001)          No. starts:        1200
 (PID.TID 0000.0001)           No. stops:        1200
 (PID.TID 0000.0001)   Seconds in section "MOM_CORRECTION_STEP [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:   1.1993408203125000E-002
-(PID.TID 0000.0001)         System time:   0.0000000000000000
-(PID.TID 0000.0001)     Wall clock time:   1.2593746185302734E-002
+(PID.TID 0000.0001)           User time:   1.3779208064079285E-002
+(PID.TID 0000.0001)         System time:   4.2028725147247314E-005
+(PID.TID 0000.0001)     Wall clock time:   1.3843774795532227E-002
 (PID.TID 0000.0001)          No. starts:        1200
 (PID.TID 0000.0001)           No. stops:        1200
 (PID.TID 0000.0001)   Seconds in section "BLOCKING_EXCHANGES  [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:  0.35201524198055267
-(PID.TID 0000.0001)         System time:   0.0000000000000000
-(PID.TID 0000.0001)     Wall clock time:  0.34507060050964355
+(PID.TID 0000.0001)           User time:  0.30736237764358521
+(PID.TID 0000.0001)         System time:   8.8986009359359741E-004
+(PID.TID 0000.0001)     Wall clock time:  0.30869293212890625
 (PID.TID 0000.0001)          No. starts:        2400
 (PID.TID 0000.0001)           No. stops:        2400
 (PID.TID 0000.0001)   Seconds in section "THERMODYNAMICS      [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:   2.8559426069259644
-(PID.TID 0000.0001)         System time:   1.6000032424926758E-002
-(PID.TID 0000.0001)     Wall clock time:   2.9169313907623291
+(PID.TID 0000.0001)           User time:   2.4166113287210464
+(PID.TID 0000.0001)         System time:   5.8220028877258301E-003
+(PID.TID 0000.0001)     Wall clock time:   2.4238090515136719
 (PID.TID 0000.0001)          No. starts:        1200
 (PID.TID 0000.0001)           No. stops:        1200
 (PID.TID 0000.0001)   Seconds in section "TRC_CORRECTION_STEP [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:   1.1996269226074219E-002
-(PID.TID 0000.0001)         System time:   0.0000000000000000
-(PID.TID 0000.0001)     Wall clock time:   9.8671913146972656E-003
+(PID.TID 0000.0001)           User time:   1.0599330067634583E-002
+(PID.TID 0000.0001)         System time:   4.2073428630828857E-005
+(PID.TID 0000.0001)     Wall clock time:   1.0649681091308594E-002
 (PID.TID 0000.0001)          No. starts:        1200
 (PID.TID 0000.0001)           No. stops:        1200
 (PID.TID 0000.0001)   Seconds in section "MONITOR             [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:   3.9997100830078125E-003
-(PID.TID 0000.0001)         System time:   0.0000000000000000
-(PID.TID 0000.0001)     Wall clock time:   6.7529678344726562E-003
-(PID.TID 0000.0001)          No. starts:         120
-(PID.TID 0000.0001)           No. stops:         120
+(PID.TID 0000.0001)           User time:   2.2379010915756226E-002
+(PID.TID 0000.0001)         System time:   4.2967498302459717E-005
+(PID.TID 0000.0001)     Wall clock time:   2.2445678710937500E-002
+(PID.TID 0000.0001)          No. starts:        1200
+(PID.TID 0000.0001)           No. stops:        1200
 (PID.TID 0000.0001)   Seconds in section "COST_TILE           [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:   1.1999607086181641E-002
-(PID.TID 0000.0001)         System time:   0.0000000000000000
-(PID.TID 0000.0001)     Wall clock time:   9.6330642700195312E-003
+(PID.TID 0000.0001)           User time:   1.0327324271202087E-002
+(PID.TID 0000.0001)         System time:   4.0017068386077881E-005
+(PID.TID 0000.0001)     Wall clock time:   1.0452032089233398E-002
 (PID.TID 0000.0001)          No. starts:        1200
 (PID.TID 0000.0001)           No. stops:        1200
 (PID.TID 0000.0001)   Seconds in section "DO_THE_MODEL_IO     [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:   8.7995707988739014E-002
-(PID.TID 0000.0001)         System time:   3.9999969303607941E-003
-(PID.TID 0000.0001)     Wall clock time:   8.7149381637573242E-002
+(PID.TID 0000.0001)           User time:   7.3838666081428528E-002
+(PID.TID 0000.0001)         System time:   1.5648990869522095E-002
+(PID.TID 0000.0001)     Wall clock time:   8.9429616928100586E-002
 (PID.TID 0000.0001)          No. starts:        1200
 (PID.TID 0000.0001)           No. stops:        1200
 (PID.TID 0000.0001)   Seconds in section "DO_WRITE_PICKUP     [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:   8.0018043518066406E-003
-(PID.TID 0000.0001)         System time:   0.0000000000000000
-(PID.TID 0000.0001)     Wall clock time:   1.4096260070800781E-002
+(PID.TID 0000.0001)           User time:   1.5399739146232605E-002
+(PID.TID 0000.0001)         System time:   6.6958367824554443E-005
+(PID.TID 0000.0001)     Wall clock time:   1.5442371368408203E-002
 (PID.TID 0000.0001)          No. starts:        1200
 (PID.TID 0000.0001)           No. stops:        1200
 (PID.TID 0000.0001)   Seconds in section "GRDCHK_MAIN         [THE_MODEL_MAIN]":
-(PID.TID 0000.0001)           User time:   34.172004699707031
-(PID.TID 0000.0001)         System time:  0.11600002646446228
-(PID.TID 0000.0001)     Wall clock time:   34.309172153472900
+(PID.TID 0000.0001)           User time:   33.185432434082031
+(PID.TID 0000.0001)         System time:   7.2125971317291260E-002
+(PID.TID 0000.0001)     Wall clock time:   33.260450124740601
 (PID.TID 0000.0001)          No. starts:           1
 (PID.TID 0000.0001)           No. stops:           1
 (PID.TID 0000.0001)   Seconds in section "INITIALISE_VARIA    [THE_MAIN_LOOP]":
-(PID.TID 0000.0001)           User time:   7.2002410888671875E-002
-(PID.TID 0000.0001)         System time:   0.0000000000000000
-(PID.TID 0000.0001)     Wall clock time:   8.1685781478881836E-002
+(PID.TID 0000.0001)           User time:   9.4329833984375000E-002
+(PID.TID 0000.0001)         System time:   1.2667894363403320E-002
+(PID.TID 0000.0001)     Wall clock time:  0.10702419281005859
 (PID.TID 0000.0001)          No. starts:           8
 (PID.TID 0000.0001)           No. stops:           8
 (PID.TID 0000.0001)   Seconds in section "MAIN LOOP           [THE_MAIN_LOOP]":
-(PID.TID 0000.0001)           User time:   34.079998016357422
-(PID.TID 0000.0001)         System time:  0.11600002646446228
-(PID.TID 0000.0001)     Wall clock time:   34.211842536926270
+(PID.TID 0000.0001)           User time:   33.079360961914062
+(PID.TID 0000.0001)         System time:   5.6145012378692627E-002
+(PID.TID 0000.0001)     Wall clock time:   33.138392686843872
 (PID.TID 0000.0001)          No. starts:           8
 (PID.TID 0000.0001)           No. stops:           8
 (PID.TID 0000.0001)   Seconds in section "MAIN_DO_LOOP        [THE_MAIN_LOOP]":
-(PID.TID 0000.0001)           User time:   31.475940704345703
-(PID.TID 0000.0001)         System time:  0.10400003194808960
-(PID.TID 0000.0001)     Wall clock time:   31.587927579879761
+(PID.TID 0000.0001)           User time:   30.154838562011719
+(PID.TID 0000.0001)         System time:   5.2157044410705566E-002
+(PID.TID 0000.0001)     Wall clock time:   30.209076881408691
 (PID.TID 0000.0001)          No. starts:         960
 (PID.TID 0000.0001)           No. stops:         960
 (PID.TID 0000.0001)   Seconds in section "COST_FINAL         [ADJOINT SPIN-DOWN]":
-(PID.TID 0000.0001)           User time:   0.0000000000000000
+(PID.TID 0000.0001)           User time:   1.7242431640625000E-003
 (PID.TID 0000.0001)         System time:   0.0000000000000000
-(PID.TID 0000.0001)     Wall clock time:   1.3160705566406250E-003
+(PID.TID 0000.0001)     Wall clock time:   1.7087459564208984E-003
 (PID.TID 0000.0001)          No. starts:           8
 (PID.TID 0000.0001)           No. stops:           8
 (PID.TID 0000.0001) // ======================================================
@@ -6027,9 +7466,9 @@ grad-res -------------------------------
 (PID.TID 0000.0001) //          Total. Y spins =              0
 (PID.TID 0000.0001) //            Avg. Y spins =       0.00E+00
 (PID.TID 0000.0001) // o Thread number: 000001
-(PID.TID 0000.0001) //            No. barriers =           3916
+(PID.TID 0000.0001) //            No. barriers =           6356
 (PID.TID 0000.0001) //      Max. barrier spins =              1
 (PID.TID 0000.0001) //      Min. barrier spins =              1
-(PID.TID 0000.0001) //     Total barrier spins =           3916
+(PID.TID 0000.0001) //     Total barrier spins =           6356
 (PID.TID 0000.0001) //      Avg. barrier spins =       1.00E+00
 PROGRAM MAIN: Execution ended Normally

--- a/verification/testreport
+++ b/verification/testreport
@@ -210,9 +210,12 @@ testoutput_run()
 	#  load experiment-specific list from file "tr_checklist" (if it exist)
 	if test -r $1/$2/tr_checklist ; then listChk=`cat $1/$2/tr_checklist` ; fi
 	if test $KIND = 1 ; then kd='g_';
+	  if test -r $1/$2/tr_checklist.tlm ; then listChk=`cat $1/$2/tr_checklist.tlm` ; fi
 	  #  TLM use same input_ad/tr_checklist --> convert
 	  listChk=`echo $listChk | sed 's/\<adm/tlm/g'`
-	elif test $KIND = 2 -o $KIND = 4 ; then kd='ad';
+	elif test $KIND = 2 ; then kd='ad';
+	  if test -r $1/$2/tr_checklist.adm ; then listChk=`cat $1/$2/tr_checklist.adm` ; fi
+	elif test $KIND = 4 ; then kd='ad';
         else kd=''; fi
 	if [ $debug -gt 0 ]; then echo "testoutput_run: listChk='$listChk'" 1>&2 ; fi
 	# remove 1rst var and expand the list: + => min max mean s.d
@@ -308,22 +311,22 @@ testoutput_run()
 	 'Qntmx') testoutput_var $1 "forcing_qnet_max"  "Qnet maximum"  $2 $refoutp ; yy=$? ;;
 	 'Qntav') testoutput_var $1 "forcing_qnet_mean" "Qnet mean"	$2 $refoutp ; yy=$? ;;
 	 'Qntsd') testoutput_var $1 "forcing_qnet_sd"   "Qnet Std.Dev"  $2 $refoutp ; yy=$? ;;
-	 'aSImn') testoutput_var $1 "seaice_area_min"   "SIce Area min"	  $2 $refoutp ; yy=$? ;;
-	 'aSImx') testoutput_var $1 "seaice_area_max"   "SIce Area max"	  $2 $refoutp ; yy=$? ;;
-	 'aSIav') testoutput_var $1 "seaice_area_mean"  "SIce Area mean"  $2 $refoutp ; yy=$? ;;
-	 'aSIsd') testoutput_var $1 "seaice_area_sd"    "SIce Area StDv"  $2 $refoutp ; yy=$? ;;
-	 'hSImn') testoutput_var $1 "seaice_heff_min"   "SIce Heff min"	  $2 $refoutp ; yy=$? ;;
-	 'hSImx') testoutput_var $1 "seaice_heff_max"   "SIce Heff max"	  $2 $refoutp ; yy=$? ;;
-	 'hSIav') testoutput_var $1 "seaice_heff_mean"  "SIce Heff mean"  $2 $refoutp ; yy=$? ;;
-	 'hSIsd') testoutput_var $1 "seaice_heff_sd"    "SIce Heff StDv"  $2 $refoutp ; yy=$? ;;
-	 'uSImn') testoutput_var $1 "seaice_uice_min"   "SIce Uice min"	  $2 $refoutp ; yy=$? ;;
-	 'uSImx') testoutput_var $1 "seaice_uice_max"   "SIce Uice max"	  $2 $refoutp ; yy=$? ;;
-	 'uSIav') testoutput_var $1 "seaice_uice_mean"  "SIce Uice mean"  $2 $refoutp ; yy=$? ;;
-	 'uSIsd') testoutput_var $1 "seaice_uice_sd"    "SIce Uice StDv"  $2 $refoutp ; yy=$? ;;
-	 'vSImn') testoutput_var $1 "seaice_vice_min"   "SIce Vice min"	  $2 $refoutp ; yy=$? ;;
-	 'vSImx') testoutput_var $1 "seaice_vice_max"   "SIce Vice max"	  $2 $refoutp ; yy=$? ;;
-	 'vSIav') testoutput_var $1 "seaice_vice_mean"  "SIce Vice mean"  $2 $refoutp ; yy=$? ;;
-	 'vSIsd') testoutput_var $1 "seaice_vice_sd"    "SIce Vice StDv"  $2 $refoutp ; yy=$? ;;
+	 'aSImn') testoutput_var $1 "seaice_${kd}area_min"  "SIce ${kd}Area min"   $2 $refoutp ; yy=$? ;;
+	 'aSImx') testoutput_var $1 "seaice_${kd}area_max"  "SIce ${kd}Area max"   $2 $refoutp ; yy=$? ;;
+	 'aSIav') testoutput_var $1 "seaice_${kd}area_mean" "SIce ${kd}Area mean"  $2 $refoutp ; yy=$? ;;
+	 'aSIsd') testoutput_var $1 "seaice_${kd}area_sd"   "SIce ${kd}Area StDv"  $2 $refoutp ; yy=$? ;;
+	 'hSImn') testoutput_var $1 "seaice_${kd}heff_min"  "SIce ${kd}Heff min"   $2 $refoutp ; yy=$? ;;
+	 'hSImx') testoutput_var $1 "seaice_${kd}heff_max"  "SIce ${kd}Heff max"   $2 $refoutp ; yy=$? ;;
+	 'hSIav') testoutput_var $1 "seaice_${kd}heff_mean" "SIce ${kd}Heff mean"  $2 $refoutp ; yy=$? ;;
+	 'hSIsd') testoutput_var $1 "seaice_${kd}heff_sd"   "SIce ${kd}Heff StDv"  $2 $refoutp ; yy=$? ;;
+	 'uSImn') testoutput_var $1 "seaice_${kd}uice_min"  "SIce ${kd}Uice min"   $2 $refoutp ; yy=$? ;;
+	 'uSImx') testoutput_var $1 "seaice_${kd}uice_max"  "SIce ${kd}Uice max"   $2 $refoutp ; yy=$? ;;
+	 'uSIav') testoutput_var $1 "seaice_${kd}uice_mean" "SIce ${kd}Uice mean"  $2 $refoutp ; yy=$? ;;
+	 'uSIsd') testoutput_var $1 "seaice_${kd}uice_sd"   "SIce ${kd}Uice StDv"  $2 $refoutp ; yy=$? ;;
+	 'vSImn') testoutput_var $1 "seaice_${kd}vice_min"  "SIce ${kd}Vice min"   $2 $refoutp ; yy=$? ;;
+	 'vSImx') testoutput_var $1 "seaice_${kd}vice_max"  "SIce ${kd}Vice max"   $2 $refoutp ; yy=$? ;;
+	 'vSIav') testoutput_var $1 "seaice_${kd}vice_mean" "SIce ${kd}Vice mean"  $2 $refoutp ; yy=$? ;;
+	 'vSIsd') testoutput_var $1 "seaice_${kd}vice_sd"   "SIce ${kd}Vice StDv"  $2 $refoutp ; yy=$? ;;
 	'AthSiG') testoutput_var $1 "thSI_Ice_Area_G" "thSIc Area Global" $2 $refoutp ; yy=$? ;;
 	'AthSiS') testoutput_var $1 "thSI_Ice_Area_S" "thSIc Area South"  $2 $refoutp ; yy=$? ;;
 	'AthSiN') testoutput_var $1 "thSI_Ice_Area_N" "thSIc Area North"  $2 $refoutp ; yy=$? ;;
@@ -344,10 +347,10 @@ testoutput_run()
             nn=`echo $xx | sed 's/pt//' | sed 's/..$//'`
             ii=`echo $xx | sed 's/^pt[0-9]*//'`
 	    case $ii in
-	    'mn') testoutput_var $1 "trcstat_ptracer0"$nn"_min"  "p0"$nn"_min"  $2 $refoutp ; yy=$? ;;
-	    'mx') testoutput_var $1 "trcstat_ptracer0"$nn"_max"  "p0"$nn"_max"  $2 $refoutp ; yy=$? ;;
-	    'av') testoutput_var $1 "trcstat_ptracer0"$nn"_mean" "p0"$nn"_mean" $2 $refoutp ; yy=$? ;;
-	    'sd') testoutput_var $1 "trcstat_ptracer0"$nn"_sd"   "p0"$nn"_StDv" $2 $refoutp ; yy=$? ;;
+	    'mn') testoutput_var $1 "trcstat_${kd}ptracer0"$nn"_min"  "${kd}pTr0"$nn"_min"  $2 $refoutp ; yy=$? ;;
+	    'mx') testoutput_var $1 "trcstat_${kd}ptracer0"$nn"_max"  "${kd}pTr0"$nn"_max"  $2 $refoutp ; yy=$? ;;
+	    'av') testoutput_var $1 "trcstat_${kd}ptracer0"$nn"_mean" "${kd}pTr0"$nn"_mean" $2 $refoutp ; yy=$? ;;
+	    'sd') testoutput_var $1 "trcstat_${kd}ptracer0"$nn"_sd"   "${kd}pTr0"$nn"_StDv" $2 $refoutp ; yy=$? ;;
 	    esac
           fi
 	  if test $xx = $sVar

--- a/verification/testreport
+++ b/verification/testreport
@@ -127,7 +127,7 @@ testoutput_var()
     #  using search strings s1 and text label
 
     if [ $debug -gt 0 ]; then
-	echo testoutput_var: grep "$2" $1/$4/$OUTPUTFILE 1>&2
+	echo testoutput_var: grep "'$2'" $1/$4/$OUTPUTFILE 1>&2
     fi
     if [ -r $1/$4/$OUTPUTFILE ]; then
 	grep "$2" $1/$4/$OUTPUTFILE | sed 's/.*=//' | nl > ${TMP}a.txt
@@ -143,7 +143,7 @@ testoutput_var()
 	return 99
     fi
     if [ $debug -gt 0 ]; then
-	echo testoutput_var: grep "$2" $1/$5 1>&2
+	echo testoutput_var: grep "'$2'" $1/$5 1>&2
     fi
     grep "$2" $1/$5 | sed 's/.*=//' | nl > ${TMP}b.txt
     lncntB=`wc -l ${TMP}b.txt | awk '{print $1}' `
@@ -307,6 +307,10 @@ testoutput_run()
 	   'Vmx') testoutput_var $1 "dynstat_${kd}vvel_max"   "${kd}V maximum"	   $2 $refoutp ; yy=$? ;;
 	   'Vav') testoutput_var $1 "dynstat_${kd}vvel_mean"  "${kd}V mean"	   $2 $refoutp ; yy=$? ;;
 	   'Vsd') testoutput_var $1 "dynstat_${kd}vvel_sd"    "${kd}V Std.Dev"	   $2 $refoutp ; yy=$? ;;
+	 'Etamn') testoutput_var $1 "dynstat_${kd}eta_min"    "${kd}Eta minimum"   $2 $refoutp ; yy=$? ;;
+	 'Etamx') testoutput_var $1 "dynstat_${kd}eta_max"    "${kd}Eta maximum"   $2 $refoutp ; yy=$? ;;
+	 'Etaav') testoutput_var $1 "dynstat_${kd}eta_mean"   "${kd}Eta mean"	   $2 $refoutp ; yy=$? ;;
+	 'Etasd') testoutput_var $1 "dynstat_${kd}eta_sd"     "${kd}Eta Std.Dev"   $2 $refoutp ; yy=$? ;;
 	 'Qntmn') testoutput_var $1 "forcing_qnet_min"  "Qnet minimum"  $2 $refoutp ; yy=$? ;;
 	 'Qntmx') testoutput_var $1 "forcing_qnet_max"  "Qnet maximum"  $2 $refoutp ; yy=$? ;;
 	 'Qntav') testoutput_var $1 "forcing_qnet_mean" "Qnet mean"	$2 $refoutp ; yy=$? ;;

--- a/verification/testreport
+++ b/verification/testreport
@@ -209,11 +209,16 @@ testoutput_run()
 	listChk=$DEF_CHECK_LIST
 	#  load experiment-specific list from file "tr_checklist" (if it exist)
 	if test -r $1/$2/tr_checklist ; then listChk=`cat $1/$2/tr_checklist` ; fi
-	sVar=`echo $listChk | awk '{print $1}'`
+	if test $KIND = 1 ; then kd='g_';
+	  #  TLM use same input_ad/tr_checklist --> convert
+	  listChk=`echo $listChk | sed 's/\<adm/tlm/g'`
+	elif test $KIND = 2 -o $KIND = 4 ; then kd='ad';
+        else kd=''; fi
+	if [ $debug -gt 0 ]; then echo "testoutput_run: listChk='$listChk'" 1>&2 ; fi
 	# remove 1rst var and expand the list: + => min max mean s.d
+	sVar=`echo $listChk | awk '{print $1}'`
 	listVar=`echo $listChk | sed 's/ [a-zA-Z0-9]*+/&mn &mx &av &sd/g' \
 			       | sed 's/+//g' | sed "s/^$sVar//"`
-	if [ $debug -gt 0 ]; then echo "testoutput_run: listVar(I)='$listVar'" 1>&2 ; fi
 	# set ref.outp file-name and, if compressed, uncompress it into subdir
 	refoutp=results/$3
 	if test ! -r $1/results/$3 ; then
@@ -262,7 +267,7 @@ testoutput_run()
 	#- put it back once:
 	  listVar=" $sVar "`echo "$listVar " | sed "s/ $sVar / /g"`
 	fi
-	if [ $debug -gt 0 ]; then echo "testoutput_run: listVar(M)='$listVar'" 1>&2 ; fi
+	if [ $debug -gt 0 ]; then echo "testoutput_run: listVar='$listVar'" 1>&2 ; fi
 	echo "listVar='$listVar'" >> $locDIR"/summary.txt"
 	#---
 	allargs=""
@@ -277,32 +282,32 @@ testoutput_run()
 		  then echo testoutput_run: testoutput_var $1 cg2d_init_res 1>&2 ; fi
 		  testoutput_var $1 "cg2d_init_res" "Press. Solver (cg2d)" $2 $refoutp ; yy=$?
 		  if [ $debug -gt 0 ] ; then echo testoutput_run: cg2dres=$yy 1>&2 ; fi ;;
-	  'Cost') testoutput_var $1 "ADM  ref_cost_function" "ADM CostFct" $2 $refoutp ; yy=$? ;;
-	 'AdGrd') testoutput_var $1 "ADM  adjoint_gradient"  "ADM Ad Grad" $2 $refoutp ; yy=$? ;;
-	 'FDGrd') testoutput_var $1 "ADM  finite-diff_grad"  "ADM FD Grad" $2 $refoutp ; yy=$? ;;
+	'admCst') testoutput_var $1 "ADM  ref_cost_function" "ADM CostFct" $2 $refoutp ; yy=$? ;;
+	'admGrd') testoutput_var $1 "ADM  adjoint_gradient"  "ADM Ad Grad" $2 $refoutp ; yy=$? ;;
+	'admFwd') testoutput_var $1 "ADM  finite-diff_grad"  "ADM FD Grad" $2 $refoutp ; yy=$? ;;
 	'tlmCst') testoutput_var $1 "TLM  ref_cost_function" "TLM CostFct" $2 $refoutp ; yy=$? ;;
 	'tlmGrd') testoutput_var $1 "TLM  tangent-lin_grad"  "TLM TL Grad" $2 $refoutp ; yy=$? ;;
-	'fwdGrd') testoutput_var $1 "TLM  finite-diff_grad"  "TLM FD Grad" $2 $refoutp ; yy=$? ;;
-	   'Tmn') testoutput_var $1 "dynstat_theta_min"  "Theta minimum"  $2 $refoutp ; yy=$? ;;
-	   'Tmx') testoutput_var $1 "dynstat_theta_max"  "Theta maximum"  $2 $refoutp ; yy=$? ;;
-	   'Tav') testoutput_var $1 "dynstat_theta_mean" "Theta mean"	  $2 $refoutp ; yy=$? ;;
-	   'Tsd') testoutput_var $1 "dynstat_theta_sd"   "Theta Std.Dev"  $2 $refoutp ; yy=$? ;;
-	   'Smn') testoutput_var $1 "dynstat_salt_min"  "Salt minimum"	  $2 $refoutp ; yy=$? ;;
-	   'Smx') testoutput_var $1 "dynstat_salt_max"  "Salt maximum"	  $2 $refoutp ; yy=$? ;;
-	   'Sav') testoutput_var $1 "dynstat_salt_mean" "Salt mean"	  $2 $refoutp ; yy=$? ;;
-	   'Ssd') testoutput_var $1 "dynstat_salt_sd"   "Salt Std.Dev"	  $2 $refoutp ; yy=$? ;;
-	   'Umn') testoutput_var $1 "dynstat_uvel_min"  "U minimum"	  $2 $refoutp ; yy=$? ;;
-	   'Umx') testoutput_var $1 "dynstat_uvel_max"  "U maximum"	  $2 $refoutp ; yy=$? ;;
-	   'Uav') testoutput_var $1 "dynstat_uvel_mean" "U mean"	  $2 $refoutp ; yy=$? ;;
-	   'Usd') testoutput_var $1 "dynstat_uvel_sd"   "U Std.Dev"	  $2 $refoutp ; yy=$? ;;
-	   'Vmn') testoutput_var $1 "dynstat_vvel_min"  "V minimum"	  $2 $refoutp ; yy=$? ;;
-	   'Vmx') testoutput_var $1 "dynstat_vvel_max"  "V maximum"	  $2 $refoutp ; yy=$? ;;
-	   'Vav') testoutput_var $1 "dynstat_vvel_mean" "V mean"	  $2 $refoutp ; yy=$? ;;
-	   'Vsd') testoutput_var $1 "dynstat_vvel_sd"   "V Std.Dev"	  $2 $refoutp ; yy=$? ;;
-	 'Qntmn') testoutput_var $1 "forcing_qnet_min" "Qnet minimum"  $2 $refoutp ; yy=$? ;;
-	 'Qntmx') testoutput_var $1 "forcing_qnet_max" "Qnet maximum"  $2 $refoutp ; yy=$? ;;
-	 'Qntav') testoutput_var $1 "forcing_qnet_mean" "Qnet mean"	  $2 $refoutp ; yy=$? ;;
-	 'Qntsd') testoutput_var $1 "forcing_qnet_sd"  "Qnet Std.Dev"  $2 $refoutp ; yy=$? ;;
+	'tlmFwd') testoutput_var $1 "TLM  finite-diff_grad"  "TLM FD Grad" $2 $refoutp ; yy=$? ;;
+	   'Tmn') testoutput_var $1 "dynstat_${kd}theta_min"  "${kd}Theta minimum" $2 $refoutp ; yy=$? ;;
+	   'Tmx') testoutput_var $1 "dynstat_${kd}theta_max"  "${kd}Theta maximum" $2 $refoutp ; yy=$? ;;
+	   'Tav') testoutput_var $1 "dynstat_${kd}theta_mean" "${kd}Theta mean"	   $2 $refoutp ; yy=$? ;;
+	   'Tsd') testoutput_var $1 "dynstat_${kd}theta_sd"   "${kd}Theta Std.Dev" $2 $refoutp ; yy=$? ;;
+	   'Smn') testoutput_var $1 "dynstat_${kd}salt_min"   "${kd}Salt minimum"  $2 $refoutp ; yy=$? ;;
+	   'Smx') testoutput_var $1 "dynstat_${kd}salt_max"   "${kd}Salt maximum"  $2 $refoutp ; yy=$? ;;
+	   'Sav') testoutput_var $1 "dynstat_${kd}salt_mean"  "${kd}Salt mean"	   $2 $refoutp ; yy=$? ;;
+	   'Ssd') testoutput_var $1 "dynstat_${kd}salt_sd"    "${kd}Salt Std.Dev"  $2 $refoutp ; yy=$? ;;
+	   'Umn') testoutput_var $1 "dynstat_${kd}uvel_min"   "${kd}U minimum"	   $2 $refoutp ; yy=$? ;;
+	   'Umx') testoutput_var $1 "dynstat_${kd}uvel_max"   "${kd}U maximum"	   $2 $refoutp ; yy=$? ;;
+	   'Uav') testoutput_var $1 "dynstat_${kd}uvel_mean"  "${kd}U mean"	   $2 $refoutp ; yy=$? ;;
+	   'Usd') testoutput_var $1 "dynstat_${kd}uvel_sd"    "${kd}U Std.Dev"	   $2 $refoutp ; yy=$? ;;
+	   'Vmn') testoutput_var $1 "dynstat_${kd}vvel_min"   "${kd}V minimum"	   $2 $refoutp ; yy=$? ;;
+	   'Vmx') testoutput_var $1 "dynstat_${kd}vvel_max"   "${kd}V maximum"	   $2 $refoutp ; yy=$? ;;
+	   'Vav') testoutput_var $1 "dynstat_${kd}vvel_mean"  "${kd}V mean"	   $2 $refoutp ; yy=$? ;;
+	   'Vsd') testoutput_var $1 "dynstat_${kd}vvel_sd"    "${kd}V Std.Dev"	   $2 $refoutp ; yy=$? ;;
+	 'Qntmn') testoutput_var $1 "forcing_qnet_min"  "Qnet minimum"  $2 $refoutp ; yy=$? ;;
+	 'Qntmx') testoutput_var $1 "forcing_qnet_max"  "Qnet maximum"  $2 $refoutp ; yy=$? ;;
+	 'Qntav') testoutput_var $1 "forcing_qnet_mean" "Qnet mean"	$2 $refoutp ; yy=$? ;;
+	 'Qntsd') testoutput_var $1 "forcing_qnet_sd"   "Qnet Std.Dev"  $2 $refoutp ; yy=$? ;;
 	 'aSImn') testoutput_var $1 "seaice_area_min"   "SIce Area min"	  $2 $refoutp ; yy=$? ;;
 	 'aSImx') testoutput_var $1 "seaice_area_max"   "SIce Area max"	  $2 $refoutp ; yy=$? ;;
 	 'aSIav') testoutput_var $1 "seaice_area_mean"  "SIce Area mean"  $2 $refoutp ; yy=$? ;;
@@ -1354,20 +1359,20 @@ if [ $verbose -gt 1 ]; then echo " temp files: $TMP" ; fi
 #  (use default or load experiment-specific list from file "tr_checklist")
 # content : 1rst = main variable used to decide if it pass or FAIL
 #         others = number of matching digits to be printed in summary.txt
-if test $KIND = 1 ; then
-    DEF_CHECK_LIST='tlmGrd tlmCst tlmGrd fwdGrd'
-    EMPTY_RESULTS='.. .. ..'
-    LEN_CHECK_LIST=`echo $DEF_CHECK_LIST | sed 's/ [a-zA-Z0-9]*+/&mn &mx &av &sd/g' | awk '{print NF-1}'`
-elif test $KIND = 2 -o $KIND = 4 ; then
-    DEF_CHECK_LIST='AdGrd Cost AdGrd FDGrd'
-    EMPTY_RESULTS='.. .. ..'
-    LEN_CHECK_LIST=`echo $DEF_CHECK_LIST | sed 's/ [a-zA-Z0-9]*+/&mn &mx &av &sd/g' | awk '{print NF-1}'`
-else
+if test $KIND = 0 ; then
     DEF_CHECK_LIST='PS PS T+ S+ U+ V+ pt1+ pt2+ pt3+ pt4+ pt5+'
     EMPTY_RESULTS='.. .. .. .. .. .. .. .. .. .. .. .. .. .. .. .. ..'
     LEN_CHECK_LIST=`echo $DEF_CHECK_LIST | sed 's/ [a-zA-Z0-9]*+/&mn &mx &av &sd/g' | awk '{print NF-1}'`
     ii=`echo $EMPTY_RESULTS | awk '{print NF}'`
     EMPTY_RESULTS=$EMPTY_RESULTS`expr $LEN_CHECK_LIST - $ii | awk 'BEGIN{FS=":"}{for(i=1;i<=$1;i++){printf "  ."}}'`
+elif test $KIND = 2 ; then
+    DEF_CHECK_LIST='admGrd admCst admGrd admFwd T+ S+ U+ V+'
+    EMPTY_RESULTS='.. .. .. .. .. .. ..  .. .. .. ..  .. .. .. ..  .. .. .. ..'
+    LEN_CHECK_LIST=`echo $DEF_CHECK_LIST | sed 's/ [a-zA-Z0-9]*+/&mn &mx &av &sd/g' | awk '{print NF-1}'`
+else
+    DEF_CHECK_LIST='admGrd admCst admGrd admFwd'
+    EMPTY_RESULTS='.. .. ..'
+    LEN_CHECK_LIST=`echo $DEF_CHECK_LIST | sed 's/ [a-zA-Z0-9]*+/&mn &mx &av &sd/g' | awk '{print NF-1}'`
 fi
 
 #  create the FORTRAN comparison code
@@ -1467,7 +1472,6 @@ if test $KIND = 0 ; then
 	line_4="$line_4  n  x  n  ."
     done
 else
-    line_0=`printf '%s %2i' 'default   ' $MATCH_CRIT`
   if test $KIND = 1 ; then
    #echo "TANGLIN=true" >> $SUMMARY
     echo "TangLin generated by TAF" >> $SUMMARY
@@ -1479,6 +1483,7 @@ else
   else
     echo "Adjoint generated by OpenAD" >> $SUMMARY
   fi
+    line_0=`printf '%s %2i' 'default   ' $MATCH_CRIT`
   if test $KIND = 1 -o $KIND = 3 ; then
     line_1="G D M    C  T  F"
     line_2="e p a R  o  L  D"
@@ -1489,6 +1494,14 @@ else
     line_3="n n k u  s  G  G"
     line_4="2 d e n  t  r  r"
     echo >> $SUMMARY
+  if test $KIND = 2 ; then
+    line_0=`printf '%s %2i   ' 'default   ' $MATCH_CRIT`
+    line_0="$line_0  ----T-----  ----S-----  ----U-----  ----V-----"
+    line_1="$line_1        m  s        m  s        m  s        m  s"
+    line_2="$line_2  m  m  e  .  m  m  e  .  m  m  e  .  m  m  e  ."
+    line_3="$line_3  i  a  a  d  i  a  a  d  i  a  a  d  i  a  a  d"
+    line_4="$line_4  n  x  n  .  n  x  n  .  n  x  n  .  n  x  n  ."
+  fi
 fi
 if test "x$CLEANUP" != xt ; then
     echo "$line_0" | tee -a $SUMMARY


### PR DESCRIPTION
## What changes does this PR introduce?
For adjoint testreport run, check some AD-monitor and report matching numbers.
This is an attempt to address issue #437

## What is the current behaviour? 
currently, only check and report cost-function, ad gradient and forward gradient.

## What is the new behaviour 
Also check for 3-D state variable ad-monitor and report matching numbers

## Does this PR introduce a breaking change? 
no

## Other information:

## Suggested addition to `tag-index`
o verification/testreport
  - add ad-monitor of 3-D state variables to testreport summary output