### PR TITLE
Fix pr716 updates

### DIFF
--- a/pkg/ecco/ecco_ad_diff.list
+++ b/pkg/ecco/ecco_ad_diff.list
@@ -30,5 +30,6 @@ ecco_cost_driver.f
 ecco_cost_final.f
 ecco_cost_init_varia.f
 ecco_init_varia.f
+ecco_read_pickup.f
 ecco_phys.f
 ecco_toolbox.f

--- a/pkg/ecco/ecco_init_varia.F
+++ b/pkg/ecco/ecco_init_varia.F
@@ -33,16 +33,19 @@ C     == local variables ==
 C     == end of interface ==
 
 #ifdef ALLOW_PSBAR_STERIC
+# ifndef ALLOW_AUTODIFF
       _BEGIN_MASTER(myThid)
+# endif
       RHOsumGlob_0 = 0. _d 0
       VOLsumGlob_0 = 0. _d 0
+# ifndef ALLOW_AUTODIFF
       _END_MASTER(myThid)
-
+# endif
       IF ( .NOT. ( startTime .EQ. baseTime .AND.  nIter0 .EQ. 0
      &     .AND. pickupSuff .EQ. ' ') ) THEN
         CALL ECCO_READ_PICKUP ( nIter0, myThid )
       ENDIF
-#endif
+#endif /* ALLOW_PSBAR_STERIC */
 
       CALL ECCO_PHYS( startTime, -1, myThid )
 

--- a/pkg/ecco/ecco_phys.F
+++ b/pkg/ecco/ecco_phys.F
@@ -130,7 +130,9 @@ CEOP
       CALL GLOBAL_SUM_TILE_RL( VOLsumTile, VOLsumGlob_1, myThid )
       CALL GLOBAL_SUM_TILE_RL( RHOsumTile, RHOsumGlob_1, myThid )
 
+# ifndef ALLOW_AUTODIFF
       _BEGIN_MASTER(myThid)
+# endif
       VOLsumGlob = VOLsumGlob_1
       RHOsumGlob = RHOsumGlob_1/VOLsumGlob
 
@@ -144,8 +146,10 @@ CEOP
 c     WRITE(msgBuf,'(A,1PE21.14)') ' sterGloH= ', sterGloH
 c     CALL PRINT_MESSAGE( msgBuf, standardMessageUnit,
 c    &                       SQUEEZE_RIGHT, myThid )
+# ifndef ALLOW_AUTODIFF
       _END_MASTER(myThid)
       _BARRIER
+# endif
 
 #endif /* ALLOW_PSBAR_STERIC */
 

--- a/verification/lab_sea/input_ad/do_run.sh
+++ b/verification/lab_sea/input_ad/do_run.sh
@@ -1,14 +1,24 @@
 #! /usr/bin/env bash
 
-#  number of additional executions to perform is given by "add_DIVA_runs"
-#  and corresponds to "nchklev_3" value in file "code_ad/tamc.h"
-add_DIVA_runs=4
+#- script to run the sequence of multiple Divided-Adjoint runs:
+#  no argment -> using non-MPI built AD-executable
+#  single-arg -> using MPI built executable and "mpirun -np ${single-arg}" command
 
+#- number of additional executions to perform is given by "add_DIVA_runs"
+#  and corresponds to "nchklev_3" value in file "code_ad/tamc.h"
+#- take it from file "run_ADM_DIVA" (as done in testreport):
+adm_diva_nb=`sed -n '/^ *add_DIVA_runs *=/p' run_ADM_DIVA | sed 's/ //g'`
+echo " Divided Adjoint Run: $adm_diva_nb"
+eval "let $adm_diva_nb"
+#- or set-it directly:
+#add_DIVA_runs=4
+
+extraRuns=`expr $add_DIVA_runs - 1`	
 if test $# = 0 ; then
     rm -f costfunction*0000 costfinal divided.ctrl snapshot*
 #- not MPI run:
     echo "Run $add_DIVA_runs times + final run:"
-    for ii in `seq 1 $add_DIVA_runs` ; do
+    for ii in `seq 0 $extraRuns` ; do
       ./mitgcmuv_ad > output_adm.txt.diva_${ii}
       echo " additional DIVA run # $ii : done"
     done
@@ -18,7 +28,7 @@ else
     rm -f costfunction*0000 costfinal divided.ctrl snapshot*
 #- MPI run on $1 procs (note: may need to edit mpirun command):
     echo "Run $add_DIVA_runs times + final run (use 'mpirun -np $1' ):"
-    for ii in `seq 1 $add_DIVA_runs` ; do
+    for ii in `seq 0 $extraRuns` ; do
       mpirun -np $1 ./mitgcmuv_ad
       echo " additional DIVA run # $ii : done"
       mv -f STDOUT.0000 STDOUT.0000.diva_${ii}

--- a/verification/testreport
+++ b/verification/testreport
@@ -876,9 +876,10 @@ runmodel()
 	      echo " Divided Adjoint Run: $adm_diva_nb" >> $RUNLOG
 	      eval "let $adm_diva_nb"
 	      if [ $add_DIVA_runs -ge 1 ] ; then
+		extraRuns=`expr $add_DIVA_runs - 1`
 		rm -f costf* divided.ctrl snapshot*
 		echo -n "(add_DIVA_runs=$add_DIVA_runs) ... "
-		for ii in `seq 1 $add_DIVA_runs` ; do
+		for ii in `seq 0 $extraRuns` ; do
 		  ( eval $COMMAND ) >> $RUNLOG 2>&1
 		  echo " additional DIVA run # $ii : done" >> $RUNLOG
 		  mv -f $OUTPUTFILE ${OUTPUTFILE}.diva_${ii}


### PR DESCRIPTION
## What changes does this PR introduce?
Fix problems with some changes from PR #716 when  generating TAF adjoint with  ALLOW_PSBAR_STERIC defined (in ECCO_OPTIONS.h), see issue #725 

## What is the current behaviour? 
TAF get confused about BEGIN_MASTER/END_MASTER additions (from PR #716) leading to major recomputations and significant slow-down.

## What is the new behaviour 
fixed by reverting changes when `pkg/autodiff` is compiled. Also add missing new src code `ecco_read_pickup.f` to `ecco_ad_diff.list`.

## Does this PR introduce a breaking change?
no

## Other information:
None of current AD verification experiments does test ALLOW_PSBAR_STERIC code but this is tested in `verification_other` 2 AD test-experiments `global_oce_cs32` and `global_oce_llc90`.

## Suggested addition to `tag-index`
Not needed if merged just after PR #716