### PR TITLE
Added in-situ salinity when solving S_b

### DIFF
--- a/doc/phys_pkgs/shelfice.rst
+++ b/doc/phys_pkgs/shelfice.rst
@@ -490,7 +490,7 @@ non-negative root is used. In the MITgcm code, the ice shelf salinity
    + (\epsilon_{q}  - \epsilon_{2}) \,S_{b} + \epsilon_{2}\,S \\
      S_{b} &= \frac{\epsilon_{2} - \epsilon_{q}\mp
      \sqrt{(\epsilon_{q}  - \epsilon_{2})^2
-     - 4\, a_{0}\,(\epsilon_{1} + \epsilon_{3})\,\epsilon_{2}}}
+     - 4\, a_{0}\,(\epsilon_{1} + \epsilon_{3})\,\epsilon_{2}\,S}}
      {2\,a_{0}\,(\epsilon_{1} + \epsilon_{3})}
    \end{aligned}
 


### PR DESCRIPTION
Corrected the solution for the quadratic equation of S_b.  In-situ salinity S is missing in the discriminant formula Discr= b**2 - 4ac, which should read: Discr = (\epsilon_{q}  - \epsilon_{2})^2 - 4\, a_{0}\,(\epsilon_{1} + \epsilon_{3})\,\epsilon_{2}\,S

NOTE: this is only a typo in the documentation.