### PR TITLE
Update documentation: outp_pkgs.rst on Potential Vorticity Matlab Toolbox

### DIFF
--- a/doc/outp_pkgs/outp_pkgs.rst
+++ b/doc/outp_pkgs/outp_pkgs.rst
@@ -2031,6 +2031,12 @@ computation. It was developed to be used in mode water studies, so that
 it comes with other related routines, in particular ones computing
 surface vertical potential vorticity fluxes.
 
+.. note::
+
+    This toolbox was developed in 2006 for the `CLIMODE project <https://www.nsf.gov/awardsearch/showAward?AWD_ID=0425150>`_.
+    The toolbox routines are available on this
+    `archived repository <https://github.com/gmaze/gmaze_legacy/tree/master/matlab/MIT>`_.
+
 Equations
 ---------
 


### PR DESCRIPTION
## What changes does this PR introduce?
Since I continue to have some requests about this 14 years old package, I figured an update to the documentation section was necessary to let people know where to find the toolbox:
 https://mitgcm.readthedocs.io/en/latest/outp_pkgs/outp_pkgs.html#potential-vorticity-matlab-toolbox

## What is the new behaviour 
I added a note to indicate the (missing) localisation of this Matlab toolbox.


## Does this PR introduce a breaking change? 
no