### PR TITLE
fix store directives for seaice_model and add more output to testreport

### DIFF
--- a/doc/tag-index
+++ b/doc/tag-index
@@ -2,6 +2,10 @@
     ==============================
 
 o pkg/seaice:
+  - clean up and simplify TAF store directives in do_oceanic_phys.F
+    for seaice_model to avoid unnecessary recomputations ;
+  - in testreport, count and report number of times s/r seaice_model is called.
+o pkg/seaice:
   - fix (untested) multi-threading and recomputations in seaice_solve4temp.F
 o files that include "tamc.h":
   - add missing declaration of local keys for TAF store-dir in pkg/obcs

--- a/model/src/do_oceanic_phys.F
+++ b/model/src/do_oceanic_phys.F
@@ -349,43 +349,23 @@ C       and modify forcing terms including effects from ice
 
 #ifdef ALLOW_SEAICE
 # ifdef ALLOW_AUTODIFF_TAMC
-CADJ STORE area     = comlev1, key=ikey_dynamics, kind=isbyte
-c CADJ STORE fu,fv    = comlev1, key=ikey_dynamics, kind=isbyte
-CADJ STORE qnet     = comlev1, key=ikey_dynamics, kind=isbyte
-CADJ STORE qsw      = comlev1, key=ikey_dynamics, kind=isbyte
-CADJ STORE theta    = comlev1, key=ikey_dynamics, kind=isbyte
-CADJ STORE salt     = comlev1, key=ikey_dynamics, kind=isbyte
+CADJ STORE qnet  = comlev1, key=ikey_dynamics, kind=isbyte
+CADJ STORE qsw   = comlev1, key=ikey_dynamics, kind=isbyte
+CADJ STORE theta = comlev1, key=ikey_dynamics, kind=isbyte
+CADJ STORE salt  = comlev1, key=ikey_dynamics, kind=isbyte
+CADJ STORE fu,fv = comlev1, key=ikey_dynamics, kind=isbyte
 #if (defined ALLOW_EXF) && (defined ALLOW_ATM_TEMP)
-CADJ STORE evap     = comlev1, key=ikey_dynamics, kind=isbyte
+CADJ STORE evap  = comlev1, key=ikey_dynamics, kind=isbyte
 #endif
 # endif /* ALLOW_AUTODIFF_TAMC */
       IF ( useSEAICE ) THEN
 # ifdef ALLOW_AUTODIFF_TAMC
-cph-adj-test(
-CADJ STORE hsnow    = comlev1, key=ikey_dynamics, kind=isbyte
-CADJ STORE heff     = comlev1, key=ikey_dynamics, kind=isbyte
-CADJ STORE tices    = comlev1, key=ikey_dynamics, kind=isbyte
-CADJ STORE empmr    = comlev1, key=ikey_dynamics, kind=isbyte
-CADJ STORE saltflux = comlev1, key=ikey_dynamics, kind=isbyte
-CADJ STORE fu,fv    = comlev1, key=ikey_dynamics, kind=isbyte
-cph-adj-test)
-#ifdef ALLOW_EXF
+CADJ STORE uvel,vvel         = comlev1, key=ikey_dynamics, kind=isbyte
+CADJ STORE uice,vice         = comlev1, key=ikey_dynamics, kind=isbyte
+#  ifdef ALLOW_EXF
 CADJ STORE atemp,aqh,precip  = comlev1, key=ikey_dynamics, kind=isbyte
 CADJ STORE swdown,lwdown     = comlev1, key=ikey_dynamics, kind=isbyte
 CADJ STORE uwind,vwind       = comlev1, key=ikey_dynamics, kind=isbyte
-#endif
-CADJ STORE uvel,vvel         = comlev1, key=ikey_dynamics, kind=isbyte
-#  ifdef SEAICE_CGRID
-CADJ STORE stressdivergencex = comlev1, key=ikey_dynamics, kind=isbyte
-CADJ STORE stressdivergencey = comlev1, key=ikey_dynamics, kind=isbyte
-#  endif
-#  ifdef SEAICE_ALLOW_DYNAMICS
-CADJ STORE uice,vice         = comlev1, key=ikey_dynamics, kind=isbyte
-#   ifdef SEAICE_ALLOW_EVP
-CADJ STORE seaice_sigma1     = comlev1, key=ikey_dynamics, kind=isbyte
-CADJ STORE seaice_sigma2     = comlev1, key=ikey_dynamics, kind=isbyte
-CADJ STORE seaice_sigma12    = comlev1, key=ikey_dynamics, kind=isbyte
-#   endif
 #  endif
 #  ifdef SEAICE_VARIABLE_SALINITY
 CADJ STORE hsalt             = comlev1, key=ikey_dynamics, kind=isbyte
@@ -412,18 +392,23 @@ CADJ STORE Qice1, Qice2      = comlev1, key=ikey_dynamics, kind=isbyte
         CALL TIMER_START('SEAICE_MODEL    [DO_OCEANIC_PHYS]', myThid)
         CALL SEAICE_MODEL( myTime, myIter, myThid )
         CALL TIMER_STOP ('SEAICE_MODEL    [DO_OCEANIC_PHYS]', myThid)
+# ifdef ALLOW_AUTODIFF_TAMC
+CADJ STORE tices = comlev1, key=ikey_dynamics, kind=isbyte
+CADJ STORE heff  = comlev1, key=ikey_dynamics, kind=isbyte
+CADJ STORE hsnow = comlev1, key=ikey_dynamics, kind=isbyte
+CADJ STORE area  = comlev1, key=ikey_dynamics, kind=isbyte
+CADJ STORE uIce  = comlev1, key=ikey_dynamics, kind=isbyte
+CADJ STORE vIce  = comlev1, key=ikey_dynamics, kind=isbyte
+# endif
 # ifdef ALLOW_COST
         CALL SEAICE_COST_SENSI ( myTime, myIter, myThid )
 # endif
 # ifdef ALLOW_AUTODIFF
       ELSEIF ( SEAICEadjMODE .EQ. -1 ) THEN
-CADJ STORE fu,fv    = comlev1, key=ikey_dynamics, kind=isbyte
+CADJ STORE area = comlev1, key=ikey_dynamics, kind=isbyte
         CALL SEAICE_FAKE( myTime, myIter, myThid )
 # endif /* ALLOW_AUTODIFF */
       ENDIF
-c # ifdef ALLOW_AUTODIFF_TAMC
-c CADJ STORE area   = comlev1, key=ikey_dynamics, kind=isbyte
-c # endif /* ALLOW_AUTODIFF_TAMC */
 #endif /* ALLOW_SEAICE */
 
 #if (defined ALLOW_OCN_COMPON_INTERF) && (defined ALLOW_THSICE)

--- a/verification/testreport
+++ b/verification/testreport
@@ -599,7 +599,7 @@ makemodel()
 	else
 	    echo "WARNING: neither ad_output_ad.f nor ad_output_ad.for found" \
 				>> $CDIR"/summary.txt"
-	    adfile=missing ; nlfd=0 ; ndop=0
+	    adfile=missing ; nlfd=0 ; ndop=0 ; nsm=0
 	fi
 	if test $adfile != missing ; then
 	    # count number of times load_fields_driver and do_oceanic_phys are called
@@ -611,9 +611,10 @@ makemodel()
 		nlfd=$((nlfd-1))
 	    fi
 	    ndop=`grep "call do_oceanic_phys("    ${adfile} | wc -l`
+	    nsm=`grep "call seaice_model(" ${adfile} | wc -l`
 	fi
-	echo " load_fields_driver, do_oceanic_phys are called " \
-	     "( $nlfd , $ndop ) time(s)" >> $CDIR"/summary.txt"
+	echo " load_fields_driver, do_oceanic_phys, seaice_model are called " \
+	     "( $nlfd , $ndop , $nsm ) time(s)" >> $CDIR"/summary.txt"
     fi
     if test $mk_fail != 0 ; then return $mk_fail ; fi
     )
@@ -1013,7 +1014,7 @@ formatresults()
 	if test $tafrep = 1 ; then
 	    grep '^ TAF reports ' $CDIR/summary.txt | awk '{printf "  (e=%i, w=%i,",$3,$6}'
 	    grep '^ load_fields_driver,' $CDIR/summary.txt \
-		| awk '{printf " lfd=%i, dop=%i)",$6,$8}'
+		| awk '{printf " lfd=%i, dop=%i, sm=%i)",$7,$9,$11}'
 	fi
     fi
     printf '\n'


### PR DESCRIPTION
## What changes does this PR introduce?
clean up store directives to reduce recomputations and add an additional feature to testreport.

## What is the current behaviour? 
The store directives for seaice_model in do_oceanic_phys are very messy. In two (out of 4 possible) verification (1D_ocean_ice_column, offline_seaice_exf) experiments, the expensive s/r seaice_model is called again from do_oceanics_phys_ad to recompute the sea ice state.

## What is the new behaviour 
cleanup and rearrangement of store directives (storing the sea ice state after seaice_model) cleans up the code (fewer store directives) and avoid recomputation of seaice_model. To monitor this behaviour, testreport now reports the number of calls of s/r seaice_model (as for load_fields_driver and do_oceanics_phys).

## Does this PR introduce a breaking change? 
No, maybe faster AD code

# Suggested addition to `tag-index`
- mode/src/do_oceanic_phys.F: clean up an simply store directives for seaice_model to avoid unnecessary recomputations
- verification/testresport: count and report number of times s/r seaice_model is called
