### PR TITLE
Fix barfile check at line 475

### DIFF
--- a/pkg/ecco/ecco_check.F
+++ b/pkg/ecco/ecco_check.F
@@ -472,7 +472,7 @@ c-- (upper/lower-case matters) in cost_gencost_customize
      &          (gencost_barfile(k)(1:17).EQ.'m_boxmean_ptracer').OR.
      &          (gencost_barfile(k)(1:16).EQ.'m_boxmean_shifwf').OR.
      &          (gencost_barfile(k)(1:16).EQ.'m_boxmean_shihtf').OR.
-     &          (gencost_barfile(k)(1:14).EQ.'m_horflux_vol')
+     &          (gencost_barfile(k)(1:13).EQ.'m_horflux_vol')
      &        )) then
             using_gencost(k)=.FALSE.
             il=ilnblnk(gencost_barfile(k))


### PR DESCRIPTION
Originally line 475 checked if gencost_barfile(k)(1:14) equals 'm_horflux_vol'. Now corrected to (1:13). This ran fine if the barfile == 'm_horflux_vol' but threw an error if there was a suffix to 'm_horflux_vol' eg 'm_horflux_vol_1'

## What changes does this PR introduce?
Bug fix 

## What is the current behaviour? 
If gencost_barfile = 'm_horflux_vol' plus a suffix, then the string compare fails and ecco_check sets use_gencost to False, turning off this costfunction.

## What is the new behaviour 
Now the string compare is corrected, barfiles such as 'm_horflux_vol_1' pass ecco_check successfully. This enables the user to have multiple barfiles with the same prefix in the same run.

## Does this PR introduce a breaking change? 
No

## Other information:

## Suggested addition to `tag-index`
(To avoid unnecessary merge conflicts, please don't update `tag-index`. One of the admins will do that when merging your pull request.)