### PR TITLE
Switch to current sphinxcontrib-bibtex

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -41,6 +41,8 @@ extensions = ['sphinx.ext.autodoc',
 
 autodoc_mock_imports = ['matplotlib', 'mpl_toolkits']
 
+bibtex_bibfiles = ['manual_references.bib']
+
 # Add any paths that contain templates here, relative to this directory.
 templates_path = ['_templates']
 

--- a/doc/contributing/contributing.rst
+++ b/doc/contributing/contributing.rst
@@ -1446,9 +1446,9 @@ we recommend following the `Anaconda installation procedure
 <https://www.anaconda.com/products/individual#Downloads>`_, then following the recipe above.
 You do not need to learn python to build the manual; just note you should
 type ``conda activate mitgcm_build_the_docs`` in a shell when starting up
-a manual editing session, and ``conda deactivate`` when you finish (note you
+a manual editing session, and ``conda deactivate`` when you finish (also note you
 only need to perform the ``conda create ...`` step above when you **initially** follow
-the recipe above). This will maintain a clean, separate python `virtual environment
+the recipe). This will maintain a clean, separate python `virtual environment
 <https://docs.conda.io/projects/conda/en/latest/user-guide/tasks/manage-environments.html>`_
 for manual compilation and won't interfere with your python setup should you
 decide to learn python in the future.

--- a/doc/contributing/contributing.rst
+++ b/doc/contributing/contributing.rst
@@ -1430,8 +1430,8 @@ installation with the following packages installed:
 These packages can be installed from the Python Package Index using pip. If you
 have an existing python installation using `Anaconda
 <https://www.anaconda.com/>`_ or one of its variants (e.g., `miniconda
-<https://docs.conda.io>`_), we recommend that you can create (and use) a clean
-environment with the required packages like this:
+<https://docs.conda.io/en/latest/miniconda.html>`_), we recommend that you can
+create (and use) a clean environment with the required packages like this:
 
 ::
 
@@ -1441,14 +1441,15 @@ environment with the required packages like this:
    [...] # do the work
    conda deactivate
 
-If you don't yet have a python installation on your computer,
-we recommend following the `Anaconda installation procedure 
-<https://www.anaconda.com/products/individual#Downloads>`_, then following the recipe above.
-You do not need to learn python to build the manual; just note you should
-type ``conda activate mitgcm_build_the_docs`` in a shell when starting up
-a manual editing session, and ``conda deactivate`` when you finish (also note you
-only need to perform the ``conda create ...`` step above when you **initially** follow
-the recipe). This will maintain a clean, separate python `virtual environment
+If you don't yet have a python installation on your computer, we recommend
+following the `Anaconda installation procedure
+<https://www.anaconda.com/products/individual#Downloads>`_, then following the
+recipe above.  You do not need to learn python to build the manual; just note
+you should type ``conda activate mitgcm_build_the_docs`` in a shell when
+starting up a manual editing session, and ``conda deactivate`` when you finish
+(also note you only need to perform the ``conda create ...`` step above when
+you **initially** follow the recipe). This will maintain a clean, separate
+python `virtual environment
 <https://docs.conda.io/projects/conda/en/latest/user-guide/tasks/manage-environments.html>`_
 for manual compilation and won't interfere with your python setup should you
 decide to learn python in the future.

--- a/doc/contributing/contributing.rst
+++ b/doc/contributing/contributing.rst
@@ -1449,8 +1449,11 @@ that permanently installs these packages, we recommend the following:
     to run the installer from a terminal window. Make sure to say "yes" when it asks to initialize Miniforge3 --  that way
     you can use it right away. This is a minimal anaconda with conda-forge already set as default.
  #. Install MITgcm doc requirements:
-    cd MITgcm
-    conda install --file doc/requirements.txt
+
+::
+
+   cd MITgcm
+   conda install --file doc/requirements.txt
 
 
 Regardless of which installation method you choose, once these modules

--- a/doc/contributing/contributing.rst
+++ b/doc/contributing/contributing.rst
@@ -1426,23 +1426,22 @@ To do this you will need a working python installation with the following packag
  - sphinx_rtd_theme
  - numpy
 
-There are many tools available to create a python environment with these packages on your local machine (e.g., using ``pip install``)
-and if you are comfortable doing so on your own, go ahead. Note that as of this writing (December 2020), sphinxcontrib-bibtex versions
-2.0.0 and higher are not supported (we suggest using version 1.0.0).
-
-However, if you are new to python, or less experienced, we suggest the following steps:
-
-#. Get miniforge from https://github.com/conda-forge/miniforge/#download (for linux, win, or mac). Follow the instructions
-   to run the installer from a terminal window. Make sure to say "yes" when it asks to initialize Miniforge3 --  that way
-   you can use it right away. This is a minimal anaconda with conda-forge already set as default.
-#. Install MITgcm doc requirements:
+These packages can be installed from the Python Package Index using pip.  If
+you are using `Anaconda <https://www.anaconda.com/>`_ or one of its variants
+and would like to use conda to install them, you will need the conda-forge
+channel.  You can create (and use) a clean environment with the required
+packages like this:
 
 ::
 
    cd MITgcm
-   conda install --file doc/requirements.txt
+   conda create --name mitgcm_build_the_docs --channel conda-forge --file doc/requirements.txt
+   conda activate mitgcm_build_the_docs
+   [...] # do the work
+   conda deactivate
 
-Once these modules are installed you can build the html version of the manual by running ``make html`` in the ``doc`` directory.
+Once these modules are installed you can build the html version of the manual
+by running ``make html`` in the ``doc`` directory.
 
 To build the pdf version of the manual you will also need a working version of LaTeX that includes
 `several packages <http://www.sphinx-doc.org/en/master/usage/builders/index.html#sphinx.builders.latex.LaTeXBuilder>`_ that are

--- a/doc/contributing/contributing.rst
+++ b/doc/contributing/contributing.rst
@@ -1428,10 +1428,8 @@ installation with the following packages installed:
  - numpy
 
 These packages can be installed from the Python Package Index using pip. If you
-are familiar with python `virtual environments
-<https://docs.conda.io/projects/conda/en/latest/user-guide/tasks/manage-environments.html>`_
-and have an existing python installation using `Anaconda
-<https://www.anaconda.com/>`_ or one of its variants (e.g. `miniconda
+have an existing python installation using `Anaconda
+<https://www.anaconda.com/>`_ or one of its variants (e.g., `miniconda
 <https://docs.conda.io>`_), we recommend that you can create (and use) a clean
 environment with the required packages like this:
 
@@ -1443,27 +1441,20 @@ environment with the required packages like this:
    [...] # do the work
    conda deactivate
 
+If you don't yet have a python installation on your computer,
+we recommend following the `Anaconda installation procedure 
+<https://www.anaconda.com/products/individual#Downloads>`_, then following the recipe above.
+You do not need to learn python to build the manual; just note you should
+type ``conda activate mitgcm_build_the_docs`` in a shell when starting up
+a manual editing session, and ``conda deactivate`` when you finish (note you
+only need to perform the ``conda create ...`` step above when you **initially** follow
+the recipe above). This will maintain a clean, separate python `virtual environment
+<https://docs.conda.io/projects/conda/en/latest/user-guide/tasks/manage-environments.html>`_
+for manual compilation and won't interfere with your python setup should you
+decide to learn python in the future.
 
-Alternatively, if you are not a python user and want a simple python
-installation that permanently installs these packages, we recommend the
-following:
-
-#. Get miniforge from https://github.com/conda-forge/miniforge/#download (for
-   linux, win, or mac). Follow the instructions to run the installer from a
-   terminal window. Make sure to say "yes" when it asks to initialize
-   Miniforge3 -- that way you can use it right away. This is a minimal anaconda
-   with conda-forge already set as default.
-#. Install MITgcm doc requirements:
-
-   ::
-
-     cd MITgcm
-     conda install --file doc/requirements.txt
-
-
-Regardless of which installation method you choose, once these modules are
-installed you can build the html version of the manual by running ``make html``
-in the ``doc`` directory.
+Once these modules are installed you can build the html version of the manual
+by running ``make html`` in the ``doc`` directory.
 
 To build the pdf version of the manual you will also need a working version of
 LaTeX that includes `several packages

--- a/doc/contributing/contributing.rst
+++ b/doc/contributing/contributing.rst
@@ -1427,10 +1427,11 @@ To do this you will need a working python installation with the following packag
  - numpy
 
 These packages can be installed from the Python Package Index using pip.  If
-you are using `Anaconda <https://www.anaconda.com/>`_ or one of its variants
-and would like to use conda to install them, you will need the conda-forge
-channel.  You can create (and use) a clean environment with the required
-packages like this:
+you are familiar with python virtual environments and have an existing python
+installation using `Anaconda <https://www.anaconda.com/>`_ or one of its
+variants, we recommend you use conda to install these packages as available
+on the conda-forge channel.  You can create (and use) a clean environment with
+the required packages like this:
 
 ::
 
@@ -1440,7 +1441,20 @@ packages like this:
    [...] # do the work
    conda deactivate
 
-Once these modules are installed you can build the html version of the manual
+
+Alternatively, if you are not a python user and want a simple python installation
+that permanently installs these packages, we recommend the following:
+
+ #. Get miniforge from https://github.com/conda-forge/miniforge/#download (for linux, win, or mac). Follow the instructions
+    to run the installer from a terminal window. Make sure to say "yes" when it asks to initialize Miniforge3 --  that way
+    you can use it right away. This is a minimal anaconda with conda-forge already set as default.
+ #. Install MITgcm doc requirements:
+    cd MITgcm
+    conda install --file doc/requirements.txt
+
+
+Regardless of which installation method you choose, once these modules
+are installed you can build the html version of the manual
 by running ``make html`` in the ``doc`` directory.
 
 To build the pdf version of the manual you will also need a working version of LaTeX that includes

--- a/doc/contributing/contributing.rst
+++ b/doc/contributing/contributing.rst
@@ -1445,15 +1445,15 @@ the required packages like this:
 Alternatively, if you are not a python user and want a simple python installation
 that permanently installs these packages, we recommend the following:
 
- #. Get miniforge from https://github.com/conda-forge/miniforge/#download (for linux, win, or mac). Follow the instructions
-    to run the installer from a terminal window. Make sure to say "yes" when it asks to initialize Miniforge3 --  that way
-    you can use it right away. This is a minimal anaconda with conda-forge already set as default.
- #. Install MITgcm doc requirements:
+#. Get miniforge from https://github.com/conda-forge/miniforge/#download (for linux, win, or mac). Follow the instructions
+   to run the installer from a terminal window. Make sure to say "yes" when it asks to initialize Miniforge3 --  that way
+   you can use it right away. This is a minimal anaconda with conda-forge already set as default.
+#. Install MITgcm doc requirements:
 
-::
+   ::
 
-   cd MITgcm
-   conda install --file doc/requirements.txt
+     cd MITgcm
+     conda install --file doc/requirements.txt
 
 
 Regardless of which installation method you choose, once these modules

--- a/doc/contributing/contributing.rst
+++ b/doc/contributing/contributing.rst
@@ -1417,8 +1417,9 @@ cause difficulty).
 Building the manual
 -------------------
 
-Once you've made your changes to the manual, you should build it locally to verify that it works as expected.
-To do this you will need a working python installation with the following packages installed:
+Once you've made your changes to the manual, you should build it locally to
+verify that it works as expected.  To do this you will need a working python
+installation with the following packages installed:
 
  - sphinx
  - sphinxcontrib-bibtex
@@ -1426,12 +1427,13 @@ To do this you will need a working python installation with the following packag
  - sphinx_rtd_theme
  - numpy
 
-These packages can be installed from the Python Package Index using pip.  If
-you are familiar with python virtual environments and have an existing python
-installation using `Anaconda <https://www.anaconda.com/>`_ or one of its
-variants, we recommend you use conda to install these packages as available
-on the conda-forge channel.  You can create (and use) a clean environment with
-the required packages like this:
+These packages can be installed from the Python Package Index using pip. If you
+are familiar with python `virtual environments
+<https://docs.conda.io/projects/conda/en/latest/user-guide/tasks/manage-environments.html>`_
+and have an existing python installation using `Anaconda
+<https://www.anaconda.com/>`_ or one of its variants (e.g. `miniconda
+<https://docs.conda.io>`_), we recommend that you can create (and use) a clean
+environment with the required packages like this:
 
 ::
 
@@ -1442,12 +1444,15 @@ the required packages like this:
    conda deactivate
 
 
-Alternatively, if you are not a python user and want a simple python installation
-that permanently installs these packages, we recommend the following:
+Alternatively, if you are not a python user and want a simple python
+installation that permanently installs these packages, we recommend the
+following:
 
-#. Get miniforge from https://github.com/conda-forge/miniforge/#download (for linux, win, or mac). Follow the instructions
-   to run the installer from a terminal window. Make sure to say "yes" when it asks to initialize Miniforge3 --  that way
-   you can use it right away. This is a minimal anaconda with conda-forge already set as default.
+#. Get miniforge from https://github.com/conda-forge/miniforge/#download (for
+   linux, win, or mac). Follow the instructions to run the installer from a
+   terminal window. Make sure to say "yes" when it asks to initialize
+   Miniforge3 -- that way you can use it right away. This is a minimal anaconda
+   with conda-forge already set as default.
 #. Install MITgcm doc requirements:
 
    ::
@@ -1456,13 +1461,16 @@ that permanently installs these packages, we recommend the following:
      conda install --file doc/requirements.txt
 
 
-Regardless of which installation method you choose, once these modules
-are installed you can build the html version of the manual
-by running ``make html`` in the ``doc`` directory.
+Regardless of which installation method you choose, once these modules are
+installed you can build the html version of the manual by running ``make html``
+in the ``doc`` directory.
 
-To build the pdf version of the manual you will also need a working version of LaTeX that includes
-`several packages <http://www.sphinx-doc.org/en/master/usage/builders/index.html#sphinx.builders.latex.LaTeXBuilder>`_ that are
-not always found in minimal LaTeX installations. The command to build the pdf version is ``make latexpdf``, which should also be run in the ``doc`` directory.
+To build the pdf version of the manual you will also need a working version of
+LaTeX that includes `several packages
+<http://www.sphinx-doc.org/en/master/usage/builders/index.html#sphinx.builders.latex.LaTeXBuilder>`_
+that are not always found in minimal LaTeX installations. The command to build
+the pdf version is ``make latexpdf``, which should also be run in the ``doc``
+directory.
 
 .. _sec_pullreq:
 

--- a/doc/phys_pkgs/fizhi.rst
+++ b/doc/phys_pkgs/fizhi.rst
@@ -336,12 +336,13 @@ Longwave Radiation
 ##################
 
 The longwave radiation package used in the fizhi package is thoroughly
-described by . As described in that document, IR fluxes are computed due
-to absorption by water vapor, carbon dioxide, and ozone. The spectral
-bands together with their absorbers and parameterization methods,
-configured for the fizhi package, are shown in :numref:`tab_phys_pkg_fizhi_longwave`.
+described by :cite:`chsz:94`. As described in that document, IR fluxes are
+computed due to absorption by water vapor, carbon dioxide, and ozone. The
+spectral bands together with their absorbers and parameterization methods,
+configured for the fizhi package, are shown in
+:numref:`tab_phys_pkg_fizhi_longwave`.
 
-.. table:: IR Spectral Bands, Absorbers, and Parameterization Method (from :cite:`chsz:94`)
+.. table:: IR Spectral Bands, Absorbers, and Parameterization Method
   :name: tab_phys_pkg_fizhi_longwave
 
   +----------------+------------------------------------+------------------------------+----------+

--- a/doc/phys_pkgs/remesh.rst
+++ b/doc/phys_pkgs/remesh.rst
@@ -76,7 +76,8 @@ Description
 ===========
 
 When :filelink:`pkg/shelfice` is enabled, the elevation of the free surface in a grid cell is
-determined by the mass of the ice shelf in that cell. In general use of :filelink:`shelfice <pkg/shelfice>`
+determined by the mass of the ice shelf in that cell, see Jordan et al. (2018)
+:cite:`jordan:18`.  In general use of :filelink:`shelfice <pkg/shelfice>`
 this mass is held constant, but if it is allowed to change the free surface adjusts if :varlink:`implicitFreeSurface` ``= .true.``
 through adjustment of the thickness of the top-level cell (:numref:`figremesh1`). If :varlink:`nonlinFreeSurf`\ ``=4``
 these changes are fully accounted for in the ocean dynamics and tracer transport. However:
@@ -109,7 +110,6 @@ can be set in ``data.shelfice`` to allow volume conservation.
    and the distance between the two, :math:`\eta`, and (b) the extent of the ice-shelf boundary layer used to calculate velocities,
    Bv (red), and tracers, B :math:`_\chi` (blue), used in the melt rate calculation.
    The model grid is represented by dashed lines with the actual sizeof the cells represented by the solid lines.
-   From Jordan et al. (2018) :cite:`jordan:18`.
 
 .. figure:: figs/remesh2.*
    :width: 80%
@@ -119,7 +119,7 @@ can be set in ``data.shelfice`` to allow volume conservation.
 
    Schematic representation of dimensionless vertical grid size, :math:`h_c`, and reference ice-shelf depth, `d`,
    at i=2 in (a) a "normal" case, (b) a cell with :math:`h_c` > :math:`h_{max}` at i=2, k=2 just before a model
-   remesh check, and (c) the same cell just after a model remesh has occurred. From Jordan et al. (2018) :cite:`jordan:18`.
+   remesh check, and (c) the same cell just after a model remesh has occurred.
 
 .. _ssub_phys_remesh_topdr:
 

--- a/doc/references.rst
+++ b/doc/references.rst
@@ -7,5 +7,5 @@
 
    .. rubric:: References
 
-.. bibliography:: manual_references.bib
+.. bibliography::
    :all:

--- a/doc/requirements.txt
+++ b/doc/requirements.txt
@@ -1,5 +1,5 @@
 sphinx
 sphinx_rtd_theme
-sphinxcontrib-bibtex<2
+sphinxcontrib-bibtex>=2
 sphinxcontrib-programoutput
 numpy

--- a/doc/tag-index
+++ b/doc/tag-index
@@ -1,6 +1,9 @@
     Notes on tags used in MITgcmUV
     ==============================
 
+o doc:
+  - require sphinxcontrib-bibtex 2.0.0 or higher
+
 checkpoint68a (2021/07/16)
 o pkg/seaice:
   - clean up and simplify TAF store directives in do_oceanic_phys.F


### PR DESCRIPTION
## What changes does this PR introduce?

Change version requirement for sphinxcontrib-bibtex from '<2' to '>=2'.

## What is the current behaviour? 

`conda install --file=doc/requirements.txt` fails in some situations.

## What is the new behaviour 

conda install works.

## Does this PR introduce a breaking change? 

The docs will no longer build with sphinxcontrib-bibtex < 2.0.0 as the configuration options have changed.

## Other information:

- sphinxcontrb-bibtex version 2.1.0 or higher is required to avoid running the html build twice.
- current sphinxcontrib-bibtex (version 2.3.0) does not support citations in figure or table captions, so the 3 currently in the manual were removed.

## Suggested addition to `tag-index`

o doc:
  - require sphinxcontrib-bibtex 2.0.0 or higher