### PR TITLE
Fix a bug in reading GMRedi fields

### DIFF
--- a/doc/tag-index
+++ b/doc/tag-index
@@ -1,6 +1,8 @@
     Notes on tags used in MITgcmUV
     ==============================
 
+o model/src:
+  - skip reading kapGM and kapRedi from ini_mixing.F when useGMRedi is .FALSE.
 o pkg/exf:
   - add option for interannual monthly forcing with pkg/cal by setting
     ${fld}_period=-1. (like -12. indicates climatological monthly forcing),

--- a/model/src/ini_mixing.F
+++ b/model/src/ini_mixing.F
@@ -94,8 +94,8 @@ CEOP
 #ifdef ALLOW_CTRL
 #ifdef ALLOW_KAPGM_CONTROL
 #ifdef ALLOW_KAPGM_3DFILE
-       IF ( GM_background_K3dFile .NE. ' ' ) THEN
-          CALL READ_FLD_XYZ_RL(GM_background_K3dFile,' ',KapGM,0,myThid)
+       IF ( useGMRedi.and.GM_background_K3dFile .NE. ' ' ) THEN
+          CALL READ_FLD_XYZ_RL(GM_background_K3dFile,' ',kapGM,0,myThid)
        ENDIF
 #endif
        _EXCH_XYZ_RL( kapGM, myThid )
@@ -103,8 +103,8 @@ CEOP
 #endif
 #ifdef ALLOW_KAPREDI_CONTROL
 #ifdef ALLOW_KAPREDI_3DFILE
-       IF ( GM_isopycK3dFile .NE. ' ' ) THEN
-          CALL READ_FLD_XYZ_RL(GM_isopycK3dFile,' ',KapRedi,0,myThid)
+       IF ( useGMRedi.and.GM_isopycK3dFile .NE. ' ' ) THEN
+          CALL READ_FLD_XYZ_RL(GM_isopycK3dFile,' ',kapRedi,0,myThid)
        ENDIF
 #endif
        _EXCH_XYZ_RL( kapRedi, myThid )


### PR DESCRIPTION
## What changes does this PR introduce?
(Bug fix, feature, docs update, ...)
A bug fix

## What is the current behaviour? 
(You can also link to an open issue here)
When the two CPP options ALLOW_KAPGM_3DFILE and ALLOW_KAPREDI_3DFILE are set, the model reads in 3d GM and Redi kappa (kapGM and kapRedi) from two files specified by GM_background_K3dFile and GM_isopycK3dFile, respectively. However, if the run-time parameter useGMRedi is set to .FALSE., the two filenames are not initialized. The model still tries to read in GM and Redi kappas from the two files and therefore crashes. 

## What is the new behaviour 
(if this is a feature change)?
When ALLOW_KAPGM_3DFILE and ALLOW_KAPREDI_3DFILE are defined and useGMRedi is set to .FALSE., the model will skip reading in kapGM and kapRedi from files.



## Does this PR introduce a breaking change? 
(What changes might users need to make in their application due to this PR?)
No


## Other information:


## Suggested addition to `tag-index`
(To avoid unnecessary merge conflicts, please don't update `tag-index`. One of the admins will do that when merging your pull request.)

o model/ini_mixing.F
- Skip reading kapGM and kapRedi when useGMRedi is .FALSE.