### PR TITLE
compile ggl90 to OpenAD experiment

### DIFF
--- a/doc/tag-index
+++ b/doc/tag-index
@@ -1,6 +1,8 @@
     Notes on tags used in MITgcmUV
     ==============================
 
+o verification/OpenAD:
+  - add ggl90 pkg to code_ad/packages.conf to get it tested in one TAF-AD exp.
 o doc:
   - require sphinxcontrib-bibtex 2.0.0 or higher
 

--- a/verification/OpenAD/README
+++ b/verification/OpenAD/README
@@ -2,8 +2,8 @@ Starting a configuration for OpenAD
 19-Aug-2005, heimbach@mit.edu, utke@mcs.anl.gov, cnh@mit.edu
 ############################################################
 
-This experiment is derived from global_ocean.90x40x15,
-but excludes packages gmredi, kpp.
+This experiment is derived from global_ocean.90x40x15.
+Additionally it tests packages gmredi, kpp, and ggl90.
 
 STEP 1:
 ######
@@ -11,7 +11,7 @@ To bypass incomplete canonicalizer, convert COMMON blocks to MODULES.
 Successfully completed.
 The built process needed to be modified, and some routines
 needed changes. Most changes were commited to default routines,
-the remaining changes are kept in code/ for now.
+the remaining changes are kept in code_oad/ for now.
 
 To build:
 --------
@@ -23,8 +23,8 @@ o long version:
 --------------
 # (chdir to built/; assume we are in built/)
 #
-# generate makefile using ifort and modified genmake2 in ../code/
-../code/genmake2  -of ../../../tools/build_options/linux_ia32_ifort -mods ../code
+# generate makefile using ifort and modified genmake2 in ../code_oad/
+../../../tools/genmake2  -of ../../../tools/build_options/linux_ia32_ifort -mods ../code_oad
 #
 # make dependencies
 make depend
@@ -64,14 +64,13 @@ STEP 2:
 ######
 Generate code for AD-related routines.
 
-Similar to step 1, but look in code_ad/ instead of code/
+Similar to step 1, but look in code_ad/ instead of code_oad/
 
 To build:
 --------
 o short version:
 ---------------
 
-../code_ad/genmake2  -of ../../../tools/build_options/linux_ia32_ifort -adof ../../../tools/adjoint_options/adjoint_f95 -mods ../code_ad
+../../../tools/genmake2  -of ../../../tools/build_options/linux_ia32_ifort -adof ../../../tools/adjoint_options/adjoint_f95 -mods ../code_ad
 
 make adAll
-

--- a/verification/OpenAD/README
+++ b/verification/OpenAD/README
@@ -5,72 +5,91 @@ Starting a configuration for OpenAD
 This experiment is derived from global_ocean.90x40x15.
 Additionally it tests packages gmredi, kpp, and ggl90.
 
-STEP 1:
-######
-To bypass incomplete canonicalizer, convert COMMON blocks to MODULES.
-Successfully completed.
+--------------------------------------
+Part 1, using OpenAD Adjoint Compiler:
+-------
+
 The built process needed to be modified, and some routines
 needed changes. Most changes were commited to default routines,
 the remaining changes are kept in code_oad/ for now.
 
 To build:
---------
-o short version:
----------------
-make makefile ; make depend ; make cb2m ; make makefile ; make small_f ; make allmods ; make
+# (chdir to build/; assume we are in build/)
 
-o long version:
+# Clean-up (if not starting from clean build dir):
+> make CLEAN
 --------------
-# (chdir to built/; assume we are in built/)
-#
-# generate makefile using ifort and modified genmake2 in ../code_oad/
-../../../tools/genmake2  -of ../../../tools/build_options/linux_ia32_ifort -mods ../code_oad
-#
-# make dependencies
-make depend
-#
-# invoke script to convert COMMON block headers to MODULE headers
-# converts FILE.h to FILE_mod.h which uses newi module FILE_mod.F90
-make cb2m
-#
-# re-generate makefile which takes into account newly created files
-# FILE_mod.h, FILE_mod.F90
-make makefile
-#
-# make .f, .f90
-make small_f
-#
-# first compile all module files .f90
-make allmods
-#
+# generate makefile using gfortran and genmake2:
+> ../../../tools/genmake2  -oad -of ../../../tools/build_options/linux_amd64_gfortran -mods ../code_oad
+
 # compile everything else
-make
+> make adAll
+
+# Note: might want to split the full single step above (make adAll) in several intermediate steps
+# such as:
+# a) invoke script to convert COMMON block headers to MODULE headers
+# converts FILE.h to FILE_mod.h which uses newi module FILE_mod.F90
+> make cb2m
+#
+# b) re-generate makefile which takes into account newly created files
+# FILE_mod.h, FILE_mod.F90
+> make makefile
+#
+# c) make .f, .f90
+> make small_f
+#
+# d) first compile all module files .f90
+> make allmods
+#
+# e) then finaly compile all f90 src files:
+> make adAll
 
 To clean:
 --------
 # Since soft links get overwritten, for now do:
-make CLEAN ; rm *.F *.F90 *.h
+> make CLEAN
 
-to run:
+To run:
+# chdir to run/; assume we are in run/, if not:
+> cd ../run
 ------
-# paremeter files are in input/
-ln -s ../input/* .
-# initial and forcing fields are elsewhere;
-# get these from verif. exp. global_ocean.90x40x15/input/*.bin
-ln -s ../../global_ocean.90x40x15/input/*.bin .
-./mitgcmuv >! output.txt
+# paremeter files are in input_oad/
+> ln -s ../input_oad/* .
+# link other forcing fields (binary files) from exp.  tutorial_global_oce_latlon
+> ../input_oad/prepare_run
 
-STEP 2:
-######
-Generate code for AD-related routines.
+# run a short test:
+> ln -s ../build/mitgcmuv_ad
+> ./mitgcmuv_ad > output.txt
 
-Similar to step 1, but look in code_ad/ instead of code_oad/
+-----------------------------------
+Part 2, using TAF Adjoint Compiler:
+-------
+similar to above but using set-up specific code from code_ad/ and input files from input_ad/
 
 To build:
---------
-o short version:
----------------
+# assume we are in build/
 
-../../../tools/genmake2  -of ../../../tools/build_options/linux_ia32_ifort -adof ../../../tools/adjoint_options/adjoint_f95 -mods ../code_ad
+# Clean-up (if not starting from clean build dir):
+> make CLEAN
+# generate makefile using gfortran and genmake2:
+> ../../../tools/genmake2  -of ../../../tools/build_options/linux_amd64_gfortran -mods ../code_ad
 
-make adAll
+# generate dependencies:
+> make depend
+
+# generate AD src code and compile
+> make adall
+
+To run:
+# assume we are in run/, if not:
+> cd ../run
+
+# link parameter files:
+> ln -s ../input_ad/* .
+# link other forcing fields (binary files) from exp.  tutorial_global_oce_latlon
+> ../input_ad/prepare_run
+
+# run a short test:
+> ln -s ../build/mitgcmuv_ad
+> ./mitgcmuv_ad > output.txt

--- a/verification/OpenAD/code_ad/packages.conf
+++ b/verification/OpenAD/code_ad/packages.conf
@@ -1,6 +1,7 @@
 #-- list of packages (or group of packages) to compile for this experiment:
 gfd
 cd_code
+ggl90
 gmredi
 kpp
 mnc


### PR DESCRIPTION
## What changes does this PR introduce?
additional test of AD-code


## What is the current behaviour? 
pkg/ggl90 was never tested in our standard AD-tests for TAF


## What is the new behaviour 
pkg/ggl90 is still not tested, but the code is compiled and passed to TAF


## Does this PR introduce a breaking change? 
No

## Suggested addition to `tag-index`
- verification/OpenAD/code_ad/packages.conf: add ggl90 to test TAF-AD code