### PR TITLE
Update global_oce_biogeo.rst to correct error in bathymetry file

### DIFF
--- a/doc/examples/global_oce_biogeo/global_oce_biogeo.rst
+++ b/doc/examples/global_oce_biogeo/global_oce_biogeo.rst
@@ -170,7 +170,7 @@ The input fields needed for this run (in
    many tracers are used, and :varlink:`PTRACERS_Iter0` which states at which
    timestep the biogeochemistry model tracers were initialized.
 
--  ``depth_g77.bin``: bathymetry data file
+-  ``bathy.bin``: bathymetry data file
 
 -  :filelink:`input/eedata <verification/tutorial_global_oce_biogeo/input/eedata>`: This file uses standard default values and does not
    contain customizations for this experiment.


### PR DESCRIPTION
Fix bathymetry file error in global_oce_biogeo documentation.

## What changes does this PR introduce?
Fixes the documentation for global_oce_biogeo

## What is the current behaviour? 
Bathymetry file is listed as depth_g77.bin

## What is the new behaviour 
Bathymetry file is listed as bathy.bin

## Does this PR introduce a breaking change? 
No

## Other information:


## Suggested addition to `tag-index`
(To avoid unnecessary merge conflicts, please don't update `tag-index`. One of the admins will do that when merging your pull request.)