### PR TITLE
get nonzero xx_si controls

### DIFF
--- a/model/src/initialise_varia.F
+++ b/model/src/initialise_varia.F
@@ -91,6 +91,10 @@ C     == Global variables ==
 # include "GRID.h"
 # include "FFIELDS.h"
 # include "CTRL_FIELDS.h"
+# ifdef ALLOW_SEAICE
+#  include "SEAICE_SIZE.h"
+#  include "SEAICE.h"
+# endif
 # if (defined ALLOW_SHELFICE) && (defined ALLOW_GENARR2D_CONTROL)
 #  include "SHELFICE.h"
 # endif
@@ -182,6 +186,10 @@ C--   Initialize variable data for packages
 #ifdef ALLOW_AUTODIFF_TAMC
 # ifdef NONLIN_FRSURF
 CADJ STORE recip_hFacC = tapelev_init, key = 1
+# endif
+# ifdef ALLOW_SEAICE
+CADJ STORE area = tapelev_init, key = 1
+CADJ STORE heff = tapelev_init, key = 1
 # endif
 # if (defined ALLOW_SHELFICE) && (defined ALLOW_GENARR2D_CONTROL)
 CADJ STORE shelficeFreshwaterFlux = tapelev_init, key = 1

--- a/pkg/autodiff/adcommon.h
+++ b/pkg/autodiff/adcommon.h
@@ -118,6 +118,18 @@ C Special Care: more forward vars in FWD common block ; check TAF AD-code !
       _RL  adBottomDragFld (1-OLx:sNx+OLx,1-OLy:sNy+OLy,nSx,nSy)
 #endif
 
+#ifdef ALLOW_SEAICE
+      COMMON /ADCTRL_FIELDS_SIHEFF/
+     &                adsihefffld
+      _RL  adsihefffld (1-OLx:sNx+OLx,1-OLy:sNy+OLy,nSx,nSy)
+      COMMON /ADCTRL_FIELDS_SIAREA/
+     &                adsiareafld
+      _RL  adsiareafld (1-OLx:sNx+OLx,1-OLy:sNy+OLy,nSx,nSy)
+      COMMON /ADCTRL_FIELDS_SIHSNOW/
+     &                adsihsnowfld
+      _RL  adsihsnowfld (1-OLx:sNx+OLx,1-OLy:sNy+OLy,nSx,nSy)
+#endif
+
 #ifdef ALLOW_EXF
 
       _RL adustress(1-OLx:sNx+OLx,1-OLy:sNy+OLy,nSx,nSy)

--- a/pkg/autodiff/addummy_in_stepping.F
+++ b/pkg/autodiff/addummy_in_stepping.F
@@ -17,6 +17,9 @@
 #ifdef ALLOW_SHELFICE
 # include "SHELFICE_OPTIONS.h"
 #endif
+#ifdef ALLOW_SEAICE
+# include "SEAICE_OPTIONS.h"
+#endif
 #include "AD_CONFIG.h"
 
 CBOP
@@ -157,6 +160,11 @@ C--   need to all the correct OpenAD EXCH S/R ; left empty for now
 # ifdef ALLOW_BOTTOMDRAG_CONTROL
         call adexch_xy_rl( myThid,adbottomdragfld)
 # endif
+# ifdef ALLOW_SEAICE
+        call adexch_xy_rl( myThid,adsihefffld)
+        call adexch_xy_rl( myThid,adsiareafld)
+        call adexch_xy_rl( myThid,adsihsnowfld)
+# endif
 # else /* ndfef AUTODIFF_TAMC_COMPATIBILITY */
 
 #  ifndef ALLOW_BULK_OFFLINE
@@ -205,6 +213,12 @@ C     problem occurs
 #  else
         CALL ADEXCH_XY_RL( adshiCDragFld, myThid )
 #  endif
+# endif
+
+# ifdef ALLOW_SEAICE
+        call ADEXCH_XY_RL( adsiheffFld, myThid )
+        call ADEXCH_XY_RL( adsiareaFld, myThid )
+        call ADEXCH_XY_RL( adsihsnowFld, myThid )
 # endif
 
 #endif /* AUTODIFF_TAMC_COMPATIBILITY */
@@ -312,6 +326,17 @@ C-----------------------------------------------------------------------
      &                 'ADJshicd','ADJshicd.',
      &                 12, doDump, dumpAdRecMn, myTime, myIter,myThid)
 #  endif
+# endif
+# ifdef ALLOW_SEAICE
+        call DUMP_ADJ_XY(dumRS, adsiheffFld,
+     &                 'ADJsihef','ADJsihef.',
+     &                 12, doDump, dumpAdRecMn, myTime, myIter,myThid)
+        call DUMP_ADJ_XY(dumRS, adsiareaFld,
+     &                 'ADJsiare','ADJsiare.',
+     &                 12, doDump, dumpAdRecMn, myTime, myIter,myThid)
+        call DUMP_ADJ_XY(dumRS, adsihsnowFld,
+     &                 'ADJsihsn','ADJsihsn.',
+     &                 12, doDump, dumpAdRecMn, myTime, myIter,myThid)
 # endif
 
 # ifdef ALLOW_DEPTH_CONTROL
@@ -426,6 +451,17 @@ C-----------------------------------------------------------------------
      &                 12, doDump, dumpAdRecMn, myTime, myIter,myThid)
 #  endif
 # endif
+# ifdef ALLOW_SEAICE
+        call DUMP_ADJ_XY(dumRS, adsiheffFld%d,
+     &                 'ADJsihef','ADJsihef.',
+     &                 12, doDump, dumpAdRecMn, myTime, myIter,myThid)
+        call DUMP_ADJ_XY(dumRS, adsiareaFld%d,
+     &                 'ADJsiare','ADJsiare.',
+     &                 12, doDump, dumpAdRecMn, myTime, myIter,myThid)
+        call DUMP_ADJ_XY(dumRS, adsihsnowFld%d,
+     &                 'ADJsihsn','ADJsihsn.',
+     &                 12, doDump, dumpAdRecMn, myTime, myIter,myThid)
+# endif
 
 # ifdef ALLOW_DEPTH_CONTROL
       CALL DUMP_ADJ_XYZ(
@@ -494,6 +530,20 @@ C=======================================================================
      &                                        var2Du, 1, 12, myThid )
           CALL MNC_CW_RL_W('D','adstate',0,0,
      &                     'adBottomDrag', var2Du, myThid)
+#endif
+#ifdef ALLOW_SEAICE
+          CALL COPY_ADVAR_OUTP( dumRS, adsiheffFld,
+     &                                        var2Du, 1, 13, myThid )
+          CALL MNC_CW_RL_W('D','adstate',0,0,
+     &                     'adsiheff', var2Du, myThid)
+          CALL COPY_ADVAR_OUTP( dumRS, adsiareaFld,
+     &                                        var2Du, 1, 14, myThid )
+          CALL MNC_CW_RL_W('D','adstate',0,0,
+     &                     'adsiarea', var2Du, myThid)
+          CALL COPY_ADVAR_OUTP( dumRS, adsihsnowFld,
+     &                                        var2Du, 1, 15, myThid )
+          CALL MNC_CW_RL_W('D','adstate',0,0,
+     &                     'adsihsnow', var2Du, myThid)
 #endif
 #ifdef ALLOW_DIFFKR_CONTROL
           CALL COPY_ADVAR_OUTP( dumRS, adDiffKr,var3Du, Nr, 12,myThid )

--- a/pkg/autodiff/common.flow
+++ b/pkg/autodiff/common.flow
@@ -104,3 +104,12 @@ c$taf COMMON GM_INP_K3D_REDI FTLNAME = g_GM_INP_K3D_REDI
 
 c$taf COMMON ctrl_fields_bottomdrag  ADNAME = adctrl_fields_bottomdrag
 c$taf COMMON ctrl_fields_bottomdrag FTLNAME = g_ctrl_fields_bottomdrag
+
+c$taf COMMON ctrl_fields_siheff  ADNAME = adctrl_fields_siheff
+c$taf COMMON ctrl_fields_siheff FTLNAME = g_ctrl_fields_siheff
+
+c$taf COMMON ctrl_fields_siarea  ADNAME = adctrl_fields_siarea
+c$taf COMMON ctrl_fields_siarea FTLNAME = g_ctrl_fields_siarea
+
+c$taf COMMON ctrl_fields_sihsnow  ADNAME = adctrl_fields_sihsnow
+c$taf COMMON ctrl_fields_sihsnow FTLNAME = g_ctrl_fields_sihsnow

--- a/pkg/ctrl/ctrl_cost_gen.F
+++ b/pkg/ctrl/ctrl_cost_gen.F
@@ -66,6 +66,7 @@ c     == local variables ==
       integer imin,imax
       integer nrec
       integer irec
+      integer lrec
       integer ilfld
 
       _RL fctile
@@ -129,14 +130,17 @@ c--   >>> Loop 1 to compute mean forcing:
       enddo
 
 c--   >>> Loop over records.
+catn: this is the cost of xx_*.00 , so it needs to loop
+catn over the same records startrec:endrec and not 1:Nrec
       do irec = 1,nrec
+        lrec=startrec+irec-1
 
 #ifdef ALLOW_AUTODIFF
         call active_read_xy(
-     &        fnamefld, tmpfld2d, irec, doglobalread,
+     &        fnamefld, tmpfld2d, lrec, doglobalread,
      &        ladinit, optimcycle, myThid, xx_gen_dummy )
 #else
-        CALL READ_REC_XY_RL( fnamefld, tmpfld2d, iRec, 1, myThid )
+        CALL READ_REC_XY_RL( fnamefld, tmpfld2d, lRec, 1, myThid )
 #endif
 
 c--     Loop over this thread tiles.

--- a/pkg/ctrl/ctrl_get_gen.F
+++ b/pkg/ctrl/ctrl_get_gen.F
@@ -177,6 +177,11 @@ cph Initial wind stress adjustments are too vigorous.
       xx_swdown_file     = 'xx_swdown'
 
       if ( gencount0 .LE. 2 .AND. (
+c OW edit
+#ifdef ALLOW_AUTODIFF
+     &   nIter0 .LE. 1 .AND. 
+#endif
+c OW
 #ifdef CTRL_SKIP_FIRST_TWO_ATM_REC_ALL
      &       xx_gen_file(1:6) .EQ. xx_aqh_file  .OR.
      &       xx_gen_file(1:8) .EQ. xx_atemp_file .OR.

--- a/pkg/ctrl/ctrl_get_gen_rec.F
+++ b/pkg/ctrl/ctrl_get_gen_rec.F
@@ -67,7 +67,9 @@ C     == local variables ==
       integer fldstartdate(4)
       _RL     fldperiod
 
-c     integer startrec
+#ifdef ECCO_VERBOSE
+      integer startrec
+#endif
 
       integer year0
       integer year1
@@ -129,12 +131,16 @@ C     fldperiod .ne. 0
 C--   Determine the current date.
        call cal_GetDate( myiter, mytime, mydate, mythid )
 
-C     Determine first record:
-c      call cal_TimePassed( fldstartdate, modelstartdate,
-c    &                      difftime, mythid )
-c      call cal_ToSeconds ( difftime, fldsecs, mythid )
-c      startrec = int((modelstart + startTime - fldsecs)/
-c    &                fldperiod) + 1
+#ifdef ECCO_VERBOSE
+catn this block was commented out as we no longer use startrec,
+catn but put back as the number is useful for debugging
+c     Determine first record:
+      call cal_TimePassed( fldstartdate, modelstartdate,
+     &                      difftime, mythid )
+      call cal_ToSeconds ( difftime, fldsecs, mythid )
+      startrec = int((modelstart + startTime - fldsecs)/
+     &                fldperiod) + 1
+#endif /* ECCO_VERBOSE */
 
 C     Determine the flux record just before mycurrentdate.
        call cal_TimePassed( fldstartdate, mydate, difftime,
@@ -165,8 +171,11 @@ C     Set switches for reading new records.
         endif
        endif
 
-       count0 = fldcount
-       count1 = fldcount + 1
+catn: undoing ts PR260
+c      count0 = fldcount
+c      count1 = fldcount + 1
+       count0 = fldcount - startrec + 1
+       count1 = fldcount - startrec + 2
 
        call cal_TimeInterval( fldsecs, 'secs', difftime, mythid )
        call cal_AddTime( fldstartdate, difftime, flddate, mythid )
@@ -231,6 +240,10 @@ C     Do some printing for the protocol.
         call print_message( msgbuf, standardmessageunit,
      &                      SQUEEZE_RIGHT , mythid)
         write(msgbuf,'(a)') ' '
+        call print_message( msgbuf, standardmessageunit,
+     &                      SQUEEZE_RIGHT , mythid)
+        write(msgbuf,'(a,1x,i10)') 
+     &               'CTRL_GET_GEN_REC startrec: ',startrec
         call print_message( msgbuf, standardmessageunit,
      &                      SQUEEZE_RIGHT , mythid)
       _END_MASTER( mythid )

--- a/pkg/ctrl/ctrl_init.F
+++ b/pkg/ctrl/ctrl_init.F
@@ -312,10 +312,11 @@ C
      &       diffrecFull, startrec, endrecFull,
      &       snx, sny, 1, ncvargrdtmp, 'xy', myThid )
 C
+catn: make length of adxx_.00 to be of length endrec
         call ctrl_init_ctrlvar (
      &       xx_gentim2d_file(iarr)(1:MAX_LEN_FNAM),
      &       300+iarr, 400+iarr,
-     &       diffrec, startrec, endrec,
+     &       endrec, 1, endrec,
      &       snx, sny, 1, ncvargrdtmp, 'xy', myThid )
 C
 #ifndef ALLOW_OPENAD

--- a/pkg/ctrl/ctrl_map_ini_genarr.F
+++ b/pkg/ctrl/ctrl_map_ini_genarr.F
@@ -11,6 +11,9 @@
 #ifdef ALLOW_DIC
 # include "DIC_OPTIONS.h"
 #endif
+#ifdef ALLOW_SEAICE
+# include "SEAICE_OPTIONS.h"
+#endif
 
 CBOP
 C     !ROUTINE: CTRL_MAP_INI_GENARR
@@ -59,6 +62,12 @@ C     == global variables ==
 #if (defined ALLOW_DIC && defined DIC_BIOTIC)
 # include "DIC_VARS.h"
 #endif
+CAB
+#ifdef ALLOW_SEAICE 
+#  include "SEAICE_SIZE.h"
+#  include "SEAICE.h"
+#endif
+CAB
 
 C     !INPUT/OUTPUT PARAMETERS:
 C     == routine arguments ==
@@ -91,6 +100,9 @@ C     == local variables ==
 # if (defined ALLOW_DIC && defined DIC_BIOTIC)
       INTEGER igen_alpha
 # endif
+# ifdef ALLOW_SEAICE
+      INTEGER igen_siarea,igen_siheff
+# endif
 #endif /* ALLOW_GENARR2D_CONTROL */
 #ifdef ALLOW_GENARR3D_CONTROL
       INTEGER igen_theta0, igen_salt0
@@ -120,6 +132,12 @@ C--   generic 2D control variables
       igen_b_glen=0
       igen_h_streamice=0
 #endif
+CAB
+#ifdef ALLOW_SEAICE
+      igen_siarea=0
+      igen_siheff=0
+#endif
+CAB
       DO iarr = 1, maxCtrlArr2D
        IF (xx_genarr2d_weight(iarr).NE.' ') THEN
         IF (xx_genarr2d_file(iarr)(1:7).EQ.'xx_etan')
@@ -149,6 +167,14 @@ C--   generic 2D control variables
         IF (xx_genarr2d_file(iarr)(1:11).EQ.'xx_alpha')
      &     igen_alpha=iarr
 #endif
+CAB
+#ifdef ALLOW_SEAICE
+        IF (xx_genarr2d_file(iarr)(1:9).EQ.'xx_siarea')
+     &     igen_siarea=iarr
+        IF (xx_genarr2d_file(iarr)(1:9).EQ.'xx_siheff')
+     &     igen_siheff=iarr
+#endif
+CAB
        ENDIF
       ENDDO
 
@@ -230,6 +256,15 @@ C--      u* drag coefficient
       IF (igen_alpha.GT.0)
      &  CALL CTRL_MAP_GENARR2D( alpha, igen_alpha, myThid )
 #endif
+
+CAB
+#ifdef ALLOW_SEAICE
+      IF (igen_siarea.GT.0)
+     &  CALL CTRL_MAP_GENARR2D(AREA,igen_siarea,myThid)
+      IF (igen_siheff.GT.0)
+     &  CALL CTRL_MAP_GENARR2D(HEFF,igen_siheff,myThid)
+#endif
+CAB
 
 #endif /* ALLOW_GENARR2D_CONTROL */
 

--- a/pkg/ctrl/ctrl_map_ini_gentim2d.F
+++ b/pkg/ctrl/ctrl_map_ini_gentim2d.F
@@ -58,7 +58,7 @@ C     == local variables ==
       integer startrec
       integer endrec
       integer diffrec
-      integer irec, jrec, krec
+      integer irec, jrec, krec, lrec
       integer replicated_nrec
       integer replicated_ntimes
       logical doglobalread
@@ -77,6 +77,9 @@ C     == local variables ==
       integer i,j,k2
       integer ilgen
 CEOP
+
+      IF (debugMode)
+     &   CALL DEBUG_CALL('CTRL_MAP_INI_GENTIM2D',myThid)
 
 c--   Now, read the control vector.
       doglobalread = .false.
@@ -117,6 +120,20 @@ C--   generic 2D control variables
      O       diffrec, startrec, endrec,
      I       myThid )
 
+catn: there is a copy of this code as ctrl_map_ini_gentim2dmd
+catn: so that this code is actually not called but a version of
+catn: it is found in ad_taf_output.  At the end of the above
+catn: ctrl_init_rec call, we get [start,end,diff]rec. So what
+catn: we need to make sure next is that when we read from
+catn: xx_atemp.0000000001.data, read from startrec:endrec, then
+catn: write out to xx_atemp.effective.0000000001.data as as
+catn: 1:diffrec. Note that the version of this in ad_taf_output.f
+catn: strips all the misc write statements so it appears as if
+catn: we did not go past here, but we did.
+catn
+catn        write(*,*) 'AA: iarr,xx_gentim2d_startdate(1,iarr): ',
+catn     &              iarr,xx_gentim2d_startdate(1,iarr)
+catn
         dosmooth=.false.
         dowc01  = .false.
         doscaling=.true.
@@ -166,21 +183,46 @@ c--   docycle
          endif
         enddo
 
-        DO jrec = 1,replicated_ntimes+1
-         DO irec = 1,replicated_nrec
+catn        write(*,'(A,1x,5I6)') 
+catn     &   'AD:[start,end,diff]rec, replicated_[nrec,ntimes]: ',
+catn     &              startrec, endrec, diffrec, 
+catn     &              replicated_nrec,replicated_ntimes
+catn
+        DO jrec = 1, replicated_ntimes+1
+         DO irec = 1, replicated_nrec
 #ifdef ALLOW_AUTODIFF_TAMC
 CADJ STORE xx_gentim2d_dummy = dummytape, key = 1 , kind = isbyte
 #endif
           krec=replicated_nrec*(jrec-1)+irec
+          lrec=startrec+irec-1
           IF (krec.LE.endrec) THEN
+catn         ilgen=ilnblnk( fnamegenIn )
+catn         write(*,*) 'AE: iarr,[i,j,k,l]rec: ',iarr,irec,jrec,lrec
+catn         write(*,*) 'AF: fnamegenIn: ', fnamegenIn(1:ilgen)
+catn: fnamegenIn is xx_atemp.0000000001, so we need to read
+catn: from startrec+irec-1 instead of irec in the call below
+catn: HOWEVER, the problem is that in the adjoint mode, the function
+catn  adactive_read_xy is called to read in adxx_atemp.0000000001
+catn  instead xx_atemp.0000000001, in which case the records need to
+catn  be diffrec:-1:1 instead of of endrec:-1:startrec.  The question 
+catn  is how can we separate that out? Can we make use of the flag 
+catn  FORWARD_SIMULATION and REVERSE_SIMULATION?
+catn  The solution now is that we make adxx file of length 1:endrec,
+catn  so that we can access record endrec:-1:startrec. The rest of
+catn  the records startec-1:-1:1 should be all zeros.
 #ifdef ALLOW_AUTODIFF
-           CALL ACTIVE_READ_XY( fnamegenIn, xx_gen, irec,
+           CALL ACTIVE_READ_XY( fnamegenIn, xx_gen, lrec,
      &          doglobalread, ladinit, optimcycle,
      &          myThid, xx_gentim2d_dummy(iarr) )
 #else
-           CALL READ_REC_XY_RL( fnamegenIn, xx_gen, iRec, 1, myThid )
+           CALL READ_REC_XY_RL( fnamegenIn, xx_gen, lRec, 1, myThid )
 #endif
+catn: now here, we write xx_atemp.effective.0000000001, so 
+catn: the krec is the correct record, no mod here
 #ifdef ALLOW_AUTODIFF
+catn         ilgen=ilnblnk( fnamegenOut )
+catn         write(*,*) 'AG: iarr,[i,j,k]rec: ',iarr,irec,jrec,krec
+catn         write(*,*) 'AH: fnamegenOut: ', fnamegenOut(1:ilgen)
            CALL ACTIVE_WRITE_XY( fnamegenOut, xx_gen, krec, optimcycle,
      &          myThid, xx_gentim2d_dummy(iarr) )
 #else
@@ -208,7 +250,9 @@ c--   rmcycle
          endif
         enddo
 
-c     print*,'endrec',endrec,replicated_ntimes,replicated_nrec
+catn        write(*,'(A,1x,5I6)'),
+catn     &  'AI:[start,end,diff]rec, replicated_[nrec,ntimes]: ',
+catn     &      startrec,endrec,diffrec,replicated_nrec,replicated_ntimes
 
         IF (replicated_ntimes.GT.0) THEN
 
@@ -217,7 +261,7 @@ c     create cyclic average
          nyearsINT=1+int((endrec-replicated_nrec)/replicated_nrec)
          recip_nyearsRL=1. _d 0/float(nyearsINT)
 
-c     print*,'nyearsINT',nyearsINT,nyearsRL
+catn        write(*,*) 'AJ: nyears[INT,RL]: ',nyearsINT,nyearsRL
 
          DO irec = 1, replicated_nrec
 
@@ -236,6 +280,9 @@ c     print*,'nyearsINT',nyearsINT,nyearsRL
 CADJ STORE xx_gentim2d_dummy = dummytape, key = 1 , kind = isbyte
 #endif
            krec=irec+(jrec-1)*replicated_nrec
+catn           write(*,*) 'AK: iarr,[i,j,k]rec: ',iarr,irec,jrec,krec
+catn           ilgen=ilnblnk( fnamegenOut )
+catn           write(*,*) 'AL: fnamegenOut: ',fnamegenOut(1:ilgen)
 #ifdef ALLOW_AUTODIFF
            call active_read_xy( fnamegenOut, xx_gen_tmp, krec,
      &          doglobalread, ladinit, optimcycle,
@@ -287,6 +334,9 @@ c     subtract cyclic average
 CADJ STORE xx_gentim2d_dummy = dummytape, key = 1 , kind = isbyte
 #endif
            krec=replicated_nrec*(jrec-1)+irec
+catn        write(*,*) 'AM: iarr,[i,j,k]rec: ',iarr,irec,jrec,krec
+catn        ilgen=ilnblnk( fnamegenOut )
+catn        write(*,*) 'AN: fnamegenOut: ',fnamegenOut(1:ilgen)
            IF (krec.LE.endrec) THEN
 #ifdef ALLOW_AUTODIFF
             CALL active_read_xy( fnamegenOut, xx_gen, kRec,
@@ -329,11 +379,19 @@ CADJ STORE xx_gentim2d_dummy = dummytape, key = 1 , kind = isbyte
 
 c--   scaling and smoothing
 
+catn: so, the fix for xx_atemp.0000000001 was already above
+catn: From now on, we read in from xx_atemp.effective.0000000001
+catn: so we no longer need to fix any record from here on out
         DO irec = 1, diffrec
 #ifdef ALLOW_AUTODIFF_TAMC
 CADJ STORE xx_gentim2d_dummy = dummytape, key = 1 , kind = isbyte
 #endif
 
+catn        ilgen=ilnblnk( fnamegenOut )
+catn        lrec=startrec+irec-1
+catn        write(*,'(A,1x,A,1x,2I6)') 'AO: fnamegenOut, irec,lrec ',
+catn     &      fnamegenOut(1:ilgen),irec,lrec
+catn
 #ifdef ALLOW_AUTODIFF
          call active_read_xy( fnamegenOut, xx_gen, irec,
      &        doglobalread, ladinit, optimcycle,
@@ -344,8 +402,14 @@ CADJ STORE xx_gentim2d_dummy = dummytape, key = 1 , kind = isbyte
 
 #ifndef ALLOW_OPENAD
          jrec=1
+catn: what should we do with the timevariable weights? do we ever
+catn: have this situation?  not sure how to fix this.  The fix
+catn: needs to be inside the do k2 loop
          do k2 = 1, maxCtrlProc
-          if (xx_gentim2d_preproc(k2,iarr).EQ.'variaweight') jrec=irec
+          if (xx_gentim2d_preproc(k2,iarr).EQ.'variaweight') then
+catn            jrec=irec
+            jrec=startrec+irec-1
+          endif
          enddo
          CALL READ_REC_3D_RL( xx_gentim2d_weight(iarr), ctrlprec, 1,
      &             wgentim2d(1-OLx,1-OLy,1,1,iarr), jrec, 1, myThid )
@@ -384,6 +448,9 @@ C--   Get appropriate mask
 
          CALL EXCH_XY_RL ( xx_gen , myThid )
 
+catn        ilgen=ilnblnk( fnamegenOut )
+catn        write(*,'(A,1x,I6,1x,A)') 
+catn     &     'AQ: irec,fnamegenOut: ',irec,fnamegenOut(1:ilgen)
 #ifdef ALLOW_AUTODIFF
          call active_write_xy( fnamegenOut, xx_gen, irec, optimcycle,
      &        myThid, xx_gentim2d_dummy(iarr) )
@@ -402,6 +469,8 @@ c--   end iarr loop
       ENDDO
 
 #endif /* ALLOW_GENTIM2D_CONTROL */
+      IF (debugMode)
+     &   CALL DEBUG_LEAVE('CTRL_MAP_INI_GENTIM2D',myThid)
 
       RETURN
       END


### PR DESCRIPTION
## What changes does this PR introduce?
Enable nonzero xx_ controls for sea ice


## What is the current behaviour? 
xx_[siarea,siheff] for sea ice are all zeros even though we get nonzero ADJ[heff,area]


## What is the new behaviour 
non-zero xx_si[area,heff] that matches corresponding ADJ at initial time.


## Does this PR introduce a breaking change? 
No expected breaking.


## Other information:
credit: Arash Bigdeli


## Suggested addition to `tag-index`
(To avoid unnecessary merge conflicts, please don't update `tag-index`. One of the admins will do that when merging your pull request.)