### PR TITLE
Fix longstep initialization

### DIFF
--- a/doc/tag-index
+++ b/doc/tag-index
@@ -1,6 +1,9 @@
     Notes on tags used in MITgcmUV
     ==============================
 
+o pkg/longstep:
+  - fix initialization of LS_fwFlux ;
+  - move params report & check to new S/R LONGSTEP_CHECK.
 o model/src:
   - fix ocean r-star pressure gradient in case model top is not uniformly at r=0
   - update ref output of secondary test "isomip.obcs".

--- a/model/src/packages_check.F
+++ b/model/src/packages_check.F
@@ -41,6 +41,8 @@ C       |-- BBL_CHECK
 C       |
 C       |-- EXF_CHECK
 C       |
+C       |-- LONGSTEP_CHECK
+C       |
 C       |-- PTRACERS_CHECK
 C       |
 C       |-- GCHEM_CHECK
@@ -292,6 +294,10 @@ C---  Continue with standard packages (with standard usePKG flag)
 
 #ifndef ALLOW_FLT
       IF (useFLT) CALL PACKAGES_ERROR_MSG('FLT',' ',myThid)
+#endif
+
+#ifdef ALLOW_LONGSTEP
+      IF (usePTRACERS) CALL LONGSTEP_CHECK( myThid )
 #endif
 
 #ifdef ALLOW_PTRACERS

--- a/pkg/longstep/longstep_check.F
+++ b/pkg/longstep/longstep_check.F
@@ -1,0 +1,60 @@
+#include "LONGSTEP_OPTIONS.h"
+
+C---+----1----+----2----+----3----+----4----+----5----+----6----+----7-|--+----|
+CBOP
+C     !ROUTINE: LONGSTEP_CHECK
+
+C     !INTERFACE:
+      SUBROUTINE LONGSTEP_CHECK( myThid )
+
+C     !DESCRIPTION:
+C     Print summary of longstep parameters
+
+C     !USES:
+      IMPLICIT NONE
+#include "SIZE.h"
+#include "EEPARAMS.h"
+#include "LONGSTEP_PARAMS.h"
+#include "PARAMS.h"
+
+C     !INPUT PARAMETERS:
+      INTEGER myThid
+CEOP
+
+#ifdef ALLOW_LONGSTEP
+
+C     !LOCAL VARIABLES:
+C     msgBuf     :: message buffer
+      CHARACTER*(MAX_LEN_MBUF) msgBuf
+
+C---+----1----+----2----+----3----+----4----+----5----+----6----+----7-|--+----|
+
+      _BEGIN_MASTER(myThid)
+
+      WRITE(msgBuf,'(A)') 'LONGSTEP_CHECK: #define ALLOW_LONGSTEP'
+      CALL PRINT_MESSAGE( msgBuf, standardMessageUnit,
+     &                    SQUEEZE_RIGHT, myThid )
+
+      WRITE(msgBuf,'(A)') '// ==================================='
+      CALL PRINT_MESSAGE( msgBuf, standardMessageUnit,
+     &                    SQUEEZE_RIGHT, myThid )
+      WRITE(msgBuf,'(A)') '// longstep parameters '
+      CALL PRINT_MESSAGE( msgBuf, standardMessageUnit,
+     &                    SQUEEZE_RIGHT, myThid )
+      WRITE(msgBuf,'(A)') '// ==================================='
+      CALL PRINT_MESSAGE( msgBuf, standardMessageUnit,
+     &                    SQUEEZE_RIGHT, myThid )
+      CALL WRITE_0D_I( LS_nIter, INDEX_NONE,
+     &   'LS_nIter =',
+     &   ' /* number of dynamics steps between ptracer steps */')
+      CALL WRITE_0D_I( LS_whenToSample, INDEX_NONE,
+     &   'LS_whenToSample =',
+     &   ' /* 0: before; 1: after TD, before DYN; 2: after */')
+
+      _END_MASTER(myThid)
+      _BARRIER
+
+#endif /* ALLOW_LONGSTEP */
+
+      RETURN
+      END

--- a/pkg/longstep/longstep_check.F
+++ b/pkg/longstep/longstep_check.F
@@ -14,8 +14,8 @@ C     !USES:
       IMPLICIT NONE
 #include "SIZE.h"
 #include "EEPARAMS.h"
-#include "LONGSTEP_PARAMS.h"
 #include "PARAMS.h"
+#include "LONGSTEP_PARAMS.h"
 
 C     !INPUT PARAMETERS:
       INTEGER myThid
@@ -50,6 +50,22 @@ C---+----1----+----2----+----3----+----4----+----5----+----6----+----7-|--+----|
       CALL WRITE_0D_I( LS_whenToSample, INDEX_NONE,
      &   'LS_whenToSample =',
      &   ' /* 0: before; 1: after TD, before DYN; 2: after */')
+
+#ifdef EXACT_CONSERV
+      IF ( (nonlinFreeSurf.GT.0 .OR. usingPCoords)
+     &     .AND. useRealFreshWaterFlux .AND. staggerTimeStep
+     &     .AND. LS_whenToSample.LT.2 ) THEN
+        WRITE(msgBuf,'(2A)')
+     &     ' LONGSTEP: staggerTimeStep with EXACT_CONSERV,',
+     &     ' useRealFreshWaterFlux'
+        CALL PRINT_ERROR( msgBuf, myThid )
+        WRITE(msgBuf,'(2A)')
+     &     ' LONGSTEP: and nonlinFreeSurf or PCoords',
+     &     ' requires LS_whenToSample=2'
+        CALL PRINT_ERROR( msgBuf, myThid )
+        STOP 'ABNORMAL END: S/R LONGSTEP_INIT_FIXED'
+      ENDIF
+#endif /* EXACT_CONSERV */
 
       _END_MASTER(myThid)
       _BARRIER

--- a/pkg/longstep/longstep_forcing_surf.F
+++ b/pkg/longstep/longstep_forcing_surf.F
@@ -6,7 +6,7 @@ C !ROUTINE: LONGSTEP_FORCING_SURF
 C !INTERFACE: ==========================================================
       SUBROUTINE LONGSTEP_FORCING_SURF(
      I                            bi, bj, iMin, iMax, jMin, jMax,
-     I                            myTime,myIter,myThid )
+     I                            myTime, myIter, myThid )
 
 C !DESCRIPTION:
 C     Precomputes surface forcing term for pkg/ptracers.
@@ -18,14 +18,16 @@ C !USES: ===============================================================
 #include "SIZE.h"
 #include "EEPARAMS.h"
 #include "PARAMS.h"
-#include "GRID.h"
-#include "SURFACE.h"
-#include "FFIELDS.h"
+c #include "GRID.h"
+c #include "SURFACE.h"
+c #include "FFIELDS.h"
 c #include "DYNVARS.h"
-#include "PTRACERS_SIZE.h"
-#include "PTRACERS_PARAMS.h"
-#include "PTRACERS_FIELDS.h"
 #include "LONGSTEP.h"
+#ifdef ALLOW_PTRACERS
+# include "PTRACERS_SIZE.h"
+# include "PTRACERS_PARAMS.h"
+# include "PTRACERS_FIELDS.h"
+#endif
 
 C !INPUT PARAMETERS: ===================================================
 C  bi,bj                :: tile indices
@@ -38,6 +40,7 @@ C  myThid               :: thread number
       INTEGER myThid
 
 #ifdef ALLOW_LONGSTEP
+#ifdef ALLOW_PTRACERS
 
 C !LOCAL VARIABLES: ====================================================
 C  i,j                  :: loop indices
@@ -154,6 +157,7 @@ C-    end local-surface-tracer / uniform-value distinction
 
 C---+----1----+----2----+----3----+----4----+----5----+----6----+----7-|--+----|
 
+#endif /* ALLOW_PTRACERS */
 #endif /* ALLOW_LONGSTEP */
 
       RETURN

--- a/pkg/longstep/longstep_init_fixed.F
+++ b/pkg/longstep/longstep_init_fixed.F
@@ -7,14 +7,13 @@ C     !INTERFACE:
       SUBROUTINE LONGSTEP_INIT_FIXED( myThid )
 
 C     !DESCRIPTION:
-C     Initialize longstep constant
+C     Initialize longstep constants
 
 C     !USES:
       IMPLICIT NONE
 #include "SIZE.h"
 #include "EEPARAMS.h"
 #include "PARAMS.h"
-#include "LONGSTEP_PARAMS.h"
 
 C     !INPUT PARAMETERS:
       INTEGER myThid
@@ -23,31 +22,6 @@ CEOP
 #ifdef ALLOW_LONGSTEP
 
 C     !LOCAL VARIABLES:
-      CHARACTER*(MAX_LEN_MBUF) msgBuf
-
-C     whether to average EmPmR or PmEpR in LS_fwFlux
-#ifdef EXACT_CONSERV
-      IF ( (nonlinFreeSurf.GT.0 .OR. usingPCoords)
-     &     .AND. useRealFreshWaterFlux ) THEN
-        LS_usePmEpR = .TRUE.
-C     can only do LS_staggerTimeStep if staggerTimeStep
-        IF ( staggerTimeStep .AND. LS_whenToSample.LT.2 ) THEN
-          WRITE(msgBuf,'(2A)')
-     &       ' LONGSTEP: staggerTimeStep with EXACT_CONSERV,',
-     &       ' useRealFreshWaterFlux'
-          CALL PRINT_ERROR( msgBuf, myThid )
-          WRITE(msgBuf,'(2A)')
-     &       ' LONGSTEP: and nonlinFreeSurf or PCoords',
-     &       ' requires LS_whenToSample=2'
-          CALL PRINT_ERROR( msgBuf, myThid )
-          STOP 'ABNORMAL END: S/R LONGSTEP_INIT_FIXED'
-        ENDIF
-      ELSE
-#else /* EXACT_CONSERV */
-      IF (.TRUE.) THEN
-#endif /* EXACT_CONSERV */
-        LS_usePmEpR = .FALSE.
-      ENDIF
 
 #ifdef ALLOW_DIAGNOSTICS
       IF ( useDiagnostics ) THEN

--- a/pkg/longstep/longstep_init_varia.F
+++ b/pkg/longstep/longstep_init_varia.F
@@ -51,6 +51,7 @@ C     initialize longstep averages to zero
 #ifdef SHORTWAVE_HEATING
       CALL LONGSTEP_RESET_3D(LS_QswCount, LS_Qsw, 1, myThid)
 #endif
+      CALL LONGSTEP_RESET_3D(LS_fwFluxCount,LS_fwFlux,1,myThid)
 #ifdef ALLOW_GMREDI
       IF ( useGMRedi ) THEN
        CALL LONGSTEP_RESET_3D(LS_KwxCount, LS_Kwx, Nr, myThid)

--- a/pkg/longstep/longstep_readparms.F
+++ b/pkg/longstep/longstep_readparms.F
@@ -14,8 +14,8 @@ C     !USES:
       IMPLICIT NONE
 #include "SIZE.h"
 #include "EEPARAMS.h"
-#include "LONGSTEP_PARAMS.h"
 #include "PARAMS.h"
+#include "LONGSTEP_PARAMS.h"
 
 C     !INPUT PARAMETERS:
       INTEGER myThid
@@ -85,6 +85,14 @@ C     Close the open data file
 C     Now set-up any remaining parameters that result from the input
 C     parameters
 
+C     whether to average EmPmR or PmEpR in LS_fwFlux
+#ifdef EXACT_CONSERV
+      LS_usePmEpR = (nonlinFreeSurf.GT.0 .OR. usingPCoords)
+     &              .AND. useRealFreshWaterFlux
+#else /* EXACT_CONSERV */
+      LS_usePmEpR = .FALSE.
+#endif /* EXACT_CONSERV */
+
       _END_MASTER(myThid)
 C     Everyone else must wait for the parameters to be loaded
       _BARRIER
@@ -93,4 +101,3 @@ C     Everyone else must wait for the parameters to be loaded
 
       RETURN
       END
-

--- a/pkg/longstep/longstep_readparms.F
+++ b/pkg/longstep/longstep_readparms.F
@@ -85,23 +85,6 @@ C     Close the open data file
 C     Now set-up any remaining parameters that result from the input
 C     parameters
 
-C--   Print a summary of longstep parameter values:
-      iUnit = standardMessageUnit
-      WRITE(msgBuf,'(A)') '// ==================================='
-      CALL PRINT_MESSAGE( msgBuf, iUnit, SQUEEZE_RIGHT , myThid )
-      WRITE(msgBuf,'(A)') '// longstep parameters '
-      CALL PRINT_MESSAGE( msgBuf, iUnit, SQUEEZE_RIGHT , myThid )
-      WRITE(msgBuf,'(A)') '// ==================================='
-      CALL PRINT_MESSAGE( msgBuf, iUnit, SQUEEZE_RIGHT , myThid )
-      CALL WRITE_0D_I( LS_nIter, INDEX_NONE,
-     &   'LS_nIter =',
-     &   ' /* number of dynamics steps between ptracer steps */')
-      CALL WRITE_0D_I( LS_whenToSample, INDEX_NONE,
-     &   'LS_whenToSample =',
-     &   ' /* 0: before; 1: after TD, before DYN; 2: after */')
-      WRITE(msgBuf,'(A)') ' -----------------------------------'
-      CALL PRINT_MESSAGE( msgBuf, iUnit, SQUEEZE_RIGHT, myThid )
-
       _END_MASTER(myThid)
 C     Everyone else must wait for the parameters to be loaded
       _BARRIER


### PR DESCRIPTION
## What changes does this PR introduce?

Bug fix

## What is the current behaviour? 

LS_fwFlux is not initialized.

## What is the new behaviour 

It is initialized.

## Does this PR introduce a breaking change? 

No

## Other information:

Logging of longstep package parameters is moved to a new s/r longstep_check, called from packages_check, so that it appears in the right place in the model output.