### PR TITLE
Switch GGL90 mxlMaxFlag from 2 to 3 in experiment vermix

### DIFF
--- a/doc/tag-index
+++ b/doc/tag-index
@@ -1,6 +1,9 @@
     Notes on tags used in MITgcmUV
     ==============================
 
+o verification/vermix:
+  - change ggl90 secondary test to use (pkg/ggl90) mxlMaxFlag=3 (instead of 2)
+    and update reference output.
 o pkg/ctrl:
   - move S/R CTRL_MAP_GENARR2D/3D out of file "ctrl_map_ini_genarr.F" into
     a new file "ctrl_map_genarr.F" ;

--- a/verification/vermix/input.ggl90/data.ggl90
+++ b/verification/vermix/input.ggl90/data.ggl90
@@ -3,11 +3,11 @@
 # =====================================================================
  &GGL90_PARM01
  GGL90writeState=.TRUE.,
-#GGL90diffTKEh=1.e3,
+#GGL90diffTKEh=1.E3,
 #GGL90alpha=30.,
 #GGL90TKEFile = 'TKE.init',
- GGL90TKEmin = 1.e-7,
- mxlMaxFlag=2,
+ GGL90TKEmin = 1.E-7,
+ mxlMaxFlag=3,
 #GGL90ck=0.15,
 #GGL90ceps = 0.35,
 #GGL90m2 = 5.,

--- a/verification/vermix/results/output.ggl90.txt
+++ b/verification/vermix/results/output.ggl90.txt
@@ -5,10 +5,10 @@
 (PID.TID 0000.0001) // ======================================================
 (PID.TID 0000.0001) // execution environment starting up...
 (PID.TID 0000.0001) 
-(PID.TID 0000.0001) // MITgcmUV version:  checkpoint61x
-(PID.TID 0000.0001) // Build user:        dfer
-(PID.TID 0000.0001) // Build host:        faulks.csail.mit.edu
-(PID.TID 0000.0001) // Build date:        Thu Nov 12 11:40:54 EST 2009
+(PID.TID 0000.0001) // MITgcmUV version:  checkpoint68a
+(PID.TID 0000.0001) // Build user:        jm_c
+(PID.TID 0000.0001) // Build host:        villon
+(PID.TID 0000.0001) // Build date:        Fri Jul 30 12:44:54 EDT 2021
 (PID.TID 0000.0001) 
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // Execution Environment parameter file "eedata"
@@ -18,7 +18,7 @@
 (PID.TID 0000.0001) ># nTx - No. threads per process in X
 (PID.TID 0000.0001) ># nTy - No. threads per process in Y
 (PID.TID 0000.0001) > &EEPARMS
-(PID.TID 0000.0001) > &
+(PID.TID 0000.0001) > /
 (PID.TID 0000.0001) ># Note: Some systems use & as the
 (PID.TID 0000.0001) ># namelist terminator. Other systems
 (PID.TID 0000.0001) ># use a / character (as shown here).
@@ -47,8 +47,11 @@
 (PID.TID 0000.0001)                   /*  note: To execute a program with MPI calls */
 (PID.TID 0000.0001)                   /*  it must be launched appropriately e.g     */
 (PID.TID 0000.0001)                   /*  "mpirun -np 64 ......"                    */
-(PID.TID 0000.0001) useCoupler=    F ;/* Flag used to control communications with   */
+(PID.TID 0000.0001) useCoupler=   F ; /* Flag used to control communications with   */
 (PID.TID 0000.0001)                   /*  other model components, through a coupler */
+(PID.TID 0000.0001) useNest2W_parent =    F ;/* Control 2-W Nesting comm */
+(PID.TID 0000.0001) useNest2W_child  =    F ;/* Control 2-W Nesting comm */
+(PID.TID 0000.0001) debugMode =    F ; /* print debug msg. (sequence of S/R calls)  */
 (PID.TID 0000.0001) printMapIncludesZeros=    F ; /* print zeros in Std.Output maps */
 (PID.TID 0000.0001) maxLengthPrt1D=   65 /* maxLength of 1D array printed to StdOut */
 (PID.TID 0000.0001) 
@@ -60,20 +63,20 @@
 (PID.TID 0000.0001) // ======================================================
 (PID.TID 0000.0001) // Tile <-> Tile connectvity table
 (PID.TID 0000.0001) // ======================================================
-(PID.TID 0000.0001) // Tile number: 000001 (process no. = 000001)
-(PID.TID 0000.0001) //        WEST: Tile = 000001, Process = 000001, Comm = put
+(PID.TID 0000.0001) // Tile number: 000001 (process no. = 000000)
+(PID.TID 0000.0001) //        WEST: Tile = 000001, Process = 000000, Comm = put
 (PID.TID 0000.0001) //                bi = 000001, bj = 000001
-(PID.TID 0000.0001) //        EAST: Tile = 000001, Process = 000001, Comm = put
+(PID.TID 0000.0001) //        EAST: Tile = 000001, Process = 000000, Comm = put
 (PID.TID 0000.0001) //                bi = 000001, bj = 000001
-(PID.TID 0000.0001) //       SOUTH: Tile = 000001, Process = 000001, Comm = put
+(PID.TID 0000.0001) //       SOUTH: Tile = 000001, Process = 000000, Comm = put
 (PID.TID 0000.0001) //                bi = 000001, bj = 000001
-(PID.TID 0000.0001) //       NORTH: Tile = 000001, Process = 000001, Comm = put
+(PID.TID 0000.0001) //       NORTH: Tile = 000001, Process = 000000, Comm = put
 (PID.TID 0000.0001) //                bi = 000001, bj = 000001
 (PID.TID 0000.0001) 
-(PID.TID 0000.0001) DEBUG_MSG: ENTERED S/R THE_MODEL_MAIN
-(PID.TID 0000.0001) DEBUG_MSG: CALLING S/R INITIALISE_FIXED
+(PID.TID 0000.0001)  INI_PARMS: opening model parameter file "data"
+(PID.TID 0000.0001)  OPEN_COPY_DATA_FILE: opening file data
 (PID.TID 0000.0001) // =======================================================
-(PID.TID 0000.0001) // Model parameter file "data"
+(PID.TID 0000.0001) // Parameter file "data"
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) ># ====================
 (PID.TID 0000.0001) ># | Model parameters |
@@ -83,15 +86,12 @@
 (PID.TID 0000.0001) > &PARM01
 (PID.TID 0000.0001) > tRef=26*1.,
 (PID.TID 0000.0001) > sRef=26*35.,
-(PID.TID 0000.0001) > viscA4=0.0E4,
 (PID.TID 0000.0001) > viscAh=0.E-2,
 (PID.TID 0000.0001) > viscAz=1.E-4,
 (PID.TID 0000.0001) > no_slip_sides=.TRUE.,
 (PID.TID 0000.0001) > no_slip_bottom=.TRUE.,
-(PID.TID 0000.0001) > diffK4T=0.E4,
 (PID.TID 0000.0001) > diffKhT=0.E-2,
 (PID.TID 0000.0001) > diffKzT=1.E-5,
-(PID.TID 0000.0001) > diffK4S=0.E4,
 (PID.TID 0000.0001) > diffKhS=0.E-2,
 (PID.TID 0000.0001) > diffKzS=1.E-5,
 (PID.TID 0000.0001) > f0=1.4e-4,
@@ -103,22 +103,22 @@
 (PID.TID 0000.0001) > implicitViscosity=.TRUE.,
 (PID.TID 0000.0001) > eosType='MDJWF',
 (PID.TID 0000.0001) > hFacMin=0.05,
-(PID.TID 0000.0001) > readBinaryPrec=64,
-(PID.TID 0000.0001) > debugLevel=1,
 (PID.TID 0000.0001) > tempAdvection=.FALSE.,
 (PID.TID 0000.0001) > tempAdvScheme=33,
 (PID.TID 0000.0001) > momAdvection=.FALSE.,
-(PID.TID 0000.0001) > &
+(PID.TID 0000.0001) > readBinaryPrec=64,
+(PID.TID 0000.0001) >#debugLevel=1,
+(PID.TID 0000.0001) > /
 (PID.TID 0000.0001) >
 (PID.TID 0000.0001) ># Elliptic solver parameters
 (PID.TID 0000.0001) > &PARM02
 (PID.TID 0000.0001) > cg2dMaxIters=300,
 (PID.TID 0000.0001) > cg2dTargetResidual=1.E-13,
-(PID.TID 0000.0001) > &
+(PID.TID 0000.0001) > /
 (PID.TID 0000.0001) >
 (PID.TID 0000.0001) ># Time stepping parameters
 (PID.TID 0000.0001) > &PARM03
-(PID.TID 0000.0001) > niter0=0,
+(PID.TID 0000.0001) > nIter0=0,
 (PID.TID 0000.0001) > nTimeSteps=20,
 (PID.TID 0000.0001) >#nTimeSteps=720,
 (PID.TID 0000.0001) >#nTimeSteps=51840,
@@ -134,35 +134,35 @@
 (PID.TID 0000.0001) > periodicExternalForcing=.TRUE.,
 (PID.TID 0000.0001) > externForcingPeriod=432000.,
 (PID.TID 0000.0001) > externForcingCycle=31104000.,
-(PID.TID 0000.0001) > &
+(PID.TID 0000.0001) > /
 (PID.TID 0000.0001) >
 (PID.TID 0000.0001) ># Gridding parameters
 (PID.TID 0000.0001) > &PARM04
 (PID.TID 0000.0001) > usingCartesianGrid=.TRUE.,
-(PID.TID 0000.0001) > usingSphericalPolarGrid=.FALSE.,
-(PID.TID 0000.0001) > dXspacing=5000,
+(PID.TID 0000.0001) > dXspacing=5000.,
 (PID.TID 0000.0001) > dYspacing=5000.,
-(PID.TID 0000.0001) > delZ=10, 10, 10, 10, 10, 11, 12, 14, 16, 18, 21, 24, 27,
-(PID.TID 0000.0001) >      31, 35, 40, 40, 40, 40, 40, 40, 40, 40, 40, 40, 40,
-(PID.TID 0000.0001) > &
+(PID.TID 0000.0001) > delZ=10., 10., 10., 10., 10., 11., 12., 14., 16., 18., 21., 24., 27.,
+(PID.TID 0000.0001) >      31., 35., 40., 40., 40., 40., 40., 40., 40., 40., 40., 40., 40.,
+(PID.TID 0000.0001) > /
 (PID.TID 0000.0001) >
 (PID.TID 0000.0001) ># Input datasets
 (PID.TID 0000.0001) > &PARM05
 (PID.TID 0000.0001) > hydrogThetaFile='T_26.init',
-(PID.TID 0000.0001) > surfQfile='Qnet_72.forcing',
-(PID.TID 0000.0001) > zonalWindFile='taux_72.forcing',
-(PID.TID 0000.0001) > &
+(PID.TID 0000.0001) > surfQnetFile   ='Qnet_72.forcing',
+(PID.TID 0000.0001) > zonalWindFile  ='taux_72.forcing',
+(PID.TID 0000.0001) > /
 (PID.TID 0000.0001) 
-(PID.TID 0000.0001) S/R INI_PARMS ; starts to read PARM01
-(PID.TID 0000.0001) S/R INI_PARMS ; read PARM01 : OK
-(PID.TID 0000.0001) S/R INI_PARMS ; starts to read PARM02
-(PID.TID 0000.0001) S/R INI_PARMS ; read PARM02 : OK
-(PID.TID 0000.0001) S/R INI_PARMS ; starts to read PARM03
-(PID.TID 0000.0001) S/R INI_PARMS ; read PARM03 : OK
-(PID.TID 0000.0001) S/R INI_PARMS ; starts to read PARM04
-(PID.TID 0000.0001) S/R INI_PARMS ; read PARM04 : OK
-(PID.TID 0000.0001) S/R INI_PARMS ; starts to read PARM05
-(PID.TID 0000.0001) S/R INI_PARMS ; read PARM05 : OK
+(PID.TID 0000.0001)  INI_PARMS ; starts to read PARM01
+(PID.TID 0000.0001)  INI_PARMS ; read PARM01 : OK
+(PID.TID 0000.0001)  INI_PARMS ; starts to read PARM02
+(PID.TID 0000.0001)  INI_PARMS ; read PARM02 : OK
+(PID.TID 0000.0001)  INI_PARMS ; starts to read PARM03
+(PID.TID 0000.0001)  INI_PARMS ; read PARM03 : OK
+(PID.TID 0000.0001)  INI_PARMS ; starts to read PARM04
+(PID.TID 0000.0001)  INI_PARMS ; read PARM04 : OK
+(PID.TID 0000.0001)  INI_PARMS ; starts to read PARM05
+(PID.TID 0000.0001)  INI_PARMS ; read PARM05 : OK
+(PID.TID 0000.0001)  INI_PARMS: finished reading file "data"
 (PID.TID 0000.0001)  PACKAGES_BOOT: opening data.pkg
 (PID.TID 0000.0001)  OPEN_COPY_DATA_FILE: opening file data.pkg
 (PID.TID 0000.0001) // =======================================================
@@ -173,23 +173,46 @@
 (PID.TID 0000.0001) > useGGL90=.TRUE.,
 (PID.TID 0000.0001) > useDiagnostics=.TRUE.,
 (PID.TID 0000.0001) > useMNC=.TRUE.,
-(PID.TID 0000.0001) > &
+(PID.TID 0000.0001) > /
 (PID.TID 0000.0001) 
 (PID.TID 0000.0001)  PACKAGES_BOOT: finished reading data.pkg
+(PID.TID 0000.0001)  PACKAGES_BOOT: On/Off package Summary
+ --------  pkgs with a standard "usePKG" On/Off switch in "data.pkg":  --------
+ pkg/opps                 compiled but not used ( useOPPS                  = F )
+ pkg/pp81                 compiled but not used ( usePP81                  = F )
+ pkg/my82                 compiled but not used ( useMY82                  = F )
+ pkg/ggl90                compiled   and   used ( useGGL90                 = T )
+ pkg/kpp                  compiled but not used ( useKPP                   = F )
+ pkg/diagnostics          compiled   and   used ( useDiagnostics           = T )
+ pkg/mnc                  compiled   and   used ( useMNC                   = T )
+ -------- pkgs without standard "usePKG" On/Off switch in "data.pkg":  --------
+ pkg/generic_advdiff      compiled   and   used ( useGAD                   = T )
+ pkg/mom_common           compiled   and   used ( momStepping              = T )
+ pkg/mom_vecinv           compiled but not used ( +vectorInvariantMomentum = F )
+ pkg/mom_fluxform         compiled   and   used ( & not vectorInvariantMom = T )
+ pkg/monitor              compiled   and   used ( monitorFreq > 0.         = T )
+ pkg/timeave              compiled but not used ( taveFreq > 0.            = F )
+ pkg/debug                compiled but not used ( debugMode                = F )
+ pkg/rw                   compiled   and   used
+ pkg/mdsio                compiled   and   used
+(PID.TID 0000.0001)  PACKAGES_BOOT: End of package Summary
+(PID.TID 0000.0001) 
 (PID.TID 0000.0001)  MNC_READPARMS: opening file 'data.mnc'
 (PID.TID 0000.0001)  OPEN_COPY_DATA_FILE: opening file data.mnc
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // Parameter file "data.mnc"
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) ># Example "data.mnc" file
+(PID.TID 0000.0001) ># Lines beginning "#" are comments
 (PID.TID 0000.0001) > &MNC_01
 (PID.TID 0000.0001) ># mnc_echo_gvtypes=.FALSE.,
 (PID.TID 0000.0001) ># mnc_use_indir=.FALSE.,
-(PID.TID 0000.0001) >  mnc_use_outdir=.FALSE.,
+(PID.TID 0000.0001) >  mnc_use_outdir=.TRUE.,
+(PID.TID 0000.0001) >  mnc_outdir_str='mnc_test_',
 (PID.TID 0000.0001) >  monitor_mnc=.FALSE.,
 (PID.TID 0000.0001) >  pickup_read_mnc=.FALSE.,
 (PID.TID 0000.0001) >  pickup_write_mnc=.FALSE.,
-(PID.TID 0000.0001) > &
+(PID.TID 0000.0001) > /
 (PID.TID 0000.0001) 
 (PID.TID 0000.0001)  MNC_READPARMS: finished reading data.mnc
 (PID.TID 0000.0001)  GGL90_READPARMS: opening data.ggl90
@@ -202,17 +225,19 @@
 (PID.TID 0000.0001) ># =====================================================================
 (PID.TID 0000.0001) > &GGL90_PARM01
 (PID.TID 0000.0001) > GGL90writeState=.TRUE.,
-(PID.TID 0000.0001) >#GGL90diffTKEh=1.e3,
+(PID.TID 0000.0001) >#GGL90diffTKEh=1.E3,
 (PID.TID 0000.0001) >#GGL90alpha=30.,
 (PID.TID 0000.0001) >#GGL90TKEFile = 'TKE.init',
-(PID.TID 0000.0001) > GGL90TKEmin = 1.e-7,
-(PID.TID 0000.0001) > mxlMaxFlag=2,
+(PID.TID 0000.0001) > GGL90TKEmin = 1.E-7,
+(PID.TID 0000.0001) > mxlMaxFlag=3,
 (PID.TID 0000.0001) >#GGL90ck=0.15,
 (PID.TID 0000.0001) >#GGL90ceps = 0.35,
 (PID.TID 0000.0001) >#GGL90m2 = 5.,
 (PID.TID 0000.0001) > GGL90mixingLengthMin=3.,
-(PID.TID 0000.0001) > &
+(PID.TID 0000.0001) > /
 (PID.TID 0000.0001) 
+(PID.TID 0000.0001)  GGL90_READPARMS ; starts to read GGL90_PARM01
+(PID.TID 0000.0001)  GGL90_READPARMS: read GGL90_PARM01 : OK
 (PID.TID 0000.0001)  GGL90_READPARMS: finished reading data.ggl90
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // GGL90 configuration
@@ -263,9 +288,18 @@
 (PID.TID 0000.0001)                 3.000000000000000E+00
 (PID.TID 0000.0001)     ;
 (PID.TID 0000.0001) mxlMaxFlag =   /* Flag for limiting mixing-length method */
-(PID.TID 0000.0001)                       2
+(PID.TID 0000.0001)                       3
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) mxlSurfFlag =   /* GGL90 flag for near surface mixing. */
+(PID.TID 0000.0001)                   F
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) calcMeanVertShear = /* calc Mean of Vert.Shear (vs shear of Mean flow) */
+(PID.TID 0000.0001)                   F
 (PID.TID 0000.0001)     ;
 (PID.TID 0000.0001) GGL90: GGL90TKEFile =
+(PID.TID 0000.0001) GGL90writeState =   /* GGL90 Boundary condition flag. */
+(PID.TID 0000.0001)                   T
+(PID.TID 0000.0001)     ;
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // End of GGL90 config. summary
 (PID.TID 0000.0001) // =======================================================
@@ -276,88 +310,125 @@
 (PID.TID 0000.0001) // Parameter file "data.diagnostics"
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) ># Diagnostic Package Choices
-(PID.TID 0000.0001) >#-----------------
-(PID.TID 0000.0001) ># for each output-stream:
-(PID.TID 0000.0001) >#  filename(n) : prefix of the output file name (only 8.c long) for outp.stream n
+(PID.TID 0000.0001) >#--------------------
+(PID.TID 0000.0001) >#  dumpAtLast (logical): always write output at the end of simulation (default=F)
+(PID.TID 0000.0001) >#  diag_mnc   (logical): write to NetCDF files (default=useMNC)
+(PID.TID 0000.0001) >#--for each output-stream:
+(PID.TID 0000.0001) >#  fileName(n) : prefix of the output file name (max 80c long) for outp.stream n
 (PID.TID 0000.0001) >#  frequency(n):< 0 : write snap-shot output every |frequency| seconds
 (PID.TID 0000.0001) >#               > 0 : write time-average output every frequency seconds
 (PID.TID 0000.0001) >#  timePhase(n)     : write at time = timePhase + multiple of |frequency|
+(PID.TID 0000.0001) >#    averagingFreq  : frequency (in s) for periodic averaging interval
+(PID.TID 0000.0001) >#    averagingPhase : phase     (in s) for periodic averaging interval
+(PID.TID 0000.0001) >#    repeatCycle    : number of averaging intervals in 1 cycle
 (PID.TID 0000.0001) >#  levels(:,n) : list of levels to write to file (Notes: declared as REAL)
-(PID.TID 0000.0001) >#                 when this entry is missing, select all common levels of this list
-(PID.TID 0000.0001) >#  fields(:,n) : list of diagnostics fields (8.c) (see "available_diagnostics.log"
-(PID.TID 0000.0001) >#                 file for the list of all available diag. in this particular config)
-(PID.TID 0000.0001) >#-----------------
-(PID.TID 0000.0001) > &diagnostics_list
+(PID.TID 0000.0001) >#                when this entry is missing, select all common levels of this list
+(PID.TID 0000.0001) >#  fields(:,n) : list of selected diagnostics fields (8.c) in outp.stream n
+(PID.TID 0000.0001) >#                (see "available_diagnostics.log" file for the full list of diags)
+(PID.TID 0000.0001) >#  missing_value(n) : missing value for real-type fields in output file "n"
+(PID.TID 0000.0001) >#  fileFlags(n)     : specific code (8c string) for output file "n"
+(PID.TID 0000.0001) >#--------------------
+(PID.TID 0000.0001) > &DIAGNOSTICS_LIST
 (PID.TID 0000.0001) ># diag_mnc     = .FALSE.,
-(PID.TID 0000.0001) >
+(PID.TID 0000.0001) >#--
+(PID.TID 0000.0001) ># fields(1:3,1)  = 'ETAN    ','ETANSQ  ','DETADT2 ',
+(PID.TID 0000.0001) >#  fileName(1) = 'surfDiag',
+(PID.TID 0000.0001) ># fileFlags(1) = 'D       ',
 (PID.TID 0000.0001) ># frequency(1) = 432000.,
-(PID.TID 0000.0001) >#  filename(1) = 'surfDiag',
-(PID.TID 0000.0001) >#  fields(1,1) = 'ETAN    ','ETANSQ  ','DETADT2 ',
-(PID.TID 0000.0001) >#  fileflags(1)= 'D       ',
 (PID.TID 0000.0001) >
+(PID.TID 0000.0001) >  fields(1:6,2)  = 'UVEL    ','VVEL    ','WVEL    ',
+(PID.TID 0000.0001) >                   'THETA   ','PHIHYD  ','DFrI_TH ',
+(PID.TID 0000.0001) >   fileName(2) = 'dynDiag',
 (PID.TID 0000.0001) >  frequency(2) = 432000.,
-(PID.TID 0000.0001) >   filename(2) = 'dynDiag',
-(PID.TID 0000.0001) >   fields(1,2) = 'UVEL    ','VVEL    ','WVEL    ',
-(PID.TID 0000.0001) >                 'THETA   ','PHIHYD  ','DFrI_TH ',
 (PID.TID 0000.0001) >
+(PID.TID 0000.0001) >  fields(1:6,3)  = 'GGL90TKE','GGL90Lmx','GGL90Kr ',
+(PID.TID 0000.0001) >                   'GGL90ArU','GGL90ArV','GGL90Prl',
+(PID.TID 0000.0001) >   fileName(3) = 'DiagMXL_3d',
 (PID.TID 0000.0001) >  frequency(3) = 432000.,
-(PID.TID 0000.0001) >   filename(3) = 'DiagMXL_3d',
-(PID.TID 0000.0001) >   fields(1,3) = 'GGL90TKE','GGL90Lmx','GGL90Kr ','GGL90Ar ',
-(PID.TID 0000.0001) >                 'GGL90Prl',
 (PID.TID 0000.0001) >
+(PID.TID 0000.0001) >  fields(1,4)  = 'MXLDEPTH',
+(PID.TID 0000.0001) >   fileName(4) = 'DiagMXL_2d',
 (PID.TID 0000.0001) >  frequency(4) = 432000.,
-(PID.TID 0000.0001) >   filename(4) = 'DiagMXL_2d',
-(PID.TID 0000.0001) >   fields(1,4) = 'MXLDEPTH',
-(PID.TID 0000.0001) > &
+(PID.TID 0000.0001) > /
 (PID.TID 0000.0001) >
+(PID.TID 0000.0001) >#--------------------
 (PID.TID 0000.0001) ># Parameter for Diagnostics of per level statistics:
-(PID.TID 0000.0001) >#-----------------
-(PID.TID 0000.0001) ># for each output-stream:
-(PID.TID 0000.0001) >#  stat_fname(n) : prefix of the output file name (only 8.c long) for outp.stream n
+(PID.TID 0000.0001) >#--------------------
+(PID.TID 0000.0001) >#  diagSt_mnc (logical): write stat-diags to NetCDF files (default=diag_mnc)
+(PID.TID 0000.0001) >#  diagSt_regMaskFile : file containing the region-mask to read-in
+(PID.TID 0000.0001) >#  nSetRegMskFile   : number of region-mask sets within the region-mask file
+(PID.TID 0000.0001) >#  set_regMask(i)   : region-mask set-index that identifies the region "i"
+(PID.TID 0000.0001) >#  val_regMask(i)   : region "i" identifier value in the region mask
+(PID.TID 0000.0001) >#--for each output-stream:
+(PID.TID 0000.0001) >#  stat_fName(n) : prefix of the output file name (max 80c long) for outp.stream n
 (PID.TID 0000.0001) >#  stat_freq(n):< 0 : write snap-shot output every |stat_freq| seconds
 (PID.TID 0000.0001) >#               > 0 : write time-average output every stat_freq seconds
 (PID.TID 0000.0001) >#  stat_phase(n)    : write at time = stat_phase + multiple of |stat_freq|
 (PID.TID 0000.0001) >#  stat_region(:,n) : list of "regions" (default: 1 region only=global)
-(PID.TID 0000.0001) >#  stat_fields(:,n) : list of diagnostics fields (8.c) (see "available_diagnostics.log"
-(PID.TID 0000.0001) >#                 file for the list of all available diag. in this particular config)
-(PID.TID 0000.0001) >#-----------------
+(PID.TID 0000.0001) >#  stat_fields(:,n) : list of selected diagnostics fields (8.c) in outp.stream n
+(PID.TID 0000.0001) >#                (see "available_diagnostics.log" file for the full list of diags)
+(PID.TID 0000.0001) >#--------------------
 (PID.TID 0000.0001) > &DIAG_STATIS_PARMS
-(PID.TID 0000.0001) >#stat_fields(1,1)= 'ETAN    ','UVEL    ','VVEL    ','WVEL    ',
-(PID.TID 0000.0001) >#                  'THETA   ','PHIHYD  ','KPPdbsfc','KPPhbl  ','KPPRi   ',
-(PID.TID 0000.0001) >#   stat_fname(1)= 'dynStDiag',
-(PID.TID 0000.0001) >#    stat_freq(1)= -86400.,
-(PID.TID 0000.0001) >#   stat_phase(1)= 0.,
-(PID.TID 0000.0001) >#   diagSt_mnc   =.FALSE.,
-(PID.TID 0000.0001) > &
+(PID.TID 0000.0001) >   diagSt_mnc   =.FALSE.,
+(PID.TID 0000.0001) >#--
+(PID.TID 0000.0001) > stat_fields(1:6,1)  = 'GGL90TKE','GGL90Lmx','GGL90Kr ',
+(PID.TID 0000.0001) >                       'GGL90ArU','GGL90ArV','GGL90Prl',
+(PID.TID 0000.0001) >  stat_fName(1) = 'dynStDiag',
+(PID.TID 0000.0001) >   stat_freq(1) = -18000.,
+(PID.TID 0000.0001) >  stat_phase(1) = 0.,
+(PID.TID 0000.0001) > /
 (PID.TID 0000.0001) >
 (PID.TID 0000.0001) 
 (PID.TID 0000.0001) S/R DIAGNOSTICS_READPARMS, read namelist "diagnostics_list": start
 (PID.TID 0000.0001) S/R DIAGNOSTICS_READPARMS, read namelist "diagnostics_list": OK
 (PID.TID 0000.0001) S/R DIAGNOSTICS_READPARMS, read namelist "DIAG_STATIS_PARMS": start
 (PID.TID 0000.0001) S/R DIAGNOSTICS_READPARMS, read namelist "DIAG_STATIS_PARMS": OK
+(PID.TID 0000.0001)  DIAGNOSTICS_READPARMS: global parameter summary:
+(PID.TID 0000.0001)  dumpAtLast = /* always write time-ave diags at the end */
+(PID.TID 0000.0001)                   F
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001)  diag_mnc =   /* write NetCDF output files */
+(PID.TID 0000.0001)                   T
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001)  useMissingValue = /* put MissingValue where mask = 0 */
+(PID.TID 0000.0001)                   F
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001)  diagCG_maxIters = /* max number of iters in diag_cg2d */
+(PID.TID 0000.0001)                     300
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001)  diagCG_resTarget = /* residual target for diag_cg2d */
+(PID.TID 0000.0001)                 1.000000000000000E-13
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001)  diagCG_pcOffDFac = /* preconditioner off-diagonal factor */
+(PID.TID 0000.0001)                 9.611687812379854E-01
+(PID.TID 0000.0001)     ;
 (PID.TID 0000.0001) -----------------------------------------------------
 (PID.TID 0000.0001)  DIAGNOSTICS_READPARMS: active diagnostics summary:
 (PID.TID 0000.0001) -----------------------------------------------------
 (PID.TID 0000.0001) Creating Output Stream: dynDiag
 (PID.TID 0000.0001) Output Frequency:     432000.000000 ; Phase:           0.000000
 (PID.TID 0000.0001)  Averaging Freq.:     432000.000000 , Phase:           0.000000 , Cycle:   1
-(PID.TID 0000.0001)  missing value:  1.234567000000E+05 ; for integers:   123456789
+(PID.TID 0000.0001)  missing value: -9.990000000000E+02
 (PID.TID 0000.0001)  Levels:    will be set later
 (PID.TID 0000.0001)  Fields:    UVEL     VVEL     WVEL     THETA    PHIHYD   DFrI_TH
 (PID.TID 0000.0001) Creating Output Stream: DiagMXL_3d
 (PID.TID 0000.0001) Output Frequency:     432000.000000 ; Phase:           0.000000
 (PID.TID 0000.0001)  Averaging Freq.:     432000.000000 , Phase:           0.000000 , Cycle:   1
-(PID.TID 0000.0001)  missing value:  1.234567000000E+05 ; for integers:   123456789
+(PID.TID 0000.0001)  missing value: -9.990000000000E+02
 (PID.TID 0000.0001)  Levels:    will be set later
-(PID.TID 0000.0001)  Fields:    GGL90TKE GGL90Lmx GGL90Kr  GGL90Ar  GGL90Prl
+(PID.TID 0000.0001)  Fields:    GGL90TKE GGL90Lmx GGL90Kr  GGL90ArU GGL90ArV GGL90Prl
 (PID.TID 0000.0001) Creating Output Stream: DiagMXL_2d
 (PID.TID 0000.0001) Output Frequency:     432000.000000 ; Phase:           0.000000
 (PID.TID 0000.0001)  Averaging Freq.:     432000.000000 , Phase:           0.000000 , Cycle:   1
-(PID.TID 0000.0001)  missing value:  1.234567000000E+05 ; for integers:   123456789
+(PID.TID 0000.0001)  missing value: -9.990000000000E+02
 (PID.TID 0000.0001)  Levels:    will be set later
 (PID.TID 0000.0001)  Fields:    MXLDEPTH
 (PID.TID 0000.0001) -----------------------------------------------------
 (PID.TID 0000.0001)  DIAGNOSTICS_READPARMS: statistics diags. summary:
+(PID.TID 0000.0001) Creating Stats. Output Stream: dynStDiag
+(PID.TID 0000.0001) Output Frequency:     -18000.000000 ; Phase:           0.000000
+(PID.TID 0000.0001)  Regions:   0
+(PID.TID 0000.0001)  Fields:    GGL90TKE GGL90Lmx GGL90Kr  GGL90ArU GGL90ArV GGL90Prl
 (PID.TID 0000.0001) -----------------------------------------------------
 (PID.TID 0000.0001) 
 (PID.TID 0000.0001) SET_PARMS: done
@@ -434,15 +505,25 @@
 (PID.TID 0000.0001) %MON AngleSN_min                  =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON AngleSN_mean                 =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON AngleSN_sd                   =   0.0000000000000E+00
+(PID.TID 0000.0001) 
+(PID.TID 0000.0001) FIND_HYD_PRESS_1D: Start to iterate (MaxIter=  260 ) until P(rho(P))
+(PID.TID 0000.0001) FIND_HYD_PRESS_1D:  converges ; critera (x  5) on Rho diff= 9.998000E-12
+(PID.TID 0000.0001)  iter    1, RMS-diff=  4.522117070724E-02, Max-diff=  9.254578595119E-02
+(PID.TID 0000.0001)  iter    2, RMS-diff=  5.501271219195E-05, Max-diff=  1.418256665602E-04
+(PID.TID 0000.0001)  iter    3, RMS-diff=  4.946437427996E-08, Max-diff=  1.465555214963E-07
+(PID.TID 0000.0001)  iter    4, RMS-diff=  3.498336160000E-11, Max-diff=  1.141415850725E-10
+(PID.TID 0000.0001)  iter    5, RMS-diff=  7.723499726203E-14, Max-diff=  2.273736754432E-13
+(PID.TID 0000.0001)  iter    6, RMS-diff=  0.000000000000E+00, Max-diff=  0.000000000000E+00
+(PID.TID 0000.0001) FIND_HYD_PRESS_1D: converged after    6 iters (nUnderCrit=  2 )
 (PID.TID 0000.0001) // =======================================================
-(PID.TID 0000.0001) // Field Model R_low (ini_masks_etc) at iteration          1
+(PID.TID 0000.0001) // Field Model R_low (ini_masks_etc)
 (PID.TID 0000.0001) // CMIN =         -6.990000000000000E+02
 (PID.TID 0000.0001) // CMAX =         -6.990000000000000E+02
 (PID.TID 0000.0001) // CINT =          0.000000000000000E+00
 (PID.TID 0000.0001) // SYMBOLS (CMIN->CMAX): -abcdefghijklmnopqrstuvwxyz+
 (PID.TID 0000.0001) //                  0.0: .
-(PID.TID 0000.0001) // RANGE I (Lo:Hi:Step):(  -1:   3:   1)
-(PID.TID 0000.0001) // RANGE J (Lo:Hi:Step):(   3:  -1:  -1)
+(PID.TID 0000.0001) // RANGE I (Lo:Hi:Step):(    -1:     3:     1)
+(PID.TID 0000.0001) // RANGE J (Lo:Hi:Step):(     3:    -1:    -1)
 (PID.TID 0000.0001) // RANGE K (Lo:Hi:Step):(   1:   1:   1)
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // =======================================================
@@ -450,14 +531,14 @@
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) 
 (PID.TID 0000.0001) // =======================================================
-(PID.TID 0000.0001) // Field Model Ro_surf (ini_masks_etc) at iteration          1
+(PID.TID 0000.0001) // Field Model Ro_surf (ini_masks_etc)
 (PID.TID 0000.0001) // CMIN =          1.000000000000000E+32
 (PID.TID 0000.0001) // CMAX =         -1.000000000000000E+32
 (PID.TID 0000.0001) // CINT =          0.000000000000000E+00
 (PID.TID 0000.0001) // SYMBOLS (CMIN->CMAX): -abcdefghijklmnopqrstuvwxyz+
 (PID.TID 0000.0001) //                  0.0: .
-(PID.TID 0000.0001) // RANGE I (Lo:Hi:Step):(  -1:   3:   1)
-(PID.TID 0000.0001) // RANGE J (Lo:Hi:Step):(   3:  -1:  -1)
+(PID.TID 0000.0001) // RANGE I (Lo:Hi:Step):(    -1:     3:     1)
+(PID.TID 0000.0001) // RANGE J (Lo:Hi:Step):(     3:    -1:    -1)
 (PID.TID 0000.0001) // RANGE K (Lo:Hi:Step):(   1:   1:   1)
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // =======================================================
@@ -465,14 +546,14 @@
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) 
 (PID.TID 0000.0001) // =======================================================
-(PID.TID 0000.0001) // Field hFacC at iteration          1
+(PID.TID 0000.0001) // Field hFacC at iteration          0
 (PID.TID 0000.0001) // CMIN =          1.000000000000000E+00
 (PID.TID 0000.0001) // CMAX =          1.000000000000000E+00
 (PID.TID 0000.0001) // CINT =          0.000000000000000E+00
 (PID.TID 0000.0001) // SYMBOLS (CMIN->CMAX): -abcdefghijklmnopqrstuvwxyz+
 (PID.TID 0000.0001) //                  0.0: .
-(PID.TID 0000.0001) // RANGE I (Lo:Hi:Step):(  -1:   3:   1)
-(PID.TID 0000.0001) // RANGE J (Lo:Hi:Step):(   3:  -1:  -1)
+(PID.TID 0000.0001) // RANGE I (Lo:Hi:Step):(    -1:     3:     1)
+(PID.TID 0000.0001) // RANGE J (Lo:Hi:Step):(     3:    -1:    -1)
 (PID.TID 0000.0001) // RANGE K (Lo:Hi:Step):(   1:   1:   1)
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // =======================================================
@@ -480,14 +561,14 @@
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) 
 (PID.TID 0000.0001) // =======================================================
-(PID.TID 0000.0001) // Field hFacW at iteration          1
+(PID.TID 0000.0001) // Field hFacW at iteration          0
 (PID.TID 0000.0001) // CMIN =          1.000000000000000E+00
 (PID.TID 0000.0001) // CMAX =          1.000000000000000E+00
 (PID.TID 0000.0001) // CINT =          0.000000000000000E+00
 (PID.TID 0000.0001) // SYMBOLS (CMIN->CMAX): -abcdefghijklmnopqrstuvwxyz+
 (PID.TID 0000.0001) //                  0.0: .
-(PID.TID 0000.0001) // RANGE I (Lo:Hi:Step):(  -1:   3:   1)
-(PID.TID 0000.0001) // RANGE J (Lo:Hi:Step):(   3:  -1:  -1)
+(PID.TID 0000.0001) // RANGE I (Lo:Hi:Step):(    -1:     3:     1)
+(PID.TID 0000.0001) // RANGE J (Lo:Hi:Step):(     3:    -1:    -1)
 (PID.TID 0000.0001) // RANGE K (Lo:Hi:Step):(   1:   1:   1)
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // =======================================================
@@ -495,20 +576,21 @@
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) 
 (PID.TID 0000.0001) // =======================================================
-(PID.TID 0000.0001) // Field hFacS at iteration          1
+(PID.TID 0000.0001) // Field hFacS at iteration          0
 (PID.TID 0000.0001) // CMIN =          1.000000000000000E+00
 (PID.TID 0000.0001) // CMAX =          1.000000000000000E+00
 (PID.TID 0000.0001) // CINT =          0.000000000000000E+00
 (PID.TID 0000.0001) // SYMBOLS (CMIN->CMAX): -abcdefghijklmnopqrstuvwxyz+
 (PID.TID 0000.0001) //                  0.0: .
-(PID.TID 0000.0001) // RANGE I (Lo:Hi:Step):(  -1:   3:   1)
-(PID.TID 0000.0001) // RANGE J (Lo:Hi:Step):(   3:  -1:  -1)
+(PID.TID 0000.0001) // RANGE I (Lo:Hi:Step):(    -1:     3:     1)
+(PID.TID 0000.0001) // RANGE J (Lo:Hi:Step):(     3:    -1:    -1)
 (PID.TID 0000.0001) // RANGE K (Lo:Hi:Step):(   1:   1:   1)
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // END OF FIELD                                          =
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) 
+(PID.TID 0000.0001) GAD_INIT_FIXED: GAD_OlMinSize=  1  0  1
 (PID.TID 0000.0001) 
 (PID.TID 0000.0001) // ===================================
 (PID.TID 0000.0001) // GAD parameters :
@@ -552,23 +634,24 @@
 (PID.TID 0000.0001) // ===================================
 (PID.TID 0000.0001) ------------------------------------------------------------
 (PID.TID 0000.0001) DIAGNOSTICS_SET_LEVELS: done
-(PID.TID 0000.0001)  Total Nb of available Diagnostics: ndiagt=   175
+(PID.TID 0000.0001)  Total Nb of available Diagnostics: ndiagt=   197
 (PID.TID 0000.0001)  write list of available Diagnostics to file: available_diagnostics.log
 (PID.TID 0000.0001) SETDIAG: Allocate 26 x  1 Levels for Diagnostic #    30 UVEL
 (PID.TID 0000.0001) SETDIAG: Allocate 26 x  1 Levels for Diagnostic #    31 VVEL
 (PID.TID 0000.0001) SETDIAG: Allocate 26 x  1 Levels for Diagnostic #    32 WVEL
 (PID.TID 0000.0001) SETDIAG: Allocate 26 x  1 Levels for Diagnostic #    26 THETA
-(PID.TID 0000.0001) SETDIAG: Allocate 26 x  1 Levels for Diagnostic #    67 PHIHYD
-(PID.TID 0000.0001) SETDIAG: Allocate 26 x  1 Levels for Diagnostic #   101 DFrI_TH
-(PID.TID 0000.0001) SETDIAG: Allocate 26 x  1 Levels for Diagnostic #   171 GGL90TKE
-(PID.TID 0000.0001) SETDIAG: Allocate 26 x  1 Levels for Diagnostic #   172 GGL90Lmx
-(PID.TID 0000.0001) SETDIAG: Allocate 26 x  1 Levels for Diagnostic #   175 GGL90Kr
-(PID.TID 0000.0001) SETDIAG: Allocate 26 x  1 Levels for Diagnostic #   174 GGL90Ar
-(PID.TID 0000.0001) SETDIAG: Allocate 26 x  1 Levels for Diagnostic #   173 GGL90Prl
-(PID.TID 0000.0001) SETDIAG: Allocate  1 x  1 Levels for Diagnostic #    71 MXLDEPTH
-(PID.TID 0000.0001)   space allocated for all diagnostics:     287 levels
-(PID.TID 0000.0001)   set mate pointer for diag #    30  UVEL     , Parms: UU      MR , mate:    31
-(PID.TID 0000.0001)   set mate pointer for diag #    31  VVEL     , Parms: VV      MR , mate:    30
+(PID.TID 0000.0001) SETDIAG: Allocate 26 x  1 Levels for Diagnostic #    71 PHIHYD
+(PID.TID 0000.0001) SETDIAG: Allocate 26 x  1 Levels for Diagnostic #   115 DFrI_TH
+(PID.TID 0000.0001) SETDIAG: Allocate 26 x  1 Levels for Diagnostic #   190 GGL90TKE
+(PID.TID 0000.0001) SETDIAG: Allocate 26 x  1 Levels for Diagnostic #   191 GGL90Lmx
+(PID.TID 0000.0001) SETDIAG: Allocate 26 x  1 Levels for Diagnostic #   195 GGL90Kr
+(PID.TID 0000.0001) SETDIAG: Allocate 26 x  1 Levels for Diagnostic #   193 GGL90ArU
+(PID.TID 0000.0001) SETDIAG: Allocate 26 x  1 Levels for Diagnostic #   194 GGL90ArV
+(PID.TID 0000.0001) SETDIAG: Allocate 26 x  1 Levels for Diagnostic #   192 GGL90Prl
+(PID.TID 0000.0001) SETDIAG: Allocate  1 x  1 Levels for Diagnostic #    76 MXLDEPTH
+(PID.TID 0000.0001)   space allocated for all diagnostics:     313 levels
+(PID.TID 0000.0001)   set mate pointer for diag #    30  UVEL     , Parms: UUR     MR , mate:    31
+(PID.TID 0000.0001)   set mate pointer for diag #    31  VVEL     , Parms: VVR     MR , mate:    30
 (PID.TID 0000.0001) DIAGNOSTICS_SET_POINTERS: Set levels for Outp.Stream: dynDiag
 (PID.TID 0000.0001)  Levels:       1.   2.   3.   4.   5.   6.   7.   8.   9.  10.  11.  12.  13.  14.  15.  16.  17.  18.  19.  20.
 (PID.TID 0000.0001)  Levels:      21.  22.  23.  24.  25.  26.
@@ -581,9 +664,16 @@
 (PID.TID 0000.0001) ------------------------------------------------------------
 (PID.TID 0000.0001) DIAGSTATS_SET_REGIONS: define no region
 (PID.TID 0000.0001) ------------------------------------------------------------
-(PID.TID 0000.0001)   space allocated for all stats-diags:       0 levels
+(PID.TID 0000.0001) SETDIAG: Allocate 26 Levels for Stats-Diag #   190 GGL90TKE
+(PID.TID 0000.0001) SETDIAG: Allocate 26 Levels for Stats-Diag #   191 GGL90Lmx
+(PID.TID 0000.0001) SETDIAG: Allocate 26 Levels for Stats-Diag #   195 GGL90Kr
+(PID.TID 0000.0001) SETDIAG: Allocate 26 Levels for Stats-Diag #   193 GGL90ArU
+(PID.TID 0000.0001) SETDIAG: Allocate 26 Levels for Stats-Diag #   194 GGL90ArV
+(PID.TID 0000.0001) SETDIAG: Allocate 26 Levels for Stats-Diag #   192 GGL90Prl
+(PID.TID 0000.0001)   space allocated for all stats-diags:     156 levels
 (PID.TID 0000.0001) DIAGSTATS_SET_POINTERS: done
 (PID.TID 0000.0001) ------------------------------------------------------------
+(PID.TID 0000.0001) DIAGSTATS_INI_IO: open file: dynStDiag.0000000000.txt , unit=     9
 (PID.TID 0000.0001) %MON fCori_max                    =   1.4000000000000E-04
 (PID.TID 0000.0001) %MON fCori_min                    =   1.4000000000000E-04
 (PID.TID 0000.0001) %MON fCori_mean                   =   1.4000000000000E-04
@@ -607,10 +697,10 @@
 (PID.TID 0000.0001) buoyancyRelation = /* Type of relation to get Buoyancy */
 (PID.TID 0000.0001)               'OCEANIC'
 (PID.TID 0000.0001)     ;
-(PID.TID 0000.0001) fluidIsAir  =  /* fluid major constituent is Air */
+(PID.TID 0000.0001) fluidIsAir   =  /* fluid major constituent is Air */
 (PID.TID 0000.0001)                   F
 (PID.TID 0000.0001)     ;
-(PID.TID 0000.0001) fluidIsWater=  /* fluid major constituent is Water */
+(PID.TID 0000.0001) fluidIsWater =  /* fluid major constituent is Water */
 (PID.TID 0000.0001)                   T
 (PID.TID 0000.0001)     ;
 (PID.TID 0000.0001) usingPCoords =  /* use p (or p*) vertical coordinate */
@@ -622,52 +712,28 @@
 (PID.TID 0000.0001) tRef =   /* Reference temperature profile ( oC or K ) */
 (PID.TID 0000.0001)    26 @  1.000000000000000E+00              /* K =  1: 26 */
 (PID.TID 0000.0001)     ;
-(PID.TID 0000.0001) sRef =   /* Reference salinity profile ( psu ) */
+(PID.TID 0000.0001) sRef =   /* Reference salinity profile ( g/kg ) */
 (PID.TID 0000.0001)    26 @  3.500000000000000E+01              /* K =  1: 26 */
 (PID.TID 0000.0001)     ;
-(PID.TID 0000.0001) viscAh =   /* Lateral eddy viscosity ( m^2/s ) */
-(PID.TID 0000.0001)                 0.000000000000000E+00
-(PID.TID 0000.0001)     ;
-(PID.TID 0000.0001) viscAhMax =   /* Maximum lateral eddy viscosity ( m^2/s ) */
-(PID.TID 0000.0001)                 1.000000000000000E+21
-(PID.TID 0000.0001)     ;
-(PID.TID 0000.0001) viscAhGrid =   /* Grid dependent lateral eddy viscosity ( non-dim. ) */
-(PID.TID 0000.0001)                 0.000000000000000E+00
-(PID.TID 0000.0001)     ;
-(PID.TID 0000.0001) useFullLeith =   /* Use Full Form of Leith Viscosity on/off flag*/
+(PID.TID 0000.0001) useStrainTensionVisc= /* Use StrainTension Form of Viscous Operator */
 (PID.TID 0000.0001)                   F
 (PID.TID 0000.0001)     ;
-(PID.TID 0000.0001) useStrainTensionVisc =   /* Use StrainTension Form of Viscous Operator on/off flag*/
+(PID.TID 0000.0001) useVariableVisc = /* Use variable horizontal viscosity */
 (PID.TID 0000.0001)                   F
 (PID.TID 0000.0001)     ;
-(PID.TID 0000.0001) useAreaViscLength =   /* Use area for visc length instead of geom. mean*/
+(PID.TID 0000.0001) useHarmonicVisc = /* Use harmonic horizontal viscosity */
 (PID.TID 0000.0001)                   F
 (PID.TID 0000.0001)     ;
-(PID.TID 0000.0001) viscC2leith = /* Leith harmonic visc. factor (on grad(vort),non-dim.) */
+(PID.TID 0000.0001) useBiharmonicVisc= /* Use biharmonic horiz.  viscosity */
+(PID.TID 0000.0001)                   F
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) useSmag3D = /* Use isotropic 3-D Smagorinsky viscosity */
+(PID.TID 0000.0001)                   F
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) viscAh  =   /* Lateral harmonic viscosity ( m^2/s ) */
 (PID.TID 0000.0001)                 0.000000000000000E+00
 (PID.TID 0000.0001)     ;
-(PID.TID 0000.0001) viscC2leithD = /* Leith harmonic viscosity factor (on grad(div),non-dim.) */
-(PID.TID 0000.0001)                 0.000000000000000E+00
-(PID.TID 0000.0001)     ;
-(PID.TID 0000.0001) viscC2smag =   /* Smagorinsky harmonic viscosity factor (non-dim.) */
-(PID.TID 0000.0001)                 0.000000000000000E+00
-(PID.TID 0000.0001)     ;
-(PID.TID 0000.0001) viscA4 =   /* Lateral biharmonic viscosity ( m^4/s ) */
-(PID.TID 0000.0001)                 0.000000000000000E+00
-(PID.TID 0000.0001)     ;
-(PID.TID 0000.0001) viscA4Max =   /* Maximum biharmonic viscosity ( m^2/s ) */
-(PID.TID 0000.0001)                 1.000000000000000E+21
-(PID.TID 0000.0001)     ;
-(PID.TID 0000.0001) viscA4Grid =   /* Grid dependent biharmonic viscosity ( non-dim. ) */
-(PID.TID 0000.0001)                 0.000000000000000E+00
-(PID.TID 0000.0001)     ;
-(PID.TID 0000.0001) viscC4leith = /* Leith biharm viscosity factor (on grad(vort), non-dim.) */
-(PID.TID 0000.0001)                 0.000000000000000E+00
-(PID.TID 0000.0001)     ;
-(PID.TID 0000.0001) viscC4leithD = /* Leith biharm viscosity factor (on grad(div), non-dim.) */
-(PID.TID 0000.0001)                 0.000000000000000E+00
-(PID.TID 0000.0001)     ;
-(PID.TID 0000.0001) viscC4Smag = /* Smagorinsky biharm viscosity factor (non-dim) */
+(PID.TID 0000.0001) viscA4  =   /* Lateral biharmonic viscosity ( m^4/s ) */
 (PID.TID 0000.0001)                 0.000000000000000E+00
 (PID.TID 0000.0001)     ;
 (PID.TID 0000.0001) no_slip_sides =  /* Viscous BCs: No-slip sides */
@@ -682,11 +748,17 @@
 (PID.TID 0000.0001) no_slip_bottom =  /* Viscous BCs: No-slip bottom */
 (PID.TID 0000.0001)                   T
 (PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) bottomVisc_pCell = /* Partial-cell in bottom Visc. BC */
+(PID.TID 0000.0001)                   F
+(PID.TID 0000.0001)     ;
 (PID.TID 0000.0001) bottomDragLinear = /* linear bottom-drag coefficient ( m/s ) */
 (PID.TID 0000.0001)                 0.000000000000000E+00
 (PID.TID 0000.0001)     ;
 (PID.TID 0000.0001) bottomDragQuadratic = /* quadratic bottom-drag coefficient (-) */
 (PID.TID 0000.0001)                 0.000000000000000E+00
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) selectBotDragQuadr = /* select quadratic bottom drag options */
+(PID.TID 0000.0001)                      -1
 (PID.TID 0000.0001)     ;
 (PID.TID 0000.0001) diffKhT =   /* Laplacian diffusion of heat laterally ( m^2/s ) */
 (PID.TID 0000.0001)                 0.000000000000000E+00
@@ -718,13 +790,13 @@
 (PID.TID 0000.0001) diffKrBL79Ho = /* Turning depth for Bryan and Lewis 1979 ( m ) */
 (PID.TID 0000.0001)                -2.000000000000000E+03
 (PID.TID 0000.0001)     ;
-(PID.TID 0000.0001) ivdc_kappa = /* Implicit Vertical Diffusivity for Convection ( m^2/s ) */
+(PID.TID 0000.0001) ivdc_kappa = /* Implicit Vertical Diffusivity for Convection ( m^2/s) */
 (PID.TID 0000.0001)                 0.000000000000000E+00
 (PID.TID 0000.0001)     ;
 (PID.TID 0000.0001) hMixCriteria=  /* Criteria for mixed-layer diagnostic */
 (PID.TID 0000.0001)                -8.000000000000000E-01
 (PID.TID 0000.0001)     ;
-(PID.TID 0000.0001) dRhoSmall=  /* Parameter for mixed-layer diagnostic */
+(PID.TID 0000.0001) dRhoSmall =  /* Parameter for mixed-layer diagnostic */
 (PID.TID 0000.0001)                 1.000000000000000E-06
 (PID.TID 0000.0001)     ;
 (PID.TID 0000.0001) hMixSmooth=  /* Smoothing parameter for mixed-layer diagnostic */
@@ -733,16 +805,23 @@
 (PID.TID 0000.0001) eosType =  /* Type of Equation of State */
 (PID.TID 0000.0001)               'MDJWF '
 (PID.TID 0000.0001)     ;
-(PID.TID 0000.0001) tAlpha =   /* Linear EOS thermal expansion coefficient ( 1/oC ) */
-(PID.TID 0000.0001)                 1.234567000000000E+05
+(PID.TID 0000.0001) eosRefP0 = /* Reference atmospheric pressure for EOS ( Pa ) */
+(PID.TID 0000.0001)                 1.013250000000000E+05
 (PID.TID 0000.0001)     ;
-(PID.TID 0000.0001) sBeta =   /* Linear EOS haline contraction coefficient ( 1/psu ) */
-(PID.TID 0000.0001)                 1.234567000000000E+05
+(PID.TID 0000.0001) selectP_inEOS_Zc = /* select pressure to use in EOS (0,1,2,3) */
+(PID.TID 0000.0001)                       2
+(PID.TID 0000.0001)     0= -g*rhoConst*z ; 1= pRef (from tRef,sRef); 2= Hyd P ; 3= Hyd+NH P
 (PID.TID 0000.0001)     ;
-(PID.TID 0000.0001) rhonil =   /* Reference density ( kg/m^3 ) */
-(PID.TID 0000.0001)                 9.998000000000000E+02
+(PID.TID 0000.0001) surf_pRef = /* Surface reference pressure ( Pa ) */
+(PID.TID 0000.0001)                 1.013250000000000E+05
 (PID.TID 0000.0001)     ;
-(PID.TID 0000.0001) rhoConst =   /* Reference density ( kg/m^3 ) */
+(PID.TID 0000.0001) HeatCapacity_Cp =  /* Specific heat capacity ( J/kg/K ) */
+(PID.TID 0000.0001)                 3.994000000000000E+03
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) celsius2K = /* 0 degree Celsius converted to Kelvin ( K ) */
+(PID.TID 0000.0001)                 2.731500000000000E+02
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) rhoConst  = /* Reference density (Boussinesq)  ( kg/m^3 ) */
 (PID.TID 0000.0001)                 9.998000000000000E+02
 (PID.TID 0000.0001)     ;
 (PID.TID 0000.0001) rhoFacC = /* normalized Reference density @ cell-Center (-) */
@@ -751,7 +830,7 @@
 (PID.TID 0000.0001) rhoFacF = /* normalized Reference density @ W-Interface (-) */
 (PID.TID 0000.0001)    27 @  1.000000000000000E+00              /* K =  1: 27 */
 (PID.TID 0000.0001)     ;
-(PID.TID 0000.0001) rhoConstFresh =   /* Reference density ( kg/m^3 ) */
+(PID.TID 0000.0001) rhoConstFresh = /* Fresh-water reference density ( kg/m^3 ) */
 (PID.TID 0000.0001)                 9.998000000000000E+02
 (PID.TID 0000.0001)     ;
 (PID.TID 0000.0001) gravity =   /* Gravitational acceleration ( m/s^2 ) */
@@ -759,6 +838,12 @@
 (PID.TID 0000.0001)     ;
 (PID.TID 0000.0001) gBaro =   /* Barotropic gravity ( m/s^2 ) */
 (PID.TID 0000.0001)                 9.810000000000000E+00
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) gravFacC = /* gravity factor (vs surf.) @ cell-Center (-) */
+(PID.TID 0000.0001)    26 @  1.000000000000000E+00              /* K =  1: 26 */
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) gravFacF = /* gravity factor (vs surf.) @ W-Interface (-) */
+(PID.TID 0000.0001)    27 @  1.000000000000000E+00              /* K =  1: 27 */
 (PID.TID 0000.0001)     ;
 (PID.TID 0000.0001) rotationPeriod =   /* Rotation Period ( s ) */
 (PID.TID 0000.0001)                 8.616400000000000E+04
@@ -772,44 +857,53 @@
 (PID.TID 0000.0001) beta =   /* Beta ( 1/(m.s) ) */
 (PID.TID 0000.0001)                 0.000000000000000E+00
 (PID.TID 0000.0001)     ;
-(PID.TID 0000.0001) freeSurfFac =   /* Implicit free surface factor */
-(PID.TID 0000.0001)                 1.000000000000000E+00
-(PID.TID 0000.0001)     ;
-(PID.TID 0000.0001) implicitFreeSurface =   /* Implicit free surface on/off flag */
-(PID.TID 0000.0001)                   T
+(PID.TID 0000.0001) fPrime =   /* Second coriolis parameter ( 1/s ) */
+(PID.TID 0000.0001)                 0.000000000000000E+00
 (PID.TID 0000.0001)     ;
 (PID.TID 0000.0001) rigidLid =   /* Rigid lid on/off flag */
 (PID.TID 0000.0001)                   F
 (PID.TID 0000.0001)     ;
-(PID.TID 0000.0001) implicSurfPress =   /* Surface Pressure implicit factor (0-1)*/
-(PID.TID 0000.0001)                 1.000000000000000E+00
-(PID.TID 0000.0001)     ;
-(PID.TID 0000.0001) implicDiv2Dflow =   /* Barot. Flow Div. implicit factor (0-1)*/
-(PID.TID 0000.0001)                 1.000000000000000E+00
-(PID.TID 0000.0001)     ;
-(PID.TID 0000.0001) exactConserv =   /* Exact Volume Conservation on/off flag*/
-(PID.TID 0000.0001)                   F
-(PID.TID 0000.0001)     ;
-(PID.TID 0000.0001) linFSConserveTr =   /* Tracer correction for Lin Free Surface on/off flag*/
-(PID.TID 0000.0001)                   F
-(PID.TID 0000.0001)     ;
-(PID.TID 0000.0001) uniformLin_PhiSurf =   /* use uniform Bo_surf on/off flag*/
+(PID.TID 0000.0001) implicitFreeSurface =   /* Implicit free surface on/off flag */
 (PID.TID 0000.0001)                   T
 (PID.TID 0000.0001)     ;
-(PID.TID 0000.0001) nonlinFreeSurf =   /* Non-linear Free Surf. options (-1,0,1,2,3)*/
-(PID.TID 0000.0001)                       0
+(PID.TID 0000.0001) freeSurfFac =   /* Implicit free surface factor */
+(PID.TID 0000.0001)                 1.000000000000000E+00
 (PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) implicSurfPress =  /* Surface Pressure implicit factor (0-1)*/
+(PID.TID 0000.0001)                 1.000000000000000E+00
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) implicDiv2DFlow =  /* Barot. Flow Div. implicit factor (0-1)*/
+(PID.TID 0000.0001)                 1.000000000000000E+00
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) uniformLin_PhiSurf = /* use uniform Bo_surf on/off flag*/
+(PID.TID 0000.0001)                   T
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) uniformFreeSurfLev = /* free-surface level-index is uniform */
+(PID.TID 0000.0001)                   T
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) hFacMin =   /* minimum partial cell factor (hFac) */
+(PID.TID 0000.0001)                 5.000000000000000E-02
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) hFacMinDr = /* minimum partial cell thickness ( m) */
+(PID.TID 0000.0001)                 0.000000000000000E+00
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) exactConserv =  /* Exact Volume Conservation on/off flag*/
+(PID.TID 0000.0001)                   F
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) linFSConserveTr = /* Tracer correction for Lin Free Surface on/off flag*/
+(PID.TID 0000.0001)                   F
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) nonlinFreeSurf = /* Non-linear Free Surf. options (-1,0,1,2,3)*/
+(PID.TID 0000.0001)                       0
 (PID.TID 0000.0001)      -1,0= Off ; 1,2,3= On, 2=+rescale gU,gV, 3=+update cg2d solv.
+(PID.TID 0000.0001)     ;
 (PID.TID 0000.0001) hFacInf =   /* lower threshold for hFac (nonlinFreeSurf only)*/
 (PID.TID 0000.0001)                 2.000000000000000E-01
 (PID.TID 0000.0001)     ;
 (PID.TID 0000.0001) hFacSup =   /* upper threshold for hFac (nonlinFreeSurf only)*/
 (PID.TID 0000.0001)                 2.000000000000000E+00
 (PID.TID 0000.0001)     ;
-(PID.TID 0000.0001) select_rStar = /* r* Vertical coord. options (=0 r coord.; > 0 uses r*) */
-(PID.TID 0000.0001)                       0
-(PID.TID 0000.0001)     ;
-(PID.TID 0000.0001) selectAddFluid = /* option for mass source/sink of fluid (=0: off) */
+(PID.TID 0000.0001) select_rStar = /* r* Vertical coord. options (=0 r coord.; >0 uses r*)*/
 (PID.TID 0000.0001)                       0
 (PID.TID 0000.0001)     ;
 (PID.TID 0000.0001) useRealFreshWaterFlux = /* Real Fresh Water Flux on/off flag*/
@@ -818,10 +912,19 @@
 (PID.TID 0000.0001) temp_EvPrRn = /* Temp. of Evap/Prec/R (UNSET=use local T)(oC)*/
 (PID.TID 0000.0001)                 1.234567000000000E+05
 (PID.TID 0000.0001)     ;
-(PID.TID 0000.0001) salt_EvPrRn = /* Salin. of Evap/Prec/R (UNSET=use local S)(ppt)*/
+(PID.TID 0000.0001) salt_EvPrRn = /* Salin. of Evap/Prec/R (UNSET=use local S)(g/kg)*/
 (PID.TID 0000.0001)                 0.000000000000000E+00
 (PID.TID 0000.0001)     ;
-(PID.TID 0000.0001) convertFW2Salt = /* convert F.W. Flux to Salt Flux (-1=use local S)(ppt)*/
+(PID.TID 0000.0001) selectAddFluid = /* option for mass source/sink of fluid (=0: off) */
+(PID.TID 0000.0001)                       0
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) temp_addMass = /* Temp. of addMass array (UNSET=use local T)(oC)*/
+(PID.TID 0000.0001)                 1.234567000000000E+05
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) salt_addMass = /* Salin. of addMass array (UNSET=use local S)(g/kg)*/
+(PID.TID 0000.0001)                 0.000000000000000E+00
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) convertFW2Salt = /* convert F.W. Flux to Salt Flux (-1=use local S)(g/kg)*/
 (PID.TID 0000.0001)                 3.500000000000000E+01
 (PID.TID 0000.0001)     ;
 (PID.TID 0000.0001) use3Dsolver = /* use 3-D pressure solver on/off flag */
@@ -833,8 +936,17 @@
 (PID.TID 0000.0001) nh_Am2 = /* Non-Hydrostatic terms scaling factor */
 (PID.TID 0000.0001)                 1.000000000000000E+00
 (PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) implicitNHPress = /* Non-Hyd Pressure implicit factor (0-1)*/
+(PID.TID 0000.0001)                 1.000000000000000E+00
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) selectNHfreeSurf = /* Non-Hyd (free-)Surface option */
+(PID.TID 0000.0001)                       0
+(PID.TID 0000.0001)     ;
 (PID.TID 0000.0001) quasiHydrostatic = /* Quasi-Hydrostatic on/off flag */
 (PID.TID 0000.0001)                   F
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) calc_wVelocity = /* vertical velocity calculation on/off flag */
+(PID.TID 0000.0001)                   T
 (PID.TID 0000.0001)     ;
 (PID.TID 0000.0001) momStepping =  /* Momentum equation on/off flag */
 (PID.TID 0000.0001)                   T
@@ -848,11 +960,15 @@
 (PID.TID 0000.0001) momViscosity =  /* Momentum viscosity on/off flag */
 (PID.TID 0000.0001)                   T
 (PID.TID 0000.0001)     ;
-(PID.TID 0000.0001) momImplVertAdv =/* Momentum implicit vert. advection on/off*/
+(PID.TID 0000.0001) momImplVertAdv= /* Momentum implicit vert. advection on/off*/
 (PID.TID 0000.0001)                   F
 (PID.TID 0000.0001)     ;
 (PID.TID 0000.0001) implicitViscosity = /* Implicit viscosity on/off flag */
 (PID.TID 0000.0001)                   T
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) selectImplicitDrag= /* Implicit bot Drag options (0,1,2)*/
+(PID.TID 0000.0001)                       0
+(PID.TID 0000.0001)     0= Expl. ; 1= Impl. on provis. Vel ; 2= Fully Impl (with surf.P)
 (PID.TID 0000.0001)     ;
 (PID.TID 0000.0001) metricTerms =  /* metric-Terms on/off flag */
 (PID.TID 0000.0001)                   F
@@ -860,14 +976,9 @@
 (PID.TID 0000.0001) useNHMTerms = /* Non-Hydrostatic Metric-Terms on/off */
 (PID.TID 0000.0001)                   F
 (PID.TID 0000.0001)     ;
-(PID.TID 0000.0001) useConstantF =  /* use Constant f0 Coriolis flag */
-(PID.TID 0000.0001)                   F
-(PID.TID 0000.0001)     ;
-(PID.TID 0000.0001) useBetaPlaneF = /* use Beta-Plane Coriolis flag */
-(PID.TID 0000.0001)                   T
-(PID.TID 0000.0001)     ;
-(PID.TID 0000.0001) useSphereF  =   /* use Spherical Coriolis flag */
-(PID.TID 0000.0001)                   F
+(PID.TID 0000.0001) selectCoriMap = /* Coriolis Map options (0,1,2,3)*/
+(PID.TID 0000.0001)                       1
+(PID.TID 0000.0001)     0= f-Plane ; 1= Beta-Plane ; 2= Spherical ; 3= read from file
 (PID.TID 0000.0001)     ;
 (PID.TID 0000.0001) use3dCoriolis = /* 3-D Coriolis on/off flag */
 (PID.TID 0000.0001)                   F
@@ -878,36 +989,17 @@
 (PID.TID 0000.0001) useCDscheme =  /* CD scheme on/off flag */
 (PID.TID 0000.0001)                   F
 (PID.TID 0000.0001)     ;
-(PID.TID 0000.0001) useJamartWetPoints= /* Coriolis WetPoints method flag */
-(PID.TID 0000.0001)                   F
-(PID.TID 0000.0001)     ;
-(PID.TID 0000.0001) useJamartMomAdv= /* V.I. Non-linear terms Jamart flag */
-(PID.TID 0000.0001)                   F
-(PID.TID 0000.0001)     ;
-(PID.TID 0000.0001) useAbsVorticity= /* Work with f+zeta in Coriolis */
-(PID.TID 0000.0001)                   F
-(PID.TID 0000.0001)     ;
-(PID.TID 0000.0001) selectVortScheme= /* Scheme selector for Vorticity-Term */
-(PID.TID 0000.0001)               123456789
-(PID.TID 0000.0001)    = 0 : enstrophy (Shallow-Water Eq.) conserving scheme by Sadourny, JAS 75
-(PID.TID 0000.0001)    = 1 : same as 0 with modified hFac
-(PID.TID 0000.0001)    = 2 : energy conserving scheme (used by Sadourny in JAS 75 paper)
-(PID.TID 0000.0001)    = 3 : energy (general) and enstrophy (2D, nonDiv.) conserving scheme
-(PID.TID 0000.0001)          from Sadourny (Burridge & Haseler, ECMWF Rep.4, 1977)
-(PID.TID 0000.0001)     ;
-(PID.TID 0000.0001) upwindVorticity= /* Upwind bias vorticity flag */
-(PID.TID 0000.0001)                   F
-(PID.TID 0000.0001)     ;
-(PID.TID 0000.0001) highOrderVorticity= /* High order interp. of vort. flag */
-(PID.TID 0000.0001)                   F
-(PID.TID 0000.0001)     ;
-(PID.TID 0000.0001) upwindShear= /* Upwind vertical Shear advection flag */
-(PID.TID 0000.0001)                   F
-(PID.TID 0000.0001)     ;
-(PID.TID 0000.0001) selectKEscheme= /* Kinetic Energy scheme selector */
+(PID.TID 0000.0001) selectCoriScheme= /* Scheme selector for Coriolis-Term */
 (PID.TID 0000.0001)                       0
+(PID.TID 0000.0001)    = 0 : original discretization (simple averaging, no hFac)
+(PID.TID 0000.0001)    = 1 : Wet-point averaging (Jamar & Ozer 1986)
+(PID.TID 0000.0001)    = 2 : energy conserving scheme (no hFac weight)
+(PID.TID 0000.0001)    = 3 : energy conserving scheme using Wet-point averaging
 (PID.TID 0000.0001)     ;
 (PID.TID 0000.0001) momForcing =  /* Momentum forcing on/off flag */
+(PID.TID 0000.0001)                   T
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) momTidalForcing = /* Momentum Tidal forcing on/off flag */
 (PID.TID 0000.0001)                   T
 (PID.TID 0000.0001)     ;
 (PID.TID 0000.0001) momPressureForcing =  /* Momentum pressure term on/off flag */
@@ -916,29 +1008,35 @@
 (PID.TID 0000.0001) implicitIntGravWave= /* Implicit Internal Gravity Wave flag */
 (PID.TID 0000.0001)                   F
 (PID.TID 0000.0001)     ;
-(PID.TID 0000.0001) staggerTimeStep =   /* Stagger time stepping on/off flag */
+(PID.TID 0000.0001) staggerTimeStep =    /* Stagger time stepping on/off flag */
 (PID.TID 0000.0001)                   F
 (PID.TID 0000.0001)     ;
-(PID.TID 0000.0001) multiDimAdvection =   /* enable/disable Multi-Dim Advection */
+(PID.TID 0000.0001) doResetHFactors = /* reset thickness factors @ each time-step */
+(PID.TID 0000.0001)                   F
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) multiDimAdvection =  /* enable/disable Multi-Dim Advection */
 (PID.TID 0000.0001)                   T
 (PID.TID 0000.0001)     ;
 (PID.TID 0000.0001) useMultiDimAdvec =   /* Multi-Dim Advection is/is-not used */
 (PID.TID 0000.0001)                   F
 (PID.TID 0000.0001)     ;
-(PID.TID 0000.0001) implicitDiffusion =/* Implicit Diffusion on/off flag */
+(PID.TID 0000.0001) implicitDiffusion = /* Implicit Diffusion on/off flag */
 (PID.TID 0000.0001)                   T
 (PID.TID 0000.0001)     ;
 (PID.TID 0000.0001) tempStepping =  /* Temperature equation on/off flag */
 (PID.TID 0000.0001)                   T
 (PID.TID 0000.0001)     ;
-(PID.TID 0000.0001) tempAdvection=  /* Temperature advection on/off flag */
+(PID.TID 0000.0001) tempAdvection = /* Temperature advection on/off flag */
 (PID.TID 0000.0001)                   F
 (PID.TID 0000.0001)     ;
-(PID.TID 0000.0001) tempImplVertAdv =/* Temp. implicit vert. advection on/off */
+(PID.TID 0000.0001) tempImplVertAdv = /* Temp. implicit vert. advection on/off */
 (PID.TID 0000.0001)                   F
 (PID.TID 0000.0001)     ;
 (PID.TID 0000.0001) tempForcing  =  /* Temperature forcing on/off flag */
 (PID.TID 0000.0001)                   T
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) doThetaClimRelax = /* apply SST relaxation on/off flag */
+(PID.TID 0000.0001)                   F
 (PID.TID 0000.0001)     ;
 (PID.TID 0000.0001) tempIsActiveTr = /* Temp. is a dynamically Active Tracer */
 (PID.TID 0000.0001)                   F
@@ -946,14 +1044,17 @@
 (PID.TID 0000.0001) saltStepping =  /* Salinity equation on/off flag */
 (PID.TID 0000.0001)                   T
 (PID.TID 0000.0001)     ;
-(PID.TID 0000.0001) saltAdvection=  /* Salinity advection on/off flag */
+(PID.TID 0000.0001) saltAdvection = /* Salinity advection on/off flag */
 (PID.TID 0000.0001)                   T
 (PID.TID 0000.0001)     ;
-(PID.TID 0000.0001) saltImplVertAdv =/* Sali. implicit vert. advection on/off */
+(PID.TID 0000.0001) saltImplVertAdv = /* Sali. implicit vert. advection on/off */
 (PID.TID 0000.0001)                   F
 (PID.TID 0000.0001)     ;
 (PID.TID 0000.0001) saltForcing  =  /* Salinity forcing on/off flag */
 (PID.TID 0000.0001)                   T
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) doSaltClimRelax = /* apply SSS relaxation on/off flag */
+(PID.TID 0000.0001)                   F
 (PID.TID 0000.0001)     ;
 (PID.TID 0000.0001) saltIsActiveTr = /* Salt  is a dynamically Active Tracer */
 (PID.TID 0000.0001)                   T
@@ -964,23 +1065,33 @@
 (PID.TID 0000.0001) writeBinaryPrec = /* Precision used for writing binary files */
 (PID.TID 0000.0001)                      32
 (PID.TID 0000.0001)     ;
+(PID.TID 0000.0001)  rwSuffixType =   /* select format of mds file suffix */
+(PID.TID 0000.0001)                       0
+(PID.TID 0000.0001)    = 0 : myIter (I10.10) ;   = 1 : 100*myTime (100th sec) ;
+(PID.TID 0000.0001)    = 2 : myTime (seconds);   = 3 : myTime/360 (10th of hr);
+(PID.TID 0000.0001)    = 4 : myTime/3600 (hours)
+(PID.TID 0000.0001)     ;
 (PID.TID 0000.0001)  globalFiles = /* write "global" (=not per tile) files */
 (PID.TID 0000.0001)                   F
 (PID.TID 0000.0001)     ;
 (PID.TID 0000.0001)  useSingleCpuIO = /* only master MPI process does I/O */
 (PID.TID 0000.0001)                   F
 (PID.TID 0000.0001)     ;
-(PID.TID 0000.0001)  debugMode  =  /* Debug Mode on/off flag */
+(PID.TID 0000.0001)  useSingleCpuInput = /* only master process reads input */
 (PID.TID 0000.0001)                   F
 (PID.TID 0000.0001)     ;
-(PID.TID 0000.0001)    debLevA  =  /* 1rst level of debugging */
-(PID.TID 0000.0001)                       1
-(PID.TID 0000.0001)     ;
-(PID.TID 0000.0001)    debLevB  =  /* 2nd  level of debugging */
+(PID.TID 0000.0001) /* debLev[*]  : level of debug & auxiliary message printing */
+(PID.TID 0000.0001) debLevZero =  0 ; /* level of disabled aux. msg printing */
+(PID.TID 0000.0001)    debLevA =  1 ; /* level of minimum  aux. msg printing */
+(PID.TID 0000.0001)    debLevB =  2 ; /* level of low aux. print (report read-file opening)*/
+(PID.TID 0000.0001)    debLevC =  3 ; /* level of moderate debug prt (most pkgs debug msg) */
+(PID.TID 0000.0001)    debLevD =  4 ; /* level of enhanced debug prt (add DEBUG_STATS prt) */
+(PID.TID 0000.0001)    debLevE =  5 ; /* level of extensive debug printing */
+(PID.TID 0000.0001) debugLevel =  /* select debug printing level */
 (PID.TID 0000.0001)                       2
 (PID.TID 0000.0001)     ;
-(PID.TID 0000.0001)  debugLevel =  /* select debugging level */
-(PID.TID 0000.0001)                       1
+(PID.TID 0000.0001)  plotLevel =  /* select PLOT_FIELD printing level */
+(PID.TID 0000.0001)                       2
 (PID.TID 0000.0001)     ;
 (PID.TID 0000.0001) //
 (PID.TID 0000.0001) // Elliptic solver(s) paramters ( PARM02 in namelist )
@@ -989,6 +1100,9 @@
 (PID.TID 0000.0001)                     300
 (PID.TID 0000.0001)     ;
 (PID.TID 0000.0001) cg2dChkResFreq =   /* 2d con. grad convergence test frequency */
+(PID.TID 0000.0001)                       1
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) cg2dUseMinResSol= /* use cg2d last-iter(=0) / min-resid.(=1) solution */
 (PID.TID 0000.0001)                       1
 (PID.TID 0000.0001)     ;
 (PID.TID 0000.0001) cg2dTargetResidual =   /* 2d con. grad target residual  */
@@ -1000,13 +1114,19 @@
 (PID.TID 0000.0001) cg2dPreCondFreq =   /* Freq. for updating cg2d preconditioner */
 (PID.TID 0000.0001)                       1
 (PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) useSRCGSolver =  /* use single reduction CG solver(s) */
+(PID.TID 0000.0001)                   F
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) printResidualFreq = /* Freq. for printing CG residual */
+(PID.TID 0000.0001)                       0
+(PID.TID 0000.0001)     ;
 (PID.TID 0000.0001) //
 (PID.TID 0000.0001) // Time stepping paramters ( PARM03 in namelist )
 (PID.TID 0000.0001) //
-(PID.TID 0000.0001) deltaTmom =   /* Momentum equation timestep ( s ) */
+(PID.TID 0000.0001) deltaTMom =   /* Momentum equation timestep ( s ) */
 (PID.TID 0000.0001)                 1.200000000000000E+03
 (PID.TID 0000.0001)     ;
-(PID.TID 0000.0001) deltaTfreesurf = /* FreeSurface equation timestep ( s ) */
+(PID.TID 0000.0001) deltaTFreeSurf = /* FreeSurface equation timestep ( s ) */
 (PID.TID 0000.0001)                 1.200000000000000E+03
 (PID.TID 0000.0001)     ;
 (PID.TID 0000.0001) dTtracerLev =  /* Tracer equation timestep ( s ) */
@@ -1033,28 +1153,34 @@
 (PID.TID 0000.0001) abEps =   /* Adams-Bashforth-2 stabilizing weight */
 (PID.TID 0000.0001)                 1.000000000000000E-02
 (PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) applyExchUV_early = /* Apply EXCH to U,V earlier in time-step */
+(PID.TID 0000.0001)                   F
+(PID.TID 0000.0001)     ;
 (PID.TID 0000.0001) pickupStrictlyMatch= /* stop if pickup do not strictly match */
 (PID.TID 0000.0001)                   T
 (PID.TID 0000.0001)     ;
-(PID.TID 0000.0001) nIter0 =   /* Run starting timestep number  */
+(PID.TID 0000.0001) nIter0   =   /* Run starting timestep number */
 (PID.TID 0000.0001)                       0
 (PID.TID 0000.0001)     ;
-(PID.TID 0000.0001) nTimeSteps =   /* Number of timesteps */
+(PID.TID 0000.0001) nTimeSteps = /* Number of timesteps */
 (PID.TID 0000.0001)                      20
 (PID.TID 0000.0001)     ;
-(PID.TID 0000.0001) baseTime =   /* Model base time ( s ). */
+(PID.TID 0000.0001) nEndIter =   /* Run ending timestep number */
+(PID.TID 0000.0001)                      20
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) baseTime =   /* Model base time ( s ) */
 (PID.TID 0000.0001)                 0.000000000000000E+00
 (PID.TID 0000.0001)     ;
-(PID.TID 0000.0001) startTime =   /* Run start time ( s ). */
+(PID.TID 0000.0001) startTime =  /* Run start time ( s ) */
 (PID.TID 0000.0001)                 0.000000000000000E+00
 (PID.TID 0000.0001)     ;
-(PID.TID 0000.0001) endTime =   /* Integration ending time ( s ). */
+(PID.TID 0000.0001) endTime  =   /* Integration ending time ( s ) */
 (PID.TID 0000.0001)                 2.400000000000000E+04
 (PID.TID 0000.0001)     ;
-(PID.TID 0000.0001) pChkPtFreq =   /* Permanent restart/checkpoint file interval ( s ). */
+(PID.TID 0000.0001) pChkPtFreq = /* Permanent restart/pickup file interval ( s ) */
 (PID.TID 0000.0001)                 6.220800000000000E+07
 (PID.TID 0000.0001)     ;
-(PID.TID 0000.0001) chkPtFreq =   /* Rolling restart/checkpoint file interval ( s ). */
+(PID.TID 0000.0001) chkPtFreq  = /* Rolling restart/pickup file interval ( s ) */
 (PID.TID 0000.0001)                 0.000000000000000E+00
 (PID.TID 0000.0001)     ;
 (PID.TID 0000.0001) pickup_write_mdsio =   /* Model IO flag. */
@@ -1067,9 +1193,6 @@
 (PID.TID 0000.0001)                   F
 (PID.TID 0000.0001)     ;
 (PID.TID 0000.0001) pickup_read_mnc =   /* Model IO flag. */
-(PID.TID 0000.0001)                   F
-(PID.TID 0000.0001)     ;
-(PID.TID 0000.0001) pickup_write_immed =   /* Model IO flag. */
 (PID.TID 0000.0001)                   F
 (PID.TID 0000.0001)     ;
 (PID.TID 0000.0001) writePickupAtEnd =   /* Model IO flag. */
@@ -1129,14 +1252,35 @@
 (PID.TID 0000.0001) usingCurvilinearGrid = /* Curvilinear coordinates flag ( True/False ) */
 (PID.TID 0000.0001)                   F
 (PID.TID 0000.0001)     ;
-(PID.TID 0000.0001) Ro_SeaLevel = /* r(1) ( units of r ==  m ) */
-(PID.TID 0000.0001)                 0.000000000000000E+00
+(PID.TID 0000.0001) useMin4hFacEdges = /* set hFacW,S as minimum of adjacent hFacC factor */
+(PID.TID 0000.0001)                   F
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) interViscAr_pCell = /* account for partial-cell in interior vert. viscosity */
+(PID.TID 0000.0001)                   F
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) interDiffKr_pCell = /* account for partial-cell in interior vert. diffusion */
+(PID.TID 0000.0001)                   F
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) pCellMix_select = /* option to enhance mixing near surface & bottom */
+(PID.TID 0000.0001)                       0
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) selectSigmaCoord = /* Hybrid-Sigma Vert. Coordinate option */
+(PID.TID 0000.0001)                       0
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) rSigmaBnd = /* r/sigma transition ( units of r ==  m ) */
+(PID.TID 0000.0001)                 1.234567000000000E+05
 (PID.TID 0000.0001)     ;
 (PID.TID 0000.0001) rkSign =   /* index orientation relative to vertical coordinate */
 (PID.TID 0000.0001)                -1.000000000000000E+00
 (PID.TID 0000.0001)     ;
 (PID.TID 0000.0001) gravitySign = /* gravity orientation relative to vertical coordinate */
 (PID.TID 0000.0001)                -1.000000000000000E+00
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) seaLev_Z =  /* reference height of sea-level [m] */
+(PID.TID 0000.0001)                 0.000000000000000E+00
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) top_Pres =  /* reference pressure at the top [Pa] */
+(PID.TID 0000.0001)                 0.000000000000000E+00
 (PID.TID 0000.0001)     ;
 (PID.TID 0000.0001) mass2rUnit = /* convert mass per unit area [kg/m2] to r-units [m] */
 (PID.TID 0000.0001)                 1.000200040008002E-03
@@ -1158,7 +1302,8 @@
 (PID.TID 0000.0001)                 2.900000000000000E+01,      /* K = 14 */
 (PID.TID 0000.0001)                 3.300000000000000E+01,      /* K = 15 */
 (PID.TID 0000.0001)                 3.750000000000000E+01,      /* K = 16 */
-(PID.TID 0000.0001)    10 @  4.000000000000000E+01              /* K = 17: 26 */
+(PID.TID 0000.0001)    10 @  4.000000000000000E+01,             /* K = 17: 26 */
+(PID.TID 0000.0001)                 2.000000000000000E+01       /* K = 27 */
 (PID.TID 0000.0001)     ;
 (PID.TID 0000.0001) drF =   /* W spacing ( units of r ) */
 (PID.TID 0000.0001)     5 @  1.000000000000000E+01,             /* K =  1:  5 */
@@ -1180,10 +1325,10 @@
 (PID.TID 0000.0001) delY = /* V spacing ( m - cartesian, degrees - spherical ) */
 (PID.TID 0000.0001)                 5.000000000000000E+03       /* J =  1 */
 (PID.TID 0000.0001)     ;
-(PID.TID 0000.0001) xgOrigin = /* X-axis origin of West  edge (cartesian: m, lat-lon: deg.) */
+(PID.TID 0000.0001) xgOrigin = /* X-axis origin of West  edge (cartesian: m, lat-lon: deg) */
 (PID.TID 0000.0001)                 0.000000000000000E+00
 (PID.TID 0000.0001)     ;
-(PID.TID 0000.0001) ygOrigin = /* Y-axis origin of South edge (cartesian: m, lat-lon: deg.) */
+(PID.TID 0000.0001) ygOrigin = /* Y-axis origin of South edge (cartesian: m, lat-lon: deg) */
 (PID.TID 0000.0001)                 0.000000000000000E+00
 (PID.TID 0000.0001)     ;
 (PID.TID 0000.0001) rSphere =  /* Radius ( ignored - cartesian, m - spherical ) */
@@ -1267,7 +1412,7 @@
 (PID.TID 0000.0001) wUnit2rVel = /* convert units: wSpeed -> rVel (=1 if z-coord)*/
 (PID.TID 0000.0001)    27 @  1.000000000000000E+00              /* K =  1: 27 */
 (PID.TID 0000.0001)     ;
-(PID.TID 0000.0001) dBdrRef = /* Vertical gradient of reference boyancy [(m/s/r)^2)] */
+(PID.TID 0000.0001) dBdrRef = /* Vertical grad. of reference buoyancy [(m/s/r)^2] */
 (PID.TID 0000.0001)    26 @  0.000000000000000E+00              /* K =  1: 26 */
 (PID.TID 0000.0001)     ;
 (PID.TID 0000.0001) rotateGrid = /* use rotated grid ( True/False ) */
@@ -1357,9 +1502,10 @@
 (PID.TID 0000.0001) 
 (PID.TID 0000.0001) == Packages configuration : Check & print summary ==
 (PID.TID 0000.0001) 
-(PID.TID 0000.0001) GAD_CHECK: #define ALLOW_GENERIC_ADVDIFF
 (PID.TID 0000.0001) GGL90_CHECK: #define ALLOW_GGL90
+(PID.TID 0000.0001) GAD_CHECK: #define ALLOW_GENERIC_ADVDIFF
 (PID.TID 0000.0001) // =======================================================
+(PID.TID 0000.0001) // Check Model config. (CONFIG_CHECK):
 (PID.TID 0000.0001) // CONFIG_CHECK : Normal End
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) 
@@ -1371,15 +1517,6 @@
 (PID.TID 0000.0001) Iteration   4, RMS-difference =  6.784304060020E-08
 (PID.TID 0000.0001) Iteration   5, RMS-difference =  3.857422717032E-11
 (PID.TID 0000.0001) Iteration   6, RMS-difference =  0.000000000000E+00
-(PID.TID 0000.0001) Iteration   7, RMS-difference =  0.000000000000E+00
-(PID.TID 0000.0001) Iteration   8, RMS-difference =  0.000000000000E+00
-(PID.TID 0000.0001) Iteration   9, RMS-difference =  0.000000000000E+00
-(PID.TID 0000.0001) Iteration  10, RMS-difference =  0.000000000000E+00
-(PID.TID 0000.0001) Iteration  11, RMS-difference =  0.000000000000E+00
-(PID.TID 0000.0001) Iteration  12, RMS-difference =  0.000000000000E+00
-(PID.TID 0000.0001) Iteration  13, RMS-difference =  0.000000000000E+00
-(PID.TID 0000.0001) Iteration  14, RMS-difference =  0.000000000000E+00
-(PID.TID 0000.0001) Iteration  15, RMS-difference =  0.000000000000E+00
 (PID.TID 0000.0001) Initial hydrostatic pressure converged.
 (PID.TID 0000.0001) 
 (PID.TID 0000.0001)  MDS_READ_FIELD: opening global file: taux_72.forcing
@@ -1399,29 +1536,42 @@ listId=    1 ; file name: dynDiag
     31 |VVEL    |     27 |      1 |  26 |       0 |       0 |
     32 |WVEL    |     53 |      0 |  26 |       0 |
     26 |THETA   |     79 |      0 |  26 |       0 |
-    67 |PHIHYD  |    105 |      0 |  26 |       0 |
-   101 |DFrI_TH |    131 |      0 |  26 |       0 |
+    71 |PHIHYD  |    105 |      0 |  26 |       0 |
+   115 |DFrI_TH |    131 |      0 |  26 |       0 |
 ------------------------------------------------------------------------
 listId=    2 ; file name: DiagMXL_3d
  nFlds, nActive,       freq     &     phase        , nLev               
-    5  |    5  |    432000.000000         0.000000 |  26
+    6  |    6  |    432000.000000         0.000000 |  26
  levels:   1   2   3   4   5   6   7   8   9  10  11  12  13  14  15  16  17  18  19  20  21  22  23  24  25
  levels:  26
  diag# | name   |   ipt  |  iMate | kLev|   count |   mate.C|           
-   171 |GGL90TKE|    157 |      0 |  26 |       0 |
-   172 |GGL90Lmx|    183 |      0 |  26 |       0 |
-   175 |GGL90Kr |    209 |      0 |  26 |       0 |
-   174 |GGL90Ar |    235 |      0 |  26 |       0 |
-   173 |GGL90Prl|    261 |      0 |  26 |       0 |
+   190 |GGL90TKE|    157 |      0 |  26 |       0 |
+   191 |GGL90Lmx|    183 |      0 |  26 |       0 |
+   195 |GGL90Kr |    209 |      0 |  26 |       0 |
+   193 |GGL90ArU|    235 |      0 |  26 |       0 |
+   194 |GGL90ArV|    261 |      0 |  26 |       0 |
+   192 |GGL90Prl|    287 |      0 |  26 |       0 |
 ------------------------------------------------------------------------
 listId=    3 ; file name: DiagMXL_2d
  nFlds, nActive,       freq     &     phase        , nLev               
     1  |    1  |    432000.000000         0.000000 |   1
  levels:   1
  diag# | name   |   ipt  |  iMate | kLev|   count |   mate.C|           
-    71 |MXLDEPTH|    287 |      0 |   1 |       0 |
+    76 |MXLDEPTH|    313 |      0 |   1 |       0 |
 ------------------------------------------------------------------------
-Global & Regional Statistics diagnostics: Number of lists:     0
+Global & Regional Statistics diagnostics: Number of lists:     1
+------------------------------------------------------------------------
+listId=   1 ; file name: dynStDiag
+ nFlds, nActive,       freq     &     phase        |                    
+    6  |    6  |    -18000.000000         0.000000 |
+ Regions:   0
+ diag# | name   |   ipt  |  iMate |    Volume   |   mate-Vol. |         
+   190 |GGL90TKE|      1 |      0 | 0.00000E+00 |
+   191 |GGL90Lmx|     27 |      0 | 0.00000E+00 |
+   195 |GGL90Kr |     53 |      0 | 0.00000E+00 |
+   193 |GGL90ArU|     79 |      0 | 0.00000E+00 |
+   194 |GGL90ArV|    105 |      0 | 0.00000E+00 |
+   192 |GGL90Prl|    131 |      0 | 0.00000E+00 |
 ------------------------------------------------------------------------
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // Model current state
@@ -1447,8 +1597,8 @@ Global & Regional Statistics diagnostics: Number of lists:     0
 (PID.TID 0000.0001) %MON dynstat_vvel_mean            =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON dynstat_vvel_sd              =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON dynstat_vvel_del2            =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON dynstat_wvel_max             =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON dynstat_wvel_min             =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON dynstat_wvel_max             =  -0.0000000000000E+00
+(PID.TID 0000.0001) %MON dynstat_wvel_min             =  -0.0000000000000E+00
 (PID.TID 0000.0001) %MON dynstat_wvel_mean            =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON dynstat_wvel_sd              =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON dynstat_wvel_del2            =   0.0000000000000E+00
@@ -1472,31 +1622,34 @@ Global & Regional Statistics diagnostics: Number of lists:     0
 (PID.TID 0000.0001) %MON dynstat_sss_mean             =   3.5000000000000E+01
 (PID.TID 0000.0001) %MON dynstat_sss_sd               =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON dynstat_sss_del2             =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON extforcing_qnet_max          =   3.5000000000000E+02
-(PID.TID 0000.0001) %MON extforcing_qnet_min          =   3.5000000000000E+02
-(PID.TID 0000.0001) %MON extforcing_qnet_mean         =   3.5000000000000E+02
-(PID.TID 0000.0001) %MON extforcing_qnet_sd           =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON extforcing_qnet_del2         =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON extforcing_qsw_max           =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON extforcing_qsw_min           =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON extforcing_qsw_mean          =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON extforcing_qsw_sd            =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON extforcing_qsw_del2          =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON extforcing_empmr_max         =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON extforcing_empmr_min         =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON extforcing_empmr_mean        =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON extforcing_empmr_sd          =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON extforcing_empmr_del2        =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON extforcing_fu_max            =   1.0000000000000E-01
-(PID.TID 0000.0001) %MON extforcing_fu_min            =   1.0000000000000E-01
-(PID.TID 0000.0001) %MON extforcing_fu_mean           =   1.0000000000000E-01
-(PID.TID 0000.0001) %MON extforcing_fu_sd             =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON extforcing_fu_del2           =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON extforcing_fv_max            =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON extforcing_fv_min            =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON extforcing_fv_mean           =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON extforcing_fv_sd             =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON extforcing_fv_del2           =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON forcing_qnet_max             =   3.5000000000000E+02
+(PID.TID 0000.0001) %MON forcing_qnet_min             =   3.5000000000000E+02
+(PID.TID 0000.0001) %MON forcing_qnet_mean            =   3.5000000000000E+02
+(PID.TID 0000.0001) %MON forcing_qnet_sd              =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON forcing_qnet_del2            =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON forcing_qsw_max              =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON forcing_qsw_min              =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON forcing_qsw_mean             =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON forcing_qsw_sd               =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON forcing_qsw_del2             =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON forcing_empmr_max            =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON forcing_empmr_min            =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON forcing_empmr_mean           =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON forcing_empmr_sd             =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON forcing_empmr_del2           =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON forcing_fu_max               =   1.0000000000000E-01
+(PID.TID 0000.0001) %MON forcing_fu_min               =   1.0000000000000E-01
+(PID.TID 0000.0001) %MON forcing_fu_mean              =   1.0000000000000E-01
+(PID.TID 0000.0001) %MON forcing_fu_sd                =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON forcing_fu_del2              =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON forcing_fv_max               =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON forcing_fv_min               =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON forcing_fv_mean              =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON forcing_fv_sd                =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON forcing_fv_del2              =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON trAdv_CFL_u_max              =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON trAdv_CFL_v_max              =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON trAdv_CFL_w_max              =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON advcfl_uvel_max              =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON advcfl_vvel_max              =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON advcfl_wvel_max              =   0.0000000000000E+00
@@ -1516,17 +1669,18 @@ Global & Regional Statistics diagnostics: Number of lists:     0
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // End MONITOR dynamic field statistics
 (PID.TID 0000.0001) // =======================================================
-S/R EXTERNAL_FIELDS_LOAD: Reading new data:   72    1         0  0.000000000000E+00
+ EXTERNAL_FIELDS_LOAD,         0 : iP,iLd,i0,i1=   72    0   72    1 ; Wght=  0.5000000000  0.5000000000
+ EXTERNAL_FIELDS_LOAD, it=         0 : Reading new data, i0,i1=   72    1 (prev=   72    0 )
 (PID.TID 0000.0001)  MDS_READ_FIELD: opening global file: taux_72.forcing
 (PID.TID 0000.0001)  MDS_READ_FIELD: opening global file: taux_72.forcing
 (PID.TID 0000.0001)  MDS_READ_FIELD: opening global file: Qnet_72.forcing
 (PID.TID 0000.0001)  MDS_READ_FIELD: opening global file: Qnet_72.forcing
-time,SST,SSS,fu,fv,Q,E-P,i0,i1,a,b =   0.0000E+00  0.0000E+00  0.0000E+00  1.0000E-01  0.0000E+00  1.7500E+02  0.0000E+00    72     1  5.0000E-01  5.0000E-01
-time,fu0,fu1,fu =   0.0000E+00  1.0000E-01  1.0000E-01  1.0000E-01  5.000000000000000E-01  5.000000000000000E-01
+(PID.TID 0000.0001) SOLVE_FOR_PRESSURE: putPmEinXvector =    F
  cg2d: Sum(rhs),rhsMax =   0.00000000000000E+00  0.00000000000000E+00
-(PID.TID 0000.0001)                    cg2d_init_res =    0.00000000000000E+00
-(PID.TID 0000.0001)                       cg2d_iters =     0
-(PID.TID 0000.0001)                         cg2d_res =    0.00000000000000E+00
+(PID.TID 0000.0001)      cg2d_init_res =   0.00000000000000E+00
+(PID.TID 0000.0001)      cg2d_iters(min,last) =       0       0
+(PID.TID 0000.0001)      cg2d_min_res  =   0.00000000000000E+00
+(PID.TID 0000.0001)      cg2d_last_res =   0.00000000000000E+00
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // Begin MONITOR dynamic field statistics
 (PID.TID 0000.0001) // =======================================================
@@ -1547,8 +1701,8 @@ time,fu0,fu1,fu =   0.0000E+00  1.0000E-01  1.0000E-01  1.0000E-01  5.0000000000
 (PID.TID 0000.0001) %MON dynstat_vvel_mean            =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON dynstat_vvel_sd              =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON dynstat_vvel_del2            =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON dynstat_wvel_max             =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON dynstat_wvel_min             =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON dynstat_wvel_max             =  -0.0000000000000E+00
+(PID.TID 0000.0001) %MON dynstat_wvel_min             =  -0.0000000000000E+00
 (PID.TID 0000.0001) %MON dynstat_wvel_mean            =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON dynstat_wvel_sd              =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON dynstat_wvel_del2            =   0.0000000000000E+00
@@ -1560,7 +1714,7 @@ time,fu0,fu1,fu =   0.0000E+00  1.0000E-01  1.0000E-01  1.0000E-01  5.0000000000
 (PID.TID 0000.0001) %MON dynstat_salt_max             =   3.5000000000000E+01
 (PID.TID 0000.0001) %MON dynstat_salt_min             =   3.5000000000000E+01
 (PID.TID 0000.0001) %MON dynstat_salt_mean            =   3.5000000000000E+01
-(PID.TID 0000.0001) %MON dynstat_salt_sd              =   6.0811623275179E-15
+(PID.TID 0000.0001) %MON dynstat_salt_sd              =   6.4050980708329E-15
 (PID.TID 0000.0001) %MON dynstat_salt_del2            =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON dynstat_sst_max              =   9.0691433247596E+00
 (PID.TID 0000.0001) %MON dynstat_sst_min              =   9.0691433247596E+00
@@ -1572,31 +1726,34 @@ time,fu0,fu1,fu =   0.0000E+00  1.0000E-01  1.0000E-01  1.0000E-01  5.0000000000
 (PID.TID 0000.0001) %MON dynstat_sss_mean             =   3.5000000000000E+01
 (PID.TID 0000.0001) %MON dynstat_sss_sd               =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON dynstat_sss_del2             =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON extforcing_qnet_max          =   1.7500000000000E+02
-(PID.TID 0000.0001) %MON extforcing_qnet_min          =   1.7500000000000E+02
-(PID.TID 0000.0001) %MON extforcing_qnet_mean         =   1.7500000000000E+02
-(PID.TID 0000.0001) %MON extforcing_qnet_sd           =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON extforcing_qnet_del2         =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON extforcing_qsw_max           =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON extforcing_qsw_min           =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON extforcing_qsw_mean          =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON extforcing_qsw_sd            =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON extforcing_qsw_del2          =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON extforcing_empmr_max         =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON extforcing_empmr_min         =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON extforcing_empmr_mean        =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON extforcing_empmr_sd          =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON extforcing_empmr_del2        =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON extforcing_fu_max            =   1.0000000000000E-01
-(PID.TID 0000.0001) %MON extforcing_fu_min            =   1.0000000000000E-01
-(PID.TID 0000.0001) %MON extforcing_fu_mean           =   1.0000000000000E-01
-(PID.TID 0000.0001) %MON extforcing_fu_sd             =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON extforcing_fu_del2           =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON extforcing_fv_max            =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON extforcing_fv_min            =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON extforcing_fv_mean           =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON extforcing_fv_sd             =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON extforcing_fv_del2           =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON forcing_qnet_max             =   1.7500000000000E+02
+(PID.TID 0000.0001) %MON forcing_qnet_min             =   1.7500000000000E+02
+(PID.TID 0000.0001) %MON forcing_qnet_mean            =   1.7500000000000E+02
+(PID.TID 0000.0001) %MON forcing_qnet_sd              =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON forcing_qnet_del2            =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON forcing_qsw_max              =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON forcing_qsw_min              =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON forcing_qsw_mean             =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON forcing_qsw_sd               =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON forcing_qsw_del2             =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON forcing_empmr_max            =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON forcing_empmr_min            =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON forcing_empmr_mean           =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON forcing_empmr_sd             =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON forcing_empmr_del2           =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON forcing_fu_max               =   1.0000000000000E-01
+(PID.TID 0000.0001) %MON forcing_fu_min               =   1.0000000000000E-01
+(PID.TID 0000.0001) %MON forcing_fu_mean              =   1.0000000000000E-01
+(PID.TID 0000.0001) %MON forcing_fu_sd                =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON forcing_fu_del2              =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON forcing_fv_max               =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON forcing_fv_min               =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON forcing_fv_mean              =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON forcing_fv_sd                =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON forcing_fv_del2              =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON trAdv_CFL_u_max              =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON trAdv_CFL_v_max              =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON trAdv_CFL_w_max              =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON advcfl_uvel_max              =   2.8771276951391E-03
 (PID.TID 0000.0001) %MON advcfl_vvel_max              =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON advcfl_wvel_max              =   0.0000000000000E+00
@@ -1616,12 +1773,18 @@ time,fu0,fu1,fu =   0.0000E+00  1.0000E-01  1.0000E-01  1.0000E-01  5.0000000000
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // End MONITOR dynamic field statistics
 (PID.TID 0000.0001) // =======================================================
-time,SST,SSS,fu,fv,Q,E-P,i0,i1,a,b =   1.2000E+03  0.0000E+00  0.0000E+00  1.0000E-01  0.0000E+00  1.7597E+02  0.0000E+00    72     1  5.0278E-01  4.9722E-01
-time,fu0,fu1,fu =   1.2000E+03  1.0000E-01  1.0000E-01  1.0000E-01  5.027777777777778E-01  4.972222222222222E-01
+ Compute Stats, Diag. #    190  GGL90TKE  vol(   0 ): 1.698E+10  Parms: SM      LR      
+ Compute Stats, Diag. #    191  GGL90Lmx  vol(   0 ): 1.698E+10  Parms: SM      LR      
+ Compute Stats, Diag. #    195  GGL90Kr   vol(   0 ): 1.698E+10  Parms: SM      LR      
+ Compute Stats, Diag. #    193  GGL90ArU  vol(   0 ): 1.698E+10  Parms: SM      LR      
+ Compute Stats, Diag. #    194  GGL90ArV  vol(   0 ): 1.698E+10  Parms: SM      LR      
+ Compute Stats, Diag. #    192  GGL90Prl  vol(   0 ): 1.698E+10  Parms: SM      LR      
+ EXTERNAL_FIELDS_LOAD,         1 : iP,iLd,i0,i1=   72    1   72    1 ; Wght=  0.4972222222  0.5027777778
  cg2d: Sum(rhs),rhsMax =   0.00000000000000E+00  0.00000000000000E+00
-(PID.TID 0000.0001)                    cg2d_init_res =    0.00000000000000E+00
-(PID.TID 0000.0001)                       cg2d_iters =     0
-(PID.TID 0000.0001)                         cg2d_res =    0.00000000000000E+00
+(PID.TID 0000.0001)      cg2d_init_res =   0.00000000000000E+00
+(PID.TID 0000.0001)      cg2d_iters(min,last) =       0       0
+(PID.TID 0000.0001)      cg2d_min_res  =   0.00000000000000E+00
+(PID.TID 0000.0001)      cg2d_last_res =   0.00000000000000E+00
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // Begin MONITOR dynamic field statistics
 (PID.TID 0000.0001) // =======================================================
@@ -1632,34 +1795,34 @@ time,fu0,fu1,fu =   1.2000E+03  1.0000E-01  1.0000E-01  1.0000E-01  5.0277777777
 (PID.TID 0000.0001) %MON dynstat_eta_mean             =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON dynstat_eta_sd               =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON dynstat_eta_del2             =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON dynstat_uvel_max             =   2.3941298720344E-02
-(PID.TID 0000.0001) %MON dynstat_uvel_min             =   5.7352698826401E-93
+(PID.TID 0000.0001) %MON dynstat_uvel_max             =   2.3961730069695E-02
+(PID.TID 0000.0001) %MON dynstat_uvel_min             =   5.4481221567710E-93
 (PID.TID 0000.0001) %MON dynstat_uvel_mean            =   3.4341632274953E-04
-(PID.TID 0000.0001) %MON dynstat_uvel_sd              =   2.8429220008659E-03
+(PID.TID 0000.0001) %MON dynstat_uvel_sd              =   2.8453780423460E-03
 (PID.TID 0000.0001) %MON dynstat_uvel_del2            =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON dynstat_vvel_max             =  -1.3672419088070E-93
-(PID.TID 0000.0001) %MON dynstat_vvel_min             =  -3.0348993003402E-03
+(PID.TID 0000.0001) %MON dynstat_vvel_max             =  -1.3308636928576E-93
+(PID.TID 0000.0001) %MON dynstat_vvel_min             =  -3.0374877103183E-03
 (PID.TID 0000.0001) %MON dynstat_vvel_mean            =  -4.3558926377550E-05
-(PID.TID 0000.0001) %MON dynstat_vvel_sd              =   3.6037819881258E-04
+(PID.TID 0000.0001) %MON dynstat_vvel_sd              =   3.6068916609367E-04
 (PID.TID 0000.0001) %MON dynstat_vvel_del2            =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON dynstat_wvel_max             =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON dynstat_wvel_min             =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON dynstat_wvel_max             =  -0.0000000000000E+00
+(PID.TID 0000.0001) %MON dynstat_wvel_min             =  -0.0000000000000E+00
 (PID.TID 0000.0001) %MON dynstat_wvel_mean            =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON dynstat_wvel_sd              =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON dynstat_wvel_del2            =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON dynstat_theta_max            =   9.0638363719213E+00
+(PID.TID 0000.0001) %MON dynstat_theta_max            =   9.0638442055310E+00
 (PID.TID 0000.0001) %MON dynstat_theta_min            =   2.2038797145082E+00
 (PID.TID 0000.0001) %MON dynstat_theta_mean           =   5.5625402431786E+00
-(PID.TID 0000.0001) %MON dynstat_theta_sd             =   2.0541303936378E+00
+(PID.TID 0000.0001) %MON dynstat_theta_sd             =   2.0541303986229E+00
 (PID.TID 0000.0001) %MON dynstat_theta_del2           =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON dynstat_salt_max             =   3.5000000000000E+01
 (PID.TID 0000.0001) %MON dynstat_salt_min             =   3.5000000000000E+01
 (PID.TID 0000.0001) %MON dynstat_salt_mean            =   3.5000000000000E+01
-(PID.TID 0000.0001) %MON dynstat_salt_sd              =   1.5145787623796E-14
+(PID.TID 0000.0001) %MON dynstat_salt_sd              =   1.2810196141666E-14
 (PID.TID 0000.0001) %MON dynstat_salt_del2            =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON dynstat_sst_max              =   9.0638363719213E+00
-(PID.TID 0000.0001) %MON dynstat_sst_min              =   9.0638363719213E+00
-(PID.TID 0000.0001) %MON dynstat_sst_mean             =   9.0638363719213E+00
+(PID.TID 0000.0001) %MON dynstat_sst_max              =   9.0638442055310E+00
+(PID.TID 0000.0001) %MON dynstat_sst_min              =   9.0638442055310E+00
+(PID.TID 0000.0001) %MON dynstat_sst_mean             =   9.0638442055310E+00
 (PID.TID 0000.0001) %MON dynstat_sst_sd               =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON dynstat_sst_del2             =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON dynstat_sss_max              =   3.5000000000000E+01
@@ -1667,38 +1830,41 @@ time,fu0,fu1,fu =   1.2000E+03  1.0000E-01  1.0000E-01  1.0000E-01  5.0277777777
 (PID.TID 0000.0001) %MON dynstat_sss_mean             =   3.5000000000000E+01
 (PID.TID 0000.0001) %MON dynstat_sss_sd               =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON dynstat_sss_del2             =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON extforcing_qnet_max          =   1.7597222222222E+02
-(PID.TID 0000.0001) %MON extforcing_qnet_min          =   1.7597222222222E+02
-(PID.TID 0000.0001) %MON extforcing_qnet_mean         =   1.7597222222222E+02
-(PID.TID 0000.0001) %MON extforcing_qnet_sd           =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON extforcing_qnet_del2         =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON extforcing_qsw_max           =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON extforcing_qsw_min           =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON extforcing_qsw_mean          =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON extforcing_qsw_sd            =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON extforcing_qsw_del2          =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON extforcing_empmr_max         =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON extforcing_empmr_min         =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON extforcing_empmr_mean        =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON extforcing_empmr_sd          =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON extforcing_empmr_del2        =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON extforcing_fu_max            =   1.0000000000000E-01
-(PID.TID 0000.0001) %MON extforcing_fu_min            =   1.0000000000000E-01
-(PID.TID 0000.0001) %MON extforcing_fu_mean           =   1.0000000000000E-01
-(PID.TID 0000.0001) %MON extforcing_fu_sd             =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON extforcing_fu_del2           =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON extforcing_fv_max            =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON extforcing_fv_min            =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON extforcing_fv_mean           =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON extforcing_fv_sd             =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON extforcing_fv_del2           =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON advcfl_uvel_max              =   5.7459116928826E-03
-(PID.TID 0000.0001) %MON advcfl_vvel_max              =   7.2837583208164E-04
+(PID.TID 0000.0001) %MON forcing_qnet_max             =   1.7597222222222E+02
+(PID.TID 0000.0001) %MON forcing_qnet_min             =   1.7597222222222E+02
+(PID.TID 0000.0001) %MON forcing_qnet_mean            =   1.7597222222222E+02
+(PID.TID 0000.0001) %MON forcing_qnet_sd              =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON forcing_qnet_del2            =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON forcing_qsw_max              =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON forcing_qsw_min              =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON forcing_qsw_mean             =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON forcing_qsw_sd               =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON forcing_qsw_del2             =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON forcing_empmr_max            =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON forcing_empmr_min            =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON forcing_empmr_mean           =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON forcing_empmr_sd             =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON forcing_empmr_del2           =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON forcing_fu_max               =   1.0000000000000E-01
+(PID.TID 0000.0001) %MON forcing_fu_min               =   1.0000000000000E-01
+(PID.TID 0000.0001) %MON forcing_fu_mean              =   1.0000000000000E-01
+(PID.TID 0000.0001) %MON forcing_fu_sd                =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON forcing_fu_del2              =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON forcing_fv_max               =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON forcing_fv_min               =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON forcing_fv_mean              =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON forcing_fv_sd                =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON forcing_fv_del2              =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON trAdv_CFL_u_max              =   2.8771276951391E-03
+(PID.TID 0000.0001) %MON trAdv_CFL_v_max              =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON trAdv_CFL_w_max              =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON advcfl_uvel_max              =   5.7508152167269E-03
+(PID.TID 0000.0001) %MON advcfl_vvel_max              =   7.2899705047638E-04
 (PID.TID 0000.0001) %MON advcfl_wvel_max              =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON advcfl_W_hf_max              =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON pe_b_mean                    =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON ke_max                       =   2.9119819908998E-04
-(PID.TID 0000.0001) %MON ke_mean                      =   4.1659550499923E-06
+(PID.TID 0000.0001) %MON ke_max                       =   2.9169541976164E-04
+(PID.TID 0000.0001) %MON ke_mean                      =   4.1730525146000E-06
 (PID.TID 0000.0001) %MON ke_vol                       =   1.7475000000000E+10
 (PID.TID 0000.0001) %MON vort_r_min                   =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON vort_r_max                   =   0.0000000000000E+00
@@ -1711,12 +1877,12 @@ time,fu0,fu1,fu =   1.2000E+03  1.0000E-01  1.0000E-01  1.0000E-01  5.0277777777
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // End MONITOR dynamic field statistics
 (PID.TID 0000.0001) // =======================================================
-time,SST,SSS,fu,fv,Q,E-P,i0,i1,a,b =   2.4000E+03  0.0000E+00  0.0000E+00  1.0000E-01  0.0000E+00  1.7694E+02  0.0000E+00    72     1  5.0556E-01  4.9444E-01
-time,fu0,fu1,fu =   2.4000E+03  1.0000E-01  1.0000E-01  1.0000E-01  5.055555555555555E-01  4.944444444444445E-01
+ EXTERNAL_FIELDS_LOAD,         2 : iP,iLd,i0,i1=   72    1   72    1 ; Wght=  0.4944444444  0.5055555556
  cg2d: Sum(rhs),rhsMax =   0.00000000000000E+00  0.00000000000000E+00
-(PID.TID 0000.0001)                    cg2d_init_res =    0.00000000000000E+00
-(PID.TID 0000.0001)                       cg2d_iters =     0
-(PID.TID 0000.0001)                         cg2d_res =    0.00000000000000E+00
+(PID.TID 0000.0001)      cg2d_init_res =   0.00000000000000E+00
+(PID.TID 0000.0001)      cg2d_iters(min,last) =       0       0
+(PID.TID 0000.0001)      cg2d_min_res  =   0.00000000000000E+00
+(PID.TID 0000.0001)      cg2d_last_res =   0.00000000000000E+00
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // Begin MONITOR dynamic field statistics
 (PID.TID 0000.0001) // =======================================================
@@ -1727,73 +1893,76 @@ time,fu0,fu1,fu =   2.4000E+03  1.0000E-01  1.0000E-01  1.0000E-01  5.0555555555
 (PID.TID 0000.0001) %MON dynstat_eta_mean             =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON dynstat_eta_sd               =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON dynstat_eta_del2             =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON dynstat_uvel_max             =   3.5052943376886E-02
-(PID.TID 0000.0001) %MON dynstat_uvel_min             =   7.9710955122945E-92
+(PID.TID 0000.0001) %MON dynstat_uvel_max             =   3.5151498638077E-02
+(PID.TID 0000.0001) %MON dynstat_uvel_min             =   7.1660878877116E-92
 (PID.TID 0000.0001) %MON dynstat_uvel_mean            =   5.0407445568084E-04
-(PID.TID 0000.0001) %MON dynstat_uvel_sd              =   4.1622680702206E-03
+(PID.TID 0000.0001) %MON dynstat_uvel_sd              =   4.1740971868793E-03
 (PID.TID 0000.0001) %MON dynstat_uvel_del2            =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON dynstat_vvel_max             =  -3.9768475394714E-92
-(PID.TID 0000.0001) %MON dynstat_vvel_min             =  -8.0534619978327E-03
+(PID.TID 0000.0001) %MON dynstat_vvel_max             =  -3.6785985674977E-92
+(PID.TID 0000.0001) %MON dynstat_vvel_min             =  -8.0793015399430E-03
 (PID.TID 0000.0001) %MON dynstat_vvel_mean            =  -1.1596482386606E-04
-(PID.TID 0000.0001) %MON dynstat_vvel_sd              =   9.5627578152801E-04
+(PID.TID 0000.0001) %MON dynstat_vvel_sd              =   9.5937372102094E-04
 (PID.TID 0000.0001) %MON dynstat_vvel_del2            =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON dynstat_wvel_max             =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON dynstat_wvel_min             =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON dynstat_wvel_max             =  -0.0000000000000E+00
+(PID.TID 0000.0001) %MON dynstat_wvel_min             =  -0.0000000000000E+00
 (PID.TID 0000.0001) %MON dynstat_wvel_mean            =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON dynstat_wvel_sd              =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON dynstat_wvel_del2            =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON dynstat_theta_max            =   9.0584891974024E+00
+(PID.TID 0000.0001) %MON dynstat_theta_max            =   9.0585165090715E+00
 (PID.TID 0000.0001) %MON dynstat_theta_min            =   2.2038827725433E+00
 (PID.TID 0000.0001) %MON dynstat_theta_mean           =   5.5624641720588E+00
-(PID.TID 0000.0001) %MON dynstat_theta_sd             =   2.0540002277009E+00
+(PID.TID 0000.0001) %MON dynstat_theta_sd             =   2.0540002440664E+00
 (PID.TID 0000.0001) %MON dynstat_theta_del2           =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON dynstat_salt_max             =   3.5000000000000E+01
 (PID.TID 0000.0001) %MON dynstat_salt_min             =   3.5000000000000E+01
 (PID.TID 0000.0001) %MON dynstat_salt_mean            =   3.5000000000000E+01
-(PID.TID 0000.0001) %MON dynstat_salt_sd              =   1.8778050533853E-14
+(PID.TID 0000.0001) %MON dynstat_salt_sd              =   1.9215294212499E-14
 (PID.TID 0000.0001) %MON dynstat_salt_del2            =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON dynstat_sst_max              =   9.0584891974024E+00
-(PID.TID 0000.0001) %MON dynstat_sst_min              =   9.0584891974024E+00
-(PID.TID 0000.0001) %MON dynstat_sst_mean             =   9.0584891974024E+00
-(PID.TID 0000.0001) %MON dynstat_sst_sd               =   1.7763568394003E-15
+(PID.TID 0000.0001) %MON dynstat_sst_max              =   9.0585165090715E+00
+(PID.TID 0000.0001) %MON dynstat_sst_min              =   9.0585165090715E+00
+(PID.TID 0000.0001) %MON dynstat_sst_mean             =   9.0585165090715E+00
+(PID.TID 0000.0001) %MON dynstat_sst_sd               =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON dynstat_sst_del2             =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON dynstat_sss_max              =   3.5000000000000E+01
 (PID.TID 0000.0001) %MON dynstat_sss_min              =   3.5000000000000E+01
 (PID.TID 0000.0001) %MON dynstat_sss_mean             =   3.5000000000000E+01
 (PID.TID 0000.0001) %MON dynstat_sss_sd               =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON dynstat_sss_del2             =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON extforcing_qnet_max          =   1.7694444444444E+02
-(PID.TID 0000.0001) %MON extforcing_qnet_min          =   1.7694444444444E+02
-(PID.TID 0000.0001) %MON extforcing_qnet_mean         =   1.7694444444444E+02
-(PID.TID 0000.0001) %MON extforcing_qnet_sd           =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON extforcing_qnet_del2         =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON extforcing_qsw_max           =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON extforcing_qsw_min           =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON extforcing_qsw_mean          =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON extforcing_qsw_sd            =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON extforcing_qsw_del2          =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON extforcing_empmr_max         =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON extforcing_empmr_min         =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON extforcing_empmr_mean        =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON extforcing_empmr_sd          =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON extforcing_empmr_del2        =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON extforcing_fu_max            =   1.0000000000000E-01
-(PID.TID 0000.0001) %MON extforcing_fu_min            =   1.0000000000000E-01
-(PID.TID 0000.0001) %MON extforcing_fu_mean           =   1.0000000000000E-01
-(PID.TID 0000.0001) %MON extforcing_fu_sd             =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON extforcing_fu_del2           =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON extforcing_fv_max            =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON extforcing_fv_min            =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON extforcing_fv_mean           =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON extforcing_fv_sd             =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON extforcing_fv_del2           =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON advcfl_uvel_max              =   8.4127064104525E-03
-(PID.TID 0000.0001) %MON advcfl_vvel_max              =   1.9328308794798E-03
+(PID.TID 0000.0001) %MON forcing_qnet_max             =   1.7694444444444E+02
+(PID.TID 0000.0001) %MON forcing_qnet_min             =   1.7694444444444E+02
+(PID.TID 0000.0001) %MON forcing_qnet_mean            =   1.7694444444444E+02
+(PID.TID 0000.0001) %MON forcing_qnet_sd              =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON forcing_qnet_del2            =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON forcing_qsw_max              =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON forcing_qsw_min              =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON forcing_qsw_mean             =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON forcing_qsw_sd               =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON forcing_qsw_del2             =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON forcing_empmr_max            =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON forcing_empmr_min            =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON forcing_empmr_mean           =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON forcing_empmr_sd             =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON forcing_empmr_del2           =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON forcing_fu_max               =   1.0000000000000E-01
+(PID.TID 0000.0001) %MON forcing_fu_min               =   1.0000000000000E-01
+(PID.TID 0000.0001) %MON forcing_fu_mean              =   1.0000000000000E-01
+(PID.TID 0000.0001) %MON forcing_fu_sd                =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON forcing_fu_del2              =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON forcing_fv_max               =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON forcing_fv_min               =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON forcing_fv_mean              =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON forcing_fv_sd                =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON forcing_fv_del2              =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON trAdv_CFL_u_max              =   5.7508152167269E-03
+(PID.TID 0000.0001) %MON trAdv_CFL_v_max              =   7.2899705047638E-04
+(PID.TID 0000.0001) %MON trAdv_CFL_w_max              =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON advcfl_uvel_max              =   8.4363596731384E-03
+(PID.TID 0000.0001) %MON advcfl_vvel_max              =   1.9390323695863E-03
 (PID.TID 0000.0001) %MON advcfl_wvel_max              =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON advcfl_W_hf_max              =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON pe_b_mean                    =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON ke_max                       =   6.4678354476684E-04
-(PID.TID 0000.0001) %MON ke_mean                      =   9.2532388779794E-06
+(PID.TID 0000.0001) %MON ke_max                       =   6.5045148493801E-04
+(PID.TID 0000.0001) %MON ke_mean                      =   9.3055120796717E-06
 (PID.TID 0000.0001) %MON ke_vol                       =   1.7475000000000E+10
 (PID.TID 0000.0001) %MON vort_r_min                   =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON vort_r_max                   =   0.0000000000000E+00
@@ -1806,12 +1975,12 @@ time,fu0,fu1,fu =   2.4000E+03  1.0000E-01  1.0000E-01  1.0000E-01  5.0555555555
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // End MONITOR dynamic field statistics
 (PID.TID 0000.0001) // =======================================================
-time,SST,SSS,fu,fv,Q,E-P,i0,i1,a,b =   3.6000E+03  0.0000E+00  0.0000E+00  1.0000E-01  0.0000E+00  1.7792E+02  0.0000E+00    72     1  5.0833E-01  4.9167E-01
-time,fu0,fu1,fu =   3.6000E+03  1.0000E-01  1.0000E-01  1.0000E-01  5.083333333333333E-01  4.916666666666667E-01
+ EXTERNAL_FIELDS_LOAD,         3 : iP,iLd,i0,i1=   72    1   72    1 ; Wght=  0.4916666667  0.5083333333
  cg2d: Sum(rhs),rhsMax =   0.00000000000000E+00  0.00000000000000E+00
-(PID.TID 0000.0001)                    cg2d_init_res =    0.00000000000000E+00
-(PID.TID 0000.0001)                       cg2d_iters =     0
-(PID.TID 0000.0001)                         cg2d_res =    0.00000000000000E+00
+(PID.TID 0000.0001)      cg2d_init_res =   0.00000000000000E+00
+(PID.TID 0000.0001)      cg2d_iters(min,last) =       0       0
+(PID.TID 0000.0001)      cg2d_min_res  =   0.00000000000000E+00
+(PID.TID 0000.0001)      cg2d_last_res =   0.00000000000000E+00
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // Begin MONITOR dynamic field statistics
 (PID.TID 0000.0001) // =======================================================
@@ -1822,34 +1991,34 @@ time,fu0,fu1,fu =   3.6000E+03  1.0000E-01  1.0000E-01  1.0000E-01  5.0833333333
 (PID.TID 0000.0001) %MON dynstat_eta_mean             =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON dynstat_eta_sd               =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON dynstat_eta_del2             =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON dynstat_uvel_max             =   4.4997930266810E-02
-(PID.TID 0000.0001) %MON dynstat_uvel_min             =   7.1770881579752E-91
+(PID.TID 0000.0001) %MON dynstat_uvel_max             =   4.5310378691267E-02
+(PID.TID 0000.0001) %MON dynstat_uvel_min             =   6.0728615516168E-91
 (PID.TID 0000.0001) %MON dynstat_uvel_mean            =   6.5009678934929E-04
-(PID.TID 0000.0001) %MON dynstat_uvel_sd              =   5.3429836491643E-03
+(PID.TID 0000.0001) %MON dynstat_uvel_sd              =   5.3803888754366E-03
 (PID.TID 0000.0001) %MON dynstat_uvel_del2            =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON dynstat_vvel_max             =  -5.8823419113297E-91
-(PID.TID 0000.0001) %MON dynstat_vvel_min             =  -1.4804339284151E-02
+(PID.TID 0000.0001) %MON dynstat_vvel_max             =  -5.1614824163966E-91
+(PID.TID 0000.0001) %MON dynstat_vvel_min             =  -1.4925655992889E-02
 (PID.TID 0000.0001) %MON dynstat_vvel_mean            =  -2.1441452125000E-04
-(PID.TID 0000.0001) %MON dynstat_vvel_sd              =   1.7578287617821E-03
+(PID.TID 0000.0001) %MON dynstat_vvel_sd              =   1.7723252670806E-03
 (PID.TID 0000.0001) %MON dynstat_vvel_del2            =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON dynstat_wvel_max             =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON dynstat_wvel_min             =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON dynstat_wvel_max             =  -0.0000000000000E+00
+(PID.TID 0000.0001) %MON dynstat_wvel_min             =  -0.0000000000000E+00
 (PID.TID 0000.0001) %MON dynstat_wvel_mean            =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON dynstat_wvel_sd              =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON dynstat_wvel_del2            =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON dynstat_theta_max            =   9.0530493066671E+00
+(PID.TID 0000.0001) %MON dynstat_theta_max            =   9.0531602387329E+00
 (PID.TID 0000.0001) %MON dynstat_theta_min            =   2.2038858305556E+00
 (PID.TID 0000.0001) %MON dynstat_theta_mean           =   5.5623876829659E+00
-(PID.TID 0000.0001) %MON dynstat_theta_sd             =   2.0538695038483E+00
+(PID.TID 0000.0001) %MON dynstat_theta_sd             =   2.0538695661233E+00
 (PID.TID 0000.0001) %MON dynstat_theta_del2           =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON dynstat_salt_max             =   3.5000000000000E+01
 (PID.TID 0000.0001) %MON dynstat_salt_min             =   3.5000000000000E+01
 (PID.TID 0000.0001) %MON dynstat_salt_mean            =   3.5000000000000E+01
-(PID.TID 0000.0001) %MON dynstat_salt_sd              =   2.6110465164963E-14
+(PID.TID 0000.0001) %MON dynstat_salt_sd              =   2.5620392283332E-14
 (PID.TID 0000.0001) %MON dynstat_salt_del2            =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON dynstat_sst_max              =   9.0530493066671E+00
-(PID.TID 0000.0001) %MON dynstat_sst_min              =   9.0530493066671E+00
-(PID.TID 0000.0001) %MON dynstat_sst_mean             =   9.0530493066671E+00
+(PID.TID 0000.0001) %MON dynstat_sst_max              =   9.0531602387329E+00
+(PID.TID 0000.0001) %MON dynstat_sst_min              =   9.0531602387329E+00
+(PID.TID 0000.0001) %MON dynstat_sst_mean             =   9.0531602387329E+00
 (PID.TID 0000.0001) %MON dynstat_sst_sd               =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON dynstat_sst_del2             =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON dynstat_sss_max              =   3.5000000000000E+01
@@ -1857,38 +2026,41 @@ time,fu0,fu1,fu =   3.6000E+03  1.0000E-01  1.0000E-01  1.0000E-01  5.0833333333
 (PID.TID 0000.0001) %MON dynstat_sss_mean             =   3.5000000000000E+01
 (PID.TID 0000.0001) %MON dynstat_sss_sd               =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON dynstat_sss_del2             =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON extforcing_qnet_max          =   1.7791666666667E+02
-(PID.TID 0000.0001) %MON extforcing_qnet_min          =   1.7791666666667E+02
-(PID.TID 0000.0001) %MON extforcing_qnet_mean         =   1.7791666666667E+02
-(PID.TID 0000.0001) %MON extforcing_qnet_sd           =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON extforcing_qnet_del2         =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON extforcing_qsw_max           =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON extforcing_qsw_min           =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON extforcing_qsw_mean          =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON extforcing_qsw_sd            =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON extforcing_qsw_del2          =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON extforcing_empmr_max         =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON extforcing_empmr_min         =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON extforcing_empmr_mean        =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON extforcing_empmr_sd          =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON extforcing_empmr_del2        =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON extforcing_fu_max            =   1.0000000000000E-01
-(PID.TID 0000.0001) %MON extforcing_fu_min            =   1.0000000000000E-01
-(PID.TID 0000.0001) %MON extforcing_fu_mean           =   1.0000000000000E-01
-(PID.TID 0000.0001) %MON extforcing_fu_sd             =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON extforcing_fu_del2           =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON extforcing_fv_max            =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON extforcing_fv_min            =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON extforcing_fv_mean           =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON extforcing_fv_sd             =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON extforcing_fv_del2           =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON advcfl_uvel_max              =   1.0799503264034E-02
-(PID.TID 0000.0001) %MON advcfl_vvel_max              =   3.5530414281963E-03
+(PID.TID 0000.0001) %MON forcing_qnet_max             =   1.7791666666667E+02
+(PID.TID 0000.0001) %MON forcing_qnet_min             =   1.7791666666667E+02
+(PID.TID 0000.0001) %MON forcing_qnet_mean            =   1.7791666666667E+02
+(PID.TID 0000.0001) %MON forcing_qnet_sd              =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON forcing_qnet_del2            =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON forcing_qsw_max              =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON forcing_qsw_min              =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON forcing_qsw_mean             =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON forcing_qsw_sd               =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON forcing_qsw_del2             =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON forcing_empmr_max            =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON forcing_empmr_min            =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON forcing_empmr_mean           =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON forcing_empmr_sd             =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON forcing_empmr_del2           =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON forcing_fu_max               =   1.0000000000000E-01
+(PID.TID 0000.0001) %MON forcing_fu_min               =   1.0000000000000E-01
+(PID.TID 0000.0001) %MON forcing_fu_mean              =   1.0000000000000E-01
+(PID.TID 0000.0001) %MON forcing_fu_sd                =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON forcing_fu_del2              =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON forcing_fv_max               =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON forcing_fv_min               =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON forcing_fv_mean              =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON forcing_fv_sd                =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON forcing_fv_del2              =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON trAdv_CFL_u_max              =   8.4363596731384E-03
+(PID.TID 0000.0001) %MON trAdv_CFL_v_max              =   1.9390323695863E-03
+(PID.TID 0000.0001) %MON trAdv_CFL_w_max              =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON advcfl_uvel_max              =   1.0874490885904E-02
+(PID.TID 0000.0001) %MON advcfl_vvel_max              =   3.5821574382934E-03
 (PID.TID 0000.0001) %MON advcfl_wvel_max              =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON advcfl_W_hf_max              =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON pe_b_mean                    =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON ke_max                       =   1.1219910949685E-03
-(PID.TID 0000.0001) %MON ke_mean                      =   1.6053017826715E-05
+(PID.TID 0000.0001) %MON ke_max                       =   1.1379028119821E-03
+(PID.TID 0000.0001) %MON ke_mean                      =   1.6279160362849E-05
 (PID.TID 0000.0001) %MON ke_vol                       =   1.7475000000000E+10
 (PID.TID 0000.0001) %MON vort_r_min                   =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON vort_r_max                   =   0.0000000000000E+00
@@ -1901,12 +2073,12 @@ time,fu0,fu1,fu =   3.6000E+03  1.0000E-01  1.0000E-01  1.0000E-01  5.0833333333
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // End MONITOR dynamic field statistics
 (PID.TID 0000.0001) // =======================================================
-time,SST,SSS,fu,fv,Q,E-P,i0,i1,a,b =   4.8000E+03  0.0000E+00  0.0000E+00  1.0000E-01  0.0000E+00  1.7889E+02  0.0000E+00    72     1  5.1111E-01  4.8889E-01
-time,fu0,fu1,fu =   4.8000E+03  1.0000E-01  1.0000E-01  1.0000E-01  5.111111111111111E-01  4.888888888888889E-01
+ EXTERNAL_FIELDS_LOAD,         4 : iP,iLd,i0,i1=   72    1   72    1 ; Wght=  0.4888888889  0.5111111111
  cg2d: Sum(rhs),rhsMax =   0.00000000000000E+00  0.00000000000000E+00
-(PID.TID 0000.0001)                    cg2d_init_res =    0.00000000000000E+00
-(PID.TID 0000.0001)                       cg2d_iters =     0
-(PID.TID 0000.0001)                         cg2d_res =    0.00000000000000E+00
+(PID.TID 0000.0001)      cg2d_init_res =   0.00000000000000E+00
+(PID.TID 0000.0001)      cg2d_iters(min,last) =       0       0
+(PID.TID 0000.0001)      cg2d_min_res  =   0.00000000000000E+00
+(PID.TID 0000.0001)      cg2d_last_res =   0.00000000000000E+00
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // Begin MONITOR dynamic field statistics
 (PID.TID 0000.0001) // =======================================================
@@ -1917,34 +2089,34 @@ time,fu0,fu1,fu =   4.8000E+03  1.0000E-01  1.0000E-01  1.0000E-01  5.1111111111
 (PID.TID 0000.0001) %MON dynstat_eta_mean             =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON dynstat_eta_sd               =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON dynstat_eta_del2             =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON dynstat_uvel_max             =   5.3408668457177E-02
-(PID.TID 0000.0001) %MON dynstat_uvel_min             =   4.6230693400078E-90
+(PID.TID 0000.0001) %MON dynstat_uvel_max             =   5.4153907314429E-02
+(PID.TID 0000.0001) %MON dynstat_uvel_min             =   3.6475115396666E-90
 (PID.TID 0000.0001) %MON dynstat_uvel_mean            =   7.7734814108220E-04
-(PID.TID 0000.0001) %MON dynstat_uvel_sd              =   6.3416162006167E-03
+(PID.TID 0000.0001) %MON dynstat_uvel_sd              =   6.4304804472228E-03
 (PID.TID 0000.0001) %MON dynstat_uvel_del2            =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON dynstat_vvel_max             =  -5.8956800169122E-90
-(PID.TID 0000.0001) %MON dynstat_vvel_min             =  -2.2990662405756E-02
+(PID.TID 0000.0001) %MON dynstat_vvel_max             =  -4.8965571848121E-90
+(PID.TID 0000.0001) %MON dynstat_vvel_min             =  -2.3380294889611E-02
 (PID.TID 0000.0001) %MON dynstat_vvel_mean            =  -3.3614197540939E-04
-(PID.TID 0000.0001) %MON dynstat_vvel_sd              =   2.7299194454887E-03
+(PID.TID 0000.0001) %MON dynstat_vvel_sd              =   2.7762364393874E-03
 (PID.TID 0000.0001) %MON dynstat_vvel_del2            =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON dynstat_wvel_max             =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON dynstat_wvel_min             =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON dynstat_wvel_max             =  -0.0000000000000E+00
+(PID.TID 0000.0001) %MON dynstat_wvel_min             =  -0.0000000000000E+00
 (PID.TID 0000.0001) %MON dynstat_wvel_mean            =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON dynstat_wvel_sd              =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON dynstat_wvel_del2            =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON dynstat_theta_max            =   9.0474150746211E+00
+(PID.TID 0000.0001) %MON dynstat_theta_max            =   9.0477555311922E+00
 (PID.TID 0000.0001) %MON dynstat_theta_min            =   2.2038888885449E+00
 (PID.TID 0000.0001) %MON dynstat_theta_mean           =   5.5623107758998E+00
-(PID.TID 0000.0001) %MON dynstat_theta_sd             =   2.0537381796870E+00
+(PID.TID 0000.0001) %MON dynstat_theta_sd             =   2.0537383574263E+00
 (PID.TID 0000.0001) %MON dynstat_theta_del2           =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON dynstat_salt_max             =   3.5000000000000E+01
 (PID.TID 0000.0001) %MON dynstat_salt_min             =   3.5000000000000E+01
 (PID.TID 0000.0001) %MON dynstat_salt_mean            =   3.5000000000000E+01
-(PID.TID 0000.0001) %MON dynstat_salt_sd              =   3.0488839169355E-14
+(PID.TID 0000.0001) %MON dynstat_salt_sd              =   3.2243513895986E-14
 (PID.TID 0000.0001) %MON dynstat_salt_del2            =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON dynstat_sst_max              =   9.0474150746211E+00
-(PID.TID 0000.0001) %MON dynstat_sst_min              =   9.0474150746211E+00
-(PID.TID 0000.0001) %MON dynstat_sst_mean             =   9.0474150746211E+00
+(PID.TID 0000.0001) %MON dynstat_sst_max              =   9.0477555311922E+00
+(PID.TID 0000.0001) %MON dynstat_sst_min              =   9.0477555311922E+00
+(PID.TID 0000.0001) %MON dynstat_sst_mean             =   9.0477555311922E+00
 (PID.TID 0000.0001) %MON dynstat_sst_sd               =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON dynstat_sst_del2             =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON dynstat_sss_max              =   3.5000000000000E+01
@@ -1952,38 +2124,41 @@ time,fu0,fu1,fu =   4.8000E+03  1.0000E-01  1.0000E-01  1.0000E-01  5.1111111111
 (PID.TID 0000.0001) %MON dynstat_sss_mean             =   3.5000000000000E+01
 (PID.TID 0000.0001) %MON dynstat_sss_sd               =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON dynstat_sss_del2             =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON extforcing_qnet_max          =   1.7888888888889E+02
-(PID.TID 0000.0001) %MON extforcing_qnet_min          =   1.7888888888889E+02
-(PID.TID 0000.0001) %MON extforcing_qnet_mean         =   1.7888888888889E+02
-(PID.TID 0000.0001) %MON extforcing_qnet_sd           =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON extforcing_qnet_del2         =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON extforcing_qsw_max           =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON extforcing_qsw_min           =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON extforcing_qsw_mean          =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON extforcing_qsw_sd            =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON extforcing_qsw_del2          =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON extforcing_empmr_max         =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON extforcing_empmr_min         =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON extforcing_empmr_mean        =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON extforcing_empmr_sd          =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON extforcing_empmr_del2        =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON extforcing_fu_max            =   1.0000000000000E-01
-(PID.TID 0000.0001) %MON extforcing_fu_min            =   1.0000000000000E-01
-(PID.TID 0000.0001) %MON extforcing_fu_mean           =   1.0000000000000E-01
-(PID.TID 0000.0001) %MON extforcing_fu_sd             =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON extforcing_fu_del2           =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON extforcing_fv_max            =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON extforcing_fv_min            =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON extforcing_fv_mean           =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON extforcing_fv_sd             =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON extforcing_fv_del2           =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON advcfl_uvel_max              =   1.2818080429722E-02
-(PID.TID 0000.0001) %MON advcfl_vvel_max              =   5.5177589773814E-03
+(PID.TID 0000.0001) %MON forcing_qnet_max             =   1.7888888888889E+02
+(PID.TID 0000.0001) %MON forcing_qnet_min             =   1.7888888888889E+02
+(PID.TID 0000.0001) %MON forcing_qnet_mean            =   1.7888888888889E+02
+(PID.TID 0000.0001) %MON forcing_qnet_sd              =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON forcing_qnet_del2            =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON forcing_qsw_max              =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON forcing_qsw_min              =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON forcing_qsw_mean             =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON forcing_qsw_sd               =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON forcing_qsw_del2             =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON forcing_empmr_max            =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON forcing_empmr_min            =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON forcing_empmr_mean           =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON forcing_empmr_sd             =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON forcing_empmr_del2           =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON forcing_fu_max               =   1.0000000000000E-01
+(PID.TID 0000.0001) %MON forcing_fu_min               =   1.0000000000000E-01
+(PID.TID 0000.0001) %MON forcing_fu_mean              =   1.0000000000000E-01
+(PID.TID 0000.0001) %MON forcing_fu_sd                =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON forcing_fu_del2              =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON forcing_fv_max               =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON forcing_fv_min               =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON forcing_fv_mean              =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON forcing_fv_sd                =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON forcing_fv_del2              =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON trAdv_CFL_u_max              =   1.0874490885904E-02
+(PID.TID 0000.0001) %MON trAdv_CFL_v_max              =   3.5821574382934E-03
+(PID.TID 0000.0001) %MON trAdv_CFL_w_max              =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON advcfl_uvel_max              =   1.2996937755463E-02
+(PID.TID 0000.0001) %MON advcfl_vvel_max              =   5.6112707735066E-03
 (PID.TID 0000.0001) %MON advcfl_wvel_max              =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON advcfl_W_hf_max              =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON pe_b_mean                    =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON ke_max                       =   1.6905282121120E-03
-(PID.TID 0000.0001) %MON ke_mean                      =   2.4192908887429E-05
+(PID.TID 0000.0001) %MON ke_max                       =   1.7396419332725E-03
+(PID.TID 0000.0001) %MON ke_mean                      =   2.4887914554787E-05
 (PID.TID 0000.0001) %MON ke_vol                       =   1.7475000000000E+10
 (PID.TID 0000.0001) %MON vort_r_min                   =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON vort_r_max                   =   0.0000000000000E+00
@@ -1996,12 +2171,12 @@ time,fu0,fu1,fu =   4.8000E+03  1.0000E-01  1.0000E-01  1.0000E-01  5.1111111111
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // End MONITOR dynamic field statistics
 (PID.TID 0000.0001) // =======================================================
-time,SST,SSS,fu,fv,Q,E-P,i0,i1,a,b =   6.0000E+03  0.0000E+00  0.0000E+00  1.0000E-01  0.0000E+00  1.7986E+02  0.0000E+00    72     1  5.1389E-01  4.8611E-01
-time,fu0,fu1,fu =   6.0000E+03  1.0000E-01  1.0000E-01  1.0000E-01  5.138888888888888E-01  4.861111111111112E-01
+ EXTERNAL_FIELDS_LOAD,         5 : iP,iLd,i0,i1=   72    1   72    1 ; Wght=  0.4861111111  0.5138888889
  cg2d: Sum(rhs),rhsMax =   0.00000000000000E+00  0.00000000000000E+00
-(PID.TID 0000.0001)                    cg2d_init_res =    0.00000000000000E+00
-(PID.TID 0000.0001)                       cg2d_iters =     0
-(PID.TID 0000.0001)                         cg2d_res =    0.00000000000000E+00
+(PID.TID 0000.0001)      cg2d_init_res =   0.00000000000000E+00
+(PID.TID 0000.0001)      cg2d_iters(min,last) =       0       0
+(PID.TID 0000.0001)      cg2d_min_res  =   0.00000000000000E+00
+(PID.TID 0000.0001)      cg2d_last_res =   0.00000000000000E+00
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // Begin MONITOR dynamic field statistics
 (PID.TID 0000.0001) // =======================================================
@@ -2012,34 +2187,34 @@ time,fu0,fu1,fu =   6.0000E+03  1.0000E-01  1.0000E-01  1.0000E-01  5.1388888888
 (PID.TID 0000.0001) %MON dynstat_eta_mean             =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON dynstat_eta_sd               =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON dynstat_eta_del2             =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON dynstat_uvel_max             =   6.0000926148631E-02
-(PID.TID 0000.0001) %MON dynstat_uvel_min             =   2.1731038374144E-89
+(PID.TID 0000.0001) %MON dynstat_uvel_max             =   6.1400586612242E-02
+(PID.TID 0000.0001) %MON dynstat_uvel_min             =   1.5664101651044E-89
 (PID.TID 0000.0001) %MON dynstat_uvel_mean            =   8.8215484231581E-04
-(PID.TID 0000.0001) %MON dynstat_uvel_sd              =   7.1249472168676E-03
+(PID.TID 0000.0001) %MON dynstat_uvel_sd              =   7.2909141933732E-03
 (PID.TID 0000.0001) %MON dynstat_uvel_del2            =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON dynstat_vvel_max             =  -4.4988219751467E-89
-(PID.TID 0000.0001) %MON dynstat_vvel_min             =  -3.2233080530355E-02
+(PID.TID 0000.0001) %MON dynstat_vvel_max             =  -3.5277659323374E-89
+(PID.TID 0000.0001) %MON dynstat_vvel_min             =  -3.3180078147189E-02
 (PID.TID 0000.0001) %MON dynstat_vvel_mean            =  -4.7763935892767E-04
-(PID.TID 0000.0001) %MON dynstat_vvel_sd              =   3.8281191134358E-03
+(PID.TID 0000.0001) %MON dynstat_vvel_sd              =   3.9398429962287E-03
 (PID.TID 0000.0001) %MON dynstat_vvel_del2            =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON dynstat_wvel_max             =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON dynstat_wvel_min             =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON dynstat_wvel_max             =  -0.0000000000000E+00
+(PID.TID 0000.0001) %MON dynstat_wvel_min             =  -0.0000000000000E+00
 (PID.TID 0000.0001) %MON dynstat_wvel_mean            =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON dynstat_wvel_sd              =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON dynstat_wvel_del2            =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON dynstat_theta_max            =   9.0414638513085E+00
+(PID.TID 0000.0001) %MON dynstat_theta_max            =   9.0422820157595E+00
 (PID.TID 0000.0001) %MON dynstat_theta_min            =   2.2038919465112E+00
 (PID.TID 0000.0001) %MON dynstat_theta_mean           =   5.5622334508605E+00
-(PID.TID 0000.0001) %MON dynstat_theta_sd             =   2.0536062204703E+00
+(PID.TID 0000.0001) %MON dynstat_theta_sd             =   2.0536066134018E+00
 (PID.TID 0000.0001) %MON dynstat_theta_del2           =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON dynstat_salt_max             =   3.5000000000000E+01
 (PID.TID 0000.0001) %MON dynstat_salt_min             =   3.5000000000000E+01
 (PID.TID 0000.0001) %MON dynstat_salt_mean            =   3.5000000000000E+01
-(PID.TID 0000.0001) %MON dynstat_salt_sd              =   3.4677333291561E-14
+(PID.TID 0000.0001) %MON dynstat_salt_sd              =   3.4462132217596E-14
 (PID.TID 0000.0001) %MON dynstat_salt_del2            =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON dynstat_sst_max              =   9.0414638513085E+00
-(PID.TID 0000.0001) %MON dynstat_sst_min              =   9.0414638513085E+00
-(PID.TID 0000.0001) %MON dynstat_sst_mean             =   9.0414638513085E+00
+(PID.TID 0000.0001) %MON dynstat_sst_max              =   9.0422820157595E+00
+(PID.TID 0000.0001) %MON dynstat_sst_min              =   9.0422820157595E+00
+(PID.TID 0000.0001) %MON dynstat_sst_mean             =   9.0422820157595E+00
 (PID.TID 0000.0001) %MON dynstat_sst_sd               =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON dynstat_sst_del2             =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON dynstat_sss_max              =   3.5000000000000E+01
@@ -2047,38 +2222,41 @@ time,fu0,fu1,fu =   6.0000E+03  1.0000E-01  1.0000E-01  1.0000E-01  5.1388888888
 (PID.TID 0000.0001) %MON dynstat_sss_mean             =   3.5000000000000E+01
 (PID.TID 0000.0001) %MON dynstat_sss_sd               =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON dynstat_sss_del2             =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON extforcing_qnet_max          =   1.7986111111111E+02
-(PID.TID 0000.0001) %MON extforcing_qnet_min          =   1.7986111111111E+02
-(PID.TID 0000.0001) %MON extforcing_qnet_mean         =   1.7986111111111E+02
-(PID.TID 0000.0001) %MON extforcing_qnet_sd           =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON extforcing_qnet_del2         =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON extforcing_qsw_max           =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON extforcing_qsw_min           =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON extforcing_qsw_mean          =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON extforcing_qsw_sd            =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON extforcing_qsw_del2          =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON extforcing_empmr_max         =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON extforcing_empmr_min         =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON extforcing_empmr_mean        =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON extforcing_empmr_sd          =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON extforcing_empmr_del2        =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON extforcing_fu_max            =   1.0000000000000E-01
-(PID.TID 0000.0001) %MON extforcing_fu_min            =   1.0000000000000E-01
-(PID.TID 0000.0001) %MON extforcing_fu_mean           =   1.0000000000000E-01
-(PID.TID 0000.0001) %MON extforcing_fu_sd             =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON extforcing_fu_del2           =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON extforcing_fv_max            =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON extforcing_fv_min            =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON extforcing_fv_mean           =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON extforcing_fv_sd             =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON extforcing_fv_del2           =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON advcfl_uvel_max              =   1.4400222275671E-02
-(PID.TID 0000.0001) %MON advcfl_vvel_max              =   7.7359393272851E-03
+(PID.TID 0000.0001) %MON forcing_qnet_max             =   1.7986111111111E+02
+(PID.TID 0000.0001) %MON forcing_qnet_min             =   1.7986111111111E+02
+(PID.TID 0000.0001) %MON forcing_qnet_mean            =   1.7986111111111E+02
+(PID.TID 0000.0001) %MON forcing_qnet_sd              =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON forcing_qnet_del2            =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON forcing_qsw_max              =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON forcing_qsw_min              =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON forcing_qsw_mean             =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON forcing_qsw_sd               =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON forcing_qsw_del2             =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON forcing_empmr_max            =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON forcing_empmr_min            =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON forcing_empmr_mean           =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON forcing_empmr_sd             =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON forcing_empmr_del2           =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON forcing_fu_max               =   1.0000000000000E-01
+(PID.TID 0000.0001) %MON forcing_fu_min               =   1.0000000000000E-01
+(PID.TID 0000.0001) %MON forcing_fu_mean              =   1.0000000000000E-01
+(PID.TID 0000.0001) %MON forcing_fu_sd                =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON forcing_fu_del2              =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON forcing_fv_max               =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON forcing_fv_min               =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON forcing_fv_mean              =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON forcing_fv_sd                =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON forcing_fv_del2              =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON trAdv_CFL_u_max              =   1.2996937755463E-02
+(PID.TID 0000.0001) %MON trAdv_CFL_v_max              =   5.6112707735066E-03
+(PID.TID 0000.0001) %MON trAdv_CFL_w_max              =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON advcfl_uvel_max              =   1.4736140786938E-02
+(PID.TID 0000.0001) %MON advcfl_vvel_max              =   7.9632187553253E-03
 (PID.TID 0000.0001) %MON advcfl_wvel_max              =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON advcfl_W_hf_max              =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON pe_b_mean                    =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON ke_max                       =   2.3195413095849E-03
-(PID.TID 0000.0001) %MON ke_mean                      =   3.3212852656410E-05
+(PID.TID 0000.0001) %MON ke_max                       =   2.4354748110905E-03
+(PID.TID 0000.0001) %MON ke_mean                      =   3.4843064566540E-05
 (PID.TID 0000.0001) %MON ke_vol                       =   1.7475000000000E+10
 (PID.TID 0000.0001) %MON vort_r_min                   =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON vort_r_max                   =   0.0000000000000E+00
@@ -2091,12 +2269,12 @@ time,fu0,fu1,fu =   6.0000E+03  1.0000E-01  1.0000E-01  1.0000E-01  5.1388888888
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // End MONITOR dynamic field statistics
 (PID.TID 0000.0001) // =======================================================
-time,SST,SSS,fu,fv,Q,E-P,i0,i1,a,b =   7.2000E+03  0.0000E+00  0.0000E+00  1.0000E-01  0.0000E+00  1.8083E+02  0.0000E+00    72     1  5.1667E-01  4.8333E-01
-time,fu0,fu1,fu =   7.2000E+03  1.0000E-01  1.0000E-01  1.0000E-01  5.166666666666667E-01  4.833333333333333E-01
+ EXTERNAL_FIELDS_LOAD,         6 : iP,iLd,i0,i1=   72    1   72    1 ; Wght=  0.4833333333  0.5166666667
  cg2d: Sum(rhs),rhsMax =   0.00000000000000E+00  0.00000000000000E+00
-(PID.TID 0000.0001)                    cg2d_init_res =    0.00000000000000E+00
-(PID.TID 0000.0001)                       cg2d_iters =     0
-(PID.TID 0000.0001)                         cg2d_res =    0.00000000000000E+00
+(PID.TID 0000.0001)      cg2d_init_res =   0.00000000000000E+00
+(PID.TID 0000.0001)      cg2d_iters(min,last) =       0       0
+(PID.TID 0000.0001)      cg2d_min_res  =   0.00000000000000E+00
+(PID.TID 0000.0001)      cg2d_last_res =   0.00000000000000E+00
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // Begin MONITOR dynamic field statistics
 (PID.TID 0000.0001) // =======================================================
@@ -2107,34 +2285,34 @@ time,fu0,fu1,fu =   7.2000E+03  1.0000E-01  1.0000E-01  1.0000E-01  5.1666666666
 (PID.TID 0000.0001) %MON dynstat_eta_mean             =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON dynstat_eta_sd               =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON dynstat_eta_del2             =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON dynstat_uvel_max             =   6.4621408892522E-02
-(PID.TID 0000.0001) %MON dynstat_uvel_min             =   6.7741990273440E-89
+(PID.TID 0000.0001) %MON dynstat_uvel_max             =   6.6794109300755E-02
+(PID.TID 0000.0001) %MON dynstat_uvel_min             =   4.1420436613160E-89
 (PID.TID 0000.0001) %MON dynstat_uvel_mean            =   9.6149609557087E-04
-(PID.TID 0000.0001) %MON dynstat_uvel_sd              =   7.6754331628148E-03
+(PID.TID 0000.0001) %MON dynstat_uvel_sd              =   7.9312164217530E-03
 (PID.TID 0000.0001) %MON dynstat_uvel_del2            =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON dynstat_vvel_max             =  -2.7825905819128E-88
-(PID.TID 0000.0001) %MON dynstat_vvel_min             =  -4.2122879469239E-02
+(PID.TID 0000.0001) %MON dynstat_vvel_max             =  -2.0543710329458E-88
+(PID.TID 0000.0001) %MON dynstat_vvel_min             =  -4.3988195550754E-02
 (PID.TID 0000.0001) %MON dynstat_vvel_mean            =  -6.3482121059842E-04
-(PID.TID 0000.0001) %MON dynstat_vvel_sd              =   5.0052993074234E-03
+(PID.TID 0000.0001) %MON dynstat_vvel_sd              =   5.2231185544220E-03
 (PID.TID 0000.0001) %MON dynstat_vvel_del2            =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON dynstat_wvel_max             =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON dynstat_wvel_min             =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON dynstat_wvel_max             =  -0.0000000000000E+00
+(PID.TID 0000.0001) %MON dynstat_wvel_min             =  -0.0000000000000E+00
 (PID.TID 0000.0001) %MON dynstat_wvel_mean            =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON dynstat_wvel_sd              =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON dynstat_wvel_del2            =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON dynstat_theta_max            =   9.0350946736216E+00
+(PID.TID 0000.0001) %MON dynstat_theta_max            =   9.0366832428191E+00
 (PID.TID 0000.0001) %MON dynstat_theta_min            =   2.2038950044547E+00
-(PID.TID 0000.0001) %MON dynstat_theta_mean           =   5.5621557078481E+00
-(PID.TID 0000.0001) %MON dynstat_theta_sd             =   2.0534736256661E+00
+(PID.TID 0000.0001) %MON dynstat_theta_mean           =   5.5621557078480E+00
+(PID.TID 0000.0001) %MON dynstat_theta_sd             =   2.0534743166228E+00
 (PID.TID 0000.0001) %MON dynstat_theta_del2           =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON dynstat_salt_max             =   3.5000000000000E+01
 (PID.TID 0000.0001) %MON dynstat_salt_min             =   3.5000000000000E+01
 (PID.TID 0000.0001) %MON dynstat_salt_mean            =   3.5000000000000E+01
-(PID.TID 0000.0001) %MON dynstat_salt_sd              =   4.0512071468925E-14
+(PID.TID 0000.0001) %MON dynstat_salt_sd              =   3.9663453304588E-14
 (PID.TID 0000.0001) %MON dynstat_salt_del2            =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON dynstat_sst_max              =   9.0350946736216E+00
-(PID.TID 0000.0001) %MON dynstat_sst_min              =   9.0350946736216E+00
-(PID.TID 0000.0001) %MON dynstat_sst_mean             =   9.0350946736216E+00
+(PID.TID 0000.0001) %MON dynstat_sst_max              =   9.0366832428191E+00
+(PID.TID 0000.0001) %MON dynstat_sst_min              =   9.0366832428191E+00
+(PID.TID 0000.0001) %MON dynstat_sst_mean             =   9.0366832428191E+00
 (PID.TID 0000.0001) %MON dynstat_sst_sd               =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON dynstat_sst_del2             =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON dynstat_sss_max              =   3.5000000000000E+01
@@ -2142,38 +2320,41 @@ time,fu0,fu1,fu =   7.2000E+03  1.0000E-01  1.0000E-01  1.0000E-01  5.1666666666
 (PID.TID 0000.0001) %MON dynstat_sss_mean             =   3.5000000000000E+01
 (PID.TID 0000.0001) %MON dynstat_sss_sd               =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON dynstat_sss_del2             =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON extforcing_qnet_max          =   1.8083333333333E+02
-(PID.TID 0000.0001) %MON extforcing_qnet_min          =   1.8083333333333E+02
-(PID.TID 0000.0001) %MON extforcing_qnet_mean         =   1.8083333333333E+02
-(PID.TID 0000.0001) %MON extforcing_qnet_sd           =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON extforcing_qnet_del2         =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON extforcing_qsw_max           =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON extforcing_qsw_min           =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON extforcing_qsw_mean          =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON extforcing_qsw_sd            =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON extforcing_qsw_del2          =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON extforcing_empmr_max         =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON extforcing_empmr_min         =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON extforcing_empmr_mean        =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON extforcing_empmr_sd          =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON extforcing_empmr_del2        =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON extforcing_fu_max            =   1.0000000000000E-01
-(PID.TID 0000.0001) %MON extforcing_fu_min            =   1.0000000000000E-01
-(PID.TID 0000.0001) %MON extforcing_fu_mean           =   1.0000000000000E-01
-(PID.TID 0000.0001) %MON extforcing_fu_sd             =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON extforcing_fu_del2           =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON extforcing_fv_max            =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON extforcing_fv_min            =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON extforcing_fv_mean           =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON extforcing_fv_sd             =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON extforcing_fv_del2           =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON advcfl_uvel_max              =   1.5509138134205E-02
-(PID.TID 0000.0001) %MON advcfl_vvel_max              =   1.0109491072617E-02
+(PID.TID 0000.0001) %MON forcing_qnet_max             =   1.8083333333333E+02
+(PID.TID 0000.0001) %MON forcing_qnet_min             =   1.8083333333333E+02
+(PID.TID 0000.0001) %MON forcing_qnet_mean            =   1.8083333333333E+02
+(PID.TID 0000.0001) %MON forcing_qnet_sd              =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON forcing_qnet_del2            =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON forcing_qsw_max              =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON forcing_qsw_min              =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON forcing_qsw_mean             =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON forcing_qsw_sd               =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON forcing_qsw_del2             =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON forcing_empmr_max            =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON forcing_empmr_min            =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON forcing_empmr_mean           =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON forcing_empmr_sd             =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON forcing_empmr_del2           =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON forcing_fu_max               =   1.0000000000000E-01
+(PID.TID 0000.0001) %MON forcing_fu_min               =   1.0000000000000E-01
+(PID.TID 0000.0001) %MON forcing_fu_mean              =   1.0000000000000E-01
+(PID.TID 0000.0001) %MON forcing_fu_sd                =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON forcing_fu_del2              =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON forcing_fv_max               =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON forcing_fv_min               =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON forcing_fv_mean              =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON forcing_fv_sd                =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON forcing_fv_del2              =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON trAdv_CFL_u_max              =   1.4736140786938E-02
+(PID.TID 0000.0001) %MON trAdv_CFL_v_max              =   7.9632187553252E-03
+(PID.TID 0000.0001) %MON trAdv_CFL_w_max              =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON advcfl_uvel_max              =   1.6030586232181E-02
+(PID.TID 0000.0001) %MON advcfl_vvel_max              =   1.0557166932181E-02
 (PID.TID 0000.0001) %MON advcfl_wvel_max              =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON advcfl_W_hf_max              =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON pe_b_mean                    =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON ke_max                       =   2.9751317310173E-03
-(PID.TID 0000.0001) %MON ke_mean                      =   4.2646384052477E-05
+(PID.TID 0000.0001) %MON ke_max                       =   3.1982071925463E-03
+(PID.TID 0000.0001) %MON ke_mean                      =   4.5756317036728E-05
 (PID.TID 0000.0001) %MON ke_vol                       =   1.7475000000000E+10
 (PID.TID 0000.0001) %MON vort_r_min                   =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON vort_r_max                   =   0.0000000000000E+00
@@ -2186,12 +2367,12 @@ time,fu0,fu1,fu =   7.2000E+03  1.0000E-01  1.0000E-01  1.0000E-01  5.1666666666
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // End MONITOR dynamic field statistics
 (PID.TID 0000.0001) // =======================================================
-time,SST,SSS,fu,fv,Q,E-P,i0,i1,a,b =   8.4000E+03  0.0000E+00  0.0000E+00  1.0000E-01  0.0000E+00  1.8181E+02  0.0000E+00    72     1  5.1944E-01  4.8056E-01
-time,fu0,fu1,fu =   8.4000E+03  1.0000E-01  1.0000E-01  1.0000E-01  5.194444444444445E-01  4.805555555555555E-01
+ EXTERNAL_FIELDS_LOAD,         7 : iP,iLd,i0,i1=   72    1   72    1 ; Wght=  0.4805555556  0.5194444444
  cg2d: Sum(rhs),rhsMax =   0.00000000000000E+00  0.00000000000000E+00
-(PID.TID 0000.0001)                    cg2d_init_res =    0.00000000000000E+00
-(PID.TID 0000.0001)                       cg2d_iters =     0
-(PID.TID 0000.0001)                         cg2d_res =    0.00000000000000E+00
+(PID.TID 0000.0001)      cg2d_init_res =   0.00000000000000E+00
+(PID.TID 0000.0001)      cg2d_iters(min,last) =       0       0
+(PID.TID 0000.0001)      cg2d_min_res  =   0.00000000000000E+00
+(PID.TID 0000.0001)      cg2d_last_res =   0.00000000000000E+00
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // Begin MONITOR dynamic field statistics
 (PID.TID 0000.0001) // =======================================================
@@ -2202,73 +2383,76 @@ time,fu0,fu1,fu =   8.4000E+03  1.0000E-01  1.0000E-01  1.0000E-01  5.1944444444
 (PID.TID 0000.0001) %MON dynstat_eta_mean             =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON dynstat_eta_sd               =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON dynstat_eta_del2             =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON dynstat_uvel_max             =   6.7243297338289E-02
-(PID.TID 0000.0001) %MON dynstat_uvel_min             =   4.5092997321594E-89
+(PID.TID 0000.0001) %MON dynstat_uvel_max             =   7.0078943763519E-02
+(PID.TID 0000.0001) %MON dynstat_uvel_min             =  -1.6293555614327E-79
 (PID.TID 0000.0001) %MON dynstat_uvel_mean            =   1.0130869525140E-03
-(PID.TID 0000.0001) %MON dynstat_uvel_sd              =   7.9901514700615E-03
+(PID.TID 0000.0001) %MON dynstat_uvel_sd              =   8.3210402855439E-03
 (PID.TID 0000.0001) %MON dynstat_uvel_del2            =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON dynstat_vvel_max             =  -1.4493167923475E-87
-(PID.TID 0000.0001) %MON dynstat_vvel_min             =  -5.2267949593123E-02
-(PID.TID 0000.0001) %MON dynstat_vvel_mean            =  -8.0315051323323E-04
-(PID.TID 0000.0001) %MON dynstat_vvel_sd              =   6.2170181163975E-03
+(PID.TID 0000.0001) %MON dynstat_vvel_max             =  -1.0042716986321E-87
+(PID.TID 0000.0001) %MON dynstat_vvel_min             =  -5.5355738448920E-02
+(PID.TID 0000.0001) %MON dynstat_vvel_mean            =  -8.0315051323322E-04
+(PID.TID 0000.0001) %MON dynstat_vvel_sd              =   6.5727798403305E-03
 (PID.TID 0000.0001) %MON dynstat_vvel_del2            =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON dynstat_wvel_max             =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON dynstat_wvel_min             =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON dynstat_wvel_max             =  -0.0000000000000E+00
+(PID.TID 0000.0001) %MON dynstat_wvel_min             =  -0.0000000000000E+00
 (PID.TID 0000.0001) %MON dynstat_wvel_mean            =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON dynstat_wvel_sd              =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON dynstat_wvel_del2            =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON dynstat_theta_max            =   9.0284202878252E+00
+(PID.TID 0000.0001) %MON dynstat_theta_max            =   9.0308847424849E+00
 (PID.TID 0000.0001) %MON dynstat_theta_min            =   2.2038980623752E+00
 (PID.TID 0000.0001) %MON dynstat_theta_mean           =   5.5620775468624E+00
-(PID.TID 0000.0001) %MON dynstat_theta_sd             =   2.0533404941014E+00
+(PID.TID 0000.0001) %MON dynstat_theta_sd             =   2.0533414518216E+00
 (PID.TID 0000.0001) %MON dynstat_theta_del2           =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON dynstat_salt_max             =   3.5000000000000E+01
 (PID.TID 0000.0001) %MON dynstat_salt_min             =   3.5000000000000E+01
 (PID.TID 0000.0001) %MON dynstat_salt_mean            =   3.5000000000000E+01
-(PID.TID 0000.0001) %MON dynstat_salt_sd              =   4.5411922016721E-14
+(PID.TID 0000.0001) %MON dynstat_salt_sd              =   4.5022969873134E-14
 (PID.TID 0000.0001) %MON dynstat_salt_del2            =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON dynstat_sst_max              =   9.0284202878252E+00
-(PID.TID 0000.0001) %MON dynstat_sst_min              =   9.0284202878252E+00
-(PID.TID 0000.0001) %MON dynstat_sst_mean             =   9.0284202878252E+00
-(PID.TID 0000.0001) %MON dynstat_sst_sd               =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON dynstat_sst_max              =   9.0308847424849E+00
+(PID.TID 0000.0001) %MON dynstat_sst_min              =   9.0308847424849E+00
+(PID.TID 0000.0001) %MON dynstat_sst_mean             =   9.0308847424849E+00
+(PID.TID 0000.0001) %MON dynstat_sst_sd               =   1.7763568394003E-15
 (PID.TID 0000.0001) %MON dynstat_sst_del2             =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON dynstat_sss_max              =   3.5000000000000E+01
 (PID.TID 0000.0001) %MON dynstat_sss_min              =   3.5000000000000E+01
 (PID.TID 0000.0001) %MON dynstat_sss_mean             =   3.5000000000000E+01
 (PID.TID 0000.0001) %MON dynstat_sss_sd               =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON dynstat_sss_del2             =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON extforcing_qnet_max          =   1.8180555555556E+02
-(PID.TID 0000.0001) %MON extforcing_qnet_min          =   1.8180555555556E+02
-(PID.TID 0000.0001) %MON extforcing_qnet_mean         =   1.8180555555556E+02
-(PID.TID 0000.0001) %MON extforcing_qnet_sd           =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON extforcing_qnet_del2         =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON extforcing_qsw_max           =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON extforcing_qsw_min           =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON extforcing_qsw_mean          =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON extforcing_qsw_sd            =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON extforcing_qsw_del2          =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON extforcing_empmr_max         =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON extforcing_empmr_min         =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON extforcing_empmr_mean        =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON extforcing_empmr_sd          =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON extforcing_empmr_del2        =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON extforcing_fu_max            =   1.0000000000000E-01
-(PID.TID 0000.0001) %MON extforcing_fu_min            =   1.0000000000000E-01
-(PID.TID 0000.0001) %MON extforcing_fu_mean           =   1.0000000000000E-01
-(PID.TID 0000.0001) %MON extforcing_fu_sd             =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON extforcing_fu_del2           =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON extforcing_fv_max            =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON extforcing_fv_min            =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON extforcing_fv_mean           =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON extforcing_fv_sd             =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON extforcing_fv_del2           =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON advcfl_uvel_max              =   1.6138391361189E-02
-(PID.TID 0000.0001) %MON advcfl_vvel_max              =   1.2544307902349E-02
+(PID.TID 0000.0001) %MON forcing_qnet_max             =   1.8180555555556E+02
+(PID.TID 0000.0001) %MON forcing_qnet_min             =   1.8180555555556E+02
+(PID.TID 0000.0001) %MON forcing_qnet_mean            =   1.8180555555556E+02
+(PID.TID 0000.0001) %MON forcing_qnet_sd              =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON forcing_qnet_del2            =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON forcing_qsw_max              =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON forcing_qsw_min              =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON forcing_qsw_mean             =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON forcing_qsw_sd               =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON forcing_qsw_del2             =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON forcing_empmr_max            =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON forcing_empmr_min            =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON forcing_empmr_mean           =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON forcing_empmr_sd             =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON forcing_empmr_del2           =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON forcing_fu_max               =   1.0000000000000E-01
+(PID.TID 0000.0001) %MON forcing_fu_min               =   1.0000000000000E-01
+(PID.TID 0000.0001) %MON forcing_fu_mean              =   1.0000000000000E-01
+(PID.TID 0000.0001) %MON forcing_fu_sd                =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON forcing_fu_del2              =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON forcing_fv_max               =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON forcing_fv_min               =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON forcing_fv_mean              =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON forcing_fv_sd                =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON forcing_fv_del2              =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON trAdv_CFL_u_max              =   1.6030586232181E-02
+(PID.TID 0000.0001) %MON trAdv_CFL_v_max              =   1.0557166932181E-02
+(PID.TID 0000.0001) %MON trAdv_CFL_w_max              =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON advcfl_uvel_max              =   1.6818946503245E-02
+(PID.TID 0000.0001) %MON advcfl_vvel_max              =   1.3285377227741E-02
 (PID.TID 0000.0001) %MON advcfl_wvel_max              =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON advcfl_W_hf_max              =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON pe_b_mean                    =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON ke_max                       =   3.6267997957974E-03
-(PID.TID 0000.0001) %MON ke_mean                      =   5.2082615347200E-05
+(PID.TID 0000.0001) %MON ke_max                       =   3.9876580691178E-03
+(PID.TID 0000.0001) %MON ke_mean                      =   5.7056271091680E-05
 (PID.TID 0000.0001) %MON ke_vol                       =   1.7475000000000E+10
 (PID.TID 0000.0001) %MON vort_r_min                   =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON vort_r_max                   =   0.0000000000000E+00
@@ -2281,12 +2465,12 @@ time,fu0,fu1,fu =   8.4000E+03  1.0000E-01  1.0000E-01  1.0000E-01  5.1944444444
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // End MONITOR dynamic field statistics
 (PID.TID 0000.0001) // =======================================================
-time,SST,SSS,fu,fv,Q,E-P,i0,i1,a,b =   9.6000E+03  0.0000E+00  0.0000E+00  1.0000E-01  0.0000E+00  1.8278E+02  0.0000E+00    72     1  5.2222E-01  4.7778E-01
-time,fu0,fu1,fu =   9.6000E+03  1.0000E-01  1.0000E-01  1.0000E-01  5.222222222222223E-01  4.777777777777777E-01
+ EXTERNAL_FIELDS_LOAD,         8 : iP,iLd,i0,i1=   72    1   72    1 ; Wght=  0.4777777778  0.5222222222
  cg2d: Sum(rhs),rhsMax =   0.00000000000000E+00  0.00000000000000E+00
-(PID.TID 0000.0001)                    cg2d_init_res =    0.00000000000000E+00
-(PID.TID 0000.0001)                       cg2d_iters =     0
-(PID.TID 0000.0001)                         cg2d_res =    0.00000000000000E+00
+(PID.TID 0000.0001)      cg2d_init_res =   0.00000000000000E+00
+(PID.TID 0000.0001)      cg2d_iters(min,last) =       0       0
+(PID.TID 0000.0001)      cg2d_min_res  =   0.00000000000000E+00
+(PID.TID 0000.0001)      cg2d_last_res =   0.00000000000000E+00
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // Begin MONITOR dynamic field statistics
 (PID.TID 0000.0001) // =======================================================
@@ -2297,34 +2481,34 @@ time,fu0,fu1,fu =   9.6000E+03  1.0000E-01  1.0000E-01  1.0000E-01  5.2222222222
 (PID.TID 0000.0001) %MON dynstat_eta_mean             =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON dynstat_eta_sd               =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON dynstat_eta_del2             =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON dynstat_uvel_max             =   6.7611486366860E-02
-(PID.TID 0000.0001) %MON dynstat_uvel_min             =  -4.0617003154860E-41
+(PID.TID 0000.0001) %MON dynstat_uvel_max             =   7.0925708368917E-02
+(PID.TID 0000.0001) %MON dynstat_uvel_min             =  -2.3743934181454E-27
 (PID.TID 0000.0001) %MON dynstat_uvel_mean            =   1.0354433730158E-03
-(PID.TID 0000.0001) %MON dynstat_uvel_sd              =   8.0403880589167E-03
+(PID.TID 0000.0001) %MON dynstat_uvel_sd              =   8.4216600289704E-03
 (PID.TID 0000.0001) %MON dynstat_uvel_del2            =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON dynstat_vvel_max             =  -6.5149048566576E-87
-(PID.TID 0000.0001) %MON dynstat_vvel_min             =  -6.2030128667197E-02
+(PID.TID 0000.0001) %MON dynstat_vvel_max             =  -4.2210831709954E-87
+(PID.TID 0000.0001) %MON dynstat_vvel_min             =  -6.6587481183418E-02
 (PID.TID 0000.0001) %MON dynstat_vvel_mean            =  -9.7776942587845E-04
-(PID.TID 0000.0001) %MON dynstat_vvel_sd              =   7.3928845364269E-03
+(PID.TID 0000.0001) %MON dynstat_vvel_sd              =   7.9069530423049E-03
 (PID.TID 0000.0001) %MON dynstat_vvel_del2            =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON dynstat_wvel_max             =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON dynstat_wvel_min             =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON dynstat_wvel_max             =  -0.0000000000000E+00
+(PID.TID 0000.0001) %MON dynstat_wvel_min             =  -0.0000000000000E+00
 (PID.TID 0000.0001) %MON dynstat_wvel_mean            =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON dynstat_wvel_sd              =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON dynstat_wvel_del2            =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON dynstat_theta_max            =   9.0215181210937E+00
+(PID.TID 0000.0001) %MON dynstat_theta_max            =   9.0247435799918E+00
 (PID.TID 0000.0001) %MON dynstat_theta_min            =   2.2039011202727E+00
 (PID.TID 0000.0001) %MON dynstat_theta_mean           =   5.5619989679035E+00
-(PID.TID 0000.0001) %MON dynstat_theta_sd             =   2.0532068986585E+00
+(PID.TID 0000.0001) %MON dynstat_theta_sd             =   2.0532079931486E+00
 (PID.TID 0000.0001) %MON dynstat_theta_del2           =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON dynstat_salt_max             =   3.5000000000000E+01
 (PID.TID 0000.0001) %MON dynstat_salt_min             =   3.5000000000000E+01
 (PID.TID 0000.0001) %MON dynstat_salt_mean            =   3.5000000000000E+01
-(PID.TID 0000.0001) %MON dynstat_salt_sd              =   5.0885042165894E-14
+(PID.TID 0000.0001) %MON dynstat_salt_sd              =   5.0786296170565E-14
 (PID.TID 0000.0001) %MON dynstat_salt_del2            =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON dynstat_sst_max              =   9.0215181210937E+00
-(PID.TID 0000.0001) %MON dynstat_sst_min              =   9.0215181210937E+00
-(PID.TID 0000.0001) %MON dynstat_sst_mean             =   9.0215181210937E+00
+(PID.TID 0000.0001) %MON dynstat_sst_max              =   9.0247435799918E+00
+(PID.TID 0000.0001) %MON dynstat_sst_min              =   9.0247435799918E+00
+(PID.TID 0000.0001) %MON dynstat_sst_mean             =   9.0247435799918E+00
 (PID.TID 0000.0001) %MON dynstat_sst_sd               =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON dynstat_sst_del2             =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON dynstat_sss_max              =   3.5000000000000E+01
@@ -2332,38 +2516,41 @@ time,fu0,fu1,fu =   9.6000E+03  1.0000E-01  1.0000E-01  1.0000E-01  5.2222222222
 (PID.TID 0000.0001) %MON dynstat_sss_mean             =   3.5000000000000E+01
 (PID.TID 0000.0001) %MON dynstat_sss_sd               =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON dynstat_sss_del2             =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON extforcing_qnet_max          =   1.8277777777778E+02
-(PID.TID 0000.0001) %MON extforcing_qnet_min          =   1.8277777777778E+02
-(PID.TID 0000.0001) %MON extforcing_qnet_mean         =   1.8277777777778E+02
-(PID.TID 0000.0001) %MON extforcing_qnet_sd           =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON extforcing_qnet_del2         =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON extforcing_qsw_max           =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON extforcing_qsw_min           =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON extforcing_qsw_mean          =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON extforcing_qsw_sd            =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON extforcing_qsw_del2          =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON extforcing_empmr_max         =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON extforcing_empmr_min         =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON extforcing_empmr_mean        =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON extforcing_empmr_sd          =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON extforcing_empmr_del2        =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON extforcing_fu_max            =   1.0000000000000E-01
-(PID.TID 0000.0001) %MON extforcing_fu_min            =   1.0000000000000E-01
-(PID.TID 0000.0001) %MON extforcing_fu_mean           =   1.0000000000000E-01
-(PID.TID 0000.0001) %MON extforcing_fu_sd             =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON extforcing_fu_del2           =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON extforcing_fv_max            =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON extforcing_fv_min            =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON extforcing_fv_mean           =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON extforcing_fv_sd             =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON extforcing_fv_del2           =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON advcfl_uvel_max              =   1.6226756728046E-02
-(PID.TID 0000.0001) %MON advcfl_vvel_max              =   1.4887230880127E-02
+(PID.TID 0000.0001) %MON forcing_qnet_max             =   1.8277777777778E+02
+(PID.TID 0000.0001) %MON forcing_qnet_min             =   1.8277777777778E+02
+(PID.TID 0000.0001) %MON forcing_qnet_mean            =   1.8277777777778E+02
+(PID.TID 0000.0001) %MON forcing_qnet_sd              =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON forcing_qnet_del2            =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON forcing_qsw_max              =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON forcing_qsw_min              =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON forcing_qsw_mean             =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON forcing_qsw_sd               =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON forcing_qsw_del2             =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON forcing_empmr_max            =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON forcing_empmr_min            =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON forcing_empmr_mean           =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON forcing_empmr_sd             =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON forcing_empmr_del2           =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON forcing_fu_max               =   1.0000000000000E-01
+(PID.TID 0000.0001) %MON forcing_fu_min               =   1.0000000000000E-01
+(PID.TID 0000.0001) %MON forcing_fu_mean              =   1.0000000000000E-01
+(PID.TID 0000.0001) %MON forcing_fu_sd                =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON forcing_fu_del2              =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON forcing_fv_max               =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON forcing_fv_min               =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON forcing_fv_mean              =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON forcing_fv_sd                =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON forcing_fv_del2              =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON trAdv_CFL_u_max              =   1.6818946503245E-02
+(PID.TID 0000.0001) %MON trAdv_CFL_v_max              =   1.3285377227741E-02
+(PID.TID 0000.0001) %MON trAdv_CFL_w_max              =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON advcfl_uvel_max              =   1.7022170008540E-02
+(PID.TID 0000.0001) %MON advcfl_vvel_max              =   1.5980995484020E-02
 (PID.TID 0000.0001) %MON advcfl_wvel_max              =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON advcfl_W_hf_max              =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON pe_b_mean                    =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON ke_max                       =   4.2095249756026E-03
-(PID.TID 0000.0001) %MON ke_mean                      =   6.0665378967907E-05
+(PID.TID 0000.0001) %MON ke_max                       =   4.7321743789924E-03
+(PID.TID 0000.0001) %MON ke_mean                      =   6.7736220042838E-05
 (PID.TID 0000.0001) %MON ke_vol                       =   1.7475000000000E+10
 (PID.TID 0000.0001) %MON vort_r_min                   =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON vort_r_max                   =   0.0000000000000E+00
@@ -2376,12 +2563,12 @@ time,fu0,fu1,fu =   9.6000E+03  1.0000E-01  1.0000E-01  1.0000E-01  5.2222222222
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // End MONITOR dynamic field statistics
 (PID.TID 0000.0001) // =======================================================
-time,SST,SSS,fu,fv,Q,E-P,i0,i1,a,b =   1.0800E+04  0.0000E+00  0.0000E+00  1.0000E-01  0.0000E+00  1.8375E+02  0.0000E+00    72     1  5.2500E-01  4.7500E-01
-time,fu0,fu1,fu =   1.0800E+04  1.0000E-01  1.0000E-01  1.0000E-01  5.250000000000000E-01  4.750000000000000E-01
+ EXTERNAL_FIELDS_LOAD,         9 : iP,iLd,i0,i1=   72    1   72    1 ; Wght=  0.4750000000  0.5250000000
  cg2d: Sum(rhs),rhsMax =   0.00000000000000E+00  0.00000000000000E+00
-(PID.TID 0000.0001)                    cg2d_init_res =    0.00000000000000E+00
-(PID.TID 0000.0001)                       cg2d_iters =     0
-(PID.TID 0000.0001)                         cg2d_res =    0.00000000000000E+00
+(PID.TID 0000.0001)      cg2d_init_res =   0.00000000000000E+00
+(PID.TID 0000.0001)      cg2d_iters(min,last) =       0       0
+(PID.TID 0000.0001)      cg2d_min_res  =   0.00000000000000E+00
+(PID.TID 0000.0001)      cg2d_last_res =   0.00000000000000E+00
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // Begin MONITOR dynamic field statistics
 (PID.TID 0000.0001) // =======================================================
@@ -2392,34 +2579,34 @@ time,fu0,fu1,fu =   1.0800E+04  1.0000E-01  1.0000E-01  1.0000E-01  5.2500000000
 (PID.TID 0000.0001) %MON dynstat_eta_mean             =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON dynstat_eta_sd               =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON dynstat_eta_del2             =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON dynstat_uvel_max             =   6.5104015949785E-02
-(PID.TID 0000.0001) %MON dynstat_uvel_min             =  -8.3003712068608E-24
+(PID.TID 0000.0001) %MON dynstat_uvel_max             =   6.8860889408803E-02
+(PID.TID 0000.0001) %MON dynstat_uvel_min             =  -6.2924019498100E-18
 (PID.TID 0000.0001) %MON dynstat_uvel_mean            =   1.0279249224075E-03
-(PID.TID 0000.0001) %MON dynstat_uvel_sd              =   7.7604036421778E-03
+(PID.TID 0000.0001) %MON dynstat_uvel_sd              =   8.1797384316002E-03
 (PID.TID 0000.0001) %MON dynstat_uvel_del2            =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON dynstat_vvel_max             =  -2.5672443079502E-86
-(PID.TID 0000.0001) %MON dynstat_vvel_min             =  -7.0098788774235E-02
+(PID.TID 0000.0001) %MON dynstat_vvel_max             =  -1.5476949849029E-86
+(PID.TID 0000.0001) %MON dynstat_vvel_min             =  -7.6469965472683E-02
 (PID.TID 0000.0001) %MON dynstat_vvel_mean            =  -1.1536394106537E-03
-(PID.TID 0000.0001) %MON dynstat_vvel_sd              =   8.3983310793709E-03
+(PID.TID 0000.0001) %MON dynstat_vvel_sd              =   9.0870247781534E-03
 (PID.TID 0000.0001) %MON dynstat_vvel_del2            =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON dynstat_wvel_max             =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON dynstat_wvel_min             =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON dynstat_wvel_max             =  -0.0000000000000E+00
+(PID.TID 0000.0001) %MON dynstat_wvel_min             =  -0.0000000000000E+00
 (PID.TID 0000.0001) %MON dynstat_wvel_mean            =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON dynstat_wvel_sd              =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON dynstat_wvel_del2            =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON dynstat_theta_max            =   9.0140325058368E+00
+(PID.TID 0000.0001) %MON dynstat_theta_max            =   9.0179675297733E+00
 (PID.TID 0000.0001) %MON dynstat_theta_min            =   2.2039041781474E+00
 (PID.TID 0000.0001) %MON dynstat_theta_mean           =   5.5619199709715E+00
-(PID.TID 0000.0001) %MON dynstat_theta_sd             =   2.0530727830075E+00
+(PID.TID 0000.0001) %MON dynstat_theta_sd             =   2.0530739002449E+00
 (PID.TID 0000.0001) %MON dynstat_theta_del2           =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON dynstat_salt_max             =   3.5000000000000E+01
 (PID.TID 0000.0001) %MON dynstat_salt_min             =   3.5000000000000E+01
 (PID.TID 0000.0001) %MON dynstat_salt_mean            =   3.5000000000000E+01
-(PID.TID 0000.0001) %MON dynstat_salt_sd              =   5.6861205059398E-14
+(PID.TID 0000.0001) %MON dynstat_salt_sd              =   5.6203222368937E-14
 (PID.TID 0000.0001) %MON dynstat_salt_del2            =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON dynstat_sst_max              =   9.0140325058368E+00
-(PID.TID 0000.0001) %MON dynstat_sst_min              =   9.0140325058368E+00
-(PID.TID 0000.0001) %MON dynstat_sst_mean             =   9.0140325058368E+00
+(PID.TID 0000.0001) %MON dynstat_sst_max              =   9.0179675297733E+00
+(PID.TID 0000.0001) %MON dynstat_sst_min              =   9.0179675297733E+00
+(PID.TID 0000.0001) %MON dynstat_sst_mean             =   9.0179675297733E+00
 (PID.TID 0000.0001) %MON dynstat_sst_sd               =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON dynstat_sst_del2             =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON dynstat_sss_max              =   3.5000000000000E+01
@@ -2427,38 +2614,41 @@ time,fu0,fu1,fu =   1.0800E+04  1.0000E-01  1.0000E-01  1.0000E-01  5.2500000000
 (PID.TID 0000.0001) %MON dynstat_sss_mean             =   3.5000000000000E+01
 (PID.TID 0000.0001) %MON dynstat_sss_sd               =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON dynstat_sss_del2             =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON extforcing_qnet_max          =   1.8375000000000E+02
-(PID.TID 0000.0001) %MON extforcing_qnet_min          =   1.8375000000000E+02
-(PID.TID 0000.0001) %MON extforcing_qnet_mean         =   1.8375000000000E+02
-(PID.TID 0000.0001) %MON extforcing_qnet_sd           =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON extforcing_qnet_del2         =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON extforcing_qsw_max           =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON extforcing_qsw_min           =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON extforcing_qsw_mean          =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON extforcing_qsw_sd            =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON extforcing_qsw_del2          =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON extforcing_empmr_max         =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON extforcing_empmr_min         =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON extforcing_empmr_mean        =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON extforcing_empmr_sd          =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON extforcing_empmr_del2        =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON extforcing_fu_max            =   1.0000000000000E-01
-(PID.TID 0000.0001) %MON extforcing_fu_min            =   1.0000000000000E-01
-(PID.TID 0000.0001) %MON extforcing_fu_mean           =   1.0000000000000E-01
-(PID.TID 0000.0001) %MON extforcing_fu_sd             =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON extforcing_fu_del2           =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON extforcing_fv_max            =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON extforcing_fv_min            =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON extforcing_fv_mean           =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON extforcing_fv_sd             =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON extforcing_fv_del2           =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON advcfl_uvel_max              =   1.5624963827948E-02
-(PID.TID 0000.0001) %MON advcfl_vvel_max              =   1.6823709305817E-02
+(PID.TID 0000.0001) %MON forcing_qnet_max             =   1.8375000000000E+02
+(PID.TID 0000.0001) %MON forcing_qnet_min             =   1.8375000000000E+02
+(PID.TID 0000.0001) %MON forcing_qnet_mean            =   1.8375000000000E+02
+(PID.TID 0000.0001) %MON forcing_qnet_sd              =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON forcing_qnet_del2            =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON forcing_qsw_max              =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON forcing_qsw_min              =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON forcing_qsw_mean             =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON forcing_qsw_sd               =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON forcing_qsw_del2             =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON forcing_empmr_max            =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON forcing_empmr_min            =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON forcing_empmr_mean           =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON forcing_empmr_sd             =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON forcing_empmr_del2           =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON forcing_fu_max               =   1.0000000000000E-01
+(PID.TID 0000.0001) %MON forcing_fu_min               =   1.0000000000000E-01
+(PID.TID 0000.0001) %MON forcing_fu_mean              =   1.0000000000000E-01
+(PID.TID 0000.0001) %MON forcing_fu_sd                =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON forcing_fu_del2              =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON forcing_fv_max               =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON forcing_fv_min               =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON forcing_fv_mean              =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON forcing_fv_sd                =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON forcing_fv_del2              =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON trAdv_CFL_u_max              =   1.7022170008540E-02
+(PID.TID 0000.0001) %MON trAdv_CFL_v_max              =   1.5980995484020E-02
+(PID.TID 0000.0001) %MON trAdv_CFL_w_max              =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON advcfl_uvel_max              =   1.6526613458113E-02
+(PID.TID 0000.0001) %MON advcfl_vvel_max              =   1.8352791713444E-02
 (PID.TID 0000.0001) %MON advcfl_wvel_max              =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON advcfl_W_hf_max              =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON pe_b_mean                    =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON ke_max                       =   4.5761865402024E-03
-(PID.TID 0000.0001) %MON ke_mean                      =   6.6571671572087E-05
+(PID.TID 0000.0001) %MON ke_max                       =   5.2947388547824E-03
+(PID.TID 0000.0001) %MON ke_mean                      =   7.5934826832046E-05
 (PID.TID 0000.0001) %MON ke_vol                       =   1.7475000000000E+10
 (PID.TID 0000.0001) %MON vort_r_min                   =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON vort_r_max                   =   0.0000000000000E+00
@@ -2471,12 +2661,12 @@ time,fu0,fu1,fu =   1.0800E+04  1.0000E-01  1.0000E-01  1.0000E-01  5.2500000000
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // End MONITOR dynamic field statistics
 (PID.TID 0000.0001) // =======================================================
-time,SST,SSS,fu,fv,Q,E-P,i0,i1,a,b =   1.2000E+04  0.0000E+00  0.0000E+00  1.0000E-01  0.0000E+00  1.8472E+02  0.0000E+00    72     1  5.2778E-01  4.7222E-01
-time,fu0,fu1,fu =   1.2000E+04  1.0000E-01  1.0000E-01  1.0000E-01  5.277777777777778E-01  4.722222222222222E-01
+ EXTERNAL_FIELDS_LOAD,        10 : iP,iLd,i0,i1=   72    1   72    1 ; Wght=  0.4722222222  0.5277777778
  cg2d: Sum(rhs),rhsMax =   0.00000000000000E+00  0.00000000000000E+00
-(PID.TID 0000.0001)                    cg2d_init_res =    0.00000000000000E+00
-(PID.TID 0000.0001)                       cg2d_iters =     0
-(PID.TID 0000.0001)                         cg2d_res =    0.00000000000000E+00
+(PID.TID 0000.0001)      cg2d_init_res =   0.00000000000000E+00
+(PID.TID 0000.0001)      cg2d_iters(min,last) =       0       0
+(PID.TID 0000.0001)      cg2d_min_res  =   0.00000000000000E+00
+(PID.TID 0000.0001)      cg2d_last_res =   0.00000000000000E+00
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // Begin MONITOR dynamic field statistics
 (PID.TID 0000.0001) // =======================================================
@@ -2487,34 +2677,34 @@ time,fu0,fu1,fu =   1.2000E+04  1.0000E-01  1.0000E-01  1.0000E-01  5.2777777777
 (PID.TID 0000.0001) %MON dynstat_eta_mean             =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON dynstat_eta_sd               =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON dynstat_eta_del2             =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON dynstat_uvel_max             =   5.8635016862451E-02
-(PID.TID 0000.0001) %MON dynstat_uvel_min             =  -2.5499293313533E-19
+(PID.TID 0000.0001) %MON dynstat_uvel_max             =   6.3110190358859E-02
+(PID.TID 0000.0001) %MON dynstat_uvel_min             =  -5.3921372742201E-15
 (PID.TID 0000.0001) %MON dynstat_uvel_mean            =   9.9075312249693E-04
-(PID.TID 0000.0001) %MON dynstat_uvel_sd              =   7.0559125271216E-03
+(PID.TID 0000.0001) %MON dynstat_uvel_sd              =   7.5190701162667E-03
 (PID.TID 0000.0001) %MON dynstat_uvel_del2            =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON dynstat_vvel_max             =  -8.9437213357973E-86
-(PID.TID 0000.0001) %MON dynstat_vvel_min             =  -7.3911134403430E-02
-(PID.TID 0000.0001) %MON dynstat_vvel_mean            =  -1.3256866167701E-03
-(PID.TID 0000.0001) %MON dynstat_vvel_sd              =   9.0168881481520E-03
+(PID.TID 0000.0001) %MON dynstat_vvel_max             =  -4.9811291741026E-86
+(PID.TID 0000.0001) %MON dynstat_vvel_min             =  -8.2680700169277E-02
+(PID.TID 0000.0001) %MON dynstat_vvel_mean            =  -1.3256866167700E-03
+(PID.TID 0000.0001) %MON dynstat_vvel_sd              =   9.8722022074408E-03
 (PID.TID 0000.0001) %MON dynstat_vvel_del2            =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON dynstat_wvel_max             =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON dynstat_wvel_min             =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON dynstat_wvel_max             =  -0.0000000000000E+00
+(PID.TID 0000.0001) %MON dynstat_wvel_min             =  -0.0000000000000E+00
 (PID.TID 0000.0001) %MON dynstat_wvel_mean            =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON dynstat_wvel_sd              =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON dynstat_wvel_del2            =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON dynstat_theta_max            =   9.0055066332963E+00
+(PID.TID 0000.0001) %MON dynstat_theta_max            =   9.0100758704200E+00
 (PID.TID 0000.0001) %MON dynstat_theta_min            =   2.2039072359991E+00
 (PID.TID 0000.0001) %MON dynstat_theta_mean           =   5.5618405560663E+00
-(PID.TID 0000.0001) %MON dynstat_theta_sd             =   2.0529381652407E+00
+(PID.TID 0000.0001) %MON dynstat_theta_sd             =   2.0529391668346E+00
 (PID.TID 0000.0001) %MON dynstat_theta_del2           =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON dynstat_salt_max             =   3.5000000000000E+01
 (PID.TID 0000.0001) %MON dynstat_salt_min             =   3.5000000000000E+01
 (PID.TID 0000.0001) %MON dynstat_salt_mean            =   3.5000000000000E+01
-(PID.TID 0000.0001) %MON dynstat_salt_sd              =   6.2155533078535E-14
+(PID.TID 0000.0001) %MON dynstat_salt_sd              =   6.1692475810188E-14
 (PID.TID 0000.0001) %MON dynstat_salt_del2            =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON dynstat_sst_max              =   9.0055066332963E+00
-(PID.TID 0000.0001) %MON dynstat_sst_min              =   9.0055066332963E+00
-(PID.TID 0000.0001) %MON dynstat_sst_mean             =   9.0055066332963E+00
+(PID.TID 0000.0001) %MON dynstat_sst_max              =   9.0100758704200E+00
+(PID.TID 0000.0001) %MON dynstat_sst_min              =   9.0100758704200E+00
+(PID.TID 0000.0001) %MON dynstat_sst_mean             =   9.0100758704200E+00
 (PID.TID 0000.0001) %MON dynstat_sst_sd               =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON dynstat_sst_del2             =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON dynstat_sss_max              =   3.5000000000000E+01
@@ -2522,38 +2712,41 @@ time,fu0,fu1,fu =   1.2000E+04  1.0000E-01  1.0000E-01  1.0000E-01  5.2777777777
 (PID.TID 0000.0001) %MON dynstat_sss_mean             =   3.5000000000000E+01
 (PID.TID 0000.0001) %MON dynstat_sss_sd               =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON dynstat_sss_del2             =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON extforcing_qnet_max          =   1.8472222222222E+02
-(PID.TID 0000.0001) %MON extforcing_qnet_min          =   1.8472222222222E+02
-(PID.TID 0000.0001) %MON extforcing_qnet_mean         =   1.8472222222222E+02
-(PID.TID 0000.0001) %MON extforcing_qnet_sd           =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON extforcing_qnet_del2         =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON extforcing_qsw_max           =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON extforcing_qsw_min           =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON extforcing_qsw_mean          =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON extforcing_qsw_sd            =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON extforcing_qsw_del2          =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON extforcing_empmr_max         =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON extforcing_empmr_min         =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON extforcing_empmr_mean        =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON extforcing_empmr_sd          =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON extforcing_empmr_del2        =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON extforcing_fu_max            =   1.0000000000000E-01
-(PID.TID 0000.0001) %MON extforcing_fu_min            =   1.0000000000000E-01
-(PID.TID 0000.0001) %MON extforcing_fu_mean           =   1.0000000000000E-01
-(PID.TID 0000.0001) %MON extforcing_fu_sd             =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON extforcing_fu_del2           =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON extforcing_fv_max            =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON extforcing_fv_min            =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON extforcing_fv_mean           =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON extforcing_fv_sd             =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON extforcing_fv_del2           =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON advcfl_uvel_max              =   1.4072404046988E-02
-(PID.TID 0000.0001) %MON advcfl_vvel_max              =   1.7738672256823E-02
+(PID.TID 0000.0001) %MON forcing_qnet_max             =   1.8472222222222E+02
+(PID.TID 0000.0001) %MON forcing_qnet_min             =   1.8472222222222E+02
+(PID.TID 0000.0001) %MON forcing_qnet_mean            =   1.8472222222222E+02
+(PID.TID 0000.0001) %MON forcing_qnet_sd              =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON forcing_qnet_del2            =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON forcing_qsw_max              =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON forcing_qsw_min              =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON forcing_qsw_mean             =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON forcing_qsw_sd               =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON forcing_qsw_del2             =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON forcing_empmr_max            =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON forcing_empmr_min            =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON forcing_empmr_mean           =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON forcing_empmr_sd             =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON forcing_empmr_del2           =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON forcing_fu_max               =   1.0000000000000E-01
+(PID.TID 0000.0001) %MON forcing_fu_min               =   1.0000000000000E-01
+(PID.TID 0000.0001) %MON forcing_fu_mean              =   1.0000000000000E-01
+(PID.TID 0000.0001) %MON forcing_fu_sd                =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON forcing_fu_del2              =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON forcing_fv_max               =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON forcing_fv_min               =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON forcing_fv_mean              =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON forcing_fv_sd                =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON forcing_fv_del2              =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON trAdv_CFL_u_max              =   1.6526613458113E-02
+(PID.TID 0000.0001) %MON trAdv_CFL_v_max              =   1.8352791713444E-02
+(PID.TID 0000.0001) %MON trAdv_CFL_w_max              =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON advcfl_uvel_max              =   1.5146445686126E-02
+(PID.TID 0000.0001) %MON advcfl_vvel_max              =   1.9843368040626E-02
 (PID.TID 0000.0001) %MON advcfl_wvel_max              =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON advcfl_W_hf_max              =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON pe_b_mean                    =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON ke_max                       =   4.4504604956309E-03
-(PID.TID 0000.0001) %MON ke_mean                      =   6.6914605111147E-05
+(PID.TID 0000.0001) %MON ke_max                       =   5.4094971538066E-03
+(PID.TID 0000.0001) %MON ke_mean                      =   7.8367914296777E-05
 (PID.TID 0000.0001) %MON ke_vol                       =   1.7475000000000E+10
 (PID.TID 0000.0001) %MON vort_r_min                   =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON vort_r_max                   =   0.0000000000000E+00
@@ -2566,12 +2759,12 @@ time,fu0,fu1,fu =   1.2000E+04  1.0000E-01  1.0000E-01  1.0000E-01  5.2777777777
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // End MONITOR dynamic field statistics
 (PID.TID 0000.0001) // =======================================================
-time,SST,SSS,fu,fv,Q,E-P,i0,i1,a,b =   1.3200E+04  0.0000E+00  0.0000E+00  1.0000E-01  0.0000E+00  1.8569E+02  0.0000E+00    72     1  5.3056E-01  4.6944E-01
-time,fu0,fu1,fu =   1.3200E+04  1.0000E-01  1.0000E-01  1.0000E-01  5.305555555555556E-01  4.694444444444444E-01
+ EXTERNAL_FIELDS_LOAD,        11 : iP,iLd,i0,i1=   72    1   72    1 ; Wght=  0.4694444444  0.5305555556
  cg2d: Sum(rhs),rhsMax =   0.00000000000000E+00  0.00000000000000E+00
-(PID.TID 0000.0001)                    cg2d_init_res =    0.00000000000000E+00
-(PID.TID 0000.0001)                       cg2d_iters =     0
-(PID.TID 0000.0001)                         cg2d_res =    0.00000000000000E+00
+(PID.TID 0000.0001)      cg2d_init_res =   0.00000000000000E+00
+(PID.TID 0000.0001)      cg2d_iters(min,last) =       0       0
+(PID.TID 0000.0001)      cg2d_min_res  =   0.00000000000000E+00
+(PID.TID 0000.0001)      cg2d_last_res =   0.00000000000000E+00
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // Begin MONITOR dynamic field statistics
 (PID.TID 0000.0001) // =======================================================
@@ -2582,34 +2775,34 @@ time,fu0,fu1,fu =   1.3200E+04  1.0000E-01  1.0000E-01  1.0000E-01  5.3055555555
 (PID.TID 0000.0001) %MON dynstat_eta_mean             =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON dynstat_eta_sd               =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON dynstat_eta_del2             =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON dynstat_uvel_max             =   4.8822684839001E-02
-(PID.TID 0000.0001) %MON dynstat_uvel_min             =  -4.2164674679364E-16
+(PID.TID 0000.0001) %MON dynstat_uvel_max             =   5.2130261167417E-02
+(PID.TID 0000.0001) %MON dynstat_uvel_min             =  -6.9536641274784E-15
 (PID.TID 0000.0001) %MON dynstat_uvel_mean            =   9.2500492763427E-04
-(PID.TID 0000.0001) %MON dynstat_uvel_sd              =   6.0584693641285E-03
+(PID.TID 0000.0001) %MON dynstat_uvel_sd              =   6.3442697648298E-03
 (PID.TID 0000.0001) %MON dynstat_uvel_del2            =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON dynstat_vvel_max             =  -2.7572676426610E-85
-(PID.TID 0000.0001) %MON dynstat_vvel_min             =  -7.2081990635178E-02
+(PID.TID 0000.0001) %MON dynstat_vvel_max             =  -1.4017665718302E-85
+(PID.TID 0000.0001) %MON dynstat_vvel_min             =  -8.0485347431524E-02
 (PID.TID 0000.0001) %MON dynstat_vvel_mean            =  -1.4889482615332E-03
-(PID.TID 0000.0001) %MON dynstat_vvel_sd              =   9.2796843949676E-03
+(PID.TID 0000.0001) %MON dynstat_vvel_sd              =   9.9169726402366E-03
 (PID.TID 0000.0001) %MON dynstat_vvel_del2            =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON dynstat_wvel_max             =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON dynstat_wvel_min             =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON dynstat_wvel_max             =  -0.0000000000000E+00
+(PID.TID 0000.0001) %MON dynstat_wvel_min             =  -0.0000000000000E+00
 (PID.TID 0000.0001) %MON dynstat_wvel_mean            =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON dynstat_wvel_sd              =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON dynstat_wvel_del2            =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON dynstat_theta_max            =   8.9966732986287E+00
+(PID.TID 0000.0001) %MON dynstat_theta_max            =   9.0003777631312E+00
 (PID.TID 0000.0001) %MON dynstat_theta_min            =   2.2039102938279E+00
 (PID.TID 0000.0001) %MON dynstat_theta_mean           =   5.5617607231879E+00
-(PID.TID 0000.0001) %MON dynstat_theta_sd             =   2.0528033054776E+00
+(PID.TID 0000.0001) %MON dynstat_theta_sd             =   2.0528039143942E+00
 (PID.TID 0000.0001) %MON dynstat_theta_del2           =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON dynstat_salt_max             =   3.5000000000000E+01
 (PID.TID 0000.0001) %MON dynstat_salt_min             =   3.5000000000000E+01
 (PID.TID 0000.0001) %MON dynstat_salt_mean            =   3.5000000000000E+01
-(PID.TID 0000.0001) %MON dynstat_salt_sd              =   6.8234949176859E-14
+(PID.TID 0000.0001) %MON dynstat_salt_sd              =   6.7963429533205E-14
 (PID.TID 0000.0001) %MON dynstat_salt_del2            =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON dynstat_sst_max              =   8.9966732986287E+00
-(PID.TID 0000.0001) %MON dynstat_sst_min              =   8.9966732986287E+00
-(PID.TID 0000.0001) %MON dynstat_sst_mean             =   8.9966732986287E+00
+(PID.TID 0000.0001) %MON dynstat_sst_max              =   9.0003777631312E+00
+(PID.TID 0000.0001) %MON dynstat_sst_min              =   9.0003777631312E+00
+(PID.TID 0000.0001) %MON dynstat_sst_mean             =   9.0003777631312E+00
 (PID.TID 0000.0001) %MON dynstat_sst_sd               =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON dynstat_sst_del2             =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON dynstat_sss_max              =   3.5000000000000E+01
@@ -2617,38 +2810,41 @@ time,fu0,fu1,fu =   1.3200E+04  1.0000E-01  1.0000E-01  1.0000E-01  5.3055555555
 (PID.TID 0000.0001) %MON dynstat_sss_mean             =   3.5000000000000E+01
 (PID.TID 0000.0001) %MON dynstat_sss_sd               =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON dynstat_sss_del2             =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON extforcing_qnet_max          =   1.8569444444444E+02
-(PID.TID 0000.0001) %MON extforcing_qnet_min          =   1.8569444444444E+02
-(PID.TID 0000.0001) %MON extforcing_qnet_mean         =   1.8569444444444E+02
-(PID.TID 0000.0001) %MON extforcing_qnet_sd           =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON extforcing_qnet_del2         =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON extforcing_qsw_max           =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON extforcing_qsw_min           =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON extforcing_qsw_mean          =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON extforcing_qsw_sd            =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON extforcing_qsw_del2          =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON extforcing_empmr_max         =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON extforcing_empmr_min         =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON extforcing_empmr_mean        =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON extforcing_empmr_sd          =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON extforcing_empmr_del2        =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON extforcing_fu_max            =   1.0000000000000E-01
-(PID.TID 0000.0001) %MON extforcing_fu_min            =   1.0000000000000E-01
-(PID.TID 0000.0001) %MON extforcing_fu_mean           =   1.0000000000000E-01
-(PID.TID 0000.0001) %MON extforcing_fu_sd             =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON extforcing_fu_del2           =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON extforcing_fv_max            =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON extforcing_fv_min            =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON extforcing_fv_mean           =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON extforcing_fv_sd             =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON extforcing_fv_del2           =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON advcfl_uvel_max              =   1.1717444361360E-02
-(PID.TID 0000.0001) %MON advcfl_vvel_max              =   1.7299677752443E-02
+(PID.TID 0000.0001) %MON forcing_qnet_max             =   1.8569444444444E+02
+(PID.TID 0000.0001) %MON forcing_qnet_min             =   1.8569444444444E+02
+(PID.TID 0000.0001) %MON forcing_qnet_mean            =   1.8569444444444E+02
+(PID.TID 0000.0001) %MON forcing_qnet_sd              =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON forcing_qnet_del2            =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON forcing_qsw_max              =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON forcing_qsw_min              =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON forcing_qsw_mean             =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON forcing_qsw_sd               =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON forcing_qsw_del2             =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON forcing_empmr_max            =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON forcing_empmr_min            =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON forcing_empmr_mean           =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON forcing_empmr_sd             =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON forcing_empmr_del2           =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON forcing_fu_max               =   1.0000000000000E-01
+(PID.TID 0000.0001) %MON forcing_fu_min               =   1.0000000000000E-01
+(PID.TID 0000.0001) %MON forcing_fu_mean              =   1.0000000000000E-01
+(PID.TID 0000.0001) %MON forcing_fu_sd                =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON forcing_fu_del2              =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON forcing_fv_max               =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON forcing_fv_min               =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON forcing_fv_mean              =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON forcing_fv_sd                =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON forcing_fv_del2              =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON trAdv_CFL_u_max              =   1.5146445686126E-02
+(PID.TID 0000.0001) %MON trAdv_CFL_v_max              =   1.9843368040626E-02
+(PID.TID 0000.0001) %MON trAdv_CFL_w_max              =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON advcfl_uvel_max              =   1.2511262680180E-02
+(PID.TID 0000.0001) %MON advcfl_vvel_max              =   1.9316483383566E-02
 (PID.TID 0000.0001) %MON advcfl_wvel_max              =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON advcfl_W_hf_max              =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON pe_b_mean                    =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON ke_max                       =   3.7897339644091E-03
-(PID.TID 0000.0001) %MON ke_mean                      =   6.2945097273979E-05
+(PID.TID 0000.0001) %MON ke_max                       =   4.5977276402781E-03
+(PID.TID 0000.0001) %MON ke_mean                      =   7.0834353118903E-05
 (PID.TID 0000.0001) %MON ke_vol                       =   1.7475000000000E+10
 (PID.TID 0000.0001) %MON vort_r_min                   =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON vort_r_max                   =   0.0000000000000E+00
@@ -2661,12 +2857,12 @@ time,fu0,fu1,fu =   1.3200E+04  1.0000E-01  1.0000E-01  1.0000E-01  5.3055555555
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // End MONITOR dynamic field statistics
 (PID.TID 0000.0001) // =======================================================
-time,SST,SSS,fu,fv,Q,E-P,i0,i1,a,b =   1.4400E+04  0.0000E+00  0.0000E+00  1.0000E-01  0.0000E+00  1.8667E+02  0.0000E+00    72     1  5.3333E-01  4.6667E-01
-time,fu0,fu1,fu =   1.4400E+04  1.0000E-01  1.0000E-01  1.0000E-01  5.333333333333333E-01  4.666666666666667E-01
+ EXTERNAL_FIELDS_LOAD,        12 : iP,iLd,i0,i1=   72    1   72    1 ; Wght=  0.4666666667  0.5333333333
  cg2d: Sum(rhs),rhsMax =   0.00000000000000E+00  0.00000000000000E+00
-(PID.TID 0000.0001)                    cg2d_init_res =    0.00000000000000E+00
-(PID.TID 0000.0001)                       cg2d_iters =     0
-(PID.TID 0000.0001)                         cg2d_res =    0.00000000000000E+00
+(PID.TID 0000.0001)      cg2d_init_res =   0.00000000000000E+00
+(PID.TID 0000.0001)      cg2d_iters(min,last) =       0       0
+(PID.TID 0000.0001)      cg2d_min_res  =   0.00000000000000E+00
+(PID.TID 0000.0001)      cg2d_last_res =   0.00000000000000E+00
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // Begin MONITOR dynamic field statistics
 (PID.TID 0000.0001) // =======================================================
@@ -2677,34 +2873,34 @@ time,fu0,fu1,fu =   1.4400E+04  1.0000E-01  1.0000E-01  1.0000E-01  5.3333333333
 (PID.TID 0000.0001) %MON dynstat_eta_mean             =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON dynstat_eta_sd               =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON dynstat_eta_del2             =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON dynstat_uvel_max             =   4.0243412426633E-02
-(PID.TID 0000.0001) %MON dynstat_uvel_min             =  -1.5902468504848E-15
+(PID.TID 0000.0001) %MON dynstat_uvel_max             =   4.0858881636918E-02
+(PID.TID 0000.0001) %MON dynstat_uvel_min             =  -1.2813993128808E-16
 (PID.TID 0000.0001) %MON dynstat_uvel_mean            =   8.3258152334816E-04
-(PID.TID 0000.0001) %MON dynstat_uvel_sd              =   5.1782315051084E-03
+(PID.TID 0000.0001) %MON dynstat_uvel_sd              =   5.2266869094126E-03
 (PID.TID 0000.0001) %MON dynstat_uvel_del2            =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON dynstat_vvel_max             =  -7.4467807398528E-85
-(PID.TID 0000.0001) %MON dynstat_vvel_min             =  -6.9506516155396E-02
+(PID.TID 0000.0001) %MON dynstat_vvel_max             =  -3.3750644842941E-85
+(PID.TID 0000.0001) %MON dynstat_vvel_min             =  -7.4001483332933E-02
 (PID.TID 0000.0001) %MON dynstat_vvel_mean            =  -1.6387157840399E-03
-(PID.TID 0000.0001) %MON dynstat_vvel_sd              =   9.6531080885174E-03
+(PID.TID 0000.0001) %MON dynstat_vvel_sd              =   9.9077100962594E-03
 (PID.TID 0000.0001) %MON dynstat_vvel_del2            =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON dynstat_wvel_max             =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON dynstat_wvel_min             =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON dynstat_wvel_max             =  -0.0000000000000E+00
+(PID.TID 0000.0001) %MON dynstat_wvel_min             =  -0.0000000000000E+00
 (PID.TID 0000.0001) %MON dynstat_wvel_mean            =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON dynstat_wvel_sd              =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON dynstat_wvel_del2            =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON dynstat_theta_max            =   8.9896218853531E+00
+(PID.TID 0000.0001) %MON dynstat_theta_max            =   8.9916578512787E+00
 (PID.TID 0000.0001) %MON dynstat_theta_min            =   2.2039133516337E+00
 (PID.TID 0000.0001) %MON dynstat_theta_mean           =   5.5616804723363E+00
-(PID.TID 0000.0001) %MON dynstat_theta_sd             =   2.0526682020511E+00
+(PID.TID 0000.0001) %MON dynstat_theta_sd             =   2.0526686193719E+00
 (PID.TID 0000.0001) %MON dynstat_theta_del2           =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON dynstat_salt_max             =   3.5000000000000E+01
 (PID.TID 0000.0001) %MON dynstat_salt_min             =   3.5000000000000E+01
 (PID.TID 0000.0001) %MON dynstat_salt_mean            =   3.5000000000000E+01
-(PID.TID 0000.0001) %MON dynstat_salt_sd              =   7.4736238702890E-14
+(PID.TID 0000.0001) %MON dynstat_salt_sd              =   7.3365343109673E-14
 (PID.TID 0000.0001) %MON dynstat_salt_del2            =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON dynstat_sst_max              =   8.9896218853531E+00
-(PID.TID 0000.0001) %MON dynstat_sst_min              =   8.9896218853531E+00
-(PID.TID 0000.0001) %MON dynstat_sst_mean             =   8.9896218853531E+00
+(PID.TID 0000.0001) %MON dynstat_sst_max              =   8.9916578512787E+00
+(PID.TID 0000.0001) %MON dynstat_sst_min              =   8.9916578512787E+00
+(PID.TID 0000.0001) %MON dynstat_sst_mean             =   8.9916578512787E+00
 (PID.TID 0000.0001) %MON dynstat_sst_sd               =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON dynstat_sst_del2             =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON dynstat_sss_max              =   3.5000000000000E+01
@@ -2712,38 +2908,41 @@ time,fu0,fu1,fu =   1.4400E+04  1.0000E-01  1.0000E-01  1.0000E-01  5.3333333333
 (PID.TID 0000.0001) %MON dynstat_sss_mean             =   3.5000000000000E+01
 (PID.TID 0000.0001) %MON dynstat_sss_sd               =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON dynstat_sss_del2             =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON extforcing_qnet_max          =   1.8666666666667E+02
-(PID.TID 0000.0001) %MON extforcing_qnet_min          =   1.8666666666667E+02
-(PID.TID 0000.0001) %MON extforcing_qnet_mean         =   1.8666666666667E+02
-(PID.TID 0000.0001) %MON extforcing_qnet_sd           =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON extforcing_qnet_del2         =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON extforcing_qsw_max           =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON extforcing_qsw_min           =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON extforcing_qsw_mean          =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON extforcing_qsw_sd            =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON extforcing_qsw_del2          =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON extforcing_empmr_max         =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON extforcing_empmr_min         =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON extforcing_empmr_mean        =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON extforcing_empmr_sd          =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON extforcing_empmr_del2        =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON extforcing_fu_max            =   1.0000000000000E-01
-(PID.TID 0000.0001) %MON extforcing_fu_min            =   1.0000000000000E-01
-(PID.TID 0000.0001) %MON extforcing_fu_mean           =   1.0000000000000E-01
-(PID.TID 0000.0001) %MON extforcing_fu_sd             =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON extforcing_fu_del2           =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON extforcing_fv_max            =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON extforcing_fv_min            =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON extforcing_fv_mean           =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON extforcing_fv_sd             =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON extforcing_fv_del2           =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON advcfl_uvel_max              =   9.6584189823919E-03
-(PID.TID 0000.0001) %MON advcfl_vvel_max              =   1.6681563877295E-02
+(PID.TID 0000.0001) %MON forcing_qnet_max             =   1.8666666666667E+02
+(PID.TID 0000.0001) %MON forcing_qnet_min             =   1.8666666666667E+02
+(PID.TID 0000.0001) %MON forcing_qnet_mean            =   1.8666666666667E+02
+(PID.TID 0000.0001) %MON forcing_qnet_sd              =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON forcing_qnet_del2            =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON forcing_qsw_max              =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON forcing_qsw_min              =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON forcing_qsw_mean             =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON forcing_qsw_sd               =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON forcing_qsw_del2             =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON forcing_empmr_max            =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON forcing_empmr_min            =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON forcing_empmr_mean           =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON forcing_empmr_sd             =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON forcing_empmr_del2           =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON forcing_fu_max               =   1.0000000000000E-01
+(PID.TID 0000.0001) %MON forcing_fu_min               =   1.0000000000000E-01
+(PID.TID 0000.0001) %MON forcing_fu_mean              =   1.0000000000000E-01
+(PID.TID 0000.0001) %MON forcing_fu_sd                =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON forcing_fu_del2              =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON forcing_fv_max               =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON forcing_fv_min               =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON forcing_fv_mean              =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON forcing_fv_sd                =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON forcing_fv_del2              =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON trAdv_CFL_u_max              =   1.2511262680180E-02
+(PID.TID 0000.0001) %MON trAdv_CFL_v_max              =   1.9316483383566E-02
+(PID.TID 0000.0001) %MON trAdv_CFL_w_max              =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON advcfl_uvel_max              =   9.8061315928604E-03
+(PID.TID 0000.0001) %MON advcfl_vvel_max              =   1.7760355999904E-02
 (PID.TID 0000.0001) %MON advcfl_wvel_max              =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON advcfl_W_hf_max              =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON pe_b_mean                    =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON ke_max                       =   3.2253440159002E-03
-(PID.TID 0000.0001) %MON ke_mean                      =   6.1687579351490E-05
+(PID.TID 0000.0001) %MON ke_max                       =   3.5728338720470E-03
+(PID.TID 0000.0001) %MON ke_mean                      =   6.4429778407213E-05
 (PID.TID 0000.0001) %MON ke_vol                       =   1.7475000000000E+10
 (PID.TID 0000.0001) %MON vort_r_min                   =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON vort_r_max                   =   0.0000000000000E+00
@@ -2756,12 +2955,12 @@ time,fu0,fu1,fu =   1.4400E+04  1.0000E-01  1.0000E-01  1.0000E-01  5.3333333333
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // End MONITOR dynamic field statistics
 (PID.TID 0000.0001) // =======================================================
-time,SST,SSS,fu,fv,Q,E-P,i0,i1,a,b =   1.5600E+04  0.0000E+00  0.0000E+00  1.0000E-01  0.0000E+00  1.8764E+02  0.0000E+00    72     1  5.3611E-01  4.6389E-01
-time,fu0,fu1,fu =   1.5600E+04  1.0000E-01  1.0000E-01  1.0000E-01  5.361111111111111E-01  4.638888888888889E-01
+ EXTERNAL_FIELDS_LOAD,        13 : iP,iLd,i0,i1=   72    1   72    1 ; Wght=  0.4638888889  0.5361111111
  cg2d: Sum(rhs),rhsMax =   0.00000000000000E+00  0.00000000000000E+00
-(PID.TID 0000.0001)                    cg2d_init_res =    0.00000000000000E+00
-(PID.TID 0000.0001)                       cg2d_iters =     0
-(PID.TID 0000.0001)                         cg2d_res =    0.00000000000000E+00
+(PID.TID 0000.0001)      cg2d_init_res =   0.00000000000000E+00
+(PID.TID 0000.0001)      cg2d_iters(min,last) =       0       0
+(PID.TID 0000.0001)      cg2d_min_res  =   0.00000000000000E+00
+(PID.TID 0000.0001)      cg2d_last_res =   0.00000000000000E+00
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // Begin MONITOR dynamic field statistics
 (PID.TID 0000.0001) // =======================================================
@@ -2772,34 +2971,34 @@ time,fu0,fu1,fu =   1.5600E+04  1.0000E-01  1.0000E-01  1.0000E-01  5.3611111111
 (PID.TID 0000.0001) %MON dynstat_eta_mean             =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON dynstat_eta_sd               =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON dynstat_eta_del2             =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON dynstat_uvel_max             =   3.4210475306662E-02
-(PID.TID 0000.0001) %MON dynstat_uvel_min             =  -1.5156078605040E-12
+(PID.TID 0000.0001) %MON dynstat_uvel_max             =   3.3366490436428E-02
+(PID.TID 0000.0001) %MON dynstat_uvel_min             =  -1.4399381564514E-16
 (PID.TID 0000.0001) %MON dynstat_uvel_mean            =   7.1615335167584E-04
-(PID.TID 0000.0001) %MON dynstat_uvel_sd              =   4.4254312501513E-03
+(PID.TID 0000.0001) %MON dynstat_uvel_sd              =   4.3731317669567E-03
 (PID.TID 0000.0001) %MON dynstat_uvel_del2            =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON dynstat_vvel_max             =  -1.7040583855919E-84
-(PID.TID 0000.0001) %MON dynstat_vvel_min             =  -6.9264808066936E-02
+(PID.TID 0000.0001) %MON dynstat_vvel_max             =  -6.4847058646684E-85
+(PID.TID 0000.0001) %MON dynstat_vvel_min             =  -7.0891825800459E-02
 (PID.TID 0000.0001) %MON dynstat_vvel_mean            =  -1.7706706426832E-03
-(PID.TID 0000.0001) %MON dynstat_vvel_sd              =   1.0160117139390E-02
+(PID.TID 0000.0001) %MON dynstat_vvel_sd              =   1.0260577026925E-02
 (PID.TID 0000.0001) %MON dynstat_vvel_del2            =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON dynstat_wvel_max             =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON dynstat_wvel_min             =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON dynstat_wvel_max             =  -0.0000000000000E+00
+(PID.TID 0000.0001) %MON dynstat_wvel_min             =  -0.0000000000000E+00
 (PID.TID 0000.0001) %MON dynstat_wvel_mean            =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON dynstat_wvel_sd              =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON dynstat_wvel_del2            =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON dynstat_theta_max            =   8.9848916916295E+00
+(PID.TID 0000.0001) %MON dynstat_theta_max            =   8.9854328498392E+00
 (PID.TID 0000.0001) %MON dynstat_theta_min            =   2.2039164094166E+00
-(PID.TID 0000.0001) %MON dynstat_theta_mean           =   5.5615998035116E+00
-(PID.TID 0000.0001) %MON dynstat_theta_sd             =   2.0525324683665E+00
+(PID.TID 0000.0001) %MON dynstat_theta_mean           =   5.5615998035115E+00
+(PID.TID 0000.0001) %MON dynstat_theta_sd             =   2.0525328251602E+00
 (PID.TID 0000.0001) %MON dynstat_theta_del2           =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON dynstat_salt_max             =   3.5000000000000E+01
 (PID.TID 0000.0001) %MON dynstat_salt_min             =   3.5000000000000E+01
 (PID.TID 0000.0001) %MON dynstat_salt_mean            =   3.5000000000000E+01
-(PID.TID 0000.0001) %MON dynstat_salt_sd              =   7.9579170858805E-14
+(PID.TID 0000.0001) %MON dynstat_salt_sd              =   7.8327707098532E-14
 (PID.TID 0000.0001) %MON dynstat_salt_del2            =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON dynstat_sst_max              =   8.9842176542738E+00
-(PID.TID 0000.0001) %MON dynstat_sst_min              =   8.9842176542738E+00
-(PID.TID 0000.0001) %MON dynstat_sst_mean             =   8.9842176542738E+00
+(PID.TID 0000.0001) %MON dynstat_sst_max              =   8.9854328498392E+00
+(PID.TID 0000.0001) %MON dynstat_sst_min              =   8.9854328498392E+00
+(PID.TID 0000.0001) %MON dynstat_sst_mean             =   8.9854328498392E+00
 (PID.TID 0000.0001) %MON dynstat_sst_sd               =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON dynstat_sst_del2             =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON dynstat_sss_max              =   3.5000000000000E+01
@@ -2807,38 +3006,41 @@ time,fu0,fu1,fu =   1.5600E+04  1.0000E-01  1.0000E-01  1.0000E-01  5.3611111111
 (PID.TID 0000.0001) %MON dynstat_sss_mean             =   3.5000000000000E+01
 (PID.TID 0000.0001) %MON dynstat_sss_sd               =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON dynstat_sss_del2             =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON extforcing_qnet_max          =   1.8763888888889E+02
-(PID.TID 0000.0001) %MON extforcing_qnet_min          =   1.8763888888889E+02
-(PID.TID 0000.0001) %MON extforcing_qnet_mean         =   1.8763888888889E+02
-(PID.TID 0000.0001) %MON extforcing_qnet_sd           =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON extforcing_qnet_del2         =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON extforcing_qsw_max           =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON extforcing_qsw_min           =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON extforcing_qsw_mean          =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON extforcing_qsw_sd            =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON extforcing_qsw_del2          =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON extforcing_empmr_max         =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON extforcing_empmr_min         =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON extforcing_empmr_mean        =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON extforcing_empmr_sd          =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON extforcing_empmr_del2        =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON extforcing_fu_max            =   1.0000000000000E-01
-(PID.TID 0000.0001) %MON extforcing_fu_min            =   1.0000000000000E-01
-(PID.TID 0000.0001) %MON extforcing_fu_mean           =   1.0000000000000E-01
-(PID.TID 0000.0001) %MON extforcing_fu_sd             =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON extforcing_fu_del2           =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON extforcing_fv_max            =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON extforcing_fv_min            =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON extforcing_fv_mean           =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON extforcing_fv_sd             =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON extforcing_fv_del2           =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON advcfl_uvel_max              =   8.2105140735988E-03
-(PID.TID 0000.0001) %MON advcfl_vvel_max              =   1.6623553936065E-02
+(PID.TID 0000.0001) %MON forcing_qnet_max             =   1.8763888888889E+02
+(PID.TID 0000.0001) %MON forcing_qnet_min             =   1.8763888888889E+02
+(PID.TID 0000.0001) %MON forcing_qnet_mean            =   1.8763888888889E+02
+(PID.TID 0000.0001) %MON forcing_qnet_sd              =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON forcing_qnet_del2            =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON forcing_qsw_max              =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON forcing_qsw_min              =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON forcing_qsw_mean             =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON forcing_qsw_sd               =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON forcing_qsw_del2             =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON forcing_empmr_max            =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON forcing_empmr_min            =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON forcing_empmr_mean           =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON forcing_empmr_sd             =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON forcing_empmr_del2           =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON forcing_fu_max               =   1.0000000000000E-01
+(PID.TID 0000.0001) %MON forcing_fu_min               =   1.0000000000000E-01
+(PID.TID 0000.0001) %MON forcing_fu_mean              =   1.0000000000000E-01
+(PID.TID 0000.0001) %MON forcing_fu_sd                =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON forcing_fu_del2              =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON forcing_fv_max               =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON forcing_fv_min               =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON forcing_fv_mean              =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON forcing_fv_sd                =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON forcing_fv_del2              =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON trAdv_CFL_u_max              =   9.8061315928604E-03
+(PID.TID 0000.0001) %MON trAdv_CFL_v_max              =   1.7760355999904E-02
+(PID.TID 0000.0001) %MON trAdv_CFL_w_max              =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON advcfl_uvel_max              =   8.0079577047426E-03
+(PID.TID 0000.0001) %MON advcfl_vvel_max              =   1.7014038192110E-02
 (PID.TID 0000.0001) %MON advcfl_wvel_max              =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON advcfl_W_hf_max              =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON pe_b_mean                    =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON ke_max                       =   2.9839851286286E-03
-(PID.TID 0000.0001) %MON ke_mean                      =   6.3230286091958E-05
+(PID.TID 0000.0001) %MON ke_max                       =   3.0694868246834E-03
+(PID.TID 0000.0001) %MON ke_mean                      =   6.4025936262299E-05
 (PID.TID 0000.0001) %MON ke_vol                       =   1.7475000000000E+10
 (PID.TID 0000.0001) %MON vort_r_min                   =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON vort_r_max                   =   0.0000000000000E+00
@@ -2851,12 +3053,12 @@ time,fu0,fu1,fu =   1.5600E+04  1.0000E-01  1.0000E-01  1.0000E-01  5.3611111111
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // End MONITOR dynamic field statistics
 (PID.TID 0000.0001) // =======================================================
-time,SST,SSS,fu,fv,Q,E-P,i0,i1,a,b =   1.6800E+04  0.0000E+00  0.0000E+00  1.0000E-01  0.0000E+00  1.8861E+02  0.0000E+00    72     1  5.3889E-01  4.6111E-01
-time,fu0,fu1,fu =   1.6800E+04  1.0000E-01  1.0000E-01  1.0000E-01  5.388888888888889E-01  4.611111111111111E-01
+ EXTERNAL_FIELDS_LOAD,        14 : iP,iLd,i0,i1=   72    1   72    1 ; Wght=  0.4611111111  0.5388888889
  cg2d: Sum(rhs),rhsMax =   0.00000000000000E+00  0.00000000000000E+00
-(PID.TID 0000.0001)                    cg2d_init_res =    0.00000000000000E+00
-(PID.TID 0000.0001)                       cg2d_iters =     0
-(PID.TID 0000.0001)                         cg2d_res =    0.00000000000000E+00
+(PID.TID 0000.0001)      cg2d_init_res =   0.00000000000000E+00
+(PID.TID 0000.0001)      cg2d_iters(min,last) =       0       0
+(PID.TID 0000.0001)      cg2d_min_res  =   0.00000000000000E+00
+(PID.TID 0000.0001)      cg2d_last_res =   0.00000000000000E+00
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // Begin MONITOR dynamic field statistics
 (PID.TID 0000.0001) // =======================================================
@@ -2867,34 +3069,34 @@ time,fu0,fu1,fu =   1.6800E+04  1.0000E-01  1.0000E-01  1.0000E-01  5.3888888888
 (PID.TID 0000.0001) %MON dynstat_eta_mean             =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON dynstat_eta_sd               =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON dynstat_eta_del2             =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON dynstat_uvel_max             =   2.9448944995224E-02
-(PID.TID 0000.0001) %MON dynstat_uvel_min             =  -1.2187943899683E-06
+(PID.TID 0000.0001) %MON dynstat_uvel_max             =   2.8243006802321E-02
+(PID.TID 0000.0001) %MON dynstat_uvel_min             =  -1.8585895142117E-10
 (PID.TID 0000.0001) %MON dynstat_uvel_mean            =   5.7908295279127E-04
-(PID.TID 0000.0001) %MON dynstat_uvel_sd              =   3.7100628001999E-03
+(PID.TID 0000.0001) %MON dynstat_uvel_sd              =   3.6188633259458E-03
 (PID.TID 0000.0001) %MON dynstat_uvel_del2            =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON dynstat_vvel_max             =  -2.9647416775994E-84
-(PID.TID 0000.0001) %MON dynstat_vvel_min             =  -7.0541889263946E-02
+(PID.TID 0000.0001) %MON dynstat_vvel_max             =  -7.2942711357016E-85
+(PID.TID 0000.0001) %MON dynstat_vvel_min             =  -7.1020457122982E-02
 (PID.TID 0000.0001) %MON dynstat_vvel_mean            =  -1.8810088400158E-03
-(PID.TID 0000.0001) %MON dynstat_vvel_sd              =   1.0642973160757E-02
+(PID.TID 0000.0001) %MON dynstat_vvel_sd              =   1.0707231233262E-02
 (PID.TID 0000.0001) %MON dynstat_vvel_del2            =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON dynstat_wvel_max             =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON dynstat_wvel_min             =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON dynstat_wvel_max             =  -0.0000000000000E+00
+(PID.TID 0000.0001) %MON dynstat_wvel_min             =  -0.0000000000000E+00
 (PID.TID 0000.0001) %MON dynstat_wvel_mean            =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON dynstat_wvel_sd              =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON dynstat_wvel_del2            =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON dynstat_theta_max            =   8.9831056910811E+00
+(PID.TID 0000.0001) %MON dynstat_theta_max            =   8.9825888567086E+00
 (PID.TID 0000.0001) %MON dynstat_theta_min            =   2.2039194671766E+00
 (PID.TID 0000.0001) %MON dynstat_theta_mean           =   5.5615187167136E+00
-(PID.TID 0000.0001) %MON dynstat_theta_sd             =   2.0523961227134E+00
+(PID.TID 0000.0001) %MON dynstat_theta_sd             =   2.0523964589459E+00
 (PID.TID 0000.0001) %MON dynstat_theta_del2           =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON dynstat_salt_max             =   3.5000000000000E+01
 (PID.TID 0000.0001) %MON dynstat_salt_min             =   3.5000000000000E+01
 (PID.TID 0000.0001) %MON dynstat_salt_mean            =   3.5000000000000E+01
-(PID.TID 0000.0001) %MON dynstat_salt_sd              =   8.4737449887778E-14
+(PID.TID 0000.0001) %MON dynstat_salt_sd              =   8.3287524227695E-14
 (PID.TID 0000.0001) %MON dynstat_salt_del2            =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON dynstat_sst_max              =   8.9795385311339E+00
-(PID.TID 0000.0001) %MON dynstat_sst_min              =   8.9795385311339E+00
-(PID.TID 0000.0001) %MON dynstat_sst_mean             =   8.9795385311339E+00
+(PID.TID 0000.0001) %MON dynstat_sst_max              =   8.9804735144709E+00
+(PID.TID 0000.0001) %MON dynstat_sst_min              =   8.9804735144709E+00
+(PID.TID 0000.0001) %MON dynstat_sst_mean             =   8.9804735144709E+00
 (PID.TID 0000.0001) %MON dynstat_sst_sd               =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON dynstat_sst_del2             =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON dynstat_sss_max              =   3.5000000000000E+01
@@ -2902,38 +3104,41 @@ time,fu0,fu1,fu =   1.6800E+04  1.0000E-01  1.0000E-01  1.0000E-01  5.3888888888
 (PID.TID 0000.0001) %MON dynstat_sss_mean             =   3.5000000000000E+01
 (PID.TID 0000.0001) %MON dynstat_sss_sd               =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON dynstat_sss_del2             =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON extforcing_qnet_max          =   1.8861111111111E+02
-(PID.TID 0000.0001) %MON extforcing_qnet_min          =   1.8861111111111E+02
-(PID.TID 0000.0001) %MON extforcing_qnet_mean         =   1.8861111111111E+02
-(PID.TID 0000.0001) %MON extforcing_qnet_sd           =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON extforcing_qnet_del2         =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON extforcing_qsw_max           =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON extforcing_qsw_min           =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON extforcing_qsw_mean          =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON extforcing_qsw_sd            =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON extforcing_qsw_del2          =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON extforcing_empmr_max         =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON extforcing_empmr_min         =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON extforcing_empmr_mean        =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON extforcing_empmr_sd          =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON extforcing_empmr_del2        =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON extforcing_fu_max            =   1.0000000000000E-01
-(PID.TID 0000.0001) %MON extforcing_fu_min            =   1.0000000000000E-01
-(PID.TID 0000.0001) %MON extforcing_fu_mean           =   1.0000000000000E-01
-(PID.TID 0000.0001) %MON extforcing_fu_sd             =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON extforcing_fu_del2           =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON extforcing_fv_max            =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON extforcing_fv_min            =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON extforcing_fv_mean           =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON extforcing_fv_sd             =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON extforcing_fv_del2           =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON advcfl_uvel_max              =   7.0677467988538E-03
-(PID.TID 0000.0001) %MON advcfl_vvel_max              =   1.6930053423347E-02
+(PID.TID 0000.0001) %MON forcing_qnet_max             =   1.8861111111111E+02
+(PID.TID 0000.0001) %MON forcing_qnet_min             =   1.8861111111111E+02
+(PID.TID 0000.0001) %MON forcing_qnet_mean            =   1.8861111111111E+02
+(PID.TID 0000.0001) %MON forcing_qnet_sd              =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON forcing_qnet_del2            =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON forcing_qsw_max              =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON forcing_qsw_min              =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON forcing_qsw_mean             =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON forcing_qsw_sd               =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON forcing_qsw_del2             =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON forcing_empmr_max            =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON forcing_empmr_min            =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON forcing_empmr_mean           =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON forcing_empmr_sd             =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON forcing_empmr_del2           =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON forcing_fu_max               =   1.0000000000000E-01
+(PID.TID 0000.0001) %MON forcing_fu_min               =   1.0000000000000E-01
+(PID.TID 0000.0001) %MON forcing_fu_mean              =   1.0000000000000E-01
+(PID.TID 0000.0001) %MON forcing_fu_sd                =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON forcing_fu_del2              =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON forcing_fv_max               =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON forcing_fv_min               =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON forcing_fv_mean              =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON forcing_fv_sd                =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON forcing_fv_del2              =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON trAdv_CFL_u_max              =   8.0079577047426E-03
+(PID.TID 0000.0001) %MON trAdv_CFL_v_max              =   1.7014038192110E-02
+(PID.TID 0000.0001) %MON trAdv_CFL_w_max              =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON advcfl_uvel_max              =   6.7783216325571E-03
+(PID.TID 0000.0001) %MON advcfl_vvel_max              =   1.7044909709516E-02
 (PID.TID 0000.0001) %MON advcfl_wvel_max              =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON advcfl_W_hf_max              =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON pe_b_mean                    =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON ke_max                       =   2.9216992511293E-03
-(PID.TID 0000.0001) %MON ke_mean                      =   6.5455487502227E-05
+(PID.TID 0000.0001) %MON ke_max                       =   2.9207863815967E-03
+(PID.TID 0000.0001) %MON ke_mean                      =   6.5807251888420E-05
 (PID.TID 0000.0001) %MON ke_vol                       =   1.7475000000000E+10
 (PID.TID 0000.0001) %MON vort_r_min                   =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON vort_r_max                   =   0.0000000000000E+00
@@ -2946,12 +3151,12 @@ time,fu0,fu1,fu =   1.6800E+04  1.0000E-01  1.0000E-01  1.0000E-01  5.3888888888
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // End MONITOR dynamic field statistics
 (PID.TID 0000.0001) // =======================================================
-time,SST,SSS,fu,fv,Q,E-P,i0,i1,a,b =   1.8000E+04  0.0000E+00  0.0000E+00  1.0000E-01  0.0000E+00  1.8958E+02  0.0000E+00    72     1  5.4167E-01  4.5833E-01
-time,fu0,fu1,fu =   1.8000E+04  1.0000E-01  1.0000E-01  1.0000E-01  5.416666666666666E-01  4.583333333333334E-01
+ EXTERNAL_FIELDS_LOAD,        15 : iP,iLd,i0,i1=   72    1   72    1 ; Wght=  0.4583333333  0.5416666667
  cg2d: Sum(rhs),rhsMax =   0.00000000000000E+00  0.00000000000000E+00
-(PID.TID 0000.0001)                    cg2d_init_res =    0.00000000000000E+00
-(PID.TID 0000.0001)                       cg2d_iters =     0
-(PID.TID 0000.0001)                         cg2d_res =    0.00000000000000E+00
+(PID.TID 0000.0001)      cg2d_init_res =   0.00000000000000E+00
+(PID.TID 0000.0001)      cg2d_iters(min,last) =       0       0
+(PID.TID 0000.0001)      cg2d_min_res  =   0.00000000000000E+00
+(PID.TID 0000.0001)      cg2d_last_res =   0.00000000000000E+00
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // Begin MONITOR dynamic field statistics
 (PID.TID 0000.0001) // =======================================================
@@ -2962,34 +3167,34 @@ time,fu0,fu1,fu =   1.8000E+04  1.0000E-01  1.0000E-01  1.0000E-01  5.4166666666
 (PID.TID 0000.0001) %MON dynstat_eta_mean             =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON dynstat_eta_sd               =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON dynstat_eta_del2             =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON dynstat_uvel_max             =   2.5000880262944E-02
-(PID.TID 0000.0001) %MON dynstat_uvel_min             =  -6.0106435500462E-04
+(PID.TID 0000.0001) %MON dynstat_uvel_max             =   2.3847559456442E-02
+(PID.TID 0000.0001) %MON dynstat_uvel_min             =  -2.8803620808485E-04
 (PID.TID 0000.0001) %MON dynstat_uvel_mean            =   4.2532785229592E-04
-(PID.TID 0000.0001) %MON dynstat_uvel_sd              =   3.0288881574755E-03
+(PID.TID 0000.0001) %MON dynstat_uvel_sd              =   2.9157166175140E-03
 (PID.TID 0000.0001) %MON dynstat_uvel_del2            =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON dynstat_vvel_max             =  -1.9371054318867E-84
-(PID.TID 0000.0001) %MON dynstat_vvel_min             =  -7.2161097360274E-02
+(PID.TID 0000.0001) %MON dynstat_vvel_max             =   1.2517060198590E-73
+(PID.TID 0000.0001) %MON dynstat_vvel_min             =  -7.2275944875013E-02
 (PID.TID 0000.0001) %MON dynstat_vvel_mean            =  -1.9665505843083E-03
-(PID.TID 0000.0001) %MON dynstat_vvel_sd              =   1.1025217730758E-02
+(PID.TID 0000.0001) %MON dynstat_vvel_sd              =   1.1091686519177E-02
 (PID.TID 0000.0001) %MON dynstat_vvel_del2            =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON dynstat_wvel_max             =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON dynstat_wvel_min             =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON dynstat_wvel_max             =  -0.0000000000000E+00
+(PID.TID 0000.0001) %MON dynstat_wvel_min             =  -0.0000000000000E+00
 (PID.TID 0000.0001) %MON dynstat_wvel_mean            =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON dynstat_wvel_sd              =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON dynstat_wvel_del2            =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON dynstat_theta_max            =   8.9809617430123E+00
+(PID.TID 0000.0001) %MON dynstat_theta_max            =   8.9806819301198E+00
 (PID.TID 0000.0001) %MON dynstat_theta_min            =   2.2039225249136E+00
-(PID.TID 0000.0001) %MON dynstat_theta_mean           =   5.5614372119425E+00
-(PID.TID 0000.0001) %MON dynstat_theta_sd             =   2.0522592173071E+00
+(PID.TID 0000.0001) %MON dynstat_theta_mean           =   5.5614372119424E+00
+(PID.TID 0000.0001) %MON dynstat_theta_sd             =   2.0522596258753E+00
 (PID.TID 0000.0001) %MON dynstat_theta_del2           =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON dynstat_salt_max             =   3.5000000000000E+01
 (PID.TID 0000.0001) %MON dynstat_salt_min             =   3.5000000000000E+01
 (PID.TID 0000.0001) %MON dynstat_salt_mean            =   3.5000000000000E+01
-(PID.TID 0000.0001) %MON dynstat_salt_sd              =   9.0404974581547E-14
+(PID.TID 0000.0001) %MON dynstat_salt_sd              =   8.8514912691714E-14
 (PID.TID 0000.0001) %MON dynstat_salt_del2            =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON dynstat_sst_max              =   8.9751651254083E+00
-(PID.TID 0000.0001) %MON dynstat_sst_min              =   8.9751651254083E+00
-(PID.TID 0000.0001) %MON dynstat_sst_mean             =   8.9751651254083E+00
+(PID.TID 0000.0001) %MON dynstat_sst_max              =   8.9759652890138E+00
+(PID.TID 0000.0001) %MON dynstat_sst_min              =   8.9759652890138E+00
+(PID.TID 0000.0001) %MON dynstat_sst_mean             =   8.9759652890138E+00
 (PID.TID 0000.0001) %MON dynstat_sst_sd               =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON dynstat_sst_del2             =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON dynstat_sss_max              =   3.5000000000000E+01
@@ -2997,38 +3202,41 @@ time,fu0,fu1,fu =   1.8000E+04  1.0000E-01  1.0000E-01  1.0000E-01  5.4166666666
 (PID.TID 0000.0001) %MON dynstat_sss_mean             =   3.5000000000000E+01
 (PID.TID 0000.0001) %MON dynstat_sss_sd               =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON dynstat_sss_del2             =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON extforcing_qnet_max          =   1.8958333333333E+02
-(PID.TID 0000.0001) %MON extforcing_qnet_min          =   1.8958333333333E+02
-(PID.TID 0000.0001) %MON extforcing_qnet_mean         =   1.8958333333333E+02
-(PID.TID 0000.0001) %MON extforcing_qnet_sd           =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON extforcing_qnet_del2         =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON extforcing_qsw_max           =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON extforcing_qsw_min           =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON extforcing_qsw_mean          =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON extforcing_qsw_sd            =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON extforcing_qsw_del2          =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON extforcing_empmr_max         =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON extforcing_empmr_min         =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON extforcing_empmr_mean        =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON extforcing_empmr_sd          =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON extforcing_empmr_del2        =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON extforcing_fu_max            =   1.0000000000000E-01
-(PID.TID 0000.0001) %MON extforcing_fu_min            =   1.0000000000000E-01
-(PID.TID 0000.0001) %MON extforcing_fu_mean           =   1.0000000000000E-01
-(PID.TID 0000.0001) %MON extforcing_fu_sd             =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON extforcing_fu_del2           =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON extforcing_fv_max            =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON extforcing_fv_min            =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON extforcing_fv_mean           =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON extforcing_fv_sd             =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON extforcing_fv_del2           =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON advcfl_uvel_max              =   6.0002112631065E-03
-(PID.TID 0000.0001) %MON advcfl_vvel_max              =   1.7318663366466E-02
+(PID.TID 0000.0001) %MON forcing_qnet_max             =   1.8958333333333E+02
+(PID.TID 0000.0001) %MON forcing_qnet_min             =   1.8958333333333E+02
+(PID.TID 0000.0001) %MON forcing_qnet_mean            =   1.8958333333333E+02
+(PID.TID 0000.0001) %MON forcing_qnet_sd              =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON forcing_qnet_del2            =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON forcing_qsw_max              =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON forcing_qsw_min              =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON forcing_qsw_mean             =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON forcing_qsw_sd               =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON forcing_qsw_del2             =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON forcing_empmr_max            =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON forcing_empmr_min            =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON forcing_empmr_mean           =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON forcing_empmr_sd             =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON forcing_empmr_del2           =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON forcing_fu_max               =   1.0000000000000E-01
+(PID.TID 0000.0001) %MON forcing_fu_min               =   1.0000000000000E-01
+(PID.TID 0000.0001) %MON forcing_fu_mean              =   1.0000000000000E-01
+(PID.TID 0000.0001) %MON forcing_fu_sd                =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON forcing_fu_del2              =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON forcing_fv_max               =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON forcing_fv_min               =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON forcing_fv_mean              =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON forcing_fv_sd                =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON forcing_fv_del2              =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON trAdv_CFL_u_max              =   6.7783216325571E-03
+(PID.TID 0000.0001) %MON trAdv_CFL_v_max              =   1.7044909709516E-02
+(PID.TID 0000.0001) %MON trAdv_CFL_w_max              =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON advcfl_uvel_max              =   5.7234142695460E-03
+(PID.TID 0000.0001) %MON advcfl_vvel_max              =   1.7346226770003E-02
 (PID.TID 0000.0001) %MON advcfl_wvel_max              =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON advcfl_W_hf_max              =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON pe_b_mean                    =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON ke_max                       =   2.9161339930805E-03
-(PID.TID 0000.0001) %MON ke_mean                      =   6.7388907231845E-05
+(PID.TID 0000.0001) %MON ke_max                       =   2.8962591498023E-03
+(PID.TID 0000.0001) %MON ke_mean                      =   6.7787569107961E-05
 (PID.TID 0000.0001) %MON ke_vol                       =   1.7475000000000E+10
 (PID.TID 0000.0001) %MON vort_r_min                   =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON vort_r_max                   =   0.0000000000000E+00
@@ -3041,12 +3249,18 @@ time,fu0,fu1,fu =   1.8000E+04  1.0000E-01  1.0000E-01  1.0000E-01  5.4166666666
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // End MONITOR dynamic field statistics
 (PID.TID 0000.0001) // =======================================================
-time,SST,SSS,fu,fv,Q,E-P,i0,i1,a,b =   1.9200E+04  0.0000E+00  0.0000E+00  1.0000E-01  0.0000E+00  1.9056E+02  0.0000E+00    72     1  5.4444E-01  4.5556E-01
-time,fu0,fu1,fu =   1.9200E+04  1.0000E-01  1.0000E-01  1.0000E-01  5.444444444444444E-01  4.555555555555556E-01
+ Compute Stats, Diag. #    190  GGL90TKE  vol(   0 ): 1.698E+10  Parms: SM      LR      
+ Compute Stats, Diag. #    191  GGL90Lmx  vol(   0 ): 1.698E+10  Parms: SM      LR      
+ Compute Stats, Diag. #    195  GGL90Kr   vol(   0 ): 1.698E+10  Parms: SM      LR      
+ Compute Stats, Diag. #    193  GGL90ArU  vol(   0 ): 1.698E+10  Parms: SM      LR      
+ Compute Stats, Diag. #    194  GGL90ArV  vol(   0 ): 1.698E+10  Parms: SM      LR      
+ Compute Stats, Diag. #    192  GGL90Prl  vol(   0 ): 1.698E+10  Parms: SM      LR      
+ EXTERNAL_FIELDS_LOAD,        16 : iP,iLd,i0,i1=   72    1   72    1 ; Wght=  0.4555555556  0.5444444444
  cg2d: Sum(rhs),rhsMax =   0.00000000000000E+00  0.00000000000000E+00
-(PID.TID 0000.0001)                    cg2d_init_res =    0.00000000000000E+00
-(PID.TID 0000.0001)                       cg2d_iters =     0
-(PID.TID 0000.0001)                         cg2d_res =    0.00000000000000E+00
+(PID.TID 0000.0001)      cg2d_init_res =   0.00000000000000E+00
+(PID.TID 0000.0001)      cg2d_iters(min,last) =       0       0
+(PID.TID 0000.0001)      cg2d_min_res  =   0.00000000000000E+00
+(PID.TID 0000.0001)      cg2d_last_res =   0.00000000000000E+00
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // Begin MONITOR dynamic field statistics
 (PID.TID 0000.0001) // =======================================================
@@ -3057,34 +3271,34 @@ time,fu0,fu1,fu =   1.9200E+04  1.0000E-01  1.0000E-01  1.0000E-01  5.4444444444
 (PID.TID 0000.0001) %MON dynstat_eta_mean             =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON dynstat_eta_sd               =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON dynstat_eta_del2             =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON dynstat_uvel_max             =   2.0445039053016E-02
-(PID.TID 0000.0001) %MON dynstat_uvel_min             =  -1.6673139119683E-03
+(PID.TID 0000.0001) %MON dynstat_uvel_max             =   1.9489436451236E-02
+(PID.TID 0000.0001) %MON dynstat_uvel_min             =  -1.2054958996516E-03
 (PID.TID 0000.0001) %MON dynstat_uvel_mean            =   2.5932629885590E-04
-(PID.TID 0000.0001) %MON dynstat_uvel_sd              =   2.4409271075033E-03
+(PID.TID 0000.0001) %MON dynstat_uvel_sd              =   2.3211821959085E-03
 (PID.TID 0000.0001) %MON dynstat_uvel_del2            =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON dynstat_vvel_max             =   4.2930304587118E-70
-(PID.TID 0000.0001) %MON dynstat_vvel_min             =  -7.3456446946509E-02
+(PID.TID 0000.0001) %MON dynstat_vvel_max             =   1.9432089014297E-57
+(PID.TID 0000.0001) %MON dynstat_vvel_min             =  -7.3529788969608E-02
 (PID.TID 0000.0001) %MON dynstat_vvel_mean            =  -2.0248319264836E-03
-(PID.TID 0000.0001) %MON dynstat_vvel_sd              =   1.1276205974759E-02
+(PID.TID 0000.0001) %MON dynstat_vvel_sd              =   1.1359539781666E-02
 (PID.TID 0000.0001) %MON dynstat_vvel_del2            =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON dynstat_wvel_max             =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON dynstat_wvel_min             =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON dynstat_wvel_max             =  -0.0000000000000E+00
+(PID.TID 0000.0001) %MON dynstat_wvel_min             =  -0.0000000000000E+00
 (PID.TID 0000.0001) %MON dynstat_wvel_mean            =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON dynstat_wvel_sd              =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON dynstat_wvel_del2            =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON dynstat_theta_max            =   8.9785926080500E+00
+(PID.TID 0000.0001) %MON dynstat_theta_max            =   8.9786084754736E+00
 (PID.TID 0000.0001) %MON dynstat_theta_min            =   2.2039255826278E+00
 (PID.TID 0000.0001) %MON dynstat_theta_mean           =   5.5613552891981E+00
-(PID.TID 0000.0001) %MON dynstat_theta_sd             =   2.0521217642142E+00
+(PID.TID 0000.0001) %MON dynstat_theta_sd             =   2.0521223116097E+00
 (PID.TID 0000.0001) %MON dynstat_theta_del2           =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON dynstat_salt_max             =   3.5000000000000E+01
 (PID.TID 0000.0001) %MON dynstat_salt_min             =   3.5000000000000E+01
 (PID.TID 0000.0001) %MON dynstat_salt_mean            =   3.5000000000000E+01
-(PID.TID 0000.0001) %MON dynstat_salt_sd              =   9.6171523210487E-14
+(PID.TID 0000.0001) %MON dynstat_salt_sd              =   9.3830614764430E-14
 (PID.TID 0000.0001) %MON dynstat_salt_del2            =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON dynstat_sst_max              =   8.9709890162135E+00
-(PID.TID 0000.0001) %MON dynstat_sst_min              =   8.9709890162135E+00
-(PID.TID 0000.0001) %MON dynstat_sst_mean             =   8.9709890162135E+00
+(PID.TID 0000.0001) %MON dynstat_sst_max              =   8.9716874401250E+00
+(PID.TID 0000.0001) %MON dynstat_sst_min              =   8.9716874401250E+00
+(PID.TID 0000.0001) %MON dynstat_sst_mean             =   8.9716874401250E+00
 (PID.TID 0000.0001) %MON dynstat_sst_sd               =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON dynstat_sst_del2             =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON dynstat_sss_max              =   3.5000000000000E+01
@@ -3092,38 +3306,41 @@ time,fu0,fu1,fu =   1.9200E+04  1.0000E-01  1.0000E-01  1.0000E-01  5.4444444444
 (PID.TID 0000.0001) %MON dynstat_sss_mean             =   3.5000000000000E+01
 (PID.TID 0000.0001) %MON dynstat_sss_sd               =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON dynstat_sss_del2             =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON extforcing_qnet_max          =   1.9055555555556E+02
-(PID.TID 0000.0001) %MON extforcing_qnet_min          =   1.9055555555556E+02
-(PID.TID 0000.0001) %MON extforcing_qnet_mean         =   1.9055555555556E+02
-(PID.TID 0000.0001) %MON extforcing_qnet_sd           =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON extforcing_qnet_del2         =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON extforcing_qsw_max           =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON extforcing_qsw_min           =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON extforcing_qsw_mean          =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON extforcing_qsw_sd            =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON extforcing_qsw_del2          =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON extforcing_empmr_max         =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON extforcing_empmr_min         =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON extforcing_empmr_mean        =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON extforcing_empmr_sd          =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON extforcing_empmr_del2        =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON extforcing_fu_max            =   1.0000000000000E-01
-(PID.TID 0000.0001) %MON extforcing_fu_min            =   1.0000000000000E-01
-(PID.TID 0000.0001) %MON extforcing_fu_mean           =   1.0000000000000E-01
-(PID.TID 0000.0001) %MON extforcing_fu_sd             =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON extforcing_fu_del2           =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON extforcing_fv_max            =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON extforcing_fv_min            =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON extforcing_fv_mean           =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON extforcing_fv_sd             =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON extforcing_fv_del2           =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON advcfl_uvel_max              =   4.9068093727238E-03
-(PID.TID 0000.0001) %MON advcfl_vvel_max              =   1.7629547267162E-02
+(PID.TID 0000.0001) %MON forcing_qnet_max             =   1.9055555555556E+02
+(PID.TID 0000.0001) %MON forcing_qnet_min             =   1.9055555555556E+02
+(PID.TID 0000.0001) %MON forcing_qnet_mean            =   1.9055555555556E+02
+(PID.TID 0000.0001) %MON forcing_qnet_sd              =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON forcing_qnet_del2            =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON forcing_qsw_max              =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON forcing_qsw_min              =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON forcing_qsw_mean             =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON forcing_qsw_sd               =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON forcing_qsw_del2             =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON forcing_empmr_max            =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON forcing_empmr_min            =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON forcing_empmr_mean           =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON forcing_empmr_sd             =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON forcing_empmr_del2           =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON forcing_fu_max               =   1.0000000000000E-01
+(PID.TID 0000.0001) %MON forcing_fu_min               =   1.0000000000000E-01
+(PID.TID 0000.0001) %MON forcing_fu_mean              =   1.0000000000000E-01
+(PID.TID 0000.0001) %MON forcing_fu_sd                =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON forcing_fu_del2              =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON forcing_fv_max               =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON forcing_fv_min               =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON forcing_fv_mean              =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON forcing_fv_sd                =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON forcing_fv_del2              =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON trAdv_CFL_u_max              =   5.7234142695460E-03
+(PID.TID 0000.0001) %MON trAdv_CFL_v_max              =   1.7346226770003E-02
+(PID.TID 0000.0001) %MON trAdv_CFL_w_max              =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON advcfl_uvel_max              =   4.6774647482966E-03
+(PID.TID 0000.0001) %MON advcfl_vvel_max              =   1.7647149352706E-02
 (PID.TID 0000.0001) %MON advcfl_wvel_max              =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON advcfl_W_hf_max              =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON pe_b_mean                    =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON ke_max                       =   2.9069246099423E-03
-(PID.TID 0000.0001) %MON ke_mean                      =   6.8639070394556E-05
+(PID.TID 0000.0001) %MON ke_max                       =   2.8932339995510E-03
+(PID.TID 0000.0001) %MON ke_mean                      =   6.9297112648819E-05
 (PID.TID 0000.0001) %MON ke_vol                       =   1.7475000000000E+10
 (PID.TID 0000.0001) %MON vort_r_min                   =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON vort_r_max                   =   0.0000000000000E+00
@@ -3136,12 +3353,12 @@ time,fu0,fu1,fu =   1.9200E+04  1.0000E-01  1.0000E-01  1.0000E-01  5.4444444444
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // End MONITOR dynamic field statistics
 (PID.TID 0000.0001) // =======================================================
-time,SST,SSS,fu,fv,Q,E-P,i0,i1,a,b =   2.0400E+04  0.0000E+00  0.0000E+00  1.0000E-01  0.0000E+00  1.9153E+02  0.0000E+00    72     1  5.4722E-01  4.5278E-01
-time,fu0,fu1,fu =   2.0400E+04  1.0000E-01  1.0000E-01  1.0000E-01  5.472222222222223E-01  4.527777777777777E-01
+ EXTERNAL_FIELDS_LOAD,        17 : iP,iLd,i0,i1=   72    1   72    1 ; Wght=  0.4527777778  0.5472222222
  cg2d: Sum(rhs),rhsMax =   0.00000000000000E+00  0.00000000000000E+00
-(PID.TID 0000.0001)                    cg2d_init_res =    0.00000000000000E+00
-(PID.TID 0000.0001)                       cg2d_iters =     0
-(PID.TID 0000.0001)                         cg2d_res =    0.00000000000000E+00
+(PID.TID 0000.0001)      cg2d_init_res =   0.00000000000000E+00
+(PID.TID 0000.0001)      cg2d_iters(min,last) =       0       0
+(PID.TID 0000.0001)      cg2d_min_res  =   0.00000000000000E+00
+(PID.TID 0000.0001)      cg2d_last_res =   0.00000000000000E+00
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // Begin MONITOR dynamic field statistics
 (PID.TID 0000.0001) // =======================================================
@@ -3152,34 +3369,34 @@ time,fu0,fu1,fu =   2.0400E+04  1.0000E-01  1.0000E-01  1.0000E-01  5.4722222222
 (PID.TID 0000.0001) %MON dynstat_eta_mean             =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON dynstat_eta_sd               =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON dynstat_eta_del2             =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON dynstat_uvel_max             =   1.5651211027230E-02
-(PID.TID 0000.0001) %MON dynstat_uvel_min             =  -6.6087555102212E-03
-(PID.TID 0000.0001) %MON dynstat_uvel_mean            =   8.5869151183839E-05
-(PID.TID 0000.0001) %MON dynstat_uvel_sd              =   2.0616324166149E-03
+(PID.TID 0000.0001) %MON dynstat_uvel_max             =   1.4915816796815E-02
+(PID.TID 0000.0001) %MON dynstat_uvel_min             =  -6.5906489910224E-03
+(PID.TID 0000.0001) %MON dynstat_uvel_mean            =   8.5869151183840E-05
+(PID.TID 0000.0001) %MON dynstat_uvel_sd              =   1.9680460591330E-03
 (PID.TID 0000.0001) %MON dynstat_uvel_del2            =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON dynstat_vvel_max             =   3.6708682383969E-60
-(PID.TID 0000.0001) %MON dynstat_vvel_min             =  -7.4078894074911E-02
+(PID.TID 0000.0001) %MON dynstat_vvel_max             =   5.3070952011837E-53
+(PID.TID 0000.0001) %MON dynstat_vvel_min             =  -7.4266453965983E-02
 (PID.TID 0000.0001) %MON dynstat_vvel_mean            =  -2.0541757315927E-03
-(PID.TID 0000.0001) %MON dynstat_vvel_sd              =   1.1382313901636E-02
+(PID.TID 0000.0001) %MON dynstat_vvel_sd              =   1.1487585719079E-02
 (PID.TID 0000.0001) %MON dynstat_vvel_del2            =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON dynstat_wvel_max             =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON dynstat_wvel_min             =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON dynstat_wvel_max             =  -0.0000000000000E+00
+(PID.TID 0000.0001) %MON dynstat_wvel_min             =  -0.0000000000000E+00
 (PID.TID 0000.0001) %MON dynstat_wvel_mean            =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON dynstat_wvel_sd              =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON dynstat_wvel_del2            =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON dynstat_theta_max            =   8.9760191775021E+00
+(PID.TID 0000.0001) %MON dynstat_theta_max            =   8.9763652159253E+00
 (PID.TID 0000.0001) %MON dynstat_theta_min            =   2.2039286403190E+00
 (PID.TID 0000.0001) %MON dynstat_theta_mean           =   5.5612729484806E+00
-(PID.TID 0000.0001) %MON dynstat_theta_sd             =   2.0519837615475E+00
+(PID.TID 0000.0001) %MON dynstat_theta_sd             =   2.0519844780487E+00
 (PID.TID 0000.0001) %MON dynstat_theta_del2           =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON dynstat_salt_max             =   3.5000000000000E+01
 (PID.TID 0000.0001) %MON dynstat_salt_min             =   3.5000000000000E+01
 (PID.TID 0000.0001) %MON dynstat_salt_mean            =   3.5000000000000E+01
-(PID.TID 0000.0001) %MON dynstat_salt_sd              =   1.0156405886093E-13
+(PID.TID 0000.0001) %MON dynstat_salt_sd              =   9.9442214514541E-14
 (PID.TID 0000.0001) %MON dynstat_salt_del2            =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON dynstat_sst_max              =   8.9669947340179E+00
-(PID.TID 0000.0001) %MON dynstat_sst_min              =   8.9669947340179E+00
-(PID.TID 0000.0001) %MON dynstat_sst_mean             =   8.9669947340179E+00
+(PID.TID 0000.0001) %MON dynstat_sst_max              =   8.9676077055198E+00
+(PID.TID 0000.0001) %MON dynstat_sst_min              =   8.9676077055198E+00
+(PID.TID 0000.0001) %MON dynstat_sst_mean             =   8.9676077055198E+00
 (PID.TID 0000.0001) %MON dynstat_sst_sd               =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON dynstat_sst_del2             =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON dynstat_sss_max              =   3.5000000000000E+01
@@ -3187,38 +3404,41 @@ time,fu0,fu1,fu =   2.0400E+04  1.0000E-01  1.0000E-01  1.0000E-01  5.4722222222
 (PID.TID 0000.0001) %MON dynstat_sss_mean             =   3.5000000000000E+01
 (PID.TID 0000.0001) %MON dynstat_sss_sd               =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON dynstat_sss_del2             =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON extforcing_qnet_max          =   1.9152777777778E+02
-(PID.TID 0000.0001) %MON extforcing_qnet_min          =   1.9152777777778E+02
-(PID.TID 0000.0001) %MON extforcing_qnet_mean         =   1.9152777777778E+02
-(PID.TID 0000.0001) %MON extforcing_qnet_sd           =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON extforcing_qnet_del2         =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON extforcing_qsw_max           =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON extforcing_qsw_min           =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON extforcing_qsw_mean          =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON extforcing_qsw_sd            =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON extforcing_qsw_del2          =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON extforcing_empmr_max         =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON extforcing_empmr_min         =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON extforcing_empmr_mean        =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON extforcing_empmr_sd          =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON extforcing_empmr_del2        =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON extforcing_fu_max            =   1.0000000000000E-01
-(PID.TID 0000.0001) %MON extforcing_fu_min            =   1.0000000000000E-01
-(PID.TID 0000.0001) %MON extforcing_fu_mean           =   1.0000000000000E-01
-(PID.TID 0000.0001) %MON extforcing_fu_sd             =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON extforcing_fu_del2           =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON extforcing_fv_max            =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON extforcing_fv_min            =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON extforcing_fv_mean           =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON extforcing_fv_sd             =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON extforcing_fv_del2           =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON advcfl_uvel_max              =   3.7562906465353E-03
-(PID.TID 0000.0001) %MON advcfl_vvel_max              =   1.7778934577979E-02
+(PID.TID 0000.0001) %MON forcing_qnet_max             =   1.9152777777778E+02
+(PID.TID 0000.0001) %MON forcing_qnet_min             =   1.9152777777778E+02
+(PID.TID 0000.0001) %MON forcing_qnet_mean            =   1.9152777777778E+02
+(PID.TID 0000.0001) %MON forcing_qnet_sd              =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON forcing_qnet_del2            =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON forcing_qsw_max              =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON forcing_qsw_min              =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON forcing_qsw_mean             =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON forcing_qsw_sd               =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON forcing_qsw_del2             =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON forcing_empmr_max            =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON forcing_empmr_min            =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON forcing_empmr_mean           =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON forcing_empmr_sd             =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON forcing_empmr_del2           =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON forcing_fu_max               =   1.0000000000000E-01
+(PID.TID 0000.0001) %MON forcing_fu_min               =   1.0000000000000E-01
+(PID.TID 0000.0001) %MON forcing_fu_mean              =   1.0000000000000E-01
+(PID.TID 0000.0001) %MON forcing_fu_sd                =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON forcing_fu_del2              =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON forcing_fv_max               =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON forcing_fv_min               =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON forcing_fv_mean              =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON forcing_fv_sd                =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON forcing_fv_del2              =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON trAdv_CFL_u_max              =   4.6774647482966E-03
+(PID.TID 0000.0001) %MON trAdv_CFL_v_max              =   1.7647149352706E-02
+(PID.TID 0000.0001) %MON trAdv_CFL_w_max              =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON advcfl_uvel_max              =   3.5797960312356E-03
+(PID.TID 0000.0001) %MON advcfl_vvel_max              =   1.7823948951836E-02
 (PID.TID 0000.0001) %MON advcfl_wvel_max              =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON advcfl_W_hf_max              =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON pe_b_mean                    =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON ke_max                       =   2.8663214769904E-03
-(PID.TID 0000.0001) %MON ke_mean                      =   6.9017204712006E-05
+(PID.TID 0000.0001) %MON ke_max                       =   2.8689938876988E-03
+(PID.TID 0000.0001) %MON ke_mean                      =   7.0032421195725E-05
 (PID.TID 0000.0001) %MON ke_vol                       =   1.7475000000000E+10
 (PID.TID 0000.0001) %MON vort_r_min                   =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON vort_r_max                   =   0.0000000000000E+00
@@ -3231,12 +3451,12 @@ time,fu0,fu1,fu =   2.0400E+04  1.0000E-01  1.0000E-01  1.0000E-01  5.4722222222
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // End MONITOR dynamic field statistics
 (PID.TID 0000.0001) // =======================================================
-time,SST,SSS,fu,fv,Q,E-P,i0,i1,a,b =   2.1600E+04  0.0000E+00  0.0000E+00  1.0000E-01  0.0000E+00  1.9250E+02  0.0000E+00    72     1  5.5000E-01  4.5000E-01
-time,fu0,fu1,fu =   2.1600E+04  1.0000E-01  1.0000E-01  1.0000E-01  5.500000000000000E-01  4.500000000000000E-01
+ EXTERNAL_FIELDS_LOAD,        18 : iP,iLd,i0,i1=   72    1   72    1 ; Wght=  0.4500000000  0.5500000000
  cg2d: Sum(rhs),rhsMax =   0.00000000000000E+00  0.00000000000000E+00
-(PID.TID 0000.0001)                    cg2d_init_res =    0.00000000000000E+00
-(PID.TID 0000.0001)                       cg2d_iters =     0
-(PID.TID 0000.0001)                         cg2d_res =    0.00000000000000E+00
+(PID.TID 0000.0001)      cg2d_init_res =   0.00000000000000E+00
+(PID.TID 0000.0001)      cg2d_iters(min,last) =       0       0
+(PID.TID 0000.0001)      cg2d_min_res  =   0.00000000000000E+00
+(PID.TID 0000.0001)      cg2d_last_res =   0.00000000000000E+00
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // Begin MONITOR dynamic field statistics
 (PID.TID 0000.0001) // =======================================================
@@ -3247,34 +3467,34 @@ time,fu0,fu1,fu =   2.1600E+04  1.0000E-01  1.0000E-01  1.0000E-01  5.5000000000
 (PID.TID 0000.0001) %MON dynstat_eta_mean             =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON dynstat_eta_sd               =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON dynstat_eta_del2             =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON dynstat_uvel_max             =   1.0659996479366E-02
-(PID.TID 0000.0001) %MON dynstat_uvel_min             =  -1.2349626072883E-02
-(PID.TID 0000.0001) %MON dynstat_uvel_mean            =  -9.0038387570707E-05
-(PID.TID 0000.0001) %MON dynstat_uvel_sd              =   2.0231970959808E-03
+(PID.TID 0000.0001) %MON dynstat_uvel_max             =   1.0086469691351E-02
+(PID.TID 0000.0001) %MON dynstat_uvel_min             =  -1.2816189457853E-02
+(PID.TID 0000.0001) %MON dynstat_uvel_mean            =  -9.0038387570706E-05
+(PID.TID 0000.0001) %MON dynstat_uvel_sd              =   1.9941462838835E-03
 (PID.TID 0000.0001) %MON dynstat_uvel_del2            =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON dynstat_vvel_max             =   2.1279996999468E-52
-(PID.TID 0000.0001) %MON dynstat_vvel_min             =  -7.3847934663330E-02
+(PID.TID 0000.0001) %MON dynstat_vvel_max             =   3.1893867161256E-52
+(PID.TID 0000.0001) %MON dynstat_vvel_min             =  -7.4220575812659E-02
 (PID.TID 0000.0001) %MON dynstat_vvel_mean            =  -2.0537399405790E-03
-(PID.TID 0000.0001) %MON dynstat_vvel_sd              =   1.1338458127052E-02
+(PID.TID 0000.0001) %MON dynstat_vvel_sd              =   1.1465059313808E-02
 (PID.TID 0000.0001) %MON dynstat_vvel_del2            =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON dynstat_wvel_max             =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON dynstat_wvel_min             =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON dynstat_wvel_max             =  -0.0000000000000E+00
+(PID.TID 0000.0001) %MON dynstat_wvel_min             =  -0.0000000000000E+00
 (PID.TID 0000.0001) %MON dynstat_wvel_mean            =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON dynstat_wvel_sd              =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON dynstat_wvel_del2            =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON dynstat_theta_max            =   8.9732495222893E+00
+(PID.TID 0000.0001) %MON dynstat_theta_max            =   8.9739155102787E+00
 (PID.TID 0000.0001) %MON dynstat_theta_min            =   2.2039316979872E+00
 (PID.TID 0000.0001) %MON dynstat_theta_mean           =   5.5611901897899E+00
-(PID.TID 0000.0001) %MON dynstat_theta_sd             =   2.0518452067742E+00
+(PID.TID 0000.0001) %MON dynstat_theta_sd             =   2.0518460933277E+00
 (PID.TID 0000.0001) %MON dynstat_theta_del2           =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON dynstat_salt_max             =   3.5000000000000E+01
 (PID.TID 0000.0001) %MON dynstat_salt_min             =   3.5000000000000E+01
 (PID.TID 0000.0001) %MON dynstat_salt_mean            =   3.5000000000000E+01
-(PID.TID 0000.0001) %MON dynstat_salt_sd              =   1.0723404670942E-13
+(PID.TID 0000.0001) %MON dynstat_salt_sd              =   1.0487973632947E-13
 (PID.TID 0000.0001) %MON dynstat_salt_del2            =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON dynstat_sst_max              =   8.9631775123583E+00
-(PID.TID 0000.0001) %MON dynstat_sst_min              =   8.9631775123583E+00
-(PID.TID 0000.0001) %MON dynstat_sst_mean             =   8.9631775123583E+00
+(PID.TID 0000.0001) %MON dynstat_sst_max              =   8.9637313445772E+00
+(PID.TID 0000.0001) %MON dynstat_sst_min              =   8.9637313445772E+00
+(PID.TID 0000.0001) %MON dynstat_sst_mean             =   8.9637313445772E+00
 (PID.TID 0000.0001) %MON dynstat_sst_sd               =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON dynstat_sst_del2             =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON dynstat_sss_max              =   3.5000000000000E+01
@@ -3282,38 +3502,41 @@ time,fu0,fu1,fu =   2.1600E+04  1.0000E-01  1.0000E-01  1.0000E-01  5.5000000000
 (PID.TID 0000.0001) %MON dynstat_sss_mean             =   3.5000000000000E+01
 (PID.TID 0000.0001) %MON dynstat_sss_sd               =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON dynstat_sss_del2             =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON extforcing_qnet_max          =   1.9250000000000E+02
-(PID.TID 0000.0001) %MON extforcing_qnet_min          =   1.9250000000000E+02
-(PID.TID 0000.0001) %MON extforcing_qnet_mean         =   1.9250000000000E+02
-(PID.TID 0000.0001) %MON extforcing_qnet_sd           =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON extforcing_qnet_del2         =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON extforcing_qsw_max           =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON extforcing_qsw_min           =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON extforcing_qsw_mean          =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON extforcing_qsw_sd            =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON extforcing_qsw_del2          =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON extforcing_empmr_max         =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON extforcing_empmr_min         =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON extforcing_empmr_mean        =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON extforcing_empmr_sd          =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON extforcing_empmr_del2        =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON extforcing_fu_max            =   1.0000000000000E-01
-(PID.TID 0000.0001) %MON extforcing_fu_min            =   1.0000000000000E-01
-(PID.TID 0000.0001) %MON extforcing_fu_mean           =   1.0000000000000E-01
-(PID.TID 0000.0001) %MON extforcing_fu_sd             =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON extforcing_fu_del2           =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON extforcing_fv_max            =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON extforcing_fv_min            =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON extforcing_fv_mean           =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON extforcing_fv_sd             =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON extforcing_fv_del2           =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON advcfl_uvel_max              =   2.9639102574920E-03
-(PID.TID 0000.0001) %MON advcfl_vvel_max              =   1.7723504319199E-02
+(PID.TID 0000.0001) %MON forcing_qnet_max             =   1.9250000000000E+02
+(PID.TID 0000.0001) %MON forcing_qnet_min             =   1.9250000000000E+02
+(PID.TID 0000.0001) %MON forcing_qnet_mean            =   1.9250000000000E+02
+(PID.TID 0000.0001) %MON forcing_qnet_sd              =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON forcing_qnet_del2            =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON forcing_qsw_max              =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON forcing_qsw_min              =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON forcing_qsw_mean             =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON forcing_qsw_sd               =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON forcing_qsw_del2             =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON forcing_empmr_max            =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON forcing_empmr_min            =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON forcing_empmr_mean           =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON forcing_empmr_sd             =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON forcing_empmr_del2           =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON forcing_fu_max               =   1.0000000000000E-01
+(PID.TID 0000.0001) %MON forcing_fu_min               =   1.0000000000000E-01
+(PID.TID 0000.0001) %MON forcing_fu_mean              =   1.0000000000000E-01
+(PID.TID 0000.0001) %MON forcing_fu_sd                =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON forcing_fu_del2              =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON forcing_fv_max               =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON forcing_fv_min               =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON forcing_fv_mean              =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON forcing_fv_sd                =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON forcing_fv_del2              =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON trAdv_CFL_u_max              =   3.5797960312356E-03
+(PID.TID 0000.0001) %MON trAdv_CFL_v_max              =   1.7823948951836E-02
+(PID.TID 0000.0001) %MON trAdv_CFL_w_max              =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON advcfl_uvel_max              =   3.0758854698848E-03
+(PID.TID 0000.0001) %MON advcfl_vvel_max              =   1.7812938195038E-02
 (PID.TID 0000.0001) %MON advcfl_wvel_max              =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON advcfl_W_hf_max              =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON pe_b_mean                    =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON ke_max                       =   2.7835764894898E-03
-(PID.TID 0000.0001) %MON ke_mean                      =   6.8439956921434E-05
+(PID.TID 0000.0001) %MON ke_max                       =   2.8052153723986E-03
+(PID.TID 0000.0001) %MON ke_mean                      =   6.9825079562712E-05
 (PID.TID 0000.0001) %MON ke_vol                       =   1.7475000000000E+10
 (PID.TID 0000.0001) %MON vort_r_min                   =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON vort_r_max                   =   0.0000000000000E+00
@@ -3326,12 +3549,12 @@ time,fu0,fu1,fu =   2.1600E+04  1.0000E-01  1.0000E-01  1.0000E-01  5.5000000000
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // End MONITOR dynamic field statistics
 (PID.TID 0000.0001) // =======================================================
-time,SST,SSS,fu,fv,Q,E-P,i0,i1,a,b =   2.2800E+04  0.0000E+00  0.0000E+00  1.0000E-01  0.0000E+00  1.9347E+02  0.0000E+00    72     1  5.5278E-01  4.4722E-01
-time,fu0,fu1,fu =   2.2800E+04  1.0000E-01  1.0000E-01  1.0000E-01  5.527777777777778E-01  4.472222222222222E-01
+ EXTERNAL_FIELDS_LOAD,        19 : iP,iLd,i0,i1=   72    1   72    1 ; Wght=  0.4472222222  0.5527777778
  cg2d: Sum(rhs),rhsMax =   0.00000000000000E+00  0.00000000000000E+00
-(PID.TID 0000.0001)                    cg2d_init_res =    0.00000000000000E+00
-(PID.TID 0000.0001)                       cg2d_iters =     0
-(PID.TID 0000.0001)                         cg2d_res =    0.00000000000000E+00
+(PID.TID 0000.0001)      cg2d_init_res =   0.00000000000000E+00
+(PID.TID 0000.0001)      cg2d_iters(min,last) =       0       0
+(PID.TID 0000.0001)      cg2d_min_res  =   0.00000000000000E+00
+(PID.TID 0000.0001)      cg2d_last_res =   0.00000000000000E+00
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // Begin MONITOR dynamic field statistics
 (PID.TID 0000.0001) // =======================================================
@@ -3342,34 +3565,34 @@ time,fu0,fu1,fu =   2.2800E+04  1.0000E-01  1.0000E-01  1.0000E-01  5.5277777777
 (PID.TID 0000.0001) %MON dynstat_eta_mean             =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON dynstat_eta_sd               =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON dynstat_eta_del2             =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON dynstat_uvel_max             =   5.6188123977673E-03
-(PID.TID 0000.0001) %MON dynstat_uvel_min             =  -1.7703868824921E-02
+(PID.TID 0000.0001) %MON dynstat_uvel_max             =   5.0987846284065E-03
+(PID.TID 0000.0001) %MON dynstat_uvel_min             =  -1.8615448411237E-02
 (PID.TID 0000.0001) %MON dynstat_uvel_mean            =  -2.6332119763916E-04
-(PID.TID 0000.0001) %MON dynstat_uvel_sd              =   2.3278065704318E-03
+(PID.TID 0000.0001) %MON dynstat_uvel_sd              =   2.3658831518623E-03
 (PID.TID 0000.0001) %MON dynstat_uvel_del2            =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON dynstat_vvel_max             =   1.2937453583908E-47
-(PID.TID 0000.0001) %MON dynstat_vvel_min             =  -7.2696147304207E-02
+(PID.TID 0000.0001) %MON dynstat_vvel_max             =   2.2079541855067E-48
+(PID.TID 0000.0001) %MON dynstat_vvel_min             =  -7.3259195373849E-02
 (PID.TID 0000.0001) %MON dynstat_vvel_mean            =  -2.0235417335466E-03
-(PID.TID 0000.0001) %MON dynstat_vvel_sd              =   1.1145774821638E-02
+(PID.TID 0000.0001) %MON dynstat_vvel_sd              =   1.1288977304874E-02
 (PID.TID 0000.0001) %MON dynstat_vvel_del2            =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON dynstat_wvel_max             =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON dynstat_wvel_min             =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON dynstat_wvel_max             =  -0.0000000000000E+00
+(PID.TID 0000.0001) %MON dynstat_wvel_min             =  -0.0000000000000E+00
 (PID.TID 0000.0001) %MON dynstat_wvel_mean            =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON dynstat_wvel_sd              =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON dynstat_wvel_del2            =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON dynstat_theta_max            =   8.9703080860679E+00
+(PID.TID 0000.0001) %MON dynstat_theta_max            =   8.9712430787679E+00
 (PID.TID 0000.0001) %MON dynstat_theta_min            =   2.2039347556325E+00
 (PID.TID 0000.0001) %MON dynstat_theta_mean           =   5.5611070131260E+00
-(PID.TID 0000.0001) %MON dynstat_theta_sd             =   2.0517061009539E+00
+(PID.TID 0000.0001) %MON dynstat_theta_sd             =   2.0517071367523E+00
 (PID.TID 0000.0001) %MON dynstat_theta_del2           =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON dynstat_salt_max             =   3.5000000000000E+01
 (PID.TID 0000.0001) %MON dynstat_salt_min             =   3.5000000000000E+01
 (PID.TID 0000.0001) %MON dynstat_salt_mean            =   3.5000000000000E+01
-(PID.TID 0000.0001) %MON dynstat_salt_sd              =   1.1304078680850E-13
+(PID.TID 0000.0001) %MON dynstat_salt_sd              =   1.1045051020628E-13
 (PID.TID 0000.0001) %MON dynstat_salt_del2            =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON dynstat_sst_max              =   8.9595179643451E+00
-(PID.TID 0000.0001) %MON dynstat_sst_min              =   8.9595179643451E+00
-(PID.TID 0000.0001) %MON dynstat_sst_mean             =   8.9595179643451E+00
+(PID.TID 0000.0001) %MON dynstat_sst_max              =   8.9600525774347E+00
+(PID.TID 0000.0001) %MON dynstat_sst_min              =   8.9600525774347E+00
+(PID.TID 0000.0001) %MON dynstat_sst_mean             =   8.9600525774347E+00
 (PID.TID 0000.0001) %MON dynstat_sst_sd               =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON dynstat_sst_del2             =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON dynstat_sss_max              =   3.5000000000000E+01
@@ -3377,38 +3600,41 @@ time,fu0,fu1,fu =   2.2800E+04  1.0000E-01  1.0000E-01  1.0000E-01  5.5277777777
 (PID.TID 0000.0001) %MON dynstat_sss_mean             =   3.5000000000000E+01
 (PID.TID 0000.0001) %MON dynstat_sss_sd               =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON dynstat_sss_del2             =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON extforcing_qnet_max          =   1.9347222222222E+02
-(PID.TID 0000.0001) %MON extforcing_qnet_min          =   1.9347222222222E+02
-(PID.TID 0000.0001) %MON extforcing_qnet_mean         =   1.9347222222222E+02
-(PID.TID 0000.0001) %MON extforcing_qnet_sd           =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON extforcing_qnet_del2         =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON extforcing_qsw_max           =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON extforcing_qsw_min           =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON extforcing_qsw_mean          =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON extforcing_qsw_sd            =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON extforcing_qsw_del2          =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON extforcing_empmr_max         =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON extforcing_empmr_min         =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON extforcing_empmr_mean        =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON extforcing_empmr_sd          =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON extforcing_empmr_del2        =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON extforcing_fu_max            =   1.0000000000000E-01
-(PID.TID 0000.0001) %MON extforcing_fu_min            =   1.0000000000000E-01
-(PID.TID 0000.0001) %MON extforcing_fu_mean           =   1.0000000000000E-01
-(PID.TID 0000.0001) %MON extforcing_fu_sd             =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON extforcing_fu_del2           =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON extforcing_fv_max            =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON extforcing_fv_min            =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON extforcing_fv_mean           =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON extforcing_fv_sd             =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON extforcing_fv_del2           =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON advcfl_uvel_max              =   4.2489285179810E-03
-(PID.TID 0000.0001) %MON advcfl_vvel_max              =   1.7447075353010E-02
+(PID.TID 0000.0001) %MON forcing_qnet_max             =   1.9347222222222E+02
+(PID.TID 0000.0001) %MON forcing_qnet_min             =   1.9347222222222E+02
+(PID.TID 0000.0001) %MON forcing_qnet_mean            =   1.9347222222222E+02
+(PID.TID 0000.0001) %MON forcing_qnet_sd              =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON forcing_qnet_del2            =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON forcing_qsw_max              =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON forcing_qsw_min              =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON forcing_qsw_mean             =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON forcing_qsw_sd               =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON forcing_qsw_del2             =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON forcing_empmr_max            =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON forcing_empmr_min            =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON forcing_empmr_mean           =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON forcing_empmr_sd             =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON forcing_empmr_del2           =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON forcing_fu_max               =   1.0000000000000E-01
+(PID.TID 0000.0001) %MON forcing_fu_min               =   1.0000000000000E-01
+(PID.TID 0000.0001) %MON forcing_fu_mean              =   1.0000000000000E-01
+(PID.TID 0000.0001) %MON forcing_fu_sd                =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON forcing_fu_del2              =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON forcing_fv_max               =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON forcing_fv_min               =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON forcing_fv_mean              =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON forcing_fv_sd                =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON forcing_fv_del2              =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON trAdv_CFL_u_max              =   3.0758854698848E-03
+(PID.TID 0000.0001) %MON trAdv_CFL_v_max              =   1.7812938195038E-02
+(PID.TID 0000.0001) %MON trAdv_CFL_w_max              =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON advcfl_uvel_max              =   4.4677076186968E-03
+(PID.TID 0000.0001) %MON advcfl_vvel_max              =   1.7582206889724E-02
 (PID.TID 0000.0001) %MON advcfl_wvel_max              =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON advcfl_W_hf_max              =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON pe_b_mean                    =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON ke_max                       =   2.6581504428181E-03
-(PID.TID 0000.0001) %MON ke_mean                      =   6.6905519502267E-05
+(PID.TID 0000.0001) %MON ke_max                       =   2.6964536557553E-03
+(PID.TID 0000.0001) %MON ke_mean                      =   6.8601235439376E-05
 (PID.TID 0000.0001) %MON ke_vol                       =   1.7475000000000E+10
 (PID.TID 0000.0001) %MON vort_r_min                   =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON vort_r_max                   =   0.0000000000000E+00
@@ -3421,139 +3647,152 @@ time,fu0,fu1,fu =   2.2800E+04  1.0000E-01  1.0000E-01  1.0000E-01  5.5277777777
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // End MONITOR dynamic field statistics
 (PID.TID 0000.0001) // =======================================================
+(PID.TID 0000.0001) DIAGSTATS_CLOSE_IO: close file: dynStDiag.0000000000.txt , unit=     9
 (PID.TID 0000.0001) %CHECKPOINT        20 ckptA
 (PID.TID 0000.0001)   Seconds in section "ALL                    [THE_MODEL_MAIN]":
-(PID.TID 0000.0001)           User time:  1.57575995
-(PID.TID 0000.0001)         System time:  0.060990999
-(PID.TID 0000.0001)     Wall clock time:  3.09547186
-(PID.TID 0000.0001)          No. starts: 1
-(PID.TID 0000.0001)           No. stops: 1
+(PID.TID 0000.0001)           User time:  0.34908300451934338
+(PID.TID 0000.0001)         System time:   1.9618999212980270E-002
+(PID.TID 0000.0001)     Wall clock time:  0.43835997581481934
+(PID.TID 0000.0001)          No. starts:           1
+(PID.TID 0000.0001)           No. stops:           1
 (PID.TID 0000.0001)   Seconds in section "INITIALISE_FIXED       [THE_MODEL_MAIN]":
-(PID.TID 0000.0001)           User time:  1.30480201
-(PID.TID 0000.0001)         System time:  0.0499920011
-(PID.TID 0000.0001)     Wall clock time:  2.29106998
-(PID.TID 0000.0001)          No. starts: 1
-(PID.TID 0000.0001)           No. stops: 1
+(PID.TID 0000.0001)           User time:  0.24502500053495169
+(PID.TID 0000.0001)         System time:   1.9375999458134174E-002
+(PID.TID 0000.0001)     Wall clock time:  0.33401012420654297
+(PID.TID 0000.0001)          No. starts:           1
+(PID.TID 0000.0001)           No. stops:           1
 (PID.TID 0000.0001)   Seconds in section "THE_MAIN_LOOP          [THE_MODEL_MAIN]":
-(PID.TID 0000.0001)           User time:  0.268959045
-(PID.TID 0000.0001)         System time:  0.0109989978
-(PID.TID 0000.0001)     Wall clock time:  0.794220924
-(PID.TID 0000.0001)          No. starts: 1
-(PID.TID 0000.0001)           No. stops: 1
+(PID.TID 0000.0001)           User time:  0.10357399284839630
+(PID.TID 0000.0001)         System time:   2.2899918258190155E-004
+(PID.TID 0000.0001)     Wall clock time:  0.10386085510253906
+(PID.TID 0000.0001)          No. starts:           1
+(PID.TID 0000.0001)           No. stops:           1
 (PID.TID 0000.0001)   Seconds in section "INITIALISE_VARIA    [THE_MAIN_LOOP]":
-(PID.TID 0000.0001)           User time:  0.050992012
-(PID.TID 0000.0001)         System time:  0.00400000066
-(PID.TID 0000.0001)     Wall clock time:  0.0623581409
-(PID.TID 0000.0001)          No. starts: 1
-(PID.TID 0000.0001)           No. stops: 1
+(PID.TID 0000.0001)           User time:   9.6319913864135742E-003
+(PID.TID 0000.0001)         System time:   1.4699995517730713E-004
+(PID.TID 0000.0001)     Wall clock time:   9.7799301147460938E-003
+(PID.TID 0000.0001)          No. starts:           1
+(PID.TID 0000.0001)           No. stops:           1
 (PID.TID 0000.0001)   Seconds in section "MAIN LOOP           [THE_MAIN_LOOP]":
-(PID.TID 0000.0001)           User time:  0.217967033
-(PID.TID 0000.0001)         System time:  0.00699899718
-(PID.TID 0000.0001)     Wall clock time:  0.731739998
-(PID.TID 0000.0001)          No. starts: 1
-(PID.TID 0000.0001)           No. stops: 1
-(PID.TID 0000.0001)   Seconds in section "FORWARD_STEP        [THE_MAIN_LOOP]":
-(PID.TID 0000.0001)           User time:  0.215968966
-(PID.TID 0000.0001)         System time:  0.00699899718
-(PID.TID 0000.0001)     Wall clock time:  0.73090601
-(PID.TID 0000.0001)          No. starts: 20
-(PID.TID 0000.0001)           No. stops: 20
+(PID.TID 0000.0001)           User time:   9.3915998935699463E-002
+(PID.TID 0000.0001)         System time:   7.9998746514320374E-005
+(PID.TID 0000.0001)     Wall clock time:   9.4053030014038086E-002
+(PID.TID 0000.0001)          No. starts:           1
+(PID.TID 0000.0001)           No. stops:           1
+(PID.TID 0000.0001)   Seconds in section "MAIN_DO_LOOP        [THE_MAIN_LOOP]":
+(PID.TID 0000.0001)           User time:   9.3736082315444946E-002
+(PID.TID 0000.0001)         System time:   7.8998506069183350E-005
+(PID.TID 0000.0001)     Wall clock time:   9.3870878219604492E-002
+(PID.TID 0000.0001)          No. starts:          20
+(PID.TID 0000.0001)           No. stops:          20
+(PID.TID 0000.0001)   Seconds in section "FORWARD_STEP        [MAIN_DO_LOOP]":
+(PID.TID 0000.0001)           User time:   9.3403041362762451E-002
+(PID.TID 0000.0001)         System time:   7.7998265624046326E-005
+(PID.TID 0000.0001)     Wall clock time:   9.3528032302856445E-002
+(PID.TID 0000.0001)          No. starts:          20
+(PID.TID 0000.0001)           No. stops:          20
 (PID.TID 0000.0001)   Seconds in section "DO_STATEVARS_DIAGS  [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:  0.00200009346
-(PID.TID 0000.0001)         System time:  0.
-(PID.TID 0000.0001)     Wall clock time:  0.00338721275
-(PID.TID 0000.0001)          No. starts: 40
-(PID.TID 0000.0001)           No. stops: 40
+(PID.TID 0000.0001)           User time:   1.0378658771514893E-003
+(PID.TID 0000.0001)         System time:   8.0000609159469604E-006
+(PID.TID 0000.0001)     Wall clock time:   1.0523796081542969E-003
+(PID.TID 0000.0001)          No. starts:          40
+(PID.TID 0000.0001)           No. stops:          40
 (PID.TID 0000.0001)   Seconds in section "LOAD_FIELDS_DRIVER  [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:  0.007999897
-(PID.TID 0000.0001)         System time:  0.000999998301
-(PID.TID 0000.0001)     Wall clock time:  0.00637412071
-(PID.TID 0000.0001)          No. starts: 20
-(PID.TID 0000.0001)           No. stops: 20
+(PID.TID 0000.0001)           User time:   9.2902779579162598E-004
+(PID.TID 0000.0001)         System time:   2.1999701857566833E-005
+(PID.TID 0000.0001)     Wall clock time:   9.5057487487792969E-004
+(PID.TID 0000.0001)          No. starts:          20
+(PID.TID 0000.0001)           No. stops:          20
 (PID.TID 0000.0001)   Seconds in section "EXTERNAL_FLDS_LOAD [LOAD_FLDS_DRIVER]":
-(PID.TID 0000.0001)           User time:  0.00400006771
-(PID.TID 0000.0001)         System time:  0.000999998301
-(PID.TID 0000.0001)     Wall clock time:  0.00472640991
-(PID.TID 0000.0001)          No. starts: 20
-(PID.TID 0000.0001)           No. stops: 20
+(PID.TID 0000.0001)           User time:   5.8296322822570801E-004
+(PID.TID 0000.0001)         System time:   2.1001324057579041E-005
+(PID.TID 0000.0001)     Wall clock time:   6.1202049255371094E-004
+(PID.TID 0000.0001)          No. starts:          20
+(PID.TID 0000.0001)           No. stops:          20
 (PID.TID 0000.0001)   Seconds in section "DO_ATMOSPHERIC_PHYS [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:  0.
-(PID.TID 0000.0001)         System time:  0.
-(PID.TID 0000.0001)     Wall clock time:  0.000789403915
-(PID.TID 0000.0001)          No. starts: 20
-(PID.TID 0000.0001)           No. stops: 20
+(PID.TID 0000.0001)           User time:   1.7005205154418945E-004
+(PID.TID 0000.0001)         System time:   0.0000000000000000
+(PID.TID 0000.0001)     Wall clock time:   1.7046928405761719E-004
+(PID.TID 0000.0001)          No. starts:          20
+(PID.TID 0000.0001)           No. stops:          20
 (PID.TID 0000.0001)   Seconds in section "DO_OCEANIC_PHYS     [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:  0.0279958248
-(PID.TID 0000.0001)         System time:  0.00100000203
-(PID.TID 0000.0001)     Wall clock time:  0.0785474777
-(PID.TID 0000.0001)          No. starts: 20
-(PID.TID 0000.0001)           No. stops: 20
+(PID.TID 0000.0001)           User time:   1.2097895145416260E-002
+(PID.TID 0000.0001)         System time:   2.5000423192977905E-005
+(PID.TID 0000.0001)     Wall clock time:   1.2127399444580078E-002
+(PID.TID 0000.0001)          No. starts:          20
+(PID.TID 0000.0001)           No. stops:          20
 (PID.TID 0000.0001)   Seconds in section "GGL90_CALC [DO_OCEANIC_PHYS]":
-(PID.TID 0000.0001)           User time:  0.00800001621
-(PID.TID 0000.0001)         System time:  0.00100000203
-(PID.TID 0000.0001)     Wall clock time:  0.0119068623
-(PID.TID 0000.0001)          No. starts: 20
-(PID.TID 0000.0001)           No. stops: 20
+(PID.TID 0000.0001)           User time:   6.2968432903289795E-003
+(PID.TID 0000.0001)         System time:   0.0000000000000000
+(PID.TID 0000.0001)     Wall clock time:   6.2959194183349609E-003
+(PID.TID 0000.0001)          No. starts:          20
+(PID.TID 0000.0001)           No. stops:          20
 (PID.TID 0000.0001)   Seconds in section "THERMODYNAMICS      [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:  0.0199970007
-(PID.TID 0000.0001)         System time:  0.
-(PID.TID 0000.0001)     Wall clock time:  0.0192782879
-(PID.TID 0000.0001)          No. starts: 20
-(PID.TID 0000.0001)           No. stops: 20
+(PID.TID 0000.0001)           User time:   1.8969088792800903E-002
+(PID.TID 0000.0001)         System time:   0.0000000000000000
+(PID.TID 0000.0001)     Wall clock time:   1.9035339355468750E-002
+(PID.TID 0000.0001)          No. starts:          20
+(PID.TID 0000.0001)           No. stops:          20
 (PID.TID 0000.0001)   Seconds in section "DYNAMICS            [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:  0.0429930687
-(PID.TID 0000.0001)         System time:  0.
-(PID.TID 0000.0001)     Wall clock time:  0.042532444
-(PID.TID 0000.0001)          No. starts: 20
-(PID.TID 0000.0001)           No. stops: 20
+(PID.TID 0000.0001)           User time:   2.5791913270950317E-002
+(PID.TID 0000.0001)         System time:   0.0000000000000000
+(PID.TID 0000.0001)     Wall clock time:   2.5807619094848633E-002
+(PID.TID 0000.0001)          No. starts:          20
+(PID.TID 0000.0001)           No. stops:          20
 (PID.TID 0000.0001)   Seconds in section "SOLVE_FOR_PRESSURE  [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:  0.00299990177
-(PID.TID 0000.0001)         System time:  0.
-(PID.TID 0000.0001)     Wall clock time:  0.00399923325
-(PID.TID 0000.0001)          No. starts: 20
-(PID.TID 0000.0001)           No. stops: 20
+(PID.TID 0000.0001)           User time:   1.8009245395660400E-003
+(PID.TID 0000.0001)         System time:   0.0000000000000000
+(PID.TID 0000.0001)     Wall clock time:   1.8098354339599609E-003
+(PID.TID 0000.0001)          No. starts:          20
+(PID.TID 0000.0001)           No. stops:          20
 (PID.TID 0000.0001)   Seconds in section "MOM_CORRECTION_STEP [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:  0.000999927521
-(PID.TID 0000.0001)         System time:  0.
-(PID.TID 0000.0001)     Wall clock time:  0.00208687782
-(PID.TID 0000.0001)          No. starts: 20
-(PID.TID 0000.0001)           No. stops: 20
+(PID.TID 0000.0001)           User time:   1.1540353298187256E-003
+(PID.TID 0000.0001)         System time:   0.0000000000000000
+(PID.TID 0000.0001)     Wall clock time:   1.1591911315917969E-003
+(PID.TID 0000.0001)          No. starts:          20
+(PID.TID 0000.0001)           No. stops:          20
+(PID.TID 0000.0001)   Seconds in section "INTEGR_CONTINUITY   [FORWARD_STEP]":
+(PID.TID 0000.0001)           User time:   4.8804283142089844E-004
+(PID.TID 0000.0001)         System time:   0.0000000000000000
+(PID.TID 0000.0001)     Wall clock time:   4.8613548278808594E-004
+(PID.TID 0000.0001)          No. starts:          20
+(PID.TID 0000.0001)           No. stops:          20
 (PID.TID 0000.0001)   Seconds in section "TRC_CORRECTION_STEP [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:  0.00200009346
-(PID.TID 0000.0001)         System time:  0.
-(PID.TID 0000.0001)     Wall clock time:  0.00163388252
-(PID.TID 0000.0001)          No. starts: 20
-(PID.TID 0000.0001)           No. stops: 20
+(PID.TID 0000.0001)           User time:   1.7595291137695312E-004
+(PID.TID 0000.0001)         System time:   0.0000000000000000
+(PID.TID 0000.0001)     Wall clock time:   1.7142295837402344E-004
+(PID.TID 0000.0001)          No. starts:          20
+(PID.TID 0000.0001)           No. stops:          20
 (PID.TID 0000.0001)   Seconds in section "BLOCKING_EXCHANGES  [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:  0.0129971504
-(PID.TID 0000.0001)         System time:  0.
-(PID.TID 0000.0001)     Wall clock time:  0.0114252567
-(PID.TID 0000.0001)          No. starts: 20
-(PID.TID 0000.0001)           No. stops: 20
+(PID.TID 0000.0001)           User time:   4.9450695514678955E-003
+(PID.TID 0000.0001)         System time:   0.0000000000000000
+(PID.TID 0000.0001)     Wall clock time:   4.9502849578857422E-003
+(PID.TID 0000.0001)          No. starts:          20
+(PID.TID 0000.0001)           No. stops:          20
 (PID.TID 0000.0001)   Seconds in section "DO_STATEVARS_TAVE   [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:  0.
-(PID.TID 0000.0001)         System time:  0.
-(PID.TID 0000.0001)     Wall clock time:  0.000794410706
-(PID.TID 0000.0001)          No. starts: 20
-(PID.TID 0000.0001)           No. stops: 20
+(PID.TID 0000.0001)           User time:   1.9800662994384766E-004
+(PID.TID 0000.0001)         System time:   0.0000000000000000
+(PID.TID 0000.0001)     Wall clock time:   1.9025802612304688E-004
+(PID.TID 0000.0001)          No. starts:          20
+(PID.TID 0000.0001)           No. stops:          20
 (PID.TID 0000.0001)   Seconds in section "MONITOR             [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:  0.0579918623
-(PID.TID 0000.0001)         System time:  0.000998999923
-(PID.TID 0000.0001)     Wall clock time:  0.0576858521
-(PID.TID 0000.0001)          No. starts: 20
-(PID.TID 0000.0001)           No. stops: 20
+(PID.TID 0000.0001)           User time:   1.4776974916458130E-002
+(PID.TID 0000.0001)         System time:   1.8000602722167969E-005
+(PID.TID 0000.0001)     Wall clock time:   1.4808654785156250E-002
+(PID.TID 0000.0001)          No. starts:          20
+(PID.TID 0000.0001)           No. stops:          20
 (PID.TID 0000.0001)   Seconds in section "DO_THE_MODEL_IO     [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:  0.0239959955
-(PID.TID 0000.0001)         System time:  0.0019999966
-(PID.TID 0000.0001)     Wall clock time:  0.334569454
-(PID.TID 0000.0001)          No. starts: 20
-(PID.TID 0000.0001)           No. stops: 20
+(PID.TID 0000.0001)           User time:   7.1380734443664551E-003
+(PID.TID 0000.0001)         System time:   0.0000000000000000
+(PID.TID 0000.0001)     Wall clock time:   7.1392059326171875E-003
+(PID.TID 0000.0001)          No. starts:          20
+(PID.TID 0000.0001)           No. stops:          20
 (PID.TID 0000.0001)   Seconds in section "DO_WRITE_PICKUP     [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:  0.00100004673
-(PID.TID 0000.0001)         System time:  0.00200000033
-(PID.TID 0000.0001)     Wall clock time:  0.143229485
-(PID.TID 0000.0001)          No. starts: 20
-(PID.TID 0000.0001)           No. stops: 20
+(PID.TID 0000.0001)           User time:   7.1299076080322266E-004
+(PID.TID 0000.0001)         System time:   0.0000000000000000
+(PID.TID 0000.0001)     Wall clock time:   7.1620941162109375E-004
+(PID.TID 0000.0001)          No. starts:          20
+(PID.TID 0000.0001)           No. stops:          20
 (PID.TID 0000.0001) // ======================================================
 (PID.TID 0000.0001) // Tile <-> Tile communication statistics
 (PID.TID 0000.0001) // ======================================================
@@ -3569,8 +3808,9 @@ time,fu0,fu1,fu =   2.2800E+04  1.0000E-01  1.0000E-01  1.0000E-01  5.5277777777
 (PID.TID 0000.0001) //          Total. Y spins =              0
 (PID.TID 0000.0001) //            Avg. Y spins =       0.00E+00
 (PID.TID 0000.0001) // o Thread number: 000001
-(PID.TID 0000.0001) //            No. barriers =           6064
+(PID.TID 0000.0001) //            No. barriers =           8766
 (PID.TID 0000.0001) //      Max. barrier spins =              1
 (PID.TID 0000.0001) //      Min. barrier spins =              1
-(PID.TID 0000.0001) //     Total barrier spins =           6064
+(PID.TID 0000.0001) //     Total barrier spins =           8766
 (PID.TID 0000.0001) //      Avg. barrier spins =       1.00E+00
+PROGRAM MAIN: Execution ended Normally


### PR DESCRIPTION
In verification experiment "vermix", change ggl90 secondary test to use mxlMaxFlag=3 (in data.ggl90) 
so that this scheme get tested in at least one experiment.
Update reference output for this test.

## What changes does this PR introduce?
update one experiment

## What is the current behaviour? 
pkg/ggl90  mxlMaxFlag=3 is not tested in any verification experiment

## What is the new behaviour 
tested, see above.

## Does this PR introduce a breaking change? 
no

## Other information:

## Suggested addition to `tag-index`
o verification/vermix:
  - change ggl90 secondary test to use (pkg/ggl90) mxlMaxFlag=3 (instead of 2)
    and update reference output.