### PR TITLE
GMRedi read k3d diffusivity

### DIFF
--- a/model/src/ini_mixing.F
+++ b/model/src/ini_mixing.F
@@ -1,11 +1,4 @@
-#include "PACKAGES_CONFIG.h"
 #include "CPP_OPTIONS.h"
-#ifdef ALLOW_CTRL
-# include "CTRL_OPTIONS.h"
-#endif
-#ifdef ALLOW_GMREDI
-# include "GMREDI_OPTIONS.h"
-#endif
 
 CBOP
 C     !ROUTINE: INI_MIXING
@@ -26,49 +19,35 @@ C     === Global variables ===
 #include "PARAMS.h"
 #include "GRID.h"
 #include "DYNVARS.h"
-#ifdef ALLOW_CTRL
-# include "CTRL_FIELDS.h"
-# ifdef ALLOW_GMREDI
-#  include "GMREDI.h"
-# endif
-#endif
 
 C     !INPUT/OUTPUT PARAMETERS:
-C     == Routine arguments ==
 C     myThid ::  Number of this instance
       INTEGER myThid
 
 C     !LOCAL VARIABLES:
-C     == Local variables ==
 C     bi,bj  :: tile indices
 C     i,j,k  :: Loop counters
       INTEGER bi, bj
       INTEGER i, j, k
 CEOP
 
+#ifdef ALLOW_3D_DIFFKR
        DO bj = myByLo(myThid), myByHi(myThid)
         DO bi = myBxLo(myThid), myBxHi(myThid)
          DO k=1,Nr
           DO j = 1-OLy, sNy+OLy
            DO i = 1-OLx, sNx+OLx
-#ifdef ALLOW_3D_DIFFKR
             diffKr(i,j,k,bi,bj) = diffKrNrS(k)
-#endif
-#if (defined (ALLOW_CTRL) && defined (ALLOW_GMREDI))
-# ifdef ALLOW_KAPGM_CONTROL
-            kapGM(i,j,k,bi,bj) = GM_background_K*
-     &        GM_bolFac2d(i,j,bi,bj)*GM_bolFac1d(k)
-# endif
-# ifdef ALLOW_KAPREDI_CONTROL
-            kapRedi(i,j,k,bi,bj) = GM_isopycK*
-     &        GM_isoFac2d(i,j,bi,bj)*GM_isoFac1d(k)
-# endif
-#endif /* ALLOW_CTRL & ALLOW_GMREDI */
            ENDDO
           ENDDO
          ENDDO
         ENDDO
        ENDDO
+       IF ( diffKrFile .NE. ' ' ) THEN
+         CALL READ_FLD_XYZ_RL( diffKrFile, ' ', diffKr, 0, myThid )
+         _EXCH_XYZ_RL( diffKr, myThid )
+       ENDIF
+#endif /* ALLOW_3D_DIFFKR */
 
 #ifdef ALLOW_BL79_LAT_VARY
        DO bj = myByLo(myThid), myByHi(myThid)
@@ -85,31 +64,5 @@ CEOP
        ENDDO
 #endif
 
-#ifdef ALLOW_3D_DIFFKR
-       IF ( diffKrFile .NE. ' ' ) THEN
-         CALL READ_FLD_XYZ_RL(diffKrFile,' ',diffKr,0,myThid)
-         _EXCH_XYZ_RL( diffKr, myThid )
-       ENDIF
-#endif /* ALLOW_3D_DIFFKR */
-#ifdef ALLOW_CTRL
-#ifdef ALLOW_KAPGM_CONTROL
-#ifdef ALLOW_KAPGM_3DFILE
-       IF ( useGMRedi.and.GM_background_K3dFile .NE. ' ' ) THEN
-          CALL READ_FLD_XYZ_RL(GM_background_K3dFile,' ',kapGM,0,myThid)
-       ENDIF
-#endif
-       _EXCH_XYZ_RL( kapGM, myThid )
-       CALL WRITE_FLD_XYZ_RL( 'KapGM', ' ', kapGM, 0, myThid )
-#endif
-#ifdef ALLOW_KAPREDI_CONTROL
-#ifdef ALLOW_KAPREDI_3DFILE
-       IF ( useGMRedi.and.GM_isopycK3dFile .NE. ' ' ) THEN
-          CALL READ_FLD_XYZ_RL(GM_isopycK3dFile,' ',kapRedi,0,myThid)
-       ENDIF
-#endif
-       _EXCH_XYZ_RL( kapRedi, myThid )
-       CALL WRITE_FLD_XYZ_RL( 'KapRedi', ' ', kapRedi, 0, myThid )
-#endif
-#endif /* ALLOW_CTRL */
       RETURN
       END

--- a/model/src/packages_init_variables.F
+++ b/model/src/packages_init_variables.F
@@ -221,12 +221,16 @@ C--   Initialize KPP vertical mixing scheme.
 
 #ifdef ALLOW_GMREDI
 C--   Initialize GM/Redi parameterization
-      IF (useGMRedi) THEN
+# ifndef ALLOW_AUTODIFF
+      IF ( useGMRedi ) THEN
+# endif
 # ifdef ALLOW_DEBUG
         IF (debugMode) CALL DEBUG_CALL('GMREDI_INIT_VARIA',myThid)
 # endif
         CALL GMREDI_INIT_VARIA( myThid )
+# ifndef ALLOW_AUTODIFF
       ENDIF
+# endif
 #endif /* ALLOW_GMREDI */
 
 #ifdef ALLOW_BBL

--- a/pkg/autodiff/adcommon.h
+++ b/pkg/autodiff/adcommon.h
@@ -103,12 +103,12 @@ C Special Care: more forward vars in FWD common block ; check TAF AD-code !
 #endif
 
 #ifdef ALLOW_KAPGM_CONTROL
-      COMMON /adCTRL_FIELDS_KAPGM/
+      COMMON /adGM_INP_K3D_GM/
      &                       adKapGM
       _RL  adKapGM (1-OLx:sNx+OLx,1-OLy:sNy+OLy,Nr,nSx,nSy)
 #endif
 #ifdef ALLOW_KAPREDI_CONTROL
-      COMMON /adCTRL_FIELDS_KAPREDI/
+      COMMON /adGM_INP_K3D_REDI/
      &                       adKapRedi
       _RL  adKapRedi (1-OLx:sNx+OLx,1-OLy:sNy+OLy,Nr,nSx,nSy)
 #endif

--- a/pkg/autodiff/addummy_in_stepping.F
+++ b/pkg/autodiff/addummy_in_stepping.F
@@ -8,6 +8,9 @@
 #ifdef ALLOW_DIAGNOSTICS
 # include "DIAG_OPTIONS.h"
 #endif
+#ifdef ALLOW_GMREDI
+# include "GMREDI_OPTIONS.h"
+#endif
 #ifdef ALLOW_GGL90
 # include "GGL90_OPTIONS.h"
 #endif
@@ -53,6 +56,9 @@ C     == Global variables ===
 C- Note: Since OpenAD uses modules, the ordering of included headers matters
 #  include "DYNVARS.h"
 #  include "FFIELDS.h"
+#  ifdef ALLOW_GMREDI
+#   include "GMREDI.h"
+#  endif
 #  ifdef ALLOW_GGL90
 #   include "GGL90.h"
 #  endif
@@ -137,10 +143,10 @@ C--   need to all the correct OpenAD EXCH S/R ; left empty for now
         call adexch_xyz_rl( myThid,addiffkr )
 # endif
 # ifdef ALLOW_KAPGM_CONTROL
-        call adexch_xyz_rl( myThid,adkapgm )
+        call adexch_xyz_rl( myThid, adKapGM )
 # endif
 # ifdef ALLOW_KAPREDI_CONTROL
-        call adexch_xyz_rl( myThid,adkapredi )
+        call adexch_xyz_rl( myThid, adKapRedi )
 # endif
 # ifdef ALLOW_SST0_CONTROL
         call adexch_xy_rl( myThid,adsst )
@@ -390,12 +396,13 @@ C-----------------------------------------------------------------------
       CALL DUMP_ADJ_XYZ(dumRS, DiffKr%d, 'ADJdifkr', 'ADJdiffkr.',
      &                  12, doDump, dumpAdRecMn, myTime, myIter,myThid)
 # endif
-# ifdef ALLOW_KAPGM_CONTROL
-      CALL DUMP_ADJ_XYZ(dumRS, KapGM%d, 'ADJkapgm', 'ADJkapgm.',
+# if ( defined ALLOW_KAPGM_CONTROL && defined GM_READ_K3D_GM )
+      CALL DUMP_ADJ_XYZ(dumRS, GM_inpK3dGM%d, 'ADJkapgm', 'ADJkapgm.',
      &                  12, doDump, dumpAdRecMn, myTime, myIter,myThid)
 # endif
-# ifdef ALLOW_KAPREDI_CONTROL
-      CALL DUMP_ADJ_XYZ(dumRS, KapRedi%d, 'ADJkapre', 'ADJkapredi.',
+# if ( defined ALLOW_KAPREDI_CONTROL && defined GM_READ_K3D_REDI )
+      CALL DUMP_ADJ_XYZ(dumRS, GM_inpK3dRedi%d, 'ADJkapre',
+     &                  'ADJkapredi.',
      &                  12, doDump, dumpAdRecMn, myTime, myIter,myThid)
 # endif
 
@@ -532,11 +539,11 @@ C     dumpAdVarExch.NE.2
 #endif
 #ifdef ALLOW_KAPGM_CONTROL
           CALL MNC_CW_RL_W('D','adstate',0,0,
-     &                     'adkapgm', adkapgm, myThid)
+     &                     'adkapgm', adKapGM, myThid)
 #endif
 #ifdef ALLOW_KAPREDI_CONTROL
           CALL MNC_CW_RL_W('D','adstate',0,0,
-     &                     'adkapredi', adkapredi, myThid)
+     &                     'adkapredi', adKapRedi, myThid)
 #endif
 #ifdef ALLOW_SHELFICE
 # ifndef SHI_ALLOW_GAMMAFRICT

--- a/pkg/autodiff/common.flow
+++ b/pkg/autodiff/common.flow
@@ -96,11 +96,11 @@ c$taf COMMON shelfice_fields_rl FTLNAME = g_shelfice_fields_rl
 c$taf COMMON ggl90_fields  ADNAME = adggl90_fields
 c$taf COMMON ggl90_fields FTLNAME = g_ggl90_fields
 
-c$taf COMMON ctrl_fields_kapgm  ADNAME = adctrl_fields_kapgm
-c$taf COMMON ctrl_fields_kapgm FTLNAME = g_ctrl_fields_kapgm
+c$taf COMMON GM_INP_K3D_GM  ADNAME = adGM_INP_K3D_GM
+c$taf COMMON GM_INP_K3D_GM FTLNAME = g_GM_INP_K3D_GM
 
-c$taf COMMON ctrl_fields_kapredi  ADNAME = adctrl_fields_kapredi
-c$taf COMMON ctrl_fields_kapredi FTLNAME = g_ctrl_fields_kapredi
+c$taf COMMON GM_INP_K3D_REDI  ADNAME = adGM_INP_K3D_REDI
+c$taf COMMON GM_INP_K3D_REDI FTLNAME = g_GM_INP_K3D_REDI
 
 c$taf COMMON ctrl_fields_bottomdrag  ADNAME = adctrl_fields_bottomdrag
 c$taf COMMON ctrl_fields_bottomdrag FTLNAME = g_ctrl_fields_bottomdrag

--- a/pkg/autodiff/g_common.h
+++ b/pkg/autodiff/g_common.h
@@ -101,12 +101,12 @@ C Special Care: more forward vars in FWD common block ; check TAF TL-code !
 #endif
 
 #ifdef ALLOW_KAPGM_CONTROL
-      COMMON /g_CTRL_FIELDS_KAPGM/
+      COMMON /g_GM_INP_K3D_GM/
      &                       g_kapgm
       _RL  g_kapgm (1-OLx:sNx+OLx,1-OLy:sNy+OLy,Nr,nSx,nSy)
 #endif
 #ifdef ALLOW_KAPREDI_CONTROL
-      COMMON /g_CTRL_FIELDS_KAPREDI/
+      COMMON /g_GM_INP_K3D_REDI/
      &                       g_kapredi
       _RL  g_kapredi (1-OLx:sNx+OLx,1-OLy:sNy+OLy,Nr,nSx,nSy)
 #endif

--- a/pkg/ctrl/CTRL_FIELDS.h
+++ b/pkg/ctrl/CTRL_FIELDS.h
@@ -16,16 +16,6 @@ C     *==============================================================*
 C     \ev
 CEOP
 
-#ifdef ALLOW_KAPGM_CONTROL
-      COMMON /CTRL_FIELDS_KAPGM/
-     &                       kapGM
-      _RL  kapGM  (1-OLx:sNx+OLx,1-OLy:sNy+OLy,Nr,nSx,nSy)
-#endif
-#ifdef ALLOW_KAPREDI_CONTROL
-      COMMON /CTRL_FIELDS_KAPREDI/
-     &                       kapRedi
-      _RL  kapRedi  (1-OLx:sNx+OLx,1-OLy:sNy+OLy,Nr,nSx,nSy)
-#endif
 #ifdef ALLOW_BOTTOMDRAG_CONTROL
       COMMON /CTRL_FIELDS_BOTTOMDRAG/
      &                       bottomDragFld

--- a/pkg/ctrl/ctrl_check.F
+++ b/pkg/ctrl/ctrl_check.F
@@ -1,4 +1,7 @@
 #include "CTRL_OPTIONS.h"
+#ifdef ALLOW_GMREDI
+# include "GMREDI_OPTIONS.h"
+#endif
 #ifdef ALLOW_EXF
 # include "EXF_OPTIONS.h"
 #endif
@@ -194,6 +197,26 @@ C-    to use DIFFKR_CONTROL, needs to define ALLOW_3D_DIFFKR in CPP_OPTIONS.h
       errCount = errCount + 1
 # endif
 #endif /* ALLOW_DIFFKR_CONTROL */
+
+#ifdef ALLOW_KAPGM_CONTROL
+C-    to use KAPGM_CONTROL, needs to define GM_READ_K3D_GM in GMREDI_OPTIONS.h
+# ifndef GM_READ_K3D_GM
+      WRITE(msgBuf,'(A)')
+     &        'Needs to define GM_READ_K3D_GM to use KAPGM_CONTROL'
+      CALL PRINT_ERROR( msgBuf, myThid )
+      errCount = errCount + 1
+# endif
+#endif /* ALLOW_KAPGM_CONTROL */
+
+#ifdef ALLOW_KAPREDI_CONTROL
+C-    to use KAPREDI_CONTROL, needs to define GM_READ_K3D_REDI in GMREDI_OPTIONS.h
+# ifndef GM_READ_K3D_REDI
+      WRITE(msgBuf,'(A)')
+     &        'Needs to define GM_READ_K3D_REDI to use KAPREDI_CONTROL'
+      CALL PRINT_ERROR( msgBuf, myThid )
+      errCount = errCount + 1
+# endif
+#endif /* ALLOW_KAPREDI_CONTROL */
 
 #if (defined (ALLOW_HFLUX_CONTROL) && defined (ALLOW_ATEMP_CONTROL))
       WRITE(msgBuf,'(A)')

--- a/pkg/ctrl/ctrl_map_ini.F
+++ b/pkg/ctrl/ctrl_map_ini.F
@@ -5,6 +5,9 @@
 #ifdef ALLOW_ECCO
 # include "ECCO_OPTIONS.h"
 #endif
+#ifdef ALLOW_GMREDI
+# include "GMREDI_OPTIONS.h"
+#endif
 
 CBOP
 C     !ROUTINE: ctrl_map_ini
@@ -43,6 +46,9 @@ c     == global variables ==
 # else
 #  include "ctrl_weights.h"
 # endif
+#endif
+#ifdef ALLOW_GMREDI
+# include "GMREDI.h"
 #endif
 #ifdef ALLOW_PTRACERS
 # include "PTRACERS_SIZE.h"
@@ -305,6 +311,7 @@ c--   diffkr.
 
 #ifdef ALLOW_AUTODIFF
 #ifdef ALLOW_KAPGM_CONTROL
+#ifdef GM_READ_K3D_GM
 c--   kapgm.
       il=ilnblnk( xx_kapgm_file )
       write(fnamegeneric(1:80),'(2a,i10.10)')
@@ -318,12 +325,12 @@ c--   kapgm.
             do j = jmin,jmax
               do i = imin,imax
 #ifdef ALLOW_OPENAD
-                kapGM(i,j,k,bi,bj) = kapGM(i,j,k,bi,bj) +
-     &                               xx_kapgm(i,j,k,bi,bj) +
-     &                               tmpfld3d(i,j,k,bi,bj)
+                GM_inpK3dGM(i,j,k,bi,bj) = GM_inpK3dGM(i,j,k,bi,bj)
+     &                               + xx_kapgm(i,j,k,bi,bj)
+     &                               + tmpfld3d(i,j,k,bi,bj)
 #else
-                kapGM(i,j,k,bi,bj) = kapGM(i,j,k,bi,bj) +
-     &                               tmpfld3d(i,j,k,bi,bj)
+                GM_inpK3dGM(i,j,k,bi,bj) = GM_inpK3dGM(i,j,k,bi,bj)
+     &                               + tmpfld3d(i,j,k,bi,bj)
 #endif
               enddo
             enddo
@@ -332,9 +339,11 @@ c--   kapgm.
       enddo
 #endif
 #endif
+#endif
 
 #ifdef ALLOW_AUTODIFF
 #ifdef ALLOW_KAPREDI_CONTROL
+#ifdef GM_READ_K3D_REDI
 c--   kapredi.
       il=ilnblnk( xx_kapredi_file )
       write(fnamegeneric(1:80),'(2a,i10.10)')
@@ -347,13 +356,14 @@ c--   kapredi.
           do k = 1,nr
             do j = jmin,jmax
               do i = imin,imax
-                kapRedi(i,j,k,bi,bj) = kapRedi(i,j,k,bi,bj) +
-     &                               tmpfld3d(i,j,k,bi,bj)
+                GM_inpK3dRedi(i,j,k,bi,bj) = GM_inpK3dRedi(i,j,k,bi,bj)
+     &                               + tmpfld3d(i,j,k,bi,bj)
               enddo
             enddo
           enddo
        enddo
       enddo
+#endif
 #endif
 #endif
 
@@ -616,10 +626,10 @@ c--   Update the tile edges.
       _EXCH_XYZ_RL( diffKr, mythid)
 # endif
 # ifdef ALLOW_KAPGM_CONTROL
-      _EXCH_XYZ_RL( kapGM, mythid)
+      _EXCH_XYZ_RL( GM_inpK3dGM, mythid )
 # endif
 # ifdef ALLOW_KAPREDI_CONTROL
-      _EXCH_XYZ_RL( kapRedi, mythid)
+      _EXCH_XYZ_RL( GM_inpK3dRedi, mythid )
 # endif
 #endif
 

--- a/pkg/ctrl/ctrl_map_ini_ecco.F
+++ b/pkg/ctrl/ctrl_map_ini_ecco.F
@@ -5,6 +5,9 @@
 #ifdef ALLOW_ECCO
 # include "ECCO_OPTIONS.h"
 #endif
+#ifdef ALLOW_GMREDI
+# include "GMREDI_OPTIONS.h"
+#endif
 
       subroutine ctrl_map_ini_ecco( mythid )
 
@@ -49,6 +52,9 @@ c     == global variables ==
 # include "CTRL_GENARR.h"
 # include "ctrl_dummy.h"
 # include "optim.h"
+#endif
+#ifdef ALLOW_GMREDI
+# include "GMREDI.h"
 #endif
 #ifdef ALLOW_ECCO
 # include "ecco_cost.h"
@@ -269,6 +275,7 @@ c-- exchange UV:
 #endif
 
 #ifdef ALLOW_KAPGM_CONTROL
+#ifdef GM_READ_K3D_GM
       boundsVec(1)=1. _d 2
       boundsVec(2)=2. _d 2
       boundsVec(3)=0.9 _d 4
@@ -276,12 +283,14 @@ c-- exchange UV:
       boundsVec(5)=0.
       paramSmooth=1
       call ctrl_map_ini_gen3D(xx_kapgm_file, 'wkapgmFld',
-     & xx_kapgm_dummy, boundsVec, kapGM, maskC, paramSmooth,
+     & xx_kapgm_dummy, boundsVec, GM_inpK3dGM, maskC, paramSmooth,
      & mythid )
-      _EXCH_XYZ_RL( kapGM, mythid )
+      _EXCH_XYZ_RL( GM_inpK3dGM, mythid )
+#endif
 #endif
 
 #ifdef ALLOW_KAPREDI_CONTROL
+#ifdef GM_READ_K3D_REDI
       boundsVec(1)=1. _d 2
       boundsVec(2)=2. _d 2
       boundsVec(3)=0.9 _d 4
@@ -289,9 +298,10 @@ c-- exchange UV:
       boundsVec(5)=0.
       paramSmooth=1
       call ctrl_map_ini_gen3D(xx_kapredi_file, 'wkaprediFld',
-     & xx_kapredi_dummy, boundsVec, kapRedi, maskC, paramSmooth,
+     & xx_kapredi_dummy, boundsVec, GM_inpK3dRedi, maskC, paramSmooth,
      & mythid )
-      _EXCH_XYZ_RL( kapRedi, mythid )
+      _EXCH_XYZ_RL( GM_inpK3dRedi, mythid )
+#endif
 #endif
 
 #ifdef ALLOW_GENTIM2D_CONTROL

--- a/pkg/ctrl/ctrl_map_ini_genarr.F
+++ b/pkg/ctrl/ctrl_map_ini_genarr.F
@@ -1,4 +1,7 @@
 #include "CTRL_OPTIONS.h"
+#ifdef ALLOW_GMREDI
+# include "GMREDI_OPTIONS.h"
+#endif
 #ifdef ALLOW_SHELFICE
 # include "SHELFICE_OPTIONS.h"
 #endif
@@ -39,6 +42,9 @@ C     == global variables ==
 #include "ctrl_dummy.h"
 #include "CTRL_FIELDS.h"
 #include "CTRL_GENARR.h"
+#ifdef ALLOW_GMREDI
+# include "GMREDI.h"
+#endif
 #ifdef ALLOW_PTRACERS
 # include "PTRACERS_SIZE.h"
 # include "PTRACERS_PARAMS.h"
@@ -280,13 +286,13 @@ C--   generic 3D control variables
      &  CALL CTRL_MAP_GENARR3D( theta, igen_theta0, myThid )
       IF (igen_salt0.GT.0)
      &  CALL CTRL_MAP_GENARR3D( salt, igen_salt0, myThid )
-# ifdef ALLOW_KAPGM_CONTROL
+# if ( defined ALLOW_KAPGM_CONTROL && defined GM_READ_K3D_GM )
       IF (igen_kapgm.GT.0)
-     &  CALL CTRL_MAP_GENARR3D( kapGM, igen_kapgm, myThid )
+     &  CALL CTRL_MAP_GENARR3D( GM_inpK3dGM, igen_kapgm, myThid )
 # endif
-# ifdef ALLOW_KAPREDI_CONTROL
+# if ( defined ALLOW_KAPREDI_CONTROL && defined GM_READ_K3D_REDI )
       IF (igen_kapredi.GT.0)
-     &  CALL CTRL_MAP_GENARR3D( kapRedi, igen_kapredi, myThid )
+     &  CALL CTRL_MAP_GENARR3D( GM_inpK3dRedi, igen_kapredi, myThid )
 # endif
 # if ( defined ALLOW_DIFFKR_CONTROL && defined ALLOW_3D_DIFFKR )
       IF (igen_diffkr.GT.0)

--- a/pkg/ecco/cost_gencost_customize.F
+++ b/pkg/ecco/cost_gencost_customize.F
@@ -42,6 +42,9 @@ c     == global variables ==
 #ifdef ALLOW_CTRL
 # include "CTRL_FIELDS.h"
 #endif
+#ifdef ALLOW_GMREDI
+# include "GMREDI.h"
+#endif
 #ifdef ALLOW_PTRACERS
 # include "PTRACERS_SIZE.h"
 # include "PTRACERS_FIELDS.h"
@@ -195,7 +198,7 @@ c    &     .TRUE.,.TRUE.,.TRUE.,1,myThid)
          elseif (gencost_barfile(k)(1:8).EQ.'m_wspeed') then
            gencost_modfld(i,j,bi,bj,k) =
      &      wspeed(i,j,bi,bj)*maskC(i,j,1,bi,bj)
-#endif
+#endif /* ALLOW_EXF */
 #ifdef ALLOW_CTRL
 #ifdef ALLOW_BOTTOMDRAG_CONTROL
          elseif (gencost_barfile(k)(1:12).EQ.'m_bottomdrag') then
@@ -276,24 +279,24 @@ c    &     .TRUE.,.TRUE.,.TRUE.,1,myThid)
            enddo
 #endif
 #ifdef ALLOW_CTRL
-#ifdef ALLOW_KAPGM_CONTROL
+#if ( defined ALLOW_KAPGM_CONTROL && defined GM_READ_K3D_GM )
          elseif (gencost_barfile(k)(1:7).EQ.'m_kapgm') then
            kk=gencost_pointer3d(k)
            do k2=1,nr
             gencost_mod3d(i,j,k2,bi,bj,kk) =
-     &       kapgm(i,j,k2,bi,bj)*maskC(i,j,k2,bi,bj)
+     &       GM_inpK3dGM(i,j,k2,bi,bj)*maskC(i,j,k2,bi,bj)
            enddo
 #endif
-#ifdef ALLOW_KAPREDI_CONTROL
+#if ( defined ALLOW_KAPREDI_CONTROL && defined GM_READ_K3D_REDI )
          elseif (gencost_barfile(k)(1:9).EQ.'m_kapredi') then
            kk=gencost_pointer3d(k)
            do k2=1,nr
             gencost_mod3d(i,j,k2,bi,bj,kk) =
-     &       kapredi(i,j,k2,bi,bj)*maskC(i,j,k2,bi,bj)
+     &       GM_inpK3dRedi(i,j,k2,bi,bj)*maskC(i,j,k2,bi,bj)
            enddo
 #endif
 #endif
-#endif
+#endif /* ALLOW_GENCOST3D */
          endif
 
          enddo

--- a/pkg/gmredi/GMREDI.h
+++ b/pkg/gmredi/GMREDI.h
@@ -68,21 +68,21 @@ C     GM_iso2dFile :: input file for 2.D horiz scaling of Isopycnal diffusivity
 C     GM_iso1dFile :: input file for 1.D vert. scaling of Isopycnal diffusivity
 C     GM_bol2dFile :: input file for 2.D horiz scaling of Thickness diffusivity
 C     GM_bol1dFile :: input file for 1.D vert. scaling of Thickness diffusivity
-C     GM_isopycK3dFile :: input file for 3.D GM_isopycK
-C     GM_background_K3dFile :: input file for 3.D GM_background_K
+C     GM_K3dRediFile :: input file for background 3.D Isopycal(Redi) diffusivity
+C     GM_K3dGMFile   :: input file for background 3.D Thickness (GM) diffusivity
 
       CHARACTER*(40) GM_taper_scheme
       CHARACTER*(MAX_LEN_FNAM) GM_iso2dFile
       CHARACTER*(MAX_LEN_FNAM) GM_iso1dFile
       CHARACTER*(MAX_LEN_FNAM) GM_bol2dFile
       CHARACTER*(MAX_LEN_FNAM) GM_bol1dFile
-      CHARACTER*(MAX_LEN_FNAM) GM_isopycK3dFile
-      CHARACTER*(MAX_LEN_FNAM) GM_background_K3dFile
+      CHARACTER*(MAX_LEN_FNAM) GM_K3dRediFile
+      CHARACTER*(MAX_LEN_FNAM) GM_K3dGMFile
       COMMON /GM_PARAMS_C/
      &                   GM_taper_scheme,
      &                   GM_iso2dFile, GM_iso1dFile,
      &                   GM_bol2dFile, GM_bol1dFile,
-     &                   GM_isopycK3dFile, GM_background_K3dFile
+     &                   GM_K3dRediFile, GM_K3dGMFile
 
 C--   COMMON /GM_PARAMS_R/ GM/Redi real-type parameters
 C     GM_isopycK       :: Isopycnal diffusivity [m^2/s] (Redi-tensor)
@@ -212,6 +212,17 @@ C     GM_bolFac1d  :: 1.D vert. scaling factor [-] of Thickness diffusivity
       COMMON /GM_COEFFICIENTS/
      &  GM_isoFac2d, GM_bolFac2d, GM_isoFac1d, GM_bolFac1d
 
+#ifdef GM_READ_K3D_REDI
+C--   COMMON /GM_INP_K3D_REDI/ 3.D background isopycnal (Redi) diffusiv. [m^2/s]
+      COMMON /GM_INP_K3D_REDI/ GM_inpK3dRedi
+      _RL GM_inpK3dRedi(1-OLx:sNx+OLx,1-OLy:sNy+OLy,Nr,nSx,nSy)
+#endif
+#ifdef GM_READ_K3D_GM
+C--   COMMON /GM_INP_K3D_GM/   3.D background thickness (GM) diffusivity [m^2/s]
+      COMMON /GM_INP_K3D_GM/   GM_inpK3dGM
+      _RL GM_inpK3dGM  (1-OLx:sNx+OLx,1-OLy:sNy+OLy,Nr,nSx,nSy)
+#endif
+
 C---+----1----+----2----+----3----+----4----+----5----+----6----+----7-|--+----|
 C---  GM/Redi tensor elements
 
@@ -252,14 +263,14 @@ C        streamfunctions PsiX and PsiY :
 #endif
 
 #ifdef GM_VISBECK_VARIABLE_K
-C     GM mixing/stirring coefficient (spatially variable in horizontal
-C     for Visbeck et al. parameterization)
+C     GM mixing/stirring coefficient (spatially variable in horizontal)
+C     for Visbeck et al. parameterization
       _RL VisbeckK(1-OLx:sNx+OLx,1-OLy:sNy+OLy,nSx,nSy)
       COMMON /GM_Visbeck/ VisbeckK
 #endif
 
 #ifdef GM_BATES_K3D
-C     GM_BatesK3d :: The 3-d eddy mixing coeffixint from Bates etal [m**2/s]
+C     GM_BatesK3d :: The 3-d eddy mixing coefficient from Bates etal [m**2/s]
 C     modesC      :: First baroclinic mode at the centre of a tracer cell [-]
 C     modesW      :: First N baroclinic mode at the western face of a cell [-]
 C     modesS      :: First N baroclinic mode at the southern face of a cell [-]

--- a/pkg/gmredi/GMREDI_OPTIONS.h
+++ b/pkg/gmredi/GMREDI_OPTIONS.h
@@ -18,6 +18,11 @@ C #define GM_EXCLUDE_AC02_TAP
 C #define GM_EXCLUDE_TAPERING
 C #define GM_EXCLUDE_SUBMESO
 
+C Allows to read-in background 3-D Redi and GM diffusivity coefficients
+C Note: need these to be defined for use as Control (pkg/ctrl) parameters
+#undef GM_READ_K3D_REDI
+#undef GM_READ_K3D_GM
+
 C This allows to use Visbeck et al formulation to compute K_GM+Redi
 #undef GM_VISBECK_VARIABLE_K
 C Use old calculation (before 2007/05/24) of Visbeck etal K_GM+Redi

--- a/pkg/gmredi/gmredi_calc_psi_b.F
+++ b/pkg/gmredi/gmredi_calc_psi_b.F
@@ -147,25 +147,26 @@ C   Note: since SlopeX,Y have been masked, no needs to mask again GM_PsiX,Y
         DO j=1-OLy,sNy+OLy
          DO i=1-OLx+1,sNx+OLx
           GM_PsiX(i,j,k,bi,bj) = SlopeX(i,j)*taperX(i,j)
-#ifdef ALLOW_KAPGM_CONTROL
+#ifdef GM_READ_K3D_GM
 #  ifdef ALLOW_KAPGM_CONTROL_OLD
-     &     *( kapGM(i,j,k,bi,bj)
+     &     *( GM_inpK3dGM(i,j,k,bi,bj)
 #  else
-     &     *( op25*( kapGM(i-1,j,km1,bi,bj)+kapGM(i,j,km1,bi,bj)
-     &             + kapGM(i-1,j,k,bi,bj)+kapGM(i,j,k,bi,bj))
+     &     *( op25
+     &        *( GM_inpK3dGM(i-1,j,km1,bi,bj)+GM_inpK3dGM(i,j,km1,bi,bj)
+     &         + GM_inpK3dGM(i-1,j,k,bi,bj)+GM_inpK3dGM(i,j,k,bi,bj) )
 #  endif
 #else
      &     *( half_K
      &          *(GM_bolFac2d(i-1,j,bi,bj)+GM_bolFac2d(i,j,bi,bj))
 #endif
 #ifdef GM_VISBECK_VARIABLE_K
-     &      +op5*(VisbeckK(i-1,j,bi,bj)+VisbeckK(i,j,bi,bj))
+     &      + op5*(VisbeckK(i-1,j,bi,bj)+VisbeckK(i,j,bi,bj))
 #endif
 #ifdef ALLOW_GM_LEITH_QG
-     &      +op25*( GM_LeithQG_K(i-1,j,km1,bi,bj)
-     &            + GM_LeithQG_K( i ,j,km1,bi,bj)
-     &            + GM_LeithQG_K(i-1,j,k,bi,bj)
-     &            + GM_LeithQG_K( i ,j,k,bi,bj) )
+     &      + op25*( GM_LeithQG_K(i-1,j,km1,bi,bj)
+     &             + GM_LeithQG_K( i ,j,km1,bi,bj)
+     &             + GM_LeithQG_K(i-1,j,k,bi,bj)
+     &             + GM_LeithQG_K( i ,j,k,bi,bj) )
 #endif
      &      )
 c    &       *maskW(i,j,km1,bi,bj)*maskW(i,j,k,bi,bj)
@@ -177,25 +178,26 @@ c    &       *maskW(i,j,km1,bi,bj)*maskW(i,j,k,bi,bj)
         DO j=1-OLy+1,sNy+OLy
          DO i=1-OLx,sNx+OLx
           GM_PsiY(i,j,k,bi,bj) = SlopeY(i,j)*taperY(i,j)
-#ifdef ALLOW_KAPGM_CONTROL
+#ifdef GM_READ_K3D_GM
 #  ifdef ALLOW_KAPGM_CONTROL_OLD
-     &     *( kapGM(i,j,k,bi,bj)
+     &     *( GM_inpK3dGM(i,j,k,bi,bj)
 #  else
-     &     *( op25*( kapGM(i,j-1,km1,bi,bj)+kapGM(i,j,km1,bi,bj)
-     &             + kapGM(i,j-1,k,bi,bj)+kapGM(i,j,k,bi,bj))
+     &     *( op25
+     &        *( GM_inpK3dGM(i,j-1,km1,bi,bj)+GM_inpK3dGM(i,j,km1,bi,bj)
+     &         + GM_inpK3dGM(i,j-1,k,bi,bj)+GM_inpK3dGM(i,j,k,bi,bj) )
 #  endif
 #else
      &     *( half_K
      &          *(GM_bolFac2d(i,j-1,bi,bj)+GM_bolFac2d(i,j,bi,bj))
 #endif
 #ifdef GM_VISBECK_VARIABLE_K
-     &      +op5*(VisbeckK(i,j-1,bi,bj)+VisbeckK(i,j,bi,bj))
+     &      + op5*(VisbeckK(i,j-1,bi,bj)+VisbeckK(i,j,bi,bj))
 #endif
 #ifdef ALLOW_GM_LEITH_QG
-     &      +op25*( GM_LeithQG_K(i,j-1,km1,bi,bj)
-     &            + GM_LeithQG_K(i, j ,km1,bi,bj)
-     &            + GM_LeithQG_K(i,j-1,k,bi,bj)
-     &            + GM_LeithQG_K(i, j ,k,bi,bj) )
+     &      + op25*( GM_LeithQG_K(i,j-1,km1,bi,bj)
+     &             + GM_LeithQG_K(i, j ,km1,bi,bj)
+     &             + GM_LeithQG_K(i,j-1,k,bi,bj)
+     &             + GM_LeithQG_K(i, j ,k,bi,bj) )
 #endif
      &      )
 c    &       *maskS(i,j,km1,bi,bj)*maskS(i,j,k,bi,bj)

--- a/pkg/gmredi/gmredi_calc_tensor.F
+++ b/pkg/gmredi/gmredi_calc_tensor.F
@@ -524,7 +524,7 @@ C-- end 1rst loop on vertical level index k
 CADJ STORE VisbeckK(:,:,bi,bj) = comlev1_bibj, key=igmkey, byte=isbyte
 #endif
       IF ( GM_Visbeck_alpha.GT.0. ) THEN
-C-     Limit range that KapGM can take
+C-     Limit range that Kappa-GM can take
        DO j=1-OLy+1,sNy+OLy-1
         DO i=1-OLx+1,sNx+OLx-1
          VisbeckK(i,j,bi,bj)=
@@ -554,20 +554,22 @@ CADJ STORE Kwz(:,:,k,bi,bj) = comlev1_bibj_k, key=kkey, byte=isbyte
      &         *(GM_bolFac1d(km1)+GM_bolFac1d(k))*op5
        DO j=1-OLy+1,sNy+OLy-1
         DO i=1-OLx+1,sNx+OLx-1
-#ifdef ALLOW_KAPREDI_CONTROL
+#ifdef GM_READ_K3D_REDI
 #  ifdef ALLOW_KAPREDI_CONTROL_OLD
-         Kgm_tmp = kapRedi(i,j,k,bi,bj)
+         Kgm_tmp = GM_inpK3dRedi(i,j,k,bi,bj)
 #  else
-         Kgm_tmp = op5*(kapRedi(i,j,k,bi,bj)+kapRedi(i,j,km1,bi,bj))
+         Kgm_tmp = op5*( GM_inpK3dRedi(i,j,km1,bi,bj)
+     &                 + GM_inpK3dRedi(i,j,k,bi,bj) )
 #  endif
 #else
          Kgm_tmp = isopycK*GM_isoFac2d(i,j,bi,bj)
 #endif
-#ifdef ALLOW_KAPGM_CONTROL
+#ifdef GM_READ_K3D_GM
 #  ifdef ALLOW_KAPGM_CONTROL_OLD
-     &           + GM_skewflx*kapGM(i,j,k,bi,bj)
+     &           + GM_skewflx*GM_inpK3dGM(i,j,k,bi,bj)
 #  else
-     &     + GM_skewflx*op5*(kapGM(i,j,k,bi,bj)+kapGM(i,j,km1,bi,bj))
+     &           + GM_skewflx*op5*( GM_inpK3dGM(i,j,km1,bi,bj)
+     &                            + GM_inpK3dGM(i,j,k,bi,bj) )
 #  endif
 #else
      &           + GM_skewflx*bolus_K*GM_bolFac2d(i,j,bi,bj)
@@ -587,12 +589,12 @@ CADJ STORE Kwz(:,:,k,bi,bj) = comlev1_bibj_k, key=kkey, byte=isbyte
 #endif
          Kwx(i,j,k,bi,bj)= Kgm_tmp*Kwx(i,j,k,bi,bj)
          Kwy(i,j,k,bi,bj)= Kgm_tmp*Kwy(i,j,k,bi,bj)
-#ifdef ALLOW_KAPREDI_CONTROL
+#ifdef GM_READ_K3D_REDI
 #  ifdef ALLOW_KAPREDI_CONTROL_OLD
-         Kwz(i,j,k,bi,bj)= ( kapRedi(i,j,k,bi,bj)
+         Kwz(i,j,k,bi,bj)= ( GM_inpK3dRedi(i,j,k,bi,bj)
 #  else
-         Kwz(i,j,k,bi,bj)= ( op5*(kapRedi(i,j,k,bi,bj)
-     &                            +kapRedi(i,j,km1,bi,bj))
+         Kwz(i,j,k,bi,bj)= ( op5*( GM_inpK3dRedi(i,j,km1,bi,bj)
+     &                           + GM_inpK3dRedi(i,j,k,bi,bj) )
 #  endif
 #else
          Kwz(i,j,k,bi,bj)= ( isopycK*GM_isoFac2d(i,j,bi,bj)
@@ -749,11 +751,12 @@ c      IF ( GM_nonUnitDiag ) THEN
         DO j=1-OLy+1,sNy+OLy-1
          DO i=1-OLx+1,sNx+OLx-1
           Kux(i,j,k,bi,bj) =
-#ifdef ALLOW_KAPREDI_CONTROL
+#ifdef GM_READ_K3D_REDI
 #  ifdef ALLOW_KAPREDI_CONTROL_OLD
-     &     ( kapRedi(i,j,k,bi,bj)
+     &     ( GM_inpK3dRedi(i,j,k,bi,bj)
 #  else
-     &     ( op5*(kapRedi(i,j,k,bi,bj)+kapRedi(i-1,j,k,bi,bj))
+     &     ( op5*( GM_inpK3dRedi(i-1,j,k,bi,bj)
+     &           + GM_inpK3dRedi(i,j,k,bi,bj) )
 #  endif
 #else
      &     ( GM_isopycK*GM_isoFac1d(k)
@@ -793,21 +796,23 @@ CADJ STORE SlopeX(:,:)       = comlev1_bibj_k, key=kkey, byte=isbyte
         DO j=1-OLy+1,sNy+OLy-1
          DO i=1-OLx+1,sNx+OLx-1
           Kuz(i,j,k,bi,bj) =
-#ifdef ALLOW_KAPREDI_CONTROL
+#ifdef GM_READ_K3D_REDI
 #  ifdef ALLOW_KAPREDI_CONTROL_OLD
-     &     ( kapRedi(i,j,k,bi,bj)
+     &     ( GM_inpK3dRedi(i,j,k,bi,bj)
 #  else
-     &     ( op5*(kapRedi(i,j,k,bi,bj)+kapRedi(i-1,j,k,bi,bj))
+     &     ( op5*( GM_inpK3dRedi(i-1,j,k,bi,bj)
+     &           + GM_inpK3dRedi(i,j,k,bi,bj) )
 #  endif
 #else
      &     ( GM_isopycK*GM_isoFac1d(k)
      &        *op5*(GM_isoFac2d(i-1,j,bi,bj)+GM_isoFac2d(i,j,bi,bj))
 #endif
-#ifdef ALLOW_KAPGM_CONTROL
+#ifdef GM_READ_K3D_GM
 #  ifdef ALLOW_KAPGM_CONTROL_OLD
-     &     - GM_skewflx*kapGM(i,j,k,bi,bj)
+     &     - GM_skewflx*GM_inpK3dGM(i,j,k,bi,bj)
 #  else
-     &     - GM_skewflx*op5*(kapGM(i,j,k,bi,bj)+kapGM(i-1,j,k,bi,bj))
+     &     - GM_skewflx*op5*( GM_inpK3dGM(i-1,j,k,bi,bj)
+     &                      + GM_inpK3dGM(i,j,k,bi,bj) )
 #  endif
 #else
      &     - GM_skewflx*GM_background_K*GM_bolFac1d(k)
@@ -842,12 +847,12 @@ c       ENDDO
         DO j=1,sNy
          DO i=1,sNx+1
 C         store in tmp1k Kuz_Redi
-#ifdef ALLOW_KAPREDI_CONTROL
+#ifdef GM_READ_K3D_REDI
 #  ifdef ALLOW_KAPREDI_CONTROL_OLD
-          tmp1k(i,j) = ( kapRedi(i,j,k,bi,bj)
+          tmp1k(i,j) = ( GM_inpK3dRedi(i,j,k,bi,bj)
 #  else
-          tmp1k(i,j) = ( op5*(kapRedi(i-1,j,k,bi,bj)
-     &                       +kapRedi(i,j,k,bi,bj))
+          tmp1k(i,j) = ( op5*( GM_inpK3dRedi(i-1,j,k,bi,bj)
+     &                       + GM_inpK3dRedi(i,j,k,bi,bj) )
 #  endif
 #else
           tmp1k(i,j) = ( GM_isopycK*GM_isoFac1d(k)
@@ -982,11 +987,12 @@ c      IF ( GM_nonUnitDiag ) THEN
         DO j=1-OLy+1,sNy+OLy-1
          DO i=1-OLx+1,sNx+OLx-1
           Kvy(i,j,k,bi,bj) =
-#ifdef ALLOW_KAPREDI_CONTROL
+#ifdef GM_READ_K3D_REDI
 #  ifdef ALLOW_KAPREDI_CONTROL_OLD
-     &     ( kapRedi(i,j,k,bi,bj)
+     &     ( GM_inpK3dRedi(i,j,k,bi,bj)
 #  else
-     &     ( op5*(kapRedi(i,j,k,bi,bj)+kapRedi(i,j-1,k,bi,bj))
+     &     ( op5*( GM_inpK3dRedi(i,j-1,k,bi,bj)
+     &           + GM_inpK3dRedi(i,j,k,bi,bj) )
 #  endif
 #else
      &     ( GM_isopycK*GM_isoFac1d(k)
@@ -1026,21 +1032,23 @@ CADJ STORE SlopeY(:,:)       = comlev1_bibj_k, key=kkey, byte=isbyte
         DO j=1-OLy+1,sNy+OLy-1
          DO i=1-OLx+1,sNx+OLx-1
           Kvz(i,j,k,bi,bj) =
-#ifdef ALLOW_KAPREDI_CONTROL
+#ifdef GM_READ_K3D_REDI
 #  ifdef ALLOW_KAPREDI_CONTROL_OLD
-     &     ( kapRedi(i,j,k,bi,bj)
+     &     ( GM_inpK3dRedi(i,j,k,bi,bj)
 #  else
-     &     ( op5*(kapRedi(i,j,k,bi,bj)+kapRedi(i,j-1,k,bi,bj))
+     &     ( op5*( GM_inpK3dRedi(i,j-1,k,bi,bj)
+     &           + GM_inpK3dRedi(i,j,k,bi,bj) )
 #  endif
 #else
      &     ( GM_isopycK*GM_isoFac1d(k)
      &        *op5*(GM_isoFac2d(i,j-1,bi,bj)+GM_isoFac2d(i,j,bi,bj))
 #endif
-#ifdef ALLOW_KAPGM_CONTROL
+#ifdef GM_READ_K3D_GM
 #  ifdef ALLOW_KAPGM_CONTROL_OLD
-     &     - GM_skewflx*kapGM(i,j,k,bi,bj)
+     &     - GM_skewflx*GM_inpK3dGM(i,j,k,bi,bj)
 #  else
-     &     - GM_skewflx*op5*(kapGM(i,j,k,bi,bj)+kapGM(i,j-1,k,bi,bj))
+     &     - GM_skewflx*op5*( GM_inpK3dGM(i,j-1,k,bi,bj)
+     &                      + GM_inpK3dGM(i,j,k,bi,bj) )
 #  endif
 #else
      &     - GM_skewflx*GM_background_K*GM_bolFac1d(k)
@@ -1075,12 +1083,12 @@ c       ENDDO
         DO j=1,sNy+1
          DO i=1,sNx
 C         store in tmp1k Kvz_Redi
-#ifdef ALLOW_KAPREDI_CONTROL
+#ifdef GM_READ_K3D_REDI
 #  ifdef ALLOW_KAPREDI_CONTROL_OLD
-          tmp1k(i,j) = ( kapRedi(i,j,k,bi,bj)
+          tmp1k(i,j) = ( GM_inpK3dRedi(i,j,k,bi,bj)
 #  else
-          tmp1k(i,j) = ( op5*(kapRedi(i,j-1,k,bi,bj)
-     &                       +kapRedi(i,j,k,bi,bj))
+          tmp1k(i,j) = ( op5*( GM_inpK3dRedi(i,j-1,k,bi,bj)
+     &                       + GM_inpK3dRedi(i,j,k,bi,bj) )
 #  endif
 #else
           tmp1k(i,j) = ( GM_isopycK*GM_isoFac1d(k)
@@ -1134,10 +1142,11 @@ C-- end 3rd  loop on vertical level index k
        DO j=1-OLy+1,sNy+OLy-1
         DO i=1-OLx+1,sNx+OLx-1
           Kux(i,j,k,bi,bj) = (
-#ifdef ALLOW_KAPREDI_CONTROL
+#ifdef GM_READ_K3D_REDI
 c#  ifdef ALLOW_KAPREDI_CONTROL_OLD
-c    &       kapRedi(i,j,k,bi,bj)
-     &       op5*(kapRedi(i,j,k,bi,bj)+kapRedi(i-1,j,k,bi,bj))
+c    &       GM_inpK3dRedi(i,j,k,bi,bj)
+     &       op5*( GM_inpK3dRedi(i-1,j,k,bi,bj)
+     &           + GM_inpK3dRedi(i,j,k,bi,bj) )
 #else
      &       GM_isopycK
 #endif
@@ -1150,10 +1159,11 @@ c    &       kapRedi(i,j,k,bi,bj)
        DO j=1-OLy+1,sNy+OLy-1
         DO i=1-OLx+1,sNx+OLx-1
           Kvy(i,j,k,bi,bj) = (
-#ifdef ALLOW_KAPREDI_CONTROL
+#ifdef GM_READ_K3D_REDI
 c#  ifdef ALLOW_KAPREDI_CONTROL_OLD
-c    &       kapRedi(i,j,k,bi,bj)
-     &       op5*(kapRedi(i,j,k,bi,bj)+kapRedi(i,j-1,k,bi,bj))
+c    &       GM_inpK3dRedi(i,j,k,bi,bj)
+     &       op5*( GM_inpK3dRedi(i,j-1,k,bi,bj)
+     &           + GM_inpK3dRedi(i,j,k,bi,bj) )
 #else
      &       GM_isopycK
 #endif

--- a/pkg/gmredi/gmredi_check.F
+++ b/pkg/gmredi/gmredi_check.F
@@ -139,6 +139,29 @@ C-     GM/Redi needs implicit diffusion (will be packaged later)
         errCount = errCount + 1
       ENDIF
 
+#ifndef GM_READ_K3D_REDI
+      IF ( GM_K3dRediFile.NE.' ' ) THEN
+       WRITE(msgBuf,'(A)')
+     &   'GMREDI_CHECK: GM_K3dRediFile is set in data.gmredi'
+       CALL PRINT_ERROR( msgBuf, myThid )
+       WRITE(msgBuf,'(A)')
+     &   'GMREDI_CHECK: without #define GM_READ_K3D_REDI'
+       CALL PRINT_ERROR( msgBuf, myThid )
+       errCount = errCount + 1
+      ENDIF
+#endif
+#ifndef GM_READ_K3D_GM
+      IF ( GM_K3dGMFile.NE.' ' ) THEN
+       WRITE(msgBuf,'(A)')
+     &   'GMREDI_CHECK: GM_K3dGMFile is set in data.gmredi'
+       CALL PRINT_ERROR( msgBuf, myThid )
+       WRITE(msgBuf,'(A)')
+     &   'GMREDI_CHECK: without #define GM_READ_K3D_GM'
+       CALL PRINT_ERROR( msgBuf, myThid )
+       errCount = errCount + 1
+      ENDIF
+#endif
+
 #ifndef GM_VISBECK_VARIABLE_K
 C     Make sure we are not trying to use something that is unavailable
       IF ( GM_Visbeck_alpha.NE.0. ) THEN

--- a/pkg/gmredi/gmredi_init_fixed.F
+++ b/pkg/gmredi/gmredi_init_fixed.F
@@ -42,8 +42,8 @@ C     === Local variables ===
 C--   Initialize arrays in common blocks :
       DO bj = myByLo(myThid), myByHi(myThid)
        DO bi = myBxLo(myThid), myBxHi(myThid)
-        DO j=1-Oly,sNy+OLy
-         DO i=1-Olx,sNx+Olx
+        DO j=1-OLy,sNy+OLy
+         DO i=1-OLx,sNx+OLx
            GM_isoFac2d(i,j,bi,bj) = 1. _d 0
            GM_bolFac2d(i,j,bi,bj) = 1. _d 0
          ENDDO
@@ -82,6 +82,51 @@ C-    Read vertical 1.D scaling factors from files:
 
 C-    Everyone else must wait for arrays to be loaded
       _BARRIER
+
+#ifdef GM_READ_K3D_REDI
+C--   Initialize 3-D Isopycnal diffusivity in common block
+      DO bj = myByLo(myThid), myByHi(myThid)
+       DO bi = myBxLo(myThid), myBxHi(myThid)
+        DO k=1,Nr
+         DO j=1-OLy,sNy+OLy
+          DO i=1-OLx,sNx+OLx
+           GM_inpK3dRedi(i,j,k,bi,bj) = GM_isopycK
+     &                  *GM_isoFac1d(k)*GM_isoFac2d(i,j,bi,bj)
+          ENDDO
+         ENDDO
+        ENDDO
+       ENDDO
+      ENDDO
+C--   Read 3-D Isopycnal diffusivity from file
+      IF ( GM_K3dRediFile .NE. ' ' ) THEN
+       CALL READ_FLD_XYZ_RL( GM_K3dRediFile, ' ',
+     &                       GM_inpK3dRedi, 0, myThid )
+       CALL EXCH_XYZ_RL( GM_inpK3dRedi, myThid )
+       CALL WRITE_FLD_XYZ_RL( 'KapRedi', ' ', GM_inpK3dRedi, 0, myThid )
+      ENDIF
+#endif
+#ifdef GM_READ_K3D_GM
+C--   Initialize 3-D Thickness diffusivity in common block
+      DO bj = myByLo(myThid), myByHi(myThid)
+       DO bi = myBxLo(myThid), myBxHi(myThid)
+        DO k=1,Nr
+         DO j=1-OLy,sNy+OLy
+          DO i=1-OLx,sNx+OLx
+           GM_inpK3dGM(i,j,k,bi,bj) = GM_background_K
+     &                  *GM_bolFac1d(k)*GM_bolFac2d(i,j,bi,bj)
+          ENDDO
+         ENDDO
+        ENDDO
+       ENDDO
+      ENDDO
+C--   Read 3-D Thickness diffusivity from file
+      IF ( GM_K3dGMFile .NE. ' ' ) THEN
+       CALL READ_FLD_XYZ_RL( GM_K3dGMFile, ' ',
+     &                       GM_inpK3dGM, 0, myThid )
+       CALL EXCH_XYZ_RL( GM_inpK3dGM, myThid )
+       CALL WRITE_FLD_XYZ_RL( 'KapGM', ' ', GM_inpK3dGM, 0, myThid )
+      ENDIF
+#endif
 
 C---+----1----+----2----+----3----+----4----+----5----+----6----+----7-|--+----|
 

--- a/pkg/gmredi/gmredi_init_varia.F
+++ b/pkg/gmredi/gmredi_init_varia.F
@@ -1,4 +1,7 @@
 #include "GMREDI_OPTIONS.h"
+#ifdef ALLOW_CTRL
+# include "CTRL_OPTIONS.h"
+#endif
 
 CBOP
 C     !ROUTINE: GMREDI_INIT_VARIA
@@ -29,9 +32,62 @@ C     myThid ::  my Thread Id number
 CEOP
 
 #ifdef ALLOW_GMREDI
-
 C     !LOCAL VARIABLES:
       INTEGER i,j,k,bi,bj
+
+C--   Initialise again 3-D control variables
+#if (defined ALLOW_KAPREDI_CONTROL && defined GM_READ_K3D_REDI )
+C--   Initialize 3-D Isopycnal diffusivity in common block
+      DO bj = myByLo(myThid), myByHi(myThid)
+       DO bi = myBxLo(myThid), myBxHi(myThid)
+        DO k=1,Nr
+         DO j=1-OLy,sNy+OLy
+          DO i=1-OLx,sNx+OLx
+           GM_inpK3dRedi(i,j,k,bi,bj) = GM_isopycK
+     &                  *GM_isoFac1d(k)*GM_isoFac2d(i,j,bi,bj)
+          ENDDO
+         ENDDO
+        ENDDO
+       ENDDO
+      ENDDO
+#endif /* ALLOW_KAPREDI_CONTROL and GM_READ_K3D_REDI */
+#if (defined ALLOW_KAPGM_CONTROL && defined GM_READ_K3D_GM )
+C--   Initialize 3-D Thickness diffusivity in common block
+      DO bj = myByLo(myThid), myByHi(myThid)
+       DO bi = myBxLo(myThid), myBxHi(myThid)
+        DO k=1,Nr
+         DO j=1-OLy,sNy+OLy
+          DO i=1-OLx,sNx+OLx
+           GM_inpK3dGM(i,j,k,bi,bj) = GM_background_K
+     &                  *GM_bolFac1d(k)*GM_bolFac2d(i,j,bi,bj)
+          ENDDO
+         ENDDO
+        ENDDO
+       ENDDO
+      ENDDO
+#endif /* ALLOW_KAPGM_CONTROL and GM_READ_K3D_GM */
+
+C---+----1----+----2----+----3----+----4----+----5----+----6----+----7-|--+----|
+#ifdef ALLOW_AUTODIFF
+      IF ( useGMRedi ) THEN
+#endif
+
+#if (defined ALLOW_KAPREDI_CONTROL && defined GM_READ_K3D_REDI )
+C--   Read (again) 3-D Isopycnal diffusivity from file
+      IF ( GM_K3dRediFile .NE. ' ' ) THEN
+       CALL READ_FLD_XYZ_RL( GM_K3dRediFile, ' ',
+     &                       GM_inpK3dRedi, 0, myThid )
+       CALL EXCH_XYZ_RL( GM_inpK3dRedi, myThid )
+      ENDIF
+#endif /* ALLOW_KAPREDI_CONTROL and GM_READ_K3D_REDI */
+#if (defined ALLOW_KAPGM_CONTROL && defined GM_READ_K3D_GM )
+C--   Read (again) 3-D Thickness diffusivity from file
+      IF ( GM_K3dGMFile .NE. ' ' ) THEN
+       CALL READ_FLD_XYZ_RL( GM_K3dGMFile, ' ',
+     &                       GM_inpK3dGM, 0, myThid )
+       CALL EXCH_XYZ_RL( GM_inpK3dGM, myThid )
+      ENDIF
+#endif /* ALLOW_KAPGM_CONTROL and GM_READ_K3D_GM */
 
       DO bj = myByLo(myThid), myByHi(myThid)
        DO bi = myBxLo(myThid), myBxHi(myThid)
@@ -85,6 +141,7 @@ C- end bi,bj loops
        ENDDO
       ENDDO
 
+C---+----1----+----2----+----3----+----4----+----5----+----6----+----7-|--+----|
 C--   write GM scaling factors to file:
       IF ( GM_iso1dFile .NE. ' ' ) THEN
         CALL WRITE_GLVEC_RS( 'GM_isoFac1d', ' ', GM_isoFac1d,
@@ -100,7 +157,6 @@ C--   write GM scaling factors to file:
       IF ( GM_bol2dFile .NE. ' ' ) THEN
         CALL WRITE_FLD_XY_RS( 'GM_bolFac2d',' ',GM_bolFac2d,-1,myThid )
       ENDIF
-#endif /* ALLOW_GMREDI */
 
 #ifdef GM_BATES_K3D
       IF (.NOT.( startTime.EQ.baseTime .AND. nIter0.EQ.0
@@ -151,7 +207,12 @@ C     Computing beta = df/dy
        ENDDO
       ENDIF
       CALL EXCH_XY_RL( gradf, myThid)
+#endif /* GM_BATES_K3D */
+
+#ifdef ALLOW_AUTODIFF
+      ENDIF
 #endif
+#endif /* ALLOW_GMREDI */
 
       RETURN
       END

--- a/pkg/gmredi/gmredi_readparms.F
+++ b/pkg/gmredi/gmredi_readparms.F
@@ -33,8 +33,14 @@ C     !LOCAL VARIABLES:
 C     === Local variables ===
 C     msgBuf     :: Informational/error message buffer
 C     iUnit      :: Work variable for IO unit number
+C     nRetired   :: Counter used to trap "retired" parameters in namelist.
+C     GM_isopycK3dFile      :: input file for 3.D GM_isopycK
+C     GM_background_K3dFile :: input file for 3.D GM_background_K
       CHARACTER*(MAX_LEN_MBUF) msgBuf
       INTEGER iUnit
+      INTEGER nRetired
+      CHARACTER*(MAX_LEN_FNAM) GM_isopycK3dFile
+      CHARACTER*(MAX_LEN_FNAM) GM_background_K3dFile
 CEOP
 
 C--   GM/Redi parameter
@@ -47,8 +53,8 @@ C     GM_slopeSqCutoff :: slope^2 cut-off value
      &          GM_background_K,
      &          GM_iso2dFile, GM_iso1dFile,
      &          GM_bol2dFile, GM_bol1dFile,
-     &          GM_background_K3dFile,
-     &          GM_isopycK3dFile,
+     &          GM_K3dRediFile, GM_K3dGMFile,
+     &          GM_background_K3dFile, GM_isopycK3dFile,
      &          GM_taper_scheme,
      &          GM_maxSlope,
      &          GM_Kmin_horiz,
@@ -111,8 +117,8 @@ C--   Default values GM/Redi
       GM_iso1dFile        = ' '
       GM_bol2dFile        = ' '
       GM_bol1dFile        = ' '
-      GM_background_K3dFile = ' '
-      GM_isopycK3dFile    = ' '
+      GM_K3dRediFile      = ' '
+      GM_K3dGMFile        = ' '
       GM_useLeithQG       = .FALSE.
 
 C--   Default values GM/Redi I/O control
@@ -165,6 +171,11 @@ C--   Default values for BatesK3d
       GM_Bates_vecFreq   = 2592000.
       GM_Bates_minRenorm = oneRL
       GM_Bates_maxRenorm = 20.
+
+C--   Initialise retired parameters to unlikely value
+      nRetired = 0
+      GM_background_K3dFile = ' '
+      GM_isopycK3dFile    = ' '
 
       WRITE(msgBuf,'(A)') ' GM_READPARMS: opening data.gmredi'
       CALL PRINT_MESSAGE( msgBuf, standardMessageUnit,
@@ -223,6 +234,37 @@ C     Fix to avoid running without getting any output:
       GM_MNC = .FALSE.
 #endif
       GM_MDSIO = (.NOT. GM_MNC) .OR. outputTypesInclusive
+
+C     Check for retired parameters
+      IF ( GM_background_K3dFile .NE. ' ' ) THEN
+        nRetired = nRetired+1
+        WRITE(msgBuf,'(2A)') 'S/R GMREDI_READPARMS: ',
+     &    '"GM_background_K3dFile" has been replaced by "GM_K3dGMFile"'
+        CALL PRINT_ERROR( msgBuf, myThid )
+        WRITE(msgBuf,'(2A)') 'S/R GMREDI_READPARMS: ',
+     &    'and is no longer allowed in file "data.gmredi"'
+        CALL PRINT_ERROR( msgBuf, myThid )
+      ENDIF
+      IF ( GM_isopycK3dFile .NE. ' ' ) THEN
+        nRetired = nRetired+1
+        WRITE(msgBuf,'(2A)') 'S/R GMREDI_READPARMS: ',
+     &    '"GM_isopycK3dFile" has been replaced by "GM_K3dRediFile"'
+        CALL PRINT_ERROR( msgBuf, myThid )
+        WRITE(msgBuf,'(2A)') 'S/R GMREDI_READPARMS: ',
+     &    'and is no longer allowed in file "data.gmredi"'
+        CALL PRINT_ERROR( msgBuf, myThid )
+      ENDIF
+
+      IF ( nRetired .GT. 0 ) THEN
+        WRITE(msgBuf,'(2A)') 'S/R GMREDI_READPARMS: ',
+     &              'Error reading parameter file "data.gmredi":'
+        CALL PRINT_ERROR( msgBuf, myThid )
+        WRITE(msgBuf,'(I4,A)') nRetired,
+     &      ' out of date parameters were found in the namelist'
+        CALL PRINT_ERROR( msgBuf, myThid )
+        CALL ALL_PROC_DIE( 0 )
+        STOP 'ABNORMAL END: S/R GMREDI_READPARMS'
+      ENDIF
 
       _END_MASTER(myThid)
 

--- a/verification/OpenAD/code_ad/GMREDI_OPTIONS.h
+++ b/verification/OpenAD/code_ad/GMREDI_OPTIONS.h
@@ -18,11 +18,21 @@ C -- exclude the clipping/tapering part of the code that is not used
 #undef GM_EXCLUDE_TAPERING
 #define GM_EXCLUDE_SUBMESO
 
+C Allows to read-in background 3-D Redi and GM diffusivity coefficients
+C Note: need these to be defined for use as Control (pkg/ctrl) parameters
+#undef GM_READ_K3D_REDI
+#define GM_READ_K3D_GM
+
 C This allows to use Visbeck et al formulation to compute K_GM+Redi
 #undef GM_VISBECK_VARIABLE_K
 C Use old calculation (before 2007/05/24) of Visbeck etal K_GM+Redi
 C (which depends on tapering scheme)
 #undef OLD_VISBECK_CALC
+
+C This allows the Bates et al formulation to calculate the
+C bolus transport and K for Redi
+#undef GM_BATES_K3D
+#undef GM_BATES_PASSIVE
 
 C This allows the leading diagonal (top two rows) to be non-unity
 C (a feature required when tapering adiabatically).
@@ -38,6 +48,9 @@ C  instead of the Skew-Flux form (=default)
 
 C Allows to use the Boundary-Value-Problem method to evaluate GM Bolus transport
 #undef GM_BOLUS_BVP
+
+C Allow QG Leith variable viscosity to be added to GMRedi coefficient
+#undef ALLOW_GM_LEITH_QG
 
 #endif /* ALLOW_GMREDI */
 #endif /* GMREDI_OPTIONS_H */

--- a/verification/global_ocean.90x40x15/code_ad/GMREDI_OPTIONS.h
+++ b/verification/global_ocean.90x40x15/code_ad/GMREDI_OPTIONS.h
@@ -18,11 +18,21 @@ C -- exclude the clipping/tapering part of the code that is not used
 #undef GM_EXCLUDE_TAPERING
 #define GM_EXCLUDE_SUBMESO
 
+C Allows to read-in background 3-D Redi and GM diffusivity coefficients
+C Note: need these to be defined for use as Control (pkg/ctrl) parameters
+#define GM_READ_K3D_REDI
+#define GM_READ_K3D_GM
+
 C This allows to use Visbeck et al formulation to compute K_GM+Redi
 #undef GM_VISBECK_VARIABLE_K
 C Use old calculation (before 2007/05/24) of Visbeck etal K_GM+Redi
 C (which depends on tapering scheme)
 #undef OLD_VISBECK_CALC
+
+C This allows the Bates et al formulation to calculate the
+C bolus transport and K for Redi
+#undef GM_BATES_K3D
+#undef GM_BATES_PASSIVE
 
 C This allows the leading diagonal (top two rows) to be non-unity
 C (a feature required when tapering adiabatically).
@@ -38,6 +48,9 @@ C  instead of the Skew-Flux form (=default)
 
 C Allows to use the Boundary-Value-Problem method to evaluate GM Bolus transport
 #undef GM_BOLUS_BVP
+
+C Allow QG Leith variable viscosity to be added to GMRedi coefficient
+#undef ALLOW_GM_LEITH_QG
 
 #endif /* ALLOW_GMREDI */
 #endif /* GMREDI_OPTIONS_H */


### PR DESCRIPTION
## What changes does this PR introduce?
Allow to read-in 3-D background Isopycnal (Redi) and Thickness (GM) diffusivity without pkg/ctrl (see issue #566)

## What is the current behaviour? 
The reading of 3-D diffusivity is already implemented when (1) using pkg/ctrl and (2) with ALLOW_KAPREDI_CONTROL and/or ALLOW_KAPGM_CONTROL defined and (3) undocumented 
ALLOW_KAPREDI_3DFILE and/or ALLOW_KAPGM_3DFILE defined, setting file-names: GM_isopycK3dFile & GM_background_K3dFile.
The code is splitting between pkg/gmredi, pkg/ctrl (arrays in CTRL_FIELDS.h) and model/src (ini_mixing.F).

## What is the new behaviour 
1) Cleaner and simpler implementation within pkg/gmredi with new CPP option: GM_READ_K3D_REDI & GM_READ_K3D_GM, arrays and parameters in GMREDI.h, setting and reading files in gmredi_init_fixed.F 
2) Update KAPREDI_CONTROL and KAPGM_CONTROL code that now requires to define new CPP options above
but keep Adjoint variable diagnostics, output files and names unchanged. Move setting of 3-D control array outside ini_mixing.F into gmredi_init_varia.F

## Does this PR introduce a breaking change?
No real breaking but requires to define the pair of new CPP options (in GMREDI_OPTIONS.h) to use 3-D GM diffusivity as control (a clean check & stop was added).

## Other information:

## Suggested addition to `tag-index`
to be added later