### PR TITLE
Fix previous modif in CPP_EEMACROS.h (from PR #487) 

### DIFF
--- a/eesupp/inc/CPP_EEMACROS.h
+++ b/eesupp/inc/CPP_EEMACROS.h
@@ -132,7 +132,6 @@ C  enable to call the corresponding R4 or R8 S/R.
 #define _GLOBAL_MAX_RS(a,b) CALL GLOBAL_MAX_R4 ( a, b )
 #define _MPI_TYPE_RS MPI_REAL
 #endif
-#endif
 
 #define _RL Real*8
 #define RL_IS_REAL8


### PR DESCRIPTION
## What changes does this PR introduce?
Fix cleaning of file "eesupp/inc/CPP_EEMACROS.h" : forgot to remove one closing "#endif"

## What is the current behaviour? 
many errors messages (1 for each src file) like:
> CPP_EEMACROS.h: 195: error: #endif without #if

## What is the new behaviour 
fixed and clean.

## Does this PR introduce a breaking change? 
no

## Other information:
These errors did not seem to stop compilation or break any regression test neither.

## Suggested addition to `tag-index`
skip it if merged shortly after PR #487 was merged in.