### PR TITLE
add missing "F90C" setting in pleiades optfile

### DIFF
--- a/tools/build_options/linux_amd64_ifort+mpi_ice_nas
+++ b/tools/build_options/linux_amd64_ifort+mpi_ice_nas
@@ -13,8 +13,10 @@
 #- Note: in both cases, the last line of 3 module setting is for NetCDF
 #        (could be skipped if not using at all this type of I/O).
 
-FC=ifort
 CC=icc
+FC=ifort
+F90C=ifort
+LINK="$F90C -shared-intel"
 
 CPP='/lib/cpp -traditional -P'
 DEFINES='-DWORDLENGTH=4 -DINTEL_COMMITQQ'
@@ -38,8 +40,6 @@ FFLAGS="$FFLAGS -fPIC"
 #CFLAGS="$CFLAGS -mcmodel=medium -shared-intel"
 #- might want to use '-r8' for fizhi pkg:
 #FFLAGS="$FFLAGS -r8"
-
-LDADD='-shared-intel'
 
 FFLAGS="$FFLAGS -W0 -WB"
 if test "x$IEEE" = x ; then     #- with optimisation:


### PR DESCRIPTION
## What changes does this PR introduce?
Fix missing setting in ` linux_amd64_ifort+mpi_ice_nas` (pleiades) optfile

## What is the current behaviour? 
Unable to compile (free format) "*.F90" src code since compiler is missing.

## What is the new behaviour 
fixed

## Does this PR introduce a breaking change? 
no

## Other information:
Note that, without MPI, the standard intel optfile (linux_amd64_ifort) works on pleiades
(can compile and run fine).

## Suggested addition to `tag-index`
