### PR TITLE
Fix PR 706  addition regarding RS parameters

### DIFF
--- a/pkg/obcs/obcs_check.F
+++ b/pkg/obcs/obcs_check.F
@@ -159,10 +159,10 @@ C
      & 'useStevensPhaseVel  =', '  /* include phase vel. term. */')
       CALL WRITE_0D_L( useStevensAdvection,    INDEX_NONE,
      & 'useStevensAdvection  =', '  /* include advection term. */')
-      CALL WRITE_0D_RL( TrelaxStevens, INDEX_NONE,
+      CALL WRITE_0D_RS( TrelaxStevens, INDEX_NONE,
      & 'TrelaxStevens =',
      & ' /* relaxation time scale for theta ( s ). */')
-      CALL WRITE_0D_RL( SrelaxStevens, INDEX_NONE,
+      CALL WRITE_0D_RS( SrelaxStevens, INDEX_NONE,
      & 'SrelaxStevens =',
      & ' /* relaxation time scale for salinity ( s ). */')
 C
@@ -194,16 +194,16 @@ C
        CALL WRITE_0D_I( spongeThickness, INDEX_NONE,
      & 'spongeThickness =',
      & ' /* number grid points in sponge */')
-       CALL WRITE_0D_RL( Urelaxobcsinner, INDEX_NONE,
+       CALL WRITE_0D_RS( Urelaxobcsinner, INDEX_NONE,
      &  'Urelaxobcsinner =',
      & ' /* innermost relaxation time scale, u-velocity ( s ). */')
-       CALL WRITE_0D_RL( Urelaxobcsbound, INDEX_NONE,
+       CALL WRITE_0D_RS( Urelaxobcsbound, INDEX_NONE,
      &  'Urelaxobcsbound =',
      & ' /* boudnary relaxation time scale, u-velocity ( s ). */')
-       CALL WRITE_0D_RL( Vrelaxobcsinner, INDEX_NONE,
+       CALL WRITE_0D_RS( Vrelaxobcsinner, INDEX_NONE,
      &  'Vrelaxobcsinner =',
      & ' /* innermost relaxation time scale, v-velocity ( s ). */')
-       CALL WRITE_0D_RL( Vrelaxobcsbound, INDEX_NONE,
+       CALL WRITE_0D_RS( Vrelaxobcsbound, INDEX_NONE,
      &  'Vrelaxobcsbound =',
      & ' /* boundary relaxation time scale, v-velocity ( s ). */')
       ENDIF


### PR DESCRIPTION

## What changes does this PR introduce?
Fix pkg/obcs summary additions (in `obcs_check.F`) from PR #706:
- use the correct type of S/R to report RS parameter value

## What is the current behaviour? 
Fail to compile when RS = real*4 and checking for consistency of S/R argument type (e.g., with ifort compiler and -devel).

## What is the new behaviour 
fixed, use the right  type of S/R

## Does this PR introduce a breaking change? 

## Other information:

## Suggested addition to `tag-index`
none if merge just after #706