### PR TITLE
Fix doc build with Sphinx v5

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -99,7 +99,7 @@ release = version
 #
 # This is also used if you do content translation via gettext catalogs.
 # Usually you set "language" from the command line for these cases.
-language = None
+language = 'en'
 
 # List of patterns, relative to source directory, that match files and
 # directories to ignore when looking for source files.


### PR DESCRIPTION
## What changes does this PR introduce?

Set the language for the docs to English

## What is the current behaviour? 

Docs do not build with Sphinx v5 since language iss set to None

## What is the new behaviour 

Docs build

## Does this PR introduce a breaking change? 

No
