### PR TITLE
Fix for PR #653 : add back 1 line that got accidentally removed

### DIFF
--- a/pkg/ggl90/ggl90_calc.F
+++ b/pkg/ggl90/ggl90_calc.F
@@ -782,7 +782,7 @@ C     ... across x-faces
          ENDDO
         ENDDO
 C     ... across y-faces
-
+        DO i=1-OLx,sNx+OLx
          dfy(i,1-OLy)=0. _d 0
         ENDDO
         DO j=1-OLy+1,sNy+OLy

--- a/pkg/ggl90/ggl90_calc_diff.F
+++ b/pkg/ggl90/ggl90_calc_diff.F
@@ -1,45 +1,48 @@
 #include "GGL90_OPTIONS.h"
 
+CBOP
+C     !ROUTINE: GGL90_CALC_DIFF
+
+C     !INTERFACE:
       SUBROUTINE GGL90_CALC_DIFF(
-     I        bi,bj,iMin,iMax,jMin,jMax,kArg,kSize,
+     I        bi, bj, iMin, iMax, jMin, jMax, kArg, kSize,
      U        KappaRx,
-     I        myThid)
+     I        myThid )
 
-C     /==========================================================\
+C     !DESCRIPTION:
+C     *==========================================================*
 C     | SUBROUTINE GGL90_CALC_DIFF                               |
-C     | o Add contrubution to net diffusivity from GGL90 mixing  |
-C     \==========================================================/
-      IMPLICIT NONE
+C     | o Add contribution to net diffusivity from GGL90 mixing  |
+C     *==========================================================*
 
+C     !USES:
+      IMPLICIT NONE
 C     == GLobal variables ==
 #include "SIZE.h"
 #include "EEPARAMS.h"
 #include "PARAMS.h"
-#include "DYNVARS.h"
-#include "GRID.h"
-#ifdef ALLOW_GGL90
+c#include "DYNVARS.h"
+c#include "GRID.h"
 #include "GGL90.h"
-#endif
 
-C     == Routine arguments ==
-C     bi, bj,   :: tile indices
+C     !INPUT/OUTPUT PARAMETERS:
+C     bi, bj    :: current tile indices
 C     iMin,iMax :: Range of points for which calculation is done
 C     jMin,jMax :: Range of points for which calculation is done
 C     kArg      :: = 0 -> do the k-loop here and treat all levels
 C                  > 0 -> k-loop is done outside and treat only level k=kArg
 C     kSize     :: 3rd Dimension of the vertical diffusivity array KappaRx
 C     KappaRx   :: vertical diffusivity array
-C     myThid    :: Instance number for this innvocation of GGL90_CALC_DIFF
-
-      INTEGER bi,bj,iMin,iMax,jMin,jMax,kArg,kSize
+C     myThid    :: my Thread Id number
+      INTEGER bi, bj, iMin, iMax, jMin, jMax, kArg, kSize
       _RL KappaRx(1-OLx:sNx+OLx,1-OLy:sNy+OLy,kSize)
       INTEGER myThid
 
 #ifdef ALLOW_GGL90
-
-C     == Local variables ==
-C     i,j,k     :: Loop counters
-      INTEGER i,j,k
+C     !LOCAL VARIABLES:
+C     i, j, k   :: Loop counters
+      INTEGER i, j, k
+CEOP
 
 C--   Add Vertical diffusivity contribution from GGL90
       IF ( kArg .EQ. 0 ) THEN

--- a/pkg/ggl90/ggl90_calc_visc.F
+++ b/pkg/ggl90/ggl90_calc_visc.F
@@ -1,57 +1,60 @@
 #include "GGL90_OPTIONS.h"
 
-      SUBROUTINE GGL90_CALC_VISC(
-     I        bi,bj,iMin,iMax,jMin,jMax,K,
-     U        KappaRU,KappaRV,
-     I        myThid)
-
 CBOP
+C     !ROUTINE: GGL90_CALC_VISC
+
+C     !INTERFACE:
+      SUBROUTINE GGL90_CALC_VISC(
+     I        bi, bj, iMin, iMax, jMin, jMax, k,
+     U        KappaRU, KappaRV,
+     I        myThid )
+
+C     !DESCRIPTION:
 C     *==========================================================*
 C     | SUBROUTINE GGL90_CALC_VISC                               |
-C     | o Add contrubution to net viscosity from GGL90 mixing    |
+C     | o Add contribution to net viscosity from GGL90 mixing    |
 C     *==========================================================*
-      IMPLICIT NONE
 
+C     !USES:
+      IMPLICIT NONE
 C     == GLobal variables ==
 #include "SIZE.h"
 #include "EEPARAMS.h"
 #include "PARAMS.h"
-#include "DYNVARS.h"
-#include "GRID.h"
+c#include "DYNVARS.h"
+c#include "GRID.h"
 #include "GGL90.h"
 
-C     == Routine arguments ==
-C     bi, bj, iMin, iMax, jMin, jMax - Range of points for which calculation
-C     myThid - Instance number for this innvocation of GGL90_CALC_VISC
-C
-      INTEGER bi,bj,iMin,iMax,jMin,jMax,K
-      _RL KappaRU(1-Olx:sNx+Olx,1-Oly:sNy+Oly,Nr)
-      _RL KappaRV(1-Olx:sNx+Olx,1-Oly:sNy+Oly,Nr)
+C     !INPUT/OUTPUT PARAMETERS:
+C     bi, bj    :: current tile indices
+C     iMin,iMax :: Range of points for which calculation is done
+C     jMin,jMax :: Range of points for which calculation is done
+C     k         :: current level index
+C     KappaRU   :: vertical viscosity array for U-component
+C     KappaRV   :: vertical viscosity array for V-component
+C     myThid    :: my Thread Id number
+      INTEGER bi, bj, iMin, iMax, jMin, jMax, k
+      _RL KappaRU(1-OLx:sNx+OLx,1-OLy:sNy+OLy,Nr)
+      _RL KappaRV(1-OLx:sNx+OLx,1-OLy:sNy+OLy,Nr)
       INTEGER myThid
-CEOP
 
 #ifdef ALLOW_GGL90
-
-C     == Local variables ==
-C     I, J, K - Loop counters
-      INTEGER i,j
-      _RL p4, p8, p16
-
-      p4=0.25 _d 0
-      p8=0.125 _d 0
-      p16=0.0625 _d 0
+C     !LOCAL VARIABLES:
+C     i, j      :: Loop counters
+      INTEGER i, j
+CEOP
 
       DO j=jMin,jMax
        DO i=iMin,iMax
-        KappaRU(i,j,k) = KappaRU(i,j,k) +
-     &                   (GGL90viscArU(i,j,k,bi,bj) - viscArNr(k) )
+        KappaRU(i,j,k) = KappaRU(i,j,k)
+     &                 + ( GGL90viscArU(i,j,k,bi,bj) - viscArNr(k) )
        ENDDO
       ENDDO
 
       DO j=jMin,jMax
        DO i=iMin,iMax
-        KappaRV(i,j,k) = KappaRV(i,j,k) + _maskS(i,j,k,bi,bj) *
-     &                   (GGL90viscArV(i,j,k,bi,bj) - viscArNr(k) )
+        KappaRV(i,j,k) = KappaRV(i,j,k)
+     &                 + ( GGL90viscArV(i,j,k,bi,bj) - viscArNr(k) )
        ENDDO
       ENDDO
 


### PR DESCRIPTION
This line of code got accidentally deleted in PR #653, and since it's in the untested "#ifdef ALLOW_GGL90_HORIZDIFF" part this did not get caught in testreport.

## What changes does this PR introduce?
bug fix

## What is the current behaviour? 
`ggl90_calc.F` does not compile anymore when `ALLOW_GGL90_HORIZDIFF` is defined.

## What is the new behaviour 
fixed

## Does this PR introduce a breaking change? 

## Other information:

## Suggested addition to `tag-index`
not needed if merged right after PR #653 (almost part of it)