### PR TITLE
Add volume objective function

### DIFF
--- a/doc/ocean_state_est/ocean_state_est.rst
+++ b/doc/ocean_state_est/ocean_state_est.rst
@@ -491,6 +491,8 @@ be used (e.g. 1000 dbar, 2000 dbar).
   +---------------------+----------------------------------+------------------+
   | ``m_boxmean_shihf`` | total shelfice heat flux over box| specify box      |
   +---------------------+----------------------------------+------------------+
+  | ``m_boxmean_vol``   | total volume over box            | specify box      |
+  +---------------------+----------------------------------+------------------+  
   | ``m_horflux_vol``   | volume transport through section | specify transect |
   +---------------------+----------------------------------+------------------+
 

--- a/pkg/ecco/ecco_check.F
+++ b/pkg/ecco/ecco_check.F
@@ -510,6 +510,7 @@ c-- (upper/lower-case matters) in cost_gencost_customize
      &          (gencost_barfile(k)(1:13).EQ.'m_boxmean_eta').OR.
      &          (gencost_barfile(k)(1:14).EQ.'m_boxmean_salt').OR.
      &          (gencost_barfile(k)(1:17).EQ.'m_boxmean_ptracer').OR.
+     &          (gencost_barfile(k)(1:17).EQ.'m_boxmean_vol').OR.
      &          (gencost_barfile(k)(1:16).EQ.'m_boxmean_shifwf').OR.
      &          (gencost_barfile(k)(1:16).EQ.'m_boxmean_shihtf').OR.
      &          (gencost_barfile(k)(1:14).EQ.'m_horflux_vol')

--- a/pkg/ecco/ecco_check.F
+++ b/pkg/ecco/ecco_check.F
@@ -510,7 +510,7 @@ c-- (upper/lower-case matters) in cost_gencost_customize
      &          (gencost_barfile(k)(1:13).EQ.'m_boxmean_eta').OR.
      &          (gencost_barfile(k)(1:14).EQ.'m_boxmean_salt').OR.
      &          (gencost_barfile(k)(1:17).EQ.'m_boxmean_ptracer').OR.
-     &          (gencost_barfile(k)(1:17).EQ.'m_boxmean_vol').OR.
+     &          (gencost_barfile(k)(1:13).EQ.'m_boxmean_vol').OR.
      &          (gencost_barfile(k)(1:16).EQ.'m_boxmean_shifwf').OR.
      &          (gencost_barfile(k)(1:16).EQ.'m_boxmean_shihtf').OR.
      &          (gencost_barfile(k)(1:14).EQ.'m_horflux_vol')

--- a/pkg/ecco/ecco_phys.F
+++ b/pkg/ecco/ecco_phys.F
@@ -384,6 +384,9 @@ cts ---
      &        THEN
              tmpfld=salt(i,j,k,bi,bj)
              IF (tmpmsk.NE.0. _d 0) tmpmsk2=1. _d 0
+            ELSEIF (gencost_barfile(kgen)(1:13).EQ.'m_boxmean_vol') THEN
+             tmpfld=1. _d 0
+             IF (tmpmsk.NE.0. _d 0) tmpmsk2=1. _d 0
 #ifdef ALLOW_PTRACERS
             ELSEIF (gencost_barfile(kgen)(1:17).EQ.'m_boxmean_ptracer')
      &        THEN
@@ -539,7 +542,8 @@ c Note: for shelfice, do not take this final average to make
 c       comparable to shelfice_cost_final.
 cts ---
        IF (gencost_barfile(kgen)(1:9).EQ.'m_boxmean' .AND.
-     &    gencost_barfile(kgen)(11:13).NE.'shi') THEN
+     &    (gencost_barfile(kgen)(11:13).NE.'shi' .OR. 
+     &     gencost_barfile(kgen)(11:13).NE.'vol')) THEN
         CALL GLOBAL_SUM_TILE_RL( areavolTile, areavolGlob, myThid )
         CALL ECCO_DIV( gencost_storefld(1-OLx,1-OLy,1,1,kgen),
      &                 areavolGlob, 1, 1, myThid )


### PR DESCRIPTION
## What changes does this PR introduce?
This PR introduces new generic integral function: m_boxmean_vol. This is used to look at the sensitivity of the total volume of a box using adjoint sensitivity experiments. 

## What is the current behaviour? 
This is a new feature.

## What is the new behaviour 
New feature is used to look at the sensitivity of the volume of a box.

## Does this PR introduce a breaking change? 
No

## Other information:

## Suggested addition to `tag-index`
(To avoid unnecessary merge conflicts, please don't update `tag-index`. One of the admins will do that when merging your pull request.)

pkg/ecco:
- added new generic integral function m_boxmean_vol to ecco_phys.F;
- edited ecco_check.F to include m_boxmean_vol;
