### PR TITLE
Simplify pkg/gmredi 

### DIFF
--- a/model/src/do_oceanic_phys.F
+++ b/model/src/do_oceanic_phys.F
@@ -614,10 +614,8 @@ cph although some of these are re-initialised later.
            Kwx(i,j,k,bi,bj)  = 0. _d 0
            Kwy(i,j,k,bi,bj)  = 0. _d 0
            Kwz(i,j,k,bi,bj)  = 0. _d 0
-#  ifdef GM_NON_UNITY_DIAGONAL
            Kux(i,j,k,bi,bj)  = 0. _d 0
            Kvy(i,j,k,bi,bj)  = 0. _d 0
-#  endif
 #  ifdef GM_EXTRA_DIAGONAL
            Kuz(i,j,k,bi,bj)  = 0. _d 0
            Kvz(i,j,k,bi,bj)  = 0. _d 0

--- a/model/src/thermodynamics.F
+++ b/model/src/thermodynamics.F
@@ -304,10 +304,8 @@ CADJ &     comlev1_bibj, key=itdkey,kind = isbyte
 # endif
 # if (defined NONLIN_FRSURF || defined ALLOW_DEPTH_CONTROL) \
         && defined ALLOW_GMREDI
-#  ifdef GM_NON_UNITY_DIAGONAL
 CADJ STORE kux(:,:,:,bi,bj) = comlev1_bibj, key=itdkey, byte=isbyte
 CADJ STORE kvy(:,:,:,bi,bj) = comlev1_bibj, key=itdkey, byte=isbyte
-#  endif
 #  ifdef GM_EXTRA_DIAGONAL
 CADJ STORE kuz(:,:,:,bi,bj) = comlev1_bibj, key=itdkey, byte=isbyte
 CADJ STORE kvz(:,:,:,bi,bj) = comlev1_bibj, key=itdkey, byte=isbyte

--- a/pkg/gmredi/GMREDI.h
+++ b/pkg/gmredi/GMREDI.h
@@ -99,7 +99,7 @@ C     subMeso_Ceff   :: efficiency coefficient of Mixed-Layer Eddies [-]
 C     subMeso_invTau :: inverse of mixing time-scale in sub-meso parameteriz. [s^-1]
 C     subMeso_LfMin  :: minimum value for length-scale "Lf" [m]
 C     subMeso_Lmax   :: maximum horizontal grid-scale length [m]
-C     Variable K with PV diffusion parameters:
+C-    Variable K with PV diffusion parameters:
 C     GM_K3D_gamma   :: mixing efficiency for 3D eddy diffusivity [-]
 C     GM_K3D_b1      :: an empirically determined constant of O(1)
 C     GM_K3D_EadyMinDepth :: upper depth for Eady calculation
@@ -213,19 +213,14 @@ C     Kwz :: K_33 element of GM/Redi tensor, Z direction at W point
       _RL Kwx(1-OLx:sNx+OLx,1-OLy:sNy+OLy,Nr,nSx,nSy)
       _RL Kwy(1-OLx:sNx+OLx,1-OLy:sNy+OLy,Nr,nSx,nSy)
       _RL Kwz(1-OLx:sNx+OLx,1-OLy:sNy+OLy,Nr,nSx,nSy)
-      COMMON /GM_Wtensor/ Kwx,Kwy,Kwz
+      COMMON /GM_Wtensor/ Kwx, Kwy, Kwz
 
-#ifdef GM_NON_UNITY_DIAGONAL
 C     Horizontal part of the tensor
 C     Kux :: K_11 element of GM/Redi tensor, X direction at U point
 C     Kvy :: K_22 element of GM/Redi tensor, Y direction at V point
       _RL Kux(1-OLx:sNx+OLx,1-OLy:sNy+OLy,Nr,nSx,nSy)
       _RL Kvy(1-OLx:sNx+OLx,1-OLy:sNy+OLy,Nr,nSx,nSy)
-      COMMON /GM_HorTensor/ Kux,Kvy
-#else
-      _RL Kux,Kvy
-      PARAMETER(Kux=1.,Kvy=1.)
-#endif
+      COMMON /GM_HorTensor/ Kux, Kvy
 
 #ifdef GM_EXTRA_DIAGONAL
 C     First/second rows of tensor corresponds to U/V points
@@ -233,10 +228,10 @@ C     Kuz :: K_13 element of GM/Redi tensor, Z direction at U point
 C     Kvz :: K_23 element of GM/Redi tensor, Z direction at V point
       _RL Kuz(1-OLx:sNx+OLx,1-OLy:sNy+OLy,Nr,nSx,nSy)
       _RL Kvz(1-OLx:sNx+OLx,1-OLy:sNy+OLy,Nr,nSx,nSy)
-      COMMON /GM_UVtensor/ Kuz,Kvz
+      COMMON /GM_UVtensor/ Kuz, Kvz
 #else
-      _RL Kuz,Kvz
-      PARAMETER(Kuz=1.,Kvz=1.)
+      _RL Kuz, Kvz
+      PARAMETER( Kuz=1., Kvz=1. )
 #endif
 
 #ifdef GM_BOLUS_ADVEC
@@ -244,7 +239,7 @@ C     GM advection formulation: bolus velocities are derived from 2
 C        streamfunctions PsiX and PsiY :
       _RL GM_PsiX(1-OLx:sNx+OLx,1-OLy:sNy+OLy,Nr,nSx,nSy)
       _RL GM_PsiY(1-OLx:sNx+OLx,1-OLy:sNy+OLy,Nr,nSx,nSy)
-      COMMON /GM_BOLUS/ GM_PsiX,GM_PsiY
+      COMMON /GM_BOLUS/ GM_PsiX, GM_PsiY
 #endif
 
 #ifdef GM_VISBECK_VARIABLE_K
@@ -262,14 +257,14 @@ C     modesS       :: First N baroclinic mode at the southern face of a tracer c
 C     Rdef         :: Deformation radius [m]
 C     gradf        :: gradient of the Coriolis paramater at a cell centre, 1/(m*s)
 
-      _RL K3D(1-Olx:sNx+Olx,1-Oly:sNy+Oly,1:Nr,nSx,nSy)
-      _RL modesC(1,1-Olx:sNx+Olx,1-Oly:sNy+Oly,1:Nr,nSx,nSy)
-      _RL modesW(GM_K3D_NModes,1-Olx:sNx+Olx,
-     &     1-Oly:sNy+Oly,1:Nr,nSx,nSy)
-      _RL modesS(GM_K3D_NModes,1-Olx:sNx+Olx,
-     &     1-Oly:sNy+Oly,1:Nr,nSx,nSy)
-      _RL Rdef(1-Olx:sNx+Olx,1-Oly:sNy+Oly,nSx,nSy)
-      _RL gradf(1-Olx:sNx+Olx,1-Oly:sNy+Oly,nSx,nSy)
+      _RL K3D(1-OLx:sNx+OLx,1-OLy:sNy+OLy,1:Nr,nSx,nSy)
+      _RL modesC(1,1-OLx:sNx+OLx,1-OLy:sNy+OLy,1:Nr,nSx,nSy)
+      _RL modesW(GM_K3D_NModes,1-OLx:sNx+OLx,
+     &     1-OLy:sNy+OLy,1:Nr,nSx,nSy)
+      _RL modesS(GM_K3D_NModes,1-OLx:sNx+OLx,
+     &     1-OLy:sNy+OLy,1:Nr,nSx,nSy)
+      _RL Rdef(1-OLx:sNx+OLx,1-OLy:sNy+OLy,nSx,nSy)
+      _RL gradf(1-OLx:sNx+OLx,1-OLy:sNy+OLy,nSx,nSy)
 
       COMMON /GM_K3D/ K3D, modesC, modesW, modesS, Rdef, gradf
 #endif

--- a/pkg/gmredi/gmredi_calc_tensor.F
+++ b/pkg/gmredi/gmredi_calc_tensor.F
@@ -48,7 +48,6 @@ C     == Global variables ==
 #endif /* ALLOW_AUTODIFF_TAMC */
 
 C     !INPUT/OUTPUT PARAMETERS:
-C     == Routine arguments ==
 C     bi, bj    :: tile indices
 C     myTime    :: Current time in simulation
 C     myIter    :: Current iteration number in simulation
@@ -67,7 +66,6 @@ CEOP
 #ifdef ALLOW_GMREDI
 
 C     !LOCAL VARIABLES:
-C     == Local variables ==
       INTEGER i,j,k
       _RL SlopeX(1-OLx:sNx+OLx,1-OLy:sNy+OLy)
       _RL SlopeY(1-OLx:sNx+OLx,1-OLy:sNy+OLy)
@@ -234,10 +232,8 @@ C-    Just initialize to zero (not use anyway)
          Kwx(i,j,k,bi,bj)  = 0. _d 0
          Kwy(i,j,k,bi,bj)  = 0. _d 0
          Kwz(i,j,k,bi,bj)  = 0. _d 0
-# ifdef GM_NON_UNITY_DIAGONAL
          Kux(i,j,k,bi,bj)  = 0. _d 0
          Kvy(i,j,k,bi,bj)  = 0. _d 0
-# endif
 # ifdef GM_EXTRA_DIAGONAL
          Kuz(i,j,k,bi,bj)  = 0. _d 0
          Kvz(i,j,k,bi,bj)  = 0. _d 0
@@ -824,6 +820,12 @@ CADJ STORE taperFct(:,:)     = comlev1_bibj_k, key=kkey, byte=isbyte
      &     )*SlopeX(i,j)*taperFct(i,j)
          ENDDO
         ENDDO
+c      ELSE
+c       DO j=1-OLy+1,sNy+OLy-1
+c        DO i=1-OLx+1,sNx+OLx-1
+c         Kuz(i,j,k,bi,bj) = 0. _d 0
+c        ENDDO
+c       ENDDO
        ENDIF
 #endif /* GM_EXTRA_DIAGONAL */
 
@@ -1053,6 +1055,12 @@ CADJ STORE taperFct(:,:)     = comlev1_bibj_k, key=kkey, byte=isbyte
      &     )*SlopeY(i,j)*taperFct(i,j)
          ENDDO
         ENDDO
+c      ELSE
+c       DO j=1-OLy+1,sNy+OLy-1
+c        DO i=1-OLx+1,sNx+OLx-1
+c         Kvz(i,j,k,bi,bj) = 0. _d 0
+c        ENDDO
+c       ENDDO
        ENDIF
 #endif /* GM_EXTRA_DIAGONAL */
 
@@ -1115,6 +1123,43 @@ C-- end 3rd  loop on vertical level index k
       ENDDO
 
 #endif /* GM_NON_UNITY_DIAGONAL || GM_EXTRA_DIAGONAL */
+
+#ifndef GM_NON_UNITY_DIAGONAL
+      DO k=1,Nr
+       DO j=1-OLy+1,sNy+OLy-1
+        DO i=1-OLx+1,sNx+OLx-1
+          Kux(i,j,k,bi,bj) = (
+#ifdef ALLOW_KAPREDI_CONTROL
+c#  ifdef ALLOW_KAPREDI_CONTROL_OLD
+c    &       kapRedi(i,j,k,bi,bj)
+     &       op5*(kapRedi(i,j,k,bi,bj)+kapRedi(i-1,j,k,bi,bj))
+#else
+     &       GM_isopycK
+#endif
+#ifdef GM_VISBECK_VARIABLE_K
+     &     + op5*(VisbeckK(i,j,bi,bj)+VisbeckK(i-1,j,bi,bj))
+#endif
+     &                       )
+        ENDDO
+       ENDDO
+       DO j=1-OLy+1,sNy+OLy-1
+        DO i=1-OLx+1,sNx+OLx-1
+          Kvy(i,j,k,bi,bj) = (
+#ifdef ALLOW_KAPREDI_CONTROL
+c#  ifdef ALLOW_KAPREDI_CONTROL_OLD
+c    &       kapRedi(i,j,k,bi,bj)
+     &       op5*(kapRedi(i,j,k,bi,bj)+kapRedi(i,j-1,k,bi,bj))
+#else
+     &       GM_isopycK
+#endif
+#ifdef GM_VISBECK_VARIABLE_K
+     &     + op5*(VisbeckK(i,j,bi,bj)+VisbeckK(i,j-1,bi,bj))
+#endif
+     &                       )
+        ENDDO
+       ENDDO
+      ENDDO
+#endif /* ndef GM_NON_UNITY_DIAGONAL */
 
 #ifdef ALLOW_TIMEAVE
 C--   Time-average
@@ -1199,9 +1244,15 @@ C     !LOCAL VARIABLES:
       DO k=1,Nr
        DO j=1-OLy+1,sNy+OLy-1
         DO i=1-OLx+1,sNx+OLx-1
-         Kwx(i,j,k,bi,bj) = 0.0
-         Kwy(i,j,k,bi,bj) = 0.0
-         Kwz(i,j,k,bi,bj) = 0.0
+         Kwx(i,j,k,bi,bj) = 0. _d 0
+         Kwy(i,j,k,bi,bj) = 0. _d 0
+         Kwz(i,j,k,bi,bj) = 0. _d 0
+         Kux(i,j,k,bi,bj) = 0. _d 0
+         Kvy(i,j,k,bi,bj) = 0. _d 0
+# ifdef GM_EXTRA_DIAGONAL
+         Kuz(i,j,k,bi,bj) = 0. _d 0
+         Kvz(i,j,k,bi,bj) = 0. _d 0
+# endif
         ENDDO
        ENDDO
       ENDDO

--- a/pkg/gmredi/gmredi_calc_tensor.F
+++ b/pkg/gmredi/gmredi_calc_tensor.F
@@ -428,9 +428,11 @@ c            N2loc = -gravity*recip_rhoConst*dSigmaDr(i,j)
 CADJ STORE dSigmaDx(:,:)       = comlev1_bibj_k, key=kkey, byte=isbyte
 CADJ STORE dSigmaDy(:,:)       = comlev1_bibj_k, key=kkey, byte=isbyte
 CADJ STORE dSigmaDr(:,:)       = comlev1_bibj_k, key=kkey, byte=isbyte
+# ifndef GM_EXCLUDE_FM07_TAP
 CADJ STORE baseSlope(:,:)      = comlev1_bibj_k, key=kkey, byte=isbyte
 CADJ STORE hTransLay(:,:)      = comlev1_bibj_k, key=kkey, byte=isbyte
 CADJ STORE recipLambda(:,:)    = comlev1_bibj_k, key=kkey, byte=isbyte
+# endif
 #endif /* ALLOW_AUTODIFF_TAMC */
 
 C     Calculate slopes for use in tensor, taper and/or clip
@@ -523,23 +525,19 @@ C-     Limit range that KapGM can take
         ENDDO
        ENDDO
       ENDIF
-cph( NEW
 #ifdef ALLOW_AUTODIFF_TAMC
 CADJ STORE VisbeckK(:,:,bi,bj) = comlev1_bibj, key=igmkey, byte=isbyte
 #endif
-cph)
 #endif /* GM_VISBECK_VARIABLE_K */
 
 C-    express the Tensor in term of Diffusivity (= m**2 / s )
       DO k=1,Nr
 #ifdef ALLOW_AUTODIFF_TAMC
+C to avoid few minor recomputations (with KAPREDI_CONTROL, KAPGM_CONTROL ?)
        kkey = (igmkey-1)*Nr + k
-# if (defined (GM_NON_UNITY_DIAGONAL) || \
-      defined (GM_VISBECK_VARIABLE_K))
 CADJ STORE Kwx(:,:,k,bi,bj) = comlev1_bibj_k, key=kkey, byte=isbyte
 CADJ STORE Kwy(:,:,k,bi,bj) = comlev1_bibj_k, key=kkey, byte=isbyte
 CADJ STORE Kwz(:,:,k,bi,bj) = comlev1_bibj_k, key=kkey, byte=isbyte
-# endif
 #endif
        km1 = MAX(k-1,1)
        isopycK = GM_isopycK
@@ -642,7 +640,7 @@ C          If using GM_K3D PsiX and PsiY are calculated in gmredi_k3d
        ENDIF
 #endif
       ENDIF
-#endif
+#endif /* GM_BOLUS_ADVEC */
 
 #ifndef GM_EXCLUDE_SUBMESO
       IF ( GM_useSubMeso .AND. GM_AdvForm ) THEN
@@ -711,14 +709,14 @@ C     Gradient of Sigma at U points
        ENDDO
 
 #ifdef ALLOW_AUTODIFF_TAMC
-CADJ STORE SlopeSqr(:,:)       = comlev1_bibj_k, key=kkey, byte=isbyte
 CADJ STORE dSigmaDx(:,:)       = comlev1_bibj_k, key=kkey, byte=isbyte
 CADJ STORE dSigmaDy(:,:)       = comlev1_bibj_k, key=kkey, byte=isbyte
 CADJ STORE dSigmaDr(:,:)       = comlev1_bibj_k, key=kkey, byte=isbyte
-CADJ STORE locMixLayer(:,:)    = comlev1_bibj_k, key=kkey, byte=isbyte
+# ifndef GM_EXCLUDE_FM07_TAP
 CADJ STORE baseSlope(:,:)      = comlev1_bibj_k, key=kkey, byte=isbyte
 CADJ STORE hTransLay(:,:)      = comlev1_bibj_k, key=kkey, byte=isbyte
 CADJ STORE recipLambda(:,:)    = comlev1_bibj_k, key=kkey, byte=isbyte
+# endif
 #endif /* ALLOW_AUTODIFF_TAMC */
 
 C     Calculate slopes for use in tensor, taper and/or clip
@@ -733,7 +731,6 @@ C     Calculate slopes for use in tensor, taper and/or clip
      I             k, bi, bj, myTime, myIter, myThid )
 
 #ifdef ALLOW_AUTODIFF_TAMC
-CADJ STORE SlopeSqr(:,:)       = comlev1_bibj_k, key=kkey, byte=isbyte
 CADJ STORE taperFct(:,:)       = comlev1_bibj_k, key=kkey, byte=isbyte
 #endif /* ALLOW_AUTODIFF_TAMC */
 
@@ -781,7 +778,6 @@ c      ENDIF
 
 #ifdef ALLOW_AUTODIFF_TAMC
 CADJ STORE SlopeX(:,:)       = comlev1_bibj_k, key=kkey, byte=isbyte
-CADJ STORE taperFct(:,:)     = comlev1_bibj_k, key=kkey, byte=isbyte
 #endif /* ALLOW_AUTODIFF_TAMC */
        IF ( GM_ExtraDiag ) THEN
         DO j=1-OLy+1,sNy+OLy-1
@@ -948,9 +944,11 @@ C     Gradient of Sigma at V points
 CADJ STORE dSigmaDx(:,:)       = comlev1_bibj_k, key=kkey, byte=isbyte
 CADJ STORE dSigmaDy(:,:)       = comlev1_bibj_k, key=kkey, byte=isbyte
 CADJ STORE dSigmaDr(:,:)       = comlev1_bibj_k, key=kkey, byte=isbyte
+# ifndef GM_EXCLUDE_FM07_TAP
 CADJ STORE baseSlope(:,:)      = comlev1_bibj_k, key=kkey, byte=isbyte
 CADJ STORE hTransLay(:,:)      = comlev1_bibj_k, key=kkey, byte=isbyte
 CADJ STORE recipLambda(:,:)    = comlev1_bibj_k, key=kkey, byte=isbyte
+# endif
 #endif /* ALLOW_AUTODIFF_TAMC */
 
 C     Calculate slopes for use in tensor, taper and/or clip
@@ -964,13 +962,9 @@ C     Calculate slopes for use in tensor, taper and/or clip
      I             kLow_S,
      I             k, bi, bj, myTime, myIter, myThid )
 
-cph(
 #ifdef ALLOW_AUTODIFF_TAMC
-cph(
-CADJ STORE taperfct(:,:)       = comlev1_bibj_k, key=kkey, byte=isbyte
-cph)
+CADJ STORE taperFct(:,:)       = comlev1_bibj_k, key=kkey, byte=isbyte
 #endif /* ALLOW_AUTODIFF_TAMC */
-cph)
 
 #ifdef GM_NON_UNITY_DIAGONAL
 c      IF ( GM_nonUnitDiag ) THEN
@@ -1016,7 +1010,6 @@ c      ENDIF
 
 #ifdef ALLOW_AUTODIFF_TAMC
 CADJ STORE SlopeY(:,:)       = comlev1_bibj_k, key=kkey, byte=isbyte
-CADJ STORE taperFct(:,:)     = comlev1_bibj_k, key=kkey, byte=isbyte
 #endif /* ALLOW_AUTODIFF_TAMC */
        IF ( GM_ExtraDiag ) THEN
         DO j=1-OLy+1,sNy+OLy-1

--- a/pkg/gmredi/gmredi_diagnostics_fill.F
+++ b/pkg/gmredi/gmredi_diagnostics_fill.F
@@ -1,15 +1,22 @@
 #include "GMREDI_OPTIONS.h"
 
-CStartOfInterface
+CBOP
+C     !ROUTINE: GMREDI_DIAGNOSTICS_FILL
+C     !INTERFACE:
       SUBROUTINE GMREDI_DIAGNOSTICS_FILL(
-     I             bi, bj, myThid )
+     I                  bi, bj, myThid )
+
+C     !DESCRIPTION: \bv
 C     *==========================================================*
 C     | SUBROUTINE GMREDI_DIAGNOSTICS_FILL
 C     | o fill GM-Redi diagnostics
 C     *==========================================================*
-C     | note: formerly was part of S/R GMREDI_CALC_TENSOR
+C     | Note: formerly was part of S/R GMREDI_CALC_TENSOR
 C     |       and was isolated in this S/R for TAF reasons
 C     *==========================================================*
+C     \ev
+
+C     !USES:
       IMPLICIT NONE
 
 C     == Global variables ==
@@ -19,26 +26,27 @@ C     == Global variables ==
 #include "GRID.h"
 #include "GMREDI.h"
 
-C     == Routine arguments ==
-C
+C     !INPUT/OUTPUT PARAMETERS:
+C     bi, bj :: tile indices
+C     myThid :: my Thread Id number
       INTEGER bi,bj
       INTEGER myThid
+
+#ifdef ALLOW_GMREDI
 #ifdef ALLOW_DIAGNOSTICS
+C     !FUNCTIONS:
       LOGICAL     DIAGNOSTICS_IS_ON
       EXTERNAL    DIAGNOSTICS_IS_ON
 #endif /* ALLOW_DIAGNOSTICS */
-CEndOfInterface
+CEOP
 
-#ifdef ALLOW_GMREDI
-
-C     == Local variables ==
+C     !LOCAL VARIABLES:
 #ifdef ALLOW_EDDYPSI
       INTEGER i,j,k
       _RL tmpfld3dloc (1-OLx:sNx+OLx,1-OLy:sNy+OLy,Nr,nSx,nSy)
 #endif
 
 C---+----1----+----2----+----3----+----4----+----5----+----6----+----7-|--+----|
-
 
 #ifdef ALLOW_DIAGNOSTICS
       IF ( useDiagnostics ) THEN
@@ -48,10 +56,8 @@ C---+----1----+----2----+----3----+----4----+----5----+----6----+----7-|--+----|
          CALL DIAGNOSTICS_FILL(VisbeckK,'GM_VisbK',0,1,1,bi,bj,myThid)
        ENDIF
 #endif
-#ifdef GM_NON_UNITY_DIAGONAL
          CALL DIAGNOSTICS_FILL(Kux,'GM_Kux  ',0,Nr,1,bi,bj,myThid)
          CALL DIAGNOSTICS_FILL(Kvy,'GM_Kvy  ',0,Nr,1,bi,bj,myThid)
-#endif
 #ifdef GM_EXTRA_DIAGONAL
        IF ( GM_ExtraDiag ) THEN
          CALL DIAGNOSTICS_FILL(Kuz,'GM_Kuz  ',0,Nr,1,bi,bj,myThid)
@@ -71,8 +77,8 @@ C---+----1----+----2----+----3----+----4----+----5----+----6----+----7-|--+----|
 #ifdef ALLOW_EDDYPSI
        IF ( DIAGNOSTICS_IS_ON('GMEdTauX',myThid) ) THEN
         DO k = 1, Nr
-         DO j = 1, sny
-          DO i = 1, snx
+         DO j = 1, sNy
+          DO i = 1, sNx
            tmpfld3dloc(i,j,k,bi,bj) =
      &      0.5*rhoConst*fCori(i,j,bi,bj)*
      &      Kwy(i,j,k,bi,bj)
@@ -85,8 +91,8 @@ C---+----1----+----2----+----3----+----4----+----5----+----6----+----7-|--+----|
 c
        IF ( DIAGNOSTICS_IS_ON('GMEdTauY',myThid) ) THEN
         DO k = 1, Nr
-         DO j = 1, sny
-          DO i = 1, snx
+         DO j = 1, sNy
+          DO i = 1, sNx
            tmpfld3dloc(i,j,k,bi,bj) =
      &      -0.5*rhoConst*fCori(i,j,bi,bj)*
      &      Kwx(i,j,k,bi,bj)

--- a/pkg/gmredi/gmredi_init_varia.F
+++ b/pkg/gmredi/gmredi_init_varia.F
@@ -24,7 +24,6 @@ C     === Global variables ===
 #include "GMREDI_TAVE.h"
 
 C     !INPUT/OUTPUT PARAMETERS:
-C     === Routine arguments ===
 C     myThid ::  my Thread Id number
       INTEGER myThid
 CEOP
@@ -32,7 +31,6 @@ CEOP
 #ifdef ALLOW_GMREDI
 
 C     !LOCAL VARIABLES:
-C     === Local variables ===
       INTEGER i,j,k,bi,bj
 
       DO bj = myByLo(myThid), myByHi(myThid)
@@ -40,18 +38,16 @@ C     === Local variables ===
 
 C     Initialize arrays in common blocks :
         DO k=1,Nr
-         DO j=1-Oly,sNy+OLy
-          DO i=1-Olx,sNx+Olx
+         DO j=1-OLy,sNy+OLy
+          DO i=1-OLx,sNx+OLx
            Kwx(i,j,k,bi,bj) = 0. _d 0
            Kwy(i,j,k,bi,bj) = 0. _d 0
            Kwz(i,j,k,bi,bj) = 0. _d 0
+           Kux(i,j,k,bi,bj) = 0. _d 0
+           Kvy(i,j,k,bi,bj) = 0. _d 0
 #ifdef GM_EXTRA_DIAGONAL
            Kuz(i,j,k,bi,bj) = 0. _d 0
            Kvz(i,j,k,bi,bj) = 0. _d 0
-#endif
-#ifdef GM_NON_UNITY_DIAGONAL
-           Kux(i,j,k,bi,bj) = 0. _d 0
-           Kvy(i,j,k,bi,bj) = 0. _d 0
 #endif
 #ifdef GM_BOLUS_ADVEC
            GM_PsiX(i,j,k,bi,bj) = 0. _d 0
@@ -106,7 +102,6 @@ C--   write GM scaling factors to file:
       ENDIF
 #endif /* ALLOW_GMREDI */
 
-
 #ifdef GM_K3D
       IF (.NOT.( startTime.EQ.baseTime .AND. nIter0.EQ.0
      &     .AND. pickupSuff.EQ.' ' )) THEN
@@ -121,8 +116,8 @@ C     Computing beta = df/dy
       IF ( selectCoriMap.EQ.1 ) THEN
        DO bj = myByLo(myThid), myByHi(myThid)
         DO bi = myBxLo(myThid), myBxHi(myThid)
-         DO j=1-Oly,sNy+Oly
-          DO i=1-Olx,sNx+Olx
+         DO j=1-OLy,sNy+OLy
+          DO i=1-OLx,sNx+OLx
            gradf(i,j,bi,bj) =  beta
           ENDDO
          ENDDO
@@ -131,8 +126,8 @@ C     Computing beta = df/dy
       ELSEIF ( selectCoriMap.EQ.2 ) THEN
        DO bj = myByLo(myThid), myByHi(myThid)
         DO bi = myBxLo(myThid), myBxHi(myThid)
-         DO j=1-Oly,sNy+Oly
-          DO i=1-Olx,sNx+Olx
+         DO j=1-OLy,sNy+OLy
+          DO i=1-OLx,sNx+OLx
            gradf(i,j,bi,bj) = recip_rSphere*fCoriCos(i,j,bi,bj)
           ENDDO
          ENDDO
@@ -141,8 +136,8 @@ C     Computing beta = df/dy
       ELSE
        DO bj = myByLo(myThid), myByHi(myThid)
         DO bi = myBxLo(myThid), myBxHi(myThid)
-         DO j=1-Oly+1,sNy+Oly-1
-          DO i=1-Olx+1,sNx+Olx-1
+         DO j=1-OLy+1,sNy+OLy-1
+          DO i=1-OLx+1,sNx+OLx-1
            gradf(i,j,bi,bj)  =  .5 _d 0*angleSinC(i,j,bi,bj)*(
      &    (fCori(i+1,j,bi,bj)-fCori(i  ,j,bi,bj))*recip_dxC(i+1,j,bi,bj)
      &   +(fCori(i  ,j,bi,bj)-fCori(i-1,j,bi,bj))*recip_dxC(i,j,bi,bj) )

--- a/pkg/gmredi/gmredi_output.F
+++ b/pkg/gmredi/gmredi_output.F
@@ -26,7 +26,6 @@ C     === Global variables ===
 #include "GMREDI_TAVE.h"
 
 C     !INPUT PARAMETERS:
-C     == Routine arguments ==
 C     myTime :: Current time of simulation ( s )
 C     myIter :: Iteration number
 C     myThid :: my Thread Id number
@@ -41,19 +40,13 @@ C     !FUNCTIONS:
       EXTERNAL DIFFERENT_MULTIPLE
 
 C     !LOCAL VARIABLES:
-C     == Local variables ==
-#if ( defined (ALLOW_TIMEAVE) || \
-      defined (GM_NON_UNITY_DIAGONAL) || defined (GM_EXTRA_DIAGONAL) )
       CHARACTER*(10) suff
-#endif
 #ifdef ALLOW_TIMEAVE
       INTEGER bi, bj
 #endif
 #ifdef ALLOW_MNC
       CHARACTER*(1) pf
 #endif
-
-#if ( defined (GM_NON_UNITY_DIAGONAL) || defined (GM_EXTRA_DIAGONAL) )
 
       IF ( DIFFERENT_MULTIPLE(diagFreq,myTime,deltaTClock)
      &   ) THEN
@@ -64,10 +57,8 @@ C     == Local variables ==
           ELSE
             CALL RW_GET_SUFFIX( suff, myTime, myIter, myThid )
           ENDIF
-#ifdef GM_NON_UNITY_DIAGONAL
           CALL WRITE_FLD_XYZ_RL( 'GM_Kux.',suff,Kux,myIter,myThid)
           CALL WRITE_FLD_XYZ_RL( 'GM_Kvy.',suff,Kvy,myIter,myThid)
-#endif
 #ifdef GM_EXTRA_DIAGONAL
           IF (GM_ExtraDiag) THEN
             CALL WRITE_FLD_XYZ_RL( 'GM_Kuz.',suff,Kuz,myIter,myThid)
@@ -87,10 +78,8 @@ C     == Local variables ==
           CALL MNC_CW_RL_W_S('D','gm_inst',0,0,'T',myTime,myThid)
           CALL MNC_CW_SET_UDIM('gm_inst', 0, myThid)
           CALL MNC_CW_I_W_S('I','gm_inst',0,0,'iter',myIter,myThid)
-#ifdef GM_NON_UNITY_DIAGONAL
           CALL MNC_CW_RL_W(pf,'gm_inst',0,0,'Kux',Kux,myThid)
           CALL MNC_CW_RL_W(pf,'gm_inst',0,0,'Kvy',Kvy,myThid)
-#endif
 #ifdef GM_EXTRA_DIAGONAL
           IF (GM_ExtraDiag) THEN
             CALL MNC_CW_RL_W(pf,'gm_inst',0,0,'Kuz',Kuz,myThid)
@@ -98,11 +87,9 @@ C     == Local variables ==
           ENDIF
 #endif
         ENDIF
-#endif
+#endif /* ALLOW_MNC */
 
       ENDIF
-
-#endif /* GM_NON_UNITY_DIAGONAL || GM_EXTRA_DIAGONAL */
 
 #ifdef ALLOW_TIMEAVE
 C     Dump files and restart average computation if needed

--- a/pkg/gmredi/gmredi_xtransport.F
+++ b/pkg/gmredi/gmredi_xtransport.F
@@ -2,9 +2,6 @@
 #ifdef ALLOW_AUTODIFF
 # include "AUTODIFF_OPTIONS.h"
 #endif
-#ifdef ALLOW_CTRL
-# include "CTRL_OPTIONS.h"
-#endif
 
 CBOP
 C     !ROUTINE: GMREDI_XTRANSPORT
@@ -32,9 +29,6 @@ C     == GLobal variables ==
 #include "PARAMS.h"
 #include "GRID.h"
 #include "GMREDI.h"
-#ifdef ALLOW_CTRL
-# include "CTRL_FIELDS.h"
-#endif
 
 #ifdef ALLOW_AUTODIFF_TAMC
 # include "tamc.h"
@@ -112,10 +106,8 @@ C     i, j    ::  Loop counters
       IF (useGMRedi) THEN
 
 #ifdef ALLOW_AUTODIFF_TAMC
-# ifdef GM_NON_UNITY_DIAGONAL
 CADJ STORE Kux(:,:,k,bi,bj) =
 CADJ &     comlev1_gmredi_k_gad, key=kkey, byte=isbyte
-# endif
 # ifdef GM_EXTRA_DIAGONAL
 CADJ STORE Kuz(:,:,k,bi,bj) =
 CADJ &     comlev1_gmredi_k_gad, key=kkey, byte=isbyte
@@ -127,64 +119,50 @@ C--   Area integrated zonal flux
        DO i=iMin,iMax
         df(i,j) = df(i,j)
      &   -xA(i,j)
-#ifdef GM_NON_UNITY_DIAGONAL
      &    *Kux(i,j,k,bi,bj)
-#else
-#ifdef ALLOW_KAPREDI_CONTROL
-     &    *(kapRedi(i,j,k,bi,bj)
-#else
-     &    *(GM_isopycK
-#endif
-#ifdef GM_VISBECK_VARIABLE_K
-     &     +op5*(VisbeckK(i,j,bi,bj)+VisbeckK(i-1,j,bi,bj))
-#endif
-     &     )
-#endif /* GM_NON_UNITY_DIAGONAL */
      &    *_recip_dxC(i,j,bi,bj)
      &    *(Tracer(i,j,k)-Tracer(i-1,j,k))
        ENDDO
       ENDDO
 
 #ifdef GM_EXTRA_DIAGONAL
-      IF (GM_ExtraDiag) THEN
+      IF ( GM_ExtraDiag ) THEN
        km1 = MAX(k-1,1)
        kp1 = MIN(k+1,Nr)
-
 C-    Vertical gradients interpolated to U points
        DO j=jMin,jMax
         DO i=iMin,iMax
-        dTdz(i,j) =  op5*(
-     &   +op5*recip_drC(k)*
-     &       ( maskC(i-1,j,k,bi,bj)*
-     &           (Tracer(i-1,j,km1)-Tracer(i-1,j,k))
-     &        +maskC( i ,j,k,bi,bj)*
-     &           (Tracer( i ,j,km1)-Tracer( i ,j,k))
-     &       )
-     &   +op5*recip_drC(kp1)*
-     &       ( maskC(i-1,j,kp1,bi,bj)*
-     &           (Tracer(i-1,j,k)-Tracer(i-1,j,kp1))
-     &        +maskC( i ,j,kp1,bi,bj)*
-     &           (Tracer( i ,j,k)-Tracer( i ,j,kp1))
-     &       )      )
-
+         dTdz(i,j) =  op5*(
+     &    +op5*recip_drC(k)*
+     &        ( maskC(i-1,j,k,bi,bj)*
+     &            (Tracer(i-1,j,km1)-Tracer(i-1,j,k))
+     &         +maskC( i ,j,k,bi,bj)*
+     &            (Tracer( i ,j,km1)-Tracer( i ,j,k))
+     &        )
+     &    +op5*recip_drC(kp1)*
+     &        ( maskC(i-1,j,kp1,bi,bj)*
+     &            (Tracer(i-1,j,k)-Tracer(i-1,j,kp1))
+     &         +maskC( i ,j,kp1,bi,bj)*
+     &            (Tracer( i ,j,k)-Tracer( i ,j,kp1))
+     &        )      )
         ENDDO
        ENDDO
 #ifdef GM_AUTODIFF_EXCESSIVE_STORE
-CADJ STORE dtdz(:,:) =
+CADJ STORE dTdz(:,:) =
 CADJ &     comlev1_gmredi_k_gad, key=kkey, byte=isbyte
 #endif
 C-    Off-diagonal components of horizontal flux
        DO j=jMin,jMax
         DO i=iMin,iMax
-        df(i,j) = df(i,j) - xA(i,j)*Kuz(i,j,k,bi,bj)*dTdz(i,j)
+         df(i,j) = df(i,j) - xA(i,j)*Kuz(i,j,k,bi,bj)*dTdz(i,j)
         ENDDO
        ENDDO
       ENDIF
 #endif /* GM_EXTRA_DIAGONAL */
 
 #ifdef GM_BOLUS_ADVEC
-      IF (GM_AdvForm .AND. GM_AdvSeparate
-     & .AND. .NOT.GM_InMomAsStress) THEN
+      IF ( GM_AdvForm .AND. GM_AdvSeparate
+     &                .AND. .NOT.GM_InMomAsStress ) THEN
        kp1 = MIN(k+1,Nr)
        maskp1 = 1.
        IF (k.GE.Nr) maskp1 = 0.
@@ -196,7 +174,7 @@ C-    Off-diagonal components of horizontal flux
         ENDDO
        ENDDO
 #ifdef GM_AUTODIFF_EXCESSIVE_STORE
-CADJ STORE utrans(:,:) =
+CADJ STORE uTrans(:,:) =
 CADJ &     comlev1_gmredi_k_gad, key=kkey, byte=isbyte
 #endif
        DO j=jMin,jMax

--- a/pkg/gmredi/gmredi_ytransport.F
+++ b/pkg/gmredi/gmredi_ytransport.F
@@ -2,10 +2,8 @@
 #ifdef ALLOW_AUTODIFF
 # include "AUTODIFF_OPTIONS.h"
 #endif
-#ifdef ALLOW_CTRL
-# include "CTRL_OPTIONS.h"
-#endif
 
+CBOP
 C     !ROUTINE: GMREDI_YTRANSPORT
 C     !INTERFACE:
       SUBROUTINE GMREDI_YTRANSPORT(
@@ -31,9 +29,6 @@ C     == GLobal variables ==
 #include "PARAMS.h"
 #include "GRID.h"
 #include "GMREDI.h"
-#ifdef ALLOW_CTRL
-# include "CTRL_FIELDS.h"
-#endif
 
 #ifdef ALLOW_AUTODIFF_TAMC
 # include "tamc.h"
@@ -111,10 +106,8 @@ C     i, j    ::  Loop counters
       IF (useGMRedi) THEN
 
 #ifdef ALLOW_AUTODIFF_TAMC
-# ifdef GM_NON_UNITY_DIAGONAL
 CADJ STORE Kvy(:,:,k,bi,bj) =
 CADJ &     comlev1_gmredi_k_gad, key=kkey, byte=isbyte
-# endif
 # ifdef GM_EXTRA_DIAGONAL
 CADJ STORE Kvz(:,:,k,bi,bj) =
 CADJ &     comlev1_gmredi_k_gad, key=kkey, byte=isbyte
@@ -126,64 +119,50 @@ C--   Area integrated meridional flux
        DO i=iMin,iMax
         df(i,j) = df(i,j)
      &   -yA(i,j)
-#ifdef GM_NON_UNITY_DIAGONAL
      &    *Kvy(i,j,k,bi,bj)
-#else
-#ifdef ALLOW_KAPREDI_CONTROL
-     &    *(kapRedi(i,j,k,bi,bj)
-#else
-     &    *(GM_isopycK
-#endif
-#ifdef GM_VISBECK_VARIABLE_K
-     &     +op5*(VisbeckK(i,j,bi,bj)+VisbeckK(i,j-1,bi,bj))
-#endif
-     &     )
-#endif /* GM_NON_UNITY_DIAGONAL */
      &    *_recip_dyC(i,j,bi,bj)
      &    *(Tracer(i,j,k)-Tracer(i,j-1,k))
        ENDDO
       ENDDO
 
 #ifdef GM_EXTRA_DIAGONAL
-      IF (GM_ExtraDiag) THEN
+      IF ( GM_ExtraDiag ) THEN
        km1 = MAX(k-1,1)
        kp1 = MIN(k+1,Nr)
-
 C-    Vertical gradients interpolated to V points
        DO j=jMin,jMax
         DO i=iMin,iMax
-        dTdz(i,j) =  op5*(
-     &   +op5*recip_drC(k)*
-     &       ( maskC(i,j-1,k,bi,bj)*
-     &           (Tracer(i,j-1,km1)-Tracer(i,j-1,k))
-     &        +maskC(i, j ,k,bi,bj)*
-     &           (Tracer(i, j ,km1)-Tracer(i, j ,k))
-     &       )
-     &   +op5*recip_drC(kp1)*
-     &       ( maskC(i,j-1,kp1,bi,bj)*
-     &           (Tracer(i,j-1,k)-Tracer(i,j-1,kp1))
-     &        +maskC(i, j ,kp1,bi,bj)*
-     &           (Tracer(i, j ,k)-Tracer(i, j ,kp1))
-     &       )      )
+         dTdz(i,j) =  op5*(
+     &    +op5*recip_drC(k)*
+     &        ( maskC(i,j-1,k,bi,bj)*
+     &            (Tracer(i,j-1,km1)-Tracer(i,j-1,k))
+     &         +maskC(i, j ,k,bi,bj)*
+     &            (Tracer(i, j ,km1)-Tracer(i, j ,k))
+     &        )
+     &    +op5*recip_drC(kp1)*
+     &        ( maskC(i,j-1,kp1,bi,bj)*
+     &            (Tracer(i,j-1,k)-Tracer(i,j-1,kp1))
+     &         +maskC(i, j ,kp1,bi,bj)*
+     &            (Tracer(i, j ,k)-Tracer(i, j ,kp1))
+     &        )      )
         ENDDO
        ENDDO
 #ifdef GM_AUTODIFF_EXCESSIVE_STORE
-CADJ STORE dtdz(:,:) =
+CADJ STORE dTdz(:,:) =
 CADJ &     comlev1_gmredi_k_gad, key=kkey, byte=isbyte
 #endif
 C-    Off-diagonal components of horizontal flux
        DO j=jMin,jMax
         DO i=iMin,iMax
-          df(i,j) = df(i,j) - yA(i,j)*Kvz(i,j,k,bi,bj)*dTdz(i,j)
-
+         df(i,j) = df(i,j) - yA(i,j)*Kvz(i,j,k,bi,bj)*dTdz(i,j)
         ENDDO
        ENDDO
       ENDIF
 #endif /* GM_EXTRA_DIAGONAL */
 
 #ifdef GM_BOLUS_ADVEC
-      IF (GM_AdvForm .AND. GM_AdvSeparate
-     & .AND. .NOT.GM_InMomAsStress) THEN
+      IF ( GM_AdvForm .AND. GM_AdvSeparate
+     &                .AND. .NOT.GM_InMomAsStress ) THEN
        kp1 = MIN(k+1,Nr)
        maskp1 = 1.
        IF (k.GE.Nr) maskp1 = 0.
@@ -195,7 +174,7 @@ C-    Off-diagonal components of horizontal flux
         ENDDO
        ENDDO
 #ifdef GM_AUTODIFF_EXCESSIVE_STORE
-CADJ STORE vtrans(:,:) =
+CADJ STORE vTrans(:,:) =
 CADJ &     comlev1_gmredi_k_gad, key=kkey, byte=isbyte
 #endif
        DO j=jMin,jMax
@@ -206,8 +185,9 @@ CADJ &     comlev1_gmredi_k_gad, key=kkey, byte=isbyte
        ENDDO
       ENDIF
 
-#ifdef ALLOW_DIAGNOSTICS
 C---+----1----+----2----+----3----+----4----+----5----+----6----+----7-|--+----|
+
+#ifdef ALLOW_DIAGNOSTICS
       IF ( useDiagnostics
      &     .AND. DIAGNOSTICS_IS_ON('GM_vbT  ', myThid )
      &     .AND. trIdentity.EQ.1 ) THEN

--- a/pkg/offline/offline_fields_load.F
+++ b/pkg/offline/offline_fields_load.F
@@ -36,7 +36,6 @@ c#include "GRID.h"
 #include "FFIELDS.h"
 #ifdef ALLOW_GMREDI
 #include "GMREDI.h"
-#include "GMREDI_TAVE.h"
 #endif
 #ifdef ALLOW_KPP
 #include "KPP.h"
@@ -247,7 +246,7 @@ c       print*,'OFFLINE READ', fn
         _EXCH_XYZ_RS(gmkz0, myThid )
         _EXCH_XYZ_RS(gmkz1, myThid )
        ENDIF
-#endif
+#endif /* ALLOW_GMREDI */
 
        IF ( ConvFile .NE. ' ' ) THEN
         I1=IFNBLNK(ConvFile)
@@ -290,7 +289,7 @@ C         even if, for convienience, it will be loaded into array KPPghat
         _EXCH_XYZ_RS(kght0, myThid )
         _EXCH_XYZ_RS(kght1, myThid )
        ENDIF
-#endif
+#endif /* ALLOW_KPP */
 
 C--   Read in 2-D fields and apply EXCH
 

--- a/pkg/offline/offline_get_diffus.F
+++ b/pkg/offline/offline_get_diffus.F
@@ -1,9 +1,12 @@
 #include "OFFLINE_OPTIONS.h"
 #ifdef ALLOW_DIC
-#include "DIC_OPTIONS.h"
+# include "DIC_OPTIONS.h"
 #endif
 #ifdef ALLOW_DARWIN
-#include "DARWIN_OPTIONS.h"
+# include "DARWIN_OPTIONS.h"
+#endif
+#ifdef ALLOW_GMREDI
+# include "GMREDI_OPTIONS.h"
 #endif
 
 CBOP
@@ -107,11 +110,15 @@ C--   Interpolate Diffusivity Components:
      &                        + aWght*gmky1(i,j,k,bi,bj)
             Kwz(i,j,k,bi,bj)  = bWght*gmkz0(i,j,k,bi,bj)
      &                        + aWght*gmkz1(i,j,k,bi,bj)
+#ifndef GM_NON_UNITY_DIAGONAL
+            Kux(i,j,k,bi,bj) = GM_isopycK
+            Kvy(i,j,k,bi,bj) = GM_isopycK
+#endif
            ENDDO
           ENDDO
          ENDDO
         ENDIF
-#endif
+#endif /* ALLOW_GMREDI */
 #ifdef ALLOW_KPP
         IF ( offlineLoadKPP ) THEN
          DO k=1,Nr
@@ -127,7 +134,7 @@ C         the product ghat*diffKzS (and not ghat alone).
           ENDDO
          ENDDO
         ENDIF
-#endif
+#endif /* ALLOW_KPP */
 
 C--   Interpolate surface forcing
 #if ( (defined ALLOW_DIC) || (defined ALLOW_DARWIN) )


### PR DESCRIPTION
## What changes does this PR introduce?
Remove condition (ifdef GM_NON_UNITY_DIAGONAL) around 3-D arrays Kux & Kvy
to simplify how GMREDI is applied (e.g., gmredi_x/ytransport)

## What is the current behaviour? 
with undef GM_NON_UNITY_DIAGONAL, Kux & Kvy are not stored and some simplified code
is needed when applied, i.e., in gmredi_xtransport & gmredi_ytransport.

## What is the new behaviour 
simpler, 3-D array Kux & Kvy are always defined, filled in gmredi_calc_tensor.F and used 
to apply gmredi to any tracer.

## Does this PR introduce a breaking change? 
no, except that with undef GM_NON_UNITY_DIAGONAL, code for ALLOW_KAPREDI_CONTROL got fixed
(corresponding to dropping wrong ALLOW_KAPREDI_CONTROL_OLD implementation).

## Other information:
Having GM_NON_UNITY_DIAGONAL undefined is not usable with any tapering function
(only with slope clipping, not much used and not recommended since diffusion is not applied along
isopycnal surface anymore) and the rarely used, small memory saving was making code more complicated 
(and not coded with few new pkg/gmredi features such as GM_K3D, GM_LeithQG_K, GM_isoFac2d,GM_isoFac1d ).
Also, with this simplified interface, storage in common block of various prognostic K-Redi is not
needed anymore, can just be definedi as local 2-D (e.g.,VisbeckK) or 3-D var (e.g.,  K3D, GM_LeithQG_K)
inside gmredi_calc_tensor.F.

## Suggested addition to `tag-index`
o pkg/gmredi:
  - remove condition (ifdef GM_NON_UNITY_DIAGONAL) around 3-D arrays Kux & Kvy
    to simplify how GMREDI is applied (e.g., gmredi_x/ytransport); fill up these
    2 arrays with constant value (gmredi_calc_tensor.F & offline_get_diffus.F)
    when GM_NON_UNITY_DIAGONAL is undef (to reproduce old results).
  - also with GM_NON_UNITY_DIAGONAL undef, fix ALLOW_KAPREDI_CONTROL averaging.
