### PR TITLE
Clean unused var

### DIFF
--- a/doc/tag-index
+++ b/doc/tag-index
@@ -1,6 +1,9 @@
     Notes on tags used in MITgcmUV
     ==============================
 
+o pkgs:
+  - remove/avoid unused variables from AD verification exp. built except from
+    halfpipe_streamice (pkg/streamice); also clean-up a bit pkg/smooth.
 o pkg/autodiff:
   - introduce separate tapes for integer arrays: the corresponding routines
     just convert between integer and double precision arrays and call the

--- a/model/src/cg2d_nsa.F
+++ b/model/src/cg2d_nsa.F
@@ -55,7 +55,7 @@ C     numIters  :: Inp: the maximum number of iterations allowed
 C                  Out: the actual number of iterations used
 C     nIterMin  :: Inp: decide to store (if >=0) or not (if <0) lowest res. sol.
 C                  Out: iteration number corresponding to lowest residual
-C     myThid    :: Thread on which I am working.
+C     myThid    :: my Thread Id number
       _RL  cg2d_b(1-OLx:sNx+OLx,1-OLy:sNy+OLy,nSx,nSy)
       _RL  cg2d_x(1-OLx:sNx+OLx,1-OLy:sNy+OLy,nSx,nSy)
       _RL  firstResidual
@@ -95,6 +95,8 @@ C                :: this field is superfluous if your cg2d is self-adjoint.
       INTEGER act1, act2
       INTEGER max1
       INTEGER icg2dkey, ikey
+#else
+      _RL    rhsNorm
 #endif
       _RL    cg2dTolerance_sq
       _RL    err_sq,  errTile(nSx,nSy)
@@ -103,7 +105,7 @@ C                :: this field is superfluous if your cg2d is self-adjoint.
       _RL    cgBeta,  alpha
       _RL    alphaSum,alphaTile(nSx,nSy)
       _RL    sumRHS,  sumRHStile(nSx,nSy)
-      _RL    rhsMax,  rhsNorm
+      _RL    rhsMax
       CHARACTER*(MAX_LEN_MBUF) msgBuf
       LOGICAL printResidual
       _RL    cg2d_z(1:sNx,1:sNy,nSx,nSy)

--- a/model/src/ini_linear_phisurf.F
+++ b/model/src/ini_linear_phisurf.F
@@ -28,7 +28,6 @@ C     === Global variables ===
 #include "SURFACE.h"
 
 C     !INPUT/OUTPUT PARAMETERS:
-C     === Routine arguments ===
 C     myThid :: my Thread Id number
       INTEGER myThid
 
@@ -37,7 +36,6 @@ C     topoHloc had to be in common for multi threading but no longer
 C     needed since MDSIO now allows (2009/06/07) to write local arrays
 
 C     !LOCAL VARIABLES:
-C     === Local variables ===
 C     topoHloc  :: Temporary array used to write surface topography
 C     bi,bj  :: tile indices
 C     i,j,k  :: Loop counters

--- a/model/src/ini_linear_phisurf.F
+++ b/model/src/ini_linear_phisurf.F
@@ -41,7 +41,9 @@ C     === Local variables ===
 C     topoHloc  :: Temporary array used to write surface topography
 C     bi,bj  :: tile indices
 C     i,j,k  :: Loop counters
+#ifndef ALLOW_AUTODIFF
       _RS topoHloc(1-OLx:sNx+OLx,1-OLy:sNy+OLy,nSx,nSy)
+#endif
       INTEGER bi, bj
       INTEGER i, j, k
       _RL     pLoc, rhoLoc

--- a/model/src/ini_pressure.F
+++ b/model/src/ini_pressure.F
@@ -29,17 +29,16 @@ C     == Global variables ==
 #include "DYNVARS.h"
 
 C     !INPUT/OUTPUT PARAMETERS:
-C     == Routine arguments ==
-C     myThid -  Number of this instance of INI_PRESSURE
+C     myThid     :: my Thread Id number
       INTEGER myThid
 
 C     !LOCAL VARIABLES:
-C     == Local variables ==
 C     dPhiHydX,Y :: Gradient (X & Y directions) of Hyd. Potential
 C     bi,bj      :: tile indices
 C     i,j,k      :: Loop counters
       INTEGER bi, bj
       INTEGER  i,  j, k
+#ifndef ALLOW_AUTODIFF
       INTEGER  iMin, iMax, jMin, jMax, npiter
       _RL PhiHydF (1-OLx:sNx+OLx,1-OLy:sNy+OLy)
       _RL PhiHydC (1-OLx:sNx+OLx,1-OLy:sNy+OLy)
@@ -48,13 +47,10 @@ C     i,j,k      :: Loop counters
       _RL oldPhi  (1-OLx:sNx+OLx,1-OLy:sNy+OLy)
       _RL count, rmspp, rmsppold
       _RL sumTile, rmsTile
+#endif
 
       CHARACTER*(MAX_LEN_MBUF) msgBuf
 CEOP
-      iMin = 1-OLx
-      iMax = sNx+OLx
-      jMin = 1-OLy
-      jMax = sNy+OLy
 
       _BEGIN_MASTER( myThid )
       WRITE(msgBuf,'(a)')
@@ -81,6 +77,11 @@ CEOP
 cph-- deal with this iterative loop for AD once it will
 cph-- really be needed;
 cph-- would need storing of totPhiHyd for each npiter
+
+       iMin = 1-OLx
+       iMax = sNx+OLx
+       jMin = 1-OLy
+       jMax = sNy+OLy
 
        rmspp    = 1. _d 0
        rmsppold = 0. _d 0

--- a/model/src/initialise_varia.F
+++ b/model/src/initialise_varia.F
@@ -97,12 +97,12 @@ C     == Global variables ==
 #endif
 
 C     !INPUT/OUTPUT PARAMETERS:
-C     == Routine arguments ==
       INTEGER myThid
 
 C     !LOCAL VARIABLES:
-C     == Local variables ==
+#ifndef ALLOW_AUTODIFF_WHTAPEIO
       INTEGER bi,bj
+#endif
 CEOP
 
 #ifdef ALLOW_DEBUG

--- a/model/src/reset_nlfs_vars.F
+++ b/model/src/reset_nlfs_vars.F
@@ -24,7 +24,6 @@ C     == Global variables
 #include "SURFACE.h"
 
 C     !INPUT/OUTPUT PARAMETERS:
-C     == Routine arguments ==
 C     myTime    :: Current time in simulation
 C     myIter    :: Current iteration number in simulation
 C     myThid    :: my Thread Id number
@@ -34,9 +33,10 @@ C     myThid    :: my Thread Id number
 
 C     !LOCAL VARIABLES:
 #ifdef NONLIN_FRSURF
-C     Local variables
-C     i,j,k,bi,bj :: loop counter
-      INTEGER i,j,bi,bj
+#ifndef DISABLE_RSTAR_CODE
+C     i, j,     :: loop counter
+C     bi, bj    :: tile indices
+      INTEGER i, j, bi, bj
 CEOP
 
 C---+----1----+----2----+----3----+----4----+----5----+----6----+----7-|--+----|
@@ -44,7 +44,6 @@ C---+----1----+----2----+----3----+----4----+----5----+----6----+----7-|--+----|
       DO bj=myByLo(myThid), myByHi(myThid)
        DO bi=myBxLo(myThid), myBxHi(myThid)
 
-#ifndef DISABLE_RSTAR_CODE
         IF ( fluidIsAir .AND. select_rStar.GE.1 ) THEN
          DO j=1-OLy,sNy+OLy
           DO i=1-OLx,sNx+OLx
@@ -58,12 +57,12 @@ C---+----1----+----2----+----3----+----4----+----5----+----6----+----7-|--+----|
           ENDDO
          ENDDO
         ENDIF
-#endif /* DISABLE_RSTAR_CODE */
 
 C- end bi,bj loop
        ENDDO
       ENDDO
 
+#endif /* DISABLE_RSTAR_CODE */
 #endif /* NONLIN_FRSURF */
 
       RETURN

--- a/pkg/autodiff/autodiff_init_varia.F
+++ b/pkg/autodiff/autodiff_init_varia.F
@@ -35,7 +35,10 @@ C     == Local variables ==
 C     bi,bj  :: tile indices
 C     i,j,k  :: Loop counters
       INTEGER bi, bj
+#if ( ( defined ALLOW_AUTODIFF_INIT_OLD && defined ECCO_CTRL_DEPRECATED ) \
+     || defined ALLOW_EP_FLUX )
       INTEGER i, j, k
+#endif
 CEOP
 
 C--   Scalar fields

--- a/pkg/autodiff/myactivefunction.F
+++ b/pkg/autodiff/myactivefunction.F
@@ -3,7 +3,7 @@
 
 CBOP
 C     !INTERFACE:
-       _RL FUNCTION myActiveFunction ( mytmp3d, mythid )
+       _RL FUNCTION myActiveFunction ( mytmp3d, myThid )
 C     !DESCRIPTION: \bv
 C     *==========================================================*
 C     *==========================================================*
@@ -17,18 +17,13 @@ C     == Global variables ===
 #include "PARAMS.h"
 
 C     !INPUT/OUTPUT PARAMETERS:
-C     == Routine arguments ==
 C     myThid - Thread number for this instance of the routine.
 C     myIter - Iteration number
 C     myTime - Current time of simulation ( s )
       _RL     mytmp3d(sNx,sNy,Nr,nSx,nSy)
       INTEGER myThid
-      INTEGER myIter
 
 C     !LOCAL VARIABLES:
-
-c     == external ==
-
 CEOP
 
       myActiveFunction = 1.0

--- a/pkg/autodiff/myactivefunction_ad.F
+++ b/pkg/autodiff/myactivefunction_ad.F
@@ -3,8 +3,8 @@
 
 CBOP
 C     !INTERFACE:
-      SUBROUTINE admyActiveFunction ( 
-     &     mytmp3d, mythid, admytmp3d,admyactivetmp )
+      SUBROUTINE admyActiveFunction(
+     &     mytmp3d, myThid, admytmp3d, admyactivetmp )
 C     !DESCRIPTION: \bv
 C     *==========================================================*
 C     *==========================================================*
@@ -18,7 +18,6 @@ C     == Global variables ===
 #include "PARAMS.h"
 
 C     !INPUT/OUTPUT PARAMETERS:
-C     == Routine arguments ==
 C     myThid - Thread number for this instance of the routine.
 C     myIter - Iteration number
 C     myTime - Current time of simulation ( s )
@@ -26,12 +25,8 @@ C     myTime - Current time of simulation ( s )
       _RL     admytmp3d(sNx,sNy,Nr,nSx,nSy)
       _RL     admyactivetmp
       INTEGER myThid
-      INTEGER myIter
 
 C     !LOCAL VARIABLES:
-
-c     == external ==
-
 CEOP
 
 cph   Do nothing and nothing will be done

--- a/pkg/bling/bling_light.F
+++ b/pkg/bling/bling_light.F
@@ -72,10 +72,6 @@ C      irr_eff      :: effective light for photosynthesis
       _RL irr_eff   (1-OLx:sNx+OLx,1-OLy:sNy+OLy,Nr)
 
 C     === Local variables ===
-      _RL solar, albedo
-      _RL dayfrac, yday, delta
-      _RL lat, sun1, dayhrs
-      _RL cosz, frac, fluxi
       _RL atten
       _RL irr_surf  (1-OLx:sNx+OLx,1-OLy:sNy+OLy)
 #ifdef ML_MEAN_LIGHT
@@ -84,6 +80,10 @@ C     === Local variables ===
       _RL tmp_ML
 #endif
 #ifndef USE_QSW
+      _RL solar, albedo
+      _RL dayfrac, yday, delta
+      _RL lat, sun1, dayhrs
+      _RL cosz, frac, fluxi
       _RL sfac      (1-OLy:sNy+OLy)
 #endif
 #ifdef PHYTO_SELF_SHADING
@@ -170,7 +170,7 @@ C convert to sfac
           sfac(j) = MAX(1. _d -5,fluxi)
        ENDDO !j
 
-#endif
+#endif /* ndef USE_QSW */
 
 c ---------------------------------------------------------------------
 c  instantaneous light, mixed layer averaged light

--- a/pkg/cost/cost_accumulate_mean.F
+++ b/pkg/cost/cost_accumulate_mean.F
@@ -1,11 +1,9 @@
 #include "COST_OPTIONS.h"
 
-      subroutine cost_accumulate_mean( myThid )
+      SUBROUTINE cost_accumulate_mean( myThid )
 C     *==========================================================*
-C     | subroutine cost_accumulate_mean                          |
+C     | SUBROUTINE cost_accumulate_mean                          |
 C     | o accumulate mean state for cost evalualtion             |
-C     *==========================================================*
-C     |                                                          |
 C     *==========================================================*
       IMPLICIT NONE
 
@@ -20,29 +18,19 @@ C     == Global variables ===
 
 C     == Routine arguments ==
 C     myThid - Thread number for this instance of the routine.
-      integer bi, bj
-      integer myThid
+      INTEGER bi, bj
+      INTEGER myThid
 
 #ifdef ALLOW_COST
 C     == Local variables
-      _RL thetaRef
-
-      integer i, j, k
-      integer ig, jg
-      integer itlo,ithi
-      integer jtlo,jthi
-
-      jtlo = mybylo(mythid)
-      jthi = mybyhi(mythid)
-      itlo = mybxlo(mythid)
-      ithi = mybxhi(mythid)
+      INTEGER i, j, k
 
 C--   Calculate cost function on tile of this instance
-      do bj = jtlo,jthi
-        do bi = itlo,ithi
-          do k = 1, Nr
-            do j=1,sNy
-              do i=1,sNx
+      DO bj = myByLo(myThid), myByHi(myThid)
+        DO bi = myBxLo(myThid), myBxHi(myThid)
+          DO k = 1, Nr
+            DO j=1,sNy
+              DO i=1,sNx
                 cMeanTheta(i,j,k,bi,bj) = cMeanTheta(i,j,k,bi,bj)
      &                + theta(i,j,k,bi,bj)
      &                /lastinterval*deltaTClock
@@ -65,11 +53,11 @@ C--   Calculate cost function on tile of this instance
      &                 /2.*vvel(i,j,k,bi,bj)
      &                 *maskS(i,j,k,bi,bj)*maskC(i,j,k,bi,bj)
      &                 /lastinterval*deltaTClock
-              end do
-            end do
-          end do
-        end do
-      end do
+              ENDDO
+            ENDDO
+          ENDDO
+        ENDDO
+      ENDDO
 
 #endif
 

--- a/pkg/cost/cost_dependent_init.F
+++ b/pkg/cost/cost_dependent_init.F
@@ -30,18 +30,15 @@ c     == routine arguments ==
 
 c     == local variables ==
 
-      integer i,j,k
+#if ( defined ALLOW_COST_VECTOR || defined  ALLOW_COST_STATE_FINAL )
+      integer i
+#endif
+#ifdef ALLOW_COST_STATE_FINAL
+      integer j, k
+#endif
       integer bi,bj
-      integer itlo,ithi
-      integer jtlo,jthi
-
-c     == external functions ==
 
 c     == end of interface ==
-      jtlo = mybylo(mythid)
-      jthi = mybyhi(mythid)
-      itlo = mybxlo(mythid)
-      ithi = mybxhi(mythid)
 
 #ifdef ALLOW_OPENAD
       fc%v = 0.0
@@ -59,8 +56,8 @@ c     == end of interface ==
       endif
 #endif
 
-      do bj = jtlo,jthi
-       do bi = itlo,ithi
+      do bj = myByLo(mythid), myByHi(mythid)
+       do bi = myBxLo(mythid), myBxHi(mythid)
 #ifdef ALLOW_COST_VECTOR
         do i=1,sNx
          objf_vector(i,bi,bj) = 0. _d 0

--- a/pkg/cost/cost_tracer.F
+++ b/pkg/cost/cost_tracer.F
@@ -33,31 +33,24 @@ C     myThid - Thread number for this instance of the routine.
       integer myThid
 
 #ifdef ALLOW_COST_TRACER
+#ifdef ALLOW_PTRACERS
 C     == Local variables
-      _RL thetaRef
       _RL locfc
-
       integer i, j, k
-      integer ig, jg
-
-ce    some reference temperature
-      thetaRef = 24.0D0
 
       locfc = 0. _d 0
-
       k=1
       DO j=1,sNy
          DO i=1,sNx
-#ifdef ALLOW_PTRACERS
             locfc = locfc + hFacC(i,j,k,bi,bj)*
      &           lambdaTr1ClimRelax*ptracer(i,j,k,bi,bj,1)*
      &           rA(i,j,bi,bj)*drF(k)*dTtracerLev(k)
-#endif
          ENDDO
       ENDDO
 
       objf_tracer(bi,bj) = objf_tracer(bi,bj) + locfc
 
+#endif /* ALLOW_PTRACERS */
 #endif /* ALLOW_COST_TRACER */
 
       RETURN

--- a/pkg/ctrl/ctrl_check.F
+++ b/pkg/ctrl/ctrl_check.F
@@ -53,7 +53,10 @@ C     msgBuf     :: Informational/error message buffer
 #endif
 
 #if ( defined ALLOW_GENARR2D_CONTROL || defined ALLOW_GENARR3D_CONTROL || defined ALLOW_GENTIM2D_CONTROL )
-      INTEGER iarr, k2
+      INTEGER iarr
+#endif
+#if ( defined ALLOW_GENARR2D_CONTROL || defined ALLOW_GENARR3D_CONTROL )
+      INTEGER k2
 #endif
 #if ( defined ALLOW_GENARR3D_CONTROL && defined ALLOW_PTRACERS )
       INTEGER iLen, iPtr, ascii_1

--- a/pkg/ctrl/ctrl_cost_driver.F
+++ b/pkg/ctrl/ctrl_cost_driver.F
@@ -5,10 +5,6 @@
 c     ==================================================================
 c     SUBROUTINE ctrl_cost_driver
 c     ==================================================================
-c
-c     ==================================================================
-c     SUBROUTINE ctrl_cost_driver
-c     ==================================================================
 
       implicit none
 
@@ -39,18 +35,21 @@ c     == local variables ==
       integer endrec
 #endif
 
-#if (defined (ALLOW_GENARR2D_CONTROL) || defined (ALLOW_GENARR3D_CONTROL) || defined (ALLOW_GENTIM2D_CONTROL))
+#if ( defined ALLOW_GENTIM2D_CONTROL  || defined ALLOW_GENARR2D_CONTROL || defined ALLOW_GENARR3D_CONTROL )
       integer iarr
       logical dodimensionalcost
       integer k2
-      _RS mask2D(1-olx:snx+olx,1-oly:sny+oly,nsx,nsy)
-      _RS mask3D(1-olx:snx+olx,1-oly:sny+oly,Nr,nsx,nsy)
+#endif
+#if ( defined ALLOW_GENTIM2D_CONTROL  || defined ALLOW_GENARR2D_CONTROL )
+      _RS mask2D(1-OLx:sNx+OLx,1-OLy:sNy+OLy,nSx,nSy)
+#endif
+#ifdef ALLOW_GENARR3D_CONTROL
+      _RS mask3D(1-OLx:sNx+OLx,1-OLy:sNy+OLy,Nr,nSx,nSy)
 #endif
 
 c     == end of interface ==
 
 c--   Evaluate the individual cost function contributions.
-
 
 #ifdef ALLOW_GENTIM2D_CONTROL
       do iarr = 1, maxCtrlTim2D
@@ -80,7 +79,7 @@ C --- Get appropriate mask for field
      &     startrec, endrec,
      &     xx_gentim2d_file(iarr),xx_gentim2d_dummy(iarr),
      &     xx_gentim2d_period(iarr),
-     &     wgentim2d(1-Olx,1-Oly,1,1,iarr),
+     &     wgentim2d(1-OLx,1-OLy,1,1,iarr),
      &     dodimensionalcost,
      &     num_gentim2d(1,1,iarr),
      &     objf_gentim2d(1,1,iarr),
@@ -111,7 +110,7 @@ C --- Get appropriate mask for field
       call ctrl_cost_gen2d (
      &     1,1,
      &     xx_genarr2d_file(iarr),xx_genarr2d_dummy(iarr),
-     &     zeroRL, wgenarr2d(1-Olx,1-Oly,1,1,iarr),
+     &     zeroRL, wgenarr2d(1-OLx,1-OLy,1,1,iarr),
      &     dodimensionalcost,
      &     num_genarr2d(1,1,iarr), objf_genarr2d(1,1,iarr),
 #ifdef ECCO_CTRL_DEPRECATED
@@ -124,7 +123,6 @@ C --- Get appropriate mask for field
 
       enddo
 #endif
-
 
 #ifdef ALLOW_GENARR3D_CONTROL
       do iarr = 1, maxCtrlArr3D
@@ -142,7 +140,7 @@ C --- Get appropriate mask for field
       if (xx_genarr3d_weight(iarr).NE.' ') then
       call ctrl_cost_gen3d (
      &     xx_genarr3d_file(iarr),xx_genarr3d_dummy(iarr),
-     &     wgenarr3d(1-Olx,1-Oly,1,1,1,iarr),
+     &     wgenarr3d(1-OLx,1-OLy,1,1,1,iarr),
      &     dodimensionalcost,
      &     num_genarr3d(1,1,iarr), objf_genarr3d(1,1,iarr),
      &     mask3D, myThid )
@@ -152,7 +150,6 @@ C --- Get appropriate mask for field
 #endif
 
 #endif
-
 
       return
       end

--- a/pkg/ctrl/ctrl_cost_gen.F
+++ b/pkg/ctrl/ctrl_cost_gen.F
@@ -33,8 +33,7 @@ C     !INTERFACE:
      I                       xx_gen_remo_slope,
 #endif /* ECCO_CTRL_DEPRECATED */
      I                       xx_gen_mask2D,
-     I                       myThid
-     &                         )
+     I                       myThid )
 
 C     !DESCRIPTION: \bv
 C     Generic routine for all 2D control penalty terms
@@ -65,20 +64,20 @@ c     == routine arguments ==
       character*(MAX_LEN_FNAM) xx_gen_file
       _RL xx_gen_dummy
       _RL xx_gen_period
-      _RL xx_gen_weight(1-olx:snx+olx,1-oly:sny+oly,nsx,nsy)
+      _RL xx_gen_weight(1-OLx:sNx+OLx,1-OLy:sNy+OLy,nSx,nSy)
       logical dodimensionalcost
-      _RL num_gen_anom(nsx,nsy)
-      _RL objf_gen_anom(nsx,nsy)
+      _RL num_gen_anom(nSx,nSy)
+      _RL objf_gen_anom(nSx,nSy)
 #ifdef ECCO_CTRL_DEPRECATED
       _RL xx_gen_wmean
-      _RL num_gen_mean(nsx,nsy)
-      _RL num_gen_smoo(nsx,nsy)
-      _RL objf_gen_mean(nsx,nsy)
-      _RL objf_gen_smoo(nsx,nsy)
+      _RL num_gen_mean(nSx,nSy)
+      _RL num_gen_smoo(nSx,nSy)
+      _RL objf_gen_mean(nSx,nSy)
+      _RL objf_gen_smoo(nSx,nSy)
       _RL xx_gen_remo_intercept
       _RL xx_gen_remo_slope
 #endif /* ECCO_CTRL_DEPRECATED */
-      _RS xx_gen_mask2D(1-olx:snx+olx,1-oly:sny+oly,nsx,nsy)
+      _RS xx_gen_mask2D(1-OLx:sNx+OLx,1-OLy:sNy+OLy,nSx,nSy)
       integer myThid
 
 #ifdef ALLOW_CTRL
@@ -86,7 +85,7 @@ c     == routine arguments ==
 c     == local variables ==
 
       integer bi,bj
-      integer i,j,kk
+      integer i, j
       integer itlo,ithi
       integer jtlo,jthi
       integer jmin,jmax
@@ -96,14 +95,17 @@ c     == local variables ==
       integer ilfld
 
       _RL fctile
-      _RL fctilem
       _RL tmpx
       _RL lengthscale
 
 #ifdef ECCO_CTRL_DEPRECATED
-      _RL xx_mean(1-olx:snx+olx,1-oly:sny+oly,nsx,nsy)
+#ifdef ALLOW_SMOOTH_BC_COST_CONTRIBUTION
+      integer kk
+#endif
+      _RL fctilem
+      _RL xx_mean(1-OLx:sNx+OLx,1-OLy:sNy+OLy,nSx,nSy)
 #endif /* ECCO_CTRL_DEPRECATED */
-      _RL tmpfld2d(1-olx:snx+olx,1-oly:sny+oly,   nsx,nsy)
+      _RL tmpfld2d(1-OLx:sNx+OLx,1-OLy:sNy+OLy,   nSx,nSy)
 
       logical doglobalread
       logical ladinit
@@ -117,14 +119,14 @@ c     == external functions ==
 
 CEOP
 
-      jtlo = mybylo(myThid)
-      jthi = mybyhi(myThid)
-      itlo = mybxlo(myThid)
-      ithi = mybxhi(myThid)
+      jtlo = myByLo(myThid)
+      jthi = myByHi(myThid)
+      itlo = myBxLo(myThid)
+      ithi = myBxHi(myThid)
       jmin = 1
-      jmax = sny
+      jmax = sNy
       imin = 1
-      imax = snx
+      imax = sNx
 
       lengthscale = 1. _d 0
 
@@ -137,8 +139,8 @@ c     Number of records to be used.
 
       do bj = jtlo,jthi
        do bi = itlo,ithi
-        do j = 1-oly,sny+oly
-         do i = 1-olx,snx+olx
+        do j = 1-OLy,sNy+OLy
+         do i = 1-OLx,sNx+OLx
           tmpfld2d(i,j,bi,bj) = 0. _d 0
          enddo
         enddo
@@ -421,8 +423,7 @@ C     !INTERFACE:
      O                       num_gen,
      O                       objf_gen,
      I                       xx_gen_mask,
-     I                       myThid
-     &                         )
+     I                       myThid )
 
 C     !DESCRIPTION: \bv
 C     Generic routine for all 3D control penalty terms
@@ -450,11 +451,11 @@ c     == routine arguments ==
 
       character*(MAX_LEN_FNAM) xx_gen_file
       _RL xx_gen_dummy
-      _RL xx_gen_weight(1-olx:snx+olx,1-oly:sny+oly,nr,nsx,nsy)
+      _RL xx_gen_weight(1-OLx:sNx+OLx,1-OLy:sNy+OLy,Nr,nSx,nSy)
       logical dodimensionalcost
-      _RL num_gen(nsx,nsy)
-      _RL objf_gen(nsx,nsy)
-      _RS xx_gen_mask(1-olx:snx+olx,1-oly:sny+oly,nr,nsx,nsy)
+      _RL num_gen(nSx,nSy)
+      _RL objf_gen(nSx,nSy)
+      _RS xx_gen_mask(1-OLx:sNx+OLx,1-OLy:sNy+OLy,Nr,nSx,nSy)
       INTEGER myThid
 
 #ifdef ALLOW_CTRL
@@ -474,7 +475,7 @@ c     == local variables ==
 
       logical doglobalread
       logical ladinit
-      _RL     tmpfld3d(1-olx:snx+olx,1-oly:sny+oly,nr,nsx,nsy)
+      _RL     tmpfld3d(1-OLx:sNx+OLx,1-OLy:sNy+OLy,Nr,nSx,nSy)
 
       character*(80) fnamefld
 
@@ -485,14 +486,14 @@ c     == external functions ==
 
 CEOP
 
-      jtlo = mybylo(myThid)
-      jthi = mybyhi(myThid)
-      itlo = mybxlo(myThid)
-      ithi = mybxhi(myThid)
+      jtlo = myByLo(myThid)
+      jthi = myByHi(myThid)
+      itlo = myBxLo(myThid)
+      ithi = myBxHi(myThid)
       jmin = 1
-      jmax = sny
+      jmax = sNy
       imin = 1
-      imax = snx
+      imax = sNx
 
 c--   Read state record from global file.
       doglobalread = .false.
@@ -500,9 +501,9 @@ c--   Read state record from global file.
 
       do bj = jtlo,jthi
        do bi = itlo,ithi
-        do k = 1,nr
-         do j = 1-oly,sny+oly
-          do i = 1-olx,snx+olx
+        do k = 1,Nr
+         do j = 1-OLy,sNy+OLy
+          do i = 1-OLx,sNx+OLx
            tmpfld3d(i,j,k,bi,bj) = 0. _d 0
           enddo
          enddo
@@ -541,7 +542,7 @@ c--     Loop over this thread tiles.
             num_gen(bi,bj)  = 0. _d 0
             objf_gen(bi,bj) = 0. _d 0
 
-            do k = 1,nr
+            do k = 1,Nr
             do j = jmin,jmax
               do i = imin,imax
                 if (xx_gen_mask(i,j,k,bi,bj) .ne. 0. _d 0) then

--- a/pkg/ctrl/ctrl_get_gen.F
+++ b/pkg/ctrl/ctrl_get_gen.F
@@ -5,8 +5,7 @@
      I          genmask, genfld, xx_gen0, xx_gen1, xx_gen_dummy,
      I          xx_gen_remo_intercept, xx_gen_remo_slope,
      I          genweight,
-     I          mytime, myiter, mythid
-     &                     )
+     I          myTime, myIter, myThid )
 
 c     ==================================================================
 c     SUBROUTINE ctrl_get_gen
@@ -36,32 +35,28 @@ c     == global variables ==
 #endif
 
 c     == routine arguments ==
-
-#ifdef ALLOW_SMOOTH
-      character*(80) fnamegeneric
-#endif
       character*(MAX_LEN_FNAM) xx_gen_file
       integer xx_genstartdate(4)
       _RL     xx_genperiod
-      _RS     genmask(1-olx:snx+olx,1-oly:sny+oly,nsx,nsy)
-      _RL     genfld(1-olx:snx+olx,1-oly:sny+oly,nsx,nsy)
-      _RL     xx_gen0(1-olx:snx+olx,1-oly:sny+oly,nsx,nsy)
-      _RL     xx_gen1(1-olx:snx+olx,1-oly:sny+oly,nsx,nsy)
+      _RS     genmask(1-OLx:sNx+OLx,1-OLy:sNy+OLy,nSx,nSy)
+      _RL     genfld(1-OLx:sNx+OLx,1-OLy:sNy+OLy,nSx,nSy)
+      _RL     xx_gen0(1-OLx:sNx+OLx,1-OLy:sNy+OLy,nSx,nSy)
+      _RL     xx_gen1(1-OLx:sNx+OLx,1-OLy:sNy+OLy,nSx,nSy)
       _RL     xx_gen_dummy
       _RL     xx_gen_remo_intercept
       _RL     xx_gen_remo_slope
-      _RL     genweight(1-olx:snx+olx,1-oly:sny+oly,nsx,nsy)
+      _RL     genweight(1-OLx:sNx+OLx,1-OLy:sNy+OLy,nSx,nSy)
+      _RL     myTime
+      integer myIter
+      integer myThid
 
-      _RL     mytime
-      integer myiter
-      integer mythid
+c     == external functions ==
+      integer  ilnblnk
+      external ilnblnk
 
 c     == local variables ==
-
       integer bi,bj
       integer i,j
-      integer itlo,ithi
-      integer jtlo,jthi
       integer jmin,jmax
       integer imin,imax
       integer ilgen
@@ -78,6 +73,9 @@ c     == local variables ==
       logical ladinit
 
       character*(80) fnamegen
+#if ( defined ALLOW_SMOOTH && defined ALLOW_SMOOTH_CTRL2D )
+      character*(80) fnamegeneric
+#endif
 #ifndef ECCO_CTRL_DEPRECATED
       character*(MAX_LEN_FNAM) xx_tauu_file
       character*(MAX_LEN_FNAM) xx_tauv_file
@@ -88,21 +86,12 @@ c     == local variables ==
       character*(MAX_LEN_FNAM) xx_swdown_file
 #endif
 
-c     == external functions ==
-
-      integer  ilnblnk
-      external ilnblnk
-
 c     == end of interface ==
 
-      jtlo = mybylo(mythid)
-      jthi = mybyhi(mythid)
-      itlo = mybxlo(mythid)
-      ithi = mybxhi(mythid)
-      jmin = 1-oly
-      jmax = sny+oly
-      imin = 1-olx
-      imax = snx+olx
+      jmin = 1-OLy
+      jmax = sNy+OLy
+      imin = 1-OLx
+      imax = sNx+OLx
 
 c--   Now, read the control vector.
       doglobalread = .false.
@@ -125,7 +114,7 @@ c--   Get the counters, flags, and the interpolation factor.
      I                       xx_genstartdate, xx_genperiod,
      O                       genfac, genfirst, genchanged,
      O                       gencount0,gencount1,
-     I                       mytime, myiter, mythid )
+     I                       myTime, myIter, mythid )
 
       if ( genfirst ) then
 cc#ifdef ALLOW_OPENAD
@@ -244,22 +233,22 @@ cph since the above is ECCO specific, we undo it here:
 cph      doCtrlUpdate = .TRUE.
       if ( doCtrlUpdate ) then
 cph)
-      do bj = jtlo,jthi
-        do bi = itlo,ithi
+       do bj = myByLo(myThid), myByHi(myThid)
+        do bi = myBxLo(myThid), myBxHi(myThid)
 c--       Calculate mask for tracer cells (0 => land, 1 => water).
-          do j = 1,sny
-            do i = 1,snx
+          do j = 1,sNy
+            do i = 1,sNx
               genfld(i,j,bi,bj) = genfld (i,j,bi,bj)
      &              + gensign*genfac            *xx_gen0(i,j,bi,bj)
      &              + gensign*(1. _d 0 - genfac)*xx_gen1(i,j,bi,bj)
               genfld(i,j,bi,bj) =
      &             genmask(i,j,bi,bj)*( genfld (i,j,bi,bj) -
      &             ( xx_gen_remo_intercept +
-     &               xx_gen_remo_slope*(mytime-starttime) ) )
+     &               xx_gen_remo_slope*(myTime-starttime) ) )
             enddo
           enddo
         enddo
-      enddo
+       enddo
 cph(
       endif
 cph)

--- a/pkg/ctrl/ctrl_get_mask.F
+++ b/pkg/ctrl/ctrl_get_mask.F
@@ -44,7 +44,6 @@ C     !INPUT/OUTPUT PARAMETERS:
       INTEGER myThid
 
 C     !LOCAL VARIABLES:
-      INTEGER i, j, bi, bj
 CEOP
 
 C --- Initial velocity
@@ -106,7 +105,6 @@ C     !INPUT/OUTPUT PARAMETERS:
       INTEGER myThid
 
 C     !LOCAL VARIABLES:
-      INTEGER i, j, bi, bj
       LOGICAL iAmDone
 CEOP
 

--- a/pkg/ctrl/ctrl_getobcse.F
+++ b/pkg/ctrl/ctrl_getobcse.F
@@ -4,10 +4,7 @@
 #endif
 
       subroutine ctrl_getobcse(
-     I                             mytime,
-     I                             myiter,
-     I                             mythid
-     &                           )
+     I                          myTime, myIter, myThid )
 
 c     ==================================================================
 c     SUBROUTINE ctrl_getobcse
@@ -41,60 +38,48 @@ c#include "OBCS_PARAMS.h"
 #endif /* ALLOW_OBCSE_CONTROL */
 
 c     == routine arguments ==
-      _RL     mytime
-      integer myiter
-      integer mythid
+      _RL     myTime
+      integer myIter
+      integer myThid
 
 #ifdef ALLOW_OBCSE_CONTROL
-c     == local variables ==
+c     == external functions ==
+      integer  ilnblnk
+      external ilnblnk
 
+c     == local variables ==
       integer bi,bj
       integer i,j,k
       integer itlo,ithi
       integer jtlo,jthi
       integer jmin,jmax
-      integer imin,imax
       integer ilobcse
       integer iobcs
-
-      _RL     dummy
       _RL     obcsefac
       logical obcsefirst
       logical obcsechanged
       integer obcsecount0
       integer obcsecount1
       integer ip1
-
-cgg      _RL maskyz   (1-oly:sny+oly,nr,nsx,nsy)
-      _RL tmpfldyz (1-oly:sny+oly,nr,nsx,nsy)
-
+cgg      _RL maskyz   (1-OLy:sNy+OLy,Nr,nSx,nSy)
+      _RL tmpfldyz (1-OLy:sNy+OLy,Nr,nSx,nSy)
       logical doglobalread
       logical ladinit
-
       character*(80) fnameobcse
-
 #ifdef ALLOW_OBCS_CONTROL_MODES
       integer nk,nz
-      _RL     tmpz (nr,nsx,nsy)
+      _RL     tmpz (Nr,nSx,nSy)
       _RL     stmp
 #endif
 
-c     == external functions ==
-
-      integer  ilnblnk
-      external ilnblnk
-
-
 c     == end of interface ==
 
-      jtlo = mybylo(mythid)
-      jthi = mybyhi(mythid)
-      itlo = mybxlo(mythid)
-      ithi = mybxhi(mythid)
-      jmin = 1-oly
-      jmax = sny+oly
-      imin = 1-olx
-      imax = snx+olx
+      jtlo = myByLo(myThid)
+      jthi = myByHi(myThid)
+      itlo = myBxLo(myThid)
+      ithi = myBxHi(myThid)
+      jmin = 1-OLy
+      jmax = sNy+OLy
       ip1  = 0
 
 c--   Now, read the control vector.
@@ -112,7 +97,7 @@ c--   Get the counters, flags, and the interpolation factor.
      I                   xx_obcsestartdate, xx_obcseperiod,
      O                   obcsefac, obcsefirst, obcsechanged,
      O                   obcsecount0,obcsecount1,
-     I                   mytime, myiter, mythid )
+     I                   myTime, myIter, myThid )
 
       do iobcs = 1,nobcs
 
@@ -163,7 +148,7 @@ cih    Compute absolute velocities from the barotropic-baroclinic modes.
            enddo
           endif
 #endif
-          do k = 1,nr
+          do k = 1,Nr
            do j = jmin,jmax
             xx_obcse1(j,k,bi,bj,iobcs)  = tmpfldyz (j,k,bi,bj)
 cgg   &                                        *   maskyz (j,k,bi,bj)
@@ -178,7 +163,7 @@ cgg   &                                        *   maskyz (j,k,bi,bj)
         do bj = jtlo,jthi
          do bi = itlo,ithi
           do j = jmin,jmax
-           do k = 1,nr
+           do k = 1,Nr
             xx_obcse0(j,k,bi,bj,iobcs) = xx_obcse1(j,k,bi,bj,iobcs)
             tmpfldyz (j,k,bi,bj)       = 0. _d 0
            enddo
@@ -232,7 +217,7 @@ cih    Compute absolute velocities from the barotropic-baroclinic modes.
            enddo
           endif
 #endif
-          do k = 1,nr
+          do k = 1,Nr
            do j = jmin,jmax
             xx_obcse1 (j,k,bi,bj,iobcs) = tmpfldyz (j,k,bi,bj)
 cgg   &                                        *   maskyz (j,k,bi,bj)
@@ -246,8 +231,8 @@ c--   Add control to model variable.
        do bj = jtlo,jthi
         do bi = itlo,ithi
 c--   Calculate mask for tracer cells (0 => land, 1 => water).
-         do k = 1,nr
-          do j = 1,sny
+         do k = 1,Nr
+          do j = 1,sNy
            i = OB_Ie(j,bi,bj)
            IF ( i.EQ.OB_indexNone ) i = 1
            if (iobcs .EQ. 1) then

--- a/pkg/ctrl/ctrl_getobcsn.F
+++ b/pkg/ctrl/ctrl_getobcsn.F
@@ -4,10 +4,7 @@
 #endif
 
       subroutine ctrl_getobcsn(
-     I                             mytime,
-     I                             myiter,
-     I                             mythid
-     &                           )
+     I                          myTime, myIter, myThid )
 
 c     ==================================================================
 c     SUBROUTINE ctrl_getobcsn
@@ -17,8 +14,8 @@ c     o Get northern obc of the control vector and add it
 c       to dyn. fields
 c
 c     started: heimbach@mit.edu, 29-Aug-2001
-c
 c     modified: gebbie@mit.edu, 18-Mar-2003
+c
 c     ==================================================================
 c     SUBROUTINE ctrl_getobcsn
 c     ==================================================================
@@ -42,65 +39,50 @@ c#include "OBCS_PARAMS.h"
 #endif /* ALLOW_OBCSN_CONTROL */
 
 c     == routine arguments ==
-      _RL     mytime
-      integer myiter
-      integer mythid
+      _RL     myTime
+      integer myIter
+      integer myThid
 
 #ifdef ALLOW_OBCSN_CONTROL
-c     == local variables ==
+c     == external functions ==
+      integer  ilnblnk
+      external ilnblnk
 
+c     == local variables ==
       integer bi,bj
       integer i,j,k
       integer itlo,ithi
       integer jtlo,jthi
-      integer jmin,jmax
       integer imin,imax
       integer ilobcsn
       integer iobcs
       integer jp1
-
-      _RL     dummy
       _RL     obcsnfac
       logical obcsnfirst
       logical obcsnchanged
       integer obcsncount0
       integer obcsncount1
-
-cgg      _RL maskxz   (1-olx:snx+olx,nr,nsx,nsy)
-      _RL tmpfldxz (1-olx:snx+olx,nr,nsx,nsy)
-
+cgg      _RL maskxz   (1-OLx:sNx+OLx,Nr,nSx,nSy)
+      _RL tmpfldxz (1-OLx:sNx+OLx,Nr,nSx,nSy)
       logical doglobalread
       logical ladinit
-
       character*(80) fnameobcsn
-
 #ifdef ALLOW_OBCS_CONTROL_MODES
       integer nk,nz
-      _RL     tmpz (nr,nsx,nsy)
+      _RL     tmpz (Nr,nSx,nSy)
       _RL     stmp
 #endif
 
-c     == external functions ==
-
-      integer  ilnblnk
-      external ilnblnk
-
-
 c     == end of interface ==
 
-      jtlo = mybylo(mythid)
-      jthi = mybyhi(mythid)
-      itlo = mybxlo(mythid)
-      ithi = mybxhi(mythid)
-cgg      jmin = 1-oly
-cgg      jmax = sny+oly
+      jtlo = myByLo(myThid)
+      jthi = myByHi(myThid)
+      itlo = myBxLo(myThid)
+      ithi = myBxHi(myThid)
 cgg      imin = 1-olx
 cgg      imax = snx+olx
-
-      jmin = 1
-      jmax = sny
       imin = 1
-      imax = snx
+      imax = sNx
       jp1  = 0
 
 c--   Now, read the control vector.
@@ -118,9 +100,10 @@ c--   Get the counters, flags, and the interpolation factor.
      I                   xx_obcsnstartdate, xx_obcsnperiod,
      O                   obcsnfac, obcsnfirst, obcsnchanged,
      O                   obcsncount0,obcsncount1,
-     I                   mytime, myiter, mythid )
+     I                   myTime, myIter, myThid )
 
       do iobcs = 1,nobcs
+
        if ( obcsnfirst ) then
         call active_read_xz( fnameobcsn, tmpfldxz,
      &                       (obcsncount0-1)*nobcs+iobcs,
@@ -168,7 +151,7 @@ cih    Compute absolute velocities from the barotropic-baroclinic modes.
            enddo
           endif
 #endif
-          do k = 1,nr
+          do k = 1,Nr
            do i = imin,imax
             xx_obcsn1(i,k,bi,bj,iobcs)  = tmpfldxz (i,k,bi,bj)
 cgg   &                                    *   maskxz (i,k,bi,bj)
@@ -182,7 +165,7 @@ cgg   &                                    *   maskxz (i,k,bi,bj)
 
         do bj = jtlo,jthi
          do bi = itlo,ithi
-          do k = 1,nr
+          do k = 1,Nr
            do i = imin,imax
             xx_obcsn0(i,k,bi,bj,iobcs) = xx_obcsn1(i,k,bi,bj,iobcs)
             tmpfldxz (i,k,bi,bj)       = 0. _d 0
@@ -237,7 +220,7 @@ cih    Compute absolute velocities from the barotropic-baroclinic modes.
            enddo
           endif
 #endif
-          do k = 1,nr
+          do k = 1,Nr
            do i = imin,imax
             xx_obcsn1 (i,k,bi,bj,iobcs) = tmpfldxz (i,k,bi,bj)
 cgg   &                                        *   maskxz (i,k,bi,bj)
@@ -245,16 +228,15 @@ cgg   &                                        *   maskxz (i,k,bi,bj)
           enddo
          enddo
         enddo
-
        endif
 
 c--   Add control to model variable.
        do bj = jtlo,jthi
         do bi = itlo,ithi
 c--   Calculate mask for tracer cells (0 => land, 1 => water).
-         do k = 1,nr
-          do i = 1,snx
-           j = OB_Jn(I,bi,bj)
+         do k = 1,Nr
+          do i = 1,sNx
+           j = OB_Jn(i,bi,bj)
            IF ( j.EQ.OB_indexNone ) j = 1
            if (iobcs .EQ. 1) then
             OBNt(i,k,bi,bj) = OBNt (i,k,bi,bj)

--- a/pkg/ctrl/ctrl_getobcss.F
+++ b/pkg/ctrl/ctrl_getobcss.F
@@ -4,10 +4,7 @@
 #endif
 
       subroutine ctrl_getobcss(
-     I                             mytime,
-     I                             myiter,
-     I                             mythid
-     &                           )
+     I                          myTime, myIter, myThid )
 
 c     ==================================================================
 c     SUBROUTINE ctrl_getobcss
@@ -17,7 +14,6 @@ c     o Get southern obc of the control vector and add it
 c       to dyn. fields
 c
 c     started: heimbach@mit.edu, 29-Aug-2001
-c
 c     new flags: gebbie@mit.edu, 25 Jan 2003.
 c
 c     ==================================================================
@@ -43,60 +39,48 @@ c#include "OBCS_PARAMS.h"
 #endif /* ALLOW_OBCSS_CONTROL */
 
 c     == routine arguments ==
-      _RL     mytime
-      integer myiter
-      integer mythid
+      _RL     myTime
+      integer myIter
+      integer myThid
 
 #ifdef ALLOW_OBCSS_CONTROL
-c     == local variables ==
+c     == external functions ==
+      integer  ilnblnk
+      external ilnblnk
 
+c     == local variables ==
       integer bi,bj
       integer i,j,k
       integer itlo,ithi
       integer jtlo,jthi
-      integer jmin,jmax
       integer imin,imax
       integer ilobcss
       integer iobcs
-
-      _RL     dummy
       _RL     obcssfac
       logical obcssfirst
       logical obcsschanged
       integer obcsscount0
       integer obcsscount1
       integer jp1
-
-cgg      _RL maskxz   (1-olx:snx+olx,nr,nsx,nsy)
-      _RL tmpfldxz (1-olx:snx+olx,nr,nsx,nsy)
-
+cgg      _RL maskxz   (1-OLx:sNx+OLx,Nr,nSx,nSy)
+      _RL tmpfldxz (1-OLx:sNx+OLx,Nr,nSx,nSy)
       logical doglobalread
       logical ladinit
-
       character*(80) fnameobcss
-
 #ifdef ALLOW_OBCS_CONTROL_MODES
       integer nk,nz
-      _RL     tmpz (nr,nsx,nsy)
+      _RL     tmpz (Nr,nSx,nSy)
       _RL     stmp
 #endif
 
-c     == external functions ==
-
-      integer  ilnblnk
-      external ilnblnk
-
-
 c     == end of interface ==
 
-      jtlo = mybylo(mythid)
-      jthi = mybyhi(mythid)
-      itlo = mybxlo(mythid)
-      ithi = mybxhi(mythid)
-      jmin = 1-oly
-      jmax = sny+oly
-      imin = 1-olx
-      imax = snx+olx
+      jtlo = myByLo(myThid)
+      jthi = myByHi(myThid)
+      itlo = myBxLo(myThid)
+      ithi = myBxHi(myThid)
+      imin = 1-OLx
+      imax = sNx+OLx
       jp1  = 1
 
 c--   Now, read the control vector.
@@ -114,9 +98,10 @@ c--   Get the counters, flags, and the interpolation factor.
      I                   xx_obcssstartdate, xx_obcssperiod,
      O                   obcssfac, obcssfirst, obcsschanged,
      O                   obcsscount0,obcsscount1,
-     I                   mytime, myiter, mythid )
+     I                   myTime, myIter, myThid )
 
       do iobcs = 1,nobcs
+
        if ( obcssfirst ) then
         call active_read_xz( fnameobcss, tmpfldxz,
      &                       (obcsscount0-1)*nobcs+iobcs,
@@ -164,7 +149,7 @@ cih    Compute absolute velocities from the barotropic-baroclinic modes.
            enddo
           endif
 #endif
-          do k = 1,nr
+          do k = 1,Nr
            do i = imin,imax
             xx_obcss1(i,k,bi,bj,iobcs)  = tmpfldxz (i,k,bi,bj)
 cgg   &                                        *   maskxz (i,k,bi,bj)
@@ -178,7 +163,7 @@ cgg   &                                        *   maskxz (i,k,bi,bj)
 
         do bj = jtlo,jthi
          do bi = itlo,ithi
-          do k = 1,nr
+          do k = 1,Nr
            do i = imin,imax
             xx_obcss0(i,k,bi,bj,iobcs) = xx_obcss1(i,k,bi,bj,iobcs)
             tmpfldxz (i,k,bi,bj)       = 0. _d 0
@@ -233,7 +218,7 @@ cih    Compute absolute velocities from the barotropic-baroclinic modes.
            enddo
           endif
 #endif
-          do k = 1,nr
+          do k = 1,Nr
            do i = imin,imax
             xx_obcss1 (i,k,bi,bj,iobcs) = tmpfldxz (i,k,bi,bj)
 cgg   &                                    *   maskxz (i,k,bi,bj)
@@ -247,9 +232,9 @@ c--   Add control to model variable.
        do bj = jtlo,jthi
         do bi = itlo,ithi
 c--   Calculate mask for tracer cells (0 => land, 1 => water).
-         do k = 1,nr
-          do i = 1,snx
-           j = OB_Js(I,bi,bj)
+         do k = 1,Nr
+          do i = 1,sNx
+           j = OB_Js(i,bi,bj)
            IF ( j.EQ.OB_indexNone ) j = 1
            if (iobcs .EQ. 1) then
             OBSt(i,k,bi,bj) = OBSt (i,k,bi,bj)

--- a/pkg/ctrl/ctrl_getobcsw.F
+++ b/pkg/ctrl/ctrl_getobcsw.F
@@ -4,10 +4,7 @@
 #endif
 
       subroutine ctrl_getobcsw(
-     I                             mytime,
-     I                             myiter,
-     I                             mythid
-     &                           )
+     I                          myTime, myIter, myThid )
 
 c     ==================================================================
 c     SUBROUTINE ctrl_getobcsw
@@ -17,8 +14,8 @@ c     o Get western obc of the control vector and add it
 c       to dyn. fields
 c
 c     started: heimbach@mit.edu, 29-Aug-2001
-c
 c     modified: gebbie@mit.edu, 18-Mar-2003
+c
 c     ==================================================================
 c     SUBROUTINE ctrl_getobcsw
 c     ==================================================================
@@ -42,60 +39,48 @@ c#include "OBCS_PARAMS.h"
 #endif /* ALLOW_OBCSW_CONTROL */
 
 c     == routine arguments ==
-      _RL     mytime
-      integer myiter
-      integer mythid
+      _RL     myTime
+      integer myIter
+      integer myThid
 
 #ifdef ALLOW_OBCSW_CONTROL
-c     == local variables ==
+c     == external functions ==
+      integer  ilnblnk
+      external ilnblnk
 
+c     == local variables ==
       integer bi,bj
       integer i,j,k
       integer itlo,ithi
       integer jtlo,jthi
       integer jmin,jmax
-      integer imin,imax
       integer ilobcsw
       integer iobcs
       integer ip1
-
-      _RL     dummy
       _RL     obcswfac
       logical obcswfirst
       logical obcswchanged
       integer obcswcount0
       integer obcswcount1
-
-cgg      _RL maskyz   (1-oly:sny+oly,nr,nsx,nsy)
-      _RL tmpfldyz (1-oly:sny+oly,nr,nsx,nsy)
-
+cgg      _RL maskyz   (1-OLy:sNy+OLy,Nr,nSx,nSy)
+      _RL tmpfldyz (1-OLy:sNy+OLy,Nr,nSx,nSy)
       logical doglobalread
       logical ladinit
-
       character*(80) fnameobcsw
-
 #ifdef ALLOW_OBCS_CONTROL_MODES
       integer nk,nz
-      _RL     tmpz (nr,nsx,nsy)
+      _RL     tmpz (Nr,nSx,nSy)
       _RL     stmp
 #endif
 
-c     == external functions ==
-
-      integer  ilnblnk
-      external ilnblnk
-
-
 c     == end of interface ==
 
-      jtlo = mybylo(mythid)
-      jthi = mybyhi(mythid)
-      itlo = mybxlo(mythid)
-      ithi = mybxhi(mythid)
-      jmin = 1-oly
-      jmax = sny+oly
-      imin = 1-olx
-      imax = snx+olx
+      jtlo = myByLo(myThid)
+      jthi = myByHi(myThid)
+      itlo = myBxLo(myThid)
+      ithi = myBxHi(myThid)
+      jmin = 1-OLy
+      jmax = sNy+OLy
       ip1  = 1
 
 c--   Now, read the control vector.
@@ -113,9 +98,10 @@ c--   Get the counters, flags, and the interpolation factor.
      I                   xx_obcswstartdate, xx_obcswperiod,
      O                   obcswfac, obcswfirst, obcswchanged,
      O                   obcswcount0,obcswcount1,
-     I                   mytime, myiter, mythid )
+     I                   myTime, myIter, myThid )
 
       do iobcs = 1,nobcs
+
        if ( obcswfirst ) then
         call active_read_yz( fnameobcsw, tmpfldyz,
      &                       (obcswcount0-1)*nobcs+iobcs,
@@ -163,7 +149,7 @@ cih    Compute absolute velocities from the barotropic-baroclinic modes.
            enddo
           endif
 #endif
-          do k = 1,nr
+          do k = 1,Nr
            do j = jmin,jmax
             xx_obcsw1(j,k,bi,bj,iobcs)  = tmpfldyz (j,k,bi,bj)
 cgg   &                                        *   maskyz (j,k,bi,bj)
@@ -177,7 +163,7 @@ cgg   &                                        *   maskyz (j,k,bi,bj)
 
         do bj = jtlo,jthi
          do bi = itlo,ithi
-          do k = 1,nr
+          do k = 1,Nr
            do j = jmin,jmax
             xx_obcsw0(j,k,bi,bj,iobcs) = xx_obcsw1(j,k,bi,bj,iobcs)
             tmpfldyz (j,k,bi,bj)       = 0. _d 0
@@ -232,7 +218,7 @@ cih    Compute absolute velocities from the barotropic-baroclinic modes.
            enddo
           endif
 #endif
-          do k = 1,nr
+          do k = 1,Nr
            do j = jmin,jmax
             xx_obcsw1 (j,k,bi,bj,iobcs) = tmpfldyz (j,k,bi,bj)
 cgg   &                                        *   maskyz (j,k,bi,bj)
@@ -246,8 +232,8 @@ c--   Add control to model variable.
        do bj = jtlo, jthi
         do bi = itlo, ithi
 c--   Calculate mask for tracer cells (0 => land, 1 => water).
-         do k = 1,nr
-          do j = 1,sny
+         do k = 1,Nr
+          do j = 1,sNy
            i = OB_Iw(j,bi,bj)
            IF ( i.EQ.OB_indexNone ) i = 1
            if (iobcs .EQ. 1) then

--- a/pkg/ctrl/ctrl_init.F
+++ b/pkg/ctrl/ctrl_init.F
@@ -50,11 +50,7 @@ c     == local variables ==
 
       integer bi,bj
       integer i,j,k
-
       integer ivar
-      integer startrec
-      integer endrec
-      integer diffrec
 
       _RL dummy
       _RL loctmp3d (1-olx:snx+olx,1-oly:sny+oly,Nr,nsx,nsy)
@@ -74,12 +70,16 @@ c     == local variables ==
 #ifdef ALLOW_GENTIM2D_CONTROL
       CHARACTER*(MAX_LEN_FNAM) fnamegen
       INTEGER ilgen, k2, diffrecFull, endrecFull
+      INTEGER diffrec, startrec, endrec
+#elif ( defined ALLOW_OBCS_CONTROL || defined ECCO_CTRL_DEPRECATED )
+      INTEGER diffrec, startrec, endrec
 #endif
 
 c     == external ==
-
+#ifdef ALLOW_GENTIM2D_CONTROL
       integer  ilnblnk
       external ilnblnk
+#endif
 
 c     == end of interface ==
 
@@ -745,7 +745,6 @@ CML     I     myThid )
      &     xx_sihsnow_file, 43, 143, diffrec, startrec, endrec,
      &     snx, sny, 1, 'c', 'xy', myThid )
 #endif /* ALLOW_sihsnow_CONTROL */
-
 
 c----------------------------------------------------------------------
 c--

--- a/pkg/ctrl/ctrl_init_obcs_variables.F
+++ b/pkg/ctrl/ctrl_init_obcs_variables.F
@@ -1,6 +1,6 @@
 #include "CTRL_OPTIONS.h"
 
-      subroutine ctrl_init_obcs_variables( mythid )
+      subroutine ctrl_init_obcs_variables( myThid )
 
 c     ==================================================================
 c     SUBROUTINE ctrl_init_obcs_variables
@@ -23,44 +23,26 @@ c     == global variables ==
 #include "SIZE.h"
 #include "PARAMS.h"
 c#include "GRID.h"
-
 #include "ctrl.h"
 #include "CTRL_OBCS.h"
 
 c     == routine arguments ==
-
-      integer mythid
+      integer myThid
 
 #ifdef ALLOW_OBCS
 c     == local variables ==
-
       integer bi,bj
       integer i,j,k
-      integer itlo,ithi
-      integer jtlo,jthi
-      integer jmin,jmax
-      integer imin,imax
-      integer ntmp
-      integer ivarindex
       integer iobcs
 
 c     == end of interface ==
 
-      jtlo = mybylo(mythid)
-      jthi = mybyhi(mythid)
-      itlo = mybxlo(mythid)
-      ithi = mybxhi(mythid)
-      jmin = 1-oly
-      jmax = sny+oly
-      imin = 1-olx
-      imax = snx+olx
-
 #ifdef ALLOW_OBCSN_CONTROL
       do iobcs = 1, nobcs
-        do bj = jtlo,jthi
-          do bi = itlo,ithi
-            do k = 1,nr
-              do i = imin,imax
+        do bj = myByLo(myThid), myByHi(myThid)
+          do bi = myBxLo(myThid), myBxHi(myThid)
+            do k = 1,Nr
+              do i = 1-OLx, sNx+OLx 
                 xx_obcsn0(i,k,bi,bj,iobcs) = 0. _d 0
                 xx_obcsn1(i,k,bi,bj,iobcs) = 0. _d 0
               enddo
@@ -72,10 +54,10 @@ c     == end of interface ==
 
 #ifdef ALLOW_OBCSS_CONTROL
       do iobcs = 1, nobcs
-        do bj = jtlo,jthi
-          do bi = itlo,ithi
-            do k = 1,nr
-              do i = imin,imax
+        do bj = myByLo(myThid), myByHi(myThid)
+          do bi = myBxLo(myThid), myBxHi(myThid)
+            do k = 1,Nr
+              do i = 1-OLx, sNx+OLx 
                 xx_obcss0(i,k,bi,bj,iobcs) = 0. _d 0
                 xx_obcss1(i,k,bi,bj,iobcs) = 0. _d 0
               enddo
@@ -87,10 +69,10 @@ c     == end of interface ==
 
 #ifdef ALLOW_OBCSW_CONTROL
       do iobcs = 1, nobcs
-        do bj = jtlo,jthi
-          do bi = itlo,ithi
-            do k = 1,nr
-              do j = jmin,jmax
+        do bj = myByLo(myThid), myByHi(myThid)
+          do bi = myBxLo(myThid), myBxHi(myThid)
+            do k = 1,Nr
+              do j = 1-OLy, sNy+OLy 
                 xx_obcsw0(j,k,bi,bj,iobcs) = 0. _d 0
                 xx_obcsw1(j,k,bi,bj,iobcs) = 0. _d 0
               enddo
@@ -102,10 +84,10 @@ c     == end of interface ==
 
 #ifdef ALLOW_OBCSE_CONTROL
       do iobcs = 1, nobcs
-        do bj = jtlo,jthi
-          do bi = itlo,ithi
-            do k = 1,nr
-              do j = jmin,jmax
+        do bj = myByLo(myThid), myByHi(myThid)
+          do bi = myBxLo(myThid), myBxHi(myThid)
+            do k = 1,Nr
+              do j = 1-OLy, sNy+OLy 
                 xx_obcse0(j,k,bi,bj,iobcs) = 0. _d 0
                 xx_obcse1(j,k,bi,bj,iobcs) = 0. _d 0
               enddo

--- a/pkg/ctrl/ctrl_map_forcing.F
+++ b/pkg/ctrl/ctrl_map_forcing.F
@@ -42,17 +42,25 @@ C     myThid :: thread number for this instance of the routine.
       INTEGER myIter
       INTEGER myThid
 
+C     !FUNCTIONS:
+#ifdef ECCO_CTRL_DEPRECATED
+      INTEGER  ilnblnk
+      EXTERNAL ilnblnk
+#endif
+
 C     !LOCAL VARIABLES:
 C     == Local variables ==
-      integer bi,bj
-      integer i,j
+#if ( defined ALLOW_GENTIM2D_CONTROL || defined ECCO_CTRL_DEPRECATED )
+      INTEGER bi,bj
+      INTEGER i,j
+#endif
 #ifndef ALLOW_OPENAD
 #ifdef ALLOW_GENTIM2D_CONTROL
-      integer iarr
-      _RL     tmpUE(1-olx:snx+olx,1-oly:sny+oly,nsx,nsy)
-      _RL     tmpVN(1-olx:snx+olx,1-oly:sny+oly,nsx,nsy)
-      _RL     tmpUX(1-olx:snx+olx,1-oly:sny+oly,nsx,nsy)
-      _RL     tmpVY(1-olx:snx+olx,1-oly:sny+oly,nsx,nsy)
+      INTEGER iarr
+      _RL     tmpUE(1-OLx:sNx+OLx,1-OLy:sNy+OLy,nSx,nSy)
+      _RL     tmpVN(1-OLx:sNx+OLx,1-OLy:sNy+OLy,nSx,nSy)
+      _RL     tmpUX(1-OLx:sNx+OLx,1-OLy:sNy+OLy,nSx,nSy)
+      _RL     tmpVY(1-OLx:sNx+OLx,1-OLy:sNy+OLy,nSx,nSy)
 #endif
 #endif
 
@@ -61,28 +69,22 @@ C     == Local variables ==
     (defined ALLOW_SFLUX0_CONTROL) || (defined ALLOW_HFLUX0_CONTROL) ||\
     (defined ALLOW_SSS_CONTROL) || (defined ALLOW_SST_CONTROL) ||\
     (defined ALLOW_HFLUXM_CONTROL)
-      integer itlo,ithi
-      integer jtlo,jthi
-      integer jmin,jmax
-      integer imin,imax
-      integer il
-      logical doglobalread
-      logical ladinit
-      _RL     tmpfld2d(1-olx:snx+olx,1-oly:sny+oly,nsx,nsy)
+      INTEGER jmin,jmax
+      INTEGER imin,imax
+      INTEGER il
+      LOGICAL doglobalread
+      LOGICAL ladinit
+      _RL     tmpfld2d(1-OLx:sNx+OLx,1-OLy:sNy+OLy,nSx,nSy)
 
-      character*( 80)   fnametauu
-      character*( 80)   fnametauv
-      character*( 80)   fnamesflux
-      character*( 80)   fnamehflux
-      character*( 80)   fnamesss
-      character*( 80)   fnamesst
+      CHARACTER*(80)   fnametauu
+      CHARACTER*(80)   fnametauv
+      CHARACTER*(80)   fnamesflux
+      CHARACTER*(80)   fnamehflux
+      CHARACTER*(80)   fnamesss
+      CHARACTER*(80)   fnamesst
 cHFLUXM_CONTROL
-      character*( 80)   fnamehfluxm
+      CHARACTER*(80)   fnamehfluxm
 cHFLUXM_CONTROL
-
-c     == external ==
-      integer  ilnblnk
-      external ilnblnk
 #endif
 #endif /* ECCO_CTRL_DEPRECATED */
 
@@ -95,191 +97,186 @@ CEOP
     (defined ALLOW_SSS_CONTROL) || (defined ALLOW_SST_CONTROL) ||\
     (defined ALLOW_HFLUXM_CONTROL)
 
-      jtlo = mybylo(mythid)
-      jthi = mybyhi(mythid)
-      itlo = mybxlo(mythid)
-      ithi = mybxhi(mythid)
       jmin = 1
-      jmax = sny
+      jmax = sNy
       imin = 1
-      imax = snx
-
+      imax = sNx
       doglobalread = .false.
       ladinit      = .false.
 
-      do bj = jtlo,jthi
-        do bi = itlo,ithi
-          do j = 1-oly,sny+oly
-            do i = 1-olx,snx+olx
+      DO bj = myByLo(myThid),myByHi(myThid)
+        DO bi = myBxLo(myThid),myBxHi(myThid)
+          DO j = 1-OLy,sNy+OLy
+            DO i = 1-OLx,sNx+OLx
               tmpfld2d(i,j,bi,bj) = 0. _d 0
-            enddo
-          enddo
-        enddo
-      enddo
+            ENDDO
+          ENDDO
+        ENDDO
+      ENDDO
 
       IF ( myIter .EQ. nIter0 ) THEN
 
 #ifdef ALLOW_TAUU0_CONTROL
 c--   tauu0.
-      il=ilnblnk( xx_tauu_file )
-      write(fnametauu(1:80),'(2a,i10.10)')
-     &     xx_tauu_file(1:il),'.',optimcycle
-      call active_read_xy ( fnametauu, tmpfld2d, 1,
-     &                      doglobalread, ladinit, optimcycle,
-     &                      mythid, xx_tauu_dummy )
-      do bj = jtlo,jthi
-        do bi = itlo,ithi
-          do j = jmin,jmax
-            do i = imin,imax
+       il=ilnblnk( xx_tauu_file )
+       WRITE(fnametauu(1:80),'(2A,I10.10)')
+     &      xx_tauu_file(1:il),'.',optimcycle
+       CALL active_read_xy ( fnametauu, tmpfld2d, 1,
+     &                       doglobalread, ladinit, optimcycle,
+     &                       myThid, xx_tauu_dummy )
+       DO bj = myByLo(myThid),myByHi(myThid)
+         DO bi = myBxLo(myThid),myBxHi(myThid)
+           DO j = jmin,jmax
+             DO i = imin,imax
 # ifdef ALLOW_OPENAD
-              fu(i,j,bi,bj) = fu(i,j,bi,bj) +
-     &                        xx_tauu0(i,j,bi,bj) +
-     &                        tmpfld2d(i,j,bi,bj)
+               fu(i,j,bi,bj) = fu(i,j,bi,bj) +
+     &                         xx_tauu0(i,j,bi,bj) +
+     &                         tmpfld2d(i,j,bi,bj)
 #else
-              fu(i,j,bi,bj) = fu(i,j,bi,bj) + tmpfld2d(i,j,bi,bj)
+               fu(i,j,bi,bj) = fu(i,j,bi,bj) + tmpfld2d(i,j,bi,bj)
 #endif
-            enddo
-          enddo
-        enddo
-      enddo
+             ENDDO
+           ENDDO
+         ENDDO
+       ENDDO
 #endif
 
 #ifdef ALLOW_TAUV0_CONTROL
 c--   tauv0.
-      il=ilnblnk( xx_tauv_file )
-      write(fnametauv(1:80),'(2a,i10.10)')
-     &     xx_tauv_file(1:il),'.',optimcycle
-      call active_read_xy ( fnametauv, tmpfld2d, 1,
-     &                      doglobalread, ladinit, optimcycle,
-     &                      mythid, xx_tauv_dummy )
-      do bj = jtlo,jthi
-        do bi = itlo,ithi
-          do j = jmin,jmax
-            do i = imin,imax
+       il=ilnblnk( xx_tauv_file )
+       WRITE(fnametauv(1:80),'(2A,I10.10)')
+     &      xx_tauv_file(1:il),'.',optimcycle
+       CALL active_read_xy ( fnametauv, tmpfld2d, 1,
+     &                       doglobalread, ladinit, optimcycle,
+     &                       myThid, xx_tauv_dummy )
+       DO bj = myByLo(myThid),myByHi(myThid)
+         DO bi = myBxLo(myThid),myBxHi(myThid)
+           DO j = jmin,jmax
+             DO i = imin,imax
 # ifdef ALLOW_OPENAD
-              fv(i,j,bi,bj) = fv(i,j,bi,bj) +
-     &                        xx_tauv0(i,j,bi,bj) +
-     &                        tmpfld2d(i,j,bi,bj)
+               fv(i,j,bi,bj) = fv(i,j,bi,bj) +
+     &                         xx_tauv0(i,j,bi,bj) +
+     &                         tmpfld2d(i,j,bi,bj)
 #else
-              fv(i,j,bi,bj) = fv(i,j,bi,bj) + tmpfld2d(i,j,bi,bj)
+               fv(i,j,bi,bj) = fv(i,j,bi,bj) + tmpfld2d(i,j,bi,bj)
 #endif
-            enddo
-          enddo
-        enddo
-      enddo
+             ENDDO
+           ENDDO
+         ENDDO
+       ENDDO
 #endif
 
 #ifdef ALLOW_SFLUX0_CONTROL
 c--   sflux0.
-      il=ilnblnk( xx_sflux_file )
-      write(fnamesflux(1:80),'(2a,i10.10)')
-     &     xx_sflux_file(1:il),'.',optimcycle
-      call active_read_xy ( fnamesflux, tmpfld2d, 1,
-     &                      doglobalread, ladinit, optimcycle,
-     &                      mythid, xx_sflux_dummy )
-      do bj = jtlo,jthi
-        do bi = itlo,ithi
-          do j = jmin,jmax
-            do i = imin,imax
+       il=ilnblnk( xx_sflux_file )
+       WRITE(fnamesflux(1:80),'(2A,I10.10)')
+     &      xx_sflux_file(1:il),'.',optimcycle
+       CALL active_read_xy ( fnamesflux, tmpfld2d, 1,
+     &                       doglobalread, ladinit, optimcycle,
+     &                       myThid, xx_sflux_dummy )
+       DO bj = myByLo(myThid),myByHi(myThid)
+         DO bi = myBxLo(myThid),myBxHi(myThid)
+           DO j = jmin,jmax
+             DO i = imin,imax
 # ifdef ALLOW_OPENAD
-              empmr(i,j,bi,bj) = empmr(i,j,bi,bj) +
-     &                           xx_sflux0(i,j,bi,bj) +
-     &                           tmpfld2d(i,j,bi,bj)
+               empmr(i,j,bi,bj) = empmr(i,j,bi,bj) +
+     &                            xx_sflux0(i,j,bi,bj) +
+     &                            tmpfld2d(i,j,bi,bj)
 #else
-              empmr(i,j,bi,bj) = empmr(i,j,bi,bj) + tmpfld2d(i,j,bi,bj)
+               empmr(i,j,bi,bj) = empmr(i,j,bi,bj) + tmpfld2d(i,j,bi,bj)
 #endif
-            enddo
-          enddo
-        enddo
-      enddo
+             ENDDO
+           ENDDO
+         ENDDO
+       ENDDO
 #endif
 
 #ifdef ALLOW_HFLUX0_CONTROL
 c--   hflux0.
-      il=ilnblnk( xx_hflux_file )
-      write(fnamehflux(1:80),'(2a,i10.10)')
-     &     xx_hflux_file(1:il),'.',optimcycle
-      call active_read_xy ( fnamehflux, tmpfld2d, 1,
-     &                      doglobalread, ladinit, optimcycle,
-     &                      mythid, xx_hflux_dummy )
-      do bj = jtlo,jthi
-        do bi = itlo,ithi
-          do j = jmin,jmax
-            do i = imin,imax
+       il=ilnblnk( xx_hflux_file )
+       WRITE(fnamehflux(1:80),'(2A,I10.10)')
+     &      xx_hflux_file(1:il),'.',optimcycle
+       CALL active_read_xy ( fnamehflux, tmpfld2d, 1,
+     &                       doglobalread, ladinit, optimcycle,
+     &                       myThid, xx_hflux_dummy )
+       DO bj = myByLo(myThid),myByHi(myThid)
+         DO bi = myBxLo(myThid),myBxHi(myThid)
+           DO j = jmin,jmax
+             DO i = imin,imax
 # ifdef ALLOW_OPENAD
-              qnet(i,j,bi,bj) = qnet(i,j,bi,bj) +
-     &                          xx_hflux0(i,j,bi,bj) +
-     &                          tmpfld2d(i,j,bi,bj)
+               qnet(i,j,bi,bj) = qnet(i,j,bi,bj) +
+     &                           xx_hflux0(i,j,bi,bj) +
+     &                           tmpfld2d(i,j,bi,bj)
 #else
-              qnet(i,j,bi,bj) = qnet(i,j,bi,bj) + tmpfld2d(i,j,bi,bj)
+               qnet(i,j,bi,bj) = qnet(i,j,bi,bj) + tmpfld2d(i,j,bi,bj)
 #endif
-            enddo
-          enddo
-        enddo
-      enddo
+             ENDDO
+           ENDDO
+         ENDDO
+       ENDDO
 #endif
 
 #ifdef ALLOW_SSS_CONTROL
 c--   sss0.
-      il=ilnblnk( xx_sss_file )
-      write(fnamesss(1:80),'(2a,i10.10)')
-     &     xx_sss_file(1:il),'.',optimcycle
-      call active_read_xy ( fnamesss, tmpfld2d, 1,
-     &                      doglobalread, ladinit, optimcycle,
-     &                      mythid, xx_sss_dummy )
-      do bj = jtlo,jthi
-        do bi = itlo,ithi
-          do j = jmin,jmax
-            do i = imin,imax
-              sss(i,j,bi,bj) = sss(i,j,bi,bj) + tmpfld2d(i,j,bi,bj)
-            enddo
-          enddo
-        enddo
-      enddo
+       il=ilnblnk( xx_sss_file )
+       WRITE(fnamesss(1:80),'(2A,I10.10)')
+     &      xx_sss_file(1:il),'.',optimcycle
+       CALL active_read_xy ( fnamesss, tmpfld2d, 1,
+     &                       doglobalread, ladinit, optimcycle,
+     &                       myThid, xx_sss_dummy )
+       DO bj = myByLo(myThid),myByHi(myThid)
+         DO bi = myBxLo(myThid),myBxHi(myThid)
+           DO j = jmin,jmax
+             DO i = imin,imax
+               sss(i,j,bi,bj) = sss(i,j,bi,bj) + tmpfld2d(i,j,bi,bj)
+             ENDDO
+           ENDDO
+         ENDDO
+       ENDDO
 #endif
 
 #ifdef ALLOW_SST_CONTROL
 c--   sst0.
-      il=ilnblnk( xx_sst_file )
-      write(fnamesst(1:80),'(2a,i10.10)')
-     &     xx_sst_file(1:il),'.',optimcycle
-      call active_read_xy ( fnamesst, tmpfld2d, 1,
-     &                      doglobalread, ladinit, optimcycle,
-     &                      mythid, xx_sst_dummy )
-      do bj = jtlo,jthi
-        do bi = itlo,ithi
-          do j = jmin,jmax
-            do i = imin,imax
-              sst(i,j,bi,bj) = sst(i,j,bi,bj) + tmpfld2d(i,j,bi,bj)
-            enddo
-          enddo
-        enddo
-      enddo
+       il=ilnblnk( xx_sst_file )
+       WRITE(fnamesst(1:80),'(2A,I10.10)')
+     &      xx_sst_file(1:il),'.',optimcycle
+       CALL active_read_xy ( fnamesst, tmpfld2d, 1,
+     &                       doglobalread, ladinit, optimcycle,
+     &                       myThid, xx_sst_dummy )
+       DO bj = myByLo(myThid),myByHi(myThid)
+         DO bi = myBxLo(myThid),myBxHi(myThid)
+           DO j = jmin,jmax
+             DO i = imin,imax
+               sst(i,j,bi,bj) = sst(i,j,bi,bj) + tmpfld2d(i,j,bi,bj)
+             ENDDO
+           ENDDO
+         ENDDO
+       ENDDO
 #endif
 
 #ifdef ALLOW_HFLUXM_CONTROL
 c--   hfluxm.
-      il=ilnblnk( xx_hfluxm_file )
-      write(fnamehfluxm(1:80),'(2a,i10.10)')
-     &     xx_hfluxm_file(1:il),'.',optimcycle
-      call active_read_xy ( fnamehfluxm, tmpfld2d, 1,
-     &                      doglobalread, ladinit, optimcycle,
-     &                      mythid, xx_hfluxm_dummy )
-      do bj = jtlo,jthi
-        do bi = itlo,ithi
-          do j = jmin,jmax
-            do i = imin,imax
+       il=ilnblnk( xx_hfluxm_file )
+       WRITE(fnamehfluxm(1:80),'(2A,I10.10)')
+     &      xx_hfluxm_file(1:il),'.',optimcycle
+       CALL active_read_xy ( fnamehfluxm, tmpfld2d, 1,
+     &                       doglobalread, ladinit, optimcycle,
+     &                       myThid, xx_hfluxm_dummy )
+       DO bj = myByLo(myThid),myByHi(myThid)
+         DO bi = myBxLo(myThid),myBxHi(myThid)
+           DO j = jmin,jmax
+             DO i = imin,imax
 # ifdef ALLOW_OPENAD
-              Qnetm(i,j,bi,bj) = Qnetm(i,j,bi,bj) +
-     &                          xx_hfluxm(i,j,bi,bj) +
-     &                          tmpfld2d(i,j,bi,bj)
+               Qnetm(i,j,bi,bj) = Qnetm(i,j,bi,bj) +
+     &                           xx_hfluxm(i,j,bi,bj) +
+     &                           tmpfld2d(i,j,bi,bj)
 #else
-              Qnetm(i,j,bi,bj) = Qnetm(i,j,bi,bj) + tmpfld2d(i,j,bi,bj)
+               Qnetm(i,j,bi,bj) = Qnetm(i,j,bi,bj) + tmpfld2d(i,j,bi,bj)
 #endif
-            enddo
-          enddo
-        enddo
-      enddo
+             ENDDO
+           ENDDO
+         ENDDO
+       ENDDO
 #endif
 
 #if (defined (ALLOW_TAUU0_CONTROL) || defined (ALLOW_TAUV0_CONTROL))
@@ -310,80 +307,80 @@ c--   hfluxm.
 #ifdef ALLOW_GENTIM2D_CONTROL
       IF ( ctrlUseGen ) THEN
 
-      do bj = mybylo(mythid),mybyhi(mythid)
-       do bi = mybxlo(mythid),mybxhi(mythid)
-        do j = 1-oly,sny+oly
-         do i = 1-olx,snx+olx
-           tmpUE(i,j,bi,bj) = 0. _d 0
-           tmpVN(i,j,bi,bj) = 0. _d 0
-           tmpUX(i,j,bi,bj) = 0. _d 0
-           tmpVY(i,j,bi,bj) = 0. _d 0
-         enddo
-        enddo
-       enddo
-      enddo
-
-      DO bj = myByLo(myThid),myByHi(myThid)
-       DO bi = myBxLo(myThid),mybxhi(myThid)
-        DO j = 1,sNy
-         DO i = 1,sNx
-          DO iarr = 1, maxCtrlTim2D
-           if (xx_gentim2d_file(iarr)(1:5).EQ.'xx_fe') tmpUE
-     &      (i,j,bi,bj)=tmpUE(i,j,bi,bj)+xx_gentim2d(i,j,bi,bj,iarr)
-           if (xx_gentim2d_file(iarr)(1:5).EQ.'xx_fn') tmpVN
-     &       (i,j,bi,bj)=tmpVN(i,j,bi,bj)+xx_gentim2d(i,j,bi,bj,iarr)
+       DO bj = myByLo(myThid),myByHi(myThid)
+        DO bi = myBxLo(myThid),myBxHi(myThid)
+         DO j = 1-OLy,sNy+OLy
+          DO i = 1-OLx,sNx+OLx
+            tmpUE(i,j,bi,bj) = 0. _d 0
+            tmpVN(i,j,bi,bj) = 0. _d 0
+            tmpUX(i,j,bi,bj) = 0. _d 0
+            tmpVY(i,j,bi,bj) = 0. _d 0
           ENDDO
          ENDDO
         ENDDO
        ENDDO
-      ENDDO
 
-      _EXCH_XY_RL(tmpUE,myThid)
-      _EXCH_XY_RL(tmpVN,myThid)
-      CALL rotate_uv2en_rl(tmpUX,tmpVY,tmpUE,tmpVN,
-     &     .FALSE.,.TRUE.,.TRUE.,1,mythid)
-
-      DO bj = myByLo(myThid),myByHi(myThid)
-       DO bi = myBxLo(myThid),mybxhi(myThid)
-        DO j = 1,sny
-         DO i = 1,snx
-          fu(i,j,bi,bj)=fu(i,j,bi,bj)+tmpUX(i,j,bi,bj)
-          fv(i,j,bi,bj)=fv(i,j,bi,bj)+tmpVY(i,j,bi,bj)
-          DO iarr = 1, maxCtrlTim2D
-           if (xx_gentim2d_file(iarr)(1:7).EQ.'xx_qnet') Qnet
-     &      (i,j,bi,bj)=Qnet(i,j,bi,bj)+xx_gentim2d(i,j,bi,bj,iarr)
-           if (xx_gentim2d_file(iarr)(1:8).EQ.'xx_empmr') EmPmR
-     &      (i,j,bi,bj)=EmPmR(i,j,bi,bj)+xx_gentim2d(i,j,bi,bj,iarr)
-           if (xx_gentim2d_file(iarr)(1:6).EQ.'xx_qsw') Qsw
-     &      (i,j,bi,bj)=Qsw(i,j,bi,bj)+xx_gentim2d(i,j,bi,bj,iarr)
-           if (xx_gentim2d_file(iarr)(1:6).EQ.'xx_sst') SST
-     &      (i,j,bi,bj)=SST(i,j,bi,bj)+xx_gentim2d(i,j,bi,bj,iarr)
-           if (xx_gentim2d_file(iarr)(1:6).EQ.'xx_sss') SSS
-     &      (i,j,bi,bj)=SSS(i,j,bi,bj)+xx_gentim2d(i,j,bi,bj,iarr)
-           if (xx_gentim2d_file(iarr)(1:8).EQ.'xx_pload') pLoad
-     &      (i,j,bi,bj)=pLoad(i,j,bi,bj)+xx_gentim2d(i,j,bi,bj,iarr)
-           if (xx_gentim2d_file(iarr)(1:11).EQ.'xx_saltflux') saltFlux
-     &      (i,j,bi,bj)=saltFlux(i,j,bi,bj)+xx_gentim2d(i,j,bi,bj,iarr)
-           if (xx_gentim2d_file(iarr)(1:5).EQ.'xx_fu') fu
-     &      (i,j,bi,bj)=fu(i,j,bi,bj)+xx_gentim2d(i,j,bi,bj,iarr)
-           if (xx_gentim2d_file(iarr)(1:5).EQ.'xx_fv') fv
-     &      (i,j,bi,bj)=fv(i,j,bi,bj)+xx_gentim2d(i,j,bi,bj,iarr)
+       DO bj = myByLo(myThid),myByHi(myThid)
+        DO bi = myBxLo(myThid),myBxHi(myThid)
+         DO j = 1,sNy
+          DO i = 1,sNx
+           DO iarr = 1, maxCtrlTim2D
+            IF (xx_gentim2d_file(iarr)(1:5).EQ.'xx_fe') tmpUE
+     &       (i,j,bi,bj)=tmpUE(i,j,bi,bj)+xx_gentim2d(i,j,bi,bj,iarr)
+            IF (xx_gentim2d_file(iarr)(1:5).EQ.'xx_fn') tmpVN
+     &        (i,j,bi,bj)=tmpVN(i,j,bi,bj)+xx_gentim2d(i,j,bi,bj,iarr)
+           ENDDO
           ENDDO
          ENDDO
         ENDDO
        ENDDO
-      ENDDO
 
-      CALL EXCH_XY_RS( Qnet , myThid )
-      CALL EXCH_XY_RS( EmPmR , myThid )
-      CALL EXCH_XY_RS( Qsw , myThid )
-      CALL EXCH_XY_RS( SST , myThid )
-      CALL EXCH_XY_RS( SSS , myThid )
-      CALL EXCH_XY_RS( pLoad , myThid )
-      CALL EXCH_XY_RS( saltFlux , myThid )
-      CALL EXCH_UV_XY_RS( fu, fv, .TRUE., myThid )
+       _EXCH_XY_RL(tmpUE,myThid)
+       _EXCH_XY_RL(tmpVN,myThid)
+       CALL rotate_uv2en_rl(tmpUX,tmpVY,tmpUE,tmpVN,
+     &      .FALSE.,.TRUE.,.TRUE.,1,myThid)
 
-      ENDIF !IF (ctrlUseGen) then
+       DO bj = myByLo(myThid),myByHi(myThid)
+        DO bi = myBxLo(myThid),myBxHi(myThid)
+         DO j = 1,sNy
+          DO i = 1,sNx
+           fu(i,j,bi,bj)=fu(i,j,bi,bj)+tmpUX(i,j,bi,bj)
+           fv(i,j,bi,bj)=fv(i,j,bi,bj)+tmpVY(i,j,bi,bj)
+           DO iarr = 1, maxCtrlTim2D
+            IF (xx_gentim2d_file(iarr)(1:7).EQ.'xx_qnet') Qnet
+     &       (i,j,bi,bj)=Qnet(i,j,bi,bj)+xx_gentim2d(i,j,bi,bj,iarr)
+            IF (xx_gentim2d_file(iarr)(1:8).EQ.'xx_empmr') EmPmR
+     &       (i,j,bi,bj)=EmPmR(i,j,bi,bj)+xx_gentim2d(i,j,bi,bj,iarr)
+            IF (xx_gentim2d_file(iarr)(1:6).EQ.'xx_qsw') Qsw
+     &       (i,j,bi,bj)=Qsw(i,j,bi,bj)+xx_gentim2d(i,j,bi,bj,iarr)
+             IF (xx_gentim2d_file(iarr)(1:6).EQ.'xx_sst') SST
+     &       (i,j,bi,bj)=SST(i,j,bi,bj)+xx_gentim2d(i,j,bi,bj,iarr)
+            IF (xx_gentim2d_file(iarr)(1:6).EQ.'xx_sss') SSS
+     &       (i,j,bi,bj)=SSS(i,j,bi,bj)+xx_gentim2d(i,j,bi,bj,iarr)
+            IF (xx_gentim2d_file(iarr)(1:8).EQ.'xx_pload') pLoad
+     &       (i,j,bi,bj)=pLoad(i,j,bi,bj)+xx_gentim2d(i,j,bi,bj,iarr)
+            IF (xx_gentim2d_file(iarr)(1:11).EQ.'xx_saltflux') saltFlux
+     &       (i,j,bi,bj)=saltFlux(i,j,bi,bj)+xx_gentim2d(i,j,bi,bj,iarr)
+            IF (xx_gentim2d_file(iarr)(1:5).EQ.'xx_fu') fu
+     &       (i,j,bi,bj)=fu(i,j,bi,bj)+xx_gentim2d(i,j,bi,bj,iarr)
+            IF (xx_gentim2d_file(iarr)(1:5).EQ.'xx_fv') fv
+     &       (i,j,bi,bj)=fv(i,j,bi,bj)+xx_gentim2d(i,j,bi,bj,iarr)
+           ENDDO
+          ENDDO
+         ENDDO
+        ENDDO
+       ENDDO
+
+       CALL EXCH_XY_RS( Qnet , myThid )
+       CALL EXCH_XY_RS( EmPmR , myThid )
+       CALL EXCH_XY_RS( Qsw , myThid )
+       CALL EXCH_XY_RS( SST , myThid )
+       CALL EXCH_XY_RS( SSS , myThid )
+       CALL EXCH_XY_RS( pLoad , myThid )
+       CALL EXCH_XY_RS( saltFlux , myThid )
+       CALL EXCH_UV_XY_RS( fu, fv, .TRUE., myThid )
+
+      ENDIF !if (ctrlUseGen) then
 #endif /* ALLOW_GENTIM2D_CONTROL */
 #endif /* ndef ALLOW_OPENAD */
 

--- a/pkg/ctrl/ctrl_map_ini_genarr.F
+++ b/pkg/ctrl/ctrl_map_ini_genarr.F
@@ -67,8 +67,11 @@ C     == local variables ==
       INTEGER igen_etan,igen_bdrag,igen_geoth
 # ifdef ALLOW_SHELFICE
       INTEGER igen_shiCoeffT, igen_shiCoeffS, igen_shiCDrag
-      INTEGER i, j, bi, bj, k2
+      INTEGER i, j, bi, bj
+#  ifdef SHI_ALLOW_GAMMAFRICT
+      INTEGER k2
       LOGICAL dragThermoEqualMom
+#  endif
 # endif
 # if (defined ALLOW_DIC && defined DIC_BIOTIC)
       INTEGER igen_alpha
@@ -168,7 +171,7 @@ C--   xx_shiCoeffT not used, but shiCoeffS is adjusted by xx_shicoeffs
         ENDDO
        ENDDO
       ENDIF
-# else
+# else /* SHI_ALLOW_GAMMAFRICT */
       dragThermoEqualMom = .FALSE.
       IF (igen_shiCDrag.GT.0)
      &  CALL CTRL_MAP_GENARR2D(shiCDragFld,igen_shiCDrag,myThid)

--- a/pkg/ctrl/ctrl_map_ini_gentim2d.F
+++ b/pkg/ctrl/ctrl_map_ini_gentim2d.F
@@ -66,11 +66,10 @@ C     == local variables ==
       logical dowc01
       logical dosmooth
       logical doscaling
-      _RL     xx_gen(1-olx:snx+olx,1-oly:sny+oly,nsx,nsy)
-      _RS     mask2D(1-olx:snx+olx,1-oly:sny+oly,nsx,nsy)
-      _RS dummyRS(1)
+      _RL     xx_gen(1-OLx:sNx+OLx,1-OLy:sNy+OLy,nSx,nSy)
+      _RS     mask2D(1-OLx:sNx+OLx,1-OLy:sNy+OLy,nSx,nSy)
 #ifdef ALLOW_ECCO
-      _RL     xx_gen_tmp(1-olx:snx+olx,1-oly:sny+oly,nsx,nsy)
+      _RL     xx_gen_tmp(1-OLx:sNx+OLx,1-OLy:sNy+OLy,nSx,nSy)
       integer nyearsINT
       _RL     recip_nyearsRL
 #endif
@@ -177,13 +176,13 @@ CADJ STORE xx_gentim2d_dummy = dummytape, key = 1 , kind = isbyte
 #ifdef ALLOW_AUTODIFF
            CALL ACTIVE_READ_XY( fnamegenIn, xx_gen, irec,
      &          doglobalread, ladinit, optimcycle,
-     &          mythid, xx_gentim2d_dummy(iarr) )
+     &          myThid, xx_gentim2d_dummy(iarr) )
 #else
            CALL READ_REC_XY_RL( fnamegenIn, xx_gen, iRec, 1, myThid )
 #endif
 #ifdef ALLOW_AUTODIFF
            CALL ACTIVE_WRITE_XY( fnamegenOut, xx_gen, krec, optimcycle,
-     &          mythid, xx_gentim2d_dummy(iarr) )
+     &          myThid, xx_gentim2d_dummy(iarr) )
 #else
            CALL WRITE_REC_XY_RL( fnamegenOut, xx_gen, iRec, 1, myThid )
 #endif
@@ -240,7 +239,7 @@ CADJ STORE xx_gentim2d_dummy = dummytape, key = 1 , kind = isbyte
 #ifdef ALLOW_AUTODIFF
            call active_read_xy( fnamegenOut, xx_gen_tmp, krec,
      &          doglobalread, ladinit, optimcycle,
-     &          mythid, xx_gentim2d_dummy(iarr) )
+     &          myThid, xx_gentim2d_dummy(iarr) )
 #else
            CALL READ_REC_XY_RL( fnamegenOut, xx_gen_tmp, krec,
      &          1, myThid )
@@ -274,7 +273,7 @@ CADJ STORE xx_gentim2d_dummy = dummytape, key = 1 , kind = isbyte
 
 #ifdef ALLOW_AUTODIFF
           call active_write_xy( fnamegenTmp, xx_gen, iRec, optimcycle,
-     &         mythid, xx_gentim2d_dummy(iarr) )
+     &         myThid, xx_gentim2d_dummy(iarr) )
 #else
           CALL WRITE_REC_XY_RL( fnamegenTmp, xx_gen, iRec, 1, myThid )
 #endif
@@ -292,14 +291,14 @@ CADJ STORE xx_gentim2d_dummy = dummytape, key = 1 , kind = isbyte
 #ifdef ALLOW_AUTODIFF
             CALL active_read_xy( fnamegenOut, xx_gen, kRec,
      &           doglobalread, ladinit, optimcycle,
-     &           mythid, xx_gentim2d_dummy(iarr) )
+     &           myThid, xx_gentim2d_dummy(iarr) )
 #else
             CALL READ_REC_XY_RL( fnamegenOut, xx_gen, kRec, 1, myThid )
 #endif
 #ifdef ALLOW_AUTODIFF
             CALL active_read_xy( fnamegenTmp, xx_gen_tmp, iRec,
      &           doglobalread, ladinit, optimcycle,
-     &           mythid, xx_gentim2d_dummy(iarr) )
+     &           myThid, xx_gentim2d_dummy(iarr) )
 #else
             CALL READ_REC_XY_RL( fnamegenTmp, xx_gen_tmp, iRec, 1,
      &           myThid )
@@ -316,7 +315,7 @@ CADJ STORE xx_gentim2d_dummy = dummytape, key = 1 , kind = isbyte
             ENDDO
 #ifdef ALLOW_AUTODIFF
             CALL active_write_xy( fnamegenOut, xx_gen, kRec,
-     &           optimcycle, mythid, xx_gentim2d_dummy(iarr) )
+     &           optimcycle, myThid, xx_gentim2d_dummy(iarr) )
 #else
             CALL WRITE_REC_XY_RL( fnamegenOut, xx_gen, kRec, 1,
      &           myThid )
@@ -338,7 +337,7 @@ CADJ STORE xx_gentim2d_dummy = dummytape, key = 1 , kind = isbyte
 #ifdef ALLOW_AUTODIFF
          call active_read_xy( fnamegenOut, xx_gen, irec,
      &        doglobalread, ladinit, optimcycle,
-     &        mythid, xx_gentim2d_dummy(iarr) )
+     &        myThid, xx_gentim2d_dummy(iarr) )
 #else
          CALL READ_REC_XY_RL( fnamegenOut, xx_gen, iRec, 1, myThid )
 #endif
@@ -349,15 +348,15 @@ CADJ STORE xx_gentim2d_dummy = dummytape, key = 1 , kind = isbyte
           if (xx_gentim2d_preproc(k2,iarr).EQ.'variaweight') jrec=irec
          enddo
          CALL READ_REC_3D_RL( xx_gentim2d_weight(iarr), ctrlprec, 1,
-     &             wgentim2d(1-Olx,1-Oly,1,1,iarr), jrec, 1, myThid )
+     &             wgentim2d(1-OLx,1-OLy,1,1,iarr), jrec, 1, myThid )
 
 C--   Get appropriate mask
          call ctrl_get_mask2D(xx_gentim2d_file(iarr), mask2D, myThid)
 
 #ifdef ALLOW_SMOOTH
          IF (useSMOOTH) THEN
-          IF (dowc01) call smooth_correl2d(xx_gen,mask2D,numsmo,mythid)
-          IF (dosmooth) call smooth2d(xx_gen,mask2D,numsmo,mythid)
+          IF (dowc01) call smooth_correl2d(xx_gen,mask2D,numsmo,myThid)
+          IF (dosmooth) call smooth2d(xx_gen,mask2D,numsmo,myThid)
          ENDIF
 #endif /* ALLOW_SMOOTH */
 
@@ -387,7 +386,7 @@ C--   Get appropriate mask
 
 #ifdef ALLOW_AUTODIFF
          call active_write_xy( fnamegenOut, xx_gen, irec, optimcycle,
-     &        mythid, xx_gentim2d_dummy(iarr) )
+     &        myThid, xx_gentim2d_dummy(iarr) )
 #else
          CALL WRITE_REC_XY_RL( fnamegenOut, xx_gen, iRec, 1, myThid )
 #endif

--- a/pkg/ctrl/ctrl_pack.F
+++ b/pkg/ctrl/ctrl_pack.F
@@ -70,17 +70,24 @@ c     == routine arguments ==
       integer mythid
 
 #ifndef EXCLUDE_CTRL_PACK
-c     == external ==
-      integer  ilnblnk
-      external ilnblnk
-
 c     == local variables ==
 
-      _RL    fcloc
+      logical doglobalread
+      logical ladinit
+      logical lxxadxx
 
       integer i, k
 c     integer ig,jg
       integer ivartype
+      integer cunit
+      integer ictrlgrad
+      _RL    fcloc
+
+      character*(128) cfile
+
+#if (defined ALLOW_OBCS || defined ECCO_CTRL_DEPRECATED)
+      character*( 80) weighttype
+#endif
 #if (defined (ALLOW_CTRL) && defined (ALLOW_OBCS))
       integer iobcs
       character*(80) fname_obcsn(3)
@@ -94,6 +101,10 @@ C     the same local file name variable can be used for different variables.
 C     This is how GENARR2/3D_CONTROL is implemented (+ provides an example)
       integer iarr
       character*(80) fname_local(3)
+#endif
+#if ( defined ALLOW_GENARR2D_CONTROL || defined ALLOW_GENTIM2D_CONTROL )
+C 9 character limit set by set_(un)pack
+      character*( 9) mskNameForSetPack
 #endif
 
 #ifdef ECCO_CTRL_DEPRECATED
@@ -141,20 +152,6 @@ cHFLUXM_CONTROL
 cHFLUXM_CONTROL
       character*( 80)   fname_shifwflx(3)
 #endif /* ECCO_CTRL_DEPRECATED */
-
-      logical doglobalread
-      logical ladinit
-      logical lxxadxx
-
-      integer cunit
-      integer ictrlgrad
-
-      character*(128) cfile
-#if (defined ALLOW_OBCS || defined ECCO_CTRL_DEPRECATED)
-      character*( 80) weighttype
-#endif
-C 9 character limit set by set_(un)pack
-      character*( 9) mskNameForSetPack
 
 c     == end of interface ==
 
@@ -806,7 +803,7 @@ cc          write(weighttype(1:80),'(a)') "wunit"
      &         lxxadxx, mythid)
         endif
        enddo
-#endif
+#endif /* ALLOW_GENARR2D_CONTROL */
 
 #ifdef ALLOW_GENARR3D_CONTROL
        do iarr = 1, maxCtrlArr3D
@@ -822,7 +819,7 @@ cc          write(weighttype(1:80),'(a)') "wunit"
      &         wunit, lxxadxx, mythid)
         endif
        enddo
-#endif
+#endif /* ALLOW_GENARR3D_CONTROL */
 
 #ifdef ALLOW_GENTIM2D_CONTROL
        do iarr = 1, maxCtrlTim2D
@@ -844,7 +841,7 @@ cc          write(weighttype(1:80),'(a)') "wunit"
      &         lxxadxx, mythid)
         endif
        enddo
-#endif
+#endif /* ALLOW_GENTIM2D_CONTROL */
 
 #ifdef ALLOW_PACKUNPACK_METHOD2
       _BEGIN_MASTER( mythid )

--- a/pkg/ctrl/ctrl_set_pack_xy.F
+++ b/pkg/ctrl/ctrl_set_pack_xy.F
@@ -3,7 +3,7 @@
       subroutine ctrl_set_pack_xy(
      &     cunit, ivartype, precondScalar,
      &     fname, masktype, weighttype,
-     &     lxxadxx, mythid)
+     &     lxxadxx, mythid )
 
 c     ==================================================================
 c     SUBROUTINE ctrl_set_pack_xy
@@ -38,62 +38,68 @@ c     == routine arguments ==
       integer mythid
 
 #ifndef EXCLUDE_CTRL_PACK
-# ifndef ALLOW_PACKUNPACK_METHOD2
-c     == local variables ==
+c     == external ==
+      integer  ilnblnk
+      external ilnblnk
 
+c     == local variables ==
+      LOGICAL doPackOld
       integer bi,bj
-      integer ip,jp
       integer i,j,k
-      integer ii
-      integer irec,nrec_nl
+      integer ii, irec
+      integer cbuffindex
+      real*4 cbuff( sNx*nSx*nPx*sNy*nSy*nPy )
+      character*(80) cfile2, cfile3
+C========================================================================
+# ifndef ALLOW_PACKUNPACK_METHOD2
+      integer ip,jp
+      integer nrec_nl
       integer itlo,ithi
       integer jtlo,jthi
       integer jmin,jmax
       integer imin,imax
-
-      integer cbuffindex
-
-      _RL     globmsk  ( snx,nsx,npx,sny,nsy,npy,nr )
-      _RL     globfld3d( snx,nsx,npx,sny,nsy,npy,nr )
+      _RL     globmsk  ( sNx,nSx,nPx,sNy,nSy,nPy,Nr )
+      _RL     globfld3d( sNx,nSx,nPx,sNy,nSy,nPy,Nr )
 #ifdef ALLOW_NONDIMENSIONAL_CONTROL_IO
       integer il
-      _RL     weightfld2d( snx,nsx,npx,sny,nsy,npy )
+      _RL     weightfld2d( sNx,nSx,nPx,sNy,nSy,nPy )
 #endif
-      real*4 cbuff      ( snx*nsx*npx*sny*nsy*npy )
-
 #ifdef ALLOW_NONDIMENSIONAL_CONTROL_IO
       character*( 80) weightname
 #endif
-
       integer reclen, irectrue
       integer cunit2, cunit3
-      character*(80) cfile2, cfile3
-      real*4 globfldtmp2( snx,nsx,npx,sny,nsy,npy )
-      real*4 globfldtmp3( snx,nsx,npx,sny,nsy,npy )
-
-      LOGICAL doPackOld
-
-c     == external ==
-
-      integer  ilnblnk
-      external ilnblnk
-
+      real*4 globfldtmp2( sNx,nSx,nPx,sNy,nSy,nPy )
+      real*4 globfldtmp3( sNx,nSx,nPx,sNy,nSy,nPy )
+# else /* ALLOW_PACKUNPACK_METHOD2 */
+      integer il
+      _RL msk3d     (1-OLx:sNx+OLx,1-OLy:sNy+OLy,Nr,nSx,nSy)
+      real*8 msk2d_buf    (sNx,sNy,nSx,nSy)
+      real*8 msk2d_buf_glo(Nx,Ny)
+      real*8 fld2d_buf    (sNx,sNy,nSx,nSy)
+      real*8 fld2d_buf_glo(Nx,Ny)
+      _RL fld2dDim  (1-OLx:sNx+OLx,1-OLy:sNy+OLy,nSx,nSy)
+      _RL fld2dNodim(1-OLx:sNx+OLx,1-OLy:sNy+OLy,nSx,nSy)
+      _RL wei2d     (1-OLx:sNx+OLx,1-OLy:sNy+OLy,nSx,nSy)
+      _RL dummy
+# endif /* ALLOW_PACKUNPACK_METHOD2 */
 c     == end of interface ==
 
+# ifndef ALLOW_PACKUNPACK_METHOD2
       jtlo = 1
-      jthi = nsy
+      jthi = nSy
       itlo = 1
-      ithi = nsx
+      ithi = nSx
       jmin = 1
-      jmax = sny
+      jmax = sNy
       imin = 1
-      imax = snx
+      imax = sNx
 
       nbuffglobal = nbuffglobal + 1
       doPackOld = (.NOT.ctrlSmoothCorrel2D).AND.(.NOT.ctrlUseGen)
 
 c     Initialise temporary file
-      do k = 1,nr
+      do k = 1,Nr
        do jp = 1,nPy
         do bj = jtlo,jthi
          do j = jmin,jmax
@@ -134,7 +140,7 @@ c--   Only the master thread will do I/O.
      &           ivartype, '_', optimcycle, '.bin'
          endif
 
-         reclen = FLOAT(snx*nsx*npx*sny*nsy*npy*4)
+         reclen = FLOAT(sNx*nSx*nPx*sNy*nSy*nPy*4)
          call mdsfindunit( cunit2, mythid )
          open( cunit2, file=cfile2, status='unknown',
      &        access='direct', recl=reclen )
@@ -178,7 +184,7 @@ c--   Only the master thread will do I/O.
          call MDSREADFIELD_3D_GL( fname, ctrlprec, 'RL',
      &        Nr, globfld3d, irec, mythid)
          do k = 1, Nr
-         irectrue = (irec-1)*nr + k
+         irectrue = (irec-1)*Nr + k
 #ifndef ALLOW_ADMTLM
          write(cunit) ncvarindex(ivartype)
          write(cunit) 1
@@ -367,47 +373,7 @@ c     -- end of irec loop --
 
       _END_MASTER( mythid )
 
-# else
-c     == local variables ==
-
-      integer bi,bj
-      integer ip,jp
-      integer i,j,k
-      integer ii
-      integer il
-      integer irec
-      integer itlo,ithi
-      integer jtlo,jthi
-
-      integer cbuffindex
-
-      _RL msk3d(1-Olx:sNx+Olx,1-Oly:sNy+Oly,Nr,nSx,nSy)
-      real*8 msk2d_buf(sNx,sNy,nSx,nSy)
-      real*8 msk2d_buf_glo(Nx,Ny)
-
-      _RL fld2d(1-Olx:sNx+Olx,1-Oly:sNy+Oly,nSx,nSy)
-      real*8 fld2d_buf(sNx,sNy,nSx,nSy)
-      real*8 fld2d_buf_glo(Nx,Ny)
-
-      _RL fld2dDim(1-Olx:sNx+Olx,1-Oly:sNy+Oly,nSx,nSy)
-      _RL fld2dNodim(1-Olx:sNx+Olx,1-Oly:sNy+Oly,nSx,nSy)
-
-      _RL wei2d(1-Olx:sNx+Olx,1-Oly:sNy+Oly,nSx,nSy)
-
-      real*4 cbuff      ( snx*nsx*npx*sny*nsy*npy )
-
-      _RL delZnorm
-      character*(80) cfile2, cfile3
-      _RL dummy
-
-      LOGICAL doPackOld
-
-c     == external ==
-
-      integer  ilnblnk
-      external ilnblnk
-
-c     == end of interface ==
+# else /* ALLOW_PACKUNPACK_METHOD2 */
 
 c-- part 1: preliminary reads and definitions
 

--- a/pkg/ctrl/ctrl_set_pack_xyz.F
+++ b/pkg/ctrl/ctrl_set_pack_xyz.F
@@ -2,7 +2,7 @@
 
       subroutine ctrl_set_pack_xyz(
      &     cunit, ivartype, fname, masktype, weighttype,
-     &     weightfld, lxxadxx, mythid)
+     &     weightfld, lxxadxx, mythid )
 
 c     ==================================================================
 c     SUBROUTINE ctrl_set_pack_xyz
@@ -37,59 +37,68 @@ c     == routine arguments ==
       character*( 80) fname
       character*(  9) masktype
       character*( 80) weighttype
-      _RL     weightfld( nr,nsx,nsy )
+      _RL     weightfld( Nr,nSx,nSy )
       logical lxxadxx
       integer mythid
 
 #ifndef EXCLUDE_CTRL_PACK
-# ifndef ALLOW_PACKUNPACK_METHOD2
-c     == local variables ==
+c     == external ==
+      integer  ilnblnk
+      external ilnblnk
 
+c     == local variables ==
+      LOGICAL doPackOld
       integer bi,bj
-      integer ip,jp
       integer i,j,k
-      integer ii
-      integer irec
+      integer ii, irec
+      integer cbuffindex
+      real*4 cbuff( sNx*nSx*nPx*sNy*nSy*nPy )
+      character*(80) cfile2, cfile3
+C========================================================================
+# ifndef ALLOW_PACKUNPACK_METHOD2
+      integer ip,jp
       integer itlo,ithi
       integer jtlo,jthi
       integer jmin,jmax
       integer imin,imax
-
-      integer cbuffindex
-
-      _RL     globmsk  ( snx,nsx,npx,sny,nsy,npy,nr )
-      _RL     globfld3d( snx,nsx,npx,sny,nsy,npy,nr )
+      _RL     globmsk  ( sNx,nSx,nPx,sNy,nSy,nPy,Nr )
+      _RL     globfld3d( sNx,nSx,nPx,sNy,nSy,nPy,Nr )
 #ifdef CTRL_PACK_PRECISE
       integer il
       character*(80) weightname
-      _RL   weightfld3d( snx,nsx,npx,sny,nsy,npy,nr )
+      _RL   weightfld3d( sNx,nSx,nPx,sNy,nSy,nPy,Nr )
 #endif
-      real*4 cbuff      ( snx*nsx*npx*sny*nsy*npy )
-      real*4 globfldtmp2( snx,nsx,npx,sny,nsy,npy )
-      real*4 globfldtmp3( snx,nsx,npx,sny,nsy,npy )
-
+      real*4 globfldtmp2( sNx,nSx,nPx,sNy,nSy,nPy )
+      real*4 globfldtmp3( sNx,nSx,nPx,sNy,nSy,nPy )
       _RL delZnorm
       integer reclen, irectrue
       integer cunit2, cunit3
-      character*(80) cfile2, cfile3
-
-      LOGICAL doPackOld
-
-c     == external ==
-
-      integer  ilnblnk
-      external ilnblnk
-
+# else /* ALLOW_PACKUNPACK_METHOD2 */
+      integer il
+      _RL msk3d(1-OLx:sNx+OLx,1-OLy:sNy+OLy,Nr,nSx,nSy)
+      real*8 msk2d_buf(sNx,sNy,nSx,nSy)
+      real*8 msk2d_buf_glo(Nx,Ny)
+      real*8 fld2d_buf(sNx,sNy,nSx,nSy)
+      real*8 fld2d_buf_glo(Nx,Ny)
+      _RL fld3dDim(1-OLx:sNx+OLx,1-OLy:sNy+OLy,Nr,nSx,nSy)
+      _RL fld3dNodim(1-OLx:sNx+OLx,1-OLy:sNy+OLy,Nr,nSx,nSy)
+#ifdef CTRL_PACK_PRECISE
+      _RL wei3d(1-OLx:sNx+OLx,1-OLy:sNy+OLy,Nr,nSx,nSy)
+#endif
+      _RL delZnorm
+      _RL dummy
+# endif /* ALLOW_PACKUNPACK_METHOD2 */
 c     == end of interface ==
 
+# ifndef ALLOW_PACKUNPACK_METHOD2
       jtlo = 1
-      jthi = nsy
+      jthi = nSy
       itlo = 1
-      ithi = nsx
+      ithi = nSx
       jmin = 1
-      jmax = sny
+      jmax = sNy
       imin = 1
-      imax = snx
+      imax = sNx
 
       doPackOld = (.NOT.ctrlSmoothCorrel3D).AND.(.NOT.ctrlUseGen)
 
@@ -101,7 +110,7 @@ c     == end of interface ==
 #endif
 
 c     Initialise temporary file
-      do k = 1,nr
+      do k = 1,Nr
        do jp = 1,nPy
         do bj = jtlo,jthi
          do j = jmin,jmax
@@ -142,7 +151,7 @@ c--   Only the master thread will do I/O.
      &           ivartype, '_', optimcycle, '.bin'
          endif
 
-         reclen = FLOAT(snx*nsx*npx*sny*nsy*npy*4)
+         reclen = FLOAT(sNx*nSx*nPx*sNy*nSy*nPy*4)
          call mdsfindunit( cunit2, mythid )
          open( cunit2, file=cfile2, status='unknown',
      &        access='direct', recl=reclen )
@@ -160,7 +169,7 @@ c--   Only the master thread will do I/O.
      &     weightname, ctrlprec, 'RL',
      &     Nr, weightfld3d, 1, mythid)
       else
-       do k = 1,nr
+       do k = 1,Nr
         do jp = 1,nPy
          do bj = jtlo,jthi
           do j = jmin,jmax
@@ -192,8 +201,8 @@ c--   Only the master thread will do I/O.
          write(cunit) 1
          write(cunit) 1
 #endif
-         do k = 1, nr
-         irectrue = (irec-1)*nr + k
+         do k = 1, Nr
+         irectrue = (irec-1)*Nr + k
             if ( doZscalePack ) then
                delZnorm = (delR(1)/delR(k))**delZexp
             else
@@ -278,50 +287,7 @@ c     -- end of irec loop --
 
       _END_MASTER( mythid )
 
-# else
-c     == local variables ==
-
-      integer bi,bj
-      integer ip,jp
-      integer i,j,k
-      integer ii
-      integer il
-      integer irec
-      integer itlo,ithi
-      integer jtlo,jthi
-
-      integer cbuffindex
-
-      _RL msk3d(1-Olx:sNx+Olx,1-Oly:sNy+Oly,Nr,nSx,nSy)
-      real*8 msk2d_buf(sNx,sNy,nSx,nSy)
-      real*8 msk2d_buf_glo(Nx,Ny)
-
-      _RL fld3d(1-Olx:sNx+Olx,1-Oly:sNy+Oly,Nr,nSx,nSy)
-      real*8 fld2d_buf(sNx,sNy,nSx,nSy)
-      real*8 fld2d_buf_glo(Nx,Ny)
-
-      _RL fld3dDim(1-Olx:sNx+Olx,1-Oly:sNy+Oly,Nr,nSx,nSy)
-      _RL fld3dNodim(1-Olx:sNx+Olx,1-Oly:sNy+Oly,Nr,nSx,nSy)
-
-#ifdef CTRL_PACK_PRECISE
-      _RL wei3d(1-Olx:sNx+Olx,1-Oly:sNy+Oly,Nr,nSx,nSy)
-#endif
-
-      real*4 cbuff      ( snx*nsx*npx*sny*nsy*npy )
-
-      character*(80) weightname
-      _RL delZnorm
-      character*(80) cfile2, cfile3
-      _RL dummy
-
-      LOGICAL doPackOld
-
-c     == external ==
-
-      integer  ilnblnk
-      external ilnblnk
-
-c     == end of interface ==
+# else /* ALLOW_PACKUNPACK_METHOD2 */
 
 c-- part 1: preliminary reads and definitions
 
@@ -433,7 +399,7 @@ c-- 2.4: array -> buffer -> global buffer -> global file
       _BARRIER
 #endif
 
-      do k = 1, nr
+      do k = 1, Nr
 
         CALL MDS_PASS_R8toRL( fld2d_buf, fld3dNodim,
      &                 0, 0, 1, k, Nr, 0, 0, .FALSE., myThid )

--- a/pkg/ctrl/ctrl_set_unpack_xy.F
+++ b/pkg/ctrl/ctrl_set_unpack_xy.F
@@ -3,7 +3,7 @@
       subroutine ctrl_set_unpack_xy(
      &     lxxadxx, cunit, ivartype, PrecondScalar,
      &     fname, masktype, weighttype,
-     &     nwetglobal, mythid)
+     &     nwetglobal, mythid )
 
 c     ==================================================================
 c     SUBROUTINE ctrl_set_unpack_xy
@@ -35,64 +35,71 @@ c     == routine arguments ==
       character*( 80) fname
       character*(  9) masktype
       character*( 80) weighttype
-      integer nwetglobal(nr)
+      integer nwetglobal(Nr)
       integer mythid
 
 #ifndef EXCLUDE_CTRL_PACK
-# ifndef ALLOW_PACKUNPACK_METHOD2
-c     == local variables ==
+c     == external ==
+      integer  ilnblnk
+      external ilnblnk
 
+c     == local variables ==
+      LOGICAL doPackOld
       integer bi,bj
-      integer ip,jp
       integer i,j,k
-      integer ii
-      integer irec,nrec_nl
+      integer ii, irec
+      integer cbuffindex
+      real*4 cbuff( sNx*nSx*nPx*sNy*nSy*nPy )
+      character*(80) cfile2, cfile3
+C========================================================================
+# ifndef ALLOW_PACKUNPACK_METHOD2
+      integer ip,jp
+      integer nrec_nl
       integer itlo,ithi
       integer jtlo,jthi
       integer jmin,jmax
       integer imin,imax
-
-      integer cbuffindex
-
-      _RL     globmsk  ( snx,nsx,npx,sny,nsy,npy,nr )
-      _RL     globfld3d( snx,nsx,npx,sny,nsy,npy,nr )
+      _RL     globmsk  ( sNx,nSx,nPx,sNy,nSy,nPy,Nr )
+      _RL     globfld3d( sNx,nSx,nPx,sNy,nSy,nPy,Nr )
 #ifdef ALLOW_NONDIMENSIONAL_CONTROL_IO
       integer il
-      _RL     weightfld2d( snx,nsx,npx,sny,nsy,npy )
+      _RL     weightfld2d( sNx,nSx,nPx,sNy,nSy,nPy )
       character*( 80) weightname
 #endif
-      real*4  cbuff    ( snx*nsx*npx*sny*nsy*npy )
-
-
-      integer reclen,irectrue
+      integer reclen, irectrue
       integer cunit2, cunit3
-      character*(80) cfile2, cfile3
-      real*4 globfldtmp2( snx,nsx,npx,sny,nsy,npy )
-      real*4 globfldtmp3( snx,nsx,npx,sny,nsy,npy )
-
-      LOGICAL doPackOld
-
-c     == external ==
-
-      integer  ilnblnk
-      external ilnblnk
-
+      real*4 globfldtmp2( sNx,nSx,nPx,sNy,nSy,nPy )
+      real*4 globfldtmp3( sNx,nSx,nPx,sNy,nSy,nPy )
+# else /* ALLOW_PACKUNPACK_METHOD2 */
+      integer il
+      _RL msk3d(1-OLx:sNx+OLx,1-OLy:sNy+OLy,Nr,nSx,nSy)
+      real*8 msk2d_buf(sNx,sNy,nSx,nSy)
+      real*8 msk2d_buf_glo(Nx,Ny)
+      real*8 fld2d_buf(sNx,sNy,nSx,nSy)
+      real*8 fld2d_buf_glo(Nx,Ny)
+      _RL fld2dDim(1-OLx:sNx+OLx,1-OLy:sNy+OLy,nSx,nSy)
+      _RL fld2dNodim(1-OLx:sNx+OLx,1-OLy:sNy+OLy,nSx,nSy)
+      _RL wei2d(1-OLx:sNx+OLx,1-OLy:sNy+OLy,nSx,nSy)
+      _RL dummy
+# endif /* ALLOW_PACKUNPACK_METHOD2 */
 c     == end of interface ==
 
+# ifndef ALLOW_PACKUNPACK_METHOD2
+
       jtlo = 1
-      jthi = nsy
+      jthi = nSy
       itlo = 1
-      ithi = nsx
+      ithi = nSx
       jmin = 1
-      jmax = sny
+      jmax = sNy
       imin = 1
-      imax = snx
+      imax = sNx
 
       nbuffGlobal = nbuffGlobal + 1
       doPackOld = (.NOT.ctrlSmoothCorrel2D).AND.(.NOT.ctrlUseGen)
 
 c     Initialise temporary file
-      do k = 1,nr
+      do k = 1,Nr
        do jp = 1,nPy
         do bj = jtlo,jthi
          do j = jmin,jmax
@@ -133,7 +140,7 @@ c--   Only the master thread will do I/O.
      &           ivartype, '_', optimcycle, '.bin'
          endif
 
-         reclen = FLOAT(snx*nsx*npx*sny*nsy*npy*4)
+         reclen = FLOAT(sNx*nSx*nPx*sNy*nSy*nPy*4)
          call mdsfindunit( cunit2, mythid )
          open( cunit2, file=cfile2, status='unknown',
      &        access='direct', recl=reclen )
@@ -174,7 +181,7 @@ c--   Only the master thread will do I/O.
       nrec_nl=int(ncvarrecs(ivartype)/Nr)
       do irec = 1, nrec_nl
          do k = 1,Nr
-         irectrue = (irec-1)*nr + k
+         irectrue = (irec-1)*Nr + k
 #ifndef ALLOW_ADMTLM
          read(cunit) filencvarindex(ivartype)
          if (filencvarindex(ivartype) .NE. ncvarindex(ivartype))
@@ -399,47 +406,7 @@ cph)
 
       _END_MASTER( mythid )
 
-# else
-c     == local variables ==
-
-      integer bi,bj
-      integer ip,jp
-      integer i,j,k
-      integer ii
-      integer il
-      integer irec
-      integer itlo,ithi
-      integer jtlo,jthi
-
-      integer cbuffindex
-
-      _RL msk3d(1-Olx:sNx+Olx,1-Oly:sNy+Oly,Nr,nSx,nSy)
-      real*8 msk2d_buf(sNx,sNy,nSx,nSy)
-      real*8 msk2d_buf_glo(Nx,Ny)
-
-      _RL fld2d(1-Olx:sNx+Olx,1-Oly:sNy+Oly,nSx,nSy)
-      real*8 fld2d_buf(sNx,sNy,nSx,nSy)
-      real*8 fld2d_buf_glo(Nx,Ny)
-
-      _RL fld2dDim(1-Olx:sNx+Olx,1-Oly:sNy+Oly,nSx,nSy)
-      _RL fld2dNodim(1-Olx:sNx+Olx,1-Oly:sNy+Oly,nSx,nSy)
-
-      _RL wei2d(1-Olx:sNx+Olx,1-Oly:sNy+Oly,nSx,nSy)
-
-      real*4 cbuff      ( snx*nsx*npx*sny*nsy*npy )
-
-      _RL delZnorm
-      character*(80) cfile2, cfile3
-      _RL dummy
-
-      LOGICAL doPackOld
-
-c     == external ==
-
-      integer  ilnblnk
-      external ilnblnk
-
-c     == end of interface ==
+# else /* ALLOW_PACKUNPACK_METHOD2 */
 
 c-- part 1: preliminary reads and definitions
 
@@ -550,7 +517,6 @@ c-- 2.1: array <- buffer <- global buffer <- global file
      &                 0, 0, 1, k, 1, 0, 0, .TRUE., myThid )
 
       enddo !do k = 1, 1
-
 
 c-- 2.2: normalize field if needed
       DO bj = myByLo(myThid), myByHi(myThid)

--- a/pkg/ctrl/ctrl_set_unpack_xyz.F
+++ b/pkg/ctrl/ctrl_set_unpack_xyz.F
@@ -2,7 +2,7 @@
 
       subroutine ctrl_set_unpack_xyz(
      &     lxxadxx, cunit, ivartype, fname, masktype, weighttype,
-     &     weightfld, nwetglobal, mythid)
+     &     weightfld, nwetglobal, mythid )
 
 c     ==================================================================
 c     SUBROUTINE ctrl_set_unpack_xyz
@@ -37,59 +37,69 @@ c     == routine arguments ==
       character*( 80)   fname
       character*(  9) masktype
       character*( 80) weighttype
-      _RL     weightfld( nr,nsx,nsy )
-      integer nwetglobal(nr)
+      _RL     weightfld( Nr,nSx,nSy )
+      integer nwetglobal(Nr)
       integer mythid
 
 #ifndef EXCLUDE_CTRL_PACK
-# ifndef ALLOW_PACKUNPACK_METHOD2
-c     == local variables ==
+c     == external ==
+      integer  ilnblnk
+      external ilnblnk
 
+c     == local variables ==
+      LOGICAL doPackOld
       integer bi,bj
-      integer ip,jp
       integer i,j,k
-      integer ii
-      integer irec
+      integer ii, irec
+      integer cbuffindex
+      real*4 cbuff( sNx*nSx*nPx*sNy*nSy*nPy )
+      character*(80) cfile2, cfile3
+C========================================================================
+# ifndef ALLOW_PACKUNPACK_METHOD2
+      integer ip,jp
       integer itlo,ithi
       integer jtlo,jthi
       integer jmin,jmax
       integer imin,imax
-
-      integer cbuffindex
-
-      _RL     globmsk  ( snx,nsx,npx,sny,nsy,npy,nr )
-      _RL     globfld3d( snx,nsx,npx,sny,nsy,npy,nr )
+      _RL     globmsk  ( sNx,nSx,nPx,sNy,nSy,nPy,Nr )
+      _RL     globfld3d( sNx,nSx,nPx,sNy,nSy,nPy,Nr )
 #ifdef CTRL_UNPACK_PRECISE
       integer il
       character*(80) weightname
-      _RL   weightfld3d( snx,nsx,npx,sny,nsy,npy,nr )
+      _RL   weightfld3d( sNx,nSx,nPx,sNy,nSy,nPy,Nr )
 #endif
-      real*4 cbuff      ( snx*nsx*npx*sny*nsy*npy )
-      real*4 globfldtmp2( snx,nsx,npx,sny,nsy,npy )
-      real*4 globfldtmp3( snx,nsx,npx,sny,nsy,npy )
-
+      real*4 globfldtmp2( sNx,nSx,nPx,sNy,nSy,nPy )
+      real*4 globfldtmp3( sNx,nSx,nPx,sNy,nSy,nPy )
       _RL delZnorm
       integer reclen, irectrue
       integer cunit2, cunit3
-      character*(80) cfile2, cfile3
+# else /* ALLOW_PACKUNPACK_METHOD2 */
+      integer il
+      _RL msk3d(1-OLx:sNx+OLx,1-OLy:sNy+OLy,Nr,nSx,nSy)
+      real*8 msk2d_buf(sNx,sNy,nSx,nSy)
+      real*8 msk2d_buf_glo(Nx,Ny)
+      real*8 fld2d_buf(sNx,sNy,nSx,nSy)
+      real*8 fld2d_buf_glo(Nx,Ny)
+      _RL fld3dDim(1-OLx:sNx+OLx,1-OLy:sNy+OLy,Nr,nSx,nSy)
+      _RL fld3dNodim(1-OLx:sNx+OLx,1-OLy:sNy+OLy,Nr,nSx,nSy)
+#ifdef CTRL_UNPACK_PRECISE
+      _RL wei3d(1-OLx:sNx+OLx,1-OLy:sNy+OLy,Nr,nSx,nSy)
+#endif
+      _RL delZnorm
+      _RL dummy
+# endif /* ALLOW_PACKUNPACK_METHOD2 */
+c     == end of interface ==
 
-      LOGICAL doPackOld
-
-c     == external ==
-
-      integer  ilnblnk
-      external ilnblnk
-
-cc     == end of interface ==
+# ifndef ALLOW_PACKUNPACK_METHOD2
 
       jtlo = 1
-      jthi = nsy
+      jthi = nSy
       itlo = 1
-      ithi = nsx
+      ithi = nSx
       jmin = 1
-      jmax = sny
+      jmax = sNy
       imin = 1
-      imax = snx
+      imax = sNx
 
 #ifdef CTRL_DELZNORM
       delZnorm = 0.
@@ -101,7 +111,7 @@ cc     == end of interface ==
       doPackOld = (.NOT.ctrlSmoothCorrel3D).AND.(.NOT.ctrlUseGen)
 
 c     Initialise temporary file
-      do k = 1,nr
+      do k = 1,Nr
        do jp = 1,nPy
         do bj = jtlo,jthi
          do j = jmin,jmax
@@ -124,7 +134,7 @@ c--   Only the master thread will do I/O.
       _BEGIN_MASTER( mythid )
 
 #ifdef CTRL_DELZNORM
-      do k = 1, nr
+      do k = 1, Nr
          print *, 'ph-delznorm ', k, delZnorm, delR(k)
          print *, 'ph-weight   ', weightfld(k,1,1)
       enddo
@@ -149,7 +159,7 @@ c--   Only the master thread will do I/O.
      &           ivartype, '_', optimcycle, '.bin'
          endif
 
-         reclen = FLOAT(snx*nsx*npx*sny*nsy*npy*4)
+         reclen = FLOAT(sNx*nSx*nPx*sNy*nSy*nPy*4)
          call mdsfindunit( cunit2, mythid )
          open( cunit2, file=cfile2, status='unknown',
      &        access='direct', recl=reclen )
@@ -167,7 +177,7 @@ c--   Only the master thread will do I/O.
      &     weightname, ctrlprec, 'RL',
      &     Nr, weightfld3d, 1, mythid)
       else
-       do k = 1,nr
+       do k = 1,Nr
         do jp = 1,nPy
          do bj = jtlo,jthi
           do j = jmin,jmax
@@ -202,7 +212,7 @@ c--   Only the master thread will do I/O.
          read(cunit) filei
 #endif /* ALLOW_ADMTLM */
          do k = 1, Nr
-         irectrue = (irec-1)*nr + k
+         irectrue = (irec-1)*Nr + k
             if ( doZscaleUnpack ) then
                delZnorm = (delR(1)/delR(k))**delZexp
             else
@@ -305,50 +315,7 @@ c
 
       _END_MASTER( mythid )
 
-# else
-c     == local variables ==
-
-      integer bi,bj
-      integer ip,jp
-      integer i,j,k
-      integer ii
-      integer il
-      integer irec
-      integer itlo,ithi
-      integer jtlo,jthi
-
-      integer cbuffindex
-
-      _RL msk3d(1-Olx:sNx+Olx,1-Oly:sNy+Oly,Nr,nSx,nSy)
-      real*8 msk2d_buf(sNx,sNy,nSx,nSy)
-      real*8 msk2d_buf_glo(Nx,Ny)
-
-      _RL fld3d(1-Olx:sNx+Olx,1-Oly:sNy+Oly,Nr,nSx,nSy)
-      real*8 fld2d_buf(sNx,sNy,nSx,nSy)
-      real*8 fld2d_buf_glo(Nx,Ny)
-
-      _RL fld3dDim(1-Olx:sNx+Olx,1-Oly:sNy+Oly,Nr,nSx,nSy)
-      _RL fld3dNodim(1-Olx:sNx+Olx,1-Oly:sNy+Oly,Nr,nSx,nSy)
-
-#ifdef CTRL_UNPACK_PRECISE
-      _RL wei3d(1-Olx:sNx+Olx,1-Oly:sNy+Oly,Nr,nSx,nSy)
-#endif
-
-      real*4 cbuff      ( snx*nsx*npx*sny*nsy*npy )
-
-      character*(80) weightname
-      _RL delZnorm
-      character*(80) cfile2, cfile3
-      _RL dummy
-
-      LOGICAL doPackOld
-
-c     == external ==
-
-      integer  ilnblnk
-      external ilnblnk
-
-c     == end of interface ==
+# else /* ALLOW_PACKUNPACK_METHOD2 */
 
 c-- part 1: preliminary reads and definitions
 
@@ -406,7 +373,7 @@ c-- 2.1: array <- buffer <- global buffer <- global file
       _BARRIER
 #endif /* ALLOW_ADMTLM */
 
-      do k = 1, nr
+      do k = 1, Nr
 
         CALL MDS_PASS_R8toRL( msk2d_buf, msk3d,
      &                 0, 0, 1, k, Nr, 0, 0, .FALSE., myThid )
@@ -458,7 +425,7 @@ c-- 2.1: array <- buffer <- global buffer <- global file
         CALL MDS_PASS_R8toRL( fld2d_buf, fld3dNodim,
      &                 0, 0, 1, k, Nr, 0, 0, .TRUE., myThid )
 
-      enddo !do k = 1, nr
+      enddo !do k = 1, Nr
 
 c-- 2.2: normalize field if needed
       DO bj = myByLo(myThid), myByHi(myThid)
@@ -523,7 +490,6 @@ c error: twice the same one
 c-- 2.4:
       call WRITE_REC_3D_RL( fname, ctrlprec,
      &        Nr, fld3dDim, irec, 0, mythid)
-
 
       enddo !do irec = 1, ncvarrecs(ivartype)
 

--- a/pkg/ctrl/ctrl_summary.F
+++ b/pkg/ctrl/ctrl_summary.F
@@ -35,15 +35,16 @@ c     == global variables ==
 #endif
 
 c     == routine arguments ==
-
       integer mythid
 
-c     == local variables ==
+c     == external ==
+      integer  ilnblnk
+      external ilnblnk
 
+c     == local variables ==
       integer bi,bj
-      integer i,k
+      integer k
       integer il
-      integer timeint(4)
       integer nwetcenter
       integer nwetsouth
       integer nwetwest
@@ -53,11 +54,9 @@ c     == local variables ==
 #if (defined (ALLOW_GENARR2D_CONTROL) || defined (ALLOW_GENARR3D_CONTROL) || defined (ALLOW_GENTIM2D_CONTROL))
       INTEGER iarr, jarr
 #endif
-
-c     == external ==
-
-      integer  ilnblnk
-      external ilnblnk
+#if ( ( defined ALLOW_GENTIM2D_CONTROL && defined ALLOW_CAL ) || defined ECCO_CTRL_DEPRECATED )
+      integer i, timeint(4)
+#endif
 
 c     == end of interface ==
 
@@ -321,7 +320,6 @@ c     == end of interface ==
 
 #endif /* ECCO_CTRL_DEPRECATED */
 
-
 #ifdef ALLOW_SMOOTH
 #ifdef ECCO_CTRL_DEPRECATED
 
@@ -364,7 +362,6 @@ c allow for switching off correl2d in adjoint
 #endif /* ECCO_CTRL_DEPRECATED */
 #endif /* ALLOW_SMOOTH */
 
-
 #if (defined (ALLOW_GENARR2D_CONTROL) || defined (ALLOW_GENARR3D_CONTROL) || defined (ALLOW_GENTIM2D_CONTROL))
 
       write(msgbuf,'(a)') ' '
@@ -386,7 +383,6 @@ c allow for switching off correl2d in adjoint
      &' /* use generic controls */'
       call print_message( msgbuf, standardmessageunit,
      &                    SQUEEZE_RIGHT , mythid)
-
 
 #ifdef ALLOW_GENARR2D_CONTROL
       do iarr = 1, maxCtrlArr2D
@@ -431,7 +427,6 @@ c allow for switching off correl2d in adjoint
       enddo
 #endif
 
-
 #ifdef ALLOW_GENARR3D_CONTROL
       do iarr = 1, maxCtrlArr3D
        if (xx_genarr3d_weight(iarr).NE.' ') then
@@ -460,7 +455,6 @@ c allow for switching off correl2d in adjoint
      &'      ncvarindex = ', ncvarindex(200+iarr)
         call print_message( msgbuf, standardmessageunit,
      &                      SQUEEZE_RIGHT , mythid)
-
 
         do jarr=1,maxCtrlProc
          if (xx_genarr3d_preproc(jarr,iarr).NE.' ') then

--- a/pkg/ctrl/ctrl_unpack.F
+++ b/pkg/ctrl/ctrl_unpack.F
@@ -907,8 +907,8 @@ cc          write(weighttype(1:80),'(a)') "wunit"
           call ctrl_set_fname( xx_genarr3d_file(iarr),
      O                         fname_local, mythid )
           ivartype    = 200+iarr
-          write(weighttype(1:80),'(80a)') ' '
-          write(weighttype(1:80),'(a)') "wunit"
+c          write(weighttype(1:80),'(80a)') ' '
+c          write(weighttype(1:80),'(a)') "wunit"
           call ctrl_set_unpack_xyz( lxxadxx, cunit, ivartype,
      &         fname_local(ictrlgrad), "maskCtrlC",
      &         xx_genarr3d_weight(iarr),
@@ -935,8 +935,8 @@ cc          write(weighttype(1:80),'(a)') "wunit"
           call ctrl_set_fname( xx_gentim2d_file(iarr),
      O                         fname_local, mythid )
           ivartype    = 300+iarr
-          write(weighttype(1:80),'(80a)') ' '
-          write(weighttype(1:80),'(a)') "wunit"
+c          write(weighttype(1:80),'(80a)') ' '
+c          write(weighttype(1:80),'(a)') "wunit"
           call ctrl_set_unpack_xy(
      &         lxxadxx, cunit, ivartype, gentim2dPrecond(iarr),
      &         fname_local(ictrlgrad), mskNameForSetUnpack,

--- a/pkg/ctrl/ctrl_unpack.F
+++ b/pkg/ctrl/ctrl_unpack.F
@@ -75,21 +75,26 @@ c     == routine arguments ==
       integer mythid
 
 #ifndef EXCLUDE_CTRL_PACK
-c     == external ==
-      integer  ilnblnk
-      external ilnblnk
-
 c     == local variables ==
 
       integer i, k
       integer ivartype
       integer ictrlgrad
+      integer cunit
+      logical lxxadxx
+      character*(128) cfile
+      character*( 80) weighttype
+
 #if (defined ALLOW_GENARR2D_CONTROL) || (defined ALLOW_GENARR3D_CONTROL) || (defined ALLOW_GENTIM2D_CONTROL)
 C-    Provided we set the file name just before calling ctrl_set_unpack,
 C     the same local file name variable can be used for different variables.
 C     This is how GENARR2/3D_CONTROL is implemented (+ provides an example)
       integer iarr
       character*(80) fname_local(3)
+#endif
+#if ( defined ALLOW_GENARR2D_CONTROL || defined ALLOW_GENTIM2D_CONTROL )
+      integer nwettmp(Nr)
+      character*( 9) mskNameForSetUnpack
 #endif
 
 #ifdef ECCO_CTRL_DEPRECATED
@@ -137,15 +142,6 @@ cHFLUXM_CONTROL
 cHFLUXM_CONTROL
       character*( 80)   fname_shifwflx(3)
 #endif /* ECCO_CTRL_DEPRECATED */
-
-      integer cunit
-      integer nwettmp(Nr)
-
-      character*(128) cfile
-      character*( 80) weighttype
-      character*( 9) mskNameForSetUnpack
-
-      logical lxxadxx
 
 #if (defined (ALLOW_CTRL) && defined (ALLOW_OBCS))
       character*(80) fname_obcsn(3)
@@ -901,7 +897,7 @@ cc          write(weighttype(1:80),'(a)') "wunit"
      &         nwettmp, mythid)
         endif
        enddo
-#endif
+#endif /* ALLOW_GENARR2D_CONTROL */
 
 #ifdef ALLOW_GENARR3D_CONTROL
        do iarr = 1, maxCtrlArr3D
@@ -917,7 +913,7 @@ cc          write(weighttype(1:80),'(a)') "wunit"
      &         wunit, nwetcglobal, mythid)
         endif
        enddo
-#endif
+#endif /* ALLOW_GENARR3D_CONTROL */
 
 #ifdef ALLOW_GENTIM2D_CONTROL
        do iarr = 1, maxCtrlTim2D
@@ -946,7 +942,7 @@ cc          write(weighttype(1:80),'(a)') "wunit"
      &         nwettmp, mythid)
         endif
        enddo
-#endif
+#endif /* ALLOW_GENTIM2D_CONTROL */
 
 #ifdef ALLOW_PACKUNPACK_METHOD2
       _BEGIN_MASTER( mythid )

--- a/pkg/ctrl/ctrl_unpack.F
+++ b/pkg/ctrl/ctrl_unpack.F
@@ -83,7 +83,6 @@ c     == local variables ==
       integer cunit
       logical lxxadxx
       character*(128) cfile
-      character*( 80) weighttype
 
 #if (defined ALLOW_GENARR2D_CONTROL) || (defined ALLOW_GENARR3D_CONTROL) || (defined ALLOW_GENTIM2D_CONTROL)
 C-    Provided we set the file name just before calling ctrl_set_unpack,
@@ -143,6 +142,9 @@ cHFLUXM_CONTROL
       character*( 80)   fname_shifwflx(3)
 #endif /* ECCO_CTRL_DEPRECATED */
 
+#if (defined ALLOW_OBCS || defined ECCO_CTRL_DEPRECATED)
+      character*(80) weighttype
+#endif
 #if (defined (ALLOW_CTRL) && defined (ALLOW_OBCS))
       character*(80) fname_obcsn(3)
       character*(80) fname_obcss(3)
@@ -318,9 +320,9 @@ c
              print *, 'WARNING: wrong nvarlength ',
      &            filenvarlength, nvarlength
              STOP 'in S/R ctrl_unpack'
-          else if ( filensx .NE. nsx .OR. filensy .NE. nsy ) then
-             print *, 'WARNING: wrong nsx or nsy ',
-     &            filensx, nsx, filensy, nsy
+          else if ( filensx .NE. nSx .OR. filensy .NE. nSy ) then
+             print *, 'WARNING: wrong nSx or nSy ',
+     &            filensx, nSx, filensy, nSy
              STOP 'in S/R ctrl_unpack'
           endif
           do k = 1, nr

--- a/pkg/dic/bio_export.F
+++ b/pkg/dic/bio_export.F
@@ -45,7 +45,7 @@ C  PTR_FE               :: iron tracer field
 C !OUTPUT PARAMETERS: ==================================================
 C  bioac               :: biological productivity (will be split
 C                         between export and dissolved pool)
-      _RL bioac(1-OLx:sNx+OLx,1-OLy:sNy+OLy,nR)
+      _RL bioac(1-OLx:sNx+OLx,1-OLy:sNy+OLy,Nr)
 
 #if (defined ALLOW_PTRACERS && defined DIC_BIOTIC)
 
@@ -61,7 +61,7 @@ C  i,j,k                  :: loop indices
       _RL tmpfe
 #endif
 #ifdef AD_SAFE
-      _RL thx, thy, theps, thaux
+      _RL thx, thy, thaux
 #endif
 CEOP
 
@@ -130,8 +130,6 @@ C     performance drop on vector computers
          thy = tmpfe/(tmpfe+KFE)
 c        thx = PTR_PO4(i,j,k)/(PTR_PO4(i,j,k)+KPO4)
 c        thy = PTR_FE(i,j,k)/(PTR_FE(i,j,k)+KFE)
-c        theps = 1. _d -6
-c        thaux = tanh( (thx-thy)/theps )
          thaux = tanh( (thx-thy)*1. _d 6 )
          nutlimit= ( 1. _d 0 - thaux ) * thx * 0.5 _d 0
      &        +    ( 1. _d 0 + thaux ) * thy * 0.5 _d 0

--- a/pkg/dic/fe_chem.F
+++ b/pkg/dic/fe_chem.F
@@ -43,7 +43,7 @@ C     !LOCAL VARIABLES:
       INTEGER i,j,k
       _RL  lig, FeL
       _RL  tmpfe
-#ifdef AD_SAFE
+#if ( defined MINFE && defined AD_SAFE )
       _RL thx, thy, theps
 #endif
 

--- a/pkg/ecco/cost_bp_read.F
+++ b/pkg/ecco/cost_bp_read.F
@@ -3,7 +3,7 @@
       subroutine cost_bp_read(
      I localobsfile, localstartdate,
      O localobs, localmask,
-     I irec,myThid)
+     I irec, myThid )
 
 c     ==================================================================
 c     SUBROUTINE cost_bp_read
@@ -35,7 +35,6 @@ c     == global variables ==
 #endif
 
 c     == routine arguments ==
-
       character*(MAX_LEN_FNAM) localobsfile
       integer localstartdate(4)
       _RL localobs   (1-OLx:sNx+OLx,1-OLy:sNy+OLy,nSx,nSy)
@@ -44,25 +43,18 @@ c     == routine arguments ==
       integer myThid
 
 #ifdef ALLOW_ECCO
+c     == external functions ==
+      integer  ilnblnk
+      external ilnblnk
 
 c     == local variables ==
-
       integer bi,bj
       integer i,j,k
-      integer itlo,ithi
-      integer jtlo,jthi
       integer jmin,jmax
       integer imin,imax
       integer nobs
-      integer bprec
-      integer beginbp
-      integer beginrun
-
       INTEGER beginlocal, beginmodel, obsrec
-
       _RL spval
-      _RL vartile
-
 cnew(
       integer  il
       integer mody, modm
@@ -71,20 +63,11 @@ cnew(
       logical exst
 cnew)
 
-c     == external functions ==
-
-      integer  ilnblnk
-      external ilnblnk
-
 c     == end of interface ==
 
       parameter (spval = -998. )
 ce    --> there is certainly a better place for this.
 
-      jtlo = myByLo(myThid)
-      jthi = myByHi(myThid)
-      itlo = myBxLo(myThid)
-      ithi = myBxHi(myThid)
       jmin = 1
       jmax = sNy
       imin = 1
@@ -115,8 +98,8 @@ ce    --> there is certainly a better place for this.
        CALL READ_REC_3D_RL( fnametmp, cost_iprec, 1,
      &                      localobs, imonth, 0, myThid )
       else
-        do bj = jtlo,jthi
-         do bi = itlo,ithi
+        do bj = myByLo(myThid), myByHi(myThid)
+         do bi = myBxLo(myThid), myBxHi(myThid)
           do j = jmin,jmax
            do i = imin,imax
             localobs(i,j,bi,bj) = spval
@@ -128,8 +111,8 @@ ce    --> there is certainly a better place for this.
 
       nobs = 0
 
-      do bj = jtlo,jthi
-        do bi = itlo,ithi
+      do bj = myByLo(myThid), myByHi(myThid)
+        do bi = myBxLo(myThid), myBxHi(myThid)
           k = 1
           do j = jmin,jmax
             do i = imin,imax

--- a/pkg/ecco/cost_gencal.F
+++ b/pkg/ecco/cost_gencal.F
@@ -36,20 +36,22 @@ C     == global variables ==
 #endif
 
 c     == routine arguments ==
-
-      integer mythid, irec, localstartdate(4)
-      _RL localperiod
       character*(MAX_LEN_FNAM) localbarfile
       character*(MAX_LEN_FNAM) localobsfile
+      integer irec, localstartdate(4)
+      _RL localperiod
       character*(128) fname1, fname2
       integer localrec, obsrec
+      logical exst
+      integer mythid
 
 #ifdef ALLOW_ECCO
+c     == external functions ==
+      integer  ilnblnk
+      external ilnblnk
 
 c     == local variables ==
-
 c      CHARACTER*(MAX_LEN_MBUF) msgBuf
-
       integer k, il
       _RL daytime
       _RL diffsecs
@@ -61,16 +63,8 @@ c      CHARACTER*(MAX_LEN_MBUF) msgBuf
       integer yday, ymod
       integer md, dd, sd, ld, wd
       integer mody, modm
-      integer beginmodel, beginlocal
-      logical exst
-
-c     == external functions ==
-
-      integer  ilnblnk
-      external ilnblnk
 
 c     == end of interface ==
-
 CEOP
 
       write(fname1(1:128),'(80a)') ' '

--- a/pkg/ecco/cost_gencost_boxmean.F
+++ b/pkg/ecco/cost_gencost_boxmean.F
@@ -1,6 +1,6 @@
 #include "ECCO_OPTIONS.h"
 
-      subroutine cost_gencost_boxmean(mythid)
+      subroutine cost_gencost_boxmean( myThid )
 
 c     ==================================================================
 c     SUBROUTINE cost_gencost_boxmean
@@ -29,14 +29,13 @@ c     == global variables ==
 #endif
 
 c     == routine arguments ==
-      integer mythid
+      integer myThid
 
 #ifdef ALLOW_GENCOST_CONTRIBUTION
-
 c     == local variables ==
 
       integer kgen
-      _RL mybar(1-olx:snx+olx,1-oly:sny+oly,nsx,nsy)
+      _RL mybar(1-OLx:sNx+OLx,1-OLy:sNy+OLy,nSx,nSy)
 
       _RL mySumTile(nSx,nSy),myVolTile(nSx,nSy)
       _RL mySumGlo,myVolGlo
@@ -45,7 +44,7 @@ c     == local variables ==
       _RL tmpSumGlo
 
       integer bi,bj
-      integer i,j,k
+      integer i,j
       integer nrecloc,irec,il,ioUnit
       character*(80) myfname
       _RL mydummy
@@ -60,10 +59,8 @@ c     == local variables ==
       _RL     tmpVar(1)
 
 c     == external functions ==
-
       integer  ilnblnk
       external ilnblnk
-
       LOGICAL  MASTER_CPU_THREAD
       EXTERNAL MASTER_CPU_THREAD
 
@@ -104,7 +101,7 @@ c read bar field
 #ifdef ALLOW_AUTODIFF
         call active_read_xy( myfname, mybar, irec,
      &                        doglobalread, ladinit,
-     &                        eccoiter, mythid,
+     &                        eccoiter, myThid,
      &                        mydummy )
 #else
         CALL READ_REC_XY_RL( myfname, mybar,
@@ -178,4 +175,5 @@ c ========
 
 #endif /* ALLOW_GENCOST_CONTRIBUTION */
 
+      return
       end

--- a/pkg/ecco/cost_gencost_moc.F
+++ b/pkg/ecco/cost_gencost_moc.F
@@ -1,6 +1,6 @@
 #include "ECCO_OPTIONS.h"
 
-      subroutine cost_gencost_moc(mythid)
+      subroutine cost_gencost_moc(myThid)
 
 c     ==================================================================
 c     SUBROUTINE cost_gencost_moc
@@ -31,23 +31,21 @@ c     == global variables ==
 #endif
 
 c     == routine arguments ==
-      integer mythid
+      integer myThid
 
 #ifdef ALLOW_GENCOST_CONTRIBUTION
 
 c     == local variables ==
 
-c      integer nnzobs, nnzbar
-      integer nrecloc, localrec, ioUnit
+      integer nrecloc, ioUnit
 
-      _RL mybar     (1-olx:snx+olx,1-oly:sny+oly,nr,nsx,nsy)
+      _RL mybar     (1-OLx:sNx+OLx,1-OLy:sNy+OLy,Nr,nSx,nSy)
       _RL gencost_mskTemporal
       _RL tmpVar(1), dummyRL
       _RS dummyRS(1)
-      _RL tmpCumSumTile(nr,nSx,nSy)
+      _RL tmpCumSumTile(Nr,nSx,nSy)
       _RL tmpNumTile(nSx,nSy)
-      _RL tmpCumSumGlo(nr)
-      _RL tmpNumGlo
+      _RL tmpCumSumGlo(Nr)
       _RL tmpTile(nSx,nSy)
       _RL myTempMax
 
@@ -76,10 +74,10 @@ c     == external functions ==
 
 c     == end of interface ==
 
-      jtlo = mybylo(mythid)
-      jthi = mybyhi(mythid)
-      itlo = mybxlo(mythid)
-      ithi = mybxhi(mythid)
+      jtlo = myByLo(myThid)
+      jthi = myByHi(myThid)
+      itlo = myBxLo(myThid)
+      ithi = myBxHi(myThid)
       imin = 1
       imax = sNx
       jmin = 1
@@ -135,11 +133,11 @@ c-- Read barfile
 #ifdef ALLOW_AUTODIFF
           call active_read_xyz( mybarfile, mybar, irec,
      &                       doglobalread, ladinit,
-     &                       eccoiter, mythid,
+     &                       eccoiter, myThid,
      &                       dummyRL )
 #else
           call READ_REC_XYZ_RL( mybarfile, mybar, irec,
-     &                       1, mythid )
+     &                       1, myThid )
 #endif /* ALLOW_AUTODIFF */
 
 c-- Initialize after read
@@ -221,7 +219,7 @@ c-- Compute global sum at each level
               ENDDO
             ENDDO
             tmpCumSumGlo(k) = 0. _d 0
-            CALL GLOBAL_SUM_TILE_RL(tmpTile, tmpCumSumGlo(k),  myThid )
+            CALL GLOBAL_SUM_TILE_RL(tmpTile, tmpCumSumGlo(k), myThid )
           enddo
 
 c=============== PART 2.2: Get max val ===================

--- a/pkg/ecco/cost_obcs_ageos.F
+++ b/pkg/ecco/cost_obcs_ageos.F
@@ -57,6 +57,7 @@ c     == routine arguments ==
      defined (ALLOW_OBCS) && \
      defined (ALLOW_ECCO))
 
+#ifdef OBCS_AGEOS_COST_CONTRIBUTION
 c     == local variables ==
 
       integer bi,bj
@@ -77,15 +78,15 @@ c     == local variables ==
       _RL fctile
       _RL fcthread
 
-      _RL rholoc (1-olx:snx+olx,1-oly:sny+oly,nsx,nsy)
-      _RL xzgrdrho(1-olx:snx+olx,Nr,nsx,nsy)
-      _RL yzgrdrho(1-oly:sny+oly,Nr,nsx,nsy)
-      _RL xzdvel1   (1-olx:snx+olx,nr,nsx,nsy)
-      _RL xzdvel2   (1-olx:snx+olx,nr,nsx,nsy)
-      _RL yzdvel1   (1-oly:sny+oly,nr,nsx,nsy)
-      _RL yzdvel2   (1-oly:sny+oly,nr,nsx,nsy)
-      _RL maskxzageos   (1-olx:snx+olx,nr,nsx,nsy)
-      _RL maskyzageos   (1-oly:sny+oly,nr,nsx,nsy)
+      _RL rholoc (1-OLx:sNx+OLx,1-OLy:sNy+OLy,nSx,nSy)
+      _RL xzgrdrho(1-OLx:sNx+OLx,Nr,nSx,nSy)
+      _RL yzgrdrho(1-OLy:sNy+OLy,Nr,nSx,nSy)
+      _RL xzdvel1   (1-OLx:sNx+OLx,Nr,nSx,nSy)
+      _RL xzdvel2   (1-OLx:sNx+OLx,Nr,nSx,nSy)
+      _RL yzdvel1   (1-OLy:sNy+OLy,Nr,nSx,nSy)
+      _RL yzdvel2   (1-OLy:sNy+OLy,Nr,nSx,nSy)
+      _RL maskxzageos   (1-OLx:sNx+OLx,Nr,nSx,nSy)
+      _RL maskyzageos   (1-OLy:sNy+OLy,Nr,nSx,nSy)
       _RL dummy
 
       character*(80) fnametheta
@@ -105,20 +106,18 @@ c     == external functions ==
 
 c     == end of interface ==
 
-      jtlo = mybylo(mythid)
-      jthi = mybyhi(mythid)
-      itlo = mybxlo(mythid)
-      ithi = mybxhi(mythid)
+      jtlo = myByLo(mythid)
+      jthi = myByHi(mythid)
+      itlo = myBxLo(mythid)
+      ithi = myBxHi(mythid)
       jmin = 1
-      jmax = sny
+      jmax = sNy
       imin = 1
-      imax = snx
+      imax = sNx
 
 c--   Read tiled data.
       doglobalread = .false.
       ladinit      = .false.
-
-#ifdef OBCS_AGEOS_COST_CONTRIBUTION
 
 #ifdef ECCO_VERBOSE
       _BEGIN_MASTER( mythid )
@@ -133,7 +132,7 @@ c--   Read tiled data.
         call print_message( msgbuf, standardmessageunit,
      &                      SQUEEZE_RIGHT , mythid)
       _END_MASTER( mythid )
-#endif
+#endif /* ECCO_VERBOSE */
 
       if (optimcycle .ge. 0) then
         iltheta = ilnblnk( tbarfile )
@@ -156,14 +155,14 @@ c--   Read tiled data.
 cgg   Code safe: always initialize to zero.
       do bj = jtlo,jthi
         do bi = itlo,ithi
-          do k = 1,nr
-            do i = 1-olx,snx+olx
+          do k = 1,Nr
+            do i = 1-OLx,sNx+OLx
               maskxzageos(i,k,bi,bj) = 0. _d 0
               xzdvel1(i,k,bi,bj)     = 0. _d 0
               xzdvel2(i,k,bi,bj)     = 0. _d 0
               xzgrdrho(i,k,bi,bj)    = 0. _d 0
             enddo
-            do j = 1-oly,sny+oly
+            do j = 1-OLy,sNy+OLy
               maskyzageos(j,k,bi,bj) = 0. _d 0
               yzdvel1(j,k,bi,bj)     = 0. _d 0
               yzdvel2(j,k,bi,bj)     = 0. _d 0
@@ -175,8 +174,8 @@ cgg   Code safe: always initialize to zero.
 
       do bj = jtlo,jthi
         do bi = itlo,ithi
-          do j = 1-oly,sny+oly
-            do i = 1-olx,snx+olx
+          do j = 1-OLy,sNy+OLy
+            do i = 1-OLx,sNx+OLx
               rholoc(i,j,bi,bj) = 0. _d 0
             enddo
           enddo
@@ -215,7 +214,6 @@ cgg     Minor problem : grad T,S needs overlap values.
         _EXCH_XYZ_RL(tbar,myThid)
         _EXCH_XYZ_RL(sbar,myThid)
 
-
         do bj = jtlo,jthi
           do bi = itlo,ithi
 
@@ -223,7 +221,7 @@ cgg     Minor problem : grad T,S needs overlap values.
             jp1 = 0
 
 cgg    Make a mask for the velocity shear comparison.
-            do k = 1,nr-1
+            do k = 1,Nr-1
               do i = imin, imax
                 j = OB_Jn(i,bi,bj)
 cgg    All these points need to be wet.
@@ -239,7 +237,7 @@ cgg    All these points need to be wet.
               enddo
             enddo
 
-            do k = 1,nr
+            do k = 1,Nr
 
 C-- jmc: both calls below are wrong if more than 1 tile => stop here
        IF ( bi.NE.1 .OR. bj.NE.1 )
@@ -292,7 +290,7 @@ c--         End of loop over layers.
             jp1 = 1
 
 cgg    Make a mask for the velocity shear comparison.
-            do k = 1,nr-1
+            do k = 1,Nr-1
               do i = imin, imax
                 j = OB_Js(i,bi,bj)
                 if ( j.eq.OB_indexNone ) then
@@ -308,7 +306,7 @@ cgg    All these points need to be wet.
               enddo
             enddo
 
-            do k = 1,nr
+            do k = 1,Nr
 
 C-- jmc: both calls below are wrong if more than 1 tile => stop here
        IF ( bi.NE.1 .OR. bj.NE.1 )
@@ -355,13 +353,13 @@ cgg        print*,'fctile S',fctile
               enddo
             enddo
 c--         End of loop over layers.
-#endif
+#endif /* ALLOW_OBCSS_CONTROL */
 
 #ifdef ALLOW_OBCSW_CONTROL
             ip1 = 1
 
 cgg    Make a mask for the velocity shear comparison.
-            do k = 1,nr-1
+            do k = 1,Nr-1
               do j = jmin, jmax
                 i = OB_Iw(j,bi,bj)
 cgg    All these points need to be wet.
@@ -377,7 +375,7 @@ cgg    All these points need to be wet.
               enddo
             enddo
 
-            do k = 1,nr
+            do k = 1,Nr
 
        IF ( bi.NE.1 .OR. bj.NE.1 )
      &  STOP 'COST_OBCS_AGEOS wrong with more than 1 tile/proc'
@@ -422,13 +420,13 @@ cgg   Make a comparison.
               enddo
             enddo
 c--         End of loop over layers.
-#endif
+#endif /* ALLOW_OBCSW_CONTROL */
 
 #ifdef ALLOW_OBCSE_CONTROL
             ip1 = 0
 
 cgg    Make a mask for the velocity shear comparison.
-            do k = 1,nr-1
+            do k = 1,Nr-1
               do j = jmin, jmax
                 i = OB_Ie(j,bi,bj)
                 if ( i.eq.OB_indexNone ) then
@@ -444,7 +442,7 @@ cgg    All these points need to be wet.
               enddo
             enddo
 
-            do k = 1,nr
+            do k = 1,Nr
 
        IF ( bi.NE.1 .OR. bj.NE.1 )
      &  STOP 'COST_OBCS_AGEOS wrong with more than 1 tile/proc'
@@ -490,7 +488,7 @@ cgg   Make a comparison.
               enddo
             enddo
 c--         End of loop over layers.
-#endif
+#endif /* ALLOW_OBCSE_CONTROL */
 
             fcthread          = fcthread          + fctile
             objf_ageos(bi,bj) = objf_ageos(bi,bj) + fctile
@@ -512,7 +510,7 @@ c--         Print cost function for each tile in each thread.
             write(msgbuf,'(a)') ' '
             call print_message( msgbuf, standardmessageunit,
      &                          SQUEEZE_RIGHT , mythid)
-#endif
+#endif /* ECCO_VERBOSE */
 
           enddo
         enddo
@@ -535,12 +533,12 @@ c--     Print cost function for all tiles.
         write(msgbuf,'(a)') ' '
         call print_message( msgbuf, standardmessageunit,
      &                      SQUEEZE_RIGHT , mythid)
-#endif
+#endif /* ECCO_VERBOSE */
 
       enddo
 c--   End of loop over records.
 
-#endif
+#endif /* OBCS_AGEOS_COST_CONTRIBUTION */
 
 #endif /* ALLOW_CTRL, ALLOW_OBCS and ALLOW_ECCO */
 

--- a/pkg/ecco/cost_obcse.F
+++ b/pkg/ecco/cost_obcse.F
@@ -11,8 +11,7 @@ C     !INTERFACE:
      I                       mytime,
      I                       startrec,
      I                       endrec,
-     I                       mythid
-     &                     )
+     I                       mythid )
 
 C     !DESCRIPTION: \bv
 c     ==================================================================
@@ -31,7 +30,6 @@ C     !USES:
       implicit none
 
 c     == global variables ==
-
 #include "EEPARAMS.h"
 #include "SIZE.h"
 #include "PARAMS.h"
@@ -53,12 +51,11 @@ c#endif
 
 C     !INPUT/OUTPUT PARAMETERS:
 c     == routine arguments ==
-
       integer myiter
       _RL     mytime
-      integer mythid
       integer startrec
       integer endrec
+      integer mythid
 
 #if (defined (ALLOW_CTRL) && defined (ALLOW_OBCS))
 
@@ -70,49 +67,33 @@ c     == external functions ==
 
 C     !LOCAL VARIABLES:
 c     == local variables ==
-
       integer bi,bj
       integer j,k
-      integer itlo,ithi
-      integer jtlo,jthi
       integer jmin,jmax
-      integer imin,imax
       integer irec
-      integer il
       integer iobcs
-c     integer i, ip1
       integer nrec
       integer ilfld
       integer igg
-
       _RL fctile
       _RL fcthread
       _RL dummy
       _RL gg
       _RL tmpx
 cgg(
-      _RL tmpfield (1-oly:sny+oly,nr,nsx,nsy)
-      _RL maskyz   (1-oly:sny+oly,nr,nsx,nsy)
-
+      _RL tmpfield (1-OLy:sNy+OLy,Nr,nSx,nSy)
+      _RL maskyz   (1-OLy:sNy+OLy,Nr,nSx,nSy)
       character*(80) fnamefld
-
       logical doglobalread
       logical ladinit
-
 #ifdef ECCO_VERBOSE
       character*(MAX_LEN_MBUF) msgbuf
 #endif
 c     == end of interface ==
 CEOP
 
-      jtlo = mybylo(mythid)
-      jthi = mybyhi(mythid)
-      itlo = mybxlo(mythid)
-      ithi = mybxhi(mythid)
       jmin = 1
-      jmax = sny
-      imin = 1
-      imax = snx
+      jmax = sNy
 
 c--   Read tiled data.
       doglobalread = .false.
@@ -166,8 +147,8 @@ cgg    Need to solve for iobcs would have been.
      &                         mythid, dummy )
 
 c--     Loop over this thread s tiles.
-        do bj = jtlo,jthi
-          do bi = itlo,ithi
+        do bj = myByLo(myThid), myByHi(myThid)
+          do bi = myBxLo(myThid), myBxHi(myThid)
 
 c--         Determine the weights to be used.
             fctile = 0. _d 0

--- a/pkg/ecco/cost_obcsn.F
+++ b/pkg/ecco/cost_obcsn.F
@@ -11,8 +11,7 @@ C     !INTERFACE:
      I                       mytime,
      I                       startrec,
      I                       endrec,
-     I                       mythid
-     &                     )
+     I                       mythid )
 
 C     !DESCRIPTION: \bv
 c     ==================================================================
@@ -31,7 +30,6 @@ C     !USES:
       implicit none
 
 c     == global variables ==
-
 #include "EEPARAMS.h"
 #include "SIZE.h"
 #include "PARAMS.h"
@@ -53,12 +51,11 @@ c#endif
 
 C     !INPUT/OUTPUT PARAMETERS:
 c     == routine arguments ==
-
       integer myiter
       _RL     mytime
-      integer mythid
       integer startrec
       integer endrec
+      integer mythid
 
 #if (defined (ALLOW_CTRL) && defined (ALLOW_OBCS))
 
@@ -70,47 +67,32 @@ c     == external functions ==
 
 C     !LOCAL VARIABLES:
 c     == local variables ==
-
       integer bi,bj
       integer i,k
-      integer itlo,ithi
-      integer jtlo,jthi
-      integer jmin,jmax
       integer imin,imax
       integer irec
       integer iobcs
-c     integer j, jp1
       integer nrec
       integer ilfld
       integer igg
-
       _RL fctile
       _RL fcthread
       _RL dummy
       _RL gg
       _RL tmpx
-      _RL tmpfield (1-olx:snx+olx,nr,nsx,nsy)
-      _RL maskxz   (1-olx:snx+olx,nr,nsx,nsy)
-
+      _RL tmpfield (1-OLx:sNx+OLx,Nr,nSx,nSy)
+      _RL maskxz   (1-OLx:sNx+OLx,Nr,nSx,nSy)
       character*(80) fnamefld
-
       logical doglobalread
       logical ladinit
-
 #ifdef ECCO_VERBOSE
       character*(MAX_LEN_MBUF) msgbuf
 #endif
 c     == end of interface ==
 CEOP
 
-      jtlo = mybylo(mythid)
-      jthi = mybyhi(mythid)
-      itlo = mybxlo(mythid)
-      ithi = mybxhi(mythid)
-      jmin = 1
-      jmax = sny
       imin = 1
-      imax = snx
+      imax = sNx
 
 c--   Read tiled data.
       doglobalread = .false.
@@ -164,8 +146,8 @@ cgg    Need to solve for iobcs would have been.
      &                         mythid, dummy )
 
 c--     Loop over this thread s tiles.
-        do bj = jtlo,jthi
-          do bi = itlo,ithi
+        do bj = myByLo(myThid), myByHi(myThid)
+          do bi = myBxLo(myThid), myBxHi(myThid)
 
 c--         Determine the weights to be used.
             fctile = 0. _d 0

--- a/pkg/ecco/cost_obcss.F
+++ b/pkg/ecco/cost_obcss.F
@@ -11,8 +11,7 @@ C     !INTERFACE:
      I                       mytime,
      I                       startrec,
      I                       endrec,
-     I                       mythid
-     &                     )
+     I                       mythid )
 
 C     !DESCRIPTION: \bv
 c     ==================================================================
@@ -31,7 +30,6 @@ C     !USES:
       implicit none
 
 c     == global variables ==
-
 #include "EEPARAMS.h"
 #include "SIZE.h"
 #include "PARAMS.h"
@@ -53,12 +51,11 @@ c#endif
 
 C     !INPUT/OUTPUT PARAMETERS:
 c     == routine arguments ==
-
       integer myiter
       _RL     mytime
-      integer mythid
       integer startrec
       integer endrec
+      integer mythid
 
 #if (defined (ALLOW_CTRL) && defined (ALLOW_OBCS))
 
@@ -70,47 +67,32 @@ c     == external functions ==
 
 C     !LOCAL VARIABLES:
 c     == local variables ==
-
       integer bi,bj
       integer i,k
-      integer itlo,ithi
-      integer jtlo,jthi
-      integer jmin,jmax
       integer imin,imax
       integer irec
       integer iobcs
-c     integer j, jp1
       integer nrec
       integer ilfld
       integer igg
-
       _RL fctile
       _RL fcthread
       _RL dummy
       _RL gg
       _RL tmpx
-      _RL tmpfield (1-olx:snx+olx,nr,nsx,nsy)
-      _RL maskxz   (1-olx:snx+olx,nr,nsx,nsy)
-
+      _RL tmpfield (1-OLx:sNx+OLx,Nr,nSx,nSy)
+      _RL maskxz   (1-OLx:sNx+OLx,Nr,nSx,nSy)
       character*(80) fnamefld
-
       logical doglobalread
       logical ladinit
-
 #ifdef ECCO_VERBOSE
       character*(MAX_LEN_MBUF) msgbuf
 #endif
 c     == end of interface ==
 CEOP
 
-      jtlo = mybylo(mythid)
-      jthi = mybyhi(mythid)
-      itlo = mybxlo(mythid)
-      ithi = mybxhi(mythid)
-      jmin = 1
-      jmax = sny
       imin = 1
-      imax = snx
+      imax = sNx
 
 c--   Read tiled data.
       doglobalread = .false.
@@ -164,10 +146,9 @@ cgg          print*,'S IREC, IOBCS',irec, iobcs
      &                         doglobalread, ladinit, 0,
      &                         mythid, dummy )
 
-
 c--     Loop over this thread s tiles.
-        do bj = jtlo,jthi
-          do bi = itlo,ithi
+        do bj = myByLo(myThid), myByHi(myThid)
+          do bi = myBxLo(myThid), myBxHi(myThid)
 
 c--         Determine the weights to be used.
             fctile = 0. _d 0

--- a/pkg/ecco/cost_obcsvol.F
+++ b/pkg/ecco/cost_obcsvol.F
@@ -8,8 +8,7 @@
      I                       mytime,
      I                       startrec,
      I                       endrec,
-     I                       mythid
-     &                     )
+     I                       mythid )
 
 c     ==================================================================
 c     SUBROUTINE cost_obcsvol
@@ -47,17 +46,21 @@ c     == global variables ==
 #endif
 
 c     == routine arguments ==
-
       integer myiter
       _RL     mytime
-      integer mythid
       integer startrec
       integer endrec
+      integer mythid
 
 #if (defined (ALLOW_CTRL) && defined (ALLOW_OBCS))
 
-c     == local variables ==
+#ifdef OBCS_VOLFLUX_COST_CONTRIBUTION
+#ifdef BAROTROPIC_OBVEL_CONTROL
+c     == external functions ==
+      integer  ilnblnk
+      external ilnblnk
 
+c     == local variables ==
       integer bi,bj
       integer i,j,k
       integer itlo,ithi
@@ -69,7 +72,6 @@ c     == local variables ==
       integer nrec
       integer ilfld
       integer igg
-
       _RL fctile
       _RL sumvol
       _RL gg
@@ -80,41 +82,30 @@ c     == local variables ==
       character*(80) fnameflds
       character*(80) fnamefldw
       character*(80) fnameflde
-
 #if (defined ALLOW_OBCSN_CONTROL || defined ALLOW_OBCSS_CONTROL)
-      _RL tmpfldxz (1-olx:snx+olx,nr,nsx,nsy)
+      _RL tmpfldxz (1-OLx:sNx+OLx,Nr,nSx,nSy)
 #endif
 #if (defined ALLOW_OBCSE_CONTROL || defined ALLOW_OBCSW_CONTROL)
-      _RL tmpfldyz (1-oly:sny+oly,nr,nsx,nsy)
+      _RL tmpfldyz (1-OLy:sNy+OLy,Nr,nSx,nSy)
 #endif
-
       logical doglobalread
       logical ladinit
-
 #ifdef ECCO_VERBOSE
       character*(MAX_LEN_MBUF) msgbuf
 #endif
 
-c     == external functions ==
-
-      integer  ilnblnk
-      external ilnblnk
-
 c     == end of interface ==
-
-#ifdef OBCS_VOLFLUX_COST_CONTRIBUTION
-#ifdef BAROTROPIC_OBVEL_CONTROL
 
       stop 's/r cost_obcsvol needs to be fixed'
 
-      jtlo = mybylo(mythid)
-      jthi = mybyhi(mythid)
-      itlo = mybxlo(mythid)
-      ithi = mybxhi(mythid)
+      jtlo = myByLo(mythid)
+      jthi = myByHi(mythid)
+      itlo = myBxLo(mythid)
+      ithi = myBxHi(mythid)
       jmin = 1
-      jmax = sny
+      jmax = sNy
       imin = 1
-      imax = snx
+      imax = sNx
 
 c--   Read tiled data.
       doglobalread = .false.
@@ -365,8 +356,8 @@ c--   Do the global summation.
       _GLOBAL_SUM_RL( sumvol, mythid )
       objf_obcsvol =  wobcsvol * sumvol* sumvol
 
-#endif
-#endif
+#endif /* BAROTROPIC_OBVEL_CONTROL */
+#endif /* OBCS_VOLFLUX_COST_CONTRIBUTION */
 
 #endif /* ALLOW_CTRL and ALLOW_OBCS */
 

--- a/pkg/ecco/cost_obcsw.F
+++ b/pkg/ecco/cost_obcsw.F
@@ -11,8 +11,7 @@ C     !INTERFACE:
      I                       mytime,
      I                       startrec,
      I                       endrec,
-     I                       mythid
-     &                     )
+     I                       mythid )
 
 C     !DESCRIPTION: \bv
 c     ==================================================================
@@ -31,7 +30,6 @@ C     !USES:
       implicit none
 
 c     == global variables ==
-
 #include "EEPARAMS.h"
 #include "SIZE.h"
 #include "PARAMS.h"
@@ -53,12 +51,11 @@ c#endif
 
 C     !INPUT/OUTPUT PARAMETERS:
 c     == routine arguments ==
-
       integer myiter
       _RL     mytime
-      integer mythid
       integer startrec
       integer endrec
+      integer mythid
 
 #if (defined (ALLOW_CTRL) && defined (ALLOW_OBCS))
 
@@ -70,47 +67,32 @@ c     == external functions ==
 
 C     !LOCAL VARIABLES:
 c     == local variables ==
-
       integer bi,bj
       integer j,k
-      integer itlo,ithi
-      integer jtlo,jthi
       integer jmin,jmax
-      integer imin,imax
       integer irec
       integer iobcs
-c     integer i, ip1
       integer nrec
       integer ilfld
       integer igg
-
       _RL fctile
       _RL fcthread
       _RL dummy
       _RL gg
       _RL tmpx
-      _RL tmpfield (1-oly:sny+oly,nr,nsx,nsy)
-      _RL maskyz   (1-oly:sny+oly,nr,nsx,nsy)
-
+      _RL tmpfield (1-OLy:sNy+OLy,Nr,nSx,nSy)
+      _RL maskyz   (1-OLy:sNy+OLy,Nr,nSx,nSy)
       character*(80) fnamefld
-
       logical doglobalread
       logical ladinit
-
 #ifdef ECCO_VERBOSE
       character*(MAX_LEN_MBUF) msgbuf
 #endif
 c     == end of interface ==
 CEOP
 
-      jtlo = mybylo(mythid)
-      jthi = mybyhi(mythid)
-      itlo = mybxlo(mythid)
-      ithi = mybxhi(mythid)
       jmin = 1
-      jmax = sny
-      imin = 1
-      imax = snx
+      jmax = sNy
 
 c--   Read tiled data.
       doglobalread = .false.
@@ -164,8 +146,8 @@ cgg    Need to solve for iobcs would have been.
      &                         mythid, dummy )
 
 c--     Loop over this thread s tiles.
-        do bj = jtlo,jthi
-          do bi = itlo,ithi
+        do bj = myByLo(myThid), myByHi(myThid)
+          do bi = myBxLo(myThid), myBxHi(myThid)
 
 c--         Determine the weights to be used.
             fctile = 0. _d 0

--- a/pkg/ecco/cost_sla_read.F
+++ b/pkg/ecco/cost_sla_read.F
@@ -1,6 +1,7 @@
 #include "ECCO_OPTIONS.h"
 
-      subroutine cost_sla_read( sla_file, sla_startdate, sla_period,
+      subroutine cost_sla_read(
+     I                sla_file, sla_startdate, sla_period,
      I                sla_intercept, sla_slope,
      O                sla_obs, sla_mask,
      I                irec, myThid )
@@ -31,12 +32,21 @@ c     == global variables ==
 #include "ECCO.h"
 
 c     == routine arguments ==
-
+      character*(MAX_LEN_FNAM) sla_file
+      integer sla_startdate(4)
+      _RL sla_period
+      _RL sla_intercept
+      _RL sla_slope
+      _RL sla_obs (1-OLx:sNx+OLx,1-OLy:sNy+OLy,nSx,nSy)
+      _RL sla_mask(1-OLx:sNx+OLx,1-OLy:sNy+OLy,nSx,nSy)
       integer irec
       integer myThid
 
-c     == local variables ==
+c     == external functions ==
+      integer  ilnblnk
+      external ilnblnk
 
+c     == local variables ==
       integer bi,bj
       integer i,j,k
       integer itlo,ithi
@@ -47,19 +57,9 @@ c     == local variables ==
       integer difftime(4)
       integer tempDate_1
       integer middate(4)
-      integer noffset
       _RL diffsecs
       _RL spval
       _RL factor
-
-      integer sla_startdate(4)
-      _RL sla_period
-      _RL sla_intercept
-      _RL sla_slope
-      _RL sla_obs    (1-OLx:sNx+OLx,1-OLy:sNy+OLy,   nSx,nSy)
-      _RL sla_mask   (1-OLx:sNx+OLx,1-OLy:sNy+OLy,   nSx,nSy)
-      character*(MAX_LEN_FNAM) sla_file
-
 cnew(
       integer  il
       _RL daytime
@@ -70,11 +70,6 @@ cnew(
       character*(80) fnametmp
       logical exst
 cnew)
-
-c     == external functions ==
-
-      integer  ilnblnk
-      external ilnblnk
 
 c     == end of interface ==
 

--- a/pkg/ecco/cost_sla_read_yd.F
+++ b/pkg/ecco/cost_sla_read_yd.F
@@ -1,10 +1,11 @@
 #include "ECCO_OPTIONS.h"
 
-      subroutine cost_sla_read_yd( sla_file, sla_startdate,
+      subroutine cost_sla_read_yd(
+     I                sla_file, sla_startdate,
 c     I                sla_startdate, sla_period,
 c     I                sla_intercept, sla_slope,
      O                sla_obs, sla_mask,
-     I                year,day, myThid )
+     I                year, day, myThid )
 
 c     ==================================================================
 c     SUBROUTINE cost_sla_read_yd
@@ -32,52 +33,36 @@ c     == global variables ==
 #include "ECCO.h"
 
 c     == routine arguments ==
-
-      integer year,day
+      character*(MAX_LEN_FNAM) sla_file
+      integer sla_startdate(4)
+c     _RL sla_period
+c     _RL sla_intercept
+c     _RL sla_slope
+      _RL sla_obs (1-OLx:sNx+OLx,1-OLy:sNy+OLy,nSx,nSy)
+      _RL sla_mask(1-OLx:sNx+OLx,1-OLy:sNy+OLy,nSx,nSy)
+      integer year, day
       integer myThid
 
-      integer sla_startdate(4)
-      _RL sla_period
-      _RL sla_intercept
-      _RL sla_slope
-      _RL sla_obs    (1-OLx:sNx+OLx,1-OLy:sNy+OLy,   nSx,nSy)
-      _RL sla_mask   (1-OLx:sNx+OLx,1-OLy:sNy+OLy,   nSx,nSy)
-      character*(MAX_LEN_FNAM) sla_file
+c     == external functions ==
+      integer  ilnblnk
+      external ilnblnk
+      integer  cal_IsLeap
+      external cal_IsLeap
 
 c     == local variables ==
-
       integer bi,bj
       integer i,j,k
       integer itlo,ithi
       integer jtlo,jthi
       integer jmin,jmax
       integer imin,imax
-      integer sshrec
-      integer difftime(4)
-      integer middate(4)
-      integer noffset
-      _RL diffsecs
       _RL spval
       _RL factor
-
 cnew(
       integer  il
-      _RL daytime
-      integer dayiter
-      integer daydate(4)
-      integer yday, ymod
-      integer md, dd, sd, ld, wd
       character*(80) fnametmp
       logical exst
 cnew)
-
-c     == external functions ==
-
-      integer  ilnblnk
-      external ilnblnk
-
-      integer  cal_IsLeap
-      external cal_IsLeap
 
 c     == end of interface ==
 

--- a/pkg/ecco/ecco_check.F
+++ b/pkg/ecco/ecco_check.F
@@ -44,9 +44,9 @@ C     === Local variables ===
 C     msgBuf      - Informational/error message buffer
       CHARACTER*(MAX_LEN_MBUF) msgBuf
 #ifdef ALLOW_GENCOST_CONTRIBUTION
-      INTEGER igen_etaday, il, k2, ioUnit
+      INTEGER igen_etaday, il
       LOGICAL exst
-      CHARACTER*(128) tempfile,tempfile1
+      CHARACTER*(128) tempfile
       INTEGER icount_transp
 #endif
 

--- a/pkg/ecco/ecco_cost.h
+++ b/pkg/ecco/ecco_cost.h
@@ -1317,7 +1317,6 @@ c     driftfile     - reference data file for drifter mean velocities
       character*(MAX_LEN_FNAM) xbtfile
       character*(MAX_LEN_FNAM) argotfile
       character*(MAX_LEN_FNAM) argosfile
-      character*(MAX_LEN_FNAM) argofile
       character*(MAX_LEN_FNAM) usercost_datafile(NUSERCOST)
       character*(MAX_LEN_FNAM) udriftfile
       character*(MAX_LEN_FNAM) vdriftfile

--- a/pkg/ecco/ecco_cost_final.F
+++ b/pkg/ecco/ecco_cost_final.F
@@ -3,7 +3,7 @@
 # include "CTRL_OPTIONS.h"
 #endif
 
-      subroutine ecco_cost_final( mythid )
+      subroutine ecco_cost_final( myThid )
 
 c     ==================================================================
 c     SUBROUTINE cost_final
@@ -50,20 +50,19 @@ c     == global variables ==
 
 c     == routine arguments ==
 
-      integer mythid
+      integer myThid
 
 C     === Functions ====
       LOGICAL  MASTER_CPU_THREAD
       EXTERNAL MASTER_CPU_THREAD
+      INTEGER  ILNBLNK
+      EXTERNAL ILNBLNK
 
 c     == local variables ==
 
       integer bi,bj
-      integer itlo,ithi
-      integer jtlo,jthi
       integer ifc
-      integer totnum
-      integer num_file,num_var
+      integer num_var
 
 #ifndef ALLOW_PROFILES
       integer NFILESPROFMAX
@@ -159,6 +158,7 @@ c the adjoint, pkg/autodiff most likely require cost though.
       _RL no_obcsn, no_obcss, no_obcsw, no_obcse, no_ageos
 #endif
 #ifdef ALLOW_PROFILES
+      integer num_file
       _RL no_profiles(NFILESPROFMAX,NVARMAX)
       _RL no_profiles_mean(NVARMAX)
 #endif
@@ -176,15 +176,8 @@ c the adjoint, pkg/autodiff most likely require cost though.
       character*(MAX_LEN_MBUF) msgBuf
 
       INTEGER IL
-C Functions
-      INTEGER ILNBLNK
 
 c     == end of interface ==
-
-      jtlo = mybylo(mythid)
-      jthi = mybyhi(mythid)
-      itlo = mybxlo(mythid)
-      ithi = mybxhi(mythid)
 
       ifc = 30
 
@@ -425,8 +418,8 @@ c     == end of interface ==
 #endif
 
 c--   Sum up all contributions.
-      do bj = jtlo,jthi
-        do bi = itlo,ithi
+      DO bj = myByLo(myThid), myByHi(myThid)
+       DO bi = myBxLo(myThid), myBxHi(myThid)
 
           tile_fc(bi,bj) = tile_fc(bi,bj)
 #ifdef ECCO_CTRL_DEPRECATED
@@ -800,8 +793,9 @@ c--   Sum up all contributions.
        enddo
 #endif
 
-        enddo
-      enddo
+C-   end bi,bj loops
+       ENDDO
+      ENDDO
 
 c local copy used in print statements, for
 c which we always want to do the global sum.
@@ -1229,7 +1223,7 @@ c--   Do global summation for each part of the cost function
      &     ' --> f_profiles =',f_profiles(num_file,num_var),
      &      num_file, num_var
          call print_message( msgBuf, standardmessageunit,
-     &                       SQUEEZE_RIGHT , mythid)
+     &                       SQUEEZE_RIGHT, myThid )
         endif
        enddo
       enddo
@@ -1239,7 +1233,7 @@ c--   Do global summation for each part of the cost function
      &     ' --> f_profiles_mean =',f_profiles_mean(num_var),
      &      num_var
          call print_message( msgBuf, standardmessageunit,
-     &                       SQUEEZE_RIGHT , mythid)
+     &                       SQUEEZE_RIGHT, myThid )
         endif
       enddo
       endif
@@ -1251,7 +1245,7 @@ c--   Do global summation for each part of the cost function
      &     ' --> f_gencost =',f_gencost(num_var),
      &      num_var
          call print_message( msgBuf, standardmessageunit,
-     &                       SQUEEZE_RIGHT , mythid)
+     &                       SQUEEZE_RIGHT, myThid )
         endif
        enddo
 #endif
@@ -1262,7 +1256,7 @@ c--   Do global summation for each part of the cost function
      &     ' --> f_gentim2d =',f_gentim2d(num_var),
      &      num_var
          call print_message( msgBuf, standardmessageunit,
-     &                       SQUEEZE_RIGHT , mythid)
+     &                       SQUEEZE_RIGHT, myThid )
         endif
        enddo
 #endif
@@ -1273,7 +1267,7 @@ c--   Do global summation for each part of the cost function
      &     ' --> f_genarr2d =',f_genarr2d(num_var),
      &      num_var
          call print_message( msgBuf, standardmessageunit,
-     &                       SQUEEZE_RIGHT , mythid)
+     &                       SQUEEZE_RIGHT, myThid )
         endif
        enddo
 #endif
@@ -1284,7 +1278,7 @@ c--   Do global summation for each part of the cost function
      &     ' --> f_genarr3d =',f_genarr3d(num_var),
      &      num_var
          call print_message( msgBuf, standardmessageunit,
-     &                       SQUEEZE_RIGHT , mythid)
+     &                       SQUEEZE_RIGHT, myThid )
         endif
        enddo
 #endif
@@ -1339,7 +1333,7 @@ C     only master thread of master CPU open and write to file
         write(msgBuf,'(A,D22.15)')
      &           ' --> fc               =', locfc
         call print_message( msgBuf, standardmessageunit,
-     &                      SQUEEZE_RIGHT , mythid)
+     &                      SQUEEZE_RIGHT, myThid )
 
         write(cfname,'(A,i4.4)') 'costfunction',eccoiter
         open(unit=ifc,file=cfname)
@@ -1631,17 +1625,17 @@ c#endif /* ECCO_CTRL_DEPRECATED */
       write(msgBuf,'(a,D22.15)')
      &  ' cost_Final: final cost function = ',locfc
       call print_message( msgBuf, standardmessageunit,
-     &                    SQUEEZE_RIGHT , mythid)
+     &                    SQUEEZE_RIGHT, myThid )
       write(msgBuf,'(a)') ' '
       call print_message( msgBuf, standardmessageunit,
-     &                    SQUEEZE_RIGHT , mythid)
+     &                    SQUEEZE_RIGHT, myThid )
       write(msgBuf,'(a)')
      &  '             cost function evaluation finished.'
       call print_message( msgBuf, standardmessageunit,
-     &                    SQUEEZE_RIGHT , mythid)
+     &                    SQUEEZE_RIGHT, myThid )
       write(msgBuf,'(a)') ' '
       call print_message( msgBuf, standardmessageunit,
-     &                    SQUEEZE_RIGHT , mythid)
+     &                    SQUEEZE_RIGHT, myThid )
 #endif
 
       return

--- a/pkg/ecco/ecco_cost_init_barfiles.F
+++ b/pkg/ecco/ecco_cost_init_barfiles.F
@@ -61,7 +61,7 @@ c     == local variables ==
       integer jmin,jmax
       integer imin,imax
 
-      integer ilps, ils, ilt, irec
+      integer ilt, irec
 
 #ifdef ALLOW_GENCOST_CONTRIBUTION
       character*(128) fname_gencostbar
@@ -69,18 +69,22 @@ c     == local variables ==
 #endif /* ALLOW_GENCOST_CONTRIBUTION */
 
 #if (defined ALLOW_SEAICE) && (defined ALLOW_SEAICE_COST_SMR_AREA)
+      integer ilps
       character*(128) fnamesmrareabar
       character*(128) fnamesmrsstbar
       character*(128) fnamesmrsssbar
       character*(128) adfnamesmrareabar
       character*(128) adfnamesmrsstbar
       character*(128) adfnamesmrsssbar
+#elif ( defined ECCO_CTRL_DEPRECATED )
+      integer ilps
 #endif
 
       _RL tmpfld2d (1-olx:snx+olx,1-oly:sny+oly,   nsx,nsy)
       _RL tmpfld3d (1-olx:snx+olx,1-oly:sny+oly,nr,nsx,nsy)
 
 #ifdef ECCO_CTRL_DEPRECATED
+      integer ils
       character*(128) fnamepsbar
       character*(128) fnametbar
       character*(128) fnamesbar
@@ -152,7 +156,7 @@ c     == end of interface ==
       enddo
 
 #ifdef ECCO_CTRL_DEPRECATED
-#
+
 #ifdef ALLOW_SSH_COST_CONTRIBUTION
       IF (using_cost_altim) THEN
 c--   Save psbar on file.

--- a/pkg/ecco/ecco_cost_init_fixed.F
+++ b/pkg/ecco/ecco_cost_init_fixed.F
@@ -61,18 +61,17 @@ c     == local variables ==
 
       integer k
       logical exst
-      _RL     dummy
-      integer tempDate1(4)
-      integer tempDate2(4)
-      integer gwunit
-      integer il, ilo,ihi
-      character*(max_len_mbuf) msgbuf
-      integer irec
       _RL     missingObsFlag
       PARAMETER ( missingObsFlag = 1. _d 23 )
+#if ( defined ECCO_CTRL_DEPRECATED || defined ALLOW_GENCOST_1D )
+      character*(MAX_LEN_MBUF) msgBuf
+      integer ilo, ihi, irec, gwunit
+#endif
+#if ( defined ECCO_CTRL_DEPRECATED && defined ALLOW_TRANSPORT_COST_CONTRIBUTION )
+      _RL     dummy
+#endif
 #ifdef ALLOW_GENCOST_CONTRIBUTION
-      integer bi,bj
-      integer i,j,kk,k2
+      integer k2
 #endif
 
 c     == external functions ==

--- a/pkg/ecco/ecco_cost_init_varia.F
+++ b/pkg/ecco/ecco_cost_init_varia.F
@@ -4,7 +4,7 @@
 # include "CTRL_OPTIONS.h"
 #endif
 
-      subroutine ecco_cost_init_varia( mythid )
+      subroutine ecco_cost_init_varia( myThid )
 
 c     ==================================================================
 c     SUBROUTINE ecco_cost_init_varia
@@ -46,36 +46,25 @@ c     == global variables ==
 #endif
 
 c     == routine arguments ==
-
-      integer mythid
+      integer myThid
 
 c     == local variables ==
-
       integer bi,bj
-      integer itlo,ithi
-      integer jtlo,jthi
       integer imin, imax
       integer jmin, jmax
       integer i,j,k
-      integer num_file,num_var
-
-      logical exst
-
-c     == external functions ==
+c     logical exst
 
 c     == end of interface ==
-      jtlo = mybylo(mythid)
-      jthi = mybyhi(mythid)
-      itlo = mybxlo(mythid)
-      ithi = mybxhi(mythid)
+
       jmin = 1-OLy
-      jmax = sny+OLy
+      jmax = sNy+OLy
       imin = 1-OLx
-      imax = snx+OLy
+      imax = sNx+OLy
 
 c--   Initialise adjoint of monthly mean files calculated
 c--   in cost_averagesfields (and their ad...).
-      call cost_averagesinit( mythid )
+      call cost_averagesinit( myThid )
       _BARRIER
 
 #ifndef ALLOW_TANGENTLINEAR_RUN
@@ -85,13 +74,13 @@ cph   of a divided adjoint run
 cph)
 c      inquire( file='costfinal', exist=exst )
 c      if ( .NOT. exst) then
-c         call ecco_cost_init_barfiles( mythid )
+c         call ecco_cost_init_barfiles( myThid )
 c      endif
 #endif
 
 c--   Initialize the tiled cost function contributions.
-      do bj = jtlo,jthi
-        do bi = itlo,ithi
+      do bj = myByLo(myThid), myByHi(myThid)
+        do bi = myBxLo(myThid), myBxHi(myThid)
 #ifdef ECCO_CTRL_DEPRECATED
           objf_hflux(bi,bj)    = 0. _d 0
           objf_hfluxm(bi,bj)   = 0. _d 0
@@ -257,8 +246,8 @@ c--   Initialize the tiled cost function contributions.
 #ifdef ECCO_CTRL_DEPRECATED
 
       k = 1
-      do bj = jtlo,jthi
-        do bi = itlo,ithi
+      do bj = myByLo(myThid), myByHi(myThid)
+        do bi = myBxLo(myThid), myBxHi(myThid)
           do j = jmin,jmax
             do i = imin,imax
 #ifdef ALLOW_SSH_COST_CONTRIBUTION
@@ -328,8 +317,8 @@ c--   Initialize the tiled cost function contributions.
       enddo
 
 #ifdef GENERIC_BAR_MONTH
-      do bj = jtlo,jthi
-       do bi = itlo,ithi
+      do bj = myByLo(myThid), myByHi(myThid)
+       do bi = myBxLo(myThid), myBxHi(myThid)
         do k =1,Nr
          do j = jmin,jmax
           do i = imin,imax
@@ -343,23 +332,23 @@ c--   Initialize the tiled cost function contributions.
 #endif
 
 c--   Initialise the "global" parts of the cost function.
-      _BEGIN_MASTER( mythid )
+      _BEGIN_MASTER( myThid )
         objf_hmean   = 0. _d 0
         objf_hfluxmm = 0. _d 0
         objf_sfluxmm = 0. _d 0
         objf_transp  = 0. _d 0
         num_hmean   = 0. _d 0
         num_transp  = 0. _d 0
-      _END_MASTER( mythid )
+      _END_MASTER( myThid )
 
 #endif /* ECCO_CTRL_DEPRECATED */
 
 c--   Initialise the "global" parts of the cost function.
 #if (defined (ALLOW_CTRL) && defined (ALLOW_OBCS))
-      _BEGIN_MASTER( mythid )
+      _BEGIN_MASTER( myThid )
         objf_obcsvol = 0. _d 0
         num_obcsvol = 0. _d 0
-      _END_MASTER( mythid )
+      _END_MASTER( myThid )
 #endif
 
       _BARRIER

--- a/pkg/ecco/ecco_local_params.h
+++ b/pkg/ecco/ecco_local_params.h
@@ -181,7 +181,6 @@ c     ==================================================================
       _RL  mult_smooth_bc
       _RL  mult_transp
 
-
       common /ecco_cost_c/
      &                hflux_errfile,
      &                hfluxm_errfile,
@@ -215,7 +214,7 @@ c     ==================================================================
      &                velerrfile,
      &                salt0errfile,
      &                temp0errfile,
-     &                etan0errfile, 
+     &                etan0errfile,
      &                uvel0errfile,
      &                vvel0errfile,
      &                vel0errfile,
@@ -404,7 +403,6 @@ c     ==================================================================
       character*(MAX_LEN_FNAM) xbtfile
       character*(MAX_LEN_FNAM) argotfile
       character*(MAX_LEN_FNAM) argosfile
-      character*(MAX_LEN_FNAM) argofile
       character*(MAX_LEN_FNAM) usercost_datafile(NUSERCOST)
       character*(MAX_LEN_FNAM) udriftfile
       character*(MAX_LEN_FNAM) vdriftfile

--- a/pkg/ecco/ecco_readparms.F
+++ b/pkg/ecco/ecco_readparms.F
@@ -41,17 +41,17 @@ c     == global variables ==
 #endif
 
 c     == routine arguments ==
-      integer myThid
+      INTEGER myThid
 
 c     == external functions ==
-      integer  ilnblnk
-      external ilnblnk
+      INTEGER  ilnblnk
+      EXTERNAL ilnblnk
 
 c     == local variables ==
 C     msgBuf      - Informational/error message buffer
 C     iUnit       - Work variable for IO unit number
       CHARACTER*(MAX_LEN_MBUF) msgBuf
-      INTEGER k, k2, iUnit, num_file, num_var
+      INTEGER k, k2, iUnit
 #ifdef ALLOW_GENCOST_CONTRIBUTION
       INTEGER IL, kk, gencost_k3d, gencost_msk_k3d, ioUnit
       CHARACTER*(128) tempfile
@@ -62,7 +62,7 @@ C     iUnit       - Work variable for IO unit number
 Catn-- retired parameters
       CHARACTER*(MAX_LEN_FNAM) topexmeanfile
       CHARACTER*(2) cost_yftype
-      integer nRetired
+      INTEGER nRetired
 
 c     == end of interface ==
 
@@ -621,7 +621,7 @@ c boxmean/horflux masks
      &          1,zeroRL,myThid)
          call ecco_zero(gencost_mskSsurf(1-OLx,1-OLy,1,1,k),
      &          1,zeroRL,myThid)
-         do k2 = 1,nr
+         do k2 = 1,Nr
           gencost_mskVertical(k2,k)= 1. _d 0
          enddo
 c deprecated:

--- a/pkg/exf/exf_adjoint_snapshots_ad.F
+++ b/pkg/exf/exf_adjoint_snapshots_ad.F
@@ -73,10 +73,6 @@ C     suff   :: Hold suffix part of a filename
 C     msgBuf :: Error message buffer
 c     CHARACTER*(10) suff
 c     CHARACTER*(MAX_LEN_MBUF) msgBuf
-#ifdef ALLOW_MNC
-      _RL var2Du(1-OLx:sNx+OLx,1-OLy:sNy+OLy,nSx,nSy)
-      _RL var2Dv(1-OLx:sNx+OLx,1-OLy:sNy+OLy,nSx,nSy)
-#endif
       _RS dumRS(1)
       _RL dumRL(1)
       INTEGER dumpAdRecEx

--- a/pkg/exf/exf_getclim.F
+++ b/pkg/exf/exf_getclim.F
@@ -71,7 +71,10 @@ c     myThid - thread number for this instance of the routine.
 
 c     == local variables ==
 
-      INTEGER bi, bj, i, j, ks
+      INTEGER ks
+#if (defined ALLOW_CLIMSST_RELAXATION || defined ALLOW_BULK_OFFLINE )
+      INTEGER i, j, bi, bj
+#endif
 #if (defined (ALLOW_CTRL) && defined (ECCO_CTRL_DEPRECATED))
       _RS mask2D(1-OLx:sNx+OLx,1-OLy:sNy+OLy,nSx,nSy)
 #endif
@@ -110,10 +113,9 @@ CADJ STORE climsst      = comlev1, key=ikey_dynamics, kind=isbyte
         ENDDO
        ENDDO
       ENDDO
-
 c--   Update the tile edges.
       _EXCH_XY_RL(climsst, myThid)
-#endif
+#endif /* ALLOW_CLIMSST_RELAXATION */
 
 #if (defined (ALLOW_CTRL) && defined (ECCO_CTRL_DEPRECATED))
 # ifdef ALLOW_SST_CONTROL
@@ -139,7 +141,6 @@ c     Get values of climatological sss fields.
      I     climsss_nlon, climsss_nlat, xC, yC, climsss_interpMethod,
 #endif
      I     myTime, myIter, myThid )
-
 c--   Update the tile edges.
       _EXCH_XY_RL(climsss, myThid)
 #endif

--- a/pkg/gmredi/gmredi_slope_limit.F
+++ b/pkg/gmredi/gmredi_slope_limit.F
@@ -95,25 +95,26 @@ C     dSigmaDr    :: vertical gradient of density
 CEOP
 
 #ifdef ALLOW_GMREDI
-
 C     !LOCAL VARIABLES:
 C     == Local variables ==
-#ifdef GMREDI_WITH_STABLE_ADJOINT
-      _RL slopeSqTmp,slopeTmp,slopeMax
-#endif
-      _RL dSigmMod(1-OLx:sNx+OLx,1-OLy:sNy+OLy)
-      _RL SlopeMod(1-OLx:sNx+OLx,1-OLy:sNy+OLy)
-      _RL dRdSigmaLtd(1-OLx:sNx+OLx,1-OLy:sNy+OLy)
-      _RL tmpFld(1-OLx:sNx+OLx,1-OLy:sNy+OLy)
-      _RL locVar(1-OLx:sNx+OLx,1-OLy:sNy+OLy)
-      _RL f1,Smod,f2,Rnondim
-      _RL maxSlopeSqr
       _RL fpi
       PARAMETER( fpi = PI )
-      INTEGER i,j
+      INTEGER i, j
+      _RL f1, Smod, f2, Rnondim
+      _RL maxSlopeSqr
+      _RL dSigmMod   (1-OLx:sNx+OLx,1-OLy:sNy+OLy)
+      _RL dRdSigmaLtd(1-OLx:sNx+OLx,1-OLy:sNy+OLy)
+      _RL tmpFld     (1-OLx:sNx+OLx,1-OLy:sNy+OLy)
+#ifndef GM_EXCLUDE_FM07_TAP
       _RL dTransLay, rLambMin, DoverLamb
       _RL taperFctLoc, taperFctHat
       _RL minTransLay
+      _RL SlopeMod(1-OLx:sNx+OLx,1-OLy:sNy+OLy)
+      _RL locVar  (1-OLx:sNx+OLx,1-OLy:sNy+OLy)
+#endif
+#ifdef GMREDI_WITH_STABLE_ADJOINT
+      _RL slopeSqTmp, slopeTmp, slopeMax
+#endif
 #ifdef ALLOW_AUTODIFF_TAMC
       INTEGER act1, act2, act3, act4
       INTEGER max1, max2, max3

--- a/pkg/grdchk/grdchk_get_obcs_mask.F
+++ b/pkg/grdchk/grdchk_get_obcs_mask.F
@@ -29,35 +29,25 @@ c     == global variables ==
 #include "grdchk.h"
 
 c     == routine arguments ==
-
       integer mythid
 
 #if (defined (ALLOW_GRDCHK) && defined (ALLOW_OBCS_CONTROL))
 c     == local variables ==
-
       integer bi,bj
       integer i,j,k
-      integer irec,iobcs
+      integer iobcs
       integer itlo,ithi
       integer jtlo,jthi
       integer jmin,jmax
       integer imin,imax
-
       _RL dummy
-
 #if (defined ALLOW_OBCSN_CONTROL || defined ALLOW_OBCSS_CONTROL)
       _RL tmpfldxz (1-olx:snx+olx,nr,nsx,nsy)
 #endif
 #if (defined ALLOW_OBCSE_CONTROL || defined ALLOW_OBCSW_CONTROL)
       _RL tmpfldyz (1-oly:sny+oly,nr,nsx,nsy)
 #endif
-
       character*( 80) fname
-
-c     == external ==
-
-      integer  ilnblnk
-      external ilnblnk
 
 c     == end of interface ==
 

--- a/pkg/grdchk/grdchk_get_position.F
+++ b/pkg/grdchk/grdchk_get_position.F
@@ -37,7 +37,10 @@ c     == global variables ==
 #include "grdchk.h"
 
 c     == routine arguments ==
+      integer       mythid
 
+#ifdef ALLOW_GRDCHK
+c     == local variables ==
       integer       icvrec
       integer       jtile
       integer       itile
@@ -47,17 +50,9 @@ c     == routine arguments ==
       integer       jtilepos
       integer       itest
       integer       ierr
-      integer       mythid
-
-#ifdef ALLOW_GRDCHK
-c     == local variables ==
-
-      integer iG,jG
       integer bi,bj
       integer i,j,k
       integer iobcs
-c     integer biwrk,bjwrk
-      integer iproc, jproc
       integer iwrk, jwrk, kwrk
       integer iobcswrk
       integer irec, irecwrk
@@ -68,10 +63,8 @@ c     integer biwrk,bjwrk
       integer icomptest
       integer nobcsmax
       integer pastit
-
       _RL wetlocal
 
-      logical ltmp
 c     == end of interface ==
 
       jtlo = 1

--- a/pkg/grdchk/grdchk_getadxx.F
+++ b/pkg/grdchk/grdchk_getadxx.F
@@ -12,8 +12,7 @@
      I                       jtilepos,
      I                       xx_comp,
      I                       ierr,
-     I                       mythid
-     &                     )
+     I                       mythid )
 
 c     ==================================================================
 c     SUBROUTINE grdchk_getadxx
@@ -42,10 +41,9 @@ c     == global variables ==
 #include "grdchk.h"
 
 c     == routine arguments ==
-
       integer icvrec
-      integer jtile
       integer itile
+      integer jtile
       integer layer
       integer itilepos
       integer jtilepos
@@ -54,17 +52,18 @@ c     == routine arguments ==
       integer mythid
 
 #ifdef ALLOW_GRDCHK
-c     == local variables ==
+c--   == external ==
+      integer  ilnblnk
+      external ilnblnk
 
+c     == local variables ==
       integer iarr
       integer il
       integer dumiter
       _RL     dumtime
       _RL     dummy
-
       logical doglobalread
       logical ladinit
-
 #if (defined ALLOW_OBCSN_CONTROL || defined ALLOW_OBCSS_CONTROL)
       _RL tmpfldxz (1-olx:snx+olx,nr,nsx,nsy)
 #endif
@@ -73,15 +72,7 @@ c     == local variables ==
 #endif
       _RL loctmp2d (1-olx:snx+olx,1-oly:sny+oly,nsx,nsy)
       _RL loctmp3d (1-olx:snx+olx,1-oly:sny+oly,Nr,nsx,nsy)
-
       character*(80) fname
-
-      integer i,j,k
-
-c--   == external ==
-
-      integer  ilnblnk
-      external ilnblnk
 
 c--   == end of interface ==
 

--- a/pkg/grdchk/grdchk_init.F
+++ b/pkg/grdchk/grdchk_init.F
@@ -31,23 +31,16 @@ c     == global variables ==
 #include "grdchk.h"
 
 c     == routine arguments ==
-
       integer       mythid
 
 #ifdef ALLOW_GRDCHK
 c     == local variables ==
-
       integer bi,bj
-      integer i,j,k
-      integer irec
+      integer k, iobcs
       integer itlo,ithi
       integer jtlo,jthi
       integer jmin,jmax
       integer imin,imax
-
-      integer itest,iobcs
-      integer icomptest
-
 c     == end of interface ==
 
       jtlo = 1

--- a/pkg/grdchk/grdchk_readparms.F
+++ b/pkg/grdchk/grdchk_readparms.F
@@ -3,7 +3,7 @@
 # include "CTRL_OPTIONS.h"
 #endif
 
-      SUBROUTINE GRDCHK_READPARMS( mythid )
+      SUBROUTINE GRDCHK_READPARMS( myThid )
 
 c     ==================================================================
 c     SUBROUTINE grdchk_readparms
@@ -18,7 +18,7 @@ c     ==================================================================
 c     SUBROUTINE grdchk_readparms
 c     ==================================================================
 
-      implicit none
+      IMPLICIT NONE
 
 c     == global variables ==
 
@@ -30,31 +30,13 @@ c     == global variables ==
 #include "grdchk.h"
 
 c     == routine arguments ==
-
-      integer mythid
+      INTEGER myThid
 
 #ifdef ALLOW_GRDCHK
 c     == local variables ==
-
       INTEGER iGloTile, jGloTile
-c     integer i,j,k
-c     integer bi,bj
-c     integer itlo,ithi
-c     integer jtlo,jthi
-c     integer jmin,jmax
-c     integer imin,imax
-
-      integer errio
-      integer il
-      integer iUnit
-
-      character*(max_len_mbuf) msgbuf
-      character*(max_len_prec) record
-
-c     == external ==
-
-      integer  ilnblnk
-      external ilnblnk
+      INTEGER iUnit
+      CHARACTER*(MAX_LEN_MBUF) msgBuf
 
 c     == end of interface ==
 
@@ -89,16 +71,7 @@ C     print a (weak) warning if data.grdchk is found
         RETURN
       ENDIF
 
-c     jtlo = mybylo(mythid)
-c     jthi = mybyhi(mythid)
-c     itlo = mybxlo(mythid)
-c     ithi = mybxhi(mythid)
-c     jmin = 1-oly
-c     jmax = sny+oly
-c     imin = 1-olx
-c     imax = snx+olx
-
-      _BEGIN_MASTER( mythid )
+      _BEGIN_MASTER( myThid )
 
 c--     Set default values.
         grdchk_eps      = 1. _d 0
@@ -166,9 +139,9 @@ C--    From Tile Global-Indices, set Tile Local-Indices and proc. number
         ENDIF
 
 c--     Summarize the gradient check setup.
-        call grdchk_Summary( mythid )
+        call grdchk_Summary( myThid )
 
-      _END_MASTER( mythid )
+      _END_MASTER( myThid )
       _BARRIER
 
 #endif /* ALLOW_GRDCHK */

--- a/pkg/grdchk/grdchk_setxx.F
+++ b/pkg/grdchk/grdchk_setxx.F
@@ -13,8 +13,7 @@
      I                       jtilepos,
      I                       xx_comp_ref,
      I                       ierr,
-     I                       mythid
-     &                     )
+     I                       mythid )
 
 c     ==================================================================
 c     SUBROUTINE grdchk_setxx
@@ -43,11 +42,10 @@ c     == global variables ==
 #include "grdchk.h"
 
 c     == routine arguments ==
-
       integer icvrec
       integer theSimulationMode
-      integer jtile
       integer itile
+      integer jtile
       integer layer
       integer itilepos
       integer jtilepos
@@ -56,18 +54,18 @@ c     == routine arguments ==
       integer mythid
 
 #ifdef ALLOW_GRDCHK
-c     == local variables ==
+c--   == external ==
+      integer  ilnblnk
+      external ilnblnk
 
+c     == local variables ==
       integer iarr
-      integer i,j,k
       integer il
       integer dumiter
       _RL     dumtime
       _RL     dummy
-
       logical doglobalread
       logical ladinit
-
 #if (defined ALLOW_OBCSN_CONTROL || defined ALLOW_OBCSS_CONTROL)
       _RL tmpfldxz (1-olx:snx+olx,nr,nsx,nsy)
 #endif
@@ -76,13 +74,7 @@ c     == local variables ==
 #endif
       _RL loctmp2d (1-olx:snx+olx,1-oly:sny+oly,nsx,nsy)
       _RL loctmp3d (1-olx:snx+olx,1-oly:sny+oly,Nr,nsx,nsy)
-
       character*(80) fname
-
-c--   == external ==
-
-      integer  ilnblnk
-      external ilnblnk
 
 c--   == end of interface ==
 

--- a/pkg/mdsio/mdsio_read_whalos.F
+++ b/pkg/mdsio/mdsio_read_whalos.F
@@ -1,9 +1,9 @@
 #include "MDSIO_OPTIONS.h"
 
 CBOP
-C     !ROUTINE: mds_read_whalos
+C     !ROUTINE: MDS_READ_WHALOS
 C     !INTERFACE:
-      subroutine mds_read_whalos(
+      SUBROUTINE MDS_READ_WHALOS(
      I                   fName,
      I                   len,
      I                   filePrec,
@@ -13,24 +13,20 @@ C     !INTERFACE:
      I                   irec,
      I                   locSingleCPUIO,
      I                   locBufferIO,
-     I                   mythid
-     &                 )
+     I                   myThid )
 
 C     !DESCRIPTION: \bv
-c     ==================================================================
-c     SUBROUTINE mds_read_whalos
-c     ==================================================================
-c     o Read file that includes halos. The main purpose is for
-c       adjoint related "tape I/O". The secondary purpose is debugging.
-c     ==================================================================
-c     SUBROUTINE mds_read_whalos
-c     ==================================================================
+C     ==================================================================
+C     SUBROUTINE MDS_READ_WHALOS
+C     o Read file that includes halos. The main purpose is for
+C       adjoint related "tape I/O". The secondary purpose is debugging.
+C     ==================================================================
 C     \ev
 
 C     !USES:
-      implicit none
+      IMPLICIT NONE
 
-c     == global variables ==
+C     == global variables ==
 #include "EEPARAMS.h"
 #include "SIZE.h"
 #include "PARAMS.h"
@@ -39,81 +35,69 @@ c     == global variables ==
 #endif
 
 C     !INPUT/OUTPUT PARAMETERS:
-c     == routine arguments ==
-c     fName     -  extended tape fName.
-c     len       -  number of characters in fName.
-c     filePrec  -  number of bits per word in file (32 or 64).
-c     fid       -  file unit (its use is not implemented yet).
-C     n2d       -  size of the fldRL third dimension.
-c     fldRL     -  array to read.
-c     irec      -  record number to be written.
-c     mythid    -  number of the thread or instance of the program.
-
-      integer mythid
-      character*(*) fName
-      integer len
-      integer fid
-      integer filePrec
-      integer n2d
-      integer irec
-      _RL     fldRL(1-Olx:sNx+Olx,1-Oly:sNy+Oly,n2d,nSx,nSy)
-      logical locSingleCPUIO, locBufferIO
-CEOP
+C     fName    ::  extended tape fName.
+C     len      ::  number of characters in fName.
+C     filePrec ::  number of bits per word in file (32 or 64).
+C     fid      ::  file unit (its use is not implemented yet).
+C     n2d      ::  size of the fldRL third dimension.
+C     fldRL    ::  array to read.
+C     irec     ::  record number to be written.
+C     myThid   ::  my Thread Id number
+      CHARACTER*(*) fName
+      INTEGER len
+      INTEGER filePrec
+      INTEGER fid
+      INTEGER n2d
+      _RL     fldRL(1-OLx:sNx+OLx,1-OLy:sNy+OLy,n2d,nSx,nSy)
+      INTEGER irec
+      LOGICAL locSingleCPUIO, locBufferIO
+      INTEGER myThid
 
 #ifdef ALLOW_WHIO
-C     !LOCAL VARIABLES:
-c     == local variables ==
+C     !FUNCTIONS:
+      INTEGER  ILNBLNK
+      INTEGER  MDS_RECLEN
+      EXTERNAL ILNBLNK
+      EXTERNAL MDS_RECLEN
 
-C     sNxWh :: x tile size with halo included
-C     sNyWh :: y tile size with halo included
+C     !LOCAL VARIABLES:
+C     == local parameters ==
+C     sNxWh   :: x tile size with halo included
+C     sNyWh   :: y tile size with halo included
 C     pocNyWh :: processor sum of sNyWh
 C     gloNyWh :: global sum of sNyWh
       INTEGER sNxWh
       INTEGER sNyWh
       INTEGER procNyWh
       INTEGER gloNyWh
-      PARAMETER ( sNxWh = sNx+2*Olx )
-      PARAMETER ( sNyWh = sNy+2*Oly )
+      PARAMETER ( sNxWh = sNx+2*OLx )
+      PARAMETER ( sNyWh = sNy+2*OLy )
       PARAMETER ( procNyWh = sNyWh*nSy*nSx )
       PARAMETER ( gloNyWh = procNyWh*nPy*nPx )
-
-      character*(MAX_LEN_FNAM) pfName
-      character*(MAX_LEN_MBUF) msgBuf
-      integer IL
-      integer bx,by
-
-      integer lengthBuff, length_of_rec
-      integer i2d, i3d
-      integer i,j,k,bi,bj,ii
-      integer dUnit, irec2d
+C     == local variables ==
+      CHARACTER*(MAX_LEN_FNAM) pfName
+      INTEGER IL
+      INTEGER lengthBuff, length_of_rec
+      INTEGER i, j, i2d
+      INTEGER dUnit, irec2d
       LOGICAL iAmDoingIO
-cph(
+Cph(
 #ifdef INTEL_COMMITQQ
-cph   Fix on Pleiades following model crashes on disk /nobackupnfs2/
-cph   reported by Yoshihiro.Nakayama@jpl.nasa.gov
-cph forrtl: Device or resource busy
-cph forrtl: severe (39): error during read, unit 1001, file
-cph   Workaround by NAS engineer Sherry.Chang@nasa.gov
-      logical results, commitqq
+Cph   Fix on Pleiades following model crashes on disk /nobackupnfs2/
+Cph   reported by Yoshihiro.Nakayama@jpl.nasa.gov
+Cph forrtl: Device or resource busy
+Cph forrtl: severe (39): error during read, unit 1001, file
+Cph   Workaround by NAS engineer Sherry.Chang@nasa.gov
+      LOGICAL results, commitqq
 #endif
-cph)
-
-
-      _RL fld2d(1:sNxWh,1:sNyWh,nSx,nSy)
-
-c     == functions ==
-      INTEGER  ILNBLNK
-      INTEGER  MDS_RECLEN
-      EXTERNAL ILNBLNK
-      EXTERNAL MDS_RECLEN
-
-c     == end of interface ==
+Cph)
+CEOP
 
 #ifdef ALLOW_WHIO_3D
       writeWh=.FALSE.
 #endif
 
-      IF ( .NOT.locSingleCpuIO ) then
+      IF ( .NOT.locSingleCpuIO ) THEN
         lengthBuff=sNxWh*procNyWh
       ELSE
         lengthBuff=sNxWh*gloNyWh
@@ -128,7 +112,7 @@ C Only do I/O if I am the master thread (and mpi process 0 IF locSingleCpuIO):
       ENDIF
 
       IF ( iAmDoingIO ) THEN
-c get the unit and open file
+C get the unit and open file
       IL  = ILNBLNK( fName )
       IF ( .NOT.locSingleCpuIO ) THEN
         WRITE(pfName,'(2A,I3.3,A)') fName(1:IL),'.',myProcId,'.data'
@@ -146,28 +130,28 @@ c get the unit and open file
       ENDIF
       ENDIF
 
-cph(
-cph   NAS Pleiades fix here:
+Cph(
+Cph   NAS Pleiades fix here:
 #ifdef INTEL_COMMITQQ
       results = commitqq(dUnit)
 #endif
-cph)
+Cph)
 
-      do i2d=1,n2d
+      DO i2d=1,n2d
 
         _BARRIER
 #ifdef ALLOW_WHIO_3D
         IF ( iAmDoingIO.AND.locBufferIO.AND.(fid.NE.0) ) THEN
-c reset counter if needed
+C reset counter if needed
           IF (jWh.EQ.nWh) jWh=0
-c increment counter
+C increment counter
           jWh=jWh+1
-c determine current file record
+C determine current file record
           irec2d=i2d+n2d*(irec-1)
           iWh=(irec2d-1)/nWh+1
-c read new chunk if needed
+C read new chunk if needed
           IF (jWh.EQ.1) THEN
-            IF ( .NOT.locSingleCpuIO ) then
+            IF ( .NOT.locSingleCpuIO ) THEN
               IF (filePrec .EQ. precFloat32) THEN
                 READ(dUnit,rec=iWh) fld3d_procbuff_r4
               ELSE
@@ -183,10 +167,10 @@ c read new chunk if needed
 #  endif
             ENDIF
           ENDIF
-c copy
+C copy
           DO i=1,lengthBuff
             j=(jWh-1)*lengthBuff+i
-            IF ( .NOT.locSingleCpuIO ) then
+            IF ( .NOT.locSingleCpuIO ) THEN
               IF (filePrec .EQ. precFloat32) THEN
                 fld2d_procbuff_r4(i)=fld3d_procbuff_r4(j)
               ELSE
@@ -208,7 +192,7 @@ c copy
         IF ( iAmDoingIO ) THEN
 #endif
           irec2d=i2d+n2d*(irec-1)
-          IF ( .NOT.locSingleCpuIO ) then
+          IF ( .NOT.locSingleCpuIO ) THEN
             IF (filePrec .EQ. precFloat32) THEN
               READ(dUnit,rec=irec2d) fld2d_procbuff_r4
             ELSE
@@ -227,7 +211,7 @@ c copy
         _BARRIER
 
         IF (filePrec .EQ. precFloat32) THEN
-          IF ( locSingleCpuIO ) then
+          IF ( locSingleCpuIO ) THEN
 #  ifndef EXCLUDE_WHIO_GLOBUFF_2D
             CALL SCATTER_2D_WH_R4 ( fld2d_globuff_r4,
      &                              fld2d_procbuff_r4,myThid)
@@ -237,7 +221,7 @@ c copy
           CALL MDS_PASS_R4toRL( fld2d_procbuff_r4, fldRL,
      &             OLx, OLy, 1, i2d, n2d, 0, 0, .TRUE., myThid )
         ELSE
-          IF ( locSingleCpuIO ) then
+          IF ( locSingleCpuIO ) THEN
 #  ifndef EXCLUDE_WHIO_GLOBUFF_2D
             CALL SCATTER_2D_WH_R8 ( fld2d_globuff_r8,
      &                              fld2d_procbuff_r8,myThid)
@@ -248,7 +232,7 @@ c copy
      &             OLx, OLy, 1, i2d, n2d, 0, 0, .TRUE., myThid )
         ENDIF
 
-      enddo
+      ENDDO
 
        IF ( iAmDoingIO.AND.(fid.EQ.0) ) THEN
          CLOSE( dUnit )

--- a/pkg/mdsio/mdsio_write_whalos.F
+++ b/pkg/mdsio/mdsio_write_whalos.F
@@ -1,9 +1,9 @@
 #include "MDSIO_OPTIONS.h"
 
 CBOP
-C     !ROUTINE: mds_write_whalos
+C     !ROUTINE: MDS_WRITE_WHALOS
 C     !INTERFACE:
-      subroutine mds_write_whalos(
+      SUBROUTINE MDS_WRITE_WHALOS(
      I                    fName,
      I                    len,
      I                    filePrec,
@@ -13,24 +13,20 @@ C     !INTERFACE:
      I                    irec,
      I                    locSingleCPUIO,
      I                    locBufferIO,
-     I                    mythid
-     &                  )
+     I                    myThid )
 
 C     !DESCRIPTION: \bv
-c     ==================================================================
-c     SUBROUTINE mds_write_whalos
-c     ==================================================================
-c     o Write file that includes halos. The main purpose is for
-c       adjoint related "tape I/O". The secondary purpose is debugging.
-c     ==================================================================
-c     SUBROUTINE mds_write_whalos
-c     ==================================================================
+C     ==================================================================
+C     SUBROUTINE MDS_WRITE_WHALOS
+C     o Write file that includes halos. The main purpose is for
+C       adjoint related "tape I/O". The secondary purpose is debugging.
+C     ==================================================================
 C     \ev
 
 C     !USES:
-      implicit none
+      IMPLICIT NONE
 
-c     == global variables ==
+C     == global variables ==
 #include "EEPARAMS.h"
 #include "SIZE.h"
 #include "PARAMS.h"
@@ -39,72 +35,59 @@ c     == global variables ==
 #endif
 
 C     !INPUT/OUTPUT PARAMETERS:
-c     == routine arguments ==
-c     fName     -  extended tape fName.
-c     len       -  number of characters in fName.
-c     filePrec  -  number of bits per word in file (32 or 64).
-c     fid       -  file unit (its use is not implemented yet).
-C     n2d       -  size of the fldRL third dimension.
-c     fldRL     -  array to read.
-c     irec      -  record number to be written.
-c     mythid    -  number of the thread or instance of the program.
-
-      integer mythid
-      character*(*) fName
-      integer len
-      integer fid
-      integer filePrec
-      integer n2d
-      integer irec
-      _RL     fldRL(1-Olx:sNx+Olx,1-Oly:sNy+Oly,n2d,nSx,nSy)
-      logical locSingleCPUIO, locBufferIO
-CEOP
+C     fName    ::  extended tape fName.
+C     len      ::  number of characters in fName.
+C     filePrec ::  number of bits per word in file (32 or 64).
+C     fid      ::  file unit (its use is not implemented yet).
+C     n2d      ::  size of the fldRL third dimension.
+C     fldRL    ::  array to read.
+C     irec     ::  record number to be written.
+C     myThid   ::  my Thread Id number
+      CHARACTER*(*) fName
+      INTEGER len
+      INTEGER filePrec
+      INTEGER fid
+      INTEGER n2d
+      _RL     fldRL(1-OLx:sNx+OLx,1-OLy:sNy+OLy,n2d,nSx,nSy)
+      INTEGER irec
+      LOGICAL locSingleCPUIO, locBufferIO
+      INTEGER myThid
 
 #ifdef ALLOW_WHIO
-C     !LOCAL VARIABLES:
-c     == local variables ==
+C     !FUNCTIONS:
+      INTEGER  ILNBLNK
+      INTEGER  MDS_RECLEN
+      EXTERNAL ILNBLNK
+      EXTERNAL MDS_RECLEN
 
-C     sNxWh :: x tile size with halo included
-C     sNyWh :: y tile size with halo included
+C     !LOCAL VARIABLES:
+C     == local parameters ==
+C     sNxWh   :: x tile size with halo included
+C     sNyWh   :: y tile size with halo included
 C     pocNyWh :: processor sum of sNyWh
 C     gloNyWh :: global sum of sNyWh
       INTEGER sNxWh
       INTEGER sNyWh
       INTEGER procNyWh
       INTEGER gloNyWh
-      PARAMETER ( sNxWh = sNx+2*Olx )
-      PARAMETER ( sNyWh = sNy+2*Oly )
+      PARAMETER ( sNxWh = sNx+2*OLx )
+      PARAMETER ( sNyWh = sNy+2*OLy )
       PARAMETER ( procNyWh = sNyWh*nSy*nSx )
       PARAMETER ( gloNyWh = procNyWh*nPy*nPx )
-
-C     !LOCAL VARIABLES:
-c     == local variables ==
-      character*(MAX_LEN_FNAM) pfName
-      character*(MAX_LEN_MBUF) msgBuf
-      integer IL
-      integer bx,by
-
-      integer lengthBuff, length_of_rec
-      integer i2d, i3d
-      integer i,j,k,bi,bj,ii
-      integer dUnit, irec2d
+C     == local variables ==
+      CHARACTER*(MAX_LEN_FNAM) pfName
+      INTEGER IL
+      INTEGER lengthBuff, length_of_rec
+      INTEGER i, j, i2d
+      INTEGER dUnit, irec2d
       LOGICAL iAmDoingIO
-
-      _RL fld2d(1:sNxWh,1:sNyWh,nSx,nSy)
-
-c     == functions ==
-      INTEGER  ILNBLNK
-      INTEGER  MDS_RECLEN
-      EXTERNAL ILNBLNK
-      EXTERNAL MDS_RECLEN
-
-c     == end of interface ==
+CEOP
 
 #ifdef ALLOW_WHIO_3D
       writeWh=.TRUE.
 #endif
 
-      IF ( .NOT.locSingleCpuIO ) then
+      IF ( .NOT.locSingleCpuIO ) THEN
         lengthBuff=sNxWh*procNyWh
       ELSE
         lengthBuff=sNxWh*gloNyWh
@@ -119,7 +102,7 @@ C Only do I/O if I am the master thread (and mpi process 0 IF locSingleCpuIO):
       ENDIF
 
       IF ( iAmDoingIO ) THEN
-c get the unit and open file
+C get the unit and open file
       IL  = ILNBLNK( fName )
       IF ( .NOT.locSingleCpuIO ) THEN
         WRITE(pfName,'(2A,I3.3,A)') fName(1:IL),'.',myProcId,'.data'
@@ -137,13 +120,12 @@ c get the unit and open file
       ENDIF
       ENDIF
 
-
-      do i2d=1,n2d
+      DO i2d=1,n2d
 
         IF (filePrec .EQ. precFloat32) THEN
           CALL MDS_PASS_R4toRL( fld2d_procbuff_r4, fldRL,
      &             OLx, OLy, 1, i2d, n2d, 0, 0, .FALSE., myThid )
-          IF ( locSingleCpuIO ) then
+          IF ( locSingleCpuIO ) THEN
             CALL BAR2( myThid )
 #  ifndef EXCLUDE_WHIO_GLOBUFF_2D
             CALL GATHER_2D_WH_R4( fld2d_globuff_r4,
@@ -153,7 +135,7 @@ c get the unit and open file
         ELSE
           CALL MDS_PASS_R8toRL( fld2d_procbuff_r8, fldRL,
      &             OLx, OLy, 1, i2d, n2d, 0, 0, .FALSE., myThid )
-          IF ( locSingleCpuIO ) then
+          IF ( locSingleCpuIO ) THEN
             CALL BAR2( myThid )
 #  ifndef EXCLUDE_WHIO_GLOBUFF_2D
             CALL GATHER_2D_WH_R8( fld2d_globuff_r8,
@@ -165,17 +147,17 @@ c get the unit and open file
         _BARRIER
 #ifdef ALLOW_WHIO_3D
         IF ( iAmDoingIO.AND.locBufferIO.AND.(fid.NE.0) ) THEN
-c reset counter if needed
+C reset counter if needed
           IF (jWh.EQ.nWh) jWh=0
-c increment counter
+C increment counter
           jWh=jWh+1
-c determine current file record
+C determine current file record
           irec2d=i2d+n2d*(irec-1)
           iWh=(irec2d-1)/nWh+1
-c copy
+C copy
           DO i=1,lengthBuff
             j=(jWh-1)*lengthBuff+i
-            IF ( .NOT.locSingleCpuIO ) then
+            IF ( .NOT.locSingleCpuIO ) THEN
               IF (filePrec .EQ. precFloat32) THEN
                 fld3d_procbuff_r4(j)=fld2d_procbuff_r4(i)
               ELSE
@@ -191,9 +173,9 @@ c copy
 #  endif
             ENDIF
           ENDDO
-c write chunk if needed
+C write chunk if needed
           IF (jWh.EQ.nWh) THEN
-            IF ( .NOT.locSingleCpuIO ) then
+            IF ( .NOT.locSingleCpuIO ) THEN
               IF (filePrec .EQ. precFloat32) THEN
                 WRITE(dUnit,rec=iWh) fld3d_procbuff_r4
               ELSE
@@ -215,7 +197,7 @@ c write chunk if needed
         IF ( iAmDoingIO ) THEN
 #endif
           irec2d=i2d+n2d*(irec-1)
-          IF ( .NOT.locSingleCpuIO ) then
+          IF ( .NOT.locSingleCpuIO ) THEN
             IF (filePrec .EQ. precFloat32) THEN
               WRITE(dUnit,rec=irec2d) fld2d_procbuff_r4
             ELSE
@@ -233,7 +215,7 @@ c write chunk if needed
         ENDIF
         _BARRIER
 
-      enddo
+      ENDDO
 
       IF ( iAmDoingIO.AND.(fid.EQ.0) ) THEN
         CLOSE( dUnit )

--- a/pkg/ptracers/ptracers_switch_onoff.F
+++ b/pkg/ptracers/ptracers_switch_onoff.F
@@ -30,7 +30,9 @@ CEOP
 
 #ifdef ALLOW_PTRACERS
 C     !LOCAL VARIABLES:
+#ifndef ALLOW_AUTODIFF
       INTEGER iTracer
+#endif
 
       IF ( .NOT.PTRACERS_startAllTrc ) THEN
 

--- a/pkg/seaice/seaice_cost_init_varia.F
+++ b/pkg/seaice/seaice_cost_init_varia.F
@@ -1,6 +1,6 @@
 #include "SEAICE_OPTIONS.h"
 
-      subroutine seaice_cost_init_varia( mythid )
+      subroutine seaice_cost_init_varia( myThid )
 
 c     ==================================================================
 c     SUBROUTINE seaice_cost_init_varia
@@ -16,7 +16,6 @@ c     ==================================================================
       implicit none
 
 c     == global variables ==
-
 #include "EEPARAMS.h"
 #include "SIZE.h"
 #include "GRID.h"
@@ -27,38 +26,20 @@ c     == global variables ==
 #endif
 
 c     == routine arguments ==
-
-      integer mythid
+      integer myThid
 
 #ifdef ALLOW_COST
 #if (defined(ALLOW_SEAICE_COST_SMR_AREA) || defined(ALLOW_COST_ICE))
 
 c     == local variables ==
-
       integer bi,bj
-      integer itlo,ithi
-      integer jtlo,jthi
-      integer imin, imax
-      integer jmin, jmax
-      integer i,j,k
-
-      logical exst
-
-c     == external functions ==
+      integer i,j
 
 c     == end of interface ==
-      jtlo = myByLo(mythid)
-      jthi = myByHi(mythid)
-      itlo = myBxLo(mythid)
-      ithi = myBxHi(mythid)
-      jmin = 1-OLy
-      jmax = sNy+OLy
-      imin = 1-OLx
-      imax = sNx+OLx
 
 c--   Initialize the tiled cost function contributions.
-      do bj = jtlo,jthi
-        do bi = itlo,ithi
+      do bj = myByLo(myThid), myByHi(myThid)
+        do bi = myBxLo(myThid), myBxHi(myThid)
           objf_ice(bi,bj)     = 0. _d 0
           objf_smrarea(bi,bj) = 0. _d 0
           objf_smrsst(bi,bj)  = 0. _d 0
@@ -72,11 +53,10 @@ c
         enddo
       enddo
 
-      k = 1
-      do bj = jtlo,jthi
-        do bi = itlo,ithi
-          do j = jmin,jmax
-            do i = imin,imax
+      do bj = myByLo(myThid), myByHi(myThid)
+        do bi = myBxLo(myThid), myBxHi(myThid)
+          do j=1-OLy,sNy+OLy
+            do i=1-OLx,sNx+OLx
 #ifdef ALLOW_SEAICE_COST_EXPORT
                uHeffExportCell(i,j,bi,bj) = 0. _d 0
                vHeffExportCell(i,j,bi,bj) = 0. _d 0
@@ -89,7 +69,7 @@ c
       _BARRIER
 
 #endif
-#endif
+#endif /* ALLOW_COST */
 
       return
       end

--- a/pkg/seaice/seaice_cost_weights.F
+++ b/pkg/seaice/seaice_cost_weights.F
@@ -19,12 +19,10 @@ c     ==================================================================
       implicit none
 
 c     == global variables ==
-
 #include "EEPARAMS.h"
 #include "SIZE.h"
 #include "PARAMS.h"
 #include "GRID.h"
-
 #ifdef ALLOW_CTRL
 # include "ctrl.h"
 #endif
@@ -35,30 +33,18 @@ c     == global variables ==
 #include "SEAICE_COST.h"
 
 c     == routine arguments ==
-
       integer  myThid
 
 #ifdef ALLOW_ECCO
+#ifdef ALLOW_SEAICE_COST_SMR_AREA
 c     == local variables ==
-
       integer bi,bj
       integer i,j,k
       integer itlo,ithi
       integer jtlo,jthi
       integer jmin,jmax
       integer imin,imax
-      integer gwunit
       integer irec,nnz
-      integer ilo,ihi
-
-      _RL dummy
-
-c     == external ==
-
-      integer  ifnblnk
-      external ifnblnk
-      integer  ilnblnk
-      external ilnblnk
 
 c     == end of interface ==
 
@@ -83,8 +69,6 @@ c--       North/South and West/East edges set to zero.
           endif
         enddo
       enddo
-
-#ifdef ALLOW_SEAICE_COST_SMR_AREA
 
       do bj = jtlo,jthi
         do bi = itlo,ithi

--- a/pkg/seaice/seaice_ctrl_map_ini.F
+++ b/pkg/seaice/seaice_ctrl_map_ini.F
@@ -41,57 +41,37 @@ c     == routine arguments ==
       integer mythid
 
 #ifdef ALLOW_CTRL
-C     !LOCAL VARIABLES:
-c     == local variables ==
-
-      integer bi,bj
-      integer i,j,k
-      integer itlo,ithi
-      integer jtlo,jthi
-      integer jmin,jmax
-      integer imin,imax
-      integer il
-
-      logical equal
-      logical doglobalread
-      logical ladinit
-
-      character*( 80)   fnamegeneric
-
-      _RL     fac
-      _RL     tmpfld2d(1-olx:snx+olx,1-oly:sny+oly,nsx,nsy)
-
 c     == external ==
       integer  ilnblnk
       external ilnblnk
 
+C     !LOCAL VARIABLES:
+c     == local variables ==
+      integer bi,bj
+      integer i,j
+      integer jmin,jmax
+      integer imin,imax
+      integer il
+      logical doglobalread
+      logical ladinit
+      character*(80) fnamegeneric
+      _RL     tmpfld2d(1-OLx:sNx+OLx,1-OLy:sNy+OLy,nSx,nSy)
+
 c     == end of interface ==
 CEOP
 
-      jtlo = mybylo(mythid)
-      jthi = mybyhi(mythid)
-      itlo = mybxlo(mythid)
-      ithi = mybxhi(mythid)
       jmin = 1
-      jmax = sny
+      jmax = sNy
       imin = 1
-      imax = snx
+      imax = sNx
 
       doglobalread = .false.
       ladinit      = .false.
 
-      equal = .true.
-
-      if ( equal ) then
-        fac = 1. _d 0
-      else
-        fac = 0. _d 0
-      endif
-
-      do bj = jtlo,jthi
-        do bi = itlo,ithi
-          do j = 1-oly,sny+oly
-            do i = 1-olx,snx+olx
+      do bj = myByLo(myThid), myByHi(myThid)
+        do bi = myBxLo(myThid), myBxHi(myThid)
+          do j = 1-OLy,sNy+OLy
+            do i = 1-OLx,sNx+OLx
               tmpfld2d(i,j,bi,bj) = 0. _d 0
             enddo
           enddo
@@ -106,8 +86,8 @@ c--   siarea.
       call active_read_xy( fnamegeneric, tmpfld2d, 1,
      &                      doglobalread, ladinit, optimcycle,
      &                      mythid, xx_siarea_dummy )
-      do bj = jtlo,jthi
-        do bi = itlo,ithi
+      do bj = myByLo(myThid), myByHi(myThid)
+        do bi = myBxLo(myThid), myBxHi(myThid)
             do j = jmin,jmax
               do i = imin,imax
                 area(i,j,bi,bj) = area(i,j,bi,bj) +
@@ -126,8 +106,8 @@ c--   siheff.
       call active_read_xy( fnamegeneric, tmpfld2d, 1,
      &                      doglobalread, ladinit, optimcycle,
      &                      mythid, xx_siheff_dummy )
-      do bj = jtlo,jthi
-        do bi = itlo,ithi
+      do bj = myByLo(myThid), myByHi(myThid)
+        do bi = myBxLo(myThid), myBxHi(myThid)
             do j = jmin,jmax
               do i = imin,imax
                 heff(i,j,bi,bj) = heff(i,j,bi,bj) +
@@ -146,8 +126,8 @@ c--   sihsnow.
       call active_read_xy( fnamegeneric, tmpfld2d, 1,
      &                      doglobalread, ladinit, optimcycle,
      &                      mythid, xx_sihsnow_dummy )
-      do bj = jtlo,jthi
-        do bi = itlo,ithi
+      do bj = myByLo(myThid), myByHi(myThid)
+        do bi = myBxLo(myThid), myBxHi(myThid)
             do j = jmin,jmax
               do i = imin,imax
                 hsnow(i,j,bi,bj) = hsnow(i,j,bi,bj) +

--- a/pkg/shelfice/shelfice_cost_accumulate.F
+++ b/pkg/shelfice/shelfice_cost_accumulate.F
@@ -24,36 +24,20 @@ C     myThid - Thread number for this instance of the routine.
 
 #ifdef ALLOW_COST
 C     == Local variables
-      _RL thetaRef
-      _RL drLoc
-
       integer bi, bj
       integer i, j
-c     integer ig, jg
-      integer itlo,ithi
-      integer jtlo,jthi
-c     integer km1, kp1, klev, k
-
-      jtlo = mybylo(mythid)
-      jthi = mybyhi(mythid)
-      itlo = mybxlo(mythid)
-      ithi = mybxhi(mythid)
 
 C--   Calculate cost function on tile of this instance
-      do bj = jtlo,jthi
-       do bi = itlo,ithi
-ccc        do klev = 1, Nr
-         do j=1,sNy
-          do i=1,sNx
-c--
-         cMeanSHIforT(i,j,bi,bj) = cMeanSHIforT(i,j,bi,bj)
+      do bj = myByLo(myThid), myByHi(myThid)
+       do bi = myBxLo(myThid), myBxHi(myThid)
+        do j=1,sNy
+         do i=1,sNx
+          cMeanSHIforT(i,j,bi,bj) = cMeanSHIforT(i,j,bi,bj)
      &         + shelficeHeatFlux(i,j,bi,bj)*deltaTClock
-         cMeanSHIforS(i,j,bi,bj) = cMeanSHIforS(i,j,bi,bj)
+          cMeanSHIforS(i,j,bi,bj) = cMeanSHIforS(i,j,bi,bj)
      &         + shelficeFreshWaterFlux(i,j,bi,bj)*deltaTClock
-c--
-          enddo
          enddo
-ccc        enddo
+        enddo
        enddo
       enddo
 

--- a/pkg/smooth/SMOOTH.h
+++ b/pkg/smooth/SMOOTH.h
@@ -1,52 +1,80 @@
-c pkg/smooth constants
+C pkg/smooth constants
 
-      integer     smoothprec
-      parameter ( smoothprec = 32 )
+      INTEGER     smoothprec
+      PARAMETER ( smoothprec = 32 )
 
-      logical smooth3DdoImpldiff
-      parameter ( smooth3DdoImpldiff = .TRUE. )
+      LOGICAL smooth3DdoImpldiff
+      PARAMETER ( smooth3DdoImpldiff = .TRUE. )
 
-      integer smoothOpNbMax
+      INTEGER smoothOpNbMax
       PARAMETER ( smoothOpNbMax = 10 )
 
-      _RL smooth2DdelTime,smooth3DdelTime
+      _RL smooth2DdelTime, smooth3DdelTime
       PARAMETER ( smooth2DdelTime = 1. _d 0 )
       PARAMETER ( smooth3DdelTime = 1. _d 0 )
 
-c fields:
+C parameters:
 
-      _RS
-     & smooth_recip_hFacC(1-Olx:sNx+Olx,1-Oly:sNy+Oly,Nr,nSx,nSy),
-     & smooth_hFacW(1-Olx:sNx+Olx,1-Oly:sNy+Oly,Nr,nSx,nSy),
-     & smooth_hFacS(1-Olx:sNx+Olx,1-Oly:sNy+Oly,Nr,nSx,nSy)
-
-      integer smooth3Dnbt(smoothOpNbMax),
-     & smooth3DtypeZ(smoothOpNbMax),smooth3DsizeZ(smoothOpNbMax),
-     & smooth3DtypeH(smoothOpNbMax),smooth3DsizeH(smoothOpNbMax),
+      COMMON /smooth_operators_i/
+     & smooth3Dnbt, smooth2Dnbt,
+     & smooth2Dtype, smooth2Dsize,
+     & smooth3DtypeZ, smooth3DsizeZ,
+     & smooth3DtypeH, smooth3DsizeH,
+     & smooth2Dfilter, smooth3Dfilter
+      INTEGER smooth2Dnbt(smoothOpNbMax),
+     & smooth2Dtype(smoothOpNbMax), smooth2Dsize(smoothOpNbMax),
+     & smooth2Dfilter(smoothOpNbMax)
+      INTEGER smooth3Dnbt(smoothOpNbMax),
+     & smooth3DtypeZ(smoothOpNbMax), smooth3DsizeZ(smoothOpNbMax),
+     & smooth3DtypeH(smoothOpNbMax), smooth3DsizeH(smoothOpNbMax),
      & smooth3Dfilter(smoothOpNbMax)
+
+      COMMON /smooth_param_r/
+     & smooth3DtotTime,
+     & smooth3D_Lx0, smooth3D_Ly0, smooth3D_Lz0,
+     & smooth2DtotTime, smooth2D_Lx0, smooth2D_Ly0
       _RL smooth3DtotTime,
      & smooth3D_Lx0(smoothOpNbMax),
-     & smooth3D_Ly0(smoothOpNbMax), smooth3D_Lz0(smoothOpNbMax),
-     & smooth3D_Lx(1-Olx:sNx+Olx,1-Oly:sNy+Oly,Nr,nSx,nSy),
-     & smooth3D_Ly(1-Olx:sNx+Olx,1-Oly:sNy+Oly,Nr,nSx,nSy),
-     & smooth3D_Lz(1-Olx:sNx+Olx,1-Oly:sNy+Oly,Nr,nSx,nSy),
-     & smooth3Dnorm (1-Olx:sNx+Olx,1-Oly:sNy+Oly,Nr,nSx,nSy)
-
-      character*(5) smooth3DmaskName(smoothOpNbMax)
-
-      integer smooth2Dnbt(smoothOpNbMax),
-     & smooth2Dtype(smoothOpNbMax),smooth2Dsize(smoothOpNbMax),
-     & smooth2Dfilter(smoothOpNbMax)
+     & smooth3D_Ly0(smoothOpNbMax), smooth3D_Lz0(smoothOpNbMax)
       _RL smooth2DtotTime,
-     & smooth2D_Lx0(smoothOpNbMax),smooth2D_Ly0(smoothOpNbMax),
-     & smooth2D_Lx(1-Olx:sNx+Olx,1-Oly:sNy+Oly,nSx,nSy),
-     & smooth2D_Ly(1-Olx:sNx+Olx,1-Oly:sNy+Oly,nSx,nSy),
-     & smooth2Dnorm (1-Olx:sNx+Olx,1-Oly:sNy+Oly,nSx,nSy)
+     & smooth2D_Lx0(smoothOpNbMax), smooth2D_Ly0(smoothOpNbMax)
 
-      character*(5) smooth2DmaskName(smoothOpNbMax)
+      COMMON /smooth_flds_c/
+     & smooth3DmaskName, smooth2DmaskName
+      CHARACTER*(5) smooth3DmaskName(smoothOpNbMax)
+      CHARACTER*(5) smooth2DmaskName(smoothOpNbMax)
 
-      _RL 
-     & smooth3D_kappaR (1-Olx:sNx+Olx,1-Oly:sNy+Oly,Nr,nSx,nSy),
+C---+----1----+----2----+----3----+----4----+----5----+----6----+----7-|--+----|
+C fields:
+      COMMON /smooth_flds_rs/
+     & smooth_recip_hFacC, smooth_hFacW, smooth_hFacS
+      _RS
+     & smooth_recip_hFacC(1-OLx:sNx+OLx,1-OLy:sNy+OLy,Nr,nSx,nSy),
+     & smooth_hFacW(1-OLx:sNx+OLx,1-OLy:sNy+OLy,Nr,nSx,nSy),
+     & smooth_hFacS(1-OLx:sNx+OLx,1-OLy:sNy+OLy,Nr,nSx,nSy)
+
+      COMMON /smooth_flds_rl/
+     & smooth3D_Lx, smooth3D_Ly, smooth3D_Lz,
+     & smooth3Dnorm,
+     & smooth2D_Lx, smooth2D_Ly,
+     & smooth2Dnorm
+      _RL
+     & smooth3D_Lx(1-OLx:sNx+OLx,1-OLy:sNy+OLy,Nr,nSx,nSy),
+     & smooth3D_Ly(1-OLx:sNx+OLx,1-OLy:sNy+OLy,Nr,nSx,nSy),
+     & smooth3D_Lz(1-OLx:sNx+OLx,1-OLy:sNy+OLy,Nr,nSx,nSy),
+     & smooth3Dnorm(1-OLx:sNx+OLx,1-OLy:sNy+OLy,Nr,nSx,nSy)
+      _RL
+     & smooth2D_Lx(1-OLx:sNx+OLx,1-OLy:sNy+OLy,nSx,nSy),
+     & smooth2D_Ly(1-OLx:sNx+OLx,1-OLy:sNy+OLy,nSx,nSy),
+     & smooth2Dnorm(1-OLx:sNx+OLx,1-OLy:sNy+OLy,nSx,nSy)
+
+      COMMON /smooth_operators_r/
+     & smooth3D_kappaR, smooth3D_Kwx, smooth3D_Kwy, smooth3D_Kwz,
+     & smooth3D_Kux, smooth3D_Kvy, smooth3D_Kuz, smooth3D_Kvz,
+     & smooth3D_Kuy, smooth3D_Kvx,
+     & smooth2D_Kux, smooth2D_Kvy
+      _RL
+     & smooth3D_kappaR(1-OLx:sNx+OLx,1-OLy:sNy+OLy,Nr,nSx,nSy),
      & smooth3D_Kwx(1-OLx:sNx+OLx,1-OLy:sNy+OLy,Nr,nSx,nSy),
      & smooth3D_Kwy(1-OLx:sNx+OLx,1-OLy:sNy+OLy,Nr,nSx,nSy),
      & smooth3D_Kwz(1-OLx:sNx+OLx,1-OLy:sNy+OLy,Nr,nSx,nSy),
@@ -56,36 +84,8 @@ c fields:
      & smooth3D_Kvz(1-OLx:sNx+OLx,1-OLy:sNy+OLy,Nr,nSx,nSy),
      & smooth3D_Kuy(1-OLx:sNx+OLx,1-OLy:sNy+OLy,Nr,nSx,nSy),
      & smooth3D_Kvx(1-OLx:sNx+OLx,1-OLy:sNy+OLy,Nr,nSx,nSy)
+      _RL
+     & smooth2D_Kux(1-OLx:sNx+OLx,1-OLy:sNy+OLy,nSx,nSy),
+     & smooth2D_Kvy(1-OLx:sNx+OLx,1-OLy:sNy+OLy,nSx,nSy)
 
-      _RL 
-     & smooth2D_Kux (1-Olx:sNx+Olx,1-Oly:sNy+Oly,nSx,nSy),
-     & smooth2D_Kvy (1-Olx:sNx+Olx,1-Oly:sNy+Oly,nSx,nSy)
-
-      COMMON /smooth_flds_rs/
-     & smooth_recip_hFacC, smooth_hFacW, smooth_hFacS
-
-      COMMON /smooth_flds_rl/
-     & smooth3Dnorm,smooth3DtotTime,
-     & smooth2Dnorm,smooth2DtotTime,
-     & smooth3D_Lx0,smooth3D_Ly0,smooth3D_Lz0,
-     & smooth3D_Lx,smooth3D_Ly,smooth3D_Lz,
-     & smooth2D_Lx0,smooth2D_Ly0,
-     & smooth2D_Lx,smooth2D_Ly
-
-      COMMON /smooth_flds_c/
-     & smooth3DmaskName, smooth2DmaskName
-
-      COMMON /smooth_operators_i/
-     & smooth3Dnbt, smooth2Dnbt,
-     & smooth2Dtype, smooth2Dsize,
-     & smooth3DtypeZ, smooth3DsizeZ,
-     & smooth3DtypeH, smooth3DsizeH,
-     & smooth2Dfilter, smooth3Dfilter
-
-      COMMON /smooth_operators_r/
-     & smooth3D_kappaR,smooth3D_Kwx,smooth3D_Kwy,smooth3D_Kwz,
-     & smooth3D_Kux,smooth3D_Kvy,smooth3D_Kuz,smooth3D_Kvz,
-     & smooth3D_Kuy,smooth3D_Kvx,
-     & smooth2D_Kux,smooth2D_Kvy
-
- 
+C---+----1----+----2----+----3----+----4----+----5----+----6----+----7-|--+----|

--- a/pkg/smooth/smooth2d.F
+++ b/pkg/smooth/smooth2d.F
@@ -1,7 +1,7 @@
 #include "SMOOTH_OPTIONS.h"
 
-      subroutine smooth2D (
-     U     fld_in,mask_in,smoothOpNb,mythid)
+      SUBROUTINE SMOOTH2D(
+     &           fld_in, mask_in, smoothOpNb, myThid )
 
 C     *==========================================================*
 C     | SUBROUTINE smooth2D
@@ -13,36 +13,29 @@ C     *==========================================================*
 #include "EEPARAMS.h"
 #include "GRID.h"
 #include "PARAMS.h"
-c#include "tamc.h"
 #include "SMOOTH.h"
 
+      _RL fld_in (1-OLx:sNx+OLx,1-OLy:sNy+OLy,nSx,nSy)
       _RS mask_in(1-OLx:sNx+OLx,1-OLy:sNy+OLy,nSx,nSy)
-      _RL fld_in(1-OLx:sNx+OLx,1-OLy:sNy+OLy,nSx,nSy)
-      integer smoothOpNb
-      integer nbt_in
-      character*( 80) fnamegeneric
-      integer i,j,bi,bj
-      integer itlo,ithi
-      integer jtlo,jthi
-      integer myThid
+      INTEGER smoothOpNb
+      INTEGER myThid
 
-      jtlo = mybylo(mythid)
-      jthi = mybyhi(mythid)
-      itlo = mybxlo(mythid)
-      ithi = mybxhi(mythid)
+      INTEGER nbt_in
+      CHARACTER*(80) fnamegeneric
 
-c read smoothing [i.e diffusion] operator:
-      write(fnamegeneric(1:80),'(1a,i3.3)')
+C read smoothing [i.e diffusion] operator:
+      WRITE(fnamegeneric(1:80),'(1A,I3.3)')
      &    'smooth2Doperator',smoothOpNb
-      CALL READ_REC_3D_RL(fnamegeneric,smoothprec,
-     &           1, smooth2D_Kux,1,1,mythid)
-      CALL READ_REC_3D_RL(fnamegeneric,smoothprec,
-     &           1, smooth2D_Kvy,2,1,mythid)
-      CALL EXCH_XY_RL ( smooth2D_Kux, myThid )
-      CALL EXCH_XY_RL ( smooth2D_Kvy, myThid )
+      CALL READ_REC_3D_RL( fnamegeneric, smoothprec,
+     &                     1, smooth2D_Kux, 1, 1, myThid )
+      CALL READ_REC_3D_RL( fnamegeneric, smoothprec,
+     &                     1, smooth2D_Kvy, 2, 1, myThid )
+      CALL EXCH_XY_RL( smooth2D_Kux, myThid )
+      CALL EXCH_XY_RL( smooth2D_Kvy, myThid )
 
-c do the smoothing:
-      nbt_in=smooth2Dnbt(smoothOpNb)
-      call smooth_diff2D(fld_in,mask_in,nbt_in,mythid)
+C do the smoothing:
+      nbt_in = smooth2Dnbt(smoothOpNb)
+      CALL SMOOTH_DIFF2D( fld_in, mask_in, nbt_in, myThid )
 
-      end
+      RETURN
+      END

--- a/pkg/smooth/smooth3d.F
+++ b/pkg/smooth/smooth3d.F
@@ -1,7 +1,7 @@
 #include "SMOOTH_OPTIONS.h"
 
-      subroutine smooth3D (
-     U     fld_in,smoothOpNb,mythid)
+      SUBROUTINE SMOOTH3D(
+     &           fld_in, smoothOpNb, myThid )
 
 C     *==========================================================*
 C     | SUBROUTINE smooth3D
@@ -13,61 +13,52 @@ C     *==========================================================*
 #include "EEPARAMS.h"
 #include "GRID.h"
 #include "PARAMS.h"
-c#include "tamc.h"
 #include "SMOOTH.h"
 
+      _RL fld_in(1-OLx:sNx+OLx,1-OLy:sNy+OLy,Nr,nSx,nSy)
+      INTEGER smoothOpNb
+      INTEGER myThid
 
-      _RL fld_in(1-OLx:sNx+OLx,1-OLy:sNy+OLy,nR,nSx,nSy)
-      integer smoothOpNb
-      integer nbt_in
-      character*( 80) fnamegeneric
-      integer i,j,k,bi,bj
-      integer itlo,ithi
-      integer jtlo,jthi
-      integer myThid
+      INTEGER nbt_in
+      CHARACTER*(80) fnamegeneric
 
-      jtlo = mybylo(mythid)
-      jthi = mybyhi(mythid)
-      itlo = mybxlo(mythid)
-      ithi = mybxhi(mythid)
-
-      
 c read smoothing [i.e diffusion] operator:
-      write(fnamegeneric(1:80),'(1a,i3.3)')
-     &    'smooth3Doperator',smoothOpNb
-      CALL READ_REC_3D_RL(fnamegeneric,smoothprec, 
-     &           Nr,smooth3D_Kwx,1, 1, myThid )
-      CALL READ_REC_3D_RL(fnamegeneric,smoothprec, 
-     &           Nr,smooth3D_Kwy,2, 1, myThid )
-      CALL READ_REC_3D_RL(fnamegeneric,smoothprec, 
-     &           Nr,smooth3D_Kwz,3, 1, myThid )
-      CALL READ_REC_3D_RL(fnamegeneric,smoothprec, 
-     &           Nr,smooth3D_Kux,4, 1, myThid )
-      CALL READ_REC_3D_RL(fnamegeneric,smoothprec, 
-     &           Nr,smooth3D_Kvy,5, 1, myThid )
-      CALL READ_REC_3D_RL(fnamegeneric,smoothprec, 
-     &           Nr,smooth3D_Kuz,6, 1, myThid )
-      CALL READ_REC_3D_RL(fnamegeneric,smoothprec, 
-     &           Nr,smooth3D_Kvz,7, 1, myThid )
-      CALL READ_REC_3D_RL(fnamegeneric,smoothprec, 
-     &           Nr,smooth3D_Kuy,8, 1, myThid )
-      CALL READ_REC_3D_RL(fnamegeneric,smoothprec, 
-     &           Nr,smooth3D_Kvx,9, 1, myThid )
-      CALL READ_REC_3D_RL(fnamegeneric,smoothprec, 
-     &           Nr,smooth3D_kappaR,10, 1, myThid )
-      CALL EXCH_XYZ_RL ( smooth3D_Kwx, myThid )
-      CALL EXCH_XYZ_RL ( smooth3D_Kwy, myThid )
-      CALL EXCH_XYZ_RL ( smooth3D_Kwz, myThid )
-      CALL EXCH_XYZ_RL ( smooth3D_Kux, myThid )
-      CALL EXCH_XYZ_RL ( smooth3D_Kvy, myThid )
-      CALL EXCH_XYZ_RL ( smooth3D_Kuz, myThid )
-      CALL EXCH_XYZ_RL ( smooth3D_Kvz, myThid )
-      CALL EXCH_XYZ_RL ( smooth3D_Kuy, myThid )
-      CALL EXCH_XYZ_RL ( smooth3D_Kvx, myThid )
-      CALL EXCH_XYZ_RL ( smooth3D_kappaR, myThid )
+      WRITE(fnamegeneric(1:80),'(1A,I3.3)')
+     &      'smooth3Doperator', smoothOpNb
+      CALL READ_REC_3D_RL( fnamegeneric, smoothprec,
+     &           Nr, smooth3D_Kwx, 1, 1, myThid )
+      CALL READ_REC_3D_RL( fnamegeneric, smoothprec,
+     &           Nr, smooth3D_Kwy, 2, 1, myThid )
+      CALL READ_REC_3D_RL( fnamegeneric, smoothprec,
+     &           Nr, smooth3D_Kwz, 3, 1, myThid )
+      CALL READ_REC_3D_RL( fnamegeneric, smoothprec,
+     &           Nr, smooth3D_Kux, 4, 1, myThid )
+      CALL READ_REC_3D_RL( fnamegeneric, smoothprec,
+     &           Nr, smooth3D_Kvy, 5, 1, myThid )
+      CALL READ_REC_3D_RL( fnamegeneric, smoothprec,
+     &           Nr, smooth3D_Kuz, 6, 1, myThid )
+      CALL READ_REC_3D_RL( fnamegeneric, smoothprec,
+     &           Nr, smooth3D_Kvz, 7, 1, myThid )
+      CALL READ_REC_3D_RL( fnamegeneric, smoothprec,
+     &           Nr, smooth3D_Kuy, 8, 1, myThid )
+      CALL READ_REC_3D_RL( fnamegeneric, smoothprec,
+     &           Nr, smooth3D_Kvx, 9, 1, myThid )
+      CALL READ_REC_3D_RL( fnamegeneric, smoothprec,
+     &           Nr, smooth3D_kappaR, 10, 1, myThid )
+      CALL EXCH_XYZ_RL( smooth3D_Kwx, myThid )
+      CALL EXCH_XYZ_RL( smooth3D_Kwy, myThid )
+      CALL EXCH_XYZ_RL( smooth3D_Kwz, myThid )
+      CALL EXCH_XYZ_RL( smooth3D_Kux, myThid )
+      CALL EXCH_XYZ_RL( smooth3D_Kvy, myThid )
+      CALL EXCH_XYZ_RL( smooth3D_Kuz, myThid )
+      CALL EXCH_XYZ_RL( smooth3D_Kvz, myThid )
+      CALL EXCH_XYZ_RL( smooth3D_Kuy, myThid )
+      CALL EXCH_XYZ_RL( smooth3D_Kvx, myThid )
+      CALL EXCH_XYZ_RL( smooth3D_kappaR, myThid )
 
 c do the smoothing:
-      nbt_in=smooth3Dnbt(smoothOpNb)
-      call smooth_diff3D(fld_in,nbt_in,mythid)
+      nbt_in = smooth3Dnbt(smoothOpNb)
+      CALL smooth_diff3D( fld_in, nbt_in, myThid )
 
-      end
+      RETURN
+      END

--- a/pkg/smooth/smooth_basic2d.F
+++ b/pkg/smooth/smooth_basic2d.F
@@ -1,7 +1,7 @@
 #include "SMOOTH_OPTIONS.h"
 
-      subroutine smooth_basic2D (
-     U     fld_in,mask_in,dist_in,nbt_in,mythid)
+      SUBROUTINE SMOOTH_BASIC2D(
+     &           fld_in, mask_in, dist_in, nbt_in, myThid )
 
 C     *==========================================================*
 C     | SUBROUTINE smooth_basic2D
@@ -15,23 +15,15 @@ C     *==========================================================*
 #include "EEPARAMS.h"
 #include "GRID.h"
 #include "PARAMS.h"
-c#include "tamc.h"
 #include "SMOOTH.h"
 
-      _RS mask_in(1-OLx:sNx+OLx,1-OLy:sNy+OLy,nSx,nSy)
       _RL fld_in(1-OLx:sNx+OLx,1-OLy:sNy+OLy,nSx,nSy)
+      _RS mask_in(1-OLx:sNx+OLx,1-OLy:sNy+OLy,nSx,nSy)
       _RL dist_in
-      integer nbt_in
-      integer i,j,bi,bj
-      integer itlo,ithi
-      integer jtlo,jthi
-      integer myThid
+      INTEGER nbt_in
+      INTEGER myThid
 
-
-      jtlo = mybylo(mythid)
-      jthi = mybyhi(mythid)
-      itlo = mybxlo(mythid)
-      ithi = mybxhi(mythid)
+      INTEGER i,j,bi,bj
 
       smooth2DtotTime=nbt_in*smooth2DdelTime
 
@@ -39,8 +31,8 @@ c#include "tamc.h"
        DO bi=myBxLo(myThid),myBxHi(myThid)
          DO j=1-OLy,sNy+OLy
           DO i=1-OLx,sNx+OLx
-          smooth2D_Lx(i,j,bi,bj)=dist_in
-          smooth2D_Ly(i,j,bi,bj)=dist_in
+            smooth2D_Lx(i,j,bi,bj) = dist_in
+            smooth2D_Ly(i,j,bi,bj) = dist_in
           ENDDO
          ENDDO
        ENDDO
@@ -50,20 +42,21 @@ c#include "tamc.h"
        DO bi=myBxLo(myThid),myBxHi(myThid)
          DO j=1-OLy,sNy+OLy
           DO i=1-OLx,sNx+OLx
-          smooth2D_Kux(i,j,bi,bj)=smooth2D_Lx(i,j,bi,bj)*
-     & smooth2D_Lx(i,j,bi,bj)/smooth2DtotTime/2
-          smooth2D_Kvy(i,j,bi,bj)=smooth2D_Ly(i,j,bi,bj)*
-     & smooth2D_Ly(i,j,bi,bj)/smooth2DtotTime/2
+            smooth2D_Kux(i,j,bi,bj) = smooth2D_Lx(i,j,bi,bj)*
+     &               smooth2D_Lx(i,j,bi,bj)/smooth2DtotTime/2
+            smooth2D_Kvy(i,j,bi,bj) = smooth2D_Ly(i,j,bi,bj)*
+     &               smooth2D_Ly(i,j,bi,bj)/smooth2DtotTime/2
           ENDDO
          ENDDO
        ENDDO
       ENDDO
 
-      CALL EXCH_XY_RL ( smooth2D_Kux , myThid )
-      CALL EXCH_XY_RL ( smooth2D_Kvy , myThid )
+      CALL EXCH_XY_RL( smooth2D_Kux , myThid )
+      CALL EXCH_XY_RL( smooth2D_Kvy , myThid )
 
-      call smooth_diff2D(fld_in,mask_in,nbt_in,mythid)
+      CALL SMOOTH_DIFF2D( fld_in, mask_in, nbt_in, myThid )
 
-      CALL EXCH_XY_RL ( fld_in , myThid )
+      CALL EXCH_XY_RL( fld_in , myThid )
 
-      end
+      RETURN
+      END

--- a/pkg/smooth/smooth_check.F
+++ b/pkg/smooth/smooth_check.F
@@ -16,8 +16,6 @@ C     !USES:
 C     == global variables ==
 #include "EEPARAMS.h"
 #include "SIZE.h"
-#include "PARAMS.h"
-#include "GRID.h"
 #include "SMOOTH.h"
 
 C     !INPUT/OUTPUT PARAMETERS:

--- a/pkg/smooth/smooth_correl2d.F
+++ b/pkg/smooth/smooth_correl2d.F
@@ -1,7 +1,7 @@
 #include "SMOOTH_OPTIONS.h"
 
-      subroutine smooth_correl2D (
-     U     fld_in,mask_in,smoothOpNb,mythid)
+      SUBROUTINE SMOOTH_CORREL2D(
+     &           fld_in, mask_in, smoothOpNb, myThid )
 
 C     *==========================================================*
 C     | SUBROUTINE smooth_correl2D
@@ -14,50 +14,41 @@ C     *==========================================================*
 #include "EEPARAMS.h"
 #include "GRID.h"
 #include "PARAMS.h"
-c#include "tamc.h"
 #include "SMOOTH.h"
 
-      _RS mask_in(1-OLx:sNx+OLx,1-OLy:sNy+OLy,nSx,nSy)
       _RL fld_in(1-OLx:sNx+OLx,1-OLy:sNy+OLy,nSx,nSy)
-      integer smoothOpNb
-      integer nbt_in
-      character*( 80) fnamegeneric
-      integer i,j,bi,bj
-      integer itlo,ithi
-      integer jtlo,jthi
-      integer myThid
+      _RS mask_in(1-OLx:sNx+OLx,1-OLy:sNy+OLy,nSx,nSy)
+      INTEGER smoothOpNb
+      INTEGER myThid
 
-
-      jtlo = mybylo(mythid)
-      jthi = mybyhi(mythid)
-      itlo = mybxlo(mythid)
-      ithi = mybxhi(mythid)
-
+      INTEGER nbt_in
+      CHARACTER*( 80) fnamegeneric
+      INTEGER i,j,bi,bj
 
 c read smoothing [i.e diffusion] operator:
-      write(fnamegeneric(1:80),'(1a,i3.3)')
+      WRITE(fnamegeneric(1:80),'(1A,I3.3)')
      &    'smooth2Doperator',smoothOpNb
-      CALL READ_REC_3D_RL(fnamegeneric,smoothprec,
-     &           1, smooth2D_Kux,1,1,mythid)
-      CALL READ_REC_3D_RL(fnamegeneric,smoothprec,
-     &           1, smooth2D_Kvy,2,1,mythid)
-      CALL EXCH_XY_RL ( smooth2D_Kux, myThid )
-      CALL EXCH_XY_RL ( smooth2D_Kvy, myThid )
+      CALL READ_REC_3D_RL( fnamegeneric, smoothprec,
+     &                     1, smooth2D_Kux,1,1,myThid )
+      CALL READ_REC_3D_RL( fnamegeneric, smoothprec,
+     &                     1, smooth2D_Kvy,2,1,myThid )
+      CALL EXCH_XY_RL( smooth2D_Kux, myThid )
+      CALL EXCH_XY_RL( smooth2D_Kvy, myThid )
 
 c read normalization field [i.e. 1/sqrt(var(filter))]:
-      write(fnamegeneric(1:80),'(1a,i3.3)')
+      WRITE(fnamegeneric(1:80),'(1A,I3.3)')
      &    'smooth2Dnorm',smoothOpNb
-      CALL READ_REC_3D_RL(fnamegeneric,smoothprec,
-     &           1, smooth2Dnorm,1,1,mythid)
-      CALL EXCH_XY_RL ( smooth2Dnorm, myThid )
+      CALL READ_REC_3D_RL( fnamegeneric, smoothprec,
+     &                     1, smooth2Dnorm, 1, 1, myThid )
+      CALL EXCH_XY_RL( smooth2Dnorm, myThid )
 
 c division by ~sqrt(area):
-      DO bj = jtlo,jthi
-       DO bi = itlo,ithi
+      DO bj=myByLo(myThid),myByHi(myThid)
+       DO bi=myBxLo(myThid),myBxHi(myThid)
         DO j = 1,sNy
          DO i = 1,sNx
-      fld_in(i,j,bi,bj)=fld_in(i,j,bi,bj)
-     & *sqrt(recip_rA(i,j,bi,bj))
+           fld_in(i,j,bi,bj)=fld_in(i,j,bi,bj)
+     & *SQRT(recip_rA(i,j,bi,bj))
          ENDDO
         ENDDO
        ENDDO
@@ -65,20 +56,21 @@ c division by ~sqrt(area):
       CALL EXCH_XY_RL ( fld_in , myThid )
 
 c do the smoothing:
-      nbt_in=smooth2Dnbt(smoothOpNb)/2
-      call smooth_diff2D(fld_in,mask_in,nbt_in,mythid)
+      nbt_in = smooth2Dnbt(smoothOpNb)/2
+      CALL SMOOTH_DIFF2D( fld_in, mask_in, nbt_in, myThid )
 
 c division by ~sqrt(var(filter)):
-       do bj = jtlo,jthi
-        do bi = itlo,ithi
+      DO bj=myByLo(myThid),myByHi(myThid)
+       DO bi=myBxLo(myThid),myBxHi(myThid)
          DO j = 1,sNy
           DO i = 1,sNx
-       fld_in(i,j,bi,bj)=fld_in(i,j,bi,bj)
-     & *smooth2Dnorm(i,j,bi,bj)
+            fld_in(i,j,bi,bj) = fld_in(i,j,bi,bj)
+     &                        *smooth2Dnorm(i,j,bi,bj)
           ENDDO
          ENDDO
         ENDDO
        ENDDO
-      CALL EXCH_XY_RL ( fld_in , myThid )
+      CALL EXCH_XY_RL( fld_in , myThid )
 
-      end
+      RETURN
+      END

--- a/pkg/smooth/smooth_correl2dw.F
+++ b/pkg/smooth/smooth_correl2dw.F
@@ -6,8 +6,8 @@
 # include "ECCO_OPTIONS.h"
 #endif
 
-      subroutine smooth_correl2Dw (
-     U     fld_in,mask_in,xx_gen_file,mythid)
+      SUBROUTINE SMOOTH_CORREL2DW(
+     &           fld_in, mask_in, xx_gen_file, myThid )
 
 C     *==========================================================*
 C     | SUBROUTINE smooth_correl2Dw
@@ -31,94 +31,86 @@ C     *==========================================================*
 # include "ecco_cost.h"
 #endif
 
-      _RS mask_in(1-OLx:sNx+OLx,1-OLy:sNy+OLy,nSx,nSy)
       _RL fld_in (1-OLx:sNx+OLx,1-OLy:sNy+OLy,nSx,nSy)
-      character*(MAX_LEN_FNAM) xx_gen_file
-      integer myThid
+      _RS mask_in(1-OLx:sNx+OLx,1-OLy:sNy+OLy,nSx,nSy)
+      CHARACTER*(MAX_LEN_FNAM) xx_gen_file
+      INTEGER myThid
 
 #ifdef ECCO_CTRL_DEPRECATED
 
 # if (defined ALLOW_CTRL) || (defined ALLOW_ECCO)
 
-      integer i,j,bi,bj
-      integer itlo,ithi
-      integer jtlo,jthi
+      INTEGER i,j,bi,bj
       _RL tmpW
       LOGICAL weightWasFound
-#if (defined (ALLOW_GENARR2D_CONTROL) || defined (ALLOW_GENARR3D_CONTROL) || defined (ALLOW_GENTIM2D_CONTROL))
+#ifdef ALLOW_GENTIM2D_CONTROL
       INTEGER iarr
 #endif
 
-      jtlo = mybylo(mythid)
-      jthi = mybyhi(mythid)
-      itlo = mybxlo(mythid)
-      ithi = mybxhi(mythid)
-
-
-      DO bj = jtlo,jthi
-       DO bi = itlo,ithi
+      DO bj=myByLo(myThid),myByHi(myThid)
+       DO bi=myBxLo(myThid),myBxHi(myThid)
         DO j = 1,sNy
          DO i = 1,sNx
 
-        weightWasFound=.TRUE.
+          weightWasFound = .TRUE.
 
-        if ( xx_gen_file .EQ. xx_hflux_file ) then
-        tmpW=whflux(i,j,bi,bj)
-        elseif ( xx_gen_file .EQ. xx_sflux_file ) then
-        tmpW=wsflux(i,j,bi,bj)
-        elseif ( xx_gen_file .EQ. xx_tauu_file ) then
-        tmpW=wtauu(i,j,bi,bj)
-        elseif ( xx_gen_file .EQ. xx_tauv_file ) then
-        tmpW=wtauv(i,j,bi,bj)
+          IF ( xx_gen_file .EQ. xx_hflux_file ) THEN
+           tmpW = whflux(i,j,bi,bj)
+          ELSEIF ( xx_gen_file .EQ. xx_sflux_file ) THEN
+           tmpW = wsflux(i,j,bi,bj)
+          ELSEIF ( xx_gen_file .EQ. xx_tauu_file ) THEN
+           tmpW = wtauu(i,j,bi,bj)
+          ELSEIF ( xx_gen_file .EQ. xx_tauv_file ) THEN
+           tmpW = wtauv(i,j,bi,bj)
 
-        elseif ( xx_gen_file .EQ. xx_atemp_file ) then
-        tmpW=watemp(i,j,bi,bj)
-        elseif ( xx_gen_file .EQ. xx_aqh_file ) then
-        tmpW=waqh(i,j,bi,bj)
-        elseif ( xx_gen_file .EQ. xx_precip_file ) then
-        tmpW=wprecip(i,j,bi,bj)
-        elseif ( xx_gen_file .EQ. xx_snowprecip_file ) then
-        tmpW=wsnowprecip(i,j,bi,bj)
+          ELSEIF ( xx_gen_file .EQ. xx_atemp_file ) THEN
+           tmpW = watemp(i,j,bi,bj)
+          ELSEIF ( xx_gen_file .EQ. xx_aqh_file ) THEN
+           tmpW = waqh(i,j,bi,bj)
+          ELSEIF ( xx_gen_file .EQ. xx_precip_file ) THEN
+           tmpW = wprecip(i,j,bi,bj)
+          ELSEIF ( xx_gen_file .EQ. xx_snowprecip_file ) THEN
+           tmpW = wsnowprecip(i,j,bi,bj)
 
-        elseif ( xx_gen_file .EQ. xx_swflux_file ) then
-        tmpW=wswflux(i,j,bi,bj)
-        elseif ( xx_gen_file .EQ. xx_swdown_file ) then
-        tmpW=wswdown(i,j,bi,bj)
-        elseif ( xx_gen_file .EQ. xx_lwflux_file ) then
-        tmpW=wlwflux(i,j,bi,bj)
-        elseif ( xx_gen_file .EQ. xx_lwdown_file ) then
-        tmpW=wlwdown(i,j,bi,bj)
+          ELSEIF ( xx_gen_file .EQ. xx_swflux_file ) THEN
+           tmpW = wswflux(i,j,bi,bj)
+          ELSEIF ( xx_gen_file .EQ. xx_swdown_file ) THEN
+           tmpW = wswdown(i,j,bi,bj)
+          ELSEIF ( xx_gen_file .EQ. xx_lwflux_file ) THEN
+           tmpW = wlwflux(i,j,bi,bj)
+          ELSEIF ( xx_gen_file .EQ. xx_lwdown_file ) THEN
+           tmpW = wlwdown(i,j,bi,bj)
 
-        elseif ( xx_gen_file .EQ. xx_evap_file ) then
-        tmpW=wevap(i,j,bi,bj)
-        elseif ( xx_gen_file .EQ. xx_apressure_file ) then
-        tmpW=wapressure(i,j,bi,bj)
-        elseif ( xx_gen_file .EQ. xx_uwind_file ) then
-        tmpW=wuwind(i,j,bi,bj)
-        elseif ( xx_gen_file .EQ. xx_vwind_file ) then
-        tmpW=wvwind(i,j,bi,bj)
+          ELSEIF ( xx_gen_file .EQ. xx_evap_file ) THEN
+           tmpW = wevap(i,j,bi,bj)
+          ELSEIF ( xx_gen_file .EQ. xx_apressure_file ) THEN
+           tmpW = wapressure(i,j,bi,bj)
+          ELSEIF ( xx_gen_file .EQ. xx_uwind_file ) THEN
+           tmpW = wuwind(i,j,bi,bj)
+          ELSEIF ( xx_gen_file .EQ. xx_vwind_file ) THEN
+           tmpW = wvwind(i,j,bi,bj)
 
-        else
-          tmpW=0.
-          weightWasFound=.FALSE.
-        endif
+          ELSE
+            tmpW = 0.
+            weightWasFound=.FALSE.
+          ENDIF
 
 #ifdef ALLOW_CTRL
 #ifdef ALLOW_GENTIM2D_CONTROL
-      do iarr = 1, maxCtrlTim2D
-        if ( xx_gen_file .EQ. xx_gentim2d_file(iarr) ) then
-          tmpW=wgentim2d(i,j,bi,bj,iarr)
-          weightWasFound=.TRUE.
-        endif
-      enddo
+          DO iarr = 1, maxCtrlTim2D
+           IF ( xx_gen_file .EQ. xx_gentim2d_file(iarr) ) THEN
+             tmpW = wgentim2d(i,j,bi,bj,iarr)
+             weightWasFound = .TRUE.
+           ENDIF
+          ENDDO
 #endif
 #endif
 
-      if ((mask_in(i,j,bi,bj).NE.0.).AND.(tmpW.NE.0.)) then
-      fld_in(i,j,bi,bj)=fld_in(i,j,bi,bj)/sqrt(tmpW)
-      else
-      fld_in(i,j,bi,bj)=fld_in(i,j,bi,bj)*0.
-      endif
+          IF ( (mask_in(i,j,bi,bj).NE.0.) .AND. (tmpW.NE.0.) ) THEN
+           fld_in(i,j,bi,bj) = fld_in(i,j,bi,bj)/SQRT(tmpW)
+          ELSE
+           fld_in(i,j,bi,bj) = fld_in(i,j,bi,bj)*0.
+          ENDIF
 
          ENDDO
         ENDDO
@@ -127,11 +119,12 @@ C     *==========================================================*
 
       CALL EXCH_XY_RL ( fld_in , myThid )
 
-      if (.NOT.weightWasFound) WRITE(errorMessageUnit,'(2A)' )
-     &       'WARNING: no weights found for ',xx_gen_file
+      IF (.NOT.weightWasFound) WRITE(errorMessageUnit,'(2A)' )
+     &       'WARNING: no weights found for ', xx_gen_file
 
 #endif /* ALLOW_ECCO or ALLOW_CTRL */
 
 #endif /* ECCO_CTRL_DEPRECATED */
 
-      end
+      RETURN
+      END

--- a/pkg/smooth/smooth_correl3d.F
+++ b/pkg/smooth/smooth_correl3d.F
@@ -1,11 +1,11 @@
 #include "SMOOTH_OPTIONS.h"
 
-      subroutine smooth_correl3D (
-     U     fld_in,smoothOpNb,mythid)
+      SUBROUTINE SMOOTH_CORREL3D(
+     &           fld_in, smoothOpNb, myThid )
 
 C     *==========================================================*
 C     | SUBROUTINE smooth_correl3D
-C     | o Routine that applies spatial correlation 
+C     | o Routine that applies spatial correlation
 C     |   operator to a 3D control field
 C     *==========================================================*
 
@@ -14,99 +14,90 @@ C     *==========================================================*
 #include "EEPARAMS.h"
 #include "GRID.h"
 #include "PARAMS.h"
-c#include "tamc.h"
 #include "SMOOTH.h"
 
+      _RL fld_in(1-OLx:sNx+OLx,1-OLy:sNy+OLy,Nr,nSx,nSy)
+      INTEGER smoothOpNb
+      INTEGER myThid
 
-      _RL fld_in(1-OLx:sNx+OLx,1-OLy:sNy+OLy,nR,nSx,nSy)
-      integer smoothOpNb
-      integer nbt_in
-      character*( 80) fnamegeneric
-      integer i,j,k,bi,bj
-      integer itlo,ithi
-      integer jtlo,jthi
-      integer myThid
+      INTEGER nbt_in
+      CHARACTER*(80) fnamegeneric
+      INTEGER i,j,k,bi,bj
 
-
-      jtlo = mybylo(mythid)
-      jthi = mybyhi(mythid)
-      itlo = mybxlo(mythid)
-      ithi = mybxhi(mythid)
-
-      
 c read smoothing [i.e diffusion] operator:
-      write(fnamegeneric(1:80),'(1a,i3.3)')
-     &    'smooth3Doperator',smoothOpNb
-      CALL READ_REC_3D_RL(fnamegeneric,smoothprec, 
-     &           Nr,smooth3D_Kwx,1, 1, myThid )
-      CALL READ_REC_3D_RL(fnamegeneric,smoothprec, 
-     &           Nr,smooth3D_Kwy,2, 1, myThid )
-      CALL READ_REC_3D_RL(fnamegeneric,smoothprec, 
-     &           Nr,smooth3D_Kwz,3, 1, myThid )
-      CALL READ_REC_3D_RL(fnamegeneric,smoothprec, 
-     &           Nr,smooth3D_Kux,4, 1, myThid )
-      CALL READ_REC_3D_RL(fnamegeneric,smoothprec, 
-     &           Nr,smooth3D_Kvy,5, 1, myThid )
-      CALL READ_REC_3D_RL(fnamegeneric,smoothprec, 
-     &           Nr,smooth3D_Kuz,6, 1, myThid )
-      CALL READ_REC_3D_RL(fnamegeneric,smoothprec, 
-     &           Nr,smooth3D_Kvz,7, 1, myThid )
-      CALL READ_REC_3D_RL(fnamegeneric,smoothprec, 
-     &           Nr,smooth3D_Kuy,8, 1, myThid )
-      CALL READ_REC_3D_RL(fnamegeneric,smoothprec, 
-     &           Nr,smooth3D_Kvx,9, 1, myThid )
-      CALL READ_REC_3D_RL(fnamegeneric,smoothprec, 
-     &           Nr,smooth3D_kappaR,10, 1, myThid )
-      CALL EXCH_XYZ_RL ( smooth3D_Kwx, myThid )
-      CALL EXCH_XYZ_RL ( smooth3D_Kwy, myThid )
-      CALL EXCH_XYZ_RL ( smooth3D_Kwz, myThid )
-      CALL EXCH_XYZ_RL ( smooth3D_Kux, myThid )
-      CALL EXCH_XYZ_RL ( smooth3D_Kvy, myThid )
-      CALL EXCH_XYZ_RL ( smooth3D_Kuz, myThid )
-      CALL EXCH_XYZ_RL ( smooth3D_Kvz, myThid )
-      CALL EXCH_XYZ_RL ( smooth3D_Kuy, myThid )
-      CALL EXCH_XYZ_RL ( smooth3D_Kvx, myThid )
-      CALL EXCH_XYZ_RL ( smooth3D_kappaR, myThid )
+      WRITE(fnamegeneric(1:80),'(1A,I3.3)')
+     &      'smooth3Doperator', smoothOpNb
+      CALL READ_REC_3D_RL( fnamegeneric, smoothprec,
+     &           Nr, smooth3D_Kwx, 1, 1, myThid )
+      CALL READ_REC_3D_RL( fnamegeneric, smoothprec,
+     &           Nr, smooth3D_Kwy, 2, 1, myThid )
+      CALL READ_REC_3D_RL( fnamegeneric, smoothprec,
+     &           Nr, smooth3D_Kwz, 3, 1, myThid )
+      CALL READ_REC_3D_RL( fnamegeneric, smoothprec,
+     &           Nr, smooth3D_Kux, 4, 1, myThid )
+      CALL READ_REC_3D_RL( fnamegeneric, smoothprec,
+     &           Nr, smooth3D_Kvy, 5, 1, myThid )
+      CALL READ_REC_3D_RL( fnamegeneric, smoothprec,
+     &           Nr, smooth3D_Kuz, 6, 1, myThid )
+      CALL READ_REC_3D_RL( fnamegeneric, smoothprec,
+     &           Nr, smooth3D_Kvz, 7, 1, myThid )
+      CALL READ_REC_3D_RL( fnamegeneric, smoothprec,
+     &           Nr, smooth3D_Kuy, 8, 1, myThid )
+      CALL READ_REC_3D_RL( fnamegeneric, smoothprec,
+     &           Nr, smooth3D_Kvx, 9, 1, myThid )
+      CALL READ_REC_3D_RL( fnamegeneric, smoothprec,
+     &           Nr, smooth3D_kappaR, 10, 1, myThid )
+      CALL EXCH_XYZ_RL( smooth3D_Kwx, myThid )
+      CALL EXCH_XYZ_RL( smooth3D_Kwy, myThid )
+      CALL EXCH_XYZ_RL( smooth3D_Kwz, myThid )
+      CALL EXCH_XYZ_RL( smooth3D_Kux, myThid )
+      CALL EXCH_XYZ_RL( smooth3D_Kvy, myThid )
+      CALL EXCH_XYZ_RL( smooth3D_Kuz, myThid )
+      CALL EXCH_XYZ_RL( smooth3D_Kvz, myThid )
+      CALL EXCH_XYZ_RL( smooth3D_Kuy, myThid )
+      CALL EXCH_XYZ_RL( smooth3D_Kvx, myThid )
+      CALL EXCH_XYZ_RL( smooth3D_kappaR, myThid )
 
 c read normalization field [i.e. 1/sqrt(var(filter))]:
-      write(fnamegeneric(1:80),'(1a,i3.3)')
-     &    'smooth3Dnorm',smoothOpNb
-      CALL READ_REC_3D_RL(fnamegeneric,smoothprec,
-     &           Nr, smooth3Dnorm,1,1,mythid)
-      CALL EXCH_XYZ_RL ( smooth3Dnorm, myThid )
+      WRITE(fnamegeneric(1:80),'(1A,I3.3)')
+     &      'smooth3Dnorm', smoothOpNb
+      CALL READ_REC_3D_RL( fnamegeneric, smoothprec,
+     &           Nr, smooth3Dnorm, 1, 1, myThid)
+      CALL EXCH_XYZ_RL( smooth3Dnorm, myThid )
 
 c division by ~sqrt(volume):
-      DO bj=jtlo,jthi
-       DO bi=itlo,ithi
+      DO bj=myByLo(myThid),myByHi(myThid)
+       DO bi=myBxLo(myThid),myBxHi(myThid)
         DO k=1,Nr
          DO j=1,sNy
-          DO i=1,sNx 
-           fld_in(i,j,k,bi,bj)=fld_in(i,j,k,bi,bj)
-     & *sqrt(recip_rA(i,j,bi,bj)*recip_drF(k))
+          DO i=1,sNx
+           fld_in(i,j,k,bi,bj) = fld_in(i,j,k,bi,bj)
+     &          *SQRT(recip_rA(i,j,bi,bj)*recip_drF(k))
           ENDDO
          ENDDO
         ENDDO
        ENDDO
       ENDDO
-      CALL EXCH_XYZ_RL ( fld_in , myThid )
+      CALL EXCH_XYZ_RL( fld_in, myThid )
 
 c do the smoothing:
-      nbt_in=smooth3Dnbt(smoothOpNb)/2
-      call smooth_diff3D(fld_in,nbt_in,mythid)
+      nbt_in = smooth3Dnbt(smoothOpNb)/2
+      CALL smooth_diff3D( fld_in, nbt_in, myThid )
 
 c division by ~sqrt(var(filter)):
-       do bj = jtlo,jthi
-        do bi = itlo,ithi
-         DO j = 1,sNy
-          DO i = 1,sNx
-           DO k = 1,nR
-       fld_in(i,j,k,bi,bj)=fld_in(i,j,k,bi,bj)
-     & *smooth3Dnorm(i,j,k,bi,bj)
-           ENDDO
+      DO bj=myByLo(myThid),myByHi(myThid)
+       DO bi=myBxLo(myThid),myBxHi(myThid)
+        DO j = 1,sNy
+         DO i = 1,sNx
+          DO k = 1,Nr
+           fld_in(i,j,k,bi,bj) = fld_in(i,j,k,bi,bj)
+     &                          *smooth3Dnorm(i,j,k,bi,bj)
           ENDDO
          ENDDO
         ENDDO
        ENDDO
-      CALL EXCH_XYZ_RL ( fld_in , myThid )
+      ENDDO
+      CALL EXCH_XYZ_RL( fld_in, myThid )
 
-      end
+      RETURN
+      END

--- a/pkg/smooth/smooth_diff2d.F
+++ b/pkg/smooth/smooth_diff2d.F
@@ -3,8 +3,8 @@
 # include "AUTODIFF_OPTIONS.h"
 #endif
 
-      subroutine smooth_diff2D (
-     U     fld_in,smooth2Dmask,nbt_in,mythid)
+      SUBROUTINE SMOOTH_DIFF2D(
+     &           fld_in, smooth2Dmask, nbt_in, myThid )
 
 C     *==========================================================*
 C     | SUBROUTINE smooth_diff2D
@@ -21,63 +21,57 @@ C     *==========================================================*
 #endif /* ALLOW_AUTODIFF_TAMC */
 #include "SMOOTH.h"
 
-      integer i,j,k, bi, bj
-      integer itlo,ithi
-      integer jtlo,jthi
-      integer myThid,myIter(nSx,nSy),key_in
-
+      _RL fld_in      (1-OLx:sNx+OLx,1-OLy:sNy+OLy,nSx,nSy)
       _RS smooth2Dmask(1-OLx:sNx+OLx,1-OLy:sNy+OLy,nSx,nSy)
+      INTEGER nbt_in
+      INTEGER myThid
 
-      _RL fld_in(1-OLx:sNx+OLx,1-OLy:sNy+OLy,nSx,nSy)
-      _RL gt_in(1-OLx:sNx+OLx,1-OLy:sNy+OLy,nSx,nSy)
-      _RL gtm1_in(1-OLx:sNx+OLx,1-OLy:sNy+OLy,nSx,nSy)
-      integer nbt_in
-
-      integer iloop, ilev_1, ilev_2, ilev_3
-      integer max_lev2, max_lev3
-      _RL ab15,ab05
+      INTEGER i, j, bi, bj
+      INTEGER myIter(nSx,nSy), iloop
+      _RL ab15, ab05
       _RL gt_tmp
-      character*( 80) fnamegeneric
+      _RL gt_in  (1-OLx:sNx+OLx,1-OLy:sNy+OLy,nSx,nSy)
+      _RL gtm1_in(1-OLx:sNx+OLx,1-OLy:sNy+OLy,nSx,nSy)
+#ifdef ALLOW_TAMC_CHECKPOINTING
+      INTEGER ilev_1, ilev_2, ilev_3
+      INTEGER max_lev2, max_lev3, key_in
+#endif
 
-
+#ifdef ALLOW_TAMC_CHECKPOINTING
 c for now: useless, because level 3 is recomputed anyway
 c but : if level3 was computed during the fwd loop by calling
 c       mdsmooth_diff3D (assumes that it would be called
 c       directly by the_main_loop) then I would need to pass key_in
 c       as a parameter, with different values for T, S, ...
 c       in order not to overwrite the same tape
-      key_in=0
+      key_in = 0
+#endif
 
-      jtlo = mybylo(mythid)
-      jthi = mybyhi(mythid)
-      itlo = mybxlo(mythid)
-      ithi = mybxhi(mythid)
-
-      DO bj = jtlo,jthi
-       DO bi = itlo,ithi
+      DO bj=myByLo(myThid),myByHi(myThid)
+       DO bi=myBxLo(myThid),myBxHi(myThid)
         DO j = 1,sNy
          DO i = 1,sNx
            gt_in(i,j,bi,bj)   = 0. _d 0
-           gtm1_in(i,j,bi,bj)   = 0. _d 0
+           gtm1_in(i,j,bi,bj) = 0. _d 0
          ENDDO
         ENDDO
        ENDDO
       ENDDO
 
-      CALL EXCH_XY_RL ( fld_in , myThid )
-      CALL EXCH_XY_RL ( gt_in , myThid )
-      CALL EXCH_XY_RL ( gtm1_in , myThid )
+      CALL EXCH_XY_RL( fld_in,  myThid )
+      CALL EXCH_XY_RL( gt_in,   myThid )
+      CALL EXCH_XY_RL( gtm1_in, myThid )
 
 #ifdef ALLOW_TAMC_CHECKPOINTING
 
 c checkpointing:
-      max_lev3=nbt_in/(nchklev_1*nchklev_2)+1
-      max_lev2=nbt_in/nchklev_1+1
+      max_lev3 = nbt_in/(nchklev_1*nchklev_2)+1
+      max_lev2 = nbt_in/nchklev_1+1
 #ifdef ALLOW_AUTODIFF_TAMC
 CADJ INIT tape_smooth2D_lev3 = USER
 #endif /* ALLOW_AUTODIFF_TAMC */
-      do ilev_3 = 1,nchklev_3
-        if(ilev_3.le.max_lev3) then
+      DO ilev_3 = 1,nchklev_3
+       IF (ilev_3.LE.max_lev3) THEN
 #ifdef ALLOW_AUTODIFF_TAMC
 CADJ STORE fld_in = tape_smooth2D_lev3 ,
 CADJ & key = key_in*max_lev3 + ilev_3
@@ -88,8 +82,8 @@ CADJ & key = key_in*max_lev3 + ilev_3
 CADJ INIT tape_smooth2D_lev2 = USER
 #endif /* ALLOW_AUTODIFF_TAMC */
 
-      do ilev_2 = 1,nchklev_2
-         if(ilev_2.le.max_lev2) then
+        DO ilev_2 = 1,nchklev_2
+         IF (ilev_2.LE.max_lev2) THEN
 #ifdef ALLOW_AUTODIFF_TAMC
 CADJ STORE fld_in = tape_smooth2D_lev2 ,
 CADJ & key = key_in*nchklev_2 + ilev_2
@@ -98,13 +92,13 @@ CADJ & key = key_in*nchklev_2 + ilev_2
 #endif /* ALLOW_AUTODIFF_TAMC */
 #ifdef ALLOW_AUTODIFF_TAMC
 CADJ INIT tape_smooth2D_lev1  = COMMON,
-CADJ & nchklev_1*nsx*nsy*nthreads_chkpt
+CADJ & nchklev_1*nSx*nSy*nthreads_chkpt
 #endif /* ALLOW_AUTODIFF_TAMC */
 
-      do ilev_1 = 1,nchklev_1
-      iloop = (ilev_2 - 1)*nchklev_1 + ilev_1
-     &            + (ilev_3 - 1)*nchklev_2*nchklev_1
-      if ( iloop .le. nbt_in ) then
+          DO ilev_1 = 1,nchklev_1
+           iloop = (ilev_2 - 1)*nchklev_1 + ilev_1
+     &           + (ilev_3 - 1)*nchklev_2*nchklev_1
+           IF ( iloop .LE. nbt_in ) THEN
 #ifdef ALLOW_AUTODIFF_TAMC
 c needed?? CADJ STORE fld_in = tape_smooth2D_lev1 ,
 c CADJ & key = key_in*nchklev_1 + ilev_1
@@ -112,87 +106,90 @@ CADJ STORE gtm1_in = tape_smooth2D_lev1 ,
 CADJ & key = key_in*nchklev_1 + ilev_1
 #endif /* ALLOW_AUTODIFF_TAMC */
 
-
 #else /* ALLOW_TAMC_CHECKPOINTING */
-      do iloop=1,nbt_in
+      DO iloop=1,nbt_in
 #endif
 
-      DO bj = jtlo,jthi
-         DO bi = itlo,ithi
-            DO j = 1,sNy
-               DO i = 1,sNx
+        DO bj=myByLo(myThid),myByHi(myThid)
+         DO bi=myBxLo(myThid),myBxHi(myThid)
+          DO j = 1,sNy
+           DO i = 1,sNx
 
-      gt_in(i,j,bi,bj)=0.
+            gt_in(i,j,bi,bj)=0.
 
-      if (smooth2Dmask(i,j,bi,bj).NE.0.) then
+            IF (smooth2Dmask(i,j,bi,bj).NE.0.) THEN
 
-      gt_in(i,j,bi,bj)=gt_in(i,j,bi,bj)+
-     & smooth2D_Kux(i,j,bi,bj)*dyG(i,j,bi,bj)*
-     & smooth2Dmask(i,j,bi,bj)*smooth2Dmask(i-1,j,bi,bj)*
-     & (fld_in(i,j,bi,bj)-fld_in(i-1,j,bi,bj))*recip_dxC(i,j,bi,bj)
+             gt_in(i,j,bi,bj) = gt_in(i,j,bi,bj)
+     &         + smooth2D_Kux(i,j,bi,bj)*dyG(i,j,bi,bj)
+     &          *smooth2Dmask(i,j,bi,bj)*smooth2Dmask(i-1,j,bi,bj)
+     &          *( fld_in(i,j,bi,bj) - fld_in(i-1,j,bi,bj) )
+     &          *recip_dxC(i,j,bi,bj)
 
-      gt_in(i,j,bi,bj)=gt_in(i,j,bi,bj)+
-     & smooth2D_Kux(i+1,j,bi,bj)*dyG(i+1,j,bi,bj)*
-     & smooth2Dmask(i,j,bi,bj)*smooth2Dmask(i+1,j,bi,bj)*
-     & (fld_in(i,j,bi,bj)-fld_in(i+1,j,bi,bj))*recip_dxC(i+1,j,bi,bj)
+             gt_in(i,j,bi,bj) = gt_in(i,j,bi,bj)
+     &         + smooth2D_Kux(i+1,j,bi,bj)*dyG(i+1,j,bi,bj)
+     &          *smooth2Dmask(i,j,bi,bj)*smooth2Dmask(i+1,j,bi,bj)
+     &          *( fld_in(i,j,bi,bj) - fld_in(i+1,j,bi,bj) )
+     &          *recip_dxC(i+1,j,bi,bj)
 
-      gt_in(i,j,bi,bj)=gt_in(i,j,bi,bj)+
-     & smooth2D_Kvy(i,j,bi,bj)*dxG(i,j,bi,bj)*
-     & smooth2Dmask(i,j,bi,bj)*smooth2Dmask(i,j-1,bi,bj)*
-     & (fld_in(i,j,bi,bj)-fld_in(i,j-1,bi,bj))*recip_dyC(i,j,bi,bj)
+             gt_in(i,j,bi,bj) = gt_in(i,j,bi,bj)
+     &         + smooth2D_Kvy(i,j,bi,bj)*dxG(i,j,bi,bj)
+     &          *smooth2Dmask(i,j,bi,bj)*smooth2Dmask(i,j-1,bi,bj)
+     &          *( fld_in(i,j,bi,bj) - fld_in(i,j-1,bi,bj) )
+     &          *recip_dyC(i,j,bi,bj)
 
-      gt_in(i,j,bi,bj)=gt_in(i,j,bi,bj)+
-     & smooth2D_Kvy(i,j+1,bi,bj)*dxG(i,j+1,bi,bj)*
-     & smooth2Dmask(i,j,bi,bj)*smooth2Dmask(i,j+1,bi,bj)*
-     & (fld_in(i,j,bi,bj)-fld_in(i,j+1,bi,bj))*recip_dyC(i,j+1,bi,bj)
+             gt_in(i,j,bi,bj) = gt_in(i,j,bi,bj)
+     &         + smooth2D_Kvy(i,j+1,bi,bj)*dxG(i,j+1,bi,bj)
+     &          *smooth2Dmask(i,j,bi,bj)*smooth2Dmask(i,j+1,bi,bj)
+     &          *( fld_in(i,j,bi,bj) - fld_in(i,j+1,bi,bj) )
+     &          *recip_dyC(i,j+1,bi,bj)
 
-      endif
+            ENDIF
 
            ENDDO
           ENDDO
          ENDDO
         ENDDO
 
-      do bj = jtlo,jthi
-         do bi = itlo,ithi
+        DO bj=myByLo(myThid),myByHi(myThid)
+         DO bi=myBxLo(myThid),myBxHi(myThid)
 c Adams-Bashforth timestepping
-      myIter(bi,bj)=iloop-1
-      IF ( myIter(bi,bj).EQ.0 ) THEN
-       ab15=1.0
-       ab05=0.0
-      ELSE
-       ab15=1.5+abEps
-       ab05=-(0.5+abEps)
-      ENDIF
-            DO j = 1,sNy
-               DO i = 1,sNx
+          myIter(bi,bj)=iloop-1
+          IF ( myIter(bi,bj).EQ.0 ) THEN
+           ab15 = 1.0
+           ab05 = 0.0
+          ELSE
+           ab15 =   1.5 + abEps
+           ab05 = -(0.5 + abEps)
+          ENDIF
+          DO j = 1,sNy
+           DO i = 1,sNx
 c Compute effective G-term with Adams-Bashforth
-        gt_tmp = ab15*gt_in(i,j,bi,bj)
-     &         + ab05*gtm1_in(i,j,bi,bj)
-        gtm1_in(i,j,bi,bj) = gt_in(i,j,bi,bj)
-        gt_in(i,j,bi,bj) = gt_tmp
+            gt_tmp = ab15*gt_in(i,j,bi,bj) + ab05*gtm1_in(i,j,bi,bj)
+            gtm1_in(i,j,bi,bj) = gt_in(i,j,bi,bj)
+            gt_in(i,j,bi,bj) = gt_tmp
 c time step:
-      fld_in(i,j,bi,bj)=fld_in(i,j,bi,bj)
-     & -gt_in(i,j,bi,bj)*recip_rA(i,j,bi,bj)*smooth2DdelTime
-           gt_in(i,j,bi,bj)=0
+            fld_in(i,j,bi,bj) = fld_in(i,j,bi,bj)
+     &        - gt_in(i,j,bi,bj)*recip_rA(i,j,bi,bj)*smooth2DdelTime
+            gt_in(i,j,bi,bj) = 0.
            ENDDO
           ENDDO
          ENDDO
         ENDDO
 
-      CALL EXCH_XY_RL ( gt_in , myThid )
-      CALL EXCH_XY_RL ( fld_in , myThid )
-      CALL EXCH_XY_RL ( gtm1_in , myThid )
+        CALL EXCH_XY_RL( gt_in,   myThid )
+        CALL EXCH_XY_RL( fld_in,  myThid )
+        CALL EXCH_XY_RL( gtm1_in, myThid )
 
 #ifdef ALLOW_TAMC_CHECKPOINTING
-      endif
-      enddo
-      endif
-      enddo
-      endif
-      enddo
+           ENDIF
+          ENDDO
+         ENDIF
+        ENDDO
+       ENDIF
+      ENDDO
 #else /* ALLOW_TAMC_CHECKPOINTING */
-      enddo
+      ENDDO
 #endif
 
-      end
+      RETURN
+      END

--- a/pkg/smooth/smooth_diff3d.F
+++ b/pkg/smooth/smooth_diff3d.F
@@ -3,7 +3,7 @@
 # include "AUTODIFF_OPTIONS.h"
 #endif
 
-      subroutine smooth_diff3D (fld_in,nbt_in,mythid)
+      SUBROUTINE SMOOTH_DIFF3D( fld_in, nbt_in, myThid )
 
 C     *==========================================================*
 C     | SUBROUTINE smooth_diff3D
@@ -20,50 +20,46 @@ C     *==========================================================*
 #endif /* ALLOW_AUTODIFF_TAMC */
 #include "SMOOTH.h"
 
-      integer i,j,k, bi,bj, iMin,iMax,jMin,jMax
-      integer itlo,ithi, jtlo,jthi
-      integer myThid, myIter(nSx,nSy)
-      integer mykkey, smoothkey
       _RL fld_in(1-OLx:sNx+OLx,1-OLy:sNy+OLy,Nr,nSx,nSy)
-      _RL fld_tmp(1-OLx:sNx+OLx,1-OLy:sNy+OLy,Nr,nSx,nSy)
-      _RL gT_in(1-OLx:sNx+OLx,1-OLy:sNy+OLy,Nr,nSx,nSy)
-      _RL gTm1_in(1-OLx:sNx+OLx,1-OLy:sNy+OLy,Nr,nSx,nSy)
-      _RL gt_AB(1-OLx:sNx+OLx,1-OLy:sNy+OLy)
-      integer nbt_in
-      integer ii, jj, kk
-      integer iloop, ilev_1, ilev_2, ilev_3
-      integer max_lev2, max_lev3, key_in
-      _RL dTtracerLev_bak(nr)
+      INTEGER nbt_in
+      INTEGER myThid
 
+      INTEGER i, j, k, bi, bj
+      INTEGER myIter(nSx,nSy), iloop
+      _RL gT_in  (1-OLx:sNx+OLx,1-OLy:sNy+OLy,Nr,nSx,nSy)
+      _RL gTm1_in(1-OLx:sNx+OLx,1-OLy:sNy+OLy,Nr,nSx,nSy)
+      _RL gt_AB  (1-OLx:sNx+OLx,1-OLy:sNy+OLy)
+#ifdef ALLOW_TAMC_CHECKPOINTING
+      INTEGER ilev_1, ilev_2, ilev_3
+      INTEGER max_lev2, max_lev3, key_in
+#endif
+
+#ifdef ALLOW_TAMC_CHECKPOINTING
 c for now: useless, because level 3 is recomputed anyway
 c but : if level3 was computed during the fwd loop by callung
 c       mdsmooth_diff3D (assumes that it would be called
 c       directly by the_main_loop) then I would need to pass key_in
 c       as a parameter, with different values for T, S, ...
 c       in order not to overwrite the same tape
-      key_in=0
+      key_in = 0
+#endif
 
-      jtlo = mybylo(mythid)
-      jthi = mybyhi(mythid)
-      itlo = mybxlo(mythid)
-      ithi = mybxhi(mythid)
-
-      DO bj=jtlo,jthi
-       DO bi=itlo,ithi
+      DO bj=myByLo(myThid),myByHi(myThid)
+       DO bi=myBxLo(myThid),myBxHi(myThid)
         DO k=1,Nr
          DO j=1-OLy,sNy+OLy
           DO i=1-OLx,sNx+OLx
            gT_in(i,j,k,bi,bj)   = 0. _d 0
-           gTm1_in(i,j,k,bi,bj)   = 0. _d 0
+           gTm1_in(i,j,k,bi,bj) = 0. _d 0
           ENDDO
          ENDDO
         ENDDO
        ENDDO
       ENDDO
 
-      CALL EXCH_XYZ_RL ( fld_in , myThid )
-      CALL EXCH_XYZ_RL ( gt_in , myThid )
-      CALL EXCH_XYZ_RL ( gtm1_in , myThid )
+      CALL EXCH_XYZ_RL( fld_in,  myThid )
+      CALL EXCH_XYZ_RL( gt_in,   myThid )
+      CALL EXCH_XYZ_RL( gtm1_in, myThid )
 
 #ifdef ALLOW_TAMC_CHECKPOINTING
 
@@ -73,8 +69,8 @@ c checkpointing:
 #ifdef ALLOW_AUTODIFF_TAMC
 CADJ INIT tape_smooth_lev3 = USER
 #endif /* ALLOW_AUTODIFF_TAMC */
-      do ilev_3 = 1,nchklev_3
-        if(ilev_3.le.max_lev3) then
+      DO ilev_3 = 1,nchklev_3
+       IF (ilev_3.LE.max_lev3) THEN
 #ifdef ALLOW_AUTODIFF_TAMC
 CADJ STORE fld_in = tape_smooth_lev3 ,
 CADJ & key = key_in*max_lev3 + ilev_3
@@ -84,8 +80,8 @@ CADJ & key = key_in*max_lev3 + ilev_3
 #ifdef ALLOW_AUTODIFF_TAMC
 CADJ INIT tape_smooth_lev2 = USER
 #endif /* ALLOW_AUTODIFF_TAMC */
-      do ilev_2 = 1,nchklev_2
-         if(ilev_2.le.max_lev2) then
+        DO ilev_2 = 1,nchklev_2
+         IF (ilev_2.LE.max_lev2) THEN
 #ifdef ALLOW_AUTODIFF_TAMC
 CADJ STORE fld_in = tape_smooth_lev2 ,
 CADJ & key = key_in*nchklev_2 + ilev_2
@@ -96,10 +92,10 @@ CADJ & key = key_in*nchklev_2 + ilev_2
 CADJ INIT tape_smooth_lev1  = COMMON,
 CADJ & nchklev_1*nsx*nsy*nthreads_chkpt
 #endif /* ALLOW_AUTODIFF_TAMC */
-      do ilev_1 = 1,nchklev_1
-      iloop = (ilev_2 - 1)*nchklev_1 + ilev_1
+          DO ilev_1 = 1,nchklev_1
+           iloop = (ilev_2 - 1)*nchklev_1 + ilev_1
      &            + (ilev_3 - 1)*nchklev_2*nchklev_1
-      if ( iloop .le. nbt_in ) then
+           IF ( iloop .LE. nbt_in ) THEN
 
 #ifdef ALLOW_AUTODIFF_TAMC
 CADJ STORE gTm1_in(:,:,:,bi,bj) = tape_smooth_lev1 ,
@@ -107,80 +103,81 @@ CADJ & key = key_in*nchklev_1 + ilev_1
 #endif /* ALLOW_AUTODIFF_TAMC */
 
 #else /* ALLOW_TAMC_CHECKPOINTING */
-      do iloop=1,nbt_in
+      DO iloop=1,nbt_in
 #endif
 
-      DO bj=jtlo,jthi
-       DO bi=itlo,ithi
-        DO k=1,Nr
-         DO j=1,sNy
-          DO i=1,sNx
-           gT_in(i,j,k,bi,bj)   = 0. _d 0
+       DO bj=myByLo(myThid),myByHi(myThid)
+        DO bi=myBxLo(myThid),myBxHi(myThid)
+         DO k=1,Nr
+          DO j=1,sNy
+           DO i=1,sNx
+            gT_in(i,j,k,bi,bj) = 0. _d 0
+           ENDDO
           ENDDO
          ENDDO
         ENDDO
        ENDDO
-      ENDDO
 
-      CALL EXCH_XYZ_RL ( gt_in , myThid )
+       CALL EXCH_XYZ_RL( gt_in, myThid )
 
 c compute gT_in:
-      CALL smooth_rhs( fld_in, gT_in, myThid )
+       CALL smooth_rhs( fld_in, gT_in, myThid )
 
-      DO bj=jtlo,jthi
-       DO bi=itlo,ithi
+       DO bj=myByLo(myThid),myByHi(myThid)
+        DO bi=myBxLo(myThid),myBxHi(myThid)
 c adams bashfort on gT_in:
-      myIter(bi,bj)=iloop-1
-        DO k=1,Nr
-        CALL ADAMS_BASHFORTH2(
+         myIter(bi,bj) = iloop-1
+         DO k=1,Nr
+          CALL ADAMS_BASHFORTH2(
      I                        bi, bj, k, Nr,
      U                        gT_in(1-OLx,1-OLy,1,bi,bj),
      U                        gTm1_in(1-OLx,1-OLy,1,bi,bj), gt_AB,
      I                        0, myIter(bi,bj), myThid )
-        ENDDO
+         ENDDO
 c time stepping:
-        DO k=1,Nr
-         DO j=1-OLy,sNy+OLy
-          DO i=1-OLx,sNx+OLx
-      if (maskc(i,j,k,bi,bj).NE.0.) then
-           fld_in(i,j,k,bi,bj)=fld_in(i,j,k,bi,bj)
-     &            +smooth3DdelTime*gT_in(i,j,k,bi,bj)
-           gT_in(i,j,k,bi,bj)=0
-      endif
+         DO k=1,Nr
+          DO j=1-OLy,sNy+OLy
+           DO i=1-OLx,sNx+OLx
+            IF (maskC(i,j,k,bi,bj).NE.0.) THEN
+             fld_in(i,j,k,bi,bj) = fld_in(i,j,k,bi,bj)
+     &            + smooth3DdelTime*gT_in(i,j,k,bi,bj)
+             gT_in(i,j,k,bi,bj) = 0
+            ENDIF
+           ENDDO
           ENDDO
          ENDDO
-        ENDDO
 
 #ifdef ALLOW_AUTODIFF_TAMC
 CADJ STORE fld_in(:,:,:,bi,bj) = tape_smooth_lev1,
 CADJ & key = key_in*nchklev_1 + ilev_1
 #endif /* ALLOW_AUTODIFF_TAMC */
 
-       if ( smooth3DdoImpldiff ) then
+         IF ( smooth3DdoImpldiff ) THEN
           CALL SMOOTH_IMPLDIFF(
      I         bi, bj, 1, sNx, 1, sNy ,
      I         smooth3DdelTime, smooth3D_kappaR(1-OLx,1-OLy,1,bi,bj),
      I         recip_hFacC,
      U         fld_in,
      I         myThid )
-       endif
+         ENDIF
 
+        ENDDO
        ENDDO
-      ENDDO
 
-      CALL EXCH_XYZ_RL ( fld_in , myThid )
-      CALL EXCH_XYZ_RL ( gt_in , myThid )
-      CALL EXCH_XYZ_RL ( gtm1_in , myThid )
+       CALL EXCH_XYZ_RL ( fld_in , myThid )
+       CALL EXCH_XYZ_RL ( gt_in , myThid )
+       CALL EXCH_XYZ_RL ( gtm1_in , myThid )
 
 #ifdef ALLOW_TAMC_CHECKPOINTING
-      endif
-      enddo
-      endif
-      enddo
-      endif
-      enddo
+           ENDIF
+          ENDDO
+         ENDIF
+        ENDDO
+       ENDIF
+      ENDDO
 #else /* ALLOW_TAMC_CHECKPOINTING */
-      enddo
+      ENDDO
 #endif
 
+      RETURN
       END

--- a/pkg/smooth/smooth_filtervar2d.F
+++ b/pkg/smooth/smooth_filtervar2d.F
@@ -3,8 +3,7 @@
 # include "SHELFICE_OPTIONS.h"
 #endif
 
-
-      SUBROUTINE SMOOTH_FILTERVAR2D ( smoothOpNb, mythid )
+      SUBROUTINE SMOOTH_FILTERVAR2D( smoothOpNb, myThid )
 
 C     *==========================================================*
 C     | SUBROUTINE smooth_filtervar2D
@@ -34,29 +33,23 @@ c     == external functions ==
       EXTERNAL PORT_RAND, PORT_RAND_NORM
 
 c     == local variables ==
-      INTEGER i,j,k, bi, bj, ii, jj, kk
-      INTEGER itlo,ithi,jtlo,jthi
-      INTEGER diLoc,djLoc,dkLoc
+      INTEGER i,j,bi, bj, ii, jj
+      INTEGER diLoc,djLoc
       INTEGER nbRand, nbt_in
-      CHARACTER*( 80) fnamegeneric
+      CHARACTER*(80) fnamegeneric
       _RL smoothTmpFld (1-OLx:sNx+OLx,1-OLy:sNy+OLy,nSx,nSy)
       _RL smoothTmpVar (1-OLx:sNx+OLx,1-OLy:sNy+OLy,nSx,nSy)
       _RL smoothTmpMean(1-OLx:sNx+OLx,1-OLy:sNy+OLy,nSx,nSy)
       _RS smooth2Dmask (1-OLx:sNx+OLx,1-OLy:sNy+OLy,nSx,nSy)
 c     == end of interface ==
 
-      jtlo = mybylo(mythid)
-      jthi = mybyhi(mythid)
-      itlo = mybxlo(mythid)
-      ithi = mybxhi(mythid)
-
 c --- allow a different mask other than maskC
 c     Note: this is essentially a copy of ctrl_get_mask
 c     but is repeated here for package independence
 c     since this subroutine is typically used simply to get
 c     filter variance without actually running the model
-      DO bj = jtlo,jthi
-       DO bi = itlo,ithi
+      DO bj=myByLo(myThid),myByHi(myThid)
+       DO bi=myBxLo(myThid),myBxHi(myThid)
         DO j = 1-OLy,sNy+OLy
          DO i = 1-OLx,sNx+OLx
           IF (smooth2DmaskName(smoothOpNb)(1:5).EQ.'maskC') THEN
@@ -84,18 +77,18 @@ c so this routine does not do anything
       nbt_in=smooth2Dnbt(smoothOpNb)/2
 
 c read smoothing [i.e diffusion] operator:
-      write(fnamegeneric(1:80),'(1a,i3.3)')
+      WRITE(fnamegeneric(1:80),'(1A,I3.3)')
      &    'smooth2Doperator',smoothOpNb
       CALL READ_REC_3D_RL(fnamegeneric,smoothprec,
-     &           1,smooth2D_Kux,1,1,mythid)
+     &           1,smooth2D_Kux,1,1,myThid)
       CALL READ_REC_3D_RL(fnamegeneric,smoothprec,
-     &           1,smooth2D_Kvy,2,1,mythid)
+     &           1,smooth2D_Kvy,2,1,myThid)
       CALL EXCH_XY_RL ( smooth2D_Kux, myThid )
       CALL EXCH_XY_RL ( smooth2D_Kvy, myThid )
 
 c initialize filter variance field:
-      DO bj=jtlo,jthi
-       DO bi=itlo,ithi
+      DO bj=myByLo(myThid),myByHi(myThid)
+       DO bi=myBxLo(myThid),myBxHi(myThid)
          DO j=1-OLy,sNy+OLy
           DO i=1-OLx,sNx+OLx
            smooth2Dnorm(i,j,bi,bj)=0.
@@ -120,8 +113,8 @@ c note: the exact method requires the adjoint of smooth_diff2D.F (see below)
       DO ii=1,diLoc
       DO jj=1,djLoc
 
-      DO bj=jtlo,jthi
-       DO bi=itlo,ithi
+      DO bj=myByLo(myThid),myByHi(myThid)
+       DO bi=myBxLo(myThid),myBxHi(myThid)
          DO j=1-OLy,sNy+OLy
           DO i=1-OLx,sNx+OLx
            smoothTmpFld(i,j,bi,bj)=0.
@@ -145,11 +138,11 @@ c adjoint:
      & "uncomment the line below and comment the stop"
       CALL ALL_PROC_DIE( myThid )
       STOP 'ABNORMAL END: S/R smooth_filtervar2D'
-c      call adsmooth_diff2D(smoothTmpFld,smooth2dmask,nbt_in,mythid)
+c      call adsmooth_diff2D(smoothTmpFld,smooth2dmask,nbt_in,myThid)
 
 c division by sqrt(area)*sqrt(area) [1 to end adj, 1 to begin fwd]
-      DO bj = jtlo,jthi
-       DO bi = itlo,ithi
+      DO bj=myByLo(myThid),myByHi(myThid)
+       DO bi=myBxLo(myThid),myBxHi(myThid)
         DO j = 1,sNy
          DO i = 1,sNx
 c division by ~volume:
@@ -165,11 +158,11 @@ c going in fwd part: we need to fill them up
       CALL EXCH_XY_RL ( smoothTmpFld,myThid )
 
 c fwd:
-      CALL smooth_diff2D(smoothTmpFld,smooth2dmask,nbt_in,mythid)
+      CALL smooth_diff2D(smoothTmpFld,smooth2dmask,nbt_in,myThid)
 
 c convert variance to normalization factor:
-      DO bj=jtlo,jthi
-       DO bi=itlo,ithi
+      DO bj=myByLo(myThid),myByHi(myThid)
+       DO bi=myBxLo(myThid),myBxHi(myThid)
          DO j=jj,sNy,djLoc
           DO i=ii,sNx,diLoc
            if (smooth2dmask(i,j,bi,bj).NE.0) then
@@ -187,8 +180,8 @@ c convert variance to normalization factor:
       ELSEIF (smooth2Dfilter(smoothOpNb).EQ.1) then
 c compute the normalization matrix using the approximate method
 
-      DO bj=jtlo,jthi
-       DO bi=itlo,ithi
+      DO bj=myByLo(myThid),myByHi(myThid)
+       DO bi=myBxLo(myThid),myBxHi(myThid)
          DO j=1-OLy,sNy+OLy
           DO i=1-OLx,sNx+OLx
            smoothTmpMean(i,j,bi,bj)   = 0. _d 0
@@ -207,8 +200,8 @@ c initialize random number generator
      & 'smooth_filtervar2D: ',ii,' members done out of',nbRand
 
 c fill smoothTmpFld with random numbers:
-      DO bj=jtlo,jthi
-       DO bi=itlo,ithi
+      DO bj=myByLo(myThid),myByHi(myThid)
+       DO bi=myBxLo(myThid),myBxHi(myThid)
          DO j=1-OLy,sNy+OLy
           DO i=1-OLx,sNx+OLx
            smoothTmpFld(i,j,bi,bj)   = 0. _d 0
@@ -226,11 +219,11 @@ c division by sqrt(area):
       CALL EXCH_XY_RL ( smoothTmpFld, myThid )
 
 c smooth random number field
-      call smooth_diff2D(smoothTmpFld,smooth2dmask,nbt_in,mythid)
+      CALL SMOOTH_DIFF2D(smoothTmpFld,smooth2dmask,nbt_in,myThid)
 
 c accumulate statistics (to compute the variance later)
-      DO bj=jtlo,jthi
-       DO bi=itlo,ithi
+      DO bj=myByLo(myThid),myByHi(myThid)
+       DO bi=myBxLo(myThid),myBxHi(myThid)
          DO j=1-OLy,sNy+OLy
           DO i=1-OLx,sNx+OLx
       smoothTmpVar(i,j,bi,bj)=smoothTmpVar(i,j,bi,bj)
@@ -245,8 +238,8 @@ c accumulate statistics (to compute the variance later)
       ENDDO
 
 c compute variance and convert it to normalization factor:
-      DO bj=jtlo,jthi
-       DO bi=itlo,ithi
+      DO bj=myByLo(myThid),myByHi(myThid)
+       DO bi=myBxLo(myThid),myBxHi(myThid)
          DO j=1-OLy,sNy+OLy
           DO i=1-OLx,sNx+OLx
            if (smooth2dmask(i,j,bi,bj).NE.0) then
@@ -263,12 +256,13 @@ c compute variance and convert it to normalization factor:
       ENDIF
 
 c write smooth2Dnorm to file:
-      write(fnamegeneric(1:80),'(1a,i3.3)')
+      WRITE(fnamegeneric(1:80),'(1A,I3.3)')
      &    'smooth2Dnorm',smoothOpNb
       CALL WRITE_REC_3D_RL(fnamegeneric,smoothprec,
-     &            1,smooth2Dnorm,1,1,mythid)
+     &            1,smooth2Dnorm,1,1,myThid)
       CALL EXCH_XY_RL ( smooth2Dnorm,  myThid )
 
       ENDIF
 
+      RETURN
       END

--- a/pkg/smooth/smooth_filtervar3d.F
+++ b/pkg/smooth/smooth_filtervar3d.F
@@ -1,6 +1,6 @@
 #include "SMOOTH_OPTIONS.h"
 
-      SUBROUTINE SMOOTH_FILTERVAR3D ( smoothOpNb, myThid )
+      SUBROUTINE SMOOTH_FILTERVAR3D( smoothOpNb, myThid )
 
 C     *==========================================================*
 C     | SUBROUTINE smooth_filtervar3D
@@ -11,13 +11,13 @@ C     |   See Weaver and Courtier 01 for details.
 C     *==========================================================*
 
       IMPLICIT NONE
+c     == global variables ==
 #include "SIZE.h"
 #include "EEPARAMS.h"
 #include "PARAMS.h"
 #include "GRID.h"
 #include "SMOOTH.h"
 
-c     == global variables ==
       INTEGER smoothOpNb, myThid
 
 c     == external functions ==
@@ -26,24 +26,18 @@ c     == external functions ==
 
 c     == local variables ==
       INTEGER i,j,k, bi, bj, ii, jj, kk
-      INTEGER itlo,ithi, jtlo,jthi
       INTEGER diLoc, djLoc,  dkLoc
       INTEGER nbRand, nbt_in
-      character*( 80) fnamegeneric
+      CHARACTER*( 80) fnamegeneric
       _RL smoothTmpFld (1-OLx:sNx+OLx,1-OLy:sNy+OLy,Nr,nSx,nSy)
       _RL smoothTmpMean(1-OLx:sNx+OLx,1-OLy:sNy+OLy,Nr,nSx,nSy)
       _RL smoothTmpVar (1-OLx:sNx+OLx,1-OLy:sNy+OLy,Nr,nSx,nSy)
       _RS smooth3Dmask (1-OLx:sNx+OLx,1-OLy:sNy+OLy,Nr,nSx,nSy)
 c     == end of interface ==
 
-      jtlo = mybylo(myThid)
-      jthi = mybyhi(myThid)
-      itlo = mybxlo(myThid)
-      ithi = mybxhi(myThid)
-
 c--   allow a mask other than maskC
-      DO bj = jtlo,jthi
-       DO bi = itlo,ithi
+      DO bj=myByLo(myThid),myByHi(myThid)
+       DO bi=myBxLo(myThid),myBxHi(myThid)
         DO k = 1,Nr
          DO j = 1-OLy,sNy+OLy
           DO i = 1-OLx,sNx+OLx
@@ -66,56 +60,56 @@ c so this routine does not do anything
 
       IF (smooth3Dfilter(smoothOpNb).NE.0) THEN
 
-      nbt_in=smooth3Dnbt(smoothOpNb)/2
+       nbt_in = smooth3Dnbt(smoothOpNb)/2
 
 c read smoothing [i.e diffusion] operator:
-      write(fnamegeneric(1:80),'(1a,i3.3)')
-     &    'smooth3Doperator',smoothOpNb
-      CALL READ_REC_3D_RL( fnamegeneric,smoothprec, Nr,smooth3D_Kwx,
-     &                     1, 1, myThid )
-      CALL READ_REC_3D_RL( fnamegeneric,smoothprec, Nr,smooth3D_Kwy,
-     &                     2, 1, myThid )
-      CALL READ_REC_3D_RL( fnamegeneric,smoothprec, Nr,smooth3D_Kwz,
-     &                     3, 1, myThid )
-      CALL READ_REC_3D_RL( fnamegeneric,smoothprec, Nr,smooth3D_Kux,
-     &                     4, 1, myThid )
-      CALL READ_REC_3D_RL( fnamegeneric,smoothprec, Nr,smooth3D_Kvy,
-     &                     5, 1, myThid )
-      CALL READ_REC_3D_RL( fnamegeneric,smoothprec, Nr,smooth3D_Kuz,
-     &                     6, 1, myThid )
-      CALL READ_REC_3D_RL( fnamegeneric,smoothprec, Nr,smooth3D_Kvz,
-     &                     7, 1, myThid )
-      CALL READ_REC_3D_RL( fnamegeneric,smoothprec, Nr,smooth3D_Kuy,
-     &                     8, 1, myThid )
-      CALL READ_REC_3D_RL( fnamegeneric,smoothprec, Nr,smooth3D_Kvx,
-     &                     9, 1, myThid )
-      CALL READ_REC_3D_RL( fnamegeneric,smoothprec, Nr,smooth3D_kappaR,
-     &                     10,1, myThid )
-      CALL EXCH_XYZ_RL ( smooth3D_Kwx, myThid )
-      CALL EXCH_XYZ_RL ( smooth3D_Kwy, myThid )
-      CALL EXCH_XYZ_RL ( smooth3D_Kwz, myThid )
-      CALL EXCH_XYZ_RL ( smooth3D_Kux, myThid )
-      CALL EXCH_XYZ_RL ( smooth3D_Kvy, myThid )
-      CALL EXCH_XYZ_RL ( smooth3D_Kuz, myThid )
-      CALL EXCH_XYZ_RL ( smooth3D_Kvz, myThid )
-      CALL EXCH_XYZ_RL ( smooth3D_Kuy, myThid )
-      CALL EXCH_XYZ_RL ( smooth3D_Kvx, myThid )
-      CALL EXCH_XYZ_RL ( smooth3D_kappaR, myThid )
+       WRITE(fnamegeneric(1:80),'(1A,I3.3)')
+     &       'smooth3Doperator', smoothOpNb
+       CALL READ_REC_3D_RL( fnamegeneric, smoothprec, Nr, smooth3D_Kwx,
+     &                      1, 1, myThid )
+       CALL READ_REC_3D_RL( fnamegeneric, smoothprec, Nr, smooth3D_Kwy,
+     &                      2, 1, myThid )
+       CALL READ_REC_3D_RL( fnamegeneric, smoothprec, Nr, smooth3D_Kwz,
+     &                      3, 1, myThid )
+       CALL READ_REC_3D_RL( fnamegeneric, smoothprec, Nr, smooth3D_Kux,
+     &                      4, 1, myThid )
+       CALL READ_REC_3D_RL( fnamegeneric, smoothprec, Nr, smooth3D_Kvy,
+     &                      5, 1, myThid )
+       CALL READ_REC_3D_RL( fnamegeneric, smoothprec, Nr, smooth3D_Kuz,
+     &                      6, 1, myThid )
+       CALL READ_REC_3D_RL( fnamegeneric, smoothprec, Nr, smooth3D_Kvz,
+     &                      7, 1, myThid )
+       CALL READ_REC_3D_RL( fnamegeneric, smoothprec, Nr, smooth3D_Kuy,
+     &                      8, 1, myThid )
+       CALL READ_REC_3D_RL( fnamegeneric, smoothprec, Nr, smooth3D_Kvx,
+     &                      9, 1, myThid )
+       CALL READ_REC_3D_RL( fnamegeneric, smoothprec, Nr,
+     &                      smooth3D_kappaR, 10, 1, myThid )
+       CALL EXCH_XYZ_RL( smooth3D_Kwx, myThid )
+       CALL EXCH_XYZ_RL( smooth3D_Kwy, myThid )
+       CALL EXCH_XYZ_RL( smooth3D_Kwz, myThid )
+       CALL EXCH_XYZ_RL( smooth3D_Kux, myThid )
+       CALL EXCH_XYZ_RL( smooth3D_Kvy, myThid )
+       CALL EXCH_XYZ_RL( smooth3D_Kuz, myThid )
+       CALL EXCH_XYZ_RL( smooth3D_Kvz, myThid )
+       CALL EXCH_XYZ_RL( smooth3D_Kuy, myThid )
+       CALL EXCH_XYZ_RL( smooth3D_Kvx, myThid )
+       CALL EXCH_XYZ_RL( smooth3D_kappaR, myThid )
 
 c initialize filter variance field:
-      DO bj=jtlo,jthi
-       DO bi=itlo,ithi
-        DO k=1,Nr
-         DO j=1-OLy,sNy+OLy
-          DO i=1-OLx,sNx+OLx
-           smooth3Dnorm(i,j,k,bi,bj)=0.
+       DO bj=myByLo(myThid),myByHi(myThid)
+        DO bi=myBxLo(myThid),myBxHi(myThid)
+         DO k=1,Nr
+          DO j=1-OLy,sNy+OLy
+           DO i=1-OLx,sNx+OLx
+            smooth3Dnorm(i,j,k,bi,bj) = 0.
+           ENDDO
           ENDDO
          ENDDO
         ENDDO
        ENDDO
-      ENDDO
 
-      IF (smooth3Dfilter(smoothOpNb).EQ.2) then
+       IF (smooth3Dfilter(smoothOpNb).EQ.2) THEN
 c compute the normalization matrix using the approximate method
 c
 c This method can be quite expensive -- so that the approximate
@@ -125,180 +119,184 @@ c of the approximate method results (that can be predicted).
 c
 c note: the exact method requires the adjoint of smooth_diff2D.F (see below)
 
-      diLoc=15 !int(5*smooth_L/smooth_dx)
-      djLoc=20 !int(5*smooth_L/smooth_dx)
-      dkLoc=8
+        diLoc = 15 !int(5*smooth_L/smooth_dx)
+        djLoc = 20 !int(5*smooth_L/smooth_dx)
+        dkLoc = 8
 
-      DO kk=1,dkLoc
-      DO ii=1,diLoc,2
-      DO jj=1,djLoc,2
+        DO kk=1,dkLoc
+         DO ii=1,diLoc,2
+          DO jj=1,djLoc,2
 
-      DO bj=jtlo,jthi
-       DO bi=itlo,ithi
-        DO k=1,Nr
-         DO j=1-OLy,sNy+OLy
-          DO i=1-OLx,sNx+OLx
-           smoothTmpFld(i,j,k,bi,bj)=0.
-          ENDDO
-         ENDDO
-        ENDDO
-
-        DO k=kk,Nr,dkLoc
-         DO j=jj,sNy,djLoc
-          DO i=ii,sNx,diLoc
-           smoothTmpFld(i,j,k,bi,bj)=1.
-          ENDDO
-         ENDDO
-        ENDDO
-       ENDDO
-      ENDDO
+           DO bj=myByLo(myThid),myByHi(myThid)
+            DO bi=myBxLo(myThid),myBxHi(myThid)
+             DO k=1,Nr
+              DO j=1-OLy,sNy+OLy
+               DO i=1-OLx,sNx+OLx
+                smoothTmpFld(i,j,k,bi,bj) = 0.
+               ENDDO
+              ENDDO
+             ENDDO
+             DO k=kk,Nr,dkLoc
+              DO j=jj,sNy,djLoc
+               DO i=ii,sNx,diLoc
+                smoothTmpFld(i,j,k,bi,bj) = 1.
+               ENDDO
+              ENDDO
+             ENDDO
+            ENDDO
+           ENDDO
 
 c note: as we go to adjoint part, we need to have 0 in overlaps
 c       so we must NOT have done an exchange for smoothTmpFld
 
 c adjoint:
-      WRITE(errorMessageUnit,'(A,/,A)' )
-     & "you need to have adsmooth_diff3D compiled and then:",
-     & "uncomment the line below and comment the stop"
-      CALL ALL_PROC_DIE( myThid )
-      STOP 'ABNORMAL END: S/R smooth_filtervar3D'
-c      call adsmooth_diff3D(smoothTmpFld,nbt_in,myThid)
+           WRITE(errorMessageUnit,'(A,/,A)' )
+     &      'you need to have adsmooth_diff3D compiled and then:',
+     &      'uncomment the line below and comment the STOP'
+           CALL ALL_PROC_DIE( myThid )
+           STOP 'ABNORMAL END: S/R smooth_filtervar3D'
+c          CALL adsmooth_diff3D( smoothTmpFld, nbt_in, myThid )
 
 c division by sqrt(volume)*sqrt(volume) [1 to end adj, 1 to begin fwd]
-      DO bj=jtlo,jthi
-       DO bi=itlo,ithi
-        DO k=1,Nr
-         DO j=1,sNy
-          DO i=1,sNx
+           DO bj=myByLo(myThid),myByHi(myThid)
+            DO bi=myBxLo(myThid),myBxHi(myThid)
+             DO k=1,Nr
+              DO j=1,sNy
+               DO i=1,sNx
 c division by ~sqrt(volume):
-        smoothTmpFld(i,j,k,bi,bj)=smoothTmpFld(i,j,k,bi,bj)
-     & *(recip_rA(i,j,bi,bj)*recip_drF(k))
-          ENDDO
-         ENDDO
-        ENDDO
-       ENDDO
-      ENDDO
+                smoothTmpFld(i,j,k,bi,bj) = smoothTmpFld(i,j,k,bi,bj)
+     &                     *(recip_rA(i,j,bi,bj)*recip_drF(k))
+               ENDDO
+              ENDDO
+             ENDDO
+            ENDDO
+           ENDDO
 
 c coming out of adjoint part: overlaps are 0
 c going in fwd part: we need to fill them up
-      CALL EXCH_XYZ_RL ( smoothTmpFld , myThid )
+           CALL EXCH_XYZ_RL( smoothTmpFld , myThid )
 
 c fwd:
-      call smooth_diff3D(smoothTmpFld,nbt_in,myThid)
+           CALL SMOOTH_DIFF3D( smoothTmpFld, nbt_in, myThid )
 
 c convert variance to normalization factor:
-      DO bj=jtlo,jthi
-       DO bi=itlo,ithi
-        DO k=1,Nr,dkLoc
-         DO j=jj,sNy,djLoc
-          DO i=ii,sNx,diLoc
-          if (smoothTmpFld(i,j,k,bi,bj).NE.0.) then
-           smooth3Dnorm(i,j,k,bi,bj)=
-     & 1/sqrt(smoothTmpFld(i,j,k,bi,bj))
-          endif
-          ENDDO
-         ENDDO
-        ENDDO
-       ENDDO
-      ENDDO
+           DO bj=myByLo(myThid),myByHi(myThid)
+            DO bi=myBxLo(myThid),myBxHi(myThid)
+             DO k=1,Nr,dkLoc
+              DO j=jj,sNy,djLoc
+               DO i=ii,sNx,diLoc
+                IF (smoothTmpFld(i,j,k,bi,bj).NE.0.) THEN
+                 smooth3Dnorm(i,j,k,bi,bj) =
+     &                    1/SQRT(smoothTmpFld(i,j,k,bi,bj))
+                ENDIF
+               ENDDO
+              ENDDO
+             ENDDO
+            ENDDO
+           ENDDO
 
-      ENDDO      !DO ii=1,diLoc
-      ENDDO      !DO jj=1,djLoc
-      ENDDO      !DO kk=1,dkLoc
+          ENDDO      !DO ii=1,diLoc
+         ENDDO      !DO jj=1,djLoc
+        ENDDO      !DO kk=1,dkLoc
 
-      ELSEIF (smooth3Dfilter(smoothOpNb).EQ.1) then
+       ELSEIF (smooth3Dfilter(smoothOpNb).EQ.1) THEN
 c compute the normalization matrix using the approximate method
 
-      DO bj=jtlo,jthi
-       DO bi=itlo,ithi
-        DO k=1,Nr
-         DO j=1-OLy,sNy+OLy
-          DO i=1-OLx,sNx+OLx
-           smoothTmpMean(i,j,k,bi,bj)   = 0. _d 0
-           smoothTmpVar(i,j,k,bi,bj)   = 0. _d 0
+        DO bj=myByLo(myThid),myByHi(myThid)
+         DO bi=myBxLo(myThid),myBxHi(myThid)
+          DO k=1,Nr
+           DO j=1-OLy,sNy+OLy
+            DO i=1-OLx,sNx+OLx
+             smoothTmpMean(i,j,k,bi,bj) = 0. _d 0
+             smoothTmpVar(i,j,k,bi,bj)  = 0. _d 0
+            ENDDO
+           ENDDO
           ENDDO
          ENDDO
         ENDDO
-       ENDDO
-      ENDDO
 
 c initialize random number generator
-      smoothTmpFld(1,1,1,1,1)=port_rand(1.d0)
-      nbRand=1000
+        smoothTmpFld(1,1,1,1,1) = port_rand(1.d0)
+        nbRand = 1000
 
-      DO ii=1,nbRand
-            WRITE(standardMessageUnit,'(A,I4,A,I4)')
-     & 'smooth_filtervar3D: ',ii,' members done out of ',nbRand
+        DO ii=1,nbRand
+         WRITE(standardMessageUnit,'(A,I4,A,I4)')
+     &   'smooth_filtervar3D: ', ii, ' members done out of ', nbRand
 
 c fill smoothTmpFld with random numbers:
-      DO bj=jtlo,jthi
-       DO bi=itlo,ithi
-        DO k=1,Nr
-         DO j=1-OLy,sNy+OLy
-          DO i=1-OLx,sNx+OLx
-           smoothTmpFld(i,j,k,bi,bj)   = 0. _d 0
-           if (smooth3dmask(i,j,k,bi,bj).NE.0) then
-           smoothTmpFld(i,j,k,bi,bj)=port_rand_norm()
-           endif
+         DO bj=myByLo(myThid),myByHi(myThid)
+          DO bi=myBxLo(myThid),myBxHi(myThid)
+           DO k=1,Nr
+            DO j=1-OLy,sNy+OLy
+             DO i=1-OLx,sNx+OLx
+              smoothTmpFld(i,j,k,bi,bj) = 0. _d 0
+              IF (smooth3dmask(i,j,k,bi,bj).NE.0) THEN
+               smoothTmpFld(i,j,k,bi,bj)=port_rand_norm()
+              ENDIF
 c division by sqrt(volume):
-       smoothTmpFld(i,j,k,bi,bj)=smoothTmpFld(i,j,k,bi,bj)
-     & *sqrt(recip_rA(i,j,bi,bj)*recip_drF(k))
+              smoothTmpFld(i,j,k,bi,bj) = smoothTmpFld(i,j,k,bi,bj)
+     &                    *SQRT(recip_rA(i,j,bi,bj)*recip_drF(k))
+             ENDDO
+            ENDDO
+           ENDDO
           ENDDO
          ENDDO
-        ENDDO
-       ENDDO
-      ENDDO
 
-      CALL EXCH_XYZ_RL ( smoothTmpFld, myThid )
+         CALL EXCH_XYZ_RL( smoothTmpFld, myThid )
 
 c smooth random number field
-      call smooth_diff3D(smoothTmpFld,nbt_in,myThid)
+         CALL SMOOTH_DIFF3D( smoothTmpFld, nbt_in, myThid )
 
 c accumulate statistics (to compute the variance later)
-      DO bj=jtlo,jthi
-       DO bi=itlo,ithi
-        DO k=1,Nr
-         DO j=1-OLy,sNy+OLy
-          DO i=1-OLx,sNx+OLx
-      smoothTmpVar(i,j,k,bi,bj)=smoothTmpVar(i,j,k,bi,bj)
-     & +smoothTmpFld(i,j,k,bi,bj)*smoothTmpFld(i,j,k,bi,bj)/nbRand
-      smoothTmpMean(i,j,k,bi,bj)=smoothTmpMean(i,j,k,bi,bj)
-     & +smoothTmpFld(i,j,k,bi,bj)/nbRand
+         DO bj=myByLo(myThid),myByHi(myThid)
+          DO bi=myBxLo(myThid),myBxHi(myThid)
+           DO k=1,Nr
+            DO j=1-OLy,sNy+OLy
+             DO i=1-OLx,sNx+OLx
+              smoothTmpVar(i,j,k,bi,bj) = smoothTmpVar(i,j,k,bi,bj)
+     &         + smoothTmpFld(i,j,k,bi,bj)
+     &          *smoothTmpFld(i,j,k,bi,bj)/nbRand
+              smoothTmpMean(i,j,k,bi,bj) = smoothTmpMean(i,j,k,bi,bj)
+     &         + smoothTmpFld(i,j,k,bi,bj)/nbRand
+             ENDDO
+            ENDDO
+           ENDDO
           ENDDO
          ENDDO
-        ENDDO
-       ENDDO
-      ENDDO
 
-      ENDDO
+C-      ii loop end
+        ENDDO
 
 c compute variance and convert it to normalization factor:
-      DO bj=jtlo,jthi
-       DO bi=itlo,ithi
-        DO k=1,Nr
-         DO j=1-OLy,sNy+OLy
-          DO i=1-OLx,sNx+OLx
-           if (smooth3dmask(i,j,k,bi,bj).NE.0) then
-           smooth3Dnorm(i,j,k,bi,bj)=
-     & 1/sqrt ( nbRand/(nbRand-1)* ( smoothTmpVar(i,j,k,bi,bj) -
-     & smoothTmpMean(i,j,k,bi,bj)*smoothTmpMean(i,j,k,bi,bj)
-     &  )  )
-           endif
+        DO bj=myByLo(myThid),myByHi(myThid)
+         DO bi=myBxLo(myThid),myBxHi(myThid)
+          DO k=1,Nr
+           DO j=1-OLy,sNy+OLy
+            DO i=1-OLx,sNx+OLx
+             IF (smooth3dmask(i,j,k,bi,bj).NE.0) THEN
+              smooth3Dnorm(i,j,k,bi,bj) = 1/SQRT(
+     &           nbRand/(nbRand-1)
+     &          *( smoothTmpVar(i,j,k,bi,bj)
+     &           - smoothTmpMean(i,j,k,bi,bj)*smoothTmpMean(i,j,k,bi,bj)
+     &           )                              )
+             ENDIF
+            ENDDO
+           ENDDO
           ENDDO
          ENDDO
         ENDDO
-       ENDDO
-      ENDDO
 
-      ENDIF
+C      end smooth3Dfilter() if block
+       ENDIF
 
 c write smooth3Dnorm_3D to file:
-      write(fnamegeneric(1:80),'(1a,i3.3)')
-     &    'smooth3Dnorm',smoothOpNb
-      CALL WRITE_REC_3D_RL( fnamegeneric, smoothprec,
-     &                      Nr, smooth3Dnorm, 1, 1, myThid )
-      CALL EXCH_XYZ_RL ( smooth3Dnorm,  myThid )
+       WRITE(fnamegeneric(1:80),'(1A,I3.3)')
+     &       'smooth3Dnorm', smoothOpNb
+       CALL WRITE_REC_3D_RL( fnamegeneric, smoothprec,
+     &                       Nr, smooth3Dnorm, 1, 1, myThid )
+       CALL EXCH_XYZ_RL( smooth3Dnorm,  myThid )
 
+C     end smooth3Dfilter() <> 0 if block
       ENDIF
 
       RETURN

--- a/pkg/smooth/smooth_hetero2d.F
+++ b/pkg/smooth/smooth_hetero2d.F
@@ -1,7 +1,7 @@
 #include "SMOOTH_OPTIONS.h"
 
-      subroutine smooth_hetero2D (
-     U     fld_in,mask_in,dist_file,nbt_in,mythid)
+      SUBROUTINE SMOOTH_HETERO2D(
+     &           fld_in, mask_in, dist_file, nbt_in, myThid )
 
 C     *==========================================================*
 C     | SUBROUTINE smooth_hetero2D
@@ -15,58 +15,52 @@ C     *==========================================================*
 #include "EEPARAMS.h"
 #include "GRID.h"
 #include "PARAMS.h"
-c#include "tamc.h"
 #include "SMOOTH.h"
 
       _RL fld_in(1-OLx:sNx+OLx,1-OLy:sNy+OLy,nSx,nSy)
       _RS mask_in(1-OLx:sNx+OLx,1-OLy:sNy+OLy,nSx,nSy)
-      character*(MAX_LEN_FNAM) dist_file
+      CHARACTER*(MAX_LEN_FNAM) dist_file
+      INTEGER nbt_in
+      INTEGER myThid
+
       _RL dist_in(1-OLx:sNx+OLx,1-OLy:sNy+OLy,nSx,nSy)
-      integer nbt_in
-      integer i,j,bi,bj
-      integer itlo,ithi
-      integer jtlo,jthi
-      integer myThid
+      INTEGER i,j,bi,bj
 
-      jtlo = mybylo(mythid)
-      jthi = mybyhi(mythid)
-      itlo = mybxlo(mythid)
-      ithi = mybxhi(mythid)
+      smooth2DtotTime = nbt_in*smooth2DdelTime
 
-      smooth2DtotTime=nbt_in*smooth2DdelTime
-
-      CALL READ_REC_3D_RL(dist_file,smoothprec,
-     &           1,dist_in,1,1,mythid)
+      CALL READ_REC_3D_RL( dist_file, smoothprec,
+     &                     1, dist_in, 1, 1, myThid )
 
       DO bj=myByLo(myThid),myByHi(myThid)
        DO bi=myBxLo(myThid),myBxHi(myThid)
-         DO j=1-OLy,sNy+OLy
-          DO i=1-OLx,sNx+OLx
-          smooth2D_Lx(i,j,bi,bj)=dist_in(i,j,bi,bj)
-          smooth2D_Ly(i,j,bi,bj)=dist_in(i,j,bi,bj)
-          ENDDO
+        DO j=1-OLy,sNy+OLy
+         DO i=1-OLx,sNx+OLx
+          smooth2D_Lx(i,j,bi,bj) = dist_in(i,j,bi,bj)
+          smooth2D_Ly(i,j,bi,bj) = dist_in(i,j,bi,bj)
          ENDDO
+        ENDDO
        ENDDO
       ENDDO
 
       DO bj=myByLo(myThid),myByHi(myThid)
        DO bi=myBxLo(myThid),myBxHi(myThid)
-         DO j=1-OLy,sNy+OLy
-          DO i=1-OLx,sNx+OLx
-          smooth2D_Kux(i,j,bi,bj)=smooth2D_Lx(i,j,bi,bj)*
-     & smooth2D_Lx(i,j,bi,bj)/smooth2DtotTime/2
-          smooth2D_Kvy(i,j,bi,bj)=smooth2D_Ly(i,j,bi,bj)*
-     & smooth2D_Ly(i,j,bi,bj)/smooth2DtotTime/2
-          ENDDO
+        DO j=1-OLy,sNy+OLy
+         DO i=1-OLx,sNx+OLx
+          smooth2D_Kux(i,j,bi,bj) = smooth2D_Lx(i,j,bi,bj)
+     &            *smooth2D_Lx(i,j,bi,bj)/smooth2DtotTime/2
+          smooth2D_Kvy(i,j,bi,bj) = smooth2D_Ly(i,j,bi,bj)
+     &            *smooth2D_Ly(i,j,bi,bj)/smooth2DtotTime/2
          ENDDO
+        ENDDO
        ENDDO
       ENDDO
 
-      CALL EXCH_XY_RL ( smooth2D_Kux , myThid )
-      CALL EXCH_XY_RL ( smooth2D_Kvy , myThid )
+      CALL EXCH_XY_RL( smooth2D_Kux, myThid )
+      CALL EXCH_XY_RL( smooth2D_Kvy, myThid )
 
-      call smooth_diff2D(fld_in,mask_in,nbt_in,mythid)
+      CALL SMOOTH_DIFF2D( fld_in, mask_in, nbt_in, myThid )
 
-      CALL EXCH_XY_RL ( fld_in , myThid )
+      CALL EXCH_XY_RL( fld_in, myThid )
 
-      end
+      RETURN
+      END

--- a/pkg/smooth/smooth_impldiff.F
+++ b/pkg/smooth/smooth_impldiff.F
@@ -11,7 +11,6 @@ C     | o Copy of model/src/impldiff
 C     |    (simplified and with specified time step)
 C     *==========================================================*
 
-
 C     !USES:
       IMPLICIT NONE
 C     == Global data ==
@@ -21,26 +20,22 @@ C     == Global data ==
 #include "GRID.h"
 
 C     !INPUT/OUTPUT PARAMETERS:
-C     == Routine Arguments ==
-      INTEGER bi,bj,iMin,iMax,jMin,jMax
-      _RL KappaRX(1-Olx:sNx+Olx,1-Oly:sNy+Oly,Nr)
-      _RS recip_hFac(1-Olx:sNx+Olx,1-Oly:sNy+Oly,Nr,nSx,nSy)
-      _RL gXnm1(1-Olx:sNx+Olx,1-Oly:sNy+Oly,Nr,nSx,nSy)
+      INTEGER bi, bj, iMin, iMax, jMin, jMax
+      _RL deltaTX
+      _RL KappaRX(1-OLx:sNx+OLx,1-OLy:sNy+OLy,Nr)
+      _RS recip_hFac(1-OLx:sNx+OLx,1-OLy:sNy+OLy,Nr,nSx,nSy)
+      _RL gXnm1(1-OLx:sNx+OLx,1-OLy:sNy+OLy,Nr,nSx,nSy)
       INTEGER myThid
 
 C     !LOCAL VARIABLES:
-C     == Local variables ==
       INTEGER i,j,k
-      _RL deltaTX
-      _RL gYnm1(1-Olx:sNx+Olx,1-Oly:sNy+Oly,Nr,nSx,nSy)
-      _RL a(1-Olx:sNx+Olx,1-Oly:sNy+Oly,Nr)
-      _RL b(1-Olx:sNx+Olx,1-Oly:sNy+Oly,Nr)
-      _RL c(1-Olx:sNx+Olx,1-Oly:sNy+Oly,Nr)
-      _RL bet(1-Olx:sNx+Olx,1-Oly:sNy+Oly,Nr)
-      _RL gam(1-Olx:sNx+Olx,1-Oly:sNy+Oly,Nr)
+      _RL gYnm1(1-OLx:sNx+OLx,1-OLy:sNy+OLy,Nr,nSx,nSy)
+      _RL a(1-OLx:sNx+OLx,1-OLy:sNy+OLy,Nr)
+      _RL b(1-OLx:sNx+OLx,1-OLy:sNy+OLy,Nr)
+      _RL c(1-OLx:sNx+OLx,1-OLy:sNy+OLy,Nr)
+      _RL bet(1-OLx:sNx+OLx,1-OLy:sNy+OLy,Nr)
+      _RL gam(1-OLx:sNx+OLx,1-OLy:sNy+OLy,Nr)
 CEOP
-
-c         deltaTX = 1. _d 0
 
 C--   Initialise
       DO k=1,Nr
@@ -137,7 +132,6 @@ CADJ loop = sequential
 
       ENDIF
 
-
       DO j=jMin,jMax
        DO i=iMin,iMax
         gYNm1(i,j,1,bi,bj) = gXNm1(i,j,1,bi,bj)*bet(i,j,1)
@@ -151,7 +145,6 @@ CADJ loop = sequential
         ENDDO
        ENDDO
       ENDDO
-
 
 C--    Backward sweep
 CADJ loop = sequential

--- a/pkg/smooth/smooth_init2d.F
+++ b/pkg/smooth/smooth_init2d.F
@@ -1,6 +1,6 @@
 #include "SMOOTH_OPTIONS.h"
 
-      subroutine smooth_init2D (smoothOpNb, mythid )
+      SUBROUTINE SMOOTH_INIT2D( smoothOpNb, myThid )
 
 C     *==========================================================*
 C     | SUBROUTINE smooth_init2D
@@ -8,7 +8,7 @@ C     | o Routine that initializes one 2D smoothing/correlation operator
 C     |   by computing/writing the corresponding diffusion operator
 C     *==========================================================*
 
-cgf the choices of smooth2Dtype and smooth2Dsize need comments...
+Cgf the choices of smooth2Dtype and smooth2Dsize need comments...
 
       IMPLICIT NONE
 #include "SIZE.h"
@@ -17,66 +17,60 @@ cgf the choices of smooth2Dtype and smooth2Dsize need comments...
 #include "GRID.h"
 #include "SMOOTH.h"
 
-      integer i,j,k, bi, bj
-      integer itlo,ithi
-      integer jtlo,jthi
-      integer myThid
-      character*( 80) fnamegeneric
-      integer smoothOpNb
+      INTEGER smoothOpNb
+      INTEGER myThid
 
-      jtlo = mybylo(mythid)
-      jthi = mybyhi(mythid)
-      itlo = mybxlo(mythid)
-      ithi = mybxhi(mythid)
+      INTEGER i, j, bi, bj
+      CHARACTER*( 80) fnamegeneric
 
+      smooth2DtotTime = smooth2Dnbt(smoothOpNb)*smooth2DdelTime
 
-      smooth2DtotTime=smooth2Dnbt(smoothOpNb)*smooth2DdelTime
-
-      if ((smooth2Dtype(smoothOpNb).NE.0).AND.
-     & (smooth2Dsize(smoothOpNb).EQ.2)) then
-      write(fnamegeneric(1:80),'(1a,i3.3)')
+      IF ( (smooth2Dtype(smoothOpNb).NE.0).AND.
+     &     (smooth2Dsize(smoothOpNb).EQ.2) ) THEN
+        WRITE(fnamegeneric(1:80),'(1A,I3.3)')
      &    'smooth2Dscales',smoothOpNb
-      CALL READ_REC_3D_RL(fnamegeneric,smoothprec,
-     &           1, smooth2D_Lx,1,1,mythid)
-      CALL READ_REC_3D_RL(fnamegeneric,smoothprec,
-     &           1, smooth2D_Ly,2,1,mythid)
-      CALL EXCH_XY_RL ( smooth2D_Lx, myThid )
-      CALL EXCH_XY_RL ( smooth2D_Ly, myThid )
-      else
+        CALL READ_REC_3D_RL( fnamegeneric, smoothprec,
+     &                       1, smooth2D_Lx, 1, 1, myThid )
+        CALL READ_REC_3D_RL( fnamegeneric, smoothprec,
+     &                       1, smooth2D_Ly, 2, 1, myThid )
+        CALL EXCH_XY_RL( smooth2D_Lx, myThid )
+        CALL EXCH_XY_RL( smooth2D_Ly, myThid )
+      ELSE
+        DO bj=myByLo(myThid),myByHi(myThid)
+         DO bi=myBxLo(myThid),myBxHi(myThid)
+           DO j=1-OLy,sNy+OLy
+            DO i=1-OLx,sNx+OLx
+             smooth2D_Lx(i,j,bi,bj)=smooth2D_Lx0(smoothOpNb)
+             smooth2D_Ly(i,j,bi,bj)=smooth2D_Ly0(smoothOpNb)
+            ENDDO
+           ENDDO
+         ENDDO
+        ENDDO
+      ENDIF
+
       DO bj=myByLo(myThid),myByHi(myThid)
        DO bi=myBxLo(myThid),myBxHi(myThid)
          DO j=1-OLy,sNy+OLy
           DO i=1-OLx,sNx+OLx
-          smooth2D_Lx(i,j,bi,bj)=smooth2D_Lx0(smoothOpNb)
-          smooth2D_Ly(i,j,bi,bj)=smooth2D_Ly0(smoothOpNb)
-          ENDDO
-         ENDDO
-       ENDDO
-      ENDDO
-      endif
-
-      DO bj=myByLo(myThid),myByHi(myThid)
-       DO bi=myBxLo(myThid),myBxHi(myThid)
-         DO j=1-OLy,sNy+OLy
-          DO i=1-OLx,sNx+OLx
-          smooth2D_Kux(i,j,bi,bj)=smooth2D_Lx(i,j,bi,bj)*
-     & smooth2D_Lx(i,j,bi,bj)/smooth2DtotTime/2
-          smooth2D_Kvy(i,j,bi,bj)=smooth2D_Ly(i,j,bi,bj)*
-     & smooth2D_Ly(i,j,bi,bj)/smooth2DtotTime/2
+           smooth2D_Kux(i,j,bi,bj)=smooth2D_Lx(i,j,bi,bj)*
+     &            smooth2D_Lx(i,j,bi,bj)/smooth2DtotTime/2
+           smooth2D_Kvy(i,j,bi,bj)=smooth2D_Ly(i,j,bi,bj)*
+     &            smooth2D_Ly(i,j,bi,bj)/smooth2DtotTime/2
           ENDDO
          ENDDO
        ENDDO
       ENDDO
 
-      CALL EXCH_XY_RL ( smooth2D_Kux , myThid )
-      CALL EXCH_XY_RL ( smooth2D_Kvy , myThid )
+      CALL EXCH_XY_RL( smooth2D_Kux, myThid )
+      CALL EXCH_XY_RL( smooth2D_Kvy, myThid )
 
-c write diffusion operator to file
-      write(fnamegeneric(1:80),'(1a,i3.3)')
-     &    'smooth2Doperator',smoothOpNb
-      CALL WRITE_REC_3D_RL(fnamegeneric,smoothprec,
-     &            1,smooth2D_Kux,1,1,mythid)
-      CALL WRITE_REC_3D_RL(fnamegeneric,smoothprec,
-     &            1,smooth2D_Kvy,2,1,mythid)
+C write diffusion operator to file
+      WRITE(fnamegeneric(1:80),'(1A,I3.3)')
+     &    'smooth2Doperator', smoothOpNb
+      CALL WRITE_REC_3D_RL( fnamegeneric, smoothprec,
+     &                      1, smooth2D_Kux, 1, 1, myThid )
+      CALL WRITE_REC_3D_RL( fnamegeneric, smoothprec,
+     &                      1, smooth2D_Kvy, 2, 1, myThid )
 
-      end
+      RETURN
+      END

--- a/pkg/smooth/smooth_init3d.F
+++ b/pkg/smooth/smooth_init3d.F
@@ -1,6 +1,6 @@
 #include "SMOOTH_OPTIONS.h"
 
-      subroutine smooth_init3D (smoothOpNb,mythid)
+      SUBROUTINE SMOOTH_INIT3D( smoothOpNb, myThid )
 
 C     *==========================================================*
 C     | SUBROUTINE smooth_init3D
@@ -8,13 +8,12 @@ C     | o Routine that initializes one 3D smoothing/correlation operator
 C     |   by computing/writing the corresponding diffusion operator
 C     *==========================================================*
 
-cgf the choices of smooth3Dtype and smooth3Dsize need comments...
-cgf
-cgf smooth3DtypeH= 1) HORIZONTAL ALONG GRID AXIS
-cgf              2-3) GMREDI TYPES
-cgf                4) HORIZONTAL BUT WITH ROTATED AXIS
-cgf for now I focus on the simpler smooth3DtypeH=1 case
-
+Cgf the choices of smooth3Dtype and smooth3Dsize need comments...
+Cgf
+Cgf smooth3DtypeH= 1) HORIZONTAL ALONG GRID AXIS
+Cgf              2-3) GMREDI TYPES
+Cgf                4) HORIZONTAL BUT WITH ROTATED AXIS
+Cgf for now I focus on the simpler smooth3DtypeH=1 case
 
       IMPLICIT NONE
 #include "SIZE.h"
@@ -23,167 +22,157 @@ cgf for now I focus on the simpler smooth3DtypeH=1 case
 #include "GRID.h"
 #include "SMOOTH.h"
 
-      integer i,j,k, bi, bj, imin, imax, jmin, jmax
-      integer itlo,ithi
-      integer jtlo,jthi
-      integer myThid
-      character*( 80) fnamegeneric
+      INTEGER smoothOpNb
+      INTEGER myThid
+
+      INTEGER i, j, k, bi, bj
+      CHARACTER*(80) fnamegeneric
       _RL smooth3D_KzMax
-      integer ii,jj,kk
-      integer smoothOpNb
 
-      jtlo = mybylo(mythid)
-      jthi = mybyhi(mythid)
-      itlo = mybxlo(mythid)
-      ithi = mybxhi(mythid)
+      smooth3DtotTime = smooth3Dnbt(smoothOpNb)*smooth3DdelTime
 
-      smooth3DtotTime=smooth3Dnbt(smoothOpNb)*smooth3DdelTime
+C vertical smoothing:
 
-c vertical smoothing:
-
-      if (smooth3DsizeZ(smoothOpNb).EQ.3) then
-      write(fnamegeneric(1:80),'(1a,i3.3)')
-     &    'smooth3DscalesZ',smoothOpNb
-      CALL READ_REC_3D_RL(fnamegeneric,smoothprec,
-     &           Nr, smooth3D_Lz,1,1,mythid)
-      CALL EXCH_XYZ_RL( smooth3D_Lz, mythid )
-      else
-      DO bj=jtlo,jthi
-       DO bi=itlo,ithi
-        DO k=1,Nr
-         DO j=1-OLy,sNy+OLy
-          DO i=1-OLx,sNx+OLx
-          smooth3D_Lz(i,j,k,bi,bj)=smooth3D_Lz0(smoothOpNb)
+      IF ( smooth3DsizeZ(smoothOpNb).EQ.3 ) THEN
+        WRITE(fnamegeneric(1:80),'(1A,I3.3)')
+     &        'smooth3DscalesZ', smoothOpNb
+        CALL READ_REC_3D_RL( fnamegeneric, smoothprec,
+     &                       Nr, smooth3D_Lz, 1, 1, myThid )
+        CALL EXCH_XYZ_RL( smooth3D_Lz, myThid )
+      ELSE
+        DO bj=myByLo(myThid),myByHi(myThid)
+         DO bi=myBxLo(myThid),myBxHi(myThid)
+          DO k=1,Nr
+           DO j=1-OLy,sNy+OLy
+            DO i=1-OLx,sNx+OLx
+             smooth3D_Lz(i,j,k,bi,bj) = smooth3D_Lz0(smoothOpNb)
+            ENDDO
+           ENDDO
           ENDDO
          ENDDO
         ENDDO
-       ENDDO
-      ENDDO
-      endif
+      ENDIF
 
-      DO bj=jtlo,jthi
-       DO bi=itlo,ithi
+      DO bj=myByLo(myThid),myByHi(myThid)
+       DO bi=myBxLo(myThid),myBxHi(myThid)
         DO k=1,Nr
          DO j=1-OLy,sNy+OLy
           DO i=1-OLx,sNx+OLx
-       smooth3D_kappaR(i,j,k,bi,bj)=smooth3D_Lz(i,j,k,bi,bj)*
-     & smooth3D_Lz(i,j,k,bi,bj)/smooth3DtotTime/2
+           smooth3D_kappaR(i,j,k,bi,bj) = smooth3D_Lz(i,j,k,bi,bj)
+     &             *smooth3D_Lz(i,j,k,bi,bj)/smooth3DtotTime/2
           ENDDO
          ENDDO
         ENDDO
        ENDDO
       ENDDO
 
-c avoid excessive vertical smoothing:
-      if (smooth3DsizeZ(smoothOpNb).NE.3) then
-      DO bj=jtlo,jthi
-       DO bi=itlo,ithi
+C avoid excessive vertical smoothing:
+      IF ( smooth3DsizeZ(smoothOpNb).NE.3 ) THEN
+        DO bj=myByLo(myThid),myByHi(myThid)
+         DO bi=myBxLo(myThid),myBxHi(myThid)
+          DO k=1,Nr
+           DO j=1-OLy,sNy+OLy
+            DO i=1-OLx,sNx+OLx
+             smooth3D_KzMax=drC(k)
+             smooth3D_KzMax = smooth3D_KzMax*smooth3D_KzMax
+     &                                      /smooth3DtotTime/2
+             IF ( smooth3D_kappaR(i,j,k,bi,bj).GT.smooth3D_KzMax ) THEN
+              smooth3D_kappaR(i,j,k,bi,bj) = smooth3D_KzMax
+             ENDIF
+            ENDDO
+           ENDDO
+          ENDDO
+         ENDDO
+        ENDDO
+      ENDIF
+
+      CALL EXCH_XYZ_RL( smooth3D_kappaR, myThid )
+
+C horizontal smoothing:
+
+      IF ( smooth3DsizeH(smoothOpNb).EQ.3 ) THEN
+        WRITE(fnamegeneric(1:80),'(1A,I3.3)')
+     &        'smooth3DscalesH', smoothOpNb
+        CALL READ_REC_3D_RL( fnamegeneric, smoothprec,
+     &                       Nr, smooth3D_Lx, 1, 1, myThid )
+        CALL READ_REC_3D_RL( fnamegeneric, smoothprec,
+     &                       Nr, smooth3D_Ly, 2, 1, myThid )
+        CALL EXCH_XYZ_RL( smooth3D_Lx, myThid )
+        CALL EXCH_XYZ_RL( smooth3D_Ly, myThid )
+      ELSE
+        DO bj=myByLo(myThid),myByHi(myThid)
+         DO bi=myBxLo(myThid),myBxHi(myThid)
+          DO k=1,Nr
+           DO j=1-OLy,sNy+OLy
+            DO i=1-OLx,sNx+OLx
+             smooth3D_Lx(i,j,k,bi,bj) = smooth3D_Lx0(smoothOpNb)
+             smooth3D_Ly(i,j,k,bi,bj) = smooth3D_Ly0(smoothOpNb)
+            ENDDO
+           ENDDO
+          ENDDO
+         ENDDO
+        ENDDO
+      ENDIF
+
+      DO bj=myByLo(myThid),myByHi(myThid)
+       DO bi=myBxLo(myThid),myBxHi(myThid)
         DO k=1,Nr
          DO j=1-OLy,sNy+OLy
           DO i=1-OLx,sNx+OLx
-
-       smooth3D_KzMax=drC(k)
-       smooth3D_KzMax=smooth3D_KzMax*smooth3D_KzMax/smooth3DtotTime/2
-       if (smooth3D_kappaR(i,j,k,bi,bj).GT.smooth3D_KzMax) then
-       smooth3D_kappaR(i,j,k,bi,bj)=smooth3D_KzMax
-       endif
+           smooth3D_Kuy(i,j,k,bi,bj) = 0.
+           smooth3D_Kvx(i,j,k,bi,bj) = 0.
+           smooth3D_Kwx(i,j,k,bi,bj) = 0.
+           smooth3D_Kwy(i,j,k,bi,bj) = 0.
+           smooth3D_Kwz(i,j,k,bi,bj) = 0.
+           smooth3D_Kux(i,j,k,bi,bj) = smooth3D_Lx(i,j,k,bi,bj)
+     &              *smooth3D_Lx(i,j,k,bi,bj)/smooth3DtotTime/2
+           smooth3D_Kvy(i,j,k,bi,bj) = smooth3D_Ly(i,j,k,bi,bj)
+     &              *smooth3D_Ly(i,j,k,bi,bj)/smooth3DtotTime/2
+           smooth3D_Kuz(i,j,k,bi,bj) = 0.
+           smooth3D_Kvz(i,j,k,bi,bj) = 0.
           ENDDO
          ENDDO
         ENDDO
        ENDDO
       ENDDO
-      endif
 
-      CALL EXCH_XYZ_RL( smooth3D_kappaR,    myThid )
+C is exchange useful here?
 
+      CALL EXCH_XYZ_RL( smooth3D_kappaR, myThid )
+      CALL EXCH_XYZ_RL( smooth3D_Kwx, myThid )
+      CALL EXCH_XYZ_RL( smooth3D_Kwy, myThid )
+      CALL EXCH_XYZ_RL( smooth3D_Kwz, myThid )
+      CALL EXCH_XYZ_RL( smooth3D_Kux, myThid )
+      CALL EXCH_XYZ_RL( smooth3D_Kvy, myThid )
+      CALL EXCH_XYZ_RL( smooth3D_Kuz, myThid )
+      CALL EXCH_XYZ_RL( smooth3D_Kvz, myThid )
+      CALL EXCH_XYZ_RL( smooth3D_Kuy, myThid )
+      CALL EXCH_XYZ_RL( smooth3D_Kvx, myThid )
 
-c hoizontal smoothing:
+C write diffusion operator to file
 
-      if (smooth3DsizeH(smoothOpNb).EQ.3) then
-      write(fnamegeneric(1:80),'(1a,i3.3)')
-     &    'smooth3DscalesH',smoothOpNb
-      CALL READ_REC_3D_RL(fnamegeneric,smoothprec,
-     &           Nr, smooth3D_Lx,1,1,mythid)
-      CALL READ_REC_3D_RL(fnamegeneric,smoothprec,
-     &           Nr, smooth3D_Ly,2,1,mythid)
-      CALL EXCH_XYZ_RL( smooth3D_Lx, mythid )
-      CALL EXCH_XYZ_RL( smooth3D_Ly, mythid )
-      else
-      DO bj=jtlo,jthi
-       DO bi=itlo,ithi
-        DO k=1,Nr
-         DO j=1-OLy,sNy+OLy
-          DO i=1-OLx,sNx+OLx
-          smooth3D_Lx(i,j,k,bi,bj)=smooth3D_Lx0(smoothOpNb)
-          smooth3D_Ly(i,j,k,bi,bj)=smooth3D_Ly0(smoothOpNb)
-          ENDDO
-         ENDDO
-        ENDDO
-       ENDDO
-      ENDDO
-      endif
+      WRITE(fnamegeneric(1:80),'(1a,i3.3)')
+     &      'smooth3Doperator', smoothOpNb
+      CALL WRITE_REC_3D_RL( fnamegeneric, smoothprec,
+     &                      Nr, smooth3D_Kwx, 1, 1, myThid )
+      CALL WRITE_REC_3D_RL( fnamegeneric, smoothprec,
+     &                      Nr, smooth3D_Kwy, 2, 1, myThid )
+      CALL WRITE_REC_3D_RL( fnamegeneric, smoothprec,
+     &                      Nr, smooth3D_Kwz, 3, 1, myThid )
+      CALL WRITE_REC_3D_RL( fnamegeneric, smoothprec,
+     &                      Nr, smooth3D_Kux, 4, 1, myThid )
+      CALL WRITE_REC_3D_RL( fnamegeneric, smoothprec,
+     &                      Nr, smooth3D_Kvy, 5, 1, myThid )
+      CALL WRITE_REC_3D_RL( fnamegeneric, smoothprec,
+     &                      Nr, smooth3D_Kuz, 6, 1, myThid )
+      CALL WRITE_REC_3D_RL( fnamegeneric, smoothprec,
+     &                      Nr, smooth3D_Kvz, 7, 1, myThid )
+      CALL WRITE_REC_3D_RL( fnamegeneric, smoothprec,
+     &                      Nr, smooth3D_Kuy, 8, 1, myThid )
+      CALL WRITE_REC_3D_RL( fnamegeneric, smoothprec,
+     &                      Nr, smooth3D_Kvx, 9, 1, myThid )
+      CALL WRITE_REC_3D_RL( fnamegeneric, smoothprec,
+     &                      Nr, smooth3D_kappaR, 10, 1, myThid )
 
-      DO bj=jtlo,jthi
-       DO bi=itlo,ithi
-        DO k=1,Nr
-         DO j=1-OLy,sNy+OLy
-          DO i=1-OLx,sNx+OLx
-      smooth3D_Kuy(i,j,k,bi,bj)=0.
-      smooth3D_Kvx(i,j,k,bi,bj)=0.
-      smooth3D_Kwx(i,j,k,bi,bj)=0.
-      smooth3D_Kwy(i,j,k,bi,bj)=0.
-      smooth3D_Kwz(i,j,k,bi,bj)=0.
-      smooth3D_Kux(i,j,k,bi,bj)=smooth3D_Lx(i,j,k,bi,bj)*
-     & smooth3D_Lx(i,j,k,bi,bj)/smooth3DtotTime/2
-      smooth3D_Kvy(i,j,k,bi,bj)=smooth3D_Ly(i,j,k,bi,bj)*
-     & smooth3D_Ly(i,j,k,bi,bj)/smooth3DtotTime/2
-      smooth3D_Kuz(i,j,k,bi,bj)=0.
-      smooth3D_Kvz(i,j,k,bi,bj)=0.
-          ENDDO
-         ENDDO
-        ENDDO
-       ENDDO
-      ENDDO
-
-c is exchange useful here?
-
-      CALL EXCH_XYZ_RL( smooth3D_kappaR,    myThid )
-      CALL EXCH_XYZ_RL( smooth3D_Kwx,    myThid )
-      CALL EXCH_XYZ_RL( smooth3D_Kwy,    myThid )
-      CALL EXCH_XYZ_RL( smooth3D_Kwz,    myThid )
-      CALL EXCH_XYZ_RL( smooth3D_Kux,    myThid )
-      CALL EXCH_XYZ_RL( smooth3D_Kvy,    myThid )
-      CALL EXCH_XYZ_RL( smooth3D_Kuz,    myThid )
-      CALL EXCH_XYZ_RL( smooth3D_Kvz,    myThid )
-      CALL EXCH_XYZ_RL( smooth3D_Kuy,    myThid )
-      CALL EXCH_XYZ_RL( smooth3D_Kvx,    myThid )
-
-
-c write diffusion operator to file
-
-      write(fnamegeneric(1:80),'(1a,i3.3)')
-     &    'smooth3Doperator',smoothOpNb
-
-      CALL WRITE_REC_3D_RL(fnamegeneric,smoothprec,
-     &           Nr,smooth3D_Kwx,1,1,mythid)
-      CALL WRITE_REC_3D_RL(fnamegeneric,smoothprec,
-     &           Nr,smooth3D_Kwy,2,1,mythid)
-      CALL WRITE_REC_3D_RL(fnamegeneric,smoothprec,
-     &           Nr,smooth3D_Kwz,3,1,mythid)
-      CALL WRITE_REC_3D_RL(fnamegeneric,smoothprec,
-     &           Nr,smooth3D_Kux,4,1,mythid)
-      CALL WRITE_REC_3D_RL(fnamegeneric,smoothprec,
-     &           Nr,smooth3D_Kvy,5,1,mythid)
-      CALL WRITE_REC_3D_RL(fnamegeneric,smoothprec,
-     &           Nr,smooth3D_Kuz,6,1,mythid)
-      CALL WRITE_REC_3D_RL(fnamegeneric,smoothprec,
-     &           Nr,smooth3D_Kvz,7,1,mythid)
-      CALL WRITE_REC_3D_RL(fnamegeneric,smoothprec,
-     &           Nr,smooth3D_Kuy,8,1,mythid)
-      CALL WRITE_REC_3D_RL(fnamegeneric,smoothprec,
-     &           Nr,smooth3D_Kvx,9,1,mythid)
-      CALL WRITE_REC_3D_RL(fnamegeneric,smoothprec,
-     &           Nr,smooth3D_kappaR,10,1,mythid)
-
-
+      RETURN
       END

--- a/pkg/smooth/smooth_init_fixed.F
+++ b/pkg/smooth/smooth_init_fixed.F
@@ -1,6 +1,6 @@
 #include "SMOOTH_OPTIONS.h"
 
-      subroutine smooth_init_fixed (mythid)
+      SUBROUTINE SMOOTH_INIT_FIXED( myThid )
 
 C     *==========================================================*
 C     | SUBROUTINE smooth_init_fixed
@@ -14,27 +14,19 @@ C     *==========================================================*
 #include "GRID.h"
 #include "SMOOTH.h"
 
-      integer myThid
-      integer ikey_bak
-      integer smoothOpNb
+      INTEGER myThid
 
-      integer i,j,k, bi, bj, imin, imax, jmin, jmax
-      integer itlo,ithi
-      integer jtlo,jthi
+      INTEGER smoothOpNb
+      INTEGER i, j, k, bi, bj
 
-      jtlo = mybylo(mythid)
-      jthi = mybyhi(mythid)
-      itlo = mybxlo(mythid)
-      ithi = mybxhi(mythid)
-
-      DO bj=jtlo,jthi
-       DO bi=itlo,ithi
+      DO bj=myByLo(myThid),myByHi(myThid)
+       DO bi=myBxLo(myThid),myBxHi(myThid)
         DO k=1,Nr
          DO j=1-OLy,sNy+OLy
           DO i=1-OLx,sNx+OLx
-          smooth_recip_hFacC(i,j,k,bi,bj)=_recip_hFacC(i,j,k,bi,bj)
-          smooth_hFacW(i,j,k,bi,bj)=_hFacW(i,j,k,bi,bj)
-          smooth_hFacS(i,j,k,bi,bj)=_hFacS(i,j,k,bi,bj)
+           smooth_recip_hFacC(i,j,k,bi,bj) = _recip_hFacC(i,j,k,bi,bj)
+           smooth_hFacW(i,j,k,bi,bj) = _hFacW(i,j,k,bi,bj)
+           smooth_hFacS(i,j,k,bi,bj) = _hFacS(i,j,k,bi,bj)
           ENDDO
          ENDDO
         ENDDO
@@ -42,31 +34,30 @@ C     *==========================================================*
       ENDDO
 
       DO smoothOpNb=1,smoothOpNbMax
-      if (smooth2Dtype(smoothOpNb).NE.0) then
-      call smooth_init2D(smoothOpNb,mythid)
-      endif
-      ENDDO 
-
-      DO smoothOpNb=1,smoothOpNbMax
-      if (smooth2Dtype(smoothOpNb).NE.0) then
-      call smooth_filtervar2D(smoothOpNb,mythid)
-      endif
+       IF (smooth2Dtype(smoothOpNb).NE.0) THEN
+        CALL smooth_init2D( smoothOpNb, myThid )
+       ENDIF
       ENDDO
 
       DO smoothOpNb=1,smoothOpNbMax
-      if ((smooth3DtypeZ(smoothOpNb).NE.0).OR.
-     & (smooth3DtypeH(smoothOpNb).NE.0)) then
-      call smooth_init3D(smoothOpNb,mythid)
-      endif
+       IF (smooth2Dtype(smoothOpNb).NE.0) THEN
+        CALL smooth_filtervar2D( smoothOpNb, myThid )
+       ENDIF
       ENDDO
 
       DO smoothOpNb=1,smoothOpNbMax
-      if ((smooth3DtypeZ(smoothOpNb).NE.0).OR.
-     & (smooth3DtypeH(smoothOpNb).NE.0)) then
-      call smooth_filtervar3D(smoothOpNb,mythid)
-      endif
+       IF ( (smooth3DtypeZ(smoothOpNb).NE.0).OR.
+     &      (smooth3DtypeH(smoothOpNb).NE.0) ) THEN
+        CALL smooth_init3D( smoothOpNb, myThid )
+       ENDIF
       ENDDO
 
-        END 
+      DO smoothOpNb=1,smoothOpNbMax
+       IF ( (smooth3DtypeZ(smoothOpNb).NE.0).OR.
+     &      (smooth3DtypeH(smoothOpNb).NE.0) ) THEN
+        CALL smooth_filtervar3D( smoothOpNb, myThid )
+       ENDIF
+      ENDDO
 
-
+      RETURN
+      END

--- a/pkg/smooth/smooth_init_varia.F
+++ b/pkg/smooth/smooth_init_varia.F
@@ -1,18 +1,16 @@
 #include "SMOOTH_OPTIONS.h"
 
-      subroutine smooth_init_varia (mythid)
+      SUBROUTINE SMOOTH_INIT_VARIA( myThid )
 
 C     *==========================================================*
-C     | SUBROUTINE smooth_init_varia
+C     | SUBROUTINE SMOOTH_INIT_VARIA
 C     | o Routine that initializes smoothing/correlation operators
 C     |  (first version is empty => see smooth_init_fixed.F)
 C     *==========================================================*
 
       IMPLICIT NONE
-        integer myThid
+      INTEGER myThid
 
-        END 
-
-
-
+      RETURN
+      END
 

--- a/pkg/smooth/smooth_readparms.F
+++ b/pkg/smooth/smooth_readparms.F
@@ -1,38 +1,35 @@
 #include "SMOOTH_OPTIONS.h"
 
-      subroutine smooth_readparms( myThid )
+      SUBROUTINE SMOOTH_READPARMS( myThid )
 
 C     *==========================================================*
-C     | SUBROUTINE smooth_readparms
+C     | SUBROUTINE SMOOTH_READPARMS
 C     | o Routine that reads the pkg/smooth namelist from data.smooth
 C     *==========================================================*
 
-      implicit none
+      IMPLICIT NONE
 
-c     == global variables ==
-
+C     == global variables ==
 #include "EEPARAMS.h"
 #include "SIZE.h"
 #include "GRID.h"
 #include "PARAMS.h"
-
 #include "SMOOTH.h"
 
-c     == routine arguments ==
+C     == routine arguments ==
+      INTEGER myThid
 
-      integer myThid
-
-c     == local variables ==
-C     msgBuf      - Informational/error message buffer
-C     iUnit       - Work variable for IO unit number
+C     == local variables ==
+C     msgBuf     :: Informational/error message buffer
+C     iUnit      :: Work variable for IO unit number
       CHARACTER*(MAX_LEN_MBUF) msgBuf
-      INTEGER iUnit, num_file, num_var
-      integer smoothOpNb
+      INTEGER iUnit
+      INTEGER smoothOpNb
 
-c     == end of interface ==
+C     == end of interface ==
 
-c--   Read the namelist input.
-      namelist /smooth_nml/
+C--   Read the namelist input.
+      NAMELIST /smooth_nml/
      &                   smooth2Dnbt,
      &                   smooth2Dtype,
      &                   smooth2Dsize,
@@ -65,7 +62,7 @@ C     print a (weak) warning if data.smooth is found
 
       _BEGIN_MASTER( myThid )
 
-c--   Set default values.
+C--   Set default values.
       DO smoothOpNb=1,smoothOpNbMax
         smooth2Dnbt(smoothOpNb)=0
         smooth2D_Lx0(smoothOpNb)=0. _d 0
@@ -90,7 +87,7 @@ c--   Set default values.
 C--   Read settings from model parameter file "data.smooth".
       WRITE(msgBuf,'(A)') 'SMOOTH_READPARMS: opening data.smooth'
       CALL PRINT_MESSAGE( msgBuf, standardMessageUnit,
-     &                    SQUEEZE_RIGHT , 1)
+     &                    SQUEEZE_RIGHT, myThid )
 
       CALL OPEN_COPY_DATA_FILE(
      I                          'data.smooth', 'SMOOTH_READPARMS',
@@ -102,7 +99,7 @@ C--   Read settings from model parameter file "data.smooth".
       WRITE(msgBuf,'(2A)') 'SMOOTH_READPARMS: ',
      &       'finished reading data.smooth'
       CALL PRINT_MESSAGE( msgBuf, standardMessageUnit,
-     &                  SQUEEZE_RIGHT , 1)
+     &                    SQUEEZE_RIGHT, myThid )
 
 #ifdef SINGLE_DISK_IO
       CLOSE(iUnit)
@@ -114,53 +111,53 @@ C--   Print pkg/smooth settings to standard output:
       WRITE(msgBuf,'(A)')
      &'// ======================================================='
       CALL PRINT_MESSAGE( msgBuf, standardMessageUnit,
-     &                    SQUEEZE_RIGHT , 1)
+     &                    SQUEEZE_RIGHT, myThid )
       WRITE(msgBuf,'(A)') '// pkg/smooth configuration'
       CALL PRINT_MESSAGE( msgBuf, standardMessageUnit,
-     &                    SQUEEZE_RIGHT , 1)
+     &                    SQUEEZE_RIGHT, myThid )
       WRITE(msgBuf,'(A)')
      &'// ======================================================='
       CALL PRINT_MESSAGE( msgBuf, standardMessageUnit,
-     &  SQUEEZE_RIGHT , 1)
+     &                    SQUEEZE_RIGHT, myThid )
 
       DO smoothOpNb=1,smoothOpNbMax
         IF (smooth2Dtype(smoothOpNb).NE.0) THEN
-          WRITE(msgBuf,'(A,I2,I6,2f6.0,A)') 'smooth 2D parameters: ',
+          WRITE(msgBuf,'(A,I2,I6,2F6.0,A)') 'smooth 2D parameters: ',
      &       smoothOpNb,smooth2Dnbt(smoothOpNb),
      &       smooth2D_Lx0(smoothOpNb),smooth2D_Ly0(smoothOpNb),
      &       smooth2DmaskName(smoothOpNb)
           CALL PRINT_MESSAGE( msgBuf, standardMessageUnit,
-     &       SQUEEZE_RIGHT , 1)
+     &                        SQUEEZE_RIGHT, myThid )
         ENDIF
       ENDDO
 
       DO smoothOpNb=1,smoothOpNbMax
         IF ((smooth3DtypeZ(smoothOpNb).NE.0).OR.
      &      (smooth3DtypeH(smoothOpNb).NE.0)) then
-          WRITE(msgBuf,'(A,I2,I6,3f6.0,A)') 'smooth 3D parameters: ',
+          WRITE(msgBuf,'(A,I2,I6,3F6.0,A)') 'smooth 3D parameters: ',
      &       smoothOpNb,smooth3Dnbt(smoothOpNb),
      &       smooth3D_Lx0(smoothOpNb),smooth3D_Ly0(smoothOpNb),
      &       smooth3D_Lz0(smoothOpNb),
      &       smooth3DmaskName(smoothOpNb)
           CALL PRINT_MESSAGE( msgBuf, standardMessageUnit,
-     &       SQUEEZE_RIGHT , 1)
+     &                        SQUEEZE_RIGHT, myThid )
         ENDIF
       ENDDO
 
       WRITE(msgBuf,'(A)')
      &'// ======================================================='
       CALL PRINT_MESSAGE( msgBuf, standardMessageUnit,
-     &                    SQUEEZE_RIGHT , 1)
+     &                    SQUEEZE_RIGHT, myThid )
       WRITE(msgBuf,'(A)') '// End of pkg/smooth config. summary'
       CALL PRINT_MESSAGE( msgBuf, standardMessageUnit,
-     &                    SQUEEZE_RIGHT , 1)
+     &                    SQUEEZE_RIGHT, myThid )
       WRITE(msgBuf,'(A)')
      &'// ======================================================='
       CALL PRINT_MESSAGE( msgBuf, standardMessageUnit,
-     &  SQUEEZE_RIGHT , 1)
+     &                    SQUEEZE_RIGHT, myThid )
       WRITE(msgBuf,'(A)') ' '
       CALL PRINT_MESSAGE( msgBuf, standardMessageUnit,
-     &  SQUEEZE_RIGHT , 1)
+     &                    SQUEEZE_RIGHT, myThid )
 
       _END_MASTER( myThid )
 

--- a/pkg/smooth/smooth_rhs.F
+++ b/pkg/smooth/smooth_rhs.F
@@ -1,16 +1,15 @@
 #include "SMOOTH_OPTIONS.h"
 
 C !INTERFACE: ==========================================================
-      SUBROUTINE smooth_rhs(fld_in,gt_in,myThid)
+      SUBROUTINE SMOOTH_RHS( fld_in, gt_in, myThid )
 
 C     *==========================================================*
 C     | SUBROUTINE smooth_rhs
-C     | o As part of smooth_diff3D, this routine computes the 
+C     | o As part of smooth_diff3D, this routine computes the
 C     |   right hand side of the tendency equation (see below).
 C     |   It is made of bits from model/src and pkg/generic_advdiff
 C     |   pieced togheter.
 C     *==========================================================*
-
 
 C !DESCRIPTION:
 C Calculates the tendency of a tracer due to advection and diffusion.
@@ -35,19 +34,16 @@ C !USES: ===============================================================
       IMPLICIT NONE
 #include "SIZE.h"
 #include "EEPARAMS.h"
-c#include "EESUPPORT.h"
 #include "PARAMS.h"
 #include "GRID.h"
 #include "SMOOTH.h"
 
 C !INPUT PARAMETERS: ===================================================
+      _RL fld_in(1-OLx:sNx+OLx,1-OLy:sNy+OLy,Nr,nSx,nSy)
+      _RL gt_in (1-OLx:sNx+OLx,1-OLy:sNy+OLy,Nr,nSx,nSy)
       INTEGER myThid
-      _RL fld_in(1-Olx:sNx+Olx,1-Oly:sNy+Oly,Nr,nSx,nSy)
-      _RL gt_in(1-Olx:sNx+Olx,1-Oly:sNy+Oly,Nr,nSx,nSy)
-
 
 C local variables:
-
       INTEGER bi,bj,iMin,iMax,jMin,jMax
       _RS xA    (1-OLx:sNx+OLx,1-OLy:sNy+OLy,nSx,nSy)
       _RS yA    (1-OLx:sNx+OLx,1-OLy:sNy+OLy,nSx,nSy)
@@ -56,23 +52,20 @@ C local variables:
       _RL dTdx  (nSx,nSy)
       _RL dTdy  (nSx,nSy)
       INTEGER i,j,k
-
-      _RL fZon  (1-OLx:sNx+OLx,1-OLy:sNy+OLy,nR,nSx,nSy)
-      _RL fMer  (1-OLx:sNx+OLx,1-OLy:sNy+OLy,nR,nSx,nSy)
-      _RL fVerT  (1-OLx:sNx+OLx,1-OLy:sNy+OLy,nR,nSx,nSy)
+      _RL fZon  (1-OLx:sNx+OLx,1-OLy:sNy+OLy,Nr,nSx,nSy)
+      _RL fMer  (1-OLx:sNx+OLx,1-OLy:sNy+OLy,Nr,nSx,nSy)
+      _RL fVerT (1-OLx:sNx+OLx,1-OLy:sNy+OLy,Nr,nSx,nSy)
       _RL df    (1-OLx:sNx+OLx,1-OLy:sNy+OLy,nSx,nSy)
-
 
       DO bj=myByLo(myThid),myByHi(myThid)
        DO bi=myBxLo(myThid),myBxHi(myThid)
-
 
 c 1rst k loop: initialization
         DO k=1,Nr
          DO j=1-OLy,sNy+OLy
           DO i=1-OLx,sNx+OLx
-           fZon(i,j,k,bi,bj)      = 0. _d 0
-           fMer(i,j,k,bi,bj)      = 0. _d 0
+           fZon(i,j,k,bi,bj)  = 0. _d 0
+           fMer(i,j,k,bi,bj)  = 0. _d 0
            fVerT(i,j,k,bi,bj) = 0. _d 0
            gt_in(i,j,k,bi,bj) = 0. _d 0
           ENDDO
@@ -89,15 +82,15 @@ c 2nd k loop: flux computation
 
          DO j=1-OLy,sNy+OLy
           DO i=1-OLx,sNx+OLx
-           df(i,j,bi,bj)        = 0. _d 0
+           df(i,j,bi,bj) = 0. _d 0
            xA(i,j,bi,bj) = _dyG(i,j,bi,bj)
      &      *drF(k)*smooth_hFacW(i,j,k,bi,bj)
            yA(i,j,bi,bj) = _dxG(i,j,bi,bj)
      &      *drF(k)*smooth_hFacS(i,j,k,bi,bj)
-           IF (K .EQ. 1) THEN
+           IF (k .EQ. 1) THEN
              maskUp(i,j,bi,bj) = 0.
            ELSE
-            maskUp(i,j,bi,bj) = 
+            maskUp(i,j,bi,bj) =
      &        maskC(i,j,k-1,bi,bj)*maskC(i,j,k,bi,bj)
            ENDIF
           ENDDO
@@ -107,7 +100,7 @@ c      ///gmredi_xtr///
 
          DO j=jMin,jMax
           DO i=iMin,iMax
-        df(i,j,bi,bj) = df(i,j,bi,bj)
+           df(i,j,bi,bj) = df(i,j,bi,bj)
      &       -xA(i,j,bi,bj)
      &       *smooth3D_Kux(i,j,k,bi,bj)
      &       *recip_dxC(i,j,bi,bj)
@@ -115,8 +108,8 @@ c      ///gmredi_xtr///
           ENDDO
          ENDDO
 
-          DO j=jMin,jMax
-           DO i=iMin,iMax
+         DO j=jMin,jMax
+          DO i=iMin,iMax
            dTdz(bi,bj) =  0.5*(
      &      +0.5*recip_drC(k)*
      &       ( maskC(i-1,j,k,bi,bj)*
@@ -129,11 +122,11 @@ c      ///gmredi_xtr///
      &       (fld_in(i-1,j,k,bi,bj)-fld_in(i-1,j,MIN(k+1,Nr),bi,bj))
      &       +maskC( i ,j,MIN(k+1,Nr),bi,bj)*
      &       (fld_in( i ,j,k,bi,bj)-fld_in( i ,j,MIN(k+1,Nr),bi,bj))
-     &       ) )
-           df(i,j,bi,bj) = df(i,j,bi,bj) 
+     &       )                )
+           df(i,j,bi,bj) = df(i,j,bi,bj)
      &      - xA(i,j,bi,bj)*smooth3D_Kuz(i,j,k,bi,bj)*dTdz(bi,bj)
-           ENDDO
           ENDDO
+         ENDDO
 
          DO j=jMin,jMax
           DO i=iMin,iMax
@@ -153,23 +146,22 @@ c      ///gmredi_xtr///
      &       )
            df(i,j,bi,bj) = df(i,j,bi,bj)
      &      - xA(i,j,bi,bj)*smooth3D_Kuy(i,j,k,bi,bj)*dTdy(bi,bj)
-       ENDDO
-      ENDDO
-
-
-c      /// end for x ///
-
-          DO j=jMin,jMax
-           DO i=iMin,iMax
-            fZon(i,j,k,bi,bj) = fZon(i,j,k,bi,bj) + df(i,j,bi,bj)
           ENDDO
          ENDDO
 
-          DO j=jMin,jMax
-           DO i=iMin,iMax
-            df(i,j,bi,bj) = 0.
-           ENDDO
+c      /// end for x ///
+
+         DO j=jMin,jMax
+          DO i=iMin,iMax
+           fZon(i,j,k,bi,bj) = fZon(i,j,k,bi,bj) + df(i,j,bi,bj)
           ENDDO
+         ENDDO
+
+         DO j=jMin,jMax
+          DO i=iMin,iMax
+           df(i,j,bi,bj) = 0.
+          ENDDO
+         ENDDO
 
 c      ///gmredi_ytr///
 
@@ -183,8 +175,8 @@ c      ///gmredi_ytr///
           ENDDO
          ENDDO
 
-          DO j=jMin,jMax
-           DO i=iMin,iMax
+         DO j=jMin,jMax
+          DO i=iMin,iMax
            dTdz(bi,bj) =  0.5*(
      &      +0.5*recip_drC(k)*
      &       ( maskC(i,j-1,k,bi,bj)*
@@ -198,10 +190,10 @@ c      ///gmredi_ytr///
      &         +maskC(i, j ,MIN(k+1,Nr),bi,bj)*
      &         (fld_in(i, j ,k,bi,bj)-fld_in(i, j ,MIN(k+1,Nr),bi,bj))
      &       )      )
-             df(i,j,bi,bj) = df(i,j,bi,bj)
-     &        - yA(i,j,bi,bj)*smooth3D_Kvz(i,j,k,bi,bj)*dTdz(bi,bj)
-           ENDDO
+           df(i,j,bi,bj) = df(i,j,bi,bj)
+     &      - yA(i,j,bi,bj)*smooth3D_Kvz(i,j,k,bi,bj)*dTdz(bi,bj)
           ENDDO
+         ENDDO
 
          DO j=jMin,jMax
           DO i=iMin,iMax
@@ -219,30 +211,28 @@ c      ///gmredi_ytr///
      &            *recip_dxC(i,j,bi,bj)*
      &            (fld_in(i,j-1,k,bi,bj)-fld_in(i-1,j-1,k,bi,bj)))
      &       )
-             df(i,j,bi,bj) = df(i,j,bi,bj)
-     &        - yA(i,j,bi,bj)*smooth3D_Kvx(i,j,k,bi,bj)*dTdx(bi,bj)
+           df(i,j,bi,bj) = df(i,j,bi,bj)
+     &      - yA(i,j,bi,bj)*smooth3D_Kvx(i,j,k,bi,bj)*dTdx(bi,bj)
           ENDDO
          ENDDO
- 
-c      /// end for y /// 
 
-          DO j=jMin,jMax
-           DO i=iMin,iMax
-            fMer(i,j,k,bi,bj) = fMer(i,j,k,bi,bj) + df(i,j,bi,bj)
-           ENDDO
-          ENDDO
+c      /// end for y ///
 
-          DO j=jMin,jMax
-           DO i=iMin,iMax
-            df(i,j,bi,bj) = 0.
-           ENDDO
+         DO j=jMin,jMax
+          DO i=iMin,iMax
+           fMer(i,j,k,bi,bj) = fMer(i,j,k,bi,bj) + df(i,j,bi,bj)
           ENDDO
+         ENDDO
+
+         DO j=jMin,jMax
+          DO i=iMin,iMax
+           df(i,j,bi,bj) = 0.
+          ENDDO
+         ENDDO
 
 c       /// GAD_DIFF_R ///
 
-       if (.NOT. smooth3DdoImpldiff ) then
-
-         IF (k.gt.1) then 
+         IF ( k.GT.1 .AND. .NOT.smooth3DdoImpldiff ) THEN
           DO j=jMin,jMax
            DO i=iMin,iMax
             df(i,j,bi,bj) =
@@ -250,66 +240,63 @@ c       /// GAD_DIFF_R ///
      &        *smooth3D_kappaR(i,j,k,bi,bj)*recip_drC(k)
      &        *(fld_in(i,j,k,bi,bj)
      &        -fld_in(i,j,k-1,bi,bj))*rkSign
-        ENDDO
-       ENDDO
-      ENDIF
-
-      endif
+           ENDDO
+          ENDDO
+         ENDIF
 
 c      ///gmredi rtrans///
 
-         IF (K.GT.1) THEN
-         DO j=jMin,jMax
-          DO i=iMin,iMax
-           dTdx(bi,bj) = 0.5*(
-     &      +0.5*(maskW(i+1,j,k,bi,bj)
-     &            *recip_dxC(i+1,j,bi,bj)*
-     &            (fld_in(i+1,j,k,bi,bj)-fld_in(i,j,k,bi,bj))
+         IF (k.GT.1) THEN
+          DO j=jMin,jMax
+           DO i=iMin,iMax
+            dTdx(bi,bj) = 0.5*(
+     &       +0.5*(maskW(i+1,j,k,bi,bj)
+     &             *recip_dxC(i+1,j,bi,bj)*
+     &             (fld_in(i+1,j,k,bi,bj)-fld_in(i,j,k,bi,bj))
      &            +maskW(i,j,k,bi,bj)
-     &            *recip_dxC(i,j,bi,bj)*
-     &            (fld_in(i,j,k,bi,bj)-fld_in(i-1,j,k,bi,bj)))
-     &      +0.5*(maskW(i+1,j,k-1,bi,bj)
-     &            *recip_dxC(i+1,j,bi,bj)*
-     &            (fld_in(i+1,j,k-1,bi,bj)-fld_in(i,j,k-1,bi,bj))
+     &             *recip_dxC(i,j,bi,bj)*
+     &             (fld_in(i,j,k,bi,bj)-fld_in(i-1,j,k,bi,bj)))
+     &       +0.5*(maskW(i+1,j,k-1,bi,bj)
+     &             *recip_dxC(i+1,j,bi,bj)*
+     &             (fld_in(i+1,j,k-1,bi,bj)-fld_in(i,j,k-1,bi,bj))
      &            +maskW(i,j,k-1,bi,bj)
-     &            *recip_dxC(i,j,bi,bj)*
-     &            (fld_in(i,j,k-1,bi,bj)-fld_in(i-1,j,k-1,bi,bj)))
-     &       )
+     &             *recip_dxC(i,j,bi,bj)*
+     &             (fld_in(i,j,k-1,bi,bj)-fld_in(i-1,j,k-1,bi,bj)))
+     &                        )
 
-           dTdy(bi,bj) = 0.5*(
-     &      +0.5*(maskS(i,j,k,bi,bj)
-     &            *recip_dyC(i,j,bi,bj)*
-     &            (fld_in(i,j,k,bi,bj)-fld_in(i,j-1,k,bi,bj))
-     &           +maskS(i,j+1,k,bi,bj)
-     &           *recip_dyC(i,j+1,bi,bj)*
-     &           (fld_in(i,j+1,k,bi,bj)-fld_in(i,j,k,bi,bj)))
-     &      +0.5*(maskS(i,j,k-1,bi,bj)
-     &           *recip_dyC(i,j,bi,bj)*
-     &           (fld_in(i,j,k-1,bi,bj)-fld_in(i,j-1,k-1,bi,bj))
-     &           +maskS(i,j+1,k-1,bi,bj)
-     &           *recip_dyC(i,j+1,bi,bj)*
-     &           (fld_in(i,j+1,k-1,bi,bj)-fld_in(i,j,k-1,bi,bj)))
-     &      )
+            dTdy(bi,bj) = 0.5*(
+     &       +0.5*(maskS(i,j,k,bi,bj)
+     &             *recip_dyC(i,j,bi,bj)*
+     &             (fld_in(i,j,k,bi,bj)-fld_in(i,j-1,k,bi,bj))
+     &            +maskS(i,j+1,k,bi,bj)
+     &             *recip_dyC(i,j+1,bi,bj)*
+     &             (fld_in(i,j+1,k,bi,bj)-fld_in(i,j,k,bi,bj)))
+     &       +0.5*(maskS(i,j,k-1,bi,bj)
+     &             *recip_dyC(i,j,bi,bj)*
+     &             (fld_in(i,j,k-1,bi,bj)-fld_in(i,j-1,k-1,bi,bj))
+     &            +maskS(i,j+1,k-1,bi,bj)
+     &             *recip_dyC(i,j+1,bi,bj)*
+     &             (fld_in(i,j+1,k-1,bi,bj)-fld_in(i,j,k-1,bi,bj)))
+     &                        )
 
-           df(i,j,bi,bj) = df(i,j,bi,bj)
+            df(i,j,bi,bj) = df(i,j,bi,bj)
      &           - rA(i,j,bi,bj)
      &           *( smooth3D_Kwx(i,j,k,bi,bj)*dTdx(bi,bj)
-     &           +smooth3D_Kwy(i,j,k,bi,bj)*dTdy(bi,bj) )
+     &             +smooth3D_Kwy(i,j,k,bi,bj)*dTdy(bi,bj) )
 
+           ENDDO
           ENDDO
-         ENDDO
          ENDIF
-
 
 c     /// end for r ///
 
-         IF (K.GT.1) THEN
-         DO j=jMin,jMax
-          DO i=iMin,iMax
-           fVerT(i,j,k-1,bi,bj) = fVerT(i,j,k-1,bi,bj) + 
-     &    df(i,j,bi,bj)*maskUp(i,j,bi,bj)
+         IF (k.GT.1) THEN
+          DO j=jMin,jMax
+           DO i=iMin,iMax
+            fVerT(i,j,k-1,bi,bj) = fVerT(i,j,k-1,bi,bj)
+     &       + df(i,j,bi,bj)*maskUp(i,j,bi,bj)
+           ENDDO
           ENDDO
-         ENDDO
          ENDIF
 
          DO j=jMin,jMax
@@ -330,37 +317,38 @@ c these exchanges are crucial:
        DO bi=myBxLo(myThid),myBxHi(myThid)
 c 3rd k loop: Divergence of fluxes
         DO k=1,Nr
-        IF (K.GT.1) THEN
-         DO j=jMin,jMax
-          DO i=iMin,iMax
-        gt_in(i,j,k,bi,bj)=gt_in(i,j,k,bi,bj)
-     &   -smooth_recip_hFacC(i,j,k,bi,bj)*recip_drF(k)
-     &   *recip_rA(i,j,bi,bj)
-     &   *( (fZon(i+1,j,k,bi,bj)-fZon(i,j,k,bi,bj))
-     &     +(fMer(i,j+1,k,bi,bj)-fMer(i,j,k,bi,bj))
-     &     +(fVerT(i,j,k,bi,bj)-fVerT(i,j,k-1,bi,bj))*rkSign
-     &    )
+         IF (k.GT.1) THEN
+          DO j=jMin,jMax
+           DO i=iMin,iMax
+            gt_in(i,j,k,bi,bj) = gt_in(i,j,k,bi,bj)
+     &       -smooth_recip_hFacC(i,j,k,bi,bj)*recip_drF(k)
+     &       *recip_rA(i,j,bi,bj)
+     &       *( (fZon(i+1,j,k,bi,bj)-fZon(i,j,k,bi,bj))
+     &         +(fMer(i,j+1,k,bi,bj)-fMer(i,j,k,bi,bj))
+     &         +(fVerT(i,j,k,bi,bj)-fVerT(i,j,k-1,bi,bj))*rkSign
+     &        )
+           ENDDO
           ENDDO
-         ENDDO
-        ELSE
-         DO j=jMin,jMax
-          DO i=iMin,iMax
-        gt_in(i,j,k,bi,bj)=gt_in(i,j,k,bi,bj)
-     &   -smooth_recip_hFacC(i,j,k,bi,bj)*recip_drF(k)
-     &   *recip_rA(i,j,bi,bj)
-     &   *( (fZon(i+1,j,k,bi,bj)-fZon(i,j,k,bi,bj))
-     &     +(fMer(i,j+1,k,bi,bj)-fMer(i,j,k,bi,bj))
-     &     +(fVerT(i,j,k,bi,bj))*rkSign
-     &    )
+         ELSE
+          DO j=jMin,jMax
+           DO i=iMin,iMax
+            gt_in(i,j,k,bi,bj) = gt_in(i,j,k,bi,bj)
+     &       -smooth_recip_hFacC(i,j,k,bi,bj)*recip_drF(k)
+     &       *recip_rA(i,j,bi,bj)
+     &       *( (fZon(i+1,j,k,bi,bj)-fZon(i,j,k,bi,bj))
+     &         +(fMer(i,j+1,k,bi,bj)-fMer(i,j,k,bi,bj))
+     &         +(fVerT(i,j,k,bi,bj))*rkSign
+     &        )
+           ENDDO
           ENDDO
-         ENDDO
-        ENDIF
+         ENDIF
         ENDDO
 
        ENDDO
       ENDDO
 
-      CALL EXCH_XYZ_RL ( gt_in , myThid )
+      CALL EXCH_XYZ_RL( gt_in, myThid )
 
+      RETURN
       END
 

--- a/pkg/thsice/thsice_albedo.F
+++ b/pkg/thsice/thsice_albedo.F
@@ -74,7 +74,7 @@ C     albsno     :: albedo of snow
 C     albice     :: albedo of ice
 C     albNewSnow :: albedo of new (fresh) snow
 C     albNewSnow :: albedo of new (fresh) snow
-C     msgBuf     :: Informational/error meesage buffer
+C     msgBuf     :: Informational/error message buffer
 c     _RL  frsnow
       _RL albsno
       _RL albice
@@ -83,7 +83,9 @@ c     _RL  frsnow
       _RL albNIR_ice, albNIR_fHice, recFac_albNIR
       INTEGER i,j
       INTEGER ii,jj,icount
+#ifndef ALLOW_AUTODIFF
       CHARACTER*(MAX_LEN_MBUF) msgBuf
+#endif
 
 C---+----1----+----2----+----3----+----4----+----5----+----6----+----7-|--+----|
 
@@ -104,7 +106,7 @@ C     Near-InfraRed albedo
          hs  = hSnow(i,j)
          Tsf = tSrf(i,j)
          age = ageSnw(i,j)
-         
+
 C---+----1----+----2----+----3----+----4----+----5----+----6----+----7-|--+----|
 C--   Albedo of Bare Sea-Ice
          albice = albIceMax + (albIceMin-albIceMax)*EXP(-hi/hAlbIce)
@@ -144,7 +146,7 @@ C--   Compute near-infrared albedo
      &         + 0.075 _d 0 * MIN( -Tsf - 1. _d 0, 0. _d 0 )
 
           sAlbNIR(i,j) = albNIR_ice * ( 1. _d 0 - hs/(hs + 0.02 _d 0) )
-     &         + ( albNIR_dsnow 
+     &         + ( albNIR_dsnow
      &             + 0.15 _d 0 *MIN( -Tsf - 1. _d 0, 0. _d 0) )
      &         * hs/(hs + 0.02 _d 0)
          ELSE
@@ -174,7 +176,7 @@ c       print*,'QQ - albedo problem', albedo, age, hs, albsno
      &      'THSICE_ALBEDO: Problem, e.g., at:', myIter,ii,jj,bi,bj
        CALL PRINT_ERROR( msgBuf , myThid)
        WRITE(msgBuf,'(A,1P3E17.9)')
-     &      'THSICE_ALBEDO: albedo=', sAlb(ii,jj),ageSnw(ii,jj), 
+     &      'THSICE_ALBEDO: albedo=', sAlb(ii,jj),ageSnw(ii,jj),
      &      hsnow(ii,jj)
        CALL PRINT_ERROR( msgBuf , myThid)
        STOP 'THSICE_ALBEDO: albedo out of range'

--- a/pkg/thsice/thsice_cost_init_varia.F
+++ b/pkg/thsice/thsice_cost_init_varia.F
@@ -1,19 +1,14 @@
 #include "THSICE_OPTIONS.h"
 
-      subroutine thsice_cost_init_varia( mythid )
+      SUBROUTINE THSICE_COST_INIT_VARIA( myThid )
 
 c     ==================================================================
-c     SUBROUTINE thsice_cost_init_varia
-c     ==================================================================
-c
-c     ==================================================================
-c     SUBROUTINE thsice_cost_init_varia
+c     SUBROUTINE THSICE_COST_INIT_VARIA
 c     ==================================================================
 
-      implicit none
+      IMPLICIT NONE
 
 c     == global variables ==
-
 #include "EEPARAMS.h"
 #include "SIZE.h"
 #include "GRID.h"
@@ -22,37 +17,23 @@ c     == global variables ==
 #endif
 
 c     == routine arguments ==
-
-      integer mythid
+      INTEGER myThid
 
 #ifdef ALLOW_COST
 c     == local variables ==
-
-      integer bi,bj
-      integer itlo,ithi
-      integer jtlo,jthi
-
-      logical exst
-
-c     == external functions ==
+      INTEGER bi,bj
 
 c     == end of interface ==
-      jtlo = myByLo(mythid)
-      jthi = myByHi(mythid)
-      itlo = myBxLo(mythid)
-      ithi = myBxHi(mythid)
 
 c--   Initialize the tiled cost function contributions.
-      do bj = jtlo,jthi
-        do bi = itlo,ithi
-# ifdef ALLOW_COST
-          objf_thsice(bi,bj)     = 0. _d 0
-          num_thsice(bi,bj)      = 0. _d 0
-# endif
-        enddo
-      enddo
+      DO bj = myByLo(myThid), myByHi(myThid)
+       DO bi = myBxLo(myThid), myBxHi(myThid)
+         objf_thsice(bi,bj) = 0. _d 0
+         num_thsice(bi,bj)  = 0. _d 0
+       ENDDO
+      ENDDO
 
-#endif
+#endif /* ALLOW_COST */
 
-      return
-      end
+      RETURN
+      END

--- a/pkg/thsice/thsice_get_exf.F
+++ b/pkg/thsice/thsice_get_exf.F
@@ -151,7 +151,7 @@ C     latent heat of evaporation or sublimation [J/kg]
 #ifdef ALLOW_AUTODIFF_TAMC
       INTEGER act1, act2, act3, act4
       INTEGER max1, max2, max3
-      INTEGER ticekey, ikey_1, ikey_2
+      INTEGER ikey_1, ikey_2
 #endif
 #ifdef ALLOW_DBUG_THSICE
       LOGICAL dBugFlag

--- a/pkg/thsice/thsice_solve4temp.F
+++ b/pkg/thsice/thsice_solve4temp.F
@@ -154,7 +154,9 @@ C     dt           :: timestep
       LOGICAL iterate4Tsf
       INTEGER i, j, k, iterMax
       INTEGER ii, jj, icount, stdUnit
+#if ( defined ALLOW_DBUG_THSICE || !defined ALLOW_AUTODIFF )
       CHARACTER*(MAX_LEN_MBUF) msgBuf
+#endif
       _RL  frsnow
       _RL  fswpen
       _RL  fswdn

--- a/verification/bottom_ctrl_5x5/code_ad/dummy_in_hfac.F
+++ b/verification/bottom_ctrl_5x5/code_ad/dummy_in_hfac.F
@@ -1,31 +1,45 @@
 #include "AUTODIFF_OPTIONS.h"
+#ifdef ALLOW_CTRL
+# include "CTRL_OPTIONS.h"
+#endif
 
-      subroutine dummy_in_hfac( myname, myIter, myThid )
+C--  File dummy_in_hfac.F:
+C--   Contents
+C--   o DUMMY_IN_HFAC
+C--   o ADDUMMY_IN_HFAC
 
-C     *==========================================================*
-C     | SUBROUTINE dummy_in_hfac
-C     *==========================================================*
+C---+----1----+----2----+----3----+----4----+----5----+----6----+----7-|--+----|
+CBOP
+C     !ROUTINE: DUMMY_IN_HFAC
+C     !INTERFACE:
+      SUBROUTINE DUMMY_IN_HFAC( myName, myIter, myThid )
 
+C     !DESCRIPTION: \bv
+C     Forward S/R is empty
+C     \ev
+
+C     !USES:
       IMPLICIT NONE
 C     == Global variables ===
 #include "SIZE.h"
 #include "EEPARAMS.h"
 #include "PARAMS.h"
 
-C     == Routine arguments ==
-C     myThid - Thread number for this instance of the routine.
-      CHARACTER*(*) myname
+C     !INPUT/OUTPUT PARAMETERS:
+C     myThid :: Thread number for this instance of the routine.
+      CHARACTER*(*) myName
       INTEGER myIter
       INTEGER myThid
+CEOP
 
       RETURN
       END
 
 C---+----1----+----2----+----3----+----4----+----5----+----6----+----7-|--+----|
 CBOP
-C     !ROUTINE: addummy_in_hfac
+C     !ROUTINE: ADDUMMY_IN_HFAC
 C     !INTERFACE:
-      subroutine addummy_in_hfac( myname, myIter, myThid )
+      SUBROUTINE ADDUMMY_IN_HFAC( myName, myIter, myThid )
 
 C     !DESCRIPTION: \bv
 C     *==========================================================*
@@ -52,87 +66,81 @@ C     == Global variables ===
 #include "adcommon.h"
 #endif
 
+C     !INPUT/OUTPUT PARAMETERS:
+C     myThid :: Thread number for this instance of the routine.
+      CHARACTER*(1) myName
+      INTEGER myIter
+      INTEGER myThid
+
+#ifdef ALLOW_AUTODIFF_MONITOR
+#ifdef ALLOW_DEPTH_CONTROL
+C     !FUNCTIONS:
       LOGICAL  DIFFERENT_MULTIPLE
       EXTERNAL DIFFERENT_MULTIPLE
       INTEGER  IO_ERRCOUNT
       EXTERNAL IO_ERRCOUNT
 
-C     !INPUT/OUTPUT PARAMETERS:
-C     == Routine arguments ==
-C     myThid - Thread number for this instance of the routine.
-      CHARACTER*(1) myname
-      integer myIter
-      integer myThid
-
-#ifdef ALLOW_AUTODIFF_MONITOR
 C     !LOCAL VARIABLES:
-c     == local variables ==
-C     suff - Hold suffix part of a filename
-C     beginIOErrCount - Begin and end IO error counts
-C     endIOErrCount
-C     msgBuf - Error message buffer
+C     suff            :: Hold suffix part of a filename
+C     beginIOErrCount :: Begin IO error counts
+C     endIOErrCount   :: End IO error counts
+C     msgBuf          :: Error message buffer
       CHARACTER*(MAX_LEN_FNAM) suff
       INTEGER beginIOErrCount
       INTEGER endIOErrCount
       CHARACTER*(MAX_LEN_MBUF) msgBuf
-      _RL mytime
-      CHARACTER*(5) myfullname
-
-c     == end of interface ==
+      _RL myTime
+      CHARACTER*(5) myFullName
 CEOP
 
-#ifdef ALLOW_DEPTH_CONTROL
+      myTime = 0.
 
-      mytime = 0.
-
-      IF (
-     &  DIFFERENT_MULTIPLE(dumpFreq,mytime,
-     &                     mytime-deltaTClock)
-     & ) THEN
+      IF ( DIFFERENT_MULTIPLE( dumpFreq, myTime, myTime-deltaTClock )
+     &   ) THEN
 
         CALL TIMER_START('I/O (WRITE)        [ADJOINT LOOP]', myThid )
 
 C--     Set suffix for this set of data files.
         WRITE(suff,'(I10.10)') myIter
-        writeBinaryPrec = writeStatePrec
+c       writeBinaryPrec = writeStatePrec
 
 C--     Read IO error counter
         beginIOErrCount = IO_ERRCOUNT(myThid)
 
-        IF ( myname .eq. 'C' ) THEN
-           myfullname = 'hFacC'
-           CALL WRITE_FLD_XYZ_RL ( 'ADJhFacC.', suff, adhfacc,
-     &          myIter, myThid)
-        ELSE IF ( myname .eq. 'W' ) THEN
-           myfullname = 'hFacW'
-           CALL WRITE_FLD_XYZ_RL ( 'ADJhFacW.', suff, adhfacw,
-     &          myIter, myThid)
-        ELSE IF ( myname .eq. 'S' ) THEN
-           myfullname = 'hFacS'
-           CALL WRITE_FLD_XYZ_RL ( 'ADJhFacS.', suff, adhfacs,
-     &          myIter, myThid)
+        IF ( myName .EQ. 'C' ) THEN
+          myFullName = 'hFacC'
+          CALL WRITE_FLD_XYZ_RL( 'ADJhFacC.', suff, adhfacc,
+     &                           myIter, myThid )
+        ELSE IF ( myName .EQ. 'W' ) THEN
+          myFullName = 'hFacW'
+          CALL WRITE_FLD_XYZ_RL( 'ADJhFacW.', suff, adhfacw,
+     &                           myIter, myThid )
+        ELSE IF ( myName .EQ. 'S' ) THEN
+          myFullName = 'hFacS'
+          CALL WRITE_FLD_XYZ_RL( 'ADJhFacS.', suff, adhfacs,
+     &                           myIter, myThid )
         ELSE
-           write(*,*) 'addummy_in_hfac: no valid myname specified'
+          WRITE(*,*) 'addummy_in_hfac: no valid myName specified'
         END IF
 C--     Reread IO error counter
         endIOErrCount = IO_ERRCOUNT(myThid)
 
 C--     Check for IO errors
         IF ( endIOErrCount .NE. beginIOErrCount ) THEN
-         WRITE(msgBuf,'(A)')  'S/R WRITE_STATE'
-         CALL PRINT_ERROR( msgBuf, 1 )
-         WRITE(msgBuf,'(A)')  'Error writing out model state'
-         CALL PRINT_ERROR( msgBuf, 1 )
-         WRITE(msgBuf,'(A,I10)') 'Timestep ',myIter
-         CALL PRINT_ERROR( msgBuf, 1 )
+          WRITE(msgBuf,'(A)')  'S/R WRITE_STATE'
+          CALL PRINT_ERROR( msgBuf, myThid )
+          WRITE(msgBuf,'(A)')  'Error writing out model state'
+          CALL PRINT_ERROR( msgBuf, myThid )
+          WRITE(msgBuf,'(A,I10)') 'Timestep ',myIter
+          CALL PRINT_ERROR( msgBuf, myThid )
         ELSE
-         WRITE(msgBuf,'(A,I10)')
-     &    '// ad'//myfullname//' written, timestep', myIter
-         CALL PRINT_MESSAGE( msgBuf, standardMessageUnit,
-     &    SQUEEZE_RIGHT, 1 )
-         WRITE(msgBuf,'(A)')  ' '
-         CALL PRINT_MESSAGE( msgBuf, standardMessageUnit,
-     &    SQUEEZE_RIGHT, 1 )
+          WRITE(msgBuf,'(A,I10)')
+     &     '// ad'//myFullName//' written, timestep', myIter
+          CALL PRINT_MESSAGE( msgBuf, standardMessageUnit,
+     &                        SQUEEZE_RIGHT, myThid )
+          WRITE(msgBuf,'(A)')  ' '
+          CALL PRINT_MESSAGE( msgBuf, standardMessageUnit,
+     &                        SQUEEZE_RIGHT, myThid )
         ENDIF
 
         CALL TIMER_STOP( 'I/O (WRITE)        [ADJOINT LOOP]', myThid )


### PR DESCRIPTION
## What changes does this PR introduce?
Remove or avoid un-used (local) variables in (TAF) AD built and clean-up (a little) pkg/smooth.

## What is the current behaviour? 
Most un-used variables have been removed from FWD verification experiment built but still many seen in AD verification exp. built (although the number went down by > x 31 after merging PR #471).

## What is the new behaviour 
clean up by removing or just avoiding some un-used variables

## Does this PR introduce a breaking change? 
no real code change, zero change in results.

## Other information:
a) for now, no changes in pkg/streamice (left AD exp halfpipe_streamice on the side).
b) there is still unused variables left in src files that are processed by TAF, but, since TAF remove them, it's less an issue + don't notice any warning.

## Suggested addition to `tag-index`
o pkgs:
  - remove/avoid unused variables from AD verification exp. built except from
    halfpipe_streamice (pkg/streamice); also clean-up a bit pkg/smooth.
