### PR TITLE
Use pass/FAIL to decide workflow success

### DIFF
--- a/.github/workflows/build_testing.yml
+++ b/.github/workflows/build_testing.yml
@@ -12,29 +12,17 @@ jobs:
      matrix:
       include:
         - exp: "offline_exf_seaice"
-          precs: "16 16 16 16 16 16 16 16 16"
         - exp: "global_ocean.cs32x15"
-          precs: "16 16 16 16 16 16"
         - exp: "tutorial_deep_convection"
-          precs: "16 16"
         - exp: "aim.5l_cs"
-          precs: "14 16"
         - exp: "isomip"
-          precs: "16 16 16 16"
         - exp: "global_ocean.90x40x15"
-          precs: "16 16 16"
         - exp: "tutorial_plume_on_slope"
-          precs: "16"
         - exp: "tutorial_advection_in_gyre"
-          precs: "16"
         - exp: "hs94.cs-32x32x5"
-          precs: "13 16"
         - exp: "tutorial_global_oce_biogeo"
-          precs: "16"
         - exp: "tutorial_global_oce_in_p"
-          precs: "16"
         - exp: "tutorial_cfc_offline"
-          precs: "16"
 
    continue-on-error: true
 
@@ -56,7 +44,6 @@ jobs:
      - name: Run a test
        env:
         MITGCM_EXP: ${{ matrix.exp }}
-        MITGCM_PRECS: ${{ matrix.precs }}
        run: |
          . tools/ci/runtr.sh
 
@@ -67,7 +54,6 @@ jobs:
      matrix:
       include:
         - exp: "global_ocean.90x40x15"
-          precs: "14"
 
    continue-on-error: true
 
@@ -84,7 +70,6 @@ jobs:
      - name: Run testreport
        env:
         MITGCM_EXP: ${{ matrix.exp }}
-        MITGCM_PRECS: ${{ matrix.precs }}
         MITGCM_DECMD: "docker exec -i openad-testing bash -lc"
         MITGCM_TROPT: "-oad -devel -of=../tools/build_options/linux_amd64_gfortran"
         MITGCM_INPUT_DIR_PAT: '/input_oad.*'
@@ -99,19 +84,12 @@ jobs:
      matrix:
       include:
         - exp: "halfpipe_streamice"
-          precs: "16"
         - exp: "hs94.1x64x5"
-          precs: "14"
         - exp: "isomip"
-          precs: "16"
         - exp: "OpenAD"
-          precs: "15 16 16"
         - exp: "tutorial_global_oce_biogeo"
-          precs: "16"
         - exp: "tutorial_global_oce_optim"
-          precs: "16"
         - exp: "tutorial_tracer_adjsens"
-          precs: "16"
 
    continue-on-error: true
 
@@ -128,7 +106,6 @@ jobs:
      - name: Run testreport
        env:
         MITGCM_EXP: ${{ matrix.exp }}
-        MITGCM_PRECS: ${{ matrix.precs }}
         MITGCM_DECMD: "docker exec -i openad-testing bash -lc"
         MITGCM_TROPT: "-oad -devel -of=../tools/build_options/linux_amd64_gfortran"
         MITGCM_INPUT_DIR_PAT: '/input_oad.*'

--- a/tools/ci/runtr.sh
+++ b/tools/ci/runtr.sh
@@ -10,7 +10,7 @@
 #
 
 if [ -z "${MITGCM_TROPT}" ]; then
- export MITGCM_TROPT='-devel -of=../tools/build_options/linux_amd64_gfortran'
+ export MITGCM_TROPT='-devel -of=../tools/build_options/linux_amd64_gfortran -match 14 -pass'
 fi
 if [ -z "${MITGCM_DECMD}" ]; then
  export MITGCM_DECMD='docker exec -i ubuntu_18_04-testreport bash -c'
@@ -19,9 +19,4 @@ if [ -z "${MITGCM_INPUT_DIR_PAT}" ]; then
  export MITGCM_INPUT_DIR_PAT='/input.*'
 fi
 
-${MITGCM_DECMD} "cd /MITgcm/verification; ./testreport -t ${MITGCM_EXP} ${MITGCM_TROPT} | \
-                 tee ${MITGCM_EXP}/testreport_out.txt"
-${MITGCM_DECMD} "cd /MITgcm/verification; python verification_parser.py \
-                    -filename ${MITGCM_EXP}/testreport_out.txt          \
-                    -threshold ${MITGCM_PRECS}                          \
-                    -input_dir_pat ${MITGCM_INPUT_DIR_PAT}"
+${MITGCM_DECMD} "cd /MITgcm/verification; ./testreport -t ${MITGCM_EXP} ${MITGCM_TROPT}"

--- a/verification/testreport
+++ b/verification/testreport
@@ -49,6 +49,7 @@ usage()
     echo " ---- output options : ----"
     echo "  (-match) NUMBER          Matching Criteria (number of digits)"
     echo "                             (DEF=\"$MATCH_CRIT\")"
+    echo "  (-pass)                  return non-zero exit code if any exp do not pass"
     echo "  (-odir) STRING           used to build output directory name"
     echo "                             (DEF=\"hostname\")"
     echo "  (-addr|-a) STRING        list of email recipients"
@@ -71,7 +72,6 @@ usage()
     echo "  (-postclean|-pc)         after each exp. test, clean build-dir & run-dir"
     echo "  (-deloutp|-do)           delete output files after successful run"
     echo "  (-deldir|-dd)            on success, delete the output directory"
-    echo "  (-pass)                  return non-zero exit code if any exp do not pass"
     echo
     echo "and where STRING can be a whitespace-delimited list"
     echo "such as:"
@@ -1136,7 +1136,7 @@ EXTRFLG=
 NOCATAD=
 MKSMALLF=
 OADSINGULARITY=
-PASSOPT=f
+CHECK_PASS=f
 
 #- type of testing (KIND):
 #   KIND=0 : forward (= default) ;  KIND=1 : Tangent Linear with TAF ;
@@ -1228,7 +1228,7 @@ for ac_option ; do
 	-postclean | --postclean | -pc | --pc) POSTCLEAN=2 ;;
 	-deloutp | --deloutp | -do | --do) POSTCLEAN=1 ;;
 
-	-pass) PASSOPT=t ;;
+	-pass) CHECK_PASS=t ;;
 
 	-mpi | --mpi) MPI=2 ;;
 	-MPI | --MPI) ac_prev=MPI ;;
@@ -1897,7 +1897,7 @@ if test "x$DELDIR" = xt ; then
     rm -rf $DRESULTS
 fi
 
-if test "$PASSOPT" = t && test "$allpass" = f; then
+if test "$CHECK_PASS" = t && test "$allpass" = f; then
     exit 1
 fi
 

--- a/verification/testreport
+++ b/verification/testreport
@@ -1746,7 +1746,7 @@ for dir in $TESTDIRS ; do
 	fres=`formatresults $dir ${genmake:-N} ${makedepend:-N} ${make:-N} ${run:-N} $results`
 	echo "$fres" | sed 's/ 99/ --/g' | sed 's/  > />/' | sed 's/  < /</' >> $SUMMARY
 	echo "fresults='$fres'" | sed 's/ 99/ --/g' >> $locDIR"/summary.txt"
-        if [[ "$fres" != *" pass "* ]]; then
+        if [[ ! "$fres" =~ " pass " ]]; then
             allpass=f
         fi
 
@@ -1773,7 +1773,7 @@ for dir in $TESTDIRS ; do
 	    fres=`formatresults $dir.$ex ${genmake:-N} ${makedepend:-N} ${make:-N} ${run:-N} $results`
 	    echo "$fres" | sed 's/ 99/ --/g' | sed 's/  > />/' | sed 's/  < /</' >> $SUMMARY
 	    echo "fresults='$fres'" | sed 's/ 99/ --/g' >> $locDIR"/summary.txt"
-            if [[ "$fres" != *" pass "* ]]; then
+            if [[ ! "$fres" =~ " pass " ]]; then
                 allpass=f
             fi
 	    if test "x$POSTCLEAN" = x2 ; then

--- a/verification/testreport
+++ b/verification/testreport
@@ -71,6 +71,7 @@ usage()
     echo "  (-postclean|-pc)         after each exp. test, clean build-dir & run-dir"
     echo "  (-deloutp|-do)           delete output files after successful run"
     echo "  (-deldir|-dd)            on success, delete the output directory"
+    echo "  (-pass)                  return non-zero exit code if any exp do not pass"
     echo
     echo "and where STRING can be a whitespace-delimited list"
     echo "such as:"
@@ -1135,6 +1136,7 @@ EXTRFLG=
 NOCATAD=
 MKSMALLF=
 OADSINGULARITY=
+PASSOPT=f
 
 #- type of testing (KIND):
 #   KIND=0 : forward (= default) ;  KIND=1 : Tangent Linear with TAF ;
@@ -1225,6 +1227,8 @@ for ac_option ; do
 
 	-postclean | --postclean | -pc | --pc) POSTCLEAN=2 ;;
 	-deloutp | --deloutp | -do | --do) POSTCLEAN=1 ;;
+
+	-pass) PASSOPT=t ;;
 
 	-mpi | --mpi) MPI=2 ;;
 	-MPI | --MPI) ac_prev=MPI ;;
@@ -1561,6 +1565,8 @@ if test "x$CLEANUP" != xt ; then
 fi
 echo "-------------------------------------------------------------------------------"
 
+allpass=t
+
 #  ...and each test directory...
 for dir in $TESTDIRS ; do
 
@@ -1740,6 +1746,9 @@ for dir in $TESTDIRS ; do
 	fres=`formatresults $dir ${genmake:-N} ${makedepend:-N} ${make:-N} ${run:-N} $results`
 	echo "$fres" | sed 's/ 99/ --/g' | sed 's/  > />/' | sed 's/  < /</' >> $SUMMARY
 	echo "fresults='$fres'" | sed 's/ 99/ --/g' >> $locDIR"/summary.txt"
+        if [[ "$fres" != *" pass "* ]]; then
+            allpass=f
+        fi
 
 	for ex in $extra_runs ; do
 	    unset run
@@ -1764,6 +1773,9 @@ for dir in $TESTDIRS ; do
 	    fres=`formatresults $dir.$ex ${genmake:-N} ${makedepend:-N} ${make:-N} ${run:-N} $results`
 	    echo "$fres" | sed 's/ 99/ --/g' | sed 's/  > />/' | sed 's/  < /</' >> $SUMMARY
 	    echo "fresults='$fres'" | sed 's/ 99/ --/g' >> $locDIR"/summary.txt"
+            if [[ "$fres" != *" pass "* ]]; then
+                allpass=f
+            fi
 	    if test "x$POSTCLEAN" = x2 ; then
 		run_clean $dir/$pfxdir.$ex
 	    fi
@@ -1884,4 +1896,9 @@ fi
 if test "x$DELDIR" = xt ; then
     rm -rf $DRESULTS
 fi
+
+if test "$PASSOPT" = t && test "$allpass" = f; then
+    exit 1
+fi
+
 echo "======== End of testreport execution ========"


### PR DESCRIPTION
## What changes does this PR introduce?

Simplifies github workflow by using pass/FAIL for each experiment instead of checking all the digits in a separate script.

## Does this PR introduce a breaking change? 

No

## Other information:

testreport gets a new option '-pass' that will cause it to return non-zero exit code if any experiments do not pass.

The script verification/verification_parser.py is no longer used but kept in the repository for now as it could still be useful.