### PR TITLE
Improve and clean IDEMIX code in pkg/ggl90

### DIFF
--- a/doc/tag-index
+++ b/doc/tag-index
@@ -1,6 +1,19 @@
     Notes on tags used in MITgcmUV
     ==============================
 
+o pkg/ggl90:
+  - fix EXCH calls in pkg/ggl90 when IDEMIX is used: no additional EXCH when
+    using zero horizontal diffusion of IDEMIX_E (IDEMIX_tau_h=0) but with
+    IDEMIX_tau_h > 0, EXCH both IDEMIX_E and GGL90TKE ; this affects results
+    of test experiment cs32.in_p and fix restart issue ;
+  - more consistent/simpler idemix code: use model parameter value for PI,
+    reduce number of IDEMIX global array, add TKE tendency from IDEMIX as output
+    of S/R GGL90_IDEMIX ; use double product of IDEMIX_E instead of power of 2
+    which affects results at machine truncation level ;
+  - update some IDEMIX default param values (following Pollmann et al., 2017)
+    but keep old default values in global_ocean.90x40x15.idemix ;
+  - apply also option calcMeanVertShear to uStarSquare calculation (wind-stress
+    magnitude) and switch on calcMeanVertShear in test experiment cs32.in_p.
 o model/src + pkgs ggl90, exf & seaice: ocean in P-coordinate
   - read geopotential anomaly directly into phi0surf instead of via pLoad (was
     a hack), specified with new input filename "geoPotAnomFile" in data&PARM05 ;

--- a/pkg/ggl90/GGL90.h
+++ b/pkg/ggl90/GGL90.h
@@ -34,7 +34,8 @@ C     GGL90mixingLengthMin - Mininum mixing length
 C     mxlMaxFlag      - Flag for limiting mixing-length method (default=0)
 C     mxlSurfFlag     - Flag to force mixing near ocean surface (default= F )
 C     calcMeanVertShear :: calculate the mean (@ grid-cell center) of vertical
-C                          shear compon. (instead of vert. shear of mean flow)
+C                          shear compon. (instead of vert. shear of mean flow);
+C                          also applies to surface stress (uStarSquare)
 C
 C     useIDEMIX       - turn on internal wave mixing contribution modeled by
 C                       IDEMIX version 1:

--- a/pkg/ggl90/GGL90.h
+++ b/pkg/ggl90/GGL90.h
@@ -104,54 +104,56 @@ CEOP
 
 #ifdef ALLOW_GGL90_IDEMIX
 C-----------------------------------------------------------------------
+C
 C     IDEMIX parameters
 C     IDEMIX_tau_v :: time scale for vertical symmetrisation (s), def: 1d
 C     IDEMIX_tau_h :: time scale for horizontal symmetrisation (s), def: 10d
 C     IDEMIX_gamma :: scaling factor (see Olbers and Eden 2013, App) def: 1.57
 C     IDEMIX_jstar :: spectral bandwidth in modes (default=10.)
-C     IDEMIX_mu0   :: dissipation parameter (default 4/3)
+C     IDEMIX_mu0   :: dissipation parameter (wrong default=4/3, should be 1/3)
 C     IDEMIX_diff_min :: minimum diffusivity, not used (def: 1e-9)
 C     IDEMIX_mixing_efficiency :: used for diagnosing Osborn diff (def: 0.1666)
 C     IDEMIX_diff_max :: maximum Osborn diffusivity (def: 1)
 C     IDEMIX_frac_F_b :: scaling factor for  bottom forcing (def: 1)
-C     IDEMIX_frac_F_s :: scaling factor for surface forcing (def: 0.2)
+C     IDEMIX_frac_F_s :: scaling factor for surface forcing (def: 0.2,
+C                        because only 20% of the surface wind energy input is
+C                        assumed to reach the interior below the mixed layer.)
+C     IDEMIX_tidal_file :: file containing tidal forcing
+C     IDEMIX_wind_file  :: file containing surface wind forcing
+C     IDEMIX_include_GM :: include eddy contribution parameterized by GMredi
+C     IDEMIX_include_GM_bottom :: include eddy contribution only at the bottom
+C
 C-----------------------------------------------------------------------
-      _RL IDEMIX_tau_v,IDEMIX_tau_h,IDEMIX_gamma, IDEMIX_jstar
+      _RL IDEMIX_tau_v, IDEMIX_tau_h, IDEMIX_gamma, IDEMIX_jstar
       _RL IDEMIX_mu0, IDEMIX_diff_min
       _RL IDEMIX_mixing_efficiency, IDEMIX_diff_max
       _RL IDEMIX_frac_F_b, IDEMIX_frac_F_s
 C-----------------------------------------------------------------------
+C
 C     IDEMIX 3-d fields, defined at interfaces (wVel-like)
-C     IDEMIX_E     :: total energy of internal waves
-C     IDEMIX_V0    :: mean lateral group velocity
-C     IDEMIX_tau_d :: dissipation parameter (see Olbers and Eden 2013, eq.12)
-C-----------------------------------------------------------------------
-      _RL IDEMIX_E    (1-OLx:sNx+OLx,1-OLy:sNy+OLy,Nr,nSx,nSy)
-      _RL IDEMIX_V0   (1-OLx:sNx+OLx,1-OLy:sNy+OLy,Nr,nSx,nSy)
-      _RL IDEMIX_tau_d(1-OLx:sNx+OLx,1-OLy:sNy+OLy,Nr,nSx,nSy)
-C-----------------------------------------------------------------------
+C     IDEMIX_E   :: total energy of internal waves
+C
 C     IDEMIX 2-d fields
 C     IDEMIX_F_B :: internal wave energy bottom forcing field (e.g., tides)
 C     IDEMIX_F_S :: IW energy surface forcing field (e.g., wind stress)
+C
 C-----------------------------------------------------------------------
-      _RL IDEMIX_F_B(1-OLx:sNx+OLx,1-OLy:sNy+OLy,nSx,nSy)
-      _RL IDEMIX_F_S(1-OLx:sNx+OLx,1-OLy:sNy+OLy,nSx,nSy)
+      _RL IDEMIX_E  (1-OLx:sNx+OLx,1-OLy:sNy+OLy,Nr,nSx,nSy)
+      _RL IDEMIX_F_B(1-OLx:sNx+OLx,1-OLy:sNy+OLy,   nSx,nSy)
+      _RL IDEMIX_F_S(1-OLx:sNx+OLx,1-OLy:sNy+OLy,   nSx,nSy)
 
-      COMMON /GGL90_IDEMIX_R/ IDEMIX_E,IDEMIX_V0,IDEMIX_tau_d
-     &     ,IDEMIX_F_b,IDEMIX_F_S
-     &     ,IDEMIX_tau_v,IDEMIX_tau_h,IDEMIX_gamma,IDEMIX_jstar
-     &     ,IDEMIX_mu0,IDEMIX_mixing_efficiency,IDEMIX_diff_max
-     &     ,IDEMIX_diff_min,IDEMIX_frac_F_b, IDEMIX_frac_F_s
+      COMMON /GGL90_IDEMIX_VARS/ IDEMIX_E, IDEMIX_F_b, IDEMIX_F_S
 
-C     IDEMIX_tidal_file :: file containing tidal forcing
-C     IDEMIX_wind_file  :: file containing surface wind forcing
+      COMMON /GGL90_IDEMIX_R/
+     &     IDEMIX_tau_v, IDEMIX_tau_h, IDEMIX_gamma, IDEMIX_jstar,
+     &     IDEMIX_mu0, IDEMIX_mixing_efficiency, IDEMIX_diff_max,
+     &     IDEMIX_diff_min, IDEMIX_frac_F_b, IDEMIX_frac_F_s
+
       CHARACTER*(MAX_LEN_FNAM)
      &            IDEMIX_tidal_file, IDEMIX_wind_file
       COMMON /GLL90_IDEMIX_C/
      &            IDEMIX_tidal_file, IDEMIX_wind_file
 
-C     IDEMIX_include_GM :: logical flag
-C     IDEMIX_include_GM_bottom :: logical flag
       LOGICAL     IDEMIX_include_GM, IDEMIX_include_GM_bottom
       COMMON /GLL90_IDEMIX_L/
      &            IDEMIX_include_GM, IDEMIX_include_GM_bottom

--- a/pkg/ggl90/ggl90_calc.F
+++ b/pkg/ggl90/ggl90_calc.F
@@ -858,17 +858,33 @@ C     end set up matrix
 C
 
 C     Apply boundary condition
-      DO j=jMin,jMax
-       DO i=iMin,iMax
-C     estimate friction velocity uStar from surface forcing
-        uStarSquare(i,j) = SQRT(
-     &    ( .5 _d 0*( surfaceForcingU(i,  j,  bi,bj)
-     &              + surfaceForcingU(i+1,j,  bi,bj) ) )**2
-     &  + ( .5 _d 0*( surfaceForcingV(i,  j,  bi,bj)
-     &              + surfaceForcingV(i,  j+1,bi,bj) ) )**2
-     &                     )*recip_coordFac
+      IF ( calcMeanVertShear ) THEN
+C     by averaging (@ grid-cell center) the 4 components @ U,V pos.
+       DO j=jMin,jMax
+        DO i=iMin,iMax
+         tempU  = surfaceForcingU( i ,j,bi,bj)
+         tempUp = surfaceForcingU(i+1,j,bi,bj)
+         tempV  = surfaceForcingV(i, j ,bi,bj)
+         tempVp = surfaceForcingV(i,j+1,bi,bj)
+         uStarSquare(i,j) = SQRT( 0.5 _d 0 *
+     &        ( tempU*tempU + tempUp*tempUp
+     &        + tempV*tempV + tempVp*tempVp )
+     &                           )*recip_coordFac
+        ENDDO
        ENDDO
-      ENDDO
+      ELSE
+       DO j=jMin,jMax
+        DO i=iMin,iMax
+C     estimate friction velocity uStar from surface forcing
+         uStarSquare(i,j) = SQRT(
+     &     ( .5 _d 0*( surfaceForcingU(i,  j,  bi,bj)
+     &               + surfaceForcingU(i+1,j,  bi,bj) ) )**2
+     &   + ( .5 _d 0*( surfaceForcingV(i,  j,  bi,bj)
+     &               + surfaceForcingV(i,  j+1,bi,bj) ) )**2
+     &                           )*recip_coordFac
+        ENDDO
+       ENDDO
+      ENDIF
 C     Dirichlet surface boundary condition for TKE
       IF ( usingPCoords ) THEN
        DO j=jMin,jMax

--- a/pkg/ggl90/ggl90_calc.F
+++ b/pkg/ggl90/ggl90_calc.F
@@ -866,9 +866,15 @@ C     by averaging (@ grid-cell center) the 4 components @ U,V pos.
          tempV  = surfaceForcingV(i, j ,bi,bj)
          tempVp = surfaceForcingV(i,j+1,bi,bj)
          uStarSquare(i,j) = SQRT(
-     &        ( ( tempU*tempU + tempUp*tempUp )
-     &        + ( tempV*tempV + tempVp*tempVp )
+     &        ( tempU*tempU + tempUp*tempUp
+     &        + tempV*tempV + tempVp*tempVp
      &        )*halfRL          )*recip_coordFac
+C Note: adding parenthesis in 4 terms sum (-> 2 group of 2) as below:
+c        uStarSquare(i,j) = SQRT(
+c    &        ( ( tempU*tempU + tempUp*tempUp )
+c    &        + ( tempV*tempV + tempVp*tempVp )
+c    &        )*halfRL          )*recip_coordFac
+C       seems to break restart !
         ENDDO
        ENDDO
       ELSE

--- a/pkg/ggl90/ggl90_calc.F
+++ b/pkg/ggl90/ggl90_calc.F
@@ -116,6 +116,9 @@ c     _RL SQRTTKE
       _RL GGL90visctmp     (1-OLx:sNx+OLx,1-OLy:sNy+OLy,Nr)
 #ifdef ALLOW_GGL90_IDEMIX
       _RL hFacI            (1-OLx:sNx+OLx,1-OLy:sNy+OLy,Nr)
+C     IDEMIX_gTKE :: TKE tendency due to internal waves
+C                    (output of S/R GGL90_IDEMIX)
+      _RL IDEMIX_gTKE     (1-OLx:sNx+OLx,1-OLy:sNy+OLy,Nr)
 #endif /* ALLOW_GGL90_IDEMIX */
       _RL recip_hFacI      (1-OLx:sNx+OLx,1-OLy:sNy+OLy,Nr)
       _RL hFac
@@ -263,7 +266,9 @@ c       rMixingLength(i,j,1)  = 0. _d 0
 
 #ifdef ALLOW_GGL90_IDEMIX
       IF ( useIDEMIX) CALL GGL90_IDEMIX(
-     &   bi, bj, hFacI, recip_hFacI, sigmaR, myTime, myIter, myThid )
+     I     bi, bj, hFacI, recip_hFacI, sigmaR,
+     O     IDEMIX_gTKE,
+     I     myTime, myIter, myThid )
 #endif /* ALLOW_GGL90_IDEMIX */
 
       DO k = 2, Nr
@@ -671,7 +676,7 @@ C     account for partical cell factor in vertical shear:
      &         /(verticalShear(i,j)+GGL90eps)
 CML         IDEMIX_RiNumber = 1./GGL90eps
           IDEMIX_RiNumber = MAX( KappaM(i,j)*Nsquare(i,j,k), 0. _d 0)/
-     &     (GGL90eps+IDEMIX_tau_d(i,j,k,bi,bj)*IDEMIX_E(i,j,k,bi,bj)**2)
+     &         ( GGL90eps + IDEMIX_gTKE(i,j,k) )
           prTemp         = MIN(5.*RiNumber, 6.6 _d 0*IDEMIX_RiNumber)
           TKEPrandtlNumber(i,j,k) = MIN(10. _d 0,prTemp)
           TKEPrandtlNumber(i,j,k) = MAX( oneRL,TKEPrandtlNumber(i,j,k) )
@@ -719,9 +724,7 @@ C     add IDEMIX contribution to the turbulent kinetic energy
         DO j=jMin,jMax
          DO i=iMin,iMax
           GGL90TKE(i,j,k,bi,bj) = GGL90TKE(i,j,k,bi,bj)
-     &         + deltaTloc*(
-     &         + IDEMIX_tau_d(i,j,k,bi,bj)*IDEMIX_E(i,j,k,bi,bj)**2
-     &         )
+     &         + deltaTloc*IDEMIX_gTKE(i,j,k)
          ENDDO
         ENDDO
        ENDIF

--- a/pkg/ggl90/ggl90_calc.F
+++ b/pkg/ggl90/ggl90_calc.F
@@ -213,6 +213,15 @@ C     case of using IDEMIX.
         ENDDO
        ENDDO
 
+#ifdef ALLOW_GGL90_IDEMIX
+C     step forward IDEMIX_E(energy) and compute tendency for TKE,
+C     IDEMIX_gTKE = tau_d * IDEMIX_E**2, following Olbers and Eden (2013)
+      IF ( useIDEMIX) CALL GGL90_IDEMIX(
+     I     bi, bj, hFacI, recip_hFacI, sigmaR,
+     O     IDEMIX_gTKE,
+     I     myTime, myIter, myThid )
+#endif /* ALLOW_GGL90_IDEMIX */
+
 C     Initialize local fields
       DO k=1,Nr
        DO j=1-OLy,sNy+OLy
@@ -263,13 +272,6 @@ c       rMixingLength(i,j,1)  = 0. _d 0
 #endif /* ALLOW_GGL90_HORIZDIFF */
        ENDDO
       ENDDO
-
-#ifdef ALLOW_GGL90_IDEMIX
-      IF ( useIDEMIX) CALL GGL90_IDEMIX(
-     I     bi, bj, hFacI, recip_hFacI, sigmaR,
-     O     IDEMIX_gTKE,
-     I     myTime, myIter, myThid )
-#endif /* ALLOW_GGL90_IDEMIX */
 
       DO k = 2, Nr
        kl = k-delK

--- a/pkg/ggl90/ggl90_calc.F
+++ b/pkg/ggl90/ggl90_calc.F
@@ -636,9 +636,9 @@ C     by averaging (@ grid-cell center) the 4 vertical shear compon @ U,V pos.
           tempV  = ( vVel(i, j ,km1,bi,bj) - vVel(i, j ,k,bi,bj) )
           tempVp = ( vVel(i,j+1,km1,bi,bj) - vVel(i,j+1,k,bi,bj) )
           verticalShear(i,j) = (
-     &                 ( tempU*tempU + tempUp*tempUp )*halfRL
-     &               + ( tempV*tempV + tempVp*tempVp )*halfRL
-     &                         )*recip_drC(k)*recip_drC(k)
+     &                 ( tempU*tempU + tempUp*tempUp )
+     &               + ( tempV*tempV + tempVp*tempVp )
+     &                         )*halfRL*recip_drC(k)*recip_drC(k)
      &                          *coordFac*coordFac
          ENDDO
         ENDDO
@@ -855,7 +855,6 @@ C     impose TKE(1) = 0.
        ENDDO
       ENDIF
 C     end set up matrix
-C
 
 C     Apply boundary condition
       IF ( calcMeanVertShear ) THEN
@@ -866,10 +865,10 @@ C     by averaging (@ grid-cell center) the 4 components @ U,V pos.
          tempUp = surfaceForcingU(i+1,j,bi,bj)
          tempV  = surfaceForcingV(i, j ,bi,bj)
          tempVp = surfaceForcingV(i,j+1,bi,bj)
-         uStarSquare(i,j) = SQRT( 0.5 _d 0 *
-     &        ( tempU*tempU + tempUp*tempUp
-     &        + tempV*tempV + tempVp*tempVp )
-     &                           )*recip_coordFac
+         uStarSquare(i,j) = SQRT(
+     &        ( ( tempU*tempU + tempUp*tempUp )
+     &        + ( tempV*tempV + tempVp*tempVp )
+     &        )*halfRL          )*recip_coordFac
         ENDDO
        ENDDO
       ELSE
@@ -881,7 +880,7 @@ C     estimate friction velocity uStar from surface forcing
      &               + surfaceForcingU(i+1,j,  bi,bj) ) )**2
      &   + ( .5 _d 0*( surfaceForcingV(i,  j,  bi,bj)
      &               + surfaceForcingV(i,  j+1,bi,bj) ) )**2
-     &                           )*recip_coordFac
+     &                          )*recip_coordFac
         ENDDO
        ENDDO
       ENDIF

--- a/pkg/ggl90/ggl90_exchanges.F
+++ b/pkg/ggl90/ggl90_exchanges.F
@@ -21,27 +21,27 @@ C     === Global variables ===
 #include "GGL90.h"
 
 C     !INPUT/OUTPUT PARAMETERS: ========================================
-C     == Routine arguments ==
-C  myThid               :: thread number
+C      myThid     :: my Thread Id number
       INTEGER myThid
 
 #ifdef ALLOW_GGL90
 C !LOCAL VARIABLES: ====================================================
-C     == Local variables ==
 CEOP
 
-#ifdef ALLOW_GGL90_HORIZDIFF
-      IF (GGL90isON .AND. GGL90diffTKEh .GT. 0. _d 0) THEN
-C Exchange overlaps
-       _EXCH_XYZ_RL(GGL90TKE,myThid)
-      ENDIF
-#endif /* ALLOW_GGL90_HORIZDIFF */
 #ifdef ALLOW_GGL90_IDEMIX
-      IF ( useIDEMIX ) THEN
-       _EXCH_XYZ_RL(IDEMIX_E,myThid)
-       _EXCH_XYZ_RL(IDEMIX_V0,myThid)
+      IF ( useIDEMIX .AND. IDEMIX_tau_h .GT. zeroRL ) THEN
+       _EXCH_XYZ_RL( GGL90TKE, myThid )
+       _EXCH_XYZ_RL( IDEMIX_E, myThid )
+      ELSEIF ( GGL90diffTKEh .GT. zeroRL ) THEN
+#else /* ALLOW_GGL90_IDEMIX */
+      IF ( GGL90diffTKEh .GT. zeroRL ) THEN
+#endif /* ALLOW_GGL90_IDEMIX */
+       _EXCH_XYZ_RL( GGL90TKE, myThid )
       ENDIF
-#endif
+
+C--   Just to check that it does not affects results:
+c      CALL EXCH_UV_3D_RL( GGL90viscArU, GGL90viscArV,
+c    I                     .FALSE., Nr, myThid )
 #endif /* ALLOW_GGL90 */
 
       RETURN

--- a/pkg/ggl90/ggl90_idemix.F
+++ b/pkg/ggl90/ggl90_idemix.F
@@ -73,12 +73,12 @@ C     === Local variables ===
       INTEGER errCode
       _RL  deltaTloc
 C     cstar :: vertical integral over N, eq (13) in Olbers+Eden (2013)
-      _RL  fxa,fxb,fxc,cstar
+      _RL  fxa,fxb,fxc,cstar,twoOverPi
       _RL  coordFac, recip_coordFac
       _RL  dfx        (1-OLx:sNx+OLx,1-OLy:sNy+OLy)
       _RL  dfy        (1-OLx:sNx+OLx,1-OLy:sNy+OLy)
 c     bN0  :: vertically integrated N
-      _RL  bN0        ((1-OLx:sNx+OLx,1-OLy:sNy+OLy)
+      _RL  bN0        (1-OLx:sNx+OLx,1-OLy:sNy+OLy)
       _RL  delta      (1-OLx:sNx+OLx,1-OLy:sNy+OLy,Nr)
       _RL  Nsquare    (1-OLx:sNx+OLx,1-OLy:sNy+OLy,Nr)
       _RL  a3d        (1-OLx:sNx+OLx,1-OLy:sNy+OLy,Nr)
@@ -110,6 +110,8 @@ CEOP
       coordFac = 1. _d 0
       IF ( usingPCoords) coordFac = gravity * rhoConst
       recip_coordFac = 1./coordFac
+
+      twoOverPi = 2. _d 0/PI
 
 C     Initialize local fields
       DO k = 1, Nr
@@ -172,9 +174,9 @@ c-----------------------------------------------------------------------
           fxa = SQRT(Nsquare(i,j,k))/fxb
           cstar = bN0(i,j)/(PI*IDEMIX_jstar)
           c0(i,j,k)=MAX(0. _d 0,
-     &             cstar*IDEMIX_gamma*IDEMIX_gofx2(fxa))
+     &             cstar*IDEMIX_gamma*IDEMIX_gofx2(fxa,twoOverPI))
           IDEMIX_V0(i,j,k,bi,bj)=MAX(0. _d 0,
-     &             cstar*IDEMIX_gamma*IDEMIX_hofx1(fxa))
+     &             cstar*IDEMIX_gamma*IDEMIX_hofx1(fxa,twoOverPI))
           fxc = MAX( 1. _d 0 , fxa )
           fxc = LOG( fxc + SQRT( fxc*fxc -1.))
           IDEMIX_tau_d(i,j,k,bi,bj) = IDEMIX_mu0*fxb*fxc*
@@ -524,29 +526,26 @@ c-----------------------------------------------------------------------
       ENDIF
 #endif /* ALLOW_DIAGNOSTICS */
 
-#endif /* ALLOW_GGL90_IDEMIX */
       RETURN
       END
 
-#ifdef ALLOW_GGL90_IDEMIX
 C     helper functions
 C---+----1----+----2----+----3----+----4----+----5----+----6----+----7-|--+----|
-      _RL FUNCTION IDEMIX_gofx2(xx)
+      _RL FUNCTION IDEMIX_gofx2(xx,toPI)
       IMPLICIT NONE
-      _RL x,c,xx
-      _RL pi
-      PARAMETER( pi = 3.14159265358979323846264338327950588d0 )
+      _RL xx
+      _RL toPI                  ! 2.d0/PI
+      _RL x,c
       x=MAX(3.d0,xx)
-      c= 1.d0-(2.d0/pi)*ASIN(1.d0/x)
-      IDEMIX_gofx2 = 2.d0/pi/c*0.9d0*x**(-2.d0/3.d0)*(1.-EXP(-x/4.3d0))
+      c= 1.d0-toPI*ASIN(1.d0/x)
+      IDEMIX_gofx2 = toPI/c*0.9d0*x**(-2.d0/3.d0)*(1.-EXP(-x/4.3d0))
       END
 C---+----1----+----2----+----3----+----4----+----5----+----6----+----7-|--+----|
-      _RL FUNCTION IDEMIX_hofx1(x)
+      _RL FUNCTION IDEMIX_hofx1(x,toPI)
       IMPLICIT NONE
       _RL x
-      _RL pi
-      PARAMETER( pi = 3.14159265358979323846264338327950588d0 )
-      IDEMIX_hofx1 = (2.d0/pi)/(1.d0-(2.d0/pi)*
-     &              ASIN(1.d0/MAX(1.01d0,x)))*(x-1.d0)/(x+1.d0)
+      _RL toPI                  ! 2.d0/PI
+      IDEMIX_hofx1 = toPI/(1.d0-toPI*ASIN(1.d0/MAX(1.01d0,x)))
+     &     *(x-1.d0)/(x+1.d0)
       END
 #endif /* ALLOW_GGL90_IDEMIX */

--- a/pkg/ggl90/ggl90_idemix.F
+++ b/pkg/ggl90/ggl90_idemix.F
@@ -16,7 +16,9 @@ CBOP
 C     !ROUTINE: GGL90_IDEMIX
 C     !INTERFACE: ======================================================
       SUBROUTINE GGL90_IDEMIX(
-     I     bi, bj, hFacI, recip_hFacI, sigmaR, myTime, myIter, myThid )
+     I     bi, bj, hFacI, recip_hFacI, sigmaR,
+     O     gTKE,
+     I     myTime, myIter, myThid )
 
 C     !DESCRIPTION: \bv
 C     *==========================================================*
@@ -50,13 +52,15 @@ C     bi, bj :: Current tile indices
 C     hFacI  :: thickness factors for w-cells (interface)
 C               with reciprocal of hFacI = recip_hFacI
 C     sigmaR :: Vertical gradient of iso-neutral density
+C     gTKE   :: TKE tendency due to internal waves (output of S/R GGL90_IDEMIX)
 C     myTime :: Current time in simulation
 C     myIter :: Current time-step number
 C     myThid :: My Thread Id number
       INTEGER bi, bj
       _RL       hFacI(1-OLx:sNx+OLx,1-OLy:sNy+OLy,Nr)
       _RL recip_hFacI(1-OLx:sNx+OLx,1-OLy:sNy+OLy,Nr)
-      _RL     sigmaR(1-OLx:sNx+OLx,1-OLy:sNy+OLy,Nr)
+      _RL        gTKE(1-OLx:sNx+OLx,1-OLy:sNy+OLy,Nr)
+      _RL     sigmaR (1-OLx:sNx+OLx,1-OLy:sNy+OLy,Nr)
       _RL     myTime
       INTEGER myIter
       INTEGER myThid
@@ -64,6 +68,10 @@ C     myThid :: My Thread Id number
 #ifdef ALLOW_GGL90_IDEMIX
 C     !FUNCTIONS:
       _RL  IDEMIX_gofx2, IDEMIX_hofx1
+#ifdef ALLOW_DIAGNOSTICS
+      LOGICAL  DIAGNOSTICS_IS_ON
+      EXTERNAL DIAGNOSTICS_IS_ON
+#endif /* ALLOW_DIAGNOSTICS */
 
 C     !LOCAL VARIABLES:
 C     === Local variables ===
@@ -84,8 +92,12 @@ c     bN0  :: vertically integrated N
       _RL  a3d        (1-OLx:sNx+OLx,1-OLy:sNy+OLy,Nr)
       _RL  b3d        (1-OLx:sNx+OLx,1-OLy:sNy+OLy,Nr)
       _RL  c3d        (1-OLx:sNx+OLx,1-OLy:sNy+OLy,Nr)
+C     v0 :: mean lateral group velocity
+      _RL  v0         (1-OLx:sNx+OLx,1-OLy:sNy+OLy,Nr)
 C     c0 ::  mean vertical group velocity, defined at interfaces (wVel-like)
       _RL  c0         (1-OLx:sNx+OLx,1-OLy:sNy+OLy,Nr)
+C     tau_d :: dissipation parameter (see Olbers and Eden 2013, eq.12)
+      _RL  tau_d      (1-OLx:sNx+OLx,1-OLy:sNy+OLy,Nr)
       _RL  forc       (1-OLx:sNx+OLx,1-OLy:sNy+OLy,Nr)
       _RL  gm_forc    (1-OLx:sNx+OLx,1-OLy:sNy+OLy)
 #ifdef ALLOW_DIAGNOSTICS
@@ -117,12 +129,15 @@ C     Initialize local fields
       DO k = 1, Nr
        DO j=1-OLy,sNy+OLy
         DO i=1-OLx,sNx+OLx
+         gTKE(i,j,k)    = 0. _d 0
          Nsquare(i,j,k) = 0. _d 0
          delta(i,j,k)   = 0. _d 0
          a3d(i,j,k)     = 0. _d 0
          b3d(i,j,k)     = 1. _d 0
          c3d(i,j,k)     = 0. _d 0
          c0(i,j,k)      = 0. _d 0
+         v0(i,j,k)      = 0. _d 0
+         tau_d(i,j,k)   = 0. _d 0
          forc(i,j,k)    = 0. _d 0
 #ifdef ALLOW_DIAGNOSTICS
          osborn_diff(i,j,k) = 0. _d 0
@@ -175,11 +190,11 @@ c-----------------------------------------------------------------------
           cstar = bN0(i,j)/(PI*IDEMIX_jstar)
           c0(i,j,k)=MAX(0. _d 0,
      &             cstar*IDEMIX_gamma*IDEMIX_gofx2(fxa,twoOverPI))
-          IDEMIX_V0(i,j,k,bi,bj)=MAX(0. _d 0,
+          v0(i,j,k)=MAX(0. _d 0,
      &             cstar*IDEMIX_gamma*IDEMIX_hofx1(fxa,twoOverPI))
           fxc = MAX( 1. _d 0 , fxa )
           fxc = LOG( fxc + SQRT( fxc*fxc -1.))
-          IDEMIX_tau_d(i,j,k,bi,bj) = IDEMIX_mu0*fxb*fxc*
+          tau_d(i,j,k) = IDEMIX_mu0*fxb*fxc*
      &         (IDEMIX_jstar*PI/(GGL90eps+bN0(i,j)) )**2
         ENDDO
        ENDDO
@@ -194,7 +209,7 @@ C     tau_h V0**2 *dt/dx**2 < 0.25 <=> V0 < sqrt( 0.25 * dx**2/(dt*tau_h) )
          DO i=1-OLx,sNx+OLx
           fxa = SQRT( 1. _d 0/( deltaTloc * IDEMIX_tau_h ) )
           fxb = 0.5*MIN( _dxF(i,j,bi,bj), _dyF(i,j,bi,bj) )*fxa
-          IDEMIX_V0(i,j,k,bi,bj) = MIN( IDEMIX_V0(i,j,k,bi,bj), fxb )
+          v0(i,j,k) = MIN( v0(i,j,k), fxb )
          ENDDO
         ENDDO
        ENDDO
@@ -280,14 +295,14 @@ c-----------------------------------------------------------------------
          dfx(1-OLx,j)=0. _d 0
          DO i=1-OLx+1,sNx+OLx
           fxa = IDEMIX_tau_h*0.5 _d 0*(
-     &        IDEMIX_V0(i-1,j,k,bi,bj)*maskC(i-1,j,kl,bi,bj)
-     &       +IDEMIX_V0(i  ,j,k,bi,bj)*maskC(i  ,j,kl,bi,bj))
+     &        v0(i-1,j,k)*maskC(i-1,j,kl,bi,bj)
+     &       +v0(i  ,j,k)*maskC(i  ,j,kl,bi,bj))
           dfx(i,j) = -fxa*_dyG(i,j,bi,bj)*drC(k)
      &                *(MIN(.5 _d 0,_hFacW(i,j,k-1,bi,bj) ) +
      &                  MIN(.5 _d 0,_hFacW(i,j,k  ,bi,bj) ) )
      &      *_recip_dxC(i,j,bi,bj)
-     &      *(IDEMIX_V0(i  ,j,k,bi,bj)*IDEMIX_E(i  ,j,k,bi,bj)
-     &       -IDEMIX_V0(i-1,j,k,bi,bj)*IDEMIX_E(i-1,j,k,bi,bj))
+     &      *(v0(i  ,j,k)*IDEMIX_E(i  ,j,k,bi,bj)
+     &       -v0(i-1,j,k)*IDEMIX_E(i-1,j,k,bi,bj))
      &         *maskW(i,j,kl,bi,bj) ! paranoia setting
          ENDDO
         ENDDO
@@ -297,14 +312,14 @@ c-----------------------------------------------------------------------
         DO j=1-OLy+1,sNy+OLy
          DO i=1-OLx,sNx+OLx
           fxa = IDEMIX_tau_h*0.5 _d 0*(
-     &        IDEMIX_V0(i,j  ,k,bi,bj)*maskC(i,j  ,kl,bi,bj)
-     &       +IDEMIX_V0(i,j-1,k,bi,bj)*maskC(i,j-1,kl,bi,bj) )
+     &        v0(i,j  ,k)*maskC(i,j  ,kl,bi,bj)
+     &       +v0(i,j-1,k)*maskC(i,j-1,kl,bi,bj) )
           dfy(i,j) = -fxa*_dxG(i,j,bi,bj)*drC(k)
      &                *(MIN(.5 _d 0,_hFacS(i,j,k-1,bi,bj) ) +
      &                  MIN(.5 _d 0,_hFacS(i,j,k  ,bi,bj) ) )
      &      *_recip_dyC(i,j,bi,bj)
-     &      *(IDEMIX_V0(i,j  ,k,bi,bj)*IDEMIX_E(i,j  ,k,bi,bj)
-     &       -IDEMIX_V0(i,j-1,k,bi,bj)*IDEMIX_E(i,j-1,k,bi,bj))
+     &      *(v0(i,j  ,k)*IDEMIX_E(i,j  ,k,bi,bj)
+     &       -v0(i,j-1,k)*IDEMIX_E(i,j-1,k,bi,bj))
      &         *maskS(i,j,kl,bi,bj) ! paranoia setting
          ENDDO
         ENDDO
@@ -427,7 +442,7 @@ C--   Center diagonal
       DO k=2,Nr
        DO j=jMin,jMax
         DO i=iMin,iMax
-         b3d(i,j,k) = 1. _d 0+deltaTloc*IDEMIX_tau_d(i,j,k,bi,bj)
+         b3d(i,j,k) = 1. _d 0+deltaTloc*tau_d(i,j,k)
      &         *IDEMIX_E(i,j,k,bi,bj)
      &         *maskC(i,j,k,bi,bj)*maskC(i,j,k-1,bi,bj)
      &        - ( a3d(i,j,k) + c3d(i,j,k) ) * c0(i,j,k)
@@ -489,6 +504,16 @@ C     solve tri-diagonal system
      O                        errCode,
      I                        bi, bj, myThid )
 
+C     generate TKE tendency due to internal waves (output)
+      DO k=2,Nr
+       DO j=jMin,jMax
+        DO i=iMin,iMax
+         gTKE(i,j,k) =
+     &        tau_d(i,j,k)*IDEMIX_E(i,j,k,bi,bj)*IDEMIX_E(i,j,k,bi,bj)
+        ENDDO
+       ENDDO
+      ENDDO
+
 #ifdef ALLOW_DIAGNOSTICS
       IF ( useDiagnostics ) THEN
 c-----------------------------------------------------------------------
@@ -496,33 +521,31 @@ c     compute diffusivity due to internal wave breaking
 c     assuming local Osborn-Cox balance model
 c     kept for diagnostics only
 c-----------------------------------------------------------------------
-       DO k=2,Nr
-        DO j=jMin,jMax
-         DO i=iMin,iMax
-          osborn_diff(i,j,k) = IDEMIX_mixing_efficiency
-     &     *IDEMIX_tau_d(i,j,k,bi,bj)
-     &         *IDEMIX_E(i,j,k,bi,bj)*IDEMIX_E(i,j,k,bi,bj)
-     &     /MAX(1. _d -12,Nsquare(i,j,k))*maskC(i,j,k,bi,bj)
-          osborn_diff(i,j,k) = MIN(IDEMIX_diff_max,osborn_diff(i,j,k))
+       IF ( DIAGNOSTICS_IS_ON('IDEMIX_K',myThid) ) THEN
+        DO k=2,Nr
+         DO j=jMin,jMax
+          DO i=iMin,iMax
+           osborn_diff(i,j,k) = IDEMIX_mixing_efficiency * gTKE(i,j,k)
+     &          /MAX(1. _d -12,Nsquare(i,j,k))*maskC(i,j,k,bi,bj)
+           osborn_diff(i,j,k) = MIN(IDEMIX_diff_max,osborn_diff(i,j,k))
+          ENDDO
          ENDDO
         ENDDO
-       ENDDO
-       CALL DIAGNOSTICS_FILL( IDEMIX_E ,'IDEMIX_E',
-     &                          0,Nr, 1, bi, bj, myThid )
-       CALL DIAGNOSTICS_FILL( IDEMIX_V0 ,'IDEMIX_v',
-     &                          0,Nr, 1, bi, bj, myThid )
-       CALL DIAGNOSTICS_FILL( IDEMIX_tau_d ,'IDEMIX_t',
-     &                          0,Nr, 1, bi, bj, myThid )
-       CALL DIAGNOSTICS_FILL( c0 ,'IDEMIX_c',
-     &                          0,Nr, 2, bi, bj, myThid )
-       CALL DIAGNOSTICS_FILL( osborn_diff ,'IDEMIX_K',
-     &                          0,Nr, 2, bi, bj, myThid )
-       CALL DIAGNOSTICS_FILL( forc ,'IDEMIX_F',
-     &                          0,Nr, 2, bi, bj, myThid )
-       CALL DIAGNOSTICS_FILL(IDEMIX_F_b,'IDEM_F_b',0,1,1,bi,bj,myThid)
-       CALL DIAGNOSTICS_FILL(IDEMIX_F_s,'IDEM_F_s',0,1,1,bi,bj,myThid)
-       CALL DIAGNOSTICS_FILL(gm_forc,'IDEM_F_g',
-     &                          0,1,2,bi,bj,myThid)
+        CALL DIAGNOSTICS_FILL( osborn_diff ,'IDEMIX_K',
+     &                          0, Nr, 2, bi, bj, myThid )
+       ENDIF
+       CALL DIAGNOSTICS_FILL( IDEMIX_E ,'IDEMIX_E',0,Nr,1,bi,bj,myThid)
+       CALL DIAGNOSTICS_FILL( tau_d,    'IDEMIX_t',0,Nr,2,bi,bj,myThid)
+       CALL DIAGNOSTICS_FILL( v0,       'IDEMIX_v',0,Nr,2,bi,bj,myThid)
+       CALL DIAGNOSTICS_FILL( c0 ,      'IDEMIX_c',0,Nr,2,bi,bj,myThid)
+       CALL DIAGNOSTICS_FILL( forc,     'IDEMIX_F',0,Nr,2,bi,bj,myThid)
+       CALL DIAGNOSTICS_FILL(IDEMIX_F_b,'IDEM_F_b',0, 1,1,bi,bj,myThid)
+       CALL DIAGNOSTICS_FILL(IDEMIX_F_s,'IDEM_F_s',0, 1,1,bi,bj,myThid)
+# ifdef ALLOW_GMREDI
+       IF (useGmredi) THEN
+        CALL DIAGNOSTICS_FILL( gm_forc, 'IDEM_F_g',0, 1,2,bi,bj,myThid)
+       ENDIF
+# endif
       ENDIF
 #endif /* ALLOW_DIAGNOSTICS */
 

--- a/pkg/ggl90/ggl90_idemix.F
+++ b/pkg/ggl90/ggl90_idemix.F
@@ -510,6 +510,8 @@ C     generate TKE tendency due to internal waves (output)
         DO i=iMin,iMax
          gTKE(i,j,k) =
      &        tau_d(i,j,k)*IDEMIX_E(i,j,k,bi,bj)*IDEMIX_E(i,j,k,bi,bj)
+C-    to reproduce older results (before adding output arguement gTKE)
+c    &        tau_d(i,j,k)*IDEMIX_E(i,j,k,bi,bj)**2
         ENDDO
        ENDDO
       ENDDO

--- a/pkg/ggl90/ggl90_idemix.F
+++ b/pkg/ggl90/ggl90_idemix.F
@@ -526,9 +526,11 @@ c-----------------------------------------------------------------------
       ENDIF
 #endif /* ALLOW_DIAGNOSTICS */
 
+#endif /* ALLOW_GGL90_IDEMIX */
       RETURN
       END
 
+#ifdef ALLOW_GGL90_IDEMIX
 C     helper functions
 C---+----1----+----2----+----3----+----4----+----5----+----6----+----7-|--+----|
       _RL FUNCTION IDEMIX_gofx2(xx,toPI)

--- a/pkg/ggl90/ggl90_init_varia.F
+++ b/pkg/ggl90/ggl90_init_varia.F
@@ -71,9 +71,7 @@ C--   Over all tiles
         DO k=1,Nr
          DO j=1-OLy,sNy+OLy
           DO i=1-OLx,sNx+OLx
-           IDEMIX_E(i,j,k,bi,bj)     = 0. _d 0
-           IDEMIX_V0(i,j,k,bi,bj)    = 0. _d 0
-           IDEMIX_tau_d(i,j,k,bi,bj) = 0. _d 0
+           IDEMIX_E(i,j,k,bi,bj) = 0. _d 0
           ENDDO
          ENDDO
         ENDDO

--- a/pkg/ggl90/ggl90_readparms.F
+++ b/pkg/ggl90/ggl90_readparms.F
@@ -116,15 +116,13 @@ C     Blanke and Delecluse (1993, JPO) use
 C-----------------------------------------------------------------------
 C     set default parameter for IDEMIX
 C-----------------------------------------------------------------------
-      IDEMIX_tau_v      =  1.0*86400.0 _d 0
+C     New (and different from Olbers and Eden, 20130) parameter default
+C     values for tau_v, jstar, mu0 according to Pollmann et al. (2017):
+      IDEMIX_tau_v      =  2.0*86400.0 _d 0
       IDEMIX_tau_h      = 10.0*86400.0 _d 0
       IDEMIX_gamma      = 1.57 _d 0
-      IDEMIX_jstar      = 10.0 _d 0
-      IDEMIX_mu0        = 4.0 _d 0/3.0 _d 0
-C     Better parameter values according to Pollmann et al., 2017:
-C     IDEMIX_tau_v      =  2.0*86400.0 _d 0
-C     IDEMIX_jstar      = 5.0 _d 0
-C     IDEMIX_mu0        = 1.0 _d 0/3.0 _d 0
+      IDEMIX_jstar      = 5.0 _d 0
+      IDEMIX_mu0        = 1.0 _d 0/3.0 _d 0
       IDEMIX_mixing_efficiency = 0.1666 _d 0
       IDEMIX_diff_max   = 1.0 _d 0
       IDEMIX_diff_min   = 1.0 _d -9

--- a/verification/global_ocean.90x40x15/input.idemix/data.ggl90
+++ b/verification/global_ocean.90x40x15/input.idemix/data.ggl90
@@ -27,4 +27,9 @@
  IDEMIX_include_GM        = .FALSE.,
  IDEMIX_tidal_file  = 'tidal_energy.bin',
  IDEMIX_wind_file   = 'wind_energy.bin',
+# these are old defaults that are not recommended
+ IDEMIX_tau_v =  86400.0,
+ IDEMIX_jstar = 10.0,
+#IDEMIX_mu0   = 4.0/3.0
+ IDEMIX_mu0   = 1.3333333333333333,
  &

--- a/verification/global_ocean.90x40x15/input.idemix/data.ggl90
+++ b/verification/global_ocean.90x40x15/input.idemix/data.ggl90
@@ -1,24 +1,25 @@
 # Parameters for Gaspar et al. (1990)'s TKE vertical mixing scheme  |
  &GGL90_PARM01
- GGL90dumpFreq=,
- GGL90taveFreq=,
- GGL90diffTKEh=0.e3,
- GGL90mixingMaps=.FALSE,
- GGL90writeState=.FALSE.,
- GGL90ck=0.1,
+ GGL90diffTKEh=0.E3,
+ GGL90ck = 0.1,
  GGL90ceps = 0.7,
  GGL90alpha=30.,
  GGL90m2 = 3.0,
- GGL90TKEmin = 0.e-6,
- GGL90TKEbottom=4.e-6,
- GGL90TKEsurfMin=1.e-4,
- GGL90mixingLengthMin=,
+ GGL90TKEmin = 0.E-6,
+ GGL90TKEbottom=4.E-6,
+ GGL90TKEsurfMin=1.E-4,
+#GGL90mixingLengthMin=,
  mxlMaxFlag=2,
- GGL90viscMax=1.e2,
- GGL90diffMax=1.e2,
- GGL90TKEFile=,
+ GGL90viscMax=1.E2,
+ GGL90diffMax=1.E2,
  GGL90_dirichlet=.FALSE.,
  useIDEMIX  = .TRUE.,
+#-- IO related params:
+#GGL90TKEFile=,
+#GGL90dumpFreq=,
+#GGL90taveFreq=,
+ GGL90mixingMaps=.FALSE.,
+ GGL90writeState=.FALSE.,
  &
 
  &GGL90_PARM02
@@ -27,4 +28,3 @@
  IDEMIX_tidal_file  = 'tidal_energy.bin',
  IDEMIX_wind_file   = 'wind_energy.bin',
  &
-

--- a/verification/global_ocean.90x40x15/results/output.idemix.txt
+++ b/verification/global_ocean.90x40x15/results/output.idemix.txt
@@ -5,10 +5,10 @@
 (PID.TID 0000.0001) // ======================================================
 (PID.TID 0000.0001) // execution environment starting up...
 (PID.TID 0000.0001) 
-(PID.TID 0000.0001) // MITgcmUV version:  checkpoint67o
-(PID.TID 0000.0001) // Build user:        mlosch
-(PID.TID 0000.0001) // Build host:        bkli04l006
-(PID.TID 0000.0001) // Build date:        Fri Feb 14 17:45:43 CET 2020
+(PID.TID 0000.0001) // MITgcmUV version:  checkpoint68a
+(PID.TID 0000.0001) // Build user:        jm_c
+(PID.TID 0000.0001) // Build host:        villon
+(PID.TID 0000.0001) // Build date:        Tue Aug 17 12:08:23 EDT 2021
 (PID.TID 0000.0001) 
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // Execution Environment parameter file "eedata"
@@ -51,7 +51,7 @@
 (PID.TID 0000.0001)                   /*  note: To execute a program with MPI calls */
 (PID.TID 0000.0001)                   /*  it must be launched appropriately e.g     */
 (PID.TID 0000.0001)                   /*  "mpirun -np 64 ......"                    */
-(PID.TID 0000.0001) useCoupler=    F ;/* Flag used to control communications with   */
+(PID.TID 0000.0001) useCoupler=   F ; /* Flag used to control communications with   */
 (PID.TID 0000.0001)                   /*  other model components, through a coupler */
 (PID.TID 0000.0001) useNest2W_parent =    F ;/* Control 2-W Nesting comm */
 (PID.TID 0000.0001) useNest2W_child  =    F ;/* Control 2-W Nesting comm */
@@ -202,7 +202,6 @@
 (PID.TID 0000.0001)  PACKAGES_BOOT: On/Off package Summary
  --------  pkgs with a standard "usePKG" On/Off switch in "data.pkg":  --------
  pkg/ggl90                compiled   and   used ( useGGL90                 = T )
- pkg/kpp                  compiled but not used ( useKPP                   = F )
  pkg/gmredi               compiled   and   used ( useGMRedi                = T )
  pkg/down_slope           compiled but not used ( useDOWN_SLOPE            = F )
  pkg/sbo                  compiled but not used ( useSBO                   = F )
@@ -229,25 +228,26 @@
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) ># Parameters for Gaspar et al. (1990)'s TKE vertical mixing scheme  |
 (PID.TID 0000.0001) > &GGL90_PARM01
-(PID.TID 0000.0001) > GGL90dumpFreq=,
-(PID.TID 0000.0001) > GGL90taveFreq=,
-(PID.TID 0000.0001) > GGL90diffTKEh=0.e3,
-(PID.TID 0000.0001) > GGL90mixingMaps=.FALSE,
-(PID.TID 0000.0001) > GGL90writeState=.FALSE.,
-(PID.TID 0000.0001) > GGL90ck=0.1,
+(PID.TID 0000.0001) > GGL90diffTKEh=0.E3,
+(PID.TID 0000.0001) > GGL90ck = 0.1,
 (PID.TID 0000.0001) > GGL90ceps = 0.7,
 (PID.TID 0000.0001) > GGL90alpha=30.,
 (PID.TID 0000.0001) > GGL90m2 = 3.0,
-(PID.TID 0000.0001) > GGL90TKEmin = 0.e-6,
-(PID.TID 0000.0001) > GGL90TKEbottom=4.e-6,
-(PID.TID 0000.0001) > GGL90TKEsurfMin=1.e-4,
-(PID.TID 0000.0001) > GGL90mixingLengthMin=,
+(PID.TID 0000.0001) > GGL90TKEmin = 0.E-6,
+(PID.TID 0000.0001) > GGL90TKEbottom=4.E-6,
+(PID.TID 0000.0001) > GGL90TKEsurfMin=1.E-4,
+(PID.TID 0000.0001) >#GGL90mixingLengthMin=,
 (PID.TID 0000.0001) > mxlMaxFlag=2,
-(PID.TID 0000.0001) > GGL90viscMax=1.e2,
-(PID.TID 0000.0001) > GGL90diffMax=1.e2,
-(PID.TID 0000.0001) > GGL90TKEFile=,
+(PID.TID 0000.0001) > GGL90viscMax=1.E2,
+(PID.TID 0000.0001) > GGL90diffMax=1.E2,
 (PID.TID 0000.0001) > GGL90_dirichlet=.FALSE.,
 (PID.TID 0000.0001) > useIDEMIX  = .TRUE.,
+(PID.TID 0000.0001) >#-- IO related params:
+(PID.TID 0000.0001) >#GGL90TKEFile=,
+(PID.TID 0000.0001) >#GGL90dumpFreq=,
+(PID.TID 0000.0001) >#GGL90taveFreq=,
+(PID.TID 0000.0001) > GGL90mixingMaps=.FALSE.,
+(PID.TID 0000.0001) > GGL90writeState=.FALSE.,
 (PID.TID 0000.0001) > /
 (PID.TID 0000.0001) >
 (PID.TID 0000.0001) > &GGL90_PARM02
@@ -256,7 +256,6 @@
 (PID.TID 0000.0001) > IDEMIX_tidal_file  = 'tidal_energy.bin',
 (PID.TID 0000.0001) > IDEMIX_wind_file   = 'wind_energy.bin',
 (PID.TID 0000.0001) > /
-(PID.TID 0000.0001) >
 (PID.TID 0000.0001) 
 (PID.TID 0000.0001)  GGL90_READPARMS ; starts to read GGL90_PARM01
 (PID.TID 0000.0001)  GGL90_READPARMS: read GGL90_PARM01 : OK
@@ -321,7 +320,7 @@
 (PID.TID 0000.0001)                   F
 (PID.TID 0000.0001)     ;
 (PID.TID 0000.0001) GGL90: GGL90TKEFile =
-(PID.TID 0000.0001) GGL90writeState =   /* GGL90 Boundary condition flag */
+(PID.TID 0000.0001) GGL90_dirichlet =   /* GGL90 Boundary condition flag */
 (PID.TID 0000.0001)                   F
 (PID.TID 0000.0001)     ;
 (PID.TID 0000.0001) useIDEMIX =   /* turn on IDEMIX contribution. */
@@ -876,7 +875,7 @@
 (PID.TID 0000.0001) tRef =   /* Reference temperature profile ( oC or K ) */
 (PID.TID 0000.0001)    15 @  2.000000000000000E+01              /* K =  1: 15 */
 (PID.TID 0000.0001)     ;
-(PID.TID 0000.0001) sRef =   /* Reference salinity profile ( psu ) */
+(PID.TID 0000.0001) sRef =   /* Reference salinity profile ( g/kg ) */
 (PID.TID 0000.0001)    15 @  3.500000000000000E+01              /* K =  1: 15 */
 (PID.TID 0000.0001)     ;
 (PID.TID 0000.0001) useStrainTensionVisc= /* Use StrainTension Form of Viscous Operator */
@@ -969,9 +968,15 @@
 (PID.TID 0000.0001) eosType =  /* Type of Equation of State */
 (PID.TID 0000.0001)               'JMD95P'
 (PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) eosRefP0 = /* Reference atmospheric pressure for EOS ( Pa ) */
+(PID.TID 0000.0001)                 1.013250000000000E+05
+(PID.TID 0000.0001)     ;
 (PID.TID 0000.0001) selectP_inEOS_Zc = /* select pressure to use in EOS (0,1,2,3) */
 (PID.TID 0000.0001)                       2
 (PID.TID 0000.0001)     0= -g*rhoConst*z ; 1= pRef (from tRef,sRef); 2= Hyd P ; 3= Hyd+NH P
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) surf_pRef = /* Surface reference pressure ( Pa ) */
+(PID.TID 0000.0001)                 1.013250000000000E+05
 (PID.TID 0000.0001)     ;
 (PID.TID 0000.0001) HeatCapacity_Cp =  /* Specific heat capacity ( J/kg/K ) */
 (PID.TID 0000.0001)                 3.994000000000000E+03
@@ -1073,7 +1078,7 @@
 (PID.TID 0000.0001) temp_EvPrRn = /* Temp. of Evap/Prec/R (UNSET=use local T)(oC)*/
 (PID.TID 0000.0001)                 1.234567000000000E+05
 (PID.TID 0000.0001)     ;
-(PID.TID 0000.0001) salt_EvPrRn = /* Salin. of Evap/Prec/R (UNSET=use local S)(psu)*/
+(PID.TID 0000.0001) salt_EvPrRn = /* Salin. of Evap/Prec/R (UNSET=use local S)(g/kg)*/
 (PID.TID 0000.0001)                 0.000000000000000E+00
 (PID.TID 0000.0001)     ;
 (PID.TID 0000.0001) selectAddFluid = /* option for mass source/sink of fluid (=0: off) */
@@ -1082,10 +1087,10 @@
 (PID.TID 0000.0001) temp_addMass = /* Temp. of addMass array (UNSET=use local T)(oC)*/
 (PID.TID 0000.0001)                 1.234567000000000E+05
 (PID.TID 0000.0001)     ;
-(PID.TID 0000.0001) salt_addMass = /* Salin. of addMass array (UNSET=use local S)(psu)*/
+(PID.TID 0000.0001) salt_addMass = /* Salin. of addMass array (UNSET=use local S)(g/kg)*/
 (PID.TID 0000.0001)                 0.000000000000000E+00
 (PID.TID 0000.0001)     ;
-(PID.TID 0000.0001) convertFW2Salt = /* convert F.W. Flux to Salt Flux (-1=use local S)(psu)*/
+(PID.TID 0000.0001) convertFW2Salt = /* convert F.W. Flux to Salt Flux (-1=use local S)(g/kg)*/
 (PID.TID 0000.0001)                -1.000000000000000E+00
 (PID.TID 0000.0001)     ;
 (PID.TID 0000.0001) use3Dsolver = /* use 3-D pressure solver on/off flag */
@@ -2329,15 +2334,15 @@ Global & Regional Statistics diagnostics: Number of lists:     0
  cg2d: Sum(rhs),rhsMax =   1.04360964314765E-14  2.64520401917383E+00
 (PID.TID 0000.0001)      cg2d_init_res =   5.58822337956443E-01
 (PID.TID 0000.0001)      cg2d_iters(min,last) =      -1     139
-(PID.TID 0000.0001)      cg2d_last_res =   8.32141252272969E-14
+(PID.TID 0000.0001)      cg2d_last_res =   8.32141253092959E-14
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // Begin MONITOR dynamic field statistics
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) %MON time_tsnumber                =                     2
 (PID.TID 0000.0001) %MON time_secondsf                =   1.7280000000000E+05
-(PID.TID 0000.0001) %MON dynstat_eta_max              =   9.0324117148353E-01
+(PID.TID 0000.0001) %MON dynstat_eta_max              =   9.0324117148348E-01
 (PID.TID 0000.0001) %MON dynstat_eta_min              =  -1.3210004431069E+00
-(PID.TID 0000.0001) %MON dynstat_eta_mean             =  -4.0753614870714E-17
+(PID.TID 0000.0001) %MON dynstat_eta_mean             =  -5.4338153160951E-18
 (PID.TID 0000.0001) %MON dynstat_eta_sd               =   4.4344471918000E-01
 (PID.TID 0000.0001) %MON dynstat_eta_del2             =   2.5909166548568E-03
 (PID.TID 0000.0001) %MON dynstat_uvel_max             =   3.1744676637344E-02
@@ -2351,8 +2356,8 @@ Global & Regional Statistics diagnostics: Number of lists:     0
 (PID.TID 0000.0001) %MON dynstat_vvel_sd              =   4.2266431274803E-03
 (PID.TID 0000.0001) %MON dynstat_vvel_del2            =   4.4141613392214E-05
 (PID.TID 0000.0001) %MON dynstat_wvel_max             =   1.0855530914353E-04
-(PID.TID 0000.0001) %MON dynstat_wvel_min             =  -9.8396819921400E-05
-(PID.TID 0000.0001) %MON dynstat_wvel_mean            =   5.8718522581178E-23
+(PID.TID 0000.0001) %MON dynstat_wvel_min             =  -9.8396819921399E-05
+(PID.TID 0000.0001) %MON dynstat_wvel_mean            =   9.9821488388002E-23
 (PID.TID 0000.0001) %MON dynstat_wvel_sd              =   1.2122659629746E-05
 (PID.TID 0000.0001) %MON dynstat_wvel_del2            =   1.7008446305722E-07
 (PID.TID 0000.0001) %MON dynstat_theta_max            =   2.9717076062146E+01
@@ -2413,21 +2418,21 @@ Global & Regional Statistics diagnostics: Number of lists:     0
 (PID.TID 0000.0001) // End MONITOR dynamic field statistics
 (PID.TID 0000.0001) // =======================================================
  EXTERNAL_FIELDS_LOAD,         2 : iP,iLd,i0,i1=   12    1   12    1 ; Wght=  0.4333333333  0.5666666667
- cg2d: Sum(rhs),rhsMax =  -3.44169137633799E-15  2.37884408973423E+00
-(PID.TID 0000.0001)      cg2d_init_res =   5.81232322475198E-01
+ cg2d: Sum(rhs),rhsMax =  -2.22044604925031E-15  2.37884408973423E+00
+(PID.TID 0000.0001)      cg2d_init_res =   5.81232322475357E-01
 (PID.TID 0000.0001)      cg2d_iters(min,last) =      -1     138
-(PID.TID 0000.0001)      cg2d_last_res =   9.86994963161495E-14
+(PID.TID 0000.0001)      cg2d_last_res =   9.86994968949567E-14
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // Begin MONITOR dynamic field statistics
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) %MON time_tsnumber                =                     3
 (PID.TID 0000.0001) %MON time_secondsf                =   2.5920000000000E+05
 (PID.TID 0000.0001) %MON dynstat_eta_max              =   8.9329116064314E-01
-(PID.TID 0000.0001) %MON dynstat_eta_min              =  -1.5760995105322E+00
-(PID.TID 0000.0001) %MON dynstat_eta_mean             =  -2.1735261264381E-17
+(PID.TID 0000.0001) %MON dynstat_eta_min              =  -1.5760995105323E+00
+(PID.TID 0000.0001) %MON dynstat_eta_mean             =   3.0791620124539E-17
 (PID.TID 0000.0001) %MON dynstat_eta_sd               =   5.2927829184694E-01
-(PID.TID 0000.0001) %MON dynstat_eta_del2             =   2.4201762211697E-03
-(PID.TID 0000.0001) %MON dynstat_uvel_max             =   5.0481261742315E-02
+(PID.TID 0000.0001) %MON dynstat_eta_del2             =   2.4201762211698E-03
+(PID.TID 0000.0001) %MON dynstat_uvel_max             =   5.0481261742316E-02
 (PID.TID 0000.0001) %MON dynstat_uvel_min             =  -4.7233665906022E-02
 (PID.TID 0000.0001) %MON dynstat_uvel_mean            =  -9.2222165955539E-04
 (PID.TID 0000.0001) %MON dynstat_uvel_sd              =   3.4935802140573E-03
@@ -2439,9 +2444,9 @@ Global & Regional Statistics diagnostics: Number of lists:     0
 (PID.TID 0000.0001) %MON dynstat_vvel_del2            =   6.1939090075861E-05
 (PID.TID 0000.0001) %MON dynstat_wvel_max             =   1.4850482901394E-04
 (PID.TID 0000.0001) %MON dynstat_wvel_min             =  -1.2994222430949E-04
-(PID.TID 0000.0001) %MON dynstat_wvel_mean            =   1.1743704516236E-23
+(PID.TID 0000.0001) %MON dynstat_wvel_mean            =  -9.3949636129884E-23
 (PID.TID 0000.0001) %MON dynstat_wvel_sd              =   1.6328070384579E-05
-(PID.TID 0000.0001) %MON dynstat_wvel_del2            =   2.2986676462225E-07
+(PID.TID 0000.0001) %MON dynstat_wvel_del2            =   2.2986676462224E-07
 (PID.TID 0000.0001) %MON dynstat_theta_max            =   2.9703777692972E+01
 (PID.TID 0000.0001) %MON dynstat_theta_min            =  -1.9013272428997E+00
 (PID.TID 0000.0001) %MON dynstat_theta_mean           =   3.6187150263427E+00
@@ -2483,7 +2488,7 @@ Global & Regional Statistics diagnostics: Number of lists:     0
 (PID.TID 0000.0001) %MON advcfl_uvel_max              =   1.6427692900569E-02
 (PID.TID 0000.0001) %MON advcfl_vvel_max              =   1.2121622365289E-02
 (PID.TID 0000.0001) %MON advcfl_wvel_max              =   4.6626364892377E-02
-(PID.TID 0000.0001) %MON advcfl_W_hf_max              =   5.2761412904532E-02
+(PID.TID 0000.0001) %MON advcfl_W_hf_max              =   5.2761412904531E-02
 (PID.TID 0000.0001) %MON pe_b_mean                    =   3.5846715085310E-04
 (PID.TID 0000.0001) %MON ke_max                       =   2.0775791857689E-03
 (PID.TID 0000.0001) %MON ke_mean                      =   2.1419970743167E-05
@@ -2500,33 +2505,33 @@ Global & Regional Statistics diagnostics: Number of lists:     0
 (PID.TID 0000.0001) // End MONITOR dynamic field statistics
 (PID.TID 0000.0001) // =======================================================
  EXTERNAL_FIELDS_LOAD,         3 : iP,iLd,i0,i1=   12    1   12    1 ; Wght=  0.4000000000  0.6000000000
- cg2d: Sum(rhs),rhsMax =  -4.32986979603811E-15  2.20486080157103E+00
-(PID.TID 0000.0001)      cg2d_init_res =   4.05101146513316E-01
+ cg2d: Sum(rhs),rhsMax =  -3.33066907387547E-16  2.20486080157103E+00
+(PID.TID 0000.0001)      cg2d_init_res =   4.05101146512987E-01
 (PID.TID 0000.0001)      cg2d_iters(min,last) =      -1     138
-(PID.TID 0000.0001)      cg2d_last_res =   8.95429440635260E-14
+(PID.TID 0000.0001)      cg2d_last_res =   8.95429440934783E-14
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // Begin MONITOR dynamic field statistics
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) %MON time_tsnumber                =                     4
 (PID.TID 0000.0001) %MON time_secondsf                =   3.4560000000000E+05
-(PID.TID 0000.0001) %MON dynstat_eta_max              =   8.6579425110882E-01
+(PID.TID 0000.0001) %MON dynstat_eta_max              =   8.6579425110887E-01
 (PID.TID 0000.0001) %MON dynstat_eta_min              =  -1.5896768336351E+00
-(PID.TID 0000.0001) %MON dynstat_eta_mean             =  -4.3470522528761E-17
+(PID.TID 0000.0001) %MON dynstat_eta_mean             =  -3.6225435440634E-17
 (PID.TID 0000.0001) %MON dynstat_eta_sd               =   5.5510480102435E-01
-(PID.TID 0000.0001) %MON dynstat_eta_del2             =   2.3412795207760E-03
+(PID.TID 0000.0001) %MON dynstat_eta_del2             =   2.3412795207759E-03
 (PID.TID 0000.0001) %MON dynstat_uvel_max             =   7.0685407848773E-02
 (PID.TID 0000.0001) %MON dynstat_uvel_min             =  -5.9965914203160E-02
 (PID.TID 0000.0001) %MON dynstat_uvel_mean            =  -8.4471593237465E-04
 (PID.TID 0000.0001) %MON dynstat_uvel_sd              =   4.6635359514134E-03
 (PID.TID 0000.0001) %MON dynstat_uvel_del2            =   5.8110038105676E-05
 (PID.TID 0000.0001) %MON dynstat_vvel_max             =   6.2599588418823E-02
-(PID.TID 0000.0001) %MON dynstat_vvel_min             =  -7.8607992735023E-02
+(PID.TID 0000.0001) %MON dynstat_vvel_min             =  -7.8607992735024E-02
 (PID.TID 0000.0001) %MON dynstat_vvel_mean            =   5.5199970916471E-04
 (PID.TID 0000.0001) %MON dynstat_vvel_sd              =   7.2697110636819E-03
 (PID.TID 0000.0001) %MON dynstat_vvel_del2            =   7.7165140574119E-05
 (PID.TID 0000.0001) %MON dynstat_wvel_max             =   1.8258249607488E-04
-(PID.TID 0000.0001) %MON dynstat_wvel_min             =  -1.5416451530435E-04
-(PID.TID 0000.0001) %MON dynstat_wvel_mean            =  -1.5266815871106E-22
+(PID.TID 0000.0001) %MON dynstat_wvel_min             =  -1.5416451530436E-04
+(PID.TID 0000.0001) %MON dynstat_wvel_mean            =   1.0745489632355E-21
 (PID.TID 0000.0001) %MON dynstat_wvel_sd              =   1.9920528953433E-05
 (PID.TID 0000.0001) %MON dynstat_wvel_del2            =   2.7643016187316E-07
 (PID.TID 0000.0001) %MON dynstat_theta_max            =   2.9695782894323E+01
@@ -2566,7 +2571,7 @@ Global & Regional Statistics diagnostics: Number of lists:     0
 (PID.TID 0000.0001) %MON forcing_fv_del2              =   4.4740184358134E-04
 (PID.TID 0000.0001) %MON trAdv_CFL_u_max              =   1.8542673516495E-02
 (PID.TID 0000.0001) %MON trAdv_CFL_v_max              =   1.1612438615113E-02
-(PID.TID 0000.0001) %MON trAdv_CFL_w_max              =   4.2907674805560E-02
+(PID.TID 0000.0001) %MON trAdv_CFL_w_max              =   4.2907674805561E-02
 (PID.TID 0000.0001) %MON advcfl_uvel_max              =   2.2788207513427E-02
 (PID.TID 0000.0001) %MON advcfl_vvel_max              =   1.5272272267783E-02
 (PID.TID 0000.0001) %MON advcfl_wvel_max              =   5.8249914569638E-02
@@ -2575,22 +2580,22 @@ Global & Regional Statistics diagnostics: Number of lists:     0
 (PID.TID 0000.0001) %MON ke_max                       =   3.6286966995962E-03
 (PID.TID 0000.0001) %MON ke_mean                      =   3.4067770418314E-05
 (PID.TID 0000.0001) %MON ke_vol                       =   1.3226782436723E+18
-(PID.TID 0000.0001) %MON vort_r_min                   =  -2.7426061450027E-07
+(PID.TID 0000.0001) %MON vort_r_min                   =  -2.7426061450028E-07
 (PID.TID 0000.0001) %MON vort_r_max                   =   2.3337380298912E-07
 (PID.TID 0000.0001) %MON vort_a_mean                  =  -2.5274807100877E-05
 (PID.TID 0000.0001) %MON vort_a_sd                    =   7.3604185547227E-05
 (PID.TID 0000.0001) %MON vort_p_mean                  =  -3.1845655425795E-05
 (PID.TID 0000.0001) %MON vort_p_sd                    =   1.3162490696471E-04
-(PID.TID 0000.0001) %MON surfExpan_theta_mean         =   2.7925287680813E-06
-(PID.TID 0000.0001) %MON surfExpan_salt_mean          =  -6.8576137008217E-08
+(PID.TID 0000.0001) %MON surfExpan_theta_mean         =   2.7925287680814E-06
+(PID.TID 0000.0001) %MON surfExpan_salt_mean          =  -6.8576137008220E-08
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // End MONITOR dynamic field statistics
 (PID.TID 0000.0001) // =======================================================
  EXTERNAL_FIELDS_LOAD,         4 : iP,iLd,i0,i1=   12    1   12    1 ; Wght=  0.3666666667  0.6333333333
- cg2d: Sum(rhs),rhsMax =   8.88178419700125E-16  2.00710277647426E+00
-(PID.TID 0000.0001)      cg2d_init_res =   5.47404787714530E-01
+ cg2d: Sum(rhs),rhsMax =   3.33066907387547E-15  2.00710277647478E+00
+(PID.TID 0000.0001)      cg2d_init_res =   5.47404787712920E-01
 (PID.TID 0000.0001)      cg2d_iters(min,last) =      -1     138
-(PID.TID 0000.0001)      cg2d_last_res =   8.10566139424672E-14
+(PID.TID 0000.0001)      cg2d_last_res =   8.10566143451495E-14
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // Begin MONITOR dynamic field statistics
 (PID.TID 0000.0001) // =======================================================
@@ -2598,22 +2603,22 @@ Global & Regional Statistics diagnostics: Number of lists:     0
 (PID.TID 0000.0001) %MON time_secondsf                =   4.3200000000000E+05
 (PID.TID 0000.0001) %MON dynstat_eta_max              =   8.9318832213169E-01
 (PID.TID 0000.0001) %MON dynstat_eta_min              =  -1.5354918886373E+00
-(PID.TID 0000.0001) %MON dynstat_eta_mean             =   2.3546533036412E-17
-(PID.TID 0000.0001) %MON dynstat_eta_sd               =   5.5353992099199E-01
+(PID.TID 0000.0001) %MON dynstat_eta_mean             =  -1.4490174176254E-17
+(PID.TID 0000.0001) %MON dynstat_eta_sd               =   5.5353992099200E-01
 (PID.TID 0000.0001) %MON dynstat_eta_del2             =   2.2733415058030E-03
 (PID.TID 0000.0001) %MON dynstat_uvel_max             =   9.1327031738056E-02
 (PID.TID 0000.0001) %MON dynstat_uvel_min             =  -7.0593584045282E-02
-(PID.TID 0000.0001) %MON dynstat_uvel_mean            =  -6.8214121075808E-04
+(PID.TID 0000.0001) %MON dynstat_uvel_mean            =  -6.8214121075809E-04
 (PID.TID 0000.0001) %MON dynstat_uvel_sd              =   5.9208004148076E-03
 (PID.TID 0000.0001) %MON dynstat_uvel_del2            =   6.6708434328704E-05
-(PID.TID 0000.0001) %MON dynstat_vvel_max             =   7.3811610600137E-02
+(PID.TID 0000.0001) %MON dynstat_vvel_max             =   7.3811610600136E-02
 (PID.TID 0000.0001) %MON dynstat_vvel_min             =  -9.2527893310200E-02
 (PID.TID 0000.0001) %MON dynstat_vvel_mean            =   2.5258284413086E-04
 (PID.TID 0000.0001) %MON dynstat_vvel_sd              =   8.4778585143132E-03
 (PID.TID 0000.0001) %MON dynstat_vvel_del2            =   8.9344005527621E-05
-(PID.TID 0000.0001) %MON dynstat_wvel_max             =   2.0694599602313E-04
-(PID.TID 0000.0001) %MON dynstat_wvel_min             =  -1.6979419174723E-04
-(PID.TID 0000.0001) %MON dynstat_wvel_mean            =   4.4626077161695E-22
+(PID.TID 0000.0001) %MON dynstat_wvel_max             =   2.0694599602314E-04
+(PID.TID 0000.0001) %MON dynstat_wvel_min             =  -1.6979419174724E-04
+(PID.TID 0000.0001) %MON dynstat_wvel_mean            =   6.8113486194166E-22
 (PID.TID 0000.0001) %MON dynstat_wvel_sd              =   2.2630209365745E-05
 (PID.TID 0000.0001) %MON dynstat_wvel_del2            =   3.0738094053107E-07
 (PID.TID 0000.0001) %MON dynstat_theta_max            =   2.9694421440997E+01
@@ -2654,12 +2659,12 @@ Global & Regional Statistics diagnostics: Number of lists:     0
 (PID.TID 0000.0001) %MON trAdv_CFL_u_max              =   2.2792835961357E-02
 (PID.TID 0000.0001) %MON trAdv_CFL_v_max              =   1.4795442924087E-02
 (PID.TID 0000.0001) %MON trAdv_CFL_w_max              =   5.2221472221523E-02
-(PID.TID 0000.0001) %MON advcfl_uvel_max              =   2.9067287093476E-02
+(PID.TID 0000.0001) %MON advcfl_uvel_max              =   2.9067287093475E-02
 (PID.TID 0000.0001) %MON advcfl_vvel_max              =   1.7976685701175E-02
 (PID.TID 0000.0001) %MON advcfl_wvel_max              =   6.7723195142611E-02
 (PID.TID 0000.0001) %MON advcfl_W_hf_max              =   7.6634141871902E-02
 (PID.TID 0000.0001) %MON pe_b_mean                    =   3.9208397730278E-04
-(PID.TID 0000.0001) %MON ke_max                       =   5.4355898279751E-03
+(PID.TID 0000.0001) %MON ke_max                       =   5.4355898279750E-03
 (PID.TID 0000.0001) %MON ke_mean                      =   4.8433885618416E-05
 (PID.TID 0000.0001) %MON ke_vol                       =   1.3226782436723E+18
 (PID.TID 0000.0001) %MON vort_r_min                   =  -2.7232030760910E-07
@@ -2674,10 +2679,10 @@ Global & Regional Statistics diagnostics: Number of lists:     0
 (PID.TID 0000.0001) // End MONITOR dynamic field statistics
 (PID.TID 0000.0001) // =======================================================
  EXTERNAL_FIELDS_LOAD,         5 : iP,iLd,i0,i1=   12    1   12    1 ; Wght=  0.3333333333  0.6666666667
- cg2d: Sum(rhs),rhsMax =   3.99680288865056E-15  1.78680552006858E+00
-(PID.TID 0000.0001)      cg2d_init_res =   6.50454581356324E-01
+ cg2d: Sum(rhs),rhsMax =   7.32747196252603E-15  1.78680552006839E+00
+(PID.TID 0000.0001)      cg2d_init_res =   6.50454581357221E-01
 (PID.TID 0000.0001)      cg2d_iters(min,last) =      -1     137
-(PID.TID 0000.0001)      cg2d_last_res =   7.34232871021525E-14
+(PID.TID 0000.0001)      cg2d_last_res =   7.34232874543373E-14
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // Begin MONITOR dynamic field statistics
 (PID.TID 0000.0001) // =======================================================
@@ -2685,22 +2690,22 @@ Global & Regional Statistics diagnostics: Number of lists:     0
 (PID.TID 0000.0001) %MON time_secondsf                =   5.1840000000000E+05
 (PID.TID 0000.0001) %MON dynstat_eta_max              =   1.0340296944667E+00
 (PID.TID 0000.0001) %MON dynstat_eta_min              =  -1.4866066951526E+00
-(PID.TID 0000.0001) %MON dynstat_eta_mean             =  -4.3470522528761E-17
+(PID.TID 0000.0001) %MON dynstat_eta_mean             =   3.6225435440634E-18
 (PID.TID 0000.0001) %MON dynstat_eta_sd               =   5.4313265113323E-01
-(PID.TID 0000.0001) %MON dynstat_eta_del2             =   2.1767472316093E-03
-(PID.TID 0000.0001) %MON dynstat_uvel_max             =   1.1143776334199E-01
-(PID.TID 0000.0001) %MON dynstat_uvel_min             =  -7.8779911776336E-02
-(PID.TID 0000.0001) %MON dynstat_uvel_mean            =  -4.7673396876869E-04
+(PID.TID 0000.0001) %MON dynstat_eta_del2             =   2.1767472316094E-03
+(PID.TID 0000.0001) %MON dynstat_uvel_max             =   1.1143776334200E-01
+(PID.TID 0000.0001) %MON dynstat_uvel_min             =  -7.8779911776337E-02
+(PID.TID 0000.0001) %MON dynstat_uvel_mean            =  -4.7673396876870E-04
 (PID.TID 0000.0001) %MON dynstat_uvel_sd              =   7.2402416895755E-03
 (PID.TID 0000.0001) %MON dynstat_uvel_del2            =   7.3235216722874E-05
 (PID.TID 0000.0001) %MON dynstat_vvel_max             =   8.2650876982429E-02
 (PID.TID 0000.0001) %MON dynstat_vvel_min             =  -1.0373565958817E-01
-(PID.TID 0000.0001) %MON dynstat_vvel_mean            =  -1.7265664307435E-05
+(PID.TID 0000.0001) %MON dynstat_vvel_mean            =  -1.7265664307431E-05
 (PID.TID 0000.0001) %MON dynstat_vvel_sd              =   9.3981949268613E-03
 (PID.TID 0000.0001) %MON dynstat_vvel_del2            =   9.8219587600152E-05
 (PID.TID 0000.0001) %MON dynstat_wvel_max             =   2.2176866590819E-04
-(PID.TID 0000.0001) %MON dynstat_wvel_min             =  -1.7602987816720E-04
-(PID.TID 0000.0001) %MON dynstat_wvel_mean            =  -1.7028371548541E-22
+(PID.TID 0000.0001) %MON dynstat_wvel_min             =  -1.7602987816729E-04
+(PID.TID 0000.0001) %MON dynstat_wvel_mean            =  -2.2900223806659E-22
 (PID.TID 0000.0001) %MON dynstat_wvel_sd              =   2.4371389486026E-05
 (PID.TID 0000.0001) %MON dynstat_wvel_del2            =   3.2254142180994E-07
 (PID.TID 0000.0001) %MON dynstat_theta_max            =   2.9696076055798E+01
@@ -2741,16 +2746,16 @@ Global & Regional Statistics diagnostics: Number of lists:     0
 (PID.TID 0000.0001) %MON trAdv_CFL_u_max              =   2.9073190867377E-02
 (PID.TID 0000.0001) %MON trAdv_CFL_v_max              =   1.7404375982142E-02
 (PID.TID 0000.0001) %MON trAdv_CFL_w_max              =   6.0668695648589E-02
-(PID.TID 0000.0001) %MON advcfl_uvel_max              =   3.4975168908124E-02
+(PID.TID 0000.0001) %MON advcfl_uvel_max              =   3.4975168908123E-02
 (PID.TID 0000.0001) %MON advcfl_vvel_max              =   2.0154174938024E-02
 (PID.TID 0000.0001) %MON advcfl_wvel_max              =   7.4594399837739E-02
-(PID.TID 0000.0001) %MON advcfl_W_hf_max              =   8.4409452447967E-02
+(PID.TID 0000.0001) %MON advcfl_W_hf_max              =   8.4409452447968E-02
 (PID.TID 0000.0001) %MON pe_b_mean                    =   3.7747919802284E-04
-(PID.TID 0000.0001) %MON ke_max                       =   7.3916505752033E-03
+(PID.TID 0000.0001) %MON ke_max                       =   7.3916505752032E-03
 (PID.TID 0000.0001) %MON ke_mean                      =   6.3572531499737E-05
 (PID.TID 0000.0001) %MON ke_vol                       =   1.3226782436723E+18
-(PID.TID 0000.0001) %MON vort_r_min                   =  -2.7022624762739E-07
-(PID.TID 0000.0001) %MON vort_r_max                   =   2.2605243908129E-07
+(PID.TID 0000.0001) %MON vort_r_min                   =  -2.7022624762737E-07
+(PID.TID 0000.0001) %MON vort_r_max                   =   2.2605243908132E-07
 (PID.TID 0000.0001) %MON vort_a_mean                  =  -2.5274806965077E-05
 (PID.TID 0000.0001) %MON vort_a_sd                    =   7.3604258317326E-05
 (PID.TID 0000.0001) %MON vort_p_mean                  =  -3.1845655254690E-05
@@ -2761,35 +2766,35 @@ Global & Regional Statistics diagnostics: Number of lists:     0
 (PID.TID 0000.0001) // End MONITOR dynamic field statistics
 (PID.TID 0000.0001) // =======================================================
  EXTERNAL_FIELDS_LOAD,         6 : iP,iLd,i0,i1=   12    1   12    1 ; Wght=  0.3000000000  0.7000000000
- cg2d: Sum(rhs),rhsMax =  -2.44249065417534E-15  1.56003720416177E+00
-(PID.TID 0000.0001)      cg2d_init_res =   7.58288548136118E-01
+ cg2d: Sum(rhs),rhsMax =   2.22044604925031E-15  1.56003720416141E+00
+(PID.TID 0000.0001)      cg2d_init_res =   7.58288548136571E-01
 (PID.TID 0000.0001)      cg2d_iters(min,last) =      -1     136
-(PID.TID 0000.0001)      cg2d_last_res =   8.51975069427158E-14
+(PID.TID 0000.0001)      cg2d_last_res =   8.51975068459881E-14
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // Begin MONITOR dynamic field statistics
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) %MON time_tsnumber                =                     7
 (PID.TID 0000.0001) %MON time_secondsf                =   6.0480000000000E+05
 (PID.TID 0000.0001) %MON dynstat_eta_max              =   1.0879093310116E+00
-(PID.TID 0000.0001) %MON dynstat_eta_min              =  -1.4506236508308E+00
-(PID.TID 0000.0001) %MON dynstat_eta_mean             =   4.3470522528761E-17
+(PID.TID 0000.0001) %MON dynstat_eta_min              =  -1.4506236508309E+00
+(PID.TID 0000.0001) %MON dynstat_eta_mean             =  -8.5129773285491E-17
 (PID.TID 0000.0001) %MON dynstat_eta_sd               =   5.3201161946605E-01
 (PID.TID 0000.0001) %MON dynstat_eta_del2             =   2.0870016115279E-03
 (PID.TID 0000.0001) %MON dynstat_uvel_max             =   1.3020024567320E-01
 (PID.TID 0000.0001) %MON dynstat_uvel_min             =  -8.4422688342361E-02
-(PID.TID 0000.0001) %MON dynstat_uvel_mean            =  -2.5576358436606E-04
+(PID.TID 0000.0001) %MON dynstat_uvel_mean            =  -2.5576358436605E-04
 (PID.TID 0000.0001) %MON dynstat_uvel_sd              =   8.5877996246748E-03
 (PID.TID 0000.0001) %MON dynstat_uvel_del2            =   7.7998179801469E-05
-(PID.TID 0000.0001) %MON dynstat_vvel_max             =   8.8729033416359E-02
+(PID.TID 0000.0001) %MON dynstat_vvel_max             =   8.8729033416358E-02
 (PID.TID 0000.0001) %MON dynstat_vvel_min             =  -1.1115928609226E-01
 (PID.TID 0000.0001) %MON dynstat_vvel_mean            =  -2.1073450501256E-04
 (PID.TID 0000.0001) %MON dynstat_vvel_sd              =   1.0026611635704E-02
 (PID.TID 0000.0001) %MON dynstat_vvel_del2            =   1.0382708892226E-04
 (PID.TID 0000.0001) %MON dynstat_wvel_max             =   2.3248313631423E-04
 (PID.TID 0000.0001) %MON dynstat_wvel_min             =  -1.8661649727598E-04
-(PID.TID 0000.0001) %MON dynstat_wvel_mean            =   6.6939115742542E-22
+(PID.TID 0000.0001) %MON dynstat_wvel_mean            =  -7.0462227097413E-23
 (PID.TID 0000.0001) %MON dynstat_wvel_sd              =   2.5167466579660E-05
-(PID.TID 0000.0001) %MON dynstat_wvel_del2            =   3.2316014324529E-07
+(PID.TID 0000.0001) %MON dynstat_wvel_del2            =   3.2316014324528E-07
 (PID.TID 0000.0001) %MON dynstat_theta_max            =   2.9698141159398E+01
 (PID.TID 0000.0001) %MON dynstat_theta_min            =  -1.9015149273148E+00
 (PID.TID 0000.0001) %MON dynstat_theta_mean           =   3.6190524513741E+00
@@ -2829,15 +2834,15 @@ Global & Regional Statistics diagnostics: Number of lists:     0
 (PID.TID 0000.0001) %MON trAdv_CFL_v_max              =   1.9512542192820E-02
 (PID.TID 0000.0001) %MON trAdv_CFL_w_max              =   6.6824149854641E-02
 (PID.TID 0000.0001) %MON advcfl_uvel_max              =   4.0236375028503E-02
-(PID.TID 0000.0001) %MON advcfl_vvel_max              =   2.1596466507114E-02
+(PID.TID 0000.0001) %MON advcfl_vvel_max              =   2.1596466507113E-02
 (PID.TID 0000.0001) %MON advcfl_wvel_max              =   7.8822758219016E-02
-(PID.TID 0000.0001) %MON advcfl_W_hf_max              =   8.9194173774150E-02
+(PID.TID 0000.0001) %MON advcfl_W_hf_max              =   8.9194173774149E-02
 (PID.TID 0000.0001) %MON pe_b_mean                    =   3.6217914194850E-04
-(PID.TID 0000.0001) %MON ke_max                       =   9.3936107570623E-03
+(PID.TID 0000.0001) %MON ke_max                       =   9.3936107570622E-03
 (PID.TID 0000.0001) %MON ke_mean                      =   7.8689179240154E-05
 (PID.TID 0000.0001) %MON ke_vol                       =   1.3226782436723E+18
-(PID.TID 0000.0001) %MON vort_r_min                   =  -2.9542290304635E-07
-(PID.TID 0000.0001) %MON vort_r_max                   =   2.4571648077553E-07
+(PID.TID 0000.0001) %MON vort_r_min                   =  -2.9542290304629E-07
+(PID.TID 0000.0001) %MON vort_r_max                   =   2.4571648077555E-07
 (PID.TID 0000.0001) %MON vort_a_mean                  =  -2.5274806970359E-05
 (PID.TID 0000.0001) %MON vort_a_sd                    =   7.3604299405672E-05
 (PID.TID 0000.0001) %MON vort_p_mean                  =  -3.1845655261345E-05
@@ -2848,40 +2853,40 @@ Global & Regional Statistics diagnostics: Number of lists:     0
 (PID.TID 0000.0001) // End MONITOR dynamic field statistics
 (PID.TID 0000.0001) // =======================================================
  EXTERNAL_FIELDS_LOAD,         7 : iP,iLd,i0,i1=   12    1   12    1 ; Wght=  0.2666666667  0.7333333333
- cg2d: Sum(rhs),rhsMax =  -1.99840144432528E-15  1.34056216067977E+00
-(PID.TID 0000.0001)      cg2d_init_res =   8.80397082298848E-01
+ cg2d: Sum(rhs),rhsMax =   7.32747196252603E-15  1.34056216067935E+00
+(PID.TID 0000.0001)      cg2d_init_res =   8.80397082299022E-01
 (PID.TID 0000.0001)      cg2d_iters(min,last) =      -1     137
-(PID.TID 0000.0001)      cg2d_last_res =   9.51326084593425E-14
+(PID.TID 0000.0001)      cg2d_last_res =   9.51326083378419E-14
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // Begin MONITOR dynamic field statistics
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) %MON time_tsnumber                =                     8
 (PID.TID 0000.0001) %MON time_secondsf                =   6.9120000000000E+05
 (PID.TID 0000.0001) %MON dynstat_eta_max              =   1.0581854481045E+00
-(PID.TID 0000.0001) %MON dynstat_eta_min              =  -1.4197671817530E+00
-(PID.TID 0000.0001) %MON dynstat_eta_mean             =   2.8980348352507E-17
+(PID.TID 0000.0001) %MON dynstat_eta_min              =  -1.4197671817531E+00
+(PID.TID 0000.0001) %MON dynstat_eta_mean             =   1.8112717720317E-17
 (PID.TID 0000.0001) %MON dynstat_eta_sd               =   5.2385880427478E-01
 (PID.TID 0000.0001) %MON dynstat_eta_del2             =   1.9936376003453E-03
 (PID.TID 0000.0001) %MON dynstat_uvel_max             =   1.4700230214573E-01
 (PID.TID 0000.0001) %MON dynstat_uvel_min             =  -8.7497140786364E-02
-(PID.TID 0000.0001) %MON dynstat_uvel_mean            =  -4.0690261438958E-05
+(PID.TID 0000.0001) %MON dynstat_uvel_mean            =  -4.0690261438954E-05
 (PID.TID 0000.0001) %MON dynstat_uvel_sd              =   9.9187926623713E-03
 (PID.TID 0000.0001) %MON dynstat_uvel_del2            =   8.1470329624996E-05
-(PID.TID 0000.0001) %MON dynstat_vvel_max             =   9.2070028050373E-02
+(PID.TID 0000.0001) %MON dynstat_vvel_max             =   9.2070028050372E-02
 (PID.TID 0000.0001) %MON dynstat_vvel_min             =  -1.1490415607267E-01
 (PID.TID 0000.0001) %MON dynstat_vvel_mean            =  -3.0987549578121E-04
 (PID.TID 0000.0001) %MON dynstat_vvel_sd              =   1.0373820118079E-02
 (PID.TID 0000.0001) %MON dynstat_vvel_del2            =   1.0636572014555E-04
 (PID.TID 0000.0001) %MON dynstat_wvel_max             =   2.3503735115136E-04
 (PID.TID 0000.0001) %MON dynstat_wvel_min             =  -1.9682954723460E-04
-(PID.TID 0000.0001) %MON dynstat_wvel_mean            =   4.6974818064942E-22
+(PID.TID 0000.0001) %MON dynstat_wvel_mean            =   3.2882372645459E-22
 (PID.TID 0000.0001) %MON dynstat_wvel_sd              =   2.5116894992670E-05
 (PID.TID 0000.0001) %MON dynstat_wvel_del2            =   3.1148782872227E-07
 (PID.TID 0000.0001) %MON dynstat_theta_max            =   2.9699838752251E+01
 (PID.TID 0000.0001) %MON dynstat_theta_min            =  -1.9024300666438E+00
 (PID.TID 0000.0001) %MON dynstat_theta_mean           =   3.6191461569904E+00
 (PID.TID 0000.0001) %MON dynstat_theta_sd             =   4.4136632644154E+00
-(PID.TID 0000.0001) %MON dynstat_theta_del2           =   5.3686809696808E-03
+(PID.TID 0000.0001) %MON dynstat_theta_del2           =   5.3686809696809E-03
 (PID.TID 0000.0001) %MON dynstat_salt_max             =   3.7428500444121E+01
 (PID.TID 0000.0001) %MON dynstat_salt_min             =   2.9733531427286E+01
 (PID.TID 0000.0001) %MON dynstat_salt_mean            =   3.4717955237706E+01
@@ -2912,46 +2917,46 @@ Global & Regional Statistics diagnostics: Number of lists:     0
 (PID.TID 0000.0001) %MON forcing_fv_mean              =  -5.8489979543915E-03
 (PID.TID 0000.0001) %MON forcing_fv_sd                =   4.6198708258185E-02
 (PID.TID 0000.0001) %MON forcing_fv_del2              =   4.5690396795039E-04
-(PID.TID 0000.0001) %MON trAdv_CFL_u_max              =   4.0244547324047E-02
+(PID.TID 0000.0001) %MON trAdv_CFL_u_max              =   4.0244547324046E-02
 (PID.TID 0000.0001) %MON trAdv_CFL_v_max              =   2.0908916650358E-02
 (PID.TID 0000.0001) %MON trAdv_CFL_w_max              =   7.0612054237868E-02
-(PID.TID 0000.0001) %MON advcfl_uvel_max              =   4.4612470708747E-02
+(PID.TID 0000.0001) %MON advcfl_uvel_max              =   4.4612470708746E-02
 (PID.TID 0000.0001) %MON advcfl_vvel_max              =   2.2324034683813E-02
 (PID.TID 0000.0001) %MON advcfl_wvel_max              =   8.0460535225851E-02
 (PID.TID 0000.0001) %MON advcfl_W_hf_max              =   9.1047447755568E-02
-(PID.TID 0000.0001) %MON pe_b_mean                    =   3.5116376349068E-04
+(PID.TID 0000.0001) %MON pe_b_mean                    =   3.5116376349069E-04
 (PID.TID 0000.0001) %MON ke_max                       =   1.1348702713848E-02
 (PID.TID 0000.0001) %MON ke_mean                      =   9.3054100867484E-05
 (PID.TID 0000.0001) %MON ke_vol                       =   1.3226782436723E+18
-(PID.TID 0000.0001) %MON vort_r_min                   =  -2.9610806940269E-07
-(PID.TID 0000.0001) %MON vort_r_max                   =   2.5844822803828E-07
+(PID.TID 0000.0001) %MON vort_r_min                   =  -2.9610806940263E-07
+(PID.TID 0000.0001) %MON vort_r_max                   =   2.5844822803832E-07
 (PID.TID 0000.0001) %MON vort_a_mean                  =  -2.5274807024393E-05
 (PID.TID 0000.0001) %MON vort_a_sd                    =   7.3604336601413E-05
 (PID.TID 0000.0001) %MON vort_p_mean                  =  -3.1845655329427E-05
 (PID.TID 0000.0001) %MON vort_p_sd                    =   1.3162439088731E-04
-(PID.TID 0000.0001) %MON surfExpan_theta_mean         =  -7.2765666614415E-07
-(PID.TID 0000.0001) %MON surfExpan_salt_mean          =  -1.4972668361343E-07
+(PID.TID 0000.0001) %MON surfExpan_theta_mean         =  -7.2765666614406E-07
+(PID.TID 0000.0001) %MON surfExpan_salt_mean          =  -1.4972668361342E-07
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // End MONITOR dynamic field statistics
 (PID.TID 0000.0001) // =======================================================
  EXTERNAL_FIELDS_LOAD,         8 : iP,iLd,i0,i1=   12    1   12    1 ; Wght=  0.2333333333  0.7666666667
- cg2d: Sum(rhs),rhsMax =  -4.21884749357559E-15  1.17833084095994E+00
-(PID.TID 0000.0001)      cg2d_init_res =   9.71286758147062E-01
+ cg2d: Sum(rhs),rhsMax =  -6.21724893790088E-15  1.17833084095994E+00
+(PID.TID 0000.0001)      cg2d_init_res =   9.71286758146264E-01
 (PID.TID 0000.0001)      cg2d_iters(min,last) =      -1     137
-(PID.TID 0000.0001)      cg2d_last_res =   8.61244862298037E-14
+(PID.TID 0000.0001)      cg2d_last_res =   8.61244862009459E-14
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // Begin MONITOR dynamic field statistics
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) %MON time_tsnumber                =                     9
 (PID.TID 0000.0001) %MON time_secondsf                =   7.7760000000000E+05
-(PID.TID 0000.0001) %MON dynstat_eta_max              =   9.7064771144247E-01
-(PID.TID 0000.0001) %MON dynstat_eta_min              =  -1.3904640651518E+00
-(PID.TID 0000.0001) %MON dynstat_eta_mean             =  -7.2450870881269E-17
+(PID.TID 0000.0001) %MON dynstat_eta_max              =   9.7064771144246E-01
+(PID.TID 0000.0001) %MON dynstat_eta_min              =  -1.3904640651519E+00
+(PID.TID 0000.0001) %MON dynstat_eta_mean             =   2.8980348352507E-17
 (PID.TID 0000.0001) %MON dynstat_eta_sd               =   5.2049155715277E-01
 (PID.TID 0000.0001) %MON dynstat_eta_del2             =   1.9154089808730E-03
 (PID.TID 0000.0001) %MON dynstat_uvel_max             =   1.6129970952847E-01
 (PID.TID 0000.0001) %MON dynstat_uvel_min             =  -8.8033948479943E-02
-(PID.TID 0000.0001) %MON dynstat_uvel_mean            =   1.5155664205258E-04
+(PID.TID 0000.0001) %MON dynstat_uvel_mean            =   1.5155664205260E-04
 (PID.TID 0000.0001) %MON dynstat_uvel_sd              =   1.1191154574655E-02
 (PID.TID 0000.0001) %MON dynstat_uvel_del2            =   8.4123434239666E-05
 (PID.TID 0000.0001) %MON dynstat_vvel_max             =   9.4601873400301E-02
@@ -2960,10 +2965,10 @@ Global & Regional Statistics diagnostics: Number of lists:     0
 (PID.TID 0000.0001) %MON dynstat_vvel_sd              =   1.0466806678177E-02
 (PID.TID 0000.0001) %MON dynstat_vvel_del2            =   1.0626811947299E-04
 (PID.TID 0000.0001) %MON dynstat_wvel_max             =   2.2998948894992E-04
-(PID.TID 0000.0001) %MON dynstat_wvel_min             =  -2.0125965910239E-04
-(PID.TID 0000.0001) %MON dynstat_wvel_mean            =   5.9892893032801E-22
+(PID.TID 0000.0001) %MON dynstat_wvel_min             =  -2.0125965910240E-04
+(PID.TID 0000.0001) %MON dynstat_wvel_mean            =   3.5231113548707E-23
 (PID.TID 0000.0001) %MON dynstat_wvel_sd              =   2.4378791994161E-05
-(PID.TID 0000.0001) %MON dynstat_wvel_del2            =   2.9067840701293E-07
+(PID.TID 0000.0001) %MON dynstat_wvel_del2            =   2.9067840701294E-07
 (PID.TID 0000.0001) %MON dynstat_theta_max            =   2.9701554244060E+01
 (PID.TID 0000.0001) %MON dynstat_theta_min            =  -1.9029608145822E+00
 (PID.TID 0000.0001) %MON dynstat_theta_mean           =   3.6192148987312E+00
@@ -2999,8 +3004,8 @@ Global & Regional Statistics diagnostics: Number of lists:     0
 (PID.TID 0000.0001) %MON forcing_fv_mean              =  -5.7752354275308E-03
 (PID.TID 0000.0001) %MON forcing_fv_sd                =   4.6406538642117E-02
 (PID.TID 0000.0001) %MON forcing_fv_del2              =   4.6058148956476E-04
-(PID.TID 0000.0001) %MON trAdv_CFL_u_max              =   4.4621531820621E-02
-(PID.TID 0000.0001) %MON trAdv_CFL_v_max              =   2.1613321806592E-02
+(PID.TID 0000.0001) %MON trAdv_CFL_u_max              =   4.4621531820620E-02
+(PID.TID 0000.0001) %MON trAdv_CFL_v_max              =   2.1613321806593E-02
 (PID.TID 0000.0001) %MON trAdv_CFL_w_max              =   7.2079229473158E-02
 (PID.TID 0000.0001) %MON advcfl_uvel_max              =   4.7929853904510E-02
 (PID.TID 0000.0001) %MON advcfl_vvel_max              =   2.2799128499320E-02
@@ -3010,45 +3015,45 @@ Global & Regional Statistics diagnostics: Number of lists:     0
 (PID.TID 0000.0001) %MON ke_max                       =   1.3175818283629E-02
 (PID.TID 0000.0001) %MON ke_mean                      =   1.0614040543521E-04
 (PID.TID 0000.0001) %MON ke_vol                       =   1.3226782436723E+18
-(PID.TID 0000.0001) %MON vort_r_min                   =  -3.3655851631684E-07
-(PID.TID 0000.0001) %MON vort_r_max                   =   2.8033634234907E-07
+(PID.TID 0000.0001) %MON vort_r_min                   =  -3.3655851631678E-07
+(PID.TID 0000.0001) %MON vort_r_max                   =   2.8033634234906E-07
 (PID.TID 0000.0001) %MON vort_a_mean                  =  -2.5274807106651E-05
 (PID.TID 0000.0001) %MON vort_a_sd                    =   7.3604366514115E-05
 (PID.TID 0000.0001) %MON vort_p_mean                  =  -3.1845655433070E-05
 (PID.TID 0000.0001) %MON vort_p_sd                    =   1.3162421249315E-04
-(PID.TID 0000.0001) %MON surfExpan_theta_mean         =  -5.8598858911858E-08
+(PID.TID 0000.0001) %MON surfExpan_theta_mean         =  -5.8598858911886E-08
 (PID.TID 0000.0001) %MON surfExpan_salt_mean          =  -1.0659779098084E-07
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // End MONITOR dynamic field statistics
 (PID.TID 0000.0001) // =======================================================
  EXTERNAL_FIELDS_LOAD,         9 : iP,iLd,i0,i1=   12    1   12    1 ; Wght=  0.2000000000  0.8000000000
- cg2d: Sum(rhs),rhsMax =   2.66453525910038E-15  1.11384181227030E+00
-(PID.TID 0000.0001)      cg2d_init_res =   9.66721968065734E-01
+ cg2d: Sum(rhs),rhsMax =   8.88178419700125E-15  1.11384181227068E+00
+(PID.TID 0000.0001)      cg2d_init_res =   9.66721968064628E-01
 (PID.TID 0000.0001)      cg2d_iters(min,last) =      -1     137
-(PID.TID 0000.0001)      cg2d_last_res =   7.75242973194116E-14
+(PID.TID 0000.0001)      cg2d_last_res =   7.75242972999645E-14
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // Begin MONITOR dynamic field statistics
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) %MON time_tsnumber                =                    10
 (PID.TID 0000.0001) %MON time_secondsf                =   8.6400000000000E+05
-(PID.TID 0000.0001) %MON dynstat_eta_max              =   8.5734360593366E-01
-(PID.TID 0000.0001) %MON dynstat_eta_min              =  -1.3657496383836E+00
-(PID.TID 0000.0001) %MON dynstat_eta_mean             =  -1.6301445948285E-17
+(PID.TID 0000.0001) %MON dynstat_eta_max              =   8.5734360593365E-01
+(PID.TID 0000.0001) %MON dynstat_eta_min              =  -1.3657496383835E+00
+(PID.TID 0000.0001) %MON dynstat_eta_mean             =  -5.4338153160951E-18
 (PID.TID 0000.0001) %MON dynstat_eta_sd               =   5.2217644926756E-01
 (PID.TID 0000.0001) %MON dynstat_eta_del2             =   1.8462579955141E-03
 (PID.TID 0000.0001) %MON dynstat_uvel_max             =   1.7267114277613E-01
 (PID.TID 0000.0001) %MON dynstat_uvel_min             =  -8.9847105264351E-02
-(PID.TID 0000.0001) %MON dynstat_uvel_mean            =   3.1129298811222E-04
+(PID.TID 0000.0001) %MON dynstat_uvel_mean            =   3.1129298811225E-04
 (PID.TID 0000.0001) %MON dynstat_uvel_sd              =   1.2364105290348E-02
 (PID.TID 0000.0001) %MON dynstat_uvel_del2            =   8.6330303150791E-05
-(PID.TID 0000.0001) %MON dynstat_vvel_max             =   9.7825518692643E-02
+(PID.TID 0000.0001) %MON dynstat_vvel_max             =   9.7825518692645E-02
 (PID.TID 0000.0001) %MON dynstat_vvel_min             =  -1.1635073451098E-01
 (PID.TID 0000.0001) %MON dynstat_vvel_mean            =  -2.7662934635690E-04
 (PID.TID 0000.0001) %MON dynstat_vvel_sd              =   1.0348133529497E-02
 (PID.TID 0000.0001) %MON dynstat_vvel_del2            =   1.0410848220091E-04
-(PID.TID 0000.0001) %MON dynstat_wvel_max             =   2.1820189243762E-04
+(PID.TID 0000.0001) %MON dynstat_wvel_max             =   2.1820189243764E-04
 (PID.TID 0000.0001) %MON dynstat_wvel_min             =  -1.9981555021753E-04
-(PID.TID 0000.0001) %MON dynstat_wvel_mean            =  -6.9287856645789E-22
+(PID.TID 0000.0001) %MON dynstat_wvel_mean            =  -3.6405484000330E-22
 (PID.TID 0000.0001) %MON dynstat_wvel_sd              =   2.3158654321943E-05
 (PID.TID 0000.0001) %MON dynstat_wvel_del2            =   2.6460495996792E-07
 (PID.TID 0000.0001) %MON dynstat_theta_max            =   2.9703702772276E+01
@@ -3091,166 +3096,166 @@ Global & Regional Statistics diagnostics: Number of lists:     0
 (PID.TID 0000.0001) %MON trAdv_CFL_w_max              =   7.1361228147918E-02
 (PID.TID 0000.0001) %MON advcfl_uvel_max              =   5.0092736195391E-02
 (PID.TID 0000.0001) %MON advcfl_vvel_max              =   2.2605081674049E-02
-(PID.TID 0000.0001) %MON advcfl_wvel_max              =   7.6673429746030E-02
-(PID.TID 0000.0001) %MON advcfl_W_hf_max              =   8.6762038923140E-02
+(PID.TID 0000.0001) %MON advcfl_wvel_max              =   7.6673429746036E-02
+(PID.TID 0000.0001) %MON advcfl_W_hf_max              =   8.6762038923146E-02
 (PID.TID 0000.0001) %MON pe_b_mean                    =   3.4891188389046E-04
 (PID.TID 0000.0001) %MON ke_max                       =   1.4810165546234E-02
 (PID.TID 0000.0001) %MON ke_mean                      =   1.1760467614129E-04
 (PID.TID 0000.0001) %MON ke_vol                       =   1.3226782436723E+18
-(PID.TID 0000.0001) %MON vort_r_min                   =  -3.7037649866954E-07
+(PID.TID 0000.0001) %MON vort_r_min                   =  -3.7037649866947E-07
 (PID.TID 0000.0001) %MON vort_r_max                   =   2.9782510030804E-07
 (PID.TID 0000.0001) %MON vort_a_mean                  =  -2.5274807184605E-05
 (PID.TID 0000.0001) %MON vort_a_sd                    =   7.3604387928554E-05
 (PID.TID 0000.0001) %MON vort_p_mean                  =  -3.1845655531290E-05
 (PID.TID 0000.0001) %MON vort_p_sd                    =   1.3162402674002E-04
-(PID.TID 0000.0001) %MON surfExpan_theta_mean         =   2.7971796785110E-07
-(PID.TID 0000.0001) %MON surfExpan_salt_mean          =  -8.6201909178322E-08
+(PID.TID 0000.0001) %MON surfExpan_theta_mean         =   2.7971796785106E-07
+(PID.TID 0000.0001) %MON surfExpan_salt_mean          =  -8.6201909178329E-08
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // End MONITOR dynamic field statistics
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) %CHECKPOINT        10 ckptA
 (PID.TID 0000.0001)   Seconds in section "ALL                    [THE_MODEL_MAIN]":
-(PID.TID 0000.0001)           User time:   13.884000197984278
-(PID.TID 0000.0001)         System time:  0.11999999778345227
-(PID.TID 0000.0001)     Wall clock time:   14.009112834930420
+(PID.TID 0000.0001)           User time:   11.392005207017064
+(PID.TID 0000.0001)         System time:  0.27557700686156750
+(PID.TID 0000.0001)     Wall clock time:   11.669352054595947
 (PID.TID 0000.0001)          No. starts:           1
 (PID.TID 0000.0001)           No. stops:           1
 (PID.TID 0000.0001)   Seconds in section "INITIALISE_FIXED       [THE_MODEL_MAIN]":
-(PID.TID 0000.0001)           User time:  0.15199999604374170
-(PID.TID 0000.0001)         System time:   3.5999998915940523E-002
-(PID.TID 0000.0001)     Wall clock time:  0.18617701530456543
+(PID.TID 0000.0001)           User time:  0.16049699671566486
+(PID.TID 0000.0001)         System time:   9.2055998742580414E-002
+(PID.TID 0000.0001)     Wall clock time:  0.25291895866394043
 (PID.TID 0000.0001)          No. starts:           1
 (PID.TID 0000.0001)           No. stops:           1
 (PID.TID 0000.0001)   Seconds in section "THE_MAIN_LOOP          [THE_MODEL_MAIN]":
-(PID.TID 0000.0001)           User time:   13.732000201940536
-(PID.TID 0000.0001)         System time:   8.3999998867511749E-002
-(PID.TID 0000.0001)     Wall clock time:   13.822904109954834
+(PID.TID 0000.0001)           User time:   11.231453537940979
+(PID.TID 0000.0001)         System time:  0.18346500396728516
+(PID.TID 0000.0001)     Wall clock time:   11.416343927383423
 (PID.TID 0000.0001)          No. starts:           1
 (PID.TID 0000.0001)           No. stops:           1
 (PID.TID 0000.0001)   Seconds in section "INITIALISE_VARIA    [THE_MAIN_LOOP]":
-(PID.TID 0000.0001)           User time:  0.56000003218650818
-(PID.TID 0000.0001)         System time:   3.9999999105930328E-002
-(PID.TID 0000.0001)     Wall clock time:  0.60124707221984863
+(PID.TID 0000.0001)           User time:  0.52097900211811066
+(PID.TID 0000.0001)         System time:  0.14011500775814056
+(PID.TID 0000.0001)     Wall clock time:  0.66118979454040527
 (PID.TID 0000.0001)          No. starts:           1
 (PID.TID 0000.0001)           No. stops:           1
 (PID.TID 0000.0001)   Seconds in section "MAIN LOOP           [THE_MAIN_LOOP]":
-(PID.TID 0000.0001)           User time:   13.172000169754028
-(PID.TID 0000.0001)         System time:   4.3999999761581421E-002
-(PID.TID 0000.0001)     Wall clock time:   13.221632003784180
+(PID.TID 0000.0001)           User time:   10.710452854633331
+(PID.TID 0000.0001)         System time:   4.3344005942344666E-002
+(PID.TID 0000.0001)     Wall clock time:   10.755128145217896
 (PID.TID 0000.0001)          No. starts:           1
 (PID.TID 0000.0001)           No. stops:           1
 (PID.TID 0000.0001)   Seconds in section "MAIN_DO_LOOP        [THE_MAIN_LOOP]":
-(PID.TID 0000.0001)           User time:   13.172000169754028
-(PID.TID 0000.0001)         System time:   4.3999999761581421E-002
-(PID.TID 0000.0001)     Wall clock time:   13.221548080444336
+(PID.TID 0000.0001)           User time:   10.710335850715637
+(PID.TID 0000.0001)         System time:   4.3344005942344666E-002
+(PID.TID 0000.0001)     Wall clock time:   10.755000114440918
 (PID.TID 0000.0001)          No. starts:          10
 (PID.TID 0000.0001)           No. stops:          10
 (PID.TID 0000.0001)   Seconds in section "FORWARD_STEP        [MAIN_DO_LOOP]":
-(PID.TID 0000.0001)           User time:   13.172000169754028
-(PID.TID 0000.0001)         System time:   4.3999999761581421E-002
-(PID.TID 0000.0001)     Wall clock time:   13.221394062042236
+(PID.TID 0000.0001)           User time:   10.710184752941132
+(PID.TID 0000.0001)         System time:   4.3344005942344666E-002
+(PID.TID 0000.0001)     Wall clock time:   10.754849195480347
 (PID.TID 0000.0001)          No. starts:          10
 (PID.TID 0000.0001)           No. stops:          10
 (PID.TID 0000.0001)   Seconds in section "DO_STATEVARS_DIAGS  [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:   4.7999143600463867E-002
-(PID.TID 0000.0001)         System time:   0.0000000000000000
-(PID.TID 0000.0001)     Wall clock time:   5.1319122314453125E-002
+(PID.TID 0000.0001)           User time:   4.2498409748077393E-002
+(PID.TID 0000.0001)         System time:   1.0102987289428711E-004
+(PID.TID 0000.0001)     Wall clock time:   4.2619466781616211E-002
 (PID.TID 0000.0001)          No. starts:          20
 (PID.TID 0000.0001)           No. stops:          20
 (PID.TID 0000.0001)   Seconds in section "LOAD_FIELDS_DRIVER  [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:   2.0000159740447998E-002
-(PID.TID 0000.0001)         System time:   0.0000000000000000
-(PID.TID 0000.0001)     Wall clock time:   1.9276857376098633E-002
+(PID.TID 0000.0001)           User time:   1.5894293785095215E-002
+(PID.TID 0000.0001)         System time:   1.0132789611816406E-006
+(PID.TID 0000.0001)     Wall clock time:   1.5898466110229492E-002
 (PID.TID 0000.0001)          No. starts:          10
 (PID.TID 0000.0001)           No. stops:          10
 (PID.TID 0000.0001)   Seconds in section "EXTERNAL_FLDS_LOAD [LOAD_FLDS_DRIVER]":
-(PID.TID 0000.0001)           User time:   2.0000159740447998E-002
+(PID.TID 0000.0001)           User time:   1.5737533569335938E-002
 (PID.TID 0000.0001)         System time:   0.0000000000000000
-(PID.TID 0000.0001)     Wall clock time:   1.9101619720458984E-002
+(PID.TID 0000.0001)     Wall clock time:   1.5744924545288086E-002
 (PID.TID 0000.0001)          No. starts:          10
 (PID.TID 0000.0001)           No. stops:          10
 (PID.TID 0000.0001)   Seconds in section "DO_ATMOSPHERIC_PHYS [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:   0.0000000000000000
+(PID.TID 0000.0001)           User time:   8.1360340118408203E-005
 (PID.TID 0000.0001)         System time:   0.0000000000000000
-(PID.TID 0000.0001)     Wall clock time:   7.8916549682617188E-005
+(PID.TID 0000.0001)     Wall clock time:   9.5129013061523438E-005
 (PID.TID 0000.0001)          No. starts:          10
 (PID.TID 0000.0001)           No. stops:          10
 (PID.TID 0000.0001)   Seconds in section "DO_OCEANIC_PHYS     [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:   3.6799994111061096
-(PID.TID 0000.0001)         System time:   8.0000013113021851E-003
-(PID.TID 0000.0001)     Wall clock time:   3.6890394687652588
+(PID.TID 0000.0001)           User time:   2.9710686206817627
+(PID.TID 0000.0001)         System time:   2.1994113922119141E-005
+(PID.TID 0000.0001)     Wall clock time:   2.9716820716857910
 (PID.TID 0000.0001)          No. starts:          10
 (PID.TID 0000.0001)           No. stops:          10
 (PID.TID 0000.0001)   Seconds in section "GGL90_CALC [DO_OCEANIC_PHYS]":
-(PID.TID 0000.0001)           User time:   2.2839907407760620
-(PID.TID 0000.0001)         System time:   4.0000006556510925E-003
-(PID.TID 0000.0001)     Wall clock time:   2.3039805889129639
+(PID.TID 0000.0001)           User time:   1.7517680525779724
+(PID.TID 0000.0001)         System time:   0.0000000000000000
+(PID.TID 0000.0001)     Wall clock time:   1.7523725032806396
 (PID.TID 0000.0001)          No. starts:         360
 (PID.TID 0000.0001)           No. stops:         360
 (PID.TID 0000.0001)   Seconds in section "THERMODYNAMICS      [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:   2.6440006494522095
+(PID.TID 0000.0001)           User time:   2.1588053703308105
 (PID.TID 0000.0001)         System time:   0.0000000000000000
-(PID.TID 0000.0001)     Wall clock time:   2.6387650966644287
+(PID.TID 0000.0001)     Wall clock time:   2.1588912010192871
 (PID.TID 0000.0001)          No. starts:          10
 (PID.TID 0000.0001)           No. stops:          10
 (PID.TID 0000.0001)   Seconds in section "DYNAMICS            [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:   3.5199999809265137
+(PID.TID 0000.0001)           User time:   2.7970561981201172
 (PID.TID 0000.0001)         System time:   0.0000000000000000
-(PID.TID 0000.0001)     Wall clock time:   3.5230817794799805
+(PID.TID 0000.0001)     Wall clock time:   2.7976257801055908
 (PID.TID 0000.0001)          No. starts:          10
 (PID.TID 0000.0001)           No. stops:          10
 (PID.TID 0000.0001)   Seconds in section "UPDATE_SURF_DR      [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:   4.7999620437622070E-002
+(PID.TID 0000.0001)           User time:   4.0106415748596191E-002
 (PID.TID 0000.0001)         System time:   0.0000000000000000
-(PID.TID 0000.0001)     Wall clock time:   5.2687883377075195E-002
+(PID.TID 0000.0001)     Wall clock time:   4.0114402770996094E-002
 (PID.TID 0000.0001)          No. starts:          10
 (PID.TID 0000.0001)           No. stops:          10
 (PID.TID 0000.0001)   Seconds in section "SOLVE_FOR_PRESSURE  [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:   1.7400002479553223
+(PID.TID 0000.0001)           User time:   1.4944530725479126
 (PID.TID 0000.0001)         System time:   0.0000000000000000
-(PID.TID 0000.0001)     Wall clock time:   1.7377040386199951
+(PID.TID 0000.0001)     Wall clock time:   1.4945201873779297
 (PID.TID 0000.0001)          No. starts:          10
 (PID.TID 0000.0001)           No. stops:          10
 (PID.TID 0000.0001)   Seconds in section "MOM_CORRECTION_STEP [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:  0.11600005626678467
+(PID.TID 0000.0001)           User time:   9.2413067817687988E-002
 (PID.TID 0000.0001)         System time:   0.0000000000000000
-(PID.TID 0000.0001)     Wall clock time:  0.11722970008850098
+(PID.TID 0000.0001)     Wall clock time:   9.2437267303466797E-002
 (PID.TID 0000.0001)          No. starts:          10
 (PID.TID 0000.0001)           No. stops:          10
 (PID.TID 0000.0001)   Seconds in section "INTEGR_CONTINUITY   [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:  0.14800024032592773
+(PID.TID 0000.0001)           User time:  0.12148272991180420
 (PID.TID 0000.0001)         System time:   0.0000000000000000
-(PID.TID 0000.0001)     Wall clock time:  0.14897942543029785
+(PID.TID 0000.0001)     Wall clock time:  0.12149548530578613
 (PID.TID 0000.0001)          No. starts:          10
 (PID.TID 0000.0001)           No. stops:          10
 (PID.TID 0000.0001)   Seconds in section "TRC_CORRECTION_STEP [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:   0.0000000000000000
+(PID.TID 0000.0001)           User time:   7.9035758972167969E-005
 (PID.TID 0000.0001)         System time:   0.0000000000000000
-(PID.TID 0000.0001)     Wall clock time:   8.2492828369140625E-005
+(PID.TID 0000.0001)     Wall clock time:   7.4625015258789062E-005
 (PID.TID 0000.0001)          No. starts:          10
 (PID.TID 0000.0001)           No. stops:          10
 (PID.TID 0000.0001)   Seconds in section "BLOCKING_EXCHANGES  [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:  0.54000055789947510
-(PID.TID 0000.0001)         System time:   0.0000000000000000
-(PID.TID 0000.0001)     Wall clock time:  0.53956127166748047
+(PID.TID 0000.0001)           User time:  0.34350371360778809
+(PID.TID 0000.0001)         System time:   3.5039931535720825E-003
+(PID.TID 0000.0001)     Wall clock time:  0.34703707695007324
 (PID.TID 0000.0001)          No. starts:          10
 (PID.TID 0000.0001)           No. stops:          10
 (PID.TID 0000.0001)   Seconds in section "MONITOR             [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:  0.60399901866912842
+(PID.TID 0000.0001)           User time:  0.56838178634643555
 (PID.TID 0000.0001)         System time:   0.0000000000000000
-(PID.TID 0000.0001)     Wall clock time:  0.60674214363098145
+(PID.TID 0000.0001)     Wall clock time:  0.56841731071472168
 (PID.TID 0000.0001)          No. starts:          10
 (PID.TID 0000.0001)           No. stops:          10
 (PID.TID 0000.0001)   Seconds in section "DO_THE_MODEL_IO     [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:   2.4000167846679688E-002
-(PID.TID 0000.0001)         System time:   8.0000013113021851E-003
-(PID.TID 0000.0001)     Wall clock time:   3.2277584075927734E-002
+(PID.TID 0000.0001)           User time:   2.6760935783386230E-002
+(PID.TID 0000.0001)         System time:   7.7109932899475098E-003
+(PID.TID 0000.0001)     Wall clock time:   3.4486770629882812E-002
 (PID.TID 0000.0001)          No. starts:          10
 (PID.TID 0000.0001)           No. stops:          10
 (PID.TID 0000.0001)   Seconds in section "DO_WRITE_PICKUP     [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:   4.0000915527343750E-002
-(PID.TID 0000.0001)         System time:   2.7999997138977051E-002
-(PID.TID 0000.0001)     Wall clock time:   6.3122272491455078E-002
+(PID.TID 0000.0001)           User time:   3.6023497581481934E-002
+(PID.TID 0000.0001)         System time:   3.2000005245208740E-002
+(PID.TID 0000.0001)     Wall clock time:   6.8093776702880859E-002
 (PID.TID 0000.0001)          No. starts:          10
 (PID.TID 0000.0001)           No. stops:          10
 (PID.TID 0000.0001) // ======================================================
@@ -3653,9 +3658,9 @@ Global & Regional Statistics diagnostics: Number of lists:     0
 (PID.TID 0000.0001) //          Total. Y spins =              0
 (PID.TID 0000.0001) //            Avg. Y spins =       0.00E+00
 (PID.TID 0000.0001) // o Thread number: 000001
-(PID.TID 0000.0001) //            No. barriers =          17294
+(PID.TID 0000.0001) //            No. barriers =          17302
 (PID.TID 0000.0001) //      Max. barrier spins =              1
 (PID.TID 0000.0001) //      Min. barrier spins =              1
-(PID.TID 0000.0001) //     Total barrier spins =          17294
+(PID.TID 0000.0001) //     Total barrier spins =          17302
 (PID.TID 0000.0001) //      Avg. barrier spins =       1.00E+00
 PROGRAM MAIN: Execution ended Normally

--- a/verification/global_ocean.cs32x15/input.in_p/data.ggl90
+++ b/verification/global_ocean.cs32x15/input.in_p/data.ggl90
@@ -1,10 +1,6 @@
 # Parameters for Gaspar et al. (1990)'s TKE vertical mixing scheme  |
  &GGL90_PARM01
-#GGL90dumpFreq=,
-#GGL90taveFreq=,
  GGL90diffTKEh=0.E3,
- GGL90mixingMaps=.FALSE.,
- GGL90writeState=.FALSE.,
  GGL90ck = 0.1,
  GGL90ceps = 0.7,
  GGL90alpha=30.,
@@ -16,9 +12,15 @@
  mxlMaxFlag=2,
  GGL90viscMax=1.E2,
  GGL90diffMax=1.E2,
-#GGL90TKEFile=,
+ calcMeanVertShear=.TRUE.,
  GGL90_dirichlet=.FALSE.,
  useIDEMIX  = .TRUE.,
+#-- IO related params:
+#GGL90TKEFile=,
+#GGL90dumpFreq=,
+#GGL90taveFreq=,
+ GGL90mixingMaps=.FALSE.,
+ GGL90writeState=.FALSE.,
  &
 
  &GGL90_PARM02

--- a/verification/global_ocean.cs32x15/input.in_p/data.ggl90
+++ b/verification/global_ocean.cs32x15/input.in_p/data.ggl90
@@ -28,4 +28,9 @@
  IDEMIX_include_GM        = .FALSE.,
  IDEMIX_tidal_file = 'idemix_tidal_forcing.192x32.bin',
  IDEMIX_wind_file  = 'idemix_wind_forcing.192x32.bin',
+# these are old defaults that are not recommended
+ IDEMIX_tau_v =  86400.0,
+ IDEMIX_jstar = 10.0,
+#IDEMIX_mu0   = 4.0/3.0
+ IDEMIX_mu0   = 1.3333333333333333,
  &

--- a/verification/global_ocean.cs32x15/input.in_p/data.ggl90
+++ b/verification/global_ocean.cs32x15/input.in_p/data.ggl90
@@ -24,13 +24,13 @@
  &
 
  &GGL90_PARM02
+#- below are old defaults that are not recommended
+# IDEMIX_tau_v =  86400.0,
+# IDEMIX_jstar = 10.0,
+# IDEMIX_mu0   = 1.3333333333333333,
+#--
  IDEMIX_include_GM_bottom = .FALSE.,
  IDEMIX_include_GM        = .FALSE.,
  IDEMIX_tidal_file = 'idemix_tidal_forcing.192x32.bin',
  IDEMIX_wind_file  = 'idemix_wind_forcing.192x32.bin',
-# these are old defaults that are not recommended
- IDEMIX_tau_v =  86400.0,
- IDEMIX_jstar = 10.0,
-#IDEMIX_mu0   = 4.0/3.0
- IDEMIX_mu0   = 1.3333333333333333,
  &

--- a/verification/global_ocean.cs32x15/results/output.in_p.txt
+++ b/verification/global_ocean.cs32x15/results/output.in_p.txt
@@ -3525,42 +3525,42 @@ listId=   2 ; file name: seaiceStDiag
  cg2d: Sum(rhs),rhsMax =   7.66661733960343E-02  2.00457239865341E+01
 (PID.TID 0000.0001)      cg2d_init_res =   4.84221893084459E-01
 (PID.TID 0000.0001)      cg2d_iters(min,last) =      -1     109
-(PID.TID 0000.0001)      cg2d_last_res =   8.82501223637362E-10
+(PID.TID 0000.0001)      cg2d_last_res =   8.74724599652742E-10
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // Begin MONITOR dynamic field statistics
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) %MON time_tsnumber                =                     2
 (PID.TID 0000.0001) %MON time_secondsf                =   1.7280000000000E+05
-(PID.TID 0000.0001) %MON dynstat_eta_max              =   1.4036965268333E+04
-(PID.TID 0000.0001) %MON dynstat_eta_min              =  -2.1104916361476E+04
-(PID.TID 0000.0001) %MON dynstat_eta_mean             =  -2.3208444477512E+01
-(PID.TID 0000.0001) %MON dynstat_eta_sd               =   6.2877655143525E+03
-(PID.TID 0000.0001) %MON dynstat_eta_del2             =   9.5570817522091E+01
-(PID.TID 0000.0001) %MON dynstat_uvel_max             =   3.8335540667625E-02
-(PID.TID 0000.0001) %MON dynstat_uvel_min             =  -4.4651029013030E-02
-(PID.TID 0000.0001) %MON dynstat_uvel_mean            =  -3.3193706828567E-04
-(PID.TID 0000.0001) %MON dynstat_uvel_sd              =   2.3396750766941E-03
-(PID.TID 0000.0001) %MON dynstat_uvel_del2            =   1.2333597813109E-05
-(PID.TID 0000.0001) %MON dynstat_vvel_max             =   7.3366327758949E-02
-(PID.TID 0000.0001) %MON dynstat_vvel_min             =  -5.6465928266594E-02
-(PID.TID 0000.0001) %MON dynstat_vvel_mean            =  -6.8051627586800E-05
-(PID.TID 0000.0001) %MON dynstat_vvel_sd              =   2.4521930392512E-03
-(PID.TID 0000.0001) %MON dynstat_vvel_del2            =   1.2959564550909E-05
-(PID.TID 0000.0001) %MON dynstat_wvel_max             =   1.8519218962490E+00
-(PID.TID 0000.0001) %MON dynstat_wvel_min             =  -2.9433404939193E+00
-(PID.TID 0000.0001) %MON dynstat_wvel_mean            =   2.4537896047374E-03
-(PID.TID 0000.0001) %MON dynstat_wvel_sd              =   8.9180465244969E-02
-(PID.TID 0000.0001) %MON dynstat_wvel_del2            =   7.6787871356586E-04
+(PID.TID 0000.0001) %MON dynstat_eta_max              =   1.4036965275148E+04
+(PID.TID 0000.0001) %MON dynstat_eta_min              =  -2.1104916362541E+04
+(PID.TID 0000.0001) %MON dynstat_eta_mean             =  -2.3208444477514E+01
+(PID.TID 0000.0001) %MON dynstat_eta_sd               =   6.2877655143708E+03
+(PID.TID 0000.0001) %MON dynstat_eta_del2             =   9.5570817523729E+01
+(PID.TID 0000.0001) %MON dynstat_uvel_max             =   3.8335540667089E-02
+(PID.TID 0000.0001) %MON dynstat_uvel_min             =  -4.4651029012879E-02
+(PID.TID 0000.0001) %MON dynstat_uvel_mean            =  -3.3193706828628E-04
+(PID.TID 0000.0001) %MON dynstat_uvel_sd              =   2.3396750766954E-03
+(PID.TID 0000.0001) %MON dynstat_uvel_del2            =   1.2333597813095E-05
+(PID.TID 0000.0001) %MON dynstat_vvel_max             =   7.3366327760971E-02
+(PID.TID 0000.0001) %MON dynstat_vvel_min             =  -5.6465928266622E-02
+(PID.TID 0000.0001) %MON dynstat_vvel_mean            =  -6.8051627587492E-05
+(PID.TID 0000.0001) %MON dynstat_vvel_sd              =   2.4521930392503E-03
+(PID.TID 0000.0001) %MON dynstat_vvel_del2            =   1.2959564550894E-05
+(PID.TID 0000.0001) %MON dynstat_wvel_max             =   1.8519218962494E+00
+(PID.TID 0000.0001) %MON dynstat_wvel_min             =  -2.9433404939104E+00
+(PID.TID 0000.0001) %MON dynstat_wvel_mean            =   2.4537896047422E-03
+(PID.TID 0000.0001) %MON dynstat_wvel_sd              =   8.9180465244918E-02
+(PID.TID 0000.0001) %MON dynstat_wvel_del2            =   7.6787871356499E-04
 (PID.TID 0000.0001) %MON dynstat_theta_max            =   2.9400596552103E+01
 (PID.TID 0000.0001) %MON dynstat_theta_min            =  -1.8753303244749E+00
 (PID.TID 0000.0001) %MON dynstat_theta_mean           =   3.5913487271234E+00
 (PID.TID 0000.0001) %MON dynstat_theta_sd             =   4.4273028223381E+00
-(PID.TID 0000.0001) %MON dynstat_theta_del2           =   2.1350327197186E-03
+(PID.TID 0000.0001) %MON dynstat_theta_del2           =   2.1350327197187E-03
 (PID.TID 0000.0001) %MON dynstat_salt_max             =   4.0715782043866E+01
-(PID.TID 0000.0001) %MON dynstat_salt_min             =   1.8061466083965E+01
+(PID.TID 0000.0001) %MON dynstat_salt_min             =   1.8061466083986E+01
 (PID.TID 0000.0001) %MON dynstat_salt_mean            =   3.4721464665322E+01
-(PID.TID 0000.0001) %MON dynstat_salt_sd              =   4.8775554545323E-01
-(PID.TID 0000.0001) %MON dynstat_salt_del2            =   5.1987260896902E-04
+(PID.TID 0000.0001) %MON dynstat_salt_sd              =   4.8775554545322E-01
+(PID.TID 0000.0001) %MON dynstat_salt_del2            =   5.1987260896929E-04
 (PID.TID 0000.0001) %MON forcing_qnet_max             =   6.9568301659527E+02
 (PID.TID 0000.0001) %MON forcing_qnet_min             =  -3.1666111122704E+02
 (PID.TID 0000.0001) %MON forcing_qnet_mean            =  -2.1816692279327E+01
@@ -3586,25 +3586,25 @@ listId=   2 ; file name: seaiceStDiag
 (PID.TID 0000.0001) %MON forcing_fv_mean              =  -1.3688466828709E-02
 (PID.TID 0000.0001) %MON forcing_fv_sd                =   7.5192568394714E-02
 (PID.TID 0000.0001) %MON forcing_fv_del2              =   2.3387409827505E-04
-(PID.TID 0000.0001) %MON trAdv_CFL_u_max              =   1.5992062360760E-02
-(PID.TID 0000.0001) %MON trAdv_CFL_v_max              =   2.4917775183023E-02
-(PID.TID 0000.0001) %MON trAdv_CFL_w_max              =   7.6016910197736E-02
-(PID.TID 0000.0001) %MON advcfl_uvel_max              =   1.4235253129306E-02
-(PID.TID 0000.0001) %MON advcfl_vvel_max              =   2.3940139947141E-02
-(PID.TID 0000.0001) %MON advcfl_wvel_max              =   8.3246481229211E-02
-(PID.TID 0000.0001) %MON advcfl_W_hf_max              =   9.1981173751798E-02
-(PID.TID 0000.0001) %MON pe_b_mean                    =   1.2124608444615E-02
-(PID.TID 0000.0001) %MON ke_max                       =   1.6821389677914E-03
-(PID.TID 0000.0001) %MON ke_mean                      =   5.3572483612507E-06
+(PID.TID 0000.0001) %MON trAdv_CFL_u_max              =   1.5992062360550E-02
+(PID.TID 0000.0001) %MON trAdv_CFL_v_max              =   2.4917775183709E-02
+(PID.TID 0000.0001) %MON trAdv_CFL_w_max              =   7.6016910197410E-02
+(PID.TID 0000.0001) %MON advcfl_uvel_max              =   1.4235253129861E-02
+(PID.TID 0000.0001) %MON advcfl_vvel_max              =   2.3940139947800E-02
+(PID.TID 0000.0001) %MON advcfl_wvel_max              =   8.3246481228855E-02
+(PID.TID 0000.0001) %MON advcfl_W_hf_max              =   9.1981173751403E-02
+(PID.TID 0000.0001) %MON pe_b_mean                    =   1.2124608444676E-02
+(PID.TID 0000.0001) %MON ke_max                       =   1.6821389677809E-03
+(PID.TID 0000.0001) %MON ke_mean                      =   5.3572483612516E-06
 (PID.TID 0000.0001) %MON ke_vol                       =   1.3604174062081E+22
-(PID.TID 0000.0001) %MON vort_r_min                   =  -3.6063117581765E-07
-(PID.TID 0000.0001) %MON vort_r_max                   =   4.3008997582352E-07
+(PID.TID 0000.0001) %MON vort_r_min                   =  -3.6063117582013E-07
+(PID.TID 0000.0001) %MON vort_r_max                   =   4.3008997581532E-07
 (PID.TID 0000.0001) %MON vort_a_mean                  =  -2.0556865257795E-05
 (PID.TID 0000.0001) %MON vort_a_sd                    =   7.5247345875121E-05
 (PID.TID 0000.0001) %MON vort_p_mean                  =  -2.4859276343880E-05
 (PID.TID 0000.0001) %MON vort_p_sd                    =   1.2919528775072E-04
-(PID.TID 0000.0001) %MON surfExpan_theta_mean         =   7.0941539455192E-03
-(PID.TID 0000.0001) %MON surfExpan_salt_mean          =  -4.3489466007081E-03
+(PID.TID 0000.0001) %MON surfExpan_theta_mean         =   7.0941539463679E-03
+(PID.TID 0000.0001) %MON surfExpan_salt_mean          =  -4.3489466007773E-03
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // End MONITOR dynamic field statistics
 (PID.TID 0000.0001) // =======================================================
@@ -3643,65 +3643,65 @@ listId=   2 ; file name: seaiceStDiag
 (PID.TID 0000.0001) // =======================================================
  EXTERNAL_FIELDS_LOAD,         2 : iP,iLd,i0,i1=   12    1   12    1 ; Wght=  0.4333333333  0.5666666667
  SEAICE_LSR: Residual Initial ipass,Uice,Vice=         1  5.59360800E-04  8.46021758E-04
- SEAICE_LSR (ipass=        1) iters,dU,Resid=       12  2.57904809E-13  2.16002447E-19
- SEAICE_LSR (ipass=        1) iters,dV,Resid=       12  1.46327395E-13  3.26910401E-19
+ SEAICE_LSR (ipass=        1) iters,dU,Resid=       12  2.57904809E-13  2.35680951E-19
+ SEAICE_LSR (ipass=        1) iters,dV,Resid=       12  1.46327395E-13  3.85544599E-19
  SEAICE_LSR: Residual Initial ipass,Uice,Vice=         2  1.59915603E-04  1.95760454E-04
- SEAICE_LSR (ipass=        2) iters,dU,Resid=       12  2.29954944E-14  1.40841413E-19
- SEAICE_LSR (ipass=        2) iters,dV,Resid=       12  3.57205585E-14  3.00186719E-19
- cg2d: Sum(rhs),rhsMax =   1.33366823273823E-01  1.98889685127990E+01
-(PID.TID 0000.0001)      cg2d_init_res =   1.91658343510547E-01
+ SEAICE_LSR (ipass=        2) iters,dU,Resid=       12  2.29954944E-14  1.56964448E-19
+ SEAICE_LSR (ipass=        2) iters,dV,Resid=       12  3.57205585E-14  3.27939976E-19
+ cg2d: Sum(rhs),rhsMax =   1.33366823273831E-01  1.98889685127973E+01
+(PID.TID 0000.0001)      cg2d_init_res =   1.91658343627827E-01
 (PID.TID 0000.0001)      cg2d_iters(min,last) =      -1     104
-(PID.TID 0000.0001)      cg2d_last_res =   9.58400802127717E-10
+(PID.TID 0000.0001)      cg2d_last_res =   9.59459770276362E-10
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // Begin MONITOR dynamic field statistics
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) %MON time_tsnumber                =                     3
 (PID.TID 0000.0001) %MON time_secondsf                =   2.5920000000000E+05
-(PID.TID 0000.0001) %MON dynstat_eta_max              =   1.3305568895580E+04
-(PID.TID 0000.0001) %MON dynstat_eta_min              =  -2.3890925990633E+04
-(PID.TID 0000.0001) %MON dynstat_eta_mean             =  -4.0057197978012E+01
-(PID.TID 0000.0001) %MON dynstat_eta_sd               =   7.0653107179326E+03
-(PID.TID 0000.0001) %MON dynstat_eta_del2             =   9.3846801634321E+01
-(PID.TID 0000.0001) %MON dynstat_uvel_max             =   5.4259923018788E-02
-(PID.TID 0000.0001) %MON dynstat_uvel_min             =  -6.3804273869750E-02
-(PID.TID 0000.0001) %MON dynstat_uvel_mean            =  -4.5161666905500E-04
-(PID.TID 0000.0001) %MON dynstat_uvel_sd              =   3.2104549173227E-03
-(PID.TID 0000.0001) %MON dynstat_uvel_del2            =   1.7242405507096E-05
-(PID.TID 0000.0001) %MON dynstat_vvel_max             =   8.8880798485755E-02
-(PID.TID 0000.0001) %MON dynstat_vvel_min             =  -8.2045964902231E-02
-(PID.TID 0000.0001) %MON dynstat_vvel_mean            =  -1.5740597697879E-04
-(PID.TID 0000.0001) %MON dynstat_vvel_sd              =   3.3122341193210E-03
-(PID.TID 0000.0001) %MON dynstat_vvel_del2            =   1.8229526773499E-05
-(PID.TID 0000.0001) %MON dynstat_wvel_max             =   2.6904765953141E+00
-(PID.TID 0000.0001) %MON dynstat_wvel_min             =  -4.3242250632580E+00
-(PID.TID 0000.0001) %MON dynstat_wvel_mean            =   8.8932549810737E-04
-(PID.TID 0000.0001) %MON dynstat_wvel_sd              =   1.2601406790899E-01
-(PID.TID 0000.0001) %MON dynstat_wvel_del2            =   1.0608938337773E-03
+(PID.TID 0000.0001) %MON dynstat_eta_max              =   1.3305568896365E+04
+(PID.TID 0000.0001) %MON dynstat_eta_min              =  -2.3890925990808E+04
+(PID.TID 0000.0001) %MON dynstat_eta_mean             =  -4.0057197978013E+01
+(PID.TID 0000.0001) %MON dynstat_eta_sd               =   7.0653107179244E+03
+(PID.TID 0000.0001) %MON dynstat_eta_del2             =   9.3846801633356E+01
+(PID.TID 0000.0001) %MON dynstat_uvel_max             =   5.4259923018645E-02
+(PID.TID 0000.0001) %MON dynstat_uvel_min             =  -6.3804273869844E-02
+(PID.TID 0000.0001) %MON dynstat_uvel_mean            =  -4.5161666905212E-04
+(PID.TID 0000.0001) %MON dynstat_uvel_sd              =   3.2104549173233E-03
+(PID.TID 0000.0001) %MON dynstat_uvel_del2            =   1.7242405507100E-05
+(PID.TID 0000.0001) %MON dynstat_vvel_max             =   8.8880798485732E-02
+(PID.TID 0000.0001) %MON dynstat_vvel_min             =  -8.2045964902272E-02
+(PID.TID 0000.0001) %MON dynstat_vvel_mean            =  -1.5740597697869E-04
+(PID.TID 0000.0001) %MON dynstat_vvel_sd              =   3.3122341193208E-03
+(PID.TID 0000.0001) %MON dynstat_vvel_del2            =   1.8229526773492E-05
+(PID.TID 0000.0001) %MON dynstat_wvel_max             =   2.6904765953131E+00
+(PID.TID 0000.0001) %MON dynstat_wvel_min             =  -4.3242250632616E+00
+(PID.TID 0000.0001) %MON dynstat_wvel_mean            =   8.8932549807623E-04
+(PID.TID 0000.0001) %MON dynstat_wvel_sd              =   1.2601406790895E-01
+(PID.TID 0000.0001) %MON dynstat_wvel_del2            =   1.0608938337789E-03
 (PID.TID 0000.0001) %MON dynstat_theta_max            =   2.9408135074514E+01
-(PID.TID 0000.0001) %MON dynstat_theta_min            =  -1.8830010737597E+00
+(PID.TID 0000.0001) %MON dynstat_theta_min            =  -1.8830010737596E+00
 (PID.TID 0000.0001) %MON dynstat_theta_mean           =   3.5914725052713E+00
-(PID.TID 0000.0001) %MON dynstat_theta_sd             =   4.4276475110507E+00
-(PID.TID 0000.0001) %MON dynstat_theta_del2           =   2.1107895637723E-03
+(PID.TID 0000.0001) %MON dynstat_theta_sd             =   4.4276475110508E+00
+(PID.TID 0000.0001) %MON dynstat_theta_del2           =   2.1107895637722E-03
 (PID.TID 0000.0001) %MON dynstat_salt_max             =   4.0715797013571E+01
-(PID.TID 0000.0001) %MON dynstat_salt_min             =   1.7830039392896E+01
+(PID.TID 0000.0001) %MON dynstat_salt_min             =   1.7830039392909E+01
 (PID.TID 0000.0001) %MON dynstat_salt_mean            =   3.4721480211925E+01
 (PID.TID 0000.0001) %MON dynstat_salt_sd              =   4.8768042466746E-01
-(PID.TID 0000.0001) %MON dynstat_salt_del2            =   5.1654635831221E-04
-(PID.TID 0000.0001) %MON forcing_qnet_max             =   9.8898462964453E+02
-(PID.TID 0000.0001) %MON forcing_qnet_min             =  -3.1582909723282E+02
+(PID.TID 0000.0001) %MON dynstat_salt_del2            =   5.1654635831236E-04
+(PID.TID 0000.0001) %MON forcing_qnet_max             =   9.8898462964462E+02
+(PID.TID 0000.0001) %MON forcing_qnet_min             =  -3.1582909723281E+02
 (PID.TID 0000.0001) %MON forcing_qnet_mean            =  -2.4196329267912E+01
 (PID.TID 0000.0001) %MON forcing_qnet_sd              =   1.6598717640820E+02
-(PID.TID 0000.0001) %MON forcing_qnet_del2            =   1.3045245247960E+00
+(PID.TID 0000.0001) %MON forcing_qnet_del2            =   1.3045245247962E+00
 (PID.TID 0000.0001) %MON forcing_qsw_max              =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON forcing_qsw_min              =  -3.0189127925792E+02
 (PID.TID 0000.0001) %MON forcing_qsw_mean             =  -1.8593879213097E+02
 (PID.TID 0000.0001) %MON forcing_qsw_sd               =   7.9086030762481E+01
 (PID.TID 0000.0001) %MON forcing_qsw_del2             =   1.1032203144530E-01
-(PID.TID 0000.0001) %MON forcing_empmr_max            =   1.7742506342706E-03
-(PID.TID 0000.0001) %MON forcing_empmr_min            =  -1.6714318397364E-03
-(PID.TID 0000.0001) %MON forcing_empmr_mean           =   1.9878564839001E-05
-(PID.TID 0000.0001) %MON forcing_empmr_sd             =   1.7354017337450E-04
-(PID.TID 0000.0001) %MON forcing_empmr_del2           =   3.3786642290123E-06
+(PID.TID 0000.0001) %MON forcing_empmr_max            =   1.7742506342736E-03
+(PID.TID 0000.0001) %MON forcing_empmr_min            =  -1.6714318397368E-03
+(PID.TID 0000.0001) %MON forcing_empmr_mean           =   1.9878564839000E-05
+(PID.TID 0000.0001) %MON forcing_empmr_sd             =   1.7354017337451E-04
+(PID.TID 0000.0001) %MON forcing_empmr_del2           =   3.3786642290135E-06
 (PID.TID 0000.0001) %MON forcing_fu_max               =   2.4751003717351E-01
 (PID.TID 0000.0001) %MON forcing_fu_min               =  -2.0922350306190E-01
 (PID.TID 0000.0001) %MON forcing_fu_mean              =  -4.4451640019368E-03
@@ -3712,25 +3712,25 @@ listId=   2 ; file name: seaiceStDiag
 (PID.TID 0000.0001) %MON forcing_fv_mean              =  -1.3688993645892E-02
 (PID.TID 0000.0001) %MON forcing_fv_sd                =   7.5246625962459E-02
 (PID.TID 0000.0001) %MON forcing_fv_del2              =   2.3426167469211E-04
-(PID.TID 0000.0001) %MON trAdv_CFL_u_max              =   2.2401775800131E-02
-(PID.TID 0000.0001) %MON trAdv_CFL_v_max              =   3.1506303245043E-02
-(PID.TID 0000.0001) %MON trAdv_CFL_w_max              =   1.1159956548577E-01
-(PID.TID 0000.0001) %MON advcfl_uvel_max              =   2.0096023730248E-02
-(PID.TID 0000.0001) %MON advcfl_vvel_max              =   2.6142675052646E-02
-(PID.TID 0000.0001) %MON advcfl_wvel_max              =   1.2220630575509E-01
-(PID.TID 0000.0001) %MON advcfl_W_hf_max              =   1.3503652012257E-01
-(PID.TID 0000.0001) %MON pe_b_mean                    =   1.3157400067899E-02
-(PID.TID 0000.0001) %MON ke_max                       =   2.6263979163870E-03
-(PID.TID 0000.0001) %MON ke_mean                      =   9.9299669067715E-06
+(PID.TID 0000.0001) %MON trAdv_CFL_u_max              =   2.2401775800102E-02
+(PID.TID 0000.0001) %MON trAdv_CFL_v_max              =   3.1506303245165E-02
+(PID.TID 0000.0001) %MON trAdv_CFL_w_max              =   1.1159956548591E-01
+(PID.TID 0000.0001) %MON advcfl_uvel_max              =   2.0096023729528E-02
+(PID.TID 0000.0001) %MON advcfl_vvel_max              =   2.6142675052298E-02
+(PID.TID 0000.0001) %MON advcfl_wvel_max              =   1.2220630575525E-01
+(PID.TID 0000.0001) %MON advcfl_W_hf_max              =   1.3503652012274E-01
+(PID.TID 0000.0001) %MON pe_b_mean                    =   1.3157400067881E-02
+(PID.TID 0000.0001) %MON ke_max                       =   2.6263979163907E-03
+(PID.TID 0000.0001) %MON ke_mean                      =   9.9299669067716E-06
 (PID.TID 0000.0001) %MON ke_vol                       =   1.3604168238985E+22
-(PID.TID 0000.0001) %MON vort_r_min                   =  -4.9874672739384E-07
-(PID.TID 0000.0001) %MON vort_r_max                   =   5.2424095251648E-07
+(PID.TID 0000.0001) %MON vort_r_min                   =  -4.9874672739054E-07
+(PID.TID 0000.0001) %MON vort_r_max                   =   5.2424095251189E-07
 (PID.TID 0000.0001) %MON vort_a_mean                  =  -2.0556865257795E-05
 (PID.TID 0000.0001) %MON vort_a_sd                    =   7.5247335755280E-05
 (PID.TID 0000.0001) %MON vort_p_mean                  =  -2.4859228572284E-05
 (PID.TID 0000.0001) %MON vort_p_sd                    =   1.2920027720410E-04
-(PID.TID 0000.0001) %MON surfExpan_theta_mean         =   1.1468274062140E-02
-(PID.TID 0000.0001) %MON surfExpan_salt_mean          =  -5.1771345817986E-03
+(PID.TID 0000.0001) %MON surfExpan_theta_mean         =   1.1468274061402E-02
+(PID.TID 0000.0001) %MON surfExpan_salt_mean          =  -5.1771345818354E-03
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // End MONITOR dynamic field statistics
 (PID.TID 0000.0001) // =======================================================
@@ -3739,124 +3739,124 @@ listId=   2 ; file name: seaiceStDiag
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) %MON seaice_tsnumber              =                     3
 (PID.TID 0000.0001) %MON seaice_time_sec              =   2.5920000000000E+05
-(PID.TID 0000.0001) %MON seaice_uice_max              =   1.2724390853029E-01
+(PID.TID 0000.0001) %MON seaice_uice_max              =   1.2724390853058E-01
 (PID.TID 0000.0001) %MON seaice_uice_min              =  -1.8208622789017E-01
-(PID.TID 0000.0001) %MON seaice_uice_mean             =  -3.0913786881449E-04
-(PID.TID 0000.0001) %MON seaice_uice_sd               =   9.4998738259479E-03
-(PID.TID 0000.0001) %MON seaice_uice_del2             =   2.0182103708200E-04
-(PID.TID 0000.0001) %MON seaice_vice_max              =   1.4350330033241E-01
-(PID.TID 0000.0001) %MON seaice_vice_min              =  -1.4748903452633E-01
-(PID.TID 0000.0001) %MON seaice_vice_mean             =   9.1141928681904E-04
-(PID.TID 0000.0001) %MON seaice_vice_sd               =   1.3506900353633E-02
-(PID.TID 0000.0001) %MON seaice_vice_del2             =   1.2914879877236E-04
-(PID.TID 0000.0001) %MON seaice_area_max              =   6.7874329947991E-01
+(PID.TID 0000.0001) %MON seaice_uice_mean             =  -3.0913786881399E-04
+(PID.TID 0000.0001) %MON seaice_uice_sd               =   9.4998738259569E-03
+(PID.TID 0000.0001) %MON seaice_uice_del2             =   2.0182103708275E-04
+(PID.TID 0000.0001) %MON seaice_vice_max              =   1.4350330033310E-01
+(PID.TID 0000.0001) %MON seaice_vice_min              =  -1.4748903452509E-01
+(PID.TID 0000.0001) %MON seaice_vice_mean             =   9.1141928681939E-04
+(PID.TID 0000.0001) %MON seaice_vice_sd               =   1.3506900353631E-02
+(PID.TID 0000.0001) %MON seaice_vice_del2             =   1.2914879877200E-04
+(PID.TID 0000.0001) %MON seaice_area_max              =   6.7874329947999E-01
 (PID.TID 0000.0001) %MON seaice_area_min              =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON seaice_area_mean             =   9.6242418794471E-03
+(PID.TID 0000.0001) %MON seaice_area_mean             =   9.6242418794470E-03
 (PID.TID 0000.0001) %MON seaice_area_sd               =   7.2159810826301E-02
-(PID.TID 0000.0001) %MON seaice_area_del2             =   8.6631787826749E-04
-(PID.TID 0000.0001) %MON seaice_heff_max              =   3.7961498185784E-01
+(PID.TID 0000.0001) %MON seaice_area_del2             =   8.6631787826751E-04
+(PID.TID 0000.0001) %MON seaice_heff_max              =   3.7961498185783E-01
 (PID.TID 0000.0001) %MON seaice_heff_min              =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON seaice_heff_mean             =   5.0600578199231E-03
+(PID.TID 0000.0001) %MON seaice_heff_mean             =   5.0600578199230E-03
 (PID.TID 0000.0001) %MON seaice_heff_sd               =   3.8280425961663E-02
-(PID.TID 0000.0001) %MON seaice_heff_del2             =   4.3387161382747E-04
-(PID.TID 0000.0001) %MON seaice_hsnow_max             =   1.8610649431798E-03
+(PID.TID 0000.0001) %MON seaice_heff_del2             =   4.3387161382752E-04
+(PID.TID 0000.0001) %MON seaice_hsnow_max             =   1.8610649431791E-03
 (PID.TID 0000.0001) %MON seaice_hsnow_min             =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON seaice_hsnow_mean            =   1.4992139780416E-05
-(PID.TID 0000.0001) %MON seaice_hsnow_sd              =   1.3089548971084E-04
-(PID.TID 0000.0001) %MON seaice_hsnow_del2            =   2.0820572686459E-06
+(PID.TID 0000.0001) %MON seaice_hsnow_sd              =   1.3089548971085E-04
+(PID.TID 0000.0001) %MON seaice_hsnow_del2            =   2.0820572686460E-06
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // End MONITOR SEAICE statistics
 (PID.TID 0000.0001) // =======================================================
  EXTERNAL_FIELDS_LOAD,         3 : iP,iLd,i0,i1=   12    1   12    1 ; Wght=  0.4000000000  0.6000000000
  SEAICE_LSR: Residual Initial ipass,Uice,Vice=         1  2.75168993E-04  3.52394067E-04
- SEAICE_LSR (ipass=        1) iters,dU,Resid=       12  3.16136006E-14  2.56402756E-19
- SEAICE_LSR (ipass=        1) iters,dV,Resid=       12  7.74831588E-14  5.27669207E-19
+ SEAICE_LSR (ipass=        1) iters,dU,Resid=       12  3.15858451E-14  2.08887314E-19
+ SEAICE_LSR (ipass=        1) iters,dV,Resid=       12  7.74866282E-14  5.15216672E-19
  SEAICE_LSR: Residual Initial ipass,Uice,Vice=         2  9.40704000E-05  7.93744659E-05
- SEAICE_LSR (ipass=        2) iters,dU,Resid=       12  2.13717932E-15  2.40101051E-19
- SEAICE_LSR (ipass=        2) iters,dV,Resid=       12  3.60770441E-14  4.46854712E-19
- cg2d: Sum(rhs),rhsMax =   1.92172284867735E-01  1.98883986255069E+01
-(PID.TID 0000.0001)      cg2d_init_res =   9.80656792989594E-02
+ SEAICE_LSR (ipass=        2) iters,dU,Resid=       12  2.16493490E-15  2.63867640E-19
+ SEAICE_LSR (ipass=        2) iters,dV,Resid=       12  3.61065344E-14  4.42035287E-19
+ cg2d: Sum(rhs),rhsMax =   1.92172284867777E-01  1.98883986255041E+01
+(PID.TID 0000.0001)      cg2d_init_res =   9.80656793086880E-02
 (PID.TID 0000.0001)      cg2d_iters(min,last) =      -1     103
-(PID.TID 0000.0001)      cg2d_last_res =   7.42172803687128E-10
+(PID.TID 0000.0001)      cg2d_last_res =   7.42172769533764E-10
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // Begin MONITOR dynamic field statistics
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) %MON time_tsnumber                =                     4
 (PID.TID 0000.0001) %MON time_secondsf                =   3.4560000000000E+05
-(PID.TID 0000.0001) %MON dynstat_eta_max              =   1.3103148517815E+04
-(PID.TID 0000.0001) %MON dynstat_eta_min              =  -2.3940437729527E+04
-(PID.TID 0000.0001) %MON dynstat_eta_mean             =  -5.7717972889121E+01
-(PID.TID 0000.0001) %MON dynstat_eta_sd               =   7.3742311473010E+03
-(PID.TID 0000.0001) %MON dynstat_eta_del2             =   9.3592001150386E+01
-(PID.TID 0000.0001) %MON dynstat_uvel_max             =   6.9746207934121E-02
-(PID.TID 0000.0001) %MON dynstat_uvel_min             =  -8.1956720116883E-02
-(PID.TID 0000.0001) %MON dynstat_uvel_mean            =  -4.6671128891593E-04
-(PID.TID 0000.0001) %MON dynstat_uvel_sd              =   4.1161818216521E-03
-(PID.TID 0000.0001) %MON dynstat_uvel_del2            =   2.2003197368481E-05
-(PID.TID 0000.0001) %MON dynstat_vvel_max             =   1.1493552948131E-01
-(PID.TID 0000.0001) %MON dynstat_vvel_min             =  -1.0576859165154E-01
-(PID.TID 0000.0001) %MON dynstat_vvel_mean            =  -2.7722740795987E-04
+(PID.TID 0000.0001) %MON dynstat_eta_max              =   1.3103148517861E+04
+(PID.TID 0000.0001) %MON dynstat_eta_min              =  -2.3940437729562E+04
+(PID.TID 0000.0001) %MON dynstat_eta_mean             =  -5.7717972889119E+01
+(PID.TID 0000.0001) %MON dynstat_eta_sd               =   7.3742311473014E+03
+(PID.TID 0000.0001) %MON dynstat_eta_del2             =   9.3592001150294E+01
+(PID.TID 0000.0001) %MON dynstat_uvel_max             =   6.9746207934105E-02
+(PID.TID 0000.0001) %MON dynstat_uvel_min             =  -8.1956720116854E-02
+(PID.TID 0000.0001) %MON dynstat_uvel_mean            =  -4.6671128891502E-04
+(PID.TID 0000.0001) %MON dynstat_uvel_sd              =   4.1161818216520E-03
+(PID.TID 0000.0001) %MON dynstat_uvel_del2            =   2.2003197368484E-05
+(PID.TID 0000.0001) %MON dynstat_vvel_max             =   1.1493552948133E-01
+(PID.TID 0000.0001) %MON dynstat_vvel_min             =  -1.0576859165153E-01
+(PID.TID 0000.0001) %MON dynstat_vvel_mean            =  -2.7722740795981E-04
 (PID.TID 0000.0001) %MON dynstat_vvel_sd              =   4.2197069784128E-03
-(PID.TID 0000.0001) %MON dynstat_vvel_del2            =   2.3149951113307E-05
-(PID.TID 0000.0001) %MON dynstat_wvel_max             =   3.4525291564695E+00
-(PID.TID 0000.0001) %MON dynstat_wvel_min             =  -5.6359456311017E+00
-(PID.TID 0000.0001) %MON dynstat_wvel_mean            =   2.6569456542827E-04
-(PID.TID 0000.0001) %MON dynstat_wvel_sd              =   1.6024169149798E-01
-(PID.TID 0000.0001) %MON dynstat_wvel_del2            =   1.3203003561285E-03
+(PID.TID 0000.0001) %MON dynstat_vvel_del2            =   2.3149951113323E-05
+(PID.TID 0000.0001) %MON dynstat_wvel_max             =   3.4525291564692E+00
+(PID.TID 0000.0001) %MON dynstat_wvel_min             =  -5.6359456311040E+00
+(PID.TID 0000.0001) %MON dynstat_wvel_mean            =   2.6569456545611E-04
+(PID.TID 0000.0001) %MON dynstat_wvel_sd              =   1.6024169149794E-01
+(PID.TID 0000.0001) %MON dynstat_wvel_del2            =   1.3203003561283E-03
 (PID.TID 0000.0001) %MON dynstat_theta_max            =   2.9415131671508E+01
 (PID.TID 0000.0001) %MON dynstat_theta_min            =  -1.8816762412202E+00
 (PID.TID 0000.0001) %MON dynstat_theta_mean           =   3.5916308872376E+00
 (PID.TID 0000.0001) %MON dynstat_theta_sd             =   4.4274608216882E+00
 (PID.TID 0000.0001) %MON dynstat_theta_del2           =   2.2856027244249E-03
 (PID.TID 0000.0001) %MON dynstat_salt_max             =   4.0715816856184E+01
-(PID.TID 0000.0001) %MON dynstat_salt_min             =   1.7561085086136E+01
+(PID.TID 0000.0001) %MON dynstat_salt_min             =   1.7561085086138E+01
 (PID.TID 0000.0001) %MON dynstat_salt_mean            =   3.4721497017536E+01
 (PID.TID 0000.0001) %MON dynstat_salt_sd              =   4.8746251858499E-01
-(PID.TID 0000.0001) %MON dynstat_salt_del2            =   5.2572504735414E-04
+(PID.TID 0000.0001) %MON dynstat_salt_del2            =   5.2572504735416E-04
 (PID.TID 0000.0001) %MON forcing_qnet_max             =   6.8114117795321E+02
-(PID.TID 0000.0001) %MON forcing_qnet_min             =  -3.1494305800167E+02
+(PID.TID 0000.0001) %MON forcing_qnet_min             =  -3.1494305800166E+02
 (PID.TID 0000.0001) %MON forcing_qnet_mean            =  -2.6000732229865E+01
 (PID.TID 0000.0001) %MON forcing_qnet_sd              =   1.6029829201219E+02
-(PID.TID 0000.0001) %MON forcing_qnet_del2            =   1.0312900226910E+00
+(PID.TID 0000.0001) %MON forcing_qnet_del2            =   1.0312900226907E+00
 (PID.TID 0000.0001) %MON forcing_qsw_max              =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON forcing_qsw_min              =  -3.0187928232211E+02
 (PID.TID 0000.0001) %MON forcing_qsw_mean             =  -1.8594494422320E+02
 (PID.TID 0000.0001) %MON forcing_qsw_sd               =   7.8977862412479E+01
 (PID.TID 0000.0001) %MON forcing_qsw_del2             =   1.1028061737212E-01
-(PID.TID 0000.0001) %MON forcing_empmr_max            =   1.6301881578001E-03
+(PID.TID 0000.0001) %MON forcing_empmr_max            =   1.6301881578003E-03
 (PID.TID 0000.0001) %MON forcing_empmr_min            =  -4.4998185712268E-04
-(PID.TID 0000.0001) %MON forcing_empmr_mean           =   2.0836607240237E-05
-(PID.TID 0000.0001) %MON forcing_empmr_sd             =   1.6001927348733E-04
-(PID.TID 0000.0001) %MON forcing_empmr_del2           =   2.0472611134098E-06
+(PID.TID 0000.0001) %MON forcing_empmr_mean           =   2.0836607240236E-05
+(PID.TID 0000.0001) %MON forcing_empmr_sd             =   1.6001927348731E-04
+(PID.TID 0000.0001) %MON forcing_empmr_del2           =   2.0472611134052E-06
 (PID.TID 0000.0001) %MON forcing_fu_max               =   2.4746198790331E-01
 (PID.TID 0000.0001) %MON forcing_fu_min               =  -2.1236929972025E-01
-(PID.TID 0000.0001) %MON forcing_fu_mean              =  -4.3930421616766E-03
-(PID.TID 0000.0001) %MON forcing_fu_sd                =   6.3996952183217E-02
-(PID.TID 0000.0001) %MON forcing_fu_del2              =   2.0640984713816E-04
+(PID.TID 0000.0001) %MON forcing_fu_mean              =  -4.3930421616753E-03
+(PID.TID 0000.0001) %MON forcing_fu_sd                =   6.3996952183218E-02
+(PID.TID 0000.0001) %MON forcing_fu_del2              =   2.0640984713827E-04
 (PID.TID 0000.0001) %MON forcing_fv_max               =   2.6086070515377E-01
 (PID.TID 0000.0001) %MON forcing_fv_min               =  -3.2928363582178E-01
-(PID.TID 0000.0001) %MON forcing_fv_mean              =  -1.3690788591846E-02
+(PID.TID 0000.0001) %MON forcing_fv_mean              =  -1.3690788591847E-02
 (PID.TID 0000.0001) %MON forcing_fv_sd                =   7.5311085550732E-02
-(PID.TID 0000.0001) %MON forcing_fv_del2              =   2.3487386222695E-04
-(PID.TID 0000.0001) %MON trAdv_CFL_u_max              =   2.9518784030454E-02
-(PID.TID 0000.0001) %MON trAdv_CFL_v_max              =   4.1208641086279E-02
-(PID.TID 0000.0001) %MON trAdv_CFL_w_max              =   1.4541304440886E-01
-(PID.TID 0000.0001) %MON advcfl_uvel_max              =   2.5031597579851E-02
-(PID.TID 0000.0001) %MON advcfl_vvel_max              =   3.2492468710833E-02
-(PID.TID 0000.0001) %MON advcfl_wvel_max              =   1.5923411534856E-01
-(PID.TID 0000.0001) %MON advcfl_W_hf_max              =   1.7595114651145E-01
-(PID.TID 0000.0001) %MON pe_b_mean                    =   1.3494867758267E-02
-(PID.TID 0000.0001) %MON ke_max                       =   4.4061204390488E-03
-(PID.TID 0000.0001) %MON ke_mean                      =   1.6180088563558E-05
+(PID.TID 0000.0001) %MON forcing_fv_del2              =   2.3487386222672E-04
+(PID.TID 0000.0001) %MON trAdv_CFL_u_max              =   2.9518784030537E-02
+(PID.TID 0000.0001) %MON trAdv_CFL_v_max              =   4.1208641086319E-02
+(PID.TID 0000.0001) %MON trAdv_CFL_w_max              =   1.4541304440894E-01
+(PID.TID 0000.0001) %MON advcfl_uvel_max              =   2.5031597579884E-02
+(PID.TID 0000.0001) %MON advcfl_vvel_max              =   3.2492468710840E-02
+(PID.TID 0000.0001) %MON advcfl_wvel_max              =   1.5923411534864E-01
+(PID.TID 0000.0001) %MON advcfl_W_hf_max              =   1.7595114651154E-01
+(PID.TID 0000.0001) %MON pe_b_mean                    =   1.3494867758269E-02
+(PID.TID 0000.0001) %MON ke_max                       =   4.4061204390507E-03
+(PID.TID 0000.0001) %MON ke_mean                      =   1.6180088563557E-05
 (PID.TID 0000.0001) %MON ke_vol                       =   1.3604162107947E+22
-(PID.TID 0000.0001) %MON vort_r_min                   =  -5.6691713457462E-07
-(PID.TID 0000.0001) %MON vort_r_max                   =   5.8099321369163E-07
+(PID.TID 0000.0001) %MON vort_r_min                   =  -5.6691713457370E-07
+(PID.TID 0000.0001) %MON vort_r_max                   =   5.8099321369328E-07
 (PID.TID 0000.0001) %MON vort_a_mean                  =  -2.0556865257794E-05
 (PID.TID 0000.0001) %MON vort_a_sd                    =   7.5247344330272E-05
 (PID.TID 0000.0001) %MON vort_p_mean                  =  -2.4859215101150E-05
 (PID.TID 0000.0001) %MON vort_p_sd                    =   1.2920355596374E-04
-(PID.TID 0000.0001) %MON surfExpan_theta_mean         =   9.2670154062557E-03
-(PID.TID 0000.0001) %MON surfExpan_salt_mean          =  -6.1896945178397E-03
+(PID.TID 0000.0001) %MON surfExpan_theta_mean         =   9.2670154059678E-03
+(PID.TID 0000.0001) %MON surfExpan_salt_mean          =  -6.1896945177679E-03
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // End MONITOR dynamic field statistics
 (PID.TID 0000.0001) // =======================================================
@@ -3865,124 +3865,124 @@ listId=   2 ; file name: seaiceStDiag
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) %MON seaice_tsnumber              =                     4
 (PID.TID 0000.0001) %MON seaice_time_sec              =   3.4560000000000E+05
-(PID.TID 0000.0001) %MON seaice_uice_max              =   1.0866972264832E-01
-(PID.TID 0000.0001) %MON seaice_uice_min              =  -1.9592069028591E-01
-(PID.TID 0000.0001) %MON seaice_uice_mean             =  -2.7035898022202E-04
-(PID.TID 0000.0001) %MON seaice_uice_sd               =   9.5886716569623E-03
-(PID.TID 0000.0001) %MON seaice_uice_del2             =   1.8776172859400E-04
-(PID.TID 0000.0001) %MON seaice_vice_max              =   1.5194283551967E-01
-(PID.TID 0000.0001) %MON seaice_vice_min              =  -1.6374102802466E-01
-(PID.TID 0000.0001) %MON seaice_vice_mean             =   9.6336397612057E-04
-(PID.TID 0000.0001) %MON seaice_vice_sd               =   1.4142746494839E-02
-(PID.TID 0000.0001) %MON seaice_vice_del2             =   1.1597772031649E-04
-(PID.TID 0000.0001) %MON seaice_area_max              =   7.8638852378632E-01
+(PID.TID 0000.0001) %MON seaice_uice_max              =   1.0866972264788E-01
+(PID.TID 0000.0001) %MON seaice_uice_min              =  -1.9592069028033E-01
+(PID.TID 0000.0001) %MON seaice_uice_mean             =  -2.7035898024298E-04
+(PID.TID 0000.0001) %MON seaice_uice_sd               =   9.5886716567609E-03
+(PID.TID 0000.0001) %MON seaice_uice_del2             =   1.8776172858960E-04
+(PID.TID 0000.0001) %MON seaice_vice_max              =   1.5194283551779E-01
+(PID.TID 0000.0001) %MON seaice_vice_min              =  -1.6374102803558E-01
+(PID.TID 0000.0001) %MON seaice_vice_mean             =   9.6336397611899E-04
+(PID.TID 0000.0001) %MON seaice_vice_sd               =   1.4142746494846E-02
+(PID.TID 0000.0001) %MON seaice_vice_del2             =   1.1597772031251E-04
+(PID.TID 0000.0001) %MON seaice_area_max              =   7.8638852378381E-01
 (PID.TID 0000.0001) %MON seaice_area_min              =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON seaice_area_mean             =   1.3342644022997E-02
-(PID.TID 0000.0001) %MON seaice_area_sd               =   9.2047062971157E-02
-(PID.TID 0000.0001) %MON seaice_area_del2             =   9.3314977903605E-04
-(PID.TID 0000.0001) %MON seaice_heff_max              =   4.5243194760048E-01
+(PID.TID 0000.0001) %MON seaice_area_mean             =   1.3342644022993E-02
+(PID.TID 0000.0001) %MON seaice_area_sd               =   9.2047062971158E-02
+(PID.TID 0000.0001) %MON seaice_area_del2             =   9.3314977903931E-04
+(PID.TID 0000.0001) %MON seaice_heff_max              =   4.5243194759897E-01
 (PID.TID 0000.0001) %MON seaice_heff_min              =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON seaice_heff_mean             =   7.2475978355320E-03
-(PID.TID 0000.0001) %MON seaice_heff_sd               =   5.0573550625033E-02
-(PID.TID 0000.0001) %MON seaice_heff_del2             =   5.0230649034551E-04
-(PID.TID 0000.0001) %MON seaice_hsnow_max             =   3.4944226281209E-03
+(PID.TID 0000.0001) %MON seaice_heff_mean             =   7.2475978355319E-03
+(PID.TID 0000.0001) %MON seaice_heff_sd               =   5.0573550625040E-02
+(PID.TID 0000.0001) %MON seaice_heff_del2             =   5.0230649034686E-04
+(PID.TID 0000.0001) %MON seaice_hsnow_max             =   3.4944226281229E-03
 (PID.TID 0000.0001) %MON seaice_hsnow_min             =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON seaice_hsnow_mean            =   3.2241768871490E-05
-(PID.TID 0000.0001) %MON seaice_hsnow_sd              =   2.6095145919640E-04
-(PID.TID 0000.0001) %MON seaice_hsnow_del2            =   4.3944604767615E-06
+(PID.TID 0000.0001) %MON seaice_hsnow_mean            =   3.2241768871504E-05
+(PID.TID 0000.0001) %MON seaice_hsnow_sd              =   2.6095145919645E-04
+(PID.TID 0000.0001) %MON seaice_hsnow_del2            =   4.3944604767628E-06
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // End MONITOR SEAICE statistics
 (PID.TID 0000.0001) // =======================================================
  EXTERNAL_FIELDS_LOAD,         4 : iP,iLd,i0,i1=   12    1   12    1 ; Wght=  0.3666666667  0.6333333333
  SEAICE_LSR: Residual Initial ipass,Uice,Vice=         1  4.38929285E-04  3.69279998E-04
- SEAICE_LSR (ipass=        1) iters,dU,Resid=       12  5.95190564E-13  5.06879933E-19
- SEAICE_LSR (ipass=        1) iters,dV,Resid=       12  8.63614735E-14  9.29870583E-19
+ SEAICE_LSR (ipass=        1) iters,dU,Resid=       12  5.95190564E-13  6.48799649E-19
+ SEAICE_LSR (ipass=        1) iters,dV,Resid=       12  8.63475957E-14  8.02719312E-19
  SEAICE_LSR: Residual Initial ipass,Uice,Vice=         2  5.39902623E-04  1.18448062E-04
- SEAICE_LSR (ipass=        2) iters,dU,Resid=       12  9.51183576E-14  4.86777810E-19
- SEAICE_LSR (ipass=        2) iters,dV,Resid=       12  3.59434704E-14  6.22310791E-19
- cg2d: Sum(rhs),rhsMax =   2.26702155328334E-01  1.98977556593965E+01
-(PID.TID 0000.0001)      cg2d_init_res =   8.14397760322875E-02
+ SEAICE_LSR (ipass=        2) iters,dU,Resid=       12  9.51183576E-14  2.50933680E-19
+ SEAICE_LSR (ipass=        2) iters,dV,Resid=       12  3.59434704E-14  6.34693024E-19
+ cg2d: Sum(rhs),rhsMax =   2.26702155328335E-01  1.98977556593952E+01
+(PID.TID 0000.0001)      cg2d_init_res =   8.14397760343671E-02
 (PID.TID 0000.0001)      cg2d_iters(min,last) =      -1     102
-(PID.TID 0000.0001)      cg2d_last_res =   8.63624714622198E-10
+(PID.TID 0000.0001)      cg2d_last_res =   8.63622643300048E-10
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // Begin MONITOR dynamic field statistics
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) %MON time_tsnumber                =                     5
 (PID.TID 0000.0001) %MON time_secondsf                =   4.3200000000000E+05
-(PID.TID 0000.0001) %MON dynstat_eta_max              =   1.3211580945173E+04
-(PID.TID 0000.0001) %MON dynstat_eta_min              =  -2.3568642266911E+04
+(PID.TID 0000.0001) %MON dynstat_eta_max              =   1.3211580945156E+04
+(PID.TID 0000.0001) %MON dynstat_eta_min              =  -2.3568642266917E+04
 (PID.TID 0000.0001) %MON dynstat_eta_mean             =  -6.8120878909310E+01
-(PID.TID 0000.0001) %MON dynstat_eta_sd               =   7.4387652472723E+03
-(PID.TID 0000.0001) %MON dynstat_eta_del2             =   9.3724904718523E+01
-(PID.TID 0000.0001) %MON dynstat_uvel_max             =   8.4685835919678E-02
-(PID.TID 0000.0001) %MON dynstat_uvel_min             =  -9.9975632962648E-02
-(PID.TID 0000.0001) %MON dynstat_uvel_mean            =  -3.9417945554047E-04
-(PID.TID 0000.0001) %MON dynstat_uvel_sd              =   5.0192208923170E-03
-(PID.TID 0000.0001) %MON dynstat_uvel_del2            =   2.6360475851171E-05
-(PID.TID 0000.0001) %MON dynstat_vvel_max             =   1.3874516759779E-01
-(PID.TID 0000.0001) %MON dynstat_vvel_min             =  -1.2778920497439E-01
-(PID.TID 0000.0001) %MON dynstat_vvel_mean            =  -3.9198056645777E-04
-(PID.TID 0000.0001) %MON dynstat_vvel_sd              =   5.1490962113437E-03
-(PID.TID 0000.0001) %MON dynstat_vvel_del2            =   2.7544634649433E-05
-(PID.TID 0000.0001) %MON dynstat_wvel_max             =   4.1196706253561E+00
-(PID.TID 0000.0001) %MON dynstat_wvel_min             =  -6.8473964874039E+00
-(PID.TID 0000.0001) %MON dynstat_wvel_mean            =   9.9320639226945E-06
-(PID.TID 0000.0001) %MON dynstat_wvel_sd              =   1.9087084979243E-01
-(PID.TID 0000.0001) %MON dynstat_wvel_del2            =   1.5406269155604E-03
+(PID.TID 0000.0001) %MON dynstat_eta_sd               =   7.4387652472743E+03
+(PID.TID 0000.0001) %MON dynstat_eta_del2             =   9.3724904718754E+01
+(PID.TID 0000.0001) %MON dynstat_uvel_max             =   8.4685835919670E-02
+(PID.TID 0000.0001) %MON dynstat_uvel_min             =  -9.9975632962618E-02
+(PID.TID 0000.0001) %MON dynstat_uvel_mean            =  -3.9417945553902E-04
+(PID.TID 0000.0001) %MON dynstat_uvel_sd              =   5.0192208923168E-03
+(PID.TID 0000.0001) %MON dynstat_uvel_del2            =   2.6360475851169E-05
+(PID.TID 0000.0001) %MON dynstat_vvel_max             =   1.3874516759782E-01
+(PID.TID 0000.0001) %MON dynstat_vvel_min             =  -1.2778920497438E-01
+(PID.TID 0000.0001) %MON dynstat_vvel_mean            =  -3.9198056645750E-04
+(PID.TID 0000.0001) %MON dynstat_vvel_sd              =   5.1490962113438E-03
+(PID.TID 0000.0001) %MON dynstat_vvel_del2            =   2.7544634649439E-05
+(PID.TID 0000.0001) %MON dynstat_wvel_max             =   4.1196706253559E+00
+(PID.TID 0000.0001) %MON dynstat_wvel_min             =  -6.8473964874055E+00
+(PID.TID 0000.0001) %MON dynstat_wvel_mean            =   9.9320639255996E-06
+(PID.TID 0000.0001) %MON dynstat_wvel_sd              =   1.9087084979239E-01
+(PID.TID 0000.0001) %MON dynstat_wvel_del2            =   1.5406269155600E-03
 (PID.TID 0000.0001) %MON dynstat_theta_max            =   2.9421633528843E+01
-(PID.TID 0000.0001) %MON dynstat_theta_min            =  -1.8949180193621E+00
+(PID.TID 0000.0001) %MON dynstat_theta_min            =  -1.8949180193622E+00
 (PID.TID 0000.0001) %MON dynstat_theta_mean           =   3.5917874016039E+00
 (PID.TID 0000.0001) %MON dynstat_theta_sd             =   4.4278777541926E+00
-(PID.TID 0000.0001) %MON dynstat_theta_del2           =   2.2608157287418E-03
+(PID.TID 0000.0001) %MON dynstat_theta_del2           =   2.2608157287417E-03
 (PID.TID 0000.0001) %MON dynstat_salt_max             =   4.0715833864089E+01
-(PID.TID 0000.0001) %MON dynstat_salt_min             =   1.7267720604630E+01
+(PID.TID 0000.0001) %MON dynstat_salt_min             =   1.7267720604628E+01
 (PID.TID 0000.0001) %MON dynstat_salt_mean            =   3.4721507077661E+01
 (PID.TID 0000.0001) %MON dynstat_salt_sd              =   4.8741110461664E-01
-(PID.TID 0000.0001) %MON dynstat_salt_del2            =   5.2158271367367E-04
-(PID.TID 0000.0001) %MON forcing_qnet_max             =   1.2842316165518E+03
-(PID.TID 0000.0001) %MON forcing_qnet_min             =  -3.1401608637906E+02
-(PID.TID 0000.0001) %MON forcing_qnet_mean            =  -2.5273152836730E+01
-(PID.TID 0000.0001) %MON forcing_qnet_sd              =   1.6348553615543E+02
+(PID.TID 0000.0001) %MON dynstat_salt_del2            =   5.2158271367364E-04
+(PID.TID 0000.0001) %MON forcing_qnet_max             =   1.2842316165516E+03
+(PID.TID 0000.0001) %MON forcing_qnet_min             =  -3.1401608637907E+02
+(PID.TID 0000.0001) %MON forcing_qnet_mean            =  -2.5273152836729E+01
+(PID.TID 0000.0001) %MON forcing_qnet_sd              =   1.6348553615544E+02
 (PID.TID 0000.0001) %MON forcing_qnet_del2            =   1.1719737120808E+00
 (PID.TID 0000.0001) %MON forcing_qsw_max              =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON forcing_qsw_min              =  -3.0186728538630E+02
 (PID.TID 0000.0001) %MON forcing_qsw_mean             =  -1.8595109436249E+02
 (PID.TID 0000.0001) %MON forcing_qsw_sd               =   7.8872389113827E+01
 (PID.TID 0000.0001) %MON forcing_qsw_del2             =   1.1030265382505E-01
-(PID.TID 0000.0001) %MON forcing_empmr_max            =   1.8716040657983E-03
-(PID.TID 0000.0001) %MON forcing_empmr_min            =  -2.8938035640616E-03
+(PID.TID 0000.0001) %MON forcing_empmr_max            =   1.8716040657982E-03
+(PID.TID 0000.0001) %MON forcing_empmr_min            =  -2.8938035640607E-03
 (PID.TID 0000.0001) %MON forcing_empmr_mean           =   1.2273598864759E-05
-(PID.TID 0000.0001) %MON forcing_empmr_sd             =   1.5587990603680E-04
-(PID.TID 0000.0001) %MON forcing_empmr_del2           =   3.3105429035549E-06
+(PID.TID 0000.0001) %MON forcing_empmr_sd             =   1.5587990603686E-04
+(PID.TID 0000.0001) %MON forcing_empmr_del2           =   3.3105429035541E-06
 (PID.TID 0000.0001) %MON forcing_fu_max               =   2.4741393863310E-01
 (PID.TID 0000.0001) %MON forcing_fu_min               =  -2.1551509637860E-01
-(PID.TID 0000.0001) %MON forcing_fu_mean              =  -4.3401455508741E-03
+(PID.TID 0000.0001) %MON forcing_fu_mean              =  -4.3401455508744E-03
 (PID.TID 0000.0001) %MON forcing_fu_sd                =   6.4043521000846E-02
-(PID.TID 0000.0001) %MON forcing_fu_del2              =   2.0725425058945E-04
+(PID.TID 0000.0001) %MON forcing_fu_del2              =   2.0725425058944E-04
 (PID.TID 0000.0001) %MON forcing_fv_max               =   2.6354394672640E-01
 (PID.TID 0000.0001) %MON forcing_fv_min               =  -3.3007153975572E-01
 (PID.TID 0000.0001) %MON forcing_fv_mean              =  -1.3692878639289E-02
 (PID.TID 0000.0001) %MON forcing_fv_sd                =   7.5385099808090E-02
-(PID.TID 0000.0001) %MON forcing_fv_del2              =   2.3568023791271E-04
-(PID.TID 0000.0001) %MON trAdv_CFL_u_max              =   3.6223042343788E-02
-(PID.TID 0000.0001) %MON trAdv_CFL_v_max              =   5.0257847721942E-02
-(PID.TID 0000.0001) %MON trAdv_CFL_w_max              =   1.7657325964949E-01
-(PID.TID 0000.0001) %MON advcfl_uvel_max              =   3.0804999826183E-02
-(PID.TID 0000.0001) %MON advcfl_vvel_max              =   3.9223493703779E-02
-(PID.TID 0000.0001) %MON advcfl_wvel_max              =   1.9336647336477E-01
-(PID.TID 0000.0001) %MON advcfl_W_hf_max              =   2.1365529897879E-01
-(PID.TID 0000.0001) %MON pe_b_mean                    =   1.3562755341100E-02
-(PID.TID 0000.0001) %MON ke_max                       =   6.4891860722998E-03
-(PID.TID 0000.0001) %MON ke_mean                      =   2.4016547148545E-05
+(PID.TID 0000.0001) %MON forcing_fv_del2              =   2.3568023791268E-04
+(PID.TID 0000.0001) %MON trAdv_CFL_u_max              =   3.6223042343877E-02
+(PID.TID 0000.0001) %MON trAdv_CFL_v_max              =   5.0257847721963E-02
+(PID.TID 0000.0001) %MON trAdv_CFL_w_max              =   1.7657325964955E-01
+(PID.TID 0000.0001) %MON advcfl_uvel_max              =   3.0804999826202E-02
+(PID.TID 0000.0001) %MON advcfl_vvel_max              =   3.9223493703787E-02
+(PID.TID 0000.0001) %MON advcfl_wvel_max              =   1.9336647336483E-01
+(PID.TID 0000.0001) %MON advcfl_W_hf_max              =   2.1365529897886E-01
+(PID.TID 0000.0001) %MON pe_b_mean                    =   1.3562755341104E-02
+(PID.TID 0000.0001) %MON ke_max                       =   6.4891860723009E-03
+(PID.TID 0000.0001) %MON ke_mean                      =   2.4016547148544E-05
 (PID.TID 0000.0001) %MON ke_vol                       =   1.3604155681425E+22
-(PID.TID 0000.0001) %MON vort_r_min                   =  -5.8033803657107E-07
-(PID.TID 0000.0001) %MON vort_r_max                   =   6.2817306900348E-07
+(PID.TID 0000.0001) %MON vort_r_min                   =  -5.8033803657097E-07
+(PID.TID 0000.0001) %MON vort_r_max                   =   6.2817306900739E-07
 (PID.TID 0000.0001) %MON vort_a_mean                  =  -2.0556865257795E-05
 (PID.TID 0000.0001) %MON vort_a_sd                    =   7.5247364060065E-05
 (PID.TID 0000.0001) %MON vort_p_mean                  =  -2.4859218018146E-05
 (PID.TID 0000.0001) %MON vort_p_sd                    =   1.2920533582752E-04
-(PID.TID 0000.0001) %MON surfExpan_theta_mean         =   6.3768200902348E-03
-(PID.TID 0000.0001) %MON surfExpan_salt_mean          =  -3.8036807426203E-03
+(PID.TID 0000.0001) %MON surfExpan_theta_mean         =   6.3768200903091E-03
+(PID.TID 0000.0001) %MON surfExpan_salt_mean          =  -3.8036807426282E-03
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // End MONITOR dynamic field statistics
 (PID.TID 0000.0001) // =======================================================
@@ -3991,80 +3991,80 @@ listId=   2 ; file name: seaiceStDiag
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) %MON seaice_tsnumber              =                     5
 (PID.TID 0000.0001) %MON seaice_time_sec              =   4.3200000000000E+05
-(PID.TID 0000.0001) %MON seaice_uice_max              =   1.2618769052764E-01
-(PID.TID 0000.0001) %MON seaice_uice_min              =  -2.0838387131850E-01
-(PID.TID 0000.0001) %MON seaice_uice_mean             =  -4.8825479332740E-04
-(PID.TID 0000.0001) %MON seaice_uice_sd               =   1.1887054972255E-02
-(PID.TID 0000.0001) %MON seaice_uice_del2             =   1.7521242942286E-04
-(PID.TID 0000.0001) %MON seaice_vice_max              =   1.5360963274694E-01
-(PID.TID 0000.0001) %MON seaice_vice_min              =  -1.5988460521131E-01
-(PID.TID 0000.0001) %MON seaice_vice_mean             =   1.0557321707334E-03
-(PID.TID 0000.0001) %MON seaice_vice_sd               =   1.5011525084912E-02
-(PID.TID 0000.0001) %MON seaice_vice_del2             =   1.1222778395468E-04
-(PID.TID 0000.0001) %MON seaice_area_max              =   8.6147320365818E-01
+(PID.TID 0000.0001) %MON seaice_uice_max              =   1.2618769052623E-01
+(PID.TID 0000.0001) %MON seaice_uice_min              =  -2.0838387131890E-01
+(PID.TID 0000.0001) %MON seaice_uice_mean             =  -4.8825479332971E-04
+(PID.TID 0000.0001) %MON seaice_uice_sd               =   1.1887054972207E-02
+(PID.TID 0000.0001) %MON seaice_uice_del2             =   1.7521242942213E-04
+(PID.TID 0000.0001) %MON seaice_vice_max              =   1.5360963274701E-01
+(PID.TID 0000.0001) %MON seaice_vice_min              =  -1.5988460521002E-01
+(PID.TID 0000.0001) %MON seaice_vice_mean             =   1.0557321707315E-03
+(PID.TID 0000.0001) %MON seaice_vice_sd               =   1.5011525084907E-02
+(PID.TID 0000.0001) %MON seaice_vice_del2             =   1.1222778395352E-04
+(PID.TID 0000.0001) %MON seaice_area_max              =   8.6147320365639E-01
 (PID.TID 0000.0001) %MON seaice_area_min              =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON seaice_area_mean             =   1.5637778361571E-02
-(PID.TID 0000.0001) %MON seaice_area_sd               =   1.0593989856836E-01
-(PID.TID 0000.0001) %MON seaice_area_del2             =   8.3973554828450E-04
-(PID.TID 0000.0001) %MON seaice_heff_max              =   5.1946745261479E-01
+(PID.TID 0000.0001) %MON seaice_area_mean             =   1.5637778361567E-02
+(PID.TID 0000.0001) %MON seaice_area_sd               =   1.0593989856834E-01
+(PID.TID 0000.0001) %MON seaice_area_del2             =   8.3973554828594E-04
+(PID.TID 0000.0001) %MON seaice_heff_max              =   5.1946745261351E-01
 (PID.TID 0000.0001) %MON seaice_heff_min              =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON seaice_heff_mean             =   8.6433266563226E-03
-(PID.TID 0000.0001) %MON seaice_heff_sd               =   5.9723348107684E-02
-(PID.TID 0000.0001) %MON seaice_heff_del2             =   4.5872954421272E-04
-(PID.TID 0000.0001) %MON seaice_hsnow_max             =   6.0910545521898E-03
+(PID.TID 0000.0001) %MON seaice_heff_mean             =   8.6433266563225E-03
+(PID.TID 0000.0001) %MON seaice_heff_sd               =   5.9723348107686E-02
+(PID.TID 0000.0001) %MON seaice_heff_del2             =   4.5872954421379E-04
+(PID.TID 0000.0001) %MON seaice_hsnow_max             =   6.0910545521926E-03
 (PID.TID 0000.0001) %MON seaice_hsnow_min             =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON seaice_hsnow_mean            =   5.3594718191971E-05
-(PID.TID 0000.0001) %MON seaice_hsnow_sd              =   4.2156702627010E-04
-(PID.TID 0000.0001) %MON seaice_hsnow_del2            =   5.9156019710790E-06
+(PID.TID 0000.0001) %MON seaice_hsnow_mean            =   5.3594718191975E-05
+(PID.TID 0000.0001) %MON seaice_hsnow_sd              =   4.2156702627013E-04
+(PID.TID 0000.0001) %MON seaice_hsnow_del2            =   5.9156019710840E-06
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // End MONITOR SEAICE statistics
 (PID.TID 0000.0001) // =======================================================
  EXTERNAL_FIELDS_LOAD,         5 : iP,iLd,i0,i1=   12    1   12    1 ; Wght=  0.3333333333  0.6666666667
  SEAICE_LSR: Residual Initial ipass,Uice,Vice=         1  4.96509922E-03  6.36071578E-04
- SEAICE_LSR (ipass=        1) iters,dU,Resid=       14  3.02535774E-15  2.14782244E-18
- SEAICE_LSR (ipass=        1) iters,dV,Resid=       14  9.64228697E-14  2.62721357E-18
+ SEAICE_LSR (ipass=        1) iters,dU,Resid=       14  3.03923553E-15  2.26831842E-18
+ SEAICE_LSR (ipass=        1) iters,dV,Resid=       14  9.64228697E-14  2.76349811E-18
  SEAICE_LSR: Residual Initial ipass,Uice,Vice=         2  2.46644437E-03  2.84151747E-04
- SEAICE_LSR (ipass=        2) iters,dU,Resid=       14  7.28583860E-16  1.10572934E-18
- SEAICE_LSR (ipass=        2) iters,dV,Resid=       14  1.63064007E-14  8.73464691E-19
- cg2d: Sum(rhs),rhsMax =   2.72439013127742E-01  1.98997839252733E+01
-(PID.TID 0000.0001)      cg2d_init_res =   7.52094074296838E-02
+ SEAICE_LSR (ipass=        2) iters,dU,Resid=       14  7.32053307E-16  1.02394523E-18
+ SEAICE_LSR (ipass=        2) iters,dV,Resid=       14  1.63064007E-14  1.09442016E-18
+ cg2d: Sum(rhs),rhsMax =   2.72439013127737E-01  1.98997839252736E+01
+(PID.TID 0000.0001)      cg2d_init_res =   7.52094074276864E-02
 (PID.TID 0000.0001)      cg2d_iters(min,last) =      -1     102
-(PID.TID 0000.0001)      cg2d_last_res =   9.19306358297010E-10
+(PID.TID 0000.0001)      cg2d_last_res =   9.19176887229875E-10
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // Begin MONITOR dynamic field statistics
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) %MON time_tsnumber                =                     6
 (PID.TID 0000.0001) %MON time_secondsf                =   5.1840000000000E+05
-(PID.TID 0000.0001) %MON dynstat_eta_max              =   1.4057155889413E+04
-(PID.TID 0000.0001) %MON dynstat_eta_min              =  -2.3264703812341E+04
-(PID.TID 0000.0001) %MON dynstat_eta_mean             =  -8.1872520246960E+01
-(PID.TID 0000.0001) %MON dynstat_eta_sd               =   7.4014592284851E+03
-(PID.TID 0000.0001) %MON dynstat_eta_del2             =   9.3885786340017E+01
-(PID.TID 0000.0001) %MON dynstat_uvel_max             =   9.8487559228261E-02
-(PID.TID 0000.0001) %MON dynstat_uvel_min             =  -1.1689504436088E-01
-(PID.TID 0000.0001) %MON dynstat_uvel_mean            =  -2.7358383792483E-04
-(PID.TID 0000.0001) %MON dynstat_uvel_sd              =   5.8990343523348E-03
-(PID.TID 0000.0001) %MON dynstat_uvel_del2            =   3.0173858380203E-05
-(PID.TID 0000.0001) %MON dynstat_vvel_max             =   1.5998521835046E-01
-(PID.TID 0000.0001) %MON dynstat_vvel_min             =  -1.4765804978217E-01
-(PID.TID 0000.0001) %MON dynstat_vvel_mean            =  -4.7216312226472E-04
-(PID.TID 0000.0001) %MON dynstat_vvel_sd              =   6.0659651358621E-03
-(PID.TID 0000.0001) %MON dynstat_vvel_del2            =   3.1335740339354E-05
-(PID.TID 0000.0001) %MON dynstat_wvel_max             =   4.6785342141243E+00
-(PID.TID 0000.0001) %MON dynstat_wvel_min             =  -7.9346306922853E+00
-(PID.TID 0000.0001) %MON dynstat_wvel_mean            =  -7.8720856047872E-05
-(PID.TID 0000.0001) %MON dynstat_wvel_sd              =   2.1722408370275E-01
+(PID.TID 0000.0001) %MON dynstat_eta_max              =   1.4057155889424E+04
+(PID.TID 0000.0001) %MON dynstat_eta_min              =  -2.3264703812330E+04
+(PID.TID 0000.0001) %MON dynstat_eta_mean             =  -8.1872520246961E+01
+(PID.TID 0000.0001) %MON dynstat_eta_sd               =   7.4014592284905E+03
+(PID.TID 0000.0001) %MON dynstat_eta_del2             =   9.3885786340847E+01
+(PID.TID 0000.0001) %MON dynstat_uvel_max             =   9.8487559228252E-02
+(PID.TID 0000.0001) %MON dynstat_uvel_min             =  -1.1689504436085E-01
+(PID.TID 0000.0001) %MON dynstat_uvel_mean            =  -2.7358383792327E-04
+(PID.TID 0000.0001) %MON dynstat_uvel_sd              =   5.8990343523346E-03
+(PID.TID 0000.0001) %MON dynstat_uvel_del2            =   3.0173858380202E-05
+(PID.TID 0000.0001) %MON dynstat_vvel_max             =   1.5998521835049E-01
+(PID.TID 0000.0001) %MON dynstat_vvel_min             =  -1.4765804978216E-01
+(PID.TID 0000.0001) %MON dynstat_vvel_mean            =  -4.7216312226430E-04
+(PID.TID 0000.0001) %MON dynstat_vvel_sd              =   6.0659651358622E-03
+(PID.TID 0000.0001) %MON dynstat_vvel_del2            =   3.1335740339359E-05
+(PID.TID 0000.0001) %MON dynstat_wvel_max             =   4.6785342141240E+00
+(PID.TID 0000.0001) %MON dynstat_wvel_min             =  -7.9346306922863E+00
+(PID.TID 0000.0001) %MON dynstat_wvel_mean            =  -7.8720856037632E-05
+(PID.TID 0000.0001) %MON dynstat_wvel_sd              =   2.1722408370271E-01
 (PID.TID 0000.0001) %MON dynstat_wvel_del2            =   1.7188256932951E-03
 (PID.TID 0000.0001) %MON dynstat_theta_max            =   2.9427696569267E+01
 (PID.TID 0000.0001) %MON dynstat_theta_min            =  -1.8898066966984E+00
 (PID.TID 0000.0001) %MON dynstat_theta_mean           =   3.5919528795527E+00
 (PID.TID 0000.0001) %MON dynstat_theta_sd             =   4.4281529223073E+00
-(PID.TID 0000.0001) %MON dynstat_theta_del2           =   2.2973075187058E-03
+(PID.TID 0000.0001) %MON dynstat_theta_del2           =   2.2973075187057E-03
 (PID.TID 0000.0001) %MON dynstat_salt_max             =   4.0715839210819E+01
-(PID.TID 0000.0001) %MON dynstat_salt_min             =   1.6954938101426E+01
+(PID.TID 0000.0001) %MON dynstat_salt_min             =   1.6954938101423E+01
 (PID.TID 0000.0001) %MON dynstat_salt_mean            =   3.4721518790394E+01
 (PID.TID 0000.0001) %MON dynstat_salt_sd              =   4.8733334407440E-01
-(PID.TID 0000.0001) %MON dynstat_salt_del2            =   5.2069854015368E-04
+(PID.TID 0000.0001) %MON dynstat_salt_del2            =   5.2069854015365E-04
 (PID.TID 0000.0001) %MON forcing_qnet_max             =   7.0134346274719E+02
 (PID.TID 0000.0001) %MON forcing_qnet_min             =  -3.1298527138330E+02
 (PID.TID 0000.0001) %MON forcing_qnet_mean            =  -2.7235754739833E+01
@@ -4075,11 +4075,11 @@ listId=   2 ; file name: seaiceStDiag
 (PID.TID 0000.0001) %MON forcing_qsw_mean             =  -1.8595724303901E+02
 (PID.TID 0000.0001) %MON forcing_qsw_sd               =   7.8769620529423E+01
 (PID.TID 0000.0001) %MON forcing_qsw_del2             =   1.1038810628945E-01
-(PID.TID 0000.0001) %MON forcing_empmr_max            =   1.6425831826967E-03
-(PID.TID 0000.0001) %MON forcing_empmr_min            =  -4.5351267256685E-04
-(PID.TID 0000.0001) %MON forcing_empmr_mean           =   1.6224517378395E-05
-(PID.TID 0000.0001) %MON forcing_empmr_sd             =   1.3097512176080E-04
-(PID.TID 0000.0001) %MON forcing_empmr_del2           =   1.9564949718453E-06
+(PID.TID 0000.0001) %MON forcing_empmr_max            =   1.6425831826979E-03
+(PID.TID 0000.0001) %MON forcing_empmr_min            =  -4.5351267256684E-04
+(PID.TID 0000.0001) %MON forcing_empmr_mean           =   1.6224517378397E-05
+(PID.TID 0000.0001) %MON forcing_empmr_sd             =   1.3097512176082E-04
+(PID.TID 0000.0001) %MON forcing_empmr_del2           =   1.9564949718458E-06
 (PID.TID 0000.0001) %MON forcing_fu_max               =   2.4736588936290E-01
 (PID.TID 0000.0001) %MON forcing_fu_min               =  -2.1866089303695E-01
 (PID.TID 0000.0001) %MON forcing_fu_mean              =  -4.2940979585603E-03
@@ -4090,25 +4090,25 @@ listId=   2 ; file name: seaiceStDiag
 (PID.TID 0000.0001) %MON forcing_fv_mean              =  -1.3696257417526E-02
 (PID.TID 0000.0001) %MON forcing_fv_sd                =   7.5466271818169E-02
 (PID.TID 0000.0001) %MON forcing_fv_del2              =   2.3657121260592E-04
-(PID.TID 0000.0001) %MON trAdv_CFL_u_max              =   4.1293657502919E-02
-(PID.TID 0000.0001) %MON trAdv_CFL_v_max              =   5.8428954476825E-02
-(PID.TID 0000.0001) %MON trAdv_CFL_w_max              =   2.0435998247595E-01
-(PID.TID 0000.0001) %MON advcfl_uvel_max              =   3.6038924976986E-02
-(PID.TID 0000.0001) %MON advcfl_vvel_max              =   4.5228091999992E-02
-(PID.TID 0000.0001) %MON advcfl_wvel_max              =   2.2381138177583E-01
-(PID.TID 0000.0001) %MON advcfl_W_hf_max              =   2.4727749400941E-01
-(PID.TID 0000.0001) %MON pe_b_mean                    =   1.3545032825655E-02
-(PID.TID 0000.0001) %MON ke_max                       =   8.7307866889117E-03
-(PID.TID 0000.0001) %MON ke_mean                      =   3.3195262458943E-05
+(PID.TID 0000.0001) %MON trAdv_CFL_u_max              =   4.1293657502974E-02
+(PID.TID 0000.0001) %MON trAdv_CFL_v_max              =   5.8428954476840E-02
+(PID.TID 0000.0001) %MON trAdv_CFL_w_max              =   2.0435998247598E-01
+(PID.TID 0000.0001) %MON advcfl_uvel_max              =   3.6038924976995E-02
+(PID.TID 0000.0001) %MON advcfl_vvel_max              =   4.5228091999998E-02
+(PID.TID 0000.0001) %MON advcfl_wvel_max              =   2.2381138177586E-01
+(PID.TID 0000.0001) %MON advcfl_W_hf_max              =   2.4727749400945E-01
+(PID.TID 0000.0001) %MON pe_b_mean                    =   1.3545032825667E-02
+(PID.TID 0000.0001) %MON ke_max                       =   8.7307866889125E-03
+(PID.TID 0000.0001) %MON ke_mean                      =   3.3195262458942E-05
 (PID.TID 0000.0001) %MON ke_vol                       =   1.3604151895946E+22
-(PID.TID 0000.0001) %MON vort_r_min                   =  -5.8446061772968E-07
-(PID.TID 0000.0001) %MON vort_r_max                   =   6.8231946581954E-07
+(PID.TID 0000.0001) %MON vort_r_min                   =  -5.8446061772980E-07
+(PID.TID 0000.0001) %MON vort_r_max                   =   6.8231946582181E-07
 (PID.TID 0000.0001) %MON vort_a_mean                  =  -2.0556865257795E-05
 (PID.TID 0000.0001) %MON vort_a_sd                    =   7.5247389189874E-05
 (PID.TID 0000.0001) %MON vort_p_mean                  =  -2.4859223237139E-05
 (PID.TID 0000.0001) %MON vort_p_sd                    =   1.2920599715590E-04
-(PID.TID 0000.0001) %MON surfExpan_theta_mean         =   3.9645607930131E-03
-(PID.TID 0000.0001) %MON surfExpan_salt_mean          =  -5.3234105819177E-03
+(PID.TID 0000.0001) %MON surfExpan_theta_mean         =   3.9645607930808E-03
+(PID.TID 0000.0001) %MON surfExpan_salt_mean          =  -5.3234105819413E-03
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // End MONITOR dynamic field statistics
 (PID.TID 0000.0001) // =======================================================
@@ -4117,81 +4117,81 @@ listId=   2 ; file name: seaiceStDiag
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) %MON seaice_tsnumber              =                     6
 (PID.TID 0000.0001) %MON seaice_time_sec              =   5.1840000000000E+05
-(PID.TID 0000.0001) %MON seaice_uice_max              =   1.8111681057988E-01
-(PID.TID 0000.0001) %MON seaice_uice_min              =  -2.1854009504565E-01
-(PID.TID 0000.0001) %MON seaice_uice_mean             =  -3.0158032194565E-04
-(PID.TID 0000.0001) %MON seaice_uice_sd               =   1.1275187417632E-02
-(PID.TID 0000.0001) %MON seaice_uice_del2             =   1.7289277121604E-04
-(PID.TID 0000.0001) %MON seaice_vice_max              =   1.6193603638015E-01
-(PID.TID 0000.0001) %MON seaice_vice_min              =  -1.6608821342790E-01
-(PID.TID 0000.0001) %MON seaice_vice_mean             =   1.0610235050064E-03
-(PID.TID 0000.0001) %MON seaice_vice_sd               =   1.5329213121624E-02
-(PID.TID 0000.0001) %MON seaice_vice_del2             =   1.1526292393073E-04
-(PID.TID 0000.0001) %MON seaice_area_max              =   9.1248316203734E-01
+(PID.TID 0000.0001) %MON seaice_uice_max              =   1.8111681057992E-01
+(PID.TID 0000.0001) %MON seaice_uice_min              =  -2.1854009504588E-01
+(PID.TID 0000.0001) %MON seaice_uice_mean             =  -3.0158032194401E-04
+(PID.TID 0000.0001) %MON seaice_uice_sd               =   1.1275187417618E-02
+(PID.TID 0000.0001) %MON seaice_uice_del2             =   1.7289277121479E-04
+(PID.TID 0000.0001) %MON seaice_vice_max              =   1.6193603638008E-01
+(PID.TID 0000.0001) %MON seaice_vice_min              =  -1.6608821342782E-01
+(PID.TID 0000.0001) %MON seaice_vice_mean             =   1.0610235050048E-03
+(PID.TID 0000.0001) %MON seaice_vice_sd               =   1.5329213121620E-02
+(PID.TID 0000.0001) %MON seaice_vice_del2             =   1.1526292392964E-04
+(PID.TID 0000.0001) %MON seaice_area_max              =   9.1248316203633E-01
 (PID.TID 0000.0001) %MON seaice_area_min              =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON seaice_area_mean             =   1.8118420550270E-02
-(PID.TID 0000.0001) %MON seaice_area_sd               =   1.1845487214509E-01
-(PID.TID 0000.0001) %MON seaice_area_del2             =   9.0889324214201E-04
-(PID.TID 0000.0001) %MON seaice_heff_max              =   5.7643416593240E-01
+(PID.TID 0000.0001) %MON seaice_area_mean             =   1.8118420550267E-02
+(PID.TID 0000.0001) %MON seaice_area_sd               =   1.1845487214508E-01
+(PID.TID 0000.0001) %MON seaice_area_del2             =   9.0889324214260E-04
+(PID.TID 0000.0001) %MON seaice_heff_max              =   5.7643416593150E-01
 (PID.TID 0000.0001) %MON seaice_heff_min              =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON seaice_heff_mean             =   1.0411363856771E-02
-(PID.TID 0000.0001) %MON seaice_heff_sd               =   6.9189390030859E-02
-(PID.TID 0000.0001) %MON seaice_heff_del2             =   4.9636538841709E-04
-(PID.TID 0000.0001) %MON seaice_hsnow_max             =   8.9803073411800E-03
+(PID.TID 0000.0001) %MON seaice_heff_mean             =   1.0411363856772E-02
+(PID.TID 0000.0001) %MON seaice_heff_sd               =   6.9189390030860E-02
+(PID.TID 0000.0001) %MON seaice_heff_del2             =   4.9636538841772E-04
+(PID.TID 0000.0001) %MON seaice_hsnow_max             =   8.9803073411834E-03
 (PID.TID 0000.0001) %MON seaice_hsnow_min             =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON seaice_hsnow_mean            =   8.1221601284076E-05
 (PID.TID 0000.0001) %MON seaice_hsnow_sd              =   6.1936758125957E-04
-(PID.TID 0000.0001) %MON seaice_hsnow_del2            =   8.4229169730900E-06
+(PID.TID 0000.0001) %MON seaice_hsnow_del2            =   8.4229169730962E-06
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // End MONITOR SEAICE statistics
 (PID.TID 0000.0001) // =======================================================
  EXTERNAL_FIELDS_LOAD,         6 : iP,iLd,i0,i1=   12    1   12    1 ; Wght=  0.3000000000  0.7000000000
  SEAICE_LSR: Residual Initial ipass,Uice,Vice=         1  5.97371443E-04  3.72018081E-04
- SEAICE_LSR (ipass=        1) iters,dU,Resid=       18  1.16365251E-14  4.65342303E-17
- SEAICE_LSR (ipass=        1) iters,dV,Resid=       18  3.34329786E-13  8.89180096E-17
+ SEAICE_LSR (ipass=        1) iters,dU,Resid=       18  1.16434640E-14  4.64406518E-17
+ SEAICE_LSR (ipass=        1) iters,dV,Resid=       18  3.34329786E-13  8.89938542E-17
  SEAICE_LSR: Residual Initial ipass,Uice,Vice=         2  6.99880975E-04  1.12510224E-04
- SEAICE_LSR (ipass=        2) iters,dU,Resid=       18  6.33174069E-15  2.72523582E-17
- SEAICE_LSR (ipass=        2) iters,dV,Resid=       18  8.65280070E-14  2.62116493E-17
- cg2d: Sum(rhs),rhsMax =   3.06634963041199E-01  1.99001503625761E+01
-(PID.TID 0000.0001)      cg2d_init_res =   7.39631764739281E-02
+ SEAICE_LSR (ipass=        2) iters,dU,Resid=       18  6.33867958E-15  2.71347430E-17
+ SEAICE_LSR (ipass=        2) iters,dV,Resid=       18  8.65557626E-14  2.57378009E-17
+ cg2d: Sum(rhs),rhsMax =   3.06634963041215E-01  1.99001503625760E+01
+(PID.TID 0000.0001)      cg2d_init_res =   7.39631764792730E-02
 (PID.TID 0000.0001)      cg2d_iters(min,last) =      -1      98
-(PID.TID 0000.0001)      cg2d_last_res =   9.17893734283402E-10
+(PID.TID 0000.0001)      cg2d_last_res =   9.17946400604766E-10
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // Begin MONITOR dynamic field statistics
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) %MON time_tsnumber                =                     7
 (PID.TID 0000.0001) %MON time_secondsf                =   6.0480000000000E+05
-(PID.TID 0000.0001) %MON dynstat_eta_max              =   1.4827165524526E+04
-(PID.TID 0000.0001) %MON dynstat_eta_min              =  -2.2986829846329E+04
-(PID.TID 0000.0001) %MON dynstat_eta_mean             =  -9.2150677020253E+01
-(PID.TID 0000.0001) %MON dynstat_eta_sd               =   7.3336382291826E+03
-(PID.TID 0000.0001) %MON dynstat_eta_del2             =   9.4075399082235E+01
+(PID.TID 0000.0001) %MON dynstat_eta_max              =   1.4827165524534E+04
+(PID.TID 0000.0001) %MON dynstat_eta_min              =  -2.2986829846317E+04
+(PID.TID 0000.0001) %MON dynstat_eta_mean             =  -9.2150677020255E+01
+(PID.TID 0000.0001) %MON dynstat_eta_sd               =   7.3336382291822E+03
+(PID.TID 0000.0001) %MON dynstat_eta_del2             =   9.4075399082326E+01
 (PID.TID 0000.0001) %MON dynstat_uvel_max             =   1.1106571154909E-01
-(PID.TID 0000.0001) %MON dynstat_uvel_min             =  -1.3168196560845E-01
-(PID.TID 0000.0001) %MON dynstat_uvel_mean            =  -1.4535873540697E-04
-(PID.TID 0000.0001) %MON dynstat_uvel_sd              =   6.7487206672972E-03
-(PID.TID 0000.0001) %MON dynstat_uvel_del2            =   3.3411833763980E-05
-(PID.TID 0000.0001) %MON dynstat_vvel_max             =   1.7841901357380E-01
+(PID.TID 0000.0001) %MON dynstat_uvel_min             =  -1.3168196560842E-01
+(PID.TID 0000.0001) %MON dynstat_uvel_mean            =  -1.4535873540564E-04
+(PID.TID 0000.0001) %MON dynstat_uvel_sd              =   6.7487206672971E-03
+(PID.TID 0000.0001) %MON dynstat_uvel_del2            =   3.3411833763977E-05
+(PID.TID 0000.0001) %MON dynstat_vvel_max             =   1.7841901357382E-01
 (PID.TID 0000.0001) %MON dynstat_vvel_min             =  -1.6522613039236E-01
-(PID.TID 0000.0001) %MON dynstat_vvel_mean            =  -5.0414016389313E-04
-(PID.TID 0000.0001) %MON dynstat_vvel_sd              =   6.9504097295048E-03
-(PID.TID 0000.0001) %MON dynstat_vvel_del2            =   3.4543407397895E-05
-(PID.TID 0000.0001) %MON dynstat_wvel_max             =   5.1172760155035E+00
-(PID.TID 0000.0001) %MON dynstat_wvel_min             =  -8.8789946886328E+00
-(PID.TID 0000.0001) %MON dynstat_wvel_mean            =  -5.9788692860846E-05
-(PID.TID 0000.0001) %MON dynstat_wvel_sd              =   2.3891259648827E-01
-(PID.TID 0000.0001) %MON dynstat_wvel_del2            =   1.8536292969527E-03
+(PID.TID 0000.0001) %MON dynstat_vvel_mean            =  -5.0414016389261E-04
+(PID.TID 0000.0001) %MON dynstat_vvel_sd              =   6.9504097295049E-03
+(PID.TID 0000.0001) %MON dynstat_vvel_del2            =   3.4543407397889E-05
+(PID.TID 0000.0001) %MON dynstat_wvel_max             =   5.1172760155033E+00
+(PID.TID 0000.0001) %MON dynstat_wvel_min             =  -8.8789946886332E+00
+(PID.TID 0000.0001) %MON dynstat_wvel_mean            =  -5.9788692875596E-05
+(PID.TID 0000.0001) %MON dynstat_wvel_sd              =   2.3891259648824E-01
+(PID.TID 0000.0001) %MON dynstat_wvel_del2            =   1.8536292969529E-03
 (PID.TID 0000.0001) %MON dynstat_theta_max            =   2.9433386612071E+01
 (PID.TID 0000.0001) %MON dynstat_theta_min            =  -1.8989892286929E+00
 (PID.TID 0000.0001) %MON dynstat_theta_mean           =   3.5921151319385E+00
 (PID.TID 0000.0001) %MON dynstat_theta_sd             =   4.4285838820622E+00
-(PID.TID 0000.0001) %MON dynstat_theta_del2           =   2.2795030341429E-03
+(PID.TID 0000.0001) %MON dynstat_theta_del2           =   2.2795030341427E-03
 (PID.TID 0000.0001) %MON dynstat_salt_max             =   4.0715829698069E+01
-(PID.TID 0000.0001) %MON dynstat_salt_min             =   1.6626710720584E+01
+(PID.TID 0000.0001) %MON dynstat_salt_min             =   1.6626710720585E+01
 (PID.TID 0000.0001) %MON dynstat_salt_mean            =   3.4721527034109E+01
 (PID.TID 0000.0001) %MON dynstat_salt_sd              =   4.8729928124986E-01
-(PID.TID 0000.0001) %MON dynstat_salt_del2            =   5.1614417372780E-04
-(PID.TID 0000.0001) %MON forcing_qnet_max             =   7.0754237038199E+02
+(PID.TID 0000.0001) %MON dynstat_salt_del2            =   5.1614417372782E-04
+(PID.TID 0000.0001) %MON forcing_qnet_max             =   7.0754237038198E+02
 (PID.TID 0000.0001) %MON forcing_qnet_min             =  -3.1225323063257E+02
 (PID.TID 0000.0001) %MON forcing_qnet_mean            =  -2.6791490864668E+01
 (PID.TID 0000.0001) %MON forcing_qnet_sd              =   1.5464059103898E+02
@@ -4201,14 +4201,14 @@ listId=   2 ; file name: seaiceStDiag
 (PID.TID 0000.0001) %MON forcing_qsw_mean             =  -1.8596338967823E+02
 (PID.TID 0000.0001) %MON forcing_qsw_sd               =   7.8669568596166E+01
 (PID.TID 0000.0001) %MON forcing_qsw_del2             =   1.1053681934197E-01
-(PID.TID 0000.0001) %MON forcing_empmr_max            =   1.6338821631089E-03
-(PID.TID 0000.0001) %MON forcing_empmr_min            =  -9.0347183189924E-04
-(PID.TID 0000.0001) %MON forcing_empmr_mean           =   1.2126416701228E-05
-(PID.TID 0000.0001) %MON forcing_empmr_sd             =   1.0980885400492E-04
-(PID.TID 0000.0001) %MON forcing_empmr_del2           =   1.9104589364830E-06
+(PID.TID 0000.0001) %MON forcing_empmr_max            =   1.6338821631088E-03
+(PID.TID 0000.0001) %MON forcing_empmr_min            =  -9.0347183189921E-04
+(PID.TID 0000.0001) %MON forcing_empmr_mean           =   1.2126416701231E-05
+(PID.TID 0000.0001) %MON forcing_empmr_sd             =   1.0980885400494E-04
+(PID.TID 0000.0001) %MON forcing_empmr_del2           =   1.9104589364832E-06
 (PID.TID 0000.0001) %MON forcing_fu_max               =   2.4731784009269E-01
 (PID.TID 0000.0001) %MON forcing_fu_min               =  -2.2180668969530E-01
-(PID.TID 0000.0001) %MON forcing_fu_mean              =  -4.2431933472304E-03
+(PID.TID 0000.0001) %MON forcing_fu_mean              =  -4.2431933472305E-03
 (PID.TID 0000.0001) %MON forcing_fu_sd                =   6.4179084307742E-02
 (PID.TID 0000.0001) %MON forcing_fu_del2              =   2.0949521291298E-04
 (PID.TID 0000.0001) %MON forcing_fv_max               =   2.6891042987167E-01
@@ -4216,25 +4216,25 @@ listId=   2 ; file name: seaiceStDiag
 (PID.TID 0000.0001) %MON forcing_fv_mean              =  -1.3697478643917E-02
 (PID.TID 0000.0001) %MON forcing_fv_sd                =   7.5554869632742E-02
 (PID.TID 0000.0001) %MON forcing_fv_del2              =   2.3767012624216E-04
-(PID.TID 0000.0001) %MON trAdv_CFL_u_max              =   4.4206063243254E-02
-(PID.TID 0000.0001) %MON trAdv_CFL_v_max              =   6.5544197569401E-02
-(PID.TID 0000.0001) %MON trAdv_CFL_w_max              =   2.2824485185863E-01
-(PID.TID 0000.0001) %MON advcfl_uvel_max              =   4.0645563521108E-02
-(PID.TID 0000.0001) %MON advcfl_vvel_max              =   5.0439357108521E-02
-(PID.TID 0000.0001) %MON advcfl_wvel_max              =   2.4998554153183E-01
-(PID.TID 0000.0001) %MON advcfl_W_hf_max              =   2.7617840980581E-01
-(PID.TID 0000.0001) %MON pe_b_mean                    =   1.3519359643328E-02
-(PID.TID 0000.0001) %MON ke_max                       =   1.0997748944714E-02
+(PID.TID 0000.0001) %MON trAdv_CFL_u_max              =   4.4206063243273E-02
+(PID.TID 0000.0001) %MON trAdv_CFL_v_max              =   6.5544197569408E-02
+(PID.TID 0000.0001) %MON trAdv_CFL_w_max              =   2.2824485185864E-01
+(PID.TID 0000.0001) %MON advcfl_uvel_max              =   4.0645563521103E-02
+(PID.TID 0000.0001) %MON advcfl_vvel_max              =   5.0439357108525E-02
+(PID.TID 0000.0001) %MON advcfl_wvel_max              =   2.4998554153184E-01
+(PID.TID 0000.0001) %MON advcfl_W_hf_max              =   2.7617840980583E-01
+(PID.TID 0000.0001) %MON pe_b_mean                    =   1.3519359643327E-02
+(PID.TID 0000.0001) %MON ke_max                       =   1.0997748944715E-02
 (PID.TID 0000.0001) %MON ke_mean                      =   4.3463045382780E-05
 (PID.TID 0000.0001) %MON ke_vol                       =   1.3604146891906E+22
-(PID.TID 0000.0001) %MON vort_r_min                   =  -6.5473874539041E-07
-(PID.TID 0000.0001) %MON vort_r_max                   =   7.4438507951586E-07
+(PID.TID 0000.0001) %MON vort_r_min                   =  -6.5473874539048E-07
+(PID.TID 0000.0001) %MON vort_r_max                   =   7.4438507951670E-07
 (PID.TID 0000.0001) %MON vort_a_mean                  =  -2.0556865257795E-05
 (PID.TID 0000.0001) %MON vort_a_sd                    =   7.5247416196692E-05
 (PID.TID 0000.0001) %MON vort_p_mean                  =  -2.4859231937694E-05
 (PID.TID 0000.0001) %MON vort_p_sd                    =   1.2920612647165E-04
-(PID.TID 0000.0001) %MON surfExpan_theta_mean         =   1.7422071322219E-03
-(PID.TID 0000.0001) %MON surfExpan_salt_mean          =  -3.9737201191890E-03
+(PID.TID 0000.0001) %MON surfExpan_theta_mean         =   1.7422071322635E-03
+(PID.TID 0000.0001) %MON surfExpan_salt_mean          =  -3.9737201191698E-03
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // End MONITOR dynamic field statistics
 (PID.TID 0000.0001) // =======================================================
@@ -4243,124 +4243,124 @@ listId=   2 ; file name: seaiceStDiag
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) %MON seaice_tsnumber              =                     7
 (PID.TID 0000.0001) %MON seaice_time_sec              =   6.0480000000000E+05
-(PID.TID 0000.0001) %MON seaice_uice_max              =   1.2380051820828E-01
-(PID.TID 0000.0001) %MON seaice_uice_min              =  -1.7560371482007E-01
-(PID.TID 0000.0001) %MON seaice_uice_mean             =  -5.8625596676388E-04
-(PID.TID 0000.0001) %MON seaice_uice_sd               =   1.2240320642895E-02
-(PID.TID 0000.0001) %MON seaice_uice_del2             =   1.7636134095625E-04
-(PID.TID 0000.0001) %MON seaice_vice_max              =   1.6087197543638E-01
-(PID.TID 0000.0001) %MON seaice_vice_min              =  -1.7121210253390E-01
-(PID.TID 0000.0001) %MON seaice_vice_mean             =   1.1519579884288E-03
-(PID.TID 0000.0001) %MON seaice_vice_sd               =   1.5520493065203E-02
-(PID.TID 0000.0001) %MON seaice_vice_del2             =   1.1752582909728E-04
-(PID.TID 0000.0001) %MON seaice_area_max              =   9.4565946566656E-01
+(PID.TID 0000.0001) %MON seaice_uice_max              =   1.2380051820820E-01
+(PID.TID 0000.0001) %MON seaice_uice_min              =  -1.7560371481995E-01
+(PID.TID 0000.0001) %MON seaice_uice_mean             =  -5.8625596676283E-04
+(PID.TID 0000.0001) %MON seaice_uice_sd               =   1.2240320642884E-02
+(PID.TID 0000.0001) %MON seaice_uice_del2             =   1.7636134095532E-04
+(PID.TID 0000.0001) %MON seaice_vice_max              =   1.6087197543637E-01
+(PID.TID 0000.0001) %MON seaice_vice_min              =  -1.7121210253368E-01
+(PID.TID 0000.0001) %MON seaice_vice_mean             =   1.1519579884278E-03
+(PID.TID 0000.0001) %MON seaice_vice_sd               =   1.5520493065195E-02
+(PID.TID 0000.0001) %MON seaice_vice_del2             =   1.1752582909644E-04
+(PID.TID 0000.0001) %MON seaice_area_max              =   9.4565946566603E-01
 (PID.TID 0000.0001) %MON seaice_area_min              =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON seaice_area_mean             =   2.0102245575574E-02
-(PID.TID 0000.0001) %MON seaice_area_sd               =   1.2819579229353E-01
-(PID.TID 0000.0001) %MON seaice_area_del2             =   9.8634583094186E-04
-(PID.TID 0000.0001) %MON seaice_heff_max              =   6.2489580803292E-01
+(PID.TID 0000.0001) %MON seaice_area_mean             =   2.0102245575572E-02
+(PID.TID 0000.0001) %MON seaice_area_sd               =   1.2819579229352E-01
+(PID.TID 0000.0001) %MON seaice_area_del2             =   9.8634583094203E-04
+(PID.TID 0000.0001) %MON seaice_heff_max              =   6.2489580803227E-01
 (PID.TID 0000.0001) %MON seaice_heff_min              =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON seaice_heff_mean             =   1.1791467653777E-02
-(PID.TID 0000.0001) %MON seaice_heff_sd               =   7.7005826009262E-02
-(PID.TID 0000.0001) %MON seaice_heff_del2             =   5.5101567801295E-04
-(PID.TID 0000.0001) %MON seaice_hsnow_max             =   1.2152458307875E-02
+(PID.TID 0000.0001) %MON seaice_heff_sd               =   7.7005826009264E-02
+(PID.TID 0000.0001) %MON seaice_heff_del2             =   5.5101567801335E-04
+(PID.TID 0000.0001) %MON seaice_hsnow_max             =   1.2152458307878E-02
 (PID.TID 0000.0001) %MON seaice_hsnow_min             =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON seaice_hsnow_mean            =   1.1329919355665E-04
-(PID.TID 0000.0001) %MON seaice_hsnow_sd              =   8.4549237799340E-04
-(PID.TID 0000.0001) %MON seaice_hsnow_del2            =   1.1324559345660E-05
+(PID.TID 0000.0001) %MON seaice_hsnow_mean            =   1.1329919355664E-04
+(PID.TID 0000.0001) %MON seaice_hsnow_sd              =   8.4549237799338E-04
+(PID.TID 0000.0001) %MON seaice_hsnow_del2            =   1.1324559345666E-05
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // End MONITOR SEAICE statistics
 (PID.TID 0000.0001) // =======================================================
  EXTERNAL_FIELDS_LOAD,         7 : iP,iLd,i0,i1=   12    1   12    1 ; Wght=  0.2666666667  0.7333333333
  SEAICE_LSR: Residual Initial ipass,Uice,Vice=         1  7.84009885E-04  4.65076813E-04
- SEAICE_LSR (ipass=        1) iters,dU,Resid=       26  2.49383847E-14  3.29780589E-16
- SEAICE_LSR (ipass=        1) iters,dV,Resid=       26  1.48853152E-13  5.24113697E-16
+ SEAICE_LSR (ipass=        1) iters,dU,Resid=       26  2.49418541E-14  3.29602939E-16
+ SEAICE_LSR (ipass=        1) iters,dV,Resid=       26  1.48839274E-13  5.24370170E-16
  SEAICE_LSR: Residual Initial ipass,Uice,Vice=         2  3.03271517E-04  1.73420916E-04
- SEAICE_LSR (ipass=        2) iters,dU,Resid=       24  8.32250935E-14  1.15232280E-15
- SEAICE_LSR (ipass=        2) iters,dV,Resid=       24  2.47191156E-13  9.51257217E-16
- cg2d: Sum(rhs),rhsMax =   3.44777960581898E-01  1.99022938823306E+01
-(PID.TID 0000.0001)      cg2d_init_res =   7.47038854670996E-02
+ SEAICE_LSR (ipass=        2) iters,dU,Resid=       24  8.32250935E-14  1.15224218E-15
+ SEAICE_LSR (ipass=        2) iters,dV,Resid=       24  2.47191156E-13  9.51158331E-16
+ cg2d: Sum(rhs),rhsMax =   3.44777960581906E-01  1.99022938823304E+01
+(PID.TID 0000.0001)      cg2d_init_res =   7.47038854679819E-02
 (PID.TID 0000.0001)      cg2d_iters(min,last) =      -1     101
-(PID.TID 0000.0001)      cg2d_last_res =   7.91116452294289E-10
+(PID.TID 0000.0001)      cg2d_last_res =   7.91144408667740E-10
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // Begin MONITOR dynamic field statistics
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) %MON time_tsnumber                =                     8
 (PID.TID 0000.0001) %MON time_secondsf                =   6.9120000000000E+05
-(PID.TID 0000.0001) %MON dynstat_eta_max              =   1.5258959681620E+04
-(PID.TID 0000.0001) %MON dynstat_eta_min              =  -2.2588193559895E+04
+(PID.TID 0000.0001) %MON dynstat_eta_max              =   1.5258959681623E+04
+(PID.TID 0000.0001) %MON dynstat_eta_min              =  -2.2588193559885E+04
 (PID.TID 0000.0001) %MON dynstat_eta_mean             =  -1.0362466303211E+02
-(PID.TID 0000.0001) %MON dynstat_eta_sd               =   7.2825660489255E+03
-(PID.TID 0000.0001) %MON dynstat_eta_del2             =   9.4222562393152E+01
+(PID.TID 0000.0001) %MON dynstat_eta_sd               =   7.2825660489262E+03
+(PID.TID 0000.0001) %MON dynstat_eta_del2             =   9.4222562393375E+01
 (PID.TID 0000.0001) %MON dynstat_uvel_max             =   1.2230591615315E-01
-(PID.TID 0000.0001) %MON dynstat_uvel_min             =  -1.4420757744228E-01
-(PID.TID 0000.0001) %MON dynstat_uvel_mean            =  -4.0413601889644E-05
-(PID.TID 0000.0001) %MON dynstat_uvel_sd              =   7.5610248887893E-03
-(PID.TID 0000.0001) %MON dynstat_uvel_del2            =   3.6076767181349E-05
-(PID.TID 0000.0001) %MON dynstat_vvel_max             =   1.9391015121811E-01
+(PID.TID 0000.0001) %MON dynstat_uvel_min             =  -1.4420757744225E-01
+(PID.TID 0000.0001) %MON dynstat_uvel_mean            =  -4.0413601889135E-05
+(PID.TID 0000.0001) %MON dynstat_uvel_sd              =   7.5610248887892E-03
+(PID.TID 0000.0001) %MON dynstat_uvel_del2            =   3.6076767181346E-05
+(PID.TID 0000.0001) %MON dynstat_vvel_max             =   1.9391015121812E-01
 (PID.TID 0000.0001) %MON dynstat_vvel_min             =  -1.8030347775239E-01
-(PID.TID 0000.0001) %MON dynstat_vvel_mean            =  -4.9241258810286E-04
-(PID.TID 0000.0001) %MON dynstat_vvel_sd              =   7.7901743330569E-03
-(PID.TID 0000.0001) %MON dynstat_vvel_del2            =   3.7194196527823E-05
-(PID.TID 0000.0001) %MON dynstat_wvel_max             =   5.4269257555973E+00
+(PID.TID 0000.0001) %MON dynstat_vvel_mean            =  -4.9241258810239E-04
+(PID.TID 0000.0001) %MON dynstat_vvel_sd              =   7.7901743330571E-03
+(PID.TID 0000.0001) %MON dynstat_vvel_del2            =   3.7194196527822E-05
+(PID.TID 0000.0001) %MON dynstat_wvel_max             =   5.4269257555972E+00
 (PID.TID 0000.0001) %MON dynstat_wvel_min             =  -9.6713174067502E+00
-(PID.TID 0000.0001) %MON dynstat_wvel_mean            =  -6.0012111797353E-06
-(PID.TID 0000.0001) %MON dynstat_wvel_sd              =   2.5577014205298E-01
-(PID.TID 0000.0001) %MON dynstat_wvel_del2            =   1.9457816266698E-03
+(PID.TID 0000.0001) %MON dynstat_wvel_mean            =  -6.0012111748858E-06
+(PID.TID 0000.0001) %MON dynstat_wvel_sd              =   2.5577014205294E-01
+(PID.TID 0000.0001) %MON dynstat_wvel_del2            =   1.9457816266697E-03
 (PID.TID 0000.0001) %MON dynstat_theta_max            =   2.9438771981169E+01
 (PID.TID 0000.0001) %MON dynstat_theta_min            =  -1.8943601431987E+00
 (PID.TID 0000.0001) %MON dynstat_theta_mean           =   3.5922804204950E+00
 (PID.TID 0000.0001) %MON dynstat_theta_sd             =   4.4289167255531E+00
-(PID.TID 0000.0001) %MON dynstat_theta_del2           =   2.3050218548299E-03
+(PID.TID 0000.0001) %MON dynstat_theta_del2           =   2.3050218548298E-03
 (PID.TID 0000.0001) %MON dynstat_salt_max             =   4.0715808459172E+01
-(PID.TID 0000.0001) %MON dynstat_salt_min             =   1.6289448781649E+01
+(PID.TID 0000.0001) %MON dynstat_salt_min             =   1.6289448781651E+01
 (PID.TID 0000.0001) %MON dynstat_salt_mean            =   3.4721535831898E+01
 (PID.TID 0000.0001) %MON dynstat_salt_sd              =   4.8725109963905E-01
-(PID.TID 0000.0001) %MON dynstat_salt_del2            =   5.1343232487742E-04
-(PID.TID 0000.0001) %MON forcing_qnet_max             =   6.9645864966771E+02
-(PID.TID 0000.0001) %MON forcing_qnet_min             =  -3.1135072560223E+02
-(PID.TID 0000.0001) %MON forcing_qnet_mean            =  -2.7739161215915E+01
+(PID.TID 0000.0001) %MON dynstat_salt_del2            =   5.1343232487746E-04
+(PID.TID 0000.0001) %MON forcing_qnet_max             =   6.9645864966770E+02
+(PID.TID 0000.0001) %MON forcing_qnet_min             =  -3.1135072560222E+02
+(PID.TID 0000.0001) %MON forcing_qnet_mean            =  -2.7739161215916E+01
 (PID.TID 0000.0001) %MON forcing_qnet_sd              =   1.5109545991253E+02
-(PID.TID 0000.0001) %MON forcing_qnet_del2            =   9.8762760048143E-01
+(PID.TID 0000.0001) %MON forcing_qnet_del2            =   9.8762760048098E-01
 (PID.TID 0000.0001) %MON forcing_qsw_max              =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON forcing_qsw_min              =  -3.0183129457886E+02
 (PID.TID 0000.0001) %MON forcing_qsw_mean             =  -1.8596948126568E+02
 (PID.TID 0000.0001) %MON forcing_qsw_sd               =   7.8572368848108E+01
 (PID.TID 0000.0001) %MON forcing_qsw_del2             =   1.1074849619963E-01
-(PID.TID 0000.0001) %MON forcing_empmr_max            =   1.6190670158027E-03
+(PID.TID 0000.0001) %MON forcing_empmr_max            =   1.6190670158020E-03
 (PID.TID 0000.0001) %MON forcing_empmr_min            =  -4.5708705957876E-04
-(PID.TID 0000.0001) %MON forcing_empmr_mean           =   1.3537284814076E-05
-(PID.TID 0000.0001) %MON forcing_empmr_sd             =   1.1072045765128E-04
-(PID.TID 0000.0001) %MON forcing_empmr_del2           =   1.7282995420497E-06
+(PID.TID 0000.0001) %MON forcing_empmr_mean           =   1.3537284814080E-05
+(PID.TID 0000.0001) %MON forcing_empmr_sd             =   1.1072045765130E-04
+(PID.TID 0000.0001) %MON forcing_empmr_del2           =   1.7282995420481E-06
 (PID.TID 0000.0001) %MON forcing_fu_max               =   2.4726979082249E-01
 (PID.TID 0000.0001) %MON forcing_fu_min               =  -2.2495248635365E-01
-(PID.TID 0000.0001) %MON forcing_fu_mean              =  -4.1948263773107E-03
+(PID.TID 0000.0001) %MON forcing_fu_mean              =  -4.1948263773108E-03
 (PID.TID 0000.0001) %MON forcing_fu_sd                =   6.4265979198157E-02
 (PID.TID 0000.0001) %MON forcing_fu_del2              =   2.1090617733586E-04
 (PID.TID 0000.0001) %MON forcing_fv_max               =   2.7159367144430E-01
 (PID.TID 0000.0001) %MON forcing_fv_min               =  -3.3243525155752E-01
 (PID.TID 0000.0001) %MON forcing_fv_mean              =  -1.3697937258375E-02
 (PID.TID 0000.0001) %MON forcing_fv_sd                =   7.5649849119089E-02
-(PID.TID 0000.0001) %MON forcing_fv_del2              =   2.3882639730304E-04
-(PID.TID 0000.0001) %MON trAdv_CFL_u_max              =   4.5062772274094E-02
-(PID.TID 0000.0001) %MON trAdv_CFL_v_max              =   7.1536765942262E-02
+(PID.TID 0000.0001) %MON forcing_fv_del2              =   2.3882639730303E-04
+(PID.TID 0000.0001) %MON trAdv_CFL_u_max              =   4.5062772274088E-02
+(PID.TID 0000.0001) %MON trAdv_CFL_v_max              =   7.1536765942264E-02
 (PID.TID 0000.0001) %MON trAdv_CFL_w_max              =   2.4800999644881E-01
-(PID.TID 0000.0001) %MON advcfl_uvel_max              =   4.4568948880118E-02
-(PID.TID 0000.0001) %MON advcfl_vvel_max              =   5.4936660478855E-02
+(PID.TID 0000.0001) %MON advcfl_uvel_max              =   4.4568948880102E-02
+(PID.TID 0000.0001) %MON advcfl_vvel_max              =   5.4936660478874E-02
 (PID.TID 0000.0001) %MON advcfl_wvel_max              =   2.7164723342493E-01
-(PID.TID 0000.0001) %MON advcfl_W_hf_max              =   3.0009441999420E-01
-(PID.TID 0000.0001) %MON pe_b_mean                    =   1.3515414642395E-02
-(PID.TID 0000.0001) %MON ke_max                       =   1.3164533477702E-02
-(PID.TID 0000.0001) %MON ke_mean                      =   5.4531592136650E-05
+(PID.TID 0000.0001) %MON advcfl_W_hf_max              =   3.0009441999421E-01
+(PID.TID 0000.0001) %MON pe_b_mean                    =   1.3515414642398E-02
+(PID.TID 0000.0001) %MON ke_max                       =   1.3164533477703E-02
+(PID.TID 0000.0001) %MON ke_mean                      =   5.4531592136651E-05
 (PID.TID 0000.0001) %MON ke_vol                       =   1.3604143151821E+22
-(PID.TID 0000.0001) %MON vort_r_min                   =  -7.1535409162125E-07
-(PID.TID 0000.0001) %MON vort_r_max                   =   8.0479084720813E-07
+(PID.TID 0000.0001) %MON vort_r_min                   =  -7.1535409162126E-07
+(PID.TID 0000.0001) %MON vort_r_max                   =   8.0479084720800E-07
 (PID.TID 0000.0001) %MON vort_a_mean                  =  -2.0556865257795E-05
 (PID.TID 0000.0001) %MON vort_a_sd                    =   7.5247442376059E-05
 (PID.TID 0000.0001) %MON vort_p_mean                  =  -2.4859237494377E-05
 (PID.TID 0000.0001) %MON vort_p_sd                    =   1.2920599029619E-04
-(PID.TID 0000.0001) %MON surfExpan_theta_mean         =   1.0635345957909E-04
-(PID.TID 0000.0001) %MON surfExpan_salt_mean          =  -4.3477838065110E-03
+(PID.TID 0000.0001) %MON surfExpan_theta_mean         =   1.0635345955771E-04
+(PID.TID 0000.0001) %MON surfExpan_salt_mean          =  -4.3477838064889E-03
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // End MONITOR dynamic field statistics
 (PID.TID 0000.0001) // =======================================================
@@ -4369,124 +4369,124 @@ listId=   2 ; file name: seaiceStDiag
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) %MON seaice_tsnumber              =                     8
 (PID.TID 0000.0001) %MON seaice_time_sec              =   6.9120000000000E+05
-(PID.TID 0000.0001) %MON seaice_uice_max              =   1.7834935911793E-01
-(PID.TID 0000.0001) %MON seaice_uice_min              =  -2.0958604516927E-01
-(PID.TID 0000.0001) %MON seaice_uice_mean             =  -5.7057897259927E-04
-(PID.TID 0000.0001) %MON seaice_uice_sd               =   1.4064670245220E-02
-(PID.TID 0000.0001) %MON seaice_uice_del2             =   2.2969740933528E-04
-(PID.TID 0000.0001) %MON seaice_vice_max              =   1.6318905434500E-01
-(PID.TID 0000.0001) %MON seaice_vice_min              =  -1.7733468405446E-01
-(PID.TID 0000.0001) %MON seaice_vice_mean             =   1.2352735066855E-03
-(PID.TID 0000.0001) %MON seaice_vice_sd               =   1.5667881345568E-02
-(PID.TID 0000.0001) %MON seaice_vice_del2             =   1.2094468751886E-04
-(PID.TID 0000.0001) %MON seaice_area_max              =   9.6695283018647E-01
+(PID.TID 0000.0001) %MON seaice_uice_max              =   1.7834935911809E-01
+(PID.TID 0000.0001) %MON seaice_uice_min              =  -2.0958604516922E-01
+(PID.TID 0000.0001) %MON seaice_uice_mean             =  -5.7057897259849E-04
+(PID.TID 0000.0001) %MON seaice_uice_sd               =   1.4064670245206E-02
+(PID.TID 0000.0001) %MON seaice_uice_del2             =   2.2969740933442E-04
+(PID.TID 0000.0001) %MON seaice_vice_max              =   1.6318905434498E-01
+(PID.TID 0000.0001) %MON seaice_vice_min              =  -1.7733468405433E-01
+(PID.TID 0000.0001) %MON seaice_vice_mean             =   1.2352735066847E-03
+(PID.TID 0000.0001) %MON seaice_vice_sd               =   1.5667881345561E-02
+(PID.TID 0000.0001) %MON seaice_vice_del2             =   1.2094468751807E-04
+(PID.TID 0000.0001) %MON seaice_area_max              =   9.6695283018622E-01
 (PID.TID 0000.0001) %MON seaice_area_min              =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON seaice_area_mean             =   2.1864498795843E-02
-(PID.TID 0000.0001) %MON seaice_area_sd               =   1.3606306622400E-01
-(PID.TID 0000.0001) %MON seaice_area_del2             =   9.8652396537426E-04
-(PID.TID 0000.0001) %MON seaice_heff_max              =   6.6718623690554E-01
+(PID.TID 0000.0001) %MON seaice_area_mean             =   2.1864498795842E-02
+(PID.TID 0000.0001) %MON seaice_area_sd               =   1.3606306622399E-01
+(PID.TID 0000.0001) %MON seaice_area_del2             =   9.8652396537413E-04
+(PID.TID 0000.0001) %MON seaice_heff_max              =   6.6718623690508E-01
 (PID.TID 0000.0001) %MON seaice_heff_min              =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON seaice_heff_mean             =   1.3301097350387E-02
-(PID.TID 0000.0001) %MON seaice_heff_sd               =   8.4566566079047E-02
-(PID.TID 0000.0001) %MON seaice_heff_del2             =   5.7292540024456E-04
-(PID.TID 0000.0001) %MON seaice_hsnow_max             =   1.5479030559524E-02
+(PID.TID 0000.0001) %MON seaice_heff_mean             =   1.3301097350388E-02
+(PID.TID 0000.0001) %MON seaice_heff_sd               =   8.4566566079050E-02
+(PID.TID 0000.0001) %MON seaice_heff_del2             =   5.7292540024474E-04
+(PID.TID 0000.0001) %MON seaice_hsnow_max             =   1.5479030559528E-02
 (PID.TID 0000.0001) %MON seaice_hsnow_min             =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON seaice_hsnow_mean            =   1.4987718929565E-04
 (PID.TID 0000.0001) %MON seaice_hsnow_sd              =   1.0946472399272E-03
-(PID.TID 0000.0001) %MON seaice_hsnow_del2            =   1.4568545170757E-05
+(PID.TID 0000.0001) %MON seaice_hsnow_del2            =   1.4568545170763E-05
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // End MONITOR SEAICE statistics
 (PID.TID 0000.0001) // =======================================================
  EXTERNAL_FIELDS_LOAD,         8 : iP,iLd,i0,i1=   12    1   12    1 ; Wght=  0.2333333333  0.7666666667
  SEAICE_LSR: Residual Initial ipass,Uice,Vice=         1  5.28183549E-04  5.26265596E-04
- SEAICE_LSR (ipass=        1) iters,dU,Resid=       34  1.51836876E-13  4.85148892E-15
- SEAICE_LSR (ipass=        1) iters,dV,Resid=       34  3.94462241E-13  9.12435494E-15
+ SEAICE_LSR (ipass=        1) iters,dU,Resid=       34  1.51836876E-13  4.85215557E-15
+ SEAICE_LSR (ipass=        1) iters,dV,Resid=       34  3.94462241E-13  9.12352264E-15
  SEAICE_LSR: Residual Initial ipass,Uice,Vice=         2  2.54139260E-04  2.23169242E-04
- SEAICE_LSR (ipass=        2) iters,dU,Resid=       32  2.93619296E-13  9.75135683E-15
- SEAICE_LSR (ipass=        2) iters,dV,Resid=       32  4.81586993E-13  1.17839033E-14
- cg2d: Sum(rhs),rhsMax =   3.75450914201533E-01  1.99064490119921E+01
-(PID.TID 0000.0001)      cg2d_init_res =   7.47155599286233E-02
+ SEAICE_LSR (ipass=        2) iters,dU,Resid=       32  2.93633173E-13  9.75091194E-15
+ SEAICE_LSR (ipass=        2) iters,dV,Resid=       32  4.81600870E-13  1.17841704E-14
+ cg2d: Sum(rhs),rhsMax =   3.75450914201616E-01  1.99064490119897E+01
+(PID.TID 0000.0001)      cg2d_init_res =   7.47155599291924E-02
 (PID.TID 0000.0001)      cg2d_iters(min,last) =      -1     101
-(PID.TID 0000.0001)      cg2d_last_res =   8.12542246192596E-10
+(PID.TID 0000.0001)      cg2d_last_res =   8.12544800447700E-10
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // Begin MONITOR dynamic field statistics
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) %MON time_tsnumber                =                     9
 (PID.TID 0000.0001) %MON time_secondsf                =   7.7760000000000E+05
-(PID.TID 0000.0001) %MON dynstat_eta_max              =   1.5337114212024E+04
-(PID.TID 0000.0001) %MON dynstat_eta_min              =  -2.2028168354116E+04
-(PID.TID 0000.0001) %MON dynstat_eta_mean             =  -1.1286712484061E+02
-(PID.TID 0000.0001) %MON dynstat_eta_sd               =   7.2626893195343E+03
-(PID.TID 0000.0001) %MON dynstat_eta_del2             =   9.4326987376924E+01
+(PID.TID 0000.0001) %MON dynstat_eta_max              =   1.5337114212018E+04
+(PID.TID 0000.0001) %MON dynstat_eta_min              =  -2.2028168354113E+04
+(PID.TID 0000.0001) %MON dynstat_eta_mean             =  -1.1286712484062E+02
+(PID.TID 0000.0001) %MON dynstat_eta_sd               =   7.2626893195324E+03
+(PID.TID 0000.0001) %MON dynstat_eta_del2             =   9.4326987376781E+01
 (PID.TID 0000.0001) %MON dynstat_uvel_max             =   1.3207783574919E-01
-(PID.TID 0000.0001) %MON dynstat_uvel_min             =  -1.5442024172421E-01
-(PID.TID 0000.0001) %MON dynstat_uvel_mean            =   2.5030836567155E-05
-(PID.TID 0000.0001) %MON dynstat_uvel_sd              =   8.3314485740997E-03
-(PID.TID 0000.0001) %MON dynstat_uvel_del2            =   3.8258381102217E-05
+(PID.TID 0000.0001) %MON dynstat_uvel_min             =  -1.5442024172418E-01
+(PID.TID 0000.0001) %MON dynstat_uvel_mean            =   2.5030836566876E-05
+(PID.TID 0000.0001) %MON dynstat_uvel_sd              =   8.3314485740996E-03
+(PID.TID 0000.0001) %MON dynstat_uvel_del2            =   3.8258381102212E-05
 (PID.TID 0000.0001) %MON dynstat_vvel_max             =   2.0644174066235E-01
-(PID.TID 0000.0001) %MON dynstat_vvel_min             =  -1.9269324111797E-01
-(PID.TID 0000.0001) %MON dynstat_vvel_mean            =  -4.5360473019830E-04
-(PID.TID 0000.0001) %MON dynstat_vvel_sd              =   8.5807626824926E-03
-(PID.TID 0000.0001) %MON dynstat_vvel_del2            =   3.9373626895046E-05
-(PID.TID 0000.0001) %MON dynstat_wvel_max             =   5.6012650985836E+00
+(PID.TID 0000.0001) %MON dynstat_vvel_min             =  -1.9269324111798E-01
+(PID.TID 0000.0001) %MON dynstat_vvel_mean            =  -4.5360473019786E-04
+(PID.TID 0000.0001) %MON dynstat_vvel_sd              =   8.5807626824928E-03
+(PID.TID 0000.0001) %MON dynstat_vvel_del2            =   3.9373626895041E-05
+(PID.TID 0000.0001) %MON dynstat_wvel_max             =   5.6012650985835E+00
 (PID.TID 0000.0001) %MON dynstat_wvel_min             =  -1.0308888422445E+01
-(PID.TID 0000.0001) %MON dynstat_wvel_mean            =   6.2161138186348E-05
-(PID.TID 0000.0001) %MON dynstat_wvel_sd              =   2.6779644378159E-01
-(PID.TID 0000.0001) %MON dynstat_wvel_del2            =   1.9974724917306E-03
+(PID.TID 0000.0001) %MON dynstat_wvel_mean            =   6.2161138179861E-05
+(PID.TID 0000.0001) %MON dynstat_wvel_sd              =   2.6779644378156E-01
+(PID.TID 0000.0001) %MON dynstat_wvel_del2            =   1.9974724917301E-03
 (PID.TID 0000.0001) %MON dynstat_theta_max            =   2.9443921619062E+01
 (PID.TID 0000.0001) %MON dynstat_theta_min            =  -1.9013704234445E+00
 (PID.TID 0000.0001) %MON dynstat_theta_mean           =   3.5924415780659E+00
 (PID.TID 0000.0001) %MON dynstat_theta_sd             =   4.4293494695673E+00
-(PID.TID 0000.0001) %MON dynstat_theta_del2           =   2.2959003664380E-03
+(PID.TID 0000.0001) %MON dynstat_theta_del2           =   2.2959003664379E-03
 (PID.TID 0000.0001) %MON dynstat_salt_max             =   4.0715781399077E+01
-(PID.TID 0000.0001) %MON dynstat_salt_min             =   1.5951592596386E+01
+(PID.TID 0000.0001) %MON dynstat_salt_min             =   1.5951592596388E+01
 (PID.TID 0000.0001) %MON dynstat_salt_mean            =   3.4721542790961E+01
 (PID.TID 0000.0001) %MON dynstat_salt_sd              =   4.8722671549479E-01
-(PID.TID 0000.0001) %MON dynstat_salt_del2            =   5.0884920016591E-04
+(PID.TID 0000.0001) %MON dynstat_salt_del2            =   5.0884920016595E-04
 (PID.TID 0000.0001) %MON forcing_qnet_max             =   7.0076884667274E+02
 (PID.TID 0000.0001) %MON forcing_qnet_min             =  -3.1324794627445E+02
 (PID.TID 0000.0001) %MON forcing_qnet_mean            =  -2.7361317785886E+01
 (PID.TID 0000.0001) %MON forcing_qnet_sd              =   1.4950043157637E+02
-(PID.TID 0000.0001) %MON forcing_qnet_del2            =   8.9646657262389E-01
+(PID.TID 0000.0001) %MON forcing_qnet_del2            =   8.9646657262377E-01
 (PID.TID 0000.0001) %MON forcing_qsw_max              =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON forcing_qsw_min              =  -3.0181929764305E+02
 (PID.TID 0000.0001) %MON forcing_qsw_mean             =  -1.8597531882431E+02
 (PID.TID 0000.0001) %MON forcing_qsw_sd               =   7.8478432782470E+01
 (PID.TID 0000.0001) %MON forcing_qsw_del2             =   1.1102150640893E-01
-(PID.TID 0000.0001) %MON forcing_empmr_max            =   1.4380294087654E-03
+(PID.TID 0000.0001) %MON forcing_empmr_max            =   1.4380294087655E-03
 (PID.TID 0000.0001) %MON forcing_empmr_min            =  -4.5888898020796E-04
-(PID.TID 0000.0001) %MON forcing_empmr_mean           =   1.0904478858147E-05
-(PID.TID 0000.0001) %MON forcing_empmr_sd             =   9.2989415970145E-05
-(PID.TID 0000.0001) %MON forcing_empmr_del2           =   1.4700609653470E-06
+(PID.TID 0000.0001) %MON forcing_empmr_mean           =   1.0904478858148E-05
+(PID.TID 0000.0001) %MON forcing_empmr_sd             =   9.2989415970152E-05
+(PID.TID 0000.0001) %MON forcing_empmr_del2           =   1.4700609653473E-06
 (PID.TID 0000.0001) %MON forcing_fu_max               =   2.4722174155228E-01
 (PID.TID 0000.0001) %MON forcing_fu_min               =  -2.2809828301201E-01
 (PID.TID 0000.0001) %MON forcing_fu_mean              =  -4.1432646346498E-03
 (PID.TID 0000.0001) %MON forcing_fu_sd                =   6.4366316866720E-02
-(PID.TID 0000.0001) %MON forcing_fu_del2              =   2.1254653390060E-04
+(PID.TID 0000.0001) %MON forcing_fu_del2              =   2.1254653390059E-04
 (PID.TID 0000.0001) %MON forcing_fv_max               =   2.7427691301694E-01
 (PID.TID 0000.0001) %MON forcing_fv_min               =  -3.3322315549145E-01
 (PID.TID 0000.0001) %MON forcing_fv_mean              =  -1.3700130484330E-02
 (PID.TID 0000.0001) %MON forcing_fv_sd                =   7.5749137942292E-02
 (PID.TID 0000.0001) %MON forcing_fv_del2              =   2.4014976562403E-04
-(PID.TID 0000.0001) %MON trAdv_CFL_u_max              =   4.7681962832422E-02
-(PID.TID 0000.0001) %MON trAdv_CFL_v_max              =   7.6412894657842E-02
-(PID.TID 0000.0001) %MON trAdv_CFL_w_max              =   2.6363699524605E-01
-(PID.TID 0000.0001) %MON advcfl_uvel_max              =   4.7772503016119E-02
-(PID.TID 0000.0001) %MON advcfl_vvel_max              =   5.9236594986982E-02
-(PID.TID 0000.0001) %MON advcfl_wvel_max              =   2.8877466863140E-01
-(PID.TID 0000.0001) %MON advcfl_W_hf_max              =   3.1900323499140E-01
-(PID.TID 0000.0001) %MON pe_b_mean                    =   1.3540852149311E-02
+(PID.TID 0000.0001) %MON trAdv_CFL_u_max              =   4.7681962832401E-02
+(PID.TID 0000.0001) %MON trAdv_CFL_v_max              =   7.6412894657841E-02
+(PID.TID 0000.0001) %MON trAdv_CFL_w_max              =   2.6363699524604E-01
+(PID.TID 0000.0001) %MON advcfl_uvel_max              =   4.7772503016098E-02
+(PID.TID 0000.0001) %MON advcfl_vvel_max              =   5.9236594987014E-02
+(PID.TID 0000.0001) %MON advcfl_wvel_max              =   2.8877466863139E-01
+(PID.TID 0000.0001) %MON advcfl_W_hf_max              =   3.1900323499139E-01
+(PID.TID 0000.0001) %MON pe_b_mean                    =   1.3540852149308E-02
 (PID.TID 0000.0001) %MON ke_max                       =   1.5119639109435E-02
-(PID.TID 0000.0001) %MON ke_mean                      =   6.6143581062836E-05
+(PID.TID 0000.0001) %MON ke_mean                      =   6.6143581062837E-05
 (PID.TID 0000.0001) %MON ke_vol                       =   1.3604138976589E+22
 (PID.TID 0000.0001) %MON vort_r_min                   =  -7.6647290029092E-07
-(PID.TID 0000.0001) %MON vort_r_max                   =   8.5160166368359E-07
+(PID.TID 0000.0001) %MON vort_r_max                   =   8.5160166368393E-07
 (PID.TID 0000.0001) %MON vort_a_mean                  =  -2.0556865257795E-05
 (PID.TID 0000.0001) %MON vort_a_sd                    =   7.5247465020122E-05
 (PID.TID 0000.0001) %MON vort_p_mean                  =  -2.4859241653960E-05
 (PID.TID 0000.0001) %MON vort_p_sd                    =   1.2920586788765E-04
-(PID.TID 0000.0001) %MON surfExpan_theta_mean         =  -1.0196472771719E-03
-(PID.TID 0000.0001) %MON surfExpan_salt_mean          =  -3.3600696936737E-03
+(PID.TID 0000.0001) %MON surfExpan_theta_mean         =  -1.0196472771614E-03
+(PID.TID 0000.0001) %MON surfExpan_salt_mean          =  -3.3600696936139E-03
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // End MONITOR dynamic field statistics
 (PID.TID 0000.0001) // =======================================================
@@ -4495,124 +4495,124 @@ listId=   2 ; file name: seaiceStDiag
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) %MON seaice_tsnumber              =                     9
 (PID.TID 0000.0001) %MON seaice_time_sec              =   7.7760000000000E+05
-(PID.TID 0000.0001) %MON seaice_uice_max              =   1.7245251978562E-01
+(PID.TID 0000.0001) %MON seaice_uice_max              =   1.7245251978580E-01
 (PID.TID 0000.0001) %MON seaice_uice_min              =  -2.2713471498286E-01
-(PID.TID 0000.0001) %MON seaice_uice_mean             =  -6.6677528162763E-04
-(PID.TID 0000.0001) %MON seaice_uice_sd               =   1.4899389762502E-02
-(PID.TID 0000.0001) %MON seaice_uice_del2             =   2.3207073471727E-04
-(PID.TID 0000.0001) %MON seaice_vice_max              =   1.6584463097105E-01
-(PID.TID 0000.0001) %MON seaice_vice_min              =  -1.8453316829986E-01
-(PID.TID 0000.0001) %MON seaice_vice_mean             =   1.3252900548820E-03
+(PID.TID 0000.0001) %MON seaice_uice_mean             =  -6.6677528162736E-04
+(PID.TID 0000.0001) %MON seaice_uice_sd               =   1.4899389762489E-02
+(PID.TID 0000.0001) %MON seaice_uice_del2             =   2.3207073471589E-04
+(PID.TID 0000.0001) %MON seaice_vice_max              =   1.6584463097101E-01
+(PID.TID 0000.0001) %MON seaice_vice_min              =  -1.8453316829973E-01
+(PID.TID 0000.0001) %MON seaice_vice_mean             =   1.3252900548840E-03
 (PID.TID 0000.0001) %MON seaice_vice_sd               =   1.5909810010815E-02
-(PID.TID 0000.0001) %MON seaice_vice_del2             =   1.3695993066405E-04
-(PID.TID 0000.0001) %MON seaice_area_max              =   9.8126604726016E-01
+(PID.TID 0000.0001) %MON seaice_vice_del2             =   1.3695993066325E-04
+(PID.TID 0000.0001) %MON seaice_area_max              =   9.8126604726008E-01
 (PID.TID 0000.0001) %MON seaice_area_min              =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON seaice_area_mean             =   2.3321636089815E-02
 (PID.TID 0000.0001) %MON seaice_area_sd               =   1.4241863878700E-01
-(PID.TID 0000.0001) %MON seaice_area_del2             =   9.3939882770105E-04
-(PID.TID 0000.0001) %MON seaice_heff_max              =   7.0559760305798E-01
+(PID.TID 0000.0001) %MON seaice_area_del2             =   9.3939882770053E-04
+(PID.TID 0000.0001) %MON seaice_heff_max              =   7.0559760305765E-01
 (PID.TID 0000.0001) %MON seaice_heff_min              =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON seaice_heff_mean             =   1.4557255480717E-02
-(PID.TID 0000.0001) %MON seaice_heff_sd               =   9.1059633811529E-02
-(PID.TID 0000.0001) %MON seaice_heff_del2             =   5.6811258924014E-04
-(PID.TID 0000.0001) %MON seaice_hsnow_max             =   1.8937109612266E-02
+(PID.TID 0000.0001) %MON seaice_heff_mean             =   1.4557255480718E-02
+(PID.TID 0000.0001) %MON seaice_heff_sd               =   9.1059633811533E-02
+(PID.TID 0000.0001) %MON seaice_heff_del2             =   5.6811258924022E-04
+(PID.TID 0000.0001) %MON seaice_hsnow_max             =   1.8937109612270E-02
 (PID.TID 0000.0001) %MON seaice_hsnow_min             =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON seaice_hsnow_mean            =   1.9073567018844E-04
+(PID.TID 0000.0001) %MON seaice_hsnow_mean            =   1.9073567018843E-04
 (PID.TID 0000.0001) %MON seaice_hsnow_sd              =   1.3647398367319E-03
-(PID.TID 0000.0001) %MON seaice_hsnow_del2            =   1.7491349829897E-05
+(PID.TID 0000.0001) %MON seaice_hsnow_del2            =   1.7491349829902E-05
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // End MONITOR SEAICE statistics
 (PID.TID 0000.0001) // =======================================================
  EXTERNAL_FIELDS_LOAD,         9 : iP,iLd,i0,i1=   12    1   12    1 ; Wght=  0.2000000000  0.8000000000
  SEAICE_LSR: Residual Initial ipass,Uice,Vice=         1  4.47373789E-04  5.83540544E-04
- SEAICE_LSR (ipass=        1) iters,dU,Resid=       44  1.49082136E-13  8.80852194E-15
- SEAICE_LSR (ipass=        1) iters,dV,Resid=       44  5.32573985E-13  2.66650523E-14
+ SEAICE_LSR (ipass=        1) iters,dU,Resid=       44  1.49068258E-13  8.80967664E-15
+ SEAICE_LSR (ipass=        1) iters,dV,Resid=       44  5.32573985E-13  2.66638463E-14
  SEAICE_LSR: Residual Initial ipass,Uice,Vice=         2  2.88171896E-04  2.91684281E-04
- SEAICE_LSR (ipass=        2) iters,dU,Resid=       42  1.91804905E-13  1.15582755E-14
- SEAICE_LSR (ipass=        2) iters,dV,Resid=       42  4.84848273E-13  2.49110202E-14
- cg2d: Sum(rhs),rhsMax =   4.11196932313765E-01  1.99115794601055E+01
-(PID.TID 0000.0001)      cg2d_init_res =   7.40329262482598E-02
+ SEAICE_LSR (ipass=        2) iters,dU,Resid=       42  1.91797966E-13  1.15596384E-14
+ SEAICE_LSR (ipass=        2) iters,dV,Resid=       42  4.84848273E-13  2.49111644E-14
+ cg2d: Sum(rhs),rhsMax =   4.11196932313810E-01  1.99115794601049E+01
+(PID.TID 0000.0001)      cg2d_init_res =   7.40329262482620E-02
 (PID.TID 0000.0001)      cg2d_iters(min,last) =      -1      99
-(PID.TID 0000.0001)      cg2d_last_res =   9.86532756215736E-10
+(PID.TID 0000.0001)      cg2d_last_res =   9.86524339265281E-10
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // Begin MONITOR dynamic field statistics
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) %MON time_tsnumber                =                    10
 (PID.TID 0000.0001) %MON time_secondsf                =   8.6400000000000E+05
-(PID.TID 0000.0001) %MON dynstat_eta_max              =   1.5135750084016E+04
-(PID.TID 0000.0001) %MON dynstat_eta_min              =  -2.4251786212335E+04
-(PID.TID 0000.0001) %MON dynstat_eta_mean             =  -1.2364486288341E+02
-(PID.TID 0000.0001) %MON dynstat_eta_sd               =   7.2869403898264E+03
-(PID.TID 0000.0001) %MON dynstat_eta_del2             =   9.4374294060000E+01
+(PID.TID 0000.0001) %MON dynstat_eta_max              =   1.5135750084013E+04
+(PID.TID 0000.0001) %MON dynstat_eta_min              =  -2.4251786212333E+04
+(PID.TID 0000.0001) %MON dynstat_eta_mean             =  -1.2364486288342E+02
+(PID.TID 0000.0001) %MON dynstat_eta_sd               =   7.2869403898258E+03
+(PID.TID 0000.0001) %MON dynstat_eta_del2             =   9.4374294060023E+01
 (PID.TID 0000.0001) %MON dynstat_uvel_max             =   1.4025406019583E-01
-(PID.TID 0000.0001) %MON dynstat_uvel_min             =  -1.6231728560717E-01
-(PID.TID 0000.0001) %MON dynstat_uvel_mean            =   4.9327593062651E-05
-(PID.TID 0000.0001) %MON dynstat_uvel_sd              =   9.0562608520665E-03
-(PID.TID 0000.0001) %MON dynstat_uvel_del2            =   4.0001352387061E-05
+(PID.TID 0000.0001) %MON dynstat_uvel_min             =  -1.6231728560713E-01
+(PID.TID 0000.0001) %MON dynstat_uvel_mean            =   4.9327593061478E-05
+(PID.TID 0000.0001) %MON dynstat_uvel_sd              =   9.0562608520664E-03
+(PID.TID 0000.0001) %MON dynstat_uvel_del2            =   4.0001352387055E-05
 (PID.TID 0000.0001) %MON dynstat_vvel_max             =   2.1608624711783E-01
-(PID.TID 0000.0001) %MON dynstat_vvel_min             =  -2.0223783624155E-01
-(PID.TID 0000.0001) %MON dynstat_vvel_mean            =  -4.0808336778816E-04
-(PID.TID 0000.0001) %MON dynstat_vvel_sd              =   9.3186816628471E-03
-(PID.TID 0000.0001) %MON dynstat_vvel_del2            =   4.1137626129645E-05
-(PID.TID 0000.0001) %MON dynstat_wvel_max             =   5.6384916643427E+00
+(PID.TID 0000.0001) %MON dynstat_vvel_min             =  -2.0223783624156E-01
+(PID.TID 0000.0001) %MON dynstat_vvel_mean            =  -4.0808336778778E-04
+(PID.TID 0000.0001) %MON dynstat_vvel_sd              =   9.3186816628473E-03
+(PID.TID 0000.0001) %MON dynstat_vvel_del2            =   4.1137626129641E-05
+(PID.TID 0000.0001) %MON dynstat_wvel_max             =   5.6384916643426E+00
 (PID.TID 0000.0001) %MON dynstat_wvel_min             =  -1.0793470434765E+01
-(PID.TID 0000.0001) %MON dynstat_wvel_mean            =   1.1977346362891E-04
-(PID.TID 0000.0001) %MON dynstat_wvel_sd              =   2.7512619659803E-01
-(PID.TID 0000.0001) %MON dynstat_wvel_del2            =   2.0122821472768E-03
+(PID.TID 0000.0001) %MON dynstat_wvel_mean            =   1.1977346363258E-04
+(PID.TID 0000.0001) %MON dynstat_wvel_sd              =   2.7512619659800E-01
+(PID.TID 0000.0001) %MON dynstat_wvel_del2            =   2.0122821472759E-03
 (PID.TID 0000.0001) %MON dynstat_theta_max            =   2.9452233210014E+01
 (PID.TID 0000.0001) %MON dynstat_theta_min            =  -1.9009836274721E+00
 (PID.TID 0000.0001) %MON dynstat_theta_mean           =   3.5926057499360E+00
 (PID.TID 0000.0001) %MON dynstat_theta_sd             =   4.4297036930181E+00
-(PID.TID 0000.0001) %MON dynstat_theta_del2           =   2.3151018753563E-03
+(PID.TID 0000.0001) %MON dynstat_theta_del2           =   2.3151018753562E-03
 (PID.TID 0000.0001) %MON dynstat_salt_max             =   4.0715753394131E+01
-(PID.TID 0000.0001) %MON dynstat_salt_min             =   1.5621720707520E+01
+(PID.TID 0000.0001) %MON dynstat_salt_min             =   1.5621720707522E+01
 (PID.TID 0000.0001) %MON dynstat_salt_mean            =   3.4721551134163E+01
 (PID.TID 0000.0001) %MON dynstat_salt_sd              =   4.8718599459171E-01
-(PID.TID 0000.0001) %MON dynstat_salt_del2            =   5.0614858738472E-04
+(PID.TID 0000.0001) %MON dynstat_salt_del2            =   5.0614858738475E-04
 (PID.TID 0000.0001) %MON forcing_qnet_max             =   7.0446786844736E+02
-(PID.TID 0000.0001) %MON forcing_qnet_min             =  -3.1232557406658E+02
-(PID.TID 0000.0001) %MON forcing_qnet_mean            =  -2.8182830424194E+01
+(PID.TID 0000.0001) %MON forcing_qnet_min             =  -3.1232557406657E+02
+(PID.TID 0000.0001) %MON forcing_qnet_mean            =  -2.8182830424196E+01
 (PID.TID 0000.0001) %MON forcing_qnet_sd              =   1.4617105712578E+02
-(PID.TID 0000.0001) %MON forcing_qnet_del2            =   8.3872555594239E-01
+(PID.TID 0000.0001) %MON forcing_qnet_del2            =   8.3872555594226E-01
 (PID.TID 0000.0001) %MON forcing_qsw_max              =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON forcing_qsw_min              =  -3.0180730070724E+02
 (PID.TID 0000.0001) %MON forcing_qsw_mean             =  -1.8597973620708E+02
 (PID.TID 0000.0001) %MON forcing_qsw_sd               =   7.8390284286186E+01
 (PID.TID 0000.0001) %MON forcing_qsw_del2             =   1.1136014417886E-01
-(PID.TID 0000.0001) %MON forcing_empmr_max            =   1.7538089233729E-03
+(PID.TID 0000.0001) %MON forcing_empmr_max            =   1.7538089233736E-03
 (PID.TID 0000.0001) %MON forcing_empmr_min            =  -4.6070107974296E-04
-(PID.TID 0000.0001) %MON forcing_empmr_mean           =   1.2715834705229E-05
-(PID.TID 0000.0001) %MON forcing_empmr_sd             =   1.0544599674262E-04
-(PID.TID 0000.0001) %MON forcing_empmr_del2           =   1.4657286808774E-06
+(PID.TID 0000.0001) %MON forcing_empmr_mean           =   1.2715834705234E-05
+(PID.TID 0000.0001) %MON forcing_empmr_sd             =   1.0544599674263E-04
+(PID.TID 0000.0001) %MON forcing_empmr_del2           =   1.4657286808769E-06
 (PID.TID 0000.0001) %MON forcing_fu_max               =   2.4734156444157E-01
 (PID.TID 0000.0001) %MON forcing_fu_min               =  -2.3124407967036E-01
-(PID.TID 0000.0001) %MON forcing_fu_mean              =  -4.0947057224826E-03
+(PID.TID 0000.0001) %MON forcing_fu_mean              =  -4.0947057224825E-03
 (PID.TID 0000.0001) %MON forcing_fu_sd                =   6.4478847337158E-02
-(PID.TID 0000.0001) %MON forcing_fu_del2              =   2.1441076063599E-04
+(PID.TID 0000.0001) %MON forcing_fu_del2              =   2.1441076063598E-04
 (PID.TID 0000.0001) %MON forcing_fv_max               =   2.7696015458957E-01
 (PID.TID 0000.0001) %MON forcing_fv_min               =  -3.3401105942538E-01
 (PID.TID 0000.0001) %MON forcing_fv_mean              =  -1.3706994668373E-02
 (PID.TID 0000.0001) %MON forcing_fv_sd                =   7.5852979941087E-02
 (PID.TID 0000.0001) %MON forcing_fv_del2              =   2.4162973236994E-04
-(PID.TID 0000.0001) %MON trAdv_CFL_u_max              =   5.0136044471913E-02
-(PID.TID 0000.0001) %MON trAdv_CFL_v_max              =   8.0223416180482E-02
-(PID.TID 0000.0001) %MON trAdv_CFL_w_max              =   2.7522548575865E-01
-(PID.TID 0000.0001) %MON advcfl_uvel_max              =   5.0231286070832E-02
-(PID.TID 0000.0001) %MON advcfl_vvel_max              =   6.2663313325647E-02
-(PID.TID 0000.0001) %MON advcfl_wvel_max              =   3.0147643118932E-01
-(PID.TID 0000.0001) %MON advcfl_W_hf_max              =   3.3302541711625E-01
+(PID.TID 0000.0001) %MON trAdv_CFL_u_max              =   5.0136044471886E-02
+(PID.TID 0000.0001) %MON trAdv_CFL_v_max              =   8.0223416180480E-02
+(PID.TID 0000.0001) %MON trAdv_CFL_w_max              =   2.7522548575864E-01
+(PID.TID 0000.0001) %MON advcfl_uvel_max              =   5.0231286070805E-02
+(PID.TID 0000.0001) %MON advcfl_vvel_max              =   6.2663313325685E-02
+(PID.TID 0000.0001) %MON advcfl_wvel_max              =   3.0147643118931E-01
+(PID.TID 0000.0001) %MON advcfl_W_hf_max              =   3.3302541711624E-01
 (PID.TID 0000.0001) %MON pe_b_mean                    =   1.3602713866758E-02
 (PID.TID 0000.0001) %MON ke_max                       =   1.6771136725635E-02
-(PID.TID 0000.0001) %MON ke_mean                      =   7.8043839196644E-05
+(PID.TID 0000.0001) %MON ke_mean                      =   7.8043839196645E-05
 (PID.TID 0000.0001) %MON ke_vol                       =   1.3604135613380E+22
-(PID.TID 0000.0001) %MON vort_r_min                   =  -8.0847415759849E-07
-(PID.TID 0000.0001) %MON vort_r_max                   =   8.7642380563978E-07
+(PID.TID 0000.0001) %MON vort_r_min                   =  -8.0847415759848E-07
+(PID.TID 0000.0001) %MON vort_r_max                   =   8.7642380564054E-07
 (PID.TID 0000.0001) %MON vort_a_mean                  =  -2.0556865257795E-05
 (PID.TID 0000.0001) %MON vort_a_sd                    =   7.5247481704435E-05
 (PID.TID 0000.0001) %MON vort_p_mean                  =  -2.4859242488275E-05
 (PID.TID 0000.0001) %MON vort_p_sd                    =   1.2920581029737E-04
-(PID.TID 0000.0001) %MON surfExpan_theta_mean         =  -1.7184897475106E-03
-(PID.TID 0000.0001) %MON surfExpan_salt_mean          =  -3.8879783103739E-03
+(PID.TID 0000.0001) %MON surfExpan_theta_mean         =  -1.7184897475152E-03
+(PID.TID 0000.0001) %MON surfExpan_salt_mean          =  -3.8879783104210E-03
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // End MONITOR dynamic field statistics
 (PID.TID 0000.0001) // =======================================================
@@ -4621,31 +4621,31 @@ listId=   2 ; file name: seaiceStDiag
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) %MON seaice_tsnumber              =                    10
 (PID.TID 0000.0001) %MON seaice_time_sec              =   8.6400000000000E+05
-(PID.TID 0000.0001) %MON seaice_uice_max              =   1.7314902420608E-01
-(PID.TID 0000.0001) %MON seaice_uice_min              =  -2.3167388153803E-01
-(PID.TID 0000.0001) %MON seaice_uice_mean             =  -6.3551659372816E-04
-(PID.TID 0000.0001) %MON seaice_uice_sd               =   1.5027694502955E-02
-(PID.TID 0000.0001) %MON seaice_uice_del2             =   2.2433227559630E-04
-(PID.TID 0000.0001) %MON seaice_vice_max              =   1.6913890839582E-01
-(PID.TID 0000.0001) %MON seaice_vice_min              =  -1.9231990342761E-01
-(PID.TID 0000.0001) %MON seaice_vice_mean             =   1.4131259211776E-03
-(PID.TID 0000.0001) %MON seaice_vice_sd               =   1.6241281134975E-02
-(PID.TID 0000.0001) %MON seaice_vice_del2             =   1.3591620479248E-04
-(PID.TID 0000.0001) %MON seaice_area_max              =   9.9122973307800E-01
+(PID.TID 0000.0001) %MON seaice_uice_max              =   1.7314902420609E-01
+(PID.TID 0000.0001) %MON seaice_uice_min              =  -2.3167388153805E-01
+(PID.TID 0000.0001) %MON seaice_uice_mean             =  -6.3551659372815E-04
+(PID.TID 0000.0001) %MON seaice_uice_sd               =   1.5027694502943E-02
+(PID.TID 0000.0001) %MON seaice_uice_del2             =   2.2433227559505E-04
+(PID.TID 0000.0001) %MON seaice_vice_max              =   1.6913890839578E-01
+(PID.TID 0000.0001) %MON seaice_vice_min              =  -1.9231990342746E-01
+(PID.TID 0000.0001) %MON seaice_vice_mean             =   1.4131259211792E-03
+(PID.TID 0000.0001) %MON seaice_vice_sd               =   1.6241281134974E-02
+(PID.TID 0000.0001) %MON seaice_vice_del2             =   1.3591620479152E-04
+(PID.TID 0000.0001) %MON seaice_area_max              =   9.9122973307799E-01
 (PID.TID 0000.0001) %MON seaice_area_min              =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON seaice_area_mean             =   2.4792227062137E-02
+(PID.TID 0000.0001) %MON seaice_area_mean             =   2.4792227062136E-02
 (PID.TID 0000.0001) %MON seaice_area_sd               =   1.4783338370493E-01
-(PID.TID 0000.0001) %MON seaice_area_del2             =   9.0555776294243E-04
-(PID.TID 0000.0001) %MON seaice_heff_max              =   7.4146789812481E-01
+(PID.TID 0000.0001) %MON seaice_area_del2             =   9.0555776294223E-04
+(PID.TID 0000.0001) %MON seaice_heff_max              =   7.4146789812456E-01
 (PID.TID 0000.0001) %MON seaice_heff_min              =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON seaice_heff_mean             =   1.5978503176034E-02
-(PID.TID 0000.0001) %MON seaice_heff_sd               =   9.7526035818440E-02
-(PID.TID 0000.0001) %MON seaice_heff_del2             =   5.6112812587901E-04
-(PID.TID 0000.0001) %MON seaice_hsnow_max             =   2.2469995500018E-02
+(PID.TID 0000.0001) %MON seaice_heff_mean             =   1.5978503176035E-02
+(PID.TID 0000.0001) %MON seaice_heff_sd               =   9.7526035818447E-02
+(PID.TID 0000.0001) %MON seaice_heff_del2             =   5.6112812587906E-04
+(PID.TID 0000.0001) %MON seaice_hsnow_max             =   2.2469995500022E-02
 (PID.TID 0000.0001) %MON seaice_hsnow_min             =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON seaice_hsnow_mean            =   2.3565268670027E-04
-(PID.TID 0000.0001) %MON seaice_hsnow_sd              =   1.6545552811390E-03
-(PID.TID 0000.0001) %MON seaice_hsnow_del2            =   2.0103641870952E-05
+(PID.TID 0000.0001) %MON seaice_hsnow_mean            =   2.3565268670026E-04
+(PID.TID 0000.0001) %MON seaice_hsnow_sd              =   1.6545552811389E-03
+(PID.TID 0000.0001) %MON seaice_hsnow_del2            =   2.0103641870954E-05
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // End MONITOR SEAICE statistics
 (PID.TID 0000.0001) // =======================================================
@@ -4676,183 +4676,183 @@ listId=   2 ; file name: seaiceStDiag
 (PID.TID 0000.0001) DIAGSTATS_CLOSE_IO: close file: seaiceStDiag.0000000000.txt , unit=    10
 (PID.TID 0000.0001) %CHECKPOINT        10 ckptA
 (PID.TID 0000.0001)   Seconds in section "ALL                    [THE_MODEL_MAIN]":
-(PID.TID 0000.0001)           User time:   17.648967304266989
-(PID.TID 0000.0001)         System time:  0.27947701234370470
-(PID.TID 0000.0001)     Wall clock time:   17.938468933105469
+(PID.TID 0000.0001)           User time:   17.574636382982135
+(PID.TID 0000.0001)         System time:  0.30429198592901230
+(PID.TID 0000.0001)     Wall clock time:   18.276706933975220
 (PID.TID 0000.0001)          No. starts:           1
 (PID.TID 0000.0001)           No. stops:           1
 (PID.TID 0000.0001)   Seconds in section "INITIALISE_FIXED       [THE_MODEL_MAIN]":
-(PID.TID 0000.0001)           User time:  0.25156001467257738
-(PID.TID 0000.0001)         System time:   7.5686997268348932E-002
-(PID.TID 0000.0001)     Wall clock time:  0.32773995399475098
+(PID.TID 0000.0001)           User time:  0.26438800990581512
+(PID.TID 0000.0001)         System time:   4.9617998767644167E-002
+(PID.TID 0000.0001)     Wall clock time:  0.38808488845825195
 (PID.TID 0000.0001)          No. starts:           1
 (PID.TID 0000.0001)           No. stops:           1
 (PID.TID 0000.0001)   Seconds in section "THE_MAIN_LOOP          [THE_MODEL_MAIN]":
-(PID.TID 0000.0001)           User time:   17.397365689277649
-(PID.TID 0000.0001)         System time:  0.20377401262521744
-(PID.TID 0000.0001)     Wall clock time:   17.610681056976318
+(PID.TID 0000.0001)           User time:   17.310180753469467
+(PID.TID 0000.0001)         System time:  0.25465998426079750
+(PID.TID 0000.0001)     Wall clock time:   17.888552904129028
 (PID.TID 0000.0001)          No. starts:           1
 (PID.TID 0000.0001)           No. stops:           1
 (PID.TID 0000.0001)   Seconds in section "INITIALISE_VARIA    [THE_MAIN_LOOP]":
-(PID.TID 0000.0001)           User time:  0.32979798316955566
-(PID.TID 0000.0001)         System time:  0.13123399764299393
-(PID.TID 0000.0001)     Wall clock time:  0.46505999565124512
+(PID.TID 0000.0001)           User time:  0.48894500732421875
+(PID.TID 0000.0001)         System time:  0.14986600354313850
+(PID.TID 0000.0001)     Wall clock time:  0.92229080200195312
 (PID.TID 0000.0001)          No. starts:           1
 (PID.TID 0000.0001)           No. stops:           1
 (PID.TID 0000.0001)   Seconds in section "MAIN LOOP           [THE_MAIN_LOOP]":
-(PID.TID 0000.0001)           User time:   17.067548036575317
-(PID.TID 0000.0001)         System time:   7.2536006569862366E-002
-(PID.TID 0000.0001)     Wall clock time:   17.145596981048584
+(PID.TID 0000.0001)           User time:   16.821198225021362
+(PID.TID 0000.0001)         System time:  0.10478799045085907
+(PID.TID 0000.0001)     Wall clock time:   16.966221094131470
 (PID.TID 0000.0001)          No. starts:           1
 (PID.TID 0000.0001)           No. stops:           1
 (PID.TID 0000.0001)   Seconds in section "MAIN_DO_LOOP        [THE_MAIN_LOOP]":
-(PID.TID 0000.0001)           User time:   17.067465305328369
-(PID.TID 0000.0001)         System time:   7.2535008192062378E-002
-(PID.TID 0000.0001)     Wall clock time:   17.145513772964478
+(PID.TID 0000.0001)           User time:   16.821107566356659
+(PID.TID 0000.0001)         System time:  0.10478498041629791
+(PID.TID 0000.0001)     Wall clock time:   16.966128110885620
 (PID.TID 0000.0001)          No. starts:          10
 (PID.TID 0000.0001)           No. stops:          10
 (PID.TID 0000.0001)   Seconds in section "FORWARD_STEP        [MAIN_DO_LOOP]":
-(PID.TID 0000.0001)           User time:   17.067304849624634
-(PID.TID 0000.0001)         System time:   7.2533011436462402E-002
-(PID.TID 0000.0001)     Wall clock time:   17.145348787307739
+(PID.TID 0000.0001)           User time:   16.820935666561127
+(PID.TID 0000.0001)         System time:  0.10477899014949799
+(PID.TID 0000.0001)     Wall clock time:   16.965954065322876
 (PID.TID 0000.0001)          No. starts:          10
 (PID.TID 0000.0001)           No. stops:          10
 (PID.TID 0000.0001)   Seconds in section "UPDATE_R_STAR       [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:  0.43627077341079712
-(PID.TID 0000.0001)         System time:   8.7991356849670410E-005
-(PID.TID 0000.0001)     Wall clock time:  0.43641877174377441
+(PID.TID 0000.0001)           User time:  0.45992785692214966
+(PID.TID 0000.0001)         System time:   4.3299794197082520E-004
+(PID.TID 0000.0001)     Wall clock time:  0.46043205261230469
 (PID.TID 0000.0001)          No. starts:          20
 (PID.TID 0000.0001)           No. stops:          20
 (PID.TID 0000.0001)   Seconds in section "DO_STATEVARS_DIAGS  [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:  0.72046405076980591
-(PID.TID 0000.0001)         System time:   7.6500028371810913E-003
-(PID.TID 0000.0001)     Wall clock time:  0.72824287414550781
+(PID.TID 0000.0001)           User time:  0.74562102556228638
+(PID.TID 0000.0001)         System time:   7.9029947519302368E-003
+(PID.TID 0000.0001)     Wall clock time:  0.75371575355529785
 (PID.TID 0000.0001)          No. starts:          30
 (PID.TID 0000.0001)           No. stops:          30
 (PID.TID 0000.0001)   Seconds in section "LOAD_FIELDS_DRIVER  [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:  0.15910220146179199
-(PID.TID 0000.0001)         System time:   2.0995736122131348E-005
-(PID.TID 0000.0001)     Wall clock time:  0.15913939476013184
+(PID.TID 0000.0001)           User time:  0.16645014286041260
+(PID.TID 0000.0001)         System time:   4.0909945964813232E-003
+(PID.TID 0000.0001)     Wall clock time:  0.18141150474548340
 (PID.TID 0000.0001)          No. starts:          10
 (PID.TID 0000.0001)           No. stops:          10
 (PID.TID 0000.0001)   Seconds in section "EXF_GETFORCING     [LOAD_FLDS_DRIVER]":
-(PID.TID 0000.0001)           User time:  0.14905661344528198
-(PID.TID 0000.0001)         System time:   9.9986791610717773E-006
-(PID.TID 0000.0001)     Wall clock time:  0.14909720420837402
+(PID.TID 0000.0001)           User time:  0.15935868024826050
+(PID.TID 0000.0001)         System time:   4.0870010852813721E-003
+(PID.TID 0000.0001)     Wall clock time:  0.17434120178222656
 (PID.TID 0000.0001)          No. starts:          10
 (PID.TID 0000.0001)           No. stops:          10
 (PID.TID 0000.0001)   Seconds in section "EXTERNAL_FLDS_LOAD [LOAD_FLDS_DRIVER]":
-(PID.TID 0000.0001)           User time:   9.7843408584594727E-003
-(PID.TID 0000.0001)         System time:   8.0019235610961914E-006
-(PID.TID 0000.0001)     Wall clock time:   9.8018646240234375E-003
+(PID.TID 0000.0001)           User time:   6.8049430847167969E-003
+(PID.TID 0000.0001)         System time:   0.0000000000000000
+(PID.TID 0000.0001)     Wall clock time:   6.8130493164062500E-003
 (PID.TID 0000.0001)          No. starts:          10
 (PID.TID 0000.0001)           No. stops:          10
 (PID.TID 0000.0001)   Seconds in section "DO_ATMOSPHERIC_PHYS [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:   8.8453292846679688E-005
+(PID.TID 0000.0001)           User time:   8.5294246673583984E-005
 (PID.TID 0000.0001)         System time:   0.0000000000000000
-(PID.TID 0000.0001)     Wall clock time:   8.7261199951171875E-005
+(PID.TID 0000.0001)     Wall clock time:   8.4877014160156250E-005
 (PID.TID 0000.0001)          No. starts:          10
 (PID.TID 0000.0001)           No. stops:          10
 (PID.TID 0000.0001)   Seconds in section "DO_OCEANIC_PHYS     [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:   5.5339111089706421
-(PID.TID 0000.0001)         System time:   8.4499865770339966E-003
-(PID.TID 0000.0001)     Wall clock time:   5.5427541732788086
+(PID.TID 0000.0001)           User time:   5.4796867370605469
+(PID.TID 0000.0001)         System time:   1.5552982687950134E-002
+(PID.TID 0000.0001)     Wall clock time:   5.4957346916198730
 (PID.TID 0000.0001)          No. starts:          10
 (PID.TID 0000.0001)           No. stops:          10
 (PID.TID 0000.0001)   Seconds in section "SEAICE_MODEL    [DO_OCEANIC_PHYS]":
-(PID.TID 0000.0001)           User time:   2.1982228755950928
-(PID.TID 0000.0001)         System time:   3.9909929037094116E-003
-(PID.TID 0000.0001)     Wall clock time:   2.2024800777435303
+(PID.TID 0000.0001)           User time:   2.2374928593635559
+(PID.TID 0000.0001)         System time:   7.5409859418869019E-003
+(PID.TID 0000.0001)     Wall clock time:   2.2451829910278320
 (PID.TID 0000.0001)          No. starts:          10
 (PID.TID 0000.0001)           No. stops:          10
 (PID.TID 0000.0001)   Seconds in section "SEAICE_DYNSOLVER   [SEAICE_MODEL]":
-(PID.TID 0000.0001)           User time:   1.8208924531936646
+(PID.TID 0000.0001)           User time:   1.8530692458152771
 (PID.TID 0000.0001)         System time:   0.0000000000000000
-(PID.TID 0000.0001)     Wall clock time:   1.8210697174072266
+(PID.TID 0000.0001)     Wall clock time:   1.8532128334045410
 (PID.TID 0000.0001)          No. starts:          10
 (PID.TID 0000.0001)           No. stops:          10
 (PID.TID 0000.0001)   Seconds in section "GGL90_CALC [DO_OCEANIC_PHYS]":
-(PID.TID 0000.0001)           User time:   2.5573980808258057
-(PID.TID 0000.0001)         System time:   3.9379894733428955E-003
-(PID.TID 0000.0001)     Wall clock time:   2.5615074634552002
+(PID.TID 0000.0001)           User time:   2.4696825742721558
+(PID.TID 0000.0001)         System time:   8.0019980669021606E-003
+(PID.TID 0000.0001)     Wall clock time:   2.4780409336090088
 (PID.TID 0000.0001)          No. starts:         120
 (PID.TID 0000.0001)           No. stops:         120
 (PID.TID 0000.0001)   Seconds in section "DYNAMICS            [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:   4.0716116428375244
-(PID.TID 0000.0001)         System time:   3.7419945001602173E-003
-(PID.TID 0000.0001)     Wall clock time:   4.0755672454833984
+(PID.TID 0000.0001)           User time:   3.8061685562133789
+(PID.TID 0000.0001)         System time:   1.0549008846282959E-002
+(PID.TID 0000.0001)     Wall clock time:   3.8176755905151367
 (PID.TID 0000.0001)          No. starts:          10
 (PID.TID 0000.0001)           No. stops:          10
 (PID.TID 0000.0001)   Seconds in section "UPDATE_CG2D         [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:   8.1894397735595703E-002
-(PID.TID 0000.0001)         System time:   1.0699033737182617E-004
-(PID.TID 0000.0001)     Wall clock time:   8.5816144943237305E-002
+(PID.TID 0000.0001)           User time:   7.1498036384582520E-002
+(PID.TID 0000.0001)         System time:   3.9499998092651367E-003
+(PID.TID 0000.0001)     Wall clock time:   7.5458765029907227E-002
 (PID.TID 0000.0001)          No. starts:          10
 (PID.TID 0000.0001)           No. stops:          10
 (PID.TID 0000.0001)   Seconds in section "SOLVE_FOR_PRESSURE  [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:   1.7584137916564941
-(PID.TID 0000.0001)         System time:   2.6899576187133789E-004
-(PID.TID 0000.0001)     Wall clock time:   1.7588489055633545
+(PID.TID 0000.0001)           User time:   1.7734459638595581
+(PID.TID 0000.0001)         System time:   3.3899843692779541E-003
+(PID.TID 0000.0001)     Wall clock time:   1.7861719131469727
 (PID.TID 0000.0001)          No. starts:          10
 (PID.TID 0000.0001)           No. stops:          10
 (PID.TID 0000.0001)   Seconds in section "MOM_CORRECTION_STEP [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:  0.13771259784698486
+(PID.TID 0000.0001)           User time:  0.13301920890808105
 (PID.TID 0000.0001)         System time:   0.0000000000000000
-(PID.TID 0000.0001)     Wall clock time:  0.13774561882019043
+(PID.TID 0000.0001)     Wall clock time:  0.13304162025451660
 (PID.TID 0000.0001)          No. starts:          10
 (PID.TID 0000.0001)           No. stops:          10
 (PID.TID 0000.0001)   Seconds in section "INTEGR_CONTINUITY   [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:  0.25348925590515137
+(PID.TID 0000.0001)           User time:  0.23056030273437500
 (PID.TID 0000.0001)         System time:   0.0000000000000000
-(PID.TID 0000.0001)     Wall clock time:  0.25354361534118652
+(PID.TID 0000.0001)     Wall clock time:  0.23063039779663086
 (PID.TID 0000.0001)          No. starts:          10
 (PID.TID 0000.0001)           No. stops:          10
 (PID.TID 0000.0001)   Seconds in section "CALC_R_STAR         [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:   4.3705582618713379E-002
-(PID.TID 0000.0001)         System time:   9.9837779998779297E-007
-(PID.TID 0000.0001)     Wall clock time:   4.3733835220336914E-002
+(PID.TID 0000.0001)           User time:   4.8941612243652344E-002
+(PID.TID 0000.0001)         System time:   3.8630068302154541E-003
+(PID.TID 0000.0001)     Wall clock time:   5.2829027175903320E-002
 (PID.TID 0000.0001)          No. starts:          10
 (PID.TID 0000.0001)           No. stops:          10
 (PID.TID 0000.0001)   Seconds in section "BLOCKING_EXCHANGES  [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:  0.21872496604919434
-(PID.TID 0000.0001)         System time:   0.0000000000000000
-(PID.TID 0000.0001)     Wall clock time:  0.21876788139343262
+(PID.TID 0000.0001)           User time:  0.20702528953552246
+(PID.TID 0000.0001)         System time:   4.1030049324035645E-003
+(PID.TID 0000.0001)     Wall clock time:  0.21116304397583008
 (PID.TID 0000.0001)          No. starts:          20
 (PID.TID 0000.0001)           No. stops:          20
 (PID.TID 0000.0001)   Seconds in section "THERMODYNAMICS      [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:   2.3474673032760620
-(PID.TID 0000.0001)         System time:   1.2072011828422546E-002
-(PID.TID 0000.0001)     Wall clock time:   2.3599941730499268
+(PID.TID 0000.0001)           User time:   2.4326133728027344
+(PID.TID 0000.0001)         System time:   7.1129947900772095E-003
+(PID.TID 0000.0001)     Wall clock time:   2.4400346279144287
 (PID.TID 0000.0001)          No. starts:          10
 (PID.TID 0000.0001)           No. stops:          10
 (PID.TID 0000.0001)   Seconds in section "TRC_CORRECTION_STEP [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:   8.3208084106445312E-005
-(PID.TID 0000.0001)         System time:   9.9837779998779297E-007
-(PID.TID 0000.0001)     Wall clock time:   8.8691711425781250E-005
+(PID.TID 0000.0001)           User time:   9.7513198852539062E-005
+(PID.TID 0000.0001)         System time:   1.9967555999755859E-006
+(PID.TID 0000.0001)     Wall clock time:   9.3460083007812500E-005
 (PID.TID 0000.0001)          No. starts:          10
 (PID.TID 0000.0001)           No. stops:          10
 (PID.TID 0000.0001)   Seconds in section "DO_STATEVARS_TAVE   [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:   8.1777572631835938E-005
-(PID.TID 0000.0001)         System time:   0.0000000000000000
-(PID.TID 0000.0001)     Wall clock time:   7.5578689575195312E-005
+(PID.TID 0000.0001)           User time:   7.8439712524414062E-005
+(PID.TID 0000.0001)         System time:   9.9837779998779297E-007
+(PID.TID 0000.0001)     Wall clock time:   7.8678131103515625E-005
 (PID.TID 0000.0001)          No. starts:          10
 (PID.TID 0000.0001)           No. stops:          10
 (PID.TID 0000.0001)   Seconds in section "MONITOR             [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:   1.1644122600555420
-(PID.TID 0000.0001)         System time:   4.1249990463256836E-003
-(PID.TID 0000.0001)     Wall clock time:   1.1690278053283691
+(PID.TID 0000.0001)           User time:   1.0958182811737061
+(PID.TID 0000.0001)         System time:   3.9050132036209106E-003
+(PID.TID 0000.0001)     Wall clock time:   1.0998036861419678
 (PID.TID 0000.0001)          No. starts:          10
 (PID.TID 0000.0001)           No. stops:          10
 (PID.TID 0000.0001)   Seconds in section "DO_THE_MODEL_IO     [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:   8.1232547760009766E-002
-(PID.TID 0000.0001)         System time:   1.1970996856689453E-002
-(PID.TID 0000.0001)     Wall clock time:   9.3215703964233398E-002
+(PID.TID 0000.0001)           User time:   8.9791059494018555E-002
+(PID.TID 0000.0001)         System time:   1.5814006328582764E-002
+(PID.TID 0000.0001)     Wall clock time:  0.12229609489440918
 (PID.TID 0000.0001)          No. starts:          10
 (PID.TID 0000.0001)           No. stops:          10
 (PID.TID 0000.0001)   Seconds in section "DO_WRITE_PICKUP     [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:   5.5189847946166992E-002
-(PID.TID 0000.0001)         System time:   2.3979008197784424E-002
-(PID.TID 0000.0001)     Wall clock time:   7.9172849655151367E-002
+(PID.TID 0000.0001)           User time:   7.6581478118896484E-002
+(PID.TID 0000.0001)         System time:   2.4028003215789795E-002
+(PID.TID 0000.0001)     Wall clock time:  0.10207891464233398
 (PID.TID 0000.0001)          No. starts:          10
 (PID.TID 0000.0001)           No. stops:          10
 (PID.TID 0000.0001) // ======================================================

--- a/verification/global_ocean.cs32x15/results/output.in_p.txt
+++ b/verification/global_ocean.cs32x15/results/output.in_p.txt
@@ -8,7 +8,7 @@
 (PID.TID 0000.0001) // MITgcmUV version:  checkpoint68a
 (PID.TID 0000.0001) // Build user:        jm_c
 (PID.TID 0000.0001) // Build host:        villon
-(PID.TID 0000.0001) // Build date:        Mon Aug 16 12:37:13 EDT 2021
+(PID.TID 0000.0001) // Build date:        Thu Aug 19 11:54:34 EDT 2021
 (PID.TID 0000.0001) 
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // Execution Environment parameter file "eedata"
@@ -400,6 +400,11 @@
 (PID.TID 0000.0001) > /
 (PID.TID 0000.0001) >
 (PID.TID 0000.0001) > &GGL90_PARM02
+(PID.TID 0000.0001) >#- below are old defaults that are not recommended
+(PID.TID 0000.0001) ># IDEMIX_tau_v =  86400.0,
+(PID.TID 0000.0001) ># IDEMIX_jstar = 10.0,
+(PID.TID 0000.0001) ># IDEMIX_mu0   = 1.3333333333333333,
+(PID.TID 0000.0001) >#--
 (PID.TID 0000.0001) > IDEMIX_include_GM_bottom = .FALSE.,
 (PID.TID 0000.0001) > IDEMIX_include_GM        = .FALSE.,
 (PID.TID 0000.0001) > IDEMIX_tidal_file = 'idemix_tidal_forcing.192x32.bin',
@@ -476,7 +481,7 @@
 (PID.TID 0000.0001)                   T
 (PID.TID 0000.0001)     ;
 (PID.TID 0000.0001) IDEMIX_tau_v =   /* IDEMIX vertical group speed parameter. */
-(PID.TID 0000.0001)                 8.640000000000000E+04
+(PID.TID 0000.0001)                 1.728000000000000E+05
 (PID.TID 0000.0001)     ;
 (PID.TID 0000.0001) IDEMIX_tau_h =   /* IDEMIX horizontal group speed parameter. */
 (PID.TID 0000.0001)                 8.640000000000000E+05
@@ -485,10 +490,10 @@
 (PID.TID 0000.0001)                 1.570000000000000E+00
 (PID.TID 0000.0001)     ;
 (PID.TID 0000.0001) IDEMIX_jstar =   /* IDEMIX baroclinic mode bandwidth. */
-(PID.TID 0000.0001)                 1.000000000000000E+01
+(PID.TID 0000.0001)                 5.000000000000000E+00
 (PID.TID 0000.0001)     ;
 (PID.TID 0000.0001) IDEMIX_mu0 =   /* IDEMIX dissipation parameter. */
-(PID.TID 0000.0001)                 1.333333333333333E+00
+(PID.TID 0000.0001)                 3.333333333333333E-01
 (PID.TID 0000.0001)     ;
 (PID.TID 0000.0001) IDEMIX_mixing_efficiency =   /* IDEMIX mixing efficiency. */
 (PID.TID 0000.0001)                 1.666000000000000E-01
@@ -3522,45 +3527,45 @@ listId=   2 ; file name: seaiceStDiag
  SEAICE_LSR: Residual Initial ipass,Uice,Vice=         2  2.91320932E-04  5.24466148E-04
  SEAICE_LSR (ipass=        2) iters,dU,Resid=       12  6.06459327E-14  9.69157167E-20
  SEAICE_LSR (ipass=        2) iters,dV,Resid=       12  4.21190860E-14  1.94946727E-19
- cg2d: Sum(rhs),rhsMax =   7.66661733960343E-02  2.00457239865341E+01
+ cg2d: Sum(rhs),rhsMax =   7.66661733960334E-02  2.00457239865341E+01
 (PID.TID 0000.0001)      cg2d_init_res =   4.84221893084459E-01
 (PID.TID 0000.0001)      cg2d_iters(min,last) =      -1     109
-(PID.TID 0000.0001)      cg2d_last_res =   8.74724599652742E-10
+(PID.TID 0000.0001)      cg2d_last_res =   8.73698225551374E-10
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // Begin MONITOR dynamic field statistics
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) %MON time_tsnumber                =                     2
 (PID.TID 0000.0001) %MON time_secondsf                =   1.7280000000000E+05
-(PID.TID 0000.0001) %MON dynstat_eta_max              =   1.4036965275148E+04
-(PID.TID 0000.0001) %MON dynstat_eta_min              =  -2.1104916362541E+04
+(PID.TID 0000.0001) %MON dynstat_eta_max              =   1.4036965276469E+04
+(PID.TID 0000.0001) %MON dynstat_eta_min              =  -2.1104916362745E+04
 (PID.TID 0000.0001) %MON dynstat_eta_mean             =  -2.3208444477514E+01
-(PID.TID 0000.0001) %MON dynstat_eta_sd               =   6.2877655143708E+03
-(PID.TID 0000.0001) %MON dynstat_eta_del2             =   9.5570817523729E+01
-(PID.TID 0000.0001) %MON dynstat_uvel_max             =   3.8335540667089E-02
-(PID.TID 0000.0001) %MON dynstat_uvel_min             =  -4.4651029012879E-02
-(PID.TID 0000.0001) %MON dynstat_uvel_mean            =  -3.3193706828628E-04
-(PID.TID 0000.0001) %MON dynstat_uvel_sd              =   2.3396750766954E-03
-(PID.TID 0000.0001) %MON dynstat_uvel_del2            =   1.2333597813095E-05
-(PID.TID 0000.0001) %MON dynstat_vvel_max             =   7.3366327760971E-02
-(PID.TID 0000.0001) %MON dynstat_vvel_min             =  -5.6465928266622E-02
-(PID.TID 0000.0001) %MON dynstat_vvel_mean            =  -6.8051627587492E-05
-(PID.TID 0000.0001) %MON dynstat_vvel_sd              =   2.4521930392503E-03
-(PID.TID 0000.0001) %MON dynstat_vvel_del2            =   1.2959564550894E-05
-(PID.TID 0000.0001) %MON dynstat_wvel_max             =   1.8519218962494E+00
-(PID.TID 0000.0001) %MON dynstat_wvel_min             =  -2.9433404939104E+00
-(PID.TID 0000.0001) %MON dynstat_wvel_mean            =   2.4537896047422E-03
-(PID.TID 0000.0001) %MON dynstat_wvel_sd              =   8.9180465244918E-02
-(PID.TID 0000.0001) %MON dynstat_wvel_del2            =   7.6787871356499E-04
-(PID.TID 0000.0001) %MON dynstat_theta_max            =   2.9400596552103E+01
-(PID.TID 0000.0001) %MON dynstat_theta_min            =  -1.8753303244749E+00
-(PID.TID 0000.0001) %MON dynstat_theta_mean           =   3.5913487271234E+00
-(PID.TID 0000.0001) %MON dynstat_theta_sd             =   4.4273028223381E+00
-(PID.TID 0000.0001) %MON dynstat_theta_del2           =   2.1350327197187E-03
-(PID.TID 0000.0001) %MON dynstat_salt_max             =   4.0715782043866E+01
-(PID.TID 0000.0001) %MON dynstat_salt_min             =   1.8061466083986E+01
-(PID.TID 0000.0001) %MON dynstat_salt_mean            =   3.4721464665322E+01
-(PID.TID 0000.0001) %MON dynstat_salt_sd              =   4.8775554545322E-01
-(PID.TID 0000.0001) %MON dynstat_salt_del2            =   5.1987260896929E-04
+(PID.TID 0000.0001) %MON dynstat_eta_sd               =   6.2877655143791E+03
+(PID.TID 0000.0001) %MON dynstat_eta_del2             =   9.5570817524595E+01
+(PID.TID 0000.0001) %MON dynstat_uvel_max             =   3.8475392352709E-02
+(PID.TID 0000.0001) %MON dynstat_uvel_min             =  -4.4818734840653E-02
+(PID.TID 0000.0001) %MON dynstat_uvel_mean            =  -3.3193706828645E-04
+(PID.TID 0000.0001) %MON dynstat_uvel_sd              =   2.3399471127987E-03
+(PID.TID 0000.0001) %MON dynstat_uvel_del2            =   1.2333958516494E-05
+(PID.TID 0000.0001) %MON dynstat_vvel_max             =   7.3366327761078E-02
+(PID.TID 0000.0001) %MON dynstat_vvel_min             =  -5.6465928920443E-02
+(PID.TID 0000.0001) %MON dynstat_vvel_mean            =  -6.8051627587629E-05
+(PID.TID 0000.0001) %MON dynstat_vvel_sd              =   2.4524493854771E-03
+(PID.TID 0000.0001) %MON dynstat_vvel_del2            =   1.2959830361881E-05
+(PID.TID 0000.0001) %MON dynstat_wvel_max             =   1.8519222567622E+00
+(PID.TID 0000.0001) %MON dynstat_wvel_min             =  -2.9433441322230E+00
+(PID.TID 0000.0001) %MON dynstat_wvel_mean            =   2.4537896047546E-03
+(PID.TID 0000.0001) %MON dynstat_wvel_sd              =   8.9180884635835E-02
+(PID.TID 0000.0001) %MON dynstat_wvel_del2            =   7.6787545006645E-04
+(PID.TID 0000.0001) %MON dynstat_theta_max            =   2.9400728092453E+01
+(PID.TID 0000.0001) %MON dynstat_theta_min            =  -1.8772209402070E+00
+(PID.TID 0000.0001) %MON dynstat_theta_mean           =   3.5913487270743E+00
+(PID.TID 0000.0001) %MON dynstat_theta_sd             =   4.4274065144544E+00
+(PID.TID 0000.0001) %MON dynstat_theta_del2           =   2.1125133401235E-03
+(PID.TID 0000.0001) %MON dynstat_salt_max             =   4.0715790109972E+01
+(PID.TID 0000.0001) %MON dynstat_salt_min             =   1.8061466083989E+01
+(PID.TID 0000.0001) %MON dynstat_salt_mean            =   3.4721464665354E+01
+(PID.TID 0000.0001) %MON dynstat_salt_sd              =   4.8779469479226E-01
+(PID.TID 0000.0001) %MON dynstat_salt_del2            =   5.1533979349649E-04
 (PID.TID 0000.0001) %MON forcing_qnet_max             =   6.9568301659527E+02
 (PID.TID 0000.0001) %MON forcing_qnet_min             =  -3.1666111122704E+02
 (PID.TID 0000.0001) %MON forcing_qnet_mean            =  -2.1816692279327E+01
@@ -3586,25 +3591,25 @@ listId=   2 ; file name: seaiceStDiag
 (PID.TID 0000.0001) %MON forcing_fv_mean              =  -1.3688466828709E-02
 (PID.TID 0000.0001) %MON forcing_fv_sd                =   7.5192568394714E-02
 (PID.TID 0000.0001) %MON forcing_fv_del2              =   2.3387409827505E-04
-(PID.TID 0000.0001) %MON trAdv_CFL_u_max              =   1.5992062360550E-02
-(PID.TID 0000.0001) %MON trAdv_CFL_v_max              =   2.4917775183709E-02
-(PID.TID 0000.0001) %MON trAdv_CFL_w_max              =   7.6016910197410E-02
-(PID.TID 0000.0001) %MON advcfl_uvel_max              =   1.4235253129861E-02
-(PID.TID 0000.0001) %MON advcfl_vvel_max              =   2.3940139947800E-02
-(PID.TID 0000.0001) %MON advcfl_wvel_max              =   8.3246481228855E-02
-(PID.TID 0000.0001) %MON advcfl_W_hf_max              =   9.1981173751403E-02
-(PID.TID 0000.0001) %MON pe_b_mean                    =   1.2124608444676E-02
-(PID.TID 0000.0001) %MON ke_max                       =   1.6821389677809E-03
-(PID.TID 0000.0001) %MON ke_mean                      =   5.3572483612516E-06
+(PID.TID 0000.0001) %MON trAdv_CFL_u_max              =   1.5992061863050E-02
+(PID.TID 0000.0001) %MON trAdv_CFL_v_max              =   2.4917775183746E-02
+(PID.TID 0000.0001) %MON trAdv_CFL_w_max              =   7.6016944092193E-02
+(PID.TID 0000.0001) %MON advcfl_uvel_max              =   1.4235257679332E-02
+(PID.TID 0000.0001) %MON advcfl_vvel_max              =   2.3940139947835E-02
+(PID.TID 0000.0001) %MON advcfl_wvel_max              =   8.3246518347193E-02
+(PID.TID 0000.0001) %MON advcfl_W_hf_max              =   9.1981214764409E-02
+(PID.TID 0000.0001) %MON pe_b_mean                    =   1.2124608444698E-02
+(PID.TID 0000.0001) %MON ke_max                       =   1.6821389677744E-03
+(PID.TID 0000.0001) %MON ke_mean                      =   5.3584166009114E-06
 (PID.TID 0000.0001) %MON ke_vol                       =   1.3604174062081E+22
-(PID.TID 0000.0001) %MON vort_r_min                   =  -3.6063117582013E-07
-(PID.TID 0000.0001) %MON vort_r_max                   =   4.3008997581532E-07
+(PID.TID 0000.0001) %MON vort_r_min                   =  -3.6133388808004E-07
+(PID.TID 0000.0001) %MON vort_r_max                   =   4.3008997581372E-07
 (PID.TID 0000.0001) %MON vort_a_mean                  =  -2.0556865257795E-05
-(PID.TID 0000.0001) %MON vort_a_sd                    =   7.5247345875121E-05
-(PID.TID 0000.0001) %MON vort_p_mean                  =  -2.4859276343880E-05
-(PID.TID 0000.0001) %MON vort_p_sd                    =   1.2919528775072E-04
-(PID.TID 0000.0001) %MON surfExpan_theta_mean         =   7.0941539463679E-03
-(PID.TID 0000.0001) %MON surfExpan_salt_mean          =  -4.3489466007773E-03
+(PID.TID 0000.0001) %MON vort_a_sd                    =   7.5247345870991E-05
+(PID.TID 0000.0001) %MON vort_p_mean                  =  -2.4859276343879E-05
+(PID.TID 0000.0001) %MON vort_p_sd                    =   1.2919529007563E-04
+(PID.TID 0000.0001) %MON surfExpan_theta_mean         =   7.0941751989975E-03
+(PID.TID 0000.0001) %MON surfExpan_salt_mean          =  -4.3489600592981E-03
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // End MONITOR dynamic field statistics
 (PID.TID 0000.0001) // =======================================================
@@ -3642,95 +3647,95 @@ listId=   2 ; file name: seaiceStDiag
 (PID.TID 0000.0001) // End MONITOR SEAICE statistics
 (PID.TID 0000.0001) // =======================================================
  EXTERNAL_FIELDS_LOAD,         2 : iP,iLd,i0,i1=   12    1   12    1 ; Wght=  0.4333333333  0.5666666667
- SEAICE_LSR: Residual Initial ipass,Uice,Vice=         1  5.59360800E-04  8.46021758E-04
- SEAICE_LSR (ipass=        1) iters,dU,Resid=       12  2.57904809E-13  2.35680951E-19
- SEAICE_LSR (ipass=        1) iters,dV,Resid=       12  1.46327395E-13  3.85544599E-19
- SEAICE_LSR: Residual Initial ipass,Uice,Vice=         2  1.59915603E-04  1.95760454E-04
- SEAICE_LSR (ipass=        2) iters,dU,Resid=       12  2.29954944E-14  1.56964448E-19
- SEAICE_LSR (ipass=        2) iters,dV,Resid=       12  3.57205585E-14  3.27939976E-19
- cg2d: Sum(rhs),rhsMax =   1.33366823273831E-01  1.98889685127973E+01
-(PID.TID 0000.0001)      cg2d_init_res =   1.91658343627827E-01
+ SEAICE_LSR: Residual Initial ipass,Uice,Vice=         1  5.59552731E-04  8.46157403E-04
+ SEAICE_LSR (ipass=        1) iters,dU,Resid=       12  2.57960320E-13  2.89103018E-19
+ SEAICE_LSR (ipass=        1) iters,dV,Resid=       12  1.46355150E-13  3.72958036E-19
+ SEAICE_LSR: Residual Initial ipass,Uice,Vice=         2  1.59909279E-04  1.95870480E-04
+ SEAICE_LSR (ipass=        2) iters,dU,Resid=       12  2.29816166E-14  1.76490575E-19
+ SEAICE_LSR (ipass=        2) iters,dV,Resid=       12  3.57535182E-14  2.54268604E-19
+ cg2d: Sum(rhs),rhsMax =   1.38052606713420E-01  1.98889658832416E+01
+(PID.TID 0000.0001)      cg2d_init_res =   1.91531361232788E-01
 (PID.TID 0000.0001)      cg2d_iters(min,last) =      -1     104
-(PID.TID 0000.0001)      cg2d_last_res =   9.59459770276362E-10
+(PID.TID 0000.0001)      cg2d_last_res =   9.55216726667132E-10
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // Begin MONITOR dynamic field statistics
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) %MON time_tsnumber                =                     3
 (PID.TID 0000.0001) %MON time_secondsf                =   2.5920000000000E+05
-(PID.TID 0000.0001) %MON dynstat_eta_max              =   1.3305568896365E+04
-(PID.TID 0000.0001) %MON dynstat_eta_min              =  -2.3890925990808E+04
-(PID.TID 0000.0001) %MON dynstat_eta_mean             =  -4.0057197978013E+01
-(PID.TID 0000.0001) %MON dynstat_eta_sd               =   7.0653107179244E+03
-(PID.TID 0000.0001) %MON dynstat_eta_del2             =   9.3846801633356E+01
-(PID.TID 0000.0001) %MON dynstat_uvel_max             =   5.4259923018645E-02
-(PID.TID 0000.0001) %MON dynstat_uvel_min             =  -6.3804273869844E-02
-(PID.TID 0000.0001) %MON dynstat_uvel_mean            =  -4.5161666905212E-04
-(PID.TID 0000.0001) %MON dynstat_uvel_sd              =   3.2104549173233E-03
-(PID.TID 0000.0001) %MON dynstat_uvel_del2            =   1.7242405507100E-05
-(PID.TID 0000.0001) %MON dynstat_vvel_max             =   8.8880798485732E-02
-(PID.TID 0000.0001) %MON dynstat_vvel_min             =  -8.2045964902272E-02
-(PID.TID 0000.0001) %MON dynstat_vvel_mean            =  -1.5740597697869E-04
-(PID.TID 0000.0001) %MON dynstat_vvel_sd              =   3.3122341193208E-03
-(PID.TID 0000.0001) %MON dynstat_vvel_del2            =   1.8229526773492E-05
-(PID.TID 0000.0001) %MON dynstat_wvel_max             =   2.6904765953131E+00
-(PID.TID 0000.0001) %MON dynstat_wvel_min             =  -4.3242250632616E+00
-(PID.TID 0000.0001) %MON dynstat_wvel_mean            =   8.8932549807623E-04
-(PID.TID 0000.0001) %MON dynstat_wvel_sd              =   1.2601406790895E-01
-(PID.TID 0000.0001) %MON dynstat_wvel_del2            =   1.0608938337789E-03
-(PID.TID 0000.0001) %MON dynstat_theta_max            =   2.9408135074514E+01
-(PID.TID 0000.0001) %MON dynstat_theta_min            =  -1.8830010737596E+00
-(PID.TID 0000.0001) %MON dynstat_theta_mean           =   3.5914725052713E+00
-(PID.TID 0000.0001) %MON dynstat_theta_sd             =   4.4276475110508E+00
-(PID.TID 0000.0001) %MON dynstat_theta_del2           =   2.1107895637722E-03
-(PID.TID 0000.0001) %MON dynstat_salt_max             =   4.0715797013571E+01
-(PID.TID 0000.0001) %MON dynstat_salt_min             =   1.7830039392909E+01
-(PID.TID 0000.0001) %MON dynstat_salt_mean            =   3.4721480211925E+01
-(PID.TID 0000.0001) %MON dynstat_salt_sd              =   4.8768042466746E-01
-(PID.TID 0000.0001) %MON dynstat_salt_del2            =   5.1654635831236E-04
-(PID.TID 0000.0001) %MON forcing_qnet_max             =   9.8898462964462E+02
+(PID.TID 0000.0001) %MON dynstat_eta_max              =   1.3305516267538E+04
+(PID.TID 0000.0001) %MON dynstat_eta_min              =  -2.3897811146253E+04
+(PID.TID 0000.0001) %MON dynstat_eta_mean             =  -4.1464584156843E+01
+(PID.TID 0000.0001) %MON dynstat_eta_sd               =   7.0652231489416E+03
+(PID.TID 0000.0001) %MON dynstat_eta_del2             =   9.3851332401790E+01
+(PID.TID 0000.0001) %MON dynstat_uvel_max             =   5.4254287487464E-02
+(PID.TID 0000.0001) %MON dynstat_uvel_min             =  -6.4682685936967E-02
+(PID.TID 0000.0001) %MON dynstat_uvel_mean            =  -4.5171961834275E-04
+(PID.TID 0000.0001) %MON dynstat_uvel_sd              =   3.2106818600630E-03
+(PID.TID 0000.0001) %MON dynstat_uvel_del2            =   1.7238998723449E-05
+(PID.TID 0000.0001) %MON dynstat_vvel_max             =   8.8892309210740E-02
+(PID.TID 0000.0001) %MON dynstat_vvel_min             =  -8.2041474526688E-02
+(PID.TID 0000.0001) %MON dynstat_vvel_mean            =  -1.5754303240927E-04
+(PID.TID 0000.0001) %MON dynstat_vvel_sd              =   3.3125842823997E-03
+(PID.TID 0000.0001) %MON dynstat_vvel_del2            =   1.8229265293268E-05
+(PID.TID 0000.0001) %MON dynstat_wvel_max             =   2.6902884982683E+00
+(PID.TID 0000.0001) %MON dynstat_wvel_min             =  -4.3239239590868E+00
+(PID.TID 0000.0001) %MON dynstat_wvel_mean            =   8.8462129421083E-04
+(PID.TID 0000.0001) %MON dynstat_wvel_sd              =   1.2601842491347E-01
+(PID.TID 0000.0001) %MON dynstat_wvel_del2            =   1.0609020315929E-03
+(PID.TID 0000.0001) %MON dynstat_theta_max            =   2.9408480192316E+01
+(PID.TID 0000.0001) %MON dynstat_theta_min            =  -1.8865125633169E+00
+(PID.TID 0000.0001) %MON dynstat_theta_mean           =   3.5914740040887E+00
+(PID.TID 0000.0001) %MON dynstat_theta_sd             =   4.4277428416434E+00
+(PID.TID 0000.0001) %MON dynstat_theta_del2           =   2.0890334659231E-03
+(PID.TID 0000.0001) %MON dynstat_salt_max             =   4.0715813000502E+01
+(PID.TID 0000.0001) %MON dynstat_salt_min             =   1.7830036718049E+01
+(PID.TID 0000.0001) %MON dynstat_salt_mean            =   3.4721481369760E+01
+(PID.TID 0000.0001) %MON dynstat_salt_sd              =   4.8771678743736E-01
+(PID.TID 0000.0001) %MON dynstat_salt_del2            =   5.1199657429540E-04
+(PID.TID 0000.0001) %MON forcing_qnet_max             =   6.8753660317769E+02
 (PID.TID 0000.0001) %MON forcing_qnet_min             =  -3.1582909723281E+02
-(PID.TID 0000.0001) %MON forcing_qnet_mean            =  -2.4196329267912E+01
-(PID.TID 0000.0001) %MON forcing_qnet_sd              =   1.6598717640820E+02
-(PID.TID 0000.0001) %MON forcing_qnet_del2            =   1.3045245247962E+00
+(PID.TID 0000.0001) %MON forcing_qnet_mean            =  -2.4471125344133E+01
+(PID.TID 0000.0001) %MON forcing_qnet_sd              =   1.6481270334977E+02
+(PID.TID 0000.0001) %MON forcing_qnet_del2            =   1.1177546456799E+00
 (PID.TID 0000.0001) %MON forcing_qsw_max              =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON forcing_qsw_min              =  -3.0189127925792E+02
 (PID.TID 0000.0001) %MON forcing_qsw_mean             =  -1.8593879213097E+02
-(PID.TID 0000.0001) %MON forcing_qsw_sd               =   7.9086030762481E+01
+(PID.TID 0000.0001) %MON forcing_qsw_sd               =   7.9086030762482E+01
 (PID.TID 0000.0001) %MON forcing_qsw_del2             =   1.1032203144530E-01
-(PID.TID 0000.0001) %MON forcing_empmr_max            =   1.7742506342736E-03
-(PID.TID 0000.0001) %MON forcing_empmr_min            =  -1.6714318397368E-03
-(PID.TID 0000.0001) %MON forcing_empmr_mean           =   1.9878564839000E-05
-(PID.TID 0000.0001) %MON forcing_empmr_sd             =   1.7354017337451E-04
-(PID.TID 0000.0001) %MON forcing_empmr_del2           =   3.3786642290135E-06
+(PID.TID 0000.0001) %MON forcing_empmr_max            =   1.7770026263123E-03
+(PID.TID 0000.0001) %MON forcing_empmr_min            =  -4.4823526083756E-04
+(PID.TID 0000.0001) %MON forcing_empmr_mean           =   2.1539032921022E-05
+(PID.TID 0000.0001) %MON forcing_empmr_sd             =   1.7645063787534E-04
+(PID.TID 0000.0001) %MON forcing_empmr_del2           =   2.7017488297787E-06
 (PID.TID 0000.0001) %MON forcing_fu_max               =   2.4751003717351E-01
 (PID.TID 0000.0001) %MON forcing_fu_min               =  -2.0922350306190E-01
-(PID.TID 0000.0001) %MON forcing_fu_mean              =  -4.4451640019368E-03
-(PID.TID 0000.0001) %MON forcing_fu_sd                =   6.3963990878599E-02
-(PID.TID 0000.0001) %MON forcing_fu_del2              =   2.0566384838744E-04
+(PID.TID 0000.0001) %MON forcing_fu_mean              =  -4.4451620513313E-03
+(PID.TID 0000.0001) %MON forcing_fu_sd                =   6.3963989757948E-02
+(PID.TID 0000.0001) %MON forcing_fu_del2              =   2.0566380550564E-04
 (PID.TID 0000.0001) %MON forcing_fv_max               =   2.5817746358114E-01
 (PID.TID 0000.0001) %MON forcing_fv_min               =  -3.2849573188785E-01
-(PID.TID 0000.0001) %MON forcing_fv_mean              =  -1.3688993645892E-02
-(PID.TID 0000.0001) %MON forcing_fv_sd                =   7.5246625962459E-02
-(PID.TID 0000.0001) %MON forcing_fv_del2              =   2.3426167469211E-04
-(PID.TID 0000.0001) %MON trAdv_CFL_u_max              =   2.2401775800102E-02
-(PID.TID 0000.0001) %MON trAdv_CFL_v_max              =   3.1506303245165E-02
-(PID.TID 0000.0001) %MON trAdv_CFL_w_max              =   1.1159956548591E-01
-(PID.TID 0000.0001) %MON advcfl_uvel_max              =   2.0096023729528E-02
-(PID.TID 0000.0001) %MON advcfl_vvel_max              =   2.6142675052298E-02
-(PID.TID 0000.0001) %MON advcfl_wvel_max              =   1.2220630575525E-01
-(PID.TID 0000.0001) %MON advcfl_W_hf_max              =   1.3503652012274E-01
-(PID.TID 0000.0001) %MON pe_b_mean                    =   1.3157400067881E-02
-(PID.TID 0000.0001) %MON ke_max                       =   2.6263979163907E-03
-(PID.TID 0000.0001) %MON ke_mean                      =   9.9299669067716E-06
+(PID.TID 0000.0001) %MON forcing_fv_mean              =  -1.3688991867914E-02
+(PID.TID 0000.0001) %MON forcing_fv_sd                =   7.5246627512635E-02
+(PID.TID 0000.0001) %MON forcing_fv_del2              =   2.3426168312794E-04
+(PID.TID 0000.0001) %MON trAdv_CFL_u_max              =   2.2399480879829E-02
+(PID.TID 0000.0001) %MON trAdv_CFL_v_max              =   3.1505581546679E-02
+(PID.TID 0000.0001) %MON trAdv_CFL_w_max              =   1.1159291957786E-01
+(PID.TID 0000.0001) %MON advcfl_uvel_max              =   2.0095833520198E-02
+(PID.TID 0000.0001) %MON advcfl_vvel_max              =   2.6274879162605E-02
+(PID.TID 0000.0001) %MON advcfl_wvel_max              =   1.2219902820118E-01
+(PID.TID 0000.0001) %MON advcfl_W_hf_max              =   1.3502847851171E-01
+(PID.TID 0000.0001) %MON pe_b_mean                    =   1.3156197486337E-02
+(PID.TID 0000.0001) %MON ke_max                       =   2.6260745816611E-03
+(PID.TID 0000.0001) %MON ke_mean                      =   9.9317755242245E-06
 (PID.TID 0000.0001) %MON ke_vol                       =   1.3604168238985E+22
-(PID.TID 0000.0001) %MON vort_r_min                   =  -4.9874672739054E-07
-(PID.TID 0000.0001) %MON vort_r_max                   =   5.2424095251189E-07
+(PID.TID 0000.0001) %MON vort_r_min                   =  -4.9977015943874E-07
+(PID.TID 0000.0001) %MON vort_r_max                   =   5.2424368570020E-07
 (PID.TID 0000.0001) %MON vort_a_mean                  =  -2.0556865257795E-05
-(PID.TID 0000.0001) %MON vort_a_sd                    =   7.5247335755280E-05
+(PID.TID 0000.0001) %MON vort_a_sd                    =   7.5247335740165E-05
 (PID.TID 0000.0001) %MON vort_p_mean                  =  -2.4859228572284E-05
-(PID.TID 0000.0001) %MON vort_p_sd                    =   1.2920027720410E-04
-(PID.TID 0000.0001) %MON surfExpan_theta_mean         =   1.1468274061402E-02
-(PID.TID 0000.0001) %MON surfExpan_salt_mean          =  -5.1771345818354E-03
+(PID.TID 0000.0001) %MON vort_p_sd                    =   1.2920027946095E-04
+(PID.TID 0000.0001) %MON surfExpan_theta_mean         =   1.1500625871852E-02
+(PID.TID 0000.0001) %MON surfExpan_salt_mean          =  -5.7353860934067E-03
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // End MONITOR dynamic field statistics
 (PID.TID 0000.0001) // =======================================================
@@ -3739,124 +3744,124 @@ listId=   2 ; file name: seaiceStDiag
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) %MON seaice_tsnumber              =                     3
 (PID.TID 0000.0001) %MON seaice_time_sec              =   2.5920000000000E+05
-(PID.TID 0000.0001) %MON seaice_uice_max              =   1.2724390853058E-01
-(PID.TID 0000.0001) %MON seaice_uice_min              =  -1.8208622789017E-01
-(PID.TID 0000.0001) %MON seaice_uice_mean             =  -3.0913786881399E-04
-(PID.TID 0000.0001) %MON seaice_uice_sd               =   9.4998738259569E-03
-(PID.TID 0000.0001) %MON seaice_uice_del2             =   2.0182103708275E-04
-(PID.TID 0000.0001) %MON seaice_vice_max              =   1.4350330033310E-01
-(PID.TID 0000.0001) %MON seaice_vice_min              =  -1.4748903452509E-01
-(PID.TID 0000.0001) %MON seaice_vice_mean             =   9.1141928681939E-04
-(PID.TID 0000.0001) %MON seaice_vice_sd               =   1.3506900353631E-02
-(PID.TID 0000.0001) %MON seaice_vice_del2             =   1.2914879877200E-04
-(PID.TID 0000.0001) %MON seaice_area_max              =   6.7874329947999E-01
+(PID.TID 0000.0001) %MON seaice_uice_max              =   1.2724427984109E-01
+(PID.TID 0000.0001) %MON seaice_uice_min              =  -1.8208668024418E-01
+(PID.TID 0000.0001) %MON seaice_uice_mean             =  -3.0920747523053E-04
+(PID.TID 0000.0001) %MON seaice_uice_sd               =   9.5005011171349E-03
+(PID.TID 0000.0001) %MON seaice_uice_del2             =   2.0182973990340E-04
+(PID.TID 0000.0001) %MON seaice_vice_max              =   1.4349914707280E-01
+(PID.TID 0000.0001) %MON seaice_vice_min              =  -1.4748942201369E-01
+(PID.TID 0000.0001) %MON seaice_vice_mean             =   9.1149297967533E-04
+(PID.TID 0000.0001) %MON seaice_vice_sd               =   1.3507372701651E-02
+(PID.TID 0000.0001) %MON seaice_vice_del2             =   1.2915897701282E-04
+(PID.TID 0000.0001) %MON seaice_area_max              =   6.7874318268466E-01
 (PID.TID 0000.0001) %MON seaice_area_min              =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON seaice_area_mean             =   9.6242418794470E-03
-(PID.TID 0000.0001) %MON seaice_area_sd               =   7.2159810826301E-02
-(PID.TID 0000.0001) %MON seaice_area_del2             =   8.6631787826751E-04
-(PID.TID 0000.0001) %MON seaice_heff_max              =   3.7961498185783E-01
+(PID.TID 0000.0001) %MON seaice_area_mean             =   9.8891530703204E-03
+(PID.TID 0000.0001) %MON seaice_area_sd               =   7.2978803034180E-02
+(PID.TID 0000.0001) %MON seaice_area_del2             =   7.4107272060734E-04
+(PID.TID 0000.0001) %MON seaice_heff_max              =   3.7961498256421E-01
 (PID.TID 0000.0001) %MON seaice_heff_min              =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON seaice_heff_mean             =   5.0600578199230E-03
-(PID.TID 0000.0001) %MON seaice_heff_sd               =   3.8280425961663E-02
-(PID.TID 0000.0001) %MON seaice_heff_del2             =   4.3387161382752E-04
-(PID.TID 0000.0001) %MON seaice_hsnow_max             =   1.8610649431791E-03
+(PID.TID 0000.0001) %MON seaice_heff_mean             =   5.2117543175003E-03
+(PID.TID 0000.0001) %MON seaice_heff_sd               =   3.8744646166044E-02
+(PID.TID 0000.0001) %MON seaice_heff_del2             =   3.8873869049535E-04
+(PID.TID 0000.0001) %MON seaice_hsnow_max             =   1.8610648711584E-03
 (PID.TID 0000.0001) %MON seaice_hsnow_min             =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON seaice_hsnow_mean            =   1.4992139780416E-05
-(PID.TID 0000.0001) %MON seaice_hsnow_sd              =   1.3089548971085E-04
-(PID.TID 0000.0001) %MON seaice_hsnow_del2            =   2.0820572686460E-06
+(PID.TID 0000.0001) %MON seaice_hsnow_mean            =   1.5451750330352E-05
+(PID.TID 0000.0001) %MON seaice_hsnow_sd              =   1.3298410271350E-04
+(PID.TID 0000.0001) %MON seaice_hsnow_del2            =   1.7228175765249E-06
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // End MONITOR SEAICE statistics
 (PID.TID 0000.0001) // =======================================================
  EXTERNAL_FIELDS_LOAD,         3 : iP,iLd,i0,i1=   12    1   12    1 ; Wght=  0.4000000000  0.6000000000
- SEAICE_LSR: Residual Initial ipass,Uice,Vice=         1  2.75168993E-04  3.52394067E-04
- SEAICE_LSR (ipass=        1) iters,dU,Resid=       12  3.15858451E-14  2.08887314E-19
- SEAICE_LSR (ipass=        1) iters,dV,Resid=       12  7.74866282E-14  5.15216672E-19
- SEAICE_LSR: Residual Initial ipass,Uice,Vice=         2  9.40704000E-05  7.93744659E-05
- SEAICE_LSR (ipass=        2) iters,dU,Resid=       12  2.16493490E-15  2.63867640E-19
- SEAICE_LSR (ipass=        2) iters,dV,Resid=       12  3.61065344E-14  4.42035287E-19
- cg2d: Sum(rhs),rhsMax =   1.92172284867777E-01  1.98883986255041E+01
-(PID.TID 0000.0001)      cg2d_init_res =   9.80656793086880E-02
+ SEAICE_LSR: Residual Initial ipass,Uice,Vice=         1  2.79848749E-04  3.78981623E-04
+ SEAICE_LSR (ipass=        1) iters,dU,Resid=       12  3.15303339E-14  2.08610517E-19
+ SEAICE_LSR (ipass=        1) iters,dV,Resid=       12  7.81145981E-14  4.05990732E-19
+ SEAICE_LSR: Residual Initial ipass,Uice,Vice=         2  9.45422945E-05  8.82846823E-05
+ SEAICE_LSR (ipass=        2) iters,dU,Resid=       12  1.88737914E-15  2.81898003E-19
+ SEAICE_LSR (ipass=        2) iters,dV,Resid=       12  3.63719471E-14  4.66684570E-19
+ cg2d: Sum(rhs),rhsMax =   1.97550682350837E-01  1.98884008355332E+01
+(PID.TID 0000.0001)      cg2d_init_res =   9.80691834943749E-02
 (PID.TID 0000.0001)      cg2d_iters(min,last) =      -1     103
-(PID.TID 0000.0001)      cg2d_last_res =   7.42172769533764E-10
+(PID.TID 0000.0001)      cg2d_last_res =   7.44346654055150E-10
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // Begin MONITOR dynamic field statistics
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) %MON time_tsnumber                =                     4
 (PID.TID 0000.0001) %MON time_secondsf                =   3.4560000000000E+05
-(PID.TID 0000.0001) %MON dynstat_eta_max              =   1.3103148517861E+04
-(PID.TID 0000.0001) %MON dynstat_eta_min              =  -2.3940437729562E+04
-(PID.TID 0000.0001) %MON dynstat_eta_mean             =  -5.7717972889119E+01
-(PID.TID 0000.0001) %MON dynstat_eta_sd               =   7.3742311473014E+03
-(PID.TID 0000.0001) %MON dynstat_eta_del2             =   9.3592001150294E+01
-(PID.TID 0000.0001) %MON dynstat_uvel_max             =   6.9746207934105E-02
-(PID.TID 0000.0001) %MON dynstat_uvel_min             =  -8.1956720116854E-02
-(PID.TID 0000.0001) %MON dynstat_uvel_mean            =  -4.6671128891502E-04
-(PID.TID 0000.0001) %MON dynstat_uvel_sd              =   4.1161818216520E-03
-(PID.TID 0000.0001) %MON dynstat_uvel_del2            =   2.2003197368484E-05
-(PID.TID 0000.0001) %MON dynstat_vvel_max             =   1.1493552948133E-01
-(PID.TID 0000.0001) %MON dynstat_vvel_min             =  -1.0576859165153E-01
-(PID.TID 0000.0001) %MON dynstat_vvel_mean            =  -2.7722740795981E-04
-(PID.TID 0000.0001) %MON dynstat_vvel_sd              =   4.2197069784128E-03
-(PID.TID 0000.0001) %MON dynstat_vvel_del2            =   2.3149951113323E-05
-(PID.TID 0000.0001) %MON dynstat_wvel_max             =   3.4525291564692E+00
-(PID.TID 0000.0001) %MON dynstat_wvel_min             =  -5.6359456311040E+00
-(PID.TID 0000.0001) %MON dynstat_wvel_mean            =   2.6569456545611E-04
-(PID.TID 0000.0001) %MON dynstat_wvel_sd              =   1.6024169149794E-01
-(PID.TID 0000.0001) %MON dynstat_wvel_del2            =   1.3203003561283E-03
-(PID.TID 0000.0001) %MON dynstat_theta_max            =   2.9415131671508E+01
-(PID.TID 0000.0001) %MON dynstat_theta_min            =  -1.8816762412202E+00
-(PID.TID 0000.0001) %MON dynstat_theta_mean           =   3.5916308872376E+00
-(PID.TID 0000.0001) %MON dynstat_theta_sd             =   4.4274608216882E+00
-(PID.TID 0000.0001) %MON dynstat_theta_del2           =   2.2856027244249E-03
-(PID.TID 0000.0001) %MON dynstat_salt_max             =   4.0715816856184E+01
-(PID.TID 0000.0001) %MON dynstat_salt_min             =   1.7561085086138E+01
-(PID.TID 0000.0001) %MON dynstat_salt_mean            =   3.4721497017536E+01
-(PID.TID 0000.0001) %MON dynstat_salt_sd              =   4.8746251858499E-01
-(PID.TID 0000.0001) %MON dynstat_salt_del2            =   5.2572504735416E-04
-(PID.TID 0000.0001) %MON forcing_qnet_max             =   6.8114117795321E+02
-(PID.TID 0000.0001) %MON forcing_qnet_min             =  -3.1494305800166E+02
-(PID.TID 0000.0001) %MON forcing_qnet_mean            =  -2.6000732229865E+01
-(PID.TID 0000.0001) %MON forcing_qnet_sd              =   1.6029829201219E+02
-(PID.TID 0000.0001) %MON forcing_qnet_del2            =   1.0312900226907E+00
+(PID.TID 0000.0001) %MON dynstat_eta_max              =   1.3102043563904E+04
+(PID.TID 0000.0001) %MON dynstat_eta_min              =  -2.3941106786997E+04
+(PID.TID 0000.0001) %MON dynstat_eta_mean             =  -5.9333353938275E+01
+(PID.TID 0000.0001) %MON dynstat_eta_sd               =   7.3741600970179E+03
+(PID.TID 0000.0001) %MON dynstat_eta_del2             =   9.3599201397349E+01
+(PID.TID 0000.0001) %MON dynstat_uvel_max             =   6.9735030876457E-02
+(PID.TID 0000.0001) %MON dynstat_uvel_min             =  -8.2735921781811E-02
+(PID.TID 0000.0001) %MON dynstat_uvel_mean            =  -4.6674549651920E-04
+(PID.TID 0000.0001) %MON dynstat_uvel_sd              =   4.1172620321907E-03
+(PID.TID 0000.0001) %MON dynstat_uvel_del2            =   2.2001121399618E-05
+(PID.TID 0000.0001) %MON dynstat_vvel_max             =   1.1498470269622E-01
+(PID.TID 0000.0001) %MON dynstat_vvel_min             =  -1.0576014588946E-01
+(PID.TID 0000.0001) %MON dynstat_vvel_mean            =  -2.7736462632272E-04
+(PID.TID 0000.0001) %MON dynstat_vvel_sd              =   4.2207654669545E-03
+(PID.TID 0000.0001) %MON dynstat_vvel_del2            =   2.3155261540270E-05
+(PID.TID 0000.0001) %MON dynstat_wvel_max             =   3.4523092468676E+00
+(PID.TID 0000.0001) %MON dynstat_wvel_min             =  -5.6353659442684E+00
+(PID.TID 0000.0001) %MON dynstat_wvel_mean            =   2.6321128349835E-04
+(PID.TID 0000.0001) %MON dynstat_wvel_sd              =   1.6024439788056E-01
+(PID.TID 0000.0001) %MON dynstat_wvel_del2            =   1.3202362579560E-03
+(PID.TID 0000.0001) %MON dynstat_theta_max            =   2.9415540496387E+01
+(PID.TID 0000.0001) %MON dynstat_theta_min            =  -1.8888212553758E+00
+(PID.TID 0000.0001) %MON dynstat_theta_mean           =   3.5916322414875E+00
+(PID.TID 0000.0001) %MON dynstat_theta_sd             =   4.4280400243304E+00
+(PID.TID 0000.0001) %MON dynstat_theta_del2           =   2.1042971283239E-03
+(PID.TID 0000.0001) %MON dynstat_salt_max             =   4.0715840180939E+01
+(PID.TID 0000.0001) %MON dynstat_salt_min             =   1.7561079564493E+01
+(PID.TID 0000.0001) %MON dynstat_salt_mean            =   3.4721498363828E+01
+(PID.TID 0000.0001) %MON dynstat_salt_sd              =   4.8760663409020E-01
+(PID.TID 0000.0001) %MON dynstat_salt_del2            =   5.1497155915765E-04
+(PID.TID 0000.0001) %MON forcing_qnet_max             =   6.8014799603551E+02
+(PID.TID 0000.0001) %MON forcing_qnet_min             =  -3.1494449143543E+02
+(PID.TID 0000.0001) %MON forcing_qnet_mean            =  -2.5937032817713E+01
+(PID.TID 0000.0001) %MON forcing_qnet_sd              =   1.6014578551995E+02
+(PID.TID 0000.0001) %MON forcing_qnet_del2            =   9.6289414230573E-01
 (PID.TID 0000.0001) %MON forcing_qsw_max              =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON forcing_qsw_min              =  -3.0187928232211E+02
-(PID.TID 0000.0001) %MON forcing_qsw_mean             =  -1.8594494422320E+02
-(PID.TID 0000.0001) %MON forcing_qsw_sd               =   7.8977862412479E+01
-(PID.TID 0000.0001) %MON forcing_qsw_del2             =   1.1028061737212E-01
-(PID.TID 0000.0001) %MON forcing_empmr_max            =   1.6301881578003E-03
-(PID.TID 0000.0001) %MON forcing_empmr_min            =  -4.4998185712268E-04
-(PID.TID 0000.0001) %MON forcing_empmr_mean           =   2.0836607240236E-05
-(PID.TID 0000.0001) %MON forcing_empmr_sd             =   1.6001927348731E-04
-(PID.TID 0000.0001) %MON forcing_empmr_del2           =   2.0472611134052E-06
+(PID.TID 0000.0001) %MON forcing_qsw_mean             =  -1.8594494413350E+02
+(PID.TID 0000.0001) %MON forcing_qsw_sd               =   7.8977862623668E+01
+(PID.TID 0000.0001) %MON forcing_qsw_del2             =   1.1028061737191E-01
+(PID.TID 0000.0001) %MON forcing_empmr_max            =   1.6292799249638E-03
+(PID.TID 0000.0001) %MON forcing_empmr_min            =  -4.4998185671539E-04
+(PID.TID 0000.0001) %MON forcing_empmr_mean           =   2.1082004593561E-05
+(PID.TID 0000.0001) %MON forcing_empmr_sd             =   1.6073176205168E-04
+(PID.TID 0000.0001) %MON forcing_empmr_del2           =   1.9628254426592E-06
 (PID.TID 0000.0001) %MON forcing_fu_max               =   2.4746198790331E-01
 (PID.TID 0000.0001) %MON forcing_fu_min               =  -2.1236929972025E-01
-(PID.TID 0000.0001) %MON forcing_fu_mean              =  -4.3930421616753E-03
-(PID.TID 0000.0001) %MON forcing_fu_sd                =   6.3996952183218E-02
-(PID.TID 0000.0001) %MON forcing_fu_del2              =   2.0640984713827E-04
+(PID.TID 0000.0001) %MON forcing_fu_mean              =  -4.3916019255706E-03
+(PID.TID 0000.0001) %MON forcing_fu_sd                =   6.3996063727460E-02
+(PID.TID 0000.0001) %MON forcing_fu_del2              =   2.0634349403201E-04
 (PID.TID 0000.0001) %MON forcing_fv_max               =   2.6086070515377E-01
 (PID.TID 0000.0001) %MON forcing_fv_min               =  -3.2928363582178E-01
-(PID.TID 0000.0001) %MON forcing_fv_mean              =  -1.3690788591847E-02
-(PID.TID 0000.0001) %MON forcing_fv_sd                =   7.5311085550732E-02
-(PID.TID 0000.0001) %MON forcing_fv_del2              =   2.3487386222672E-04
-(PID.TID 0000.0001) %MON trAdv_CFL_u_max              =   2.9518784030537E-02
-(PID.TID 0000.0001) %MON trAdv_CFL_v_max              =   4.1208641086319E-02
-(PID.TID 0000.0001) %MON trAdv_CFL_w_max              =   1.4541304440894E-01
-(PID.TID 0000.0001) %MON advcfl_uvel_max              =   2.5031597579884E-02
-(PID.TID 0000.0001) %MON advcfl_vvel_max              =   3.2492468710840E-02
-(PID.TID 0000.0001) %MON advcfl_wvel_max              =   1.5923411534864E-01
-(PID.TID 0000.0001) %MON advcfl_W_hf_max              =   1.7595114651154E-01
-(PID.TID 0000.0001) %MON pe_b_mean                    =   1.3494867758269E-02
-(PID.TID 0000.0001) %MON ke_max                       =   4.4061204390507E-03
-(PID.TID 0000.0001) %MON ke_mean                      =   1.6180088563557E-05
-(PID.TID 0000.0001) %MON ke_vol                       =   1.3604162107947E+22
-(PID.TID 0000.0001) %MON vort_r_min                   =  -5.6691713457370E-07
-(PID.TID 0000.0001) %MON vort_r_max                   =   5.8099321369328E-07
+(PID.TID 0000.0001) %MON forcing_fv_mean              =  -1.3689821827328E-02
+(PID.TID 0000.0001) %MON forcing_fv_sd                =   7.5311854890290E-02
+(PID.TID 0000.0001) %MON forcing_fv_del2              =   2.3488214592842E-04
+(PID.TID 0000.0001) %MON trAdv_CFL_u_max              =   2.9515066731923E-02
+(PID.TID 0000.0001) %MON trAdv_CFL_v_max              =   4.1207065877344E-02
+(PID.TID 0000.0001) %MON trAdv_CFL_w_max              =   1.4539971668644E-01
+(PID.TID 0000.0001) %MON advcfl_uvel_max              =   2.5031828295967E-02
+(PID.TID 0000.0001) %MON advcfl_vvel_max              =   3.2506370061914E-02
+(PID.TID 0000.0001) %MON advcfl_wvel_max              =   1.5921950144033E-01
+(PID.TID 0000.0001) %MON advcfl_W_hf_max              =   1.7593501984241E-01
+(PID.TID 0000.0001) %MON pe_b_mean                    =   1.3492773716362E-02
+(PID.TID 0000.0001) %MON ke_max                       =   4.4053414307293E-03
+(PID.TID 0000.0001) %MON ke_mean                      =   1.6188369780099E-05
+(PID.TID 0000.0001) %MON ke_vol                       =   1.3604161595818E+22
+(PID.TID 0000.0001) %MON vort_r_min                   =  -5.6821824599306E-07
+(PID.TID 0000.0001) %MON vort_r_max                   =   5.8099816666122E-07
 (PID.TID 0000.0001) %MON vort_a_mean                  =  -2.0556865257794E-05
-(PID.TID 0000.0001) %MON vort_a_sd                    =   7.5247344330272E-05
-(PID.TID 0000.0001) %MON vort_p_mean                  =  -2.4859215101150E-05
-(PID.TID 0000.0001) %MON vort_p_sd                    =   1.2920355596374E-04
-(PID.TID 0000.0001) %MON surfExpan_theta_mean         =   9.2670154059678E-03
-(PID.TID 0000.0001) %MON surfExpan_salt_mean          =  -6.1896945177679E-03
+(PID.TID 0000.0001) %MON vort_a_sd                    =   7.5247344303265E-05
+(PID.TID 0000.0001) %MON vort_p_mean                  =  -2.4859216048072E-05
+(PID.TID 0000.0001) %MON vort_p_sd                    =   1.2920357705815E-04
+(PID.TID 0000.0001) %MON surfExpan_theta_mean         =   9.2646952496066E-03
+(PID.TID 0000.0001) %MON surfExpan_salt_mean          =  -6.2744284455989E-03
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // End MONITOR dynamic field statistics
 (PID.TID 0000.0001) // =======================================================
@@ -3865,124 +3870,124 @@ listId=   2 ; file name: seaiceStDiag
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) %MON seaice_tsnumber              =                     4
 (PID.TID 0000.0001) %MON seaice_time_sec              =   3.4560000000000E+05
-(PID.TID 0000.0001) %MON seaice_uice_max              =   1.0866972264788E-01
-(PID.TID 0000.0001) %MON seaice_uice_min              =  -1.9592069028033E-01
-(PID.TID 0000.0001) %MON seaice_uice_mean             =  -2.7035898024298E-04
-(PID.TID 0000.0001) %MON seaice_uice_sd               =   9.5886716567609E-03
-(PID.TID 0000.0001) %MON seaice_uice_del2             =   1.8776172858960E-04
-(PID.TID 0000.0001) %MON seaice_vice_max              =   1.5194283551779E-01
-(PID.TID 0000.0001) %MON seaice_vice_min              =  -1.6374102803558E-01
-(PID.TID 0000.0001) %MON seaice_vice_mean             =   9.6336397611899E-04
-(PID.TID 0000.0001) %MON seaice_vice_sd               =   1.4142746494846E-02
-(PID.TID 0000.0001) %MON seaice_vice_del2             =   1.1597772031251E-04
-(PID.TID 0000.0001) %MON seaice_area_max              =   7.8638852378381E-01
+(PID.TID 0000.0001) %MON seaice_uice_max              =   1.0868746797049E-01
+(PID.TID 0000.0001) %MON seaice_uice_min              =  -1.9589770875602E-01
+(PID.TID 0000.0001) %MON seaice_uice_mean             =  -2.6880473282193E-04
+(PID.TID 0000.0001) %MON seaice_uice_sd               =   9.5683242353441E-03
+(PID.TID 0000.0001) %MON seaice_uice_del2             =   1.8684636214708E-04
+(PID.TID 0000.0001) %MON seaice_vice_max              =   1.5216497569976E-01
+(PID.TID 0000.0001) %MON seaice_vice_min              =  -1.6372540807830E-01
+(PID.TID 0000.0001) %MON seaice_vice_mean             =   9.6920603283433E-04
+(PID.TID 0000.0001) %MON seaice_vice_sd               =   1.4178989732687E-02
+(PID.TID 0000.0001) %MON seaice_vice_del2             =   1.1647691578557E-04
+(PID.TID 0000.0001) %MON seaice_area_max              =   7.8638726019433E-01
 (PID.TID 0000.0001) %MON seaice_area_min              =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON seaice_area_mean             =   1.3342644022993E-02
-(PID.TID 0000.0001) %MON seaice_area_sd               =   9.2047062971158E-02
-(PID.TID 0000.0001) %MON seaice_area_del2             =   9.3314977903931E-04
-(PID.TID 0000.0001) %MON seaice_heff_max              =   4.5243194759897E-01
+(PID.TID 0000.0001) %MON seaice_area_mean             =   1.3621511580829E-02
+(PID.TID 0000.0001) %MON seaice_area_sd               =   9.3182635255965E-02
+(PID.TID 0000.0001) %MON seaice_area_del2             =   8.1646287645478E-04
+(PID.TID 0000.0001) %MON seaice_heff_max              =   4.5246697082647E-01
 (PID.TID 0000.0001) %MON seaice_heff_min              =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON seaice_heff_mean             =   7.2475978355319E-03
-(PID.TID 0000.0001) %MON seaice_heff_sd               =   5.0573550625040E-02
-(PID.TID 0000.0001) %MON seaice_heff_del2             =   5.0230649034686E-04
-(PID.TID 0000.0001) %MON seaice_hsnow_max             =   3.4944226281229E-03
+(PID.TID 0000.0001) %MON seaice_heff_mean             =   7.4176172462607E-03
+(PID.TID 0000.0001) %MON seaice_heff_sd               =   5.1245459447642E-02
+(PID.TID 0000.0001) %MON seaice_heff_del2             =   4.4896241361259E-04
+(PID.TID 0000.0001) %MON seaice_hsnow_max             =   3.6101804455447E-03
 (PID.TID 0000.0001) %MON seaice_hsnow_min             =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON seaice_hsnow_mean            =   3.2241768871504E-05
-(PID.TID 0000.0001) %MON seaice_hsnow_sd              =   2.6095145919645E-04
-(PID.TID 0000.0001) %MON seaice_hsnow_del2            =   4.3944604767628E-06
+(PID.TID 0000.0001) %MON seaice_hsnow_mean            =   3.3613103709604E-05
+(PID.TID 0000.0001) %MON seaice_hsnow_sd              =   2.6980322015693E-04
+(PID.TID 0000.0001) %MON seaice_hsnow_del2            =   3.5048476024768E-06
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // End MONITOR SEAICE statistics
 (PID.TID 0000.0001) // =======================================================
  EXTERNAL_FIELDS_LOAD,         4 : iP,iLd,i0,i1=   12    1   12    1 ; Wght=  0.3666666667  0.6333333333
- SEAICE_LSR: Residual Initial ipass,Uice,Vice=         1  4.38929285E-04  3.69279998E-04
- SEAICE_LSR (ipass=        1) iters,dU,Resid=       12  5.95190564E-13  6.48799649E-19
- SEAICE_LSR (ipass=        1) iters,dV,Resid=       12  8.63475957E-14  8.02719312E-19
- SEAICE_LSR: Residual Initial ipass,Uice,Vice=         2  5.39902623E-04  1.18448062E-04
- SEAICE_LSR (ipass=        2) iters,dU,Resid=       12  9.51183576E-14  2.50933680E-19
- SEAICE_LSR (ipass=        2) iters,dV,Resid=       12  3.59434704E-14  6.34693024E-19
- cg2d: Sum(rhs),rhsMax =   2.26702155328335E-01  1.98977556593952E+01
-(PID.TID 0000.0001)      cg2d_init_res =   8.14397760343671E-02
+ SEAICE_LSR: Residual Initial ipass,Uice,Vice=         1  5.14769994E-04  3.81249722E-04
+ SEAICE_LSR (ipass=        1) iters,dU,Resid=       12  6.04183370E-13  5.54188802E-19
+ SEAICE_LSR (ipass=        1) iters,dV,Resid=       12  8.65557626E-14  7.16649267E-19
+ SEAICE_LSR: Residual Initial ipass,Uice,Vice=         2  5.56061673E-04  1.19802125E-04
+ SEAICE_LSR (ipass=        2) iters,dU,Resid=       12  9.29811783E-14  6.43434356E-19
+ SEAICE_LSR (ipass=        2) iters,dV,Resid=       12  3.57908148E-14  5.82939947E-19
+ cg2d: Sum(rhs),rhsMax =   2.46921854634471E-01  1.98977600082372E+01
+(PID.TID 0000.0001)      cg2d_init_res =   8.11909424783931E-02
 (PID.TID 0000.0001)      cg2d_iters(min,last) =      -1     102
-(PID.TID 0000.0001)      cg2d_last_res =   8.63622643300048E-10
+(PID.TID 0000.0001)      cg2d_last_res =   8.61153296608416E-10
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // Begin MONITOR dynamic field statistics
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) %MON time_tsnumber                =                     5
 (PID.TID 0000.0001) %MON time_secondsf                =   4.3200000000000E+05
-(PID.TID 0000.0001) %MON dynstat_eta_max              =   1.3211580945156E+04
-(PID.TID 0000.0001) %MON dynstat_eta_min              =  -2.3568642266917E+04
-(PID.TID 0000.0001) %MON dynstat_eta_mean             =  -6.8120878909310E+01
-(PID.TID 0000.0001) %MON dynstat_eta_sd               =   7.4387652472743E+03
-(PID.TID 0000.0001) %MON dynstat_eta_del2             =   9.3724904718754E+01
-(PID.TID 0000.0001) %MON dynstat_uvel_max             =   8.4685835919670E-02
-(PID.TID 0000.0001) %MON dynstat_uvel_min             =  -9.9975632962618E-02
-(PID.TID 0000.0001) %MON dynstat_uvel_mean            =  -3.9417945553902E-04
-(PID.TID 0000.0001) %MON dynstat_uvel_sd              =   5.0192208923168E-03
-(PID.TID 0000.0001) %MON dynstat_uvel_del2            =   2.6360475851169E-05
-(PID.TID 0000.0001) %MON dynstat_vvel_max             =   1.3874516759782E-01
-(PID.TID 0000.0001) %MON dynstat_vvel_min             =  -1.2778920497438E-01
-(PID.TID 0000.0001) %MON dynstat_vvel_mean            =  -3.9198056645750E-04
-(PID.TID 0000.0001) %MON dynstat_vvel_sd              =   5.1490962113438E-03
-(PID.TID 0000.0001) %MON dynstat_vvel_del2            =   2.7544634649439E-05
-(PID.TID 0000.0001) %MON dynstat_wvel_max             =   4.1196706253559E+00
-(PID.TID 0000.0001) %MON dynstat_wvel_min             =  -6.8473964874055E+00
-(PID.TID 0000.0001) %MON dynstat_wvel_mean            =   9.9320639255996E-06
-(PID.TID 0000.0001) %MON dynstat_wvel_sd              =   1.9087084979239E-01
-(PID.TID 0000.0001) %MON dynstat_wvel_del2            =   1.5406269155600E-03
-(PID.TID 0000.0001) %MON dynstat_theta_max            =   2.9421633528843E+01
-(PID.TID 0000.0001) %MON dynstat_theta_min            =  -1.8949180193622E+00
-(PID.TID 0000.0001) %MON dynstat_theta_mean           =   3.5917874016039E+00
-(PID.TID 0000.0001) %MON dynstat_theta_sd             =   4.4278777541926E+00
-(PID.TID 0000.0001) %MON dynstat_theta_del2           =   2.2608157287417E-03
-(PID.TID 0000.0001) %MON dynstat_salt_max             =   4.0715833864089E+01
-(PID.TID 0000.0001) %MON dynstat_salt_min             =   1.7267720604628E+01
-(PID.TID 0000.0001) %MON dynstat_salt_mean            =   3.4721507077661E+01
-(PID.TID 0000.0001) %MON dynstat_salt_sd              =   4.8741110461664E-01
-(PID.TID 0000.0001) %MON dynstat_salt_del2            =   5.2158271367364E-04
-(PID.TID 0000.0001) %MON forcing_qnet_max             =   1.2842316165516E+03
-(PID.TID 0000.0001) %MON forcing_qnet_min             =  -3.1401608637907E+02
-(PID.TID 0000.0001) %MON forcing_qnet_mean            =  -2.5273152836729E+01
-(PID.TID 0000.0001) %MON forcing_qnet_sd              =   1.6348553615544E+02
-(PID.TID 0000.0001) %MON forcing_qnet_del2            =   1.1719737120808E+00
+(PID.TID 0000.0001) %MON dynstat_eta_max              =   1.3206450587225E+04
+(PID.TID 0000.0001) %MON dynstat_eta_min              =  -2.3570108701462E+04
+(PID.TID 0000.0001) %MON dynstat_eta_mean             =  -7.4196636602510E+01
+(PID.TID 0000.0001) %MON dynstat_eta_sd               =   7.4414451457969E+03
+(PID.TID 0000.0001) %MON dynstat_eta_del2             =   9.3713979243348E+01
+(PID.TID 0000.0001) %MON dynstat_uvel_max             =   8.4677501399395E-02
+(PID.TID 0000.0001) %MON dynstat_uvel_min             =  -1.0059659830970E-01
+(PID.TID 0000.0001) %MON dynstat_uvel_mean            =  -3.9406105637186E-04
+(PID.TID 0000.0001) %MON dynstat_uvel_sd              =   5.0200330685401E-03
+(PID.TID 0000.0001) %MON dynstat_uvel_del2            =   2.6355172119911E-05
+(PID.TID 0000.0001) %MON dynstat_vvel_max             =   1.3882605793582E-01
+(PID.TID 0000.0001) %MON dynstat_vvel_min             =  -1.2778199457556E-01
+(PID.TID 0000.0001) %MON dynstat_vvel_mean            =  -3.9213624386388E-04
+(PID.TID 0000.0001) %MON dynstat_vvel_sd              =   5.1500824631696E-03
+(PID.TID 0000.0001) %MON dynstat_vvel_del2            =   2.7545873507414E-05
+(PID.TID 0000.0001) %MON dynstat_wvel_max             =   4.1196896511715E+00
+(PID.TID 0000.0001) %MON dynstat_wvel_min             =  -6.8475928984619E+00
+(PID.TID 0000.0001) %MON dynstat_wvel_mean            =  -3.7972891002643E-06
+(PID.TID 0000.0001) %MON dynstat_wvel_sd              =   1.9087019974448E-01
+(PID.TID 0000.0001) %MON dynstat_wvel_del2            =   1.5405211282264E-03
+(PID.TID 0000.0001) %MON dynstat_theta_max            =   2.9421955996520E+01
+(PID.TID 0000.0001) %MON dynstat_theta_min            =  -1.8938186730594E+00
+(PID.TID 0000.0001) %MON dynstat_theta_mean           =   3.5917949497776E+00
+(PID.TID 0000.0001) %MON dynstat_theta_sd             =   4.4284288843716E+00
+(PID.TID 0000.0001) %MON dynstat_theta_del2           =   2.0808775382787E-03
+(PID.TID 0000.0001) %MON dynstat_salt_max             =   4.0715864194544E+01
+(PID.TID 0000.0001) %MON dynstat_salt_min             =   1.7267714188180E+01
+(PID.TID 0000.0001) %MON dynstat_salt_mean            =   3.4721512091915E+01
+(PID.TID 0000.0001) %MON dynstat_salt_sd              =   4.8754211288184E-01
+(PID.TID 0000.0001) %MON dynstat_salt_del2            =   5.1074884787387E-04
+(PID.TID 0000.0001) %MON forcing_qnet_max             =   1.4306536842617E+03
+(PID.TID 0000.0001) %MON forcing_qnet_min             =  -3.1401884126880E+02
+(PID.TID 0000.0001) %MON forcing_qnet_mean            =  -2.6394683645553E+01
+(PID.TID 0000.0001) %MON forcing_qnet_sd              =   1.5892995271629E+02
+(PID.TID 0000.0001) %MON forcing_qnet_del2            =   1.3421308992178E+00
 (PID.TID 0000.0001) %MON forcing_qsw_max              =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON forcing_qsw_min              =  -3.0186728538630E+02
-(PID.TID 0000.0001) %MON forcing_qsw_mean             =  -1.8595109436249E+02
-(PID.TID 0000.0001) %MON forcing_qsw_sd               =   7.8872389113827E+01
-(PID.TID 0000.0001) %MON forcing_qsw_del2             =   1.1030265382505E-01
-(PID.TID 0000.0001) %MON forcing_empmr_max            =   1.8716040657982E-03
-(PID.TID 0000.0001) %MON forcing_empmr_min            =  -2.8938035640607E-03
-(PID.TID 0000.0001) %MON forcing_empmr_mean           =   1.2273598864759E-05
-(PID.TID 0000.0001) %MON forcing_empmr_sd             =   1.5587990603686E-04
-(PID.TID 0000.0001) %MON forcing_empmr_del2           =   3.3105429035541E-06
+(PID.TID 0000.0001) %MON forcing_qsw_mean             =  -1.8595109427343E+02
+(PID.TID 0000.0001) %MON forcing_qsw_sd               =   7.8872389323804E+01
+(PID.TID 0000.0001) %MON forcing_qsw_del2             =   1.1030265382374E-01
+(PID.TID 0000.0001) %MON forcing_empmr_max            =   1.8665720765267E-03
+(PID.TID 0000.0001) %MON forcing_empmr_min            =  -3.5162002222686E-03
+(PID.TID 0000.0001) %MON forcing_empmr_mean           =   1.7536058566747E-05
+(PID.TID 0000.0001) %MON forcing_empmr_sd             =   1.6165792072811E-04
+(PID.TID 0000.0001) %MON forcing_empmr_del2           =   3.7124011822217E-06
 (PID.TID 0000.0001) %MON forcing_fu_max               =   2.4741393863310E-01
 (PID.TID 0000.0001) %MON forcing_fu_min               =  -2.1551509637860E-01
-(PID.TID 0000.0001) %MON forcing_fu_mean              =  -4.3401455508744E-03
-(PID.TID 0000.0001) %MON forcing_fu_sd                =   6.4043521000846E-02
-(PID.TID 0000.0001) %MON forcing_fu_del2              =   2.0725425058944E-04
+(PID.TID 0000.0001) %MON forcing_fu_mean              =  -4.3387419469924E-03
+(PID.TID 0000.0001) %MON forcing_fu_sd                =   6.4042638461375E-02
+(PID.TID 0000.0001) %MON forcing_fu_del2              =   2.0717903790887E-04
 (PID.TID 0000.0001) %MON forcing_fv_max               =   2.6354394672640E-01
 (PID.TID 0000.0001) %MON forcing_fv_min               =  -3.3007153975572E-01
-(PID.TID 0000.0001) %MON forcing_fv_mean              =  -1.3692878639289E-02
-(PID.TID 0000.0001) %MON forcing_fv_sd                =   7.5385099808090E-02
-(PID.TID 0000.0001) %MON forcing_fv_del2              =   2.3568023791268E-04
-(PID.TID 0000.0001) %MON trAdv_CFL_u_max              =   3.6223042343877E-02
-(PID.TID 0000.0001) %MON trAdv_CFL_v_max              =   5.0257847721963E-02
-(PID.TID 0000.0001) %MON trAdv_CFL_w_max              =   1.7657325964955E-01
-(PID.TID 0000.0001) %MON advcfl_uvel_max              =   3.0804999826202E-02
-(PID.TID 0000.0001) %MON advcfl_vvel_max              =   3.9223493703787E-02
-(PID.TID 0000.0001) %MON advcfl_wvel_max              =   1.9336647336483E-01
-(PID.TID 0000.0001) %MON advcfl_W_hf_max              =   2.1365529897886E-01
-(PID.TID 0000.0001) %MON pe_b_mean                    =   1.3562755341104E-02
-(PID.TID 0000.0001) %MON ke_max                       =   6.4891860723009E-03
-(PID.TID 0000.0001) %MON ke_mean                      =   2.4016547148544E-05
-(PID.TID 0000.0001) %MON ke_vol                       =   1.3604155681425E+22
-(PID.TID 0000.0001) %MON vort_r_min                   =  -5.8033803657097E-07
-(PID.TID 0000.0001) %MON vort_r_max                   =   6.2817306900739E-07
+(PID.TID 0000.0001) %MON forcing_fv_mean              =  -1.3691517234408E-02
+(PID.TID 0000.0001) %MON forcing_fv_sd                =   7.5386118530856E-02
+(PID.TID 0000.0001) %MON forcing_fv_del2              =   2.3568502807376E-04
+(PID.TID 0000.0001) %MON trAdv_CFL_u_max              =   3.6219911212534E-02
+(PID.TID 0000.0001) %MON trAdv_CFL_v_max              =   5.0264918149080E-02
+(PID.TID 0000.0001) %MON trAdv_CFL_w_max              =   1.7658010226675E-01
+(PID.TID 0000.0001) %MON advcfl_uvel_max              =   3.0805948017716E-02
+(PID.TID 0000.0001) %MON advcfl_vvel_max              =   3.9246361539246E-02
+(PID.TID 0000.0001) %MON advcfl_wvel_max              =   1.9337393591326E-01
+(PID.TID 0000.0001) %MON advcfl_W_hf_max              =   2.1366357860980E-01
+(PID.TID 0000.0001) %MON pe_b_mean                    =   1.3558464970427E-02
+(PID.TID 0000.0001) %MON ke_max                       =   6.4891609599450E-03
+(PID.TID 0000.0001) %MON ke_mean                      =   2.4025019502503E-05
+(PID.TID 0000.0001) %MON ke_vol                       =   1.3604155093609E+22
+(PID.TID 0000.0001) %MON vort_r_min                   =  -5.8247085685285E-07
+(PID.TID 0000.0001) %MON vort_r_max                   =   6.2817743517033E-07
 (PID.TID 0000.0001) %MON vort_a_mean                  =  -2.0556865257795E-05
-(PID.TID 0000.0001) %MON vort_a_sd                    =   7.5247364060065E-05
-(PID.TID 0000.0001) %MON vort_p_mean                  =  -2.4859218018146E-05
-(PID.TID 0000.0001) %MON vort_p_sd                    =   1.2920533582752E-04
-(PID.TID 0000.0001) %MON surfExpan_theta_mean         =   6.3768200903091E-03
-(PID.TID 0000.0001) %MON surfExpan_salt_mean          =  -3.8036807426282E-03
+(PID.TID 0000.0001) %MON vort_a_sd                    =   7.5247363993428E-05
+(PID.TID 0000.0001) %MON vort_p_mean                  =  -2.4859219139138E-05
+(PID.TID 0000.0001) %MON vort_p_sd                    =   1.2920535511148E-04
+(PID.TID 0000.0001) %MON surfExpan_theta_mean         =   6.4683516916120E-03
+(PID.TID 0000.0001) %MON surfExpan_salt_mean          =  -5.5624027172782E-03
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // End MONITOR dynamic field statistics
 (PID.TID 0000.0001) // =======================================================
@@ -3991,124 +3996,124 @@ listId=   2 ; file name: seaiceStDiag
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) %MON seaice_tsnumber              =                     5
 (PID.TID 0000.0001) %MON seaice_time_sec              =   4.3200000000000E+05
-(PID.TID 0000.0001) %MON seaice_uice_max              =   1.2618769052623E-01
-(PID.TID 0000.0001) %MON seaice_uice_min              =  -2.0838387131890E-01
-(PID.TID 0000.0001) %MON seaice_uice_mean             =  -4.8825479332971E-04
-(PID.TID 0000.0001) %MON seaice_uice_sd               =   1.1887054972207E-02
-(PID.TID 0000.0001) %MON seaice_uice_del2             =   1.7521242942213E-04
-(PID.TID 0000.0001) %MON seaice_vice_max              =   1.5360963274701E-01
-(PID.TID 0000.0001) %MON seaice_vice_min              =  -1.5988460521002E-01
-(PID.TID 0000.0001) %MON seaice_vice_mean             =   1.0557321707315E-03
-(PID.TID 0000.0001) %MON seaice_vice_sd               =   1.5011525084907E-02
-(PID.TID 0000.0001) %MON seaice_vice_del2             =   1.1222778395352E-04
-(PID.TID 0000.0001) %MON seaice_area_max              =   8.6147320365639E-01
+(PID.TID 0000.0001) %MON seaice_uice_max              =   1.2617173250948E-01
+(PID.TID 0000.0001) %MON seaice_uice_min              =  -2.1181189963400E-01
+(PID.TID 0000.0001) %MON seaice_uice_mean             =  -4.9065464301376E-04
+(PID.TID 0000.0001) %MON seaice_uice_sd               =   1.1923663482877E-02
+(PID.TID 0000.0001) %MON seaice_uice_del2             =   1.7675814513578E-04
+(PID.TID 0000.0001) %MON seaice_vice_max              =   1.5590224674018E-01
+(PID.TID 0000.0001) %MON seaice_vice_min              =  -1.5990024993454E-01
+(PID.TID 0000.0001) %MON seaice_vice_mean             =   1.0617076627556E-03
+(PID.TID 0000.0001) %MON seaice_vice_sd               =   1.5044902242010E-02
+(PID.TID 0000.0001) %MON seaice_vice_del2             =   1.1221431379913E-04
+(PID.TID 0000.0001) %MON seaice_area_max              =   8.6147187163621E-01
 (PID.TID 0000.0001) %MON seaice_area_min              =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON seaice_area_mean             =   1.5637778361567E-02
-(PID.TID 0000.0001) %MON seaice_area_sd               =   1.0593989856834E-01
-(PID.TID 0000.0001) %MON seaice_area_del2             =   8.3973554828594E-04
-(PID.TID 0000.0001) %MON seaice_heff_max              =   5.1946745261351E-01
+(PID.TID 0000.0001) %MON seaice_area_mean             =   1.6823036460807E-02
+(PID.TID 0000.0001) %MON seaice_area_sd               =   1.0898638375462E-01
+(PID.TID 0000.0001) %MON seaice_area_del2             =   8.2042101162262E-04
+(PID.TID 0000.0001) %MON seaice_heff_max              =   5.1952019351093E-01
 (PID.TID 0000.0001) %MON seaice_heff_min              =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON seaice_heff_mean             =   8.6433266563225E-03
-(PID.TID 0000.0001) %MON seaice_heff_sd               =   5.9723348107686E-02
-(PID.TID 0000.0001) %MON seaice_heff_del2             =   4.5872954421379E-04
-(PID.TID 0000.0001) %MON seaice_hsnow_max             =   6.0910545521926E-03
+(PID.TID 0000.0001) %MON seaice_heff_mean             =   9.2966023543850E-03
+(PID.TID 0000.0001) %MON seaice_heff_sd               =   6.1499026295168E-02
+(PID.TID 0000.0001) %MON seaice_heff_del2             =   5.2732601586369E-04
+(PID.TID 0000.0001) %MON seaice_hsnow_max             =   6.0898210087050E-03
 (PID.TID 0000.0001) %MON seaice_hsnow_min             =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON seaice_hsnow_mean            =   5.3594718191975E-05
-(PID.TID 0000.0001) %MON seaice_hsnow_sd              =   4.2156702627013E-04
-(PID.TID 0000.0001) %MON seaice_hsnow_del2            =   5.9156019710840E-06
+(PID.TID 0000.0001) %MON seaice_hsnow_mean            =   5.6971773372443E-05
+(PID.TID 0000.0001) %MON seaice_hsnow_sd              =   4.3980831098812E-04
+(PID.TID 0000.0001) %MON seaice_hsnow_del2            =   7.3362875323111E-06
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // End MONITOR SEAICE statistics
 (PID.TID 0000.0001) // =======================================================
  EXTERNAL_FIELDS_LOAD,         5 : iP,iLd,i0,i1=   12    1   12    1 ; Wght=  0.3333333333  0.6666666667
- SEAICE_LSR: Residual Initial ipass,Uice,Vice=         1  4.96509922E-03  6.36071578E-04
- SEAICE_LSR (ipass=        1) iters,dU,Resid=       14  3.03923553E-15  2.26831842E-18
- SEAICE_LSR (ipass=        1) iters,dV,Resid=       14  9.64228697E-14  2.76349811E-18
- SEAICE_LSR: Residual Initial ipass,Uice,Vice=         2  2.46644437E-03  2.84151747E-04
- SEAICE_LSR (ipass=        2) iters,dU,Resid=       14  7.32053307E-16  1.02394523E-18
- SEAICE_LSR (ipass=        2) iters,dV,Resid=       14  1.63064007E-14  1.09442016E-18
- cg2d: Sum(rhs),rhsMax =   2.72439013127737E-01  1.98997839252736E+01
-(PID.TID 0000.0001)      cg2d_init_res =   7.52094074276864E-02
+ SEAICE_LSR: Residual Initial ipass,Uice,Vice=         1  8.04682470E-04  3.66039483E-04
+ SEAICE_LSR (ipass=        1) iters,dU,Resid=       12  2.82773804E-13  2.00474385E-16
+ SEAICE_LSR (ipass=        1) iters,dV,Resid=       12  5.37576927E-13  1.80689949E-16
+ SEAICE_LSR: Residual Initial ipass,Uice,Vice=         2  2.11383335E-04  8.29260290E-05
+ SEAICE_LSR (ipass=        2) iters,dU,Resid=       12  6.25749452E-14  8.84672737E-17
+ SEAICE_LSR (ipass=        2) iters,dV,Resid=       12  7.50233209E-14  3.99679457E-17
+ cg2d: Sum(rhs),rhsMax =   2.98910739557900E-01  1.98998102596207E+01
+(PID.TID 0000.0001)      cg2d_init_res =   7.51483734631959E-02
 (PID.TID 0000.0001)      cg2d_iters(min,last) =      -1     102
-(PID.TID 0000.0001)      cg2d_last_res =   9.19176887229875E-10
+(PID.TID 0000.0001)      cg2d_last_res =   9.19052240374549E-10
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // Begin MONITOR dynamic field statistics
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) %MON time_tsnumber                =                     6
 (PID.TID 0000.0001) %MON time_secondsf                =   5.1840000000000E+05
-(PID.TID 0000.0001) %MON dynstat_eta_max              =   1.4057155889424E+04
-(PID.TID 0000.0001) %MON dynstat_eta_min              =  -2.3264703812330E+04
-(PID.TID 0000.0001) %MON dynstat_eta_mean             =  -8.1872520246961E+01
-(PID.TID 0000.0001) %MON dynstat_eta_sd               =   7.4014592284905E+03
-(PID.TID 0000.0001) %MON dynstat_eta_del2             =   9.3885786340847E+01
-(PID.TID 0000.0001) %MON dynstat_uvel_max             =   9.8487559228252E-02
-(PID.TID 0000.0001) %MON dynstat_uvel_min             =  -1.1689504436085E-01
-(PID.TID 0000.0001) %MON dynstat_uvel_mean            =  -2.7358383792327E-04
-(PID.TID 0000.0001) %MON dynstat_uvel_sd              =   5.8990343523346E-03
-(PID.TID 0000.0001) %MON dynstat_uvel_del2            =   3.0173858380202E-05
-(PID.TID 0000.0001) %MON dynstat_vvel_max             =   1.5998521835049E-01
-(PID.TID 0000.0001) %MON dynstat_vvel_min             =  -1.4765804978216E-01
-(PID.TID 0000.0001) %MON dynstat_vvel_mean            =  -4.7216312226430E-04
-(PID.TID 0000.0001) %MON dynstat_vvel_sd              =   6.0659651358622E-03
-(PID.TID 0000.0001) %MON dynstat_vvel_del2            =   3.1335740339359E-05
-(PID.TID 0000.0001) %MON dynstat_wvel_max             =   4.6785342141240E+00
-(PID.TID 0000.0001) %MON dynstat_wvel_min             =  -7.9346306922863E+00
-(PID.TID 0000.0001) %MON dynstat_wvel_mean            =  -7.8720856037632E-05
-(PID.TID 0000.0001) %MON dynstat_wvel_sd              =   2.1722408370271E-01
-(PID.TID 0000.0001) %MON dynstat_wvel_del2            =   1.7188256932951E-03
-(PID.TID 0000.0001) %MON dynstat_theta_max            =   2.9427696569267E+01
-(PID.TID 0000.0001) %MON dynstat_theta_min            =  -1.8898066966984E+00
-(PID.TID 0000.0001) %MON dynstat_theta_mean           =   3.5919528795527E+00
-(PID.TID 0000.0001) %MON dynstat_theta_sd             =   4.4281529223073E+00
-(PID.TID 0000.0001) %MON dynstat_theta_del2           =   2.2973075187057E-03
-(PID.TID 0000.0001) %MON dynstat_salt_max             =   4.0715839210819E+01
-(PID.TID 0000.0001) %MON dynstat_salt_min             =   1.6954938101423E+01
-(PID.TID 0000.0001) %MON dynstat_salt_mean            =   3.4721518790394E+01
-(PID.TID 0000.0001) %MON dynstat_salt_sd              =   4.8733334407440E-01
-(PID.TID 0000.0001) %MON dynstat_salt_del2            =   5.2069854015365E-04
-(PID.TID 0000.0001) %MON forcing_qnet_max             =   7.0134346274719E+02
-(PID.TID 0000.0001) %MON forcing_qnet_min             =  -3.1298527138330E+02
-(PID.TID 0000.0001) %MON forcing_qnet_mean            =  -2.7235754739833E+01
-(PID.TID 0000.0001) %MON forcing_qnet_sd              =   1.5584123876468E+02
-(PID.TID 0000.0001) %MON forcing_qnet_del2            =   1.0122314012850E+00
+(PID.TID 0000.0001) %MON dynstat_eta_max              =   1.4047421309107E+04
+(PID.TID 0000.0001) %MON dynstat_eta_min              =  -2.3265646906980E+04
+(PID.TID 0000.0001) %MON dynstat_eta_mean             =  -8.9827839564071E+01
+(PID.TID 0000.0001) %MON dynstat_eta_sd               =   7.4066176253566E+03
+(PID.TID 0000.0001) %MON dynstat_eta_del2             =   9.3881187679444E+01
+(PID.TID 0000.0001) %MON dynstat_uvel_max             =   9.8471364986082E-02
+(PID.TID 0000.0001) %MON dynstat_uvel_min             =  -1.1747471290654E-01
+(PID.TID 0000.0001) %MON dynstat_uvel_mean            =  -2.7306429182615E-04
+(PID.TID 0000.0001) %MON dynstat_uvel_sd              =   5.8998428004929E-03
+(PID.TID 0000.0001) %MON dynstat_uvel_del2            =   3.0161258512734E-05
+(PID.TID 0000.0001) %MON dynstat_vvel_max             =   1.6007919883689E-01
+(PID.TID 0000.0001) %MON dynstat_vvel_min             =  -1.4764970987817E-01
+(PID.TID 0000.0001) %MON dynstat_vvel_mean            =  -4.7244960268451E-04
+(PID.TID 0000.0001) %MON dynstat_vvel_sd              =   6.0671675544928E-03
+(PID.TID 0000.0001) %MON dynstat_vvel_del2            =   3.1335453692598E-05
+(PID.TID 0000.0001) %MON dynstat_wvel_max             =   4.6785033261316E+00
+(PID.TID 0000.0001) %MON dynstat_wvel_min             =  -7.9345735970041E+00
+(PID.TID 0000.0001) %MON dynstat_wvel_mean            =  -8.8724478963585E-05
+(PID.TID 0000.0001) %MON dynstat_wvel_sd              =   2.1722410682252E-01
+(PID.TID 0000.0001) %MON dynstat_wvel_del2            =   1.7186717646396E-03
+(PID.TID 0000.0001) %MON dynstat_theta_max            =   2.9427781828069E+01
+(PID.TID 0000.0001) %MON dynstat_theta_min            =  -1.8962377329236E+00
+(PID.TID 0000.0001) %MON dynstat_theta_mean           =   3.5919644014676E+00
+(PID.TID 0000.0001) %MON dynstat_theta_sd             =   4.4288020059048E+00
+(PID.TID 0000.0001) %MON dynstat_theta_del2           =   2.0815556168914E-03
+(PID.TID 0000.0001) %MON dynstat_salt_max             =   4.0715876245592E+01
+(PID.TID 0000.0001) %MON dynstat_salt_min             =   1.6954920736290E+01
+(PID.TID 0000.0001) %MON dynstat_salt_mean            =   3.4721525439999E+01
+(PID.TID 0000.0001) %MON dynstat_salt_sd              =   4.8747856399512E-01
+(PID.TID 0000.0001) %MON dynstat_salt_del2            =   5.0853912182684E-04
+(PID.TID 0000.0001) %MON forcing_qnet_max             =   6.7025240976665E+02
+(PID.TID 0000.0001) %MON forcing_qnet_min             =  -3.1305243490932E+02
+(PID.TID 0000.0001) %MON forcing_qnet_mean            =  -2.7786891353735E+01
+(PID.TID 0000.0001) %MON forcing_qnet_sd              =   1.5325213095022E+02
+(PID.TID 0000.0001) %MON forcing_qnet_del2            =   8.5144766530336E-01
 (PID.TID 0000.0001) %MON forcing_qsw_max              =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON forcing_qsw_min              =  -3.0185528845048E+02
-(PID.TID 0000.0001) %MON forcing_qsw_mean             =  -1.8595724303901E+02
-(PID.TID 0000.0001) %MON forcing_qsw_sd               =   7.8769620529423E+01
-(PID.TID 0000.0001) %MON forcing_qsw_del2             =   1.1038810628945E-01
-(PID.TID 0000.0001) %MON forcing_empmr_max            =   1.6425831826979E-03
-(PID.TID 0000.0001) %MON forcing_empmr_min            =  -4.5351267256684E-04
-(PID.TID 0000.0001) %MON forcing_empmr_mean           =   1.6224517378397E-05
-(PID.TID 0000.0001) %MON forcing_empmr_sd             =   1.3097512176082E-04
-(PID.TID 0000.0001) %MON forcing_empmr_del2           =   1.9564949718458E-06
+(PID.TID 0000.0001) %MON forcing_qsw_mean             =  -1.8595720275291E+02
+(PID.TID 0000.0001) %MON forcing_qsw_sd               =   7.8769715408587E+01
+(PID.TID 0000.0001) %MON forcing_qsw_del2             =   1.1038814379170E-01
+(PID.TID 0000.0001) %MON forcing_empmr_max            =   1.6094303159290E-03
+(PID.TID 0000.0001) %MON forcing_empmr_min            =  -4.5351270375867E-04
+(PID.TID 0000.0001) %MON forcing_empmr_mean           =   1.8442069413249E-05
+(PID.TID 0000.0001) %MON forcing_empmr_sd             =   1.3887219958938E-04
+(PID.TID 0000.0001) %MON forcing_empmr_del2           =   1.8138422281247E-06
 (PID.TID 0000.0001) %MON forcing_fu_max               =   2.4736588936290E-01
 (PID.TID 0000.0001) %MON forcing_fu_min               =  -2.1866089303695E-01
-(PID.TID 0000.0001) %MON forcing_fu_mean              =  -4.2940979585603E-03
-(PID.TID 0000.0001) %MON forcing_fu_sd                =   6.4104903864008E-02
-(PID.TID 0000.0001) %MON forcing_fu_del2              =   2.0827633324864E-04
+(PID.TID 0000.0001) %MON forcing_fu_mean              =  -4.2896087808197E-03
+(PID.TID 0000.0001) %MON forcing_fu_sd                =   6.4103785391289E-02
+(PID.TID 0000.0001) %MON forcing_fu_del2              =   2.0827438970549E-04
 (PID.TID 0000.0001) %MON forcing_fv_max               =   2.6622718829904E-01
 (PID.TID 0000.0001) %MON forcing_fv_min               =  -3.3085944368965E-01
-(PID.TID 0000.0001) %MON forcing_fv_mean              =  -1.3696257417526E-02
-(PID.TID 0000.0001) %MON forcing_fv_sd                =   7.5466271818169E-02
-(PID.TID 0000.0001) %MON forcing_fv_del2              =   2.3657121260592E-04
-(PID.TID 0000.0001) %MON trAdv_CFL_u_max              =   4.1293657502974E-02
-(PID.TID 0000.0001) %MON trAdv_CFL_v_max              =   5.8428954476840E-02
-(PID.TID 0000.0001) %MON trAdv_CFL_w_max              =   2.0435998247598E-01
-(PID.TID 0000.0001) %MON advcfl_uvel_max              =   3.6038924976995E-02
-(PID.TID 0000.0001) %MON advcfl_vvel_max              =   4.5228091999998E-02
-(PID.TID 0000.0001) %MON advcfl_wvel_max              =   2.2381138177586E-01
-(PID.TID 0000.0001) %MON advcfl_W_hf_max              =   2.4727749400945E-01
-(PID.TID 0000.0001) %MON pe_b_mean                    =   1.3545032825667E-02
-(PID.TID 0000.0001) %MON ke_max                       =   8.7307866889125E-03
-(PID.TID 0000.0001) %MON ke_mean                      =   3.3195262458942E-05
-(PID.TID 0000.0001) %MON ke_vol                       =   1.3604151895946E+22
-(PID.TID 0000.0001) %MON vort_r_min                   =  -5.8446061772980E-07
-(PID.TID 0000.0001) %MON vort_r_max                   =   6.8231946582181E-07
+(PID.TID 0000.0001) %MON forcing_fv_mean              =  -1.3693588699084E-02
+(PID.TID 0000.0001) %MON forcing_fv_sd                =   7.5467685968560E-02
+(PID.TID 0000.0001) %MON forcing_fv_del2              =   2.3656568213681E-04
+(PID.TID 0000.0001) %MON trAdv_CFL_u_max              =   4.1293132082132E-02
+(PID.TID 0000.0001) %MON trAdv_CFL_v_max              =   5.8435045069123E-02
+(PID.TID 0000.0001) %MON trAdv_CFL_w_max              =   2.0436008581553E-01
+(PID.TID 0000.0001) %MON advcfl_uvel_max              =   3.6040672193936E-02
+(PID.TID 0000.0001) %MON advcfl_vvel_max              =   4.5254660442564E-02
+(PID.TID 0000.0001) %MON advcfl_wvel_max              =   2.2381138655660E-01
+(PID.TID 0000.0001) %MON advcfl_W_hf_max              =   2.4727761905127E-01
+(PID.TID 0000.0001) %MON pe_b_mean                    =   1.3538388757152E-02
+(PID.TID 0000.0001) %MON ke_max                       =   8.7302407280484E-03
+(PID.TID 0000.0001) %MON ke_mean                      =   3.3206408532521E-05
+(PID.TID 0000.0001) %MON ke_vol                       =   1.3604149685058E+22
+(PID.TID 0000.0001) %MON vort_r_min                   =  -5.8476721193868E-07
+(PID.TID 0000.0001) %MON vort_r_max                   =   6.8233334161843E-07
 (PID.TID 0000.0001) %MON vort_a_mean                  =  -2.0556865257795E-05
-(PID.TID 0000.0001) %MON vort_a_sd                    =   7.5247389189874E-05
-(PID.TID 0000.0001) %MON vort_p_mean                  =  -2.4859223237139E-05
-(PID.TID 0000.0001) %MON vort_p_sd                    =   1.2920599715590E-04
-(PID.TID 0000.0001) %MON surfExpan_theta_mean         =   3.9645607930808E-03
-(PID.TID 0000.0001) %MON surfExpan_salt_mean          =  -5.3234105819413E-03
+(PID.TID 0000.0001) %MON vort_a_sd                    =   7.5247389070017E-05
+(PID.TID 0000.0001) %MON vort_p_mean                  =  -2.4859227151444E-05
+(PID.TID 0000.0001) %MON vort_p_sd                    =   1.2920606915235E-04
+(PID.TID 0000.0001) %MON surfExpan_theta_mean         =   3.9312610484869E-03
+(PID.TID 0000.0001) %MON surfExpan_salt_mean          =  -6.0895576117060E-03
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // End MONITOR dynamic field statistics
 (PID.TID 0000.0001) // =======================================================
@@ -4117,124 +4122,124 @@ listId=   2 ; file name: seaiceStDiag
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) %MON seaice_tsnumber              =                     6
 (PID.TID 0000.0001) %MON seaice_time_sec              =   5.1840000000000E+05
-(PID.TID 0000.0001) %MON seaice_uice_max              =   1.8111681057992E-01
-(PID.TID 0000.0001) %MON seaice_uice_min              =  -2.1854009504588E-01
-(PID.TID 0000.0001) %MON seaice_uice_mean             =  -3.0158032194401E-04
-(PID.TID 0000.0001) %MON seaice_uice_sd               =   1.1275187417618E-02
-(PID.TID 0000.0001) %MON seaice_uice_del2             =   1.7289277121479E-04
-(PID.TID 0000.0001) %MON seaice_vice_max              =   1.6193603638008E-01
-(PID.TID 0000.0001) %MON seaice_vice_min              =  -1.6608821342782E-01
-(PID.TID 0000.0001) %MON seaice_vice_mean             =   1.0610235050048E-03
-(PID.TID 0000.0001) %MON seaice_vice_sd               =   1.5329213121620E-02
-(PID.TID 0000.0001) %MON seaice_vice_del2             =   1.1526292392964E-04
-(PID.TID 0000.0001) %MON seaice_area_max              =   9.1248316203633E-01
+(PID.TID 0000.0001) %MON seaice_uice_max              =   1.8248176355315E-01
+(PID.TID 0000.0001) %MON seaice_uice_min              =  -2.5323963490216E-01
+(PID.TID 0000.0001) %MON seaice_uice_mean             =  -5.3013068679317E-04
+(PID.TID 0000.0001) %MON seaice_uice_sd               =   1.3095956280708E-02
+(PID.TID 0000.0001) %MON seaice_uice_del2             =   2.0068134822632E-04
+(PID.TID 0000.0001) %MON seaice_vice_max              =   1.6272048622439E-01
+(PID.TID 0000.0001) %MON seaice_vice_min              =  -1.6617428026771E-01
+(PID.TID 0000.0001) %MON seaice_vice_mean             =   1.1131719804357E-03
+(PID.TID 0000.0001) %MON seaice_vice_sd               =   1.5448026638607E-02
+(PID.TID 0000.0001) %MON seaice_vice_del2             =   1.1457314456640E-04
+(PID.TID 0000.0001) %MON seaice_area_max              =   9.1248327261122E-01
 (PID.TID 0000.0001) %MON seaice_area_min              =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON seaice_area_mean             =   1.8118420550267E-02
-(PID.TID 0000.0001) %MON seaice_area_sd               =   1.1845487214508E-01
-(PID.TID 0000.0001) %MON seaice_area_del2             =   9.0889324214260E-04
-(PID.TID 0000.0001) %MON seaice_heff_max              =   5.7643416593150E-01
+(PID.TID 0000.0001) %MON seaice_area_mean             =   1.9654706639506E-02
+(PID.TID 0000.0001) %MON seaice_area_sd               =   1.2266465642272E-01
+(PID.TID 0000.0001) %MON seaice_area_del2             =   7.8099515173623E-04
+(PID.TID 0000.0001) %MON seaice_heff_max              =   5.7646752706247E-01
 (PID.TID 0000.0001) %MON seaice_heff_min              =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON seaice_heff_mean             =   1.0411363856772E-02
-(PID.TID 0000.0001) %MON seaice_heff_sd               =   6.9189390030860E-02
-(PID.TID 0000.0001) %MON seaice_heff_del2             =   4.9636538841772E-04
-(PID.TID 0000.0001) %MON seaice_hsnow_max             =   8.9803073411834E-03
+(PID.TID 0000.0001) %MON seaice_heff_mean             =   1.1262636196020E-02
+(PID.TID 0000.0001) %MON seaice_heff_sd               =   7.1553254315723E-02
+(PID.TID 0000.0001) %MON seaice_heff_del2             =   5.1311454956016E-04
+(PID.TID 0000.0001) %MON seaice_hsnow_max             =   9.0867155981524E-03
 (PID.TID 0000.0001) %MON seaice_hsnow_min             =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON seaice_hsnow_mean            =   8.1221601284076E-05
-(PID.TID 0000.0001) %MON seaice_hsnow_sd              =   6.1936758125957E-04
-(PID.TID 0000.0001) %MON seaice_hsnow_del2            =   8.4229169730962E-06
+(PID.TID 0000.0001) %MON seaice_hsnow_mean            =   8.6973728658317E-05
+(PID.TID 0000.0001) %MON seaice_hsnow_sd              =   6.5033986871209E-04
+(PID.TID 0000.0001) %MON seaice_hsnow_del2            =   1.0243679794257E-05
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // End MONITOR SEAICE statistics
 (PID.TID 0000.0001) // =======================================================
  EXTERNAL_FIELDS_LOAD,         6 : iP,iLd,i0,i1=   12    1   12    1 ; Wght=  0.3000000000  0.7000000000
- SEAICE_LSR: Residual Initial ipass,Uice,Vice=         1  5.97371443E-04  3.72018081E-04
- SEAICE_LSR (ipass=        1) iters,dU,Resid=       18  1.16434640E-14  4.64406518E-17
- SEAICE_LSR (ipass=        1) iters,dV,Resid=       18  3.34329786E-13  8.89938542E-17
- SEAICE_LSR: Residual Initial ipass,Uice,Vice=         2  6.99880975E-04  1.12510224E-04
- SEAICE_LSR (ipass=        2) iters,dU,Resid=       18  6.33867958E-15  2.71347430E-17
- SEAICE_LSR (ipass=        2) iters,dV,Resid=       18  8.65557626E-14  2.57378009E-17
- cg2d: Sum(rhs),rhsMax =   3.06634963041215E-01  1.99001503625760E+01
-(PID.TID 0000.0001)      cg2d_init_res =   7.39631764792730E-02
+ SEAICE_LSR: Residual Initial ipass,Uice,Vice=         1  7.24696686E-04  4.01115302E-04
+ SEAICE_LSR (ipass=        1) iters,dU,Resid=       16  1.60319674E-13  5.83295504E-16
+ SEAICE_LSR (ipass=        1) iters,dV,Resid=       16  1.88932203E-13  5.78870109E-16
+ SEAICE_LSR: Residual Initial ipass,Uice,Vice=         2  5.52972014E-04  1.06212230E-04
+ SEAICE_LSR (ipass=        2) iters,dU,Resid=       16  8.13012851E-14  3.15939687E-16
+ SEAICE_LSR (ipass=        2) iters,dV,Resid=       16  4.81559237E-14  1.59956114E-16
+ cg2d: Sum(rhs),rhsMax =   3.38571388980930E-01  1.99001902034457E+01
+(PID.TID 0000.0001)      cg2d_init_res =   7.38742758473712E-02
 (PID.TID 0000.0001)      cg2d_iters(min,last) =      -1      98
-(PID.TID 0000.0001)      cg2d_last_res =   9.17946400604766E-10
+(PID.TID 0000.0001)      cg2d_last_res =   9.08470108689426E-10
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // Begin MONITOR dynamic field statistics
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) %MON time_tsnumber                =                     7
 (PID.TID 0000.0001) %MON time_secondsf                =   6.0480000000000E+05
-(PID.TID 0000.0001) %MON dynstat_eta_max              =   1.4827165524534E+04
-(PID.TID 0000.0001) %MON dynstat_eta_min              =  -2.2986829846317E+04
-(PID.TID 0000.0001) %MON dynstat_eta_mean             =  -9.2150677020255E+01
-(PID.TID 0000.0001) %MON dynstat_eta_sd               =   7.3336382291822E+03
-(PID.TID 0000.0001) %MON dynstat_eta_del2             =   9.4075399082326E+01
-(PID.TID 0000.0001) %MON dynstat_uvel_max             =   1.1106571154909E-01
-(PID.TID 0000.0001) %MON dynstat_uvel_min             =  -1.3168196560842E-01
-(PID.TID 0000.0001) %MON dynstat_uvel_mean            =  -1.4535873540564E-04
-(PID.TID 0000.0001) %MON dynstat_uvel_sd              =   6.7487206672971E-03
-(PID.TID 0000.0001) %MON dynstat_uvel_del2            =   3.3411833763977E-05
-(PID.TID 0000.0001) %MON dynstat_vvel_max             =   1.7841901357382E-01
-(PID.TID 0000.0001) %MON dynstat_vvel_min             =  -1.6522613039236E-01
-(PID.TID 0000.0001) %MON dynstat_vvel_mean            =  -5.0414016389261E-04
-(PID.TID 0000.0001) %MON dynstat_vvel_sd              =   6.9504097295049E-03
-(PID.TID 0000.0001) %MON dynstat_vvel_del2            =   3.4543407397889E-05
-(PID.TID 0000.0001) %MON dynstat_wvel_max             =   5.1172760155033E+00
-(PID.TID 0000.0001) %MON dynstat_wvel_min             =  -8.8789946886332E+00
-(PID.TID 0000.0001) %MON dynstat_wvel_mean            =  -5.9788692875596E-05
-(PID.TID 0000.0001) %MON dynstat_wvel_sd              =   2.3891259648824E-01
-(PID.TID 0000.0001) %MON dynstat_wvel_del2            =   1.8536292969529E-03
-(PID.TID 0000.0001) %MON dynstat_theta_max            =   2.9433386612071E+01
-(PID.TID 0000.0001) %MON dynstat_theta_min            =  -1.8989892286929E+00
-(PID.TID 0000.0001) %MON dynstat_theta_mean           =   3.5921151319385E+00
-(PID.TID 0000.0001) %MON dynstat_theta_sd             =   4.4285838820622E+00
-(PID.TID 0000.0001) %MON dynstat_theta_del2           =   2.2795030341427E-03
-(PID.TID 0000.0001) %MON dynstat_salt_max             =   4.0715829698069E+01
-(PID.TID 0000.0001) %MON dynstat_salt_min             =   1.6626710720585E+01
-(PID.TID 0000.0001) %MON dynstat_salt_mean            =   3.4721527034109E+01
-(PID.TID 0000.0001) %MON dynstat_salt_sd              =   4.8729928124986E-01
-(PID.TID 0000.0001) %MON dynstat_salt_del2            =   5.1614417372782E-04
-(PID.TID 0000.0001) %MON forcing_qnet_max             =   7.0754237038198E+02
-(PID.TID 0000.0001) %MON forcing_qnet_min             =  -3.1225323063257E+02
-(PID.TID 0000.0001) %MON forcing_qnet_mean            =  -2.6791490864668E+01
-(PID.TID 0000.0001) %MON forcing_qnet_sd              =   1.5464059103898E+02
-(PID.TID 0000.0001) %MON forcing_qnet_del2            =   1.0215907404576E+00
+(PID.TID 0000.0001) %MON dynstat_eta_max              =   1.4818614714353E+04
+(PID.TID 0000.0001) %MON dynstat_eta_min              =  -2.2987825585533E+04
+(PID.TID 0000.0001) %MON dynstat_eta_mean             =  -1.0174849230372E+02
+(PID.TID 0000.0001) %MON dynstat_eta_sd               =   7.3400202822628E+03
+(PID.TID 0000.0001) %MON dynstat_eta_del2             =   9.4058870445538E+01
+(PID.TID 0000.0001) %MON dynstat_uvel_max             =   1.1104071858112E-01
+(PID.TID 0000.0001) %MON dynstat_uvel_min             =  -1.3225551897072E-01
+(PID.TID 0000.0001) %MON dynstat_uvel_mean            =  -1.4440511776364E-04
+(PID.TID 0000.0001) %MON dynstat_uvel_sd              =   6.7496216459071E-03
+(PID.TID 0000.0001) %MON dynstat_uvel_del2            =   3.3378303108113E-05
+(PID.TID 0000.0001) %MON dynstat_vvel_max             =   1.7852315626066E-01
+(PID.TID 0000.0001) %MON dynstat_vvel_min             =  -1.6521576471278E-01
+(PID.TID 0000.0001) %MON dynstat_vvel_mean            =  -5.0461655929721E-04
+(PID.TID 0000.0001) %MON dynstat_vvel_sd              =   6.9514947057400E-03
+(PID.TID 0000.0001) %MON dynstat_vvel_del2            =   3.4531881138106E-05
+(PID.TID 0000.0001) %MON dynstat_wvel_max             =   5.1171207335517E+00
+(PID.TID 0000.0001) %MON dynstat_wvel_min             =  -8.8785543860629E+00
+(PID.TID 0000.0001) %MON dynstat_wvel_mean            =  -6.8284390632446E-05
+(PID.TID 0000.0001) %MON dynstat_wvel_sd              =   2.3891349980692E-01
+(PID.TID 0000.0001) %MON dynstat_wvel_del2            =   1.8534458644225E-03
+(PID.TID 0000.0001) %MON dynstat_theta_max            =   2.9433093835998E+01
+(PID.TID 0000.0001) %MON dynstat_theta_min            =  -1.8987890960814E+00
+(PID.TID 0000.0001) %MON dynstat_theta_mean           =   3.5921301300220E+00
+(PID.TID 0000.0001) %MON dynstat_theta_sd             =   4.4292068285828E+00
+(PID.TID 0000.0001) %MON dynstat_theta_del2           =   2.0661931617952E-03
+(PID.TID 0000.0001) %MON dynstat_salt_max             =   4.0715873150316E+01
+(PID.TID 0000.0001) %MON dynstat_salt_min             =   1.6626658610937E+01
+(PID.TID 0000.0001) %MON dynstat_salt_mean            =   3.4721534981610E+01
+(PID.TID 0000.0001) %MON dynstat_salt_sd              =   4.8743879684537E-01
+(PID.TID 0000.0001) %MON dynstat_salt_del2            =   5.0413223351981E-04
+(PID.TID 0000.0001) %MON forcing_qnet_max             =   6.8175964293967E+02
+(PID.TID 0000.0001) %MON forcing_qnet_min             =  -3.1203737625305E+02
+(PID.TID 0000.0001) %MON forcing_qnet_mean            =  -2.7368212425748E+01
+(PID.TID 0000.0001) %MON forcing_qnet_sd              =   1.5218872274847E+02
+(PID.TID 0000.0001) %MON forcing_qnet_del2            =   9.1947694506017E-01
 (PID.TID 0000.0001) %MON forcing_qsw_max              =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON forcing_qsw_min              =  -3.0184329151467E+02
-(PID.TID 0000.0001) %MON forcing_qsw_mean             =  -1.8596338967823E+02
-(PID.TID 0000.0001) %MON forcing_qsw_sd               =   7.8669568596166E+01
-(PID.TID 0000.0001) %MON forcing_qsw_del2             =   1.1053681934197E-01
-(PID.TID 0000.0001) %MON forcing_empmr_max            =   1.6338821631088E-03
-(PID.TID 0000.0001) %MON forcing_empmr_min            =  -9.0347183189921E-04
-(PID.TID 0000.0001) %MON forcing_empmr_mean           =   1.2126416701231E-05
-(PID.TID 0000.0001) %MON forcing_empmr_sd             =   1.0980885400494E-04
-(PID.TID 0000.0001) %MON forcing_empmr_del2           =   1.9104589364832E-06
+(PID.TID 0000.0001) %MON forcing_qsw_mean             =  -1.8596329449463E+02
+(PID.TID 0000.0001) %MON forcing_qsw_sd               =   7.8669793140559E+01
+(PID.TID 0000.0001) %MON forcing_qsw_del2             =   1.1053691834775E-01
+(PID.TID 0000.0001) %MON forcing_empmr_max            =   1.6400411693378E-03
+(PID.TID 0000.0001) %MON forcing_empmr_min            =  -8.6384680083895E-04
+(PID.TID 0000.0001) %MON forcing_empmr_mean           =   1.4064272968405E-05
+(PID.TID 0000.0001) %MON forcing_empmr_sd             =   1.1807936086519E-04
+(PID.TID 0000.0001) %MON forcing_empmr_del2           =   1.9274730826426E-06
 (PID.TID 0000.0001) %MON forcing_fu_max               =   2.4731784009269E-01
 (PID.TID 0000.0001) %MON forcing_fu_min               =  -2.2180668969530E-01
-(PID.TID 0000.0001) %MON forcing_fu_mean              =  -4.2431933472305E-03
-(PID.TID 0000.0001) %MON forcing_fu_sd                =   6.4179084307742E-02
-(PID.TID 0000.0001) %MON forcing_fu_del2              =   2.0949521291298E-04
+(PID.TID 0000.0001) %MON forcing_fu_mean              =  -4.2376259214400E-03
+(PID.TID 0000.0001) %MON forcing_fu_sd                =   6.4177034730750E-02
+(PID.TID 0000.0001) %MON forcing_fu_del2              =   2.0947926923992E-04
 (PID.TID 0000.0001) %MON forcing_fv_max               =   2.6891042987167E-01
 (PID.TID 0000.0001) %MON forcing_fv_min               =  -3.3164734762358E-01
-(PID.TID 0000.0001) %MON forcing_fv_mean              =  -1.3697478643917E-02
-(PID.TID 0000.0001) %MON forcing_fv_sd                =   7.5554869632742E-02
-(PID.TID 0000.0001) %MON forcing_fv_del2              =   2.3767012624216E-04
-(PID.TID 0000.0001) %MON trAdv_CFL_u_max              =   4.4206063243273E-02
-(PID.TID 0000.0001) %MON trAdv_CFL_v_max              =   6.5544197569408E-02
-(PID.TID 0000.0001) %MON trAdv_CFL_w_max              =   2.2824485185864E-01
-(PID.TID 0000.0001) %MON advcfl_uvel_max              =   4.0645563521103E-02
-(PID.TID 0000.0001) %MON advcfl_vvel_max              =   5.0439357108525E-02
-(PID.TID 0000.0001) %MON advcfl_wvel_max              =   2.4998554153184E-01
-(PID.TID 0000.0001) %MON advcfl_W_hf_max              =   2.7617840980583E-01
-(PID.TID 0000.0001) %MON pe_b_mean                    =   1.3519359643327E-02
-(PID.TID 0000.0001) %MON ke_max                       =   1.0997748944715E-02
-(PID.TID 0000.0001) %MON ke_mean                      =   4.3463045382780E-05
-(PID.TID 0000.0001) %MON ke_vol                       =   1.3604146891906E+22
-(PID.TID 0000.0001) %MON vort_r_min                   =  -6.5473874539048E-07
-(PID.TID 0000.0001) %MON vort_r_max                   =   7.4438507951670E-07
+(PID.TID 0000.0001) %MON forcing_fv_mean              =  -1.3693477988828E-02
+(PID.TID 0000.0001) %MON forcing_fv_sd                =   7.5556815550984E-02
+(PID.TID 0000.0001) %MON forcing_fv_del2              =   2.3758940782124E-04
+(PID.TID 0000.0001) %MON trAdv_CFL_u_max              =   4.4206778115182E-02
+(PID.TID 0000.0001) %MON trAdv_CFL_v_max              =   6.5548911619987E-02
+(PID.TID 0000.0001) %MON trAdv_CFL_w_max              =   2.2823505287838E-01
+(PID.TID 0000.0001) %MON advcfl_uvel_max              =   4.0648644572797E-02
+(PID.TID 0000.0001) %MON advcfl_vvel_max              =   5.0468798422355E-02
+(PID.TID 0000.0001) %MON advcfl_wvel_max              =   2.4997469409108E-01
+(PID.TID 0000.0001) %MON advcfl_W_hf_max              =   2.7616655294788E-01
+(PID.TID 0000.0001) %MON pe_b_mean                    =   1.3509167365897E-02
+(PID.TID 0000.0001) %MON ke_max                       =   1.0996393613957E-02
+(PID.TID 0000.0001) %MON ke_mean                      =   4.3475726507794E-05
+(PID.TID 0000.0001) %MON ke_vol                       =   1.3604143997070E+22
+(PID.TID 0000.0001) %MON vort_r_min                   =  -6.5507378469327E-07
+(PID.TID 0000.0001) %MON vort_r_max                   =   7.4443112579087E-07
 (PID.TID 0000.0001) %MON vort_a_mean                  =  -2.0556865257795E-05
-(PID.TID 0000.0001) %MON vort_a_sd                    =   7.5247416196692E-05
-(PID.TID 0000.0001) %MON vort_p_mean                  =  -2.4859231937694E-05
-(PID.TID 0000.0001) %MON vort_p_sd                    =   1.2920612647165E-04
-(PID.TID 0000.0001) %MON surfExpan_theta_mean         =   1.7422071322635E-03
-(PID.TID 0000.0001) %MON surfExpan_salt_mean          =  -3.9737201191698E-03
+(PID.TID 0000.0001) %MON vort_a_sd                    =   7.5247416047823E-05
+(PID.TID 0000.0001) %MON vort_p_mean                  =  -2.4859237146016E-05
+(PID.TID 0000.0001) %MON vort_p_sd                    =   1.2920621521011E-04
+(PID.TID 0000.0001) %MON surfExpan_theta_mean         =   1.6963175331424E-03
+(PID.TID 0000.0001) %MON surfExpan_salt_mean          =  -4.6232736213871E-03
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // End MONITOR dynamic field statistics
 (PID.TID 0000.0001) // =======================================================
@@ -4243,124 +4248,124 @@ listId=   2 ; file name: seaiceStDiag
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) %MON seaice_tsnumber              =                     7
 (PID.TID 0000.0001) %MON seaice_time_sec              =   6.0480000000000E+05
-(PID.TID 0000.0001) %MON seaice_uice_max              =   1.2380051820820E-01
-(PID.TID 0000.0001) %MON seaice_uice_min              =  -1.7560371481995E-01
-(PID.TID 0000.0001) %MON seaice_uice_mean             =  -5.8625596676283E-04
-(PID.TID 0000.0001) %MON seaice_uice_sd               =   1.2240320642884E-02
-(PID.TID 0000.0001) %MON seaice_uice_del2             =   1.7636134095532E-04
-(PID.TID 0000.0001) %MON seaice_vice_max              =   1.6087197543637E-01
-(PID.TID 0000.0001) %MON seaice_vice_min              =  -1.7121210253368E-01
-(PID.TID 0000.0001) %MON seaice_vice_mean             =   1.1519579884278E-03
-(PID.TID 0000.0001) %MON seaice_vice_sd               =   1.5520493065195E-02
-(PID.TID 0000.0001) %MON seaice_vice_del2             =   1.1752582909644E-04
-(PID.TID 0000.0001) %MON seaice_area_max              =   9.4565946566603E-01
+(PID.TID 0000.0001) %MON seaice_uice_max              =   1.2385597373059E-01
+(PID.TID 0000.0001) %MON seaice_uice_min              =  -2.0546226275266E-01
+(PID.TID 0000.0001) %MON seaice_uice_mean             =  -7.2134937348230E-04
+(PID.TID 0000.0001) %MON seaice_uice_sd               =   1.3636757105882E-02
+(PID.TID 0000.0001) %MON seaice_uice_del2             =   2.0522894866409E-04
+(PID.TID 0000.0001) %MON seaice_vice_max              =   1.6249387477680E-01
+(PID.TID 0000.0001) %MON seaice_vice_min              =  -1.7112552226390E-01
+(PID.TID 0000.0001) %MON seaice_vice_mean             =   1.1707936837457E-03
+(PID.TID 0000.0001) %MON seaice_vice_sd               =   1.5630470215323E-02
+(PID.TID 0000.0001) %MON seaice_vice_del2             =   1.1858160534925E-04
+(PID.TID 0000.0001) %MON seaice_area_max              =   9.4573688651004E-01
 (PID.TID 0000.0001) %MON seaice_area_min              =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON seaice_area_mean             =   2.0102245575572E-02
-(PID.TID 0000.0001) %MON seaice_area_sd               =   1.2819579229352E-01
-(PID.TID 0000.0001) %MON seaice_area_del2             =   9.8634583094203E-04
-(PID.TID 0000.0001) %MON seaice_heff_max              =   6.2489580803227E-01
+(PID.TID 0000.0001) %MON seaice_area_mean             =   2.1733938306411E-02
+(PID.TID 0000.0001) %MON seaice_area_sd               =   1.3301706439799E-01
+(PID.TID 0000.0001) %MON seaice_area_del2             =   8.3577026272132E-04
+(PID.TID 0000.0001) %MON seaice_heff_max              =   6.2501371569024E-01
 (PID.TID 0000.0001) %MON seaice_heff_min              =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON seaice_heff_mean             =   1.1791467653777E-02
-(PID.TID 0000.0001) %MON seaice_heff_sd               =   7.7005826009264E-02
-(PID.TID 0000.0001) %MON seaice_heff_del2             =   5.5101567801335E-04
-(PID.TID 0000.0001) %MON seaice_hsnow_max             =   1.2152458307878E-02
+(PID.TID 0000.0001) %MON seaice_heff_mean             =   1.2814005727862E-02
+(PID.TID 0000.0001) %MON seaice_heff_sd               =   7.9962447903951E-02
+(PID.TID 0000.0001) %MON seaice_heff_del2             =   5.6113642962952E-04
+(PID.TID 0000.0001) %MON seaice_hsnow_max             =   1.2349441764047E-02
 (PID.TID 0000.0001) %MON seaice_hsnow_min             =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON seaice_hsnow_mean            =   1.1329919355664E-04
-(PID.TID 0000.0001) %MON seaice_hsnow_sd              =   8.4549237799338E-04
-(PID.TID 0000.0001) %MON seaice_hsnow_del2            =   1.1324559345666E-05
+(PID.TID 0000.0001) %MON seaice_hsnow_mean            =   1.2245137973178E-04
+(PID.TID 0000.0001) %MON seaice_hsnow_sd              =   8.9245051502550E-04
+(PID.TID 0000.0001) %MON seaice_hsnow_del2            =   1.3220636738827E-05
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // End MONITOR SEAICE statistics
 (PID.TID 0000.0001) // =======================================================
  EXTERNAL_FIELDS_LOAD,         7 : iP,iLd,i0,i1=   12    1   12    1 ; Wght=  0.2666666667  0.7333333333
- SEAICE_LSR: Residual Initial ipass,Uice,Vice=         1  7.84009885E-04  4.65076813E-04
- SEAICE_LSR (ipass=        1) iters,dU,Resid=       26  2.49418541E-14  3.29602939E-16
- SEAICE_LSR (ipass=        1) iters,dV,Resid=       26  1.48839274E-13  5.24370170E-16
- SEAICE_LSR: Residual Initial ipass,Uice,Vice=         2  3.03271517E-04  1.73420916E-04
- SEAICE_LSR (ipass=        2) iters,dU,Resid=       24  8.32250935E-14  1.15224218E-15
- SEAICE_LSR (ipass=        2) iters,dV,Resid=       24  2.47191156E-13  9.51158331E-16
- cg2d: Sum(rhs),rhsMax =   3.44777960581906E-01  1.99022938823304E+01
-(PID.TID 0000.0001)      cg2d_init_res =   7.47038854679819E-02
+ SEAICE_LSR: Residual Initial ipass,Uice,Vice=         1  5.56844777E-04  4.63718106E-04
+ SEAICE_LSR (ipass=        1) iters,dU,Resid=       22  5.11023515E-13  6.35544597E-15
+ SEAICE_LSR (ipass=        1) iters,dV,Resid=       22  8.96588359E-13  8.77221964E-15
+ SEAICE_LSR: Residual Initial ipass,Uice,Vice=         2  2.62829534E-04  1.79914879E-04
+ SEAICE_LSR (ipass=        2) iters,dU,Resid=       22  2.50055185E-13  3.31286079E-15
+ SEAICE_LSR (ipass=        2) iters,dV,Resid=       22  2.44304577E-13  2.49919975E-15
+ cg2d: Sum(rhs),rhsMax =   3.77046423409817E-01  1.99023261255124E+01
+(PID.TID 0000.0001)      cg2d_init_res =   7.47404701567706E-02
 (PID.TID 0000.0001)      cg2d_iters(min,last) =      -1     101
-(PID.TID 0000.0001)      cg2d_last_res =   7.91144408667740E-10
+(PID.TID 0000.0001)      cg2d_last_res =   7.99209981226649E-10
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // Begin MONITOR dynamic field statistics
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) %MON time_tsnumber                =                     8
 (PID.TID 0000.0001) %MON time_secondsf                =   6.9120000000000E+05
-(PID.TID 0000.0001) %MON dynstat_eta_max              =   1.5258959681623E+04
-(PID.TID 0000.0001) %MON dynstat_eta_min              =  -2.2588193559885E+04
-(PID.TID 0000.0001) %MON dynstat_eta_mean             =  -1.0362466303211E+02
-(PID.TID 0000.0001) %MON dynstat_eta_sd               =   7.2825660489262E+03
-(PID.TID 0000.0001) %MON dynstat_eta_del2             =   9.4222562393375E+01
-(PID.TID 0000.0001) %MON dynstat_uvel_max             =   1.2230591615315E-01
-(PID.TID 0000.0001) %MON dynstat_uvel_min             =  -1.4420757744225E-01
-(PID.TID 0000.0001) %MON dynstat_uvel_mean            =  -4.0413601889135E-05
-(PID.TID 0000.0001) %MON dynstat_uvel_sd              =   7.5610248887892E-03
-(PID.TID 0000.0001) %MON dynstat_uvel_del2            =   3.6076767181346E-05
-(PID.TID 0000.0001) %MON dynstat_vvel_max             =   1.9391015121812E-01
-(PID.TID 0000.0001) %MON dynstat_vvel_min             =  -1.8030347775239E-01
-(PID.TID 0000.0001) %MON dynstat_vvel_mean            =  -4.9241258810239E-04
-(PID.TID 0000.0001) %MON dynstat_vvel_sd              =   7.7901743330571E-03
-(PID.TID 0000.0001) %MON dynstat_vvel_del2            =   3.7194196527822E-05
-(PID.TID 0000.0001) %MON dynstat_wvel_max             =   5.4269257555972E+00
-(PID.TID 0000.0001) %MON dynstat_wvel_min             =  -9.6713174067502E+00
-(PID.TID 0000.0001) %MON dynstat_wvel_mean            =  -6.0012111748858E-06
-(PID.TID 0000.0001) %MON dynstat_wvel_sd              =   2.5577014205294E-01
-(PID.TID 0000.0001) %MON dynstat_wvel_del2            =   1.9457816266697E-03
-(PID.TID 0000.0001) %MON dynstat_theta_max            =   2.9438771981169E+01
-(PID.TID 0000.0001) %MON dynstat_theta_min            =  -1.8943601431987E+00
-(PID.TID 0000.0001) %MON dynstat_theta_mean           =   3.5922804204950E+00
-(PID.TID 0000.0001) %MON dynstat_theta_sd             =   4.4289167255531E+00
-(PID.TID 0000.0001) %MON dynstat_theta_del2           =   2.3050218548298E-03
-(PID.TID 0000.0001) %MON dynstat_salt_max             =   4.0715808459172E+01
-(PID.TID 0000.0001) %MON dynstat_salt_min             =   1.6289448781651E+01
-(PID.TID 0000.0001) %MON dynstat_salt_mean            =   3.4721535831898E+01
-(PID.TID 0000.0001) %MON dynstat_salt_sd              =   4.8725109963905E-01
-(PID.TID 0000.0001) %MON dynstat_salt_del2            =   5.1343232487746E-04
-(PID.TID 0000.0001) %MON forcing_qnet_max             =   6.9645864966770E+02
-(PID.TID 0000.0001) %MON forcing_qnet_min             =  -3.1135072560222E+02
-(PID.TID 0000.0001) %MON forcing_qnet_mean            =  -2.7739161215916E+01
-(PID.TID 0000.0001) %MON forcing_qnet_sd              =   1.5109545991253E+02
-(PID.TID 0000.0001) %MON forcing_qnet_del2            =   9.8762760048098E-01
+(PID.TID 0000.0001) %MON dynstat_eta_max              =   1.5252766928891E+04
+(PID.TID 0000.0001) %MON dynstat_eta_min              =  -2.2590264394117E+04
+(PID.TID 0000.0001) %MON dynstat_eta_mean             =  -1.1332328727091E+02
+(PID.TID 0000.0001) %MON dynstat_eta_sd               =   7.2867954624191E+03
+(PID.TID 0000.0001) %MON dynstat_eta_del2             =   9.4204610103329E+01
+(PID.TID 0000.0001) %MON dynstat_uvel_max             =   1.2227172027585E-01
+(PID.TID 0000.0001) %MON dynstat_uvel_min             =  -1.4478349574407E-01
+(PID.TID 0000.0001) %MON dynstat_uvel_mean            =  -3.9246287302674E-05
+(PID.TID 0000.0001) %MON dynstat_uvel_sd              =   7.5621001270320E-03
+(PID.TID 0000.0001) %MON dynstat_uvel_del2            =   3.6026043229991E-05
+(PID.TID 0000.0001) %MON dynstat_vvel_max             =   1.9403114456787E-01
+(PID.TID 0000.0001) %MON dynstat_vvel_min             =  -1.8029119995015E-01
+(PID.TID 0000.0001) %MON dynstat_vvel_mean            =  -4.9274962923236E-04
+(PID.TID 0000.0001) %MON dynstat_vvel_sd              =   7.7914808040336E-03
+(PID.TID 0000.0001) %MON dynstat_vvel_del2            =   3.7170774458577E-05
+(PID.TID 0000.0001) %MON dynstat_wvel_max             =   5.4266229014260E+00
+(PID.TID 0000.0001) %MON dynstat_wvel_min             =  -9.6703275946041E+00
+(PID.TID 0000.0001) %MON dynstat_wvel_mean            =  -1.2758175079778E-05
+(PID.TID 0000.0001) %MON dynstat_wvel_sd              =   2.5577130352593E-01
+(PID.TID 0000.0001) %MON dynstat_wvel_del2            =   1.9455189919483E-03
+(PID.TID 0000.0001) %MON dynstat_theta_max            =   2.9437973390775E+01
+(PID.TID 0000.0001) %MON dynstat_theta_min            =  -1.8997345304021E+00
+(PID.TID 0000.0001) %MON dynstat_theta_mean           =   3.5922959683491E+00
+(PID.TID 0000.0001) %MON dynstat_theta_sd             =   4.4296014298145E+00
+(PID.TID 0000.0001) %MON dynstat_theta_del2           =   2.0699678155382E-03
+(PID.TID 0000.0001) %MON dynstat_salt_max             =   4.0715858077129E+01
+(PID.TID 0000.0001) %MON dynstat_salt_min             =   1.6289333168521E+01
+(PID.TID 0000.0001) %MON dynstat_salt_mean            =   3.4721543903361E+01
+(PID.TID 0000.0001) %MON dynstat_salt_sd              =   4.8740082748283E-01
+(PID.TID 0000.0001) %MON dynstat_salt_del2            =   5.0055989845447E-04
+(PID.TID 0000.0001) %MON forcing_qnet_max             =   6.7781447605764E+02
+(PID.TID 0000.0001) %MON forcing_qnet_min             =  -3.1096788228008E+02
+(PID.TID 0000.0001) %MON forcing_qnet_mean            =  -2.7808283240581E+01
+(PID.TID 0000.0001) %MON forcing_qnet_sd              =   1.4963474255975E+02
+(PID.TID 0000.0001) %MON forcing_qnet_del2            =   7.9985796103905E-01
 (PID.TID 0000.0001) %MON forcing_qsw_max              =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON forcing_qsw_min              =  -3.0183129457886E+02
-(PID.TID 0000.0001) %MON forcing_qsw_mean             =  -1.8596948126568E+02
-(PID.TID 0000.0001) %MON forcing_qsw_sd               =   7.8572368848108E+01
-(PID.TID 0000.0001) %MON forcing_qsw_del2             =   1.1074849619963E-01
-(PID.TID 0000.0001) %MON forcing_empmr_max            =   1.6190670158020E-03
-(PID.TID 0000.0001) %MON forcing_empmr_min            =  -4.5708705957876E-04
-(PID.TID 0000.0001) %MON forcing_empmr_mean           =   1.3537284814080E-05
-(PID.TID 0000.0001) %MON forcing_empmr_sd             =   1.1072045765130E-04
-(PID.TID 0000.0001) %MON forcing_empmr_del2           =   1.7282995420481E-06
+(PID.TID 0000.0001) %MON forcing_qsw_mean             =  -1.8596934796250E+02
+(PID.TID 0000.0001) %MON forcing_qsw_sd               =   7.8572683769638E+01
+(PID.TID 0000.0001) %MON forcing_qsw_del2             =   1.1074865260168E-01
+(PID.TID 0000.0001) %MON forcing_empmr_max            =   1.3074952096940E-03
+(PID.TID 0000.0001) %MON forcing_empmr_min            =  -4.5708696944378E-04
+(PID.TID 0000.0001) %MON forcing_empmr_mean           =   1.3656221645510E-05
+(PID.TID 0000.0001) %MON forcing_empmr_sd             =   1.0657795605362E-04
+(PID.TID 0000.0001) %MON forcing_empmr_del2           =   1.4716790874340E-06
 (PID.TID 0000.0001) %MON forcing_fu_max               =   2.4726979082249E-01
 (PID.TID 0000.0001) %MON forcing_fu_min               =  -2.2495248635365E-01
-(PID.TID 0000.0001) %MON forcing_fu_mean              =  -4.1948263773108E-03
-(PID.TID 0000.0001) %MON forcing_fu_sd                =   6.4265979198157E-02
-(PID.TID 0000.0001) %MON forcing_fu_del2              =   2.1090617733586E-04
+(PID.TID 0000.0001) %MON forcing_fu_mean              =  -4.1869437917756E-03
+(PID.TID 0000.0001) %MON forcing_fu_sd                =   6.4263393630479E-02
+(PID.TID 0000.0001) %MON forcing_fu_del2              =   2.1096942058233E-04
 (PID.TID 0000.0001) %MON forcing_fv_max               =   2.7159367144430E-01
 (PID.TID 0000.0001) %MON forcing_fv_min               =  -3.3243525155752E-01
-(PID.TID 0000.0001) %MON forcing_fv_mean              =  -1.3697937258375E-02
-(PID.TID 0000.0001) %MON forcing_fv_sd                =   7.5649849119089E-02
-(PID.TID 0000.0001) %MON forcing_fv_del2              =   2.3882639730303E-04
-(PID.TID 0000.0001) %MON trAdv_CFL_u_max              =   4.5062772274088E-02
-(PID.TID 0000.0001) %MON trAdv_CFL_v_max              =   7.1536765942264E-02
-(PID.TID 0000.0001) %MON trAdv_CFL_w_max              =   2.4800999644881E-01
-(PID.TID 0000.0001) %MON advcfl_uvel_max              =   4.4568948880102E-02
-(PID.TID 0000.0001) %MON advcfl_vvel_max              =   5.4936660478874E-02
-(PID.TID 0000.0001) %MON advcfl_wvel_max              =   2.7164723342493E-01
-(PID.TID 0000.0001) %MON advcfl_W_hf_max              =   3.0009441999421E-01
-(PID.TID 0000.0001) %MON pe_b_mean                    =   1.3515414642398E-02
-(PID.TID 0000.0001) %MON ke_max                       =   1.3164533477703E-02
-(PID.TID 0000.0001) %MON ke_mean                      =   5.4531592136651E-05
-(PID.TID 0000.0001) %MON ke_vol                       =   1.3604143151821E+22
-(PID.TID 0000.0001) %MON vort_r_min                   =  -7.1535409162126E-07
-(PID.TID 0000.0001) %MON vort_r_max                   =   8.0479084720800E-07
+(PID.TID 0000.0001) %MON forcing_fv_mean              =  -1.3695587789903E-02
+(PID.TID 0000.0001) %MON forcing_fv_sd                =   7.5650819647251E-02
+(PID.TID 0000.0001) %MON forcing_fv_del2              =   2.3884606993314E-04
+(PID.TID 0000.0001) %MON trAdv_CFL_u_max              =   4.5059938100482E-02
+(PID.TID 0000.0001) %MON trAdv_CFL_v_max              =   7.1538551255827E-02
+(PID.TID 0000.0001) %MON trAdv_CFL_w_max              =   2.4798531495033E-01
+(PID.TID 0000.0001) %MON advcfl_uvel_max              =   4.4573764557678E-02
+(PID.TID 0000.0001) %MON advcfl_vvel_max              =   5.4949017827616E-02
+(PID.TID 0000.0001) %MON advcfl_wvel_max              =   2.7162009197378E-01
+(PID.TID 0000.0001) %MON advcfl_W_hf_max              =   3.0006455514973E-01
+(PID.TID 0000.0001) %MON pe_b_mean                    =   1.3499565795334E-02
+(PID.TID 0000.0001) %MON ke_max                       =   1.3162009019090E-02
+(PID.TID 0000.0001) %MON ke_mean                      =   5.4548618667877E-05
+(PID.TID 0000.0001) %MON ke_vol                       =   1.3604139659303E+22
+(PID.TID 0000.0001) %MON vort_r_min                   =  -7.1574187565841E-07
+(PID.TID 0000.0001) %MON vort_r_max                   =   8.0489280726738E-07
 (PID.TID 0000.0001) %MON vort_a_mean                  =  -2.0556865257795E-05
-(PID.TID 0000.0001) %MON vort_a_sd                    =   7.5247442376059E-05
-(PID.TID 0000.0001) %MON vort_p_mean                  =  -2.4859237494377E-05
-(PID.TID 0000.0001) %MON vort_p_sd                    =   1.2920599029619E-04
-(PID.TID 0000.0001) %MON surfExpan_theta_mean         =   1.0635345955771E-04
-(PID.TID 0000.0001) %MON surfExpan_salt_mean          =  -4.3477838064889E-03
+(PID.TID 0000.0001) %MON vort_a_sd                    =   7.5247442190199E-05
+(PID.TID 0000.0001) %MON vort_p_mean                  =  -2.4859243761478E-05
+(PID.TID 0000.0001) %MON vort_p_sd                    =   1.2920608598897E-04
+(PID.TID 0000.0001) %MON surfExpan_theta_mean         =   2.6966485832603E-05
+(PID.TID 0000.0001) %MON surfExpan_salt_mean          =  -4.3975543199979E-03
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // End MONITOR dynamic field statistics
 (PID.TID 0000.0001) // =======================================================
@@ -4369,124 +4374,124 @@ listId=   2 ; file name: seaiceStDiag
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) %MON seaice_tsnumber              =                     8
 (PID.TID 0000.0001) %MON seaice_time_sec              =   6.9120000000000E+05
-(PID.TID 0000.0001) %MON seaice_uice_max              =   1.7834935911809E-01
-(PID.TID 0000.0001) %MON seaice_uice_min              =  -2.0958604516922E-01
-(PID.TID 0000.0001) %MON seaice_uice_mean             =  -5.7057897259849E-04
-(PID.TID 0000.0001) %MON seaice_uice_sd               =   1.4064670245206E-02
-(PID.TID 0000.0001) %MON seaice_uice_del2             =   2.2969740933442E-04
-(PID.TID 0000.0001) %MON seaice_vice_max              =   1.6318905434498E-01
-(PID.TID 0000.0001) %MON seaice_vice_min              =  -1.7733468405433E-01
-(PID.TID 0000.0001) %MON seaice_vice_mean             =   1.2352735066847E-03
-(PID.TID 0000.0001) %MON seaice_vice_sd               =   1.5667881345561E-02
-(PID.TID 0000.0001) %MON seaice_vice_del2             =   1.2094468751807E-04
-(PID.TID 0000.0001) %MON seaice_area_max              =   9.6695283018622E-01
+(PID.TID 0000.0001) %MON seaice_uice_max              =   1.7784906821530E-01
+(PID.TID 0000.0001) %MON seaice_uice_min              =  -2.3403641080251E-01
+(PID.TID 0000.0001) %MON seaice_uice_mean             =  -6.3829898127697E-04
+(PID.TID 0000.0001) %MON seaice_uice_sd               =   1.4643806450225E-02
+(PID.TID 0000.0001) %MON seaice_uice_del2             =   2.3481830643792E-04
+(PID.TID 0000.0001) %MON seaice_vice_max              =   1.6462465976202E-01
+(PID.TID 0000.0001) %MON seaice_vice_min              =  -1.7710915546706E-01
+(PID.TID 0000.0001) %MON seaice_vice_mean             =   1.2473679558672E-03
+(PID.TID 0000.0001) %MON seaice_vice_sd               =   1.5756145045408E-02
+(PID.TID 0000.0001) %MON seaice_vice_del2             =   1.2200412977778E-04
+(PID.TID 0000.0001) %MON seaice_area_max              =   9.6723407633678E-01
 (PID.TID 0000.0001) %MON seaice_area_min              =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON seaice_area_mean             =   2.1864498795842E-02
-(PID.TID 0000.0001) %MON seaice_area_sd               =   1.3606306622399E-01
-(PID.TID 0000.0001) %MON seaice_area_del2             =   9.8652396537413E-04
-(PID.TID 0000.0001) %MON seaice_heff_max              =   6.6718623690508E-01
+(PID.TID 0000.0001) %MON seaice_area_mean             =   2.3369665050350E-02
+(PID.TID 0000.0001) %MON seaice_area_sd               =   1.4118652836029E-01
+(PID.TID 0000.0001) %MON seaice_area_del2             =   8.4619766231335E-04
+(PID.TID 0000.0001) %MON seaice_heff_max              =   6.6746107116645E-01
 (PID.TID 0000.0001) %MON seaice_heff_min              =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON seaice_heff_mean             =   1.3301097350388E-02
-(PID.TID 0000.0001) %MON seaice_heff_sd               =   8.4566566079050E-02
-(PID.TID 0000.0001) %MON seaice_heff_del2             =   5.7292540024474E-04
-(PID.TID 0000.0001) %MON seaice_hsnow_max             =   1.5479030559528E-02
+(PID.TID 0000.0001) %MON seaice_heff_mean             =   1.4323041848974E-02
+(PID.TID 0000.0001) %MON seaice_heff_sd               =   8.7868421327187E-02
+(PID.TID 0000.0001) %MON seaice_heff_del2             =   5.4491595849144E-04
+(PID.TID 0000.0001) %MON seaice_hsnow_max             =   1.5781629949644E-02
 (PID.TID 0000.0001) %MON seaice_hsnow_min             =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON seaice_hsnow_mean            =   1.4987718929565E-04
-(PID.TID 0000.0001) %MON seaice_hsnow_sd              =   1.0946472399272E-03
-(PID.TID 0000.0001) %MON seaice_hsnow_del2            =   1.4568545170763E-05
+(PID.TID 0000.0001) %MON seaice_hsnow_mean            =   1.6265317393874E-04
+(PID.TID 0000.0001) %MON seaice_hsnow_sd              =   1.1600287010372E-03
+(PID.TID 0000.0001) %MON seaice_hsnow_del2            =   1.5096370528015E-05
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // End MONITOR SEAICE statistics
 (PID.TID 0000.0001) // =======================================================
  EXTERNAL_FIELDS_LOAD,         8 : iP,iLd,i0,i1=   12    1   12    1 ; Wght=  0.2333333333  0.7666666667
- SEAICE_LSR: Residual Initial ipass,Uice,Vice=         1  5.28183549E-04  5.26265596E-04
- SEAICE_LSR (ipass=        1) iters,dU,Resid=       34  1.51836876E-13  4.85215557E-15
- SEAICE_LSR (ipass=        1) iters,dV,Resid=       34  3.94462241E-13  9.12352264E-15
- SEAICE_LSR: Residual Initial ipass,Uice,Vice=         2  2.54139260E-04  2.23169242E-04
- SEAICE_LSR (ipass=        2) iters,dU,Resid=       32  2.93633173E-13  9.75091194E-15
- SEAICE_LSR (ipass=        2) iters,dV,Resid=       32  4.81600870E-13  1.17841704E-14
- cg2d: Sum(rhs),rhsMax =   3.75450914201616E-01  1.99064490119897E+01
-(PID.TID 0000.0001)      cg2d_init_res =   7.47155599291924E-02
+ SEAICE_LSR: Residual Initial ipass,Uice,Vice=         1  4.64729697E-04  5.33243207E-04
+ SEAICE_LSR (ipass=        1) iters,dU,Resid=       32  1.43177137E-13  4.40901891E-15
+ SEAICE_LSR (ipass=        1) iters,dV,Resid=       32  4.62643812E-13  1.20297098E-14
+ SEAICE_LSR: Residual Initial ipass,Uice,Vice=         2  2.61187710E-04  2.28437871E-04
+ SEAICE_LSR (ipass=        2) iters,dU,Resid=       30  3.56333019E-13  1.14402201E-14
+ SEAICE_LSR (ipass=        2) iters,dV,Resid=       30  7.42975126E-13  2.03711376E-14
+ cg2d: Sum(rhs),rhsMax =   4.07036455565376E-01  1.99064581953247E+01
+(PID.TID 0000.0001)      cg2d_init_res =   7.47327075259546E-02
 (PID.TID 0000.0001)      cg2d_iters(min,last) =      -1     101
-(PID.TID 0000.0001)      cg2d_last_res =   8.12544800447700E-10
+(PID.TID 0000.0001)      cg2d_last_res =   8.10166090807646E-10
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // Begin MONITOR dynamic field statistics
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) %MON time_tsnumber                =                     9
 (PID.TID 0000.0001) %MON time_secondsf                =   7.7760000000000E+05
-(PID.TID 0000.0001) %MON dynstat_eta_max              =   1.5337114212018E+04
-(PID.TID 0000.0001) %MON dynstat_eta_min              =  -2.2028168354113E+04
-(PID.TID 0000.0001) %MON dynstat_eta_mean             =  -1.1286712484062E+02
-(PID.TID 0000.0001) %MON dynstat_eta_sd               =   7.2626893195324E+03
-(PID.TID 0000.0001) %MON dynstat_eta_del2             =   9.4326987376781E+01
-(PID.TID 0000.0001) %MON dynstat_uvel_max             =   1.3207783574919E-01
-(PID.TID 0000.0001) %MON dynstat_uvel_min             =  -1.5442024172418E-01
-(PID.TID 0000.0001) %MON dynstat_uvel_mean            =   2.5030836566876E-05
-(PID.TID 0000.0001) %MON dynstat_uvel_sd              =   8.3314485740996E-03
-(PID.TID 0000.0001) %MON dynstat_uvel_del2            =   3.8258381102212E-05
-(PID.TID 0000.0001) %MON dynstat_vvel_max             =   2.0644174066235E-01
-(PID.TID 0000.0001) %MON dynstat_vvel_min             =  -1.9269324111798E-01
-(PID.TID 0000.0001) %MON dynstat_vvel_mean            =  -4.5360473019786E-04
-(PID.TID 0000.0001) %MON dynstat_vvel_sd              =   8.5807626824928E-03
-(PID.TID 0000.0001) %MON dynstat_vvel_del2            =   3.9373626895041E-05
-(PID.TID 0000.0001) %MON dynstat_wvel_max             =   5.6012650985835E+00
-(PID.TID 0000.0001) %MON dynstat_wvel_min             =  -1.0308888422445E+01
-(PID.TID 0000.0001) %MON dynstat_wvel_mean            =   6.2161138179861E-05
-(PID.TID 0000.0001) %MON dynstat_wvel_sd              =   2.6779644378156E-01
-(PID.TID 0000.0001) %MON dynstat_wvel_del2            =   1.9974724917301E-03
-(PID.TID 0000.0001) %MON dynstat_theta_max            =   2.9443921619062E+01
-(PID.TID 0000.0001) %MON dynstat_theta_min            =  -1.9013704234445E+00
-(PID.TID 0000.0001) %MON dynstat_theta_mean           =   3.5924415780659E+00
-(PID.TID 0000.0001) %MON dynstat_theta_sd             =   4.4293494695673E+00
-(PID.TID 0000.0001) %MON dynstat_theta_del2           =   2.2959003664379E-03
-(PID.TID 0000.0001) %MON dynstat_salt_max             =   4.0715781399077E+01
-(PID.TID 0000.0001) %MON dynstat_salt_min             =   1.5951592596388E+01
-(PID.TID 0000.0001) %MON dynstat_salt_mean            =   3.4721542790961E+01
-(PID.TID 0000.0001) %MON dynstat_salt_sd              =   4.8722671549479E-01
-(PID.TID 0000.0001) %MON dynstat_salt_del2            =   5.0884920016595E-04
-(PID.TID 0000.0001) %MON forcing_qnet_max             =   7.0076884667274E+02
-(PID.TID 0000.0001) %MON forcing_qnet_min             =  -3.1324794627445E+02
-(PID.TID 0000.0001) %MON forcing_qnet_mean            =  -2.7361317785886E+01
-(PID.TID 0000.0001) %MON forcing_qnet_sd              =   1.4950043157637E+02
-(PID.TID 0000.0001) %MON forcing_qnet_del2            =   8.9646657262377E-01
+(PID.TID 0000.0001) %MON dynstat_eta_max              =   1.5331983266011E+04
+(PID.TID 0000.0001) %MON dynstat_eta_min              =  -2.2030319324835E+04
+(PID.TID 0000.0001) %MON dynstat_eta_mean             =  -1.2236234858132E+02
+(PID.TID 0000.0001) %MON dynstat_eta_sd               =   7.2643239927947E+03
+(PID.TID 0000.0001) %MON dynstat_eta_del2             =   9.4299655958881E+01
+(PID.TID 0000.0001) %MON dynstat_uvel_max             =   1.3203457812345E-01
+(PID.TID 0000.0001) %MON dynstat_uvel_min             =  -1.5500466684655E-01
+(PID.TID 0000.0001) %MON dynstat_uvel_mean            =   2.6039080233384E-05
+(PID.TID 0000.0001) %MON dynstat_uvel_sd              =   8.3323284343756E-03
+(PID.TID 0000.0001) %MON dynstat_uvel_del2            =   3.8173128376153E-05
+(PID.TID 0000.0001) %MON dynstat_vvel_max             =   2.0658456341604E-01
+(PID.TID 0000.0001) %MON dynstat_vvel_min             =  -1.9267726934399E-01
+(PID.TID 0000.0001) %MON dynstat_vvel_mean            =  -4.5361671088827E-04
+(PID.TID 0000.0001) %MON dynstat_vvel_sd              =   8.5819920030704E-03
+(PID.TID 0000.0001) %MON dynstat_vvel_del2            =   3.9330008639439E-05
+(PID.TID 0000.0001) %MON dynstat_wvel_max             =   5.6008050338516E+00
+(PID.TID 0000.0001) %MON dynstat_wvel_min             =  -1.0307356101096E+01
+(PID.TID 0000.0001) %MON dynstat_wvel_mean            =   5.5311506116009E-05
+(PID.TID 0000.0001) %MON dynstat_wvel_sd              =   2.6779766746478E-01
+(PID.TID 0000.0001) %MON dynstat_wvel_del2            =   1.9971290400690E-03
+(PID.TID 0000.0001) %MON dynstat_theta_max            =   2.9442503383681E+01
+(PID.TID 0000.0001) %MON dynstat_theta_min            =  -1.9011819797437E+00
+(PID.TID 0000.0001) %MON dynstat_theta_mean           =   3.5924562598215E+00
+(PID.TID 0000.0001) %MON dynstat_theta_sd             =   4.4300101153574E+00
+(PID.TID 0000.0001) %MON dynstat_theta_del2           =   2.0643328977749E-03
+(PID.TID 0000.0001) %MON dynstat_salt_max             =   4.0715837042050E+01
+(PID.TID 0000.0001) %MON dynstat_salt_min             =   1.5951386260632E+01
+(PID.TID 0000.0001) %MON dynstat_salt_mean            =   3.4721550719441E+01
+(PID.TID 0000.0001) %MON dynstat_salt_sd              =   4.8737478012424E-01
+(PID.TID 0000.0001) %MON dynstat_salt_del2            =   4.9613915063497E-04
+(PID.TID 0000.0001) %MON forcing_qnet_max             =   6.9586199710053E+02
+(PID.TID 0000.0001) %MON forcing_qnet_min             =  -3.0984416531123E+02
+(PID.TID 0000.0001) %MON forcing_qnet_mean            =  -2.7234305426717E+01
+(PID.TID 0000.0001) %MON forcing_qnet_sd              =   1.4858452732874E+02
+(PID.TID 0000.0001) %MON forcing_qnet_del2            =   8.6205894518607E-01
 (PID.TID 0000.0001) %MON forcing_qsw_max              =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON forcing_qsw_min              =  -3.0181929764305E+02
-(PID.TID 0000.0001) %MON forcing_qsw_mean             =  -1.8597531882431E+02
-(PID.TID 0000.0001) %MON forcing_qsw_sd               =   7.8478432782470E+01
-(PID.TID 0000.0001) %MON forcing_qsw_del2             =   1.1102150640893E-01
-(PID.TID 0000.0001) %MON forcing_empmr_max            =   1.4380294087655E-03
-(PID.TID 0000.0001) %MON forcing_empmr_min            =  -4.5888898020796E-04
-(PID.TID 0000.0001) %MON forcing_empmr_mean           =   1.0904478858148E-05
-(PID.TID 0000.0001) %MON forcing_empmr_sd             =   9.2989415970152E-05
-(PID.TID 0000.0001) %MON forcing_empmr_del2           =   1.4700609653473E-06
+(PID.TID 0000.0001) %MON forcing_qsw_mean             =  -1.8597517092670E+02
+(PID.TID 0000.0001) %MON forcing_qsw_sd               =   7.8478782586486E+01
+(PID.TID 0000.0001) %MON forcing_qsw_del2             =   1.1102171989524E-01
+(PID.TID 0000.0001) %MON forcing_empmr_max            =   1.1512645350295E-03
+(PID.TID 0000.0001) %MON forcing_empmr_min            =  -6.1284535245131E-04
+(PID.TID 0000.0001) %MON forcing_empmr_mean           =   1.0664502055732E-05
+(PID.TID 0000.0001) %MON forcing_empmr_sd             =   9.1357177605444E-05
+(PID.TID 0000.0001) %MON forcing_empmr_del2           =   1.5589769665934E-06
 (PID.TID 0000.0001) %MON forcing_fu_max               =   2.4722174155228E-01
 (PID.TID 0000.0001) %MON forcing_fu_min               =  -2.2809828301201E-01
-(PID.TID 0000.0001) %MON forcing_fu_mean              =  -4.1432646346498E-03
-(PID.TID 0000.0001) %MON forcing_fu_sd                =   6.4366316866720E-02
-(PID.TID 0000.0001) %MON forcing_fu_del2              =   2.1254653390059E-04
+(PID.TID 0000.0001) %MON forcing_fu_mean              =  -4.1332034150703E-03
+(PID.TID 0000.0001) %MON forcing_fu_sd                =   6.4363271668821E-02
+(PID.TID 0000.0001) %MON forcing_fu_del2              =   2.1264814385873E-04
 (PID.TID 0000.0001) %MON forcing_fv_max               =   2.7427691301694E-01
 (PID.TID 0000.0001) %MON forcing_fv_min               =  -3.3322315549145E-01
-(PID.TID 0000.0001) %MON forcing_fv_mean              =  -1.3700130484330E-02
-(PID.TID 0000.0001) %MON forcing_fv_sd                =   7.5749137942292E-02
-(PID.TID 0000.0001) %MON forcing_fv_del2              =   2.4014976562403E-04
-(PID.TID 0000.0001) %MON trAdv_CFL_u_max              =   4.7681962832401E-02
-(PID.TID 0000.0001) %MON trAdv_CFL_v_max              =   7.6412894657841E-02
-(PID.TID 0000.0001) %MON trAdv_CFL_w_max              =   2.6363699524604E-01
-(PID.TID 0000.0001) %MON advcfl_uvel_max              =   4.7772503016098E-02
-(PID.TID 0000.0001) %MON advcfl_vvel_max              =   5.9236594987014E-02
-(PID.TID 0000.0001) %MON advcfl_wvel_max              =   2.8877466863139E-01
-(PID.TID 0000.0001) %MON advcfl_W_hf_max              =   3.1900323499139E-01
-(PID.TID 0000.0001) %MON pe_b_mean                    =   1.3540852149308E-02
-(PID.TID 0000.0001) %MON ke_max                       =   1.5119639109435E-02
-(PID.TID 0000.0001) %MON ke_mean                      =   6.6143581062837E-05
-(PID.TID 0000.0001) %MON ke_vol                       =   1.3604138976589E+22
-(PID.TID 0000.0001) %MON vort_r_min                   =  -7.6647290029092E-07
-(PID.TID 0000.0001) %MON vort_r_max                   =   8.5160166368393E-07
+(PID.TID 0000.0001) %MON forcing_fv_mean              =  -1.3699974369496E-02
+(PID.TID 0000.0001) %MON forcing_fv_sd                =   7.5748373669698E-02
+(PID.TID 0000.0001) %MON forcing_fv_del2              =   2.4023524221570E-04
+(PID.TID 0000.0001) %MON trAdv_CFL_u_max              =   4.7688336814347E-02
+(PID.TID 0000.0001) %MON trAdv_CFL_v_max              =   7.6413253430723E-02
+(PID.TID 0000.0001) %MON trAdv_CFL_w_max              =   2.6359789892952E-01
+(PID.TID 0000.0001) %MON advcfl_uvel_max              =   4.7778890850981E-02
+(PID.TID 0000.0001) %MON advcfl_vvel_max              =   5.9252423449064E-02
+(PID.TID 0000.0001) %MON advcfl_wvel_max              =   2.8873176986035E-01
+(PID.TID 0000.0001) %MON advcfl_W_hf_max              =   3.1895592808200E-01
+(PID.TID 0000.0001) %MON pe_b_mean                    =   1.3518616691663E-02
+(PID.TID 0000.0001) %MON ke_max                       =   1.5115913660220E-02
+(PID.TID 0000.0001) %MON ke_mean                      =   6.6160133797378E-05
+(PID.TID 0000.0001) %MON ke_vol                       =   1.3604135447389E+22
+(PID.TID 0000.0001) %MON vort_r_min                   =  -7.6693414218150E-07
+(PID.TID 0000.0001) %MON vort_r_max                   =   8.5177667540065E-07
 (PID.TID 0000.0001) %MON vort_a_mean                  =  -2.0556865257795E-05
-(PID.TID 0000.0001) %MON vort_a_sd                    =   7.5247465020122E-05
-(PID.TID 0000.0001) %MON vort_p_mean                  =  -2.4859241653960E-05
-(PID.TID 0000.0001) %MON vort_p_sd                    =   1.2920586788765E-04
-(PID.TID 0000.0001) %MON surfExpan_theta_mean         =  -1.0196472771614E-03
-(PID.TID 0000.0001) %MON surfExpan_salt_mean          =  -3.3600696936139E-03
+(PID.TID 0000.0001) %MON vort_a_sd                    =   7.5247464799343E-05
+(PID.TID 0000.0001) %MON vort_p_mean                  =  -2.4859248166198E-05
+(PID.TID 0000.0001) %MON vort_p_sd                    =   1.2920593878293E-04
+(PID.TID 0000.0001) %MON surfExpan_theta_mean         =  -1.0883157060516E-03
+(PID.TID 0000.0001) %MON surfExpan_salt_mean          =  -3.2906098334689E-03
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // End MONITOR dynamic field statistics
 (PID.TID 0000.0001) // =======================================================
@@ -4495,124 +4500,124 @@ listId=   2 ; file name: seaiceStDiag
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) %MON seaice_tsnumber              =                     9
 (PID.TID 0000.0001) %MON seaice_time_sec              =   7.7760000000000E+05
-(PID.TID 0000.0001) %MON seaice_uice_max              =   1.7245251978580E-01
-(PID.TID 0000.0001) %MON seaice_uice_min              =  -2.2713471498286E-01
-(PID.TID 0000.0001) %MON seaice_uice_mean             =  -6.6677528162736E-04
-(PID.TID 0000.0001) %MON seaice_uice_sd               =   1.4899389762489E-02
-(PID.TID 0000.0001) %MON seaice_uice_del2             =   2.3207073471589E-04
-(PID.TID 0000.0001) %MON seaice_vice_max              =   1.6584463097101E-01
-(PID.TID 0000.0001) %MON seaice_vice_min              =  -1.8453316829973E-01
-(PID.TID 0000.0001) %MON seaice_vice_mean             =   1.3252900548840E-03
-(PID.TID 0000.0001) %MON seaice_vice_sd               =   1.5909810010815E-02
-(PID.TID 0000.0001) %MON seaice_vice_del2             =   1.3695993066325E-04
-(PID.TID 0000.0001) %MON seaice_area_max              =   9.8126604726008E-01
+(PID.TID 0000.0001) %MON seaice_uice_max              =   1.7177921580336E-01
+(PID.TID 0000.0001) %MON seaice_uice_min              =  -2.3110030227366E-01
+(PID.TID 0000.0001) %MON seaice_uice_mean             =  -6.7345697196031E-04
+(PID.TID 0000.0001) %MON seaice_uice_sd               =   1.4918309605113E-02
+(PID.TID 0000.0001) %MON seaice_uice_del2             =   2.3417149810623E-04
+(PID.TID 0000.0001) %MON seaice_vice_max              =   1.6590143582208E-01
+(PID.TID 0000.0001) %MON seaice_vice_min              =  -1.8429858578858E-01
+(PID.TID 0000.0001) %MON seaice_vice_mean             =   1.3461760280350E-03
+(PID.TID 0000.0001) %MON seaice_vice_sd               =   1.6011320013794E-02
+(PID.TID 0000.0001) %MON seaice_vice_del2             =   1.3880962183081E-04
+(PID.TID 0000.0001) %MON seaice_area_max              =   9.8169826449459E-01
 (PID.TID 0000.0001) %MON seaice_area_min              =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON seaice_area_mean             =   2.3321636089815E-02
-(PID.TID 0000.0001) %MON seaice_area_sd               =   1.4241863878700E-01
-(PID.TID 0000.0001) %MON seaice_area_del2             =   9.3939882770053E-04
-(PID.TID 0000.0001) %MON seaice_heff_max              =   7.0559760305765E-01
+(PID.TID 0000.0001) %MON seaice_area_mean             =   2.4557882781131E-02
+(PID.TID 0000.0001) %MON seaice_area_sd               =   1.4707272144486E-01
+(PID.TID 0000.0001) %MON seaice_area_del2             =   9.0852000470726E-04
+(PID.TID 0000.0001) %MON seaice_heff_max              =   7.0604821783835E-01
 (PID.TID 0000.0001) %MON seaice_heff_min              =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON seaice_heff_mean             =   1.4557255480718E-02
-(PID.TID 0000.0001) %MON seaice_heff_sd               =   9.1059633811533E-02
-(PID.TID 0000.0001) %MON seaice_heff_del2             =   5.6811258924022E-04
-(PID.TID 0000.0001) %MON seaice_hsnow_max             =   1.8937109612270E-02
+(PID.TID 0000.0001) %MON seaice_heff_mean             =   1.5543293991659E-02
+(PID.TID 0000.0001) %MON seaice_heff_sd               =   9.4527791284221E-02
+(PID.TID 0000.0001) %MON seaice_heff_del2             =   5.7797486970568E-04
+(PID.TID 0000.0001) %MON seaice_hsnow_max             =   1.9325335976212E-02
 (PID.TID 0000.0001) %MON seaice_hsnow_min             =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON seaice_hsnow_mean            =   1.9073567018843E-04
-(PID.TID 0000.0001) %MON seaice_hsnow_sd              =   1.3647398367319E-03
-(PID.TID 0000.0001) %MON seaice_hsnow_del2            =   1.7491349829902E-05
+(PID.TID 0000.0001) %MON seaice_hsnow_mean            =   2.0682602768947E-04
+(PID.TID 0000.0001) %MON seaice_hsnow_sd              =   1.4520717854017E-03
+(PID.TID 0000.0001) %MON seaice_hsnow_del2            =   1.6959593721112E-05
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // End MONITOR SEAICE statistics
 (PID.TID 0000.0001) // =======================================================
  EXTERNAL_FIELDS_LOAD,         9 : iP,iLd,i0,i1=   12    1   12    1 ; Wght=  0.2000000000  0.8000000000
- SEAICE_LSR: Residual Initial ipass,Uice,Vice=         1  4.47373789E-04  5.83540544E-04
- SEAICE_LSR (ipass=        1) iters,dU,Resid=       44  1.49068258E-13  8.80967664E-15
- SEAICE_LSR (ipass=        1) iters,dV,Resid=       44  5.32573985E-13  2.66638463E-14
- SEAICE_LSR: Residual Initial ipass,Uice,Vice=         2  2.88171896E-04  2.91684281E-04
- SEAICE_LSR (ipass=        2) iters,dU,Resid=       42  1.91797966E-13  1.15596384E-14
- SEAICE_LSR (ipass=        2) iters,dV,Resid=       42  4.84848273E-13  2.49111644E-14
- cg2d: Sum(rhs),rhsMax =   4.11196932313810E-01  1.99115794601049E+01
-(PID.TID 0000.0001)      cg2d_init_res =   7.40329262482620E-02
-(PID.TID 0000.0001)      cg2d_iters(min,last) =      -1      99
-(PID.TID 0000.0001)      cg2d_last_res =   9.86524339265281E-10
+ SEAICE_LSR: Residual Initial ipass,Uice,Vice=         1  4.72150144E-04  6.04428974E-04
+ SEAICE_LSR (ipass=        1) iters,dU,Resid=       42  6.36157793E-14  3.66006782E-15
+ SEAICE_LSR (ipass=        1) iters,dV,Resid=       42  6.86478652E-13  3.58852499E-14
+ SEAICE_LSR: Residual Initial ipass,Uice,Vice=         2  2.96087236E-04  3.15998588E-04
+ SEAICE_LSR (ipass=        2) iters,dU,Resid=       40  1.18620391E-13  7.00099738E-15
+ SEAICE_LSR (ipass=        2) iters,dV,Resid=       40  7.68718422E-13  4.14008410E-14
+ cg2d: Sum(rhs),rhsMax =   4.35870885061287E-01  1.99115679746786E+01
+(PID.TID 0000.0001)      cg2d_init_res =   7.43066221781459E-02
+(PID.TID 0000.0001)      cg2d_iters(min,last) =      -1     100
+(PID.TID 0000.0001)      cg2d_last_res =   8.64383276998700E-10
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // Begin MONITOR dynamic field statistics
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) %MON time_tsnumber                =                    10
 (PID.TID 0000.0001) %MON time_secondsf                =   8.6400000000000E+05
-(PID.TID 0000.0001) %MON dynstat_eta_max              =   1.5135750084013E+04
-(PID.TID 0000.0001) %MON dynstat_eta_min              =  -2.4251786212333E+04
-(PID.TID 0000.0001) %MON dynstat_eta_mean             =  -1.2364486288342E+02
-(PID.TID 0000.0001) %MON dynstat_eta_sd               =   7.2869403898258E+03
-(PID.TID 0000.0001) %MON dynstat_eta_del2             =   9.4374294060023E+01
-(PID.TID 0000.0001) %MON dynstat_uvel_max             =   1.4025406019583E-01
-(PID.TID 0000.0001) %MON dynstat_uvel_min             =  -1.6231728560713E-01
-(PID.TID 0000.0001) %MON dynstat_uvel_mean            =   4.9327593061478E-05
-(PID.TID 0000.0001) %MON dynstat_uvel_sd              =   9.0562608520664E-03
-(PID.TID 0000.0001) %MON dynstat_uvel_del2            =   4.0001352387055E-05
-(PID.TID 0000.0001) %MON dynstat_vvel_max             =   2.1608624711783E-01
-(PID.TID 0000.0001) %MON dynstat_vvel_min             =  -2.0223783624156E-01
-(PID.TID 0000.0001) %MON dynstat_vvel_mean            =  -4.0808336778778E-04
-(PID.TID 0000.0001) %MON dynstat_vvel_sd              =   9.3186816628473E-03
-(PID.TID 0000.0001) %MON dynstat_vvel_del2            =   4.1137626129641E-05
-(PID.TID 0000.0001) %MON dynstat_wvel_max             =   5.6384916643426E+00
-(PID.TID 0000.0001) %MON dynstat_wvel_min             =  -1.0793470434765E+01
-(PID.TID 0000.0001) %MON dynstat_wvel_mean            =   1.1977346363258E-04
-(PID.TID 0000.0001) %MON dynstat_wvel_sd              =   2.7512619659800E-01
-(PID.TID 0000.0001) %MON dynstat_wvel_del2            =   2.0122821472759E-03
-(PID.TID 0000.0001) %MON dynstat_theta_max            =   2.9452233210014E+01
-(PID.TID 0000.0001) %MON dynstat_theta_min            =  -1.9009836274721E+00
-(PID.TID 0000.0001) %MON dynstat_theta_mean           =   3.5926057499360E+00
-(PID.TID 0000.0001) %MON dynstat_theta_sd             =   4.4297036930181E+00
-(PID.TID 0000.0001) %MON dynstat_theta_del2           =   2.3151018753562E-03
-(PID.TID 0000.0001) %MON dynstat_salt_max             =   4.0715753394131E+01
-(PID.TID 0000.0001) %MON dynstat_salt_min             =   1.5621720707522E+01
-(PID.TID 0000.0001) %MON dynstat_salt_mean            =   3.4721551134163E+01
-(PID.TID 0000.0001) %MON dynstat_salt_sd              =   4.8718599459171E-01
-(PID.TID 0000.0001) %MON dynstat_salt_del2            =   5.0614858738475E-04
-(PID.TID 0000.0001) %MON forcing_qnet_max             =   7.0446786844736E+02
-(PID.TID 0000.0001) %MON forcing_qnet_min             =  -3.1232557406657E+02
-(PID.TID 0000.0001) %MON forcing_qnet_mean            =  -2.8182830424196E+01
-(PID.TID 0000.0001) %MON forcing_qnet_sd              =   1.4617105712578E+02
-(PID.TID 0000.0001) %MON forcing_qnet_del2            =   8.3872555594226E-01
+(PID.TID 0000.0001) %MON dynstat_eta_max              =   1.5132394478832E+04
+(PID.TID 0000.0001) %MON dynstat_eta_min              =  -2.4253343107851E+04
+(PID.TID 0000.0001) %MON dynstat_eta_mean             =  -1.3106412158346E+02
+(PID.TID 0000.0001) %MON dynstat_eta_sd               =   7.2833685962032E+03
+(PID.TID 0000.0001) %MON dynstat_eta_del2             =   9.4347835954878E+01
+(PID.TID 0000.0001) %MON dynstat_uvel_max             =   1.4020135816502E-01
+(PID.TID 0000.0001) %MON dynstat_uvel_min             =  -1.6291817268774E-01
+(PID.TID 0000.0001) %MON dynstat_uvel_mean            =   4.9698598813872E-05
+(PID.TID 0000.0001) %MON dynstat_uvel_sd              =   9.0569193235663E-03
+(PID.TID 0000.0001) %MON dynstat_uvel_del2            =   3.9888651703503E-05
+(PID.TID 0000.0001) %MON dynstat_vvel_max             =   2.1625255099422E-01
+(PID.TID 0000.0001) %MON dynstat_vvel_min             =  -2.0221792432647E-01
+(PID.TID 0000.0001) %MON dynstat_vvel_mean            =  -4.0752631113081E-04
+(PID.TID 0000.0001) %MON dynstat_vvel_sd              =   9.3200586622295E-03
+(PID.TID 0000.0001) %MON dynstat_vvel_del2            =   4.1073471318545E-05
+(PID.TID 0000.0001) %MON dynstat_wvel_max             =   5.6379391452218E+00
+(PID.TID 0000.0001) %MON dynstat_wvel_min             =  -1.0791317451331E+01
+(PID.TID 0000.0001) %MON dynstat_wvel_mean            =   1.1709354382722E-04
+(PID.TID 0000.0001) %MON dynstat_wvel_sd              =   2.7512761802426E-01
+(PID.TID 0000.0001) %MON dynstat_wvel_del2            =   2.0118138611067E-03
+(PID.TID 0000.0001) %MON dynstat_theta_max            =   2.9452368643180E+01
+(PID.TID 0000.0001) %MON dynstat_theta_min            =  -1.9007315789492E+00
+(PID.TID 0000.0001) %MON dynstat_theta_mean           =   3.5926147963155E+00
+(PID.TID 0000.0001) %MON dynstat_theta_sd             =   4.4304129050029E+00
+(PID.TID 0000.0001) %MON dynstat_theta_del2           =   2.0720402244744E-03
+(PID.TID 0000.0001) %MON dynstat_salt_max             =   4.0715815008935E+01
+(PID.TID 0000.0001) %MON dynstat_salt_min             =   1.5621397827668E+01
+(PID.TID 0000.0001) %MON dynstat_salt_mean            =   3.4721557372507E+01
+(PID.TID 0000.0001) %MON dynstat_salt_sd              =   4.8734454632876E-01
+(PID.TID 0000.0001) %MON dynstat_salt_del2            =   4.9274556808780E-04
+(PID.TID 0000.0001) %MON forcing_qnet_max             =   1.5167064466480E+03
+(PID.TID 0000.0001) %MON forcing_qnet_min             =  -3.0866983061640E+02
+(PID.TID 0000.0001) %MON forcing_qnet_mean            =  -2.7245054970430E+01
+(PID.TID 0000.0001) %MON forcing_qnet_sd              =   1.4809521232419E+02
+(PID.TID 0000.0001) %MON forcing_qnet_del2            =   9.7949775845405E-01
 (PID.TID 0000.0001) %MON forcing_qsw_max              =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON forcing_qsw_min              =  -3.0180730070724E+02
-(PID.TID 0000.0001) %MON forcing_qsw_mean             =  -1.8597973620708E+02
-(PID.TID 0000.0001) %MON forcing_qsw_sd               =   7.8390284286186E+01
-(PID.TID 0000.0001) %MON forcing_qsw_del2             =   1.1136014417886E-01
-(PID.TID 0000.0001) %MON forcing_empmr_max            =   1.7538089233736E-03
-(PID.TID 0000.0001) %MON forcing_empmr_min            =  -4.6070107974296E-04
-(PID.TID 0000.0001) %MON forcing_empmr_mean           =   1.2715834705234E-05
-(PID.TID 0000.0001) %MON forcing_empmr_sd             =   1.0544599674263E-04
-(PID.TID 0000.0001) %MON forcing_empmr_del2           =   1.4657286808769E-06
+(PID.TID 0000.0001) %MON forcing_qsw_mean             =  -1.8597957906796E+02
+(PID.TID 0000.0001) %MON forcing_qsw_sd               =   7.8390656348558E+01
+(PID.TID 0000.0001) %MON forcing_qsw_del2             =   1.1136040205860E-01
+(PID.TID 0000.0001) %MON forcing_empmr_max            =   1.3900868211354E-03
+(PID.TID 0000.0001) %MON forcing_empmr_min            =  -3.8525481980110E-03
+(PID.TID 0000.0001) %MON forcing_empmr_mean           =   1.0266561192928E-05
+(PID.TID 0000.0001) %MON forcing_empmr_sd             =   1.1205343489865E-04
+(PID.TID 0000.0001) %MON forcing_empmr_del2           =   1.9346498266320E-06
 (PID.TID 0000.0001) %MON forcing_fu_max               =   2.4734156444157E-01
 (PID.TID 0000.0001) %MON forcing_fu_min               =  -2.3124407967036E-01
-(PID.TID 0000.0001) %MON forcing_fu_mean              =  -4.0947057224825E-03
-(PID.TID 0000.0001) %MON forcing_fu_sd                =   6.4478847337158E-02
-(PID.TID 0000.0001) %MON forcing_fu_del2              =   2.1441076063598E-04
+(PID.TID 0000.0001) %MON forcing_fu_mean              =  -4.0820700199901E-03
+(PID.TID 0000.0001) %MON forcing_fu_sd                =   6.4475182847372E-02
+(PID.TID 0000.0001) %MON forcing_fu_del2              =   2.1461479548919E-04
 (PID.TID 0000.0001) %MON forcing_fv_max               =   2.7696015458957E-01
 (PID.TID 0000.0001) %MON forcing_fv_min               =  -3.3401105942538E-01
-(PID.TID 0000.0001) %MON forcing_fv_mean              =  -1.3706994668373E-02
-(PID.TID 0000.0001) %MON forcing_fv_sd                =   7.5852979941087E-02
-(PID.TID 0000.0001) %MON forcing_fv_del2              =   2.4162973236994E-04
-(PID.TID 0000.0001) %MON trAdv_CFL_u_max              =   5.0136044471886E-02
-(PID.TID 0000.0001) %MON trAdv_CFL_v_max              =   8.0223416180480E-02
-(PID.TID 0000.0001) %MON trAdv_CFL_w_max              =   2.7522548575864E-01
-(PID.TID 0000.0001) %MON advcfl_uvel_max              =   5.0231286070805E-02
-(PID.TID 0000.0001) %MON advcfl_vvel_max              =   6.2663313325685E-02
-(PID.TID 0000.0001) %MON advcfl_wvel_max              =   3.0147643118931E-01
-(PID.TID 0000.0001) %MON advcfl_W_hf_max              =   3.3302541711624E-01
-(PID.TID 0000.0001) %MON pe_b_mean                    =   1.3602713866758E-02
-(PID.TID 0000.0001) %MON ke_max                       =   1.6771136725635E-02
-(PID.TID 0000.0001) %MON ke_mean                      =   7.8043839196645E-05
-(PID.TID 0000.0001) %MON ke_vol                       =   1.3604135613380E+22
-(PID.TID 0000.0001) %MON vort_r_min                   =  -8.0847415759848E-07
-(PID.TID 0000.0001) %MON vort_r_max                   =   8.7642380564054E-07
+(PID.TID 0000.0001) %MON forcing_fv_mean              =  -1.3712175431008E-02
+(PID.TID 0000.0001) %MON forcing_fv_sd                =   7.5847420608053E-02
+(PID.TID 0000.0001) %MON forcing_fv_del2              =   2.4172678628536E-04
+(PID.TID 0000.0001) %MON trAdv_CFL_u_max              =   5.0143028180738E-02
+(PID.TID 0000.0001) %MON trAdv_CFL_v_max              =   8.0221367305917E-02
+(PID.TID 0000.0001) %MON trAdv_CFL_w_max              =   2.7516917442134E-01
+(PID.TID 0000.0001) %MON advcfl_uvel_max              =   5.0238285355477E-02
+(PID.TID 0000.0001) %MON advcfl_vvel_max              =   6.2679909399953E-02
+(PID.TID 0000.0001) %MON advcfl_wvel_max              =   3.0141467328660E-01
+(PID.TID 0000.0001) %MON advcfl_W_hf_max              =   3.3295727987037E-01
+(PID.TID 0000.0001) %MON pe_b_mean                    =   1.3573014408703E-02
+(PID.TID 0000.0001) %MON ke_max                       =   1.6765953109115E-02
+(PID.TID 0000.0001) %MON ke_mean                      =   7.8061030522754E-05
+(PID.TID 0000.0001) %MON ke_vol                       =   1.3604132158194E+22
+(PID.TID 0000.0001) %MON vort_r_min                   =  -8.0901572145259E-07
+(PID.TID 0000.0001) %MON vort_r_max                   =   8.7668281604593E-07
 (PID.TID 0000.0001) %MON vort_a_mean                  =  -2.0556865257795E-05
-(PID.TID 0000.0001) %MON vort_a_sd                    =   7.5247481704435E-05
-(PID.TID 0000.0001) %MON vort_p_mean                  =  -2.4859242488275E-05
-(PID.TID 0000.0001) %MON vort_p_sd                    =   1.2920581029737E-04
-(PID.TID 0000.0001) %MON surfExpan_theta_mean         =  -1.7184897475152E-03
-(PID.TID 0000.0001) %MON surfExpan_salt_mean          =  -3.8879783104210E-03
+(PID.TID 0000.0001) %MON vort_a_sd                    =   7.5247481433079E-05
+(PID.TID 0000.0001) %MON vort_p_mean                  =  -2.4859249139176E-05
+(PID.TID 0000.0001) %MON vort_p_sd                    =   1.2920585367245E-04
+(PID.TID 0000.0001) %MON surfExpan_theta_mean         =  -1.7682078863470E-03
+(PID.TID 0000.0001) %MON surfExpan_salt_mean          =  -3.0728482111754E-03
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // End MONITOR dynamic field statistics
 (PID.TID 0000.0001) // =======================================================
@@ -4621,31 +4626,31 @@ listId=   2 ; file name: seaiceStDiag
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) %MON seaice_tsnumber              =                    10
 (PID.TID 0000.0001) %MON seaice_time_sec              =   8.6400000000000E+05
-(PID.TID 0000.0001) %MON seaice_uice_max              =   1.7314902420609E-01
-(PID.TID 0000.0001) %MON seaice_uice_min              =  -2.3167388153805E-01
-(PID.TID 0000.0001) %MON seaice_uice_mean             =  -6.3551659372815E-04
-(PID.TID 0000.0001) %MON seaice_uice_sd               =   1.5027694502943E-02
-(PID.TID 0000.0001) %MON seaice_uice_del2             =   2.2433227559505E-04
-(PID.TID 0000.0001) %MON seaice_vice_max              =   1.6913890839578E-01
-(PID.TID 0000.0001) %MON seaice_vice_min              =  -1.9231990342746E-01
-(PID.TID 0000.0001) %MON seaice_vice_mean             =   1.4131259211792E-03
-(PID.TID 0000.0001) %MON seaice_vice_sd               =   1.6241281134974E-02
-(PID.TID 0000.0001) %MON seaice_vice_del2             =   1.3591620479152E-04
-(PID.TID 0000.0001) %MON seaice_area_max              =   9.9122973307799E-01
+(PID.TID 0000.0001) %MON seaice_uice_max              =   1.7238918404294E-01
+(PID.TID 0000.0001) %MON seaice_uice_min              =  -2.3433649120502E-01
+(PID.TID 0000.0001) %MON seaice_uice_mean             =  -6.3143921355342E-04
+(PID.TID 0000.0001) %MON seaice_uice_sd               =   1.4991042018500E-02
+(PID.TID 0000.0001) %MON seaice_uice_del2             =   2.2256157130530E-04
+(PID.TID 0000.0001) %MON seaice_vice_max              =   1.6321350891186E-01
+(PID.TID 0000.0001) %MON seaice_vice_min              =  -1.9202425260188E-01
+(PID.TID 0000.0001) %MON seaice_vice_mean             =   1.4322875043862E-03
+(PID.TID 0000.0001) %MON seaice_vice_sd               =   1.6295582028912E-02
+(PID.TID 0000.0001) %MON seaice_vice_del2             =   1.3912402439043E-04
+(PID.TID 0000.0001) %MON seaice_area_max              =   9.9180817594126E-01
 (PID.TID 0000.0001) %MON seaice_area_min              =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON seaice_area_mean             =   2.4792227062136E-02
-(PID.TID 0000.0001) %MON seaice_area_sd               =   1.4783338370493E-01
-(PID.TID 0000.0001) %MON seaice_area_del2             =   9.0555776294223E-04
-(PID.TID 0000.0001) %MON seaice_heff_max              =   7.4146789812456E-01
+(PID.TID 0000.0001) %MON seaice_area_mean             =   2.5496011537460E-02
+(PID.TID 0000.0001) %MON seaice_area_sd               =   1.5116133930882E-01
+(PID.TID 0000.0001) %MON seaice_area_del2             =   1.0140913231997E-03
+(PID.TID 0000.0001) %MON seaice_heff_max              =   7.4209254532922E-01
 (PID.TID 0000.0001) %MON seaice_heff_min              =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON seaice_heff_mean             =   1.5978503176035E-02
-(PID.TID 0000.0001) %MON seaice_heff_sd               =   9.7526035818447E-02
-(PID.TID 0000.0001) %MON seaice_heff_del2             =   5.6112812587906E-04
-(PID.TID 0000.0001) %MON seaice_hsnow_max             =   2.2469995500022E-02
+(PID.TID 0000.0001) %MON seaice_heff_mean             =   1.6719012294700E-02
+(PID.TID 0000.0001) %MON seaice_heff_sd               =   1.0065206165602E-01
+(PID.TID 0000.0001) %MON seaice_heff_del2             =   6.3727400848403E-04
+(PID.TID 0000.0001) %MON seaice_hsnow_max             =   2.2938947193868E-02
 (PID.TID 0000.0001) %MON seaice_hsnow_min             =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON seaice_hsnow_mean            =   2.3565268670026E-04
-(PID.TID 0000.0001) %MON seaice_hsnow_sd              =   1.6545552811389E-03
-(PID.TID 0000.0001) %MON seaice_hsnow_del2            =   2.0103641870954E-05
+(PID.TID 0000.0001) %MON seaice_hsnow_mean            =   2.5329474749554E-04
+(PID.TID 0000.0001) %MON seaice_hsnow_sd              =   1.7627286743298E-03
+(PID.TID 0000.0001) %MON seaice_hsnow_del2            =   1.9061746866339E-05
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // End MONITOR SEAICE statistics
 (PID.TID 0000.0001) // =======================================================
@@ -4676,183 +4681,183 @@ listId=   2 ; file name: seaiceStDiag
 (PID.TID 0000.0001) DIAGSTATS_CLOSE_IO: close file: seaiceStDiag.0000000000.txt , unit=    10
 (PID.TID 0000.0001) %CHECKPOINT        10 ckptA
 (PID.TID 0000.0001)   Seconds in section "ALL                    [THE_MODEL_MAIN]":
-(PID.TID 0000.0001)           User time:   17.574636382982135
-(PID.TID 0000.0001)         System time:  0.30429198592901230
-(PID.TID 0000.0001)     Wall clock time:   18.276706933975220
+(PID.TID 0000.0001)           User time:   18.194577297195792
+(PID.TID 0000.0001)         System time:  0.22383599355816841
+(PID.TID 0000.0001)     Wall clock time:   18.455493927001953
 (PID.TID 0000.0001)          No. starts:           1
 (PID.TID 0000.0001)           No. stops:           1
 (PID.TID 0000.0001)   Seconds in section "INITIALISE_FIXED       [THE_MODEL_MAIN]":
-(PID.TID 0000.0001)           User time:  0.26438800990581512
-(PID.TID 0000.0001)         System time:   4.9617998767644167E-002
-(PID.TID 0000.0001)     Wall clock time:  0.38808488845825195
+(PID.TID 0000.0001)           User time:  0.18510099407285452
+(PID.TID 0000.0001)         System time:   6.1655003577470779E-002
+(PID.TID 0000.0001)     Wall clock time:  0.25413298606872559
 (PID.TID 0000.0001)          No. starts:           1
 (PID.TID 0000.0001)           No. stops:           1
 (PID.TID 0000.0001)   Seconds in section "THE_MAIN_LOOP          [THE_MODEL_MAIN]":
-(PID.TID 0000.0001)           User time:   17.310180753469467
-(PID.TID 0000.0001)         System time:  0.25465998426079750
-(PID.TID 0000.0001)     Wall clock time:   17.888552904129028
+(PID.TID 0000.0001)           User time:   18.009407132863998
+(PID.TID 0000.0001)         System time:  0.16215999424457550
+(PID.TID 0000.0001)     Wall clock time:   18.201278924942017
 (PID.TID 0000.0001)          No. starts:           1
 (PID.TID 0000.0001)           No. stops:           1
 (PID.TID 0000.0001)   Seconds in section "INITIALISE_VARIA    [THE_MAIN_LOOP]":
-(PID.TID 0000.0001)           User time:  0.48894500732421875
-(PID.TID 0000.0001)         System time:  0.14986600354313850
-(PID.TID 0000.0001)     Wall clock time:  0.92229080200195312
+(PID.TID 0000.0001)           User time:  0.42976601421833038
+(PID.TID 0000.0001)         System time:  0.11624599248170853
+(PID.TID 0000.0001)     Wall clock time:  0.54752993583679199
 (PID.TID 0000.0001)          No. starts:           1
 (PID.TID 0000.0001)           No. stops:           1
 (PID.TID 0000.0001)   Seconds in section "MAIN LOOP           [THE_MAIN_LOOP]":
-(PID.TID 0000.0001)           User time:   16.821198225021362
-(PID.TID 0000.0001)         System time:  0.10478799045085907
-(PID.TID 0000.0001)     Wall clock time:   16.966221094131470
+(PID.TID 0000.0001)           User time:   17.579615473747253
+(PID.TID 0000.0001)         System time:   4.5908987522125244E-002
+(PID.TID 0000.0001)     Wall clock time:   17.653721094131470
 (PID.TID 0000.0001)          No. starts:           1
 (PID.TID 0000.0001)           No. stops:           1
 (PID.TID 0000.0001)   Seconds in section "MAIN_DO_LOOP        [THE_MAIN_LOOP]":
-(PID.TID 0000.0001)           User time:   16.821107566356659
-(PID.TID 0000.0001)         System time:  0.10478498041629791
-(PID.TID 0000.0001)     Wall clock time:   16.966128110885620
+(PID.TID 0000.0001)           User time:   17.579535543918610
+(PID.TID 0000.0001)         System time:   4.5906990766525269E-002
+(PID.TID 0000.0001)     Wall clock time:   17.653632640838623
 (PID.TID 0000.0001)          No. starts:          10
 (PID.TID 0000.0001)           No. stops:          10
 (PID.TID 0000.0001)   Seconds in section "FORWARD_STEP        [MAIN_DO_LOOP]":
-(PID.TID 0000.0001)           User time:   16.820935666561127
-(PID.TID 0000.0001)         System time:  0.10477899014949799
-(PID.TID 0000.0001)     Wall clock time:   16.965954065322876
+(PID.TID 0000.0001)           User time:   17.579367876052856
+(PID.TID 0000.0001)         System time:   4.5904994010925293E-002
+(PID.TID 0000.0001)     Wall clock time:   17.653470039367676
 (PID.TID 0000.0001)          No. starts:          10
 (PID.TID 0000.0001)           No. stops:          10
 (PID.TID 0000.0001)   Seconds in section "UPDATE_R_STAR       [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:  0.45992785692214966
-(PID.TID 0000.0001)         System time:   4.3299794197082520E-004
-(PID.TID 0000.0001)     Wall clock time:  0.46043205261230469
+(PID.TID 0000.0001)           User time:  0.47937172651290894
+(PID.TID 0000.0001)         System time:   4.7013163566589355E-005
+(PID.TID 0000.0001)     Wall clock time:  0.47951698303222656
 (PID.TID 0000.0001)          No. starts:          20
 (PID.TID 0000.0001)           No. stops:          20
 (PID.TID 0000.0001)   Seconds in section "DO_STATEVARS_DIAGS  [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:  0.74562102556228638
-(PID.TID 0000.0001)         System time:   7.9029947519302368E-003
-(PID.TID 0000.0001)     Wall clock time:  0.75371575355529785
+(PID.TID 0000.0001)           User time:  0.78015941381454468
+(PID.TID 0000.0001)         System time:   3.6700069904327393E-003
+(PID.TID 0000.0001)     Wall clock time:  0.78390288352966309
 (PID.TID 0000.0001)          No. starts:          30
 (PID.TID 0000.0001)           No. stops:          30
 (PID.TID 0000.0001)   Seconds in section "LOAD_FIELDS_DRIVER  [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:  0.16645014286041260
-(PID.TID 0000.0001)         System time:   4.0909945964813232E-003
-(PID.TID 0000.0001)     Wall clock time:  0.18141150474548340
+(PID.TID 0000.0001)           User time:  0.17316156625747681
+(PID.TID 0000.0001)         System time:   7.3889940977096558E-003
+(PID.TID 0000.0001)     Wall clock time:  0.20458364486694336
 (PID.TID 0000.0001)          No. starts:          10
 (PID.TID 0000.0001)           No. stops:          10
 (PID.TID 0000.0001)   Seconds in section "EXF_GETFORCING     [LOAD_FLDS_DRIVER]":
-(PID.TID 0000.0001)           User time:  0.15935868024826050
-(PID.TID 0000.0001)         System time:   4.0870010852813721E-003
-(PID.TID 0000.0001)     Wall clock time:  0.17434120178222656
+(PID.TID 0000.0001)           User time:  0.16430950164794922
+(PID.TID 0000.0001)         System time:   7.3800086975097656E-003
+(PID.TID 0000.0001)     Wall clock time:  0.19573903083801270
 (PID.TID 0000.0001)          No. starts:          10
 (PID.TID 0000.0001)           No. stops:          10
 (PID.TID 0000.0001)   Seconds in section "EXTERNAL_FLDS_LOAD [LOAD_FLDS_DRIVER]":
-(PID.TID 0000.0001)           User time:   6.8049430847167969E-003
-(PID.TID 0000.0001)         System time:   0.0000000000000000
-(PID.TID 0000.0001)     Wall clock time:   6.8130493164062500E-003
+(PID.TID 0000.0001)           User time:   8.5287094116210938E-003
+(PID.TID 0000.0001)         System time:   4.9918889999389648E-006
+(PID.TID 0000.0001)     Wall clock time:   8.5382461547851562E-003
 (PID.TID 0000.0001)          No. starts:          10
 (PID.TID 0000.0001)           No. stops:          10
 (PID.TID 0000.0001)   Seconds in section "DO_ATMOSPHERIC_PHYS [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:   8.5294246673583984E-005
+(PID.TID 0000.0001)           User time:   1.1259317398071289E-004
 (PID.TID 0000.0001)         System time:   0.0000000000000000
-(PID.TID 0000.0001)     Wall clock time:   8.4877014160156250E-005
+(PID.TID 0000.0001)     Wall clock time:   1.1396408081054688E-004
 (PID.TID 0000.0001)          No. starts:          10
 (PID.TID 0000.0001)           No. stops:          10
 (PID.TID 0000.0001)   Seconds in section "DO_OCEANIC_PHYS     [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:   5.4796867370605469
-(PID.TID 0000.0001)         System time:   1.5552982687950134E-002
-(PID.TID 0000.0001)     Wall clock time:   5.4957346916198730
+(PID.TID 0000.0001)           User time:   5.5864607691764832
+(PID.TID 0000.0001)         System time:   7.5120031833648682E-003
+(PID.TID 0000.0001)     Wall clock time:   5.5958542823791504
 (PID.TID 0000.0001)          No. starts:          10
 (PID.TID 0000.0001)           No. stops:          10
 (PID.TID 0000.0001)   Seconds in section "SEAICE_MODEL    [DO_OCEANIC_PHYS]":
-(PID.TID 0000.0001)           User time:   2.2374928593635559
-(PID.TID 0000.0001)         System time:   7.5409859418869019E-003
-(PID.TID 0000.0001)     Wall clock time:   2.2451829910278320
+(PID.TID 0000.0001)           User time:   2.2371020913124084
+(PID.TID 0000.0001)         System time:   0.0000000000000000
+(PID.TID 0000.0001)     Wall clock time:   2.2373747825622559
 (PID.TID 0000.0001)          No. starts:          10
 (PID.TID 0000.0001)           No. stops:          10
 (PID.TID 0000.0001)   Seconds in section "SEAICE_DYNSOLVER   [SEAICE_MODEL]":
-(PID.TID 0000.0001)           User time:   1.8530692458152771
+(PID.TID 0000.0001)           User time:   1.8485223650932312
 (PID.TID 0000.0001)         System time:   0.0000000000000000
-(PID.TID 0000.0001)     Wall clock time:   1.8532128334045410
+(PID.TID 0000.0001)     Wall clock time:   1.8487968444824219
 (PID.TID 0000.0001)          No. starts:          10
 (PID.TID 0000.0001)           No. stops:          10
 (PID.TID 0000.0001)   Seconds in section "GGL90_CALC [DO_OCEANIC_PHYS]":
-(PID.TID 0000.0001)           User time:   2.4696825742721558
-(PID.TID 0000.0001)         System time:   8.0019980669021606E-003
-(PID.TID 0000.0001)     Wall clock time:   2.4780409336090088
+(PID.TID 0000.0001)           User time:   2.5566228628158569
+(PID.TID 0000.0001)         System time:   3.5599917173385620E-003
+(PID.TID 0000.0001)     Wall clock time:   2.5617899894714355
 (PID.TID 0000.0001)          No. starts:         120
 (PID.TID 0000.0001)           No. stops:         120
 (PID.TID 0000.0001)   Seconds in section "DYNAMICS            [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:   3.8061685562133789
-(PID.TID 0000.0001)         System time:   1.0549008846282959E-002
-(PID.TID 0000.0001)     Wall clock time:   3.8176755905151367
+(PID.TID 0000.0001)           User time:   4.2428106069564819
+(PID.TID 0000.0001)         System time:   7.2019994258880615E-003
+(PID.TID 0000.0001)     Wall clock time:   4.2520029544830322
 (PID.TID 0000.0001)          No. starts:          10
 (PID.TID 0000.0001)           No. stops:          10
 (PID.TID 0000.0001)   Seconds in section "UPDATE_CG2D         [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:   7.1498036384582520E-002
-(PID.TID 0000.0001)         System time:   3.9499998092651367E-003
-(PID.TID 0000.0001)     Wall clock time:   7.5458765029907227E-002
+(PID.TID 0000.0001)           User time:   9.0324282646179199E-002
+(PID.TID 0000.0001)         System time:   3.9279907941818237E-003
+(PID.TID 0000.0001)     Wall clock time:   9.4273090362548828E-002
 (PID.TID 0000.0001)          No. starts:          10
 (PID.TID 0000.0001)           No. stops:          10
 (PID.TID 0000.0001)   Seconds in section "SOLVE_FOR_PRESSURE  [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:   1.7734459638595581
-(PID.TID 0000.0001)         System time:   3.3899843692779541E-003
-(PID.TID 0000.0001)     Wall clock time:   1.7861719131469727
+(PID.TID 0000.0001)           User time:   1.8449710607528687
+(PID.TID 0000.0001)         System time:   3.7939995527267456E-003
+(PID.TID 0000.0001)     Wall clock time:   1.8489282131195068
 (PID.TID 0000.0001)          No. starts:          10
 (PID.TID 0000.0001)           No. stops:          10
 (PID.TID 0000.0001)   Seconds in section "MOM_CORRECTION_STEP [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:  0.13301920890808105
-(PID.TID 0000.0001)         System time:   0.0000000000000000
-(PID.TID 0000.0001)     Wall clock time:  0.13304162025451660
+(PID.TID 0000.0001)           User time:  0.12545299530029297
+(PID.TID 0000.0001)         System time:   1.7899274826049805E-004
+(PID.TID 0000.0001)     Wall clock time:  0.12565612792968750
 (PID.TID 0000.0001)          No. starts:          10
 (PID.TID 0000.0001)           No. stops:          10
 (PID.TID 0000.0001)   Seconds in section "INTEGR_CONTINUITY   [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:  0.23056030273437500
-(PID.TID 0000.0001)         System time:   0.0000000000000000
-(PID.TID 0000.0001)     Wall clock time:  0.23063039779663086
+(PID.TID 0000.0001)           User time:  0.22340869903564453
+(PID.TID 0000.0001)         System time:   6.0051679611206055E-006
+(PID.TID 0000.0001)     Wall clock time:  0.22344732284545898
 (PID.TID 0000.0001)          No. starts:          10
 (PID.TID 0000.0001)           No. stops:          10
 (PID.TID 0000.0001)   Seconds in section "CALC_R_STAR         [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:   4.8941612243652344E-002
-(PID.TID 0000.0001)         System time:   3.8630068302154541E-003
-(PID.TID 0000.0001)     Wall clock time:   5.2829027175903320E-002
+(PID.TID 0000.0001)           User time:   4.1802167892456055E-002
+(PID.TID 0000.0001)         System time:   7.0035457611083984E-006
+(PID.TID 0000.0001)     Wall clock time:   4.1822910308837891E-002
 (PID.TID 0000.0001)          No. starts:          10
 (PID.TID 0000.0001)           No. stops:          10
 (PID.TID 0000.0001)   Seconds in section "BLOCKING_EXCHANGES  [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:  0.20702528953552246
-(PID.TID 0000.0001)         System time:   4.1030049324035645E-003
-(PID.TID 0000.0001)     Wall clock time:  0.21116304397583008
+(PID.TID 0000.0001)           User time:  0.21759414672851562
+(PID.TID 0000.0001)         System time:   3.7997961044311523E-005
+(PID.TID 0000.0001)     Wall clock time:  0.21768260002136230
 (PID.TID 0000.0001)          No. starts:          20
 (PID.TID 0000.0001)           No. stops:          20
 (PID.TID 0000.0001)   Seconds in section "THERMODYNAMICS      [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:   2.4326133728027344
-(PID.TID 0000.0001)         System time:   7.1129947900772095E-003
-(PID.TID 0000.0001)     Wall clock time:   2.4400346279144287
+(PID.TID 0000.0001)           User time:   2.4549789428710938
+(PID.TID 0000.0001)         System time:   3.5986304283142090E-005
+(PID.TID 0000.0001)     Wall clock time:   2.4552199840545654
 (PID.TID 0000.0001)          No. starts:          10
 (PID.TID 0000.0001)           No. stops:          10
 (PID.TID 0000.0001)   Seconds in section "TRC_CORRECTION_STEP [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:   9.7513198852539062E-005
+(PID.TID 0000.0001)           User time:   8.9406967163085938E-005
 (PID.TID 0000.0001)         System time:   1.9967555999755859E-006
-(PID.TID 0000.0001)     Wall clock time:   9.3460083007812500E-005
+(PID.TID 0000.0001)     Wall clock time:   8.9645385742187500E-005
 (PID.TID 0000.0001)          No. starts:          10
 (PID.TID 0000.0001)           No. stops:          10
 (PID.TID 0000.0001)   Seconds in section "DO_STATEVARS_TAVE   [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:   7.8439712524414062E-005
+(PID.TID 0000.0001)           User time:   1.0061264038085938E-004
 (PID.TID 0000.0001)         System time:   9.9837779998779297E-007
-(PID.TID 0000.0001)     Wall clock time:   7.8678131103515625E-005
+(PID.TID 0000.0001)     Wall clock time:   9.4890594482421875E-005
 (PID.TID 0000.0001)          No. starts:          10
 (PID.TID 0000.0001)           No. stops:          10
 (PID.TID 0000.0001)   Seconds in section "MONITOR             [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:   1.0958182811737061
-(PID.TID 0000.0001)         System time:   3.9050132036209106E-003
-(PID.TID 0000.0001)     Wall clock time:   1.0998036861419678
+(PID.TID 0000.0001)           User time:   1.1802294254302979
+(PID.TID 0000.0001)         System time:   0.0000000000000000
+(PID.TID 0000.0001)     Wall clock time:   1.1803152561187744
 (PID.TID 0000.0001)          No. starts:          10
 (PID.TID 0000.0001)           No. stops:          10
 (PID.TID 0000.0001)   Seconds in section "DO_THE_MODEL_IO     [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:   8.9791059494018555E-002
-(PID.TID 0000.0001)         System time:   1.5814006328582764E-002
-(PID.TID 0000.0001)     Wall clock time:  0.12229609489440918
+(PID.TID 0000.0001)           User time:   7.4335813522338867E-002
+(PID.TID 0000.0001)         System time:   7.9769939184188843E-003
+(PID.TID 0000.0001)     Wall clock time:   8.2329034805297852E-002
 (PID.TID 0000.0001)          No. starts:          10
 (PID.TID 0000.0001)           No. stops:          10
 (PID.TID 0000.0001)   Seconds in section "DO_WRITE_PICKUP     [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:   7.6581478118896484E-002
-(PID.TID 0000.0001)         System time:   2.4028003215789795E-002
-(PID.TID 0000.0001)     Wall clock time:  0.10207891464233398
+(PID.TID 0000.0001)           User time:   6.0430526733398438E-002
+(PID.TID 0000.0001)         System time:   4.0059983730316162E-003
+(PID.TID 0000.0001)     Wall clock time:   6.4439535140991211E-002
 (PID.TID 0000.0001)          No. starts:          10
 (PID.TID 0000.0001)           No. stops:          10
 (PID.TID 0000.0001) // ======================================================
@@ -4991,9 +4996,9 @@ listId=   2 ; file name: seaiceStDiag
 (PID.TID 0000.0001) //          Total. Y spins =              0
 (PID.TID 0000.0001) //            Avg. Y spins =       0.00E+00
 (PID.TID 0000.0001) // o Thread number: 000001
-(PID.TID 0000.0001) //            No. barriers =          19884
+(PID.TID 0000.0001) //            No. barriers =          19762
 (PID.TID 0000.0001) //      Max. barrier spins =              1
 (PID.TID 0000.0001) //      Min. barrier spins =              1
-(PID.TID 0000.0001) //     Total barrier spins =          19884
+(PID.TID 0000.0001) //     Total barrier spins =          19762
 (PID.TID 0000.0001) //      Avg. barrier spins =       1.00E+00
 PROGRAM MAIN: Execution ended Normally

--- a/verification/global_ocean.cs32x15/results/output.in_p.txt
+++ b/verification/global_ocean.cs32x15/results/output.in_p.txt
@@ -8,7 +8,7 @@
 (PID.TID 0000.0001) // MITgcmUV version:  checkpoint68a
 (PID.TID 0000.0001) // Build user:        jm_c
 (PID.TID 0000.0001) // Build host:        villon
-(PID.TID 0000.0001) // Build date:        Thu Aug  5 11:20:09 EDT 2021
+(PID.TID 0000.0001) // Build date:        Mon Aug 16 12:37:13 EDT 2021
 (PID.TID 0000.0001) 
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // Execution Environment parameter file "eedata"
@@ -376,11 +376,7 @@
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) ># Parameters for Gaspar et al. (1990)'s TKE vertical mixing scheme  |
 (PID.TID 0000.0001) > &GGL90_PARM01
-(PID.TID 0000.0001) >#GGL90dumpFreq=,
-(PID.TID 0000.0001) >#GGL90taveFreq=,
 (PID.TID 0000.0001) > GGL90diffTKEh=0.E3,
-(PID.TID 0000.0001) > GGL90mixingMaps=.FALSE.,
-(PID.TID 0000.0001) > GGL90writeState=.FALSE.,
 (PID.TID 0000.0001) > GGL90ck = 0.1,
 (PID.TID 0000.0001) > GGL90ceps = 0.7,
 (PID.TID 0000.0001) > GGL90alpha=30.,
@@ -392,9 +388,15 @@
 (PID.TID 0000.0001) > mxlMaxFlag=2,
 (PID.TID 0000.0001) > GGL90viscMax=1.E2,
 (PID.TID 0000.0001) > GGL90diffMax=1.E2,
-(PID.TID 0000.0001) >#GGL90TKEFile=,
+(PID.TID 0000.0001) > calcMeanVertShear=.TRUE.,
 (PID.TID 0000.0001) > GGL90_dirichlet=.FALSE.,
 (PID.TID 0000.0001) > useIDEMIX  = .TRUE.,
+(PID.TID 0000.0001) >#-- IO related params:
+(PID.TID 0000.0001) >#GGL90TKEFile=,
+(PID.TID 0000.0001) >#GGL90dumpFreq=,
+(PID.TID 0000.0001) >#GGL90taveFreq=,
+(PID.TID 0000.0001) > GGL90mixingMaps=.FALSE.,
+(PID.TID 0000.0001) > GGL90writeState=.FALSE.,
 (PID.TID 0000.0001) > /
 (PID.TID 0000.0001) >
 (PID.TID 0000.0001) > &GGL90_PARM02
@@ -464,7 +466,7 @@
 (PID.TID 0000.0001)                   F
 (PID.TID 0000.0001)     ;
 (PID.TID 0000.0001) calcMeanVertShear = /* calc Mean of Vert.Shear (vs shear of Mean flow) */
-(PID.TID 0000.0001)                   F
+(PID.TID 0000.0001)                   T
 (PID.TID 0000.0001)     ;
 (PID.TID 0000.0001) GGL90: GGL90TKEFile =
 (PID.TID 0000.0001) GGL90_dirichlet =   /* GGL90 Boundary condition flag */
@@ -3523,42 +3525,42 @@ listId=   2 ; file name: seaiceStDiag
  cg2d: Sum(rhs),rhsMax =   7.66661733960343E-02  2.00457239865341E+01
 (PID.TID 0000.0001)      cg2d_init_res =   4.84221893084459E-01
 (PID.TID 0000.0001)      cg2d_iters(min,last) =      -1     109
-(PID.TID 0000.0001)      cg2d_last_res =   8.82011137744516E-10
+(PID.TID 0000.0001)      cg2d_last_res =   8.82501223637362E-10
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // Begin MONITOR dynamic field statistics
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) %MON time_tsnumber                =                     2
 (PID.TID 0000.0001) %MON time_secondsf                =   1.7280000000000E+05
-(PID.TID 0000.0001) %MON dynstat_eta_max              =   1.4036965268694E+04
-(PID.TID 0000.0001) %MON dynstat_eta_min              =  -2.1104916361533E+04
-(PID.TID 0000.0001) %MON dynstat_eta_mean             =  -2.3208444477513E+01
-(PID.TID 0000.0001) %MON dynstat_eta_sd               =   6.2877655143526E+03
-(PID.TID 0000.0001) %MON dynstat_eta_del2             =   9.5570817522074E+01
-(PID.TID 0000.0001) %MON dynstat_uvel_max             =   3.8335540667596E-02
-(PID.TID 0000.0001) %MON dynstat_uvel_min             =  -4.4651029013022E-02
-(PID.TID 0000.0001) %MON dynstat_uvel_mean            =  -3.3193706828569E-04
-(PID.TID 0000.0001) %MON dynstat_uvel_sd              =   2.3396750766942E-03
-(PID.TID 0000.0001) %MON dynstat_uvel_del2            =   1.2333597813108E-05
-(PID.TID 0000.0001) %MON dynstat_vvel_max             =   7.3366327759110E-02
-(PID.TID 0000.0001) %MON dynstat_vvel_min             =  -5.6465928266595E-02
-(PID.TID 0000.0001) %MON dynstat_vvel_mean            =  -6.8051627586838E-05
+(PID.TID 0000.0001) %MON dynstat_eta_max              =   1.4036965268333E+04
+(PID.TID 0000.0001) %MON dynstat_eta_min              =  -2.1104916361476E+04
+(PID.TID 0000.0001) %MON dynstat_eta_mean             =  -2.3208444477512E+01
+(PID.TID 0000.0001) %MON dynstat_eta_sd               =   6.2877655143525E+03
+(PID.TID 0000.0001) %MON dynstat_eta_del2             =   9.5570817522091E+01
+(PID.TID 0000.0001) %MON dynstat_uvel_max             =   3.8335540667625E-02
+(PID.TID 0000.0001) %MON dynstat_uvel_min             =  -4.4651029013030E-02
+(PID.TID 0000.0001) %MON dynstat_uvel_mean            =  -3.3193706828567E-04
+(PID.TID 0000.0001) %MON dynstat_uvel_sd              =   2.3396750766941E-03
+(PID.TID 0000.0001) %MON dynstat_uvel_del2            =   1.2333597813109E-05
+(PID.TID 0000.0001) %MON dynstat_vvel_max             =   7.3366327758949E-02
+(PID.TID 0000.0001) %MON dynstat_vvel_min             =  -5.6465928266594E-02
+(PID.TID 0000.0001) %MON dynstat_vvel_mean            =  -6.8051627586800E-05
 (PID.TID 0000.0001) %MON dynstat_vvel_sd              =   2.4521930392512E-03
-(PID.TID 0000.0001) %MON dynstat_vvel_del2            =   1.2959564550908E-05
+(PID.TID 0000.0001) %MON dynstat_vvel_del2            =   1.2959564550909E-05
 (PID.TID 0000.0001) %MON dynstat_wvel_max             =   1.8519218962490E+00
-(PID.TID 0000.0001) %MON dynstat_wvel_min             =  -2.9433404939188E+00
-(PID.TID 0000.0001) %MON dynstat_wvel_mean            =   2.4537896047355E-03
-(PID.TID 0000.0001) %MON dynstat_wvel_sd              =   8.9180465244966E-02
-(PID.TID 0000.0001) %MON dynstat_wvel_del2            =   7.6787871356582E-04
+(PID.TID 0000.0001) %MON dynstat_wvel_min             =  -2.9433404939193E+00
+(PID.TID 0000.0001) %MON dynstat_wvel_mean            =   2.4537896047374E-03
+(PID.TID 0000.0001) %MON dynstat_wvel_sd              =   8.9180465244969E-02
+(PID.TID 0000.0001) %MON dynstat_wvel_del2            =   7.6787871356586E-04
 (PID.TID 0000.0001) %MON dynstat_theta_max            =   2.9400596552103E+01
 (PID.TID 0000.0001) %MON dynstat_theta_min            =  -1.8753303244749E+00
 (PID.TID 0000.0001) %MON dynstat_theta_mean           =   3.5913487271234E+00
 (PID.TID 0000.0001) %MON dynstat_theta_sd             =   4.4273028223381E+00
 (PID.TID 0000.0001) %MON dynstat_theta_del2           =   2.1350327197186E-03
 (PID.TID 0000.0001) %MON dynstat_salt_max             =   4.0715782043866E+01
-(PID.TID 0000.0001) %MON dynstat_salt_min             =   1.8061466083966E+01
+(PID.TID 0000.0001) %MON dynstat_salt_min             =   1.8061466083965E+01
 (PID.TID 0000.0001) %MON dynstat_salt_mean            =   3.4721464665322E+01
-(PID.TID 0000.0001) %MON dynstat_salt_sd              =   4.8775554545322E-01
-(PID.TID 0000.0001) %MON dynstat_salt_del2            =   5.1987260896904E-04
+(PID.TID 0000.0001) %MON dynstat_salt_sd              =   4.8775554545323E-01
+(PID.TID 0000.0001) %MON dynstat_salt_del2            =   5.1987260896902E-04
 (PID.TID 0000.0001) %MON forcing_qnet_max             =   6.9568301659527E+02
 (PID.TID 0000.0001) %MON forcing_qnet_min             =  -3.1666111122704E+02
 (PID.TID 0000.0001) %MON forcing_qnet_mean            =  -2.1816692279327E+01
@@ -3584,25 +3586,25 @@ listId=   2 ; file name: seaiceStDiag
 (PID.TID 0000.0001) %MON forcing_fv_mean              =  -1.3688466828709E-02
 (PID.TID 0000.0001) %MON forcing_fv_sd                =   7.5192568394714E-02
 (PID.TID 0000.0001) %MON forcing_fv_del2              =   2.3387409827505E-04
-(PID.TID 0000.0001) %MON trAdv_CFL_u_max              =   1.5992062360749E-02
-(PID.TID 0000.0001) %MON trAdv_CFL_v_max              =   2.4917775183077E-02
-(PID.TID 0000.0001) %MON trAdv_CFL_w_max              =   7.6016910197718E-02
-(PID.TID 0000.0001) %MON advcfl_uvel_max              =   1.4235253129336E-02
-(PID.TID 0000.0001) %MON advcfl_vvel_max              =   2.3940139947193E-02
-(PID.TID 0000.0001) %MON advcfl_wvel_max              =   8.3246481229192E-02
-(PID.TID 0000.0001) %MON advcfl_W_hf_max              =   9.1981173751777E-02
-(PID.TID 0000.0001) %MON pe_b_mean                    =   1.2124608444616E-02
-(PID.TID 0000.0001) %MON ke_max                       =   1.6821389677917E-03
+(PID.TID 0000.0001) %MON trAdv_CFL_u_max              =   1.5992062360760E-02
+(PID.TID 0000.0001) %MON trAdv_CFL_v_max              =   2.4917775183023E-02
+(PID.TID 0000.0001) %MON trAdv_CFL_w_max              =   7.6016910197736E-02
+(PID.TID 0000.0001) %MON advcfl_uvel_max              =   1.4235253129306E-02
+(PID.TID 0000.0001) %MON advcfl_vvel_max              =   2.3940139947141E-02
+(PID.TID 0000.0001) %MON advcfl_wvel_max              =   8.3246481229211E-02
+(PID.TID 0000.0001) %MON advcfl_W_hf_max              =   9.1981173751798E-02
+(PID.TID 0000.0001) %MON pe_b_mean                    =   1.2124608444615E-02
+(PID.TID 0000.0001) %MON ke_max                       =   1.6821389677914E-03
 (PID.TID 0000.0001) %MON ke_mean                      =   5.3572483612507E-06
 (PID.TID 0000.0001) %MON ke_vol                       =   1.3604174062081E+22
-(PID.TID 0000.0001) %MON vort_r_min                   =  -3.6063117581779E-07
-(PID.TID 0000.0001) %MON vort_r_max                   =   4.3008997582309E-07
+(PID.TID 0000.0001) %MON vort_r_min                   =  -3.6063117581765E-07
+(PID.TID 0000.0001) %MON vort_r_max                   =   4.3008997582352E-07
 (PID.TID 0000.0001) %MON vort_a_mean                  =  -2.0556865257795E-05
 (PID.TID 0000.0001) %MON vort_a_sd                    =   7.5247345875121E-05
 (PID.TID 0000.0001) %MON vort_p_mean                  =  -2.4859276343880E-05
 (PID.TID 0000.0001) %MON vort_p_sd                    =   1.2919528775072E-04
-(PID.TID 0000.0001) %MON surfExpan_theta_mean         =   7.0941539455669E-03
-(PID.TID 0000.0001) %MON surfExpan_salt_mean          =  -4.3489466007181E-03
+(PID.TID 0000.0001) %MON surfExpan_theta_mean         =   7.0941539455192E-03
+(PID.TID 0000.0001) %MON surfExpan_salt_mean          =  -4.3489466007081E-03
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // End MONITOR dynamic field statistics
 (PID.TID 0000.0001) // =======================================================
@@ -3641,50 +3643,50 @@ listId=   2 ; file name: seaiceStDiag
 (PID.TID 0000.0001) // =======================================================
  EXTERNAL_FIELDS_LOAD,         2 : iP,iLd,i0,i1=   12    1   12    1 ; Wght=  0.4333333333  0.5666666667
  SEAICE_LSR: Residual Initial ipass,Uice,Vice=         1  5.59360800E-04  8.46021758E-04
- SEAICE_LSR (ipass=        1) iters,dU,Resid=       12  2.57849297E-13  2.16632898E-19
- SEAICE_LSR (ipass=        1) iters,dV,Resid=       12  1.46355150E-13  2.84187427E-19
+ SEAICE_LSR (ipass=        1) iters,dU,Resid=       12  2.57904809E-13  2.16002447E-19
+ SEAICE_LSR (ipass=        1) iters,dV,Resid=       12  1.46327395E-13  3.26910401E-19
  SEAICE_LSR: Residual Initial ipass,Uice,Vice=         2  1.59915603E-04  1.95760454E-04
- SEAICE_LSR (ipass=        2) iters,dU,Resid=       12  2.29677388E-14  1.43869322E-19
- SEAICE_LSR (ipass=        2) iters,dV,Resid=       12  3.57066807E-14  2.66875488E-19
- cg2d: Sum(rhs),rhsMax =   1.33366823273812E-01  1.98889685127989E+01
-(PID.TID 0000.0001)      cg2d_init_res =   1.91658343512744E-01
+ SEAICE_LSR (ipass=        2) iters,dU,Resid=       12  2.29954944E-14  1.40841413E-19
+ SEAICE_LSR (ipass=        2) iters,dV,Resid=       12  3.57205585E-14  3.00186719E-19
+ cg2d: Sum(rhs),rhsMax =   1.33366823273823E-01  1.98889685127990E+01
+(PID.TID 0000.0001)      cg2d_init_res =   1.91658343510547E-01
 (PID.TID 0000.0001)      cg2d_iters(min,last) =      -1     104
-(PID.TID 0000.0001)      cg2d_last_res =   9.60112865940889E-10
+(PID.TID 0000.0001)      cg2d_last_res =   9.58400802127717E-10
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // Begin MONITOR dynamic field statistics
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) %MON time_tsnumber                =                     3
 (PID.TID 0000.0001) %MON time_secondsf                =   2.5920000000000E+05
-(PID.TID 0000.0001) %MON dynstat_eta_max              =   1.3305568895935E+04
-(PID.TID 0000.0001) %MON dynstat_eta_min              =  -2.3890925990618E+04
-(PID.TID 0000.0001) %MON dynstat_eta_mean             =  -4.0057197978013E+01
-(PID.TID 0000.0001) %MON dynstat_eta_sd               =   7.0653107179180E+03
-(PID.TID 0000.0001) %MON dynstat_eta_del2             =   9.3846801632577E+01
-(PID.TID 0000.0001) %MON dynstat_uvel_max             =   5.4259923018776E-02
-(PID.TID 0000.0001) %MON dynstat_uvel_min             =  -6.3804490707108E-02
-(PID.TID 0000.0001) %MON dynstat_uvel_mean            =  -4.5161666905462E-04
-(PID.TID 0000.0001) %MON dynstat_uvel_sd              =   3.2104549461372E-03
-(PID.TID 0000.0001) %MON dynstat_uvel_del2            =   1.7242405595665E-05
-(PID.TID 0000.0001) %MON dynstat_vvel_max             =   8.8880798509184E-02
-(PID.TID 0000.0001) %MON dynstat_vvel_min             =  -8.2045964902220E-02
-(PID.TID 0000.0001) %MON dynstat_vvel_mean            =  -1.5740597697878E-04
-(PID.TID 0000.0001) %MON dynstat_vvel_sd              =   3.3122341536262E-03
-(PID.TID 0000.0001) %MON dynstat_vvel_del2            =   1.8229526142440E-05
-(PID.TID 0000.0001) %MON dynstat_wvel_max             =   2.6904765961234E+00
-(PID.TID 0000.0001) %MON dynstat_wvel_min             =  -4.3242250634441E+00
-(PID.TID 0000.0001) %MON dynstat_wvel_mean            =   8.8932549799798E-04
-(PID.TID 0000.0001) %MON dynstat_wvel_sd              =   1.2601406897856E-01
-(PID.TID 0000.0001) %MON dynstat_wvel_del2            =   1.0608938386622E-03
+(PID.TID 0000.0001) %MON dynstat_eta_max              =   1.3305568895580E+04
+(PID.TID 0000.0001) %MON dynstat_eta_min              =  -2.3890925990633E+04
+(PID.TID 0000.0001) %MON dynstat_eta_mean             =  -4.0057197978012E+01
+(PID.TID 0000.0001) %MON dynstat_eta_sd               =   7.0653107179326E+03
+(PID.TID 0000.0001) %MON dynstat_eta_del2             =   9.3846801634321E+01
+(PID.TID 0000.0001) %MON dynstat_uvel_max             =   5.4259923018788E-02
+(PID.TID 0000.0001) %MON dynstat_uvel_min             =  -6.3804273869750E-02
+(PID.TID 0000.0001) %MON dynstat_uvel_mean            =  -4.5161666905500E-04
+(PID.TID 0000.0001) %MON dynstat_uvel_sd              =   3.2104549173227E-03
+(PID.TID 0000.0001) %MON dynstat_uvel_del2            =   1.7242405507096E-05
+(PID.TID 0000.0001) %MON dynstat_vvel_max             =   8.8880798485755E-02
+(PID.TID 0000.0001) %MON dynstat_vvel_min             =  -8.2045964902231E-02
+(PID.TID 0000.0001) %MON dynstat_vvel_mean            =  -1.5740597697879E-04
+(PID.TID 0000.0001) %MON dynstat_vvel_sd              =   3.3122341193210E-03
+(PID.TID 0000.0001) %MON dynstat_vvel_del2            =   1.8229526773499E-05
+(PID.TID 0000.0001) %MON dynstat_wvel_max             =   2.6904765953141E+00
+(PID.TID 0000.0001) %MON dynstat_wvel_min             =  -4.3242250632580E+00
+(PID.TID 0000.0001) %MON dynstat_wvel_mean            =   8.8932549810737E-04
+(PID.TID 0000.0001) %MON dynstat_wvel_sd              =   1.2601406790899E-01
+(PID.TID 0000.0001) %MON dynstat_wvel_del2            =   1.0608938337773E-03
 (PID.TID 0000.0001) %MON dynstat_theta_max            =   2.9408135074514E+01
 (PID.TID 0000.0001) %MON dynstat_theta_min            =  -1.8830010737597E+00
 (PID.TID 0000.0001) %MON dynstat_theta_mean           =   3.5914725052713E+00
-(PID.TID 0000.0001) %MON dynstat_theta_sd             =   4.4276475140560E+00
-(PID.TID 0000.0001) %MON dynstat_theta_del2           =   2.1107909097209E-03
+(PID.TID 0000.0001) %MON dynstat_theta_sd             =   4.4276475110507E+00
+(PID.TID 0000.0001) %MON dynstat_theta_del2           =   2.1107895637723E-03
 (PID.TID 0000.0001) %MON dynstat_salt_max             =   4.0715797013571E+01
-(PID.TID 0000.0001) %MON dynstat_salt_min             =   1.7830039392902E+01
+(PID.TID 0000.0001) %MON dynstat_salt_min             =   1.7830039392896E+01
 (PID.TID 0000.0001) %MON dynstat_salt_mean            =   3.4721480211925E+01
-(PID.TID 0000.0001) %MON dynstat_salt_sd              =   4.8768042704066E-01
-(PID.TID 0000.0001) %MON dynstat_salt_del2            =   5.1654684586103E-04
+(PID.TID 0000.0001) %MON dynstat_salt_sd              =   4.8768042466746E-01
+(PID.TID 0000.0001) %MON dynstat_salt_del2            =   5.1654635831221E-04
 (PID.TID 0000.0001) %MON forcing_qnet_max             =   9.8898462964453E+02
 (PID.TID 0000.0001) %MON forcing_qnet_min             =  -3.1582909723282E+02
 (PID.TID 0000.0001) %MON forcing_qnet_mean            =  -2.4196329267912E+01
@@ -3695,11 +3697,11 @@ listId=   2 ; file name: seaiceStDiag
 (PID.TID 0000.0001) %MON forcing_qsw_mean             =  -1.8593879213097E+02
 (PID.TID 0000.0001) %MON forcing_qsw_sd               =   7.9086030762481E+01
 (PID.TID 0000.0001) %MON forcing_qsw_del2             =   1.1032203144530E-01
-(PID.TID 0000.0001) %MON forcing_empmr_max            =   1.7742506342707E-03
+(PID.TID 0000.0001) %MON forcing_empmr_max            =   1.7742506342706E-03
 (PID.TID 0000.0001) %MON forcing_empmr_min            =  -1.6714318397364E-03
 (PID.TID 0000.0001) %MON forcing_empmr_mean           =   1.9878564839001E-05
 (PID.TID 0000.0001) %MON forcing_empmr_sd             =   1.7354017337450E-04
-(PID.TID 0000.0001) %MON forcing_empmr_del2           =   3.3786642290124E-06
+(PID.TID 0000.0001) %MON forcing_empmr_del2           =   3.3786642290123E-06
 (PID.TID 0000.0001) %MON forcing_fu_max               =   2.4751003717351E-01
 (PID.TID 0000.0001) %MON forcing_fu_min               =  -2.0922350306190E-01
 (PID.TID 0000.0001) %MON forcing_fu_mean              =  -4.4451640019368E-03
@@ -3710,25 +3712,25 @@ listId=   2 ; file name: seaiceStDiag
 (PID.TID 0000.0001) %MON forcing_fv_mean              =  -1.3688993645892E-02
 (PID.TID 0000.0001) %MON forcing_fv_sd                =   7.5246625962459E-02
 (PID.TID 0000.0001) %MON forcing_fv_del2              =   2.3426167469211E-04
-(PID.TID 0000.0001) %MON trAdv_CFL_u_max              =   2.2401775800108E-02
-(PID.TID 0000.0001) %MON trAdv_CFL_v_max              =   3.1506303245055E-02
-(PID.TID 0000.0001) %MON trAdv_CFL_w_max              =   1.1159956548839E-01
-(PID.TID 0000.0001) %MON advcfl_uvel_max              =   2.0096023730288E-02
-(PID.TID 0000.0001) %MON advcfl_vvel_max              =   2.6142675054198E-02
-(PID.TID 0000.0001) %MON advcfl_wvel_max              =   1.2220630575796E-01
-(PID.TID 0000.0001) %MON advcfl_W_hf_max              =   1.3503652012573E-01
-(PID.TID 0000.0001) %MON pe_b_mean                    =   1.3157400067864E-02
-(PID.TID 0000.0001) %MON ke_max                       =   2.6263979163857E-03
-(PID.TID 0000.0001) %MON ke_mean                      =   9.9299670972211E-06
+(PID.TID 0000.0001) %MON trAdv_CFL_u_max              =   2.2401775800131E-02
+(PID.TID 0000.0001) %MON trAdv_CFL_v_max              =   3.1506303245043E-02
+(PID.TID 0000.0001) %MON trAdv_CFL_w_max              =   1.1159956548577E-01
+(PID.TID 0000.0001) %MON advcfl_uvel_max              =   2.0096023730248E-02
+(PID.TID 0000.0001) %MON advcfl_vvel_max              =   2.6142675052646E-02
+(PID.TID 0000.0001) %MON advcfl_wvel_max              =   1.2220630575509E-01
+(PID.TID 0000.0001) %MON advcfl_W_hf_max              =   1.3503652012257E-01
+(PID.TID 0000.0001) %MON pe_b_mean                    =   1.3157400067899E-02
+(PID.TID 0000.0001) %MON ke_max                       =   2.6263979163870E-03
+(PID.TID 0000.0001) %MON ke_mean                      =   9.9299669067715E-06
 (PID.TID 0000.0001) %MON ke_vol                       =   1.3604168238985E+22
-(PID.TID 0000.0001) %MON vort_r_min                   =  -4.9874672741229E-07
-(PID.TID 0000.0001) %MON vort_r_max                   =   5.2424095251657E-07
+(PID.TID 0000.0001) %MON vort_r_min                   =  -4.9874672739384E-07
+(PID.TID 0000.0001) %MON vort_r_max                   =   5.2424095251648E-07
 (PID.TID 0000.0001) %MON vort_a_mean                  =  -2.0556865257795E-05
 (PID.TID 0000.0001) %MON vort_a_sd                    =   7.5247335755280E-05
 (PID.TID 0000.0001) %MON vort_p_mean                  =  -2.4859228572284E-05
-(PID.TID 0000.0001) %MON vort_p_sd                    =   1.2920027720448E-04
-(PID.TID 0000.0001) %MON surfExpan_theta_mean         =   1.1468274062207E-02
-(PID.TID 0000.0001) %MON surfExpan_salt_mean          =  -5.1771345819545E-03
+(PID.TID 0000.0001) %MON vort_p_sd                    =   1.2920027720410E-04
+(PID.TID 0000.0001) %MON surfExpan_theta_mean         =   1.1468274062140E-02
+(PID.TID 0000.0001) %MON surfExpan_salt_mean          =  -5.1771345817986E-03
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // End MONITOR dynamic field statistics
 (PID.TID 0000.0001) // =======================================================
@@ -3737,16 +3739,16 @@ listId=   2 ; file name: seaiceStDiag
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) %MON seaice_tsnumber              =                     3
 (PID.TID 0000.0001) %MON seaice_time_sec              =   2.5920000000000E+05
-(PID.TID 0000.0001) %MON seaice_uice_max              =   1.2724390853030E-01
+(PID.TID 0000.0001) %MON seaice_uice_max              =   1.2724390853029E-01
 (PID.TID 0000.0001) %MON seaice_uice_min              =  -1.8208622789017E-01
-(PID.TID 0000.0001) %MON seaice_uice_mean             =  -3.0913786881447E-04
-(PID.TID 0000.0001) %MON seaice_uice_sd               =   9.4998738259483E-03
-(PID.TID 0000.0001) %MON seaice_uice_del2             =   2.0182103708204E-04
-(PID.TID 0000.0001) %MON seaice_vice_max              =   1.4350330033244E-01
-(PID.TID 0000.0001) %MON seaice_vice_min              =  -1.4748903452627E-01
-(PID.TID 0000.0001) %MON seaice_vice_mean             =   9.1141928681906E-04
+(PID.TID 0000.0001) %MON seaice_uice_mean             =  -3.0913786881449E-04
+(PID.TID 0000.0001) %MON seaice_uice_sd               =   9.4998738259479E-03
+(PID.TID 0000.0001) %MON seaice_uice_del2             =   2.0182103708200E-04
+(PID.TID 0000.0001) %MON seaice_vice_max              =   1.4350330033241E-01
+(PID.TID 0000.0001) %MON seaice_vice_min              =  -1.4748903452633E-01
+(PID.TID 0000.0001) %MON seaice_vice_mean             =   9.1141928681904E-04
 (PID.TID 0000.0001) %MON seaice_vice_sd               =   1.3506900353633E-02
-(PID.TID 0000.0001) %MON seaice_vice_del2             =   1.2914879877234E-04
+(PID.TID 0000.0001) %MON seaice_vice_del2             =   1.2914879877236E-04
 (PID.TID 0000.0001) %MON seaice_area_max              =   6.7874329947991E-01
 (PID.TID 0000.0001) %MON seaice_area_min              =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON seaice_area_mean             =   9.6242418794471E-03
@@ -3761,100 +3763,100 @@ listId=   2 ; file name: seaiceStDiag
 (PID.TID 0000.0001) %MON seaice_hsnow_min             =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON seaice_hsnow_mean            =   1.4992139780416E-05
 (PID.TID 0000.0001) %MON seaice_hsnow_sd              =   1.3089548971084E-04
-(PID.TID 0000.0001) %MON seaice_hsnow_del2            =   2.0820572686460E-06
+(PID.TID 0000.0001) %MON seaice_hsnow_del2            =   2.0820572686459E-06
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // End MONITOR SEAICE statistics
 (PID.TID 0000.0001) // =======================================================
  EXTERNAL_FIELDS_LOAD,         3 : iP,iLd,i0,i1=   12    1   12    1 ; Wght=  0.4000000000  0.6000000000
  SEAICE_LSR: Residual Initial ipass,Uice,Vice=         1  2.75168993E-04  3.52394067E-04
- SEAICE_LSR (ipass=        1) iters,dU,Resid=       12  3.16413562E-14  2.08434219E-19
- SEAICE_LSR (ipass=        1) iters,dV,Resid=       12  7.74866282E-14  4.57964846E-19
- SEAICE_LSR: Residual Initial ipass,Uice,Vice=         2  9.40704001E-05  7.93744660E-05
- SEAICE_LSR (ipass=        2) iters,dU,Resid=       12  2.15105711E-15  2.71133310E-19
- SEAICE_LSR (ipass=        2) iters,dV,Resid=       12  3.60787789E-14  4.25070440E-19
- cg2d: Sum(rhs),rhsMax =   1.92172345838122E-01  1.98883986255107E+01
-(PID.TID 0000.0001)      cg2d_init_res =   9.80656814771134E-02
+ SEAICE_LSR (ipass=        1) iters,dU,Resid=       12  3.16136006E-14  2.56402756E-19
+ SEAICE_LSR (ipass=        1) iters,dV,Resid=       12  7.74831588E-14  5.27669207E-19
+ SEAICE_LSR: Residual Initial ipass,Uice,Vice=         2  9.40704000E-05  7.93744659E-05
+ SEAICE_LSR (ipass=        2) iters,dU,Resid=       12  2.13717932E-15  2.40101051E-19
+ SEAICE_LSR (ipass=        2) iters,dV,Resid=       12  3.60770441E-14  4.46854712E-19
+ cg2d: Sum(rhs),rhsMax =   1.92172284867735E-01  1.98883986255069E+01
+(PID.TID 0000.0001)      cg2d_init_res =   9.80656792989594E-02
 (PID.TID 0000.0001)      cg2d_iters(min,last) =      -1     103
-(PID.TID 0000.0001)      cg2d_last_res =   7.42172723947246E-10
+(PID.TID 0000.0001)      cg2d_last_res =   7.42172803687128E-10
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // Begin MONITOR dynamic field statistics
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) %MON time_tsnumber                =                     4
 (PID.TID 0000.0001) %MON time_secondsf                =   3.4560000000000E+05
-(PID.TID 0000.0001) %MON dynstat_eta_max              =   1.3103148491284E+04
-(PID.TID 0000.0001) %MON dynstat_eta_min              =  -2.3940438472822E+04
-(PID.TID 0000.0001) %MON dynstat_eta_mean             =  -5.7717991201284E+01
-(PID.TID 0000.0001) %MON dynstat_eta_sd               =   7.3742311481120E+03
-(PID.TID 0000.0001) %MON dynstat_eta_del2             =   9.3592001123689E+01
-(PID.TID 0000.0001) %MON dynstat_uvel_max             =   6.9746207793473E-02
-(PID.TID 0000.0001) %MON dynstat_uvel_min             =  -8.1959328824495E-02
-(PID.TID 0000.0001) %MON dynstat_uvel_mean            =  -4.6671128565780E-04
-(PID.TID 0000.0001) %MON dynstat_uvel_sd              =   4.1161819713203E-03
-(PID.TID 0000.0001) %MON dynstat_uvel_del2            =   2.2003197827426E-05
-(PID.TID 0000.0001) %MON dynstat_vvel_max             =   1.1493554157730E-01
-(PID.TID 0000.0001) %MON dynstat_vvel_min             =  -1.0576859148938E-01
-(PID.TID 0000.0001) %MON dynstat_vvel_mean            =  -2.7722741101554E-04
-(PID.TID 0000.0001) %MON dynstat_vvel_sd              =   4.2197071582986E-03
-(PID.TID 0000.0001) %MON dynstat_vvel_del2            =   2.3149952971262E-05
-(PID.TID 0000.0001) %MON dynstat_wvel_max             =   3.4525294265057E+00
-(PID.TID 0000.0001) %MON dynstat_wvel_min             =  -5.6359456226126E+00
-(PID.TID 0000.0001) %MON dynstat_wvel_mean            =   2.6569446718863E-04
-(PID.TID 0000.0001) %MON dynstat_wvel_sd              =   1.6024170482463E-01
-(PID.TID 0000.0001) %MON dynstat_wvel_del2            =   1.3203004118675E-03
+(PID.TID 0000.0001) %MON dynstat_eta_max              =   1.3103148517815E+04
+(PID.TID 0000.0001) %MON dynstat_eta_min              =  -2.3940437729527E+04
+(PID.TID 0000.0001) %MON dynstat_eta_mean             =  -5.7717972889121E+01
+(PID.TID 0000.0001) %MON dynstat_eta_sd               =   7.3742311473010E+03
+(PID.TID 0000.0001) %MON dynstat_eta_del2             =   9.3592001150386E+01
+(PID.TID 0000.0001) %MON dynstat_uvel_max             =   6.9746207934121E-02
+(PID.TID 0000.0001) %MON dynstat_uvel_min             =  -8.1956720116883E-02
+(PID.TID 0000.0001) %MON dynstat_uvel_mean            =  -4.6671128891593E-04
+(PID.TID 0000.0001) %MON dynstat_uvel_sd              =   4.1161818216521E-03
+(PID.TID 0000.0001) %MON dynstat_uvel_del2            =   2.2003197368481E-05
+(PID.TID 0000.0001) %MON dynstat_vvel_max             =   1.1493552948131E-01
+(PID.TID 0000.0001) %MON dynstat_vvel_min             =  -1.0576859165154E-01
+(PID.TID 0000.0001) %MON dynstat_vvel_mean            =  -2.7722740795987E-04
+(PID.TID 0000.0001) %MON dynstat_vvel_sd              =   4.2197069784128E-03
+(PID.TID 0000.0001) %MON dynstat_vvel_del2            =   2.3149951113307E-05
+(PID.TID 0000.0001) %MON dynstat_wvel_max             =   3.4525291564695E+00
+(PID.TID 0000.0001) %MON dynstat_wvel_min             =  -5.6359456311017E+00
+(PID.TID 0000.0001) %MON dynstat_wvel_mean            =   2.6569456542827E-04
+(PID.TID 0000.0001) %MON dynstat_wvel_sd              =   1.6024169149798E-01
+(PID.TID 0000.0001) %MON dynstat_wvel_del2            =   1.3203003561285E-03
 (PID.TID 0000.0001) %MON dynstat_theta_max            =   2.9415131671508E+01
-(PID.TID 0000.0001) %MON dynstat_theta_min            =  -1.8816762412292E+00
-(PID.TID 0000.0001) %MON dynstat_theta_mean           =   3.5916308870674E+00
-(PID.TID 0000.0001) %MON dynstat_theta_sd             =   4.4274608224274E+00
-(PID.TID 0000.0001) %MON dynstat_theta_del2           =   2.2856036660045E-03
+(PID.TID 0000.0001) %MON dynstat_theta_min            =  -1.8816762412202E+00
+(PID.TID 0000.0001) %MON dynstat_theta_mean           =   3.5916308872376E+00
+(PID.TID 0000.0001) %MON dynstat_theta_sd             =   4.4274608216882E+00
+(PID.TID 0000.0001) %MON dynstat_theta_del2           =   2.2856027244249E-03
 (PID.TID 0000.0001) %MON dynstat_salt_max             =   4.0715816856184E+01
-(PID.TID 0000.0001) %MON dynstat_salt_min             =   1.7561085086134E+01
-(PID.TID 0000.0001) %MON dynstat_salt_mean            =   3.4721497017552E+01
-(PID.TID 0000.0001) %MON dynstat_salt_sd              =   4.8746252007397E-01
-(PID.TID 0000.0001) %MON dynstat_salt_del2            =   5.2572587779482E-04
+(PID.TID 0000.0001) %MON dynstat_salt_min             =   1.7561085086136E+01
+(PID.TID 0000.0001) %MON dynstat_salt_mean            =   3.4721497017536E+01
+(PID.TID 0000.0001) %MON dynstat_salt_sd              =   4.8746251858499E-01
+(PID.TID 0000.0001) %MON dynstat_salt_del2            =   5.2572504735414E-04
 (PID.TID 0000.0001) %MON forcing_qnet_max             =   6.8114117795321E+02
 (PID.TID 0000.0001) %MON forcing_qnet_min             =  -3.1494305800167E+02
-(PID.TID 0000.0001) %MON forcing_qnet_mean            =  -2.6000702229765E+01
-(PID.TID 0000.0001) %MON forcing_qnet_sd              =   1.6029830736002E+02
-(PID.TID 0000.0001) %MON forcing_qnet_del2            =   1.0312944669857E+00
+(PID.TID 0000.0001) %MON forcing_qnet_mean            =  -2.6000732229865E+01
+(PID.TID 0000.0001) %MON forcing_qnet_sd              =   1.6029829201219E+02
+(PID.TID 0000.0001) %MON forcing_qnet_del2            =   1.0312900226910E+00
 (PID.TID 0000.0001) %MON forcing_qsw_max              =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON forcing_qsw_min              =  -3.0187928232211E+02
 (PID.TID 0000.0001) %MON forcing_qsw_mean             =  -1.8594494422320E+02
 (PID.TID 0000.0001) %MON forcing_qsw_sd               =   7.8977862412479E+01
 (PID.TID 0000.0001) %MON forcing_qsw_del2             =   1.1028061737212E-01
-(PID.TID 0000.0001) %MON forcing_empmr_max            =   1.6301881578100E-03
+(PID.TID 0000.0001) %MON forcing_empmr_max            =   1.6301881578001E-03
 (PID.TID 0000.0001) %MON forcing_empmr_min            =  -4.4998185712268E-04
-(PID.TID 0000.0001) %MON forcing_empmr_mean           =   2.0836628845366E-05
-(PID.TID 0000.0001) %MON forcing_empmr_sd             =   1.6001929469458E-04
-(PID.TID 0000.0001) %MON forcing_empmr_del2           =   2.0472614157226E-06
+(PID.TID 0000.0001) %MON forcing_empmr_mean           =   2.0836607240237E-05
+(PID.TID 0000.0001) %MON forcing_empmr_sd             =   1.6001927348733E-04
+(PID.TID 0000.0001) %MON forcing_empmr_del2           =   2.0472611134098E-06
 (PID.TID 0000.0001) %MON forcing_fu_max               =   2.4746198790331E-01
 (PID.TID 0000.0001) %MON forcing_fu_min               =  -2.1236929972025E-01
-(PID.TID 0000.0001) %MON forcing_fu_mean              =  -4.3930421616762E-03
-(PID.TID 0000.0001) %MON forcing_fu_sd                =   6.3996952183216E-02
-(PID.TID 0000.0001) %MON forcing_fu_del2              =   2.0640984713818E-04
+(PID.TID 0000.0001) %MON forcing_fu_mean              =  -4.3930421616766E-03
+(PID.TID 0000.0001) %MON forcing_fu_sd                =   6.3996952183217E-02
+(PID.TID 0000.0001) %MON forcing_fu_del2              =   2.0640984713816E-04
 (PID.TID 0000.0001) %MON forcing_fv_max               =   2.6086070515377E-01
 (PID.TID 0000.0001) %MON forcing_fv_min               =  -3.2928363582178E-01
-(PID.TID 0000.0001) %MON forcing_fv_mean              =  -1.3690788591843E-02
-(PID.TID 0000.0001) %MON forcing_fv_sd                =   7.5311085550734E-02
-(PID.TID 0000.0001) %MON forcing_fv_del2              =   2.3487386222678E-04
-(PID.TID 0000.0001) %MON trAdv_CFL_u_max              =   2.9518783958312E-02
-(PID.TID 0000.0001) %MON trAdv_CFL_v_max              =   4.1208641023932E-02
-(PID.TID 0000.0001) %MON trAdv_CFL_w_max              =   1.4541304417015E-01
-(PID.TID 0000.0001) %MON advcfl_uvel_max              =   2.5031597586829E-02
-(PID.TID 0000.0001) %MON advcfl_vvel_max              =   3.2492472130390E-02
-(PID.TID 0000.0001) %MON advcfl_wvel_max              =   1.5923411508716E-01
-(PID.TID 0000.0001) %MON advcfl_W_hf_max              =   1.7595114622261E-01
-(PID.TID 0000.0001) %MON pe_b_mean                    =   1.3494867730142E-02
-(PID.TID 0000.0001) %MON ke_max                       =   4.4061204244284E-03
-(PID.TID 0000.0001) %MON ke_mean                      =   1.6180089833473E-05
+(PID.TID 0000.0001) %MON forcing_fv_mean              =  -1.3690788591846E-02
+(PID.TID 0000.0001) %MON forcing_fv_sd                =   7.5311085550732E-02
+(PID.TID 0000.0001) %MON forcing_fv_del2              =   2.3487386222695E-04
+(PID.TID 0000.0001) %MON trAdv_CFL_u_max              =   2.9518784030454E-02
+(PID.TID 0000.0001) %MON trAdv_CFL_v_max              =   4.1208641086279E-02
+(PID.TID 0000.0001) %MON trAdv_CFL_w_max              =   1.4541304440886E-01
+(PID.TID 0000.0001) %MON advcfl_uvel_max              =   2.5031597579851E-02
+(PID.TID 0000.0001) %MON advcfl_vvel_max              =   3.2492468710833E-02
+(PID.TID 0000.0001) %MON advcfl_wvel_max              =   1.5923411534856E-01
+(PID.TID 0000.0001) %MON advcfl_W_hf_max              =   1.7595114651145E-01
+(PID.TID 0000.0001) %MON pe_b_mean                    =   1.3494867758267E-02
+(PID.TID 0000.0001) %MON ke_max                       =   4.4061204390488E-03
+(PID.TID 0000.0001) %MON ke_mean                      =   1.6180088563558E-05
 (PID.TID 0000.0001) %MON ke_vol                       =   1.3604162107947E+22
-(PID.TID 0000.0001) %MON vort_r_min                   =  -5.6691713435697E-07
-(PID.TID 0000.0001) %MON vort_r_max                   =   5.8099321369133E-07
-(PID.TID 0000.0001) %MON vort_a_mean                  =  -2.0556865257795E-05
-(PID.TID 0000.0001) %MON vort_a_sd                    =   7.5247344330259E-05
+(PID.TID 0000.0001) %MON vort_r_min                   =  -5.6691713457462E-07
+(PID.TID 0000.0001) %MON vort_r_max                   =   5.8099321369163E-07
+(PID.TID 0000.0001) %MON vort_a_mean                  =  -2.0556865257794E-05
+(PID.TID 0000.0001) %MON vort_a_sd                    =   7.5247344330272E-05
 (PID.TID 0000.0001) %MON vort_p_mean                  =  -2.4859215101150E-05
-(PID.TID 0000.0001) %MON vort_p_sd                    =   1.2920355596567E-04
-(PID.TID 0000.0001) %MON surfExpan_theta_mean         =   9.2670149058223E-03
-(PID.TID 0000.0001) %MON surfExpan_salt_mean          =  -6.1897018288567E-03
+(PID.TID 0000.0001) %MON vort_p_sd                    =   1.2920355596374E-04
+(PID.TID 0000.0001) %MON surfExpan_theta_mean         =   9.2670154062557E-03
+(PID.TID 0000.0001) %MON surfExpan_salt_mean          =  -6.1896945178397E-03
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // End MONITOR dynamic field statistics
 (PID.TID 0000.0001) // =======================================================
@@ -3864,123 +3866,123 @@ listId=   2 ; file name: seaiceStDiag
 (PID.TID 0000.0001) %MON seaice_tsnumber              =                     4
 (PID.TID 0000.0001) %MON seaice_time_sec              =   3.4560000000000E+05
 (PID.TID 0000.0001) %MON seaice_uice_max              =   1.0866972264832E-01
-(PID.TID 0000.0001) %MON seaice_uice_min              =  -1.9592069054440E-01
-(PID.TID 0000.0001) %MON seaice_uice_mean             =  -2.7035898072293E-04
-(PID.TID 0000.0001) %MON seaice_uice_sd               =   9.5886716644679E-03
-(PID.TID 0000.0001) %MON seaice_uice_del2             =   1.8776172896929E-04
-(PID.TID 0000.0001) %MON seaice_vice_max              =   1.5194283551953E-01
-(PID.TID 0000.0001) %MON seaice_vice_min              =  -1.6374102802527E-01
-(PID.TID 0000.0001) %MON seaice_vice_mean             =   9.6336397594752E-04
-(PID.TID 0000.0001) %MON seaice_vice_sd               =   1.4142746494289E-02
-(PID.TID 0000.0001) %MON seaice_vice_del2             =   1.1597772033130E-04
-(PID.TID 0000.0001) %MON seaice_area_max              =   7.8638852378627E-01
+(PID.TID 0000.0001) %MON seaice_uice_min              =  -1.9592069028591E-01
+(PID.TID 0000.0001) %MON seaice_uice_mean             =  -2.7035898022202E-04
+(PID.TID 0000.0001) %MON seaice_uice_sd               =   9.5886716569623E-03
+(PID.TID 0000.0001) %MON seaice_uice_del2             =   1.8776172859400E-04
+(PID.TID 0000.0001) %MON seaice_vice_max              =   1.5194283551967E-01
+(PID.TID 0000.0001) %MON seaice_vice_min              =  -1.6374102802466E-01
+(PID.TID 0000.0001) %MON seaice_vice_mean             =   9.6336397612057E-04
+(PID.TID 0000.0001) %MON seaice_vice_sd               =   1.4142746494839E-02
+(PID.TID 0000.0001) %MON seaice_vice_del2             =   1.1597772031649E-04
+(PID.TID 0000.0001) %MON seaice_area_max              =   7.8638852378632E-01
 (PID.TID 0000.0001) %MON seaice_area_min              =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON seaice_area_mean             =   1.3342646700675E-02
-(PID.TID 0000.0001) %MON seaice_area_sd               =   9.2047063847110E-02
-(PID.TID 0000.0001) %MON seaice_area_del2             =   9.3314980206416E-04
+(PID.TID 0000.0001) %MON seaice_area_mean             =   1.3342644022997E-02
+(PID.TID 0000.0001) %MON seaice_area_sd               =   9.2047062971157E-02
+(PID.TID 0000.0001) %MON seaice_area_del2             =   9.3314977903605E-04
 (PID.TID 0000.0001) %MON seaice_heff_max              =   4.5243194760048E-01
 (PID.TID 0000.0001) %MON seaice_heff_min              =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON seaice_heff_mean             =   7.2475991744740E-03
-(PID.TID 0000.0001) %MON seaice_heff_sd               =   5.0573551009081E-02
-(PID.TID 0000.0001) %MON seaice_heff_del2             =   5.0230650102927E-04
-(PID.TID 0000.0001) %MON seaice_hsnow_max             =   3.4944226281616E-03
+(PID.TID 0000.0001) %MON seaice_heff_mean             =   7.2475978355320E-03
+(PID.TID 0000.0001) %MON seaice_heff_sd               =   5.0573550625033E-02
+(PID.TID 0000.0001) %MON seaice_heff_del2             =   5.0230649034551E-04
+(PID.TID 0000.0001) %MON seaice_hsnow_max             =   3.4944226281209E-03
 (PID.TID 0000.0001) %MON seaice_hsnow_min             =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON seaice_hsnow_mean            =   3.2241768871318E-05
-(PID.TID 0000.0001) %MON seaice_hsnow_sd              =   2.6095145919473E-04
-(PID.TID 0000.0001) %MON seaice_hsnow_del2            =   4.3944604765836E-06
+(PID.TID 0000.0001) %MON seaice_hsnow_mean            =   3.2241768871490E-05
+(PID.TID 0000.0001) %MON seaice_hsnow_sd              =   2.6095145919640E-04
+(PID.TID 0000.0001) %MON seaice_hsnow_del2            =   4.3944604767615E-06
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // End MONITOR SEAICE statistics
 (PID.TID 0000.0001) // =======================================================
  EXTERNAL_FIELDS_LOAD,         4 : iP,iLd,i0,i1=   12    1   12    1 ; Wght=  0.3666666667  0.6333333333
- SEAICE_LSR: Residual Initial ipass,Uice,Vice=         1  4.38929525E-04  3.69280041E-04
- SEAICE_LSR (ipass=        1) iters,dU,Resid=       12  5.95301586E-13  5.61717919E-19
- SEAICE_LSR (ipass=        1) iters,dV,Resid=       12  8.63614735E-14  8.74060619E-19
- SEAICE_LSR: Residual Initial ipass,Uice,Vice=         2  5.39902649E-04  1.18448099E-04
- SEAICE_LSR (ipass=        2) iters,dU,Resid=       12  9.51183576E-14  4.32473540E-19
- SEAICE_LSR (ipass=        2) iters,dV,Resid=       12  3.59434704E-14  6.67592217E-19
- cg2d: Sum(rhs),rhsMax =   2.26710518696016E-01  1.98977556594674E+01
-(PID.TID 0000.0001)      cg2d_init_res =   8.14399363315810E-02
+ SEAICE_LSR: Residual Initial ipass,Uice,Vice=         1  4.38929285E-04  3.69279998E-04
+ SEAICE_LSR (ipass=        1) iters,dU,Resid=       12  5.95190564E-13  5.06879933E-19
+ SEAICE_LSR (ipass=        1) iters,dV,Resid=       12  8.63614735E-14  9.29870583E-19
+ SEAICE_LSR: Residual Initial ipass,Uice,Vice=         2  5.39902623E-04  1.18448062E-04
+ SEAICE_LSR (ipass=        2) iters,dU,Resid=       12  9.51183576E-14  4.86777810E-19
+ SEAICE_LSR (ipass=        2) iters,dV,Resid=       12  3.59434704E-14  6.22310791E-19
+ cg2d: Sum(rhs),rhsMax =   2.26702155328334E-01  1.98977556593965E+01
+(PID.TID 0000.0001)      cg2d_init_res =   8.14397760322875E-02
 (PID.TID 0000.0001)      cg2d_iters(min,last) =      -1     102
-(PID.TID 0000.0001)      cg2d_last_res =   8.63624305554337E-10
+(PID.TID 0000.0001)      cg2d_last_res =   8.63624714622198E-10
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // Begin MONITOR dynamic field statistics
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) %MON time_tsnumber                =                     5
 (PID.TID 0000.0001) %MON time_secondsf                =   4.3200000000000E+05
-(PID.TID 0000.0001) %MON dynstat_eta_max              =   1.3211580222448E+04
-(PID.TID 0000.0001) %MON dynstat_eta_min              =  -2.3568643155887E+04
-(PID.TID 0000.0001) %MON dynstat_eta_mean             =  -6.8123391986487E+01
-(PID.TID 0000.0001) %MON dynstat_eta_sd               =   7.4387698981167E+03
-(PID.TID 0000.0001) %MON dynstat_eta_del2             =   9.3724905540961E+01
-(PID.TID 0000.0001) %MON dynstat_uvel_max             =   8.4685800685940E-02
-(PID.TID 0000.0001) %MON dynstat_uvel_min             =  -9.9993001163063E-02
-(PID.TID 0000.0001) %MON dynstat_uvel_mean            =  -3.9417931945738E-04
-(PID.TID 0000.0001) %MON dynstat_uvel_sd              =   5.0192220777333E-03
-(PID.TID 0000.0001) %MON dynstat_uvel_del2            =   2.6360486033343E-05
-(PID.TID 0000.0001) %MON dynstat_vvel_max             =   1.3874544773806E-01
-(PID.TID 0000.0001) %MON dynstat_vvel_min             =  -1.2778921802670E-01
-(PID.TID 0000.0001) %MON dynstat_vvel_mean            =  -3.9198082314973E-04
-(PID.TID 0000.0001) %MON dynstat_vvel_sd              =   5.1490971217027E-03
-(PID.TID 0000.0001) %MON dynstat_vvel_del2            =   2.7544629639818E-05
-(PID.TID 0000.0001) %MON dynstat_wvel_max             =   4.1196721405463E+00
-(PID.TID 0000.0001) %MON dynstat_wvel_min             =  -6.8473957341305E+00
-(PID.TID 0000.0001) %MON dynstat_wvel_mean            =   9.9288185036879E-06
-(PID.TID 0000.0001) %MON dynstat_wvel_sd              =   1.9087093741426E-01
-(PID.TID 0000.0001) %MON dynstat_wvel_del2            =   1.5406273207793E-03
-(PID.TID 0000.0001) %MON dynstat_theta_max            =   2.9421633528842E+01
-(PID.TID 0000.0001) %MON dynstat_theta_min            =  -1.8949180195126E+00
-(PID.TID 0000.0001) %MON dynstat_theta_mean           =   3.5917874069290E+00
-(PID.TID 0000.0001) %MON dynstat_theta_sd             =   4.4278777493531E+00
-(PID.TID 0000.0001) %MON dynstat_theta_del2           =   2.2608159534624E-03
+(PID.TID 0000.0001) %MON dynstat_eta_max              =   1.3211580945173E+04
+(PID.TID 0000.0001) %MON dynstat_eta_min              =  -2.3568642266911E+04
+(PID.TID 0000.0001) %MON dynstat_eta_mean             =  -6.8120878909310E+01
+(PID.TID 0000.0001) %MON dynstat_eta_sd               =   7.4387652472723E+03
+(PID.TID 0000.0001) %MON dynstat_eta_del2             =   9.3724904718523E+01
+(PID.TID 0000.0001) %MON dynstat_uvel_max             =   8.4685835919678E-02
+(PID.TID 0000.0001) %MON dynstat_uvel_min             =  -9.9975632962648E-02
+(PID.TID 0000.0001) %MON dynstat_uvel_mean            =  -3.9417945554047E-04
+(PID.TID 0000.0001) %MON dynstat_uvel_sd              =   5.0192208923170E-03
+(PID.TID 0000.0001) %MON dynstat_uvel_del2            =   2.6360475851171E-05
+(PID.TID 0000.0001) %MON dynstat_vvel_max             =   1.3874516759779E-01
+(PID.TID 0000.0001) %MON dynstat_vvel_min             =  -1.2778920497439E-01
+(PID.TID 0000.0001) %MON dynstat_vvel_mean            =  -3.9198056645777E-04
+(PID.TID 0000.0001) %MON dynstat_vvel_sd              =   5.1490962113437E-03
+(PID.TID 0000.0001) %MON dynstat_vvel_del2            =   2.7544634649433E-05
+(PID.TID 0000.0001) %MON dynstat_wvel_max             =   4.1196706253561E+00
+(PID.TID 0000.0001) %MON dynstat_wvel_min             =  -6.8473964874039E+00
+(PID.TID 0000.0001) %MON dynstat_wvel_mean            =   9.9320639226945E-06
+(PID.TID 0000.0001) %MON dynstat_wvel_sd              =   1.9087084979243E-01
+(PID.TID 0000.0001) %MON dynstat_wvel_del2            =   1.5406269155604E-03
+(PID.TID 0000.0001) %MON dynstat_theta_max            =   2.9421633528843E+01
+(PID.TID 0000.0001) %MON dynstat_theta_min            =  -1.8949180193621E+00
+(PID.TID 0000.0001) %MON dynstat_theta_mean           =   3.5917874016039E+00
+(PID.TID 0000.0001) %MON dynstat_theta_sd             =   4.4278777541926E+00
+(PID.TID 0000.0001) %MON dynstat_theta_del2           =   2.2608157287418E-03
 (PID.TID 0000.0001) %MON dynstat_salt_max             =   4.0715833864089E+01
-(PID.TID 0000.0001) %MON dynstat_salt_min             =   1.7267720604616E+01
-(PID.TID 0000.0001) %MON dynstat_salt_mean            =   3.4721507079721E+01
-(PID.TID 0000.0001) %MON dynstat_salt_sd              =   4.8741110090596E-01
-(PID.TID 0000.0001) %MON dynstat_salt_del2            =   5.2158307277492E-04
-(PID.TID 0000.0001) %MON forcing_qnet_max             =   1.2842316161670E+03
-(PID.TID 0000.0001) %MON forcing_qnet_min             =  -3.1401608637913E+02
-(PID.TID 0000.0001) %MON forcing_qnet_mean            =  -2.5274074588268E+01
-(PID.TID 0000.0001) %MON forcing_qnet_sd              =   1.6348264755356E+02
-(PID.TID 0000.0001) %MON forcing_qnet_del2            =   1.1719904781514E+00
+(PID.TID 0000.0001) %MON dynstat_salt_min             =   1.7267720604630E+01
+(PID.TID 0000.0001) %MON dynstat_salt_mean            =   3.4721507077661E+01
+(PID.TID 0000.0001) %MON dynstat_salt_sd              =   4.8741110461664E-01
+(PID.TID 0000.0001) %MON dynstat_salt_del2            =   5.2158271367367E-04
+(PID.TID 0000.0001) %MON forcing_qnet_max             =   1.2842316165518E+03
+(PID.TID 0000.0001) %MON forcing_qnet_min             =  -3.1401608637906E+02
+(PID.TID 0000.0001) %MON forcing_qnet_mean            =  -2.5273152836730E+01
+(PID.TID 0000.0001) %MON forcing_qnet_sd              =   1.6348553615543E+02
+(PID.TID 0000.0001) %MON forcing_qnet_del2            =   1.1719737120808E+00
 (PID.TID 0000.0001) %MON forcing_qsw_max              =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON forcing_qsw_min              =  -3.0186728538630E+02
 (PID.TID 0000.0001) %MON forcing_qsw_mean             =  -1.8595109436249E+02
-(PID.TID 0000.0001) %MON forcing_qsw_sd               =   7.8872389113840E+01
+(PID.TID 0000.0001) %MON forcing_qsw_sd               =   7.8872389113827E+01
 (PID.TID 0000.0001) %MON forcing_qsw_del2             =   1.1030265382505E-01
-(PID.TID 0000.0001) %MON forcing_empmr_max            =   1.8715898778233E-03
-(PID.TID 0000.0001) %MON forcing_empmr_min            =  -2.8938035623425E-03
-(PID.TID 0000.0001) %MON forcing_empmr_mean           =   1.2276542248561E-05
-(PID.TID 0000.0001) %MON forcing_empmr_sd             =   1.5588252540596E-04
-(PID.TID 0000.0001) %MON forcing_empmr_del2           =   3.3105845312153E-06
+(PID.TID 0000.0001) %MON forcing_empmr_max            =   1.8716040657983E-03
+(PID.TID 0000.0001) %MON forcing_empmr_min            =  -2.8938035640616E-03
+(PID.TID 0000.0001) %MON forcing_empmr_mean           =   1.2273598864759E-05
+(PID.TID 0000.0001) %MON forcing_empmr_sd             =   1.5587990603680E-04
+(PID.TID 0000.0001) %MON forcing_empmr_del2           =   3.3105429035549E-06
 (PID.TID 0000.0001) %MON forcing_fu_max               =   2.4741393863310E-01
 (PID.TID 0000.0001) %MON forcing_fu_min               =  -2.1551509637860E-01
-(PID.TID 0000.0001) %MON forcing_fu_mean              =  -4.3401455481083E-03
-(PID.TID 0000.0001) %MON forcing_fu_sd                =   6.4043520998559E-02
-(PID.TID 0000.0001) %MON forcing_fu_del2              =   2.0725425058962E-04
+(PID.TID 0000.0001) %MON forcing_fu_mean              =  -4.3401455508741E-03
+(PID.TID 0000.0001) %MON forcing_fu_sd                =   6.4043521000846E-02
+(PID.TID 0000.0001) %MON forcing_fu_del2              =   2.0725425058945E-04
 (PID.TID 0000.0001) %MON forcing_fv_max               =   2.6354394672640E-01
 (PID.TID 0000.0001) %MON forcing_fv_min               =  -3.3007153975572E-01
-(PID.TID 0000.0001) %MON forcing_fv_mean              =  -1.3692878633789E-02
-(PID.TID 0000.0001) %MON forcing_fv_sd                =   7.5385099810636E-02
-(PID.TID 0000.0001) %MON forcing_fv_del2              =   2.3568023791208E-04
-(PID.TID 0000.0001) %MON trAdv_CFL_u_max              =   3.6223033002705E-02
-(PID.TID 0000.0001) %MON trAdv_CFL_v_max              =   5.0257850820463E-02
-(PID.TID 0000.0001) %MON trAdv_CFL_w_max              =   1.7657324159962E-01
-(PID.TID 0000.0001) %MON advcfl_uvel_max              =   3.0805000034764E-02
-(PID.TID 0000.0001) %MON advcfl_vvel_max              =   3.9223572899907E-02
-(PID.TID 0000.0001) %MON advcfl_wvel_max              =   1.9336645359768E-01
-(PID.TID 0000.0001) %MON advcfl_W_hf_max              =   2.1365527713828E-01
-(PID.TID 0000.0001) %MON pe_b_mean                    =   1.3562757835328E-02
-(PID.TID 0000.0001) %MON ke_max                       =   6.4891853774633E-03
-(PID.TID 0000.0001) %MON ke_mean                      =   2.4016557010082E-05
-(PID.TID 0000.0001) %MON ke_vol                       =   1.3604155681418E+22
-(PID.TID 0000.0001) %MON vort_r_min                   =  -5.8033804999958E-07
-(PID.TID 0000.0001) %MON vort_r_max                   =   6.2817306901052E-07
+(PID.TID 0000.0001) %MON forcing_fv_mean              =  -1.3692878639289E-02
+(PID.TID 0000.0001) %MON forcing_fv_sd                =   7.5385099808090E-02
+(PID.TID 0000.0001) %MON forcing_fv_del2              =   2.3568023791271E-04
+(PID.TID 0000.0001) %MON trAdv_CFL_u_max              =   3.6223042343788E-02
+(PID.TID 0000.0001) %MON trAdv_CFL_v_max              =   5.0257847721942E-02
+(PID.TID 0000.0001) %MON trAdv_CFL_w_max              =   1.7657325964949E-01
+(PID.TID 0000.0001) %MON advcfl_uvel_max              =   3.0804999826183E-02
+(PID.TID 0000.0001) %MON advcfl_vvel_max              =   3.9223493703779E-02
+(PID.TID 0000.0001) %MON advcfl_wvel_max              =   1.9336647336477E-01
+(PID.TID 0000.0001) %MON advcfl_W_hf_max              =   2.1365529897879E-01
+(PID.TID 0000.0001) %MON pe_b_mean                    =   1.3562755341100E-02
+(PID.TID 0000.0001) %MON ke_max                       =   6.4891860722998E-03
+(PID.TID 0000.0001) %MON ke_mean                      =   2.4016547148545E-05
+(PID.TID 0000.0001) %MON ke_vol                       =   1.3604155681425E+22
+(PID.TID 0000.0001) %MON vort_r_min                   =  -5.8033803657107E-07
+(PID.TID 0000.0001) %MON vort_r_max                   =   6.2817306900348E-07
 (PID.TID 0000.0001) %MON vort_a_mean                  =  -2.0556865257795E-05
-(PID.TID 0000.0001) %MON vort_a_sd                    =   7.5247364059986E-05
-(PID.TID 0000.0001) %MON vort_p_mean                  =  -2.4859218018158E-05
-(PID.TID 0000.0001) %MON vort_p_sd                    =   1.2920533584326E-04
-(PID.TID 0000.0001) %MON surfExpan_theta_mean         =   6.3767953734860E-03
-(PID.TID 0000.0001) %MON surfExpan_salt_mean          =  -3.8046674499065E-03
+(PID.TID 0000.0001) %MON vort_a_sd                    =   7.5247364060065E-05
+(PID.TID 0000.0001) %MON vort_p_mean                  =  -2.4859218018146E-05
+(PID.TID 0000.0001) %MON vort_p_sd                    =   1.2920533582752E-04
+(PID.TID 0000.0001) %MON surfExpan_theta_mean         =   6.3768200902348E-03
+(PID.TID 0000.0001) %MON surfExpan_salt_mean          =  -3.8036807426203E-03
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // End MONITOR dynamic field statistics
 (PID.TID 0000.0001) // =======================================================
@@ -3989,124 +3991,124 @@ listId=   2 ; file name: seaiceStDiag
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) %MON seaice_tsnumber              =                     5
 (PID.TID 0000.0001) %MON seaice_time_sec              =   4.3200000000000E+05
-(PID.TID 0000.0001) %MON seaice_uice_max              =   1.2618769054760E-01
-(PID.TID 0000.0001) %MON seaice_uice_min              =  -2.0838387298751E-01
-(PID.TID 0000.0001) %MON seaice_uice_mean             =  -4.8825476885390E-04
-(PID.TID 0000.0001) %MON seaice_uice_sd               =   1.1887054538567E-02
-(PID.TID 0000.0001) %MON seaice_uice_del2             =   1.7521242827318E-04
-(PID.TID 0000.0001) %MON seaice_vice_max              =   1.5360963268411E-01
-(PID.TID 0000.0001) %MON seaice_vice_min              =  -1.5988460518111E-01
-(PID.TID 0000.0001) %MON seaice_vice_mean             =   1.0557321985098E-03
-(PID.TID 0000.0001) %MON seaice_vice_sd               =   1.5011525232033E-02
-(PID.TID 0000.0001) %MON seaice_vice_del2             =   1.1222778385121E-04
-(PID.TID 0000.0001) %MON seaice_area_max              =   8.6147320365295E-01
+(PID.TID 0000.0001) %MON seaice_uice_max              =   1.2618769052764E-01
+(PID.TID 0000.0001) %MON seaice_uice_min              =  -2.0838387131850E-01
+(PID.TID 0000.0001) %MON seaice_uice_mean             =  -4.8825479332740E-04
+(PID.TID 0000.0001) %MON seaice_uice_sd               =   1.1887054972255E-02
+(PID.TID 0000.0001) %MON seaice_uice_del2             =   1.7521242942286E-04
+(PID.TID 0000.0001) %MON seaice_vice_max              =   1.5360963274694E-01
+(PID.TID 0000.0001) %MON seaice_vice_min              =  -1.5988460521131E-01
+(PID.TID 0000.0001) %MON seaice_vice_mean             =   1.0557321707334E-03
+(PID.TID 0000.0001) %MON seaice_vice_sd               =   1.5011525084912E-02
+(PID.TID 0000.0001) %MON seaice_vice_del2             =   1.1222778395468E-04
+(PID.TID 0000.0001) %MON seaice_area_max              =   8.6147320365818E-01
 (PID.TID 0000.0001) %MON seaice_area_min              =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON seaice_area_mean             =   1.5638338174183E-02
-(PID.TID 0000.0001) %MON seaice_area_sd               =   1.0593994303663E-01
-(PID.TID 0000.0001) %MON seaice_area_del2             =   8.3974130936008E-04
-(PID.TID 0000.0001) %MON seaice_heff_max              =   5.1946745261072E-01
+(PID.TID 0000.0001) %MON seaice_area_mean             =   1.5637778361571E-02
+(PID.TID 0000.0001) %MON seaice_area_sd               =   1.0593989856836E-01
+(PID.TID 0000.0001) %MON seaice_area_del2             =   8.3973554828450E-04
+(PID.TID 0000.0001) %MON seaice_heff_max              =   5.1946745261479E-01
 (PID.TID 0000.0001) %MON seaice_heff_min              =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON seaice_heff_mean             =   8.6436066598054E-03
-(PID.TID 0000.0001) %MON seaice_heff_sd               =   5.9723364267535E-02
-(PID.TID 0000.0001) %MON seaice_heff_del2             =   4.5873218824101E-04
-(PID.TID 0000.0001) %MON seaice_hsnow_max             =   6.0910545521316E-03
+(PID.TID 0000.0001) %MON seaice_heff_mean             =   8.6433266563226E-03
+(PID.TID 0000.0001) %MON seaice_heff_sd               =   5.9723348107684E-02
+(PID.TID 0000.0001) %MON seaice_heff_del2             =   4.5872954421272E-04
+(PID.TID 0000.0001) %MON seaice_hsnow_max             =   6.0910545521898E-03
 (PID.TID 0000.0001) %MON seaice_hsnow_min             =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON seaice_hsnow_mean            =   5.3594720373961E-05
-(PID.TID 0000.0001) %MON seaice_hsnow_sd              =   4.2156702617561E-04
-(PID.TID 0000.0001) %MON seaice_hsnow_del2            =   5.9156019733736E-06
+(PID.TID 0000.0001) %MON seaice_hsnow_mean            =   5.3594718191971E-05
+(PID.TID 0000.0001) %MON seaice_hsnow_sd              =   4.2156702627010E-04
+(PID.TID 0000.0001) %MON seaice_hsnow_del2            =   5.9156019710790E-06
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // End MONITOR SEAICE statistics
 (PID.TID 0000.0001) // =======================================================
  EXTERNAL_FIELDS_LOAD,         5 : iP,iLd,i0,i1=   12    1   12    1 ; Wght=  0.3333333333  0.6666666667
- SEAICE_LSR: Residual Initial ipass,Uice,Vice=         1  4.96511277E-03  6.36073954E-04
- SEAICE_LSR (ipass=        1) iters,dU,Resid=       14  3.02535774E-15  2.13693749E-18
- SEAICE_LSR (ipass=        1) iters,dV,Resid=       14  9.64089919E-14  2.66940149E-18
- SEAICE_LSR: Residual Initial ipass,Uice,Vice=         2  2.46644880E-03  2.84151855E-04
- SEAICE_LSR (ipass=        2) iters,dU,Resid=       14  7.32053307E-16  1.18570121E-18
- SEAICE_LSR (ipass=        2) iters,dV,Resid=       14  1.63202785E-14  9.04130228E-19
- cg2d: Sum(rhs),rhsMax =   2.72445141368315E-01  1.98997839258059E+01
-(PID.TID 0000.0001)      cg2d_init_res =   7.52093901585962E-02
+ SEAICE_LSR: Residual Initial ipass,Uice,Vice=         1  4.96509922E-03  6.36071578E-04
+ SEAICE_LSR (ipass=        1) iters,dU,Resid=       14  3.02535774E-15  2.14782244E-18
+ SEAICE_LSR (ipass=        1) iters,dV,Resid=       14  9.64228697E-14  2.62721357E-18
+ SEAICE_LSR: Residual Initial ipass,Uice,Vice=         2  2.46644437E-03  2.84151747E-04
+ SEAICE_LSR (ipass=        2) iters,dU,Resid=       14  7.28583860E-16  1.10572934E-18
+ SEAICE_LSR (ipass=        2) iters,dV,Resid=       14  1.63064007E-14  8.73464691E-19
+ cg2d: Sum(rhs),rhsMax =   2.72439013127742E-01  1.98997839252733E+01
+(PID.TID 0000.0001)      cg2d_init_res =   7.52094074296838E-02
 (PID.TID 0000.0001)      cg2d_iters(min,last) =      -1     102
-(PID.TID 0000.0001)      cg2d_last_res =   9.19175750514436E-10
+(PID.TID 0000.0001)      cg2d_last_res =   9.19306358297010E-10
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // Begin MONITOR dynamic field statistics
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) %MON time_tsnumber                =                     6
 (PID.TID 0000.0001) %MON time_secondsf                =   5.1840000000000E+05
-(PID.TID 0000.0001) %MON dynstat_eta_max              =   1.4057155948794E+04
-(PID.TID 0000.0001) %MON dynstat_eta_min              =  -2.3264704766074E+04
-(PID.TID 0000.0001) %MON dynstat_eta_mean             =  -8.1874361888848E+01
-(PID.TID 0000.0001) %MON dynstat_eta_sd               =   7.4014614458549E+03
-(PID.TID 0000.0001) %MON dynstat_eta_del2             =   9.3885787623660E+01
-(PID.TID 0000.0001) %MON dynstat_uvel_max             =   9.8487510694349E-02
-(PID.TID 0000.0001) %MON dynstat_uvel_min             =  -1.1691793036583E-01
-(PID.TID 0000.0001) %MON dynstat_uvel_mean            =  -2.7358341277631E-04
-(PID.TID 0000.0001) %MON dynstat_uvel_sd              =   5.8990357372130E-03
-(PID.TID 0000.0001) %MON dynstat_uvel_del2            =   3.0173877700578E-05
-(PID.TID 0000.0001) %MON dynstat_vvel_max             =   1.5998592308853E-01
-(PID.TID 0000.0001) %MON dynstat_vvel_min             =  -1.4765811970747E-01
-(PID.TID 0000.0001) %MON dynstat_vvel_mean            =  -4.7216313027408E-04
-(PID.TID 0000.0001) %MON dynstat_vvel_sd              =   6.0659668714266E-03
-(PID.TID 0000.0001) %MON dynstat_vvel_del2            =   3.1335743176807E-05
-(PID.TID 0000.0001) %MON dynstat_wvel_max             =   4.6785390156040E+00
-(PID.TID 0000.0001) %MON dynstat_wvel_min             =  -7.9346321103368E+00
-(PID.TID 0000.0001) %MON dynstat_wvel_mean            =  -7.8722250383185E-05
-(PID.TID 0000.0001) %MON dynstat_wvel_sd              =   2.1722422781681E-01
-(PID.TID 0000.0001) %MON dynstat_wvel_del2            =   1.7188264762376E-03
-(PID.TID 0000.0001) %MON dynstat_theta_max            =   2.9427696569262E+01
-(PID.TID 0000.0001) %MON dynstat_theta_min            =  -1.8898066910790E+00
-(PID.TID 0000.0001) %MON dynstat_theta_mean           =   3.5919528846622E+00
-(PID.TID 0000.0001) %MON dynstat_theta_sd             =   4.4281529172640E+00
-(PID.TID 0000.0001) %MON dynstat_theta_del2           =   2.2973005294811E-03
+(PID.TID 0000.0001) %MON dynstat_eta_max              =   1.4057155889413E+04
+(PID.TID 0000.0001) %MON dynstat_eta_min              =  -2.3264703812341E+04
+(PID.TID 0000.0001) %MON dynstat_eta_mean             =  -8.1872520246960E+01
+(PID.TID 0000.0001) %MON dynstat_eta_sd               =   7.4014592284851E+03
+(PID.TID 0000.0001) %MON dynstat_eta_del2             =   9.3885786340017E+01
+(PID.TID 0000.0001) %MON dynstat_uvel_max             =   9.8487559228261E-02
+(PID.TID 0000.0001) %MON dynstat_uvel_min             =  -1.1689504436088E-01
+(PID.TID 0000.0001) %MON dynstat_uvel_mean            =  -2.7358383792483E-04
+(PID.TID 0000.0001) %MON dynstat_uvel_sd              =   5.8990343523348E-03
+(PID.TID 0000.0001) %MON dynstat_uvel_del2            =   3.0173858380203E-05
+(PID.TID 0000.0001) %MON dynstat_vvel_max             =   1.5998521835046E-01
+(PID.TID 0000.0001) %MON dynstat_vvel_min             =  -1.4765804978217E-01
+(PID.TID 0000.0001) %MON dynstat_vvel_mean            =  -4.7216312226472E-04
+(PID.TID 0000.0001) %MON dynstat_vvel_sd              =   6.0659651358621E-03
+(PID.TID 0000.0001) %MON dynstat_vvel_del2            =   3.1335740339354E-05
+(PID.TID 0000.0001) %MON dynstat_wvel_max             =   4.6785342141243E+00
+(PID.TID 0000.0001) %MON dynstat_wvel_min             =  -7.9346306922853E+00
+(PID.TID 0000.0001) %MON dynstat_wvel_mean            =  -7.8720856047872E-05
+(PID.TID 0000.0001) %MON dynstat_wvel_sd              =   2.1722408370275E-01
+(PID.TID 0000.0001) %MON dynstat_wvel_del2            =   1.7188256932951E-03
+(PID.TID 0000.0001) %MON dynstat_theta_max            =   2.9427696569267E+01
+(PID.TID 0000.0001) %MON dynstat_theta_min            =  -1.8898066966984E+00
+(PID.TID 0000.0001) %MON dynstat_theta_mean           =   3.5919528795527E+00
+(PID.TID 0000.0001) %MON dynstat_theta_sd             =   4.4281529223073E+00
+(PID.TID 0000.0001) %MON dynstat_theta_del2           =   2.2973075187058E-03
 (PID.TID 0000.0001) %MON dynstat_salt_max             =   4.0715839210819E+01
-(PID.TID 0000.0001) %MON dynstat_salt_min             =   1.6954938101262E+01
-(PID.TID 0000.0001) %MON dynstat_salt_mean            =   3.4721518791927E+01
-(PID.TID 0000.0001) %MON dynstat_salt_sd              =   4.8733334044216E-01
-(PID.TID 0000.0001) %MON dynstat_salt_del2            =   5.2069799482924E-04
-(PID.TID 0000.0001) %MON forcing_qnet_max             =   7.0134347649332E+02
-(PID.TID 0000.0001) %MON forcing_qnet_min             =  -3.1298527138340E+02
-(PID.TID 0000.0001) %MON forcing_qnet_mean            =  -2.7235694354660E+01
-(PID.TID 0000.0001) %MON forcing_qnet_sd              =   1.5584136959459E+02
-(PID.TID 0000.0001) %MON forcing_qnet_del2            =   1.0122427565224E+00
+(PID.TID 0000.0001) %MON dynstat_salt_min             =   1.6954938101426E+01
+(PID.TID 0000.0001) %MON dynstat_salt_mean            =   3.4721518790394E+01
+(PID.TID 0000.0001) %MON dynstat_salt_sd              =   4.8733334407440E-01
+(PID.TID 0000.0001) %MON dynstat_salt_del2            =   5.2069854015368E-04
+(PID.TID 0000.0001) %MON forcing_qnet_max             =   7.0134346274719E+02
+(PID.TID 0000.0001) %MON forcing_qnet_min             =  -3.1298527138330E+02
+(PID.TID 0000.0001) %MON forcing_qnet_mean            =  -2.7235754739833E+01
+(PID.TID 0000.0001) %MON forcing_qnet_sd              =   1.5584123876468E+02
+(PID.TID 0000.0001) %MON forcing_qnet_del2            =   1.0122314012850E+00
 (PID.TID 0000.0001) %MON forcing_qsw_max              =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON forcing_qsw_min              =  -3.0185528845048E+02
-(PID.TID 0000.0001) %MON forcing_qsw_mean             =  -1.8595724303889E+02
-(PID.TID 0000.0001) %MON forcing_qsw_sd               =   7.8769620529700E+01
-(PID.TID 0000.0001) %MON forcing_qsw_del2             =   1.1038810628946E-01
-(PID.TID 0000.0001) %MON forcing_empmr_max            =   1.6425831825545E-03
-(PID.TID 0000.0001) %MON forcing_empmr_min            =  -4.5351267256662E-04
-(PID.TID 0000.0001) %MON forcing_empmr_mean           =   1.6223725202882E-05
-(PID.TID 0000.0001) %MON forcing_empmr_sd             =   1.3096755130072E-04
-(PID.TID 0000.0001) %MON forcing_empmr_del2           =   1.9565175641447E-06
+(PID.TID 0000.0001) %MON forcing_qsw_mean             =  -1.8595724303901E+02
+(PID.TID 0000.0001) %MON forcing_qsw_sd               =   7.8769620529423E+01
+(PID.TID 0000.0001) %MON forcing_qsw_del2             =   1.1038810628945E-01
+(PID.TID 0000.0001) %MON forcing_empmr_max            =   1.6425831826967E-03
+(PID.TID 0000.0001) %MON forcing_empmr_min            =  -4.5351267256685E-04
+(PID.TID 0000.0001) %MON forcing_empmr_mean           =   1.6224517378395E-05
+(PID.TID 0000.0001) %MON forcing_empmr_sd             =   1.3097512176080E-04
+(PID.TID 0000.0001) %MON forcing_empmr_del2           =   1.9564949718453E-06
 (PID.TID 0000.0001) %MON forcing_fu_max               =   2.4736588936290E-01
 (PID.TID 0000.0001) %MON forcing_fu_min               =  -2.1866089303695E-01
-(PID.TID 0000.0001) %MON forcing_fu_mean              =  -4.2940981237460E-03
-(PID.TID 0000.0001) %MON forcing_fu_sd                =   6.4104903732477E-02
-(PID.TID 0000.0001) %MON forcing_fu_del2              =   2.0827632802803E-04
+(PID.TID 0000.0001) %MON forcing_fu_mean              =  -4.2940979585603E-03
+(PID.TID 0000.0001) %MON forcing_fu_sd                =   6.4104903864008E-02
+(PID.TID 0000.0001) %MON forcing_fu_del2              =   2.0827633324864E-04
 (PID.TID 0000.0001) %MON forcing_fv_max               =   2.6622718829904E-01
 (PID.TID 0000.0001) %MON forcing_fv_min               =  -3.3085944368965E-01
-(PID.TID 0000.0001) %MON forcing_fv_mean              =  -1.3696256899234E-02
-(PID.TID 0000.0001) %MON forcing_fv_sd                =   7.5466272006318E-02
-(PID.TID 0000.0001) %MON forcing_fv_del2              =   2.3657121260899E-04
-(PID.TID 0000.0001) %MON trAdv_CFL_u_max              =   4.1293651384403E-02
-(PID.TID 0000.0001) %MON trAdv_CFL_v_max              =   5.8428978116263E-02
-(PID.TID 0000.0001) %MON trAdv_CFL_w_max              =   2.0436001182537E-01
-(PID.TID 0000.0001) %MON advcfl_uvel_max              =   3.6038925813795E-02
-(PID.TID 0000.0001) %MON advcfl_vvel_max              =   4.5228291230636E-02
-(PID.TID 0000.0001) %MON advcfl_wvel_max              =   2.2381141391192E-01
-(PID.TID 0000.0001) %MON advcfl_W_hf_max              =   2.4727752952248E-01
-(PID.TID 0000.0001) %MON pe_b_mean                    =   1.3545033007431E-02
-(PID.TID 0000.0001) %MON ke_max                       =   8.7307898957389E-03
-(PID.TID 0000.0001) %MON ke_mean                      =   3.3195279633309E-05
-(PID.TID 0000.0001) %MON ke_vol                       =   1.3604151895031E+22
-(PID.TID 0000.0001) %MON vort_r_min                   =  -5.8446288002858E-07
-(PID.TID 0000.0001) %MON vort_r_max                   =   6.8231946597489E-07
+(PID.TID 0000.0001) %MON forcing_fv_mean              =  -1.3696257417526E-02
+(PID.TID 0000.0001) %MON forcing_fv_sd                =   7.5466271818169E-02
+(PID.TID 0000.0001) %MON forcing_fv_del2              =   2.3657121260592E-04
+(PID.TID 0000.0001) %MON trAdv_CFL_u_max              =   4.1293657502919E-02
+(PID.TID 0000.0001) %MON trAdv_CFL_v_max              =   5.8428954476825E-02
+(PID.TID 0000.0001) %MON trAdv_CFL_w_max              =   2.0435998247595E-01
+(PID.TID 0000.0001) %MON advcfl_uvel_max              =   3.6038924976986E-02
+(PID.TID 0000.0001) %MON advcfl_vvel_max              =   4.5228091999992E-02
+(PID.TID 0000.0001) %MON advcfl_wvel_max              =   2.2381138177583E-01
+(PID.TID 0000.0001) %MON advcfl_W_hf_max              =   2.4727749400941E-01
+(PID.TID 0000.0001) %MON pe_b_mean                    =   1.3545032825655E-02
+(PID.TID 0000.0001) %MON ke_max                       =   8.7307866889117E-03
+(PID.TID 0000.0001) %MON ke_mean                      =   3.3195262458943E-05
+(PID.TID 0000.0001) %MON ke_vol                       =   1.3604151895946E+22
+(PID.TID 0000.0001) %MON vort_r_min                   =  -5.8446061772968E-07
+(PID.TID 0000.0001) %MON vort_r_max                   =   6.8231946581954E-07
 (PID.TID 0000.0001) %MON vort_a_mean                  =  -2.0556865257795E-05
-(PID.TID 0000.0001) %MON vort_a_sd                    =   7.5247389189750E-05
-(PID.TID 0000.0001) %MON vort_p_mean                  =  -2.4859223238345E-05
-(PID.TID 0000.0001) %MON vort_p_sd                    =   1.2920599723842E-04
-(PID.TID 0000.0001) %MON surfExpan_theta_mean         =   3.9645349942838E-03
-(PID.TID 0000.0001) %MON surfExpan_salt_mean          =  -5.3231499524139E-03
+(PID.TID 0000.0001) %MON vort_a_sd                    =   7.5247389189874E-05
+(PID.TID 0000.0001) %MON vort_p_mean                  =  -2.4859223237139E-05
+(PID.TID 0000.0001) %MON vort_p_sd                    =   1.2920599715590E-04
+(PID.TID 0000.0001) %MON surfExpan_theta_mean         =   3.9645607930131E-03
+(PID.TID 0000.0001) %MON surfExpan_salt_mean          =  -5.3234105819177E-03
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // End MONITOR dynamic field statistics
 (PID.TID 0000.0001) // =======================================================
@@ -4115,124 +4117,124 @@ listId=   2 ; file name: seaiceStDiag
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) %MON seaice_tsnumber              =                     6
 (PID.TID 0000.0001) %MON seaice_time_sec              =   5.1840000000000E+05
-(PID.TID 0000.0001) %MON seaice_uice_max              =   1.8111487142967E-01
-(PID.TID 0000.0001) %MON seaice_uice_min              =  -2.1854009563155E-01
-(PID.TID 0000.0001) %MON seaice_uice_mean             =  -3.0158120184435E-04
-(PID.TID 0000.0001) %MON seaice_uice_sd               =   1.1275174878975E-02
-(PID.TID 0000.0001) %MON seaice_uice_del2             =   1.7289253403011E-04
-(PID.TID 0000.0001) %MON seaice_vice_max              =   1.6193602165153E-01
-(PID.TID 0000.0001) %MON seaice_vice_min              =  -1.6608821057161E-01
-(PID.TID 0000.0001) %MON seaice_vice_mean             =   1.0610223927245E-03
-(PID.TID 0000.0001) %MON seaice_vice_sd               =   1.5329209027852E-02
-(PID.TID 0000.0001) %MON seaice_vice_del2             =   1.1526290300421E-04
-(PID.TID 0000.0001) %MON seaice_area_max              =   9.1248316205289E-01
+(PID.TID 0000.0001) %MON seaice_uice_max              =   1.8111681057988E-01
+(PID.TID 0000.0001) %MON seaice_uice_min              =  -2.1854009504565E-01
+(PID.TID 0000.0001) %MON seaice_uice_mean             =  -3.0158032194565E-04
+(PID.TID 0000.0001) %MON seaice_uice_sd               =   1.1275187417632E-02
+(PID.TID 0000.0001) %MON seaice_uice_del2             =   1.7289277121604E-04
+(PID.TID 0000.0001) %MON seaice_vice_max              =   1.6193603638015E-01
+(PID.TID 0000.0001) %MON seaice_vice_min              =  -1.6608821342790E-01
+(PID.TID 0000.0001) %MON seaice_vice_mean             =   1.0610235050064E-03
+(PID.TID 0000.0001) %MON seaice_vice_sd               =   1.5329213121624E-02
+(PID.TID 0000.0001) %MON seaice_vice_del2             =   1.1526292393073E-04
+(PID.TID 0000.0001) %MON seaice_area_max              =   9.1248316203734E-01
 (PID.TID 0000.0001) %MON seaice_area_min              =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON seaice_area_mean             =   1.8118810518896E-02
-(PID.TID 0000.0001) %MON seaice_area_sd               =   1.1845582029111E-01
-(PID.TID 0000.0001) %MON seaice_area_del2             =   9.0889693609072E-04
-(PID.TID 0000.0001) %MON seaice_heff_max              =   5.7643416597313E-01
+(PID.TID 0000.0001) %MON seaice_area_mean             =   1.8118420550270E-02
+(PID.TID 0000.0001) %MON seaice_area_sd               =   1.1845487214509E-01
+(PID.TID 0000.0001) %MON seaice_area_del2             =   9.0889324214201E-04
+(PID.TID 0000.0001) %MON seaice_heff_max              =   5.7643416593240E-01
 (PID.TID 0000.0001) %MON seaice_heff_min              =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON seaice_heff_mean             =   1.0411569836604E-02
-(PID.TID 0000.0001) %MON seaice_heff_sd               =   6.9189814067503E-02
-(PID.TID 0000.0001) %MON seaice_heff_del2             =   4.9636765328059E-04
-(PID.TID 0000.0001) %MON seaice_hsnow_max             =   8.9803073393399E-03
+(PID.TID 0000.0001) %MON seaice_heff_mean             =   1.0411363856771E-02
+(PID.TID 0000.0001) %MON seaice_heff_sd               =   6.9189390030859E-02
+(PID.TID 0000.0001) %MON seaice_heff_del2             =   4.9636538841709E-04
+(PID.TID 0000.0001) %MON seaice_hsnow_max             =   8.9803073411800E-03
 (PID.TID 0000.0001) %MON seaice_hsnow_min             =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON seaice_hsnow_mean            =   8.1222265547615E-05
-(PID.TID 0000.0001) %MON seaice_hsnow_sd              =   6.1936752424970E-04
-(PID.TID 0000.0001) %MON seaice_hsnow_del2            =   8.4229177753038E-06
+(PID.TID 0000.0001) %MON seaice_hsnow_mean            =   8.1221601284076E-05
+(PID.TID 0000.0001) %MON seaice_hsnow_sd              =   6.1936758125957E-04
+(PID.TID 0000.0001) %MON seaice_hsnow_del2            =   8.4229169730900E-06
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // End MONITOR SEAICE statistics
 (PID.TID 0000.0001) // =======================================================
  EXTERNAL_FIELDS_LOAD,         6 : iP,iLd,i0,i1=   12    1   12    1 ; Wght=  0.3000000000  0.7000000000
- SEAICE_LSR: Residual Initial ipass,Uice,Vice=         1  5.97555599E-04  3.72045857E-04
- SEAICE_LSR (ipass=        1) iters,dU,Resid=       18  1.16469334E-14  4.64250785E-17
- SEAICE_LSR (ipass=        1) iters,dV,Resid=       18  3.34329786E-13  8.88369854E-17
- SEAICE_LSR: Residual Initial ipass,Uice,Vice=         2  6.99889450E-04  1.12522872E-04
- SEAICE_LSR (ipass=        2) iters,dU,Resid=       18  6.34214903E-15  2.71335083E-17
- SEAICE_LSR (ipass=        2) iters,dV,Resid=       18  8.65696403E-14  2.57513213E-17
- cg2d: Sum(rhs),rhsMax =   3.06636020965908E-01  1.99001503629673E+01
-(PID.TID 0000.0001)      cg2d_init_res =   7.39636104206411E-02
+ SEAICE_LSR: Residual Initial ipass,Uice,Vice=         1  5.97371443E-04  3.72018081E-04
+ SEAICE_LSR (ipass=        1) iters,dU,Resid=       18  1.16365251E-14  4.65342303E-17
+ SEAICE_LSR (ipass=        1) iters,dV,Resid=       18  3.34329786E-13  8.89180096E-17
+ SEAICE_LSR: Residual Initial ipass,Uice,Vice=         2  6.99880975E-04  1.12510224E-04
+ SEAICE_LSR (ipass=        2) iters,dU,Resid=       18  6.33174069E-15  2.72523582E-17
+ SEAICE_LSR (ipass=        2) iters,dV,Resid=       18  8.65280070E-14  2.62116493E-17
+ cg2d: Sum(rhs),rhsMax =   3.06634963041199E-01  1.99001503625761E+01
+(PID.TID 0000.0001)      cg2d_init_res =   7.39631764739281E-02
 (PID.TID 0000.0001)      cg2d_iters(min,last) =      -1      98
-(PID.TID 0000.0001)      cg2d_last_res =   9.17981367347677E-10
+(PID.TID 0000.0001)      cg2d_last_res =   9.17893734283402E-10
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // Begin MONITOR dynamic field statistics
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) %MON time_tsnumber                =                     7
 (PID.TID 0000.0001) %MON time_secondsf                =   6.0480000000000E+05
-(PID.TID 0000.0001) %MON dynstat_eta_max              =   1.4827165775304E+04
-(PID.TID 0000.0001) %MON dynstat_eta_min              =  -2.2986830765342E+04
-(PID.TID 0000.0001) %MON dynstat_eta_mean             =  -9.2150994952139E+01
-(PID.TID 0000.0001) %MON dynstat_eta_sd               =   7.3336357466236E+03
-(PID.TID 0000.0001) %MON dynstat_eta_del2             =   9.4075396322822E+01
-(PID.TID 0000.0001) %MON dynstat_uvel_max             =   1.1106567379374E-01
-(PID.TID 0000.0001) %MON dynstat_uvel_min             =  -1.3170590424716E-01
-(PID.TID 0000.0001) %MON dynstat_uvel_mean            =  -1.4535833456559E-04
-(PID.TID 0000.0001) %MON dynstat_uvel_sd              =   6.7487226402683E-03
-(PID.TID 0000.0001) %MON dynstat_uvel_del2            =   3.3411847358987E-05
-(PID.TID 0000.0001) %MON dynstat_vvel_max             =   1.7842023246696E-01
-(PID.TID 0000.0001) %MON dynstat_vvel_min             =  -1.6522627075750E-01
-(PID.TID 0000.0001) %MON dynstat_vvel_mean            =  -5.0413978085019E-04
-(PID.TID 0000.0001) %MON dynstat_vvel_sd              =   6.9504126531001E-03
-(PID.TID 0000.0001) %MON dynstat_vvel_del2            =   3.4543413728316E-05
-(PID.TID 0000.0001) %MON dynstat_wvel_max             =   5.1172839819232E+00
-(PID.TID 0000.0001) %MON dynstat_wvel_min             =  -8.8789994976883E+00
-(PID.TID 0000.0001) %MON dynstat_wvel_mean            =  -5.9789098221007E-05
-(PID.TID 0000.0001) %MON dynstat_wvel_sd              =   2.3891276420620E-01
-(PID.TID 0000.0001) %MON dynstat_wvel_del2            =   1.8536303107602E-03
-(PID.TID 0000.0001) %MON dynstat_theta_max            =   2.9433386612059E+01
-(PID.TID 0000.0001) %MON dynstat_theta_min            =  -1.8989892287735E+00
-(PID.TID 0000.0001) %MON dynstat_theta_mean           =   3.5921151355954E+00
-(PID.TID 0000.0001) %MON dynstat_theta_sd             =   4.4285838835944E+00
-(PID.TID 0000.0001) %MON dynstat_theta_del2           =   2.2794987308283E-03
-(PID.TID 0000.0001) %MON dynstat_salt_max             =   4.0715829698070E+01
-(PID.TID 0000.0001) %MON dynstat_salt_min             =   1.6626710719527E+01
-(PID.TID 0000.0001) %MON dynstat_salt_mean            =   3.4721527034398E+01
-(PID.TID 0000.0001) %MON dynstat_salt_sd              =   4.8729928176583E-01
-(PID.TID 0000.0001) %MON dynstat_salt_del2            =   5.1614286602662E-04
-(PID.TID 0000.0001) %MON forcing_qnet_max             =   7.0899081761694E+02
-(PID.TID 0000.0001) %MON forcing_qnet_min             =  -3.1225323012466E+02
-(PID.TID 0000.0001) %MON forcing_qnet_mean            =  -2.6791264329698E+01
-(PID.TID 0000.0001) %MON forcing_qnet_sd              =   1.5464203941239E+02
-(PID.TID 0000.0001) %MON forcing_qnet_del2            =   1.0216866455756E+00
+(PID.TID 0000.0001) %MON dynstat_eta_max              =   1.4827165524526E+04
+(PID.TID 0000.0001) %MON dynstat_eta_min              =  -2.2986829846329E+04
+(PID.TID 0000.0001) %MON dynstat_eta_mean             =  -9.2150677020253E+01
+(PID.TID 0000.0001) %MON dynstat_eta_sd               =   7.3336382291826E+03
+(PID.TID 0000.0001) %MON dynstat_eta_del2             =   9.4075399082235E+01
+(PID.TID 0000.0001) %MON dynstat_uvel_max             =   1.1106571154909E-01
+(PID.TID 0000.0001) %MON dynstat_uvel_min             =  -1.3168196560845E-01
+(PID.TID 0000.0001) %MON dynstat_uvel_mean            =  -1.4535873540697E-04
+(PID.TID 0000.0001) %MON dynstat_uvel_sd              =   6.7487206672972E-03
+(PID.TID 0000.0001) %MON dynstat_uvel_del2            =   3.3411833763980E-05
+(PID.TID 0000.0001) %MON dynstat_vvel_max             =   1.7841901357380E-01
+(PID.TID 0000.0001) %MON dynstat_vvel_min             =  -1.6522613039236E-01
+(PID.TID 0000.0001) %MON dynstat_vvel_mean            =  -5.0414016389313E-04
+(PID.TID 0000.0001) %MON dynstat_vvel_sd              =   6.9504097295048E-03
+(PID.TID 0000.0001) %MON dynstat_vvel_del2            =   3.4543407397895E-05
+(PID.TID 0000.0001) %MON dynstat_wvel_max             =   5.1172760155035E+00
+(PID.TID 0000.0001) %MON dynstat_wvel_min             =  -8.8789946886328E+00
+(PID.TID 0000.0001) %MON dynstat_wvel_mean            =  -5.9788692860846E-05
+(PID.TID 0000.0001) %MON dynstat_wvel_sd              =   2.3891259648827E-01
+(PID.TID 0000.0001) %MON dynstat_wvel_del2            =   1.8536292969527E-03
+(PID.TID 0000.0001) %MON dynstat_theta_max            =   2.9433386612071E+01
+(PID.TID 0000.0001) %MON dynstat_theta_min            =  -1.8989892286929E+00
+(PID.TID 0000.0001) %MON dynstat_theta_mean           =   3.5921151319385E+00
+(PID.TID 0000.0001) %MON dynstat_theta_sd             =   4.4285838820622E+00
+(PID.TID 0000.0001) %MON dynstat_theta_del2           =   2.2795030341429E-03
+(PID.TID 0000.0001) %MON dynstat_salt_max             =   4.0715829698069E+01
+(PID.TID 0000.0001) %MON dynstat_salt_min             =   1.6626710720584E+01
+(PID.TID 0000.0001) %MON dynstat_salt_mean            =   3.4721527034109E+01
+(PID.TID 0000.0001) %MON dynstat_salt_sd              =   4.8729928124986E-01
+(PID.TID 0000.0001) %MON dynstat_salt_del2            =   5.1614417372780E-04
+(PID.TID 0000.0001) %MON forcing_qnet_max             =   7.0754237038199E+02
+(PID.TID 0000.0001) %MON forcing_qnet_min             =  -3.1225323063257E+02
+(PID.TID 0000.0001) %MON forcing_qnet_mean            =  -2.6791490864668E+01
+(PID.TID 0000.0001) %MON forcing_qnet_sd              =   1.5464059103898E+02
+(PID.TID 0000.0001) %MON forcing_qnet_del2            =   1.0215907404576E+00
 (PID.TID 0000.0001) %MON forcing_qsw_max              =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON forcing_qsw_min              =  -3.0184329151467E+02
-(PID.TID 0000.0001) %MON forcing_qsw_mean             =  -1.8596338967800E+02
-(PID.TID 0000.0001) %MON forcing_qsw_sd               =   7.8669568596688E+01
-(PID.TID 0000.0001) %MON forcing_qsw_del2             =   1.1053681934200E-01
-(PID.TID 0000.0001) %MON forcing_empmr_max            =   1.6338821648964E-03
-(PID.TID 0000.0001) %MON forcing_empmr_min            =  -9.0951973051810E-04
-(PID.TID 0000.0001) %MON forcing_empmr_mean           =   1.2124618991500E-05
-(PID.TID 0000.0001) %MON forcing_empmr_sd             =   1.0982268127284E-04
-(PID.TID 0000.0001) %MON forcing_empmr_del2           =   1.9110962454474E-06
+(PID.TID 0000.0001) %MON forcing_qsw_mean             =  -1.8596338967823E+02
+(PID.TID 0000.0001) %MON forcing_qsw_sd               =   7.8669568596166E+01
+(PID.TID 0000.0001) %MON forcing_qsw_del2             =   1.1053681934197E-01
+(PID.TID 0000.0001) %MON forcing_empmr_max            =   1.6338821631089E-03
+(PID.TID 0000.0001) %MON forcing_empmr_min            =  -9.0347183189924E-04
+(PID.TID 0000.0001) %MON forcing_empmr_mean           =   1.2126416701228E-05
+(PID.TID 0000.0001) %MON forcing_empmr_sd             =   1.0980885400492E-04
+(PID.TID 0000.0001) %MON forcing_empmr_del2           =   1.9104589364830E-06
 (PID.TID 0000.0001) %MON forcing_fu_max               =   2.4731784009269E-01
 (PID.TID 0000.0001) %MON forcing_fu_min               =  -2.2180668969530E-01
-(PID.TID 0000.0001) %MON forcing_fu_mean              =  -4.2431932022488E-03
-(PID.TID 0000.0001) %MON forcing_fu_sd                =   6.4179084439649E-02
-(PID.TID 0000.0001) %MON forcing_fu_del2              =   2.0949521760943E-04
+(PID.TID 0000.0001) %MON forcing_fu_mean              =  -4.2431933472304E-03
+(PID.TID 0000.0001) %MON forcing_fu_sd                =   6.4179084307742E-02
+(PID.TID 0000.0001) %MON forcing_fu_del2              =   2.0949521291298E-04
 (PID.TID 0000.0001) %MON forcing_fv_max               =   2.6891042987167E-01
 (PID.TID 0000.0001) %MON forcing_fv_min               =  -3.3164734762358E-01
-(PID.TID 0000.0001) %MON forcing_fv_mean              =  -1.3697479619320E-02
-(PID.TID 0000.0001) %MON forcing_fv_sd                =   7.5554869303913E-02
-(PID.TID 0000.0001) %MON forcing_fv_del2              =   2.3767012486422E-04
-(PID.TID 0000.0001) %MON trAdv_CFL_u_max              =   4.4206068300082E-02
-(PID.TID 0000.0001) %MON trAdv_CFL_v_max              =   6.5544247331663E-02
-(PID.TID 0000.0001) %MON trAdv_CFL_w_max              =   2.2824495998660E-01
-(PID.TID 0000.0001) %MON advcfl_uvel_max              =   4.0645565113539E-02
-(PID.TID 0000.0001) %MON advcfl_vvel_max              =   5.0439701691681E-02
-(PID.TID 0000.0001) %MON advcfl_wvel_max              =   2.4998566003623E-01
-(PID.TID 0000.0001) %MON advcfl_W_hf_max              =   2.7617854064167E-01
-(PID.TID 0000.0001) %MON pe_b_mean                    =   1.3519355960781E-02
-(PID.TID 0000.0001) %MON ke_max                       =   1.0997759666225E-02
-(PID.TID 0000.0001) %MON ke_mean                      =   4.3463076243132E-05
-(PID.TID 0000.0001) %MON ke_vol                       =   1.3604146891236E+22
-(PID.TID 0000.0001) %MON vort_r_min                   =  -6.5474257631794E-07
-(PID.TID 0000.0001) %MON vort_r_max                   =   7.4438508056853E-07
+(PID.TID 0000.0001) %MON forcing_fv_mean              =  -1.3697478643917E-02
+(PID.TID 0000.0001) %MON forcing_fv_sd                =   7.5554869632742E-02
+(PID.TID 0000.0001) %MON forcing_fv_del2              =   2.3767012624216E-04
+(PID.TID 0000.0001) %MON trAdv_CFL_u_max              =   4.4206063243254E-02
+(PID.TID 0000.0001) %MON trAdv_CFL_v_max              =   6.5544197569401E-02
+(PID.TID 0000.0001) %MON trAdv_CFL_w_max              =   2.2824485185863E-01
+(PID.TID 0000.0001) %MON advcfl_uvel_max              =   4.0645563521108E-02
+(PID.TID 0000.0001) %MON advcfl_vvel_max              =   5.0439357108521E-02
+(PID.TID 0000.0001) %MON advcfl_wvel_max              =   2.4998554153183E-01
+(PID.TID 0000.0001) %MON advcfl_W_hf_max              =   2.7617840980581E-01
+(PID.TID 0000.0001) %MON pe_b_mean                    =   1.3519359643328E-02
+(PID.TID 0000.0001) %MON ke_max                       =   1.0997748944714E-02
+(PID.TID 0000.0001) %MON ke_mean                      =   4.3463045382780E-05
+(PID.TID 0000.0001) %MON ke_vol                       =   1.3604146891906E+22
+(PID.TID 0000.0001) %MON vort_r_min                   =  -6.5473874539041E-07
+(PID.TID 0000.0001) %MON vort_r_max                   =   7.4438507951586E-07
 (PID.TID 0000.0001) %MON vort_a_mean                  =  -2.0556865257795E-05
-(PID.TID 0000.0001) %MON vort_a_sd                    =   7.5247416196616E-05
-(PID.TID 0000.0001) %MON vort_p_mean                  =  -2.4859231938764E-05
-(PID.TID 0000.0001) %MON vort_p_sd                    =   1.2920612660917E-04
-(PID.TID 0000.0001) %MON surfExpan_theta_mean         =   1.7421889966901E-03
-(PID.TID 0000.0001) %MON surfExpan_salt_mean          =  -3.9731240182327E-03
+(PID.TID 0000.0001) %MON vort_a_sd                    =   7.5247416196692E-05
+(PID.TID 0000.0001) %MON vort_p_mean                  =  -2.4859231937694E-05
+(PID.TID 0000.0001) %MON vort_p_sd                    =   1.2920612647165E-04
+(PID.TID 0000.0001) %MON surfExpan_theta_mean         =   1.7422071322219E-03
+(PID.TID 0000.0001) %MON surfExpan_salt_mean          =  -3.9737201191890E-03
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // End MONITOR dynamic field statistics
 (PID.TID 0000.0001) // =======================================================
@@ -4241,124 +4243,124 @@ listId=   2 ; file name: seaiceStDiag
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) %MON seaice_tsnumber              =                     7
 (PID.TID 0000.0001) %MON seaice_time_sec              =   6.0480000000000E+05
-(PID.TID 0000.0001) %MON seaice_uice_max              =   1.2380051626662E-01
-(PID.TID 0000.0001) %MON seaice_uice_min              =  -1.7560371479699E-01
-(PID.TID 0000.0001) %MON seaice_uice_mean             =  -5.8625968725422E-04
-(PID.TID 0000.0001) %MON seaice_uice_sd               =   1.2240326052805E-02
-(PID.TID 0000.0001) %MON seaice_uice_del2             =   1.7636114596030E-04
-(PID.TID 0000.0001) %MON seaice_vice_max              =   1.6087199519775E-01
-(PID.TID 0000.0001) %MON seaice_vice_min              =  -1.7121208913120E-01
-(PID.TID 0000.0001) %MON seaice_vice_mean             =   1.1519494196631E-03
-(PID.TID 0000.0001) %MON seaice_vice_sd               =   1.5520475977469E-02
-(PID.TID 0000.0001) %MON seaice_vice_del2             =   1.1752577858205E-04
-(PID.TID 0000.0001) %MON seaice_area_max              =   9.4565946578573E-01
+(PID.TID 0000.0001) %MON seaice_uice_max              =   1.2380051820828E-01
+(PID.TID 0000.0001) %MON seaice_uice_min              =  -1.7560371482007E-01
+(PID.TID 0000.0001) %MON seaice_uice_mean             =  -5.8625596676388E-04
+(PID.TID 0000.0001) %MON seaice_uice_sd               =   1.2240320642895E-02
+(PID.TID 0000.0001) %MON seaice_uice_del2             =   1.7636134095625E-04
+(PID.TID 0000.0001) %MON seaice_vice_max              =   1.6087197543638E-01
+(PID.TID 0000.0001) %MON seaice_vice_min              =  -1.7121210253390E-01
+(PID.TID 0000.0001) %MON seaice_vice_mean             =   1.1519579884288E-03
+(PID.TID 0000.0001) %MON seaice_vice_sd               =   1.5520493065203E-02
+(PID.TID 0000.0001) %MON seaice_vice_del2             =   1.1752582909728E-04
+(PID.TID 0000.0001) %MON seaice_area_max              =   9.4565946566656E-01
 (PID.TID 0000.0001) %MON seaice_area_min              =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON seaice_area_mean             =   2.0102533872126E-02
-(PID.TID 0000.0001) %MON seaice_area_sd               =   1.2819650713221E-01
-(PID.TID 0000.0001) %MON seaice_area_del2             =   9.8633223741965E-04
-(PID.TID 0000.0001) %MON seaice_heff_max              =   6.2489580830863E-01
+(PID.TID 0000.0001) %MON seaice_area_mean             =   2.0102245575574E-02
+(PID.TID 0000.0001) %MON seaice_area_sd               =   1.2819579229353E-01
+(PID.TID 0000.0001) %MON seaice_area_del2             =   9.8634583094186E-04
+(PID.TID 0000.0001) %MON seaice_heff_max              =   6.2489580803292E-01
 (PID.TID 0000.0001) %MON seaice_heff_min              =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON seaice_heff_mean             =   1.1791507252772E-02
-(PID.TID 0000.0001) %MON seaice_heff_sd               =   7.7005864103179E-02
-(PID.TID 0000.0001) %MON seaice_heff_del2             =   5.5101271260105E-04
-(PID.TID 0000.0001) %MON seaice_hsnow_max             =   1.2152458296475E-02
+(PID.TID 0000.0001) %MON seaice_heff_mean             =   1.1791467653777E-02
+(PID.TID 0000.0001) %MON seaice_heff_sd               =   7.7005826009262E-02
+(PID.TID 0000.0001) %MON seaice_heff_del2             =   5.5101567801295E-04
+(PID.TID 0000.0001) %MON seaice_hsnow_max             =   1.2152458307875E-02
 (PID.TID 0000.0001) %MON seaice_hsnow_min             =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON seaice_hsnow_mean            =   1.1329922036001E-04
-(PID.TID 0000.0001) %MON seaice_hsnow_sd              =   8.4549238818426E-04
-(PID.TID 0000.0001) %MON seaice_hsnow_del2            =   1.1324560365751E-05
+(PID.TID 0000.0001) %MON seaice_hsnow_mean            =   1.1329919355665E-04
+(PID.TID 0000.0001) %MON seaice_hsnow_sd              =   8.4549237799340E-04
+(PID.TID 0000.0001) %MON seaice_hsnow_del2            =   1.1324559345660E-05
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // End MONITOR SEAICE statistics
 (PID.TID 0000.0001) // =======================================================
  EXTERNAL_FIELDS_LOAD,         7 : iP,iLd,i0,i1=   12    1   12    1 ; Wght=  0.2666666667  0.7333333333
- SEAICE_LSR: Residual Initial ipass,Uice,Vice=         1  7.84011771E-04  4.65080461E-04
- SEAICE_LSR (ipass=        1) iters,dU,Resid=       26  2.49453236E-14  3.29805635E-16
- SEAICE_LSR (ipass=        1) iters,dV,Resid=       26  1.48839274E-13  5.24560410E-16
- SEAICE_LSR: Residual Initial ipass,Uice,Vice=         2  3.03271666E-04  1.73421429E-04
- SEAICE_LSR (ipass=        2) iters,dU,Resid=       24  8.32233588E-14  1.15238414E-15
- SEAICE_LSR (ipass=        2) iters,dV,Resid=       24  2.47191156E-13  9.51197803E-16
- cg2d: Sum(rhs),rhsMax =   3.44787828999006E-01  1.99022938825278E+01
-(PID.TID 0000.0001)      cg2d_init_res =   7.47046778143397E-02
+ SEAICE_LSR: Residual Initial ipass,Uice,Vice=         1  7.84009885E-04  4.65076813E-04
+ SEAICE_LSR (ipass=        1) iters,dU,Resid=       26  2.49383847E-14  3.29780589E-16
+ SEAICE_LSR (ipass=        1) iters,dV,Resid=       26  1.48853152E-13  5.24113697E-16
+ SEAICE_LSR: Residual Initial ipass,Uice,Vice=         2  3.03271517E-04  1.73420916E-04
+ SEAICE_LSR (ipass=        2) iters,dU,Resid=       24  8.32250935E-14  1.15232280E-15
+ SEAICE_LSR (ipass=        2) iters,dV,Resid=       24  2.47191156E-13  9.51257217E-16
+ cg2d: Sum(rhs),rhsMax =   3.44777960581898E-01  1.99022938823306E+01
+(PID.TID 0000.0001)      cg2d_init_res =   7.47038854670996E-02
 (PID.TID 0000.0001)      cg2d_iters(min,last) =      -1     101
-(PID.TID 0000.0001)      cg2d_last_res =   7.91097878565698E-10
+(PID.TID 0000.0001)      cg2d_last_res =   7.91116452294289E-10
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // Begin MONITOR dynamic field statistics
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) %MON time_tsnumber                =                     8
 (PID.TID 0000.0001) %MON time_secondsf                =   6.9120000000000E+05
-(PID.TID 0000.0001) %MON dynstat_eta_max              =   1.5258960171454E+04
-(PID.TID 0000.0001) %MON dynstat_eta_min              =  -2.2588194944125E+04
-(PID.TID 0000.0001) %MON dynstat_eta_mean             =  -1.0362762903304E+02
-(PID.TID 0000.0001) %MON dynstat_eta_sd               =   7.2825677890053E+03
-(PID.TID 0000.0001) %MON dynstat_eta_del2             =   9.4222561377277E+01
-(PID.TID 0000.0001) %MON dynstat_uvel_max             =   1.2230589666487E-01
-(PID.TID 0000.0001) %MON dynstat_uvel_min             =  -1.4423233898817E-01
-(PID.TID 0000.0001) %MON dynstat_uvel_mean            =  -4.0413376318021E-05
-(PID.TID 0000.0001) %MON dynstat_uvel_sd              =   7.5610260664325E-03
-(PID.TID 0000.0001) %MON dynstat_uvel_del2            =   3.6076791580728E-05
-(PID.TID 0000.0001) %MON dynstat_vvel_max             =   1.9391212830420E-01
-(PID.TID 0000.0001) %MON dynstat_vvel_min             =  -1.8030368271196E-01
-(PID.TID 0000.0001) %MON dynstat_vvel_mean            =  -4.9241213582589E-04
-(PID.TID 0000.0001) %MON dynstat_vvel_sd              =   7.7901763944607E-03
-(PID.TID 0000.0001) %MON dynstat_vvel_del2            =   3.7194199379396E-05
-(PID.TID 0000.0001) %MON dynstat_wvel_max             =   5.4269357441407E+00
-(PID.TID 0000.0001) %MON dynstat_wvel_min             =  -9.6713254848445E+00
-(PID.TID 0000.0001) %MON dynstat_wvel_mean            =  -6.0049479533738E-06
-(PID.TID 0000.0001) %MON dynstat_wvel_sd              =   2.5577032881899E-01
-(PID.TID 0000.0001) %MON dynstat_wvel_del2            =   1.9457828214331E-03
-(PID.TID 0000.0001) %MON dynstat_theta_max            =   2.9438771981149E+01
-(PID.TID 0000.0001) %MON dynstat_theta_min            =  -1.8943601382442E+00
-(PID.TID 0000.0001) %MON dynstat_theta_mean           =   3.5922804312922E+00
-(PID.TID 0000.0001) %MON dynstat_theta_sd             =   4.4289165898053E+00
-(PID.TID 0000.0001) %MON dynstat_theta_del2           =   2.3050335312676E-03
-(PID.TID 0000.0001) %MON dynstat_salt_max             =   4.0715808459173E+01
-(PID.TID 0000.0001) %MON dynstat_salt_min             =   1.6289448777444E+01
-(PID.TID 0000.0001) %MON dynstat_salt_mean            =   3.4721535834293E+01
-(PID.TID 0000.0001) %MON dynstat_salt_sd              =   4.8725103964767E-01
-(PID.TID 0000.0001) %MON dynstat_salt_del2            =   5.1343213441999E-04
-(PID.TID 0000.0001) %MON forcing_qnet_max             =   6.9645857577619E+02
-(PID.TID 0000.0001) %MON forcing_qnet_min             =  -3.1135072422576E+02
-(PID.TID 0000.0001) %MON forcing_qnet_mean            =  -2.7740407874297E+01
-(PID.TID 0000.0001) %MON forcing_qnet_sd              =   1.5109454315024E+02
-(PID.TID 0000.0001) %MON forcing_qnet_del2            =   9.8763028938142E-01
+(PID.TID 0000.0001) %MON dynstat_eta_max              =   1.5258959681620E+04
+(PID.TID 0000.0001) %MON dynstat_eta_min              =  -2.2588193559895E+04
+(PID.TID 0000.0001) %MON dynstat_eta_mean             =  -1.0362466303211E+02
+(PID.TID 0000.0001) %MON dynstat_eta_sd               =   7.2825660489255E+03
+(PID.TID 0000.0001) %MON dynstat_eta_del2             =   9.4222562393152E+01
+(PID.TID 0000.0001) %MON dynstat_uvel_max             =   1.2230591615315E-01
+(PID.TID 0000.0001) %MON dynstat_uvel_min             =  -1.4420757744228E-01
+(PID.TID 0000.0001) %MON dynstat_uvel_mean            =  -4.0413601889644E-05
+(PID.TID 0000.0001) %MON dynstat_uvel_sd              =   7.5610248887893E-03
+(PID.TID 0000.0001) %MON dynstat_uvel_del2            =   3.6076767181349E-05
+(PID.TID 0000.0001) %MON dynstat_vvel_max             =   1.9391015121811E-01
+(PID.TID 0000.0001) %MON dynstat_vvel_min             =  -1.8030347775239E-01
+(PID.TID 0000.0001) %MON dynstat_vvel_mean            =  -4.9241258810286E-04
+(PID.TID 0000.0001) %MON dynstat_vvel_sd              =   7.7901743330569E-03
+(PID.TID 0000.0001) %MON dynstat_vvel_del2            =   3.7194196527823E-05
+(PID.TID 0000.0001) %MON dynstat_wvel_max             =   5.4269257555973E+00
+(PID.TID 0000.0001) %MON dynstat_wvel_min             =  -9.6713174067502E+00
+(PID.TID 0000.0001) %MON dynstat_wvel_mean            =  -6.0012111797353E-06
+(PID.TID 0000.0001) %MON dynstat_wvel_sd              =   2.5577014205298E-01
+(PID.TID 0000.0001) %MON dynstat_wvel_del2            =   1.9457816266698E-03
+(PID.TID 0000.0001) %MON dynstat_theta_max            =   2.9438771981169E+01
+(PID.TID 0000.0001) %MON dynstat_theta_min            =  -1.8943601431987E+00
+(PID.TID 0000.0001) %MON dynstat_theta_mean           =   3.5922804204950E+00
+(PID.TID 0000.0001) %MON dynstat_theta_sd             =   4.4289167255531E+00
+(PID.TID 0000.0001) %MON dynstat_theta_del2           =   2.3050218548299E-03
+(PID.TID 0000.0001) %MON dynstat_salt_max             =   4.0715808459172E+01
+(PID.TID 0000.0001) %MON dynstat_salt_min             =   1.6289448781649E+01
+(PID.TID 0000.0001) %MON dynstat_salt_mean            =   3.4721535831898E+01
+(PID.TID 0000.0001) %MON dynstat_salt_sd              =   4.8725109963905E-01
+(PID.TID 0000.0001) %MON dynstat_salt_del2            =   5.1343232487742E-04
+(PID.TID 0000.0001) %MON forcing_qnet_max             =   6.9645864966771E+02
+(PID.TID 0000.0001) %MON forcing_qnet_min             =  -3.1135072560223E+02
+(PID.TID 0000.0001) %MON forcing_qnet_mean            =  -2.7739161215915E+01
+(PID.TID 0000.0001) %MON forcing_qnet_sd              =   1.5109545991253E+02
+(PID.TID 0000.0001) %MON forcing_qnet_del2            =   9.8762760048143E-01
 (PID.TID 0000.0001) %MON forcing_qsw_max              =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON forcing_qsw_min              =  -3.0183129457886E+02
-(PID.TID 0000.0001) %MON forcing_qsw_mean             =  -1.8596948126549E+02
-(PID.TID 0000.0001) %MON forcing_qsw_sd               =   7.8572368848569E+01
-(PID.TID 0000.0001) %MON forcing_qsw_del2             =   1.1074849619966E-01
-(PID.TID 0000.0001) %MON forcing_empmr_max            =   1.6190670316917E-03
-(PID.TID 0000.0001) %MON forcing_empmr_min            =  -4.5708705957279E-04
-(PID.TID 0000.0001) %MON forcing_empmr_mean           =   1.3540409069664E-05
-(PID.TID 0000.0001) %MON forcing_empmr_sd             =   1.1074980349474E-04
-(PID.TID 0000.0001) %MON forcing_empmr_del2           =   1.7285029206764E-06
+(PID.TID 0000.0001) %MON forcing_qsw_mean             =  -1.8596948126568E+02
+(PID.TID 0000.0001) %MON forcing_qsw_sd               =   7.8572368848108E+01
+(PID.TID 0000.0001) %MON forcing_qsw_del2             =   1.1074849619963E-01
+(PID.TID 0000.0001) %MON forcing_empmr_max            =   1.6190670158027E-03
+(PID.TID 0000.0001) %MON forcing_empmr_min            =  -4.5708705957876E-04
+(PID.TID 0000.0001) %MON forcing_empmr_mean           =   1.3537284814076E-05
+(PID.TID 0000.0001) %MON forcing_empmr_sd             =   1.1072045765128E-04
+(PID.TID 0000.0001) %MON forcing_empmr_del2           =   1.7282995420497E-06
 (PID.TID 0000.0001) %MON forcing_fu_max               =   2.4726979082249E-01
 (PID.TID 0000.0001) %MON forcing_fu_min               =  -2.2495248635365E-01
-(PID.TID 0000.0001) %MON forcing_fu_mean              =  -4.1948264350584E-03
-(PID.TID 0000.0001) %MON forcing_fu_sd                =   6.4265979219148E-02
-(PID.TID 0000.0001) %MON forcing_fu_del2              =   2.1090617759496E-04
+(PID.TID 0000.0001) %MON forcing_fu_mean              =  -4.1948263773107E-03
+(PID.TID 0000.0001) %MON forcing_fu_sd                =   6.4265979198157E-02
+(PID.TID 0000.0001) %MON forcing_fu_del2              =   2.1090617733586E-04
 (PID.TID 0000.0001) %MON forcing_fv_max               =   2.7159367144430E-01
 (PID.TID 0000.0001) %MON forcing_fv_min               =  -3.3243525155752E-01
-(PID.TID 0000.0001) %MON forcing_fv_mean              =  -1.3697937133067E-02
-(PID.TID 0000.0001) %MON forcing_fv_sd                =   7.5649849203593E-02
-(PID.TID 0000.0001) %MON forcing_fv_del2              =   2.3882639630366E-04
-(PID.TID 0000.0001) %MON trAdv_CFL_u_max              =   4.5062789061951E-02
-(PID.TID 0000.0001) %MON trAdv_CFL_v_max              =   7.1536840377808E-02
-(PID.TID 0000.0001) %MON trAdv_CFL_w_max              =   2.4801018355592E-01
-(PID.TID 0000.0001) %MON advcfl_uvel_max              =   4.4568950799642E-02
-(PID.TID 0000.0001) %MON advcfl_vvel_max              =   5.4936664998500E-02
-(PID.TID 0000.0001) %MON advcfl_wvel_max              =   2.7164743854869E-01
-(PID.TID 0000.0001) %MON advcfl_W_hf_max              =   3.0009464639556E-01
-(PID.TID 0000.0001) %MON pe_b_mean                    =   1.3515411915763E-02
-(PID.TID 0000.0001) %MON ke_max                       =   1.3164552916653E-02
-(PID.TID 0000.0001) %MON ke_mean                      =   5.4531615006063E-05
-(PID.TID 0000.0001) %MON ke_vol                       =   1.3604143151705E+22
-(PID.TID 0000.0001) %MON vort_r_min                   =  -7.1536024377307E-07
-(PID.TID 0000.0001) %MON vort_r_max                   =   8.0479085135927E-07
+(PID.TID 0000.0001) %MON forcing_fv_mean              =  -1.3697937258375E-02
+(PID.TID 0000.0001) %MON forcing_fv_sd                =   7.5649849119089E-02
+(PID.TID 0000.0001) %MON forcing_fv_del2              =   2.3882639730304E-04
+(PID.TID 0000.0001) %MON trAdv_CFL_u_max              =   4.5062772274094E-02
+(PID.TID 0000.0001) %MON trAdv_CFL_v_max              =   7.1536765942262E-02
+(PID.TID 0000.0001) %MON trAdv_CFL_w_max              =   2.4800999644881E-01
+(PID.TID 0000.0001) %MON advcfl_uvel_max              =   4.4568948880118E-02
+(PID.TID 0000.0001) %MON advcfl_vvel_max              =   5.4936660478855E-02
+(PID.TID 0000.0001) %MON advcfl_wvel_max              =   2.7164723342493E-01
+(PID.TID 0000.0001) %MON advcfl_W_hf_max              =   3.0009441999420E-01
+(PID.TID 0000.0001) %MON pe_b_mean                    =   1.3515414642395E-02
+(PID.TID 0000.0001) %MON ke_max                       =   1.3164533477702E-02
+(PID.TID 0000.0001) %MON ke_mean                      =   5.4531592136650E-05
+(PID.TID 0000.0001) %MON ke_vol                       =   1.3604143151821E+22
+(PID.TID 0000.0001) %MON vort_r_min                   =  -7.1535409162125E-07
+(PID.TID 0000.0001) %MON vort_r_max                   =   8.0479084720813E-07
 (PID.TID 0000.0001) %MON vort_a_mean                  =  -2.0556865257795E-05
-(PID.TID 0000.0001) %MON vort_a_sd                    =   7.5247442376099E-05
-(PID.TID 0000.0001) %MON vort_p_mean                  =  -2.4859237494861E-05
-(PID.TID 0000.0001) %MON vort_p_sd                    =   1.2920599051224E-04
-(PID.TID 0000.0001) %MON surfExpan_theta_mean         =   1.0634865291266E-04
-(PID.TID 0000.0001) %MON surfExpan_salt_mean          =  -4.3488189318201E-03
+(PID.TID 0000.0001) %MON vort_a_sd                    =   7.5247442376059E-05
+(PID.TID 0000.0001) %MON vort_p_mean                  =  -2.4859237494377E-05
+(PID.TID 0000.0001) %MON vort_p_sd                    =   1.2920599029619E-04
+(PID.TID 0000.0001) %MON surfExpan_theta_mean         =   1.0635345957909E-04
+(PID.TID 0000.0001) %MON surfExpan_salt_mean          =  -4.3477838065110E-03
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // End MONITOR dynamic field statistics
 (PID.TID 0000.0001) // =======================================================
@@ -4367,124 +4369,124 @@ listId=   2 ; file name: seaiceStDiag
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) %MON seaice_tsnumber              =                     8
 (PID.TID 0000.0001) %MON seaice_time_sec              =   6.9120000000000E+05
-(PID.TID 0000.0001) %MON seaice_uice_max              =   1.7834933829788E-01
-(PID.TID 0000.0001) %MON seaice_uice_min              =  -2.0958605384522E-01
-(PID.TID 0000.0001) %MON seaice_uice_mean             =  -5.7058167001799E-04
-(PID.TID 0000.0001) %MON seaice_uice_sd               =   1.4064683353171E-02
-(PID.TID 0000.0001) %MON seaice_uice_del2             =   2.2969746101197E-04
-(PID.TID 0000.0001) %MON seaice_vice_max              =   1.6318933765426E-01
-(PID.TID 0000.0001) %MON seaice_vice_min              =  -1.7733465443334E-01
-(PID.TID 0000.0001) %MON seaice_vice_mean             =   1.2352732184135E-03
-(PID.TID 0000.0001) %MON seaice_vice_sd               =   1.5667884964241E-02
-(PID.TID 0000.0001) %MON seaice_vice_del2             =   1.2094463352133E-04
-(PID.TID 0000.0001) %MON seaice_area_max              =   9.6695283055931E-01
+(PID.TID 0000.0001) %MON seaice_uice_max              =   1.7834935911793E-01
+(PID.TID 0000.0001) %MON seaice_uice_min              =  -2.0958604516927E-01
+(PID.TID 0000.0001) %MON seaice_uice_mean             =  -5.7057897259927E-04
+(PID.TID 0000.0001) %MON seaice_uice_sd               =   1.4064670245220E-02
+(PID.TID 0000.0001) %MON seaice_uice_del2             =   2.2969740933528E-04
+(PID.TID 0000.0001) %MON seaice_vice_max              =   1.6318905434500E-01
+(PID.TID 0000.0001) %MON seaice_vice_min              =  -1.7733468405446E-01
+(PID.TID 0000.0001) %MON seaice_vice_mean             =   1.2352735066855E-03
+(PID.TID 0000.0001) %MON seaice_vice_sd               =   1.5667881345568E-02
+(PID.TID 0000.0001) %MON seaice_vice_del2             =   1.2094468751886E-04
+(PID.TID 0000.0001) %MON seaice_area_max              =   9.6695283018647E-01
 (PID.TID 0000.0001) %MON seaice_area_min              =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON seaice_area_mean             =   2.1864708477054E-02
-(PID.TID 0000.0001) %MON seaice_area_sd               =   1.3606379439172E-01
-(PID.TID 0000.0001) %MON seaice_area_del2             =   9.8650306424196E-04
-(PID.TID 0000.0001) %MON seaice_heff_max              =   6.6718623756519E-01
+(PID.TID 0000.0001) %MON seaice_area_mean             =   2.1864498795843E-02
+(PID.TID 0000.0001) %MON seaice_area_sd               =   1.3606306622400E-01
+(PID.TID 0000.0001) %MON seaice_area_del2             =   9.8652396537426E-04
+(PID.TID 0000.0001) %MON seaice_heff_max              =   6.6718623690554E-01
 (PID.TID 0000.0001) %MON seaice_heff_min              =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON seaice_heff_mean             =   1.3301436263542E-02
-(PID.TID 0000.0001) %MON seaice_heff_sd               =   8.4567271247894E-02
-(PID.TID 0000.0001) %MON seaice_heff_del2             =   5.7290682905218E-04
-(PID.TID 0000.0001) %MON seaice_hsnow_max             =   1.5479030469956E-02
+(PID.TID 0000.0001) %MON seaice_heff_mean             =   1.3301097350387E-02
+(PID.TID 0000.0001) %MON seaice_heff_sd               =   8.4566566079047E-02
+(PID.TID 0000.0001) %MON seaice_heff_del2             =   5.7292540024456E-04
+(PID.TID 0000.0001) %MON seaice_hsnow_max             =   1.5479030559524E-02
 (PID.TID 0000.0001) %MON seaice_hsnow_min             =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON seaice_hsnow_mean            =   1.4987753141536E-04
-(PID.TID 0000.0001) %MON seaice_hsnow_sd              =   1.0946473225953E-03
-(PID.TID 0000.0001) %MON seaice_hsnow_del2            =   1.4568544265251E-05
+(PID.TID 0000.0001) %MON seaice_hsnow_mean            =   1.4987718929565E-04
+(PID.TID 0000.0001) %MON seaice_hsnow_sd              =   1.0946472399272E-03
+(PID.TID 0000.0001) %MON seaice_hsnow_del2            =   1.4568545170757E-05
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // End MONITOR SEAICE statistics
 (PID.TID 0000.0001) // =======================================================
  EXTERNAL_FIELDS_LOAD,         8 : iP,iLd,i0,i1=   12    1   12    1 ; Wght=  0.2333333333  0.7666666667
- SEAICE_LSR: Residual Initial ipass,Uice,Vice=         1  5.28188382E-04  5.26283526E-04
- SEAICE_LSR (ipass=        1) iters,dU,Resid=       34  1.51836876E-13  4.85146730E-15
- SEAICE_LSR (ipass=        1) iters,dV,Resid=       34  3.94434485E-13  9.12332826E-15
- SEAICE_LSR: Residual Initial ipass,Uice,Vice=         2  2.54141431E-04  2.23170658E-04
- SEAICE_LSR (ipass=        2) iters,dU,Resid=       32  2.93619296E-13  9.75121332E-15
- SEAICE_LSR (ipass=        2) iters,dV,Resid=       32  4.81586993E-13  1.17836576E-14
- cg2d: Sum(rhs),rhsMax =   3.75459259988693E-01  1.99064490112570E+01
-(PID.TID 0000.0001)      cg2d_init_res =   7.47164554225904E-02
+ SEAICE_LSR: Residual Initial ipass,Uice,Vice=         1  5.28183549E-04  5.26265596E-04
+ SEAICE_LSR (ipass=        1) iters,dU,Resid=       34  1.51836876E-13  4.85148892E-15
+ SEAICE_LSR (ipass=        1) iters,dV,Resid=       34  3.94462241E-13  9.12435494E-15
+ SEAICE_LSR: Residual Initial ipass,Uice,Vice=         2  2.54139260E-04  2.23169242E-04
+ SEAICE_LSR (ipass=        2) iters,dU,Resid=       32  2.93619296E-13  9.75135683E-15
+ SEAICE_LSR (ipass=        2) iters,dV,Resid=       32  4.81586993E-13  1.17839033E-14
+ cg2d: Sum(rhs),rhsMax =   3.75450914201533E-01  1.99064490119921E+01
+(PID.TID 0000.0001)      cg2d_init_res =   7.47155599286233E-02
 (PID.TID 0000.0001)      cg2d_iters(min,last) =      -1     101
-(PID.TID 0000.0001)      cg2d_last_res =   8.12560133455258E-10
+(PID.TID 0000.0001)      cg2d_last_res =   8.12542246192596E-10
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // Begin MONITOR dynamic field statistics
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) %MON time_tsnumber                =                     9
 (PID.TID 0000.0001) %MON time_secondsf                =   7.7760000000000E+05
-(PID.TID 0000.0001) %MON dynstat_eta_max              =   1.5337114937583E+04
-(PID.TID 0000.0001) %MON dynstat_eta_min              =  -2.2028170153378E+04
-(PID.TID 0000.0001) %MON dynstat_eta_mean             =  -1.1286963372633E+02
-(PID.TID 0000.0001) %MON dynstat_eta_sd               =   7.2626903690756E+03
-(PID.TID 0000.0001) %MON dynstat_eta_del2             =   9.4326993688039E+01
-(PID.TID 0000.0001) %MON dynstat_uvel_max             =   1.3207784169512E-01
-(PID.TID 0000.0001) %MON dynstat_uvel_min             =  -1.5444577904238E-01
-(PID.TID 0000.0001) %MON dynstat_uvel_mean            =   2.5030934633050E-05
-(PID.TID 0000.0001) %MON dynstat_uvel_sd              =   8.3314507337099E-03
-(PID.TID 0000.0001) %MON dynstat_uvel_del2            =   3.8258400149785E-05
-(PID.TID 0000.0001) %MON dynstat_vvel_max             =   2.0644460191657E-01
-(PID.TID 0000.0001) %MON dynstat_vvel_min             =  -1.9269351529441E-01
-(PID.TID 0000.0001) %MON dynstat_vvel_mean            =  -4.5360400760860E-04
-(PID.TID 0000.0001) %MON dynstat_vvel_sd              =   8.5807662213869E-03
-(PID.TID 0000.0001) %MON dynstat_vvel_del2            =   3.9373637541925E-05
-(PID.TID 0000.0001) %MON dynstat_wvel_max             =   5.6012773532031E+00
-(PID.TID 0000.0001) %MON dynstat_wvel_min             =  -1.0308899990410E+01
-(PID.TID 0000.0001) %MON dynstat_wvel_mean            =   6.2159879662619E-05
-(PID.TID 0000.0001) %MON dynstat_wvel_sd              =   2.6779665278977E-01
-(PID.TID 0000.0001) %MON dynstat_wvel_del2            =   1.9974739808093E-03
-(PID.TID 0000.0001) %MON dynstat_theta_max            =   2.9443921619034E+01
-(PID.TID 0000.0001) %MON dynstat_theta_min            =  -1.9013704199928E+00
-(PID.TID 0000.0001) %MON dynstat_theta_mean           =   3.5924415875412E+00
-(PID.TID 0000.0001) %MON dynstat_theta_sd             =   4.4293494713789E+00
-(PID.TID 0000.0001) %MON dynstat_theta_del2           =   2.2956173656768E-03
+(PID.TID 0000.0001) %MON dynstat_eta_max              =   1.5337114212024E+04
+(PID.TID 0000.0001) %MON dynstat_eta_min              =  -2.2028168354116E+04
+(PID.TID 0000.0001) %MON dynstat_eta_mean             =  -1.1286712484061E+02
+(PID.TID 0000.0001) %MON dynstat_eta_sd               =   7.2626893195343E+03
+(PID.TID 0000.0001) %MON dynstat_eta_del2             =   9.4326987376924E+01
+(PID.TID 0000.0001) %MON dynstat_uvel_max             =   1.3207783574919E-01
+(PID.TID 0000.0001) %MON dynstat_uvel_min             =  -1.5442024172421E-01
+(PID.TID 0000.0001) %MON dynstat_uvel_mean            =   2.5030836567155E-05
+(PID.TID 0000.0001) %MON dynstat_uvel_sd              =   8.3314485740997E-03
+(PID.TID 0000.0001) %MON dynstat_uvel_del2            =   3.8258381102217E-05
+(PID.TID 0000.0001) %MON dynstat_vvel_max             =   2.0644174066235E-01
+(PID.TID 0000.0001) %MON dynstat_vvel_min             =  -1.9269324111797E-01
+(PID.TID 0000.0001) %MON dynstat_vvel_mean            =  -4.5360473019830E-04
+(PID.TID 0000.0001) %MON dynstat_vvel_sd              =   8.5807626824926E-03
+(PID.TID 0000.0001) %MON dynstat_vvel_del2            =   3.9373626895046E-05
+(PID.TID 0000.0001) %MON dynstat_wvel_max             =   5.6012650985836E+00
+(PID.TID 0000.0001) %MON dynstat_wvel_min             =  -1.0308888422445E+01
+(PID.TID 0000.0001) %MON dynstat_wvel_mean            =   6.2161138186348E-05
+(PID.TID 0000.0001) %MON dynstat_wvel_sd              =   2.6779644378159E-01
+(PID.TID 0000.0001) %MON dynstat_wvel_del2            =   1.9974724917306E-03
+(PID.TID 0000.0001) %MON dynstat_theta_max            =   2.9443921619062E+01
+(PID.TID 0000.0001) %MON dynstat_theta_min            =  -1.9013704234445E+00
+(PID.TID 0000.0001) %MON dynstat_theta_mean           =   3.5924415780659E+00
+(PID.TID 0000.0001) %MON dynstat_theta_sd             =   4.4293494695673E+00
+(PID.TID 0000.0001) %MON dynstat_theta_del2           =   2.2959003664380E-03
 (PID.TID 0000.0001) %MON dynstat_salt_max             =   4.0715781399077E+01
-(PID.TID 0000.0001) %MON dynstat_salt_min             =   1.5951592584123E+01
-(PID.TID 0000.0001) %MON dynstat_salt_mean            =   3.4721542793058E+01
-(PID.TID 0000.0001) %MON dynstat_salt_sd              =   4.8722666260948E-01
-(PID.TID 0000.0001) %MON dynstat_salt_del2            =   5.0884351735623E-04
-(PID.TID 0000.0001) %MON forcing_qnet_max             =   7.0076787275899E+02
-(PID.TID 0000.0001) %MON forcing_qnet_min             =  -3.1324794358945E+02
-(PID.TID 0000.0001) %MON forcing_qnet_mean            =  -2.7361056441962E+01
-(PID.TID 0000.0001) %MON forcing_qnet_sd              =   1.4950246002781E+02
-(PID.TID 0000.0001) %MON forcing_qnet_del2            =   8.9657133575897E-01
+(PID.TID 0000.0001) %MON dynstat_salt_min             =   1.5951592596386E+01
+(PID.TID 0000.0001) %MON dynstat_salt_mean            =   3.4721542790961E+01
+(PID.TID 0000.0001) %MON dynstat_salt_sd              =   4.8722671549479E-01
+(PID.TID 0000.0001) %MON dynstat_salt_del2            =   5.0884920016591E-04
+(PID.TID 0000.0001) %MON forcing_qnet_max             =   7.0076884667274E+02
+(PID.TID 0000.0001) %MON forcing_qnet_min             =  -3.1324794627445E+02
+(PID.TID 0000.0001) %MON forcing_qnet_mean            =  -2.7361317785886E+01
+(PID.TID 0000.0001) %MON forcing_qnet_sd              =   1.4950043157637E+02
+(PID.TID 0000.0001) %MON forcing_qnet_del2            =   8.9646657262389E-01
 (PID.TID 0000.0001) %MON forcing_qsw_max              =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON forcing_qsw_min              =  -3.0181929764305E+02
-(PID.TID 0000.0001) %MON forcing_qsw_mean             =  -1.8597531882428E+02
-(PID.TID 0000.0001) %MON forcing_qsw_sd               =   7.8478432782533E+01
-(PID.TID 0000.0001) %MON forcing_qsw_del2             =   1.1102150640878E-01
-(PID.TID 0000.0001) %MON forcing_empmr_max            =   1.4380704894109E-03
-(PID.TID 0000.0001) %MON forcing_empmr_min            =  -4.5888898019391E-04
-(PID.TID 0000.0001) %MON forcing_empmr_mean           =   1.0903939542617E-05
-(PID.TID 0000.0001) %MON forcing_empmr_sd             =   9.2984738797948E-05
-(PID.TID 0000.0001) %MON forcing_empmr_del2           =   1.4700212944129E-06
+(PID.TID 0000.0001) %MON forcing_qsw_mean             =  -1.8597531882431E+02
+(PID.TID 0000.0001) %MON forcing_qsw_sd               =   7.8478432782470E+01
+(PID.TID 0000.0001) %MON forcing_qsw_del2             =   1.1102150640893E-01
+(PID.TID 0000.0001) %MON forcing_empmr_max            =   1.4380294087654E-03
+(PID.TID 0000.0001) %MON forcing_empmr_min            =  -4.5888898020796E-04
+(PID.TID 0000.0001) %MON forcing_empmr_mean           =   1.0904478858147E-05
+(PID.TID 0000.0001) %MON forcing_empmr_sd             =   9.2989415970145E-05
+(PID.TID 0000.0001) %MON forcing_empmr_del2           =   1.4700609653470E-06
 (PID.TID 0000.0001) %MON forcing_fu_max               =   2.4722174155228E-01
 (PID.TID 0000.0001) %MON forcing_fu_min               =  -2.2809828301201E-01
-(PID.TID 0000.0001) %MON forcing_fu_mean              =  -4.1432638279679E-03
-(PID.TID 0000.0001) %MON forcing_fu_sd                =   6.4366317078742E-02
-(PID.TID 0000.0001) %MON forcing_fu_del2              =   2.1254653108223E-04
+(PID.TID 0000.0001) %MON forcing_fu_mean              =  -4.1432646346498E-03
+(PID.TID 0000.0001) %MON forcing_fu_sd                =   6.4366316866720E-02
+(PID.TID 0000.0001) %MON forcing_fu_del2              =   2.1254653390060E-04
 (PID.TID 0000.0001) %MON forcing_fv_max               =   2.7427691301694E-01
 (PID.TID 0000.0001) %MON forcing_fv_min               =  -3.3322315549145E-01
-(PID.TID 0000.0001) %MON forcing_fv_mean              =  -1.3700131539919E-02
-(PID.TID 0000.0001) %MON forcing_fv_sd                =   7.5749137571901E-02
-(PID.TID 0000.0001) %MON forcing_fv_del2              =   2.4014977025264E-04
-(PID.TID 0000.0001) %MON trAdv_CFL_u_max              =   4.7681964399794E-02
-(PID.TID 0000.0001) %MON trAdv_CFL_v_max              =   7.6412995843834E-02
-(PID.TID 0000.0001) %MON trAdv_CFL_w_max              =   2.6363727055232E-01
-(PID.TID 0000.0001) %MON advcfl_uvel_max              =   4.7772504587042E-02
-(PID.TID 0000.0001) %MON advcfl_vvel_max              =   5.9236598252955E-02
-(PID.TID 0000.0001) %MON advcfl_wvel_max              =   2.8877497046123E-01
-(PID.TID 0000.0001) %MON advcfl_W_hf_max              =   3.1900356811457E-01
-(PID.TID 0000.0001) %MON pe_b_mean                    =   1.3540848467445E-02
-(PID.TID 0000.0001) %MON ke_max                       =   1.5119669190741E-02
-(PID.TID 0000.0001) %MON ke_mean                      =   6.6143625475416E-05
-(PID.TID 0000.0001) %MON ke_vol                       =   1.3604138975510E+22
-(PID.TID 0000.0001) %MON vort_r_min                   =  -7.6648160334981E-07
-(PID.TID 0000.0001) %MON vort_r_max                   =   8.5160167559439E-07
+(PID.TID 0000.0001) %MON forcing_fv_mean              =  -1.3700130484330E-02
+(PID.TID 0000.0001) %MON forcing_fv_sd                =   7.5749137942292E-02
+(PID.TID 0000.0001) %MON forcing_fv_del2              =   2.4014976562403E-04
+(PID.TID 0000.0001) %MON trAdv_CFL_u_max              =   4.7681962832422E-02
+(PID.TID 0000.0001) %MON trAdv_CFL_v_max              =   7.6412894657842E-02
+(PID.TID 0000.0001) %MON trAdv_CFL_w_max              =   2.6363699524605E-01
+(PID.TID 0000.0001) %MON advcfl_uvel_max              =   4.7772503016119E-02
+(PID.TID 0000.0001) %MON advcfl_vvel_max              =   5.9236594986982E-02
+(PID.TID 0000.0001) %MON advcfl_wvel_max              =   2.8877466863140E-01
+(PID.TID 0000.0001) %MON advcfl_W_hf_max              =   3.1900323499140E-01
+(PID.TID 0000.0001) %MON pe_b_mean                    =   1.3540852149311E-02
+(PID.TID 0000.0001) %MON ke_max                       =   1.5119639109435E-02
+(PID.TID 0000.0001) %MON ke_mean                      =   6.6143581062836E-05
+(PID.TID 0000.0001) %MON ke_vol                       =   1.3604138976589E+22
+(PID.TID 0000.0001) %MON vort_r_min                   =  -7.6647290029092E-07
+(PID.TID 0000.0001) %MON vort_r_max                   =   8.5160166368359E-07
 (PID.TID 0000.0001) %MON vort_a_mean                  =  -2.0556865257795E-05
-(PID.TID 0000.0001) %MON vort_a_sd                    =   7.5247465020263E-05
-(PID.TID 0000.0001) %MON vort_p_mean                  =  -2.4859241655756E-05
-(PID.TID 0000.0001) %MON vort_p_sd                    =   1.2920586832074E-04
-(PID.TID 0000.0001) %MON surfExpan_theta_mean         =  -1.0196459205534E-03
-(PID.TID 0000.0001) %MON surfExpan_salt_mean          =  -3.3598992830310E-03
+(PID.TID 0000.0001) %MON vort_a_sd                    =   7.5247465020122E-05
+(PID.TID 0000.0001) %MON vort_p_mean                  =  -2.4859241653960E-05
+(PID.TID 0000.0001) %MON vort_p_sd                    =   1.2920586788765E-04
+(PID.TID 0000.0001) %MON surfExpan_theta_mean         =  -1.0196472771719E-03
+(PID.TID 0000.0001) %MON surfExpan_salt_mean          =  -3.3600696936737E-03
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // End MONITOR dynamic field statistics
 (PID.TID 0000.0001) // =======================================================
@@ -4493,124 +4495,124 @@ listId=   2 ; file name: seaiceStDiag
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) %MON seaice_tsnumber              =                     9
 (PID.TID 0000.0001) %MON seaice_time_sec              =   7.7760000000000E+05
-(PID.TID 0000.0001) %MON seaice_uice_max              =   1.7245246295070E-01
-(PID.TID 0000.0001) %MON seaice_uice_min              =  -2.2713472540308E-01
-(PID.TID 0000.0001) %MON seaice_uice_mean             =  -6.6674813623499E-04
-(PID.TID 0000.0001) %MON seaice_uice_sd               =   1.4899260313228E-02
-(PID.TID 0000.0001) %MON seaice_uice_del2             =   2.3207089833700E-04
-(PID.TID 0000.0001) %MON seaice_vice_max              =   1.6584903296750E-01
-(PID.TID 0000.0001) %MON seaice_vice_min              =  -1.8453310155105E-01
-(PID.TID 0000.0001) %MON seaice_vice_mean             =   1.3252831557036E-03
-(PID.TID 0000.0001) %MON seaice_vice_sd               =   1.5909821206588E-02
-(PID.TID 0000.0001) %MON seaice_vice_del2             =   1.3695994301835E-04
-(PID.TID 0000.0001) %MON seaice_area_max              =   9.8126604692735E-01
+(PID.TID 0000.0001) %MON seaice_uice_max              =   1.7245251978562E-01
+(PID.TID 0000.0001) %MON seaice_uice_min              =  -2.2713471498286E-01
+(PID.TID 0000.0001) %MON seaice_uice_mean             =  -6.6677528162763E-04
+(PID.TID 0000.0001) %MON seaice_uice_sd               =   1.4899389762502E-02
+(PID.TID 0000.0001) %MON seaice_uice_del2             =   2.3207073471727E-04
+(PID.TID 0000.0001) %MON seaice_vice_max              =   1.6584463097105E-01
+(PID.TID 0000.0001) %MON seaice_vice_min              =  -1.8453316829986E-01
+(PID.TID 0000.0001) %MON seaice_vice_mean             =   1.3252900548820E-03
+(PID.TID 0000.0001) %MON seaice_vice_sd               =   1.5909810010815E-02
+(PID.TID 0000.0001) %MON seaice_vice_del2             =   1.3695993066405E-04
+(PID.TID 0000.0001) %MON seaice_area_max              =   9.8126604726016E-01
 (PID.TID 0000.0001) %MON seaice_area_min              =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON seaice_area_mean             =   2.3321780857855E-02
-(PID.TID 0000.0001) %MON seaice_area_sd               =   1.4241926688389E-01
-(PID.TID 0000.0001) %MON seaice_area_del2             =   9.3939922835679E-04
-(PID.TID 0000.0001) %MON seaice_heff_max              =   7.0559760364944E-01
+(PID.TID 0000.0001) %MON seaice_area_mean             =   2.3321636089815E-02
+(PID.TID 0000.0001) %MON seaice_area_sd               =   1.4241863878700E-01
+(PID.TID 0000.0001) %MON seaice_area_del2             =   9.3939882770105E-04
+(PID.TID 0000.0001) %MON seaice_heff_max              =   7.0559760305798E-01
 (PID.TID 0000.0001) %MON seaice_heff_min              =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON seaice_heff_mean             =   1.4557543757836E-02
-(PID.TID 0000.0001) %MON seaice_heff_sd               =   9.1060460994025E-02
-(PID.TID 0000.0001) %MON seaice_heff_del2             =   5.6810563212809E-04
-(PID.TID 0000.0001) %MON seaice_hsnow_max             =   1.8937109996440E-02
+(PID.TID 0000.0001) %MON seaice_heff_mean             =   1.4557255480717E-02
+(PID.TID 0000.0001) %MON seaice_heff_sd               =   9.1059633811529E-02
+(PID.TID 0000.0001) %MON seaice_heff_del2             =   5.6811258924014E-04
+(PID.TID 0000.0001) %MON seaice_hsnow_max             =   1.8937109612266E-02
 (PID.TID 0000.0001) %MON seaice_hsnow_min             =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON seaice_hsnow_mean            =   1.9073675312087E-04
-(PID.TID 0000.0001) %MON seaice_hsnow_sd              =   1.3647402460495E-03
-(PID.TID 0000.0001) %MON seaice_hsnow_del2            =   1.7491250916360E-05
+(PID.TID 0000.0001) %MON seaice_hsnow_mean            =   1.9073567018844E-04
+(PID.TID 0000.0001) %MON seaice_hsnow_sd              =   1.3647398367319E-03
+(PID.TID 0000.0001) %MON seaice_hsnow_del2            =   1.7491349829897E-05
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // End MONITOR SEAICE statistics
 (PID.TID 0000.0001) // =======================================================
  EXTERNAL_FIELDS_LOAD,         9 : iP,iLd,i0,i1=   12    1   12    1 ; Wght=  0.2000000000  0.8000000000
- SEAICE_LSR: Residual Initial ipass,Uice,Vice=         1  4.47377613E-04  5.83547697E-04
- SEAICE_LSR (ipass=        1) iters,dU,Resid=       44  1.49068258E-13  8.80778533E-15
- SEAICE_LSR (ipass=        1) iters,dV,Resid=       44  5.32587863E-13  2.66647463E-14
- SEAICE_LSR: Residual Initial ipass,Uice,Vice=         2  2.88171415E-04  2.91685873E-04
- SEAICE_LSR (ipass=        2) iters,dU,Resid=       42  1.91797966E-13  1.15586544E-14
- SEAICE_LSR (ipass=        2) iters,dV,Resid=       42  4.84834395E-13  2.49093264E-14
- cg2d: Sum(rhs),rhsMax =   4.11206018440665E-01  1.99115794589270E+01
-(PID.TID 0000.0001)      cg2d_init_res =   7.40332349857585E-02
+ SEAICE_LSR: Residual Initial ipass,Uice,Vice=         1  4.47373789E-04  5.83540544E-04
+ SEAICE_LSR (ipass=        1) iters,dU,Resid=       44  1.49082136E-13  8.80852194E-15
+ SEAICE_LSR (ipass=        1) iters,dV,Resid=       44  5.32573985E-13  2.66650523E-14
+ SEAICE_LSR: Residual Initial ipass,Uice,Vice=         2  2.88171896E-04  2.91684281E-04
+ SEAICE_LSR (ipass=        2) iters,dU,Resid=       42  1.91804905E-13  1.15582755E-14
+ SEAICE_LSR (ipass=        2) iters,dV,Resid=       42  4.84848273E-13  2.49110202E-14
+ cg2d: Sum(rhs),rhsMax =   4.11196932313765E-01  1.99115794601055E+01
+(PID.TID 0000.0001)      cg2d_init_res =   7.40329262482598E-02
 (PID.TID 0000.0001)      cg2d_iters(min,last) =      -1      99
-(PID.TID 0000.0001)      cg2d_last_res =   9.86540414514610E-10
+(PID.TID 0000.0001)      cg2d_last_res =   9.86532756215736E-10
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // Begin MONITOR dynamic field statistics
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) %MON time_tsnumber                =                    10
 (PID.TID 0000.0001) %MON time_secondsf                =   8.6400000000000E+05
-(PID.TID 0000.0001) %MON dynstat_eta_max              =   1.5135750915006E+04
-(PID.TID 0000.0001) %MON dynstat_eta_min              =  -2.4251786313081E+04
-(PID.TID 0000.0001) %MON dynstat_eta_mean             =  -1.2364759502904E+02
-(PID.TID 0000.0001) %MON dynstat_eta_sd               =   7.2869427093871E+03
-(PID.TID 0000.0001) %MON dynstat_eta_del2             =   9.4374297791126E+01
-(PID.TID 0000.0001) %MON dynstat_uvel_max             =   1.4025409653678E-01
-(PID.TID 0000.0001) %MON dynstat_uvel_min             =  -1.6234354306936E-01
-(PID.TID 0000.0001) %MON dynstat_uvel_mean            =   4.9327486238383E-05
-(PID.TID 0000.0001) %MON dynstat_uvel_sd              =   9.0562629719199E-03
-(PID.TID 0000.0001) %MON dynstat_uvel_del2            =   4.0001403491250E-05
-(PID.TID 0000.0001) %MON dynstat_vvel_max             =   2.1608997077319E-01
-(PID.TID 0000.0001) %MON dynstat_vvel_min             =  -2.0223817168046E-01
-(PID.TID 0000.0001) %MON dynstat_vvel_mean            =  -4.0808266760936E-04
-(PID.TID 0000.0001) %MON dynstat_vvel_sd              =   9.3186855678021E-03
-(PID.TID 0000.0001) %MON dynstat_vvel_del2            =   4.1137726096054E-05
-(PID.TID 0000.0001) %MON dynstat_wvel_max             =   5.6385049847274E+00
-(PID.TID 0000.0001) %MON dynstat_wvel_min             =  -1.0793485028446E+01
-(PID.TID 0000.0001) %MON dynstat_wvel_mean            =   1.1977399553217E-04
-(PID.TID 0000.0001) %MON dynstat_wvel_sd              =   2.7512642472043E-01
-(PID.TID 0000.0001) %MON dynstat_wvel_del2            =   2.0122839738196E-03
-(PID.TID 0000.0001) %MON dynstat_theta_max            =   2.9452233210011E+01
-(PID.TID 0000.0001) %MON dynstat_theta_min            =  -1.9009836205383E+00
-(PID.TID 0000.0001) %MON dynstat_theta_mean           =   3.5926057810499E+00
-(PID.TID 0000.0001) %MON dynstat_theta_sd             =   4.4297035982106E+00
-(PID.TID 0000.0001) %MON dynstat_theta_del2           =   2.3151679121003E-03
-(PID.TID 0000.0001) %MON dynstat_salt_max             =   4.0715753394133E+01
-(PID.TID 0000.0001) %MON dynstat_salt_min             =   1.5621720678927E+01
-(PID.TID 0000.0001) %MON dynstat_salt_mean            =   3.4721551136375E+01
-(PID.TID 0000.0001) %MON dynstat_salt_sd              =   4.8718593479136E-01
-(PID.TID 0000.0001) %MON dynstat_salt_del2            =   5.0616065154707E-04
-(PID.TID 0000.0001) %MON forcing_qnet_max             =   7.0446790890174E+02
-(PID.TID 0000.0001) %MON forcing_qnet_min             =  -3.1232556961829E+02
-(PID.TID 0000.0001) %MON forcing_qnet_mean            =  -2.8186605840501E+01
-(PID.TID 0000.0001) %MON forcing_qnet_sd              =   1.4616031039215E+02
-(PID.TID 0000.0001) %MON forcing_qnet_del2            =   8.3870840619659E-01
+(PID.TID 0000.0001) %MON dynstat_eta_max              =   1.5135750084016E+04
+(PID.TID 0000.0001) %MON dynstat_eta_min              =  -2.4251786212335E+04
+(PID.TID 0000.0001) %MON dynstat_eta_mean             =  -1.2364486288341E+02
+(PID.TID 0000.0001) %MON dynstat_eta_sd               =   7.2869403898264E+03
+(PID.TID 0000.0001) %MON dynstat_eta_del2             =   9.4374294060000E+01
+(PID.TID 0000.0001) %MON dynstat_uvel_max             =   1.4025406019583E-01
+(PID.TID 0000.0001) %MON dynstat_uvel_min             =  -1.6231728560717E-01
+(PID.TID 0000.0001) %MON dynstat_uvel_mean            =   4.9327593062651E-05
+(PID.TID 0000.0001) %MON dynstat_uvel_sd              =   9.0562608520665E-03
+(PID.TID 0000.0001) %MON dynstat_uvel_del2            =   4.0001352387061E-05
+(PID.TID 0000.0001) %MON dynstat_vvel_max             =   2.1608624711783E-01
+(PID.TID 0000.0001) %MON dynstat_vvel_min             =  -2.0223783624155E-01
+(PID.TID 0000.0001) %MON dynstat_vvel_mean            =  -4.0808336778816E-04
+(PID.TID 0000.0001) %MON dynstat_vvel_sd              =   9.3186816628471E-03
+(PID.TID 0000.0001) %MON dynstat_vvel_del2            =   4.1137626129645E-05
+(PID.TID 0000.0001) %MON dynstat_wvel_max             =   5.6384916643427E+00
+(PID.TID 0000.0001) %MON dynstat_wvel_min             =  -1.0793470434765E+01
+(PID.TID 0000.0001) %MON dynstat_wvel_mean            =   1.1977346362891E-04
+(PID.TID 0000.0001) %MON dynstat_wvel_sd              =   2.7512619659803E-01
+(PID.TID 0000.0001) %MON dynstat_wvel_del2            =   2.0122821472768E-03
+(PID.TID 0000.0001) %MON dynstat_theta_max            =   2.9452233210014E+01
+(PID.TID 0000.0001) %MON dynstat_theta_min            =  -1.9009836274721E+00
+(PID.TID 0000.0001) %MON dynstat_theta_mean           =   3.5926057499360E+00
+(PID.TID 0000.0001) %MON dynstat_theta_sd             =   4.4297036930181E+00
+(PID.TID 0000.0001) %MON dynstat_theta_del2           =   2.3151018753563E-03
+(PID.TID 0000.0001) %MON dynstat_salt_max             =   4.0715753394131E+01
+(PID.TID 0000.0001) %MON dynstat_salt_min             =   1.5621720707520E+01
+(PID.TID 0000.0001) %MON dynstat_salt_mean            =   3.4721551134163E+01
+(PID.TID 0000.0001) %MON dynstat_salt_sd              =   4.8718599459171E-01
+(PID.TID 0000.0001) %MON dynstat_salt_del2            =   5.0614858738472E-04
+(PID.TID 0000.0001) %MON forcing_qnet_max             =   7.0446786844736E+02
+(PID.TID 0000.0001) %MON forcing_qnet_min             =  -3.1232557406658E+02
+(PID.TID 0000.0001) %MON forcing_qnet_mean            =  -2.8182830424194E+01
+(PID.TID 0000.0001) %MON forcing_qnet_sd              =   1.4617105712578E+02
+(PID.TID 0000.0001) %MON forcing_qnet_del2            =   8.3872555594239E-01
 (PID.TID 0000.0001) %MON forcing_qsw_max              =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON forcing_qsw_min              =  -3.0180730070724E+02
-(PID.TID 0000.0001) %MON forcing_qsw_mean             =  -1.8597973620677E+02
-(PID.TID 0000.0001) %MON forcing_qsw_sd               =   7.8390284286903E+01
-(PID.TID 0000.0001) %MON forcing_qsw_del2             =   1.1136014417954E-01
-(PID.TID 0000.0001) %MON forcing_empmr_max            =   1.7511223113328E-03
-(PID.TID 0000.0001) %MON forcing_empmr_min            =  -4.6070107971882E-04
-(PID.TID 0000.0001) %MON forcing_empmr_mean           =   1.2716098112648E-05
-(PID.TID 0000.0001) %MON forcing_empmr_sd             =   1.0544462198140E-04
-(PID.TID 0000.0001) %MON forcing_empmr_del2           =   1.4654735293588E-06
+(PID.TID 0000.0001) %MON forcing_qsw_mean             =  -1.8597973620708E+02
+(PID.TID 0000.0001) %MON forcing_qsw_sd               =   7.8390284286186E+01
+(PID.TID 0000.0001) %MON forcing_qsw_del2             =   1.1136014417886E-01
+(PID.TID 0000.0001) %MON forcing_empmr_max            =   1.7538089233729E-03
+(PID.TID 0000.0001) %MON forcing_empmr_min            =  -4.6070107974296E-04
+(PID.TID 0000.0001) %MON forcing_empmr_mean           =   1.2715834705229E-05
+(PID.TID 0000.0001) %MON forcing_empmr_sd             =   1.0544599674262E-04
+(PID.TID 0000.0001) %MON forcing_empmr_del2           =   1.4657286808774E-06
 (PID.TID 0000.0001) %MON forcing_fu_max               =   2.4734156444157E-01
 (PID.TID 0000.0001) %MON forcing_fu_min               =  -2.3124407967036E-01
-(PID.TID 0000.0001) %MON forcing_fu_mean              =  -4.0947053438261E-03
-(PID.TID 0000.0001) %MON forcing_fu_sd                =   6.4478847434813E-02
-(PID.TID 0000.0001) %MON forcing_fu_del2              =   2.1441075627203E-04
+(PID.TID 0000.0001) %MON forcing_fu_mean              =  -4.0947057224826E-03
+(PID.TID 0000.0001) %MON forcing_fu_sd                =   6.4478847337158E-02
+(PID.TID 0000.0001) %MON forcing_fu_del2              =   2.1441076063599E-04
 (PID.TID 0000.0001) %MON forcing_fv_max               =   2.7696015458957E-01
 (PID.TID 0000.0001) %MON forcing_fv_min               =  -3.3401105942538E-01
-(PID.TID 0000.0001) %MON forcing_fv_mean              =  -1.3706995844462E-02
-(PID.TID 0000.0001) %MON forcing_fv_sd                =   7.5852979801884E-02
-(PID.TID 0000.0001) %MON forcing_fv_del2              =   2.4162975367436E-04
-(PID.TID 0000.0001) %MON trAdv_CFL_u_max              =   5.0136044943013E-02
-(PID.TID 0000.0001) %MON trAdv_CFL_v_max              =   8.0223542011197E-02
-(PID.TID 0000.0001) %MON trAdv_CFL_w_max              =   2.7522584402411E-01
-(PID.TID 0000.0001) %MON advcfl_uvel_max              =   5.0231286543205E-02
-(PID.TID 0000.0001) %MON advcfl_vvel_max              =   6.2663313695969E-02
-(PID.TID 0000.0001) %MON advcfl_wvel_max              =   3.0147682400479E-01
-(PID.TID 0000.0001) %MON advcfl_W_hf_max              =   3.3302585062081E-01
-(PID.TID 0000.0001) %MON pe_b_mean                    =   1.3602711390692E-02
-(PID.TID 0000.0001) %MON ke_max                       =   1.6771177670341E-02
-(PID.TID 0000.0001) %MON ke_mean                      =   7.8043890337153E-05
-(PID.TID 0000.0001) %MON ke_vol                       =   1.3604135612467E+22
-(PID.TID 0000.0001) %MON vort_r_min                   =  -8.0848523293760E-07
-(PID.TID 0000.0001) %MON vort_r_max                   =   8.7642383282329E-07
+(PID.TID 0000.0001) %MON forcing_fv_mean              =  -1.3706994668373E-02
+(PID.TID 0000.0001) %MON forcing_fv_sd                =   7.5852979941087E-02
+(PID.TID 0000.0001) %MON forcing_fv_del2              =   2.4162973236994E-04
+(PID.TID 0000.0001) %MON trAdv_CFL_u_max              =   5.0136044471913E-02
+(PID.TID 0000.0001) %MON trAdv_CFL_v_max              =   8.0223416180482E-02
+(PID.TID 0000.0001) %MON trAdv_CFL_w_max              =   2.7522548575865E-01
+(PID.TID 0000.0001) %MON advcfl_uvel_max              =   5.0231286070832E-02
+(PID.TID 0000.0001) %MON advcfl_vvel_max              =   6.2663313325647E-02
+(PID.TID 0000.0001) %MON advcfl_wvel_max              =   3.0147643118932E-01
+(PID.TID 0000.0001) %MON advcfl_W_hf_max              =   3.3302541711625E-01
+(PID.TID 0000.0001) %MON pe_b_mean                    =   1.3602713866758E-02
+(PID.TID 0000.0001) %MON ke_max                       =   1.6771136725635E-02
+(PID.TID 0000.0001) %MON ke_mean                      =   7.8043839196644E-05
+(PID.TID 0000.0001) %MON ke_vol                       =   1.3604135613380E+22
+(PID.TID 0000.0001) %MON vort_r_min                   =  -8.0847415759849E-07
+(PID.TID 0000.0001) %MON vort_r_max                   =   8.7642380563978E-07
 (PID.TID 0000.0001) %MON vort_a_mean                  =  -2.0556865257795E-05
-(PID.TID 0000.0001) %MON vort_a_sd                    =   7.5247481704715E-05
-(PID.TID 0000.0001) %MON vort_p_mean                  =  -2.4859242489939E-05
-(PID.TID 0000.0001) %MON vort_p_sd                    =   1.2920581098098E-04
-(PID.TID 0000.0001) %MON surfExpan_theta_mean         =  -1.7184773255441E-03
-(PID.TID 0000.0001) %MON surfExpan_salt_mean          =  -3.8880691750391E-03
+(PID.TID 0000.0001) %MON vort_a_sd                    =   7.5247481704435E-05
+(PID.TID 0000.0001) %MON vort_p_mean                  =  -2.4859242488275E-05
+(PID.TID 0000.0001) %MON vort_p_sd                    =   1.2920581029737E-04
+(PID.TID 0000.0001) %MON surfExpan_theta_mean         =  -1.7184897475106E-03
+(PID.TID 0000.0001) %MON surfExpan_salt_mean          =  -3.8879783103739E-03
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // End MONITOR dynamic field statistics
 (PID.TID 0000.0001) // =======================================================
@@ -4619,31 +4621,31 @@ listId=   2 ; file name: seaiceStDiag
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) %MON seaice_tsnumber              =                    10
 (PID.TID 0000.0001) %MON seaice_time_sec              =   8.6400000000000E+05
-(PID.TID 0000.0001) %MON seaice_uice_max              =   1.7314889933273E-01
-(PID.TID 0000.0001) %MON seaice_uice_min              =  -2.3167465842746E-01
-(PID.TID 0000.0001) %MON seaice_uice_mean             =  -6.3550477794731E-04
-(PID.TID 0000.0001) %MON seaice_uice_sd               =   1.5027693211699E-02
-(PID.TID 0000.0001) %MON seaice_uice_del2             =   2.2433240874478E-04
-(PID.TID 0000.0001) %MON seaice_vice_max              =   1.6914203332145E-01
-(PID.TID 0000.0001) %MON seaice_vice_min              =  -1.9231978540510E-01
-(PID.TID 0000.0001) %MON seaice_vice_mean             =   1.4131087463021E-03
-(PID.TID 0000.0001) %MON seaice_vice_sd               =   1.6241304178548E-02
-(PID.TID 0000.0001) %MON seaice_vice_del2             =   1.3591619693837E-04
-(PID.TID 0000.0001) %MON seaice_area_max              =   9.9122973122470E-01
+(PID.TID 0000.0001) %MON seaice_uice_max              =   1.7314902420608E-01
+(PID.TID 0000.0001) %MON seaice_uice_min              =  -2.3167388153803E-01
+(PID.TID 0000.0001) %MON seaice_uice_mean             =  -6.3551659372816E-04
+(PID.TID 0000.0001) %MON seaice_uice_sd               =   1.5027694502955E-02
+(PID.TID 0000.0001) %MON seaice_uice_del2             =   2.2433227559630E-04
+(PID.TID 0000.0001) %MON seaice_vice_max              =   1.6913890839582E-01
+(PID.TID 0000.0001) %MON seaice_vice_min              =  -1.9231990342761E-01
+(PID.TID 0000.0001) %MON seaice_vice_mean             =   1.4131259211776E-03
+(PID.TID 0000.0001) %MON seaice_vice_sd               =   1.6241281134975E-02
+(PID.TID 0000.0001) %MON seaice_vice_del2             =   1.3591620479248E-04
+(PID.TID 0000.0001) %MON seaice_area_max              =   9.9122973307800E-01
 (PID.TID 0000.0001) %MON seaice_area_min              =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON seaice_area_mean             =   2.4792236874850E-02
-(PID.TID 0000.0001) %MON seaice_area_sd               =   1.4783362689839E-01
-(PID.TID 0000.0001) %MON seaice_area_del2             =   9.0555061362705E-04
-(PID.TID 0000.0001) %MON seaice_heff_max              =   7.4146789782609E-01
+(PID.TID 0000.0001) %MON seaice_area_mean             =   2.4792227062137E-02
+(PID.TID 0000.0001) %MON seaice_area_sd               =   1.4783338370493E-01
+(PID.TID 0000.0001) %MON seaice_area_del2             =   9.0555776294243E-04
+(PID.TID 0000.0001) %MON seaice_heff_max              =   7.4146789812481E-01
 (PID.TID 0000.0001) %MON seaice_heff_min              =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON seaice_heff_mean             =   1.5978866254007E-02
-(PID.TID 0000.0001) %MON seaice_heff_sd               =   9.7527400028689E-02
-(PID.TID 0000.0001) %MON seaice_heff_del2             =   5.6114211260668E-04
-(PID.TID 0000.0001) %MON seaice_hsnow_max             =   2.2469995969795E-02
+(PID.TID 0000.0001) %MON seaice_heff_mean             =   1.5978503176034E-02
+(PID.TID 0000.0001) %MON seaice_heff_sd               =   9.7526035818440E-02
+(PID.TID 0000.0001) %MON seaice_heff_del2             =   5.6112812587901E-04
+(PID.TID 0000.0001) %MON seaice_hsnow_max             =   2.2469995500018E-02
 (PID.TID 0000.0001) %MON seaice_hsnow_min             =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON seaice_hsnow_mean            =   2.3565424288213E-04
-(PID.TID 0000.0001) %MON seaice_hsnow_sd              =   1.6545563435351E-03
-(PID.TID 0000.0001) %MON seaice_hsnow_del2            =   2.0103500736772E-05
+(PID.TID 0000.0001) %MON seaice_hsnow_mean            =   2.3565268670027E-04
+(PID.TID 0000.0001) %MON seaice_hsnow_sd              =   1.6545552811390E-03
+(PID.TID 0000.0001) %MON seaice_hsnow_del2            =   2.0103641870952E-05
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // End MONITOR SEAICE statistics
 (PID.TID 0000.0001) // =======================================================
@@ -4674,183 +4676,183 @@ listId=   2 ; file name: seaiceStDiag
 (PID.TID 0000.0001) DIAGSTATS_CLOSE_IO: close file: seaiceStDiag.0000000000.txt , unit=    10
 (PID.TID 0000.0001) %CHECKPOINT        10 ckptA
 (PID.TID 0000.0001)   Seconds in section "ALL                    [THE_MODEL_MAIN]":
-(PID.TID 0000.0001)           User time:   16.903894424438477
-(PID.TID 0000.0001)         System time:  0.13567499443888664
-(PID.TID 0000.0001)     Wall clock time:   17.065328836441040
+(PID.TID 0000.0001)           User time:   17.648967304266989
+(PID.TID 0000.0001)         System time:  0.27947701234370470
+(PID.TID 0000.0001)     Wall clock time:   17.938468933105469
 (PID.TID 0000.0001)          No. starts:           1
 (PID.TID 0000.0001)           No. stops:           1
 (PID.TID 0000.0001)   Seconds in section "INITIALISE_FIXED       [THE_MODEL_MAIN]":
-(PID.TID 0000.0001)           User time:  0.20251399278640747
-(PID.TID 0000.0001)         System time:   6.0594998300075531E-002
-(PID.TID 0000.0001)     Wall clock time:  0.26405692100524902
+(PID.TID 0000.0001)           User time:  0.25156001467257738
+(PID.TID 0000.0001)         System time:   7.5686997268348932E-002
+(PID.TID 0000.0001)     Wall clock time:  0.32773995399475098
 (PID.TID 0000.0001)          No. starts:           1
 (PID.TID 0000.0001)           No. stops:           1
 (PID.TID 0000.0001)   Seconds in section "THE_MAIN_LOOP          [THE_MODEL_MAIN]":
-(PID.TID 0000.0001)           User time:   16.701365709304810
-(PID.TID 0000.0001)         System time:   7.5041994452476501E-002
-(PID.TID 0000.0001)     Wall clock time:   16.801229953765869
+(PID.TID 0000.0001)           User time:   17.397365689277649
+(PID.TID 0000.0001)         System time:  0.20377401262521744
+(PID.TID 0000.0001)     Wall clock time:   17.610681056976318
 (PID.TID 0000.0001)          No. starts:           1
 (PID.TID 0000.0001)           No. stops:           1
 (PID.TID 0000.0001)   Seconds in section "INITIALISE_VARIA    [THE_MAIN_LOOP]":
-(PID.TID 0000.0001)           User time:  0.43145598471164703
-(PID.TID 0000.0001)         System time:   4.3416999280452728E-002
-(PID.TID 0000.0001)     Wall clock time:  0.47490906715393066
+(PID.TID 0000.0001)           User time:  0.32979798316955566
+(PID.TID 0000.0001)         System time:  0.13123399764299393
+(PID.TID 0000.0001)     Wall clock time:  0.46505999565124512
 (PID.TID 0000.0001)          No. starts:           1
 (PID.TID 0000.0001)           No. stops:           1
 (PID.TID 0000.0001)   Seconds in section "MAIN LOOP           [THE_MAIN_LOOP]":
-(PID.TID 0000.0001)           User time:   16.269886076450348
-(PID.TID 0000.0001)         System time:   3.1619995832443237E-002
-(PID.TID 0000.0001)     Wall clock time:   16.326296091079712
+(PID.TID 0000.0001)           User time:   17.067548036575317
+(PID.TID 0000.0001)         System time:   7.2536006569862366E-002
+(PID.TID 0000.0001)     Wall clock time:   17.145596981048584
 (PID.TID 0000.0001)          No. starts:           1
 (PID.TID 0000.0001)           No. stops:           1
 (PID.TID 0000.0001)   Seconds in section "MAIN_DO_LOOP        [THE_MAIN_LOOP]":
-(PID.TID 0000.0001)           User time:   16.269790112972260
-(PID.TID 0000.0001)         System time:   3.1617991626262665E-002
-(PID.TID 0000.0001)     Wall clock time:   16.326192855834961
+(PID.TID 0000.0001)           User time:   17.067465305328369
+(PID.TID 0000.0001)         System time:   7.2535008192062378E-002
+(PID.TID 0000.0001)     Wall clock time:   17.145513772964478
 (PID.TID 0000.0001)          No. starts:          10
 (PID.TID 0000.0001)           No. stops:          10
 (PID.TID 0000.0001)   Seconds in section "FORWARD_STEP        [MAIN_DO_LOOP]":
-(PID.TID 0000.0001)           User time:   16.269616425037384
-(PID.TID 0000.0001)         System time:   3.1616993248462677E-002
-(PID.TID 0000.0001)     Wall clock time:   16.326024293899536
+(PID.TID 0000.0001)           User time:   17.067304849624634
+(PID.TID 0000.0001)         System time:   7.2533011436462402E-002
+(PID.TID 0000.0001)     Wall clock time:   17.145348787307739
 (PID.TID 0000.0001)          No. starts:          10
 (PID.TID 0000.0001)           No. stops:          10
 (PID.TID 0000.0001)   Seconds in section "UPDATE_R_STAR       [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:  0.41738724708557129
-(PID.TID 0000.0001)         System time:   0.0000000000000000
-(PID.TID 0000.0001)     Wall clock time:  0.41744875907897949
+(PID.TID 0000.0001)           User time:  0.43627077341079712
+(PID.TID 0000.0001)         System time:   8.7991356849670410E-005
+(PID.TID 0000.0001)     Wall clock time:  0.43641877174377441
 (PID.TID 0000.0001)          No. starts:          20
 (PID.TID 0000.0001)           No. stops:          20
 (PID.TID 0000.0001)   Seconds in section "DO_STATEVARS_DIAGS  [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:  0.68943130970001221
-(PID.TID 0000.0001)         System time:   3.7830024957656860E-003
-(PID.TID 0000.0001)     Wall clock time:  0.69330072402954102
+(PID.TID 0000.0001)           User time:  0.72046405076980591
+(PID.TID 0000.0001)         System time:   7.6500028371810913E-003
+(PID.TID 0000.0001)     Wall clock time:  0.72824287414550781
 (PID.TID 0000.0001)          No. starts:          30
 (PID.TID 0000.0001)           No. stops:          30
 (PID.TID 0000.0001)   Seconds in section "LOAD_FIELDS_DRIVER  [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:  0.16868954896926880
-(PID.TID 0000.0001)         System time:   4.1519999504089355E-003
-(PID.TID 0000.0001)     Wall clock time:  0.19634413719177246
+(PID.TID 0000.0001)           User time:  0.15910220146179199
+(PID.TID 0000.0001)         System time:   2.0995736122131348E-005
+(PID.TID 0000.0001)     Wall clock time:  0.15913939476013184
 (PID.TID 0000.0001)          No. starts:          10
 (PID.TID 0000.0001)           No. stops:          10
 (PID.TID 0000.0001)   Seconds in section "EXF_GETFORCING     [LOAD_FLDS_DRIVER]":
-(PID.TID 0000.0001)           User time:  0.15860056877136230
-(PID.TID 0000.0001)         System time:   3.9499998092651367E-003
-(PID.TID 0000.0001)     Wall clock time:  0.18607592582702637
+(PID.TID 0000.0001)           User time:  0.14905661344528198
+(PID.TID 0000.0001)         System time:   9.9986791610717773E-006
+(PID.TID 0000.0001)     Wall clock time:  0.14909720420837402
 (PID.TID 0000.0001)          No. starts:          10
 (PID.TID 0000.0001)           No. stops:          10
 (PID.TID 0000.0001)   Seconds in section "EXTERNAL_FLDS_LOAD [LOAD_FLDS_DRIVER]":
-(PID.TID 0000.0001)           User time:   9.8230242729187012E-003
-(PID.TID 0000.0001)         System time:   1.9500404596328735E-004
-(PID.TID 0000.0001)     Wall clock time:   1.0022401809692383E-002
+(PID.TID 0000.0001)           User time:   9.7843408584594727E-003
+(PID.TID 0000.0001)         System time:   8.0019235610961914E-006
+(PID.TID 0000.0001)     Wall clock time:   9.8018646240234375E-003
 (PID.TID 0000.0001)          No. starts:          10
 (PID.TID 0000.0001)           No. stops:          10
 (PID.TID 0000.0001)   Seconds in section "DO_ATMOSPHERIC_PHYS [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:   8.9228153228759766E-005
-(PID.TID 0000.0001)         System time:   1.9967555999755859E-006
-(PID.TID 0000.0001)     Wall clock time:   8.9883804321289062E-005
+(PID.TID 0000.0001)           User time:   8.8453292846679688E-005
+(PID.TID 0000.0001)         System time:   0.0000000000000000
+(PID.TID 0000.0001)     Wall clock time:   8.7261199951171875E-005
 (PID.TID 0000.0001)          No. starts:          10
 (PID.TID 0000.0001)           No. stops:          10
 (PID.TID 0000.0001)   Seconds in section "DO_OCEANIC_PHYS     [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:   5.4456337690353394
-(PID.TID 0000.0001)         System time:   3.8460046052932739E-003
-(PID.TID 0000.0001)     Wall clock time:   5.4498126506805420
+(PID.TID 0000.0001)           User time:   5.5339111089706421
+(PID.TID 0000.0001)         System time:   8.4499865770339966E-003
+(PID.TID 0000.0001)     Wall clock time:   5.5427541732788086
 (PID.TID 0000.0001)          No. starts:          10
 (PID.TID 0000.0001)           No. stops:          10
 (PID.TID 0000.0001)   Seconds in section "SEAICE_MODEL    [DO_OCEANIC_PHYS]":
-(PID.TID 0000.0001)           User time:   2.2070937752723694
-(PID.TID 0000.0001)         System time:   0.0000000000000000
-(PID.TID 0000.0001)     Wall clock time:   2.2072227001190186
+(PID.TID 0000.0001)           User time:   2.1982228755950928
+(PID.TID 0000.0001)         System time:   3.9909929037094116E-003
+(PID.TID 0000.0001)     Wall clock time:   2.2024800777435303
 (PID.TID 0000.0001)          No. starts:          10
 (PID.TID 0000.0001)           No. stops:          10
 (PID.TID 0000.0001)   Seconds in section "SEAICE_DYNSOLVER   [SEAICE_MODEL]":
-(PID.TID 0000.0001)           User time:   1.8254236578941345
+(PID.TID 0000.0001)           User time:   1.8208924531936646
 (PID.TID 0000.0001)         System time:   0.0000000000000000
-(PID.TID 0000.0001)     Wall clock time:   1.8255391120910645
+(PID.TID 0000.0001)     Wall clock time:   1.8210697174072266
 (PID.TID 0000.0001)          No. starts:          10
 (PID.TID 0000.0001)           No. stops:          10
 (PID.TID 0000.0001)   Seconds in section "GGL90_CALC [DO_OCEANIC_PHYS]":
-(PID.TID 0000.0001)           User time:   2.5438731312751770
-(PID.TID 0000.0001)         System time:   3.4930035471916199E-003
-(PID.TID 0000.0001)     Wall clock time:   2.5476126670837402
+(PID.TID 0000.0001)           User time:   2.5573980808258057
+(PID.TID 0000.0001)         System time:   3.9379894733428955E-003
+(PID.TID 0000.0001)     Wall clock time:   2.5615074634552002
 (PID.TID 0000.0001)          No. starts:         120
 (PID.TID 0000.0001)           No. stops:         120
 (PID.TID 0000.0001)   Seconds in section "DYNAMICS            [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:   3.6693588495254517
-(PID.TID 0000.0001)         System time:   0.0000000000000000
-(PID.TID 0000.0001)     Wall clock time:   3.6695494651794434
+(PID.TID 0000.0001)           User time:   4.0716116428375244
+(PID.TID 0000.0001)         System time:   3.7419945001602173E-003
+(PID.TID 0000.0001)     Wall clock time:   4.0755672454833984
 (PID.TID 0000.0001)          No. starts:          10
 (PID.TID 0000.0001)           No. stops:          10
 (PID.TID 0000.0001)   Seconds in section "UPDATE_CG2D         [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:   7.3876023292541504E-002
-(PID.TID 0000.0001)         System time:   0.0000000000000000
-(PID.TID 0000.0001)     Wall clock time:   7.3889493942260742E-002
+(PID.TID 0000.0001)           User time:   8.1894397735595703E-002
+(PID.TID 0000.0001)         System time:   1.0699033737182617E-004
+(PID.TID 0000.0001)     Wall clock time:   8.5816144943237305E-002
 (PID.TID 0000.0001)          No. starts:          10
 (PID.TID 0000.0001)           No. stops:          10
 (PID.TID 0000.0001)   Seconds in section "SOLVE_FOR_PRESSURE  [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:   1.7274365425109863
-(PID.TID 0000.0001)         System time:   0.0000000000000000
-(PID.TID 0000.0001)     Wall clock time:   1.7279577255249023
+(PID.TID 0000.0001)           User time:   1.7584137916564941
+(PID.TID 0000.0001)         System time:   2.6899576187133789E-004
+(PID.TID 0000.0001)     Wall clock time:   1.7588489055633545
 (PID.TID 0000.0001)          No. starts:          10
 (PID.TID 0000.0001)           No. stops:          10
 (PID.TID 0000.0001)   Seconds in section "MOM_CORRECTION_STEP [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:  0.11745131015777588
+(PID.TID 0000.0001)           User time:  0.13771259784698486
 (PID.TID 0000.0001)         System time:   0.0000000000000000
-(PID.TID 0000.0001)     Wall clock time:  0.11746811866760254
+(PID.TID 0000.0001)     Wall clock time:  0.13774561882019043
 (PID.TID 0000.0001)          No. starts:          10
 (PID.TID 0000.0001)           No. stops:          10
 (PID.TID 0000.0001)   Seconds in section "INTEGR_CONTINUITY   [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:  0.20778417587280273
+(PID.TID 0000.0001)           User time:  0.25348925590515137
 (PID.TID 0000.0001)         System time:   0.0000000000000000
-(PID.TID 0000.0001)     Wall clock time:  0.20779728889465332
+(PID.TID 0000.0001)     Wall clock time:  0.25354361534118652
 (PID.TID 0000.0001)          No. starts:          10
 (PID.TID 0000.0001)           No. stops:          10
 (PID.TID 0000.0001)   Seconds in section "CALC_R_STAR         [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:   3.8580894470214844E-002
-(PID.TID 0000.0001)         System time:   0.0000000000000000
-(PID.TID 0000.0001)     Wall clock time:   3.8593530654907227E-002
+(PID.TID 0000.0001)           User time:   4.3705582618713379E-002
+(PID.TID 0000.0001)         System time:   9.9837779998779297E-007
+(PID.TID 0000.0001)     Wall clock time:   4.3733835220336914E-002
 (PID.TID 0000.0001)          No. starts:          10
 (PID.TID 0000.0001)           No. stops:          10
 (PID.TID 0000.0001)   Seconds in section "BLOCKING_EXCHANGES  [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:  0.27460718154907227
+(PID.TID 0000.0001)           User time:  0.21872496604919434
 (PID.TID 0000.0001)         System time:   0.0000000000000000
-(PID.TID 0000.0001)     Wall clock time:  0.27465033531188965
+(PID.TID 0000.0001)     Wall clock time:  0.21876788139343262
 (PID.TID 0000.0001)          No. starts:          20
 (PID.TID 0000.0001)           No. stops:          20
 (PID.TID 0000.0001)   Seconds in section "THERMODYNAMICS      [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:   2.2598072290420532
-(PID.TID 0000.0001)         System time:   0.0000000000000000
-(PID.TID 0000.0001)     Wall clock time:   2.2600007057189941
+(PID.TID 0000.0001)           User time:   2.3474673032760620
+(PID.TID 0000.0001)         System time:   1.2072011828422546E-002
+(PID.TID 0000.0001)     Wall clock time:   2.3599941730499268
 (PID.TID 0000.0001)          No. starts:          10
 (PID.TID 0000.0001)           No. stops:          10
 (PID.TID 0000.0001)   Seconds in section "TRC_CORRECTION_STEP [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:   7.4148178100585938E-005
-(PID.TID 0000.0001)         System time:   0.0000000000000000
-(PID.TID 0000.0001)     Wall clock time:   7.4148178100585938E-005
+(PID.TID 0000.0001)           User time:   8.3208084106445312E-005
+(PID.TID 0000.0001)         System time:   9.9837779998779297E-007
+(PID.TID 0000.0001)     Wall clock time:   8.8691711425781250E-005
 (PID.TID 0000.0001)          No. starts:          10
 (PID.TID 0000.0001)           No. stops:          10
 (PID.TID 0000.0001)   Seconds in section "DO_STATEVARS_TAVE   [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:   7.0571899414062500E-005
+(PID.TID 0000.0001)           User time:   8.1777572631835938E-005
 (PID.TID 0000.0001)         System time:   0.0000000000000000
-(PID.TID 0000.0001)     Wall clock time:   7.3194503784179688E-005
+(PID.TID 0000.0001)     Wall clock time:   7.5578689575195312E-005
 (PID.TID 0000.0001)          No. starts:          10
 (PID.TID 0000.0001)           No. stops:          10
 (PID.TID 0000.0001)   Seconds in section "MONITOR             [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:   1.0636043548583984
-(PID.TID 0000.0001)         System time:   0.0000000000000000
-(PID.TID 0000.0001)     Wall clock time:   1.0636730194091797
+(PID.TID 0000.0001)           User time:   1.1644122600555420
+(PID.TID 0000.0001)         System time:   4.1249990463256836E-003
+(PID.TID 0000.0001)     Wall clock time:   1.1690278053283691
 (PID.TID 0000.0001)          No. starts:          10
 (PID.TID 0000.0001)           No. stops:          10
 (PID.TID 0000.0001)   Seconds in section "DO_THE_MODEL_IO     [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:   6.7115306854248047E-002
-(PID.TID 0000.0001)         System time:   7.8269988298416138E-003
-(PID.TID 0000.0001)     Wall clock time:   7.4983835220336914E-002
+(PID.TID 0000.0001)           User time:   8.1232547760009766E-002
+(PID.TID 0000.0001)         System time:   1.1970996856689453E-002
+(PID.TID 0000.0001)     Wall clock time:   9.3215703964233398E-002
 (PID.TID 0000.0001)          No. starts:          10
 (PID.TID 0000.0001)           No. stops:          10
 (PID.TID 0000.0001)   Seconds in section "DO_WRITE_PICKUP     [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:   4.5541524887084961E-002
-(PID.TID 0000.0001)         System time:   1.1978998780250549E-002
-(PID.TID 0000.0001)     Wall clock time:   5.7532072067260742E-002
+(PID.TID 0000.0001)           User time:   5.5189847946166992E-002
+(PID.TID 0000.0001)         System time:   2.3979008197784424E-002
+(PID.TID 0000.0001)     Wall clock time:   7.9172849655151367E-002
 (PID.TID 0000.0001)          No. starts:          10
 (PID.TID 0000.0001)           No. stops:          10
 (PID.TID 0000.0001) // ======================================================
@@ -4989,9 +4991,9 @@ listId=   2 ; file name: seaiceStDiag
 (PID.TID 0000.0001) //          Total. Y spins =              0
 (PID.TID 0000.0001) //            Avg. Y spins =       0.00E+00
 (PID.TID 0000.0001) // o Thread number: 000001
-(PID.TID 0000.0001) //            No. barriers =          19882
+(PID.TID 0000.0001) //            No. barriers =          19884
 (PID.TID 0000.0001) //      Max. barrier spins =              1
 (PID.TID 0000.0001) //      Min. barrier spins =              1
-(PID.TID 0000.0001) //     Total barrier spins =          19882
+(PID.TID 0000.0001) //     Total barrier spins =          19884
 (PID.TID 0000.0001) //      Avg. barrier spins =       1.00E+00
 PROGRAM MAIN: Execution ended Normally


### PR DESCRIPTION
## What changes does this PR introduce?

This PR addresses points raised in issue #511 
A) Fix EXCH calls in pkg/ggl90 when IDEMIX is used:
1) When useIDEMIX=T and IDEMIX_tau_h > 0 (horizontal diffusion of IDEMIX_E),
   exchange both IDEMIX_E and GGL90TKE ;
2) skip EXCH of IDEMIX_V0 (not needed);
3) With IDEMIX_tau_h=0 (no horizontal diffusion) no need for additional EXCH.

This affects results of test experiment cs32.in_p (likely due to viscosity near CS-grid corner) but does not change results of experiment global_ocean.90x40x15.idemix (probably because overlap size is large enough and not using CS grid). This does fix restart for test experiment  cs32.in_p.

B) More consistent IDEMIX routine (use model parameter value for PI), change few global IDEMIX array into local variables, return TKE tendency from IDEMIX as output of S/R GGL90_IDEMIX ; use double product of IDEMIX_E instead of power of 2 which affects results at machine truncation level.

C) Improve some IDEMIX default parameter values (following Pollmann et al., 2017) but keep old default values in test experiment global_ocean.90x40x15.idemix.

D) In ggl90_calc.F, change option calcMeanVertShear to also apply to wind-stress magnitude (for uStarSquare calculation) and turn on calcMeanVertShear in test experiment cs32.in_p

## What is the current behaviour? 
see above

## What is the new behaviour 
see above

## Does this PR introduce a breaking change? 
- option calcMeanVertShear is extended to uStarSquare calculation.
- EXCH and restart fixed for IDEMIX
- some IDEMIX parameter default value changed

## Other information:

## Suggested addition to `tag-index`
o pkg/ggl90:
  - fix EXCH calls in pkg/ggl90 when IDEMIX is used: no additional EXCH when
    using zero horizontal diffusion of IDEMIX_E (IDEMIX_tau_h=0) but with
    IDEMIX_tau_h > 0, EXCH both IDEMIX_E and GGL90TKE ; this affects results
    of test experiment cs32.in_p and fix restart issue ;
  - more consistent/simpler idemix code: use model parameter value for PI, 
    reduce number of IDEMIX global array, add TKE tendency from IDEMIX as output
    of S/R GGL90_IDEMIX ; use double product of IDEMIX_E instead of power of 2
    which affects results at machine truncation level ;
  - update some IDEMIX default param values (following Pollmann et al., 2017)
    but keep old default values in global_ocean.90x40x15.idemix ;
  - apply also option calcMeanVertShear to uStarSquare calculation (wind-stress
    magnitude) and switch on calcMeanVertShear in test experiment cs32.in_p.
