### PR TITLE
Remove 2 old things

### DIFF
--- a/doc/tag-index
+++ b/doc/tag-index
@@ -1,8 +1,12 @@
     Notes on tags used in MITgcmUV
     ==============================
 
+o eessup/inc & pkg/thsice:
+  - Remove 2 CPP options for deprecated code and remove corresponding code:
+    a) USE_OLD_MACROS_R4R8toRSRL (added in May 2009) and
+    b) OLD_THSICE_CALL_SEQUENCE  (added in Jan 2013).
 o pkg/shelfice:
-  - fix missing loacal keys declaration in shelfice_thermodynamics.F for TAF
+  - fix missing local keys declaration in shelfice_thermodynamics.F for TAF
     storge dir. with SHI_ALLOW_GAMMAFRICT defined ;
   - remove included PACKAGES_CONFIG.h in many verification exp. "tamc.h".
 o tools/build_options:

--- a/eesupp/inc/CPP_EEMACROS.h
+++ b/eesupp/inc/CPP_EEMACROS.h
@@ -125,20 +125,12 @@ C  enable to call the corresponding R4 or R8 S/R.
 #define _GLOBAL_SUM_RS(a,b) CALL GLOBAL_SUM_R8 ( a, b)
 #define _GLOBAL_MAX_RS(a,b) CALL GLOBAL_MAX_R8 ( a, b )
 #define _MPI_TYPE_RS MPI_DOUBLE_PRECISION
-#ifdef USE_OLD_MACROS_R4R8toRSRL
-#define _GLOBAL_SUM_R4(a,b) CALL GLOBAL_SUM_R8 ( a, b )
-#define _GLOBAL_MAX_R4(a,b) CALL GLOBAL_MAX_R8 ( a, b )
-#endif
 #else
 #define _RS Real*4
 #define RS_IS_REAL4
 #define _GLOBAL_SUM_RS(a,b) CALL GLOBAL_SUM_R4 ( a, b )
 #define _GLOBAL_MAX_RS(a,b) CALL GLOBAL_MAX_R4 ( a, b )
 #define _MPI_TYPE_RS MPI_REAL
-#ifdef USE_OLD_MACROS_R4R8toRSRL
-cph Needed for some backward compatibility with broken packages
-#define _GLOBAL_SUM_R4(a,b) CALL GLOBAL_SUM_R4 ( a, b )
-#define _GLOBAL_MAX_R4(a,b) CALL GLOBAL_MAX_R4 ( a, b )
 #endif
 #endif
 
@@ -146,11 +138,6 @@ cph Needed for some backward compatibility with broken packages
 #define RL_IS_REAL8
 #define _GLOBAL_SUM_RL(a,b) CALL GLOBAL_SUM_R8 ( a, b )
 #define _GLOBAL_MAX_RL(a,b) CALL GLOBAL_MAX_R8 ( a, b )
-#ifdef USE_OLD_MACROS_R4R8toRSRL
-cph Needed for some backward compatibility with broken packages
-#define _GLOBAL_SUM_R8(a,b) CALL GLOBAL_SUM_R8 ( a, b )
-#define _GLOBAL_MAX_R8(a,b) CALL GLOBAL_MAX_R8 ( a, b )
-#endif
 #define _MPI_TYPE_RL MPI_DOUBLE_PRECISION
 
 #define _MPI_TYPE_R4 MPI_REAL
@@ -169,13 +156,6 @@ C           will directly call the corrresponding S/R.
 #define _EXCH_XY_RL(a,b) CALL EXCH_XY_RL ( a, b )
 #define _EXCH_XYZ_RS(a,b) CALL EXCH_XYZ_RS ( a, b )
 #define _EXCH_XYZ_RL(a,b) CALL EXCH_XYZ_RL ( a, b )
-#ifdef USE_OLD_MACROS_R4R8toRSRL
-cph Needed for some backward compatibility with broken packages
-#define _EXCH_XY_R4(a,b) CALL EXCH_XY_RS ( a, b )
-#define _EXCH_XY_R8(a,b) CALL EXCH_XY_RL ( a, b )
-#define _EXCH_XYZ_R4(a,b) CALL EXCH_XYZ_RS ( a, b )
-#define _EXCH_XYZ_R8(a,b) CALL EXCH_XYZ_RL ( a, b )
-#endif
 
 C--   Control use of JAM routines for Artic network (no longer supported)
 C     These invoke optimized versions of "exchange" and "sum" that

--- a/eesupp/inc/CPP_EEOPTIONS.h
+++ b/eesupp/inc/CPP_EEOPTIONS.h
@@ -62,9 +62,6 @@ C--   Control use of "double" precision constants.
 C     Use D0 where it means REAL*8 but not where it means REAL*16
 #define D0 d0
 
-C--   Enable some old macro conventions for backward compatibility
-#undef USE_OLD_MACROS_R4R8toRSRL
-
 C=== IO related options ===
 C--   Flag used to indicate whether Fortran formatted write
 C     and read are threadsafe. On SGI the routines can be thread

--- a/model/inc/CPP_OPTIONS.h
+++ b/model/inc/CPP_OPTIONS.h
@@ -160,10 +160,6 @@ C   Default is to use "new" grid files (OLD_GRID_IO undef) but OLD_GRID_IO
 C   is still useful with, e.g., single-domain curvilinear configurations.
 #undef OLD_GRID_IO
 
-C o Use thsice+seaice (old) call sequence: ice-Dyn,ice-Advect,ice-Thermo(thsice)
-C              as opposed to new sequence: ice-Thermo(thsice),ice-Dyn,ice-Advect
-#undef OLD_THSICE_CALL_SEQUENCE
-
 C o Use old EXTERNAL_FORCING_U,V,T,S subroutines (for backward compatibility)
 #undef USE_OLD_EXTERNAL_FORCING
 

--- a/model/src/do_oceanic_phys.F
+++ b/model/src/do_oceanic_phys.F
@@ -316,7 +316,6 @@ CADJ STORE salt  = comlev1, key=ikey_dynamics, kind=isbyte
       ENDIF
 #endif /* ALLOW_FRAZIL */
 
-#ifndef OLD_THSICE_CALL_SEQUENCE
 #if (defined ALLOW_THSICE) && !(defined ALLOW_ATM2D)
       IF ( useThSIce .AND. fluidIsWater ) THEN
 # ifdef ALLOW_AUTODIFF_TAMC
@@ -347,7 +346,6 @@ C       and modify forcing terms including effects from ice
         CALL TIMER_STOP( 'THSICE_MAIN     [DO_OCEANIC_PHYS]', myThid)
       ENDIF
 #endif /* ALLOW_THSICE */
-#endif /* ndef OLD_THSICE_CALL_SEQUENCE */
 
 #ifdef ALLOW_SEAICE
 # ifdef ALLOW_AUTODIFF_TAMC
@@ -448,30 +446,6 @@ CADJ STORE qsw               = comlev1, key=ikey_dynamics, kind=isbyte
 CADJ STORE area              = comlev1, key=ikey_dynamics, kind=isbyte
 # endif
 #endif
-
-#ifdef OLD_THSICE_CALL_SEQUENCE
-#if (defined ALLOW_THSICE) && !(defined ALLOW_ATM2D)
-      IF ( useThSIce .AND. fluidIsWater ) THEN
-# ifdef ALLOW_AUTODIFF_TAMC
-cph(
-#  ifdef NONLIN_FRSURF
-CADJ STORE uice,vice         = comlev1, key=ikey_dynamics, kind=isbyte
-CADJ STORE salt,theta        = comlev1, key=ikey_dynamics, kind=isbyte
-CADJ STORE qnet,qsw, empmr   = comlev1, key=ikey_dynamics, kind=isbyte
-CADJ STORE hFac_surfC        = comlev1, key=ikey_dynamics, kind=isbyte
-#  endif
-# endif
-# ifdef ALLOW_DEBUG
-        IF (debugMode) CALL DEBUG_CALL('THSICE_MAIN',myThid)
-# endif
-C--     Step forward Therm.Sea-Ice variables
-C       and modify forcing terms including effects from ice
-        CALL TIMER_START('THSICE_MAIN     [DO_OCEANIC_PHYS]', myThid)
-        CALL THSICE_MAIN( myTime, myIter, myThid )
-        CALL TIMER_STOP( 'THSICE_MAIN     [DO_OCEANIC_PHYS]', myThid)
-      ENDIF
-#endif /* ALLOW_THSICE */
-#endif /* OLD_THSICE_CALL_SEQUENCE */
 
 #ifdef ALLOW_SHELFICE
       IF ( useShelfIce .AND. fluidIsWater ) THEN

--- a/pkg/thsice/thsice_advdiff.F
+++ b/pkg/thsice/thsice_advdiff.F
@@ -155,7 +155,6 @@ C     but what matter here is just to have the right order of magnitude.
       ENDIF
 #endif /* ALLOW_GENERIC_ADVDIFF */
 
-#ifndef OLD_THSICE_CALL_SEQUENCE
 #ifdef ALLOW_DIAGNOSTICS
       IF ( useDiagnostics ) THEN
         CALL DIAGNOSTICS_FILL(iceMask,'SI_AdvFr',0,1,1,bi,bj,myThid)
@@ -186,7 +185,6 @@ C-     Ice-Volume weighted quantities:
         ENDIF
       ENDIF
 #endif /* ALLOW_DIAGNOSTICS */
-#endif /* ndef OLD_THSICE_CALL_SEQUENCE */
 
 C--   Initialisation (+ build oceanic mask)
       DO j=1-OLy,sNy+OLy
@@ -543,39 +541,6 @@ C---  if not multiDimAdvection
 
 C---  end if multiDimAdvection
       ENDIF
-
-#ifdef OLD_THSICE_CALL_SEQUENCE
-#ifdef ALLOW_DIAGNOSTICS
-      IF ( useDiagnostics ) THEN
-        CALL DIAGNOSTICS_FILL(iceMask,'SI_AdvFr',0,1,1,bi,bj,myThid)
-C-     Ice-fraction weighted quantities:
-        tmpFac = 1. _d 0
-        CALL DIAGNOSTICS_FRACT_FILL(
-     I                   iceHeight, iceMask,tmpFac,1,'SI_AdvHi',
-     I                   0,1,1,bi,bj,myThid)
-        CALL DIAGNOSTICS_FRACT_FILL(
-     I                   snowHeight,iceMask,tmpFac,1,'SI_AdvHs',
-     I                   0,1,1,bi,bj,myThid)
-C-     Ice-Volume weighted quantities:
-        IF ( DIAGNOSTICS_IS_ON('SI_AdvQ1',myThid) .OR.
-     &       DIAGNOSTICS_IS_ON('SI_AdvQ2',myThid) ) THEN
-         DO j=1,sNy
-          DO i=1,sNx
-           iceVol(i,j) = iceMask(i,j,bi,bj)*iceHeight(i,j,bi,bj)
-          ENDDO
-         ENDDO
-         CALL DIAGNOSTICS_FRACT_FILL(
-     I                   Qice1(1-OLx,1-OLy,bi,bj),
-     I                   iceVol,tmpFac,1,'SI_AdvQ1',
-     I                   0,1,2,bi,bj,myThid)
-         CALL DIAGNOSTICS_FRACT_FILL(
-     I                   Qice2(1-OLx,1-OLy,bi,bj),
-     I                   iceVol,tmpFac,1,'SI_AdvQ2',
-     I                   0,1,2,bi,bj,myThid)
-        ENDIF
-      ENDIF
-#endif /* ALLOW_DIAGNOSTICS */
-#endif /* OLD_THSICE_CALL_SEQUENCE */
 
 #endif /* ALLOW_THSICE */
 

--- a/pkg/thsice/thsice_check.F
+++ b/pkg/thsice/thsice_check.F
@@ -103,17 +103,6 @@ C-    need some form of ATM-surface pkg to provide Air-Ice surf fluxes
 # endif
 #endif /* ALLOW_AUTODIFF */
 
-#ifdef OLD_THSICE_CALL_SEQUENCE
-        WRITE(msgBuf,'(2A)') '** WARNING ** THSICE_CHECK: ',
-     &   'OLD_THSICE_CALL_SEQUENCE code no longer maintained'
-        CALL PRINT_MESSAGE( msgBuf, errorMessageUnit,
-     &                      SQUEEZE_RIGHT, myThid )
-        WRITE(msgBuf,'(2A)') '** WARNING ** THSICE_CHECK: ',
-     &   'option and related code will be removed after chkpt-64e'
-        CALL PRINT_MESSAGE( msgBuf, errorMessageUnit,
-     &                      SQUEEZE_RIGHT, myThid )
-#endif /* OLD_THSICE_CALL_SEQUENCE */
-
       IF ( useAIM .AND. .NOT.( stepFwd_oceMxL .OR. useCoupler )
      &            .AND.  tauRelax_MxL.NE. -1. _d 0 ) THEN
 C-    with pkg/aim, usual way to use pkg/thsice is to step-forward Mixed-Layer

--- a/pkg/thsice/thsice_diagnostics_init.F
+++ b/pkg/thsice/thsice_diagnostics_init.F
@@ -121,16 +121,6 @@ c     IF ( useDiagnotics ) THEN
         CALL DIAGNOSTICS_ADDTOLIST( diagNum,
      I            diagName, diagCode, diagUnits, diagTitle, 0, myThid )
 
-#ifdef OLD_THSICE_CALL_SEQUENCE
-        diagName  = 'SI_FrcFx'
-        diagTitle = 'Sea-Ice fraction [0-1], synchro. with fluxes'
-        diagUnits = '0-1             '
-        diagCode  = 'SM P    M1      '
-        CALL DIAGNOSTICS_ADDTOLIST( diagNum,
-     I            diagName, diagCode, diagUnits, diagTitle, 0, myThid )
-        numFrcFx  = diagNum
-#endif /* OLD_THSICE_CALL_SEQUENCE */
-
         diagName  = 'SIalbedo'
         diagTitle = 'Sea-Ice Albedo [0-1] (area weighted average)'
         diagUnits = '0-1             '
@@ -233,13 +223,8 @@ C-     Advective flux:
         ENDIF
       ENDDO
 
-#ifdef OLD_THSICE_CALL_SEQUENCE
-C--   Intermediate State, just after advection:
-        locName   = ' after advection'
-#else /* OLD_THSICE_CALL_SEQUENCE */
 C--   Intermediate State, just before advection:
         locName   = 'before advection'
-#endif /* OLD_THSICE_CALL_SEQUENCE */
         diagName  = 'SI_AdvFr'
         diagTitle = 'Sea-Ice fraction  [0-1] ('//locName//')'
         diagUnits = '0-1             '

--- a/pkg/thsice/thsice_do_advect.F
+++ b/pkg/thsice/thsice_do_advect.F
@@ -48,10 +48,8 @@ C     === Local variables ===
 C     bi, bj    :: Tile indices
 C     uIce/vIce :: ice velocity on C-grid [m/s]
       INTEGER bi, bj
-#ifndef OLD_THSICE_CALL_SEQUENCE
       INTEGER i, j
       INTEGER iMin, iMax, jMin, jMax
-#endif
 #ifdef ALLOW_AUTODIFF_TAMC
       INTEGER act1, act2, act3, act4
       INTEGER max1, max2, max3
@@ -61,7 +59,6 @@ C     uIce/vIce :: ice velocity on C-grid [m/s]
       _RL  vIce(1-OLx:sNx+OLx,1-OLy:sNy+OLy)
 
       IF ( thSIceAdvScheme.GT.0 .AND. biArg.EQ.0 .AND. bjArg.EQ.0 ) THEN
-#ifndef OLD_THSICE_CALL_SEQUENCE
 c      iMin = 1
 c      iMax = sNx
 c      jMin = 1
@@ -134,21 +131,9 @@ C--     cumulate time-averaged fields and also fill-up flux diagnostics
      &   _EXCH_XY_RL( iceMask, myThid )
        IF ( useRealFreshWaterFlux )
      &  _EXCH_XY_RS( sIceLoad, myThid )
-#endif /* ndef OLD_THSICE_CALL_SEQUENCE */
 
 C---+----1----+----2----+----3----+----4----+----5----+----6----+----7-|--+----|
 
-#ifdef OLD_THSICE_CALL_SEQUENCE
-      ELSEIF ( thSIceAdvScheme.GT.0 ) THEN
-         bi = biArg
-         bj = bjArg
-         CALL THSICE_GET_VELOCITY(
-     O                        uIce, vIce,
-     I                        bi,bj, myTime, myIter, myThid )
-         CALL THSICE_ADVDIFF(
-     U                        uIce, vIce,
-     I                        bi,bj, myTime, myIter, myThid )
-#endif /* OLD_THSICE_CALL_SEQUENCE */
       ENDIF
 
       RETURN

--- a/pkg/thsice/thsice_main.F
+++ b/pkg/thsice/thsice_main.F
@@ -170,14 +170,6 @@ C-   end if not useCheapAML
         ENDIF
 #endif
 
-#ifdef OLD_THSICE_CALL_SEQUENCE
-C-      do sea-ice advection before getting surface fluxes
-C Note: will inline this S/R once thSIce in Atmos. set-up is settled
-        IF ( thSIceAdvScheme.GT.0 )
-     &   CALL THSICE_DO_ADVECT(
-     I                   bi,bj, myTime, myIter, myThid )
-#endif /* OLD_THSICE_CALL_SEQUENCE */
-
 #ifndef ALLOW_AUTODIFF
         IF ( useBulkforce .OR. useCheapAML ) THEN
          CALL THSICE_GET_PRECIP(
@@ -284,10 +276,6 @@ C--   Exchange fields that are advected by seaice dynamics
      &               .OR. stressReduction.GT.zeroRL ) THEN
         CALL THSICE_DO_EXCH( myThid )
       ENDIF
-#ifdef OLD_THSICE_CALL_SEQUENCE
-      IF ( useRealFreshWaterFlux )
-     &  _EXCH_XY_RS( sIceLoad, myThid )
-#else /* OLD_THSICE_CALL_SEQUENCE */
       IF ( thSIceAdvScheme.GT.0 .AND. .NOT.useSEAICE ) THEN
 C-    when useSEAICE=.true., this S/R is called from SEAICE_MODEL;
 C     otherwise, call it from here, after thsice-thermodynamics is done
@@ -296,7 +284,6 @@ C     otherwise, call it from here, after thsice-thermodynamics is done
       ELSEIF ( thSIceAdvScheme.LE.0 .AND. useRealFreshWaterFlux ) THEN
         _EXCH_XY_RS( sIceLoad, myThid )
       ENDIF
-#endif /* OLD_THSICE_CALL_SEQUENCE */
 
       DO bj=myByLo(myThid),myByHi(myThid)
        DO bi=myBxLo(myThid),myBxHi(myThid)
@@ -315,11 +302,7 @@ C     otherwise, call it from here, after thsice-thermodynamics is done
 
 C--   Cumulate time-averaged fields and also fill-up flux diagnostics
 C     (if not done in THSICE_DO_ADVECT call)
-#ifdef OLD_THSICE_CALL_SEQUENCE
-        IF ( .TRUE. ) THEN
-#else /* OLD_THSICE_CALL_SEQUENCE */
         IF ( thSIceAdvScheme.LE.0 ) THEN
-#endif /* OLD_THSICE_CALL_SEQUENCE */
          CALL THSICE_AVE(
      I                     bi,bj, myTime, myIter, myThid )
         ENDIF

--- a/pkg/thsice/thsice_slab_ocean.F
+++ b/pkg/thsice/thsice_slab_ocean.F
@@ -154,11 +154,7 @@ c-- End of IF ( stepFwd_oceMxL ) THEN
 
 C--   Cumulate time-averaged fields and also fill-up flux diagnostics
 C     (if not done in THSICE_DO_ADVECT call)
-#ifdef OLD_THSICE_CALL_SEQUENCE
-      IF ( .TRUE. ) THEN
-#else /* OLD_THSICE_CALL_SEQUENCE */
       IF ( thSIceAdvScheme.LE.0 ) THEN
-#endif /* OLD_THSICE_CALL_SEQUENCE */
          CALL THSICE_AVE(
      I                    bi, bj, myTime, myIter, myThid )
       ENDIF

--- a/pkg/thsice/thsice_step_fwd.F
+++ b/pkg/thsice/thsice_step_fwd.F
@@ -184,9 +184,6 @@ C--
 
 #ifdef ALLOW_DIAGNOSTICS
       IF ( useDiagnostics ) THEN
-# ifdef OLD_THSICE_CALL_SEQUENCE
-        CALL DIAGNOSTICS_FILL(iceMask,'SI_FrcFx',0,1,1,bi,bj,myThid)
-# endif
         CALL DIAGNOSTICS_FRACT_FILL( snowPrc,
      I                       iceMask(1-OLx,1-OLy,bi,bj), oneRL, 1,
      I                              'SIsnwPrc', 0,1,2,bi,bj,myThid )
@@ -402,9 +399,6 @@ C--    Net fluxes : (only non-zero contribution where frzmltMxL > 0 )
 CADJ STORE snowHeight(:,:,bi,bj) =
 CADJ &     comlev1_bibj,key=ticekey,byte=isbyte
 # endif
-#ifdef OLD_THSICE_CALL_SEQUENCE
-      IF ( .TRUE. ) THEN
-#else /* OLD_THSICE_CALL_SEQUENCE */
       IF ( thSIceAdvScheme.LE.0 ) THEN
 C- note: 1) regarding sIceLoad in ocean-dynamics, in case thSIceAdvScheme > 0,
 C          compute sIceLoad in THSICE_DO_ADVECT after seaice advection is done.
@@ -412,7 +406,6 @@ C        2) regarding sIceLoad in seaice-dynamics, probably better not to update
 C          sIceLoad here, to keep the balance between sIceLoad and adjusted Eta.
 C        3) not sure in the case of no advection (thSIceAdvScheme=0) but using
 C          seaice dynamics (unlikely senario anyway).
-#endif /* OLD_THSICE_CALL_SEQUENCE */
 C--   Compute Sea-Ice Loading (= mass of sea-ice + snow / area unit)
        DO j = jMin, jMax
         DO i = iMin, iMax
@@ -425,21 +418,6 @@ C--   Compute Sea-Ice Loading (= mass of sea-ice + snow / area unit)
         ENDDO
        ENDDO
       ENDIF
-
-#ifdef OLD_THSICE_CALL_SEQUENCE
-      IF ( thSIceAdvScheme.GT.0 ) THEN
-C--   note: those fluxes should to be added directly to Qnet, EmPmR & saltFlux
-       DO j = jMin, jMax
-        DO i = iMin, iMax
-         IF ( hOceMxL(i,j,bi,bj).GT.0. _d 0 ) THEN
-          Qnet(i,j,bi,bj) = Qnet(i,j,bi,bj) - oceQnet(i,j,bi,bj)
-          EmPmR(i,j,bi,bj)= EmPmR(i,j,bi,bj)- oceFWfx(i,j,bi,bj)
-          saltFlux(i,j,bi,bj)=saltFlux(i,j,bi,bj) - oceSflx(i,j,bi,bj)
-         ENDIF
-        ENDDO
-       ENDDO
-      ENDIF
-#endif /* OLD_THSICE_CALL_SEQUENCE */
 
 #ifdef ALLOW_BULK_FORCE
       IF ( useBulkForce ) THEN

--- a/verification/global_oce_biogeo_bling/code/CPP_OPTIONS.h
+++ b/verification/global_oce_biogeo_bling/code/CPP_OPTIONS.h
@@ -150,22 +150,10 @@ C   The definition of the flag is commented to avoid interference with
 C   such other header files.
 C#define COSINEMETH_III
 
-C o Use "OLD" UV discretisation near boundaries (*not* recommended)
-C   Note - only works with pkg/mom_fluxform and "no_slip_sides=.FALSE."
-C          because the old code did not have no-slip BCs
-#undef OLD_ADV_BCS
-
 C o Use LONG.bin, LATG.bin, etc., initialization for ini_curviliear_grid.F
 C   Default is to use "new" grid files (OLD_GRID_IO undef) but OLD_GRID_IO
 C   is still useful with, e.g., single-domain curvilinear configurations.
 #undef OLD_GRID_IO
-
-C o Use thsice+seaice (old) call sequence: ice-Dyn,ice-Advect,ice-Thermo(thsice)
-C              as opposed to new sequence: ice-Thermo(thsice),ice-Dyn,ice-Advect
-#undef OLD_THSICE_CALL_SEQUENCE
-
-C o Use old EXTERNAL_FORCING_U,V,T,S subroutines (for backward compatibility)
-#undef USE_OLD_EXTERNAL_FORCING
 
 C-- Other option files:
 

--- a/verification/tutorial_deep_convection/code/CPP_OPTIONS.h
+++ b/verification/tutorial_deep_convection/code/CPP_OPTIONS.h
@@ -143,22 +143,10 @@ C   The definition of the flag is commented to avoid interference with
 C   such other header files.
 C#define COSINEMETH_III
 
-C o Use "OLD" UV discretisation near boundaries (*not* recommended)
-C   Note - only works with pkg/mom_fluxform and "no_slip_sides=.FALSE."
-C          because the old code did not have no-slip BCs
-#undef OLD_ADV_BCS
-
 C o Use LONG.bin, LATG.bin, etc., initialization for ini_curviliear_grid.F
 C   Default is to use "new" grid files (OLD_GRID_IO undef) but OLD_GRID_IO
 C   is still useful with, e.g., single-domain curvilinear configurations.
 #undef OLD_GRID_IO
-
-C o Use thsice+seaice (old) call sequence: ice-Dyn,ice-Advect,ice-Thermo(thsice)
-C              as opposed to new sequence: ice-Thermo(thsice),ice-Dyn,ice-Advect
-#undef OLD_THSICE_CALL_SEQUENCE
-
-C o Use old EXTERNAL_FORCING_U,V,T,S subroutines (for backward compatibility)
-#undef USE_OLD_EXTERNAL_FORCING
 
 C-- Other option files:
 


### PR DESCRIPTION
## What changes does this PR introduce?
Remove 2 CPP options  for deprecated code and remove corresponding code:
   -> remove completely: USE_OLD_MACROS_R4R8toRSRL
      (was added on May 25, 2009, i.e. > 12.yrs ago)
      only in 2 files: CPP_EEOPTIONS.h  &  CPP_EEMACROS.h
   -> remove completely: OLD_THSICE_CALL_SEQUENCE
      (was added on Jan 21, 2013, i.e. > 8.yrs ago)

## What is the current behaviour? 
un-used code for a long time, confusing and requiring work to be maintained

## What is the new behaviour 
simple, clearer code

## Does this PR introduce a breaking change? 
old, un-used code gone.

## Other information:

## Suggested addition to `tag-index`
o eessup/inc & pkg/thsice:
  - Remove 2 CPP options for deprecated code and remove corresponding code:
    a) USE_OLD_MACROS_R4R8toRSRL (added in May 2009) and
    b) OLD_THSICE_CALL_SEQUENCE  (added in Jan 2013)
