### PR TITLE
Output time-series of global mean atm pressure load (ploadbar)

### DIFF
--- a/model/src/do_the_model_io.F
+++ b/model/src/do_the_model_io.F
@@ -57,6 +57,8 @@ C       |-- SBO_OUTPUT
 C       |
 C       |-- STERGLOH_OUTPUT
 C       |
+C       |-- PLOADBAR_OUTPUT
+C       |
 C       |-- SEAICE_OUTPUT
 C       |
 C       |-- SHELFICE_OUTPUT
@@ -207,6 +209,7 @@ C     Do SBO diagnostics.
 #ifdef ALLOW_ECCO
       IF ( useECCO ) THEN
         CALL STERGLOH_OUTPUT( myTime, myIter, myThid )
+        CALL PLOADBAR_OUTPUT( myTime, myIter, myThid )
       ENDIF
 #endif
 

--- a/model/src/turnoff_model_io.F
+++ b/model/src/turnoff_model_io.F
@@ -87,7 +87,10 @@ C-    should call a S/R OBCS_TURNOFF_IO (like SEAICE) to reset this flag
 
 #ifdef ALLOW_ECCO
 C-    should call a S/R ECCO_TURNOFF_IO (like SEAICE) to reset this flag
-      IF ( useECCO ) ecco_output_sterGloH = .FALSE.
+      IF ( useECCO ) THEN 
+        ecco_output_sterGloH = .FALSE.
+        ecco_output_ploadbar = .FALSE.
+      ENDIF
 #endif
 
 C--   Disable SBO output

--- a/pkg/ecco/ECCO.h
+++ b/pkg/ecco/ECCO.h
@@ -166,12 +166,15 @@ C                 the current model integration.
       _RL trSalt(1-OLx:sNx+OLx,1-OLy:sNy+OLy,Nr,nSx,nSy)
       _RL eccoVol_0(1-OLx:sNx+OLx,1-OLy:sNy+OLy,Nr,nSx,nSy)
 
-C     Two runtime parameters related to outputting sterGloH
+C     Three runtime parameters related to outputting sterGloH & ploadbar
 C     ecco_output_sterGloH :: output sterGloH at each time step if true
+C     ecco_output_ploadbar :: output ploadbar at each time step if true
 C     ecco_keepTSeriesOutp_open :: keep the sterGloH file open if true
       COMMON /ECCO_L/
-     &                ecco_output_sterGloH, ecco_keepTSeriesOutp_open
-      LOGICAL ecco_output_sterGloH, ecco_keepTSeriesOutp_open
+     &                ecco_output_sterGloH, ecco_output_ploadbar,
+     &                ecco_keepTSeriesOutp_open
+      LOGICAL ecco_output_sterGloH, ecco_output_ploadbar, 
+     &        ecco_keepTSeriesOutp_open
 
 C     file precision
       COMMON /PREC_TYPE_COST/
@@ -294,7 +297,7 @@ C                            Note: currently only used in drifter velocity cost
       INTEGER gencost_enddate2(NGENCOST)
       INTEGER gencost_enddate(4,NGENCOST)
       INTEGER gencost_pointer3d(NGENCOST)
-      INTEGER  gencost_smooth2Ddiffnbt(NGENCOST)
+      INTEGER gencost_smooth2Ddiffnbt(NGENCOST)
       INTEGER gencost_preproc_i(NGENPPROC,NGENCOST)
       INTEGER gencost_posproc_i(NGENPPROC,NGENCOST)
       INTEGER gencost_msk_pointer3d(NGENCOST)

--- a/pkg/ecco/ecco_check.F
+++ b/pkg/ecco/ecco_check.F
@@ -719,6 +719,16 @@ C ============ other pkg/ecco related checks
          STOP 'ABNORMAL END: S/R ECCO_CHECK'
       ENDIF
 #endif
+#if !defined(ATMOSPHERIC_LOADING) || !defined(ALLOW_IB_CORR)
+      IF (ecco_output_ploadbar) THEN
+         WRITE(msgBuf,'(3A)') 'ECCO_CHECK:',
+     &         ' Cannot set ecco_output_ploadbar to TRUE',
+     &         ' with #undef ATMOSPHERIC_LOADING or '
+     &         ' #undef ALLOW_IB_CORR'
+         CALL PRINT_ERROR( msgBuf, myThid )
+         STOP 'ABNORMAL END: S/R ECCO_CHECK'
+      ENDIF
+#endif
       _END_MASTER(myThid)
 
       RETURN

--- a/pkg/ecco/ecco_readparms.F
+++ b/pkg/ecco/ecco_readparms.F
@@ -166,6 +166,7 @@ c--   Read the namelist input.
      &                   wmean_lwflux, wmean_lwdown, wmean_evap,
      &                   wmean_snowprecip, wmean_apressure,
      &                   cost_iprec, ecco_output_sterGloH,
+     &                   ecco_output_ploadbar,
      &                   ecco_keepTSeriesOutp_open,
      &                   cost_yftype, topexmeanfile
 
@@ -499,6 +500,7 @@ catn  eccov4 will run without needing to read in these params
         wmean_tau             =      0. _d 0
         cost_iprec  = precFloat32
         ecco_output_sterGloH  =      .FALSE.
+        ecco_output_ploadbar  =      .FALSE.
         ecco_keepTSeriesOutp_open =  .FALSE.
 
 Catn-- retired parameters

--- a/pkg/ecco/ploadbar_output.F
+++ b/pkg/ecco/ploadbar_output.F
@@ -1,0 +1,131 @@
+#include "ECCO_OPTIONS.h"
+
+C---+----1----+----2----+----3----+----4----+----5----+----6----+----7-|--+----|
+CBOP
+C !ROUTINE: PLOADBAR_OUTPUT
+
+C !INTERFACE:
+      SUBROUTINE PLOADBAR_OUTPUT( myTime, myIter, myThid )
+
+C !DESCRIPTION: \bv
+C     *==========================================================*
+C     | SUBROUTINE PLOADBAR_OUTPUT
+C     | o Ouput the global mean pload
+C     *==========================================================*
+
+C !USES:
+      IMPLICIT NONE
+C     === Global variables ===
+#include "SIZE.h"
+#include "EEPARAMS.h"
+#include "PARAMS.h"
+#ifdef ALLOW_ECCO
+# include "ECCO_SIZE.h"
+# include "ECCO.h"
+#endif
+
+C !INPUT PARAMETERS:
+C     myTime    :: my time in simulation ( s )
+C     myIter    :: my Iteration number
+C     myThid    :: my Thread Id number
+      _RL     myTime
+      INTEGER myIter
+      INTEGER myThid
+
+#ifdef ALLOW_ECCO
+#ifdef ATMOSPHERIC_LOADING
+#ifdef ALLOW_IB_CORR
+
+C !FUNCTIONS:
+c     LOGICAL  DIFFERENT_MULTIPLE
+c     EXTERNAL DIFFERENT_MULTIPLE
+
+C--   Local variables shared by S/R within this file (ploadbar_output.F)
+C     IOunit_outpFile :: IO-unit of binary output file
+      INTEGER IOunit_outpFile
+      COMMON /PLOADBAR_OUTPUT_LOCAL/ IOunit_outpFile
+
+C !LOCAL VARIABLES:
+C     fName     :: output file name
+C     msgBuf    :: Informational/error message buffer
+      CHARACTER*(10) suff
+      CHARACTER*(MAX_LEN_FNAM) fName
+      CHARACTER*(MAX_LEN_MBUF) msgBuf
+      INTEGER irecord
+      INTEGER ioUnit
+      _RL     tmpVar(1)
+      _RS     dummyRS(1)
+
+C-----------------------------------------------------------------
+C     Save the global mean pressure load (pload) at every time step
+C-----------------------------------------------------------------
+
+      IF ( ecco_output_ploadbar ) THEN
+        irecord = myIter - nIter0 + 1
+
+#ifdef ALLOW_MDSIO
+        IF ( rwSuffixType.EQ.0 ) THEN
+          WRITE(fName,'(A,I10.10)') 'ploadbar_global.', nIter0
+        ELSE
+          CALL RW_GET_SUFFIX( suff, startTime, nIter0, myThid )
+          WRITE(fName,'(A,A)') 'ploadbar_global.', suff
+        ENDIF
+
+        IF ( ecco_keepTSeriesOutp_open ) THEN
+          IF ( myIter .EQ. nIter0 ) THEN
+C-    to open new IO unit and keep it open
+            ioUnit = -1
+          ELSE
+C-    to write to already open IO unit
+            ioUnit = IOunit_outpFile
+          ENDIF
+C-    skip writing meta file (unless last time to write to file)
+          IF ( myIter .NE. nEndIter ) irecord = -irecord
+        ELSE
+C-    to open new IO unit, write and close it all within same call
+          ioUnit  = 0
+        ENDIF
+
+        tmpVar(1) = ploadbar
+        CALL MDS_WRITEVEC_LOC(
+     I             fName, precFloat64, ioUnit,
+     I             'RL', 1, tmpVar, dummyRS,
+     I             0, 0, irecord, myIter, myThid )
+
+        IF ( ecco_keepTSeriesOutp_open ) THEN
+C-      multi-threaded: only master-thread save IO-unit to shared variable
+C                 (in common block) and close open file (after last write)
+          _BEGIN_MASTER(myThid)
+          IF ( myIter .EQ. nIter0 ) THEN
+C-      save for next write to same file:
+            IOunit_outpFile = ioUnit
+          ENDIF
+          IF ( myIter .EQ. nEndIter .AND. ioUnit .GT. 0 ) THEN
+C-      after last write, close IO-unit:
+            IF ( debugLevel.GE.debLevC ) THEN
+              WRITE(msgBuf,'(A,I8,3A)')
+     &          ' PLOADBAR_OUTPUT: close ioUnit=', ioUnit,
+     &          ', file: ', fName(1:26), '.data'
+              CALL PRINT_MESSAGE( msgBuf, standardMessageUnit,
+     &                            SQUEEZE_RIGHT, myThid )
+            ENDIF
+            CLOSE( ioUnit )
+          ELSEIF ( myIter .EQ. nEndIter .AND. debugMode ) THEN
+            WRITE(msgBuf,'(2A,I10,A)')
+     &          ' PLOADBAR_OUTPUT: no file to close',
+     &          ' (ioUnit=', ioUnit, ' )'
+            CALL PRINT_MESSAGE( msgBuf, standardMessageUnit,
+     &                          SQUEEZE_RIGHT, myThid )
+          ENDIF
+          _END_MASTER(myThid)
+        ENDIF
+
+#endif /* ALLOW_MDSIO */
+      ENDIF
+
+#endif /* ATMOSPHERIC_LOADING */
+#endif /* ALLOW_IB_CORR */
+#endif /* ALLOW_ECCO */
+
+      RETURN
+      END


### PR DESCRIPTION
## What changes does this PR introduce?
(Bug fix, feature, docs update, ...)
New feature

## What is the current behaviour? 
(You can also link to an open issue here)


## What is the new behaviour 
(if this is a feature change)?
Output time-series of global mean atmospheric pressure loading (ploadbar) at each time step in a similar way to outputting global mean steric height change (PR #507) 


## Does this PR introduce a breaking change? 
(What changes might users need to make in their application due to this PR?)
No


## Other information:


## Suggested addition to `tag-index`
(To avoid unnecessary merge conflicts, please don't update `tag-index`. One of the admins will do that when merging your pull request.)

- add time-series output of global mean atmospheric pressure loading at each time step
    (variable: ploadbar, with #define ATMOSPHERIC_LOADING and #define ALLOW_IB_CORR); turned on
    with run-time switch "ecco_output_ploadbar = .TRUE.".