### PR TITLE
Fix for TAF v5.8.0 : no store-dir to non-existing variables

### DIFF
--- a/doc/tag-index
+++ b/doc/tag-index
@@ -1,6 +1,9 @@
     Notes on tags used in MITgcmUV
     ==============================
 
+o pkg/dic:
+  - remove TAF storage dir for variable "OmegaC" (within wrong CPP option).
+
 checkpoint68o (2023/03/13)
 o model/src:
   - salt/temp/ptracer_integrate.F: optimise store directives

--- a/pkg/dic/dic_ad_check_lev1_dir.h
+++ b/pkg/dic/dic_ad_check_lev1_dir.h
@@ -7,10 +7,6 @@ CADJ STORE fIce               = comlev1, key = ikey_dynamics
 CADJ STORE silicaSurf         = comlev1, key = ikey_dynamics
 CADJ STORE atmosPCO2          = comlev1, key = ikey_dynamics
 
-#ifdef DIC_BIOTIC
-CADJ STORE omegaC             = comlev1, key = ikey_dynamics
-#endif
-
 CADJ STORE gsm_s              = comlev1, key = ikey_dynamics
 CADJ STORE co2atmos           = comlev1, key = ikey_dynamics
 CADJ STORE total_atmos_carbon = comlev1, key = ikey_dynamics

--- a/pkg/dic/dic_ad_check_lev2_dir.h
+++ b/pkg/dic/dic_ad_check_lev2_dir.h
@@ -7,10 +7,6 @@ CADJ STORE fIce               = tapelev2, key = ilev_2
 CADJ STORE silicaSurf         = tapelev2, key = ilev_2
 CADJ STORE atmosPCO2          = tapelev2, key = ilev_2
 
-#ifdef DIC_BIOTIC
-CADJ STORE omegaC             = tapelev2, key = ilev_2
-#endif
-
 CADJ STORE gsm_s              = tapelev2, key = ilev_2
 CADJ STORE co2atmos           = tapelev2, key = ilev_2
 CADJ STORE total_atmos_carbon = tapelev2, key = ilev_2

--- a/pkg/dic/dic_ad_check_lev3_dir.h
+++ b/pkg/dic/dic_ad_check_lev3_dir.h
@@ -7,10 +7,6 @@ CADJ STORE fIce               = tapelev3, key = ilev_3
 CADJ STORE silicaSurf         = tapelev3, key = ilev_3
 CADJ STORE atmosPCO2          = tapelev3, key = ilev_3
 
-#ifdef DIC_BIOTIC
-CADJ STORE omegaC             = tapelev3, key = ilev_3
-#endif
-
 CADJ STORE gsm_s              = tapelev3, key = ilev_3
 CADJ STORE co2atmos           = tapelev3, key = ilev_3
 CADJ STORE total_atmos_carbon = tapelev3, key = ilev_3

--- a/pkg/dic/dic_ad_check_lev4_dir.h
+++ b/pkg/dic/dic_ad_check_lev4_dir.h
@@ -7,10 +7,6 @@ CADJ STORE fIce               = tapelev4, key = ilev_4
 CADJ STORE silicaSurf         = tapelev4, key = ilev_4
 CADJ STORE atmosPCO2          = tapelev4, key = ilev_4
 
-#ifdef DIC_BIOTIC
-CADJ STORE omegaC             = tapelev4, key = ilev_4
-#endif
-
 CADJ STORE gsm_s              = tapelev4, key = ilev_4
 CADJ STORE co2atmos           = tapelev4, key = ilev_4
 CADJ STORE total_atmos_carbon = tapelev4, key = ilev_4


### PR DESCRIPTION
- After PR #683, variable "OmegaC" is only available when DIC_CALCITE_SAT is defined (never used otherwise), but CPP has not been updated and this store dir now applies to undefined "OmegaC" when DIC_CALCITE_SAT is undef.
- Remove storage since DIC_CALCITE_SAT code has never been tested in TAF adjoint set-up so a) might not be needed but b) other storage dir might be.

## What changes does this PR introduce?
Remove TAF storage dir for non-existing variables

## What is the current behaviour? 
These storage dir were just ignored by TAF until version v5.7.7

## What is the new behaviour 
With version 5.8.0, these wrong storage dir cause an error.
By removing these wrong storage dirs the TAF errors are gone
and the code is cleaner.


## Does this PR introduce a breaking change? 
No.

## Other information:


## Suggested addition to `tag-index`
o pkg/dic:
  - remove TAF storage dir for variable "OmegaC".