### PR TITLE
Fix incorrect array subscript order

### DIFF
--- a/doc/tag-index
+++ b/doc/tag-index
@@ -1,6 +1,9 @@
     Notes on tags used in MITgcmUV
     ==============================
 
+o pkg/ecco:
+  - fix incorrect order of array indices for "objf_gencost" and "num_gencost"
+    in 2 gencost v4 S/R (bpv4 & sstv4).
 o eessup/inc & pkg/thsice:
   - Remove 2 CPP options for deprecated code and remove corresponding code:
     a) USE_OLD_MACROS_R4R8toRSRL (added in May 2009) and

--- a/pkg/ecco/cost_gencost_bpv4.F
+++ b/pkg/ecco/cost_gencost_bpv4.F
@@ -311,9 +311,9 @@ c-- map to global cost variables
      &             (locbpmask(i,j,bi,bj).NE. 0. _d 0).AND.
      &             (maskc(i,j,1,bi,bj).NE. 0. _d 0) ) then
                  junk = bpdifanom(i,j,bi,bj)
-                 objf_gencost(kgen,bi,bj) = objf_gencost(kgen,bi,bj)
+                 objf_gencost(bi,bj,kgen) = objf_gencost(bi,bj,kgen)
      &               + junk*junk*locwbp(i,j,bi,bj)
-                 num_gencost(kgen,bi,bj) = num_gencost(kgen,bi,bj)
+                 num_gencost(bi,bj,kgen) = num_gencost(bi,bj,kgen)
      &               + 1. _d 0
               endif
             enddo

--- a/pkg/ecco/cost_gencost_sstv4.F
+++ b/pkg/ecco/cost_gencost_sstv4.F
@@ -321,12 +321,12 @@ c ------------------------------------
              junk = anom_sst(i,j,bi,bj)
              junkweight = gencost_weight(i,j,bi,bj,kgen_lsc)*
      &          maskc(i,j,1,bi,bj)
-             objf_gencost(kgen_lsc,bi,bj) =
-     &          objf_gencost(kgen_lsc,bi,bj)
+             objf_gencost(bi,bj,kgen_lsc) =
+     &          objf_gencost(bi,bj,kgen_lsc)
      &            +junk*junk*junkweight/ndaysaveRL
              if ( (junkweight.GT.0.).AND.(nb_sst(i,j,bi,bj).GT.0.) )
-     &          num_gencost(kgen_lsc,bi,bj) =
-     &          num_gencost(kgen_lsc,bi,bj) + 1. _d 0 /ndaysaveRL
+     &          num_gencost(bi,bj,kgen_lsc) =
+     &          num_gencost(bi,bj,kgen_lsc) + 1. _d 0 /ndaysaveRL
             enddo
            enddo
           enddo
@@ -432,11 +432,11 @@ c compute cost:
              junk = anom_sst(i,j,bi,bj)
              junkweight = gencost_weight(i,j,bi,bj,kgen)*
      &          maskc(i,j,1,bi,bj)*msk_sst(i,j,bi,bj)
-             objf_gencost(kgen,bi,bj) =
-     &          objf_gencost(kgen,bi,bj)+junk*junk*junkweight
+             objf_gencost(bi,bj,kgen) =
+     &          objf_gencost(bi,bj,kgen)+junk*junk*junkweight
              if (junkweight.GT.0.)
-     &          num_gencost(kgen,bi,bj) =
-     &          num_gencost(kgen,bi,bj) + 1. _d 0
+     &          num_gencost(bi,bj,kgen) =
+     &          num_gencost(bi,bj,kgen) + 1. _d 0
             enddo
            enddo
           enddo


### PR DESCRIPTION
## What changes does this PR introduce?
(Bug fix, feature, docs update, ...)
A bug fix

## What is the current behaviour? 
(You can also link to an open issue here)
A couple of subroutines have incorrect order of array subscripts for the two variables: objf_gencost and num_gencost. The generic cost term is declared as the last (third) dimension in ecco.h for the two variables, but is incorrectly used as the first dimension. It is a benign bug when nSx and nSy both are set to 1.

## What is the new behaviour 
(if this is a feature change)?


## Does this PR introduce a breaking change? 
(What changes might users need to make in their application due to this PR?)
Users might get different (and correct) results if they are using the two subroutines with either nSx or nSy set to values larger than 1. 

## Other information:


## Suggested addition to `tag-index`
(To avoid unnecessary merge conflicts, please don't update `tag-index`. One of the admins will do that when merging your pull request.)