### PR TITLE
Minimum over lap size

### DIFF
--- a/doc/tag-index
+++ b/doc/tag-index
@@ -1,7 +1,10 @@
     Notes on tags used in MITgcmUV
     ==============================
 
-o pkg/ggl90: 
+o model/src:
+  - fix few loop range to allow to run with OLx,y=1 when momStepping=F ;
+  - add check and stop if momStepping=T and overlap-size is smaller than 2.
+o pkg/ggl90:
   - add 3 store directives for gg90tke in ggl90_calc.F and break some loops
     in two to help TAF without extra storage requirements.
 o pkg/seaice:

--- a/eesupp/src/exch1_rx_cube.template
+++ b/eesupp/src/exch1_rx_cube.template
@@ -12,29 +12,17 @@ C     !INTERFACE:
      I                 cornerMode, myThid )
 
 C     !DESCRIPTION:
-C     *==========================================================*
+C     *==============================================================*
 C     | SUBROUTINE EXCH1_RX_CUBE
 C     | o Forward-mode edge exchanges for RX array on CS config.
-C     *==========================================================*
+C     *==============================================================*
 C     | Controlling routine for exchange of XY edges of an array
-C     | distributed in X and Y. The routine interfaces to
-C     | communication routines that can use messages passing
-C     | exchanges, put type exchanges or get type exchanges.
-C     |  This allows anything from MPI to raw memory channel to
-C     | memmap segments to be used as a inter-process and/or
-C     | inter-thread communiation and synchronisation
-C     | mechanism.
-C     | Notes --
-C     | 1. Some low-level mechanisms such as raw memory-channel
-C     | or SGI/CRAY shmem put do not have direct Fortran bindings
-C     | and are invoked through C stub routines.
-C     | 2. Although this routine is fairly general but it does
-C     | require nSx and nSy are the same for all innvocations.
-C     | There are many common data structures ( myByLo,
-C     | westCommunicationMode, mpiIdW etc... ) tied in with
-C     | (nSx,nSy). To support arbitray nSx and nSy would require
-C     | general forms of these.
-C     *==========================================================*
+C     | distributed in X and Y.
+C     | This is a preliminary (exch1), simpler version with few
+C     | limitations (no MPI, 1 tile per face, regular 6 squared faces,
+C     | multi-threads only on shared arrays, i.e., in commom block)
+C     | that are fixed in generalised pkg/exch2 implementation.
+C     *==============================================================*
 
 C     !USES:
       IMPLICIT NONE

--- a/eesupp/src/exch1_uv_rx_cube.template
+++ b/eesupp/src/exch1_uv_rx_cube.template
@@ -12,32 +12,21 @@ C     !INTERFACE:
      I                 cornerMode, myThid )
 
 C     !DESCRIPTION:
-C     *==========================================================*
+C     *==============================================================*
 C     | SUBROUTINE EXCH1_UV_RX_CUBE
 C     | o Forward-mode edge exchanges for RX vector on CS config.
-C     *==========================================================*
+C     *==============================================================*
 C     | Controlling routine for exchange of XY edges of an array
-C     | distributed in X and Y. The routine interfaces to
-C     | communication routines that can use messages passing
-C     | exchanges, put type exchanges or get type exchanges.
-C     |  This allows anything from MPI to raw memory channel to
-C     | memmap segments to be used as a inter-process and/or
-C     | inter-thread communiation and synchronisation
-C     | mechanism.
-C     | Notes --
-C     | 1. Some low-level mechanisms such as raw memory-channel
-C     | or SGI/CRAY shmem put do not have direct Fortran bindings
-C     | and are invoked through C stub routines.
-C     | 2. Although this routine is fairly general but it does
-C     | require nSx and nSy are the same for all innvocations.
-C     | There are many common data structures ( myByLo,
-C     | westCommunicationMode, mpiIdW etc... ) tied in with
-C     | (nSx,nSy). To support arbitray nSx and nSy would require
-C     | general forms of these.
-C     | 3. Exchanges on the cube of vector quantities need to be
-C     | paired to allow rotations and sign reversal to be applied
-C     | consistently between vector components as they rotate.
-C     *==========================================================*
+C     | distributed in X and Y.
+C     | This is a preliminary (exch1), simpler version with few
+C     | limitations (no MPI, 1 tile per face, regular 6 squared faces,
+C     | multi-threads only on shared arrays, i.e., in commom block)
+C     | that are fixed in generalised pkg/exch2 implementation.
+C     | Notes:
+C     |  Exchanges on the cube of vector quantities need to be
+C     |  paired to allow rotations and sign reversal to be applied
+C     |  consistently between vector components as they rotate.
+C     *==============================================================*
 
 C     !USES:
       IMPLICIT NONE
@@ -185,6 +174,7 @@ C        Tile Odd:Odd-2 [get] [West<-North]
           ENDDO
          ENDDO
 
+C--    end "K" loop
         ENDDO
 
         bt = bl+1
@@ -240,14 +230,17 @@ C        Tile Even:Even-1 [get] [West<-East]
           ENDDO
          ENDDO
 
+C--    end "K" loop
         ENDDO
 
+C--    end "bl" loop
        ENDDO
 
+       IF ( OLx.GE.2 .AND. OLy.GE.2 ) THEN
 C-     Add one valid uVel,vVel value next to the corner, that allows
-C       to compute vorticity on a wider stencil (e.g., vort3(0,1) & (1,0))
-       DO bt = 1,6
-        DO K = 1,myNz
+C      to compute vorticity on a wider stencil (e.g., vort3(0,1) & (1,0))
+        DO bt = 1,6
+         DO K = 1,myNz
 C      SW corner:
           Uarray(0,0,K,bt,1)=Varray(1,0,K,bt,1)
           Varray(0,0,K,bt,1)=Uarray(0,1,K,bt,1)
@@ -260,8 +253,9 @@ C      SE corner:
 C      NE corner:
           Uarray(sNx+2,sNy+1,K,bt,1)=Varray(sNx,sNy+2,K,bt,1)
           Varray(sNx+1,sNy+2,K,bt,1)=Uarray(sNx+2,sNy,K,bt,1)
+         ENDDO
         ENDDO
-       ENDDO
+       ENDIF
 
 C      Fix degeneracy at corners
        IF (.FALSE.) THEN
@@ -300,6 +294,7 @@ C         Top right
         ENDDO
        ENDIF
 
+C--    end "repeat" loop
        ENDDO
 
       ENDIF

--- a/eesupp/src/exch1_z_rx_cube.template
+++ b/eesupp/src/exch1_z_rx_cube.template
@@ -13,33 +13,22 @@ C     !INTERFACE:
      I                 cornerMode, myThid )
 
 C     !DESCRIPTION:
-C     *==========================================================*
+C     *==============================================================*
 C     | SUBROUTINE EXCH1_Z_RX_CUBE
 C     | o Forward-mode edge exchanges for RX array on CS config:
 C     |   Fill overlap region through tile exchanges,
 C     |   according to CS topology,
 C     |   for a Zeta-located, scalar field RX arrays.
-C     *==========================================================*
+C     *==============================================================*
 C     | Controlling routine for exchange of XY edges of an array
-C     | distributed in X and Y. The routine interfaces to
-C     | communication routines that can use messages passing
-C     | exchanges, put type exchanges or get type exchanges.
-C     |  This allows anything from MPI to raw memory channel to
-C     | memmap segments to be used as a inter-process and/or
-C     | inter-thread communiation and synchronisation
-C     | mechanism.
-C     | Notes --
-C     | 1. Some low-level mechanisms such as raw memory-channel
-C     | or SGI/CRAY shmem put do not have direct Fortran bindings
-C     | and are invoked through C stub routines.
-C     | 2. Although this routine is fairly general but it does
-C     | require nSx and nSy are the same for all innvocations.
-C     | There are many common data structures ( myByLo,
-C     | westCommunicationMode, mpiIdW etc... ) tied in with
-C     | (nSx,nSy). To support arbitray nSx and nSy would require
-C     | general forms of these.
-C     | 3. zeta coord exchange operation for cube sphere grid
-C     *==========================================================*
+C     | distributed in X and Y.
+C     | This is a preliminary (exch1), simpler version with few
+C     | limitations (no MPI, 1 tile per face, regular 6 squared faces,
+C     | multi-threads only on shared arrays, i.e., in commom block)
+C     | that are fixed in generalised pkg/exch2 implementation.
+C     | Notes:
+C     |  zeta coord exchange operation for cube sphere grid
+C     *==============================================================*
 
 C     !USES:
       IMPLICIT NONE

--- a/model/src/config_check.F
+++ b/model/src/config_check.F
@@ -464,12 +464,12 @@ C---+----1----+----2----+----3----+----4----+----5----+----6----+----7-|--+----|
 C--   Check parameter consistency :
 
       IF ( ( OLx.LT.2 .OR. OLy.LT.2 ) .AND. momStepping ) THEN
-C-    Current algorithm (solve_for_pressure, RHS) prevent to use
-C     momAdvection or viscAh > 0 with OLx,y=1 ; should still allow to
-C     use OLx,y=1 when momAdvection=F and viscAh=0 but some loop range
+C-    Current algorithm (solve_for_pressure, RHS) prevents to use
+C     momAdvection or viscAh > 0 with OLx,y=1 ; it should still allow us
+C     to use OLx,y=1 when momAdvection=F and viscAh=0 but some loop range
 C     in few momentum S/R are not carefully set to support this.
         WRITE(msgBuf,'(A,A)') 'CONFIG_CHECK: Cannot use momStepping',
-     &   ' with overlap (OLx,OLy) smaller than 2'
+     &  ' with overlap (OLx,OLy) smaller than 2'
         CALL PRINT_ERROR( msgBuf, myThid )
         errCount = errCount + 1
       ENDIF

--- a/model/src/config_check.F
+++ b/model/src/config_check.F
@@ -469,7 +469,7 @@ C     momAdvection or viscAh > 0 with OLx,y=1 ; should still allow to
 C     use OLx,y=1 when momAdvection=F and viscAh=0 but some loop range
 C     in few momentum S/R are not carefully set to support this.
         WRITE(msgBuf,'(A,A)') 'CONFIG_CHECK: Cannot use momStepping',
-     &  ' with overlap (OLx,OLy) smaller than 2'
+     &   ' with overlap (OLx,OLy) smaller than 2'
         CALL PRINT_ERROR( msgBuf, myThid )
         errCount = errCount + 1
       ENDIF

--- a/model/src/config_check.F
+++ b/model/src/config_check.F
@@ -463,6 +463,16 @@ C---+----1----+----2----+----3----+----4----+----5----+----6----+----7-|--+----|
 
 C--   Check parameter consistency :
 
+      IF ( ( OLx.LT.2 .OR. OLy.LT.2 ) .AND. momStepping ) THEN
+C-    Current algorithm (solve_for_pressure, RHS) prevent to use
+C     momAdvection or viscAh > 0 with OLx,y=1 ; should still allow to
+C     use OLx,y=1 when momAdvection=F and viscAh=0 but some loop range
+C     in few momentum S/R are not carefully set to support this.
+        WRITE(msgBuf,'(A,A)') 'CONFIG_CHECK: Cannot use momStepping',
+     &  ' with overlap (OLx,OLy) smaller than 2'
+        CALL PRINT_ERROR( msgBuf, myThid )
+        errCount = errCount + 1
+      ENDIF
       IF ( ( OLx.LT.3 .OR. OLy.LT.3 ) .AND.
      &     ( viscC4leithD.NE.0.  .OR. viscC4leith.NE.0.
      &     .OR. viscC4smag.NE.0. .OR. viscA4Grid.NE.0.

--- a/model/src/ini_cg2d.F
+++ b/model/src/ini_cg2d.F
@@ -163,7 +163,7 @@ C-  when using a normalisation of RHS, tolerance has no unit => no conversion
       ELSE
 C-  convert Target-Residual (in W unit) to cg2d-solver residual unit [m^2/s^2]
         cg2dTolerance = cg2dNorm * cg2dTargetResWunit
-     &                           * globalArea / deltaTmom
+     &                           * globalArea / deltaTMom
       ENDIF
       _END_MASTER(myThid)
 
@@ -199,14 +199,14 @@ C           defaults to 0.51 but can be set at runtime.
       DO bj=myByLo(myThid),myByHi(myThid)
        DO bi=myBxLo(myThid),myBxHi(myThid)
 C-    calculate and store solver main diagonal :
-        DO j=0,sNy+1
-         DO i=0,sNx+1
-           ks = ksurfC(i,j,bi,bj)
+        DO j=0,sNy
+         DO i=0,sNx
+           ks = kSurfC(i,j,bi,bj)
            aC2d(i,j,bi,bj) = -(
      &       aW2d(i,j,bi,bj) + aW2d(i+1,j, bi,bj)
      &      +aS2d(i,j,bi,bj) + aS2d( i,j+1,bi,bj)
      &      +freeSurfFac*myNorm*recip_Bo(i,j,bi,bj)*deepFac2F(ks)
-     &                  *rA(i,j,bi,bj)/deltaTMom/deltaTfreesurf
+     &                  *rA(i,j,bi,bj)/deltaTMom/deltaTFreeSurf
      &                        )
          ENDDO
         ENDDO

--- a/model/src/ini_curvilinear_grid.F
+++ b/model/src/ini_curvilinear_grid.F
@@ -419,11 +419,11 @@ C     geographical north when they have not been read from a file
 C--   Exchange Angle (either loaded from file or computed)
       CALL EXCH_UV_AGRID_3D_RS(angleSinC,angleCosC,.TRUE., 1, myThid)
 
-c     CALL WRITE_FULLARRAY_RL('dxV',dxV,1,0,0,1,0,myThid)
-c     CALL WRITE_FULLARRAY_RL('dyU',dyU,1,0,0,1,0,myThid)
-c     CALL WRITE_FULLARRAY_RL('rAz',rAz,1,0,0,1,0,myThid)
-c     CALL WRITE_FULLARRAY_RL('xG' ,xG ,1,0,0,1,0,myThid)
-c     CALL WRITE_FULLARRAY_RL('yG' ,yG ,1,0,0,1,0,myThid)
+c     CALL WRITE_FULLARRAY_RS('dxV',dxV,1,0,0,1,0,myThid)
+c     CALL WRITE_FULLARRAY_RS('dyU',dyU,1,0,0,1,0,myThid)
+c     CALL WRITE_FULLARRAY_RS('rAz',rAz,1,0,0,1,0,myThid)
+c     CALL WRITE_FULLARRAY_RS('xG' ,xG ,1,0,0,1,0,myThid)
+c     CALL WRITE_FULLARRAY_RS('yG' ,yG ,1,0,0,1,0,myThid)
 
 C--   Now let us look at all these beasts
       IF ( plotLevel.GE.debLevC ) THEN

--- a/model/src/ini_nlfs_vars.F
+++ b/model/src/ini_nlfs_vars.F
@@ -32,8 +32,10 @@ C     Local variables
 C     i,j,k,bi,bj  :: loop counter
       INTEGER bi,bj
 #ifdef NONLIN_FRSURF
-      INTEGER i, j
-      INTEGER k, ks
+      INTEGER i, j, ks
+# ifdef ALLOW_AUTODIFF
+      INTEGER k
+# endif
       _RL hFacInfMOM, Rmin_tmp
 #else /* NONLIN_FRSURF */
 # ifdef EXACT_CONSERV

--- a/model/src/set_parms.F
+++ b/model/src/set_parms.F
@@ -35,7 +35,7 @@ c     EXTERNAL ILNBLNK
 
 C     !LOCAL VARIABLES:
       CHARACTER*(MAX_LEN_MBUF) msgBuf
-      INTEGER k
+      INTEGER errCount, k
       _RL tmpVar
 CEOP
 
@@ -49,6 +49,7 @@ C-    For off-line calculation, switch off Momentum and Active-tracers (=T,S):
 #endif /* ALLOW_OFFLINE */
 
       _BEGIN_MASTER(myThid)
+      errCount = 0
 
 C--   On/Off flags for each terms of the momentum equation
       nonHydrostatic   = momStepping .AND. nonHydrostatic
@@ -69,27 +70,26 @@ C--   On/Off flags for each terms of the momentum equation
       calc_wVelocity   = momStepping .OR. exactConserv
 
 #ifndef ALLOW_3D_VISCAH
-       IF ( viscAhDfile.NE.' ' .OR. viscAhZfile.NE.' ' ) THEN
+      IF ( viscAhDfile.NE.' ' .OR. viscAhZfile.NE.' ' ) THEN
         WRITE(msgBuf,'(2A)') 'SET_PARMS: ',
      &      'viscAhDfile and viscAhZfile cannot be used with'
         CALL PRINT_ERROR( msgBuf, myThid )
         WRITE(msgBuf,'(2A)') 'SET_PARMS: ',
      &      '"#undef ALLOW_3D_VISCAH" in MOM_COMMON_OPTIONS.h'
         CALL PRINT_ERROR( msgBuf, myThid )
-        STOP 'ABNORMAL END: S/R SET_PARMS'
-c       errCount = errCount + 1
-       ENDIF
+        errCount = errCount + 1
+      ENDIF
 #endif
 #ifndef ALLOW_3D_VISCA4
-       IF ( viscA4Dfile.NE.' ' .OR. viscA4Zfile.NE.' ' ) THEN
+      IF ( viscA4Dfile.NE.' ' .OR. viscA4Zfile.NE.' ' ) THEN
         WRITE(msgBuf,'(2A)') 'SET_PARMS: ',
      &      'viscA4Dfile and viscA4Zfile cannot be used with'
         CALL PRINT_ERROR( msgBuf, myThid )
         WRITE(msgBuf,'(2A)') 'SET_PARMS: ',
      &      '"#undef ALLOW_3D_VISCA4" in MOM_COMMON_OPTIONS.h'
         CALL PRINT_ERROR( msgBuf, myThid )
-        STOP 'ABNORMAL END: S/R SET_PARMS'
-       ENDIF
+        errCount = errCount + 1
+      ENDIF
 #endif
 
 #ifdef ALLOW_MOM_COMMON
@@ -241,7 +241,7 @@ C     set default according to EOS type (as it was until chkpt65t)
           WRITE(msgBuf,'(A,I9,A)') 'SET_PARMS: selectP_inEOS_Zc=',
      &                  selectP_inEOS_Zc, ' : invalid selection'
           CALL PRINT_ERROR( msgBuf, myThid )
-          STOP 'ABNORMAL END: S/R SET_PARMS'
+          errCount = errCount + 1
         ELSEIF ( .NOT.nonHydrostatic ) THEN
           selectP_inEOS_Zc = MIN( selectP_inEOS_Zc, 2 )
         ENDIF
@@ -250,7 +250,7 @@ C     set default according to EOS type (as it was until chkpt65t)
           WRITE(msgBuf,'(A,I9,2A)') 'SET_PARMS: selectP_inEOS_Zc=',
      &     selectP_inEOS_Zc, ' : invalid with eosType=', eosType
           CALL PRINT_ERROR( msgBuf, myThid )
-          STOP 'ABNORMAL END: S/R SET_PARMS'
+          errCount = errCount + 1
         ENDIF
       ELSE
         selectP_inEOS_Zc = -1
@@ -290,7 +290,24 @@ C     several places, test for last iteration with time==endTime :
       ENDIF
 #endif /* ALLOW_LONGSTEP */
 
-C--  After this point, main model parameters are not supposed to be modified.
+      IF ( OLx.LE.0 .OR. OLy.LE.0 ) THEN
+C--   Overlap-size will be checked later in CONFIG_CHECK. This minimal
+C     check here is just to set-up the model grid (INI_GRID) safely.
+        WRITE(msgBuf,'(2A)') 'SET_PARMS: ',
+     &      'model unusable with no overlap (OLx,OLy = 0)'
+        CALL PRINT_ERROR( msgBuf, myThid )
+        errCount = errCount + 1
+      ENDIF
+
+      IF ( errCount.GE.1 ) THEN
+        WRITE(msgBuf,'(A,I3,A)')
+     &       'SET_PARMS: detected', errCount,' fatal error(s)'
+        CALL PRINT_ERROR( msgBuf, myThid )
+        CALL ALL_PROC_DIE( 0 )
+        STOP 'ABNORMAL END: S/R SET_PARMS'
+      ENDIF
+
+C--   After this point, main model parameters are not supposed to be modified.
        WRITE(msgBuf,'(A,A)') 'SET_PARMS: done'
        CALL PRINT_MESSAGE( msgBuf, standardMessageUnit,
      &                      SQUEEZE_RIGHT , 1)

--- a/pkg/debug/write_fullarray_rl.F
+++ b/pkg/debug/write_fullarray_rl.F
@@ -16,8 +16,11 @@ C     | Only used for debugging purpose.
 C     |  can write local array (with no bi,bj) corresponding to
 C     |      tile biArg,bjArg
 C     |  or global array (with bi,bj) (called with biArg=bjArg=0)
-C     | Warning: does not explicitly do the byte-swapping
-C     |          (=> write little-endian binary file).
+C     | Warning:
+C     |   1) does not explicitly do the byte-swapping unless
+C     |      specified by compiler option.
+C     |   2) ignores writeBinaryPrec and just write output with
+C     |      same precision as input array (float32/float64)
 C     *==========================================================*
 C     \ev
 C     !USES:
@@ -35,7 +38,7 @@ C     == Routine arguments ==
       INTEGER iRec
       INTEGER myIter
       INTEGER myThid
-      _RL fld(1-Olx:sNx+Olx,1-Oly:sNy+Oly,kSize,nSx,nSy)
+      _RL fld(1-OLx:sNx+OLx,1-OLy:sNy+OLy,kSize,nSx,nSy)
 
 C     !FUNCTIONS:
 C     ==  Functions ==
@@ -84,18 +87,18 @@ C--   Write full global array:
 c        OPEN( dUnit, file=fullName, status='unknown',
 c    &         form='unformatted')
 c        WRITE(dUnit) ((( fld(i,j,k,bi,bj),
-c    &                        i=1-Olx,sNx+Olx),
-c    &                        j=1-Oly,sNy+Oly),
+c    &                        i=1-OLx,sNx+OLx),
+c    &                        j=1-OLy,sNy+OLy),
 c    &                        k=1,kSize)
          length_of_rec = MDS_RECLEN(
-     &                   filePrec, (sNx+2*Olx)*(sNy+2*Oly), myThid )
+     &                   filePrec, (sNx+2*OLx)*(sNy+2*OLy), myThid )
          OPEN( dUnit, file=fullName, status='unknown',
      &         access='direct', recl=length_of_rec )
          DO k = 1,kSize
            kRec = k + (iRec-1)*kSize
            WRITE(dUnit,rec=kRec) (( fld(i,j,k,bi,bj),
-     &                                i=1-Olx,sNx+Olx),
-     &                                j=1-Oly,sNy+Oly )
+     &                                i=1-OLx,sNx+OLx),
+     &                                j=1-OLy,sNy+OLy )
          ENDDO
          CLOSE(dUnit)
 
@@ -118,18 +121,18 @@ C--   Write local array:
 c        OPEN( dUnit, file=fullName, status='unknown',
 c    &         form='unformatted')
 c        WRITE(dUnit) ((( fld(i,j,k,1,1),
-c    &                       i=1-Olx,sNx+Olx),
-c    &                       j=1-Oly,sNy+Oly),
+c    &                       i=1-OLx,sNx+OLx),
+c    &                       j=1-OLy,sNy+OLy),
 c    &                       k=1,kSize)
          length_of_rec = MDS_RECLEN(
-     &                   filePrec, (sNx+2*Olx)*(sNy+2*Oly), myThid )
+     &                   filePrec, (sNx+2*OLx)*(sNy+2*OLy), myThid )
          OPEN( dUnit, file=fullName, status='unknown',
      &         access='direct', recl=length_of_rec )
          DO k = 1,kSize
            kRec = k + (iRec-1)*kSize
            WRITE(dUnit,rec=kRec) (( fld(i,j,k,1,1),
-     &                                i=1-Olx,sNx+Olx),
-     &                                j=1-Oly,sNy+Oly )
+     &                                i=1-OLx,sNx+OLx),
+     &                                j=1-OLy,sNy+OLy )
          ENDDO
          CLOSE(dUnit)
 

--- a/pkg/debug/write_fullarray_rs.F
+++ b/pkg/debug/write_fullarray_rs.F
@@ -16,8 +16,11 @@ C     | Only used for debugging purpose.
 C     |  can write local array (with no bi,bj) corresponding to
 C     |      tile biArg,bjArg
 C     |  or global array (with bi,bj) (called with biArg=bjArg=0)
-C     | Warning: does not explicitly do the byte-swapping
-C     |          (=> write little-endian binary file).
+C     | Warning:
+C     |   1) does not explicitly do the byte-swapping unless
+C     |      specified by compiler option.
+C     |   2) ignores writeBinaryPrec and just write output with
+C     |      same precision as input array (float32/float64)
 C     *==========================================================*
 C     \ev
 C     !USES:
@@ -35,7 +38,7 @@ C     == Routine arguments ==
       INTEGER iRec
       INTEGER myIter
       INTEGER myThid
-      _RS fld(1-Olx:sNx+Olx,1-Oly:sNy+Oly,kSize,nSx,nSy)
+      _RS fld(1-OLx:sNx+OLx,1-OLy:sNy+OLy,kSize,nSx,nSy)
 
 C     !FUNCTIONS:
 C     ==  Functions ==
@@ -84,18 +87,18 @@ C--   Write full global array:
 c        OPEN( dUnit, file=fullName, status='unknown',
 c    &         form='unformatted')
 c        WRITE(dUnit) ((( fld(i,j,k,bi,bj),
-c    &                        i=1-Olx,sNx+Olx),
-c    &                        j=1-Oly,sNy+Oly),
+c    &                        i=1-OLx,sNx+OLx),
+c    &                        j=1-OLy,sNy+OLy),
 c    &                        k=1,kSize)
          length_of_rec = MDS_RECLEN(
-     &                   filePrec, (sNx+2*Olx)*(sNy+2*Oly), myThid )
+     &                   filePrec, (sNx+2*OLx)*(sNy+2*OLy), myThid )
          OPEN( dUnit, file=fullName, status='unknown',
      &         access='direct', recl=length_of_rec )
          DO k = 1,kSize
            kRec = k + (iRec-1)*kSize
            WRITE(dUnit,rec=kRec) (( fld(i,j,k,bi,bj),
-     &                                i=1-Olx,sNx+Olx),
-     &                                j=1-Oly,sNy+Oly )
+     &                                i=1-OLx,sNx+OLx),
+     &                                j=1-OLy,sNy+OLy )
          ENDDO
          CLOSE(dUnit)
 
@@ -118,18 +121,18 @@ C--   Write local array:
 c        OPEN( dUnit, file=fullName, status='unknown',
 c    &         form='unformatted')
 c        WRITE(dUnit) ((( fld(i,j,k,1,1),
-c    &                       i=1-Olx,sNx+Olx),
-c    &                       j=1-Oly,sNy+Oly),
+c    &                       i=1-OLx,sNx+OLx),
+c    &                       j=1-OLy,sNy+OLy),
 c    &                       k=1,kSize)
          length_of_rec = MDS_RECLEN(
-     &                   filePrec, (sNx+2*Olx)*(sNy+2*Oly), myThid )
+     &                   filePrec, (sNx+2*OLx)*(sNy+2*OLy), myThid )
          OPEN( dUnit, file=fullName, status='unknown',
      &         access='direct', recl=length_of_rec )
          DO k = 1,kSize
            kRec = k + (iRec-1)*kSize
            WRITE(dUnit,rec=kRec) (( fld(i,j,k,1,1),
-     &                                i=1-Olx,sNx+Olx),
-     &                                j=1-Oly,sNy+Oly )
+     &                                i=1-OLx,sNx+OLx),
+     &                                j=1-OLy,sNy+OLy )
          ENDDO
          CLOSE(dUnit)
 

--- a/pkg/exch2/exch2_uv_3d_rx.template
+++ b/pkg/exch2/exch2_uv_3d_rx.template
@@ -87,7 +87,7 @@ C---  using CubedSphereExchange:
      &       exch2_isSedge(myTile) .EQ. 1 ) THEN
          DO k=1,myNz
 C         Uphi(sNx+1,    0,k,bi,bj)= vPhi(sNx+1,    1,k,bi,bj)
-          DO j=1-olx,0
+          DO j=1-OLx,0
            Uphi(sNx+1,    j,k,bi,bj)= vPhi(sNx+(1-j),    1,k,bi,bj)
           ENDDO
          ENDDO
@@ -97,7 +97,7 @@ C         Uphi(sNx+1,    0,k,bi,bj)= vPhi(sNx+1,    1,k,bi,bj)
      &        exch2_isNedge(myTile) .EQ. 1 ) THEN
           DO k=1,myNz
 C          Uphi(sNx+1,sNy+1,k,bi,bj)=-vPhi(sNx+1,sNy+1,k,bi,bj)
-           DO j=1,olx
+           DO j=1,OLx
             Uphi(sNx+1,sNy+j,k,bi,bj)=-vPhi(sNx+j,sNy+1,k,bi,bj)
            ENDDO
           ENDDO
@@ -107,7 +107,7 @@ C          Uphi(sNx+1,sNy+1,k,bi,bj)=-vPhi(sNx+1,sNy+1,k,bi,bj)
      &        exch2_isNedge(myTile) .EQ. 1 ) THEN
           DO k=1,myNz
 C          Uphi(sNx+1,sNy+1,k,bi,bj)= vPhi(sNx+1,sNy+1,k,bi,bj)
-           DO j=1,olx
+           DO j=1,OLx
             Uphi(sNx+1,sNy+j,k,bi,bj)= vPhi(sNx+j,sNy+1,k,bi,bj)
            ENDDO
           ENDDO
@@ -135,8 +135,10 @@ C        Zero SW corner points
            ENDDO
           ENDDO
 #endif
+          IF ( OLx.GE.2 .AND. OLy.GE.2 ) THEN
             uPhi(0,0,k,bi,bj)=vPhi(1,0,k,bi,bj)
             vPhi(0,0,k,bi,bj)=uPhi(0,1,k,bi,bj)
+          ENDIF
          ENDDO
         ENDIF
 
@@ -156,12 +158,14 @@ C        Zero NW corner points
            ENDDO
           ENDDO
 #endif
-          IF ( withSigns ) THEN
+          IF ( OLx.GE.2 .AND. OLy.GE.2 ) THEN
+           IF ( withSigns ) THEN
             uPhi(0,sNy+1,k,bi,bj)=-vPhi(1,sNy+2,k,bi,bj)
             vPhi(0,sNy+2,k,bi,bj)=-uPhi(0,sNy,k,bi,bj)
-          ELSE
+           ELSE
             uPhi(0,sNy+1,k,bi,bj)= vPhi(1,sNy+2,k,bi,bj)
             vPhi(0,sNy+2,k,bi,bj)= uPhi(0,sNy,k,bi,bj)
+           ENDIF
           ENDIF
          ENDDO
         ENDIF
@@ -182,12 +186,14 @@ C        Zero SE corner points
            ENDDO
           ENDDO
 #endif
-          IF ( withSigns ) THEN
+          IF ( OLx.GE.2 .AND. OLy.GE.2 ) THEN
+           IF ( withSigns ) THEN
             uPhi(sNx+2,0,k,bi,bj)=-vPhi(sNx,0,k,bi,bj)
             vPhi(sNx+1,0,k,bi,bj)=-uPhi(sNx+2,1,k,bi,bj)
-          ELSE
+           ELSE
             uPhi(sNx+2,0,k,bi,bj)= vPhi(sNx,0,k,bi,bj)
             vPhi(sNx+1,0,k,bi,bj)= uPhi(sNx+2,1,k,bi,bj)
+           ENDIF
           ENDIF
          ENDDO
         ENDIF
@@ -208,8 +214,10 @@ C        Zero NE corner points
            ENDDO
           ENDDO
 #endif
+          IF ( OLx.GE.2 .AND. OLy.GE.2 ) THEN
             uPhi(sNx+2,sNy+1,k,bi,bj)=vPhi(sNx,sNy+2,k,bi,bj)
             vPhi(sNx+1,sNy+2,k,bi,bj)=uPhi(sNx+2,sNy,k,bi,bj)
+          ENDIF
          ENDDO
         ENDIF
 

--- a/pkg/mom_common/mom_calc_visc.F
+++ b/pkg/mom_common/mom_calc_visc.F
@@ -141,13 +141,14 @@ C     !LOCAL VARIABLES:
 #ifdef ALLOW_LEITH_QG
       _RL viscAh_ZLthQG(1-OLx:sNx+OLx,1-OLy:sNy+OLy)
       _RL viscAh_DLthQG(1-OLx:sNx+OLx,1-OLy:sNy+OLy)
+      _RL sqargQG
 #endif
       _RL viscAh_ZSmg(1-OLx:sNx+OLx,1-OLy:sNy+OLy)
       _RL viscAh_DSmg(1-OLx:sNx+OLx,1-OLy:sNy+OLy)
       _RL viscA4_ZSmg(1-OLx:sNx+OLx,1-OLy:sNy+OLy)
       _RL viscA4_DSmg(1-OLx:sNx+OLx,1-OLy:sNy+OLy)
+      _RL sqargAh, sqargA4, sqargAhD, sqargA4D, sqargSmag
       LOGICAL calcLeith, calcSmag, calcLeithQG
-      _RL sqargAh, sqargA4, sqargAhD, sqargA4D, sqargQG, sqargSmag
 
 #ifdef ALLOW_AUTODIFF_TAMC
           act1 = bi - myBxLo(myThid)


### PR DESCRIPTION
## What changes does this PR introduce?
Clarify minimum overlap-size needed for main model.
 1) fix few loop range to allow to run with OLx,y=1 when momStepping=F ;
 2) add check and stop if momStepping=T and overlap-size is smaller than 2.

## What is the current behaviour? 
minimum overlap-size is checked for to satisfy tracer advection requirement (in gad_check.F)
and  biharmonic viscosity. However, there is no check related to other part of the main model,
specially whether one could use  overlap-size of just 1  

## What is the new behaviour 
- fix few loop range in main model src code (ini_cg2d.F, uv exch) to enable to run with overlap-size = 1,
  as long as momStepping=F.
- also add a check and stop for minimum overlap-size.

## Does this PR introduce a breaking change? 
no

## Other information:
The few minor changes here allow, e.g, to use (safely) OLx,y=1 for offline and tracer advection problems.

## Suggested addition to `tag-index`
o model/src: 
  - fix few loop range to allow to run with OLx,y=1 when momStepping=F ;
  - add check and stop if momStepping=T and overlap-size is smaller than 2.
