### PR TITLE
reports "staf" server in experiment summary.txt

### DIFF
--- a/verification/testreport
+++ b/verification/testreport
@@ -585,9 +585,11 @@ makemodel()
 	fi
     fi
     if test $KIND = 1 -a -f taf_ftl.log ; then
+	grep 'Processing files at' make.tr_log | tail -1 >> $CDIR"/summary.txt"
 	head -1 taf_ftl.log >> $CDIR"/summary.txt"
     fi
     if test $KIND = 2 -a -f taf_ad.log ; then
+	grep 'Processing files at' make.tr_log | tail -1 >> $CDIR"/summary.txt"
 	head -1 taf_ad.log >> $CDIR"/summary.txt"
 	nerr=`grep -c 'TAF *.* ERROR ' taf_ad.log`
 	nwar=`grep -c '^TAF *.* RECOMPUTATION *.* WARNING ' taf_ad.log`


### PR DESCRIPTION
## What changes does this PR introduce?
Minor update to testreport: reports which TAF server is used in each experiment `summary.txt`

## What is the current behaviour? 
"staf" prints which server it uses in `build/make.tr_log` but this is not collected into the testreport output dir (sent by email when using "-a").

## What is the new behaviour 
add this 1 line report to each experiment `summary.txt` in testreport output dir.

## Does this PR introduce a breaking change? 
no

## Other information:
This might be useful information to collect after PR #649 got merged (since server is no longer explicitly scpecified in ad-optfile).

## Suggested addition to `tag-index`
none (minor update with no noticeable effect for almost all users)