### PR TITLE
Use more standard syntax

### DIFF
--- a/doc/tag-index
+++ b/doc/tag-index
@@ -1,6 +1,8 @@
     Notes on tags used in MITgcmUV
     ==============================
 
+o pkg/ecco + other:
+  - fix few non-standard syntax (+ repeated setting of "gencost_msk_is3d").
 o pkg/bling:
   - fix call to S/R BLING_BIO_NITROGEN when USE_SIBLING is defined.
 o pkg/ecco:

--- a/model/src/apply_forcing.F
+++ b/model/src/apply_forcing.F
@@ -675,8 +675,8 @@ C     where the flux at the bottom is applied as kSurfC
         ENDDO
        ENDDO
       ELSE
-       STOP 'Ooops, geothermal heat flux not implemented '//
-     &      'for .NOT.usingZCoords and .not.kSurface.EQ.Nr'
+C-    Neither Z-Coords nor kSurface=Nr : not implemented
+       STOP 'ABNORMAL END: S/R APPLY_FORCING_T (geothermal-flux)'
       ENDIF
 #endif /* ALLOW_GEOTHERMAL_FLUX */
 

--- a/pkg/autodiff/cg2d_mad.F
+++ b/pkg/autodiff/cg2d_mad.F
@@ -102,7 +102,7 @@ CEOP
 C--   mark output of cg2d as being called from here
       IF ( debugLevel .GE. debLevZero ) THEN
        _BEGIN_MASTER( myThid )
-       WRITE(standardmessageunit,'(A)')
+       WRITE(standardMessageUnit,'(A)')
      &      ' Calling cg2d from S/R CG2D_MAD'
        _END_MASTER( myThid )
       ENDIF
@@ -295,10 +295,10 @@ CEOP
 C--   mark output of cg2d as being called from here
       IF ( debugLevel .GE. debLevZero ) THEN
        _BEGIN_MASTER( myThid )
-       WRITE(standardmessageunit,'(A,L)')
+       WRITE(standardMessageUnit,'(A,L1)')
      &      ' Calling CG2D_STORE with doStore = ', doStore
-       WRITE(standardmessageunit,'(A,I4)')
-     &      ' Calling CG2D_STORE with ikey_dynamics = ', ikey_dynamics
+       WRITE(standardMessageUnit,'(A,I6)')
+     &      ' Calling CG2D_STORE with ikey_dynamics=', ikey_dynamics
        _END_MASTER( myThid )
       ENDIF
 

--- a/pkg/ctrl/ctrl_unpack.F
+++ b/pkg/ctrl/ctrl_unpack.F
@@ -881,12 +881,16 @@ c----------------------------------------------------------------------
        do iarr = 1, maxCtrlArr2D
         if (xx_genarr2d_weight(iarr).NE.' ') then
          mskNameForSetUnpack='maskCtrlC'
-         nwettmp(1:Nr) = nwetcglobal(1:Nr)
+         DO k=1,Nr
+           nwettmp(k) = nwetcglobal(k)
+         ENDDO
 # ifdef ALLOW_SHELFICE
          if ((xx_genarr2d_file(iarr)(1:11).eq.'xx_shicoeff').or.
      &       (xx_genarr2d_file(iarr)(1:11).eq.'xx_shicdrag')) then
           mskNameForSetUnpack='maskCtrlI'
-          nwettmp(1:Nr) = nwetiglobal(1:Nr)
+          DO k=1,Nr
+           nwettmp(k) = nwetiglobal(k) 
+          ENDDO
          endif
 # endif
           call ctrl_set_fname( xx_genarr2d_file(iarr),
@@ -923,11 +927,15 @@ cc          write(weighttype(1:80),'(a)') "wunit"
        do iarr = 1, maxCtrlTim2D
         if (xx_gentim2d_weight(iarr).NE.' ') then
          mskNameForSetUnpack='maskCtrlC'
-         nwettmp(1:Nr) = nwetcglobal(1:Nr)
+         DO k=1,Nr
+           nwettmp(k) = nwetcglobal(k)
+         ENDDO
 # ifdef ALLOW_SHELFICE
          if (xx_gentim2d_file(iarr)(1:11).eq.'xx_shifwflx') then
-            mskNameForSetUnpack='maskCtrlI'
-            nwettmp(1:Nr) = nwetiglobal(1:Nr)
+           mskNameForSetUnpack='maskCtrlI'
+           DO k=1,Nr
+             nwettmp(k) = nwetiglobal(k)
+           ENDDO
          endif
 # endif
           call ctrl_set_fname( xx_gentim2d_file(iarr),

--- a/pkg/ecco/ecco_readparms.F
+++ b/pkg/ecco/ecco_readparms.F
@@ -16,10 +16,9 @@ c     ==================================================================
 c     SUBROUTINE ecco_readparms
 c     ==================================================================
 
-      implicit none
+      IMPLICIT NONE
 
 c     == global variables ==
-
 #include "EEPARAMS.h"
 #include "SIZE.h"
 #include "GRID.h"
@@ -29,8 +28,7 @@ c     == global variables ==
 # ifdef ECCO_CTRL_DEPRECATED
 #  include "ecco_cost.h"
 # else
-#  include "ECCO_SIZE.h"
-#  include "ECCO.h"
+#  include "ecco.h"
 #  include "ecco_local_params.h"
 # endif
 #endif
@@ -42,8 +40,11 @@ c     == global variables ==
 #endif
 
 c     == routine arguments ==
-
       integer myThid
+
+c     == external functions ==
+      integer  ilnblnk
+      external ilnblnk
 
 c     == local variables ==
 C     msgBuf      - Informational/error message buffer
@@ -58,14 +59,9 @@ C     iUnit       - Work variable for IO unit number
 #endif
 
 Catn-- retired parameters
-      character*(MAX_LEN_FNAM) topexmeanfile
-      character*(2) cost_yftype
+      CHARACTER*(MAX_LEN_FNAM) topexmeanfile
+      CHARACTER*(2) cost_yftype
       integer nRetired
-
-c     == external functions ==
-
-      integer  ilnblnk
-      external ilnblnk
 
 c     == end of interface ==
 
@@ -181,7 +177,6 @@ c--   Read the namelist input.
      &         gencost_scalefile,
      &         gencost_errfile,
      &         gencost_itracer,
-     &         gencost_kLev_select,
      &         gencost_preproc,
      &         gencost_preproc_c,
      &         gencost_preproc_i,
@@ -512,7 +507,7 @@ Catn-- retired parameters
 c--     Next, read the data.ecco file.
         WRITE(msgBuf,'(A)') 'ECCO_READPARMS: opening data.ecco'
         CALL PRINT_MESSAGE( msgBuf, standardMessageUnit,
-     &                    SQUEEZE_RIGHT , 1)
+     &                      SQUEEZE_RIGHT, myThid )
 
         CALL OPEN_COPY_DATA_FILE(
      I                          'data.ecco', 'ECCO_READPARMS',
@@ -524,7 +519,7 @@ c--     Next, read the data.ecco file.
         WRITE(msgBuf,'(A)')
      &       'ECCO_READPARMS: finished reading #1: ecco_cost_nml'
         CALL PRINT_MESSAGE( msgBuf, standardMessageUnit,
-     &       SQUEEZE_RIGHT , 1)
+     &                      SQUEEZE_RIGHT, myThid )
 
 C--   Check parameters:
         IF ( cost_yftype.NE.'RL' ) THEN
@@ -604,7 +599,6 @@ c--   Set default values.
          gencost_outputlevel(k)= 0
          gencost_errfile(k)    = ' '
          gencost_itracer(k)    = 1
-         gencost_kLev_select(k)= 1
          gencost_mask(k)       = ' '
          gencost_barfile(k)    = ' '
          gencost_spmin(k)      = 0. _d 0
@@ -615,7 +609,7 @@ c--   Set default values.
          gencost_is1d(k)       = .FALSE.
          gencost_is3d(k)       = .FALSE.
          gencost_pointer3d(k)  = 0
-         gencost_msk_is3d      = .FALSE.
+         gencost_msk_is3d(k)   = .FALSE.
          gencost_msk_pointer3d(k)  = 0
 c boxmean/horflux masks
          call ecco_zero(gencost_mskCsurf(1-OLx,1-OLy,1,1,k),
@@ -651,7 +645,7 @@ c boxmean/horflux masks
       WRITE(msgBuf,'(A)')
      &     'ECCO_READPARMS: finished reading #2: ecco_gencost_nml'
       CALL PRINT_MESSAGE( msgBuf, standardMessageUnit,
-     &     SQUEEZE_RIGHT , 1)
+     &                    SQUEEZE_RIGHT, myThid )
 
       gencost_k3d=1
       gencost_msk_k3d=1
@@ -682,7 +676,7 @@ catn with and without requirements of datafile or errfile
            WRITE(msgBuf,'(A,I3,3A,L5)') 'gencost k_boxmean/horflux=',
      &     k,' ',gencost_name(k)(1:il),': ',using_gencost(k)
            CALL PRINT_MESSAGE( msgBuf, standardMessageUnit,
-     &     SQUEEZE_RIGHT , 1)
+     &                         SQUEEZE_RIGHT, myThid )
 
            if ( gencost_msk_is3d(k) ) then
              gencost_msk_pointer3d(k)=gencost_msk_k3d
@@ -697,7 +691,7 @@ catn add cost global transport using gencost framework
            WRITE(msgBuf,'(A,i3,3A,L5)') 'gencost k_transp=',
      &     k,' ',gencost_name(k)(1:il),': ',using_gencost(k)
            CALL PRINT_MESSAGE( msgBuf, standardMessageUnit,
-     &     SQUEEZE_RIGHT , 1)
+     &                         SQUEEZE_RIGHT, myThid )
 
 cts moc cost function using gencost framework
          elseif ( gencost_name(k)(1:3).EQ.'moc' ) then
@@ -707,7 +701,7 @@ cts moc cost function using gencost framework
            WRITE(msgBuf,'(A,i2,2A,L5)') 'gencost k_moc=',
      &     k,gencost_name(k)(1:il),': ',using_gencost(k)
            CALL PRINT_MESSAGE( msgBuf, standardMessageUnit,
-     &     SQUEEZE_RIGHT , 1)
+     &                         SQUEEZE_RIGHT, myThid )
 
 c pre-specified generic cost terms that create their own barfile
          elseif (
@@ -849,10 +843,10 @@ catn separate out blocks of gencost_flag so that each block is checked
      &          'ERROR in ECCO_READPARMS: for gencost',k,
      &          '  ',gencost_name(k)(1:il)
             CALL PRINT_MESSAGE( msgBuf, errorMessageUnit,
-     &          SQUEEZE_RIGHT , 1)
+     &                          SQUEEZE_RIGHT, myThid )
             STOP
      &           'ECCO_READPARMS: gencost_avgperiod not properly set'
-          end if
+          endif
 
           if ( gencost_spmin(k) .EQ. 0. _d 0 .AND.
      &        gencost_spmax(k) .EQ. 0. _d 0 ) then
@@ -861,7 +855,7 @@ catn separate out blocks of gencost_flag so that each block is checked
      &          'ERROR in ECCO_READPARMS: for gencost',k,
      &          '  ',gencost_name(k)(1:il)
             CALL PRINT_MESSAGE( msgBuf, errorMessageUnit,
-     &          SQUEEZE_RIGHT , 1)
+     &                          SQUEEZE_RIGHT, myThid )
             STOP
      &       'ECCO_READPARMS: gencost_spmin, gencost_spmax not set'
           endif
@@ -872,7 +866,7 @@ catn separate out blocks of gencost_flag so that each block is checked
      &          'ERROR in ECCO_READPARMS: for gencost',k,
      &          '  ',gencost_name(k)(1:il)
             CALL PRINT_MESSAGE( msgBuf, errorMessageUnit,
-     &          SQUEEZE_RIGHT , 1)
+     &                          SQUEEZE_RIGHT, myThid )
             STOP
      &       'ECCO_READPARMS: gencost_spzero not set'
           endif
@@ -897,7 +891,7 @@ catn -- checking boxmean and transp
      &          'ERROR in ECCO_READPARMS: for gencost',k,
      &          '  ',gencost_name(k)(1:il)
               CALL PRINT_MESSAGE( msgBuf, errorMessageUnit,
-     &          SQUEEZE_RIGHT , 1)
+     &                            SQUEEZE_RIGHT, myThid )
             STOP
      &           'ECCO_READPARMS: gencost_avgperiod not properly set'
             endif
@@ -923,7 +917,7 @@ catn -- checking boxmean and transp
       WRITE(msgBuf,'(A)')
      &     'ECCO_READPARMS: done'
       CALL PRINT_MESSAGE( msgBuf, standardMessageUnit,
-     &     SQUEEZE_RIGHT , 1)
+     &                    SQUEEZE_RIGHT, myThid )
 
       _BARRIER
 


### PR DESCRIPTION
## What changes does this PR introduce?
minor syntax changes

## What is the current behaviour? 
few isolated non-standard coding in some recent (or less recent) code addition, e.g.,
apply_forcing.F (PR #334), cg2d_mad.F (PR #470)

## What is the new behaviour 
fix few of them ; few more files in pkg/ecco which are modified in PR #505 are left unchanged
(best to fix in this other PR).  

## Does this PR introduce a breaking change? 
no

## Other information:
These non-standard syntax cause an error when using old g77 compiler. This is not a serious limitation since it's not used much anymore but still probably better for portability to use more uniform syntax across the code.
Note: g77 (fwd & adm) testreport are not run anymore on daily bases since the upgrade of "batsi" (from fc29 to fc33) on Dec 10, 2020. Still run fwd (+ adm starting today) once a month on local laptop.

## Suggested addition to `tag-index`
o pkg/ecco + other:
  - fix few non-standard syntax (+ repeated setting of "gencost_msk_is3d").