### PR TITLE
Bump python version for doc build check

### DIFF
--- a/.github/workflows/build_testing.yml
+++ b/.github/workflows/build_testing.yml
@@ -147,7 +147,7 @@ jobs:
      - name: Set up Python
        uses: actions/setup-python@v2
        with:
-         python-version: 3.6
+         python-version: 3.11
 
      - name: install dependencies
        run: tools/ci/install_doc_dependencies.sh
@@ -169,7 +169,7 @@ jobs:
      - name: Set up Python
        uses: actions/setup-python@v2
        with:
-         python-version: 3.6
+         python-version: 3.11
 
      - name: install dependencies
        run: tools/ci/install_doc_dependencies.sh


### PR DESCRIPTION
## What changes does this PR introduce?

Bug fix for CI

## What is the current behaviour? 

Doc build in github actions fails because it is set to use unsupported python 3.6.

## What is the new behaviour 

Set to use python 3.11

## Does this PR introduce a breaking change? 

No.

## Other information:

## Suggested addition to `tag-index`
