### PR TITLE
Document diagnostics fileFlags

### DIFF
--- a/doc/outp_pkgs/outp_pkgs.rst
+++ b/doc/outp_pkgs/outp_pkgs.rst
@@ -346,6 +346,41 @@ fields at output levels 1-5. The names of diagnostics quantities are
 does time averaging every 3600. seconds, includes fields with all
 levels, and the names of diagnostics quantities are ``THETA`` and ``SALT``.
 
+The :varlink:`fileflags` parameter is explained in
+:numref:`diagnostic_fileflags`.  Only the first three characters matter.  The
+first character determines the precision of the output files.  The default is
+to use :varlink:`writeBinaryPrec`.  The second character determines whether the
+fields are to be integrated or interpolated vertically or written as is (the
+default).  The third character is used to write hFac-weighted fields.  Whether
+this is permitted is determined by a diagnostic’s parsing code, see
+:numref:`diagnostic_parsing_array` and the file available_diagnostics.log for a
+given setup:  parse(3) has to be ``'R'``, parse(5) blank and parse(9:10)
+``'MR'``.  Vorticity-point diagnostics cannot be hFac weighted.
+
+.. table:: Diagnostic fileflags
+   :name: diagnostic_fileflags
+
+   +---------------+-------+----------------------------------------------+
+   | Character pos | Value | Description                                  |
+   +===============+=======+==============================================+
+   | 1             | R     | precision: 32 bits                           |
+   +---------------+-------+----------------------------------------------+
+   |               | D     | precision: 64 bits                           |
+   +---------------+-------+----------------------------------------------+
+   |               |       | precision: writeBinaryPrec                   |
+   +---------------+-------+----------------------------------------------+
+   | 2             | I     | integrate vertically                         |
+   +---------------+-------+----------------------------------------------+
+   |               | P     | interpolate vertically                       |
+   +---------------+-------+----------------------------------------------+
+   |               |       | do not integrate or interpolate              |
+   +---------------+-------+----------------------------------------------+
+   | 3             | h     | cumulate hFac-weighted fields (if permitted) |
+   +---------------+-------+----------------------------------------------+
+   |               |       | do not include hFac                          |
+   +---------------+-------+----------------------------------------------+
+
+
 The user must assure that enough computer memory is allocated for the
 diagnostics and the output streams selected for a particular experiment.
 This is accomplished by modifying the file

--- a/doc/outp_pkgs/outp_pkgs.rst
+++ b/doc/outp_pkgs/outp_pkgs.rst
@@ -330,8 +330,9 @@ the separate output files. A sample ``data.diagnostics`` namelist file:
       frequency(1) = 86400.,
       fields(1:2,2) = 'THETA   ','SALT    ',
        fileName(2) = 'diagout2',
-      fileFlags(2) = ' P1     ',
+      fileFlags(2) = ' P      ',
       frequency(2) = 3600.,
+      levels(1:5,2) = 100000.0, 70000.0, 50000.0, 30000.0, 20000.0,
      &
 
      &DIAG_STATIS_PARMS
@@ -343,23 +344,26 @@ the prefix ``diagout1``, does time averaging every 86400. seconds,
 (frequency is 86400.), and will write fields which are multiple-level
 fields at output levels 1-5. The names of diagnostics quantities are
 ``UVEL`` and ``VVEL``. The second set of output files has the prefix diagout2,
-does time averaging every 3600. seconds, includes fields with all
-levels, and the names of diagnostics quantities are ``THETA`` and ``SALT``.
+does time averaging every 3600. seconds and the names of diagnostics quantities
+are ``THETA`` and ``SALT``.  It interpolates vertically to the pressure levels
+100000 Pa, ..., 20000 Pa.
 
 The :varlink:`fileFlags` parameter is explained in
 :numref:`diagnostic_fileFlags`.  Only the first three characters matter.  The
 first character determines the precision of the output files.  The default is
 to use :varlink:`writeBinaryPrec`.  The second character determines whether the
 fields are to be integrated or interpolated vertically or written as is (the
-default).  The third character controls inclusion of an hFac factor.  Whether
-this is permitted is determined by a diagnostic’s parsing code, see
-:numref:`diagnostic_parsing_array` and the file available_diagnostics.log for a
-given setup:  parse(3) has to be ``'R'``, parse(5) blank and parse(9:10)
-``'MR'``.  Vorticity-point diagnostics cannot be hFac weighted.
-Including hFac is necessary for correct thickness weights when integrating
-vertically (second character ``'I'``) and shaved cells or the non-linear free
-surface are in use.  It can also be useful for computing budgets when not
-integrating vertically.
+default).  Interpolation is only available in the atmosphere.  The desired
+pressure levels need to be specified in ``levels``.  The third character is
+used to time average the product of a diagnostic with the appropriate
+thickness factor, hFacC, hFacW or hFacS.  This is mostly useful with a
+non-linear free surface where the thickness factors vary in time.  This will
+have an effect only for certain diagnostics, as determined by the parsing code
+(see :numref:`diagnostic_parsing_array` and the file available_diagnostics.log
+for a given setup):  parse(3) has to be ``'R'``, parse(5) blank and parse(9:10)
+``'MR'``.  Vorticity-point diagnostics cannot be hFac weighted.  Note that the
+appropriate hFac factors are automatically included when integrating vertically
+(second character ``'I'``), so the 'h' is not needed in this case.
 
 .. table:: Diagnostic fileFlags
    :name: diagnostic_fileflags
@@ -379,9 +383,7 @@ integrating vertically.
    +---------------+-------+----------------------------------------------+
    |               |       | do not integrate or interpolate              |
    +---------------+-------+----------------------------------------------+
-   | 3             | h     | include hFac (if permitted)                  |
-   +---------------+-------+----------------------------------------------+
-   |               |       | do not include hFac                          |
+   | 3             | h     | multiply by hFac (if permitted) when filled  |
    +---------------+-------+----------------------------------------------+
 
 

--- a/doc/outp_pkgs/outp_pkgs.rst
+++ b/doc/outp_pkgs/outp_pkgs.rst
@@ -363,7 +363,9 @@ have an effect only for certain diagnostics, as determined by the parsing code
 for a given setup):  parse(3) has to be ``'R'``, parse(5) blank and parse(9:10)
 ``'MR'``.  Vorticity-point diagnostics cannot be hFac weighted.  Note that the
 appropriate hFac factors are automatically included when integrating vertically
-(second character ``'I'``), so the 'h' is not needed in this case.
+(second character ``'I'``), so the 'h' is not needed in this case
+but could still improve accuracy of a time-averaged vertical integral when using
+non-linear free surface.
 
 .. table:: Diagnostic fileFlags
    :name: diagnostic_fileflags
@@ -468,7 +470,7 @@ Additionally the packages :ref:`gmredi <sub_phys_pkg_gmredi>`,
    225 |ADJkapgm| 15 |       |SMRA    MR|dJ/d[m^2/s]     |dJ/dKgm: Sensitivity to GM Intensity
    226 |ADJkapre| 15 |       |SMRA    MR|dJ/d[m^2/s]     |dJ/dKredi: Sensitivity to Redi Coefficient
 
-:: 
+::
 
    227 |TRAC01  | 15 |       |SMR     MR|mol C/m         |Dissolved Inorganic Carbon concentration
    241 |ADJptr01| 15 |       |SMRA    MR|dJ/mol C/m      |sensitivity to Dissolved Inorganic Carbon concentration

--- a/doc/outp_pkgs/outp_pkgs.rst
+++ b/doc/outp_pkgs/outp_pkgs.rst
@@ -331,8 +331,8 @@ the separate output files. A sample ``data.diagnostics`` namelist file:
       fields(1:2,2) = 'THETA   ','SALT    ',
        fileName(2) = 'diagout2',
       fileFlags(2) = ' P      ',
-      frequency(2) = 3600.,
       levels(1:5,2) = 100000.0, 70000.0, 50000.0, 30000.0, 20000.0,
+      frequency(2) = 3600.,
      &
 
      &DIAG_STATIS_PARMS

--- a/doc/outp_pkgs/outp_pkgs.rst
+++ b/doc/outp_pkgs/outp_pkgs.rst
@@ -326,11 +326,11 @@ the separate output files. A sample ``data.diagnostics`` namelist file:
      &DIAGNOSTICS_LIST
       fields(1:2,1) = 'UVEL    ','VVEL    ',
        levels(1:5,1) = 1.,2.,3.,4.,5.,
-       filename(1) = 'diagout1',
+       fileName(1) = 'diagout1',
       frequency(1) = 86400.,
       fields(1:2,2) = 'THETA   ','SALT    ',
-       filename(2) = 'diagout2',
-      fileflags(2) = ' P1     ',
+       fileName(2) = 'diagout2',
+      fileFlags(2) = ' P1     ',
       frequency(2) = 3600.,
      &
 
@@ -346,18 +346,22 @@ fields at output levels 1-5. The names of diagnostics quantities are
 does time averaging every 3600. seconds, includes fields with all
 levels, and the names of diagnostics quantities are ``THETA`` and ``SALT``.
 
-The :varlink:`fileflags` parameter is explained in
-:numref:`diagnostic_fileflags`.  Only the first three characters matter.  The
+The :varlink:`fileFlags` parameter is explained in
+:numref:`diagnostic_fileFlags`.  Only the first three characters matter.  The
 first character determines the precision of the output files.  The default is
 to use :varlink:`writeBinaryPrec`.  The second character determines whether the
 fields are to be integrated or interpolated vertically or written as is (the
-default).  The third character is used to write hFac-weighted fields.  Whether
+default).  The third character controls inclusion of an hFac factor.  Whether
 this is permitted is determined by a diagnostic’s parsing code, see
 :numref:`diagnostic_parsing_array` and the file available_diagnostics.log for a
 given setup:  parse(3) has to be ``'R'``, parse(5) blank and parse(9:10)
 ``'MR'``.  Vorticity-point diagnostics cannot be hFac weighted.
+Including hFac is necessary for correct thickness weights when integrating
+vertically (second character ``'I'``) and shaved cells or the non-linear free
+surface are in use.  It can also be useful for computing budgets when not
+integrating vertically.
 
-.. table:: Diagnostic fileflags
+.. table:: Diagnostic fileFlags
    :name: diagnostic_fileflags
 
    +---------------+-------+----------------------------------------------+
@@ -375,7 +379,7 @@ given setup:  parse(3) has to be ``'R'``, parse(5) blank and parse(9:10)
    +---------------+-------+----------------------------------------------+
    |               |       | do not integrate or interpolate              |
    +---------------+-------+----------------------------------------------+
-   | 3             | h     | cumulate hFac-weighted fields (if permitted) |
+   | 3             | h     | include hFac (if permitted)                  |
    +---------------+-------+----------------------------------------------+
    |               |       | do not include hFac                          |
    +---------------+-------+----------------------------------------------+

--- a/doc/tag-index
+++ b/doc/tag-index
@@ -1,11 +1,14 @@
     Notes on tags used in MITgcmUV
     ==============================
 
+o pkg/diagnostics (+doc):
+  - fix index-loop range in diagnostics_sum_levels.F and document "fileFlags"
+    and associated features (vertical interpolation & integral & hFac scaling).
 o pkg/gmredi:
-   - in gmredi_slope_limit.F, fix tape keys by using local tapes.
+  - in gmredi_slope_limit.F, fix tape keys by using local tapes.
 o pkg/ggl90:
-   - cleaning: remove maskS multiplication in ggl90_calc_visc.F (no equivalent
-     for KappaRU) and update "output_oadm.ggl90.txt" in OpenAD exp.
+  - cleaning: remove maskS multiplication in ggl90_calc_visc.F (no equivalent
+    for KappaRU) and update "output_oadm.ggl90.txt" in OpenAD exp.
 o pkg/ggl90:
   - Add code in pkg/ggl90 to parameterize Langmuir Circulation (LC) effects on
     vertical mixing (useLANGMUIR=T); follows: Tak et al, Ocean Modelling, 2023;

--- a/pkg/diagnostics/DIAGNOSTICS.h
+++ b/pkg/diagnostics/DIAGNOSTICS.h
@@ -100,7 +100,7 @@ C     fnames(n)   :: output file name for output stream # n
 C     fflags(n)   :: character string with per-file flags
 C                 :: 1rst: file precision ('R','D' or ' ' to use default outp prec)
 C                 :: 2nd: 'I'; integrate vertically ; 'P': interpolate vertically
-C                 :: 3rd: 'h'; cumulate thickness weighted field (if permitted)
+C                 :: 3rd: 'h'; multiply by hFac (if permitted) when filled
 C useMissingValue :: put MissingValue where mask = 0 (NetCDF output only)
 
       _RL freq(numLists), phase(numLists)

--- a/pkg/diagnostics/diagnostics_sum_levels.F
+++ b/pkg/diagnostics/diagnostics_sum_levels.F
@@ -82,8 +82,8 @@ C--   Cumulate levels directly:
 
              DO k = 1,nlevels(listId)
               kLev = NINT(levs(k,listId))
-              DO j = 1-OLy,sNy+OLy
-               DO i = 1-OLx,sNx+OLx
+              DO j = 1,sNy+1
+               DO i = 1,sNx+1
                 tmpFld(i,j) = tmpFld(i,j) + fld3d(i,j,kLev,bi,bj)
                ENDDO
               ENDDO
@@ -105,8 +105,8 @@ C--   Cumulate the level-thickness product:
               ELSE
                 tmpFac = drF(kLev)
               ENDIF
-              DO j = 1-OLy,sNy+OLy
-               DO i = 1-OLx,sNx+OLx
+              DO j = 1,sNy+1
+               DO i = 1,sNx+1
                 tmpFld(i,j) = tmpFld(i,j)
      &                      + tmpFac*fld3d(i,j,kLev,bi,bj)
                ENDDO
@@ -129,8 +129,8 @@ C--   Cumulate the level-thickness & hFac product:
                ELSE
                  tmpFac = drF(kLev)
                ENDIF
-               DO j = 1-OLy,sNy+OLy
-                DO i = 1-OLx,sNx+OLx
+               DO j = 1,sNy+1
+                DO i = 1,sNx+1
                  tmpFld(i,j) = tmpFld(i,j)
      &                       + tmpFac*fld3d(i,j,kLev,bi,bj)
      &                               *hFacC(i,j,kLev,bi,bj)
@@ -145,8 +145,8 @@ C--   Cumulate the level-thickness & hFac product:
                ELSE
                  tmpFac = drF(kLev)
                ENDIF
-               DO j = 1-OLy,sNy+OLy
-                DO i = 1-OLx,sNx+OLx
+               DO j = 1,sNy+1
+                DO i = 1,sNx+1
                  tmpFld(i,j) = tmpFld(i,j)
      &                       + tmpFac*fld3d(i,j,kLev,bi,bj)
      &                               *hFacW(i,j,kLev,bi,bj)
@@ -161,8 +161,8 @@ C--   Cumulate the level-thickness & hFac product:
                ELSE
                  tmpFac = drF(kLev)
                ENDIF
-               DO j = 1-OLy,sNy+OLy
-                DO i = 1-OLx,sNx+OLx
+               DO j = 1,sNy+1
+                DO i = 1,sNx+1
                  tmpFld(i,j) = tmpFld(i,j)
      &                       + tmpFac*fld3d(i,j,kLev,bi,bj)
      &                               *hFacS(i,j,kLev,bi,bj)
@@ -177,8 +177,8 @@ C--   Cumulate the level-thickness & hFac product:
                ELSE
                  tmpFac = drF(kLev)
                ENDIF
-               DO j = 2-OLy,sNy+OLy
-                DO i = 2-OLx,sNx+OLx
+               DO j = 1,sNy+1
+                DO i = 1,sNx+1
                  hFacLoc = MIN(
      &                          hFacW( i, j, kLev,bi,bj),
      &                          hFacW( i,j-1,kLev,bi,bj),


### PR DESCRIPTION
## What changes does this PR introduce?

docs update

## What is the current behaviour? 

The fileflags parameter of the diagnostics package is not documented.

## What is the new behaviour 

It is.

## Does this PR introduce a breaking change? 

No.

## Other information:

Hopefully this will save users (myself included) from having to dig into the code to remember how to set this.

The comment in DIAGNOSTICS.h says that 'h' in third position means "thickness weighted".  I think this is misleading as this only controls the inclusion of hFac*, not drF, which is triggered by the 'integrate' flag, but I may be wrong.