### PR TITLE
Fix "Add interannual monthly forcing to exf"

### DIFF
--- a/doc/tag-index
+++ b/doc/tag-index
@@ -1,6 +1,8 @@
     Notes on tags used in MITgcmUV
     ==============================
 
+o pkg/exf:
+  - fix issue in interannual monthly forcing addition (case ${fld}period=0)
 o model/src:
   - skip reading kapGM and kapRedi from ini_mixing.F when useGMRedi is .FALSE.
 o pkg/exf:

--- a/pkg/exf/exf_getffield_start.F
+++ b/pkg/exf/exf_getffield_start.F
@@ -77,8 +77,8 @@ c       WRITE(msgBuf,'(5A)') 'S/R EXF_GETFFIELD_START: ',
       ENDIF
 
 C--   Convert start-date to start_time (case using Calendar)
-      IF ( useCAL .AND. .NOT.(fld_period.EQ.-12. .OR.
-     &     (fld_period.EQ.-1 .AND. useYearlyFields)) ) THEN
+      IF ( useCAL .AND. (fld_period.GT.0. .OR.
+     &     (fld_period.EQ.-1 .AND. .NOT.useYearlyFields)) ) THEN
 #ifdef ALLOW_CAL
         CALL CAL_FULLDATE( fld_startdate1, fld_startdate2,
      &                     date_array, myThid )

--- a/pkg/exf/exf_getffield_start.F
+++ b/pkg/exf/exf_getffield_start.F
@@ -78,7 +78,7 @@ c       WRITE(msgBuf,'(5A)') 'S/R EXF_GETFFIELD_START: ',
 
 C--   Convert start-date to start_time (case using Calendar)
       IF ( useCAL .AND. (fld_period.GT.0. .OR.
-     &     (fld_period.EQ.-1 .AND. .NOT.useYearlyFields)) ) THEN
+     &     (fld_period.EQ.-1. .AND. .NOT.useYearlyFields)) ) THEN
 #ifdef ALLOW_CAL
         CALL CAL_FULLDATE( fld_startdate1, fld_startdate2,
      &                     date_array, myThid )


### PR DESCRIPTION
## What changes does this PR introduce?

Skip computation of ${fld}startTime when ${fld}period is zero, just as it was before #545 broke it!