### PR TITLE
build option files for AWI machine albedo

### DIFF
--- a/tools/build_options/linux_amd64_gfortran_albedo
+++ b/tools/build_options/linux_amd64_gfortran_albedo
@@ -1,0 +1,128 @@
+#!/bin/bash
+
+# Build options for gfortran compiler (GNU) on Linux amd64 platform albedo (@AWI)
+#
+#  Tested with gcc-gfortran v12.1.0 loading the following modules
+#
+# module purge
+# module load gcc
+# module load openmpi/4.1.3
+# module load netcdf-fortran/4.5.4-openmpi4.1.3-gcc12.1.0
+# albedo0::> module list
+# Currently Loaded Modulefiles:
+#  1) gcc/12.1.0   2) openmpi/4.1.3
+#  3) netcdf-fortran/4.5.4-openmpi4.1.3-oneapi2022.1.0
+#
+
+if test "x$MPI" = xtrue ; then
+  CC=mpicc
+  FC=mpif77
+  F90C=mpif90
+else
+  CC=gcc
+  FC=gfortran
+  F90C=gfortran
+fi
+
+DEFINES='-DWORDLENGTH=4 -DNML_TERMINATOR'
+EXTENDED_SRC_FLAG='-ffixed-line-length-132'
+F90FIXEDFORMAT='-ffixed-form'
+GET_FC_VERSION="--version"
+OMPFLAG='-fopenmp'
+
+NOOPTFLAGS='-O0'
+NOOPTFILES=''
+
+CFLAGS='-O0'
+
+#- for setting specific options, check compiler version:
+fcVers=`$CC -dumpversion | head -n 1 | sed 's/^[^0-9]* //;s/\..*$//'`
+if ! [[ $fcVers =~ ^[0-9]+$ ]] ; then
+  echo "    un-recognized gompiler-version '$fcVers' ; ignored (-> set to 0)" ; fcVers=0 ;
+else echo "    get gompiler-version: '$fcVers'" ; fi
+
+if [ $fcVers -ge 10 ] ; then
+  FFLAGS="$FFLAGS -fallow-argument-mismatch"
+fi
+#- Requires gfortran from 2006 onwards for -fconvert=big-endian
+FFLAGS="$FFLAGS -fconvert=big-endian -fimplicit-none"
+#- for big setups, compile & link with "-fPIC" or set memory-model to "medium":
+#CFLAGS="$CFLAGS -fPIC"
+#FFLAGS="$FFLAGS -fPIC"
+#-  with FC 19, need to use this without -fPIC (which cancels -mcmodel option):
+CFLAGS="$CFLAGS -mcmodel=medium"
+FFLAGS="$FFLAGS -mcmodel=medium"
+#- might want to use '-fdefault-real-8' for fizhi pkg:
+#FFLAGS="$FFLAGS -fdefault-real-8 -fdefault-double-8"
+#- speeds up compilation at the cost of more memory overhead
+FFLAGS="$FFLAGS -pipe"
+
+if test "x$IEEE" = x ; then     #- with optimisation:
+    #- full optimisation
+    FOPTIM='-march=core-avx2 -mtune=core-avx2 -funroll-loops'
+    # -O3 is generally not recommended, so we use -O2 with -ftree-vectorize
+    # as the default
+    #FOPTIM="$FOPTIM -O3"
+    #- can use -O2 (safe optimisation) to avoid Pb with some gcc version of -O3:
+    FOPTIM="$FOPTIM -O2 -ftree-vectorize"
+    NOOPTFILES="$NOOPTFILES ini_masks_etc.F"
+else
+   # these may also be useful, but require specific gfortran versions:
+   # -Wnonstd-intrinsics        for gfortran <= 4.3
+   # -Wintrinsics-std           for gfortran >= 4.4
+   # -Wno-tabs                  for gfortran >= 4.3
+   # -Wno-unused-dummy-argument for gfortran >= 4.6
+   #FFLAGS="$FFLAGS -Waliasing -Wampersand -Wsurprising -Wline-truncation"
+   #- or simply:
+    FFLAGS="$FFLAGS -Wall"
+    if [ $fcVers -ge 10 ] ; then
+      FFLAGS="$FFLAGS -Wno-unused-dummy-argument"
+    fi
+   #- to get plenty of warnings: -Wall -Wextra (older form: -Wall -W) or:
+   #FFLAGS="$FFLAGS -Wconversion -Wimplicit-interface -Wunused-labels"
+  if test "x$DEVEL" = x ; then  #- no optimisation + IEEE :
+    FOPTIM='-O0'
+  else                          #- development/check options:
+    FOPTIM='-O0 -g -fbounds-check'
+    FOPTIM="$FOPTIM -ffpe-trap=invalid,zero,overflow -finit-real=inf"
+  fi
+fi
+
+F90FLAGS=$FFLAGS
+F90OPTIM=$FOPTIM
+
+INCLUDEDIRS=''
+INCLUDES=''
+LIBS=''
+
+if [[ -n $( nf-config --fflags )  && ($? == 0) ]]; then
+    INCLUDES=$(nf-config --fflags)
+#    LIBS=$(nf-config --flibs)
+    LIBS="-L$(nf-config --prefix)/lib -lnetcdff"
+fi
+
+if [ -n "$MPI_HOME" -a -z "$MPI_INC_DIR" ]; then
+    MPI_INC_DIR="$MPI_HOME/include"
+fi
+
+if [ "x$MPI" = xtrue ] ; then
+   if [ -z "$MPI_INC_DIR" ] ; then
+      # MPI env variables are not set, trying pkg-config insteal
+      if [[ -n $( pkg-config --cflags-only-I ompi ) && ($? == 0) ]] ; then
+         MPI_INC_DIR=$(pkg-config --cflags-only-I ompi | awk '{ print $1 }' | sed -e "s/-I//" )
+      else
+         echo MPI_HOME is not set and pkg-config not available, aborting
+         exit 1
+      fi
+   fi
+   if [ -n "$MPI_INC_DIR" ] ; then
+      # only fill this if we can find MPI, otherwise triggers netcdf error
+      INCLUDES+=" -I$MPI_INC_DIR"
+      INCLUDEDIRS+=" $MPI_INC_DIR"
+      #- used for parallel (MPI) DIVA
+      MPIINCLUDEDIR="$MPI_INC_DIR"
+   else
+      echo could not set MPI_INC_DIR, aborting
+      exit 1
+   fi
+fi

--- a/tools/build_options/linux_amd64_gfortran_albedo
+++ b/tools/build_options/linux_amd64_gfortran_albedo
@@ -38,8 +38,8 @@ CFLAGS='-O0'
 #- for setting specific options, check compiler version:
 fcVers=`$CC -dumpversion | head -n 1 | sed 's/^[^0-9]* //;s/\..*$//'`
 if ! [[ $fcVers =~ ^[0-9]+$ ]] ; then
-  echo "    un-recognized gompiler-version '$fcVers' ; ignored (-> set to 0)" ; fcVers=0 ;
-else echo "    get gompiler-version: '$fcVers'" ; fi
+  echo "    un-recognized compiler-version '$fcVers' ; ignored (-> set to 0)" ; fcVers=0 ;
+else echo "    get compiler-version: '$fcVers'" ; fi
 
 if [ $fcVers -ge 10 ] ; then
   FFLAGS="$FFLAGS -fallow-argument-mismatch"

--- a/tools/build_options/linux_amd64_ifort_albedo
+++ b/tools/build_options/linux_amd64_ifort_albedo
@@ -27,7 +27,6 @@ fi
 #LINK="$F90C -ipo"
 
 DEFINES='-DWORDLENGTH=4'
-CPP='cpp -traditional -P'
 F90FIXEDFORMAT='-fixed -Tf'
 EXTENDED_SRC_FLAG='-132'
 GET_FC_VERSION="--version"

--- a/tools/build_options/linux_amd64_ifort_albedo
+++ b/tools/build_options/linux_amd64_ifort_albedo
@@ -1,0 +1,115 @@
+#!/bin/bash
+#
+# Build options for intel compiler on Linux amd64 platform albedo (@AWI)
+# derived from linux_amd64_ifort
+#
+#  Tested with intel-oneapi-compilers/2022.1.0 loading the following modules
+#
+# module purge (to remove you have anything that may conflict with ifort)
+# module load intel-oneapi-compilers
+# # module load intel-oneapi-mkl
+# module load intel-oneapi-mpi
+# module load netcdf-fortran/4.5.4-oneapi2022.1.0
+# albedo0::> module list
+# Currently Loaded Modulefiles:
+#  1) intel-oneapi-compilers/2022.1.0   2) intel-oneapi-mpi/2021.6.0
+#  3) netcdf-fortran/4.5.4-oneapi2022.1.0
+
+if test "x$MPI" = xtrue ; then
+  CC=mpiicc
+  FC=mpiifort
+  F90C=mpiifort
+else
+  CC=icc
+  FC=ifort
+  F90C=ifort
+fi
+#LINK="$F90C -ipo"
+
+DEFINES='-DWORDLENGTH=4'
+CPP='cpp -traditional -P'
+F90FIXEDFORMAT='-fixed -Tf'
+EXTENDED_SRC_FLAG='-132'
+GET_FC_VERSION="--version"
+OMPFLAG='-qopenmp'
+
+NOOPTFLAGS='-O0'
+NOOPTFILES=''
+
+FFLAGS="$FFLAGS -W0 -WB -convert big_endian -assume byterecl"
+FFLAGS="$FFLAGS -fPIC"
+#- might want to use '-r8' for fizhi pkg:
+#FFLAGS="$FFLAGS -r8"
+
+if test "x$IEEE" = x ; then     #- with optimisation:
+    # FOPTIM='-fast' does not work because there are no static netcdf
+    # libaries, also the implied '-xHost' is not recognized so we use
+    # -xcore-avx2 instead and spell out the options explicitly.
+    # '-ipo' makes linking very slow with no effect, so we will skip that, too.
+    #FOPTIM='-ipo -align -O3 -static -no-prec-div -fp-model fast=2 -xHost'
+    FOPTIM='-ip -align -O3 -no-prec-div -fp-model fast=2 -march=core-avx2'
+    # probably not necessary
+    FOPTIM="$FOPTIM -mtune=core-avx2"
+    # additional options from benchmarkers
+    FOPTIM="$FOPTIM -qopt-prefetch=5 -unroll-aggressive"
+    # report optimization (very cryptic)
+    #FOPTIM="$FOPTIM -qopt-report5"
+    # reduce optimization level a little for some files
+    NOOPTFLAGS='-ip -align -O1 -no-prec-div -fp-model fast=2 -march=core-avx2'
+    #NOOPTFLAGS="$NOOPTFLAGS -mtune=core-avx2"
+    NOOPTFILES='obcs_init_fixed.F obcs_set_connect.F'
+else
+  if test "x$DEVEL" = x ; then  #- no optimisation + IEEE :
+    # "-fp-model [keyword]" is the recommended method of controlling precision
+    FOPTIM='-O0 -noalign -march=core-avx2 -ip -fp-model consistent'
+# alternatives, see man pages for details
+#   FOPTIM='-O0 -noalign -march=core-avx2 -ip -mp1'
+#   FOPTIM='-O0 -noalign -march=core-avx2 -ip -fp-model precise'
+#   FOPTIM='-O0 -noalign -march=core-avx2 -ip -mieee-fp'
+  else                          #- development/check options:
+#    FFLAGS="$FFLAGS -warn all -warn nounused"
+    FFLAGS="$FFLAGS -warn unused"
+    FOPTIM="-fpe0 -check all -ftrapuv -fp-model precise"
+    FOPTIM="$FOPTIM -O0 -noalign -g -traceback"
+  fi
+fi
+
+F90FLAGS=$FFLAGS
+F90OPTIM=$FOPTIM
+CFLAGS='-O0 -fPIC -ip'
+
+INCLUDEDIRS=''
+INCLUDES=''
+LIBS=''
+
+if [[ -n $( nf-config --fflags )  && ($? == 0) ]]; then
+    INCLUDES=$(nf-config --fflags)
+#    LIBS=$(nf-config --flibs)
+    LIBS="-L$(nf-config --prefix)/lib -lnetcdff"
+fi
+
+if [ -n "$MPI_HOME" -a -z "$MPI_INC_DIR" ]; then
+    MPI_INC_DIR="$MPI_HOME/include"
+fi
+
+if [ "x$MPI" = xtrue ] ; then
+   if [ -z "$MPI_INC_DIR" ] ; then
+      # MPI env variables are not set, trying pkg-config insteal
+      if [[ -n $( pkg-config --cflags-only-I impi ) && ($? == 0) ]] ; then
+         MPI_INC_DIR=$(pkg-config --cflags-only-I impi | awk '{ print $1 }' | sed -e "s/-I//" )
+      else
+         echo MPI_HOME is not set and pkg-config not available, aborting
+         exit 1
+      fi
+   fi
+   if [ -n "$MPI_INC_DIR" ] ; then
+      # only fill this if we can find MPI, otherwise triggers netcdf error
+      INCLUDES+=" -I$MPI_INC_DIR"
+      INCLUDEDIRS+=" $MPI_INC_DIR"
+      #- used for parallel (MPI) DIVA
+      MPIINCLUDEDIR="$MPI_INC_DIR"
+   else
+      echo could not set MPI_INC_DIR, aborting
+      exit 1
+   fi
+fi


### PR DESCRIPTION
After some experimenting and testing, these build options files (and optimisation flags) appear to be useful for AWI's albedo with
- AMD Rome Epyc 7702 cpu
- Nvidia A40/A100 GPU
- note that the OMP flag for ifort is no longer "-openmp" but "-qopenmp" (at least since version 2021.4.0 (20210910)). Since albedo only has more recent ifort versions installed. I updated this flag.
