### PR TITLE
Update counting of TAF RECOMPUTATION WARNING

### DIFF
--- a/verification/testreport
+++ b/verification/testreport
@@ -590,7 +590,7 @@ makemodel()
     if test $KIND = 2 -a -f taf_ad.log ; then
 	head -1 taf_ad.log >> $CDIR"/summary.txt"
 	nerr=`grep -c 'TAF *.* ERROR ' taf_ad.log`
-	nwar=`grep -c 'TAF RECOMPUTATION *.* WARNING ' taf_ad.log`
+	nwar=`grep -c '^TAF\> *.* RECOMPUTATION *.* WARNING ' taf_ad.log`
 	if test -f taf_output ; then
 	    n2er=`grep -c 'TAF *.* ERROR ' taf_output`
 	    n3er=`grep -c '\*ERROR\* ' taf_output`


### PR DESCRIPTION
With new version (5.5.1) of TAF, reports of recomputation warnings changed
a little bit (dropping one additional "TAF" before RECOMPUTATION).
With this minor update, testreport catches the same number of warnings with
both new and previous version of TAF.

## What changes does this PR introduce?
see above

## Does this PR introduce a breaking change? 
no

## Other information:

## Suggested addition to `tag-index`
nothing to add there (minor update)