### PR TITLE
Avoid too large tracer gradient "slope"

### DIFF
--- a/doc/tag-index
+++ b/doc/tag-index
@@ -1,6 +1,10 @@
     Notes on tags used in MITgcmUV
     ==============================
 
+o pkg/generic_advdiff:
+  - improve "slope" calculation in DST2 Flux-Limiter advection scheme to avoid
+    potential over-flow arithmetic in division by small slope (issue #459),
+    similar to what has been done in gad_dst3fl_*.F routines.
 o pkg/diagnostics:
   - use Integer*8 conversion in diagnostics_out.F to get time-record to write
     in meta file (avoid integer overflow with large time & small diag-freq).

--- a/pkg/generic_advdiff/gad_fluxlimit_adv_r.F
+++ b/pkg/generic_advdiff/gad_fluxlimit_adv_r.F
@@ -5,7 +5,7 @@ C !ROUTINE: GAD_FLUXLIMIT_ADV_R
 
 C !INTERFACE: ==========================================================
       SUBROUTINE GAD_FLUXLIMIT_ADV_R(
-     I           bi,bj,k,dTarg,
+     I           bi, bj, k, dTarg,
      I           rTrans, wFld,
      I           tracer,
      O           wT,
@@ -32,13 +32,13 @@ C !USES: ===============================================================
 #include "PARAMS.h"
 
 C !INPUT PARAMETERS: ===================================================
-C  bi,bj              :: tile indices
+C  bi, bj             :: tile indices
 C  k                  :: vertical level
 C  rTrans             :: vertical volume transport
 C  wFld               :: vertical flow
 C  tracer             :: tracer field
 C  myThid             :: thread number
-      INTEGER bi,bj,k
+      INTEGER bi, bj, k
       _RL dTarg
       _RL rTrans(1-OLx:sNx+OLx,1-OLy:sNy+OLy)
       _RL wFld  (1-OLx:sNx+OLx,1-OLy:sNy+OLy)
@@ -50,62 +50,65 @@ C  wT                 :: vertical advective flux
       _RL wT    (1-OLx:sNx+OLx,1-OLy:sNy+OLy)
 
 C !LOCAL VARIABLES: ====================================================
-C  i,j                :: loop indices
+C  i, j               :: loop indices
 C  kp1                :: =min( k+1 , Nr )
 C  km1                :: =max( k-1 , 1 )
 C  km2                :: =max( k-2 , 1 )
-C  bi,bj              :: tile indices or (1,1) depending on use
+C  bi, bj             :: tile indices or (1,1) depending on use
 C  Cr                 :: slope ratio
-C  Rjm,Rj,Rjp         :: differences at i-1,i,i+1
+C  Rjm, Rj, Rjp       :: differences at k-1,k,k+1
 C  wLoc               :: velocity, vertical component
-      INTEGER i,j,kp1,km1,km2
-      _RL Cr,Rjm,Rj,Rjp
+      INTEGER i, j, kp1, km1, km2
+      _RL Cr, Rjm, Rj, Rjp
       _RL wLoc, wCFL
+      _RL CrMax
+      PARAMETER( CrMax = 1.D+6 )
+
 C Statement function provides Limiter(Cr)
 #include "GAD_FLUX_LIMITER.h"
 CEOP
 
-      km2=MAX(1,k-2)
-      km1=MAX(1,k-1)
-      kp1=MIN(Nr,k+1)
+      km2 = MAX(1,k-2)
+      km1 = MAX(1,k-1)
+      kp1 = MIN(Nr,k+1)
 
       IF ( k.GT.Nr) THEN
-       DO j=1-Oly,sNy+Oly
-        DO i=1-Olx,sNx+Olx
+       DO j=1-OLy,sNy+OLy
+        DO i=1-OLx,sNx+OLx
          wT(i,j) = 0.
         ENDDO
        ENDDO
       ELSE
-       DO j=1-Oly,sNy+Oly
-        DO i=1-Olx,sNx+Olx
+       DO j=1-OLy,sNy+OLy
+        DO i=1-OLx,sNx+OLx
 
          wLoc = wFld(i,j)
          wCFL = ABS( wLoc*dTarg*recip_drC(k) )
-         Rjp=(tracer(i,j,kp1)-tracer(i,j,k))
-     &        *maskC(i,j,kp1,bi,bj)
-         Rj= (tracer(i,j,k)  -tracer(i,j,kM1))
-         Rjm=(tracer(i,j,km1)-tracer(i,j,kM2))
-     &        *maskC(i,j,km2,bi,bj)
+         Rjp = (tracer(i,j,kp1)-tracer(i,j,k))
+     &          *maskC(i,j,kp1,bi,bj)
+         Rj  = (tracer(i,j,k)  -tracer(i,j,km1))
+         Rjm = (tracer(i,j,km1)-tracer(i,j,km2))
+     &          *maskC(i,j,km2,bi,bj)
 
-         IF (Rj.NE.0.) THEN
-          IF (rTrans(i,j).LT.0.) THEN
-            Cr=Rjm/Rj
-          ELSE
-            Cr=Rjp/Rj
-          ENDIF
+         IF ( rTrans(i,j).LT.zeroRL ) THEN
+           Cr = Rjm
          ELSE
-          IF (rTrans(i,j).LT.0.) THEN
-            Cr=Rjm*1.E20
-          ELSE
-            Cr=Rjp*1.E20
-          ENDIF
+           Cr = Rjp
          ENDIF
-         Cr=Limiter(Cr)
-         wT(i,j) = maskC(i,j,kM1,bi,bj)*(
-     &     rTrans(i,j)*
-     &        (tracer(i,j,k)+tracer(i,j,kM1))*0.5 _d 0
-     &    +ABS(rTrans(i,j))*((1.-Cr)+wCFL*Cr)
-     &                     *Rj*0.5 _d 0 )
+         IF ( ABS(Rj)*CrMax .LE. ABS(Cr) ) THEN
+           Cr = SIGN( CrMax, Cr )*SIGN( oneRL, Rj )
+         ELSE
+           Cr = Cr/Rj
+         ENDIF
+
+C        calculate Limiter Function:
+         Cr = Limiter(Cr)
+
+         wT(i,j) = maskC(i,j,km1,bi,bj)*(
+     &      rTrans(i,j)*
+     &        (tracer(i,j,k)+tracer(i,j,km1))*0.5 _d 0
+     &    + ABS(rTrans(i,j))*( (oneRL-Cr) + wCFL*Cr )
+     &                      *Rj*0.5 _d 0 )
         ENDDO
        ENDDO
       ENDIF

--- a/pkg/generic_advdiff/gad_fluxlimit_adv_x.F
+++ b/pkg/generic_advdiff/gad_fluxlimit_adv_x.F
@@ -5,7 +5,7 @@ C !ROUTINE: GAD_FLUXLIMIT_ADV_X
 
 C !INTERFACE: ==========================================================
       SUBROUTINE GAD_FLUXLIMIT_ADV_X(
-     I           bi,bj,k, calcCFL, deltaTloc,
+     I           bi, bj, k, calcCFL, deltaTloc,
      I           uTrans, uFld,
      I           maskLocW, tracer,
      O           uT,
@@ -27,10 +27,11 @@ C the slope ratio.
 C !USES: ===============================================================
       IMPLICIT NONE
 #include "SIZE.h"
+#include "EEPARAMS.h"
 #include "GRID.h"
 
 C !INPUT PARAMETERS: ===================================================
-C  bi,bj             :: tile indices
+C  bi, bj            :: tile indices
 C  k                 :: vertical level
 C  calcCFL           :: =T: calculate CFL number ; =F: take uFld as CFL
 C  deltaTloc         :: local time-step (s)
@@ -38,7 +39,7 @@ C  uTrans            :: zonal volume transport
 C  uFld              :: zonal flow / CFL number
 C  tracer            :: tracer field
 C  myThid            :: thread number
-      INTEGER bi,bj,k
+      INTEGER bi, bj, k
       LOGICAL calcCFL
       _RL deltaTloc
       _RL uTrans(1-OLx:sNx+OLx,1-OLy:sNy+OLy)
@@ -52,49 +53,52 @@ C  uT                :: zonal advective flux
       _RL uT    (1-OLx:sNx+OLx,1-OLy:sNy+OLy)
 
 C !LOCAL VARIABLES: ====================================================
-C  i,j               :: loop indices
+C  i, j              :: loop indices
 C  Cr                :: slope ratio
-C  Rjm,Rj,Rjp        :: differences at i-1,i,i+1
+C  Rjm, Rj, Rjp      :: differences at i-1,i,i+1
       INTEGER i,j
-      _RL Cr,Rjm,Rj,Rjp
+      _RL Cr, Rjm, Rj, Rjp
       _RL uCFL
+      _RL CrMax
+      PARAMETER( CrMax = 1.D+6 )
+
 C Statement function provides Limiter(Cr)
 #include "GAD_FLUX_LIMITER.h"
 CEOP
 
-      DO j=1-Oly,sNy+Oly
-       uT(1-Olx,j)=0.
-       uT(2-Olx,j)=0.
-       uT(sNx+Olx,j)=0.
+      DO j=1-OLy,sNy+OLy
+       uT(1-OLx,j) = 0. _d 0
+       uT(2-OLx,j) = 0. _d 0
+       uT(sNx+OLx,j) = 0. _d 0
       ENDDO
-      DO j=1-Oly,sNy+Oly
-       DO i=1-Olx+2,sNx+Olx-1
+      DO j=1-OLy,sNy+OLy
+       DO i=1-OLx+2,sNx+OLx-1
 
         uCFL = uFld(i,j)
         IF ( calcCFL ) uCFL = ABS( uFld(i,j)*deltaTloc
      &                  *recip_dxC(i,j,bi,bj)*recip_deepFacC(k) )
-        Rjp=(tracer(i+1,j)-tracer( i ,j))*maskLocW(i+1,j)
-        Rj =(tracer( i ,j)-tracer(i-1,j))*maskLocW( i ,j)
-        Rjm=(tracer(i-1,j)-tracer(i-2,j))*maskLocW(i-1,j)
+        Rjp = (tracer(i+1,j)-tracer( i ,j))*maskLocW(i+1,j)
+        Rj  = (tracer( i ,j)-tracer(i-1,j))*maskLocW( i ,j)
+        Rjm = (tracer(i-1,j)-tracer(i-2,j))*maskLocW(i-1,j)
 
-        IF (Rj.NE.0.) THEN
-         IF (uTrans(i,j).GT.0) THEN
-           Cr=Rjm/Rj
-         ELSE
-           Cr=Rjp/Rj
-         ENDIF
+        IF ( uTrans(i,j).GT.zeroRL ) THEN
+          Cr = Rjm
         ELSE
-         IF (uTrans(i,j).GT.0) THEN
-           Cr=Rjm*1.E20
-         ELSE
-           Cr=Rjp*1.E20
-         ENDIF
+          Cr = Rjp
         ENDIF
-        Cr=Limiter(Cr)
+        IF ( ABS(Rj)*CrMax .LE. ABS(Cr) ) THEN
+          Cr = SIGN( CrMax, Cr )*SIGN( oneRL, Rj )
+        ELSE
+          Cr = Cr/Rj
+        ENDIF
+
+C       calculate Limiter Function:
+        Cr = Limiter(Cr)
+
         uT(i,j) =
-     &   uTrans(i,j)*(Tracer(i,j)+Tracer(i-1,j))*0.5 _d 0
-     &   -ABS(uTrans(i,j))*((1.-Cr)+uCFL*Cr)
-     &                    *Rj*0.5 _d 0
+     &     uTrans(i,j)*(Tracer(i,j)+Tracer(i-1,j))*0.5 _d 0
+     &   - ABS(uTrans(i,j))*( (oneRL-Cr) + uCFL*Cr )
+     &                     *Rj*0.5 _d 0
        ENDDO
       ENDDO
 

--- a/pkg/generic_advdiff/gad_fluxlimit_adv_y.F
+++ b/pkg/generic_advdiff/gad_fluxlimit_adv_y.F
@@ -5,7 +5,7 @@ C !ROUTINE: GAD_FLUXLIMIT_ADV_Y
 
 C !INTERFACE: ==========================================================
       SUBROUTINE GAD_FLUXLIMIT_ADV_Y(
-     I           bi,bj,k, calcCFL, deltaTloc,
+     I           bi, bj, k, calcCFL, deltaTloc,
      I           vTrans, vFld,
      I           maskLocS, tracer,
      O           vT,
@@ -27,10 +27,11 @@ C the slope ratio.
 C !USES: ===============================================================
       IMPLICIT NONE
 #include "SIZE.h"
+#include "EEPARAMS.h"
 #include "GRID.h"
 
 C !INPUT PARAMETERS: ===================================================
-C  bi,bj             :: tile indices
+C  bi, bj            :: tile indices
 C  k                 :: vertical level
 C  calcCFL           :: =T: calculate CFL number ; =F: take vFld as CFL
 C  deltaTloc         :: local time-step (s)
@@ -38,7 +39,7 @@ C  vTrans            :: meridional volume transport
 C  vFld              :: meridional flow / CFL number
 C  tracer            :: tracer field
 C  myThid            :: thread number
-      INTEGER bi,bj,k
+      INTEGER bi, bj, k
       LOGICAL calcCFL
       _RL deltaTloc
       _RL vTrans(1-OLx:sNx+OLx,1-OLy:sNy+OLy)
@@ -52,49 +53,52 @@ C  vT                :: meridional advective flux
       _RL vT    (1-OLx:sNx+OLx,1-OLy:sNy+OLy)
 
 C !LOCAL VARIABLES: ====================================================
-C  i,j               :: loop indices
+C  i, j              :: loop indices
 C  Cr                :: slope ratio
-C  Rjm,Rj,Rjp        :: differences at j-1,j,j+1
+C  Rjm, Rj, Rjp      :: differences at j-1,j,j+1
       INTEGER i,j
-      _RL Cr,Rjm,Rj,Rjp
+      _RL Cr, Rjm, Rj, Rjp
       _RL vCFL
+      _RL CrMax
+      PARAMETER( CrMax = 1.D+6 )
+
 C Statement function provides Limiter(Cr)
 #include "GAD_FLUX_LIMITER.h"
 CEOP
 
-      DO i=1-Olx,sNx+Olx
-       vT(i,1-Oly)=0.
-       vT(i,2-Oly)=0.
-       vT(i,sNy+Oly)=0.
+      DO i=1-OLx,sNx+OLx
+       vT(i,1-OLy) = 0. _d 0
+       vT(i,2-OLy) = 0. _d 0
+       vT(i,sNy+OLy) = 0. _d 0
       ENDDO
-      DO j=1-Oly+2,sNy+Oly-1
-       DO i=1-Olx,sNx+Olx
+      DO j=1-OLy+2,sNy+OLy-1
+       DO i=1-OLx,sNx+OLx
 
         vCFL = vFld(i,j)
         IF ( calcCFL ) vCFL = ABS( vFld(i,j)*deltaTloc
      &                  *recip_dyC(i,j,bi,bj)*recip_deepFacC(k) )
-        Rjp=(tracer(i,j+1)-tracer(i, j ))*maskLocS(i,j+1)
-        Rj =(tracer(i, j )-tracer(i,j-1))*maskLocS(i, j )
-        Rjm=(tracer(i,j-1)-tracer(i,j-2))*maskLocS(i,j-1)
+        Rjp = (tracer(i,j+1)-tracer(i, j ))*maskLocS(i,j+1)
+        Rj  = (tracer(i, j )-tracer(i,j-1))*maskLocS(i, j )
+        Rjm = (tracer(i,j-1)-tracer(i,j-2))*maskLocS(i,j-1)
 
-        IF (Rj.NE.0.) THEN
-         IF (vTrans(i,j).GT.0) THEN
-           Cr=Rjm/Rj
-         ELSE
-           Cr=Rjp/Rj
-         ENDIF
+        IF ( vTrans(i,j).GT.zeroRL ) THEN
+          Cr = Rjm
         ELSE
-         IF (vTrans(i,j).GT.0) THEN
-           Cr=Rjm*1.E20
-         ELSE
-           Cr=Rjp*1.E20
-         ENDIF
+          Cr = Rjp
         ENDIF
-        Cr=Limiter(Cr)
+        IF ( ABS(Rj)*CrMax .LE. ABS(Cr) ) THEN
+          Cr = SIGN( CrMax, Cr )*SIGN( oneRL, Rj )
+        ELSE
+          Cr = Cr/Rj
+        ENDIF
+
+C       calculate Limiter Function:
+        Cr = Limiter(Cr)
+
         vT(i,j) =
-     &   vTrans(i,j)*(Tracer(i,j)+Tracer(i,j-1))*0.5 _d 0
-     &   -ABS(vTrans(i,j))*((1.-Cr)+vCFL*Cr)
-     &                    *Rj*0.5 _d 0
+     &     vTrans(i,j)*(Tracer(i,j)+Tracer(i,j-1))*0.5 _d 0
+     &   - ABS(vTrans(i,j))*( (oneRL-Cr) + vCFL*Cr )
+     &                     *Rj*0.5 _d 0
        ENDDO
       ENDDO
 

--- a/pkg/generic_advdiff/gad_fluxlimit_impl_r.F
+++ b/pkg/generic_advdiff/gad_fluxlimit_impl_r.F
@@ -27,10 +27,10 @@ C     == Global variables ===
 
 C     !INPUT/OUTPUT PARAMETERS:
 C     == Routine Arguments ==
-C     bi,bj        :: tile indices
+C     bi, bj       :: tile indices
 C     k            :: vertical level
-C     iMin,iMax    :: computation domain
-C     jMin,jMax    :: computation domain
+C     iMin, iMax   :: computation domain
+C     jMin, jMax   :: computation domain
 C     deltaTarg    :: time step
 C     rTrans       :: vertical volume transport
 C     recip_hFac   :: inverse of cell open-depth factor
@@ -51,29 +51,31 @@ C     myThid       :: thread number
       INTEGER myThid
 
 C     == Local Variables ==
-C     i,j          :: loop indices
+C     i, j         :: loop indices
 C     kp1          :: =min( k+1 , Nr )
 C     km1          :: =max( k-1 , 1 )
 C     km2          :: =max( k-2 , 1 )
 C     Cr           :: slope ratio
-C     Rjm,Rj,Rjp   :: differences at i-1,i,i+1
+C     Rjm, Rj, Rjp :: differences at k-1,k,k+1
 C     w_CFL        :: Courant-Friedrich-Levy number
 C     upwindFac    :: upwind factor
 C     rCenter      :: centered contribution
 C     rUpwind      :: upwind   contribution
-      INTEGER i,j,kp1,km1,km2
-      _RL Cr,Rjm,Rj,Rjp, w_CFL
+      INTEGER i, j, kp1, km1, km2
+      _RL Cr, Rjm, Rj, Rjp, w_CFL
       _RL upwindFac(1-OLx:sNx+OLx,1-OLy:sNy+OLy)
       _RL rCenter, rUpwind
       _RL deltaTcfl
+      _RL CrMax
+      PARAMETER( CrMax = 1.D+6 )
 
 C Statement function provides Limiter(Cr)
 #include "GAD_FLUX_LIMITER.h"
 CEOP
 
-      km2=MAX(1,k-2)
-      km1=MAX(1,k-1)
-      kp1=MIN(Nr,k+1)
+      km2 = MAX(1,k-2)
+      km1 = MAX(1,k-1)
+      kp1 = MIN(Nr,k+1)
 
 C--   process interior interface only:
       IF ( k.GT.1 .AND. k.LE.Nr ) THEN
@@ -84,22 +86,25 @@ C--   Compute the upwind fraction:
         DO i=iMin,iMax
          w_CFL = deltaTcfl*rTrans(i,j)*recip_rA(i,j,bi,bj)*recip_drC(k)
      &                    *recip_deepFac2F(k)*recip_rhoFacF(k)
-         Rjp=(tFld(i,j,kp1)-tFld(i,j,k)  )*maskC(i,j,kp1,bi,bj)
-         Rj =(tFld(i,j,k)  -tFld(i,j,km1))
-         Rjm=(tFld(i,j,km1)-tFld(i,j,km2))*maskC(i,j,km2,bi,bj)
+         Rjp = (tFld(i,j,kp1)-tFld(i,j,k)  )*maskC(i,j,kp1,bi,bj)
+         Rj  = (tFld(i,j,k)  -tFld(i,j,km1))
+         Rjm = (tFld(i,j,km1)-tFld(i,j,km2))*maskC(i,j,km2,bi,bj)
 
-         IF ( Rj.NE.0. _d 0) THEN
-          IF (rTrans(i,j).LT.0. _d 0) THEN
-            Cr=Rjm/Rj
-          ELSE
-            Cr=Rjp/Rj
-          ENDIF
-          upwindFac(i,j) = 1. _d 0
-     &                   - Limiter(Cr) * ( 1. _d 0 + ABS(w_CFL) )
-          upwindFac(i,j) = MAX( -1. _d 0, upwindFac(i,j) )
+         IF ( rTrans(i,j).LT.zeroRL ) THEN
+           Cr = Rjm
          ELSE
-          upwindFac(i,j) = 0. _d 0
+           Cr = Rjp
          ENDIF
+         IF ( ABS(Rj)*CrMax .LE. ABS(Cr) ) THEN
+           Cr = SIGN( CrMax, Cr )*SIGN( oneRL, Rj )
+         ELSE
+           Cr = Cr/Rj
+         ENDIF
+
+C        calculate upwind fraction using Limiter Function:
+         upwindFac(i,j) = 1. _d 0
+     &                  - Limiter(Cr) * ( 1. _d 0 + ABS(w_CFL) )
+         upwindFac(i,j) = MAX( -1. _d 0, upwindFac(i,j) )
         ENDDO
        ENDDO
 


### PR DESCRIPTION
Avoid machine over-flow in computing tracer distribution slope by
putting a cap (here: CrMax =1.e+6) before entering Limiter Fct.
This is similar to what has been done (for some time) in gad_dst3fl_adv_*.F routines.

Note: the precise value of the CrMax does not matter much for any of the
current (in GAD_FLUX_LIMITER.h) Limiter functions.

## What changes does this PR introduce?
supposed to fix issue #459 

## What is the current behaviour? 
Division by "Rj" can result in overflow since it could be very small but not zero.

## What is the new behaviour 
Avoid this division when Rj is too small (compared to neighboring gradient).

## Does this PR introduce a breaking change? 
no

## Other information:


## Suggested addition to `tag-index`
o pkg/generic_advdiff:
  - improve "slope" calculation in DST2 Flux-Limiter advection scheme to avoid
    potential over-flow arithmetic in division by small slope (issue #459),
    similar to what has been done in gad_dst3fl_*.F routines.
