### PR TITLE
Post pr470: Fix type of AD vars in cg2d_mad.F

### DIFF
--- a/doc/tag-index
+++ b/doc/tag-index
@@ -1,6 +1,9 @@
     Notes on tags used in MITgcmUV
     ==============================
 
+o pkg/autodiff:
+  - fix type (_RS vs_RL) of AD-vars in hand-written AD routine cg2d_mad.F and
+    in adcommon.h, common block adgrid_rs.
 o model/src:
   - fix missing initialisation of local working arrays that were previously
     in common block in CG2D.h (needed when using blank tiles).

--- a/pkg/autodiff/adcommon.h
+++ b/pkg/autodiff/adcommon.h
@@ -17,24 +17,24 @@ C--   heimbach@mit.edu 11-Jan-2001
 #else
      &                     adgunm1, adgvnm1, adgtnm1, adgsnm1
 #endif
-      _RL adetan(1-olx:snx+olx,1-oly:sny+oly,nsx,nsy)
-      _RL adgu(1-olx:snx+olx,1-oly:sny+oly,nr,nsx,nsy)
-      _RL adgv(1-olx:snx+olx,1-oly:sny+oly,nr,nsx,nsy)
-      _RL adsalt(1-olx:snx+olx,1-oly:sny+oly,nr,nsx,nsy)
-      _RL adtheta(1-olx:snx+olx,1-oly:sny+oly,nr,nsx,nsy)
-      _RL aduvel(1-olx:snx+olx,1-oly:sny+oly,nr,nsx,nsy)
-      _RL advvel(1-olx:snx+olx,1-oly:sny+oly,nr,nsx,nsy)
-      _RL adwvel(1-olx:snx+olx,1-oly:sny+oly,nr,nsx,nsy)
+      _RL adetan(1-OLx:sNx+OLx,1-OLy:sNy+OLy,nSx,nSy)
+      _RL adgu(1-OLx:sNx+OLx,1-OLy:sNy+OLy,nr,nSx,nSy)
+      _RL adgv(1-OLx:sNx+OLx,1-OLy:sNy+OLy,nr,nSx,nSy)
+      _RL adsalt(1-OLx:sNx+OLx,1-OLy:sNy+OLy,nr,nSx,nSy)
+      _RL adtheta(1-OLx:sNx+OLx,1-OLy:sNy+OLy,nr,nSx,nSy)
+      _RL aduvel(1-OLx:sNx+OLx,1-OLy:sNy+OLy,nr,nSx,nSy)
+      _RL advvel(1-OLx:sNx+OLx,1-OLy:sNy+OLy,nr,nSx,nSy)
+      _RL adwvel(1-OLx:sNx+OLx,1-OLy:sNy+OLy,nr,nSx,nSy)
 #ifdef ALLOW_ADAMSBASHFORTH_3
-      _RL adgtnm(1-olx:snx+olx,1-oly:sny+oly,nr,nsx,nsy,2)
-      _RL adgsnm(1-olx:snx+olx,1-oly:sny+oly,nr,nsx,nsy,2)
-      _RL adgunm(1-olx:snx+olx,1-oly:sny+oly,nr,nsx,nsy,2)
-      _RL adgvnm(1-olx:snx+olx,1-oly:sny+oly,nr,nsx,nsy,2)
+      _RL adgtnm(1-OLx:sNx+OLx,1-OLy:sNy+OLy,nr,nSx,nSy,2)
+      _RL adgsnm(1-OLx:sNx+OLx,1-OLy:sNy+OLy,nr,nSx,nSy,2)
+      _RL adgunm(1-OLx:sNx+OLx,1-OLy:sNy+OLy,nr,nSx,nSy,2)
+      _RL adgvnm(1-OLx:sNx+OLx,1-OLy:sNy+OLy,nr,nSx,nSy,2)
 #else
-      _RL adgtnm1(1-olx:snx+olx,1-oly:sny+oly,nr,nsx,nsy)
-      _RL adgsnm1(1-olx:snx+olx,1-oly:sny+oly,nr,nsx,nsy)
-      _RL adgunm1(1-olx:snx+olx,1-oly:sny+oly,nr,nsx,nsy)
-      _RL adgvnm1(1-olx:snx+olx,1-oly:sny+oly,nr,nsx,nsy)
+      _RL adgtnm1(1-OLx:sNx+OLx,1-OLy:sNy+OLy,nr,nSx,nSy)
+      _RL adgsnm1(1-OLx:sNx+OLx,1-OLy:sNy+OLy,nr,nSx,nSy)
+      _RL adgunm1(1-OLx:sNx+OLx,1-OLy:sNy+OLy,nr,nSx,nSy)
+      _RL adgvnm1(1-OLx:sNx+OLx,1-OLy:sNy+OLy,nr,nSx,nSy)
 #endif
 
 #ifdef USE_OLD_EXTERNAL_FORCING
@@ -46,13 +46,13 @@ c     _RL adgt(1-olx:snx+olx,1-oly:sny+oly,nr,nsx,nsy)
 
       common /addynvars_r_2/
      &                     adetah
-      _RL adetah(1-olx:snx+olx,1-oly:sny+oly,nsx,nsy)
+      _RL adetah(1-OLx:sNx+OLx,1-OLy:sNy+OLy,nSx,nSy)
 
 #ifdef ALLOW_AUTODIFF_MONITOR_DIAG
       common /addynvars_diag/
      &                     adtotphihyd, adrhoinsitu
-      _RL adrhoinsitu(1-olx:snx+olx,1-oly:sny+oly,nr,nsx,nsy)
-      _RL adtotphihyd(1-olx:snx+olx,1-oly:sny+oly,nr,nsx,nsy)
+      _RL adrhoinsitu(1-OLx:sNx+OLx,1-OLy:sNy+OLy,nr,nSx,nSy)
+      _RL adtotphihyd(1-OLx:sNx+OLx,1-OLy:sNy+OLy,nr,nSx,nSy)
 #endif
 
 #ifdef ALLOW_CD_CODE
@@ -60,11 +60,11 @@ c     _RL adgt(1-olx:snx+olx,1-oly:sny+oly,nr,nsx,nsy)
      &                      aduveld, advveld,
      &                       adetanm1,
      &                      adunm1, advnm1
-      _RL aduveld(1-olx:snx+olx,1-oly:sny+oly,nr,nsx,nsy)
-      _RL advveld(1-olx:snx+olx,1-oly:sny+oly,nr,nsx,nsy)
-      _RL adetanm1(1-olx:snx+olx,1-oly:sny+oly,nsx,nsy)
-      _RL adunm1(1-olx:snx+olx,1-oly:sny+oly,nr,nsx,nsy)
-      _RL advnm1(1-olx:snx+olx,1-oly:sny+oly,nr,nsx,nsy)
+      _RL aduveld(1-OLx:sNx+OLx,1-OLy:sNy+OLy,nr,nSx,nSy)
+      _RL advveld(1-OLx:sNx+OLx,1-OLy:sNy+OLy,nr,nSx,nSy)
+      _RL adetanm1(1-OLx:sNx+OLx,1-OLy:sNy+OLy,nSx,nSy)
+      _RL adunm1(1-OLx:sNx+OLx,1-OLy:sNy+OLy,nr,nSx,nSy)
+      _RL advnm1(1-OLx:sNx+OLx,1-OLy:sNy+OLy,nr,nSx,nSy)
 #endif
 
       COMMON /adffields_fu/ adfu
@@ -125,33 +125,33 @@ c     _RL adgt(1-olx:snx+olx,1-oly:sny+oly,nr,nsx,nsy)
 
 #ifdef ALLOW_EXF
 
-      _RL adhflux(1-olx:snx+olx,1-oly:sny+oly,nsx,nsy)
-      _RL adsflux(1-olx:snx+olx,1-oly:sny+oly,nsx,nsy)
+      _RL adhflux(1-OLx:sNx+OLx,1-OLy:sNy+OLy,nSx,nSy)
+      _RL adsflux(1-OLx:sNx+OLx,1-OLy:sNy+OLy,nSx,nSy)
       common /adexf_hsflux_r/ adhflux, adsflux
 
-      _RL adustress(1-olx:snx+olx,1-oly:sny+oly,nsx,nsy)
-      _RL advstress(1-olx:snx+olx,1-oly:sny+oly,nsx,nsy)
+      _RL adustress(1-OLx:sNx+OLx,1-OLy:sNy+OLy,nSx,nSy)
+      _RL advstress(1-OLx:sNx+OLx,1-OLy:sNy+OLy,nSx,nSy)
       common /adexf_stress_r/ adustress, advstress
 
-      _RL adwspeed(1-olx:snx+olx,1-oly:sny+oly,nsx,nsy)
+      _RL adwspeed(1-OLx:sNx+OLx,1-OLy:sNy+OLy,nSx,nSy)
       common /adexf_wspeed_r/ adwspeed
 
 # ifdef ALLOW_RUNOFF
-      _RL adrunoff    (1-olx:snx+olx,1-oly:sny+oly,nsx,nsy)
-      _RL adrunoff0   (1-olx:snx+olx,1-oly:sny+oly,nsx,nsy)
-      _RL adrunoff1   (1-olx:snx+olx,1-oly:sny+oly,nsx,nsy)
+      _RL adrunoff    (1-OLx:sNx+OLx,1-OLy:sNy+OLy,nSx,nSy)
+      _RL adrunoff0   (1-OLx:sNx+OLx,1-OLy:sNy+OLy,nSx,nSy)
+      _RL adrunoff1   (1-OLx:sNx+OLx,1-OLy:sNy+OLy,nSx,nSy)
       common /exfl_runoff_r_ad/ adrunoff, adrunoff0, adrunoff1
 # endif
 
 # ifdef ALLOW_ATM_TEMP
-      _RL adatemp     (1-olx:snx+olx,1-oly:sny+oly,nsx,nsy)
-      _RL adaqh       (1-olx:snx+olx,1-oly:sny+oly,nsx,nsy)
-      _RL adhs        (1-olx:snx+olx,1-oly:sny+oly,nsx,nsy)
-      _RL adhl        (1-olx:snx+olx,1-oly:sny+oly,nsx,nsy)
-      _RL adlwflux    (1-olx:snx+olx,1-oly:sny+oly,nsx,nsy)
-      _RL adevap      (1-olx:snx+olx,1-oly:sny+oly,nsx,nsy)
-      _RL adprecip    (1-olx:snx+olx,1-oly:sny+oly,nsx,nsy)
-      _RL adsnowprecip(1-olx:snx+olx,1-oly:sny+oly,nsx,nsy)
+      _RL adatemp     (1-OLx:sNx+OLx,1-OLy:sNy+OLy,nSx,nSy)
+      _RL adaqh       (1-OLx:sNx+OLx,1-OLy:sNy+OLy,nSx,nSy)
+      _RL adhs        (1-OLx:sNx+OLx,1-OLy:sNy+OLy,nSx,nSy)
+      _RL adhl        (1-OLx:sNx+OLx,1-OLy:sNy+OLy,nSx,nSy)
+      _RL adlwflux    (1-OLx:sNx+OLx,1-OLy:sNy+OLy,nSx,nSy)
+      _RL adevap      (1-OLx:sNx+OLx,1-OLy:sNy+OLy,nSx,nSy)
+      _RL adprecip    (1-OLx:sNx+OLx,1-OLy:sNy+OLy,nSx,nSy)
+      _RL adsnowprecip(1-OLx:sNx+OLx,1-OLy:sNy+OLy,nSx,nSy)
       common /adexf_atm_temp_r/ adatemp, adaqh, adhs, adhl,
      & adlwflux, adevap, adprecip, adsnowprecip
 #  ifdef SHORTWAVE_HEATING
@@ -160,32 +160,32 @@ c     _RL adgt(1-olx:snx+olx,1-oly:sny+oly,nr,nsx,nsy)
 #  endif
 # endif /* ALLOW_ATM_TEMP */
 
-      _RL aduwind     (1-olx:snx+olx,1-oly:sny+oly,nsx,nsy)
-      _RL advwind     (1-olx:snx+olx,1-oly:sny+oly,nsx,nsy)
+      _RL aduwind     (1-OLx:sNx+OLx,1-OLy:sNy+OLy,nSx,nSy)
+      _RL advwind     (1-OLx:sNx+OLx,1-OLy:sNy+OLy,nSx,nSy)
       common /adexf_atm_wind_r/ aduwind, advwind
 
 # ifdef ALLOW_DOWNWARD_RADIATION
-      _RL adswdown    (1-olx:snx+olx,1-oly:sny+oly,nsx,nsy)
-      _RL adlwdown    (1-olx:snx+olx,1-oly:sny+oly,nsx,nsy)
+      _RL adswdown    (1-OLx:sNx+OLx,1-OLy:sNy+OLy,nSx,nSy)
+      _RL adlwdown    (1-OLx:sNx+OLx,1-OLy:sNy+OLy,nSx,nSy)
       common /adexf_rad_down_r/ adswdown, adlwdown
 # endif
 # ifdef ALLOW_CLIMSST_RELAXATION
-      _RL adclimsst(1-olx:snx+olx,1-oly:sny+oly,nsx,nsy)
+      _RL adclimsst(1-OLx:sNx+OLx,1-OLy:sNy+OLy,nSx,nSy)
       common /adexf_clim_sst_r/ adclimsst
 # endif
 # ifdef ALLOW_CLIMSSS_RELAXATION
-      _RL adclimsss(1-olx:snx+olx,1-oly:sny+oly,nsx,nsy)
+      _RL adclimsss(1-OLx:sNx+OLx,1-OLy:sNy+OLy,nSx,nSy)
       common /adexf_clim_sss_r/ adclimsss
 # endif
 
 #endif /* ALLOW_EXF */
 
 #ifdef ALLOW_SEAICE
-      _RL adarea  (1-olx:snx+olx,1-oly:sny+oly,nsx,nsy)
-      _RL adheff  (1-olx:snx+olx,1-oly:sny+oly,nsx,nsy)
-      _RL adhsnow (1-olx:snx+olx,1-oly:sny+oly,nsx,nsy)
-      _RL aduice  (1-olx:snx+olx,1-oly:sny+oly,nsx,nsy)
-      _RL advice  (1-olx:snx+olx,1-oly:sny+oly,nsx,nsy)
+      _RL adarea  (1-OLx:sNx+OLx,1-OLy:sNy+OLy,nSx,nSy)
+      _RL adheff  (1-OLx:sNx+OLx,1-OLy:sNy+OLy,nSx,nSy)
+      _RL adhsnow (1-OLx:sNx+OLx,1-OLy:sNy+OLy,nSx,nSy)
+      _RL aduice  (1-OLx:sNx+OLx,1-OLy:sNy+OLy,nSx,nSy)
+      _RL advice  (1-OLx:sNx+OLx,1-OLy:sNy+OLy,nSx,nSy)
       common /adseaice_dynvars_1/
      &     adarea, adheff, adhsnow, aduice, advice
 # ifdef SEAICE_VARIABLE_SALINITY
@@ -195,20 +195,20 @@ c     _RL adgt(1-olx:snx+olx,1-oly:sny+oly,nr,nsx,nsy)
 #endif /* ALLOW_SEAICE */
 
 #ifdef ALLOW_GGL90
-      _RL adggl90tke     (1-olx:snx+olx,1-oly:sny+oly,nr,nsx,nsy)
-      _RL adggl90diffkr  (1-olx:snx+olx,1-oly:sny+oly,nr,nsx,nsy)
+      _RL adggl90tke     (1-OLx:sNx+OLx,1-OLy:sNy+OLy,nr,nSx,nSy)
+      _RL adggl90diffkr  (1-OLx:sNx+OLx,1-OLy:sNy+OLy,nr,nSx,nSy)
       common /adggl90_fields/ adggl90tke, adggl90diffkr
 #endif
 
 #ifdef ALLOW_DEPTH_CONTROL
-      _RL adr_low_control(1-olx:snx+olx,1-oly:sny+oly,nsx,nsy)
-      _RL adhfacc(1-olx:snx+olx,1-oly:sny+oly,1:nr,nsx,nsy)
-      _RL adhfacs(1-olx:snx+olx,1-oly:sny+oly,1:nr,nsx,nsy)
-      _RL adhfacw(1-olx:snx+olx,1-oly:sny+oly,1:nr,nsx,nsy)
-      _RL adrecip_rcol(1-olx:snx+olx,1-oly:sny+oly,nsx,nsy)
-      _RL adrecip_hfacc(1-olx:snx+olx,1-oly:sny+oly,1:nr,nsx,nsy)
-      _RL adrecip_hfacs(1-olx:snx+olx,1-oly:sny+oly,1:nr,nsx,nsy)
-      _RL adrecip_hfacw(1-olx:snx+olx,1-oly:sny+oly,1:nr,nsx,nsy)
+      _RS adr_low_control(1-OLx:sNx+OLx,1-OLy:sNy+OLy,nSx,nSy)
+      _RS adhfacc(1-OLx:sNx+OLx,1-OLy:sNy+OLy,1:nr,nSx,nSy)
+      _RS adhfacs(1-OLx:sNx+OLx,1-OLy:sNy+OLy,1:nr,nSx,nSy)
+      _RS adhfacw(1-OLx:sNx+OLx,1-OLy:sNy+OLy,1:nr,nSx,nSy)
+      _RS adrecip_rcol(1-OLx:sNx+OLx,1-OLy:sNy+OLy,nSx,nSy)
+      _RS adrecip_hfacc(1-OLx:sNx+OLx,1-OLy:sNy+OLy,1:nr,nSx,nSy)
+      _RS adrecip_hfacs(1-OLx:sNx+OLx,1-OLy:sNy+OLy,1:nr,nSx,nSy)
+      _RS adrecip_hfacw(1-OLx:sNx+OLx,1-OLy:sNy+OLy,1:nr,nSx,nSy)
       common /adgrid_rs/
      &     adr_low_control, adhfacc, adhfacw, adhfacs,
      &     adrecip_rcol, adrecip_hfacc, adrecip_hfacw, adrecip_hfacs
@@ -227,7 +227,5 @@ c     _RL adgt(1-olx:snx+olx,1-oly:sny+oly,nr,nsx,nsy)
      &  adshelficeforcingt, adshelficeforcings, adshitranscoefft,
      &  adshitranscoeffs, adshicdragfld, adshidragquadfld
 #endif
-
-
 
 #endif /* ALLOW_AUTODIFF_MONITOR */

--- a/pkg/autodiff/cg2d_mad.F
+++ b/pkg/autodiff/cg2d_mad.F
@@ -74,12 +74,12 @@ c     _RL  firstResidual, minResidualSq, lastResidual
 #if ( defined NONLIN_FRSURF || defined ALLOW_DEPTH_CONTROL )
 C     directly imported from TAF-generated code, make sure that they are
 C     consistent with what is found in S/R update_cg2d_ad
-      _RL aW2d_ad(1-OLx:sNx+OLx,1-OLy:sNy+OLy,nSx,nSy)
-      _RL aS2d_ad(1-OLx:sNx+OLx,1-OLy:sNy+OLy,nSx,nSy)
-      _RL aC2d_ad(1-OLx:sNx+OLx,1-OLy:sNy+OLy,nSx,nSy)
-      _RL pW_ad  (1-OLx:sNx+OLx,1-OLy:sNy+OLy,nSx,nSy)
-      _RL pS_ad  (1-OLx:sNx+OLx,1-OLy:sNy+OLy,nSx,nSy)
-      _RL pC_ad  (1-OLx:sNx+OLx,1-OLy:sNy+OLy,nSx,nSy)
+      _RS aW2d_ad(1-OLx:sNx+OLx,1-OLy:sNy+OLy,nSx,nSy)
+      _RS aS2d_ad(1-OLx:sNx+OLx,1-OLy:sNy+OLy,nSx,nSy)
+      _RS aC2d_ad(1-OLx:sNx+OLx,1-OLy:sNy+OLy,nSx,nSy)
+      _RS pW_ad  (1-OLx:sNx+OLx,1-OLy:sNy+OLy,nSx,nSy)
+      _RS pS_ad  (1-OLx:sNx+OLx,1-OLy:sNy+OLy,nSx,nSy)
+      _RS pC_ad  (1-OLx:sNx+OLx,1-OLy:sNy+OLy,nSx,nSy)
       COMMON /CG2D_I_R_AD/
      &     aW2d_ad, aS2d_ad, aC2d_ad, pW_ad, pS_ad, pC_ad
 #endif /* NONLIN_FRSURF or ALLOW_DEPTH_CONTROL */


### PR DESCRIPTION
All 6 forward-variable arrays in common block CG2D_I_R are "_RS" as well as corresponding AD-variable arrays
in TAF generated code. Change these 6 AD-variable arrays from _RL to _RS in this "hand-written" adjoint S/R CG2D_MAD to get type to match. Also fix same issue for 8 AD-variable arrays in "hand-written" common block adgrid_rs (in file adcommon.h), switching type from _RL to _RS.

## What changes does this PR introduce?
Fix AD code in case type "_RS" is "real*4" (and different from _RL), when NONLIN_FRSURF or ALLOW_DEPTH_CONTROL are defined in gc2d_mad.F and when ALLOW_DEPTH_CONTROL is defined in adcommon.h

## What is the current behaviour? 
When _RS is real*4, type of variables in AD-common block CG2D_I_R_AD and in common block adgrdi_rs in, respectively,  hand-written Ad routine CG2D_MAD and in adcommon.h don't match the rest of TAF generated AD-code.

## What is the new behaviour 
Change to the right "_RS" type.

## Does this PR introduce a breaking change? 
No change if _RS is real*8, but fix issue #526 when _RS is real*4

## Other information:

## Suggested addition to `tag-index`
o pkg/autodiff:
  - fix type (_RS vs_RL) of AD-vars in hand-written AD routine cg2d_mad.F + in adcommon.h

