### PR TITLE
initialise variables locally to help taf

### DIFF
--- a/doc/tag-index
+++ b/doc/tag-index
@@ -1,6 +1,9 @@
     Notes on tags used in MITgcmUV
     ==============================
 
+o pkg/mom_common:
+  - initialise again hdiv in mom_calc_hdiv.F (in case it got dropped by TAF in
+    calling S/R).
 o model/src:
   - fix a bug in convective_adjustment.F AD code by adjusting store directives
     for theta and salt ; update experiment isomip reference AD output.

--- a/pkg/mom_common/mom_calc_hdiv.F
+++ b/pkg/mom_common/mom_calc_hdiv.F
@@ -28,7 +28,7 @@ C     == Local variables ==
       INTEGER i,j
 
 #ifdef ALLOW_AUTODIFF
-C     Initialise (again) hDiv (in case it got drop out in calling S/R):
+C     Initialise (again) hDiv (in case it got dropped in calling S/R):
       DO j=1-OLy,sNy+OLy
        DO i=1-OLx,sNx+OLx
         hDiv(i,j)=0. _d 0

--- a/pkg/mom_common/mom_calc_hdiv.F
+++ b/pkg/mom_common/mom_calc_hdiv.F
@@ -27,6 +27,11 @@ C     myThid - Instance number for this innvocation of CALC_MOM_RHS
 C     == Local variables ==
       INTEGER i,j
 
+      DO j=1-OLy,sNy+OLy
+       DO i=1-OLx,sNx+OLx
+        hDiv(i,j)=0. _d 0
+       ENDDO
+      ENDDO
       IF (hDivScheme.EQ.1) THEN
        DO j=1-OLy,sNy+OLy-1
         DO i=1-OLx,sNx+OLx-1

--- a/pkg/mom_common/mom_calc_hdiv.F
+++ b/pkg/mom_common/mom_calc_hdiv.F
@@ -17,7 +17,7 @@ C     == Global variables ==
 #include "PARAMS.h"
 #include "GRID.h"
 C     == Routine arguments ==
-C     myThid - Instance number for this innvocation of CALC_MOM_RHS
+C     myThid  :: my Thread Id number
       INTEGER bi,bj,k,hDivScheme
       _RL uFld(1-OLx:sNx+OLx,1-OLy:sNy+OLy)
       _RL vFld(1-OLx:sNx+OLx,1-OLy:sNy+OLy)
@@ -27,11 +27,14 @@ C     myThid - Instance number for this innvocation of CALC_MOM_RHS
 C     == Local variables ==
       INTEGER i,j
 
+#ifdef ALLOW_AUTODIFF
+C     Initialise (again) hDiv (in case it got drop out in calling S/R):
       DO j=1-OLy,sNy+OLy
        DO i=1-OLx,sNx+OLx
         hDiv(i,j)=0. _d 0
        ENDDO
       ENDDO
+#endif
       IF (hDivScheme.EQ.1) THEN
        DO j=1-OLy,sNy+OLy-1
         DO i=1-OLx,sNx+OLx-1


### PR DESCRIPTION
## What changes does this PR introduce?
bug fix after a  taf update 5.1.1

## What is the current behaviour? 
taf dropped some initialisations in mom_vecvinmd before calling mom_calc_hdiv that lead to
```
Program received signal SIGFPE: Floating-point exception - erroneous arithmetic operation.
Backtrace for this error:
#0  0x2AAAABB58287
#1  0x2AAAABB5888E
#2  0x2AAAAC57865F
#3  0x117F19E in mom_vi_hdissip_ at ad_taf_output.f:204244
#4  0x11211C0 in mom_vecinvmd_ at ad_taf_output.f:200351
```
in verification_other/global_oce_llc on some platforms.

## What is the new behaviour 
verification experiment should work again with current taf versions.

## Does this PR introduce a breaking change? 
No, except that it may circumvent a bug in TAF

## Other information:

## Suggested addition to `tag-index`
o pkg/mom_common/mom_calc_hdiv.F: initialise hdiv again to help TAF