### PR TITLE
Revision to let scratch files contain the ensemble member index when …

### DIFF
--- a/doc/tag-index
+++ b/doc/tag-index
@@ -1,6 +1,8 @@
     Notes on tags used in MITgcmUV
     ==============================
 
+o eesupp:
+  - fix scratch file names when using PDAF.
 o pkg/exf:
   - fix issue in interannual monthly forcing addition (case ${fld}period=0)
 o model/src:

--- a/eesupp/inc/CPP_EEMACROS.h
+++ b/eesupp/inc/CPP_EEMACROS.h
@@ -191,8 +191,8 @@ C     and S/R open_copy_data_file. The default of I9.9 should work for
 C     a long time (until we will use 10e10 processors and more)
 #define FMT_PROC_ID 'I9.9'
 
-C--   Set the format for writing combined processor and ensemble task
-C     ID in S/R eeset_parms and S/R open_copy_data_file.
-#define FMT_PROCTSK_ID 'I9.6,a1,I6.6'
+C--   Set the format for writing ensemble task IDs in S/R eeset_parms
+C     and S/R open_copy_data_file.
+#define FMT_TSK_ID 'I6.6'
 
 #endif /* _CPP_EEMACROS_H_ */

--- a/eesupp/inc/CPP_EEMACROS.h
+++ b/eesupp/inc/CPP_EEMACROS.h
@@ -191,4 +191,8 @@ C     and S/R open_copy_data_file. The default of I9.9 should work for
 C     a long time (until we will use 10e10 processors and more)
 #define FMT_PROC_ID 'I9.9'
 
+C--   Set the format for writing combined processor and ensemble task
+C     ID in S/R eeset_parms and S/R open_copy_data_file.
+#define FMT_PROCTSK_ID 'I9.6,a1,I6.6'
+
 #endif /* _CPP_EEMACROS_H_ */

--- a/eesupp/src/eeset_parms.F
+++ b/eesupp/src/eeset_parms.F
@@ -161,9 +161,9 @@ C     After opening regular files here, they are closed with STATUS='DELETE'
 #ifdef USE_PDAF
 #define FMT_PROCTSK_ID 'I6.6,a1,I6.6'
       CALL GET_TASKID_PDAF(mpi_task_id)
-      WRITE(scratchFile1,'(A,'//FMT_PROCTSK_ID//')') 'scratch1.',
+      WRITE(scratchFile1,'(A,I6.6,a1,I6.6)') 'scratch1.',
      &     procId,".",mpi_task_id
-      WRITE(scratchFile2,'(A,'//FMT_PROCTSK_ID//')') 'scratch2.',
+      WRITE(scratchFile2,'(A,I6.6,a1,I6.6)') 'scratch2.',
      &     procId,".",mpi_task_id
 #else
       WRITE(scratchFile1,'(A,'//FMT_PROC_ID//')') 'scratch1.', procId

--- a/eesupp/src/eeset_parms.F
+++ b/eesupp/src/eeset_parms.F
@@ -159,11 +159,10 @@ C     this definition will go into CPP_EEMACROS.h, once this method is
 C     properly established
 C     After opening regular files here, they are closed with STATUS='DELETE'
 #ifdef USE_PDAF
-#define FMT_PROCTSK_ID 'I6.6,a1,I6.6'
       CALL GET_TASKID_PDAF(mpi_task_id)
-      WRITE(scratchFile1,'(A,I6.6,a1,I6.6)') 'scratch1.',
+      WRITE(scratchFile1,'('//FMT_PROCTSK_ID//')') 'scratch1.',
      &     procId,".",mpi_task_id
-      WRITE(scratchFile2,'(A,I6.6,a1,I6.6)') 'scratch2.',
+      WRITE(scratchFile2,'('//FMT_PROCTSK_ID//')') 'scratch2.',
      &     procId,".",mpi_task_id
 #else
       WRITE(scratchFile1,'(A,'//FMT_PROC_ID//')') 'scratch1.', procId

--- a/eesupp/src/eeset_parms.F
+++ b/eesupp/src/eeset_parms.F
@@ -59,6 +59,9 @@ C     record :: Temp. for textual I/O
 C     mpiRC  :: Error code reporting variable used with MPI.
       INTEGER mpiRC
 #endif
+#ifdef USE_PDAF
+      INTEGER mpi_task_id
+#endif
 CEOP
 
       NAMELIST /EEPARMS/
@@ -155,8 +158,17 @@ C     multi-node/multi-processor systems
 C     this definition will go into CPP_EEMACROS.h, once this method is
 C     properly established
 C     After opening regular files here, they are closed with STATUS='DELETE'
+#ifdef USE_PDAF
+#define FMT_PROCTSK_ID 'I6.6,a1,I6.6'
+      CALL GET_TASKID_PDAF(mpi_task_id)
+      WRITE(scratchFile1,'(A,'//FMT_PROCTSK_ID//')') 'scratch1.',
+     &     procId,".",mpi_task_id
+      WRITE(scratchFile2,'(A,'//FMT_PROCTSK_ID//')') 'scratch2.',
+     &     procId,".",mpi_task_id
+#else
       WRITE(scratchFile1,'(A,'//FMT_PROC_ID//')') 'scratch1.', procId
       WRITE(scratchFile2,'(A,'//FMT_PROC_ID//')') 'scratch2.', procId
+#endif
       OPEN(UNIT=scrUnit1, FILE=scratchFile1, STATUS='UNKNOWN')
       OPEN(UNIT=scrUnit2, FILE=scratchFile2, STATUS='UNKNOWN')
 # endif
@@ -216,7 +228,6 @@ C--   Report contents of parameter file
         CALL PRINT_MESSAGE(msgBuf,standardMessageUnit, SQUEEZE_RIGHT, 1)
         GOTO 2000
  2001  CONTINUE
-
        WRITE(msgBuf,'(A)') ' '
        CALL PRINT_MESSAGE(msgBuf,standardMessageUnit, SQUEEZE_RIGHT, 1)
       ENDIF

--- a/eesupp/src/eeset_parms.F
+++ b/eesupp/src/eeset_parms.F
@@ -160,10 +160,10 @@ C     properly established
 C     After opening regular files here, they are closed with STATUS='DELETE'
 #ifdef USE_PDAF
       CALL GET_TASKID_PDAF(mpi_task_id)
-      WRITE(scratchFile1,'('//FMT_PROCTSK_ID//')') 'scratch1.',
-     &     procId,".",mpi_task_id
-      WRITE(scratchFile2,'('//FMT_PROCTSK_ID//')') 'scratch2.',
-     &     procId,".",mpi_task_id
+      WRITE(scratchFile1,'(A,'//FMT_PROC_ID//',A,'//FMT_TSK_ID//')') 
+     &     'scratch1.', procId,'.', mpi_task_id
+      WRITE(scratchFile2,'(A,'//FMT_PROC_ID//',A,'//FMT_TSK_ID//')') 
+     &     'scratch2.', procId,'.', mpi_task_id
 #else
       WRITE(scratchFile1,'(A,'//FMT_PROC_ID//')') 'scratch1.', procId
       WRITE(scratchFile2,'(A,'//FMT_PROC_ID//')') 'scratch2.', procId

--- a/eesupp/src/eeset_parms.F
+++ b/eesupp/src/eeset_parms.F
@@ -160,10 +160,10 @@ C     properly established
 C     After opening regular files here, they are closed with STATUS='DELETE'
 #ifdef USE_PDAF
       CALL GET_TASKID_PDAF(mpi_task_id)
-      WRITE(scratchFile1,'(A,'//FMT_PROC_ID//',A,'//FMT_TSK_ID//')') 
-     &     'scratch1.', procId,'.', mpi_task_id
-      WRITE(scratchFile2,'(A,'//FMT_PROC_ID//',A,'//FMT_TSK_ID//')') 
-     &     'scratch2.', procId,'.', mpi_task_id
+      WRITE(scratchFile1,'(A,'//FMT_PROC_ID//',A,'//FMT_TSK_ID//')')
+     &     'scratch1.', procId, '.', mpi_task_id
+      WRITE(scratchFile2,'(A,'//FMT_PROC_ID//',A,'//FMT_TSK_ID//')')
+     &     'scratch2.', procId, '.', mpi_task_id
 #else
       WRITE(scratchFile1,'(A,'//FMT_PROC_ID//')') 'scratch1.', procId
       WRITE(scratchFile2,'(A,'//FMT_PROC_ID//')') 'scratch2.', procId

--- a/eesupp/src/open_copy_data_file.F
+++ b/eesupp/src/open_copy_data_file.F
@@ -54,6 +54,9 @@ C     msgBuf    :: Informational/error message buffer
 C     mpiRC  :: Error code reporting variable used with MPI.
       INTEGER mpiRC
 #endif
+#ifdef USE_PDAF
+      INTEGER mpi_task_id
+#endif
 CEOP
 
       _BEGIN_MASTER(myThid)
@@ -90,8 +93,17 @@ C     multi-node/multi-processor systems
       OPEN(UNIT=scrUnit2,STATUS='SCRATCH')
 #else
 C     After opening regular files here, they are closed with STATUS='DELETE'
+#ifdef USE_PDAF
+#define FMT_PROCTSK_ID 'I6.6,a1,I6.6'
+      CALL GET_TASKID_PDAF(mpi_task_id)
+      WRITE(scratchFile1,'(A,'//FMT_PROCTSK_ID//')') 'scratch1.',
+     &     myProcId,".",mpi_task_id
+      WRITE(scratchFile2,'(A,'//FMT_PROCTSK_ID//')') 'scratch2.',
+     &     myProcId,".",mpi_task_id
+#else
       WRITE(scratchFile1,'(A,'//FMT_PROC_ID//')') 'scratch1.', myProcId
       WRITE(scratchFile2,'(A,'//FMT_PROC_ID//')') 'scratch2.', myProcId
+#endif
       OPEN(UNIT=scrUnit1, FILE=scratchFile1, STATUS='UNKNOWN')
       OPEN(UNIT=scrUnit2, FILE=scratchFile2, STATUS='UNKNOWN')
 #endif /* USE_FORTRAN_SCRATCH_FILES */

--- a/eesupp/src/open_copy_data_file.F
+++ b/eesupp/src/open_copy_data_file.F
@@ -94,11 +94,10 @@ C     multi-node/multi-processor systems
 #else
 C     After opening regular files here, they are closed with STATUS='DELETE'
 #ifdef USE_PDAF
-#define FMT_PROCTSK_ID 'I6.6,a1,I6.6'
       CALL GET_TASKID_PDAF(mpi_task_id)
-      WRITE(scratchFile1,'(A,'//FMT_PROCTSK_ID//')') 'scratch1.',
+      WRITE(scratchFile1,'(A,I6.6,a1,I6.6)') 'scratch1.',
      &     myProcId,".",mpi_task_id
-      WRITE(scratchFile2,'(A,'//FMT_PROCTSK_ID//')') 'scratch2.',
+      WRITE(scratchFile2,'(A,I6.6,a1,I6.6)') 'scratch2.',
      &     myProcId,".",mpi_task_id
 #else
       WRITE(scratchFile1,'(A,'//FMT_PROC_ID//')') 'scratch1.', myProcId

--- a/eesupp/src/open_copy_data_file.F
+++ b/eesupp/src/open_copy_data_file.F
@@ -95,10 +95,10 @@ C     multi-node/multi-processor systems
 C     After opening regular files here, they are closed with STATUS='DELETE'
 #ifdef USE_PDAF
       CALL GET_TASKID_PDAF(mpi_task_id)
-      WRITE(scratchFile1,'(A,I6.6,a1,I6.6)') 'scratch1.',
-     &     myProcId,".",mpi_task_id
-      WRITE(scratchFile2,'(A,I6.6,a1,I6.6)') 'scratch2.',
-     &     myProcId,".",mpi_task_id
+      WRITE(scratchFile1,'('//FMT_PROCTSK_ID//')') 'scratch1.',
+     &     myprocId,".",mpi_task_id
+      WRITE(scratchFile2,'('//FMT_PROCTSK_ID//')') 'scratch2.',
+     &     myprocId,".",mpi_task_id
 #else
       WRITE(scratchFile1,'(A,'//FMT_PROC_ID//')') 'scratch1.', myProcId
       WRITE(scratchFile2,'(A,'//FMT_PROC_ID//')') 'scratch2.', myProcId

--- a/eesupp/src/open_copy_data_file.F
+++ b/eesupp/src/open_copy_data_file.F
@@ -95,10 +95,10 @@ C     multi-node/multi-processor systems
 C     After opening regular files here, they are closed with STATUS='DELETE'
 #ifdef USE_PDAF
       CALL GET_TASKID_PDAF(mpi_task_id)
-      WRITE(scratchFile1,'('//FMT_PROCTSK_ID//')') 'scratch1.',
-     &     myprocId,".",mpi_task_id
-      WRITE(scratchFile2,'('//FMT_PROCTSK_ID//')') 'scratch2.',
-     &     myprocId,".",mpi_task_id
+      WRITE(scratchFile1,'(A,'//FMT_PROC_ID//',A1,'//FMT_TSK_ID//')') 
+     &     'scratch1.', myProcId, '.', mpi_task_id
+      WRITE(scratchFile2,'(A,'//FMT_PROC_ID//',A1,'//FMT_TSK_ID//')') 
+     &     'scratch2.', myProcId, '.', mpi_task_id
 #else
       WRITE(scratchFile1,'(A,'//FMT_PROC_ID//')') 'scratch1.', myProcId
       WRITE(scratchFile2,'(A,'//FMT_PROC_ID//')') 'scratch2.', myProcId

--- a/eesupp/src/open_copy_data_file.F
+++ b/eesupp/src/open_copy_data_file.F
@@ -95,9 +95,9 @@ C     multi-node/multi-processor systems
 C     After opening regular files here, they are closed with STATUS='DELETE'
 #ifdef USE_PDAF
       CALL GET_TASKID_PDAF(mpi_task_id)
-      WRITE(scratchFile1,'(A,'//FMT_PROC_ID//',A1,'//FMT_TSK_ID//')') 
+      WRITE(scratchFile1,'(A,'//FMT_PROC_ID//',A,'//FMT_TSK_ID//')')
      &     'scratch1.', myProcId, '.', mpi_task_id
-      WRITE(scratchFile2,'(A,'//FMT_PROC_ID//',A1,'//FMT_TSK_ID//')') 
+      WRITE(scratchFile2,'(A,'//FMT_PROC_ID//',A,'//FMT_TSK_ID//')')
      &     'scratch2.', myProcId, '.', mpi_task_id
 #else
       WRITE(scratchFile1,'(A,'//FMT_PROC_ID//')') 'scratch1.', myProcId


### PR DESCRIPTION
…running in ensemble mode with PDAF. This avoids a race condition on file creation and modification.

## What changes does this PR introduce?
This a bug fix for running with PDAF. 


## What is the current behaviour? 
A race condition of the scratch files of eesupp occurs when running in ensemble mode with PDAF. This is because each ensemble model uses the same file name.


## What is the new behaviour 
Now the scratch files contain the ensemble index, so that they are distinct for each ensemble member.


## Does this PR introduce a breaking change? 
When running without data assimialtion with PDAF no changes are required. For ensemble data assimilation with PDAF, this requires release 2.0 to run. 


## Other information:


## Suggested addition to `tag-index`
(To avoid unnecessary merge conflicts, please don't update `tag-index`. One of the admins will do that when merging your pull request.)