### PR TITLE
Open read-only files

### DIFF
--- a/model/src/ini_eos.F
+++ b/model/src/ini_eos.F
@@ -85,7 +85,11 @@ C     relative to reference atmospheric pressure of 1.atm = 101325 Pa
          IF ( tAlpha .EQ. UNSET_RL ) tAlpha = 2.  _d -4
          IF ( sBeta  .EQ. UNSET_RL ) sBeta  = 7.4 _d -4
       ELSEIF ( equationOfState .EQ. 'POLY3' ) THEN
-         OPEN(37,FILE='POLY3.COEFFS',STATUS='OLD',FORM='FORMATTED')
+         OPEN(37,FILE='POLY3.COEFFS',STATUS='OLD',
+#ifdef SPECIFY_FILE_PERMISSION
+     &        ACTION='read',
+#endif
+     &        FORM='FORMATTED')
          READ(37,*) k
          IF (k.NE.Nr) THEN
             WRITE(msgBuf,'(A)')

--- a/pkg/admtlm/admtlm_dsvd2model.F
+++ b/pkg/admtlm/admtlm_dsvd2model.F
@@ -181,6 +181,9 @@ cph     &      access  = 'sequential'   )
           open( cunit, file   = cfile,
      &         status = 'old',
      &         form   = 'unformatted',
+#ifdef SPECIFY_FILE_PERMISSION
+     &         action='read',
+#endif
      &         access  = 'sequential'   )
 
 c--       Header information.

--- a/pkg/atm2d/atm2d_init_fixed.F
+++ b/pkg/atm2d/atm2d_init_fixed.F
@@ -53,7 +53,11 @@ C     set default values for these parms in couple.nml
 
 C     Next lines done in stand-alone ML model, so don't use any
 C     MITGCM helper routines; hopefully no unit conflict...
-      OPEN(514,file='couple.nml',status='old')
+      OPEN(514,file='couple.nml',
+#ifdef SPECIFY_FILE_PERMISSION
+     &     action='read',
+#endif
+           status='old')
       READ(514,COUPLE_PARM)
       CLOSE(514)
 

--- a/pkg/atm2d/forward_step_atm2d.F
+++ b/pkg/atm2d/forward_step_atm2d.F
@@ -101,14 +101,23 @@ C    &             idyear,iyr,inyr,monid,inday,dayid
          OPEN(6007,
      &     FILE='ncep_taux_variations_'//ncep_yr//'.bin',STATUS='old',
      &     ACCESS='direct', RECL=4*sNx*sNy,
+#ifdef SPECIFY_FILE_PERMISSION
+     &     ACTION='read',
+#endif
      &     FORM='unformatted')
          OPEN(6008,
      &     FILE='ncep_tauy_variations_'//ncep_yr//'.bin',STATUS='old',
      &     ACCESS='direct', RECL=4*sNx*sNy,
+#ifdef SPECIFY_FILE_PERMISSION
+     &     ACTION='read',
+#endif
      &     FORM='unformatted')
          OPEN(6009,
      &     FILE='ncep_speed_variations_'//ncep_yr//'.bin',STATUS='old',
      &     ACCESS='direct', RECL=4*sNx*sNy,
+#ifdef SPECIFY_FILE_PERMISSION
+     &     ACTION='read',
+#endif
      &     FORM='unformatted')
          ncep_counter = 1
 #endif

--- a/pkg/atm2d/init_atm2d.F
+++ b/pkg/atm2d/init_atm2d.F
@@ -207,6 +207,9 @@ c
       IF ( atmosTauuFile .NE. ' '  ) THEN
          OPEN(dUnit, FILE=atmosTauuFile,STATUS='old',
      &        ACCESS='direct', RECL=8*jm0*nForcingPer,
+#ifdef SPECIFY_FILE_PERMISSION
+     &        ACTION='read',
+#endif
      &        FORM='unformatted')
          READ(dUnit,REC=1), atau
          CLOSE(dUnit)
@@ -215,6 +218,9 @@ c
       IF ( atmosTauvFile .NE. ' '  ) THEN
          OPEN(dUnit, FILE=atmosTauvFile, STATUS='old',
      &        ACCESS='direct', RECL=8*jm0*nForcingPer,
+#ifdef SPECIFY_FILE_PERMISSION
+     &        ACTION='read',
+#endif
      &        FORM='unformatted')
          READ(dUnit, REC=1), atav
          CLOSE(dUnit)
@@ -223,6 +229,9 @@ c
       IF ( atmosWindFile .NE. ' '  ) THEN
          OPEN(dUnit, FILE=atmosWindFile, STATUS='old',
      &        ACCESS='direct', RECL=8*jm0*nForcingPer,
+#ifdef SPECIFY_FILE_PERMISSION
+     &        ACTION='read',
+#endif
      &        FORM='unformatted')
          READ(dUnit, REC=1), awind
          CLOSE(dUnit)

--- a/pkg/atm_ocn_coupler/CPP_EEOPTIONS.h
+++ b/pkg/atm_ocn_coupler/CPP_EEOPTIONS.h
@@ -91,6 +91,10 @@ C     set size. However, on vector CRAY systems this degrades
 C     performance.
 #define REAL4_IS_SLOW
 
+C--   Explicitly specify action='read' when open read-only files. 
+C     On NASA Ames' Pleiades it improves performance.
+#undef SPECIFY_FILE_PERMISSION 
+
 C--   Control use of "double" precision constants.
 C     Use D0 where it means REAL*8 but not where it means REAL*16
 #define D0 d0

--- a/pkg/atm_ocn_coupler/cpl_read_params.F
+++ b/pkg/atm_ocn_coupler/cpl_read_params.F
@@ -54,7 +54,11 @@ C--   Read-in parameter file:
         WRITE(msgUnit,'(2A)') 'CPL_READ_PARAMS: ',
      &                        'Reading parameter file "data.cpl"'
         ioUnit = 88
-        OPEN( ioUnit, FILE='data.cpl',STATUS='old')
+        OPEN( ioUnit, FILE='data.cpl',
+#ifdef SPECIFY_FILE_PERMISSION
+     &        ACTION='read',
+#endif
+     &        STATUS='old')
         READ( ioUnit, COUPLER_PARAMS )
         CLOSE(ioUnit )
       ELSE

--- a/pkg/atm_ocn_coupler/set_runoffmap.F
+++ b/pkg/atm_ocn_coupler/set_runoffmap.F
@@ -70,6 +70,9 @@ c    &       ACCESS='direct', RECL=lengthRec )
 c       READ(88,rec=1) tmpfld
         lengthRec=3*WORDLENGTH*2
         OPEN(88, FILE=runOffMapFile(1:lengthName), STATUS='OLD',
+#ifdef SPECIFY_FILE_PERMISSION
+     &       ACTION='read',
+#endif
      &       ACCESS='direct', RECL=lengthRec )
         DO n=1,nROmap
          iRec = n
@@ -90,6 +93,9 @@ C-    Read (ocean) grid cell area from file ;
       WRITE(msgUnit,'(2A)') 'SET_RUNOFFMAP: ','reading OCN grid area'
         lengthRec=Nx_ocn*Ny_ocn*WORDLENGTH*2
         OPEN(88, FILE='RA.bin', STATUS='OLD',
+#ifdef SPECIFY_FILE_PERMISSION
+     &       ACTION='read',
+#endif
      &       ACCESS='direct', RECL=lengthRec )
         iRec = 1
         READ(88,rec=iRec) rAc

--- a/pkg/cfc/cfc_atmos.F
+++ b/pkg/cfc/cfc_atmos.F
@@ -64,7 +64,11 @@ C read in CFC atmospheric timeseries data
 
 C assign a free unit number as the I/O channel for this subroutine
       CALL MDSFINDUNIT( iUnit, myThid )
-      OPEN(iUnit,FILE=atmCFC_inpFile(1:iL),STATUS='old')
+      OPEN(iUnit,FILE=atmCFC_inpFile(1:iL),
+#ifdef SPECIFY_FILE_PERMISSION
+     &     ACTION='read',
+#endif
+     &     STATUS='old')
 C skip 6 descriptor lines
       DO i =1,6
         READ(iUnit,*)

--- a/pkg/cost/cost_final_restore.F
+++ b/pkg/cost/cost_final_restore.F
@@ -45,7 +45,11 @@ cph      IF (myProcId .eq. 0) THEN
 c
            inquire(file='divided.ctrl',exist=exst)
            if (exst) then
-              open(unit=76,file='divided.ctrl',form='formatted')
+              open(unit=76,file='divided.ctrl',
+#ifdef SPECIFY_FILE_PERMISSION
+     &             action='read',
+#endif
+     &             form='formatted')
               read(unit=76,fmt=*) idivbeg,idivend
               close(unit=76)
            else
@@ -54,7 +58,11 @@ c
 c
            if ( idivbeg .EQ. 0 ) then
               lastdiva = .TRUE.
+#ifndef SPECIFY_FILE_PERMISSION
               open(unit=76,file='costfinal')
+#else 
+              open(unit=76,file='costfinal',action='read')
+#endif
               read(76,*) fc
               close(76)
            else

--- a/pkg/ctrl/ctrl_init.F
+++ b/pkg/ctrl/ctrl_init.F
@@ -396,6 +396,9 @@ c     run-time option and also define filename=baro_invmodes.bin
         CALL MDSFINDUNIT( dUnit, myThid )
         length_of_rec = MDS_RECLEN( 64, NR*NR, myThid )
         open(dUnit, file='baro_invmodes.bin', status='old',
+#ifdef SPECIFY_FILE_PERMISSION
+     &         action='read',
+#endif
      &         access='direct', recl=length_of_rec )
         do j = 1,Nr
            read(dUnit,rec=j) ((modesv(k,i,j), k=1,Nr), i=1,Nr)

--- a/pkg/ctrl/ctrl_unpack.F
+++ b/pkg/ctrl/ctrl_unpack.F
@@ -261,6 +261,9 @@ c--   Only Proc 0 will do I/O.
 
           open( cunit, file   = cfile,
      &         status = 'old',
+#ifdef SPECIFY_FILE_PERMISSION
+     &         action='read',
+#endif
      &         form   = 'unformatted',
      &         access  = 'sequential'   )
 

--- a/pkg/diagnostics/diagnostics_read_pickup.F
+++ b/pkg/diagnostics/diagnostics_read_pickup.F
@@ -144,7 +144,11 @@ C         Read ndiag()
 C--    jmc: should really write 1 file per tile
           WRITE(fn,'(A,I10.10)') 'pickup_ndiag.', nIter0
           CALL MDSFINDUNIT( dUnit, myThid )
+#ifndef SPECIFY_FILE_PERMISSION
           OPEN( dUnit, file=fn )
+#else
+          OPEN( dUnit, file=fn, action='read')
+#endif
           DO n = 1,nlists
             DO m = 1,nfields(n)
               ndId = ABS(jdiag(m,n))

--- a/pkg/dic/dic_init_fixed.F
+++ b/pkg/dic/dic_init_fixed.F
@@ -63,7 +63,11 @@ C     Set other constant/flag
 
       IF ( dic_int1.EQ.2 ) THEN
         CALL MDSFINDUNIT( iUnit, mythid )
-        OPEN(UNIT=iUnit,FILE='co2atmos.dat',STATUS='old')
+        OPEN(UNIT=iUnit,FILE='co2atmos.dat',
+#ifdef SPECIFY_FILE_PERMISSION
+     &       ACTION='read',
+#endif
+     &       STATUS='old')
         DO k=1,dic_int2
           READ(iUnit,*) co2atmos(k)
           WRITE(standardMessageUnit,*) 'co2atmos',co2atmos(k)

--- a/pkg/dic/dic_read_co2_pickup.F
+++ b/pkg/dic/dic_read_co2_pickup.F
@@ -67,6 +67,9 @@ C--   First check if pickup file exist
         CALL MDSFINDUNIT( ioUnit, myThid )
         length_of_rec = MDS_RECLEN( fp, 2, myThid )
         OPEN( ioUnit, file=filNam, status='old',
+#ifdef SPECIFY_FILE_PERMISSION
+     &        action='read',
+#endif
      &        access='direct', recl=length_of_rec )
         READ(ioUnit,rec=1) tmpFld
 #ifdef _BYTESWAPIO

--- a/pkg/exf/exf_interp_read.F
+++ b/pkg/exf/exf_interp_read.F
@@ -131,6 +131,9 @@ C--   master thread of process 0, only, opens a global file
         CALL MDSFINDUNIT( ioUnit, myThid )
         length_of_rec=MDS_RECLEN( filePrec, nx_in*ny_in, myThid )
         OPEN( ioUnit, file=infile, status='old', access='direct',
+#ifdef SPECIFY_FILE_PERMISSION
+     &       action='read',
+#endif
      &       recl=length_of_rec )
         IF ( filePrec .EQ. 32 ) THEN
 #ifdef EXF_INTERP_USE_DYNALLOC

--- a/pkg/fizhi/fizhi_init_vegsurftiles.F
+++ b/pkg/fizhi/fizhi_init_vegsurftiles.F
@@ -67,7 +67,11 @@ C     !LOCAL VARIABLES:
 C Only do I/O if I am the master thread
       _BEGIN_MASTER( myThid )
 
-      open(iUnit,file=fn,status='old',access='direct',recl=recl)
+      open(iUnit,file=fn,status='old',
+#ifdef SPECIFY_FILE_PERMISSION
+     &     action='read',
+#endif
+           access='direct',recl=recl)
       read(iunit,rec=1) globalarr
       close( iunit )
       _END_MASTER( myThid )

--- a/pkg/fizhi/fizhi_readwrite_vegtiles.F
+++ b/pkg/fizhi/fizhi_readwrite_vegtiles.F
@@ -377,6 +377,9 @@ C       fizhi_land_coms.h
      &              fn(1:ilst),'.',iG,'.',jG,'.data'
        print *,' Opening ',dataFName
        open( iUnit, file=dataFName, status='old',
+#ifdef SPECIFY_FILE_PERMISSION
+     &       action='read',
+#endif
      &       access='direct', recl=length_of_rec )
 
        irec = 0

--- a/pkg/fizhi/update_ocean_exports.F
+++ b/pkg/fizhi/update_ocean_exports.F
@@ -231,6 +231,9 @@ C---------- Read in Header file ----------------------------------
 
        close(iunit)
        open (iunit,file=sicedata,form='unformatted',access='direct',
+#ifdef SPECIFY_FILE_PERMISSION
+     .                                         action='read',
+#endif
      .                                         recl=xsize*ysize*4)
        nrec = 1
        call bcheader (iunit, ndmax, nrec,
@@ -491,6 +494,9 @@ C---------- Read in Header file ----------------------------------
 
        close(iunit)
        open (iunit,file=sstdata,form='unformatted',access='direct',
+#ifdef SPECIFY_FILE_PERMISSION
+     .                                        action='read',
+#endif
      .                                        recl=xsize*ysize*4)
        nrec = 1
        call bcheader (iunit, ndmax, nrec,

--- a/pkg/mdsio/mdsio_facef_read.F
+++ b/pkg/mdsio/mdsio_facef_read.F
@@ -76,6 +76,9 @@ C     Figure out offset of tile within face
       CALL MDSFINDUNIT( dUnit, myThid )
       length_of_rec = MDS_RECLEN( fPrec, (dNx+1), myThid )
       OPEN( dUnit, file=fName(1:iLen), status='old',
+#ifdef SPECIFY_FILE_PERMISSION
+     &             action='read',
+#endif
      &             access='direct', recl=length_of_rec )
       j = 0
       jBase=(irec-1)*(dNy+1)
@@ -114,6 +117,9 @@ C     Figure out offset of tile within face
       CALL MDSFINDUNIT( dUnit, myThid )
       length_of_rec = MDS_RECLEN( fPrec, (sNx+1)*(sNy+1), myThid )
       OPEN( dUnit, file=fName(1:iLen), status='old',
+#ifdef SPECIFY_FILE_PERMISSION
+     &             action='read',
+#endif
      &             access='direct', recl=length_of_rec )
       IF ( fPrec.EQ.precFloat32 ) THEN
         READ(dUnit, rec=irec) ioBuf4

--- a/pkg/mdsio/mdsio_read_field.F
+++ b/pkg/mdsio/mdsio_read_field.F
@@ -268,6 +268,9 @@ C Otherwise stop program.
          IF ( globalFile) THEN
           length_of_rec = MDS_RECLEN( filePrec, xSize*ySize, myThid )
           OPEN( dUnit, file=dataFName, status='old',
+#ifdef SPECIFY_FILE_PERMISSION
+     &         action='read',
+#endif
      &         access='direct', recl=length_of_rec )
          ELSE
           WRITE(msgBuf,'(2A)')
@@ -380,6 +383,9 @@ C If we are reading from a global file then we open it here
         IF (globalFile) THEN
          length_of_rec = MDS_RECLEN( filePrec, sNx, myThid )
          OPEN( dUnit, file=dataFName, status='old',
+#ifdef SPECIFY_FILE_PERMISSION
+     &        action='read',
+#endif
      &        access='direct', recl=length_of_rec )
          fileIsOpen=.TRUE.
         ENDIF
@@ -463,6 +469,9 @@ C (This is a place-holder for the active/passive mechanism
             ENDIF
             length_of_rec = MDS_RECLEN( filePrec, sNx*sNy*nNz, myThid )
             OPEN( dUnit, file=dataFName, status='old',
+#ifdef SPECIFY_FILE_PERMISSION
+     &            action='read',
+#endif
      &            access='direct', recl=length_of_rec )
             fileIsOpen=.TRUE.
            ELSE

--- a/pkg/mdsio/mdsio_read_meta.F
+++ b/pkg/mdsio/mdsio_read_meta.F
@@ -191,6 +191,9 @@ C-    Assign a free unit number as the I/O channel for this subroutine
 
 C-    Open meta-file
         OPEN( mUnit, FILE=mFileName, STATUS='old',
+#ifdef SPECIFY_FILE_PERMISSION
+     &        ACTION='read',
+#endif
      &        FORM='formatted', IOSTAT=errIO )
 c       write(0,*) 'errIO=',errIO
         IF ( errIO .NE. 0 ) THEN

--- a/pkg/mdsio/mdsio_read_section.F
+++ b/pkg/mdsio/mdsio_read_section.F
@@ -154,6 +154,9 @@ C If we are reading from a global file then we open it here
       IF (globalFile) THEN
        length_of_rec = MDS_RECLEN( filePrec, sNx, myThid )
        OPEN( dUnit, file=dataFName, status='old',
+#ifdef SPECIFY_FILE_PERMISSION
+     &       action='read',
+#endif
      &       access='direct', recl=length_of_rec )
        fileIsOpen=.TRUE.
       ENDIF
@@ -179,6 +182,9 @@ C (This is a place-holder for the active/passive mechanism
           ENDIF
           length_of_rec = MDS_RECLEN( filePrec, sNx, myThid )
           OPEN( dUnit, file=dataFName, status='old',
+#ifdef SPECIFY_FILE_PERMISSION
+     &          action='read',
+#endif
      &          access='direct', recl=length_of_rec )
           fileIsOpen=.TRUE.
          ELSE
@@ -432,6 +438,9 @@ C If we are reading from a global file then we open it here
       IF (globalFile) THEN
        length_of_rec = MDS_RECLEN( filePrec, sNy, myThid )
        OPEN( dUnit, file=dataFName, status='old',
+#ifdef SPECIFY_FILE_PERMISSION
+     &       action='read',
+#endif
      &       access='direct', recl=length_of_rec )
        fileIsOpen=.TRUE.
       ENDIF
@@ -457,6 +466,9 @@ C (This is a place-holder for the active/passive mechanism
           ENDIF
           length_of_rec = MDS_RECLEN( filePrec, sNy, myThid )
           OPEN( dUnit, file=dataFName, status='old',
+#ifdef SPECIFY_FILE_PERMISSION
+     &          action='read',
+#endif
      &          access='direct', recl=length_of_rec )
           fileIsOpen=.TRUE.
          ELSE

--- a/pkg/mdsio/mdsio_read_tape.F
+++ b/pkg/mdsio/mdsio_read_tape.F
@@ -129,6 +129,9 @@ C-    If global file is visible to process 0, then open it here.
           ENDIF
           length_of_rec = MDS_RECLEN( filePrec, vec_size, myThid )
           OPEN( dUnit, file=dataFName, status='old',
+#ifdef SPECIFY_FILE_PERMISSION
+     &          action='read',
+#endif
      &          access='direct', recl=length_of_rec )
          ELSE
 C     Otherwise stop program.
@@ -194,6 +197,9 @@ C-    Check first for global file with with MDS name (ie. fName.data)
 C-    And open it here
           length_of_rec = MDS_RECLEN( filePrec, nSize, myThid )
           OPEN( dUnit, file=dataFName, status='old',
+#ifdef SPECIFY_FILE_PERMISSION
+     &          action='read',
+#endif
      &          access='direct', recl=length_of_rec )
           fileIsOpen=.TRUE.
         ENDIF
@@ -214,6 +220,9 @@ C-    If we are reading from a tiled MDS file then we open each one here
           ENDIF
           length_of_rec = MDS_RECLEN( filePrec, nSize, myThid )
           OPEN( dUnit, file=dataFName, status='old',
+#ifdef SPECIFY_FILE_PERMISSION
+     &          action='read',
+#endif
      &          access='direct', recl=length_of_rec )
           fileIsOpen=.TRUE.
          ELSE

--- a/pkg/mdsio/mdsio_read_whalos.F
+++ b/pkg/mdsio/mdsio_read_whalos.F
@@ -124,6 +124,9 @@ C get the unit and open file
       IF (fid.EQ.0) THEN
         CALL MDSFINDUNIT( dUnit, myThid )
         OPEN( dUnit, file=pfName, status='old',
+#ifdef SPECIFY_FILE_PERMISSION
+     &         action='read',
+#endif
      &         access='direct', recl=length_of_rec )
       ELSE
         dUnit=fid

--- a/pkg/mdsio/mdsio_readvec_loc.F
+++ b/pkg/mdsio/mdsio_readvec_loc.F
@@ -177,6 +177,9 @@ C--   Open the file:
           ENDIF
           length_of_rec = MDS_RECLEN( filePrec, nSize, myThid )
           OPEN( dUnit, file=dataFname, status=_OLD_STATUS,
+#ifdef SPECIFY_FILE_PERMISSION
+     &          action='read',
+#endif
      &          access='direct', recl=length_of_rec )
           fileIsOpen=.TRUE.
         ELSE

--- a/pkg/regrid/regrid_init_varia.F
+++ b/pkg/regrid/regrid_init_varia.F
@@ -139,7 +139,11 @@ C         locate the points that belong to this tile
               STOP ' stopped in REGRID_INIT_VARIA()'
             ENDIF
 
-            open(unit=iUnit, file=fname, status='old', iostat=errIO)
+            open(unit=iUnit, file=fname, status='old', 
+#ifdef SPECIFY_FILE_PERMISSION
+     &           action='read',
+#endif
+     &           iostat=errIO)
 
             IF (errIO .LT. 0) THEN
               WRITE(msgBuf,'(A)')  'S/R REGRID_INIT_VARIA()'


### PR DESCRIPTION
## What changes does this PR introduce?
(Bug fix, feature, docs update, ...)
New feature


## What is the current behaviour? 
(You can also link to an open issue here)
Some open statements do not specify action='read' for read-only files.

## What is the new behaviour 
(if this is a feature change)?
Add a CPP option to allow explicitly specifying action='read' when opening read-only files. On NASA Ames' Pleiades, specifying action='read' significantly improves code performance. See #535

## Does this PR introduce a breaking change? 
(What changes might users need to make in their application due to this PR?)
No

## Other information:


## Suggested addition to `tag-index`
(To avoid unnecessary merge conflicts, please don't update `tag-index`. One of the admins will do that when merging your pull request.)
A CPP option (SPECIFY_FILE_PERMISSION) is added in CPP_EEOPTIONS.h. When defined, open statements specify action='read' for read-only files. The default is undefined. As a result, pkg/mdsio, pkg/exf, a few other packages, model/src/ini_eos.F were changed. 