### PR TITLE
Fix PR #508: Remove added calls to S/R ECCO_ZERO

### DIFF
--- a/pkg/ecco/ecco_phys.F
+++ b/pkg/ecco/ecco_phys.F
@@ -241,12 +241,6 @@ c-- init
       call ecco_zero(trVol,Nr,zeroRL,myThid)
       call ecco_zero(trHeat,Nr,zeroRL,myThid)
       call ecco_zero(trSalt,Nr,zeroRL,myThid)
-      call ecco_zero(trVolW,Nr,zeroRL,myThid)
-      call ecco_zero(trHeatW,Nr,zeroRL,myThid)
-      call ecco_zero(trSaltW,Nr,zeroRL,myThid)
-      call ecco_zero(trVolS,Nr,zeroRL,myThid)
-      call ecco_zero(trHeatS,Nr,zeroRL,myThid)
-      call ecco_zero(trSaltS,Nr,zeroRL,myThid)
 
 #ifdef ALLOW_GENCOST_CONTRIBUTION
 


### PR DESCRIPTION
In ecco_phys.F, few added calls to S/R ECCO_ZERO (in PR #508) applies to wrong shape arrays
(missing nSx,nSy dimensions for local arrays: trVolW,S, trHeatW,S and trSaltW,S).
Did not seem to be needed before these changes were made so remove these calls.

## What changes does this PR introduce?
fix a bug

## What is the current behaviour? 
S/R ECCO_ZERO calls applies to wrong-shape arrrays ; This make AD experiment "lab_sea" to fail with
gfortran v10.2.1 (on batsi, seg-fault) and also, with open64 compiler (on engaging), all experiments using pkg/ecco.

## What is the new behaviour 
fixed (back to prior PR #508 regarding ECCO_ZERO calls)

## Does this PR introduce a breaking change? 
no

## Other information:

## Suggested addition to `tag-index`
not needed if merged just after PR #508