### PR TITLE
Fix front_relax "data.mpi" addition from PR-643

### DIFF
--- a/verification/front_relax/input/data.mpi
+++ b/verification/front_relax/input/data.mpi
@@ -4,7 +4,7 @@
 #
 # Continuous equation parameters
  &PARM01
- tRef= 29., 28., 27., 26., 25., 24., 23., 22., 21., 20., 19., 18., 17., 16., 15., 10*0.,
+ tRef= 25*17.5,
  viscAr=2.E-4,
  viscAh=3.E+2,
  no_slip_sides=.FALSE.,
@@ -31,6 +31,7 @@
  staggerTimeStep=.TRUE.
  tempAdvScheme=20,
  saltAdvScheme=20,
+#momStepping=.FALSE.,
  readBinaryPrec=64,
  writeBinaryPrec=64,
  useSingleCpuIO=.TRUE.,


### PR DESCRIPTION
In experiment `front_relax/input", import` changes from "data" into "data.mpi" so that, apart from globalFiles/useSingleCpuIO switch, these 2 files stay identical. 

This was left behind in latest "data" update from PR #643

## What changes does this PR introduce?
fix a customized parameter file "data.mpi"

## What is the current behaviour? 
forgot to update this file when updated "data" (in same dir).

## What is the new behaviour 
fixed

## Does this PR introduce a breaking changes?
no

## Other information:

## Suggested addition to `tag-index`
none if merged just after PR #643