### PR TITLE
Post pr507 fix

### DIFF
--- a/pkg/ecco/stergloh_output.F
+++ b/pkg/ecco/stergloh_output.F
@@ -98,15 +98,22 @@ C                 (in common block) and close open file (after last write)
 C-      save for next write to same file:
             IOunit_outpFile = ioUnit
           ENDIF
-          IF ( myIter .EQ. nEndIter ) THEN
+          IF ( myIter .EQ. nEndIter .AND. ioUnit .GT. 0 ) THEN
 C-      after last write, close IO-unit:
             IF ( debugLevel.GE.debLevC ) THEN
-              WRITE(msgBuf,'(3A)')
-     &        ' STERGLOH_OUTPUT: close file: ', fName(1:26), '.data'
+              WRITE(msgBuf,'(A,I8,3A)')
+     &          ' STERGLOH_OUTPUT: close ioUnit=', ioUnit,
+     &          ', file: ', fName(1:26), '.data'
               CALL PRINT_MESSAGE( msgBuf, standardMessageUnit,
      &                            SQUEEZE_RIGHT, myThid )
             ENDIF
             CLOSE( ioUnit )
+          ELSEIF ( myIter .EQ. nEndIter .AND. debugMode ) THEN
+            WRITE(msgBuf,'(2A,I10,A)')
+     &          ' STERGLOH_OUTPUT: no file to close',
+     &          ' (ioUnit=', ioUnit, ' )'
+            CALL PRINT_MESSAGE( msgBuf, standardMessageUnit,
+     &                          SQUEEZE_RIGHT, myThid )
           ENDIF
           _END_MASTER(myThid)
         ENDIF

--- a/pkg/ecco/stergloh_output.F
+++ b/pkg/ecco/stergloh_output.F
@@ -49,10 +49,9 @@ C     msgBuf    :: Informational/error message buffer
       CHARACTER*(10) suff
       CHARACTER*(MAX_LEN_FNAM) fName
       CHARACTER*(MAX_LEN_MBUF) msgBuf
-      INTEGER narr
-      PARAMETER( narr = 1 )
       INTEGER irecord
       INTEGER ioUnit
+      _RL     tmpVar(1)
       _RS     dummyRS(1)
 
 C-----------------------------------------------------------------
@@ -85,9 +84,10 @@ C-    to open new IO unit, write and close it all within same call
           ioUnit  = 0
         ENDIF
 
+        tmpVar(1) = sterGloH
         CALL MDS_WRITEVEC_LOC(
      I             fName, precFloat64, ioUnit,
-     I             'RL', narr, sterGloH, dummyRS,
+     I             'RL', 1, tmpVar, dummyRS,
      I             0, 0, irecord, myIter, myThid )
 
         IF ( ecco_keepTSeriesOutp_open ) THEN

--- a/pkg/seaice/seaice_cost_weights.F
+++ b/pkg/seaice/seaice_cost_weights.F
@@ -99,12 +99,8 @@ c--
       irec  = 1
       k     = 1
       if ( smrarea_errfile .NE. ' ' ) then
-         IF ( cost_yftype.EQ.'RL' ) THEN
-           CALL READ_REC_3D_RL( smrarea_errfile, cost_iprec, nnz,
-     &                          wsmrarea, irec, 0, mythid )
-         ELSE
-           STOP 'S/R SEAICE_COST_WEIGHTS: invalid cost_yftype'
-         ENDIF
+         CALL READ_REC_3D_RL( smrarea_errfile, cost_iprec, nnz,
+     &                        wsmrarea, irec, 0, mythid )
          do bj = jtlo,jthi
            do bi = itlo,ithi
              do j = jmin,jmax
@@ -143,4 +139,5 @@ c--
 
 #endif
 
+      return
       end


### PR DESCRIPTION
## What changes does this PR introduce?
Fix bugs/problems that were introduced in PR #507, as reported in issue #519

## What is the current behaviour? 
- pkg/seaice with pkg/ecco and ALLOW_SEAICE_COST_SMR_AREA defined fail to compile src file: seaice_cost_weights.F (--> AD experiment 1D_ocean_ice_column & lab_sea)
- new option ecco_keepTSeriesOutp_open does not work when used with MPI (--> global_oce_cs32 from https://github.com/MITgcm/verification_other fails with MPI)
- minor: S/R MDS_WRITEVEC_LOC expects vector as input argument (and not scalar variable); this prevents to check consistency in S/R argument call (e.g., with intel compiler + -devel option) as it fails the check here.

## What is the new behaviour 
fix all 3

## Does this PR introduce a breaking change? 
no

## Other information:

## Suggested addition to `tag-index`
skip if merged just after PR #507