### PR TITLE
Fixes to restore stratification inside ice-shelf cavities

### DIFF
--- a/pkg/ggl90/ggl90_calc.F
+++ b/pkg/ggl90/ggl90_calc.F
@@ -42,6 +42,9 @@ C !USES: ============================================================
 #ifdef ALLOW_AUTODIFF_TAMC
 # include "tamc.h"
 #endif
+#ifdef ALLOW_SHELFICE
+#include "SHELFICE.h"
+#endif
 
 C !INPUT PARAMETERS: ===================================================
 C Routine arguments
@@ -90,6 +93,10 @@ C     TKEPrandtlNumber :: here, an empirical function of the Richardson number
       INTEGER kp1, km1, kl
       INTEGER kSrf, kTop, kBot, delK
       INTEGER errCode
+#ifdef ALLOW_SHELFICE
+      INTEGER ktmp, kSrftmp, kToptmp
+      _RL     explDissFacSI, implDissFacSI
+#endif
       _RL deltaTloc
       _RL explDissFac, implDissFac
       _RL totalDepth   (1-OLx:sNx+OLx,1-OLy:sNy+OLy)
@@ -192,6 +199,11 @@ CEOP
 C     explicit/implicit timestepping weights for dissipation
       explDissFac = 0. _d 0
       implDissFac = 1. _d 0 - explDissFac
+
+#ifdef ALLOW_SHELFICE
+      explDissFacSI = 0.5 _d 0
+      implDissFacSI = 1. _d 0 - explDissFacSI
+#endif
 
 C     For nonlinear free surface and especially with r*-coordinates, the
 C     hFacs change every timestep, so we need to update them here in the
@@ -296,6 +308,14 @@ C     mixing length
          GGL90mixingLength(i,j,k) = SQRTTWO *
      &        SQRTTKE(i,j,k)/SQRT( MAX(Nsquare(i,j,k),GGL90eps) )
      &        * maskC(i,j,k,bi,bj)*maskC(i,j,k-1,bi,bj)
+
+#ifdef ALLOW_SHELFICE
+        if (k .LT. kTopC(i,j,bi,bj)) THEN
+         SQRTTKE(i,j,k) = 0.0 _d 0
+         Nsquare(i,j,k) = 0.0 _d 0
+         GGL90mixingLength(i,j,k) = 0.0 _d 0
+        endif
+#endif
         ENDDO
        ENDDO
       ENDDO
@@ -304,7 +324,16 @@ C- ensure mixing between first and second level
       IF (mxlSurfFlag) THEN
        DO j=jMin,jMax
         DO i=iMin,iMax
+#ifdef ALLOW_SHELFICE
+         ktmp = kTopC(i,j,bi,bj)
+         if (ktmp .EQ. 0) THEN
+           GGL90mixingLength(i,j,kTop)=drF(kSrf)*recip_coordFac
+         ELSE
+           GGL90mixingLength(i,j,ktmp+1)=drF(ktmp)*recip_coordFac
+         ENDIF
+#else
          GGL90mixingLength(i,j,kTop)=drF(kSrf)*recip_coordFac
+#endif
         ENDDO
        ENDDO
       ENDIF
@@ -666,6 +695,31 @@ C     from the averaged flow at grid-cell center (2 compon x 2 pos.)
         ENDDO
        ENDIF
 
+#ifdef ALLOW_SHELFICE
+        DO j=jMin,jMax
+         DO i=iMin,iMax
+           IF (k .EQ. kTopC(i,j,bi,bj)) THEN
+            IF ( debugLevel.GE.debLevE )
+     &        print '(A,3i4,3(1x,1P3E15.6))',
+     &              'GGLVS0 i j k vS ', i,j,k,
+     &                verticalShear(i,j)
+
+             verticalShear(i,j) = 0.0 _d 0
+            IF ( debugLevel.GE.debLevE )
+     &        print '(A,3i4,3(1x,1P3E15.6))',
+     &              'GGLVS1 i j k vS ', i,j,k,
+     &                verticalShear(i,j)
+           ELSEIF ((kTopC(i,j,bi,bj) .GT. 0) .AND.
+     &             (maskC(i,j,k,bi,bj) .GT. 0)) THEN
+            IF ( debugLevel.GE.debLevE )
+     &        print '(A,3i4,3(1x,1P3E15.6))',
+     &              'GGLVSS i j k vS ', i,j,k,
+     &                verticalShear(i,j)
+           ENDIF
+         ENDDO
+        ENDDO
+#endif
+
 C     compute Prandtl number (always greater than 0)
 #ifdef ALLOW_GGL90_IDEMIX
        IF ( useIDEMIX ) THEN
@@ -710,13 +764,55 @@ C     dissipation term
          TKEdissipation = explDissFac*GGL90ceps
      &        *SQRTTKE(i,j,k)*rMixingLength(i,j,k)
      &        *GGL90TKE(i,j,k,bi,bj)
+
+CIGF use explDissFacSI under shelfice
+#ifdef ALLOW_SHELFICE
+         IF (kTopC(i,j,bi,bj) .GT. 0) THEN
+          TKEdissipation = explDissFacSI*GGL90ceps
+     &        *SQRTTKE(i,j,k)*rMixingLength(i,j,k)
+     &        *GGL90TKE(i,j,k,bi,bj)
+         ENDIF
+#endif
+
 C     partial update with sum of explicit contributions
+#ifdef ALLOW_SHELFICE
+        IF ((kTopC(i,j,bi,bj) .GT. 0) .AND.
+     &      (maskC(i,j,k, bi,bj) .GT. 0)) THEN
+         IF ( debugLevel.GE.debLevE )
+     &   print  '(A,4i4,1(1x,1P3E15.6))',
+     &   'GGLT i,j,k,kTopC GGL90TKE PRE  ',i,j,k,
+     &    kTopC(i,j,bi,bj),
+     &    GGL90TKE(i,j,k,bi,bj)
+        ENDIF
+#endif
          GGL90TKE(i,j,k,bi,bj) = GGL90TKE(i,j,k,bi,bj)
      &        + deltaTloc*(
      &        + KappaM(i,j)*verticalShear(i,j)
      &        - KappaH*Nsquare(i,j,k)
      &        - TKEdissipation
      &        )
+
+#ifdef ALLOW_SHELFICE
+        IF ( debugLevel.GE.debLevE ) THEN
+         IF ((kTopC(i,j,bi,bj) .GT. 0) .AND.
+     &       (maskC(i,j,k, bi,bj) .GT. 0)) THEN
+         print  '(A,4i4,1(1x,1P3E15.6))',
+     &   'GGLT i,j,k,kTopC GGL90TKE POST ', i,j,k,
+     &    kTopC(i,j,bi,bj),
+     &    GGL90TKE(i,j,k,bi,bj)
+
+         print  '(A,4i4,3(1x,1P3E10.1))',
+     &    'GGLT i,j,k,kTopC A+B ', i,j,k, kTopC(i,j,bi,bj),
+     &     KappaM(i,j)*verticalShear(i,j),
+     &     - KappaH*Nsquare(i,j,k)
+
+         print  '(A,4i4,3(1x,1P3E10.1))',
+     &    'GGLT i,j,k,kTopC +C ', i,j,k, kTopC(i,j,bi,bj),
+     &     - TKEdissipation
+         ENDIF
+        ENDIF
+#endif
+
         ENDDO
        ENDDO
 
@@ -848,6 +944,16 @@ C--   Center diagonal
      &        + implDissFac*deltaTloc*GGL90ceps*SQRTTKE(i,j,k)
      &        * rMixingLength(i,j,k)
      &        * maskC(i,j,k,bi,bj)*maskC(i,j,km1,bi,bj)
+CIGF use implDissFacSI under shelf ice
+#ifdef ALLOW_SHELFICE
+         IF (kTopC(i,j,bi,bj) .GT. 0) THEN
+          b3d(i,j,k) = 1. _d 0 - c3d(i,j,k) - a3d(i,j,k)
+     &        + implDissFacSI*deltaTloc*GGL90ceps*SQRTTKE(i,j,k)
+     &        * rMixingLength(i,j,k)
+     &        * maskC(i,j,k,bi,bj)*maskC(i,j,km1,bi,bj)
+         ENDIF
+#endif
+
         ENDDO
        ENDDO
       ENDDO
@@ -892,6 +998,13 @@ C     estimate friction velocity uStar from surface forcing
      &   + ( .5 _d 0*( surfaceForcingV(i,  j,  bi,bj)
      &               + surfaceForcingV(i,  j+1,bi,bj) ) )**2
      &                          )*recip_coordFac
+CIGF SET KSURF TO KTOPC WHERE KTOPC IS NONZERO
+CIGF and also set uStarSquare to zero (no influence of surface forcing)
+#ifdef ALLOW_SHELFICE
+        IF (kTopC(i,j,bi,bj) .GT. 0) THEN
+          uStarSquare(i,j) = 0.0 _d 0
+        ENDIF
+#endif
         ENDDO
        ENDDO
       ENDIF
@@ -908,11 +1021,26 @@ C     Dirichlet surface boundary condition for TKE
       ELSE
        DO j=jMin,jMax
         DO i=iMin,iMax
+CIGF SET KSURF TO KTOPC WHERE KTOPC IS NONZERO
+#ifdef ALLOW_SHELFICE
+         IF (kTopC(i,j,bi,bj) .GT. 0) THEN
+          kSrftmp = kTopC(i,j,bi,bj)
+         ELSE
+          kSrftmp = 1
+         ENDIF
+         kToptmp = MIN(Nr,kSrftmp+1)
+         GGL90TKE(i,j,kSrftmp,bi,bj) = maskC(i,j,kSrftmp,bi,bj)
+     &        *MAX(GGL90TKEsurfMin,GGL90m2*uStarSquare(i,j))
+         GGL90TKE(i,j,kToptmp,bi,bj) = GGL90TKE(i,j,kToptmp,bi,bj)
+     &        - a3d(i,j,kToptmp)*GGL90TKE(i,j,kSrftmp,bi,bj)
+         a3d(i,j,kToptmp) = 0. _d 0
+#else
          GGL90TKE(i,j,kSrf,bi,bj) = maskC(i,j,kSrf,bi,bj)
      &        *MAX(GGL90TKEsurfMin,GGL90m2*uStarSquare(i,j))
          GGL90TKE(i,j,kTop,bi,bj) = GGL90TKE(i,j,kTop,bi,bj)
      &        - a3d(i,j,kTop)*GGL90TKE(i,j,kSrf,bi,bj)
          a3d(i,j,kTop) = 0. _d 0
+#endif
         ENDDO
        ENDDO
       ENDIF

--- a/pkg/gmredi/gmredi_calc_tensor.F
+++ b/pkg/gmredi/gmredi_calc_tensor.F
@@ -113,6 +113,7 @@ C     !LOCAL VARIABLES:
       _RL tmp1k(1-OLx:sNx+OLx,1-OLy:sNy+OLy)
 #endif
 #endif /* ALLOW_DIAGNOSTICS */
+
 #ifdef ALLOW_AUTODIFF_TAMC
       INTEGER act1, act2, act3, act4
       INTEGER max1, max2, max3
@@ -133,6 +134,7 @@ C---+----1----+----2----+----3----+----4----+----5----+----6----+----7-|--+----|
      &                    + act3*max1*max2
      &                    + act4*max1*max2*max3
 #endif /* ALLOW_AUTODIFF_TAMC */
+
 
 #ifdef ALLOW_DIAGNOSTICS
       doDiagRediFlx = .FALSE.
@@ -328,10 +330,10 @@ C-- 1rst loop on k : compute Tensor Coeff. at W points.
 C      Gradient of Sigma at rVel points
          dSigmaDx(i,j)=op25*( sigmaX(i+1,j,k-1)+sigmaX(i,j,k-1)
      &                       +sigmaX(i+1,j, k )+sigmaX(i,j, k )
-     &                      )*maskC(i,j,k,bi,bj)
+     &                      )*maskC(i,j,k,bi,bj)*maskC(i,j,k-1,bi,bj)
          dSigmaDy(i,j)=op25*( sigmaY(i,j+1,k-1)+sigmaY(i,j,k-1)
      &                       +sigmaY(i,j+1, k )+sigmaY(i,j, k )
-     &                      )*maskC(i,j,k,bi,bj)
+     &                      )*maskC(i,j,k,bi,bj)*maskC(i,j,k-1,bi,bj)
 c        dSigmaDr(i,j)=sigmaR(i,j,k)
         ENDDO
        ENDDO

--- a/pkg/gmredi/gmredi_xtransport.F
+++ b/pkg/gmredi/gmredi_xtransport.F
@@ -36,9 +36,6 @@ C     == GLobal variables ==
 #  include "PTRACERS_SIZE.h"
 # endif
 #endif /* ALLOW_AUTODIFF_TAMC */
-#ifdef ALLOW_SHELFICE
-# include "SHELFICE.h"
-#endif /* ALLOW_SHELFICE */
 
 C     !INPUT/OUTPUT PARAMETERS:
 C     trIdentity   :: tracer Id number
@@ -135,28 +132,19 @@ C--   Area integrated zonal flux
 C-    Vertical gradients interpolated to U points
        DO j=jMin,jMax
         DO i=iMin,iMax
-#ifdef ALLOW_SHELFICE
-           if (k-1 .ge. kTopC(i,j,bi,bj).and.
-     &         k-1 .ge. kTopC(i-1,j,bi,bj)) then
-#endif /* ALLOW_SHELFICE */
          dTdz(i,j) =  op5*(
      &    +op5*recip_drC(k)*
-     &        ( maskC(i-1,j,k,bi,bj)*
+     &        ( maskC(i-1,j,k,bi,bj)*maskC(i-1,j,km1,bi,bj)*
      &            (Tracer(i-1,j,km1)-Tracer(i-1,j,k))
-     &         +maskC( i ,j,k,bi,bj)*
+     &         +maskC( i ,j,k,bi,bj)*maskC( i ,j,km1,bi,bj)*
      &            (Tracer( i ,j,km1)-Tracer( i ,j,k))
      &        )
      &    +op5*recip_drC(kp1)*
-     &        ( maskC(i-1,j,kp1,bi,bj)*
+     &        ( maskC(i-1,j,kp1,bi,bj)*maskC(i-1,j,k,bi,bj)*
      &            (Tracer(i-1,j,k)-Tracer(i-1,j,kp1))
-     &         +maskC( i ,j,kp1,bi,bj)*
+     &         +maskC( i ,j,kp1,bi,bj)*maskC( i ,j,k,bi,bj)*
      &            (Tracer( i ,j,k)-Tracer( i ,j,kp1))
      &        )      )
-#ifdef ALLOW_SHELFICE
-           else
-       dTdz(i,j) =0.
-           endif
-#endif /* ALLOW_SHELFICE */
         ENDDO
        ENDDO
 #ifdef GM_AUTODIFF_EXCESSIVE_STORE

--- a/pkg/gmredi/gmredi_xtransport.F
+++ b/pkg/gmredi/gmredi_xtransport.F
@@ -36,6 +36,9 @@ C     == GLobal variables ==
 #  include "PTRACERS_SIZE.h"
 # endif
 #endif /* ALLOW_AUTODIFF_TAMC */
+#ifdef ALLOW_SHELFICE
+# include "SHELFICE.h"
+#endif /* ALLOW_SHELFICE */
 
 C     !INPUT/OUTPUT PARAMETERS:
 C     trIdentity   :: tracer Id number
@@ -132,6 +135,10 @@ C--   Area integrated zonal flux
 C-    Vertical gradients interpolated to U points
        DO j=jMin,jMax
         DO i=iMin,iMax
+#ifdef ALLOW_SHELFICE
+           if (k-1 .ge. kTopC(i,j,bi,bj).and.
+     &         k-1 .ge. kTopC(i-1,j,bi,bj)) then
+#endif /* ALLOW_SHELFICE */
          dTdz(i,j) =  op5*(
      &    +op5*recip_drC(k)*
      &        ( maskC(i-1,j,k,bi,bj)*
@@ -145,6 +152,11 @@ C-    Vertical gradients interpolated to U points
      &         +maskC( i ,j,kp1,bi,bj)*
      &            (Tracer( i ,j,k)-Tracer( i ,j,kp1))
      &        )      )
+#ifdef ALLOW_SHELFICE
+           else
+       dTdz(i,j) =0.
+           endif
+#endif /* ALLOW_SHELFICE */
         ENDDO
        ENDDO
 #ifdef GM_AUTODIFF_EXCESSIVE_STORE

--- a/pkg/gmredi/gmredi_ytransport.F
+++ b/pkg/gmredi/gmredi_ytransport.F
@@ -36,6 +36,9 @@ C     == GLobal variables ==
 #  include "PTRACERS_SIZE.h"
 # endif
 #endif /* ALLOW_AUTODIFF_TAMC */
+#ifdef ALLOW_SHELFICE
+# include "SHELFICE.h"
+#endif /* ALLOW_SHELFICE */
 
 C     !INPUT/OUTPUT PARAMETERS:
 C     trIdentity   :: tracer Id number
@@ -132,6 +135,10 @@ C--   Area integrated meridional flux
 C-    Vertical gradients interpolated to V points
        DO j=jMin,jMax
         DO i=iMin,iMax
+#ifdef ALLOW_SHELFICE
+           if (k-1 .ge. kTopC(i,j,bi,bj).and.
+     &         k-1 .ge. kTopC(i,j-1,bi,bj)) then
+#endif /* ALLOW_SHELFICE */
          dTdz(i,j) =  op5*(
      &    +op5*recip_drC(k)*
      &        ( maskC(i,j-1,k,bi,bj)*
@@ -145,6 +152,11 @@ C-    Vertical gradients interpolated to V points
      &         +maskC(i, j ,kp1,bi,bj)*
      &            (Tracer(i, j ,k)-Tracer(i, j ,kp1))
      &        )      )
+#ifdef ALLOW_SHELFICE
+           else
+       dTdz(i,j) =0.
+           endif
+#endif /* ALLOW_SHELFICE */
         ENDDO
        ENDDO
 #ifdef GM_AUTODIFF_EXCESSIVE_STORE

--- a/pkg/gmredi/gmredi_ytransport.F
+++ b/pkg/gmredi/gmredi_ytransport.F
@@ -36,9 +36,6 @@ C     == GLobal variables ==
 #  include "PTRACERS_SIZE.h"
 # endif
 #endif /* ALLOW_AUTODIFF_TAMC */
-#ifdef ALLOW_SHELFICE
-# include "SHELFICE.h"
-#endif /* ALLOW_SHELFICE */
 
 C     !INPUT/OUTPUT PARAMETERS:
 C     trIdentity   :: tracer Id number
@@ -135,28 +132,19 @@ C--   Area integrated meridional flux
 C-    Vertical gradients interpolated to V points
        DO j=jMin,jMax
         DO i=iMin,iMax
-#ifdef ALLOW_SHELFICE
-           if (k-1 .ge. kTopC(i,j,bi,bj).and.
-     &         k-1 .ge. kTopC(i,j-1,bi,bj)) then
-#endif /* ALLOW_SHELFICE */
          dTdz(i,j) =  op5*(
      &    +op5*recip_drC(k)*
-     &        ( maskC(i,j-1,k,bi,bj)*
+     &        ( maskC(i,j-1,k,bi,bj)*maskC(i,j-1,km1,bi,bj)*
      &            (Tracer(i,j-1,km1)-Tracer(i,j-1,k))
-     &         +maskC(i, j ,k,bi,bj)*
+     &         +maskC(i, j ,k,bi,bj)*maskC(i, j ,km1,bi,bj)*
      &            (Tracer(i, j ,km1)-Tracer(i, j ,k))
      &        )
      &    +op5*recip_drC(kp1)*
-     &        ( maskC(i,j-1,kp1,bi,bj)*
+     &        ( maskC(i,j-1,kp1,bi,bj)*maskC(i,j-1,k,bi,bj)*
      &            (Tracer(i,j-1,k)-Tracer(i,j-1,kp1))
-     &         +maskC(i, j ,kp1,bi,bj)*
+     &         +maskC(i, j ,kp1,bi,bj)*maskC(i, j ,k,bi,bj)*
      &            (Tracer(i, j ,k)-Tracer(i, j ,kp1))
      &        )      )
-#ifdef ALLOW_SHELFICE
-           else
-       dTdz(i,j) =0.
-           endif
-#endif /* ALLOW_SHELFICE */
         ENDDO
        ENDDO
 #ifdef GM_AUTODIFF_EXCESSIVE_STORE


### PR DESCRIPTION
## What changes does this PR introduce?
Bug fix

## What is the current behaviour? 
There were unrealistic strong mixing inside ice-shelf cavities that is caused by incorrect masking/vertical layer index at the ceilings inside ice cavities.

## What is the new behaviour 
The stratification inside ice cavities are restored. The fixes are mainly to use the correct vertical index and/or turn off ggl90/gmredi at the ceilings of ice cavities .


## Does this PR introduce a breaking change? 
Probably not. But results may change if pkg/shelfice is turned on.


## Other information:
@mmazloff noticed the incorrect stratification inside ice-shelf cavities. @ifenty and I implemented the fixes. However, some of the fixes still need improvement. The fixes are probably not working for p coordinates. This PR is related to issue #588.

## Suggested addition to `tag-index`
o  ggl90/ggl90_calc.F not to use values inside ice-shelf
o     gmredi/gmredi_calc_tensor.F: mask out dSigmaDx and dSigmaDy at cavity ceilings
o     gmredi/gmredi_xtransport.F and gmredi_ytransport.F: set dTdz to zero at cavity ceilings
