### PR TITLE
Fixes some math notation in Docs

### DIFF
--- a/doc/algorithm/algorithm.rst
+++ b/doc/algorithm/algorithm.rst
@@ -48,17 +48,17 @@ Basic operators:
 | :math:`\delta_x` :
   :math:`\delta_x \Phi = \frac{1}{\Delta x} \delta_i \Phi`
 |
-| :math:`\overline{\nabla}` = horizontal gradient operator :
-  :math:`\overline{\nabla} \Phi = \{ \delta_x \Phi , \delta_y \Phi \}`
+| :math:`\overline{\boldsymbol{\nabla}}` = horizontal gradient operator :
+  :math:`\overline{\boldsymbol{\nabla}} \Phi = \{ \delta_x \Phi , \delta_y \Phi \}`
 |
-| :math:`\overline{\nabla} \cdot` = horizontal divergence operator :
-  :math:`\overline{\nabla}\cdot \vec{\mathrm{f}}  = 
+| :math:`\overline{\boldsymbol{\nabla}} \cdot` = horizontal divergence operator :
+  :math:`\overline{\boldsymbol{\nabla}}\cdot \vec{\mathrm{{\bf f}}}  = 
   \frac{1}{\cal A} \{ \delta_i \Delta y \, \mathrm{f}_x 
                     + \delta_j \Delta x \, \mathrm{f}_y \}`
 |
 | :math:`\overline{\nabla}^2` = horizontal Laplacian operator :
   :math:`\overline{\nabla}^2 \Phi = 
-     \overline{\nabla}\cdot \overline{\nabla}\Phi`
+     \overline{\boldsymbol{\nabla}} \cdot \overline{\boldsymbol{\nabla}} \Phi`
 |
 
 .. _time_stepping:
@@ -617,11 +617,11 @@ follow equations:
 
 .. math::
    \eta^* = \epsilon_{fs} \left( \eta^{n} + \Delta t ({\mathcal{P-E}}) \right)- \Delta t
-     \nabla \cdot H \widehat{ \vec{\bf v}^{**} }
+     \boldsymbol{\nabla} \cdot H \widehat{ \vec{\bf v}^{**} }
    :label: nstar-sync
 
 .. math::
-   \nabla \cdot g H \nabla \eta^{n+1} - \frac{\epsilon_{fs} \eta^{n+1}}{\Delta t^2} ~ = ~ - \frac{\eta^*}{\Delta t^2}
+   \boldsymbol{\nabla} \cdot g H \boldsymbol{\nabla} \eta^{n+1} - \frac{\epsilon_{fs} \eta^{n+1}}{\Delta t^2} ~ = ~ - \frac{\eta^*}{\Delta t^2}
    :label: elliptic-sync
 
 .. math::
@@ -740,11 +740,11 @@ position in time of variables appropriately:
 
 .. math::
    \eta^*  = \epsilon_{fs} \left( \eta^{n-1/2} + \Delta t ({\mathcal{P-E}})^n \right)- \Delta t
-     \nabla \cdot H \widehat{ \vec{\bf v}^{**} }
+     \boldsymbol{\nabla} \cdot H \widehat{ \vec{\bf v}^{**} }
    :label: nstar-staggered
 
 .. math::
-   \nabla \cdot g H \nabla \eta^{n+1/2}  -  \frac{\epsilon_{fs} \eta^{n+1/2}}{\Delta t^2}
+   \boldsymbol{\nabla} \cdot g H \nabla \eta^{n+1/2}  -  \frac{\epsilon_{fs} \eta^{n+1/2}}{\Delta t^2}
    ~ = ~ - \frac{\eta^*}{\Delta t^2}
    :label: elliptic-staggered
 
@@ -2046,17 +2046,17 @@ forcing, respectively, namely:
 
 .. math::
    G_{adv}^\tau = \partial_x u \tau + \partial_y v \tau + \partial_r w \tau
-   - \tau \nabla \cdot {\bf v}
+   - \tau \boldsymbol{\nabla} \cdot {\bf v}
    :label: g_adv-tau
 
 .. math::
-   G_{diff}^\tau = \nabla \cdot {\bf K} \nabla \tau
+   G_{diff}^\tau = \boldsymbol{\nabla} \cdot \left ( {\bf K} \boldsymbol{\nabla} \tau \right )
    :label: g_diff-tau
 
 and the forcing can be some arbitrary function of state, time and
 space.
 
-The term, :math:`\tau \nabla \cdot {\bf v}`, is required to retain local
+The term, :math:`\tau \boldsymbol{\nabla} \cdot {\bf v}`, is required to retain local
 conservation in conjunction with the linear implicit free-surface. It
 only affects the surface layer since the flow is non-divergent
 everywhere else. This term is therefore referred to as the surface
@@ -2545,8 +2545,8 @@ divergent motions. As such, a small :math:`\mathcal{O}(\epsilon)` correction is 
 
 .. math::
     \nu_{*} = \left(\frac{\Lambda \Delta s}{\pi}\right)^{3} 
-    \sqrt{|\nabla_{h}(f\mathbf{\hat{z}}) + \nabla_{h}(\nabla \times \mathbf{v}_{h*}) + 
-    \partial_{z} \frac{f}{N^{2}} \nabla_{h} b|^{2} + | \nabla[\nabla \cdot \mathbf{v}_{h}]|^{2}}
+    \sqrt{|\nabla_{h}(f\mathbf{\hat{z}}) + \boldsymbol{\nabla}_{h}(\boldsymbol{\nabla} \times \mathbf{v}_{h*}) + 
+    \partial_{z} \frac{f}{N^{2}} \nabla_{h} b|^{2} + | \boldsymbol{\nabla} [\boldsymbol{\nabla} \cdot \mathbf{v}_{h}]|^{2}}
     :label: bachman2017_eq40
 
 This form is, however, numerically awkward; as the Brunt-Väisälä Frequency becomes very small
@@ -2558,8 +2558,8 @@ the Froude number, and :math:`Ro_{*}`, the Rossby number. The second of which,
 .. math::
     \begin{aligned}
     \nu_{*} = & \left(\frac{\Lambda \Delta s}{\pi}\right)^{3} \\
-    & \sqrt{min\left(|\nabla_{h}q_{2*} + \partial_{z} \frac{f^{2}}{N^{2}} \nabla_{h} b |,
-    \left( 1 + \frac{Fr_{*}^{2}}{Ro_{*}^{2}} + Fr_{*}^{4}\right) |\nabla_{h}q_{2*}|\right)^{2} + | \nabla[\nabla \cdot \mathbf{v}_{h}]|^{2}},
+    & \sqrt{\min \left(|\boldsymbol{\nabla}_{h}q_{2*} + \partial_{z} \frac{f^{2}}{N^{2}} \boldsymbol{\nabla}_{h} b |,
+    \left( 1 + \frac{Fr_{*}^{2}}{Ro_{*}^{2}} + Fr_{*}^{4}\right) |\nabla_{h}q_{2*}|\right)^{2} + | \boldsymbol{\nabla}[\boldsymbol{\nabla} \cdot \mathbf{v}_{h}]|^{2}},
     \end{aligned}
     :label: bachman2017_eq56
 

--- a/doc/algorithm/algorithm.rst
+++ b/doc/algorithm/algorithm.rst
@@ -18,7 +18,7 @@ Notation
 Because of the particularity of the vertical direction in stratified
 fluid context, in this chapter, the vector notations are mostly used for
 the horizontal component: the horizontal part of a vector is simply
-written :math:`\vec{\bf v}` (instead of :math:`{\bf v_h}` or
+written :math:`\vec{\bf v}` (instead of :math:`{{\bf v}_h}` or
 :math:`\vec{\mathbf{v}}_{h}` in chapter 1) and a 3D vector is simply
 written :math:`\vec{v}` (instead of :math:`\vec{\mathbf{v}}` in chapter
 1).
@@ -127,9 +127,9 @@ The horizontal momentum and continuity equations for the ocean
 .. math::
 
    \begin{aligned}
-   \partial_t u + g \partial_x \eta & = & G_u \\
-   \partial_t v + g \partial_y \eta & = & G_v \\
-   \partial_x u + \partial_y v + \partial_z w & = & 0\end{aligned}
+   \partial_t u + g \partial_x \eta & = G_u \\
+   \partial_t v + g \partial_y \eta & = G_v \\
+   \partial_x u + \partial_y v + \partial_z w & = 0\end{aligned}
 
 where we are adopting the oceanic notation for brevity. All terms in
 the momentum equations, except for surface pressure gradient, are
@@ -257,10 +257,10 @@ those implicit terms is provided in :numref:`implicit-backward-stepping`, and mo
 
    \begin{aligned}
    u^{n+1} - \Delta t \partial_z A_v \partial_z u^{n+1}
-   + \Delta t g \partial_x \eta^{n+1} & = & u^{n} + \Delta t G_u^{(n+1/2)}
+   + \Delta t g \partial_x \eta^{n+1} & = u^{n} + \Delta t G_u^{(n+1/2)}
    \\
    v^{n+1} - \Delta t \partial_z A_v \partial_z v^{n+1}
-   + \Delta t g \partial_y \eta^{n+1} & = & v^{n} + \Delta t G_v^{(n+1/2)}\end{aligned}
+   + \Delta t g \partial_y \eta^{n+1} & = v^{n} + \Delta t G_v^{(n+1/2)}\end{aligned}
 
 
 .. _press_meth_linear:
@@ -856,9 +856,9 @@ As before, the explicit predictions for momentum are consolidated as:
 .. math::
 
    \begin{aligned}
-   u^* & = & u^n + \Delta t G_u^{(n+1/2)} \\
-   v^* & = & v^n + \Delta t G_v^{(n+1/2)} \\
-   w^* & = & w^n + \Delta t G_w^{(n+1/2)}\end{aligned}
+   u^* & = u^n + \Delta t G_u^{(n+1/2)} \\
+   v^* & = v^n + \Delta t G_v^{(n+1/2)} \\
+   w^* & = w^n + \Delta t G_w^{(n+1/2)}\end{aligned}
 
 but this time we introduce an intermediate step by splitting the
 tendency of the flow as follows:
@@ -1313,8 +1313,8 @@ where the Coriolis parameters :math:`f` and :math:`f'` are defined:
 .. math::
 
    \begin{aligned}
-   f & = & 2 \Omega \sin{\varphi} \\
-   f' & = & 2 \Omega \cos{\varphi}\end{aligned}
+   f & = 2 \Omega \sin{\varphi} \\
+   f' & = 2 \Omega \cos{\varphi}\end{aligned}
 
 where :math:`\varphi` is geographic latitude when using spherical
 geometry, otherwise the :math:`\beta`-plane definition is used:
@@ -1322,8 +1322,8 @@ geometry, otherwise the :math:`\beta`-plane definition is used:
 .. math::
 
    \begin{aligned}
-   f & = & f_o + \beta y \\
-   f' & = & 0\end{aligned}
+   f & = f_o + \beta y \\
+   f' & = 0\end{aligned}
 
 This discretization globally conserves kinetic energy. It should be
 noted that despite the use of this discretization in former
@@ -1393,8 +1393,8 @@ exclusively been used to date:
 .. math::
 
    \begin{aligned}
-   G_u^{metric} & = & \frac{u \overline{v}^{ij} }{a} \tan{\varphi} \\
-   G_v^{metric} & = & \frac{ \overline{u}^{ij} \overline{u}^{ij}}{a} \tan{\varphi}\end{aligned}
+   G_u^{metric} & = \frac{u \overline{v}^{ij} }{a} \tan{\varphi} \\
+   G_v^{metric} & = \frac{ \overline{u}^{ij} \overline{u}^{ij}}{a} \tan{\varphi}\end{aligned}
 
 where :math:`\tan{\varphi}` is evaluated at the :math:`u` and :math:`v`
 points respectively.
@@ -1434,11 +1434,11 @@ in the past, used a different discretization in the model which is:
 .. math::
 
    \begin{aligned}
-   G_u^{metric} & = &
+   G_u^{metric} & = 
    - \frac{u}{a} \overline{w}^{ik} \\
-   G_v^{metric} & = &
+   G_v^{metric} & = 
    - \frac{v}{a} \overline{w}^{jk} \\
-   G_w^{metric} & = &
+   G_w^{metric} & = 
      \frac{1}{a} ( {\overline{u}^{ik}}^2 + {\overline{v}^{jk}}^2 )\end{aligned}
 
 .. admonition:: S/R  :filelink:`MOM_U_METRIC_NH <pkg/mom_common/mom_u_metric_nh.F>`, :filelink:`MOM_V_METRIC_NH <pkg/mom_common/mom_v_metric_nh.F>`
@@ -1586,9 +1586,9 @@ In the interior the vertical stresses are discretized:
 .. math::
 
    \begin{aligned}
-   \tau_{13} & = & A_v \frac{1}{\Delta r_c} \delta_k u \\
-   \tau_{23} & = & A_v \frac{1}{\Delta r_c} \delta_k v \\
-   \tau_{33} & = & A_v \frac{1}{\Delta r_f} \delta_k w\end{aligned}
+   \tau_{13} & = A_v \frac{1}{\Delta r_c} \delta_k u \\
+   \tau_{23} & = A_v \frac{1}{\Delta r_c} \delta_k v \\
+   \tau_{33} & = A_v \frac{1}{\Delta r_f} \delta_k w\end{aligned}
 
 It should be noted that in the non-hydrostatic form, the stress tensor
 is even less consistent than for the hydrostatic (see Wajsowicz (1993)
@@ -1967,10 +1967,10 @@ where
 .. math::
 
    \begin{aligned}
-   D^* & = & \frac{1}{{\cal A}_c h_c} (
+   D^* & = \frac{1}{{\cal A}_c h_c} (
      \delta_i \Delta y_g h_w \nabla^2 u
    + \delta_j \Delta x_g h_s \nabla^2 v ) \\
-   \zeta^* & = & \frac{1}{{\cal A}_\zeta} (
+   \zeta^* & = \frac{1}{{\cal A}_\zeta} (
      \delta_i \Delta y_c \nabla^2 v
    - \delta_j \Delta x_c \nabla^2 u )\end{aligned}
 
@@ -2003,8 +2003,8 @@ In the interior the vertical stresses are discretized:
 .. math::
 
    \begin{aligned}
-   \tau_{13} & = & A_v \frac{1}{\Delta r_c} \delta_k u \\
-   \tau_{23} & = & A_v \frac{1}{\Delta r_c} \delta_k v\end{aligned}
+   \tau_{13} & = A_v \frac{1}{\Delta r_c} \delta_k u \\
+   \tau_{23} & = A_v \frac{1}{\Delta r_c} \delta_k v\end{aligned}
 
 .. admonition:: S/R  :filelink:`MOM_U_RVISCFLUX <pkg/mom_common/mom_u_rviscflux.F>`, :filelink:`MOM_V_RVISCFLUX <pkg/mom_common/mom_u_rviscflux.F>`
   :class: note

--- a/doc/algorithm/algorithm.rst
+++ b/doc/algorithm/algorithm.rst
@@ -1739,7 +1739,7 @@ following or the conformal spherical cube system.
 The non-hydrostatic vector invariant equations read:
 
 .. math::
-   \partial_t \vec{v} + ( 2\vec{\Omega} + \vec{\zeta}) \wedge \vec{v}
+   \partial_t \vec{v} + ( 2\vec{\boldsymbol{\Omega}} + \vec{\zeta}) \wedge \vec{v}
    - b \hat{r}
    + \vec{\nabla} B = \vec{\nabla} \cdot \vec{\bf \tau}
    :label: vect_invar_nh

--- a/doc/algorithm/nonlinear-freesurf.rst
+++ b/doc/algorithm/nonlinear-freesurf.rst
@@ -217,13 +217,13 @@ the barotropic part (to find :math:`\eta`) and baroclinic part (to find
 To illustrate this, consider the shallow water model, with a source of
 fresh water (:math:`\mathcal{P}`):
 
-.. math:: \partial_t h + \nabla \cdot h \vec{\bf v} = \mathcal{P}
+.. math:: \partial_t h + \boldsymbol{\nabla} \cdot h \vec{\bf v} = \mathcal{P}
 
 where :math:`h` is the total thickness of the water column. To conserve
 the tracer :math:`\theta` we have to discretize:
 
 .. math::
-   \partial_t (h \theta) + \nabla \cdot ( h \theta \vec{\bf v})
+   \partial_t (h \theta) + \boldsymbol{\nabla} \cdot ( h \theta \vec{\bf v})
      = \mathcal{P} \theta_{\mathrm{rain}}
 
 Using the implicit (non-linear) free surface described above
@@ -231,7 +231,7 @@ Using the implicit (non-linear) free surface described above
 
 .. math::
    \begin{aligned}
-   h^{n+1} = h^{n} - \Delta t \nabla \cdot (h^n \, \vec{\bf v}^{n+1} ) + \Delta t \mathcal{P} \\\end{aligned}
+   h^{n+1} = h^{n} - \Delta t \boldsymbol{\nabla} \cdot (h^n \, \vec{\bf v}^{n+1} ) + \Delta t \mathcal{P} \\\end{aligned}
 
 The discretized form of the tracer equation must adopt the same “form”
 in the computation of tracer fluxes, that is, the same value of
@@ -240,7 +240,7 @@ in the computation of tracer fluxes, that is, the same value of
 .. math::
    \begin{aligned}
    h^{n+1} \, \theta^{n+1} = h^n \, \theta^n
-           - \Delta t \nabla \cdot (h^n \, \theta^n \, \vec{\bf v}^{n+1})
+           - \Delta t \boldsymbol{\nabla} \cdot (h^n \, \theta^n \, \vec{\bf v}^{n+1})
            + \Delta t \mathcal{P} \theta_{rain}\end{aligned}
 
 The use of a 3 time-levels time-stepping scheme such as the
@@ -256,7 +256,7 @@ formulation (with the “*surface correction*” turned “on”, see tracer
 section):
 
 .. math::
-   G_\theta^n = \left(- \nabla \cdot (h^n \, \theta^n \, \vec{\bf v}^{n+1})
+   G_\theta^n = \left(- \boldsymbol{\nabla} \cdot (h^n \, \theta^n \, \vec{\bf v}^{n+1})
             - \dot{r}_{surf}^{n+1} \theta^n \right) / h^n
 
 Then, in a second step, the thickness variation (expansion/reduction)
@@ -268,7 +268,7 @@ is taken into account:
 
 Note that with a simple forward time step (no Adams-Bashforth), these
 two formulations are equivalent, since
-:math:`(h^{n+1} - h^{n})/ \Delta t = \mathcal{P} - \nabla \cdot (h^n \, \vec{\bf v}^{n+1} ) = P + \dot{r}_{surf}^{n+1}`
+:math:`(h^{n+1} - h^{n})/ \Delta t = \mathcal{P} - \boldsymbol{\nabla} \cdot (h^n \, \vec{\bf v}^{n+1} ) = P + \dot{r}_{surf}^{n+1}`
 
 .. _nonlin-freesurf-timestepping:
 
@@ -319,9 +319,9 @@ r-coordinate.
      \begin{aligned}
      \eta^{n+1/2} \hspace{-1mm} & =
      \eta^{n-1/2} + \Delta t P^{n+1/2} - \Delta t
-     \nabla \cdot \int \vec{\bf v}^{n+1/2} dh^{n} \\
+     \boldsymbol{\nabla} \cdot \int \vec{\bf v}^{n+1/2} dh^{n} \\
      & = \eta^{n-1/2} + \Delta t P^{n+1/2} - \Delta t
-     \nabla \cdot \int \!\!\! \left( \vec{\bf v}^* - g \Delta t \nabla \eta^{n+1/2} \right) dh^{n}\end{aligned}
+     \boldsymbol{\nabla} \cdot \int \!\!\! \left( \vec{\bf v}^* - g \Delta t \nabla \eta^{n+1/2} \right) dh^{n}\end{aligned}
      :label: nstar-nlfs
 
   .. math::
@@ -331,7 +331,7 @@ r-coordinate.
 
   .. math::
      h^{n+1} = h^{n} + \Delta t P^{n+1/2} - \Delta t
-       \nabla \cdot \int \vec{\bf v}^{n+1/2} dh^{n}
+       \boldsymbol{\nabla} \cdot \int \vec{\bf v}^{n+1/2} dh^{n}
      :label: h-n+1-nlfs
 
   .. math::

--- a/doc/examples/advection_in_gyre/advection_in_gyre.rst
+++ b/doc/examples/advection_in_gyre/advection_in_gyre.rst
@@ -43,10 +43,10 @@ Advection and tracer transport
 In general, the tracer problem we want to solve can be written
 
 .. math::
-   \frac{\partial C}{\partial t} = -U \cdot \nabla C + S
+   \frac{\partial C}{\partial t} = -\boldsymbol{U} \cdot \boldsymbol{\nabla} C + S
    :label: eg-adv-gyre-generic-tracer
 
-where :math:`C` is the tracer concentration in a model cell, :math:`U=(u,v,w)`
+where :math:`C` is the tracer concentration in a model cell, :math:`\boldsymbol{U}=(u,v,w)`
 is the model 3-D flow field. In
 :eq:`eg-adv-gyre-generic-tracer`, :math:`S` represents
 source, sink and tendency terms not associated with advective transport.
@@ -57,7 +57,7 @@ of mixing. In this section we are primarily concerned with
 
 #. how to introduce the tracer term, :math:`C`, into an integration
 
-#. the different discretized forms of the :math:`-U \cdot \nabla C` term
+#. the different discretized forms of the :math:`-\boldsymbol{U} \cdot \boldsymbol{\nabla} C` term
    that are available
 
 Introducing a tracer into the flow

--- a/doc/examples/deep_convection/deep_convection.rst
+++ b/doc/examples/deep_convection/deep_convection.rst
@@ -112,7 +112,7 @@ solved in this configuration as follows:
      \frac{1}{\rho}\frac{\partial p^{'}}{\partial x} -
      \nabla_{h}\cdot A_{h}\nabla_{h}u -
      \frac{\partial}{\partial z}A_{z}\frac{\partial u}{\partial z}
-    & = &
+    & =
    \begin{cases}
    0 & \text{(surface)} \\
    0 & \text{(interior)}
@@ -122,7 +122,7 @@ solved in this configuration as follows:
      \frac{1}{\rho}\frac{\partial p^{'}}{\partial y} -
      \nabla_{h}\cdot A_{h}\nabla_{h}v -
      \frac{\partial}{\partial z}A_{z}\frac{\partial v}{\partial z}
-   & = &
+   & =
    \begin{cases}
    0 & \text{(surface)} \\
    0 & \text{(interior)}
@@ -132,7 +132,7 @@ solved in this configuration as follows:
      \frac{1}{\rho}\frac{\partial p^{'}}{\partial z} -
      \nabla_{h}\cdot A_{h}\nabla_{h}w -
      \frac{\partial}{\partial z}A_{z}\frac{\partial w}{\partial z}
-   & = &
+   & =
    \begin{cases}
    0 & \text{(surface)} \\
    0 & \text{(interior)}
@@ -141,13 +141,13 @@ solved in this configuration as follows:
    \frac{\partial u}{\partial x} +
    \frac{\partial v}{\partial y} +
    \frac{\partial w}{\partial z} +
-   &=&
+   &=
    0
    \\
    \frac{D\theta}{Dt} -
     \nabla_{h}\cdot K_{h}\nabla_{h}\theta
     - \frac{\partial}{\partial z}K_{z}\frac{\partial\theta}{\partial z}
-   & = &
+   & =
    \begin{cases}
    {\cal F}_\theta & \text{(surface)} \\
    0 & \text{(interior)}

--- a/doc/examples/global_oce_biogeo/global_oce_biogeo.rst
+++ b/doc/examples/global_oce_biogeo/global_oce_biogeo.rst
@@ -63,7 +63,7 @@ comes from chemical and biological sources and sinks. For any tracer
 
 .. math::
 
-   \frac{\partial A}{\partial t}=-\nabla \cdot (\vec{u^{*}} A)+\nabla \cdot
+   \frac{\partial A}{\partial t}=-\boldsymbol{\nabla} \cdot (\vec{u^{*}} A)+\boldsymbol{\nabla} \cdot
      (\mathbf{K}\nabla A)+S_A \nonumber
 
 where :math:`\vec{u^{*}}` is the transformed Eulerian mean circulation

--- a/doc/examples/global_oce_biogeo/global_oce_biogeo.rst
+++ b/doc/examples/global_oce_biogeo/global_oce_biogeo.rst
@@ -75,11 +75,11 @@ The sources and sinks are:
 
 .. math::
    \begin{aligned}
-   S_{DIC} & = &  F_{CO_2} + V_{CO_2} + r_{C:P} S_{PO_4}  + J_{Ca} \\
-   S_{ALK} & = &  V_{ALK}-r_{N:P} S_{PO_4}  + 2 J_{Ca}  \\
-   S_{PO_4}& = &  -f_{DOP} J_{prod} - \frac{\partial F_P}{\partial z} + \kappa_{remin} [DOP]\\
-   S_{DOP} & = &  f_{DOP} J_{prod} -\kappa_{remin} [DOP] \\
-   S_{O_2} & = & \left\{ \begin{array}{ll}
+   S_{DIC} & =  F_{CO_2} + V_{CO_2} + r_{C:P} S_{PO_4}  + J_{Ca} \\
+   S_{ALK} & =  V_{ALK}-r_{N:P} S_{PO_4}  + 2 J_{Ca}  \\
+   S_{PO_4}& =  -f_{DOP} J_{prod} - \frac{\partial F_P}{\partial z} + \kappa_{remin} [DOP]\\
+   S_{DOP} & =  f_{DOP} J_{prod} -\kappa_{remin} [DOP] \\
+   S_{O_2} & = \left\{ \begin{array}{ll}
                   -r_{O:P} S_{PO_4} & \mbox{if $O_2>O_{2crit}$} \\
                    0  & \mbox{if $O_2<O_{2crit}$}
                          \end{array}

--- a/doc/examples/global_oce_in_p/global_oce_in_p.rst
+++ b/doc/examples/global_oce_in_p/global_oce_in_p.rst
@@ -91,8 +91,8 @@ variables :math:`x` and :math:`y` are initialized according to
 .. math::
 
    \begin{aligned}
-   x=r\cos(\phi),~\Delta x & = &r\cos(\Delta \phi) \\
-   y=r\lambda,~\Delta y &= &r\Delta \lambda \end{aligned}
+   x=r\cos(\phi),~\Delta x & = r\cos(\Delta \phi) \\
+   y=r\lambda,~\Delta y & = r\Delta \lambda \end{aligned}
 
 Arctic polar regions are not included in this experiment. Meridionally
 the model extends from 80\ :sup:`o`\ S to

--- a/doc/examples/held_suarez_cs/held_suarez_cs.rst
+++ b/doc/examples/held_suarez_cs/held_suarez_cs.rst
@@ -77,9 +77,9 @@ layer. It is defined so as to decay as pressure decreases according to
 
    \begin{aligned}
    \label{eq:eg-hs-define_kv}
-   k_\mathbf{v} & = & k_{f}~\max[0,~(p^*/P^{0}_{s}-\sigma_{b})/(1-\sigma_{b})]
+   k_\mathbf{v} & = k_{f}~\max[0,~(p^*/P^{0}_{s}-\sigma_{b})/(1-\sigma_{b})]
    \\
-   \sigma_{b} & = & 0.7 ~~{\rm and}~~
+   \sigma_{b} & = 0.7 ~~{\rm and}~~
    k_{f}  =  1/86400 ~{\rm s}^{-1}\end{aligned}
 
 where :math:`p^*` is the pressure level of the cell center and

--- a/doc/examples/held_suarez_cs/held_suarez_cs.rst
+++ b/doc/examples/held_suarez_cs/held_suarez_cs.rst
@@ -139,9 +139,9 @@ configuration:
 .. math::
    \frac{\partial \vec{\mathbf{v}}_h}{\partial t}
    +(f + \zeta)\hat{\mathbf{k}} \times \vec{\mathbf{v}}_h
-   +\mathbf{\nabla }_{p} (\rm{KE})
+   +\mathbf{\boldsymbol{\nabla}}_{p} (\rm{KE})
    + \omega \frac{\partial \vec{\mathbf{v}}_h }{\partial p}
-   +\mathbf{\nabla }_p \Phi ^{\prime }
+   +\mathbf{\boldsymbol{\nabla}}_p \Phi ^{\prime }
    = -k_\mathbf{v}\vec{\mathbf{v}}_h
    :label: eg-hs-model_equations
 
@@ -150,12 +150,12 @@ configuration:
    +\frac{\partial \Pi }{\partial p}\theta ^{\prime } =0
 
 .. math::
-   \mathbf{\nabla }_{p}\cdot \vec{\mathbf{v}}_h+\frac{\partial \omega }{
+   \mathbf{\boldsymbol{\nabla}}_{p}\cdot \vec{\mathbf{v}}_h+\frac{\partial \omega }{
    \partial p} =0
 
 .. math::
    \frac{\partial \theta }{\partial t}
-   + \mathbf{\nabla }_{p}\cdot (\theta \vec{\mathbf{v}}_h)
+   + \mathbf{\boldsymbol{\nabla}}_{p}\cdot (\theta \vec{\mathbf{v}}_h)
    + \frac{\partial (\theta \omega)}{\partial p}
    = -k_{\theta}[\theta-\theta_{eq}]
 

--- a/doc/examples/plume_on_slope/plume_on_slope.rst
+++ b/doc/examples/plume_on_slope/plume_on_slope.rst
@@ -147,12 +147,12 @@ where
 .. math::
 
    \begin{aligned}
-   Nx & = & 320 \\
-   Lx & = & 6400 \;\; \mbox{(m)} \\
-   \Delta x_1 & = & \frac{2}{3} \frac{Lx}{Nx} \;\; \mbox{(m)} \\
-   \Delta x_2 & = & \frac{Lx/2}{Nx-Lx/(2 \Delta x_1)} \;\; \mbox{(m)} \\
-   i_s & = & Lx/( 2 \Delta x_1 ) \\
-   w & = & 40\end{aligned}
+   Nx & = 320 \\
+   Lx & = 6400 \;\; \mbox{(m)} \\
+   \Delta x_1 & = \frac{2}{3} \frac{Lx}{Nx} \;\; \mbox{(m)} \\
+   \Delta x_2 & = \frac{Lx/2}{Nx-Lx/(2 \Delta x_1)} \;\; \mbox{(m)} \\
+   i_s & = Lx/( 2 \Delta x_1 ) \\
+   w & = 40\end{aligned}
 
 Here, :math:`\Delta x_1` is the resolution on the shelf,
 :math:`\Delta x_2` is the resolution in deep water and :math:`Nx` is the
@@ -167,11 +167,11 @@ where
 .. math::
 
    \begin{aligned}
-   H_o & = & 200 \;\; \mbox{(m)} \\
-   h_s & = & 40 \;\; \mbox{(m)} \\
-   x_s & = & 1500 + Lx/2 \;\; \mbox{(m)} \\
-   L_s & = & \frac{(H_o - h_s)}{2 s} \;\; \mbox{(m)} \\
-   s & = & 0.15\end{aligned}
+   H_o & = 200 \;\; \mbox{(m)} \\
+   h_s & = 40 \;\; \mbox{(m)} \\
+   x_s & = 1500 + Lx/2 \;\; \mbox{(m)} \\
+   L_s & = \frac{(H_o - h_s)}{2 s} \;\; \mbox{(m)} \\
+   s & = 0.15\end{aligned}
 
 Here, :math:`s` is the maximum slope, :math:`H_o` is the maximum depth,
 :math:`h_s` is the shelf depth, :math:`x_s` is the lateral position of
@@ -188,9 +188,9 @@ where
 .. math::
 
    \begin{aligned}
-   Q_o & = & 200 \;\; \mbox{(W m$^{-2}$)} \\
-   x_q & = & 2500 + Lx/2 \;\; \mbox{(m)} \\
-   L_q & = & 100 \;\; \mbox{(m)}\end{aligned}
+   Q_o & = 200 \;\; \mbox{(W m$^{-2}$)} \\
+   x_q & = 2500 + Lx/2 \;\; \mbox{(m)} \\
+   L_q & = 100 \;\; \mbox{(m)}\end{aligned}
 
 Here, :math:`Q_o` is the maximum heat flux, :math:`x_q` is the
 position of the cut-off, and :math:`L_q` is the width of the cut-off.

--- a/doc/examples/tracer_adjsens/tracer_adjsens.rst
+++ b/doc/examples/tracer_adjsens/tracer_adjsens.rst
@@ -31,7 +31,7 @@ currents. The full equation for the time evolution
 
 .. math::
    \frac{\partial C}{\partial t} \, = \,
-   -U\cdot \nabla C \, - \, \mu C \, + \, \Gamma(C) \,+ \, S
+   -\boldsymbol{U} \cdot \boldsymbol{\nabla} C \, - \, \mu C \, + \, \Gamma(C) \,+ \, S
    :label: carbon_ddt
 
 also includes a source term :math:`S`. This term represents interior

--- a/doc/outp_pkgs/outp_pkgs.rst
+++ b/doc/outp_pkgs/outp_pkgs.rst
@@ -2031,7 +2031,7 @@ The package is also able to compute the simpler planetary vorticity as:
 
 .. math::
    \begin{aligned}
-   Q_{spl} &=& -\frac{f}{\rho}\frac{\sigma_\theta}{\partial z}\end{aligned}
+   Q_{spl} & = -\frac{f}{\rho}\frac{\sigma_\theta}{\partial z}\end{aligned}
    :label: pv_eq3
 
 Surface vertical potential vorticity fluxes
@@ -2118,7 +2118,7 @@ processes. Taking the ratio of :eq:`pv_eq14a` and
 .. math::
 
    \begin{aligned}
-     \frac{J^F_z}{J^B_Z} &=& \frac{ \frac{1}{\rho\delta_e} \vec{k}\times\tau\cdot \boldsymbol{\nabla}\sigma }
+     \frac{J^F_z}{J^B_Z} & = \frac{ \frac{1}{\rho\delta_e} \vec{k}\times\tau\cdot \boldsymbol{\nabla}\sigma }
      {-\frac{f}{h}\left( \frac{\alpha Q_{net}}{C_w}-\rho_0 \beta S_{net}\right)} \\
      &\simeq& \frac{Q_{Ek}/\delta_e}{Q_{net}/h} \nonumber\end{aligned}
 
@@ -2127,9 +2127,9 @@ where appears the lateral heat flux induced by Ekman currents:
 .. math::
 
    \begin{aligned}
-     Q_{Ek} &=& -\frac{C_w}{\alpha\rho f}\vec{k}\times\tau\cdot \boldsymbol{\nabla}\sigma
+     Q_{Ek} & = -\frac{C_w}{\alpha\rho f}\vec{k}\times\tau\cdot \boldsymbol{\nabla}\sigma
      \nonumber \\
-     &=& \frac{C_w}{\alpha}\delta_e\vec{u_{Ek}}\cdot \boldsymbol{\nabla}\sigma\end{aligned}
+     & = \frac{C_w}{\alpha}\delta_e\vec{u_{Ek}}\cdot \boldsymbol{\nabla}\sigma\end{aligned}
 
 which can be computed with the package. In the aim of comparing both
 processes, it will be useful to plot surface net and lateral
@@ -2180,7 +2180,7 @@ Key routines
 
    .. math::
       \begin{aligned}
-        J^B_z &=& -\frac{f}{h}\frac{\alpha Q_{net}}{C_w} \end{aligned}
+        J^B_z & = -\frac{f}{h}\frac{\alpha Q_{net}}{C_w} \end{aligned}
 
    which is a simplified version of the full expression given in
    :eq:`pv_eq14a`. Requires the net surface heat flux and the
@@ -2193,7 +2193,7 @@ Key routines
 
    .. math::
       \begin{aligned}
-       Q_{Ek} &=& - \frac{C_w \delta_e}{\alpha f}J^F_z\end{aligned}
+       Q_{Ek} & = - \frac{C_w \delta_e}{\alpha f}J^F_z\end{aligned}
 
    Requires the PV flux due to frictional forces and the Ekman layer
    depth, and produces one output with the heat flux and with QEk as a
@@ -2283,7 +2283,7 @@ The conservative flux form of the potential vorticity equation is:
 
 .. math::
    \begin{aligned}
-   \frac{\partial \rho Q}{\partial t} + \nabla \cdot \vec{J} &=& 0 \end{aligned}
+   \frac{\partial \rho Q}{\partial t} + \nabla \cdot \vec{J} & = 0 \end{aligned}
    :label: pv_eq4
 
 where the potential vorticity :math:`Q` is given by :eq:`pv_eq2`.
@@ -2292,39 +2292,39 @@ The generalized flux vector of potential vorticity is:
 
 .. math::
    \begin{aligned}
-    \vec{J} &=& \rho Q \vec{u} + \vec{N_Q}\end{aligned}
+    \vec{J} & = \rho Q \vec{u} + \vec{N_Q}\end{aligned}
 
 which allows to rewrite :eq:`pv_eq4` as:
 
 .. math::
    \begin{aligned}
-   \frac{DQ}{dt} &=& -\frac{1}{\rho}\nabla\cdot\vec{N_Q}\end{aligned}
+   \frac{DQ}{dt} & = -\frac{1}{\rho}\nabla\cdot\vec{N_Q}\end{aligned}
    :label: pv_eq5
 
 where the non-advective PV flux :math:`\vec{N_Q}` is given by:
 
 .. math::
    \begin{aligned}
-   \vec{N_Q} &=& -\frac{\rho_0}{g}B\vec{\omega_a} + \vec{F}\times\nabla\sigma_\theta \end{aligned}
+   \vec{N_Q} & = -\frac{\rho_0}{g}B\vec{\omega_a} + \vec{F}\times\nabla\sigma_\theta \end{aligned}
    :label: pv_eq6
 
 Its first component is linked to the buoyancy forcing:
 
 .. math::
    \begin{aligned}
-    B &=& -\frac{g}{\rho_o}\frac{D \sigma_\theta}{dt} \end{aligned}
+    B & = -\frac{g}{\rho_o}\frac{D \sigma_\theta}{dt} \end{aligned}
 
 and the second one to the non-conservative body forces per unit mass:
 
 .. math::
    \begin{aligned}
-    \vec{F} &=& \frac{D \vec{u}}{dt} + 2\Omega\times\vec{u} + \nabla p \end{aligned}
+    \vec{F} & = \frac{D \vec{u}}{dt} + 2\Omega\times\vec{u} + \nabla p \end{aligned}
 
 Note that introducing :math:`B` into :eq:`pv_eq6` yields:
 
    .. math::
       \begin{aligned}
-        \vec{N_Q} &=& \omega_a \frac{D \sigma_\theta}{dt} + \vec{F}\times\nabla\sigma_\theta\end{aligned}
+        \vec{N_Q} & = \omega_a \frac{D \sigma_\theta}{dt} + \vec{F}\times\nabla\sigma_\theta\end{aligned}
 
 
 Determining the PV flux at the ocean’s surface
@@ -2346,16 +2346,16 @@ package) and of hydrostatic and geostrophic balances, we can write:
 
 .. math::
    \begin{aligned}
-     \vec{u_g} &=& \frac{1}{\rho f} \vec{k}\times\nabla p \\
-     \frac{\partial p_m}{\partial z} &=& -\sigma_m g \\
-     \frac{\partial \sigma_m}{\partial t} + \vec{u}_m\cdot \boldsymbol{\nabla}\sigma_m &=& -\frac{\rho_0}{g}B \end{aligned}
+     \vec{u_g} & = \frac{1}{\rho f} \vec{k}\times\nabla p \\
+     \frac{\partial p_m}{\partial z} & = -\sigma_m g \\
+     \frac{\partial \sigma_m}{\partial t} + \vec{u}_m\cdot \boldsymbol{\nabla}\sigma_m & = -\frac{\rho_0}{g}B \end{aligned}
    :label: pv_eq7
 
 where:
 
 .. math::
    \begin{aligned}
-     \vec{u}_m &=& \vec{u}_g + \vec{u}_{Ek} + o(R_o) \end{aligned}
+     \vec{u}_m & = \vec{u}_g + \vec{u}_{Ek} + o(R_o) \end{aligned}
    :label: pv_eq8
 
 is the full velocity field composed of the geostrophic current
@@ -2363,7 +2363,7 @@ is the full velocity field composed of the geostrophic current
 
 .. math::
   \begin{aligned}
-     \vec{u}_{Ek} &=& -\frac{1}{\rho f}\vec{k}\times\frac{\partial \tau}{\partial z}\end{aligned}
+     \vec{u}_{Ek} & = -\frac{1}{\rho f}\vec{k}\times\frac{\partial \tau}{\partial z}\end{aligned}
   :label: pv_eq9
 
 (where :math:`\tau` is the wind stress) and last by other ageostrophic
@@ -2373,26 +2373,26 @@ Partitioning the buoyancy forcing as:
 
 .. math::
    \begin{aligned}
-     B &=& B_g + B_{Ek}\end{aligned}
+     B & = B_g + B_{Ek}\end{aligned}
    :label: pv_eq10
 
 and using :eq:`pv_eq8` and :eq:`pv_eq9`, :eq:`pv_eq7` becomes:
 
 .. math::
    \begin{aligned}
-    \frac{\partial \sigma_m}{\partial t} + \vec{u}_g\cdot \boldsymbol{\nabla}\sigma_m &=& -\frac{\rho_0}{g} B_g\end{aligned}
+    \frac{\partial \sigma_m}{\partial t} + \vec{u}_g\cdot \boldsymbol{\nabla}\sigma_m & = -\frac{\rho_0}{g} B_g\end{aligned}
 
 revealing the “wind-driven buoyancy forcing”:
 
 .. math::
    \begin{aligned}
-     B_{Ek} &=& \frac{g}{\rho_0}\frac{1}{\rho f}\left(\vec{k}\times\frac{\partial \tau}{\partial z}\right)\cdot \boldsymbol{\nabla}\sigma_m\end{aligned}
+     B_{Ek} & = \frac{g}{\rho_0}\frac{1}{\rho f}\left(\vec{k}\times\frac{\partial \tau}{\partial z}\right)\cdot \boldsymbol{\nabla}\sigma_m\end{aligned}
 
 Note that since:
 
 .. math::
    \begin{aligned}
-     \frac{\partial B_g}{\partial z} &=& \frac{\partial}{\partial z}\left(-\frac{g}{\rho_0}\vec{u_g}\cdot \boldsymbol{\nabla}\sigma_m\right)
+     \frac{\partial B_g}{\partial z} & = \frac{\partial}{\partial z}\left(-\frac{g}{\rho_0}\vec{u_g}\cdot \boldsymbol{\nabla}\sigma_m\right)
      = -\frac{g}{\rho_0}\frac{\partial \vec{u_g}}{\partial z}\cdot \boldsymbol{\nabla}\sigma_m
      = 0\end{aligned}
 
@@ -2409,7 +2409,7 @@ where :math:`\mathcal{B}_{in}` is the vertically integrated surface buoyancy (in
 
 .. math::
    \begin{aligned}
-     \mathcal{B}_{in} &=& \frac{g}{\rho_o}\left( \frac{\alpha Q_{net}}{C_w} - \rho_0\beta S_{net}\right)\end{aligned}
+     \mathcal{B}_{in} & = \frac{g}{\rho_o}\left( \frac{\alpha Q_{net}}{C_w} - \rho_0\beta S_{net}\right)\end{aligned}
    :label: pv_eq12
 
 with :math:`\alpha\simeq 2.5\times10^{-4}\, \text{K}^{-1}` the thermal
@@ -2426,7 +2426,7 @@ Introducing the body force in the Ekman layer:
 
 .. math::
    \begin{aligned}
-     F_z &=& \frac{1}{\rho}\frac{\partial \tau}{\partial z}\end{aligned}
+     F_z & = \frac{1}{\rho}\frac{\partial \tau}{\partial z}\end{aligned}
 
 the vertical component of :eq:`pv_eq6` is:
 
@@ -2450,7 +2450,7 @@ vanishes and we obtain:
 
 .. math::
    \begin{aligned}
-     \vec{N_Q}_z &=& -\frac{\rho_0}{g}f B_g\end{aligned}
+     \vec{N_Q}_z & = -\frac{\rho_0}{g}f B_g\end{aligned}
    :label: pv_eq13
 
 Note that the wind-stress forcing does not appear explicitly here but

--- a/doc/outp_pkgs/outp_pkgs.rst
+++ b/doc/outp_pkgs/outp_pkgs.rst
@@ -2283,7 +2283,7 @@ The conservative flux form of the potential vorticity equation is:
 
 .. math::
    \begin{aligned}
-   \frac{\partial \rho Q}{\partial t} + \nabla \cdot \vec{J} & = 0 \end{aligned}
+   \frac{\partial \rho Q}{\partial t} + \boldsymbol{\nabla} \cdot \vec{J} & = 0 \end{aligned}
    :label: pv_eq4
 
 where the potential vorticity :math:`Q` is given by :eq:`pv_eq2`.

--- a/doc/outp_pkgs/outp_pkgs.rst
+++ b/doc/outp_pkgs/outp_pkgs.rst
@@ -2017,7 +2017,7 @@ The package then computes the potential vorticity as:
 
 .. math::
    \begin{aligned}
-   Q &= -\frac{1}{\rho} \omega\cdot\nabla\sigma_\theta\\
+   Q &= -\frac{1}{\rho} \omega\cdot \boldsymbol{\nabla}\sigma_\theta\\
     &= -\frac{1}{\rho}\left(\omega_x \frac{\partial \sigma_\theta}{\partial x} +
    \omega_y \frac{\partial \sigma_\theta}{\partial y} +
    \left(f+\zeta\right) \frac{\partial \sigma_\theta}{\partial z}\right)\end{aligned}
@@ -2050,7 +2050,7 @@ by:
    :label: pv_eq14a
 
 .. math::
-   J^F_z = \frac{1}{\rho\delta_e} \vec{k}\times\tau\cdot\nabla\sigma_m
+   J^F_z = \frac{1}{\rho\delta_e} \vec{k}\times\tau\cdot \boldsymbol{\nabla}\sigma_m
   :label: pv_eq15a
 
 These components can be computed with the package. Details on the
@@ -2102,10 +2102,10 @@ mixing which reduces the stratification and the PV.
 
 .. math::
    \begin{aligned}
-    \vec{k}\times\tau\cdot\nabla\sigma &> 0 \phantom{WWW}\text{("Down-front" wind)} \\
+    \vec{k}\times\tau\cdot \boldsymbol{\nabla}\sigma &> 0 \phantom{WWW}\text{("Down-front" wind)} \\
     J^F_z &> 0 \phantom{WWW}\text{(upward)} \\
      -\rho^{-1}\nabla\cdot J^F_z &< 0 \phantom{WWW}\text{(PV flux divergence)} \\
-     PV &\searrow \phantom{WWW}\text{where } \vec{k}\times\tau\cdot\nabla\sigma>0 \end{aligned}
+     PV &\searrow \phantom{WWW}\text{where } \vec{k}\times\tau\cdot \boldsymbol{\nabla}\sigma>0 \end{aligned}
 
 
 Diabatic versus frictional processes
@@ -2118,7 +2118,7 @@ processes. Taking the ratio of :eq:`pv_eq14a` and
 .. math::
 
    \begin{aligned}
-     \frac{J^F_z}{J^B_Z} &=& \frac{ \frac{1}{\rho\delta_e} \vec{k}\times\tau\cdot\nabla\sigma }
+     \frac{J^F_z}{J^B_Z} &=& \frac{ \frac{1}{\rho\delta_e} \vec{k}\times\tau\cdot \boldsymbol{\nabla}\sigma }
      {-\frac{f}{h}\left( \frac{\alpha Q_{net}}{C_w}-\rho_0 \beta S_{net}\right)} \\
      &\simeq& \frac{Q_{Ek}/\delta_e}{Q_{net}/h} \nonumber\end{aligned}
 
@@ -2127,9 +2127,9 @@ where appears the lateral heat flux induced by Ekman currents:
 .. math::
 
    \begin{aligned}
-     Q_{Ek} &=& -\frac{C_w}{\alpha\rho f}\vec{k}\times\tau\cdot\nabla\sigma
+     Q_{Ek} &=& -\frac{C_w}{\alpha\rho f}\vec{k}\times\tau\cdot \boldsymbol{\nabla}\sigma
      \nonumber \\
-     &=& \frac{C_w}{\alpha}\delta_e\vec{u_{Ek}}\cdot\nabla\sigma\end{aligned}
+     &=& \frac{C_w}{\alpha}\delta_e\vec{u_{Ek}}\cdot \boldsymbol{\nabla}\sigma\end{aligned}
 
 which can be computed with the package. In the aim of comparing both
 processes, it will be useful to plot surface net and lateral
@@ -2348,7 +2348,7 @@ package) and of hydrostatic and geostrophic balances, we can write:
    \begin{aligned}
      \vec{u_g} &=& \frac{1}{\rho f} \vec{k}\times\nabla p \\
      \frac{\partial p_m}{\partial z} &=& -\sigma_m g \\
-     \frac{\partial \sigma_m}{\partial t} + \vec{u}_m\cdot\nabla\sigma_m &=& -\frac{\rho_0}{g}B \end{aligned}
+     \frac{\partial \sigma_m}{\partial t} + \vec{u}_m\cdot \boldsymbol{\nabla}\sigma_m &=& -\frac{\rho_0}{g}B \end{aligned}
    :label: pv_eq7
 
 where:
@@ -2380,20 +2380,20 @@ and using :eq:`pv_eq8` and :eq:`pv_eq9`, :eq:`pv_eq7` becomes:
 
 .. math::
    \begin{aligned}
-    \frac{\partial \sigma_m}{\partial t} + \vec{u}_g\cdot\nabla\sigma_m &=& -\frac{\rho_0}{g} B_g\end{aligned}
+    \frac{\partial \sigma_m}{\partial t} + \vec{u}_g\cdot \boldsymbol{\nabla}\sigma_m &=& -\frac{\rho_0}{g} B_g\end{aligned}
 
 revealing the “wind-driven buoyancy forcing”:
 
 .. math::
    \begin{aligned}
-     B_{Ek} &=& \frac{g}{\rho_0}\frac{1}{\rho f}\left(\vec{k}\times\frac{\partial \tau}{\partial z}\right)\cdot\nabla\sigma_m\end{aligned}
+     B_{Ek} &=& \frac{g}{\rho_0}\frac{1}{\rho f}\left(\vec{k}\times\frac{\partial \tau}{\partial z}\right)\cdot \boldsymbol{\nabla}\sigma_m\end{aligned}
 
 Note that since:
 
 .. math::
    \begin{aligned}
-     \frac{\partial B_g}{\partial z} &=& \frac{\partial}{\partial z}\left(-\frac{g}{\rho_0}\vec{u_g}\cdot\nabla\sigma_m\right)
-     = -\frac{g}{\rho_0}\frac{\partial \vec{u_g}}{\partial z}\cdot\nabla\sigma_m
+     \frac{\partial B_g}{\partial z} &=& \frac{\partial}{\partial z}\left(-\frac{g}{\rho_0}\vec{u_g}\cdot \boldsymbol{\nabla}\sigma_m\right)
+     = -\frac{g}{\rho_0}\frac{\partial \vec{u_g}}{\partial z}\cdot \boldsymbol{\nabla}\sigma_m
      = 0\end{aligned}
 
 :math:`B_g` must be uniform throughout the depth of the mixed layer and
@@ -2438,7 +2438,7 @@ the vertical component of :eq:`pv_eq6` is:
      &= -\frac{\rho_0}{g}B_g\omega_z
      -\frac{\rho_0}{g}
      \left(\frac{g}{\rho_0}\frac{1}{\rho f}\vec{k}\times\frac{\partial \tau}{\partial z}
-       \cdot\nabla\sigma_m\right)\omega_z
+       \cdot \boldsymbol{\nabla}\sigma_m\right)\omega_z
      + \frac{1}{\rho}
      \left( \frac{\partial \tau}{\partial z}\times\nabla\sigma_\theta \right)\cdot\vec{k}\\
      &= -\frac{\rho_0}{g}B_g\omega_z
@@ -2465,9 +2465,9 @@ integrated “wind-driven buoyancy forcing”:
      B_g &= \frac{1}{h}\left( \mathcal{B}_{in} - \int_{-h}^0B_{Ek}dz \right)  \\
      &= \frac{1}{h}\frac{g}{\rho_0}\left( \frac{\alpha Q_{net}}{C_w} - \rho_0 \beta S_{net}\right)
      - \frac{1}{h}\int_{-h}^0
-     \frac{g}{\rho_0}\frac{1}{\rho f}\vec{k}\times \frac{\partial \tau}{\partial z} \cdot\nabla\sigma_m dz \\
+     \frac{g}{\rho_0}\frac{1}{\rho f}\vec{k}\times \frac{\partial \tau}{\partial z} \cdot \boldsymbol{\nabla}\sigma_m dz \\
      &= \frac{1}{h}\frac{g}{\rho_0}\left( \frac{\alpha Q_{net}}{C_w} - \rho_0 \beta S_{net}\right)
-     - \frac{g}{\rho_0}\frac{1}{\rho f \delta_e}\vec{k}\times\tau\cdot\nabla\sigma_m\end{aligned}
+     - \frac{g}{\rho_0}\frac{1}{\rho f \delta_e}\vec{k}\times\tau\cdot \boldsymbol{\nabla}\sigma_m\end{aligned}
 
 Finally, from :eq:`pv_eq6`, the vertical surface flux of PV may
 be written as:
@@ -2476,7 +2476,7 @@ be written as:
    \begin{aligned}
      \vec{N_Q}_z &= J^B_z + J^F_z  \\
      J^B_z &= -\frac{f}{h}\left( \frac{\alpha Q_{net}}{C_w}-\rho_0 \beta S_{net}\right) \\
-     J^F_z &= \frac{1}{\rho\delta_e} \vec{k}\times\tau\cdot\nabla\sigma_m \end{aligned}
+     J^F_z &= \frac{1}{\rho\delta_e} \vec{k}\times\tau\cdot \boldsymbol{\nabla}\sigma_m \end{aligned}
 
 .. _sub_outp_pkg_flt:
 

--- a/doc/overview/eqn_motion_ocn.rst
+++ b/doc/overview/eqn_motion_ocn.rst
@@ -9,7 +9,7 @@ obtained. The non-Boussinesq equations for oceanic motion are:
 
 .. math::
    \frac{D\vec{\mathbf{v}}_{h}}{Dt}+f\hat{\mathbf{k}}\times \vec{\mathbf{v}}
-   _{h}+\frac{1}{\rho }\mathbf{\nabla }_{z}p  = \vec{\mathbf{\mathcal{F}}} 
+   _{h}+\frac{1}{\rho }\mathbf{\boldsymbol{\nabla}}_{z}p  = \vec{\mathbf{\mathcal{F}}} 
    :label: non-boussinesq_horizmom
 
 .. math::
@@ -17,7 +17,7 @@ obtained. The non-Boussinesq equations for oceanic motion are:
    :label: non-boussinesq_vertmom
 
 .. math::
-   \frac{1}{\rho }\frac{D\rho }{Dt}+\mathbf{\nabla }_{z}\cdot \vec{\mathbf{v}}
+   \frac{1}{\rho }\frac{D\rho }{Dt}+\mathbf{\boldsymbol{\nabla}}_{z}\cdot \vec{\mathbf{v}}
    _{h}+\frac{\partial w}{\partial z}  = 0
    :label: eq-zns-cont
 
@@ -54,7 +54,7 @@ is the reciprocal of the sound speed (:math:`c_{s}`) squared.
 Substituting into :eq:`eq-zns-cont` gives:
 
 .. math::
-   \frac{1}{\rho c_{s}^{2}}\frac{Dp}{Dt}+\mathbf{\nabla }_{z}\cdot \vec{\mathbf{
+   \frac{1}{\rho c_{s}^{2}}\frac{Dp}{Dt}+\mathbf{\boldsymbol{\nabla}}_{z}\cdot \vec{\mathbf{
    v}}+\partial _{z}w\approx 0  
    :label: eq-zns-pressure
 
@@ -65,7 +65,7 @@ yields a system that can be explicitly integrated forward:
 
 .. math::
    \frac{D\vec{\mathbf{v}}_{h}}{Dt}+f\hat{\mathbf{k}}\times \vec{\mathbf{v}}
-   _{h}+\frac{1}{\rho }\mathbf{\nabla }_{z}p = \vec{\mathbf{\mathcal{F}}}
+   _{h}+\frac{1}{\rho }\mathbf{\boldsymbol{\nabla}}_{z}p = \vec{\mathbf{\mathcal{F}}}
    :label: eq-cns-hmom 
 
 .. math::
@@ -73,7 +73,7 @@ yields a system that can be explicitly integrated forward:
    :label: eq-cns-hydro
 
 .. math::
-   \frac{1}{\rho c_{s}^{2}}\frac{Dp}{Dt}+\mathbf{\nabla }_{z}\cdot \vec{\mathbf{v}}_{h}+\frac{\partial w}{\partial z} = 0
+   \frac{1}{\rho c_{s}^{2}}\frac{Dp}{Dt}+\mathbf{\boldsymbol{\nabla}}_{z}\cdot \vec{\mathbf{v}}_{h}+\frac{\partial w}{\partial z} = 0
    :label: eq-cns-cont
 
 .. math::
@@ -99,7 +99,7 @@ acceleration:
 
 .. math::
    \frac{D\vec{\mathbf{v}}_{h}}{Dt}+f\hat{\mathbf{k}}\times \vec{\mathbf{v}}
-   _{h}+\frac{1}{\rho _{o}}\mathbf{\nabla }_{z}p = \vec{\mathbf{\mathcal{F}}}
+   _{h}+\frac{1}{\rho _{o}}\mathbf{\boldsymbol{\nabla}}_{z}p = \vec{\mathbf{\mathcal{F}}}
    :label: eq-zcb-hmom
 
 .. math::
@@ -108,7 +108,7 @@ acceleration:
    :label: eq-zcb-hydro
 
 .. math::
-   \frac{1}{\rho _{o}c_{s}^{2}}\frac{Dp}{Dt}+\mathbf{\nabla }_{z}\cdot \vec{
+   \frac{1}{\rho _{o}c_{s}^{2}}\frac{Dp}{Dt}+\mathbf{\boldsymbol{\nabla}}_{z}\cdot \vec{
    \mathbf{v}}_{h}+\frac{\partial w}{\partial z}  = 0  
    :label: eq-zcb-cont
 
@@ -152,12 +152,12 @@ from differentiating the EOS, the continuity equation then becomes:
 .. math::
 
    \frac{1}{\rho _{o}c_{s}^{2}}\left( \frac{Dp_{o}}{Dt}+\epsilon _{s}\frac{
-   Dp^{\prime }}{Dt}\right) +\mathbf{\nabla }_{z}\cdot \vec{\mathbf{v}}_{h}+
+   Dp^{\prime }}{Dt}\right) +\mathbf{\boldsymbol{\nabla}}_{z}\cdot \vec{\mathbf{v}}_{h}+
    \frac{\partial w}{\partial z}=0
 
 If the time- and space-scales of the motions of interest are longer
 than those of acoustic modes, then
-:math:`\frac{Dp^{\prime }}{Dt}<<(\frac{Dp_{o}}{Dt}, \mathbf{\nabla }\cdot \vec{\mathbf{v}}_{h})`
+:math:`\frac{Dp^{\prime }}{Dt}<<(\frac{Dp_{o}}{Dt}, \mathbf{\boldsymbol{\nabla}}\cdot \vec{\mathbf{v}}_{h})`
 in the continuity equations and :math:`\left. \frac{\partial \rho }{\partial p}\right| _{\theta ,S}\frac{
 Dp^{\prime }}{Dt}<<\left. \frac{\partial \rho }{\partial p}\right| _{\theta
 ,S}\frac{Dp_{o}}{Dt}` in the EOS :eq:`EOSexpansion`. Thus we set :math:`\epsilon_{s}=0`, removing the
@@ -165,18 +165,18 @@ dependency on :math:`p^{\prime }` in the continuity equation and EOS. Expanding
 :math:`\frac{Dp_{o}(z)}{Dt}=-g\rho _{o}w` then leads to the anelastic continuity equation:
 
 .. math::
-   \mathbf{\nabla }_{z}\cdot \vec{\mathbf{v}}_{h}+\frac{\partial w}{\partial z}-
+   \mathbf{\boldsymbol{\nabla}}_{z}\cdot \vec{\mathbf{v}}_{h}+\frac{\partial w}{\partial z}-
    \frac{g}{c_{s}^{2}}w = 0
    :label: eq-za-cont1
 
 A slightly different route leads to the quasi-Boussinesq continuity
 equation where we use the scaling
 :math:`\frac{\partial \rho ^{\prime }}{\partial t}+
-\mathbf{\nabla }_{3}\cdot \rho ^{\prime }\vec{\mathbf{v}}<<\mathbf{\nabla }
+\mathbf{\boldsymbol{\nabla}}_{3}\cdot \rho ^{\prime }\vec{\mathbf{v}}<<\mathbf{\boldsymbol{\nabla}}
 _{3}\cdot \rho _{o}\vec{\mathbf{v}}` yielding:
 
 .. math::
-   \mathbf{\nabla }_{z}\cdot \vec{\mathbf{v}}_{h}+\frac{1}{\rho _{o}}\frac{
+   \mathbf{\boldsymbol{\nabla}}_{z}\cdot \vec{\mathbf{v}}_{h}+\frac{1}{\rho _{o}}\frac{
    \partial \left( \rho _{o}w\right) }{\partial z} = 0
    :label: eq-za-cont2
 
@@ -193,7 +193,7 @@ equations for the ocean are then:
 
 .. math::
    \frac{D\vec{\mathbf{v}}_{h}}{Dt}+f\hat{\mathbf{k}}\times \vec{\mathbf{v}}
-   _{h}+\frac{1}{\rho _{o}}\mathbf{\nabla }_{z}p = \vec{\mathbf{\mathcal{F}}}
+   _{h}+\frac{1}{\rho _{o}}\mathbf{\boldsymbol{\nabla}}_{z}p = \vec{\mathbf{\mathcal{F}}}
    :label: eq-zab-hmom
 
 .. math::
@@ -202,7 +202,7 @@ equations for the ocean are then:
    :label: eq-zab-hydro
 
 .. math::
-   \mathbf{\nabla }_{z}\cdot \vec{\mathbf{v}}_{h}+\frac{1}{\rho _{o}}\frac{
+   \mathbf{\boldsymbol{\nabla}}_{z}\cdot \vec{\mathbf{v}}_{h}+\frac{1}{\rho _{o}}\frac{
    \partial \left( \rho _{o}w\right) }{\partial z} = 0
    :label: eq-zab-cont
 
@@ -228,7 +228,7 @@ equations:
 
 .. math::
    \frac{D\vec{\mathbf{v}}_{h}}{Dt}+f\hat{\mathbf{k}}\times \vec{\mathbf{v}}
-   _{h}+\frac{1}{\rho _{c}}\mathbf{\nabla }_{z}p = \vec{\mathbf{\mathcal{F}}}
+   _{h}+\frac{1}{\rho _{c}}\mathbf{\boldsymbol{\nabla}}_{z}p = \vec{\mathbf{\mathcal{F}}}
    :label: eq-ztb-hmom
 
 .. math::
@@ -237,7 +237,7 @@ equations:
    :label: eq-ztb-hydro
 
 .. math::
-   \mathbf{\nabla }_{z}\cdot \vec{\mathbf{v}}_{h}+\frac{\partial w}{\partial z} = 0
+   \mathbf{\boldsymbol{\nabla}}_{z}\cdot \vec{\mathbf{v}}_{h}+\frac{\partial w}{\partial z} = 0
    :label: eq-ztb-cont
 
 .. math::
@@ -277,7 +277,7 @@ equations:
 
 .. math::
    \frac{D\vec{\mathbf{v}}_{h}}{Dt}+f\hat{\mathbf{k}}\times \vec{\mathbf{v}}
-   _{h}+\frac{1}{\rho _{c}}\mathbf{\nabla }_{z}p^{\prime } = \vec{\mathbf{
+   _{h}+\frac{1}{\rho _{c}}\mathbf{\boldsymbol{\nabla}}_{z}p^{\prime } = \vec{\mathbf{
    \mathcal{F}}}
    :label: eq-ocean-mom
 
@@ -287,7 +287,7 @@ equations:
    :label: eq-ocean-wmom
 
 .. math::
-   \mathbf{\nabla }_{z}\cdot \vec{\mathbf{v}}_{h}+\frac{\partial w}{\partial z} = 0
+   \mathbf{\boldsymbol{\nabla}}_{z}\cdot \vec{\mathbf{v}}_{h}+\frac{\partial w}{\partial z} = 0
    :label: eq-ocean-cont
 
 .. math::

--- a/doc/overview/finding_pressure.rst
+++ b/doc/overview/finding_pressure.rst
@@ -40,21 +40,21 @@ The surface pressure equation can be obtained by integrating continuity,
 :eq:`continuity`, vertically from :math:`r=R_{fixed}` to :math:`r=R_{moving}`
 
 .. math::
-   \int_{R_{fixed}}^{R_{moving}}\left( \mathbf{\nabla }_{h}\cdot \vec{\mathbf{v}
+   \int_{R_{fixed}}^{R_{moving}}\left( \mathbf{\boldsymbol{\nabla}}_{h}\cdot \vec{\mathbf{v}
    }_{h}+\partial _{r}\dot{r}\right) dr=0
 
 Thus:
 
 .. math::
-   \frac{\partial \eta }{\partial t}+\vec{\mathbf{v}}.\nabla \eta
-   +\int_{R_{fixed}}^{R_{moving}}\mathbf{\nabla }_{h}\cdot \vec{\mathbf{v}}
+   \frac{\partial \eta }{\partial t}+\vec{\mathbf{v}} \cdot \boldsymbol{\nabla} \eta
+   +\int_{R_{fixed}}^{R_{moving}}\mathbf{\boldsymbol{\nabla}}_{h}\cdot \vec{\mathbf{v}}
    _{h}dr=0
 
 where :math:`\eta =R_{moving}-R_{o}` is the free-surface
 :math:`r`-anomaly in units of :math:`r`. The above can be rearranged to yield, using Leibnitz’s theorem:
 
 .. math::
-   \frac{\partial \eta }{\partial t}+\mathbf{\nabla }_{h}\cdot
+   \frac{\partial \eta }{\partial t}+\mathbf{\boldsymbol{\nabla}}_{h}\cdot
    \int_{R_{fixed}}^{R_{moving}}\vec{\mathbf{v}}_{h}dr=\text{source}
    :label: free-surface
 
@@ -64,7 +64,7 @@ Whether :math:`\phi` is pressure (ocean model, :math:`p/\rho _{c}`) or
 geopotential (atmospheric model), in :eq:`mom-h`, the horizontal gradient term can be written
 
 .. math::
-   \mathbf{\nabla }_{h}\phi _{s}=\mathbf{\nabla }_{h}\left( b_{s}\eta \right)
+   \mathbf{\boldsymbol{\nabla}}_{h}\phi _{s}=\mathbf{\boldsymbol{\nabla}}_{h}\left( b_{s}\eta \right)
    :label: phi-surf
 
 where :math:`b_{s}` is the buoyancy at the surface.
@@ -83,7 +83,7 @@ continuity equation :eq:`continuity`, we deduce that:
 
 .. math::
    \nabla _{3}^{2}\phi _{nh}=\nabla .\vec{\mathbf{G}}_{\vec{v}}-\left( \mathbf{
-   \nabla }_{h}^{2}\phi _{s}+\mathbf{\nabla }^{2}\phi _{hyd}\right) =\nabla .
+   \nabla }_{h}^{2}\phi _{s}+\mathbf{\boldsymbol{\nabla}}^{2}\phi _{hyd}\right) =\nabla .
    \vec{\mathbf{F}}
    :label: 3d-invert
 
@@ -119,7 +119,7 @@ Eq. :eq:`nonormalflow` implies, making use of :eq:`mom-h`, that:
 where
 
 .. math::
-   \vec{\mathbf{F}}=\vec{\mathbf{G}}_{\vec{v}}-\left( \mathbf{\nabla }_{h}\phi_{s}+\mathbf{\nabla }\phi _{hyd}\right)
+   \vec{\mathbf{F}}=\vec{\mathbf{G}}_{\vec{v}}-\left( \mathbf{\boldsymbol{\nabla}}_{h}\phi_{s}+\mathbf{\boldsymbol{\nabla}}\phi _{hyd}\right)
 
 presenting inhomogeneous Neumann boundary conditions to the Elliptic
 problem :eq:`3d-invert`. As shown, for example, by Williams (1969) :cite:`williams:69`, one

--- a/doc/overview/hydro_prim_eqn.rst
+++ b/doc/overview/hydro_prim_eqn.rst
@@ -6,7 +6,7 @@ Hydrostatic Primitive Equations for the Atmosphere in Pressure Coordinates
 The hydrostatic primitive equations (**HPE**’s) in :math:`p-`\coordinates are:
 
 .. math::
-   \frac{D\vec{\mathbf{v}}_{h}}{Dt}+f\hat{\mathbf{k}}\times \vec{\mathbf{v}}_{h}+\mathbf{\nabla }_{p}\phi = \vec{\mathbf{\mathcal{F}}}
+   \frac{D\vec{\mathbf{v}}_{h}}{Dt}+f\hat{\mathbf{k}}\times \vec{\mathbf{v}}_{h}+\mathbf{\boldsymbol{\nabla}}_{p}\phi = \vec{\mathbf{\mathcal{F}}}
    :label: atmos-mom
  
 .. math::
@@ -14,7 +14,7 @@ The hydrostatic primitive equations (**HPE**’s) in :math:`p-`\coordinates are:
    :label: eq-p-hydro-start
 
 .. math::
-   \mathbf{\nabla }_{p}\cdot \vec{\mathbf{v}}_{h}+\frac{\partial \omega }{\partial p} = 0
+   \mathbf{\boldsymbol{\nabla}}_{p}\cdot \vec{\mathbf{v}}_{h}+\frac{\partial \omega }{\partial p} = 0
    :label: atmos-cont
 
 .. math::
@@ -26,7 +26,7 @@ The hydrostatic primitive equations (**HPE**’s) in :math:`p-`\coordinates are:
    :label: atmos-heat
 
 where :math:`\vec{\mathbf{v}}_{h}=(u,v,0)` is the ‘horizontal’ (on pressure surfaces) component of velocity,
-:math:`\frac{D}{Dt}=\frac{\partial}{\partial t}+\vec{\mathbf{v}}_{h}\cdot \mathbf{\nabla }_{p}+\omega \frac{\partial }{\partial p}`
+:math:`\frac{D}{Dt}=\frac{\partial}{\partial t}+\vec{\mathbf{v}}_{h}\cdot \mathbf{\boldsymbol{\nabla}}_{p}+\omega \frac{\partial }{\partial p}`
 is the total derivative, :math:`f=2\Omega \sin \varphi` is the Coriolis
 parameter, :math:`\phi =gz` is the geopotential, :math:`\alpha =1/\rho`
 is the specific volume, :math:`\omega =\frac{Dp }{Dt}` is the vertical
@@ -144,7 +144,7 @@ The final form of the **HPE**’s in :math:`p-`\coordinates is then:
 
 .. math::
    \frac{D\vec{\mathbf{v}}_{h}}{Dt}+f\hat{\mathbf{k}}\times \vec{\mathbf{v}}
-   _{h}+\mathbf{\nabla }_{p}\phi ^{\prime } = \vec{\mathbf{\mathcal{F}}} 
+   _{h}+\mathbf{\boldsymbol{\nabla}}_{p}\phi ^{\prime } = \vec{\mathbf{\mathcal{F}}} 
    :label: atmos-prime
 
 .. math::
@@ -152,7 +152,7 @@ The final form of the **HPE**’s in :math:`p-`\coordinates is then:
    :label: atmos-prime2
  
 .. math::
-   \mathbf{\nabla }_{p}\cdot \vec{\mathbf{v}}_{h}+\frac{\partial \omega }{
+   \mathbf{\boldsymbol{\nabla}}_{p}\cdot \vec{\mathbf{v}}_{h}+\frac{\partial \omega }{
    \partial p} = 0
    :label: atmos-prime3
  

--- a/doc/overview/hydrostatic.rst
+++ b/doc/overview/hydrostatic.rst
@@ -13,7 +13,7 @@ non-hydrostatic terms:
 and write :eq:`horiz-mtm` in the form:
 
 .. math::
-   \frac{\partial \vec{\mathbf{v}_{h}}}{\partial t}+\mathbf{\boldsymbol{\nabla}}_{h}\phi
+   \frac{\partial \vec{\mathbf{v}}_{h}}{\partial t}+\mathbf{\boldsymbol{\nabla}}_{h}\phi
    _{s}+\mathbf{\boldsymbol{\nabla}}_{h}\phi _{hyd}+\epsilon _{nh}\mathbf{\boldsymbol{\nabla}}_{h}\phi
    _{nh}=\vec{\mathbf{G}}_{\vec{v}_{h}}  
    :label: mom-h

--- a/doc/overview/hydrostatic.rst
+++ b/doc/overview/hydrostatic.rst
@@ -13,8 +13,8 @@ non-hydrostatic terms:
 and write :eq:`horiz-mtm` in the form:
 
 .. math::
-   \frac{\partial \vec{\mathbf{v}_{h}}}{\partial t}+\mathbf{\nabla }_{h}\phi
-   _{s}+\mathbf{\nabla }_{h}\phi _{hyd}+\epsilon _{nh}\mathbf{\nabla }_{h}\phi
+   \frac{\partial \vec{\mathbf{v}_{h}}}{\partial t}+\mathbf{\boldsymbol{\nabla}}_{h}\phi
+   _{s}+\mathbf{\boldsymbol{\nabla}}_{h}\phi _{hyd}+\epsilon _{nh}\mathbf{\boldsymbol{\nabla}}_{h}\phi
    _{nh}=\vec{\mathbf{G}}_{\vec{v}_{h}}  
    :label: mom-h
 

--- a/doc/overview/overview.rst
+++ b/doc/overview/overview.rst
@@ -186,7 +186,7 @@ see :numref:`zandp-vert-coord`.
 
 .. math::
    \frac{D\vec{\mathbf{v}_{h}}}{Dt}+\left( 2\vec{\boldsymbol{\Omega}}\times \vec{\mathbf{v}}
-   \right) _{h}+\mathbf{\nabla }_{h}\phi =\mathcal{F}_{\vec{\mathbf{v}_{h}}}\text{  horizontal momentum}
+   \right) _{h}+\mathbf{\boldsymbol{\nabla}}_{h}\phi =\mathcal{F}_{\vec{\mathbf{v}_{h}}}\text{  horizontal momentum}
    :label: horiz-mtm
 
 .. math::
@@ -195,7 +195,7 @@ see :numref:`zandp-vert-coord`.
    :label: vert-mtm
 
 .. math::
-   \mathbf{\nabla }_{h}\cdot \vec{\mathbf{v}}_{h}+\frac{\partial \dot{r}}{
+   \mathbf{\boldsymbol{\nabla}}_{h}\cdot \vec{\mathbf{v}}_{h}+\frac{\partial \dot{r}}{
    \partial r}=0\text{  continuity}
    :label: continuity
 
@@ -217,14 +217,14 @@ Here:
 
 .. math::
 
-   \frac{D}{Dt}=\frac{\partial }{\partial t}+\vec{\mathbf{v}}\cdot \nabla \text{ is the total derivative}
+   \frac{D}{Dt}=\frac{\partial }{\partial t}+\vec{\mathbf{v}}\cdot \boldsymbol{\nabla} \text{ is the total derivative}
 
 .. math::
 
-   \mathbf{\nabla }=\mathbf{\nabla }_{h}+\widehat{\boldsymbol{k}}\frac{\partial }{\partial r}
+   \mathbf{\boldsymbol{\nabla}}=\mathbf{\boldsymbol{\nabla}}_{h}+\widehat{\boldsymbol{k}}\frac{\partial }{\partial r}
    \text{  is the ‘grad’ operator}
 
-with :math:`\mathbf{\nabla }_{h}` operating in the horizontal and
+with :math:`\mathbf{\boldsymbol{\nabla}}_{h}` operating in the horizontal and
 :math:`\widehat{\boldsymbol{k}}
 \frac{\partial }{\partial r}` operating in the vertical, where
 :math:`\widehat{\boldsymbol{k}}` is a unit vector in the vertical

--- a/doc/overview/overview.rst
+++ b/doc/overview/overview.rst
@@ -185,12 +185,12 @@ see :numref:`zandp-vert-coord`.
     Vertical coordinates and kinematic boundary conditions for atmosphere (top) and ocean (bottom).
 
 .. math::
-   \frac{D\vec{\mathbf{v}_{h}}}{Dt}+\left( 2\vec{\Omega}\times \vec{\mathbf{v}}
+   \frac{D\vec{\mathbf{v}_{h}}}{Dt}+\left( 2\vec{\boldsymbol{\Omega}}\times \vec{\mathbf{v}}
    \right) _{h}+\mathbf{\nabla }_{h}\phi =\mathcal{F}_{\vec{\mathbf{v}_{h}}}\text{  horizontal momentum}
    :label: horiz-mtm
 
 .. math::
-   \frac{D\dot{r}}{Dt}+\widehat{\boldsymbol{k}}\cdot \left( 2\vec{\Omega}\times \vec{\mathbf{
+   \frac{D\dot{r}}{Dt}+\widehat{\boldsymbol{k}}\cdot \left( 2\vec{\boldsymbol{\Omega}}\times \vec{\mathbf{
    v}}\right) +\frac{\partial \phi }{\partial r}+b=\mathcal{F}_{\dot{r}}\text{  vertical momentum}
    :label: vert-mtm
 
@@ -237,7 +237,7 @@ with :math:`\mathbf{\nabla }_{h}` operating in the horizontal and
 
 .. math:: \phi \text{ is the ‘pressure’/‘geopotential’}
 
-.. math:: \vec{\Omega}\text{ is the Earth's rotation}
+.. math:: \vec{\boldsymbol{\Omega}}\text{ is the Earth's rotation}
 
 .. math:: b\text{ is the ‘buoyancy’}
 

--- a/doc/overview/overview.rst
+++ b/doc/overview/overview.rst
@@ -185,8 +185,8 @@ see :numref:`zandp-vert-coord`.
     Vertical coordinates and kinematic boundary conditions for atmosphere (top) and ocean (bottom).
 
 .. math::
-   \frac{D\vec{\mathbf{v}_{h}}}{Dt}+\left( 2\vec{\boldsymbol{\Omega}}\times \vec{\mathbf{v}}
-   \right) _{h}+\mathbf{\boldsymbol{\nabla}}_{h}\phi =\mathcal{F}_{\vec{\mathbf{v}_{h}}}\text{  horizontal momentum}
+   \frac{D\vec{\mathbf{v}}_{h}}{Dt}+\left( 2\vec{\boldsymbol{\Omega}}\times \vec{\mathbf{v}}
+   \right) _{h}+\mathbf{\boldsymbol{\nabla}}_{h}\phi =\mathcal{F}_{\vec{\mathbf{v}}_{h}}\text{  horizontal momentum}
    :label: horiz-mtm
 
 .. math::

--- a/doc/overview/overview.rst
+++ b/doc/overview/overview.rst
@@ -190,7 +190,7 @@ see :numref:`zandp-vert-coord`.
    :label: horiz-mtm
 
 .. math::
-   \frac{D\dot{r}}{Dt}+\widehat{k}\cdot \left( 2\vec{\Omega}\times \vec{\mathbf{
+   \frac{D\dot{r}}{Dt}+\widehat{\boldsymbol{k}}\cdot \left( 2\vec{\Omega}\times \vec{\mathbf{
    v}}\right) +\frac{\partial \phi }{\partial r}+b=\mathcal{F}_{\dot{r}}\text{  vertical momentum}
    :label: vert-mtm
 
@@ -221,13 +221,13 @@ Here:
 
 .. math::
 
-   \mathbf{\nabla }=\mathbf{\nabla }_{h}+\widehat{k}\frac{\partial }{\partial r}
+   \mathbf{\nabla }=\mathbf{\nabla }_{h}+\widehat{\boldsymbol{k}}\frac{\partial }{\partial r}
    \text{  is the ‘grad’ operator}
 
 with :math:`\mathbf{\nabla }_{h}` operating in the horizontal and
-:math:`\widehat{k}
+:math:`\widehat{\boldsymbol{k}}
 \frac{\partial }{\partial r}` operating in the vertical, where
-:math:`\widehat{k}` is a unit vector in the vertical
+:math:`\widehat{\boldsymbol{k}}` is a unit vector in the vertical
 
 .. math:: t\text{ is time}
 

--- a/doc/phys_pkgs/bulk_force.rst
+++ b/doc/phys_pkgs/bulk_force.rst
@@ -140,9 +140,9 @@ Turbulent scales are:
 .. math::
 
    \begin{aligned}
-   u^* & = & c_u u_s \nonumber\\
-   T^* & = & c_T \Delta T \nonumber\\
-   q^* & = & c_q \Delta q \nonumber\end{aligned}
+   u^* & = c_u u_s \nonumber\\
+   T^* & = c_T \Delta T \nonumber\\
+   q^* & = c_q \Delta q \nonumber\end{aligned}
 
 We find the “integrated flux profile” for momentum and stability if
 there are stable QQ conditions (:math:`\Upsilon>0`) :
@@ -154,9 +154,9 @@ and for unstable QQ conditions (:math:`\Upsilon<0`):
 .. math::
 
    \begin{aligned}
-   \psi_m & = & 2 ln(0.5(1+\chi)) + ln(0.5(1+\chi^2)) - 2 \tan^{-1} \chi + \pi/2
+   \psi_m & = 2 ln(0.5(1+\chi)) + ln(0.5(1+\chi^2)) - 2 \tan^{-1} \chi + \pi/2
    \nonumber \\
-   \psi_s & = & 2 ln(0.5(1+\chi^2)) \nonumber\end{aligned}
+   \psi_s & = 2 ln(0.5(1+\chi^2)) \nonumber\end{aligned}
 
 where
 
@@ -172,9 +172,9 @@ The coefficients are updated through 5 iterations as:
 .. math::
 
    \begin{aligned}
-   c_u & = & \frac {\hat{c_u}}{1+\hat{c_u}(\lambda - \psi_m)/\kappa} \nonumber \\
-   c_T & = & \frac {\hat{c_T}}{1+\hat{c_T}(\lambda - \psi_s)/\kappa} \nonumber \\
-   c_q & = & c'_T\end{aligned}
+   c_u & = \frac {\hat{c_u}}{1+\hat{c_u}(\lambda - \psi_m)/\kappa} \nonumber \\
+   c_T & = \frac {\hat{c_T}}{1+\hat{c_T}(\lambda - \psi_s)/\kappa} \nonumber \\
+   c_q & = c'_T\end{aligned}
 
 where :math:`\lambda =ln(h_T/z_{ref})`.
 
@@ -201,9 +201,9 @@ to surface temperature
 .. math::
 
    \begin{aligned}
-   \frac{dQ_s}{d_T} & = & \rho_{air} c_{p_{air}} u_s c_u c_T \nonumber \\
-   \frac{dQ_l}{d_T} & = & \frac{\rho_{air} L^2 u_s c_u c_q c}{T_{srf}^2} \nonumber \\
-   \frac{dQ_{]lw}^{up}}{d_T} & = &  4 \epsilon \sigma t_{srf}^3 \nonumber\end{aligned}
+   \frac{dQ_s}{d_T} & = \rho_{air} c_{p_{air}} u_s c_u c_T \nonumber \\
+   \frac{dQ_l}{d_T} & = \frac{\rho_{air} L^2 u_s c_u c_q c}{T_{srf}^2} \nonumber \\
+   \frac{dQ_{]lw}^{up}}{d_T} & =  4 \epsilon \sigma t_{srf}^3 \nonumber\end{aligned}
 
 And total derivative :math:`\frac{dQ_o}{dT}= \frac{dQ_s}{dT} +
 \frac{dQ_l}{dT} + \frac{dQ_{lw}^{up}}{dT}`.

--- a/doc/phys_pkgs/fizhi.rst
+++ b/doc/phys_pkgs/fizhi.rst
@@ -173,11 +173,11 @@ as a function of relative humidity:
 
 where
 
-RH\ :sub:`c` & = & 1-s(1-s)(2-+2 s)r
-s & = & p/p\ :sub:`surf`
-r & = & ( )
-RH\ :sub:`min` & = & 0.75
-& = & 0.573285 .
+RH\ :sub:`c` & = 1-s(1-s)(2-+2 s)r
+s & = p/p\ :sub:`surf`
+r & = ( )
+RH\ :sub:`min` & = 0.75
+& = 0.573285 .
 
 These cloud fractions are suppressed, however, in regions where the
 convective sub-cloud layer is conditionally unstable. The functional
@@ -2106,8 +2106,8 @@ and Analysis forcing.
 .. math::
 
    \begin{aligned}
-   {\bf DTDT} & = & \pp{T}{t}_{Dynamics} + \pp{T}{t}_{Moist Processes} + \pp{T}{t}_{Shortwave Radiation} \\
-              & + & \pp{T}{t}_{Longwave Radiation} + \pp{T}{t}_{Turbulence} + \pp{T}{t}_{Analysis} \end{aligned}
+   {\bf DTDT} & = \pp{T}{t}_{Dynamics} + \pp{T}{t}_{Moist Processes} + \pp{T}{t}_{Shortwave Radiation} \\
+              & + \pp{T}{t}_{Longwave Radiation} + \pp{T}{t}_{Turbulence} + \pp{T}{t}_{Analysis} \end{aligned}
 
 
 DQDT - Total Specific Humidity Tendency  (g/kg/day)
@@ -2359,8 +2359,8 @@ the Analysis forcing.
 .. math::
 
    \begin{aligned}
-   {\bf DIABT} & = & \pp{T}{t}_{Moist Processes} + \pp{T}{t}_{Shortwave Radiation} \\
-              & + & \pp{T}{t}_{Longwave Radiation} + \pp{T}{t}_{Turbulence} + \pp{T}{t}_{Analysis} \end{aligned}
+   {\bf DIABT} & = \pp{T}{t}_{Moist Processes} + \pp{T}{t}_{Shortwave Radiation} \\
+              & + \pp{T}{t}_{Longwave Radiation} + \pp{T}{t}_{Turbulence} + \pp{T}{t}_{Analysis} \end{aligned}
 
 If we define the time-tendency of Temperature due to Diabatic
 processes as
@@ -2368,8 +2368,8 @@ processes as
 .. math::
 
    \begin{aligned}
-   \pp{T}{t}_{Diabatic} & = & \pp{T}{t}_{Moist Processes} + \pp{T}{t}_{Shortwave Radiation} \\
-                        & + & \pp{T}{t}_{Longwave Radiation} + \pp{T}{t}_{Turbulence}\end{aligned}
+   \pp{T}{t}_{Diabatic} & = \pp{T}{t}_{Moist Processes} + \pp{T}{t}_{Shortwave Radiation} \\
+                        & + \pp{T}{t}_{Longwave Radiation} + \pp{T}{t}_{Turbulence}\end{aligned}
 
 then, since there are no surface pressure changes due to Diabatic
 processes, we may write
@@ -2525,8 +2525,8 @@ specific humidity, given by:
 .. math::
 
    \begin{aligned}
-   {\bf QINT} & = & \int_{surf}^{top} \rho q dz \\
-              & = & \frac{\pi}{g} \int_0^1 q dp
+   {\bf QINT} & = \int_{surf}^{top} \rho q dz \\
+              & = \frac{\pi}{g} \int_0^1 q dp
    \end{aligned}
 
 where we have used the hydrostatic relation

--- a/doc/phys_pkgs/gmredi.rst
+++ b/doc/phys_pkgs/gmredi.rst
@@ -112,8 +112,8 @@ streamfunction is specified in terms of the isoneutral slopes
 .. math::
 
    \begin{aligned}
-   F_x^\star & = & -\kappa_{GM} S_y \\
-   F_y^\star & = &  \kappa_{GM} S_x\end{aligned}
+   F_x^\star & = -\kappa_{GM} S_y \\
+   F_y^\star & =  \kappa_{GM} S_x\end{aligned}
 
 with boundary conditions :math:`F_x^\star=F_y^\star=0` on upper and
 lower boundaries. In the end, the bolus transport in the GM
@@ -174,14 +174,14 @@ be re-written in terms of a non-divergent flux and a skew-flux:
 
    \begin{aligned}
    \bf{u}^\star \tau
-   & = &
+   & =
    \left( \begin{array}{c}
    - \partial_z ( \kappa_{GM} S_x ) \tau \\
    - \partial_z ( \kappa_{GM} S_y ) \tau \\
    (\partial_x \kappa_{GM} S_x + \partial_y \kappa_{GM} S_y)\tau
    \end{array} \right)
    \\
-   & = &
+   & =
    \left( \begin{array}{c}
    - \partial_z ( \kappa_{GM} S_x \tau) \\
    - \partial_z ( \kappa_{GM} S_y \tau) \\
@@ -348,11 +348,11 @@ magnitude is simply restricted by an upper limit:
 .. math::
 
    \begin{aligned}
-   |\nabla \sigma| & = & \sqrt{ \sigma_x^2 + \sigma_y^2 } \\
-   S_{lim} & = & - \frac{|\nabla \sigma|}{ S_{max} }
+   |\nabla \sigma| & = \sqrt{ \sigma_x^2 + \sigma_y^2 } \\
+   S_{lim} & = - \frac{|\nabla \sigma|}{ S_{max} }
    \;\;\;\;\;\;\;\; \mbox{where $S_{max}$ is a parameter} \\
-   \sigma_z^\star & = & \min( \sigma_z , S_{lim} ) \\
-   {[s_x,s_y]} & = & - \frac{ [\sigma_x,\sigma_y] }{\sigma_z^\star}\end{aligned}
+   \sigma_z^\star & = \min( \sigma_z , S_{lim} ) \\
+   {[s_x,s_y]} & = - \frac{ [\sigma_x,\sigma_y] }{\sigma_z^\star}\end{aligned}
 
 Notice that this algorithm assumes stable stratification through the
 “min” function. In the case where the fluid is well stratified

--- a/doc/phys_pkgs/seaice.rst
+++ b/doc/phys_pkgs/seaice.rst
@@ -1089,7 +1089,7 @@ al. 2015 :cite:`kimmritz:15`, the evolution equations of stress
 
 .. math::
    \mathbf{u}^{p+1}=\mathbf{u}^p+\frac{1}{\beta}
-   \Big(\frac{\Delta t}{m}\nabla \cdot{\bf \sigma}^{p+1}+
+   \Big(\frac{\Delta t}{m}\boldsymbol{\nabla} \cdot{\bf \sigma}^{p+1}+
    \frac{\Delta t}{m}\mathbf{R}^{p}+\mathbf{u}_n
      -\mathbf{u}^p\Big)
    :label: eq_evpstarmom
@@ -1535,7 +1535,7 @@ thickness :math:`h` following the evolution equation
 
 
 .. math::
-   \frac{\partial g}{\partial t} = - \nabla \cdot (\mathbf{u} g) - \frac{\partial}{\partial h}(fg) + \Psi.
+   \frac{\partial g}{\partial t} = - \boldsymbol{\nabla} \cdot (\mathbf{u} g) - \frac{\partial}{\partial h}(fg) + \Psi.
    :label: eq_itd
 
 

--- a/doc/phys_pkgs/seaice.rst
+++ b/doc/phys_pkgs/seaice.rst
@@ -1089,7 +1089,7 @@ al. 2015 :cite:`kimmritz:15`, the evolution equations of stress
 
 .. math::
    \mathbf{u}^{p+1}=\mathbf{u}^p+\frac{1}{\beta}
-   \Big(\frac{\Delta t}{m}\boldsymbol{\nabla} \cdot{\bf \sigma}^{p+1}+
+   \Big(\frac{\Delta t}{m}\boldsymbol{\nabla} \cdot\boldsymbol{\sigma}^{p+1}+
    \frac{\Delta t}{m}\mathbf{R}^{p}+\mathbf{u}_n
      -\mathbf{u}^p\Big)
    :label: eq_evpstarmom

--- a/doc/phys_pkgs/thsice.rst
+++ b/doc/phys_pkgs/thsice.rst
@@ -80,8 +80,8 @@ calculated as:
 .. math::
 
    \begin{aligned}
-   q_1 & = & -c_{i}*T_f + L_i \nonumber \\
-   q_2 & = & -c_{f}T_{mlt}+ c_{i}(T_{mlt}-T{f}) + L_i(1-\frac{T_{mlt}}{T_f})
+   q_1 & = -c_{i}*T_f + L_i \nonumber \\
+   q_2 & = -c_{f}T_{mlt}+ c_{i}(T_{mlt}-T{f}) + L_i(1-\frac{T_{mlt}}{T_f})
    \nonumber\end{aligned}
 
 where :math:`c_f` is specific heat of liquid fresh water, :math:`c_i` is
@@ -191,9 +191,9 @@ a unit mass of seaice with temperature :math:`T`. For the upper layer
 .. math::
 
    \begin{aligned}
-   q_1 & = & - c_f T_f + c_i (T_f-T)+ L_{i}(1-\frac{T_f}{T})
+   q_1 & = - c_f T_f + c_i (T_f-T)+ L_{i}(1-\frac{T_f}{T})
    \nonumber \\
-   q_2 & = & -c_i T+L_i \nonumber\end{aligned}
+   q_2 & = -c_i T+L_i \nonumber\end{aligned}
 
 where :math:`c_f` is specific heat of liquid fresh water, :math:`c_i` is
 the specific heat of fresh ice, and :math:`L_i` is latent heat of

--- a/pkg/cheapaml/cheapaml_calc_rhs.F
+++ b/pkg/cheapaml/cheapaml_calc_rhs.F
@@ -31,7 +31,7 @@ C using the Tr file, as is the diffusive flux.
 C
 C The tendency is the divergence of the fluxes:
 C \begin{equation*}
-C G_\theta = G_\theta + \nabla \cdot {\bf F}
+C G_\theta = G_\theta + \boldsymbol{\nabla} \cdot {\bf F}
 C \end{equation*}
 C
 C The tendency is assumed to contain data on entry.

--- a/pkg/generic_advdiff/gad_calc_rhs.F
+++ b/pkg/generic_advdiff/gad_calc_rhs.F
@@ -31,7 +31,7 @@ C \end{equation*}
 C
 C The tendency is the divergence of the fluxes:
 C \begin{equation*}
-C G_\theta = G_\theta + \nabla \cdot {\bf F}
+C G_\theta = G_\theta + \boldsymbol{\nabla} \cdot {\bf F}
 C \end{equation*}
 C
 C The tendency is assumed to contain data on entry.

--- a/pkg/mom_fluxform/mom_fluxform.F
+++ b/pkg/mom_fluxform/mom_fluxform.F
@@ -7,15 +7,15 @@ C Package "mom\_fluxform" provides methods for calculating explicit terms
 C in the momentum equation cast in flux-form:
 C \begin{eqnarray*}
 C G^u & = & -\frac{1}{\rho} \partial_x \phi_h
-C           -\nabla \cdot {\bf v} u
+C           -\boldsymbol{\nabla} \cdot {\bf v} u
 C           -fv
-C           +\frac{1}{\rho} \nabla \cdot {\bf \tau}^x
+C           +\frac{1}{\rho} \boldsymbol{\nabla} \cdot {\bf \tau}^x
 C           + \mbox{metrics}
 C \\
 C G^v & = & -\frac{1}{\rho} \partial_y \phi_h
-C           -\nabla \cdot {\bf v} v
+C           -\boldsymbol{\nabla} \cdot {\bf v} v
 C           +fu
-C           +\frac{1}{\rho} \nabla \cdot {\bf \tau}^y
+C           +\frac{1}{\rho} \boldsymbol{\nabla} \cdot {\bf \tau}^y
 C           + \mbox{metrics}
 C \end{eqnarray*}
 C where ${\bf v}=(u,v,w)$ and $\tau$, the stress tensor, includes surface

--- a/pkg/smooth/smooth_rhs.F
+++ b/pkg/smooth/smooth_rhs.F
@@ -26,7 +26,7 @@ C \end{equation*}
 C
 C The tendency is the divergence of the fluxes:
 C \begin{equation*}
-C G_\theta = G_\theta + \nabla \cdot {\bf F}
+C G_\theta = G_\theta + \boldsymbol{\nabla} \cdot {\bf F}
 C \end{equation*}
 C
 C The tendency is assumed to contain data on entry.


### PR DESCRIPTION
## What changes does this PR introduce?
This PR fixes some notational issues in the Documentation in the math. In particular, sometimes subscripts were converted to boldface by accident, or `{\bf ...}` was not typesetting bold.

## Does this PR introduce a breaking change? 
No breaking changes are introduced.

## Suggested addition to `tag-index`
(To avoid unnecessary merge conflicts, please don't update `tag-index`. One of the admins will do that when merging your pull request.)