### PR TITLE
F90 module list generation

### DIFF
--- a/tools/f90mkdepend
+++ b/tools/f90mkdepend
@@ -15,8 +15,9 @@ cat /dev/null > f90mkdepend.log
 for filename in *.F90 *.F *.h; do
   # quick check for "use" to speed up processing
   if grep -i '^ *use ' $filename > /dev/null; then
+
     # extract module name in lower case
-    modreflist=$(grep -i '^ *use ' $filename | awk '{print tolower($2)}' | sed 's/,.*$//') 
+    modreflist=$(grep -i '^ *use ' $filename | awk '{print tolower($2)}' | sed 's/,.*$\|\r$//' | sed 's/\r$//')
 
     echo "$filename => $modreflist" >> f90mkdepend.log
 
@@ -32,7 +33,7 @@ for filename in *.F90 *.F *.h; do
         # source file name is module name without "_mod"
         depline="$depline ${m%_mod}.o"
       else
-        echo "WARNING: f90mkdepend: no source file found for module $m" 1>&2
+        echo "WARNING: in $filename f90mkdepend: no source file found for module $m" 1>&2
       fi
     done
     echo $depline

--- a/tools/f90mkdepend
+++ b/tools/f90mkdepend
@@ -17,7 +17,7 @@ for filename in *.F90 *.F *.h; do
   if grep -i '^ *use ' $filename > /dev/null; then
 
     # extract module name in lower case
-    modreflist=$(grep -i '^ *use ' $filename | awk '{print tolower($2)}' | sed 's/,.*$\|\r$//' | sed 's/\r$//')
+    modreflist=$(grep -i '^ *use ' $filename | awk '{print tolower($2)}' | sed 's/,.*$\|\r$//')
 
     echo "$filename => $modreflist" >> f90mkdepend.log
 
@@ -33,7 +33,7 @@ for filename in *.F90 *.F *.h; do
         # source file name is module name without "_mod"
         depline="$depline ${m%_mod}.o"
       else
-        echo "WARNING: in $filename f90mkdepend: no source file found for module $m" 1>&2
+        echo "WARNING: f90mkdepend: for $filename no source file found for module $m" 1>&2
       fi
     done
     echo $depline


### PR DESCRIPTION
## What changes does this PR introduce?
Bug in `f90mkdepend` tool. 

## What is the current behaviour? 
`modreflist` keeps a carriage return character if modules are loaded with a line break. This affects any code that has `USE <modulename>` type integration

Example module loading scenario for `blabla_do_something.F90`:
```
#include "BLABLA_OPTIONS.h"
...
    USE blablareadin,   only: read_some_stuff, blabla_var
    USE blablaphysics
...
```

`f90mkdepend` produces the following warning to error output:
```
WARNING: f90mkdepend: no source file found for module blablaphysics
```
and `f90mkdepend.log` (in vim) produces:
```
blabla_do_something.F90 => blablareadin
blablaphysics^M
```

This creates missing dependencies for `blabla_do_something.f90`, which leads to compilation errors.

## What is the new behaviour 
Updated `f90mkdepend` tool accounts for carriage returns when creating `modreflist`. Now `^M` is removed from module name `blablaphysics`

## Does this PR introduce a breaking change? 
Not that I know of

## Other information:
Tested using a package in development written in F90, with the current mitgcm code checkpoint, and on the verification problem `tutorial_global_oce_latlon`

## Suggested addition to `tag-index`