### PR TITLE
DIC carbonate dissolution updates

### DIFF
--- a/doc/tag-index
+++ b/doc/tag-index
@@ -1,6 +1,17 @@
     Notes on tags used in MITgcmUV
     ==============================
 
+o pkg/dic:
+  - rename CPP: CAR_DISS -> DIC_CALCITE_SAT and AD_SAFE -> DIC_AD_SAFE and put
+    all carbonate-saturation code and 3D arrays inside #ifdef DIC_CALCITE_SAT
+    block and time-ave arrays within #ifdef ALLOW_TIMEAVE ;
+  - add run-time params: useCalciteSaturation, calcOmegaCalciteFreq, nIterCO3,
+    selectCalciteBottomRemin, KierRateK, KierRateExp and WsinkPIC ;
+  - switch order of arguments to "myTime, myIter, myThid" in few remaining
+    pkg/dic S/R + S/R calls in pkg/gchem ;
+  - update exp. so_box_biogeo (define CARBONCHEM_TOTALPHSCALE & DIC_CALCITE_SAT)
+    + add 2 new secondary tests (caSat0 & caSat3) with useCalciteSaturation=T
+    and using 3-D silicate input file.
 o TAF tape keys:
   - rename many local taf keys to use shorter and more consistent names ;
   - pkg/thsice: fix bug in key computations.

--- a/pkg/dic/DIC_LOAD.h
+++ b/pkg/dic/DIC_LOAD.h
@@ -5,8 +5,10 @@ C     chlinput      :: chlorophyll climatology input field [mg/m3]
       COMMON /DIC_LOAD_I/ DIC_ldRec
       COMMON /DIC_LOAD_RS/
      &    dicwind0, dicwind1, ice0, ice1, atmosp0, atmosp1,
-     &    silicaSurf0, silicaSurf1,
-     &    silicaDeep0, silicaDeep1
+     &    silicaSurf0, silicaSurf1
+#ifdef CAR_DISS
+     &    , silicaDeep0, silicaDeep1
+#endif
 #ifdef READ_PAR
      &  , par0, par1
 #endif
@@ -26,8 +28,10 @@ C     chlinput      :: chlorophyll climatology input field [mg/m3]
       _RS atmosp1    (1-OLx:sNx+OLx,1-OLy:sNy+OLy,nSx,nSy)
       _RS silicaSurf0(1-OLx:sNx+OLx,1-OLy:sNy+OLy,nSx,nSy)
       _RS silicaSurf1(1-OLx:sNx+OLx,1-OLy:sNy+OLy,nSx,nSy)
+#ifdef CAR_DISS
       _RS silicaDeep0(1-OLx:sNx+OLx,1-OLy:sNy+OLy,Nr,nSx,nSy)
       _RS silicaDeep1(1-OLx:sNx+OLx,1-OLy:sNy+OLy,Nr,nSx,nSy)
+#endif
 #ifdef READ_PAR
       _RS par0       (1-OLx:sNx+OLx,1-OLy:sNy+OLy,nSx,nSy)
       _RS par1       (1-OLx:sNx+OLx,1-OLy:sNy+OLy,nSx,nSy)

--- a/pkg/dic/DIC_LOAD.h
+++ b/pkg/dic/DIC_LOAD.h
@@ -6,7 +6,7 @@ C     chlinput      :: chlorophyll climatology input field [mg/m3]
       COMMON /DIC_LOAD_RS/
      &    dicwind0, dicwind1, ice0, ice1, atmosp0, atmosp1,
      &    silicaSurf0, silicaSurf1
-#ifdef CAR_DISS
+#ifdef DIC_CALCITE_SAT
      &    , silicaDeep0, silicaDeep1
 #endif
 #ifdef READ_PAR
@@ -28,7 +28,7 @@ C     chlinput      :: chlorophyll climatology input field [mg/m3]
       _RS atmosp1    (1-OLx:sNx+OLx,1-OLy:sNy+OLy,nSx,nSy)
       _RS silicaSurf0(1-OLx:sNx+OLx,1-OLy:sNy+OLy,nSx,nSy)
       _RS silicaSurf1(1-OLx:sNx+OLx,1-OLy:sNy+OLy,nSx,nSy)
-#ifdef CAR_DISS
+#ifdef DIC_CALCITE_SAT
       _RS silicaDeep0(1-OLx:sNx+OLx,1-OLy:sNy+OLy,Nr,nSx,nSy)
       _RS silicaDeep1(1-OLx:sNx+OLx,1-OLy:sNy+OLy,Nr,nSx,nSy)
 #endif

--- a/pkg/dic/DIC_LOAD.h
+++ b/pkg/dic/DIC_LOAD.h
@@ -7,7 +7,7 @@ C     chlinput      :: chlorophyll climatology input field [mg/m3]
      &    dicwind0, dicwind1, ice0, ice1, atmosp0, atmosp1,
      &    silicaSurf0, silicaSurf1
 #ifdef DIC_CALCITE_SAT
-     &    , silicaDeep0, silicaDeep1
+     &  , silicaDeep0, silicaDeep1
 #endif
 #ifdef READ_PAR
      &  , par0, par1

--- a/pkg/dic/DIC_OPTIONS.h
+++ b/pkg/dic/DIC_OPTIONS.h
@@ -46,6 +46,9 @@ C Include self-shading effect by phytoplankton
 C Include iron sediment source using DOP flux
 #undef SEDFE
 
+C For Adjoint built
+#undef DIC_AD_SAFE
+
 #endif /* ALLOW_DIC */
 #endif /* DIC_OPTIONS_H */
 

--- a/pkg/dic/DIC_OPTIONS.h
+++ b/pkg/dic/DIC_OPTIONS.h
@@ -38,7 +38,7 @@ C put back bugs related to Water-Vapour in carbonate chemistry & air-sea fluxes
 #undef WATERVAP_BUG
 
 C dissolution only below saturation horizon following method by Karsten Friis
-#undef CAR_DISS
+#undef DIC_CALCITE_SAT
 
 C Include self-shading effect by phytoplankton
 #undef LIGHT_CHL

--- a/pkg/dic/DIC_VARS.h
+++ b/pkg/dic/DIC_VARS.h
@@ -28,6 +28,9 @@ C     useCalciteSaturation :: Dissolve calcium carbonate only below saturation
 C                             horizon (needs DIC_CALCITE_SAT to be defined)
 C     calcOmegaCalciteFreq :: Frequency at which 3D calcite saturation state,
 C                             omegaC, is updated (s).
+C     nIterCO3           :: Number of iterations of the Follows 3D pH solver to 
+C                       calculate deep carbonate ion concenetration (no
+C                       effect when using the Munhoven/SolveSapHe solvers).
 C     KierRateK   :: Rate constant (%) for calcite dissolution from
 C                       Kier (1980) Geochem. Cosmochem. Acta.
 C     KierRateExp :: Rate exponent for calcite dissolution from
@@ -41,7 +44,7 @@ C     omegaC      :: Local saturation state with respect to calcite
        COMMON /CARBON_NEEDS/
      &              AtmospCO2, AtmosP, pH, pCO2, FluxCO2,
      &              wind, fIce, Kwexch_Pre, silicaSurf,
-     &              zca, calcOmegaCalciteFreq,
+     &              zca, calcOmegaCalciteFreq, nIterCO3,
      &              KierRateK, KierRateExp, WsinkPIC,
      &              selectCalciteBottomRemin,
      &              useCalciteSaturation
@@ -61,6 +64,7 @@ C     omegaC      :: Local saturation state with respect to calcite
       _RL  KierRateExp
       _RL  WsinkPIC
       INTEGER selectCalciteBottomRemin
+      INTEGER nIterCO3
       LOGICAL useCalciteSaturation
 
 #ifdef DIC_CALCITE_SAT

--- a/pkg/dic/DIC_VARS.h
+++ b/pkg/dic/DIC_VARS.h
@@ -8,8 +8,7 @@ C     *==========================================================*
 
 C     AtmospCO2   :: Atmospheric pCO2 (atm).
 C     AtmosP      :: Atmospheric Pressure loaded from file (atm).
-C     pH          :: surface ocean pH (acidity) for pCO2
-C                       calculations.
+C     pH          :: surface ocean pH (acidity) for pCO2 calculations.
 C     pCO2        :: surface ocean partial pressure of CO2 (atm).
 C     FluxCO2     :: Air-sea flux of CO2 (mol/m2/s).
 C     wind        :: Wind speed loaded from file for air-sea
@@ -21,14 +20,12 @@ C     Kwexch_Pre  :: Common part of piston velocity used for
 C                       for air-sea CO2 and O2 flux calculations.
 C     silicaSurf  :: Surface ocean concentration of silicate for
 C                       pCO2 calculations. Read in from file (mol/m3).
-C     silicaDeep  :: 3D-field of silicate concentration for pH and
-C                       carbonate calculations. Read in from file (mol/m3).
 C     zca         :: Scale depth for CaCO3 remineralization [m]
 C     useCalciteSaturation :: Dissolve calcium carbonate only below saturation
 C                             horizon (needs DIC_CALCITE_SAT to be defined)
 C     calcOmegaCalciteFreq :: Frequency at which 3D calcite saturation state,
 C                             omegaC, is updated (s).
-C     nIterCO3           :: Number of iterations of the Follows 3D pH solver to 
+C     nIterCO3    :: Number of iterations of the Follows 3D pH solver to
 C                       calculate deep carbonate ion concenetration (no
 C                       effect when using the Munhoven/SolveSapHe solvers).
 C     KierRateK   :: Rate constant (%) for calcite dissolution from
@@ -39,14 +36,13 @@ C     WsinkPIC    :: sinking speed (m/s) of particulate inorganic carbon for
 C                    calculation of calcite dissolution through the watercolumn
 C     selectCalciteBottomRemin :: to either remineralize in bottom or top layer
 C                       if flux reaches bottom layer; =0 : bottom, =1 : top
-C     omegaC      :: Local saturation state with respect to calcite
 
        COMMON /CARBON_NEEDS/
      &              AtmospCO2, AtmosP, pH, pCO2, FluxCO2,
      &              wind, fIce, Kwexch_Pre, silicaSurf,
-     &              zca, calcOmegaCalciteFreq, nIterCO3,
+     &              zca, calcOmegaCalciteFreq,
      &              KierRateK, KierRateExp, WsinkPIC,
-     &              selectCalciteBottomRemin,
+     &              selectCalciteBottomRemin, nIterCO3,
      &              useCalciteSaturation
 
       _RL  AtmospCO2(1-OLx:sNx+OLx,1-OLy:sNy+OLy,nSx,nSy)
@@ -68,6 +64,9 @@ C     omegaC      :: Local saturation state with respect to calcite
       LOGICAL useCalciteSaturation
 
 #ifdef DIC_CALCITE_SAT
+C     silicaDeep  :: 3D-field of silicate concentration for pH and
+C                    carbonate calculations. Read in from file (mol/m3).
+C     omegaC      :: Local saturation state with respect to calcite
        COMMON /DIC_CALCITE_SAT_FIELDS/
      &              silicaDeep, omegaC
       _RL  silicaDeep(1-OLx:sNx+OLx,1-OLy:sNy+OLy,Nr,nSx,nSy)

--- a/pkg/dic/DIC_VARS.h
+++ b/pkg/dic/DIC_VARS.h
@@ -25,7 +25,10 @@ C     Kwexch_Pre  :: Common part of piston velocity used for
 C                       for air-sea CO2 and O2 flux calculations.
        COMMON /CARBON_NEEDS/
      &              AtmospCO2, AtmosP, pH, pCO2, FluxCO2,
-     &              wind, fIce, Kwexch_Pre, silicaSurf, silicaDeep
+     &              wind, fIce, Kwexch_Pre, silicaSurf
+#ifdef CAR_DISS
+     &            , silicaDeep
+#endif
       _RL  AtmospCO2(1-OLx:sNx+OLx,1-OLy:sNy+OLy,nSx,nSy)
       _RL  AtmosP(1-OLx:sNx+OLx,1-OLy:sNy+OLy,nSx,nSy)
       _RL  pCO2(1-OLx:sNx+OLx,1-OLy:sNy+OLy,nSx,nSy)
@@ -35,7 +38,9 @@ C                       for air-sea CO2 and O2 flux calculations.
       _RL  fIce(1-OLx:sNx+OLx,1-OLy:sNy+OLy,nSx,nSy)
       _RL  Kwexch_Pre(1-OLx:sNx+OLx,1-OLy:sNy+OLy,nSx,nSy)
       _RL  silicaSurf(1-OLx:sNx+OLx,1-OLy:sNy+OLy,nSx,nSy)
+#ifdef CAR_DISS
       _RL  silicaDeep(1-OLx:sNx+OLx,1-OLy:sNy+OLy,Nr,nSx,nSy)
+#endif
 
 C Store dissociation and carbon chemistry coefficients for
 C    pCO2 solvers (see carbon_chem.F).
@@ -217,7 +222,8 @@ C  dic_int4          :: timestep between file entries
 C  dic_pCO2          :: atmospheric pCO2 to be read from data.dic
       COMMON /DIC_FILENAMES/
      &        DIC_windFile, DIC_atmospFile, DIC_silicaFile,
-     &        DIC_deepSilicaFile, DIC_iceFile, DIC_parFile,
+     &        DIC_deepSilicaFile, 
+     &        DIC_iceFile, DIC_parFile,
      &        DIC_chlaFile, DIC_ironFile,
      &        DIC_forcingPeriod, DIC_forcingCycle,
      &        dic_pCO2, dic_int1, dic_int2, dic_int3, dic_int4
@@ -261,7 +267,10 @@ C  DIC_timeAve  :: period over which DIC averages are calculated [s]
 
       COMMON /BIOTIC_TAVE/
      &     BIOave, CARave, SURave, SUROave, pCO2ave, pHave,
-     &     fluxCO2ave, omegaCave, pfluxave, epfluxave, cfluxave,
+     &     fluxCO2ave, pfluxave, epfluxave, cfluxave, 
+#ifdef CAR_DISS
+     &     omegaCave,
+#endif
      &     DIC_timeAve
 
       _RL BIOave    (1-OLx:sNx+OLx,1-OLy:sNy+OLy,Nr,nSx,nSy)
@@ -271,7 +280,9 @@ C  DIC_timeAve  :: period over which DIC averages are calculated [s]
       _RL pCO2ave   (1-OLx:sNx+OLx,1-OLy:sNy+OLy,nSx,nSy)
       _RL pHave     (1-OLx:sNx+OLx,1-OLy:sNy+OLy,nSx,nSy)
       _RL fluxCO2ave(1-OLx:sNx+OLx,1-OLy:sNy+OLy,nSx,nSy)
+#ifdef CAR_DISS
       _RL OmegaCave (1-OLx:sNx+OLx,1-OLy:sNy+OLy,Nr,nSx,nSy)
+#endif
       _RL pfluxave  (1-OLx:sNx+OLx,1-OLy:sNy+OLy,Nr,nSx,nSy)
       _RL epfluxave (1-OLx:sNx+OLx,1-OLy:sNy+OLy,Nr,nSx,nSy)
       _RL cfluxave  (1-OLx:sNx+OLx,1-OLy:sNy+OLy,Nr,nSx,nSy)
@@ -322,15 +333,17 @@ C  cfeload           :: not used (legacy adjoint param)
 C  QSW_underice      :: is Qsw is masked by ice fraction?
 
       COMMON /BIOTIC_NEEDS/
-     &     par, alpha, rain_ratio, InputFe, omegaC, CHL,
+     &     par, alpha, rain_ratio, InputFe, CHL,
      &     Kpo4, DOPfraction, zcrit, KRemin,
      &     KDOPremin,zca,R_op,R_cp,R_NP, R_FeP,
      &     O2crit, alpfe, KScav, ligand_stab, ligand_tot, KFE,
      &     freefemax, fesedflux_pcm, FeIntSec,
      &     parfrac, k0, kchl, lit0,
      &     alphaUniform, rainRatioUniform,
+#ifdef CAR_DISS
+     &     omegaC,
+#endif
      &     nlev, QSW_underice
-
 c    &     alphamax, alphamin,
 c    &     calpha, crain_ratio, cInputFe, calpfe, feload, cfeload,
 
@@ -338,7 +351,9 @@ c    &     calpha, crain_ratio, cInputFe, calpfe, feload, cfeload,
       _RL alpha(1-OLx:sNx+OLx,1-OLy:sNy+OLy,nSx,nSy)
       _RL rain_ratio(1-OLx:sNx+OLx,1-OLy:sNy+OLy,nSx,nSy)
       _RL InputFe(1-OLx:sNx+OLx,1-OLy:sNy+OLy,nSx,nSy)
+#ifdef CAR_DISS
       _RL omegaC(1-OLx:sNx+OLx,1-OLy:sNy+OLy,Nr,nSx,nSy)
+#endif
       _RL CHL(1-OLx:sNx+OLx,1-OLy:sNy+OLy,nSx,nSy)
       _RL Kpo4
       _RL DOPfraction
@@ -357,7 +372,7 @@ c    &     calpha, crain_ratio, cInputFe, calpfe, feload, cfeload,
       _RL KScav
       _RL ligand_stab
       _RL ligand_tot
-      _RL  KFe
+      _RL KFe
       _RL freefemax
       _RL k0, kchl, parfrac, lit0
       _RL alphaUniform

--- a/pkg/dic/DIC_VARS.h
+++ b/pkg/dic/DIC_VARS.h
@@ -26,7 +26,7 @@ C                       for air-sea CO2 and O2 flux calculations.
        COMMON /CARBON_NEEDS/
      &              AtmospCO2, AtmosP, pH, pCO2, FluxCO2,
      &              wind, fIce, Kwexch_Pre, silicaSurf
-#ifdef CAR_DISS
+#ifdef DIC_CALCITE_SAT
      &            , silicaDeep
 #endif
       _RL  AtmospCO2(1-OLx:sNx+OLx,1-OLy:sNy+OLy,nSx,nSy)
@@ -38,7 +38,7 @@ C                       for air-sea CO2 and O2 flux calculations.
       _RL  fIce(1-OLx:sNx+OLx,1-OLy:sNy+OLy,nSx,nSy)
       _RL  Kwexch_Pre(1-OLx:sNx+OLx,1-OLy:sNy+OLy,nSx,nSy)
       _RL  silicaSurf(1-OLx:sNx+OLx,1-OLy:sNy+OLy,nSx,nSy)
-#ifdef CAR_DISS
+#ifdef DIC_CALCITE_SAT
       _RL  silicaDeep(1-OLx:sNx+OLx,1-OLy:sNy+OLy,Nr,nSx,nSy)
 #endif
 
@@ -268,7 +268,7 @@ C  DIC_timeAve  :: period over which DIC averages are calculated [s]
       COMMON /BIOTIC_TAVE/
      &     BIOave, CARave, SURave, SUROave, pCO2ave, pHave,
      &     fluxCO2ave, pfluxave, epfluxave, cfluxave, 
-#ifdef CAR_DISS
+#ifdef DIC_CALCITE_SAT
      &     omegaCave,
 #endif
      &     DIC_timeAve
@@ -280,7 +280,7 @@ C  DIC_timeAve  :: period over which DIC averages are calculated [s]
       _RL pCO2ave   (1-OLx:sNx+OLx,1-OLy:sNy+OLy,nSx,nSy)
       _RL pHave     (1-OLx:sNx+OLx,1-OLy:sNy+OLy,nSx,nSy)
       _RL fluxCO2ave(1-OLx:sNx+OLx,1-OLy:sNy+OLy,nSx,nSy)
-#ifdef CAR_DISS
+#ifdef DIC_CALCITE_SAT
       _RL OmegaCave (1-OLx:sNx+OLx,1-OLy:sNy+OLy,Nr,nSx,nSy)
 #endif
       _RL pfluxave  (1-OLx:sNx+OLx,1-OLy:sNy+OLy,Nr,nSx,nSy)
@@ -340,7 +340,7 @@ C  QSW_underice      :: is Qsw is masked by ice fraction?
      &     freefemax, fesedflux_pcm, FeIntSec,
      &     parfrac, k0, kchl, lit0,
      &     alphaUniform, rainRatioUniform,
-#ifdef CAR_DISS
+#ifdef DIC_CALCITE_SAT
      &     omegaC,
 #endif
      &     nlev, QSW_underice
@@ -351,7 +351,7 @@ c    &     calpha, crain_ratio, cInputFe, calpfe, feload, cfeload,
       _RL alpha(1-OLx:sNx+OLx,1-OLy:sNy+OLy,nSx,nSy)
       _RL rain_ratio(1-OLx:sNx+OLx,1-OLy:sNy+OLy,nSx,nSy)
       _RL InputFe(1-OLx:sNx+OLx,1-OLy:sNy+OLy,nSx,nSy)
-#ifdef CAR_DISS
+#ifdef DIC_CALCITE_SAT
       _RL omegaC(1-OLx:sNx+OLx,1-OLy:sNy+OLy,Nr,nSx,nSy)
 #endif
       _RL CHL(1-OLx:sNx+OLx,1-OLy:sNy+OLy,nSx,nSy)

--- a/pkg/dic/DIC_VARS.h
+++ b/pkg/dic/DIC_VARS.h
@@ -24,14 +24,16 @@ C                       pCO2 calculations. Read in from file (mol/m3).
 C     silicaDeep  :: 3d-field of silicate concentration for pH and
 C                       carbonate calculations. Read in from file (mol/m3).
 C     useCalciteSaturation :: Dissolve calcium carbonate only below saturation horizon
-C     zca         :: Scale depth for CaCO3 remineralization [m]
+C     calcOmegaCalciteFreq :: Frequency that 3d calcite saturation state, omegaC,
+C                       is calculated. 
 C     omegaC      :: Local saturation state with respect to calcite
+C     zca         :: Scale depth for CaCO3 remineralization [m]
 
        COMMON /CARBON_NEEDS/
      &              AtmospCO2, AtmosP, pH, pCO2, FluxCO2,
      &              wind, fIce, Kwexch_Pre, silicaSurf,
 #ifdef DIC_CALCITE_SAT
-     &              silicaDeep, omegaC,
+     &              silicaDeep, calcOmegaCalciteFreq, omegaC, 
 #endif
      &              zca, useCalciteSaturation
 
@@ -47,9 +49,10 @@ C     omegaC      :: Local saturation state with respect to calcite
 #ifdef DIC_CALCITE_SAT
       _RL  silicaDeep(1-OLx:sNx+OLx,1-OLy:sNy+OLy,Nr,nSx,nSy)
       _RL  omegaC(1-OLx:sNx+OLx,1-OLy:sNy+OLy,Nr,nSx,nSy)
+      _RL  calcOmegaCalciteFreq
 #endif
+      _RL  zca
       LOGICAL useCalciteSaturation
-      _RL zca
       
 C Store dissociation and carbon chemistry coefficients for
 C    pCO2 solvers (see carbon_chem.F).

--- a/pkg/dic/DIC_VARS.h
+++ b/pkg/dic/DIC_VARS.h
@@ -26,16 +26,26 @@ C                       carbonate calculations. Read in from file (mol/m3).
 C     useCalciteSaturation :: Dissolve calcium carbonate only below saturation horizon
 C     calcOmegaCalciteFreq :: Frequency that 3d calcite saturation state, omegaC,
 C                       is calculated. 
+C     KierRateK            :: Rate constant (%) for calcite dissolution from  
+C                       Kier (1980) Geochem. Cosmochem. Acta.
+C     KierRateExp          :: Rate exponent for calcite dissolution from
+C                       Kier (1980) Geochem. Cosmochem. Acta.
+C     WsinkPIC             :: sinking speed (m/s) of particulate inorganic carbon
+C                       for calculation of calcite dissolution through the watercolumn
+C     selectCalciteBottomRemin :: flag to either remineralize in bottom or top layer if flux
+c                       reaches bottom layer 0=bottom, 1=top 
 C     omegaC      :: Local saturation state with respect to calcite
 C     zca         :: Scale depth for CaCO3 remineralization [m]
 
        COMMON /CARBON_NEEDS/
      &              AtmospCO2, AtmosP, pH, pCO2, FluxCO2,
-     &              wind, fIce, Kwexch_Pre, silicaSurf,
+     &              wind, fIce, Kwexch_Pre, silicaSurf, zca, 
 #ifdef DIC_CALCITE_SAT
      &              silicaDeep, calcOmegaCalciteFreq, omegaC, 
+     &              KierRateK, KierRateExp, WsinkPIC, 
+     &              selectCalciteBottomRemin,
 #endif
-     &              zca, useCalciteSaturation
+     &              useCalciteSaturation
 
       _RL  AtmospCO2(1-OLx:sNx+OLx,1-OLy:sNy+OLy,nSx,nSy)
       _RL  AtmosP(1-OLx:sNx+OLx,1-OLy:sNy+OLy,nSx,nSy)
@@ -46,12 +56,16 @@ C     zca         :: Scale depth for CaCO3 remineralization [m]
       _RL  fIce(1-OLx:sNx+OLx,1-OLy:sNy+OLy,nSx,nSy)
       _RL  Kwexch_Pre(1-OLx:sNx+OLx,1-OLy:sNy+OLy,nSx,nSy)
       _RL  silicaSurf(1-OLx:sNx+OLx,1-OLy:sNy+OLy,nSx,nSy)
+      _RL  zca
 #ifdef DIC_CALCITE_SAT
       _RL  silicaDeep(1-OLx:sNx+OLx,1-OLy:sNy+OLy,Nr,nSx,nSy)
       _RL  omegaC(1-OLx:sNx+OLx,1-OLy:sNy+OLy,Nr,nSx,nSy)
       _RL  calcOmegaCalciteFreq
+      _RL  KierRateK
+      _RL  KierRateExp 
+      _RL  WsinkPIC
+      INTEGER selectCalciteBottomRemin
 #endif
-      _RL  zca
       LOGICAL useCalciteSaturation
       
 C Store dissociation and carbon chemistry coefficients for

--- a/pkg/dic/alk_surfforcing.F
+++ b/pkg/dic/alk_surfforcing.F
@@ -6,7 +6,7 @@ C !ROUTINE: ALK_SURFFORCING
 C !INTERFACE: ==========================================================
       SUBROUTINE ALK_SURFFORCING( PTR_ALK , GALK,
      I           bi,bj,imin,imax,jmin,jmax,
-     I           myIter,myTime,myThid)
+     I           myTime, myIter, myThid )
 
 C !DESCRIPTION:
 C Calculate the alkalinity change due to freshwater flux
@@ -23,15 +23,15 @@ C !USES: ===============================================================
 #include "DIC_VARS.h"
 
 C !INPUT PARAMETERS: ===================================================
-C  myThid               :: thread number
-C  myIter               :: current timestep
-C  myTime               :: current time
-C  bi,bj                :: tile indices
 C  PTR_ALK              :: alkalinity field
-      INTEGER myIter, myThid
-      _RL myTime
+C  bi,bj                :: tile indices
+C  myTime               :: current time
+C  myIter               :: current timestep
+C  myThid               :: thread number
       _RL  PTR_ALK(1-OLx:sNx+OLx,1-OLy:sNy+OLy,Nr)
       INTEGER iMin,iMax,jMin,jMax, bi, bj
+      _RL myTime
+      INTEGER myIter, myThid
 
 C !OUTPUT PARAMETERS: ==================================================
 C  GALK                 :: tendency term of alkalinity

--- a/pkg/dic/bio_export.F
+++ b/pkg/dic/bio_export.F
@@ -60,7 +60,7 @@ C  i,j,k                  :: loop indices
 #ifdef ALLOW_FE
       _RL tmpfe
 #endif
-#ifdef AD_SAFE
+#ifdef DIC_AD_SAFE
       _RL thx, thy, thaux
 #endif
 CEOP
@@ -125,7 +125,7 @@ C     performance drop on vector computers
 #else
          tmpfe=PTR_FE(i,j,k)
 #endif
-#ifdef AD_SAFE
+#ifdef DIC_AD_SAFE
          thx = tmppo4/(tmppo4+KPO4)
          thy = tmpfe/(tmpfe+KFE)
 c        thx = PTR_PO4(i,j,k)/(PTR_PO4(i,j,k)+KPO4)

--- a/pkg/dic/bio_export.F
+++ b/pkg/dic/bio_export.F
@@ -10,7 +10,7 @@ C !INTERFACE: ==========================================================
 #endif
      O           bioac,
      I           bi,bj,iMin,iMax,jMin,jMax,
-     I           myIter,myTime,myThid)
+     I           myTime, myIter, myThid )
 
 c !DESCRIPTION:
 C  Calculate biological activity and export
@@ -28,19 +28,19 @@ C !USES: ===============================================================
 #endif
 
 C !INPUT PARAMETERS: ===================================================
-C  myThid               :: thread number
-C  myIter               :: current timestep
-C  myTime               :: current time
 C  PTR_PO4              :: phosphate tracer field
 C  PTR_FE               :: iron tracer field
-      INTEGER myIter
-      _RL myTime
-      INTEGER myThid
+C  myTime               :: current time
+C  myIter               :: current timestep
+C  myThid               :: thread number
       _RL  PTR_PO4(1-OLx:sNx+OLx,1-OLy:sNy+OLy,Nr)
 #ifdef ALLOW_FE
       _RL  PTR_FE(1-OLx:sNx+OLx,1-OLy:sNy+OLy,Nr)
 #endif
       INTEGER iMin, iMax, jMin, jMax, bi, bj
+      _RL myTime
+      INTEGER myIter
+      INTEGER myThid
 
 C !OUTPUT PARAMETERS: ==================================================
 C  bioac               :: biological productivity (will be split

--- a/pkg/dic/calcite_saturation.F
+++ b/pkg/dic/calcite_saturation.F
@@ -6,7 +6,7 @@ C !ROUTINE: CALCITE_SATURATION
 C !INTERFACE: ==========================================================
       SUBROUTINE CALCITE_SATURATION( PTR_DIC, PTR_ALK, PTR_PO4,
      I           bi,bj,imin,imax,jmin,jmax,
-     I           myIter,myTime,myThid )
+     I           myTime, myIter, myThid )
 
 C !DESCRIPTION:
 C  Calculate carbonate fluxes
@@ -21,15 +21,15 @@ C !USES: ===============================================================
 #include "DIC_VARS.h"
 
 C !INPUT PARAMETERS: ===================================================
-C  myIter               :: current timestep
 C  myTime               :: current time
+C  myIter               :: current timestep
 C  myThid               :: thread number
        _RL  PTR_DIC(1-OLx:sNx+OLx,1-OLy:sNy+OLy,Nr)
        _RL  PTR_ALK(1-OLx:sNx+OLx,1-OLy:sNy+OLy,Nr)
        _RL  PTR_PO4(1-OLx:sNx+OLx,1-OLy:sNy+OLy,Nr)
       INTEGER imin, imax, jmin, jmax, bi, bj
-      INTEGER myIter
       _RL myTime
+      INTEGER myIter
       INTEGER myThid
 
 C !OUTPUT PARAMETERS: ===================================================

--- a/pkg/dic/calcite_saturation.F
+++ b/pkg/dic/calcite_saturation.F
@@ -34,8 +34,7 @@ C  myThid               :: thread number
 
 C !OUTPUT PARAMETERS: ===================================================
 
-#if (defined ALLOW_PTRACERS && defined DIC_BIOTIC)
-#ifdef DIC_CALCITE_SAT
+#if ( defined DIC_BIOTIC && defined DIC_CALCITE_SAT )
 
 C !LOCAL VARIABLES: ====================================================
 C  i,j,k                  :: loop indices
@@ -237,7 +236,6 @@ C-     end k loop
        ENDIF
 #endif /* ALLOW_DIAGNOSTICS */
 
-#endif /* DIC_CALCITE_SAT */
-#endif /* defined ALLOW_PTRACERS && defined DIC_BIOTIC */
+#endif /* DIC_BIOTIC and DIC_CALCITE_SAT */
        RETURN
        END

--- a/pkg/dic/calcite_saturation.F
+++ b/pkg/dic/calcite_saturation.F
@@ -34,7 +34,8 @@ C  myThid               :: thread number
 
 C !OUTPUT PARAMETERS: ===================================================
 
-#ifdef DIC_BIOTIC
+#if (defined ALLOW_PTRACERS && defined DIC_BIOTIC)
+#ifdef CAR_DISS
 
 C !LOCAL VARIABLES: ====================================================
 C  i,j,k                  :: loop indices
@@ -236,6 +237,7 @@ C-     end k loop
        ENDIF
 #endif /* ALLOW_DIAGNOSTICS */
 
-#endif /* DIC_BIOTIC */
+#endif /* CAR_DISS */
+#endif /* defined ALLOW_PTRACERS && defined DIC_BIOTIC */
        RETURN
        END

--- a/pkg/dic/calcite_saturation.F
+++ b/pkg/dic/calcite_saturation.F
@@ -52,7 +52,7 @@ C  i,j,k                  :: loop indices
        _RL locSalt(1-OLx:sNx+OLx,1-OLy:sNy+OLy)
 
        INTEGER CO3ITER
-       INTEGER CO3ITERmax
+C       INTEGER CO3ITERmax
 CEOP
 
 Cmick...................................................
@@ -152,12 +152,12 @@ Cmick -DEC 04
 Cmick- NOW ITERATE pH SOLVER AT DEPTH ONLY
 Cmick  TO ENSURE ACCURATE ESTIMATE OF CO3 AT DEPTH
 Cmick - NOTE Si STILL USING A UNIFORM DUMMY VALUE
-            CO3itermax = 10
+C            nIterCO3 = 10
 Cmick - SO NOW WE ITERATE, UPDATING THE ESTIMATE OF pH and CO3--
 Cmick - SINCE WE CALL THIS FOR DEEP OCEAN INFREQUENTLY (MONTHLY?)
 CMIKC - CAN AFFORD TO MAKE SEVERAL ITERATIONS...
 
-            DO CO3iter = 1, CO3itermax
+            DO CO3iter = 1, nIterCO3
               CALL CALC_PCO2_APPROX(
      I          locTemp(i,j), locSalt(i,j),
      I          diclocal, po4local,

--- a/pkg/dic/calcite_saturation.F
+++ b/pkg/dic/calcite_saturation.F
@@ -9,7 +9,9 @@ C !INTERFACE: ==========================================================
      I           myTime, myIter, myThid )
 
 C !DESCRIPTION:
-C  Calculate carbonate fluxes
+C  Calculate carbonate fluxes:
+C   - determine carbonate ion concentration through full domain
+C   - calculate calcite saturation state
 
 C !USES: ===============================================================
       IMPLICIT NONE
@@ -52,18 +54,9 @@ C  i,j,k                  :: loop indices
        _RL locSalt(1-OLx:sNx+OLx,1-OLy:sNy+OLy)
 
        INTEGER CO3ITER
-C       INTEGER CO3ITERmax
 CEOP
 
-Cmick...................................................
-c       write(6,*)'myIter ',myIter,'  CALLED CALCITE_SATURATION'
-c      write(6,*)'WARNING calcite_sat needs 3d silica & H0 set=7.9'
-c       write(6,*)'        - & Fixed first guess of deep pH to 7.9'
-Cmick....................................................
-
        DO k=1,Nr
-c determine carbonate ion concentration through full domain
-c determine calcite saturation state
         DO j=1-OLy,sNy+OLy
          DO i=1-OLx,sNx+OLx
             locTemp(i,j) = theta(i,j,k,bi,bj)
@@ -104,12 +97,14 @@ C Now correct the coefficients for pressure dependence
 
           IF ( maskC(i,j,k,bi,bj).EQ.oneRS ) THEN
 #ifdef CARBONCHEM_SOLVESAPHE
+C calcium concentration already calculated in S/R DIC_COEFFS_SURF
            calcium = cat(i,j,bi,bj)
 #else
            calcium = 1.028 _d -2*salt(i,j,k,bi,bj)/35. _d 0
 #endif
 
-c 30 micromol = 0.03 mol m-3
+C SilicaDeep filled with constant value of 0.03 mol/m3 unless 
+C     DIC_deepSilicaFile provided.
            sitlocal = silicaDeep(i,j,k,bi,bj)
            po4local = PTR_PO4(i,j,k)
            diclocal = PTR_DIC(i,j,k)
@@ -148,14 +143,10 @@ C Use the original Follows et al. (2006) solver
 #endif
             pHlocal(i,j) = 7.9 _d 0
 
-Cmick -DEC 04
-Cmick- NOW ITERATE pH SOLVER AT DEPTH ONLY
-Cmick  TO ENSURE ACCURATE ESTIMATE OF CO3 AT DEPTH
-Cmick - NOTE Si STILL USING A UNIFORM DUMMY VALUE
-C            nIterCO3 = 10
-Cmick - SO NOW WE ITERATE, UPDATING THE ESTIMATE OF pH and CO3--
-Cmick - SINCE WE CALL THIS FOR DEEP OCEAN INFREQUENTLY (MONTHLY?)
-CMIKC - CAN AFFORD TO MAKE SEVERAL ITERATIONS...
+C Since we start cold with an arbitrary pH, we must iterate pH solver 
+C    to ensure accurate estimate of co3 at depth
+C    Because we may call this for deep ocean infrequently can afford to make
+C    several iterations
 
             DO CO3iter = 1, nIterCO3
               CALL CALC_PCO2_APPROX(
@@ -170,12 +161,6 @@ CMIKC - CAN AFFORD TO MAKE SEVERAL ITERATIONS...
      I          bt(i,j,bi,bj),st(i,j,bi,bj),ft(i,j,bi,bj),
      U          pHlocal(i,j), pCO2local(i,j), carbonate(i,j),
      I          i,j,k,bi,bj,myIter,myThid )
-
-c........................................................
-c               if(i .eq. 76 .and. j .eq. 36  .and. k .eq. 15) then
-c                 write(6,*)'Iteration, pH = ',CO3iter,pHlocal
-c               endif
-c........................................................
             ENDDO
 #ifdef CARBONCHEM_SOLVESAPHE
            ENDIF

--- a/pkg/dic/calcite_saturation.F
+++ b/pkg/dic/calcite_saturation.F
@@ -35,7 +35,7 @@ C  myThid               :: thread number
 C !OUTPUT PARAMETERS: ===================================================
 
 #if (defined ALLOW_PTRACERS && defined DIC_BIOTIC)
-#ifdef CAR_DISS
+#ifdef DIC_CALCITE_SAT
 
 C !LOCAL VARIABLES: ====================================================
 C  i,j,k                  :: loop indices
@@ -237,7 +237,7 @@ C-     end k loop
        ENDIF
 #endif /* ALLOW_DIAGNOSTICS */
 
-#endif /* CAR_DISS */
+#endif /* DIC_CALCITE_SAT */
 #endif /* defined ALLOW_PTRACERS && defined DIC_BIOTIC */
        RETURN
        END

--- a/pkg/dic/calcite_saturation.F
+++ b/pkg/dic/calcite_saturation.F
@@ -103,7 +103,7 @@ C calcium concentration already calculated in S/R DIC_COEFFS_SURF
            calcium = 1.028 _d -2*salt(i,j,k,bi,bj)/35. _d 0
 #endif
 
-C SilicaDeep filled with constant value of 0.03 mol/m3 unless 
+C SilicaDeep filled with constant value of 0.03 mol/m3 unless
 C     DIC_deepSilicaFile provided.
            sitlocal = silicaDeep(i,j,k,bi,bj)
            po4local = PTR_PO4(i,j,k)
@@ -143,7 +143,7 @@ C Use the original Follows et al. (2006) solver
 #endif
             pHlocal(i,j) = 7.9 _d 0
 
-C Since we start cold with an arbitrary pH, we must iterate pH solver 
+C Since we start cold with an arbitrary pH, we must iterate pH solver
 C    to ensure accurate estimate of co3 at depth
 C    Because we may call this for deep ocean infrequently can afford to make
 C    several iterations

--- a/pkg/dic/calcite_saturation.F
+++ b/pkg/dic/calcite_saturation.F
@@ -138,7 +138,6 @@ C call AHINI_FOR_AT to get better initial guess of pH
      I          sitlocal, alklocal,
      U          pHlocal(i,j), pCO2local(i,j), carbonate(i,j),
      I          i,j,k,bi,bj, debugPrt,myIter,myThid )
-            debugPrt = .FALSE.
 
 C- convert carbonate to mol kg^-1-SW for calculation of saturation state
             carbonate(i,j) = carbonate(i,j)*permil
@@ -185,6 +184,7 @@ c........................................................
 
            omegaC(i,j,k,bi,bj) = calcium * carbonate(i,j)
      &                         / Ksp_TP_Calc(i,j,bi,bj)
+           debugPrt = .FALSE.
 
 Cmick...................................................
 c            if(omegaC(i,j,k,bi,bj) .eq. 0.) then

--- a/pkg/dic/car_flux.F
+++ b/pkg/dic/car_flux.F
@@ -6,7 +6,7 @@ C !ROUTINE: CAR_FLUX
 C !INTERFACE: ==========================================================
       SUBROUTINE CAR_FLUX( CAR_S, cflux,
      I           bi,bj,imin,imax,jmin,jmax,
-     I           myIter,myTime,myThid)
+     I           myTime, myIter, myThid )
 
 C !DESCRIPTION:
 C Calculate carbonate fluxes
@@ -21,15 +21,15 @@ C !USES: ===============================================================
 #include "DIC_VARS.h"
 
 C !INPUT PARAMETERS: ===================================================
-C  myThid               :: thread number
-C  myIter               :: current timestep
-C  myTime               :: current time
 C  CAR_S                :: carbonate source
-      INTEGER myIter
-      _RL myTime
-      INTEGER myThid
+C  myTime               :: current time
+C  myIter               :: current timestep
+C  myThid               :: thread number
       _RL  CAR_S(1-OLx:sNx+OLx,1-OLy:sNy+OLy,Nr)
       INTEGER imin, imax, jmin, jmax, bi, bj
+      _RL myTime
+      INTEGER myIter
+      INTEGER myThid
 
 C !OUTPUT PARAMETERS: ===================================================
 C  cflux                :: carbonate flux
@@ -46,7 +46,7 @@ c  depth_l                :: depth and lower interface
 c  flux_u, flux_l         :: flux through upper and lower interfaces
 c  reminFac               :: abbreviation
 c  zbase                  :: depth of bottom of current productive layer
-      INTEGER I,J,k, ko, kop1
+      INTEGER i,j,k, ko, kop1
       _RL zbase
       _RL caexport(1-OLx:sNx+OLx,1-OLy:sNy+OLy)
       _RL reminFac
@@ -64,12 +64,12 @@ C- Calculate carbonate flux from base of each layer
 C--   If no layer below initial layer (because of bottom or
 C--   topography), then remineralize in here
           IF (k.EQ.Nr) THEN
-           cflux(i,j,k)=cflux(i,j,k) + CAR_S(i,j,k) 
+           cflux(i,j,k)=cflux(i,j,k) + CAR_S(i,j,k)
           ELSEIF ( _hFacC(i,j,k+1,bi,bj).EQ.0. _d 0 ) THEN
-           cflux(i,j,k)=cflux(i,j,k) + CAR_S(i,j,k) 
+           cflux(i,j,k)=cflux(i,j,k) + CAR_S(i,j,k)
           ELSE
 C- flux out of layer k
-           caexport(i,j) = CAR_S(i,j,k)*drF(k) * _hFacC(i,j,k,bi,bj) 
+           caexport(i,j) = CAR_S(i,j,k)*drF(k) * _hFacC(i,j,k,bi,bj)
           ENDIF
          ENDIF
         ENDDO
@@ -91,7 +91,7 @@ C     in order to save a few expensive exp-function calls
 #ifndef NONLIN_FRSURF
 C     For the linear free surface, hFacC can be omitted, buying another
 C     performance increase of a factor of six on a vector computer.
-C     For now this is not implemented via run time flags, in order to 
+C     For now this is not implemented via run time flags, in order to
 C     avoid making this code too complicated.
         depth_l  = -rF(ko) + drF(ko)
         reminFac = exp(-(depth_l-zbase)/zca)
@@ -106,7 +106,7 @@ C--   Lower flux (no flux to ocean bottom)
 #endif /* NONLIN_FRSURF */
            flux_l   = caexport(i,j)*reminFac
      &          *maskC(i,j,kop1,bi,bj)
-C           
+C
            cflux(i,j,ko)=cflux(i,j,ko) + (flux_u(i,j)-flux_l)
      &          *recip_drF(ko) * _recip_hFacC(i,j,ko,bi,bj)
 C--   Store flux through upper layer for the next k-level

--- a/pkg/dic/car_flux_omega_top.F
+++ b/pkg/dic/car_flux_omega_top.F
@@ -1,12 +1,12 @@
 #include "DIC_OPTIONS.h"
 
 CBOP
-C !ROUTINE: CAR_FLUX
+C !ROUTINE: CAR_FLUX_OMEGA_TOP
 
 C !INTERFACE: ==========================================================
       SUBROUTINE CAR_FLUX_OMEGA_TOP( bioac, cflux,
      I           bi,bj,imin,imax,jmin,jmax,
-     I           myIter,myTime,myThid)
+     I           myTime, myIter, myThid )
 
 C !DESCRIPTION:
 C  Calculate carbonate fluxes
@@ -23,15 +23,15 @@ C !USES: ===============================================================
 #include "DIC_VARS.h"
 
 C !INPUT PARAMETERS: ===================================================
-C  myThid               :: thread number
-C  myIter               :: current timestep
-C  myTime               :: current time
 C  bioac                :: biological productivity
-      INTEGER myIter
-      _RL myTime
-      INTEGER myThid
+C  myTime               :: current time
+C  myIter               :: current timestep
+C  myThid               :: thread number
       _RL  bioac(1-OLx:sNx+OLx,1-OLy:sNy+OLy,Nr)
-       INTEGER imin, imax, jmin, jmax, bi, bj
+      INTEGER imin, imax, jmin, jmax, bi, bj
+      _RL myTime
+      INTEGER myIter
+      INTEGER myThid
 
 C !OUTPUT PARAMETERS: ===================================================
 C cflux                :: carbonate flux

--- a/pkg/dic/car_flux_omega_top.F
+++ b/pkg/dic/car_flux_omega_top.F
@@ -65,7 +65,10 @@ c     _RL   tmp
 
 
 CEOP
-
+C initialize fluxes
+      flux_u = 0. _d 0
+      flux_l = 0. _d 0
+      
 c flag to either remineralize in bottom or top layer if flux
 c reaches bottom layer 0=bottom, 1=top
       iflx=1

--- a/pkg/dic/car_flux_omega_top.F
+++ b/pkg/dic/car_flux_omega_top.F
@@ -37,9 +37,8 @@ C !OUTPUT PARAMETERS: ===================================================
 C cflux                :: carbonate flux
       _RL  cflux(1-OLx:sNx+OLx,1-OLy:sNy+OLy,Nr)
 
-#ifdef ALLOW_PTRACERS
-#ifdef DIC_BIOTIC
-
+#if (defined ALLOW_PTRACERS && defined DIC_BIOTIC)
+#ifdef CAR_DISS
 C !LOCAL VARIABLES: ====================================================
 C  i,j,k                  :: loop indices
 c  ko                     :: loop-within-loop index
@@ -197,7 +196,7 @@ c end diagnostic
         ENDDO
        ENDDO
 c
-#endif
-#endif
+#endif /* CAR_DISS */
+#endif /* defined ALLOW_PTRACERS && defined DIC_BIOTIC */
        RETURN
        END

--- a/pkg/dic/car_flux_omega_top.F
+++ b/pkg/dic/car_flux_omega_top.F
@@ -38,7 +38,7 @@ C cflux                :: carbonate flux
       _RL  cflux(1-OLx:sNx+OLx,1-OLy:sNy+OLy,Nr)
 
 #if (defined ALLOW_PTRACERS && defined DIC_BIOTIC)
-#ifdef CAR_DISS
+#ifdef DIC_CALCITE_SAT
 C !LOCAL VARIABLES: ====================================================
 C  i,j,k                  :: loop indices
 c  ko                     :: loop-within-loop index
@@ -196,7 +196,7 @@ c end diagnostic
         ENDDO
        ENDDO
 c
-#endif /* CAR_DISS */
+#endif /* DIC_CALCITE_SAT */
 #endif /* defined ALLOW_PTRACERS && defined DIC_BIOTIC */
        RETURN
        END

--- a/pkg/dic/car_flux_omega_top.F
+++ b/pkg/dic/car_flux_omega_top.F
@@ -37,58 +37,54 @@ C !OUTPUT PARAMETERS: ===================================================
 C cflux                :: carbonate flux
       _RL  cflux(1-OLx:sNx+OLx,1-OLy:sNy+OLy,Nr)
 
-#if (defined ALLOW_PTRACERS && defined DIC_BIOTIC)
-#ifdef DIC_CALCITE_SAT
+#if ( defined DIC_BIOTIC && defined DIC_CALCITE_SAT )
 C !LOCAL VARIABLES: ====================================================
 C  i,j,k                  :: loop indices
-c  ko                     :: loop-within-loop index
-c caexport                :: flux of carbonate from base each "productive"
-c                            layer
-c depth_u, depth_l        :: depths of upper and lower interfaces
-c flux_u, flux_l          :: flux through upper and lower interfaces
+C  ko                     :: loop-within-loop index
+C caexport                :: flux of carbonate from base each "productive"
+C                            layer
+C depth_u, depth_l        :: depths of upper and lower interfaces
+C flux_u, flux_l          :: flux through upper and lower interfaces
        _RL caexport(1-OLx:sNx+OLx,1-OLy:sNy+OLy)
-       INTEGER I,J,k, ko, kBottom
+       INTEGER i,j,k, ko, kBottom
        _RL flux_u, flux_l
-c variables for calcium carbonate dissolution
+C variables for calcium carbonate dissolution
        _RL KierRate
        _RL DissolutionRate
        _RL dumrate
 
-c diagnostics
+C diagnostics
 c     _RL   exp_tot
 c     _RL   flx_tot
 c     integer knum
 c     _RL   omeg_bot
 c     _RL   tmp
 
-
 CEOP
 C initialize fluxes
       flux_u = 0. _d 0
       flux_l = 0. _d 0
-      
-c flag to either remineralize in bottom or top layer if flux
-c reaches bottom layer 0=bottom, 1=top
-C      selectCalciteBottomRemin=1
-c set some nominal particulate sinking rate
-c try 100m/day
+
+C to either remineralize in bottom or top layer if flux reaches bottom layer
+C      selectCalciteBottomRemin =0 : in bottom layer, =1 : in top layer
+C set some nominal particulate sinking rate, try 100m/day:
 C       WsinkPIC = 100. _d 0/86400. _d 0
-c calculate carbonate flux from base of each nlev
+C calculate carbonate flux from base of each nlev
        DO j=jmin,jmax
         DO i=imin,imax
 c        exp_tot=0
-         do k=1,nR
+         do k=1,Nr
             cflux(i,j,k)=0. _d 0
          enddo
-         
+
          kBottom   = kLowC(i,j,bi,bj)
-         
+
          DO k=1,nLev
           if (hFacC(i,j,k,bi,bj).gt.0. _d 0) then
            caexport(i,j)= R_CP*rain_ratio(i,j,bi,bj)*bioac(i,j,k)*
      &           (1. _d 0-DOPfraction)*drF(k)*hFacC(i,j,k,bi,bj)
 c          exp_tot=exp_tot+caexport(i,j)
-c calculate flux to each layer from base of k
+C calculate flux to each layer from base of k
            Do ko=k+1,Nr
             if (hFacC(i,j,ko,bi,bj).gt.0. _d 0) then
               if (ko .eq. k+1) then
@@ -97,76 +93,74 @@ c calculate flux to each layer from base of k
                 flux_u = flux_l
               endif
 
-
-
 C flux through lower face of cell
               if (omegaC(i,j,ko,bi,bj) .gt. 1. _d 0) then
                 flux_l = flux_u
 
-c if at bottom, remineralize remaining flux
+C if at bottom, remineralize remaining flux
                 if (ko.eq.kBottom) then
-                  if (selectCalciteBottomRemin.eq.1) then
-c ... at surface
+                  if (selectCalciteBottomRemin.EQ.1) then
+C ... at surface
                      cflux(i,j,1)=cflux(i,j,1)+
      &                  ( (flux_l)/(drF(1)*hFacC(i,j,1,bi,bj)) )
                   else
 
-c ... at bottom
+C ... at bottom
                      flux_l=0. _d 0
                   endif
                 endif
               else
-c if dissolution, then use rate from Kier (1980) Geochem. Cosmochem. Acta
-c Kiers dissolution rate in %  per day
-                 KierRate = KierRateK* 
+C if dissolution, then use rate from Kier (1980) Geochem. Cosmochem. Acta
+C Kiers dissolution rate in %  per day
+                 KierRate = KierRateK*
      &             ((1. _d 0-omegaC(i,j,ko,bi,bj))**KierRateExp)
-c convert to per s
-c Karsten finds Kier value not in 0/0 after all... therefore drop 100 factor
+C convert to per s
+C Karsten finds Kier value not in 0/0 after all... therefore drop 100 factor
 c                DissolutionRate = KierRate/(100.0*86400.0)
                  DissolutionRate = KierRate/(86400. _d 0)
 c                flux_l = flux_u*(1.0-DissolutionRate*drF(k)/WsinkPIC)
-c Karstens version
-c - gives NaNs (because using kierrate, not dissolution rate)???
+C Karstens version
+C - gives NaNs (because using kierrate, not dissolution rate)???
 c                flux_l = flux_u*(1.0-KierRate)**(drF(k)/WsinkPIC)
-c MICKS NEW VERSION... based on vertical sinking/remin balance
+C MICKS NEW VERSION... based on vertical sinking/remin balance
                  dumrate = -1. _d 0*DissolutionRate*drF(ko)*
      &                       hFacC(i,j,ko,bi,bj)/WsinkPIC
                  flux_l = flux_u*exp(dumrate)
-c TEST ............................
+C TEST ............................
 c           if(i .eq. 76 .and. j .eq. 36)then
 c            write(6,*)'k,flux_l/flux_u',ko,(flux_l/flux_u)
 c            write(6,*)'K, KierRate, drF(k), drF(ko), WsinkPIC,OmegaC'
 c            write(6,*)ko,KierRate,drF(k),drF(ko),WsinkPIC,
 c    &            omegaC(i,j,ko,bi,bj)
 c           endif
-c TEST ............................
-c no flux to ocean bottom
+C TEST ............................
+C no flux to ocean bottom
                  if (ko.eq.kBottom)
      &                      flux_l=0. _d 0
               endif
 
-c flux divergence
+C flux divergence
              cflux(i,j,ko)=cflux(i,j,ko) +
      &          ( (flux_u-flux_l)/(drF(ko)*hFacC(i,j,ko,bi,bj)) )
-c TEST ............................
+C TEST ............................
 c            if(i .eq. 76 .and. j .eq. 36)then
 c               write(6,*)'k,flux_l/flux_u',ko,(flux_l/flux_u)
 c              write(6,*)'k,flux_l,cflux ',ko,flux_l,cflux(i,j,ko)
 c            endif
-c TEST ............................
+C TEST ............................
            else
-c if no layer below initial layer, remineralize
+C if no layer below initial layer, remineralize
                if (ko.eq.k+1) then
-                if (selectCalciteBottomRemin.eq.1.and.
-     &                  omegaC(i,j,k,bi,bj) .gt. 1. _d 0) then
-c ... at surface
+                if ( selectCalciteBottomRemin.EQ.1 .AND.
+     &                  omegaC(i,j,k,bi,bj) .GT. 1. _d 0 ) then
+C ... at surface
                    cflux(i,j,1)=cflux(i,j,1)
      &                  +bioac(i,j,k)*(1. _d 0-DOPfraction)*
      &                    R_CP*rain_ratio(i,j,bi,bj)
      &                   *drF(k)*hFacC(i,j,k,bi,bj)/
      &                    (drF(1)*hFacC(i,j,1,bi,bj) )
                 else
-c ... at bottom
+C ... at bottom
                   cflux(i,j,k)=cflux(i,j,k)
      &                  +bioac(i,j,k)*(1. _d 0-DOPfraction)*
      &                    R_CP*rain_ratio(i,j,bi,bj)
@@ -177,7 +171,7 @@ c ... at bottom
 
           endif
          ENDDO
-c diagnostic
+C diagnostic
 c        flx_tot=0
 c        k=0
 c        do k=1,nR
@@ -194,11 +188,10 @@ c          print*,'QQ car_flux', knum,
 c    &                 omeg_bot, exp_tot, flx_tot, exp_tot-flx_tot
 c         endif
 c        endif
-c end diagnostic
+C end diagnostic
         ENDDO
        ENDDO
 c
-#endif /* DIC_CALCITE_SAT */
-#endif /* defined ALLOW_PTRACERS && defined DIC_BIOTIC */
+#endif /* DIC_BIOTIC and DIC_CALCITE_SAT */
        RETURN
        END

--- a/pkg/dic/car_flux_omega_top.F
+++ b/pkg/dic/car_flux_omega_top.F
@@ -52,8 +52,6 @@ c flux_u, flux_l          :: flux through upper and lower interfaces
 c variables for calcium carbonate dissolution
        _RL KierRate
        _RL DissolutionRate
-       _RL WsinkPIC
-       INTEGER iflx
        _RL dumrate
 
 c diagnostics
@@ -71,10 +69,10 @@ C initialize fluxes
       
 c flag to either remineralize in bottom or top layer if flux
 c reaches bottom layer 0=bottom, 1=top
-      iflx=1
+C      selectCalciteBottomRemin=1
 c set some nominal particulate sinking rate
 c try 100m/day
-       WsinkPIC = 100. _d 0/86400. _d 0
+C       WsinkPIC = 100. _d 0/86400. _d 0
 c calculate carbonate flux from base of each nlev
        DO j=jmin,jmax
         DO i=imin,imax
@@ -107,7 +105,7 @@ C flux through lower face of cell
 
 c if at bottom, remineralize remaining flux
                 if (ko.eq.kBottom) then
-                  if (iflx.eq.1) then
+                  if (selectCalciteBottomRemin.eq.1) then
 c ... at surface
                      cflux(i,j,1)=cflux(i,j,1)+
      &                  ( (flux_l)/(drF(1)*hFacC(i,j,1,bi,bj)) )
@@ -120,8 +118,8 @@ c ... at bottom
               else
 c if dissolution, then use rate from Kier (1980) Geochem. Cosmochem. Acta
 c Kiers dissolution rate in %  per day
-                 KierRate = 7.177 _d 0* 
-     &             ((1. _d 0-omegaC(i,j,ko,bi,bj))**4.54 _d 0)
+                 KierRate = KierRateK* 
+     &             ((1. _d 0-omegaC(i,j,ko,bi,bj))**KierRateExp)
 c convert to per s
 c Karsten finds Kier value not in 0/0 after all... therefore drop 100 factor
 c                DissolutionRate = KierRate/(100.0*86400.0)
@@ -159,7 +157,8 @@ c TEST ............................
            else
 c if no layer below initial layer, remineralize
                if (ko.eq.k+1) then
-                if (iflx.eq.1.and.omegaC(i,j,k,bi,bj) .gt. 1. _d 0) then
+                if (selectCalciteBottomRemin.eq.1.and.
+     &                  omegaC(i,j,k,bi,bj) .gt. 1. _d 0) then
 c ... at surface
                    cflux(i,j,1)=cflux(i,j,1)
      &                  +bioac(i,j,k)*(1. _d 0-DOPfraction)*

--- a/pkg/dic/dic_biotic_diags.F
+++ b/pkg/dic/dic_biotic_diags.F
@@ -58,12 +58,6 @@ C      Normalize by integrated time
      &                 bi,bj,myThid)
          CALL TIMEAVE_NORMALIZE(fluxCO2ave,DIC_timeAve, 1 ,
      &                 bi,bj,myThid)
-#ifdef DIC_CALCITE_SAT
-         IF ( useCalciteSaturation ) THEN
-          CALL TIMEAVE_NORMALIZE(OmegaCave, DIC_timeAve, Nr ,
-     &                 bi,bj,myThid)
-         ENDIF
-#endif
          CALL TIMEAVE_NORMALIZE(pfluxave,DIC_timeAve, Nr ,
      &                 bi,bj,myThid)
          CALL TIMEAVE_NORMALIZE(epfluxave,DIC_timeAve, Nr ,
@@ -93,12 +87,6 @@ C      Normalize by integrated time
      &        myIter,myThid)
          CALL WRITE_FLD_XY_RL('DIC_fluxCO2ave.',suff,fluxCO2ave,
      &        myIter,myThid)
-#ifdef DIC_CALCITE_SAT
-         IF ( useCalciteSaturation ) THEN
-          CALL WRITE_FLD_XYZ_RL('DIC_OmegaCtave.',suff,OmegaCave,
-     &        myIter,myThid)
-         ENDIF
-#endif
          CALL WRITE_FLD_XYZ_RL('DIC_pfluxtave.',suff,pfluxave,
      &        myIter,myThid)
          CALL WRITE_FLD_XYZ_RL('DIC_epfluxtave.',suff,epfluxave,
@@ -132,12 +120,6 @@ C      Normalize by integrated time
      &        pf,'dic_tave',0,0,'dic_pCO2_ave',pCO2ave,myThid)
          CALL MNC_CW_RL_W(
      &        pf,'dic_tave',0,0,'dic_fluxCO2_ave',fluxCO2ave,myThid)
-#ifdef DIC_CALCITE_SAT
-         IF ( useCalciteSaturation ) THEN
-          CALL MNC_CW_RL_W(
-     &        pf,'dic_tave',0,0,'dic_OmegaC_ave',OmegaCave,myThid)
-         ENDIF
-#endif
          CALL MNC_CW_RL_W(
      &        pf,'dic_tave',0,0,'dic_pflux_ave',pfluxave,myThid)
          CALL MNC_CW_RL_W(
@@ -157,11 +139,6 @@ C      Reset averages to zero
          CALL TIMEAVE_RESET(pCO2ave,1,bi,bj,myThid)
          CALL TIMEAVE_RESET(pHave,1,bi,bj,myThid)
          CALL TIMEAVE_RESET(fluxCO2ave,1,bi,bj,myThid)
-#ifdef DIC_CALCITE_SAT
-         IF ( useCalciteSaturation ) THEN
-          CALL TIMEAVE_RESET(OmegaCave,Nr,bi,bj,myThid)
-         ENDIF
-#endif
          CALL TIMEAVE_RESET(pfluxave,Nr,bi,bj,myThid)
          CALL TIMEAVE_RESET(epfluxave,Nr,bi,bj,myThid)
          CALL TIMEAVE_RESET(cfluxave,Nr,bi,bj,myThid)

--- a/pkg/dic/dic_biotic_diags.F
+++ b/pkg/dic/dic_biotic_diags.F
@@ -58,8 +58,10 @@ C      Normalize by integrated time
      &                 bi,bj,myThid)
          CALL TIMEAVE_NORMALIZE(fluxCO2ave,DIC_timeAve, 1 ,
      &                 bi,bj,myThid)
+#ifdef CAR_DISS
          CALL TIMEAVE_NORMALIZE(OmegaCave, DIC_timeAve, Nr ,
      &                 bi,bj,myThid)
+#endif
          CALL TIMEAVE_NORMALIZE(pfluxave,DIC_timeAve, Nr ,
      &                 bi,bj,myThid)
          CALL TIMEAVE_NORMALIZE(epfluxave,DIC_timeAve, Nr ,
@@ -89,8 +91,10 @@ C      Normalize by integrated time
      &        myIter,myThid)
          CALL WRITE_FLD_XY_RL('DIC_fluxCO2ave.',suff,fluxCO2ave,
      &        myIter,myThid)
+#ifdef CAR_DISS
          CALL WRITE_FLD_XYZ_RL('DIC_OmegaCtave.',suff,OmegaCave,
      &        myIter,myThid)
+#endif
          CALL WRITE_FLD_XYZ_RL('DIC_pfluxtave.',suff,pfluxave,
      &        myIter,myThid)
          CALL WRITE_FLD_XYZ_RL('DIC_epfluxtave.',suff,epfluxave,
@@ -124,8 +128,10 @@ C      Normalize by integrated time
      &        pf,'dic_tave',0,0,'dic_pCO2_ave',pCO2ave,myThid)
          CALL MNC_CW_RL_W(
      &        pf,'dic_tave',0,0,'dic_fluxCO2_ave',fluxCO2ave,myThid)
+#ifdef CAR_DISS
          CALL MNC_CW_RL_W(
      &        pf,'dic_tave',0,0,'dic_OmegaC_ave',OmegaCave,myThid)
+#endif
          CALL MNC_CW_RL_W(
      &        pf,'dic_tave',0,0,'dic_pflux_ave',pfluxave,myThid)
          CALL MNC_CW_RL_W(
@@ -145,7 +151,9 @@ C      Reset averages to zero
          CALL TIMEAVE_RESET(pCO2ave,1,bi,bj,myThid)
          CALL TIMEAVE_RESET(pHave,1,bi,bj,myThid)
          CALL TIMEAVE_RESET(fluxCO2ave,1,bi,bj,myThid)
+#ifdef CAR_DISS
          CALL TIMEAVE_RESET(OmegaCave,Nr,bi,bj,myThid)
+#endif
          CALL TIMEAVE_RESET(pfluxave,Nr,bi,bj,myThid)
          CALL TIMEAVE_RESET(epfluxave,Nr,bi,bj,myThid)
          CALL TIMEAVE_RESET(cfluxave,Nr,bi,bj,myThid)

--- a/pkg/dic/dic_biotic_diags.F
+++ b/pkg/dic/dic_biotic_diags.F
@@ -59,8 +59,10 @@ C      Normalize by integrated time
          CALL TIMEAVE_NORMALIZE(fluxCO2ave,DIC_timeAve, 1 ,
      &                 bi,bj,myThid)
 #ifdef DIC_CALCITE_SAT
-         CALL TIMEAVE_NORMALIZE(OmegaCave, DIC_timeAve, Nr ,
+         IF ( useCalciteSaturation ) THEN
+          CALL TIMEAVE_NORMALIZE(OmegaCave, DIC_timeAve, Nr ,
      &                 bi,bj,myThid)
+         ENDIF
 #endif
          CALL TIMEAVE_NORMALIZE(pfluxave,DIC_timeAve, Nr ,
      &                 bi,bj,myThid)
@@ -92,8 +94,10 @@ C      Normalize by integrated time
          CALL WRITE_FLD_XY_RL('DIC_fluxCO2ave.',suff,fluxCO2ave,
      &        myIter,myThid)
 #ifdef DIC_CALCITE_SAT
-         CALL WRITE_FLD_XYZ_RL('DIC_OmegaCtave.',suff,OmegaCave,
+         IF ( useCalciteSaturation ) THEN
+          CALL WRITE_FLD_XYZ_RL('DIC_OmegaCtave.',suff,OmegaCave,
      &        myIter,myThid)
+         ENDIF
 #endif
          CALL WRITE_FLD_XYZ_RL('DIC_pfluxtave.',suff,pfluxave,
      &        myIter,myThid)
@@ -129,8 +133,10 @@ C      Normalize by integrated time
          CALL MNC_CW_RL_W(
      &        pf,'dic_tave',0,0,'dic_fluxCO2_ave',fluxCO2ave,myThid)
 #ifdef DIC_CALCITE_SAT
-         CALL MNC_CW_RL_W(
+         IF ( useCalciteSaturation ) THEN
+          CALL MNC_CW_RL_W(
      &        pf,'dic_tave',0,0,'dic_OmegaC_ave',OmegaCave,myThid)
+         ENDIF
 #endif
          CALL MNC_CW_RL_W(
      &        pf,'dic_tave',0,0,'dic_pflux_ave',pfluxave,myThid)
@@ -152,7 +158,9 @@ C      Reset averages to zero
          CALL TIMEAVE_RESET(pHave,1,bi,bj,myThid)
          CALL TIMEAVE_RESET(fluxCO2ave,1,bi,bj,myThid)
 #ifdef DIC_CALCITE_SAT
-         CALL TIMEAVE_RESET(OmegaCave,Nr,bi,bj,myThid)
+         IF ( useCalciteSaturation ) THEN
+          CALL TIMEAVE_RESET(OmegaCave,Nr,bi,bj,myThid)
+         ENDIF
 #endif
          CALL TIMEAVE_RESET(pfluxave,Nr,bi,bj,myThid)
          CALL TIMEAVE_RESET(epfluxave,Nr,bi,bj,myThid)

--- a/pkg/dic/dic_biotic_diags.F
+++ b/pkg/dic/dic_biotic_diags.F
@@ -58,7 +58,7 @@ C      Normalize by integrated time
      &                 bi,bj,myThid)
          CALL TIMEAVE_NORMALIZE(fluxCO2ave,DIC_timeAve, 1 ,
      &                 bi,bj,myThid)
-#ifdef CAR_DISS
+#ifdef DIC_CALCITE_SAT
          CALL TIMEAVE_NORMALIZE(OmegaCave, DIC_timeAve, Nr ,
      &                 bi,bj,myThid)
 #endif
@@ -91,7 +91,7 @@ C      Normalize by integrated time
      &        myIter,myThid)
          CALL WRITE_FLD_XY_RL('DIC_fluxCO2ave.',suff,fluxCO2ave,
      &        myIter,myThid)
-#ifdef CAR_DISS
+#ifdef DIC_CALCITE_SAT
          CALL WRITE_FLD_XYZ_RL('DIC_OmegaCtave.',suff,OmegaCave,
      &        myIter,myThid)
 #endif
@@ -128,7 +128,7 @@ C      Normalize by integrated time
      &        pf,'dic_tave',0,0,'dic_pCO2_ave',pCO2ave,myThid)
          CALL MNC_CW_RL_W(
      &        pf,'dic_tave',0,0,'dic_fluxCO2_ave',fluxCO2ave,myThid)
-#ifdef CAR_DISS
+#ifdef DIC_CALCITE_SAT
          CALL MNC_CW_RL_W(
      &        pf,'dic_tave',0,0,'dic_OmegaC_ave',OmegaCave,myThid)
 #endif
@@ -151,7 +151,7 @@ C      Reset averages to zero
          CALL TIMEAVE_RESET(pCO2ave,1,bi,bj,myThid)
          CALL TIMEAVE_RESET(pHave,1,bi,bj,myThid)
          CALL TIMEAVE_RESET(fluxCO2ave,1,bi,bj,myThid)
-#ifdef CAR_DISS
+#ifdef DIC_CALCITE_SAT
          CALL TIMEAVE_RESET(OmegaCave,Nr,bi,bj,myThid)
 #endif
          CALL TIMEAVE_RESET(pfluxave,Nr,bi,bj,myThid)

--- a/pkg/dic/dic_biotic_forcing.F
+++ b/pkg/dic/dic_biotic_forcing.F
@@ -230,9 +230,21 @@ C- Carbonate sink
        ENDDO
 
 C carbonate
+       IF ( .NOT. useCalciteSaturation ) THEN
+C calcite dissolution occurs according to a power law scaled by zca 
+C    code follwing the old OCMIP way
+#ifdef ALLOW_DEBUG
+        IF (debugMode) CALL DEBUG_CALL('CAR_FLUX',myThid)
+#endif
+        CALL CAR_FLUX(
+     I                    CAR_S,
+     U                    cflux,
+     I                    bi, bj, iMin, iMax, jMin, jMax,
+     I                    myIter, myTime, myThid )       
 #ifdef DIC_CALCITE_SAT
-C dissolution only below saturation horizon
-C code following method by Karsten Friis
+       ELSE       
+C calcite dissolution occurs only below saturation horizon
+C    code following method by Karsten Friis
         nCALCITEstep = 3600
         IF(myIter .lt. (nIter0+5) .or.
      &               mod(myIter,nCALCITEstep) .eq. 0)THEN
@@ -253,18 +265,9 @@ C code following method by Karsten Friis
      O                    cflux,
      I                    bi, bj, iMin, iMax, jMin, jMax,
      I                    myIter, myTime, myThid )
-#else
-C old OCMIP way
-#ifdef ALLOW_DEBUG
-        IF (debugMode) CALL DEBUG_CALL('CAR_FLUX',myThid)
-#endif
-        CALL CAR_FLUX(
-     I                    CAR_S,
-     U                    cflux,
-     I                    bi, bj, iMin, iMax, jMin, jMax,
-     I                    myIter, myTime, myThid )
 #endif /* DIC_CALCITE_SAT */
-
+       ENDIF
+       
 C add all tendencies for PO4, DOP, ALK, DIC
        DO k=1,Nr
          DO j=jMin,jMax

--- a/pkg/dic/dic_biotic_forcing.F
+++ b/pkg/dic/dic_biotic_forcing.F
@@ -98,7 +98,7 @@ C  freefe                 :: iron not bound to ligand
       _RL  freefe(1-OLx:sNx+OLx,1-OLy:sNy+OLy,Nr)
 #endif
       INTEGER i,j,k
-#ifdef CAR_DISS
+#ifdef DIC_CALCITE_SAT
       INTEGER nCALCITEstep
 #endif
 #ifdef ALLOW_FE
@@ -230,7 +230,7 @@ C- Carbonate sink
        ENDDO
 
 C carbonate
-#ifdef CAR_DISS
+#ifdef DIC_CALCITE_SAT
 C dissolution only below saturation horizon
 C code following method by Karsten Friis
         nCALCITEstep = 3600
@@ -263,7 +263,7 @@ C old OCMIP way
      U                    cflux,
      I                    bi, bj, iMin, iMax, jMin, jMax,
      I                    myIter, myTime, myThid )
-#endif /* CAR_DISS */
+#endif /* DIC_CALCITE_SAT */
 
 C add all tendencies for PO4, DOP, ALK, DIC
        DO k=1,Nr
@@ -388,7 +388,7 @@ C save averages
      &                             BIOac(i,j,k)*deltaTClock
             CARave(i,j,k,bi,bj)   =CARave(i,j,k,bi,bj)+
      &                             CAR(i,j,k)*deltaTClock
-#ifdef CAR_DISS
+#ifdef DIC_CALCITE_SAT
             OmegaCave(i,j,k,bi,bj)=OmegaCave(i,j,k,bi,bj)+
      &                             OmegaC(i,j,k,bi,bj)*deltaTClock
 #endif

--- a/pkg/dic/dic_biotic_forcing.F
+++ b/pkg/dic/dic_biotic_forcing.F
@@ -13,7 +13,7 @@ C !INTERFACE: ==========================================================
      U                      PTR_FE,
 #endif
      I                      bi, bj, iMin, iMax, jMin, jMax,
-     I                      myIter, myTime, myThid )
+     I                      myTime, myIter, myThid )
 
 C !DESCRIPTION:
 C updates all the tracers for the effects of air-sea exchange, biological
@@ -38,8 +38,8 @@ c  PTR_DOP              :: dissolve organic phosphurous
 c  PTR_O2               :: oxygen
 C  PTR_FE               :: iron
 c  bi, bj               :: current tile indices
-C  myIter               :: current timestep
 C  myTime               :: current time
+C  myIter               :: current timestep
 C  myThid               :: thread number
       _RL  PTR_DIC(1-OLx:sNx+OLx,1-OLy:sNy+OLy,Nr)
       _RL  PTR_ALK(1-OLx:sNx+OLx,1-OLy:sNy+OLy,Nr)
@@ -52,8 +52,8 @@ C  myThid               :: thread number
       _RL  PTR_FE(1-OLx:sNx+OLx,1-OLy:sNy+OLy,Nr)
 #endif
       INTEGER bi, bj, iMin, iMax, jMin, jMax
-      INTEGER myIter
       _RL myTime
+      INTEGER myIter
       INTEGER myThid
 
 #ifdef DIC_BIOTIC
@@ -160,7 +160,7 @@ C carbon air-sea interaction
      I                    PTR_DIC, PTR_ALK, PTR_PO4,
      O                    SURC,
      I                    bi, bj, iMin, iMax, jMin, jMax,
-     I                    myIter, myTime, myThid )
+     I                    myTime, myIter, myThid )
 
 C alkalinity air-sea interaction
 #ifdef ALLOW_DEBUG
@@ -170,7 +170,7 @@ C alkalinity air-sea interaction
      I                    PTR_ALK,
      O                    SURA,
      I                    bi, bj, iMin, iMax, jMin, jMax,
-     I                    myIter, myTime, myThid )
+     I                    myTime, myIter, myThid )
 
 #ifdef ALLOW_O2
 C oxygen air-sea interaction
@@ -181,7 +181,7 @@ C oxygen air-sea interaction
      I                    PTR_O2,
      O                    SURO,
      I                    bi, bj, iMin, iMax, jMin, jMax,
-     I                    myIter, myTime, myThid )
+     I                    myTime, myIter, myThid )
 #endif
 
 #ifdef ALLOW_FE
@@ -200,23 +200,23 @@ C biological activity
        IF (debugMode) CALL DEBUG_CALL('BIO_EXPORT',myThid)
 #endif
        CALL BIO_EXPORT(
-     I               PTR_PO4,
+     I                    PTR_PO4,
 #ifdef ALLOW_FE
-     I               PTR_FE,
+     I                    PTR_FE,
 #endif
-     O               BIOac,
-     I               bi, bj, iMin, iMax, jMin, jMax,
-     I               myIter, myTime, myThid )
+     O                    BIOac,
+     I                    bi, bj, iMin, iMax, jMin, jMax,
+     I                    myTime, myIter, myThid )
 
 C flux of po4 from layers with biological activity
 #ifdef ALLOW_DEBUG
        IF (debugMode) CALL DEBUG_CALL('PHOS_FLUX',myThid)
 #endif
        CALL PHOS_FLUX(
-     I               BIOac,
-     U               pflux, exportflux,
-     I               bi, bj, iMin, iMax, jMin, jMax,
-     I               myIter, myTime, myThid )
+     I                    BIOac,
+     U                    pflux, exportflux,
+     I                    bi, bj, iMin, iMax, jMin, jMax,
+     I                    myTime, myIter, myThid )
 
 C- Carbonate sink
        DO k=1,Nr
@@ -235,15 +235,15 @@ C calcite dissolution occurs only below saturation horizon
 C    code following method by Karsten Friis
 C could be expensive, so find out if it is time to update the omega calcite
 C    field (requires 3-d computation of pH).
-        IF ( DIFFERENT_MULTIPLE(calcOmegaCalciteFreq, myTime,
-     &                                    deltaTClock) ) THEN
+        IF ( DIFFERENT_MULTIPLE( calcOmegaCalciteFreq, myTime,
+     &                                    deltaTClock ) ) THEN
 #ifdef ALLOW_DEBUG
           IF (debugMode) CALL DEBUG_CALL('CALCITE_SATURATION',myThid)
 #endif
           CALL CALCITE_SATURATION(
      I                    PTR_DIC, PTR_ALK, PTR_PO4,
      I                    bi, bj, iMin, iMax, jMin, jMax,
-     I                    myIter, myTime, myThid )
+     I                    myTime, myIter, myThid )
         ENDIF
 #ifdef ALLOW_DEBUG
         IF (debugMode) CALL DEBUG_CALL('CAR_FLUX_OMEGA_TOP',myThid)
@@ -252,7 +252,7 @@ C    field (requires 3-d computation of pH).
      I                    BIOac,
      O                    cflux,
      I                    bi, bj, iMin, iMax, jMin, jMax,
-     I                    myIter, myTime, myThid )
+     I                    myTime, myIter, myThid )
        ELSE
 #endif /* DIC_CALCITE_SAT */
 C calcite dissolution occurs according to a power law scaled by zca
@@ -264,7 +264,7 @@ C    code follwing the old OCMIP way
      I                    CAR_S,
      U                    cflux,
      I                    bi, bj, iMin, iMax, jMin, jMax,
-     I                    myIter, myTime, myThid )
+     I                    myTime, myIter, myThid )
 #ifdef DIC_CALCITE_SAT
        ENDIF
 #endif /* DIC_CALCITE_SAT */

--- a/pkg/dic/dic_biotic_forcing.F
+++ b/pkg/dic/dic_biotic_forcing.F
@@ -106,6 +106,10 @@ C  freefe                 :: iron not bound to ligand
       INTEGER kBottom
 # endif
 #endif
+
+C !FUNCTIONS:       ====================================================
+      LOGICAL  DIFFERENT_MULTIPLE
+      EXTERNAL DIFFERENT_MULTIPLE
 CEOP
 
 #ifdef ALLOW_DEBUG
@@ -236,7 +240,7 @@ C    code follwing the old OCMIP way
 #ifdef ALLOW_DEBUG
         IF (debugMode) CALL DEBUG_CALL('CAR_FLUX',myThid)
 #endif
-        CALL CAR_FLUX(
+         CALL CAR_FLUX(
      I                    CAR_S,
      U                    cflux,
      I                    bi, bj, iMin, iMax, jMin, jMax,
@@ -245,9 +249,10 @@ C    code follwing the old OCMIP way
        ELSE       
 C calcite dissolution occurs only below saturation horizon
 C    code following method by Karsten Friis
-        nCALCITEstep = 3600
-        IF(myIter .lt. (nIter0+5) .or.
-     &               mod(myIter,nCALCITEstep) .eq. 0)THEN
+C could be expensive, so find out if it is time to update the omega calcite
+C    field (requires 3-d computation of pH).
+        IF ( DIFFERENT_MULTIPLE(calcOmegaCalciteFreq, myTime,
+     &                                    deltaTClock) ) THEN
 #ifdef ALLOW_DEBUG
           IF (debugMode) CALL DEBUG_CALL('CALCITE_SATURATION',myThid)
 #endif

--- a/pkg/dic/dic_biotic_forcing.F
+++ b/pkg/dic/dic_biotic_forcing.F
@@ -56,8 +56,10 @@ C  myThid               :: thread number
       _RL myTime
       INTEGER myThid
 
-#ifdef ALLOW_PTRACERS
 #ifdef DIC_BIOTIC
+C !FUNCTIONS:       ====================================================
+      LOGICAL  DIFFERENT_MULTIPLE
+      EXTERNAL DIFFERENT_MULTIPLE
 
 C !LOCAL VARIABLES: ====================================================
 C  i,j,k                  :: loop indices
@@ -98,18 +100,11 @@ C  freefe                 :: iron not bound to ligand
       _RL  freefe(1-OLx:sNx+OLx,1-OLy:sNy+OLy,Nr)
 #endif
       INTEGER i,j,k
-#ifdef DIC_CALCITE_SAT
-      INTEGER nCALCITEstep
-#endif
 #ifdef ALLOW_FE
 # ifdef SEDFE
       INTEGER kBottom
 # endif
 #endif
-
-C !FUNCTIONS:       ====================================================
-      LOGICAL  DIFFERENT_MULTIPLE
-      EXTERNAL DIFFERENT_MULTIPLE
 CEOP
 
 #ifdef ALLOW_DEBUG
@@ -234,19 +229,8 @@ C- Carbonate sink
        ENDDO
 
 C carbonate
-       IF ( .NOT. useCalciteSaturation ) THEN
-C calcite dissolution occurs according to a power law scaled by zca 
-C    code follwing the old OCMIP way
-#ifdef ALLOW_DEBUG
-        IF (debugMode) CALL DEBUG_CALL('CAR_FLUX',myThid)
-#endif
-         CALL CAR_FLUX(
-     I                    CAR_S,
-     U                    cflux,
-     I                    bi, bj, iMin, iMax, jMin, jMax,
-     I                    myIter, myTime, myThid )       
 #ifdef DIC_CALCITE_SAT
-       ELSE       
+       IF ( useCalciteSaturation ) THEN
 C calcite dissolution occurs only below saturation horizon
 C    code following method by Karsten Friis
 C could be expensive, so find out if it is time to update the omega calcite
@@ -261,7 +245,6 @@ C    field (requires 3-d computation of pH).
      I                    bi, bj, iMin, iMax, jMin, jMax,
      I                    myIter, myTime, myThid )
         ENDIF
-
 #ifdef ALLOW_DEBUG
         IF (debugMode) CALL DEBUG_CALL('CAR_FLUX_OMEGA_TOP',myThid)
 #endif
@@ -270,9 +253,22 @@ C    field (requires 3-d computation of pH).
      O                    cflux,
      I                    bi, bj, iMin, iMax, jMin, jMax,
      I                    myIter, myTime, myThid )
+       ELSE
 #endif /* DIC_CALCITE_SAT */
+C calcite dissolution occurs according to a power law scaled by zca
+C    code follwing the old OCMIP way
+#ifdef ALLOW_DEBUG
+        IF (debugMode) CALL DEBUG_CALL('CAR_FLUX',myThid)
+#endif
+         CALL CAR_FLUX(
+     I                    CAR_S,
+     U                    cflux,
+     I                    bi, bj, iMin, iMax, jMin, jMax,
+     I                    myIter, myTime, myThid )
+#ifdef DIC_CALCITE_SAT
        ENDIF
-       
+#endif /* DIC_CALCITE_SAT */
+
 C add all tendencies for PO4, DOP, ALK, DIC
        DO k=1,Nr
          DO j=jMin,jMax
@@ -396,10 +392,6 @@ C save averages
      &                             BIOac(i,j,k)*deltaTClock
             CARave(i,j,k,bi,bj)   =CARave(i,j,k,bi,bj)+
      &                             CAR(i,j,k)*deltaTClock
-#ifdef DIC_CALCITE_SAT
-            OmegaCave(i,j,k,bi,bj)=OmegaCave(i,j,k,bi,bj)+
-     &                             OmegaC(i,j,k,bi,bj)*deltaTClock
-#endif
             pfluxave(i,j,k,bi,bj) =pfluxave(i,j,k,bi,bj) +
      &                             pflux(i,j,k)*deltaTClock
             epfluxave(i,j,k,bi,bj)=epfluxave(i,j,k,bi,bj) +
@@ -450,7 +442,6 @@ C---+----1----+----2----+----3----+----4----+----5----+----6----+----7-|--+----|
 #endif
 
 #endif /* DIC_BIOTIC */
-#endif /* ALLOW_PTRACERS */
 
        RETURN
        END

--- a/pkg/dic/dic_biotic_forcing.F
+++ b/pkg/dic/dic_biotic_forcing.F
@@ -263,7 +263,7 @@ C old OCMIP way
      U                    cflux,
      I                    bi, bj, iMin, iMax, jMin, jMax,
      I                    myIter, myTime, myThid )
-#endif
+#endif /* CAR_DISS */
 
 C add all tendencies for PO4, DOP, ALK, DIC
        DO k=1,Nr
@@ -388,8 +388,10 @@ C save averages
      &                             BIOac(i,j,k)*deltaTClock
             CARave(i,j,k,bi,bj)   =CARave(i,j,k,bi,bj)+
      &                             CAR(i,j,k)*deltaTClock
+#ifdef CAR_DISS
             OmegaCave(i,j,k,bi,bj)=OmegaCave(i,j,k,bi,bj)+
      &                             OmegaC(i,j,k,bi,bj)*deltaTClock
+#endif
             pfluxave(i,j,k,bi,bj) =pfluxave(i,j,k,bi,bj) +
      &                             pflux(i,j,k)*deltaTClock
             epfluxave(i,j,k,bi,bj)=epfluxave(i,j,k,bi,bj) +

--- a/pkg/dic/dic_biotic_init.F
+++ b/pkg/dic/dic_biotic_init.F
@@ -39,7 +39,9 @@ C set arrays to zero if first timestep
           CALL TIMEAVE_RESET(pHave,   1,  bi, bj, myThid)
           CALL TIMEAVE_RESET(fluxCO2ave,   1,  bi, bj, myThid)
 #ifdef DIC_CALCITE_SAT
-          CALL TIMEAVE_RESET(OmegaCave,   Nr,  bi, bj, myThid)
+          IF ( useCalciteSaturation ) THEN
+           CALL TIMEAVE_RESET(OmegaCave,   Nr,  bi, bj, myThid)
+          ENDIF
 #endif
           CALL TIMEAVE_RESET(pfluxave,   Nr,  bi, bj, myThid)
           CALL TIMEAVE_RESET(epfluxave,   Nr,  bi, bj, myThid)

--- a/pkg/dic/dic_biotic_init.F
+++ b/pkg/dic/dic_biotic_init.F
@@ -38,7 +38,9 @@ C set arrays to zero if first timestep
           CALL TIMEAVE_RESET(pCO2ave,   1,  bi, bj, myThid)
           CALL TIMEAVE_RESET(pHave,   1,  bi, bj, myThid)
           CALL TIMEAVE_RESET(fluxCO2ave,   1,  bi, bj, myThid)
+#ifdef CAR_DISS
           CALL TIMEAVE_RESET(OmegaCave,   Nr,  bi, bj, myThid)
+#endif
           CALL TIMEAVE_RESET(pfluxave,   Nr,  bi, bj, myThid)
           CALL TIMEAVE_RESET(epfluxave,   Nr,  bi, bj, myThid)
           CALL TIMEAVE_RESET(cfluxave,   Nr,  bi, bj, myThid)

--- a/pkg/dic/dic_biotic_init.F
+++ b/pkg/dic/dic_biotic_init.F
@@ -38,11 +38,6 @@ C set arrays to zero if first timestep
           CALL TIMEAVE_RESET(pCO2ave,   1,  bi, bj, myThid)
           CALL TIMEAVE_RESET(pHave,   1,  bi, bj, myThid)
           CALL TIMEAVE_RESET(fluxCO2ave,   1,  bi, bj, myThid)
-#ifdef DIC_CALCITE_SAT
-          IF ( useCalciteSaturation ) THEN
-           CALL TIMEAVE_RESET(OmegaCave,   Nr,  bi, bj, myThid)
-          ENDIF
-#endif
           CALL TIMEAVE_RESET(pfluxave,   Nr,  bi, bj, myThid)
           CALL TIMEAVE_RESET(epfluxave,   Nr,  bi, bj, myThid)
           CALL TIMEAVE_RESET(cfluxave,   Nr,  bi, bj, myThid)

--- a/pkg/dic/dic_biotic_init.F
+++ b/pkg/dic/dic_biotic_init.F
@@ -38,7 +38,7 @@ C set arrays to zero if first timestep
           CALL TIMEAVE_RESET(pCO2ave,   1,  bi, bj, myThid)
           CALL TIMEAVE_RESET(pHave,   1,  bi, bj, myThid)
           CALL TIMEAVE_RESET(fluxCO2ave,   1,  bi, bj, myThid)
-#ifdef CAR_DISS
+#ifdef DIC_CALCITE_SAT
           CALL TIMEAVE_RESET(OmegaCave,   Nr,  bi, bj, myThid)
 #endif
           CALL TIMEAVE_RESET(pfluxave,   Nr,  bi, bj, myThid)

--- a/pkg/dic/dic_diagnostics_init.F
+++ b/pkg/dic/dic_diagnostics_init.F
@@ -78,7 +78,7 @@ C     Define diagnostics Names :
       CALL DIAGNOSTICS_ADDTOLIST( diagNum,
      I       diagName, diagCode, diagUnits, diagTitle, 0, myThid )
 
-#ifdef CAR_DISS
+#ifdef DIC_CALCITE_SAT
       diagName  = 'DIC3DSIT'
       diagTitle = 'Three dimensional silicate concentration (mol/m3)'
       diagUnits = 'mol/m3          '

--- a/pkg/dic/dic_diagnostics_init.F
+++ b/pkg/dic/dic_diagnostics_init.F
@@ -79,41 +79,41 @@ C     Define diagnostics Names :
      I       diagName, diagCode, diagUnits, diagTitle, 0, myThid )
 
 #ifdef DIC_CALCITE_SAT
-      diagName  = 'DIC3DSIT'
-      diagTitle = 'Three dimensional silicate concentration (mol/m3)'
-      diagUnits = 'mol/m3          '
-      diagCode  = 'SMRP    MR      '
-      CALL DIAGNOSTICS_ADDTOLIST( diagNum,
+       diagName  = 'DIC3DSIT'
+       diagTitle = 'Three dimensional silicate concentration (mol/m3)'
+       diagUnits = 'mol/m3          '
+       diagCode  = 'SMRP    MR      '
+       CALL DIAGNOSTICS_ADDTOLIST( diagNum,
      I       diagName, diagCode, diagUnits, diagTitle, 0, myThid )
 
-      diagName  = 'OMEGAC  '
-      diagTitle = 'Carbonate saturation'
-      diagUnits = 'mol eq/m3/s     '
-      diagCode  = 'SMRP    MR      '
-      CALL DIAGNOSTICS_ADDTOLIST( diagNum,
+       diagName  = 'OMEGAC  '
+       diagTitle = 'Carbonate saturation'
+       diagUnits = 'mol eq/m3/s     '
+       diagCode  = 'SMRP    MR      '
+       CALL DIAGNOSTICS_ADDTOLIST( diagNum,
      I       diagName, diagCode, diagUnits, diagTitle, 0, myThid )
 
-      diagName  = 'DIC3DPH '
-      diagTitle = 'Three dimensional pH (dimensionless)'
-      diagUnits = 'dimensionless   '
-      diagCode  = 'SM P    MR      '
-      CALL DIAGNOSTICS_ADDTOLIST( diagNum,
+       diagName  = 'DIC3DPH '
+       diagTitle = 'Three dimensional pH (dimensionless)'
+       diagUnits = 'dimensionless   '
+       diagCode  = 'SM P    MR      '
+       CALL DIAGNOSTICS_ADDTOLIST( diagNum,
      I       diagName, diagCode, diagUnits, diagTitle, 0, myThid )
 
-      diagName  = 'DIC3DPCO'
-      diagTitle = 'Three dimensional CO2 partial pressure (atm)'
-      diagUnits = 'atm             '
-      diagCode  = 'SMRP    MR      '
-      CALL DIAGNOSTICS_ADDTOLIST( diagNum,
+       diagName  = 'DIC3DPCO'
+       diagTitle = 'Three dimensional CO2 partial pressure (atm)'
+       diagUnits = 'atm             '
+       diagCode  = 'SMRP    MR      '
+       CALL DIAGNOSTICS_ADDTOLIST( diagNum,
      I       diagName, diagCode, diagUnits, diagTitle, 0, myThid )
 
-      diagName  = 'DIC3DCO3'
-      diagTitle = 'Three dimensional carbonate concentration (mol/m3)'
-      diagUnits = 'mol/m3          '
-      diagCode  = 'SMRP    MR      '
-      CALL DIAGNOSTICS_ADDTOLIST( diagNum,
+       diagName  = 'DIC3DCO3'
+       diagTitle = 'Three dimensional carbonate concentration (mol/m3)'
+       diagUnits = 'mol/m3          '
+       diagCode  = 'SMRP    MR      '
+       CALL DIAGNOSTICS_ADDTOLIST( diagNum,
      I       diagName, diagCode, diagUnits, diagTitle, 0, myThid )
-#endif
+#endif /* DIC_CALCITE_SAT */
 
 C---+----1----+----2----+----3----+----4----+----5----+----6----+----7-|--+----|
 

--- a/pkg/dic/dic_fields_load.F
+++ b/pkg/dic/dic_fields_load.F
@@ -30,9 +30,12 @@ C  myThid               :: thread number
 #ifdef ALLOW_DIC
 
 c !LOCAL VARIABLES: ===================================================
-      INTEGER bi, bj, i, j,k
+      INTEGER bi, bj, i, j
       INTEGER intimeP, intime0, intime1
       _RL aWght,bWght
+#ifdef DIC_CALCITE_SAT
+      INTEGER k
+#endif
 #ifdef READ_PAR
       CHARACTER*(MAX_LEN_MBUF) msgBuf
 #endif
@@ -104,8 +107,7 @@ C     data for the period ahead and the period behind myTime.
      &        myIter,myThid )
         ENDIF
 #ifdef DIC_CALCITE_SAT
-        IF ( useCalciteSaturation .AND. 
-     &       DIC_deepSilicaFile .NE. ' '  ) THEN
+        IF ( DIC_deepSilicaFile .NE. ' '  ) THEN
          CALL READ_REC_XYZ_RS( DIC_deepSilicaFile,silicaDeep0,intime0,
      &        myIter,myThid )
          CALL READ_REC_XYZ_RS( DIC_deepSilicaFile,silicaDeep1,intime1,
@@ -149,8 +151,8 @@ C--   fill-in overlap after loading temp arrays:
         _EXCH_XY_RS(atmosp1, myThid )
         _EXCH_XY_RS(silicaSurf0, myThid )
         _EXCH_XY_RS(silicaSurf1, myThid )
-#ifdef DIC_CALCITE_SAT       
-      IF ( useCalciteSaturation ) THEN
+#ifdef DIC_CALCITE_SAT
+      IF ( DIC_deepSilicaFile .NE. ' '  ) THEN
         _EXCH_XYZ_RS(silicaDeep0, myThid )
         _EXCH_XYZ_RS(silicaDeep1, myThid )
       ENDIF
@@ -206,7 +208,7 @@ c          pisvel(i,j,bi,bj)  =0.337*wind(i,j,bi,bj)**2/3.6d5    !QQQQ
 #endif
 #ifdef DIC_CALCITE_SAT
          IF ( useCalciteSaturation .AND.
-     &          DIC_deepSilicaFile .NE. ' '  ) THEN
+     &        DIC_deepSilicaFile .NE. ' '  ) THEN
           DO k=1,Nr
            DO j=1-OLy,sNy+OLy
             DO i=1-OLx,sNx+OLx
@@ -227,12 +229,12 @@ C If file provided for surface silicate, read it in
            ENDDO
 #ifndef ALLOW_AUTODIFF
 #ifdef DIC_CALCITE_SAT
-         ELSEIF ( useCalciteSaturation .AND.
-     &              DIC_deepSilicaFile .NE. ' '  ) THEN
+         ELSEIF ( DIC_deepSilicaFile .NE. ' '  ) THEN
            DO j=1-OLy,sNy+OLy
             DO i=1-OLx,sNx+OLx
 C If no surface silicate file but deep (3d) silicate provided, use top level
-             silicaSurf(i,j,bi,bj) = silicaDeep(i,j,1,bi,bj)
+             silicaSurf(i,j,bi,bj) = bWght*silicaDeep0(i,j,1,bi,bj)
+     &                             + aWght*silicaDeep1(i,j,1,bi,bj)
             ENDDO
            ENDDO
 #endif /* DIC_CALCITE_SAT */

--- a/pkg/dic/dic_fields_load.F
+++ b/pkg/dic/dic_fields_load.F
@@ -103,7 +103,7 @@ C     data for the period ahead and the period behind myTime.
          CALL READ_REC_XY_RS( DIC_silicaFile,silicaSurf1,intime1,
      &        myIter,myThid )
         ENDIF
-#ifdef CAR_DISS
+#ifdef DIC_CALCITE_SAT
         IF ( DIC_deepSilicaFile .NE. ' '  ) THEN
          CALL READ_REC_XYZ_RS( DIC_deepSilicaFile,silicaDeep0,intime0,
      &        myIter,myThid )
@@ -148,7 +148,7 @@ C--   fill-in overlap after loading temp arrays:
         _EXCH_XY_RS(atmosp1, myThid )
         _EXCH_XY_RS(silicaSurf0, myThid )
         _EXCH_XY_RS(silicaSurf1, myThid )
-#ifdef CAR_DISS       
+#ifdef DIC_CALCITE_SAT       
         _EXCH_XYZ_RS(silicaDeep0, myThid )
         _EXCH_XYZ_RS(silicaDeep1, myThid )
 #endif
@@ -201,7 +201,7 @@ c          pisvel(i,j,bi,bj)  =0.337*wind(i,j,bi,bj)**2/3.6d5    !QQQQ
            ENDDO
          ENDIF
 #endif
-#ifdef CAR_DISS
+#ifdef DIC_CALCITE_SAT
          IF ( DIC_deepSilicaFile .NE. ' '  ) THEN
           DO k=1,Nr
            DO j=1-OLy,sNy+OLy
@@ -222,7 +222,7 @@ C If file provided for surface silicate, read it in
             ENDDO
            ENDDO
 #ifndef ALLOW_AUTODIFF
-#ifdef CAR_DISS
+#ifdef DIC_CALCITE_SAT
          ELSEIF ( DIC_deepSilicaFile .NE. ' '  ) THEN
            DO j=1-OLy,sNy+OLy
             DO i=1-OLx,sNx+OLx
@@ -230,7 +230,7 @@ C If no surface silicate file but deep (3d) silicate provided, use top level
              silicaSurf(i,j,bi,bj) = silicaDeep(i,j,1,bi,bj)
             ENDDO
            ENDDO
-#endif /* CAR_DISS */
+#endif /* DIC_CALCITE_SAT */
 #endif /* not ALLOW_AUTODIFF */
          ENDIF
 

--- a/pkg/dic/dic_fields_load.F
+++ b/pkg/dic/dic_fields_load.F
@@ -104,7 +104,8 @@ C     data for the period ahead and the period behind myTime.
      &        myIter,myThid )
         ENDIF
 #ifdef DIC_CALCITE_SAT
-        IF ( DIC_deepSilicaFile .NE. ' '  ) THEN
+        IF ( useCalciteSaturation .AND. 
+     &       DIC_deepSilicaFile .NE. ' '  ) THEN
          CALL READ_REC_XYZ_RS( DIC_deepSilicaFile,silicaDeep0,intime0,
      &        myIter,myThid )
          CALL READ_REC_XYZ_RS( DIC_deepSilicaFile,silicaDeep1,intime1,
@@ -149,8 +150,10 @@ C--   fill-in overlap after loading temp arrays:
         _EXCH_XY_RS(silicaSurf0, myThid )
         _EXCH_XY_RS(silicaSurf1, myThid )
 #ifdef DIC_CALCITE_SAT       
+      IF ( useCalciteSaturation ) THEN
         _EXCH_XYZ_RS(silicaDeep0, myThid )
         _EXCH_XYZ_RS(silicaDeep1, myThid )
+      ENDIF
 #endif
         _EXCH_XY_RS(ice0, myThid )
         _EXCH_XY_RS(ice1, myThid )
@@ -202,7 +205,8 @@ c          pisvel(i,j,bi,bj)  =0.337*wind(i,j,bi,bj)**2/3.6d5    !QQQQ
          ENDIF
 #endif
 #ifdef DIC_CALCITE_SAT
-         IF ( DIC_deepSilicaFile .NE. ' '  ) THEN
+         IF ( useCalciteSaturation .AND.
+     &          DIC_deepSilicaFile .NE. ' '  ) THEN
           DO k=1,Nr
            DO j=1-OLy,sNy+OLy
             DO i=1-OLx,sNx+OLx
@@ -223,7 +227,8 @@ C If file provided for surface silicate, read it in
            ENDDO
 #ifndef ALLOW_AUTODIFF
 #ifdef DIC_CALCITE_SAT
-         ELSEIF ( DIC_deepSilicaFile .NE. ' '  ) THEN
+         ELSEIF ( useCalciteSaturation .AND.
+     &              DIC_deepSilicaFile .NE. ' '  ) THEN
            DO j=1-OLy,sNy+OLy
             DO i=1-OLx,sNx+OLx
 C If no surface silicate file but deep (3d) silicate provided, use top level

--- a/pkg/dic/dic_fields_load.F
+++ b/pkg/dic/dic_fields_load.F
@@ -5,7 +5,7 @@ C !ROUTINE: DIC_FIELDS_LOAD
 
 C !INTERFACE: ==========================================================
       SUBROUTINE DIC_FIELDS_LOAD (
-     I           myIter, myTime, myThid )
+     I           myTime, myIter, myThid )
 
 C !DESCRIPTION:
 C  Read in fields needed for CO2,O2 fluxterms, silica for pH calculation
@@ -20,11 +20,11 @@ C !USES: ===============================================================
 #include "DIC_LOAD.h"
 
 C !INPUT PARAMETERS: ===================================================
-C  myIter               :: current timestep
 C  myTime               :: current time
+C  myIter               :: current timestep
 C  myThid               :: thread number
-      INTEGER myIter
       _RL myTime
+      INTEGER myIter
       INTEGER myThid
 
 #ifdef ALLOW_DIC

--- a/pkg/dic/dic_fields_load.F
+++ b/pkg/dic/dic_fields_load.F
@@ -103,12 +103,14 @@ C     data for the period ahead and the period behind myTime.
          CALL READ_REC_XY_RS( DIC_silicaFile,silicaSurf1,intime1,
      &        myIter,myThid )
         ENDIF
+#ifdef CAR_DISS
         IF ( DIC_deepSilicaFile .NE. ' '  ) THEN
          CALL READ_REC_XYZ_RS( DIC_deepSilicaFile,silicaDeep0,intime0,
      &        myIter,myThid )
          CALL READ_REC_XYZ_RS( DIC_deepSilicaFile,silicaDeep1,intime1,
      &        myIter,myThid )
         ENDIF
+#endif
         IF ( DIC_iceFile .NE. ' '  ) THEN
          CALL READ_REC_XY_RS( DIC_iceFile,ice0,intime0,
      &       myIter,myThid )
@@ -146,8 +148,10 @@ C--   fill-in overlap after loading temp arrays:
         _EXCH_XY_RS(atmosp1, myThid )
         _EXCH_XY_RS(silicaSurf0, myThid )
         _EXCH_XY_RS(silicaSurf1, myThid )
+#ifdef CAR_DISS       
         _EXCH_XYZ_RS(silicaDeep0, myThid )
         _EXCH_XYZ_RS(silicaDeep1, myThid )
+#endif
         _EXCH_XY_RS(ice0, myThid )
         _EXCH_XY_RS(ice1, myThid )
 #ifdef READ_PAR
@@ -197,6 +201,7 @@ c          pisvel(i,j,bi,bj)  =0.337*wind(i,j,bi,bj)**2/3.6d5    !QQQQ
            ENDDO
          ENDIF
 #endif
+#ifdef CAR_DISS
          IF ( DIC_deepSilicaFile .NE. ' '  ) THEN
           DO k=1,Nr
            DO j=1-OLy,sNy+OLy
@@ -207,7 +212,7 @@ c          pisvel(i,j,bi,bj)  =0.337*wind(i,j,bi,bj)**2/3.6d5    !QQQQ
            ENDDO
           ENDDO
          ENDIF
-
+#endif
          IF ( DIC_silicaFile .NE. ' '  ) THEN
            DO j=1-OLy,sNy+OLy
             DO i=1-OLx,sNx+OLx
@@ -217,6 +222,7 @@ C If file provided for surface silicate, read it in
             ENDDO
            ENDDO
 #ifndef ALLOW_AUTODIFF
+#ifdef CAR_DISS
          ELSEIF ( DIC_deepSilicaFile .NE. ' '  ) THEN
            DO j=1-OLy,sNy+OLy
             DO i=1-OLx,sNx+OLx
@@ -224,7 +230,8 @@ C If no surface silicate file but deep (3d) silicate provided, use top level
              silicaSurf(i,j,bi,bj) = silicaDeep(i,j,1,bi,bj)
             ENDDO
            ENDDO
-#endif
+#endif /* CAR_DISS */
+#endif /* not ALLOW_AUTODIFF */
          ENDIF
 
          IF ( DIC_iceFile .NE. ' '  ) THEN

--- a/pkg/dic/dic_ini_forcing.F
+++ b/pkg/dic/dic_ini_forcing.F
@@ -58,18 +58,20 @@ C First call requires that we initialize everything to zero for safety
       CALL LEF_ZERO( chlinput,myThid )
 #endif
 #ifdef DIC_CALCITE_SAT
-      DO bj = myByLo(myThid), myByHi(myThid)
-       DO bi = myBxLo(myThid), myBxHi(myThid)
-        DO k=1,Nr
-         DO j=1-OLy,sNy+OLy
-          DO i=1-OLx,sNx+OLx
-           silicaDeep0(i,j,k,bi,bj) = 0. _d 0
-           silicaDeep1(i,j,k,bi,bj) = 0. _d 0
+      IF ( useCalciteSaturation ) THEN
+       DO bj = myByLo(myThid), myByHi(myThid)
+        DO bi = myBxLo(myThid), myBxHi(myThid)
+         DO k=1,Nr
+          DO j=1-OLy,sNy+OLy
+           DO i=1-OLx,sNx+OLx
+            silicaDeep0(i,j,k,bi,bj) = 0. _d 0
+            silicaDeep1(i,j,k,bi,bj) = 0. _d 0
+           ENDDO
           ENDDO
          ENDDO
         ENDDO
        ENDDO
-      ENDDO
+      ENDIF
 #endif
 
 #ifdef READ_PAR
@@ -105,13 +107,15 @@ C If the chlorophyll climatology is not provided, use this default value.
           ENDDO
          ENDDO       
 #ifdef DIC_CALCITE_SAT
-         DO k=1,Nr
-          DO j=1-OLy,sNy+OLy
-           DO i=1-OLx,sNx+OLx
-             silicaDeep(i,j,k,bi,bj) = 3. _d -2*maskC(i,j,k,bi,bj)
+         IF ( useCalciteSaturation ) THEN
+          DO k=1,Nr
+           DO j=1-OLy,sNy+OLy
+            DO i=1-OLx,sNx+OLx
+              silicaDeep(i,j,k,bi,bj) = 3. _d -2*maskC(i,j,k,bi,bj)
+            ENDDO
            ENDDO
           ENDDO
-         ENDDO
+         ENDIF 
 #endif
 C-    end bi,bj loops
         ENDDO

--- a/pkg/dic/dic_ini_forcing.F
+++ b/pkg/dic/dic_ini_forcing.F
@@ -57,7 +57,7 @@ C First call requires that we initialize everything to zero for safety
 #ifdef LIGHT_CHL
       CALL LEF_ZERO( chlinput,myThid )
 #endif
-#ifdef CAR_DISS
+#ifdef DIC_CALCITE_SAT
       DO bj = myByLo(myThid), myByHi(myThid)
        DO bi = myBxLo(myThid), myBxHi(myThid)
         DO k=1,Nr
@@ -104,7 +104,7 @@ C If the chlorophyll climatology is not provided, use this default value.
 #endif
           ENDDO
          ENDDO       
-#ifdef CAR_DISS
+#ifdef DIC_CALCITE_SAT
          DO k=1,Nr
           DO j=1-OLy,sNy+OLy
            DO i=1-OLx,sNx+OLx

--- a/pkg/dic/dic_ini_forcing.F
+++ b/pkg/dic/dic_ini_forcing.F
@@ -57,6 +57,7 @@ C First call requires that we initialize everything to zero for safety
 #ifdef LIGHT_CHL
       CALL LEF_ZERO( chlinput,myThid )
 #endif
+#ifdef CAR_DISS
       DO bj = myByLo(myThid), myByHi(myThid)
        DO bi = myBxLo(myThid), myBxHi(myThid)
         DO k=1,Nr
@@ -69,6 +70,7 @@ C First call requires that we initialize everything to zero for safety
         ENDDO
        ENDDO
       ENDDO
+#endif
 
 #ifdef READ_PAR
 #ifdef USE_QSW
@@ -85,31 +87,32 @@ C set reasonable values to those that need at least something
         DO bi = myBxLo(myThid), myBxHi(myThid)
          DO j=1-OLy,sNy+OLy
           DO i=1-OLx,sNx+OLx
-            WIND(i,j,bi,bj)    = 5. _d 0*maskC(i,j,1,bi,bj)
-            AtmosP(i,j,bi,bj)  = 1. _d 0*maskC(i,j,1,bi,bj)
-C If neither surface nor deep silicate is provided, set to constant value
+            WIND(i,j,bi,bj)       = 5. _d 0*maskC(i,j,1,bi,bj)
+            AtmosP(i,j,bi,bj)     = 1. _d 0*maskC(i,j,1,bi,bj)
             silicaSurf(i,j,bi,bj) = 7.6838 _d -3*maskC(i,j,1,bi,bj)
-            fIce(i,j,bi,bj)    = 0. _d 0
-            FluxCO2(i,j,bi,bj) = 0. _d 0
+            fIce(i,j,bi,bj)       = 0. _d 0
+            FluxCO2(i,j,bi,bj)    = 0. _d 0
 #ifdef READ_PAR
-            PAR(i,j,bi,bj)     = 100. _d 0*maskC(i,j,1,bi,bj)
+            PAR(i,j,bi,bj)        = 100. _d 0*maskC(i,j,1,bi,bj)
 #endif
 #ifdef LIGHT_CHL
 C If the chlorophyll climatology is not provided, use this default value.
-            CHL(i,j,bi,bj)     = 1. _d -2*maskC(i,j,1,bi,bj)
+            CHL(i,j,bi,bj)        = 1. _d -2*maskC(i,j,1,bi,bj)
 #endif
 #ifdef ALLOW_FE
-            InputFe(i,j,bi,bj) = 1. _d -11*maskC(i,j,1,bi,bj)
+            InputFe(i,j,bi,bj)    = 1. _d -11*maskC(i,j,1,bi,bj)
 #endif
           ENDDO
-         ENDDO
+         ENDDO       
+#ifdef CAR_DISS
          DO k=1,Nr
           DO j=1-OLy,sNy+OLy
            DO i=1-OLx,sNx+OLx
-             silicaDeep(i,j,k,bi,bj) = 3 _d -2*maskC(i,j,k,bi,bj)
+             silicaDeep(i,j,k,bi,bj) = 3. _d -2*maskC(i,j,k,bi,bj)
            ENDDO
           ENDDO
          ENDDO
+#endif
 C-    end bi,bj loops
         ENDDO
        ENDDO

--- a/pkg/dic/dic_ini_forcing.F
+++ b/pkg/dic/dic_ini_forcing.F
@@ -27,7 +27,10 @@ CEOP
 #ifdef ALLOW_DIC
 
 c !LOCAL VARIABLES: ===================================================
-       INTEGER bi,bj,i,j,k
+       INTEGER bi,bj,i,j
+#ifdef DIC_CALCITE_SAT
+      INTEGER k
+#endif
 #if (defined (READ_PAR) && defined (USE_QSW))
        CHARACTER*(MAX_LEN_MBUF) msgBuf
 #endif
@@ -58,20 +61,18 @@ C First call requires that we initialize everything to zero for safety
       CALL LEF_ZERO( chlinput,myThid )
 #endif
 #ifdef DIC_CALCITE_SAT
-      IF ( useCalciteSaturation ) THEN
-       DO bj = myByLo(myThid), myByHi(myThid)
-        DO bi = myBxLo(myThid), myBxHi(myThid)
-         DO k=1,Nr
-          DO j=1-OLy,sNy+OLy
-           DO i=1-OLx,sNx+OLx
-            silicaDeep0(i,j,k,bi,bj) = 0. _d 0
-            silicaDeep1(i,j,k,bi,bj) = 0. _d 0
-           ENDDO
+      DO bj = myByLo(myThid), myByHi(myThid)
+       DO bi = myBxLo(myThid), myBxHi(myThid)
+        DO k=1,Nr
+         DO j=1-OLy,sNy+OLy
+          DO i=1-OLx,sNx+OLx
+           silicaDeep0(i,j,k,bi,bj) = 0. _d 0
+           silicaDeep1(i,j,k,bi,bj) = 0. _d 0
           ENDDO
          ENDDO
         ENDDO
        ENDDO
-      ENDIF
+      ENDDO
 #endif
 
 #ifdef READ_PAR
@@ -105,7 +106,7 @@ C If the chlorophyll climatology is not provided, use this default value.
             InputFe(i,j,bi,bj)    = 1. _d -11*maskC(i,j,1,bi,bj)
 #endif
           ENDDO
-         ENDDO       
+         ENDDO
 #ifdef DIC_CALCITE_SAT
          IF ( useCalciteSaturation ) THEN
           DO k=1,Nr
@@ -115,7 +116,7 @@ C If the chlorophyll climatology is not provided, use this default value.
             ENDDO
            ENDDO
           ENDDO
-         ENDIF 
+         ENDIF
 #endif
 C-    end bi,bj loops
         ENDDO

--- a/pkg/dic/dic_init_fixed.F
+++ b/pkg/dic/dic_init_fixed.F
@@ -26,8 +26,10 @@ CEOP
 
 #ifdef ALLOW_DIC
       INTEGER k
-      CHARACTER*(MAX_LEN_MBUF) msgBuf
       INTEGER iUnit
+#ifdef DIC_BIOTIC
+      CHARACTER*(MAX_LEN_MBUF) msgBuf
+#endif
 
 C---+----1----+----2----+----3----+----4----+----5----+----6----+----7-|--+----|
 
@@ -62,7 +64,7 @@ C coefficients for determining saturation O2
 C     Set other constant/flag
 
       IF ( dic_int1.EQ.2 ) THEN
-        CALL MDSFINDUNIT( iUnit, mythid )
+        CALL MDSFINDUNIT( iUnit, myThid )
         OPEN(UNIT=iUnit,FILE='co2atmos.dat',STATUS='old')
         DO k=1,dic_int2
           READ(iUnit,*) co2atmos(k)

--- a/pkg/dic/dic_init_varia.F
+++ b/pkg/dic/dic_init_varia.F
@@ -58,6 +58,7 @@ C--   Initialise alpha & rain_ratio fields with fixed (& Uniform) values
             rain_ratio(i,j,bi,bj) = rainRatioUniform
           ENDDO
         ENDDO
+#ifdef CAR_DISS
         DO k = 1, Nr
          DO j=1-OLy,sNy+OLy
           DO i=1-OLx,sNx+OLx
@@ -65,6 +66,7 @@ C--   Initialise alpha & rain_ratio fields with fixed (& Uniform) values
           ENDDO
          ENDDO
         ENDDO
+#endif /* CAR_DISS */
        ENDDO
       ENDDO
 #endif /* DIC_BIOTIC */

--- a/pkg/dic/dic_init_varia.F
+++ b/pkg/dic/dic_init_varia.F
@@ -59,13 +59,15 @@ C--   Initialise alpha & rain_ratio fields with fixed (& Uniform) values
           ENDDO
         ENDDO
 #ifdef DIC_CALCITE_SAT
-        DO k = 1, Nr
-         DO j=1-OLy,sNy+OLy
-          DO i=1-OLx,sNx+OLx
-            omegaC(i,j,k,bi,bj) =  0. _d 0
+        IF ( useCalciteSaturation ) THEN
+          DO k = 1, Nr
+           DO j=1-OLy,sNy+OLy
+            DO i=1-OLx,sNx+OLx
+              omegaC(i,j,k,bi,bj) =  0. _d 0
+            ENDDO
+           ENDDO
           ENDDO
-         ENDDO
-        ENDDO
+        ENDIF
 #endif /* DIC_CALCITE_SAT */
        ENDDO
       ENDDO

--- a/pkg/dic/dic_init_varia.F
+++ b/pkg/dic/dic_init_varia.F
@@ -58,7 +58,7 @@ C--   Initialise alpha & rain_ratio fields with fixed (& Uniform) values
             rain_ratio(i,j,bi,bj) = rainRatioUniform
           ENDDO
         ENDDO
-#ifdef CAR_DISS
+#ifdef DIC_CALCITE_SAT
         DO k = 1, Nr
          DO j=1-OLy,sNy+OLy
           DO i=1-OLx,sNx+OLx
@@ -66,7 +66,7 @@ C--   Initialise alpha & rain_ratio fields with fixed (& Uniform) values
           ENDDO
          ENDDO
         ENDDO
-#endif /* CAR_DISS */
+#endif /* DIC_CALCITE_SAT */
        ENDDO
       ENDDO
 #endif /* DIC_BIOTIC */

--- a/pkg/dic/dic_init_varia.F
+++ b/pkg/dic/dic_init_varia.F
@@ -27,8 +27,12 @@ C     myThid               :: thread number
 CEOP
 
 #ifdef ALLOW_DIC
+#ifdef DIC_BIOTIC
       INTEGER i,j, bi,bj
+# ifdef DIC_CALCITE_SAT
       INTEGER k
+# endif
+#endif
 c     CHARACTER*(MAX_LEN_MBUF) msgBuf
 
 C---+----1----+----2----+----3----+----4----+----5----+----6----+----7-|--+----|
@@ -59,15 +63,13 @@ C--   Initialise alpha & rain_ratio fields with fixed (& Uniform) values
           ENDDO
         ENDDO
 #ifdef DIC_CALCITE_SAT
-        IF ( useCalciteSaturation ) THEN
-          DO k = 1, Nr
-           DO j=1-OLy,sNy+OLy
-            DO i=1-OLx,sNx+OLx
-              omegaC(i,j,k,bi,bj) =  0. _d 0
-            ENDDO
-           ENDDO
+        DO k = 1, Nr
+         DO j=1-OLy,sNy+OLy
+          DO i=1-OLx,sNx+OLx
+            omegaC(i,j,k,bi,bj) =  0. _d 0
           ENDDO
-        ENDIF
+         ENDDO
+        ENDDO
 #endif /* DIC_CALCITE_SAT */
        ENDDO
       ENDDO

--- a/pkg/dic/dic_mnc_init.F
+++ b/pkg/dic/dic_mnc_init.F
@@ -75,7 +75,7 @@ CEOP
       CALL MNC_CW_ADD_VATTR_TEXT('dic_fluxCO2_ave','description',
      &     '', myThid)
 
-#ifdef CAR_DISS
+#ifdef DIC_CALCITE_SAT
       CALL MNC_CW_ADD_VNAME(
      &     'dic_OmegaC_ave', 'Cen_xy_Hn__C__t', 4,5, myThid)
       CALL MNC_CW_ADD_VATTR_TEXT(

--- a/pkg/dic/dic_mnc_init.F
+++ b/pkg/dic/dic_mnc_init.F
@@ -15,6 +15,7 @@ C     !USES:
 #include "SIZE.h"
 #include "EEPARAMS.h"
 #include "PARAMS.h"
+#include "DIC_VARS.h"
 
 C     !INPUT PARAMETERS:
 C     myThid               :: thread number
@@ -76,12 +77,14 @@ CEOP
      &     '', myThid)
 
 #ifdef DIC_CALCITE_SAT
-      CALL MNC_CW_ADD_VNAME(
+      IF ( useCalciteSaturation ) THEN
+       CALL MNC_CW_ADD_VNAME(
      &     'dic_OmegaC_ave', 'Cen_xy_Hn__C__t', 4,5, myThid)
-      CALL MNC_CW_ADD_VATTR_TEXT(
+       CALL MNC_CW_ADD_VATTR_TEXT(
      &     'dic_OmegaC_ave','units','--', myThid)
-      CALL MNC_CW_ADD_VATTR_TEXT('dic_OmegaC_ave','description',
+       CALL MNC_CW_ADD_VATTR_TEXT('dic_OmegaC_ave','description',
      &     '', myThid)
+      ENDIF
 #endif
 
       CALL MNC_CW_ADD_VNAME(

--- a/pkg/dic/dic_mnc_init.F
+++ b/pkg/dic/dic_mnc_init.F
@@ -76,17 +76,6 @@ CEOP
       CALL MNC_CW_ADD_VATTR_TEXT('dic_fluxCO2_ave','description',
      &     '', myThid)
 
-#ifdef DIC_CALCITE_SAT
-      IF ( useCalciteSaturation ) THEN
-       CALL MNC_CW_ADD_VNAME(
-     &     'dic_OmegaC_ave', 'Cen_xy_Hn__C__t', 4,5, myThid)
-       CALL MNC_CW_ADD_VATTR_TEXT(
-     &     'dic_OmegaC_ave','units','--', myThid)
-       CALL MNC_CW_ADD_VATTR_TEXT('dic_OmegaC_ave','description',
-     &     '', myThid)
-      ENDIF
-#endif
-
       CALL MNC_CW_ADD_VNAME(
      &     'dic_pflux_ave', 'Cen_xy_Hn__C__t', 4,5, myThid)
       CALL MNC_CW_ADD_VATTR_TEXT(
@@ -107,7 +96,6 @@ CEOP
      &     'dic_cflux_ave','units','--', myThid)
       CALL MNC_CW_ADD_VATTR_TEXT('dic_cflux_ave','description',
      &     '', myThid)
-
 
       ENDIF
 

--- a/pkg/dic/dic_mnc_init.F
+++ b/pkg/dic/dic_mnc_init.F
@@ -75,12 +75,14 @@ CEOP
       CALL MNC_CW_ADD_VATTR_TEXT('dic_fluxCO2_ave','description',
      &     '', myThid)
 
+#ifdef CAR_DISS
       CALL MNC_CW_ADD_VNAME(
      &     'dic_OmegaC_ave', 'Cen_xy_Hn__C__t', 4,5, myThid)
       CALL MNC_CW_ADD_VATTR_TEXT(
      &     'dic_OmegaC_ave','units','--', myThid)
       CALL MNC_CW_ADD_VATTR_TEXT('dic_OmegaC_ave','description',
      &     '', myThid)
+#endif
 
       CALL MNC_CW_ADD_VNAME(
      &     'dic_pflux_ave', 'Cen_xy_Hn__C__t', 4,5, myThid)

--- a/pkg/dic/dic_readparms.F
+++ b/pkg/dic/dic_readparms.F
@@ -75,7 +75,9 @@ C     =2 :: use SEC solver  from Munhoven (2013);
 C     =3 :: use FAST solver from Munhoven (2013);
 C  useCalciteSaturation :: dissolve calcium carbonate below the calcite saturation
 C          horizon following method by Karsten Friis
-C   zca         :: scale depth for CaCO3 remineralization (m)
+C  calcOmegaCalciteFreq :: Frequency that 3d calcite saturation state, omegaC,
+C          is calculated. 
+C   zca         :: scale depth for CaCO3 remineralization power law (m)
 C----
 
       NAMELIST /ABIOTIC_PARMS/
@@ -83,7 +85,11 @@ C----
      &  selectBTconst, selectFTconst,
      &  selectHFconst, selectK1K2const,
      &  selectPHsolver,
-     &  useCalciteSaturation, zca
+     &  useCalciteSaturation, 
+#ifdef DIC_CALCITE_SAT
+     &  calcOmegaCalciteFreq,
+#endif
+     &  zca
 
 #ifdef DIC_BIOTIC
 C-- Biotic dic parameters:
@@ -145,6 +151,10 @@ C---+----1----+----2----+----3----+----4----+----5----+----6----+----7-|--+----|
        selectK1K2const = UNSET_I
        selectPHsolver  = UNSET_I
        useCalciteSaturation = .FALSE.
+#ifdef DIC_CALCITE_SAT
+C set calcite saturation calculation to every timestep - could be expensive       
+       calcOmegaCalciteFreq = deltaTClock
+#endif
        zca             = 3500. _d 0
 
 #ifdef DIC_BIOTIC
@@ -356,7 +366,14 @@ C- namelist ABIOTIC_PARMS
        CALL WRITE_0D_L( useCalciteSaturation, INDEX_NONE, 
      &  'useCalciteSaturation  =',
      &  '  /* Flag for omegaC calculation on/off */')
-     
+#ifdef DIC_CALCITE_SAT
+      IF ( useCalciteSaturation ) THEN 
+       CALL WRITE_0D_RL( calcOmegaCalciteFreq, INDEX_NONE,
+     &  'calcOmegaCalciteFreq =',
+     &  ' /* Frequency of calcite saturation calculation (s) */')
+      ENDIF
+#endif
+
 #ifdef DIC_BIOTIC
 C- namelist BIOTIC_PARMS
        CALL WRITE_0D_RL( DOPfraction, INDEX_NONE,'DOPfraction =',
@@ -521,8 +538,8 @@ C---+----1----+----2----+----3----+----4----+----5----+----6----+----7-|--+----|
 #endif /* CARBONCHEM_SOLVESAPHE */
 
 #ifdef DIC_CALCITE_SAT
-C Issue a soft message if a deepSilicaFile is supplied but will not be used
-C    because useCalciteSaturation is FALSE
+C Issue a soft message if a deepSilicaFile is supplied 
+C    but will not be used because useCalciteSaturation is FALSE
       IF ( DIC_deepSilicaFile .NE. ' ' .AND. 
      &                        .NOT. useCalciteSaturation ) THEN
         WRITE(msgBuf,'(2A)') 'DIC_READPARMS: ',

--- a/pkg/dic/dic_readparms.F
+++ b/pkg/dic/dic_readparms.F
@@ -73,13 +73,17 @@ C     =0 :: use Follows et al., (2006) solver;
 C     =1 :: use the GENERAL solver from Munhoven (2013);
 C     =2 :: use SEC solver  from Munhoven (2013);
 C     =3 :: use FAST solver from Munhoven (2013);
+C  useCalciteSaturation :: dissolve calcium carbonate below the calcite saturation
+C          horizon following method by Karsten Friis
+C   zca         :: scale depth for CaCO3 remineralization (m)
 C----
 
       NAMELIST /ABIOTIC_PARMS/
      &  permil, Pa2Atm,
      &  selectBTconst, selectFTconst,
      &  selectHFconst, selectK1K2const,
-     &  selectPHsolver
+     &  selectPHsolver,
+     &  useCalciteSaturation, zca
 
 #ifdef DIC_BIOTIC
 C-- Biotic dic parameters:
@@ -92,7 +96,6 @@ C                  first layer deeper than -zcrit
 C   O2crit      :: critical oxygen level (mol/m3)
 C   R_OP, R_CP  :: stochiometric ratios
 C   R_NP, R_FeP
-C   zca         :: scale depth for CaCO3 remineralization (m)
 CC Parameters for light/nutrient limited bioac
 C   parfrac     :: fraction of Qsw that is PAR
 C   k0          :: light attentuation coefficient (1/m)
@@ -115,7 +118,7 @@ C                  read in rainRatioUniform and filled in 2d array rain_ratio
 
       NAMELIST /BIOTIC_PARMS/
      & DOPfraction, KDOPRemin, KRemin, zcrit,
-     & O2crit, R_OP, R_CP, R_NP, R_FeP, zca,
+     & O2crit, R_OP, R_CP, R_NP, R_FeP, 
      & parfrac, k0, lit0, KPO4, KFE, kchl,
      & alpfe, fesedflux_pcm, FeIntSec, freefemax,
      & KScav, ligand_stab, ligand_tot,
@@ -141,6 +144,8 @@ C---+----1----+----2----+----3----+----4----+----5----+----6----+----7-|--+----|
        selectHFconst   = UNSET_I
        selectK1K2const = UNSET_I
        selectPHsolver  = UNSET_I
+       useCalciteSaturation = .FALSE.
+       zca             = 3500. _d 0
 
 #ifdef DIC_BIOTIC
        DOPfraction = 0.67 _d 0
@@ -152,7 +157,6 @@ C---+----1----+----2----+----3----+----4----+----5----+----6----+----7-|--+----|
        R_CP        = 117. _d 0
        R_NP        = 16. _d 0
        R_FeP       = 0.000468 _d 0
-       zca         = 3500. _d 0
        parfrac     = 0.4 _d 0
        k0          = 0.02 _d 0
        kchl        = 0.02 _d 0
@@ -347,7 +351,12 @@ C- namelist ABIOTIC_PARMS
      &  ' /* Ref. density to convert mol/m3 to mol/kg */')
        CALL WRITE_0D_RL( Pa2Atm, INDEX_NONE,'Pa2Atm =',
      &  ' /* Atmosph. pressure conversion coeff (to Atm) */')
-
+       CALL WRITE_0D_RL( zca, INDEX_NONE,'zca =',
+     &  ' /* Scale depth for CaCO3 remineralization (m) */')
+       CALL WRITE_0D_L( useCalciteSaturation, INDEX_NONE, 
+     &  'useCalciteSaturation  =',
+     &  '  /* Flag for omegaC calculation on/off */')
+     
 #ifdef DIC_BIOTIC
 C- namelist BIOTIC_PARMS
        CALL WRITE_0D_RL( DOPfraction, INDEX_NONE,'DOPfraction =',
@@ -368,8 +377,6 @@ C- namelist BIOTIC_PARMS
      &  ' /* Stochiometric ratio R_NP */')
        CALL WRITE_0D_RL( R_FeP, INDEX_NONE,'R_FeP =',
      &  ' /* Stochiometric ratio R_FeP */')
-       CALL WRITE_0D_RL( zca, INDEX_NONE,'zca =',
-     &  ' /* Scale depth for CaCO3 remineralization (m) */')
        CALL WRITE_0D_RL( parfrac, INDEX_NONE,'parfrac =',
      &  ' /* Fraction of Qsw that is PAR */')
        CALL WRITE_0D_RL( k0, INDEX_NONE,'k0 =',
@@ -412,8 +419,10 @@ C- namelist DIC_FORCING
        CALL WRITE_0D_C( DIC_silicaFile, -1,INDEX_NONE,
      & 'DIC_silicaFile=','  /* File name of surface silica */')
 #ifdef DIC_CALCITE_SAT
+      IF ( useCalciteSaturation ) THEN
        CALL WRITE_0D_C( DIC_deepSilicaFile, -1,INDEX_NONE,
      & 'DIC_deepSilicaFile=','  /* File name of 3d silica field */')
+      ENDIF
 #endif
        CALL WRITE_0D_C( DIC_iceFile, -1, INDEX_NONE, 'DIC_iceFile =',
      & '  /* File name of seaice fraction */')
@@ -511,7 +520,33 @@ C---+----1----+----2----+----3----+----4----+----5----+----6----+----7-|--+----|
       ENDIF
 #endif /* CARBONCHEM_SOLVESAPHE */
 
-#ifndef DIC_CALCITE_SAT
+#ifdef DIC_CALCITE_SAT
+C Issue a soft message if a deepSilicaFile is supplied but will not be used
+C    because useCalciteSaturation is FALSE
+      IF ( DIC_deepSilicaFile .NE. ' ' .AND. 
+     &                        .NOT. useCalciteSaturation ) THEN
+        WRITE(msgBuf,'(2A)') 'DIC_READPARMS: ',
+     &    'to use: DIC_deepSilicaFile (3d silicate input)'
+         CALL PRINT_MESSAGE(msgBuf,iUnit,SQUEEZE_RIGHT,myThid)
+        WRITE(msgBuf,'(2A)') 'DIC_READPARMS: ',
+     &    'needs: "useCalciteSaturation=.TRUE." in "data.dic"'
+         CALL PRINT_MESSAGE(msgBuf,iUnit,SQUEEZE_RIGHT,myThid)
+      ENDIF
+#else
+C Issue an error and stop if useCalciteSaturation is TRUE but 
+C    DIC_CALCITE_SATURATION code is not compiled
+      IF ( useCalciteSaturation ) THEN
+        WRITE(msgBuf,'(2A)') 'DIC_READPARMS: ',
+     &    'to enable: useCalciteSaturation'
+        CALL PRINT_ERROR( msgBuf, myThid )
+        WRITE(msgBuf,'(2A)') 'DIC_READPARMS: ',
+     &    'needs: "#define DIC_CALCITE_SAT" in "DIC_OPTIONS.h"'
+        CALL PRINT_ERROR( msgBuf, myThid )
+        errCount = errCount + 1
+      ENDIF
+
+C Issue an error and stop if deepSilicaFile is supplied but 
+C    DIC_CALCITE_SATURATION code is not compiled
       IF ( DIC_deepSilicaFile .NE. ' '  ) THEN
         WRITE(msgBuf,'(2A)') 'DIC_READPARMS: ',
      &    'to use: DIC_deepSilicaFile (3d silicate input)'
@@ -519,7 +554,7 @@ C---+----1----+----2----+----3----+----4----+----5----+----6----+----7-|--+----|
         WRITE(msgBuf,'(2A)') 'DIC_READPARMS: ',
      &    'needs: "#define DIC_CALCITE_SAT" in "DIC_OPTIONS.h"'
         CALL PRINT_ERROR( msgBuf, myThid )
-        errCount = errCount + 1      
+        errCount = errCount + 1
       ENDIF
 #endif /* DIC_CALCITE_SAT */
 

--- a/pkg/dic/dic_readparms.F
+++ b/pkg/dic/dic_readparms.F
@@ -77,6 +77,9 @@ C  useCalciteSaturation :: dissolve calcium carbonate below the calcite
 C                          saturation horizon following method by Karsten Friis
 C  calcOmegaCalciteFreq :: Frequency that 3d calcite saturation state, omegaC,
 C                          is calculated.
+C  nIterCO3           :: Number of iterations of the Follows 3D pH solver to 
+C                          calculate deep carbonate ion concenetration (no
+C                          effect when using the Munhoven/SolveSapHe solvers).
 C  KierRateK            :: Rate constant (%) for calcite dissolution from
 C                          Kier (1980) Geochem. Cosmochem. Acta.
 C  KierRateExp          :: Rate exponent for calcite dissolution from
@@ -95,7 +98,7 @@ C----
      &  selectPHsolver,
      &  useCalciteSaturation,
      &  calcOmegaCalciteFreq, KierRateK, KierRateExp,
-     &  WsinkPIC, selectCalciteBottomRemin,
+     &  WsinkPIC, selectCalciteBottomRemin, nIterCO3,
      &  zca
 
 #ifdef DIC_BIOTIC
@@ -164,6 +167,8 @@ C set calcite saturation calculation to every timestep - could be expensive
 C flag to either remineralize in bottom or top layer if flux
 C reaches bottom layer 0=bottom, 1=top
        selectCalciteBottomRemin = 1
+C number of iterations for the Follows 3d pH solver
+       nIterCO3               = 10
 C set some nominal particulate sinking rate (m/s); try 100m/day:
        WsinkPIC                 = 100. _d 0/86400. _d 0
 C Kier rate exponent for calcite (4.2 for aragonite)

--- a/pkg/dic/dic_readparms.F
+++ b/pkg/dic/dic_readparms.F
@@ -73,18 +73,18 @@ C     =0 :: use Follows et al., (2006) solver;
 C     =1 :: use the GENERAL solver from Munhoven (2013);
 C     =2 :: use SEC solver  from Munhoven (2013);
 C     =3 :: use FAST solver from Munhoven (2013);
-C  useCalciteSaturation :: dissolve calcium carbonate below the calcite saturation
-C          horizon following method by Karsten Friis
+C  useCalciteSaturation :: dissolve calcium carbonate below the calcite
+C                          saturation horizon following method by Karsten Friis
 C  calcOmegaCalciteFreq :: Frequency that 3d calcite saturation state, omegaC,
-C          is calculated. 
-C  KierRateK            :: Rate constant (%) for calcite dissolution from  
-C          Kier (1980) Geochem. Cosmochem. Acta.
+C                          is calculated.
+C  KierRateK            :: Rate constant (%) for calcite dissolution from
+C                          Kier (1980) Geochem. Cosmochem. Acta.
 C  KierRateExp          :: Rate exponent for calcite dissolution from
-C          Kier (1980) Geochem. Cosmochem. Acta.
+C                          Kier (1980) Geochem. Cosmochem. Acta.
 C  WsinkPIC             :: sinking speed (m/s) of particulate inorganic carbon
-C          for calculation of calcite dissolution through the watercolumn
-C  selectCalciteBottomRemin :: flag to either remineralize in bottom or top layer if flux
-c          reaches bottom layer 0=bottom, 1=top 
+C                          for calcite dissolution through the watercolumn
+C  selectCalciteBottomRemin :: to either remineralize in bottom or top layer
+C                          if flux reaches bottom layer: =0 : bottom, =1 : top
 C   zca         :: scale depth for CaCO3 remineralization power law (m)
 C----
 
@@ -93,11 +93,9 @@ C----
      &  selectBTconst, selectFTconst,
      &  selectHFconst, selectK1K2const,
      &  selectPHsolver,
-     &  useCalciteSaturation, 
-#ifdef DIC_CALCITE_SAT
-     &  calcOmegaCalciteFreq, KierRateK, KierRateExp, 
+     &  useCalciteSaturation,
+     &  calcOmegaCalciteFreq, KierRateK, KierRateExp,
      &  WsinkPIC, selectCalciteBottomRemin,
-#endif
      &  zca
 
 #ifdef DIC_BIOTIC
@@ -133,7 +131,7 @@ C                  read in rainRatioUniform and filled in 2d array rain_ratio
 
       NAMELIST /BIOTIC_PARMS/
      & DOPfraction, KDOPRemin, KRemin, zcrit,
-     & O2crit, R_OP, R_CP, R_NP, R_FeP, 
+     & O2crit, R_OP, R_CP, R_NP, R_FeP,
      & parfrac, k0, lit0, KPO4, KFE, kchl,
      & alpfe, fesedflux_pcm, FeIntSec, freefemax,
      & KScav, ligand_stab, ligand_tot,
@@ -160,20 +158,19 @@ C---+----1----+----2----+----3----+----4----+----5----+----6----+----7-|--+----|
        selectK1K2const = UNSET_I
        selectPHsolver  = UNSET_I
        useCalciteSaturation = .FALSE.
-#ifdef DIC_CALCITE_SAT
-C set calcite saturation calculation to every timestep - could be expensive       
+C-- Parameters used in Calcite Saturation calculation (useCalciteSaturation=T):
+C set calcite saturation calculation to every timestep - could be expensive
        calcOmegaCalciteFreq     = deltaTClock
-c flag to either remineralize in bottom or top layer if flux
-c reaches bottom layer 0=bottom, 1=top
+C flag to either remineralize in bottom or top layer if flux
+C reaches bottom layer 0=bottom, 1=top
        selectCalciteBottomRemin = 1
-c set some nominal particulate sinking rate (m/s)
-c try 100m/day
+C set some nominal particulate sinking rate (m/s); try 100m/day:
        WsinkPIC                 = 100. _d 0/86400. _d 0
 C Kier rate exponent for calcite (4.2 for aragonite)
        KierRateExp              = 4.54 _d 0
 C Kier dissolution rate constant (%/day)
        KierRateK                = 7.177 _d 0
-#endif
+C-- setting default values for Calcite Saturation params ends here.
        zca                      = 3500. _d 0
 
 #ifdef DIC_BIOTIC
@@ -215,7 +212,7 @@ C Kier dissolution rate constant (%/day)
        dic_int3    = 0
        dic_int4    = 0
        dic_pCO2    = 278. _d -6
-c default periodic forcing to same as for physics
+C default periodic forcing to same as for physics
        DIC_forcingPeriod = externForcingPeriod
        DIC_forcingCycle  = externForcingCycle
 
@@ -382,25 +379,23 @@ C- namelist ABIOTIC_PARMS
      &  ' /* Atmosph. pressure conversion coeff (to Atm) */')
        CALL WRITE_0D_RL( zca, INDEX_NONE,'zca =',
      &  ' /* Scale depth for CaCO3 remineralization (m) */')
-       CALL WRITE_0D_L( useCalciteSaturation, INDEX_NONE, 
+       CALL WRITE_0D_L( useCalciteSaturation, INDEX_NONE,
      &  'useCalciteSaturation  =',
      &  '  /* Flag for omegaC calculation on/off */')
-#ifdef DIC_CALCITE_SAT
-      IF ( useCalciteSaturation ) THEN 
+      IF ( useCalciteSaturation ) THEN
        CALL WRITE_0D_RL( calcOmegaCalciteFreq, INDEX_NONE,
      &  'calcOmegaCalciteFreq =',
      &  ' /* Frequency of calcite saturation calculation (s) */')
        CALL WRITE_0D_RL( KierRateK, INDEX_NONE, 'KierRateK =',
-     &  ' /* Rate constant for calcite dissolution (%/day) */')     
+     &  ' /* Rate constant for calcite dissolution (%/day) */')
        CALL WRITE_0D_RL( KierRateExp, INDEX_NONE, 'KierRateExp =',
-     &  ' /* Rate exponent for calcite dissolution */')     
+     &  ' /* Rate exponent for calcite dissolution */')
        CALL WRITE_0D_RL( WsinkPIC, INDEX_NONE, 'WsinkPIC =',
      &  ' /* Sinking speed of particulate inorganic carbon (m/s) */')
-       CALL WRITE_0D_I( selectCalciteBottomRemin, INDEX_NONE, 
+       CALL WRITE_0D_I( selectCalciteBottomRemin, INDEX_NONE,
      &  'selectCalciteBottomRemin =',
-     &  ' /* Remineralize CO3 bottom flux (0) here or (1) top layer */')     
+     &  ' /* Remineralize CO3 bottom flux: =0: here, =1: top layer */')
       ENDIF
-#endif
 
 #ifdef DIC_BIOTIC
 C- namelist BIOTIC_PARMS
@@ -463,12 +458,10 @@ C- namelist DIC_FORCING
      & '  /* File name of atmospheric pressure*/')
        CALL WRITE_0D_C( DIC_silicaFile, -1,INDEX_NONE,
      & 'DIC_silicaFile=','  /* File name of surface silica */')
-#ifdef DIC_CALCITE_SAT
       IF ( useCalciteSaturation ) THEN
        CALL WRITE_0D_C( DIC_deepSilicaFile, -1,INDEX_NONE,
      & 'DIC_deepSilicaFile=','  /* File name of 3d silica field */')
       ENDIF
-#endif
        CALL WRITE_0D_C( DIC_iceFile, -1, INDEX_NONE, 'DIC_iceFile =',
      & '  /* File name of seaice fraction */')
        CALL WRITE_0D_C( DIC_parFile, -1,INDEX_NONE,'DIC_parFile=',
@@ -566,9 +559,9 @@ C---+----1----+----2----+----3----+----4----+----5----+----6----+----7-|--+----|
 #endif /* CARBONCHEM_SOLVESAPHE */
 
 #ifdef DIC_CALCITE_SAT
-C Issue a soft message if a deepSilicaFile is supplied 
+C Issue a soft message if a deepSilicaFile is supplied
 C    but will not be used because useCalciteSaturation is FALSE
-      IF ( DIC_deepSilicaFile .NE. ' ' .AND. 
+      IF ( DIC_deepSilicaFile .NE. ' ' .AND.
      &                        .NOT. useCalciteSaturation ) THEN
         WRITE(msgBuf,'(2A)') 'DIC_READPARMS: ',
      &    'to use: DIC_deepSilicaFile (3d silicate input)'
@@ -578,7 +571,7 @@ C    but will not be used because useCalciteSaturation is FALSE
          CALL PRINT_MESSAGE(msgBuf,iUnit,SQUEEZE_RIGHT,myThid)
       ENDIF
 #else
-C Issue an error and stop if useCalciteSaturation is TRUE but 
+C Issue an error and stop if useCalciteSaturation is TRUE but
 C    DIC_CALCITE_SATURATION code is not compiled
       IF ( useCalciteSaturation ) THEN
         WRITE(msgBuf,'(2A)') 'DIC_READPARMS: ',
@@ -590,7 +583,7 @@ C    DIC_CALCITE_SATURATION code is not compiled
         errCount = errCount + 1
       ENDIF
 
-C Issue an error and stop if deepSilicaFile is supplied but 
+C Issue an error and stop if deepSilicaFile is supplied but
 C    DIC_CALCITE_SATURATION code is not compiled
       IF ( DIC_deepSilicaFile .NE. ' '  ) THEN
         WRITE(msgBuf,'(2A)') 'DIC_READPARMS: ',

--- a/pkg/dic/dic_readparms.F
+++ b/pkg/dic/dic_readparms.F
@@ -411,8 +411,10 @@ C- namelist DIC_FORCING
      & '  /* File name of atmospheric pressure*/')
        CALL WRITE_0D_C( DIC_silicaFile, -1,INDEX_NONE,
      & 'DIC_silicaFile=','  /* File name of surface silica */')
+#ifdef CAR_DISS
        CALL WRITE_0D_C( DIC_deepSilicaFile, -1,INDEX_NONE,
      & 'DIC_deepSilicaFile=','  /* File name of 3d silica field */')
+#endif
        CALL WRITE_0D_C( DIC_iceFile, -1, INDEX_NONE, 'DIC_iceFile =',
      & '  /* File name of seaice fraction */')
        CALL WRITE_0D_C( DIC_parFile, -1,INDEX_NONE,'DIC_parFile=',
@@ -508,6 +510,18 @@ C---+----1----+----2----+----3----+----4----+----5----+----6----+----7-|--+----|
         errCount = errCount + 1
       ENDIF
 #endif /* CARBONCHEM_SOLVESAPHE */
+
+#ifndef CAR_DISS
+      IF ( DIC_deepSilicaFile .NE. ' '  ) THEN
+        WRITE(msgBuf,'(2A)') 'DIC_READPARMS: ',
+     &    'to use: DIC_deepSilicaFile (3d silicate input)'
+        CALL PRINT_ERROR( msgBuf, myThid )
+        WRITE(msgBuf,'(2A)') 'DIC_READPARMS: ',
+     &    'needs: "#define CAR_DISS" in "DIC_OPTIONS.h"'
+        CALL PRINT_ERROR( msgBuf, myThid )
+        errCount = errCount + 1      
+      ENDIF
+#endif /* CAR_DISS */
 
       IF ( errCount.GE.1 ) THEN
         WRITE(msgBuf,'(A,I3,A)')

--- a/pkg/dic/dic_readparms.F
+++ b/pkg/dic/dic_readparms.F
@@ -77,7 +77,7 @@ C  useCalciteSaturation :: dissolve calcium carbonate below the calcite
 C                          saturation horizon following method by Karsten Friis
 C  calcOmegaCalciteFreq :: Frequency that 3d calcite saturation state, omegaC,
 C                          is calculated.
-C  nIterCO3           :: Number of iterations of the Follows 3D pH solver to 
+C  nIterCO3             :: Number of iterations of the Follows 3D pH solver to
 C                          calculate deep carbonate ion concenetration (no
 C                          effect when using the Munhoven/SolveSapHe solvers).
 C  KierRateK            :: Rate constant (%) for calcite dissolution from
@@ -96,9 +96,9 @@ C----
      &  selectBTconst, selectFTconst,
      &  selectHFconst, selectK1K2const,
      &  selectPHsolver,
-     &  useCalciteSaturation,
-     &  calcOmegaCalciteFreq, KierRateK, KierRateExp,
-     &  WsinkPIC, selectCalciteBottomRemin, nIterCO3,
+     &  useCalciteSaturation, calcOmegaCalciteFreq,
+     &  nIterCO3, KierRateK, KierRateExp,
+     &  WsinkPIC, selectCalciteBottomRemin,
      &  zca
 
 #ifdef DIC_BIOTIC
@@ -163,13 +163,13 @@ C---+----1----+----2----+----3----+----4----+----5----+----6----+----7-|--+----|
        useCalciteSaturation = .FALSE.
 C-- Parameters used in Calcite Saturation calculation (useCalciteSaturation=T):
 C set calcite saturation calculation to every timestep - could be expensive
-       calcOmegaCalciteFreq     = deltaTClock
+       calcOmegaCalciteFreq = deltaTClock
+C number of iterations for the Follows 3d pH solver
+       nIterCO3             = 10
+C set some nominal particulate sinking rate (m/s); try 100m/day:
 C flag to either remineralize in bottom or top layer if flux
 C reaches bottom layer 0=bottom, 1=top
        selectCalciteBottomRemin = 1
-C number of iterations for the Follows 3d pH solver
-       nIterCO3               = 10
-C set some nominal particulate sinking rate (m/s); try 100m/day:
        WsinkPIC                 = 100. _d 0/86400. _d 0
 C Kier rate exponent for calcite (4.2 for aragonite)
        KierRateExp              = 4.54 _d 0

--- a/pkg/dic/dic_readparms.F
+++ b/pkg/dic/dic_readparms.F
@@ -77,6 +77,14 @@ C  useCalciteSaturation :: dissolve calcium carbonate below the calcite saturati
 C          horizon following method by Karsten Friis
 C  calcOmegaCalciteFreq :: Frequency that 3d calcite saturation state, omegaC,
 C          is calculated. 
+C  KierRateK            :: Rate constant (%) for calcite dissolution from  
+C          Kier (1980) Geochem. Cosmochem. Acta.
+C  KierRateExp          :: Rate exponent for calcite dissolution from
+C          Kier (1980) Geochem. Cosmochem. Acta.
+C  WsinkPIC             :: sinking speed (m/s) of particulate inorganic carbon
+C          for calculation of calcite dissolution through the watercolumn
+C  selectCalciteBottomRemin :: flag to either remineralize in bottom or top layer if flux
+c          reaches bottom layer 0=bottom, 1=top 
 C   zca         :: scale depth for CaCO3 remineralization power law (m)
 C----
 
@@ -87,7 +95,8 @@ C----
      &  selectPHsolver,
      &  useCalciteSaturation, 
 #ifdef DIC_CALCITE_SAT
-     &  calcOmegaCalciteFreq,
+     &  calcOmegaCalciteFreq, KierRateK, KierRateExp, 
+     &  WsinkPIC, selectCalciteBottomRemin,
 #endif
      &  zca
 
@@ -153,9 +162,19 @@ C---+----1----+----2----+----3----+----4----+----5----+----6----+----7-|--+----|
        useCalciteSaturation = .FALSE.
 #ifdef DIC_CALCITE_SAT
 C set calcite saturation calculation to every timestep - could be expensive       
-       calcOmegaCalciteFreq = deltaTClock
+       calcOmegaCalciteFreq     = deltaTClock
+c flag to either remineralize in bottom or top layer if flux
+c reaches bottom layer 0=bottom, 1=top
+       selectCalciteBottomRemin = 1
+c set some nominal particulate sinking rate (m/s)
+c try 100m/day
+       WsinkPIC                 = 100. _d 0/86400. _d 0
+C Kier rate exponent for calcite (4.2 for aragonite)
+       KierRateExp              = 4.54 _d 0
+C Kier dissolution rate constant (%/day)
+       KierRateK                = 7.177 _d 0
 #endif
-       zca             = 3500. _d 0
+       zca                      = 3500. _d 0
 
 #ifdef DIC_BIOTIC
        DOPfraction = 0.67 _d 0
@@ -371,6 +390,15 @@ C- namelist ABIOTIC_PARMS
        CALL WRITE_0D_RL( calcOmegaCalciteFreq, INDEX_NONE,
      &  'calcOmegaCalciteFreq =',
      &  ' /* Frequency of calcite saturation calculation (s) */')
+       CALL WRITE_0D_RL( KierRateK, INDEX_NONE, 'KierRateK =',
+     &  ' /* Rate constant for calcite dissolution (%/day) */')     
+       CALL WRITE_0D_RL( KierRateExp, INDEX_NONE, 'KierRateExp =',
+     &  ' /* Rate exponent for calcite dissolution */')     
+       CALL WRITE_0D_RL( WsinkPIC, INDEX_NONE, 'WsinkPIC =',
+     &  ' /* Sinking speed of particulate inorganic carbon (m/s) */')
+       CALL WRITE_0D_I( selectCalciteBottomRemin, INDEX_NONE, 
+     &  'selectCalciteBottomRemin =',
+     &  ' /* Remineralize CO3 bottom flux (0) here or (1) top layer */')     
       ENDIF
 #endif
 

--- a/pkg/dic/dic_readparms.F
+++ b/pkg/dic/dic_readparms.F
@@ -411,7 +411,7 @@ C- namelist DIC_FORCING
      & '  /* File name of atmospheric pressure*/')
        CALL WRITE_0D_C( DIC_silicaFile, -1,INDEX_NONE,
      & 'DIC_silicaFile=','  /* File name of surface silica */')
-#ifdef CAR_DISS
+#ifdef DIC_CALCITE_SAT
        CALL WRITE_0D_C( DIC_deepSilicaFile, -1,INDEX_NONE,
      & 'DIC_deepSilicaFile=','  /* File name of 3d silica field */')
 #endif
@@ -511,17 +511,17 @@ C---+----1----+----2----+----3----+----4----+----5----+----6----+----7-|--+----|
       ENDIF
 #endif /* CARBONCHEM_SOLVESAPHE */
 
-#ifndef CAR_DISS
+#ifndef DIC_CALCITE_SAT
       IF ( DIC_deepSilicaFile .NE. ' '  ) THEN
         WRITE(msgBuf,'(2A)') 'DIC_READPARMS: ',
      &    'to use: DIC_deepSilicaFile (3d silicate input)'
         CALL PRINT_ERROR( msgBuf, myThid )
         WRITE(msgBuf,'(2A)') 'DIC_READPARMS: ',
-     &    'needs: "#define CAR_DISS" in "DIC_OPTIONS.h"'
+     &    'needs: "#define DIC_CALCITE_SAT" in "DIC_OPTIONS.h"'
         CALL PRINT_ERROR( msgBuf, myThid )
         errCount = errCount + 1      
       ENDIF
-#endif /* CAR_DISS */
+#endif /* DIC_CALCITE_SAT */
 
       IF ( errCount.GE.1 ) THEN
         WRITE(msgBuf,'(A,I3,A)')

--- a/pkg/dic/dic_surfforcing.F
+++ b/pkg/dic/dic_surfforcing.F
@@ -9,7 +9,7 @@ C !ROUTINE: DIC_SURFFORCING
 C !INTERFACE: ==========================================================
       SUBROUTINE DIC_SURFFORCING( PTR_CO2 , PTR_ALK, PTR_PO4, GDC,
      I           bi, bj, iMin, iMax, jMin, jMax,
-     I           myIter, myTime, myThid )
+     I           myTime, myIter, myThid )
 
 C !DESCRIPTION:
 C  Calculate the carbon air-sea flux terms
@@ -29,16 +29,16 @@ C !USES: ===============================================================
 #endif
 
 C !INPUT PARAMETERS: ===================================================
-C  myThid               :: thread number
-C  myIter               :: current timestep
-C  myTime               :: current time
 C  PTR_CO2              :: DIC tracer field
-      INTEGER myIter, myThid
-      _RL myTime
+C  myTime               :: current time
+C  myIter               :: current timestep
+C  myThid               :: thread number
       _RL  PTR_CO2(1-OLx:sNx+OLx,1-OLy:sNy+OLy,Nr)
       _RL  PTR_ALK(1-OLx:sNx+OLx,1-OLy:sNy+OLy,Nr)
       _RL  PTR_PO4(1-OLx:sNx+OLx,1-OLy:sNy+OLy,Nr)
       INTEGER iMin,iMax,jMin,jMax, bi, bj
+      _RL myTime
+      INTEGER myIter, myThid
 
 C !OUTPUT PARAMETERS: ===================================================
 C GDC                   :: tendency due to air-sea exchange

--- a/pkg/dic/dic_surfforcing_init.F
+++ b/pkg/dic/dic_surfforcing_init.F
@@ -104,6 +104,7 @@ C If file provided for surface silicate, read it in
          ENDDO
         ENDDO
 #ifndef ALLOW_AUTODIFF
+#ifdef CAR_DISS
        ELSEIF ( DIC_deepSilicaFile .NE. ' '  ) THEN
         DO bj = myByLo(myThid), myByHi(myThid)
          DO bi = myBxLo(myThid), myBxHi(myThid)
@@ -115,7 +116,8 @@ C If no surface silicate file but deep (3d) silicate provided, use top level
           ENDDO
          ENDDO
         ENDDO
-#endif
+#endif /* CAR_DISS */
+#endif /* not ALLOW_AUTODIFF */
        ENDIF
 
 C end periodicExternalForcing

--- a/pkg/dic/dic_surfforcing_init.F
+++ b/pkg/dic/dic_surfforcing_init.F
@@ -104,7 +104,7 @@ C If file provided for surface silicate, read it in
          ENDDO
         ENDDO
 #ifndef ALLOW_AUTODIFF
-#ifdef CAR_DISS
+#ifdef DIC_CALCITE_SAT
        ELSEIF ( DIC_deepSilicaFile .NE. ' '  ) THEN
         DO bj = myByLo(myThid), myByHi(myThid)
          DO bi = myBxLo(myThid), myBxHi(myThid)
@@ -116,7 +116,7 @@ C If no surface silicate file but deep (3d) silicate provided, use top level
           ENDDO
          ENDDO
         ENDDO
-#endif /* CAR_DISS */
+#endif /* DIC_CALCITE_SAT */
 #endif /* not ALLOW_AUTODIFF */
        ENDIF
 

--- a/pkg/dic/dic_surfforcing_init.F
+++ b/pkg/dic/dic_surfforcing_init.F
@@ -105,7 +105,8 @@ C If file provided for surface silicate, read it in
         ENDDO
 #ifndef ALLOW_AUTODIFF
 #ifdef DIC_CALCITE_SAT
-       ELSEIF ( DIC_deepSilicaFile .NE. ' '  ) THEN
+       ELSEIF ( useCalciteSaturation .AND. 
+     &            DIC_deepSilicaFile .NE. ' '  ) THEN
         DO bj = myByLo(myThid), myByHi(myThid)
          DO bi = myBxLo(myThid), myBxHi(myThid)
           DO j=1-OLy,sNy+OLy

--- a/pkg/dic/dic_surfforcing_init.F
+++ b/pkg/dic/dic_surfforcing_init.F
@@ -79,6 +79,15 @@ C--   Get reccord number and weight for time interpolation:
      &        nIter0,myThid )
          CALL READ_REC_XY_RS( DIC_silicaFile,silicaSurf1,intime1,
      &        nIter0,myThid )
+#ifndef ALLOW_AUTODIFF
+#ifdef DIC_CALCITE_SAT
+       ELSEIF ( DIC_deepSilicaFile .NE. ' '  ) THEN
+         CALL READ_REC_XYZ_RS( DIC_deepSilicaFile, silicaDeep0,
+     &                         intime0, nIter0, myThid )
+         CALL READ_REC_XYZ_RS( DIC_deepSilicaFile, silicaDeep1,
+     &                         intime1, nIter0, myThid )
+#endif /* DIC_CALCITE_SAT */
+#endif /* ndef ALLOW_AUTODIFF */
        ENDIF
 
 c#ifdef ALLOW_OFFLINE
@@ -105,20 +114,20 @@ C If file provided for surface silicate, read it in
         ENDDO
 #ifndef ALLOW_AUTODIFF
 #ifdef DIC_CALCITE_SAT
-       ELSEIF ( useCalciteSaturation .AND. 
-     &            DIC_deepSilicaFile .NE. ' '  ) THEN
+       ELSEIF ( DIC_deepSilicaFile .NE. ' '  ) THEN
         DO bj = myByLo(myThid), myByHi(myThid)
          DO bi = myBxLo(myThid), myBxHi(myThid)
           DO j=1-OLy,sNy+OLy
            DO i=1-OLx,sNx+OLx
 C If no surface silicate file but deep (3d) silicate provided, use top level
-             silicaSurf(i,j,bi,bj) = silicaDeep(i,j,kLev,bi,bj)
+             silicaSurf(i,j,bi,bj) = bWght*silicaDeep0(i,j,kLev,bi,bj)
+     &                             + aWght*silicaDeep1(i,j,kLev,bi,bj)
            ENDDO
           ENDDO
          ENDDO
         ENDDO
 #endif /* DIC_CALCITE_SAT */
-#endif /* not ALLOW_AUTODIFF */
+#endif /* ndef ALLOW_AUTODIFF */
        ENDIF
 
 C end periodicExternalForcing

--- a/pkg/dic/fe_chem.F
+++ b/pkg/dic/fe_chem.F
@@ -43,7 +43,7 @@ C     !LOCAL VARIABLES:
       INTEGER i,j,k
       _RL  lig, FeL
       _RL  tmpfe
-#if ( defined MINFE && defined AD_SAFE )
+#if ( defined MINFE && defined DIC_AD_SAFE )
       _RL thx, thy, theps
 #endif
 
@@ -90,7 +90,7 @@ C   Ligand,FeL,Fe calculation
                 freefe(i,j,k) = 0. _d 0
               ENDIF
 #ifdef MINFE
-#ifdef AD_SAFE
+#ifdef DIC_AD_SAFE
               thx=freefe(i,j,k)
               thy=freefemax
               theps=1. _d -8

--- a/pkg/dic/o2_surfforcing.F
+++ b/pkg/dic/o2_surfforcing.F
@@ -6,7 +6,7 @@ C !ROUTINE: O2_SURFFORCING
 C !INTERFACE: ==========================================================
       SUBROUTINE O2_SURFFORCING( PTR_O2, SGO2,
      I           bi,bj,iMin,iMax,jMin,jMax,
-     I           myIter, myTime, myThid )
+     I           myTime, myIter, myThid )
 
 C !DESCRIPTION:
 C Calculate the oxygen air-sea flux terms
@@ -22,13 +22,13 @@ C !USES: ===============================================================
 #include "DIC_VARS.h"
 
 c  !INPUT PARAMETERS: ===================================================
-C  myThid               :: thread number
-C  myIter               :: current timestep
-C  myTime               :: current time
 C  PTR_O2               :: oxygen tracer field
-      _RL myTime
+C  myTime               :: current time
+C  myIter               :: current timestep
+C  myThid               :: thread number
       _RL  PTR_O2(1-OLx:sNx+OLx,1-OLy:sNy+OLy,Nr)
       INTEGER iMin,iMax,jMin,jMax, bi, bj
+      _RL myTime
       INTEGER myIter, myThid
 
 c  !OUTPUT PARAMETERS: ===================================================
@@ -41,7 +41,7 @@ C  SGO2                  :: air-sea exchange of oxygen
 
 C !LOCAL VARIABLES: ===================================================
 C I, J, K - Loop counters
-      INTEGER I,J,K
+      INTEGER i,j,k
 C Solubility relation coefficients
       _RL SchmidtNoO2(1-OLx:sNx+OLx,1-OLy:sNy+OLy)
       _RL O2sat(1-OLx:sNx+OLx,1-OLy:sNy+OLy)
@@ -60,8 +60,7 @@ C Solubility relation coefficients
       _RL  oCnew
 CEOP
 
-
-      K=1
+      k=1
 
 C calculate SCHMIDT NO. for O2
         DO j=jmin,jmax
@@ -106,11 +105,10 @@ c Convert from ml/l to mol/m^3
 C Determine flux, inc. correction for local atmos surface pressure
               FluxO2(i,j) = Kwexch(i,j)*
      &                     (AtmosP(i,j,bi,bj)*O2sat(i,j)
-     &                      - PTR_O2(i,j,K))
+     &                      - PTR_O2(i,j,k))
             ELSE
               FluxO2(i,j) = 0. _d 0
             ENDIF
-
 
           END DO
         END DO
@@ -119,12 +117,11 @@ C update surface tendencies
         DO j=jmin,jmax
           DO i=imin,imax
            SGO2(i,j)= FluxO2(i,j)
-     &         *recip_drF(K) * recip_hFacC(i,j,K,bi,bj)
+     &         *recip_drF(k) * recip_hFacC(i,j,k,bi,bj)
           ENDDO
          ENDDO
 #endif
 #endif
-
 
         RETURN
         END

--- a/pkg/dic/phos_flux.F
+++ b/pkg/dic/phos_flux.F
@@ -6,7 +6,7 @@ C !ROUTINE: PHOS_FLUX
 C !INTERFACE: ==========================================================
       SUBROUTINE PHOS_FLUX( BIOac, pflux, exportflux,
      I           bi,bj,imin,imax,jmin,jmax,
-     I           myIter,myTime,myThid)
+     I           myTime, myIter, myThid )
 
 C !DESCRIPTION:
 C Calculate the PO4 flux to depth from bio activity
@@ -21,15 +21,15 @@ C !USES: ===============================================================
 #include "DIC_VARS.h"
 
 C !INPUT PARAMETERS: ===================================================
-C  myThid               :: thread number
-C  myIter               :: current timestep
-C  myTime               :: current time
 C  BIOac                :: biological productivity
-      INTEGER myIter
-      _RL myTime
-      INTEGER myThid
+C  myTime               :: current time
+C  myIter               :: current timestep
+C  myThid               :: thread number
       _RL  BIOac(1-OLx:sNx+OLx,1-OLy:sNy+OLy,Nr)
       INTEGER imin, imax, jmin, jmax, bi, bj
+      _RL myTime
+      INTEGER myIter
+      INTEGER myThid
 
 C !OUTPUT PARAMETERS: ===================================================
 C  pflux                :: changes to PO4 due to flux and reminerlization
@@ -47,7 +47,7 @@ c  depth_l                :: depth and lower interface
 c  flux_u, flux_l         :: flux through upper and lower interfaces
 c  reminFac               :: abbreviation
 c  zbase                  :: depth of bottom of current productive layer
-      INTEGER I,J,k, ko, kop1
+      INTEGER i,j,k, ko, kop1
       _RL zbase
       _RL bexport(1-OLx:sNx+OLx,1-OLy:sNy+OLy)
       _RL reminFac
@@ -65,7 +65,7 @@ C- Calculate PO4 flux from base of each layer
 C--   If no layer below initial layer (because of bottom or
 C--   topography), then remineralize in here
           IF (k.EQ.Nr) THEN
-           pflux(i,j,k)=pflux(i,j,k)+BIOac(i,j,k)*(1. _d 0-DOPfraction) 
+           pflux(i,j,k)=pflux(i,j,k)+BIOac(i,j,k)*(1. _d 0-DOPfraction)
           ELSEIF (hFacC(i,j,k+1,bi,bj).EQ.0. _d 0) THEN
            pflux(i,j,k)=pflux(i,j,k)+BIOac(i,j,k)*(1. _d 0-DOPfraction)
           ELSE
@@ -93,11 +93,11 @@ C     in order to save a few expensive exp-function calls
 #ifndef NONLIN_FRSURF
 C     For the linear free surface, hFacC can be omitted, buying another
 C     performance increase of a factor of six on a vector computer.
-C     For now this is not implemented via run time flags, in order to 
+C     For now this is not implemented via run time flags, in order to
 C     avoid making this code too complicated.
         depth_l  = -rF(ko) + drF(ko)
 C       reminFac = (depth_l/zbase)**(-Kremin)
-C     The following form does the same, but is faster 
+C     The following form does the same, but is faster
         reminFac = exp(-Kremin*log(depth_l/zbase))
 #endif
         DO j=jmin,jmax
@@ -107,12 +107,12 @@ C--   Lower flux (no flux to ocean bottom)
 #ifdef NONLIN_FRSURF
            depth_l  = -rF(ko) + drF(ko) * _hFacC(i,j,ko,bi,bj)
 C          reminFac = (depth_l/zbase)**(-Kremin)
-C     The following form does the same, but is faster 
+C     The following form does the same, but is faster
            reminFac = exp(-Kremin*log(depth_l/zbase))
 #endif
            flux_l   = bexport(i,j)*reminFac
      &          *maskC(i,j,kop1,bi,bj)
-C     
+C
            pflux(i,j,ko)=pflux(i,j,ko) + (flux_u(i,j)-flux_l)
      &          *recip_drF(ko) * _recip_hFacC(i,j,ko,bi,bj)
            exportflux(i,j,ko)=exportflux(i,j,ko)+flux_u(i,j)

--- a/pkg/gchem/gchem_fields_load.F
+++ b/pkg/gchem/gchem_fields_load.F
@@ -5,7 +5,7 @@ C !ROUTINE: GCHEM_FIELDS_LOAD
 
 C !INTERFACE: ==========================================================
       SUBROUTINE GCHEM_FIELDS_LOAD (
-     I           myTime, myIter, myThid)
+     I           myTime, myIter, myThid )
 
 C !DESCRIPTION:
 C  calls routines which read in fields needed for any tracer experiment
@@ -32,7 +32,7 @@ c load external data     c
 cccccccccccccccccccccccccc
 #ifdef ALLOW_DIC
       IF ( useDIC ) THEN
-       CALL DIC_FIELDS_LOAD (myIter,myTime,myThid)
+       CALL DIC_FIELDS_LOAD( myTime, myIter, myThid )
       ENDIF
 #endif
 

--- a/pkg/gchem/gchem_forcing_sep.F
+++ b/pkg/gchem/gchem_forcing_sep.F
@@ -154,7 +154,7 @@ ccccccccccccccccccccccccccc DIC cccccccccccccccccccccccccccccccc
      &                          pTracer(1-OLx,1-OLy,1,bi,bj,5),
      &                          pTracer(1-OLx,1-OLy,1,bi,bj,6),
      &                          bi, bj, iMin, iMax, jMin, jMax,
-     &                          myIter, myTime, myThid )
+     &                          myTime, myIter, myThid )
 #else
 #ifdef ALLOW_O2
           CALL DIC_BIOTIC_FORCING( pTracer(1-OLx,1-OLy,1,bi,bj,1),
@@ -163,14 +163,14 @@ ccccccccccccccccccccccccccc DIC cccccccccccccccccccccccccccccccc
      &                          pTracer(1-OLx,1-OLy,1,bi,bj,4),
      &                          pTracer(1-OLx,1-OLy,1,bi,bj,5),
      &                          bi, bj, iMin, iMax, jMin, jMax,
-     &                          myIter, myTime, myThid )
+     &                          myTime, myIter, myThid )
 #else
           CALL DIC_BIOTIC_FORCING( pTracer(1-OLx,1-OLy,1,bi,bj,1),
      &                          pTracer(1-OLx,1-OLy,1,bi,bj,2),
      &                          pTracer(1-OLx,1-OLy,1,bi,bj,3),
      &                          pTracer(1-OLx,1-OLy,1,bi,bj,4),
      &                          bi, bj, iMin, iMax, jMin, jMax,
-     &                          myIter, myTime, myThid )
+     &                          myTime, myIter, myThid )
 #endif
 #endif
 # ifndef ALLOW_AUTODIFF

--- a/verification/so_box_biogeo/code/DIC_OPTIONS.h
+++ b/verification/so_box_biogeo/code/DIC_OPTIONS.h
@@ -46,6 +46,9 @@ C Include self-shading effect by phytoplankton
 C Include iron sediment source using DOP flux
 #undef SEDFE
 
+C For Adjoint built
+#undef DIC_AD_SAFE
+
 #endif /* ALLOW_DIC */
 #endif /* DIC_OPTIONS_H */
 

--- a/verification/so_box_biogeo/code/DIC_OPTIONS.h
+++ b/verification/so_box_biogeo/code/DIC_OPTIONS.h
@@ -16,7 +16,7 @@ C In S/R CARBON_CHEM convert ak1 and ak2 to the total pH scale
 C  consistent with other coefficients (currently on the seawater scale).
 C NOTE: Has NO effect when CARBONCHEM_SOLVESAPHE is defined (different
 C  coeffs are used).
-#undef CARBONCHEM_TOTALPHSCALE
+#define CARBONCHEM_TOTALPHSCALE
 
 C BIOTIC OPTIONS
 #define DIC_BIOTIC
@@ -38,7 +38,7 @@ C put back bugs related to Water-Vapour in carbonate chemistry & air-sea fluxes
 #undef WATERVAP_BUG
 
 C dissolution only below saturation horizon following method by Karsten Friis
-#undef CAR_DISS
+#define DIC_CALCITE_SAT
 
 C Include self-shading effect by phytoplankton
 #undef LIGHT_CHL

--- a/verification/so_box_biogeo/input.caSat0/data.diagnostics
+++ b/verification/so_box_biogeo/input.caSat0/data.diagnostics
@@ -1,0 +1,78 @@
+# Diagnostic Package Choices
+#--------------------
+#  dumpAtLast (logical): always write output at the end of simulation (default=F)
+#  diag_mnc   (logical): write to NetCDF files (default=useMNC)
+#--for each output-stream:
+#  fileName(n) : prefix of the output file name (max 80c long) for outp.stream n
+#  frequency(n):< 0 : write snap-shot output every |frequency| seconds
+#               > 0 : write time-average output every frequency seconds
+#  timePhase(n)     : write at time = timePhase + multiple of |frequency|
+#    averagingFreq  : frequency (in s) for periodic averaging interval
+#    averagingPhase : phase     (in s) for periodic averaging interval
+#    repeatCycle    : number of averaging intervals in 1 cycle
+#  levels(:,n) : list of levels to write to file (Notes: declared as REAL)
+#                when this entry is missing, select all common levels of this list
+#  fields(:,n) : list of selected diagnostics fields (8.c) in outp.stream n
+#                (see "available_diagnostics.log" file for the full list of diags)
+#  missing_value(n) : missing value for real-type fields in output file "n"
+#  fileFlags(n)     : specific code (8c string) for output file "n"
+#--------------------
+ &DIAGNOSTICS_LIST
+# diagCG_maxIters = 200,
+# diagCG_resTarget = 1.E-10,
+# diagCG_pcOffDFac = 0.96,
+# diagCG_prtResFrq = 20,
+  xPsi0 = 300.,
+  yPsi0 = -26.,
+#--
+  fields(1:10,1) = 'ETAN    ','ETANSQ  ','DETADT2 ','PHIBOT  ','PHIBOTSQ',
+                   'DICTFLX ','DICOFLX ','DICCFLX ','DICPCO2 ','DICPHAV ',
+   levels(1,1) = 1.,
+   fileName(1) = 'surfDiag',
+  frequency(1) = 2592000.,
+# frequency(1) = 432000.,
+  fields(1:9,2)  = 'VVELMASS','UVELMASS','THETA   ','SALT    ',
+                   'GM_PsiX ','GM_PsiY ','PhiVEL  ','PsiVEL  ',
+                   'CONVADJ ',
+   fileName(2) = 'dynDiag',
+  frequency(2) = 2592000.,
+  frequency(2) = 432000.,
+  fields(1:9,3)  = 'DICBIOA ','DICCARB ',
+                   'TRAC01  ','TRAC02  ','TRAC03  ','TRAC04  ','TRAC05  ',
+                   'ADVxTr05','DFrITr05',
+#  fileName(3) = 'dicDiag',
+  frequency(3) = 2592000.,
+  fields(1:8,4)  = 'ADVx_TH ','ADVy_TH ','ADVr_TH ',
+                   'DFxE_TH ','DFyE_TH ','DFrE_TH ','DFrI_TH ',
+                   'ADVx_SLT',
+#  fileName(4) = 'flxDiag',
+  frequency(4) = 0.,
+ &
+
+#--------------------
+# Parameter for Diagnostics of per level statistics:
+#--------------------
+#  diagSt_mnc (logical): write stat-diags to NetCDF files (default=diag_mnc)
+#  diagSt_regMaskFile : file containing the region-mask to read-in
+#  nSetRegMskFile   : number of region-mask sets within the region-mask file
+#  set_regMask(i)   : region-mask set-index that identifies the region "i"
+#  val_regMask(i)   : region "i" identifier value in the region mask
+#--for each output-stream:
+#  stat_fName(n) : prefix of the output file name (max 80c long) for outp.stream n
+#  stat_freq(n):< 0 : write snap-shot output every |stat_freq| seconds
+#               > 0 : write time-average output every stat_freq seconds
+#  stat_phase(n)    : write at time = stat_phase + multiple of |stat_freq|
+#  stat_region(:,n) : list of "regions" (default: 1 region only=global)
+#  stat_fields(:,n) : list of selected diagnostics fields (8.c) in outp.stream n
+#                (see "available_diagnostics.log" file for the full list of diags)
+#--------------------
+ &DIAG_STATIS_PARMS
+#---
+ stat_fields(1:20,1) = 'ETAN    ','DETADT2 ','THETA   ','SALT    ','CONVADJ ',
+                       'UVEL    ','VVEL    ','WVEL    ','GM_PsiX ','GM_PsiY ',
+                       'TRAC01  ','TRAC02  ','TRAC03  ','TRAC04  ','TRAC05  ',
+                       'DIC3DSIT','OMEGAC  ','DIC3DPH ','DIC3DPCO','DIC3DCO3',
+  stat_fName(1) = 'dynStDiag',
+   stat_freq(1) = 432000.,
+  stat_phase(1) = 0.,
+ &

--- a/verification/so_box_biogeo/input.caSat0/data.dic
+++ b/verification/so_box_biogeo/input.caSat0/data.dic
@@ -1,0 +1,18 @@
+# DIC parameters
+ &ABIOTIC_PARMS
+  useCalciteSaturation= .TRUE.,
+# calcOmegaCalciteFreq= 86400.,
+ &
+
+ &BIOTIC_PARMS
+  alphaUniform = 0.97e-10,
+  rainRatioUniform = 5.e-2,
+  KRemin = 0.95,
+ &
+
+ &DIC_FORCING
+  DIC_iceFile='fice_box.bin',
+  DIC_windFile='tren_speed_box.bin',
+  DIC_silicaFile='sillev1_box.bin',
+  DIC_deepSilicaFile='silicate_3D_12m_box.bin',
+ &

--- a/verification/so_box_biogeo/input.caSat0/eedata
+++ b/verification/so_box_biogeo/input.caSat0/eedata
@@ -1,0 +1,12 @@
+# Example "eedata" file
+# Lines beginning "#" are comments
+#  nTx      :: No. threads per process in X
+#  nTy      :: No. threads per process in Y
+# debugMode :: print debug msg (sequence of S/R calls)
+ &EEPARMS
+ nTx=1,
+ nTy=1,
+#debugMode=.TRUE.,
+ &
+# Note: Some systems use & as the namelist terminator (as shown here).
+#       Other systems use a / character.

--- a/verification/so_box_biogeo/input.caSat0/eedata.mth
+++ b/verification/so_box_biogeo/input.caSat0/eedata.mth
@@ -1,0 +1,12 @@
+# Example "eedata" file  for multi-threaded test
+#   (copy "eedata.mth" to "eedata" to use it)
+# Lines beginning "#" are comments
+#  nTx      :: No. threads per process in X
+#  nTy      :: No. threads per process in Y
+# debugMode :: print debug msg (sequence of S/R calls)
+ &EEPARMS
+ nTx=1,
+ nTy=2,
+ &
+# Note: Some systems use & as the namelist terminator (as shown here).
+#       Other systems use a / character.

--- a/verification/so_box_biogeo/input.caSat3/data.diagnostics
+++ b/verification/so_box_biogeo/input.caSat3/data.diagnostics
@@ -1,0 +1,78 @@
+# Diagnostic Package Choices
+#--------------------
+#  dumpAtLast (logical): always write output at the end of simulation (default=F)
+#  diag_mnc   (logical): write to NetCDF files (default=useMNC)
+#--for each output-stream:
+#  fileName(n) : prefix of the output file name (max 80c long) for outp.stream n
+#  frequency(n):< 0 : write snap-shot output every |frequency| seconds
+#               > 0 : write time-average output every frequency seconds
+#  timePhase(n)     : write at time = timePhase + multiple of |frequency|
+#    averagingFreq  : frequency (in s) for periodic averaging interval
+#    averagingPhase : phase     (in s) for periodic averaging interval
+#    repeatCycle    : number of averaging intervals in 1 cycle
+#  levels(:,n) : list of levels to write to file (Notes: declared as REAL)
+#                when this entry is missing, select all common levels of this list
+#  fields(:,n) : list of selected diagnostics fields (8.c) in outp.stream n
+#                (see "available_diagnostics.log" file for the full list of diags)
+#  missing_value(n) : missing value for real-type fields in output file "n"
+#  fileFlags(n)     : specific code (8c string) for output file "n"
+#--------------------
+ &DIAGNOSTICS_LIST
+# diagCG_maxIters = 200,
+# diagCG_resTarget = 1.E-10,
+# diagCG_pcOffDFac = 0.96,
+# diagCG_prtResFrq = 20,
+  xPsi0 = 300.,
+  yPsi0 = -26.,
+#--
+  fields(1:10,1) = 'ETAN    ','ETANSQ  ','DETADT2 ','PHIBOT  ','PHIBOTSQ',
+                   'DICTFLX ','DICOFLX ','DICCFLX ','DICPCO2 ','DICPHAV ',
+   levels(1,1) = 1.,
+   fileName(1) = 'surfDiag',
+  frequency(1) = 2592000.,
+# frequency(1) = 432000.,
+  fields(1:9,2)  = 'VVELMASS','UVELMASS','THETA   ','SALT    ',
+                   'GM_PsiX ','GM_PsiY ','PhiVEL  ','PsiVEL  ',
+                   'CONVADJ ',
+   fileName(2) = 'dynDiag',
+  frequency(2) = 2592000.,
+  frequency(2) = 432000.,
+  fields(1:9,3)  = 'DICBIOA ','DICCARB ',
+                   'TRAC01  ','TRAC02  ','TRAC03  ','TRAC04  ','TRAC05  ',
+                   'ADVxTr05','DFrITr05',
+#  fileName(3) = 'dicDiag',
+  frequency(3) = 2592000.,
+  fields(1:8,4)  = 'ADVx_TH ','ADVy_TH ','ADVr_TH ',
+                   'DFxE_TH ','DFyE_TH ','DFrE_TH ','DFrI_TH ',
+                   'ADVx_SLT',
+#  fileName(4) = 'flxDiag',
+  frequency(4) = 0.,
+ &
+
+#--------------------
+# Parameter for Diagnostics of per level statistics:
+#--------------------
+#  diagSt_mnc (logical): write stat-diags to NetCDF files (default=diag_mnc)
+#  diagSt_regMaskFile : file containing the region-mask to read-in
+#  nSetRegMskFile   : number of region-mask sets within the region-mask file
+#  set_regMask(i)   : region-mask set-index that identifies the region "i"
+#  val_regMask(i)   : region "i" identifier value in the region mask
+#--for each output-stream:
+#  stat_fName(n) : prefix of the output file name (max 80c long) for outp.stream n
+#  stat_freq(n):< 0 : write snap-shot output every |stat_freq| seconds
+#               > 0 : write time-average output every stat_freq seconds
+#  stat_phase(n)    : write at time = stat_phase + multiple of |stat_freq|
+#  stat_region(:,n) : list of "regions" (default: 1 region only=global)
+#  stat_fields(:,n) : list of selected diagnostics fields (8.c) in outp.stream n
+#                (see "available_diagnostics.log" file for the full list of diags)
+#--------------------
+ &DIAG_STATIS_PARMS
+#---
+ stat_fields(1:20,1) = 'ETAN    ','DETADT2 ','THETA   ','SALT    ','CONVADJ ',
+                       'UVEL    ','VVEL    ','WVEL    ','GM_PsiX ','GM_PsiY ',
+                       'TRAC01  ','TRAC02  ','TRAC03  ','TRAC04  ','TRAC05  ',
+                       'DIC3DSIT','OMEGAC  ','DIC3DPH ','DIC3DPCO','DIC3DCO3',
+  stat_fName(1) = 'dynStDiag',
+   stat_freq(1) = 432000.,
+  stat_phase(1) = 0.,
+ &

--- a/verification/so_box_biogeo/input.caSat3/data.dic
+++ b/verification/so_box_biogeo/input.caSat3/data.dic
@@ -1,0 +1,24 @@
+# DIC parameters
+ &ABIOTIC_PARMS
+  useCalciteSaturation= .TRUE.,
+# calcOmegaCalciteFreq= 86400.,
+  selectBTconst=1,
+  selectFTconst=1,
+  selectHFconst=1,
+  selectK1K2const=6,
+# Munhoven "GENERAL" solver: =1 ; Munhoven "SEC" solver: =2 ; Munhoven "FAST" solver: =3
+  selectPHsolver=3,
+ &
+
+ &BIOTIC_PARMS
+  alphaUniform = 0.97e-10,
+  rainRatioUniform = 5.e-2,
+  KRemin = 0.95,
+ &
+
+ &DIC_FORCING
+  DIC_iceFile='fice_box.bin',
+  DIC_windFile='tren_speed_box.bin',
+  DIC_silicaFile='sillev1_box.bin',
+  DIC_deepSilicaFile='silicate_3D_12m_box.bin',
+ &

--- a/verification/so_box_biogeo/input.caSat3/eedata
+++ b/verification/so_box_biogeo/input.caSat3/eedata
@@ -1,0 +1,12 @@
+# Example "eedata" file
+# Lines beginning "#" are comments
+#  nTx      :: No. threads per process in X
+#  nTy      :: No. threads per process in Y
+# debugMode :: print debug msg (sequence of S/R calls)
+ &EEPARMS
+ nTx=1,
+ nTy=1,
+#debugMode=.TRUE.,
+ &
+# Note: Some systems use & as the namelist terminator (as shown here).
+#       Other systems use a / character.

--- a/verification/so_box_biogeo/input.caSat3/eedata.mth
+++ b/verification/so_box_biogeo/input.caSat3/eedata.mth
@@ -1,0 +1,12 @@
+# Example "eedata" file  for multi-threaded test
+#   (copy "eedata.mth" to "eedata" to use it)
+# Lines beginning "#" are comments
+#  nTx      :: No. threads per process in X
+#  nTy      :: No. threads per process in Y
+# debugMode :: print debug msg (sequence of S/R calls)
+ &EEPARMS
+ nTx=1,
+ nTy=2,
+ &
+# Note: Some systems use & as the namelist terminator (as shown here).
+#       Other systems use a / character.

--- a/verification/so_box_biogeo/input.saphe/data.dic
+++ b/verification/so_box_biogeo/input.saphe/data.dic
@@ -4,7 +4,7 @@
   selectFTconst=1,
   selectHFconst=1,
   selectK1K2const=6,
-# Munhoven "GENERAL" solver:
+# Munhoven "GENERAL" solver: =1 ; Munhoven "SEC" solver: =2 ; Munhoven "FAST" solver: =3
   selectPHsolver=1,
  &
 

--- a/verification/so_box_biogeo/input/eedata
+++ b/verification/so_box_biogeo/input/eedata
@@ -1,10 +1,12 @@
 # Example "eedata" file
 # Lines beginning "#" are comments
-# nTx - No. threads per process in X
-# nTy - No. threads per process in Y
+#  nTx      :: No. threads per process in X
+#  nTy      :: No. threads per process in Y
+# debugMode :: print debug msg (sequence of S/R calls)
  &EEPARMS
  nTx=1,
  nTy=1,
+#debugMode=.TRUE.,
  &
 # Note: Some systems use & as the namelist terminator (as shown here).
 #       Other systems use a / character.

--- a/verification/so_box_biogeo/input/eedata.mth
+++ b/verification/so_box_biogeo/input/eedata.mth
@@ -1,8 +1,9 @@
 # Example "eedata" file  for multi-threaded test
 #   (copy "eedata.mth" to "eedata" to use it)
 # Lines beginning "#" are comments
-# nTx - No. threads per process in X
-# nTy - No. threads per process in Y
+#  nTx      :: No. threads per process in X
+#  nTy      :: No. threads per process in Y
+# debugMode :: print debug msg (sequence of S/R calls)
  &EEPARMS
  nTx=1,
  nTy=2,

--- a/verification/so_box_biogeo/results/output.caSat0.txt
+++ b/verification/so_box_biogeo/results/output.caSat0.txt
@@ -1,0 +1,4802 @@
+(PID.TID 0000.0001) 
+(PID.TID 0000.0001) // ======================================================
+(PID.TID 0000.0001) //                      MITgcm UV
+(PID.TID 0000.0001) //                      =========
+(PID.TID 0000.0001) // ======================================================
+(PID.TID 0000.0001) // execution environment starting up...
+(PID.TID 0000.0001) 
+(PID.TID 0000.0001) // MITgcmUV version:  checkpoint68m
+(PID.TID 0000.0001) // Build user:        jm_c
+(PID.TID 0000.0001) // Build host:        villon
+(PID.TID 0000.0001) // Build date:        Thu Jan 12 12:38:05 EST 2023
+(PID.TID 0000.0001) 
+(PID.TID 0000.0001) // =======================================================
+(PID.TID 0000.0001) // Execution Environment parameter file "eedata"
+(PID.TID 0000.0001) // =======================================================
+(PID.TID 0000.0001) ># Example "eedata" file
+(PID.TID 0000.0001) ># Lines beginning "#" are comments
+(PID.TID 0000.0001) >#  nTx      :: No. threads per process in X
+(PID.TID 0000.0001) >#  nTy      :: No. threads per process in Y
+(PID.TID 0000.0001) ># debugMode :: print debug msg (sequence of S/R calls)
+(PID.TID 0000.0001) > &EEPARMS
+(PID.TID 0000.0001) > nTx=1,
+(PID.TID 0000.0001) > nTy=1,
+(PID.TID 0000.0001) >#debugMode=.TRUE.,
+(PID.TID 0000.0001) > /
+(PID.TID 0000.0001) ># Note: Some systems use & as the namelist terminator (as shown here).
+(PID.TID 0000.0001) >#       Other systems use a / character.
+(PID.TID 0000.0001) 
+(PID.TID 0000.0001) // =======================================================
+(PID.TID 0000.0001) // Computational Grid Specification ( see files "SIZE.h" )
+(PID.TID 0000.0001) //                                  ( and "eedata"       )
+(PID.TID 0000.0001) // =======================================================
+(PID.TID 0000.0001)      nPx =    1 ; /* No. processes in X */
+(PID.TID 0000.0001)      nPy =    1 ; /* No. processes in Y */
+(PID.TID 0000.0001)      nSx =    3 ; /* No. tiles in X per process */
+(PID.TID 0000.0001)      nSy =    2 ; /* No. tiles in Y per process */
+(PID.TID 0000.0001)      sNx =   14 ; /* Tile size in X */
+(PID.TID 0000.0001)      sNy =   10 ; /* Tile size in Y */
+(PID.TID 0000.0001)      OLx =    3 ; /* Tile overlap distance in X */
+(PID.TID 0000.0001)      OLy =    3 ; /* Tile overlap distance in Y */
+(PID.TID 0000.0001)      nTx =    1 ; /* No. threads in X per process */
+(PID.TID 0000.0001)      nTy =    1 ; /* No. threads in Y per process */
+(PID.TID 0000.0001)       Nr =   15 ; /* No. levels in the vertical   */
+(PID.TID 0000.0001)       Nx =   42 ; /* Total domain size in X ( = nPx*nSx*sNx ) */
+(PID.TID 0000.0001)       Ny =   20 ; /* Total domain size in Y ( = nPy*nSy*sNy ) */
+(PID.TID 0000.0001)   nTiles =    6 ; /* Total no. tiles per process ( = nSx*nSy ) */
+(PID.TID 0000.0001)   nProcs =    1 ; /* Total no. processes ( = nPx*nPy ) */
+(PID.TID 0000.0001) nThreads =    1 ; /* Total no. threads per process ( = nTx*nTy ) */
+(PID.TID 0000.0001) usingMPI =    F ; /* Flag used to control whether MPI is in use */
+(PID.TID 0000.0001)                   /*  note: To execute a program with MPI calls */
+(PID.TID 0000.0001)                   /*  it must be launched appropriately e.g     */
+(PID.TID 0000.0001)                   /*  "mpirun -np 64 ......"                    */
+(PID.TID 0000.0001) useCoupler=   F ; /* Flag used to control communications with   */
+(PID.TID 0000.0001)                   /*  other model components, through a coupler */
+(PID.TID 0000.0001) useNest2W_parent =    F ;/* Control 2-W Nesting comm */
+(PID.TID 0000.0001) useNest2W_child  =    F ;/* Control 2-W Nesting comm */
+(PID.TID 0000.0001) debugMode =    F ; /* print debug msg. (sequence of S/R calls)  */
+(PID.TID 0000.0001) printMapIncludesZeros=    F ; /* print zeros in Std.Output maps */
+(PID.TID 0000.0001) maxLengthPrt1D=   65 /* maxLength of 1D array printed to StdOut */
+(PID.TID 0000.0001) 
+(PID.TID 0000.0001) // ======================================================
+(PID.TID 0000.0001) // Mapping of tiles to threads
+(PID.TID 0000.0001) // ======================================================
+(PID.TID 0000.0001) // -o- Thread   1, tiles (   1:   3,   1:   2)
+(PID.TID 0000.0001) 
+(PID.TID 0000.0001) // ======================================================
+(PID.TID 0000.0001) // Tile <-> Tile connectvity table
+(PID.TID 0000.0001) // ======================================================
+(PID.TID 0000.0001) // Tile number: 000001 (process no. = 000000)
+(PID.TID 0000.0001) //        WEST: Tile = 000003, Process = 000000, Comm = put
+(PID.TID 0000.0001) //                bi = 000003, bj = 000001
+(PID.TID 0000.0001) //        EAST: Tile = 000002, Process = 000000, Comm = put
+(PID.TID 0000.0001) //                bi = 000002, bj = 000001
+(PID.TID 0000.0001) //       SOUTH: Tile = 000004, Process = 000000, Comm = put
+(PID.TID 0000.0001) //                bi = 000001, bj = 000002
+(PID.TID 0000.0001) //       NORTH: Tile = 000004, Process = 000000, Comm = put
+(PID.TID 0000.0001) //                bi = 000001, bj = 000002
+(PID.TID 0000.0001) // Tile number: 000002 (process no. = 000000)
+(PID.TID 0000.0001) //        WEST: Tile = 000001, Process = 000000, Comm = put
+(PID.TID 0000.0001) //                bi = 000001, bj = 000001
+(PID.TID 0000.0001) //        EAST: Tile = 000003, Process = 000000, Comm = put
+(PID.TID 0000.0001) //                bi = 000003, bj = 000001
+(PID.TID 0000.0001) //       SOUTH: Tile = 000005, Process = 000000, Comm = put
+(PID.TID 0000.0001) //                bi = 000002, bj = 000002
+(PID.TID 0000.0001) //       NORTH: Tile = 000005, Process = 000000, Comm = put
+(PID.TID 0000.0001) //                bi = 000002, bj = 000002
+(PID.TID 0000.0001) // Tile number: 000003 (process no. = 000000)
+(PID.TID 0000.0001) //        WEST: Tile = 000002, Process = 000000, Comm = put
+(PID.TID 0000.0001) //                bi = 000002, bj = 000001
+(PID.TID 0000.0001) //        EAST: Tile = 000001, Process = 000000, Comm = put
+(PID.TID 0000.0001) //                bi = 000001, bj = 000001
+(PID.TID 0000.0001) //       SOUTH: Tile = 000006, Process = 000000, Comm = put
+(PID.TID 0000.0001) //                bi = 000003, bj = 000002
+(PID.TID 0000.0001) //       NORTH: Tile = 000006, Process = 000000, Comm = put
+(PID.TID 0000.0001) //                bi = 000003, bj = 000002
+(PID.TID 0000.0001) // Tile number: 000004 (process no. = 000000)
+(PID.TID 0000.0001) //        WEST: Tile = 000006, Process = 000000, Comm = put
+(PID.TID 0000.0001) //                bi = 000003, bj = 000002
+(PID.TID 0000.0001) //        EAST: Tile = 000005, Process = 000000, Comm = put
+(PID.TID 0000.0001) //                bi = 000002, bj = 000002
+(PID.TID 0000.0001) //       SOUTH: Tile = 000001, Process = 000000, Comm = put
+(PID.TID 0000.0001) //                bi = 000001, bj = 000001
+(PID.TID 0000.0001) //       NORTH: Tile = 000001, Process = 000000, Comm = put
+(PID.TID 0000.0001) //                bi = 000001, bj = 000001
+(PID.TID 0000.0001) // Tile number: 000005 (process no. = 000000)
+(PID.TID 0000.0001) //        WEST: Tile = 000004, Process = 000000, Comm = put
+(PID.TID 0000.0001) //                bi = 000001, bj = 000002
+(PID.TID 0000.0001) //        EAST: Tile = 000006, Process = 000000, Comm = put
+(PID.TID 0000.0001) //                bi = 000003, bj = 000002
+(PID.TID 0000.0001) //       SOUTH: Tile = 000002, Process = 000000, Comm = put
+(PID.TID 0000.0001) //                bi = 000002, bj = 000001
+(PID.TID 0000.0001) //       NORTH: Tile = 000002, Process = 000000, Comm = put
+(PID.TID 0000.0001) //                bi = 000002, bj = 000001
+(PID.TID 0000.0001) // Tile number: 000006 (process no. = 000000)
+(PID.TID 0000.0001) //        WEST: Tile = 000005, Process = 000000, Comm = put
+(PID.TID 0000.0001) //                bi = 000002, bj = 000002
+(PID.TID 0000.0001) //        EAST: Tile = 000004, Process = 000000, Comm = put
+(PID.TID 0000.0001) //                bi = 000001, bj = 000002
+(PID.TID 0000.0001) //       SOUTH: Tile = 000003, Process = 000000, Comm = put
+(PID.TID 0000.0001) //                bi = 000003, bj = 000001
+(PID.TID 0000.0001) //       NORTH: Tile = 000003, Process = 000000, Comm = put
+(PID.TID 0000.0001) //                bi = 000003, bj = 000001
+(PID.TID 0000.0001) 
+(PID.TID 0000.0001)  INI_PARMS: opening model parameter file "data"
+(PID.TID 0000.0001)  OPEN_COPY_DATA_FILE: opening file data
+(PID.TID 0000.0001) // =======================================================
+(PID.TID 0000.0001) // Parameter file "data"
+(PID.TID 0000.0001) // =======================================================
+(PID.TID 0000.0001) ># ====================
+(PID.TID 0000.0001) ># | Model parameters |
+(PID.TID 0000.0001) ># ====================
+(PID.TID 0000.0001) >#
+(PID.TID 0000.0001) ># Continuous equation parameters
+(PID.TID 0000.0001) > &PARM01
+(PID.TID 0000.0001) > tRef=15*20.,
+(PID.TID 0000.0001) > sRef=15*35.,
+(PID.TID 0000.0001) > viscAh=3.E5,
+(PID.TID 0000.0001) > viscAz=1.E-3,
+(PID.TID 0000.0001) > diffKhT=0.E3,
+(PID.TID 0000.0001) > diffKhS=0.E3,
+(PID.TID 0000.0001) >#diffKzT=3.E-5,
+(PID.TID 0000.0001) >#diffKzS=3.E-5,
+(PID.TID 0000.0001) > diffKrBL79surf= 3.E-5,
+(PID.TID 0000.0001) > diffKrBL79deep= 13.E-5,
+(PID.TID 0000.0001) > diffKrBL79Ho  = -2000.,
+(PID.TID 0000.0001) > diffKrBL79scl = 150.,
+(PID.TID 0000.0001) > gravity=9.81,
+(PID.TID 0000.0001) > rhoConst=1035.,
+(PID.TID 0000.0001) > rhoConstFresh=1000.,
+(PID.TID 0000.0001) > eosType='JMD95Z',
+(PID.TID 0000.0001) > implicitFreeSurface=.TRUE.,
+(PID.TID 0000.0001) > exactConserv=.TRUE.,
+(PID.TID 0000.0001) >#implicitViscosity=.TRUE.,
+(PID.TID 0000.0001) > implicitDiffusion=.TRUE.,
+(PID.TID 0000.0001) > ivdc_kappa=10.,
+(PID.TID 0000.0001) > allowFreezing=.TRUE.,
+(PID.TID 0000.0001) >#useCDscheme=.TRUE.,
+(PID.TID 0000.0001) ># turn on looped cells
+(PID.TID 0000.0001) > hFacMin=.1,
+(PID.TID 0000.0001) > hFacMindz=50.,
+(PID.TID 0000.0001) >#- I/O params:
+(PID.TID 0000.0001) >#globalFiles=.TRUE.,
+(PID.TID 0000.0001) > /
+(PID.TID 0000.0001) >
+(PID.TID 0000.0001) ># Elliptic solver parameters
+(PID.TID 0000.0001) > &PARM02
+(PID.TID 0000.0001) > cg2dMaxIters=1000,
+(PID.TID 0000.0001) > cg2dTargetResidual=1.E-13,
+(PID.TID 0000.0001) > /
+(PID.TID 0000.0001) >
+(PID.TID 0000.0001) ># Time stepping parameters
+(PID.TID 0000.0001) > &PARM03
+(PID.TID 0000.0001) > nIter0=0,
+(PID.TID 0000.0001) >#nTimeSteps = 1440,
+(PID.TID 0000.0001) > nTimeSteps = 10,
+(PID.TID 0000.0001) >#tauCD      = 321428.,
+(PID.TID 0000.0001) > deltaTMom     = 900.,
+(PID.TID 0000.0001) > deltaTtracer  = 43200.,
+(PID.TID 0000.0001) > deltaTFreeSurf= 43200.,
+(PID.TID 0000.0001) > deltaTClock   = 43200.,
+(PID.TID 0000.0001) > abEps      = 0.1,
+(PID.TID 0000.0001) > pChkptFreq = 311040000.,
+(PID.TID 0000.0001) > chkptFreq  = 31104000.,
+(PID.TID 0000.0001) > dumpFreq   = 2592000.,
+(PID.TID 0000.0001) > monitorFreq= 864000.,
+(PID.TID 0000.0001) > tauThetaClimRelax = 5184000.,
+(PID.TID 0000.0001) > tauSaltClimRelax  = 7776000.,
+(PID.TID 0000.0001) > periodicExternalForcing=.TRUE.,
+(PID.TID 0000.0001) > externForcingPeriod = 2592000.,
+(PID.TID 0000.0001) > externForcingCycle = 31104000.,
+(PID.TID 0000.0001) > monitorFreq= 1.,
+(PID.TID 0000.0001) > /
+(PID.TID 0000.0001) >
+(PID.TID 0000.0001) ># Gridding parameters
+(PID.TID 0000.0001) > &PARM04
+(PID.TID 0000.0001) > usingSphericalPolarGrid=.TRUE.,
+(PID.TID 0000.0001) > delZ=  50., 70.,  100., 140., 190.,
+(PID.TID 0000.0001) >       240., 290., 340., 390., 440.,
+(PID.TID 0000.0001) >       490., 540., 590., 640., 690.,
+(PID.TID 0000.0001) > xgOrigin= 236.25,
+(PID.TID 0000.0001) > ygOrigin= -81.5625,
+(PID.TID 0000.0001) > delX=42*2.8125,
+(PID.TID 0000.0001) > delY=20*2.8125,
+(PID.TID 0000.0001) > /
+(PID.TID 0000.0001) >
+(PID.TID 0000.0001) ># Input datasets
+(PID.TID 0000.0001) > &PARM05
+(PID.TID 0000.0001) > checkIniTemp  = .FALSE.,
+(PID.TID 0000.0001) > bathyFile     = 'bathy_box.bin',
+(PID.TID 0000.0001) > pSurfInitFile = 'Eta_ini.bin',
+(PID.TID 0000.0001) > uVelInitFile  = 'U_ini.bin',
+(PID.TID 0000.0001) > vVelInitFile  = 'V_ini.bin',
+(PID.TID 0000.0001) > hydrogThetaFile='T_ini.bin',
+(PID.TID 0000.0001) > hydrogSaltFile= 'S_ini.bin',
+(PID.TID 0000.0001) > zonalWindFile = 'tren_taux_box.bin',
+(PID.TID 0000.0001) > meridWindFile = 'tren_tauy_box.bin',
+(PID.TID 0000.0001) > thetaClimFile = 'lev_monthly_temp_box.bin',
+(PID.TID 0000.0001) > saltClimFile  = 'lev_monthly_salt_box.bin',
+(PID.TID 0000.0001) > surfQnetFile  = 'shi_qnet_box.bin',
+(PID.TID 0000.0001) > EmPmRFile     = 'shi_empmr_year_box.bin',
+(PID.TID 0000.0001) > the_run_name  = 'OBC + Biogeo S.Ocean Box',
+(PID.TID 0000.0001) > /
+(PID.TID 0000.0001) 
+(PID.TID 0000.0001)  INI_PARMS ; starts to read PARM01
+(PID.TID 0000.0001)  INI_PARMS ; read PARM01 : OK
+(PID.TID 0000.0001)  INI_PARMS ; starts to read PARM02
+(PID.TID 0000.0001)  INI_PARMS ; read PARM02 : OK
+(PID.TID 0000.0001)  INI_PARMS ; starts to read PARM03
+(PID.TID 0000.0001)  INI_PARMS ; read PARM03 : OK
+(PID.TID 0000.0001)  INI_PARMS ; starts to read PARM04
+(PID.TID 0000.0001)  INI_PARMS ; read PARM04 : OK
+(PID.TID 0000.0001)  INI_PARMS ; starts to read PARM05
+(PID.TID 0000.0001)  INI_PARMS ; read PARM05 : OK
+(PID.TID 0000.0001)  INI_PARMS: finished reading file "data"
+(PID.TID 0000.0001)  PACKAGES_BOOT: opening data.pkg
+(PID.TID 0000.0001)  OPEN_COPY_DATA_FILE: opening file data.pkg
+(PID.TID 0000.0001) // =======================================================
+(PID.TID 0000.0001) // Parameter file "data.pkg"
+(PID.TID 0000.0001) // =======================================================
+(PID.TID 0000.0001) ># Packages
+(PID.TID 0000.0001) > &PACKAGES
+(PID.TID 0000.0001) > usePTRACERS=.TRUE.,
+(PID.TID 0000.0001) > useGCHEM =.TRUE.,
+(PID.TID 0000.0001) > useGMRedi=.TRUE.,
+(PID.TID 0000.0001) > useOBCS  =.TRUE.,
+(PID.TID 0000.0001) > useDiagnostics=.TRUE.,
+(PID.TID 0000.0001) > /
+(PID.TID 0000.0001) 
+(PID.TID 0000.0001)  PACKAGES_BOOT: finished reading data.pkg
+(PID.TID 0000.0001)  PACKAGES_BOOT: On/Off package Summary
+ --------  pkgs with a standard "usePKG" On/Off switch in "data.pkg":  --------
+ pkg/obcs                 compiled   and   used ( useOBCS                  = T )
+ pkg/gmredi               compiled   and   used ( useGMRedi                = T )
+ pkg/ptracers             compiled   and   used ( usePTRACERS              = T )
+ pkg/gchem                compiled   and   used ( useGCHEM                 = T )
+ pkg/diagnostics          compiled   and   used ( useDiagnostics           = T )
+ -------- pkgs without standard "usePKG" On/Off switch in "data.pkg":  --------
+ pkg/generic_advdiff      compiled   and   used ( useGAD                   = T )
+ pkg/mom_common           compiled   and   used ( momStepping              = T )
+ pkg/mom_vecinv           compiled but not used ( +vectorInvariantMomentum = F )
+ pkg/mom_fluxform         compiled   and   used ( & not vectorInvariantMom = T )
+ pkg/cd_code              compiled but not used ( useCDscheme              = F )
+ pkg/monitor              compiled   and   used ( monitorFreq > 0.         = T )
+ pkg/debug                compiled but not used ( debugMode                = F )
+ pkg/rw                   compiled   and   used
+ pkg/mdsio                compiled   and   used
+(PID.TID 0000.0001)  PACKAGES_BOOT: End of package Summary
+(PID.TID 0000.0001) 
+(PID.TID 0000.0001)  OBCS_READPARMS: opening data.obcs
+(PID.TID 0000.0001)  OPEN_COPY_DATA_FILE: opening file data.obcs
+(PID.TID 0000.0001) // =======================================================
+(PID.TID 0000.0001) // Parameter file "data.obcs"
+(PID.TID 0000.0001) // =======================================================
+(PID.TID 0000.0001) ># Open-boundaries
+(PID.TID 0000.0001) > &OBCS_PARM01
+(PID.TID 0000.0001) ># This flag turns off checking and fixing problematic topography across
+(PID.TID 0000.0001) ># open boundaries.
+(PID.TID 0000.0001) > OBCSfixTopo=.FALSE.,
+(PID.TID 0000.0001) > OB_Iwest = 20*1,
+(PID.TID 0000.0001) > OB_Ieast = 20*-1,
+(PID.TID 0000.0001) > OB_Jnorth= 42*-1,
+(PID.TID 0000.0001) > OBWconnectFile = 'connect_obW.bin',
+(PID.TID 0000.0001) > OBEconnectFile = 'connect_obE.bin',
+(PID.TID 0000.0001) > OBNconnectFile = 'connect_obN.bin',
+(PID.TID 0000.0001) ># OBWconnectFile = 'zeros_obX.bin',
+(PID.TID 0000.0001) ># OBEconnectFile = 'zeros_obX.bin',
+(PID.TID 0000.0001) ># OBNconnectFile = 'zeros_obX.bin',
+(PID.TID 0000.0001) > useOBCSprescribe = .TRUE.,
+(PID.TID 0000.0001) > OBCS_u1_adv_T = 1,
+(PID.TID 0000.0001) > OBCS_u1_adv_S = 1,
+(PID.TID 0000.0001) > OBCS_u1_adv_Tr(1:5) = 5*1,
+(PID.TID 0000.0001) > OBWuFile = 'U_obW.bin',
+(PID.TID 0000.0001) > OBEuFile = 'U_obE.bin',
+(PID.TID 0000.0001) > OBNuFile = 'U_obN.bin',
+(PID.TID 0000.0001) > OBWvFile = 'V_obW.bin',
+(PID.TID 0000.0001) > OBEvFile = 'V_obE.bin',
+(PID.TID 0000.0001) > OBNvFile = 'V_obN.bin',
+(PID.TID 0000.0001) > OBWtFile = 'T_obW.bin',
+(PID.TID 0000.0001) > OBEtFile = 'T_obE.bin',
+(PID.TID 0000.0001) > OBNtFile = 'T_obN.bin',
+(PID.TID 0000.0001) > OBWsFile = 'S_obW.bin',
+(PID.TID 0000.0001) > OBEsFile = 'S_obE.bin',
+(PID.TID 0000.0001) > OBNsFile = 'S_obN.bin',
+(PID.TID 0000.0001) > OBWptrFile(1) = 'Trac01_obW.bin',
+(PID.TID 0000.0001) > OBEptrFile(1) = 'Trac01_obE.bin',
+(PID.TID 0000.0001) > OBNptrFile(1) = 'Trac01_obN.bin',
+(PID.TID 0000.0001) > OBWptrFile(2) = 'Trac02_obW.bin',
+(PID.TID 0000.0001) > OBEptrFile(2) = 'Trac02_obE.bin',
+(PID.TID 0000.0001) > OBNptrFile(2) = 'Trac02_obN.bin',
+(PID.TID 0000.0001) > OBWptrFile(3) = 'Trac03_obW.bin',
+(PID.TID 0000.0001) > OBEptrFile(3) = 'Trac03_obE.bin',
+(PID.TID 0000.0001) > OBNptrFile(3) = 'Trac03_obN.bin',
+(PID.TID 0000.0001) > OBWptrFile(4) = 'Trac04_obW.bin',
+(PID.TID 0000.0001) > OBEptrFile(4) = 'Trac04_obE.bin',
+(PID.TID 0000.0001) > OBNptrFile(4) = 'Trac04_obN.bin',
+(PID.TID 0000.0001) > OBWptrFile(5) = 'Trac05_obW.bin',
+(PID.TID 0000.0001) > OBEptrFile(5) = 'Trac05_obE.bin',
+(PID.TID 0000.0001) > OBNptrFile(5) = 'Trac05_obN.bin',
+(PID.TID 0000.0001) >#OBCS_monitorFreq= 1200.,
+(PID.TID 0000.0001) > OBCS_monSelect = 1,
+(PID.TID 0000.0001) > /
+(PID.TID 0000.0001) >
+(PID.TID 0000.0001) ># Orlanski parameters
+(PID.TID 0000.0001) > &OBCS_PARM02
+(PID.TID 0000.0001) >#Cmax=0.45,
+(PID.TID 0000.0001) >#cVelTimeScale=1000.,
+(PID.TID 0000.0001) > /
+(PID.TID 0000.0001) 
+(PID.TID 0000.0001)  OBCS_READPARMS: finished reading data.obcs
+(PID.TID 0000.0001)  OB_indexUnset = /* unset OB index value (i.e. no OB) */
+(PID.TID 0000.0001)                       0
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001)  Northern OB global indices : OB_Jnorth =
+(PID.TID 0000.0001)    42 @       20                            /* I =  1: 42 */
+(PID.TID 0000.0001)  Southern OB global indices : OB_Jsouth =
+(PID.TID 0000.0001)    42 @        0                            /* I =  1: 42 */
+(PID.TID 0000.0001)  Eastern  OB global indices : OB_Ieast =
+(PID.TID 0000.0001)    20 @       42                            /* J =  1: 20 */
+(PID.TID 0000.0001)  Western  OB global indices : OB_Iwest =
+(PID.TID 0000.0001)    20 @        1                            /* J =  1: 20 */
+(PID.TID 0000.0001) 
+(PID.TID 0000.0001)  GM_READPARMS: opening data.gmredi
+(PID.TID 0000.0001)  OPEN_COPY_DATA_FILE: opening file data.gmredi
+(PID.TID 0000.0001) // =======================================================
+(PID.TID 0000.0001) // Parameter file "data.gmredi"
+(PID.TID 0000.0001) // =======================================================
+(PID.TID 0000.0001) ># from MOM
+(PID.TID 0000.0001) ># GM_background_K: 	isopycnal diffusion coefficien
+(PID.TID 0000.0001) ># GM_maxSlope:		max slope of isopycnals
+(PID.TID 0000.0001) ># GM_Scrit:		transition for scaling diffusion coefficient
+(PID.TID 0000.0001) ># GM_Sd:		half width scaling for diffusion coefficient
+(PID.TID 0000.0001) ># real background diff:	horizontal diffusion
+(PID.TID 0000.0001) >
+(PID.TID 0000.0001) ># ifdef GM_VISBECK_VARIABLE_K, include following in GM_PARM01
+(PID.TID 0000.0001) ># GM_Visbeck_alpha   = 0.,
+(PID.TID 0000.0001) ># GM_Visbeck_length  = 2.e+5,
+(PID.TID 0000.0001) ># GM_Visbeck_depth   = 1.e+3,
+(PID.TID 0000.0001) ># GM_Visbeck_maxval_K= 2.5e+3,
+(PID.TID 0000.0001) >
+(PID.TID 0000.0001) > &GM_PARM01
+(PID.TID 0000.0001) >  GM_AdvForm         = .TRUE.,
+(PID.TID 0000.0001) >  GM_background_K    = 1.e+3,
+(PID.TID 0000.0001) >  GM_taper_scheme    = 'gkw91',
+(PID.TID 0000.0001) >  GM_maxSlope        = 1.e-2,
+(PID.TID 0000.0001) >  GM_Kmin_horiz      = 100.,
+(PID.TID 0000.0001) >  GM_Scrit           = 4.e-3,
+(PID.TID 0000.0001) >  GM_Sd              = 1.e-3,
+(PID.TID 0000.0001) > /
+(PID.TID 0000.0001) 
+(PID.TID 0000.0001)  GM_READPARMS: finished reading data.gmredi
+(PID.TID 0000.0001)  PTRACERS_READPARMS: opening data.ptracers
+(PID.TID 0000.0001)  OPEN_COPY_DATA_FILE: opening file data.ptracers
+(PID.TID 0000.0001) // =======================================================
+(PID.TID 0000.0001) // Parameter file "data.ptracers"
+(PID.TID 0000.0001) // =======================================================
+(PID.TID 0000.0001) > &PTRACERS_PARM01
+(PID.TID 0000.0001) > PTRACERS_numInUse=5,
+(PID.TID 0000.0001) > PTRACERS_Iter0= 0,
+(PID.TID 0000.0001) ># tracer 1 - dic
+(PID.TID 0000.0001) > PTRACERS_names(1)='DIC',
+(PID.TID 0000.0001) > PTRACERS_long_names(1)='Dissolved Inorganic Carbon (DIC) [mol C/m^3]',
+(PID.TID 0000.0001) > PTRACERS_units(1)='mol/m^3',
+(PID.TID 0000.0001) > PTRACERS_advScheme(1)=77,
+(PID.TID 0000.0001) > PTRACERS_diffKh(1)=0.E3,
+(PID.TID 0000.0001) > PTRACERS_diffKr(1)=3.E-5,
+(PID.TID 0000.0001) > PTRACERS_useGMRedi(1)=.TRUE.,
+(PID.TID 0000.0001) > PTRACERS_initialFile(1)='Trac01_ini.bin',
+(PID.TID 0000.0001) >#- use F95 syntax (to be converted with -DNML_EXTENDED_F77 if needed)
+(PID.TID 0000.0001) > PTRACERS_ref(1:15,1) = 2.0282, 2.0609, 2.1206, 2.1581,
+(PID.TID 0000.0001) >                     2.1904, 2.2188, 2.2474, 2.2699,
+(PID.TID 0000.0001) >                     2.2792, 2.2814, 2.2815, 2.2806,
+(PID.TID 0000.0001) >                     2.2800, 2.2760, 2.2758,
+(PID.TID 0000.0001) > PTRACERS_EvPrRn(1)= 0.,
+(PID.TID 0000.0001) ># tracer 2 - alk
+(PID.TID 0000.0001) > PTRACERS_names(2)='Alk',
+(PID.TID 0000.0001) > PTRACERS_long_names(2)='Alkalinity (Alk) [mol eq/m^3]',
+(PID.TID 0000.0001) > PTRACERS_units(2)='mol/m^3',
+(PID.TID 0000.0001) > PTRACERS_advScheme(2)=77,
+(PID.TID 0000.0001) > PTRACERS_diffKh(2)=0.E3,
+(PID.TID 0000.0001) > PTRACERS_diffKr(2)=3.E-5,
+(PID.TID 0000.0001) > PTRACERS_useGMRedi(2)=.TRUE.,
+(PID.TID 0000.0001) > PTRACERS_initialFile(2)='Trac02_ini.bin',
+(PID.TID 0000.0001) >#- use F95 syntax (to be converted with -DNML_EXTENDED_F77 if needed)
+(PID.TID 0000.0001) > PTRACERS_ref(1:15,2) = 2.3086, 2.3149, 2.3164, 2.3112,
+(PID.TID 0000.0001) >                     2.3098, 2.3160, 2.3313, 2.3517,
+(PID.TID 0000.0001) >                     2.3667, 2.3761, 2.3832, 2.3862,
+(PID.TID 0000.0001) >                     2.3881, 2.3863, 2.3867,
+(PID.TID 0000.0001) > PTRACERS_EvPrRn(2)= 0.,
+(PID.TID 0000.0001) ># tracer 3 - po4
+(PID.TID 0000.0001) > PTRACERS_names(3)='PO4',
+(PID.TID 0000.0001) > PTRACERS_long_names(3)='Phosphate (PO4) [mol P/m^3]',
+(PID.TID 0000.0001) > PTRACERS_units(3)='mol/m^3',
+(PID.TID 0000.0001) > PTRACERS_advScheme(3)=77,
+(PID.TID 0000.0001) > PTRACERS_diffKh(3)=0.E3,
+(PID.TID 0000.0001) > PTRACERS_diffKr(3)=3.E-5,
+(PID.TID 0000.0001) > PTRACERS_useGMRedi(3)=.TRUE.,
+(PID.TID 0000.0001) > PTRACERS_initialFile(3)='Trac03_ini.bin',
+(PID.TID 0000.0001) >#- use F95 syntax (to be converted with -DNML_EXTENDED_F77 if needed)
+(PID.TID 0000.0001) > PTRACERS_ref(1:15,3) = 0.5438E-3, 0.7821E-3, 1.1335E-3, 1.4913E-3,
+(PID.TID 0000.0001) >                     1.8606E-3, 2.1986E-3, 2.3966E-3, 2.4187E-3,
+(PID.TID 0000.0001) >                     2.4046E-3, 2.3291E-3, 2.2922E-3, 2.2886E-3,
+(PID.TID 0000.0001) >                     2.2608E-3, 2.2356E-3, 2.2296E-3,
+(PID.TID 0000.0001) >#PTRACERS_EvPrRn(3)= 0.,
+(PID.TID 0000.0001) ># tracer 4 - dop
+(PID.TID 0000.0001) > PTRACERS_names(4)='DOP',
+(PID.TID 0000.0001) > PTRACERS_long_names(4)='Dissolved Organic Phosphorus (DOP) [mol P/m^3]',
+(PID.TID 0000.0001) > PTRACERS_units(4)='mol/m^3',
+(PID.TID 0000.0001) > PTRACERS_advScheme(4)=77,
+(PID.TID 0000.0001) > PTRACERS_diffKh(4)=0.E3,
+(PID.TID 0000.0001) > PTRACERS_diffKr(4)=3.E-5,
+(PID.TID 0000.0001) > PTRACERS_useGMRedi(4)=.TRUE.,
+(PID.TID 0000.0001) > PTRACERS_initialFile(4)='Trac04_ini.bin',
+(PID.TID 0000.0001) >#- use F95 syntax (to be converted with -DNML_EXTENDED_F77 if needed)
+(PID.TID 0000.0001) > PTRACERS_ref(1:15,4) = 15*0.,
+(PID.TID 0000.0001) >#PTRACERS_EvPrRn(4)= 0.,
+(PID.TID 0000.0001) ># tracer 5 - o2
+(PID.TID 0000.0001) > PTRACERS_names(5)='O2',
+(PID.TID 0000.0001) > PTRACERS_long_names(5)='Dissolved Oxygen (O2) [mol O/m^3]',
+(PID.TID 0000.0001) > PTRACERS_units(5)='mol/m^3',
+(PID.TID 0000.0001) > PTRACERS_advScheme(5)=77,
+(PID.TID 0000.0001) > PTRACERS_diffKh(5)=0.E3,
+(PID.TID 0000.0001) > PTRACERS_diffKr(5)=3.E-5,
+(PID.TID 0000.0001) > PTRACERS_useGMRedi(5)=.TRUE.,
+(PID.TID 0000.0001) > PTRACERS_initialFile(5)='Trac05_ini.bin',
+(PID.TID 0000.0001) >#- use F95 syntax (to be converted with -DNML_EXTENDED_F77 if needed)
+(PID.TID 0000.0001) > PTRACERS_ref(1:15,5) = 0.2457, 0.2336, 0.1975, 0.1729,
+(PID.TID 0000.0001) >                     0.1591, 0.1503, 0.1424, 0.1445,
+(PID.TID 0000.0001) >                     0.1549, 0.1661, 0.1774, 0.1863,
+(PID.TID 0000.0001) >                     0.1925, 0.2021, 0.2051,
+(PID.TID 0000.0001) >#PTRACERS_EvPrRn(5)= 0.,
+(PID.TID 0000.0001) > /
+(PID.TID 0000.0001) 
+(PID.TID 0000.0001)  PTRACERS_READPARMS: finished reading data.ptracers
+(PID.TID 0000.0001)  GCHEM_READPARMS: opening data.gchem
+(PID.TID 0000.0001)  OPEN_COPY_DATA_FILE: opening file data.gchem
+(PID.TID 0000.0001) // =======================================================
+(PID.TID 0000.0001) // Parameter file "data.gchem"
+(PID.TID 0000.0001) // =======================================================
+(PID.TID 0000.0001) > &GCHEM_PARM01
+(PID.TID 0000.0001) >  useDIC=.TRUE.,
+(PID.TID 0000.0001) >  nsubtime=1,
+(PID.TID 0000.0001) > /
+(PID.TID 0000.0001) 
+(PID.TID 0000.0001)  GCHEM_READPARMS: finished reading data.gchem
+(PID.TID 0000.0001)  DIC_READPARMS: opening data.dic
+(PID.TID 0000.0001)  OPEN_COPY_DATA_FILE: opening file data.dic
+(PID.TID 0000.0001) // =======================================================
+(PID.TID 0000.0001) // Parameter file "data.dic"
+(PID.TID 0000.0001) // =======================================================
+(PID.TID 0000.0001) ># DIC parameters
+(PID.TID 0000.0001) > &ABIOTIC_PARMS
+(PID.TID 0000.0001) >  useCalciteSaturation= .TRUE.,
+(PID.TID 0000.0001) ># calcOmegaCalciteFreq= 86400.,
+(PID.TID 0000.0001) > /
+(PID.TID 0000.0001) >
+(PID.TID 0000.0001) > &BIOTIC_PARMS
+(PID.TID 0000.0001) >  alphaUniform = 0.97e-10,
+(PID.TID 0000.0001) >  rainRatioUniform = 5.e-2,
+(PID.TID 0000.0001) >  KRemin = 0.95,
+(PID.TID 0000.0001) > /
+(PID.TID 0000.0001) >
+(PID.TID 0000.0001) > &DIC_FORCING
+(PID.TID 0000.0001) >  DIC_iceFile='fice_box.bin',
+(PID.TID 0000.0001) >  DIC_windFile='tren_speed_box.bin',
+(PID.TID 0000.0001) >  DIC_silicaFile='sillev1_box.bin',
+(PID.TID 0000.0001) >  DIC_deepSilicaFile='silicate_3D_12m_box.bin',
+(PID.TID 0000.0001) > /
+(PID.TID 0000.0001) 
+(PID.TID 0000.0001)  DIC_READPARMS: finished reading data.dic
+(PID.TID 0000.0001) 
+(PID.TID 0000.0001) // ===================================
+(PID.TID 0000.0001) // DIC package parameters :
+(PID.TID 0000.0001) // ===================================
+(PID.TID 0000.0001) Using Follows et al. (2006) for pH/pCO2
+(PID.TID 0000.0001) Using Munhoven (2013) Solvesaphe carbon coefficients
+(PID.TID 0000.0001) Using Millero (1995)/Mehrbach K1 and K2 coefficients
+(PID.TID 0000.0001) Using Dickson and Riley (1979) KF coefficient
+(PID.TID 0000.0001) Using Uppstrom (1974) BT estimation from salinity
+(PID.TID 0000.0001) Using Riley (1965) FT estimation from salinity
+(PID.TID 0000.0001) permil = /* Ref. density to convert mol/m3 to mol/kg */
+(PID.TID 0000.0001)                 9.760858955588092E-04
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) Pa2Atm = /* Atmosph. pressure conversion coeff (to Atm) */
+(PID.TID 0000.0001)                 1.013250000000000E+05
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) zca = /* Scale depth for CaCO3 remineralization (m) */
+(PID.TID 0000.0001)                 3.500000000000000E+03
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) useCalciteSaturation  =  /* Flag for omegaC calculation on/off */
+(PID.TID 0000.0001)                   T
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) calcOmegaCalciteFreq = /* Frequency of calcite saturation calculation (s) */
+(PID.TID 0000.0001)                 4.320000000000000E+04
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) KierRateK = /* Rate constant for calcite dissolution (%/day) */
+(PID.TID 0000.0001)                 7.177000000000000E+00
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) KierRateExp = /* Rate exponent for calcite dissolution */
+(PID.TID 0000.0001)                 4.540000000000000E+00
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) WsinkPIC = /* Sinking speed of particulate inorganic carbon (m/s) */
+(PID.TID 0000.0001)                 1.157407407407407E-03
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) selectCalciteBottomRemin = /* Remineralize CO3 bottom flux: =0: here, =1: top layer */
+(PID.TID 0000.0001)                       1
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) DOPfraction = /* Fraction of new production going to DOP */
+(PID.TID 0000.0001)                 6.700000000000000E-01
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) KDOPRemin = /* DOP remineralization rate (1/s) */
+(PID.TID 0000.0001)                 6.430041152263375E-08
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) KRemin = /* Remin power law coeff. */
+(PID.TID 0000.0001)                 9.500000000000000E-01
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) zcrit = /* Minimum depth for biological activity (m) */
+(PID.TID 0000.0001)                 5.000000000000000E+02
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) O2crit = /* Critical oxygen level (mol/m3) */
+(PID.TID 0000.0001)                 4.000000000000000E-03
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) R_OP = /* Stochiometric ratio R_OP */
+(PID.TID 0000.0001)                -1.700000000000000E+02
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) R_CP = /* Stochiometric ratio R_CP */
+(PID.TID 0000.0001)                 1.170000000000000E+02
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) R_NP = /* Stochiometric ratio R_NP */
+(PID.TID 0000.0001)                 1.600000000000000E+01
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) R_FeP = /* Stochiometric ratio R_FeP */
+(PID.TID 0000.0001)                 4.680000000000000E-04
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) parfrac = /* Fraction of Qsw that is PAR */
+(PID.TID 0000.0001)                 4.000000000000000E-01
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) k0 = /* Light attentuation coefficient, water (1/m) */
+(PID.TID 0000.0001)                 2.000000000000000E-02
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) kchl = /* Light attentuation coefficient, chlorophyll (m2/mg) */
+(PID.TID 0000.0001)                 2.000000000000000E-02
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) lit0 = /* Half saturation light constant (W/m2) */
+(PID.TID 0000.0001)                 3.000000000000000E+01
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) KPO4 = /* Half saturation phosphate constant (mol/m3) */
+(PID.TID 0000.0001)                 5.000000000000000E-04
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) KFE = /* Half saturation fe constant (mol/m3) */
+(PID.TID 0000.0001)                 1.200000000000000E-07
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) alpfe = /* Solubility of aeolian fe */
+(PID.TID 0000.0001)                 1.000000000000000E-02
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) fesedflux_pcm = /* Sediment Fe flux = fesedflux_pcm*pflux+FeIntSec */
+(PID.TID 0000.0001)                 7.208000000000001E-02
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) FeIntSec = /* Sediment Fe flux = fesedflux_pcm * pflux + FeIntSec */
+(PID.TID 0000.0001)                 5.787037037037037E-12
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) freefemax = /* Max solubility of free iron (mol/m3) */
+(PID.TID 0000.0001)                 3.000000000000000E-07
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) KScav = /* Iron scavenging rate */
+(PID.TID 0000.0001)                 6.108539094650206E-09
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) ligand_stab = /* Ligand-free iron stability constant (m3/mol) */
+(PID.TID 0000.0001)                 1.000000000000000E+08
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) ligand_tot = /* Total free ligand  (mol/m3) */
+(PID.TID 0000.0001)                 1.000000000000000E-06
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) alphaUniform = /* Timescale for biological activity */
+(PID.TID 0000.0001)                 9.700000000000000E-11
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) rainRatioUniform= /* Inorganic/organic carbon rain ratio */
+(PID.TID 0000.0001)                 5.000000000000000E-02
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) QSW_underice  =  /* Flag for Qsw under Sea-Ice (i.e. SI fract included) */
+(PID.TID 0000.0001)                   F
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) DIC_windFile =  /* File name of wind speeds */
+(PID.TID 0000.0001)               'tren_speed_box.bin'
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) DIC_atmospFile=  /* File name of atmospheric pressure*/
+(PID.TID 0000.0001)               ''
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) DIC_silicaFile=  /* File name of surface silica */
+(PID.TID 0000.0001)               'sillev1_box.bin'
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) DIC_deepSilicaFile=  /* File name of 3d silica field */
+(PID.TID 0000.0001)               'silicate_3D_12m_box.bin'
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) DIC_iceFile =  /* File name of seaice fraction */
+(PID.TID 0000.0001)               'fice_box.bin'
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) DIC_parFile=  /* File name of photosynthetically available radiation */
+(PID.TID 0000.0001)               ''
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) DIC_chlaFile=  /* File name of chlorophyll climatology */
+(PID.TID 0000.0001)               ''
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) DIC_ironFile =  /* File name of aeolian iron flux */
+(PID.TID 0000.0001)               ''
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) DIC_forcingPeriod = /* Periodic forcing parameter specific for DIC (s) */
+(PID.TID 0000.0001)                 2.592000000000000E+06
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) DIC_forcingCycle = /* Periodic forcing parameter specific for DIC (s) */
+(PID.TID 0000.0001)                 3.110400000000000E+07
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) dic_int1 =  /*  */
+(PID.TID 0000.0001)                       0
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) dic_int2 =  /*  */
+(PID.TID 0000.0001)                       0
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) dic_int3 =  /*  */
+(PID.TID 0000.0001)                       0
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) dic_int4 =  /*  */
+(PID.TID 0000.0001)                       0
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) dic_pCO2 = /* Atmospheric pCO2 to be read in data.dic */
+(PID.TID 0000.0001)                 2.780000000000000E-04
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) GCHEM_TR_REGISTER:  Start registering GCHEM tracers
+(PID.TID 0000.0001)   DIC_TR_REGISTER:  number of DIC tracers=    5
+(PID.TID 0000.0001)   DIC_TR_REGISTER:   starting at pTrc num=    1
+(PID.TID 0000.0001)   DIC_TR_REGISTER:  Numb. Trac & SepForc Trac:    5    5
+(PID.TID 0000.0001) GCHEM_TR_REGISTER:  Numb. Trac & SepForc Trac:    5    5
+(PID.TID 0000.0001) 
+(PID.TID 0000.0001)  DIAGNOSTICS_READPARMS: opening data.diagnostics
+(PID.TID 0000.0001)  OPEN_COPY_DATA_FILE: opening file data.diagnostics
+(PID.TID 0000.0001) // =======================================================
+(PID.TID 0000.0001) // Parameter file "data.diagnostics"
+(PID.TID 0000.0001) // =======================================================
+(PID.TID 0000.0001) ># Diagnostic Package Choices
+(PID.TID 0000.0001) >#--------------------
+(PID.TID 0000.0001) >#  dumpAtLast (logical): always write output at the end of simulation (default=F)
+(PID.TID 0000.0001) >#  diag_mnc   (logical): write to NetCDF files (default=useMNC)
+(PID.TID 0000.0001) >#--for each output-stream:
+(PID.TID 0000.0001) >#  fileName(n) : prefix of the output file name (max 80c long) for outp.stream n
+(PID.TID 0000.0001) >#  frequency(n):< 0 : write snap-shot output every |frequency| seconds
+(PID.TID 0000.0001) >#               > 0 : write time-average output every frequency seconds
+(PID.TID 0000.0001) >#  timePhase(n)     : write at time = timePhase + multiple of |frequency|
+(PID.TID 0000.0001) >#    averagingFreq  : frequency (in s) for periodic averaging interval
+(PID.TID 0000.0001) >#    averagingPhase : phase     (in s) for periodic averaging interval
+(PID.TID 0000.0001) >#    repeatCycle    : number of averaging intervals in 1 cycle
+(PID.TID 0000.0001) >#  levels(:,n) : list of levels to write to file (Notes: declared as REAL)
+(PID.TID 0000.0001) >#                when this entry is missing, select all common levels of this list
+(PID.TID 0000.0001) >#  fields(:,n) : list of selected diagnostics fields (8.c) in outp.stream n
+(PID.TID 0000.0001) >#                (see "available_diagnostics.log" file for the full list of diags)
+(PID.TID 0000.0001) >#  missing_value(n) : missing value for real-type fields in output file "n"
+(PID.TID 0000.0001) >#  fileFlags(n)     : specific code (8c string) for output file "n"
+(PID.TID 0000.0001) >#--------------------
+(PID.TID 0000.0001) > &DIAGNOSTICS_LIST
+(PID.TID 0000.0001) ># diagCG_maxIters = 200,
+(PID.TID 0000.0001) ># diagCG_resTarget = 1.E-10,
+(PID.TID 0000.0001) ># diagCG_pcOffDFac = 0.96,
+(PID.TID 0000.0001) ># diagCG_prtResFrq = 20,
+(PID.TID 0000.0001) >  xPsi0 = 300.,
+(PID.TID 0000.0001) >  yPsi0 = -26.,
+(PID.TID 0000.0001) >#--
+(PID.TID 0000.0001) >  fields(1:10,1) = 'ETAN    ','ETANSQ  ','DETADT2 ','PHIBOT  ','PHIBOTSQ',
+(PID.TID 0000.0001) >                   'DICTFLX ','DICOFLX ','DICCFLX ','DICPCO2 ','DICPHAV ',
+(PID.TID 0000.0001) >   levels(1,1) = 1.,
+(PID.TID 0000.0001) >   fileName(1) = 'surfDiag',
+(PID.TID 0000.0001) >  frequency(1) = 2592000.,
+(PID.TID 0000.0001) ># frequency(1) = 432000.,
+(PID.TID 0000.0001) >  fields(1:9,2)  = 'VVELMASS','UVELMASS','THETA   ','SALT    ',
+(PID.TID 0000.0001) >                   'GM_PsiX ','GM_PsiY ','PhiVEL  ','PsiVEL  ',
+(PID.TID 0000.0001) >                   'CONVADJ ',
+(PID.TID 0000.0001) >   fileName(2) = 'dynDiag',
+(PID.TID 0000.0001) >  frequency(2) = 2592000.,
+(PID.TID 0000.0001) >  frequency(2) = 432000.,
+(PID.TID 0000.0001) >  fields(1:9,3)  = 'DICBIOA ','DICCARB ',
+(PID.TID 0000.0001) >                   'TRAC01  ','TRAC02  ','TRAC03  ','TRAC04  ','TRAC05  ',
+(PID.TID 0000.0001) >                   'ADVxTr05','DFrITr05',
+(PID.TID 0000.0001) >#  fileName(3) = 'dicDiag',
+(PID.TID 0000.0001) >  frequency(3) = 2592000.,
+(PID.TID 0000.0001) >  fields(1:8,4)  = 'ADVx_TH ','ADVy_TH ','ADVr_TH ',
+(PID.TID 0000.0001) >                   'DFxE_TH ','DFyE_TH ','DFrE_TH ','DFrI_TH ',
+(PID.TID 0000.0001) >                   'ADVx_SLT',
+(PID.TID 0000.0001) >#  fileName(4) = 'flxDiag',
+(PID.TID 0000.0001) >  frequency(4) = 0.,
+(PID.TID 0000.0001) > /
+(PID.TID 0000.0001) >
+(PID.TID 0000.0001) >#--------------------
+(PID.TID 0000.0001) ># Parameter for Diagnostics of per level statistics:
+(PID.TID 0000.0001) >#--------------------
+(PID.TID 0000.0001) >#  diagSt_mnc (logical): write stat-diags to NetCDF files (default=diag_mnc)
+(PID.TID 0000.0001) >#  diagSt_regMaskFile : file containing the region-mask to read-in
+(PID.TID 0000.0001) >#  nSetRegMskFile   : number of region-mask sets within the region-mask file
+(PID.TID 0000.0001) >#  set_regMask(i)   : region-mask set-index that identifies the region "i"
+(PID.TID 0000.0001) >#  val_regMask(i)   : region "i" identifier value in the region mask
+(PID.TID 0000.0001) >#--for each output-stream:
+(PID.TID 0000.0001) >#  stat_fName(n) : prefix of the output file name (max 80c long) for outp.stream n
+(PID.TID 0000.0001) >#  stat_freq(n):< 0 : write snap-shot output every |stat_freq| seconds
+(PID.TID 0000.0001) >#               > 0 : write time-average output every stat_freq seconds
+(PID.TID 0000.0001) >#  stat_phase(n)    : write at time = stat_phase + multiple of |stat_freq|
+(PID.TID 0000.0001) >#  stat_region(:,n) : list of "regions" (default: 1 region only=global)
+(PID.TID 0000.0001) >#  stat_fields(:,n) : list of selected diagnostics fields (8.c) in outp.stream n
+(PID.TID 0000.0001) >#                (see "available_diagnostics.log" file for the full list of diags)
+(PID.TID 0000.0001) >#--------------------
+(PID.TID 0000.0001) > &DIAG_STATIS_PARMS
+(PID.TID 0000.0001) >#---
+(PID.TID 0000.0001) > stat_fields(1:20,1) = 'ETAN    ','DETADT2 ','THETA   ','SALT    ','CONVADJ ',
+(PID.TID 0000.0001) >                       'UVEL    ','VVEL    ','WVEL    ','GM_PsiX ','GM_PsiY ',
+(PID.TID 0000.0001) >                       'TRAC01  ','TRAC02  ','TRAC03  ','TRAC04  ','TRAC05  ',
+(PID.TID 0000.0001) >                       'DIC3DSIT','OMEGAC  ','DIC3DPH ','DIC3DPCO','DIC3DCO3',
+(PID.TID 0000.0001) >  stat_fName(1) = 'dynStDiag',
+(PID.TID 0000.0001) >   stat_freq(1) = 432000.,
+(PID.TID 0000.0001) >  stat_phase(1) = 0.,
+(PID.TID 0000.0001) > /
+(PID.TID 0000.0001) 
+(PID.TID 0000.0001) S/R DIAGNOSTICS_READPARMS, read namelist "diagnostics_list": start
+(PID.TID 0000.0001) S/R DIAGNOSTICS_READPARMS, read namelist "diagnostics_list": OK
+(PID.TID 0000.0001) S/R DIAGNOSTICS_READPARMS, read namelist "DIAG_STATIS_PARMS": start
+(PID.TID 0000.0001) S/R DIAGNOSTICS_READPARMS, read namelist "DIAG_STATIS_PARMS": OK
+(PID.TID 0000.0001)  DIAGNOSTICS_READPARMS: global parameter summary:
+(PID.TID 0000.0001)  dumpAtLast = /* always write time-ave diags at the end */
+(PID.TID 0000.0001)                   F
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001)  diag_mnc =   /* write NetCDF output files */
+(PID.TID 0000.0001)                   F
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001)  useMissingValue = /* put MissingValue where mask = 0 */
+(PID.TID 0000.0001)                   F
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001)  diagCG_maxIters = /* max number of iters in diag_cg2d */
+(PID.TID 0000.0001)                    1000
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001)  diagCG_resTarget = /* residual target for diag_cg2d */
+(PID.TID 0000.0001)                 1.000000000000000E-13
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001)  diagCG_pcOffDFac = /* preconditioner off-diagonal factor */
+(PID.TID 0000.0001)                 9.611687812379854E-01
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) -----------------------------------------------------
+(PID.TID 0000.0001)  DIAGNOSTICS_READPARMS: active diagnostics summary:
+(PID.TID 0000.0001) -----------------------------------------------------
+(PID.TID 0000.0001) Creating Output Stream: surfDiag
+(PID.TID 0000.0001) Output Frequency:    2592000.000000 ; Phase:           0.000000
+(PID.TID 0000.0001)  Averaging Freq.:    2592000.000000 , Phase:           0.000000 , Cycle:   1
+(PID.TID 0000.0001)  missing value: -9.990000000000E+02
+(PID.TID 0000.0001)  Levels:       1.
+(PID.TID 0000.0001)  Fields:    ETAN     ETANSQ   DETADT2  PHIBOT   PHIBOTSQ DICTFLX  DICOFLX  DICCFLX  DICPCO2  DICPHAV
+(PID.TID 0000.0001) Creating Output Stream: dynDiag
+(PID.TID 0000.0001) Output Frequency:     432000.000000 ; Phase:           0.000000
+(PID.TID 0000.0001)  Averaging Freq.:     432000.000000 , Phase:           0.000000 , Cycle:   1
+(PID.TID 0000.0001)  missing value: -9.990000000000E+02
+(PID.TID 0000.0001)  Levels:    will be set later
+(PID.TID 0000.0001)  Fields:    VVELMASS UVELMASS THETA    SALT     GM_PsiX  GM_PsiY  PhiVEL   PsiVEL   CONVADJ
+(PID.TID 0000.0001) -----------------------------------------------------
+(PID.TID 0000.0001)  DIAGNOSTICS_READPARMS: statistics diags. summary:
+(PID.TID 0000.0001) Creating Stats. Output Stream: dynStDiag
+(PID.TID 0000.0001) Output Frequency:     432000.000000 ; Phase:           0.000000
+(PID.TID 0000.0001)  Regions:   0
+(PID.TID 0000.0001)  Fields:    ETAN     DETADT2  THETA    SALT     CONVADJ  UVEL     VVEL     WVEL     GM_PsiX  GM_PsiY
+(PID.TID 0000.0001)  Fields:    TRAC01   TRAC02   TRAC03   TRAC04   TRAC05   DIC3DSIT OMEGAC   DIC3DPH  DIC3DPCO DIC3DCO3
+(PID.TID 0000.0001) -----------------------------------------------------
+(PID.TID 0000.0001) 
+(PID.TID 0000.0001) SET_PARMS: done
+(PID.TID 0000.0001) Enter INI_VERTICAL_GRID: setInterFDr=    T ; setCenterDr=    F
+(PID.TID 0000.0001) %MON XC_max                       =   3.5296875000000E+02
+(PID.TID 0000.0001) %MON XC_min                       =   2.3765625000000E+02
+(PID.TID 0000.0001) %MON XC_mean                      =   2.9531250000000E+02
+(PID.TID 0000.0001) %MON XC_sd                        =   3.4090083441706E+01
+(PID.TID 0000.0001) %MON XG_max                       =   3.5156250000000E+02
+(PID.TID 0000.0001) %MON XG_min                       =   2.3625000000000E+02
+(PID.TID 0000.0001) %MON XG_mean                      =   2.9390625000000E+02
+(PID.TID 0000.0001) %MON XG_sd                        =   3.4090083441706E+01
+(PID.TID 0000.0001) %MON DXC_max                      =   2.7929930890376E+05
+(PID.TID 0000.0001) %MON DXC_min                      =   5.3457499214614E+04
+(PID.TID 0000.0001) %MON DXC_mean                     =   1.7889438140789E+05
+(PID.TID 0000.0001) %MON DXC_sd                       =   6.9711490203249E+04
+(PID.TID 0000.0001) %MON DXF_max                      =   2.7929930890376E+05
+(PID.TID 0000.0001) %MON DXF_min                      =   5.3457499214614E+04
+(PID.TID 0000.0001) %MON DXF_mean                     =   1.7889438140789E+05
+(PID.TID 0000.0001) %MON DXF_sd                       =   6.9711490203249E+04
+(PID.TID 0000.0001) %MON DXG_max                      =   2.7576500024724E+05
+(PID.TID 0000.0001) %MON DXG_min                      =   4.5880659601012E+04
+(PID.TID 0000.0001) %MON DXG_mean                     =   1.7292088380237E+05
+(PID.TID 0000.0001) %MON DXG_sd                       =   7.0928664230424E+04
+(PID.TID 0000.0001) %MON DXV_max                      =   2.7576500024724E+05
+(PID.TID 0000.0001) %MON DXV_min                      =   4.5880659601012E+04
+(PID.TID 0000.0001) %MON DXV_mean                     =   1.7292088380237E+05
+(PID.TID 0000.0001) %MON DXV_sd                       =   7.0928664230424E+04
+(PID.TID 0000.0001) %MON YC_max                       =  -2.6718750000000E+01
+(PID.TID 0000.0001) %MON YC_min                       =  -8.0156250000000E+01
+(PID.TID 0000.0001) %MON YC_mean                      =  -5.3437500000000E+01
+(PID.TID 0000.0001) %MON YC_sd                        =   1.6217666148756E+01
+(PID.TID 0000.0001) %MON YG_max                       =  -2.8125000000000E+01
+(PID.TID 0000.0001) %MON YG_min                       =  -8.1562500000000E+01
+(PID.TID 0000.0001) %MON YG_mean                      =  -5.4843750000000E+01
+(PID.TID 0000.0001) %MON YG_sd                        =   1.6217666148756E+01
+(PID.TID 0000.0001) %MON DYC_max                      =   3.1268664380261E+05
+(PID.TID 0000.0001) %MON DYC_min                      =   3.1268664380261E+05
+(PID.TID 0000.0001) %MON DYC_mean                     =   3.1268664380261E+05
+(PID.TID 0000.0001) %MON DYC_sd                       =   6.9849193096161E-10
+(PID.TID 0000.0001) %MON DYF_max                      =   3.1268664380261E+05
+(PID.TID 0000.0001) %MON DYF_min                      =   3.1268664380261E+05
+(PID.TID 0000.0001) %MON DYF_mean                     =   3.1268664380261E+05
+(PID.TID 0000.0001) %MON DYF_sd                       =   6.9849193096161E-10
+(PID.TID 0000.0001) %MON DYG_max                      =   3.1268664380261E+05
+(PID.TID 0000.0001) %MON DYG_min                      =   3.1268664380261E+05
+(PID.TID 0000.0001) %MON DYG_mean                     =   3.1268664380261E+05
+(PID.TID 0000.0001) %MON DYG_sd                       =   6.9849193096161E-10
+(PID.TID 0000.0001) %MON DYU_max                      =   3.1268664380261E+05
+(PID.TID 0000.0001) %MON DYU_min                      =   3.1268664380261E+05
+(PID.TID 0000.0001) %MON DYU_mean                     =   3.1268664380261E+05
+(PID.TID 0000.0001) %MON DYU_sd                       =   6.9849193096161E-10
+(PID.TID 0000.0001) %MON RA_max                       =   8.7324395636096E+10
+(PID.TID 0000.0001) %MON RA_min                       =   1.6713767855193E+10
+(PID.TID 0000.0001) %MON RA_mean                      =   5.5932267789893E+10
+(PID.TID 0000.0001) %MON RA_sd                        =   2.1795663493704E+10
+(PID.TID 0000.0001) %MON RAW_max                      =   8.7324395636096E+10
+(PID.TID 0000.0001) %MON RAW_min                      =   1.6713767855193E+10
+(PID.TID 0000.0001) %MON RAW_mean                     =   5.5932267789893E+10
+(PID.TID 0000.0001) %MON RAW_sd                       =   2.1795663493704E+10
+(PID.TID 0000.0001) %MON RAS_max                      =   8.6219375474631E+10
+(PID.TID 0000.0001) %MON RAS_min                      =   1.4344829161122E+10
+(PID.TID 0000.0001) %MON RAS_mean                     =   5.4064622394411E+10
+(PID.TID 0000.0001) %MON RAS_sd                       =   2.2176219345146E+10
+(PID.TID 0000.0001) %MON RAZ_max                      =   8.6219375474631E+10
+(PID.TID 0000.0001) %MON RAZ_min                      =   1.4344829161122E+10
+(PID.TID 0000.0001) %MON RAZ_mean                     =   5.4064622394411E+10
+(PID.TID 0000.0001) %MON RAZ_sd                       =   2.2176219345146E+10
+(PID.TID 0000.0001) %MON AngleCS_max                  =   1.0000000000000E+00
+(PID.TID 0000.0001) %MON AngleCS_min                  =   1.0000000000000E+00
+(PID.TID 0000.0001) %MON AngleCS_mean                 =   1.0000000000000E+00
+(PID.TID 0000.0001) %MON AngleCS_sd                   =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON AngleSN_max                  =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON AngleSN_min                  =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON AngleSN_mean                 =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON AngleSN_sd                   =   0.0000000000000E+00
+(PID.TID 0000.0001)  MDS_READ_FIELD: opening global file: bathy_box.bin
+(PID.TID 0000.0001) // =======================================================
+(PID.TID 0000.0001) // Field Model R_low (ini_masks_etc)
+(PID.TID 0000.0001) // CMIN =         -5.200000000000000E+03
+(PID.TID 0000.0001) // CMAX =         -5.000000000000000E+01
+(PID.TID 0000.0001) // CINT =          1.907407407407407E+02
+(PID.TID 0000.0001) // SYMBOLS (CMIN->CMAX): -abcdefghijklmnopqrstuvwxyz+
+(PID.TID 0000.0001) //                  0.0: .
+(PID.TID 0000.0001) // RANGE I (Lo:Hi:Step):(    -2:    45:     1)
+(PID.TID 0000.0001) // RANGE J (Lo:Hi:Step):(    23:    -2:    -1)
+(PID.TID 0000.0001) // RANGE K (Lo:Hi:Step):(   1:   1:   1)
+(PID.TID 0000.0001) // =======================================================
+(PID.TID 0000.0001) K =   1
+(PID.TID 0000.0001) //                I=7       I=17      I=21      I=31      I=35      I=45
+(PID.TID 0000.0001) // |--J--|210123456|890123456|234567890|234567890|678901234|678901234|
+(PID.TID 0000.0001) //     23 ...............................+yyyyyyyyyyyyyyxxxyy.........
+(PID.TID 0000.0001) //     22 ...............................++zz..zyxz..zyxy.............
+(PID.TID 0000.0001) //     21 ............................................................
+(PID.TID 0000.0001) //     20 kfeijklmkkjiiihihgffhihgffff........zole..zoledcaabdfhkfeijk
+(PID.TID 0000.0001) //     19 lhehijlmkjihhhihggfeihggfeev........ohgf..ohgfqihdddfilhehij
+(PID.TID 0000.0001) //     18 kfehhikmjjihhhihggfeihggfef+.......shgff.shgfflgiddfhkkfehhi
+(PID.TID 0000.0001) //     17 jggfhhjmjiiiiihgggffhgggfff.......xfbbbdxfbbbdddffggjkjggfhh
+(PID.TID 0000.0001) //     16 ljjeegjmjgfgijihggffihggffp......zfa-aaafa-aaaddddfgklljjeeg
+(PID.TID 0000.0001) //     15 jhgeehkmihfefijihgggjihgggy......h------------abddfhkljhgeeh
+(PID.TID 0000.0001) //     14 jggfghkljigeeefgikiifgikii+...++p---aaa---aaa--adddgjkjggfgh
+(PID.TID 0000.0001) //     13 llifgjlljhgeeeeffhjkeffhjk....++j---------------addfgkllifgj
+(PID.TID 0000.0001) //     12 jllhiklkihfedddddefidddefi....+zsqmb-afamb-afaaabddffhjllhik
+(PID.TID 0000.0001) //     11 hjnjmljhhfedddddddfgddddfgj..+zzsqpnnqjipnnqjigifffdefhjnjml
+(PID.TID 0000.0001) //     10 fijmljhhgeddddaadddfaadddfjlllkjihggjkmwggjkmwvjddfddefijmlj
+(PID.TID 0000.0001) //      9 ffhggdddddccdddddddddddddddfihggggggkkjkggkkjkkjjodddeffhggd
+(PID.TID 0000.0001) //      8 aa-baddaaaaaaaaabbbdaabbbddeghhgilolvxomolvxomnllkefgdaa-bad
+(PID.TID 0000.0001) //     13 llifgjlljhgeeeeffhjkeffhjk....++j---------------addfgkllifgj
+(PID.TID 0000.0001) //     12 jllhiklkihfedddddefidddefi....+zsqmb-afamb-afaaabddffhjllhik
+(PID.TID 0000.0001) //     11 hjnjmljhhfedddddddfgddddfgj..+zzsqpnnqjipnnqjigifffdefhjnjml
+(PID.TID 0000.0001) //     10 fijmljhhgeddddaadddfaadddfjlllkjihggjkmwggjkmwvjddfddefijmlj
+(PID.TID 0000.0001) //      9 ffhggdddddccdddddddddddddddfihggggggkkjkggkkjkkjjodddeffhggd
+(PID.TID 0000.0001) //      8 aa-baddaaaaaaaaabbbdaabbbddeghhgilolvxomolvxomnllkefgdaa-bad
+(PID.TID 0000.0001) //      7 ---aaaaaddaaabdddddedddddefgill..zqjkigdqjkigddddddbaa---aaa
+(PID.TID 0000.0001) //      6 aadddddddddddddddeegdddeeghpy...yxnhgeddnhgedddddddbaaaadddd
+(PID.TID 0000.0001) //      5 dgnhigghffeddffilloxfilloxy....zyxoihgggoihgggdddddddddgnhig
+(PID.TID 0000.0001) //      4 z..npvwvvwy++yyyyxxzyyyxxz......ywttqmigttqmigghggfflyz..npv
+(PID.TID 0000.0001) //      3 ...............................+yyyyyyyyyyyyyyxxxyy.........
+(PID.TID 0000.0001) //      2 ...............................++zz..zyxz..zyxy.............
+(PID.TID 0000.0001) //      1 ............................................................
+(PID.TID 0000.0001) //      0 kfeijklmkkjiiihihgffhihgffff........zole..zoledcaabdfhkfeijk
+(PID.TID 0000.0001) //     -1 lhehijlmkjihhhihggfeihggfeev........ohgf..ohgfqihdddfilhehij
+(PID.TID 0000.0001) //     -2 kfehhikmjjihhhihggfeihggfef+.......shgff.shgfflgiddfhkkfehhi
+(PID.TID 0000.0001) // =======================================================
+(PID.TID 0000.0001) // END OF FIELD                                          =
+(PID.TID 0000.0001) // =======================================================
+(PID.TID 0000.0001) 
+(PID.TID 0000.0001) // =======================================================
+(PID.TID 0000.0001) // Field Model Ro_surf (ini_masks_etc)
+(PID.TID 0000.0001) // CMIN =          1.000000000000000E+32
+(PID.TID 0000.0001) // CMAX =         -1.000000000000000E+32
+(PID.TID 0000.0001) // CINT =          0.000000000000000E+00
+(PID.TID 0000.0001) // SYMBOLS (CMIN->CMAX): -abcdefghijklmnopqrstuvwxyz+
+(PID.TID 0000.0001) //                  0.0: .
+(PID.TID 0000.0001) // RANGE I (Lo:Hi:Step):(    -2:    45:     1)
+(PID.TID 0000.0001) // RANGE J (Lo:Hi:Step):(    23:    -2:    -1)
+(PID.TID 0000.0001) // RANGE K (Lo:Hi:Step):(   1:   1:   1)
+(PID.TID 0000.0001) // =======================================================
+(PID.TID 0000.0001) // =======================================================
+(PID.TID 0000.0001) // END OF FIELD                                          =
+(PID.TID 0000.0001) // =======================================================
+(PID.TID 0000.0001) 
+(PID.TID 0000.0001) // =======================================================
+(PID.TID 0000.0001) // Field hFacC at iteration          0
+(PID.TID 0000.0001) // CMIN =          1.000000000000000E+00
+(PID.TID 0000.0001) // CMAX =          1.000000000000000E+00
+(PID.TID 0000.0001) // CINT =          0.000000000000000E+00
+(PID.TID 0000.0001) // SYMBOLS (CMIN->CMAX): -abcdefghijklmnopqrstuvwxyz+
+(PID.TID 0000.0001) //                  0.0: .
+(PID.TID 0000.0001) // RANGE I (Lo:Hi:Step):(    -2:    45:     1)
+(PID.TID 0000.0001) // RANGE J (Lo:Hi:Step):(    23:    -2:    -1)
+(PID.TID 0000.0001) // RANGE K (Lo:Hi:Step):(   1:   1:   1)
+(PID.TID 0000.0001) // =======================================================
+(PID.TID 0000.0001) // =======================================================
+(PID.TID 0000.0001) // END OF FIELD                                          =
+(PID.TID 0000.0001) // =======================================================
+(PID.TID 0000.0001) 
+(PID.TID 0000.0001) // =======================================================
+(PID.TID 0000.0001) // Field hFacW at iteration          0
+(PID.TID 0000.0001) // CMIN =          1.000000000000000E+00
+(PID.TID 0000.0001) // CMAX =          1.000000000000000E+00
+(PID.TID 0000.0001) // CINT =          0.000000000000000E+00
+(PID.TID 0000.0001) // SYMBOLS (CMIN->CMAX): -abcdefghijklmnopqrstuvwxyz+
+(PID.TID 0000.0001) //                  0.0: .
+(PID.TID 0000.0001) // RANGE I (Lo:Hi:Step):(    -2:    45:     1)
+(PID.TID 0000.0001) // RANGE J (Lo:Hi:Step):(    23:    -2:    -1)
+(PID.TID 0000.0001) // RANGE K (Lo:Hi:Step):(   1:   1:   1)
+(PID.TID 0000.0001) // =======================================================
+(PID.TID 0000.0001) // =======================================================
+(PID.TID 0000.0001) // END OF FIELD                                          =
+(PID.TID 0000.0001) // =======================================================
+(PID.TID 0000.0001) 
+(PID.TID 0000.0001) // =======================================================
+(PID.TID 0000.0001) // Field hFacS at iteration          0
+(PID.TID 0000.0001) // CMIN =          1.000000000000000E+00
+(PID.TID 0000.0001) // CMAX =          1.000000000000000E+00
+(PID.TID 0000.0001) // CINT =          0.000000000000000E+00
+(PID.TID 0000.0001) // SYMBOLS (CMIN->CMAX): -abcdefghijklmnopqrstuvwxyz+
+(PID.TID 0000.0001) //                  0.0: .
+(PID.TID 0000.0001) // RANGE I (Lo:Hi:Step):(    -2:    45:     1)
+(PID.TID 0000.0001) // RANGE J (Lo:Hi:Step):(    23:    -2:    -1)
+(PID.TID 0000.0001) // RANGE K (Lo:Hi:Step):(   1:   1:   1)
+(PID.TID 0000.0001) // =======================================================
+(PID.TID 0000.0001) // =======================================================
+(PID.TID 0000.0001) // END OF FIELD                                          =
+(PID.TID 0000.0001) // =======================================================
+(PID.TID 0000.0001) 
+(PID.TID 0000.0001) GAD_INIT_FIXED: GAD_OlMinSize=  1  0  1
+(PID.TID 0000.0001) 
+(PID.TID 0000.0001) // ===================================
+(PID.TID 0000.0001) // GAD parameters :
+(PID.TID 0000.0001) // ===================================
+(PID.TID 0000.0001) tempAdvScheme =   /* Temp. Horiz.Advection scheme selector */
+(PID.TID 0000.0001)                       2
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) tempVertAdvScheme =   /* Temp. Vert. Advection scheme selector */
+(PID.TID 0000.0001)                       2
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) tempMultiDimAdvec =   /* use Muti-Dim Advec method for Temp */
+(PID.TID 0000.0001)                   F
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) tempSOM_Advection = /* use 2nd Order Moment Advection for Temp */
+(PID.TID 0000.0001)                   F
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) AdamsBashforthGt = /* apply Adams-Bashforth extrapolation on Gt */
+(PID.TID 0000.0001)                   T
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) AdamsBashforth_T = /* apply Adams-Bashforth extrapolation on Temp */
+(PID.TID 0000.0001)                   F
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) saltAdvScheme =   /* Salt. Horiz.advection scheme selector */
+(PID.TID 0000.0001)                       2
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) saltVertAdvScheme =   /* Salt. Vert. Advection scheme selector */
+(PID.TID 0000.0001)                       2
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) saltMultiDimAdvec =   /* use Muti-Dim Advec method for Salt */
+(PID.TID 0000.0001)                   F
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) saltSOM_Advection = /* use 2nd Order Moment Advection for Salt */
+(PID.TID 0000.0001)                   F
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) AdamsBashforthGs = /* apply Adams-Bashforth extrapolation on Gs */
+(PID.TID 0000.0001)                   T
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) AdamsBashforth_S = /* apply Adams-Bashforth extrapolation on Salt */
+(PID.TID 0000.0001)                   F
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) // ===================================
+(PID.TID 0000.0001)  MDS_READ_SEC_XZ: opening global file: connect_obN.bin
+(PID.TID 0000.0001)  MDS_READ_SEC_YZ: opening global file: connect_obE.bin
+(PID.TID 0000.0001)  MDS_READ_SEC_YZ: opening global file: connect_obW.bin
+(PID.TID 0000.0001) OBCS_SET_CONNECT: @ k=   1, maxConnect=         1 , numConnect=         1
+(PID.TID 0000.0001)  listConnect:       1
+(PID.TID 0000.0001) OBCS_SET_CONNECT: @ k=   2, maxConnect=         1 , numConnect=         1
+(PID.TID 0000.0001)  listConnect:       1
+(PID.TID 0000.0001) OBCS_SET_CONNECT: @ k=   3, maxConnect=         1 , numConnect=         1
+(PID.TID 0000.0001)  listConnect:       1
+(PID.TID 0000.0001) OBCS_SET_CONNECT: @ k=   4, maxConnect=         1 , numConnect=         1
+(PID.TID 0000.0001)  listConnect:       1
+(PID.TID 0000.0001) OBCS_SET_CONNECT: @ k=   5, maxConnect=         1 , numConnect=         1
+(PID.TID 0000.0001)  listConnect:       1
+(PID.TID 0000.0001) OBCS_SET_CONNECT: @ k=   6, maxConnect=         1 , numConnect=         1
+(PID.TID 0000.0001)  listConnect:       1
+(PID.TID 0000.0001) OBCS_SET_CONNECT: @ k=   7, maxConnect=         1 , numConnect=         1
+(PID.TID 0000.0001)  listConnect:       1
+(PID.TID 0000.0001) OBCS_SET_CONNECT: @ k=   8, maxConnect=         1 , numConnect=         1
+(PID.TID 0000.0001)  listConnect:       1
+(PID.TID 0000.0001) OBCS_SET_CONNECT: @ k=   9, maxConnect=         1 , numConnect=         1
+(PID.TID 0000.0001)  listConnect:       1
+(PID.TID 0000.0001) OBCS_SET_CONNECT: @ k=  10, maxConnect=         1 , numConnect=         1
+(PID.TID 0000.0001)  listConnect:       1
+(PID.TID 0000.0001) OBCS_SET_CONNECT: @ k=  11, maxConnect=         1 , numConnect=         1
+(PID.TID 0000.0001)  listConnect:       1
+(PID.TID 0000.0001) OBCS_SET_CONNECT: @ k=  12, maxConnect=         1 , numConnect=         1
+(PID.TID 0000.0001)  listConnect:       1
+(PID.TID 0000.0001) OBCS_SET_CONNECT: @ k=  13, maxConnect=         5 , numConnect=         5
+(PID.TID 0000.0001)  listConnect:       1       2       3       4       5
+(PID.TID 0000.0001) OBCS_SET_CONNECT: @ k=  14, maxConnect=         5 , numConnect=         5
+(PID.TID 0000.0001)  listConnect:       1       2       3       4       5
+(PID.TID 0000.0001) OBCS_SET_CONNECT: @ k=  15, maxConnect=         3 , numConnect=         2
+(PID.TID 0000.0001)  listConnect:       1       3
+(PID.TID 0000.0001) PTRACERS_INIT_FIXED: updated GAD_OlMinSize=  2  0  1
+ QQ load dic parameters, initial fixed
+(PID.TID 0000.0001) 
+(PID.TID 0000.0001) // ===================================
+(PID.TID 0000.0001) //  DIC_INIT_FIXED parameters :
+(PID.TID 0000.0001) nlev = /* Number of level over which Bio act is computed */
+(PID.TID 0000.0001)                       6
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) ------------------------------------------------------------
+(PID.TID 0000.0001) DIAGNOSTICS_SET_LEVELS: done
+(PID.TID 0000.0001)  Total Nb of available Diagnostics: ndiagt=   300
+(PID.TID 0000.0001)  write list of available Diagnostics to file: available_diagnostics.log
+(PID.TID 0000.0001) SETDIAG: Allocate  1 x  1 Levels for Diagnostic #    23 ETAN
+(PID.TID 0000.0001) SETDIAG: Allocate  1 x  1 Levels for Diagnostic #    24 ETANSQ
+(PID.TID 0000.0001) SETDIAG: Allocate  1 x  1 Levels for Diagnostic #    25 DETADT2
+(PID.TID 0000.0001) SETDIAG: Allocate  1 x  1 Levels for Diagnostic #    73 PHIBOT
+(PID.TID 0000.0001) SETDIAG: Allocate  1 x  1 Levels for Diagnostic #    74 PHIBOTSQ
+(PID.TID 0000.0001) SETDIAG: Allocate  1 x  1 Levels for Diagnostic #   286 DICTFLX
+(PID.TID 0000.0001) SETDIAG: Allocate  1 x  1 Levels for Diagnostic #   287 DICOFLX
+(PID.TID 0000.0001) SETDIAG: Allocate  1 x  1 Levels for Diagnostic #   288 DICCFLX
+(PID.TID 0000.0001) SETDIAG: Allocate  1 x  1 Levels for Diagnostic #   289 DICPCO2
+(PID.TID 0000.0001) SETDIAG: Allocate  1 x  1 Levels for Diagnostic #   290 DICPHAV
+(PID.TID 0000.0001) SETDIAG: Allocate 15 x  1 Levels for Diagnostic #    46 VVELMASS
+(PID.TID 0000.0001) SETDIAG: Allocate 15 x  1 Levels for Diagnostic #    45 UVELMASS
+(PID.TID 0000.0001) SETDIAG: Allocate 15 x  1 Levels for Diagnostic #    26 THETA
+(PID.TID 0000.0001) SETDIAG: Allocate 15 x  1 Levels for Diagnostic #    27 SALT
+(PID.TID 0000.0001) SETDIAG: Allocate 15 x  1 Levels for Diagnostic #   204 GM_PsiX
+(PID.TID 0000.0001) SETDIAG: Allocate 15 x  1 Levels for Diagnostic #   205 GM_PsiY
+(PID.TID 0000.0001) SETDIAG: Diag #    48 PhiVEL   processed from Diag #    45 UVELMASS
+(PID.TID 0000.0001) - NOTE - SETDIAG:  Diagnostic  #    45 UVELMASS is already set
+(PID.TID 0000.0001) - NOTE - SETDIAG:  Vector-mate #    46 VVELMASS is already set
+(PID.TID 0000.0001) SETDIAG: Diag #    49 PsiVEL   processed from Diag #    48 PhiVEL
+(PID.TID 0000.0001) - NOTE - SETDIAG:  Diagnostic  #    48 PhiVEL   is already set
+(PID.TID 0000.0001) SETDIAG: Allocate 15 x  1 Levels for Diagnostic #    78 CONVADJ
+(PID.TID 0000.0001)   space allocated for all diagnostics:     115 levels
+(PID.TID 0000.0001)   set mate pointer for diag #    46  VVELMASS , Parms: VVr     MR , mate:    45
+(PID.TID 0000.0001)   set mate pointer for diag #    45  UVELMASS , Parms: UUr     MR , mate:    46
+(PID.TID 0000.0001)   set mate pointer for diag #   204  GM_PsiX  , Parms: UU      LR , mate:   205
+(PID.TID 0000.0001)   set mate pointer for diag #   205  GM_PsiY  , Parms: VV      LR , mate:   204
+(PID.TID 0000.0001) DIAGNOSTICS_SET_POINTERS: Set levels for Outp.Stream: dynDiag
+(PID.TID 0000.0001)  Levels:       1.   2.   3.   4.   5.   6.   7.   8.   9.  10.  11.  12.  13.  14.  15.
+(PID.TID 0000.0001) DIAGNOSTICS_SET_POINTERS: done
+(PID.TID 0000.0001) ------------------------------------------------------------
+(PID.TID 0000.0001) DIAGNOSTICS_SET_CALC: setting indices iPsi0,jPsi0 where Psi == 0 :
+(PID.TID 0000.0001) DIAGNOSTICS_SET_CALC: d2Min=       5.394531E+00, ijMin=         925.000
+(PID.TID 0000.0001)  SELECT : bi,bj=    2    2 ; i,j=   10   10 ; ijLoc=         925.000
+(PID.TID 0000.0001) ------------------------------------------------------------
+(PID.TID 0000.0001) DIAGSTATS_SET_REGIONS: define no region
+(PID.TID 0000.0001) ------------------------------------------------------------
+(PID.TID 0000.0001) SETDIAG: Allocate  1 Levels for Stats-Diag #    23 ETAN
+(PID.TID 0000.0001) SETDIAG: Allocate  1 Levels for Stats-Diag #    25 DETADT2
+(PID.TID 0000.0001) SETDIAG: Allocate 15 Levels for Stats-Diag #    26 THETA
+(PID.TID 0000.0001) SETDIAG: Allocate 15 Levels for Stats-Diag #    27 SALT
+(PID.TID 0000.0001) SETDIAG: Allocate 15 Levels for Stats-Diag #    78 CONVADJ
+(PID.TID 0000.0001) SETDIAG: Allocate 15 Levels for Stats-Diag #    30 UVEL
+(PID.TID 0000.0001) SETDIAG: Allocate 15 Levels for Stats-Diag #    31 VVEL
+(PID.TID 0000.0001) SETDIAG: Allocate 15 Levels for Stats-Diag #    32 WVEL
+(PID.TID 0000.0001) SETDIAG: Allocate 15 Levels for Stats-Diag #   204 GM_PsiX
+(PID.TID 0000.0001) SETDIAG: Allocate 15 Levels for Stats-Diag #   205 GM_PsiY
+(PID.TID 0000.0001) SETDIAG: Allocate 15 Levels for Stats-Diag #   213 TRAC01
+(PID.TID 0000.0001) SETDIAG: Allocate 15 Levels for Stats-Diag #   227 TRAC02
+(PID.TID 0000.0001) SETDIAG: Allocate 15 Levels for Stats-Diag #   241 TRAC03
+(PID.TID 0000.0001) SETDIAG: Allocate 15 Levels for Stats-Diag #   255 TRAC04
+(PID.TID 0000.0001) SETDIAG: Allocate 15 Levels for Stats-Diag #   269 TRAC05
+(PID.TID 0000.0001) SETDIAG: Allocate 15 Levels for Stats-Diag #   291 DIC3DSIT
+(PID.TID 0000.0001) SETDIAG: Allocate 15 Levels for Stats-Diag #   292 OMEGAC
+(PID.TID 0000.0001) SETDIAG: Allocate 15 Levels for Stats-Diag #   293 DIC3DPH
+(PID.TID 0000.0001) SETDIAG: Allocate 15 Levels for Stats-Diag #   294 DIC3DPCO
+(PID.TID 0000.0001) SETDIAG: Allocate 15 Levels for Stats-Diag #   295 DIC3DCO3
+(PID.TID 0000.0001)   space allocated for all stats-diags:     272 levels
+(PID.TID 0000.0001) DIAGSTATS_SET_POINTERS: done
+(PID.TID 0000.0001) ------------------------------------------------------------
+(PID.TID 0000.0001) DIAGSTATS_INI_IO: open file: dynStDiag.0000000000.txt , unit=     9
+(PID.TID 0000.0001) %MON fCori_max                    =  -6.5572427009593E-05
+(PID.TID 0000.0001) %MON fCori_min                    =  -1.4369532533658E-04
+(PID.TID 0000.0001) %MON fCori_mean                   =  -1.1250506132776E-04
+(PID.TID 0000.0001) %MON fCori_sd                     =   2.4357644817991E-05
+(PID.TID 0000.0001) %MON fCoriG_max                   =  -6.8749664608828E-05
+(PID.TID 0000.0001) %MON fCoriG_min                   =  -1.4426394581537E-04
+(PID.TID 0000.0001) %MON fCoriG_mean                  =  -1.1451888327629E-04
+(PID.TID 0000.0001) %MON fCoriG_sd                    =   2.3580812438249E-05
+(PID.TID 0000.0001) %MON fCoriCos_max                 =   1.3027003865390E-04
+(PID.TID 0000.0001) %MON fCoriCos_min                 =   2.4933504190762E-05
+(PID.TID 0000.0001) %MON fCoriCos_mean                =   8.3439440192105E-05
+(PID.TID 0000.0001) %MON fCoriCos_sd                  =   3.2514647311668E-05
+(PID.TID 0000.0001) INI_CG2D: CG2D normalisation factor =  7.8420435099722891E-05
+(PID.TID 0000.0001) 
+(PID.TID 0000.0001) // =======================================================
+(PID.TID 0000.0001) // Model configuration
+(PID.TID 0000.0001) // =======================================================
+(PID.TID 0000.0001) //
+(PID.TID 0000.0001) // "Physical" paramters ( PARM01 in namelist )
+(PID.TID 0000.0001) //
+(PID.TID 0000.0001) buoyancyRelation = /* Type of relation to get Buoyancy */
+(PID.TID 0000.0001)               'OCEANIC'
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) fluidIsAir   =  /* fluid major constituent is Air */
+(PID.TID 0000.0001)                   F
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) fluidIsWater =  /* fluid major constituent is Water */
+(PID.TID 0000.0001)                   T
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) usingPCoords =  /* use p (or p*) vertical coordinate */
+(PID.TID 0000.0001)                   F
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) usingZCoords =  /* use z (or z*) vertical coordinate */
+(PID.TID 0000.0001)                   T
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) tRef =   /* Reference temperature profile ( oC or K ) */
+(PID.TID 0000.0001)    15 @  2.000000000000000E+01              /* K =  1: 15 */
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) sRef =   /* Reference salinity profile ( g/kg ) */
+(PID.TID 0000.0001)    15 @  3.500000000000000E+01              /* K =  1: 15 */
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) rhoRef =   /* Density vertical profile from (Ref,sRef)( kg/m^3 ) */
+(PID.TID 0000.0001)                 1.024872626184147E+03,      /* K =  1 */
+(PID.TID 0000.0001)                 1.025135462285008E+03,      /* K =  2 */
+(PID.TID 0000.0001)                 1.025507198938228E+03,      /* K =  3 */
+(PID.TID 0000.0001)                 1.026030780760464E+03,      /* K =  4 */
+(PID.TID 0000.0001)                 1.026748377776259E+03,      /* K =  5 */
+(PID.TID 0000.0001)                 1.027679406285166E+03,      /* K =  6 */
+(PID.TID 0000.0001)                 1.028820735595355E+03,      /* K =  7 */
+(PID.TID 0000.0001)                 1.030168558073105E+03,      /* K =  8 */
+(PID.TID 0000.0001)                 1.031718419899614E+03,      /* K =  9 */
+(PID.TID 0000.0001)                 1.033465256541184E+03,      /* K = 10 */
+(PID.TID 0000.0001)                 1.035403432414885E+03,      /* K = 11 */
+(PID.TID 0000.0001)                 1.037526784183520E+03,      /* K = 12 */
+(PID.TID 0000.0001)                 1.039828667078104E+03,      /* K = 13 */
+(PID.TID 0000.0001)                 1.042302003623418E+03,      /* K = 14 */
+(PID.TID 0000.0001)                 1.044939334132512E+03       /* K = 15 */
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) dBdrRef = /* Vertical grad. of reference buoyancy [(m/s/r)^2] */
+(PID.TID 0000.0001)    15 @  0.000000000000000E+00              /* K =  1: 15 */
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) useStrainTensionVisc= /* Use StrainTension Form of Viscous Operator */
+(PID.TID 0000.0001)                   F
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) useVariableVisc = /* Use variable horizontal viscosity */
+(PID.TID 0000.0001)                   F
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) useHarmonicVisc = /* Use harmonic horizontal viscosity */
+(PID.TID 0000.0001)                   T
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) useBiharmonicVisc= /* Use biharmonic horiz.  viscosity */
+(PID.TID 0000.0001)                   F
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) useSmag3D = /* Use isotropic 3-D Smagorinsky viscosity */
+(PID.TID 0000.0001)                   F
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) viscAh  =   /* Lateral harmonic viscosity ( m^2/s ) */
+(PID.TID 0000.0001)                 3.000000000000000E+05
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) viscA4  =   /* Lateral biharmonic viscosity ( m^4/s ) */
+(PID.TID 0000.0001)                 0.000000000000000E+00
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) no_slip_sides =  /* Viscous BCs: No-slip sides */
+(PID.TID 0000.0001)                   T
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) sideDragFactor = /* side-drag scaling factor (non-dim) */
+(PID.TID 0000.0001)                 2.000000000000000E+00
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) viscArNr = /* vertical profile of vertical viscosity ( m^2/s )*/
+(PID.TID 0000.0001)    15 @  1.000000000000000E-03              /* K =  1: 15 */
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) no_slip_bottom =  /* Viscous BCs: No-slip bottom */
+(PID.TID 0000.0001)                   T
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) bottomVisc_pCell = /* Partial-cell in bottom Visc. BC */
+(PID.TID 0000.0001)                   F
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) bottomDragLinear = /* linear bottom-drag coefficient ( m/s ) */
+(PID.TID 0000.0001)                 0.000000000000000E+00
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) bottomDragQuadratic = /* quadratic bottom-drag coefficient (-) */
+(PID.TID 0000.0001)                 0.000000000000000E+00
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) selectBotDragQuadr = /* select quadratic bottom drag options */
+(PID.TID 0000.0001)                      -1
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) diffKhT =   /* Laplacian diffusion of heat laterally ( m^2/s ) */
+(PID.TID 0000.0001)                 0.000000000000000E+00
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) diffK4T =   /* Biharmonic diffusion of heat laterally ( m^4/s ) */
+(PID.TID 0000.0001)                 0.000000000000000E+00
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) diffKhS =   /* Laplacian diffusion of salt laterally ( m^2/s ) */
+(PID.TID 0000.0001)                 0.000000000000000E+00
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) diffK4S =   /* Biharmonic diffusion of salt laterally ( m^4/s ) */
+(PID.TID 0000.0001)                 0.000000000000000E+00
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) diffKrNrT = /* vertical profile of vertical diffusion of Temp ( m^2/s )*/
+(PID.TID 0000.0001)    15 @  0.000000000000000E+00              /* K =  1: 15 */
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) diffKrNrS = /* vertical profile of vertical diffusion of Salt ( m^2/s )*/
+(PID.TID 0000.0001)    15 @  0.000000000000000E+00              /* K =  1: 15 */
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) diffKrBL79surf = /* Surface diffusion for Bryan and Lewis 79 ( m^2/s ) */
+(PID.TID 0000.0001)                 3.000000000000000E-05
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) diffKrBL79deep = /* Deep diffusion for Bryan and Lewis 1979 ( m^2/s ) */
+(PID.TID 0000.0001)                 1.300000000000000E-04
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) diffKrBL79scl = /* Depth scale for Bryan and Lewis 1979 ( m ) */
+(PID.TID 0000.0001)                 1.500000000000000E+02
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) diffKrBL79Ho = /* Turning depth for Bryan and Lewis 1979 ( m ) */
+(PID.TID 0000.0001)                -2.000000000000000E+03
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) ivdc_kappa = /* Implicit Vertical Diffusivity for Convection ( m^2/s) */
+(PID.TID 0000.0001)                 1.000000000000000E+01
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) hMixCriteria=  /* Criteria for mixed-layer diagnostic */
+(PID.TID 0000.0001)                -8.000000000000000E-01
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) dRhoSmall =  /* Parameter for mixed-layer diagnostic */
+(PID.TID 0000.0001)                 1.000000000000000E-06
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) hMixSmooth=  /* Smoothing parameter for mixed-layer diagnostic */
+(PID.TID 0000.0001)                 0.000000000000000E+00
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) eosType =  /* Type of Equation of State */
+(PID.TID 0000.0001)               'JMD95Z'
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) eosRefP0 = /* Reference atmospheric pressure for EOS ( Pa ) */
+(PID.TID 0000.0001)                 1.013250000000000E+05
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) selectP_inEOS_Zc = /* select pressure to use in EOS (0,1,2,3) */
+(PID.TID 0000.0001)                       0
+(PID.TID 0000.0001)     0= -g*rhoConst*z ; 1= pRef (from tRef,sRef); 2= Hyd P ; 3= Hyd+NH P
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) surf_pRef = /* Surface reference pressure ( Pa ) */
+(PID.TID 0000.0001)                 1.013250000000000E+05
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) HeatCapacity_Cp =  /* Specific heat capacity ( J/kg/K ) */
+(PID.TID 0000.0001)                 3.994000000000000E+03
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) celsius2K = /* 0 degree Celsius converted to Kelvin ( K ) */
+(PID.TID 0000.0001)                 2.731500000000000E+02
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) rhoConst  = /* Reference density (Boussinesq)  ( kg/m^3 ) */
+(PID.TID 0000.0001)                 1.035000000000000E+03
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) rhoFacC = /* normalized Reference density @ cell-Center (-) */
+(PID.TID 0000.0001)    15 @  1.000000000000000E+00              /* K =  1: 15 */
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) rhoFacF = /* normalized Reference density @ W-Interface (-) */
+(PID.TID 0000.0001)    16 @  1.000000000000000E+00              /* K =  1: 16 */
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) rhoConstFresh = /* Fresh-water reference density ( kg/m^3 ) */
+(PID.TID 0000.0001)                 1.000000000000000E+03
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) gravity =   /* Gravitational acceleration ( m/s^2 ) */
+(PID.TID 0000.0001)                 9.810000000000000E+00
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) gBaro =   /* Barotropic gravity ( m/s^2 ) */
+(PID.TID 0000.0001)                 9.810000000000000E+00
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) gravFacC = /* gravity factor (vs surf.) @ cell-Center (-) */
+(PID.TID 0000.0001)    15 @  1.000000000000000E+00              /* K =  1: 15 */
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) gravFacF = /* gravity factor (vs surf.) @ W-Interface (-) */
+(PID.TID 0000.0001)    16 @  1.000000000000000E+00              /* K =  1: 16 */
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) rotationPeriod =   /* Rotation Period ( s ) */
+(PID.TID 0000.0001)                 8.616400000000000E+04
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) omega =   /* Angular velocity ( rad/s ) */
+(PID.TID 0000.0001)                 7.292123516990375E-05
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) f0 =   /* Reference coriolis parameter ( 1/s ) */
+(PID.TID 0000.0001)                 1.000000000000000E-04
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) beta =   /* Beta ( 1/(m.s) ) */
+(PID.TID 0000.0001)                 9.999999999999999E-12
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) fPrime =   /* Second coriolis parameter ( 1/s ) */
+(PID.TID 0000.0001)                 0.000000000000000E+00
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) rigidLid =   /* Rigid lid on/off flag */
+(PID.TID 0000.0001)                   F
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) implicitFreeSurface =   /* Implicit free surface on/off flag */
+(PID.TID 0000.0001)                   T
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) freeSurfFac =   /* Implicit free surface factor */
+(PID.TID 0000.0001)                 1.000000000000000E+00
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) implicSurfPress =  /* Surface Pressure implicit factor (0-1) */
+(PID.TID 0000.0001)                 1.000000000000000E+00
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) implicDiv2DFlow =  /* Barot. Flow Div. implicit factor (0-1) */
+(PID.TID 0000.0001)                 1.000000000000000E+00
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) uniformLin_PhiSurf = /* use uniform Bo_surf on/off flag */
+(PID.TID 0000.0001)                   T
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) uniformFreeSurfLev = /* free-surface level-index is uniform */
+(PID.TID 0000.0001)                   T
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) sIceLoadFac =  /* scale factor for sIceLoad (0-1) */
+(PID.TID 0000.0001)                 1.000000000000000E+00
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) hFacMin =   /* minimum partial cell factor (hFac) */
+(PID.TID 0000.0001)                 1.000000000000000E-01
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) hFacMinDr = /* minimum partial cell thickness ( m) */
+(PID.TID 0000.0001)                 5.000000000000000E+01
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) exactConserv =  /* Exact Volume Conservation on/off flag */
+(PID.TID 0000.0001)                   T
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) linFSConserveTr = /* Tracer correction for Lin Free Surface on/off flag */
+(PID.TID 0000.0001)                   F
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) nonlinFreeSurf = /* Non-linear Free Surf. options (-1,0,1,2,3)*/
+(PID.TID 0000.0001)                       0
+(PID.TID 0000.0001)      -1,0= Off ; 1,2,3= On, 2=+rescale gU,gV, 3=+update cg2d solv.
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) hFacInf =   /* lower threshold for hFac (nonlinFreeSurf only)*/
+(PID.TID 0000.0001)                 2.000000000000000E-01
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) hFacSup =   /* upper threshold for hFac (nonlinFreeSurf only)*/
+(PID.TID 0000.0001)                 2.000000000000000E+00
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) select_rStar = /* r* Vertical coord. options (=0 r coord.; >0 uses r*)*/
+(PID.TID 0000.0001)                       0
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) useRealFreshWaterFlux = /* Real Fresh Water Flux on/off flag*/
+(PID.TID 0000.0001)                   F
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) temp_EvPrRn = /* Temp. of Evap/Prec/R (UNSET=use local T)(oC)*/
+(PID.TID 0000.0001)                 1.234567000000000E+05
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) salt_EvPrRn = /* Salin. of Evap/Prec/R (UNSET=use local S)(g/kg)*/
+(PID.TID 0000.0001)                 0.000000000000000E+00
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) selectAddFluid = /* option for mass source/sink of fluid (=0: off) */
+(PID.TID 0000.0001)                       0
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) temp_addMass = /* Temp. of addMass array (UNSET=use local T)(oC)*/
+(PID.TID 0000.0001)                 1.234567000000000E+05
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) salt_addMass = /* Salin. of addMass array (UNSET=use local S)(g/kg)*/
+(PID.TID 0000.0001)                 0.000000000000000E+00
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) convertFW2Salt = /* convert F.W. Flux to Salt Flux (-1=use local S)(g/kg)*/
+(PID.TID 0000.0001)                 3.500000000000000E+01
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) use3Dsolver = /* use 3-D pressure solver on/off flag */
+(PID.TID 0000.0001)                   F
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) nonHydrostatic =  /* Non-Hydrostatic on/off flag */
+(PID.TID 0000.0001)                   F
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) nh_Am2 = /* Non-Hydrostatic terms scaling factor */
+(PID.TID 0000.0001)                 1.000000000000000E+00
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) implicitNHPress = /* Non-Hyd Pressure implicit factor (0-1)*/
+(PID.TID 0000.0001)                 1.000000000000000E+00
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) selectNHfreeSurf = /* Non-Hyd (free-)Surface option */
+(PID.TID 0000.0001)                       0
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) quasiHydrostatic = /* Quasi-Hydrostatic on/off flag */
+(PID.TID 0000.0001)                   F
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) calc_wVelocity = /* vertical velocity calculation on/off flag */
+(PID.TID 0000.0001)                   T
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) momStepping =  /* Momentum equation on/off flag */
+(PID.TID 0000.0001)                   T
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) vectorInvariantMomentum= /* Vector-Invariant Momentum on/off */
+(PID.TID 0000.0001)                   F
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) momAdvection =  /* Momentum advection on/off flag */
+(PID.TID 0000.0001)                   T
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) momViscosity =  /* Momentum viscosity on/off flag */
+(PID.TID 0000.0001)                   T
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) momImplVertAdv= /* Momentum implicit vert. advection on/off*/
+(PID.TID 0000.0001)                   F
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) implicitViscosity = /* Implicit viscosity on/off flag */
+(PID.TID 0000.0001)                   F
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) selectImplicitDrag= /* Implicit bot Drag options (0,1,2)*/
+(PID.TID 0000.0001)                       0
+(PID.TID 0000.0001)     0= Expl. ; 1= Impl. on provis. Vel ; 2= Fully Impl (with surf.P)
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) metricTerms =  /* metric-Terms on/off flag */
+(PID.TID 0000.0001)                   T
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) useNHMTerms = /* Non-Hydrostatic Metric-Terms on/off */
+(PID.TID 0000.0001)                   F
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) selectCoriMap = /* Coriolis Map options (0,1,2,3)*/
+(PID.TID 0000.0001)                       2
+(PID.TID 0000.0001)     0= f-Plane ; 1= Beta-Plane ; 2= Spherical ; 3= read from file
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) use3dCoriolis = /* 3-D Coriolis on/off flag */
+(PID.TID 0000.0001)                   F
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) useCoriolis =  /* Coriolis on/off flag */
+(PID.TID 0000.0001)                   T
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) useCDscheme =  /* CD scheme on/off flag */
+(PID.TID 0000.0001)                   F
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) selectCoriScheme= /* Scheme selector for Coriolis-Term */
+(PID.TID 0000.0001)                       0
+(PID.TID 0000.0001)    = 0 : original discretization (simple averaging, no hFac)
+(PID.TID 0000.0001)    = 1 : Wet-point averaging (Jamar & Ozer 1986)
+(PID.TID 0000.0001)    = 2 : energy conserving scheme (no hFac weight)
+(PID.TID 0000.0001)    = 3 : energy conserving scheme using Wet-point averaging
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) momForcing =  /* Momentum forcing on/off flag */
+(PID.TID 0000.0001)                   T
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) momTidalForcing = /* Momentum Tidal forcing on/off flag */
+(PID.TID 0000.0001)                   T
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) momPressureForcing =  /* Momentum pressure term on/off flag */
+(PID.TID 0000.0001)                   T
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) implicitIntGravWave= /* Implicit Internal Gravity Wave flag */
+(PID.TID 0000.0001)                   F
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) staggerTimeStep =    /* Stagger time stepping on/off flag */
+(PID.TID 0000.0001)                   F
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) doResetHFactors = /* reset thickness factors @ each time-step */
+(PID.TID 0000.0001)                   F
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) multiDimAdvection =  /* enable/disable Multi-Dim Advection */
+(PID.TID 0000.0001)                   T
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) useMultiDimAdvec =   /* Multi-Dim Advection is/is-not used */
+(PID.TID 0000.0001)                   T
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) implicitDiffusion = /* Implicit Diffusion on/off flag */
+(PID.TID 0000.0001)                   T
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) tempStepping =  /* Temperature equation on/off flag */
+(PID.TID 0000.0001)                   T
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) tempAdvection = /* Temperature advection on/off flag */
+(PID.TID 0000.0001)                   T
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) tempImplVertAdv = /* Temp. implicit vert. advection on/off */
+(PID.TID 0000.0001)                   F
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) tempForcing  =  /* Temperature forcing on/off flag */
+(PID.TID 0000.0001)                   T
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) doThetaClimRelax = /* apply SST relaxation on/off flag */
+(PID.TID 0000.0001)                   T
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) tempIsActiveTr = /* Temp. is a dynamically Active Tracer */
+(PID.TID 0000.0001)                   T
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) saltStepping =  /* Salinity equation on/off flag */
+(PID.TID 0000.0001)                   T
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) saltAdvection = /* Salinity advection on/off flag */
+(PID.TID 0000.0001)                   T
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) saltImplVertAdv = /* Sali. implicit vert. advection on/off */
+(PID.TID 0000.0001)                   F
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) saltForcing  =  /* Salinity forcing on/off flag */
+(PID.TID 0000.0001)                   T
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) doSaltClimRelax = /* apply SSS relaxation on/off flag */
+(PID.TID 0000.0001)                   T
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) saltIsActiveTr = /* Salt  is a dynamically Active Tracer */
+(PID.TID 0000.0001)                   T
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001)  readBinaryPrec = /* Precision used for reading binary files */
+(PID.TID 0000.0001)                      32
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) writeBinaryPrec = /* Precision used for writing binary files */
+(PID.TID 0000.0001)                      32
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001)  rwSuffixType =   /* select format of mds file suffix */
+(PID.TID 0000.0001)                       0
+(PID.TID 0000.0001)    = 0 : myIter (I10.10) ;   = 1 : 100*myTime (100th sec) ;
+(PID.TID 0000.0001)    = 2 : myTime (seconds);   = 3 : myTime/360 (10th of hr);
+(PID.TID 0000.0001)    = 4 : myTime/3600 (hours)
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001)  globalFiles = /* write "global" (=not per tile) files */
+(PID.TID 0000.0001)                   F
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001)  useSingleCpuIO = /* only master MPI process does I/O */
+(PID.TID 0000.0001)                   F
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001)  useSingleCpuInput = /* only master process reads input */
+(PID.TID 0000.0001)                   F
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) /* debLev[*]  : level of debug & auxiliary message printing */
+(PID.TID 0000.0001) debLevZero =  0 ; /* level of disabled aux. msg printing */
+(PID.TID 0000.0001)    debLevA =  1 ; /* level of minimum  aux. msg printing */
+(PID.TID 0000.0001)    debLevB =  2 ; /* level of low aux. print (report read-file opening)*/
+(PID.TID 0000.0001)    debLevC =  3 ; /* level of moderate debug prt (most pkgs debug msg) */
+(PID.TID 0000.0001)    debLevD =  4 ; /* level of enhanced debug prt (add DEBUG_STATS prt) */
+(PID.TID 0000.0001)    debLevE =  5 ; /* level of extensive debug printing */
+(PID.TID 0000.0001) debugLevel =  /* select debug printing level */
+(PID.TID 0000.0001)                       2
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001)  plotLevel =  /* select PLOT_FIELD printing level */
+(PID.TID 0000.0001)                       2
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) //
+(PID.TID 0000.0001) // Elliptic solver(s) paramters ( PARM02 in namelist )
+(PID.TID 0000.0001) //
+(PID.TID 0000.0001) cg2dMaxIters =   /* Upper limit on 2d con. grad iterations  */
+(PID.TID 0000.0001)                    1000
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) cg2dMinItersNSA =   /* Minimum number of iterations of 2d con. grad solver  */
+(PID.TID 0000.0001)                       0
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) cg2dUseMinResSol= /* use cg2d last-iter(=0) / min-resid.(=1) solution */
+(PID.TID 0000.0001)                       0
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) cg2dTargetResidual =   /* 2d con. grad target residual  */
+(PID.TID 0000.0001)                 1.000000000000000E-13
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) cg2dTargetResWunit =   /* CG2d target residual [W units] */
+(PID.TID 0000.0001)                -1.000000000000000E+00
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) cg2dPreCondFreq =   /* Freq. for updating cg2d preconditioner */
+(PID.TID 0000.0001)                       1
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) useSRCGSolver =  /* use single reduction CG solver(s) */
+(PID.TID 0000.0001)                   F
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) useNSACGSolver =  /* use not-self-adjoint CG solver */
+(PID.TID 0000.0001)                   F
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) printResidualFreq = /* Freq. for printing CG residual */
+(PID.TID 0000.0001)                       0
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) //
+(PID.TID 0000.0001) // Time stepping paramters ( PARM03 in namelist )
+(PID.TID 0000.0001) //
+(PID.TID 0000.0001) deltaTMom =   /* Momentum equation timestep ( s ) */
+(PID.TID 0000.0001)                 9.000000000000000E+02
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) deltaTFreeSurf = /* FreeSurface equation timestep ( s ) */
+(PID.TID 0000.0001)                 4.320000000000000E+04
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) dTtracerLev =  /* Tracer equation timestep ( s ) */
+(PID.TID 0000.0001)    15 @  4.320000000000000E+04              /* K =  1: 15 */
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) deltaTClock  =   /* Model clock timestep ( s ) */
+(PID.TID 0000.0001)                 4.320000000000000E+04
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) cAdjFreq =   /* Convective adjustment interval ( s ) */
+(PID.TID 0000.0001)                 0.000000000000000E+00
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) momForcingOutAB = /* =1: take Momentum Forcing out of Adams-Bash. stepping */
+(PID.TID 0000.0001)                       0
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) tracForcingOutAB = /* =1: take T,S,pTr Forcing out of Adams-Bash. stepping */
+(PID.TID 0000.0001)                       0
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) momDissip_In_AB = /* put Dissipation Tendency in Adams-Bash. stepping */
+(PID.TID 0000.0001)                   T
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) doAB_onGtGs = /* apply AB on Tendencies (rather than on T,S)*/
+(PID.TID 0000.0001)                   T
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) abEps =   /* Adams-Bashforth-2 stabilizing weight */
+(PID.TID 0000.0001)                 1.000000000000000E-01
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) applyExchUV_early = /* Apply EXCH to U,V earlier in time-step */
+(PID.TID 0000.0001)                   F
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) pickupStrictlyMatch= /* stop if pickup do not strictly match */
+(PID.TID 0000.0001)                   T
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) nIter0   =   /* Run starting timestep number */
+(PID.TID 0000.0001)                       0
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) nTimeSteps = /* Number of timesteps */
+(PID.TID 0000.0001)                      10
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) nEndIter =   /* Run ending timestep number */
+(PID.TID 0000.0001)                      10
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) baseTime =   /* Model base time ( s ) */
+(PID.TID 0000.0001)                 0.000000000000000E+00
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) startTime =  /* Run start time ( s ) */
+(PID.TID 0000.0001)                 0.000000000000000E+00
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) endTime  =   /* Integration ending time ( s ) */
+(PID.TID 0000.0001)                 4.320000000000000E+05
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) pChkPtFreq = /* Permanent restart/pickup file interval ( s ) */
+(PID.TID 0000.0001)                 3.110400000000000E+08
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) chkPtFreq  = /* Rolling restart/pickup file interval ( s ) */
+(PID.TID 0000.0001)                 3.110400000000000E+07
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) pickup_write_mdsio =   /* Model IO flag. */
+(PID.TID 0000.0001)                   T
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) pickup_read_mdsio =   /* Model IO flag. */
+(PID.TID 0000.0001)                   T
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) writePickupAtEnd =   /* Model IO flag. */
+(PID.TID 0000.0001)                   T
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) dumpFreq =   /* Model state write out interval ( s ). */
+(PID.TID 0000.0001)                 2.592000000000000E+06
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) dumpInitAndLast= /* write out Initial & Last iter. model state */
+(PID.TID 0000.0001)                   T
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) snapshot_mdsio =   /* Model IO flag. */
+(PID.TID 0000.0001)                   T
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) monitorFreq =   /* Monitor output interval ( s ). */
+(PID.TID 0000.0001)                 1.000000000000000E+00
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) monitorSelect = /* select group of variables to monitor */
+(PID.TID 0000.0001)                       3
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) monitor_stdio =   /* Model IO flag. */
+(PID.TID 0000.0001)                   T
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) externForcingPeriod =   /* forcing period (s) */
+(PID.TID 0000.0001)                 2.592000000000000E+06
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) externForcingCycle =   /* period of the cyle (s). */
+(PID.TID 0000.0001)                 3.110400000000000E+07
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) tauThetaClimRelax =   /* relaxation time scale (s) */
+(PID.TID 0000.0001)                 5.184000000000000E+06
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) tauSaltClimRelax =   /* relaxation time scale (s) */
+(PID.TID 0000.0001)                 7.776000000000000E+06
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) latBandClimRelax =   /* max. Lat. where relaxation */
+(PID.TID 0000.0001)                 1.800000000000000E+02
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) //
+(PID.TID 0000.0001) // Gridding paramters ( PARM04 in namelist )
+(PID.TID 0000.0001) //
+(PID.TID 0000.0001) usingCartesianGrid = /* Cartesian coordinates flag ( True/False ) */
+(PID.TID 0000.0001)                   F
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) usingCylindricalGrid = /* Cylindrical coordinates flag ( True/False ) */
+(PID.TID 0000.0001)                   F
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) usingSphericalPolarGrid = /* Spherical coordinates flag ( True/False ) */
+(PID.TID 0000.0001)                   T
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) usingCurvilinearGrid = /* Curvilinear coordinates flag ( True/False ) */
+(PID.TID 0000.0001)                   F
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) useMin4hFacEdges = /* set hFacW,S as minimum of adjacent hFacC factor */
+(PID.TID 0000.0001)                   F
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) interViscAr_pCell = /* account for partial-cell in interior vert. viscosity */
+(PID.TID 0000.0001)                   F
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) interDiffKr_pCell = /* account for partial-cell in interior vert. diffusion */
+(PID.TID 0000.0001)                   F
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) pCellMix_select = /* option to enhance mixing near surface & bottom */
+(PID.TID 0000.0001)                       0
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) selectSigmaCoord = /* Hybrid-Sigma Vert. Coordinate option */
+(PID.TID 0000.0001)                       0
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) rSigmaBnd = /* r/sigma transition ( units of r ==  m ) */
+(PID.TID 0000.0001)                 1.234567000000000E+05
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) rkSign =   /* index orientation relative to vertical coordinate */
+(PID.TID 0000.0001)                -1.000000000000000E+00
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) gravitySign = /* gravity orientation relative to vertical coordinate */
+(PID.TID 0000.0001)                -1.000000000000000E+00
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) seaLev_Z =  /* reference height of sea-level [m] */
+(PID.TID 0000.0001)                 0.000000000000000E+00
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) top_Pres =  /* reference pressure at the top [Pa] */
+(PID.TID 0000.0001)                 0.000000000000000E+00
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) mass2rUnit = /* convert mass per unit area [kg/m2] to r-units [m] */
+(PID.TID 0000.0001)                 9.661835748792270E-04
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) rUnit2mass = /* convert r-units [m] to mass per unit area [kg/m2] */
+(PID.TID 0000.0001)                 1.035000000000000E+03
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) drC =   /* C spacing ( units of r ) */
+(PID.TID 0000.0001)                 2.500000000000000E+01,      /* K =  1 */
+(PID.TID 0000.0001)                 6.000000000000000E+01,      /* K =  2 */
+(PID.TID 0000.0001)                 8.500000000000000E+01,      /* K =  3 */
+(PID.TID 0000.0001)                 1.200000000000000E+02,      /* K =  4 */
+(PID.TID 0000.0001)                 1.650000000000000E+02,      /* K =  5 */
+(PID.TID 0000.0001)                 2.150000000000000E+02,      /* K =  6 */
+(PID.TID 0000.0001)                 2.650000000000000E+02,      /* K =  7 */
+(PID.TID 0000.0001)                 3.150000000000000E+02,      /* K =  8 */
+(PID.TID 0000.0001)                 3.650000000000000E+02,      /* K =  9 */
+(PID.TID 0000.0001)                 4.150000000000000E+02,      /* K = 10 */
+(PID.TID 0000.0001)                 4.650000000000000E+02,      /* K = 11 */
+(PID.TID 0000.0001)                 5.150000000000000E+02,      /* K = 12 */
+(PID.TID 0000.0001)                 5.650000000000000E+02,      /* K = 13 */
+(PID.TID 0000.0001)                 6.150000000000000E+02,      /* K = 14 */
+(PID.TID 0000.0001)                 6.650000000000000E+02,      /* K = 15 */
+(PID.TID 0000.0001)                 3.450000000000000E+02       /* K = 16 */
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) drF =   /* W spacing ( units of r ) */
+(PID.TID 0000.0001)                 5.000000000000000E+01,      /* K =  1 */
+(PID.TID 0000.0001)                 7.000000000000000E+01,      /* K =  2 */
+(PID.TID 0000.0001)                 1.000000000000000E+02,      /* K =  3 */
+(PID.TID 0000.0001)                 1.400000000000000E+02,      /* K =  4 */
+(PID.TID 0000.0001)                 1.900000000000000E+02,      /* K =  5 */
+(PID.TID 0000.0001)                 2.400000000000000E+02,      /* K =  6 */
+(PID.TID 0000.0001)                 2.900000000000000E+02,      /* K =  7 */
+(PID.TID 0000.0001)                 3.400000000000000E+02,      /* K =  8 */
+(PID.TID 0000.0001)                 3.900000000000000E+02,      /* K =  9 */
+(PID.TID 0000.0001)                 4.400000000000000E+02,      /* K = 10 */
+(PID.TID 0000.0001)                 4.900000000000000E+02,      /* K = 11 */
+(PID.TID 0000.0001)                 5.400000000000000E+02,      /* K = 12 */
+(PID.TID 0000.0001)                 5.900000000000000E+02,      /* K = 13 */
+(PID.TID 0000.0001)                 6.400000000000000E+02,      /* K = 14 */
+(PID.TID 0000.0001)                 6.900000000000000E+02       /* K = 15 */
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) delX = /* U spacing ( m - cartesian, degrees - spherical ) */
+(PID.TID 0000.0001)    42 @  2.812500000000000E+00              /* I =  1: 42 */
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) delY = /* V spacing ( m - cartesian, degrees - spherical ) */
+(PID.TID 0000.0001)    20 @  2.812500000000000E+00              /* J =  1: 20 */
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) xgOrigin = /* X-axis origin of West  edge (cartesian: m, lat-lon: deg) */
+(PID.TID 0000.0001)                 2.362500000000000E+02
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) ygOrigin = /* Y-axis origin of South edge (cartesian: m, lat-lon: deg) */
+(PID.TID 0000.0001)                -8.156250000000000E+01
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) rSphere =  /* Radius ( ignored - cartesian, m - spherical ) */
+(PID.TID 0000.0001)                 6.370000000000000E+06
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) deepAtmosphere = /* Deep/Shallow Atmosphere flag (True/False) */
+(PID.TID 0000.0001)                   F
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) xC =  /* xC(:,1,:,1) : P-point X coord ( deg. or m if cartesian) */
+(PID.TID 0000.0001)                 2.376562500000000E+02,      /* I =  1 */
+(PID.TID 0000.0001)                 2.404687500000000E+02,      /* I =  2 */
+(PID.TID 0000.0001)                 2.432812500000000E+02,      /* I =  3 */
+(PID.TID 0000.0001)                 2.460937500000000E+02,      /* I =  4 */
+(PID.TID 0000.0001)                 2.489062500000000E+02,      /* I =  5 */
+(PID.TID 0000.0001)                 2.517187500000000E+02,      /* I =  6 */
+(PID.TID 0000.0001)                 2.545312500000000E+02,      /* I =  7 */
+(PID.TID 0000.0001)                 2.573437500000000E+02,      /* I =  8 */
+(PID.TID 0000.0001)                 2.601562500000000E+02,      /* I =  9 */
+(PID.TID 0000.0001)                 2.629687500000000E+02,      /* I = 10 */
+(PID.TID 0000.0001)                 2.657812500000000E+02,      /* I = 11 */
+(PID.TID 0000.0001)                 2.685937500000000E+02,      /* I = 12 */
+(PID.TID 0000.0001)                 2.714062500000000E+02,      /* I = 13 */
+(PID.TID 0000.0001)                 2.742187500000000E+02,      /* I = 14 */
+(PID.TID 0000.0001)                 2.770312500000000E+02,      /* I = 15 */
+(PID.TID 0000.0001)                 2.798437500000000E+02,      /* I = 16 */
+(PID.TID 0000.0001)                 2.826562500000000E+02,      /* I = 17 */
+(PID.TID 0000.0001)                 2.854687500000000E+02,      /* I = 18 */
+(PID.TID 0000.0001)                 2.882812500000000E+02,      /* I = 19 */
+(PID.TID 0000.0001)                 2.910937500000000E+02,      /* I = 20 */
+(PID.TID 0000.0001)                 2.939062500000000E+02,      /* I = 21 */
+(PID.TID 0000.0001)                 2.967187500000000E+02,      /* I = 22 */
+(PID.TID 0000.0001)                 2.995312500000000E+02,      /* I = 23 */
+(PID.TID 0000.0001)                 3.023437500000000E+02,      /* I = 24 */
+(PID.TID 0000.0001)                 3.051562500000000E+02,      /* I = 25 */
+(PID.TID 0000.0001)                 3.079687500000000E+02,      /* I = 26 */
+(PID.TID 0000.0001)                 3.107812500000000E+02,      /* I = 27 */
+(PID.TID 0000.0001)                 3.135937500000000E+02,      /* I = 28 */
+(PID.TID 0000.0001)                 3.164062500000000E+02,      /* I = 29 */
+(PID.TID 0000.0001)                 3.192187500000000E+02,      /* I = 30 */
+(PID.TID 0000.0001)                 3.220312500000000E+02,      /* I = 31 */
+(PID.TID 0000.0001)                 3.248437500000000E+02,      /* I = 32 */
+(PID.TID 0000.0001)                 3.276562500000000E+02,      /* I = 33 */
+(PID.TID 0000.0001)                 3.304687500000000E+02,      /* I = 34 */
+(PID.TID 0000.0001)                 3.332812500000000E+02,      /* I = 35 */
+(PID.TID 0000.0001)                 3.360937500000000E+02,      /* I = 36 */
+(PID.TID 0000.0001)                 3.389062500000000E+02,      /* I = 37 */
+(PID.TID 0000.0001)                 3.417187500000000E+02,      /* I = 38 */
+(PID.TID 0000.0001)                 3.445312500000000E+02,      /* I = 39 */
+(PID.TID 0000.0001)                 3.473437500000000E+02,      /* I = 40 */
+(PID.TID 0000.0001)                 3.501562500000000E+02,      /* I = 41 */
+(PID.TID 0000.0001)                 3.529687500000000E+02       /* I = 42 */
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) yC =  /* yC(1,:,1,:) : P-point Y coord ( deg. or m if cartesian) */
+(PID.TID 0000.0001)                -8.015625000000000E+01,      /* J =  1 */
+(PID.TID 0000.0001)                -7.734375000000000E+01,      /* J =  2 */
+(PID.TID 0000.0001)                -7.453125000000000E+01,      /* J =  3 */
+(PID.TID 0000.0001)                -7.171875000000000E+01,      /* J =  4 */
+(PID.TID 0000.0001)                -6.890625000000000E+01,      /* J =  5 */
+(PID.TID 0000.0001)                -6.609375000000000E+01,      /* J =  6 */
+(PID.TID 0000.0001)                -6.328125000000000E+01,      /* J =  7 */
+(PID.TID 0000.0001)                -6.046875000000000E+01,      /* J =  8 */
+(PID.TID 0000.0001)                -5.765625000000000E+01,      /* J =  9 */
+(PID.TID 0000.0001)                -5.484375000000000E+01,      /* J = 10 */
+(PID.TID 0000.0001)                -5.203125000000000E+01,      /* J = 11 */
+(PID.TID 0000.0001)                -4.921875000000000E+01,      /* J = 12 */
+(PID.TID 0000.0001)                -4.640625000000000E+01,      /* J = 13 */
+(PID.TID 0000.0001)                -4.359375000000000E+01,      /* J = 14 */
+(PID.TID 0000.0001)                -4.078125000000000E+01,      /* J = 15 */
+(PID.TID 0000.0001)                -3.796875000000000E+01,      /* J = 16 */
+(PID.TID 0000.0001)                -3.515625000000000E+01,      /* J = 17 */
+(PID.TID 0000.0001)                -3.234375000000000E+01,      /* J = 18 */
+(PID.TID 0000.0001)                -2.953125000000000E+01,      /* J = 19 */
+(PID.TID 0000.0001)                -2.671875000000000E+01       /* J = 20 */
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) rcoord = /* P-point R coordinate (  units of r ) */
+(PID.TID 0000.0001)                -2.500000000000000E+01,      /* K =  1 */
+(PID.TID 0000.0001)                -8.500000000000000E+01,      /* K =  2 */
+(PID.TID 0000.0001)                -1.700000000000000E+02,      /* K =  3 */
+(PID.TID 0000.0001)                -2.900000000000000E+02,      /* K =  4 */
+(PID.TID 0000.0001)                -4.550000000000000E+02,      /* K =  5 */
+(PID.TID 0000.0001)                -6.700000000000000E+02,      /* K =  6 */
+(PID.TID 0000.0001)                -9.350000000000000E+02,      /* K =  7 */
+(PID.TID 0000.0001)                -1.250000000000000E+03,      /* K =  8 */
+(PID.TID 0000.0001)                -1.615000000000000E+03,      /* K =  9 */
+(PID.TID 0000.0001)                -2.030000000000000E+03,      /* K = 10 */
+(PID.TID 0000.0001)                -2.495000000000000E+03,      /* K = 11 */
+(PID.TID 0000.0001)                -3.010000000000000E+03,      /* K = 12 */
+(PID.TID 0000.0001)                -3.575000000000000E+03,      /* K = 13 */
+(PID.TID 0000.0001)                -4.190000000000000E+03,      /* K = 14 */
+(PID.TID 0000.0001)                -4.855000000000000E+03       /* K = 15 */
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) rF =   /* W-Interf. R coordinate (  units of r ) */
+(PID.TID 0000.0001)                 0.000000000000000E+00,      /* K =  1 */
+(PID.TID 0000.0001)                -5.000000000000000E+01,      /* K =  2 */
+(PID.TID 0000.0001)                -1.200000000000000E+02,      /* K =  3 */
+(PID.TID 0000.0001)                -2.200000000000000E+02,      /* K =  4 */
+(PID.TID 0000.0001)                -3.600000000000000E+02,      /* K =  5 */
+(PID.TID 0000.0001)                -5.500000000000000E+02,      /* K =  6 */
+(PID.TID 0000.0001)                -7.900000000000000E+02,      /* K =  7 */
+(PID.TID 0000.0001)                -1.080000000000000E+03,      /* K =  8 */
+(PID.TID 0000.0001)                -1.420000000000000E+03,      /* K =  9 */
+(PID.TID 0000.0001)                -1.810000000000000E+03,      /* K = 10 */
+(PID.TID 0000.0001)                -2.250000000000000E+03,      /* K = 11 */
+(PID.TID 0000.0001)                -2.740000000000000E+03,      /* K = 12 */
+(PID.TID 0000.0001)                -3.280000000000000E+03,      /* K = 13 */
+(PID.TID 0000.0001)                -3.870000000000000E+03,      /* K = 14 */
+(PID.TID 0000.0001)                -4.510000000000000E+03,      /* K = 15 */
+(PID.TID 0000.0001)                -5.200000000000000E+03       /* K = 16 */
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) deepFacC = /* deep-model grid factor @ cell-Center (-) */
+(PID.TID 0000.0001)    15 @  1.000000000000000E+00              /* K =  1: 15 */
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) deepFacF = /* deep-model grid factor @ W-Interface (-) */
+(PID.TID 0000.0001)    16 @  1.000000000000000E+00              /* K =  1: 16 */
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) rotateGrid = /* use rotated grid ( True/False ) */
+(PID.TID 0000.0001)                   F
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) phiEuler = /* Euler angle, rotation about original z-coordinate [rad] */
+(PID.TID 0000.0001)                 0.000000000000000E+00
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) thetaEuler = /* Euler angle, rotation about new x-coordinate [rad] */
+(PID.TID 0000.0001)                 0.000000000000000E+00
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) psiEuler = /* Euler angle, rotation about new z-coordinate [rad] */
+(PID.TID 0000.0001)                 0.000000000000000E+00
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) dxF =  /* dxF(:,1,:,1) ( units: m ) */
+(PID.TID 0000.0001)    42 @  5.345749921461356E+04              /* I =  1: 42 */
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) dxF =  /* dxF(1,:,1,:) ( units: m ) */
+(PID.TID 0000.0001)                 5.345749921461356E+04,      /* J =  1 */
+(PID.TID 0000.0001)                 6.851003143764105E+04,      /* J =  2 */
+(PID.TID 0000.0001)                 8.339751699416524E+04,      /* J =  3 */
+(PID.TID 0000.0001)                 9.808409062749070E+04,      /* J =  4 */
+(PID.TID 0000.0001)                 1.125343710953429E+05,      /* J =  5 */
+(PID.TID 0000.0001)                 1.267135464063795E+05,      /* J =  6 */
+(PID.TID 0000.0001)                 1.405874576853274E+05,      /* J =  7 */
+(PID.TID 0000.0001)                 1.541226814647045E+05,      /* J =  8 */
+(PID.TID 0000.0001)                 1.672866102048804E+05,      /* J =  9 */
+(PID.TID 0000.0001)                 1.800475308484964E+05,      /* J = 10 */
+(PID.TID 0000.0001)                 1.923747012199971E+05,      /* J = 11 */
+(PID.TID 0000.0001)                 2.042384240862251E+05,      /* J = 12 */
+(PID.TID 0000.0001)                 2.156101186996563E+05,      /* J = 13 */
+(PID.TID 0000.0001)                 2.264623896519241E+05,      /* J = 14 */
+(PID.TID 0000.0001)                 2.367690928717577E+05,      /* J = 15 */
+(PID.TID 0000.0001)                 2.465053986083400E+05,      /* J = 16 */
+(PID.TID 0000.0001)                 2.556478512483520E+05,      /* J = 17 */
+(PID.TID 0000.0001)                 2.641744258225996E+05,      /* J = 18 */
+(PID.TID 0000.0001)                 2.720645810660936E+05,      /* J = 19 */
+(PID.TID 0000.0001)                 2.792993089037565E+05       /* J = 20 */
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) dyF =  /* dyF(:,1,:,1) ( units: m ) */
+(PID.TID 0000.0001)    42 @  3.126866438026091E+05              /* I =  1: 42 */
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) dyF =  /* dyF(1,:,1,:) ( units: m ) */
+(PID.TID 0000.0001)    20 @  3.126866438026091E+05              /* J =  1: 20 */
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) dxG =  /* dxG(:,1,:,1) ( units: m ) */
+(PID.TID 0000.0001)    42 @  4.588065960101153E+04              /* I =  1: 42 */
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) dxG =  /* dxG(1,:,1,:) ( units: m ) */
+(PID.TID 0000.0001)                 4.588065960101153E+04,      /* J =  1 */
+(PID.TID 0000.0001)                 6.100213802959342E+04,      /* J =  2 */
+(PID.TID 0000.0001)                 7.597665696450579E+04,      /* J =  3 */
+(PID.TID 0000.0001)                 9.076814147802141E+04,      /* J =  4 */
+(PID.TID 0000.0001)                 1.053409575883663E+05,      /* J =  5 */
+(PID.TID 0000.0001)                 1.196599981051027E+05,      /* J =  6 */
+(PID.TID 0000.0001)                 1.336907672054259E+05,      /* J =  7 */
+(PID.TID 0000.0001)                 1.473994635376230E+05,      /* J =  8 */
+(PID.TID 0000.0001)                 1.607530616514898E+05,      /* J =  9 */
+(PID.TID 0000.0001)                 1.737193915595329E+05,      /* J = 10 */
+(PID.TID 0000.0001)                 1.862672162372875E+05,      /* J = 11 */
+(PID.TID 0000.0001)                 1.983663068760452E+05,      /* J = 12 */
+(PID.TID 0000.0001)                 2.099875157067021E+05,      /* J = 13 */
+(PID.TID 0000.0001)                 2.211028462192875E+05,      /* J = 14 */
+(PID.TID 0000.0001)                 2.316855206090085E+05,      /* J = 15 */
+(PID.TID 0000.0001)                 2.417100442863276E+05,      /* J = 16 */
+(PID.TID 0000.0001)                 2.511522672956614E+05,      /* J = 17 */
+(PID.TID 0000.0001)                 2.599894424947394E+05,      /* J = 18 */
+(PID.TID 0000.0001)                 2.682002803544621E+05,      /* J = 19 */
+(PID.TID 0000.0001)                 2.757650002472408E+05       /* J = 20 */
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) dyG =  /* dyG(:,1,:,1) ( units: m ) */
+(PID.TID 0000.0001)    42 @  3.126866438026091E+05              /* I =  1: 42 */
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) dyG =  /* dyG(1,:,1,:) ( units: m ) */
+(PID.TID 0000.0001)    20 @  3.126866438026091E+05              /* J =  1: 20 */
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) dxC =  /* dxC(:,1,:,1) ( units: m ) */
+(PID.TID 0000.0001)    42 @  5.345749921461356E+04              /* I =  1: 42 */
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) dxC =  /* dxC(1,:,1,:) ( units: m ) */
+(PID.TID 0000.0001)                 5.345749921461356E+04,      /* J =  1 */
+(PID.TID 0000.0001)                 6.851003143764105E+04,      /* J =  2 */
+(PID.TID 0000.0001)                 8.339751699416524E+04,      /* J =  3 */
+(PID.TID 0000.0001)                 9.808409062749070E+04,      /* J =  4 */
+(PID.TID 0000.0001)                 1.125343710953429E+05,      /* J =  5 */
+(PID.TID 0000.0001)                 1.267135464063795E+05,      /* J =  6 */
+(PID.TID 0000.0001)                 1.405874576853274E+05,      /* J =  7 */
+(PID.TID 0000.0001)                 1.541226814647045E+05,      /* J =  8 */
+(PID.TID 0000.0001)                 1.672866102048804E+05,      /* J =  9 */
+(PID.TID 0000.0001)                 1.800475308484964E+05,      /* J = 10 */
+(PID.TID 0000.0001)                 1.923747012199971E+05,      /* J = 11 */
+(PID.TID 0000.0001)                 2.042384240862251E+05,      /* J = 12 */
+(PID.TID 0000.0001)                 2.156101186996563E+05,      /* J = 13 */
+(PID.TID 0000.0001)                 2.264623896519241E+05,      /* J = 14 */
+(PID.TID 0000.0001)                 2.367690928717577E+05,      /* J = 15 */
+(PID.TID 0000.0001)                 2.465053986083400E+05,      /* J = 16 */
+(PID.TID 0000.0001)                 2.556478512483520E+05,      /* J = 17 */
+(PID.TID 0000.0001)                 2.641744258225996E+05,      /* J = 18 */
+(PID.TID 0000.0001)                 2.720645810660936E+05,      /* J = 19 */
+(PID.TID 0000.0001)                 2.792993089037565E+05       /* J = 20 */
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) dyC =  /* dyC(:,1,:,1) ( units: m ) */
+(PID.TID 0000.0001)    42 @  3.126866438026091E+05              /* I =  1: 42 */
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) dyC =  /* dyC(1,:,1,:) ( units: m ) */
+(PID.TID 0000.0001)    20 @  3.126866438026091E+05              /* J =  1: 20 */
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) dxV =  /* dxV(:,1,:,1) ( units: m ) */
+(PID.TID 0000.0001)    42 @  4.588065960101153E+04              /* I =  1: 42 */
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) dxV =  /* dxV(1,:,1,:) ( units: m ) */
+(PID.TID 0000.0001)                 4.588065960101153E+04,      /* J =  1 */
+(PID.TID 0000.0001)                 6.100213802959342E+04,      /* J =  2 */
+(PID.TID 0000.0001)                 7.597665696450579E+04,      /* J =  3 */
+(PID.TID 0000.0001)                 9.076814147802141E+04,      /* J =  4 */
+(PID.TID 0000.0001)                 1.053409575883663E+05,      /* J =  5 */
+(PID.TID 0000.0001)                 1.196599981051027E+05,      /* J =  6 */
+(PID.TID 0000.0001)                 1.336907672054259E+05,      /* J =  7 */
+(PID.TID 0000.0001)                 1.473994635376230E+05,      /* J =  8 */
+(PID.TID 0000.0001)                 1.607530616514898E+05,      /* J =  9 */
+(PID.TID 0000.0001)                 1.737193915595329E+05,      /* J = 10 */
+(PID.TID 0000.0001)                 1.862672162372875E+05,      /* J = 11 */
+(PID.TID 0000.0001)                 1.983663068760452E+05,      /* J = 12 */
+(PID.TID 0000.0001)                 2.099875157067021E+05,      /* J = 13 */
+(PID.TID 0000.0001)                 2.211028462192875E+05,      /* J = 14 */
+(PID.TID 0000.0001)                 2.316855206090085E+05,      /* J = 15 */
+(PID.TID 0000.0001)                 2.417100442863276E+05,      /* J = 16 */
+(PID.TID 0000.0001)                 2.511522672956614E+05,      /* J = 17 */
+(PID.TID 0000.0001)                 2.599894424947394E+05,      /* J = 18 */
+(PID.TID 0000.0001)                 2.682002803544621E+05,      /* J = 19 */
+(PID.TID 0000.0001)                 2.757650002472408E+05       /* J = 20 */
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) dyU =  /* dyU(:,1,:,1) ( units: m ) */
+(PID.TID 0000.0001)    42 @  3.126866438026091E+05              /* I =  1: 42 */
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) dyU =  /* dyU(1,:,1,:) ( units: m ) */
+(PID.TID 0000.0001)    20 @  3.126866438026091E+05              /* J =  1: 20 */
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) rA  =  /* rA (:,1,:,1) ( units: m^2 ) */
+(PID.TID 0000.0001)    42 @  1.671376785519299E+10              /* I =  1: 42 */
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) rA  =  /* rA (1,:,1,:) ( units: m^2 ) */
+(PID.TID 0000.0001)                 1.671376785519299E+10,      /* J =  1 */
+(PID.TID 0000.0001)                 2.142002110131771E+10,      /* J =  2 */
+(PID.TID 0000.0001)                 2.607467164043704E+10,      /* J =  3 */
+(PID.TID 0000.0001)                 3.066650601170349E+10,      /* J =  4 */
+(PID.TID 0000.0001)                 3.518446208391881E+10,      /* J =  5 */
+(PID.TID 0000.0001)                 3.961765570517892E+10,      /* J =  6 */
+(PID.TID 0000.0001)                 4.395540692374860E+10,      /* J =  7 */
+(PID.TID 0000.0001)                 4.818726571700000E+10,      /* J =  8 */
+(PID.TID 0000.0001)                 5.230303716643333E+10,      /* J =  9 */
+(PID.TID 0000.0001)                 5.629280601812741E+10,      /* J = 10 */
+(PID.TID 0000.0001)                 6.014696056945659E+10,      /* J = 11 */
+(PID.TID 0000.0001)                 6.385621582452237E+10,      /* J = 12 */
+(PID.TID 0000.0001)                 6.741163586252303E+10,      /* J = 13 */
+(PID.TID 0000.0001)                 7.080465536516846E+10,      /* J = 14 */
+(PID.TID 0000.0001)                 7.402710025128452E+10,      /* J = 15 */
+(PID.TID 0000.0001)                 7.707120736888658E+10,      /* J = 16 */
+(PID.TID 0000.0001)                 7.992964319729683E+10,      /* J = 17 */
+(PID.TID 0000.0001)                 8.259552151423444E+10,      /* J = 18 */
+(PID.TID 0000.0001)                 8.506241998533159E+10,      /* J = 19 */
+(PID.TID 0000.0001)                 8.732439563609566E+10       /* J = 20 */
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) rAw =  /* rAw(:,1,:,1) ( units: m^2 ) */
+(PID.TID 0000.0001)    42 @  1.671376785519299E+10              /* I =  1: 42 */
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) rAw =  /* rAw(1,:,1,:) ( units: m^2 ) */
+(PID.TID 0000.0001)                 1.671376785519299E+10,      /* J =  1 */
+(PID.TID 0000.0001)                 2.142002110131771E+10,      /* J =  2 */
+(PID.TID 0000.0001)                 2.607467164043704E+10,      /* J =  3 */
+(PID.TID 0000.0001)                 3.066650601170349E+10,      /* J =  4 */
+(PID.TID 0000.0001)                 3.518446208391881E+10,      /* J =  5 */
+(PID.TID 0000.0001)                 3.961765570517892E+10,      /* J =  6 */
+(PID.TID 0000.0001)                 4.395540692374860E+10,      /* J =  7 */
+(PID.TID 0000.0001)                 4.818726571700000E+10,      /* J =  8 */
+(PID.TID 0000.0001)                 5.230303716643333E+10,      /* J =  9 */
+(PID.TID 0000.0001)                 5.629280601812741E+10,      /* J = 10 */
+(PID.TID 0000.0001)                 6.014696056945659E+10,      /* J = 11 */
+(PID.TID 0000.0001)                 6.385621582452237E+10,      /* J = 12 */
+(PID.TID 0000.0001)                 6.741163586252303E+10,      /* J = 13 */
+(PID.TID 0000.0001)                 7.080465536516846E+10,      /* J = 14 */
+(PID.TID 0000.0001)                 7.402710025128452E+10,      /* J = 15 */
+(PID.TID 0000.0001)                 7.707120736888658E+10,      /* J = 16 */
+(PID.TID 0000.0001)                 7.992964319729683E+10,      /* J = 17 */
+(PID.TID 0000.0001)                 8.259552151423444E+10,      /* J = 18 */
+(PID.TID 0000.0001)                 8.506241998533159E+10,      /* J = 19 */
+(PID.TID 0000.0001)                 8.732439563609566E+10       /* J = 20 */
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) rAs =  /* rAs(:,1,:,1) ( units: m^2 ) */
+(PID.TID 0000.0001)    42 @  1.434482916112175E+10              /* I =  1: 42 */
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) rAs =  /* rAs(1,:,1,:) ( units: m^2 ) */
+(PID.TID 0000.0001)                 1.434482916112175E+10,      /* J =  1 */
+(PID.TID 0000.0001)                 1.907263880047594E+10,      /* J =  2 */
+(PID.TID 0000.0001)                 2.375450078239423E+10,      /* J =  3 */
+(PID.TID 0000.0001)                 2.837913609127881E+10,      /* J =  4 */
+(PID.TID 0000.0001)                 3.293540357560110E+10,      /* J =  5 */
+(PID.TID 0000.0001)                 3.741232678790870E+10,      /* J =  6 */
+(PID.TID 0000.0001)                 4.179912042805190E+10,      /* J =  7 */
+(PID.TID 0000.0001)                 4.608521632591324E+10,      /* J =  8 */
+(PID.TID 0000.0001)                 5.026028890105701E+10,      /* J =  9 */
+(PID.TID 0000.0001)                 5.431428003795675E+10,      /* J = 10 */
+(PID.TID 0000.0001)                 5.823742331687641E+10,      /* J = 11 */
+(PID.TID 0000.0001)                 6.202026754202965E+10,      /* J = 12 */
+(PID.TID 0000.0001)                 6.565369951034003E+10,      /* J = 13 */
+(PID.TID 0000.0001)                 6.912896596594559E+10,      /* J = 14 */
+(PID.TID 0000.0001)                 7.243769468755632E+10,      /* J = 15 */
+(PID.TID 0000.0001)                 7.557191465787256E+10,      /* J = 16 */
+(PID.TID 0000.0001)                 7.852407526645966E+10,      /* J = 17 */
+(PID.TID 0000.0001)                 8.128706449983365E+10,      /* J = 18 */
+(PID.TID 0000.0001)                 8.385422607492096E+10,      /* J = 19 */
+(PID.TID 0000.0001)                 8.621937547463148E+10       /* J = 20 */
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) globalArea = /* Integrated horizontal Area (m^2) */
+(PID.TID 0000.0001)                 3.507619373042164E+13
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) the_run_name = /* Name of this simulation */
+(PID.TID 0000.0001)               'OBC + Biogeo S.Ocean Box'
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) // =======================================================
+(PID.TID 0000.0001) // End of Model config. summary
+(PID.TID 0000.0001) // =======================================================
+(PID.TID 0000.0001) 
+(PID.TID 0000.0001) == Packages configuration : Check & print summary ==
+(PID.TID 0000.0001) 
+(PID.TID 0000.0001) OBCS_CHECK: #define ALLOW_OBCS
+(PID.TID 0000.0001) OBCS_CHECK: start summary:
+(PID.TID 0000.0001) useOBCSprescribe = /* prescribe OB values */
+(PID.TID 0000.0001)                   T
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) useOBCSbalance = /* balance the flow through OB */
+(PID.TID 0000.0001)                   F
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) OBCS_uvApplyFac = /* Factor to apply to U,V 2nd column/row */
+(PID.TID 0000.0001)                 1.000000000000000E+00
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) OBCS_u1_adv_T = /* Temp uses upwind adv-scheme @ OB */
+(PID.TID 0000.0001)                       1
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) OBCS_u1_adv_S = /* Salt uses upwind adv-scheme @ OB */
+(PID.TID 0000.0001)                       1
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) OBCS_u1_adv_Tr = /* pTr uses upwind adv-scheme @ OB */
+(PID.TID 0000.0001)     5 @        1
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) OBCS_monitorFreq = /* monitor output frequency [s] */
+(PID.TID 0000.0001)                 1.000000000000000E+00
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) OBCS_monSelect = /* select group of variables to monitor */
+(PID.TID 0000.0001)                       1
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) useOBCStides = /* apply tidal forcing through OB */
+(PID.TID 0000.0001)                   F
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) tidalPeriod = /* (s) */
+(PID.TID 0000.0001)    10 @  0.000000000000000E+00              /* I =  1: 10 */
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) OB_indexNone = /* null value for OB index (i.e. no OB) */
+(PID.TID 0000.0001)                     -99
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) ======== Tile bi=   1 , bj=   1 ========
+(PID.TID 0000.0001)  OB_Jn = /* Northern OB local indices */
+(PID.TID 0000.0001)    20 @      -99                            /* I = -2: 17 */
+(PID.TID 0000.0001)  OB_Js = /* Southern OB local indices */
+(PID.TID 0000.0001)    20 @      -99                            /* I = -2: 17 */
+(PID.TID 0000.0001)  OB_Ie = /* Eastern OB local indices */
+(PID.TID 0000.0001)    16 @      -99                            /* J = -2: 13 */
+(PID.TID 0000.0001)  OB_Iw = /* Western OB local indices */
+(PID.TID 0000.0001)    16 @        1                            /* J = -2: 13 */
+(PID.TID 0000.0001) ======== Tile bi=   2 , bj=   1 ========
+(PID.TID 0000.0001)  OB_Jn = /* Northern OB local indices */
+(PID.TID 0000.0001)    20 @      -99                            /* I = -2: 17 */
+(PID.TID 0000.0001)  OB_Js = /* Southern OB local indices */
+(PID.TID 0000.0001)    20 @      -99                            /* I = -2: 17 */
+(PID.TID 0000.0001)  OB_Ie = /* Eastern OB local indices */
+(PID.TID 0000.0001)    16 @      -99                            /* J = -2: 13 */
+(PID.TID 0000.0001)  OB_Iw = /* Western OB local indices */
+(PID.TID 0000.0001)    16 @      -99                            /* J = -2: 13 */
+(PID.TID 0000.0001) ======== Tile bi=   3 , bj=   1 ========
+(PID.TID 0000.0001)  OB_Jn = /* Northern OB local indices */
+(PID.TID 0000.0001)    20 @      -99                            /* I = -2: 17 */
+(PID.TID 0000.0001)  OB_Js = /* Southern OB local indices */
+(PID.TID 0000.0001)    20 @      -99                            /* I = -2: 17 */
+(PID.TID 0000.0001)  OB_Ie = /* Eastern OB local indices */
+(PID.TID 0000.0001)    16 @       14                            /* J = -2: 13 */
+(PID.TID 0000.0001)  OB_Iw = /* Western OB local indices */
+(PID.TID 0000.0001)    16 @      -99                            /* J = -2: 13 */
+(PID.TID 0000.0001) ======== Tile bi=   1 , bj=   2 ========
+(PID.TID 0000.0001)  OB_Jn = /* Northern OB local indices */
+(PID.TID 0000.0001)    20 @       10                            /* I = -2: 17 */
+(PID.TID 0000.0001)  OB_Js = /* Southern OB local indices */
+(PID.TID 0000.0001)    20 @      -99                            /* I = -2: 17 */
+(PID.TID 0000.0001)  OB_Ie = /* Eastern OB local indices */
+(PID.TID 0000.0001)    16 @      -99                            /* J = -2: 13 */
+(PID.TID 0000.0001)  OB_Iw = /* Western OB local indices */
+(PID.TID 0000.0001)    16 @        1                            /* J = -2: 13 */
+(PID.TID 0000.0001) ======== Tile bi=   2 , bj=   2 ========
+(PID.TID 0000.0001)  OB_Jn = /* Northern OB local indices */
+(PID.TID 0000.0001)    20 @       10                            /* I = -2: 17 */
+(PID.TID 0000.0001)  OB_Js = /* Southern OB local indices */
+(PID.TID 0000.0001)    20 @      -99                            /* I = -2: 17 */
+(PID.TID 0000.0001)  OB_Ie = /* Eastern OB local indices */
+(PID.TID 0000.0001)    16 @      -99                            /* J = -2: 13 */
+(PID.TID 0000.0001)  OB_Iw = /* Western OB local indices */
+(PID.TID 0000.0001)    16 @      -99                            /* J = -2: 13 */
+(PID.TID 0000.0001) ======== Tile bi=   3 , bj=   2 ========
+(PID.TID 0000.0001)  OB_Jn = /* Northern OB local indices */
+(PID.TID 0000.0001)    20 @       10                            /* I = -2: 17 */
+(PID.TID 0000.0001)  OB_Js = /* Southern OB local indices */
+(PID.TID 0000.0001)    20 @      -99                            /* I = -2: 17 */
+(PID.TID 0000.0001)  OB_Ie = /* Eastern OB local indices */
+(PID.TID 0000.0001)    16 @       14                            /* J = -2: 13 */
+(PID.TID 0000.0001)  OB_Iw = /* Western OB local indices */
+(PID.TID 0000.0001)    16 @      -99                            /* J = -2: 13 */
+(PID.TID 0000.0001) OBCS_CHECK: end summary.
+(PID.TID 0000.0001) OBCS_CHECK: #define ALLOW_ORLANSKI
+(PID.TID 0000.0001) OBCS_CHECK: set-up OK
+(PID.TID 0000.0001) OBCS_CHECK: check Inside Mask and OB locations: OK
+(PID.TID 0000.0001) GMREDI_CHECK: #define GMREDI
+(PID.TID 0000.0001) GM_AdvForm =     /* if FALSE => use SkewFlux Form */
+(PID.TID 0000.0001)                   T
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) GM_InMomAsStress = /* if TRUE => apply as Eddy Stress */
+(PID.TID 0000.0001)                   F
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) GM_AdvSeparate = /* Calc Bolus & Euler Adv. separately */
+(PID.TID 0000.0001)                   F
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) GM_ExtraDiag =   /* Tensor Extra Diag (line 1&2) non 0 */
+(PID.TID 0000.0001)                   T
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) GM_isopycK =    /* Background Isopyc. Diffusivity [m^2/s] */
+(PID.TID 0000.0001)                 1.000000000000000E+03
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) GM_skewflx*K =  /* Background GM_SkewFlx Diffusivity [m^2/s] */
+(PID.TID 0000.0001)                 0.000000000000000E+00
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) GM_advec*K =    /* Backg. GM-Advec(=Bolus) Diffusivity [m^2/s]*/
+(PID.TID 0000.0001)                 1.000000000000000E+03
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) GM_Kmin_horiz = /* Minimum Horizontal Diffusivity [m^2/s] */
+(PID.TID 0000.0001)                 1.000000000000000E+02
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) GM_Visbeck_alpha = /* Visbeck alpha coeff. [-] */
+(PID.TID 0000.0001)                 0.000000000000000E+00
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) GM_Small_Number =  /* epsilon used in slope calc */
+(PID.TID 0000.0001)                 9.999999999999999E-21
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) GM_slopeSqCutoff = /* Slope^2 cut-off value */
+(PID.TID 0000.0001)                 1.000000000000000E+48
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) GM_taper_scheme =  /* Type of Tapering/Clipping scheme */
+(PID.TID 0000.0001)               'gkw91                                   '
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) GM_maxSlope =  /* Maximum Slope (Tapering/Clipping) */
+(PID.TID 0000.0001)                 1.000000000000000E-02
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) GM_facTrL2dz = /* Minimum Trans.Layer Thick. (factor of dz) */
+(PID.TID 0000.0001)                 1.000000000000000E+00
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) GM_facTrL2ML = /* Max.Trans.Layer Thick. (factor of MxL Depth)*/
+(PID.TID 0000.0001)                 5.000000000000000E+00
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) GM_maxTransLay = /* Maximum Transition Layer Thickness [m] */
+(PID.TID 0000.0001)                 5.000000000000000E+02
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) GM_UseBVP = /* if TRUE => use bvp a la Ferrari et al. (2010) */
+(PID.TID 0000.0001)                   F
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) GM_BVP_ModeNumber = /* Vertical mode number for BVP wave speed */
+(PID.TID 0000.0001)                       1
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) GM_BVP_cMin = /* Minimum wave speed for BVP [m/s] */
+(PID.TID 0000.0001)                 1.000000000000000E-01
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) GM_useSubMeso = /* if TRUE => use Sub-Meso param. (B.Fox-Kemper) */
+(PID.TID 0000.0001)                   F
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) subMeso_Ceff = /* efficiency coeff. of Mixed-Layer Eddies [-] */
+(PID.TID 0000.0001)                 7.000000000000001E-02
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) subMeso_invTau = /* inverse of Sub-Meso mixing time-scale [/s] */
+(PID.TID 0000.0001)                 2.000000000000000E-06
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) subMeso_LfMin = /* minimum length-scale "Lf" [m] */
+(PID.TID 0000.0001)                 1.000000000000000E+03
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) subMeso_Lmax = /* maximum grid-scale length [m] */
+(PID.TID 0000.0001)                 1.100000000000000E+05
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) GM_useLeithQG = /* if TRUE => add QG Leith viscosity to GMRedi tensor */
+(PID.TID 0000.0001)                   F
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) PTRACERS_CHECK: #define ALLOW_PTRACERS
+(PID.TID 0000.0001) // ===================================
+(PID.TID 0000.0001) // PTRACERS parameters
+(PID.TID 0000.0001) // ===================================
+(PID.TID 0000.0001) PTRACERS_numInUse = /* number of tracers */
+(PID.TID 0000.0001)                       5
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) PTRACERS_Iter0 = /* timestep number when tracers are initialized */
+(PID.TID 0000.0001)                       0
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) PTRACERS_startAllTrc =/* all tracers start @ startTime */
+(PID.TID 0000.0001)                   T
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) PTRACERS_doAB_onGpTr =/* apply AB on Tendencies (rather than on Tracers) */
+(PID.TID 0000.0001)                   T
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) PTRACERS_addSrelax2EmP =/* add Salt relaxation to EmP */
+(PID.TID 0000.0001)                   F
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) PTRACERS_dTLev =   /* Ptracer timestep ( s ) */
+(PID.TID 0000.0001)    15 @  4.320000000000000E+04              /* K =  1: 15 */
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) PTRACERS_monitorFreq = /* Frequency^-1 for monitor output (s) */
+(PID.TID 0000.0001)                 1.000000000000000E+00
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) PTRACERS_dumpFreq = /* Frequency^-1 for snapshot output (s) */
+(PID.TID 0000.0001)                 2.592000000000000E+06
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) PTRACERS_taveFreq = /* Frequency^-1 for time-Aver. output (s) */
+(PID.TID 0000.0001)                 0.000000000000000E+00
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) PTRACERS_useRecords = /* all tracers in 1 file */
+(PID.TID 0000.0001)                   F
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) PTRACERS_timeave_mnc = /* use MNC for Tave output */
+(PID.TID 0000.0001)                   F
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) PTRACERS_snapshot_mnc = /* use MNC for snapshot output */
+(PID.TID 0000.0001)                   F
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) PTRACERS_pickup_write_mnc = /* use MNC for writing pickups */
+(PID.TID 0000.0001)                   F
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) PTRACERS_pickup_read_mnc = /* use MNC for reading pickups */
+(PID.TID 0000.0001)                   F
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001)  -----------------------------------
+(PID.TID 0000.0001)  tracer number :    1
+(PID.TID 0000.0001) PTRACERS_names = /* Tracer short name */
+(PID.TID 0000.0001)               'DIC'
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) PTRACERS_long_names = /* Tracer long name */
+(PID.TID 0000.0001)               'Dissolved Inorganic Carbon (DIC) [mol C/m^3]'
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) PTRACERS_ioLabel = /* tracer IO Label */
+(PID.TID 0000.0001)               '01'
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) PTRACERS_advScheme = /* Advection Scheme */
+(PID.TID 0000.0001)                      77
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) PTRACERS_SOM_Advection = /* tracer uses SOM advection scheme */
+(PID.TID 0000.0001)                   F
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) PTRACERS_ImplVertAdv = /* implicit vert. advection flag */
+(PID.TID 0000.0001)                   F
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) PTRACERS_MultiDimAdv = /* tracer uses Multi-Dim advection */
+(PID.TID 0000.0001)                   T
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) PTRACERS_AdamsBashGtr = /* apply AB on tracer tendency */
+(PID.TID 0000.0001)                   F
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) PTRACERS_AdamsBash_Tr = /* apply AB on passive tracer */
+(PID.TID 0000.0001)                   F
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) PTRACERS_diffKh = /* Laplacian Diffusivity */
+(PID.TID 0000.0001)                 0.000000000000000E+00
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) PTRACERS_diffK4 = /* Biharmonic Diffusivity */
+(PID.TID 0000.0001)                 0.000000000000000E+00
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) PTRACERS_diffKrNr = /* Vertical Diffusivity */
+(PID.TID 0000.0001)    15 @  3.000000000000000E-05              /* K =  1: 15 */
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) PTRACERS_useGMRedi = /* apply GM-Redi */
+(PID.TID 0000.0001)                   T
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) PTRACERS_useDWNSLP = /* apply DOWN-SLOPE Flow */
+(PID.TID 0000.0001)                   F
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) PTRACERS_useKPP = /* apply KPP scheme */
+(PID.TID 0000.0001)                   F
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) PTRACERS_ref = /* Reference vertical profile */
+(PID.TID 0000.0001)                 2.028200000000000E+00,      /* K =  1 */
+(PID.TID 0000.0001)                 2.060900000000000E+00,      /* K =  2 */
+(PID.TID 0000.0001)                 2.120600000000000E+00,      /* K =  3 */
+(PID.TID 0000.0001)                 2.158100000000000E+00,      /* K =  4 */
+(PID.TID 0000.0001)                 2.190400000000000E+00,      /* K =  5 */
+(PID.TID 0000.0001)                 2.218800000000000E+00,      /* K =  6 */
+(PID.TID 0000.0001)                 2.247400000000000E+00,      /* K =  7 */
+(PID.TID 0000.0001)                 2.269900000000000E+00,      /* K =  8 */
+(PID.TID 0000.0001)                 2.279200000000000E+00,      /* K =  9 */
+(PID.TID 0000.0001)                 2.281400000000000E+00,      /* K = 10 */
+(PID.TID 0000.0001)                 2.281500000000000E+00,      /* K = 11 */
+(PID.TID 0000.0001)                 2.280600000000000E+00,      /* K = 12 */
+(PID.TID 0000.0001)                 2.280000000000000E+00,      /* K = 13 */
+(PID.TID 0000.0001)                 2.276000000000000E+00,      /* K = 14 */
+(PID.TID 0000.0001)                 2.275800000000000E+00       /* K = 15 */
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) PTRACERS_EvPrRn =/* tracer conc. in Evap. & Rain */
+(PID.TID 0000.0001)                 0.000000000000000E+00
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001)  -----------------------------------
+(PID.TID 0000.0001)  tracer number :    2
+(PID.TID 0000.0001) PTRACERS_names = /* Tracer short name */
+(PID.TID 0000.0001)               'Alk'
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) PTRACERS_long_names = /* Tracer long name */
+(PID.TID 0000.0001)               'Alkalinity (Alk) [mol eq/m^3]'
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) PTRACERS_ioLabel = /* tracer IO Label */
+(PID.TID 0000.0001)               '02'
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) PTRACERS_advScheme = /* Advection Scheme */
+(PID.TID 0000.0001)                      77
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) PTRACERS_SOM_Advection = /* tracer uses SOM advection scheme */
+(PID.TID 0000.0001)                   F
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) PTRACERS_ImplVertAdv = /* implicit vert. advection flag */
+(PID.TID 0000.0001)                   F
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) PTRACERS_MultiDimAdv = /* tracer uses Multi-Dim advection */
+(PID.TID 0000.0001)                   T
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) PTRACERS_AdamsBashGtr = /* apply AB on tracer tendency */
+(PID.TID 0000.0001)                   F
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) PTRACERS_AdamsBash_Tr = /* apply AB on passive tracer */
+(PID.TID 0000.0001)                   F
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) PTRACERS_diffKh = /* Laplacian Diffusivity */
+(PID.TID 0000.0001)                 0.000000000000000E+00
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) PTRACERS_diffK4 = /* Biharmonic Diffusivity */
+(PID.TID 0000.0001)                 0.000000000000000E+00
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) PTRACERS_diffKrNr = /* Vertical Diffusivity */
+(PID.TID 0000.0001)    15 @  3.000000000000000E-05              /* K =  1: 15 */
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) PTRACERS_useGMRedi = /* apply GM-Redi */
+(PID.TID 0000.0001)                   T
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) PTRACERS_useDWNSLP = /* apply DOWN-SLOPE Flow */
+(PID.TID 0000.0001)                   F
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) PTRACERS_useKPP = /* apply KPP scheme */
+(PID.TID 0000.0001)                   F
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) PTRACERS_ref = /* Reference vertical profile */
+(PID.TID 0000.0001)                 2.308600000000000E+00,      /* K =  1 */
+(PID.TID 0000.0001)                 2.314900000000000E+00,      /* K =  2 */
+(PID.TID 0000.0001)                 2.316400000000000E+00,      /* K =  3 */
+(PID.TID 0000.0001)                 2.311200000000000E+00,      /* K =  4 */
+(PID.TID 0000.0001)                 2.309800000000000E+00,      /* K =  5 */
+(PID.TID 0000.0001)                 2.316000000000000E+00,      /* K =  6 */
+(PID.TID 0000.0001)                 2.331300000000000E+00,      /* K =  7 */
+(PID.TID 0000.0001)                 2.351700000000000E+00,      /* K =  8 */
+(PID.TID 0000.0001)                 2.366700000000000E+00,      /* K =  9 */
+(PID.TID 0000.0001)                 2.376100000000000E+00,      /* K = 10 */
+(PID.TID 0000.0001)                 2.383200000000000E+00,      /* K = 11 */
+(PID.TID 0000.0001)                 2.386200000000000E+00,      /* K = 12 */
+(PID.TID 0000.0001)                 2.388100000000000E+00,      /* K = 13 */
+(PID.TID 0000.0001)                 2.386300000000000E+00,      /* K = 14 */
+(PID.TID 0000.0001)                 2.386700000000000E+00       /* K = 15 */
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) PTRACERS_EvPrRn =/* tracer conc. in Evap. & Rain */
+(PID.TID 0000.0001)                 0.000000000000000E+00
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001)  -----------------------------------
+(PID.TID 0000.0001)  tracer number :    3
+(PID.TID 0000.0001) PTRACERS_names = /* Tracer short name */
+(PID.TID 0000.0001)               'PO4'
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) PTRACERS_long_names = /* Tracer long name */
+(PID.TID 0000.0001)               'Phosphate (PO4) [mol P/m^3]'
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) PTRACERS_ioLabel = /* tracer IO Label */
+(PID.TID 0000.0001)               '03'
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) PTRACERS_advScheme = /* Advection Scheme */
+(PID.TID 0000.0001)                      77
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) PTRACERS_SOM_Advection = /* tracer uses SOM advection scheme */
+(PID.TID 0000.0001)                   F
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) PTRACERS_ImplVertAdv = /* implicit vert. advection flag */
+(PID.TID 0000.0001)                   F
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) PTRACERS_MultiDimAdv = /* tracer uses Multi-Dim advection */
+(PID.TID 0000.0001)                   T
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) PTRACERS_AdamsBashGtr = /* apply AB on tracer tendency */
+(PID.TID 0000.0001)                   F
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) PTRACERS_AdamsBash_Tr = /* apply AB on passive tracer */
+(PID.TID 0000.0001)                   F
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) PTRACERS_diffKh = /* Laplacian Diffusivity */
+(PID.TID 0000.0001)                 0.000000000000000E+00
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) PTRACERS_diffK4 = /* Biharmonic Diffusivity */
+(PID.TID 0000.0001)                 0.000000000000000E+00
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) PTRACERS_diffKrNr = /* Vertical Diffusivity */
+(PID.TID 0000.0001)    15 @  3.000000000000000E-05              /* K =  1: 15 */
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) PTRACERS_useGMRedi = /* apply GM-Redi */
+(PID.TID 0000.0001)                   T
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) PTRACERS_useDWNSLP = /* apply DOWN-SLOPE Flow */
+(PID.TID 0000.0001)                   F
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) PTRACERS_useKPP = /* apply KPP scheme */
+(PID.TID 0000.0001)                   F
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) PTRACERS_ref = /* Reference vertical profile */
+(PID.TID 0000.0001)                 5.438000000000000E-04,      /* K =  1 */
+(PID.TID 0000.0001)                 7.821000000000000E-04,      /* K =  2 */
+(PID.TID 0000.0001)                 1.133500000000000E-03,      /* K =  3 */
+(PID.TID 0000.0001)                 1.491300000000000E-03,      /* K =  4 */
+(PID.TID 0000.0001)                 1.860600000000000E-03,      /* K =  5 */
+(PID.TID 0000.0001)                 2.198600000000000E-03,      /* K =  6 */
+(PID.TID 0000.0001)                 2.396600000000000E-03,      /* K =  7 */
+(PID.TID 0000.0001)                 2.418700000000000E-03,      /* K =  8 */
+(PID.TID 0000.0001)                 2.404600000000000E-03,      /* K =  9 */
+(PID.TID 0000.0001)                 2.329100000000000E-03,      /* K = 10 */
+(PID.TID 0000.0001)                 2.292200000000000E-03,      /* K = 11 */
+(PID.TID 0000.0001)                 2.288600000000000E-03,      /* K = 12 */
+(PID.TID 0000.0001)                 2.260800000000000E-03,      /* K = 13 */
+(PID.TID 0000.0001)                 2.235600000000000E-03,      /* K = 14 */
+(PID.TID 0000.0001)                 2.229600000000000E-03       /* K = 15 */
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) PTRACERS_EvPrRn =/* tracer conc. in Evap. & Rain */
+(PID.TID 0000.0001)                 1.234567000000000E+05
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001)  -----------------------------------
+(PID.TID 0000.0001)  tracer number :    4
+(PID.TID 0000.0001) PTRACERS_names = /* Tracer short name */
+(PID.TID 0000.0001)               'DOP'
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) PTRACERS_long_names = /* Tracer long name */
+(PID.TID 0000.0001)               'Dissolved Organic Phosphorus (DOP) [mol P/m^3]'
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) PTRACERS_ioLabel = /* tracer IO Label */
+(PID.TID 0000.0001)               '04'
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) PTRACERS_advScheme = /* Advection Scheme */
+(PID.TID 0000.0001)                      77
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) PTRACERS_SOM_Advection = /* tracer uses SOM advection scheme */
+(PID.TID 0000.0001)                   F
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) PTRACERS_ImplVertAdv = /* implicit vert. advection flag */
+(PID.TID 0000.0001)                   F
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) PTRACERS_MultiDimAdv = /* tracer uses Multi-Dim advection */
+(PID.TID 0000.0001)                   T
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) PTRACERS_AdamsBashGtr = /* apply AB on tracer tendency */
+(PID.TID 0000.0001)                   F
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) PTRACERS_AdamsBash_Tr = /* apply AB on passive tracer */
+(PID.TID 0000.0001)                   F
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) PTRACERS_diffKh = /* Laplacian Diffusivity */
+(PID.TID 0000.0001)                 0.000000000000000E+00
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) PTRACERS_diffK4 = /* Biharmonic Diffusivity */
+(PID.TID 0000.0001)                 0.000000000000000E+00
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) PTRACERS_diffKrNr = /* Vertical Diffusivity */
+(PID.TID 0000.0001)    15 @  3.000000000000000E-05              /* K =  1: 15 */
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) PTRACERS_useGMRedi = /* apply GM-Redi */
+(PID.TID 0000.0001)                   T
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) PTRACERS_useDWNSLP = /* apply DOWN-SLOPE Flow */
+(PID.TID 0000.0001)                   F
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) PTRACERS_useKPP = /* apply KPP scheme */
+(PID.TID 0000.0001)                   F
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) PTRACERS_ref = /* Reference vertical profile */
+(PID.TID 0000.0001)    15 @  0.000000000000000E+00              /* K =  1: 15 */
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) PTRACERS_EvPrRn =/* tracer conc. in Evap. & Rain */
+(PID.TID 0000.0001)                 1.234567000000000E+05
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001)  -----------------------------------
+(PID.TID 0000.0001)  tracer number :    5
+(PID.TID 0000.0001) PTRACERS_names = /* Tracer short name */
+(PID.TID 0000.0001)               'O2'
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) PTRACERS_long_names = /* Tracer long name */
+(PID.TID 0000.0001)               'Dissolved Oxygen (O2) [mol O/m^3]'
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) PTRACERS_ioLabel = /* tracer IO Label */
+(PID.TID 0000.0001)               '05'
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) PTRACERS_advScheme = /* Advection Scheme */
+(PID.TID 0000.0001)                      77
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) PTRACERS_SOM_Advection = /* tracer uses SOM advection scheme */
+(PID.TID 0000.0001)                   F
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) PTRACERS_ImplVertAdv = /* implicit vert. advection flag */
+(PID.TID 0000.0001)                   F
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) PTRACERS_MultiDimAdv = /* tracer uses Multi-Dim advection */
+(PID.TID 0000.0001)                   T
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) PTRACERS_AdamsBashGtr = /* apply AB on tracer tendency */
+(PID.TID 0000.0001)                   F
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) PTRACERS_AdamsBash_Tr = /* apply AB on passive tracer */
+(PID.TID 0000.0001)                   F
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) PTRACERS_diffKh = /* Laplacian Diffusivity */
+(PID.TID 0000.0001)                 0.000000000000000E+00
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) PTRACERS_diffK4 = /* Biharmonic Diffusivity */
+(PID.TID 0000.0001)                 0.000000000000000E+00
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) PTRACERS_diffKrNr = /* Vertical Diffusivity */
+(PID.TID 0000.0001)    15 @  3.000000000000000E-05              /* K =  1: 15 */
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) PTRACERS_useGMRedi = /* apply GM-Redi */
+(PID.TID 0000.0001)                   T
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) PTRACERS_useDWNSLP = /* apply DOWN-SLOPE Flow */
+(PID.TID 0000.0001)                   F
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) PTRACERS_useKPP = /* apply KPP scheme */
+(PID.TID 0000.0001)                   F
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) PTRACERS_ref = /* Reference vertical profile */
+(PID.TID 0000.0001)                 2.457000000000000E-01,      /* K =  1 */
+(PID.TID 0000.0001)                 2.336000000000000E-01,      /* K =  2 */
+(PID.TID 0000.0001)                 1.975000000000000E-01,      /* K =  3 */
+(PID.TID 0000.0001)                 1.729000000000000E-01,      /* K =  4 */
+(PID.TID 0000.0001)                 1.591000000000000E-01,      /* K =  5 */
+(PID.TID 0000.0001)                 1.503000000000000E-01,      /* K =  6 */
+(PID.TID 0000.0001)                 1.424000000000000E-01,      /* K =  7 */
+(PID.TID 0000.0001)                 1.445000000000000E-01,      /* K =  8 */
+(PID.TID 0000.0001)                 1.549000000000000E-01,      /* K =  9 */
+(PID.TID 0000.0001)                 1.661000000000000E-01,      /* K = 10 */
+(PID.TID 0000.0001)                 1.774000000000000E-01,      /* K = 11 */
+(PID.TID 0000.0001)                 1.863000000000000E-01,      /* K = 12 */
+(PID.TID 0000.0001)                 1.925000000000000E-01,      /* K = 13 */
+(PID.TID 0000.0001)                 2.021000000000000E-01,      /* K = 14 */
+(PID.TID 0000.0001)                 2.051000000000000E-01       /* K = 15 */
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) PTRACERS_EvPrRn =/* tracer conc. in Evap. & Rain */
+(PID.TID 0000.0001)                 1.234567000000000E+05
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001)  -----------------------------------
+(PID.TID 0000.0001) GCHEM_CHECK  --> Starts to check GCHEM set-up
+(PID.TID 0000.0001) GCHEM_CHECK  <-- Ends Normally
+(PID.TID 0000.0001) 
+(PID.TID 0000.0001) GAD_CHECK: #define ALLOW_GENERIC_ADVDIFF
+(PID.TID 0000.0001) // =======================================================
+(PID.TID 0000.0001) // Check Model config. (CONFIG_CHECK):
+(PID.TID 0000.0001) // CONFIG_CHECK : Normal End
+(PID.TID 0000.0001) // =======================================================
+(PID.TID 0000.0001) 
+(PID.TID 0000.0001)  MDS_READ_FIELD: opening global file: U_ini.bin
+(PID.TID 0000.0001)  MDS_READ_FIELD: opening global file: V_ini.bin
+(PID.TID 0000.0001)  MDS_READ_FIELD: opening global file: T_ini.bin
+(PID.TID 0000.0001)  MDS_READ_FIELD: opening global file: S_ini.bin
+(PID.TID 0000.0001)  MDS_READ_FIELD: opening global file: Eta_ini.bin
+(PID.TID 0000.0001) Start initial hydrostatic pressure computation
+(PID.TID 0000.0001) Pressure is predetermined for buoyancyRelation OCEANIC
+(PID.TID 0000.0001) 
+(PID.TID 0000.0001)  MDS_READ_FIELD: opening global file: tren_taux_box.bin
+(PID.TID 0000.0001)  MDS_READ_FIELD: opening global file: tren_tauy_box.bin
+(PID.TID 0000.0001)  MDS_READ_FIELD: opening global file: shi_qnet_box.bin
+(PID.TID 0000.0001)  MDS_READ_FIELD: opening global file: shi_empmr_year_box.bin
+(PID.TID 0000.0001)  MDS_READ_FIELD: opening global file: lev_monthly_temp_box.bin
+(PID.TID 0000.0001)  MDS_READ_FIELD: opening global file: lev_monthly_salt_box.bin
+(PID.TID 0000.0001)  write diagnostics summary to file ioUnit:      6
+Iter.Nb:         0 ; Time(s):  0.0000000000000E+00
+------------------------------------------------------------------------
+2D/3D diagnostics: Number of lists:     2
+------------------------------------------------------------------------
+listId=    1 ; file name: surfDiag
+ nFlds, nActive,       freq     &     phase        , nLev               
+   10  |   10  |   2592000.000000         0.000000 |   1
+ levels:   1
+ diag# | name   |   ipt  |  iMate | kLev|   count |   mate.C|           
+    23 |ETAN    |      1 |      0 |   1 |       0 |
+    24 |ETANSQ  |      2 |      0 |   1 |       0 |
+    25 |DETADT2 |      3 |      0 |   1 |       0 |
+    73 |PHIBOT  |      4 |      0 |   1 |       0 |
+    74 |PHIBOTSQ|      5 |      0 |   1 |       0 |
+   286 |DICTFLX |      6 |      0 |   1 |       0 |
+   287 |DICOFLX |      7 |      0 |   1 |       0 |
+   288 |DICCFLX |      8 |      0 |   1 |       0 |
+   289 |DICPCO2 |      9 |      0 |   1 |       0 |
+   290 |DICPHAV |     10 |      0 |   1 |       0 |
+------------------------------------------------------------------------
+listId=    2 ; file name: dynDiag
+ nFlds, nActive,       freq     &     phase        , nLev               
+    9  |    9  |    432000.000000         0.000000 |  15
+ levels:   1   2   3   4   5   6   7   8   9  10  11  12  13  14  15
+ diag# | name   |   ipt  |  iMate | kLev|   count |   mate.C|           
+    46 |VVELMASS|     11 |     26 |  15 |       0 |       0 |
+    45 |UVELMASS|     26 |     11 |  15 |       0 |       0 |
+    26 |THETA   |     41 |      0 |  15 |       0 |
+    27 |SALT    |     56 |      0 |  15 |       0 |
+   204 |GM_PsiX |     71 |     86 |  15 |       0 |       0 |
+   205 |GM_PsiY |     86 |     71 |  15 |       0 |       0 |
+    48 |PhiVEL  |    -26 |     11 |  15 |       0 |       0 |
+    49 |PsiVEL  |    -26 |     11 |  15 |       0 |       0 |
+    78 |CONVADJ |    101 |      0 |  15 |       0 |
+------------------------------------------------------------------------
+Global & Regional Statistics diagnostics: Number of lists:     1
+------------------------------------------------------------------------
+listId=   1 ; file name: dynStDiag
+ nFlds, nActive,       freq     &     phase        |                    
+   20  |   20  |    432000.000000         0.000000 |
+ Regions:   0
+ diag# | name   |   ipt  |  iMate |    Volume   |   mate-Vol. |         
+    23 |ETAN    |      1 |      0 | 0.00000E+00 |
+    25 |DETADT2 |      2 |      0 | 0.00000E+00 |
+    26 |THETA   |      3 |      0 | 0.00000E+00 |
+    27 |SALT    |     18 |      0 | 0.00000E+00 |
+    78 |CONVADJ |     33 |      0 | 0.00000E+00 |
+    30 |UVEL    |     48 |      0 | 0.00000E+00 |
+    31 |VVEL    |     63 |      0 | 0.00000E+00 |
+    32 |WVEL    |     78 |      0 | 0.00000E+00 |
+   204 |GM_PsiX |     93 |      0 | 0.00000E+00 |
+   205 |GM_PsiY |    108 |      0 | 0.00000E+00 |
+   213 |TRAC01  |    123 |      0 | 0.00000E+00 |
+   227 |TRAC02  |    138 |      0 | 0.00000E+00 |
+   241 |TRAC03  |    153 |      0 | 0.00000E+00 |
+   255 |TRAC04  |    168 |      0 | 0.00000E+00 |
+   269 |TRAC05  |    183 |      0 | 0.00000E+00 |
+   291 |DIC3DSIT|    198 |      0 | 0.00000E+00 |
+   292 |OMEGAC  |    213 |      0 | 0.00000E+00 |
+   293 |DIC3DPH |    228 |      0 | 0.00000E+00 |
+   294 |DIC3DPCO|    243 |      0 | 0.00000E+00 |
+   295 |DIC3DCO3|    258 |      0 | 0.00000E+00 |
+------------------------------------------------------------------------
+(PID.TID 0000.0001)  MDS_READ_FIELD: opening global file: Trac01_ini.bin
+(PID.TID 0000.0001)  MDS_READ_FIELD: opening global file: Trac02_ini.bin
+(PID.TID 0000.0001)  MDS_READ_FIELD: opening global file: Trac03_ini.bin
+(PID.TID 0000.0001)  MDS_READ_FIELD: opening global file: Trac04_ini.bin
+(PID.TID 0000.0001)  MDS_READ_FIELD: opening global file: Trac05_ini.bin
+ DIC_SURFFORCING_INIT, it=         0 : Reading new data, i0,i1=   12    1
+(PID.TID 0000.0001)  MDS_READ_FIELD: opening global file: sillev1_box.bin
+(PID.TID 0000.0001)  MDS_READ_FIELD: opening global file: sillev1_box.bin
+ OBCS_FIELDS_LOAD,         0 : iP,iLd,i0,i1=   12    0   12    1 ; Wght=  0.5000000000  0.5000000000
+ OBCS_FIELDS_LOAD, it=         0 : Reading new data, i0,i1=   12    1 (prev=   12    0 )
+(PID.TID 0000.0001)  MDS_READ_SEC_YZ: opening global file: U_obE.bin
+(PID.TID 0000.0001)  MDS_READ_SEC_YZ: opening global file: U_obE.bin
+(PID.TID 0000.0001)  MDS_READ_SEC_YZ: opening global file: V_obE.bin
+(PID.TID 0000.0001)  MDS_READ_SEC_YZ: opening global file: V_obE.bin
+(PID.TID 0000.0001)  MDS_READ_SEC_YZ: opening global file: T_obE.bin
+(PID.TID 0000.0001)  MDS_READ_SEC_YZ: opening global file: T_obE.bin
+(PID.TID 0000.0001)  MDS_READ_SEC_YZ: opening global file: S_obE.bin
+(PID.TID 0000.0001)  MDS_READ_SEC_YZ: opening global file: S_obE.bin
+(PID.TID 0000.0001)  MDS_READ_SEC_YZ: opening global file: U_obW.bin
+(PID.TID 0000.0001)  MDS_READ_SEC_YZ: opening global file: U_obW.bin
+(PID.TID 0000.0001)  MDS_READ_SEC_YZ: opening global file: V_obW.bin
+(PID.TID 0000.0001)  MDS_READ_SEC_YZ: opening global file: V_obW.bin
+(PID.TID 0000.0001)  MDS_READ_SEC_YZ: opening global file: T_obW.bin
+(PID.TID 0000.0001)  MDS_READ_SEC_YZ: opening global file: T_obW.bin
+(PID.TID 0000.0001)  MDS_READ_SEC_YZ: opening global file: S_obW.bin
+(PID.TID 0000.0001)  MDS_READ_SEC_YZ: opening global file: S_obW.bin
+(PID.TID 0000.0001)  MDS_READ_SEC_XZ: opening global file: U_obN.bin
+(PID.TID 0000.0001)  MDS_READ_SEC_XZ: opening global file: U_obN.bin
+(PID.TID 0000.0001)  MDS_READ_SEC_XZ: opening global file: V_obN.bin
+(PID.TID 0000.0001)  MDS_READ_SEC_XZ: opening global file: V_obN.bin
+(PID.TID 0000.0001)  MDS_READ_SEC_XZ: opening global file: T_obN.bin
+(PID.TID 0000.0001)  MDS_READ_SEC_XZ: opening global file: T_obN.bin
+(PID.TID 0000.0001)  MDS_READ_SEC_XZ: opening global file: S_obN.bin
+(PID.TID 0000.0001)  MDS_READ_SEC_XZ: opening global file: S_obN.bin
+(PID.TID 0000.0001)  MDS_READ_SEC_YZ: opening global file: Trac01_obE.bin
+(PID.TID 0000.0001)  MDS_READ_SEC_YZ: opening global file: Trac01_obE.bin
+(PID.TID 0000.0001)  MDS_READ_SEC_YZ: opening global file: Trac01_obW.bin
+(PID.TID 0000.0001)  MDS_READ_SEC_YZ: opening global file: Trac01_obW.bin
+(PID.TID 0000.0001)  MDS_READ_SEC_XZ: opening global file: Trac01_obN.bin
+(PID.TID 0000.0001)  MDS_READ_SEC_XZ: opening global file: Trac01_obN.bin
+(PID.TID 0000.0001)  MDS_READ_SEC_YZ: opening global file: Trac02_obE.bin
+(PID.TID 0000.0001)  MDS_READ_SEC_YZ: opening global file: Trac02_obE.bin
+(PID.TID 0000.0001)  MDS_READ_SEC_YZ: opening global file: Trac02_obW.bin
+(PID.TID 0000.0001)  MDS_READ_SEC_YZ: opening global file: Trac02_obW.bin
+(PID.TID 0000.0001)  MDS_READ_SEC_XZ: opening global file: Trac02_obN.bin
+(PID.TID 0000.0001)  MDS_READ_SEC_XZ: opening global file: Trac02_obN.bin
+(PID.TID 0000.0001)  MDS_READ_SEC_YZ: opening global file: Trac03_obE.bin
+(PID.TID 0000.0001)  MDS_READ_SEC_YZ: opening global file: Trac03_obE.bin
+(PID.TID 0000.0001)  MDS_READ_SEC_YZ: opening global file: Trac03_obW.bin
+(PID.TID 0000.0001)  MDS_READ_SEC_YZ: opening global file: Trac03_obW.bin
+(PID.TID 0000.0001)  MDS_READ_SEC_XZ: opening global file: Trac03_obN.bin
+(PID.TID 0000.0001)  MDS_READ_SEC_XZ: opening global file: Trac03_obN.bin
+(PID.TID 0000.0001)  MDS_READ_SEC_YZ: opening global file: Trac04_obE.bin
+(PID.TID 0000.0001)  MDS_READ_SEC_YZ: opening global file: Trac04_obE.bin
+(PID.TID 0000.0001)  MDS_READ_SEC_YZ: opening global file: Trac04_obW.bin
+(PID.TID 0000.0001)  MDS_READ_SEC_YZ: opening global file: Trac04_obW.bin
+(PID.TID 0000.0001)  MDS_READ_SEC_XZ: opening global file: Trac04_obN.bin
+(PID.TID 0000.0001)  MDS_READ_SEC_XZ: opening global file: Trac04_obN.bin
+(PID.TID 0000.0001)  MDS_READ_SEC_YZ: opening global file: Trac05_obE.bin
+(PID.TID 0000.0001)  MDS_READ_SEC_YZ: opening global file: Trac05_obE.bin
+(PID.TID 0000.0001)  MDS_READ_SEC_YZ: opening global file: Trac05_obW.bin
+(PID.TID 0000.0001)  MDS_READ_SEC_YZ: opening global file: Trac05_obW.bin
+(PID.TID 0000.0001)  MDS_READ_SEC_XZ: opening global file: Trac05_obN.bin
+(PID.TID 0000.0001)  MDS_READ_SEC_XZ: opening global file: Trac05_obN.bin
+(PID.TID 0000.0001) // =======================================================
+(PID.TID 0000.0001) // Model current state
+(PID.TID 0000.0001) // =======================================================
+(PID.TID 0000.0001) 
+(PID.TID 0000.0001) // =======================================================
+(PID.TID 0000.0001) // Begin MONITOR dynamic field statistics
+(PID.TID 0000.0001) // =======================================================
+(PID.TID 0000.0001) %MON time_tsnumber                =                     0
+(PID.TID 0000.0001) %MON time_secondsf                =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON dynstat_eta_max              =   4.2498448491096E-01
+(PID.TID 0000.0001) %MON dynstat_eta_min              =  -1.4817472696304E+00
+(PID.TID 0000.0001) %MON dynstat_eta_mean             =  -5.1768973270635E-01
+(PID.TID 0000.0001) %MON dynstat_eta_sd               =   5.9968952443660E-01
+(PID.TID 0000.0001) %MON dynstat_eta_del2             =   2.3532016988898E-03
+(PID.TID 0000.0001) %MON dynstat_uvel_max             =   1.3023830950260E-01
+(PID.TID 0000.0001) %MON dynstat_uvel_min             =  -6.0768067836761E-02
+(PID.TID 0000.0001) %MON dynstat_uvel_mean            =   7.3493858379116E-03
+(PID.TID 0000.0001) %MON dynstat_uvel_sd              =   1.4643824433314E-02
+(PID.TID 0000.0001) %MON dynstat_uvel_del2            =   1.6249141681668E-04
+(PID.TID 0000.0001) %MON dynstat_vvel_max             =   1.2960743904114E-01
+(PID.TID 0000.0001) %MON dynstat_vvel_min             =  -8.8518343865871E-02
+(PID.TID 0000.0001) %MON dynstat_vvel_mean            =   8.9127213327288E-04
+(PID.TID 0000.0001) %MON dynstat_vvel_sd              =   8.4376087770051E-03
+(PID.TID 0000.0001) %MON dynstat_vvel_del2            =   1.0650506343562E-04
+(PID.TID 0000.0001) %MON dynstat_wvel_max             =   5.5220275294497E-05
+(PID.TID 0000.0001) %MON dynstat_wvel_min             =  -1.4137995947489E-04
+(PID.TID 0000.0001) %MON dynstat_wvel_mean            =  -2.4324096431404E-07
+(PID.TID 0000.0001) %MON dynstat_wvel_sd              =   5.5064315434168E-06
+(PID.TID 0000.0001) %MON dynstat_wvel_del2            =   1.4504545477429E-07
+(PID.TID 0000.0001) %MON dynstat_theta_max            =   2.4157361984253E+01
+(PID.TID 0000.0001) %MON dynstat_theta_min            =  -2.8958356380463E+00
+(PID.TID 0000.0001) %MON dynstat_theta_mean           =   2.3216137302711E+00
+(PID.TID 0000.0001) %MON dynstat_theta_sd             =   3.2103641662143E+00
+(PID.TID 0000.0001) %MON dynstat_theta_del2           =   6.6465388359911E-03
+(PID.TID 0000.0001) %MON dynstat_salt_max             =   3.6600784301758E+01
+(PID.TID 0000.0001) %MON dynstat_salt_min             =   3.3084754943848E+01
+(PID.TID 0000.0001) %MON dynstat_salt_mean            =   3.4483933613549E+01
+(PID.TID 0000.0001) %MON dynstat_salt_sd              =   1.9644712446743E-01
+(PID.TID 0000.0001) %MON dynstat_salt_del2            =   1.1588922083609E-03
+(PID.TID 0000.0001) %MON forcing_qnet_max             =   6.9361846923828E+01
+(PID.TID 0000.0001) %MON forcing_qnet_min             =  -2.0417861938477E+02
+(PID.TID 0000.0001) %MON forcing_qnet_mean            =  -1.1295642419045E+02
+(PID.TID 0000.0001) %MON forcing_qnet_sd              =   4.1815497434578E+01
+(PID.TID 0000.0001) %MON forcing_qnet_del2            =   8.8869422460177E-01
+(PID.TID 0000.0001) %MON forcing_qsw_max              =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON forcing_qsw_min              =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON forcing_qsw_mean             =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON forcing_qsw_sd               =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON forcing_qsw_del2             =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON forcing_empmr_max            =   2.5141471127199E-05
+(PID.TID 0000.0001) %MON forcing_empmr_min            =  -3.9761445691511E-05
+(PID.TID 0000.0001) %MON forcing_empmr_mean           =  -9.3236499820974E-06
+(PID.TID 0000.0001) %MON forcing_empmr_sd             =   1.0249687273683E-05
+(PID.TID 0000.0001) %MON forcing_empmr_del2           =   9.8755541425843E-08
+(PID.TID 0000.0001) %MON forcing_fu_max               =   2.1824374794960E-01
+(PID.TID 0000.0001) %MON forcing_fu_min               =  -1.0302186757326E-01
+(PID.TID 0000.0001) %MON forcing_fu_mean              =   7.3083621898039E-02
+(PID.TID 0000.0001) %MON forcing_fu_sd                =   7.2594531176829E-02
+(PID.TID 0000.0001) %MON forcing_fu_del2              =   5.9615425353979E-04
+(PID.TID 0000.0001) %MON forcing_fv_max               =   1.4191913604736E-01
+(PID.TID 0000.0001) %MON forcing_fv_min               =  -7.7472656965256E-02
+(PID.TID 0000.0001) %MON forcing_fv_mean              =  -1.7821404000724E-02
+(PID.TID 0000.0001) %MON forcing_fv_sd                =   3.3449841576786E-02
+(PID.TID 0000.0001) %MON forcing_fv_del2              =   3.7447536985508E-04
+(PID.TID 0000.0001) %MON trAdv_CFL_u_max              =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON trAdv_CFL_v_max              =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON trAdv_CFL_w_max              =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON advcfl_uvel_max              =   3.3632667693019E-02
+(PID.TID 0000.0001) %MON advcfl_vvel_max              =   1.7906237690509E-02
+(PID.TID 0000.0001) %MON advcfl_wvel_max              =   3.3657438911329E-02
+(PID.TID 0000.0001) %MON advcfl_W_hf_max              =   1.7963571321516E-02
+(PID.TID 0000.0001) %MON pe_b_mean                    =   8.4564277375069E-04
+(PID.TID 0000.0001) %MON ke_max                       =   9.2757393409125E-03
+(PID.TID 0000.0001) %MON ke_mean                      =   1.6130429888475E-04
+(PID.TID 0000.0001) %MON ke_vol                       =   1.2769337095763E+17
+(PID.TID 0000.0001) %MON vort_r_min                   =  -4.7830461303030E-07
+(PID.TID 0000.0001) %MON vort_r_max                   =   7.0582698239818E-07
+(PID.TID 0000.0001) %MON vort_a_mean                  =  -1.0457492699542E-04
+(PID.TID 0000.0001) %MON vort_a_sd                    =   2.1292568575566E-05
+(PID.TID 0000.0001) %MON vort_p_mean                  =  -1.2574624497018E-04
+(PID.TID 0000.0001) %MON vort_p_sd                    =   1.1183795518383E-04
+(PID.TID 0000.0001) %MON surfExpan_theta_mean         =  -1.4505528465063E-07
+(PID.TID 0000.0001) %MON surfExpan_salt_mean          =   7.1872208131480E-08
+(PID.TID 0000.0001) // =======================================================
+(PID.TID 0000.0001) // End MONITOR dynamic field statistics
+(PID.TID 0000.0001) // =======================================================
+(PID.TID 0000.0001) // =======================================================
+(PID.TID 0000.0001) // Begin OBCS MONITOR field statistics
+(PID.TID 0000.0001) // =======================================================
+(PID.TID 0000.0001) %MON obc_E_uVel_max               =   8.4231816232204E-02
+(PID.TID 0000.0001) %MON obc_E_uVel_min               =  -6.0768067836761E-02
+(PID.TID 0000.0001) %MON obc_E_uVel_mean              =   7.3664911249156E-03
+(PID.TID 0000.0001) %MON obc_E_uVel_sd                =   1.4300273749965E-02
+(PID.TID 0000.0001) %MON obc_E_uVel_Int               =   1.2629560767914E+08
+(PID.TID 0000.0001) %MON obc_W_uVel_max               =   5.9702914208174E-02
+(PID.TID 0000.0001) %MON obc_W_uVel_min               =  -2.5726319290698E-02
+(PID.TID 0000.0001) %MON obc_W_uVel_mean              =   7.0236617289703E-03
+(PID.TID 0000.0001) %MON obc_W_uVel_sd                =   1.1103839461495E-02
+(PID.TID 0000.0001) %MON obc_W_uVel_Int               =   1.3126718559515E+08
+(PID.TID 0000.0001) %MON obc_N_vVel_max               =   4.7468712553382E-02
+(PID.TID 0000.0001) %MON obc_N_vVel_min               =  -7.0454828441143E-02
+(PID.TID 0000.0001) %MON obc_N_vVel_mean              =   1.6522467327141E-04
+(PID.TID 0000.0001) %MON obc_N_vVel_sd                =   6.4416742406190E-03
+(PID.TID 0000.0001) %MON obc_N_vVel_Int               =   4.8301529307681E+06
+(PID.TID 0000.0001) %MON obc_E_theta_max              =   1.9184095382690E+01
+(PID.TID 0000.0001) %MON obc_E_theta_min              =  -1.6429638266563E+00
+(PID.TID 0000.0001) %MON obc_E_theta_mean             =   1.9094777718074E+00
+(PID.TID 0000.0001) %MON obc_E_theta_sd               =   2.9652256041640E+00
+(PID.TID 0000.0001) %MON obc_W_theta_max              =   2.1404630661011E+01
+(PID.TID 0000.0001) %MON obc_W_theta_min              =  -1.4417628645897E+00
+(PID.TID 0000.0001) %MON obc_W_theta_mean             =   2.4654016052560E+00
+(PID.TID 0000.0001) %MON obc_W_theta_sd               =   2.9592378831378E+00
+(PID.TID 0000.0001) %MON obc_N_theta_max              =   2.3972635269165E+01
+(PID.TID 0000.0001) %MON obc_N_theta_min              =  -6.3042351603508E-01
+(PID.TID 0000.0001) %MON obc_N_theta_mean             =   4.8710207613799E+00
+(PID.TID 0000.0001) %MON obc_N_theta_sd               =   4.7009472474846E+00
+(PID.TID 0000.0001) // =======================================================
+(PID.TID 0000.0001) // End OBCS MONITOR field statistics
+(PID.TID 0000.0001) // =======================================================
+(PID.TID 0000.0001) // =======================================================
+(PID.TID 0000.0001) // Begin MONITOR ptracer field statistics
+(PID.TID 0000.0001) // =======================================================
+(PID.TID 0000.0001) %MON trcstat_ptracer01_max        =   2.3591387271881E+00
+(PID.TID 0000.0001) %MON trcstat_ptracer01_min        =   1.9367703199387E+00
+(PID.TID 0000.0001) %MON trcstat_ptracer01_mean       =   2.2425301046135E+00
+(PID.TID 0000.0001) %MON trcstat_ptracer01_sd         =   7.5981612504913E-02
+(PID.TID 0000.0001) %MON trcstat_ptracer01_del2       =   1.0693771728119E-04
+(PID.TID 0000.0001) %MON trcstat_ptracer02_max        =   2.4116826057434E+00
+(PID.TID 0000.0001) %MON trcstat_ptracer02_min        =   2.1899123191833E+00
+(PID.TID 0000.0001) %MON trcstat_ptracer02_mean       =   2.3520448323130E+00
+(PID.TID 0000.0001) %MON trcstat_ptracer02_sd         =   3.5091243992577E-02
+(PID.TID 0000.0001) %MON trcstat_ptracer02_del2       =   8.0636971566538E-05
+(PID.TID 0000.0001) %MON trcstat_ptracer03_max        =   2.7654629666358E-03
+(PID.TID 0000.0001) %MON trcstat_ptracer03_min        =   4.7440538764931E-05
+(PID.TID 0000.0001) %MON trcstat_ptracer03_mean       =   2.0556800669777E-03
+(PID.TID 0000.0001) %MON trcstat_ptracer03_sd         =   5.0322634216633E-04
+(PID.TID 0000.0001) %MON trcstat_ptracer03_del2       =   6.7075508236597E-07
+(PID.TID 0000.0001) %MON trcstat_ptracer04_max        =   2.5665847351775E-04
+(PID.TID 0000.0001) %MON trcstat_ptracer04_min        =  -7.4560205121088E-07
+(PID.TID 0000.0001) %MON trcstat_ptracer04_mean       =   6.2001614686786E-06
+(PID.TID 0000.0001) %MON trcstat_ptracer04_sd         =   2.6096018939081E-05
+(PID.TID 0000.0001) %MON trcstat_ptracer04_del2       =   1.3468378546213E-07
+(PID.TID 0000.0001) %MON trcstat_ptracer05_max        =   3.8357657194138E-01
+(PID.TID 0000.0001) %MON trcstat_ptracer05_min        =   8.2342259585857E-02
+(PID.TID 0000.0001) %MON trcstat_ptracer05_mean       =   2.1413280166756E-01
+(PID.TID 0000.0001) %MON trcstat_ptracer05_sd         =   4.3053560479973E-02
+(PID.TID 0000.0001) %MON trcstat_ptracer05_del2       =   1.1918591217244E-04
+(PID.TID 0000.0001) // =======================================================
+(PID.TID 0000.0001) // End MONITOR ptracer field statistics
+(PID.TID 0000.0001) // =======================================================
+ EXTERNAL_FIELDS_LOAD,         0 : iP,iLd,i0,i1=   12    0   12    1 ; Wght=  0.5000000000  0.5000000000
+ EXTERNAL_FIELDS_LOAD, it=         0 : Reading new data, i0,i1=   12    1 (prev=   12    0 )
+(PID.TID 0000.0001)  MDS_READ_FIELD: opening global file: tren_taux_box.bin
+(PID.TID 0000.0001)  MDS_READ_FIELD: opening global file: tren_taux_box.bin
+(PID.TID 0000.0001)  MDS_READ_FIELD: opening global file: tren_tauy_box.bin
+(PID.TID 0000.0001)  MDS_READ_FIELD: opening global file: tren_tauy_box.bin
+(PID.TID 0000.0001)  MDS_READ_FIELD: opening global file: shi_qnet_box.bin
+(PID.TID 0000.0001)  MDS_READ_FIELD: opening global file: shi_qnet_box.bin
+(PID.TID 0000.0001)  MDS_READ_FIELD: opening global file: shi_empmr_year_box.bin
+(PID.TID 0000.0001)  MDS_READ_FIELD: opening global file: shi_empmr_year_box.bin
+(PID.TID 0000.0001)  MDS_READ_FIELD: opening global file: lev_monthly_temp_box.bin
+(PID.TID 0000.0001)  MDS_READ_FIELD: opening global file: lev_monthly_temp_box.bin
+(PID.TID 0000.0001)  MDS_READ_FIELD: opening global file: lev_monthly_salt_box.bin
+(PID.TID 0000.0001)  MDS_READ_FIELD: opening global file: lev_monthly_salt_box.bin
+ DIC_FIELDS_LOAD,         0 : iP,iLd,i0,i1=   12    0   12    1 ; Wght=  0.5000000000  0.5000000000
+ DIC_FIELDS_LOAD, it=         0 : Reading new data, i0,i1=   12    1 (prev=   12    0 )
+(PID.TID 0000.0001)  MDS_READ_FIELD: opening global file: tren_speed_box.bin
+(PID.TID 0000.0001)  MDS_READ_FIELD: opening global file: tren_speed_box.bin
+(PID.TID 0000.0001)  MDS_READ_FIELD: opening global file: sillev1_box.bin
+(PID.TID 0000.0001)  MDS_READ_FIELD: opening global file: sillev1_box.bin
+(PID.TID 0000.0001)  MDS_READ_FIELD: opening global file: silicate_3D_12m_box.bin
+(PID.TID 0000.0001)  MDS_READ_FIELD: opening global file: silicate_3D_12m_box.bin
+(PID.TID 0000.0001)  MDS_READ_FIELD: opening global file: fice_box.bin
+(PID.TID 0000.0001)  MDS_READ_FIELD: opening global file: fice_box.bin
+ OBCS_FIELDS_LOAD,         1 : iP,iLd,i0,i1=   12    1   12    1 ; Wght=  0.4833333333  0.5166666667
+(PID.TID 0000.0001) SOLVE_FOR_PRESSURE: putPmEinXvector =    F
+ cg2d: Sum(rhs),rhsMax =   3.70300204682829E+01  9.88743731864319E-01
+(PID.TID 0000.0001)      cg2d_init_res =   2.37603699273327E-01
+(PID.TID 0000.0001)      cg2d_iters(min,last) =      -1      80
+(PID.TID 0000.0001)      cg2d_last_res =   7.83460039210268E-14
+(PID.TID 0000.0001) // =======================================================
+(PID.TID 0000.0001) // Begin MONITOR dynamic field statistics
+(PID.TID 0000.0001) // =======================================================
+(PID.TID 0000.0001) %MON time_tsnumber                =                     1
+(PID.TID 0000.0001) %MON time_secondsf                =   4.3200000000000E+04
+(PID.TID 0000.0001) %MON dynstat_eta_max              =   4.5995434788303E-01
+(PID.TID 0000.0001) %MON dynstat_eta_min              =  -1.4926906630212E+00
+(PID.TID 0000.0001) %MON dynstat_eta_mean             =  -5.1751416804791E-01
+(PID.TID 0000.0001) %MON dynstat_eta_sd               =   6.0178255889349E-01
+(PID.TID 0000.0001) %MON dynstat_eta_del2             =   2.3589778971511E-03
+(PID.TID 0000.0001) %MON dynstat_uvel_max             =   1.3027291294470E-01
+(PID.TID 0000.0001) %MON dynstat_uvel_min             =  -6.0691849142313E-02
+(PID.TID 0000.0001) %MON dynstat_uvel_mean            =   7.4175285308401E-03
+(PID.TID 0000.0001) %MON dynstat_uvel_sd              =   1.4633337899631E-02
+(PID.TID 0000.0001) %MON dynstat_uvel_del2            =   1.6238374490497E-04
+(PID.TID 0000.0001) %MON dynstat_vvel_max             =   1.2954916558810E-01
+(PID.TID 0000.0001) %MON dynstat_vvel_min             =  -8.8515782804455E-02
+(PID.TID 0000.0001) %MON dynstat_vvel_mean            =   9.1326993179764E-04
+(PID.TID 0000.0001) %MON dynstat_vvel_sd              =   8.4326980060472E-03
+(PID.TID 0000.0001) %MON dynstat_vvel_del2            =   1.0638914247425E-04
+(PID.TID 0000.0001) %MON dynstat_wvel_max             =   5.5009566978399E-05
+(PID.TID 0000.0001) %MON dynstat_wvel_min             =  -1.4162700010206E-04
+(PID.TID 0000.0001) %MON dynstat_wvel_mean            =  -2.4323740420733E-07
+(PID.TID 0000.0001) %MON dynstat_wvel_sd              =   5.4535039627299E-06
+(PID.TID 0000.0001) %MON dynstat_wvel_del2            =   1.4032734702382E-07
+(PID.TID 0000.0001) %MON dynstat_theta_max            =   2.4176176055431E+01
+(PID.TID 0000.0001) %MON dynstat_theta_min            =  -2.8959442458374E+00
+(PID.TID 0000.0001) %MON dynstat_theta_mean           =   2.3219357947834E+00
+(PID.TID 0000.0001) %MON dynstat_theta_sd             =   3.2112571801567E+00
+(PID.TID 0000.0001) %MON dynstat_theta_del2           =   6.6436082635441E-03
+(PID.TID 0000.0001) %MON dynstat_salt_max             =   3.6600983637883E+01
+(PID.TID 0000.0001) %MON dynstat_salt_min             =   3.3083605831074E+01
+(PID.TID 0000.0001) %MON dynstat_salt_mean            =   3.4483935079098E+01
+(PID.TID 0000.0001) %MON dynstat_salt_sd              =   1.9645820244523E-01
+(PID.TID 0000.0001) %MON dynstat_salt_del2            =   1.1582977948130E-03
+(PID.TID 0000.0001) %MON forcing_qnet_max             =   6.8294754028320E+01
+(PID.TID 0000.0001) %MON forcing_qnet_min             =  -2.1320401000977E+02
+(PID.TID 0000.0001) %MON forcing_qnet_mean            =  -1.2120328054684E+02
+(PID.TID 0000.0001) %MON forcing_qnet_sd              =   4.4775932709347E+01
+(PID.TID 0000.0001) %MON forcing_qnet_del2            =   8.3492965265813E-01
+(PID.TID 0000.0001) %MON forcing_qsw_max              =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON forcing_qsw_min              =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON forcing_qsw_mean             =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON forcing_qsw_sd               =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON forcing_qsw_del2             =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON forcing_empmr_max            =   2.5141471127199E-05
+(PID.TID 0000.0001) %MON forcing_empmr_min            =  -3.9761445691511E-05
+(PID.TID 0000.0001) %MON forcing_empmr_mean           =  -9.3236499820974E-06
+(PID.TID 0000.0001) %MON forcing_empmr_sd             =   1.0249687273683E-05
+(PID.TID 0000.0001) %MON forcing_empmr_del2           =   9.8755541425843E-08
+(PID.TID 0000.0001) %MON forcing_fu_max               =   2.1189042925835E-01
+(PID.TID 0000.0001) %MON forcing_fu_min               =  -9.0532809495926E-02
+(PID.TID 0000.0001) %MON forcing_fu_mean              =   7.6106089453040E-02
+(PID.TID 0000.0001) %MON forcing_fu_sd                =   7.1216399468495E-02
+(PID.TID 0000.0001) %MON forcing_fu_del2              =   5.5128220616824E-04
+(PID.TID 0000.0001) %MON forcing_fv_max               =   1.5118104964495E-01
+(PID.TID 0000.0001) %MON forcing_fv_min               =  -7.6193943619728E-02
+(PID.TID 0000.0001) %MON forcing_fv_mean              =  -1.9592570688621E-02
+(PID.TID 0000.0001) %MON forcing_fv_sd                =   3.3563926402948E-02
+(PID.TID 0000.0001) %MON forcing_fv_del2              =   3.7626012825569E-04
+(PID.TID 0000.0001) %MON trAdv_CFL_u_max              =   8.1675162763305E-02
+(PID.TID 0000.0001) %MON trAdv_CFL_v_max              =   1.8487912745656E-02
+(PID.TID 0000.0001) %MON trAdv_CFL_w_max              =   6.2844837867684E-02
+(PID.TID 0000.0001) %MON advcfl_uvel_max              =   3.3641603666416E-02
+(PID.TID 0000.0001) %MON advcfl_vvel_max              =   1.7898186776852E-02
+(PID.TID 0000.0001) %MON advcfl_wvel_max              =   1.6762428505230E-02
+(PID.TID 0000.0001) %MON advcfl_W_hf_max              =   1.7994960012968E-02
+(PID.TID 0000.0001) %MON pe_b_mean                    =   8.4878613014088E-04
+(PID.TID 0000.0001) %MON ke_max                       =   9.2726630591449E-03
+(PID.TID 0000.0001) %MON ke_mean                      =   1.6162367406714E-04
+(PID.TID 0000.0001) %MON ke_vol                       =   1.2769337095763E+17
+(PID.TID 0000.0001) %MON vort_r_min                   =  -4.7776380617399E-07
+(PID.TID 0000.0001) %MON vort_r_max                   =   7.0533584638701E-07
+(PID.TID 0000.0001) %MON vort_a_mean                  =  -1.0457492648028E-04
+(PID.TID 0000.0001) %MON vort_a_sd                    =   2.1292605380161E-05
+(PID.TID 0000.0001) %MON vort_p_mean                  =  -1.2574624435076E-04
+(PID.TID 0000.0001) %MON vort_p_sd                    =   1.1183798042838E-04
+(PID.TID 0000.0001) %MON surfExpan_theta_mean         =   2.2002699834481E-08
+(PID.TID 0000.0001) %MON surfExpan_salt_mean          =   1.0362440405314E-07
+(PID.TID 0000.0001) // =======================================================
+(PID.TID 0000.0001) // End MONITOR dynamic field statistics
+(PID.TID 0000.0001) // =======================================================
+(PID.TID 0000.0001) // =======================================================
+(PID.TID 0000.0001) // Begin OBCS MONITOR field statistics
+(PID.TID 0000.0001) // =======================================================
+(PID.TID 0000.0001) %MON obc_E_uVel_max               =   8.4097423652808E-02
+(PID.TID 0000.0001) %MON obc_E_uVel_min               =  -6.0691849142313E-02
+(PID.TID 0000.0001) %MON obc_E_uVel_mean              =   7.3646583987137E-03
+(PID.TID 0000.0001) %MON obc_E_uVel_sd                =   1.4300890782899E-02
+(PID.TID 0000.0001) %MON obc_E_uVel_Int               =   1.2626418630559E+08
+(PID.TID 0000.0001) %MON obc_W_uVel_max               =   5.9750952695807E-02
+(PID.TID 0000.0001) %MON obc_W_uVel_min               =  -2.5728699409713E-02
+(PID.TID 0000.0001) %MON obc_W_uVel_mean              =   7.0192873374808E-03
+(PID.TID 0000.0001) %MON obc_W_uVel_sd                =   1.1107779277586E-02
+(PID.TID 0000.0001) %MON obc_W_uVel_Int               =   1.3118543136471E+08
+(PID.TID 0000.0001) %MON obc_N_vVel_max               =   4.7415303376814E-02
+(PID.TID 0000.0001) %MON obc_N_vVel_min               =  -7.0506425450246E-02
+(PID.TID 0000.0001) %MON obc_N_vVel_mean              =   1.6346447363572E-04
+(PID.TID 0000.0001) %MON obc_N_vVel_sd                =   6.4402877553886E-03
+(PID.TID 0000.0001) %MON obc_N_vVel_Int               =   4.7786955227386E+06
+(PID.TID 0000.0001) %MON obc_E_theta_max              =   1.9205570983887E+01
+(PID.TID 0000.0001) %MON obc_E_theta_min              =  -1.6343102912108E+00
+(PID.TID 0000.0001) %MON obc_E_theta_mean             =   1.9094666342927E+00
+(PID.TID 0000.0001) %MON obc_E_theta_sd               =   2.9656966224417E+00
+(PID.TID 0000.0001) %MON obc_W_theta_max              =   2.1424821790059E+01
+(PID.TID 0000.0001) %MON obc_W_theta_min              =  -1.4418450812499E+00
+(PID.TID 0000.0001) %MON obc_W_theta_mean             =   2.4656188431364E+00
+(PID.TID 0000.0001) %MON obc_W_theta_sd               =   2.9597766264317E+00
+(PID.TID 0000.0001) %MON obc_N_theta_max              =   2.3993523279826E+01
+(PID.TID 0000.0001) %MON obc_N_theta_min              =  -6.3092609544595E-01
+(PID.TID 0000.0001) %MON obc_N_theta_mean             =   4.8712326540729E+00
+(PID.TID 0000.0001) %MON obc_N_theta_sd               =   4.7018270697657E+00
+(PID.TID 0000.0001) // =======================================================
+(PID.TID 0000.0001) // End OBCS MONITOR field statistics
+(PID.TID 0000.0001) // =======================================================
+(PID.TID 0000.0001) // =======================================================
+(PID.TID 0000.0001) // Begin MONITOR ptracer field statistics
+(PID.TID 0000.0001) // =======================================================
+(PID.TID 0000.0001) %MON trcstat_ptracer01_max        =   2.3591394770776E+00
+(PID.TID 0000.0001) %MON trcstat_ptracer01_min        =   1.9367486749817E+00
+(PID.TID 0000.0001) %MON trcstat_ptracer01_mean       =   2.2425286949238E+00
+(PID.TID 0000.0001) %MON trcstat_ptracer01_sd         =   7.5984993439482E-02
+(PID.TID 0000.0001) %MON trcstat_ptracer01_del2       =   1.0685608891979E-04
+(PID.TID 0000.0001) %MON trcstat_ptracer02_max        =   2.4116827787738E+00
+(PID.TID 0000.0001) %MON trcstat_ptracer02_min        =   2.1899459792551E+00
+(PID.TID 0000.0001) %MON trcstat_ptracer02_mean       =   2.3520451784955E+00
+(PID.TID 0000.0001) %MON trcstat_ptracer02_sd         =   3.5091068499635E-02
+(PID.TID 0000.0001) %MON trcstat_ptracer02_del2       =   8.0629800485248E-05
+(PID.TID 0000.0001) %MON trcstat_ptracer03_max        =   2.7654670647513E-03
+(PID.TID 0000.0001) %MON trcstat_ptracer03_min        =   4.7395120481237E-05
+(PID.TID 0000.0001) %MON trcstat_ptracer03_mean       =   2.0556705765263E-03
+(PID.TID 0000.0001) %MON trcstat_ptracer03_sd         =   5.0324302750848E-04
+(PID.TID 0000.0001) %MON trcstat_ptracer03_del2       =   6.7043671858714E-07
+(PID.TID 0000.0001) %MON trcstat_ptracer04_max        =   2.5699611737368E-04
+(PID.TID 0000.0001) %MON trcstat_ptracer04_min        =  -7.4705281297197E-07
+(PID.TID 0000.0001) %MON trcstat_ptracer04_mean       =   6.2084159923944E-06
+(PID.TID 0000.0001) %MON trcstat_ptracer04_sd         =   2.6136106693571E-05
+(PID.TID 0000.0001) %MON trcstat_ptracer04_del2       =   1.3456372290705E-07
+(PID.TID 0000.0001) %MON trcstat_ptracer05_max        =   3.8361753713501E-01
+(PID.TID 0000.0001) %MON trcstat_ptracer05_min        =   8.2383316333612E-02
+(PID.TID 0000.0001) %MON trcstat_ptracer05_mean       =   2.1413094083900E-01
+(PID.TID 0000.0001) %MON trcstat_ptracer05_sd         =   4.3051033243526E-02
+(PID.TID 0000.0001) %MON trcstat_ptracer05_del2       =   1.1897591872251E-04
+(PID.TID 0000.0001) // =======================================================
+(PID.TID 0000.0001) // End MONITOR ptracer field statistics
+(PID.TID 0000.0001) // =======================================================
+ EXTERNAL_FIELDS_LOAD,         1 : iP,iLd,i0,i1=   12    1   12    1 ; Wght=  0.4833333333  0.5166666667
+ DIC_FIELDS_LOAD,         1 : iP,iLd,i0,i1=   12    1   12    1 ; Wght=  0.4833333333  0.5166666667
+ OBCS_FIELDS_LOAD,         2 : iP,iLd,i0,i1=   12    1   12    1 ; Wght=  0.4666666667  0.5333333333
+ cg2d: Sum(rhs),rhsMax =   3.70217753957371E+01  9.88625784851453E-01
+(PID.TID 0000.0001)      cg2d_init_res =   2.18099076329334E-01
+(PID.TID 0000.0001)      cg2d_iters(min,last) =      -1      80
+(PID.TID 0000.0001)      cg2d_last_res =   9.55927126932183E-14
+(PID.TID 0000.0001) // =======================================================
+(PID.TID 0000.0001) // Begin MONITOR dynamic field statistics
+(PID.TID 0000.0001) // =======================================================
+(PID.TID 0000.0001) %MON time_tsnumber                =                     2
+(PID.TID 0000.0001) %MON time_secondsf                =   8.6400000000000E+04
+(PID.TID 0000.0001) %MON dynstat_eta_max              =   4.6334347157143E-01
+(PID.TID 0000.0001) %MON dynstat_eta_min              =  -1.5054718669162E+00
+(PID.TID 0000.0001) %MON dynstat_eta_mean             =  -5.1733721838717E-01
+(PID.TID 0000.0001) %MON dynstat_eta_sd               =   6.0496709348125E-01
+(PID.TID 0000.0001) %MON dynstat_eta_del2             =   2.3577831149832E-03
+(PID.TID 0000.0001) %MON dynstat_uvel_max             =   1.3041106999456E-01
+(PID.TID 0000.0001) %MON dynstat_uvel_min             =  -6.0615630447865E-02
+(PID.TID 0000.0001) %MON dynstat_uvel_mean            =   7.4725824773712E-03
+(PID.TID 0000.0001) %MON dynstat_uvel_sd              =   1.4631652665722E-02
+(PID.TID 0000.0001) %MON dynstat_uvel_del2            =   1.6226581855361E-04
+(PID.TID 0000.0001) %MON dynstat_vvel_max             =   1.2953153531427E-01
+(PID.TID 0000.0001) %MON dynstat_vvel_min             =  -8.8521495760349E-02
+(PID.TID 0000.0001) %MON dynstat_vvel_mean            =   9.3671467481625E-04
+(PID.TID 0000.0001) %MON dynstat_vvel_sd              =   8.4317722124119E-03
+(PID.TID 0000.0001) %MON dynstat_vvel_del2            =   1.0631845421267E-04
+(PID.TID 0000.0001) %MON dynstat_wvel_max             =   5.4857585207279E-05
+(PID.TID 0000.0001) %MON dynstat_wvel_min             =  -1.4187401954804E-04
+(PID.TID 0000.0001) %MON dynstat_wvel_mean            =  -2.4323384410062E-07
+(PID.TID 0000.0001) %MON dynstat_wvel_sd              =   5.4672365947540E-06
+(PID.TID 0000.0001) %MON dynstat_wvel_del2            =   1.4054166570978E-07
+(PID.TID 0000.0001) %MON dynstat_theta_max            =   2.4191250964543E+01
+(PID.TID 0000.0001) %MON dynstat_theta_min            =  -2.8960457389717E+00
+(PID.TID 0000.0001) %MON dynstat_theta_mean           =   2.3222538696213E+00
+(PID.TID 0000.0001) %MON dynstat_theta_sd             =   3.2121304166893E+00
+(PID.TID 0000.0001) %MON dynstat_theta_del2           =   6.6406361958254E-03
+(PID.TID 0000.0001) %MON dynstat_salt_max             =   3.6601160772400E+01
+(PID.TID 0000.0001) %MON dynstat_salt_min             =   3.3082402903474E+01
+(PID.TID 0000.0001) %MON dynstat_salt_mean            =   3.4483935951541E+01
+(PID.TID 0000.0001) %MON dynstat_salt_sd              =   1.9646577404095E-01
+(PID.TID 0000.0001) %MON dynstat_salt_del2            =   1.1576659921708E-03
+(PID.TID 0000.0001) %MON forcing_qnet_max             =   6.8330323791504E+01
+(PID.TID 0000.0001) %MON forcing_qnet_min             =  -2.1277729593913E+02
+(PID.TID 0000.0001) %MON forcing_qnet_mean            =  -1.2092838533496E+02
+(PID.TID 0000.0001) %MON forcing_qnet_sd              =   4.4621997369695E+01
+(PID.TID 0000.0001) %MON forcing_qnet_del2            =   8.3603312595688E-01
+(PID.TID 0000.0001) %MON forcing_qsw_max              =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON forcing_qsw_min              =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON forcing_qsw_mean             =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON forcing_qsw_sd               =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON forcing_qsw_del2             =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON forcing_empmr_max            =   2.5141471127199E-05
+(PID.TID 0000.0001) %MON forcing_empmr_min            =  -3.9761445691511E-05
+(PID.TID 0000.0001) %MON forcing_empmr_mean           =  -9.3236499820974E-06
+(PID.TID 0000.0001) %MON forcing_empmr_sd             =   1.0249687273683E-05
+(PID.TID 0000.0001) %MON forcing_empmr_del2           =   9.8755541425843E-08
+(PID.TID 0000.0001) %MON forcing_fu_max               =   2.1201943308115E-01
+(PID.TID 0000.0001) %MON forcing_fu_min               =  -9.0949111431837E-02
+(PID.TID 0000.0001) %MON forcing_fu_mean              =   7.6005340534540E-02
+(PID.TID 0000.0001) %MON forcing_fu_sd                =   7.1251205601334E-02
+(PID.TID 0000.0001) %MON forcing_fu_del2              =   5.5216683859400E-04
+(PID.TID 0000.0001) %MON forcing_fv_max               =   1.5087231919169E-01
+(PID.TID 0000.0001) %MON forcing_fv_min               =  -7.6163741697868E-02
+(PID.TID 0000.0001) %MON forcing_fv_mean              =  -1.9533531799024E-02
+(PID.TID 0000.0001) %MON forcing_fv_sd                =   3.3549641941976E-02
+(PID.TID 0000.0001) %MON forcing_fv_del2              =   3.7565688124801E-04
+(PID.TID 0000.0001) %MON trAdv_CFL_u_max              =   8.3734380919868E-02
+(PID.TID 0000.0001) %MON trAdv_CFL_v_max              =   1.9400977256355E-02
+(PID.TID 0000.0001) %MON trAdv_CFL_w_max              =   6.4038758935331E-02
+(PID.TID 0000.0001) %MON advcfl_uvel_max              =   3.3677281265160E-02
+(PID.TID 0000.0001) %MON advcfl_vvel_max              =   1.7895751022576E-02
+(PID.TID 0000.0001) %MON advcfl_wvel_max              =   1.6791664779384E-02
+(PID.TID 0000.0001) %MON advcfl_W_hf_max              =   1.8026346013162E-02
+(PID.TID 0000.0001) %MON pe_b_mean                    =   8.5371721839429E-04
+(PID.TID 0000.0001) %MON ke_max                       =   9.2836853228384E-03
+(PID.TID 0000.0001) %MON ke_mean                      =   1.6201167056061E-04
+(PID.TID 0000.0001) %MON ke_vol                       =   1.2769337095763E+17
+(PID.TID 0000.0001) %MON vort_r_min                   =  -4.7734233399894E-07
+(PID.TID 0000.0001) %MON vort_r_max                   =   7.0506910459598E-07
+(PID.TID 0000.0001) %MON vort_a_mean                  =  -1.0457492596515E-04
+(PID.TID 0000.0001) %MON vort_a_sd                    =   2.1292637161886E-05
+(PID.TID 0000.0001) %MON vort_p_mean                  =  -1.2574624373134E-04
+(PID.TID 0000.0001) %MON vort_p_sd                    =   1.1183801627528E-04
+(PID.TID 0000.0001) %MON surfExpan_theta_mean         =   2.6874756579119E-07
+(PID.TID 0000.0001) %MON surfExpan_salt_mean          =   1.0981311502989E-07
+(PID.TID 0000.0001) // =======================================================
+(PID.TID 0000.0001) // End MONITOR dynamic field statistics
+(PID.TID 0000.0001) // =======================================================
+(PID.TID 0000.0001) // =======================================================
+(PID.TID 0000.0001) // Begin OBCS MONITOR field statistics
+(PID.TID 0000.0001) // =======================================================
+(PID.TID 0000.0001) %MON obc_E_uVel_max               =   8.3963031073411E-02
+(PID.TID 0000.0001) %MON obc_E_uVel_min               =  -6.0615630447865E-02
+(PID.TID 0000.0001) %MON obc_E_uVel_mean              =   7.3628256725119E-03
+(PID.TID 0000.0001) %MON obc_E_uVel_sd                =   1.4301519717685E-02
+(PID.TID 0000.0001) %MON obc_E_uVel_Int               =   1.2623276493204E+08
+(PID.TID 0000.0001) %MON obc_W_uVel_max               =   5.9798991183440E-02
+(PID.TID 0000.0001) %MON obc_W_uVel_min               =  -2.5731079528729E-02
+(PID.TID 0000.0001) %MON obc_W_uVel_mean              =   7.0149129459912E-03
+(PID.TID 0000.0001) %MON obc_W_uVel_sd                =   1.1111732089572E-02
+(PID.TID 0000.0001) %MON obc_W_uVel_Int               =   1.3110367713427E+08
+(PID.TID 0000.0001) %MON obc_N_vVel_max               =   4.7361894200246E-02
+(PID.TID 0000.0001) %MON obc_N_vVel_min               =  -7.0558022459348E-02
+(PID.TID 0000.0001) %MON obc_N_vVel_mean              =   1.6170427400003E-04
+(PID.TID 0000.0001) %MON obc_N_vVel_sd                =   6.4389177929887E-03
+(PID.TID 0000.0001) %MON obc_N_vVel_Int               =   4.7272381147091E+06
+(PID.TID 0000.0001) %MON obc_E_theta_max              =   1.9227046585083E+01
+(PID.TID 0000.0001) %MON obc_E_theta_min              =  -1.6256567557653E+00
+(PID.TID 0000.0001) %MON obc_E_theta_mean             =   1.9094554967779E+00
+(PID.TID 0000.0001) %MON obc_E_theta_sd               =   2.9661690420752E+00
+(PID.TID 0000.0001) %MON obc_W_theta_max              =   2.1445012919108E+01
+(PID.TID 0000.0001) %MON obc_W_theta_min              =  -1.4419272979101E+00
+(PID.TID 0000.0001) %MON obc_W_theta_mean             =   2.4658360810169E+00
+(PID.TID 0000.0001) %MON obc_W_theta_sd               =   2.9603162977268E+00
+(PID.TID 0000.0001) %MON obc_N_theta_max              =   2.4014411290487E+01
+(PID.TID 0000.0001) %MON obc_N_theta_min              =  -6.3142867485682E-01
+(PID.TID 0000.0001) %MON obc_N_theta_mean             =   4.8714445467659E+00
+(PID.TID 0000.0001) %MON obc_N_theta_sd               =   4.7027078335556E+00
+(PID.TID 0000.0001) // =======================================================
+(PID.TID 0000.0001) // End OBCS MONITOR field statistics
+(PID.TID 0000.0001) // =======================================================
+(PID.TID 0000.0001) // =======================================================
+(PID.TID 0000.0001) // Begin MONITOR ptracer field statistics
+(PID.TID 0000.0001) // =======================================================
+(PID.TID 0000.0001) %MON trcstat_ptracer01_max        =   2.3591401654397E+00
+(PID.TID 0000.0001) %MON trcstat_ptracer01_min        =   1.9367271042752E+00
+(PID.TID 0000.0001) %MON trcstat_ptracer01_mean       =   2.2425272764841E+00
+(PID.TID 0000.0001) %MON trcstat_ptracer01_sd         =   7.5988388933325E-02
+(PID.TID 0000.0001) %MON trcstat_ptracer01_del2       =   1.0677384839569E-04
+(PID.TID 0000.0001) %MON trcstat_ptracer02_max        =   2.4116832757561E+00
+(PID.TID 0000.0001) %MON trcstat_ptracer02_min        =   2.1899799305598E+00
+(PID.TID 0000.0001) %MON trcstat_ptracer02_mean       =   2.3520454966805E+00
+(PID.TID 0000.0001) %MON trcstat_ptracer02_sd         =   3.5090900751946E-02
+(PID.TID 0000.0001) %MON trcstat_ptracer02_del2       =   8.0623943309462E-05
+(PID.TID 0000.0001) %MON trcstat_ptracer03_max        =   2.7654707905471E-03
+(PID.TID 0000.0001) %MON trcstat_ptracer03_min        =   4.7350030617099E-05
+(PID.TID 0000.0001) %MON trcstat_ptracer03_mean       =   2.0556610772909E-03
+(PID.TID 0000.0001) %MON trcstat_ptracer03_sd         =   5.0325958484516E-04
+(PID.TID 0000.0001) %MON trcstat_ptracer03_del2       =   6.7007347325832E-07
+(PID.TID 0000.0001) %MON trcstat_ptracer04_max        =   2.5734372514985E-04
+(PID.TID 0000.0001) %MON trcstat_ptracer04_min        =  -7.5081759287795E-07
+(PID.TID 0000.0001) %MON trcstat_ptracer04_mean       =   6.2166640460367E-06
+(PID.TID 0000.0001) %MON trcstat_ptracer04_sd         =   2.6176363994778E-05
+(PID.TID 0000.0001) %MON trcstat_ptracer04_del2       =   1.3445374783806E-07
+(PID.TID 0000.0001) %MON trcstat_ptracer05_max        =   3.8365288067711E-01
+(PID.TID 0000.0001) %MON trcstat_ptracer05_min        =   8.2401869335757E-02
+(PID.TID 0000.0001) %MON trcstat_ptracer05_mean       =   2.1412908339770E-01
+(PID.TID 0000.0001) %MON trcstat_ptracer05_sd         =   4.3048525270866E-02
+(PID.TID 0000.0001) %MON trcstat_ptracer05_del2       =   1.1876374153122E-04
+(PID.TID 0000.0001) // =======================================================
+(PID.TID 0000.0001) // End MONITOR ptracer field statistics
+(PID.TID 0000.0001) // =======================================================
+ EXTERNAL_FIELDS_LOAD,         2 : iP,iLd,i0,i1=   12    1   12    1 ; Wght=  0.4666666667  0.5333333333
+ DIC_FIELDS_LOAD,         2 : iP,iLd,i0,i1=   12    1   12    1 ; Wght=  0.4666666667  0.5333333333
+ OBCS_FIELDS_LOAD,         3 : iP,iLd,i0,i1=   12    1   12    1 ; Wght=  0.4500000000  0.5500000000
+ cg2d: Sum(rhs),rhsMax =   3.69813004132884E+01  9.89366639092217E-01
+(PID.TID 0000.0001)      cg2d_init_res =   5.67526980566402E-02
+(PID.TID 0000.0001)      cg2d_iters(min,last) =      -1      79
+(PID.TID 0000.0001)      cg2d_last_res =   6.56260092680578E-14
+(PID.TID 0000.0001) // =======================================================
+(PID.TID 0000.0001) // Begin MONITOR dynamic field statistics
+(PID.TID 0000.0001) // =======================================================
+(PID.TID 0000.0001) %MON time_tsnumber                =                     3
+(PID.TID 0000.0001) %MON time_secondsf                =   1.2960000000000E+05
+(PID.TID 0000.0001) %MON dynstat_eta_max              =   4.6213989059191E-01
+(PID.TID 0000.0001) %MON dynstat_eta_min              =  -1.5125833035862E+00
+(PID.TID 0000.0001) %MON dynstat_eta_mean             =  -5.1715888372412E-01
+(PID.TID 0000.0001) %MON dynstat_eta_sd               =   6.0875958600885E-01
+(PID.TID 0000.0001) %MON dynstat_eta_del2             =   2.3647144329516E-03
+(PID.TID 0000.0001) %MON dynstat_uvel_max             =   1.3062261868045E-01
+(PID.TID 0000.0001) %MON dynstat_uvel_min             =  -6.0539411753416E-02
+(PID.TID 0000.0001) %MON dynstat_uvel_mean            =   7.5079985726029E-03
+(PID.TID 0000.0001) %MON dynstat_uvel_sd              =   1.4636773745285E-02
+(PID.TID 0000.0001) %MON dynstat_uvel_del2            =   1.6215293796818E-04
+(PID.TID 0000.0001) %MON dynstat_vvel_max             =   1.2955742043983E-01
+(PID.TID 0000.0001) %MON dynstat_vvel_min             =  -8.8542959561069E-02
+(PID.TID 0000.0001) %MON dynstat_vvel_mean            =   9.5026324011132E-04
+(PID.TID 0000.0001) %MON dynstat_vvel_sd              =   8.4359882216886E-03
+(PID.TID 0000.0001) %MON dynstat_vvel_del2            =   1.0627935286095E-04
+(PID.TID 0000.0001) %MON dynstat_wvel_max             =   5.4890354380308E-05
+(PID.TID 0000.0001) %MON dynstat_wvel_min             =  -1.4180007284655E-04
+(PID.TID 0000.0001) %MON dynstat_wvel_mean            =  -2.4323028399391E-07
+(PID.TID 0000.0001) %MON dynstat_wvel_sd              =   5.4605074086474E-06
+(PID.TID 0000.0001) %MON dynstat_wvel_del2            =   1.4055591218984E-07
+(PID.TID 0000.0001) %MON dynstat_theta_max            =   2.4207205522541E+01
+(PID.TID 0000.0001) %MON dynstat_theta_min            =  -2.8961461882647E+00
+(PID.TID 0000.0001) %MON dynstat_theta_mean           =   2.3225679277077E+00
+(PID.TID 0000.0001) %MON dynstat_theta_sd             =   3.2129999380289E+00
+(PID.TID 0000.0001) %MON dynstat_theta_del2           =   6.6377896898328E-03
+(PID.TID 0000.0001) %MON dynstat_salt_max             =   3.6601334730652E+01
+(PID.TID 0000.0001) %MON dynstat_salt_min             =   3.3081176678740E+01
+(PID.TID 0000.0001) %MON dynstat_salt_mean            =   3.4483936926475E+01
+(PID.TID 0000.0001) %MON dynstat_salt_sd              =   1.9647408903632E-01
+(PID.TID 0000.0001) %MON dynstat_salt_del2            =   1.1570457958611E-03
+(PID.TID 0000.0001) %MON forcing_qnet_max             =   6.8365893554688E+01
+(PID.TID 0000.0001) %MON forcing_qnet_min             =  -2.1235058186849E+02
+(PID.TID 0000.0001) %MON forcing_qnet_mean            =  -1.2065349012308E+02
+(PID.TID 0000.0001) %MON forcing_qnet_sd              =   4.4471574191313E+01
+(PID.TID 0000.0001) %MON forcing_qnet_del2            =   8.3718643192961E-01
+(PID.TID 0000.0001) %MON forcing_qsw_max              =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON forcing_qsw_min              =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON forcing_qsw_mean             =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON forcing_qsw_sd               =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON forcing_qsw_del2             =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON forcing_empmr_max            =   2.5141471127199E-05
+(PID.TID 0000.0001) %MON forcing_empmr_min            =  -3.9761445691511E-05
+(PID.TID 0000.0001) %MON forcing_empmr_mean           =  -9.3236499820974E-06
+(PID.TID 0000.0001) %MON forcing_empmr_sd             =   1.0249687273683E-05
+(PID.TID 0000.0001) %MON forcing_empmr_del2           =   9.8755541425843E-08
+(PID.TID 0000.0001) %MON forcing_fu_max               =   2.1214843690395E-01
+(PID.TID 0000.0001) %MON forcing_fu_min               =  -9.1365413367748E-02
+(PID.TID 0000.0001) %MON forcing_fu_mean              =   7.5904591616040E-02
+(PID.TID 0000.0001) %MON forcing_fu_sd                =   7.1286791719395E-02
+(PID.TID 0000.0001) %MON forcing_fu_del2              =   5.5309620030393E-04
+(PID.TID 0000.0001) %MON forcing_fv_max               =   1.5056358873844E-01
+(PID.TID 0000.0001) %MON forcing_fv_min               =  -7.6133539776007E-02
+(PID.TID 0000.0001) %MON forcing_fv_mean              =  -1.9474492909428E-02
+(PID.TID 0000.0001) %MON forcing_fv_sd                =   3.3536075112207E-02
+(PID.TID 0000.0001) %MON forcing_fv_del2              =   3.7509025945884E-04
+(PID.TID 0000.0001) %MON trAdv_CFL_u_max              =   8.3935653812237E-02
+(PID.TID 0000.0001) %MON trAdv_CFL_v_max              =   2.0000272635172E-02
+(PID.TID 0000.0001) %MON trAdv_CFL_w_max              =   6.3877407297722E-02
+(PID.TID 0000.0001) %MON advcfl_uvel_max              =   3.3731911478655E-02
+(PID.TID 0000.0001) %MON advcfl_vvel_max              =   1.7899327246398E-02
+(PID.TID 0000.0001) %MON advcfl_wvel_max              =   1.6782912731427E-02
+(PID.TID 0000.0001) %MON advcfl_W_hf_max              =   1.8016950432267E-02
+(PID.TID 0000.0001) %MON pe_b_mean                    =   8.5967060596595E-04
+(PID.TID 0000.0001) %MON ke_max                       =   9.3049026000510E-03
+(PID.TID 0000.0001) %MON ke_mean                      =   1.6238894530997E-04
+(PID.TID 0000.0001) %MON ke_vol                       =   1.2769337095763E+17
+(PID.TID 0000.0001) %MON vort_r_min                   =  -4.7703855977354E-07
+(PID.TID 0000.0001) %MON vort_r_max                   =   7.0514402478036E-07
+(PID.TID 0000.0001) %MON vort_a_mean                  =  -1.0457492545002E-04
+(PID.TID 0000.0001) %MON vort_a_sd                    =   2.1292658560979E-05
+(PID.TID 0000.0001) %MON vort_p_mean                  =  -1.2574624311192E-04
+(PID.TID 0000.0001) %MON vort_p_sd                    =   1.1183803880499E-04
+(PID.TID 0000.0001) %MON surfExpan_theta_mean         =   4.3299011362969E-07
+(PID.TID 0000.0001) %MON surfExpan_salt_mean          =   1.1235984607563E-07
+(PID.TID 0000.0001) // =======================================================
+(PID.TID 0000.0001) // End MONITOR dynamic field statistics
+(PID.TID 0000.0001) // =======================================================
+(PID.TID 0000.0001) // =======================================================
+(PID.TID 0000.0001) // Begin OBCS MONITOR field statistics
+(PID.TID 0000.0001) // =======================================================
+(PID.TID 0000.0001) %MON obc_E_uVel_max               =   8.3828638494015E-02
+(PID.TID 0000.0001) %MON obc_E_uVel_min               =  -6.0539411753416E-02
+(PID.TID 0000.0001) %MON obc_E_uVel_mean              =   7.3609929463100E-03
+(PID.TID 0000.0001) %MON obc_E_uVel_sd                =   1.4302160552751E-02
+(PID.TID 0000.0001) %MON obc_E_uVel_Int               =   1.2620134355850E+08
+(PID.TID 0000.0001) %MON obc_W_uVel_max               =   5.9847029671073E-02
+(PID.TID 0000.0001) %MON obc_W_uVel_min               =  -2.5733459647745E-02
+(PID.TID 0000.0001) %MON obc_W_uVel_mean              =   7.0105385545017E-03
+(PID.TID 0000.0001) %MON obc_W_uVel_sd                =   1.1115697883587E-02
+(PID.TID 0000.0001) %MON obc_W_uVel_Int               =   1.3102192290383E+08
+(PID.TID 0000.0001) %MON obc_N_vVel_max               =   4.7308485023677E-02
+(PID.TID 0000.0001) %MON obc_N_vVel_min               =  -7.0609619468451E-02
+(PID.TID 0000.0001) %MON obc_N_vVel_mean              =   1.5994407436435E-04
+(PID.TID 0000.0001) %MON obc_N_vVel_sd                =   6.4375643639680E-03
+(PID.TID 0000.0001) %MON obc_N_vVel_Int               =   4.6757807066797E+06
+(PID.TID 0000.0001) %MON obc_E_theta_max              =   1.9248522186279E+01
+(PID.TID 0000.0001) %MON obc_E_theta_min              =  -1.6170032203197E+00
+(PID.TID 0000.0001) %MON obc_E_theta_mean             =   1.9094443592632E+00
+(PID.TID 0000.0001) %MON obc_E_theta_sd               =   2.9666428623953E+00
+(PID.TID 0000.0001) %MON obc_W_theta_max              =   2.1465204048157E+01
+(PID.TID 0000.0001) %MON obc_W_theta_min              =  -1.4420095145702E+00
+(PID.TID 0000.0001) %MON obc_W_theta_mean             =   2.4660533188974E+00
+(PID.TID 0000.0001) %MON obc_W_theta_sd               =   2.9608568965157E+00
+(PID.TID 0000.0001) %MON obc_N_theta_max              =   2.4035299301147E+01
+(PID.TID 0000.0001) %MON obc_N_theta_min              =  -6.3193125426769E-01
+(PID.TID 0000.0001) %MON obc_N_theta_mean             =   4.8716564394589E+00
+(PID.TID 0000.0001) %MON obc_N_theta_sd               =   4.7035895383254E+00
+(PID.TID 0000.0001) // =======================================================
+(PID.TID 0000.0001) // End OBCS MONITOR field statistics
+(PID.TID 0000.0001) // =======================================================
+(PID.TID 0000.0001) // =======================================================
+(PID.TID 0000.0001) // Begin MONITOR ptracer field statistics
+(PID.TID 0000.0001) // =======================================================
+(PID.TID 0000.0001) %MON trcstat_ptracer01_max        =   2.3591408214335E+00
+(PID.TID 0000.0001) %MON trcstat_ptracer01_min        =   1.9367055709494E+00
+(PID.TID 0000.0001) %MON trcstat_ptracer01_mean       =   2.2425258753527E+00
+(PID.TID 0000.0001) %MON trcstat_ptracer01_sd         =   7.5991732806562E-02
+(PID.TID 0000.0001) %MON trcstat_ptracer01_del2       =   1.0670249166970E-04
+(PID.TID 0000.0001) %MON trcstat_ptracer02_max        =   2.4116838423798E+00
+(PID.TID 0000.0001) %MON trcstat_ptracer02_min        =   2.1900145897440E+00
+(PID.TID 0000.0001) %MON trcstat_ptracer02_mean       =   2.3520458155540E+00
+(PID.TID 0000.0001) %MON trcstat_ptracer02_sd         =   3.5090709956612E-02
+(PID.TID 0000.0001) %MON trcstat_ptracer02_del2       =   8.0618223796290E-05
+(PID.TID 0000.0001) %MON trcstat_ptracer03_max        =   2.7654743177706E-03
+(PID.TID 0000.0001) %MON trcstat_ptracer03_min        =   4.7305272335174E-05
+(PID.TID 0000.0001) %MON trcstat_ptracer03_mean       =   2.0556517479929E-03
+(PID.TID 0000.0001) %MON trcstat_ptracer03_sd         =   5.0327566434960E-04
+(PID.TID 0000.0001) %MON trcstat_ptracer03_del2       =   6.6983504437431E-07
+(PID.TID 0000.0001) %MON trcstat_ptracer04_max        =   2.5768558511593E-04
+(PID.TID 0000.0001) %MON trcstat_ptracer04_min        =  -7.5456580951666E-07
+(PID.TID 0000.0001) %MON trcstat_ptracer04_mean       =   6.2248777377114E-06
+(PID.TID 0000.0001) %MON trcstat_ptracer04_sd         =   2.6216452075251E-05
+(PID.TID 0000.0001) %MON trcstat_ptracer04_del2       =   1.3439656196080E-07
+(PID.TID 0000.0001) %MON trcstat_ptracer05_max        =   3.8368924867501E-01
+(PID.TID 0000.0001) %MON trcstat_ptracer05_min        =   8.2409939169764E-02
+(PID.TID 0000.0001) %MON trcstat_ptracer05_mean       =   2.1412723897038E-01
+(PID.TID 0000.0001) %MON trcstat_ptracer05_sd         =   4.3046032949387E-02
+(PID.TID 0000.0001) %MON trcstat_ptracer05_del2       =   1.1857347653469E-04
+(PID.TID 0000.0001) // =======================================================
+(PID.TID 0000.0001) // End MONITOR ptracer field statistics
+(PID.TID 0000.0001) // =======================================================
+ EXTERNAL_FIELDS_LOAD,         3 : iP,iLd,i0,i1=   12    1   12    1 ; Wght=  0.4500000000  0.5500000000
+ DIC_FIELDS_LOAD,         3 : iP,iLd,i0,i1=   12    1   12    1 ; Wght=  0.4500000000  0.5500000000
+ OBCS_FIELDS_LOAD,         4 : iP,iLd,i0,i1=   12    1   12    1 ; Wght=  0.4333333333  0.5666666667
+ cg2d: Sum(rhs),rhsMax =   3.69444848326875E+01  9.90008392871430E-01
+(PID.TID 0000.0001)      cg2d_init_res =   3.68743323783192E-02
+(PID.TID 0000.0001)      cg2d_iters(min,last) =      -1      77
+(PID.TID 0000.0001)      cg2d_last_res =   9.79870323355741E-14
+(PID.TID 0000.0001) // =======================================================
+(PID.TID 0000.0001) // Begin MONITOR dynamic field statistics
+(PID.TID 0000.0001) // =======================================================
+(PID.TID 0000.0001) %MON time_tsnumber                =                     4
+(PID.TID 0000.0001) %MON time_secondsf                =   1.7280000000000E+05
+(PID.TID 0000.0001) %MON dynstat_eta_max              =   4.6395963974077E-01
+(PID.TID 0000.0001) %MON dynstat_eta_min              =  -1.5149075975102E+00
+(PID.TID 0000.0001) %MON dynstat_eta_mean             =  -5.1697916405877E-01
+(PID.TID 0000.0001) %MON dynstat_eta_sd               =   6.1240461071870E-01
+(PID.TID 0000.0001) %MON dynstat_eta_del2             =   2.3695017619383E-03
+(PID.TID 0000.0001) %MON dynstat_uvel_max             =   1.3086193662600E-01
+(PID.TID 0000.0001) %MON dynstat_uvel_min             =  -6.0463193058968E-02
+(PID.TID 0000.0001) %MON dynstat_uvel_mean            =   7.5291434462894E-03
+(PID.TID 0000.0001) %MON dynstat_uvel_sd              =   1.4646053100495E-02
+(PID.TID 0000.0001) %MON dynstat_uvel_del2            =   1.6204374780074E-04
+(PID.TID 0000.0001) %MON dynstat_vvel_max             =   1.2962069131972E-01
+(PID.TID 0000.0001) %MON dynstat_vvel_min             =  -8.8554900694422E-02
+(PID.TID 0000.0001) %MON dynstat_vvel_mean            =   9.5300989732081E-04
+(PID.TID 0000.0001) %MON dynstat_vvel_sd              =   8.4439077426228E-03
+(PID.TID 0000.0001) %MON dynstat_vvel_del2            =   1.0624956418926E-04
+(PID.TID 0000.0001) %MON dynstat_wvel_max             =   5.5001242850584E-05
+(PID.TID 0000.0001) %MON dynstat_wvel_min             =  -1.4149847831267E-04
+(PID.TID 0000.0001) %MON dynstat_wvel_mean            =  -2.4322672388720E-07
+(PID.TID 0000.0001) %MON dynstat_wvel_sd              =   5.4499461582882E-06
+(PID.TID 0000.0001) %MON dynstat_wvel_del2            =   1.4051527256648E-07
+(PID.TID 0000.0001) %MON dynstat_theta_max            =   2.4223666545653E+01
+(PID.TID 0000.0001) %MON dynstat_theta_min            =  -2.8962364234641E+00
+(PID.TID 0000.0001) %MON dynstat_theta_mean           =   2.3228801417064E+00
+(PID.TID 0000.0001) %MON dynstat_theta_sd             =   3.2138692979141E+00
+(PID.TID 0000.0001) %MON dynstat_theta_del2           =   6.6350188422182E-03
+(PID.TID 0000.0001) %MON dynstat_salt_max             =   3.6601515138275E+01
+(PID.TID 0000.0001) %MON dynstat_salt_min             =   3.3079951761183E+01
+(PID.TID 0000.0001) %MON dynstat_salt_mean            =   3.4483937899956E+01
+(PID.TID 0000.0001) %MON dynstat_salt_sd              =   1.9648308320519E-01
+(PID.TID 0000.0001) %MON dynstat_salt_del2            =   1.1564384485617E-03
+(PID.TID 0000.0001) %MON forcing_qnet_max             =   6.8401463317871E+01
+(PID.TID 0000.0001) %MON forcing_qnet_min             =  -2.1192386779785E+02
+(PID.TID 0000.0001) %MON forcing_qnet_mean            =  -1.2037859491120E+02
+(PID.TID 0000.0001) %MON forcing_qnet_sd              =   4.4324698931511E+01
+(PID.TID 0000.0001) %MON forcing_qnet_del2            =   8.3838936492374E-01
+(PID.TID 0000.0001) %MON forcing_qsw_max              =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON forcing_qsw_min              =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON forcing_qsw_mean             =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON forcing_qsw_sd               =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON forcing_qsw_del2             =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON forcing_empmr_max            =   2.5141471127199E-05
+(PID.TID 0000.0001) %MON forcing_empmr_min            =  -3.9761445691511E-05
+(PID.TID 0000.0001) %MON forcing_empmr_mean           =  -9.3236499820974E-06
+(PID.TID 0000.0001) %MON forcing_empmr_sd             =   1.0249687273683E-05
+(PID.TID 0000.0001) %MON forcing_empmr_del2           =   9.8755541425843E-08
+(PID.TID 0000.0001) %MON forcing_fu_max               =   2.1227744072676E-01
+(PID.TID 0000.0001) %MON forcing_fu_min               =  -9.1781715303659E-02
+(PID.TID 0000.0001) %MON forcing_fu_mean              =   7.5803842697540E-02
+(PID.TID 0000.0001) %MON forcing_fu_sd                =   7.1323156655177E-02
+(PID.TID 0000.0001) %MON forcing_fu_del2              =   5.5407006621995E-04
+(PID.TID 0000.0001) %MON forcing_fv_max               =   1.5025485828519E-01
+(PID.TID 0000.0001) %MON forcing_fv_min               =  -7.6103337854147E-02
+(PID.TID 0000.0001) %MON forcing_fv_mean              =  -1.9415454019831E-02
+(PID.TID 0000.0001) %MON forcing_fv_sd                =   3.3523226784915E-02
+(PID.TID 0000.0001) %MON forcing_fv_del2              =   3.7456042910420E-04
+(PID.TID 0000.0001) %MON trAdv_CFL_u_max              =   8.4584073989630E-02
+(PID.TID 0000.0001) %MON trAdv_CFL_v_max              =   2.0953896428465E-02
+(PID.TID 0000.0001) %MON trAdv_CFL_w_max              =   6.3706421403378E-02
+(PID.TID 0000.0001) %MON advcfl_uvel_max              =   3.3793712810127E-02
+(PID.TID 0000.0001) %MON advcfl_vvel_max              =   1.7908068591976E-02
+(PID.TID 0000.0001) %MON advcfl_wvel_max              =   1.6747217159198E-02
+(PID.TID 0000.0001) %MON advcfl_W_hf_max              =   1.7978630185610E-02
+(PID.TID 0000.0001) %MON pe_b_mean                    =   8.6541751879117E-04
+(PID.TID 0000.0001) %MON ke_max                       =   9.3301988778789E-03
+(PID.TID 0000.0001) %MON ke_mean                      =   1.6274233025701E-04
+(PID.TID 0000.0001) %MON ke_vol                       =   1.2769337095763E+17
+(PID.TID 0000.0001) %MON vort_r_min                   =  -4.7669670741190E-07
+(PID.TID 0000.0001) %MON vort_r_max                   =   7.0557709425580E-07
+(PID.TID 0000.0001) %MON vort_a_mean                  =  -1.0457492493489E-04
+(PID.TID 0000.0001) %MON vort_a_sd                    =   2.1292671158631E-05
+(PID.TID 0000.0001) %MON vort_p_mean                  =  -1.2574624249250E-04
+(PID.TID 0000.0001) %MON vort_p_sd                    =   1.1183804529477E-04
+(PID.TID 0000.0001) %MON surfExpan_theta_mean         =   4.7796200915453E-07
+(PID.TID 0000.0001) %MON surfExpan_salt_mean          =   1.2282832566760E-07
+(PID.TID 0000.0001) // =======================================================
+(PID.TID 0000.0001) // End MONITOR dynamic field statistics
+(PID.TID 0000.0001) // =======================================================
+(PID.TID 0000.0001) // =======================================================
+(PID.TID 0000.0001) // Begin OBCS MONITOR field statistics
+(PID.TID 0000.0001) // =======================================================
+(PID.TID 0000.0001) %MON obc_E_uVel_max               =   8.3694245914618E-02
+(PID.TID 0000.0001) %MON obc_E_uVel_min               =  -6.0463193058968E-02
+(PID.TID 0000.0001) %MON obc_E_uVel_mean              =   7.3591602201081E-03
+(PID.TID 0000.0001) %MON obc_E_uVel_sd                =   1.4302813286498E-02
+(PID.TID 0000.0001) %MON obc_E_uVel_Int               =   1.2616992218495E+08
+(PID.TID 0000.0001) %MON obc_W_uVel_max               =   5.9895068158706E-02
+(PID.TID 0000.0001) %MON obc_W_uVel_min               =  -2.5735839766761E-02
+(PID.TID 0000.0001) %MON obc_W_uVel_mean              =   7.0061641630121E-03
+(PID.TID 0000.0001) %MON obc_W_uVel_sd                =   1.1119676645741E-02
+(PID.TID 0000.0001) %MON obc_W_uVel_Int               =   1.3094016867339E+08
+(PID.TID 0000.0001) %MON obc_N_vVel_max               =   4.7255075847109E-02
+(PID.TID 0000.0001) %MON obc_N_vVel_min               =  -7.0661216477553E-02
+(PID.TID 0000.0001) %MON obc_N_vVel_mean              =   1.5818387472866E-04
+(PID.TID 0000.0001) %MON obc_N_vVel_sd                =   6.4362274787566E-03
+(PID.TID 0000.0001) %MON obc_N_vVel_Int               =   4.6243232986502E+06
+(PID.TID 0000.0001) %MON obc_E_theta_max              =   1.9269997787476E+01
+(PID.TID 0000.0001) %MON obc_E_theta_min              =  -1.6083496848742E+00
+(PID.TID 0000.0001) %MON obc_E_theta_mean             =   1.9094332217485E+00
+(PID.TID 0000.0001) %MON obc_E_theta_sd               =   2.9671180827308E+00
+(PID.TID 0000.0001) %MON obc_W_theta_max              =   2.1485395177205E+01
+(PID.TID 0000.0001) %MON obc_W_theta_min              =  -1.4420917312304E+00
+(PID.TID 0000.0001) %MON obc_W_theta_mean             =   2.4662705567779E+00
+(PID.TID 0000.0001) %MON obc_W_theta_sd               =   2.9613984222904E+00
+(PID.TID 0000.0001) %MON obc_N_theta_max              =   2.4056187311808E+01
+(PID.TID 0000.0001) %MON obc_N_theta_min              =  -6.3243383367856E-01
+(PID.TID 0000.0001) %MON obc_N_theta_mean             =   4.8718683321519E+00
+(PID.TID 0000.0001) %MON obc_N_theta_sd               =   4.7044721835460E+00
+(PID.TID 0000.0001) // =======================================================
+(PID.TID 0000.0001) // End OBCS MONITOR field statistics
+(PID.TID 0000.0001) // =======================================================
+(PID.TID 0000.0001) // =======================================================
+(PID.TID 0000.0001) // Begin MONITOR ptracer field statistics
+(PID.TID 0000.0001) // =======================================================
+(PID.TID 0000.0001) %MON trcstat_ptracer01_max        =   2.3591414669024E+00
+(PID.TID 0000.0001) %MON trcstat_ptracer01_min        =   1.9366840972159E+00
+(PID.TID 0000.0001) %MON trcstat_ptracer01_mean       =   2.2425244894660E+00
+(PID.TID 0000.0001) %MON trcstat_ptracer01_sd         =   7.5995026423712E-02
+(PID.TID 0000.0001) %MON trcstat_ptracer01_del2       =   1.0662688202066E-04
+(PID.TID 0000.0001) %MON trcstat_ptracer02_max        =   2.4116844083675E+00
+(PID.TID 0000.0001) %MON trcstat_ptracer02_min        =   2.1900507045915E+00
+(PID.TID 0000.0001) %MON trcstat_ptracer02_mean       =   2.3520461389860E+00
+(PID.TID 0000.0001) %MON trcstat_ptracer02_sd         =   3.5090502330770E-02
+(PID.TID 0000.0001) %MON trcstat_ptracer02_del2       =   8.0612156385816E-05
+(PID.TID 0000.0001) %MON trcstat_ptracer03_max        =   2.7654777774314E-03
+(PID.TID 0000.0001) %MON trcstat_ptracer03_min        =   4.7260823943134E-05
+(PID.TID 0000.0001) %MON trcstat_ptracer03_mean       =   2.0556425437223E-03
+(PID.TID 0000.0001) %MON trcstat_ptracer03_sd         =   5.0329136367624E-04
+(PID.TID 0000.0001) %MON trcstat_ptracer03_del2       =   6.6954418309516E-07
+(PID.TID 0000.0001) %MON trcstat_ptracer04_max        =   2.5801936011785E-04
+(PID.TID 0000.0001) %MON trcstat_ptracer04_min        =  -7.5838724074807E-07
+(PID.TID 0000.0001) %MON trcstat_ptracer04_mean       =   6.2330587770700E-06
+(PID.TID 0000.0001) %MON trcstat_ptracer04_sd         =   2.6256412055353E-05
+(PID.TID 0000.0001) %MON trcstat_ptracer04_del2       =   1.3432484291057E-07
+(PID.TID 0000.0001) %MON trcstat_ptracer05_max        =   3.8372724940548E-01
+(PID.TID 0000.0001) %MON trcstat_ptracer05_min        =   8.2416015768654E-02
+(PID.TID 0000.0001) %MON trcstat_ptracer05_mean       =   2.1412540377670E-01
+(PID.TID 0000.0001) %MON trcstat_ptracer05_sd         =   4.3043561864795E-02
+(PID.TID 0000.0001) %MON trcstat_ptracer05_del2       =   1.1837744056211E-04
+(PID.TID 0000.0001) // =======================================================
+(PID.TID 0000.0001) // End MONITOR ptracer field statistics
+(PID.TID 0000.0001) // =======================================================
+ EXTERNAL_FIELDS_LOAD,         4 : iP,iLd,i0,i1=   12    1   12    1 ; Wght=  0.4333333333  0.5666666667
+ DIC_FIELDS_LOAD,         4 : iP,iLd,i0,i1=   12    1   12    1 ; Wght=  0.4333333333  0.5666666667
+ OBCS_FIELDS_LOAD,         5 : iP,iLd,i0,i1=   12    1   12    1 ; Wght=  0.4166666667  0.5833333333
+ cg2d: Sum(rhs),rhsMax =   3.69076054258846E+01  9.90650485228004E-01
+(PID.TID 0000.0001)      cg2d_init_res =   2.70765733367530E-02
+(PID.TID 0000.0001)      cg2d_iters(min,last) =      -1      77
+(PID.TID 0000.0001)      cg2d_last_res =   7.96680707147545E-14
+(PID.TID 0000.0001) // =======================================================
+(PID.TID 0000.0001) // Begin MONITOR dynamic field statistics
+(PID.TID 0000.0001) // =======================================================
+(PID.TID 0000.0001) %MON time_tsnumber                =                     5
+(PID.TID 0000.0001) %MON time_secondsf                =   2.1600000000000E+05
+(PID.TID 0000.0001) %MON dynstat_eta_max              =   4.6742181670386E-01
+(PID.TID 0000.0001) %MON dynstat_eta_min              =  -1.5153341969223E+00
+(PID.TID 0000.0001) %MON dynstat_eta_mean             =  -5.1679805939112E-01
+(PID.TID 0000.0001) %MON dynstat_eta_sd               =   6.1516973521395E-01
+(PID.TID 0000.0001) %MON dynstat_eta_del2             =   2.3717076841684E-03
+(PID.TID 0000.0001) %MON dynstat_uvel_max             =   1.3110535878860E-01
+(PID.TID 0000.0001) %MON dynstat_uvel_min             =  -6.0386974364519E-02
+(PID.TID 0000.0001) %MON dynstat_uvel_mean            =   7.5431447413553E-03
+(PID.TID 0000.0001) %MON dynstat_uvel_sd              =   1.4657547896250E-02
+(PID.TID 0000.0001) %MON dynstat_uvel_del2            =   1.6193726470229E-04
+(PID.TID 0000.0001) %MON dynstat_vvel_max             =   1.2970860601232E-01
+(PID.TID 0000.0001) %MON dynstat_vvel_min             =  -8.8551055672804E-02
+(PID.TID 0000.0001) %MON dynstat_vvel_mean            =   9.4679719200852E-04
+(PID.TID 0000.0001) %MON dynstat_vvel_sd              =   8.4539789984647E-03
+(PID.TID 0000.0001) %MON dynstat_vvel_del2            =   1.0622004487125E-04
+(PID.TID 0000.0001) %MON dynstat_wvel_max             =   5.5082374388282E-05
+(PID.TID 0000.0001) %MON dynstat_wvel_min             =  -1.4119944512572E-04
+(PID.TID 0000.0001) %MON dynstat_wvel_mean            =  -2.4322316378049E-07
+(PID.TID 0000.0001) %MON dynstat_wvel_sd              =   5.4439293150668E-06
+(PID.TID 0000.0001) %MON dynstat_wvel_del2            =   1.4050122398176E-07
+(PID.TID 0000.0001) %MON dynstat_theta_max            =   2.4240184811830E+01
+(PID.TID 0000.0001) %MON dynstat_theta_min            =  -2.8963115492864E+00
+(PID.TID 0000.0001) %MON dynstat_theta_mean           =   2.3231921950168E+00
+(PID.TID 0000.0001) %MON dynstat_theta_sd             =   3.2147400722502E+00
+(PID.TID 0000.0001) %MON dynstat_theta_del2           =   6.6322877540844E-03
+(PID.TID 0000.0001) %MON dynstat_salt_max             =   3.6601696154099E+01
+(PID.TID 0000.0001) %MON dynstat_salt_min             =   3.3078734354698E+01
+(PID.TID 0000.0001) %MON dynstat_salt_mean            =   3.4483938694908E+01
+(PID.TID 0000.0001) %MON dynstat_salt_sd              =   1.9649189319730E-01
+(PID.TID 0000.0001) %MON dynstat_salt_del2            =   1.1558406489509E-03
+(PID.TID 0000.0001) %MON forcing_qnet_max             =   6.8437033081055E+01
+(PID.TID 0000.0001) %MON forcing_qnet_min             =  -2.1149715372721E+02
+(PID.TID 0000.0001) %MON forcing_qnet_mean            =  -1.2010369969932E+02
+(PID.TID 0000.0001) %MON forcing_qnet_sd              =   4.4181406974067E+01
+(PID.TID 0000.0001) %MON forcing_qnet_del2            =   8.3964171164123E-01
+(PID.TID 0000.0001) %MON forcing_qsw_max              =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON forcing_qsw_min              =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON forcing_qsw_mean             =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON forcing_qsw_sd               =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON forcing_qsw_del2             =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON forcing_empmr_max            =   2.5141471127199E-05
+(PID.TID 0000.0001) %MON forcing_empmr_min            =  -3.9761445691511E-05
+(PID.TID 0000.0001) %MON forcing_empmr_mean           =  -9.3236499820974E-06
+(PID.TID 0000.0001) %MON forcing_empmr_sd             =   1.0249687273683E-05
+(PID.TID 0000.0001) %MON forcing_empmr_del2           =   9.8755541425843E-08
+(PID.TID 0000.0001) %MON forcing_fu_max               =   2.1240644454956E-01
+(PID.TID 0000.0001) %MON forcing_fu_min               =  -9.2198017239571E-02
+(PID.TID 0000.0001) %MON forcing_fu_mean              =   7.5703093779040E-02
+(PID.TID 0000.0001) %MON forcing_fu_sd                =   7.1360299218031E-02
+(PID.TID 0000.0001) %MON forcing_fu_del2              =   5.5508820210295E-04
+(PID.TID 0000.0001) %MON forcing_fv_max               =   1.4994612783194E-01
+(PID.TID 0000.0001) %MON forcing_fv_min               =  -7.6073135932287E-02
+(PID.TID 0000.0001) %MON forcing_fv_mean              =  -1.9356415130235E-02
+(PID.TID 0000.0001) %MON forcing_fv_sd                =   3.3511097786534E-02
+(PID.TID 0000.0001) %MON forcing_fv_del2              =   3.7406754651863E-04
+(PID.TID 0000.0001) %MON trAdv_CFL_u_max              =   8.4795968536339E-02
+(PID.TID 0000.0001) %MON trAdv_CFL_v_max              =   2.1796445154491E-02
+(PID.TID 0000.0001) %MON trAdv_CFL_w_max              =   6.3006748820173E-02
+(PID.TID 0000.0001) %MON advcfl_uvel_max              =   3.3856574012296E-02
+(PID.TID 0000.0001) %MON advcfl_vvel_max              =   1.7920214664715E-02
+(PID.TID 0000.0001) %MON advcfl_wvel_max              =   1.6711824738168E-02
+(PID.TID 0000.0001) %MON advcfl_W_hf_max              =   1.7940635380680E-02
+(PID.TID 0000.0001) %MON pe_b_mean                    =   8.6973873149404E-04
+(PID.TID 0000.0001) %MON ke_max                       =   9.3563820626241E-03
+(PID.TID 0000.0001) %MON ke_mean                      =   1.6308471162421E-04
+(PID.TID 0000.0001) %MON ke_vol                       =   1.2769337095763E+17
+(PID.TID 0000.0001) %MON vort_r_min                   =  -4.7629354144137E-07
+(PID.TID 0000.0001) %MON vort_r_max                   =   7.0627187721182E-07
+(PID.TID 0000.0001) %MON vort_a_mean                  =  -1.0457492441976E-04
+(PID.TID 0000.0001) %MON vort_a_sd                    =   2.1292678749744E-05
+(PID.TID 0000.0001) %MON vort_p_mean                  =  -1.2574624187308E-04
+(PID.TID 0000.0001) %MON vort_p_sd                    =   1.1183804115107E-04
+(PID.TID 0000.0001) %MON surfExpan_theta_mean         =   4.0468429483687E-07
+(PID.TID 0000.0001) %MON surfExpan_salt_mean          =   1.3657719718631E-07
+(PID.TID 0000.0001) // =======================================================
+(PID.TID 0000.0001) // End MONITOR dynamic field statistics
+(PID.TID 0000.0001) // =======================================================
+(PID.TID 0000.0001) // =======================================================
+(PID.TID 0000.0001) // Begin OBCS MONITOR field statistics
+(PID.TID 0000.0001) // =======================================================
+(PID.TID 0000.0001) %MON obc_E_uVel_max               =   8.3559853335222E-02
+(PID.TID 0000.0001) %MON obc_E_uVel_min               =  -6.0386974364519E-02
+(PID.TID 0000.0001) %MON obc_E_uVel_mean              =   7.3573274939063E-03
+(PID.TID 0000.0001) %MON obc_E_uVel_sd                =   1.4303477917298E-02
+(PID.TID 0000.0001) %MON obc_E_uVel_Int               =   1.2613850081140E+08
+(PID.TID 0000.0001) %MON obc_W_uVel_max               =   5.9943106646339E-02
+(PID.TID 0000.0001) %MON obc_W_uVel_min               =  -2.5738219885776E-02
+(PID.TID 0000.0001) %MON obc_W_uVel_mean              =   7.0017897715226E-03
+(PID.TID 0000.0001) %MON obc_W_uVel_sd                =   1.1123668362120E-02
+(PID.TID 0000.0001) %MON obc_W_uVel_Int               =   1.3085841444295E+08
+(PID.TID 0000.0001) %MON obc_N_vVel_max               =   4.7201666670541E-02
+(PID.TID 0000.0001) %MON obc_N_vVel_min               =  -7.0712813486656E-02
+(PID.TID 0000.0001) %MON obc_N_vVel_mean              =   1.5642367509297E-04
+(PID.TID 0000.0001) %MON obc_N_vVel_sd                =   6.4349071476655E-03
+(PID.TID 0000.0001) %MON obc_N_vVel_Int               =   4.5728658906207E+06
+(PID.TID 0000.0001) %MON obc_E_theta_max              =   1.9291473388672E+01
+(PID.TID 0000.0001) %MON obc_E_theta_min              =  -1.5996961494287E+00
+(PID.TID 0000.0001) %MON obc_E_theta_mean             =   1.9094220842338E+00
+(PID.TID 0000.0001) %MON obc_E_theta_sd               =   2.9675947024092E+00
+(PID.TID 0000.0001) %MON obc_W_theta_max              =   2.1505586306254E+01
+(PID.TID 0000.0001) %MON obc_W_theta_min              =  -1.4421739478906E+00
+(PID.TID 0000.0001) %MON obc_W_theta_mean             =   2.4664877946583E+00
+(PID.TID 0000.0001) %MON obc_W_theta_sd               =   2.9619408745425E+00
+(PID.TID 0000.0001) %MON obc_N_theta_max              =   2.4077075322469E+01
+(PID.TID 0000.0001) %MON obc_N_theta_min              =  -6.3293641308943E-01
+(PID.TID 0000.0001) %MON obc_N_theta_mean             =   4.8720802248449E+00
+(PID.TID 0000.0001) %MON obc_N_theta_sd               =   4.7053557686883E+00
+(PID.TID 0000.0001) // =======================================================
+(PID.TID 0000.0001) // End OBCS MONITOR field statistics
+(PID.TID 0000.0001) // =======================================================
+(PID.TID 0000.0001) // =======================================================
+(PID.TID 0000.0001) // Begin MONITOR ptracer field statistics
+(PID.TID 0000.0001) // =======================================================
+(PID.TID 0000.0001) %MON trcstat_ptracer01_max        =   2.3591421088083E+00
+(PID.TID 0000.0001) %MON trcstat_ptracer01_min        =   1.9366626786061E+00
+(PID.TID 0000.0001) %MON trcstat_ptracer01_mean       =   2.2425230994738E+00
+(PID.TID 0000.0001) %MON trcstat_ptracer01_sd         =   7.5998323303088E-02
+(PID.TID 0000.0001) %MON trcstat_ptracer01_del2       =   1.0655128297286E-04
+(PID.TID 0000.0001) %MON trcstat_ptracer02_max        =   2.4116849837933E+00
+(PID.TID 0000.0001) %MON trcstat_ptracer02_min        =   2.1900885568449E+00
+(PID.TID 0000.0001) %MON trcstat_ptracer02_mean       =   2.3520464542823E+00
+(PID.TID 0000.0001) %MON trcstat_ptracer02_sd         =   3.5090302249086E-02
+(PID.TID 0000.0001) %MON trcstat_ptracer02_del2       =   8.0605667446540E-05
+(PID.TID 0000.0001) %MON trcstat_ptracer03_max        =   2.7654812115095E-03
+(PID.TID 0000.0001) %MON trcstat_ptracer03_min        =   4.7216676238750E-05
+(PID.TID 0000.0001) %MON trcstat_ptracer03_mean       =   2.0556333514037E-03
+(PID.TID 0000.0001) %MON trcstat_ptracer03_sd         =   5.0330695423354E-04
+(PID.TID 0000.0001) %MON trcstat_ptracer03_del2       =   6.6925234083256E-07
+(PID.TID 0000.0001) %MON trcstat_ptracer04_max        =   2.5834842094182E-04
+(PID.TID 0000.0001) %MON trcstat_ptracer04_min        =  -7.6229478014002E-07
+(PID.TID 0000.0001) %MON trcstat_ptracer04_mean       =   6.2412143525986E-06
+(PID.TID 0000.0001) %MON trcstat_ptracer04_sd         =   2.6296275912119E-05
+(PID.TID 0000.0001) %MON trcstat_ptracer04_del2       =   1.3425710876208E-07
+(PID.TID 0000.0001) %MON trcstat_ptracer05_max        =   3.8376464887278E-01
+(PID.TID 0000.0001) %MON trcstat_ptracer05_min        =   8.2422333836580E-02
+(PID.TID 0000.0001) %MON trcstat_ptracer05_mean       =   2.1412356922377E-01
+(PID.TID 0000.0001) %MON trcstat_ptracer05_sd         =   4.3041094943624E-02
+(PID.TID 0000.0001) %MON trcstat_ptracer05_del2       =   1.1818374735142E-04
+(PID.TID 0000.0001) // =======================================================
+(PID.TID 0000.0001) // End MONITOR ptracer field statistics
+(PID.TID 0000.0001) // =======================================================
+ EXTERNAL_FIELDS_LOAD,         5 : iP,iLd,i0,i1=   12    1   12    1 ; Wght=  0.4166666667  0.5833333333
+ DIC_FIELDS_LOAD,         5 : iP,iLd,i0,i1=   12    1   12    1 ; Wght=  0.4166666667  0.5833333333
+ OBCS_FIELDS_LOAD,         6 : iP,iLd,i0,i1=   12    1   12    1 ; Wght=  0.4000000000  0.6000000000
+ cg2d: Sum(rhs),rhsMax =   3.68604606178160E+01  9.91567272730777E-01
+(PID.TID 0000.0001)      cg2d_init_res =   1.48015177643454E-02
+(PID.TID 0000.0001)      cg2d_iters(min,last) =      -1      76
+(PID.TID 0000.0001)      cg2d_last_res =   7.89128155850116E-14
+(PID.TID 0000.0001) // =======================================================
+(PID.TID 0000.0001) // Begin MONITOR dynamic field statistics
+(PID.TID 0000.0001) // =======================================================
+(PID.TID 0000.0001) %MON time_tsnumber                =                     6
+(PID.TID 0000.0001) %MON time_secondsf                =   2.5920000000000E+05
+(PID.TID 0000.0001) %MON dynstat_eta_max              =   4.6999038601379E-01
+(PID.TID 0000.0001) %MON dynstat_eta_min              =  -1.5152481176502E+00
+(PID.TID 0000.0001) %MON dynstat_eta_mean             =  -5.1661556972116E-01
+(PID.TID 0000.0001) %MON dynstat_eta_sd               =   6.1658103672773E-01
+(PID.TID 0000.0001) %MON dynstat_eta_del2             =   2.3736315171179E-03
+(PID.TID 0000.0001) %MON dynstat_uvel_max             =   1.3135016104574E-01
+(PID.TID 0000.0001) %MON dynstat_uvel_min             =  -6.0310755670071E-02
+(PID.TID 0000.0001) %MON dynstat_uvel_mean            =   7.5556985596957E-03
+(PID.TID 0000.0001) %MON dynstat_uvel_sd              =   1.4669695779405E-02
+(PID.TID 0000.0001) %MON dynstat_uvel_del2            =   1.6183624438474E-04
+(PID.TID 0000.0001) %MON dynstat_vvel_max             =   1.2980890775925E-01
+(PID.TID 0000.0001) %MON dynstat_vvel_min             =  -8.8535428945471E-02
+(PID.TID 0000.0001) %MON dynstat_vvel_mean            =   9.3568261909357E-04
+(PID.TID 0000.0001) %MON dynstat_vvel_sd              =   8.4651885756853E-03
+(PID.TID 0000.0001) %MON dynstat_vvel_del2            =   1.0619049059375E-04
+(PID.TID 0000.0001) %MON dynstat_wvel_max             =   5.5109426798928E-05
+(PID.TID 0000.0001) %MON dynstat_wvel_min             =  -1.4100108171508E-04
+(PID.TID 0000.0001) %MON dynstat_wvel_mean            =  -2.4321960367378E-07
+(PID.TID 0000.0001) %MON dynstat_wvel_sd              =   5.4438789134140E-06
+(PID.TID 0000.0001) %MON dynstat_wvel_del2            =   1.4054669441006E-07
+(PID.TID 0000.0001) %MON dynstat_theta_max            =   2.4256673239195E+01
+(PID.TID 0000.0001) %MON dynstat_theta_min            =  -2.8963725482635E+00
+(PID.TID 0000.0001) %MON dynstat_theta_mean           =   2.3235054855065E+00
+(PID.TID 0000.0001) %MON dynstat_theta_sd             =   3.2156151642625E+00
+(PID.TID 0000.0001) %MON dynstat_theta_del2           =   6.6295982957714E-03
+(PID.TID 0000.0001) %MON dynstat_salt_max             =   3.6601874127639E+01
+(PID.TID 0000.0001) %MON dynstat_salt_min             =   3.3077503206939E+01
+(PID.TID 0000.0001) %MON dynstat_salt_mean            =   3.4483939305470E+01
+(PID.TID 0000.0001) %MON dynstat_salt_sd              =   1.9650016219741E-01
+(PID.TID 0000.0001) %MON dynstat_salt_del2            =   1.1552488206347E-03
+(PID.TID 0000.0001) %MON forcing_qnet_max             =   6.8472602844238E+01
+(PID.TID 0000.0001) %MON forcing_qnet_min             =  -2.1107043965658E+02
+(PID.TID 0000.0001) %MON forcing_qnet_mean            =  -1.1982880448744E+02
+(PID.TID 0000.0001) %MON forcing_qnet_sd              =   4.4041733294347E+01
+(PID.TID 0000.0001) %MON forcing_qnet_del2            =   8.4094325131889E-01
+(PID.TID 0000.0001) %MON forcing_qsw_max              =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON forcing_qsw_min              =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON forcing_qsw_mean             =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON forcing_qsw_sd               =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON forcing_qsw_del2             =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON forcing_empmr_max            =   2.5141471127199E-05
+(PID.TID 0000.0001) %MON forcing_empmr_min            =  -3.9761445691511E-05
+(PID.TID 0000.0001) %MON forcing_empmr_mean           =  -9.3236499820974E-06
+(PID.TID 0000.0001) %MON forcing_empmr_sd             =   1.0249687273683E-05
+(PID.TID 0000.0001) %MON forcing_empmr_del2           =   9.8755541425843E-08
+(PID.TID 0000.0001) %MON forcing_fu_max               =   2.1253544837236E-01
+(PID.TID 0000.0001) %MON forcing_fu_min               =  -9.2614319175482E-02
+(PID.TID 0000.0001) %MON forcing_fu_mean              =   7.5602344860540E-02
+(PID.TID 0000.0001) %MON forcing_fu_sd                =   7.1398218194354E-02
+(PID.TID 0000.0001) %MON forcing_fu_del2              =   5.5615036481995E-04
+(PID.TID 0000.0001) %MON forcing_fv_max               =   1.4963739737868E-01
+(PID.TID 0000.0001) %MON forcing_fv_min               =  -7.6042934010426E-02
+(PID.TID 0000.0001) %MON forcing_fv_mean              =  -1.9297376240638E-02
+(PID.TID 0000.0001) %MON forcing_fv_sd                =   3.3499688898391E-02
+(PID.TID 0000.0001) %MON forcing_fv_del2              =   3.7361175793077E-04
+(PID.TID 0000.0001) %MON trAdv_CFL_u_max              =   8.5269630985716E-02
+(PID.TID 0000.0001) %MON trAdv_CFL_v_max              =   2.2854163869584E-02
+(PID.TID 0000.0001) %MON trAdv_CFL_w_max              =   6.2232714685373E-02
+(PID.TID 0000.0001) %MON advcfl_uvel_max              =   3.3919791609302E-02
+(PID.TID 0000.0001) %MON advcfl_vvel_max              =   1.7934072101716E-02
+(PID.TID 0000.0001) %MON advcfl_wvel_max              =   1.6688347205730E-02
+(PID.TID 0000.0001) %MON advcfl_W_hf_max              =   1.7915431559092E-02
+(PID.TID 0000.0001) %MON pe_b_mean                    =   8.7182684647676E-04
+(PID.TID 0000.0001) %MON ke_max                       =   9.3830442426115E-03
+(PID.TID 0000.0001) %MON ke_mean                      =   1.6343104906184E-04
+(PID.TID 0000.0001) %MON ke_vol                       =   1.2769337095763E+17
+(PID.TID 0000.0001) %MON vort_r_min                   =  -4.7585079446337E-07
+(PID.TID 0000.0001) %MON vort_r_max                   =   7.0706927681087E-07
+(PID.TID 0000.0001) %MON vort_a_mean                  =  -1.0457492390463E-04
+(PID.TID 0000.0001) %MON vort_a_sd                    =   2.1292685036605E-05
+(PID.TID 0000.0001) %MON vort_p_mean                  =  -1.2574624125366E-04
+(PID.TID 0000.0001) %MON vort_p_sd                    =   1.1183803238886E-04
+(PID.TID 0000.0001) %MON surfExpan_theta_mean         =   2.5334040790048E-07
+(PID.TID 0000.0001) %MON surfExpan_salt_mean          =   1.4788626310415E-07
+(PID.TID 0000.0001) // =======================================================
+(PID.TID 0000.0001) // End MONITOR dynamic field statistics
+(PID.TID 0000.0001) // =======================================================
+(PID.TID 0000.0001) // =======================================================
+(PID.TID 0000.0001) // Begin OBCS MONITOR field statistics
+(PID.TID 0000.0001) // =======================================================
+(PID.TID 0000.0001) %MON obc_E_uVel_max               =   8.3425460755825E-02
+(PID.TID 0000.0001) %MON obc_E_uVel_min               =  -6.0310755670071E-02
+(PID.TID 0000.0001) %MON obc_E_uVel_mean              =   7.3554947677044E-03
+(PID.TID 0000.0001) %MON obc_E_uVel_sd                =   1.4304154443492E-02
+(PID.TID 0000.0001) %MON obc_E_uVel_Int               =   1.2610707943785E+08
+(PID.TID 0000.0001) %MON obc_W_uVel_max               =   5.9991145133972E-02
+(PID.TID 0000.0001) %MON obc_W_uVel_min               =  -2.5740600004792E-02
+(PID.TID 0000.0001) %MON obc_W_uVel_mean              =   6.9974153800331E-03
+(PID.TID 0000.0001) %MON obc_W_uVel_sd                =   1.1127673018781E-02
+(PID.TID 0000.0001) %MON obc_W_uVel_Int               =   1.3077666021251E+08
+(PID.TID 0000.0001) %MON obc_N_vVel_max               =   4.7148257493973E-02
+(PID.TID 0000.0001) %MON obc_N_vVel_min               =  -7.0764410495758E-02
+(PID.TID 0000.0001) %MON obc_N_vVel_mean              =   1.5466347545728E-04
+(PID.TID 0000.0001) %MON obc_N_vVel_sd                =   6.4336033808868E-03
+(PID.TID 0000.0001) %MON obc_N_vVel_Int               =   4.5214084825912E+06
+(PID.TID 0000.0001) %MON obc_E_theta_max              =   1.9312948989868E+01
+(PID.TID 0000.0001) %MON obc_E_theta_min              =  -1.5910426139832E+00
+(PID.TID 0000.0001) %MON obc_E_theta_mean             =   1.9094109467191E+00
+(PID.TID 0000.0001) %MON obc_E_theta_sd               =   2.9680727207563E+00
+(PID.TID 0000.0001) %MON obc_W_theta_max              =   2.1525777435303E+01
+(PID.TID 0000.0001) %MON obc_W_theta_min              =  -1.4422561645508E+00
+(PID.TID 0000.0001) %MON obc_W_theta_mean             =   2.4667050325388E+00
+(PID.TID 0000.0001) %MON obc_W_theta_sd               =   2.9624842527631E+00
+(PID.TID 0000.0001) %MON obc_N_theta_max              =   2.4097963333130E+01
+(PID.TID 0000.0001) %MON obc_N_theta_min              =  -6.3343899250031E-01
+(PID.TID 0000.0001) %MON obc_N_theta_mean             =   4.8722921175379E+00
+(PID.TID 0000.0001) %MON obc_N_theta_sd               =   4.7062402932228E+00
+(PID.TID 0000.0001) // =======================================================
+(PID.TID 0000.0001) // End OBCS MONITOR field statistics
+(PID.TID 0000.0001) // =======================================================
+(PID.TID 0000.0001) // =======================================================
+(PID.TID 0000.0001) // Begin MONITOR ptracer field statistics
+(PID.TID 0000.0001) // =======================================================
+(PID.TID 0000.0001) %MON trcstat_ptracer01_max        =   2.3591427497582E+00
+(PID.TID 0000.0001) %MON trcstat_ptracer01_min        =   1.9366413170450E+00
+(PID.TID 0000.0001) %MON trcstat_ptracer01_mean       =   2.2425216892794E+00
+(PID.TID 0000.0001) %MON trcstat_ptracer01_sd         =   7.6001672101472E-02
+(PID.TID 0000.0001) %MON trcstat_ptracer01_del2       =   1.0647601249863E-04
+(PID.TID 0000.0001) %MON trcstat_ptracer02_max        =   2.4116855799363E+00
+(PID.TID 0000.0001) %MON trcstat_ptracer02_min        =   2.1901275596032E+00
+(PID.TID 0000.0001) %MON trcstat_ptracer02_mean       =   2.3520467504499E+00
+(PID.TID 0000.0001) %MON trcstat_ptracer02_sd         =   3.5090129322308E-02
+(PID.TID 0000.0001) %MON trcstat_ptracer02_del2       =   8.0598793708928E-05
+(PID.TID 0000.0001) %MON trcstat_ptracer03_max        =   2.7654846357374E-03
+(PID.TID 0000.0001) %MON trcstat_ptracer03_min        =   4.7172826647483E-05
+(PID.TID 0000.0001) %MON trcstat_ptracer03_mean       =   2.0556240677567E-03
+(PID.TID 0000.0001) %MON trcstat_ptracer03_sd         =   5.0332270860231E-04
+(PID.TID 0000.0001) %MON trcstat_ptracer03_del2       =   6.6895952488566E-07
+(PID.TID 0000.0001) %MON trcstat_ptracer04_max        =   2.5867373024591E-04
+(PID.TID 0000.0001) %MON trcstat_ptracer04_min        =  -7.6625129981406E-07
+(PID.TID 0000.0001) %MON trcstat_ptracer04_mean       =   6.2493443777087E-06
+(PID.TID 0000.0001) %MON trcstat_ptracer04_sd         =   2.6336037079404E-05
+(PID.TID 0000.0001) %MON trcstat_ptracer04_del2       =   1.3419273801687E-07
+(PID.TID 0000.0001) %MON trcstat_ptracer05_max        =   3.8380040823710E-01
+(PID.TID 0000.0001) %MON trcstat_ptracer05_min        =   8.2429634331529E-02
+(PID.TID 0000.0001) %MON trcstat_ptracer05_mean       =   2.1412172564592E-01
+(PID.TID 0000.0001) %MON trcstat_ptracer05_sd         =   4.3038612322839E-02
+(PID.TID 0000.0001) %MON trcstat_ptracer05_del2       =   1.1799274470709E-04
+(PID.TID 0000.0001) // =======================================================
+(PID.TID 0000.0001) // End MONITOR ptracer field statistics
+(PID.TID 0000.0001) // =======================================================
+ EXTERNAL_FIELDS_LOAD,         6 : iP,iLd,i0,i1=   12    1   12    1 ; Wght=  0.4000000000  0.6000000000
+ DIC_FIELDS_LOAD,         6 : iP,iLd,i0,i1=   12    1   12    1 ; Wght=  0.4000000000  0.6000000000
+ OBCS_FIELDS_LOAD,         7 : iP,iLd,i0,i1=   12    1   12    1 ; Wght=  0.3833333333  0.6166666667
+ cg2d: Sum(rhs),rhsMax =   3.68074301550226E+01  9.92642448786696E-01
+(PID.TID 0000.0001)      cg2d_init_res =   9.67818023158134E-03
+(PID.TID 0000.0001)      cg2d_iters(min,last) =      -1      76
+(PID.TID 0000.0001)      cg2d_last_res =   5.61356601531656E-14
+(PID.TID 0000.0001) // =======================================================
+(PID.TID 0000.0001) // Begin MONITOR dynamic field statistics
+(PID.TID 0000.0001) // =======================================================
+(PID.TID 0000.0001) %MON time_tsnumber                =                     7
+(PID.TID 0000.0001) %MON time_secondsf                =   3.0240000000000E+05
+(PID.TID 0000.0001) %MON dynstat_eta_max              =   4.7008106519615E-01
+(PID.TID 0000.0001) %MON dynstat_eta_min              =  -1.5146775749600E+00
+(PID.TID 0000.0001) %MON dynstat_eta_mean             =  -5.1643169504890E-01
+(PID.TID 0000.0001) %MON dynstat_eta_sd               =   6.1656733459346E-01
+(PID.TID 0000.0001) %MON dynstat_eta_del2             =   2.3756765429368E-03
+(PID.TID 0000.0001) %MON dynstat_uvel_max             =   1.3159765754242E-01
+(PID.TID 0000.0001) %MON dynstat_uvel_min             =  -6.0234536975622E-02
+(PID.TID 0000.0001) %MON dynstat_uvel_mean            =   7.5695103794253E-03
+(PID.TID 0000.0001) %MON dynstat_uvel_sd              =   1.4681330089115E-02
+(PID.TID 0000.0001) %MON dynstat_uvel_del2            =   1.6174305717656E-04
+(PID.TID 0000.0001) %MON dynstat_vvel_max             =   1.2991340263216E-01
+(PID.TID 0000.0001) %MON dynstat_vvel_min             =  -8.8511799774137E-02
+(PID.TID 0000.0001) %MON dynstat_vvel_mean            =   9.2437862859792E-04
+(PID.TID 0000.0001) %MON dynstat_vvel_sd              =   8.4766780757673E-03
+(PID.TID 0000.0001) %MON dynstat_vvel_del2            =   1.0616134270546E-04
+(PID.TID 0000.0001) %MON dynstat_wvel_max             =   5.5103833278965E-05
+(PID.TID 0000.0001) %MON dynstat_wvel_min             =  -1.4087470086022E-04
+(PID.TID 0000.0001) %MON dynstat_wvel_mean            =  -2.4321604356707E-07
+(PID.TID 0000.0001) %MON dynstat_wvel_sd              =   5.4473953131717E-06
+(PID.TID 0000.0001) %MON dynstat_wvel_del2            =   1.4063565223417E-07
+(PID.TID 0000.0001) %MON dynstat_theta_max            =   2.4273136344714E+01
+(PID.TID 0000.0001) %MON dynstat_theta_min            =  -2.8964216396834E+00
+(PID.TID 0000.0001) %MON dynstat_theta_mean           =   2.3238206533726E+00
+(PID.TID 0000.0001) %MON dynstat_theta_sd             =   3.2164965291096E+00
+(PID.TID 0000.0001) %MON dynstat_theta_del2           =   6.6269562665548E-03
+(PID.TID 0000.0001) %MON dynstat_salt_max             =   3.6602048807536E+01
+(PID.TID 0000.0001) %MON dynstat_salt_min             =   3.3076225669671E+01
+(PID.TID 0000.0001) %MON dynstat_salt_mean            =   3.4483939801185E+01
+(PID.TID 0000.0001) %MON dynstat_salt_sd              =   1.9650792897861E-01
+(PID.TID 0000.0001) %MON dynstat_salt_del2            =   1.1546602343412E-03
+(PID.TID 0000.0001) %MON forcing_qnet_max             =   6.8508172607422E+01
+(PID.TID 0000.0001) %MON forcing_qnet_min             =  -2.1064372558594E+02
+(PID.TID 0000.0001) %MON forcing_qnet_mean            =  -1.1955390927556E+02
+(PID.TID 0000.0001) %MON forcing_qnet_sd              =   4.3905712423966E+01
+(PID.TID 0000.0001) %MON forcing_qnet_del2            =   8.4229375591307E-01
+(PID.TID 0000.0001) %MON forcing_qsw_max              =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON forcing_qsw_min              =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON forcing_qsw_mean             =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON forcing_qsw_sd               =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON forcing_qsw_del2             =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON forcing_empmr_max            =   2.5141471127199E-05
+(PID.TID 0000.0001) %MON forcing_empmr_min            =  -3.9761445691511E-05
+(PID.TID 0000.0001) %MON forcing_empmr_mean           =  -9.3236499820974E-06
+(PID.TID 0000.0001) %MON forcing_empmr_sd             =   1.0249687273683E-05
+(PID.TID 0000.0001) %MON forcing_empmr_del2           =   9.8755541425843E-08
+(PID.TID 0000.0001) %MON forcing_fu_max               =   2.1268687546253E-01
+(PID.TID 0000.0001) %MON forcing_fu_min               =  -9.3030621111393E-02
+(PID.TID 0000.0001) %MON forcing_fu_mean              =   7.5501595942040E-02
+(PID.TID 0000.0001) %MON forcing_fu_sd                =   7.1436912347776E-02
+(PID.TID 0000.0001) %MON forcing_fu_del2              =   5.5725630261794E-04
+(PID.TID 0000.0001) %MON forcing_fv_max               =   1.4932866692543E-01
+(PID.TID 0000.0001) %MON forcing_fv_min               =  -7.6012732088566E-02
+(PID.TID 0000.0001) %MON forcing_fv_mean              =  -1.9238337351042E-02
+(PID.TID 0000.0001) %MON forcing_fv_sd                =   3.3489000856457E-02
+(PID.TID 0000.0001) %MON forcing_fv_del2              =   3.7319319925167E-04
+(PID.TID 0000.0001) %MON trAdv_CFL_u_max              =   8.5613351677080E-02
+(PID.TID 0000.0001) %MON trAdv_CFL_v_max              =   2.3925825217887E-02
+(PID.TID 0000.0001) %MON trAdv_CFL_w_max              =   6.1327010612069E-02
+(PID.TID 0000.0001) %MON advcfl_uvel_max              =   3.3983704965208E-02
+(PID.TID 0000.0001) %MON advcfl_vvel_max              =   1.7948508850452E-02
+(PID.TID 0000.0001) %MON advcfl_wvel_max              =   1.6673389252497E-02
+(PID.TID 0000.0001) %MON advcfl_W_hf_max              =   1.7899373756357E-02
+(PID.TID 0000.0001) %MON pe_b_mean                    =   8.7154814810678E-04
+(PID.TID 0000.0001) %MON ke_max                       =   9.4102991907660E-03
+(PID.TID 0000.0001) %MON ke_mean                      =   1.6378194905914E-04
+(PID.TID 0000.0001) %MON ke_vol                       =   1.2769337095763E+17
+(PID.TID 0000.0001) %MON vort_r_min                   =  -4.7538312146136E-07
+(PID.TID 0000.0001) %MON vort_r_max                   =   7.0780499724177E-07
+(PID.TID 0000.0001) %MON vort_a_mean                  =  -1.0457492338949E-04
+(PID.TID 0000.0001) %MON vort_a_sd                    =   2.1292692094140E-05
+(PID.TID 0000.0001) %MON vort_p_mean                  =  -1.2574624063424E-04
+(PID.TID 0000.0001) %MON vort_p_sd                    =   1.1183802341423E-04
+(PID.TID 0000.0001) %MON surfExpan_theta_mean         =   8.7499050927811E-08
+(PID.TID 0000.0001) %MON surfExpan_salt_mean          =   1.5572833546516E-07
+(PID.TID 0000.0001) // =======================================================
+(PID.TID 0000.0001) // End MONITOR dynamic field statistics
+(PID.TID 0000.0001) // =======================================================
+(PID.TID 0000.0001) // =======================================================
+(PID.TID 0000.0001) // Begin OBCS MONITOR field statistics
+(PID.TID 0000.0001) // =======================================================
+(PID.TID 0000.0001) %MON obc_E_uVel_max               =   8.3291068176428E-02
+(PID.TID 0000.0001) %MON obc_E_uVel_min               =  -6.0234536975622E-02
+(PID.TID 0000.0001) %MON obc_E_uVel_mean              =   7.3536620415026E-03
+(PID.TID 0000.0001) %MON obc_E_uVel_sd                =   1.4304842863392E-02
+(PID.TID 0000.0001) %MON obc_E_uVel_Int               =   1.2607565806430E+08
+(PID.TID 0000.0001) %MON obc_W_uVel_max               =   6.0039183621605E-02
+(PID.TID 0000.0001) %MON obc_W_uVel_min               =  -2.5742980123808E-02
+(PID.TID 0000.0001) %MON obc_W_uVel_mean              =   6.9930409885435E-03
+(PID.TID 0000.0001) %MON obc_W_uVel_sd                =   1.1131690601760E-02
+(PID.TID 0000.0001) %MON obc_W_uVel_Int               =   1.3069490598207E+08
+(PID.TID 0000.0001) %MON obc_N_vVel_max               =   4.7094848317405E-02
+(PID.TID 0000.0001) %MON obc_N_vVel_min               =  -7.0816007504861E-02
+(PID.TID 0000.0001) %MON obc_N_vVel_mean              =   1.5290327582159E-04
+(PID.TID 0000.0001) %MON obc_N_vVel_sd                =   6.4323161884926E-03
+(PID.TID 0000.0001) %MON obc_N_vVel_Int               =   4.4699510745618E+06
+(PID.TID 0000.0001) %MON obc_E_theta_max              =   1.9334424591064E+01
+(PID.TID 0000.0001) %MON obc_E_theta_min              =  -1.5823890785376E+00
+(PID.TID 0000.0001) %MON obc_E_theta_mean             =   1.9093998092044E+00
+(PID.TID 0000.0001) %MON obc_E_theta_sd               =   2.9685521370964E+00
+(PID.TID 0000.0001) %MON obc_W_theta_max              =   2.1545968564351E+01
+(PID.TID 0000.0001) %MON obc_W_theta_min              =  -1.4423383812110E+00
+(PID.TID 0000.0001) %MON obc_W_theta_mean             =   2.4669222704193E+00
+(PID.TID 0000.0001) %MON obc_W_theta_sd               =   2.9630285564427E+00
+(PID.TID 0000.0001) %MON obc_N_theta_max              =   2.4118851343791E+01
+(PID.TID 0000.0001) %MON obc_N_theta_min              =  -6.3394157191118E-01
+(PID.TID 0000.0001) %MON obc_N_theta_mean             =   4.8725040102309E+00
+(PID.TID 0000.0001) %MON obc_N_theta_sd               =   4.7071257566199E+00
+(PID.TID 0000.0001) // =======================================================
+(PID.TID 0000.0001) // End OBCS MONITOR field statistics
+(PID.TID 0000.0001) // =======================================================
+(PID.TID 0000.0001) // =======================================================
+(PID.TID 0000.0001) // Begin MONITOR ptracer field statistics
+(PID.TID 0000.0001) // =======================================================
+(PID.TID 0000.0001) %MON trcstat_ptracer01_max        =   2.3591433911875E+00
+(PID.TID 0000.0001) %MON trcstat_ptracer01_min        =   1.9366200089386E+00
+(PID.TID 0000.0001) %MON trcstat_ptracer01_mean       =   2.2425202505508E+00
+(PID.TID 0000.0001) %MON trcstat_ptracer01_sd         =   7.6005098777939E-02
+(PID.TID 0000.0001) %MON trcstat_ptracer01_del2       =   1.0639617380071E-04
+(PID.TID 0000.0001) %MON trcstat_ptracer02_max        =   2.4116862007430E+00
+(PID.TID 0000.0001) %MON trcstat_ptracer02_min        =   2.1901665807237E+00
+(PID.TID 0000.0001) %MON trcstat_ptracer02_mean       =   2.3520470240973E+00
+(PID.TID 0000.0001) %MON trcstat_ptracer02_sd         =   3.5089991159361E-02
+(PID.TID 0000.0001) %MON trcstat_ptracer02_del2       =   8.0591577780621E-05
+(PID.TID 0000.0001) %MON trcstat_ptracer03_max        =   2.7654880588400E-03
+(PID.TID 0000.0001) %MON trcstat_ptracer03_min        =   4.7129272619617E-05
+(PID.TID 0000.0001) %MON trcstat_ptracer03_mean       =   2.0556146322958E-03
+(PID.TID 0000.0001) %MON trcstat_ptracer03_sd         =   5.0333879851479E-04
+(PID.TID 0000.0001) %MON trcstat_ptracer03_del2       =   6.6860531204279E-07
+(PID.TID 0000.0001) %MON trcstat_ptracer04_max        =   2.5899480803230E-04
+(PID.TID 0000.0001) %MON trcstat_ptracer04_min        =  -7.7022530970579E-07
+(PID.TID 0000.0001) %MON trcstat_ptracer04_mean       =   6.2574442496260E-06
+(PID.TID 0000.0001) %MON trcstat_ptracer04_sd         =   2.6375671855123E-05
+(PID.TID 0000.0001) %MON trcstat_ptracer04_del2       =   1.3410865020940E-07
+(PID.TID 0000.0001) %MON trcstat_ptracer05_max        =   3.8383443643592E-01
+(PID.TID 0000.0001) %MON trcstat_ptracer05_min        =   8.2438560948496E-02
+(PID.TID 0000.0001) %MON trcstat_ptracer05_mean       =   2.1411986640507E-01
+(PID.TID 0000.0001) %MON trcstat_ptracer05_sd         =   4.3036101568632E-02
+(PID.TID 0000.0001) %MON trcstat_ptracer05_del2       =   1.1779545872810E-04
+(PID.TID 0000.0001) // =======================================================
+(PID.TID 0000.0001) // End MONITOR ptracer field statistics
+(PID.TID 0000.0001) // =======================================================
+ EXTERNAL_FIELDS_LOAD,         7 : iP,iLd,i0,i1=   12    1   12    1 ; Wght=  0.3833333333  0.6166666667
+ DIC_FIELDS_LOAD,         7 : iP,iLd,i0,i1=   12    1   12    1 ; Wght=  0.3833333333  0.6166666667
+ OBCS_FIELDS_LOAD,         8 : iP,iLd,i0,i1=   12    1   12    1 ; Wght=  0.3666666667  0.6333333333
+ cg2d: Sum(rhs),rhsMax =   3.67609180744336E+01  9.93541857101072E-01
+(PID.TID 0000.0001)      cg2d_init_res =   1.38807595302222E-02
+(PID.TID 0000.0001)      cg2d_iters(min,last) =      -1      76
+(PID.TID 0000.0001)      cg2d_last_res =   7.28273104908896E-14
+(PID.TID 0000.0001) // =======================================================
+(PID.TID 0000.0001) // Begin MONITOR dynamic field statistics
+(PID.TID 0000.0001) // =======================================================
+(PID.TID 0000.0001) %MON time_tsnumber                =                     8
+(PID.TID 0000.0001) %MON time_secondsf                =   3.4560000000000E+05
+(PID.TID 0000.0001) %MON dynstat_eta_max              =   4.6723536497608E-01
+(PID.TID 0000.0001) %MON dynstat_eta_min              =  -1.5132080757544E+00
+(PID.TID 0000.0001) %MON dynstat_eta_mean             =  -5.1624643537434E-01
+(PID.TID 0000.0001) %MON dynstat_eta_sd               =   6.1540913193987E-01
+(PID.TID 0000.0001) %MON dynstat_eta_del2             =   2.3769577727386E-03
+(PID.TID 0000.0001) %MON dynstat_uvel_max             =   1.3184375173849E-01
+(PID.TID 0000.0001) %MON dynstat_uvel_min             =  -6.0158318281174E-02
+(PID.TID 0000.0001) %MON dynstat_uvel_mean            =   7.5844790515267E-03
+(PID.TID 0000.0001) %MON dynstat_uvel_sd              =   1.4691681115239E-02
+(PID.TID 0000.0001) %MON dynstat_uvel_del2            =   1.6165719148398E-04
+(PID.TID 0000.0001) %MON dynstat_vvel_max             =   1.3001700092231E-01
+(PID.TID 0000.0001) %MON dynstat_vvel_min             =  -8.8481552609679E-02
+(PID.TID 0000.0001) %MON dynstat_vvel_mean            =   9.1626110527408E-04
+(PID.TID 0000.0001) %MON dynstat_vvel_sd              =   8.4875135541305E-03
+(PID.TID 0000.0001) %MON dynstat_vvel_del2            =   1.0613049146976E-04
+(PID.TID 0000.0001) %MON dynstat_wvel_max             =   5.5090002988546E-05
+(PID.TID 0000.0001) %MON dynstat_wvel_min             =  -1.4076607694846E-04
+(PID.TID 0000.0001) %MON dynstat_wvel_mean            =  -2.4321248346036E-07
+(PID.TID 0000.0001) %MON dynstat_wvel_sd              =   5.4515180270604E-06
+(PID.TID 0000.0001) %MON dynstat_wvel_del2            =   1.4073681914374E-07
+(PID.TID 0000.0001) %MON dynstat_theta_max            =   2.4289604917873E+01
+(PID.TID 0000.0001) %MON dynstat_theta_min            =  -2.8964598657543E+00
+(PID.TID 0000.0001) %MON dynstat_theta_mean           =   2.3241374181710E+00
+(PID.TID 0000.0001) %MON dynstat_theta_sd             =   3.2173838587216E+00
+(PID.TID 0000.0001) %MON dynstat_theta_del2           =   6.6243773847626E-03
+(PID.TID 0000.0001) %MON dynstat_salt_max             =   3.6602221012721E+01
+(PID.TID 0000.0001) %MON dynstat_salt_min             =   3.3074878196556E+01
+(PID.TID 0000.0001) %MON dynstat_salt_mean            =   3.4483940230520E+01
+(PID.TID 0000.0001) %MON dynstat_salt_sd              =   1.9651534080036E-01
+(PID.TID 0000.0001) %MON dynstat_salt_del2            =   1.1540770021512E-03
+(PID.TID 0000.0001) %MON forcing_qnet_max             =   6.8543742370605E+01
+(PID.TID 0000.0001) %MON forcing_qnet_min             =  -2.1021701151530E+02
+(PID.TID 0000.0001) %MON forcing_qnet_mean            =  -1.1927901406368E+02
+(PID.TID 0000.0001) %MON forcing_qnet_sd              =   4.3773378415024E+01
+(PID.TID 0000.0001) %MON forcing_qnet_del2            =   8.4369299028848E-01
+(PID.TID 0000.0001) %MON forcing_qsw_max              =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON forcing_qsw_min              =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON forcing_qsw_mean             =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON forcing_qsw_sd               =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON forcing_qsw_del2             =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON forcing_empmr_max            =   2.5141471127199E-05
+(PID.TID 0000.0001) %MON forcing_empmr_min            =  -3.9761445691511E-05
+(PID.TID 0000.0001) %MON forcing_empmr_mean           =  -9.3236499820974E-06
+(PID.TID 0000.0001) %MON forcing_empmr_sd             =   1.0249687273683E-05
+(PID.TID 0000.0001) %MON forcing_empmr_del2           =   9.8755541425843E-08
+(PID.TID 0000.0001) %MON forcing_fu_max               =   2.1288872435689E-01
+(PID.TID 0000.0001) %MON forcing_fu_min               =  -9.3446923047304E-02
+(PID.TID 0000.0001) %MON forcing_fu_mean              =   7.5400847023540E-02
+(PID.TID 0000.0001) %MON forcing_fu_sd                =   7.1476380419357E-02
+(PID.TID 0000.0001) %MON forcing_fu_del2              =   5.5840575540377E-04
+(PID.TID 0000.0001) %MON forcing_fv_max               =   1.4901993647218E-01
+(PID.TID 0000.0001) %MON forcing_fv_min               =  -7.6058066760500E-02
+(PID.TID 0000.0001) %MON forcing_fv_mean              =  -1.9179298461445E-02
+(PID.TID 0000.0001) %MON forcing_fv_sd                =   3.3479034351115E-02
+(PID.TID 0000.0001) %MON forcing_fv_del2              =   3.7281199587619E-04
+(PID.TID 0000.0001) %MON trAdv_CFL_u_max              =   8.6024459238591E-02
+(PID.TID 0000.0001) %MON trAdv_CFL_v_max              =   2.5145861281093E-02
+(PID.TID 0000.0001) %MON trAdv_CFL_w_max              =   6.0433509400697E-02
+(PID.TID 0000.0001) %MON advcfl_uvel_max              =   3.4047256191796E-02
+(PID.TID 0000.0001) %MON advcfl_vvel_max              =   1.7962821729570E-02
+(PID.TID 0000.0001) %MON advcfl_wvel_max              =   1.6660532942941E-02
+(PID.TID 0000.0001) %MON advcfl_W_hf_max              =   1.7885572129922E-02
+(PID.TID 0000.0001) %MON pe_b_mean                    =   8.6936786355898E-04
+(PID.TID 0000.0001) %MON ke_max                       =   9.4375168068006E-03
+(PID.TID 0000.0001) %MON ke_mean                      =   1.6412107367389E-04
+(PID.TID 0000.0001) %MON ke_vol                       =   1.2769337095763E+17
+(PID.TID 0000.0001) %MON vort_r_min                   =  -4.7489606858037E-07
+(PID.TID 0000.0001) %MON vort_r_max                   =   7.0834847859322E-07
+(PID.TID 0000.0001) %MON vort_a_mean                  =  -1.0457492287436E-04
+(PID.TID 0000.0001) %MON vort_a_sd                    =   2.1292700168765E-05
+(PID.TID 0000.0001) %MON vort_p_mean                  =  -1.2574624001482E-04
+(PID.TID 0000.0001) %MON vort_p_sd                    =   1.1183801666247E-04
+(PID.TID 0000.0001) %MON surfExpan_theta_mean         =  -3.7780077551823E-08
+(PID.TID 0000.0001) %MON surfExpan_salt_mean          =   1.6198243314544E-07
+(PID.TID 0000.0001) // =======================================================
+(PID.TID 0000.0001) // End MONITOR dynamic field statistics
+(PID.TID 0000.0001) // =======================================================
+(PID.TID 0000.0001) // =======================================================
+(PID.TID 0000.0001) // Begin OBCS MONITOR field statistics
+(PID.TID 0000.0001) // =======================================================
+(PID.TID 0000.0001) %MON obc_E_uVel_max               =   8.3156675597032E-02
+(PID.TID 0000.0001) %MON obc_E_uVel_min               =  -6.0158318281174E-02
+(PID.TID 0000.0001) %MON obc_E_uVel_mean              =   7.3518293153007E-03
+(PID.TID 0000.0001) %MON obc_E_uVel_sd                =   1.4305543175280E-02
+(PID.TID 0000.0001) %MON obc_E_uVel_Int               =   1.2604423669076E+08
+(PID.TID 0000.0001) %MON obc_W_uVel_max               =   6.0087222109238E-02
+(PID.TID 0000.0001) %MON obc_W_uVel_min               =  -2.5745360242824E-02
+(PID.TID 0000.0001) %MON obc_W_uVel_mean              =   6.9886665970540E-03
+(PID.TID 0000.0001) %MON obc_W_uVel_sd                =   1.1135721097065E-02
+(PID.TID 0000.0001) %MON obc_W_uVel_Int               =   1.3061315175163E+08
+(PID.TID 0000.0001) %MON obc_N_vVel_max               =   4.7041439140836E-02
+(PID.TID 0000.0001) %MON obc_N_vVel_min               =  -7.0867604513963E-02
+(PID.TID 0000.0001) %MON obc_N_vVel_mean              =   1.5114307618590E-04
+(PID.TID 0000.0001) %MON obc_N_vVel_sd                =   6.4310455804353E-03
+(PID.TID 0000.0001) %MON obc_N_vVel_Int               =   4.4184936665323E+06
+(PID.TID 0000.0001) %MON obc_E_theta_max              =   1.9355900192261E+01
+(PID.TID 0000.0001) %MON obc_E_theta_min              =  -1.5737355430921E+00
+(PID.TID 0000.0001) %MON obc_E_theta_mean             =   1.9093886716897E+00
+(PID.TID 0000.0001) %MON obc_E_theta_sd               =   2.9690329507524E+00
+(PID.TID 0000.0001) %MON obc_W_theta_max              =   2.1566159693400E+01
+(PID.TID 0000.0001) %MON obc_W_theta_min              =  -1.4424205978711E+00
+(PID.TID 0000.0001) %MON obc_W_theta_mean             =   2.4671395082998E+00
+(PID.TID 0000.0001) %MON obc_W_theta_sd               =   2.9635737850715E+00
+(PID.TID 0000.0001) %MON obc_N_theta_max              =   2.4139739354451E+01
+(PID.TID 0000.0001) %MON obc_N_theta_min              =  -6.3444415132205E-01
+(PID.TID 0000.0001) %MON obc_N_theta_mean             =   4.8727159029239E+00
+(PID.TID 0000.0001) %MON obc_N_theta_sd               =   4.7080121583499E+00
+(PID.TID 0000.0001) // =======================================================
+(PID.TID 0000.0001) // End OBCS MONITOR field statistics
+(PID.TID 0000.0001) // =======================================================
+(PID.TID 0000.0001) // =======================================================
+(PID.TID 0000.0001) // Begin MONITOR ptracer field statistics
+(PID.TID 0000.0001) // =======================================================
+(PID.TID 0000.0001) %MON trcstat_ptracer01_max        =   2.3591440330977E+00
+(PID.TID 0000.0001) %MON trcstat_ptracer01_min        =   1.9365987519411E+00
+(PID.TID 0000.0001) %MON trcstat_ptracer01_mean       =   2.2425187837345E+00
+(PID.TID 0000.0001) %MON trcstat_ptracer01_sd         =   7.6008603218245E-02
+(PID.TID 0000.0001) %MON trcstat_ptracer01_del2       =   1.0631846020503E-04
+(PID.TID 0000.0001) %MON trcstat_ptracer02_max        =   2.4116868452737E+00
+(PID.TID 0000.0001) %MON trcstat_ptracer02_min        =   2.1902045792250E+00
+(PID.TID 0000.0001) %MON trcstat_ptracer02_mean       =   2.3520472771944E+00
+(PID.TID 0000.0001) %MON trcstat_ptracer02_sd         =   3.5089885797199E-02
+(PID.TID 0000.0001) %MON trcstat_ptracer02_del2       =   8.0584050600072E-05
+(PID.TID 0000.0001) %MON trcstat_ptracer03_max        =   2.7654914810244E-03
+(PID.TID 0000.0001) %MON trcstat_ptracer03_min        =   4.7086010634046E-05
+(PID.TID 0000.0001) %MON trcstat_ptracer03_mean       =   2.0556050397947E-03
+(PID.TID 0000.0001) %MON trcstat_ptracer03_sd         =   5.0335525039907E-04
+(PID.TID 0000.0001) %MON trcstat_ptracer03_del2       =   6.6826974911584E-07
+(PID.TID 0000.0001) %MON trcstat_ptracer04_max        =   2.5931118414272E-04
+(PID.TID 0000.0001) %MON trcstat_ptracer04_min        =  -7.7420934168380E-07
+(PID.TID 0000.0001) %MON trcstat_ptracer04_mean       =   6.2655097828300E-06
+(PID.TID 0000.0001) %MON trcstat_ptracer04_sd         =   2.6415159444563E-05
+(PID.TID 0000.0001) %MON trcstat_ptracer04_del2       =   1.3403480721239E-07
+(PID.TID 0000.0001) %MON trcstat_ptracer05_max        =   3.8386684828878E-01
+(PID.TID 0000.0001) %MON trcstat_ptracer05_min        =   8.2449211969712E-02
+(PID.TID 0000.0001) %MON trcstat_ptracer05_mean       =   2.1411799002302E-01
+(PID.TID 0000.0001) %MON trcstat_ptracer05_sd         =   4.3033560541227E-02
+(PID.TID 0000.0001) %MON trcstat_ptracer05_del2       =   1.1760435248651E-04
+(PID.TID 0000.0001) // =======================================================
+(PID.TID 0000.0001) // End MONITOR ptracer field statistics
+(PID.TID 0000.0001) // =======================================================
+ EXTERNAL_FIELDS_LOAD,         8 : iP,iLd,i0,i1=   12    1   12    1 ; Wght=  0.3666666667  0.6333333333
+ DIC_FIELDS_LOAD,         8 : iP,iLd,i0,i1=   12    1   12    1 ; Wght=  0.3666666667  0.6333333333
+ OBCS_FIELDS_LOAD,         9 : iP,iLd,i0,i1=   12    1   12    1 ; Wght=  0.3500000000  0.6500000000
+ cg2d: Sum(rhs),rhsMax =   3.67312203274175E+01  9.93985653357504E-01
+(PID.TID 0000.0001)      cg2d_init_res =   1.78714566347305E-02
+(PID.TID 0000.0001)      cg2d_iters(min,last) =      -1      77
+(PID.TID 0000.0001)      cg2d_last_res =   7.07449220495416E-14
+(PID.TID 0000.0001) // =======================================================
+(PID.TID 0000.0001) // Begin MONITOR dynamic field statistics
+(PID.TID 0000.0001) // =======================================================
+(PID.TID 0000.0001) %MON time_tsnumber                =                     9
+(PID.TID 0000.0001) %MON time_secondsf                =   3.8880000000000E+05
+(PID.TID 0000.0001) %MON dynstat_eta_max              =   4.6188295381627E-01
+(PID.TID 0000.0001) %MON dynstat_eta_min              =  -1.5105381190453E+00
+(PID.TID 0000.0001) %MON dynstat_eta_mean             =  -5.1605979069747E-01
+(PID.TID 0000.0001) %MON dynstat_eta_sd               =   6.1355378384906E-01
+(PID.TID 0000.0001) %MON dynstat_eta_del2             =   2.3768604243972E-03
+(PID.TID 0000.0001) %MON dynstat_uvel_max             =   1.3207882409837E-01
+(PID.TID 0000.0001) %MON dynstat_uvel_min             =  -6.0082099586725E-02
+(PID.TID 0000.0001) %MON dynstat_uvel_mean            =   7.5988230765452E-03
+(PID.TID 0000.0001) %MON dynstat_uvel_sd              =   1.4700264721465E-02
+(PID.TID 0000.0001) %MON dynstat_uvel_del2            =   1.6157611435575E-04
+(PID.TID 0000.0001) %MON dynstat_vvel_max             =   1.3011535745598E-01
+(PID.TID 0000.0001) %MON dynstat_vvel_min             =  -8.8444901322574E-02
+(PID.TID 0000.0001) %MON dynstat_vvel_mean            =   9.1241750449551E-04
+(PID.TID 0000.0001) %MON dynstat_vvel_sd              =   8.4967950695218E-03
+(PID.TID 0000.0001) %MON dynstat_vvel_del2            =   1.0609380448029E-04
+(PID.TID 0000.0001) %MON dynstat_wvel_max             =   5.5079523697177E-05
+(PID.TID 0000.0001) %MON dynstat_wvel_min             =  -1.4064975274828E-04
+(PID.TID 0000.0001) %MON dynstat_wvel_mean            =  -2.4320892335365E-07
+(PID.TID 0000.0001) %MON dynstat_wvel_sd              =   5.4544864209949E-06
+(PID.TID 0000.0001) %MON dynstat_wvel_del2            =   1.4082365022984E-07
+(PID.TID 0000.0001) %MON dynstat_theta_max            =   2.4306104930293E+01
+(PID.TID 0000.0001) %MON dynstat_theta_min            =  -2.8964871861477E+00
+(PID.TID 0000.0001) %MON dynstat_theta_mean           =   2.3244549100803E+00
+(PID.TID 0000.0001) %MON dynstat_theta_sd             =   3.2182751879220E+00
+(PID.TID 0000.0001) %MON dynstat_theta_del2           =   6.6218581067712E-03
+(PID.TID 0000.0001) %MON dynstat_salt_max             =   3.6602391437169E+01
+(PID.TID 0000.0001) %MON dynstat_salt_min             =   3.3073456244647E+01
+(PID.TID 0000.0001) %MON dynstat_salt_mean            =   3.4483940599069E+01
+(PID.TID 0000.0001) %MON dynstat_salt_sd              =   1.9652251996430E-01
+(PID.TID 0000.0001) %MON dynstat_salt_del2            =   1.1534995544742E-03
+(PID.TID 0000.0001) %MON forcing_qnet_max             =   6.8579312133789E+01
+(PID.TID 0000.0001) %MON forcing_qnet_min             =  -2.0979029744466E+02
+(PID.TID 0000.0001) %MON forcing_qnet_mean            =  -1.1900411885181E+02
+(PID.TID 0000.0001) %MON forcing_qnet_sd              =   4.3644764804007E+01
+(PID.TID 0000.0001) %MON forcing_qnet_del2            =   8.4514071241070E-01
+(PID.TID 0000.0001) %MON forcing_qsw_max              =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON forcing_qsw_min              =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON forcing_qsw_mean             =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON forcing_qsw_sd               =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON forcing_qsw_del2             =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON forcing_empmr_max            =   2.5141471127199E-05
+(PID.TID 0000.0001) %MON forcing_empmr_min            =  -3.9761445691511E-05
+(PID.TID 0000.0001) %MON forcing_empmr_mean           =  -9.3236499820974E-06
+(PID.TID 0000.0001) %MON forcing_empmr_sd             =   1.0249687273683E-05
+(PID.TID 0000.0001) %MON forcing_empmr_del2           =   9.8755541425843E-08
+(PID.TID 0000.0001) %MON forcing_fu_max               =   2.1309057325125E-01
+(PID.TID 0000.0001) %MON forcing_fu_min               =  -9.3863224983215E-02
+(PID.TID 0000.0001) %MON forcing_fu_mean              =   7.5300098105040E-02
+(PID.TID 0000.0001) %MON forcing_fu_sd                =   7.1516621127784E-02
+(PID.TID 0000.0001) %MON forcing_fu_del2              =   5.5959845502938E-04
+(PID.TID 0000.0001) %MON forcing_fv_max               =   1.4871120601892E-01
+(PID.TID 0000.0001) %MON forcing_fv_min               =  -7.6119570682446E-02
+(PID.TID 0000.0001) %MON forcing_fv_mean              =  -1.9120259571849E-02
+(PID.TID 0000.0001) %MON forcing_fv_sd                =   3.3469790026933E-02
+(PID.TID 0000.0001) %MON forcing_fv_del2              =   3.7246826249842E-04
+(PID.TID 0000.0001) %MON trAdv_CFL_u_max              =   8.8149843865976E-02
+(PID.TID 0000.0001) %MON trAdv_CFL_v_max              =   2.6399234303102E-02
+(PID.TID 0000.0001) %MON trAdv_CFL_w_max              =   6.1249989698742E-02
+(PID.TID 0000.0001) %MON advcfl_uvel_max              =   3.4107961145615E-02
+(PID.TID 0000.0001) %MON advcfl_vvel_max              =   1.7976410420801E-02
+(PID.TID 0000.0001) %MON advcfl_wvel_max              =   1.6646765256782E-02
+(PID.TID 0000.0001) %MON advcfl_W_hf_max              =   1.7870792113899E-02
+(PID.TID 0000.0001) %MON pe_b_mean                    =   8.6603607747074E-04
+(PID.TID 0000.0001) %MON ke_max                       =   9.4633213657973E-03
+(PID.TID 0000.0001) %MON ke_mean                      =   1.6442186705882E-04
+(PID.TID 0000.0001) %MON ke_vol                       =   1.2769337095763E+17
+(PID.TID 0000.0001) %MON vort_r_min                   =  -4.7439238151693E-07
+(PID.TID 0000.0001) %MON vort_r_max                   =   7.0861943366491E-07
+(PID.TID 0000.0001) %MON vort_a_mean                  =  -1.0457492235923E-04
+(PID.TID 0000.0001) %MON vort_a_sd                    =   2.1292708323084E-05
+(PID.TID 0000.0001) %MON vort_p_mean                  =  -1.2574623939540E-04
+(PID.TID 0000.0001) %MON vort_p_sd                    =   1.1183801272312E-04
+(PID.TID 0000.0001) %MON surfExpan_theta_mean         =  -9.8017408805823E-08
+(PID.TID 0000.0001) %MON surfExpan_salt_mean          =   1.6840134834570E-07
+(PID.TID 0000.0001) // =======================================================
+(PID.TID 0000.0001) // End MONITOR dynamic field statistics
+(PID.TID 0000.0001) // =======================================================
+(PID.TID 0000.0001) // =======================================================
+(PID.TID 0000.0001) // Begin OBCS MONITOR field statistics
+(PID.TID 0000.0001) // =======================================================
+(PID.TID 0000.0001) %MON obc_E_uVel_max               =   8.3022283017635E-02
+(PID.TID 0000.0001) %MON obc_E_uVel_min               =  -6.0082099586725E-02
+(PID.TID 0000.0001) %MON obc_E_uVel_mean              =   7.3499965890989E-03
+(PID.TID 0000.0001) %MON obc_E_uVel_sd                =   1.4306255377412E-02
+(PID.TID 0000.0001) %MON obc_E_uVel_Int               =   1.2601281531721E+08
+(PID.TID 0000.0001) %MON obc_W_uVel_max               =   6.0135260596871E-02
+(PID.TID 0000.0001) %MON obc_W_uVel_min               =  -2.5747740361840E-02
+(PID.TID 0000.0001) %MON obc_W_uVel_mean              =   6.9842922055644E-03
+(PID.TID 0000.0001) %MON obc_W_uVel_sd                =   1.1139764490681E-02
+(PID.TID 0000.0001) %MON obc_W_uVel_Int               =   1.3053139752119E+08
+(PID.TID 0000.0001) %MON obc_N_vVel_max               =   4.6988029964268E-02
+(PID.TID 0000.0001) %MON obc_N_vVel_min               =  -7.0919201523066E-02
+(PID.TID 0000.0001) %MON obc_N_vVel_mean              =   1.4938287655021E-04
+(PID.TID 0000.0001) %MON obc_N_vVel_sd                =   6.4297915665466E-03
+(PID.TID 0000.0001) %MON obc_N_vVel_Int               =   4.3670362585028E+06
+(PID.TID 0000.0001) %MON obc_E_theta_max              =   1.9377375793457E+01
+(PID.TID 0000.0001) %MON obc_E_theta_min              =  -1.5650820076466E+00
+(PID.TID 0000.0001) %MON obc_E_theta_mean             =   1.9093775341749E+00
+(PID.TID 0000.0001) %MON obc_E_theta_sd               =   2.9695151610455E+00
+(PID.TID 0000.0001) %MON obc_W_theta_max              =   2.1586350822449E+01
+(PID.TID 0000.0001) %MON obc_W_theta_min              =  -1.4425028145313E+00
+(PID.TID 0000.0001) %MON obc_W_theta_mean             =   2.4673567461802E+00
+(PID.TID 0000.0001) %MON obc_W_theta_sd               =   2.9641199381389E+00
+(PID.TID 0000.0001) %MON obc_N_theta_max              =   2.4160627365112E+01
+(PID.TID 0000.0001) %MON obc_N_theta_min              =  -6.3494673073292E-01
+(PID.TID 0000.0001) %MON obc_N_theta_mean             =   4.8729277956169E+00
+(PID.TID 0000.0001) %MON obc_N_theta_sd               =   4.7088994978830E+00
+(PID.TID 0000.0001) // =======================================================
+(PID.TID 0000.0001) // End OBCS MONITOR field statistics
+(PID.TID 0000.0001) // =======================================================
+(PID.TID 0000.0001) // =======================================================
+(PID.TID 0000.0001) // Begin MONITOR ptracer field statistics
+(PID.TID 0000.0001) // =======================================================
+(PID.TID 0000.0001) %MON trcstat_ptracer01_max        =   2.3591446742776E+00
+(PID.TID 0000.0001) %MON trcstat_ptracer01_min        =   1.9365775433759E+00
+(PID.TID 0000.0001) %MON trcstat_ptracer01_mean       =   2.2425172950346E+00
+(PID.TID 0000.0001) %MON trcstat_ptracer01_sd         =   7.6012168189549E-02
+(PID.TID 0000.0001) %MON trcstat_ptracer01_del2       =   1.0624209550302E-04
+(PID.TID 0000.0001) %MON trcstat_ptracer02_max        =   2.4116875111597E+00
+(PID.TID 0000.0001) %MON trcstat_ptracer02_min        =   2.1902410680924E+00
+(PID.TID 0000.0001) %MON trcstat_ptracer02_mean       =   2.3520475137584E+00
+(PID.TID 0000.0001) %MON trcstat_ptracer02_sd         =   3.5089806390256E-02
+(PID.TID 0000.0001) %MON trcstat_ptracer02_del2       =   8.0576251953819E-05
+(PID.TID 0000.0001) %MON trcstat_ptracer03_max        =   2.7654948952691E-03
+(PID.TID 0000.0001) %MON trcstat_ptracer03_min        =   4.7043036957142E-05
+(PID.TID 0000.0001) %MON trcstat_ptracer03_mean       =   2.0555953298210E-03
+(PID.TID 0000.0001) %MON trcstat_ptracer03_sd         =   5.0337196960256E-04
+(PID.TID 0000.0001) %MON trcstat_ptracer03_del2       =   6.6794322464362E-07
+(PID.TID 0000.0001) %MON trcstat_ptracer04_max        =   2.5962277598367E-04
+(PID.TID 0000.0001) %MON trcstat_ptracer04_min        =  -7.7821378166312E-07
+(PID.TID 0000.0001) %MON trcstat_ptracer04_mean       =   6.2735394737443E-06
+(PID.TID 0000.0001) %MON trcstat_ptracer04_sd         =   2.6454493080859E-05
+(PID.TID 0000.0001) %MON trcstat_ptracer04_del2       =   1.3396788665641E-07
+(PID.TID 0000.0001) %MON trcstat_ptracer05_max        =   3.8389779926146E-01
+(PID.TID 0000.0001) %MON trcstat_ptracer05_min        =   8.2461047396573E-02
+(PID.TID 0000.0001) %MON trcstat_ptracer05_mean       =   2.1411609961828E-01
+(PID.TID 0000.0001) %MON trcstat_ptracer05_sd         =   4.3030995534209E-02
+(PID.TID 0000.0001) %MON trcstat_ptracer05_del2       =   1.1741788079132E-04
+(PID.TID 0000.0001) // =======================================================
+(PID.TID 0000.0001) // End MONITOR ptracer field statistics
+(PID.TID 0000.0001) // =======================================================
+ EXTERNAL_FIELDS_LOAD,         9 : iP,iLd,i0,i1=   12    1   12    1 ; Wght=  0.3500000000  0.6500000000
+ DIC_FIELDS_LOAD,         9 : iP,iLd,i0,i1=   12    1   12    1 ; Wght=  0.3500000000  0.6500000000
+ OBCS_FIELDS_LOAD,        10 : iP,iLd,i0,i1=   12    1   12    1 ; Wght=  0.3333333333  0.6666666667
+ cg2d: Sum(rhs),rhsMax =   3.67227792917983E+01  9.93851880945147E-01
+(PID.TID 0000.0001)      cg2d_init_res =   2.01899465663214E-02
+(PID.TID 0000.0001)      cg2d_iters(min,last) =      -1      76
+(PID.TID 0000.0001)      cg2d_last_res =   6.96835802799745E-14
+(PID.TID 0000.0001) // =======================================================
+(PID.TID 0000.0001) // Begin MONITOR dynamic field statistics
+(PID.TID 0000.0001) // =======================================================
+(PID.TID 0000.0001) %MON time_tsnumber                =                    10
+(PID.TID 0000.0001) %MON time_secondsf                =   4.3200000000000E+05
+(PID.TID 0000.0001) %MON dynstat_eta_max              =   4.5495146813194E-01
+(PID.TID 0000.0001) %MON dynstat_eta_min              =  -1.5066528418583E+00
+(PID.TID 0000.0001) %MON dynstat_eta_mean             =  -5.1587176101829E-01
+(PID.TID 0000.0001) %MON dynstat_eta_sd               =   6.1142533727477E-01
+(PID.TID 0000.0001) %MON dynstat_eta_del2             =   2.3752778367485E-03
+(PID.TID 0000.0001) %MON dynstat_uvel_max             =   1.3229128585363E-01
+(PID.TID 0000.0001) %MON dynstat_uvel_min             =  -6.0005880892277E-02
+(PID.TID 0000.0001) %MON dynstat_uvel_mean            =   7.6103312429381E-03
+(PID.TID 0000.0001) %MON dynstat_uvel_sd              =   1.4706749526433E-02
+(PID.TID 0000.0001) %MON dynstat_uvel_del2            =   1.6149725675726E-04
+(PID.TID 0000.0001) %MON dynstat_vvel_max             =   1.3020377539174E-01
+(PID.TID 0000.0001) %MON dynstat_vvel_min             =  -8.8402110726863E-02
+(PID.TID 0000.0001) %MON dynstat_vvel_mean            =   9.1197097927159E-04
+(PID.TID 0000.0001) %MON dynstat_vvel_sd              =   8.5038229349660E-03
+(PID.TID 0000.0001) %MON dynstat_vvel_del2            =   1.0604696742966E-04
+(PID.TID 0000.0001) %MON dynstat_wvel_max             =   5.5072411404962E-05
+(PID.TID 0000.0001) %MON dynstat_wvel_min             =  -1.4052859622017E-04
+(PID.TID 0000.0001) %MON dynstat_wvel_mean            =  -2.4320536324694E-07
+(PID.TID 0000.0001) %MON dynstat_wvel_sd              =   5.4558857007693E-06
+(PID.TID 0000.0001) %MON dynstat_wvel_del2            =   1.4087891938884E-07
+(PID.TID 0000.0001) %MON dynstat_theta_max            =   2.4322649951257E+01
+(PID.TID 0000.0001) %MON dynstat_theta_min            =  -2.8965031130308E+00
+(PID.TID 0000.0001) %MON dynstat_theta_mean           =   2.3247721883562E+00
+(PID.TID 0000.0001) %MON dynstat_theta_sd             =   3.2191682574255E+00
+(PID.TID 0000.0001) %MON dynstat_theta_del2           =   6.6193985504276E-03
+(PID.TID 0000.0001) %MON dynstat_salt_max             =   3.6602560423703E+01
+(PID.TID 0000.0001) %MON dynstat_salt_min             =   3.3071971867600E+01
+(PID.TID 0000.0001) %MON dynstat_salt_mean            =   3.4483940892459E+01
+(PID.TID 0000.0001) %MON dynstat_salt_sd              =   1.9652954654874E-01
+(PID.TID 0000.0001) %MON dynstat_salt_del2            =   1.1529285753811E-03
+(PID.TID 0000.0001) %MON forcing_qnet_max             =   6.8614881896973E+01
+(PID.TID 0000.0001) %MON forcing_qnet_min             =  -2.0936358337402E+02
+(PID.TID 0000.0001) %MON forcing_qnet_mean            =  -1.1872922363993E+02
+(PID.TID 0000.0001) %MON forcing_qnet_sd              =   4.3519904575408E+01
+(PID.TID 0000.0001) %MON forcing_qnet_del2            =   8.4663667354220E-01
+(PID.TID 0000.0001) %MON forcing_qsw_max              =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON forcing_qsw_min              =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON forcing_qsw_mean             =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON forcing_qsw_sd               =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON forcing_qsw_del2             =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON forcing_empmr_max            =   2.5141471127199E-05
+(PID.TID 0000.0001) %MON forcing_empmr_min            =  -3.9761445691511E-05
+(PID.TID 0000.0001) %MON forcing_empmr_mean           =  -9.3236499820974E-06
+(PID.TID 0000.0001) %MON forcing_empmr_sd             =   1.0249687273683E-05
+(PID.TID 0000.0001) %MON forcing_empmr_del2           =   9.8755541425843E-08
+(PID.TID 0000.0001) %MON forcing_fu_max               =   2.1329242214561E-01
+(PID.TID 0000.0001) %MON forcing_fu_min               =  -9.4279526919127E-02
+(PID.TID 0000.0001) %MON forcing_fu_mean              =   7.5199349186540E-02
+(PID.TID 0000.0001) %MON forcing_fu_sd                =   7.1557633169571E-02
+(PID.TID 0000.0001) %MON forcing_fu_del2              =   5.6083412558175E-04
+(PID.TID 0000.0001) %MON forcing_fv_max               =   1.4840247556567E-01
+(PID.TID 0000.0001) %MON forcing_fv_min               =  -7.6181074604392E-02
+(PID.TID 0000.0001) %MON forcing_fv_mean              =  -1.9061220682252E-02
+(PID.TID 0000.0001) %MON forcing_fv_sd                =   3.3461268482461E-02
+(PID.TID 0000.0001) %MON forcing_fv_del2              =   3.7216210294159E-04
+(PID.TID 0000.0001) %MON trAdv_CFL_u_max              =   8.8656915856445E-02
+(PID.TID 0000.0001) %MON trAdv_CFL_v_max              =   2.7295590561753E-02
+(PID.TID 0000.0001) %MON trAdv_CFL_w_max              =   6.0832153044100E-02
+(PID.TID 0000.0001) %MON advcfl_uvel_max              =   3.4162827149630E-02
+(PID.TID 0000.0001) %MON advcfl_vvel_max              =   1.7988626020349E-02
+(PID.TID 0000.0001) %MON advcfl_wvel_max              =   1.6632425634825E-02
+(PID.TID 0000.0001) %MON advcfl_W_hf_max              =   1.7855398107974E-02
+(PID.TID 0000.0001) %MON pe_b_mean                    =   8.6226167350384E-04
+(PID.TID 0000.0001) %MON ke_max                       =   9.4860880054333E-03
+(PID.TID 0000.0001) %MON ke_mean                      =   1.6465658681107E-04
+(PID.TID 0000.0001) %MON ke_vol                       =   1.2769337095763E+17
+(PID.TID 0000.0001) %MON vort_r_min                   =  -4.7387570898137E-07
+(PID.TID 0000.0001) %MON vort_r_max                   =   7.0858610076746E-07
+(PID.TID 0000.0001) %MON vort_a_mean                  =  -1.0457492184410E-04
+(PID.TID 0000.0001) %MON vort_a_sd                    =   2.1292715264401E-05
+(PID.TID 0000.0001) %MON vort_p_mean                  =  -1.2574623877598E-04
+(PID.TID 0000.0001) %MON vort_p_sd                    =   1.1183801085560E-04
+(PID.TID 0000.0001) %MON surfExpan_theta_mean         =  -1.0081652361944E-07
+(PID.TID 0000.0001) %MON surfExpan_salt_mean          =   1.7523576523517E-07
+(PID.TID 0000.0001) // =======================================================
+(PID.TID 0000.0001) // End MONITOR dynamic field statistics
+(PID.TID 0000.0001) // =======================================================
+(PID.TID 0000.0001) // =======================================================
+(PID.TID 0000.0001) // Begin OBCS MONITOR field statistics
+(PID.TID 0000.0001) // =======================================================
+(PID.TID 0000.0001) %MON obc_E_uVel_max               =   8.2887890438239E-02
+(PID.TID 0000.0001) %MON obc_E_uVel_min               =  -6.0005880892277E-02
+(PID.TID 0000.0001) %MON obc_E_uVel_mean              =   7.3481638628970E-03
+(PID.TID 0000.0001) %MON obc_E_uVel_sd                =   1.4306979468011E-02
+(PID.TID 0000.0001) %MON obc_E_uVel_Int               =   1.2598139394366E+08
+(PID.TID 0000.0001) %MON obc_W_uVel_max               =   6.0183299084504E-02
+(PID.TID 0000.0001) %MON obc_W_uVel_min               =  -2.5750120480855E-02
+(PID.TID 0000.0001) %MON obc_W_uVel_mean              =   6.9799178140749E-03
+(PID.TID 0000.0001) %MON obc_W_uVel_sd                =   1.1143820768569E-02
+(PID.TID 0000.0001) %MON obc_W_uVel_Int               =   1.3044964329075E+08
+(PID.TID 0000.0001) %MON obc_N_vVel_max               =   4.6934620787700E-02
+(PID.TID 0000.0001) %MON obc_N_vVel_min               =  -7.0970798532168E-02
+(PID.TID 0000.0001) %MON obc_N_vVel_mean              =   1.4762267691452E-04
+(PID.TID 0000.0001) %MON obc_N_vVel_sd                =   6.4285541565376E-03
+(PID.TID 0000.0001) %MON obc_N_vVel_Int               =   4.3155788504734E+06
+(PID.TID 0000.0001) %MON obc_E_theta_max              =   1.9398851394653E+01
+(PID.TID 0000.0001) %MON obc_E_theta_min              =  -1.5564284722010E+00
+(PID.TID 0000.0001) %MON obc_E_theta_mean             =   1.9093663966602E+00
+(PID.TID 0000.0001) %MON obc_E_theta_sd               =   2.9699987672955E+00
+(PID.TID 0000.0001) %MON obc_W_theta_max              =   2.1606541951497E+01
+(PID.TID 0000.0001) %MON obc_W_theta_min              =  -1.4425850311915E+00
+(PID.TID 0000.0001) %MON obc_W_theta_mean             =   2.4675739840607E+00
+(PID.TID 0000.0001) %MON obc_W_theta_sd               =   2.9646670151341E+00
+(PID.TID 0000.0001) %MON obc_N_theta_max              =   2.4181515375773E+01
+(PID.TID 0000.0001) %MON obc_N_theta_min              =  -6.3544931014379E-01
+(PID.TID 0000.0001) %MON obc_N_theta_mean             =   4.8731396883099E+00
+(PID.TID 0000.0001) %MON obc_N_theta_sd               =   4.7097877746890E+00
+(PID.TID 0000.0001) // =======================================================
+(PID.TID 0000.0001) // End OBCS MONITOR field statistics
+(PID.TID 0000.0001) // =======================================================
+(PID.TID 0000.0001) // =======================================================
+(PID.TID 0000.0001) // Begin MONITOR ptracer field statistics
+(PID.TID 0000.0001) // =======================================================
+(PID.TID 0000.0001) %MON trcstat_ptracer01_max        =   2.3591453133227E+00
+(PID.TID 0000.0001) %MON trcstat_ptracer01_min        =   1.9365563814862E+00
+(PID.TID 0000.0001) %MON trcstat_ptracer01_mean       =   2.2425157930180E+00
+(PID.TID 0000.0001) %MON trcstat_ptracer01_sd         =   7.6015769917700E-02
+(PID.TID 0000.0001) %MON trcstat_ptracer01_del2       =   1.0616673265010E-04
+(PID.TID 0000.0001) %MON trcstat_ptracer02_max        =   2.4116881965466E+00
+(PID.TID 0000.0001) %MON trcstat_ptracer02_min        =   2.1902762049508E+00
+(PID.TID 0000.0001) %MON trcstat_ptracer02_mean       =   2.3520477380038E+00
+(PID.TID 0000.0001) %MON trcstat_ptracer02_sd         =   3.5089745012795E-02
+(PID.TID 0000.0001) %MON trcstat_ptracer02_del2       =   8.0568179794797E-05
+(PID.TID 0000.0001) %MON trcstat_ptracer03_max        =   2.7654982933499E-03
+(PID.TID 0000.0001) %MON trcstat_ptracer03_min        =   4.7000348252381E-05
+(PID.TID 0000.0001) %MON trcstat_ptracer03_mean       =   2.0555855624018E-03
+(PID.TID 0000.0001) %MON trcstat_ptracer03_sd         =   5.0338880807836E-04
+(PID.TID 0000.0001) %MON trcstat_ptracer03_del2       =   6.6762191054504E-07
+(PID.TID 0000.0001) %MON trcstat_ptracer04_max        =   2.5992982256490E-04
+(PID.TID 0000.0001) %MON trcstat_ptracer04_min        =  -7.8225528728462E-07
+(PID.TID 0000.0001) %MON trcstat_ptracer04_mean       =   6.2815338882793E-06
+(PID.TID 0000.0001) %MON trcstat_ptracer04_sd         =   2.6493676981253E-05
+(PID.TID 0000.0001) %MON trcstat_ptracer04_del2       =   1.3390690975716E-07
+(PID.TID 0000.0001) %MON trcstat_ptracer05_max        =   3.8392749043023E-01
+(PID.TID 0000.0001) %MON trcstat_ptracer05_min        =   8.2473302296527E-02
+(PID.TID 0000.0001) %MON trcstat_ptracer05_mean       =   2.1411420038195E-01
+(PID.TID 0000.0001) %MON trcstat_ptracer05_sd         =   4.3028416473433E-02
+(PID.TID 0000.0001) %MON trcstat_ptracer05_del2       =   1.1723518895981E-04
+(PID.TID 0000.0001) // =======================================================
+(PID.TID 0000.0001) // End MONITOR ptracer field statistics
+(PID.TID 0000.0001) // =======================================================
+ Computing Diagnostic #     46  VVELMASS     Counter:      10   Parms: VVr     MR      
+           Vector  Mate for  VVELMASS     Diagnostic #     45  UVELMASS exists 
+ Computing Diagnostic #     45  UVELMASS     Counter:      10   Parms: UUr     MR      
+           Vector  Mate for  UVELMASS     Diagnostic #     46  VVELMASS exists 
+ Computing Diagnostic #     26  THETA        Counter:      10   Parms: SMR     MR      
+ Computing Diagnostic #     27  SALT         Counter:      10   Parms: SMR     MR      
+ Computing Diagnostic #    204  GM_PsiX      Counter:      10   Parms: UU      LR      
+           Vector  Mate for  GM_PsiX      Diagnostic #    205  GM_PsiY  exists 
+ Computing Diagnostic #    205  GM_PsiY      Counter:      10   Parms: VV      LR      
+           Vector  Mate for  GM_PsiY      Diagnostic #    204  GM_PsiX  exists 
+ Post-Processing Diag #     48  PhiVEL     Parms: SMR P   MR      
+   from diag: UVELMASS (#    45) Cnt=      10 and diag: VVELMASS (#    46) Cnt=      10
+ diag_cg2d (it=       10) a2dNorm,x2dNorm= 4.382025E-03 , 2.580578E+03 ; Criter= 1.00E-13
+ diag_cg2d : k=   1 , it=   118   119 ; ini,min,last_Res= 4.6401048E+00 1.3836641E-13 8.3280875E-14
+ diag_calc_psivel: bi,bj=   1   1 : npass,nPts=     1     154
+ diag_calc_psivel:            is,js=   2   1 ; ix,jx=  15   1 ; iy,jy=   2  11
+ diag_calc_psivel: bi,bj=   2   1 : npass,nPts=     1     165
+ diag_calc_psivel:            is,js=   1   1 ; ix,jx=  15   1 ; iy,jy=   1  11
+ diag_calc_psivel: bi,bj=   3   1 : npass,nPts=     1     154
+ diag_calc_psivel:            is,js=   1   1 ; ix,jx=  14   1 ; iy,jy=   1  11
+ diag_calc_psivel: bi,bj=   1   2 : npass,nPts=     1     140
+ diag_calc_psivel:            is,js=   2   1 ; ix,jx=  15   1 ; iy,jy=   2  10
+ diag_calc_psivel: bi,bj=   2   2 : npass,nPts=     1     150
+ diag_calc_psivel:            is,js=   1   1 ; ix,jx=  15   1 ; iy,jy=   1  10
+ diag_calc_psivel: bi,bj=   3   2 : npass,nPts=     1     140
+ diag_calc_psivel:            is,js=   1   1 ; ix,jx=  14   1 ; iy,jy=   1  10
+ diag_cg2d : k=   2 , it=   117   118 ; ini,min,last_Res= 3.4623535E+00 1.3351191E-13 7.9137454E-14
+ diag_cg2d : k=   3 , it=   115   116 ; ini,min,last_Res= 1.9802671E+00 1.2528812E-13 7.5702565E-14
+ diag_cg2d : k=   4 , it=   113   114 ; ini,min,last_Res= 2.1004367E+00 1.3088947E-13 6.7517396E-14
+ diag_cg2d : k=   5 , it=   114   115 ; ini,min,last_Res= 2.7419337E+00 1.1731228E-13 5.9478770E-14
+ diag_cg2d : k=   6 , it=   107   108 ; ini,min,last_Res= 1.9661365E+00 1.4552646E-13 8.7440467E-14
+ diag_cg2d : k=   7 , it=   108   109 ; ini,min,last_Res= 2.4720610E+00 1.3433339E-13 6.6274345E-14
+ diag_cg2d : k=   8 , it=   106   107 ; ini,min,last_Res= 2.0341515E+00 1.0865842E-13 6.1845582E-14
+ diag_cg2d : k=   9 , it=   106   107 ; ini,min,last_Res= 2.0921677E+00 1.5951575E-13 8.6497473E-14
+ diag_cg2d : k=  10 , it=   106   107 ; ini,min,last_Res= 1.9862873E+00 1.5872005E-13 8.1157636E-14
+ diag_cg2d : k=  11 , it=   107   108 ; ini,min,last_Res= 2.2278394E+00 1.1529770E-13 6.8774709E-14
+ diag_cg2d : k=  12 , it=   113   114 ; ini,min,last_Res= 2.2733609E+00 1.7056513E-13 9.7881950E-14
+ diag_cg2d : k=  13 , it=    93    94 ; ini,min,last_Res= 2.3369813E+00 1.1754064E-13 5.0199351E-14
+ diag_cg2d : k=  14 , it=    76    77 ; ini,min,last_Res= 1.9509990E+00 1.7733845E-13 9.3994883E-14
+ diag_cg2d : k=  15 , it=    46    47 ; ini,min,last_Res= 1.6967056E+00 1.2685517E-13 6.7570091E-14
+  get Post-Proc. Diag #     49  PsiVEL   from previous computation of Diag #     48
+ Computing Diagnostic #     78  CONVADJ      Counter:      10   Parms: SMR     LR      
+ Compute Stats, Diag. #     23  ETAN      vol(   0 ): 3.508E+14  Parms: SM      M1      
+ Compute Stats, Diag. #     25  DETADT2   vol(   0 ): 3.508E+14  Parms: SM      M1      
+ Compute Stats, Diag. #     26  THETA     vol(   0 ): 1.277E+18  Parms: SMR     MR      
+ Compute Stats, Diag. #     27  SALT      vol(   0 ): 1.277E+18  Parms: SMR     MR      
+ Compute Stats, Diag. #     78  CONVADJ   vol(   0 ): 1.242E+18  Parms: SMR     LR      
+ Compute Stats, Diag. #     30  UVEL      vol(   0 ): 1.242E+18  Parms: UUR     MR      
+ Compute Stats, Diag. #     31  VVEL      vol(   0 ): 1.225E+18  Parms: VVR     MR      
+ Compute Stats, Diag. #     32  WVEL      vol(   0 ): 1.242E+18  Parms: WM      LR      
+ Compute Stats, Diag. #    204  GM_PsiX   vol(   0 ): 1.211E+18  Parms: UU      LR      
+ Compute Stats, Diag. #    205  GM_PsiY   vol(   0 ): 1.200E+18  Parms: VV      LR      
+ Compute Stats, Diag. #    213  TRAC01    vol(   0 ): 1.277E+18  Parms: SMR     MR      
+ Compute Stats, Diag. #    227  TRAC02    vol(   0 ): 1.277E+18  Parms: SMR     MR      
+ Compute Stats, Diag. #    241  TRAC03    vol(   0 ): 1.277E+18  Parms: SMR     MR      
+ Compute Stats, Diag. #    255  TRAC04    vol(   0 ): 1.277E+18  Parms: SMR     MR      
+ Compute Stats, Diag. #    269  TRAC05    vol(   0 ): 1.277E+18  Parms: SMR     MR      
+ Compute Stats, Diag. #    291  DIC3DSIT  vol(   0 ): 1.277E+18  Parms: SMRP    MR      
+ Compute Stats, Diag. #    292  OMEGAC    vol(   0 ): 1.277E+18  Parms: SMRP    MR      
+ Compute Stats, Diag. #    293  DIC3DPH   vol(   0 ): 1.277E+18  Parms: SM P    MR      
+ Compute Stats, Diag. #    294  DIC3DPCO  vol(   0 ): 1.277E+18  Parms: SMRP    MR      
+ Compute Stats, Diag. #    295  DIC3DCO3  vol(   0 ): 1.277E+18  Parms: SMRP    MR      
+(PID.TID 0000.0001) DIAGSTATS_CLOSE_IO: close file: dynStDiag.0000000000.txt , unit=     9
+(PID.TID 0000.0001) %CHECKPOINT        10 ckptA
+(PID.TID 0000.0001)   Seconds in section "ALL                    [THE_MODEL_MAIN]":
+(PID.TID 0000.0001)           User time:   5.9984199802856892
+(PID.TID 0000.0001)         System time:   3.1985998153686523E-002
+(PID.TID 0000.0001)     Wall clock time:   6.0408639907836914
+(PID.TID 0000.0001)          No. starts:           1
+(PID.TID 0000.0001)           No. stops:           1
+(PID.TID 0000.0001)   Seconds in section "INITIALISE_FIXED       [THE_MODEL_MAIN]":
+(PID.TID 0000.0001)           User time:   6.0029000742360950E-002
+(PID.TID 0000.0001)         System time:   3.9009999018162489E-003
+(PID.TID 0000.0001)     Wall clock time:   6.4080953598022461E-002
+(PID.TID 0000.0001)          No. starts:           1
+(PID.TID 0000.0001)           No. stops:           1
+(PID.TID 0000.0001)   Seconds in section "THE_MAIN_LOOP          [THE_MODEL_MAIN]":
+(PID.TID 0000.0001)           User time:   5.9383488260209560
+(PID.TID 0000.0001)         System time:   2.8083998244255781E-002
+(PID.TID 0000.0001)     Wall clock time:   5.9767510890960693
+(PID.TID 0000.0001)          No. starts:           1
+(PID.TID 0000.0001)           No. stops:           1
+(PID.TID 0000.0001)   Seconds in section "INITIALISE_VARIA    [THE_MAIN_LOOP]":
+(PID.TID 0000.0001)           User time:   9.3758001923561096E-002
+(PID.TID 0000.0001)         System time:   1.2119000311940908E-002
+(PID.TID 0000.0001)     Wall clock time:  0.10602998733520508
+(PID.TID 0000.0001)          No. starts:           1
+(PID.TID 0000.0001)           No. stops:           1
+(PID.TID 0000.0001)   Seconds in section "MAIN LOOP           [THE_MAIN_LOOP]":
+(PID.TID 0000.0001)           User time:   5.8445631563663483
+(PID.TID 0000.0001)         System time:   1.5962997451424599E-002
+(PID.TID 0000.0001)     Wall clock time:   5.8706951141357422
+(PID.TID 0000.0001)          No. starts:           1
+(PID.TID 0000.0001)           No. stops:           1
+(PID.TID 0000.0001)   Seconds in section "MAIN_DO_LOOP        [THE_MAIN_LOOP]":
+(PID.TID 0000.0001)           User time:   5.8444621115922928
+(PID.TID 0000.0001)         System time:   1.5962997451424599E-002
+(PID.TID 0000.0001)     Wall clock time:   5.8706066608428955
+(PID.TID 0000.0001)          No. starts:          10
+(PID.TID 0000.0001)           No. stops:          10
+(PID.TID 0000.0001)   Seconds in section "FORWARD_STEP        [MAIN_DO_LOOP]":
+(PID.TID 0000.0001)           User time:   5.8443004488945007
+(PID.TID 0000.0001)         System time:   1.5961999073624611E-002
+(PID.TID 0000.0001)     Wall clock time:   5.8704288005828857
+(PID.TID 0000.0001)          No. starts:          10
+(PID.TID 0000.0001)           No. stops:          10
+(PID.TID 0000.0001)   Seconds in section "DO_STATEVARS_DIAGS  [FORWARD_STEP]":
+(PID.TID 0000.0001)           User time:   9.8513185977935791E-002
+(PID.TID 0000.0001)         System time:   1.0002404451370239E-006
+(PID.TID 0000.0001)     Wall clock time:   9.8537921905517578E-002
+(PID.TID 0000.0001)          No. starts:          20
+(PID.TID 0000.0001)           No. stops:          20
+(PID.TID 0000.0001)   Seconds in section "LOAD_FIELDS_DRIVER  [FORWARD_STEP]":
+(PID.TID 0000.0001)           User time:   1.9291132688522339E-002
+(PID.TID 0000.0001)         System time:   4.0800124406814575E-004
+(PID.TID 0000.0001)     Wall clock time:   2.2109746932983398E-002
+(PID.TID 0000.0001)          No. starts:          10
+(PID.TID 0000.0001)           No. stops:          10
+(PID.TID 0000.0001)   Seconds in section "EXTERNAL_FLDS_LOAD [LOAD_FLDS_DRIVER]":
+(PID.TID 0000.0001)           User time:   3.9969682693481445E-003
+(PID.TID 0000.0001)         System time:   1.0000541806221008E-005
+(PID.TID 0000.0001)     Wall clock time:   4.0121078491210938E-003
+(PID.TID 0000.0001)          No. starts:          10
+(PID.TID 0000.0001)           No. stops:          10
+(PID.TID 0000.0001)   Seconds in section "DO_ATMOSPHERIC_PHYS [FORWARD_STEP]":
+(PID.TID 0000.0001)           User time:   8.5651874542236328E-005
+(PID.TID 0000.0001)         System time:   1.0002404451370239E-006
+(PID.TID 0000.0001)     Wall clock time:   8.4638595581054688E-005
+(PID.TID 0000.0001)          No. starts:          10
+(PID.TID 0000.0001)           No. stops:          10
+(PID.TID 0000.0001)   Seconds in section "DO_OCEANIC_PHYS     [FORWARD_STEP]":
+(PID.TID 0000.0001)           User time:  0.35851092636585236
+(PID.TID 0000.0001)         System time:   9.8999589681625366E-005
+(PID.TID 0000.0001)     Wall clock time:  0.35879850387573242
+(PID.TID 0000.0001)          No. starts:          10
+(PID.TID 0000.0001)           No. stops:          10
+(PID.TID 0000.0001)   Seconds in section "THERMODYNAMICS      [FORWARD_STEP]":
+(PID.TID 0000.0001)           User time:   3.0632503032684326
+(PID.TID 0000.0001)         System time:   0.0000000000000000
+(PID.TID 0000.0001)     Wall clock time:   3.0687279701232910
+(PID.TID 0000.0001)          No. starts:          10
+(PID.TID 0000.0001)           No. stops:          10
+(PID.TID 0000.0001)   Seconds in section "DYNAMICS            [FORWARD_STEP]":
+(PID.TID 0000.0001)           User time:  0.57211667299270630
+(PID.TID 0000.0001)         System time:   0.0000000000000000
+(PID.TID 0000.0001)     Wall clock time:  0.57322597503662109
+(PID.TID 0000.0001)          No. starts:          10
+(PID.TID 0000.0001)           No. stops:          10
+(PID.TID 0000.0001)   Seconds in section "SOLVE_FOR_PRESSURE  [FORWARD_STEP]":
+(PID.TID 0000.0001)           User time:  0.22901052236557007
+(PID.TID 0000.0001)         System time:   0.0000000000000000
+(PID.TID 0000.0001)     Wall clock time:  0.22904920578002930
+(PID.TID 0000.0001)          No. starts:          10
+(PID.TID 0000.0001)           No. stops:          10
+(PID.TID 0000.0001)   Seconds in section "MOM_CORRECTION_STEP [FORWARD_STEP]":
+(PID.TID 0000.0001)           User time:   2.7062237262725830E-002
+(PID.TID 0000.0001)         System time:   0.0000000000000000
+(PID.TID 0000.0001)     Wall clock time:   2.7070045471191406E-002
+(PID.TID 0000.0001)          No. starts:          10
+(PID.TID 0000.0001)           No. stops:          10
+(PID.TID 0000.0001)   Seconds in section "INTEGR_CONTINUITY   [FORWARD_STEP]":
+(PID.TID 0000.0001)           User time:   3.5544395446777344E-002
+(PID.TID 0000.0001)         System time:   0.0000000000000000
+(PID.TID 0000.0001)     Wall clock time:   3.5560369491577148E-002
+(PID.TID 0000.0001)          No. starts:          10
+(PID.TID 0000.0001)           No. stops:          10
+(PID.TID 0000.0001)   Seconds in section "TRC_CORRECTION_STEP [FORWARD_STEP]":
+(PID.TID 0000.0001)           User time:   9.0420246124267578E-005
+(PID.TID 0000.0001)         System time:   0.0000000000000000
+(PID.TID 0000.0001)     Wall clock time:   8.9883804321289062E-005
+(PID.TID 0000.0001)          No. starts:          10
+(PID.TID 0000.0001)           No. stops:          10
+(PID.TID 0000.0001)   Seconds in section "GCHEM_FORCING_SEP  [FORWARD_STEP]":
+(PID.TID 0000.0001)           User time:  0.75452995300292969
+(PID.TID 0000.0001)         System time:   3.5480000078678131E-003
+(PID.TID 0000.0001)     Wall clock time:  0.75899457931518555
+(PID.TID 0000.0001)          No. starts:          10
+(PID.TID 0000.0001)           No. stops:          10
+(PID.TID 0000.0001)   Seconds in section "BLOCKING_EXCHANGES  [FORWARD_STEP]":
+(PID.TID 0000.0001)           User time:   5.5092632770538330E-002
+(PID.TID 0000.0001)         System time:   7.4001029133796692E-005
+(PID.TID 0000.0001)     Wall clock time:   5.5184125900268555E-002
+(PID.TID 0000.0001)          No. starts:          10
+(PID.TID 0000.0001)           No. stops:          10
+(PID.TID 0000.0001)   Seconds in section "MONITOR             [FORWARD_STEP]":
+(PID.TID 0000.0001)           User time:  0.15797179937362671
+(PID.TID 0000.0001)         System time:   0.0000000000000000
+(PID.TID 0000.0001)     Wall clock time:  0.15812349319458008
+(PID.TID 0000.0001)          No. starts:          10
+(PID.TID 0000.0001)           No. stops:          10
+(PID.TID 0000.0001)   Seconds in section "DO_THE_MODEL_IO     [FORWARD_STEP]":
+(PID.TID 0000.0001)           User time:  0.45955932140350342
+(PID.TID 0000.0001)         System time:   1.1824999004602432E-002
+(PID.TID 0000.0001)     Wall clock time:  0.47145223617553711
+(PID.TID 0000.0001)          No. starts:          10
+(PID.TID 0000.0001)           No. stops:          10
+(PID.TID 0000.0001)   Seconds in section "PTRACERS_RESET      [FORWARD_STEP]":
+(PID.TID 0000.0001)           User time:   8.6903572082519531E-005
+(PID.TID 0000.0001)         System time:   0.0000000000000000
+(PID.TID 0000.0001)     Wall clock time:   8.8930130004882812E-005
+(PID.TID 0000.0001)          No. starts:          10
+(PID.TID 0000.0001)           No. stops:          10
+(PID.TID 0000.0001)   Seconds in section "DO_WRITE_PICKUP     [FORWARD_STEP]":
+(PID.TID 0000.0001)           User time:   1.1693358421325684E-002
+(PID.TID 0000.0001)         System time:   0.0000000000000000
+(PID.TID 0000.0001)     Wall clock time:   1.1698722839355469E-002
+(PID.TID 0000.0001)          No. starts:          10
+(PID.TID 0000.0001)           No. stops:          10
+(PID.TID 0000.0001) // ======================================================
+(PID.TID 0000.0001) // Tile <-> Tile communication statistics
+(PID.TID 0000.0001) // ======================================================
+(PID.TID 0000.0001) // o Tile number: 000001
+(PID.TID 0000.0001) //         No. X exchanges =              0
+(PID.TID 0000.0001) //            Max. X spins =              0
+(PID.TID 0000.0001) //            Min. X spins =     1000000000
+(PID.TID 0000.0001) //          Total. X spins =              0
+(PID.TID 0000.0001) //            Avg. X spins =       0.00E+00
+(PID.TID 0000.0001) //         No. Y exchanges =              0
+(PID.TID 0000.0001) //            Max. Y spins =              0
+(PID.TID 0000.0001) //            Min. Y spins =     1000000000
+(PID.TID 0000.0001) //          Total. Y spins =              0
+(PID.TID 0000.0001) //            Avg. Y spins =       0.00E+00
+(PID.TID 0000.0001) // o Tile number: 000002
+(PID.TID 0000.0001) //         No. X exchanges =              0
+(PID.TID 0000.0001) //            Max. X spins =              0
+(PID.TID 0000.0001) //            Min. X spins =     1000000000
+(PID.TID 0000.0001) //          Total. X spins =              0
+(PID.TID 0000.0001) //            Avg. X spins =       0.00E+00
+(PID.TID 0000.0001) //         No. Y exchanges =              0
+(PID.TID 0000.0001) //            Max. Y spins =              0
+(PID.TID 0000.0001) //            Min. Y spins =     1000000000
+(PID.TID 0000.0001) //          Total. Y spins =              0
+(PID.TID 0000.0001) //            Avg. Y spins =       0.00E+00
+(PID.TID 0000.0001) // o Tile number: 000003
+(PID.TID 0000.0001) //         No. X exchanges =              0
+(PID.TID 0000.0001) //            Max. X spins =              0
+(PID.TID 0000.0001) //            Min. X spins =     1000000000
+(PID.TID 0000.0001) //          Total. X spins =              0
+(PID.TID 0000.0001) //            Avg. X spins =       0.00E+00
+(PID.TID 0000.0001) //         No. Y exchanges =              0
+(PID.TID 0000.0001) //            Max. Y spins =              0
+(PID.TID 0000.0001) //            Min. Y spins =     1000000000
+(PID.TID 0000.0001) //          Total. Y spins =              0
+(PID.TID 0000.0001) //            Avg. Y spins =       0.00E+00
+(PID.TID 0000.0001) // o Tile number: 000004
+(PID.TID 0000.0001) //         No. X exchanges =              0
+(PID.TID 0000.0001) //            Max. X spins =              0
+(PID.TID 0000.0001) //            Min. X spins =     1000000000
+(PID.TID 0000.0001) //          Total. X spins =              0
+(PID.TID 0000.0001) //            Avg. X spins =       0.00E+00
+(PID.TID 0000.0001) //         No. Y exchanges =              0
+(PID.TID 0000.0001) //            Max. Y spins =              0
+(PID.TID 0000.0001) //            Min. Y spins =     1000000000
+(PID.TID 0000.0001) //          Total. Y spins =              0
+(PID.TID 0000.0001) //            Avg. Y spins =       0.00E+00
+(PID.TID 0000.0001) // o Tile number: 000005
+(PID.TID 0000.0001) //         No. X exchanges =              0
+(PID.TID 0000.0001) //            Max. X spins =              0
+(PID.TID 0000.0001) //            Min. X spins =     1000000000
+(PID.TID 0000.0001) //          Total. X spins =              0
+(PID.TID 0000.0001) //            Avg. X spins =       0.00E+00
+(PID.TID 0000.0001) //         No. Y exchanges =              0
+(PID.TID 0000.0001) //            Max. Y spins =              0
+(PID.TID 0000.0001) //            Min. Y spins =     1000000000
+(PID.TID 0000.0001) //          Total. Y spins =              0
+(PID.TID 0000.0001) //            Avg. Y spins =       0.00E+00
+(PID.TID 0000.0001) // o Tile number: 000006
+(PID.TID 0000.0001) //         No. X exchanges =              0
+(PID.TID 0000.0001) //            Max. X spins =              0
+(PID.TID 0000.0001) //            Min. X spins =     1000000000
+(PID.TID 0000.0001) //          Total. X spins =              0
+(PID.TID 0000.0001) //            Avg. X spins =       0.00E+00
+(PID.TID 0000.0001) //         No. Y exchanges =              0
+(PID.TID 0000.0001) //            Max. Y spins =              0
+(PID.TID 0000.0001) //            Min. Y spins =     1000000000
+(PID.TID 0000.0001) //          Total. Y spins =              0
+(PID.TID 0000.0001) //            Avg. Y spins =       0.00E+00
+(PID.TID 0000.0001) // o Thread number: 000001
+(PID.TID 0000.0001) //            No. barriers =          21532
+(PID.TID 0000.0001) //      Max. barrier spins =              1
+(PID.TID 0000.0001) //      Min. barrier spins =              1
+(PID.TID 0000.0001) //     Total barrier spins =          21532
+(PID.TID 0000.0001) //      Avg. barrier spins =       1.00E+00
+PROGRAM MAIN: Execution ended Normally

--- a/verification/so_box_biogeo/results/output.caSat3.txt
+++ b/verification/so_box_biogeo/results/output.caSat3.txt
@@ -1,0 +1,4808 @@
+(PID.TID 0000.0001) 
+(PID.TID 0000.0001) // ======================================================
+(PID.TID 0000.0001) //                      MITgcm UV
+(PID.TID 0000.0001) //                      =========
+(PID.TID 0000.0001) // ======================================================
+(PID.TID 0000.0001) // execution environment starting up...
+(PID.TID 0000.0001) 
+(PID.TID 0000.0001) // MITgcmUV version:  checkpoint68m
+(PID.TID 0000.0001) // Build user:        jm_c
+(PID.TID 0000.0001) // Build host:        villon
+(PID.TID 0000.0001) // Build date:        Thu Jan 12 12:38:05 EST 2023
+(PID.TID 0000.0001) 
+(PID.TID 0000.0001) // =======================================================
+(PID.TID 0000.0001) // Execution Environment parameter file "eedata"
+(PID.TID 0000.0001) // =======================================================
+(PID.TID 0000.0001) ># Example "eedata" file
+(PID.TID 0000.0001) ># Lines beginning "#" are comments
+(PID.TID 0000.0001) >#  nTx      :: No. threads per process in X
+(PID.TID 0000.0001) >#  nTy      :: No. threads per process in Y
+(PID.TID 0000.0001) ># debugMode :: print debug msg (sequence of S/R calls)
+(PID.TID 0000.0001) > &EEPARMS
+(PID.TID 0000.0001) > nTx=1,
+(PID.TID 0000.0001) > nTy=1,
+(PID.TID 0000.0001) >#debugMode=.TRUE.,
+(PID.TID 0000.0001) > /
+(PID.TID 0000.0001) ># Note: Some systems use & as the namelist terminator (as shown here).
+(PID.TID 0000.0001) >#       Other systems use a / character.
+(PID.TID 0000.0001) 
+(PID.TID 0000.0001) // =======================================================
+(PID.TID 0000.0001) // Computational Grid Specification ( see files "SIZE.h" )
+(PID.TID 0000.0001) //                                  ( and "eedata"       )
+(PID.TID 0000.0001) // =======================================================
+(PID.TID 0000.0001)      nPx =    1 ; /* No. processes in X */
+(PID.TID 0000.0001)      nPy =    1 ; /* No. processes in Y */
+(PID.TID 0000.0001)      nSx =    3 ; /* No. tiles in X per process */
+(PID.TID 0000.0001)      nSy =    2 ; /* No. tiles in Y per process */
+(PID.TID 0000.0001)      sNx =   14 ; /* Tile size in X */
+(PID.TID 0000.0001)      sNy =   10 ; /* Tile size in Y */
+(PID.TID 0000.0001)      OLx =    3 ; /* Tile overlap distance in X */
+(PID.TID 0000.0001)      OLy =    3 ; /* Tile overlap distance in Y */
+(PID.TID 0000.0001)      nTx =    1 ; /* No. threads in X per process */
+(PID.TID 0000.0001)      nTy =    1 ; /* No. threads in Y per process */
+(PID.TID 0000.0001)       Nr =   15 ; /* No. levels in the vertical   */
+(PID.TID 0000.0001)       Nx =   42 ; /* Total domain size in X ( = nPx*nSx*sNx ) */
+(PID.TID 0000.0001)       Ny =   20 ; /* Total domain size in Y ( = nPy*nSy*sNy ) */
+(PID.TID 0000.0001)   nTiles =    6 ; /* Total no. tiles per process ( = nSx*nSy ) */
+(PID.TID 0000.0001)   nProcs =    1 ; /* Total no. processes ( = nPx*nPy ) */
+(PID.TID 0000.0001) nThreads =    1 ; /* Total no. threads per process ( = nTx*nTy ) */
+(PID.TID 0000.0001) usingMPI =    F ; /* Flag used to control whether MPI is in use */
+(PID.TID 0000.0001)                   /*  note: To execute a program with MPI calls */
+(PID.TID 0000.0001)                   /*  it must be launched appropriately e.g     */
+(PID.TID 0000.0001)                   /*  "mpirun -np 64 ......"                    */
+(PID.TID 0000.0001) useCoupler=   F ; /* Flag used to control communications with   */
+(PID.TID 0000.0001)                   /*  other model components, through a coupler */
+(PID.TID 0000.0001) useNest2W_parent =    F ;/* Control 2-W Nesting comm */
+(PID.TID 0000.0001) useNest2W_child  =    F ;/* Control 2-W Nesting comm */
+(PID.TID 0000.0001) debugMode =    F ; /* print debug msg. (sequence of S/R calls)  */
+(PID.TID 0000.0001) printMapIncludesZeros=    F ; /* print zeros in Std.Output maps */
+(PID.TID 0000.0001) maxLengthPrt1D=   65 /* maxLength of 1D array printed to StdOut */
+(PID.TID 0000.0001) 
+(PID.TID 0000.0001) // ======================================================
+(PID.TID 0000.0001) // Mapping of tiles to threads
+(PID.TID 0000.0001) // ======================================================
+(PID.TID 0000.0001) // -o- Thread   1, tiles (   1:   3,   1:   2)
+(PID.TID 0000.0001) 
+(PID.TID 0000.0001) // ======================================================
+(PID.TID 0000.0001) // Tile <-> Tile connectvity table
+(PID.TID 0000.0001) // ======================================================
+(PID.TID 0000.0001) // Tile number: 000001 (process no. = 000000)
+(PID.TID 0000.0001) //        WEST: Tile = 000003, Process = 000000, Comm = put
+(PID.TID 0000.0001) //                bi = 000003, bj = 000001
+(PID.TID 0000.0001) //        EAST: Tile = 000002, Process = 000000, Comm = put
+(PID.TID 0000.0001) //                bi = 000002, bj = 000001
+(PID.TID 0000.0001) //       SOUTH: Tile = 000004, Process = 000000, Comm = put
+(PID.TID 0000.0001) //                bi = 000001, bj = 000002
+(PID.TID 0000.0001) //       NORTH: Tile = 000004, Process = 000000, Comm = put
+(PID.TID 0000.0001) //                bi = 000001, bj = 000002
+(PID.TID 0000.0001) // Tile number: 000002 (process no. = 000000)
+(PID.TID 0000.0001) //        WEST: Tile = 000001, Process = 000000, Comm = put
+(PID.TID 0000.0001) //                bi = 000001, bj = 000001
+(PID.TID 0000.0001) //        EAST: Tile = 000003, Process = 000000, Comm = put
+(PID.TID 0000.0001) //                bi = 000003, bj = 000001
+(PID.TID 0000.0001) //       SOUTH: Tile = 000005, Process = 000000, Comm = put
+(PID.TID 0000.0001) //                bi = 000002, bj = 000002
+(PID.TID 0000.0001) //       NORTH: Tile = 000005, Process = 000000, Comm = put
+(PID.TID 0000.0001) //                bi = 000002, bj = 000002
+(PID.TID 0000.0001) // Tile number: 000003 (process no. = 000000)
+(PID.TID 0000.0001) //        WEST: Tile = 000002, Process = 000000, Comm = put
+(PID.TID 0000.0001) //                bi = 000002, bj = 000001
+(PID.TID 0000.0001) //        EAST: Tile = 000001, Process = 000000, Comm = put
+(PID.TID 0000.0001) //                bi = 000001, bj = 000001
+(PID.TID 0000.0001) //       SOUTH: Tile = 000006, Process = 000000, Comm = put
+(PID.TID 0000.0001) //                bi = 000003, bj = 000002
+(PID.TID 0000.0001) //       NORTH: Tile = 000006, Process = 000000, Comm = put
+(PID.TID 0000.0001) //                bi = 000003, bj = 000002
+(PID.TID 0000.0001) // Tile number: 000004 (process no. = 000000)
+(PID.TID 0000.0001) //        WEST: Tile = 000006, Process = 000000, Comm = put
+(PID.TID 0000.0001) //                bi = 000003, bj = 000002
+(PID.TID 0000.0001) //        EAST: Tile = 000005, Process = 000000, Comm = put
+(PID.TID 0000.0001) //                bi = 000002, bj = 000002
+(PID.TID 0000.0001) //       SOUTH: Tile = 000001, Process = 000000, Comm = put
+(PID.TID 0000.0001) //                bi = 000001, bj = 000001
+(PID.TID 0000.0001) //       NORTH: Tile = 000001, Process = 000000, Comm = put
+(PID.TID 0000.0001) //                bi = 000001, bj = 000001
+(PID.TID 0000.0001) // Tile number: 000005 (process no. = 000000)
+(PID.TID 0000.0001) //        WEST: Tile = 000004, Process = 000000, Comm = put
+(PID.TID 0000.0001) //                bi = 000001, bj = 000002
+(PID.TID 0000.0001) //        EAST: Tile = 000006, Process = 000000, Comm = put
+(PID.TID 0000.0001) //                bi = 000003, bj = 000002
+(PID.TID 0000.0001) //       SOUTH: Tile = 000002, Process = 000000, Comm = put
+(PID.TID 0000.0001) //                bi = 000002, bj = 000001
+(PID.TID 0000.0001) //       NORTH: Tile = 000002, Process = 000000, Comm = put
+(PID.TID 0000.0001) //                bi = 000002, bj = 000001
+(PID.TID 0000.0001) // Tile number: 000006 (process no. = 000000)
+(PID.TID 0000.0001) //        WEST: Tile = 000005, Process = 000000, Comm = put
+(PID.TID 0000.0001) //                bi = 000002, bj = 000002
+(PID.TID 0000.0001) //        EAST: Tile = 000004, Process = 000000, Comm = put
+(PID.TID 0000.0001) //                bi = 000001, bj = 000002
+(PID.TID 0000.0001) //       SOUTH: Tile = 000003, Process = 000000, Comm = put
+(PID.TID 0000.0001) //                bi = 000003, bj = 000001
+(PID.TID 0000.0001) //       NORTH: Tile = 000003, Process = 000000, Comm = put
+(PID.TID 0000.0001) //                bi = 000003, bj = 000001
+(PID.TID 0000.0001) 
+(PID.TID 0000.0001)  INI_PARMS: opening model parameter file "data"
+(PID.TID 0000.0001)  OPEN_COPY_DATA_FILE: opening file data
+(PID.TID 0000.0001) // =======================================================
+(PID.TID 0000.0001) // Parameter file "data"
+(PID.TID 0000.0001) // =======================================================
+(PID.TID 0000.0001) ># ====================
+(PID.TID 0000.0001) ># | Model parameters |
+(PID.TID 0000.0001) ># ====================
+(PID.TID 0000.0001) >#
+(PID.TID 0000.0001) ># Continuous equation parameters
+(PID.TID 0000.0001) > &PARM01
+(PID.TID 0000.0001) > tRef=15*20.,
+(PID.TID 0000.0001) > sRef=15*35.,
+(PID.TID 0000.0001) > viscAh=3.E5,
+(PID.TID 0000.0001) > viscAz=1.E-3,
+(PID.TID 0000.0001) > diffKhT=0.E3,
+(PID.TID 0000.0001) > diffKhS=0.E3,
+(PID.TID 0000.0001) >#diffKzT=3.E-5,
+(PID.TID 0000.0001) >#diffKzS=3.E-5,
+(PID.TID 0000.0001) > diffKrBL79surf= 3.E-5,
+(PID.TID 0000.0001) > diffKrBL79deep= 13.E-5,
+(PID.TID 0000.0001) > diffKrBL79Ho  = -2000.,
+(PID.TID 0000.0001) > diffKrBL79scl = 150.,
+(PID.TID 0000.0001) > gravity=9.81,
+(PID.TID 0000.0001) > rhoConst=1035.,
+(PID.TID 0000.0001) > rhoConstFresh=1000.,
+(PID.TID 0000.0001) > eosType='JMD95Z',
+(PID.TID 0000.0001) > implicitFreeSurface=.TRUE.,
+(PID.TID 0000.0001) > exactConserv=.TRUE.,
+(PID.TID 0000.0001) >#implicitViscosity=.TRUE.,
+(PID.TID 0000.0001) > implicitDiffusion=.TRUE.,
+(PID.TID 0000.0001) > ivdc_kappa=10.,
+(PID.TID 0000.0001) > allowFreezing=.TRUE.,
+(PID.TID 0000.0001) >#useCDscheme=.TRUE.,
+(PID.TID 0000.0001) ># turn on looped cells
+(PID.TID 0000.0001) > hFacMin=.1,
+(PID.TID 0000.0001) > hFacMindz=50.,
+(PID.TID 0000.0001) >#- I/O params:
+(PID.TID 0000.0001) >#globalFiles=.TRUE.,
+(PID.TID 0000.0001) > /
+(PID.TID 0000.0001) >
+(PID.TID 0000.0001) ># Elliptic solver parameters
+(PID.TID 0000.0001) > &PARM02
+(PID.TID 0000.0001) > cg2dMaxIters=1000,
+(PID.TID 0000.0001) > cg2dTargetResidual=1.E-13,
+(PID.TID 0000.0001) > /
+(PID.TID 0000.0001) >
+(PID.TID 0000.0001) ># Time stepping parameters
+(PID.TID 0000.0001) > &PARM03
+(PID.TID 0000.0001) > nIter0=0,
+(PID.TID 0000.0001) >#nTimeSteps = 1440,
+(PID.TID 0000.0001) > nTimeSteps = 10,
+(PID.TID 0000.0001) >#tauCD      = 321428.,
+(PID.TID 0000.0001) > deltaTMom     = 900.,
+(PID.TID 0000.0001) > deltaTtracer  = 43200.,
+(PID.TID 0000.0001) > deltaTFreeSurf= 43200.,
+(PID.TID 0000.0001) > deltaTClock   = 43200.,
+(PID.TID 0000.0001) > abEps      = 0.1,
+(PID.TID 0000.0001) > pChkptFreq = 311040000.,
+(PID.TID 0000.0001) > chkptFreq  = 31104000.,
+(PID.TID 0000.0001) > dumpFreq   = 2592000.,
+(PID.TID 0000.0001) > monitorFreq= 864000.,
+(PID.TID 0000.0001) > tauThetaClimRelax = 5184000.,
+(PID.TID 0000.0001) > tauSaltClimRelax  = 7776000.,
+(PID.TID 0000.0001) > periodicExternalForcing=.TRUE.,
+(PID.TID 0000.0001) > externForcingPeriod = 2592000.,
+(PID.TID 0000.0001) > externForcingCycle = 31104000.,
+(PID.TID 0000.0001) > monitorFreq= 1.,
+(PID.TID 0000.0001) > /
+(PID.TID 0000.0001) >
+(PID.TID 0000.0001) ># Gridding parameters
+(PID.TID 0000.0001) > &PARM04
+(PID.TID 0000.0001) > usingSphericalPolarGrid=.TRUE.,
+(PID.TID 0000.0001) > delZ=  50., 70.,  100., 140., 190.,
+(PID.TID 0000.0001) >       240., 290., 340., 390., 440.,
+(PID.TID 0000.0001) >       490., 540., 590., 640., 690.,
+(PID.TID 0000.0001) > xgOrigin= 236.25,
+(PID.TID 0000.0001) > ygOrigin= -81.5625,
+(PID.TID 0000.0001) > delX=42*2.8125,
+(PID.TID 0000.0001) > delY=20*2.8125,
+(PID.TID 0000.0001) > /
+(PID.TID 0000.0001) >
+(PID.TID 0000.0001) ># Input datasets
+(PID.TID 0000.0001) > &PARM05
+(PID.TID 0000.0001) > checkIniTemp  = .FALSE.,
+(PID.TID 0000.0001) > bathyFile     = 'bathy_box.bin',
+(PID.TID 0000.0001) > pSurfInitFile = 'Eta_ini.bin',
+(PID.TID 0000.0001) > uVelInitFile  = 'U_ini.bin',
+(PID.TID 0000.0001) > vVelInitFile  = 'V_ini.bin',
+(PID.TID 0000.0001) > hydrogThetaFile='T_ini.bin',
+(PID.TID 0000.0001) > hydrogSaltFile= 'S_ini.bin',
+(PID.TID 0000.0001) > zonalWindFile = 'tren_taux_box.bin',
+(PID.TID 0000.0001) > meridWindFile = 'tren_tauy_box.bin',
+(PID.TID 0000.0001) > thetaClimFile = 'lev_monthly_temp_box.bin',
+(PID.TID 0000.0001) > saltClimFile  = 'lev_monthly_salt_box.bin',
+(PID.TID 0000.0001) > surfQnetFile  = 'shi_qnet_box.bin',
+(PID.TID 0000.0001) > EmPmRFile     = 'shi_empmr_year_box.bin',
+(PID.TID 0000.0001) > the_run_name  = 'OBC + Biogeo S.Ocean Box',
+(PID.TID 0000.0001) > /
+(PID.TID 0000.0001) 
+(PID.TID 0000.0001)  INI_PARMS ; starts to read PARM01
+(PID.TID 0000.0001)  INI_PARMS ; read PARM01 : OK
+(PID.TID 0000.0001)  INI_PARMS ; starts to read PARM02
+(PID.TID 0000.0001)  INI_PARMS ; read PARM02 : OK
+(PID.TID 0000.0001)  INI_PARMS ; starts to read PARM03
+(PID.TID 0000.0001)  INI_PARMS ; read PARM03 : OK
+(PID.TID 0000.0001)  INI_PARMS ; starts to read PARM04
+(PID.TID 0000.0001)  INI_PARMS ; read PARM04 : OK
+(PID.TID 0000.0001)  INI_PARMS ; starts to read PARM05
+(PID.TID 0000.0001)  INI_PARMS ; read PARM05 : OK
+(PID.TID 0000.0001)  INI_PARMS: finished reading file "data"
+(PID.TID 0000.0001)  PACKAGES_BOOT: opening data.pkg
+(PID.TID 0000.0001)  OPEN_COPY_DATA_FILE: opening file data.pkg
+(PID.TID 0000.0001) // =======================================================
+(PID.TID 0000.0001) // Parameter file "data.pkg"
+(PID.TID 0000.0001) // =======================================================
+(PID.TID 0000.0001) ># Packages
+(PID.TID 0000.0001) > &PACKAGES
+(PID.TID 0000.0001) > usePTRACERS=.TRUE.,
+(PID.TID 0000.0001) > useGCHEM =.TRUE.,
+(PID.TID 0000.0001) > useGMRedi=.TRUE.,
+(PID.TID 0000.0001) > useOBCS  =.TRUE.,
+(PID.TID 0000.0001) > useDiagnostics=.TRUE.,
+(PID.TID 0000.0001) > /
+(PID.TID 0000.0001) 
+(PID.TID 0000.0001)  PACKAGES_BOOT: finished reading data.pkg
+(PID.TID 0000.0001)  PACKAGES_BOOT: On/Off package Summary
+ --------  pkgs with a standard "usePKG" On/Off switch in "data.pkg":  --------
+ pkg/obcs                 compiled   and   used ( useOBCS                  = T )
+ pkg/gmredi               compiled   and   used ( useGMRedi                = T )
+ pkg/ptracers             compiled   and   used ( usePTRACERS              = T )
+ pkg/gchem                compiled   and   used ( useGCHEM                 = T )
+ pkg/diagnostics          compiled   and   used ( useDiagnostics           = T )
+ -------- pkgs without standard "usePKG" On/Off switch in "data.pkg":  --------
+ pkg/generic_advdiff      compiled   and   used ( useGAD                   = T )
+ pkg/mom_common           compiled   and   used ( momStepping              = T )
+ pkg/mom_vecinv           compiled but not used ( +vectorInvariantMomentum = F )
+ pkg/mom_fluxform         compiled   and   used ( & not vectorInvariantMom = T )
+ pkg/cd_code              compiled but not used ( useCDscheme              = F )
+ pkg/monitor              compiled   and   used ( monitorFreq > 0.         = T )
+ pkg/debug                compiled but not used ( debugMode                = F )
+ pkg/rw                   compiled   and   used
+ pkg/mdsio                compiled   and   used
+(PID.TID 0000.0001)  PACKAGES_BOOT: End of package Summary
+(PID.TID 0000.0001) 
+(PID.TID 0000.0001)  OBCS_READPARMS: opening data.obcs
+(PID.TID 0000.0001)  OPEN_COPY_DATA_FILE: opening file data.obcs
+(PID.TID 0000.0001) // =======================================================
+(PID.TID 0000.0001) // Parameter file "data.obcs"
+(PID.TID 0000.0001) // =======================================================
+(PID.TID 0000.0001) ># Open-boundaries
+(PID.TID 0000.0001) > &OBCS_PARM01
+(PID.TID 0000.0001) ># This flag turns off checking and fixing problematic topography across
+(PID.TID 0000.0001) ># open boundaries.
+(PID.TID 0000.0001) > OBCSfixTopo=.FALSE.,
+(PID.TID 0000.0001) > OB_Iwest = 20*1,
+(PID.TID 0000.0001) > OB_Ieast = 20*-1,
+(PID.TID 0000.0001) > OB_Jnorth= 42*-1,
+(PID.TID 0000.0001) > OBWconnectFile = 'connect_obW.bin',
+(PID.TID 0000.0001) > OBEconnectFile = 'connect_obE.bin',
+(PID.TID 0000.0001) > OBNconnectFile = 'connect_obN.bin',
+(PID.TID 0000.0001) ># OBWconnectFile = 'zeros_obX.bin',
+(PID.TID 0000.0001) ># OBEconnectFile = 'zeros_obX.bin',
+(PID.TID 0000.0001) ># OBNconnectFile = 'zeros_obX.bin',
+(PID.TID 0000.0001) > useOBCSprescribe = .TRUE.,
+(PID.TID 0000.0001) > OBCS_u1_adv_T = 1,
+(PID.TID 0000.0001) > OBCS_u1_adv_S = 1,
+(PID.TID 0000.0001) > OBCS_u1_adv_Tr(1:5) = 5*1,
+(PID.TID 0000.0001) > OBWuFile = 'U_obW.bin',
+(PID.TID 0000.0001) > OBEuFile = 'U_obE.bin',
+(PID.TID 0000.0001) > OBNuFile = 'U_obN.bin',
+(PID.TID 0000.0001) > OBWvFile = 'V_obW.bin',
+(PID.TID 0000.0001) > OBEvFile = 'V_obE.bin',
+(PID.TID 0000.0001) > OBNvFile = 'V_obN.bin',
+(PID.TID 0000.0001) > OBWtFile = 'T_obW.bin',
+(PID.TID 0000.0001) > OBEtFile = 'T_obE.bin',
+(PID.TID 0000.0001) > OBNtFile = 'T_obN.bin',
+(PID.TID 0000.0001) > OBWsFile = 'S_obW.bin',
+(PID.TID 0000.0001) > OBEsFile = 'S_obE.bin',
+(PID.TID 0000.0001) > OBNsFile = 'S_obN.bin',
+(PID.TID 0000.0001) > OBWptrFile(1) = 'Trac01_obW.bin',
+(PID.TID 0000.0001) > OBEptrFile(1) = 'Trac01_obE.bin',
+(PID.TID 0000.0001) > OBNptrFile(1) = 'Trac01_obN.bin',
+(PID.TID 0000.0001) > OBWptrFile(2) = 'Trac02_obW.bin',
+(PID.TID 0000.0001) > OBEptrFile(2) = 'Trac02_obE.bin',
+(PID.TID 0000.0001) > OBNptrFile(2) = 'Trac02_obN.bin',
+(PID.TID 0000.0001) > OBWptrFile(3) = 'Trac03_obW.bin',
+(PID.TID 0000.0001) > OBEptrFile(3) = 'Trac03_obE.bin',
+(PID.TID 0000.0001) > OBNptrFile(3) = 'Trac03_obN.bin',
+(PID.TID 0000.0001) > OBWptrFile(4) = 'Trac04_obW.bin',
+(PID.TID 0000.0001) > OBEptrFile(4) = 'Trac04_obE.bin',
+(PID.TID 0000.0001) > OBNptrFile(4) = 'Trac04_obN.bin',
+(PID.TID 0000.0001) > OBWptrFile(5) = 'Trac05_obW.bin',
+(PID.TID 0000.0001) > OBEptrFile(5) = 'Trac05_obE.bin',
+(PID.TID 0000.0001) > OBNptrFile(5) = 'Trac05_obN.bin',
+(PID.TID 0000.0001) >#OBCS_monitorFreq= 1200.,
+(PID.TID 0000.0001) > OBCS_monSelect = 1,
+(PID.TID 0000.0001) > /
+(PID.TID 0000.0001) >
+(PID.TID 0000.0001) ># Orlanski parameters
+(PID.TID 0000.0001) > &OBCS_PARM02
+(PID.TID 0000.0001) >#Cmax=0.45,
+(PID.TID 0000.0001) >#cVelTimeScale=1000.,
+(PID.TID 0000.0001) > /
+(PID.TID 0000.0001) 
+(PID.TID 0000.0001)  OBCS_READPARMS: finished reading data.obcs
+(PID.TID 0000.0001)  OB_indexUnset = /* unset OB index value (i.e. no OB) */
+(PID.TID 0000.0001)                       0
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001)  Northern OB global indices : OB_Jnorth =
+(PID.TID 0000.0001)    42 @       20                            /* I =  1: 42 */
+(PID.TID 0000.0001)  Southern OB global indices : OB_Jsouth =
+(PID.TID 0000.0001)    42 @        0                            /* I =  1: 42 */
+(PID.TID 0000.0001)  Eastern  OB global indices : OB_Ieast =
+(PID.TID 0000.0001)    20 @       42                            /* J =  1: 20 */
+(PID.TID 0000.0001)  Western  OB global indices : OB_Iwest =
+(PID.TID 0000.0001)    20 @        1                            /* J =  1: 20 */
+(PID.TID 0000.0001) 
+(PID.TID 0000.0001)  GM_READPARMS: opening data.gmredi
+(PID.TID 0000.0001)  OPEN_COPY_DATA_FILE: opening file data.gmredi
+(PID.TID 0000.0001) // =======================================================
+(PID.TID 0000.0001) // Parameter file "data.gmredi"
+(PID.TID 0000.0001) // =======================================================
+(PID.TID 0000.0001) ># from MOM
+(PID.TID 0000.0001) ># GM_background_K: 	isopycnal diffusion coefficien
+(PID.TID 0000.0001) ># GM_maxSlope:		max slope of isopycnals
+(PID.TID 0000.0001) ># GM_Scrit:		transition for scaling diffusion coefficient
+(PID.TID 0000.0001) ># GM_Sd:		half width scaling for diffusion coefficient
+(PID.TID 0000.0001) ># real background diff:	horizontal diffusion
+(PID.TID 0000.0001) >
+(PID.TID 0000.0001) ># ifdef GM_VISBECK_VARIABLE_K, include following in GM_PARM01
+(PID.TID 0000.0001) ># GM_Visbeck_alpha   = 0.,
+(PID.TID 0000.0001) ># GM_Visbeck_length  = 2.e+5,
+(PID.TID 0000.0001) ># GM_Visbeck_depth   = 1.e+3,
+(PID.TID 0000.0001) ># GM_Visbeck_maxval_K= 2.5e+3,
+(PID.TID 0000.0001) >
+(PID.TID 0000.0001) > &GM_PARM01
+(PID.TID 0000.0001) >  GM_AdvForm         = .TRUE.,
+(PID.TID 0000.0001) >  GM_background_K    = 1.e+3,
+(PID.TID 0000.0001) >  GM_taper_scheme    = 'gkw91',
+(PID.TID 0000.0001) >  GM_maxSlope        = 1.e-2,
+(PID.TID 0000.0001) >  GM_Kmin_horiz      = 100.,
+(PID.TID 0000.0001) >  GM_Scrit           = 4.e-3,
+(PID.TID 0000.0001) >  GM_Sd              = 1.e-3,
+(PID.TID 0000.0001) > /
+(PID.TID 0000.0001) 
+(PID.TID 0000.0001)  GM_READPARMS: finished reading data.gmredi
+(PID.TID 0000.0001)  PTRACERS_READPARMS: opening data.ptracers
+(PID.TID 0000.0001)  OPEN_COPY_DATA_FILE: opening file data.ptracers
+(PID.TID 0000.0001) // =======================================================
+(PID.TID 0000.0001) // Parameter file "data.ptracers"
+(PID.TID 0000.0001) // =======================================================
+(PID.TID 0000.0001) > &PTRACERS_PARM01
+(PID.TID 0000.0001) > PTRACERS_numInUse=5,
+(PID.TID 0000.0001) > PTRACERS_Iter0= 0,
+(PID.TID 0000.0001) ># tracer 1 - dic
+(PID.TID 0000.0001) > PTRACERS_names(1)='DIC',
+(PID.TID 0000.0001) > PTRACERS_long_names(1)='Dissolved Inorganic Carbon (DIC) [mol C/m^3]',
+(PID.TID 0000.0001) > PTRACERS_units(1)='mol/m^3',
+(PID.TID 0000.0001) > PTRACERS_advScheme(1)=77,
+(PID.TID 0000.0001) > PTRACERS_diffKh(1)=0.E3,
+(PID.TID 0000.0001) > PTRACERS_diffKr(1)=3.E-5,
+(PID.TID 0000.0001) > PTRACERS_useGMRedi(1)=.TRUE.,
+(PID.TID 0000.0001) > PTRACERS_initialFile(1)='Trac01_ini.bin',
+(PID.TID 0000.0001) >#- use F95 syntax (to be converted with -DNML_EXTENDED_F77 if needed)
+(PID.TID 0000.0001) > PTRACERS_ref(1:15,1) = 2.0282, 2.0609, 2.1206, 2.1581,
+(PID.TID 0000.0001) >                     2.1904, 2.2188, 2.2474, 2.2699,
+(PID.TID 0000.0001) >                     2.2792, 2.2814, 2.2815, 2.2806,
+(PID.TID 0000.0001) >                     2.2800, 2.2760, 2.2758,
+(PID.TID 0000.0001) > PTRACERS_EvPrRn(1)= 0.,
+(PID.TID 0000.0001) ># tracer 2 - alk
+(PID.TID 0000.0001) > PTRACERS_names(2)='Alk',
+(PID.TID 0000.0001) > PTRACERS_long_names(2)='Alkalinity (Alk) [mol eq/m^3]',
+(PID.TID 0000.0001) > PTRACERS_units(2)='mol/m^3',
+(PID.TID 0000.0001) > PTRACERS_advScheme(2)=77,
+(PID.TID 0000.0001) > PTRACERS_diffKh(2)=0.E3,
+(PID.TID 0000.0001) > PTRACERS_diffKr(2)=3.E-5,
+(PID.TID 0000.0001) > PTRACERS_useGMRedi(2)=.TRUE.,
+(PID.TID 0000.0001) > PTRACERS_initialFile(2)='Trac02_ini.bin',
+(PID.TID 0000.0001) >#- use F95 syntax (to be converted with -DNML_EXTENDED_F77 if needed)
+(PID.TID 0000.0001) > PTRACERS_ref(1:15,2) = 2.3086, 2.3149, 2.3164, 2.3112,
+(PID.TID 0000.0001) >                     2.3098, 2.3160, 2.3313, 2.3517,
+(PID.TID 0000.0001) >                     2.3667, 2.3761, 2.3832, 2.3862,
+(PID.TID 0000.0001) >                     2.3881, 2.3863, 2.3867,
+(PID.TID 0000.0001) > PTRACERS_EvPrRn(2)= 0.,
+(PID.TID 0000.0001) ># tracer 3 - po4
+(PID.TID 0000.0001) > PTRACERS_names(3)='PO4',
+(PID.TID 0000.0001) > PTRACERS_long_names(3)='Phosphate (PO4) [mol P/m^3]',
+(PID.TID 0000.0001) > PTRACERS_units(3)='mol/m^3',
+(PID.TID 0000.0001) > PTRACERS_advScheme(3)=77,
+(PID.TID 0000.0001) > PTRACERS_diffKh(3)=0.E3,
+(PID.TID 0000.0001) > PTRACERS_diffKr(3)=3.E-5,
+(PID.TID 0000.0001) > PTRACERS_useGMRedi(3)=.TRUE.,
+(PID.TID 0000.0001) > PTRACERS_initialFile(3)='Trac03_ini.bin',
+(PID.TID 0000.0001) >#- use F95 syntax (to be converted with -DNML_EXTENDED_F77 if needed)
+(PID.TID 0000.0001) > PTRACERS_ref(1:15,3) = 0.5438E-3, 0.7821E-3, 1.1335E-3, 1.4913E-3,
+(PID.TID 0000.0001) >                     1.8606E-3, 2.1986E-3, 2.3966E-3, 2.4187E-3,
+(PID.TID 0000.0001) >                     2.4046E-3, 2.3291E-3, 2.2922E-3, 2.2886E-3,
+(PID.TID 0000.0001) >                     2.2608E-3, 2.2356E-3, 2.2296E-3,
+(PID.TID 0000.0001) >#PTRACERS_EvPrRn(3)= 0.,
+(PID.TID 0000.0001) ># tracer 4 - dop
+(PID.TID 0000.0001) > PTRACERS_names(4)='DOP',
+(PID.TID 0000.0001) > PTRACERS_long_names(4)='Dissolved Organic Phosphorus (DOP) [mol P/m^3]',
+(PID.TID 0000.0001) > PTRACERS_units(4)='mol/m^3',
+(PID.TID 0000.0001) > PTRACERS_advScheme(4)=77,
+(PID.TID 0000.0001) > PTRACERS_diffKh(4)=0.E3,
+(PID.TID 0000.0001) > PTRACERS_diffKr(4)=3.E-5,
+(PID.TID 0000.0001) > PTRACERS_useGMRedi(4)=.TRUE.,
+(PID.TID 0000.0001) > PTRACERS_initialFile(4)='Trac04_ini.bin',
+(PID.TID 0000.0001) >#- use F95 syntax (to be converted with -DNML_EXTENDED_F77 if needed)
+(PID.TID 0000.0001) > PTRACERS_ref(1:15,4) = 15*0.,
+(PID.TID 0000.0001) >#PTRACERS_EvPrRn(4)= 0.,
+(PID.TID 0000.0001) ># tracer 5 - o2
+(PID.TID 0000.0001) > PTRACERS_names(5)='O2',
+(PID.TID 0000.0001) > PTRACERS_long_names(5)='Dissolved Oxygen (O2) [mol O/m^3]',
+(PID.TID 0000.0001) > PTRACERS_units(5)='mol/m^3',
+(PID.TID 0000.0001) > PTRACERS_advScheme(5)=77,
+(PID.TID 0000.0001) > PTRACERS_diffKh(5)=0.E3,
+(PID.TID 0000.0001) > PTRACERS_diffKr(5)=3.E-5,
+(PID.TID 0000.0001) > PTRACERS_useGMRedi(5)=.TRUE.,
+(PID.TID 0000.0001) > PTRACERS_initialFile(5)='Trac05_ini.bin',
+(PID.TID 0000.0001) >#- use F95 syntax (to be converted with -DNML_EXTENDED_F77 if needed)
+(PID.TID 0000.0001) > PTRACERS_ref(1:15,5) = 0.2457, 0.2336, 0.1975, 0.1729,
+(PID.TID 0000.0001) >                     0.1591, 0.1503, 0.1424, 0.1445,
+(PID.TID 0000.0001) >                     0.1549, 0.1661, 0.1774, 0.1863,
+(PID.TID 0000.0001) >                     0.1925, 0.2021, 0.2051,
+(PID.TID 0000.0001) >#PTRACERS_EvPrRn(5)= 0.,
+(PID.TID 0000.0001) > /
+(PID.TID 0000.0001) 
+(PID.TID 0000.0001)  PTRACERS_READPARMS: finished reading data.ptracers
+(PID.TID 0000.0001)  GCHEM_READPARMS: opening data.gchem
+(PID.TID 0000.0001)  OPEN_COPY_DATA_FILE: opening file data.gchem
+(PID.TID 0000.0001) // =======================================================
+(PID.TID 0000.0001) // Parameter file "data.gchem"
+(PID.TID 0000.0001) // =======================================================
+(PID.TID 0000.0001) > &GCHEM_PARM01
+(PID.TID 0000.0001) >  useDIC=.TRUE.,
+(PID.TID 0000.0001) >  nsubtime=1,
+(PID.TID 0000.0001) > /
+(PID.TID 0000.0001) 
+(PID.TID 0000.0001)  GCHEM_READPARMS: finished reading data.gchem
+(PID.TID 0000.0001)  DIC_READPARMS: opening data.dic
+(PID.TID 0000.0001)  OPEN_COPY_DATA_FILE: opening file data.dic
+(PID.TID 0000.0001) // =======================================================
+(PID.TID 0000.0001) // Parameter file "data.dic"
+(PID.TID 0000.0001) // =======================================================
+(PID.TID 0000.0001) ># DIC parameters
+(PID.TID 0000.0001) > &ABIOTIC_PARMS
+(PID.TID 0000.0001) >  useCalciteSaturation= .TRUE.,
+(PID.TID 0000.0001) ># calcOmegaCalciteFreq= 86400.,
+(PID.TID 0000.0001) >  selectBTconst=1,
+(PID.TID 0000.0001) >  selectFTconst=1,
+(PID.TID 0000.0001) >  selectHFconst=1,
+(PID.TID 0000.0001) >  selectK1K2const=6,
+(PID.TID 0000.0001) ># Munhoven "GENERAL" solver: =1 ; Munhoven "SEC" solver: =2 ; Munhoven "FAST" solver: =3
+(PID.TID 0000.0001) >  selectPHsolver=3,
+(PID.TID 0000.0001) > /
+(PID.TID 0000.0001) >
+(PID.TID 0000.0001) > &BIOTIC_PARMS
+(PID.TID 0000.0001) >  alphaUniform = 0.97e-10,
+(PID.TID 0000.0001) >  rainRatioUniform = 5.e-2,
+(PID.TID 0000.0001) >  KRemin = 0.95,
+(PID.TID 0000.0001) > /
+(PID.TID 0000.0001) >
+(PID.TID 0000.0001) > &DIC_FORCING
+(PID.TID 0000.0001) >  DIC_iceFile='fice_box.bin',
+(PID.TID 0000.0001) >  DIC_windFile='tren_speed_box.bin',
+(PID.TID 0000.0001) >  DIC_silicaFile='sillev1_box.bin',
+(PID.TID 0000.0001) >  DIC_deepSilicaFile='silicate_3D_12m_box.bin',
+(PID.TID 0000.0001) > /
+(PID.TID 0000.0001) 
+(PID.TID 0000.0001)  DIC_READPARMS: finished reading data.dic
+(PID.TID 0000.0001) 
+(PID.TID 0000.0001) // ===================================
+(PID.TID 0000.0001) // DIC package parameters :
+(PID.TID 0000.0001) // ===================================
+(PID.TID 0000.0001) Using Munhoven (2013) Solvesaphe for pH/pCO2
+(PID.TID 0000.0001) Using Munhoven (2013) Solvesaphe carbon coefficients
+(PID.TID 0000.0001) Using Waters et al. (2014) K1 and K2 coefficients
+(PID.TID 0000.0001) Using Dickson and Riley (1979) KF coefficient
+(PID.TID 0000.0001) Using Uppstrom (1974) BT estimation from salinity
+(PID.TID 0000.0001) Using Riley (1965) FT estimation from salinity
+(PID.TID 0000.0001) permil = /* Ref. density to convert mol/m3 to mol/kg */
+(PID.TID 0000.0001)                 9.760858955588092E-04
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) Pa2Atm = /* Atmosph. pressure conversion coeff (to Atm) */
+(PID.TID 0000.0001)                 1.013250000000000E+05
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) zca = /* Scale depth for CaCO3 remineralization (m) */
+(PID.TID 0000.0001)                 3.500000000000000E+03
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) useCalciteSaturation  =  /* Flag for omegaC calculation on/off */
+(PID.TID 0000.0001)                   T
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) calcOmegaCalciteFreq = /* Frequency of calcite saturation calculation (s) */
+(PID.TID 0000.0001)                 4.320000000000000E+04
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) KierRateK = /* Rate constant for calcite dissolution (%/day) */
+(PID.TID 0000.0001)                 7.177000000000000E+00
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) KierRateExp = /* Rate exponent for calcite dissolution */
+(PID.TID 0000.0001)                 4.540000000000000E+00
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) WsinkPIC = /* Sinking speed of particulate inorganic carbon (m/s) */
+(PID.TID 0000.0001)                 1.157407407407407E-03
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) selectCalciteBottomRemin = /* Remineralize CO3 bottom flux: =0: here, =1: top layer */
+(PID.TID 0000.0001)                       1
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) DOPfraction = /* Fraction of new production going to DOP */
+(PID.TID 0000.0001)                 6.700000000000000E-01
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) KDOPRemin = /* DOP remineralization rate (1/s) */
+(PID.TID 0000.0001)                 6.430041152263375E-08
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) KRemin = /* Remin power law coeff. */
+(PID.TID 0000.0001)                 9.500000000000000E-01
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) zcrit = /* Minimum depth for biological activity (m) */
+(PID.TID 0000.0001)                 5.000000000000000E+02
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) O2crit = /* Critical oxygen level (mol/m3) */
+(PID.TID 0000.0001)                 4.000000000000000E-03
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) R_OP = /* Stochiometric ratio R_OP */
+(PID.TID 0000.0001)                -1.700000000000000E+02
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) R_CP = /* Stochiometric ratio R_CP */
+(PID.TID 0000.0001)                 1.170000000000000E+02
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) R_NP = /* Stochiometric ratio R_NP */
+(PID.TID 0000.0001)                 1.600000000000000E+01
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) R_FeP = /* Stochiometric ratio R_FeP */
+(PID.TID 0000.0001)                 4.680000000000000E-04
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) parfrac = /* Fraction of Qsw that is PAR */
+(PID.TID 0000.0001)                 4.000000000000000E-01
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) k0 = /* Light attentuation coefficient, water (1/m) */
+(PID.TID 0000.0001)                 2.000000000000000E-02
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) kchl = /* Light attentuation coefficient, chlorophyll (m2/mg) */
+(PID.TID 0000.0001)                 2.000000000000000E-02
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) lit0 = /* Half saturation light constant (W/m2) */
+(PID.TID 0000.0001)                 3.000000000000000E+01
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) KPO4 = /* Half saturation phosphate constant (mol/m3) */
+(PID.TID 0000.0001)                 5.000000000000000E-04
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) KFE = /* Half saturation fe constant (mol/m3) */
+(PID.TID 0000.0001)                 1.200000000000000E-07
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) alpfe = /* Solubility of aeolian fe */
+(PID.TID 0000.0001)                 1.000000000000000E-02
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) fesedflux_pcm = /* Sediment Fe flux = fesedflux_pcm*pflux+FeIntSec */
+(PID.TID 0000.0001)                 7.208000000000001E-02
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) FeIntSec = /* Sediment Fe flux = fesedflux_pcm * pflux + FeIntSec */
+(PID.TID 0000.0001)                 5.787037037037037E-12
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) freefemax = /* Max solubility of free iron (mol/m3) */
+(PID.TID 0000.0001)                 3.000000000000000E-07
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) KScav = /* Iron scavenging rate */
+(PID.TID 0000.0001)                 6.108539094650206E-09
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) ligand_stab = /* Ligand-free iron stability constant (m3/mol) */
+(PID.TID 0000.0001)                 1.000000000000000E+08
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) ligand_tot = /* Total free ligand  (mol/m3) */
+(PID.TID 0000.0001)                 1.000000000000000E-06
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) alphaUniform = /* Timescale for biological activity */
+(PID.TID 0000.0001)                 9.700000000000000E-11
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) rainRatioUniform= /* Inorganic/organic carbon rain ratio */
+(PID.TID 0000.0001)                 5.000000000000000E-02
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) QSW_underice  =  /* Flag for Qsw under Sea-Ice (i.e. SI fract included) */
+(PID.TID 0000.0001)                   F
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) DIC_windFile =  /* File name of wind speeds */
+(PID.TID 0000.0001)               'tren_speed_box.bin'
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) DIC_atmospFile=  /* File name of atmospheric pressure*/
+(PID.TID 0000.0001)               ''
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) DIC_silicaFile=  /* File name of surface silica */
+(PID.TID 0000.0001)               'sillev1_box.bin'
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) DIC_deepSilicaFile=  /* File name of 3d silica field */
+(PID.TID 0000.0001)               'silicate_3D_12m_box.bin'
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) DIC_iceFile =  /* File name of seaice fraction */
+(PID.TID 0000.0001)               'fice_box.bin'
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) DIC_parFile=  /* File name of photosynthetically available radiation */
+(PID.TID 0000.0001)               ''
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) DIC_chlaFile=  /* File name of chlorophyll climatology */
+(PID.TID 0000.0001)               ''
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) DIC_ironFile =  /* File name of aeolian iron flux */
+(PID.TID 0000.0001)               ''
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) DIC_forcingPeriod = /* Periodic forcing parameter specific for DIC (s) */
+(PID.TID 0000.0001)                 2.592000000000000E+06
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) DIC_forcingCycle = /* Periodic forcing parameter specific for DIC (s) */
+(PID.TID 0000.0001)                 3.110400000000000E+07
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) dic_int1 =  /*  */
+(PID.TID 0000.0001)                       0
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) dic_int2 =  /*  */
+(PID.TID 0000.0001)                       0
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) dic_int3 =  /*  */
+(PID.TID 0000.0001)                       0
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) dic_int4 =  /*  */
+(PID.TID 0000.0001)                       0
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) dic_pCO2 = /* Atmospheric pCO2 to be read in data.dic */
+(PID.TID 0000.0001)                 2.780000000000000E-04
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) GCHEM_TR_REGISTER:  Start registering GCHEM tracers
+(PID.TID 0000.0001)   DIC_TR_REGISTER:  number of DIC tracers=    5
+(PID.TID 0000.0001)   DIC_TR_REGISTER:   starting at pTrc num=    1
+(PID.TID 0000.0001)   DIC_TR_REGISTER:  Numb. Trac & SepForc Trac:    5    5
+(PID.TID 0000.0001) GCHEM_TR_REGISTER:  Numb. Trac & SepForc Trac:    5    5
+(PID.TID 0000.0001) 
+(PID.TID 0000.0001)  DIAGNOSTICS_READPARMS: opening data.diagnostics
+(PID.TID 0000.0001)  OPEN_COPY_DATA_FILE: opening file data.diagnostics
+(PID.TID 0000.0001) // =======================================================
+(PID.TID 0000.0001) // Parameter file "data.diagnostics"
+(PID.TID 0000.0001) // =======================================================
+(PID.TID 0000.0001) ># Diagnostic Package Choices
+(PID.TID 0000.0001) >#--------------------
+(PID.TID 0000.0001) >#  dumpAtLast (logical): always write output at the end of simulation (default=F)
+(PID.TID 0000.0001) >#  diag_mnc   (logical): write to NetCDF files (default=useMNC)
+(PID.TID 0000.0001) >#--for each output-stream:
+(PID.TID 0000.0001) >#  fileName(n) : prefix of the output file name (max 80c long) for outp.stream n
+(PID.TID 0000.0001) >#  frequency(n):< 0 : write snap-shot output every |frequency| seconds
+(PID.TID 0000.0001) >#               > 0 : write time-average output every frequency seconds
+(PID.TID 0000.0001) >#  timePhase(n)     : write at time = timePhase + multiple of |frequency|
+(PID.TID 0000.0001) >#    averagingFreq  : frequency (in s) for periodic averaging interval
+(PID.TID 0000.0001) >#    averagingPhase : phase     (in s) for periodic averaging interval
+(PID.TID 0000.0001) >#    repeatCycle    : number of averaging intervals in 1 cycle
+(PID.TID 0000.0001) >#  levels(:,n) : list of levels to write to file (Notes: declared as REAL)
+(PID.TID 0000.0001) >#                when this entry is missing, select all common levels of this list
+(PID.TID 0000.0001) >#  fields(:,n) : list of selected diagnostics fields (8.c) in outp.stream n
+(PID.TID 0000.0001) >#                (see "available_diagnostics.log" file for the full list of diags)
+(PID.TID 0000.0001) >#  missing_value(n) : missing value for real-type fields in output file "n"
+(PID.TID 0000.0001) >#  fileFlags(n)     : specific code (8c string) for output file "n"
+(PID.TID 0000.0001) >#--------------------
+(PID.TID 0000.0001) > &DIAGNOSTICS_LIST
+(PID.TID 0000.0001) ># diagCG_maxIters = 200,
+(PID.TID 0000.0001) ># diagCG_resTarget = 1.E-10,
+(PID.TID 0000.0001) ># diagCG_pcOffDFac = 0.96,
+(PID.TID 0000.0001) ># diagCG_prtResFrq = 20,
+(PID.TID 0000.0001) >  xPsi0 = 300.,
+(PID.TID 0000.0001) >  yPsi0 = -26.,
+(PID.TID 0000.0001) >#--
+(PID.TID 0000.0001) >  fields(1:10,1) = 'ETAN    ','ETANSQ  ','DETADT2 ','PHIBOT  ','PHIBOTSQ',
+(PID.TID 0000.0001) >                   'DICTFLX ','DICOFLX ','DICCFLX ','DICPCO2 ','DICPHAV ',
+(PID.TID 0000.0001) >   levels(1,1) = 1.,
+(PID.TID 0000.0001) >   fileName(1) = 'surfDiag',
+(PID.TID 0000.0001) >  frequency(1) = 2592000.,
+(PID.TID 0000.0001) ># frequency(1) = 432000.,
+(PID.TID 0000.0001) >  fields(1:9,2)  = 'VVELMASS','UVELMASS','THETA   ','SALT    ',
+(PID.TID 0000.0001) >                   'GM_PsiX ','GM_PsiY ','PhiVEL  ','PsiVEL  ',
+(PID.TID 0000.0001) >                   'CONVADJ ',
+(PID.TID 0000.0001) >   fileName(2) = 'dynDiag',
+(PID.TID 0000.0001) >  frequency(2) = 2592000.,
+(PID.TID 0000.0001) >  frequency(2) = 432000.,
+(PID.TID 0000.0001) >  fields(1:9,3)  = 'DICBIOA ','DICCARB ',
+(PID.TID 0000.0001) >                   'TRAC01  ','TRAC02  ','TRAC03  ','TRAC04  ','TRAC05  ',
+(PID.TID 0000.0001) >                   'ADVxTr05','DFrITr05',
+(PID.TID 0000.0001) >#  fileName(3) = 'dicDiag',
+(PID.TID 0000.0001) >  frequency(3) = 2592000.,
+(PID.TID 0000.0001) >  fields(1:8,4)  = 'ADVx_TH ','ADVy_TH ','ADVr_TH ',
+(PID.TID 0000.0001) >                   'DFxE_TH ','DFyE_TH ','DFrE_TH ','DFrI_TH ',
+(PID.TID 0000.0001) >                   'ADVx_SLT',
+(PID.TID 0000.0001) >#  fileName(4) = 'flxDiag',
+(PID.TID 0000.0001) >  frequency(4) = 0.,
+(PID.TID 0000.0001) > /
+(PID.TID 0000.0001) >
+(PID.TID 0000.0001) >#--------------------
+(PID.TID 0000.0001) ># Parameter for Diagnostics of per level statistics:
+(PID.TID 0000.0001) >#--------------------
+(PID.TID 0000.0001) >#  diagSt_mnc (logical): write stat-diags to NetCDF files (default=diag_mnc)
+(PID.TID 0000.0001) >#  diagSt_regMaskFile : file containing the region-mask to read-in
+(PID.TID 0000.0001) >#  nSetRegMskFile   : number of region-mask sets within the region-mask file
+(PID.TID 0000.0001) >#  set_regMask(i)   : region-mask set-index that identifies the region "i"
+(PID.TID 0000.0001) >#  val_regMask(i)   : region "i" identifier value in the region mask
+(PID.TID 0000.0001) >#--for each output-stream:
+(PID.TID 0000.0001) >#  stat_fName(n) : prefix of the output file name (max 80c long) for outp.stream n
+(PID.TID 0000.0001) >#  stat_freq(n):< 0 : write snap-shot output every |stat_freq| seconds
+(PID.TID 0000.0001) >#               > 0 : write time-average output every stat_freq seconds
+(PID.TID 0000.0001) >#  stat_phase(n)    : write at time = stat_phase + multiple of |stat_freq|
+(PID.TID 0000.0001) >#  stat_region(:,n) : list of "regions" (default: 1 region only=global)
+(PID.TID 0000.0001) >#  stat_fields(:,n) : list of selected diagnostics fields (8.c) in outp.stream n
+(PID.TID 0000.0001) >#                (see "available_diagnostics.log" file for the full list of diags)
+(PID.TID 0000.0001) >#--------------------
+(PID.TID 0000.0001) > &DIAG_STATIS_PARMS
+(PID.TID 0000.0001) >#---
+(PID.TID 0000.0001) > stat_fields(1:20,1) = 'ETAN    ','DETADT2 ','THETA   ','SALT    ','CONVADJ ',
+(PID.TID 0000.0001) >                       'UVEL    ','VVEL    ','WVEL    ','GM_PsiX ','GM_PsiY ',
+(PID.TID 0000.0001) >                       'TRAC01  ','TRAC02  ','TRAC03  ','TRAC04  ','TRAC05  ',
+(PID.TID 0000.0001) >                       'DIC3DSIT','OMEGAC  ','DIC3DPH ','DIC3DPCO','DIC3DCO3',
+(PID.TID 0000.0001) >  stat_fName(1) = 'dynStDiag',
+(PID.TID 0000.0001) >   stat_freq(1) = 432000.,
+(PID.TID 0000.0001) >  stat_phase(1) = 0.,
+(PID.TID 0000.0001) > /
+(PID.TID 0000.0001) 
+(PID.TID 0000.0001) S/R DIAGNOSTICS_READPARMS, read namelist "diagnostics_list": start
+(PID.TID 0000.0001) S/R DIAGNOSTICS_READPARMS, read namelist "diagnostics_list": OK
+(PID.TID 0000.0001) S/R DIAGNOSTICS_READPARMS, read namelist "DIAG_STATIS_PARMS": start
+(PID.TID 0000.0001) S/R DIAGNOSTICS_READPARMS, read namelist "DIAG_STATIS_PARMS": OK
+(PID.TID 0000.0001)  DIAGNOSTICS_READPARMS: global parameter summary:
+(PID.TID 0000.0001)  dumpAtLast = /* always write time-ave diags at the end */
+(PID.TID 0000.0001)                   F
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001)  diag_mnc =   /* write NetCDF output files */
+(PID.TID 0000.0001)                   F
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001)  useMissingValue = /* put MissingValue where mask = 0 */
+(PID.TID 0000.0001)                   F
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001)  diagCG_maxIters = /* max number of iters in diag_cg2d */
+(PID.TID 0000.0001)                    1000
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001)  diagCG_resTarget = /* residual target for diag_cg2d */
+(PID.TID 0000.0001)                 1.000000000000000E-13
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001)  diagCG_pcOffDFac = /* preconditioner off-diagonal factor */
+(PID.TID 0000.0001)                 9.611687812379854E-01
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) -----------------------------------------------------
+(PID.TID 0000.0001)  DIAGNOSTICS_READPARMS: active diagnostics summary:
+(PID.TID 0000.0001) -----------------------------------------------------
+(PID.TID 0000.0001) Creating Output Stream: surfDiag
+(PID.TID 0000.0001) Output Frequency:    2592000.000000 ; Phase:           0.000000
+(PID.TID 0000.0001)  Averaging Freq.:    2592000.000000 , Phase:           0.000000 , Cycle:   1
+(PID.TID 0000.0001)  missing value: -9.990000000000E+02
+(PID.TID 0000.0001)  Levels:       1.
+(PID.TID 0000.0001)  Fields:    ETAN     ETANSQ   DETADT2  PHIBOT   PHIBOTSQ DICTFLX  DICOFLX  DICCFLX  DICPCO2  DICPHAV
+(PID.TID 0000.0001) Creating Output Stream: dynDiag
+(PID.TID 0000.0001) Output Frequency:     432000.000000 ; Phase:           0.000000
+(PID.TID 0000.0001)  Averaging Freq.:     432000.000000 , Phase:           0.000000 , Cycle:   1
+(PID.TID 0000.0001)  missing value: -9.990000000000E+02
+(PID.TID 0000.0001)  Levels:    will be set later
+(PID.TID 0000.0001)  Fields:    VVELMASS UVELMASS THETA    SALT     GM_PsiX  GM_PsiY  PhiVEL   PsiVEL   CONVADJ
+(PID.TID 0000.0001) -----------------------------------------------------
+(PID.TID 0000.0001)  DIAGNOSTICS_READPARMS: statistics diags. summary:
+(PID.TID 0000.0001) Creating Stats. Output Stream: dynStDiag
+(PID.TID 0000.0001) Output Frequency:     432000.000000 ; Phase:           0.000000
+(PID.TID 0000.0001)  Regions:   0
+(PID.TID 0000.0001)  Fields:    ETAN     DETADT2  THETA    SALT     CONVADJ  UVEL     VVEL     WVEL     GM_PsiX  GM_PsiY
+(PID.TID 0000.0001)  Fields:    TRAC01   TRAC02   TRAC03   TRAC04   TRAC05   DIC3DSIT OMEGAC   DIC3DPH  DIC3DPCO DIC3DCO3
+(PID.TID 0000.0001) -----------------------------------------------------
+(PID.TID 0000.0001) 
+(PID.TID 0000.0001) SET_PARMS: done
+(PID.TID 0000.0001) Enter INI_VERTICAL_GRID: setInterFDr=    T ; setCenterDr=    F
+(PID.TID 0000.0001) %MON XC_max                       =   3.5296875000000E+02
+(PID.TID 0000.0001) %MON XC_min                       =   2.3765625000000E+02
+(PID.TID 0000.0001) %MON XC_mean                      =   2.9531250000000E+02
+(PID.TID 0000.0001) %MON XC_sd                        =   3.4090083441706E+01
+(PID.TID 0000.0001) %MON XG_max                       =   3.5156250000000E+02
+(PID.TID 0000.0001) %MON XG_min                       =   2.3625000000000E+02
+(PID.TID 0000.0001) %MON XG_mean                      =   2.9390625000000E+02
+(PID.TID 0000.0001) %MON XG_sd                        =   3.4090083441706E+01
+(PID.TID 0000.0001) %MON DXC_max                      =   2.7929930890376E+05
+(PID.TID 0000.0001) %MON DXC_min                      =   5.3457499214614E+04
+(PID.TID 0000.0001) %MON DXC_mean                     =   1.7889438140789E+05
+(PID.TID 0000.0001) %MON DXC_sd                       =   6.9711490203249E+04
+(PID.TID 0000.0001) %MON DXF_max                      =   2.7929930890376E+05
+(PID.TID 0000.0001) %MON DXF_min                      =   5.3457499214614E+04
+(PID.TID 0000.0001) %MON DXF_mean                     =   1.7889438140789E+05
+(PID.TID 0000.0001) %MON DXF_sd                       =   6.9711490203249E+04
+(PID.TID 0000.0001) %MON DXG_max                      =   2.7576500024724E+05
+(PID.TID 0000.0001) %MON DXG_min                      =   4.5880659601012E+04
+(PID.TID 0000.0001) %MON DXG_mean                     =   1.7292088380237E+05
+(PID.TID 0000.0001) %MON DXG_sd                       =   7.0928664230424E+04
+(PID.TID 0000.0001) %MON DXV_max                      =   2.7576500024724E+05
+(PID.TID 0000.0001) %MON DXV_min                      =   4.5880659601012E+04
+(PID.TID 0000.0001) %MON DXV_mean                     =   1.7292088380237E+05
+(PID.TID 0000.0001) %MON DXV_sd                       =   7.0928664230424E+04
+(PID.TID 0000.0001) %MON YC_max                       =  -2.6718750000000E+01
+(PID.TID 0000.0001) %MON YC_min                       =  -8.0156250000000E+01
+(PID.TID 0000.0001) %MON YC_mean                      =  -5.3437500000000E+01
+(PID.TID 0000.0001) %MON YC_sd                        =   1.6217666148756E+01
+(PID.TID 0000.0001) %MON YG_max                       =  -2.8125000000000E+01
+(PID.TID 0000.0001) %MON YG_min                       =  -8.1562500000000E+01
+(PID.TID 0000.0001) %MON YG_mean                      =  -5.4843750000000E+01
+(PID.TID 0000.0001) %MON YG_sd                        =   1.6217666148756E+01
+(PID.TID 0000.0001) %MON DYC_max                      =   3.1268664380261E+05
+(PID.TID 0000.0001) %MON DYC_min                      =   3.1268664380261E+05
+(PID.TID 0000.0001) %MON DYC_mean                     =   3.1268664380261E+05
+(PID.TID 0000.0001) %MON DYC_sd                       =   6.9849193096161E-10
+(PID.TID 0000.0001) %MON DYF_max                      =   3.1268664380261E+05
+(PID.TID 0000.0001) %MON DYF_min                      =   3.1268664380261E+05
+(PID.TID 0000.0001) %MON DYF_mean                     =   3.1268664380261E+05
+(PID.TID 0000.0001) %MON DYF_sd                       =   6.9849193096161E-10
+(PID.TID 0000.0001) %MON DYG_max                      =   3.1268664380261E+05
+(PID.TID 0000.0001) %MON DYG_min                      =   3.1268664380261E+05
+(PID.TID 0000.0001) %MON DYG_mean                     =   3.1268664380261E+05
+(PID.TID 0000.0001) %MON DYG_sd                       =   6.9849193096161E-10
+(PID.TID 0000.0001) %MON DYU_max                      =   3.1268664380261E+05
+(PID.TID 0000.0001) %MON DYU_min                      =   3.1268664380261E+05
+(PID.TID 0000.0001) %MON DYU_mean                     =   3.1268664380261E+05
+(PID.TID 0000.0001) %MON DYU_sd                       =   6.9849193096161E-10
+(PID.TID 0000.0001) %MON RA_max                       =   8.7324395636096E+10
+(PID.TID 0000.0001) %MON RA_min                       =   1.6713767855193E+10
+(PID.TID 0000.0001) %MON RA_mean                      =   5.5932267789893E+10
+(PID.TID 0000.0001) %MON RA_sd                        =   2.1795663493704E+10
+(PID.TID 0000.0001) %MON RAW_max                      =   8.7324395636096E+10
+(PID.TID 0000.0001) %MON RAW_min                      =   1.6713767855193E+10
+(PID.TID 0000.0001) %MON RAW_mean                     =   5.5932267789893E+10
+(PID.TID 0000.0001) %MON RAW_sd                       =   2.1795663493704E+10
+(PID.TID 0000.0001) %MON RAS_max                      =   8.6219375474631E+10
+(PID.TID 0000.0001) %MON RAS_min                      =   1.4344829161122E+10
+(PID.TID 0000.0001) %MON RAS_mean                     =   5.4064622394411E+10
+(PID.TID 0000.0001) %MON RAS_sd                       =   2.2176219345146E+10
+(PID.TID 0000.0001) %MON RAZ_max                      =   8.6219375474631E+10
+(PID.TID 0000.0001) %MON RAZ_min                      =   1.4344829161122E+10
+(PID.TID 0000.0001) %MON RAZ_mean                     =   5.4064622394411E+10
+(PID.TID 0000.0001) %MON RAZ_sd                       =   2.2176219345146E+10
+(PID.TID 0000.0001) %MON AngleCS_max                  =   1.0000000000000E+00
+(PID.TID 0000.0001) %MON AngleCS_min                  =   1.0000000000000E+00
+(PID.TID 0000.0001) %MON AngleCS_mean                 =   1.0000000000000E+00
+(PID.TID 0000.0001) %MON AngleCS_sd                   =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON AngleSN_max                  =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON AngleSN_min                  =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON AngleSN_mean                 =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON AngleSN_sd                   =   0.0000000000000E+00
+(PID.TID 0000.0001)  MDS_READ_FIELD: opening global file: bathy_box.bin
+(PID.TID 0000.0001) // =======================================================
+(PID.TID 0000.0001) // Field Model R_low (ini_masks_etc)
+(PID.TID 0000.0001) // CMIN =         -5.200000000000000E+03
+(PID.TID 0000.0001) // CMAX =         -5.000000000000000E+01
+(PID.TID 0000.0001) // CINT =          1.907407407407407E+02
+(PID.TID 0000.0001) // SYMBOLS (CMIN->CMAX): -abcdefghijklmnopqrstuvwxyz+
+(PID.TID 0000.0001) //                  0.0: .
+(PID.TID 0000.0001) // RANGE I (Lo:Hi:Step):(    -2:    45:     1)
+(PID.TID 0000.0001) // RANGE J (Lo:Hi:Step):(    23:    -2:    -1)
+(PID.TID 0000.0001) // RANGE K (Lo:Hi:Step):(   1:   1:   1)
+(PID.TID 0000.0001) // =======================================================
+(PID.TID 0000.0001) K =   1
+(PID.TID 0000.0001) //                I=7       I=17      I=21      I=31      I=35      I=45
+(PID.TID 0000.0001) // |--J--|210123456|890123456|234567890|234567890|678901234|678901234|
+(PID.TID 0000.0001) //     23 ...............................+yyyyyyyyyyyyyyxxxyy.........
+(PID.TID 0000.0001) //     22 ...............................++zz..zyxz..zyxy.............
+(PID.TID 0000.0001) //     21 ............................................................
+(PID.TID 0000.0001) //     20 kfeijklmkkjiiihihgffhihgffff........zole..zoledcaabdfhkfeijk
+(PID.TID 0000.0001) //     19 lhehijlmkjihhhihggfeihggfeev........ohgf..ohgfqihdddfilhehij
+(PID.TID 0000.0001) //     18 kfehhikmjjihhhihggfeihggfef+.......shgff.shgfflgiddfhkkfehhi
+(PID.TID 0000.0001) //     17 jggfhhjmjiiiiihgggffhgggfff.......xfbbbdxfbbbdddffggjkjggfhh
+(PID.TID 0000.0001) //     16 ljjeegjmjgfgijihggffihggffp......zfa-aaafa-aaaddddfgklljjeeg
+(PID.TID 0000.0001) //     15 jhgeehkmihfefijihgggjihgggy......h------------abddfhkljhgeeh
+(PID.TID 0000.0001) //     14 jggfghkljigeeefgikiifgikii+...++p---aaa---aaa--adddgjkjggfgh
+(PID.TID 0000.0001) //     13 llifgjlljhgeeeeffhjkeffhjk....++j---------------addfgkllifgj
+(PID.TID 0000.0001) //     12 jllhiklkihfedddddefidddefi....+zsqmb-afamb-afaaabddffhjllhik
+(PID.TID 0000.0001) //     11 hjnjmljhhfedddddddfgddddfgj..+zzsqpnnqjipnnqjigifffdefhjnjml
+(PID.TID 0000.0001) //     10 fijmljhhgeddddaadddfaadddfjlllkjihggjkmwggjkmwvjddfddefijmlj
+(PID.TID 0000.0001) //      9 ffhggdddddccdddddddddddddddfihggggggkkjkggkkjkkjjodddeffhggd
+(PID.TID 0000.0001) //      8 aa-baddaaaaaaaaabbbdaabbbddeghhgilolvxomolvxomnllkefgdaa-bad
+(PID.TID 0000.0001) //     13 llifgjlljhgeeeeffhjkeffhjk....++j---------------addfgkllifgj
+(PID.TID 0000.0001) //     12 jllhiklkihfedddddefidddefi....+zsqmb-afamb-afaaabddffhjllhik
+(PID.TID 0000.0001) //     11 hjnjmljhhfedddddddfgddddfgj..+zzsqpnnqjipnnqjigifffdefhjnjml
+(PID.TID 0000.0001) //     10 fijmljhhgeddddaadddfaadddfjlllkjihggjkmwggjkmwvjddfddefijmlj
+(PID.TID 0000.0001) //      9 ffhggdddddccdddddddddddddddfihggggggkkjkggkkjkkjjodddeffhggd
+(PID.TID 0000.0001) //      8 aa-baddaaaaaaaaabbbdaabbbddeghhgilolvxomolvxomnllkefgdaa-bad
+(PID.TID 0000.0001) //      7 ---aaaaaddaaabdddddedddddefgill..zqjkigdqjkigddddddbaa---aaa
+(PID.TID 0000.0001) //      6 aadddddddddddddddeegdddeeghpy...yxnhgeddnhgedddddddbaaaadddd
+(PID.TID 0000.0001) //      5 dgnhigghffeddffilloxfilloxy....zyxoihgggoihgggdddddddddgnhig
+(PID.TID 0000.0001) //      4 z..npvwvvwy++yyyyxxzyyyxxz......ywttqmigttqmigghggfflyz..npv
+(PID.TID 0000.0001) //      3 ...............................+yyyyyyyyyyyyyyxxxyy.........
+(PID.TID 0000.0001) //      2 ...............................++zz..zyxz..zyxy.............
+(PID.TID 0000.0001) //      1 ............................................................
+(PID.TID 0000.0001) //      0 kfeijklmkkjiiihihgffhihgffff........zole..zoledcaabdfhkfeijk
+(PID.TID 0000.0001) //     -1 lhehijlmkjihhhihggfeihggfeev........ohgf..ohgfqihdddfilhehij
+(PID.TID 0000.0001) //     -2 kfehhikmjjihhhihggfeihggfef+.......shgff.shgfflgiddfhkkfehhi
+(PID.TID 0000.0001) // =======================================================
+(PID.TID 0000.0001) // END OF FIELD                                          =
+(PID.TID 0000.0001) // =======================================================
+(PID.TID 0000.0001) 
+(PID.TID 0000.0001) // =======================================================
+(PID.TID 0000.0001) // Field Model Ro_surf (ini_masks_etc)
+(PID.TID 0000.0001) // CMIN =          1.000000000000000E+32
+(PID.TID 0000.0001) // CMAX =         -1.000000000000000E+32
+(PID.TID 0000.0001) // CINT =          0.000000000000000E+00
+(PID.TID 0000.0001) // SYMBOLS (CMIN->CMAX): -abcdefghijklmnopqrstuvwxyz+
+(PID.TID 0000.0001) //                  0.0: .
+(PID.TID 0000.0001) // RANGE I (Lo:Hi:Step):(    -2:    45:     1)
+(PID.TID 0000.0001) // RANGE J (Lo:Hi:Step):(    23:    -2:    -1)
+(PID.TID 0000.0001) // RANGE K (Lo:Hi:Step):(   1:   1:   1)
+(PID.TID 0000.0001) // =======================================================
+(PID.TID 0000.0001) // =======================================================
+(PID.TID 0000.0001) // END OF FIELD                                          =
+(PID.TID 0000.0001) // =======================================================
+(PID.TID 0000.0001) 
+(PID.TID 0000.0001) // =======================================================
+(PID.TID 0000.0001) // Field hFacC at iteration          0
+(PID.TID 0000.0001) // CMIN =          1.000000000000000E+00
+(PID.TID 0000.0001) // CMAX =          1.000000000000000E+00
+(PID.TID 0000.0001) // CINT =          0.000000000000000E+00
+(PID.TID 0000.0001) // SYMBOLS (CMIN->CMAX): -abcdefghijklmnopqrstuvwxyz+
+(PID.TID 0000.0001) //                  0.0: .
+(PID.TID 0000.0001) // RANGE I (Lo:Hi:Step):(    -2:    45:     1)
+(PID.TID 0000.0001) // RANGE J (Lo:Hi:Step):(    23:    -2:    -1)
+(PID.TID 0000.0001) // RANGE K (Lo:Hi:Step):(   1:   1:   1)
+(PID.TID 0000.0001) // =======================================================
+(PID.TID 0000.0001) // =======================================================
+(PID.TID 0000.0001) // END OF FIELD                                          =
+(PID.TID 0000.0001) // =======================================================
+(PID.TID 0000.0001) 
+(PID.TID 0000.0001) // =======================================================
+(PID.TID 0000.0001) // Field hFacW at iteration          0
+(PID.TID 0000.0001) // CMIN =          1.000000000000000E+00
+(PID.TID 0000.0001) // CMAX =          1.000000000000000E+00
+(PID.TID 0000.0001) // CINT =          0.000000000000000E+00
+(PID.TID 0000.0001) // SYMBOLS (CMIN->CMAX): -abcdefghijklmnopqrstuvwxyz+
+(PID.TID 0000.0001) //                  0.0: .
+(PID.TID 0000.0001) // RANGE I (Lo:Hi:Step):(    -2:    45:     1)
+(PID.TID 0000.0001) // RANGE J (Lo:Hi:Step):(    23:    -2:    -1)
+(PID.TID 0000.0001) // RANGE K (Lo:Hi:Step):(   1:   1:   1)
+(PID.TID 0000.0001) // =======================================================
+(PID.TID 0000.0001) // =======================================================
+(PID.TID 0000.0001) // END OF FIELD                                          =
+(PID.TID 0000.0001) // =======================================================
+(PID.TID 0000.0001) 
+(PID.TID 0000.0001) // =======================================================
+(PID.TID 0000.0001) // Field hFacS at iteration          0
+(PID.TID 0000.0001) // CMIN =          1.000000000000000E+00
+(PID.TID 0000.0001) // CMAX =          1.000000000000000E+00
+(PID.TID 0000.0001) // CINT =          0.000000000000000E+00
+(PID.TID 0000.0001) // SYMBOLS (CMIN->CMAX): -abcdefghijklmnopqrstuvwxyz+
+(PID.TID 0000.0001) //                  0.0: .
+(PID.TID 0000.0001) // RANGE I (Lo:Hi:Step):(    -2:    45:     1)
+(PID.TID 0000.0001) // RANGE J (Lo:Hi:Step):(    23:    -2:    -1)
+(PID.TID 0000.0001) // RANGE K (Lo:Hi:Step):(   1:   1:   1)
+(PID.TID 0000.0001) // =======================================================
+(PID.TID 0000.0001) // =======================================================
+(PID.TID 0000.0001) // END OF FIELD                                          =
+(PID.TID 0000.0001) // =======================================================
+(PID.TID 0000.0001) 
+(PID.TID 0000.0001) GAD_INIT_FIXED: GAD_OlMinSize=  1  0  1
+(PID.TID 0000.0001) 
+(PID.TID 0000.0001) // ===================================
+(PID.TID 0000.0001) // GAD parameters :
+(PID.TID 0000.0001) // ===================================
+(PID.TID 0000.0001) tempAdvScheme =   /* Temp. Horiz.Advection scheme selector */
+(PID.TID 0000.0001)                       2
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) tempVertAdvScheme =   /* Temp. Vert. Advection scheme selector */
+(PID.TID 0000.0001)                       2
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) tempMultiDimAdvec =   /* use Muti-Dim Advec method for Temp */
+(PID.TID 0000.0001)                   F
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) tempSOM_Advection = /* use 2nd Order Moment Advection for Temp */
+(PID.TID 0000.0001)                   F
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) AdamsBashforthGt = /* apply Adams-Bashforth extrapolation on Gt */
+(PID.TID 0000.0001)                   T
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) AdamsBashforth_T = /* apply Adams-Bashforth extrapolation on Temp */
+(PID.TID 0000.0001)                   F
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) saltAdvScheme =   /* Salt. Horiz.advection scheme selector */
+(PID.TID 0000.0001)                       2
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) saltVertAdvScheme =   /* Salt. Vert. Advection scheme selector */
+(PID.TID 0000.0001)                       2
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) saltMultiDimAdvec =   /* use Muti-Dim Advec method for Salt */
+(PID.TID 0000.0001)                   F
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) saltSOM_Advection = /* use 2nd Order Moment Advection for Salt */
+(PID.TID 0000.0001)                   F
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) AdamsBashforthGs = /* apply Adams-Bashforth extrapolation on Gs */
+(PID.TID 0000.0001)                   T
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) AdamsBashforth_S = /* apply Adams-Bashforth extrapolation on Salt */
+(PID.TID 0000.0001)                   F
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) // ===================================
+(PID.TID 0000.0001)  MDS_READ_SEC_XZ: opening global file: connect_obN.bin
+(PID.TID 0000.0001)  MDS_READ_SEC_YZ: opening global file: connect_obE.bin
+(PID.TID 0000.0001)  MDS_READ_SEC_YZ: opening global file: connect_obW.bin
+(PID.TID 0000.0001) OBCS_SET_CONNECT: @ k=   1, maxConnect=         1 , numConnect=         1
+(PID.TID 0000.0001)  listConnect:       1
+(PID.TID 0000.0001) OBCS_SET_CONNECT: @ k=   2, maxConnect=         1 , numConnect=         1
+(PID.TID 0000.0001)  listConnect:       1
+(PID.TID 0000.0001) OBCS_SET_CONNECT: @ k=   3, maxConnect=         1 , numConnect=         1
+(PID.TID 0000.0001)  listConnect:       1
+(PID.TID 0000.0001) OBCS_SET_CONNECT: @ k=   4, maxConnect=         1 , numConnect=         1
+(PID.TID 0000.0001)  listConnect:       1
+(PID.TID 0000.0001) OBCS_SET_CONNECT: @ k=   5, maxConnect=         1 , numConnect=         1
+(PID.TID 0000.0001)  listConnect:       1
+(PID.TID 0000.0001) OBCS_SET_CONNECT: @ k=   6, maxConnect=         1 , numConnect=         1
+(PID.TID 0000.0001)  listConnect:       1
+(PID.TID 0000.0001) OBCS_SET_CONNECT: @ k=   7, maxConnect=         1 , numConnect=         1
+(PID.TID 0000.0001)  listConnect:       1
+(PID.TID 0000.0001) OBCS_SET_CONNECT: @ k=   8, maxConnect=         1 , numConnect=         1
+(PID.TID 0000.0001)  listConnect:       1
+(PID.TID 0000.0001) OBCS_SET_CONNECT: @ k=   9, maxConnect=         1 , numConnect=         1
+(PID.TID 0000.0001)  listConnect:       1
+(PID.TID 0000.0001) OBCS_SET_CONNECT: @ k=  10, maxConnect=         1 , numConnect=         1
+(PID.TID 0000.0001)  listConnect:       1
+(PID.TID 0000.0001) OBCS_SET_CONNECT: @ k=  11, maxConnect=         1 , numConnect=         1
+(PID.TID 0000.0001)  listConnect:       1
+(PID.TID 0000.0001) OBCS_SET_CONNECT: @ k=  12, maxConnect=         1 , numConnect=         1
+(PID.TID 0000.0001)  listConnect:       1
+(PID.TID 0000.0001) OBCS_SET_CONNECT: @ k=  13, maxConnect=         5 , numConnect=         5
+(PID.TID 0000.0001)  listConnect:       1       2       3       4       5
+(PID.TID 0000.0001) OBCS_SET_CONNECT: @ k=  14, maxConnect=         5 , numConnect=         5
+(PID.TID 0000.0001)  listConnect:       1       2       3       4       5
+(PID.TID 0000.0001) OBCS_SET_CONNECT: @ k=  15, maxConnect=         3 , numConnect=         2
+(PID.TID 0000.0001)  listConnect:       1       3
+(PID.TID 0000.0001) PTRACERS_INIT_FIXED: updated GAD_OlMinSize=  2  0  1
+ QQ load dic parameters, initial fixed
+(PID.TID 0000.0001) 
+(PID.TID 0000.0001) // ===================================
+(PID.TID 0000.0001) //  DIC_INIT_FIXED parameters :
+(PID.TID 0000.0001) nlev = /* Number of level over which Bio act is computed */
+(PID.TID 0000.0001)                       6
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) ------------------------------------------------------------
+(PID.TID 0000.0001) DIAGNOSTICS_SET_LEVELS: done
+(PID.TID 0000.0001)  Total Nb of available Diagnostics: ndiagt=   300
+(PID.TID 0000.0001)  write list of available Diagnostics to file: available_diagnostics.log
+(PID.TID 0000.0001) SETDIAG: Allocate  1 x  1 Levels for Diagnostic #    23 ETAN
+(PID.TID 0000.0001) SETDIAG: Allocate  1 x  1 Levels for Diagnostic #    24 ETANSQ
+(PID.TID 0000.0001) SETDIAG: Allocate  1 x  1 Levels for Diagnostic #    25 DETADT2
+(PID.TID 0000.0001) SETDIAG: Allocate  1 x  1 Levels for Diagnostic #    73 PHIBOT
+(PID.TID 0000.0001) SETDIAG: Allocate  1 x  1 Levels for Diagnostic #    74 PHIBOTSQ
+(PID.TID 0000.0001) SETDIAG: Allocate  1 x  1 Levels for Diagnostic #   286 DICTFLX
+(PID.TID 0000.0001) SETDIAG: Allocate  1 x  1 Levels for Diagnostic #   287 DICOFLX
+(PID.TID 0000.0001) SETDIAG: Allocate  1 x  1 Levels for Diagnostic #   288 DICCFLX
+(PID.TID 0000.0001) SETDIAG: Allocate  1 x  1 Levels for Diagnostic #   289 DICPCO2
+(PID.TID 0000.0001) SETDIAG: Allocate  1 x  1 Levels for Diagnostic #   290 DICPHAV
+(PID.TID 0000.0001) SETDIAG: Allocate 15 x  1 Levels for Diagnostic #    46 VVELMASS
+(PID.TID 0000.0001) SETDIAG: Allocate 15 x  1 Levels for Diagnostic #    45 UVELMASS
+(PID.TID 0000.0001) SETDIAG: Allocate 15 x  1 Levels for Diagnostic #    26 THETA
+(PID.TID 0000.0001) SETDIAG: Allocate 15 x  1 Levels for Diagnostic #    27 SALT
+(PID.TID 0000.0001) SETDIAG: Allocate 15 x  1 Levels for Diagnostic #   204 GM_PsiX
+(PID.TID 0000.0001) SETDIAG: Allocate 15 x  1 Levels for Diagnostic #   205 GM_PsiY
+(PID.TID 0000.0001) SETDIAG: Diag #    48 PhiVEL   processed from Diag #    45 UVELMASS
+(PID.TID 0000.0001) - NOTE - SETDIAG:  Diagnostic  #    45 UVELMASS is already set
+(PID.TID 0000.0001) - NOTE - SETDIAG:  Vector-mate #    46 VVELMASS is already set
+(PID.TID 0000.0001) SETDIAG: Diag #    49 PsiVEL   processed from Diag #    48 PhiVEL
+(PID.TID 0000.0001) - NOTE - SETDIAG:  Diagnostic  #    48 PhiVEL   is already set
+(PID.TID 0000.0001) SETDIAG: Allocate 15 x  1 Levels for Diagnostic #    78 CONVADJ
+(PID.TID 0000.0001)   space allocated for all diagnostics:     115 levels
+(PID.TID 0000.0001)   set mate pointer for diag #    46  VVELMASS , Parms: VVr     MR , mate:    45
+(PID.TID 0000.0001)   set mate pointer for diag #    45  UVELMASS , Parms: UUr     MR , mate:    46
+(PID.TID 0000.0001)   set mate pointer for diag #   204  GM_PsiX  , Parms: UU      LR , mate:   205
+(PID.TID 0000.0001)   set mate pointer for diag #   205  GM_PsiY  , Parms: VV      LR , mate:   204
+(PID.TID 0000.0001) DIAGNOSTICS_SET_POINTERS: Set levels for Outp.Stream: dynDiag
+(PID.TID 0000.0001)  Levels:       1.   2.   3.   4.   5.   6.   7.   8.   9.  10.  11.  12.  13.  14.  15.
+(PID.TID 0000.0001) DIAGNOSTICS_SET_POINTERS: done
+(PID.TID 0000.0001) ------------------------------------------------------------
+(PID.TID 0000.0001) DIAGNOSTICS_SET_CALC: setting indices iPsi0,jPsi0 where Psi == 0 :
+(PID.TID 0000.0001) DIAGNOSTICS_SET_CALC: d2Min=       5.394531E+00, ijMin=         925.000
+(PID.TID 0000.0001)  SELECT : bi,bj=    2    2 ; i,j=   10   10 ; ijLoc=         925.000
+(PID.TID 0000.0001) ------------------------------------------------------------
+(PID.TID 0000.0001) DIAGSTATS_SET_REGIONS: define no region
+(PID.TID 0000.0001) ------------------------------------------------------------
+(PID.TID 0000.0001) SETDIAG: Allocate  1 Levels for Stats-Diag #    23 ETAN
+(PID.TID 0000.0001) SETDIAG: Allocate  1 Levels for Stats-Diag #    25 DETADT2
+(PID.TID 0000.0001) SETDIAG: Allocate 15 Levels for Stats-Diag #    26 THETA
+(PID.TID 0000.0001) SETDIAG: Allocate 15 Levels for Stats-Diag #    27 SALT
+(PID.TID 0000.0001) SETDIAG: Allocate 15 Levels for Stats-Diag #    78 CONVADJ
+(PID.TID 0000.0001) SETDIAG: Allocate 15 Levels for Stats-Diag #    30 UVEL
+(PID.TID 0000.0001) SETDIAG: Allocate 15 Levels for Stats-Diag #    31 VVEL
+(PID.TID 0000.0001) SETDIAG: Allocate 15 Levels for Stats-Diag #    32 WVEL
+(PID.TID 0000.0001) SETDIAG: Allocate 15 Levels for Stats-Diag #   204 GM_PsiX
+(PID.TID 0000.0001) SETDIAG: Allocate 15 Levels for Stats-Diag #   205 GM_PsiY
+(PID.TID 0000.0001) SETDIAG: Allocate 15 Levels for Stats-Diag #   213 TRAC01
+(PID.TID 0000.0001) SETDIAG: Allocate 15 Levels for Stats-Diag #   227 TRAC02
+(PID.TID 0000.0001) SETDIAG: Allocate 15 Levels for Stats-Diag #   241 TRAC03
+(PID.TID 0000.0001) SETDIAG: Allocate 15 Levels for Stats-Diag #   255 TRAC04
+(PID.TID 0000.0001) SETDIAG: Allocate 15 Levels for Stats-Diag #   269 TRAC05
+(PID.TID 0000.0001) SETDIAG: Allocate 15 Levels for Stats-Diag #   291 DIC3DSIT
+(PID.TID 0000.0001) SETDIAG: Allocate 15 Levels for Stats-Diag #   292 OMEGAC
+(PID.TID 0000.0001) SETDIAG: Allocate 15 Levels for Stats-Diag #   293 DIC3DPH
+(PID.TID 0000.0001) SETDIAG: Allocate 15 Levels for Stats-Diag #   294 DIC3DPCO
+(PID.TID 0000.0001) SETDIAG: Allocate 15 Levels for Stats-Diag #   295 DIC3DCO3
+(PID.TID 0000.0001)   space allocated for all stats-diags:     272 levels
+(PID.TID 0000.0001) DIAGSTATS_SET_POINTERS: done
+(PID.TID 0000.0001) ------------------------------------------------------------
+(PID.TID 0000.0001) DIAGSTATS_INI_IO: open file: dynStDiag.0000000000.txt , unit=     9
+(PID.TID 0000.0001) %MON fCori_max                    =  -6.5572427009593E-05
+(PID.TID 0000.0001) %MON fCori_min                    =  -1.4369532533658E-04
+(PID.TID 0000.0001) %MON fCori_mean                   =  -1.1250506132776E-04
+(PID.TID 0000.0001) %MON fCori_sd                     =   2.4357644817991E-05
+(PID.TID 0000.0001) %MON fCoriG_max                   =  -6.8749664608828E-05
+(PID.TID 0000.0001) %MON fCoriG_min                   =  -1.4426394581537E-04
+(PID.TID 0000.0001) %MON fCoriG_mean                  =  -1.1451888327629E-04
+(PID.TID 0000.0001) %MON fCoriG_sd                    =   2.3580812438249E-05
+(PID.TID 0000.0001) %MON fCoriCos_max                 =   1.3027003865390E-04
+(PID.TID 0000.0001) %MON fCoriCos_min                 =   2.4933504190762E-05
+(PID.TID 0000.0001) %MON fCoriCos_mean                =   8.3439440192105E-05
+(PID.TID 0000.0001) %MON fCoriCos_sd                  =   3.2514647311668E-05
+(PID.TID 0000.0001) INI_CG2D: CG2D normalisation factor =  7.8420435099722891E-05
+(PID.TID 0000.0001) 
+(PID.TID 0000.0001) // =======================================================
+(PID.TID 0000.0001) // Model configuration
+(PID.TID 0000.0001) // =======================================================
+(PID.TID 0000.0001) //
+(PID.TID 0000.0001) // "Physical" paramters ( PARM01 in namelist )
+(PID.TID 0000.0001) //
+(PID.TID 0000.0001) buoyancyRelation = /* Type of relation to get Buoyancy */
+(PID.TID 0000.0001)               'OCEANIC'
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) fluidIsAir   =  /* fluid major constituent is Air */
+(PID.TID 0000.0001)                   F
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) fluidIsWater =  /* fluid major constituent is Water */
+(PID.TID 0000.0001)                   T
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) usingPCoords =  /* use p (or p*) vertical coordinate */
+(PID.TID 0000.0001)                   F
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) usingZCoords =  /* use z (or z*) vertical coordinate */
+(PID.TID 0000.0001)                   T
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) tRef =   /* Reference temperature profile ( oC or K ) */
+(PID.TID 0000.0001)    15 @  2.000000000000000E+01              /* K =  1: 15 */
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) sRef =   /* Reference salinity profile ( g/kg ) */
+(PID.TID 0000.0001)    15 @  3.500000000000000E+01              /* K =  1: 15 */
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) rhoRef =   /* Density vertical profile from (Ref,sRef)( kg/m^3 ) */
+(PID.TID 0000.0001)                 1.024872626184147E+03,      /* K =  1 */
+(PID.TID 0000.0001)                 1.025135462285008E+03,      /* K =  2 */
+(PID.TID 0000.0001)                 1.025507198938228E+03,      /* K =  3 */
+(PID.TID 0000.0001)                 1.026030780760464E+03,      /* K =  4 */
+(PID.TID 0000.0001)                 1.026748377776259E+03,      /* K =  5 */
+(PID.TID 0000.0001)                 1.027679406285166E+03,      /* K =  6 */
+(PID.TID 0000.0001)                 1.028820735595355E+03,      /* K =  7 */
+(PID.TID 0000.0001)                 1.030168558073105E+03,      /* K =  8 */
+(PID.TID 0000.0001)                 1.031718419899614E+03,      /* K =  9 */
+(PID.TID 0000.0001)                 1.033465256541184E+03,      /* K = 10 */
+(PID.TID 0000.0001)                 1.035403432414885E+03,      /* K = 11 */
+(PID.TID 0000.0001)                 1.037526784183520E+03,      /* K = 12 */
+(PID.TID 0000.0001)                 1.039828667078104E+03,      /* K = 13 */
+(PID.TID 0000.0001)                 1.042302003623418E+03,      /* K = 14 */
+(PID.TID 0000.0001)                 1.044939334132512E+03       /* K = 15 */
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) dBdrRef = /* Vertical grad. of reference buoyancy [(m/s/r)^2] */
+(PID.TID 0000.0001)    15 @  0.000000000000000E+00              /* K =  1: 15 */
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) useStrainTensionVisc= /* Use StrainTension Form of Viscous Operator */
+(PID.TID 0000.0001)                   F
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) useVariableVisc = /* Use variable horizontal viscosity */
+(PID.TID 0000.0001)                   F
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) useHarmonicVisc = /* Use harmonic horizontal viscosity */
+(PID.TID 0000.0001)                   T
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) useBiharmonicVisc= /* Use biharmonic horiz.  viscosity */
+(PID.TID 0000.0001)                   F
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) useSmag3D = /* Use isotropic 3-D Smagorinsky viscosity */
+(PID.TID 0000.0001)                   F
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) viscAh  =   /* Lateral harmonic viscosity ( m^2/s ) */
+(PID.TID 0000.0001)                 3.000000000000000E+05
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) viscA4  =   /* Lateral biharmonic viscosity ( m^4/s ) */
+(PID.TID 0000.0001)                 0.000000000000000E+00
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) no_slip_sides =  /* Viscous BCs: No-slip sides */
+(PID.TID 0000.0001)                   T
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) sideDragFactor = /* side-drag scaling factor (non-dim) */
+(PID.TID 0000.0001)                 2.000000000000000E+00
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) viscArNr = /* vertical profile of vertical viscosity ( m^2/s )*/
+(PID.TID 0000.0001)    15 @  1.000000000000000E-03              /* K =  1: 15 */
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) no_slip_bottom =  /* Viscous BCs: No-slip bottom */
+(PID.TID 0000.0001)                   T
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) bottomVisc_pCell = /* Partial-cell in bottom Visc. BC */
+(PID.TID 0000.0001)                   F
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) bottomDragLinear = /* linear bottom-drag coefficient ( m/s ) */
+(PID.TID 0000.0001)                 0.000000000000000E+00
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) bottomDragQuadratic = /* quadratic bottom-drag coefficient (-) */
+(PID.TID 0000.0001)                 0.000000000000000E+00
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) selectBotDragQuadr = /* select quadratic bottom drag options */
+(PID.TID 0000.0001)                      -1
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) diffKhT =   /* Laplacian diffusion of heat laterally ( m^2/s ) */
+(PID.TID 0000.0001)                 0.000000000000000E+00
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) diffK4T =   /* Biharmonic diffusion of heat laterally ( m^4/s ) */
+(PID.TID 0000.0001)                 0.000000000000000E+00
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) diffKhS =   /* Laplacian diffusion of salt laterally ( m^2/s ) */
+(PID.TID 0000.0001)                 0.000000000000000E+00
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) diffK4S =   /* Biharmonic diffusion of salt laterally ( m^4/s ) */
+(PID.TID 0000.0001)                 0.000000000000000E+00
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) diffKrNrT = /* vertical profile of vertical diffusion of Temp ( m^2/s )*/
+(PID.TID 0000.0001)    15 @  0.000000000000000E+00              /* K =  1: 15 */
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) diffKrNrS = /* vertical profile of vertical diffusion of Salt ( m^2/s )*/
+(PID.TID 0000.0001)    15 @  0.000000000000000E+00              /* K =  1: 15 */
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) diffKrBL79surf = /* Surface diffusion for Bryan and Lewis 79 ( m^2/s ) */
+(PID.TID 0000.0001)                 3.000000000000000E-05
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) diffKrBL79deep = /* Deep diffusion for Bryan and Lewis 1979 ( m^2/s ) */
+(PID.TID 0000.0001)                 1.300000000000000E-04
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) diffKrBL79scl = /* Depth scale for Bryan and Lewis 1979 ( m ) */
+(PID.TID 0000.0001)                 1.500000000000000E+02
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) diffKrBL79Ho = /* Turning depth for Bryan and Lewis 1979 ( m ) */
+(PID.TID 0000.0001)                -2.000000000000000E+03
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) ivdc_kappa = /* Implicit Vertical Diffusivity for Convection ( m^2/s) */
+(PID.TID 0000.0001)                 1.000000000000000E+01
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) hMixCriteria=  /* Criteria for mixed-layer diagnostic */
+(PID.TID 0000.0001)                -8.000000000000000E-01
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) dRhoSmall =  /* Parameter for mixed-layer diagnostic */
+(PID.TID 0000.0001)                 1.000000000000000E-06
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) hMixSmooth=  /* Smoothing parameter for mixed-layer diagnostic */
+(PID.TID 0000.0001)                 0.000000000000000E+00
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) eosType =  /* Type of Equation of State */
+(PID.TID 0000.0001)               'JMD95Z'
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) eosRefP0 = /* Reference atmospheric pressure for EOS ( Pa ) */
+(PID.TID 0000.0001)                 1.013250000000000E+05
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) selectP_inEOS_Zc = /* select pressure to use in EOS (0,1,2,3) */
+(PID.TID 0000.0001)                       0
+(PID.TID 0000.0001)     0= -g*rhoConst*z ; 1= pRef (from tRef,sRef); 2= Hyd P ; 3= Hyd+NH P
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) surf_pRef = /* Surface reference pressure ( Pa ) */
+(PID.TID 0000.0001)                 1.013250000000000E+05
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) HeatCapacity_Cp =  /* Specific heat capacity ( J/kg/K ) */
+(PID.TID 0000.0001)                 3.994000000000000E+03
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) celsius2K = /* 0 degree Celsius converted to Kelvin ( K ) */
+(PID.TID 0000.0001)                 2.731500000000000E+02
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) rhoConst  = /* Reference density (Boussinesq)  ( kg/m^3 ) */
+(PID.TID 0000.0001)                 1.035000000000000E+03
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) rhoFacC = /* normalized Reference density @ cell-Center (-) */
+(PID.TID 0000.0001)    15 @  1.000000000000000E+00              /* K =  1: 15 */
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) rhoFacF = /* normalized Reference density @ W-Interface (-) */
+(PID.TID 0000.0001)    16 @  1.000000000000000E+00              /* K =  1: 16 */
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) rhoConstFresh = /* Fresh-water reference density ( kg/m^3 ) */
+(PID.TID 0000.0001)                 1.000000000000000E+03
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) gravity =   /* Gravitational acceleration ( m/s^2 ) */
+(PID.TID 0000.0001)                 9.810000000000000E+00
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) gBaro =   /* Barotropic gravity ( m/s^2 ) */
+(PID.TID 0000.0001)                 9.810000000000000E+00
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) gravFacC = /* gravity factor (vs surf.) @ cell-Center (-) */
+(PID.TID 0000.0001)    15 @  1.000000000000000E+00              /* K =  1: 15 */
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) gravFacF = /* gravity factor (vs surf.) @ W-Interface (-) */
+(PID.TID 0000.0001)    16 @  1.000000000000000E+00              /* K =  1: 16 */
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) rotationPeriod =   /* Rotation Period ( s ) */
+(PID.TID 0000.0001)                 8.616400000000000E+04
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) omega =   /* Angular velocity ( rad/s ) */
+(PID.TID 0000.0001)                 7.292123516990375E-05
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) f0 =   /* Reference coriolis parameter ( 1/s ) */
+(PID.TID 0000.0001)                 1.000000000000000E-04
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) beta =   /* Beta ( 1/(m.s) ) */
+(PID.TID 0000.0001)                 9.999999999999999E-12
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) fPrime =   /* Second coriolis parameter ( 1/s ) */
+(PID.TID 0000.0001)                 0.000000000000000E+00
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) rigidLid =   /* Rigid lid on/off flag */
+(PID.TID 0000.0001)                   F
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) implicitFreeSurface =   /* Implicit free surface on/off flag */
+(PID.TID 0000.0001)                   T
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) freeSurfFac =   /* Implicit free surface factor */
+(PID.TID 0000.0001)                 1.000000000000000E+00
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) implicSurfPress =  /* Surface Pressure implicit factor (0-1) */
+(PID.TID 0000.0001)                 1.000000000000000E+00
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) implicDiv2DFlow =  /* Barot. Flow Div. implicit factor (0-1) */
+(PID.TID 0000.0001)                 1.000000000000000E+00
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) uniformLin_PhiSurf = /* use uniform Bo_surf on/off flag */
+(PID.TID 0000.0001)                   T
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) uniformFreeSurfLev = /* free-surface level-index is uniform */
+(PID.TID 0000.0001)                   T
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) sIceLoadFac =  /* scale factor for sIceLoad (0-1) */
+(PID.TID 0000.0001)                 1.000000000000000E+00
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) hFacMin =   /* minimum partial cell factor (hFac) */
+(PID.TID 0000.0001)                 1.000000000000000E-01
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) hFacMinDr = /* minimum partial cell thickness ( m) */
+(PID.TID 0000.0001)                 5.000000000000000E+01
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) exactConserv =  /* Exact Volume Conservation on/off flag */
+(PID.TID 0000.0001)                   T
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) linFSConserveTr = /* Tracer correction for Lin Free Surface on/off flag */
+(PID.TID 0000.0001)                   F
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) nonlinFreeSurf = /* Non-linear Free Surf. options (-1,0,1,2,3)*/
+(PID.TID 0000.0001)                       0
+(PID.TID 0000.0001)      -1,0= Off ; 1,2,3= On, 2=+rescale gU,gV, 3=+update cg2d solv.
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) hFacInf =   /* lower threshold for hFac (nonlinFreeSurf only)*/
+(PID.TID 0000.0001)                 2.000000000000000E-01
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) hFacSup =   /* upper threshold for hFac (nonlinFreeSurf only)*/
+(PID.TID 0000.0001)                 2.000000000000000E+00
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) select_rStar = /* r* Vertical coord. options (=0 r coord.; >0 uses r*)*/
+(PID.TID 0000.0001)                       0
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) useRealFreshWaterFlux = /* Real Fresh Water Flux on/off flag*/
+(PID.TID 0000.0001)                   F
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) temp_EvPrRn = /* Temp. of Evap/Prec/R (UNSET=use local T)(oC)*/
+(PID.TID 0000.0001)                 1.234567000000000E+05
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) salt_EvPrRn = /* Salin. of Evap/Prec/R (UNSET=use local S)(g/kg)*/
+(PID.TID 0000.0001)                 0.000000000000000E+00
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) selectAddFluid = /* option for mass source/sink of fluid (=0: off) */
+(PID.TID 0000.0001)                       0
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) temp_addMass = /* Temp. of addMass array (UNSET=use local T)(oC)*/
+(PID.TID 0000.0001)                 1.234567000000000E+05
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) salt_addMass = /* Salin. of addMass array (UNSET=use local S)(g/kg)*/
+(PID.TID 0000.0001)                 0.000000000000000E+00
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) convertFW2Salt = /* convert F.W. Flux to Salt Flux (-1=use local S)(g/kg)*/
+(PID.TID 0000.0001)                 3.500000000000000E+01
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) use3Dsolver = /* use 3-D pressure solver on/off flag */
+(PID.TID 0000.0001)                   F
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) nonHydrostatic =  /* Non-Hydrostatic on/off flag */
+(PID.TID 0000.0001)                   F
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) nh_Am2 = /* Non-Hydrostatic terms scaling factor */
+(PID.TID 0000.0001)                 1.000000000000000E+00
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) implicitNHPress = /* Non-Hyd Pressure implicit factor (0-1)*/
+(PID.TID 0000.0001)                 1.000000000000000E+00
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) selectNHfreeSurf = /* Non-Hyd (free-)Surface option */
+(PID.TID 0000.0001)                       0
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) quasiHydrostatic = /* Quasi-Hydrostatic on/off flag */
+(PID.TID 0000.0001)                   F
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) calc_wVelocity = /* vertical velocity calculation on/off flag */
+(PID.TID 0000.0001)                   T
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) momStepping =  /* Momentum equation on/off flag */
+(PID.TID 0000.0001)                   T
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) vectorInvariantMomentum= /* Vector-Invariant Momentum on/off */
+(PID.TID 0000.0001)                   F
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) momAdvection =  /* Momentum advection on/off flag */
+(PID.TID 0000.0001)                   T
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) momViscosity =  /* Momentum viscosity on/off flag */
+(PID.TID 0000.0001)                   T
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) momImplVertAdv= /* Momentum implicit vert. advection on/off*/
+(PID.TID 0000.0001)                   F
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) implicitViscosity = /* Implicit viscosity on/off flag */
+(PID.TID 0000.0001)                   F
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) selectImplicitDrag= /* Implicit bot Drag options (0,1,2)*/
+(PID.TID 0000.0001)                       0
+(PID.TID 0000.0001)     0= Expl. ; 1= Impl. on provis. Vel ; 2= Fully Impl (with surf.P)
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) metricTerms =  /* metric-Terms on/off flag */
+(PID.TID 0000.0001)                   T
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) useNHMTerms = /* Non-Hydrostatic Metric-Terms on/off */
+(PID.TID 0000.0001)                   F
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) selectCoriMap = /* Coriolis Map options (0,1,2,3)*/
+(PID.TID 0000.0001)                       2
+(PID.TID 0000.0001)     0= f-Plane ; 1= Beta-Plane ; 2= Spherical ; 3= read from file
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) use3dCoriolis = /* 3-D Coriolis on/off flag */
+(PID.TID 0000.0001)                   F
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) useCoriolis =  /* Coriolis on/off flag */
+(PID.TID 0000.0001)                   T
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) useCDscheme =  /* CD scheme on/off flag */
+(PID.TID 0000.0001)                   F
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) selectCoriScheme= /* Scheme selector for Coriolis-Term */
+(PID.TID 0000.0001)                       0
+(PID.TID 0000.0001)    = 0 : original discretization (simple averaging, no hFac)
+(PID.TID 0000.0001)    = 1 : Wet-point averaging (Jamar & Ozer 1986)
+(PID.TID 0000.0001)    = 2 : energy conserving scheme (no hFac weight)
+(PID.TID 0000.0001)    = 3 : energy conserving scheme using Wet-point averaging
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) momForcing =  /* Momentum forcing on/off flag */
+(PID.TID 0000.0001)                   T
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) momTidalForcing = /* Momentum Tidal forcing on/off flag */
+(PID.TID 0000.0001)                   T
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) momPressureForcing =  /* Momentum pressure term on/off flag */
+(PID.TID 0000.0001)                   T
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) implicitIntGravWave= /* Implicit Internal Gravity Wave flag */
+(PID.TID 0000.0001)                   F
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) staggerTimeStep =    /* Stagger time stepping on/off flag */
+(PID.TID 0000.0001)                   F
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) doResetHFactors = /* reset thickness factors @ each time-step */
+(PID.TID 0000.0001)                   F
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) multiDimAdvection =  /* enable/disable Multi-Dim Advection */
+(PID.TID 0000.0001)                   T
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) useMultiDimAdvec =   /* Multi-Dim Advection is/is-not used */
+(PID.TID 0000.0001)                   T
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) implicitDiffusion = /* Implicit Diffusion on/off flag */
+(PID.TID 0000.0001)                   T
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) tempStepping =  /* Temperature equation on/off flag */
+(PID.TID 0000.0001)                   T
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) tempAdvection = /* Temperature advection on/off flag */
+(PID.TID 0000.0001)                   T
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) tempImplVertAdv = /* Temp. implicit vert. advection on/off */
+(PID.TID 0000.0001)                   F
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) tempForcing  =  /* Temperature forcing on/off flag */
+(PID.TID 0000.0001)                   T
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) doThetaClimRelax = /* apply SST relaxation on/off flag */
+(PID.TID 0000.0001)                   T
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) tempIsActiveTr = /* Temp. is a dynamically Active Tracer */
+(PID.TID 0000.0001)                   T
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) saltStepping =  /* Salinity equation on/off flag */
+(PID.TID 0000.0001)                   T
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) saltAdvection = /* Salinity advection on/off flag */
+(PID.TID 0000.0001)                   T
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) saltImplVertAdv = /* Sali. implicit vert. advection on/off */
+(PID.TID 0000.0001)                   F
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) saltForcing  =  /* Salinity forcing on/off flag */
+(PID.TID 0000.0001)                   T
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) doSaltClimRelax = /* apply SSS relaxation on/off flag */
+(PID.TID 0000.0001)                   T
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) saltIsActiveTr = /* Salt  is a dynamically Active Tracer */
+(PID.TID 0000.0001)                   T
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001)  readBinaryPrec = /* Precision used for reading binary files */
+(PID.TID 0000.0001)                      32
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) writeBinaryPrec = /* Precision used for writing binary files */
+(PID.TID 0000.0001)                      32
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001)  rwSuffixType =   /* select format of mds file suffix */
+(PID.TID 0000.0001)                       0
+(PID.TID 0000.0001)    = 0 : myIter (I10.10) ;   = 1 : 100*myTime (100th sec) ;
+(PID.TID 0000.0001)    = 2 : myTime (seconds);   = 3 : myTime/360 (10th of hr);
+(PID.TID 0000.0001)    = 4 : myTime/3600 (hours)
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001)  globalFiles = /* write "global" (=not per tile) files */
+(PID.TID 0000.0001)                   F
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001)  useSingleCpuIO = /* only master MPI process does I/O */
+(PID.TID 0000.0001)                   F
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001)  useSingleCpuInput = /* only master process reads input */
+(PID.TID 0000.0001)                   F
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) /* debLev[*]  : level of debug & auxiliary message printing */
+(PID.TID 0000.0001) debLevZero =  0 ; /* level of disabled aux. msg printing */
+(PID.TID 0000.0001)    debLevA =  1 ; /* level of minimum  aux. msg printing */
+(PID.TID 0000.0001)    debLevB =  2 ; /* level of low aux. print (report read-file opening)*/
+(PID.TID 0000.0001)    debLevC =  3 ; /* level of moderate debug prt (most pkgs debug msg) */
+(PID.TID 0000.0001)    debLevD =  4 ; /* level of enhanced debug prt (add DEBUG_STATS prt) */
+(PID.TID 0000.0001)    debLevE =  5 ; /* level of extensive debug printing */
+(PID.TID 0000.0001) debugLevel =  /* select debug printing level */
+(PID.TID 0000.0001)                       2
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001)  plotLevel =  /* select PLOT_FIELD printing level */
+(PID.TID 0000.0001)                       2
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) //
+(PID.TID 0000.0001) // Elliptic solver(s) paramters ( PARM02 in namelist )
+(PID.TID 0000.0001) //
+(PID.TID 0000.0001) cg2dMaxIters =   /* Upper limit on 2d con. grad iterations  */
+(PID.TID 0000.0001)                    1000
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) cg2dMinItersNSA =   /* Minimum number of iterations of 2d con. grad solver  */
+(PID.TID 0000.0001)                       0
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) cg2dUseMinResSol= /* use cg2d last-iter(=0) / min-resid.(=1) solution */
+(PID.TID 0000.0001)                       0
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) cg2dTargetResidual =   /* 2d con. grad target residual  */
+(PID.TID 0000.0001)                 1.000000000000000E-13
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) cg2dTargetResWunit =   /* CG2d target residual [W units] */
+(PID.TID 0000.0001)                -1.000000000000000E+00
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) cg2dPreCondFreq =   /* Freq. for updating cg2d preconditioner */
+(PID.TID 0000.0001)                       1
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) useSRCGSolver =  /* use single reduction CG solver(s) */
+(PID.TID 0000.0001)                   F
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) useNSACGSolver =  /* use not-self-adjoint CG solver */
+(PID.TID 0000.0001)                   F
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) printResidualFreq = /* Freq. for printing CG residual */
+(PID.TID 0000.0001)                       0
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) //
+(PID.TID 0000.0001) // Time stepping paramters ( PARM03 in namelist )
+(PID.TID 0000.0001) //
+(PID.TID 0000.0001) deltaTMom =   /* Momentum equation timestep ( s ) */
+(PID.TID 0000.0001)                 9.000000000000000E+02
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) deltaTFreeSurf = /* FreeSurface equation timestep ( s ) */
+(PID.TID 0000.0001)                 4.320000000000000E+04
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) dTtracerLev =  /* Tracer equation timestep ( s ) */
+(PID.TID 0000.0001)    15 @  4.320000000000000E+04              /* K =  1: 15 */
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) deltaTClock  =   /* Model clock timestep ( s ) */
+(PID.TID 0000.0001)                 4.320000000000000E+04
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) cAdjFreq =   /* Convective adjustment interval ( s ) */
+(PID.TID 0000.0001)                 0.000000000000000E+00
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) momForcingOutAB = /* =1: take Momentum Forcing out of Adams-Bash. stepping */
+(PID.TID 0000.0001)                       0
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) tracForcingOutAB = /* =1: take T,S,pTr Forcing out of Adams-Bash. stepping */
+(PID.TID 0000.0001)                       0
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) momDissip_In_AB = /* put Dissipation Tendency in Adams-Bash. stepping */
+(PID.TID 0000.0001)                   T
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) doAB_onGtGs = /* apply AB on Tendencies (rather than on T,S)*/
+(PID.TID 0000.0001)                   T
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) abEps =   /* Adams-Bashforth-2 stabilizing weight */
+(PID.TID 0000.0001)                 1.000000000000000E-01
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) applyExchUV_early = /* Apply EXCH to U,V earlier in time-step */
+(PID.TID 0000.0001)                   F
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) pickupStrictlyMatch= /* stop if pickup do not strictly match */
+(PID.TID 0000.0001)                   T
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) nIter0   =   /* Run starting timestep number */
+(PID.TID 0000.0001)                       0
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) nTimeSteps = /* Number of timesteps */
+(PID.TID 0000.0001)                      10
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) nEndIter =   /* Run ending timestep number */
+(PID.TID 0000.0001)                      10
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) baseTime =   /* Model base time ( s ) */
+(PID.TID 0000.0001)                 0.000000000000000E+00
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) startTime =  /* Run start time ( s ) */
+(PID.TID 0000.0001)                 0.000000000000000E+00
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) endTime  =   /* Integration ending time ( s ) */
+(PID.TID 0000.0001)                 4.320000000000000E+05
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) pChkPtFreq = /* Permanent restart/pickup file interval ( s ) */
+(PID.TID 0000.0001)                 3.110400000000000E+08
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) chkPtFreq  = /* Rolling restart/pickup file interval ( s ) */
+(PID.TID 0000.0001)                 3.110400000000000E+07
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) pickup_write_mdsio =   /* Model IO flag. */
+(PID.TID 0000.0001)                   T
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) pickup_read_mdsio =   /* Model IO flag. */
+(PID.TID 0000.0001)                   T
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) writePickupAtEnd =   /* Model IO flag. */
+(PID.TID 0000.0001)                   T
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) dumpFreq =   /* Model state write out interval ( s ). */
+(PID.TID 0000.0001)                 2.592000000000000E+06
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) dumpInitAndLast= /* write out Initial & Last iter. model state */
+(PID.TID 0000.0001)                   T
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) snapshot_mdsio =   /* Model IO flag. */
+(PID.TID 0000.0001)                   T
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) monitorFreq =   /* Monitor output interval ( s ). */
+(PID.TID 0000.0001)                 1.000000000000000E+00
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) monitorSelect = /* select group of variables to monitor */
+(PID.TID 0000.0001)                       3
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) monitor_stdio =   /* Model IO flag. */
+(PID.TID 0000.0001)                   T
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) externForcingPeriod =   /* forcing period (s) */
+(PID.TID 0000.0001)                 2.592000000000000E+06
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) externForcingCycle =   /* period of the cyle (s). */
+(PID.TID 0000.0001)                 3.110400000000000E+07
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) tauThetaClimRelax =   /* relaxation time scale (s) */
+(PID.TID 0000.0001)                 5.184000000000000E+06
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) tauSaltClimRelax =   /* relaxation time scale (s) */
+(PID.TID 0000.0001)                 7.776000000000000E+06
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) latBandClimRelax =   /* max. Lat. where relaxation */
+(PID.TID 0000.0001)                 1.800000000000000E+02
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) //
+(PID.TID 0000.0001) // Gridding paramters ( PARM04 in namelist )
+(PID.TID 0000.0001) //
+(PID.TID 0000.0001) usingCartesianGrid = /* Cartesian coordinates flag ( True/False ) */
+(PID.TID 0000.0001)                   F
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) usingCylindricalGrid = /* Cylindrical coordinates flag ( True/False ) */
+(PID.TID 0000.0001)                   F
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) usingSphericalPolarGrid = /* Spherical coordinates flag ( True/False ) */
+(PID.TID 0000.0001)                   T
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) usingCurvilinearGrid = /* Curvilinear coordinates flag ( True/False ) */
+(PID.TID 0000.0001)                   F
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) useMin4hFacEdges = /* set hFacW,S as minimum of adjacent hFacC factor */
+(PID.TID 0000.0001)                   F
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) interViscAr_pCell = /* account for partial-cell in interior vert. viscosity */
+(PID.TID 0000.0001)                   F
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) interDiffKr_pCell = /* account for partial-cell in interior vert. diffusion */
+(PID.TID 0000.0001)                   F
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) pCellMix_select = /* option to enhance mixing near surface & bottom */
+(PID.TID 0000.0001)                       0
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) selectSigmaCoord = /* Hybrid-Sigma Vert. Coordinate option */
+(PID.TID 0000.0001)                       0
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) rSigmaBnd = /* r/sigma transition ( units of r ==  m ) */
+(PID.TID 0000.0001)                 1.234567000000000E+05
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) rkSign =   /* index orientation relative to vertical coordinate */
+(PID.TID 0000.0001)                -1.000000000000000E+00
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) gravitySign = /* gravity orientation relative to vertical coordinate */
+(PID.TID 0000.0001)                -1.000000000000000E+00
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) seaLev_Z =  /* reference height of sea-level [m] */
+(PID.TID 0000.0001)                 0.000000000000000E+00
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) top_Pres =  /* reference pressure at the top [Pa] */
+(PID.TID 0000.0001)                 0.000000000000000E+00
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) mass2rUnit = /* convert mass per unit area [kg/m2] to r-units [m] */
+(PID.TID 0000.0001)                 9.661835748792270E-04
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) rUnit2mass = /* convert r-units [m] to mass per unit area [kg/m2] */
+(PID.TID 0000.0001)                 1.035000000000000E+03
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) drC =   /* C spacing ( units of r ) */
+(PID.TID 0000.0001)                 2.500000000000000E+01,      /* K =  1 */
+(PID.TID 0000.0001)                 6.000000000000000E+01,      /* K =  2 */
+(PID.TID 0000.0001)                 8.500000000000000E+01,      /* K =  3 */
+(PID.TID 0000.0001)                 1.200000000000000E+02,      /* K =  4 */
+(PID.TID 0000.0001)                 1.650000000000000E+02,      /* K =  5 */
+(PID.TID 0000.0001)                 2.150000000000000E+02,      /* K =  6 */
+(PID.TID 0000.0001)                 2.650000000000000E+02,      /* K =  7 */
+(PID.TID 0000.0001)                 3.150000000000000E+02,      /* K =  8 */
+(PID.TID 0000.0001)                 3.650000000000000E+02,      /* K =  9 */
+(PID.TID 0000.0001)                 4.150000000000000E+02,      /* K = 10 */
+(PID.TID 0000.0001)                 4.650000000000000E+02,      /* K = 11 */
+(PID.TID 0000.0001)                 5.150000000000000E+02,      /* K = 12 */
+(PID.TID 0000.0001)                 5.650000000000000E+02,      /* K = 13 */
+(PID.TID 0000.0001)                 6.150000000000000E+02,      /* K = 14 */
+(PID.TID 0000.0001)                 6.650000000000000E+02,      /* K = 15 */
+(PID.TID 0000.0001)                 3.450000000000000E+02       /* K = 16 */
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) drF =   /* W spacing ( units of r ) */
+(PID.TID 0000.0001)                 5.000000000000000E+01,      /* K =  1 */
+(PID.TID 0000.0001)                 7.000000000000000E+01,      /* K =  2 */
+(PID.TID 0000.0001)                 1.000000000000000E+02,      /* K =  3 */
+(PID.TID 0000.0001)                 1.400000000000000E+02,      /* K =  4 */
+(PID.TID 0000.0001)                 1.900000000000000E+02,      /* K =  5 */
+(PID.TID 0000.0001)                 2.400000000000000E+02,      /* K =  6 */
+(PID.TID 0000.0001)                 2.900000000000000E+02,      /* K =  7 */
+(PID.TID 0000.0001)                 3.400000000000000E+02,      /* K =  8 */
+(PID.TID 0000.0001)                 3.900000000000000E+02,      /* K =  9 */
+(PID.TID 0000.0001)                 4.400000000000000E+02,      /* K = 10 */
+(PID.TID 0000.0001)                 4.900000000000000E+02,      /* K = 11 */
+(PID.TID 0000.0001)                 5.400000000000000E+02,      /* K = 12 */
+(PID.TID 0000.0001)                 5.900000000000000E+02,      /* K = 13 */
+(PID.TID 0000.0001)                 6.400000000000000E+02,      /* K = 14 */
+(PID.TID 0000.0001)                 6.900000000000000E+02       /* K = 15 */
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) delX = /* U spacing ( m - cartesian, degrees - spherical ) */
+(PID.TID 0000.0001)    42 @  2.812500000000000E+00              /* I =  1: 42 */
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) delY = /* V spacing ( m - cartesian, degrees - spherical ) */
+(PID.TID 0000.0001)    20 @  2.812500000000000E+00              /* J =  1: 20 */
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) xgOrigin = /* X-axis origin of West  edge (cartesian: m, lat-lon: deg) */
+(PID.TID 0000.0001)                 2.362500000000000E+02
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) ygOrigin = /* Y-axis origin of South edge (cartesian: m, lat-lon: deg) */
+(PID.TID 0000.0001)                -8.156250000000000E+01
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) rSphere =  /* Radius ( ignored - cartesian, m - spherical ) */
+(PID.TID 0000.0001)                 6.370000000000000E+06
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) deepAtmosphere = /* Deep/Shallow Atmosphere flag (True/False) */
+(PID.TID 0000.0001)                   F
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) xC =  /* xC(:,1,:,1) : P-point X coord ( deg. or m if cartesian) */
+(PID.TID 0000.0001)                 2.376562500000000E+02,      /* I =  1 */
+(PID.TID 0000.0001)                 2.404687500000000E+02,      /* I =  2 */
+(PID.TID 0000.0001)                 2.432812500000000E+02,      /* I =  3 */
+(PID.TID 0000.0001)                 2.460937500000000E+02,      /* I =  4 */
+(PID.TID 0000.0001)                 2.489062500000000E+02,      /* I =  5 */
+(PID.TID 0000.0001)                 2.517187500000000E+02,      /* I =  6 */
+(PID.TID 0000.0001)                 2.545312500000000E+02,      /* I =  7 */
+(PID.TID 0000.0001)                 2.573437500000000E+02,      /* I =  8 */
+(PID.TID 0000.0001)                 2.601562500000000E+02,      /* I =  9 */
+(PID.TID 0000.0001)                 2.629687500000000E+02,      /* I = 10 */
+(PID.TID 0000.0001)                 2.657812500000000E+02,      /* I = 11 */
+(PID.TID 0000.0001)                 2.685937500000000E+02,      /* I = 12 */
+(PID.TID 0000.0001)                 2.714062500000000E+02,      /* I = 13 */
+(PID.TID 0000.0001)                 2.742187500000000E+02,      /* I = 14 */
+(PID.TID 0000.0001)                 2.770312500000000E+02,      /* I = 15 */
+(PID.TID 0000.0001)                 2.798437500000000E+02,      /* I = 16 */
+(PID.TID 0000.0001)                 2.826562500000000E+02,      /* I = 17 */
+(PID.TID 0000.0001)                 2.854687500000000E+02,      /* I = 18 */
+(PID.TID 0000.0001)                 2.882812500000000E+02,      /* I = 19 */
+(PID.TID 0000.0001)                 2.910937500000000E+02,      /* I = 20 */
+(PID.TID 0000.0001)                 2.939062500000000E+02,      /* I = 21 */
+(PID.TID 0000.0001)                 2.967187500000000E+02,      /* I = 22 */
+(PID.TID 0000.0001)                 2.995312500000000E+02,      /* I = 23 */
+(PID.TID 0000.0001)                 3.023437500000000E+02,      /* I = 24 */
+(PID.TID 0000.0001)                 3.051562500000000E+02,      /* I = 25 */
+(PID.TID 0000.0001)                 3.079687500000000E+02,      /* I = 26 */
+(PID.TID 0000.0001)                 3.107812500000000E+02,      /* I = 27 */
+(PID.TID 0000.0001)                 3.135937500000000E+02,      /* I = 28 */
+(PID.TID 0000.0001)                 3.164062500000000E+02,      /* I = 29 */
+(PID.TID 0000.0001)                 3.192187500000000E+02,      /* I = 30 */
+(PID.TID 0000.0001)                 3.220312500000000E+02,      /* I = 31 */
+(PID.TID 0000.0001)                 3.248437500000000E+02,      /* I = 32 */
+(PID.TID 0000.0001)                 3.276562500000000E+02,      /* I = 33 */
+(PID.TID 0000.0001)                 3.304687500000000E+02,      /* I = 34 */
+(PID.TID 0000.0001)                 3.332812500000000E+02,      /* I = 35 */
+(PID.TID 0000.0001)                 3.360937500000000E+02,      /* I = 36 */
+(PID.TID 0000.0001)                 3.389062500000000E+02,      /* I = 37 */
+(PID.TID 0000.0001)                 3.417187500000000E+02,      /* I = 38 */
+(PID.TID 0000.0001)                 3.445312500000000E+02,      /* I = 39 */
+(PID.TID 0000.0001)                 3.473437500000000E+02,      /* I = 40 */
+(PID.TID 0000.0001)                 3.501562500000000E+02,      /* I = 41 */
+(PID.TID 0000.0001)                 3.529687500000000E+02       /* I = 42 */
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) yC =  /* yC(1,:,1,:) : P-point Y coord ( deg. or m if cartesian) */
+(PID.TID 0000.0001)                -8.015625000000000E+01,      /* J =  1 */
+(PID.TID 0000.0001)                -7.734375000000000E+01,      /* J =  2 */
+(PID.TID 0000.0001)                -7.453125000000000E+01,      /* J =  3 */
+(PID.TID 0000.0001)                -7.171875000000000E+01,      /* J =  4 */
+(PID.TID 0000.0001)                -6.890625000000000E+01,      /* J =  5 */
+(PID.TID 0000.0001)                -6.609375000000000E+01,      /* J =  6 */
+(PID.TID 0000.0001)                -6.328125000000000E+01,      /* J =  7 */
+(PID.TID 0000.0001)                -6.046875000000000E+01,      /* J =  8 */
+(PID.TID 0000.0001)                -5.765625000000000E+01,      /* J =  9 */
+(PID.TID 0000.0001)                -5.484375000000000E+01,      /* J = 10 */
+(PID.TID 0000.0001)                -5.203125000000000E+01,      /* J = 11 */
+(PID.TID 0000.0001)                -4.921875000000000E+01,      /* J = 12 */
+(PID.TID 0000.0001)                -4.640625000000000E+01,      /* J = 13 */
+(PID.TID 0000.0001)                -4.359375000000000E+01,      /* J = 14 */
+(PID.TID 0000.0001)                -4.078125000000000E+01,      /* J = 15 */
+(PID.TID 0000.0001)                -3.796875000000000E+01,      /* J = 16 */
+(PID.TID 0000.0001)                -3.515625000000000E+01,      /* J = 17 */
+(PID.TID 0000.0001)                -3.234375000000000E+01,      /* J = 18 */
+(PID.TID 0000.0001)                -2.953125000000000E+01,      /* J = 19 */
+(PID.TID 0000.0001)                -2.671875000000000E+01       /* J = 20 */
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) rcoord = /* P-point R coordinate (  units of r ) */
+(PID.TID 0000.0001)                -2.500000000000000E+01,      /* K =  1 */
+(PID.TID 0000.0001)                -8.500000000000000E+01,      /* K =  2 */
+(PID.TID 0000.0001)                -1.700000000000000E+02,      /* K =  3 */
+(PID.TID 0000.0001)                -2.900000000000000E+02,      /* K =  4 */
+(PID.TID 0000.0001)                -4.550000000000000E+02,      /* K =  5 */
+(PID.TID 0000.0001)                -6.700000000000000E+02,      /* K =  6 */
+(PID.TID 0000.0001)                -9.350000000000000E+02,      /* K =  7 */
+(PID.TID 0000.0001)                -1.250000000000000E+03,      /* K =  8 */
+(PID.TID 0000.0001)                -1.615000000000000E+03,      /* K =  9 */
+(PID.TID 0000.0001)                -2.030000000000000E+03,      /* K = 10 */
+(PID.TID 0000.0001)                -2.495000000000000E+03,      /* K = 11 */
+(PID.TID 0000.0001)                -3.010000000000000E+03,      /* K = 12 */
+(PID.TID 0000.0001)                -3.575000000000000E+03,      /* K = 13 */
+(PID.TID 0000.0001)                -4.190000000000000E+03,      /* K = 14 */
+(PID.TID 0000.0001)                -4.855000000000000E+03       /* K = 15 */
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) rF =   /* W-Interf. R coordinate (  units of r ) */
+(PID.TID 0000.0001)                 0.000000000000000E+00,      /* K =  1 */
+(PID.TID 0000.0001)                -5.000000000000000E+01,      /* K =  2 */
+(PID.TID 0000.0001)                -1.200000000000000E+02,      /* K =  3 */
+(PID.TID 0000.0001)                -2.200000000000000E+02,      /* K =  4 */
+(PID.TID 0000.0001)                -3.600000000000000E+02,      /* K =  5 */
+(PID.TID 0000.0001)                -5.500000000000000E+02,      /* K =  6 */
+(PID.TID 0000.0001)                -7.900000000000000E+02,      /* K =  7 */
+(PID.TID 0000.0001)                -1.080000000000000E+03,      /* K =  8 */
+(PID.TID 0000.0001)                -1.420000000000000E+03,      /* K =  9 */
+(PID.TID 0000.0001)                -1.810000000000000E+03,      /* K = 10 */
+(PID.TID 0000.0001)                -2.250000000000000E+03,      /* K = 11 */
+(PID.TID 0000.0001)                -2.740000000000000E+03,      /* K = 12 */
+(PID.TID 0000.0001)                -3.280000000000000E+03,      /* K = 13 */
+(PID.TID 0000.0001)                -3.870000000000000E+03,      /* K = 14 */
+(PID.TID 0000.0001)                -4.510000000000000E+03,      /* K = 15 */
+(PID.TID 0000.0001)                -5.200000000000000E+03       /* K = 16 */
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) deepFacC = /* deep-model grid factor @ cell-Center (-) */
+(PID.TID 0000.0001)    15 @  1.000000000000000E+00              /* K =  1: 15 */
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) deepFacF = /* deep-model grid factor @ W-Interface (-) */
+(PID.TID 0000.0001)    16 @  1.000000000000000E+00              /* K =  1: 16 */
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) rotateGrid = /* use rotated grid ( True/False ) */
+(PID.TID 0000.0001)                   F
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) phiEuler = /* Euler angle, rotation about original z-coordinate [rad] */
+(PID.TID 0000.0001)                 0.000000000000000E+00
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) thetaEuler = /* Euler angle, rotation about new x-coordinate [rad] */
+(PID.TID 0000.0001)                 0.000000000000000E+00
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) psiEuler = /* Euler angle, rotation about new z-coordinate [rad] */
+(PID.TID 0000.0001)                 0.000000000000000E+00
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) dxF =  /* dxF(:,1,:,1) ( units: m ) */
+(PID.TID 0000.0001)    42 @  5.345749921461356E+04              /* I =  1: 42 */
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) dxF =  /* dxF(1,:,1,:) ( units: m ) */
+(PID.TID 0000.0001)                 5.345749921461356E+04,      /* J =  1 */
+(PID.TID 0000.0001)                 6.851003143764105E+04,      /* J =  2 */
+(PID.TID 0000.0001)                 8.339751699416524E+04,      /* J =  3 */
+(PID.TID 0000.0001)                 9.808409062749070E+04,      /* J =  4 */
+(PID.TID 0000.0001)                 1.125343710953429E+05,      /* J =  5 */
+(PID.TID 0000.0001)                 1.267135464063795E+05,      /* J =  6 */
+(PID.TID 0000.0001)                 1.405874576853274E+05,      /* J =  7 */
+(PID.TID 0000.0001)                 1.541226814647045E+05,      /* J =  8 */
+(PID.TID 0000.0001)                 1.672866102048804E+05,      /* J =  9 */
+(PID.TID 0000.0001)                 1.800475308484964E+05,      /* J = 10 */
+(PID.TID 0000.0001)                 1.923747012199971E+05,      /* J = 11 */
+(PID.TID 0000.0001)                 2.042384240862251E+05,      /* J = 12 */
+(PID.TID 0000.0001)                 2.156101186996563E+05,      /* J = 13 */
+(PID.TID 0000.0001)                 2.264623896519241E+05,      /* J = 14 */
+(PID.TID 0000.0001)                 2.367690928717577E+05,      /* J = 15 */
+(PID.TID 0000.0001)                 2.465053986083400E+05,      /* J = 16 */
+(PID.TID 0000.0001)                 2.556478512483520E+05,      /* J = 17 */
+(PID.TID 0000.0001)                 2.641744258225996E+05,      /* J = 18 */
+(PID.TID 0000.0001)                 2.720645810660936E+05,      /* J = 19 */
+(PID.TID 0000.0001)                 2.792993089037565E+05       /* J = 20 */
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) dyF =  /* dyF(:,1,:,1) ( units: m ) */
+(PID.TID 0000.0001)    42 @  3.126866438026091E+05              /* I =  1: 42 */
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) dyF =  /* dyF(1,:,1,:) ( units: m ) */
+(PID.TID 0000.0001)    20 @  3.126866438026091E+05              /* J =  1: 20 */
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) dxG =  /* dxG(:,1,:,1) ( units: m ) */
+(PID.TID 0000.0001)    42 @  4.588065960101153E+04              /* I =  1: 42 */
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) dxG =  /* dxG(1,:,1,:) ( units: m ) */
+(PID.TID 0000.0001)                 4.588065960101153E+04,      /* J =  1 */
+(PID.TID 0000.0001)                 6.100213802959342E+04,      /* J =  2 */
+(PID.TID 0000.0001)                 7.597665696450579E+04,      /* J =  3 */
+(PID.TID 0000.0001)                 9.076814147802141E+04,      /* J =  4 */
+(PID.TID 0000.0001)                 1.053409575883663E+05,      /* J =  5 */
+(PID.TID 0000.0001)                 1.196599981051027E+05,      /* J =  6 */
+(PID.TID 0000.0001)                 1.336907672054259E+05,      /* J =  7 */
+(PID.TID 0000.0001)                 1.473994635376230E+05,      /* J =  8 */
+(PID.TID 0000.0001)                 1.607530616514898E+05,      /* J =  9 */
+(PID.TID 0000.0001)                 1.737193915595329E+05,      /* J = 10 */
+(PID.TID 0000.0001)                 1.862672162372875E+05,      /* J = 11 */
+(PID.TID 0000.0001)                 1.983663068760452E+05,      /* J = 12 */
+(PID.TID 0000.0001)                 2.099875157067021E+05,      /* J = 13 */
+(PID.TID 0000.0001)                 2.211028462192875E+05,      /* J = 14 */
+(PID.TID 0000.0001)                 2.316855206090085E+05,      /* J = 15 */
+(PID.TID 0000.0001)                 2.417100442863276E+05,      /* J = 16 */
+(PID.TID 0000.0001)                 2.511522672956614E+05,      /* J = 17 */
+(PID.TID 0000.0001)                 2.599894424947394E+05,      /* J = 18 */
+(PID.TID 0000.0001)                 2.682002803544621E+05,      /* J = 19 */
+(PID.TID 0000.0001)                 2.757650002472408E+05       /* J = 20 */
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) dyG =  /* dyG(:,1,:,1) ( units: m ) */
+(PID.TID 0000.0001)    42 @  3.126866438026091E+05              /* I =  1: 42 */
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) dyG =  /* dyG(1,:,1,:) ( units: m ) */
+(PID.TID 0000.0001)    20 @  3.126866438026091E+05              /* J =  1: 20 */
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) dxC =  /* dxC(:,1,:,1) ( units: m ) */
+(PID.TID 0000.0001)    42 @  5.345749921461356E+04              /* I =  1: 42 */
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) dxC =  /* dxC(1,:,1,:) ( units: m ) */
+(PID.TID 0000.0001)                 5.345749921461356E+04,      /* J =  1 */
+(PID.TID 0000.0001)                 6.851003143764105E+04,      /* J =  2 */
+(PID.TID 0000.0001)                 8.339751699416524E+04,      /* J =  3 */
+(PID.TID 0000.0001)                 9.808409062749070E+04,      /* J =  4 */
+(PID.TID 0000.0001)                 1.125343710953429E+05,      /* J =  5 */
+(PID.TID 0000.0001)                 1.267135464063795E+05,      /* J =  6 */
+(PID.TID 0000.0001)                 1.405874576853274E+05,      /* J =  7 */
+(PID.TID 0000.0001)                 1.541226814647045E+05,      /* J =  8 */
+(PID.TID 0000.0001)                 1.672866102048804E+05,      /* J =  9 */
+(PID.TID 0000.0001)                 1.800475308484964E+05,      /* J = 10 */
+(PID.TID 0000.0001)                 1.923747012199971E+05,      /* J = 11 */
+(PID.TID 0000.0001)                 2.042384240862251E+05,      /* J = 12 */
+(PID.TID 0000.0001)                 2.156101186996563E+05,      /* J = 13 */
+(PID.TID 0000.0001)                 2.264623896519241E+05,      /* J = 14 */
+(PID.TID 0000.0001)                 2.367690928717577E+05,      /* J = 15 */
+(PID.TID 0000.0001)                 2.465053986083400E+05,      /* J = 16 */
+(PID.TID 0000.0001)                 2.556478512483520E+05,      /* J = 17 */
+(PID.TID 0000.0001)                 2.641744258225996E+05,      /* J = 18 */
+(PID.TID 0000.0001)                 2.720645810660936E+05,      /* J = 19 */
+(PID.TID 0000.0001)                 2.792993089037565E+05       /* J = 20 */
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) dyC =  /* dyC(:,1,:,1) ( units: m ) */
+(PID.TID 0000.0001)    42 @  3.126866438026091E+05              /* I =  1: 42 */
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) dyC =  /* dyC(1,:,1,:) ( units: m ) */
+(PID.TID 0000.0001)    20 @  3.126866438026091E+05              /* J =  1: 20 */
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) dxV =  /* dxV(:,1,:,1) ( units: m ) */
+(PID.TID 0000.0001)    42 @  4.588065960101153E+04              /* I =  1: 42 */
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) dxV =  /* dxV(1,:,1,:) ( units: m ) */
+(PID.TID 0000.0001)                 4.588065960101153E+04,      /* J =  1 */
+(PID.TID 0000.0001)                 6.100213802959342E+04,      /* J =  2 */
+(PID.TID 0000.0001)                 7.597665696450579E+04,      /* J =  3 */
+(PID.TID 0000.0001)                 9.076814147802141E+04,      /* J =  4 */
+(PID.TID 0000.0001)                 1.053409575883663E+05,      /* J =  5 */
+(PID.TID 0000.0001)                 1.196599981051027E+05,      /* J =  6 */
+(PID.TID 0000.0001)                 1.336907672054259E+05,      /* J =  7 */
+(PID.TID 0000.0001)                 1.473994635376230E+05,      /* J =  8 */
+(PID.TID 0000.0001)                 1.607530616514898E+05,      /* J =  9 */
+(PID.TID 0000.0001)                 1.737193915595329E+05,      /* J = 10 */
+(PID.TID 0000.0001)                 1.862672162372875E+05,      /* J = 11 */
+(PID.TID 0000.0001)                 1.983663068760452E+05,      /* J = 12 */
+(PID.TID 0000.0001)                 2.099875157067021E+05,      /* J = 13 */
+(PID.TID 0000.0001)                 2.211028462192875E+05,      /* J = 14 */
+(PID.TID 0000.0001)                 2.316855206090085E+05,      /* J = 15 */
+(PID.TID 0000.0001)                 2.417100442863276E+05,      /* J = 16 */
+(PID.TID 0000.0001)                 2.511522672956614E+05,      /* J = 17 */
+(PID.TID 0000.0001)                 2.599894424947394E+05,      /* J = 18 */
+(PID.TID 0000.0001)                 2.682002803544621E+05,      /* J = 19 */
+(PID.TID 0000.0001)                 2.757650002472408E+05       /* J = 20 */
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) dyU =  /* dyU(:,1,:,1) ( units: m ) */
+(PID.TID 0000.0001)    42 @  3.126866438026091E+05              /* I =  1: 42 */
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) dyU =  /* dyU(1,:,1,:) ( units: m ) */
+(PID.TID 0000.0001)    20 @  3.126866438026091E+05              /* J =  1: 20 */
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) rA  =  /* rA (:,1,:,1) ( units: m^2 ) */
+(PID.TID 0000.0001)    42 @  1.671376785519299E+10              /* I =  1: 42 */
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) rA  =  /* rA (1,:,1,:) ( units: m^2 ) */
+(PID.TID 0000.0001)                 1.671376785519299E+10,      /* J =  1 */
+(PID.TID 0000.0001)                 2.142002110131771E+10,      /* J =  2 */
+(PID.TID 0000.0001)                 2.607467164043704E+10,      /* J =  3 */
+(PID.TID 0000.0001)                 3.066650601170349E+10,      /* J =  4 */
+(PID.TID 0000.0001)                 3.518446208391881E+10,      /* J =  5 */
+(PID.TID 0000.0001)                 3.961765570517892E+10,      /* J =  6 */
+(PID.TID 0000.0001)                 4.395540692374860E+10,      /* J =  7 */
+(PID.TID 0000.0001)                 4.818726571700000E+10,      /* J =  8 */
+(PID.TID 0000.0001)                 5.230303716643333E+10,      /* J =  9 */
+(PID.TID 0000.0001)                 5.629280601812741E+10,      /* J = 10 */
+(PID.TID 0000.0001)                 6.014696056945659E+10,      /* J = 11 */
+(PID.TID 0000.0001)                 6.385621582452237E+10,      /* J = 12 */
+(PID.TID 0000.0001)                 6.741163586252303E+10,      /* J = 13 */
+(PID.TID 0000.0001)                 7.080465536516846E+10,      /* J = 14 */
+(PID.TID 0000.0001)                 7.402710025128452E+10,      /* J = 15 */
+(PID.TID 0000.0001)                 7.707120736888658E+10,      /* J = 16 */
+(PID.TID 0000.0001)                 7.992964319729683E+10,      /* J = 17 */
+(PID.TID 0000.0001)                 8.259552151423444E+10,      /* J = 18 */
+(PID.TID 0000.0001)                 8.506241998533159E+10,      /* J = 19 */
+(PID.TID 0000.0001)                 8.732439563609566E+10       /* J = 20 */
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) rAw =  /* rAw(:,1,:,1) ( units: m^2 ) */
+(PID.TID 0000.0001)    42 @  1.671376785519299E+10              /* I =  1: 42 */
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) rAw =  /* rAw(1,:,1,:) ( units: m^2 ) */
+(PID.TID 0000.0001)                 1.671376785519299E+10,      /* J =  1 */
+(PID.TID 0000.0001)                 2.142002110131771E+10,      /* J =  2 */
+(PID.TID 0000.0001)                 2.607467164043704E+10,      /* J =  3 */
+(PID.TID 0000.0001)                 3.066650601170349E+10,      /* J =  4 */
+(PID.TID 0000.0001)                 3.518446208391881E+10,      /* J =  5 */
+(PID.TID 0000.0001)                 3.961765570517892E+10,      /* J =  6 */
+(PID.TID 0000.0001)                 4.395540692374860E+10,      /* J =  7 */
+(PID.TID 0000.0001)                 4.818726571700000E+10,      /* J =  8 */
+(PID.TID 0000.0001)                 5.230303716643333E+10,      /* J =  9 */
+(PID.TID 0000.0001)                 5.629280601812741E+10,      /* J = 10 */
+(PID.TID 0000.0001)                 6.014696056945659E+10,      /* J = 11 */
+(PID.TID 0000.0001)                 6.385621582452237E+10,      /* J = 12 */
+(PID.TID 0000.0001)                 6.741163586252303E+10,      /* J = 13 */
+(PID.TID 0000.0001)                 7.080465536516846E+10,      /* J = 14 */
+(PID.TID 0000.0001)                 7.402710025128452E+10,      /* J = 15 */
+(PID.TID 0000.0001)                 7.707120736888658E+10,      /* J = 16 */
+(PID.TID 0000.0001)                 7.992964319729683E+10,      /* J = 17 */
+(PID.TID 0000.0001)                 8.259552151423444E+10,      /* J = 18 */
+(PID.TID 0000.0001)                 8.506241998533159E+10,      /* J = 19 */
+(PID.TID 0000.0001)                 8.732439563609566E+10       /* J = 20 */
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) rAs =  /* rAs(:,1,:,1) ( units: m^2 ) */
+(PID.TID 0000.0001)    42 @  1.434482916112175E+10              /* I =  1: 42 */
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) rAs =  /* rAs(1,:,1,:) ( units: m^2 ) */
+(PID.TID 0000.0001)                 1.434482916112175E+10,      /* J =  1 */
+(PID.TID 0000.0001)                 1.907263880047594E+10,      /* J =  2 */
+(PID.TID 0000.0001)                 2.375450078239423E+10,      /* J =  3 */
+(PID.TID 0000.0001)                 2.837913609127881E+10,      /* J =  4 */
+(PID.TID 0000.0001)                 3.293540357560110E+10,      /* J =  5 */
+(PID.TID 0000.0001)                 3.741232678790870E+10,      /* J =  6 */
+(PID.TID 0000.0001)                 4.179912042805190E+10,      /* J =  7 */
+(PID.TID 0000.0001)                 4.608521632591324E+10,      /* J =  8 */
+(PID.TID 0000.0001)                 5.026028890105701E+10,      /* J =  9 */
+(PID.TID 0000.0001)                 5.431428003795675E+10,      /* J = 10 */
+(PID.TID 0000.0001)                 5.823742331687641E+10,      /* J = 11 */
+(PID.TID 0000.0001)                 6.202026754202965E+10,      /* J = 12 */
+(PID.TID 0000.0001)                 6.565369951034003E+10,      /* J = 13 */
+(PID.TID 0000.0001)                 6.912896596594559E+10,      /* J = 14 */
+(PID.TID 0000.0001)                 7.243769468755632E+10,      /* J = 15 */
+(PID.TID 0000.0001)                 7.557191465787256E+10,      /* J = 16 */
+(PID.TID 0000.0001)                 7.852407526645966E+10,      /* J = 17 */
+(PID.TID 0000.0001)                 8.128706449983365E+10,      /* J = 18 */
+(PID.TID 0000.0001)                 8.385422607492096E+10,      /* J = 19 */
+(PID.TID 0000.0001)                 8.621937547463148E+10       /* J = 20 */
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) globalArea = /* Integrated horizontal Area (m^2) */
+(PID.TID 0000.0001)                 3.507619373042164E+13
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) the_run_name = /* Name of this simulation */
+(PID.TID 0000.0001)               'OBC + Biogeo S.Ocean Box'
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) // =======================================================
+(PID.TID 0000.0001) // End of Model config. summary
+(PID.TID 0000.0001) // =======================================================
+(PID.TID 0000.0001) 
+(PID.TID 0000.0001) == Packages configuration : Check & print summary ==
+(PID.TID 0000.0001) 
+(PID.TID 0000.0001) OBCS_CHECK: #define ALLOW_OBCS
+(PID.TID 0000.0001) OBCS_CHECK: start summary:
+(PID.TID 0000.0001) useOBCSprescribe = /* prescribe OB values */
+(PID.TID 0000.0001)                   T
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) useOBCSbalance = /* balance the flow through OB */
+(PID.TID 0000.0001)                   F
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) OBCS_uvApplyFac = /* Factor to apply to U,V 2nd column/row */
+(PID.TID 0000.0001)                 1.000000000000000E+00
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) OBCS_u1_adv_T = /* Temp uses upwind adv-scheme @ OB */
+(PID.TID 0000.0001)                       1
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) OBCS_u1_adv_S = /* Salt uses upwind adv-scheme @ OB */
+(PID.TID 0000.0001)                       1
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) OBCS_u1_adv_Tr = /* pTr uses upwind adv-scheme @ OB */
+(PID.TID 0000.0001)     5 @        1
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) OBCS_monitorFreq = /* monitor output frequency [s] */
+(PID.TID 0000.0001)                 1.000000000000000E+00
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) OBCS_monSelect = /* select group of variables to monitor */
+(PID.TID 0000.0001)                       1
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) useOBCStides = /* apply tidal forcing through OB */
+(PID.TID 0000.0001)                   F
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) tidalPeriod = /* (s) */
+(PID.TID 0000.0001)    10 @  0.000000000000000E+00              /* I =  1: 10 */
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) OB_indexNone = /* null value for OB index (i.e. no OB) */
+(PID.TID 0000.0001)                     -99
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) ======== Tile bi=   1 , bj=   1 ========
+(PID.TID 0000.0001)  OB_Jn = /* Northern OB local indices */
+(PID.TID 0000.0001)    20 @      -99                            /* I = -2: 17 */
+(PID.TID 0000.0001)  OB_Js = /* Southern OB local indices */
+(PID.TID 0000.0001)    20 @      -99                            /* I = -2: 17 */
+(PID.TID 0000.0001)  OB_Ie = /* Eastern OB local indices */
+(PID.TID 0000.0001)    16 @      -99                            /* J = -2: 13 */
+(PID.TID 0000.0001)  OB_Iw = /* Western OB local indices */
+(PID.TID 0000.0001)    16 @        1                            /* J = -2: 13 */
+(PID.TID 0000.0001) ======== Tile bi=   2 , bj=   1 ========
+(PID.TID 0000.0001)  OB_Jn = /* Northern OB local indices */
+(PID.TID 0000.0001)    20 @      -99                            /* I = -2: 17 */
+(PID.TID 0000.0001)  OB_Js = /* Southern OB local indices */
+(PID.TID 0000.0001)    20 @      -99                            /* I = -2: 17 */
+(PID.TID 0000.0001)  OB_Ie = /* Eastern OB local indices */
+(PID.TID 0000.0001)    16 @      -99                            /* J = -2: 13 */
+(PID.TID 0000.0001)  OB_Iw = /* Western OB local indices */
+(PID.TID 0000.0001)    16 @      -99                            /* J = -2: 13 */
+(PID.TID 0000.0001) ======== Tile bi=   3 , bj=   1 ========
+(PID.TID 0000.0001)  OB_Jn = /* Northern OB local indices */
+(PID.TID 0000.0001)    20 @      -99                            /* I = -2: 17 */
+(PID.TID 0000.0001)  OB_Js = /* Southern OB local indices */
+(PID.TID 0000.0001)    20 @      -99                            /* I = -2: 17 */
+(PID.TID 0000.0001)  OB_Ie = /* Eastern OB local indices */
+(PID.TID 0000.0001)    16 @       14                            /* J = -2: 13 */
+(PID.TID 0000.0001)  OB_Iw = /* Western OB local indices */
+(PID.TID 0000.0001)    16 @      -99                            /* J = -2: 13 */
+(PID.TID 0000.0001) ======== Tile bi=   1 , bj=   2 ========
+(PID.TID 0000.0001)  OB_Jn = /* Northern OB local indices */
+(PID.TID 0000.0001)    20 @       10                            /* I = -2: 17 */
+(PID.TID 0000.0001)  OB_Js = /* Southern OB local indices */
+(PID.TID 0000.0001)    20 @      -99                            /* I = -2: 17 */
+(PID.TID 0000.0001)  OB_Ie = /* Eastern OB local indices */
+(PID.TID 0000.0001)    16 @      -99                            /* J = -2: 13 */
+(PID.TID 0000.0001)  OB_Iw = /* Western OB local indices */
+(PID.TID 0000.0001)    16 @        1                            /* J = -2: 13 */
+(PID.TID 0000.0001) ======== Tile bi=   2 , bj=   2 ========
+(PID.TID 0000.0001)  OB_Jn = /* Northern OB local indices */
+(PID.TID 0000.0001)    20 @       10                            /* I = -2: 17 */
+(PID.TID 0000.0001)  OB_Js = /* Southern OB local indices */
+(PID.TID 0000.0001)    20 @      -99                            /* I = -2: 17 */
+(PID.TID 0000.0001)  OB_Ie = /* Eastern OB local indices */
+(PID.TID 0000.0001)    16 @      -99                            /* J = -2: 13 */
+(PID.TID 0000.0001)  OB_Iw = /* Western OB local indices */
+(PID.TID 0000.0001)    16 @      -99                            /* J = -2: 13 */
+(PID.TID 0000.0001) ======== Tile bi=   3 , bj=   2 ========
+(PID.TID 0000.0001)  OB_Jn = /* Northern OB local indices */
+(PID.TID 0000.0001)    20 @       10                            /* I = -2: 17 */
+(PID.TID 0000.0001)  OB_Js = /* Southern OB local indices */
+(PID.TID 0000.0001)    20 @      -99                            /* I = -2: 17 */
+(PID.TID 0000.0001)  OB_Ie = /* Eastern OB local indices */
+(PID.TID 0000.0001)    16 @       14                            /* J = -2: 13 */
+(PID.TID 0000.0001)  OB_Iw = /* Western OB local indices */
+(PID.TID 0000.0001)    16 @      -99                            /* J = -2: 13 */
+(PID.TID 0000.0001) OBCS_CHECK: end summary.
+(PID.TID 0000.0001) OBCS_CHECK: #define ALLOW_ORLANSKI
+(PID.TID 0000.0001) OBCS_CHECK: set-up OK
+(PID.TID 0000.0001) OBCS_CHECK: check Inside Mask and OB locations: OK
+(PID.TID 0000.0001) GMREDI_CHECK: #define GMREDI
+(PID.TID 0000.0001) GM_AdvForm =     /* if FALSE => use SkewFlux Form */
+(PID.TID 0000.0001)                   T
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) GM_InMomAsStress = /* if TRUE => apply as Eddy Stress */
+(PID.TID 0000.0001)                   F
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) GM_AdvSeparate = /* Calc Bolus & Euler Adv. separately */
+(PID.TID 0000.0001)                   F
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) GM_ExtraDiag =   /* Tensor Extra Diag (line 1&2) non 0 */
+(PID.TID 0000.0001)                   T
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) GM_isopycK =    /* Background Isopyc. Diffusivity [m^2/s] */
+(PID.TID 0000.0001)                 1.000000000000000E+03
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) GM_skewflx*K =  /* Background GM_SkewFlx Diffusivity [m^2/s] */
+(PID.TID 0000.0001)                 0.000000000000000E+00
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) GM_advec*K =    /* Backg. GM-Advec(=Bolus) Diffusivity [m^2/s]*/
+(PID.TID 0000.0001)                 1.000000000000000E+03
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) GM_Kmin_horiz = /* Minimum Horizontal Diffusivity [m^2/s] */
+(PID.TID 0000.0001)                 1.000000000000000E+02
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) GM_Visbeck_alpha = /* Visbeck alpha coeff. [-] */
+(PID.TID 0000.0001)                 0.000000000000000E+00
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) GM_Small_Number =  /* epsilon used in slope calc */
+(PID.TID 0000.0001)                 9.999999999999999E-21
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) GM_slopeSqCutoff = /* Slope^2 cut-off value */
+(PID.TID 0000.0001)                 1.000000000000000E+48
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) GM_taper_scheme =  /* Type of Tapering/Clipping scheme */
+(PID.TID 0000.0001)               'gkw91                                   '
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) GM_maxSlope =  /* Maximum Slope (Tapering/Clipping) */
+(PID.TID 0000.0001)                 1.000000000000000E-02
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) GM_facTrL2dz = /* Minimum Trans.Layer Thick. (factor of dz) */
+(PID.TID 0000.0001)                 1.000000000000000E+00
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) GM_facTrL2ML = /* Max.Trans.Layer Thick. (factor of MxL Depth)*/
+(PID.TID 0000.0001)                 5.000000000000000E+00
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) GM_maxTransLay = /* Maximum Transition Layer Thickness [m] */
+(PID.TID 0000.0001)                 5.000000000000000E+02
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) GM_UseBVP = /* if TRUE => use bvp a la Ferrari et al. (2010) */
+(PID.TID 0000.0001)                   F
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) GM_BVP_ModeNumber = /* Vertical mode number for BVP wave speed */
+(PID.TID 0000.0001)                       1
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) GM_BVP_cMin = /* Minimum wave speed for BVP [m/s] */
+(PID.TID 0000.0001)                 1.000000000000000E-01
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) GM_useSubMeso = /* if TRUE => use Sub-Meso param. (B.Fox-Kemper) */
+(PID.TID 0000.0001)                   F
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) subMeso_Ceff = /* efficiency coeff. of Mixed-Layer Eddies [-] */
+(PID.TID 0000.0001)                 7.000000000000001E-02
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) subMeso_invTau = /* inverse of Sub-Meso mixing time-scale [/s] */
+(PID.TID 0000.0001)                 2.000000000000000E-06
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) subMeso_LfMin = /* minimum length-scale "Lf" [m] */
+(PID.TID 0000.0001)                 1.000000000000000E+03
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) subMeso_Lmax = /* maximum grid-scale length [m] */
+(PID.TID 0000.0001)                 1.100000000000000E+05
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) GM_useLeithQG = /* if TRUE => add QG Leith viscosity to GMRedi tensor */
+(PID.TID 0000.0001)                   F
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) PTRACERS_CHECK: #define ALLOW_PTRACERS
+(PID.TID 0000.0001) // ===================================
+(PID.TID 0000.0001) // PTRACERS parameters
+(PID.TID 0000.0001) // ===================================
+(PID.TID 0000.0001) PTRACERS_numInUse = /* number of tracers */
+(PID.TID 0000.0001)                       5
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) PTRACERS_Iter0 = /* timestep number when tracers are initialized */
+(PID.TID 0000.0001)                       0
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) PTRACERS_startAllTrc =/* all tracers start @ startTime */
+(PID.TID 0000.0001)                   T
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) PTRACERS_doAB_onGpTr =/* apply AB on Tendencies (rather than on Tracers) */
+(PID.TID 0000.0001)                   T
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) PTRACERS_addSrelax2EmP =/* add Salt relaxation to EmP */
+(PID.TID 0000.0001)                   F
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) PTRACERS_dTLev =   /* Ptracer timestep ( s ) */
+(PID.TID 0000.0001)    15 @  4.320000000000000E+04              /* K =  1: 15 */
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) PTRACERS_monitorFreq = /* Frequency^-1 for monitor output (s) */
+(PID.TID 0000.0001)                 1.000000000000000E+00
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) PTRACERS_dumpFreq = /* Frequency^-1 for snapshot output (s) */
+(PID.TID 0000.0001)                 2.592000000000000E+06
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) PTRACERS_taveFreq = /* Frequency^-1 for time-Aver. output (s) */
+(PID.TID 0000.0001)                 0.000000000000000E+00
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) PTRACERS_useRecords = /* all tracers in 1 file */
+(PID.TID 0000.0001)                   F
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) PTRACERS_timeave_mnc = /* use MNC for Tave output */
+(PID.TID 0000.0001)                   F
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) PTRACERS_snapshot_mnc = /* use MNC for snapshot output */
+(PID.TID 0000.0001)                   F
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) PTRACERS_pickup_write_mnc = /* use MNC for writing pickups */
+(PID.TID 0000.0001)                   F
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) PTRACERS_pickup_read_mnc = /* use MNC for reading pickups */
+(PID.TID 0000.0001)                   F
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001)  -----------------------------------
+(PID.TID 0000.0001)  tracer number :    1
+(PID.TID 0000.0001) PTRACERS_names = /* Tracer short name */
+(PID.TID 0000.0001)               'DIC'
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) PTRACERS_long_names = /* Tracer long name */
+(PID.TID 0000.0001)               'Dissolved Inorganic Carbon (DIC) [mol C/m^3]'
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) PTRACERS_ioLabel = /* tracer IO Label */
+(PID.TID 0000.0001)               '01'
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) PTRACERS_advScheme = /* Advection Scheme */
+(PID.TID 0000.0001)                      77
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) PTRACERS_SOM_Advection = /* tracer uses SOM advection scheme */
+(PID.TID 0000.0001)                   F
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) PTRACERS_ImplVertAdv = /* implicit vert. advection flag */
+(PID.TID 0000.0001)                   F
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) PTRACERS_MultiDimAdv = /* tracer uses Multi-Dim advection */
+(PID.TID 0000.0001)                   T
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) PTRACERS_AdamsBashGtr = /* apply AB on tracer tendency */
+(PID.TID 0000.0001)                   F
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) PTRACERS_AdamsBash_Tr = /* apply AB on passive tracer */
+(PID.TID 0000.0001)                   F
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) PTRACERS_diffKh = /* Laplacian Diffusivity */
+(PID.TID 0000.0001)                 0.000000000000000E+00
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) PTRACERS_diffK4 = /* Biharmonic Diffusivity */
+(PID.TID 0000.0001)                 0.000000000000000E+00
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) PTRACERS_diffKrNr = /* Vertical Diffusivity */
+(PID.TID 0000.0001)    15 @  3.000000000000000E-05              /* K =  1: 15 */
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) PTRACERS_useGMRedi = /* apply GM-Redi */
+(PID.TID 0000.0001)                   T
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) PTRACERS_useDWNSLP = /* apply DOWN-SLOPE Flow */
+(PID.TID 0000.0001)                   F
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) PTRACERS_useKPP = /* apply KPP scheme */
+(PID.TID 0000.0001)                   F
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) PTRACERS_ref = /* Reference vertical profile */
+(PID.TID 0000.0001)                 2.028200000000000E+00,      /* K =  1 */
+(PID.TID 0000.0001)                 2.060900000000000E+00,      /* K =  2 */
+(PID.TID 0000.0001)                 2.120600000000000E+00,      /* K =  3 */
+(PID.TID 0000.0001)                 2.158100000000000E+00,      /* K =  4 */
+(PID.TID 0000.0001)                 2.190400000000000E+00,      /* K =  5 */
+(PID.TID 0000.0001)                 2.218800000000000E+00,      /* K =  6 */
+(PID.TID 0000.0001)                 2.247400000000000E+00,      /* K =  7 */
+(PID.TID 0000.0001)                 2.269900000000000E+00,      /* K =  8 */
+(PID.TID 0000.0001)                 2.279200000000000E+00,      /* K =  9 */
+(PID.TID 0000.0001)                 2.281400000000000E+00,      /* K = 10 */
+(PID.TID 0000.0001)                 2.281500000000000E+00,      /* K = 11 */
+(PID.TID 0000.0001)                 2.280600000000000E+00,      /* K = 12 */
+(PID.TID 0000.0001)                 2.280000000000000E+00,      /* K = 13 */
+(PID.TID 0000.0001)                 2.276000000000000E+00,      /* K = 14 */
+(PID.TID 0000.0001)                 2.275800000000000E+00       /* K = 15 */
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) PTRACERS_EvPrRn =/* tracer conc. in Evap. & Rain */
+(PID.TID 0000.0001)                 0.000000000000000E+00
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001)  -----------------------------------
+(PID.TID 0000.0001)  tracer number :    2
+(PID.TID 0000.0001) PTRACERS_names = /* Tracer short name */
+(PID.TID 0000.0001)               'Alk'
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) PTRACERS_long_names = /* Tracer long name */
+(PID.TID 0000.0001)               'Alkalinity (Alk) [mol eq/m^3]'
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) PTRACERS_ioLabel = /* tracer IO Label */
+(PID.TID 0000.0001)               '02'
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) PTRACERS_advScheme = /* Advection Scheme */
+(PID.TID 0000.0001)                      77
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) PTRACERS_SOM_Advection = /* tracer uses SOM advection scheme */
+(PID.TID 0000.0001)                   F
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) PTRACERS_ImplVertAdv = /* implicit vert. advection flag */
+(PID.TID 0000.0001)                   F
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) PTRACERS_MultiDimAdv = /* tracer uses Multi-Dim advection */
+(PID.TID 0000.0001)                   T
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) PTRACERS_AdamsBashGtr = /* apply AB on tracer tendency */
+(PID.TID 0000.0001)                   F
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) PTRACERS_AdamsBash_Tr = /* apply AB on passive tracer */
+(PID.TID 0000.0001)                   F
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) PTRACERS_diffKh = /* Laplacian Diffusivity */
+(PID.TID 0000.0001)                 0.000000000000000E+00
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) PTRACERS_diffK4 = /* Biharmonic Diffusivity */
+(PID.TID 0000.0001)                 0.000000000000000E+00
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) PTRACERS_diffKrNr = /* Vertical Diffusivity */
+(PID.TID 0000.0001)    15 @  3.000000000000000E-05              /* K =  1: 15 */
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) PTRACERS_useGMRedi = /* apply GM-Redi */
+(PID.TID 0000.0001)                   T
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) PTRACERS_useDWNSLP = /* apply DOWN-SLOPE Flow */
+(PID.TID 0000.0001)                   F
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) PTRACERS_useKPP = /* apply KPP scheme */
+(PID.TID 0000.0001)                   F
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) PTRACERS_ref = /* Reference vertical profile */
+(PID.TID 0000.0001)                 2.308600000000000E+00,      /* K =  1 */
+(PID.TID 0000.0001)                 2.314900000000000E+00,      /* K =  2 */
+(PID.TID 0000.0001)                 2.316400000000000E+00,      /* K =  3 */
+(PID.TID 0000.0001)                 2.311200000000000E+00,      /* K =  4 */
+(PID.TID 0000.0001)                 2.309800000000000E+00,      /* K =  5 */
+(PID.TID 0000.0001)                 2.316000000000000E+00,      /* K =  6 */
+(PID.TID 0000.0001)                 2.331300000000000E+00,      /* K =  7 */
+(PID.TID 0000.0001)                 2.351700000000000E+00,      /* K =  8 */
+(PID.TID 0000.0001)                 2.366700000000000E+00,      /* K =  9 */
+(PID.TID 0000.0001)                 2.376100000000000E+00,      /* K = 10 */
+(PID.TID 0000.0001)                 2.383200000000000E+00,      /* K = 11 */
+(PID.TID 0000.0001)                 2.386200000000000E+00,      /* K = 12 */
+(PID.TID 0000.0001)                 2.388100000000000E+00,      /* K = 13 */
+(PID.TID 0000.0001)                 2.386300000000000E+00,      /* K = 14 */
+(PID.TID 0000.0001)                 2.386700000000000E+00       /* K = 15 */
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) PTRACERS_EvPrRn =/* tracer conc. in Evap. & Rain */
+(PID.TID 0000.0001)                 0.000000000000000E+00
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001)  -----------------------------------
+(PID.TID 0000.0001)  tracer number :    3
+(PID.TID 0000.0001) PTRACERS_names = /* Tracer short name */
+(PID.TID 0000.0001)               'PO4'
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) PTRACERS_long_names = /* Tracer long name */
+(PID.TID 0000.0001)               'Phosphate (PO4) [mol P/m^3]'
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) PTRACERS_ioLabel = /* tracer IO Label */
+(PID.TID 0000.0001)               '03'
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) PTRACERS_advScheme = /* Advection Scheme */
+(PID.TID 0000.0001)                      77
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) PTRACERS_SOM_Advection = /* tracer uses SOM advection scheme */
+(PID.TID 0000.0001)                   F
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) PTRACERS_ImplVertAdv = /* implicit vert. advection flag */
+(PID.TID 0000.0001)                   F
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) PTRACERS_MultiDimAdv = /* tracer uses Multi-Dim advection */
+(PID.TID 0000.0001)                   T
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) PTRACERS_AdamsBashGtr = /* apply AB on tracer tendency */
+(PID.TID 0000.0001)                   F
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) PTRACERS_AdamsBash_Tr = /* apply AB on passive tracer */
+(PID.TID 0000.0001)                   F
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) PTRACERS_diffKh = /* Laplacian Diffusivity */
+(PID.TID 0000.0001)                 0.000000000000000E+00
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) PTRACERS_diffK4 = /* Biharmonic Diffusivity */
+(PID.TID 0000.0001)                 0.000000000000000E+00
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) PTRACERS_diffKrNr = /* Vertical Diffusivity */
+(PID.TID 0000.0001)    15 @  3.000000000000000E-05              /* K =  1: 15 */
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) PTRACERS_useGMRedi = /* apply GM-Redi */
+(PID.TID 0000.0001)                   T
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) PTRACERS_useDWNSLP = /* apply DOWN-SLOPE Flow */
+(PID.TID 0000.0001)                   F
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) PTRACERS_useKPP = /* apply KPP scheme */
+(PID.TID 0000.0001)                   F
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) PTRACERS_ref = /* Reference vertical profile */
+(PID.TID 0000.0001)                 5.438000000000000E-04,      /* K =  1 */
+(PID.TID 0000.0001)                 7.821000000000000E-04,      /* K =  2 */
+(PID.TID 0000.0001)                 1.133500000000000E-03,      /* K =  3 */
+(PID.TID 0000.0001)                 1.491300000000000E-03,      /* K =  4 */
+(PID.TID 0000.0001)                 1.860600000000000E-03,      /* K =  5 */
+(PID.TID 0000.0001)                 2.198600000000000E-03,      /* K =  6 */
+(PID.TID 0000.0001)                 2.396600000000000E-03,      /* K =  7 */
+(PID.TID 0000.0001)                 2.418700000000000E-03,      /* K =  8 */
+(PID.TID 0000.0001)                 2.404600000000000E-03,      /* K =  9 */
+(PID.TID 0000.0001)                 2.329100000000000E-03,      /* K = 10 */
+(PID.TID 0000.0001)                 2.292200000000000E-03,      /* K = 11 */
+(PID.TID 0000.0001)                 2.288600000000000E-03,      /* K = 12 */
+(PID.TID 0000.0001)                 2.260800000000000E-03,      /* K = 13 */
+(PID.TID 0000.0001)                 2.235600000000000E-03,      /* K = 14 */
+(PID.TID 0000.0001)                 2.229600000000000E-03       /* K = 15 */
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) PTRACERS_EvPrRn =/* tracer conc. in Evap. & Rain */
+(PID.TID 0000.0001)                 1.234567000000000E+05
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001)  -----------------------------------
+(PID.TID 0000.0001)  tracer number :    4
+(PID.TID 0000.0001) PTRACERS_names = /* Tracer short name */
+(PID.TID 0000.0001)               'DOP'
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) PTRACERS_long_names = /* Tracer long name */
+(PID.TID 0000.0001)               'Dissolved Organic Phosphorus (DOP) [mol P/m^3]'
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) PTRACERS_ioLabel = /* tracer IO Label */
+(PID.TID 0000.0001)               '04'
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) PTRACERS_advScheme = /* Advection Scheme */
+(PID.TID 0000.0001)                      77
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) PTRACERS_SOM_Advection = /* tracer uses SOM advection scheme */
+(PID.TID 0000.0001)                   F
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) PTRACERS_ImplVertAdv = /* implicit vert. advection flag */
+(PID.TID 0000.0001)                   F
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) PTRACERS_MultiDimAdv = /* tracer uses Multi-Dim advection */
+(PID.TID 0000.0001)                   T
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) PTRACERS_AdamsBashGtr = /* apply AB on tracer tendency */
+(PID.TID 0000.0001)                   F
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) PTRACERS_AdamsBash_Tr = /* apply AB on passive tracer */
+(PID.TID 0000.0001)                   F
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) PTRACERS_diffKh = /* Laplacian Diffusivity */
+(PID.TID 0000.0001)                 0.000000000000000E+00
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) PTRACERS_diffK4 = /* Biharmonic Diffusivity */
+(PID.TID 0000.0001)                 0.000000000000000E+00
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) PTRACERS_diffKrNr = /* Vertical Diffusivity */
+(PID.TID 0000.0001)    15 @  3.000000000000000E-05              /* K =  1: 15 */
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) PTRACERS_useGMRedi = /* apply GM-Redi */
+(PID.TID 0000.0001)                   T
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) PTRACERS_useDWNSLP = /* apply DOWN-SLOPE Flow */
+(PID.TID 0000.0001)                   F
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) PTRACERS_useKPP = /* apply KPP scheme */
+(PID.TID 0000.0001)                   F
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) PTRACERS_ref = /* Reference vertical profile */
+(PID.TID 0000.0001)    15 @  0.000000000000000E+00              /* K =  1: 15 */
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) PTRACERS_EvPrRn =/* tracer conc. in Evap. & Rain */
+(PID.TID 0000.0001)                 1.234567000000000E+05
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001)  -----------------------------------
+(PID.TID 0000.0001)  tracer number :    5
+(PID.TID 0000.0001) PTRACERS_names = /* Tracer short name */
+(PID.TID 0000.0001)               'O2'
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) PTRACERS_long_names = /* Tracer long name */
+(PID.TID 0000.0001)               'Dissolved Oxygen (O2) [mol O/m^3]'
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) PTRACERS_ioLabel = /* tracer IO Label */
+(PID.TID 0000.0001)               '05'
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) PTRACERS_advScheme = /* Advection Scheme */
+(PID.TID 0000.0001)                      77
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) PTRACERS_SOM_Advection = /* tracer uses SOM advection scheme */
+(PID.TID 0000.0001)                   F
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) PTRACERS_ImplVertAdv = /* implicit vert. advection flag */
+(PID.TID 0000.0001)                   F
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) PTRACERS_MultiDimAdv = /* tracer uses Multi-Dim advection */
+(PID.TID 0000.0001)                   T
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) PTRACERS_AdamsBashGtr = /* apply AB on tracer tendency */
+(PID.TID 0000.0001)                   F
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) PTRACERS_AdamsBash_Tr = /* apply AB on passive tracer */
+(PID.TID 0000.0001)                   F
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) PTRACERS_diffKh = /* Laplacian Diffusivity */
+(PID.TID 0000.0001)                 0.000000000000000E+00
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) PTRACERS_diffK4 = /* Biharmonic Diffusivity */
+(PID.TID 0000.0001)                 0.000000000000000E+00
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) PTRACERS_diffKrNr = /* Vertical Diffusivity */
+(PID.TID 0000.0001)    15 @  3.000000000000000E-05              /* K =  1: 15 */
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) PTRACERS_useGMRedi = /* apply GM-Redi */
+(PID.TID 0000.0001)                   T
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) PTRACERS_useDWNSLP = /* apply DOWN-SLOPE Flow */
+(PID.TID 0000.0001)                   F
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) PTRACERS_useKPP = /* apply KPP scheme */
+(PID.TID 0000.0001)                   F
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) PTRACERS_ref = /* Reference vertical profile */
+(PID.TID 0000.0001)                 2.457000000000000E-01,      /* K =  1 */
+(PID.TID 0000.0001)                 2.336000000000000E-01,      /* K =  2 */
+(PID.TID 0000.0001)                 1.975000000000000E-01,      /* K =  3 */
+(PID.TID 0000.0001)                 1.729000000000000E-01,      /* K =  4 */
+(PID.TID 0000.0001)                 1.591000000000000E-01,      /* K =  5 */
+(PID.TID 0000.0001)                 1.503000000000000E-01,      /* K =  6 */
+(PID.TID 0000.0001)                 1.424000000000000E-01,      /* K =  7 */
+(PID.TID 0000.0001)                 1.445000000000000E-01,      /* K =  8 */
+(PID.TID 0000.0001)                 1.549000000000000E-01,      /* K =  9 */
+(PID.TID 0000.0001)                 1.661000000000000E-01,      /* K = 10 */
+(PID.TID 0000.0001)                 1.774000000000000E-01,      /* K = 11 */
+(PID.TID 0000.0001)                 1.863000000000000E-01,      /* K = 12 */
+(PID.TID 0000.0001)                 1.925000000000000E-01,      /* K = 13 */
+(PID.TID 0000.0001)                 2.021000000000000E-01,      /* K = 14 */
+(PID.TID 0000.0001)                 2.051000000000000E-01       /* K = 15 */
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) PTRACERS_EvPrRn =/* tracer conc. in Evap. & Rain */
+(PID.TID 0000.0001)                 1.234567000000000E+05
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001)  -----------------------------------
+(PID.TID 0000.0001) GCHEM_CHECK  --> Starts to check GCHEM set-up
+(PID.TID 0000.0001) GCHEM_CHECK  <-- Ends Normally
+(PID.TID 0000.0001) 
+(PID.TID 0000.0001) GAD_CHECK: #define ALLOW_GENERIC_ADVDIFF
+(PID.TID 0000.0001) // =======================================================
+(PID.TID 0000.0001) // Check Model config. (CONFIG_CHECK):
+(PID.TID 0000.0001) // CONFIG_CHECK : Normal End
+(PID.TID 0000.0001) // =======================================================
+(PID.TID 0000.0001) 
+(PID.TID 0000.0001)  MDS_READ_FIELD: opening global file: U_ini.bin
+(PID.TID 0000.0001)  MDS_READ_FIELD: opening global file: V_ini.bin
+(PID.TID 0000.0001)  MDS_READ_FIELD: opening global file: T_ini.bin
+(PID.TID 0000.0001)  MDS_READ_FIELD: opening global file: S_ini.bin
+(PID.TID 0000.0001)  MDS_READ_FIELD: opening global file: Eta_ini.bin
+(PID.TID 0000.0001) Start initial hydrostatic pressure computation
+(PID.TID 0000.0001) Pressure is predetermined for buoyancyRelation OCEANIC
+(PID.TID 0000.0001) 
+(PID.TID 0000.0001)  MDS_READ_FIELD: opening global file: tren_taux_box.bin
+(PID.TID 0000.0001)  MDS_READ_FIELD: opening global file: tren_tauy_box.bin
+(PID.TID 0000.0001)  MDS_READ_FIELD: opening global file: shi_qnet_box.bin
+(PID.TID 0000.0001)  MDS_READ_FIELD: opening global file: shi_empmr_year_box.bin
+(PID.TID 0000.0001)  MDS_READ_FIELD: opening global file: lev_monthly_temp_box.bin
+(PID.TID 0000.0001)  MDS_READ_FIELD: opening global file: lev_monthly_salt_box.bin
+(PID.TID 0000.0001)  write diagnostics summary to file ioUnit:      6
+Iter.Nb:         0 ; Time(s):  0.0000000000000E+00
+------------------------------------------------------------------------
+2D/3D diagnostics: Number of lists:     2
+------------------------------------------------------------------------
+listId=    1 ; file name: surfDiag
+ nFlds, nActive,       freq     &     phase        , nLev               
+   10  |   10  |   2592000.000000         0.000000 |   1
+ levels:   1
+ diag# | name   |   ipt  |  iMate | kLev|   count |   mate.C|           
+    23 |ETAN    |      1 |      0 |   1 |       0 |
+    24 |ETANSQ  |      2 |      0 |   1 |       0 |
+    25 |DETADT2 |      3 |      0 |   1 |       0 |
+    73 |PHIBOT  |      4 |      0 |   1 |       0 |
+    74 |PHIBOTSQ|      5 |      0 |   1 |       0 |
+   286 |DICTFLX |      6 |      0 |   1 |       0 |
+   287 |DICOFLX |      7 |      0 |   1 |       0 |
+   288 |DICCFLX |      8 |      0 |   1 |       0 |
+   289 |DICPCO2 |      9 |      0 |   1 |       0 |
+   290 |DICPHAV |     10 |      0 |   1 |       0 |
+------------------------------------------------------------------------
+listId=    2 ; file name: dynDiag
+ nFlds, nActive,       freq     &     phase        , nLev               
+    9  |    9  |    432000.000000         0.000000 |  15
+ levels:   1   2   3   4   5   6   7   8   9  10  11  12  13  14  15
+ diag# | name   |   ipt  |  iMate | kLev|   count |   mate.C|           
+    46 |VVELMASS|     11 |     26 |  15 |       0 |       0 |
+    45 |UVELMASS|     26 |     11 |  15 |       0 |       0 |
+    26 |THETA   |     41 |      0 |  15 |       0 |
+    27 |SALT    |     56 |      0 |  15 |       0 |
+   204 |GM_PsiX |     71 |     86 |  15 |       0 |       0 |
+   205 |GM_PsiY |     86 |     71 |  15 |       0 |       0 |
+    48 |PhiVEL  |    -26 |     11 |  15 |       0 |       0 |
+    49 |PsiVEL  |    -26 |     11 |  15 |       0 |       0 |
+    78 |CONVADJ |    101 |      0 |  15 |       0 |
+------------------------------------------------------------------------
+Global & Regional Statistics diagnostics: Number of lists:     1
+------------------------------------------------------------------------
+listId=   1 ; file name: dynStDiag
+ nFlds, nActive,       freq     &     phase        |                    
+   20  |   20  |    432000.000000         0.000000 |
+ Regions:   0
+ diag# | name   |   ipt  |  iMate |    Volume   |   mate-Vol. |         
+    23 |ETAN    |      1 |      0 | 0.00000E+00 |
+    25 |DETADT2 |      2 |      0 | 0.00000E+00 |
+    26 |THETA   |      3 |      0 | 0.00000E+00 |
+    27 |SALT    |     18 |      0 | 0.00000E+00 |
+    78 |CONVADJ |     33 |      0 | 0.00000E+00 |
+    30 |UVEL    |     48 |      0 | 0.00000E+00 |
+    31 |VVEL    |     63 |      0 | 0.00000E+00 |
+    32 |WVEL    |     78 |      0 | 0.00000E+00 |
+   204 |GM_PsiX |     93 |      0 | 0.00000E+00 |
+   205 |GM_PsiY |    108 |      0 | 0.00000E+00 |
+   213 |TRAC01  |    123 |      0 | 0.00000E+00 |
+   227 |TRAC02  |    138 |      0 | 0.00000E+00 |
+   241 |TRAC03  |    153 |      0 | 0.00000E+00 |
+   255 |TRAC04  |    168 |      0 | 0.00000E+00 |
+   269 |TRAC05  |    183 |      0 | 0.00000E+00 |
+   291 |DIC3DSIT|    198 |      0 | 0.00000E+00 |
+   292 |OMEGAC  |    213 |      0 | 0.00000E+00 |
+   293 |DIC3DPH |    228 |      0 | 0.00000E+00 |
+   294 |DIC3DPCO|    243 |      0 | 0.00000E+00 |
+   295 |DIC3DCO3|    258 |      0 | 0.00000E+00 |
+------------------------------------------------------------------------
+(PID.TID 0000.0001)  MDS_READ_FIELD: opening global file: Trac01_ini.bin
+(PID.TID 0000.0001)  MDS_READ_FIELD: opening global file: Trac02_ini.bin
+(PID.TID 0000.0001)  MDS_READ_FIELD: opening global file: Trac03_ini.bin
+(PID.TID 0000.0001)  MDS_READ_FIELD: opening global file: Trac04_ini.bin
+(PID.TID 0000.0001)  MDS_READ_FIELD: opening global file: Trac05_ini.bin
+ DIC_SURFFORCING_INIT, it=         0 : Reading new data, i0,i1=   12    1
+(PID.TID 0000.0001)  MDS_READ_FIELD: opening global file: sillev1_box.bin
+(PID.TID 0000.0001)  MDS_READ_FIELD: opening global file: sillev1_box.bin
+ OBCS_FIELDS_LOAD,         0 : iP,iLd,i0,i1=   12    0   12    1 ; Wght=  0.5000000000  0.5000000000
+ OBCS_FIELDS_LOAD, it=         0 : Reading new data, i0,i1=   12    1 (prev=   12    0 )
+(PID.TID 0000.0001)  MDS_READ_SEC_YZ: opening global file: U_obE.bin
+(PID.TID 0000.0001)  MDS_READ_SEC_YZ: opening global file: U_obE.bin
+(PID.TID 0000.0001)  MDS_READ_SEC_YZ: opening global file: V_obE.bin
+(PID.TID 0000.0001)  MDS_READ_SEC_YZ: opening global file: V_obE.bin
+(PID.TID 0000.0001)  MDS_READ_SEC_YZ: opening global file: T_obE.bin
+(PID.TID 0000.0001)  MDS_READ_SEC_YZ: opening global file: T_obE.bin
+(PID.TID 0000.0001)  MDS_READ_SEC_YZ: opening global file: S_obE.bin
+(PID.TID 0000.0001)  MDS_READ_SEC_YZ: opening global file: S_obE.bin
+(PID.TID 0000.0001)  MDS_READ_SEC_YZ: opening global file: U_obW.bin
+(PID.TID 0000.0001)  MDS_READ_SEC_YZ: opening global file: U_obW.bin
+(PID.TID 0000.0001)  MDS_READ_SEC_YZ: opening global file: V_obW.bin
+(PID.TID 0000.0001)  MDS_READ_SEC_YZ: opening global file: V_obW.bin
+(PID.TID 0000.0001)  MDS_READ_SEC_YZ: opening global file: T_obW.bin
+(PID.TID 0000.0001)  MDS_READ_SEC_YZ: opening global file: T_obW.bin
+(PID.TID 0000.0001)  MDS_READ_SEC_YZ: opening global file: S_obW.bin
+(PID.TID 0000.0001)  MDS_READ_SEC_YZ: opening global file: S_obW.bin
+(PID.TID 0000.0001)  MDS_READ_SEC_XZ: opening global file: U_obN.bin
+(PID.TID 0000.0001)  MDS_READ_SEC_XZ: opening global file: U_obN.bin
+(PID.TID 0000.0001)  MDS_READ_SEC_XZ: opening global file: V_obN.bin
+(PID.TID 0000.0001)  MDS_READ_SEC_XZ: opening global file: V_obN.bin
+(PID.TID 0000.0001)  MDS_READ_SEC_XZ: opening global file: T_obN.bin
+(PID.TID 0000.0001)  MDS_READ_SEC_XZ: opening global file: T_obN.bin
+(PID.TID 0000.0001)  MDS_READ_SEC_XZ: opening global file: S_obN.bin
+(PID.TID 0000.0001)  MDS_READ_SEC_XZ: opening global file: S_obN.bin
+(PID.TID 0000.0001)  MDS_READ_SEC_YZ: opening global file: Trac01_obE.bin
+(PID.TID 0000.0001)  MDS_READ_SEC_YZ: opening global file: Trac01_obE.bin
+(PID.TID 0000.0001)  MDS_READ_SEC_YZ: opening global file: Trac01_obW.bin
+(PID.TID 0000.0001)  MDS_READ_SEC_YZ: opening global file: Trac01_obW.bin
+(PID.TID 0000.0001)  MDS_READ_SEC_XZ: opening global file: Trac01_obN.bin
+(PID.TID 0000.0001)  MDS_READ_SEC_XZ: opening global file: Trac01_obN.bin
+(PID.TID 0000.0001)  MDS_READ_SEC_YZ: opening global file: Trac02_obE.bin
+(PID.TID 0000.0001)  MDS_READ_SEC_YZ: opening global file: Trac02_obE.bin
+(PID.TID 0000.0001)  MDS_READ_SEC_YZ: opening global file: Trac02_obW.bin
+(PID.TID 0000.0001)  MDS_READ_SEC_YZ: opening global file: Trac02_obW.bin
+(PID.TID 0000.0001)  MDS_READ_SEC_XZ: opening global file: Trac02_obN.bin
+(PID.TID 0000.0001)  MDS_READ_SEC_XZ: opening global file: Trac02_obN.bin
+(PID.TID 0000.0001)  MDS_READ_SEC_YZ: opening global file: Trac03_obE.bin
+(PID.TID 0000.0001)  MDS_READ_SEC_YZ: opening global file: Trac03_obE.bin
+(PID.TID 0000.0001)  MDS_READ_SEC_YZ: opening global file: Trac03_obW.bin
+(PID.TID 0000.0001)  MDS_READ_SEC_YZ: opening global file: Trac03_obW.bin
+(PID.TID 0000.0001)  MDS_READ_SEC_XZ: opening global file: Trac03_obN.bin
+(PID.TID 0000.0001)  MDS_READ_SEC_XZ: opening global file: Trac03_obN.bin
+(PID.TID 0000.0001)  MDS_READ_SEC_YZ: opening global file: Trac04_obE.bin
+(PID.TID 0000.0001)  MDS_READ_SEC_YZ: opening global file: Trac04_obE.bin
+(PID.TID 0000.0001)  MDS_READ_SEC_YZ: opening global file: Trac04_obW.bin
+(PID.TID 0000.0001)  MDS_READ_SEC_YZ: opening global file: Trac04_obW.bin
+(PID.TID 0000.0001)  MDS_READ_SEC_XZ: opening global file: Trac04_obN.bin
+(PID.TID 0000.0001)  MDS_READ_SEC_XZ: opening global file: Trac04_obN.bin
+(PID.TID 0000.0001)  MDS_READ_SEC_YZ: opening global file: Trac05_obE.bin
+(PID.TID 0000.0001)  MDS_READ_SEC_YZ: opening global file: Trac05_obE.bin
+(PID.TID 0000.0001)  MDS_READ_SEC_YZ: opening global file: Trac05_obW.bin
+(PID.TID 0000.0001)  MDS_READ_SEC_YZ: opening global file: Trac05_obW.bin
+(PID.TID 0000.0001)  MDS_READ_SEC_XZ: opening global file: Trac05_obN.bin
+(PID.TID 0000.0001)  MDS_READ_SEC_XZ: opening global file: Trac05_obN.bin
+(PID.TID 0000.0001) // =======================================================
+(PID.TID 0000.0001) // Model current state
+(PID.TID 0000.0001) // =======================================================
+(PID.TID 0000.0001) 
+(PID.TID 0000.0001) // =======================================================
+(PID.TID 0000.0001) // Begin MONITOR dynamic field statistics
+(PID.TID 0000.0001) // =======================================================
+(PID.TID 0000.0001) %MON time_tsnumber                =                     0
+(PID.TID 0000.0001) %MON time_secondsf                =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON dynstat_eta_max              =   4.2498448491096E-01
+(PID.TID 0000.0001) %MON dynstat_eta_min              =  -1.4817472696304E+00
+(PID.TID 0000.0001) %MON dynstat_eta_mean             =  -5.1768973270635E-01
+(PID.TID 0000.0001) %MON dynstat_eta_sd               =   5.9968952443660E-01
+(PID.TID 0000.0001) %MON dynstat_eta_del2             =   2.3532016988898E-03
+(PID.TID 0000.0001) %MON dynstat_uvel_max             =   1.3023830950260E-01
+(PID.TID 0000.0001) %MON dynstat_uvel_min             =  -6.0768067836761E-02
+(PID.TID 0000.0001) %MON dynstat_uvel_mean            =   7.3493858379116E-03
+(PID.TID 0000.0001) %MON dynstat_uvel_sd              =   1.4643824433314E-02
+(PID.TID 0000.0001) %MON dynstat_uvel_del2            =   1.6249141681668E-04
+(PID.TID 0000.0001) %MON dynstat_vvel_max             =   1.2960743904114E-01
+(PID.TID 0000.0001) %MON dynstat_vvel_min             =  -8.8518343865871E-02
+(PID.TID 0000.0001) %MON dynstat_vvel_mean            =   8.9127213327288E-04
+(PID.TID 0000.0001) %MON dynstat_vvel_sd              =   8.4376087770051E-03
+(PID.TID 0000.0001) %MON dynstat_vvel_del2            =   1.0650506343562E-04
+(PID.TID 0000.0001) %MON dynstat_wvel_max             =   5.5220275294497E-05
+(PID.TID 0000.0001) %MON dynstat_wvel_min             =  -1.4137995947489E-04
+(PID.TID 0000.0001) %MON dynstat_wvel_mean            =  -2.4324096431404E-07
+(PID.TID 0000.0001) %MON dynstat_wvel_sd              =   5.5064315434168E-06
+(PID.TID 0000.0001) %MON dynstat_wvel_del2            =   1.4504545477429E-07
+(PID.TID 0000.0001) %MON dynstat_theta_max            =   2.4157361984253E+01
+(PID.TID 0000.0001) %MON dynstat_theta_min            =  -2.8958356380463E+00
+(PID.TID 0000.0001) %MON dynstat_theta_mean           =   2.3216137302711E+00
+(PID.TID 0000.0001) %MON dynstat_theta_sd             =   3.2103641662143E+00
+(PID.TID 0000.0001) %MON dynstat_theta_del2           =   6.6465388359911E-03
+(PID.TID 0000.0001) %MON dynstat_salt_max             =   3.6600784301758E+01
+(PID.TID 0000.0001) %MON dynstat_salt_min             =   3.3084754943848E+01
+(PID.TID 0000.0001) %MON dynstat_salt_mean            =   3.4483933613549E+01
+(PID.TID 0000.0001) %MON dynstat_salt_sd              =   1.9644712446743E-01
+(PID.TID 0000.0001) %MON dynstat_salt_del2            =   1.1588922083609E-03
+(PID.TID 0000.0001) %MON forcing_qnet_max             =   6.9361846923828E+01
+(PID.TID 0000.0001) %MON forcing_qnet_min             =  -2.0417861938477E+02
+(PID.TID 0000.0001) %MON forcing_qnet_mean            =  -1.1295642419045E+02
+(PID.TID 0000.0001) %MON forcing_qnet_sd              =   4.1815497434578E+01
+(PID.TID 0000.0001) %MON forcing_qnet_del2            =   8.8869422460177E-01
+(PID.TID 0000.0001) %MON forcing_qsw_max              =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON forcing_qsw_min              =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON forcing_qsw_mean             =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON forcing_qsw_sd               =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON forcing_qsw_del2             =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON forcing_empmr_max            =   2.5141471127199E-05
+(PID.TID 0000.0001) %MON forcing_empmr_min            =  -3.9761445691511E-05
+(PID.TID 0000.0001) %MON forcing_empmr_mean           =  -9.3236499820974E-06
+(PID.TID 0000.0001) %MON forcing_empmr_sd             =   1.0249687273683E-05
+(PID.TID 0000.0001) %MON forcing_empmr_del2           =   9.8755541425843E-08
+(PID.TID 0000.0001) %MON forcing_fu_max               =   2.1824374794960E-01
+(PID.TID 0000.0001) %MON forcing_fu_min               =  -1.0302186757326E-01
+(PID.TID 0000.0001) %MON forcing_fu_mean              =   7.3083621898039E-02
+(PID.TID 0000.0001) %MON forcing_fu_sd                =   7.2594531176829E-02
+(PID.TID 0000.0001) %MON forcing_fu_del2              =   5.9615425353979E-04
+(PID.TID 0000.0001) %MON forcing_fv_max               =   1.4191913604736E-01
+(PID.TID 0000.0001) %MON forcing_fv_min               =  -7.7472656965256E-02
+(PID.TID 0000.0001) %MON forcing_fv_mean              =  -1.7821404000724E-02
+(PID.TID 0000.0001) %MON forcing_fv_sd                =   3.3449841576786E-02
+(PID.TID 0000.0001) %MON forcing_fv_del2              =   3.7447536985508E-04
+(PID.TID 0000.0001) %MON trAdv_CFL_u_max              =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON trAdv_CFL_v_max              =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON trAdv_CFL_w_max              =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON advcfl_uvel_max              =   3.3632667693019E-02
+(PID.TID 0000.0001) %MON advcfl_vvel_max              =   1.7906237690509E-02
+(PID.TID 0000.0001) %MON advcfl_wvel_max              =   3.3657438911329E-02
+(PID.TID 0000.0001) %MON advcfl_W_hf_max              =   1.7963571321516E-02
+(PID.TID 0000.0001) %MON pe_b_mean                    =   8.4564277375069E-04
+(PID.TID 0000.0001) %MON ke_max                       =   9.2757393409125E-03
+(PID.TID 0000.0001) %MON ke_mean                      =   1.6130429888475E-04
+(PID.TID 0000.0001) %MON ke_vol                       =   1.2769337095763E+17
+(PID.TID 0000.0001) %MON vort_r_min                   =  -4.7830461303030E-07
+(PID.TID 0000.0001) %MON vort_r_max                   =   7.0582698239818E-07
+(PID.TID 0000.0001) %MON vort_a_mean                  =  -1.0457492699542E-04
+(PID.TID 0000.0001) %MON vort_a_sd                    =   2.1292568575566E-05
+(PID.TID 0000.0001) %MON vort_p_mean                  =  -1.2574624497018E-04
+(PID.TID 0000.0001) %MON vort_p_sd                    =   1.1183795518383E-04
+(PID.TID 0000.0001) %MON surfExpan_theta_mean         =  -1.4505528465063E-07
+(PID.TID 0000.0001) %MON surfExpan_salt_mean          =   7.1872208131480E-08
+(PID.TID 0000.0001) // =======================================================
+(PID.TID 0000.0001) // End MONITOR dynamic field statistics
+(PID.TID 0000.0001) // =======================================================
+(PID.TID 0000.0001) // =======================================================
+(PID.TID 0000.0001) // Begin OBCS MONITOR field statistics
+(PID.TID 0000.0001) // =======================================================
+(PID.TID 0000.0001) %MON obc_E_uVel_max               =   8.4231816232204E-02
+(PID.TID 0000.0001) %MON obc_E_uVel_min               =  -6.0768067836761E-02
+(PID.TID 0000.0001) %MON obc_E_uVel_mean              =   7.3664911249156E-03
+(PID.TID 0000.0001) %MON obc_E_uVel_sd                =   1.4300273749965E-02
+(PID.TID 0000.0001) %MON obc_E_uVel_Int               =   1.2629560767914E+08
+(PID.TID 0000.0001) %MON obc_W_uVel_max               =   5.9702914208174E-02
+(PID.TID 0000.0001) %MON obc_W_uVel_min               =  -2.5726319290698E-02
+(PID.TID 0000.0001) %MON obc_W_uVel_mean              =   7.0236617289703E-03
+(PID.TID 0000.0001) %MON obc_W_uVel_sd                =   1.1103839461495E-02
+(PID.TID 0000.0001) %MON obc_W_uVel_Int               =   1.3126718559515E+08
+(PID.TID 0000.0001) %MON obc_N_vVel_max               =   4.7468712553382E-02
+(PID.TID 0000.0001) %MON obc_N_vVel_min               =  -7.0454828441143E-02
+(PID.TID 0000.0001) %MON obc_N_vVel_mean              =   1.6522467327141E-04
+(PID.TID 0000.0001) %MON obc_N_vVel_sd                =   6.4416742406190E-03
+(PID.TID 0000.0001) %MON obc_N_vVel_Int               =   4.8301529307681E+06
+(PID.TID 0000.0001) %MON obc_E_theta_max              =   1.9184095382690E+01
+(PID.TID 0000.0001) %MON obc_E_theta_min              =  -1.6429638266563E+00
+(PID.TID 0000.0001) %MON obc_E_theta_mean             =   1.9094777718074E+00
+(PID.TID 0000.0001) %MON obc_E_theta_sd               =   2.9652256041640E+00
+(PID.TID 0000.0001) %MON obc_W_theta_max              =   2.1404630661011E+01
+(PID.TID 0000.0001) %MON obc_W_theta_min              =  -1.4417628645897E+00
+(PID.TID 0000.0001) %MON obc_W_theta_mean             =   2.4654016052560E+00
+(PID.TID 0000.0001) %MON obc_W_theta_sd               =   2.9592378831378E+00
+(PID.TID 0000.0001) %MON obc_N_theta_max              =   2.3972635269165E+01
+(PID.TID 0000.0001) %MON obc_N_theta_min              =  -6.3042351603508E-01
+(PID.TID 0000.0001) %MON obc_N_theta_mean             =   4.8710207613799E+00
+(PID.TID 0000.0001) %MON obc_N_theta_sd               =   4.7009472474846E+00
+(PID.TID 0000.0001) // =======================================================
+(PID.TID 0000.0001) // End OBCS MONITOR field statistics
+(PID.TID 0000.0001) // =======================================================
+(PID.TID 0000.0001) // =======================================================
+(PID.TID 0000.0001) // Begin MONITOR ptracer field statistics
+(PID.TID 0000.0001) // =======================================================
+(PID.TID 0000.0001) %MON trcstat_ptracer01_max        =   2.3591387271881E+00
+(PID.TID 0000.0001) %MON trcstat_ptracer01_min        =   1.9367703199387E+00
+(PID.TID 0000.0001) %MON trcstat_ptracer01_mean       =   2.2425301046135E+00
+(PID.TID 0000.0001) %MON trcstat_ptracer01_sd         =   7.5981612504913E-02
+(PID.TID 0000.0001) %MON trcstat_ptracer01_del2       =   1.0693771728119E-04
+(PID.TID 0000.0001) %MON trcstat_ptracer02_max        =   2.4116826057434E+00
+(PID.TID 0000.0001) %MON trcstat_ptracer02_min        =   2.1899123191833E+00
+(PID.TID 0000.0001) %MON trcstat_ptracer02_mean       =   2.3520448323130E+00
+(PID.TID 0000.0001) %MON trcstat_ptracer02_sd         =   3.5091243992577E-02
+(PID.TID 0000.0001) %MON trcstat_ptracer02_del2       =   8.0636971566538E-05
+(PID.TID 0000.0001) %MON trcstat_ptracer03_max        =   2.7654629666358E-03
+(PID.TID 0000.0001) %MON trcstat_ptracer03_min        =   4.7440538764931E-05
+(PID.TID 0000.0001) %MON trcstat_ptracer03_mean       =   2.0556800669777E-03
+(PID.TID 0000.0001) %MON trcstat_ptracer03_sd         =   5.0322634216633E-04
+(PID.TID 0000.0001) %MON trcstat_ptracer03_del2       =   6.7075508236597E-07
+(PID.TID 0000.0001) %MON trcstat_ptracer04_max        =   2.5665847351775E-04
+(PID.TID 0000.0001) %MON trcstat_ptracer04_min        =  -7.4560205121088E-07
+(PID.TID 0000.0001) %MON trcstat_ptracer04_mean       =   6.2001614686786E-06
+(PID.TID 0000.0001) %MON trcstat_ptracer04_sd         =   2.6096018939081E-05
+(PID.TID 0000.0001) %MON trcstat_ptracer04_del2       =   1.3468378546213E-07
+(PID.TID 0000.0001) %MON trcstat_ptracer05_max        =   3.8357657194138E-01
+(PID.TID 0000.0001) %MON trcstat_ptracer05_min        =   8.2342259585857E-02
+(PID.TID 0000.0001) %MON trcstat_ptracer05_mean       =   2.1413280166756E-01
+(PID.TID 0000.0001) %MON trcstat_ptracer05_sd         =   4.3053560479973E-02
+(PID.TID 0000.0001) %MON trcstat_ptracer05_del2       =   1.1918591217244E-04
+(PID.TID 0000.0001) // =======================================================
+(PID.TID 0000.0001) // End MONITOR ptracer field statistics
+(PID.TID 0000.0001) // =======================================================
+ EXTERNAL_FIELDS_LOAD,         0 : iP,iLd,i0,i1=   12    0   12    1 ; Wght=  0.5000000000  0.5000000000
+ EXTERNAL_FIELDS_LOAD, it=         0 : Reading new data, i0,i1=   12    1 (prev=   12    0 )
+(PID.TID 0000.0001)  MDS_READ_FIELD: opening global file: tren_taux_box.bin
+(PID.TID 0000.0001)  MDS_READ_FIELD: opening global file: tren_taux_box.bin
+(PID.TID 0000.0001)  MDS_READ_FIELD: opening global file: tren_tauy_box.bin
+(PID.TID 0000.0001)  MDS_READ_FIELD: opening global file: tren_tauy_box.bin
+(PID.TID 0000.0001)  MDS_READ_FIELD: opening global file: shi_qnet_box.bin
+(PID.TID 0000.0001)  MDS_READ_FIELD: opening global file: shi_qnet_box.bin
+(PID.TID 0000.0001)  MDS_READ_FIELD: opening global file: shi_empmr_year_box.bin
+(PID.TID 0000.0001)  MDS_READ_FIELD: opening global file: shi_empmr_year_box.bin
+(PID.TID 0000.0001)  MDS_READ_FIELD: opening global file: lev_monthly_temp_box.bin
+(PID.TID 0000.0001)  MDS_READ_FIELD: opening global file: lev_monthly_temp_box.bin
+(PID.TID 0000.0001)  MDS_READ_FIELD: opening global file: lev_monthly_salt_box.bin
+(PID.TID 0000.0001)  MDS_READ_FIELD: opening global file: lev_monthly_salt_box.bin
+ DIC_FIELDS_LOAD,         0 : iP,iLd,i0,i1=   12    0   12    1 ; Wght=  0.5000000000  0.5000000000
+ DIC_FIELDS_LOAD, it=         0 : Reading new data, i0,i1=   12    1 (prev=   12    0 )
+(PID.TID 0000.0001)  MDS_READ_FIELD: opening global file: tren_speed_box.bin
+(PID.TID 0000.0001)  MDS_READ_FIELD: opening global file: tren_speed_box.bin
+(PID.TID 0000.0001)  MDS_READ_FIELD: opening global file: sillev1_box.bin
+(PID.TID 0000.0001)  MDS_READ_FIELD: opening global file: sillev1_box.bin
+(PID.TID 0000.0001)  MDS_READ_FIELD: opening global file: silicate_3D_12m_box.bin
+(PID.TID 0000.0001)  MDS_READ_FIELD: opening global file: silicate_3D_12m_box.bin
+(PID.TID 0000.0001)  MDS_READ_FIELD: opening global file: fice_box.bin
+(PID.TID 0000.0001)  MDS_READ_FIELD: opening global file: fice_box.bin
+ OBCS_FIELDS_LOAD,         1 : iP,iLd,i0,i1=   12    1   12    1 ; Wght=  0.4833333333  0.5166666667
+(PID.TID 0000.0001) SOLVE_FOR_PRESSURE: putPmEinXvector =    F
+ cg2d: Sum(rhs),rhsMax =   3.70300204682829E+01  9.88743731864319E-01
+(PID.TID 0000.0001)      cg2d_init_res =   2.37603699273327E-01
+(PID.TID 0000.0001)      cg2d_iters(min,last) =      -1      80
+(PID.TID 0000.0001)      cg2d_last_res =   7.83460039210268E-14
+(PID.TID 0000.0001) // =======================================================
+(PID.TID 0000.0001) // Begin MONITOR dynamic field statistics
+(PID.TID 0000.0001) // =======================================================
+(PID.TID 0000.0001) %MON time_tsnumber                =                     1
+(PID.TID 0000.0001) %MON time_secondsf                =   4.3200000000000E+04
+(PID.TID 0000.0001) %MON dynstat_eta_max              =   4.5995434788303E-01
+(PID.TID 0000.0001) %MON dynstat_eta_min              =  -1.4926906630212E+00
+(PID.TID 0000.0001) %MON dynstat_eta_mean             =  -5.1751416804791E-01
+(PID.TID 0000.0001) %MON dynstat_eta_sd               =   6.0178255889349E-01
+(PID.TID 0000.0001) %MON dynstat_eta_del2             =   2.3589778971511E-03
+(PID.TID 0000.0001) %MON dynstat_uvel_max             =   1.3027291294470E-01
+(PID.TID 0000.0001) %MON dynstat_uvel_min             =  -6.0691849142313E-02
+(PID.TID 0000.0001) %MON dynstat_uvel_mean            =   7.4175285308401E-03
+(PID.TID 0000.0001) %MON dynstat_uvel_sd              =   1.4633337899631E-02
+(PID.TID 0000.0001) %MON dynstat_uvel_del2            =   1.6238374490497E-04
+(PID.TID 0000.0001) %MON dynstat_vvel_max             =   1.2954916558810E-01
+(PID.TID 0000.0001) %MON dynstat_vvel_min             =  -8.8515782804455E-02
+(PID.TID 0000.0001) %MON dynstat_vvel_mean            =   9.1326993179764E-04
+(PID.TID 0000.0001) %MON dynstat_vvel_sd              =   8.4326980060472E-03
+(PID.TID 0000.0001) %MON dynstat_vvel_del2            =   1.0638914247425E-04
+(PID.TID 0000.0001) %MON dynstat_wvel_max             =   5.5009566978399E-05
+(PID.TID 0000.0001) %MON dynstat_wvel_min             =  -1.4162700010206E-04
+(PID.TID 0000.0001) %MON dynstat_wvel_mean            =  -2.4323740420733E-07
+(PID.TID 0000.0001) %MON dynstat_wvel_sd              =   5.4535039627299E-06
+(PID.TID 0000.0001) %MON dynstat_wvel_del2            =   1.4032734702382E-07
+(PID.TID 0000.0001) %MON dynstat_theta_max            =   2.4176176055431E+01
+(PID.TID 0000.0001) %MON dynstat_theta_min            =  -2.8959442458374E+00
+(PID.TID 0000.0001) %MON dynstat_theta_mean           =   2.3219357947834E+00
+(PID.TID 0000.0001) %MON dynstat_theta_sd             =   3.2112571801567E+00
+(PID.TID 0000.0001) %MON dynstat_theta_del2           =   6.6436082635441E-03
+(PID.TID 0000.0001) %MON dynstat_salt_max             =   3.6600983637883E+01
+(PID.TID 0000.0001) %MON dynstat_salt_min             =   3.3083605831074E+01
+(PID.TID 0000.0001) %MON dynstat_salt_mean            =   3.4483935079098E+01
+(PID.TID 0000.0001) %MON dynstat_salt_sd              =   1.9645820244523E-01
+(PID.TID 0000.0001) %MON dynstat_salt_del2            =   1.1582977948130E-03
+(PID.TID 0000.0001) %MON forcing_qnet_max             =   6.8294754028320E+01
+(PID.TID 0000.0001) %MON forcing_qnet_min             =  -2.1320401000977E+02
+(PID.TID 0000.0001) %MON forcing_qnet_mean            =  -1.2120328054684E+02
+(PID.TID 0000.0001) %MON forcing_qnet_sd              =   4.4775932709347E+01
+(PID.TID 0000.0001) %MON forcing_qnet_del2            =   8.3492965265813E-01
+(PID.TID 0000.0001) %MON forcing_qsw_max              =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON forcing_qsw_min              =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON forcing_qsw_mean             =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON forcing_qsw_sd               =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON forcing_qsw_del2             =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON forcing_empmr_max            =   2.5141471127199E-05
+(PID.TID 0000.0001) %MON forcing_empmr_min            =  -3.9761445691511E-05
+(PID.TID 0000.0001) %MON forcing_empmr_mean           =  -9.3236499820974E-06
+(PID.TID 0000.0001) %MON forcing_empmr_sd             =   1.0249687273683E-05
+(PID.TID 0000.0001) %MON forcing_empmr_del2           =   9.8755541425843E-08
+(PID.TID 0000.0001) %MON forcing_fu_max               =   2.1189042925835E-01
+(PID.TID 0000.0001) %MON forcing_fu_min               =  -9.0532809495926E-02
+(PID.TID 0000.0001) %MON forcing_fu_mean              =   7.6106089453040E-02
+(PID.TID 0000.0001) %MON forcing_fu_sd                =   7.1216399468495E-02
+(PID.TID 0000.0001) %MON forcing_fu_del2              =   5.5128220616824E-04
+(PID.TID 0000.0001) %MON forcing_fv_max               =   1.5118104964495E-01
+(PID.TID 0000.0001) %MON forcing_fv_min               =  -7.6193943619728E-02
+(PID.TID 0000.0001) %MON forcing_fv_mean              =  -1.9592570688621E-02
+(PID.TID 0000.0001) %MON forcing_fv_sd                =   3.3563926402948E-02
+(PID.TID 0000.0001) %MON forcing_fv_del2              =   3.7626012825569E-04
+(PID.TID 0000.0001) %MON trAdv_CFL_u_max              =   8.1675162763305E-02
+(PID.TID 0000.0001) %MON trAdv_CFL_v_max              =   1.8487912745656E-02
+(PID.TID 0000.0001) %MON trAdv_CFL_w_max              =   6.2844837867684E-02
+(PID.TID 0000.0001) %MON advcfl_uvel_max              =   3.3641603666416E-02
+(PID.TID 0000.0001) %MON advcfl_vvel_max              =   1.7898186776852E-02
+(PID.TID 0000.0001) %MON advcfl_wvel_max              =   1.6762428505230E-02
+(PID.TID 0000.0001) %MON advcfl_W_hf_max              =   1.7994960012968E-02
+(PID.TID 0000.0001) %MON pe_b_mean                    =   8.4878613014088E-04
+(PID.TID 0000.0001) %MON ke_max                       =   9.2726630591449E-03
+(PID.TID 0000.0001) %MON ke_mean                      =   1.6162367406714E-04
+(PID.TID 0000.0001) %MON ke_vol                       =   1.2769337095763E+17
+(PID.TID 0000.0001) %MON vort_r_min                   =  -4.7776380617399E-07
+(PID.TID 0000.0001) %MON vort_r_max                   =   7.0533584638701E-07
+(PID.TID 0000.0001) %MON vort_a_mean                  =  -1.0457492648028E-04
+(PID.TID 0000.0001) %MON vort_a_sd                    =   2.1292605380161E-05
+(PID.TID 0000.0001) %MON vort_p_mean                  =  -1.2574624435076E-04
+(PID.TID 0000.0001) %MON vort_p_sd                    =   1.1183798042838E-04
+(PID.TID 0000.0001) %MON surfExpan_theta_mean         =   2.2002699834481E-08
+(PID.TID 0000.0001) %MON surfExpan_salt_mean          =   1.0362440405314E-07
+(PID.TID 0000.0001) // =======================================================
+(PID.TID 0000.0001) // End MONITOR dynamic field statistics
+(PID.TID 0000.0001) // =======================================================
+(PID.TID 0000.0001) // =======================================================
+(PID.TID 0000.0001) // Begin OBCS MONITOR field statistics
+(PID.TID 0000.0001) // =======================================================
+(PID.TID 0000.0001) %MON obc_E_uVel_max               =   8.4097423652808E-02
+(PID.TID 0000.0001) %MON obc_E_uVel_min               =  -6.0691849142313E-02
+(PID.TID 0000.0001) %MON obc_E_uVel_mean              =   7.3646583987137E-03
+(PID.TID 0000.0001) %MON obc_E_uVel_sd                =   1.4300890782899E-02
+(PID.TID 0000.0001) %MON obc_E_uVel_Int               =   1.2626418630559E+08
+(PID.TID 0000.0001) %MON obc_W_uVel_max               =   5.9750952695807E-02
+(PID.TID 0000.0001) %MON obc_W_uVel_min               =  -2.5728699409713E-02
+(PID.TID 0000.0001) %MON obc_W_uVel_mean              =   7.0192873374808E-03
+(PID.TID 0000.0001) %MON obc_W_uVel_sd                =   1.1107779277586E-02
+(PID.TID 0000.0001) %MON obc_W_uVel_Int               =   1.3118543136471E+08
+(PID.TID 0000.0001) %MON obc_N_vVel_max               =   4.7415303376814E-02
+(PID.TID 0000.0001) %MON obc_N_vVel_min               =  -7.0506425450246E-02
+(PID.TID 0000.0001) %MON obc_N_vVel_mean              =   1.6346447363572E-04
+(PID.TID 0000.0001) %MON obc_N_vVel_sd                =   6.4402877553886E-03
+(PID.TID 0000.0001) %MON obc_N_vVel_Int               =   4.7786955227386E+06
+(PID.TID 0000.0001) %MON obc_E_theta_max              =   1.9205570983887E+01
+(PID.TID 0000.0001) %MON obc_E_theta_min              =  -1.6343102912108E+00
+(PID.TID 0000.0001) %MON obc_E_theta_mean             =   1.9094666342927E+00
+(PID.TID 0000.0001) %MON obc_E_theta_sd               =   2.9656966224417E+00
+(PID.TID 0000.0001) %MON obc_W_theta_max              =   2.1424821790059E+01
+(PID.TID 0000.0001) %MON obc_W_theta_min              =  -1.4418450812499E+00
+(PID.TID 0000.0001) %MON obc_W_theta_mean             =   2.4656188431364E+00
+(PID.TID 0000.0001) %MON obc_W_theta_sd               =   2.9597766264317E+00
+(PID.TID 0000.0001) %MON obc_N_theta_max              =   2.3993523279826E+01
+(PID.TID 0000.0001) %MON obc_N_theta_min              =  -6.3092609544595E-01
+(PID.TID 0000.0001) %MON obc_N_theta_mean             =   4.8712326540729E+00
+(PID.TID 0000.0001) %MON obc_N_theta_sd               =   4.7018270697657E+00
+(PID.TID 0000.0001) // =======================================================
+(PID.TID 0000.0001) // End OBCS MONITOR field statistics
+(PID.TID 0000.0001) // =======================================================
+(PID.TID 0000.0001) // =======================================================
+(PID.TID 0000.0001) // Begin MONITOR ptracer field statistics
+(PID.TID 0000.0001) // =======================================================
+(PID.TID 0000.0001) %MON trcstat_ptracer01_max        =   2.3591394662250E+00
+(PID.TID 0000.0001) %MON trcstat_ptracer01_min        =   1.9367503757050E+00
+(PID.TID 0000.0001) %MON trcstat_ptracer01_mean       =   2.2425286258840E+00
+(PID.TID 0000.0001) %MON trcstat_ptracer01_sd         =   7.5985119850633E-02
+(PID.TID 0000.0001) %MON trcstat_ptracer01_del2       =   1.0685574152928E-04
+(PID.TID 0000.0001) %MON trcstat_ptracer02_max        =   2.4116827787738E+00
+(PID.TID 0000.0001) %MON trcstat_ptracer02_min        =   2.1899459792551E+00
+(PID.TID 0000.0001) %MON trcstat_ptracer02_mean       =   2.3520451784955E+00
+(PID.TID 0000.0001) %MON trcstat_ptracer02_sd         =   3.5091068496443E-02
+(PID.TID 0000.0001) %MON trcstat_ptracer02_del2       =   8.0629800641419E-05
+(PID.TID 0000.0001) %MON trcstat_ptracer03_max        =   2.7654670647513E-03
+(PID.TID 0000.0001) %MON trcstat_ptracer03_min        =   4.7395120481237E-05
+(PID.TID 0000.0001) %MON trcstat_ptracer03_mean       =   2.0556705765263E-03
+(PID.TID 0000.0001) %MON trcstat_ptracer03_sd         =   5.0324302750848E-04
+(PID.TID 0000.0001) %MON trcstat_ptracer03_del2       =   6.7043671858714E-07
+(PID.TID 0000.0001) %MON trcstat_ptracer04_max        =   2.5699611737368E-04
+(PID.TID 0000.0001) %MON trcstat_ptracer04_min        =  -7.4705281297197E-07
+(PID.TID 0000.0001) %MON trcstat_ptracer04_mean       =   6.2084159923944E-06
+(PID.TID 0000.0001) %MON trcstat_ptracer04_sd         =   2.6136106693571E-05
+(PID.TID 0000.0001) %MON trcstat_ptracer04_del2       =   1.3456372290705E-07
+(PID.TID 0000.0001) %MON trcstat_ptracer05_max        =   3.8361753713501E-01
+(PID.TID 0000.0001) %MON trcstat_ptracer05_min        =   8.2383316333612E-02
+(PID.TID 0000.0001) %MON trcstat_ptracer05_mean       =   2.1413094083900E-01
+(PID.TID 0000.0001) %MON trcstat_ptracer05_sd         =   4.3051033243526E-02
+(PID.TID 0000.0001) %MON trcstat_ptracer05_del2       =   1.1897591872251E-04
+(PID.TID 0000.0001) // =======================================================
+(PID.TID 0000.0001) // End MONITOR ptracer field statistics
+(PID.TID 0000.0001) // =======================================================
+ EXTERNAL_FIELDS_LOAD,         1 : iP,iLd,i0,i1=   12    1   12    1 ; Wght=  0.4833333333  0.5166666667
+ DIC_FIELDS_LOAD,         1 : iP,iLd,i0,i1=   12    1   12    1 ; Wght=  0.4833333333  0.5166666667
+ OBCS_FIELDS_LOAD,         2 : iP,iLd,i0,i1=   12    1   12    1 ; Wght=  0.4666666667  0.5333333333
+ cg2d: Sum(rhs),rhsMax =   3.70217753957371E+01  9.88625784851453E-01
+(PID.TID 0000.0001)      cg2d_init_res =   2.18099076329334E-01
+(PID.TID 0000.0001)      cg2d_iters(min,last) =      -1      80
+(PID.TID 0000.0001)      cg2d_last_res =   9.55927126932183E-14
+(PID.TID 0000.0001) // =======================================================
+(PID.TID 0000.0001) // Begin MONITOR dynamic field statistics
+(PID.TID 0000.0001) // =======================================================
+(PID.TID 0000.0001) %MON time_tsnumber                =                     2
+(PID.TID 0000.0001) %MON time_secondsf                =   8.6400000000000E+04
+(PID.TID 0000.0001) %MON dynstat_eta_max              =   4.6334347157143E-01
+(PID.TID 0000.0001) %MON dynstat_eta_min              =  -1.5054718669162E+00
+(PID.TID 0000.0001) %MON dynstat_eta_mean             =  -5.1733721838717E-01
+(PID.TID 0000.0001) %MON dynstat_eta_sd               =   6.0496709348125E-01
+(PID.TID 0000.0001) %MON dynstat_eta_del2             =   2.3577831149832E-03
+(PID.TID 0000.0001) %MON dynstat_uvel_max             =   1.3041106999456E-01
+(PID.TID 0000.0001) %MON dynstat_uvel_min             =  -6.0615630447865E-02
+(PID.TID 0000.0001) %MON dynstat_uvel_mean            =   7.4725824773712E-03
+(PID.TID 0000.0001) %MON dynstat_uvel_sd              =   1.4631652665722E-02
+(PID.TID 0000.0001) %MON dynstat_uvel_del2            =   1.6226581855361E-04
+(PID.TID 0000.0001) %MON dynstat_vvel_max             =   1.2953153531427E-01
+(PID.TID 0000.0001) %MON dynstat_vvel_min             =  -8.8521495760349E-02
+(PID.TID 0000.0001) %MON dynstat_vvel_mean            =   9.3671467481625E-04
+(PID.TID 0000.0001) %MON dynstat_vvel_sd              =   8.4317722124119E-03
+(PID.TID 0000.0001) %MON dynstat_vvel_del2            =   1.0631845421267E-04
+(PID.TID 0000.0001) %MON dynstat_wvel_max             =   5.4857585207279E-05
+(PID.TID 0000.0001) %MON dynstat_wvel_min             =  -1.4187401954804E-04
+(PID.TID 0000.0001) %MON dynstat_wvel_mean            =  -2.4323384410062E-07
+(PID.TID 0000.0001) %MON dynstat_wvel_sd              =   5.4672365947540E-06
+(PID.TID 0000.0001) %MON dynstat_wvel_del2            =   1.4054166570978E-07
+(PID.TID 0000.0001) %MON dynstat_theta_max            =   2.4191250964543E+01
+(PID.TID 0000.0001) %MON dynstat_theta_min            =  -2.8960457389717E+00
+(PID.TID 0000.0001) %MON dynstat_theta_mean           =   2.3222538696213E+00
+(PID.TID 0000.0001) %MON dynstat_theta_sd             =   3.2121304166893E+00
+(PID.TID 0000.0001) %MON dynstat_theta_del2           =   6.6406361958254E-03
+(PID.TID 0000.0001) %MON dynstat_salt_max             =   3.6601160772400E+01
+(PID.TID 0000.0001) %MON dynstat_salt_min             =   3.3082402903474E+01
+(PID.TID 0000.0001) %MON dynstat_salt_mean            =   3.4483935951541E+01
+(PID.TID 0000.0001) %MON dynstat_salt_sd              =   1.9646577404095E-01
+(PID.TID 0000.0001) %MON dynstat_salt_del2            =   1.1576659921708E-03
+(PID.TID 0000.0001) %MON forcing_qnet_max             =   6.8330323791504E+01
+(PID.TID 0000.0001) %MON forcing_qnet_min             =  -2.1277729593913E+02
+(PID.TID 0000.0001) %MON forcing_qnet_mean            =  -1.2092838533496E+02
+(PID.TID 0000.0001) %MON forcing_qnet_sd              =   4.4621997369695E+01
+(PID.TID 0000.0001) %MON forcing_qnet_del2            =   8.3603312595688E-01
+(PID.TID 0000.0001) %MON forcing_qsw_max              =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON forcing_qsw_min              =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON forcing_qsw_mean             =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON forcing_qsw_sd               =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON forcing_qsw_del2             =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON forcing_empmr_max            =   2.5141471127199E-05
+(PID.TID 0000.0001) %MON forcing_empmr_min            =  -3.9761445691511E-05
+(PID.TID 0000.0001) %MON forcing_empmr_mean           =  -9.3236499820974E-06
+(PID.TID 0000.0001) %MON forcing_empmr_sd             =   1.0249687273683E-05
+(PID.TID 0000.0001) %MON forcing_empmr_del2           =   9.8755541425843E-08
+(PID.TID 0000.0001) %MON forcing_fu_max               =   2.1201943308115E-01
+(PID.TID 0000.0001) %MON forcing_fu_min               =  -9.0949111431837E-02
+(PID.TID 0000.0001) %MON forcing_fu_mean              =   7.6005340534540E-02
+(PID.TID 0000.0001) %MON forcing_fu_sd                =   7.1251205601334E-02
+(PID.TID 0000.0001) %MON forcing_fu_del2              =   5.5216683859400E-04
+(PID.TID 0000.0001) %MON forcing_fv_max               =   1.5087231919169E-01
+(PID.TID 0000.0001) %MON forcing_fv_min               =  -7.6163741697868E-02
+(PID.TID 0000.0001) %MON forcing_fv_mean              =  -1.9533531799024E-02
+(PID.TID 0000.0001) %MON forcing_fv_sd                =   3.3549641941976E-02
+(PID.TID 0000.0001) %MON forcing_fv_del2              =   3.7565688124801E-04
+(PID.TID 0000.0001) %MON trAdv_CFL_u_max              =   8.3734380919868E-02
+(PID.TID 0000.0001) %MON trAdv_CFL_v_max              =   1.9400977256355E-02
+(PID.TID 0000.0001) %MON trAdv_CFL_w_max              =   6.4038758935331E-02
+(PID.TID 0000.0001) %MON advcfl_uvel_max              =   3.3677281265160E-02
+(PID.TID 0000.0001) %MON advcfl_vvel_max              =   1.7895751022576E-02
+(PID.TID 0000.0001) %MON advcfl_wvel_max              =   1.6791664779384E-02
+(PID.TID 0000.0001) %MON advcfl_W_hf_max              =   1.8026346013162E-02
+(PID.TID 0000.0001) %MON pe_b_mean                    =   8.5371721839429E-04
+(PID.TID 0000.0001) %MON ke_max                       =   9.2836853228384E-03
+(PID.TID 0000.0001) %MON ke_mean                      =   1.6201167056061E-04
+(PID.TID 0000.0001) %MON ke_vol                       =   1.2769337095763E+17
+(PID.TID 0000.0001) %MON vort_r_min                   =  -4.7734233399894E-07
+(PID.TID 0000.0001) %MON vort_r_max                   =   7.0506910459598E-07
+(PID.TID 0000.0001) %MON vort_a_mean                  =  -1.0457492596515E-04
+(PID.TID 0000.0001) %MON vort_a_sd                    =   2.1292637161886E-05
+(PID.TID 0000.0001) %MON vort_p_mean                  =  -1.2574624373134E-04
+(PID.TID 0000.0001) %MON vort_p_sd                    =   1.1183801627528E-04
+(PID.TID 0000.0001) %MON surfExpan_theta_mean         =   2.6874756579119E-07
+(PID.TID 0000.0001) %MON surfExpan_salt_mean          =   1.0981311502989E-07
+(PID.TID 0000.0001) // =======================================================
+(PID.TID 0000.0001) // End MONITOR dynamic field statistics
+(PID.TID 0000.0001) // =======================================================
+(PID.TID 0000.0001) // =======================================================
+(PID.TID 0000.0001) // Begin OBCS MONITOR field statistics
+(PID.TID 0000.0001) // =======================================================
+(PID.TID 0000.0001) %MON obc_E_uVel_max               =   8.3963031073411E-02
+(PID.TID 0000.0001) %MON obc_E_uVel_min               =  -6.0615630447865E-02
+(PID.TID 0000.0001) %MON obc_E_uVel_mean              =   7.3628256725119E-03
+(PID.TID 0000.0001) %MON obc_E_uVel_sd                =   1.4301519717685E-02
+(PID.TID 0000.0001) %MON obc_E_uVel_Int               =   1.2623276493204E+08
+(PID.TID 0000.0001) %MON obc_W_uVel_max               =   5.9798991183440E-02
+(PID.TID 0000.0001) %MON obc_W_uVel_min               =  -2.5731079528729E-02
+(PID.TID 0000.0001) %MON obc_W_uVel_mean              =   7.0149129459912E-03
+(PID.TID 0000.0001) %MON obc_W_uVel_sd                =   1.1111732089572E-02
+(PID.TID 0000.0001) %MON obc_W_uVel_Int               =   1.3110367713427E+08
+(PID.TID 0000.0001) %MON obc_N_vVel_max               =   4.7361894200246E-02
+(PID.TID 0000.0001) %MON obc_N_vVel_min               =  -7.0558022459348E-02
+(PID.TID 0000.0001) %MON obc_N_vVel_mean              =   1.6170427400003E-04
+(PID.TID 0000.0001) %MON obc_N_vVel_sd                =   6.4389177929887E-03
+(PID.TID 0000.0001) %MON obc_N_vVel_Int               =   4.7272381147091E+06
+(PID.TID 0000.0001) %MON obc_E_theta_max              =   1.9227046585083E+01
+(PID.TID 0000.0001) %MON obc_E_theta_min              =  -1.6256567557653E+00
+(PID.TID 0000.0001) %MON obc_E_theta_mean             =   1.9094554967779E+00
+(PID.TID 0000.0001) %MON obc_E_theta_sd               =   2.9661690420752E+00
+(PID.TID 0000.0001) %MON obc_W_theta_max              =   2.1445012919108E+01
+(PID.TID 0000.0001) %MON obc_W_theta_min              =  -1.4419272979101E+00
+(PID.TID 0000.0001) %MON obc_W_theta_mean             =   2.4658360810169E+00
+(PID.TID 0000.0001) %MON obc_W_theta_sd               =   2.9603162977268E+00
+(PID.TID 0000.0001) %MON obc_N_theta_max              =   2.4014411290487E+01
+(PID.TID 0000.0001) %MON obc_N_theta_min              =  -6.3142867485682E-01
+(PID.TID 0000.0001) %MON obc_N_theta_mean             =   4.8714445467659E+00
+(PID.TID 0000.0001) %MON obc_N_theta_sd               =   4.7027078335556E+00
+(PID.TID 0000.0001) // =======================================================
+(PID.TID 0000.0001) // End OBCS MONITOR field statistics
+(PID.TID 0000.0001) // =======================================================
+(PID.TID 0000.0001) // =======================================================
+(PID.TID 0000.0001) // Begin MONITOR ptracer field statistics
+(PID.TID 0000.0001) // =======================================================
+(PID.TID 0000.0001) %MON trcstat_ptracer01_max        =   2.3591401437445E+00
+(PID.TID 0000.0001) %MON trcstat_ptracer01_min        =   1.9367304746343E+00
+(PID.TID 0000.0001) %MON trcstat_ptracer01_mean       =   2.2425271352692E+00
+(PID.TID 0000.0001) %MON trcstat_ptracer01_sd         =   7.5988649097726E-02
+(PID.TID 0000.0001) %MON trcstat_ptracer01_del2       =   1.0677317644063E-04
+(PID.TID 0000.0001) %MON trcstat_ptracer02_max        =   2.4116832757561E+00
+(PID.TID 0000.0001) %MON trcstat_ptracer02_min        =   2.1899799305598E+00
+(PID.TID 0000.0001) %MON trcstat_ptracer02_mean       =   2.3520454966805E+00
+(PID.TID 0000.0001) %MON trcstat_ptracer02_sd         =   3.5090900745649E-02
+(PID.TID 0000.0001) %MON trcstat_ptracer02_del2       =   8.0623943560528E-05
+(PID.TID 0000.0001) %MON trcstat_ptracer03_max        =   2.7654707905471E-03
+(PID.TID 0000.0001) %MON trcstat_ptracer03_min        =   4.7350030617099E-05
+(PID.TID 0000.0001) %MON trcstat_ptracer03_mean       =   2.0556610772909E-03
+(PID.TID 0000.0001) %MON trcstat_ptracer03_sd         =   5.0325958484516E-04
+(PID.TID 0000.0001) %MON trcstat_ptracer03_del2       =   6.7007347325832E-07
+(PID.TID 0000.0001) %MON trcstat_ptracer04_max        =   2.5734372514985E-04
+(PID.TID 0000.0001) %MON trcstat_ptracer04_min        =  -7.5081759287795E-07
+(PID.TID 0000.0001) %MON trcstat_ptracer04_mean       =   6.2166640460367E-06
+(PID.TID 0000.0001) %MON trcstat_ptracer04_sd         =   2.6176363994778E-05
+(PID.TID 0000.0001) %MON trcstat_ptracer04_del2       =   1.3445374783806E-07
+(PID.TID 0000.0001) %MON trcstat_ptracer05_max        =   3.8365288067711E-01
+(PID.TID 0000.0001) %MON trcstat_ptracer05_min        =   8.2401869335757E-02
+(PID.TID 0000.0001) %MON trcstat_ptracer05_mean       =   2.1412908339770E-01
+(PID.TID 0000.0001) %MON trcstat_ptracer05_sd         =   4.3048525270866E-02
+(PID.TID 0000.0001) %MON trcstat_ptracer05_del2       =   1.1876374153122E-04
+(PID.TID 0000.0001) // =======================================================
+(PID.TID 0000.0001) // End MONITOR ptracer field statistics
+(PID.TID 0000.0001) // =======================================================
+ EXTERNAL_FIELDS_LOAD,         2 : iP,iLd,i0,i1=   12    1   12    1 ; Wght=  0.4666666667  0.5333333333
+ DIC_FIELDS_LOAD,         2 : iP,iLd,i0,i1=   12    1   12    1 ; Wght=  0.4666666667  0.5333333333
+ OBCS_FIELDS_LOAD,         3 : iP,iLd,i0,i1=   12    1   12    1 ; Wght=  0.4500000000  0.5500000000
+ cg2d: Sum(rhs),rhsMax =   3.69813004132884E+01  9.89366639092217E-01
+(PID.TID 0000.0001)      cg2d_init_res =   5.67526980566402E-02
+(PID.TID 0000.0001)      cg2d_iters(min,last) =      -1      79
+(PID.TID 0000.0001)      cg2d_last_res =   6.56260092680578E-14
+(PID.TID 0000.0001) // =======================================================
+(PID.TID 0000.0001) // Begin MONITOR dynamic field statistics
+(PID.TID 0000.0001) // =======================================================
+(PID.TID 0000.0001) %MON time_tsnumber                =                     3
+(PID.TID 0000.0001) %MON time_secondsf                =   1.2960000000000E+05
+(PID.TID 0000.0001) %MON dynstat_eta_max              =   4.6213989059191E-01
+(PID.TID 0000.0001) %MON dynstat_eta_min              =  -1.5125833035862E+00
+(PID.TID 0000.0001) %MON dynstat_eta_mean             =  -5.1715888372412E-01
+(PID.TID 0000.0001) %MON dynstat_eta_sd               =   6.0875958600885E-01
+(PID.TID 0000.0001) %MON dynstat_eta_del2             =   2.3647144329516E-03
+(PID.TID 0000.0001) %MON dynstat_uvel_max             =   1.3062261868045E-01
+(PID.TID 0000.0001) %MON dynstat_uvel_min             =  -6.0539411753416E-02
+(PID.TID 0000.0001) %MON dynstat_uvel_mean            =   7.5079985726029E-03
+(PID.TID 0000.0001) %MON dynstat_uvel_sd              =   1.4636773745285E-02
+(PID.TID 0000.0001) %MON dynstat_uvel_del2            =   1.6215293796818E-04
+(PID.TID 0000.0001) %MON dynstat_vvel_max             =   1.2955742043983E-01
+(PID.TID 0000.0001) %MON dynstat_vvel_min             =  -8.8542959561069E-02
+(PID.TID 0000.0001) %MON dynstat_vvel_mean            =   9.5026324011132E-04
+(PID.TID 0000.0001) %MON dynstat_vvel_sd              =   8.4359882216886E-03
+(PID.TID 0000.0001) %MON dynstat_vvel_del2            =   1.0627935286095E-04
+(PID.TID 0000.0001) %MON dynstat_wvel_max             =   5.4890354380308E-05
+(PID.TID 0000.0001) %MON dynstat_wvel_min             =  -1.4180007284655E-04
+(PID.TID 0000.0001) %MON dynstat_wvel_mean            =  -2.4323028399391E-07
+(PID.TID 0000.0001) %MON dynstat_wvel_sd              =   5.4605074086474E-06
+(PID.TID 0000.0001) %MON dynstat_wvel_del2            =   1.4055591218984E-07
+(PID.TID 0000.0001) %MON dynstat_theta_max            =   2.4207205522541E+01
+(PID.TID 0000.0001) %MON dynstat_theta_min            =  -2.8961461882647E+00
+(PID.TID 0000.0001) %MON dynstat_theta_mean           =   2.3225679277077E+00
+(PID.TID 0000.0001) %MON dynstat_theta_sd             =   3.2129999380289E+00
+(PID.TID 0000.0001) %MON dynstat_theta_del2           =   6.6377896898328E-03
+(PID.TID 0000.0001) %MON dynstat_salt_max             =   3.6601334730652E+01
+(PID.TID 0000.0001) %MON dynstat_salt_min             =   3.3081176678740E+01
+(PID.TID 0000.0001) %MON dynstat_salt_mean            =   3.4483936926475E+01
+(PID.TID 0000.0001) %MON dynstat_salt_sd              =   1.9647408903632E-01
+(PID.TID 0000.0001) %MON dynstat_salt_del2            =   1.1570457958611E-03
+(PID.TID 0000.0001) %MON forcing_qnet_max             =   6.8365893554688E+01
+(PID.TID 0000.0001) %MON forcing_qnet_min             =  -2.1235058186849E+02
+(PID.TID 0000.0001) %MON forcing_qnet_mean            =  -1.2065349012308E+02
+(PID.TID 0000.0001) %MON forcing_qnet_sd              =   4.4471574191313E+01
+(PID.TID 0000.0001) %MON forcing_qnet_del2            =   8.3718643192961E-01
+(PID.TID 0000.0001) %MON forcing_qsw_max              =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON forcing_qsw_min              =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON forcing_qsw_mean             =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON forcing_qsw_sd               =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON forcing_qsw_del2             =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON forcing_empmr_max            =   2.5141471127199E-05
+(PID.TID 0000.0001) %MON forcing_empmr_min            =  -3.9761445691511E-05
+(PID.TID 0000.0001) %MON forcing_empmr_mean           =  -9.3236499820974E-06
+(PID.TID 0000.0001) %MON forcing_empmr_sd             =   1.0249687273683E-05
+(PID.TID 0000.0001) %MON forcing_empmr_del2           =   9.8755541425843E-08
+(PID.TID 0000.0001) %MON forcing_fu_max               =   2.1214843690395E-01
+(PID.TID 0000.0001) %MON forcing_fu_min               =  -9.1365413367748E-02
+(PID.TID 0000.0001) %MON forcing_fu_mean              =   7.5904591616040E-02
+(PID.TID 0000.0001) %MON forcing_fu_sd                =   7.1286791719395E-02
+(PID.TID 0000.0001) %MON forcing_fu_del2              =   5.5309620030393E-04
+(PID.TID 0000.0001) %MON forcing_fv_max               =   1.5056358873844E-01
+(PID.TID 0000.0001) %MON forcing_fv_min               =  -7.6133539776007E-02
+(PID.TID 0000.0001) %MON forcing_fv_mean              =  -1.9474492909428E-02
+(PID.TID 0000.0001) %MON forcing_fv_sd                =   3.3536075112207E-02
+(PID.TID 0000.0001) %MON forcing_fv_del2              =   3.7509025945884E-04
+(PID.TID 0000.0001) %MON trAdv_CFL_u_max              =   8.3935653812237E-02
+(PID.TID 0000.0001) %MON trAdv_CFL_v_max              =   2.0000272635172E-02
+(PID.TID 0000.0001) %MON trAdv_CFL_w_max              =   6.3877407297722E-02
+(PID.TID 0000.0001) %MON advcfl_uvel_max              =   3.3731911478655E-02
+(PID.TID 0000.0001) %MON advcfl_vvel_max              =   1.7899327246398E-02
+(PID.TID 0000.0001) %MON advcfl_wvel_max              =   1.6782912731427E-02
+(PID.TID 0000.0001) %MON advcfl_W_hf_max              =   1.8016950432267E-02
+(PID.TID 0000.0001) %MON pe_b_mean                    =   8.5967060596595E-04
+(PID.TID 0000.0001) %MON ke_max                       =   9.3049026000510E-03
+(PID.TID 0000.0001) %MON ke_mean                      =   1.6238894530997E-04
+(PID.TID 0000.0001) %MON ke_vol                       =   1.2769337095763E+17
+(PID.TID 0000.0001) %MON vort_r_min                   =  -4.7703855977354E-07
+(PID.TID 0000.0001) %MON vort_r_max                   =   7.0514402478036E-07
+(PID.TID 0000.0001) %MON vort_a_mean                  =  -1.0457492545002E-04
+(PID.TID 0000.0001) %MON vort_a_sd                    =   2.1292658560979E-05
+(PID.TID 0000.0001) %MON vort_p_mean                  =  -1.2574624311192E-04
+(PID.TID 0000.0001) %MON vort_p_sd                    =   1.1183803880499E-04
+(PID.TID 0000.0001) %MON surfExpan_theta_mean         =   4.3299011362969E-07
+(PID.TID 0000.0001) %MON surfExpan_salt_mean          =   1.1235984607563E-07
+(PID.TID 0000.0001) // =======================================================
+(PID.TID 0000.0001) // End MONITOR dynamic field statistics
+(PID.TID 0000.0001) // =======================================================
+(PID.TID 0000.0001) // =======================================================
+(PID.TID 0000.0001) // Begin OBCS MONITOR field statistics
+(PID.TID 0000.0001) // =======================================================
+(PID.TID 0000.0001) %MON obc_E_uVel_max               =   8.3828638494015E-02
+(PID.TID 0000.0001) %MON obc_E_uVel_min               =  -6.0539411753416E-02
+(PID.TID 0000.0001) %MON obc_E_uVel_mean              =   7.3609929463100E-03
+(PID.TID 0000.0001) %MON obc_E_uVel_sd                =   1.4302160552751E-02
+(PID.TID 0000.0001) %MON obc_E_uVel_Int               =   1.2620134355850E+08
+(PID.TID 0000.0001) %MON obc_W_uVel_max               =   5.9847029671073E-02
+(PID.TID 0000.0001) %MON obc_W_uVel_min               =  -2.5733459647745E-02
+(PID.TID 0000.0001) %MON obc_W_uVel_mean              =   7.0105385545017E-03
+(PID.TID 0000.0001) %MON obc_W_uVel_sd                =   1.1115697883587E-02
+(PID.TID 0000.0001) %MON obc_W_uVel_Int               =   1.3102192290383E+08
+(PID.TID 0000.0001) %MON obc_N_vVel_max               =   4.7308485023677E-02
+(PID.TID 0000.0001) %MON obc_N_vVel_min               =  -7.0609619468451E-02
+(PID.TID 0000.0001) %MON obc_N_vVel_mean              =   1.5994407436435E-04
+(PID.TID 0000.0001) %MON obc_N_vVel_sd                =   6.4375643639680E-03
+(PID.TID 0000.0001) %MON obc_N_vVel_Int               =   4.6757807066797E+06
+(PID.TID 0000.0001) %MON obc_E_theta_max              =   1.9248522186279E+01
+(PID.TID 0000.0001) %MON obc_E_theta_min              =  -1.6170032203197E+00
+(PID.TID 0000.0001) %MON obc_E_theta_mean             =   1.9094443592632E+00
+(PID.TID 0000.0001) %MON obc_E_theta_sd               =   2.9666428623953E+00
+(PID.TID 0000.0001) %MON obc_W_theta_max              =   2.1465204048157E+01
+(PID.TID 0000.0001) %MON obc_W_theta_min              =  -1.4420095145702E+00
+(PID.TID 0000.0001) %MON obc_W_theta_mean             =   2.4660533188974E+00
+(PID.TID 0000.0001) %MON obc_W_theta_sd               =   2.9608568965157E+00
+(PID.TID 0000.0001) %MON obc_N_theta_max              =   2.4035299301147E+01
+(PID.TID 0000.0001) %MON obc_N_theta_min              =  -6.3193125426769E-01
+(PID.TID 0000.0001) %MON obc_N_theta_mean             =   4.8716564394589E+00
+(PID.TID 0000.0001) %MON obc_N_theta_sd               =   4.7035895383254E+00
+(PID.TID 0000.0001) // =======================================================
+(PID.TID 0000.0001) // End OBCS MONITOR field statistics
+(PID.TID 0000.0001) // =======================================================
+(PID.TID 0000.0001) // =======================================================
+(PID.TID 0000.0001) // Begin MONITOR ptracer field statistics
+(PID.TID 0000.0001) // =======================================================
+(PID.TID 0000.0001) %MON trcstat_ptracer01_max        =   2.3591407889056E+00
+(PID.TID 0000.0001) %MON trcstat_ptracer01_min        =   1.9367106142423E+00
+(PID.TID 0000.0001) %MON trcstat_ptracer01_mean       =   2.2425256639625E+00
+(PID.TID 0000.0001) %MON trcstat_ptracer01_sd         =   7.5992122462497E-02
+(PID.TID 0000.0001) %MON trcstat_ptracer01_del2       =   1.0670152236762E-04
+(PID.TID 0000.0001) %MON trcstat_ptracer02_max        =   2.4116838423798E+00
+(PID.TID 0000.0001) %MON trcstat_ptracer02_min        =   2.1900145897440E+00
+(PID.TID 0000.0001) %MON trcstat_ptracer02_mean       =   2.3520458155541E+00
+(PID.TID 0000.0001) %MON trcstat_ptracer02_sd         =   3.5090709947298E-02
+(PID.TID 0000.0001) %MON trcstat_ptracer02_del2       =   8.0618224144674E-05
+(PID.TID 0000.0001) %MON trcstat_ptracer03_max        =   2.7654743177706E-03
+(PID.TID 0000.0001) %MON trcstat_ptracer03_min        =   4.7305272335174E-05
+(PID.TID 0000.0001) %MON trcstat_ptracer03_mean       =   2.0556517479929E-03
+(PID.TID 0000.0001) %MON trcstat_ptracer03_sd         =   5.0327566434960E-04
+(PID.TID 0000.0001) %MON trcstat_ptracer03_del2       =   6.6983504437431E-07
+(PID.TID 0000.0001) %MON trcstat_ptracer04_max        =   2.5768558511593E-04
+(PID.TID 0000.0001) %MON trcstat_ptracer04_min        =  -7.5456580951666E-07
+(PID.TID 0000.0001) %MON trcstat_ptracer04_mean       =   6.2248777377114E-06
+(PID.TID 0000.0001) %MON trcstat_ptracer04_sd         =   2.6216452075251E-05
+(PID.TID 0000.0001) %MON trcstat_ptracer04_del2       =   1.3439656196080E-07
+(PID.TID 0000.0001) %MON trcstat_ptracer05_max        =   3.8368924867501E-01
+(PID.TID 0000.0001) %MON trcstat_ptracer05_min        =   8.2409939169764E-02
+(PID.TID 0000.0001) %MON trcstat_ptracer05_mean       =   2.1412723897038E-01
+(PID.TID 0000.0001) %MON trcstat_ptracer05_sd         =   4.3046032949387E-02
+(PID.TID 0000.0001) %MON trcstat_ptracer05_del2       =   1.1857347653469E-04
+(PID.TID 0000.0001) // =======================================================
+(PID.TID 0000.0001) // End MONITOR ptracer field statistics
+(PID.TID 0000.0001) // =======================================================
+ EXTERNAL_FIELDS_LOAD,         3 : iP,iLd,i0,i1=   12    1   12    1 ; Wght=  0.4500000000  0.5500000000
+ DIC_FIELDS_LOAD,         3 : iP,iLd,i0,i1=   12    1   12    1 ; Wght=  0.4500000000  0.5500000000
+ OBCS_FIELDS_LOAD,         4 : iP,iLd,i0,i1=   12    1   12    1 ; Wght=  0.4333333333  0.5666666667
+ cg2d: Sum(rhs),rhsMax =   3.69444848326875E+01  9.90008392871430E-01
+(PID.TID 0000.0001)      cg2d_init_res =   3.68743323783192E-02
+(PID.TID 0000.0001)      cg2d_iters(min,last) =      -1      77
+(PID.TID 0000.0001)      cg2d_last_res =   9.79870323355741E-14
+(PID.TID 0000.0001) // =======================================================
+(PID.TID 0000.0001) // Begin MONITOR dynamic field statistics
+(PID.TID 0000.0001) // =======================================================
+(PID.TID 0000.0001) %MON time_tsnumber                =                     4
+(PID.TID 0000.0001) %MON time_secondsf                =   1.7280000000000E+05
+(PID.TID 0000.0001) %MON dynstat_eta_max              =   4.6395963974077E-01
+(PID.TID 0000.0001) %MON dynstat_eta_min              =  -1.5149075975102E+00
+(PID.TID 0000.0001) %MON dynstat_eta_mean             =  -5.1697916405877E-01
+(PID.TID 0000.0001) %MON dynstat_eta_sd               =   6.1240461071870E-01
+(PID.TID 0000.0001) %MON dynstat_eta_del2             =   2.3695017619383E-03
+(PID.TID 0000.0001) %MON dynstat_uvel_max             =   1.3086193662600E-01
+(PID.TID 0000.0001) %MON dynstat_uvel_min             =  -6.0463193058968E-02
+(PID.TID 0000.0001) %MON dynstat_uvel_mean            =   7.5291434462894E-03
+(PID.TID 0000.0001) %MON dynstat_uvel_sd              =   1.4646053100495E-02
+(PID.TID 0000.0001) %MON dynstat_uvel_del2            =   1.6204374780074E-04
+(PID.TID 0000.0001) %MON dynstat_vvel_max             =   1.2962069131972E-01
+(PID.TID 0000.0001) %MON dynstat_vvel_min             =  -8.8554900694422E-02
+(PID.TID 0000.0001) %MON dynstat_vvel_mean            =   9.5300989732081E-04
+(PID.TID 0000.0001) %MON dynstat_vvel_sd              =   8.4439077426228E-03
+(PID.TID 0000.0001) %MON dynstat_vvel_del2            =   1.0624956418926E-04
+(PID.TID 0000.0001) %MON dynstat_wvel_max             =   5.5001242850584E-05
+(PID.TID 0000.0001) %MON dynstat_wvel_min             =  -1.4149847831267E-04
+(PID.TID 0000.0001) %MON dynstat_wvel_mean            =  -2.4322672388720E-07
+(PID.TID 0000.0001) %MON dynstat_wvel_sd              =   5.4499461582882E-06
+(PID.TID 0000.0001) %MON dynstat_wvel_del2            =   1.4051527256648E-07
+(PID.TID 0000.0001) %MON dynstat_theta_max            =   2.4223666545653E+01
+(PID.TID 0000.0001) %MON dynstat_theta_min            =  -2.8962364234641E+00
+(PID.TID 0000.0001) %MON dynstat_theta_mean           =   2.3228801417064E+00
+(PID.TID 0000.0001) %MON dynstat_theta_sd             =   3.2138692979141E+00
+(PID.TID 0000.0001) %MON dynstat_theta_del2           =   6.6350188422182E-03
+(PID.TID 0000.0001) %MON dynstat_salt_max             =   3.6601515138275E+01
+(PID.TID 0000.0001) %MON dynstat_salt_min             =   3.3079951761183E+01
+(PID.TID 0000.0001) %MON dynstat_salt_mean            =   3.4483937899956E+01
+(PID.TID 0000.0001) %MON dynstat_salt_sd              =   1.9648308320519E-01
+(PID.TID 0000.0001) %MON dynstat_salt_del2            =   1.1564384485617E-03
+(PID.TID 0000.0001) %MON forcing_qnet_max             =   6.8401463317871E+01
+(PID.TID 0000.0001) %MON forcing_qnet_min             =  -2.1192386779785E+02
+(PID.TID 0000.0001) %MON forcing_qnet_mean            =  -1.2037859491120E+02
+(PID.TID 0000.0001) %MON forcing_qnet_sd              =   4.4324698931511E+01
+(PID.TID 0000.0001) %MON forcing_qnet_del2            =   8.3838936492374E-01
+(PID.TID 0000.0001) %MON forcing_qsw_max              =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON forcing_qsw_min              =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON forcing_qsw_mean             =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON forcing_qsw_sd               =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON forcing_qsw_del2             =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON forcing_empmr_max            =   2.5141471127199E-05
+(PID.TID 0000.0001) %MON forcing_empmr_min            =  -3.9761445691511E-05
+(PID.TID 0000.0001) %MON forcing_empmr_mean           =  -9.3236499820974E-06
+(PID.TID 0000.0001) %MON forcing_empmr_sd             =   1.0249687273683E-05
+(PID.TID 0000.0001) %MON forcing_empmr_del2           =   9.8755541425843E-08
+(PID.TID 0000.0001) %MON forcing_fu_max               =   2.1227744072676E-01
+(PID.TID 0000.0001) %MON forcing_fu_min               =  -9.1781715303659E-02
+(PID.TID 0000.0001) %MON forcing_fu_mean              =   7.5803842697540E-02
+(PID.TID 0000.0001) %MON forcing_fu_sd                =   7.1323156655177E-02
+(PID.TID 0000.0001) %MON forcing_fu_del2              =   5.5407006621995E-04
+(PID.TID 0000.0001) %MON forcing_fv_max               =   1.5025485828519E-01
+(PID.TID 0000.0001) %MON forcing_fv_min               =  -7.6103337854147E-02
+(PID.TID 0000.0001) %MON forcing_fv_mean              =  -1.9415454019831E-02
+(PID.TID 0000.0001) %MON forcing_fv_sd                =   3.3523226784915E-02
+(PID.TID 0000.0001) %MON forcing_fv_del2              =   3.7456042910420E-04
+(PID.TID 0000.0001) %MON trAdv_CFL_u_max              =   8.4584073989630E-02
+(PID.TID 0000.0001) %MON trAdv_CFL_v_max              =   2.0953896428465E-02
+(PID.TID 0000.0001) %MON trAdv_CFL_w_max              =   6.3706421403378E-02
+(PID.TID 0000.0001) %MON advcfl_uvel_max              =   3.3793712810127E-02
+(PID.TID 0000.0001) %MON advcfl_vvel_max              =   1.7908068591976E-02
+(PID.TID 0000.0001) %MON advcfl_wvel_max              =   1.6747217159198E-02
+(PID.TID 0000.0001) %MON advcfl_W_hf_max              =   1.7978630185610E-02
+(PID.TID 0000.0001) %MON pe_b_mean                    =   8.6541751879117E-04
+(PID.TID 0000.0001) %MON ke_max                       =   9.3301988778789E-03
+(PID.TID 0000.0001) %MON ke_mean                      =   1.6274233025701E-04
+(PID.TID 0000.0001) %MON ke_vol                       =   1.2769337095763E+17
+(PID.TID 0000.0001) %MON vort_r_min                   =  -4.7669670741190E-07
+(PID.TID 0000.0001) %MON vort_r_max                   =   7.0557709425580E-07
+(PID.TID 0000.0001) %MON vort_a_mean                  =  -1.0457492493489E-04
+(PID.TID 0000.0001) %MON vort_a_sd                    =   2.1292671158631E-05
+(PID.TID 0000.0001) %MON vort_p_mean                  =  -1.2574624249250E-04
+(PID.TID 0000.0001) %MON vort_p_sd                    =   1.1183804529477E-04
+(PID.TID 0000.0001) %MON surfExpan_theta_mean         =   4.7796200915453E-07
+(PID.TID 0000.0001) %MON surfExpan_salt_mean          =   1.2282832566760E-07
+(PID.TID 0000.0001) // =======================================================
+(PID.TID 0000.0001) // End MONITOR dynamic field statistics
+(PID.TID 0000.0001) // =======================================================
+(PID.TID 0000.0001) // =======================================================
+(PID.TID 0000.0001) // Begin OBCS MONITOR field statistics
+(PID.TID 0000.0001) // =======================================================
+(PID.TID 0000.0001) %MON obc_E_uVel_max               =   8.3694245914618E-02
+(PID.TID 0000.0001) %MON obc_E_uVel_min               =  -6.0463193058968E-02
+(PID.TID 0000.0001) %MON obc_E_uVel_mean              =   7.3591602201081E-03
+(PID.TID 0000.0001) %MON obc_E_uVel_sd                =   1.4302813286498E-02
+(PID.TID 0000.0001) %MON obc_E_uVel_Int               =   1.2616992218495E+08
+(PID.TID 0000.0001) %MON obc_W_uVel_max               =   5.9895068158706E-02
+(PID.TID 0000.0001) %MON obc_W_uVel_min               =  -2.5735839766761E-02
+(PID.TID 0000.0001) %MON obc_W_uVel_mean              =   7.0061641630121E-03
+(PID.TID 0000.0001) %MON obc_W_uVel_sd                =   1.1119676645741E-02
+(PID.TID 0000.0001) %MON obc_W_uVel_Int               =   1.3094016867339E+08
+(PID.TID 0000.0001) %MON obc_N_vVel_max               =   4.7255075847109E-02
+(PID.TID 0000.0001) %MON obc_N_vVel_min               =  -7.0661216477553E-02
+(PID.TID 0000.0001) %MON obc_N_vVel_mean              =   1.5818387472866E-04
+(PID.TID 0000.0001) %MON obc_N_vVel_sd                =   6.4362274787566E-03
+(PID.TID 0000.0001) %MON obc_N_vVel_Int               =   4.6243232986502E+06
+(PID.TID 0000.0001) %MON obc_E_theta_max              =   1.9269997787476E+01
+(PID.TID 0000.0001) %MON obc_E_theta_min              =  -1.6083496848742E+00
+(PID.TID 0000.0001) %MON obc_E_theta_mean             =   1.9094332217485E+00
+(PID.TID 0000.0001) %MON obc_E_theta_sd               =   2.9671180827308E+00
+(PID.TID 0000.0001) %MON obc_W_theta_max              =   2.1485395177205E+01
+(PID.TID 0000.0001) %MON obc_W_theta_min              =  -1.4420917312304E+00
+(PID.TID 0000.0001) %MON obc_W_theta_mean             =   2.4662705567779E+00
+(PID.TID 0000.0001) %MON obc_W_theta_sd               =   2.9613984222904E+00
+(PID.TID 0000.0001) %MON obc_N_theta_max              =   2.4056187311808E+01
+(PID.TID 0000.0001) %MON obc_N_theta_min              =  -6.3243383367856E-01
+(PID.TID 0000.0001) %MON obc_N_theta_mean             =   4.8718683321519E+00
+(PID.TID 0000.0001) %MON obc_N_theta_sd               =   4.7044721835460E+00
+(PID.TID 0000.0001) // =======================================================
+(PID.TID 0000.0001) // End OBCS MONITOR field statistics
+(PID.TID 0000.0001) // =======================================================
+(PID.TID 0000.0001) // =======================================================
+(PID.TID 0000.0001) // Begin MONITOR ptracer field statistics
+(PID.TID 0000.0001) // =======================================================
+(PID.TID 0000.0001) %MON trcstat_ptracer01_max        =   2.3591414235517E+00
+(PID.TID 0000.0001) %MON trcstat_ptracer01_min        =   1.9366907984711E+00
+(PID.TID 0000.0001) %MON trcstat_ptracer01_mean       =   2.2425242077795E+00
+(PID.TID 0000.0001) %MON trcstat_ptracer01_sd         =   7.5995546082247E-02
+(PID.TID 0000.0001) %MON trcstat_ptracer01_del2       =   1.0662562584733E-04
+(PID.TID 0000.0001) %MON trcstat_ptracer02_max        =   2.4116844083675E+00
+(PID.TID 0000.0001) %MON trcstat_ptracer02_min        =   2.1900507045915E+00
+(PID.TID 0000.0001) %MON trcstat_ptracer02_mean       =   2.3520461389861E+00
+(PID.TID 0000.0001) %MON trcstat_ptracer02_sd         =   3.5090502318528E-02
+(PID.TID 0000.0001) %MON trcstat_ptracer02_del2       =   8.0612156843339E-05
+(PID.TID 0000.0001) %MON trcstat_ptracer03_max        =   2.7654777774314E-03
+(PID.TID 0000.0001) %MON trcstat_ptracer03_min        =   4.7260823943134E-05
+(PID.TID 0000.0001) %MON trcstat_ptracer03_mean       =   2.0556425437223E-03
+(PID.TID 0000.0001) %MON trcstat_ptracer03_sd         =   5.0329136367624E-04
+(PID.TID 0000.0001) %MON trcstat_ptracer03_del2       =   6.6954418309516E-07
+(PID.TID 0000.0001) %MON trcstat_ptracer04_max        =   2.5801936011785E-04
+(PID.TID 0000.0001) %MON trcstat_ptracer04_min        =  -7.5838724074807E-07
+(PID.TID 0000.0001) %MON trcstat_ptracer04_mean       =   6.2330587770700E-06
+(PID.TID 0000.0001) %MON trcstat_ptracer04_sd         =   2.6256412055353E-05
+(PID.TID 0000.0001) %MON trcstat_ptracer04_del2       =   1.3432484291057E-07
+(PID.TID 0000.0001) %MON trcstat_ptracer05_max        =   3.8372724940548E-01
+(PID.TID 0000.0001) %MON trcstat_ptracer05_min        =   8.2416015768654E-02
+(PID.TID 0000.0001) %MON trcstat_ptracer05_mean       =   2.1412540377670E-01
+(PID.TID 0000.0001) %MON trcstat_ptracer05_sd         =   4.3043561864795E-02
+(PID.TID 0000.0001) %MON trcstat_ptracer05_del2       =   1.1837744056211E-04
+(PID.TID 0000.0001) // =======================================================
+(PID.TID 0000.0001) // End MONITOR ptracer field statistics
+(PID.TID 0000.0001) // =======================================================
+ EXTERNAL_FIELDS_LOAD,         4 : iP,iLd,i0,i1=   12    1   12    1 ; Wght=  0.4333333333  0.5666666667
+ DIC_FIELDS_LOAD,         4 : iP,iLd,i0,i1=   12    1   12    1 ; Wght=  0.4333333333  0.5666666667
+ OBCS_FIELDS_LOAD,         5 : iP,iLd,i0,i1=   12    1   12    1 ; Wght=  0.4166666667  0.5833333333
+ cg2d: Sum(rhs),rhsMax =   3.69076054258846E+01  9.90650485228004E-01
+(PID.TID 0000.0001)      cg2d_init_res =   2.70765733367530E-02
+(PID.TID 0000.0001)      cg2d_iters(min,last) =      -1      77
+(PID.TID 0000.0001)      cg2d_last_res =   7.96680707147545E-14
+(PID.TID 0000.0001) // =======================================================
+(PID.TID 0000.0001) // Begin MONITOR dynamic field statistics
+(PID.TID 0000.0001) // =======================================================
+(PID.TID 0000.0001) %MON time_tsnumber                =                     5
+(PID.TID 0000.0001) %MON time_secondsf                =   2.1600000000000E+05
+(PID.TID 0000.0001) %MON dynstat_eta_max              =   4.6742181670386E-01
+(PID.TID 0000.0001) %MON dynstat_eta_min              =  -1.5153341969223E+00
+(PID.TID 0000.0001) %MON dynstat_eta_mean             =  -5.1679805939112E-01
+(PID.TID 0000.0001) %MON dynstat_eta_sd               =   6.1516973521395E-01
+(PID.TID 0000.0001) %MON dynstat_eta_del2             =   2.3717076841684E-03
+(PID.TID 0000.0001) %MON dynstat_uvel_max             =   1.3110535878860E-01
+(PID.TID 0000.0001) %MON dynstat_uvel_min             =  -6.0386974364519E-02
+(PID.TID 0000.0001) %MON dynstat_uvel_mean            =   7.5431447413553E-03
+(PID.TID 0000.0001) %MON dynstat_uvel_sd              =   1.4657547896250E-02
+(PID.TID 0000.0001) %MON dynstat_uvel_del2            =   1.6193726470229E-04
+(PID.TID 0000.0001) %MON dynstat_vvel_max             =   1.2970860601232E-01
+(PID.TID 0000.0001) %MON dynstat_vvel_min             =  -8.8551055672804E-02
+(PID.TID 0000.0001) %MON dynstat_vvel_mean            =   9.4679719200852E-04
+(PID.TID 0000.0001) %MON dynstat_vvel_sd              =   8.4539789984647E-03
+(PID.TID 0000.0001) %MON dynstat_vvel_del2            =   1.0622004487125E-04
+(PID.TID 0000.0001) %MON dynstat_wvel_max             =   5.5082374388282E-05
+(PID.TID 0000.0001) %MON dynstat_wvel_min             =  -1.4119944512572E-04
+(PID.TID 0000.0001) %MON dynstat_wvel_mean            =  -2.4322316378049E-07
+(PID.TID 0000.0001) %MON dynstat_wvel_sd              =   5.4439293150668E-06
+(PID.TID 0000.0001) %MON dynstat_wvel_del2            =   1.4050122398176E-07
+(PID.TID 0000.0001) %MON dynstat_theta_max            =   2.4240184811830E+01
+(PID.TID 0000.0001) %MON dynstat_theta_min            =  -2.8963115492864E+00
+(PID.TID 0000.0001) %MON dynstat_theta_mean           =   2.3231921950168E+00
+(PID.TID 0000.0001) %MON dynstat_theta_sd             =   3.2147400722502E+00
+(PID.TID 0000.0001) %MON dynstat_theta_del2           =   6.6322877540844E-03
+(PID.TID 0000.0001) %MON dynstat_salt_max             =   3.6601696154099E+01
+(PID.TID 0000.0001) %MON dynstat_salt_min             =   3.3078734354698E+01
+(PID.TID 0000.0001) %MON dynstat_salt_mean            =   3.4483938694908E+01
+(PID.TID 0000.0001) %MON dynstat_salt_sd              =   1.9649189319730E-01
+(PID.TID 0000.0001) %MON dynstat_salt_del2            =   1.1558406489509E-03
+(PID.TID 0000.0001) %MON forcing_qnet_max             =   6.8437033081055E+01
+(PID.TID 0000.0001) %MON forcing_qnet_min             =  -2.1149715372721E+02
+(PID.TID 0000.0001) %MON forcing_qnet_mean            =  -1.2010369969932E+02
+(PID.TID 0000.0001) %MON forcing_qnet_sd              =   4.4181406974067E+01
+(PID.TID 0000.0001) %MON forcing_qnet_del2            =   8.3964171164123E-01
+(PID.TID 0000.0001) %MON forcing_qsw_max              =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON forcing_qsw_min              =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON forcing_qsw_mean             =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON forcing_qsw_sd               =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON forcing_qsw_del2             =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON forcing_empmr_max            =   2.5141471127199E-05
+(PID.TID 0000.0001) %MON forcing_empmr_min            =  -3.9761445691511E-05
+(PID.TID 0000.0001) %MON forcing_empmr_mean           =  -9.3236499820974E-06
+(PID.TID 0000.0001) %MON forcing_empmr_sd             =   1.0249687273683E-05
+(PID.TID 0000.0001) %MON forcing_empmr_del2           =   9.8755541425843E-08
+(PID.TID 0000.0001) %MON forcing_fu_max               =   2.1240644454956E-01
+(PID.TID 0000.0001) %MON forcing_fu_min               =  -9.2198017239571E-02
+(PID.TID 0000.0001) %MON forcing_fu_mean              =   7.5703093779040E-02
+(PID.TID 0000.0001) %MON forcing_fu_sd                =   7.1360299218031E-02
+(PID.TID 0000.0001) %MON forcing_fu_del2              =   5.5508820210295E-04
+(PID.TID 0000.0001) %MON forcing_fv_max               =   1.4994612783194E-01
+(PID.TID 0000.0001) %MON forcing_fv_min               =  -7.6073135932287E-02
+(PID.TID 0000.0001) %MON forcing_fv_mean              =  -1.9356415130235E-02
+(PID.TID 0000.0001) %MON forcing_fv_sd                =   3.3511097786534E-02
+(PID.TID 0000.0001) %MON forcing_fv_del2              =   3.7406754651863E-04
+(PID.TID 0000.0001) %MON trAdv_CFL_u_max              =   8.4795968536339E-02
+(PID.TID 0000.0001) %MON trAdv_CFL_v_max              =   2.1796445154491E-02
+(PID.TID 0000.0001) %MON trAdv_CFL_w_max              =   6.3006748820173E-02
+(PID.TID 0000.0001) %MON advcfl_uvel_max              =   3.3856574012296E-02
+(PID.TID 0000.0001) %MON advcfl_vvel_max              =   1.7920214664715E-02
+(PID.TID 0000.0001) %MON advcfl_wvel_max              =   1.6711824738168E-02
+(PID.TID 0000.0001) %MON advcfl_W_hf_max              =   1.7940635380680E-02
+(PID.TID 0000.0001) %MON pe_b_mean                    =   8.6973873149404E-04
+(PID.TID 0000.0001) %MON ke_max                       =   9.3563820626241E-03
+(PID.TID 0000.0001) %MON ke_mean                      =   1.6308471162421E-04
+(PID.TID 0000.0001) %MON ke_vol                       =   1.2769337095763E+17
+(PID.TID 0000.0001) %MON vort_r_min                   =  -4.7629354144137E-07
+(PID.TID 0000.0001) %MON vort_r_max                   =   7.0627187721182E-07
+(PID.TID 0000.0001) %MON vort_a_mean                  =  -1.0457492441976E-04
+(PID.TID 0000.0001) %MON vort_a_sd                    =   2.1292678749744E-05
+(PID.TID 0000.0001) %MON vort_p_mean                  =  -1.2574624187308E-04
+(PID.TID 0000.0001) %MON vort_p_sd                    =   1.1183804115107E-04
+(PID.TID 0000.0001) %MON surfExpan_theta_mean         =   4.0468429483687E-07
+(PID.TID 0000.0001) %MON surfExpan_salt_mean          =   1.3657719718631E-07
+(PID.TID 0000.0001) // =======================================================
+(PID.TID 0000.0001) // End MONITOR dynamic field statistics
+(PID.TID 0000.0001) // =======================================================
+(PID.TID 0000.0001) // =======================================================
+(PID.TID 0000.0001) // Begin OBCS MONITOR field statistics
+(PID.TID 0000.0001) // =======================================================
+(PID.TID 0000.0001) %MON obc_E_uVel_max               =   8.3559853335222E-02
+(PID.TID 0000.0001) %MON obc_E_uVel_min               =  -6.0386974364519E-02
+(PID.TID 0000.0001) %MON obc_E_uVel_mean              =   7.3573274939063E-03
+(PID.TID 0000.0001) %MON obc_E_uVel_sd                =   1.4303477917298E-02
+(PID.TID 0000.0001) %MON obc_E_uVel_Int               =   1.2613850081140E+08
+(PID.TID 0000.0001) %MON obc_W_uVel_max               =   5.9943106646339E-02
+(PID.TID 0000.0001) %MON obc_W_uVel_min               =  -2.5738219885776E-02
+(PID.TID 0000.0001) %MON obc_W_uVel_mean              =   7.0017897715226E-03
+(PID.TID 0000.0001) %MON obc_W_uVel_sd                =   1.1123668362120E-02
+(PID.TID 0000.0001) %MON obc_W_uVel_Int               =   1.3085841444295E+08
+(PID.TID 0000.0001) %MON obc_N_vVel_max               =   4.7201666670541E-02
+(PID.TID 0000.0001) %MON obc_N_vVel_min               =  -7.0712813486656E-02
+(PID.TID 0000.0001) %MON obc_N_vVel_mean              =   1.5642367509297E-04
+(PID.TID 0000.0001) %MON obc_N_vVel_sd                =   6.4349071476655E-03
+(PID.TID 0000.0001) %MON obc_N_vVel_Int               =   4.5728658906207E+06
+(PID.TID 0000.0001) %MON obc_E_theta_max              =   1.9291473388672E+01
+(PID.TID 0000.0001) %MON obc_E_theta_min              =  -1.5996961494287E+00
+(PID.TID 0000.0001) %MON obc_E_theta_mean             =   1.9094220842338E+00
+(PID.TID 0000.0001) %MON obc_E_theta_sd               =   2.9675947024092E+00
+(PID.TID 0000.0001) %MON obc_W_theta_max              =   2.1505586306254E+01
+(PID.TID 0000.0001) %MON obc_W_theta_min              =  -1.4421739478906E+00
+(PID.TID 0000.0001) %MON obc_W_theta_mean             =   2.4664877946583E+00
+(PID.TID 0000.0001) %MON obc_W_theta_sd               =   2.9619408745425E+00
+(PID.TID 0000.0001) %MON obc_N_theta_max              =   2.4077075322469E+01
+(PID.TID 0000.0001) %MON obc_N_theta_min              =  -6.3293641308943E-01
+(PID.TID 0000.0001) %MON obc_N_theta_mean             =   4.8720802248449E+00
+(PID.TID 0000.0001) %MON obc_N_theta_sd               =   4.7053557686883E+00
+(PID.TID 0000.0001) // =======================================================
+(PID.TID 0000.0001) // End OBCS MONITOR field statistics
+(PID.TID 0000.0001) // =======================================================
+(PID.TID 0000.0001) // =======================================================
+(PID.TID 0000.0001) // Begin MONITOR ptracer field statistics
+(PID.TID 0000.0001) // =======================================================
+(PID.TID 0000.0001) %MON trcstat_ptracer01_max        =   2.3591420546447E+00
+(PID.TID 0000.0001) %MON trcstat_ptracer01_min        =   1.9366710307456E+00
+(PID.TID 0000.0001) %MON trcstat_ptracer01_mean       =   2.2425227482320E+00
+(PID.TID 0000.0001) %MON trcstat_ptracer01_sd         =   7.5998971530587E-02
+(PID.TID 0000.0001) %MON trcstat_ptracer01_del2       =   1.0654975141877E-04
+(PID.TID 0000.0001) %MON trcstat_ptracer02_max        =   2.4116849837933E+00
+(PID.TID 0000.0001) %MON trcstat_ptracer02_min        =   2.1900885568449E+00
+(PID.TID 0000.0001) %MON trcstat_ptracer02_mean       =   2.3520464542825E+00
+(PID.TID 0000.0001) %MON trcstat_ptracer02_sd         =   3.5090302234005E-02
+(PID.TID 0000.0001) %MON trcstat_ptracer02_del2       =   8.0605668026350E-05
+(PID.TID 0000.0001) %MON trcstat_ptracer03_max        =   2.7654812115095E-03
+(PID.TID 0000.0001) %MON trcstat_ptracer03_min        =   4.7216676238750E-05
+(PID.TID 0000.0001) %MON trcstat_ptracer03_mean       =   2.0556333514037E-03
+(PID.TID 0000.0001) %MON trcstat_ptracer03_sd         =   5.0330695423354E-04
+(PID.TID 0000.0001) %MON trcstat_ptracer03_del2       =   6.6925234083256E-07
+(PID.TID 0000.0001) %MON trcstat_ptracer04_max        =   2.5834842094182E-04
+(PID.TID 0000.0001) %MON trcstat_ptracer04_min        =  -7.6229478014002E-07
+(PID.TID 0000.0001) %MON trcstat_ptracer04_mean       =   6.2412143525986E-06
+(PID.TID 0000.0001) %MON trcstat_ptracer04_sd         =   2.6296275912119E-05
+(PID.TID 0000.0001) %MON trcstat_ptracer04_del2       =   1.3425710876208E-07
+(PID.TID 0000.0001) %MON trcstat_ptracer05_max        =   3.8376464887278E-01
+(PID.TID 0000.0001) %MON trcstat_ptracer05_min        =   8.2422333836580E-02
+(PID.TID 0000.0001) %MON trcstat_ptracer05_mean       =   2.1412356922377E-01
+(PID.TID 0000.0001) %MON trcstat_ptracer05_sd         =   4.3041094943624E-02
+(PID.TID 0000.0001) %MON trcstat_ptracer05_del2       =   1.1818374735142E-04
+(PID.TID 0000.0001) // =======================================================
+(PID.TID 0000.0001) // End MONITOR ptracer field statistics
+(PID.TID 0000.0001) // =======================================================
+ EXTERNAL_FIELDS_LOAD,         5 : iP,iLd,i0,i1=   12    1   12    1 ; Wght=  0.4166666667  0.5833333333
+ DIC_FIELDS_LOAD,         5 : iP,iLd,i0,i1=   12    1   12    1 ; Wght=  0.4166666667  0.5833333333
+ OBCS_FIELDS_LOAD,         6 : iP,iLd,i0,i1=   12    1   12    1 ; Wght=  0.4000000000  0.6000000000
+ cg2d: Sum(rhs),rhsMax =   3.68604606178160E+01  9.91567272730777E-01
+(PID.TID 0000.0001)      cg2d_init_res =   1.48015177643454E-02
+(PID.TID 0000.0001)      cg2d_iters(min,last) =      -1      76
+(PID.TID 0000.0001)      cg2d_last_res =   7.89128155850116E-14
+(PID.TID 0000.0001) // =======================================================
+(PID.TID 0000.0001) // Begin MONITOR dynamic field statistics
+(PID.TID 0000.0001) // =======================================================
+(PID.TID 0000.0001) %MON time_tsnumber                =                     6
+(PID.TID 0000.0001) %MON time_secondsf                =   2.5920000000000E+05
+(PID.TID 0000.0001) %MON dynstat_eta_max              =   4.6999038601379E-01
+(PID.TID 0000.0001) %MON dynstat_eta_min              =  -1.5152481176502E+00
+(PID.TID 0000.0001) %MON dynstat_eta_mean             =  -5.1661556972116E-01
+(PID.TID 0000.0001) %MON dynstat_eta_sd               =   6.1658103672773E-01
+(PID.TID 0000.0001) %MON dynstat_eta_del2             =   2.3736315171179E-03
+(PID.TID 0000.0001) %MON dynstat_uvel_max             =   1.3135016104574E-01
+(PID.TID 0000.0001) %MON dynstat_uvel_min             =  -6.0310755670071E-02
+(PID.TID 0000.0001) %MON dynstat_uvel_mean            =   7.5556985596957E-03
+(PID.TID 0000.0001) %MON dynstat_uvel_sd              =   1.4669695779405E-02
+(PID.TID 0000.0001) %MON dynstat_uvel_del2            =   1.6183624438474E-04
+(PID.TID 0000.0001) %MON dynstat_vvel_max             =   1.2980890775925E-01
+(PID.TID 0000.0001) %MON dynstat_vvel_min             =  -8.8535428945471E-02
+(PID.TID 0000.0001) %MON dynstat_vvel_mean            =   9.3568261909357E-04
+(PID.TID 0000.0001) %MON dynstat_vvel_sd              =   8.4651885756853E-03
+(PID.TID 0000.0001) %MON dynstat_vvel_del2            =   1.0619049059375E-04
+(PID.TID 0000.0001) %MON dynstat_wvel_max             =   5.5109426798928E-05
+(PID.TID 0000.0001) %MON dynstat_wvel_min             =  -1.4100108171508E-04
+(PID.TID 0000.0001) %MON dynstat_wvel_mean            =  -2.4321960367378E-07
+(PID.TID 0000.0001) %MON dynstat_wvel_sd              =   5.4438789134140E-06
+(PID.TID 0000.0001) %MON dynstat_wvel_del2            =   1.4054669441006E-07
+(PID.TID 0000.0001) %MON dynstat_theta_max            =   2.4256673239195E+01
+(PID.TID 0000.0001) %MON dynstat_theta_min            =  -2.8963725482635E+00
+(PID.TID 0000.0001) %MON dynstat_theta_mean           =   2.3235054855065E+00
+(PID.TID 0000.0001) %MON dynstat_theta_sd             =   3.2156151642625E+00
+(PID.TID 0000.0001) %MON dynstat_theta_del2           =   6.6295982957714E-03
+(PID.TID 0000.0001) %MON dynstat_salt_max             =   3.6601874127639E+01
+(PID.TID 0000.0001) %MON dynstat_salt_min             =   3.3077503206939E+01
+(PID.TID 0000.0001) %MON dynstat_salt_mean            =   3.4483939305470E+01
+(PID.TID 0000.0001) %MON dynstat_salt_sd              =   1.9650016219741E-01
+(PID.TID 0000.0001) %MON dynstat_salt_del2            =   1.1552488206347E-03
+(PID.TID 0000.0001) %MON forcing_qnet_max             =   6.8472602844238E+01
+(PID.TID 0000.0001) %MON forcing_qnet_min             =  -2.1107043965658E+02
+(PID.TID 0000.0001) %MON forcing_qnet_mean            =  -1.1982880448744E+02
+(PID.TID 0000.0001) %MON forcing_qnet_sd              =   4.4041733294347E+01
+(PID.TID 0000.0001) %MON forcing_qnet_del2            =   8.4094325131889E-01
+(PID.TID 0000.0001) %MON forcing_qsw_max              =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON forcing_qsw_min              =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON forcing_qsw_mean             =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON forcing_qsw_sd               =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON forcing_qsw_del2             =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON forcing_empmr_max            =   2.5141471127199E-05
+(PID.TID 0000.0001) %MON forcing_empmr_min            =  -3.9761445691511E-05
+(PID.TID 0000.0001) %MON forcing_empmr_mean           =  -9.3236499820974E-06
+(PID.TID 0000.0001) %MON forcing_empmr_sd             =   1.0249687273683E-05
+(PID.TID 0000.0001) %MON forcing_empmr_del2           =   9.8755541425843E-08
+(PID.TID 0000.0001) %MON forcing_fu_max               =   2.1253544837236E-01
+(PID.TID 0000.0001) %MON forcing_fu_min               =  -9.2614319175482E-02
+(PID.TID 0000.0001) %MON forcing_fu_mean              =   7.5602344860540E-02
+(PID.TID 0000.0001) %MON forcing_fu_sd                =   7.1398218194354E-02
+(PID.TID 0000.0001) %MON forcing_fu_del2              =   5.5615036481995E-04
+(PID.TID 0000.0001) %MON forcing_fv_max               =   1.4963739737868E-01
+(PID.TID 0000.0001) %MON forcing_fv_min               =  -7.6042934010426E-02
+(PID.TID 0000.0001) %MON forcing_fv_mean              =  -1.9297376240638E-02
+(PID.TID 0000.0001) %MON forcing_fv_sd                =   3.3499688898391E-02
+(PID.TID 0000.0001) %MON forcing_fv_del2              =   3.7361175793077E-04
+(PID.TID 0000.0001) %MON trAdv_CFL_u_max              =   8.5269630985716E-02
+(PID.TID 0000.0001) %MON trAdv_CFL_v_max              =   2.2854163869584E-02
+(PID.TID 0000.0001) %MON trAdv_CFL_w_max              =   6.2232714685373E-02
+(PID.TID 0000.0001) %MON advcfl_uvel_max              =   3.3919791609302E-02
+(PID.TID 0000.0001) %MON advcfl_vvel_max              =   1.7934072101716E-02
+(PID.TID 0000.0001) %MON advcfl_wvel_max              =   1.6688347205730E-02
+(PID.TID 0000.0001) %MON advcfl_W_hf_max              =   1.7915431559092E-02
+(PID.TID 0000.0001) %MON pe_b_mean                    =   8.7182684647676E-04
+(PID.TID 0000.0001) %MON ke_max                       =   9.3830442426115E-03
+(PID.TID 0000.0001) %MON ke_mean                      =   1.6343104906184E-04
+(PID.TID 0000.0001) %MON ke_vol                       =   1.2769337095763E+17
+(PID.TID 0000.0001) %MON vort_r_min                   =  -4.7585079446337E-07
+(PID.TID 0000.0001) %MON vort_r_max                   =   7.0706927681087E-07
+(PID.TID 0000.0001) %MON vort_a_mean                  =  -1.0457492390463E-04
+(PID.TID 0000.0001) %MON vort_a_sd                    =   2.1292685036605E-05
+(PID.TID 0000.0001) %MON vort_p_mean                  =  -1.2574624125366E-04
+(PID.TID 0000.0001) %MON vort_p_sd                    =   1.1183803238886E-04
+(PID.TID 0000.0001) %MON surfExpan_theta_mean         =   2.5334040790048E-07
+(PID.TID 0000.0001) %MON surfExpan_salt_mean          =   1.4788626310415E-07
+(PID.TID 0000.0001) // =======================================================
+(PID.TID 0000.0001) // End MONITOR dynamic field statistics
+(PID.TID 0000.0001) // =======================================================
+(PID.TID 0000.0001) // =======================================================
+(PID.TID 0000.0001) // Begin OBCS MONITOR field statistics
+(PID.TID 0000.0001) // =======================================================
+(PID.TID 0000.0001) %MON obc_E_uVel_max               =   8.3425460755825E-02
+(PID.TID 0000.0001) %MON obc_E_uVel_min               =  -6.0310755670071E-02
+(PID.TID 0000.0001) %MON obc_E_uVel_mean              =   7.3554947677044E-03
+(PID.TID 0000.0001) %MON obc_E_uVel_sd                =   1.4304154443492E-02
+(PID.TID 0000.0001) %MON obc_E_uVel_Int               =   1.2610707943785E+08
+(PID.TID 0000.0001) %MON obc_W_uVel_max               =   5.9991145133972E-02
+(PID.TID 0000.0001) %MON obc_W_uVel_min               =  -2.5740600004792E-02
+(PID.TID 0000.0001) %MON obc_W_uVel_mean              =   6.9974153800331E-03
+(PID.TID 0000.0001) %MON obc_W_uVel_sd                =   1.1127673018781E-02
+(PID.TID 0000.0001) %MON obc_W_uVel_Int               =   1.3077666021251E+08
+(PID.TID 0000.0001) %MON obc_N_vVel_max               =   4.7148257493973E-02
+(PID.TID 0000.0001) %MON obc_N_vVel_min               =  -7.0764410495758E-02
+(PID.TID 0000.0001) %MON obc_N_vVel_mean              =   1.5466347545728E-04
+(PID.TID 0000.0001) %MON obc_N_vVel_sd                =   6.4336033808868E-03
+(PID.TID 0000.0001) %MON obc_N_vVel_Int               =   4.5214084825912E+06
+(PID.TID 0000.0001) %MON obc_E_theta_max              =   1.9312948989868E+01
+(PID.TID 0000.0001) %MON obc_E_theta_min              =  -1.5910426139832E+00
+(PID.TID 0000.0001) %MON obc_E_theta_mean             =   1.9094109467191E+00
+(PID.TID 0000.0001) %MON obc_E_theta_sd               =   2.9680727207563E+00
+(PID.TID 0000.0001) %MON obc_W_theta_max              =   2.1525777435303E+01
+(PID.TID 0000.0001) %MON obc_W_theta_min              =  -1.4422561645508E+00
+(PID.TID 0000.0001) %MON obc_W_theta_mean             =   2.4667050325388E+00
+(PID.TID 0000.0001) %MON obc_W_theta_sd               =   2.9624842527631E+00
+(PID.TID 0000.0001) %MON obc_N_theta_max              =   2.4097963333130E+01
+(PID.TID 0000.0001) %MON obc_N_theta_min              =  -6.3343899250031E-01
+(PID.TID 0000.0001) %MON obc_N_theta_mean             =   4.8722921175379E+00
+(PID.TID 0000.0001) %MON obc_N_theta_sd               =   4.7062402932228E+00
+(PID.TID 0000.0001) // =======================================================
+(PID.TID 0000.0001) // End OBCS MONITOR field statistics
+(PID.TID 0000.0001) // =======================================================
+(PID.TID 0000.0001) // =======================================================
+(PID.TID 0000.0001) // Begin MONITOR ptracer field statistics
+(PID.TID 0000.0001) // =======================================================
+(PID.TID 0000.0001) %MON trcstat_ptracer01_max        =   2.3591426847918E+00
+(PID.TID 0000.0001) %MON trcstat_ptracer01_min        =   1.9366513108319E+00
+(PID.TID 0000.0001) %MON trcstat_ptracer01_mean       =   2.2425212688706E+00
+(PID.TID 0000.0001) %MON trcstat_ptracer01_sd         =   7.6002448251637E-02
+(PID.TID 0000.0001) %MON trcstat_ptracer01_del2       =   1.0647421639979E-04
+(PID.TID 0000.0001) %MON trcstat_ptracer02_max        =   2.4116855799363E+00
+(PID.TID 0000.0001) %MON trcstat_ptracer02_min        =   2.1901275596032E+00
+(PID.TID 0000.0001) %MON trcstat_ptracer02_mean       =   2.3520467504502E+00
+(PID.TID 0000.0001) %MON trcstat_ptracer02_sd         =   3.5090129304475E-02
+(PID.TID 0000.0001) %MON trcstat_ptracer02_del2       =   8.0598794424270E-05
+(PID.TID 0000.0001) %MON trcstat_ptracer03_max        =   2.7654846357374E-03
+(PID.TID 0000.0001) %MON trcstat_ptracer03_min        =   4.7172826647483E-05
+(PID.TID 0000.0001) %MON trcstat_ptracer03_mean       =   2.0556240677567E-03
+(PID.TID 0000.0001) %MON trcstat_ptracer03_sd         =   5.0332270860231E-04
+(PID.TID 0000.0001) %MON trcstat_ptracer03_del2       =   6.6895952488566E-07
+(PID.TID 0000.0001) %MON trcstat_ptracer04_max        =   2.5867373024591E-04
+(PID.TID 0000.0001) %MON trcstat_ptracer04_min        =  -7.6625129981406E-07
+(PID.TID 0000.0001) %MON trcstat_ptracer04_mean       =   6.2493443777087E-06
+(PID.TID 0000.0001) %MON trcstat_ptracer04_sd         =   2.6336037079404E-05
+(PID.TID 0000.0001) %MON trcstat_ptracer04_del2       =   1.3419273801687E-07
+(PID.TID 0000.0001) %MON trcstat_ptracer05_max        =   3.8380040823710E-01
+(PID.TID 0000.0001) %MON trcstat_ptracer05_min        =   8.2429634331529E-02
+(PID.TID 0000.0001) %MON trcstat_ptracer05_mean       =   2.1412172564592E-01
+(PID.TID 0000.0001) %MON trcstat_ptracer05_sd         =   4.3038612322839E-02
+(PID.TID 0000.0001) %MON trcstat_ptracer05_del2       =   1.1799274470709E-04
+(PID.TID 0000.0001) // =======================================================
+(PID.TID 0000.0001) // End MONITOR ptracer field statistics
+(PID.TID 0000.0001) // =======================================================
+ EXTERNAL_FIELDS_LOAD,         6 : iP,iLd,i0,i1=   12    1   12    1 ; Wght=  0.4000000000  0.6000000000
+ DIC_FIELDS_LOAD,         6 : iP,iLd,i0,i1=   12    1   12    1 ; Wght=  0.4000000000  0.6000000000
+ OBCS_FIELDS_LOAD,         7 : iP,iLd,i0,i1=   12    1   12    1 ; Wght=  0.3833333333  0.6166666667
+ cg2d: Sum(rhs),rhsMax =   3.68074301550226E+01  9.92642448786696E-01
+(PID.TID 0000.0001)      cg2d_init_res =   9.67818023158134E-03
+(PID.TID 0000.0001)      cg2d_iters(min,last) =      -1      76
+(PID.TID 0000.0001)      cg2d_last_res =   5.61356601531656E-14
+(PID.TID 0000.0001) // =======================================================
+(PID.TID 0000.0001) // Begin MONITOR dynamic field statistics
+(PID.TID 0000.0001) // =======================================================
+(PID.TID 0000.0001) %MON time_tsnumber                =                     7
+(PID.TID 0000.0001) %MON time_secondsf                =   3.0240000000000E+05
+(PID.TID 0000.0001) %MON dynstat_eta_max              =   4.7008106519615E-01
+(PID.TID 0000.0001) %MON dynstat_eta_min              =  -1.5146775749600E+00
+(PID.TID 0000.0001) %MON dynstat_eta_mean             =  -5.1643169504890E-01
+(PID.TID 0000.0001) %MON dynstat_eta_sd               =   6.1656733459346E-01
+(PID.TID 0000.0001) %MON dynstat_eta_del2             =   2.3756765429368E-03
+(PID.TID 0000.0001) %MON dynstat_uvel_max             =   1.3159765754242E-01
+(PID.TID 0000.0001) %MON dynstat_uvel_min             =  -6.0234536975622E-02
+(PID.TID 0000.0001) %MON dynstat_uvel_mean            =   7.5695103794253E-03
+(PID.TID 0000.0001) %MON dynstat_uvel_sd              =   1.4681330089115E-02
+(PID.TID 0000.0001) %MON dynstat_uvel_del2            =   1.6174305717656E-04
+(PID.TID 0000.0001) %MON dynstat_vvel_max             =   1.2991340263216E-01
+(PID.TID 0000.0001) %MON dynstat_vvel_min             =  -8.8511799774137E-02
+(PID.TID 0000.0001) %MON dynstat_vvel_mean            =   9.2437862859792E-04
+(PID.TID 0000.0001) %MON dynstat_vvel_sd              =   8.4766780757673E-03
+(PID.TID 0000.0001) %MON dynstat_vvel_del2            =   1.0616134270546E-04
+(PID.TID 0000.0001) %MON dynstat_wvel_max             =   5.5103833278965E-05
+(PID.TID 0000.0001) %MON dynstat_wvel_min             =  -1.4087470086022E-04
+(PID.TID 0000.0001) %MON dynstat_wvel_mean            =  -2.4321604356707E-07
+(PID.TID 0000.0001) %MON dynstat_wvel_sd              =   5.4473953131717E-06
+(PID.TID 0000.0001) %MON dynstat_wvel_del2            =   1.4063565223417E-07
+(PID.TID 0000.0001) %MON dynstat_theta_max            =   2.4273136344714E+01
+(PID.TID 0000.0001) %MON dynstat_theta_min            =  -2.8964216396834E+00
+(PID.TID 0000.0001) %MON dynstat_theta_mean           =   2.3238206533726E+00
+(PID.TID 0000.0001) %MON dynstat_theta_sd             =   3.2164965291096E+00
+(PID.TID 0000.0001) %MON dynstat_theta_del2           =   6.6269562665548E-03
+(PID.TID 0000.0001) %MON dynstat_salt_max             =   3.6602048807536E+01
+(PID.TID 0000.0001) %MON dynstat_salt_min             =   3.3076225669671E+01
+(PID.TID 0000.0001) %MON dynstat_salt_mean            =   3.4483939801185E+01
+(PID.TID 0000.0001) %MON dynstat_salt_sd              =   1.9650792897861E-01
+(PID.TID 0000.0001) %MON dynstat_salt_del2            =   1.1546602343412E-03
+(PID.TID 0000.0001) %MON forcing_qnet_max             =   6.8508172607422E+01
+(PID.TID 0000.0001) %MON forcing_qnet_min             =  -2.1064372558594E+02
+(PID.TID 0000.0001) %MON forcing_qnet_mean            =  -1.1955390927556E+02
+(PID.TID 0000.0001) %MON forcing_qnet_sd              =   4.3905712423966E+01
+(PID.TID 0000.0001) %MON forcing_qnet_del2            =   8.4229375591307E-01
+(PID.TID 0000.0001) %MON forcing_qsw_max              =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON forcing_qsw_min              =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON forcing_qsw_mean             =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON forcing_qsw_sd               =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON forcing_qsw_del2             =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON forcing_empmr_max            =   2.5141471127199E-05
+(PID.TID 0000.0001) %MON forcing_empmr_min            =  -3.9761445691511E-05
+(PID.TID 0000.0001) %MON forcing_empmr_mean           =  -9.3236499820974E-06
+(PID.TID 0000.0001) %MON forcing_empmr_sd             =   1.0249687273683E-05
+(PID.TID 0000.0001) %MON forcing_empmr_del2           =   9.8755541425843E-08
+(PID.TID 0000.0001) %MON forcing_fu_max               =   2.1268687546253E-01
+(PID.TID 0000.0001) %MON forcing_fu_min               =  -9.3030621111393E-02
+(PID.TID 0000.0001) %MON forcing_fu_mean              =   7.5501595942040E-02
+(PID.TID 0000.0001) %MON forcing_fu_sd                =   7.1436912347776E-02
+(PID.TID 0000.0001) %MON forcing_fu_del2              =   5.5725630261794E-04
+(PID.TID 0000.0001) %MON forcing_fv_max               =   1.4932866692543E-01
+(PID.TID 0000.0001) %MON forcing_fv_min               =  -7.6012732088566E-02
+(PID.TID 0000.0001) %MON forcing_fv_mean              =  -1.9238337351042E-02
+(PID.TID 0000.0001) %MON forcing_fv_sd                =   3.3489000856457E-02
+(PID.TID 0000.0001) %MON forcing_fv_del2              =   3.7319319925167E-04
+(PID.TID 0000.0001) %MON trAdv_CFL_u_max              =   8.5613351677080E-02
+(PID.TID 0000.0001) %MON trAdv_CFL_v_max              =   2.3925825217887E-02
+(PID.TID 0000.0001) %MON trAdv_CFL_w_max              =   6.1327010612069E-02
+(PID.TID 0000.0001) %MON advcfl_uvel_max              =   3.3983704965208E-02
+(PID.TID 0000.0001) %MON advcfl_vvel_max              =   1.7948508850452E-02
+(PID.TID 0000.0001) %MON advcfl_wvel_max              =   1.6673389252497E-02
+(PID.TID 0000.0001) %MON advcfl_W_hf_max              =   1.7899373756357E-02
+(PID.TID 0000.0001) %MON pe_b_mean                    =   8.7154814810678E-04
+(PID.TID 0000.0001) %MON ke_max                       =   9.4102991907660E-03
+(PID.TID 0000.0001) %MON ke_mean                      =   1.6378194905914E-04
+(PID.TID 0000.0001) %MON ke_vol                       =   1.2769337095763E+17
+(PID.TID 0000.0001) %MON vort_r_min                   =  -4.7538312146136E-07
+(PID.TID 0000.0001) %MON vort_r_max                   =   7.0780499724177E-07
+(PID.TID 0000.0001) %MON vort_a_mean                  =  -1.0457492338949E-04
+(PID.TID 0000.0001) %MON vort_a_sd                    =   2.1292692094140E-05
+(PID.TID 0000.0001) %MON vort_p_mean                  =  -1.2574624063424E-04
+(PID.TID 0000.0001) %MON vort_p_sd                    =   1.1183802341423E-04
+(PID.TID 0000.0001) %MON surfExpan_theta_mean         =   8.7499050927811E-08
+(PID.TID 0000.0001) %MON surfExpan_salt_mean          =   1.5572833546516E-07
+(PID.TID 0000.0001) // =======================================================
+(PID.TID 0000.0001) // End MONITOR dynamic field statistics
+(PID.TID 0000.0001) // =======================================================
+(PID.TID 0000.0001) // =======================================================
+(PID.TID 0000.0001) // Begin OBCS MONITOR field statistics
+(PID.TID 0000.0001) // =======================================================
+(PID.TID 0000.0001) %MON obc_E_uVel_max               =   8.3291068176428E-02
+(PID.TID 0000.0001) %MON obc_E_uVel_min               =  -6.0234536975622E-02
+(PID.TID 0000.0001) %MON obc_E_uVel_mean              =   7.3536620415026E-03
+(PID.TID 0000.0001) %MON obc_E_uVel_sd                =   1.4304842863392E-02
+(PID.TID 0000.0001) %MON obc_E_uVel_Int               =   1.2607565806430E+08
+(PID.TID 0000.0001) %MON obc_W_uVel_max               =   6.0039183621605E-02
+(PID.TID 0000.0001) %MON obc_W_uVel_min               =  -2.5742980123808E-02
+(PID.TID 0000.0001) %MON obc_W_uVel_mean              =   6.9930409885435E-03
+(PID.TID 0000.0001) %MON obc_W_uVel_sd                =   1.1131690601760E-02
+(PID.TID 0000.0001) %MON obc_W_uVel_Int               =   1.3069490598207E+08
+(PID.TID 0000.0001) %MON obc_N_vVel_max               =   4.7094848317405E-02
+(PID.TID 0000.0001) %MON obc_N_vVel_min               =  -7.0816007504861E-02
+(PID.TID 0000.0001) %MON obc_N_vVel_mean              =   1.5290327582159E-04
+(PID.TID 0000.0001) %MON obc_N_vVel_sd                =   6.4323161884926E-03
+(PID.TID 0000.0001) %MON obc_N_vVel_Int               =   4.4699510745618E+06
+(PID.TID 0000.0001) %MON obc_E_theta_max              =   1.9334424591064E+01
+(PID.TID 0000.0001) %MON obc_E_theta_min              =  -1.5823890785376E+00
+(PID.TID 0000.0001) %MON obc_E_theta_mean             =   1.9093998092044E+00
+(PID.TID 0000.0001) %MON obc_E_theta_sd               =   2.9685521370964E+00
+(PID.TID 0000.0001) %MON obc_W_theta_max              =   2.1545968564351E+01
+(PID.TID 0000.0001) %MON obc_W_theta_min              =  -1.4423383812110E+00
+(PID.TID 0000.0001) %MON obc_W_theta_mean             =   2.4669222704193E+00
+(PID.TID 0000.0001) %MON obc_W_theta_sd               =   2.9630285564427E+00
+(PID.TID 0000.0001) %MON obc_N_theta_max              =   2.4118851343791E+01
+(PID.TID 0000.0001) %MON obc_N_theta_min              =  -6.3394157191118E-01
+(PID.TID 0000.0001) %MON obc_N_theta_mean             =   4.8725040102309E+00
+(PID.TID 0000.0001) %MON obc_N_theta_sd               =   4.7071257566199E+00
+(PID.TID 0000.0001) // =======================================================
+(PID.TID 0000.0001) // End OBCS MONITOR field statistics
+(PID.TID 0000.0001) // =======================================================
+(PID.TID 0000.0001) // =======================================================
+(PID.TID 0000.0001) // Begin MONITOR ptracer field statistics
+(PID.TID 0000.0001) // =======================================================
+(PID.TID 0000.0001) %MON trcstat_ptracer01_max        =   2.3591433154288E+00
+(PID.TID 0000.0001) %MON trcstat_ptracer01_min        =   1.9366316365663E+00
+(PID.TID 0000.0001) %MON trcstat_ptracer01_mean       =   2.2425197615112E+00
+(PID.TID 0000.0001) %MON trcstat_ptracer01_sd         =   7.6006001871729E-02
+(PID.TID 0000.0001) %MON trcstat_ptracer01_del2       =   1.0639412268547E-04
+(PID.TID 0000.0001) %MON trcstat_ptracer02_max        =   2.4116862007430E+00
+(PID.TID 0000.0001) %MON trcstat_ptracer02_min        =   2.1901665807237E+00
+(PID.TID 0000.0001) %MON trcstat_ptracer02_mean       =   2.3520470240977E+00
+(PID.TID 0000.0001) %MON trcstat_ptracer02_sd         =   3.5089991138865E-02
+(PID.TID 0000.0001) %MON trcstat_ptracer02_del2       =   8.0591578644631E-05
+(PID.TID 0000.0001) %MON trcstat_ptracer03_max        =   2.7654880588400E-03
+(PID.TID 0000.0001) %MON trcstat_ptracer03_min        =   4.7129272619617E-05
+(PID.TID 0000.0001) %MON trcstat_ptracer03_mean       =   2.0556146322958E-03
+(PID.TID 0000.0001) %MON trcstat_ptracer03_sd         =   5.0333879851479E-04
+(PID.TID 0000.0001) %MON trcstat_ptracer03_del2       =   6.6860531204279E-07
+(PID.TID 0000.0001) %MON trcstat_ptracer04_max        =   2.5899480803230E-04
+(PID.TID 0000.0001) %MON trcstat_ptracer04_min        =  -7.7022530970579E-07
+(PID.TID 0000.0001) %MON trcstat_ptracer04_mean       =   6.2574442496260E-06
+(PID.TID 0000.0001) %MON trcstat_ptracer04_sd         =   2.6375671855123E-05
+(PID.TID 0000.0001) %MON trcstat_ptracer04_del2       =   1.3410865020940E-07
+(PID.TID 0000.0001) %MON trcstat_ptracer05_max        =   3.8383443643592E-01
+(PID.TID 0000.0001) %MON trcstat_ptracer05_min        =   8.2438560948496E-02
+(PID.TID 0000.0001) %MON trcstat_ptracer05_mean       =   2.1411986640507E-01
+(PID.TID 0000.0001) %MON trcstat_ptracer05_sd         =   4.3036101568632E-02
+(PID.TID 0000.0001) %MON trcstat_ptracer05_del2       =   1.1779545872810E-04
+(PID.TID 0000.0001) // =======================================================
+(PID.TID 0000.0001) // End MONITOR ptracer field statistics
+(PID.TID 0000.0001) // =======================================================
+ EXTERNAL_FIELDS_LOAD,         7 : iP,iLd,i0,i1=   12    1   12    1 ; Wght=  0.3833333333  0.6166666667
+ DIC_FIELDS_LOAD,         7 : iP,iLd,i0,i1=   12    1   12    1 ; Wght=  0.3833333333  0.6166666667
+ OBCS_FIELDS_LOAD,         8 : iP,iLd,i0,i1=   12    1   12    1 ; Wght=  0.3666666667  0.6333333333
+ cg2d: Sum(rhs),rhsMax =   3.67609180744336E+01  9.93541857101072E-01
+(PID.TID 0000.0001)      cg2d_init_res =   1.38807595302222E-02
+(PID.TID 0000.0001)      cg2d_iters(min,last) =      -1      76
+(PID.TID 0000.0001)      cg2d_last_res =   7.28273104908896E-14
+(PID.TID 0000.0001) // =======================================================
+(PID.TID 0000.0001) // Begin MONITOR dynamic field statistics
+(PID.TID 0000.0001) // =======================================================
+(PID.TID 0000.0001) %MON time_tsnumber                =                     8
+(PID.TID 0000.0001) %MON time_secondsf                =   3.4560000000000E+05
+(PID.TID 0000.0001) %MON dynstat_eta_max              =   4.6723536497608E-01
+(PID.TID 0000.0001) %MON dynstat_eta_min              =  -1.5132080757544E+00
+(PID.TID 0000.0001) %MON dynstat_eta_mean             =  -5.1624643537434E-01
+(PID.TID 0000.0001) %MON dynstat_eta_sd               =   6.1540913193987E-01
+(PID.TID 0000.0001) %MON dynstat_eta_del2             =   2.3769577727386E-03
+(PID.TID 0000.0001) %MON dynstat_uvel_max             =   1.3184375173849E-01
+(PID.TID 0000.0001) %MON dynstat_uvel_min             =  -6.0158318281174E-02
+(PID.TID 0000.0001) %MON dynstat_uvel_mean            =   7.5844790515267E-03
+(PID.TID 0000.0001) %MON dynstat_uvel_sd              =   1.4691681115239E-02
+(PID.TID 0000.0001) %MON dynstat_uvel_del2            =   1.6165719148398E-04
+(PID.TID 0000.0001) %MON dynstat_vvel_max             =   1.3001700092231E-01
+(PID.TID 0000.0001) %MON dynstat_vvel_min             =  -8.8481552609679E-02
+(PID.TID 0000.0001) %MON dynstat_vvel_mean            =   9.1626110527408E-04
+(PID.TID 0000.0001) %MON dynstat_vvel_sd              =   8.4875135541305E-03
+(PID.TID 0000.0001) %MON dynstat_vvel_del2            =   1.0613049146976E-04
+(PID.TID 0000.0001) %MON dynstat_wvel_max             =   5.5090002988546E-05
+(PID.TID 0000.0001) %MON dynstat_wvel_min             =  -1.4076607694846E-04
+(PID.TID 0000.0001) %MON dynstat_wvel_mean            =  -2.4321248346036E-07
+(PID.TID 0000.0001) %MON dynstat_wvel_sd              =   5.4515180270604E-06
+(PID.TID 0000.0001) %MON dynstat_wvel_del2            =   1.4073681914374E-07
+(PID.TID 0000.0001) %MON dynstat_theta_max            =   2.4289604917873E+01
+(PID.TID 0000.0001) %MON dynstat_theta_min            =  -2.8964598657543E+00
+(PID.TID 0000.0001) %MON dynstat_theta_mean           =   2.3241374181710E+00
+(PID.TID 0000.0001) %MON dynstat_theta_sd             =   3.2173838587216E+00
+(PID.TID 0000.0001) %MON dynstat_theta_del2           =   6.6243773847626E-03
+(PID.TID 0000.0001) %MON dynstat_salt_max             =   3.6602221012721E+01
+(PID.TID 0000.0001) %MON dynstat_salt_min             =   3.3074878196556E+01
+(PID.TID 0000.0001) %MON dynstat_salt_mean            =   3.4483940230520E+01
+(PID.TID 0000.0001) %MON dynstat_salt_sd              =   1.9651534080036E-01
+(PID.TID 0000.0001) %MON dynstat_salt_del2            =   1.1540770021512E-03
+(PID.TID 0000.0001) %MON forcing_qnet_max             =   6.8543742370605E+01
+(PID.TID 0000.0001) %MON forcing_qnet_min             =  -2.1021701151530E+02
+(PID.TID 0000.0001) %MON forcing_qnet_mean            =  -1.1927901406368E+02
+(PID.TID 0000.0001) %MON forcing_qnet_sd              =   4.3773378415024E+01
+(PID.TID 0000.0001) %MON forcing_qnet_del2            =   8.4369299028848E-01
+(PID.TID 0000.0001) %MON forcing_qsw_max              =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON forcing_qsw_min              =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON forcing_qsw_mean             =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON forcing_qsw_sd               =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON forcing_qsw_del2             =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON forcing_empmr_max            =   2.5141471127199E-05
+(PID.TID 0000.0001) %MON forcing_empmr_min            =  -3.9761445691511E-05
+(PID.TID 0000.0001) %MON forcing_empmr_mean           =  -9.3236499820974E-06
+(PID.TID 0000.0001) %MON forcing_empmr_sd             =   1.0249687273683E-05
+(PID.TID 0000.0001) %MON forcing_empmr_del2           =   9.8755541425843E-08
+(PID.TID 0000.0001) %MON forcing_fu_max               =   2.1288872435689E-01
+(PID.TID 0000.0001) %MON forcing_fu_min               =  -9.3446923047304E-02
+(PID.TID 0000.0001) %MON forcing_fu_mean              =   7.5400847023540E-02
+(PID.TID 0000.0001) %MON forcing_fu_sd                =   7.1476380419357E-02
+(PID.TID 0000.0001) %MON forcing_fu_del2              =   5.5840575540377E-04
+(PID.TID 0000.0001) %MON forcing_fv_max               =   1.4901993647218E-01
+(PID.TID 0000.0001) %MON forcing_fv_min               =  -7.6058066760500E-02
+(PID.TID 0000.0001) %MON forcing_fv_mean              =  -1.9179298461445E-02
+(PID.TID 0000.0001) %MON forcing_fv_sd                =   3.3479034351115E-02
+(PID.TID 0000.0001) %MON forcing_fv_del2              =   3.7281199587619E-04
+(PID.TID 0000.0001) %MON trAdv_CFL_u_max              =   8.6024459238591E-02
+(PID.TID 0000.0001) %MON trAdv_CFL_v_max              =   2.5145861281093E-02
+(PID.TID 0000.0001) %MON trAdv_CFL_w_max              =   6.0433509400697E-02
+(PID.TID 0000.0001) %MON advcfl_uvel_max              =   3.4047256191796E-02
+(PID.TID 0000.0001) %MON advcfl_vvel_max              =   1.7962821729570E-02
+(PID.TID 0000.0001) %MON advcfl_wvel_max              =   1.6660532942941E-02
+(PID.TID 0000.0001) %MON advcfl_W_hf_max              =   1.7885572129922E-02
+(PID.TID 0000.0001) %MON pe_b_mean                    =   8.6936786355898E-04
+(PID.TID 0000.0001) %MON ke_max                       =   9.4375168068006E-03
+(PID.TID 0000.0001) %MON ke_mean                      =   1.6412107367389E-04
+(PID.TID 0000.0001) %MON ke_vol                       =   1.2769337095763E+17
+(PID.TID 0000.0001) %MON vort_r_min                   =  -4.7489606858037E-07
+(PID.TID 0000.0001) %MON vort_r_max                   =   7.0834847859322E-07
+(PID.TID 0000.0001) %MON vort_a_mean                  =  -1.0457492287436E-04
+(PID.TID 0000.0001) %MON vort_a_sd                    =   2.1292700168765E-05
+(PID.TID 0000.0001) %MON vort_p_mean                  =  -1.2574624001482E-04
+(PID.TID 0000.0001) %MON vort_p_sd                    =   1.1183801666247E-04
+(PID.TID 0000.0001) %MON surfExpan_theta_mean         =  -3.7780077551823E-08
+(PID.TID 0000.0001) %MON surfExpan_salt_mean          =   1.6198243314544E-07
+(PID.TID 0000.0001) // =======================================================
+(PID.TID 0000.0001) // End MONITOR dynamic field statistics
+(PID.TID 0000.0001) // =======================================================
+(PID.TID 0000.0001) // =======================================================
+(PID.TID 0000.0001) // Begin OBCS MONITOR field statistics
+(PID.TID 0000.0001) // =======================================================
+(PID.TID 0000.0001) %MON obc_E_uVel_max               =   8.3156675597032E-02
+(PID.TID 0000.0001) %MON obc_E_uVel_min               =  -6.0158318281174E-02
+(PID.TID 0000.0001) %MON obc_E_uVel_mean              =   7.3518293153007E-03
+(PID.TID 0000.0001) %MON obc_E_uVel_sd                =   1.4305543175280E-02
+(PID.TID 0000.0001) %MON obc_E_uVel_Int               =   1.2604423669076E+08
+(PID.TID 0000.0001) %MON obc_W_uVel_max               =   6.0087222109238E-02
+(PID.TID 0000.0001) %MON obc_W_uVel_min               =  -2.5745360242824E-02
+(PID.TID 0000.0001) %MON obc_W_uVel_mean              =   6.9886665970540E-03
+(PID.TID 0000.0001) %MON obc_W_uVel_sd                =   1.1135721097065E-02
+(PID.TID 0000.0001) %MON obc_W_uVel_Int               =   1.3061315175163E+08
+(PID.TID 0000.0001) %MON obc_N_vVel_max               =   4.7041439140836E-02
+(PID.TID 0000.0001) %MON obc_N_vVel_min               =  -7.0867604513963E-02
+(PID.TID 0000.0001) %MON obc_N_vVel_mean              =   1.5114307618590E-04
+(PID.TID 0000.0001) %MON obc_N_vVel_sd                =   6.4310455804353E-03
+(PID.TID 0000.0001) %MON obc_N_vVel_Int               =   4.4184936665323E+06
+(PID.TID 0000.0001) %MON obc_E_theta_max              =   1.9355900192261E+01
+(PID.TID 0000.0001) %MON obc_E_theta_min              =  -1.5737355430921E+00
+(PID.TID 0000.0001) %MON obc_E_theta_mean             =   1.9093886716897E+00
+(PID.TID 0000.0001) %MON obc_E_theta_sd               =   2.9690329507524E+00
+(PID.TID 0000.0001) %MON obc_W_theta_max              =   2.1566159693400E+01
+(PID.TID 0000.0001) %MON obc_W_theta_min              =  -1.4424205978711E+00
+(PID.TID 0000.0001) %MON obc_W_theta_mean             =   2.4671395082998E+00
+(PID.TID 0000.0001) %MON obc_W_theta_sd               =   2.9635737850715E+00
+(PID.TID 0000.0001) %MON obc_N_theta_max              =   2.4139739354451E+01
+(PID.TID 0000.0001) %MON obc_N_theta_min              =  -6.3444415132205E-01
+(PID.TID 0000.0001) %MON obc_N_theta_mean             =   4.8727159029239E+00
+(PID.TID 0000.0001) %MON obc_N_theta_sd               =   4.7080121583499E+00
+(PID.TID 0000.0001) // =======================================================
+(PID.TID 0000.0001) // End OBCS MONITOR field statistics
+(PID.TID 0000.0001) // =======================================================
+(PID.TID 0000.0001) // =======================================================
+(PID.TID 0000.0001) // Begin MONITOR ptracer field statistics
+(PID.TID 0000.0001) // =======================================================
+(PID.TID 0000.0001) %MON trcstat_ptracer01_max        =   2.3591439465573E+00
+(PID.TID 0000.0001) %MON trcstat_ptracer01_min        =   1.9366120052776E+00
+(PID.TID 0000.0001) %MON trcstat_ptracer01_mean       =   2.2425182265403E+00
+(PID.TID 0000.0001) %MON trcstat_ptracer01_sd         =   7.6009632409383E-02
+(PID.TID 0000.0001) %MON trcstat_ptracer01_del2       =   1.0631616245791E-04
+(PID.TID 0000.0001) %MON trcstat_ptracer02_max        =   2.4116868452737E+00
+(PID.TID 0000.0001) %MON trcstat_ptracer02_min        =   2.1902045792250E+00
+(PID.TID 0000.0001) %MON trcstat_ptracer02_mean       =   2.3520472771949E+00
+(PID.TID 0000.0001) %MON trcstat_ptracer02_sd         =   3.5089885774127E-02
+(PID.TID 0000.0001) %MON trcstat_ptracer02_del2       =   8.0584051625775E-05
+(PID.TID 0000.0001) %MON trcstat_ptracer03_max        =   2.7654914810244E-03
+(PID.TID 0000.0001) %MON trcstat_ptracer03_min        =   4.7086010634046E-05
+(PID.TID 0000.0001) %MON trcstat_ptracer03_mean       =   2.0556050397947E-03
+(PID.TID 0000.0001) %MON trcstat_ptracer03_sd         =   5.0335525039907E-04
+(PID.TID 0000.0001) %MON trcstat_ptracer03_del2       =   6.6826974911584E-07
+(PID.TID 0000.0001) %MON trcstat_ptracer04_max        =   2.5931118414272E-04
+(PID.TID 0000.0001) %MON trcstat_ptracer04_min        =  -7.7420934168380E-07
+(PID.TID 0000.0001) %MON trcstat_ptracer04_mean       =   6.2655097828300E-06
+(PID.TID 0000.0001) %MON trcstat_ptracer04_sd         =   2.6415159444563E-05
+(PID.TID 0000.0001) %MON trcstat_ptracer04_del2       =   1.3403480721239E-07
+(PID.TID 0000.0001) %MON trcstat_ptracer05_max        =   3.8386684828878E-01
+(PID.TID 0000.0001) %MON trcstat_ptracer05_min        =   8.2449211969712E-02
+(PID.TID 0000.0001) %MON trcstat_ptracer05_mean       =   2.1411799002302E-01
+(PID.TID 0000.0001) %MON trcstat_ptracer05_sd         =   4.3033560541227E-02
+(PID.TID 0000.0001) %MON trcstat_ptracer05_del2       =   1.1760435248651E-04
+(PID.TID 0000.0001) // =======================================================
+(PID.TID 0000.0001) // End MONITOR ptracer field statistics
+(PID.TID 0000.0001) // =======================================================
+ EXTERNAL_FIELDS_LOAD,         8 : iP,iLd,i0,i1=   12    1   12    1 ; Wght=  0.3666666667  0.6333333333
+ DIC_FIELDS_LOAD,         8 : iP,iLd,i0,i1=   12    1   12    1 ; Wght=  0.3666666667  0.6333333333
+ OBCS_FIELDS_LOAD,         9 : iP,iLd,i0,i1=   12    1   12    1 ; Wght=  0.3500000000  0.6500000000
+ cg2d: Sum(rhs),rhsMax =   3.67312203274175E+01  9.93985653357504E-01
+(PID.TID 0000.0001)      cg2d_init_res =   1.78714566347305E-02
+(PID.TID 0000.0001)      cg2d_iters(min,last) =      -1      77
+(PID.TID 0000.0001)      cg2d_last_res =   7.07449220495416E-14
+(PID.TID 0000.0001) // =======================================================
+(PID.TID 0000.0001) // Begin MONITOR dynamic field statistics
+(PID.TID 0000.0001) // =======================================================
+(PID.TID 0000.0001) %MON time_tsnumber                =                     9
+(PID.TID 0000.0001) %MON time_secondsf                =   3.8880000000000E+05
+(PID.TID 0000.0001) %MON dynstat_eta_max              =   4.6188295381627E-01
+(PID.TID 0000.0001) %MON dynstat_eta_min              =  -1.5105381190453E+00
+(PID.TID 0000.0001) %MON dynstat_eta_mean             =  -5.1605979069747E-01
+(PID.TID 0000.0001) %MON dynstat_eta_sd               =   6.1355378384906E-01
+(PID.TID 0000.0001) %MON dynstat_eta_del2             =   2.3768604243972E-03
+(PID.TID 0000.0001) %MON dynstat_uvel_max             =   1.3207882409837E-01
+(PID.TID 0000.0001) %MON dynstat_uvel_min             =  -6.0082099586725E-02
+(PID.TID 0000.0001) %MON dynstat_uvel_mean            =   7.5988230765452E-03
+(PID.TID 0000.0001) %MON dynstat_uvel_sd              =   1.4700264721465E-02
+(PID.TID 0000.0001) %MON dynstat_uvel_del2            =   1.6157611435575E-04
+(PID.TID 0000.0001) %MON dynstat_vvel_max             =   1.3011535745598E-01
+(PID.TID 0000.0001) %MON dynstat_vvel_min             =  -8.8444901322574E-02
+(PID.TID 0000.0001) %MON dynstat_vvel_mean            =   9.1241750449551E-04
+(PID.TID 0000.0001) %MON dynstat_vvel_sd              =   8.4967950695218E-03
+(PID.TID 0000.0001) %MON dynstat_vvel_del2            =   1.0609380448029E-04
+(PID.TID 0000.0001) %MON dynstat_wvel_max             =   5.5079523697177E-05
+(PID.TID 0000.0001) %MON dynstat_wvel_min             =  -1.4064975274828E-04
+(PID.TID 0000.0001) %MON dynstat_wvel_mean            =  -2.4320892335365E-07
+(PID.TID 0000.0001) %MON dynstat_wvel_sd              =   5.4544864209949E-06
+(PID.TID 0000.0001) %MON dynstat_wvel_del2            =   1.4082365022984E-07
+(PID.TID 0000.0001) %MON dynstat_theta_max            =   2.4306104930293E+01
+(PID.TID 0000.0001) %MON dynstat_theta_min            =  -2.8964871861477E+00
+(PID.TID 0000.0001) %MON dynstat_theta_mean           =   2.3244549100803E+00
+(PID.TID 0000.0001) %MON dynstat_theta_sd             =   3.2182751879220E+00
+(PID.TID 0000.0001) %MON dynstat_theta_del2           =   6.6218581067712E-03
+(PID.TID 0000.0001) %MON dynstat_salt_max             =   3.6602391437169E+01
+(PID.TID 0000.0001) %MON dynstat_salt_min             =   3.3073456244647E+01
+(PID.TID 0000.0001) %MON dynstat_salt_mean            =   3.4483940599069E+01
+(PID.TID 0000.0001) %MON dynstat_salt_sd              =   1.9652251996430E-01
+(PID.TID 0000.0001) %MON dynstat_salt_del2            =   1.1534995544742E-03
+(PID.TID 0000.0001) %MON forcing_qnet_max             =   6.8579312133789E+01
+(PID.TID 0000.0001) %MON forcing_qnet_min             =  -2.0979029744466E+02
+(PID.TID 0000.0001) %MON forcing_qnet_mean            =  -1.1900411885181E+02
+(PID.TID 0000.0001) %MON forcing_qnet_sd              =   4.3644764804007E+01
+(PID.TID 0000.0001) %MON forcing_qnet_del2            =   8.4514071241070E-01
+(PID.TID 0000.0001) %MON forcing_qsw_max              =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON forcing_qsw_min              =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON forcing_qsw_mean             =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON forcing_qsw_sd               =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON forcing_qsw_del2             =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON forcing_empmr_max            =   2.5141471127199E-05
+(PID.TID 0000.0001) %MON forcing_empmr_min            =  -3.9761445691511E-05
+(PID.TID 0000.0001) %MON forcing_empmr_mean           =  -9.3236499820974E-06
+(PID.TID 0000.0001) %MON forcing_empmr_sd             =   1.0249687273683E-05
+(PID.TID 0000.0001) %MON forcing_empmr_del2           =   9.8755541425843E-08
+(PID.TID 0000.0001) %MON forcing_fu_max               =   2.1309057325125E-01
+(PID.TID 0000.0001) %MON forcing_fu_min               =  -9.3863224983215E-02
+(PID.TID 0000.0001) %MON forcing_fu_mean              =   7.5300098105040E-02
+(PID.TID 0000.0001) %MON forcing_fu_sd                =   7.1516621127784E-02
+(PID.TID 0000.0001) %MON forcing_fu_del2              =   5.5959845502938E-04
+(PID.TID 0000.0001) %MON forcing_fv_max               =   1.4871120601892E-01
+(PID.TID 0000.0001) %MON forcing_fv_min               =  -7.6119570682446E-02
+(PID.TID 0000.0001) %MON forcing_fv_mean              =  -1.9120259571849E-02
+(PID.TID 0000.0001) %MON forcing_fv_sd                =   3.3469790026933E-02
+(PID.TID 0000.0001) %MON forcing_fv_del2              =   3.7246826249842E-04
+(PID.TID 0000.0001) %MON trAdv_CFL_u_max              =   8.8149843865976E-02
+(PID.TID 0000.0001) %MON trAdv_CFL_v_max              =   2.6399234303102E-02
+(PID.TID 0000.0001) %MON trAdv_CFL_w_max              =   6.1249989698742E-02
+(PID.TID 0000.0001) %MON advcfl_uvel_max              =   3.4107961145615E-02
+(PID.TID 0000.0001) %MON advcfl_vvel_max              =   1.7976410420801E-02
+(PID.TID 0000.0001) %MON advcfl_wvel_max              =   1.6646765256782E-02
+(PID.TID 0000.0001) %MON advcfl_W_hf_max              =   1.7870792113899E-02
+(PID.TID 0000.0001) %MON pe_b_mean                    =   8.6603607747074E-04
+(PID.TID 0000.0001) %MON ke_max                       =   9.4633213657973E-03
+(PID.TID 0000.0001) %MON ke_mean                      =   1.6442186705882E-04
+(PID.TID 0000.0001) %MON ke_vol                       =   1.2769337095763E+17
+(PID.TID 0000.0001) %MON vort_r_min                   =  -4.7439238151693E-07
+(PID.TID 0000.0001) %MON vort_r_max                   =   7.0861943366491E-07
+(PID.TID 0000.0001) %MON vort_a_mean                  =  -1.0457492235923E-04
+(PID.TID 0000.0001) %MON vort_a_sd                    =   2.1292708323084E-05
+(PID.TID 0000.0001) %MON vort_p_mean                  =  -1.2574623939540E-04
+(PID.TID 0000.0001) %MON vort_p_sd                    =   1.1183801272312E-04
+(PID.TID 0000.0001) %MON surfExpan_theta_mean         =  -9.8017408805823E-08
+(PID.TID 0000.0001) %MON surfExpan_salt_mean          =   1.6840134834570E-07
+(PID.TID 0000.0001) // =======================================================
+(PID.TID 0000.0001) // End MONITOR dynamic field statistics
+(PID.TID 0000.0001) // =======================================================
+(PID.TID 0000.0001) // =======================================================
+(PID.TID 0000.0001) // Begin OBCS MONITOR field statistics
+(PID.TID 0000.0001) // =======================================================
+(PID.TID 0000.0001) %MON obc_E_uVel_max               =   8.3022283017635E-02
+(PID.TID 0000.0001) %MON obc_E_uVel_min               =  -6.0082099586725E-02
+(PID.TID 0000.0001) %MON obc_E_uVel_mean              =   7.3499965890989E-03
+(PID.TID 0000.0001) %MON obc_E_uVel_sd                =   1.4306255377412E-02
+(PID.TID 0000.0001) %MON obc_E_uVel_Int               =   1.2601281531721E+08
+(PID.TID 0000.0001) %MON obc_W_uVel_max               =   6.0135260596871E-02
+(PID.TID 0000.0001) %MON obc_W_uVel_min               =  -2.5747740361840E-02
+(PID.TID 0000.0001) %MON obc_W_uVel_mean              =   6.9842922055644E-03
+(PID.TID 0000.0001) %MON obc_W_uVel_sd                =   1.1139764490681E-02
+(PID.TID 0000.0001) %MON obc_W_uVel_Int               =   1.3053139752119E+08
+(PID.TID 0000.0001) %MON obc_N_vVel_max               =   4.6988029964268E-02
+(PID.TID 0000.0001) %MON obc_N_vVel_min               =  -7.0919201523066E-02
+(PID.TID 0000.0001) %MON obc_N_vVel_mean              =   1.4938287655021E-04
+(PID.TID 0000.0001) %MON obc_N_vVel_sd                =   6.4297915665466E-03
+(PID.TID 0000.0001) %MON obc_N_vVel_Int               =   4.3670362585028E+06
+(PID.TID 0000.0001) %MON obc_E_theta_max              =   1.9377375793457E+01
+(PID.TID 0000.0001) %MON obc_E_theta_min              =  -1.5650820076466E+00
+(PID.TID 0000.0001) %MON obc_E_theta_mean             =   1.9093775341749E+00
+(PID.TID 0000.0001) %MON obc_E_theta_sd               =   2.9695151610455E+00
+(PID.TID 0000.0001) %MON obc_W_theta_max              =   2.1586350822449E+01
+(PID.TID 0000.0001) %MON obc_W_theta_min              =  -1.4425028145313E+00
+(PID.TID 0000.0001) %MON obc_W_theta_mean             =   2.4673567461802E+00
+(PID.TID 0000.0001) %MON obc_W_theta_sd               =   2.9641199381389E+00
+(PID.TID 0000.0001) %MON obc_N_theta_max              =   2.4160627365112E+01
+(PID.TID 0000.0001) %MON obc_N_theta_min              =  -6.3494673073292E-01
+(PID.TID 0000.0001) %MON obc_N_theta_mean             =   4.8729277956169E+00
+(PID.TID 0000.0001) %MON obc_N_theta_sd               =   4.7088994978830E+00
+(PID.TID 0000.0001) // =======================================================
+(PID.TID 0000.0001) // End OBCS MONITOR field statistics
+(PID.TID 0000.0001) // =======================================================
+(PID.TID 0000.0001) // =======================================================
+(PID.TID 0000.0001) // Begin MONITOR ptracer field statistics
+(PID.TID 0000.0001) // =======================================================
+(PID.TID 0000.0001) %MON trcstat_ptracer01_max        =   2.3591445769663E+00
+(PID.TID 0000.0001) %MON trcstat_ptracer01_min        =   1.9365924144883E+00
+(PID.TID 0000.0001) %MON trcstat_ptracer01_mean       =   2.2425166701824E+00
+(PID.TID 0000.0001) %MON trcstat_ptracer01_sd         =   7.6013322584988E-02
+(PID.TID 0000.0001) %MON trcstat_ptracer01_del2       =   1.0623955947811E-04
+(PID.TID 0000.0001) %MON trcstat_ptracer02_max        =   2.4116875111597E+00
+(PID.TID 0000.0001) %MON trcstat_ptracer02_min        =   2.1902410680924E+00
+(PID.TID 0000.0001) %MON trcstat_ptracer02_mean       =   2.3520475137591E+00
+(PID.TID 0000.0001) %MON trcstat_ptracer02_sd         =   3.5089806364697E-02
+(PID.TID 0000.0001) %MON trcstat_ptracer02_del2       =   8.0576253154173E-05
+(PID.TID 0000.0001) %MON trcstat_ptracer03_max        =   2.7654948952691E-03
+(PID.TID 0000.0001) %MON trcstat_ptracer03_min        =   4.7043036957142E-05
+(PID.TID 0000.0001) %MON trcstat_ptracer03_mean       =   2.0555953298210E-03
+(PID.TID 0000.0001) %MON trcstat_ptracer03_sd         =   5.0337196960256E-04
+(PID.TID 0000.0001) %MON trcstat_ptracer03_del2       =   6.6794322464362E-07
+(PID.TID 0000.0001) %MON trcstat_ptracer04_max        =   2.5962277598367E-04
+(PID.TID 0000.0001) %MON trcstat_ptracer04_min        =  -7.7821378166312E-07
+(PID.TID 0000.0001) %MON trcstat_ptracer04_mean       =   6.2735394737443E-06
+(PID.TID 0000.0001) %MON trcstat_ptracer04_sd         =   2.6454493080859E-05
+(PID.TID 0000.0001) %MON trcstat_ptracer04_del2       =   1.3396788665641E-07
+(PID.TID 0000.0001) %MON trcstat_ptracer05_max        =   3.8389779926146E-01
+(PID.TID 0000.0001) %MON trcstat_ptracer05_min        =   8.2461047396573E-02
+(PID.TID 0000.0001) %MON trcstat_ptracer05_mean       =   2.1411609961828E-01
+(PID.TID 0000.0001) %MON trcstat_ptracer05_sd         =   4.3030995534209E-02
+(PID.TID 0000.0001) %MON trcstat_ptracer05_del2       =   1.1741788079132E-04
+(PID.TID 0000.0001) // =======================================================
+(PID.TID 0000.0001) // End MONITOR ptracer field statistics
+(PID.TID 0000.0001) // =======================================================
+ EXTERNAL_FIELDS_LOAD,         9 : iP,iLd,i0,i1=   12    1   12    1 ; Wght=  0.3500000000  0.6500000000
+ DIC_FIELDS_LOAD,         9 : iP,iLd,i0,i1=   12    1   12    1 ; Wght=  0.3500000000  0.6500000000
+ OBCS_FIELDS_LOAD,        10 : iP,iLd,i0,i1=   12    1   12    1 ; Wght=  0.3333333333  0.6666666667
+ cg2d: Sum(rhs),rhsMax =   3.67227792917983E+01  9.93851880945147E-01
+(PID.TID 0000.0001)      cg2d_init_res =   2.01899465663214E-02
+(PID.TID 0000.0001)      cg2d_iters(min,last) =      -1      76
+(PID.TID 0000.0001)      cg2d_last_res =   6.96835802799745E-14
+(PID.TID 0000.0001) // =======================================================
+(PID.TID 0000.0001) // Begin MONITOR dynamic field statistics
+(PID.TID 0000.0001) // =======================================================
+(PID.TID 0000.0001) %MON time_tsnumber                =                    10
+(PID.TID 0000.0001) %MON time_secondsf                =   4.3200000000000E+05
+(PID.TID 0000.0001) %MON dynstat_eta_max              =   4.5495146813194E-01
+(PID.TID 0000.0001) %MON dynstat_eta_min              =  -1.5066528418583E+00
+(PID.TID 0000.0001) %MON dynstat_eta_mean             =  -5.1587176101829E-01
+(PID.TID 0000.0001) %MON dynstat_eta_sd               =   6.1142533727477E-01
+(PID.TID 0000.0001) %MON dynstat_eta_del2             =   2.3752778367485E-03
+(PID.TID 0000.0001) %MON dynstat_uvel_max             =   1.3229128585363E-01
+(PID.TID 0000.0001) %MON dynstat_uvel_min             =  -6.0005880892277E-02
+(PID.TID 0000.0001) %MON dynstat_uvel_mean            =   7.6103312429381E-03
+(PID.TID 0000.0001) %MON dynstat_uvel_sd              =   1.4706749526433E-02
+(PID.TID 0000.0001) %MON dynstat_uvel_del2            =   1.6149725675726E-04
+(PID.TID 0000.0001) %MON dynstat_vvel_max             =   1.3020377539174E-01
+(PID.TID 0000.0001) %MON dynstat_vvel_min             =  -8.8402110726863E-02
+(PID.TID 0000.0001) %MON dynstat_vvel_mean            =   9.1197097927159E-04
+(PID.TID 0000.0001) %MON dynstat_vvel_sd              =   8.5038229349660E-03
+(PID.TID 0000.0001) %MON dynstat_vvel_del2            =   1.0604696742966E-04
+(PID.TID 0000.0001) %MON dynstat_wvel_max             =   5.5072411404962E-05
+(PID.TID 0000.0001) %MON dynstat_wvel_min             =  -1.4052859622017E-04
+(PID.TID 0000.0001) %MON dynstat_wvel_mean            =  -2.4320536324694E-07
+(PID.TID 0000.0001) %MON dynstat_wvel_sd              =   5.4558857007693E-06
+(PID.TID 0000.0001) %MON dynstat_wvel_del2            =   1.4087891938884E-07
+(PID.TID 0000.0001) %MON dynstat_theta_max            =   2.4322649951257E+01
+(PID.TID 0000.0001) %MON dynstat_theta_min            =  -2.8965031130308E+00
+(PID.TID 0000.0001) %MON dynstat_theta_mean           =   2.3247721883562E+00
+(PID.TID 0000.0001) %MON dynstat_theta_sd             =   3.2191682574255E+00
+(PID.TID 0000.0001) %MON dynstat_theta_del2           =   6.6193985504276E-03
+(PID.TID 0000.0001) %MON dynstat_salt_max             =   3.6602560423703E+01
+(PID.TID 0000.0001) %MON dynstat_salt_min             =   3.3071971867600E+01
+(PID.TID 0000.0001) %MON dynstat_salt_mean            =   3.4483940892459E+01
+(PID.TID 0000.0001) %MON dynstat_salt_sd              =   1.9652954654874E-01
+(PID.TID 0000.0001) %MON dynstat_salt_del2            =   1.1529285753811E-03
+(PID.TID 0000.0001) %MON forcing_qnet_max             =   6.8614881896973E+01
+(PID.TID 0000.0001) %MON forcing_qnet_min             =  -2.0936358337402E+02
+(PID.TID 0000.0001) %MON forcing_qnet_mean            =  -1.1872922363993E+02
+(PID.TID 0000.0001) %MON forcing_qnet_sd              =   4.3519904575408E+01
+(PID.TID 0000.0001) %MON forcing_qnet_del2            =   8.4663667354220E-01
+(PID.TID 0000.0001) %MON forcing_qsw_max              =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON forcing_qsw_min              =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON forcing_qsw_mean             =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON forcing_qsw_sd               =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON forcing_qsw_del2             =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON forcing_empmr_max            =   2.5141471127199E-05
+(PID.TID 0000.0001) %MON forcing_empmr_min            =  -3.9761445691511E-05
+(PID.TID 0000.0001) %MON forcing_empmr_mean           =  -9.3236499820974E-06
+(PID.TID 0000.0001) %MON forcing_empmr_sd             =   1.0249687273683E-05
+(PID.TID 0000.0001) %MON forcing_empmr_del2           =   9.8755541425843E-08
+(PID.TID 0000.0001) %MON forcing_fu_max               =   2.1329242214561E-01
+(PID.TID 0000.0001) %MON forcing_fu_min               =  -9.4279526919127E-02
+(PID.TID 0000.0001) %MON forcing_fu_mean              =   7.5199349186540E-02
+(PID.TID 0000.0001) %MON forcing_fu_sd                =   7.1557633169571E-02
+(PID.TID 0000.0001) %MON forcing_fu_del2              =   5.6083412558175E-04
+(PID.TID 0000.0001) %MON forcing_fv_max               =   1.4840247556567E-01
+(PID.TID 0000.0001) %MON forcing_fv_min               =  -7.6181074604392E-02
+(PID.TID 0000.0001) %MON forcing_fv_mean              =  -1.9061220682252E-02
+(PID.TID 0000.0001) %MON forcing_fv_sd                =   3.3461268482461E-02
+(PID.TID 0000.0001) %MON forcing_fv_del2              =   3.7216210294159E-04
+(PID.TID 0000.0001) %MON trAdv_CFL_u_max              =   8.8656915856445E-02
+(PID.TID 0000.0001) %MON trAdv_CFL_v_max              =   2.7295590561753E-02
+(PID.TID 0000.0001) %MON trAdv_CFL_w_max              =   6.0832153044100E-02
+(PID.TID 0000.0001) %MON advcfl_uvel_max              =   3.4162827149630E-02
+(PID.TID 0000.0001) %MON advcfl_vvel_max              =   1.7988626020349E-02
+(PID.TID 0000.0001) %MON advcfl_wvel_max              =   1.6632425634825E-02
+(PID.TID 0000.0001) %MON advcfl_W_hf_max              =   1.7855398107974E-02
+(PID.TID 0000.0001) %MON pe_b_mean                    =   8.6226167350384E-04
+(PID.TID 0000.0001) %MON ke_max                       =   9.4860880054333E-03
+(PID.TID 0000.0001) %MON ke_mean                      =   1.6465658681107E-04
+(PID.TID 0000.0001) %MON ke_vol                       =   1.2769337095763E+17
+(PID.TID 0000.0001) %MON vort_r_min                   =  -4.7387570898137E-07
+(PID.TID 0000.0001) %MON vort_r_max                   =   7.0858610076746E-07
+(PID.TID 0000.0001) %MON vort_a_mean                  =  -1.0457492184410E-04
+(PID.TID 0000.0001) %MON vort_a_sd                    =   2.1292715264401E-05
+(PID.TID 0000.0001) %MON vort_p_mean                  =  -1.2574623877598E-04
+(PID.TID 0000.0001) %MON vort_p_sd                    =   1.1183801085560E-04
+(PID.TID 0000.0001) %MON surfExpan_theta_mean         =  -1.0081652361944E-07
+(PID.TID 0000.0001) %MON surfExpan_salt_mean          =   1.7523576523517E-07
+(PID.TID 0000.0001) // =======================================================
+(PID.TID 0000.0001) // End MONITOR dynamic field statistics
+(PID.TID 0000.0001) // =======================================================
+(PID.TID 0000.0001) // =======================================================
+(PID.TID 0000.0001) // Begin OBCS MONITOR field statistics
+(PID.TID 0000.0001) // =======================================================
+(PID.TID 0000.0001) %MON obc_E_uVel_max               =   8.2887890438239E-02
+(PID.TID 0000.0001) %MON obc_E_uVel_min               =  -6.0005880892277E-02
+(PID.TID 0000.0001) %MON obc_E_uVel_mean              =   7.3481638628970E-03
+(PID.TID 0000.0001) %MON obc_E_uVel_sd                =   1.4306979468011E-02
+(PID.TID 0000.0001) %MON obc_E_uVel_Int               =   1.2598139394366E+08
+(PID.TID 0000.0001) %MON obc_W_uVel_max               =   6.0183299084504E-02
+(PID.TID 0000.0001) %MON obc_W_uVel_min               =  -2.5750120480855E-02
+(PID.TID 0000.0001) %MON obc_W_uVel_mean              =   6.9799178140749E-03
+(PID.TID 0000.0001) %MON obc_W_uVel_sd                =   1.1143820768569E-02
+(PID.TID 0000.0001) %MON obc_W_uVel_Int               =   1.3044964329075E+08
+(PID.TID 0000.0001) %MON obc_N_vVel_max               =   4.6934620787700E-02
+(PID.TID 0000.0001) %MON obc_N_vVel_min               =  -7.0970798532168E-02
+(PID.TID 0000.0001) %MON obc_N_vVel_mean              =   1.4762267691452E-04
+(PID.TID 0000.0001) %MON obc_N_vVel_sd                =   6.4285541565376E-03
+(PID.TID 0000.0001) %MON obc_N_vVel_Int               =   4.3155788504734E+06
+(PID.TID 0000.0001) %MON obc_E_theta_max              =   1.9398851394653E+01
+(PID.TID 0000.0001) %MON obc_E_theta_min              =  -1.5564284722010E+00
+(PID.TID 0000.0001) %MON obc_E_theta_mean             =   1.9093663966602E+00
+(PID.TID 0000.0001) %MON obc_E_theta_sd               =   2.9699987672955E+00
+(PID.TID 0000.0001) %MON obc_W_theta_max              =   2.1606541951497E+01
+(PID.TID 0000.0001) %MON obc_W_theta_min              =  -1.4425850311915E+00
+(PID.TID 0000.0001) %MON obc_W_theta_mean             =   2.4675739840607E+00
+(PID.TID 0000.0001) %MON obc_W_theta_sd               =   2.9646670151341E+00
+(PID.TID 0000.0001) %MON obc_N_theta_max              =   2.4181515375773E+01
+(PID.TID 0000.0001) %MON obc_N_theta_min              =  -6.3544931014379E-01
+(PID.TID 0000.0001) %MON obc_N_theta_mean             =   4.8731396883099E+00
+(PID.TID 0000.0001) %MON obc_N_theta_sd               =   4.7097877746890E+00
+(PID.TID 0000.0001) // =======================================================
+(PID.TID 0000.0001) // End OBCS MONITOR field statistics
+(PID.TID 0000.0001) // =======================================================
+(PID.TID 0000.0001) // =======================================================
+(PID.TID 0000.0001) // Begin MONITOR ptracer field statistics
+(PID.TID 0000.0001) // =======================================================
+(PID.TID 0000.0001) %MON trcstat_ptracer01_max        =   2.3591452052478E+00
+(PID.TID 0000.0001) %MON trcstat_ptracer01_min        =   1.9365728623028E+00
+(PID.TID 0000.0001) %MON trcstat_ptracer01_mean       =   2.2425151009874E+00
+(PID.TID 0000.0001) %MON trcstat_ptracer01_sd         =   7.6017048660225E-02
+(PID.TID 0000.0001) %MON trcstat_ptracer01_del2       =   1.0616396656959E-04
+(PID.TID 0000.0001) %MON trcstat_ptracer02_max        =   2.4116881965466E+00
+(PID.TID 0000.0001) %MON trcstat_ptracer02_min        =   2.1902762049508E+00
+(PID.TID 0000.0001) %MON trcstat_ptracer02_mean       =   2.3520477380047E+00
+(PID.TID 0000.0001) %MON trcstat_ptracer02_sd         =   3.5089744984834E-02
+(PID.TID 0000.0001) %MON trcstat_ptracer02_del2       =   8.0568181181900E-05
+(PID.TID 0000.0001) %MON trcstat_ptracer03_max        =   2.7654982933499E-03
+(PID.TID 0000.0001) %MON trcstat_ptracer03_min        =   4.7000348252381E-05
+(PID.TID 0000.0001) %MON trcstat_ptracer03_mean       =   2.0555855624018E-03
+(PID.TID 0000.0001) %MON trcstat_ptracer03_sd         =   5.0338880807836E-04
+(PID.TID 0000.0001) %MON trcstat_ptracer03_del2       =   6.6762191054504E-07
+(PID.TID 0000.0001) %MON trcstat_ptracer04_max        =   2.5992982256490E-04
+(PID.TID 0000.0001) %MON trcstat_ptracer04_min        =  -7.8225528728462E-07
+(PID.TID 0000.0001) %MON trcstat_ptracer04_mean       =   6.2815338882793E-06
+(PID.TID 0000.0001) %MON trcstat_ptracer04_sd         =   2.6493676981253E-05
+(PID.TID 0000.0001) %MON trcstat_ptracer04_del2       =   1.3390690975716E-07
+(PID.TID 0000.0001) %MON trcstat_ptracer05_max        =   3.8392749043023E-01
+(PID.TID 0000.0001) %MON trcstat_ptracer05_min        =   8.2473302296527E-02
+(PID.TID 0000.0001) %MON trcstat_ptracer05_mean       =   2.1411420038195E-01
+(PID.TID 0000.0001) %MON trcstat_ptracer05_sd         =   4.3028416473433E-02
+(PID.TID 0000.0001) %MON trcstat_ptracer05_del2       =   1.1723518895981E-04
+(PID.TID 0000.0001) // =======================================================
+(PID.TID 0000.0001) // End MONITOR ptracer field statistics
+(PID.TID 0000.0001) // =======================================================
+ Computing Diagnostic #     46  VVELMASS     Counter:      10   Parms: VVr     MR      
+           Vector  Mate for  VVELMASS     Diagnostic #     45  UVELMASS exists 
+ Computing Diagnostic #     45  UVELMASS     Counter:      10   Parms: UUr     MR      
+           Vector  Mate for  UVELMASS     Diagnostic #     46  VVELMASS exists 
+ Computing Diagnostic #     26  THETA        Counter:      10   Parms: SMR     MR      
+ Computing Diagnostic #     27  SALT         Counter:      10   Parms: SMR     MR      
+ Computing Diagnostic #    204  GM_PsiX      Counter:      10   Parms: UU      LR      
+           Vector  Mate for  GM_PsiX      Diagnostic #    205  GM_PsiY  exists 
+ Computing Diagnostic #    205  GM_PsiY      Counter:      10   Parms: VV      LR      
+           Vector  Mate for  GM_PsiY      Diagnostic #    204  GM_PsiX  exists 
+ Post-Processing Diag #     48  PhiVEL     Parms: SMR P   MR      
+   from diag: UVELMASS (#    45) Cnt=      10 and diag: VVELMASS (#    46) Cnt=      10
+ diag_cg2d (it=       10) a2dNorm,x2dNorm= 4.382025E-03 , 2.580578E+03 ; Criter= 1.00E-13
+ diag_cg2d : k=   1 , it=   118   119 ; ini,min,last_Res= 4.6401048E+00 1.3836641E-13 8.3280875E-14
+ diag_calc_psivel: bi,bj=   1   1 : npass,nPts=     1     154
+ diag_calc_psivel:            is,js=   2   1 ; ix,jx=  15   1 ; iy,jy=   2  11
+ diag_calc_psivel: bi,bj=   2   1 : npass,nPts=     1     165
+ diag_calc_psivel:            is,js=   1   1 ; ix,jx=  15   1 ; iy,jy=   1  11
+ diag_calc_psivel: bi,bj=   3   1 : npass,nPts=     1     154
+ diag_calc_psivel:            is,js=   1   1 ; ix,jx=  14   1 ; iy,jy=   1  11
+ diag_calc_psivel: bi,bj=   1   2 : npass,nPts=     1     140
+ diag_calc_psivel:            is,js=   2   1 ; ix,jx=  15   1 ; iy,jy=   2  10
+ diag_calc_psivel: bi,bj=   2   2 : npass,nPts=     1     150
+ diag_calc_psivel:            is,js=   1   1 ; ix,jx=  15   1 ; iy,jy=   1  10
+ diag_calc_psivel: bi,bj=   3   2 : npass,nPts=     1     140
+ diag_calc_psivel:            is,js=   1   1 ; ix,jx=  14   1 ; iy,jy=   1  10
+ diag_cg2d : k=   2 , it=   117   118 ; ini,min,last_Res= 3.4623535E+00 1.3351191E-13 7.9137454E-14
+ diag_cg2d : k=   3 , it=   115   116 ; ini,min,last_Res= 1.9802671E+00 1.2528812E-13 7.5702565E-14
+ diag_cg2d : k=   4 , it=   113   114 ; ini,min,last_Res= 2.1004367E+00 1.3088947E-13 6.7517396E-14
+ diag_cg2d : k=   5 , it=   114   115 ; ini,min,last_Res= 2.7419337E+00 1.1731228E-13 5.9478770E-14
+ diag_cg2d : k=   6 , it=   107   108 ; ini,min,last_Res= 1.9661365E+00 1.4552646E-13 8.7440467E-14
+ diag_cg2d : k=   7 , it=   108   109 ; ini,min,last_Res= 2.4720610E+00 1.3433339E-13 6.6274345E-14
+ diag_cg2d : k=   8 , it=   106   107 ; ini,min,last_Res= 2.0341515E+00 1.0865842E-13 6.1845582E-14
+ diag_cg2d : k=   9 , it=   106   107 ; ini,min,last_Res= 2.0921677E+00 1.5951575E-13 8.6497473E-14
+ diag_cg2d : k=  10 , it=   106   107 ; ini,min,last_Res= 1.9862873E+00 1.5872005E-13 8.1157636E-14
+ diag_cg2d : k=  11 , it=   107   108 ; ini,min,last_Res= 2.2278394E+00 1.1529770E-13 6.8774709E-14
+ diag_cg2d : k=  12 , it=   113   114 ; ini,min,last_Res= 2.2733609E+00 1.7056513E-13 9.7881950E-14
+ diag_cg2d : k=  13 , it=    93    94 ; ini,min,last_Res= 2.3369813E+00 1.1754064E-13 5.0199351E-14
+ diag_cg2d : k=  14 , it=    76    77 ; ini,min,last_Res= 1.9509990E+00 1.7733845E-13 9.3994883E-14
+ diag_cg2d : k=  15 , it=    46    47 ; ini,min,last_Res= 1.6967056E+00 1.2685517E-13 6.7570091E-14
+  get Post-Proc. Diag #     49  PsiVEL   from previous computation of Diag #     48
+ Computing Diagnostic #     78  CONVADJ      Counter:      10   Parms: SMR     LR      
+ Compute Stats, Diag. #     23  ETAN      vol(   0 ): 3.508E+14  Parms: SM      M1      
+ Compute Stats, Diag. #     25  DETADT2   vol(   0 ): 3.508E+14  Parms: SM      M1      
+ Compute Stats, Diag. #     26  THETA     vol(   0 ): 1.277E+18  Parms: SMR     MR      
+ Compute Stats, Diag. #     27  SALT      vol(   0 ): 1.277E+18  Parms: SMR     MR      
+ Compute Stats, Diag. #     78  CONVADJ   vol(   0 ): 1.242E+18  Parms: SMR     LR      
+ Compute Stats, Diag. #     30  UVEL      vol(   0 ): 1.242E+18  Parms: UUR     MR      
+ Compute Stats, Diag. #     31  VVEL      vol(   0 ): 1.225E+18  Parms: VVR     MR      
+ Compute Stats, Diag. #     32  WVEL      vol(   0 ): 1.242E+18  Parms: WM      LR      
+ Compute Stats, Diag. #    204  GM_PsiX   vol(   0 ): 1.211E+18  Parms: UU      LR      
+ Compute Stats, Diag. #    205  GM_PsiY   vol(   0 ): 1.200E+18  Parms: VV      LR      
+ Compute Stats, Diag. #    213  TRAC01    vol(   0 ): 1.277E+18  Parms: SMR     MR      
+ Compute Stats, Diag. #    227  TRAC02    vol(   0 ): 1.277E+18  Parms: SMR     MR      
+ Compute Stats, Diag. #    241  TRAC03    vol(   0 ): 1.277E+18  Parms: SMR     MR      
+ Compute Stats, Diag. #    255  TRAC04    vol(   0 ): 1.277E+18  Parms: SMR     MR      
+ Compute Stats, Diag. #    269  TRAC05    vol(   0 ): 1.277E+18  Parms: SMR     MR      
+ Compute Stats, Diag. #    291  DIC3DSIT  vol(   0 ): 1.277E+18  Parms: SMRP    MR      
+ Compute Stats, Diag. #    292  OMEGAC    vol(   0 ): 1.277E+18  Parms: SMRP    MR      
+ Compute Stats, Diag. #    293  DIC3DPH   vol(   0 ): 1.277E+18  Parms: SM P    MR      
+ Compute Stats, Diag. #    294  DIC3DPCO  vol(   0 ): 1.277E+18  Parms: SMRP    MR      
+ Compute Stats, Diag. #    295  DIC3DCO3  vol(   0 ): 1.277E+18  Parms: SMRP    MR      
+(PID.TID 0000.0001) DIAGSTATS_CLOSE_IO: close file: dynStDiag.0000000000.txt , unit=     9
+(PID.TID 0000.0001) %CHECKPOINT        10 ckptA
+(PID.TID 0000.0001)   Seconds in section "ALL                    [THE_MODEL_MAIN]":
+(PID.TID 0000.0001)           User time:   6.9647440910339355
+(PID.TID 0000.0001)         System time:   6.5347000723704696E-002
+(PID.TID 0000.0001)     Wall clock time:   7.0341498851776123
+(PID.TID 0000.0001)          No. starts:           1
+(PID.TID 0000.0001)           No. stops:           1
+(PID.TID 0000.0001)   Seconds in section "INITIALISE_FIXED       [THE_MODEL_MAIN]":
+(PID.TID 0000.0001)           User time:   3.8306001573801041E-002
+(PID.TID 0000.0001)         System time:   2.0370999583974481E-002
+(PID.TID 0000.0001)     Wall clock time:   5.8680057525634766E-002
+(PID.TID 0000.0001)          No. starts:           1
+(PID.TID 0000.0001)           No. stops:           1
+(PID.TID 0000.0001)   Seconds in section "THE_MAIN_LOOP          [THE_MODEL_MAIN]":
+(PID.TID 0000.0001)           User time:   6.9264229834079742
+(PID.TID 0000.0001)         System time:   4.4945001602172852E-002
+(PID.TID 0000.0001)     Wall clock time:   6.9754350185394287
+(PID.TID 0000.0001)          No. starts:           1
+(PID.TID 0000.0001)           No. stops:           1
+(PID.TID 0000.0001)   Seconds in section "INITIALISE_VARIA    [THE_MAIN_LOOP]":
+(PID.TID 0000.0001)           User time:   8.4157001227140427E-002
+(PID.TID 0000.0001)         System time:   2.0475000143051147E-002
+(PID.TID 0000.0001)     Wall clock time:  0.10468506813049316
+(PID.TID 0000.0001)          No. starts:           1
+(PID.TID 0000.0001)           No. stops:           1
+(PID.TID 0000.0001)   Seconds in section "MAIN LOOP           [THE_MAIN_LOOP]":
+(PID.TID 0000.0001)           User time:   6.8422439247369766
+(PID.TID 0000.0001)         System time:   2.4464003741741180E-002
+(PID.TID 0000.0001)     Wall clock time:   6.8707249164581299
+(PID.TID 0000.0001)          No. starts:           1
+(PID.TID 0000.0001)           No. stops:           1
+(PID.TID 0000.0001)   Seconds in section "MAIN_DO_LOOP        [THE_MAIN_LOOP]":
+(PID.TID 0000.0001)           User time:   6.8421610966324806
+(PID.TID 0000.0001)         System time:   2.4462003260850906E-002
+(PID.TID 0000.0001)     Wall clock time:   6.8706371784210205
+(PID.TID 0000.0001)          No. starts:          10
+(PID.TID 0000.0001)           No. stops:          10
+(PID.TID 0000.0001)   Seconds in section "FORWARD_STEP        [MAIN_DO_LOOP]":
+(PID.TID 0000.0001)           User time:   6.8420025631785393
+(PID.TID 0000.0001)         System time:   2.4459004402160645E-002
+(PID.TID 0000.0001)     Wall clock time:   6.8704802989959717
+(PID.TID 0000.0001)          No. starts:          10
+(PID.TID 0000.0001)           No. stops:          10
+(PID.TID 0000.0001)   Seconds in section "DO_STATEVARS_DIAGS  [FORWARD_STEP]":
+(PID.TID 0000.0001)           User time:   9.2992231249809265E-002
+(PID.TID 0000.0001)         System time:   3.8300082087516785E-004
+(PID.TID 0000.0001)     Wall clock time:   9.3419551849365234E-002
+(PID.TID 0000.0001)          No. starts:          20
+(PID.TID 0000.0001)           No. stops:          20
+(PID.TID 0000.0001)   Seconds in section "LOAD_FIELDS_DRIVER  [FORWARD_STEP]":
+(PID.TID 0000.0001)           User time:   1.4354526996612549E-002
+(PID.TID 0000.0001)         System time:   4.9993395805358887E-006
+(PID.TID 0000.0001)     Wall clock time:   1.4362573623657227E-002
+(PID.TID 0000.0001)          No. starts:          10
+(PID.TID 0000.0001)           No. stops:          10
+(PID.TID 0000.0001)   Seconds in section "EXTERNAL_FLDS_LOAD [LOAD_FLDS_DRIVER]":
+(PID.TID 0000.0001)           User time:   3.9075613021850586E-003
+(PID.TID 0000.0001)         System time:   0.0000000000000000
+(PID.TID 0000.0001)     Wall clock time:   3.9122104644775391E-003
+(PID.TID 0000.0001)          No. starts:          10
+(PID.TID 0000.0001)           No. stops:          10
+(PID.TID 0000.0001)   Seconds in section "DO_ATMOSPHERIC_PHYS [FORWARD_STEP]":
+(PID.TID 0000.0001)           User time:   8.6545944213867188E-005
+(PID.TID 0000.0001)         System time:   0.0000000000000000
+(PID.TID 0000.0001)     Wall clock time:   8.8691711425781250E-005
+(PID.TID 0000.0001)          No. starts:          10
+(PID.TID 0000.0001)           No. stops:          10
+(PID.TID 0000.0001)   Seconds in section "DO_OCEANIC_PHYS     [FORWARD_STEP]":
+(PID.TID 0000.0001)           User time:  0.34521125257015228
+(PID.TID 0000.0001)         System time:   1.8998980522155762E-005
+(PID.TID 0000.0001)     Wall clock time:  0.34527325630187988
+(PID.TID 0000.0001)          No. starts:          10
+(PID.TID 0000.0001)           No. stops:          10
+(PID.TID 0000.0001)   Seconds in section "THERMODYNAMICS      [FORWARD_STEP]":
+(PID.TID 0000.0001)           User time:   2.8180139809846878
+(PID.TID 0000.0001)         System time:   3.4999102354049683E-005
+(PID.TID 0000.0001)     Wall clock time:   2.8198080062866211
+(PID.TID 0000.0001)          No. starts:          10
+(PID.TID 0000.0001)           No. stops:          10
+(PID.TID 0000.0001)   Seconds in section "DYNAMICS            [FORWARD_STEP]":
+(PID.TID 0000.0001)           User time:  0.56629127264022827
+(PID.TID 0000.0001)         System time:   1.6000121831893921E-005
+(PID.TID 0000.0001)     Wall clock time:  0.56672358512878418
+(PID.TID 0000.0001)          No. starts:          10
+(PID.TID 0000.0001)           No. stops:          10
+(PID.TID 0000.0001)   Seconds in section "SOLVE_FOR_PRESSURE  [FORWARD_STEP]":
+(PID.TID 0000.0001)           User time:  0.20636498928070068
+(PID.TID 0000.0001)         System time:   3.5002827644348145E-005
+(PID.TID 0000.0001)     Wall clock time:  0.20645356178283691
+(PID.TID 0000.0001)          No. starts:          10
+(PID.TID 0000.0001)           No. stops:          10
+(PID.TID 0000.0001)   Seconds in section "MOM_CORRECTION_STEP [FORWARD_STEP]":
+(PID.TID 0000.0001)           User time:   2.8114140033721924E-002
+(PID.TID 0000.0001)         System time:   0.0000000000000000
+(PID.TID 0000.0001)     Wall clock time:   2.8125286102294922E-002
+(PID.TID 0000.0001)          No. starts:          10
+(PID.TID 0000.0001)           No. stops:          10
+(PID.TID 0000.0001)   Seconds in section "INTEGR_CONTINUITY   [FORWARD_STEP]":
+(PID.TID 0000.0001)           User time:   3.6823451519012451E-002
+(PID.TID 0000.0001)         System time:   0.0000000000000000
+(PID.TID 0000.0001)     Wall clock time:   3.6845445632934570E-002
+(PID.TID 0000.0001)          No. starts:          10
+(PID.TID 0000.0001)           No. stops:          10
+(PID.TID 0000.0001)   Seconds in section "TRC_CORRECTION_STEP [FORWARD_STEP]":
+(PID.TID 0000.0001)           User time:   9.7811222076416016E-005
+(PID.TID 0000.0001)         System time:   0.0000000000000000
+(PID.TID 0000.0001)     Wall clock time:   9.5605850219726562E-005
+(PID.TID 0000.0001)          No. starts:          10
+(PID.TID 0000.0001)           No. stops:          10
+(PID.TID 0000.0001)   Seconds in section "GCHEM_FORCING_SEP  [FORWARD_STEP]":
+(PID.TID 0000.0001)           User time:   1.9307047724723816
+(PID.TID 0000.0001)         System time:   0.0000000000000000
+(PID.TID 0000.0001)     Wall clock time:   1.9322307109832764
+(PID.TID 0000.0001)          No. starts:          10
+(PID.TID 0000.0001)           No. stops:          10
+(PID.TID 0000.0001)   Seconds in section "BLOCKING_EXCHANGES  [FORWARD_STEP]":
+(PID.TID 0000.0001)           User time:   6.1262726783752441E-002
+(PID.TID 0000.0001)         System time:   0.0000000000000000
+(PID.TID 0000.0001)     Wall clock time:   6.1310768127441406E-002
+(PID.TID 0000.0001)          No. starts:          10
+(PID.TID 0000.0001)           No. stops:          10
+(PID.TID 0000.0001)   Seconds in section "MONITOR             [FORWARD_STEP]":
+(PID.TID 0000.0001)           User time:  0.15578538179397583
+(PID.TID 0000.0001)         System time:   2.0004808902740479E-006
+(PID.TID 0000.0001)     Wall clock time:  0.15581560134887695
+(PID.TID 0000.0001)          No. starts:          10
+(PID.TID 0000.0001)           No. stops:          10
+(PID.TID 0000.0001)   Seconds in section "DO_THE_MODEL_IO     [FORWARD_STEP]":
+(PID.TID 0000.0001)           User time:  0.57006824016571045
+(PID.TID 0000.0001)         System time:   1.9959997385740280E-002
+(PID.TID 0000.0001)     Wall clock time:  0.59040403366088867
+(PID.TID 0000.0001)          No. starts:          10
+(PID.TID 0000.0001)           No. stops:          10
+(PID.TID 0000.0001)   Seconds in section "PTRACERS_RESET      [FORWARD_STEP]":
+(PID.TID 0000.0001)           User time:   1.1163949966430664E-004
+(PID.TID 0000.0001)         System time:   0.0000000000000000
+(PID.TID 0000.0001)     Wall clock time:   1.1181831359863281E-004
+(PID.TID 0000.0001)          No. starts:          10
+(PID.TID 0000.0001)           No. stops:          10
+(PID.TID 0000.0001)   Seconds in section "DO_WRITE_PICKUP     [FORWARD_STEP]":
+(PID.TID 0000.0001)           User time:   1.3774216175079346E-002
+(PID.TID 0000.0001)         System time:   3.9750039577484131E-003
+(PID.TID 0000.0001)     Wall clock time:   1.7751216888427734E-002
+(PID.TID 0000.0001)          No. starts:          10
+(PID.TID 0000.0001)           No. stops:          10
+(PID.TID 0000.0001) // ======================================================
+(PID.TID 0000.0001) // Tile <-> Tile communication statistics
+(PID.TID 0000.0001) // ======================================================
+(PID.TID 0000.0001) // o Tile number: 000001
+(PID.TID 0000.0001) //         No. X exchanges =              0
+(PID.TID 0000.0001) //            Max. X spins =              0
+(PID.TID 0000.0001) //            Min. X spins =     1000000000
+(PID.TID 0000.0001) //          Total. X spins =              0
+(PID.TID 0000.0001) //            Avg. X spins =       0.00E+00
+(PID.TID 0000.0001) //         No. Y exchanges =              0
+(PID.TID 0000.0001) //            Max. Y spins =              0
+(PID.TID 0000.0001) //            Min. Y spins =     1000000000
+(PID.TID 0000.0001) //          Total. Y spins =              0
+(PID.TID 0000.0001) //            Avg. Y spins =       0.00E+00
+(PID.TID 0000.0001) // o Tile number: 000002
+(PID.TID 0000.0001) //         No. X exchanges =              0
+(PID.TID 0000.0001) //            Max. X spins =              0
+(PID.TID 0000.0001) //            Min. X spins =     1000000000
+(PID.TID 0000.0001) //          Total. X spins =              0
+(PID.TID 0000.0001) //            Avg. X spins =       0.00E+00
+(PID.TID 0000.0001) //         No. Y exchanges =              0
+(PID.TID 0000.0001) //            Max. Y spins =              0
+(PID.TID 0000.0001) //            Min. Y spins =     1000000000
+(PID.TID 0000.0001) //          Total. Y spins =              0
+(PID.TID 0000.0001) //            Avg. Y spins =       0.00E+00
+(PID.TID 0000.0001) // o Tile number: 000003
+(PID.TID 0000.0001) //         No. X exchanges =              0
+(PID.TID 0000.0001) //            Max. X spins =              0
+(PID.TID 0000.0001) //            Min. X spins =     1000000000
+(PID.TID 0000.0001) //          Total. X spins =              0
+(PID.TID 0000.0001) //            Avg. X spins =       0.00E+00
+(PID.TID 0000.0001) //         No. Y exchanges =              0
+(PID.TID 0000.0001) //            Max. Y spins =              0
+(PID.TID 0000.0001) //            Min. Y spins =     1000000000
+(PID.TID 0000.0001) //          Total. Y spins =              0
+(PID.TID 0000.0001) //            Avg. Y spins =       0.00E+00
+(PID.TID 0000.0001) // o Tile number: 000004
+(PID.TID 0000.0001) //         No. X exchanges =              0
+(PID.TID 0000.0001) //            Max. X spins =              0
+(PID.TID 0000.0001) //            Min. X spins =     1000000000
+(PID.TID 0000.0001) //          Total. X spins =              0
+(PID.TID 0000.0001) //            Avg. X spins =       0.00E+00
+(PID.TID 0000.0001) //         No. Y exchanges =              0
+(PID.TID 0000.0001) //            Max. Y spins =              0
+(PID.TID 0000.0001) //            Min. Y spins =     1000000000
+(PID.TID 0000.0001) //          Total. Y spins =              0
+(PID.TID 0000.0001) //            Avg. Y spins =       0.00E+00
+(PID.TID 0000.0001) // o Tile number: 000005
+(PID.TID 0000.0001) //         No. X exchanges =              0
+(PID.TID 0000.0001) //            Max. X spins =              0
+(PID.TID 0000.0001) //            Min. X spins =     1000000000
+(PID.TID 0000.0001) //          Total. X spins =              0
+(PID.TID 0000.0001) //            Avg. X spins =       0.00E+00
+(PID.TID 0000.0001) //         No. Y exchanges =              0
+(PID.TID 0000.0001) //            Max. Y spins =              0
+(PID.TID 0000.0001) //            Min. Y spins =     1000000000
+(PID.TID 0000.0001) //          Total. Y spins =              0
+(PID.TID 0000.0001) //            Avg. Y spins =       0.00E+00
+(PID.TID 0000.0001) // o Tile number: 000006
+(PID.TID 0000.0001) //         No. X exchanges =              0
+(PID.TID 0000.0001) //            Max. X spins =              0
+(PID.TID 0000.0001) //            Min. X spins =     1000000000
+(PID.TID 0000.0001) //          Total. X spins =              0
+(PID.TID 0000.0001) //            Avg. X spins =       0.00E+00
+(PID.TID 0000.0001) //         No. Y exchanges =              0
+(PID.TID 0000.0001) //            Max. Y spins =              0
+(PID.TID 0000.0001) //            Min. Y spins =     1000000000
+(PID.TID 0000.0001) //          Total. Y spins =              0
+(PID.TID 0000.0001) //            Avg. Y spins =       0.00E+00
+(PID.TID 0000.0001) // o Thread number: 000001
+(PID.TID 0000.0001) //            No. barriers =          21532
+(PID.TID 0000.0001) //      Max. barrier spins =              1
+(PID.TID 0000.0001) //      Min. barrier spins =              1
+(PID.TID 0000.0001) //     Total barrier spins =          21532
+(PID.TID 0000.0001) //      Avg. barrier spins =       1.00E+00
+PROGRAM MAIN: Execution ended Normally

--- a/verification/tutorial_dic_adjoffline/code_ad/DIC_OPTIONS.h
+++ b/verification/tutorial_dic_adjoffline/code_ad/DIC_OPTIONS.h
@@ -6,6 +6,19 @@
 #ifdef ALLOW_DIC
 C     Package-specific Options & Macros go here
 
+C ABIOTIC OPTIONS
+C Compile Munhoven (2013) "Solvesaphe" package for pH/pCO2
+C  can still select Follows et al (2006) solver in data.dic,
+C  but will use solvesaphe dissociation coefficient options.
+#undef CARBONCHEM_SOLVESAPHE
+
+C In S/R CARBON_CHEM convert ak1 and ak2 to the total pH scale
+C  consistent with other coefficients (currently on the seawater scale).
+C NOTE: Has NO effect when CARBONCHEM_SOLVESAPHE is defined (different
+C  coeffs are used).
+#undef CARBONCHEM_TOTALPHSCALE
+
+C BIOTIC OPTIONS
 #define DIC_BIOTIC
 #define ALLOW_O2
 #define ALLOW_FE
@@ -25,15 +38,16 @@ C put back bugs related to Water-Vapour in carbonate chemistry & air-sea fluxes
 #undef WATERVAP_BUG
 
 C dissolution only below saturation horizon following method by Karsten Friis
-#undef CAR_DISS
+#undef DIC_CALCITE_SAT
 
 C Include self-shading effect by phytoplankton
 #undef LIGHT_CHL
+
 C Include iron sediment source using DOP flux
 #undef SEDFE
 
 C For Adjoint built
-#define AD_SAFE
+#define DIC_AD_SAFE
 
 #endif /* ALLOW_DIC */
 #endif /* DIC_OPTIONS_H */


### PR DESCRIPTION
## What changes does this PR introduce?
This P/R addresses several modifications highlighted by issue  #678, including:
- Rename the old CPP option `CAR_DISS` to a more exact name `DIC_CALCITE_SAT` (calcium carbonate is dissolved when defined/undefined, but only the defined option uses the more mechanistic way of dissolving only when waters are undersaturated wrt omegaC.)
- 3-D silica/omegaC arrays within CPP option to streamline memory usage when not defined.
- Use the CPP option to empty `S/R calcite_saturation` and `S/R car_flux_omega_top` when it's not defined.
- add `pkg/dic` run-time parameter (`useCalciteSaturation`) to turn on/off omegaC calculation in `data.dic` once the code has been compiled.
- Change the conditional call to `S/R calcite_saturation` using a run-time parameter `calcOmegaCalciteFreq` (defaults to `deltaTClock`) with function `DIFFERENT_MULTIPLE`.
- Promote several hard-coded parameters from `S/R car_flux_omega_top` to run time `data.dic` options.
- switch order of arguments to "myTime, myIter, myThid" in few remaining pkg/dic S/R + S/R calls in pkg/gchem.
- update exp. so_box_biogeo (define `CARBONCHEM_TOTALPHSCALE` & `DIC_CALCITE_SAT`) + add 2 new secondary tests (`caSat0` & `caSat3`) with `useCalciteSaturation=T` and using 3-D silicate input file.

Still to do:
- Improve restart/first guess pH (Carry 3d pH variable/3d pH pickup?). Currently, the first guess pH is set to 7.9 and `S/R calc_pco2_approx` is iterated by `CO3itermax = 10` every time `S/R calcite_saturation` is called.

## Does this PR introduce a breaking change? 
Yes, CPP option `CAR_DISS` is depreciated. 

## Suggested addition to `tag-index`
pkg/dic: overhaul calcium carbonate dissolution.