### PR TITLE
Fix usage of ALLOW_AUTODIFF_TAMC/ALLOW_AUTODIFF flags in pkg/seaice

### DIFF
--- a/doc/tag-index
+++ b/doc/tag-index
@@ -1,6 +1,13 @@
     Notes on tags used in MITgcmUV
     ==============================
 
+o pkg/seaice:
+  - fix compile error related to ALLOW_AUTODIFF_TAMC/ALLOW_AUTODIFF mix-up
+    in seaice_evp.F; also replace many ALLOW_AUTODIFF_TAMC by ALLOW_AUTODIFF
+    where code is not specific to TAF/TAMC;
+  - call S/R seaice_get_dynforcing every timestep to always have valid TAUX/Y;
+  - move most of routine body of seaice_dynsolver.F inside the
+    SEAICE_ALLOW_DYNAMICS block.
 o pkg/ecco:
   - fix "sterGloH" output after a restart (issue related to Greatbatch
     correction) by writing & reading (small) new "pickup_ecco" files.

--- a/pkg/seaice/SEAICE.h
+++ b/pkg/seaice/SEAICE.h
@@ -25,15 +25,15 @@ C              note: for non-zero AREA, actual ice thickness is HEFF / AREA
 C     HSNOW :: effective snow thickness in m
 C              at center of grid, i.e., tracer point
 C              note: for non-zero AREA, actual snow thickness is HSNOW / AREA
-C     HSALT :: effective sea ice salinity in g/m^2
-C              at center of grid, i.e., tracer point
 C \ev
 CEOP
 
 C--   Grid variables for seaice
+C     static masks (depend only on geometry)
+C     HEFFM     :: land-sea mask at C-points (copy of maskC(k=kSrf))
+C     SIMaskU/V :: land-sea mask at U/V-points (copies of maskW/S(k=kSrf))
       COMMON/ARRAY/HEFFM, SIMaskU, SIMaskV
       _RL HEFFM      (1-OLx:sNx+OLx,1-OLy:sNy+OLy,nSx,nSy)
-C     static masks (depend only on geometry)
       _RL SIMaskU    (1-OLx:sNx+OLx,1-OLy:sNy+OLy,nSx,nSy)
       _RL SIMaskV    (1-OLx:sNx+OLx,1-OLy:sNy+OLy,nSx,nSy)
 #ifdef SEAICE_CGRID
@@ -49,6 +49,7 @@ C     k1/2AtC    for metric terms in U/V ice equations.
       _RS k2AtC      (1-OLx:sNx+OLx,1-OLy:sNy+OLy,nSx,nSy)
       _RS k2AtZ      (1-OLx:sNx+OLx,1-OLy:sNy+OLy,nSx,nSy)
 #else
+C     UVM         :: B-grid velocity-point mask
       COMMON/ARRAYB/ UVM
       _RS UVM        (1-OLx:sNx+OLx,1-OLy:sNy+OLy,nSx,nSy)
 C     k1/2AtC/U/V :: coefficients at C, U, and V points
@@ -68,10 +69,16 @@ C--   Dynamical variables
 #ifdef SEAICE_ITD
      &                       ,AREAITD,HEFFITD,HSNOWITD,
      &                        opnWtrFrac, fw2ObyRidge
+C     Fields for dynamic ice thickness distribution (ITD)
+C     AREAITD     :: area classes
+C     HEFFITD     :: ice thickenss classes (in meters)
+C     HSNOWITD    :: snow thickness classes (in meters)
+C     openWtrFrac :: fraction of open water (= 1-AREA) for ridging param.
+C     fw2ObyRidge :: fresh water flux (kg/m^2/s) due to snow pushed into
+C                    ocean during ridging
       _RL AREAITD    (1-OLx:sNx+OLx,1-OLy:sNy+OLy,nITD,nSx,nSy)
       _RL HEFFITD    (1-OLx:sNx+OLx,1-OLy:sNy+OLy,nITD,nSx,nSy)
       _RL HSNOWITD   (1-OLx:sNx+OLx,1-OLy:sNy+OLy,nITD,nSx,nSy)
-C     fraction of open water (= 1-AREA) needed for ridging parameterization
       _RL opnWtrFrac (1-OLx:sNx+OLx,1-OLy:sNy+OLy,nSx,nSy)
       _RL fw2ObyRidge(1-OLx:sNx+OLx,1-OLy:sNy+OLy,nSx,nSy)
 #endif /* SEAICE_ITD */
@@ -81,8 +88,15 @@ C     fraction of open water (= 1-AREA) needed for ridging parameterization
       _RL UICE       (1-OLx:sNx+OLx,1-OLy:sNy+OLy,nSx,nSy)
       _RL VICE       (1-OLx:sNx+OLx,1-OLy:sNy+OLy,nSx,nSy)
 
-C     uIceC :: average of UICE between last two time steps
-C     vIceC :: average of VICE between last two time steps
+C     ETA,  etaZ    :: shear viscosity as C-points, at Z-points (N s/m = kg/s)
+C     ZETA, zetaA   :: bulk viscosity at C-points, at Z-points
+C     PRESS         :: maximum vertically integrated ice strength/pressure (N/m)
+C     e11, e22, e12 :: components strain rate tensor (1/s)
+C     deltaC        :: deformation rate tensor invariant, for VP sea ice
+C                      = sqrt( (e11+e22)**2 + (1/e)*(e11-e22)**2 + 4*e12**2) )
+C     FORCEX/Y      :: momentum forcing
+C                      ( units of [rho * h * u / deltaT] = kg/m/s^2 )
+C     u/vIceNm1     :: sea ice drift velocities of previous timestep (m/s)
       COMMON/SEAICE_DYNVARS_3/
      &     ETA,etaZ,ZETA,zetaZ,PRESS, e11, e22, e12, deltaC,
      &     FORCEX,FORCEY,
@@ -106,119 +120,63 @@ C
       _RL uIceNm1    (1-OLx:sNx+OLx,1-OLy:sNy+OLy,nSx,nSy)
       _RL vIceNm1    (1-OLx:sNx+OLx,1-OLy:sNy+OLy,nSx,nSy)
 
-#ifndef SEAICE_CGRID
-      COMMON/SEAICE_DYNVARS_BGRID/ AMASS, DAIRN, uIceC, vIceC
-      _RL AMASS      (1-OLx:sNx+OLx,1-OLy:sNy+OLy,nSx,nSy)
-      _RL DAIRN      (1-OLx:sNx+OLx,1-OLy:sNy+OLy,nSx,nSy)
-      _RL uIceC      (1-OLx:sNx+OLx,1-OLy:sNy+OLy,nSx,nSy)
-      _RL vIceC      (1-OLx:sNx+OLx,1-OLy:sNy+OLy,nSx,nSy)
-#else
+C     DWATN         :: (linear) ice-ocean drag coefficient
+C                      ( units of [rho|u|] = kg/m^2/s )
+C     PRESS0        :: maximal compressive stress/strength (N/m)
+C     FORCEX/Y0     :: external momentum forcing fields (part of FORCEX/Y)
+C     ZMAX/ZMIN     :: maximum/minimum bulk viscosities
+C     tensileStrFac :: factor k to compute the maximal tensile stress k*PRESS0
+      COMMON/SEAICE_DYNVARS_4/
+     &     DWATN, PRESS0, FORCEX0, FORCEY0, ZMAX, ZMIN, tensileStrFac
+      _RL DWATN        (1-OLx:sNx+OLx,1-OLy:sNy+OLy,nSx,nSy)
+      _RL PRESS0       (1-OLx:sNx+OLx,1-OLy:sNy+OLy,nSx,nSy)
+      _RL FORCEX0      (1-OLx:sNx+OLx,1-OLy:sNy+OLy,nSx,nSy)
+      _RL FORCEY0      (1-OLx:sNx+OLx,1-OLy:sNy+OLy,nSx,nSy)
+      _RL ZMAX         (1-OLx:sNx+OLx,1-OLy:sNy+OLy,nSx,nSy)
+      _RL ZMIN         (1-OLx:sNx+OLx,1-OLy:sNy+OLy,nSx,nSy)
+      _RL tensileStrFac(1-OLx:sNx+OLx,1-OLy:sNy+OLy,nSx,nSy)
+
+#ifdef SEAICE_CGRID
+C     seaiceMassC/U/V :: mass (ice+snow) at C/U/V-points ( kg/m^2 )
       COMMON/SEAICE_DYNVARS_CGRID/
      &     seaiceMassC, seaiceMassU, seaiceMassV
       _RL seaiceMassC(1-OLx:sNx+OLx,1-OLy:sNy+OLy,nSx,nSy)
       _RL seaiceMassU(1-OLx:sNx+OLx,1-OLy:sNy+OLy,nSx,nSy)
       _RL seaiceMassV(1-OLx:sNx+OLx,1-OLy:sNy+OLy,nSx,nSy)
-#endif
-
-      COMMON/SEAICE_DYNVARS_4/
-     &     DWATN, PRESS0, FORCEX0, FORCEY0, ZMAX, ZMIN, tensileStrFac
-      _RL DWATN      (1-OLx:sNx+OLx,1-OLy:sNy+OLy,nSx,nSy)
-      _RL PRESS0     (1-OLx:sNx+OLx,1-OLy:sNy+OLy,nSx,nSy)
-      _RL FORCEX0    (1-OLx:sNx+OLx,1-OLy:sNy+OLy,nSx,nSy)
-      _RL FORCEY0    (1-OLx:sNx+OLx,1-OLy:sNy+OLy,nSx,nSy)
-      _RL ZMAX       (1-OLx:sNx+OLx,1-OLy:sNy+OLy,nSx,nSy)
-      _RL ZMIN       (1-OLx:sNx+OLx,1-OLy:sNy+OLy,nSx,nSy)
-C     factor k to compute the maximal tensile stress from k*PRESS0,
-C     in analogy to the maximal compressive stress PRESS0
-      _RL tensileStrFac(1-OLx:sNx+OLx,1-OLy:sNy+OLy,nSx,nSy)
-#ifdef SEAICE_ALLOW_BOTTOMDRAG
-      COMMON/SEAICE_BOTTOMDRAG/ CbotC
-      _RL CbotC      (1-OLx:sNx+OLx,1-OLy:sNy+OLy,nSx,nSy)
-#endif /* SEAICE_ALLOW_BOTTOMDRAG */
-
-      COMMON/SEAICE_REG_NEG/d_HEFFbyNEG,d_HSNWbyNEG
-C     The change of mean ice thickness due to out-of-bounds values following
-C     sea ice dynamics and advection
-      _RL d_HEFFbyNEG (1-OLx:sNx+OLx,1-OLy:sNy+OLy,nSx,nSy)
-      _RL d_HSNWbyNEG (1-OLx:sNx+OLx,1-OLy:sNy+OLy,nSx,nSy)
-C
-#ifdef EXF_SEAICE_FRACTION
-      COMMON/SEAICE_RELAX/d_AREAbyRLX,d_HEFFbyRLX
-C     ICE/SNOW stocks tendency associated with relaxation towards observation
-      _RL d_AREAbyRLX (1-OLx:sNx+OLx,1-OLy:sNy+OLy,nSx,nSy)
-C     The change of mean ice thickness due to relaxation
-      _RL d_HEFFbyRLX (1-OLx:sNx+OLx,1-OLy:sNy+OLy,nSx,nSy)
-#endif /* EXF_SEAICE_FRACTION */
-#ifdef SEAICE_VARIABLE_SALINITY
-      COMMON/SEAICE_SALINITY_R/HSALT, saltFluxAdjust
-      _RL HSALT         (1-OLx:sNx+OLx,1-OLy:sNy+OLy,nSx,nSy)
-      _RL saltFluxAdjust(1-OLx:sNx+OLx,1-OLy:sNy+OLy,nSx,nSy)
-#endif /* SEAICE_VARIABLE_SALINITY */
-
-C     saltWtrIce contains m of salty ice melted (<0) or created (>0)
-C     frWtrIce contains m of freshwater ice melted (<0) or created (>0)
-C              that is, ice due to precipitation or snow
-C     frWtrAtm contains freshwater flux from the atmosphere
-      COMMON/ICEFLUX/ saltWtrIce, frWtrIce
-      _RL saltWtrIce (1-OLx:sNx+OLx,1-OLy:sNy+OLy,nSx,nSy)
-      _RL frWtrIce   (1-OLx:sNx+OLx,1-OLy:sNy+OLy,nSx,nSy)
-
-C     TICES :: Seaice/snow surface temperature for each category
-      COMMON/MULTICATEGORY/TICES
-      _RL TICES      (1-OLx:sNx+OLx,1-OLy:sNy+OLy,nITD,nSx,nSy)
-
-#if (defined (SEAICE_CGRID) && defined (SEAICE_ALLOW_FREEDRIFT))
+C     stressDivergenceX/Y :: div of (vert. integr.) stress tensor (N/m^2)
+      COMMON /SEAICE_STRESSDIV/
+     &     stressDivergenceX, stressDivergenceY
+      _RL stressDivergenceX(1-OLx:sNx+OLx,1-OLy:sNy+OLy,nSx,nSy)
+      _RL stressDivergenceY(1-OLx:sNx+OLx,1-OLy:sNy+OLy,nSx,nSy)
+# ifdef SEAICE_ALLOW_FREEDRIFT
+C     u/vice_fd :: free drift velocities (m/s)
       COMMON /SEAICE_FD_FIELDS/
      &     uice_fd, vice_fd
       _RL uice_fd   (1-OLx:sNx+OLx,1-OLy:sNy+OLy,nSx,nSy)
       _RL vice_fd   (1-OLx:sNx+OLx,1-OLy:sNy+OLy,nSx,nSy)
-#endif
-
-#if (defined (SEAICE_CGRID) && defined (SEAICE_ALLOW_EVP))
+# endif
+# ifdef SEAICE_ALLOW_EVP
 C
 C     additional fields needed by the EVP solver
 C
-C     seaice_sigma1  - sigma11+sigma22, defined at C-points
-C     seaice_sigma2  - sigma11-sigma22, defined at C-points
-C     seaice_sigma12 - off-diagonal term, defined at Z-points
+C     (vertically integrated) stress tensor, with diagonal terms sigma11/22
+C     seaice_sigma1  :: sigma11+sigma22, defined at C-points   (N/m)
+C     seaice_sigma2  :: sigma11-sigma22, defined at C-points   (N/m)
+C     seaice_sigma12 :: off-diagonal term, defined at Z-points (N/m)
       COMMON /SEAICE_EVP_FIELDS/
      &     seaice_sigma1, seaice_sigma2, seaice_sigma12
       _RL seaice_sigma1    (1-OLx:sNx+OLx,1-OLy:sNy+OLy,nSx,nSy)
       _RL seaice_sigma2    (1-OLx:sNx+OLx,1-OLy:sNy+OLy,nSx,nSy)
       _RL seaice_sigma12   (1-OLx:sNx+OLx,1-OLy:sNy+OLy,nSx,nSy)
-#endif /* SEAICE_ALLOW_EVP and SEAICE_CGRID */
+# endif /* SEAICE_ALLOW_EVP */
 
-#ifdef SEAICE_CGRID
-C     stressDivergenceX/Y - divergence of stress tensor
-      COMMON /SEAICE_STRESSDIV/
-     &     stressDivergenceX, stressDivergenceY
-      _RL stressDivergenceX(1-OLx:sNx+OLx,1-OLy:sNy+OLy,nSx,nSy)
-      _RL stressDivergenceY(1-OLx:sNx+OLx,1-OLy:sNy+OLy,nSx,nSy)
-#endif /* SEAICE_CGRID */
+# ifdef SEAICE_ALLOW_BOTTOMDRAG
+C     CbobC :: (linear) bottom drag coefficient for basals stress param.
+      COMMON/SEAICE_BOTTOMDRAG/ CbotC
+      _RL CbotC      (1-OLx:sNx+OLx,1-OLy:sNy+OLy,nSx,nSy)
+# endif /* SEAICE_ALLOW_BOTTOMDRAG */
 
-#ifndef SEAICE_CGRID
-      COMMON/WIND_STRESS_OCE/WINDX,WINDY
-C     WINDX  - zonal      wind stress over water at C points
-C     WINDY  - meridional wind stress over water at C points
-      _RL WINDX      (1-OLx:sNx+OLx,1-OLy:sNy+OLy,nSx,nSy)
-      _RL WINDY      (1-OLx:sNx+OLx,1-OLy:sNy+OLy,nSx,nSy)
-
-      COMMON/GWATXY/GWATX,GWATY
-      _RL GWATX      (1-OLx:sNx+OLx,1-OLy:sNy+OLy,nSx,nSy)
-      _RL GWATY      (1-OLx:sNx+OLx,1-OLy:sNy+OLy,nSx,nSy)
-
-C--   KGEO    Level used as a proxy for geostrophic velocity.
-      COMMON/SEAICE_KGEO/KGEO
-      INTEGER KGEO   (1-OLx:sNx+OLx,1-OLy:sNy+OLy,nSx,nSy)
-#endif
-
-C     SWFracB :: fraction of surface Short-Wave radiation reaching
-C                the bottom of ocean surface level
-      _RL SWFracB
-      COMMON /SEAICE_SW_R/
-     &       SWFracB
-
-#if (defined SEAICE_ALLOW_JFNK) || (defined SEAICE_ALLOW_KRYLOV)
+# if (defined SEAICE_ALLOW_JFNK) || (defined SEAICE_ALLOW_KRYLOV)
 C     diagnostics for the JFNK and Krylov solver
       INTEGER totalNewtonIters
       INTEGER totalNewtonFails
@@ -233,7 +191,74 @@ C     diagnostics for the JFNK and Krylov solver
       PARAMETER ( nVec=2*sNx*sNy )
       _RL scalarProductMetric( nVec, 1, nSx, nSy )
       COMMON /SEAICE_KRYLOV_RL/ scalarProductMetric
-#endif /* SEAICE_ALLOW_JFNK or SEAICE_ALLOW_KRYLOV */
+# endif /* SEAICE_ALLOW_JFNK or SEAICE_ALLOW_KRYLOV */
+
+#else /* ndef SEAICE_CGRID */
+C     AMASS :: sea ice mass
+C     DAIRN :: (linear) atmosphere-ice drag coefficient
+C     uIceC :: average of UICE between last two time steps
+C     vIceC :: average of VICE between last two time steps
+      COMMON/SEAICE_DYNVARS_BGRID/ AMASS, DAIRN, uIceC, vIceC
+      _RL AMASS      (1-OLx:sNx+OLx,1-OLy:sNy+OLy,nSx,nSy)
+      _RL DAIRN      (1-OLx:sNx+OLx,1-OLy:sNy+OLy,nSx,nSy)
+      _RL uIceC      (1-OLx:sNx+OLx,1-OLy:sNy+OLy,nSx,nSy)
+      _RL vIceC      (1-OLx:sNx+OLx,1-OLy:sNy+OLy,nSx,nSy)
+
+      COMMON/WIND_STRESS_OCE/WINDX,WINDY
+C     WINDX  - zonal      wind stress over water at C points
+C     WINDY  - meridional wind stress over water at C points
+      _RL WINDX      (1-OLx:sNx+OLx,1-OLy:sNy+OLy,nSx,nSy)
+      _RL WINDY      (1-OLx:sNx+OLx,1-OLy:sNy+OLy,nSx,nSy)
+
+C     GWATX/Y :: geostrophic ocean velocities
+      COMMON/GWATXY/GWATX,GWATY
+      _RL GWATX      (1-OLx:sNx+OLx,1-OLy:sNy+OLy,nSx,nSy)
+      _RL GWATY      (1-OLx:sNx+OLx,1-OLy:sNy+OLy,nSx,nSy)
+
+C--   KGEO    Level used as a proxy for geostrophic velocity.
+      COMMON/SEAICE_KGEO/KGEO
+      INTEGER KGEO   (1-OLx:sNx+OLx,1-OLy:sNy+OLy,nSx,nSy)
+#endif /* SEAICE_CGRID */
+
+      COMMON/SEAICE_REG_NEG/d_HEFFbyNEG,d_HSNWbyNEG
+C     The change of mean ice thickness due to out-of-bounds values following
+C     sea ice dynamics and advection
+      _RL d_HEFFbyNEG (1-OLx:sNx+OLx,1-OLy:sNy+OLy,nSx,nSy)
+      _RL d_HSNWbyNEG (1-OLx:sNx+OLx,1-OLy:sNy+OLy,nSx,nSy)
+C
+#ifdef EXF_SEAICE_FRACTION
+      COMMON/SEAICE_RELAX/d_AREAbyRLX,d_HEFFbyRLX
+C     ICE/SNOW stocks tendency associated with relaxation towards observation
+      _RL d_AREAbyRLX (1-OLx:sNx+OLx,1-OLy:sNy+OLy,nSx,nSy)
+C     The change of mean ice thickness due to relaxation
+      _RL d_HEFFbyRLX (1-OLx:sNx+OLx,1-OLy:sNy+OLy,nSx,nSy)
+#endif /* EXF_SEAICE_FRACTION */
+
+#ifdef SEAICE_VARIABLE_SALINITY
+C     HSALT          :: effective sea ice salinity in g/m^2
+C                       at center of grid, i.e., tracer point
+C     saltFluxAdjust :: adjust salt flux, if HSALT < 0 (e.g. due to advection)
+      COMMON/SEAICE_SALINITY_R/HSALT, saltFluxAdjust
+      _RL HSALT         (1-OLx:sNx+OLx,1-OLy:sNy+OLy,nSx,nSy)
+      _RL saltFluxAdjust(1-OLx:sNx+OLx,1-OLy:sNy+OLy,nSx,nSy)
+#endif /* SEAICE_VARIABLE_SALINITY */
+
+C     saltWtrIce :: contains m of salty ice melted (<0) or created (>0)
+C     frWtrIce   :: contains m of freshwater ice melted (<0) or created (>0)
+C                   that is, ice due to precipitation or snow
+      COMMON/ICEFLUX/ saltWtrIce, frWtrIce
+      _RL saltWtrIce (1-OLx:sNx+OLx,1-OLy:sNy+OLy,nSx,nSy)
+      _RL frWtrIce   (1-OLx:sNx+OLx,1-OLy:sNy+OLy,nSx,nSy)
+
+C     TICES :: Seaice/snow surface temperature for each category
+      COMMON/MULTICATEGORY/TICES
+      _RL TICES      (1-OLx:sNx+OLx,1-OLy:sNy+OLy,nITD,nSx,nSy)
+
+C     SWFracB :: fraction of surface Short-Wave radiation reaching
+C                the bottom of ocean surface level
+      _RL SWFracB
+      COMMON /SEAICE_SW_R/
+     &       SWFracB
 
 CEH3 ;;; Local Variables: ***
 CEH3 ;;; mode:fortran ***

--- a/pkg/seaice/SEAICE.h
+++ b/pkg/seaice/SEAICE.h
@@ -155,10 +155,9 @@ C     u/vice_fd :: free drift velocities (m/s)
       _RL uice_fd   (1-OLx:sNx+OLx,1-OLy:sNy+OLy,nSx,nSy)
       _RL vice_fd   (1-OLx:sNx+OLx,1-OLy:sNy+OLy,nSx,nSy)
 # endif
+
 # ifdef SEAICE_ALLOW_EVP
-C
-C     additional fields needed by the EVP solver
-C
+C--   Additional fields needed by the EVP solver:
 C     (vertically integrated) stress tensor, with diagonal terms sigma11/22
 C     seaice_sigma1  :: sigma11+sigma22, defined at C-points   (N/m)
 C     seaice_sigma2  :: sigma11-sigma22, defined at C-points   (N/m)

--- a/pkg/seaice/SEAICE_SIZE.h
+++ b/pkg/seaice/SEAICE_SIZE.h
@@ -28,10 +28,8 @@ C-    Maximum Number of tracers
       INTEGER SItrMaxNum
       PARAMETER(SItrMaxNum = 3 )
 
-C-    Define this here, even if it not a parameters to avoid double
-C     declarations
-      INTEGER nEVPstepMax
 #ifdef ALLOW_AUTODIFF
+      INTEGER nEVPstepMax
       PARAMETER ( nEVPstepMax=180 )
       INTEGER NMAX_TICE
       PARAMETER ( NMAX_TICE=10 )

--- a/pkg/seaice/SEAICE_SIZE.h
+++ b/pkg/seaice/SEAICE_SIZE.h
@@ -28,8 +28,10 @@ C-    Maximum Number of tracers
       INTEGER SItrMaxNum
       PARAMETER(SItrMaxNum = 3 )
 
-#ifdef ALLOW_AUTODIFF
+C-    Define this here, even if it not a parameters to avoid double
+C     declarations
       INTEGER nEVPstepMax
+#ifdef ALLOW_AUTODIFF
       PARAMETER ( nEVPstepMax=180 )
       INTEGER NMAX_TICE
       PARAMETER ( NMAX_TICE=10 )

--- a/pkg/seaice/dynsolver.F
+++ b/pkg/seaice/dynsolver.F
@@ -1,4 +1,7 @@
 #include "SEAICE_OPTIONS.h"
+#ifdef ALLOW_EXF
+# include "EXF_OPTIONS.h"
+#endif
 #ifdef ALLOW_AUTODIFF
 # include "AUTODIFF_OPTIONS.h"
 #endif
@@ -24,7 +27,6 @@ C     === Global variables ===
 #include "SEAICE_PARAMS.h"
 #include "SEAICE.h"
 #ifdef ALLOW_EXF
-# include "EXF_OPTIONS.h"
 # include "EXF_FIELDS.h"
 #endif
 #ifdef ALLOW_AUTODIFF_TAMC

--- a/pkg/seaice/dynsolver.F
+++ b/pkg/seaice/dynsolver.F
@@ -77,10 +77,10 @@ C--   Compute proxy for geostrophic velocity,
        DO bi=myBxLo(myThid),myBxHi(myThid)
         DO j=0,sNy+1
          DO i=0,sNx+1
-          GWATX(I,J,bi,bj)=HALF*(uVel(i,j,KGEO(I,J,bi,bj),bi,bj)
-     &                         +uVel(i,j-1,KGEO(I,J,bi,bj),bi,bj))
-          GWATY(I,J,bi,bj)=HALF*(vVel(i,j,KGEO(I,J,bi,bj),bi,bj)
-     &                         +vVel(i-1,j,KGEO(I,J,bi,bj),bi,bj))
+          GWATX(i,j,bi,bj)=HALF*(uVel(i,j,KGEO(i,j,bi,bj),bi,bj)
+     &                         +uVel(i,j-1,KGEO(i,j,bi,bj),bi,bj))
+          GWATY(i,j,bi,bj)=HALF*(vVel(i,j,KGEO(i,j,bi,bj),bi,bj)
+     &                         +vVel(i-1,j,KGEO(i,j,bi,bj),bi,bj))
 #ifdef SEAICE_DEBUG
 c          write(*,'(2i4,2i2,f7.1,7f12.3)')
 c     &     ,i,j,bi,bj,UVM(I,J,bi,bj)
@@ -103,10 +103,10 @@ C--   NOW SET UP MASS PER UNIT AREA AND CORIOLIS TERM
         ENDDO
         DO j=1,sNy
          DO i=1,sNx
-          AMASS(I,J,bi,bj)=RHOICE*QUART*(
+          AMASS(i,j,bi,bj)=RHOICE*QUART*(
      &          HEFF(i,j  ,bi,bj) + HEFF(i-1,j  ,bi,bj)
      &         +HEFF(i,j-1,bi,bj) + HEFF(i-1,j-1,bi,bj) )
-          COR_ICE(I,J,bi,bj)=AMASS(I,J,bi,bj) * _fCoriG(I,J,bi,bj)
+          COR_ICE(i,j,bi,bj)=AMASS(i,j,bi,bj) * _fCoriG(i,j,bi,bj)
          ENDDO
         ENDDO
        ENDDO
@@ -120,10 +120,10 @@ C     locations from wind on tracer locations
        DO bi=myBxLo(myThid),myBxHi(myThid)
         DO j=1,sNy
          DO i=1,sNx
-          U1=QUART*(UWIND(I-1,J-1,bi,bj)+UWIND(I-1,J,bi,bj)
-     &             +UWIND(I  ,J-1,bi,bj)+UWIND(I  ,J,bi,bj))
-          V1=QUART*(VWIND(I-1,J-1,bi,bj)+VWIND(I-1,J,bi,bj)
-     &             +VWIND(I  ,J-1,bi,bj)+VWIND(I  ,J,bi,bj))
+          U1=QUART*(UWIND(i-1,j-1,bi,bj)+UWIND(i-1,j,bi,bj)
+     &             +UWIND(i  ,j-1,bi,bj)+UWIND(i  ,j,bi,bj))
+          V1=QUART*(VWIND(i-1,j-1,bi,bj)+VWIND(i-1,j,bi,bj)
+     &             +VWIND(i  ,j-1,bi,bj)+VWIND(i  ,j,bi,bj))
           AAA=U1**2+V1**2
           IF ( AAA .LE. SEAICE_EPS_SQ ) THEN
              AAA=SEAICE_EPS
@@ -131,29 +131,29 @@ C     locations from wind on tracer locations
              AAA=SQRT(AAA)
           ENDIF
 C first ocean surface stress
-          DAIRN(I,J,bi,bj)=RHOAIR*OCEAN_drag
+          DAIRN(i,j,bi,bj)=RHOAIR*OCEAN_drag
      &         *(2.70 _d 0+0.142 _d 0*AAA+0.0764 _d 0*AAA*AAA)
-          WINDX(I,J,bi,bj)=DAIRN(I,J,bi,bj)*
-     &         (COSWIN*U1-SIGN(SINWIN, _fCori(I,J,bi,bj))*V1)
-          WINDY(I,J,bi,bj)=DAIRN(I,J,bi,bj)*
-     &         (SIGN(SINWIN, _fCori(I,J,bi,bj))*U1+COSWIN*V1)
+          WINDX(i,j,bi,bj)=DAIRN(i,j,bi,bj)*
+     &         (COSWIN*U1-SIGN(SINWIN, _fCori(i,j,bi,bj))*V1)
+          WINDY(i,j,bi,bj)=DAIRN(i,j,bi,bj)*
+     &         (SIGN(SINWIN, _fCori(i,j,bi,bj))*U1+COSWIN*V1)
 
 C now ice surface stress
-          IF ( YC(I,J,bi,bj) .LT. ZERO ) THEN
-           DAIRN(I,J,bi,bj) =
-     &          RHOAIR*(SEAICE_drag_south*AAA*AREA(I,J,bi,bj)
+          IF ( YC(i,j,bi,bj) .LT. ZERO ) THEN
+           DAIRN(i,j,bi,bj) =
+     &          RHOAIR*(SEAICE_drag_south*AAA*AREA(i,j,bi,bj)
      &          +OCEAN_drag*(2.70 _d 0+0.142 _d 0*AAA
-     &          +0.0764 _d 0*AAA*AAA)*(ONE-AREA(I,J,bi,bj)))
+     &          +0.0764 _d 0*AAA*AAA)*(ONE-AREA(i,j,bi,bj)))
           ELSE
-           DAIRN(I,J,bi,bj) =
-     &          RHOAIR*(SEAICE_drag*AAA*AREA(I,J,bi,bj)
+           DAIRN(i,j,bi,bj) =
+     &          RHOAIR*(SEAICE_drag*AAA*AREA(i,j,bi,bj)
      &          +OCEAN_drag*(2.70 _d 0+0.142 _d 0*AAA
-     &          +0.0764 _d 0*AAA*AAA)*(ONE-AREA(I,J,bi,bj)))
+     &          +0.0764 _d 0*AAA*AAA)*(ONE-AREA(i,j,bi,bj)))
           ENDIF
-          FORCEX(I,J,bi,bj)=DAIRN(I,J,bi,bj)*
-     &         (COSWIN*U1-SIGN(SINWIN, _fCori(I,J,bi,bj))*V1)
-          FORCEY(I,J,bi,bj)=DAIRN(I,J,bi,bj)*
-     &         (SIGN(SINWIN, _fCori(I,J,bi,bj))*U1+COSWIN*V1)
+          FORCEX(i,j,bi,bj)=DAIRN(i,j,bi,bj)*
+     &         (COSWIN*U1-SIGN(SINWIN, _fCori(i,j,bi,bj))*V1)
+          FORCEY(i,j,bi,bj)=DAIRN(i,j,bi,bj)*
+     &         (SIGN(SINWIN, _fCori(i,j,bi,bj))*U1+COSWIN*V1)
          ENDDO
         ENDDO
        ENDDO
@@ -192,19 +192,19 @@ C-    add atmospheric loading and Sea-Ice loading
         DO j=1-OLy+1,sNy+OLy
          DO i=1-OLx+1,sNx+OLx
 C--   NOW ADD IN TILT
-          FORCEX(I,J,bi,bj)=FORCEX(I,J,bi,bj)
-     &      -AMASS(I,J,bi,bj)
+          FORCEX(i,j,bi,bj)=FORCEX(i,j,bi,bj)
+     &      -AMASS(i,j,bi,bj)
      &         *( (phiSurf(i, j )-phiSurf(i-1, j ))*SIMaskU(i, j ,bi,bj)
      &           +(phiSurf(i,j-1)-phiSurf(i-1,j-1))*SIMaskV(i,j-1,bi,bj)
-     &          )*HALF*_recip_dxV(I,J,bi,bj)
-          FORCEY(I,J,bi,bj)=FORCEY(I,J,bi,bj)
-     &      -AMASS(I,J,bi,bj)
+     &          )*HALF*_recip_dxV(i,j,bi,bj)
+          FORCEY(i,j,bi,bj)=FORCEY(i,j,bi,bj)
+     &      -AMASS(i,j,bi,bj)
      &         *( (phiSurf( i ,j)-phiSurf( i ,j-1))*SIMaskV( i ,j,bi,bj)
      &           +(phiSurf(i-1,j)-phiSurf(i-1,j-1))*SIMaskV(i-1,j,bi,bj)
-     &          )*HALF*_recip_dyU(I,J,bi,bj)
+     &          )*HALF*_recip_dyU(i,j,bi,bj)
 C NOW KEEP FORCEX0
-          FORCEX0(I,J,bi,bj)=FORCEX(I,J,bi,bj)
-          FORCEY0(I,J,bi,bj)=FORCEY(I,J,bi,bj)
+          FORCEX0(i,j,bi,bj)=FORCEX(i,j,bi,bj)
+          FORCEY0(i,j,bi,bj)=FORCEY(i,j,bi,bj)
          ENDDO
         ENDDO
 #endif /* EXPLICIT_SSH_SLOPE */
@@ -212,22 +212,22 @@ C NOW KEEP FORCEX0
          DO i=1-OLx,sNx+OLx
 #ifndef EXPLICIT_SSH_SLOPE
 C--   NOW ADD IN TILT
-          FORCEX(I,J,bi,bj)=FORCEX(I,J,bi,bj)
-     &         -COR_ICE(I,J,bi,bj)*GWATY(I,J,bi,bj)
-          FORCEY(I,J,bi,bj)=FORCEY(I,J,bi,bj)
-     &         +COR_ICE(I,J,bi,bj)*GWATX(I,J,bi,bj)
+          FORCEX(i,j,bi,bj)=FORCEX(i,j,bi,bj)
+     &         -COR_ICE(i,j,bi,bj)*GWATY(i,j,bi,bj)
+          FORCEY(i,j,bi,bj)=FORCEY(i,j,bi,bj)
+     &         +COR_ICE(i,j,bi,bj)*GWATX(i,j,bi,bj)
 C NOW KEEP FORCEX0
-          FORCEX0(I,J,bi,bj)=FORCEX(I,J,bi,bj)
-          FORCEY0(I,J,bi,bj)=FORCEY(I,J,bi,bj)
+          FORCEX0(i,j,bi,bj)=FORCEX(i,j,bi,bj)
+          FORCEY0(i,j,bi,bj)=FORCEY(i,j,bi,bj)
 #endif /* EXPLICIT_SSH_SLOPE */
 C--   NOW SET UP ICE PRESSURE AND VISCOSITIES
-          PRESS0(I,J,bi,bj)=PSTAR*HEFF(I,J,bi,bj)
+          PRESS0(i,j,bi,bj)=PSTAR*HEFF(i,j,bi,bj)
      &         *EXP(-SEAICE_cStar*(ONE-AREA(i,j,bi,bj)))
 CML          ZMAX(I,J,bi,bj)=(5.0 _d +12/(2.0 _d +04))*PRESS0(I,J,bi,bj)
-          ZMAX(I,J,bi,bj)=SEAICE_zetaMaxFac*PRESS0(I,J,bi,bj)
+          ZMAX(i,j,bi,bj)=SEAICE_zetaMaxFac*PRESS0(i,j,bi,bj)
 CML          ZMIN(I,J,bi,bj)=4.0 _d +08
-          ZMIN(I,J,bi,bj)=SEAICE_zetaMin
-          PRESS0(I,J,bi,bj)=PRESS0(I,J,bi,bj)*HEFFM(I,J,bi,bj)
+          ZMIN(i,j,bi,bj)=SEAICE_zetaMin
+          PRESS0(i,j,bi,bj)=PRESS0(i,j,bi,bj)*HEFFM(i,j,bi,bj)
          ENDDO
         ENDDO
        ENDDO
@@ -253,10 +253,10 @@ C NOW DO PREDICTOR TIME STEP
        DO bi=myBxLo(myThid),myBxHi(myThid)
         DO j=1-OLy,sNy+OLy
          DO i=1-OLx,sNx+OLx
-          UICENM1(I,J,bi,bj)=UICE(I,J,bi,bj)
-          VICENM1(I,J,bi,bj)=VICE(I,J,bi,bj)
-          UICEC(I,J,bi,bj)=UICE(I,J,bi,bj)
-          VICEC(I,J,bi,bj)=VICE(I,J,bi,bj)
+          UICENM1(i,j,bi,bj)=UICE(i,j,bi,bj)
+          VICENM1(i,j,bi,bj)=VICE(i,j,bi,bj)
+          UICEC(i,j,bi,bj)=UICE(i,j,bi,bj)
+          VICEC(i,j,bi,bj)=VICE(i,j,bi,bj)
          ENDDO
         ENDDO
        ENDDO
@@ -274,10 +274,10 @@ C NOW DO MODIFIED EULER STEP
        DO bi=myBxLo(myThid),myBxHi(myThid)
         DO j=1-OLy,sNy+OLy
          DO i=1-OLx,sNx+OLx
-          UICE(I,J,bi,bj)=HALF*(UICE(I,J,bi,bj)+UICENM1(I,J,bi,bj))
-          VICE(I,J,bi,bj)=HALF*(VICE(I,J,bi,bj)+VICENM1(I,J,bi,bj))
-          UICEC(I,J,bi,bj)=UICE(I,J,bi,bj)
-          VICEC(I,J,bi,bj)=VICE(I,J,bi,bj)
+          UICE(i,j,bi,bj)=HALF*(UICE(i,j,bi,bj)+UICENM1(i,j,bi,bj))
+          VICE(i,j,bi,bj)=HALF*(VICE(i,j,bi,bj)+VICENM1(i,j,bi,bj))
+          UICEC(i,j,bi,bj)=UICE(i,j,bi,bj)
+          VICEC(i,j,bi,bj)=VICE(i,j,bi,bj)
          ENDDO
         ENDDO
        ENDDO

--- a/pkg/seaice/seaice_advdiff.F
+++ b/pkg/seaice/seaice_advdiff.F
@@ -136,14 +136,16 @@ CADJ STORE vc   = comlev1, key = ikey_dynamics, kind=isbyte
        DO bi=myBxLo(myThid),myBxHi(myThid)
 C---   loops on tile indices bi,bj
 
-#ifdef ALLOW_AUTODIFF_TAMC
-C     Initialise for TAF
+#ifdef ALLOW_AUTODIFF
+C     Initialise to help AD-tools
         DO j=1-OLy,sNy+OLy
          DO i=1-OLx,sNx+OLx
-          gFld(i,j)       = 0. _d 0
+          gFld(i,j) = 0. _d 0
          ENDDO
         ENDDO
+#endif
 C
+#ifdef ALLOW_AUTODIFF_TAMC
         tkey = bi + (bj-1)*nSx + (ikey_dynamics-1)*nSx*nSy
 CADJ STORE area(:,:,bi,bj)  = comlev1_bibj, key=tkey, kind=isbyte
 CADJ STORE heff(:,:,bi,bj)  = comlev1_bibj, key=tkey, kind=isbyte

--- a/pkg/seaice/seaice_advdiff.F
+++ b/pkg/seaice/seaice_advdiff.F
@@ -435,7 +435,7 @@ C--   store previous value for spurious maxima treament
             SItrPrev(i,j,bi,bj)=SItracer(i,j,bi,bj,iTr)
 #endif
 #ifdef ALLOW_SITRACER_DEBUG_DIAG
-            diagArray(I,J,2+(iTr-1)*5) = SItrExt(i,j,bi,bj)
+            diagArray(i,j,2+(iTr-1)*5) = SItrExt(i,j,bi,bj)
 #endif
            ENDDO
           ENDDO
@@ -467,39 +467,40 @@ C--   scale back to actual value, or move effective value to ocean bucket
          IF (SItrMate(iTr).EQ.'HEFF') THEN
           DO j=1,sNy
            DO i=1,sNx
-            if (HEFF(I,J,bi,bj).GE.siEps) then
-            SItracer(i,j,bi,bj,iTr)=SItrExt(i,j,bi,bj)/HEFF(I,J,bi,bj)
-            SItrBucket(i,j,bi,bj,iTr)=0. _d 0
-            else
-            SItracer(i,j,bi,bj,iTr)=0. _d 0
-            SItrBucket(i,j,bi,bj,iTr)=SItrExt(i,j,bi,bj)
-            endif
+            IF (HEFF(i,j,bi,bj).GE.siEps) THEN
+             SItracer(i,j,bi,bj,iTr)=SItrExt(i,j,bi,bj)/HEFF(i,j,bi,bj)
+             SItrBucket(i,j,bi,bj,iTr)=0. _d 0
+            ELSE
+             SItracer(i,j,bi,bj,iTr)=0. _d 0
+             SItrBucket(i,j,bi,bj,iTr)=SItrExt(i,j,bi,bj)
+            ENDIF
 #ifdef ALLOW_SITRACER_ADVCAP
 C hack to try avoid 'spontaneous generation' of maxima, which supposedly would
 C occur less frequently if we advected SItr with uXheff instead SItrXheff with u
-             tmpscal1=max(SItrPrev(i,j,bi,bj),
+            tmpscal1=max(SItrPrev(i,j,bi,bj),
      &       SItrPrev(i+1,j,bi,bj),SItrPrev(i-1,j,bi,bj),
      &       SItrPrev(i,j+1,bi,bj),SItrPrev(i,j-1,bi,bj))
-             tmpscal2=MAX(ZERO,SItracer(i,j,bi,bj,iTr)-tmpscal1)
-             SItracer(i,j,bi,bj,iTr)=SItracer(i,j,bi,bj,iTr)-tmpscal2
-             SItrBucket(i,j,bi,bj,iTr)=SItrBucket(i,j,bi,bj,iTr)
-     &           +tmpscal2*HEFF(I,J,bi,bj)
+            tmpscal2=MAX(ZERO,SItracer(i,j,bi,bj,iTr)-tmpscal1)
+            SItracer(i,j,bi,bj,iTr)=SItracer(i,j,bi,bj,iTr)-tmpscal2
+            SItrBucket(i,j,bi,bj,iTr)=SItrBucket(i,j,bi,bj,iTr)
+     &           +tmpscal2*HEFF(i,j,bi,bj)
 #endif
 C           treat case of potential negative value
-            if (HEFF(I,J,bi,bj).GE.siEps) then
-              tmpscal1=MIN(0. _d 0,SItracer(i,j,bi,bj,iTr))
-              SItracer(i,j,bi,bj,iTr)=SItracer(i,j,bi,bj,iTr)-tmpscal1
-              SItrBucket(i,j,bi,bj,iTr)=SItrBucket(i,j,bi,bj,iTr)
-     &                                 +HEFF(I,J,bi,bj)*tmpscal1
-            endif
+            IF (HEFF(i,j,bi,bj).GE.siEps) THEN
+             tmpscal1=MIN(0. _d 0,SItracer(i,j,bi,bj,iTr))
+             SItracer(i,j,bi,bj,iTr)=SItracer(i,j,bi,bj,iTr)-tmpscal1
+             SItrBucket(i,j,bi,bj,iTr)=SItrBucket(i,j,bi,bj,iTr)
+     &                                 +HEFF(i,j,bi,bj)*tmpscal1
+            ENDIF
 #ifdef ALLOW_SITRACER_DEBUG_DIAG
-      diagArray(I,J,1+(iTr-1)*5)= - SItrBucket(i,j,bi,bj,iTr)
-     &  *HEFFM(I,J,bi,bj)/SEAICE_deltaTtherm*SEAICE_rhoIce
-      tmpscal1= ( HEFF(I,J,bi,bj)*SItracer(i,j,bi,bj,iTr)
-     &  + SItrBucket(i,j,bi,bj,iTr) )*HEFFM(I,J,bi,bj)
-      diagArray(I,J,2+(iTr-1)*5)= tmpscal1-diagArray(I,J,2+(iTr-1)*5)
-      diagArray(I,J,3+(iTr-1)*5)=HEFFM(i,j,bi,bj) *
-     &  SEAICE_deltaTtherm * gFld(i,j)
+            diagArray(i,j,1+(iTr-1)*5)= -SItrBucket(i,j,bi,bj,iTr)
+     &      * HEFFM(i,j,bi,bj)/SEAICE_deltaTtherm*SEAICE_rhoIce
+            tmpscal1= ( HEFF(i,j,bi,bj)*SItracer(i,j,bi,bj,iTr)
+     &      + SItrBucket(i,j,bi,bj,iTr) )*HEFFM(i,j,bi,bj)
+            diagArray(i,j,2+(iTr-1)*5)= tmpscal1
+     &                                - diagArray(i,j,2+(iTr-1)*5)
+            diagArray(i,j,3+(iTr-1)*5)= HEFFM(i,j,bi,bj)
+     &      * SEAICE_deltaTtherm * gFld(i,j)
 #endif
            ENDDO
           ENDDO
@@ -507,30 +508,30 @@ c TAF?   ELSEIF (SItrMate(iTr).EQ.'AREA') THEN
          ELSE
           DO j=1,sNy
            DO i=1,sNx
-            if (AREA(I,J,bi,bj).GE.SEAICE_area_floor) then
-            SItracer(i,j,bi,bj,iTr)=SItrExt(i,j,bi,bj)/AREA(I,J,bi,bj)
-            else
-            SItracer(i,j,bi,bj,iTr)=0. _d 0
-            endif
+            IF (AREA(i,j,bi,bj).GE.SEAICE_area_floor) THEN
+             SItracer(i,j,bi,bj,iTr)=SItrExt(i,j,bi,bj)/AREA(i,j,bi,bj)
+            ELSE
+             SItracer(i,j,bi,bj,iTr)=0. _d 0
+            ENDIF
             SItrBucket(i,j,bi,bj,iTr)=0. _d 0
 #ifdef ALLOW_SITRACER_ADVCAP
-             tmpscal1=max(SItrPrev(i,j,bi,bj),
+            tmpscal1=max(SItrPrev(i,j,bi,bj),
      &       SItrPrev(i+1,j,bi,bj),SItrPrev(i-1,j,bi,bj),
      &       SItrPrev(i,j+1,bi,bj),SItrPrev(i,j-1,bi,bj))
-             tmpscal2=MAX(ZERO,SItracer(i,j,bi,bj,iTr)-tmpscal1)
-             SItracer(i,j,bi,bj,iTr)=SItracer(i,j,bi,bj,iTr)-tmpscal2
+            tmpscal2=MAX(ZERO,SItracer(i,j,bi,bj,iTr)-tmpscal1)
+            SItracer(i,j,bi,bj,iTr)=SItracer(i,j,bi,bj,iTr)-tmpscal2
 #endif
 C           treat case of potential negative value
-            if (AREA(I,J,bi,bj).GE.SEAICE_area_floor) then
+            IF (AREA(i,j,bi,bj).GE.SEAICE_area_floor) THEN
               tmpscal1=MIN(0. _d 0,SItracer(i,j,bi,bj,iTr))
               SItracer(i,j,bi,bj,iTr)=SItracer(i,j,bi,bj,iTr)-tmpscal1
-            endif
+            ENDIF
 #ifdef ALLOW_SITRACER_DEBUG_DIAG
-      diagArray(I,J,1+(iTr-1)*5)= 0. _d 0
-      diagArray(I,J,2+(iTr-1)*5)= - diagArray(I,J,2+(iTr-1)*5)
-     & + AREA(I,J,bi,bj)*SItracer(i,j,bi,bj,iTr)*HEFFM(I,J,bi,bj)
-      diagArray(I,J,3+(iTr-1)*5)=HEFFM(i,j,bi,bj) *
-     &  SEAICE_deltaTtherm * gFld(i,j)
+            diagArray(i,j,1+(iTr-1)*5)= 0. _d 0
+            diagArray(i,j,2+(iTr-1)*5)= - diagArray(i,j,2+(iTr-1)*5)
+     &      + AREA(i,j,bi,bj)*SItracer(i,j,bi,bj,iTr)*HEFFM(i,j,bi,bj)
+            diagArray(i,j,3+(iTr-1)*5)=HEFFM(i,j,bi,bj)
+     &      * SEAICE_deltaTtherm * gFld(i,j)
 #endif
            ENDDO
           ENDDO
@@ -548,28 +549,28 @@ C---   end bi,bj loops
       ENDDO
 
 #else /* not ALLOW_GENERIC_ADVDIFF */
-      WRITE(msgBuf,'(2A)')
+       WRITE(msgBuf,'(2A)')
      &  'SEAICE_ADVDIFF: cannot use SEAICEmultiDimAdvection',
      &  ' without pkg/generic_advdiff'
-      CALL PRINT_ERROR( msgBuf , myThid )
-      WRITE(msgBuf,'(2A)') 'SEAICE_ADVDIFF: ',
+       CALL PRINT_ERROR( msgBuf , myThid )
+       WRITE(msgBuf,'(2A)') 'SEAICE_ADVDIFF: ',
      &  'Re-compile with pkg "generic_advdiff" in packages.conf'
-      CALL PRINT_ERROR( msgBuf , myThid )
-      CALL ALL_PROC_DIE( myThid )
-      STOP 'ABNORMAL END: S/R SEAICE_ADVDIFF'
+       CALL PRINT_ERROR( msgBuf , myThid )
+       CALL ALL_PROC_DIE( myThid )
+       STOP 'ABNORMAL END: S/R SEAICE_ADVDIFF'
 #endif /* ALLOW_GENERIC_ADVDIFF */
       ELSE
 C--   if not multiDimAdvection
 #ifdef SEAICE_ITD
 C     just for safety
-      WRITE(msgBuf,'(2A)') 'SEAICE_ADVDIFF: ',
+       WRITE(msgBuf,'(2A)') 'SEAICE_ADVDIFF: ',
      &  'ITD with SEAICEmultiDimAdvection=.False. is not allowed,'
-      CALL PRINT_ERROR( msgBuf , myThid )
-      WRITE(msgBuf,'(2A)') 'SEAICE_ADVDIFF: ',
+       CALL PRINT_ERROR( msgBuf , myThid )
+       WRITE(msgBuf,'(2A)') 'SEAICE_ADVDIFF: ',
      &  'use a multidimensional advection scheme (in data.seaice)'
-      CALL PRINT_ERROR( msgBuf , myThid )
-      CALL ALL_PROC_DIE( myThid )
-      STOP 'ABNORMAL END: S/R SEAICE_ADVDIFF'
+       CALL PRINT_ERROR( msgBuf , myThid )
+       CALL ALL_PROC_DIE( myThid )
+       STOP 'ABNORMAL END: S/R SEAICE_ADVDIFF'
 #endif /* SEAICE_ITD */
 
        IF ( SEAICEadvHEff ) THEN

--- a/pkg/seaice/seaice_advection.F
+++ b/pkg/seaice/seaice_advection.F
@@ -170,7 +170,9 @@ C     make local copy to be tampered with if necessary
        CALL PRINT_ERROR( msgBuf, myThid )
        STOP 'ABNORMAL END: S/R SEAICE_ADVECTION'
       ENDIF
+#endif /* ALLOW_AUTODIFF_TAMC */
 C
+#ifdef ALLOW_AUTODIFF
       IF ( inAdMode .AND. useApproxAdvectionInAdMode ) THEN
 C     In AD-mode, we change non-linear, potentially unstable AD advection
 C     schemes to linear schemes with more stability. So far only DST3 with
@@ -180,7 +182,7 @@ C     combination is possible.
      &      advectionScheme = ENUM_DST3
 C     here is room for more advection schemes as this becomes necessary
       ENDIF
-#endif /* ALLOW_AUTODIFF_TAMC */
+#endif /* ALLOW_AUTODIFF */
 
 #ifdef ALLOW_DIAGNOSTICS
 C--   Set diagnostic suffix for the current tracer
@@ -201,7 +203,7 @@ C     These inital values do not alter the numerical results. They
 C     just ensure that all memory references are to valid floating
 C     point numbers. This prevents spurious hardware signals due to
 C     uninitialised but inert locations.
-#ifdef ALLOW_AUTODIFF_TAMC
+#ifdef ALLOW_AUTODIFF
       DO j=1-OLy,sNy+OLy
        DO i=1-OLx,sNx+OLx
         localTij(i,j) = 0. _d 0
@@ -272,7 +274,7 @@ C--   Make local copy of sea-ice field and mask West & South
        ENDDO
       ENDDO
 
-#ifdef ALLOW_AUTODIFF_TAMC
+#ifdef ALLOW_AUTODIFF
 C-     Initialise Advective flux in X & Y
        DO j=1-OLy,sNy+OLy
         DO i=1-OLx,sNx+OLx
@@ -387,7 +389,7 @@ CADJ &     comlev1_bibj_k_gadice_pass, key=dkey, byte=isbyte
           CALL GAD_DST3FL_ADV_X(    bi,bj,k, .TRUE.,
      I         SEAICE_deltaTtherm, uTrans, uFld, maskLocW, localTij,
      O         af, myThid )
-#ifndef ALLOW_AUTODIFF_TAMC
+#ifndef ALLOW_AUTODIFF
          ELSEIF ( advectionScheme.EQ.ENUM_OS7MP ) THEN
           CALL GAD_OS7MP_ADV_X(     bi,bj,k, .TRUE.,
      I         SEAICE_deltaTtherm, uTrans, uFld, maskLocW, localTij,
@@ -601,7 +603,7 @@ CADJ &     comlev1_bibj_k_gadice_pass, key=dkey, byte=isbyte
           CALL GAD_DST3FL_ADV_Y(    bi,bj,k, .TRUE.,
      I         SEAICE_deltaTtherm, vTrans, vFld, maskLocS, localTij,
      O         af, myThid )
-#ifndef ALLOW_AUTODIFF_TAMC
+#ifndef ALLOW_AUTODIFF
          ELSEIF ( advectionScheme.EQ.ENUM_OS7MP ) THEN
           CALL GAD_OS7MP_ADV_Y(     bi,bj,k, .TRUE.,
      I         SEAICE_deltaTtherm, vTrans, vFld, maskLocS, localTij,

--- a/pkg/seaice/seaice_budget_ocean.F
+++ b/pkg/seaice/seaice_budget_ocean.F
@@ -1,4 +1,7 @@
 #include "SEAICE_OPTIONS.h"
+#ifdef ALLOW_EXF
+# include "EXF_OPTIONS.h"
+#endif
 
 CStartOfInterface
       SUBROUTINE SEAICE_BUDGET_OCEAN(
@@ -25,7 +28,6 @@ C     === Global variables ===
 # include "SEAICE_SIZE.h"
 # include "SEAICE_PARAMS.h"
 # ifdef ALLOW_EXF
-#  include "EXF_OPTIONS.h"
 #  include "EXF_FIELDS.h"
 # endif
 #endif

--- a/pkg/seaice/seaice_budget_ocean.F
+++ b/pkg/seaice/seaice_budget_ocean.F
@@ -81,20 +81,20 @@ C
       recip_lhEvap = 1./SEAICE_lhEvap
       recip_rhoConstFresh = 1./rhoConstFresh
 
-      DO J=1,sNy
-       DO I=1,sNx
-        netHeatFlux(I,J) = 0. _d 0
-        SWHeatFlux (I,J) = 0. _d 0
+      DO j=1,sNy
+       DO i=1,sNx
+        netHeatFlux(i,j) = 0. _d 0
+        SWHeatFlux (i,j) = 0. _d 0
 C
 C     MAX_TICE does not exist anly longer, lets see if it works without
 C       tsurfLoc (I,J) = MIN(celsius2K+MAX_TICE,TSURF(I,J))
-        tsurfLoc (I,J) = TSURF(I,J)
+        tsurfLoc (i,j) = TSURF(i,j)
 # ifdef ALLOW_ATM_TEMP
 C     Is this necessary?
-        atempLoc (I,J) = MAX(celsius2K+MIN_ATEMP,ATEMP(I,J,bi,bj))
+        atempLoc (i,j) = MAX(celsius2K+MIN_ATEMP,ATEMP(i,j,bi,bj))
 # endif
 # ifdef ALLOW_DOWNWARD_RADIATION
-        lwdownLoc(I,J) = MAX(MIN_LWDOWN,LWDOWN(I,J,bi,bj))
+        lwdownLoc(i,j) = MAX(MIN_LWDOWN,LWDOWN(i,j,bi,bj))
 # endif
        ENDDO
       ENDDO
@@ -102,11 +102,11 @@ C     Is this necessary?
 
 C NOW DETERMINE OPEN WATER HEAT BUD. ASSUMING TSURF=WATER TEMP.
 C WATER ALBEDO IS ASSUMED TO BE THE CONSTANT SEAICE_waterAlbedo
-      DO J=1,sNy
-       DO I=1,sNx
+      DO j=1,sNy
+       DO i=1,sNx
 #ifdef SEAICE_EXTERNAL_FLUXES
-        netHeatFlux(I,J) = Qnet(I,J,bi,bj)
-        SWHeatFlux (I,J) =  Qsw(I,J,bi,bj)
+        netHeatFlux(i,j) = Qnet(i,j,bi,bj)
+        SWHeatFlux (i,j) =  Qsw(i,j,bi,bj)
 #else /* SEAICE_EXTERNAL_FLUXES undefined */
 C     This is an example of how one could implement surface fluxes
 C     over the ocean (if one dislikes the fluxes computed in pkg/exf).
@@ -116,28 +116,28 @@ C     diagnostics (e.g., hl, hs, lwflux, sflux). To properly
 C     diagnose them, one has to save them again as different (SI-)fields.
 # ifdef ALLOW_DOWNWARD_RADIATION
 C     net upward short wave heat flux
-        SWHeatFlux(I,J) = (SEAICE_waterAlbedo - 1. _d 0)
-     &       *swdown(I,J,bi,bj)
+        SWHeatFlux(i,j) = (SEAICE_waterAlbedo - 1. _d 0)
+     &       *swdown(i,j,bi,bj)
 C     lwup = emissivity*stefanBoltzmann*Tsrf^4 + (1-emissivity)*lwdown
 C     the second terms is the reflected incoming long wave radiation
 C     so that the net upward long wave heat flux is:
-        lwflux(I,J,bi,bj) = - lwdownLoc(I,J)*SEAICE_emissivity
-     &       + D3*tsurfLoc(I,J)**4
-        sstdegC = tsurfLoc(I,J) - TMELT
+        lwflux(i,j,bi,bj) = - lwdownLoc(i,j)*SEAICE_emissivity
+     &       + D3*tsurfLoc(i,j)**4
+        sstdegC = tsurfLoc(i,j) - TMELT
 C     downward sensible heat
-        hs(I,J,bi,bj) = D1*UG(I,J)*(atempLoc(I,J)-tsurfLoc(I,J))
+        hs(i,j,bi,bj) = D1*UG(i,j)*(atempLoc(i,j)-tsurfLoc(i,j))
 C     saturation humidity
         ssq = QS1*6.11 _d 0 *EXP( 17.2694 _d 0
      &                           *sstdegC/(sstdegC+237.3 _d 0) )
 C     downward latent heat
-        hl(I,J,bi,bj) = D1W*UG(I,J)*(AQH(I,J,bi,bj)-ssq)
+        hl(i,j,bi,bj) = D1W*UG(i,j)*(AQH(i,j,bi,bj)-ssq)
 C     net heat is positive upward
-        netHeatFlux(I,J)=SWHeatFlux(I,J)
-     &       + lwflux(I,J,bi,bj)
-     &       - hs(I,J,bi,bj) - hl(I,J,bi,bj)
+        netHeatFlux(i,j)=SWHeatFlux(i,j)
+     &       + lwflux(i,j,bi,bj)
+     &       - hs(i,j,bi,bj) - hl(i,j,bi,bj)
 C     compute evaporation here again because latent heat is different
 C     from its previous value
-        evap(i,j,bi,bj) = -hl(I,J,bi,bj)
+        evap(i,j,bi,bj) = -hl(i,j,bi,bj)
      &       *recip_lhEvap*recip_rhoConstFresh
 C     Salt flux from Precipitation and Evaporation.
         sflux(i,j,bi,bj) = evap(i,j,bi,bj) - precip(i,j,bi,bj)

--- a/pkg/seaice/seaice_calc_viscosities.F
+++ b/pkg/seaice/seaice_calc_viscosities.F
@@ -103,7 +103,7 @@ C--   basic constants
 C
       DO bj=myByLo(myThid),myByHi(myThid)
        DO bi=myBxLo(myThid),myBxHi(myThid)
-#ifdef ALLOW_AUTODIFF_TAMC
+#ifdef ALLOW_AUTODIFF
         DO j=1-OLy,sNy+OLy
          DO i=1-OLx,sNx+OLx
           deltaCreg  (i,j) = SEAICE_deltaMin
@@ -111,7 +111,7 @@ C
           recip_shear(i,j) = 0. _d 0
          ENDDO
         ENDDO
-#endif /* ALLOW_AUTODIFF_TAMC */
+#endif /* ALLOW_AUTODIFF */
 C     need to do this beforehand for easier vectorization after
 C     TAFization
         IF ( SEAICEetaZmethod .EQ. 0 ) THEN
@@ -145,13 +145,13 @@ C     (and energy conserving)
      &                / SQRT( shearDefSq + smallNbrSq )
 C         recip_shear(i,j) = 1. _d 0 / ( shearDef + smallNbr )
 #else
-# ifdef ALLOW_AUTODIFF_TAMC
+# ifdef ALLOW_AUTODIFF
 C     avoid sqrt of 0
           shearDef = 0. _d 0
           IF ( shearDefSq .GT. 0. _d 0 ) shearDef = SQRT(shearDefSq)
 # else
           shearDef = SQRT(shearDefSq)
-# endif /* ALLOW_AUTODIFF_TAMC */
+# endif /* ALLOW_AUTODIFF */
           recip_shear(i,j) = 1. _d 0 / MAX( ShearDef, smallNbr )
 #endif /* SEAICE_DELTA_SMOOTHREG */
          ENDDO
@@ -346,14 +346,14 @@ CML          deltaCsq =
 CML     &         (e11(i,j,bi,bj)**2+e22(i,j,bi,bj)**2)*(ONE+recip_e2)
 CML     &         + 4. _d 0*recip_e2*e12Csq(i,j)
 CML     &         + 2. _d 0*e11(i,j,bi,bj)*e22(i,j,bi,bj)*(ONE-recip_e2)
-#ifdef ALLOW_AUTODIFF_TAMC
+#ifdef ALLOW_AUTODIFF
 C     avoid sqrt of 0
            deltaC(i,j,bi,bj) = 0. _d 0
            IF ( deltaCsq .GT. 0. _d 0 )
      &          deltaC(i,j,bi,bj) = SQRT(deltaCsq)
 #else
            deltaC(i,j,bi,bj) = SQRT(deltaCsq)
-#endif /* ALLOW_AUTODIFF_TAMC */
+#endif /* ALLOW_AUTODIFF */
 #ifdef SEAICE_DELTA_SMOOTHREG
 C     smooth regularization (without max-function) of delta for
 C     better differentiability

--- a/pkg/seaice/seaice_check.F
+++ b/pkg/seaice/seaice_check.F
@@ -596,7 +596,7 @@ C--   SEAICE_MULTICATEGORY is obsolete: issue warning but continue.
       CALL PRINT_MESSAGE( msgBuf, ioUnit, SQUEEZE_RIGHT, myThid )
 #endif /* SEAICE_MULTICATEGORY */
 
-C--   SEAICE_ALLOW_TD_IF is obsolete: issue warning and stop.
+C--   SEAICE_ALLOW_TD_IF is obsolete: issue error and stop.
 #ifdef SEAICE_ALLOW_TD_IF
          WRITE(msgBuf,'(A)')
      &     'SEAICE_ALLOW_TD_IF option is obsolete:'
@@ -607,7 +607,7 @@ C--   SEAICE_ALLOW_TD_IF is obsolete: issue warning and stop.
          errCount = errCount + 1
 #endif /* SEAICE_ALLOW_TD_IF */
 
-C--   SEAICE_DO_OPEN_WATER_GROWTH is obsolete: issue warning and stop.
+C--   SEAICE_DO_OPEN_WATER_GROWTH is obsolete: issue error and stop.
 #if defined(SEAICE_DO_OPEN_WATER_GROWTH) || \
       defined(SEAICE_DO_OPEN_WATER_MELT)
          WRITE(msgBuf,'(2A)') 'SEAICE_CHECK: ',
@@ -619,7 +619,7 @@ C--   SEAICE_DO_OPEN_WATER_GROWTH is obsolete: issue warning and stop.
          errCount = errCount + 1
 #endif /* SEAICE_DO_OPEN_WATER_GROWTH */
 
-C--   SEAICE_OCN_MELT_ACT_ON_AREA is obsolete: issue warning and stop.
+C--   SEAICE_OCN_MELT_ACT_ON_AREA is obsolete: issue error and stop.
 #ifdef SEAICE_OCN_MELT_ACT_ON_AREA
          WRITE(msgBuf,'(A)')
      &     'SEAICE_OCN_MELT_ACT_ON_AREA option is obsolete:'
@@ -630,7 +630,7 @@ C--   SEAICE_OCN_MELT_ACT_ON_AREA is obsolete: issue warning and stop.
          errCount = errCount + 1
 #endif /* SEAICE_OCN_MELT_ACT_ON_AREA */
 
-C--   FENTY_AREA_EXPANSION_CONTRACTION is obsolete: issue warning and stop.
+C--   FENTY_AREA_EXPANSION_CONTRACTION is obsolete: issue error and stop.
 #ifdef FENTY_AREA_EXPANSION_CONTRACTION
          WRITE(msgBuf,'(A)')
      &     'FENTY_AREA_EXPANSION_CONTRACTION option is obsolete:'
@@ -641,7 +641,7 @@ C--   FENTY_AREA_EXPANSION_CONTRACTION is obsolete: issue warning and stop.
          errCount = errCount + 1
 #endif /* SEAICE_DO_OPEN_WATER_MELT */
 
-C--   SEAICE_AGE is obsolete: issue warning and stop.
+C--   SEAICE_AGE is obsolete: issue error and stop.
 #ifdef SEAICE_AGE
          WRITE(msgBuf,'(2A)') 'SEAICE_CHECK: ',
      &     'SEAICE_AGE option is obsolete: '
@@ -652,7 +652,7 @@ C--   SEAICE_AGE is obsolete: issue warning and stop.
          errCount = errCount + 1
 #endif /* SEAICE_AGE */
 
-C--   SEAICE_SALINITY is obsolete: issue warning and stop.
+C--   SEAICE_SALINITY is obsolete: issue error and stop.
 #ifdef SEAICE_SALINITY
          WRITE(msgBuf,'(A)')
      &     'SEAICE_SALINITY option is obsolete'
@@ -663,7 +663,7 @@ C--   SEAICE_SALINITY is obsolete: issue warning and stop.
          errCount = errCount + 1
 #endif /* SEAICE_SALINITY */
 
-C--   SEAICE_OLD_AND_BAD_DISCRETIZATION is obsolete: issue warning and stop.
+C--   SEAICE_OLD_AND_BAD_DISCRETIZATION is obsolete: issue error and stop.
 #ifdef SEAICE_OLD_AND_BAD_DISCRETIZATION
          WRITE(msgBuf,'(A)')
      &     'SEAICE_OLD_AND_BAD_DISCRETIZATION option is obsolete'
@@ -723,8 +723,8 @@ C      without EXF (assuming a simple scaling of wind-stress over ice)
           WRITE(msgBuf,'(A,A)')
      &         'lwFlux is read from lwfluxfile = ',lwfluxfile(1:i)
           CALL PRINT_ERROR( msgBuf, myThid )
-          WRITE(msgBuf,'(A)')
-     &         'implying that lwdown = 0. For pkg/seaice to work '//
+          WRITE(msgBuf,'(2A)')
+     &         'implying that lwdown = 0. For pkg/seaice to work ',
      &         'properly lwdown should be read from lwdownfile!'
           CALL PRINT_ERROR( msgBuf, myThid )
           errCount = errCount + 1
@@ -734,8 +734,8 @@ C      without EXF (assuming a simple scaling of wind-stress over ice)
           WRITE(msgBuf,'(A,A)')
      &         'swFlux is read from swfluxfile = ',swfluxfile(1:i)
           CALL PRINT_ERROR( msgBuf, myThid )
-          WRITE(msgBuf,'(A)')
-     &         'implying that swdown = 0. For pkg/seaice to work '//
+          WRITE(msgBuf,'(2A)')
+     &         'implying that swdown = 0. For pkg/seaice to work ',
      &         'properly swdown should be read from swdownfile!'
           CALL PRINT_ERROR( msgBuf, myThid )
           errCount = errCount + 1
@@ -785,6 +785,7 @@ C     end if usePW79thermodynamics
 
 #ifdef SEAICE_ALLOW_DYNAMICS
       IF ( SEAICEuseDynamics ) THEN
+C--   Check Overlap size:
        IF ( SEAICEuseJFNK ) THEN
         IF ( OLx.LT.3 .OR. OLy.LT.3 ) THEN
          WRITE(msgBuf,'(A,A)')
@@ -833,13 +834,23 @@ C     end if usePW79thermodynamics
          errCount = errCount + 1
         ENDIF
        ENDIF
+C--   Check time-steps:
+# ifdef ALLOW_AUTODIFF
+       IF ( useHB87stressCoupling .AND.
+     &      ( SEAICE_deltaTdyn .GT. SEAICE_deltaTtherm ) )  THEN
+         WRITE(msgBuf,'(2A)') 'SEAICE_CHECK: useHB87stressCoupling',
+     &        ' not working with deltaTdyn > deltaTtherm'
+         CALL PRINT_ERROR( msgBuf, myThid )
+         errCount = errCount + 1
+       ENDIF
+# endif
 
 # ifdef SEAICE_ALLOW_EVP
        IF ( SEAICEuseEVP ) THEN
 #  ifdef ALLOW_AUTODIFF_TAMC
         IF ( SEAICEnEVPstarSteps.GT.nEVPstepMax ) THEN
-         WRITE(msgBuf,'(A)')
-     &        'SEAICE_CHECK: need to set nEVPstepMax to >= '//
+         WRITE(msgBuf,'(2A)')
+     &        'SEAICE_CHECK: need to set nEVPstepMax to >= ',
      &        'SEAICEnEVPstarSteps'
          CALL PRINT_ERROR( msgBuf, myThid )
          WRITE(msgBuf,'(A,I4)')
@@ -851,13 +862,13 @@ C     end if usePW79thermodynamics
         IF ( .NOT.(SEAICEuseEVPstar.OR.SEAICEuseEVPrev)
      &       .AND. SEAICEnEVPstarSteps.NE.
      &       INT(SEAICE_deltaTdyn/SEAICE_deltaTevp) ) THEN
-         WRITE(msgBuf,'(A)') 'SEAICE_CHECK: SEAICEnEVPstarSteps is '//
+         WRITE(msgBuf,'(2A)') 'SEAICE_CHECK: SEAICEnEVPstarSteps is ',
      &        'set in namelist, but SEAICEuseEVPstar = .FALSE.'
          CALL PRINT_ERROR( msgBuf, myThid )
          errCount = errCount + 1
         ENDIF
        ENDIF
-# else
+# else /* SEAICE_ALLOW_EVP */
        IF ( SEAICEuseEVP ) THEN
         WRITE(msgBuf,'(A)')
      &       'SEAICE_CHECK: SEAICEuseEVP = .TRUE., so EVP is turned on'
@@ -865,23 +876,23 @@ C     end if usePW79thermodynamics
         WRITE(msgBuf,'(A)')
      &       'SEAICE_CHECK: by setting appropriate runtime parameters,'
         CALL PRINT_ERROR( msgBuf, myThid )
-        WRITE(msgBuf,'(A)') 'SEAICE_CHECK: but cpp-flag '//
+        WRITE(msgBuf,'(2A)') 'SEAICE_CHECK: but cpp-flag ',
      &       'SEAICE_ALLOW_EVP is not defined in SEAICE_OPTIONS.h'
         CALL PRINT_ERROR( msgBuf, myThid )
         errCount = errCount + 1
        ENDIF
-# endif
+# endif /* SEAICE_ALLOW_EVP */
 
 #ifdef SEAICE_ALLOW_EVP
        IF ( SEAICEuseEVP .AND. (SEAICE_eccfr.NE.SEAICE_eccen) ) THEN
-        WRITE(msgBuf,'(A)') 'SEAICE_CHECK: SEAICEuseEVP = .TRUE., '//
+        WRITE(msgBuf,'(2A)') 'SEAICE_CHECK: SEAICEuseEVP = .TRUE., ',
      &       'so EVP is turned on by setting appropriate'
         CALL PRINT_ERROR( msgBuf, myThid )
         WRITE(msgBuf,'(A,F5.2,A,F5.2,A)')
      &       'SEAICE_CHECK: runtime parameters, but SEAICE_eccfr(=',
      &       SEAICE_eccfr , ')/=SEAICE_eccen(=', SEAICE_eccen, ')'
         CALL PRINT_ERROR( msgBuf, myThid )
-        WRITE(msgBuf,'(A)')'SEAICE_CHECK: implies a non-normal flow '//
+        WRITE(msgBuf,'(2A)')'SEAICE_CHECK: implies a non-normal flow ',
      &       'rule for the elliptical yield curve,'
         CALL PRINT_ERROR( msgBuf, myThid )
         WRITE(msgBuf,'(A)')
@@ -900,10 +911,10 @@ C     end if usePW79thermodynamics
      &      SEAICEuseMCS .OR.
 # endif
      &      .FALSE. ) ) THEN
-        WRITE(msgBuf,'(A)') 'SEAICE_CHECK: SEAICEuseMCS, '//
+        WRITE(msgBuf,'(2A)') 'SEAICE_CHECK: SEAICEuseMCS, ',
      &      'SEAICEuseTD, SEAICEusePL, or SEAICEuseMCE = .TRUE.,'
         CALL PRINT_ERROR( msgBuf, myThid )
-        WRITE(msgBuf,'(A)') 'SEAICE_CHECK: and SEAICEuseEVP = '//
+        WRITE(msgBuf,'(2A)') 'SEAICE_CHECK: and SEAICEuseEVP = ',
      &       '.TRUE., but these non-standard rheologies'
         CALL PRINT_ERROR( msgBuf, myThid )
         WRITE(msgBuf,'(A)')
@@ -934,7 +945,7 @@ C     SEAICEuseDynamics
         WRITE(msgBuf,'(A)')
      &      'SEAICE_CHECK: SEAICE_clipVelocities = .TRUE.'
         CALL PRINT_ERROR( msgBuf, myThid )
-        WRITE(msgBuf,'(A)') 'SEAICE_CHECK: but cpp-flag '//
+        WRITE(msgBuf,'(2A)') 'SEAICE_CHECK: but cpp-flag ',
      &       'SEAICE_ALLOW_CLIPVELS is not defined in SEAICE_OPTIONS.h'
         CALL PRINT_ERROR( msgBuf, myThid )
         errCount = errCount + 1
@@ -944,11 +955,11 @@ C     SEAICEuseDynamics
 #ifndef SEAICE_ALLOW_CLIPZETA
       IF ( SEAICE_evpDampC .GT. 0. _d 0 .OR.
      &     SEAICE_zetaMin  .GT. 0. _d 0 ) THEN
-        WRITE(msgBuf,'(A)')
-     &      'SEAICE_CHECK: SEAICE_evpDampC and/or SEAICE_zetaMin '//
+        WRITE(msgBuf,'(2A)')
+     &      'SEAICE_CHECK: SEAICE_evpDampC and/or SEAICE_zetaMin ',
      &      'are set in data.seaice'
         CALL PRINT_ERROR( msgBuf, myThid )
-        WRITE(msgBuf,'(A)') 'SEAICE_CHECK: but cpp-flag '//
+        WRITE(msgBuf,'(2A)') 'SEAICE_CHECK: but cpp-flag ',
      &       'SEAICE_ALLOW_CLIPZETA is not defined in SEAICE_OPTIONS.h'
         CALL PRINT_ERROR( msgBuf, myThid )
         errCount = errCount + 1
@@ -957,7 +968,7 @@ C     SEAICEuseDynamics
 
 #ifndef SEAICE_ALLOW_TEM
       IF ( SEAICEuseTEM ) THEN
-       WRITE(msgBuf,'(A)') 'SEAICE_CHECK: SEAICEuseTEM requires '//
+       WRITE(msgBuf,'(2A)') 'SEAICE_CHECK: SEAICEuseTEM requires ',
      &      'that SEAICE_ALLOW_TEM is defined.'
        CALL PRINT_ERROR( msgBuf, myThid )
        errCount = errCount + 1
@@ -965,7 +976,7 @@ C     SEAICEuseDynamics
 #endif
 #ifndef SEAICE_ALLOW_MCE
       IF ( SEAICEuseMCE ) THEN
-       WRITE(msgBuf,'(A)') 'SEAICE_CHECK: SEAICEuseMCE requires '//
+       WRITE(msgBuf,'(2A)') 'SEAICE_CHECK: SEAICEuseMCE requires ',
      &      'that SEAICE_ALLOW_MCE is defined.'
        CALL PRINT_ERROR( msgBuf, myThid )
        errCount = errCount + 1
@@ -973,7 +984,7 @@ C     SEAICEuseDynamics
 #endif
 #ifndef SEAICE_ALLOW_MCS
       IF ( SEAICEuseMCS ) THEN
-       WRITE(msgBuf,'(A)') 'SEAICE_CHECK: SEAICEuseMCS requires '//
+       WRITE(msgBuf,'(2A)') 'SEAICE_CHECK: SEAICEuseMCS requires ',
      &      'that SEAICE_ALLOW_MCS is defined.'
        CALL PRINT_ERROR( msgBuf, myThid )
        errCount = errCount + 1
@@ -981,13 +992,13 @@ C     SEAICEuseDynamics
 #endif
 #ifndef SEAICE_ALLOW_TEARDROP
       IF (SEAICEuseTD ) THEN
-       WRITE(msgBuf,'(A)') 'SEAICE_CHECK: SEAICEuseTD requires  '//
+       WRITE(msgBuf,'(2A)') 'SEAICE_CHECK: SEAICEuseTD requires ',
      &      'that SEAICE_ALLOW_TEARDROP is defined.'
        CALL PRINT_ERROR( msgBuf, myThid )
        errCount = errCount + 1
       ENDIF
       IF ( SEAICEusePL ) THEN
-       WRITE(msgBuf,'(A)') 'SEAICE_CHECK: SEAICEusePL requires '//
+       WRITE(msgBuf,'(2A)') 'SEAICE_CHECK: SEAICEusePL requires ',
      &      'that SEAICE_ALLOW_TEARDROP is defined.'
        CALL PRINT_ERROR( msgBuf, myThid )
        errCount = errCount + 1
@@ -1007,7 +1018,7 @@ C     SEAICEuseDynamics
      &     .OR. SEAICEuseMCS
 # endif
      &     .OR. FALSE ) THEN
-       WRITE(msgBuf,'(A)') 'SEAICE_CHECK: non-default rheologies '//
+       WRITE(msgBuf,'(2A)') 'SEAICE_CHECK: non-default rheologies ',
      &      'require that SEAICE_CGRID is defined.'
        CALL PRINT_ERROR( msgBuf, myThid )
        errCount = errCount + 1
@@ -1052,7 +1063,7 @@ C      errCount = errCount + 1
      &     (SEAICEuseTD     .AND. SEAICEuseTEM) .OR.
      &     (SEAICEusePL     .AND. SEAICEuseTEM)
      &     ) THEN
-       WRITE(msgBuf,'(A)') 'SEAICE_CHECK: More than one rheology '//
+       WRITE(msgBuf,'(2A)') 'SEAICE_CHECK: More than one rheology ',
      &      'flag = .TRUE.,'
        CALL PRINT_ERROR( msgBuf, myThid )
        WRITE(msgBuf,'(A)')
@@ -1083,7 +1094,7 @@ C--   SEAICE_ALLOW_FREEDRIFT and SEAICEuseFREEDRIFT
         WRITE(msgBuf,'(A)')
      &      'SEAICE_CHECK: SEAICEadvSalt = .TRUE. but cpp-flag'
         CALL PRINT_ERROR( msgBuf, myThid )
-        WRITE(msgBuf,'(A)') 'SEAICE_CHECK: '//
+        WRITE(msgBuf,'(2A)') 'SEAICE_CHECK: ',
      &   'SEAICE_VARIABLE_SALINITY is undef in SEAICE_OPTIONS.h'
         CALL PRINT_ERROR( msgBuf, myThid )
         errCount = errCount + 1
@@ -1124,7 +1135,7 @@ C--   SEAICE_ALLOW_FREEDRIFT and SEAICEuseFREEDRIFT
         WRITE(msgBuf,'(A)')
      &      'SEAICE_CHECK: SEAICEuseJFNK = .TRUE. but cpp-flag'
         CALL PRINT_ERROR( msgBuf, myThid )
-        WRITE(msgBuf,'(A)') 'SEAICE_CHECK: '//
+        WRITE(msgBuf,'(2A)') 'SEAICE_CHECK: ',
      &   'SEAICE_ALLOW_JFNK is undef in SEAICE_OPTIONS.h'
         CALL PRINT_ERROR( msgBuf, myThid )
         errCount = errCount + 1
@@ -1135,7 +1146,7 @@ C--   SEAICE_ALLOW_FREEDRIFT and SEAICEuseFREEDRIFT
         WRITE(msgBuf,'(A)')
      &      'SEAICE_CHECK: SEAICEuseKRYLOV = .TRUE. but cpp-flag'
         CALL PRINT_ERROR( msgBuf, myThid )
-        WRITE(msgBuf,'(A)') 'SEAICE_CHECK: '//
+        WRITE(msgBuf,'(2A)') 'SEAICE_CHECK: ',
      &   'SEAICE_ALLOW_KRYLOV is undef in SEAICE_OPTIONS.h'
         CALL PRINT_ERROR( msgBuf, myThid )
         errCount = errCount + 1
@@ -1144,21 +1155,21 @@ C--   SEAICE_ALLOW_FREEDRIFT and SEAICEuseFREEDRIFT
 
       IF ( SEAICEuseDynamics .AND. .NOT.SEAICEuseJFNK ) THEN
        IF ( SEAICEuseBDF2 ) THEN
-        WRITE(msgBuf,'(A)') 'SEAICE_CHECK: SEAICEuseBDF2 = .TRUE. '//
+        WRITE(msgBuf,'(2A)') 'SEAICE_CHECK: SEAICEuseBDF2 = .TRUE. ',
      &       'only allowed with SEAICEuseJFNK = .TRUE.'
         CALL PRINT_ERROR( msgBuf, myThid )
         errCount = errCount + 1
        ENDIF
        IF ( SEAICEuseIMEX ) THEN
-        WRITE(msgBuf,'(A)') 'SEAICE_CHECK: SEAICEuseIMEX = .TRUE. '//
+        WRITE(msgBuf,'(2A)') 'SEAICE_CHECK: SEAICEuseIMEX = .TRUE. ',
      &       'only allowed with SEAICEuseJFNK = .TRUE.'
         CALL PRINT_ERROR( msgBuf, myThid )
         errCount = errCount + 1
        ENDIF
       ENDIF
       IF ( SEAICEuseIMEX ) THEN
-       WRITE(msgBuf,'(A)') '** WARNING ** SEAICE_CHECK: '//
-     &      'SEAICEuseIMEX = .TRUE. '//
+       WRITE(msgBuf,'(3A)') '** WARNING ** SEAICE_CHECK: ',
+     &      'SEAICEuseIMEX = .TRUE. ',
      &      'currently has no effect, because the code is missing'
        CALL PRINT_MESSAGE( msgBuf, ioUnit, SQUEEZE_RIGHT, myThid )
       ENDIF
@@ -1167,7 +1178,7 @@ C--   SEAICE_ALLOW_FREEDRIFT and SEAICEuseFREEDRIFT
        WRITE(msgBuf,'(A,I2)')
      &      'SEAICE_CHECK: SEAICEetaZmethod = ', SEAICEetaZmethod
        CALL PRINT_ERROR( msgBuf, myThid )
-       WRITE(msgBuf,'(A)') 'SEAICE_CHECK: '//
+       WRITE(msgBuf,'(2A)') 'SEAICE_CHECK: ',
      &      'is no longer allowed; allowed values are 0 and 3'
        CALL PRINT_ERROR( msgBuf, myThid )
        errCount = errCount + 1
@@ -1178,8 +1189,7 @@ C--   SEAICE_ALLOW_FREEDRIFT and SEAICEuseFREEDRIFT
        WRITE(msgBuf,'(A,I2)')
      &      'SEAICE_CHECK: SEAICEpressReplFac = ', SEAICEpressReplFac
        CALL PRINT_ERROR( msgBuf, myThid )
-       WRITE(msgBuf,'(A)') 'SEAICE_CHECK: '//
-     &      'cannot < 0 or > 1'
+       WRITE(msgBuf,'(A)') 'SEAICE_CHECK: cannot be < 0 or > 1'
        CALL PRINT_ERROR( msgBuf, myThid )
        errCount = errCount + 1
       ENDIF
@@ -1222,7 +1232,7 @@ C--   Some sanity checks for SEAICEdWatMin
        WRITE(msgBuf,'(A,I2)')
      &      'SEAICE_CHECK: SEAICEbasalDragK2 = ', SEAICEbasalDragK2
        CALL PRINT_ERROR( msgBuf, myThid )
-       WRITE(msgBuf,'(A)') 'SEAICE_CHECK: is greater than 0, '//
+       WRITE(msgBuf,'(2A)') 'SEAICE_CHECK: is greater than 0, ',
      &      'but SEAICE_ALLOW_BOTTOMDRAG is not defined'
        CALL PRINT_ERROR( msgBuf, myThid )
        errCount = errCount + 1
@@ -1235,17 +1245,17 @@ C     the zero-layer thermodynamics of S/R SEAICE_GROWTH and the
 C     advection in S/R SEAICE_ADVDIFF
 C     If useThSice=.TRUE., do not reset it here, but issue a warning
       IF ( useThSice ) THEN
-       WRITE(msgBuf,'(A)') '** WARNING ** SEAICE_CHECK: '//
+       WRITE(msgBuf,'(2A)') '** WARNING ** SEAICE_CHECK: ',
      &      'SEAICE_ITD is defined, but useThSice = .TRUE.'
        CALL PRINT_MESSAGE( msgBuf, ioUnit, SQUEEZE_RIGHT, myThid )
        CALL PRINT_MESSAGE( msgBuf, standardMessageUnit,
      &      SQUEEZE_RIGHT, myThid )
-       WRITE(msgBuf,'(A)') '** WARNING ** SEAICE_CHECK: '//
+       WRITE(msgBuf,'(2A)') '** WARNING ** SEAICE_CHECK: ',
      &      'avoids the ice thickness distribution code.'
        CALL PRINT_MESSAGE( msgBuf, ioUnit, SQUEEZE_RIGHT, myThid )
        CALL PRINT_MESSAGE( msgBuf, standardMessageUnit,
      &      SQUEEZE_RIGHT, myThid )
-       WRITE(msgBuf,'(A)') '** WARNING ** SEAICE_CHECK: '//
+       WRITE(msgBuf,'(2A)') '** WARNING ** SEAICE_CHECK: ',
      &      'If you want the ITD code, set useThSice=.FALSE.'
        CALL PRINT_MESSAGE( msgBuf, ioUnit, SQUEEZE_RIGHT, myThid )
        CALL PRINT_MESSAGE( msgBuf, standardMessageUnit,
@@ -1257,10 +1267,10 @@ C
      &      'SEAICE_CHECK: SEAICEmultiDimAdvection = ',
      &      SEAICEmultiDimAdvection
        CALL PRINT_ERROR( msgBuf, myThid )
-       WRITE(msgBuf,'(A)') 'SEAICE_CHECK: is not allowed when '//
+       WRITE(msgBuf,'(2A)') 'SEAICE_CHECK: is not allowed when ',
      &      'SEAICE_ITD is defined'
        CALL PRINT_ERROR( msgBuf, myThid )
-       WRITE(msgBuf,'(A)') 'SEAICE_CHECK: use a multiDimAdvection '//
+       WRITE(msgBuf,'(2A)') 'SEAICE_CHECK: use a multiDimAdvection ',
      &      'scheme instead'
        CALL PRINT_ERROR( msgBuf, myThid )
        errCount = errCount + 1
@@ -1268,8 +1278,8 @@ C
 #endif
 
 #ifdef ALLOW_SEAICE_COST_SMR_AREA
-      WRITE(msgBuf,'(A)')
-     & 'SEAICE_CHECK: cpp-flag ALLOW_SEAICE_COST_SMR_AREA '//
+      WRITE(msgBuf,'(2A)')
+     & 'SEAICE_CHECK: cpp-flag ALLOW_SEAICE_COST_SMR_AREA ',
      & 'is not allowed anymore.'
       CALL PRINT_ERROR( msgBuf, myThid )
       WRITE(msgBuf,'(A)')
@@ -1279,9 +1289,9 @@ C
 #endif
 
       IF ( errCount .GE. 1 ) THEN
-       WRITE(msgBuf,'(A,I3,A)') 'SEAICE_CHECK: ', errCount,
-     &      ' parameter/CPP-flag combinations are '//
-     &      'inconsistent or incomplete'
+       WRITE(msgBuf,'(A,I3,2A)') 'SEAICE_CHECK: ', errCount,
+     &      ' parameter/CPP-flag combinations are',
+     &      ' inconsistent or incomplete'
        CALL PRINT_ERROR( msgBuf, myThid )
        WRITE(msgBuf,'(A,I3,A)')
      &       'SEAICE_CHECK: detected', errCount,' fatal error(s)'

--- a/pkg/seaice/seaice_check.F
+++ b/pkg/seaice/seaice_check.F
@@ -834,16 +834,6 @@ C--   Check Overlap size:
          errCount = errCount + 1
         ENDIF
        ENDIF
-C--   Check time-steps:
-# ifdef ALLOW_AUTODIFF
-       IF ( useHB87stressCoupling .AND.
-     &      ( SEAICE_deltaTdyn .GT. SEAICE_deltaTtherm ) )  THEN
-         WRITE(msgBuf,'(2A)') 'SEAICE_CHECK: useHB87stressCoupling',
-     &        ' not working with deltaTdyn > deltaTtherm'
-         CALL PRINT_ERROR( msgBuf, myThid )
-         errCount = errCount + 1
-       ENDIF
-# endif
 
 # ifdef SEAICE_ALLOW_EVP
        IF ( SEAICEuseEVP ) THEN
@@ -900,17 +890,9 @@ C--   Check time-steps:
         CALL PRINT_ERROR( msgBuf, myThid )
         errCount = errCount + 1
        ENDIF
-       IF ( SEAICEuseEVP .AND. (
-# ifdef SEAICE_ALLOW_TEARDROP
-     &      SEAICEuseTD .OR. SEAICEusePL .OR.
-# endif
-# ifdef SEAICE_ALLOW_MCE
-     &      SEAICEuseMCE .OR.
-# endif
-# ifdef SEAICE_ALLOW_MCS
-     &      SEAICEuseMCS .OR.
-# endif
-     &      .FALSE. ) ) THEN
+       IF ( SEAICEuseEVP .AND.
+     &      ( SEAICEuseTD .OR. SEAICEusePL .OR.
+     &        SEAICEuseMCE .OR.  SEAICEuseMCS ) ) THEN
         WRITE(msgBuf,'(2A)') 'SEAICE_CHECK: SEAICEuseMCS, ',
      &      'SEAICEuseTD, SEAICEusePL, or SEAICEuseMCE = .TRUE.,'
         CALL PRINT_ERROR( msgBuf, myThid )
@@ -1005,19 +987,25 @@ C     SEAICEuseDynamics
       ENDIF
 #endif
 
+      i = 0
+      IF ( SEAICEuseTEM ) i = i + 1
+      IF ( SEAICEuseMCS ) i = i + 1
+      IF ( SEAICEuseMCE ) i = i + 1
+      IF ( SEAICEuseTD  ) i = i + 1
+      IF ( SEAICEusePL  ) i = i + 1
+      IF ( i .GT. 1 ) THEN
+       WRITE(msgBuf,'(2A)') 'SEAICE_CHECK: More than one rheology ',
+     &      'flag = .TRUE.,'
+       CALL PRINT_ERROR( msgBuf, myThid )
+       WRITE(msgBuf,'(A)')
+     &      'SEAICE_CHECK: but only one can be .TRUE. at a time.'
+       CALL PRINT_ERROR( msgBuf, myThid )
+       errCount = errCount + 1
+      ENDIF
+
 #ifndef SEAICE_CGRID
 
-      IF ( SEAICEuseTEM
-# ifdef SEAICE_ALLOW_TEARDROP
-     &     .OR. SEAICEuseTD .OR. SEAICEusePL
-# endif
-# ifdef SEAICE_ALLOW_MCE
-     &     .OR. SEAICEuseMCE
-# endif
-# ifdef SEAICE_ALLOW_MCS
-     &     .OR. SEAICEuseMCS
-# endif
-     &     .OR. FALSE ) THEN
+      IF ( i .GE. 1 ) THEN
        WRITE(msgBuf,'(2A)') 'SEAICE_CHECK: non-default rheologies ',
      &      'require that SEAICE_CGRID is defined.'
        CALL PRINT_ERROR( msgBuf, myThid )
@@ -1049,29 +1037,6 @@ C     SEAICEuseDynamics
 C      errCount = errCount + 1
       ENDIF
 #endif /* ndef SEAICE_CGRID */
-
-#if ( defined SEAICE_ALLOW_TEARDROP || defined SEAICE_ALLOW_MCS || \
-      defined SEAICE_ALLOW_MCE || defined SEAICE_ALLOW_TEM )
-      IF ( (SEAICEuseMCE    .AND. SEAICEuseMCS) .OR.
-     &     (SEAICEuseMCE    .AND. SEAICEuseTD) .OR.
-     &     (SEAICEuseMCE    .AND. SEAICEusePL) .OR.
-     &     (SEAICEuseMCE    .AND. SEAICEuseTEM) .OR.
-     &     (SEAICEuseMCS    .AND. SEAICEuseTD) .OR.
-     &     (SEAICEuseMCS    .AND. SEAICEusePL) .OR.
-     &     (SEAICEuseMCS    .AND. SEAICEuseTEM) .OR.
-     &     (SEAICEuseTD     .AND. SEAICEusePL) .OR.
-     &     (SEAICEuseTD     .AND. SEAICEuseTEM) .OR.
-     &     (SEAICEusePL     .AND. SEAICEuseTEM)
-     &     ) THEN
-       WRITE(msgBuf,'(2A)') 'SEAICE_CHECK: More than one rheology ',
-     &      'flag = .TRUE.,'
-       CALL PRINT_ERROR( msgBuf, myThid )
-       WRITE(msgBuf,'(A)')
-     &      'SEAICE_CHECK: but only one can be .TRUE. at a time.'
-       CALL PRINT_ERROR( msgBuf, myThid )
-       errCount = errCount + 1
-      ENDIF
-#endif
 
 C--   SEAICE_ALLOW_FREEDRIFT and SEAICEuseFREEDRIFT
 #ifndef SEAICE_ALLOW_FREEDRIFT

--- a/pkg/seaice/seaice_dynsolver.F
+++ b/pkg/seaice/seaice_dynsolver.F
@@ -283,7 +283,7 @@ C--   basic forcing by wind stress
           ENDDO
          ENDIF
 
-         IF ( SEAICEuseTILT ) then
+         IF ( SEAICEuseTILT ) THEN
           DO j=1-OLy+1,sNy+OLy
            DO i=1-OLx+1,sNx+OLx
 C--   now add in tilt
@@ -538,7 +538,7 @@ C
      &           + e12(i+1,j+1,bi,bj)**2 + e12(i  ,j+1,bi,bj)**2 )
 C     shear deformation as sqrt((e11-e22)**2 + 4*e12**2); the 4 pulled into
 C     the average
-            sig1(i,j) = sqrt(sigm*sigm + sigTmp)
+            sig1(i,j) = SQRT(sigm*sigm + sigTmp)
            ENDDO
           ENDDO
           CALL DIAGNOSTICS_FILL(sig1,'SIshear ',0,1,2,bi,bj,myThid)

--- a/pkg/seaice/seaice_dynsolver.F
+++ b/pkg/seaice/seaice_dynsolver.F
@@ -133,7 +133,8 @@ C     in S/R seaice_ocean_stress
      O     TAUX, TAUY,
      I     myTime, myIter, myThid )
 
-      IF (
+#ifdef SEAICE_ALLOW_DYNAMICS
+      IF ( SEAICEuseDYNAMICS .AND.
      &  DIFFERENT_MULTIPLE(SEAICE_deltaTdyn,myTime,SEAICE_deltaTtherm)
      &   ) THEN
 
@@ -143,166 +144,164 @@ CADJ STORE zmax   = comlev1, key=ikey_dynamics, kind=isbyte
 #endif /* ALLOW_AUTODIFF_TAMC and SEAICE_ALLOW_EVP */
 
 C--   NOW SET UP MASS PER UNIT AREA AND CORIOLIS TERM
-      DO bj=myByLo(myThid),myByHi(myThid)
-       DO bi=myBxLo(myThid),myBxHi(myThid)
-        DO j=1-OLy+1,sNy+OLy
-         DO i=1-OLx+1,sNx+OLx
-          seaiceMassC(i,j,bi,bj)=SEAICE_rhoIce*HEFF(i,j,bi,bj)
-          seaiceMassU(i,j,bi,bj)=SEAICE_rhoIce*HALF*(
-     &          HEFF(i,j,bi,bj) + HEFF(i-1,j  ,bi,bj) )
-          seaiceMassV(i,j,bi,bj)=SEAICE_rhoIce*HALF*(
-     &          HEFF(i,j,bi,bj) + HEFF(i  ,j-1,bi,bj) )
-         ENDDO
-        ENDDO
-        IF ( SEAICEaddSnowMass ) THEN
-         DO j=1-OLy+1,sNy+OLy
-          DO i=1-OLx+1,sNx+OLx
-           seaiceMassC(i,j,bi,bj)=seaiceMassC(i,j,bi,bj)
-     &          +                 SEAICE_rhoSnow*HSNOW(i,j,bi,bj)
-           seaiceMassU(i,j,bi,bj)=seaiceMassU(i,j,bi,bj)
-     &         +                  SEAICE_rhoSnow*HALF*(
-     &          HSNOW(i,j,bi,bj) + HSNOW(i-1,j  ,bi,bj) )
-
-           seaiceMassV(i,j,bi,bj)=seaiceMassV(i,j,bi,bj)
-     &         +                  SEAICE_rhoSnow*HALF*(
-     &          HSNOW(i,j,bi,bj) + HSNOW(i  ,j-1,bi,bj) )
-          ENDDO
-         ENDDO
-        ENDIF
-       ENDDO
-      ENDDO
-
-#ifndef ALLOW_AUTODIFF
-      IF ( SEAICE_maskRHS ) THEN
-C     dynamic masking of areas with no ice, not recommended
-C     and only kept for testing purposes
        DO bj=myByLo(myThid),myByHi(myThid)
         DO bi=myBxLo(myThid),myBxHi(myThid)
          DO j=1-OLy+1,sNy+OLy
           DO i=1-OLx+1,sNx+OLx
-           seaiceMaskU(i,j,bi,bj)=AREA(i,j,bi,bj)+AREA(i-1,j,bi,bj)
-           mask_uice=HEFFM(i,j,bi,bj)+HEFFM(i-1,j  ,bi,bj)
-           IF ( (seaiceMaskU(i,j,bi,bj) .GT. 0. _d 0) .AND.
-     &         (mask_uice .GT. 1.5 _d 0) ) THEN
-            seaiceMaskU(i,j,bi,bj) = 1. _d 0
-           ELSE
-            seaiceMaskU(i,j,bi,bj) = 0. _d 0
-           ENDIF
-           seaiceMaskV(i,j,bi,bj)=AREA(i,j,bi,bj)+AREA(i,j-1,bi,bj)
-           mask_vice=HEFFM(i,j,bi,bj)+HEFFM(i  ,j-1,bi,bj)
-           IF ( (seaiceMaskV(i,j,bi,bj) .GT. 0. _d 0) .AND.
-     &         (mask_vice .GT. 1.5 _d 0) ) THEN
-            seaiceMaskV(i,j,bi,bj) = 1. _d 0
-           ELSE
-            seaiceMaskV(i,j,bi,bj) = 0. _d 0
-           ENDIF
+           seaiceMassC(i,j,bi,bj)=SEAICE_rhoIce*HEFF(i,j,bi,bj)
+           seaiceMassU(i,j,bi,bj)=SEAICE_rhoIce*HALF*(
+     &          HEFF(i,j,bi,bj) + HEFF(i-1,j  ,bi,bj) )
+           seaiceMassV(i,j,bi,bj)=SEAICE_rhoIce*HALF*(
+     &          HEFF(i,j,bi,bj) + HEFF(i  ,j-1,bi,bj) )
+          ENDDO
+         ENDDO
+         IF ( SEAICEaddSnowMass ) THEN
+          DO j=1-OLy+1,sNy+OLy
+           DO i=1-OLx+1,sNx+OLx
+            seaiceMassC(i,j,bi,bj)=seaiceMassC(i,j,bi,bj)
+     &           +                 SEAICE_rhoSnow*HSNOW(i,j,bi,bj)
+            seaiceMassU(i,j,bi,bj)=seaiceMassU(i,j,bi,bj)
+     &           +                  SEAICE_rhoSnow*HALF*(
+     &           HSNOW(i,j,bi,bj) + HSNOW(i-1,j  ,bi,bj) )
+
+            seaiceMassV(i,j,bi,bj)=seaiceMassV(i,j,bi,bj)
+     &           +                  SEAICE_rhoSnow*HALF*(
+     &           HSNOW(i,j,bi,bj) + HSNOW(i  ,j-1,bi,bj) )
+           ENDDO
+          ENDDO
+         ENDIF
+        ENDDO
+       ENDDO
+
+#ifndef ALLOW_AUTODIFF
+       IF ( SEAICE_maskRHS ) THEN
+C     dynamic masking of areas with no ice, not recommended
+C     and only kept for testing purposes
+        DO bj=myByLo(myThid),myByHi(myThid)
+         DO bi=myBxLo(myThid),myBxHi(myThid)
+          DO j=1-OLy+1,sNy+OLy
+           DO i=1-OLx+1,sNx+OLx
+            seaiceMaskU(i,j,bi,bj)=AREA(i,j,bi,bj)+AREA(i-1,j,bi,bj)
+            mask_uice=HEFFM(i,j,bi,bj)+HEFFM(i-1,j  ,bi,bj)
+            IF ( (seaiceMaskU(i,j,bi,bj) .GT. 0. _d 0) .AND.
+     &           (mask_uice .GT. 1.5 _d 0) ) THEN
+             seaiceMaskU(i,j,bi,bj) = 1. _d 0
+            ELSE
+             seaiceMaskU(i,j,bi,bj) = 0. _d 0
+            ENDIF
+            seaiceMaskV(i,j,bi,bj)=AREA(i,j,bi,bj)+AREA(i,j-1,bi,bj)
+            mask_vice=HEFFM(i,j,bi,bj)+HEFFM(i  ,j-1,bi,bj)
+            IF ( (seaiceMaskV(i,j,bi,bj) .GT. 0. _d 0) .AND.
+     &           (mask_vice .GT. 1.5 _d 0) ) THEN
+             seaiceMaskV(i,j,bi,bj) = 1. _d 0
+            ELSE
+             seaiceMaskV(i,j,bi,bj) = 0. _d 0
+            ENDIF
+           ENDDO
           ENDDO
          ENDDO
         ENDDO
-       ENDDO
-       CALL EXCH_UV_XY_RL( seaiceMaskU, seaiceMaskV, .FALSE., myThid )
-      ENDIF
+        CALL EXCH_UV_XY_RL( seaiceMaskU, seaiceMaskV, .FALSE., myThid )
+       ENDIF
 #endif /* ndef ALLOW_AUTODIFF */
 
 C--   NOW SET UP FORCING FIELDS
 
 C     initialise fields
 #if (defined ALLOW_AUTODIFF && defined SEAICE_ALLOW_EVP)
-      DO bj=myByLo(myThid),myByHi(myThid)
-       DO bi=myBxLo(myThid),myBxHi(myThid)
-        DO j=1-OLy,sNy+OLy
-         DO i=1-OLx,sNx+OLx
-          stressDivergenceX(i,j,bi,bj) = 0. _d 0
-          stressDivergenceY(i,j,bi,bj) = 0. _d 0
+       DO bj=myByLo(myThid),myByHi(myThid)
+        DO bi=myBxLo(myThid),myBxHi(myThid)
+         DO j=1-OLy,sNy+OLy
+          DO i=1-OLx,sNx+OLx
+           stressDivergenceX(i,j,bi,bj) = 0. _d 0
+           stressDivergenceY(i,j,bi,bj) = 0. _d 0
+          ENDDO
          ENDDO
         ENDDO
        ENDDO
-      ENDDO
 #endif
 
-      DO bj=myByLo(myThid),myByHi(myThid)
-       DO bi=myBxLo(myThid),myBxHi(myThid)
+       DO bj=myByLo(myThid),myByHi(myThid)
+        DO bi=myBxLo(myThid),myBxHi(myThid)
 C--   Compute surface pressure at z==0:
 C-    use actual sea surface height for tilt computations
-        IF ( usingPCoords ) THEN
-         DO j=1-OLy,sNy+OLy
-          DO i=1-OLx,sNx+OLx
-           phiSurf(i,j) = phiHydLow(i,j,bi,bj)
-          ENDDO
-         ENDDO
-        ELSE
-         DO j=1-OLy,sNy+OLy
-          DO i=1-OLx,sNx+OLx
-           phiSurf(i,j) = Bo_surf(i,j,bi,bj)*etaN(i,j,bi,bj)
-          ENDDO
-         ENDDO
-        ENDIF
-#ifdef ATMOSPHERIC_LOADING
-C--   add atmospheric loading and Sea-Ice loading as it is done for phi0surf
-C--   in S/R external_forcing_surf
-        IF ( usingZCoords ) THEN
-         IF ( useRealFreshWaterFlux ) THEN
+         IF ( usingPCoords ) THEN
           DO j=1-OLy,sNy+OLy
            DO i=1-OLx,sNx+OLx
-            phiSurf(i,j) = phiSurf(i,j)
-     &                   + ( pload(i,j,bi,bj)
-     &                      +sIceLoad(i,j,bi,bj)*gravity*sIceLoadFac
-     &                     )*recip_rhoConst
+            phiSurf(i,j) = phiHydLow(i,j,bi,bj)
            ENDDO
           ENDDO
          ELSE
           DO j=1-OLy,sNy+OLy
            DO i=1-OLx,sNx+OLx
-            phiSurf(i,j) = phiSurf(i,j)
-     &                   + pload(i,j,bi,bj)*recip_rhoConst
+            phiSurf(i,j) = Bo_surf(i,j,bi,bj)*etaN(i,j,bi,bj)
            ENDDO
           ENDDO
          ENDIF
-C       ELSEIF ( usingPCoords ) THEN
+#ifdef ATMOSPHERIC_LOADING
+C--   add atmospheric loading and Sea-Ice loading as it is done for phi0surf
+C--   in S/R external_forcing_surf
+         IF ( usingZCoords ) THEN
+          IF ( useRealFreshWaterFlux ) THEN
+           DO j=1-OLy,sNy+OLy
+            DO i=1-OLx,sNx+OLx
+             phiSurf(i,j) = phiSurf(i,j)
+     &                    + ( pload(i,j,bi,bj)
+     &                       +sIceLoad(i,j,bi,bj)*gravity*sIceLoadFac
+     &                      )*recip_rhoConst
+            ENDDO
+           ENDDO
+          ELSE
+           DO j=1-OLy,sNy+OLy
+            DO i=1-OLx,sNx+OLx
+             phiSurf(i,j) = phiSurf(i,j)
+     &                    + pload(i,j,bi,bj)*recip_rhoConst
+            ENDDO
+           ENDDO
+          ENDIF
+C        ELSEIF ( usingPCoords ) THEN
 C     The true atmospheric P-loading is not yet implemented for P-coord
 C     (requires time varying dP(Nr) like dP(k-bottom) with NonLin FS).
-        ENDIF
+         ENDIF
 #endif /* ATMOSPHERIC_LOADING */
 C--   basic forcing by wind stress
-        IF ( SEAICEscaleSurfStress ) THEN
-         DO j=1-OLy+1,sNy+OLy
-          DO i=1-OLx+1,sNx+OLx
-           FORCEX0(i,j,bi,bj)=TAUX(i,j,bi,bj)
-     &          * 0.5 _d 0*(AREA(i,j,bi,bj)+AREA(i-1,j,bi,bj))
-           FORCEY0(i,j,bi,bj)=TAUY(i,j,bi,bj)
-     &          * 0.5 _d 0*(AREA(i,j,bi,bj)+AREA(i,j-1,bi,bj))
+         IF ( SEAICEscaleSurfStress ) THEN
+          DO j=1-OLy+1,sNy+OLy
+           DO i=1-OLx+1,sNx+OLx
+            FORCEX0(i,j,bi,bj)=TAUX(i,j,bi,bj)
+     &           * 0.5 _d 0*(AREA(i,j,bi,bj)+AREA(i-1,j,bi,bj))
+            FORCEY0(i,j,bi,bj)=TAUY(i,j,bi,bj)
+     &           * 0.5 _d 0*(AREA(i,j,bi,bj)+AREA(i,j-1,bi,bj))
+           ENDDO
           ENDDO
-         ENDDO
-        ELSE
-         DO j=1-OLy+1,sNy+OLy
-          DO i=1-OLx+1,sNx+OLx
-           FORCEX0(i,j,bi,bj)=TAUX(i,j,bi,bj)
-           FORCEY0(i,j,bi,bj)=TAUY(i,j,bi,bj)
+         ELSE
+          DO j=1-OLy+1,sNy+OLy
+           DO i=1-OLx+1,sNx+OLx
+            FORCEX0(i,j,bi,bj)=TAUX(i,j,bi,bj)
+            FORCEY0(i,j,bi,bj)=TAUY(i,j,bi,bj)
+           ENDDO
           ENDDO
-         ENDDO
-        ENDIF
+         ENDIF
 
-        IF ( SEAICEuseTILT ) then
-        DO j=1-OLy+1,sNy+OLy
-         DO i=1-OLx+1,sNx+OLx
+         IF ( SEAICEuseTILT ) then
+          DO j=1-OLy+1,sNy+OLy
+           DO i=1-OLx+1,sNx+OLx
 C--   now add in tilt
-          FORCEX0(i,j,bi,bj)=FORCEX0(i,j,bi,bj)
-     &         -seaiceMassU(i,j,bi,bj)*_recip_dxC(i,j,bi,bj)
-     &         *( phiSurf(i,j)-phiSurf(i-1,j) )
-          FORCEY0(i,j,bi,bj)=FORCEY0(i,j,bi,bj)
-     &         -seaiceMassV(i,j,bi,bj)* _recip_dyC(i,j,bi,bj)
-     &         *( phiSurf(i,j)-phiSurf(i,j-1) )
-         ENDDO
+            FORCEX0(i,j,bi,bj)=FORCEX0(i,j,bi,bj)
+     &           -seaiceMassU(i,j,bi,bj)*_recip_dxC(i,j,bi,bj)
+     &           *( phiSurf(i,j)-phiSurf(i-1,j) )
+            FORCEY0(i,j,bi,bj)=FORCEY0(i,j,bi,bj)
+     &           -seaiceMassV(i,j,bi,bj)* _recip_dyC(i,j,bi,bj)
+     &           *( phiSurf(i,j)-phiSurf(i,j-1) )
+           ENDDO
+          ENDDO
+         ENDIF
+
+         CALL SEAICE_CALC_ICE_STRENGTH( bi, bj, myTime, myIter, myThid )
+
         ENDDO
-        ENDIF
-
-        CALL SEAICE_CALC_ICE_STRENGTH( bi, bj, myTime, myIter, myThid )
-
        ENDDO
-      ENDDO
 
-#ifdef SEAICE_ALLOW_DYNAMICS
-      IF ( SEAICEuseDYNAMICS ) THEN
 #ifdef SEAICE_ALLOW_FREEDRIFT
        IF ( SEAICEuseFREEDRIFT .OR. SEAICEuseEVP
      &                         .OR. LSR_mixIniGuess.EQ.0 ) THEN
@@ -370,12 +369,9 @@ C     Jacobian-free Newton Krylov solver (Lemieux et al. 2010, 2012)
 # endif /*  ALLOW_AUTODIFF */
 #endif /* SEAICE_ALLOW_JFNK */
 
-C End of IF (SEAICEuseDYNAMICS ...
+C End of IF (SEAICEuseDYNAMICS and DIFFERENT_MULTIPLE ...
       ENDIF
 #endif /* SEAICE_ALLOW_DYNAMICS */
-
-C End of IF (DIFFERENT_MULTIPLE ...
-      ENDIF
 
 C Update ocean surface stress
       IF ( SEAICEupdateOceanStress ) THEN

--- a/pkg/seaice/seaice_dynsolver.F
+++ b/pkg/seaice/seaice_dynsolver.F
@@ -58,20 +58,21 @@ C     !FUNCTIONS:
 #endif /* ALLOW_DIAGNOSTICS */
 
 C     !LOCAL VARIABLES:
-C     === In Local common block ===
-C     TAUX   :: zonal      wind stress over seaice at U point
-C     TAUY   :: meridional wind stress over seaice at V point
-#ifndef ALLOW_AUTODIFF
-      COMMON /WIND_STRESS_ICE/ TAUX, TAUY
-#endif
-      _RL TAUX   (1-OLx:sNx+OLx,1-OLy:sNy+OLy,nSx,nSy)
-      _RL TAUY   (1-OLx:sNx+OLx,1-OLy:sNy+OLy,nSx,nSy)
 C     === Local variables ===
 C     i,j    :: Loop counters
 C     bi,bj  :: tile counters
       INTEGER i, j, bi, bj
-      _RL phiSurf(1-OLx:sNx+OLx,1-OLy:sNy+OLy)
+#ifdef SEAICE_ALLOW_DYNAMICS
+# ifndef ALLOW_AUTODIFF
       _RL mask_uice, mask_vice
+# endif
+C     phiSurf :: geopotential height at sea surface (including pressure load)
+      _RL phiSurf(1-OLx:sNx+OLx,1-OLy:sNy+OLy)
+#endif
+C     TAUX    :: zonal      wind stress over seaice at U point
+C     TAUY    :: meridional wind stress over seaice at V point
+      _RL TAUX   (1-OLx:sNx+OLx,1-OLy:sNy+OLy,nSx,nSy)
+      _RL TAUY   (1-OLx:sNx+OLx,1-OLy:sNy+OLy,nSx,nSy)
 #ifdef ALLOW_DIAGNOSTICS
 # ifdef ALLOW_AUTODIFF
       _RL strDivX(1-OLx:sNx+OLx,1-OLy:sNy+OLy,nSx,nSy)
@@ -91,18 +92,16 @@ C     bi,bj  :: tile counters
 
       DO bj=myByLo(myThid),myByHi(myThid)
        DO bi=myBxLo(myThid),myBxHi(myThid)
+        DO j=1-OLy,sNy+OLy
+         DO i=1-OLx,sNx+OLx
 #ifdef ALLOW_AUTODIFF
 C Following re-initialisation breaks some "artificial" AD dependencies
 C incured by IF (DIFFERENT_MULTIPLE ... statement
-        DO j=1-OLy,sNy+OLy
-         DO i=1-OLx,sNx+OLx
           PRESS0(i,j,bi,bj) = SEAICE_strength*HEFF(i,j,bi,bj)
      &         *EXP(-SEAICE_cStar*(ONE-AREA(i,j,bi,bj)))
           ZMAX(i,j,bi,bj)   = SEAICE_zetaMaxFac*PRESS0(i,j,bi,bj)
           ZMIN(i,j,bi,bj)   = SEAICE_zetaMin
           PRESS0(i,j,bi,bj) = PRESS0(i,j,bi,bj)*HEFFM(i,j,bi,bj)
-          TAUX(i,j,bi,bj)   = 0. _d 0
-          TAUY(i,j,bi,bj)   = 0. _d 0
 # ifdef SEAICE_ALLOW_FREEDRIFT
           uice_fd(i,j,bi,bj)= 0. _d 0
           vice_fd(i,j,bi,bj)= 0. _d 0
@@ -111,19 +110,13 @@ C incured by IF (DIFFERENT_MULTIPLE ... statement
           strDivX(i,j,bi,bj)= 0. _d 0
           strDivY(i,j,bi,bj)= 0. _d 0
 # endif
+#endif /* ALLOW_AUTODIFF */
+C     Always initialise these local variables, needed for TAF, but also
+C     because they are not completely filled in S/R seaice_get_dynforcing
+          TAUX(i,j,bi,bj) = 0. _d 0
+          TAUY(i,j,bi,bj) = 0. _d 0
          ENDDO
         ENDDO
-#else /* ALLOW_AUTODIFF */
-C Initialise local variables in common block
-        IF ( myIter.EQ.nIter0 ) THEN
-         DO j=1-OLy,sNy+OLy
-          DO i=1-OLx,sNx+OLx
-           TAUX(i,j,bi,bj) = 0. _d 0
-           TAUY(i,j,bi,bj) = 0. _d 0
-          ENDDO
-         ENDDO
-        ENDIF
-#endif /* ALLOW_AUTODIFF */
        ENDDO
       ENDDO
 # ifdef ALLOW_AUTODIFF_TAMC
@@ -132,17 +125,22 @@ CADJ STORE vice    = comlev1, key=ikey_dynamics, kind=isbyte
 CADJ STORE uicenm1 = comlev1, key=ikey_dynamics, kind=isbyte
 CADJ STORE vicenm1 = comlev1, key=ikey_dynamics, kind=isbyte
 # endif /* ALLOW_AUTODIFF_TAMC */
+C--   interface of dynamics with atmopheric forcing fields (wind/stress)
+C     Call this in each time step so that we can use the surface stress
+C     in S/R seaice_ocean_stress
+      CALL SEAICE_GET_DYNFORCING (
+     I     uIce, vIce, AREA, SIMaskU, SIMaskV,
+     O     TAUX, TAUY,
+     I     myTime, myIter, myThid )
 
       IF (
      &  DIFFERENT_MULTIPLE(SEAICE_deltaTdyn,myTime,SEAICE_deltaTtherm)
      &   ) THEN
 
-# ifdef ALLOW_AUTODIFF_TAMC
-# ifdef SEAICE_ALLOW_EVP
+#if (defined ALLOW_AUTODIFF_TAMC && defined SEAICE_ALLOW_EVP)
 CADJ STORE press0 = comlev1, key=ikey_dynamics, kind=isbyte
 CADJ STORE zmax   = comlev1, key=ikey_dynamics, kind=isbyte
-# endif
-# endif /* ALLOW_AUTODIFF_TAMC */
+#endif /* ALLOW_AUTODIFF_TAMC and SEAICE_ALLOW_EVP */
 
 C--   NOW SET UP MASS PER UNIT AREA AND CORIOLIS TERM
       DO bj=myByLo(myThid),myByHi(myThid)
@@ -209,32 +207,18 @@ C     and only kept for testing purposes
 C--   NOW SET UP FORCING FIELDS
 
 C     initialise fields
+#if (defined ALLOW_AUTODIFF && defined SEAICE_ALLOW_EVP)
       DO bj=myByLo(myThid),myByHi(myThid)
        DO bi=myBxLo(myThid),myBxHi(myThid)
         DO j=1-OLy,sNy+OLy
          DO i=1-OLx,sNx+OLx
-          TAUX (i,j,bi,bj)= 0. _d 0
-          TAUY (i,j,bi,bj)= 0. _d 0
-#ifdef ALLOW_AUTODIFF
-# ifdef SEAICE_ALLOW_EVP
           stressDivergenceX(i,j,bi,bj) = 0. _d 0
           stressDivergenceY(i,j,bi,bj) = 0. _d 0
-# endif
-#endif
          ENDDO
         ENDDO
        ENDDO
       ENDDO
-
-# ifdef ALLOW_AUTODIFF_TAMC
-CADJ STORE uice = comlev1, key=ikey_dynamics, kind=isbyte
-CADJ STORE vice = comlev1, key=ikey_dynamics, kind=isbyte
-# endif /* ALLOW_AUTODIFF_TAMC */
-C--   interface of dynamics with atmopheric forcing fields (wind/stress)
-      CALL SEAICE_GET_DYNFORCING (
-     I     uIce, vIce, AREA, SIMaskU, SIMaskV,
-     O     TAUX, TAUY,
-     I     myTime, myIter, myThid )
+#endif
 
       DO bj=myByLo(myThid),myByHi(myThid)
        DO bi=myBxLo(myThid),myBxHi(myThid)
@@ -393,29 +377,23 @@ C End of IF (SEAICEuseDYNAMICS ...
 C End of IF (DIFFERENT_MULTIPLE ...
       ENDIF
 
-#ifdef ALLOW_AUTODIFF_TAMC
-CADJ STORE uice  = comlev1, key=ikey_dynamics, kind=isbyte
-CADJ STORE vice  = comlev1, key=ikey_dynamics, kind=isbyte
-CADJ STORE stressDivergenceX  = comlev1,
-CADJ &     key=ikey_dynamics, kind=isbyte
-CADJ STORE stressDivergenceY  = comlev1,
-CADJ &     key=ikey_dynamics, kind=isbyte
-CADJ STORE DWATN = comlev1, key=ikey_dynamics, kind=isbyte
-#endif /* ALLOW_AUTODIFF_TAMC */
-
 C Update ocean surface stress
       IF ( SEAICEupdateOceanStress ) THEN
+#ifdef ALLOW_AUTODIFF_TAMC
+CADJ STORE uice, vice, DWATN = comlev1, key=ikey_dynamics, kind=isbyte
+CADJ STORE stressDivergenceX = comlev1, key=ikey_dynamics, kind=isbyte
+CADJ STORE stressDivergenceY = comlev1, key=ikey_dynamics, kind=isbyte
+#endif /* ALLOW_AUTODIFF_TAMC */
         CALL SEAICE_OCEAN_STRESS (
      I              TAUX, TAUY, myTime, myIter, myThid )
       ENDIF
 
-#ifdef SEAICE_ALLOW_DYNAMICS
-#ifdef SEAICE_ALLOW_CLIPVELS
+#if (defined SEAICE_ALLOW_DYNAMICS && defined SEAICE_ALLOW_CLIPVELS)
       IF ( SEAICEuseDYNAMICS .AND. SEAICE_clipVelocities) THEN
-#ifdef ALLOW_AUTODIFF_TAMC
+# ifdef ALLOW_AUTODIFF_TAMC
 CADJ STORE uice = comlev1, key=ikey_dynamics, kind=isbyte
 CADJ STORE vice = comlev1, key=ikey_dynamics, kind=isbyte
-#endif /* ALLOW_AUTODIFF_TAMC */
+# endif /* ALLOW_AUTODIFF_TAMC */
 c Put a cap on ice velocity
 c limit velocity to 0.40 m s-1 to avoid potential CFL violations
 c in open water areas (drift of zero thickness ice)
@@ -432,8 +410,7 @@ c in open water areas (drift of zero thickness ice)
         ENDDO
        ENDDO
       ENDIF
-#endif /* SEAICE_ALLOW_CLIPVELS */
-#endif /* SEAICE_ALLOW_DYNAMICS */
+#endif /* SEAICE_ALLOW_DYNAMICS and SEAICE_ALLOW_CLIPVELS */
 
 #ifdef ALLOW_DIAGNOSTICS
 C     diagnostics related to mechanics/dynamics/momentum equations
@@ -496,7 +473,7 @@ C
 C     stress diagnostics
 C
          IF ( diag_SIsigma_isOn ) THEN
-#ifdef SEAICE_ALLOW_EVP
+# ifdef SEAICE_ALLOW_EVP
 C     This could go directly into EVP, but to keep a better eye on it,
 C     I would like to keep it here.
           IF ( SEAICEuseEVP ) THEN
@@ -521,9 +498,9 @@ C     PRESS = PRESS(n-1), n = number of sub-cycling steps
             ENDDO
            ENDDO
           ELSE
-#else
+# else
           IF ( .TRUE. ) THEN
-#endif /* SEAICE_ALLOW_EVP */
+# endif /* SEAICE_ALLOW_EVP */
            CALL SEAICE_CALC_STRESS(
      I          e11, e22, e12, press, zeta, eta, etaZ,
      O          sig1, sig2, sig12,
@@ -732,7 +709,6 @@ C     bi/bj-loop
        ENDDO
 C     useDiagnostics
       ENDIF
-
 #endif   /* ALLOW_DIAGNOSTICS */
 #endif  /* SEAICE_CGRID */
 

--- a/pkg/seaice/seaice_dynsolver.F
+++ b/pkg/seaice/seaice_dynsolver.F
@@ -61,7 +61,9 @@ C     !LOCAL VARIABLES:
 C     === In Local common block ===
 C     TAUX   :: zonal      wind stress over seaice at U point
 C     TAUY   :: meridional wind stress over seaice at V point
-      COMMON/WIND_STRESS_ICE/TAUX,TAUY
+#ifndef ALLOW_AUTODIFF
+      COMMON /WIND_STRESS_ICE/ TAUX, TAUY
+#endif
       _RL TAUX   (1-OLx:sNx+OLx,1-OLy:sNy+OLy,nSx,nSy)
       _RL TAUY   (1-OLx:sNx+OLx,1-OLy:sNy+OLy,nSx,nSy)
 C     === Local variables ===
@@ -87,25 +89,11 @@ C     bi,bj  :: tile counters
       LOGICAL diag_SIpRfric_isOn, diag_SIpSfric_isOn
 #endif /* ALLOW_DIAGNOSTICS */
 
-C Initialise local variables in common block
-      IF ( myIter.EQ.nIter0 ) THEN
-       DO bj=myByLo(myThid),myByHi(myThid)
-        DO bi=myBxLo(myThid),myBxHi(myThid)
-         DO j=1-OLy,sNy+OLy
-          DO i=1-OLx,sNx+OLx
-           TAUX(i,j,bi,bj) = 0. _d 0
-           TAUY(i,j,bi,bj) = 0. _d 0
-          ENDDO
-         ENDDO
-        ENDDO
-       ENDDO
-      ENDIF
-
-# ifdef ALLOW_AUTODIFF
-C Following re-initialisation breaks some "artificial" AD dependencies
-C incured by IF (DIFFERENT_MULTIPLE ... statement
       DO bj=myByLo(myThid),myByHi(myThid)
        DO bi=myBxLo(myThid),myBxHi(myThid)
+#ifdef ALLOW_AUTODIFF
+C Following re-initialisation breaks some "artificial" AD dependencies
+C incured by IF (DIFFERENT_MULTIPLE ... statement
         DO j=1-OLy,sNy+OLy
          DO i=1-OLx,sNx+OLx
           PRESS0(i,j,bi,bj) = SEAICE_strength*HEFF(i,j,bi,bj)
@@ -125,9 +113,19 @@ C incured by IF (DIFFERENT_MULTIPLE ... statement
 # endif
          ENDDO
         ENDDO
+#else /* ALLOW_AUTODIFF */
+C Initialise local variables in common block
+        IF ( myIter.EQ.nIter0 ) THEN
+         DO j=1-OLy,sNy+OLy
+          DO i=1-OLx,sNx+OLx
+           TAUX(i,j,bi,bj) = 0. _d 0
+           TAUY(i,j,bi,bj) = 0. _d 0
+          ENDDO
+         ENDDO
+        ENDIF
+#endif /* ALLOW_AUTODIFF */
        ENDDO
       ENDDO
-# endif /* ALLOW_AUTODIFF */
 # ifdef ALLOW_AUTODIFF_TAMC
 CADJ STORE uice    = comlev1, key=ikey_dynamics, kind=isbyte
 CADJ STORE vice    = comlev1, key=ikey_dynamics, kind=isbyte

--- a/pkg/seaice/seaice_evp.F
+++ b/pkg/seaice/seaice_evp.F
@@ -397,14 +397,14 @@ C     (and energy conserving) according to Bouillon et al. 2013, eq (11)
            DO i=0,sNx+1
             deltaSq = ep(I,J)**2 + recip_ecc2 * em(I,J)**2
      &           + recip_ecc2 * 4. _d 0 * e12Csq(I,J)
-#ifdef ALLOW_AUTODIFF_TAMC
+#ifdef ALLOW_AUTODIFF
 C     avoid sqrt of 0
             deltaC(I,J,bi,bj) = 0. _d 0
             IF ( deltaSq .GT. 0. _d 0 )
      &           deltaC(I,J,bi,bj) = SQRT(deltaSq)
 #else
             deltaC(I,J,bi,bj) = SQRT(deltaSq)
-#endif /* ALLOW_AUTODIFF_TAMC */
+#endif /* ALLOW_AUTODIFF */
 #ifdef SEAICE_DELTA_SMOOTHREG
 C     smooth regularization (without max-function) of delta for
 C     better differentiability

--- a/pkg/seaice/seaice_evp.F
+++ b/pkg/seaice/seaice_evp.F
@@ -98,6 +98,9 @@ C     betaFacU/V     :: analog betaFacP1U/V
       INTEGER i, j, bi, bj
       INTEGER kSrf
       INTEGER nEVPstep, iEVPstep
+#ifndef ALLOW_AUTODIFF
+      INTEGER nEVPstepMax
+#endif
 #ifdef ALLOW_AUTODIFF_TAMC
 C     evpkey :: tape key (depends on evp iteration)
 C     tkey   :: tape key (depends on tile indices and evpkey)

--- a/pkg/seaice/seaice_evp.F
+++ b/pkg/seaice/seaice_evp.F
@@ -202,10 +202,10 @@ C     copy number of internal time steps from previously defined parameter
 C     SEAICE_evpAlpha = 2. * SEAICE_evpTauRelax/SEAICE_deltaTevp
       DO bj=myByLo(myThid),myByHi(myThid)
        DO bi=myBxLo(myThid),myBxHi(myThid)
-        DO J=1-OLy,sNy+OLy
-         DO I=1-OLx,sNx+OLx
-          denom1(I,J,bi,bj) = 1. _d 0 / ( SEAICE_evpAlpha + 1. _d 0 )
-          denom2(I,J,bi,bj) = 1. _d 0 / ( SEAICE_evpAlpha + ecc2 )
+        DO j=1-OLy,sNy+OLy
+         DO i=1-OLx,sNx+OLx
+          denom1(i,j,bi,bj) = 1. _d 0 / ( SEAICE_evpAlpha + 1. _d 0 )
+          denom2(i,j,bi,bj) = 1. _d 0 / ( SEAICE_evpAlpha + ecc2 )
          ENDDO
         ENDDO
        ENDDO
@@ -226,10 +226,10 @@ C     explicit terms
        recip_evpRevFac = recip_ecc2
        DO bj=myByLo(myThid),myByHi(myThid)
         DO bi=myBxLo(myThid),myBxHi(myThid)
-         DO J=1-OLy,sNy+OLy
-          DO I=1-OLx,sNx+OLx
-           denom1(I,J,bi,bj)     = 1. _d 0 / SEAICE_evpAlpha
-           denom2(I,J,bi,bj)     = denom1(i,j,bi,bj)
+         DO j=1-OLy,sNy+OLy
+          DO i=1-OLx,sNx+OLx
+           denom1(i,j,bi,bj)     = 1. _d 0 / SEAICE_evpAlpha
+           denom2(i,j,bi,bj)     = denom1(i,j,bi,bj)
           ENDDO
          ENDDO
         ENDDO
@@ -252,34 +252,34 @@ C
         DO j=1-OLy,sNy+OLy
          DO i=1-OLx,sNx+OLx
 C     use u/vIce as work arrays: copy previous time step to u/vIceNm1
-          uIceNm1(I,J,bi,bj)   = uIce(I,J,bi,bj)
-          vIceNm1(I,J,bi,bj)   = vIce(I,J,bi,bj)
+          uIceNm1(i,j,bi,bj)   = uIce(i,j,bi,bj)
+          vIceNm1(i,j,bi,bj)   = vIce(i,j,bi,bj)
 C     initialise strain rates
-          e11  (I,J,bi,bj)     = 0. _d 0
-          e22  (I,J,bi,bj)     = 0. _d 0
-          e12  (I,J,bi,bj)     = 0. _d 0
+          e11  (i,j,bi,bj)     = 0. _d 0
+          e22  (i,j,bi,bj)     = 0. _d 0
+          e12  (i,j,bi,bj)     = 0. _d 0
 C     initialise adative-EVP-specific fields
-          evpAlphaC(I,J,bi,bj) = SEAICE_evpAlpha
-          evpAlphaZ(I,J,bi,bj) = SEAICE_evpAlpha
-          evpBetaU (I,J,bi,bj) = SEAICE_evpBeta
-          evpBetaV (I,J,bi,bj) = SEAICE_evpBeta
+          evpAlphaC(i,j,bi,bj) = SEAICE_evpAlpha
+          evpAlphaZ(i,j,bi,bj) = SEAICE_evpAlpha
+          evpBetaU (i,j,bi,bj) = SEAICE_evpBeta
+          evpBetaV (i,j,bi,bj) = SEAICE_evpBeta
          ENDDO
         ENDDO
 C     initialise fractional areas at velocity points
         IF ( SEAICEscaleSurfStress ) THEN
-         DO J=1,sNy
-          DO I=1,sNx
-           areaW(I,J,bi,bj) =
-     &          0.5 _d 0*(AREA(I,J,bi,bj)+AREA(I-1,J,bi,bj))
-           areaS(I,J,bi,bj) =
-     &          0.5 _d 0*(AREA(I,J,bi,bj)+AREA(I,J-1,bi,bj))
+         DO j=1,sNy
+          DO i=1,sNx
+           areaW(i,j,bi,bj) =
+     &          0.5 _d 0*(AREA(i,j,bi,bj)+AREA(i-1,j,bi,bj))
+           areaS(i,j,bi,bj) =
+     &          0.5 _d 0*(AREA(i,j,bi,bj)+AREA(i,j-1,bi,bj))
           ENDDO
          ENDDO
         ELSE
-         DO J=1,sNy
-          DO I=1,sNx
-           areaW(I,J,bi,bj) = 1. _d 0
-           areaS(I,J,bi,bj) = 1. _d 0
+         DO j=1,sNy
+          DO i=1,sNx
+           areaW(i,j,bi,bj) = 1. _d 0
+           areaS(i,j,bi,bj) = 1. _d 0
           ENDDO
          ENDDO
         ENDIF
@@ -296,7 +296,7 @@ CML     &      /SEAICE_deltaTevp**2
         DO bi=myBxLo(myThid),myBxHi(myThid)
          DO j=1-OLy,sNy+OLy
           DO i=1-OLx,sNx+OLx
-           zMax (I,J,bi,bj)   = _rA(I,J,bi,bj) * fac
+           zMax (i,j,bi,bj)   = _rA(i,j,bi,bj) * fac
           ENDDO
          ENDDO
         ENDDO
@@ -343,26 +343,26 @@ C     save previous (p-1) iteration
           IF ( printResidual ) THEN
            DO j=1,sNy
             DO i=1,sNx
-             sig11Pm1(I,J,bi,bj) = seaice_sigma1(I,J,bi,bj)
-             sig22Pm1(I,J,bi,bj) = seaice_sigma2(I,J,bi,bj)
-             sig12Pm1(I,J,bi,bj) = seaice_sigma12(I,J,bi,bj)
-             uIcePm1 (I,J,bi,bj) = uIce(i,j,bi,bj)
-             vIcePm1 (I,J,bi,bj) = vIce(i,j,bi,bj)
+             sig11Pm1(i,j,bi,bj) = seaice_sigma1(i,j,bi,bj)
+             sig22Pm1(i,j,bi,bj) = seaice_sigma2(i,j,bi,bj)
+             sig12Pm1(i,j,bi,bj) = seaice_sigma12(i,j,bi,bj)
+             uIcePm1 (i,j,bi,bj) = uIce(i,j,bi,bj)
+             vIcePm1 (i,j,bi,bj) = vIce(i,j,bi,bj)
             ENDDO
            ENDDO
           ENDIF
 #endif /* ALLOW_SEAICE_EVP_RESIDUAL */
           DO j=1-OLy,sNy+OLy
            DO i=1-OLx,sNx+OLx
-            seaice_div    (I,J) = 0. _d 0
-            seaice_tension(I,J) = 0. _d 0
-            seaice_shear  (I,J) = 0. _d 0
-            pressC        (I,J) = 0. _d 0
-            e12Csq        (I,J) = 0. _d 0
-            zetaC         (I,J) = 0. _d 0
-            deltaZ        (I,J) = 0. _d 0
-            zetaZ   (I,J,bi,bj) = 0. _d 0
-            deltaC  (I,J,bi,bj) = 0. _d 0
+            seaice_div    (i,j) = 0. _d 0
+            seaice_tension(i,j) = 0. _d 0
+            seaice_shear  (i,j) = 0. _d 0
+            pressC        (i,j) = 0. _d 0
+            e12Csq        (i,j) = 0. _d 0
+            zetaC         (i,j) = 0. _d 0
+            deltaZ        (i,j) = 0. _d 0
+            zetaZ   (i,j,bi,bj) = 0. _d 0
+            deltaC  (i,j,bi,bj) = 0. _d 0
            ENDDO
           ENDDO
           DO j=1-OLy,sNy+OLy
@@ -378,8 +378,8 @@ C     average strain rates to C points
            DO j=1-OLy+1,sNy+OLy-1
             DO i=1-OLx+1,sNx+OLx-1
              tmp = 0.25 *
-     &            ( e12(I,J  ,bi,bj) + e12(I+1,J  ,bi,bj)
-     &            + e12(I,J+1,bi,bj) + e12(I+1,J+1,bi,bj) )
+     &            ( e12(i,j  ,bi,bj) + e12(i+1,j  ,bi,bj)
+     &            + e12(i,j+1,bi,bj) + e12(i+1,j+1,bi,bj) )
              e12Csq(i,j) = tmp*tmp
             ENDDO
            ENDDO
@@ -388,36 +388,36 @@ C     average strain rates to C points
             DO i=1-OLx+1,sNx+OLx-1
 C     area weighted average of the squares of e12 is more accurate
 C     (and energy conserving) according to Bouillon et al. 2013, eq (11)
-             e12Csq(i,j) = 0.25 _d 0 * recip_rA(I,J,bi,bj) *
-     &            ( rAz(I  ,J  ,bi,bj)*e12(I  ,J  ,bi,bj)**2
-     &            + rAz(I+1,J  ,bi,bj)*e12(I+1,J  ,bi,bj)**2
-     &            + rAz(I  ,J+1,bi,bj)*e12(I  ,J+1,bi,bj)**2
-     &            + rAz(I+1,J+1,bi,bj)*e12(I+1,J+1,bi,bj)**2 )
+             e12Csq(i,j) = 0.25 _d 0 * recip_rA(i,j,bi,bj) *
+     &            ( rAz(i  ,j  ,bi,bj)*e12(i  ,j  ,bi,bj)**2
+     &            + rAz(i+1,j  ,bi,bj)*e12(i+1,j  ,bi,bj)**2
+     &            + rAz(i  ,j+1,bi,bj)*e12(i  ,j+1,bi,bj)**2
+     &            + rAz(i+1,j+1,bi,bj)*e12(i+1,j+1,bi,bj)**2 )
             ENDDO
            ENDDO
           ENDIF
           DO j=0,sNy+1
            DO i=0,sNx+1
-            deltaSq = ep(I,J)**2 + recip_ecc2 * em(I,J)**2
-     &           + recip_ecc2 * 4. _d 0 * e12Csq(I,J)
+            deltaSq = ep(i,j)**2 + recip_ecc2 * em(i,j)**2
+     &           + recip_ecc2 * 4. _d 0 * e12Csq(i,j)
 #ifdef ALLOW_AUTODIFF
 C     avoid sqrt of 0
-            deltaC(I,J,bi,bj) = 0. _d 0
+            deltaC(i,j,bi,bj) = 0. _d 0
             IF ( deltaSq .GT. 0. _d 0 )
-     &           deltaC(I,J,bi,bj) = SQRT(deltaSq)
+     &           deltaC(i,j,bi,bj) = SQRT(deltaSq)
 #else
-            deltaC(I,J,bi,bj) = SQRT(deltaSq)
+            deltaC(i,j,bi,bj) = SQRT(deltaSq)
 #endif /* ALLOW_AUTODIFF */
 #ifdef SEAICE_DELTA_SMOOTHREG
 C     smooth regularization (without max-function) of delta for
 C     better differentiability
 CML            deltaCreg  = SQRT(deltaSq + deltaMinSq)
-            deltaCreg  = deltaC(I,J,bi,bj) + SEAICE_deltaMin
+            deltaCreg  = deltaC(i,j,bi,bj) + SEAICE_deltaMin
 #else
-            deltaCreg  = MAX(deltaC(I,J,bi,bj),SEAICE_deltaMin)
+            deltaCreg  = MAX(deltaC(i,j,bi,bj),SEAICE_deltaMin)
 #endif /* SEAICE_DELTA_SMOOTHREG */
-            zetaC(I,J) = HALF*( press0(I,J,bi,bj)
-     &           * ( 1. _d 0 + tensileStrFac(I,J,bi,bj) )
+            zetaC(i,j) = HALF*( press0(i,j,bi,bj)
+     &           * ( 1. _d 0 + tensileStrFac(i,j,bi,bj) )
      &           )/deltaCreg
            ENDDO
           ENDDO
@@ -426,27 +426,27 @@ CML            deltaCreg  = SQRT(deltaSq + deltaMinSq)
             DO i=0,sNx+1
 CML   I do not like these hidden regularisations, why do we need to
 CML   divide by mass?
-             evpAlphaC(I,J,bi,bj) = SQRT(zetaC(I,J)
-     &            * EVPcFac / MAX(seaiceMassC(I,J,bi,bj), 1.D-04)
-     &            * recip_rA(I,J,bi,bj) ) * HEFFM(I,J,bi,bj)
-             evpAlphaC(I,J,bi,bj) =
-     &            MAX(evpAlphaC(I,J,bi,bj),SEAICEaEVPalphaMin)
+             evpAlphaC(i,j,bi,bj) = SQRT(zetaC(i,j)
+     &            * EVPcFac / MAX(seaiceMassC(i,j,bi,bj), 1.D-04)
+     &            * recip_rA(i,j,bi,bj) ) * HEFFM(i,j,bi,bj)
+             evpAlphaC(i,j,bi,bj) =
+     &            MAX(evpAlphaC(i,j,bi,bj),SEAICEaEVPalphaMin)
             ENDDO
            ENDDO
           ENDIF
 C     compute zetaZ and deltaZ by simple averaging (following
 C     Bouillon et al., 2013)
-          DO J=1,sNy+1
-           DO I=1,sNx+1
-            sumNorm = HEFFM(I,J,  bi,bj)+HEFFM(I-1,J,  bi,bj)
-     &              + HEFFM(I,J-1,bi,bj)+HEFFM(I-1,J-1,bi,bj)
+          DO j=1,sNy+1
+           DO i=1,sNx+1
+            sumNorm = HEFFM(i,j,  bi,bj)+HEFFM(i-1,j,  bi,bj)
+     &              + HEFFM(i,j-1,bi,bj)+HEFFM(i-1,j-1,bi,bj)
             IF ( sumNorm.GT.0. _d 0 ) sumNorm = 1. _d 0 / sumNorm
-            zetaZ(I,J,bi,bj) = sumNorm *
-     &           ( zetaC(I,  J) + zetaC(I-1,J-1)
-     &           + zetaC(I-1,J) + zetaC(I,  J-1) )
-            deltaZ(I,J) = sumNorm *
-     &           ( deltaC(I,  J,bi,bj) + deltaC(I-1,J-1,bi,bj)
-     &           + deltaC(I-1,J,bi,bj) + deltaC(I,  J-1,bi,bj) )
+            zetaZ(i,j,bi,bj) = sumNorm *
+     &           ( zetaC(i,  j) + zetaC(i-1,j-1)
+     &           + zetaC(i-1,j) + zetaC(i,  j-1) )
+            deltaZ(i,j) = sumNorm *
+     &           ( deltaC(i,  j,bi,bj) + deltaC(i-1,j-1,bi,bj)
+     &           + deltaC(i-1,j,bi,bj) + deltaC(i,  j-1,bi,bj) )
            ENDDO
           ENDDO
 #ifdef SEAICE_ALLOW_CLIPZETA
@@ -457,30 +457,30 @@ CADJ STORE zetaz(:,:,bi,bj) = comlev1_bibj_evp, key = tkey, byte=isbyte
 C     regularize zeta if necessary
           DO j=0,sNy+1
            DO i=0,sNx+1
-            zetaC(I,J)  = MAX(zMin(I,J,bi,bj),MIN(zMax(I,J,bi,bj)
-     &           ,zetaC(I,J)))
+            zetaC(i,j)  = MAX(zMin(i,j,bi,bj),MIN(zMax(i,j,bi,bj)
+     &           ,zetaC(i,j)))
 CML            zetaC(I,J)   = zetaC(I,J)*HEFFM(I,J,bi,bj)
 C
 C     zMin, zMax are defined at C-points, make sure that they are not
 C     masked by boundaries/land points
             zMaxZ       = MAX(
-     &           MAX(zMax(I,  J,bi,bj),zMax(I,  J-1,bi,bj)),
-     &           MAX(zMax(I-1,J,bi,bj),zMax(I-1,J-1,bi,bj)) )
+     &           MAX(zMax(i,  j,bi,bj),zMax(i,  j-1,bi,bj)),
+     &           MAX(zMax(i-1,j,bi,bj),zMax(i-1,j-1,bi,bj)) )
             zMinZ       = MAX(
-     &           MAX(zMin(I,  J,bi,bj),zMin(I,  J-1,bi,bj)),
-     &           MAX(zMin(I-1,J,bi,bj),zMin(I-1,J-1,bi,bj)) )
-            zetaZ(I,J,bi,bj) = MAX(zMinZ,MIN(zMaxZ,zetaZ(I,J,bi,bj)))
+     &           MAX(zMin(i,  j,bi,bj),zMin(i,  j-1,bi,bj)),
+     &           MAX(zMin(i-1,j,bi,bj),zMin(i-1,j-1,bi,bj)) )
+            zetaZ(i,j,bi,bj) = MAX(zMinZ,MIN(zMaxZ,zetaZ(i,j,bi,bj)))
            ENDDO
           ENDDO
 #endif /* SEAICE_ALLOW_CLIPZETA */
 C     recompute pressure
           DO j=0,sNy+1
            DO i=0,sNx+1
-            pressC(I,J) =
-     &           ( press0(I,J,bi,bj) * ( 1. _d 0 - SEAICEpressReplFac )
-     &           + TWO*zetaC(I,J)*deltaC(I,J,bi,bj)*SEAICEpressReplFac
-     &             /(1. _d 0 + tensileStrFac(I,J,bi,bj))
-     &           ) * (1. _d 0 - tensileStrFac(I,J,bi,bj))
+            pressC(i,j) =
+     &           ( press0(i,j,bi,bj) * ( 1. _d 0 - SEAICEpressReplFac )
+     &           + TWO*zetaC(i,j)*deltaC(i,j,bi,bj)*SEAICEpressReplFac
+     &             /(1. _d 0 + tensileStrFac(i,j,bi,bj))
+     &           ) * (1. _d 0 - tensileStrFac(i,j,bi,bj))
            ENDDO
           ENDDO
 #ifdef ALLOW_DIAGNOSTICS
@@ -488,9 +488,9 @@ C     recompute pressure
 C     save eta, zeta, and pressure for diagnostics
            DO j=1,sNy
             DO i=1,sNx
-             press(I,J,bi,bj) = pressC(I,J)
-             zeta (I,J,bi,bj) = zetaC(I,J)
-             eta  (I,J,bi,bj) = zetaC(I,J)*recip_ecc2
+             press(i,j,bi,bj) = pressC(i,j)
+             zeta (i,j,bi,bj) = zetaC(i,j)
+             eta  (i,j,bi,bj) = zetaC(i,j)*recip_ecc2
             ENDDO
            ENDDO
           ENDIF
@@ -504,19 +504,19 @@ C     P * ( D_s/Delta     ) = 2*zeta*D_s
           IF ( SEAICEuseTEM ) THEN
            DO j=0,sNy
             DO i=0,sNx
-             etaDenC   = em(I,J)**2 + 4. _d 0 * e12Csq(I,J)
+             etaDenC   = em(i,j)**2 + 4. _d 0 * e12Csq(i,j)
              etaDenC  = SQRT(MAX(deltaMinSq,etaDenC))
-             zetaMaxC = ecc2*zetaC(I,J)
-     &            *(deltaC(I,J,bi,bj)-ep(I,J))/etaDenC
+             zetaMaxC = ecc2*zetaC(i,j)
+     &            *(deltaC(i,j,bi,bj)-ep(i,j))/etaDenC
 #ifdef ALLOW_DIAGNOSTICS
 C     save new eta for diagnostics
-             eta(I,J,bi,bj) = MIN(zetaC(I,J),zetaMaxC)*recip_ecc2
+             eta(i,j,bi,bj) = MIN(zetaC(i,j),zetaMaxC)*recip_ecc2
 #endif /* ALLOW_DIAGNOSTICS */
-             seaice_div    (I,J) =
-     &            ( 2. _d 0 *zetaC(I,J)*ep(I,J) - pressC(I,J)
-     &            ) * HEFFM(I,J,bi,bj)
-             seaice_tension(I,J) = 2. _d 0*MIN(zetaC(I,J),zetaMaxC)
-     &            * em(I,J) * HEFFM(I,J,bi,bj)
+             seaice_div    (i,j) =
+     &            ( 2. _d 0 *zetaC(i,j)*ep(i,j) - pressC(i,j)
+     &            ) * HEFFM(i,j,bi,bj)
+             seaice_tension(i,j) = 2. _d 0*MIN(zetaC(i,j),zetaMaxC)
+     &            * em(i,j) * HEFFM(i,j,bi,bj)
             ENDDO
            ENDDO
            DO j=1,sNy+1
@@ -530,39 +530,39 @@ CML     &           +          HEFFM(I-1,J-1,bi,bj) )
 C     Averaging the squares gives more accurate viscous-plastic behavior
 C     than squaring the averages
              etaDenZ  =
-     &            sumNorm * recip_rAz(I,J,bi,bj) *
-     &                    ( _rA(I  ,J  ,bi,bj) * em(I,  J  )**2
-     &                    + _rA(I-1,J-1,bi,bj) * em(I-1,J-1)**2
-     &                    + _rA(I-1,J  ,bi,bj) * em(I-1,J  )**2
-     &                    + _rA(I  ,J-1,bi,bj) * em(I,  J-1)**2 )
-     &                    + 4. _d 0*e12(I,J,bi,bj)**2
+     &            sumNorm * recip_rAz(i,j,bi,bj) *
+     &                    ( _rA(i  ,j  ,bi,bj) * em(i,  j  )**2
+     &                    + _rA(i-1,j-1,bi,bj) * em(i-1,j-1)**2
+     &                    + _rA(i-1,j  ,bi,bj) * em(i-1,j  )**2
+     &                    + _rA(i  ,j-1,bi,bj) * em(i,  j-1)**2 )
+     &                    + 4. _d 0*e12(i,j,bi,bj)**2
              etaDenZ  = SQRT(MAX(deltaMinSq,etaDenZ))
-             zetaMaxZ = ecc2*zetaZ(I,J,bi,bj) * ( deltaZ(I,J)
-     &            - sumNorm * ( ep(I,J  ) + ep(I-1,J  )
-     &                        + ep(I,J-1) + ep(I-1,J-1) )
+             zetaMaxZ = ecc2*zetaZ(i,j,bi,bj) * ( deltaZ(i,j)
+     &            - sumNorm * ( ep(i,j  ) + ep(i-1,j  )
+     &                        + ep(i,j-1) + ep(i-1,j-1) )
      &            )/etaDenZ
-             seaice_shear  (I,J) =
-     &            2. _d 0*MIN(zetaZ(I,J,bi,bj),zetaMaxZ)
-     &            * 2. _d 0*e12(I,J,bi,bj)
+             seaice_shear  (i,j) =
+     &            2. _d 0*MIN(zetaZ(i,j,bi,bj),zetaMaxZ)
+     &            * 2. _d 0*e12(i,j,bi,bj)
             ENDDO
            ENDDO
           ELSE
 #else
           IF (.TRUE. ) THEN
 #endif /* SEAICE_ALLOW_TEM */
-           DO J=0,sNy
-            DO I=0,sNx
-             seaice_div    (I,J) =
-     &            ( 2. _d 0 *zetaC(I,J)*ep(I,J) - pressC(I,J)
-     &            ) * HEFFM(I,J,bi,bj)
-             seaice_tension(I,J) = 2. _d 0*zetaC(I,J)
-     &            * em(I,J) * HEFFM(I,J,bi,bj)
+           DO j=0,sNy
+            DO i=0,sNx
+             seaice_div    (i,j) =
+     &            ( 2. _d 0 *zetaC(i,j)*ep(i,j) - pressC(i,j)
+     &            ) * HEFFM(i,j,bi,bj)
+             seaice_tension(i,j) = 2. _d 0*zetaC(i,j)
+     &            * em(i,j) * HEFFM(i,j,bi,bj)
             ENDDO
            ENDDO
-           DO J=1,sNy+1
-            DO I=1,sNx+1
-             seaice_shear  (I,J) =
-     &            2. _d 0*zetaZ(I,J,bi,bj)*e12(I,J,bi,bj)
+           DO j=1,sNy+1
+            DO i=1,sNx+1
+             seaice_shear  (i,j) =
+     &            2. _d 0*zetaZ(i,j,bi,bj)*e12(i,j,bi,bj)
             ENDDO
            ENDDO
           ENDIF
@@ -576,40 +576,40 @@ CADJ STORE denom2(:,:,bi,bj) = comlev1_bibj_evp, key=tkey, byte=isbyte
           IF ( useAdaptiveEVP ) THEN
            DO j=0,sNy
             DO i=0,sNx
-             denom1(I,J,bi,bj) = 1. _d 0 /  evpAlphaC(I,J,bi,bj)
-             denom2(I,J,bi,bj) = denom1(I,J,bi,bj)
+             denom1(i,j,bi,bj) = 1. _d 0 /  evpAlphaC(i,j,bi,bj)
+             denom2(i,j,bi,bj) = denom1(i,j,bi,bj)
             ENDDO
            ENDDO
           ENDIF
           DO j=0,sNy
            DO i=0,sNx
 C     sigma1 and sigma2 are computed on C points
-            seaice_sigma1 (I,J,bi,bj) = ( seaice_sigma1 (I,J,bi,bj)
-     &           * ( evpAlphaC(I,J,bi,bj) - evpRevFac )
-     &           + seaice_div(I,J)
-     &           ) * denom1(I,J,bi,bj)
-     &           *HEFFM(I,J,bi,bj)
-            seaice_sigma2 (I,J,bi,bj) = ( seaice_sigma2 (I,J,bi,bj)
-     &           * ( evpAlphaC(I,J,bi,bj) - evpRevFac )
-     &           + seaice_tension(I,J)*recip_evpRevFac
-     &           ) * denom2(I,J,bi,bj)
-     &         *HEFFM(I,J,bi,bj)
+            seaice_sigma1 (i,j,bi,bj) = ( seaice_sigma1 (i,j,bi,bj)
+     &           * ( evpAlphaC(i,j,bi,bj) - evpRevFac )
+     &           + seaice_div(i,j)
+     &           ) * denom1(i,j,bi,bj)
+     &           *HEFFM(i,j,bi,bj)
+            seaice_sigma2 (i,j,bi,bj) = ( seaice_sigma2 (i,j,bi,bj)
+     &           * ( evpAlphaC(i,j,bi,bj) - evpRevFac )
+     &           + seaice_tension(i,j)*recip_evpRevFac
+     &           ) * denom2(i,j,bi,bj)
+     &         *HEFFM(i,j,bi,bj)
 #ifdef SEAICE_EVP_ELIMINATE_UNDERFLOWS
 C     Code to avoid very small numbers that can degrade performance.
 C     Many compilers can handle this more efficiently with the help of
 C     a flag (copied from CICE after correspondence with Elizabeth Hunke)
-            seaice_sigma1(I,J,bi,bj) = SIGN(MAX(
-     &           ABS( seaice_sigma1(I,J,bi,bj) ), SEAICE_EPS ),
-     &           seaice_sigma1(I,J,bi,bj) )
-            seaice_sigma2(I,J,bi,bj) = SIGN(MAX(
-     &           ABS( seaice_sigma2(I,J,bi,bj) ), SEAICE_EPS ),
-     &           seaice_sigma2(I,J,bi,bj) )
+            seaice_sigma1(i,j,bi,bj) = SIGN(MAX(
+     &           ABS( seaice_sigma1(i,j,bi,bj) ), SEAICE_EPS ),
+     &           seaice_sigma1(i,j,bi,bj) )
+            seaice_sigma2(i,j,bi,bj) = SIGN(MAX(
+     &           ABS( seaice_sigma2(i,j,bi,bj) ), SEAICE_EPS ),
+     &           seaice_sigma2(i,j,bi,bj) )
 #endif /* SEAICE_EVP_ELIMINATE_UNDERFLOWS */
 C     recover sigma11 and sigma22
-            sig11(I,J) = 0.5 _d 0 *
-     &           ( seaice_sigma1(I,J,bi,bj)+seaice_sigma2(I,J,bi,bj) )
-            sig22(I,J) = 0.5 _d 0 *
-     &           ( seaice_sigma1(I,J,bi,bj)-seaice_sigma2(I,J,bi,bj) )
+            sig11(i,j) = 0.5 _d 0 *
+     &           ( seaice_sigma1(i,j,bi,bj)+seaice_sigma2(i,j,bi,bj) )
+            sig22(i,j) = 0.5 _d 0 *
+     &           ( seaice_sigma1(i,j,bi,bj)-seaice_sigma2(i,j,bi,bj) )
            ENDDO
           ENDDO
 
@@ -621,43 +621,43 @@ C     sigma12 is computed on Z points
           IF ( useAdaptiveEVP ) THEN
            DO j=1,sNy+1
             DO i=1,sNx+1
-             evpAlphaZ(I,J,bi,bj) = 0.25 _d 0 *
-     &            ( evpAlphaC(I,  J,bi,bj)+evpAlphaC(I-1,J-1,bi,bj)
-     &            + evpAlphaC(I-1,J,bi,bj)+evpAlphaC(I,  J-1,bi,bj) )
-             denom2(I,J,bi,bj) = 1. _d 0 /  evpAlphaZ(I,J,bi,bj)
+             evpAlphaZ(i,j,bi,bj) = 0.25 _d 0 *
+     &            ( evpAlphaC(i,  j,bi,bj)+evpAlphaC(i-1,j-1,bi,bj)
+     &            + evpAlphaC(i-1,j,bi,bj)+evpAlphaC(i,  j-1,bi,bj) )
+             denom2(i,j,bi,bj) = 1. _d 0 /  evpAlphaZ(i,j,bi,bj)
             ENDDO
            ENDDO
           ENDIF
           DO j=1,sNy+1
            DO i=1,sNx+1
-            seaice_sigma12(I,J,bi,bj) = ( seaice_sigma12(I,J,bi,bj)
-     &           * ( evpAlphaZ(I,J,bi,bj) - evpRevFac )
-     &           + seaice_shear(I,J)*recip_evpRevFac
-     &           ) * denom2(I,J,bi,bj)
+            seaice_sigma12(i,j,bi,bj) = ( seaice_sigma12(i,j,bi,bj)
+     &           * ( evpAlphaZ(i,j,bi,bj) - evpRevFac )
+     &           + seaice_shear(i,j)*recip_evpRevFac
+     &           ) * denom2(i,j,bi,bj)
 #ifdef SEAICE_EVP_ELIMINATE_UNDERFLOWS
-            seaice_sigma12(I,J,bi,bj) = SIGN(MAX(
-     &           ABS( seaice_sigma12(I,J,bi,bj) ), SEAICE_EPS ),
-     &           seaice_sigma12(I,J,bi,bj) )
+            seaice_sigma12(i,j,bi,bj) = SIGN(MAX(
+     &           ABS( seaice_sigma12(i,j,bi,bj) ), SEAICE_EPS ),
+     &           seaice_sigma12(i,j,bi,bj) )
 #endif /* SEAICE_EVP_ELIMINATE_UNDERFLOWS */
            ENDDO
           ENDDO
 C
 C     compute divergence of stress tensor
 C
-          DO J=1,sNy
-           DO I=1,sNx
-            stressDivergenceX(I,J,bi,bj) =
-     &           ( sig11(I  ,J  ) * _dyF(I  ,J,bi,bj)
-     &           - sig11(I-1,J  ) * _dyF(I-1,J,bi,bj)
-     &           + seaice_sigma12(I,J+1,bi,bj) * _dxV(I,J+1,bi,bj)
-     &           - seaice_sigma12(I,J  ,bi,bj) * _dxV(I,J  ,bi,bj)
-     &           ) * recip_rAw(I,J,bi,bj)
-            stressDivergenceY(I,J,bi,bj) =
-     &           ( sig22(I,J  ) * _dxF(I,J  ,bi,bj)
-     &           - sig22(I,J-1) * _dxF(I,J-1,bi,bj)
-     &           + seaice_sigma12(I+1,J,bi,bj) * _dyU(I+1,J,bi,bj)
-     &           - seaice_sigma12(I  ,J,bi,bj) * _dyU(I  ,J,bi,bj)
-     &           ) * recip_rAs(I,J,bi,bj)
+          DO j=1,sNy
+           DO i=1,sNx
+            stressDivergenceX(i,j,bi,bj) =
+     &           ( sig11(i  ,j  ) * _dyF(i  ,j,bi,bj)
+     &           - sig11(i-1,j  ) * _dyF(i-1,j,bi,bj)
+     &           + seaice_sigma12(i,j+1,bi,bj) * _dxV(i,j+1,bi,bj)
+     &           - seaice_sigma12(i,j  ,bi,bj) * _dxV(i,j  ,bi,bj)
+     &           ) * recip_rAw(i,j,bi,bj)
+            stressDivergenceY(i,j,bi,bj) =
+     &           ( sig22(i,j  ) * _dxF(i,j  ,bi,bj)
+     &           - sig22(i,j-1) * _dxF(i,j-1,bi,bj)
+     &           + seaice_sigma12(i+1,j,bi,bj) * _dyU(i+1,j,bi,bj)
+     &           - seaice_sigma12(i  ,j,bi,bj) * _dyU(i  ,j,bi,bj)
+     &           ) * recip_rAs(i,j,bi,bj)
            ENDDO
           ENDDO
          ENDDO
@@ -677,11 +677,11 @@ C
              sig12Pm1(i,j,bi,bj)  =
      &            seaice_sigma12(i,j,bi,bj)-sig12Pm1(i,j,bi,bj)
              sig11Pm1(i,j,bi,bj)  =
-     &            evpAlphaC(I,J,bi,bj) * sig11Pm1(i,j,bi,bj)
+     &            evpAlphaC(i,j,bi,bj) * sig11Pm1(i,j,bi,bj)
              sig22Pm1(i,j,bi,bj)  =
-     &            evpAlphaC(I,J,bi,bj) * sig22Pm1(i,j,bi,bj)
+     &            evpAlphaC(i,j,bi,bj) * sig22Pm1(i,j,bi,bj)
              sig12Pm1(i,j,bi,bj)  =
-     &            evpAlphaZ(I,J,bi,bj) * sig12Pm1(i,j,bi,bj)
+     &            evpAlphaZ(i,j,bi,bj) * sig12Pm1(i,j,bi,bj)
             ENDDO
            ENDDO
            IF ( .NOT. SEAICEscaleSurfStress ) THEN
@@ -745,8 +745,8 @@ C
 
         DO bj=myByLo(myThid),myByHi(myThid)
          DO bi=myBxLo(myThid),myBxHi(myThid)
-          DO J=1,sNy
-           DO I=1,sNx
+          DO j=1,sNy
+           DO i=1,sNx
 C     over open water, all terms that contain sea ice mass drop out and
 C     the balance is determined by the atmosphere-ice and ice-ocean stress;
 C     the staggering of uIce and vIce can cause stripes in the open ocean
@@ -755,8 +755,8 @@ C     we mask this term here in order to avoid the stripes and because
 C     over open ocean, u/vIce do not advect anything, so that the associated
 C     error is small and most likely only confined to the ice edge but may
 C     propagate into the ice covered regions.
-            locMaskU = seaiceMassU(I,J,bi,bj)
-            locMaskV = seaiceMassV(I,J,bi,bj)
+            locMaskU = seaiceMassU(i,j,bi,bj)
+            locMaskV = seaiceMassV(i,j,bi,bj)
             IF ( locMaskU .NE. 0. _d 0 ) locMaskU = 1. _d 0
             IF ( locMaskV .NE. 0. _d 0 ) locMaskV = 1. _d 0
 C     to recover old results replace the above lines with the line below
@@ -764,49 +764,49 @@ C           locMaskU = 1. _d 0
 C           locMaskV = 1. _d 0
 C     set up anti symmetric drag force and add in ice ocean stress
 C     ( remember to average to correct velocity points )
-            FORCEX(I,J,bi,bj)=FORCEX0(I,J,bi,bj)+
-     &           ( 0.5 _d 0 * ( DWATN(I,J,bi,bj)+DWATN(I-1,J,bi,bj) ) *
-     &           COSWAT * uVel(I,J,kSrf,bi,bj)
-     &           - SIGN(SINWAT, _fCori(I,J,bi,bj))* 0.5 _d 0 *
-     &           ( DWATN(I  ,J,bi,bj) * 0.5 _d 0 *
-     &            (vVel(I  ,J  ,kSrf,bi,bj)-vIce(I  ,J  ,bi,bj)
-     &            +vVel(I  ,J+1,kSrf,bi,bj)-vIce(I  ,J+1,bi,bj))
-     &           + DWATN(I-1,J,bi,bj) * 0.5 _d 0 *
-     &            (vVel(I-1,J  ,kSrf,bi,bj)-vIce(I-1,J  ,bi,bj)
-     &            +vVel(I-1,J+1,kSrf,bi,bj)-vIce(I-1,J+1,bi,bj))
-     &           )*locMaskU ) * areaW(I,J,bi,bj)
-            FORCEY(I,J,bi,bj)=FORCEY0(I,J,bi,bj)+
-     &           ( 0.5 _d 0 * ( DWATN(I,J,bi,bj)+DWATN(I,J-1,bi,bj) ) *
-     &           COSWAT * vVel(I,J,kSrf,bi,bj)
-     &           + SIGN(SINWAT, _fCori(I,J,bi,bj)) * 0.5 _d 0 *
-     &           ( DWATN(I,J  ,bi,bj) * 0.5 _d 0 *
-     &            (uVel(I  ,J  ,kSrf,bi,bj)-uIce(I  ,J  ,bi,bj)
-     &            +uVel(I+1,J  ,kSrf,bi,bj)-uIce(I+1,J  ,bi,bj))
-     &           + DWATN(I,J-1,bi,bj) * 0.5 _d 0 *
-     &            (uVel(I  ,J-1,kSrf,bi,bj)-uIce(I  ,J-1,bi,bj)
-     &            +uVel(I+1,J-1,kSrf,bi,bj)-uIce(I+1,J-1,bi,bj))
-     &           )*locMaskV ) * areaS(I,J,bi,bj)
+            FORCEX(i,j,bi,bj)=FORCEX0(i,j,bi,bj)+
+     &           ( 0.5 _d 0 * ( DWATN(i,j,bi,bj)+DWATN(i-1,j,bi,bj) ) *
+     &           COSWAT * uVel(i,j,kSrf,bi,bj)
+     &           - SIGN(SINWAT, _fCori(i,j,bi,bj))* 0.5 _d 0 *
+     &           ( DWATN(i  ,j,bi,bj) * 0.5 _d 0 *
+     &            (vVel(i  ,j  ,kSrf,bi,bj)-vIce(i  ,j  ,bi,bj)
+     &            +vVel(i  ,j+1,kSrf,bi,bj)-vIce(i  ,j+1,bi,bj))
+     &           + DWATN(i-1,j,bi,bj) * 0.5 _d 0 *
+     &            (vVel(i-1,j  ,kSrf,bi,bj)-vIce(i-1,j  ,bi,bj)
+     &            +vVel(i-1,j+1,kSrf,bi,bj)-vIce(i-1,j+1,bi,bj))
+     &           )*locMaskU ) * areaW(i,j,bi,bj)
+            FORCEY(i,j,bi,bj)=FORCEY0(i,j,bi,bj)+
+     &           ( 0.5 _d 0 * ( DWATN(i,j,bi,bj)+DWATN(i,j-1,bi,bj) ) *
+     &           COSWAT * vVel(i,j,kSrf,bi,bj)
+     &           + SIGN(SINWAT, _fCori(i,j,bi,bj)) * 0.5 _d 0 *
+     &           ( DWATN(i,j  ,bi,bj) * 0.5 _d 0 *
+     &            (uVel(i  ,j  ,kSrf,bi,bj)-uIce(i  ,j  ,bi,bj)
+     &            +uVel(i+1,j  ,kSrf,bi,bj)-uIce(i+1,j  ,bi,bj))
+     &           + DWATN(i,j-1,bi,bj) * 0.5 _d 0 *
+     &            (uVel(i  ,j-1,kSrf,bi,bj)-uIce(i  ,j-1,bi,bj)
+     &            +uVel(i+1,j-1,kSrf,bi,bj)-uIce(i+1,j-1,bi,bj))
+     &           )*locMaskV ) * areaS(i,j,bi,bj)
 C     coriols terms
-            FORCEX(I,J,bi,bj)=FORCEX(I,J,bi,bj) + 0.5 _d 0*(
-     &             seaiceMassC(I  ,J,bi,bj) * _fCori(I  ,J,bi,bj)
-     &           * 0.5 _d 0*( vIce(I  ,J,bi,bj)+vIce(I  ,J+1,bi,bj) )
-     &           + seaiceMassC(I-1,J,bi,bj) * _fCori(I-1,J,bi,bj)
-     &           * 0.5 _d 0*( vIce(I-1,J,bi,bj)+vIce(I-1,J+1,bi,bj) )
+            FORCEX(i,j,bi,bj)=FORCEX(i,j,bi,bj) + 0.5 _d 0*(
+     &             seaiceMassC(i  ,j,bi,bj) * _fCori(i  ,j,bi,bj)
+     &           * 0.5 _d 0*( vIce(i  ,j,bi,bj)+vIce(i  ,j+1,bi,bj) )
+     &           + seaiceMassC(i-1,j,bi,bj) * _fCori(i-1,j,bi,bj)
+     &           * 0.5 _d 0*( vIce(i-1,j,bi,bj)+vIce(i-1,j+1,bi,bj) )
      &           )
-            FORCEY(I,J,bi,bj)=FORCEY(I,J,bi,bj) - 0.5 _d 0*(
-     &             seaiceMassC(I,J  ,bi,bj) * _fCori(I,J  ,bi,bj)
-     &           * 0.5 _d 0*( uIce(I,J  ,bi,bj)+uIce(I+1,  J,bi,bj) )
-     &           + seaiceMassC(I,J-1,bi,bj) * _fCori(I,J-1,bi,bj)
-     &           * 0.5 _d 0*( uIce(I,J-1,bi,bj)+uIce(I+1,J-1,bi,bj) )
+            FORCEY(i,j,bi,bj)=FORCEY(i,j,bi,bj) - 0.5 _d 0*(
+     &             seaiceMassC(i,j  ,bi,bj) * _fCori(i,j  ,bi,bj)
+     &           * 0.5 _d 0*( uIce(i,j  ,bi,bj)+uIce(i+1,  j,bi,bj) )
+     &           + seaiceMassC(i,j-1,bi,bj) * _fCori(i,j-1,bi,bj)
+     &           * 0.5 _d 0*( uIce(i,j-1,bi,bj)+uIce(i+1,j-1,bi,bj) )
      &           )
            ENDDO
           ENDDO
 #ifdef SEAICE_ALLOW_MOM_ADVECTION
           IF ( SEAICEmomAdvection ) THEN
-           DO J=1-OLy,sNy+OLy
-            DO I=1-OLx,sNx+OLx
-             gUmom(I,J) = 0. _d 0
-             gVmom(I,J) = 0. _d 0
+           DO j=1-OLy,sNy+OLy
+            DO i=1-OLx,sNx+OLx
+             gUmom(i,j) = 0. _d 0
+             gVmom(i,j) = 0. _d 0
             ENDDO
            ENDDO
            CALL SEAICE_MOM_ADVECTION(
@@ -814,10 +814,10 @@ C     coriols terms
      I          uIce, vIce,
      O          gUmom, gVmom,
      I          myTime, myIter, myThid )
-           DO J=1,sNy
-            DO I=1,sNx
-             FORCEX(I,J,bi,bj) = FORCEX(I,J,bi,bj) + gUmom(I,J)
-             FORCEY(I,J,bi,bj) = FORCEY(I,J,bi,bj) + gVmom(I,J)
+           DO j=1,sNy
+            DO i=1,sNx
+             FORCEX(i,j,bi,bj) = FORCEX(i,j,bi,bj) + gUmom(i,j)
+             FORCEY(i,j,bi,bj) = FORCEY(i,j,bi,bj) + gVmom(i,j)
             ENDDO
            ENDDO
           ENDIF
@@ -826,52 +826,52 @@ C
 C     step momentum equations with ice-ocean stress term treated implicitly
 C
           IF ( useAdaptiveEVP ) THEN
-           DO J=1,sNy
-            DO I=1,sNx
+           DO j=1,sNy
+            DO i=1,sNx
 C     compute and adjust parameters that are constant otherwise
-             evpBetaU(I,J,bi,bj) = 0.5 _d 0*(evpAlphaC(I-1,J,bi,bj)
-     &                                      +evpAlphaC(I,  J,bi,bj))
-             evpBetaV(I,J,bi,bj) = 0.5 _d 0*(evpAlphaC(I,J-1,bi,bj)
-     &                                      +evpAlphaC(I,J,  bi,bj))
+             evpBetaU(i,j,bi,bj) = 0.5 _d 0*(evpAlphaC(i-1,j,bi,bj)
+     &                                      +evpAlphaC(i,  j,bi,bj))
+             evpBetaV(i,j,bi,bj) = 0.5 _d 0*(evpAlphaC(i,j-1,bi,bj)
+     &                                      +evpAlphaC(i,j,  bi,bj))
 
             ENDDO
            ENDDO
           ENDIF
-          DO J=1,sNy
-           DO I=1,sNx
-            betaFacU   = evpBetaU(I,J,bi,bj)*recip_deltaT
-            betaFacV   = evpBetaV(I,J,bi,bj)*recip_deltaT
+          DO j=1,sNy
+           DO i=1,sNx
+            betaFacU   = evpBetaU(i,j,bi,bj)*recip_deltaT
+            betaFacV   = evpBetaV(i,j,bi,bj)*recip_deltaT
             tmp        = evpStarFac*recip_deltaT
             betaFacP1V = betaFacV + tmp
             betaFacP1U = betaFacU + tmp
-            denomU = seaiceMassU(I,J,bi,bj)*betaFacP1U
-     &           + 0.5 _d 0*( DWATN(I,J,bi,bj) + DWATN(I-1,J,bi,bj) )
-     &           * COSWAT * areaW(I,J,bi,bj)
-            denomV = seaiceMassV(I,J,bi,bj)*betaFacP1V
-     &           + 0.5 _d 0*( DWATN(I,J,bi,bj) + DWATN(I,J-1,bi,bj) )
-     &           * COSWAT * areaS(I,J,bi,bj)
+            denomU = seaiceMassU(i,j,bi,bj)*betaFacP1U
+     &           + 0.5 _d 0*( DWATN(i,j,bi,bj) + DWATN(i-1,j,bi,bj) )
+     &           * COSWAT * areaW(i,j,bi,bj)
+            denomV = seaiceMassV(i,j,bi,bj)*betaFacP1V
+     &           + 0.5 _d 0*( DWATN(i,j,bi,bj) + DWATN(i,j-1,bi,bj) )
+     &           * COSWAT * areaS(i,j,bi,bj)
 #ifdef SEAICE_ALLOW_BOTTOMDRAG
-            denomU = denomU + areaW(I,J,bi,bj)
-     &           * 0.5 _d 0*( CbotC(I,J,bi,bj) + CbotC(I-1,J,bi,bj) )
-            denomV = denomV + areaS(I,J,bi,bj)
-     &           * 0.5 _d 0*( CbotC(I,J,bi,bj) + CbotC(I,J-1,bi,bj) )
+            denomU = denomU + areaW(i,j,bi,bj)
+     &           * 0.5 _d 0*( CbotC(i,j,bi,bj) + CbotC(i-1,j,bi,bj) )
+            denomV = denomV + areaS(i,j,bi,bj)
+     &           * 0.5 _d 0*( CbotC(i,j,bi,bj) + CbotC(i,j-1,bi,bj) )
 #endif /* SEAICE_ALLOW_BOTTOMDRAG */
             IF ( denomU .EQ. 0. _d 0 ) denomU = 1. _d 0
             IF ( denomV .EQ. 0. _d 0 ) denomV = 1. _d 0
-            uIce(I,J,bi,bj) = seaiceMaskU(I,J,bi,bj) *
-     &           ( seaiceMassU(I,J,bi,bj)*betaFacU
-     &           * uIce(I,J,bi,bj)
-     &           + seaiceMassU(I,J,bi,bj)*recip_deltaT*evpStarFac
-     &           * uIceNm1(I,J,bi,bj)
-     &           + FORCEX(I,J,bi,bj)
-     &           + stressDivergenceX(I,J,bi,bj) ) / denomU
-            vIce(I,J,bi,bj) = seaiceMaskV(I,J,bi,bj) *
-     &           ( seaiceMassV(I,J,bi,bj)*betaFacV
-     &           * vIce(I,J,bi,bj)
-     &           + seaiceMassV(I,J,bi,bj)*recip_deltaT*evpStarFac
-     &           * vIceNm1(I,J,bi,bj)
-     &           + FORCEY(I,J,bi,bj)
-     &           + stressDivergenceY(I,J,bi,bj) ) / denomV
+            uIce(i,j,bi,bj) = seaiceMaskU(i,j,bi,bj) *
+     &           ( seaiceMassU(i,j,bi,bj)*betaFacU
+     &           * uIce(i,j,bi,bj)
+     &           + seaiceMassU(i,j,bi,bj)*recip_deltaT*evpStarFac
+     &           * uIceNm1(i,j,bi,bj)
+     &           + FORCEX(i,j,bi,bj)
+     &           + stressDivergenceX(i,j,bi,bj) ) / denomU
+            vIce(i,j,bi,bj) = seaiceMaskV(i,j,bi,bj) *
+     &           ( seaiceMassV(i,j,bi,bj)*betaFacV
+     &           * vIce(i,j,bi,bj)
+     &           + seaiceMassV(i,j,bi,bj)*recip_deltaT*evpStarFac
+     &           * vIceNm1(i,j,bi,bj)
+     &           + FORCEY(i,j,bi,bj)
+     &           + stressDivergenceY(i,j,bi,bj) ) / denomV
 C--   to change results  of lab_sea.hb87 test exp. (only preserve 2 digits for cg2d)
 c           uIce(i,j,bi,bj) = uIceNm1(i,j,bi,bj)
 c    &                       +( uIce(i,j,bi,bj) - uIceNm1(i,j,bi,bj) )
@@ -906,14 +906,14 @@ CADJ STORE vIce = comlev1_evp, key = evpkey, byte = isbyte
          DO bj=myByLo(myThid),myByHi(myThid)
           DO bi=myBxLo(myThid),myBxHi(myThid)
            resTile(bi,bj) = 0. _d 0
-           DO J=1,sNy
-            DO I=1,sNx
-             uIcePm1(I,J,bi,bj) = seaiceMaskU(I,J,bi,bj) *
-     &            ( uIce(I,J,bi,bj)-uIcePm1(i,j,bi,bj) )
-     &            * evpBetaU(I,J,bi,bj)
-             vIcePm1(I,J,bi,bj) = seaiceMaskV(I,J,bi,bj) *
-     &            ( vIce(I,J,bi,bj)-vIcePm1(i,j,bi,bj) )
-     &            * evpBetaV(I,J,bi,bj)
+           DO j=1,sNy
+            DO i=1,sNx
+             uIcePm1(i,j,bi,bj) = seaiceMaskU(i,j,bi,bj) *
+     &            ( uIce(i,j,bi,bj)-uIcePm1(i,j,bi,bj) )
+     &            * evpBetaU(i,j,bi,bj)
+             vIcePm1(i,j,bi,bj) = seaiceMaskV(i,j,bi,bj) *
+     &            ( vIce(i,j,bi,bj)-vIcePm1(i,j,bi,bj) )
+     &            * evpBetaV(i,j,bi,bj)
             ENDDO
            ENDDO
            IF ( .NOT. SEAICEscaleSurfStress ) THEN
@@ -921,16 +921,16 @@ C     multiply with mask (concentration) to only count ice contributions
             DO j=1,sNy
              DO i=1,sNx
               resTile(bi,bj) = resTile(bi,bj) + AREA(i,j,bi,bj) *
-     &             ( uIcePm1(I,J,bi,bj)*uIcePm1(I,J,bi,bj)
-     &             + vIcePm1(I,J,bi,bj)*vIcePm1(I,J,bi,bj) )
+     &             ( uIcePm1(i,j,bi,bj)*uIcePm1(i,j,bi,bj)
+     &             + vIcePm1(i,j,bi,bj)*vIcePm1(i,j,bi,bj) )
              ENDDO
             ENDDO
            ELSE
             DO j=1,sNy
              DO i=1,sNx
               resTile(bi,bj) = resTile(bi,bj)
-     &             + uIcePm1(I,J,bi,bj)*uIcePm1(I,J,bi,bj)
-     &             + vIcePm1(I,J,bi,bj)*vIcePm1(I,J,bi,bj)
+     &             + uIcePm1(i,j,bi,bj)*uIcePm1(i,j,bi,bj)
+     &             + vIcePm1(i,j,bi,bj)*vIcePm1(i,j,bi,bj)
              ENDDO
             ENDDO
            ENDIF

--- a/pkg/seaice/seaice_evp.F
+++ b/pkg/seaice/seaice_evp.F
@@ -102,8 +102,6 @@ C     betaFacU/V     :: analog betaFacP1U/V
 C     evpkey :: tape key (depends on evp iteration)
 C     tkey   :: tape key (depends on tile indices and evpkey)
       INTEGER evpkey, tkey
-#else
-      INTEGER nEVPstepMax
 #endif
 
       _RL COSWAT
@@ -242,7 +240,7 @@ C
       betaFacP1  = betaFac + evpStarFac*recip_deltaT
       betaFacP1U = betaFacP1
       betaFacP1V = betaFacP1
-#ifndef ALLOW_AUTODIFF_TAMC
+#ifndef ALLOW_AUTODIFF
       nEVPstepMax = nEVPstep
 #endif
 

--- a/pkg/seaice/seaice_get_dynforcing.F
+++ b/pkg/seaice/seaice_get_dynforcing.F
@@ -156,7 +156,7 @@ C     make local copies of wind field
           ENDDO
          ENDDO
          IF ( useRelativeWind ) THEN
-C     undo subtraction of ocean velocities and subtract ice velocities
+C     subtract ice velocities from each component wind-speed
           DO j=1-OLy,sNy+OLy-1
            DO i=1-OLx,sNx+OLx-1
             uTmp(i,j)=uwind(i,j,bi,bj)

--- a/pkg/seaice/seaice_growth.F
+++ b/pkg/seaice/seaice_growth.F
@@ -574,7 +574,7 @@ C     prepare SItrAREA to be computed as cumulative sum
         ENDIF
 #endif /* ALLOW_DIAGNOSTICS */
 
-#if (defined ALLOW_AUTODIFF_TAMC && defined SEAICE_MODIFY_GROWTH_ADJ)
+#if (defined ALLOW_AUTODIFF && defined SEAICE_MODIFY_GROWTH_ADJ)
 Cgf no additional dependency of air-sea fluxes to ice
         IF ( SEAICEadjMODE.GE.1 ) THEN
          DO J=1,sNy
@@ -659,7 +659,7 @@ Cif       Do not regularize when HEFFpreTH = 0
         ENDDO
 #endif /* SEAICE_ITD */
 
-#if (defined ALLOW_AUTODIFF_TAMC && defined SEAICE_MODIFY_GROWTH_ADJ)
+#if (defined ALLOW_AUTODIFF && defined SEAICE_MODIFY_GROWTH_ADJ)
         CALL ZERO_ADJ_1D( sNx*sNy, heffActual, myThid)
         CALL ZERO_ADJ_1D( sNx*sNy, hsnowActual, myThid)
         CALL ZERO_ADJ_1D( sNx*sNy, recip_heffActual, myThid)
@@ -974,7 +974,7 @@ CADJ STORE r_QbyATM_open   = comlev1_bibj, key = tkey, byte = isbyte
 CADJ STORE r_FWbySublim    = comlev1_bibj, key = tkey, byte = isbyte
 #endif /* ALLOW_AUTODIFF_TAMC */
 
-#if (defined ALLOW_AUTODIFF_TAMC && defined SEAICE_MODIFY_GROWTH_ADJ)
+#if (defined ALLOW_AUTODIFF && defined SEAICE_MODIFY_GROWTH_ADJ)
 Cgf no additional dependency through ice cover
         IF ( SEAICEadjMODE.GE.3 ) THEN
 #ifdef SEAICE_ITD
@@ -1097,7 +1097,7 @@ C     due to lateral melt
         ENDDO
 #endif /* SEAICE_ITD */
 
-#if (defined ALLOW_AUTODIFF_TAMC && defined SEAICE_MODIFY_GROWTH_ADJ)
+#if (defined ALLOW_AUTODIFF && defined SEAICE_MODIFY_GROWTH_ADJ)
         CALL ZERO_ADJ_1D( sNx*sNy, r_QbyOCN, myThid)
 #endif
 
@@ -1905,7 +1905,7 @@ C       limit area reduction so that actual ice thickness does not increase
         ENDIF
 #endif /* SEAICE_ITD */
 
-#if (defined ALLOW_AUTODIFF_TAMC && defined SEAICE_MODIFY_GROWTH_ADJ)
+#if (defined ALLOW_AUTODIFF && defined SEAICE_MODIFY_GROWTH_ADJ)
 Cgf 'bulk' linearization of area=f(HEFF)
         IF ( SEAICEadjMODE.GE.1 ) THEN
 #ifdef SEAICE_ITD

--- a/pkg/seaice/seaice_growth.F
+++ b/pkg/seaice/seaice_growth.F
@@ -96,9 +96,9 @@ C     i,j,bi,bj :: Loop counters
       INTEGER i, j, bi, bj
 C     number of surface interface layer
       INTEGER kSurface
-C     IT :: ice thickness category index (MULTICATEGORIES and ITD code)
+C     IT        :: ice thickness category index (MULTICATEGORIES and ITD code)
       INTEGER IT
-C     msgBuf      :: Informational/error message buffer
+C     msgBuf    :: Informational/error message buffer
 #ifdef ALLOW_BALANCE_FLUXES
       CHARACTER*(MAX_LEN_MBUF) msgBuf
 #elif (defined (SEAICE_DEBUG))
@@ -165,7 +165,7 @@ C     tkey :: tape key (depends on tiles)
 #endif
 
 C==   local arrays ==
-C--   TmixLoc        :: ocean surface/mixed-layer temperature (in K)
+C     TmixLoc   :: ocean surface/mixed-layer temperature (in K)
       _RL TmixLoc       (1:sNx,1:sNy)
 
 #ifndef SEAICE_ITD
@@ -177,7 +177,7 @@ C     actual snow thickness
 C     actual ice thickness (with lower limit only) Reciprocal
       _RL recip_heffActual    (1:sNx,1:sNy)
 
-C     AREA_PRE :: hold sea-ice fraction field before any seaice-thermo update
+C     AREA_PRE  :: hold sea-ice fraction field before any seaice-thermo update
       _RL AREApreTH           (1:sNx,1:sNy)
       _RL HEFFpreTH           (1:sNx,1:sNy)
       _RL HSNWpreTH           (1:sNx,1:sNy)
@@ -278,23 +278,23 @@ C     over one time step
 #endif
 
 #ifdef SEAICE_ITD
-      _RL d_HEFFbySublim_ITD         (1:sNx,1:sNy,1:nITD)
-      _RL d_HSNWbySublim_ITD         (1:sNx,1:sNy,1:nITD)
-      _RL d_HEFFbyOCNonICE_ITD       (1:sNx,1:sNy,1:nITD)
-      _RL d_HSNWbyATMonSNW_ITD       (1:sNx,1:sNy,1:nITD)
-      _RL d_HEFFbyATMonOCN_ITD       (1:sNx,1:sNy,1:nITD)
-      _RL d_HEFFbyATMonOCN_cover_ITD (1:sNx,1:sNy,1:nITD)
-      _RL d_HEFFbyATMonOCN_open_ITD  (1:sNx,1:sNy,1:nITD)
-      _RL d_HSNWbyRAIN_ITD           (1:sNx,1:sNy,1:nITD)
-      _RL d_HSNWbyOCNonSNW_ITD       (1:sNx,1:sNy,1:nITD)
-      _RL d_HEFFbyFLOODING_ITD       (1:sNx,1:sNy,1:nITD)
+      _RL d_HEFFbySublim_ITD        (1:sNx,1:sNy,1:nITD)
+      _RL d_HSNWbySublim_ITD        (1:sNx,1:sNy,1:nITD)
+      _RL d_HEFFbyOCNonICE_ITD      (1:sNx,1:sNy,1:nITD)
+      _RL d_HSNWbyATMonSNW_ITD      (1:sNx,1:sNy,1:nITD)
+      _RL d_HEFFbyATMonOCN_ITD      (1:sNx,1:sNy,1:nITD)
+      _RL d_HEFFbyATMonOCN_cover_ITD(1:sNx,1:sNy,1:nITD)
+      _RL d_HEFFbyATMonOCN_open_ITD (1:sNx,1:sNy,1:nITD)
+      _RL d_HSNWbyRAIN_ITD          (1:sNx,1:sNy,1:nITD)
+      _RL d_HSNWbyOCNonSNW_ITD      (1:sNx,1:sNy,1:nITD)
+      _RL d_HEFFbyFLOODING_ITD      (1:sNx,1:sNy,1:nITD)
 #endif
 
 #ifdef ALLOW_DIAGNOSTICS
 C ICE/SNOW stocks tendencies associated with the various melt/freeze processes
-      _RL d_AREAbyATM         (1:sNx,1:sNy)
-      _RL d_AREAbyOCN         (1:sNx,1:sNy)
-      _RL d_AREAbyICE         (1:sNx,1:sNy)
+      _RL d_AREAbyATM   (1:sNx,1:sNy)
+      _RL d_AREAbyOCN   (1:sNx,1:sNy)
+      _RL d_AREAbyICE   (1:sNx,1:sNy)
 C     Helper variables for diagnostics
       _RL DIAGarrayA    (1:sNx,1:sNy)
       _RL DIAGarrayB    (1:sNx,1:sNy)
@@ -315,10 +315,10 @@ C     Helper variables for diagnostics
 #endif
 
 #ifdef ALLOW_SALT_PLUME
-      _RL localSPfrac          (1:sNx,1:sNy)
+      _RL localSPfrac         (1:sNx,1:sNy)
 #ifdef SALT_PLUME_IN_LEADS
-      _RL leadPlumeFraction    (1:sNx,1:sNy)
-      _RL IceGrowthRateInLeads (1:sNx,1:sNy)
+      _RL leadPlumeFraction   (1:sNx,1:sNy)
+      _RL IceGrowthRateInLeads(1:sNx,1:sNy)
 #endif /* SALT_PLUME_IN_LEADS */
 #endif /* ALLOW_SALT_PLUME */
 
@@ -416,73 +416,73 @@ C store position of 'grease' in tracer array
 C array initializations
 C =====================
 
-        DO J=1,sNy
-         DO I=1,sNx
-          a_QbyATM_cover (I,J)       = 0.0 _d 0
-          a_QbyATM_open(I,J)         = 0.0 _d 0
-          r_QbyATM_cover (I,J)       = 0.0 _d 0
-          r_QbyATM_open (I,J)        = 0.0 _d 0
+        DO j=1,sNy
+         DO i=1,sNx
+          a_QbyATM_cover(i,j)        = 0.0 _d 0
+          a_QbyATM_open (i,j)        = 0.0 _d 0
+          r_QbyATM_cover(i,j)        = 0.0 _d 0
+          r_QbyATM_open (i,j)        = 0.0 _d 0
 
-          a_QSWbyATM_open (I,J)      = 0.0 _d 0
-          a_QSWbyATM_cover (I,J)     = 0.0 _d 0
+          a_QSWbyATM_open (i,j)      = 0.0 _d 0
+          a_QSWbyATM_cover(i,j)      = 0.0 _d 0
 
-          a_QbyOCN (I,J)             = 0.0 _d 0
-          r_QbyOCN (I,J)             = 0.0 _d 0
+          a_QbyOCN (i,j)             = 0.0 _d 0
+          r_QbyOCN (i,j)             = 0.0 _d 0
 
 #ifdef ALLOW_DIAGNOSTICS
-          d_AREAbyATM(I,J)           = 0.0 _d 0
-          d_AREAbyICE(I,J)           = 0.0 _d 0
-          d_AREAbyOCN(I,J)           = 0.0 _d 0
+          d_AREAbyATM(i,j)           = 0.0 _d 0
+          d_AREAbyICE(i,j)           = 0.0 _d 0
+          d_AREAbyOCN(i,j)           = 0.0 _d 0
 #endif
 
-          d_HEFFbyOCNonICE(I,J)      = 0.0 _d 0
-          d_HEFFbyATMonOCN(I,J)      = 0.0 _d 0
-          d_HEFFbyFLOODING(I,J)      = 0.0 _d 0
+          d_HEFFbyOCNonICE(i,j)      = 0.0 _d 0
+          d_HEFFbyATMonOCN(i,j)      = 0.0 _d 0
+          d_HEFFbyFLOODING(i,j)      = 0.0 _d 0
 
-          d_HEFFbyATMonOCN_open(I,J) = 0.0 _d 0
-          d_HEFFbyATMonOCN_cover(I,J) = 0.0 _d 0
+          d_HEFFbyATMonOCN_open(i,j) = 0.0 _d 0
+          d_HEFFbyATMonOCN_cover(i,j)= 0.0 _d 0
 
-          d_HSNWbyATMonSNW(I,J)      = 0.0 _d 0
-          d_HSNWbyOCNonSNW(I,J)      = 0.0 _d 0
-          d_HSNWbyRAIN(I,J)          = 0.0 _d 0
-          a_FWbySublim(I,J)          = 0.0 _d 0
-          r_FWbySublim(I,J)          = 0.0 _d 0
-          d_HEFFbySublim(I,J)        = 0.0 _d 0
-          d_HSNWbySublim(I,J)        = 0.0 _d 0
+          d_HSNWbyATMonSNW(i,j)      = 0.0 _d 0
+          d_HSNWbyOCNonSNW(i,j)      = 0.0 _d 0
+          d_HSNWbyRAIN(i,j)          = 0.0 _d 0
+          a_FWbySublim(i,j)          = 0.0 _d 0
+          r_FWbySublim(i,j)          = 0.0 _d 0
+          d_HEFFbySublim(i,j)        = 0.0 _d 0
+          d_HSNWbySublim(i,j)        = 0.0 _d 0
 #ifdef SEAICE_CAP_SUBLIM
-          latentHeatFluxMax(I,J)     = 0.0 _d 0
+          latentHeatFluxMax(i,j)     = 0.0 _d 0
 #endif
-          d_HFRWbyRAIN(I,J)          = 0.0 _d 0
-          tmparr1(I,J)               = 0.0 _d 0
+          d_HFRWbyRAIN(i,j)          = 0.0 _d 0
+          tmparr1(i,j)               = 0.0 _d 0
 #if defined ( ALLOW_SITRACER ) && defined ( SEAICE_GREASE )
-          greaseLayerThick(I,J)      = 0.0 _d 0
-          d_HEFFbyGREASE(I,J)        = 0.0 _d 0
+          greaseLayerThick(i,j)      = 0.0 _d 0
+          d_HEFFbyGREASE(i,j)        = 0.0 _d 0
 #endif
           DO IT=1,SEAICE_multDim
-            ticeInMult(I,J,IT)            = 0.0 _d 0
-            ticeOutMult(I,J,IT)           = 0.0 _d 0
-            a_QbyATMmult_cover(I,J,IT)    = 0.0 _d 0
-            a_QSWbyATMmult_cover(I,J,IT)  = 0.0 _d 0
-            a_FWbySublimMult(I,J,IT)      = 0.0 _d 0
+            ticeInMult(i,j,IT)            = 0.0 _d 0
+            ticeOutMult(i,j,IT)           = 0.0 _d 0
+            a_QbyATMmult_cover(i,j,IT)    = 0.0 _d 0
+            a_QSWbyATMmult_cover(i,j,IT)  = 0.0 _d 0
+            a_FWbySublimMult(i,j,IT)      = 0.0 _d 0
 #ifdef SEAICE_CAP_SUBLIM
-            latentHeatFluxMaxMult(I,J,IT) = 0.0 _d 0
+            latentHeatFluxMaxMult(i,j,IT) = 0.0 _d 0
 #endif
 #ifdef SEAICE_ITD
-            d_HEFFbySublim_ITD(I,J,IT)         = 0.0 _d 0
-            d_HSNWbySublim_ITD(I,J,IT)         = 0.0 _d 0
-            d_HEFFbyOCNonICE_ITD(I,J,IT)       = 0.0 _d 0
-            d_HSNWbyATMonSNW_ITD(I,J,IT)       = 0.0 _d 0
-            d_HEFFbyATMonOCN_ITD(I,J,IT)       = 0.0 _d 0
-            d_HEFFbyATMonOCN_cover_ITD(I,J,IT) = 0.0 _d 0
-            d_HEFFbyATMonOCN_open_ITD(I,J,IT)  = 0.0 _d 0
-            d_HSNWbyRAIN_ITD(I,J,IT)           = 0.0 _d 0
-            d_HSNWbyOCNonSNW_ITD(I,J,IT)       = 0.0 _d 0
-            d_HEFFbyFLOODING_ITD(I,J,IT)       = 0.0 _d 0
-            r_QbyATMmult_cover(I,J,IT)         = 0.0 _d 0
-            r_FWbySublimMult(I,J,IT)           = 0.0 _d 0
+            d_HEFFbySublim_ITD(i,j,IT)         = 0.0 _d 0
+            d_HSNWbySublim_ITD(i,j,IT)         = 0.0 _d 0
+            d_HEFFbyOCNonICE_ITD(i,j,IT)       = 0.0 _d 0
+            d_HSNWbyATMonSNW_ITD(i,j,IT)       = 0.0 _d 0
+            d_HEFFbyATMonOCN_ITD(i,j,IT)       = 0.0 _d 0
+            d_HEFFbyATMonOCN_cover_ITD(i,j,IT) = 0.0 _d 0
+            d_HEFFbyATMonOCN_open_ITD(i,j,IT)  = 0.0 _d 0
+            d_HSNWbyRAIN_ITD(i,j,IT)           = 0.0 _d 0
+            d_HSNWbyOCNonSNW_ITD(i,j,IT)       = 0.0 _d 0
+            d_HEFFbyFLOODING_ITD(i,j,IT)       = 0.0 _d 0
+            r_QbyATMmult_cover(i,j,IT)         = 0.0 _d 0
+            r_FWbySublimMult(i,j,IT)           = 0.0 _d 0
 C for lateral melt parameterization:
-            latMeltFrac(I,J,IT)                = 0.0 _d 0
-            latMeltRate(I,J,IT)                = 0.0 _d 0
+            latMeltFrac(i,j,IT)                = 0.0 _d 0
+            latMeltRate(i,j,IT)                = 0.0 _d 0
 #endif
           ENDDO
          ENDDO
@@ -496,39 +496,39 @@ C     This part has been mostly moved to S/R seaice_reg_ridge, which is
 C     called before S/R seaice_growth
 
 C     store regularized values of heff, hsnow, area at the onset of thermo.
-        DO J=1,sNy
-         DO I=1,sNx
-          HEFFpreTH(I,J)=HEFF(I,J,bi,bj)
-          HSNWpreTH(I,J)=HSNOW(I,J,bi,bj)
-          AREApreTH(I,J)=AREA(I,J,bi,bj)
+        DO j=1,sNy
+         DO i=1,sNx
+          HEFFpreTH(i,j) = HEFF(i,j,bi,bj)
+          HSNWpreTH(i,j) = HSNOW(i,j,bi,bj)
+          AREApreTH(i,j) = AREA(i,j,bi,bj)
 #ifdef ALLOW_DIAGNOSTICS
-          DIAGarrayB(I,J) = AREA(I,J,bi,bj)
-          DIAGarrayC(I,J) = HEFF(I,J,bi,bj)
-          DIAGarrayD(I,J) = HSNOW(I,J,bi,bj)
+          DIAGarrayB(i,j) = AREA(i,j,bi,bj)
+          DIAGarrayC(i,j) = HEFF(i,j,bi,bj)
+          DIAGarrayD(i,j) = HSNOW(i,j,bi,bj)
 #endif
 #ifdef ALLOW_SITRACER
-          SItrHEFF(I,J,bi,bj,1)=HEFF(I,J,bi,bj)
-          SItrAREA(I,J,bi,bj,2)=AREA(I,J,bi,bj)
+          SItrHEFF(i,j,bi,bj,1)=HEFF(i,j,bi,bj)
+          SItrAREA(i,j,bi,bj,2)=AREA(i,j,bi,bj)
 #endif
          ENDDO
         ENDDO
 #ifdef SEAICE_ITD
         DO IT=1,SEAICE_multDim
-         DO J=1,sNy
-          DO I=1,sNx
-           HEFFITDpreTH(I,J,IT)=HEFFITD(I,J,IT,bi,bj)
-           HSNWITDpreTH(I,J,IT)=HSNOWITD(I,J,IT,bi,bj)
-           AREAITDpreTH(I,J,IT)=AREAITD(I,J,IT,bi,bj)
+         DO j=1,sNy
+          DO i=1,sNx
+           HEFFITDpreTH(i,j,IT)=HEFFITD(i,j,IT,bi,bj)
+           HSNWITDpreTH(i,j,IT)=HSNOWITD(i,j,IT,bi,bj)
+           AREAITDpreTH(i,j,IT)=AREAITD(i,j,IT,bi,bj)
 
 C     keep track of areal and volume fraction of each ITD category
-           IF (AREA(I,J,bi,bj) .GT. ZERO) THEN
-            areaFracFactor(I,J,IT)=AREAITD(I,J,IT,bi,bj)/AREA(I,J,bi,bj)
+           IF (AREA(i,j,bi,bj) .GT. ZERO) THEN
+            areaFracFactor(i,j,IT)=AREAITD(i,j,IT,bi,bj)/AREA(i,j,bi,bj)
            ELSE
 C           if there is no ice, potential growth starts in 1st category
             IF (IT .EQ. 1) THEN
-             areaFracFactor(I,J,IT)=ONE
+             areaFracFactor(i,j,IT)=ONE
             ELSE
-             areaFracFactor(I,J,IT)=ZERO
+             areaFracFactor(i,j,IT)=ZERO
             ENDIF
            ENDIF
           ENDDO
@@ -537,16 +537,16 @@ C           if there is no ice, potential growth starts in 1st category
 #ifdef ALLOW_SITRACER
 C     prepare SItrHEFF to be computed as cumulative sum
         DO iTr=2,5
-         DO J=1,sNy
-          DO I=1,sNx
-           SItrHEFF(I,J,bi,bj,iTr)=ZERO
+         DO j=1,sNy
+          DO i=1,sNx
+           SItrHEFF(i,j,bi,bj,iTr)=ZERO
           ENDDO
          ENDDO
         ENDDO
 C     prepare SItrAREA to be computed as cumulative sum
-        DO J=1,sNy
-         DO I=1,sNx
-          SItrAREA(I,J,bi,bj,3)=ZERO
+        DO j=1,sNy
+         DO i=1,sNx
+          SItrAREA(i,j,bi,bj,3)=ZERO
          ENDDO
         ENDDO
 #endif
@@ -577,20 +577,20 @@ C     prepare SItrAREA to be computed as cumulative sum
 #if (defined ALLOW_AUTODIFF && defined SEAICE_MODIFY_GROWTH_ADJ)
 Cgf no additional dependency of air-sea fluxes to ice
         IF ( SEAICEadjMODE.GE.1 ) THEN
-         DO J=1,sNy
-          DO I=1,sNx
-           HEFFpreTH(I,J) = 0. _d 0
-           HSNWpreTH(I,J) = 0. _d 0
-           AREApreTH(I,J) = 0. _d 0
+         DO j=1,sNy
+          DO i=1,sNx
+           HEFFpreTH(i,j) = 0. _d 0
+           HSNWpreTH(i,j) = 0. _d 0
+           AREApreTH(i,j) = 0. _d 0
           ENDDO
          ENDDO
 #ifdef SEAICE_ITD
          DO IT=1,SEAICE_multDim
-          DO J=1,sNy
-           DO I=1,sNx
-            HEFFITDpreTH(I,J,IT) = 0. _d 0
-            HSNWITDpreTH(I,J,IT) = 0. _d 0
-            AREAITDpreTH(I,J,IT) = 0. _d 0
+          DO j=1,sNy
+           DO i=1,sNx
+            HEFFITDpreTH(i,j,IT) = 0. _d 0
+            HSNWITDpreTH(i,j,IT) = 0. _d 0
+            AREAITDpreTH(i,j,IT) = 0. _d 0
            ENDDO
           ENDDO
          ENDDO
@@ -608,52 +608,52 @@ CADJ STORE HSNWpreTH = comlev1_bibj, key = tkey, byte = isbyte
 #endif /* ALLOW_AUTODIFF_TAMC */
 #ifdef SEAICE_ITD
         DO IT=1,SEAICE_multDim
-         DO J=1,sNy
-          DO I=1,sNx
-           IF (HEFFITDpreTH(I,J,IT) .GT. ZERO) THEN
+         DO j=1,sNy
+          DO i=1,sNx
+           IF (HEFFITDpreTH(i,j,IT) .GT. ZERO) THEN
 C     regularize AREA with SEAICE_area_reg
-            tmpscal1 = SQRT(AREAITDpreTH(I,J,IT) * AREAITDpreTH(I,J,IT)
-     &                     + area_reg_sq)
+            tmpscal1 = SQRT( AREAITDpreTH(i,j,IT)*AREAITDpreTH(i,j,IT)
+     &                     + area_reg_sq )
 C     heffActual calculated with the regularized AREA
-            tmpscal2 = HEFFITDpreTH(I,J,IT) / tmpscal1
+            tmpscal2 = HEFFITDpreTH(i,j,IT) / tmpscal1
 C     regularize heffActual with SEAICE_hice_reg (add lower bound)
-            heffActualMult(I,J,IT) = SQRT(tmpscal2 * tmpscal2
+            heffActualMult(i,j,IT) = SQRT(tmpscal2 * tmpscal2
      &                                    + hice_reg_sq)
 C     hsnowActual calculated with the regularized AREA
-            hsnowActualMult(I,J,IT) = HSNWITDpreTH(I,J,IT) / tmpscal1
+            hsnowActualMult(i,j,IT) = HSNWITDpreTH(i,j,IT) / tmpscal1
 C     regularize the inverse of heffActual by hice_reg
-            recip_heffActualMult(I,J,IT)  = AREAITDpreTH(I,J,IT) /
-     &           sqrt(HEFFITDpreTH(I,J,IT) * HEFFITDpreTH(I,J,IT)
+            recip_heffActualMult(i,j,IT)  = AREAITDpreTH(i,j,IT) /
+     &           SQRT(HEFFITDpreTH(i,j,IT) * HEFFITDpreTH(i,j,IT)
      &           + hice_reg_sq)
 C     Do not regularize when HEFFpreTH = 0
            ELSE
-            heffActualMult(I,J,IT) = ZERO
-            hsnowActualMult(I,J,IT) = ZERO
-            recip_heffActualMult(I,J,IT)  = ZERO
+            heffActualMult(i,j,IT) = ZERO
+            hsnowActualMult(i,j,IT) = ZERO
+            recip_heffActualMult(i,j,IT)  = ZERO
            ENDIF
           ENDDO
          ENDDO
         ENDDO
 #else /* ndef SEAICE_ITD */
-        DO J=1,sNy
-         DO I=1,sNx
-          IF (HEFFpreTH(I,J) .GT. ZERO) THEN
+        DO j=1,sNy
+         DO i=1,sNx
+          IF (HEFFpreTH(i,j) .GT. ZERO) THEN
 Cif        regularize AREA with SEAICE_area_reg
-           tmpscal1 = SQRT(AREApreTH(I,J)* AREApreTH(I,J) + area_reg_sq)
+           tmpscal1 = SQRT(AREApreTH(i,j)* AREApreTH(i,j) + area_reg_sq)
 Cif        heffActual calculated with the regularized AREA
-           tmpscal2 = HEFFpreTH(I,J) / tmpscal1
+           tmpscal2 = HEFFpreTH(i,j) / tmpscal1
 Cif        regularize heffActual with SEAICE_hice_reg (add lower bound)
-           heffActual(I,J) = SQRT(tmpscal2 * tmpscal2 + hice_reg_sq)
+           heffActual(i,j) = SQRT(tmpscal2 * tmpscal2 + hice_reg_sq)
 Cif        hsnowActual calculated with the regularized AREA
-           hsnowActual(I,J) = HSNWpreTH(I,J) / tmpscal1
+           hsnowActual(i,j) = HSNWpreTH(i,j) / tmpscal1
 Cif        regularize the inverse of heffActual by hice_reg
-           recip_heffActual(I,J)  = AREApreTH(I,J) /
-     &                 sqrt(HEFFpreTH(I,J)*HEFFpreTH(I,J) + hice_reg_sq)
+           recip_heffActual(i,j)  = AREApreTH(i,j) /
+     &                 SQRT(HEFFpreTH(i,j)*HEFFpreTH(i,j) + hice_reg_sq)
 Cif       Do not regularize when HEFFpreTH = 0
           ELSE
-           heffActual(I,J) = ZERO
-           hsnowActual(I,J) = ZERO
-           recip_heffActual(I,J)  = ZERO
+           heffActual(i,j) = ZERO
+           hsnowActual(i,j) = ZERO
+           recip_heffActual(i,j)  = ZERO
           ENDIF
          ENDDO
         ENDDO
@@ -673,28 +673,28 @@ C     will sublimate all of the snow and ice over one time
 C     step (W/m^2)
 #ifdef SEAICE_ITD
         DO IT=1,SEAICE_multDim
-         DO J=1,sNy
-          DO I=1,sNx
-           IF (HEFFITDpreTH(I,J,IT) .GT. ZERO) THEN
-            latentHeatFluxMaxMult(I,J,IT) = lhSublim*recip_deltaTtherm *
-     &           (HEFFITDpreTH(I,J,IT)*SEAICE_rhoIce +
-     &            HSNWITDpreTH(I,J,IT)*SEAICE_rhoSnow)
-     &           /AREAITDpreTH(I,J,IT)
+         DO j=1,sNy
+          DO i=1,sNx
+           IF (HEFFITDpreTH(i,j,IT) .GT. ZERO) THEN
+            latentHeatFluxMaxMult(i,j,IT) = lhSublim*recip_deltaTtherm *
+     &           (HEFFITDpreTH(i,j,IT)*SEAICE_rhoIce +
+     &            HSNWITDpreTH(i,j,IT)*SEAICE_rhoSnow)
+     &           /AREAITDpreTH(i,j,IT)
            ELSE
-            latentHeatFluxMaxMult(I,J,IT) = ZERO
+            latentHeatFluxMaxMult(i,j,IT) = ZERO
            ENDIF
           ENDDO
          ENDDO
         ENDDO
 #else /* ndef SEAICE_ITD */
-        DO J=1,sNy
-         DO I=1,sNx
-          IF (HEFFpreTH(I,J) .GT. ZERO) THEN
-           latentHeatFluxMax(I,J) = lhSublim * recip_deltaTtherm *
-     &          (HEFFpreTH(I,J) * SEAICE_rhoIce +
-     &           HSNWpreTH(I,J) * SEAICE_rhoSnow)/AREApreTH(I,J)
+        DO j=1,sNy
+         DO i=1,sNx
+          IF (HEFFpreTH(i,j) .GT. ZERO) THEN
+           latentHeatFluxMax(i,j) = lhSublim * recip_deltaTtherm *
+     &          (HEFFpreTH(i,j) * SEAICE_rhoIce +
+     &           HSNWpreTH(i,j) * SEAICE_rhoSnow)/AREApreTH(i,j)
           ELSE
-           latentHeatFluxMax(I,J) = ZERO
+           latentHeatFluxMax(i,j) = ZERO
           ENDIF
          ENDDO
         ENDDO
@@ -713,7 +713,7 @@ C ================================================================
 C ocean surface/mixed layer temperature
           TmixLoc(i,j) = theta(i,j,kSurface,bi,bj)+celsius2K
 C wind speed from exf
-          UG(I,J) = MAX(SEAICE_EPS,wspeed(I,J,bi,bj))
+          UG(i,j) = MAX(SEAICE_EPS,wspeed(i,j,bi,bj))
          ENDDO
         ENDDO
 
@@ -735,17 +735,17 @@ C =======================================================================
 
         IF (useRelativeWind.AND.useAtmWind) THEN
 C     Compute relative wind speed over sea ice.
-         DO J=1,sNy
-          DO I=1,sNx
+         DO j=1,sNy
+          DO i=1,sNx
            SPEED_SQ =
-     &          (uWind(I,J,bi,bj)
+     &          (uWind(i,j,bi,bj)
      &          -0.5 _d 0*(uice(i,j,bi,bj)+uice(i+1,j,bi,bj)))**2
-     &          +(vWind(I,J,bi,bj)
+     &          +(vWind(i,j,bi,bj)
      &          -0.5 _d 0*(vice(i,j,bi,bj)+vice(i,j+1,bi,bj)))**2
            IF ( SPEED_SQ .LE. SEAICE_EPS_SQ ) THEN
-             UG(I,J)=SEAICE_EPS
+             UG(i,j)=SEAICE_EPS
            ELSE
-             UG(I,J)=SQRT(SPEED_SQ)
+             UG(i,j)=SQRT(SPEED_SQ)
            ENDIF
           ENDDO
          ENDDO
@@ -763,11 +763,11 @@ CADJ &                       key = tkey, byte = isbyte
 
 C--   Start loop over multi-categories
         DO IT=1,SEAICE_multDim
-         DO J=1,sNy
-          DO I=1,sNx
-           ticeInMult(I,J,IT)  = TICES(I,J,IT,bi,bj)
-           ticeOutMult(I,J,IT) = TICES(I,J,IT,bi,bj)
-           TICES(I,J,IT,bi,bj) = ZERO
+         DO j=1,sNy
+          DO i=1,sNx
+           ticeInMult(i,j,IT)  = TICES(i,j,IT,bi,bj)
+           ticeOutMult(i,j,IT) = TICES(i,j,IT,bi,bj)
+           TICES(i,j,IT,bi,bj) = ZERO
           ENDDO
          ENDDO
 #ifndef SEAICE_ITD
@@ -777,12 +777,12 @@ C--   assume homogeneous distribution between 0 and 2 x heffActual
          pFac = (2.0 _d 0*IT - 1.0 _d 0)*recip_denominator
          pFacSnow = 1. _d 0
          IF ( SEAICE_useMultDimSnow ) pFacSnow=pFac
-         DO J=1,sNy
-          DO I=1,sNx
-           heffActualMult(I,J,IT)        = heffActual(I,J)*pFac
-           hsnowActualMult(I,J,IT)       = hsnowActual(I,J)*pFacSnow
+         DO j=1,sNy
+          DO i=1,sNx
+           heffActualMult(i,j,IT)        = heffActual(i,j)*pFac
+           hsnowActualMult(i,j,IT)       = hsnowActual(i,j)*pFacSnow
 #ifdef SEAICE_CAP_SUBLIM
-           latentHeatFluxMaxMult(I,J,IT) = latentHeatFluxMax(I,J)*pFac
+           latentHeatFluxMaxMult(i,j,IT) = latentHeatFluxMax(i,j)*pFac
 #endif
           ENDDO
          ENDDO
@@ -836,8 +836,8 @@ CADJ &     comlev1_bibj, key = tkey, byte = isbyte
 #endif /* ALLOW_AUTODIFF_TAMC */
 
         DO IT=1,SEAICE_multDim
-         DO J=1,sNy
-          DO I=1,sNx
+         DO j=1,sNy
+          DO i=1,sNx
 C     update TICES
 CMLC     and tIce, if required later on (currently not the case)
 CML#ifdef SEAICE_ITD
@@ -853,24 +853,24 @@ CML#else
 CML           tIce(I,J,bi,bj) = tIce(I,J,bi,bj)
 CML     &          +  ticeOutMult(I,J,IT)*SEAICE_PDF(IT)
 CML#endif
-           TICES(I,J,IT,bi,bj) = ticeOutMult(I,J,IT)
+           TICES(i,j,IT,bi,bj) = ticeOutMult(i,j,IT)
 C     average over categories
 #ifdef SEAICE_ITD
 C     calculate area weighted mean
 C     (fluxes are per unit (ice surface) area and are thus area weighted)
-           a_QbyATM_cover   (I,J) = a_QbyATM_cover(I,J)
-     &          + a_QbyATMmult_cover(I,J,IT)*areaFracFactor(I,J,IT)
-           a_QSWbyATM_cover (I,J) = a_QSWbyATM_cover(I,J)
-     &          + a_QSWbyATMmult_cover(I,J,IT)*areaFracFactor(I,J,IT)
-           a_FWbySublim     (I,J) = a_FWbySublim(I,J)
-     &          + a_FWbySublimMult(I,J,IT)*areaFracFactor(I,J,IT)
+           a_QbyATM_cover   (i,j) = a_QbyATM_cover(i,j)
+     &          + a_QbyATMmult_cover(i,j,IT)*areaFracFactor(i,j,IT)
+           a_QSWbyATM_cover (i,j) = a_QSWbyATM_cover(i,j)
+     &          + a_QSWbyATMmult_cover(i,j,IT)*areaFracFactor(i,j,IT)
+           a_FWbySublim     (i,j) = a_FWbySublim(i,j)
+     &          + a_FWbySublimMult(i,j,IT)*areaFracFactor(i,j,IT)
 #else
-           a_QbyATM_cover   (I,J) = a_QbyATM_cover(I,J)
-     &          + a_QbyATMmult_cover(I,J,IT)*SEAICE_PDF(IT)
-           a_QSWbyATM_cover (I,J) = a_QSWbyATM_cover(I,J)
-     &          + a_QSWbyATMmult_cover(I,J,IT)*SEAICE_PDF(IT)
-           a_FWbySublim     (I,J) = a_FWbySublim(I,J)
-     &          + a_FWbySublimMult(I,J,IT)*SEAICE_PDF(IT)
+           a_QbyATM_cover   (i,j) = a_QbyATM_cover(i,j)
+     &          + a_QbyATMmult_cover(i,j,IT)*SEAICE_PDF(IT)
+           a_QSWbyATM_cover (i,j) = a_QSWbyATM_cover(i,j)
+     &          + a_QSWbyATMmult_cover(i,j,IT)*SEAICE_PDF(IT)
+           a_FWbySublim     (i,j) = a_FWbySublim(i,j)
+     &          + a_FWbySublimMult(i,j,IT)*SEAICE_PDF(IT)
 #endif
           ENDDO
          ENDDO
@@ -878,10 +878,10 @@ C     (fluxes are per unit (ice surface) area and are thus area weighted)
 
 #ifdef SEAICE_CAP_SUBLIM
 # ifdef ALLOW_DIAGNOSTICS
-        DO J=1,sNy
-         DO I=1,sNx
+        DO j=1,sNy
+         DO i=1,sNx
 C          The actual latent heat flux realized by SOLVE4TEMP
-           DIAGarrayA(I,J) = a_FWbySublim(I,J) * lhSublim
+           DIAGarrayA(i,j) = a_FWbySublim(i,j) * lhSublim
          ENDDO
         ENDDO
 Cif     The actual vs. maximum latent heat flux
@@ -906,58 +906,58 @@ CADJ STORE a_FWbySublim    = comlev1_bibj, key = tkey, byte = isbyte
 C switch heat fluxes from W/m2 to 'effective' ice meters
 #ifdef SEAICE_ITD
         DO IT=1,SEAICE_multDim
-         DO J=1,sNy
-          DO I=1,sNx
-           a_QbyATMmult_cover(I,J,IT)   = a_QbyATMmult_cover(I,J,IT)
-     &          * convertQ2HI * AREAITDpreTH(I,J,IT)
-           a_QSWbyATMmult_cover(I,J,IT) = a_QSWbyATMmult_cover(I,J,IT)
-     &          * convertQ2HI * AREAITDpreTH(I,J,IT)
+         DO j=1,sNy
+          DO i=1,sNx
+           a_QbyATMmult_cover(i,j,IT)   = a_QbyATMmult_cover(i,j,IT)
+     &          * convertQ2HI * AREAITDpreTH(i,j,IT)
+           a_QSWbyATMmult_cover(i,j,IT) = a_QSWbyATMmult_cover(i,j,IT)
+     &          * convertQ2HI * AREAITDpreTH(i,j,IT)
 C and initialize r_QbyATMmult_cover
-           r_QbyATMmult_cover(I,J,IT)=a_QbyATMmult_cover(I,J,IT)
+           r_QbyATMmult_cover(i,j,IT)=a_QbyATMmult_cover(i,j,IT)
 C     Convert fresh water flux by sublimation to 'effective' ice meters.
 C     Negative sublimation is resublimation and will be added as snow.
 #ifdef SEAICE_DISABLE_SUBLIM
-           a_FWbySublimMult(I,J,IT) = ZERO
+           a_FWbySublimMult(i,j,IT) = ZERO
 #endif
-           a_FWbySublimMult(I,J,IT) = SEAICE_deltaTtherm*recip_rhoIce
-     &            * a_FWbySublimMult(I,J,IT)*AREAITDpreTH(I,J,IT)
-           r_FWbySublimMult(I,J,IT)=a_FWbySublimMult(I,J,IT)
+           a_FWbySublimMult(i,j,IT) = SEAICE_deltaTtherm*recip_rhoIce
+     &            * a_FWbySublimMult(i,j,IT)*AREAITDpreTH(i,j,IT)
+           r_FWbySublimMult(i,j,IT)=a_FWbySublimMult(i,j,IT)
           ENDDO
          ENDDO
         ENDDO
-        DO J=1,sNy
-         DO I=1,sNx
-          a_QbyATM_open(I,J)    = a_QbyATM_open(I,J)
-     &         * convertQ2HI * ( ONE - AREApreTH(I,J) )
-          a_QSWbyATM_open(I,J)  = a_QSWbyATM_open(I,J)
-     &         * convertQ2HI * ( ONE - AREApreTH(I,J) )
+        DO j=1,sNy
+         DO i=1,sNx
+          a_QbyATM_open(i,j)    = a_QbyATM_open(i,j)
+     &         * convertQ2HI * ( ONE - AREApreTH(i,j) )
+          a_QSWbyATM_open(i,j)  = a_QSWbyATM_open(i,j)
+     &         * convertQ2HI * ( ONE - AREApreTH(i,j) )
 C and initialize r_QbyATM_open
-          r_QbyATM_open(I,J)=a_QbyATM_open(I,J)
+          r_QbyATM_open(i,j)=a_QbyATM_open(i,j)
          ENDDO
         ENDDO
 #else /* SEAICE_ITD */
-        DO J=1,sNy
-         DO I=1,sNx
-          a_QbyATM_cover(I,J)   = a_QbyATM_cover(I,J)
-     &         * convertQ2HI * AREApreTH(I,J)
-          a_QSWbyATM_cover(I,J) = a_QSWbyATM_cover(I,J)
-     &         * convertQ2HI * AREApreTH(I,J)
-          a_QbyATM_open(I,J)    = a_QbyATM_open(I,J)
-     &         * convertQ2HI * ( ONE - AREApreTH(I,J) )
-          a_QSWbyATM_open(I,J)  = a_QSWbyATM_open(I,J)
-     &         * convertQ2HI * ( ONE - AREApreTH(I,J) )
+        DO j=1,sNy
+         DO i=1,sNx
+          a_QbyATM_cover(i,j)   = a_QbyATM_cover(i,j)
+     &         * convertQ2HI * AREApreTH(i,j)
+          a_QSWbyATM_cover(i,j) = a_QSWbyATM_cover(i,j)
+     &         * convertQ2HI * AREApreTH(i,j)
+          a_QbyATM_open(i,j)    = a_QbyATM_open(i,j)
+     &         * convertQ2HI * ( ONE - AREApreTH(i,j) )
+          a_QSWbyATM_open(i,j)  = a_QSWbyATM_open(i,j)
+     &         * convertQ2HI * ( ONE - AREApreTH(i,j) )
 C and initialize r_QbyATM_cover/r_QbyATM_open
-          r_QbyATM_cover(I,J)=a_QbyATM_cover(I,J)
-          r_QbyATM_open(I,J)=a_QbyATM_open(I,J)
+          r_QbyATM_cover(i,j)=a_QbyATM_cover(i,j)
+          r_QbyATM_open(i,j)=a_QbyATM_open(i,j)
 C     Convert fresh water flux by sublimation to 'effective' ice meters.
 C     Negative sublimation is resublimation and will be added as snow.
 #ifdef SEAICE_DISABLE_SUBLIM
 Cgf just for those who may need to omit this term to reproduce old results
-          a_FWbySublim(I,J) = ZERO
+          a_FWbySublim(i,j) = ZERO
 #endif /* SEAICE_DISABLE_SUBLIM */
-          a_FWbySublim(I,J) = SEAICE_deltaTtherm*recip_rhoIce
-     &           * a_FWbySublim(I,J)*AREApreTH(I,J)
-          r_FWbySublim(I,J)=a_FWbySublim(I,J)
+          a_FWbySublim(i,j) = SEAICE_deltaTtherm*recip_rhoIce
+     &           * a_FWbySublim(i,j)*AREApreTH(i,j)
+          r_FWbySublim(i,j)=a_FWbySublim(i,j)
          ENDDO
         ENDDO
 #endif /* SEAICE_ITD */
@@ -979,20 +979,20 @@ Cgf no additional dependency through ice cover
         IF ( SEAICEadjMODE.GE.3 ) THEN
 #ifdef SEAICE_ITD
          DO IT=1,SEAICE_multDim
-          DO J=1,sNy
-           DO I=1,sNx
-            a_QbyATMmult_cover(I,J,IT)   = 0. _d 0
-            r_QbyATMmult_cover(I,J,IT)   = 0. _d 0
-            a_QSWbyATMmult_cover(I,J,IT) = 0. _d 0
+          DO j=1,sNy
+           DO i=1,sNx
+            a_QbyATMmult_cover(i,j,IT)   = 0. _d 0
+            r_QbyATMmult_cover(i,j,IT)   = 0. _d 0
+            a_QSWbyATMmult_cover(i,j,IT) = 0. _d 0
            ENDDO
           ENDDO
          ENDDO
 #else /* ndef SEAICE_ITD */
-         DO J=1,sNy
-          DO I=1,sNx
-           a_QbyATM_cover(I,J)   = 0. _d 0
-           r_QbyATM_cover(I,J)   = 0. _d 0
-           a_QSWbyATM_cover(I,J) = 0. _d 0
+         DO j=1,sNy
+          DO i=1,sNx
+           a_QbyATM_cover(i,j)   = 0. _d 0
+           r_QbyATM_cover(i,j)   = 0. _d 0
+           a_QSWbyATM_cover(i,j) = 0. _d 0
           ENDDO
          ENDDO
 #endif /* SEAICE_ITD */
@@ -1010,23 +1010,23 @@ CADJ STORE salt(:,:,kSurface,bi,bj) = comlev1_bibj,
 CADJ &                       key = tkey, byte = isbyte
 #endif
 
-        DO J=1,sNy
-         DO I=1,sNx
+        DO j=1,sNy
+         DO i=1,sNx
 C         FREEZING TEMP. OF SEA WATER (deg C)
           tempFrz = SEAICE_tempFrz0 +
-     &              SEAICE_dTempFrz_dS *salt(I,J,kSurface,bi,bj)
+     &              SEAICE_dTempFrz_dS *salt(i,j,kSurface,bi,bj)
 C efficiency of turbulent fluxes : dependency to sign of THETA-TBC
-          IF ( theta(I,J,kSurface,bi,bj) .GE. tempFrz ) THEN
+          IF ( theta(i,j,kSurface,bi,bj) .GE. tempFrz ) THEN
            tmpscal1 = SEAICE_mcPheePiston
           ELSE
            tmpscal1 =SEAICE_frazilFrac*dzSurf/SEAICE_deltaTtherm
           ENDIF
 C efficiency of turbulent fluxes : dependency to AREA (McPhee cases)
-          IF ( (AREApreTH(I,J) .GT. 0. _d 0).AND.
+          IF ( (AREApreTH(i,j) .GT. 0. _d 0).AND.
      &         (.NOT.SEAICE_mcPheeStepFunc) ) THEN
            MixedLayerTurbulenceFactor = ONE -
-     &          SEAICE_mcPheeTaper * AREApreTH(I,J)
-          ELSEIF ( (AREApreTH(I,J) .GT. 0. _d 0).AND.
+     &          SEAICE_mcPheeTaper * AREApreTH(i,j)
+          ELSEIF ( (AREApreTH(i,j) .GT. 0. _d 0).AND.
      &             (SEAICE_mcPheeStepFunc) ) THEN
            MixedLayerTurbulenceFactor = ONE - SEAICE_mcPheeTaper
           ELSE
@@ -1034,7 +1034,7 @@ C efficiency of turbulent fluxes : dependency to AREA (McPhee cases)
           ENDIF
 C maximum turbulent flux, in ice meters
           tmpscal2= - (HeatCapacity_Cp*rhoConst * recip_QI)
-     &         * (theta(I,J,kSurface,bi,bj)-tempFrz)
+     &         * (theta(i,j,kSurface,bi,bj)-tempFrz)
      &         * SEAICE_deltaTtherm * HEFFM(i,j,bi,bj)
 C available turbulent flux
           a_QbyOCN(i,j) =
@@ -1049,12 +1049,12 @@ C average floe diameter or a floe size distribution
 C following Steele (1992, Tab. 2)
 C ======================================================
         DO IT=1,SEAICE_multDim
-         DO J=1,sNy
-          DO I=1,sNx
+         DO j=1,sNy
+          DO i=1,sNx
            tempFrz = SEAICE_tempFrz0 +
-     &          SEAICE_dTempFrz_dS *salt(I,J,kSurface,bi,bj)
-           tmpscal1=(theta(I,J,kSurface,bi,bj)-tempFrz)
-           tmpscal2=sqrt(0.87 + 0.067*UG(i,j)) * UG(i,j)
+     &          SEAICE_dTempFrz_dS *salt(i,j,kSurface,bi,bj)
+           tmpscal1=(theta(i,j,kSurface,bi,bj)-tempFrz)
+           tmpscal2=SQRT(0.87 + 0.067*UG(i,j)) * UG(i,j)
 
 C     variable floe diameter following Luepkes et al. (2012, JGR, Equ. 26)
 C     with beta=1
@@ -1063,34 +1063,34 @@ CML           floeDiameter = floeDiameterMin
 CML     &          * (tmpscal3 / (tmpscal3-AREApreTH(I,J)))
 C     this form involves fewer divisions but gives the same result
            floeDiameter = floeDiameterMin * floeDiameterMax
-     &          / ( floeDiameterMax*( 1. _d 0 - AREApreTH(I,J) )
-     &            + floeDiameterMin*AREApreTH(I,J) )
+     &          / ( floeDiameterMax*( 1. _d 0 - AREApreTH(i,j) )
+     &            + floeDiameterMin*AREApreTH(i,j) )
 C     following the idea of SEAICE_areaLossFormula == 1:
-           IF (a_QbyATMmult_cover(i,j,it).LT.ZERO .OR.
+           IF (a_QbyATMmult_cover(i,j,IT).LT.ZERO .OR.
      &         a_QbyATM_open(i,j) .LT.ZERO .OR.
      &         a_QbyOCN(i,j)      .LT.ZERO) THEN
 C     lateral melt rate as suggested by Perovich, 1983 (PhD thesis)
-C           latMeltRate(i,j,it) = 1.6 _d -6 * tmpscal1**1.36
+c           latMeltRate(i,j,IT) = 1.6 _d -6 * tmpscal1**1.36
 C     The following for does the same, but is faster
-            latMeltRate(i,j,it) = ZERO
+            latMeltRate(i,j,IT) = ZERO
             IF (tmpscal1 .GT. ZERO)
-     &         latMeltRate(i,j,it) = 1.6 _d -6 * exp(1.36*log(tmpscal1))
+     &         latMeltRate(i,j,IT) = 1.6 _d -6 * exp(1.36*log(tmpscal1))
 C     lateral melt rate as suggested by Maykut and Perovich, 1987
 C     (JGR 92(C7)), Equ. 24
-c           latMeltRate(i,j,it) = 13.5 _d -6 * tmpscal2 * tmpscal1**1.3
+c           latMeltRate(i,j,IT) = 13.5 _d -6 * tmpscal2 * tmpscal1**1.3
 C     further suggestion by Maykut and Perovich to avoid
 C     latMeltRate -> 0 for UG -> 0
-c           latMeltRate(i,j,it) = (1.6 _d -6 + 13.5 _d -6 * tmpscal2)
+c           latMeltRate(i,j,IT) = (1.6 _d -6 + 13.5 _d -6 * tmpscal2)
 c    &                          * tmpscal1**1.3
 C     factor determining fraction of area and ice volume reduction
 C     due to lateral melt
-            latMeltFrac(i,j,it) =
-     &       latMeltRate(i,j,it)*SEAICE_deltaTtherm*PI /
+            latMeltFrac(i,j,IT) =
+     &       latMeltRate(i,j,IT)*SEAICE_deltaTtherm*PI /
      &       (floeAlpha * floeDiameter)
-            latMeltFrac(i,j,it)=max(ZERO, min(latMeltFrac(i,j,it),ONE))
+            latMeltFrac(i,j,IT)=max(ZERO, min(latMeltFrac(i,j,IT),ONE))
            ELSE
-            latMeltRate(i,j,it)=0.0 _d 0
-            latMeltFrac(i,j,it)=0.0 _d 0
+            latMeltRate(i,j,IT)=0.0 _d 0
+            latMeltFrac(i,j,IT)=0.0 _d 0
            ENDIF
           ENDDO
          ENDDO
@@ -1214,23 +1214,23 @@ CADJ STORE r_FWbySublim     = comlev1_bibj,key=tkey,byte=isbyte
 #ifdef SEAICE_ITD
         DO IT=1,SEAICE_multDim
 #endif /* SEAICE_ITD */
-        DO J=1,sNy
-         DO I=1,sNx
+        DO j=1,sNy
+         DO i=1,sNx
 C     First sublimate/deposite snow
           tmpscal2 =
 #ifdef SEAICE_ITD
-     &     MAX(MIN(r_FWbySublimMult(I,J,IT),HSNOWITD(I,J,IT,bi,bj)
+     &     MAX(MIN(r_FWbySublimMult(i,j,IT),HSNOWITD(i,j,IT,bi,bj)
      &             *SNOW2ICE),ZERO)
-          d_HSNWbySublim_ITD(I,J,IT) = - tmpscal2 * ICE2SNOW
+          d_HSNWbySublim_ITD(i,j,IT) = - tmpscal2 * ICE2SNOW
 C         accumulate change over ITD categories
-          d_HSNWbySublim(I,J)     = d_HSNWbySublim(I,J)      - tmpscal2
+          d_HSNWbySublim(i,j)     = d_HSNWbySublim(i,j)      - tmpscal2
      &                                                       *ICE2SNOW
-          r_FWbySublimMult(I,J,IT)= r_FWbySublimMult(I,J,IT) - tmpscal2
+          r_FWbySublimMult(i,j,IT)= r_FWbySublimMult(i,j,IT) - tmpscal2
 #else /* ndef SEAICE_ITD */
-     &     MAX(MIN(r_FWbySublim(I,J),HSNOW(I,J,bi,bj)*SNOW2ICE),ZERO)
-          d_HSNWbySublim(I,J) = - tmpscal2 * ICE2SNOW
-          HSNOW(I,J,bi,bj)    = HSNOW(I,J,bi,bj)  - tmpscal2*ICE2SNOW
-          r_FWbySublim(I,J)   = r_FWbySublim(I,J) - tmpscal2
+     &     MAX(MIN(r_FWbySublim(i,j),HSNOW(i,j,bi,bj)*SNOW2ICE),ZERO)
+          d_HSNWbySublim(i,j) = - tmpscal2 * ICE2SNOW
+          HSNOW(i,j,bi,bj)    = HSNOW(i,j,bi,bj)  - tmpscal2*ICE2SNOW
+          r_FWbySublim(i,j)   = r_FWbySublim(i,j) - tmpscal2
 #endif /* SEAICE_ITD */
          ENDDO
         ENDDO
@@ -1238,37 +1238,37 @@ C         accumulate change over ITD categories
 CADJ STORE heff(:,:,bi,bj) = comlev1_bibj,key=tkey,byte=isbyte
 CADJ STORE r_FWbySublim    = comlev1_bibj,key=tkey,byte=isbyte
 #endif /* ALLOW_AUTODIFF_TAMC */
-        DO J=1,sNy
-         DO I=1,sNx
+        DO j=1,sNy
+         DO i=1,sNx
 C     If anything is left, sublimate ice
           tmpscal2 =
 #ifdef SEAICE_ITD
-     &     MAX(MIN(r_FWbySublimMult(I,J,IT),HEFFITD(I,J,IT,bi,bj)),ZERO)
-          d_HEFFbySublim_ITD(I,J,IT) = - tmpscal2
+     &     MAX(MIN(r_FWbySublimMult(i,j,IT),HEFFITD(i,j,IT,bi,bj)),ZERO)
+          d_HEFFbySublim_ITD(i,j,IT) = - tmpscal2
 C         accumulate change over ITD categories
-          d_HEFFbySublim(I,J)      = d_HEFFbySublim(I,J)      - tmpscal2
-          r_FWbySublimMult(I,J,IT) = r_FWbySublimMult(I,J,IT) - tmpscal2
+          d_HEFFbySublim(i,j)      = d_HEFFbySublim(i,j)      - tmpscal2
+          r_FWbySublimMult(i,j,IT) = r_FWbySublimMult(i,j,IT) - tmpscal2
 #else /* ndef SEAICE_ITD */
-     &     MAX(MIN(r_FWbySublim(I,J),HEFF(I,J,bi,bj)),ZERO)
-          d_HEFFbySublim(I,J) = - tmpscal2
-          HEFF(I,J,bi,bj)     = HEFF(I,J,bi,bj)   - tmpscal2
-          r_FWbySublim(I,J)   = r_FWbySublim(I,J) - tmpscal2
+     &     MAX(MIN(r_FWbySublim(i,j),HEFF(i,j,bi,bj)),ZERO)
+          d_HEFFbySublim(i,j) = - tmpscal2
+          HEFF(i,j,bi,bj)     = HEFF(i,j,bi,bj)   - tmpscal2
+          r_FWbySublim(i,j)   = r_FWbySublim(i,j) - tmpscal2
 #endif /* SEAICE_ITD */
          ENDDO
         ENDDO
-        DO J=1,sNy
-         DO I=1,sNx
+        DO j=1,sNy
+         DO i=1,sNx
 C     If anything is left, it will be evaporated from the ocean rather than sublimated.
 C     Since a_QbyATM_cover was computed for sublimation, not simple evaporation, we need to
 C     remove the fusion part for the residual (that happens to be precisely r_FWbySublim).
 #ifdef SEAICE_ITD
-          a_QbyATMmult_cover(I,J,IT) = a_QbyATMmult_cover(I,J,IT)
-     &                               - r_FWbySublimMult(I,J,IT)
-          r_QbyATMmult_cover(I,J,IT) = r_QbyATMmult_cover(I,J,IT)
-     &                               - r_FWbySublimMult(I,J,IT)
+          a_QbyATMmult_cover(i,j,IT) = a_QbyATMmult_cover(i,j,IT)
+     &                               - r_FWbySublimMult(i,j,IT)
+          r_QbyATMmult_cover(i,j,IT) = r_QbyATMmult_cover(i,j,IT)
+     &                               - r_FWbySublimMult(i,j,IT)
 #else /* ndef SEAICE_ITD */
-          a_QbyATM_cover(I,J) = a_QbyATM_cover(I,J)-r_FWbySublim(I,J)
-          r_QbyATM_cover(I,J) = r_QbyATM_cover(I,J)-r_FWbySublim(I,J)
+          a_QbyATM_cover(i,j) = a_QbyATM_cover(i,j)-r_FWbySublim(i,j)
+          r_QbyATM_cover(i,j) = r_QbyATM_cover(i,j)-r_FWbySublim(i,j)
 #endif /* SEAICE_ITD */
          ENDDO
         ENDDO
@@ -1289,40 +1289,40 @@ CADJ STORE r_QbyOCN = comlev1_bibj,key=tkey,byte=isbyte
 
 #ifdef SEAICE_ITD
         DO IT=1,SEAICE_multDim
-         DO J=1,sNy
-          DO I=1,sNx
+         DO j=1,sNy
+          DO i=1,sNx
 C          ice growth/melt due to ocean heat r_QbyOCN (W/m^2) is
 C          equally distributed under the ice and hence weighted by
 C          fractional area of each thickness category
-           tmpscal1=MAX(r_QbyOCN(i,j)*areaFracFactor(I,J,IT),
-     &                               -HEFFITD(I,J,IT,bi,bj))
-           d_HEFFbyOCNonICE_ITD(I,J,IT)=tmpscal1
-           d_HEFFbyOCNonICE(I,J) = d_HEFFbyOCNonICE(I,J) + tmpscal1
+           tmpscal1=MAX(r_QbyOCN(i,j)*areaFracFactor(i,j,IT),
+     &                               -HEFFITD(i,j,IT,bi,bj))
+           d_HEFFbyOCNonICE_ITD(i,j,IT)=tmpscal1
+           d_HEFFbyOCNonICE(i,j) = d_HEFFbyOCNonICE(i,j) + tmpscal1
           ENDDO
          ENDDO
         ENDDO
 #ifdef ALLOW_SITRACER
-        DO J=1,sNy
-         DO I=1,sNx
-          SItrHEFF(I,J,bi,bj,2) = HEFFpreTH(I,J)
-     &                          + d_HEFFbySublim(I,J)
-     &                          + d_HEFFbyOCNonICE(I,J)
+        DO j=1,sNy
+         DO i=1,sNx
+          SItrHEFF(i,j,bi,bj,2) = HEFFpreTH(i,j)
+     &                          + d_HEFFbySublim(i,j)
+     &                          + d_HEFFbyOCNonICE(i,j)
          ENDDO
         ENDDO
 #endif
-        DO J=1,sNy
-         DO I=1,sNx
-          r_QbyOCN(I,J)=r_QbyOCN(I,J)-d_HEFFbyOCNonICE(I,J)
+        DO j=1,sNy
+         DO i=1,sNx
+          r_QbyOCN(i,j)=r_QbyOCN(i,j)-d_HEFFbyOCNonICE(i,j)
          ENDDO
         ENDDO
 #else /* SEAICE_ITD */
-        DO J=1,sNy
-         DO I=1,sNx
-          d_HEFFbyOCNonICE(I,J)=MAX(r_QbyOCN(i,j), -HEFF(I,J,bi,bj))
-          r_QbyOCN(I,J)=r_QbyOCN(I,J)-d_HEFFbyOCNonICE(I,J)
-          HEFF(I,J,bi,bj)=HEFF(I,J,bi,bj) + d_HEFFbyOCNonICE(I,J)
+        DO j=1,sNy
+         DO i=1,sNx
+          d_HEFFbyOCNonICE(i,j)=MAX(r_QbyOCN(i,j), -HEFF(i,j,bi,bj))
+          r_QbyOCN(i,j)=r_QbyOCN(i,j)-d_HEFFbyOCNonICE(i,j)
+          HEFF(i,j,bi,bj)=HEFF(i,j,bi,bj) + d_HEFFbyOCNonICE(i,j)
 #ifdef ALLOW_SITRACER
-          SItrHEFF(I,J,bi,bj,2)=HEFF(I,J,bi,bj)
+          SItrHEFF(i,j,bi,bj,2)=HEFF(i,j,bi,bj)
 #endif
          ENDDO
         ENDDO
@@ -1340,39 +1340,39 @@ CADJ STORE r_QbyATM_cover = comlev1_bibj,key=tkey,byte=isbyte
 
 #ifdef SEAICE_ITD
         DO IT=1,SEAICE_multDim
-         DO J=1,sNy
-          DO I=1,sNx
+         DO j=1,sNy
+          DO i=1,sNx
 C     Convert to standard units (meters of ice) rather than to meters
 C     of snow. This appears to be more robust.
-           tmpscal1=MAX(r_QbyATMmult_cover(I,J,IT),
-     &                  -HSNOWITD(I,J,IT,bi,bj)*SNOW2ICE)
+           tmpscal1=MAX(r_QbyATMmult_cover(i,j,IT),
+     &                  -HSNOWITD(i,j,IT,bi,bj)*SNOW2ICE)
            tmpscal2=MIN(tmpscal1,0. _d 0)
 #ifdef SEAICE_MODIFY_GROWTH_ADJ
 Cgf no additional dependency through snow
            IF ( SEAICEadjMODE.GE.2 ) tmpscal2 = 0. _d 0
 #endif
-           d_HSNWbyATMonSNW_ITD(I,J,IT) = tmpscal2*ICE2SNOW
-           d_HSNWbyATMonSNW(I,J) = d_HSNWbyATMonSNW(I,J)
+           d_HSNWbyATMonSNW_ITD(i,j,IT) = tmpscal2*ICE2SNOW
+           d_HSNWbyATMonSNW(i,j) = d_HSNWbyATMonSNW(i,j)
      &                           + tmpscal2*ICE2SNOW
-           r_QbyATMmult_cover(I,J,IT)=r_QbyATMmult_cover(I,J,IT)
+           r_QbyATMmult_cover(i,j,IT)=r_QbyATMmult_cover(i,j,IT)
      &                           - tmpscal2
           ENDDO
          ENDDO
         ENDDO
 #else /* SEAICE_ITD */
-        DO J=1,sNy
-         DO I=1,sNx
+        DO j=1,sNy
+         DO i=1,sNx
 C     Convert to standard units (meters of ice) rather than to meters
 C     of snow. This appears to be more robust.
-          tmpscal1=MAX(r_QbyATM_cover(I,J),-HSNOW(I,J,bi,bj)*SNOW2ICE)
+          tmpscal1=MAX(r_QbyATM_cover(i,j),-HSNOW(i,j,bi,bj)*SNOW2ICE)
           tmpscal2=MIN(tmpscal1,0. _d 0)
 #ifdef SEAICE_MODIFY_GROWTH_ADJ
 Cgf no additional dependency through snow
           IF ( SEAICEadjMODE.GE.2 ) tmpscal2 = 0. _d 0
 #endif
-          d_HSNWbyATMonSNW(I,J)= tmpscal2*ICE2SNOW
-          HSNOW(I,J,bi,bj) = HSNOW(I,J,bi,bj) + tmpscal2*ICE2SNOW
-          r_QbyATM_cover(I,J)=r_QbyATM_cover(I,J) - tmpscal2
+          d_HSNWbyATMonSNW(i,j)= tmpscal2*ICE2SNOW
+          HSNOW(i,j,bi,bj) = HSNOW(i,j,bi,bj) + tmpscal2*ICE2SNOW
+          r_QbyATM_cover(i,j)=r_QbyATM_cover(i,j) - tmpscal2
          ENDDO
         ENDDO
 #endif /* SEAICE_ITD */
@@ -1392,50 +1392,50 @@ Cgf warming conditions, the lab_sea results were not changed.
 
 #ifdef SEAICE_ITD
         DO IT=1,SEAICE_multDim
-         DO J=1,sNy
-          DO I=1,sNx
-           tmpscal1 = HEFFITDpreTH(I,J,IT)
-     &              + d_HEFFbySublim_ITD(I,J,IT)
-     &              + d_HEFFbyOCNonICE_ITD(I,J,IT)
+         DO j=1,sNy
+          DO i=1,sNx
+           tmpscal1 = HEFFITDpreTH(i,j,IT)
+     &              + d_HEFFbySublim_ITD(i,j,IT)
+     &              + d_HEFFbyOCNonICE_ITD(i,j,IT)
            tmpscal2 = MAX(-tmpscal1,
-     &                     r_QbyATMmult_cover(I,J,IT)
+     &                     r_QbyATMmult_cover(i,j,IT)
 C         Limit ice growth by potential melt by ocean
-     &              + AREAITDpreTH(I,J,IT) * r_QbyOCN(I,J))
-           d_HEFFbyATMonOCN_cover_ITD(I,J,IT) = tmpscal2
-           d_HEFFbyATMonOCN_cover(I,J) = d_HEFFbyATMonOCN_cover(I,J)
+     &              + AREAITDpreTH(i,j,IT) * r_QbyOCN(i,j))
+           d_HEFFbyATMonOCN_cover_ITD(i,j,IT) = tmpscal2
+           d_HEFFbyATMonOCN_cover(i,j) = d_HEFFbyATMonOCN_cover(i,j)
      &                                 + tmpscal2
-           d_HEFFbyATMonOCN_ITD(I,J,IT) = d_HEFFbyATMonOCN_ITD(I,J,IT)
+           d_HEFFbyATMonOCN_ITD(i,j,IT) = d_HEFFbyATMonOCN_ITD(i,j,IT)
      &                                 + tmpscal2
-           d_HEFFbyATMonOCN(I,J)       = d_HEFFbyATMonOCN(I,J)
+           d_HEFFbyATMonOCN(i,j)       = d_HEFFbyATMonOCN(i,j)
      &                                 + tmpscal2
-           r_QbyATMmult_cover(I,J,IT)  = r_QbyATMmult_cover(I,J,IT)
+           r_QbyATMmult_cover(i,j,IT)  = r_QbyATMmult_cover(i,j,IT)
      &                                 - tmpscal2
           ENDDO
          ENDDO
         ENDDO
 #ifdef ALLOW_SITRACER
-        DO J=1,sNy
-         DO I=1,sNx
-          SItrHEFF(I,J,bi,bj,3) = SItrHEFF(I,J,bi,bj,2)
-     &                          + d_HEFFbyATMonOCN_cover(I,J)
+        DO j=1,sNy
+         DO i=1,sNx
+          SItrHEFF(i,j,bi,bj,3) = SItrHEFF(i,j,bi,bj,2)
+     &                          + d_HEFFbyATMonOCN_cover(i,j)
          ENDDO
         ENDDO
 #endif
 #else /* ndef SEAICE_ITD */
-        DO J=1,sNy
-         DO I=1,sNx
+        DO j=1,sNy
+         DO i=1,sNx
 
-          tmpscal2 = MAX(-HEFF(I,J,bi,bj),r_QbyATM_cover(I,J)+
+          tmpscal2 = MAX(-HEFF(i,j,bi,bj),r_QbyATM_cover(i,j)+
 C         Limit ice growth by potential melt by ocean
-     &        AREApreTH(I,J) * r_QbyOCN(I,J))
+     &        AREApreTH(i,j) * r_QbyOCN(i,j))
 
-          d_HEFFbyATMonOCN_cover(I,J)=tmpscal2
-          d_HEFFbyATMonOCN(I,J)=d_HEFFbyATMonOCN(I,J)+tmpscal2
-          r_QbyATM_cover(I,J)=r_QbyATM_cover(I,J)-tmpscal2
-          HEFF(I,J,bi,bj) = HEFF(I,J,bi,bj) + tmpscal2
+          d_HEFFbyATMonOCN_cover(i,j)=tmpscal2
+          d_HEFFbyATMonOCN(i,j)=d_HEFFbyATMonOCN(i,j)+tmpscal2
+          r_QbyATM_cover(i,j)=r_QbyATM_cover(i,j)-tmpscal2
+          HEFF(i,j,bi,bj) = HEFF(i,j,bi,bj) + tmpscal2
 
 #ifdef ALLOW_SITRACER
-          SItrHEFF(I,J,bi,bj,3)=HEFF(I,J,bi,bj)
+          SItrHEFF(i,j,bi,bj,3)=HEFF(i,j,bi,bj)
 #endif
          ENDDO
         ENDDO
@@ -1450,50 +1450,50 @@ CADJ STORE AREApreTH = comlev1_bibj,key=tkey,byte=isbyte
 #endif /* ALLOW_AUTODIFF_TAMC */
         IF ( snowPrecipFile .NE. ' ' ) THEN
 C add snowPrecip to HSNOW
-         DO J=1,sNy
-          DO I=1,sNx
-           d_HSNWbyRAIN(I,J) = convertPRECIP2HI * ICE2SNOW *
-     &          snowPrecip(i,j,bi,bj) * AREApreTH(I,J)
-           d_HFRWbyRAIN(I,J) = -convertPRECIP2HI *
-     &          ( PRECIP(I,J,bi,bj) - snowPrecip(I,J,bi,bj) ) *
-     &          AREApreTH(I,J)
-           HSNOW(I,J,bi,bj) = HSNOW(I,J,bi,bj) + d_HSNWbyRAIN(I,J)
+         DO j=1,sNy
+          DO i=1,sNx
+           d_HSNWbyRAIN(i,j) = convertPRECIP2HI * ICE2SNOW *
+     &          snowPrecip(i,j,bi,bj) * AREApreTH(i,j)
+           d_HFRWbyRAIN(i,j) = -convertPRECIP2HI *
+     &          ( PRECIP(i,j,bi,bj) - snowPrecip(i,j,bi,bj) ) *
+     &          AREApreTH(i,j)
+           HSNOW(i,j,bi,bj) = HSNOW(i,j,bi,bj) + d_HSNWbyRAIN(i,j)
           ENDDO
          ENDDO
         ELSE
 C attribute precip to fresh water or snow stock,
 C depending on atmospheric conditions.
-         DO J=1,sNy
-          DO I=1,sNx
+         DO j=1,sNy
+          DO i=1,sNx
 C possible alternatives to the a_QbyATM_cover criterium
 c          IF (tIce(I,J,bi,bj) .LT. TMIX) THEN ! would require computing tIce
 c          IF (atemp(I,J,bi,bj) .LT. celsius2K) THEN
-           IF ( a_QbyATM_cover(I,J).GE. 0. _d 0 ) THEN
+           IF ( a_QbyATM_cover(i,j).GE. 0. _d 0 ) THEN
 C           add precip as snow
-            d_HFRWbyRAIN(I,J)=0. _d 0
-            d_HSNWbyRAIN(I,J)=convertPRECIP2HI*ICE2SNOW*
-     &            PRECIP(I,J,bi,bj)*AREApreTH(I,J)
+            d_HFRWbyRAIN(i,j)=0. _d 0
+            d_HSNWbyRAIN(i,j)=convertPRECIP2HI*ICE2SNOW*
+     &            PRECIP(i,j,bi,bj)*AREApreTH(i,j)
            ELSE
 C           add precip to the fresh water bucket
-            d_HFRWbyRAIN(I,J)=-convertPRECIP2HI*
-     &            PRECIP(I,J,bi,bj)*AREApreTH(I,J)
-            d_HSNWbyRAIN(I,J)=0. _d 0
+            d_HFRWbyRAIN(i,j)=-convertPRECIP2HI*
+     &            PRECIP(i,j,bi,bj)*AREApreTH(i,j)
+            d_HSNWbyRAIN(i,j)=0. _d 0
            ENDIF
          ENDDO
         ENDDO
 #ifdef SEAICE_ITD
         DO IT=1,SEAICE_multDim
-         DO J=1,sNy
-          DO I=1,sNx
-           d_HSNWbyRAIN_ITD(I,J,IT)
-     &     = d_HSNWbyRAIN(I,J)*areaFracFactor(I,J,IT)
+         DO j=1,sNy
+          DO i=1,sNx
+           d_HSNWbyRAIN_ITD(i,j,IT)
+     &     = d_HSNWbyRAIN(i,j)*areaFracFactor(i,j,IT)
           ENDDO
          ENDDO
         ENDDO
 #else /* ndef SEAICE_ITD */
-        DO J=1,sNy
-         DO I=1,sNx
-          HSNOW(I,J,bi,bj) = HSNOW(I,J,bi,bj) + d_HSNWbyRAIN(I,J)
+        DO j=1,sNy
+         DO i=1,sNx
+          HSNOW(i,j,bi,bj) = HSNOW(i,j,bi,bj) + d_HSNWbyRAIN(i,j)
          ENDDO
         ENDDO
 #endif /* SEAICE_ITD */
@@ -1518,38 +1518,38 @@ CADJ STORE r_QbyOCN = comlev1_bibj,key=tkey,byte=isbyte
 
 #ifdef SEAICE_ITD
         DO IT=1,SEAICE_multDim
-         DO J=1,sNy
-          DO I=1,sNx
-           tmpscal4 = HSNWITDpreTH(I,J,IT)
-     &              + d_HSNWbySublim_ITD(I,J,IT)
-     &              + d_HSNWbyATMonSNW_ITD(I,J,IT)
-     &              + d_HSNWbyRAIN_ITD(I,J,IT)
-           tmpscal1=MAX(r_QbyOCN(i,j)*ICE2SNOW*areaFracFactor(I,J,IT),
+         DO j=1,sNy
+          DO i=1,sNx
+           tmpscal4 = HSNWITDpreTH(i,j,IT)
+     &              + d_HSNWbySublim_ITD(i,j,IT)
+     &              + d_HSNWbyATMonSNW_ITD(i,j,IT)
+     &              + d_HSNWbyRAIN_ITD(i,j,IT)
+           tmpscal1=MAX(r_QbyOCN(i,j)*ICE2SNOW*areaFracFactor(i,j,IT),
      &                  -tmpscal4)
            tmpscal2=MIN(tmpscal1,0. _d 0)
 #ifdef SEAICE_MODIFY_GROWTH_ADJ
 Cgf no additional dependency through snow
-           if ( SEAICEadjMODE.GE.2 ) tmpscal2 = 0. _d 0
+           IF ( SEAICEadjMODE.GE.2 ) tmpscal2 = 0. _d 0
 #endif
-           d_HSNWbyOCNonSNW_ITD(I,J,IT) = tmpscal2
-           d_HSNWbyOCNonSNW(I,J) = d_HSNWbyOCNonSNW(I,J) + tmpscal2
-           r_QbyOCN(I,J)=r_QbyOCN(I,J) - tmpscal2*SNOW2ICE
+           d_HSNWbyOCNonSNW_ITD(i,j,IT) = tmpscal2
+           d_HSNWbyOCNonSNW(i,j) = d_HSNWbyOCNonSNW(i,j) + tmpscal2
+           r_QbyOCN(i,j)=r_QbyOCN(i,j) - tmpscal2*SNOW2ICE
           ENDDO
          ENDDO
         ENDDO
 #else /* ndef SEAICE_ITD */
-        DO J=1,sNy
-         DO I=1,sNx
-          tmpscal1=MAX(r_QbyOCN(i,j)*ICE2SNOW, -HSNOW(I,J,bi,bj))
+        DO j=1,sNy
+         DO i=1,sNx
+          tmpscal1=MAX(r_QbyOCN(i,j)*ICE2SNOW, -HSNOW(i,j,bi,bj))
           tmpscal2=MIN(tmpscal1,0. _d 0)
 #ifdef SEAICE_MODIFY_GROWTH_ADJ
 Cgf no additional dependency through snow
-          if ( SEAICEadjMODE.GE.2 ) tmpscal2 = 0. _d 0
+          IF ( SEAICEadjMODE.GE.2 ) tmpscal2 = 0. _d 0
 #endif
-          d_HSNWbyOCNonSNW(I,J) = tmpscal2
-          r_QbyOCN(I,J)=r_QbyOCN(I,J)
-     &                               -d_HSNWbyOCNonSNW(I,J)*SNOW2ICE
-          HSNOW(I,J,bi,bj) = HSNOW(I,J,bi,bj)+d_HSNWbyOCNonSNW(I,J)
+          d_HSNWbyOCNonSNW(i,j) = tmpscal2
+          r_QbyOCN(i,j)=r_QbyOCN(i,j)
+     &                               -d_HSNWbyOCNonSNW(i,j)*SNOW2ICE
+          HSNOW(i,j,bi,bj) = HSNOW(i,j,bi,bj)+d_HSNWbyOCNonSNW(i,j)
          ENDDO
         ENDDO
 #endif /* SEAICE_ITD */
@@ -1569,30 +1569,30 @@ CADJ STORE a_QSWbyATM_cover = comlev1_bibj,key=tkey,byte=isbyte
 CADJ STORE a_QSWbyATM_open = comlev1_bibj,key=tkey,byte=isbyte
 #endif /* ALLOW_AUTODIFF_TAMC */
 
-        DO J=1,sNy
-         DO I=1,sNx
+        DO j=1,sNy
+         DO i=1,sNx
 #ifdef SEAICE_ITD
 C         HEFF will be updated at the end of PART 3,
 C         hence sum of tendencies so far is needed
-          tmpscal4 = HEFFpreTH(I,J)
-     &             + d_HEFFbySublim(I,J)
-     &             + d_HEFFbyOCNonICE(I,J)
-     &             + d_HEFFbyATMonOCN(I,J)
+          tmpscal4 = HEFFpreTH(i,j)
+     &             + d_HEFFbySublim(i,j)
+     &             + d_HEFFbyOCNonICE(i,j)
+     &             + d_HEFFbyATMonOCN(i,j)
 #else /* ndef SEAICE_ITD */
 C         HEFF is updated step by step throughout seaice_growth
-          tmpscal4 = HEFF(I,J,bi,bj)
+          tmpscal4 = HEFF(i,j,bi,bj)
 #endif /* SEAICE_ITD */
 C           Initial ice growth is triggered by open water
 C           heat flux overcoming potential melt by ocean
-            tmpscal1=r_QbyATM_open(I,J)+r_QbyOCN(i,j) *
-     &            (1.0 _d 0 - AREApreTH(I,J))
+            tmpscal1=r_QbyATM_open(i,j)+r_QbyOCN(i,j) *
+     &            (1.0 _d 0 - AREApreTH(i,j))
 C           Penetrative shortwave flux beyond first layer
 C           that is therefore not available to ice growth/melt
-            tmpscal2=SWFracB * a_QSWbyATM_open(I,J)
+            tmpscal2=SWFracB * a_QSWbyATM_open(i,j)
 C           impose -HEFF as the maxmum melting if SEAICE_doOpenWaterMelt
 C           or 0. otherwise (no melting if not SEAICE_doOpenWaterMelt)
             tmpscal3=facOpenGrow*MAX(tmpscal1-tmpscal2,
-     &           -tmpscal4*facOpenMelt)*HEFFM(I,J,bi,bj)
+     &           -tmpscal4*facOpenMelt)*HEFFM(i,j,bi,bj)
 #if defined ( ALLOW_SITRACER ) && defined ( SEAICE_GREASE )
 C Grease ice is a tracer or "bucket" for newly formed frazil ice
 C  that instead of becoming solid sea ice instantly has a half-time
@@ -1605,11 +1605,11 @@ C store freezing/melting condition:
 C
 C 1) mechanical removal of grease by ridging:
 C    if there is no open water left after advection, there cannot be any grease ice
-          if ((1.0 _d 0 - AREApreTH(I,J)).LE.siEps) then
-           tmpscal3 = tmpscal3 + SItracer(I,J,bi,bj,iTrGrease)
-           SItracer(I,J,bi,bj,iTrGrease) = 0. _d 0
+          IF ((1.0 _d 0 - AREApreTH(i,j)).LE.siEps) THEN
+           tmpscal3 = tmpscal3 + SItracer(i,j,bi,bj,iTrGrease)
+           SItracer(i,j,bi,bj,iTrGrease) = 0. _d 0
 
-          elseif (greaseNewFrazil .GT. 0. _d 0) then
+          ELSEIF (greaseNewFrazil .GT. 0. _d 0) THEN
 C    new ice growth goes into grease tracer not HEFF:
            tmpscal3=0. _d 0
 C
@@ -1620,49 +1620,49 @@ C    time scale dependent solidification
 C    (50%  of grease ice area become solid ice within 24h):
            tmpscal1=exp(-SEAICE_deltaTtherm/greaseDecayTime)
 C    gain in solid sea ice volume due to solidified grease:
-           d_HEFFbyGREASE(I,J) =
-     &             SItracer(I,J,bi,bj,iTrGrease)
+           d_HEFFbyGREASE(i,j) =
+     &             SItracer(i,j,bi,bj,iTrGrease)
      &           * (1.0 _d 0 - tmpscal1)
 C    ... and related loss of grease ice (tracer) volume
-           SItracer(I,J,bi,bj,iTrGrease) =
-     &             SItracer(I,J,bi,bj,iTrGrease) * tmpscal1
+           SItracer(i,j,bi,bj,iTrGrease) =
+     &             SItracer(i,j,bi,bj,iTrGrease) * tmpscal1
 C    the solidified grease ice volume needs to be added to HEFF:
-           SItrBucket(I,J,bi,bj,iTrGrease) =
-     &             SItrBucket(I,J,bi,bj,iTrGrease)
-     &           + d_HEFFbyGREASE(I,J)
+           SItrBucket(i,j,bi,bj,iTrGrease) =
+     &             SItrBucket(i,j,bi,bj,iTrGrease)
+     &           + d_HEFFbyGREASE(i,j)
 C
 C 3) grease ice growth from new frazil ice:
 C
            SItracer(i,j,bi,bj,iTrGrease) =
      &      SItracer(i,j,bi,bj,iTrGrease) + greaseNewFrazil
-          endif
+          ENDIF
 C 4) mapping SItrBucket to external variable, in this case HEFF, ...
-          tmpscal3=tmpscal3+SItrBucket(I,J,bi,bj,iTrGrease)
+          tmpscal3=tmpscal3+SItrBucket(i,j,bi,bj,iTrGrease)
 C    ... and empty SItrBucket for tracer 'grease'
-          SItrBucket(I,J,bi,bj,iTrGrease)=0. _d 0
+          SItrBucket(i,j,bi,bj,iTrGrease)=0. _d 0
 #endif /* SEAICE_GREASE */
 #ifdef SEAICE_ITD
 C         ice growth in open water adds to first category
-          d_HEFFbyATMonOCN_open_ITD(I,J,1)=tmpscal3
-          d_HEFFbyATMonOCN_ITD(I,J,1)     =d_HEFFbyATMonOCN_ITD(I,J,1)
+          d_HEFFbyATMonOCN_open_ITD(i,j,1)=tmpscal3
+          d_HEFFbyATMonOCN_ITD(i,j,1)     =d_HEFFbyATMonOCN_ITD(i,j,1)
      &                                    +tmpscal3
 #endif /* SEAICE_ITD */
-          d_HEFFbyATMonOCN_open(I,J)=tmpscal3
-          d_HEFFbyATMonOCN(I,J)=d_HEFFbyATMonOCN(I,J)+tmpscal3
-          r_QbyATM_open(I,J)=r_QbyATM_open(I,J)-tmpscal3
-          HEFF(I,J,bi,bj) = HEFF(I,J,bi,bj) + tmpscal3
+          d_HEFFbyATMonOCN_open(i,j)=tmpscal3
+          d_HEFFbyATMonOCN(i,j)=d_HEFFbyATMonOCN(i,j)+tmpscal3
+          r_QbyATM_open(i,j)=r_QbyATM_open(i,j)-tmpscal3
+          HEFF(i,j,bi,bj) = HEFF(i,j,bi,bj) + tmpscal3
          ENDDO
         ENDDO
 
 #ifdef ALLOW_SITRACER
-        DO J=1,sNy
-         DO I=1,sNx
+        DO j=1,sNy
+         DO i=1,sNx
 C needs to be here to allow use also with LEGACY branch
 #ifdef SEAICE_ITD
-          SItrHEFF(I,J,bi,bj,4)=SItrHEFF(I,J,bi,bj,3)
-     &                         +d_HEFFbyATMonOCN_open(I,J)
+          SItrHEFF(i,j,bi,bj,4)=SItrHEFF(i,j,bi,bj,3)
+     &                         +d_HEFFbyATMonOCN_open(i,j)
 #else /* ndef SEAICE_ITD */
-          SItrHEFF(I,J,bi,bj,4)=HEFF(I,J,bi,bj)
+          SItrHEFF(i,j,bi,bj,4)=HEFF(i,j,bi,bj)
 #endif /* SEAICE_ITD */
          ENDDO
         ENDDO
@@ -1679,35 +1679,35 @@ CADJ STORE hsnow(:,:,bi,bj) = comlev1_bibj,key=tkey,byte=isbyte
         IF ( SEAICEuseFlooding ) THEN
 #ifdef SEAICE_ITD
          DO IT=1,SEAICE_multDim
-          DO J=1,sNy
-           DO I=1,sNx
-            tmpscal3 = HEFFITDpreTH(I,J,IT)
-     &               + d_HEFFbySublim_ITD(I,J,IT)
-     &               + d_HEFFbyOCNonICE_ITD(I,J,IT)
-     &               + d_HEFFbyATMonOCN_ITD(I,J,IT)
-            tmpscal4 = HSNWITDpreTH(I,J,IT)
-     &               + d_HSNWbySublim_ITD(I,J,IT)
-     &               + d_HSNWbyATMonSNW_ITD(I,J,IT)
-     &               + d_HSNWbyRAIN_ITD(I,J,IT)
+          DO j=1,sNy
+           DO i=1,sNx
+            tmpscal3 = HEFFITDpreTH(i,j,IT)
+     &               + d_HEFFbySublim_ITD(i,j,IT)
+     &               + d_HEFFbyOCNonICE_ITD(i,j,IT)
+     &               + d_HEFFbyATMonOCN_ITD(i,j,IT)
+            tmpscal4 = HSNWITDpreTH(i,j,IT)
+     &               + d_HSNWbySublim_ITD(i,j,IT)
+     &               + d_HSNWbyATMonSNW_ITD(i,j,IT)
+     &               + d_HSNWbyRAIN_ITD(i,j,IT)
             tmpscal0 = (tmpscal4*SEAICE_rhoSnow
      &               +  tmpscal3*SEAICE_rhoIce)
      &               * recip_rhoConst
             tmpscal1 = MAX( 0. _d 0, tmpscal0 - tmpscal3)
-            d_HEFFbyFLOODING_ITD(I,J,IT) = tmpscal1
-            d_HEFFbyFLOODING(I,J) = d_HEFFbyFLOODING(I,J)  + tmpscal1
+            d_HEFFbyFLOODING_ITD(i,j,IT) = tmpscal1
+            d_HEFFbyFLOODING(i,j) = d_HEFFbyFLOODING(i,j)  + tmpscal1
            ENDDO
           ENDDO
          ENDDO
 #else /* ndef SEAICE_ITD */
-         DO J=1,sNy
-          DO I=1,sNx
-           tmpscal0 = (HSNOW(I,J,bi,bj)*SEAICE_rhoSnow
-     &              +HEFF(I,J,bi,bj)*SEAICE_rhoIce)*recip_rhoConst
-           tmpscal1 = MAX( 0. _d 0, tmpscal0 - HEFF(I,J,bi,bj))
-           d_HEFFbyFLOODING(I,J)=tmpscal1
-           HEFF(I,J,bi,bj) = HEFF(I,J,bi,bj)+d_HEFFbyFLOODING(I,J)
-           HSNOW(I,J,bi,bj) = HSNOW(I,J,bi,bj)-
-     &                           d_HEFFbyFLOODING(I,J)*ICE2SNOW
+         DO j=1,sNy
+          DO i=1,sNx
+           tmpscal0 = (HSNOW(i,j,bi,bj)*SEAICE_rhoSnow
+     &              +HEFF(i,j,bi,bj)*SEAICE_rhoIce)*recip_rhoConst
+           tmpscal1 = MAX( 0. _d 0, tmpscal0 - HEFF(i,j,bi,bj))
+           d_HEFFbyFLOODING(i,j)=tmpscal1
+           HEFF(i,j,bi,bj) = HEFF(i,j,bi,bj)+d_HEFFbyFLOODING(i,j)
+           HSNOW(i,j,bi,bj) = HSNOW(i,j,bi,bj)-
+     &                           d_HEFFbyFLOODING(i,j)*ICE2SNOW
           ENDDO
          ENDDO
 #endif /* SEAICE_ITD */
@@ -1717,19 +1717,19 @@ CADJ STORE hsnow(:,:,bi,bj) = comlev1_bibj,key=tkey,byte=isbyte
 C apply ice and snow thickness changes
 C =================================================================
          DO IT=1,SEAICE_multDim
-          DO J=1,sNy
-           DO I=1,sNx
-            HEFFITD(I,J,IT,bi,bj) = HEFFITD(I,J,IT,bi,bj)
-     &                            + d_HEFFbySublim_ITD(I,J,IT)
-     &                            + d_HEFFbyOCNonICE_ITD(I,J,IT)
-     &                            + d_HEFFbyATMonOCN_ITD(I,J,IT)
-     &                            + d_HEFFbyFLOODING_ITD(I,J,IT)
-            HSNOWITD(I,J,IT,bi,bj) = HSNOWITD(I,J,IT,bi,bj)
-     &                            + d_HSNWbySublim_ITD(I,J,IT)
-     &                            + d_HSNWbyATMonSNW_ITD(I,J,IT)
-     &                            + d_HSNWbyRAIN_ITD(I,J,IT)
-     &                            + d_HSNWbyOCNonSNW_ITD(I,J,IT)
-     &                            - d_HEFFbyFLOODING_ITD(I,J,IT)
+          DO j=1,sNy
+           DO i=1,sNx
+            HEFFITD(i,j,IT,bi,bj) = HEFFITD(i,j,IT,bi,bj)
+     &                            + d_HEFFbySublim_ITD(i,j,IT)
+     &                            + d_HEFFbyOCNonICE_ITD(i,j,IT)
+     &                            + d_HEFFbyATMonOCN_ITD(i,j,IT)
+     &                            + d_HEFFbyFLOODING_ITD(i,j,IT)
+            HSNOWITD(i,j,IT,bi,bj) = HSNOWITD(i,j,IT,bi,bj)
+     &                            + d_HSNWbySublim_ITD(i,j,IT)
+     &                            + d_HSNWbyATMonSNW_ITD(i,j,IT)
+     &                            + d_HSNWbyRAIN_ITD(i,j,IT)
+     &                            + d_HSNWbyOCNonSNW_ITD(i,j,IT)
+     &                            - d_HEFFbyFLOODING_ITD(i,j,IT)
      &                            * ICE2SNOW
            ENDDO
           ENDDO
@@ -1765,45 +1765,45 @@ C--   in thinnest category account for lateral ice growth and melt the
 C--   "non-ITD" way, so that the ITD simulation with SEAICE_multDim=1
 C--   is identical with the non-ITD simulation;
 C--   use HEFF, ARE, HSNOW, etc. as temporal storage for 1st category
-        DO J=1,sNy
-         DO I=1,sNx
-          HEFF(I,J,bi,bj)=HEFFITD(I,J,1,bi,bj)
-          AREA(I,J,bi,bj)=AREAITD(I,J,1,bi,bj)
-          HSNOW(I,J,bi,bj)=HSNOWITD(I,J,1,bi,bj)
-          HEFFpreTH(I,J)=HEFFITDpreTH(I,J,1)
-          AREApreTH(I,J)=AREAITDpreTH(I,J,1)
-          recip_heffActual(I,J)=recip_heffActualMult(I,J,1)
+        DO j=1,sNy
+         DO i=1,sNx
+          HEFF(i,j,bi,bj)=HEFFITD(i,j,1,bi,bj)
+          AREA(i,j,bi,bj)=AREAITD(i,j,1,bi,bj)
+          HSNOW(i,j,bi,bj)=HSNOWITD(i,j,1,bi,bj)
+          HEFFpreTH(i,j)=HEFFITDpreTH(i,j,1)
+          AREApreTH(i,j)=AREAITDpreTH(i,j,1)
+          recip_heffActual(i,j)=recip_heffActualMult(i,j,1)
          ENDDO
         ENDDO
 #endif /* SEAICE_ITD */
-        DO J=1,sNy
-         DO I=1,sNx
+        DO j=1,sNy
+         DO i=1,sNx
 
 #if defined ( ALLOW_SITRACER ) && defined ( SEAICE_GREASE )
 C         grease ice layer thickness (Hg) includes
 C         1 part frazil ice and 3 parts sea water
 C         i.e. HO = 0.25 * Hg
-          recip_HO=4. _d 0 / greaseLayerThick(I,J)
+          recip_HO=4. _d 0 / greaseLayerThick(i,j)
 #else /* SEAICE_GREASE */
-          IF ( YC(I,J,bi,bj) .LT. ZERO ) THEN
+          IF ( YC(i,j,bi,bj) .LT. ZERO ) THEN
            recip_HO=1. _d 0 / HO_south
           ELSE
            recip_HO=1. _d 0 / HO
           ENDIF
 #endif /* SEAICE_GREASE */
-          recip_HH = recip_heffActual(I,J)
+          recip_HH = recip_heffActual(i,j)
 
 C gain of ice over open water : computed from
 #if defined ( ALLOW_SITRACER ) && defined ( SEAICE_GREASE )
 C   from growth by ATM with grease ice time delay
-          tmpscal4 = MAX(ZERO,d_HEFFbyGREASE(I,J))
+          tmpscal4 = MAX(ZERO,d_HEFFbyGREASE(i,j))
 #else /* SEAICE_GREASE */
 C   (SEAICE_areaGainFormula.EQ.1) from growth by ATM
 C   (SEAICE_areaGainFormula.EQ.2) from predicted growth by ATM
           IF (SEAICE_areaGainFormula.EQ.1) THEN
-            tmpscal4 = MAX(ZERO,d_HEFFbyATMonOCN_open(I,J))
+            tmpscal4 = MAX(ZERO,d_HEFFbyATMonOCN_open(i,j))
           ELSE
-            tmpscal4=MAX(ZERO,a_QbyATM_open(I,J))
+            tmpscal4=MAX(ZERO,a_QbyATM_open(i,j))
           ENDIF
 #endif /* SEAICE_GREASE */
 
@@ -1812,18 +1812,18 @@ C   (SEAICE_areaLossFormula.EQ.1) from all but only melt conributions by ATM and
 C   (SEAICE_areaLossFormula.EQ.2) from net melt-growth>0 by ATM and OCN
 C   (SEAICE_areaLossFormula.EQ.3) from predicted melt by ATM
           IF (SEAICE_areaLossFormula.EQ.1) THEN
-            tmpscal3 = MIN( 0. _d 0 , d_HEFFbyATMonOCN_cover(I,J) )
-     &        + MIN( 0. _d 0 , d_HEFFbyATMonOCN_open(I,J) )
-     &        + MIN( 0. _d 0 , d_HEFFbyOCNonICE(I,J) )
+            tmpscal3 = MIN( 0. _d 0 , d_HEFFbyATMonOCN_cover(i,j) )
+     &        + MIN( 0. _d 0 , d_HEFFbyATMonOCN_open(i,j) )
+     &        + MIN( 0. _d 0 , d_HEFFbyOCNonICE(i,j) )
           ELSEIF (SEAICE_areaLossFormula.EQ.2) THEN
-            tmpscal3 = MIN( 0. _d 0 , d_HEFFbyATMonOCN_cover(I,J)
-     &        + d_HEFFbyATMonOCN_open(I,J) + d_HEFFbyOCNonICE(I,J) )
+            tmpscal3 = MIN( 0. _d 0 , d_HEFFbyATMonOCN_cover(i,j)
+     &        + d_HEFFbyATMonOCN_open(i,j) + d_HEFFbyOCNonICE(i,j) )
           ELSE
 C           compute heff after ice melt by ocn:
-            tmpscal0=HEFF(I,J,bi,bj) - d_HEFFbyATMonOCN(I,J)
+            tmpscal0=HEFF(i,j,bi,bj) - d_HEFFbyATMonOCN(i,j)
 C           compute available heat left after snow melt by atm:
-            tmpscal1= a_QbyATM_open(I,J)+a_QbyATM_cover(I,J)
-     &            - d_HSNWbyATMonSNW(I,J)*SNOW2ICE
+            tmpscal1= a_QbyATM_open(i,j)+a_QbyATM_cover(i,j)
+     &            - d_HSNWbyATMonSNW(i,j)*SNOW2ICE
 C           could not melt more than all the ice
             tmpscal2 = MAX(-tmpscal0,tmpscal1)
             tmpscal3 = MIN(ZERO,tmpscal2)
@@ -1832,72 +1832,72 @@ C           could not melt more than all the ice
 C apply tendency
           IF ( (HEFF(i,j,bi,bj).GT.0. _d 0).OR.
      &        (HSNOW(i,j,bi,bj).GT.0. _d 0) ) THEN
-           AREA(I,J,bi,bj)=MAX(0. _d 0,
-     &      MIN( SEAICE_area_max, AREA(I,J,bi,bj)
+           AREA(i,j,bi,bj)=MAX(0. _d 0,
+     &      MIN( SEAICE_area_max, AREA(i,j,bi,bj)
      &       + recip_HO*tmpscal4+HALF*recip_HH*tmpscal3
      &       * areaPDFfac ))
           ELSE
-           AREA(I,J,bi,bj)=0. _d 0
+           AREA(i,j,bi,bj)=0. _d 0
           ENDIF
 #ifdef ALLOW_SITRACER
-          SItrAREA(I,J,bi,bj,3)=AREA(I,J,bi,bj)
+          SItrAREA(i,j,bi,bj,3)=AREA(i,j,bi,bj)
 #endif /* ALLOW_SITRACER */
 #ifdef ALLOW_DIAGNOSTICS
-          d_AREAbyATM(I,J)=
-     &       recip_HO*MAX(ZERO,d_HEFFbyATMonOCN_open(I,J))
-     &       +HALF*recip_HH*MIN(0. _d 0,d_HEFFbyATMonOCN_open(I,J))
+          d_AREAbyATM(i,j)=
+     &       recip_HO*MAX(ZERO,d_HEFFbyATMonOCN_open(i,j))
+     &       +HALF*recip_HH*MIN(0. _d 0,d_HEFFbyATMonOCN_open(i,j))
      &       *areaPDFfac
-          d_AREAbyICE(I,J)=
-     &        HALF*recip_HH*MIN(0. _d 0,d_HEFFbyATMonOCN_cover(I,J))
+          d_AREAbyICE(i,j)=
+     &        HALF*recip_HH*MIN(0. _d 0,d_HEFFbyATMonOCN_cover(i,j))
      &       *areaPDFfac
-          d_AREAbyOCN(I,J)=
-     &        HALF*recip_HH*MIN( 0. _d 0,d_HEFFbyOCNonICE(I,J) )
+          d_AREAbyOCN(i,j)=
+     &        HALF*recip_HH*MIN( 0. _d 0,d_HEFFbyOCNonICE(i,j) )
      &       *areaPDFfac
 #endif /* ALLOW_DIAGNOSTICS */
          ENDDO
         ENDDO
 #ifdef SEAICE_ITD
 C       transfer 1st category values back into ITD variables
-        DO J=1,sNy
-         DO I=1,sNx
-          HEFFITD(I,J,1,bi,bj)=HEFF(I,J,bi,bj)
-          AREAITD(I,J,1,bi,bj)=AREA(I,J,bi,bj)
-          HSNOWITD(I,J,1,bi,bj)=HSNOW(I,J,bi,bj)
+        DO j=1,sNy
+         DO i=1,sNx
+          HEFFITD(i,j,1,bi,bj)=HEFF(i,j,bi,bj)
+          AREAITD(i,j,1,bi,bj)=AREA(i,j,bi,bj)
+          HSNOWITD(i,j,1,bi,bj)=HSNOW(i,j,bi,bj)
          ENDDO
         ENDDO
 C       now melt ice laterally in all other thickness categories
 C       (areal growth, i.e. new ice formation, only occurrs in 1st category)
-        IF (SEAICE_multDim .gt. 1) THEN
+        IF (SEAICE_multDim .GT. 1) THEN
          DO IT=2,SEAICE_multDim
-          DO J=1,sNy
-           DO I=1,sNx
-            IF (HEFFITD(I,J,IT,bi,bj).LE.ZERO) THEN
+          DO j=1,sNy
+           DO i=1,sNx
+            IF (HEFFITD(i,j,IT,bi,bj).LE.ZERO) THEN
 C       when thickness is zero, area should be zero, too:
-             AREAITD(I,J,IT,bi,bj)=ZERO
+             AREAITD(i,j,IT,bi,bj)=ZERO
             ELSE
 C     tmpscal1 is the minimal ice concentration after lateral melt that will
 C     not lead to an unphysical increase of ice thickness by lateral melt;
 C     estimated as the concentration before thermodynamics scaled by the
 C     ratio of new ice thickness and ice thickness before thermodynamics
-             IF ( HEFFITDpreTH(I,J,IT).LE.ZERO ) THEN
+             IF ( HEFFITDpreTH(i,j,IT).LE.ZERO ) THEN
               tmpscal1=0. _d 0
              ELSE
-              tmpscal1=AREAITDpreTH(I,J,IT)*
-     &             HEFFITD(I,J,IT,bi,bj)/HEFFITDpreTH(I,J,IT)
+              tmpscal1=AREAITDpreTH(i,j,IT)*
+     &             HEFFITD(i,j,IT,bi,bj)/HEFFITDpreTH(i,j,IT)
              ENDIF
 C       melt ice laterally based on an average floe sice
 C       following Steele (1992)
-             AREAITD(I,J,IT,bi,bj) = AREAITD(I,J,IT,bi,bj)
-     &                             * (ONE - latMeltFrac(I,J,IT))
+             AREAITD(i,j,IT,bi,bj) = AREAITD(i,j,IT,bi,bj)
+     &                             * (ONE - latMeltFrac(i,j,IT))
 CML   not necessary:
 CML          AREAITD(I,J,IT,bi,bj) = max(ZERO,AREAITD(I,J,IT,bi,bj))
 C       limit area reduction so that actual ice thickness does not increase
-             AREAITD(I,J,IT,bi,bj) = max(AREAITD(I,J,IT,bi,bj),
+             AREAITD(i,j,IT,bi,bj) = max(AREAITD(i,j,IT,bi,bj),
      &                                   tmpscal1)
             ENDIF
 #ifdef ALLOW_SITRACER
-            SItrAREA(I,J,bi,bj,3)=SItrAREA(I,J,bi,bj,3)
-     &                           +AREAITD(I,J,IT,bi,bj)
+            SItrAREA(i,j,bi,bj,3)=SItrAREA(i,j,bi,bj,3)
+     &                           +AREAITD(i,j,IT,bi,bj)
 #endif /* ALLOW_SITRACER */
            ENDDO
           ENDDO
@@ -1910,19 +1910,19 @@ Cgf 'bulk' linearization of area=f(HEFF)
         IF ( SEAICEadjMODE.GE.1 ) THEN
 #ifdef SEAICE_ITD
          DO IT=1,SEAICE_multDim
-          DO J=1,sNy
-           DO I=1,sNx
-            AREAITD(I,J,IT,bi,bj) = AREAITDpreTH(I,J,IT) + 0.1 _d 0 *
-     &               ( HEFFITD(I,J,IT,bi,bj) - HEFFITDpreTH(I,J,IT) )
+          DO j=1,sNy
+           DO i=1,sNx
+            AREAITD(i,j,IT,bi,bj) = AREAITDpreTH(i,j,IT) + 0.1 _d 0 *
+     &               ( HEFFITD(i,j,IT,bi,bj) - HEFFITDpreTH(i,j,IT) )
            ENDDO
           ENDDO
          ENDDO
 #else /* ndef SEAICE_ITD */
-         DO J=1,sNy
-          DO I=1,sNx
+         DO j=1,sNy
+          DO i=1,sNx
 C            AREA(I,J,bi,bj) = 0.1 _d 0 * HEFF(I,J,bi,bj)
-           AREA(I,J,bi,bj) = AREApreTH(I,J) + 0.1 _d 0 *
-     &               ( HEFF(I,J,bi,bj) - HEFFpreTH(I,J) )
+           AREA(i,j,bi,bj) = AREApreTH(i,j) + 0.1 _d 0 *
+     &               ( HEFF(i,j,bi,bj) - HEFFpreTH(i,j) )
           ENDDO
          ENDDO
 #endif /* SEAICE_ITD */
@@ -1941,14 +1941,14 @@ C     (the updated HEFF is used below for ice salinity increments)
 #if defined ( ALLOW_SITRACER ) && defined ( SEAICE_GREASE )
 C convert SItracer 'grease' from grease ice volume back to ratio:
 C ===============================================================
-        DO J=1,sNy
-         DO I=1,sNx
-          if (HEFF(I,J,bi,bj).GT.siEps) then
-           SItracer(I,J,bi,bj,iTrGrease) =
-     &      SItracer(I,J,bi,bj,iTrGrease) / HEFF(I,J,bi,bj)
-          else
-           SItracer(I,J,bi,bj,iTrGrease) = 0. _d 0
-          endif
+        DO j=1,sNy
+         DO i=1,sNx
+          IF (HEFF(i,j,bi,bj).GT.siEps) THEN
+           SItracer(i,j,bi,bj,iTrGrease) =
+     &      SItracer(i,j,bi,bj,iTrGrease) / HEFF(i,j,bi,bj)
+          ELSE
+           SItracer(i,j,bi,bj,iTrGrease) = 0. _d 0
+          ENDIF
          ENDDO
         ENDDO
 #endif /* SEAICE_GREASE */
@@ -1972,33 +1972,33 @@ CADJ STORE salt(:,:,kSurface,bi,bj) = comlev1_bibj,
 CADJ &                       key = tkey, byte = isbyte
 #  endif /* ALLOW_SALT_PLUME */
 # endif /* ALLOW_AUTODIFF_TAMC */
-        DO J=1,sNy
-         DO I=1,sNx
-          tmpscal1 = d_HEFFbyNEG(I,J,bi,bj) + d_HEFFbyOCNonICE(I,J) +
-     &               d_HEFFbyATMonOCN(I,J) + d_HEFFbyFLOODING(I,J)
-     &             + d_HEFFbySublim(I,J)
+        DO j=1,sNy
+         DO i=1,sNx
+          tmpscal1 = d_HEFFbyNEG(i,j,bi,bj) + d_HEFFbyOCNonICE(i,j) +
+     &               d_HEFFbyATMonOCN(i,j) + d_HEFFbyFLOODING(i,j)
+     &             + d_HEFFbySublim(i,j)
 #ifdef EXF_SEAICE_FRACTION
-     &             + d_HEFFbyRLX(I,J,bi,bj)
+     &             + d_HEFFbyRLX(i,j,bi,bj)
 #endif
 Catn: can not take out more that surface salinity when SSS<SEAICE_salt0
           tmpscal3 = max( 0. _d 0,
-     &                    min(SEAICE_salt0,salt(I,J,kSurface,bi,bj)) )
-          tmpscal2 = tmpscal1 * tmpscal3 * HEFFM(I,J,bi,bj)
+     &                    min(SEAICE_salt0,salt(i,j,kSurface,bi,bj)) )
+          tmpscal2 = tmpscal1 * tmpscal3 * HEFFM(i,j,bi,bj)
      &            * recip_deltaTtherm * SEAICE_rhoIce
-          saltFlux(I,J,bi,bj) = tmpscal2
+          saltFlux(i,j,bi,bj) = tmpscal2
 #ifdef ALLOW_SALT_PLUME
 #ifdef SALT_PLUME_SPLIT_BASIN
 catn attempt to split East/West basins in Arctic
-          localSPfrac(I,J) = SPsalFRAC(1)
+          localSPfrac(i,j) = SPsalFRAC(1)
           IF ( SaltPlumeSplitBasin ) THEN
-            localSPfrac(I,J) = SPsalFRAC(2)
-            IF(YC(I,J,bi,bj).LT. 85.0 .AND. YC(I,J,bi,bj).GT. 71.0
-     &       .AND. XC(I,J,bi,bj) .LT. -90.0) THEN
-             localSPfrac(I,J) = SPsalFRAC(1)
+            localSPfrac(i,j) = SPsalFRAC(2)
+            IF(YC(i,j,bi,bj).LT. 85.0 .AND. YC(i,j,bi,bj).GT. 71.0
+     &       .AND. XC(i,j,bi,bj) .LT. -90.0) THEN
+             localSPfrac(i,j) = SPsalFRAC(1)
             ENDIF
           ENDIF
 #else
-          localSPfrac(I,J) = SPsalFRAC
+          localSPfrac(i,j) = SPsalFRAC
 #endif /* SALT_PLUME_SPLIT_BASIN */
 #ifdef SALT_PLUME_IN_LEADS
 Catn: Only d_HEFFbyATMonOCN should contribute to plume.
@@ -2008,20 +2008,20 @@ C     is that when d_HEFF is formed from below via ocean freezing, it
 C     occurs more uniform over grid cell and not inLeads, thus not
 C     participating in pkg/salt_plume.
 C     Note: tmpscal1 is defined only after saltFlux is calculated.
-          IceGrowthRateInLeads(I,J)=max(0. _d 0,d_HEFFbyATMonOCN(I,J))
-          tmpscal1 = IceGrowthRateInLeads(I,J)
-          leadPlumeFraction(I,J) =
-     &      (ONE + EXP( (SPinflectionPoint - AREApreTH(I,J))*5.0
+          IceGrowthRateInLeads(i,j)=max(0. _d 0,d_HEFFbyATMonOCN(i,j))
+          tmpscal1 = IceGrowthRateInLeads(i,j)
+          leadPlumeFraction(i,j) =
+     &      (ONE + EXP( (SPinflectionPoint - AREApreTH(i,j))*5.0
      &                 /(ONE - SPinflectionPoint) ))**(-ONE)
-          localSPfrac(I,J)=localSPfrac(I,J)*leadPlumeFraction(I,J)
+          localSPfrac(i,j)=localSPfrac(i,j)*leadPlumeFraction(i,j)
 #endif /* SALT_PLUME_IN_LEADS */
-          tmpscal3 = tmpscal1*salt(I,J,kSurface,bi,bj)*HEFFM(I,J,bi,bj)
+          tmpscal3 = tmpscal1*salt(i,j,kSurface,bi,bj)*HEFFM(i,j,bi,bj)
      &            * recip_deltaTtherm * SEAICE_rhoIce
-          saltPlumeFlux(I,J,bi,bj) = MAX( tmpscal3-tmpscal2 , 0. _d 0)
-     &            *localSPfrac(I,J)
+          saltPlumeFlux(i,j,bi,bj) = MAX( tmpscal3-tmpscal2 , 0. _d 0)
+     &            *localSPfrac(i,j)
 C if SaltPlumeSouthernOcean=.FALSE. turn off salt plume in Southern Ocean
           IF ( .NOT. SaltPlumeSouthernOcean ) THEN
-           IF ( YC(I,J,bi,bj) .LT. 0.0 _d 0 )
+           IF ( YC(i,j,bi,bj) .LT. 0.0 _d 0 )
      &          saltPlumeFlux(i,j,bi,bj) = 0.0 _d 0
           ENDIF
 #endif /* ALLOW_SALT_PLUME */
@@ -2035,48 +2035,48 @@ C if SaltPlumeSouthernOcean=.FALSE. turn off salt plume in Southern Ocean
 CADJ STORE hsalt(:,:,bi,bj) = comlev1_bibj,key=tkey,byte=isbyte
 #endif /* ALLOW_AUTODIFF_TAMC */
 
-        DO J=1,sNy
-         DO I=1,sNx
+        DO j=1,sNy
+         DO i=1,sNx
 C sum up the terms that affect the salt content of the ice pack
-         tmpscal1=d_HEFFbyOCNonICE(I,J)+d_HEFFbyATMonOCN(I,J)
+         tmpscal1=d_HEFFbyOCNonICE(i,j)+d_HEFFbyATMonOCN(i,j)
 
 C recompute HEFF before thermodynamic updates (which is not AREApreTH in legacy code)
-         tmpscal2=HEFF(I,J,bi,bj)-tmpscal1-d_HEFFbyFLOODING(I,J)
+         tmpscal2=HEFF(i,j,bi,bj)-tmpscal1-d_HEFFbyFLOODING(i,j)
 C tmpscal1 > 0 : m of sea ice that is created
           IF ( tmpscal1 .GE. 0.0 ) THEN
-             saltFlux(I,J,bi,bj) =
-     &            HEFFM(I,J,bi,bj)*recip_deltaTtherm
-     &            *SEAICE_saltFrac*salt(I,J,kSurface,bi,bj)
+             saltFlux(i,j,bi,bj) =
+     &            HEFFM(i,j,bi,bj)*recip_deltaTtherm
+     &            *SEAICE_saltFrac*salt(i,j,kSurface,bi,bj)
      &            *tmpscal1*SEAICE_rhoIce
 #ifdef ALLOW_SALT_PLUME
 #ifdef SALT_PLUME_SPLIT_BASIN
 catn attempt to split East/West basins in Arctic
-             localSPfrac(I,J) = SPsalFRAC(1)
+             localSPfrac(i,j) = SPsalFRAC(1)
              IF ( SaltPlumeSplitBasin ) THEN
-               localSPfrac(I,J) = SPsalFRAC(2)
-               IF(YC(I,J,bi,bj).LT. 85.0 .AND. YC(I,J,bi,bj).GT. 71.0
-     &                  .AND. XC(I,J,bi,bj) .LT. -90.0) THEN
-                 localSPfrac(I,J) = SPsalFRAC(1)
+               localSPfrac(i,j) = SPsalFRAC(2)
+               IF(YC(i,j,bi,bj).LT. 85.0 .AND. YC(i,j,bi,bj).GT. 71.0
+     &                  .AND. XC(i,j,bi,bj) .LT. -90.0) THEN
+                 localSPfrac(i,j) = SPsalFRAC(1)
                ENDIF
              ENDIF
 #else
-             localSPfrac(I,J) = SPsalFRAC
+             localSPfrac(i,j) = SPsalFRAC
 #endif /* SALT_PLUME_SPLIT_BASIN */
 #ifndef SALT_PLUME_IN_LEADS
 C saltPlumeFlux is defined only during freezing:
-             saltPlumeFlux(I,J,bi,bj)=
-     &            HEFFM(I,J,bi,bj)*recip_deltaTtherm
-     &            *(ONE-SEAICE_saltFrac)*salt(I,J,kSurface,bi,bj)
+             saltPlumeFlux(i,j,bi,bj)=
+     &            HEFFM(i,j,bi,bj)*recip_deltaTtherm
+     &            *(ONE-SEAICE_saltFrac)*salt(i,j,kSurface,bi,bj)
      &            *tmpscal1*SEAICE_rhoIce
-     &            *localSPfrac(I,J)
+     &            *localSPfrac(i,j)
 #endif /* ndef SALT_PLUME_IN_LEADS */
 #endif /* ALLOW_SALT_PLUME */
 
 C tmpscal1 < 0 : m of sea ice that is melted
           ELSE
-             saltFlux(I,J,bi,bj) =
-     &         HEFFM(I,J,bi,bj)*recip_deltaTtherm
-     &         *HSALT(I,J,bi,bj)
+             saltFlux(i,j,bi,bj) =
+     &         HEFFM(i,j,bi,bj)*recip_deltaTtherm
+     &         *HSALT(i,j,bi,bj)
      &         *tmpscal1/tmpscal2
 #ifdef ALLOW_SALT_PLUME
 #ifndef SALT_PLUME_IN_LEADS
@@ -2094,43 +2094,43 @@ C     is that when d_HEFF is formed from below via ocean freezing, it
 C     occurs more uniform over grid cell and not inLeads, thus not
 C     participating in pkg/salt_plume.
 C     Note: tmpscal1 is defined only after saltFlux is calculated.
-          IceGrowthRateInLeads(I,J)=max(0. _d 0,d_HEFFbyATMonOCN(I,J))
-          tmpscal1 = IceGrowthRateInLeads(I,J)
-          leadPlumeFraction(I,J) =
-     &      (ONE + EXP( (SPinflectionPoint - AREApreTH(I,J))*5.0
+          IceGrowthRateInLeads(i,j)=max(0. _d 0,d_HEFFbyATMonOCN(i,j))
+          tmpscal1 = IceGrowthRateInLeads(i,j)
+          leadPlumeFraction(i,j) =
+     &      (ONE + EXP( (SPinflectionPoint - AREApreTH(i,j))*5.0
      &                 /(ONE - SPinflectionPoint) ))**(-ONE)
-          localSPfrac(I,J)=localSPfrac(I,J)*leadPlumeFraction(I,J)
+          localSPfrac(i,j)=localSPfrac(i,j)*leadPlumeFraction(i,j)
           IF ( tmpscal1 .GE. 0.0) THEN
 C saltPlumeFlux is defined only during freezing:
-             saltPlumeFlux(I,J,bi,bj)=
-     &            HEFFM(I,J,bi,bj)*recip_deltaTtherm
-     &            *(ONE-SEAICE_saltFrac)*salt(I,J,kSurface,bi,bj)
+             saltPlumeFlux(i,j,bi,bj)=
+     &            HEFFM(i,j,bi,bj)*recip_deltaTtherm
+     &            *(ONE-SEAICE_saltFrac)*salt(i,j,kSurface,bi,bj)
      &            *tmpscal1*SEAICE_rhoIce
-     &            *localSPfrac(I,J)
+     &            *localSPfrac(i,j)
           ELSE
-             saltPlumeFlux(I,J,bi,bj) = 0. _d 0
+             saltPlumeFlux(i,j,bi,bj) = 0. _d 0
           ENDIF
 #endif /* SALT_PLUME_IN_LEADS */
 C if SaltPlumeSouthernOcean=.FALSE. turn off salt plume in Southern Ocean
           IF ( .NOT. SaltPlumeSouthernOcean ) THEN
-           IF ( YC(I,J,bi,bj) .LT. 0.0 _d 0 )
+           IF ( YC(i,j,bi,bj) .LT. 0.0 _d 0 )
      &          saltPlumeFlux(i,j,bi,bj) = 0.0 _d 0
           ENDIF
 #endif /* ALLOW_SALT_PLUME */
 C update HSALT based on surface saltFlux
-          HSALT(I,J,bi,bj) = HSALT(I,J,bi,bj) +
-     &         saltFlux(I,J,bi,bj) * SEAICE_deltaTtherm
-          saltFlux(I,J,bi,bj) =
-     &         saltFlux(I,J,bi,bj) + saltFluxAdjust(I,J,bi,bj)
+          HSALT(i,j,bi,bj) = HSALT(i,j,bi,bj) +
+     &         saltFlux(i,j,bi,bj) * SEAICE_deltaTtherm
+          saltFlux(i,j,bi,bj) =
+     &         saltFlux(i,j,bi,bj) + saltFluxAdjust(i,j,bi,bj)
          ENDDO
         ENDDO
 #endif /* SEAICE_VARIABLE_SALINITY */
 
 #ifdef ALLOW_SITRACER
-        DO J=1,sNy
-         DO I=1,sNx
+        DO j=1,sNy
+         DO i=1,sNx
 C needs to be here to allow use also with LEGACY branch
-          SItrHEFF(I,J,bi,bj,5)=HEFF(I,J,bi,bj)
+          SItrHEFF(i,j,bi,bj,5)=HEFF(i,j,bi,bj)
          ENDDO
         ENDDO
 #endif /* ALLOW_SITRACER */
@@ -2145,17 +2145,17 @@ C =====================================================
 
 #ifdef SEAICE_ITD
 C compute total of "mult" fluxes for ocean forcing
-        DO J=1,sNy
-         DO I=1,sNx
-          a_QbyATM_cover(I,J)   = 0.0 _d 0
-          r_QbyATM_cover(I,J)   = 0.0 _d 0
-          a_QSWbyATM_cover(I,J) = 0.0 _d 0
-          r_FWbySublim(I,J)     = 0.0 _d 0
+        DO j=1,sNy
+         DO i=1,sNx
+          a_QbyATM_cover(i,j)   = 0.0 _d 0
+          r_QbyATM_cover(i,j)   = 0.0 _d 0
+          a_QSWbyATM_cover(i,j) = 0.0 _d 0
+          r_FWbySublim(i,j)     = 0.0 _d 0
          ENDDO
         ENDDO
         DO IT=1,SEAICE_multDim
-         DO J=1,sNy
-          DO I=1,sNx
+         DO j=1,sNy
+          DO i=1,sNx
 C if fluxes in W/m^2 then use:
 c           a_QbyATM_cover(I,J)=a_QbyATM_cover(I,J)
 c     &      + a_QbyATMmult_cover(I,J,IT) * areaFracFactor(I,J,IT)
@@ -2166,14 +2166,14 @@ c     &      + a_QSWbyATMmult_cover(I,J,IT) * areaFracFactor(I,J,IT)
 c           r_FWbySublim(I,J)=r_FWbySublim(I,J)
 c     &      + r_FWbySublimMult(I,J,IT) * areaFracFactor(I,J,IT)
 C if fluxes in effective ice meters, i.e. ice volume per area, then use:
-           a_QbyATM_cover(I,J)=a_QbyATM_cover(I,J)
-     &      + a_QbyATMmult_cover(I,J,IT)
-           r_QbyATM_cover(I,J)=r_QbyATM_cover(I,J)
-     &      + r_QbyATMmult_cover(I,J,IT)
-           a_QSWbyATM_cover(I,J)=a_QSWbyATM_cover(I,J)
-     &      + a_QSWbyATMmult_cover(I,J,IT)
-           r_FWbySublim(I,J)=r_FWbySublim(I,J)
-     &      + r_FWbySublimMult(I,J,IT)
+           a_QbyATM_cover(i,j)=a_QbyATM_cover(i,j)
+     &      + a_QbyATMmult_cover(i,j,IT)
+           r_QbyATM_cover(i,j)=r_QbyATM_cover(i,j)
+     &      + r_QbyATMmult_cover(i,j,IT)
+           a_QSWbyATM_cover(i,j)=a_QSWbyATM_cover(i,j)
+     &      + a_QSWbyATMmult_cover(i,j,IT)
+           r_FWbySublim(i,j)=r_FWbySublim(i,j)
+     &      + r_FWbySublimMult(i,j,IT)
           ENDDO
          ENDDO
         ENDDO
@@ -2185,35 +2185,35 @@ CADJ &                              key = tkey, byte = isbyte
 CADJ STORE d_hsnwbyocnonsnw = comlev1_bibj,key=tkey,byte=isbyte
 #endif /* ALLOW_AUTODIFF_TAMC */
 
-        DO J=1,sNy
-         DO I=1,sNx
-          QNET(I,J,bi,bj) = r_QbyATM_cover(I,J) + r_QbyATM_open(I,J)
-     &         +   a_QSWbyATM_cover(I,J)
-     &         - ( d_HEFFbyOCNonICE(I,J)
-     &           + d_HSNWbyOCNonSNW(I,J)*SNOW2ICE
-     &           + d_HEFFbyNEG(I,J,bi,bj)
+        DO j=1,sNy
+         DO i=1,sNx
+          QNET(i,j,bi,bj) = r_QbyATM_cover(i,j) + r_QbyATM_open(i,j)
+     &         +   a_QSWbyATM_cover(i,j)
+     &         - ( d_HEFFbyOCNonICE(i,j)
+     &           + d_HSNWbyOCNonSNW(i,j)*SNOW2ICE
+     &           + d_HEFFbyNEG(i,j,bi,bj)
 #ifdef EXF_SEAICE_FRACTION
-     &           + d_HEFFbyRLX(I,J,bi,bj)
+     &           + d_HEFFbyRLX(i,j,bi,bj)
 #endif
-     &           + d_HSNWbyNEG(I,J,bi,bj)*SNOW2ICE
+     &           + d_HSNWbyNEG(i,j,bi,bj)*SNOW2ICE
      &           - convertPRECIP2HI *
-     &             snowPrecip(i,j,bi,bj) * (ONE-AREApreTH(I,J))
-     &           ) * HEFFM(I,J,bi,bj)
+     &             snowPrecip(i,j,bi,bj) * (ONE-AREApreTH(i,j))
+     &           ) * HEFFM(i,j,bi,bj)
          ENDDO
         ENDDO
-        DO J=1,sNy
-         DO I=1,sNx
-          QSW(I,J,bi,bj)  = a_QSWbyATM_cover(I,J) + a_QSWbyATM_open(I,J)
+        DO j=1,sNy
+         DO i=1,sNx
+          QSW(i,j,bi,bj)  = a_QSWbyATM_cover(i,j) + a_QSWbyATM_open(i,j)
          ENDDO
         ENDDO
 
 C switch heat fluxes from 'effective' ice meters to W/m2
 C ======================================================
 
-        DO J=1,sNy
-         DO I=1,sNx
-          QNET(I,J,bi,bj) = QNET(I,J,bi,bj)*convertHI2Q
-          QSW(I,J,bi,bj)  = QSW(I,J,bi,bj)*convertHI2Q
+        DO j=1,sNy
+         DO i=1,sNx
+          QNET(i,j,bi,bj) = QNET(i,j,bi,bj)*convertHI2Q
+          QSW(i,j,bi,bj)  = QSW(i,j,bi,bj)*convertHI2Q
          ENDDO
         ENDDO
 
@@ -2242,18 +2242,18 @@ C real fresh water + non linear free surface framework, a mismatch
 C between ice and ocean boundary condition can result in all cases.
 C Below we therefore anticipate on external_forcing_surf.F
 C to diagnoze and/or apply the correction to QNET.
-        DO J=1,sNy
-         DO I=1,sNx
+        DO j=1,sNy
+         DO i=1,sNx
 catn: initialize tmpscal1
            tmpscal1 = ZERO
 C ocean water going to ice/snow, in precip units
-           tmpscal3=rhoConstFresh*HEFFM(I,J,bi,bj)*(
-     &       ( d_HSNWbyATMonSNW(I,J)*SNOW2ICE
-     &       + d_HSNWbyOCNonSNW(I,J)*SNOW2ICE
-     &       + d_HEFFbyOCNonICE(I,J) + d_HEFFbyATMonOCN(I,J)
-     &       + d_HEFFbyNEG(I,J,bi,bj)+ d_HSNWbyNEG(I,J,bi,bj)*SNOW2ICE )
+           tmpscal3=rhoConstFresh*HEFFM(i,j,bi,bj)*(
+     &       ( d_HSNWbyATMonSNW(i,j)*SNOW2ICE
+     &       + d_HSNWbyOCNonSNW(i,j)*SNOW2ICE
+     &       + d_HEFFbyOCNonICE(i,j) + d_HEFFbyATMonOCN(i,j)
+     &       + d_HEFFbyNEG(i,j,bi,bj)+ d_HSNWbyNEG(i,j,bi,bj)*SNOW2ICE )
      &       * convertHI2PRECIP
-     &       - snowPrecip(i,j,bi,bj) * (ONE-AREApreTH(I,J)) )
+     &       - snowPrecip(i,j,bi,bj) * (ONE-AREApreTH(i,j)) )
 C factor in the heat content as done in external_forcing_surf.F
            IF ( (temp_EvPrRn.NE.UNSET_RL).AND.
      &         useRealFreshWaterFlux.AND.(nonlinFreeSurf.NE.0) ) THEN
@@ -2262,21 +2262,21 @@ C factor in the heat content as done in external_forcing_surf.F
            ELSEIF ( (temp_EvPrRn.EQ.UNSET_RL).AND.
      &         useRealFreshWaterFlux.AND.(nonlinFreeSurf.NE.0) ) THEN
              tmpscal1 = - tmpscal3*
-     &         HeatCapacity_Cp * theta(I,J,kSurface,bi,bj)
+     &         HeatCapacity_Cp * theta(i,j,kSurface,bi,bj)
            ELSEIF ( (temp_EvPrRn.NE.UNSET_RL) ) THEN
              tmpscal1 = - tmpscal3*HeatCapacity_Cp*
-     &       ( temp_EvPrRn - theta(I,J,kSurface,bi,bj) )
+     &       ( temp_EvPrRn - theta(i,j,kSurface,bi,bj) )
            ELSEIF ( (temp_EvPrRn.EQ.UNSET_RL) ) THEN
              tmpscal1 = ZERO
            ENDIF
 #ifdef ALLOW_DIAGNOSTICS
 C in all cases, diagnoze the boundary condition mismatch to SIaaflux
-           DIAGarrayA(I,J)=tmpscal1
+           DIAGarrayA(i,j)=tmpscal1
 #endif
 C remove the mismatch when real fresh water is exchanged (at 0degC here)
            IF ( useRealFreshWaterFlux.AND.(nonlinFreeSurf.GT.0)
      &          .AND.SEAICEheatConsFix )
-     &       QNET(I,J,bi,bj)=QNET(I,J,bi,bj)+tmpscal1
+     &       QNET(i,j,bi,bj)=QNET(i,j,bi,bj)+tmpscal1
          ENDDO
         ENDDO
 #ifdef ALLOW_DIAGNOSTICS
@@ -2289,8 +2289,8 @@ C remove the mismatch when real fresh water is exchanged (at 0degC here)
 
 C compute the net heat flux, incl. adv. by water, entering ocean+ice
 C ===================================================================
-        DO J=1,sNy
-         DO I=1,sNx
+        DO j=1,sNy
+         DO i=1,sNx
 Cgf 1) SIatmQnt (analogous to qnet; excl. adv. by water exch.)
 CML If I consider the atmosphere above the ice, the surface flux
 CML which is relevant for the air temperature dT/dt Eq
@@ -2299,24 +2299,24 @@ CML according to wave-length) fluxes but not for "latent heat flux",
 CML since it does not contribute to heating the air.
 CML So this diagnostic is only good for heat budget calculations within
 CML the ice-ocean system.
-           SIatmQnt(I,J,bi,bj) =
-     &            HEFFM(I,J,bi,bj)*convertHI2Q*(
-     &            a_QSWbyATM_cover(I,J) +
-     &            a_QbyATM_cover(I,J) + a_QbyATM_open(I,J) )
+           SIatmQnt(i,j,bi,bj) =
+     &            HEFFM(i,j,bi,bj)*convertHI2Q*(
+     &            a_QSWbyATM_cover(i,j) +
+     &            a_QbyATM_cover(i,j) + a_QbyATM_open(i,j) )
 Cgf 2) SItflux (analogous to tflux; includes advection by water
 C             exchanged between atmosphere and ocean+ice)
 C solid water going to atm, in precip units
-           tmpscal1 = rhoConstFresh*HEFFM(I,J,bi,bj)
-     &       * convertHI2PRECIP * ( - d_HSNWbyRAIN(I,J)*SNOW2ICE
-     &       + a_FWbySublim(I,J) - r_FWbySublim(I,J) )
+           tmpscal1 = rhoConstFresh*HEFFM(i,j,bi,bj)
+     &       * convertHI2PRECIP * ( - d_HSNWbyRAIN(i,j)*SNOW2ICE
+     &       + a_FWbySublim(i,j) - r_FWbySublim(i,j) )
 C liquid water going to atm, in precip units
-           tmpscal2=rhoConstFresh*HEFFM(I,J,bi,bj)*
-     &       ( ( EVAP(I,J,bi,bj)-PRECIP(I,J,bi,bj) )
-     &         * ( ONE - AREApreTH(I,J) )
+           tmpscal2=rhoConstFresh*HEFFM(i,j,bi,bj)*
+     &       ( ( EVAP(i,j,bi,bj)-PRECIP(i,j,bi,bj) )
+     &         * ( ONE - AREApreTH(i,j) )
 #ifdef ALLOW_RUNOFF
-     &         - RUNOFF(I,J,bi,bj)
+     &         - RUNOFF(i,j,bi,bj)
 #endif /* ALLOW_RUNOFF */
-     &         + ( d_HFRWbyRAIN(I,J) + r_FWbySublim(I,J) )
+     &         + ( d_HFRWbyRAIN(i,j) + r_FWbySublim(i,j) )
      &         *convertHI2PRECIP )
 C In real fresh water flux + nonlinFS, we factor in the advected specific
 C energy (referenced to 0 for 0deC liquid water). In virtual salt flux or
@@ -2330,14 +2330,14 @@ C linFS, rain/evap get a special treatment (see external_forcing_surf.F).
            ELSEIF ( (temp_EvPrRn.EQ.UNSET_RL).AND.
      &          useRealFreshWaterFlux.AND.(nonlinFreeSurf.NE.0) ) THEN
              tmpscal2= - tmpscal2*
-     &        ( ZERO + HeatCapacity_Cp * theta(I,J,kSurface,bi,bj) )
+     &        ( ZERO + HeatCapacity_Cp * theta(i,j,kSurface,bi,bj) )
            ELSEIF ( (temp_EvPrRn.NE.UNSET_RL) ) THEN
              tmpscal2= - tmpscal2*HeatCapacity_Cp*
-     &        ( temp_EvPrRn - theta(I,J,kSurface,bi,bj) )
+     &        ( temp_EvPrRn - theta(i,j,kSurface,bi,bj) )
            ELSEIF ( (temp_EvPrRn.EQ.UNSET_RL) ) THEN
              tmpscal2= ZERO
            ENDIF
-           SItflux(I,J,bi,bj)= SIatmQnt(I,J,bi,bj)-tmpscal1-tmpscal2
+           SItflux(i,j,bi,bj)= SIatmQnt(i,j,bi,bj)-tmpscal1-tmpscal2
          ENDDO
         ENDDO
 
@@ -2345,43 +2345,43 @@ C compute net fresh water flux leaving/entering
 C the ocean, accounting for fresh/salt water stocks.
 C ==================================================
 
-        DO J=1,sNy
-         DO I=1,sNx
-          tmpscal1= d_HSNWbyATMonSNW(I,J)*SNOW2ICE
-     &             +d_HFRWbyRAIN(I,J)
-     &             +d_HSNWbyOCNonSNW(I,J)*SNOW2ICE
-     &             +d_HEFFbyOCNonICE(I,J)
-     &             +d_HEFFbyATMonOCN(I,J)
-     &             +d_HEFFbyNEG(I,J,bi,bj)
+        DO j=1,sNy
+         DO i=1,sNx
+          tmpscal1= d_HSNWbyATMonSNW(i,j)*SNOW2ICE
+     &             +d_HFRWbyRAIN(i,j)
+     &             +d_HSNWbyOCNonSNW(i,j)*SNOW2ICE
+     &             +d_HEFFbyOCNonICE(i,j)
+     &             +d_HEFFbyATMonOCN(i,j)
+     &             +d_HEFFbyNEG(i,j,bi,bj)
 #ifdef EXF_SEAICE_FRACTION
-     &             +d_HEFFbyRLX(I,J,bi,bj)
+     &             +d_HEFFbyRLX(i,j,bi,bj)
 #endif
-     &             +d_HSNWbyNEG(I,J,bi,bj)*SNOW2ICE
+     &             +d_HSNWbyNEG(i,j,bi,bj)*SNOW2ICE
 C     If r_FWbySublim>0, then it is evaporated from ocean.
-     &             +r_FWbySublim(I,J)
-          EmPmR(I,J,bi,bj)  = HEFFM(I,J,bi,bj)*(
-     &         ( EVAP(I,J,bi,bj)-PRECIP(I,J,bi,bj) )
-     &         * ( ONE - AREApreTH(I,J) )
+     &             +r_FWbySublim(i,j)
+          EmPmR(i,j,bi,bj)  = HEFFM(i,j,bi,bj)*(
+     &         ( EVAP(i,j,bi,bj)-PRECIP(i,j,bi,bj) )
+     &         * ( ONE - AREApreTH(i,j) )
 #ifdef ALLOW_RUNOFF
-     &         - RUNOFF(I,J,bi,bj)
+     &         - RUNOFF(i,j,bi,bj)
 #endif /* ALLOW_RUNOFF */
      &         + tmpscal1*convertHI2PRECIP
      &         )*rhoConstFresh
 #ifdef SEAICE_ITD
 C     beware of the sign: fw2ObyRidge is snow mass moved into the ocean
 C     by ridging, so requires a minus sign
-     &         - fw2ObyRidge(I,J,bi,bj)*recip_deltaTtherm
-     &           * HEFFM(I,J,bi,bj)
+     &         - fw2ObyRidge(i,j,bi,bj)*recip_deltaTtherm
+     &           * HEFFM(i,j,bi,bj)
 #endif /* SEAICE_ITD */
 C and the flux leaving/entering the ocean+ice
-           SIatmFW(I,J,bi,bj) = HEFFM(I,J,bi,bj)*(
-     &          EVAP(I,J,bi,bj)*( ONE - AREApreTH(I,J) )
-     &          - PRECIP(I,J,bi,bj)
+           SIatmFW(i,j,bi,bj) = HEFFM(i,j,bi,bj)*(
+     &          EVAP(i,j,bi,bj)*( ONE - AREApreTH(i,j) )
+     &          - PRECIP(i,j,bi,bj)
 #ifdef ALLOW_RUNOFF
-     &          - RUNOFF(I,J,bi,bj)
+     &          - RUNOFF(i,j,bi,bj)
 #endif /* ALLOW_RUNOFF */
      &           )*rhoConstFresh
-     &     + a_FWbySublim(I,J) * SEAICE_rhoIce * recip_deltaTtherm
+     &     + a_FWbySublim(i,j) * SEAICE_rhoIce * recip_deltaTtherm
 
          ENDDO
         ENDDO
@@ -2403,15 +2403,15 @@ CADJ STORE hsnow(:,:,bi,bj) = comlev1_bibj,key=tkey,byte=isbyte
 #endif /* ALLOW_AUTODIFF_TAMC */
 
         IF ( useRealFreshWaterFlux ) THEN
-         DO J=1,sNy
-          DO I=1,sNx
+         DO j=1,sNy
+          DO i=1,sNx
 #ifdef SEAICE_CAP_ICELOAD
-           tmpscal1 = HEFF(I,J,bi,bj)*SEAICE_rhoIce
-     &              + HSNOW(I,J,bi,bj)*SEAICE_rhoSnow
+           tmpscal1 = HEFF(i,j,bi,bj)*SEAICE_rhoIce
+     &              + HSNOW(i,j,bi,bj)*SEAICE_rhoSnow
            tmpscal2 = MIN(tmpscal1,heffTooHeavy*rhoConst)
 #else
-           tmpscal2 = HEFF(I,J,bi,bj)*SEAICE_rhoIce
-     &              + HSNOW(I,J,bi,bj)*SEAICE_rhoSnow
+           tmpscal2 = HEFF(i,j,bi,bj)*SEAICE_rhoIce
+     &              + HSNOW(i,j,bi,bj)*SEAICE_rhoSnow
 #endif
            sIceLoad(i,j,bi,bj) = tmpscal2
           ENDDO
@@ -2438,7 +2438,7 @@ C to translate global mean FWF adjustements (see below) we may need :
          DO j=1,sNy
           DO i=1,sNx
            FWF2HFsiTile(bi,bj) = FWF2HFsiTile(bi,bj) +
-     &       HeatCapacity_Cp * theta(I,J,kSurface,bi,bj)
+     &       HeatCapacity_Cp * theta(i,j,kSurface,bi,bj)
      &       * rA(i,j,bi,bj) * maskInC(i,j,bi,bj)
           ENDDO
          ENDDO
@@ -2491,43 +2491,43 @@ C ===================================================================
          CALL DIAGNOSTICS_SCALE_FILL(r_QbyATM_cover,
      &      convertHI2Q,1, 'SIqneti ',0,1,3,bi,bj,myThid)
 C three that actually need intermediate storage
-         DO J=1,sNy
-          DO I=1,sNx
-            DIAGarrayA(I,J) = HEFFM(I,J,bi,bj)
-     &        * d_HSNWbyRAIN(I,J)*SEAICE_rhoSnow*recip_deltaTtherm
-            DIAGarrayB(I,J) =  AREA(I,J,bi,bj)-AREApreTH(I,J)
+         DO j=1,sNy
+          DO i=1,sNx
+            DIAGarrayA(i,j) = HEFFM(i,j,bi,bj)
+     &        * d_HSNWbyRAIN(i,j)*SEAICE_rhoSnow*recip_deltaTtherm
+            DIAGarrayB(i,j) =  AREA(i,j,bi,bj)-AREApreTH(i,j)
           ENDDO
          ENDDO
          CALL DIAGNOSTICS_FILL(DIAGarrayA,
      &      'SIsnPrcp',0,1,3,bi,bj,myThid)
          CALL DIAGNOSTICS_SCALE_FILL(DIAGarrayB,
      &      tmpscal1,1,'SIdA    ',0,1,3,bi,bj,myThid)
-         DO J=1,sNy
-          DO I=1,sNx
-           DIAGarrayB(I,J) = HEFFM(I,J,bi,bj) *
-     &       a_FWbySublim(I,J) * SEAICE_rhoIce * recip_deltaTtherm
+         DO j=1,sNy
+          DO i=1,sNx
+           DIAGarrayB(i,j) = HEFFM(i,j,bi,bj) *
+     &       a_FWbySublim(i,j) * SEAICE_rhoIce * recip_deltaTtherm
           ENDDO
          ENDDO
          CALL DIAGNOSTICS_FILL(DIAGarrayB,
      &      'SIfwSubl',0,1,3,bi,bj,myThid)
 C
-         DO J=1,sNy
-          DO I=1,sNx
+         DO j=1,sNy
+          DO i=1,sNx
 C the actual Freshwater flux of sublimated ice, >0 decreases ice
-           DIAGarrayA(I,J) = HEFFM(I,J,bi,bj)
-     &       * (a_FWbySublim(I,J)-r_FWbySublim(I,J))
+           DIAGarrayA(i,j) = HEFFM(i,j,bi,bj)
+     &       * (a_FWbySublim(i,j)-r_FWbySublim(i,j))
      &       * SEAICE_rhoIce * recip_deltaTtherm
 C the residual Freshwater flux of sublimated ice
-           DIAGarrayC(I,J) = HEFFM(I,J,bi,bj)
-     &       * r_FWbySublim(I,J)
+           DIAGarrayC(i,j) = HEFFM(i,j,bi,bj)
+     &       * r_FWbySublim(i,j)
      &       * SEAICE_rhoIce * recip_deltaTtherm
 C the latent heat flux
-           tmpscal1= EVAP(I,J,bi,bj)*( ONE - AREApreTH(I,J) )
-     &             + r_FWbySublim(I,J)*convertHI2PRECIP
-           tmpscal2= ( a_FWbySublim(I,J)-r_FWbySublim(I,J) )
+           tmpscal1= EVAP(i,j,bi,bj)*( ONE - AREApreTH(i,j) )
+     &             + r_FWbySublim(i,j)*convertHI2PRECIP
+           tmpscal2= ( a_FWbySublim(i,j)-r_FWbySublim(i,j) )
      &             * convertHI2PRECIP
            tmpscal3= SEAICE_lhEvap+SEAICE_lhFusion
-           DIAGarrayB(I,J) = -HEFFM(I,J,bi,bj)*rhoConstFresh
+           DIAGarrayB(i,j) = -HEFFM(i,j,bi,bj)*rhoConstFresh
      &             * ( tmpscal1*SEAICE_lhEvap + tmpscal2*tmpscal3 )
           ENDDO
          ENDDO
@@ -2599,10 +2599,10 @@ C           adjust SItflux consistently
             ELSEIF ( (temp_EvPrRn.EQ.UNSET_RL).AND.
      &        useRealFreshWaterFlux.AND.(nonlinFreeSurf.NE.0) ) THEN
             tmpscal1=
-     &       ( ZERO + HeatCapacity_Cp * theta(I,J,kSurface,bi,bj) )
+     &       ( ZERO + HeatCapacity_Cp * theta(i,j,kSurface,bi,bj) )
             ELSEIF ( (temp_EvPrRn.NE.UNSET_RL) ) THEN
             tmpscal1=
-     &       HeatCapacity_Cp*(temp_EvPrRn - theta(I,J,kSurface,bi,bj))
+     &       HeatCapacity_Cp*(temp_EvPrRn - theta(i,j,kSurface,bi,bj))
             ELSE
             tmpscal1=ZERO
             ENDIF

--- a/pkg/seaice/seaice_lsr.F
+++ b/pkg/seaice/seaice_lsr.F
@@ -175,7 +175,7 @@ C
 C
       recip_deltaT = 1. _d 0 / SEAICE_deltaTdyn
 
-#ifdef ALLOW_AUTODIFF_TAMC
+#ifdef ALLOW_AUTODIFF
 cph break artificial dependencies
       DO bj=myByLo(myThid),myByHi(myThid)
        DO bi=myBxLo(myThid),myBxHi(myThid)

--- a/pkg/seaice/seaice_lsr.F
+++ b/pkg/seaice/seaice_lsr.F
@@ -934,7 +934,7 @@ C--   Compute residual norm and print
      &            - (uIce(i,j,bi,bj)+uIce(i+1,j,bi,bj)) )**2
      &          + ( (vIceNm1(i,j,bi,bj)+vIceNm1(i,j+1,bi,bj))
      &            - (vIce(i,j,bi,bj)+vIce(i,j+1,bi,bj)) )**2 )
-           IF ( area(i,j,bi,bj) .gt. 0.5 _d 0 ) THEN
+           IF ( area(i,j,bi,bj) .GT. 0.5 _d 0 ) THEN
             EKnorm = EKnorm + 0.5 _d 0 * heff(i,j,bi,bj) *
      &           ( ( (uIce(i,j,bi,bj)+uIce(i+1,j,bi,bj)) )**2
      &           + ( (vIce(i,j,bi,bj)+vIce(i,j+1,bi,bj)) )**2 )
@@ -947,11 +947,11 @@ C--   Compute residual norm and print
        _GLOBAL_SUM_RL( resnorm, myThid )
        _GLOBAL_SUM_RL( EKnorm, myThid )
        _GLOBAL_SUM_RL( counter, myThid )
-       IF ( counter .gt. 0. _d 0 ) EKnorm = EKnorm/counter
+       IF ( counter .GT. 0. _d 0 ) EKnorm = EKnorm/counter
        _BEGIN_MASTER( myThid )
        WRITE(standardMessageUnit,'(A,I7,1X,2E22.14)')
      &      'S/R SEAICE_LSR: IPSEUDO, RESNORM, EKNORM = ',
-     &      ipass, sqrt(resnorm), EKnorm
+     &      ipass, SQRT(resnorm), EKnorm
        _END_MASTER( myThid )
       ENDIF
 #endif /* SEAICE_ALLOW_CHECK_LSR_CONVERGENCE */
@@ -1348,7 +1348,7 @@ C     normalizing
           BU(i,j,bi,bj)    = BU(i,j,bi,bj)  * recip_rAw(i,j,bi,bj)
      &         + seaiceMaskU(i,j,bi,bj) *
      &         ( bdfAlphaOverDt*seaiceMassU(i,j,bi,bj)
-     &         + 0.5 _d 0 * ( dragSym(i,  J,bi,bj)
+     &         + 0.5 _d 0 * ( dragSym(i,  j,bi,bj)
      &                      + dragSym(i-1,j,bi,bj) )*areaW(i,j)
      &         )
           uRt1(i,j,bi,bj) = uRt1(i,j,bi,bj) * recip_rAw(i,j,bi,bj)
@@ -1816,12 +1816,12 @@ CADJ loop = sequential
       ENDDO
 CADJ loop = sequential
       DO i=iMin,iMax-1
-       iM=sNx-I
+       iM=sNx-i
        DO j=jMinLoc,jMax,jStep
 #else
 CADJ loop = sequential
        DO i=iMin,iMax-1
-        iM=sNx-I
+        iM=sNx-i
 #endif /* SEAICE_VECTORIZE_LSR */
         URT(iM,j)=URT(iM,j)-CUU(iM,j)*URT(iM+1,j)
        ENDDO

--- a/pkg/seaice/seaice_model.F
+++ b/pkg/seaice/seaice_model.F
@@ -124,7 +124,7 @@ C-    Fill-in EXF wind-stess diags, weighted by open-ocean fraction
       ENDIF
 #endif /* ALLOW_EXF */
 
-#ifdef ALLOW_AUTODIFF_TAMC
+#ifdef ALLOW_AUTODIFF
       DO bj=myByLo(myThid),myByHi(myThid)
        DO bi=myBxLo(myThid),myBxHi(myThid)
         DO j=1-OLy,sNy+OLy
@@ -140,6 +140,8 @@ C-    Fill-in EXF wind-stess diags, weighted by open-ocean fraction
         ENDDO
        ENDDO
       ENDDO
+#endif /* ALLOW_AUTODIFF */
+#ifdef ALLOW_AUTODIFF_TAMC
 CADJ STORE heff  = comlev1, key=ikey_dynamics, kind=isbyte
 CADJ STORE area  = comlev1, key=ikey_dynamics, kind=isbyte
 CADJ STORE hsnow = comlev1, key=ikey_dynamics, kind=isbyte

--- a/pkg/seaice/seaice_model.F
+++ b/pkg/seaice/seaice_model.F
@@ -1,4 +1,7 @@
 #include "SEAICE_OPTIONS.h"
+#ifdef ALLOW_EXF
+# include "EXF_OPTIONS.h"
+#endif
 #ifdef ALLOW_AUTODIFF
 # include "AUTODIFF_OPTIONS.h"
 #endif
@@ -37,7 +40,6 @@ C !USES: ===============================================================
 #include "SEAICE.h"
 #include "SEAICE_TRACER.h"
 #ifdef ALLOW_EXF
-# include "EXF_OPTIONS.h"
 # include "EXF_FIELDS.h"
 #endif
 #ifdef ALLOW_AUTODIFF_TAMC

--- a/pkg/seaice/seaice_reg_ridge.F
+++ b/pkg/seaice/seaice_reg_ridge.F
@@ -91,16 +91,16 @@ C
         tkey = bi + (bj-1)*nSx + (ikey_dynamics-1)*nSx*nSy
 #endif /* ALLOW_AUTODIFF_TAMC */
 
-        DO J=1-OLy,sNy+OLy
-         DO I=1-OLx,sNx+OLx
-          d_HEFFbyNEG(I,J,bi,bj)    = 0.0 _d 0
-          d_HSNWbyNEG(I,J,bi,bj)    = 0.0 _d 0
+        DO j=1-OLy,sNy+OLy
+         DO i=1-OLx,sNx+OLx
+          d_HEFFbyNEG(i,j,bi,bj)    = 0.0 _d 0
+          d_HSNWbyNEG(i,j,bi,bj)    = 0.0 _d 0
 #ifdef EXF_SEAICE_FRACTION
-          d_AREAbyRLX(I,J,bi,bj)    = 0.0 _d 0
-          d_HEFFbyRLX(I,J,bi,bj)    = 0.0 _d 0
+          d_AREAbyRLX(i,j,bi,bj)    = 0.0 _d 0
+          d_HEFFbyRLX(i,j,bi,bj)    = 0.0 _d 0
 #endif /* EXF_SEAICE_FRACTION */
 #ifdef SEAICE_VARIABLE_SALINITY
-          saltFluxAdjust(I,J,bi,bj) = 0.0 _d 0
+          saltFluxAdjust(i,j,bi,bj) = 0.0 _d 0
 #endif /* SEAICE_VARIABLE_SALINITY */
          ENDDO
         ENDDO
@@ -119,26 +119,26 @@ CADJ STORE heff(:,:,bi,bj) = comlev1_bibj, key = tkey,byte=isbyte
 CADJ STORE area(:,:,bi,bj) = comlev1_bibj, key = tkey,byte=isbyte
 C--   (0) relax sea ice concentration towards observation
         IF ( SEAICE_tauAreaObsRelax .GT. zeroRL ) THEN
-         DO J=1,sNy
-          DO I=1,sNx
-           IF ( exf_iceFraction(I,J,bi,bj).GT.AREA(I,J,bi,bj) ) THEN
+         DO j=1,sNy
+          DO i=1,sNx
+           IF ( exf_iceFraction(i,j,bi,bj).GT.AREA(i,j,bi,bj) ) THEN
             d_AREAbyRLX(i,j,bi,bj) =
      &       SEAICE_deltaTtherm/SEAICE_tauAreaObsRelax
-     &       * (exf_iceFraction(I,J,bi,bj) - AREA(I,J,bi,bj))
+     &       * (exf_iceFraction(i,j,bi,bj) - AREA(i,j,bi,bj))
            ENDIF
-           IF ( exf_iceFraction(I,J,bi,bj).GT.zeroRS .AND.
-     &          AREA(I,J,bi,bj).EQ.0. _d 0) THEN
+           IF ( exf_iceFraction(i,j,bi,bj).GT.zeroRS .AND.
+     &          AREA(i,j,bi,bj).EQ.0. _d 0) THEN
 C           d_HEFFbyRLX(i,j,bi,bj) = 1. _d 1 * siEps * d_AREAbyRLX(i,j,bi,bj)
             d_HEFFbyRLX(i,j,bi,bj) = 1. _d 1 * siEps
            ENDIF
 #ifdef SEAICE_ITD
-           AREAITD(I,J,1,bi,bj) = AREAITD(I,J,1,bi,bj)
+           AREAITD(i,j,1,bi,bj) = AREAITD(i,j,1,bi,bj)
      &                          +  d_AREAbyRLX(i,j,bi,bj)
-           HEFFITD(I,J,1,bi,bj) = HEFFITD(I,J,1,bi,bj)
+           HEFFITD(i,j,1,bi,bj) = HEFFITD(i,j,1,bi,bj)
      &                          +  d_HEFFbyRLX(i,j,bi,bj)
 #endif /* SEAICE_ITD */
-           AREA(I,J,bi,bj) = AREA(I,J,bi,bj) +  d_AREAbyRLX(i,j,bi,bj)
-           HEFF(I,J,bi,bj) = HEFF(I,J,bi,bj) +  d_HEFFbyRLX(i,j,bi,bj)
+           AREA(i,j,bi,bj) = AREA(i,j,bi,bj) +  d_AREAbyRLX(i,j,bi,bj)
+           HEFF(i,j,bi,bj) = HEFF(i,j,bi,bj) +  d_HEFFbyRLX(i,j,bi,bj)
           ENDDO
          ENDDO
         ENDIF
@@ -148,17 +148,17 @@ C--   (1) treat the case of negative values:
 
 #ifdef SEAICE_ITD
         DO IT=1,SEAICE_multDim
-         DO J=1,sNy
-          DO I=1,sNx
+         DO j=1,sNy
+          DO i=1,sNx
            tmpscal1=0. _d 0
            tmpscal2=0. _d 0
-           tmpscal1=MAX(-HEFFITD(I,J,IT,bi,bj),0. _d 0)
-           HEFFITD(I,J,IT,bi,bj)=HEFFITD(I,J,IT,bi,bj)+tmpscal1
-           d_HEFFbyNEG(I,J,bi,bj)=d_HEFFbyNEG(I,J,bi,bj)+tmpscal1
-           tmpscal2=MAX(-HSNOWITD(I,J,IT,bi,bj),0. _d 0)
-           HSNOWITD(I,J,IT,bi,bj)=HSNOWITD(I,J,IT,bi,bj)+tmpscal2
-           d_HSNWbyNEG(I,J,bi,bj)=d_HSNWbyNEG(I,J,bi,bj)+tmpscal2
-           AREAITD(I,J,IT,bi,bj)=MAX(AREAITD(I,J,IT,bi,bj),0. _d 0)
+           tmpscal1=MAX(-HEFFITD(i,j,IT,bi,bj),0. _d 0)
+           HEFFITD(i,j,IT,bi,bj)=HEFFITD(i,j,IT,bi,bj)+tmpscal1
+           d_HEFFbyNEG(i,j,bi,bj)=d_HEFFbyNEG(i,j,bi,bj)+tmpscal1
+           tmpscal2=MAX(-HSNOWITD(i,j,IT,bi,bj),0. _d 0)
+           HSNOWITD(i,j,IT,bi,bj)=HSNOWITD(i,j,IT,bi,bj)+tmpscal2
+           d_HSNWbyNEG(i,j,bi,bj)=d_HSNWbyNEG(i,j,bi,bj)+tmpscal2
+           AREAITD(i,j,IT,bi,bj)=MAX(AREAITD(i,j,IT,bi,bj),0. _d 0)
 C     AREA, HEFF, and HSNOW will be updated at end of PART 1
 C     by calling SEAICE_ITD_SUM
           ENDDO
@@ -173,13 +173,13 @@ CADJ STORE heff(:,:,bi,bj)  = comlev1_bibj, key = tkey,byte=isbyte
 CADJ STORE hsnow(:,:,bi,bj) = comlev1_bibj, key = tkey,byte=isbyte
 CADJ STORE area(:,:,bi,bj)  = comlev1_bibj, key = tkey,byte=isbyte
 #endif /* ALLOW_AUTODIFF_TAMC */
-        DO J=1,sNy
-         DO I=1,sNx
-          d_HEFFbyNEG(I,J,bi,bj)=MAX(-HEFF(I,J,bi,bj),0. _d 0)
-          HEFF(I,J,bi,bj)=HEFF(I,J,bi,bj)+d_HEFFbyNEG(I,J,bi,bj)
-          d_HSNWbyNEG(I,J,bi,bj)=MAX(-HSNOW(I,J,bi,bj),0. _d 0)
-          HSNOW(I,J,bi,bj)=HSNOW(I,J,bi,bj)+d_HSNWbyNEG(I,J,bi,bj)
-          AREA(I,J,bi,bj)=MAX(AREA(I,J,bi,bj),0. _d 0)
+        DO j=1,sNy
+         DO i=1,sNx
+          d_HEFFbyNEG(i,j,bi,bj)=MAX(-HEFF(i,j,bi,bj),0. _d 0)
+          HEFF(i,j,bi,bj)=HEFF(i,j,bi,bj)+d_HEFFbyNEG(i,j,bi,bj)
+          d_HSNWbyNEG(i,j,bi,bj)=MAX(-HSNOW(i,j,bi,bj),0. _d 0)
+          HSNOW(i,j,bi,bj)=HSNOW(i,j,bi,bj)+d_HSNWbyNEG(i,j,bi,bj)
+          AREA(i,j,bi,bj)=MAX(AREA(i,j,bi,bj),0. _d 0)
          ENDDO
         ENDDO
 #endif /* SEAICE_ITD */
@@ -193,11 +193,11 @@ C     We avoid applying the correction to each class because that leads to
 C     funny structures in the net heat and freshwater flux into the ocean.
 C     Let us keep our fingers crossed, that the model will be benign!
         DO IT=1,SEAICE_multDim
-         DO J=1,sNy
-          DO I=1,sNx
-           IF (HEFF(I,J,bi,bj).LE.siEps) THEN
-            HEFFITD(I,J,IT,bi,bj) = 0. _d 0
-            HSNOWITD(I,J,IT,bi,bj) = 0. _d 0
+         DO j=1,sNy
+          DO i=1,sNx
+           IF (HEFF(i,j,bi,bj).LE.siEps) THEN
+            HEFFITD(i,j,IT,bi,bj) = 0. _d 0
+            HSNOWITD(i,j,IT,bi,bj) = 0. _d 0
            ENDIF
           ENDDO
          ENDDO
@@ -212,21 +212,21 @@ C     probably be removed again, once this bug is fixed (but it does not
 C     hurt, either).
 CADJ INCOMPLETE TICES
 #endif /* ALLOW_AUTODIFF_TAMC */
-        DO J=1,sNy
-         DO I=1,sNx
+        DO j=1,sNy
+         DO i=1,sNx
           tmpscal1=0. _d 0
           tmpscal2=0. _d 0
-          IF (HEFF(I,J,bi,bj).LE.siEps) THEN
-           tmpscal1=-HEFF(I,J,bi,bj)
-           tmpscal2=-HSNOW(I,J,bi,bj)
+          IF (HEFF(i,j,bi,bj).LE.siEps) THEN
+           tmpscal1=-HEFF(i,j,bi,bj)
+           tmpscal2=-HSNOW(i,j,bi,bj)
            DO IT=1,SEAICE_multDim
-            TICES(I,J,IT,bi,bj)=celsius2K
+            TICES(i,j,IT,bi,bj)=celsius2K
            ENDDO
           ENDIF
-          HEFF(I,J,bi,bj)=HEFF(I,J,bi,bj)+tmpscal1
-          HSNOW(I,J,bi,bj)=HSNOW(I,J,bi,bj)+tmpscal2
-          d_HEFFbyNEG(I,J,bi,bj)=d_HEFFbyNEG(I,J,bi,bj)+tmpscal1
-          d_HSNWbyNEG(I,J,bi,bj)=d_HSNWbyNEG(I,J,bi,bj)+tmpscal2
+          HEFF(i,j,bi,bj)=HEFF(i,j,bi,bj)+tmpscal1
+          HSNOW(i,j,bi,bj)=HSNOW(i,j,bi,bj)+tmpscal2
+          d_HEFFbyNEG(i,j,bi,bj)=d_HEFFbyNEG(i,j,bi,bj)+tmpscal1
+          d_HSNWbyNEG(i,j,bi,bj)=d_HSNWbyNEG(i,j,bi,bj)+tmpscal2
          ENDDO
         ENDDO
 
@@ -234,11 +234,11 @@ C--   (3) treat the case of area but no ice/snow:
 
 #ifdef SEAICE_ITD
         DO IT=1,SEAICE_multDim
-         DO J=1,sNy
-          DO I=1,sNx
-           IF ( (HEFFITD(I,J,IT,bi,bj) .EQ.0. _d 0).AND.
-     &          (HSNOWITD(I,J,IT,bi,bj).EQ.0. _d 0))
-     &          AREAITD(I,J,IT,bi,bj)=0. _d 0
+         DO j=1,sNy
+          DO i=1,sNx
+           IF ( (HEFFITD(i,j,IT,bi,bj) .EQ.0. _d 0).AND.
+     &          (HSNOWITD(i,j,IT,bi,bj).EQ.0. _d 0))
+     &          AREAITD(i,j,IT,bi,bj)=0. _d 0
           ENDDO
          ENDDO
         ENDDO
@@ -247,10 +247,10 @@ C--   (3) treat the case of area but no ice/snow:
 CADJ STORE heff(:,:,bi,bj)  = comlev1_bibj, key = tkey,byte=isbyte
 CADJ STORE hsnow(:,:,bi,bj) = comlev1_bibj, key = tkey,byte=isbyte
 #endif /* ALLOW_AUTODIFF_TAMC */
-         DO J=1,sNy
-          DO I=1,sNx
+         DO j=1,sNy
+          DO i=1,sNx
            IF ((HEFF(i,j,bi,bj).EQ.0. _d 0).AND.
-     &        (HSNOW(i,j,bi,bj).EQ.0. _d 0)) AREA(I,J,bi,bj)=0. _d 0
+     &        (HSNOW(i,j,bi,bj).EQ.0. _d 0)) AREA(i,j,bi,bj)=0. _d 0
          ENDDO
         ENDDO
 #endif /* SEAICE_ITD */
@@ -261,15 +261,15 @@ C--   (4) treat the case of very small area:
 #ifdef SEAICE_ITD
         recip_nitd = 1. _d 0 / float(SEAICE_multDim)
         DO IT=1,SEAICE_multDim
-         DO J=1,sNy
-          DO I=1,sNx
-           IF ((HEFFITD(I,J,IT,bi,bj).GT.0).OR.
-     &          (HSNOWITD(I,J,IT,bi,bj).GT.0)) THEN
+         DO j=1,sNy
+          DO i=1,sNx
+           IF ((HEFFITD(i,j,IT,bi,bj).GT.0).OR.
+     &          (HSNOWITD(i,j,IT,bi,bj).GT.0)) THEN
 C     SEAICE_area_floor*SEAICE_multDim cannot be allowed to exceed 1
 C     hence use SEAICE_area_floor devided by SEAICE_multDim
 C     (or install a warning in e.g. seaice_readparms.F)
-            AREAITD(I,J,IT,bi,bj)=
-     &        MAX(AREAITD(I,J,IT,bi,bj),SEAICE_area_floor*recip_nitd)
+            AREAITD(i,j,IT,bi,bj)=
+     &        MAX(AREAITD(i,j,IT,bi,bj),SEAICE_area_floor*recip_nitd)
           ENDIF
          ENDDO
         ENDDO
@@ -278,10 +278,10 @@ C     (or install a warning in e.g. seaice_readparms.F)
 #ifdef ALLOW_AUTODIFF_TAMC
 CADJ STORE area(:,:,bi,bj)  = comlev1_bibj, key = tkey,byte=isbyte
 #endif /* ALLOW_AUTODIFF_TAMC */
-       DO J=1,sNy
-        DO I=1,sNx
+       DO j=1,sNy
+        DO i=1,sNx
          IF ((HEFF(i,j,bi,bj).GT.0).OR.(HSNOW(i,j,bi,bj).GT.0)) THEN
-          AREA(I,J,bi,bj)=MAX(AREA(I,J,bi,bj),SEAICE_area_floor)
+          AREA(i,j,bi,bj)=MAX(AREA(i,j,bi,bj),SEAICE_area_floor)
          ENDIF
         ENDDO
        ENDDO
@@ -294,13 +294,13 @@ C     (5) treat sea ice salinity pathological cases
 CADJ STORE hsalt(:,:,bi,bj) = comlev1_bibj, key = tkey,byte=isbyte
 CADJ STORE heff(:,:,bi,bj)  = comlev1_bibj, key = tkey,byte=isbyte
 #endif /* ALLOW_AUTODIFF_TAMC */
-        DO J=1,sNy
-         DO I=1,sNx
-          IF ( (HSALT(I,J,bi,bj) .LT. 0.0).OR.
-     &         (HEFF(I,J,bi,bj) .EQ. 0.0)  ) THEN
-             saltFluxAdjust(I,J,bi,bj) = - HEFFM(I,J,bi,bj) *
-     &            HSALT(I,J,bi,bj) * recip_deltaTtherm
-             HSALT(I,J,bi,bj) = 0.0 _d 0
+        DO j=1,sNy
+         DO i=1,sNx
+          IF ( (HSALT(i,j,bi,bj) .LT. 0.0).OR.
+     &         (HEFF(i,j,bi,bj) .EQ. 0.0)  ) THEN
+             saltFluxAdjust(i,j,bi,bj) = - HEFFM(i,j,bi,bj) *
+     &            HSALT(i,j,bi,bj) * recip_deltaTtherm
+             HSALT(i,j,bi,bj) = 0.0 _d 0
           ENDIF
          ENDDO
         ENDDO
@@ -315,37 +315,37 @@ C     treat case of excessive ice cover, e.g., due to ridging:
 #ifdef SEAICE_ITD
 
 C     catch up with item (2) that involves category sums AREA and HEFF
-        DO J=1,sNy
-         DO I=1,sNx
+        DO j=1,sNy
+         DO i=1,sNx
           tmpscal1itd(i,j) = 0. _d 0
           tmpscal2itd(i,j) = 0. _d 0
           tmpscal3itd(i,j) = 0. _d 0
          ENDDO
         ENDDO
         DO IT=1,SEAICE_multDim
-         DO J=1,sNy
-          DO I=1,sNx
+         DO j=1,sNy
+          DO i=1,sNx
 C     TICES was changed above (item 2), now update TICE as ice volume
 C     weighted average of TICES
            tmpscal1itd(i,j)=tmpscal1itd(i,j)
-     &          +        TICES(I,J,IT,bi,bj) * HEFFITD(I,J,IT,bi,bj)
-           tmpscal2itd(i,j)=tmpscal2itd(i,j) + HEFFITD(I,J,IT,bi,bj)
+     &          +        TICES(i,j,IT,bi,bj) * HEFFITD(i,j,IT,bi,bj)
+           tmpscal2itd(i,j)=tmpscal2itd(i,j) + HEFFITD(i,j,IT,bi,bj)
 C     also compute total of AREAITD for diagnostics and SItrArea
-           tmpscal3itd(i,j)=tmpscal3itd(i,j) + AREAITD(I,J,IT,bi,bj)
+           tmpscal3itd(i,j)=tmpscal3itd(i,j) + AREAITD(i,j,IT,bi,bj)
           ENDDO
          ENDDO
         ENDDO
-        DO J=1,sNy
-         DO I=1,sNx
+        DO j=1,sNy
+         DO i=1,sNx
 C     save pre-ridging ice concentration for diagnostics:
 C     these lines are executed before "ridging" is applied to AREA
 C     hence we execute them here before SEAICE_ITD_REDIST is called
 C     although this means that AREA has not been completely regularized
 #ifdef ALLOW_DIAGNOSTICS
-          DIAGarrayA(I,J) = tmpscal3itd(i,j)
+          DIAGarrayA(i,j) = tmpscal3itd(i,j)
 #endif
 #ifdef ALLOW_SITRACER
-          SItrAREA(I,J,bi,bj,1)=tmpscal3itd(i,j)
+          SItrAREA(i,j,bi,bj,1)=tmpscal3itd(i,j)
 #endif
          ENDDO
         ENDDO
@@ -364,18 +364,18 @@ C     concentration AREA to match single category values
 #ifdef ALLOW_AUTODIFF_TAMC
 CADJ STORE area(:,:,bi,bj)  = comlev1_bibj, key = tkey,byte=isbyte
 #endif /* ALLOW_AUTODIFF_TAMC */
-        DO J=1,sNy
-         DO I=1,sNx
+        DO j=1,sNy
+         DO i=1,sNx
 C     save pre-ridging ice concentration for diagnostics
 #ifdef ALLOW_DIAGNOSTICS
-          DIAGarrayA(I,J) = AREA(I,J,bi,bj)
+          DIAGarrayA(i,j) = AREA(i,j,bi,bj)
 #endif /*  ALLOW_DIAGNOSTICS */
 #ifdef ALLOW_SITRACER
-          SItrAREA(I,J,bi,bj,1)=AREA(I,J,bi,bj)
+          SItrAREA(i,j,bi,bj,1)=AREA(i,j,bi,bj)
 #endif /*  ALLOW_SITRACER */
 C     this is the simple Hibler (1979)-type ridging (capping of
 C     concentrations > 1) for the non-ITD sea ice model
-          AREA(I,J,bi,bj)=MIN(AREA(I,J,bi,bj),SEAICE_area_max)
+          AREA(i,j,bi,bj)=MIN(AREA(i,j,bi,bj),SEAICE_area_max)
          ENDDO
         ENDDO
 

--- a/pkg/seaice/seaice_reg_ridge.F
+++ b/pkg/seaice/seaice_reg_ridge.F
@@ -109,7 +109,7 @@ C =====================================================================
 C ========== PART 1: treat pathological cases (post advdiff) ==========
 C =====================================================================
 
-#if (defined ALLOW_AUTODIFF_TAMC && defined SEAICE_MODIFY_GROWTH_ADJ)
+#if (defined ALLOW_AUTODIFF && defined SEAICE_MODIFY_GROWTH_ADJ)
 Cgf no dependency through pathological cases treatment
         IF ( SEAICEadjMODE.EQ.0 ) THEN
 #endif
@@ -381,7 +381,7 @@ C     concentrations > 1) for the non-ITD sea ice model
 
 #endif /* SEAICE_ITD */
 
-#if (defined ALLOW_AUTODIFF_TAMC && defined SEAICE_MODIFY_GROWTH_ADJ)
+#if (defined ALLOW_AUTODIFF && defined SEAICE_MODIFY_GROWTH_ADJ)
 C        end SEAICEadjMODE.EQ.0 statement:
         ENDIF
 #endif

--- a/verification/offline_exf_seaice/input/data
+++ b/verification/offline_exf_seaice/input/data
@@ -47,7 +47,6 @@
  &PARM03
  startTime=0.0,
 #endTime=432000.,
-#deltaT=1800.0,
 # Use half the original time step to test the option of stepping
 # the sea ice dynamics solver with a longer timestep.
  deltaT= 900.0,

--- a/verification/offline_exf_seaice/input/data
+++ b/verification/offline_exf_seaice/input/data
@@ -47,14 +47,17 @@
  &PARM03
  startTime=0.0,
 #endTime=432000.,
- deltaT=1800.0,
+#deltaT=1800.0,
+# Use half the original time step to test the option of stepping
+# the sea ice dynamics solver with a longer timestep.
+ deltaT= 900.0,
  abEps=0.1,
  forcing_In_AB = .FALSE.,
  pChkptFreq=3600000.,
  dumpFreq = 864000.,
  monitorFreq=86400.,
  monitorSelect=2,
- nTimeSteps=12,
+ nTimeSteps=24,
  monitorFreq=21600.,
  &
 

--- a/verification/offline_exf_seaice/input/data.ice
+++ b/verification/offline_exf_seaice/input/data.ice
@@ -27,7 +27,7 @@
  thSIceFract_InitFile='const100.bin',
  thSIceThick_InitFile='const+20.bin',
 #thSIce_diagFreq=2592000.,
- thSIce_monFreq =21600.,
+#thSIce_monFreq =21600.,
  thSIce_monFreq =1800.,
  &
 

--- a/verification/offline_exf_seaice/input/data.seaice
+++ b/verification/offline_exf_seaice/input/data.seaice
@@ -9,6 +9,7 @@
  LSR_mixIniGuess    = 1,
  SEAICE_no_Slip     = .FALSE.,
  SEAICEwriteState   = .TRUE.,
+ SEAICE_deltaTdyn   = 1800.,
  SEAICE_monFreq = 21600.,
  SEAICE_monFreq = 1800.,
  &

--- a/verification/offline_exf_seaice/results/output.txt
+++ b/verification/offline_exf_seaice/results/output.txt
@@ -5,21 +5,23 @@
 (PID.TID 0000.0001) // ======================================================
 (PID.TID 0000.0001) // execution environment starting up...
 (PID.TID 0000.0001) 
-(PID.TID 0000.0001) // MITgcmUV version:  checkpoint67t
+(PID.TID 0000.0001) // MITgcmUV version:  checkpoint68o
 (PID.TID 0000.0001) // Build user:        jm_c
 (PID.TID 0000.0001) // Build host:        villon
-(PID.TID 0000.0001) // Build date:        Fri Dec 11 09:58:42 EST 2020
+(PID.TID 0000.0001) // Build date:        Thu May  4 14:32:22 EDT 2023
 (PID.TID 0000.0001) 
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // Execution Environment parameter file "eedata"
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) ># Example "eedata" file
 (PID.TID 0000.0001) ># Lines beginning "#" are comments
-(PID.TID 0000.0001) ># nTx - No. threads per process in X
-(PID.TID 0000.0001) ># nTy - No. threads per process in Y
+(PID.TID 0000.0001) >#  nTx      :: No. threads per process in X
+(PID.TID 0000.0001) >#  nTy      :: No. threads per process in Y
+(PID.TID 0000.0001) ># debugMode :: print debug msg (sequence of S/R calls)
 (PID.TID 0000.0001) > &EEPARMS
 (PID.TID 0000.0001) > nTx=1,
 (PID.TID 0000.0001) > nTy=1,
+(PID.TID 0000.0001) >#debugMode=.TRUE.,
 (PID.TID 0000.0001) > /
 (PID.TID 0000.0001) ># Note: Some systems use & as the namelist terminator (as shown here).
 (PID.TID 0000.0001) >#       Other systems use a / character.
@@ -155,14 +157,16 @@
 (PID.TID 0000.0001) > &PARM03
 (PID.TID 0000.0001) > startTime=0.0,
 (PID.TID 0000.0001) >#endTime=432000.,
-(PID.TID 0000.0001) > deltaT=1800.0,
+(PID.TID 0000.0001) ># Use half the original time step to test the option of stepping
+(PID.TID 0000.0001) ># the sea ice dynamics solver with a longer timestep.
+(PID.TID 0000.0001) > deltaT= 900.0,
 (PID.TID 0000.0001) > abEps=0.1,
 (PID.TID 0000.0001) > forcing_In_AB = .FALSE.,
 (PID.TID 0000.0001) > pChkptFreq=3600000.,
 (PID.TID 0000.0001) > dumpFreq = 864000.,
 (PID.TID 0000.0001) > monitorFreq=86400.,
 (PID.TID 0000.0001) > monitorSelect=2,
-(PID.TID 0000.0001) > nTimeSteps=12,
+(PID.TID 0000.0001) > nTimeSteps=24,
 (PID.TID 0000.0001) > monitorFreq=21600.,
 (PID.TID 0000.0001) > /
 (PID.TID 0000.0001) >
@@ -318,6 +322,7 @@
 (PID.TID 0000.0001) > LSR_mixIniGuess    = 1,
 (PID.TID 0000.0001) > SEAICE_no_Slip     = .FALSE.,
 (PID.TID 0000.0001) > SEAICEwriteState   = .TRUE.,
+(PID.TID 0000.0001) > SEAICE_deltaTdyn   = 1800.,
 (PID.TID 0000.0001) > SEAICE_monFreq = 21600.,
 (PID.TID 0000.0001) > SEAICE_monFreq = 1800.,
 (PID.TID 0000.0001) > /
@@ -360,7 +365,7 @@
 (PID.TID 0000.0001) > thSIceFract_InitFile='const100.bin',
 (PID.TID 0000.0001) > thSIceThick_InitFile='const+20.bin',
 (PID.TID 0000.0001) >#thSIce_diagFreq=2592000.,
-(PID.TID 0000.0001) > thSIce_monFreq =21600.,
+(PID.TID 0000.0001) >#thSIce_monFreq =21600.,
 (PID.TID 0000.0001) > thSIce_monFreq =1800.,
 (PID.TID 0000.0001) > /
 (PID.TID 0000.0001) >
@@ -414,8 +419,8 @@
  ThSI: thSIceAdvScheme   =        77
  ThSI: thSIceBalanceAtmFW=         0
  ThSI: thSIce_diffK      =  0.0000000000000E+00
- ThSI: thSIce_deltaT     =  1.8000000000000E+03
- ThSI: ocean_deltaT      =  1.8000000000000E+03
+ ThSI: thSIce_deltaT     =  9.0000000000000E+02
+ ThSI: ocean_deltaT      =  9.0000000000000E+02
  ThSI: stepFwd_oceMxL    =         F
  ThSI: tauRelax_MxL      =  0.0000000000000E+00
  ThSI: tauRelax_MxL_salt =  0.0000000000000E+00
@@ -787,6 +792,9 @@
 (PID.TID 0000.0001) exf_monFreq  = /* EXF monitor frequency [ s ] */
 (PID.TID 0000.0001)                 8.640000000000000E+07
 (PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) exf_adjMonSelect = /* select group of exf AD-variables to monitor */
+(PID.TID 0000.0001)                       1
+(PID.TID 0000.0001)     ;
 (PID.TID 0000.0001) repeatPeriod = /* period for cycling forcing dataset [ s ] */
 (PID.TID 0000.0001)                 0.000000000000000E+00
 (PID.TID 0000.0001)     ;
@@ -847,22 +855,31 @@
 (PID.TID 0000.0001) sstExtrapol = /* extrapolation coeff from lev. 1 & 2 to surf [-] */
 (PID.TID 0000.0001)                 0.000000000000000E+00
 (PID.TID 0000.0001)     ;
-(PID.TID 0000.0001) cDrag_1 = /* coef used in drag calculation [?] */
+(PID.TID 0000.0001) cDrag_1 = /* coef used in drag calculation [m/s] */
 (PID.TID 0000.0001)                 2.700000000000000E-03
 (PID.TID 0000.0001)     ;
-(PID.TID 0000.0001) cDrag_2 = /* coef used in drag calculation [?] */
+(PID.TID 0000.0001) cDrag_2 = /* coef used in drag calculation [-] */
 (PID.TID 0000.0001)                 1.420000000000000E-04
 (PID.TID 0000.0001)     ;
-(PID.TID 0000.0001) cDrag_3 = /* coef used in drag calculation [?] */
+(PID.TID 0000.0001) cDrag_3 = /* coef used in drag calculation [s/m] */
 (PID.TID 0000.0001)                 7.640000000000000E-05
 (PID.TID 0000.0001)     ;
-(PID.TID 0000.0001) cStanton_1 = /* coef used in Stanton number calculation [?] */
+(PID.TID 0000.0001) cDrag_8 = /* coef used in drag calculation [(s/m)^6] */
+(PID.TID 0000.0001)                 1.234567000000000E+05
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) cDragMax = /* maximum drag (Large and Yeager, 2009) [-] */
+(PID.TID 0000.0001)                 1.234567000000000E+05
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) umax = /* at maximum wind (Large and Yeager, 2009) [m/s] */
+(PID.TID 0000.0001)                 1.234567000000000E+05
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) cStanton_1 = /* coef used in Stanton number calculation [-] */
 (PID.TID 0000.0001)                 3.270000000000000E-02
 (PID.TID 0000.0001)     ;
-(PID.TID 0000.0001) cStanton_2 = /* coef used in Stanton number calculation [?] */
+(PID.TID 0000.0001) cStanton_2 = /* coef used in Stanton number calculation [-] */
 (PID.TID 0000.0001)                 1.800000000000000E-02
 (PID.TID 0000.0001)     ;
-(PID.TID 0000.0001) cDalton = /* coef used in Dalton number calculation [?] */
+(PID.TID 0000.0001) cDalton = /* Dalton number [-] */
 (PID.TID 0000.0001)                 3.460000000000000E-02
 (PID.TID 0000.0001)     ;
 (PID.TID 0000.0001) exf_scal_BulkCdn= /* Drag coefficient scaling factor [-] */
@@ -985,7 +1002,7 @@
 (PID.TID 0000.0001)    Seaice time stepping configuration   > START <
 (PID.TID 0000.0001)    ----------------------------------------------
 (PID.TID 0000.0001) SEAICE_deltaTtherm= /* thermodynamic timestep */
-(PID.TID 0000.0001)                 1.800000000000000E+03
+(PID.TID 0000.0001)                 9.000000000000000E+02
 (PID.TID 0000.0001)     ;
 (PID.TID 0000.0001) SEAICE_deltaTdyn  = /* dynamic timestep */
 (PID.TID 0000.0001)                 1.800000000000000E+03
@@ -1248,35 +1265,35 @@
 (PID.TID 0000.0001) 
 (PID.TID 0000.0001) ------------------------------------------------------------
 (PID.TID 0000.0001) DIAGNOSTICS_SET_LEVELS: done
-(PID.TID 0000.0001)  Total Nb of available Diagnostics: ndiagt=   256
+(PID.TID 0000.0001)  Total Nb of available Diagnostics: ndiagt=   258
 (PID.TID 0000.0001)  write list of available Diagnostics to file: available_diagnostics.log
-(PID.TID 0000.0001) SETDIAG: Allocate  1 x  1 Levels for Diagnostic #   224 SI_Fract
-(PID.TID 0000.0001) SETDIAG: Allocate  1 x  1 Levels for Diagnostic #   225 SI_Thick
-(PID.TID 0000.0001) - NOTE - SETDIAG: Counter-mate #   224 SI_Fract is already set
+(PID.TID 0000.0001) SETDIAG: Allocate  1 x  1 Levels for Diagnostic #   226 SI_Fract
+(PID.TID 0000.0001) SETDIAG: Allocate  1 x  1 Levels for Diagnostic #   227 SI_Thick
+(PID.TID 0000.0001) - NOTE - SETDIAG: Counter-mate #   226 SI_Fract is already set
 (PID.TID 0000.0001) SETDIAG: Allocate  1 x  1 Levels for Diagnostic #    26 THETA
-(PID.TID 0000.0001) SETDIAG: Allocate  1 x  1 Levels for Diagnostic #   227 SI_Tsrf
-(PID.TID 0000.0001) - NOTE - SETDIAG: Counter-mate #   224 SI_Fract is already set
-(PID.TID 0000.0001) SETDIAG: Allocate  1 x  1 Levels for Diagnostic #   237 SIflx2oc
-(PID.TID 0000.0001) SETDIAG: Allocate  1 x  1 Levels for Diagnostic #   238 SIfrw2oc
-(PID.TID 0000.0001) SETDIAG: Allocate  1 x  1 Levels for Diagnostic #   239 SIsaltFx
-(PID.TID 0000.0001) SETDIAG: Allocate  1 x  1 Levels for Diagnostic #   235 SIflxAtm
-(PID.TID 0000.0001) SETDIAG: Allocate  1 x  1 Levels for Diagnostic #   236 SIfrwAtm
-(PID.TID 0000.0001) SETDIAG: Allocate  1 x  1 Levels for Diagnostic #   163 SIuice
-(PID.TID 0000.0001) SETDIAG: Allocate  1 x  1 Levels for Diagnostic #   164 SIvice
-(PID.TID 0000.0001) SETDIAG: Allocate  1 x  1 Levels for Diagnostic #   163 SIuice
-(PID.TID 0000.0001) SETDIAG: Allocate  1 x  1 Levels for Diagnostic #   164 SIvice
-(PID.TID 0000.0001) SETDIAG: Allocate  1 x  1 Levels for Diagnostic #   149 SIheff
-(PID.TID 0000.0001) SETDIAG: Allocate  1 x  1 Levels for Diagnostic #   224 SI_Fract
-(PID.TID 0000.0001) SETDIAG: Allocate  1 x  1 Levels for Diagnostic #   225 SI_Thick
-(PID.TID 0000.0001) - NOTE - SETDIAG: Counter-mate #   224 SI_Fract is already set
-(PID.TID 0000.0001) SETDIAG: Allocate  1 x  1 Levels for Diagnostic #   227 SI_Tsrf
-(PID.TID 0000.0001) - NOTE - SETDIAG: Counter-mate #   224 SI_Fract is already set
+(PID.TID 0000.0001) SETDIAG: Allocate  1 x  1 Levels for Diagnostic #   229 SI_Tsrf
+(PID.TID 0000.0001) - NOTE - SETDIAG: Counter-mate #   226 SI_Fract is already set
+(PID.TID 0000.0001) SETDIAG: Allocate  1 x  1 Levels for Diagnostic #   239 SIflx2oc
+(PID.TID 0000.0001) SETDIAG: Allocate  1 x  1 Levels for Diagnostic #   240 SIfrw2oc
+(PID.TID 0000.0001) SETDIAG: Allocate  1 x  1 Levels for Diagnostic #   241 SIsaltFx
+(PID.TID 0000.0001) SETDIAG: Allocate  1 x  1 Levels for Diagnostic #   237 SIflxAtm
+(PID.TID 0000.0001) SETDIAG: Allocate  1 x  1 Levels for Diagnostic #   238 SIfrwAtm
+(PID.TID 0000.0001) SETDIAG: Allocate  1 x  1 Levels for Diagnostic #   165 SIuice
+(PID.TID 0000.0001) SETDIAG: Allocate  1 x  1 Levels for Diagnostic #   166 SIvice
+(PID.TID 0000.0001) SETDIAG: Allocate  1 x  1 Levels for Diagnostic #   165 SIuice
+(PID.TID 0000.0001) SETDIAG: Allocate  1 x  1 Levels for Diagnostic #   166 SIvice
+(PID.TID 0000.0001) SETDIAG: Allocate  1 x  1 Levels for Diagnostic #   151 SIheff
+(PID.TID 0000.0001) SETDIAG: Allocate  1 x  1 Levels for Diagnostic #   226 SI_Fract
+(PID.TID 0000.0001) SETDIAG: Allocate  1 x  1 Levels for Diagnostic #   227 SI_Thick
+(PID.TID 0000.0001) - NOTE - SETDIAG: Counter-mate #   226 SI_Fract is already set
+(PID.TID 0000.0001) SETDIAG: Allocate  1 x  1 Levels for Diagnostic #   229 SI_Tsrf
+(PID.TID 0000.0001) - NOTE - SETDIAG: Counter-mate #   226 SI_Fract is already set
 (PID.TID 0000.0001) SETDIAG: Allocate  1 x  1 Levels for Diagnostic #    26 THETA
 (PID.TID 0000.0001)   space allocated for all diagnostics:      18 levels
-(PID.TID 0000.0001)   set mate pointer for diag #   163  SIuice   , Parms: UU      M1 , mate:   164
-(PID.TID 0000.0001)   set mate pointer for diag #   164  SIvice   , Parms: VV      M1 , mate:   163
-(PID.TID 0000.0001)   set mate pointer for diag #   163  SIuice   , Parms: UU      M1 , mate:   164
-(PID.TID 0000.0001)   set mate pointer for diag #   164  SIvice   , Parms: VV      M1 , mate:   163
+(PID.TID 0000.0001)   set mate pointer for diag #   165  SIuice   , Parms: UU      M1 , mate:   166
+(PID.TID 0000.0001)   set mate pointer for diag #   166  SIvice   , Parms: VV      M1 , mate:   165
+(PID.TID 0000.0001)   set mate pointer for diag #   165  SIuice   , Parms: UU      M1 , mate:   166
+(PID.TID 0000.0001)   set mate pointer for diag #   166  SIvice   , Parms: VV      M1 , mate:   165
 (PID.TID 0000.0001) DIAGNOSTICS_SET_POINTERS: Set levels for Outp.Stream: iceDiag
 (PID.TID 0000.0001)  Levels:       1.
 (PID.TID 0000.0001) DIAGNOSTICS_SET_POINTERS: Set levels for Outp.Stream: snapshot
@@ -1285,25 +1302,25 @@
 (PID.TID 0000.0001) ------------------------------------------------------------
 (PID.TID 0000.0001) DIAGSTATS_SET_REGIONS: define no region
 (PID.TID 0000.0001) ------------------------------------------------------------
-(PID.TID 0000.0001) SETDIAG: Allocate  1 Levels for Stats-Diag #   224 SI_Fract
-(PID.TID 0000.0001) SETDIAG: Allocate  1 Levels for Stats-Diag #   225 SI_Thick
-(PID.TID 0000.0001) - NOTE - SETDIAG: Counter Diagnostic #   224 SI_Fract has already been set
+(PID.TID 0000.0001) SETDIAG: Allocate  1 Levels for Stats-Diag #   226 SI_Fract
+(PID.TID 0000.0001) SETDIAG: Allocate  1 Levels for Stats-Diag #   227 SI_Thick
+(PID.TID 0000.0001) - NOTE - SETDIAG: Counter Diagnostic #   226 SI_Fract has already been set
 (PID.TID 0000.0001) SETDIAG: Allocate  1 Levels for Stats-Diag #    26 THETA
-(PID.TID 0000.0001) SETDIAG: Allocate  1 Levels for Stats-Diag #   227 SI_Tsrf
-(PID.TID 0000.0001) - NOTE - SETDIAG: Counter Diagnostic #   224 SI_Fract has already been set
-(PID.TID 0000.0001) SETDIAG: Allocate  1 Levels for Stats-Diag #   228 SI_Tice1
-(PID.TID 0000.0001) - NOTE - SETDIAG: Counter Diagnostic #   224 SI_Fract has already been set
-(PID.TID 0000.0001) SETDIAG: Allocate  1 Levels for Stats-Diag #   229 SI_Tice2
-(PID.TID 0000.0001) - NOTE - SETDIAG: Counter Diagnostic #   224 SI_Fract has already been set
-(PID.TID 0000.0001) SETDIAG: Allocate  1 Levels for Stats-Diag #   237 SIflx2oc
-(PID.TID 0000.0001) SETDIAG: Allocate  1 Levels for Stats-Diag #   238 SIfrw2oc
-(PID.TID 0000.0001) SETDIAG: Allocate  1 Levels for Stats-Diag #   239 SIsaltFx
-(PID.TID 0000.0001) SETDIAG: Allocate  1 Levels for Stats-Diag #   235 SIflxAtm
-(PID.TID 0000.0001) SETDIAG: Allocate  1 Levels for Stats-Diag #   236 SIfrwAtm
-(PID.TID 0000.0001) SETDIAG: Allocate  1 Levels for Stats-Diag #   226 SI_SnowH
-(PID.TID 0000.0001) - NOTE - SETDIAG: Counter Diagnostic #   224 SI_Fract has already been set
-(PID.TID 0000.0001) SETDIAG: Allocate  1 Levels for Stats-Diag #   163 SIuice
-(PID.TID 0000.0001) SETDIAG: Allocate  1 Levels for Stats-Diag #   164 SIvice
+(PID.TID 0000.0001) SETDIAG: Allocate  1 Levels for Stats-Diag #   229 SI_Tsrf
+(PID.TID 0000.0001) - NOTE - SETDIAG: Counter Diagnostic #   226 SI_Fract has already been set
+(PID.TID 0000.0001) SETDIAG: Allocate  1 Levels for Stats-Diag #   230 SI_Tice1
+(PID.TID 0000.0001) - NOTE - SETDIAG: Counter Diagnostic #   226 SI_Fract has already been set
+(PID.TID 0000.0001) SETDIAG: Allocate  1 Levels for Stats-Diag #   231 SI_Tice2
+(PID.TID 0000.0001) - NOTE - SETDIAG: Counter Diagnostic #   226 SI_Fract has already been set
+(PID.TID 0000.0001) SETDIAG: Allocate  1 Levels for Stats-Diag #   239 SIflx2oc
+(PID.TID 0000.0001) SETDIAG: Allocate  1 Levels for Stats-Diag #   240 SIfrw2oc
+(PID.TID 0000.0001) SETDIAG: Allocate  1 Levels for Stats-Diag #   241 SIsaltFx
+(PID.TID 0000.0001) SETDIAG: Allocate  1 Levels for Stats-Diag #   237 SIflxAtm
+(PID.TID 0000.0001) SETDIAG: Allocate  1 Levels for Stats-Diag #   238 SIfrwAtm
+(PID.TID 0000.0001) SETDIAG: Allocate  1 Levels for Stats-Diag #   228 SI_SnowH
+(PID.TID 0000.0001) - NOTE - SETDIAG: Counter Diagnostic #   226 SI_Fract has already been set
+(PID.TID 0000.0001) SETDIAG: Allocate  1 Levels for Stats-Diag #   165 SIuice
+(PID.TID 0000.0001) SETDIAG: Allocate  1 Levels for Stats-Diag #   166 SIvice
 (PID.TID 0000.0001)   space allocated for all stats-diags:      14 levels
 (PID.TID 0000.0001) DIAGSTATS_SET_POINTERS: done
 (PID.TID 0000.0001) ------------------------------------------------------------
@@ -1346,8 +1363,14 @@
 (PID.TID 0000.0001) tRef =   /* Reference temperature profile ( oC or K ) */
 (PID.TID 0000.0001)                -1.620000000000000E+00       /* K =  1 */
 (PID.TID 0000.0001)     ;
-(PID.TID 0000.0001) sRef =   /* Reference salinity profile ( psu ) */
+(PID.TID 0000.0001) sRef =   /* Reference salinity profile ( g/kg ) */
 (PID.TID 0000.0001)                 3.000000000000000E+01       /* K =  1 */
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) rhoRef =   /* Density vertical profile from (Ref,sRef)( kg/m^3 ) */
+(PID.TID 0000.0001)                 1.030000000000000E+03       /* K =  1 */
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) dBdrRef = /* Vertical grad. of reference buoyancy [(m/s/r)^2] */
+(PID.TID 0000.0001)                 0.000000000000000E+00       /* K =  1 */
 (PID.TID 0000.0001)     ;
 (PID.TID 0000.0001) useStrainTensionVisc= /* Use StrainTension Form of Viscous Operator */
 (PID.TID 0000.0001)                   F
@@ -1442,7 +1465,7 @@
 (PID.TID 0000.0001) tAlpha = /* Linear EOS thermal expansion coefficient ( 1/oC ) */
 (PID.TID 0000.0001)                 2.000000000000000E-04
 (PID.TID 0000.0001)     ;
-(PID.TID 0000.0001) sBeta  = /* Linear EOS haline contraction coefficient ( 1/psu ) */
+(PID.TID 0000.0001) sBeta  = /* Linear EOS haline contraction coefficient ( 1/(g/kg) ) */
 (PID.TID 0000.0001)                 0.000000000000000E+00
 (PID.TID 0000.0001)     ;
 (PID.TID 0000.0001) rhoNil    = /* Reference density for Linear EOS ( kg/m^3 ) */
@@ -1509,17 +1532,20 @@
 (PID.TID 0000.0001) freeSurfFac =   /* Implicit free surface factor */
 (PID.TID 0000.0001)                 1.000000000000000E+00
 (PID.TID 0000.0001)     ;
-(PID.TID 0000.0001) implicSurfPress =  /* Surface Pressure implicit factor (0-1)*/
+(PID.TID 0000.0001) implicSurfPress =  /* Surface Pressure implicit factor (0-1) */
 (PID.TID 0000.0001)                 1.000000000000000E+00
 (PID.TID 0000.0001)     ;
-(PID.TID 0000.0001) implicDiv2DFlow =  /* Barot. Flow Div. implicit factor (0-1)*/
+(PID.TID 0000.0001) implicDiv2DFlow =  /* Barot. Flow Div. implicit factor (0-1) */
 (PID.TID 0000.0001)                 1.000000000000000E+00
 (PID.TID 0000.0001)     ;
-(PID.TID 0000.0001) uniformLin_PhiSurf = /* use uniform Bo_surf on/off flag*/
+(PID.TID 0000.0001) uniformLin_PhiSurf = /* use uniform Bo_surf on/off flag */
 (PID.TID 0000.0001)                   T
 (PID.TID 0000.0001)     ;
 (PID.TID 0000.0001) uniformFreeSurfLev = /* free-surface level-index is uniform */
 (PID.TID 0000.0001)                   T
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) sIceLoadFac =  /* scale factor for sIceLoad (0-1) */
+(PID.TID 0000.0001)                 1.000000000000000E+00
 (PID.TID 0000.0001)     ;
 (PID.TID 0000.0001) hFacMin =   /* minimum partial cell factor (hFac) */
 (PID.TID 0000.0001)                 1.000000000000000E+00
@@ -1527,10 +1553,10 @@
 (PID.TID 0000.0001) hFacMinDr = /* minimum partial cell thickness ( m) */
 (PID.TID 0000.0001)                 0.000000000000000E+00
 (PID.TID 0000.0001)     ;
-(PID.TID 0000.0001) exactConserv =  /* Exact Volume Conservation on/off flag*/
+(PID.TID 0000.0001) exactConserv =  /* Exact Volume Conservation on/off flag */
 (PID.TID 0000.0001)                   F
 (PID.TID 0000.0001)     ;
-(PID.TID 0000.0001) linFSConserveTr = /* Tracer correction for Lin Free Surface on/off flag*/
+(PID.TID 0000.0001) linFSConserveTr = /* Tracer correction for Lin Free Surface on/off flag */
 (PID.TID 0000.0001)                   F
 (PID.TID 0000.0001)     ;
 (PID.TID 0000.0001) nonlinFreeSurf = /* Non-linear Free Surf. options (-1,0,1,2,3)*/
@@ -1552,7 +1578,7 @@
 (PID.TID 0000.0001) temp_EvPrRn = /* Temp. of Evap/Prec/R (UNSET=use local T)(oC)*/
 (PID.TID 0000.0001)                 1.234567000000000E+05
 (PID.TID 0000.0001)     ;
-(PID.TID 0000.0001) salt_EvPrRn = /* Salin. of Evap/Prec/R (UNSET=use local S)(psu)*/
+(PID.TID 0000.0001) salt_EvPrRn = /* Salin. of Evap/Prec/R (UNSET=use local S)(g/kg)*/
 (PID.TID 0000.0001)                 0.000000000000000E+00
 (PID.TID 0000.0001)     ;
 (PID.TID 0000.0001) selectAddFluid = /* option for mass source/sink of fluid (=0: off) */
@@ -1561,10 +1587,10 @@
 (PID.TID 0000.0001) temp_addMass = /* Temp. of addMass array (UNSET=use local T)(oC)*/
 (PID.TID 0000.0001)                 1.234567000000000E+05
 (PID.TID 0000.0001)     ;
-(PID.TID 0000.0001) salt_addMass = /* Salin. of addMass array (UNSET=use local S)(psu)*/
+(PID.TID 0000.0001) salt_addMass = /* Salin. of addMass array (UNSET=use local S)(g/kg)*/
 (PID.TID 0000.0001)                 0.000000000000000E+00
 (PID.TID 0000.0001)     ;
-(PID.TID 0000.0001) convertFW2Salt = /* convert F.W. Flux to Salt Flux (-1=use local S)(psu)*/
+(PID.TID 0000.0001) convertFW2Salt = /* convert F.W. Flux to Salt Flux (-1=use local S)(g/kg)*/
 (PID.TID 0000.0001)                -1.000000000000000E+00
 (PID.TID 0000.0001)     ;
 (PID.TID 0000.0001) use3Dsolver = /* use 3-D pressure solver on/off flag */
@@ -1736,8 +1762,8 @@
 (PID.TID 0000.0001) cg2dMaxIters =   /* Upper limit on 2d con. grad iterations  */
 (PID.TID 0000.0001)                     500
 (PID.TID 0000.0001)     ;
-(PID.TID 0000.0001) cg2dChkResFreq =   /* 2d con. grad convergence test frequency */
-(PID.TID 0000.0001)                       1
+(PID.TID 0000.0001) cg2dMinItersNSA =   /* Minimum number of iterations of 2d con. grad solver  */
+(PID.TID 0000.0001)                       0
 (PID.TID 0000.0001)     ;
 (PID.TID 0000.0001) cg2dUseMinResSol= /* use cg2d last-iter(=0) / min-resid.(=1) solution */
 (PID.TID 0000.0001)                       0
@@ -1754,6 +1780,9 @@
 (PID.TID 0000.0001) useSRCGSolver =  /* use single reduction CG solver(s) */
 (PID.TID 0000.0001)                   F
 (PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) useNSACGSolver =  /* use not-self-adjoint CG solver */
+(PID.TID 0000.0001)                   F
+(PID.TID 0000.0001)     ;
 (PID.TID 0000.0001) printResidualFreq = /* Freq. for printing CG residual */
 (PID.TID 0000.0001)                       0
 (PID.TID 0000.0001)     ;
@@ -1761,16 +1790,16 @@
 (PID.TID 0000.0001) // Time stepping paramters ( PARM03 in namelist )
 (PID.TID 0000.0001) //
 (PID.TID 0000.0001) deltaTMom =   /* Momentum equation timestep ( s ) */
-(PID.TID 0000.0001)                 1.800000000000000E+03
+(PID.TID 0000.0001)                 9.000000000000000E+02
 (PID.TID 0000.0001)     ;
 (PID.TID 0000.0001) deltaTFreeSurf = /* FreeSurface equation timestep ( s ) */
-(PID.TID 0000.0001)                 1.800000000000000E+03
+(PID.TID 0000.0001)                 9.000000000000000E+02
 (PID.TID 0000.0001)     ;
 (PID.TID 0000.0001) dTtracerLev =  /* Tracer equation timestep ( s ) */
-(PID.TID 0000.0001)                 1.800000000000000E+03       /* K =  1 */
+(PID.TID 0000.0001)                 9.000000000000000E+02       /* K =  1 */
 (PID.TID 0000.0001)     ;
 (PID.TID 0000.0001) deltaTClock  =   /* Model clock timestep ( s ) */
-(PID.TID 0000.0001)                 1.800000000000000E+03
+(PID.TID 0000.0001)                 9.000000000000000E+02
 (PID.TID 0000.0001)     ;
 (PID.TID 0000.0001) cAdjFreq =   /* Convective adjustment interval ( s ) */
 (PID.TID 0000.0001)                 0.000000000000000E+00
@@ -1800,10 +1829,10 @@
 (PID.TID 0000.0001)                       0
 (PID.TID 0000.0001)     ;
 (PID.TID 0000.0001) nTimeSteps = /* Number of timesteps */
-(PID.TID 0000.0001)                      12
+(PID.TID 0000.0001)                      24
 (PID.TID 0000.0001)     ;
 (PID.TID 0000.0001) nEndIter =   /* Run ending timestep number */
-(PID.TID 0000.0001)                      12
+(PID.TID 0000.0001)                      24
 (PID.TID 0000.0001)     ;
 (PID.TID 0000.0001) baseTime =   /* Model base time ( s ) */
 (PID.TID 0000.0001)                 0.000000000000000E+00
@@ -2024,15 +2053,6 @@
 (PID.TID 0000.0001) deepFacF = /* deep-model grid factor @ W-Interface (-) */
 (PID.TID 0000.0001)     2 @  1.000000000000000E+00              /* K =  1:  2 */
 (PID.TID 0000.0001)     ;
-(PID.TID 0000.0001) rVel2wUnit = /* convert units: rVel -> wSpeed (=1 if z-coord)*/
-(PID.TID 0000.0001)     2 @  1.000000000000000E+00              /* K =  1:  2 */
-(PID.TID 0000.0001)     ;
-(PID.TID 0000.0001) wUnit2rVel = /* convert units: wSpeed -> rVel (=1 if z-coord)*/
-(PID.TID 0000.0001)     2 @  1.000000000000000E+00              /* K =  1:  2 */
-(PID.TID 0000.0001)     ;
-(PID.TID 0000.0001) dBdrRef = /* Vertical grad. of reference buoyancy [(m/s/r)^2] */
-(PID.TID 0000.0001)                 0.000000000000000E+00       /* K =  1 */
-(PID.TID 0000.0001)     ;
 (PID.TID 0000.0001) rotateGrid = /* use rotated grid ( True/False ) */
 (PID.TID 0000.0001)                   F
 (PID.TID 0000.0001)     ;
@@ -2144,29 +2164,29 @@ listId=    1 ; file name: iceDiag
    11  |   11  |     86400.000000         0.000000 |   1
  levels:   1
  diag# | name   |   ipt  |  iMate | kLev|   count |   mate.C|           
-   224 |SI_Fract|      1 |      0 |   1 |       0 |
-   225 |SI_Thick|      2 |      1 |   1 |       0 |       0 |
+   226 |SI_Fract|      1 |      0 |   1 |       0 |
+   227 |SI_Thick|      2 |      1 |   1 |       0 |       0 |
     26 |THETA   |      3 |      0 |   1 |       0 |
-   227 |SI_Tsrf |      4 |      1 |   1 |       0 |       0 |
-   237 |SIflx2oc|      5 |      0 |   1 |       0 |
-   238 |SIfrw2oc|      6 |      0 |   1 |       0 |
-   239 |SIsaltFx|      7 |      0 |   1 |       0 |
-   235 |SIflxAtm|      8 |      0 |   1 |       0 |
-   236 |SIfrwAtm|      9 |      0 |   1 |       0 |
-   163 |SIuice  |     10 |     11 |   1 |       0 |       0 |
-   164 |SIvice  |     11 |     10 |   1 |       0 |       0 |
+   229 |SI_Tsrf |      4 |      1 |   1 |       0 |       0 |
+   239 |SIflx2oc|      5 |      0 |   1 |       0 |
+   240 |SIfrw2oc|      6 |      0 |   1 |       0 |
+   241 |SIsaltFx|      7 |      0 |   1 |       0 |
+   237 |SIflxAtm|      8 |      0 |   1 |       0 |
+   238 |SIfrwAtm|      9 |      0 |   1 |       0 |
+   165 |SIuice  |     10 |     11 |   1 |       0 |       0 |
+   166 |SIvice  |     11 |     10 |   1 |       0 |       0 |
 ------------------------------------------------------------------------
 listId=    2 ; file name: snapshot
  nFlds, nActive,       freq     &     phase        , nLev               
     7  |    7  |    -86400.000000         0.000000 |   1
  levels:   1
  diag# | name   |   ipt  |  iMate | kLev|   count |   mate.C|           
-   163 |SIuice  |     12 |     13 |   1 |       0 |       0 |
-   164 |SIvice  |     13 |     12 |   1 |       0 |       0 |
-   149 |SIheff  |     14 |      0 |   1 |       0 |
-   224 |SI_Fract|     15 |      0 |   1 |       0 |
-   225 |SI_Thick|     16 |     15 |   1 |       0 |       0 |
-   227 |SI_Tsrf |     17 |     15 |   1 |       0 |       0 |
+   165 |SIuice  |     12 |     13 |   1 |       0 |       0 |
+   166 |SIvice  |     13 |     12 |   1 |       0 |       0 |
+   151 |SIheff  |     14 |      0 |   1 |       0 |
+   226 |SI_Fract|     15 |      0 |   1 |       0 |
+   227 |SI_Thick|     16 |     15 |   1 |       0 |       0 |
+   229 |SI_Tsrf |     17 |     15 |   1 |       0 |       0 |
     26 |THETA   |     18 |      0 |   1 |       0 |
 ------------------------------------------------------------------------
 Global & Regional Statistics diagnostics: Number of lists:     1
@@ -2176,20 +2196,20 @@ listId=   1 ; file name: iceStDiag
    14  |   14  |      7200.000000      1800.000000 |
  Regions:   0
  diag# | name   |   ipt  |  iMate |    Volume   |   mate-Vol. |         
-   224 |SI_Fract|      1 |      0 | 0.00000E+00 |
-   225 |SI_Thick|      2 |      1 | 0.00000E+00 | 0.00000E+00 |
+   226 |SI_Fract|      1 |      0 | 0.00000E+00 |
+   227 |SI_Thick|      2 |      1 | 0.00000E+00 | 0.00000E+00 |
     26 |THETA   |      3 |      0 | 0.00000E+00 |
-   227 |SI_Tsrf |      4 |      1 | 0.00000E+00 | 0.00000E+00 |
-   228 |SI_Tice1|      5 |      1 | 0.00000E+00 | 0.00000E+00 |
-   229 |SI_Tice2|      6 |      1 | 0.00000E+00 | 0.00000E+00 |
-   237 |SIflx2oc|      7 |      0 | 0.00000E+00 |
-   238 |SIfrw2oc|      8 |      0 | 0.00000E+00 |
-   239 |SIsaltFx|      9 |      0 | 0.00000E+00 |
-   235 |SIflxAtm|     10 |      0 | 0.00000E+00 |
-   236 |SIfrwAtm|     11 |      0 | 0.00000E+00 |
-   226 |SI_SnowH|     12 |      1 | 0.00000E+00 | 0.00000E+00 |
-   163 |SIuice  |     13 |      0 | 0.00000E+00 |
-   164 |SIvice  |     14 |      0 | 0.00000E+00 |
+   229 |SI_Tsrf |      4 |      1 | 0.00000E+00 | 0.00000E+00 |
+   230 |SI_Tice1|      5 |      1 | 0.00000E+00 | 0.00000E+00 |
+   231 |SI_Tice2|      6 |      1 | 0.00000E+00 | 0.00000E+00 |
+   239 |SIflx2oc|      7 |      0 | 0.00000E+00 |
+   240 |SIfrw2oc|      8 |      0 | 0.00000E+00 |
+   241 |SIsaltFx|      9 |      0 | 0.00000E+00 |
+   237 |SIflxAtm|     10 |      0 | 0.00000E+00 |
+   238 |SIfrwAtm|     11 |      0 | 0.00000E+00 |
+   228 |SI_SnowH|     12 |      1 | 0.00000E+00 | 0.00000E+00 |
+   165 |SIuice  |     13 |      0 | 0.00000E+00 |
+   166 |SIvice  |     14 |      0 | 0.00000E+00 |
 ------------------------------------------------------------------------
 (PID.TID 0000.0001)  MDS_READ_FIELD: opening global file: windx.bin
 (PID.TID 0000.0001)  MDS_READ_FIELD: opening global file: tair_4x.bin
@@ -2242,9 +2262,9 @@ listId=   1 ; file name: iceStDiag
 (PID.TID 0000.0001) %MON trAdv_CFL_u_max              =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON trAdv_CFL_v_max              =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON trAdv_CFL_w_max              =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON advcfl_uvel_max              =   1.9690054439531E-01
-(PID.TID 0000.0001) %MON advcfl_vvel_max              =   8.2010221574612E-02
-(PID.TID 0000.0001) %MON advcfl_wvel_max              =   8.7816487489057E-02
+(PID.TID 0000.0001) %MON advcfl_uvel_max              =   9.8450272197654E-02
+(PID.TID 0000.0001) %MON advcfl_vvel_max              =   4.1005110787306E-02
+(PID.TID 0000.0001) %MON advcfl_wvel_max              =   4.3908243744528E-02
 (PID.TID 0000.0001) %MON advcfl_W_hf_max              =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON pe_b_mean                    =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON ke_max                       =   1.4564487757410E-01
@@ -2409,29 +2429,40 @@ listId=   1 ; file name: iceStDiag
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // End MONITOR EXF statistics
 (PID.TID 0000.0001) // =======================================================
- SEAICE_LSR: Residual Initial ipass,Uice,Vice=    1  8.33439597E-01  1.20506078E-01
- SEAICE_LSR: Residual FrDrift U_fd,V_fd=  2.35737084E+03  5.23300008E+02
- SEAICE_LSR (ipass=   1) iters,dU,Resid=  1500  1.10611793E-06  1.19316739E-02
- SEAICE_LSR (ipass=   1) iters,dV,Resid=   502  9.93356005E-13  7.37873538E-09
- SEAICE_LSR: Residual Initial ipass,Uice,Vice=    2  7.90680830E-01  1.27481070E-01
- SEAICE_LSR: Residual FrDrift U_fd,V_fd=  8.89176982E+01  1.13326545E+01
- SEAICE_LSR (ipass=   2) iters,dU,Resid=  1500  3.33219075E-05  5.95807665E-02
- SEAICE_LSR (ipass=   2) iters,dV,Resid=   392  9.51150400E-13  2.95263878E-10
+ SEAICE_LSR: Residual Initial ipass,Uice,Vice=         1  8.33439597E-01  1.20506078E-01
+ SEAICE_LSR: Residual FrDrift U_fd,V_fd=  2.35740960E+03  5.23309025E+02
+ SEAICE_LSR (ipass=        1) iters,dU,Resid=     1500  1.10610101E-06  1.19317410E-02
+ SEAICE_LSR (ipass=        1) iters,dV,Resid=      502  9.93358824E-13  7.37875585E-09
+ SEAICE_LSR: Residual Initial ipass,Uice,Vice=         2  7.90681342E-01  1.27481328E-01
+ SEAICE_LSR: Residual FrDrift U_fd,V_fd=  8.89207011E+01  1.13330631E+01
+ SEAICE_LSR (ipass=        2) iters,dU,Resid=     1500  3.33228975E-05  5.95852058E-02
+ SEAICE_LSR (ipass=        2) iters,dV,Resid=      392  9.51135221E-13  2.95269106E-10
+ Computing Diagnostic #    165  SIuice       Counter:       1   Parms: UU      M1      
+           Vector  Mate for  SIuice       Diagnostic #    166  SIvice   exists 
+ Computing Diagnostic #    166  SIvice       Counter:       1   Parms: VV      M1      
+           Vector  Mate for  SIvice       Diagnostic #    165  SIuice   exists 
+ Computing Diagnostic #    151  SIheff       Counter:       1   Parms: SM      M1      
+ Computing Diagnostic #    226  SI_Fract     Counter:       1   Parms: SM P    M1      
+ Computing Diagnostic #    227  SI_Thick     Counter:       1   Parms: SM PC   M1      
+       use Counter Mate for  SI_Thick     Diagnostic #    226  SI_Fract
+ Computing Diagnostic #    229  SI_Tsrf      Counter:       1   Parms: SM  C   M1      
+       use Counter Mate for  SI_Tsrf      Diagnostic #    226  SI_Fract
+ Computing Diagnostic #     26  THETA        Counter:       1   Parms: SMR     MR      
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // Begin MONITOR SEAICE statistics
 (PID.TID 0000.0001) // =======================================================
-(PID.TID 0000.0001) %MON seaice_tsnumber              =                     1
+(PID.TID 0000.0001) %MON seaice_tsnumber              =                     2
 (PID.TID 0000.0001) %MON seaice_time_sec              =   1.8000000000000E+03
-(PID.TID 0000.0001) %MON seaice_uice_max              =   2.8588538990214E-01
-(PID.TID 0000.0001) %MON seaice_uice_min              =   6.3158501874265E-03
-(PID.TID 0000.0001) %MON seaice_uice_mean             =   1.8809666978113E-01
-(PID.TID 0000.0001) %MON seaice_uice_sd               =   9.5014074230491E-02
-(PID.TID 0000.0001) %MON seaice_uice_del2             =   6.5182695329844E-05
-(PID.TID 0000.0001) %MON seaice_vice_max              =   7.5679091185730E-03
-(PID.TID 0000.0001) %MON seaice_vice_min              =  -7.2445989601779E-03
-(PID.TID 0000.0001) %MON seaice_vice_mean             =  -7.7328976195178E-05
-(PID.TID 0000.0001) %MON seaice_vice_sd               =   2.9082343728416E-03
-(PID.TID 0000.0001) %MON seaice_vice_del2             =   2.1051239057076E-06
+(PID.TID 0000.0001) %MON seaice_uice_max              =   2.8588000066545E-01
+(PID.TID 0000.0001) %MON seaice_uice_min              =   6.3156810660238E-03
+(PID.TID 0000.0001) %MON seaice_uice_mean             =   1.8809306801570E-01
+(PID.TID 0000.0001) %MON seaice_uice_sd               =   9.5012357249819E-02
+(PID.TID 0000.0001) %MON seaice_uice_del2             =   6.5181397629905E-05
+(PID.TID 0000.0001) %MON seaice_vice_max              =   7.5677056007996E-03
+(PID.TID 0000.0001) %MON seaice_vice_min              =  -7.2442628295366E-03
+(PID.TID 0000.0001) %MON seaice_vice_mean             =  -7.7305000521621E-05
+(PID.TID 0000.0001) %MON seaice_vice_sd               =   2.9081319040201E-03
+(PID.TID 0000.0001) %MON seaice_vice_del2             =   2.1050494703053E-06
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // End MONITOR SEAICE statistics
 (PID.TID 0000.0001) // =======================================================
@@ -2439,97 +2470,86 @@ listId=   1 ; file name: iceStDiag
 (PID.TID 0000.0001) // Begin MONITOR Therm.SeaIce statistics
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) %MON thSI_time_sec                =   1.8000000000000E+03
-(PID.TID 0000.0001) %MON thSI_Ice_Area_G              =   6.9482539206043E+10
-(PID.TID 0000.0001) %MON thSI_Ice_Area_S              =   2.9484400013076E+10
-(PID.TID 0000.0001) %MON thSI_Ice_Area_N              =   3.9998139192967E+10
-(PID.TID 0000.0001) %MON thSI_IceH_ave_G              =   2.0004330219441E-01
-(PID.TID 0000.0001) %MON thSI_IceH_ave_S              =   2.0009940250930E-01
-(PID.TID 0000.0001) %MON thSI_IceH_ave_N              =   2.0000194816748E-01
-(PID.TID 0000.0001) %MON thSI_IceH_max_S              =   2.0473312138041E-01
-(PID.TID 0000.0001) %MON thSI_IceH_max_N              =   2.0032785765516E-01
+(PID.TID 0000.0001) %MON thSI_Ice_Area_G              =   6.9482538941805E+10
+(PID.TID 0000.0001) %MON thSI_Ice_Area_S              =   2.9484399388042E+10
+(PID.TID 0000.0001) %MON thSI_Ice_Area_N              =   3.9998139553763E+10
+(PID.TID 0000.0001) %MON thSI_IceH_ave_G              =   2.0004338012067E-01
+(PID.TID 0000.0001) %MON thSI_IceH_ave_S              =   2.0009936816331E-01
+(PID.TID 0000.0001) %MON thSI_IceH_ave_N              =   2.0000210885584E-01
+(PID.TID 0000.0001) %MON thSI_IceH_max_S              =   2.0475036719926E-01
+(PID.TID 0000.0001) %MON thSI_IceH_max_N              =   2.0032725098115E-01
 (PID.TID 0000.0001) %MON thSI_SnwH_ave_G              =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON thSI_SnwH_ave_S              =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON thSI_SnwH_ave_N              =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON thSI_SnwH_max_S              =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON thSI_SnwH_max_N              =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON thSI_Tsrf_ave_G              =  -2.1061754211703E+00
-(PID.TID 0000.0001) %MON thSI_Tsrf_ave_S              =  -2.1041015850334E+00
-(PID.TID 0000.0001) %MON thSI_Tsrf_ave_N              =  -2.1077041376421E+00
-(PID.TID 0000.0001) %MON thSI_Tsrf_min_S              =  -3.6805798424775E+00
-(PID.TID 0000.0001) %MON thSI_Tsrf_min_N              =  -3.6805798424775E+00
-(PID.TID 0000.0001) %MON thSI_Tsrf_max_S              =  -4.8735132065731E-01
-(PID.TID 0000.0001) %MON thSI_Tsrf_max_N              =  -4.8735132065731E-01
-(PID.TID 0000.0001) %MON thSI_Tic1_ave_G              =  -1.7313802408098E+00
-(PID.TID 0000.0001) %MON thSI_Tic1_ave_S              =  -1.7314309797875E+00
-(PID.TID 0000.0001) %MON thSI_Tic1_ave_N              =  -1.7313428206372E+00
-(PID.TID 0000.0001) %MON thSI_Tic1_min_S              =  -1.8720116256869E+00
-(PID.TID 0000.0001) %MON thSI_Tic1_min_N              =  -1.8720116256869E+00
-(PID.TID 0000.0001) %MON thSI_Tic1_max_S              =  -1.5937877370027E+00
-(PID.TID 0000.0001) %MON thSI_Tic1_max_N              =  -1.5937877370027E+00
-(PID.TID 0000.0001) %MON thSI_Tic2_ave_G              =  -1.6842901256825E+00
-(PID.TID 0000.0001) %MON thSI_Tic2_ave_S              =  -1.6842963230426E+00
-(PID.TID 0000.0001) %MON thSI_Tic2_ave_N              =  -1.6842855551079E+00
-(PID.TID 0000.0001) %MON thSI_Tic2_min_S              =  -1.7014671239557E+00
-(PID.TID 0000.0001) %MON thSI_Tic2_min_N              =  -1.7014671239557E+00
-(PID.TID 0000.0001) %MON thSI_Tic2_max_S              =  -1.2740344225381E+00
-(PID.TID 0000.0001) %MON thSI_Tic2_max_N              =  -1.6674843024137E+00
-(PID.TID 0000.0001) %MON thSI_TotEnerg_G              =  -4.1584483659420E+18
+(PID.TID 0000.0001) %MON thSI_Tsrf_ave_G              =  -2.1067950084854E+00
+(PID.TID 0000.0001) %MON thSI_Tsrf_ave_S              =  -2.1046960134778E+00
+(PID.TID 0000.0001) %MON thSI_Tsrf_ave_N              =  -2.1083422706283E+00
+(PID.TID 0000.0001) %MON thSI_Tsrf_min_S              =  -3.6827608886553E+00
+(PID.TID 0000.0001) %MON thSI_Tsrf_min_N              =  -3.6828508071288E+00
+(PID.TID 0000.0001) %MON thSI_Tsrf_max_S              =  -4.8788224216476E-01
+(PID.TID 0000.0001) %MON thSI_Tsrf_max_N              =  -4.8843608268018E-01
+(PID.TID 0000.0001) %MON thSI_Tic1_ave_G              =  -1.7324035285965E+00
+(PID.TID 0000.0001) %MON thSI_Tic1_ave_S              =  -1.7324979260096E+00
+(PID.TID 0000.0001) %MON thSI_Tic1_ave_N              =  -1.7323339102459E+00
+(PID.TID 0000.0001) %MON thSI_Tic1_min_S              =  -1.8761664991455E+00
+(PID.TID 0000.0001) %MON thSI_Tic1_min_N              =  -1.8761664991455E+00
+(PID.TID 0000.0001) %MON thSI_Tic1_max_S              =  -1.5922224773333E+00
+(PID.TID 0000.0001) %MON thSI_Tic1_max_N              =  -1.5922133894237E+00
+(PID.TID 0000.0001) %MON thSI_Tic2_ave_G              =  -1.6820766560794E+00
+(PID.TID 0000.0001) %MON thSI_Tic2_ave_S              =  -1.6820859208102E+00
+(PID.TID 0000.0001) %MON thSI_Tic2_ave_N              =  -1.6820698233151E+00
+(PID.TID 0000.0001) %MON thSI_Tic2_min_S              =  -1.6969787872540E+00
+(PID.TID 0000.0001) %MON thSI_Tic2_min_N              =  -1.6969787872540E+00
+(PID.TID 0000.0001) %MON thSI_Tic2_max_S              =  -1.2381641165479E+00
+(PID.TID 0000.0001) %MON thSI_Tic2_max_N              =  -1.6674315639644E+00
+(PID.TID 0000.0001) %MON thSI_TotEnerg_G              =  -4.1584611394473E+18
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // End MONITOR Therm.SeaIce statistics
 (PID.TID 0000.0001) // =======================================================
- Computing Diagnostic #    163  SIuice       Counter:       1   Parms: UU      M1      
-           Vector  Mate for  SIuice       Diagnostic #    164  SIvice   exists 
- Computing Diagnostic #    164  SIvice       Counter:       1   Parms: VV      M1      
-           Vector  Mate for  SIvice       Diagnostic #    163  SIuice   exists 
- Computing Diagnostic #    149  SIheff       Counter:       1   Parms: SM      M1      
- Computing Diagnostic #    224  SI_Fract     Counter:       1   Parms: SM P    M1      
- Computing Diagnostic #    225  SI_Thick     Counter:       1   Parms: SM PC   M1      
-       use Counter Mate for  SI_Thick     Diagnostic #    224  SI_Fract
- Computing Diagnostic #    227  SI_Tsrf      Counter:       1   Parms: SM  C   M1      
-       use Counter Mate for  SI_Tsrf      Diagnostic #    224  SI_Fract
- Computing Diagnostic #     26  THETA        Counter:       1   Parms: SMR     MR      
- Compute Stats, Diag. #    224  SI_Fract  vol(   0 ): 6.950E+10  Parms: SM P    M1      
- Compute Stats, Diag. #    225  SI_Thick  vol(   0 ): 6.950E+10  Parms: SM PC   M1      
-    use Counter Mate  #    224  SI_Fract  vol(   0 ): 6.950E+10 integral 6.950E+10
- Compute Stats, Diag. #     26  THETA     vol(   0 ): 6.950E+11  Parms: SMR     MR      
- Compute Stats, Diag. #    227  SI_Tsrf   vol(   0 ): 6.950E+10  Parms: SM  C   M1      
-    use Counter Mate  #    224  SI_Fract  vol(   0 ): 6.950E+10 integral 6.950E+10
- Compute Stats, Diag. #    228  SI_Tice1  vol(   0 ): 6.950E+10  Parms: SM  C   M1      
-    use Counter Mate  #    224  SI_Fract  vol(   0 ): 6.950E+10 integral 6.950E+10
- Compute Stats, Diag. #    229  SI_Tice2  vol(   0 ): 6.950E+10  Parms: SM  C   M1      
-    use Counter Mate  #    224  SI_Fract  vol(   0 ): 6.950E+10 integral 6.950E+10
- Compute Stats, Diag. #    237  SIflx2oc  vol(   0 ): 6.950E+10  Parms: SM      M1      
- Compute Stats, Diag. #    238  SIfrw2oc  vol(   0 ): 6.950E+10  Parms: SM      M1      
- Compute Stats, Diag. #    239  SIsaltFx  vol(   0 ): 6.950E+10  Parms: SM      M1      
- Compute Stats, Diag. #    235  SIflxAtm  vol(   0 ): 6.950E+10  Parms: SM      M1      
- Compute Stats, Diag. #    236  SIfrwAtm  vol(   0 ): 6.950E+10  Parms: SM      M1      
- Compute Stats, Diag. #    226  SI_SnowH  vol(   0 ): 6.950E+10  Parms: SM PC   M1      
-    use Counter Mate  #    224  SI_Fract  vol(   0 ): 6.950E+10 integral 6.950E+10
- Compute Stats, Diag. #    163  SIuice    vol(   0 ): 6.900E+10  Parms: UU      M1      
- Compute Stats, Diag. #    164  SIvice    vol(   0 ): 6.750E+10  Parms: VV      M1      
- SEAICE_LSR: Residual Initial ipass,Uice,Vice=    1  2.61369648E-01  8.44250267E-02
- SEAICE_LSR: Residual FrDrift U_fd,V_fd=  2.68665702E+00  8.55301968E-01
- SEAICE_LSR (ipass=   1) iters,dU,Resid=  1500  2.80406220E-05  1.50070478E-02
- SEAICE_LSR (ipass=   1) iters,dV,Resid=   258  9.63110017E-13  1.19420313E-11
- SEAICE_LSR: Residual Initial ipass,Uice,Vice=    2  1.34112401E-01  3.69954996E-02
- SEAICE_LSR: Residual FrDrift U_fd,V_fd=  4.16868230E+00  9.56491850E-01
- SEAICE_LSR (ipass=   2) iters,dU,Resid=  1500  4.66677409E-05  3.08486168E-02
- SEAICE_LSR (ipass=   2) iters,dV,Resid=   270  9.62192132E-13  1.03501443E-11
+ Compute Stats, Diag. #    226  SI_Fract  vol(   0 ): 1.390E+11  Parms: SM P    M1      
+ Compute Stats, Diag. #    227  SI_Thick  vol(   0 ): 1.390E+11  Parms: SM PC   M1      
+    use Counter Mate  #    226  SI_Fract  vol(   0 ): 1.390E+11 integral 1.390E+11
+ Compute Stats, Diag. #     26  THETA     vol(   0 ): 1.390E+12  Parms: SMR     MR      
+ Compute Stats, Diag. #    229  SI_Tsrf   vol(   0 ): 1.390E+11  Parms: SM  C   M1      
+    use Counter Mate  #    226  SI_Fract  vol(   0 ): 1.390E+11 integral 1.390E+11
+ Compute Stats, Diag. #    230  SI_Tice1  vol(   0 ): 1.390E+11  Parms: SM  C   M1      
+    use Counter Mate  #    226  SI_Fract  vol(   0 ): 1.390E+11 integral 1.390E+11
+ Compute Stats, Diag. #    231  SI_Tice2  vol(   0 ): 1.390E+11  Parms: SM  C   M1      
+    use Counter Mate  #    226  SI_Fract  vol(   0 ): 1.390E+11 integral 1.390E+11
+ Compute Stats, Diag. #    239  SIflx2oc  vol(   0 ): 1.390E+11  Parms: SM      M1      
+ Compute Stats, Diag. #    240  SIfrw2oc  vol(   0 ): 1.390E+11  Parms: SM      M1      
+ Compute Stats, Diag. #    241  SIsaltFx  vol(   0 ): 1.390E+11  Parms: SM      M1      
+ Compute Stats, Diag. #    237  SIflxAtm  vol(   0 ): 1.390E+11  Parms: SM      M1      
+ Compute Stats, Diag. #    238  SIfrwAtm  vol(   0 ): 1.390E+11  Parms: SM      M1      
+ Compute Stats, Diag. #    228  SI_SnowH  vol(   0 ): 1.390E+11  Parms: SM PC   M1      
+    use Counter Mate  #    226  SI_Fract  vol(   0 ): 1.390E+11 integral 1.390E+11
+ Compute Stats, Diag. #    165  SIuice    vol(   0 ): 1.380E+11  Parms: UU      M1      
+ Compute Stats, Diag. #    166  SIvice    vol(   0 ): 1.350E+11  Parms: VV      M1      
+ SEAICE_LSR: Residual Initial ipass,Uice,Vice=         1  2.61374744E-01  8.44258091E-02
+ SEAICE_LSR: Residual FrDrift U_fd,V_fd=  2.68679036E+00  8.55357363E-01
+ SEAICE_LSR (ipass=        1) iters,dU,Resid=     1500  2.80411895E-05  1.50086187E-02
+ SEAICE_LSR (ipass=        1) iters,dV,Resid=      258  9.63235351E-13  1.19441475E-11
+ SEAICE_LSR: Residual Initial ipass,Uice,Vice=         2  1.34115283E-01  3.69964148E-02
+ SEAICE_LSR: Residual FrDrift U_fd,V_fd=  4.17416284E+00  9.56565548E-01
+ SEAICE_LSR (ipass=        2) iters,dU,Resid=     1500  4.66702394E-05  3.08514139E-02
+ SEAICE_LSR (ipass=        2) iters,dV,Resid=      270  9.62336981E-13  1.03523419E-11
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // Begin MONITOR SEAICE statistics
 (PID.TID 0000.0001) // =======================================================
-(PID.TID 0000.0001) %MON seaice_tsnumber              =                     2
+(PID.TID 0000.0001) %MON seaice_tsnumber              =                     4
 (PID.TID 0000.0001) %MON seaice_time_sec              =   3.6000000000000E+03
-(PID.TID 0000.0001) %MON seaice_uice_max              =   5.7807660076686E-01
-(PID.TID 0000.0001) %MON seaice_uice_min              =   7.6992714497757E-02
-(PID.TID 0000.0001) %MON seaice_uice_mean             =   4.7854220678156E-01
-(PID.TID 0000.0001) %MON seaice_uice_sd               =   1.2242666035877E-01
-(PID.TID 0000.0001) %MON seaice_uice_del2             =   1.3488615758411E-04
-(PID.TID 0000.0001) %MON seaice_vice_max              =   7.8688415828962E-02
-(PID.TID 0000.0001) %MON seaice_vice_min              =  -6.5186002991134E-02
-(PID.TID 0000.0001) %MON seaice_vice_mean             =  -1.4023426425965E-05
-(PID.TID 0000.0001) %MON seaice_vice_sd               =   2.3606014777294E-02
-(PID.TID 0000.0001) %MON seaice_vice_del2             =   4.4373451166640E-05
+(PID.TID 0000.0001) %MON seaice_uice_max              =   5.7807290264585E-01
+(PID.TID 0000.0001) %MON seaice_uice_min              =   7.6989476680113E-02
+(PID.TID 0000.0001) %MON seaice_uice_mean             =   4.7853763599652E-01
+(PID.TID 0000.0001) %MON seaice_uice_sd               =   1.2242841515388E-01
+(PID.TID 0000.0001) %MON seaice_uice_del2             =   1.3493723830527E-04
+(PID.TID 0000.0001) %MON seaice_vice_max              =   7.8686073621970E-02
+(PID.TID 0000.0001) %MON seaice_vice_min              =  -6.5185017103690E-02
+(PID.TID 0000.0001) %MON seaice_vice_mean             =  -1.3971467396988E-05
+(PID.TID 0000.0001) %MON seaice_vice_sd               =   2.3605465992030E-02
+(PID.TID 0000.0001) %MON seaice_vice_del2             =   4.4379323458012E-05
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // End MONITOR SEAICE statistics
 (PID.TID 0000.0001) // =======================================================
@@ -2537,67 +2557,67 @@ listId=   1 ; file name: iceStDiag
 (PID.TID 0000.0001) // Begin MONITOR Therm.SeaIce statistics
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) %MON thSI_time_sec                =   3.6000000000000E+03
-(PID.TID 0000.0001) %MON thSI_Ice_Area_G              =   6.9414311146224E+10
-(PID.TID 0000.0001) %MON thSI_Ice_Area_S              =   2.9422127142203E+10
-(PID.TID 0000.0001) %MON thSI_Ice_Area_N              =   3.9992184004021E+10
-(PID.TID 0000.0001) %MON thSI_IceH_ave_G              =   2.0023094662288E-01
-(PID.TID 0000.0001) %MON thSI_IceH_ave_S              =   2.0051088233824E-01
-(PID.TID 0000.0001) %MON thSI_IceH_ave_N              =   2.0002499877547E-01
-(PID.TID 0000.0001) %MON thSI_IceH_max_S              =   2.1986068207362E-01
-(PID.TID 0000.0001) %MON thSI_IceH_max_N              =   2.0056667957720E-01
+(PID.TID 0000.0001) %MON thSI_Ice_Area_G              =   6.9414293900784E+10
+(PID.TID 0000.0001) %MON thSI_Ice_Area_S              =   2.9422098395879E+10
+(PID.TID 0000.0001) %MON thSI_Ice_Area_N              =   3.9992195504905E+10
+(PID.TID 0000.0001) %MON thSI_IceH_ave_G              =   2.0023046027326E-01
+(PID.TID 0000.0001) %MON thSI_IceH_ave_S              =   2.0051046362209E-01
+(PID.TID 0000.0001) %MON thSI_IceH_ave_N              =   2.0002446292861E-01
+(PID.TID 0000.0001) %MON thSI_IceH_max_S              =   2.2011100178263E-01
+(PID.TID 0000.0001) %MON thSI_IceH_max_N              =   2.0056939094410E-01
 (PID.TID 0000.0001) %MON thSI_SnwH_ave_G              =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON thSI_SnwH_ave_S              =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON thSI_SnwH_ave_N              =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON thSI_SnwH_max_S              =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON thSI_SnwH_max_N              =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON thSI_Tsrf_ave_G              =  -2.1239783365740E+00
-(PID.TID 0000.0001) %MON thSI_Tsrf_ave_S              =  -2.1207215615041E+00
-(PID.TID 0000.0001) %MON thSI_Tsrf_ave_N              =  -2.1263743360065E+00
-(PID.TID 0000.0001) %MON thSI_Tsrf_min_S              =  -3.7726641121678E+00
-(PID.TID 0000.0001) %MON thSI_Tsrf_min_N              =  -3.7728191925572E+00
-(PID.TID 0000.0001) %MON thSI_Tsrf_max_S              =  -4.4348326213349E-01
-(PID.TID 0000.0001) %MON thSI_Tsrf_max_N              =  -4.4449547478908E-01
-(PID.TID 0000.0001) %MON thSI_Tic1_ave_G              =  -1.7668708295472E+00
-(PID.TID 0000.0001) %MON thSI_Tic1_ave_S              =  -1.7670590580831E+00
-(PID.TID 0000.0001) %MON thSI_Tic1_ave_N              =  -1.7667320140088E+00
-(PID.TID 0000.0001) %MON thSI_Tic1_min_S              =  -2.0491658321426E+00
-(PID.TID 0000.0001) %MON thSI_Tic1_min_N              =  -2.0491658321426E+00
-(PID.TID 0000.0001) %MON thSI_Tic1_max_S              =  -1.5036973913289E+00
-(PID.TID 0000.0001) %MON thSI_Tic1_max_N              =  -1.5036667845608E+00
-(PID.TID 0000.0001) %MON thSI_Tic2_ave_G              =  -1.6786586000252E+00
-(PID.TID 0000.0001) %MON thSI_Tic2_ave_S              =  -1.6786827157639E+00
-(PID.TID 0000.0001) %MON thSI_Tic2_ave_N              =  -1.6786408150532E+00
-(PID.TID 0000.0001) %MON thSI_Tic2_min_S              =  -1.7240266571417E+00
-(PID.TID 0000.0001) %MON thSI_Tic2_min_N              =  -1.7240266571417E+00
-(PID.TID 0000.0001) %MON thSI_Tic2_max_S              =  -9.9157790696120E-01
-(PID.TID 0000.0001) %MON thSI_Tic2_max_N              =  -1.6358728871486E+00
-(PID.TID 0000.0001) %MON thSI_TotEnerg_G              =  -4.1593950894880E+18
+(PID.TID 0000.0001) %MON thSI_Tsrf_ave_G              =  -2.1250019588391E+00
+(PID.TID 0000.0001) %MON thSI_Tsrf_ave_S              =  -2.1216806717896E+00
+(PID.TID 0000.0001) %MON thSI_Tsrf_ave_N              =  -2.1274454164472E+00
+(PID.TID 0000.0001) %MON thSI_Tsrf_min_S              =  -3.7771424441881E+00
+(PID.TID 0000.0001) %MON thSI_Tsrf_min_N              =  -3.7772833679670E+00
+(PID.TID 0000.0001) %MON thSI_Tsrf_max_S              =  -4.3545028444741E-01
+(PID.TID 0000.0001) %MON thSI_Tsrf_max_N              =  -4.4266869827375E-01
+(PID.TID 0000.0001) %MON thSI_Tic1_ave_G              =  -1.7691652258210E+00
+(PID.TID 0000.0001) %MON thSI_Tic1_ave_S              =  -1.7696490602620E+00
+(PID.TID 0000.0001) %MON thSI_Tic1_ave_N              =  -1.7688084058902E+00
+(PID.TID 0000.0001) %MON thSI_Tic1_min_S              =  -2.0577655402391E+00
+(PID.TID 0000.0001) %MON thSI_Tic1_min_N              =  -2.0577635921326E+00
+(PID.TID 0000.0001) %MON thSI_Tic1_max_S              =  -1.5010642528897E+00
+(PID.TID 0000.0001) %MON thSI_Tic1_max_N              =  -1.5009636285080E+00
+(PID.TID 0000.0001) %MON thSI_Tic2_ave_G              =  -1.6760684813046E+00
+(PID.TID 0000.0001) %MON thSI_Tic2_ave_S              =  -1.6761447235940E+00
+(PID.TID 0000.0001) %MON thSI_Tic2_ave_N              =  -1.6760122538720E+00
+(PID.TID 0000.0001) %MON thSI_Tic2_min_S              =  -1.7191410044165E+00
+(PID.TID 0000.0001) %MON thSI_Tic2_min_N              =  -1.7191409129949E+00
+(PID.TID 0000.0001) %MON thSI_Tic2_max_S              =  -9.4895451591682E-01
+(PID.TID 0000.0001) %MON thSI_Tic2_max_N              =  -1.6352753252117E+00
+(PID.TID 0000.0001) %MON thSI_TotEnerg_G              =  -4.1594197067727E+18
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // End MONITOR Therm.SeaIce statistics
 (PID.TID 0000.0001) // =======================================================
- SEAICE_LSR: Residual Initial ipass,Uice,Vice=    1  1.26658341E-01  4.15281431E-02
- SEAICE_LSR: Residual FrDrift U_fd,V_fd=  3.77943971E+00  8.70396467E-01
- SEAICE_LSR (ipass=   1) iters,dU,Resid=  1500  4.06148434E-06  2.57666877E-03
- SEAICE_LSR (ipass=   1) iters,dV,Resid=   196  9.53277388E-13  5.89503961E-11
- SEAICE_LSR: Residual Initial ipass,Uice,Vice=    2  5.87919033E-02  3.15645218E-02
- SEAICE_LSR: Residual FrDrift U_fd,V_fd=  3.78094400E+00  6.09113832E-01
- SEAICE_LSR (ipass=   2) iters,dU,Resid=  1500  2.95466824E-07  1.33282802E-04
- SEAICE_LSR (ipass=   2) iters,dV,Resid=   254  9.39668482E-13  1.46633909E-11
+ SEAICE_LSR: Residual Initial ipass,Uice,Vice=         1  1.26656329E-01  4.15632034E-02
+ SEAICE_LSR: Residual FrDrift U_fd,V_fd=  3.78005127E+00  8.70498945E-01
+ SEAICE_LSR (ipass=        1) iters,dU,Resid=     1500  4.06316765E-06  2.57821920E-03
+ SEAICE_LSR (ipass=        1) iters,dV,Resid=      196  9.55149154E-13  5.89483068E-11
+ SEAICE_LSR: Residual Initial ipass,Uice,Vice=         2  5.87877427E-02  3.15724810E-02
+ SEAICE_LSR: Residual FrDrift U_fd,V_fd=  3.78061321E+00  6.09150236E-01
+ SEAICE_LSR (ipass=        2) iters,dU,Resid=     1500  2.95568878E-07  1.33347117E-04
+ SEAICE_LSR (ipass=        2) iters,dV,Resid=      254  9.42381589E-13  1.47041311E-11
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // Begin MONITOR SEAICE statistics
 (PID.TID 0000.0001) // =======================================================
-(PID.TID 0000.0001) %MON seaice_tsnumber              =                     3
+(PID.TID 0000.0001) %MON seaice_tsnumber              =                     6
 (PID.TID 0000.0001) %MON seaice_time_sec              =   5.4000000000000E+03
-(PID.TID 0000.0001) %MON seaice_uice_max              =   5.6891298230317E-01
-(PID.TID 0000.0001) %MON seaice_uice_min              =   1.5749667813549E-01
-(PID.TID 0000.0001) %MON seaice_uice_mean             =   4.5811444304616E-01
-(PID.TID 0000.0001) %MON seaice_uice_sd               =   7.6930548942553E-02
-(PID.TID 0000.0001) %MON seaice_uice_del2             =   1.2342478196938E-04
-(PID.TID 0000.0001) %MON seaice_vice_max              =   9.5486412298207E-02
-(PID.TID 0000.0001) %MON seaice_vice_min              =  -9.1048900751943E-02
-(PID.TID 0000.0001) %MON seaice_vice_mean             =  -1.2949626640188E-03
-(PID.TID 0000.0001) %MON seaice_vice_sd               =   3.4248136980704E-02
-(PID.TID 0000.0001) %MON seaice_vice_del2             =   5.5150437111547E-05
+(PID.TID 0000.0001) %MON seaice_uice_max              =   5.6891177835247E-01
+(PID.TID 0000.0001) %MON seaice_uice_min              =   1.5745373987876E-01
+(PID.TID 0000.0001) %MON seaice_uice_mean             =   4.5810429651922E-01
+(PID.TID 0000.0001) %MON seaice_uice_sd               =   7.6951140013552E-02
+(PID.TID 0000.0001) %MON seaice_uice_del2             =   1.2359319516150E-04
+(PID.TID 0000.0001) %MON seaice_vice_max              =   9.5483540829499E-02
+(PID.TID 0000.0001) %MON seaice_vice_min              =  -9.1015574102371E-02
+(PID.TID 0000.0001) %MON seaice_vice_mean             =  -1.2892901876725E-03
+(PID.TID 0000.0001) %MON seaice_vice_sd               =   3.4237698314309E-02
+(PID.TID 0000.0001) %MON seaice_vice_del2             =   5.5506460670904E-05
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // End MONITOR SEAICE statistics
 (PID.TID 0000.0001) // =======================================================
@@ -2605,67 +2625,67 @@ listId=   1 ; file name: iceStDiag
 (PID.TID 0000.0001) // Begin MONITOR Therm.SeaIce statistics
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) %MON thSI_time_sec                =   5.4000000000000E+03
-(PID.TID 0000.0001) %MON thSI_Ice_Area_G              =   6.9354148532712E+10
-(PID.TID 0000.0001) %MON thSI_Ice_Area_S              =   2.9365042416983E+10
-(PID.TID 0000.0001) %MON thSI_Ice_Area_N              =   3.9989106115729E+10
-(PID.TID 0000.0001) %MON thSI_IceH_ave_G              =   2.0039539618881E-01
-(PID.TID 0000.0001) %MON thSI_IceH_ave_S              =   2.0089291099419E-01
-(PID.TID 0000.0001) %MON thSI_IceH_ave_N              =   2.0003005810597E-01
-(PID.TID 0000.0001) %MON thSI_IceH_max_S              =   2.3852802861800E-01
-(PID.TID 0000.0001) %MON thSI_IceH_max_N              =   2.0084559111782E-01
+(PID.TID 0000.0001) %MON thSI_Ice_Area_G              =   6.9354178967083E+10
+(PID.TID 0000.0001) %MON thSI_Ice_Area_S              =   2.9365002145323E+10
+(PID.TID 0000.0001) %MON thSI_Ice_Area_N              =   3.9989176821760E+10
+(PID.TID 0000.0001) %MON thSI_IceH_ave_G              =   2.0039394283965E-01
+(PID.TID 0000.0001) %MON thSI_IceH_ave_S              =   2.0089128847835E-01
+(PID.TID 0000.0001) %MON thSI_IceH_ave_N              =   2.0002873012690E-01
+(PID.TID 0000.0001) %MON thSI_IceH_max_S              =   2.3902108812363E-01
+(PID.TID 0000.0001) %MON thSI_IceH_max_N              =   2.0084791435179E-01
 (PID.TID 0000.0001) %MON thSI_SnwH_ave_G              =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON thSI_SnwH_ave_S              =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON thSI_SnwH_ave_N              =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON thSI_SnwH_max_S              =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON thSI_SnwH_max_N              =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON thSI_Tsrf_ave_G              =  -2.1431724283421E+00
-(PID.TID 0000.0001) %MON thSI_Tsrf_ave_S              =  -2.1387827424208E+00
-(PID.TID 0000.0001) %MON thSI_Tsrf_ave_N              =  -2.1463958890742E+00
-(PID.TID 0000.0001) %MON thSI_Tsrf_min_S              =  -3.8654066932352E+00
-(PID.TID 0000.0001) %MON thSI_Tsrf_min_N              =  -3.8655229736811E+00
-(PID.TID 0000.0001) %MON thSI_Tsrf_max_S              =  -3.9277201093244E-01
-(PID.TID 0000.0001) %MON thSI_Tsrf_max_N              =  -4.0509623253455E-01
-(PID.TID 0000.0001) %MON thSI_Tic1_ave_G              =  -1.8051525093210E+00
-(PID.TID 0000.0001) %MON thSI_Tic1_ave_S              =  -1.8059522713097E+00
-(PID.TID 0000.0001) %MON thSI_Tic1_ave_N              =  -1.8045626899307E+00
-(PID.TID 0000.0001) %MON thSI_Tic1_min_S              =  -2.2273422907968E+00
-(PID.TID 0000.0001) %MON thSI_Tic1_min_N              =  -2.2273397032330E+00
-(PID.TID 0000.0001) %MON thSI_Tic1_max_S              =  -1.4262355299130E+00
-(PID.TID 0000.0001) %MON thSI_Tic1_max_N              =  -1.4259718618112E+00
-(PID.TID 0000.0001) %MON thSI_Tic2_ave_G              =  -1.6798211599325E+00
-(PID.TID 0000.0001) %MON thSI_Tic2_ave_S              =  -1.6799953606682E+00
-(PID.TID 0000.0001) %MON thSI_Tic2_ave_N              =  -1.6796926879956E+00
-(PID.TID 0000.0001) %MON thSI_Tic2_min_S              =  -1.7600802698739E+00
-(PID.TID 0000.0001) %MON thSI_Tic2_min_N              =  -1.7600800375891E+00
-(PID.TID 0000.0001) %MON thSI_Tic2_max_S              =  -8.0345206461562E-01
-(PID.TID 0000.0001) %MON thSI_Tic2_max_N              =  -1.6063570236205E+00
-(PID.TID 0000.0001) %MON thSI_TotEnerg_G              =  -4.1602323844881E+18
+(PID.TID 0000.0001) %MON thSI_Tsrf_ave_G              =  -2.1448758534892E+00
+(PID.TID 0000.0001) %MON thSI_Tsrf_ave_S              =  -2.1405355736147E+00
+(PID.TID 0000.0001) %MON thSI_Tsrf_ave_N              =  -2.1480630240676E+00
+(PID.TID 0000.0001) %MON thSI_Tsrf_min_S              =  -3.8722791657586E+00
+(PID.TID 0000.0001) %MON thSI_Tsrf_min_N              =  -3.8725360181309E+00
+(PID.TID 0000.0001) %MON thSI_Tsrf_max_S              =  -3.7938160421084E-01
+(PID.TID 0000.0001) %MON thSI_Tsrf_max_N              =  -4.0332739240400E-01
+(PID.TID 0000.0001) %MON thSI_Tic1_ave_G              =  -1.8086461718062E+00
+(PID.TID 0000.0001) %MON thSI_Tic1_ave_S              =  -1.8099052970708E+00
+(PID.TID 0000.0001) %MON thSI_Tic1_ave_N              =  -1.8077175791659E+00
+(PID.TID 0000.0001) %MON thSI_Tic1_min_S              =  -2.2405141599266E+00
+(PID.TID 0000.0001) %MON thSI_Tic1_min_N              =  -2.2405062418046E+00
+(PID.TID 0000.0001) %MON thSI_Tic1_max_S              =  -1.4229026798472E+00
+(PID.TID 0000.0001) %MON thSI_Tic1_max_N              =  -1.4225588375799E+00
+(PID.TID 0000.0001) %MON thSI_Tic2_ave_G              =  -1.6776741671195E+00
+(PID.TID 0000.0001) %MON thSI_Tic2_ave_S              =  -1.6779464190383E+00
+(PID.TID 0000.0001) %MON thSI_Tic2_ave_N              =  -1.6774733839764E+00
+(PID.TID 0000.0001) %MON thSI_Tic2_min_S              =  -1.7567348733397E+00
+(PID.TID 0000.0001) %MON thSI_Tic2_min_N              =  -1.7567347614707E+00
+(PID.TID 0000.0001) %MON thSI_Tic2_max_S              =  -7.6443920159708E-01
+(PID.TID 0000.0001) %MON thSI_Tic2_max_N              =  -1.6051681520032E+00
+(PID.TID 0000.0001) %MON thSI_TotEnerg_G              =  -4.1602693972947E+18
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // End MONITOR Therm.SeaIce statistics
 (PID.TID 0000.0001) // =======================================================
- SEAICE_LSR: Residual Initial ipass,Uice,Vice=    1  3.35697727E-02  2.67236872E-02
- SEAICE_LSR: Residual FrDrift U_fd,V_fd=  4.93703865E+00  6.75491665E-01
- SEAICE_LSR (ipass=   1) iters,dU,Resid=  1500  5.78381271E-08  2.22095442E-05
- SEAICE_LSR (ipass=   1) iters,dV,Resid=   322  9.45719197E-13  1.66131865E-11
- SEAICE_LSR: Residual Initial ipass,Uice,Vice=    2  2.75870054E-02  2.01959772E-02
- SEAICE_LSR: Residual FrDrift U_fd,V_fd=  5.60648855E+00  7.75344449E-01
- SEAICE_LSR (ipass=   2) iters,dU,Resid=  1500  1.66262704E-09  5.58247590E-07
- SEAICE_LSR (ipass=   2) iters,dV,Resid=   318  9.69887365E-13  1.66420646E-11
+ SEAICE_LSR: Residual Initial ipass,Uice,Vice=         1  3.35315910E-02  2.66781713E-02
+ SEAICE_LSR: Residual FrDrift U_fd,V_fd=  4.93701800E+00  6.75531874E-01
+ SEAICE_LSR (ipass=        1) iters,dU,Resid=     1500  5.78302463E-08  2.22087882E-05
+ SEAICE_LSR (ipass=        1) iters,dV,Resid=      322  9.52047469E-13  1.67243732E-11
+ SEAICE_LSR: Residual Initial ipass,Uice,Vice=         2  2.75449623E-02  2.01714202E-02
+ SEAICE_LSR: Residual FrDrift U_fd,V_fd=  5.59855301E+00  7.75214232E-01
+ SEAICE_LSR (ipass=        2) iters,dU,Resid=     1500  1.65500991E-09  5.55118748E-07
+ SEAICE_LSR (ipass=        2) iters,dV,Resid=      318  9.76690950E-13  1.67558196E-11
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // Begin MONITOR SEAICE statistics
 (PID.TID 0000.0001) // =======================================================
-(PID.TID 0000.0001) %MON seaice_tsnumber              =                     4
+(PID.TID 0000.0001) %MON seaice_tsnumber              =                     8
 (PID.TID 0000.0001) %MON seaice_time_sec              =   7.2000000000000E+03
-(PID.TID 0000.0001) %MON seaice_uice_max              =   5.8982742684367E-01
-(PID.TID 0000.0001) %MON seaice_uice_min              =   1.9150851298278E-01
-(PID.TID 0000.0001) %MON seaice_uice_mean             =   4.6356065600540E-01
-(PID.TID 0000.0001) %MON seaice_uice_sd               =   7.7977107400177E-02
-(PID.TID 0000.0001) %MON seaice_uice_del2             =   1.1653537495617E-04
-(PID.TID 0000.0001) %MON seaice_vice_max              =   1.1538507746618E-01
-(PID.TID 0000.0001) %MON seaice_vice_min              =  -1.1094124704967E-01
-(PID.TID 0000.0001) %MON seaice_vice_mean             =  -1.9796273101786E-03
-(PID.TID 0000.0001) %MON seaice_vice_sd               =   4.3785448218009E-02
-(PID.TID 0000.0001) %MON seaice_vice_del2             =   5.6491764642222E-05
+(PID.TID 0000.0001) %MON seaice_uice_max              =   5.8983256057547E-01
+(PID.TID 0000.0001) %MON seaice_uice_min              =   1.9137442619644E-01
+(PID.TID 0000.0001) %MON seaice_uice_mean             =   4.6355089676598E-01
+(PID.TID 0000.0001) %MON seaice_uice_sd               =   7.7999416089823E-02
+(PID.TID 0000.0001) %MON seaice_uice_del2             =   1.1675196807897E-04
+(PID.TID 0000.0001) %MON seaice_vice_max              =   1.1538111752947E-01
+(PID.TID 0000.0001) %MON seaice_vice_min              =  -1.1087779650532E-01
+(PID.TID 0000.0001) %MON seaice_vice_mean             =  -1.9686042397536E-03
+(PID.TID 0000.0001) %MON seaice_vice_sd               =   4.3765416554726E-02
+(PID.TID 0000.0001) %MON seaice_vice_del2             =   5.6979913856911E-05
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // End MONITOR SEAICE statistics
 (PID.TID 0000.0001) // =======================================================
@@ -2673,67 +2693,67 @@ listId=   1 ; file name: iceStDiag
 (PID.TID 0000.0001) // Begin MONITOR Therm.SeaIce statistics
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) %MON thSI_time_sec                =   7.2000000000000E+03
-(PID.TID 0000.0001) %MON thSI_Ice_Area_G              =   6.9296913827799E+10
-(PID.TID 0000.0001) %MON thSI_Ice_Area_S              =   2.9311607718514E+10
-(PID.TID 0000.0001) %MON thSI_Ice_Area_N              =   3.9985306109285E+10
-(PID.TID 0000.0001) %MON thSI_IceH_ave_G              =   2.0055264302254E-01
-(PID.TID 0000.0001) %MON thSI_IceH_ave_S              =   2.0125278590856E-01
-(PID.TID 0000.0001) %MON thSI_IceH_ave_N              =   2.0003939664233E-01
-(PID.TID 0000.0001) %MON thSI_IceH_max_S              =   2.5793126486325E-01
-(PID.TID 0000.0001) %MON thSI_IceH_max_N              =   2.0105337184767E-01
+(PID.TID 0000.0001) %MON thSI_Ice_Area_G              =   6.9297009462262E+10
+(PID.TID 0000.0001) %MON thSI_Ice_Area_S              =   2.9311564259609E+10
+(PID.TID 0000.0001) %MON thSI_Ice_Area_N              =   3.9985445202654E+10
+(PID.TID 0000.0001) %MON thSI_IceH_ave_G              =   2.0055002136064E-01
+(PID.TID 0000.0001) %MON thSI_IceH_ave_S              =   2.0124986283430E-01
+(PID.TID 0000.0001) %MON thSI_IceH_ave_N              =   2.0003699847888E-01
+(PID.TID 0000.0001) %MON thSI_IceH_max_S              =   2.5865953753667E-01
+(PID.TID 0000.0001) %MON thSI_IceH_max_N              =   2.0105767139050E-01
 (PID.TID 0000.0001) %MON thSI_SnwH_ave_G              =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON thSI_SnwH_ave_S              =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON thSI_SnwH_ave_N              =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON thSI_SnwH_max_S              =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON thSI_SnwH_max_N              =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON thSI_Tsrf_ave_G              =  -2.1630543313741E+00
-(PID.TID 0000.0001) %MON thSI_Tsrf_ave_S              =  -2.1578380779645E+00
-(PID.TID 0000.0001) %MON thSI_Tsrf_ave_N              =  -2.1668781553880E+00
-(PID.TID 0000.0001) %MON thSI_Tsrf_min_S              =  -3.9566612853199E+00
-(PID.TID 0000.0001) %MON thSI_Tsrf_min_N              =  -3.9570193716355E+00
-(PID.TID 0000.0001) %MON thSI_Tsrf_max_S              =  -3.3853821338370E-01
-(PID.TID 0000.0001) %MON thSI_Tsrf_max_N              =  -3.7146909354540E-01
-(PID.TID 0000.0001) %MON thSI_Tic1_ave_G              =  -1.8442924501689E+00
-(PID.TID 0000.0001) %MON thSI_Tic1_ave_S              =  -1.8458892285763E+00
-(PID.TID 0000.0001) %MON thSI_Tic1_ave_N              =  -1.8431148164538E+00
-(PID.TID 0000.0001) %MON thSI_Tic1_min_S              =  -2.4023629063389E+00
-(PID.TID 0000.0001) %MON thSI_Tic1_min_N              =  -2.4023523415582E+00
-(PID.TID 0000.0001) %MON thSI_Tic1_max_S              =  -1.3587409875908E+00
-(PID.TID 0000.0001) %MON thSI_Tic1_max_N              =  -1.3582577313353E+00
-(PID.TID 0000.0001) %MON thSI_Tic2_ave_G              =  -1.6853523251104E+00
-(PID.TID 0000.0001) %MON thSI_Tic2_ave_S              =  -1.6857707838748E+00
-(PID.TID 0000.0001) %MON thSI_Tic2_ave_N              =  -1.6850437092454E+00
-(PID.TID 0000.0001) %MON thSI_Tic2_min_S              =  -1.8042885497049E+00
-(PID.TID 0000.0001) %MON thSI_Tic2_min_N              =  -1.8042881328034E+00
-(PID.TID 0000.0001) %MON thSI_Tic2_max_S              =  -6.7513567691282E-01
-(PID.TID 0000.0001) %MON thSI_Tic2_max_N              =  -1.5793849361828E+00
-(PID.TID 0000.0001) %MON thSI_TotEnerg_G              =  -4.1609632415625E+18
+(PID.TID 0000.0001) %MON thSI_Tsrf_ave_G              =  -2.1654258444250E+00
+(PID.TID 0000.0001) %MON thSI_Tsrf_ave_S              =  -2.1603676060524E+00
+(PID.TID 0000.0001) %MON thSI_Tsrf_ave_N              =  -2.1691338156216E+00
+(PID.TID 0000.0001) %MON thSI_Tsrf_min_S              =  -3.9658528334590E+00
+(PID.TID 0000.0001) %MON thSI_Tsrf_min_N              =  -3.9664242707770E+00
+(PID.TID 0000.0001) %MON thSI_Tsrf_max_S              =  -3.2466466541540E-01
+(PID.TID 0000.0001) %MON thSI_Tsrf_max_N              =  -3.6953910997276E-01
+(PID.TID 0000.0001) %MON thSI_Tic1_ave_G              =  -1.8489945583475E+00
+(PID.TID 0000.0001) %MON thSI_Tic1_ave_S              =  -1.8512030011265E+00
+(PID.TID 0000.0001) %MON thSI_Tic1_ave_N              =  -1.8473658306767E+00
+(PID.TID 0000.0001) %MON thSI_Tic1_min_S              =  -2.4199482701582E+00
+(PID.TID 0000.0001) %MON thSI_Tic1_min_N              =  -2.4199350324383E+00
+(PID.TID 0000.0001) %MON thSI_Tic1_max_S              =  -1.3549784458104E+00
+(PID.TID 0000.0001) %MON thSI_Tic1_max_N              =  -1.3544127852447E+00
+(PID.TID 0000.0001) %MON thSI_Tic2_ave_G              =  -1.6839976973750E+00
+(PID.TID 0000.0001) %MON thSI_Tic2_ave_S              =  -1.6845669773004E+00
+(PID.TID 0000.0001) %MON thSI_Tic2_ave_N              =  -1.6835778531410E+00
+(PID.TID 0000.0001) %MON thSI_Tic2_min_S              =  -1.8032918619329E+00
+(PID.TID 0000.0001) %MON thSI_Tic2_min_N              =  -1.8032904498778E+00
+(PID.TID 0000.0001) %MON thSI_Tic2_max_S              =  -6.4301781791629E-01
+(PID.TID 0000.0001) %MON thSI_Tic2_max_N              =  -1.5777223281387E+00
+(PID.TID 0000.0001) %MON thSI_TotEnerg_G              =  -4.1610083310406E+18
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // End MONITOR Therm.SeaIce statistics
 (PID.TID 0000.0001) // =======================================================
- SEAICE_LSR: Residual Initial ipass,Uice,Vice=    1  2.01968877E-02  1.74801194E-02
- SEAICE_LSR: Residual FrDrift U_fd,V_fd=  5.21468423E+00  1.01997643E+00
- SEAICE_LSR (ipass=   1) iters,dU,Resid=  1500  3.88077228E-08  2.15340140E-05
- SEAICE_LSR (ipass=   1) iters,dV,Resid=   314  9.54590573E-13  1.54933965E-11
- SEAICE_LSR: Residual Initial ipass,Uice,Vice=    2  1.84436598E-02  1.45901818E-02
- SEAICE_LSR: Residual FrDrift U_fd,V_fd=  5.33067047E+00  1.14105060E+00
- SEAICE_LSR (ipass=   2) iters,dU,Resid=  1500  5.11520841E-08  3.23885967E-05
- SEAICE_LSR (ipass=   2) iters,dV,Resid=   306  9.86211113E-13  1.52356859E-11
+ SEAICE_LSR: Residual Initial ipass,Uice,Vice=         1  2.01474749E-02  1.74877914E-02
+ SEAICE_LSR: Residual FrDrift U_fd,V_fd=  5.21349508E+00  1.02062284E+00
+ SEAICE_LSR (ipass=        1) iters,dU,Resid=     1500  3.88575469E-08  2.15727103E-05
+ SEAICE_LSR (ipass=        1) iters,dV,Resid=      314  9.64429925E-13  1.56476245E-11
+ SEAICE_LSR: Residual Initial ipass,Uice,Vice=         2  1.83886741E-02  1.45882873E-02
+ SEAICE_LSR: Residual FrDrift U_fd,V_fd=  5.33557346E+00  1.14253243E+00
+ SEAICE_LSR (ipass=        2) iters,dU,Resid=     1500  5.11460856E-08  3.23895562E-05
+ SEAICE_LSR (ipass=        2) iters,dV,Resid=      306  9.96633331E-13  1.53937991E-11
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // Begin MONITOR SEAICE statistics
 (PID.TID 0000.0001) // =======================================================
-(PID.TID 0000.0001) %MON seaice_tsnumber              =                     5
+(PID.TID 0000.0001) %MON seaice_tsnumber              =                    10
 (PID.TID 0000.0001) %MON seaice_time_sec              =   9.0000000000000E+03
-(PID.TID 0000.0001) %MON seaice_uice_max              =   5.9802931036510E-01
-(PID.TID 0000.0001) %MON seaice_uice_min              =   2.0317531626883E-01
-(PID.TID 0000.0001) %MON seaice_uice_mean             =   4.6425019839911E-01
-(PID.TID 0000.0001) %MON seaice_uice_sd               =   7.8490041340796E-02
-(PID.TID 0000.0001) %MON seaice_uice_del2             =   1.1441063691113E-04
-(PID.TID 0000.0001) %MON seaice_vice_max              =   1.2570559680669E-01
-(PID.TID 0000.0001) %MON seaice_vice_min              =  -1.1934228724376E-01
-(PID.TID 0000.0001) %MON seaice_vice_mean             =  -2.0869260423667E-03
-(PID.TID 0000.0001) %MON seaice_vice_sd               =   4.8463231065269E-02
-(PID.TID 0000.0001) %MON seaice_vice_del2             =   5.9365278604046E-05
+(PID.TID 0000.0001) %MON seaice_uice_max              =   5.9804249676075E-01
+(PID.TID 0000.0001) %MON seaice_uice_min              =   2.0288596445772E-01
+(PID.TID 0000.0001) %MON seaice_uice_mean             =   4.6423809821367E-01
+(PID.TID 0000.0001) %MON seaice_uice_sd               =   7.8516274025035E-02
+(PID.TID 0000.0001) %MON seaice_uice_del2             =   1.1485102684851E-04
+(PID.TID 0000.0001) %MON seaice_vice_max              =   1.2571562563925E-01
+(PID.TID 0000.0001) %MON seaice_vice_min              =  -1.1931367955632E-01
+(PID.TID 0000.0001) %MON seaice_vice_mean             =  -2.0793454983409E-03
+(PID.TID 0000.0001) %MON seaice_vice_sd               =   4.8451654598116E-02
+(PID.TID 0000.0001) %MON seaice_vice_del2             =   5.9915022021375E-05
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // End MONITOR SEAICE statistics
 (PID.TID 0000.0001) // =======================================================
@@ -2741,86 +2761,86 @@ listId=   1 ; file name: iceStDiag
 (PID.TID 0000.0001) // Begin MONITOR Therm.SeaIce statistics
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) %MON thSI_time_sec                =   9.0000000000000E+03
-(PID.TID 0000.0001) %MON thSI_Ice_Area_G              =   6.9241184998669E+10
-(PID.TID 0000.0001) %MON thSI_Ice_Area_S              =   2.9260057193998E+10
-(PID.TID 0000.0001) %MON thSI_Ice_Area_N              =   3.9981127804671E+10
-(PID.TID 0000.0001) %MON thSI_IceH_ave_G              =   2.0070723303238E-01
-(PID.TID 0000.0001) %MON thSI_IceH_ave_S              =   2.0160297180381E-01
-(PID.TID 0000.0001) %MON thSI_IceH_ave_N              =   2.0005168955168E-01
-(PID.TID 0000.0001) %MON thSI_IceH_max_S              =   2.7554053642010E-01
-(PID.TID 0000.0001) %MON thSI_IceH_max_N              =   2.0126789686398E-01
+(PID.TID 0000.0001) %MON thSI_Ice_Area_G              =   6.9241329971173E+10
+(PID.TID 0000.0001) %MON thSI_Ice_Area_S              =   2.9259997977431E+10
+(PID.TID 0000.0001) %MON thSI_Ice_Area_N              =   3.9981331993741E+10
+(PID.TID 0000.0001) %MON thSI_IceH_ave_G              =   2.0070358346888E-01
+(PID.TID 0000.0001) %MON thSI_IceH_ave_S              =   2.0159891252735E-01
+(PID.TID 0000.0001) %MON thSI_IceH_ave_N              =   2.0004834450775E-01
+(PID.TID 0000.0001) %MON thSI_IceH_max_S              =   2.7658682927254E-01
+(PID.TID 0000.0001) %MON thSI_IceH_max_N              =   2.0127315508117E-01
 (PID.TID 0000.0001) %MON thSI_SnwH_ave_G              =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON thSI_SnwH_ave_S              =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON thSI_SnwH_ave_N              =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON thSI_SnwH_max_S              =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON thSI_SnwH_max_N              =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON thSI_Tsrf_ave_G              =  -2.1828070291845E+00
-(PID.TID 0000.0001) %MON thSI_Tsrf_ave_S              =  -2.1769534876847E+00
-(PID.TID 0000.0001) %MON thSI_Tsrf_ave_N              =  -2.1870909243240E+00
-(PID.TID 0000.0001) %MON thSI_Tsrf_min_S              =  -4.0444559723380E+00
-(PID.TID 0000.0001) %MON thSI_Tsrf_min_N              =  -4.0451483063413E+00
-(PID.TID 0000.0001) %MON thSI_Tsrf_max_S              =  -2.8886249192206E-01
-(PID.TID 0000.0001) %MON thSI_Tsrf_max_N              =  -3.4198572566762E-01
-(PID.TID 0000.0001) %MON thSI_Tic1_ave_G              =  -1.8829368946781E+00
-(PID.TID 0000.0001) %MON thSI_Tic1_ave_S              =  -1.8853900652333E+00
-(PID.TID 0000.0001) %MON thSI_Tic1_ave_N              =  -1.8811276280220E+00
-(PID.TID 0000.0001) %MON thSI_Tic1_min_S              =  -2.5704612754284E+00
-(PID.TID 0000.0001) %MON thSI_Tic1_min_N              =  -2.5704409227865E+00
-(PID.TID 0000.0001) %MON thSI_Tic1_max_S              =  -1.2906441892946E+00
-(PID.TID 0000.0001) %MON thSI_Tic1_max_N              =  -1.2986911710271E+00
-(PID.TID 0000.0001) %MON thSI_Tic2_ave_G              =  -1.6935818863641E+00
-(PID.TID 0000.0001) %MON thSI_Tic2_ave_S              =  -1.6943093864164E+00
-(PID.TID 0000.0001) %MON thSI_Tic2_ave_N              =  -1.6930453392479E+00
-(PID.TID 0000.0001) %MON thSI_Tic2_min_S              =  -1.8528070623051E+00
-(PID.TID 0000.0001) %MON thSI_Tic2_min_N              =  -1.8528036508145E+00
-(PID.TID 0000.0001) %MON thSI_Tic2_max_S              =  -5.8520713961356E-01
-(PID.TID 0000.0001) %MON thSI_Tic2_max_N              =  -1.5550199795551E+00
-(PID.TID 0000.0001) %MON thSI_TotEnerg_G              =  -4.1615849216043E+18
+(PID.TID 0000.0001) %MON thSI_Tsrf_ave_G              =  -2.1857895262030E+00
+(PID.TID 0000.0001) %MON thSI_Tsrf_ave_S              =  -2.1801893707638E+00
+(PID.TID 0000.0001) %MON thSI_Tsrf_ave_N              =  -2.1898879523597E+00
+(PID.TID 0000.0001) %MON thSI_Tsrf_min_S              =  -4.0557317391770E+00
+(PID.TID 0000.0001) %MON thSI_Tsrf_min_N              =  -4.0566016345845E+00
+(PID.TID 0000.0001) %MON thSI_Tsrf_max_S              =  -2.7595195736235E-01
+(PID.TID 0000.0001) %MON thSI_Tsrf_max_N              =  -3.3995554539898E-01
+(PID.TID 0000.0001) %MON thSI_Tic1_ave_G              =  -1.8887637160368E+00
+(PID.TID 0000.0001) %MON thSI_Tic1_ave_S              =  -1.8919624695642E+00
+(PID.TID 0000.0001) %MON thSI_Tic1_ave_N              =  -1.8864045905951E+00
+(PID.TID 0000.0001) %MON thSI_Tic1_min_S              =  -2.5920039700698E+00
+(PID.TID 0000.0001) %MON thSI_Tic1_min_N              =  -2.5919851480787E+00
+(PID.TID 0000.0001) %MON thSI_Tic1_max_S              =  -1.2902352418359E+00
+(PID.TID 0000.0001) %MON thSI_Tic1_max_N              =  -1.2945876887886E+00
+(PID.TID 0000.0001) %MON thSI_Tic2_ave_G              =  -1.6931137864937E+00
+(PID.TID 0000.0001) %MON thSI_Tic2_ave_S              =  -1.6940465026439E+00
+(PID.TID 0000.0001) %MON thSI_Tic2_ave_N              =  -1.6924258952945E+00
+(PID.TID 0000.0001) %MON thSI_Tic2_min_S              =  -1.8543615499512E+00
+(PID.TID 0000.0001) %MON thSI_Tic2_min_N              =  -1.8543571540238E+00
+(PID.TID 0000.0001) %MON thSI_Tic2_max_S              =  -5.6018328935305E-01
+(PID.TID 0000.0001) %MON thSI_Tic2_max_N              =  -1.5530353895910E+00
+(PID.TID 0000.0001) %MON thSI_TotEnerg_G              =  -4.1616355600590E+18
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // End MONITOR Therm.SeaIce statistics
 (PID.TID 0000.0001) // =======================================================
- Compute Stats, Diag. #    224  SI_Fract  vol(   0 ): 2.780E+11  Parms: SM P    M1      
- Compute Stats, Diag. #    225  SI_Thick  vol(   0 ): 2.775E+11  Parms: SM PC   M1      
-    use Counter Mate  #    224  SI_Fract  vol(   0 ): 2.780E+11 integral 2.775E+11
- Compute Stats, Diag. #     26  THETA     vol(   0 ): 2.780E+12  Parms: SMR     MR      
- Compute Stats, Diag. #    227  SI_Tsrf   vol(   0 ): 2.775E+11  Parms: SM  C   M1      
-    use Counter Mate  #    224  SI_Fract  vol(   0 ): 2.780E+11 integral 2.775E+11
- Compute Stats, Diag. #    228  SI_Tice1  vol(   0 ): 2.775E+11  Parms: SM  C   M1      
-    use Counter Mate  #    224  SI_Fract  vol(   0 ): 2.780E+11 integral 2.775E+11
- Compute Stats, Diag. #    229  SI_Tice2  vol(   0 ): 2.775E+11  Parms: SM  C   M1      
-    use Counter Mate  #    224  SI_Fract  vol(   0 ): 2.780E+11 integral 2.775E+11
- Compute Stats, Diag. #    237  SIflx2oc  vol(   0 ): 2.780E+11  Parms: SM      M1      
- Compute Stats, Diag. #    238  SIfrw2oc  vol(   0 ): 2.780E+11  Parms: SM      M1      
- Compute Stats, Diag. #    239  SIsaltFx  vol(   0 ): 2.780E+11  Parms: SM      M1      
- Compute Stats, Diag. #    235  SIflxAtm  vol(   0 ): 2.780E+11  Parms: SM      M1      
- Compute Stats, Diag. #    236  SIfrwAtm  vol(   0 ): 2.780E+11  Parms: SM      M1      
- Compute Stats, Diag. #    226  SI_SnowH  vol(   0 ): 2.775E+11  Parms: SM PC   M1      
-    use Counter Mate  #    224  SI_Fract  vol(   0 ): 2.780E+11 integral 2.775E+11
- Compute Stats, Diag. #    163  SIuice    vol(   0 ): 2.760E+11  Parms: UU      M1      
- Compute Stats, Diag. #    164  SIvice    vol(   0 ): 2.700E+11  Parms: VV      M1      
- SEAICE_LSR: Residual Initial ipass,Uice,Vice=    1  1.65286881E-02  1.32420393E-02
- SEAICE_LSR: Residual FrDrift U_fd,V_fd=  5.83220303E+00  1.43684623E+00
- SEAICE_LSR (ipass=   1) iters,dU,Resid=  1500  7.53712374E-08  7.05272233E-05
- SEAICE_LSR (ipass=   1) iters,dV,Resid=   300  8.91689500E-13  1.29412478E-11
- SEAICE_LSR: Residual Initial ipass,Uice,Vice=    2  1.54050368E-02  1.12975451E-02
- SEAICE_LSR: Residual FrDrift U_fd,V_fd=  6.19390190E+00  1.60761310E+00
- SEAICE_LSR (ipass=   2) iters,dU,Resid=  1500  7.23271565E-08  6.93622821E-05
- SEAICE_LSR (ipass=   2) iters,dV,Resid=   290  9.57053881E-13  1.32909476E-11
+ Compute Stats, Diag. #    226  SI_Fract  vol(   0 ): 5.560E+11  Parms: SM P    M1      
+ Compute Stats, Diag. #    227  SI_Thick  vol(   0 ): 5.550E+11  Parms: SM PC   M1      
+    use Counter Mate  #    226  SI_Fract  vol(   0 ): 5.560E+11 integral 5.550E+11
+ Compute Stats, Diag. #     26  THETA     vol(   0 ): 5.560E+12  Parms: SMR     MR      
+ Compute Stats, Diag. #    229  SI_Tsrf   vol(   0 ): 5.550E+11  Parms: SM  C   M1      
+    use Counter Mate  #    226  SI_Fract  vol(   0 ): 5.560E+11 integral 5.550E+11
+ Compute Stats, Diag. #    230  SI_Tice1  vol(   0 ): 5.550E+11  Parms: SM  C   M1      
+    use Counter Mate  #    226  SI_Fract  vol(   0 ): 5.560E+11 integral 5.550E+11
+ Compute Stats, Diag. #    231  SI_Tice2  vol(   0 ): 5.550E+11  Parms: SM  C   M1      
+    use Counter Mate  #    226  SI_Fract  vol(   0 ): 5.560E+11 integral 5.550E+11
+ Compute Stats, Diag. #    239  SIflx2oc  vol(   0 ): 5.560E+11  Parms: SM      M1      
+ Compute Stats, Diag. #    240  SIfrw2oc  vol(   0 ): 5.560E+11  Parms: SM      M1      
+ Compute Stats, Diag. #    241  SIsaltFx  vol(   0 ): 5.560E+11  Parms: SM      M1      
+ Compute Stats, Diag. #    237  SIflxAtm  vol(   0 ): 5.560E+11  Parms: SM      M1      
+ Compute Stats, Diag. #    238  SIfrwAtm  vol(   0 ): 5.560E+11  Parms: SM      M1      
+ Compute Stats, Diag. #    228  SI_SnowH  vol(   0 ): 5.550E+11  Parms: SM PC   M1      
+    use Counter Mate  #    226  SI_Fract  vol(   0 ): 5.560E+11 integral 5.550E+11
+ Compute Stats, Diag. #    165  SIuice    vol(   0 ): 5.520E+11  Parms: UU      M1      
+ Compute Stats, Diag. #    166  SIvice    vol(   0 ): 5.400E+11  Parms: VV      M1      
+ SEAICE_LSR: Residual Initial ipass,Uice,Vice=         1  1.65039166E-02  1.32573898E-02
+ SEAICE_LSR: Residual FrDrift U_fd,V_fd=  5.84451846E+00  1.44016278E+00
+ SEAICE_LSR (ipass=        1) iters,dU,Resid=     1500  7.55997000E-08  7.08609319E-05
+ SEAICE_LSR (ipass=        1) iters,dV,Resid=      300  9.03319086E-13  1.31059602E-11
+ SEAICE_LSR: Residual Initial ipass,Uice,Vice=         2  1.53774066E-02  1.13017321E-02
+ SEAICE_LSR: Residual FrDrift U_fd,V_fd=  6.20860400E+00  1.61163385E+00
+ SEAICE_LSR (ipass=        2) iters,dU,Resid=     1500  7.23390670E-08  6.93762040E-05
+ SEAICE_LSR (ipass=        2) iters,dV,Resid=      290  9.69072045E-13  1.34573989E-11
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // Begin MONITOR SEAICE statistics
 (PID.TID 0000.0001) // =======================================================
-(PID.TID 0000.0001) %MON seaice_tsnumber              =                     6
+(PID.TID 0000.0001) %MON seaice_tsnumber              =                    12
 (PID.TID 0000.0001) %MON seaice_time_sec              =   1.0800000000000E+04
-(PID.TID 0000.0001) %MON seaice_uice_max              =   6.0271002183890E-01
-(PID.TID 0000.0001) %MON seaice_uice_min              =   2.0325160339660E-01
-(PID.TID 0000.0001) %MON seaice_uice_mean             =   4.6431394904546E-01
-(PID.TID 0000.0001) %MON seaice_uice_sd               =   7.9048235770198E-02
-(PID.TID 0000.0001) %MON seaice_uice_del2             =   1.1657043178640E-04
-(PID.TID 0000.0001) %MON seaice_vice_max              =   1.3233633431919E-01
-(PID.TID 0000.0001) %MON seaice_vice_min              =  -1.2270431313089E-01
-(PID.TID 0000.0001) %MON seaice_vice_mean             =  -1.9919316248966E-03
-(PID.TID 0000.0001) %MON seaice_vice_sd               =   5.0610015476114E-02
-(PID.TID 0000.0001) %MON seaice_vice_del2             =   6.3948850385583E-05
+(PID.TID 0000.0001) %MON seaice_uice_max              =   6.0272989798091E-01
+(PID.TID 0000.0001) %MON seaice_uice_min              =   2.0268649110057E-01
+(PID.TID 0000.0001) %MON seaice_uice_mean             =   4.6429764288548E-01
+(PID.TID 0000.0001) %MON seaice_uice_sd               =   7.9084292541976E-02
+(PID.TID 0000.0001) %MON seaice_uice_del2             =   1.1743857299103E-04
+(PID.TID 0000.0001) %MON seaice_vice_max              =   1.3237997594615E-01
+(PID.TID 0000.0001) %MON seaice_vice_min              =  -1.2270613198675E-01
+(PID.TID 0000.0001) %MON seaice_vice_mean             =  -1.9877666830768E-03
+(PID.TID 0000.0001) %MON seaice_vice_sd               =   5.0607843282868E-02
+(PID.TID 0000.0001) %MON seaice_vice_del2             =   6.4779144790048E-05
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // End MONITOR SEAICE statistics
 (PID.TID 0000.0001) // =======================================================
@@ -2828,67 +2848,67 @@ listId=   1 ; file name: iceStDiag
 (PID.TID 0000.0001) // Begin MONITOR Therm.SeaIce statistics
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) %MON thSI_time_sec                =   1.0800000000000E+04
-(PID.TID 0000.0001) %MON thSI_Ice_Area_G              =   6.9186130767648E+10
-(PID.TID 0000.0001) %MON thSI_Ice_Area_S              =   2.9209406114052E+10
-(PID.TID 0000.0001) %MON thSI_Ice_Area_N              =   3.9976724653596E+10
-(PID.TID 0000.0001) %MON thSI_IceH_ave_G              =   2.0086197155187E-01
-(PID.TID 0000.0001) %MON thSI_IceH_ave_S              =   2.0194983974830E-01
-(PID.TID 0000.0001) %MON thSI_IceH_ave_N              =   2.0006710943589E-01
-(PID.TID 0000.0001) %MON thSI_IceH_max_S              =   2.9109432053516E-01
-(PID.TID 0000.0001) %MON thSI_IceH_max_N              =   2.0149481608594E-01
+(PID.TID 0000.0001) %MON thSI_Ice_Area_G              =   6.9186318841831E+10
+(PID.TID 0000.0001) %MON thSI_Ice_Area_S              =   2.9209333757007E+10
+(PID.TID 0000.0001) %MON thSI_Ice_Area_N              =   3.9976985084824E+10
+(PID.TID 0000.0001) %MON thSI_IceH_ave_G              =   2.0085745616970E-01
+(PID.TID 0000.0001) %MON thSI_IceH_ave_S              =   2.0194479135373E-01
+(PID.TID 0000.0001) %MON thSI_IceH_ave_N              =   2.0006299064839E-01
+(PID.TID 0000.0001) %MON thSI_IceH_max_S              =   2.9244142660767E-01
+(PID.TID 0000.0001) %MON thSI_IceH_max_N              =   2.0149646652779E-01
 (PID.TID 0000.0001) %MON thSI_SnwH_ave_G              =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON thSI_SnwH_ave_S              =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON thSI_SnwH_ave_N              =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON thSI_SnwH_max_S              =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON thSI_SnwH_max_N              =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON thSI_Tsrf_ave_G              =  -2.2018112933445E+00
-(PID.TID 0000.0001) %MON thSI_Tsrf_ave_S              =  -2.1954033108485E+00
-(PID.TID 0000.0001) %MON thSI_Tsrf_ave_N              =  -2.2064933518352E+00
-(PID.TID 0000.0001) %MON thSI_Tsrf_min_S              =  -4.1272069328350E+00
-(PID.TID 0000.0001) %MON thSI_Tsrf_min_N              =  -4.1281410834954E+00
-(PID.TID 0000.0001) %MON thSI_Tsrf_max_S              =  -2.4530759663426E-01
-(PID.TID 0000.0001) %MON thSI_Tsrf_max_N              =  -3.1588424803268E-01
-(PID.TID 0000.0001) %MON thSI_Tic1_ave_G              =  -1.9200127961011E+00
-(PID.TID 0000.0001) %MON thSI_Tic1_ave_S              =  -1.9232697185370E+00
-(PID.TID 0000.0001) %MON thSI_Tic1_ave_N              =  -1.9176106979478E+00
-(PID.TID 0000.0001) %MON thSI_Tic1_min_S              =  -2.7286443096108E+00
-(PID.TID 0000.0001) %MON thSI_Tic1_min_N              =  -2.7286098861134E+00
-(PID.TID 0000.0001) %MON thSI_Tic1_max_S              =  -1.2245486015227E+00
-(PID.TID 0000.0001) %MON thSI_Tic1_max_N              =  -1.2458530284538E+00
-(PID.TID 0000.0001) %MON thSI_Tic2_ave_G              =  -1.7033247288949E+00
-(PID.TID 0000.0001) %MON thSI_Tic2_ave_S              =  -1.7043908417704E+00
-(PID.TID 0000.0001) %MON thSI_Tic2_ave_N              =  -1.7025384320703E+00
-(PID.TID 0000.0001) %MON thSI_Tic2_min_S              =  -1.9028328908369E+00
-(PID.TID 0000.0001) %MON thSI_Tic2_min_N              =  -1.9028233756374E+00
-(PID.TID 0000.0001) %MON thSI_Tic2_max_S              =  -5.2024678094934E-01
-(PID.TID 0000.0001) %MON thSI_Tic2_max_N              =  -1.5331293703025E+00
-(PID.TID 0000.0001) %MON thSI_TotEnerg_G              =  -4.1621020509718E+18
+(PID.TID 0000.0001) %MON thSI_Tsrf_ave_G              =  -2.2053185097194E+00
+(PID.TID 0000.0001) %MON thSI_Tsrf_ave_S              =  -2.1992427996829E+00
+(PID.TID 0000.0001) %MON thSI_Tsrf_ave_N              =  -2.2097577499944E+00
+(PID.TID 0000.0001) %MON thSI_Tsrf_min_S              =  -4.1402151774893E+00
+(PID.TID 0000.0001) %MON thSI_Tsrf_min_N              =  -4.1412788315055E+00
+(PID.TID 0000.0001) %MON thSI_Tsrf_max_S              =  -2.3365569560822E-01
+(PID.TID 0000.0001) %MON thSI_Tsrf_max_N              =  -3.1379494691207E-01
+(PID.TID 0000.0001) %MON thSI_Tic1_ave_G              =  -1.9268078043763E+00
+(PID.TID 0000.0001) %MON thSI_Tic1_ave_S              =  -1.9309195073691E+00
+(PID.TID 0000.0001) %MON thSI_Tic1_ave_N              =  -1.9237753152757E+00
+(PID.TID 0000.0001) %MON thSI_Tic1_min_S              =  -2.7534614374722E+00
+(PID.TID 0000.0001) %MON thSI_Tic1_min_N              =  -2.7534329443252E+00
+(PID.TID 0000.0001) %MON thSI_Tic1_max_S              =  -1.2235710556563E+00
+(PID.TID 0000.0001) %MON thSI_Tic1_max_N              =  -1.2416067129471E+00
+(PID.TID 0000.0001) %MON thSI_Tic2_ave_G              =  -1.7037063503453E+00
+(PID.TID 0000.0001) %MON thSI_Tic2_ave_S              =  -1.7050298396926E+00
+(PID.TID 0000.0001) %MON thSI_Tic2_ave_N              =  -1.7027302421421E+00
+(PID.TID 0000.0001) %MON thSI_Tic2_min_S              =  -1.9068103206369E+00
+(PID.TID 0000.0001) %MON thSI_Tic2_min_N              =  -1.9068010820486E+00
+(PID.TID 0000.0001) %MON thSI_Tic2_max_S              =  -5.0134920610812E-01
+(PID.TID 0000.0001) %MON thSI_Tic2_max_N              =  -1.5309576805998E+00
+(PID.TID 0000.0001) %MON thSI_TotEnerg_G              =  -4.1621551182925E+18
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // End MONITOR Therm.SeaIce statistics
 (PID.TID 0000.0001) // =======================================================
- SEAICE_LSR: Residual Initial ipass,Uice,Vice=    1  1.43895331E-02  1.08581144E-02
- SEAICE_LSR: Residual FrDrift U_fd,V_fd=  7.22402898E+00  1.99239410E+00
- SEAICE_LSR (ipass=   1) iters,dU,Resid=  1500  7.24478084E-08  9.94218690E-05
- SEAICE_LSR (ipass=   1) iters,dV,Resid=   286  9.93281846E-13  1.34111800E-11
- SEAICE_LSR: Residual Initial ipass,Uice,Vice=    2  1.33307215E-02  9.65750596E-03
- SEAICE_LSR: Residual FrDrift U_fd,V_fd=  7.86985072E+00  2.20981877E+00
- SEAICE_LSR (ipass=   2) iters,dU,Resid=  1500  5.19661792E-08  6.88334983E-05
- SEAICE_LSR (ipass=   2) iters,dV,Resid=   278  9.05490960E-13  1.18792542E-11
+ SEAICE_LSR: Residual Initial ipass,Uice,Vice=         1  1.44401064E-02  1.08624927E-02
+ SEAICE_LSR: Residual FrDrift U_fd,V_fd=  7.23988495E+00  1.99879352E+00
+ SEAICE_LSR (ipass=        1) iters,dU,Resid=     1500  7.32915121E-08  1.00284203E-04
+ SEAICE_LSR (ipass=        1) iters,dV,Resid=      288  8.84903262E-13  1.19703342E-11
+ SEAICE_LSR: Residual Initial ipass,Uice,Vice=         2  1.33704452E-02  9.65874887E-03
+ SEAICE_LSR: Residual FrDrift U_fd,V_fd=  7.88075353E+00  2.21624733E+00
+ SEAICE_LSR (ipass=        2) iters,dU,Resid=     1500  5.20356076E-08  6.88883739E-05
+ SEAICE_LSR (ipass=        2) iters,dV,Resid=      278  9.16836052E-13  1.20255348E-11
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // Begin MONITOR SEAICE statistics
 (PID.TID 0000.0001) // =======================================================
-(PID.TID 0000.0001) %MON seaice_tsnumber              =                     7
+(PID.TID 0000.0001) %MON seaice_tsnumber              =                    14
 (PID.TID 0000.0001) %MON seaice_time_sec              =   1.2600000000000E+04
-(PID.TID 0000.0001) %MON seaice_uice_max              =   6.0594743637505E-01
-(PID.TID 0000.0001) %MON seaice_uice_min              =   1.9668666055706E-01
-(PID.TID 0000.0001) %MON seaice_uice_mean             =   4.6420048691356E-01
-(PID.TID 0000.0001) %MON seaice_uice_sd               =   7.9611559624848E-02
-(PID.TID 0000.0001) %MON seaice_uice_del2             =   1.2108781999301E-04
-(PID.TID 0000.0001) %MON seaice_vice_max              =   1.4142700823969E-01
-(PID.TID 0000.0001) %MON seaice_vice_min              =  -1.2457470571817E-01
-(PID.TID 0000.0001) %MON seaice_vice_mean             =  -1.8372083919213E-03
-(PID.TID 0000.0001) %MON seaice_vice_sd               =   5.1777139670197E-02
-(PID.TID 0000.0001) %MON seaice_vice_del2             =   7.0902580281430E-05
+(PID.TID 0000.0001) %MON seaice_uice_max              =   6.0597832719700E-01
+(PID.TID 0000.0001) %MON seaice_uice_min              =   1.9587160155422E-01
+(PID.TID 0000.0001) %MON seaice_uice_mean             =   4.6417954781457E-01
+(PID.TID 0000.0001) %MON seaice_uice_sd               =   7.9660020906589E-02
+(PID.TID 0000.0001) %MON seaice_uice_del2             =   1.2249909167169E-04
+(PID.TID 0000.0001) %MON seaice_vice_max              =   1.4175339456169E-01
+(PID.TID 0000.0001) %MON seaice_vice_min              =  -1.2460343548074E-01
+(PID.TID 0000.0001) %MON seaice_vice_mean             =  -1.8355017971547E-03
+(PID.TID 0000.0001) %MON seaice_vice_sd               =   5.1779694171590E-02
+(PID.TID 0000.0001) %MON seaice_vice_del2             =   7.2272692353903E-05
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // End MONITOR SEAICE statistics
 (PID.TID 0000.0001) // =======================================================
@@ -2896,67 +2916,67 @@ listId=   1 ; file name: iceStDiag
 (PID.TID 0000.0001) // Begin MONITOR Therm.SeaIce statistics
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) %MON thSI_time_sec                =   1.2600000000000E+04
-(PID.TID 0000.0001) %MON thSI_Ice_Area_G              =   6.9131362123586E+10
-(PID.TID 0000.0001) %MON thSI_Ice_Area_S              =   2.9159262909910E+10
-(PID.TID 0000.0001) %MON thSI_Ice_Area_N              =   3.9972099213676E+10
-(PID.TID 0000.0001) %MON thSI_IceH_ave_G              =   2.0101815601741E-01
-(PID.TID 0000.0001) %MON thSI_IceH_ave_S              =   2.0229593826690E-01
-(PID.TID 0000.0001) %MON thSI_IceH_ave_N              =   2.0008602612462E-01
-(PID.TID 0000.0001) %MON thSI_IceH_max_S              =   3.0477977254317E-01
-(PID.TID 0000.0001) %MON thSI_IceH_max_N              =   2.0176326792403E-01
+(PID.TID 0000.0001) %MON thSI_Ice_Area_G              =   6.9131585353562E+10
+(PID.TID 0000.0001) %MON thSI_Ice_Area_S              =   2.9159178085501E+10
+(PID.TID 0000.0001) %MON thSI_Ice_Area_N              =   3.9972407268061E+10
+(PID.TID 0000.0001) %MON thSI_IceH_ave_G              =   2.0101296534554E-01
+(PID.TID 0000.0001) %MON thSI_IceH_ave_S              =   2.0229009658511E-01
+(PID.TID 0000.0001) %MON thSI_IceH_ave_N              =   2.0008132024837E-01
+(PID.TID 0000.0001) %MON thSI_IceH_max_S              =   3.0637956073484E-01
+(PID.TID 0000.0001) %MON thSI_IceH_max_N              =   2.0177252799137E-01
 (PID.TID 0000.0001) %MON thSI_SnwH_ave_G              =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON thSI_SnwH_ave_S              =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON thSI_SnwH_ave_N              =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON thSI_SnwH_max_S              =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON thSI_SnwH_max_N              =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON thSI_Tsrf_ave_G              =  -2.2196341655256E+00
-(PID.TID 0000.0001) %MON thSI_Tsrf_ave_S              =  -2.2126799808244E+00
-(PID.TID 0000.0001) %MON thSI_Tsrf_ave_N              =  -2.2247071765512E+00
-(PID.TID 0000.0001) %MON thSI_Tsrf_min_S              =  -4.2038178906114E+00
-(PID.TID 0000.0001) %MON thSI_Tsrf_min_N              =  -4.2049009781240E+00
-(PID.TID 0000.0001) %MON thSI_Tsrf_max_S              =  -2.0748315029443E-01
-(PID.TID 0000.0001) %MON thSI_Tsrf_max_N              =  -2.9258225453245E-01
-(PID.TID 0000.0001) %MON thSI_Tic1_ave_G              =  -1.9547416864288E+00
-(PID.TID 0000.0001) %MON thSI_Tic1_ave_S              =  -1.9586654698600E+00
-(PID.TID 0000.0001) %MON thSI_Tic1_ave_N              =  -1.9518477098094E+00
-(PID.TID 0000.0001) %MON thSI_Tic1_min_S              =  -2.8748583757378E+00
-(PID.TID 0000.0001) %MON thSI_Tic1_min_N              =  -2.8748005746758E+00
-(PID.TID 0000.0001) %MON thSI_Tic1_max_S              =  -1.1643315220594E+00
-(PID.TID 0000.0001) %MON thSI_Tic1_max_N              =  -1.1986382393090E+00
-(PID.TID 0000.0001) %MON thSI_Tic2_ave_G              =  -1.7137364331147E+00
-(PID.TID 0000.0001) %MON thSI_Tic2_ave_S              =  -1.7151380947746E+00
-(PID.TID 0000.0001) %MON thSI_Tic2_ave_N              =  -1.7127026410762E+00
-(PID.TID 0000.0001) %MON thSI_Tic2_min_S              =  -1.9523396082997E+00
-(PID.TID 0000.0001) %MON thSI_Tic2_min_N              =  -1.9523203655224E+00
-(PID.TID 0000.0001) %MON thSI_Tic2_max_S              =  -4.7177400602053E-01
-(PID.TID 0000.0001) %MON thSI_Tic2_max_N              =  -1.5134940096244E+00
-(PID.TID 0000.0001) %MON thSI_TotEnerg_G              =  -4.1625204413235E+18
+(PID.TID 0000.0001) %MON thSI_Tsrf_ave_G              =  -2.2235576907135E+00
+(PID.TID 0000.0001) %MON thSI_Tsrf_ave_S              =  -2.2169992162156E+00
+(PID.TID 0000.0001) %MON thSI_Tsrf_ave_N              =  -2.2283419841530E+00
+(PID.TID 0000.0001) %MON thSI_Tsrf_min_S              =  -4.2181336951722E+00
+(PID.TID 0000.0001) %MON thSI_Tsrf_min_N              =  -4.2193106898588E+00
+(PID.TID 0000.0001) %MON thSI_Tsrf_max_S              =  -1.9708417624625E-01
+(PID.TID 0000.0001) %MON thSI_Tsrf_max_N              =  -2.9046782023017E-01
+(PID.TID 0000.0001) %MON thSI_Tic1_ave_G              =  -1.9623009740336E+00
+(PID.TID 0000.0001) %MON thSI_Tic1_ave_S              =  -1.9671645003117E+00
+(PID.TID 0000.0001) %MON thSI_Tic1_ave_N              =  -1.9587139497344E+00
+(PID.TID 0000.0001) %MON thSI_Tic1_min_S              =  -2.9021317150885E+00
+(PID.TID 0000.0001) %MON thSI_Tic1_min_N              =  -2.9020866166180E+00
+(PID.TID 0000.0001) %MON thSI_Tic1_max_S              =  -1.1629765915039E+00
+(PID.TID 0000.0001) %MON thSI_Tic1_max_N              =  -1.1943270438412E+00
+(PID.TID 0000.0001) %MON thSI_Tic2_ave_G              =  -1.7148663811638E+00
+(PID.TID 0000.0001) %MON thSI_Tic2_ave_S              =  -1.7165726377178E+00
+(PID.TID 0000.0001) %MON thSI_Tic2_ave_N              =  -1.7136079560275E+00
+(PID.TID 0000.0001) %MON thSI_Tic2_min_S              =  -1.9584333906790E+00
+(PID.TID 0000.0001) %MON thSI_Tic2_min_N              =  -1.9584168842558E+00
+(PID.TID 0000.0001) %MON thSI_Tic2_max_S              =  -4.5774717131947E-01
+(PID.TID 0000.0001) %MON thSI_Tic2_max_N              =  -1.5112385201009E+00
+(PID.TID 0000.0001) %MON thSI_TotEnerg_G              =  -4.1625727935927E+18
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // End MONITOR Therm.SeaIce statistics
 (PID.TID 0000.0001) // =======================================================
- SEAICE_LSR: Residual Initial ipass,Uice,Vice=    1  1.32839981E-02  9.92624199E-03
- SEAICE_LSR: Residual FrDrift U_fd,V_fd=  9.53642241E+00  2.71093488E+00
- SEAICE_LSR (ipass=   1) iters,dU,Resid=  1500  8.17123634E-08  1.04704329E-04
- SEAICE_LSR (ipass=   1) iters,dV,Resid=   280  8.82863227E-13  1.14189873E-11
- SEAICE_LSR: Residual Initial ipass,Uice,Vice=    2  1.23308519E-02  9.01141463E-03
- SEAICE_LSR: Residual FrDrift U_fd,V_fd=  1.03926360E+01  2.84049552E+00
- SEAICE_LSR (ipass=   2) iters,dU,Resid=  1500  3.46436493E-08  5.76068614E-05
- SEAICE_LSR (ipass=   2) iters,dV,Resid=   270  8.88317198E-13  1.12647777E-11
+ SEAICE_LSR: Residual Initial ipass,Uice,Vice=         1  1.33984080E-02  9.91979500E-03
+ SEAICE_LSR: Residual FrDrift U_fd,V_fd=  9.50521764E+00  2.71432983E+00
+ SEAICE_LSR (ipass=        1) iters,dU,Resid=     1500  8.25946989E-08  1.05814487E-04
+ SEAICE_LSR (ipass=        1) iters,dV,Resid=      280  8.94333219E-13  1.15616658E-11
+ SEAICE_LSR: Residual Initial ipass,Uice,Vice=         2  1.24349093E-02  9.00398432E-03
+ SEAICE_LSR: Residual FrDrift U_fd,V_fd=  1.03150195E+01  2.84081135E+00
+ SEAICE_LSR (ipass=        2) iters,dU,Resid=     1500  3.46322855E-08  5.76843390E-05
+ SEAICE_LSR (ipass=        2) iters,dV,Resid=      270  8.97733277E-13  1.13794136E-11
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // Begin MONITOR SEAICE statistics
 (PID.TID 0000.0001) // =======================================================
-(PID.TID 0000.0001) %MON seaice_tsnumber              =                     8
+(PID.TID 0000.0001) %MON seaice_tsnumber              =                    16
 (PID.TID 0000.0001) %MON seaice_time_sec              =   1.4400000000000E+04
-(PID.TID 0000.0001) %MON seaice_uice_max              =   6.0858542498772E-01
-(PID.TID 0000.0001) %MON seaice_uice_min              =   1.8564872747978E-01
-(PID.TID 0000.0001) %MON seaice_uice_mean             =   4.6402672565373E-01
-(PID.TID 0000.0001) %MON seaice_uice_sd               =   8.0214773739535E-02
-(PID.TID 0000.0001) %MON seaice_uice_del2             =   1.2677124170441E-04
-(PID.TID 0000.0001) %MON seaice_vice_max              =   1.4982412770843E-01
-(PID.TID 0000.0001) %MON seaice_vice_min              =  -1.2593345052758E-01
-(PID.TID 0000.0001) %MON seaice_vice_mean             =  -1.6771675316785E-03
-(PID.TID 0000.0001) %MON seaice_vice_sd               =   5.2568960930114E-02
-(PID.TID 0000.0001) %MON seaice_vice_del2             =   7.9974819061584E-05
+(PID.TID 0000.0001) %MON seaice_uice_max              =   6.0861899485746E-01
+(PID.TID 0000.0001) %MON seaice_uice_min              =   1.8465289478520E-01
+(PID.TID 0000.0001) %MON seaice_uice_mean             =   4.6400141408549E-01
+(PID.TID 0000.0001) %MON seaice_uice_sd               =   8.0276309223622E-02
+(PID.TID 0000.0001) %MON seaice_uice_del2             =   1.2879213720739E-04
+(PID.TID 0000.0001) %MON seaice_vice_max              =   1.5020803676210E-01
+(PID.TID 0000.0001) %MON seaice_vice_min              =  -1.2597919963047E-01
+(PID.TID 0000.0001) %MON seaice_vice_mean             =  -1.6780796309721E-03
+(PID.TID 0000.0001) %MON seaice_vice_sd               =   5.2571749568313E-02
+(PID.TID 0000.0001) %MON seaice_vice_del2             =   8.1651092192841E-05
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // End MONITOR SEAICE statistics
 (PID.TID 0000.0001) // =======================================================
@@ -2964,67 +2984,67 @@ listId=   1 ; file name: iceStDiag
 (PID.TID 0000.0001) // Begin MONITOR Therm.SeaIce statistics
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) %MON thSI_time_sec                =   1.4400000000000E+04
-(PID.TID 0000.0001) %MON thSI_Ice_Area_G              =   6.9076741820902E+10
-(PID.TID 0000.0001) %MON thSI_Ice_Area_S              =   2.9109471420227E+10
-(PID.TID 0000.0001) %MON thSI_Ice_Area_N              =   3.9967270400676E+10
-(PID.TID 0000.0001) %MON thSI_IceH_ave_G              =   2.0117620531205E-01
-(PID.TID 0000.0001) %MON thSI_IceH_ave_S              =   2.0264229591747E-01
-(PID.TID 0000.0001) %MON thSI_IceH_ave_N              =   2.0010840352949E-01
-(PID.TID 0000.0001) %MON thSI_IceH_max_S              =   3.1692742967036E-01
-(PID.TID 0000.0001) %MON thSI_IceH_max_N              =   2.0205659702328E-01
+(PID.TID 0000.0001) %MON thSI_Ice_Area_G              =   6.9076991480584E+10
+(PID.TID 0000.0001) %MON thSI_Ice_Area_S              =   2.9109374378608E+10
+(PID.TID 0000.0001) %MON thSI_Ice_Area_N              =   3.9967617101976E+10
+(PID.TID 0000.0001) %MON thSI_IceH_ave_G              =   2.0117053419963E-01
+(PID.TID 0000.0001) %MON thSI_IceH_ave_S              =   2.0263586865935E-01
+(PID.TID 0000.0001) %MON thSI_IceH_ave_N              =   2.0010329595851E-01
+(PID.TID 0000.0001) %MON thSI_IceH_max_S              =   3.1872326905373E-01
+(PID.TID 0000.0001) %MON thSI_IceH_max_N              =   2.0206336383271E-01
 (PID.TID 0000.0001) %MON thSI_SnwH_ave_G              =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON thSI_SnwH_ave_S              =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON thSI_SnwH_ave_N              =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON thSI_SnwH_max_S              =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON thSI_SnwH_max_N              =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON thSI_Tsrf_ave_G              =  -2.2359954691800E+00
-(PID.TID 0000.0001) %MON thSI_Tsrf_ave_S              =  -2.2284564592520E+00
-(PID.TID 0000.0001) %MON thSI_Tsrf_ave_N              =  -2.2414863769110E+00
-(PID.TID 0000.0001) %MON thSI_Tsrf_min_S              =  -4.2736669602223E+00
-(PID.TID 0000.0001) %MON thSI_Tsrf_min_N              =  -4.2748436426499E+00
-(PID.TID 0000.0001) %MON thSI_Tsrf_max_S              =  -1.7465400952675E-01
-(PID.TID 0000.0001) %MON thSI_Tsrf_max_N              =  -2.7163626575909E-01
-(PID.TID 0000.0001) %MON thSI_Tic1_ave_G              =  -1.9866173586171E+00
-(PID.TID 0000.0001) %MON thSI_Tic1_ave_S              =  -1.9910205180916E+00
-(PID.TID 0000.0001) %MON thSI_Tic1_ave_N              =  -1.9833697849151E+00
-(PID.TID 0000.0001) %MON thSI_Tic1_min_S              =  -3.0079621185142E+00
-(PID.TID 0000.0001) %MON thSI_Tic1_min_N              =  -3.0078681490686E+00
-(PID.TID 0000.0001) %MON thSI_Tic1_max_S              =  -1.1094854920328E+00
-(PID.TID 0000.0001) %MON thSI_Tic1_max_N              =  -1.1561730446095E+00
-(PID.TID 0000.0001) %MON thSI_Tic2_ave_G              =  -1.7242207637134E+00
-(PID.TID 0000.0001) %MON thSI_Tic2_ave_S              =  -1.7259292055387E+00
-(PID.TID 0000.0001) %MON thSI_Tic2_ave_N              =  -1.7229606933536E+00
-(PID.TID 0000.0001) %MON thSI_Tic2_min_S              =  -1.9999063687280E+00
-(PID.TID 0000.0001) %MON thSI_Tic2_min_N              =  -1.9998729531211E+00
-(PID.TID 0000.0001) %MON thSI_Tic2_max_S              =  -4.3438233865282E-01
-(PID.TID 0000.0001) %MON thSI_Tic2_max_N              =  -1.4958683318289E+00
-(PID.TID 0000.0001) %MON thSI_TotEnerg_G              =  -4.1628469915727E+18
+(PID.TID 0000.0001) %MON thSI_Tsrf_ave_G              =  -2.2402165136845E+00
+(PID.TID 0000.0001) %MON thSI_Tsrf_ave_S              =  -2.2331219533384E+00
+(PID.TID 0000.0001) %MON thSI_Tsrf_ave_N              =  -2.2453836521867E+00
+(PID.TID 0000.0001) %MON thSI_Tsrf_min_S              =  -4.2888436550018E+00
+(PID.TID 0000.0001) %MON thSI_Tsrf_min_N              =  -4.2900945489297E+00
+(PID.TID 0000.0001) %MON thSI_Tsrf_max_S              =  -1.6542286360969E-01
+(PID.TID 0000.0001) %MON thSI_Tsrf_max_N              =  -2.6952108277852E-01
+(PID.TID 0000.0001) %MON thSI_Tic1_ave_G              =  -1.9947176528851E+00
+(PID.TID 0000.0001) %MON thSI_Tic1_ave_S              =  -2.0001217702152E+00
+(PID.TID 0000.0001) %MON thSI_Tic1_ave_N              =  -1.9907318899383E+00
+(PID.TID 0000.0001) %MON thSI_Tic1_min_S              =  -3.0368366562233E+00
+(PID.TID 0000.0001) %MON thSI_Tic1_min_N              =  -3.0367667873003E+00
+(PID.TID 0000.0001) %MON thSI_Tic1_max_S              =  -1.1078963442638E+00
+(PID.TID 0000.0001) %MON thSI_Tic1_max_N              =  -1.1518493817367E+00
+(PID.TID 0000.0001) %MON thSI_Tic2_ave_G              =  -1.7259697237073E+00
+(PID.TID 0000.0001) %MON thSI_Tic2_ave_S              =  -1.7280228790905E+00
+(PID.TID 0000.0001) %MON thSI_Tic2_ave_N              =  -1.7244554355913E+00
+(PID.TID 0000.0001) %MON thSI_Tic2_min_S              =  -2.0077224070628E+00
+(PID.TID 0000.0001) %MON thSI_Tic2_min_N              =  -2.0076957471264E+00
+(PID.TID 0000.0001) %MON thSI_Tic2_max_S              =  -4.2405007698369E-01
+(PID.TID 0000.0001) %MON thSI_Tic2_max_N              =  -1.4936011181381E+00
+(PID.TID 0000.0001) %MON thSI_TotEnerg_G              =  -4.1628957160545E+18
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // End MONITOR Therm.SeaIce statistics
 (PID.TID 0000.0001) // =======================================================
- SEAICE_LSR: Residual Initial ipass,Uice,Vice=    1  1.24954112E-02  8.93029391E-03
- SEAICE_LSR: Residual FrDrift U_fd,V_fd=  1.48169248E+01  3.04014438E+00
- SEAICE_LSR (ipass=   1) iters,dU,Resid=  1500  8.20876211E-08  1.02912158E-04
- SEAICE_LSR (ipass=   1) iters,dV,Resid=   274  9.24357813E-13  1.15448612E-11
- SEAICE_LSR: Residual Initial ipass,Uice,Vice=    2  1.16660157E-02  8.55093894E-03
- SEAICE_LSR: Residual FrDrift U_fd,V_fd=  1.92634011E+01  3.13144751E+00
- SEAICE_LSR (ipass=   2) iters,dU,Resid=  1500  2.76194321E-08  4.35057217E-05
- SEAICE_LSR (ipass=   2) iters,dV,Resid=   264  9.09466946E-13  1.12037791E-11
+ SEAICE_LSR: Residual Initial ipass,Uice,Vice=         1  1.26440309E-02  8.90616931E-03
+ SEAICE_LSR: Residual FrDrift U_fd,V_fd=  1.43290646E+01  3.02912731E+00
+ SEAICE_LSR (ipass=        1) iters,dU,Resid=     1500  8.28755621E-08  1.04026361E-04
+ SEAICE_LSR (ipass=        1) iters,dV,Resid=      274  9.35494737E-13  1.16779547E-11
+ SEAICE_LSR: Residual Initial ipass,Uice,Vice=         2  1.18104256E-02  8.51066199E-03
+ SEAICE_LSR: Residual FrDrift U_fd,V_fd=  1.83322157E+01  3.10025392E+00
+ SEAICE_LSR (ipass=        2) iters,dU,Resid=     1500  2.75245828E-08  4.35072852E-05
+ SEAICE_LSR (ipass=        2) iters,dV,Resid=      264  9.17058096E-13  1.12912132E-11
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // Begin MONITOR SEAICE statistics
 (PID.TID 0000.0001) // =======================================================
-(PID.TID 0000.0001) %MON seaice_tsnumber              =                     9
+(PID.TID 0000.0001) %MON seaice_tsnumber              =                    18
 (PID.TID 0000.0001) %MON seaice_time_sec              =   1.6200000000000E+04
-(PID.TID 0000.0001) %MON seaice_uice_max              =   6.1077959402359E-01
-(PID.TID 0000.0001) %MON seaice_uice_min              =   1.7035467791643E-01
-(PID.TID 0000.0001) %MON seaice_uice_mean             =   4.6382991153608E-01
-(PID.TID 0000.0001) %MON seaice_uice_sd               =   8.0851969050731E-02
-(PID.TID 0000.0001) %MON seaice_uice_del2             =   1.3292257116359E-04
-(PID.TID 0000.0001) %MON seaice_vice_max              =   1.5688883378583E-01
-(PID.TID 0000.0001) %MON seaice_vice_min              =  -1.2732849329198E-01
-(PID.TID 0000.0001) %MON seaice_vice_mean             =  -1.5338594318180E-03
-(PID.TID 0000.0001) %MON seaice_vice_sd               =   5.3184105029352E-02
-(PID.TID 0000.0001) %MON seaice_vice_del2             =   8.9503900221658E-05
+(PID.TID 0000.0001) %MON seaice_uice_max              =   6.1081222663487E-01
+(PID.TID 0000.0001) %MON seaice_uice_min              =   1.6918403711525E-01
+(PID.TID 0000.0001) %MON seaice_uice_mean             =   4.6380069143378E-01
+(PID.TID 0000.0001) %MON seaice_uice_sd               =   8.0927166633950E-02
+(PID.TID 0000.0001) %MON seaice_uice_del2             =   1.3547840774025E-04
+(PID.TID 0000.0001) %MON seaice_vice_max              =   1.5731286048729E-01
+(PID.TID 0000.0001) %MON seaice_vice_min              =  -1.2741542456306E-01
+(PID.TID 0000.0001) %MON seaice_vice_mean             =  -1.5374913369231E-03
+(PID.TID 0000.0001) %MON seaice_vice_sd               =   5.3182199101814E-02
+(PID.TID 0000.0001) %MON seaice_vice_del2             =   9.1211432762648E-05
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // End MONITOR SEAICE statistics
 (PID.TID 0000.0001) // =======================================================
@@ -3032,86 +3052,86 @@ listId=   1 ; file name: iceStDiag
 (PID.TID 0000.0001) // Begin MONITOR Therm.SeaIce statistics
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) %MON thSI_time_sec                =   1.6200000000000E+04
-(PID.TID 0000.0001) %MON thSI_Ice_Area_G              =   6.9022188701181E+10
-(PID.TID 0000.0001) %MON thSI_Ice_Area_S              =   2.9059960123102E+10
-(PID.TID 0000.0001) %MON thSI_Ice_Area_N              =   3.9962228578079E+10
-(PID.TID 0000.0001) %MON thSI_IceH_ave_G              =   2.0133627404359E-01
-(PID.TID 0000.0001) %MON thSI_IceH_ave_S              =   2.0298936539525E-01
-(PID.TID 0000.0001) %MON thSI_IceH_ave_N              =   2.0013416969486E-01
-(PID.TID 0000.0001) %MON thSI_IceH_max_S              =   3.2786423728301E-01
-(PID.TID 0000.0001) %MON thSI_IceH_max_N              =   2.0237081943745E-01
+(PID.TID 0000.0001) %MON thSI_Ice_Area_G              =   6.9022455187348E+10
+(PID.TID 0000.0001) %MON thSI_Ice_Area_S              =   2.9059849370683E+10
+(PID.TID 0000.0001) %MON thSI_Ice_Area_N              =   3.9962605816665E+10
+(PID.TID 0000.0001) %MON thSI_IceH_ave_G              =   2.0133030834318E-01
+(PID.TID 0000.0001) %MON thSI_IceH_ave_S              =   2.0298256465531E-01
+(PID.TID 0000.0001) %MON thSI_IceH_ave_N              =   2.0012882714416E-01
+(PID.TID 0000.0001) %MON thSI_IceH_max_S              =   3.2980568938115E-01
+(PID.TID 0000.0001) %MON thSI_IceH_max_N              =   2.0237339473992E-01
 (PID.TID 0000.0001) %MON thSI_SnwH_ave_G              =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON thSI_SnwH_ave_S              =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON thSI_SnwH_ave_N              =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON thSI_SnwH_max_S              =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON thSI_SnwH_max_N              =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON thSI_Tsrf_ave_G              =  -2.2507405435278E+00
-(PID.TID 0000.0001) %MON thSI_Tsrf_ave_S              =  -2.2425496316426E+00
-(PID.TID 0000.0001) %MON thSI_Tsrf_ave_N              =  -2.2566968573076E+00
-(PID.TID 0000.0001) %MON thSI_Tsrf_min_S              =  -4.3365397959956E+00
-(PID.TID 0000.0001) %MON thSI_Tsrf_min_N              =  -4.3377862447673E+00
-(PID.TID 0000.0001) %MON thSI_Tsrf_max_S              =  -1.4610107131034E-01
-(PID.TID 0000.0001) %MON thSI_Tsrf_max_N              =  -2.5269527253841E-01
-(PID.TID 0000.0001) %MON thSI_Tic1_ave_G              =  -2.0153685012717E+00
-(PID.TID 0000.0001) %MON thSI_Tic1_ave_S              =  -2.0200367289189E+00
-(PID.TID 0000.0001) %MON thSI_Tic1_ave_N              =  -2.0119254032814E+00
-(PID.TID 0000.0001) %MON thSI_Tic1_min_S              =  -3.1275923072412E+00
-(PID.TID 0000.0001) %MON thSI_Tic1_min_N              =  -3.1274479286559E+00
-(PID.TID 0000.0001) %MON thSI_Tic1_max_S              =  -1.0594677728930E+00
-(PID.TID 0000.0001) %MON thSI_Tic1_max_N              =  -1.1177572688673E+00
-(PID.TID 0000.0001) %MON thSI_Tic2_ave_G              =  -1.7343676254975E+00
-(PID.TID 0000.0001) %MON thSI_Tic2_ave_S              =  -1.7363350773535E+00
-(PID.TID 0000.0001) %MON thSI_Tic2_ave_N              =  -1.7329165117038E+00
-(PID.TID 0000.0001) %MON thSI_Tic2_min_S              =  -2.0445916532890E+00
-(PID.TID 0000.0001) %MON thSI_Tic2_min_N              =  -2.0445390420582E+00
-(PID.TID 0000.0001) %MON thSI_Tic2_max_S              =  -4.0459247146516E-01
-(PID.TID 0000.0001) %MON thSI_Tic2_max_N              =  -1.4800111932061E+00
-(PID.TID 0000.0001) %MON thSI_TotEnerg_G              =  -4.1630892081632E+18
+(PID.TID 0000.0001) %MON thSI_Tsrf_ave_G              =  -2.2551419939523E+00
+(PID.TID 0000.0001) %MON thSI_Tsrf_ave_S              =  -2.2474305066354E+00
+(PID.TID 0000.0001) %MON thSI_Tsrf_ave_N              =  -2.2607496027474E+00
+(PID.TID 0000.0001) %MON thSI_Tsrf_min_S              =  -4.3521514058966E+00
+(PID.TID 0000.0001) %MON thSI_Tsrf_min_N              =  -4.3534664580762E+00
+(PID.TID 0000.0001) %MON thSI_Tsrf_max_S              =  -1.3791709054080E-01
+(PID.TID 0000.0001) %MON thSI_Tsrf_max_N              =  -2.5059640232032E-01
+(PID.TID 0000.0001) %MON thSI_Tic1_ave_G              =  -2.0237894275540E+00
+(PID.TID 0000.0001) %MON thSI_Tic1_ave_S              =  -2.0294977888736E+00
+(PID.TID 0000.0001) %MON thSI_Tic1_ave_N              =  -2.0195792530248E+00
+(PID.TID 0000.0001) %MON thSI_Tic1_min_S              =  -3.1572559748898E+00
+(PID.TID 0000.0001) %MON thSI_Tic1_min_N              =  -3.1571529660825E+00
+(PID.TID 0000.0001) %MON thSI_Tic1_max_S              =  -1.0577457709557E+00
+(PID.TID 0000.0001) %MON thSI_Tic1_max_N              =  -1.1134558062533E+00
+(PID.TID 0000.0001) %MON thSI_Tic2_ave_G              =  -1.7365992046368E+00
+(PID.TID 0000.0001) %MON thSI_Tic2_ave_S              =  -1.7389431710183E+00
+(PID.TID 0000.0001) %MON thSI_Tic2_ave_N              =  -1.7348704234675E+00
+(PID.TID 0000.0001) %MON thSI_Tic2_min_S              =  -2.0537077719769E+00
+(PID.TID 0000.0001) %MON thSI_Tic2_min_N              =  -2.0536678692777E+00
+(PID.TID 0000.0001) %MON thSI_Tic2_max_S              =  -3.9698204639433E-01
+(PID.TID 0000.0001) %MON thSI_Tic2_max_N              =  -1.4777786892524E+00
+(PID.TID 0000.0001) %MON thSI_TotEnerg_G              =  -4.1631317603354E+18
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // End MONITOR Therm.SeaIce statistics
 (PID.TID 0000.0001) // =======================================================
- Compute Stats, Diag. #    224  SI_Fract  vol(   0 ): 2.780E+11  Parms: SM P    M1      
- Compute Stats, Diag. #    225  SI_Thick  vol(   0 ): 2.766E+11  Parms: SM PC   M1      
-    use Counter Mate  #    224  SI_Fract  vol(   0 ): 2.780E+11 integral 2.766E+11
- Compute Stats, Diag. #     26  THETA     vol(   0 ): 2.780E+12  Parms: SMR     MR      
- Compute Stats, Diag. #    227  SI_Tsrf   vol(   0 ): 2.766E+11  Parms: SM  C   M1      
-    use Counter Mate  #    224  SI_Fract  vol(   0 ): 2.780E+11 integral 2.766E+11
- Compute Stats, Diag. #    228  SI_Tice1  vol(   0 ): 2.766E+11  Parms: SM  C   M1      
-    use Counter Mate  #    224  SI_Fract  vol(   0 ): 2.780E+11 integral 2.766E+11
- Compute Stats, Diag. #    229  SI_Tice2  vol(   0 ): 2.766E+11  Parms: SM  C   M1      
-    use Counter Mate  #    224  SI_Fract  vol(   0 ): 2.780E+11 integral 2.766E+11
- Compute Stats, Diag. #    237  SIflx2oc  vol(   0 ): 2.780E+11  Parms: SM      M1      
- Compute Stats, Diag. #    238  SIfrw2oc  vol(   0 ): 2.780E+11  Parms: SM      M1      
- Compute Stats, Diag. #    239  SIsaltFx  vol(   0 ): 2.780E+11  Parms: SM      M1      
- Compute Stats, Diag. #    235  SIflxAtm  vol(   0 ): 2.780E+11  Parms: SM      M1      
- Compute Stats, Diag. #    236  SIfrwAtm  vol(   0 ): 2.780E+11  Parms: SM      M1      
- Compute Stats, Diag. #    226  SI_SnowH  vol(   0 ): 2.766E+11  Parms: SM PC   M1      
-    use Counter Mate  #    224  SI_Fract  vol(   0 ): 2.780E+11 integral 2.766E+11
- Compute Stats, Diag. #    163  SIuice    vol(   0 ): 2.760E+11  Parms: UU      M1      
- Compute Stats, Diag. #    164  SIvice    vol(   0 ): 2.700E+11  Parms: VV      M1      
- SEAICE_LSR: Residual Initial ipass,Uice,Vice=    1  1.18354544E-02  8.41435659E-03
- SEAICE_LSR: Residual FrDrift U_fd,V_fd=  3.12673387E+01  3.69213251E+00
- SEAICE_LSR (ipass=   1) iters,dU,Resid=  1500  7.90586727E-08  1.01321687E-04
- SEAICE_LSR (ipass=   1) iters,dV,Resid=   270  9.20721832E-13  1.11778027E-11
- SEAICE_LSR: Residual Initial ipass,Uice,Vice=    2  1.13171231E-02  7.61492199E-03
- SEAICE_LSR: Residual FrDrift U_fd,V_fd=  3.07626653E+01  3.72258866E+00
- SEAICE_LSR (ipass=   2) iters,dU,Resid=  1500  2.28712855E-08  3.54177171E-05
- SEAICE_LSR (ipass=   2) iters,dV,Resid=   260  8.89038843E-13  1.06676904E-11
+ Compute Stats, Diag. #    226  SI_Fract  vol(   0 ): 5.560E+11  Parms: SM P    M1      
+ Compute Stats, Diag. #    227  SI_Thick  vol(   0 ): 5.532E+11  Parms: SM PC   M1      
+    use Counter Mate  #    226  SI_Fract  vol(   0 ): 5.560E+11 integral 5.532E+11
+ Compute Stats, Diag. #     26  THETA     vol(   0 ): 5.560E+12  Parms: SMR     MR      
+ Compute Stats, Diag. #    229  SI_Tsrf   vol(   0 ): 5.532E+11  Parms: SM  C   M1      
+    use Counter Mate  #    226  SI_Fract  vol(   0 ): 5.560E+11 integral 5.532E+11
+ Compute Stats, Diag. #    230  SI_Tice1  vol(   0 ): 5.532E+11  Parms: SM  C   M1      
+    use Counter Mate  #    226  SI_Fract  vol(   0 ): 5.560E+11 integral 5.532E+11
+ Compute Stats, Diag. #    231  SI_Tice2  vol(   0 ): 5.532E+11  Parms: SM  C   M1      
+    use Counter Mate  #    226  SI_Fract  vol(   0 ): 5.560E+11 integral 5.532E+11
+ Compute Stats, Diag. #    239  SIflx2oc  vol(   0 ): 5.560E+11  Parms: SM      M1      
+ Compute Stats, Diag. #    240  SIfrw2oc  vol(   0 ): 5.560E+11  Parms: SM      M1      
+ Compute Stats, Diag. #    241  SIsaltFx  vol(   0 ): 5.560E+11  Parms: SM      M1      
+ Compute Stats, Diag. #    237  SIflxAtm  vol(   0 ): 5.560E+11  Parms: SM      M1      
+ Compute Stats, Diag. #    238  SIfrwAtm  vol(   0 ): 5.560E+11  Parms: SM      M1      
+ Compute Stats, Diag. #    228  SI_SnowH  vol(   0 ): 5.532E+11  Parms: SM PC   M1      
+    use Counter Mate  #    226  SI_Fract  vol(   0 ): 5.560E+11 integral 5.532E+11
+ Compute Stats, Diag. #    165  SIuice    vol(   0 ): 5.520E+11  Parms: UU      M1      
+ Compute Stats, Diag. #    166  SIvice    vol(   0 ): 5.400E+11  Parms: VV      M1      
+ SEAICE_LSR: Residual Initial ipass,Uice,Vice=         1  1.19937421E-02  8.37422470E-03
+ SEAICE_LSR: Residual FrDrift U_fd,V_fd=  3.00600323E+01  3.63151604E+00
+ SEAICE_LSR (ipass=        1) iters,dU,Resid=     1500  7.97904599E-08  1.02390962E-04
+ SEAICE_LSR (ipass=        1) iters,dV,Resid=      270  9.32018351E-13  1.13074557E-11
+ SEAICE_LSR: Residual Initial ipass,Uice,Vice=         2  1.14051678E-02  7.65785541E-03
+ SEAICE_LSR: Residual FrDrift U_fd,V_fd=  3.00108638E+01  3.66921803E+00
+ SEAICE_LSR (ipass=        2) iters,dU,Resid=     1500  2.27128536E-08  3.53107626E-05
+ SEAICE_LSR (ipass=        2) iters,dV,Resid=      260  8.95436503E-13  1.07369089E-11
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // Begin MONITOR SEAICE statistics
 (PID.TID 0000.0001) // =======================================================
-(PID.TID 0000.0001) %MON seaice_tsnumber              =                    10
+(PID.TID 0000.0001) %MON seaice_tsnumber              =                    20
 (PID.TID 0000.0001) %MON seaice_time_sec              =   1.8000000000000E+04
-(PID.TID 0000.0001) %MON seaice_uice_max              =   6.1264395785013E-01
-(PID.TID 0000.0001) %MON seaice_uice_min              =   1.5501879708363E-01
-(PID.TID 0000.0001) %MON seaice_uice_mean             =   4.6362357050274E-01
-(PID.TID 0000.0001) %MON seaice_uice_sd               =   8.1510372863770E-02
-(PID.TID 0000.0001) %MON seaice_uice_del2             =   1.3906985330909E-04
-(PID.TID 0000.0001) %MON seaice_vice_max              =   1.6276649255362E-01
-(PID.TID 0000.0001) %MON seaice_vice_min              =  -1.2886034307673E-01
-(PID.TID 0000.0001) %MON seaice_vice_mean             =  -1.4127793186979E-03
-(PID.TID 0000.0001) %MON seaice_vice_sd               =   5.3687781491635E-02
-(PID.TID 0000.0001) %MON seaice_vice_del2             =   9.8852186308901E-05
+(PID.TID 0000.0001) %MON seaice_uice_max              =   6.1267080708919E-01
+(PID.TID 0000.0001) %MON seaice_uice_min              =   1.5371301854211E-01
+(PID.TID 0000.0001) %MON seaice_uice_mean             =   4.6359093605089E-01
+(PID.TID 0000.0001) %MON seaice_uice_sd               =   8.1598574764103E-02
+(PID.TID 0000.0001) %MON seaice_uice_del2             =   1.4216309850147E-04
+(PID.TID 0000.0001) %MON seaice_vice_max              =   1.6321246085179E-01
+(PID.TID 0000.0001) %MON seaice_vice_min              =  -1.2895990482468E-01
+(PID.TID 0000.0001) %MON seaice_vice_mean             =  -1.4192151104136E-03
+(PID.TID 0000.0001) %MON seaice_vice_sd               =   5.3678004902023E-02
+(PID.TID 0000.0001) %MON seaice_vice_del2             =   1.0089827949107E-04
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // End MONITOR SEAICE statistics
 (PID.TID 0000.0001) // =======================================================
@@ -3119,67 +3139,67 @@ listId=   1 ; file name: iceStDiag
 (PID.TID 0000.0001) // Begin MONITOR Therm.SeaIce statistics
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) %MON thSI_time_sec                =   1.8000000000000E+04
-(PID.TID 0000.0001) %MON thSI_Ice_Area_G              =   6.8967680088890E+10
-(PID.TID 0000.0001) %MON thSI_Ice_Area_S              =   2.9010687460823E+10
-(PID.TID 0000.0001) %MON thSI_Ice_Area_N              =   3.9956992628067E+10
-(PID.TID 0000.0001) %MON thSI_IceH_ave_G              =   2.0149827949730E-01
-(PID.TID 0000.0001) %MON thSI_IceH_ave_S              =   2.0333736863669E-01
-(PID.TID 0000.0001) %MON thSI_IceH_ave_N              =   2.0016301283366E-01
-(PID.TID 0000.0001) %MON thSI_IceH_max_S              =   3.3785198526001E-01
-(PID.TID 0000.0001) %MON thSI_IceH_max_N              =   2.0274963329694E-01
+(PID.TID 0000.0001) %MON thSI_Ice_Area_G              =   6.8967956829878E+10
+(PID.TID 0000.0001) %MON thSI_Ice_Area_S              =   2.9010563706469E+10
+(PID.TID 0000.0001) %MON thSI_Ice_Area_N              =   3.9957393123409E+10
+(PID.TID 0000.0001) %MON thSI_IceH_ave_G              =   2.0149217712679E-01
+(PID.TID 0000.0001) %MON thSI_IceH_ave_S              =   2.0333037533172E-01
+(PID.TID 0000.0001) %MON thSI_IceH_ave_N              =   2.0015757639434E-01
+(PID.TID 0000.0001) %MON thSI_IceH_max_S              =   3.3990303911865E-01
+(PID.TID 0000.0001) %MON thSI_IceH_max_N              =   2.0274571170437E-01
 (PID.TID 0000.0001) %MON thSI_SnwH_ave_G              =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON thSI_SnwH_ave_S              =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON thSI_SnwH_ave_N              =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON thSI_SnwH_max_S              =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON thSI_SnwH_max_N              =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON thSI_Tsrf_ave_G              =  -2.2638160019695E+00
-(PID.TID 0000.0001) %MON thSI_Tsrf_ave_S              =  -2.2548888427737E+00
-(PID.TID 0000.0001) %MON thSI_Tsrf_ave_N              =  -2.2702975464580E+00
-(PID.TID 0000.0001) %MON thSI_Tsrf_min_S              =  -4.3925375451391E+00
-(PID.TID 0000.0001) %MON thSI_Tsrf_min_N              =  -4.3938497752739E+00
-(PID.TID 0000.0001) %MON thSI_Tsrf_max_S              =  -1.2116332597736E-01
-(PID.TID 0000.0001) %MON thSI_Tsrf_max_N              =  -2.3547677031819E-01
-(PID.TID 0000.0001) %MON thSI_Tic1_ave_G              =  -2.0409102901999E+00
-(PID.TID 0000.0001) %MON thSI_Tic1_ave_S              =  -2.0456196760332E+00
-(PID.TID 0000.0001) %MON thSI_Tic1_ave_N              =  -2.0374368256599E+00
-(PID.TID 0000.0001) %MON thSI_Tic1_min_S              =  -3.2339832150077E+00
-(PID.TID 0000.0001) %MON thSI_Tic1_min_N              =  -3.2337740893389E+00
-(PID.TID 0000.0001) %MON thSI_Tic1_max_S              =  -1.0137553327077E+00
-(PID.TID 0000.0001) %MON thSI_Tic1_max_N              =  -1.0828231690896E+00
-(PID.TID 0000.0001) %MON thSI_Tic2_ave_G              =  -1.7439076626016E+00
-(PID.TID 0000.0001) %MON thSI_Tic2_ave_S              =  -1.7460735230213E+00
-(PID.TID 0000.0001) %MON thSI_Tic2_ave_N              =  -1.7423102060260E+00
-(PID.TID 0000.0001) %MON thSI_Tic2_min_S              =  -2.0858307884428E+00
-(PID.TID 0000.0001) %MON thSI_Tic2_min_N              =  -2.0857537363363E+00
-(PID.TID 0000.0001) %MON thSI_Tic2_max_S              =  -3.8014136011543E-01
-(PID.TID 0000.0001) %MON thSI_Tic2_max_N              =  -1.4657004220877E+00
-(PID.TID 0000.0001) %MON thSI_TotEnerg_G              =  -4.1632547684349E+18
+(PID.TID 0000.0001) %MON thSI_Tsrf_ave_G              =  -2.2682900021204E+00
+(PID.TID 0000.0001) %MON thSI_Tsrf_ave_S              =  -2.2598648589828E+00
+(PID.TID 0000.0001) %MON thSI_Tsrf_ave_N              =  -2.2744069715377E+00
+(PID.TID 0000.0001) %MON thSI_Tsrf_min_S              =  -4.4082068543005E+00
+(PID.TID 0000.0001) %MON thSI_Tsrf_min_N              =  -4.4095946010703E+00
+(PID.TID 0000.0001) %MON thSI_Tsrf_max_S              =  -1.1391435143056E-01
+(PID.TID 0000.0001) %MON thSI_Tsrf_max_N              =  -2.3340566270581E-01
+(PID.TID 0000.0001) %MON thSI_Tic1_ave_G              =  -2.0494494801934E+00
+(PID.TID 0000.0001) %MON thSI_Tic1_ave_S              =  -2.0552183610664E+00
+(PID.TID 0000.0001) %MON thSI_Tic1_ave_N              =  -2.0451946638310E+00
+(PID.TID 0000.0001) %MON thSI_Tic1_min_S              =  -3.2637192222359E+00
+(PID.TID 0000.0001) %MON thSI_Tic1_min_N              =  -3.2635750519245E+00
+(PID.TID 0000.0001) %MON thSI_Tic1_max_S              =  -1.0119697831286E+00
+(PID.TID 0000.0001) %MON thSI_Tic1_max_N              =  -1.0785659972275E+00
+(PID.TID 0000.0001) %MON thSI_Tic2_ave_G              =  -1.7464904556961E+00
+(PID.TID 0000.0001) %MON thSI_Tic2_ave_S              =  -1.7490558337333E+00
+(PID.TID 0000.0001) %MON thSI_Tic2_ave_N              =  -1.7445983707859E+00
+(PID.TID 0000.0001) %MON thSI_Tic2_min_S              =  -2.0958365390465E+00
+(PID.TID 0000.0001) %MON thSI_Tic2_min_N              =  -2.0957803191530E+00
+(PID.TID 0000.0001) %MON thSI_Tic2_max_S              =  -3.7449923057324E-01
+(PID.TID 0000.0001) %MON thSI_Tic2_max_N              =  -1.4635299019426E+00
+(PID.TID 0000.0001) %MON thSI_TotEnerg_G              =  -4.1632890409800E+18
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // End MONITOR Therm.SeaIce statistics
 (PID.TID 0000.0001) // =======================================================
- SEAICE_LSR: Residual Initial ipass,Uice,Vice=    1  1.13647632E-02  7.37970701E-03
- SEAICE_LSR: Residual FrDrift U_fd,V_fd=  2.84609422E+01  4.31243665E+00
- SEAICE_LSR (ipass=   1) iters,dU,Resid=  1500  7.56648207E-08  1.00494862E-04
- SEAICE_LSR (ipass=   1) iters,dV,Resid=   266  9.66435265E-13  1.14475217E-11
- SEAICE_LSR: Residual Initial ipass,Uice,Vice=    2  1.06732424E-02  7.01528520E-03
- SEAICE_LSR: Residual FrDrift U_fd,V_fd=  2.81210990E+01  4.61796132E+00
- SEAICE_LSR (ipass=   2) iters,dU,Resid=  1500  1.94031690E-08  3.08526264E-05
- SEAICE_LSR (ipass=   2) iters,dV,Resid=   256  9.18917720E-13  1.07601357E-11
+ SEAICE_LSR: Residual Initial ipass,Uice,Vice=         1  1.15720550E-02  7.43284642E-03
+ SEAICE_LSR: Residual FrDrift U_fd,V_fd=  2.77293844E+01  4.18612852E+00
+ SEAICE_LSR (ipass=        1) iters,dU,Resid=     1500  7.64364875E-08  1.01624995E-04
+ SEAICE_LSR (ipass=        1) iters,dV,Resid=      266  9.79882842E-13  1.15987784E-11
+ SEAICE_LSR: Residual Initial ipass,Uice,Vice=         2  1.08583551E-02  7.08763994E-03
+ SEAICE_LSR: Residual FrDrift U_fd,V_fd=  2.73707148E+01  4.47555832E+00
+ SEAICE_LSR (ipass=        2) iters,dU,Resid=     1500  1.92375366E-08  3.06611754E-05
+ SEAICE_LSR (ipass=        2) iters,dV,Resid=      256  9.26383970E-13  1.08390186E-11
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // Begin MONITOR SEAICE statistics
 (PID.TID 0000.0001) // =======================================================
-(PID.TID 0000.0001) %MON seaice_tsnumber              =                    11
+(PID.TID 0000.0001) %MON seaice_tsnumber              =                    22
 (PID.TID 0000.0001) %MON seaice_time_sec              =   1.9800000000000E+04
-(PID.TID 0000.0001) %MON seaice_uice_max              =   6.1424931346824E-01
-(PID.TID 0000.0001) %MON seaice_uice_min              =   1.4059790586977E-01
-(PID.TID 0000.0001) %MON seaice_uice_mean             =   4.6341382288413E-01
-(PID.TID 0000.0001) %MON seaice_uice_sd               =   8.2178478907956E-02
-(PID.TID 0000.0001) %MON seaice_uice_del2             =   1.4510029915098E-04
-(PID.TID 0000.0001) %MON seaice_vice_max              =   1.6758657584423E-01
-(PID.TID 0000.0001) %MON seaice_vice_min              =  -1.3180828943523E-01
-(PID.TID 0000.0001) %MON seaice_vice_mean             =  -1.3117894666680E-03
-(PID.TID 0000.0001) %MON seaice_vice_sd               =   5.4108443788555E-02
-(PID.TID 0000.0001) %MON seaice_vice_del2             =   1.0852540190449E-04
+(PID.TID 0000.0001) %MON seaice_uice_max              =   6.1426769318762E-01
+(PID.TID 0000.0001) %MON seaice_uice_min              =   1.3919992895051E-01
+(PID.TID 0000.0001) %MON seaice_uice_mean             =   4.6337819443470E-01
+(PID.TID 0000.0001) %MON seaice_uice_sd               =   8.2278478612756E-02
+(PID.TID 0000.0001) %MON seaice_uice_del2             =   1.4866968172772E-04
+(PID.TID 0000.0001) %MON seaice_vice_max              =   1.6803871069106E-01
+(PID.TID 0000.0001) %MON seaice_vice_min              =  -1.3288547137667E-01
+(PID.TID 0000.0001) %MON seaice_vice_mean             =  -1.3210486395847E-03
+(PID.TID 0000.0001) %MON seaice_vice_sd               =   5.4089763575233E-02
+(PID.TID 0000.0001) %MON seaice_vice_del2             =   1.1118320037247E-04
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // End MONITOR SEAICE statistics
 (PID.TID 0000.0001) // =======================================================
@@ -3187,56 +3207,56 @@ listId=   1 ; file name: iceStDiag
 (PID.TID 0000.0001) // Begin MONITOR Therm.SeaIce statistics
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) %MON thSI_time_sec                =   1.9800000000000E+04
-(PID.TID 0000.0001) %MON thSI_Ice_Area_G              =   6.8913198917403E+10
-(PID.TID 0000.0001) %MON thSI_Ice_Area_S              =   2.8961628111754E+10
-(PID.TID 0000.0001) %MON thSI_Ice_Area_N              =   3.9951570805650E+10
-(PID.TID 0000.0001) %MON thSI_IceH_ave_G              =   2.0166208145281E-01
-(PID.TID 0000.0001) %MON thSI_IceH_ave_S              =   2.0368637416399E-01
-(PID.TID 0000.0001) %MON thSI_IceH_ave_N              =   2.0019463445365E-01
-(PID.TID 0000.0001) %MON thSI_IceH_max_S              =   3.4707521256980E-01
-(PID.TID 0000.0001) %MON thSI_IceH_max_N              =   2.0314894516917E-01
+(PID.TID 0000.0001) %MON thSI_Ice_Area_G              =   6.8913469046700E+10
+(PID.TID 0000.0001) %MON thSI_Ice_Area_S              =   2.8961481042000E+10
+(PID.TID 0000.0001) %MON thSI_Ice_Area_N              =   3.9951988004700E+10
+(PID.TID 0000.0001) %MON thSI_IceH_ave_G              =   2.0165600783153E-01
+(PID.TID 0000.0001) %MON thSI_IceH_ave_S              =   2.0367942345259E-01
+(PID.TID 0000.0001) %MON thSI_IceH_ave_N              =   2.0018921941683E-01
+(PID.TID 0000.0001) %MON thSI_IceH_max_S              =   3.4922107184097E-01
+(PID.TID 0000.0001) %MON thSI_IceH_max_N              =   2.0313697187067E-01
 (PID.TID 0000.0001) %MON thSI_SnwH_ave_G              =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON thSI_SnwH_ave_S              =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON thSI_SnwH_ave_N              =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON thSI_SnwH_max_S              =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON thSI_SnwH_max_N              =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON thSI_Tsrf_ave_G              =  -2.2752420606315E+00
-(PID.TID 0000.0001) %MON thSI_Tsrf_ave_S              =  -2.2654859309407E+00
-(PID.TID 0000.0001) %MON thSI_Tsrf_ave_N              =  -2.2823144583926E+00
-(PID.TID 0000.0001) %MON thSI_Tsrf_min_S              =  -4.4419830223145E+00
-(PID.TID 0000.0001) %MON thSI_Tsrf_min_N              =  -4.4433688973964E+00
-(PID.TID 0000.0001) %MON thSI_Tsrf_max_S              =  -9.9277880468618E-02
-(PID.TID 0000.0001) %MON thSI_Tsrf_max_N              =  -2.1975015075511E-01
-(PID.TID 0000.0001) %MON thSI_Tic1_ave_G              =  -2.0632952612766E+00
-(PID.TID 0000.0001) %MON thSI_Tic1_ave_S              =  -2.0678238294251E+00
-(PID.TID 0000.0001) %MON thSI_Tic1_ave_N              =  -2.0599551605447E+00
-(PID.TID 0000.0001) %MON thSI_Tic1_min_S              =  -3.3277852389717E+00
-(PID.TID 0000.0001) %MON thSI_Tic1_min_N              =  -3.3274976923468E+00
-(PID.TID 0000.0001) %MON thSI_Tic1_max_S              =  -9.7186862445535E-01
-(PID.TID 0000.0001) %MON thSI_Tic1_max_N              =  -1.0509055322776E+00
-(PID.TID 0000.0001) %MON thSI_Tic2_ave_G              =  -1.7526773384921E+00
-(PID.TID 0000.0001) %MON thSI_Tic2_ave_S              =  -1.7549733052429E+00
-(PID.TID 0000.0001) %MON thSI_Tic2_ave_N              =  -1.7509839201812E+00
-(PID.TID 0000.0001) %MON thSI_Tic2_min_S              =  -2.1233484340801E+00
-(PID.TID 0000.0001) %MON thSI_Tic2_min_N              =  -2.1232417965908E+00
-(PID.TID 0000.0001) %MON thSI_Tic2_max_S              =  -3.5953873095487E-01
-(PID.TID 0000.0001) %MON thSI_Tic2_max_N              =  -1.4527383941270E+00
-(PID.TID 0000.0001) %MON thSI_TotEnerg_G              =  -4.1633512006595E+18
+(PID.TID 0000.0001) %MON thSI_Tsrf_ave_G              =  -2.2796950325039E+00
+(PID.TID 0000.0001) %MON thSI_Tsrf_ave_S              =  -2.2704527325524E+00
+(PID.TID 0000.0001) %MON thSI_Tsrf_ave_N              =  -2.2863948416548E+00
+(PID.TID 0000.0001) %MON thSI_Tsrf_min_S              =  -4.4573960247831E+00
+(PID.TID 0000.0001) %MON thSI_Tsrf_min_N              =  -4.4588758897069E+00
+(PID.TID 0000.0001) %MON thSI_Tsrf_max_S              =  -9.2834261563617E-02
+(PID.TID 0000.0001) %MON thSI_Tsrf_max_N              =  -2.1771400055394E-01
+(PID.TID 0000.0001) %MON thSI_Tic1_ave_G              =  -2.0717774947243E+00
+(PID.TID 0000.0001) %MON thSI_Tic1_ave_S              =  -2.0773679694807E+00
+(PID.TID 0000.0001) %MON thSI_Tic1_ave_N              =  -2.0676542649798E+00
+(PID.TID 0000.0001) %MON thSI_Tic1_min_S              =  -3.3569985942131E+00
+(PID.TID 0000.0001) %MON thSI_Tic1_min_N              =  -3.3568058687890E+00
+(PID.TID 0000.0001) %MON thSI_Tic1_max_S              =  -9.7006573533213E-01
+(PID.TID 0000.0001) %MON thSI_Tic1_max_N              =  -1.0467056858330E+00
+(PID.TID 0000.0001) %MON thSI_Tic2_ave_G              =  -1.7554919301499E+00
+(PID.TID 0000.0001) %MON thSI_Tic2_ave_S              =  -1.7582018764305E+00
+(PID.TID 0000.0001) %MON thSI_Tic2_ave_N              =  -1.7534932213467E+00
+(PID.TID 0000.0001) %MON thSI_Tic2_min_S              =  -2.1338705709479E+00
+(PID.TID 0000.0001) %MON thSI_Tic2_min_N              =  -2.1337951618448E+00
+(PID.TID 0000.0001) %MON thSI_Tic2_max_S              =  -3.5530385543329E-01
+(PID.TID 0000.0001) %MON thSI_Tic2_max_N              =  -1.4506436691123E+00
+(PID.TID 0000.0001) %MON thSI_TotEnerg_G              =  -4.1633755371494E+18
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // End MONITOR Therm.SeaIce statistics
 (PID.TID 0000.0001) // =======================================================
- SEAICE_LSR: Residual Initial ipass,Uice,Vice=    1  1.06867732E-02  6.90835771E-03
- SEAICE_LSR: Residual FrDrift U_fd,V_fd=  2.56309913E+01  5.02430402E+00
- SEAICE_LSR (ipass=   1) iters,dU,Resid=  1500  7.32660615E-08  1.00789960E-04
- SEAICE_LSR (ipass=   1) iters,dV,Resid=   264  9.26717036E-13  1.07690855E-11
- SEAICE_LSR: Residual Initial ipass,Uice,Vice=    2  1.02056773E-02  6.64252819E-03
- SEAICE_LSR: Residual FrDrift U_fd,V_fd=  2.47712738E+01  5.13013701E+00
- SEAICE_LSR (ipass=   2) iters,dU,Resid=  1500  1.68251150E-08  2.76365551E-05
- SEAICE_LSR (ipass=   2) iters,dV,Resid=   254  8.73509598E-13  1.00333108E-11
+ SEAICE_LSR: Residual Initial ipass,Uice,Vice=         1  1.08646080E-02  6.99242184E-03
+ SEAICE_LSR: Residual FrDrift U_fd,V_fd=  2.49199866E+01  4.87360492E+00
+ SEAICE_LSR (ipass=        1) iters,dU,Resid=     1500  7.41646212E-08  1.02101708E-04
+ SEAICE_LSR (ipass=        1) iters,dV,Resid=      264  9.42912415E-13  1.09499866E-11
+ SEAICE_LSR: Residual Initial ipass,Uice,Vice=         2  1.03838491E-02  6.73659333E-03
+ SEAICE_LSR: Residual FrDrift U_fd,V_fd=  2.40548176E+01  4.98030928E+00
+ SEAICE_LSR (ipass=        2) iters,dU,Resid=     1500  1.67309966E-08  2.74316636E-05
+ SEAICE_LSR (ipass=        2) iters,dV,Resid=      254  8.83140783E-13  1.01374740E-11
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // Begin MONITOR dynamic field statistics
 (PID.TID 0000.0001) // =======================================================
-(PID.TID 0000.0001) %MON time_tsnumber                =                    12
+(PID.TID 0000.0001) %MON time_tsnumber                =                    24
 (PID.TID 0000.0001) %MON time_secondsf                =   2.1600000000000E+04
 (PID.TID 0000.0001) %MON dynstat_eta_max              =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON dynstat_eta_min              =   0.0000000000000E+00
@@ -3258,22 +3278,22 @@ listId=   1 ; file name: iceStDiag
 (PID.TID 0000.0001) %MON dynstat_wvel_mean            =  -1.8006686469634E-21
 (PID.TID 0000.0001) %MON dynstat_wvel_sd              =   1.8006622332191E-05
 (PID.TID 0000.0001) %MON dynstat_wvel_del2            =   3.4047422448573E-07
-(PID.TID 0000.0001) %MON dynstat_theta_max            =  -1.6116166858956E+00
-(PID.TID 0000.0001) %MON dynstat_theta_min            =  -1.6198943984140E+00
-(PID.TID 0000.0001) %MON dynstat_theta_mean           =  -1.6145850790965E+00
-(PID.TID 0000.0001) %MON dynstat_theta_sd             =   2.1226977817299E-03
-(PID.TID 0000.0001) %MON dynstat_theta_del2           =   6.0060575435947E-06
+(PID.TID 0000.0001) %MON dynstat_theta_max            =  -1.6116289876020E+00
+(PID.TID 0000.0001) %MON dynstat_theta_min            =  -1.6201505483769E+00
+(PID.TID 0000.0001) %MON dynstat_theta_mean           =  -1.6146038919065E+00
+(PID.TID 0000.0001) %MON dynstat_theta_sd             =   2.1179978721758E-03
+(PID.TID 0000.0001) %MON dynstat_theta_del2           =   5.7916816120817E-06
 (PID.TID 0000.0001) %MON dynstat_salt_max             =   3.0000000000000E+01
 (PID.TID 0000.0001) %MON dynstat_salt_min             =   3.0000000000000E+01
 (PID.TID 0000.0001) %MON dynstat_salt_mean            =   3.0000000000000E+01
 (PID.TID 0000.0001) %MON dynstat_salt_sd              =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON dynstat_salt_del2            =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON trAdv_CFL_u_max              =   1.9690054439531E-01
-(PID.TID 0000.0001) %MON trAdv_CFL_v_max              =   8.2010221574612E-02
-(PID.TID 0000.0001) %MON trAdv_CFL_w_max              =   2.9800257921617E-02
-(PID.TID 0000.0001) %MON advcfl_uvel_max              =   1.9690054439531E-01
-(PID.TID 0000.0001) %MON advcfl_vvel_max              =   8.2010221574612E-02
-(PID.TID 0000.0001) %MON advcfl_wvel_max              =   8.7816487489057E-02
+(PID.TID 0000.0001) %MON trAdv_CFL_u_max              =   9.8450272197654E-02
+(PID.TID 0000.0001) %MON trAdv_CFL_v_max              =   4.1005110787306E-02
+(PID.TID 0000.0001) %MON trAdv_CFL_w_max              =   1.4900128960809E-02
+(PID.TID 0000.0001) %MON advcfl_uvel_max              =   9.8450272197654E-02
+(PID.TID 0000.0001) %MON advcfl_vvel_max              =   4.1005110787306E-02
+(PID.TID 0000.0001) %MON advcfl_wvel_max              =   4.3908243744528E-02
 (PID.TID 0000.0001) %MON advcfl_W_hf_max              =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON pe_b_mean                    =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON ke_max                       =   1.4564487757410E-01
@@ -3285,7 +3305,7 @@ listId=   1 ; file name: iceStDiag
 (PID.TID 0000.0001) %MON vort_a_sd                    =   1.5889649807104E-05
 (PID.TID 0000.0001) %MON vort_p_mean                  =  -6.8228760045090E-22
 (PID.TID 0000.0001) %MON vort_p_sd                    =   3.0669223294758E-05
-(PID.TID 0000.0001) %MON surfExpan_theta_mean         =   5.8225539497177E-09
+(PID.TID 0000.0001) %MON surfExpan_theta_mean         =   6.0203691997909E-09
 (PID.TID 0000.0001) %MON surfExpan_salt_mean          =   1.6750406018264E-20
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // End MONITOR dynamic field statistics
@@ -3293,18 +3313,18 @@ listId=   1 ; file name: iceStDiag
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // Begin MONITOR SEAICE statistics
 (PID.TID 0000.0001) // =======================================================
-(PID.TID 0000.0001) %MON seaice_tsnumber              =                    12
+(PID.TID 0000.0001) %MON seaice_tsnumber              =                    24
 (PID.TID 0000.0001) %MON seaice_time_sec              =   2.1600000000000E+04
-(PID.TID 0000.0001) %MON seaice_uice_max              =   6.1564839876923E-01
-(PID.TID 0000.0001) %MON seaice_uice_min              =   1.2759185985814E-01
-(PID.TID 0000.0001) %MON seaice_uice_mean             =   4.6320322271165E-01
-(PID.TID 0000.0001) %MON seaice_uice_sd               =   8.2846803437482E-02
-(PID.TID 0000.0001) %MON seaice_uice_del2             =   1.5088022259846E-04
-(PID.TID 0000.0001) %MON seaice_vice_max              =   1.7150555247705E-01
-(PID.TID 0000.0001) %MON seaice_vice_min              =  -1.3767759317492E-01
-(PID.TID 0000.0001) %MON seaice_vice_mean             =  -1.2260255050367E-03
-(PID.TID 0000.0001) %MON seaice_vice_sd               =   5.4467120912040E-02
-(PID.TID 0000.0001) %MON seaice_vice_del2             =   1.1890009089601E-04
+(PID.TID 0000.0001) %MON seaice_uice_max              =   6.1565635211976E-01
+(PID.TID 0000.0001) %MON seaice_uice_min              =   1.2613902459537E-01
+(PID.TID 0000.0001) %MON seaice_uice_mean             =   4.6316499903727E-01
+(PID.TID 0000.0001) %MON seaice_uice_sd               =   8.2957326819679E-02
+(PID.TID 0000.0001) %MON seaice_uice_del2             =   1.5476426869189E-04
+(PID.TID 0000.0001) %MON seaice_vice_max              =   1.7192269716743E-01
+(PID.TID 0000.0001) %MON seaice_vice_min              =  -1.3870837424919E-01
+(PID.TID 0000.0001) %MON seaice_vice_mean             =  -1.2384930761290E-03
+(PID.TID 0000.0001) %MON seaice_vice_sd               =   5.4440484840901E-02
+(PID.TID 0000.0001) %MON seaice_vice_del2             =   1.2199920508588E-04
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // End MONITOR SEAICE statistics
 (PID.TID 0000.0001) // =======================================================
@@ -3312,212 +3332,212 @@ listId=   1 ; file name: iceStDiag
 (PID.TID 0000.0001) // Begin MONITOR Therm.SeaIce statistics
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) %MON thSI_time_sec                =   2.1600000000000E+04
-(PID.TID 0000.0001) %MON thSI_Ice_Area_G              =   6.8858735153395E+10
-(PID.TID 0000.0001) %MON thSI_Ice_Area_S              =   2.8912761539978E+10
-(PID.TID 0000.0001) %MON thSI_Ice_Area_N              =   3.9945973613417E+10
-(PID.TID 0000.0001) %MON thSI_IceH_ave_G              =   2.0182749748112E-01
-(PID.TID 0000.0001) %MON thSI_IceH_ave_S              =   2.0403636178056E-01
-(PID.TID 0000.0001) %MON thSI_IceH_ave_N              =   2.0022872891982E-01
-(PID.TID 0000.0001) %MON thSI_IceH_max_S              =   3.5566815387252E-01
-(PID.TID 0000.0001) %MON thSI_IceH_max_N              =   2.0356003839215E-01
+(PID.TID 0000.0001) %MON thSI_Ice_Area_G              =   6.8858968514095E+10
+(PID.TID 0000.0001) %MON thSI_Ice_Area_S              =   2.8912567388742E+10
+(PID.TID 0000.0001) %MON thSI_Ice_Area_N              =   3.9946401125353E+10
+(PID.TID 0000.0001) %MON thSI_IceH_ave_G              =   2.0182163425304E-01
+(PID.TID 0000.0001) %MON thSI_IceH_ave_S              =   2.0402976533078E-01
+(PID.TID 0000.0001) %MON thSI_IceH_ave_N              =   2.0022342423186E-01
+(PID.TID 0000.0001) %MON thSI_IceH_max_S              =   3.5785604279032E-01
+(PID.TID 0000.0001) %MON thSI_IceH_max_N              =   2.0353250545789E-01
 (PID.TID 0000.0001) %MON thSI_SnwH_ave_G              =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON thSI_SnwH_ave_S              =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON thSI_SnwH_ave_N              =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON thSI_SnwH_max_S              =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON thSI_SnwH_max_N              =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON thSI_Tsrf_ave_G              =  -2.2850900503564E+00
-(PID.TID 0000.0001) %MON thSI_Tsrf_ave_S              =  -2.2744095745021E+00
-(PID.TID 0000.0001) %MON thSI_Tsrf_ave_N              =  -2.2928205429086E+00
-(PID.TID 0000.0001) %MON thSI_Tsrf_min_S              =  -4.4853386595504E+00
-(PID.TID 0000.0001) %MON thSI_Tsrf_min_N              =  -4.4868129597643E+00
-(PID.TID 0000.0001) %MON thSI_Tsrf_max_S              =  -7.9936972183489E-02
-(PID.TID 0000.0001) %MON thSI_Tsrf_max_N              =  -2.0532496763094E-01
-(PID.TID 0000.0001) %MON thSI_Tic1_ave_G              =  -2.0826700761529E+00
-(PID.TID 0000.0001) %MON thSI_Tic1_ave_S              =  -2.0868053087914E+00
-(PID.TID 0000.0001) %MON thSI_Tic1_ave_N              =  -2.0796200912401E+00
-(PID.TID 0000.0001) %MON thSI_Tic1_min_S              =  -3.4099077906874E+00
-(PID.TID 0000.0001) %MON thSI_Tic1_min_N              =  -3.4095293208865E+00
-(PID.TID 0000.0001) %MON thSI_Tic1_max_S              =  -9.3337931573189E-01
-(PID.TID 0000.0001) %MON thSI_Tic1_max_N              =  -1.0216195575216E+00
-(PID.TID 0000.0001) %MON thSI_Tic2_ave_G              =  -1.7605915023783E+00
-(PID.TID 0000.0001) %MON thSI_Tic2_ave_S              =  -1.7629457326682E+00
-(PID.TID 0000.0001) %MON thSI_Tic2_ave_N              =  -1.7588551147326E+00
-(PID.TID 0000.0001) %MON thSI_Tic2_min_S              =  -2.1570836631195E+00
-(PID.TID 0000.0001) %MON thSI_Tic2_min_N              =  -2.1569426779584E+00
-(PID.TID 0000.0001) %MON thSI_Tic2_max_S              =  -3.4178883181588E-01
-(PID.TID 0000.0001) %MON thSI_Tic2_max_N              =  -1.4409528645202E+00
-(PID.TID 0000.0001) %MON thSI_TotEnerg_G              =  -4.1633856605353E+18
+(PID.TID 0000.0001) %MON thSI_Tsrf_ave_G              =  -2.2894451140387E+00
+(PID.TID 0000.0001) %MON thSI_Tsrf_ave_S              =  -2.2792815782609E+00
+(PID.TID 0000.0001) %MON thSI_Tsrf_ave_N              =  -2.2968013189734E+00
+(PID.TID 0000.0001) %MON thSI_Tsrf_min_S              =  -4.5002485237845E+00
+(PID.TID 0000.0001) %MON thSI_Tsrf_min_N              =  -4.5018453860230E+00
+(PID.TID 0000.0001) %MON thSI_Tsrf_max_S              =  -7.4169544557371E-02
+(PID.TID 0000.0001) %MON thSI_Tsrf_max_N              =  -2.0332776378401E-01
+(PID.TID 0000.0001) %MON thSI_Tic1_ave_G              =  -2.0909513482079E+00
+(PID.TID 0000.0001) %MON thSI_Tic1_ave_S              =  -2.0961372290412E+00
+(PID.TID 0000.0001) %MON thSI_Tic1_ave_N              =  -2.0871265354632E+00
+(PID.TID 0000.0001) %MON thSI_Tic1_min_S              =  -3.4381321259936E+00
+(PID.TID 0000.0001) %MON thSI_Tic1_min_N              =  -3.4378842006290E+00
+(PID.TID 0000.0001) %MON thSI_Tic1_max_S              =  -9.3158922245359E-01
+(PID.TID 0000.0001) %MON thSI_Tic1_max_N              =  -1.0174834710637E+00
+(PID.TID 0000.0001) %MON thSI_Tic2_ave_G              =  -1.7635341457071E+00
+(PID.TID 0000.0001) %MON thSI_Tic2_ave_S              =  -1.7663091022987E+00
+(PID.TID 0000.0001) %MON thSI_Tic2_ave_N              =  -1.7614874944864E+00
+(PID.TID 0000.0001) %MON thSI_Tic2_min_S              =  -2.1678005130547E+00
+(PID.TID 0000.0001) %MON thSI_Tic2_min_N              =  -2.1677033786135E+00
+(PID.TID 0000.0001) %MON thSI_Tic2_max_S              =  -3.3855418862721E-01
+(PID.TID 0000.0001) %MON thSI_Tic2_max_N              =  -1.4389387324759E+00
+(PID.TID 0000.0001) %MON thSI_TotEnerg_G              =  -4.1633988440614E+18
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // End MONITOR Therm.SeaIce statistics
 (PID.TID 0000.0001) // =======================================================
- Computing Diagnostic #    224  SI_Fract     Counter:      12   Parms: SM P    M1      
- Computing Diagnostic #    225  SI_Thick     Counter:      12   Parms: SM PC   M1      
-       use Counter Mate for  SI_Thick     Diagnostic #    224  SI_Fract
- Computing Diagnostic #     26  THETA        Counter:      12   Parms: SMR     MR      
- Computing Diagnostic #    227  SI_Tsrf      Counter:      12   Parms: SM  C   M1      
-       use Counter Mate for  SI_Tsrf      Diagnostic #    224  SI_Fract
- Computing Diagnostic #    237  SIflx2oc     Counter:      12   Parms: SM      M1      
- Computing Diagnostic #    238  SIfrw2oc     Counter:      12   Parms: SM      M1      
- Computing Diagnostic #    239  SIsaltFx     Counter:      12   Parms: SM      M1      
- Computing Diagnostic #    235  SIflxAtm     Counter:      12   Parms: SM      M1      
- Computing Diagnostic #    236  SIfrwAtm     Counter:      12   Parms: SM      M1      
- Computing Diagnostic #    163  SIuice       Counter:      12   Parms: UU      M1      
-           Vector  Mate for  SIuice       Diagnostic #    164  SIvice   exists 
- Computing Diagnostic #    164  SIvice       Counter:      12   Parms: VV      M1      
-           Vector  Mate for  SIvice       Diagnostic #    163  SIuice   exists 
- Compute Stats, Diag. #    224  SI_Fract  vol(   0 ): 2.085E+11  Parms: SM P    M1      
- Compute Stats, Diag. #    225  SI_Thick  vol(   0 ): 2.069E+11  Parms: SM PC   M1      
-    use Counter Mate  #    224  SI_Fract  vol(   0 ): 2.085E+11 integral 2.069E+11
- Compute Stats, Diag. #     26  THETA     vol(   0 ): 2.085E+12  Parms: SMR     MR      
- Compute Stats, Diag. #    227  SI_Tsrf   vol(   0 ): 2.069E+11  Parms: SM  C   M1      
-    use Counter Mate  #    224  SI_Fract  vol(   0 ): 2.085E+11 integral 2.069E+11
- Compute Stats, Diag. #    228  SI_Tice1  vol(   0 ): 2.069E+11  Parms: SM  C   M1      
-    use Counter Mate  #    224  SI_Fract  vol(   0 ): 2.085E+11 integral 2.069E+11
- Compute Stats, Diag. #    229  SI_Tice2  vol(   0 ): 2.069E+11  Parms: SM  C   M1      
-    use Counter Mate  #    224  SI_Fract  vol(   0 ): 2.085E+11 integral 2.069E+11
- Compute Stats, Diag. #    237  SIflx2oc  vol(   0 ): 2.085E+11  Parms: SM      M1      
- Compute Stats, Diag. #    238  SIfrw2oc  vol(   0 ): 2.085E+11  Parms: SM      M1      
- Compute Stats, Diag. #    239  SIsaltFx  vol(   0 ): 2.085E+11  Parms: SM      M1      
- Compute Stats, Diag. #    235  SIflxAtm  vol(   0 ): 2.085E+11  Parms: SM      M1      
- Compute Stats, Diag. #    236  SIfrwAtm  vol(   0 ): 2.085E+11  Parms: SM      M1      
- Compute Stats, Diag. #    226  SI_SnowH  vol(   0 ): 2.069E+11  Parms: SM PC   M1      
-    use Counter Mate  #    224  SI_Fract  vol(   0 ): 2.085E+11 integral 2.069E+11
- Compute Stats, Diag. #    163  SIuice    vol(   0 ): 2.070E+11  Parms: UU      M1      
- Compute Stats, Diag. #    164  SIvice    vol(   0 ): 2.025E+11  Parms: VV      M1      
+ Computing Diagnostic #    226  SI_Fract     Counter:      24   Parms: SM P    M1      
+ Computing Diagnostic #    227  SI_Thick     Counter:      24   Parms: SM PC   M1      
+       use Counter Mate for  SI_Thick     Diagnostic #    226  SI_Fract
+ Computing Diagnostic #     26  THETA        Counter:      24   Parms: SMR     MR      
+ Computing Diagnostic #    229  SI_Tsrf      Counter:      24   Parms: SM  C   M1      
+       use Counter Mate for  SI_Tsrf      Diagnostic #    226  SI_Fract
+ Computing Diagnostic #    239  SIflx2oc     Counter:      24   Parms: SM      M1      
+ Computing Diagnostic #    240  SIfrw2oc     Counter:      24   Parms: SM      M1      
+ Computing Diagnostic #    241  SIsaltFx     Counter:      24   Parms: SM      M1      
+ Computing Diagnostic #    237  SIflxAtm     Counter:      24   Parms: SM      M1      
+ Computing Diagnostic #    238  SIfrwAtm     Counter:      24   Parms: SM      M1      
+ Computing Diagnostic #    165  SIuice       Counter:      24   Parms: UU      M1      
+           Vector  Mate for  SIuice       Diagnostic #    166  SIvice   exists 
+ Computing Diagnostic #    166  SIvice       Counter:      24   Parms: VV      M1      
+           Vector  Mate for  SIvice       Diagnostic #    165  SIuice   exists 
+ Compute Stats, Diag. #    226  SI_Fract  vol(   0 ): 4.170E+11  Parms: SM P    M1      
+ Compute Stats, Diag. #    227  SI_Thick  vol(   0 ): 4.137E+11  Parms: SM PC   M1      
+    use Counter Mate  #    226  SI_Fract  vol(   0 ): 4.170E+11 integral 4.137E+11
+ Compute Stats, Diag. #     26  THETA     vol(   0 ): 4.170E+12  Parms: SMR     MR      
+ Compute Stats, Diag. #    229  SI_Tsrf   vol(   0 ): 4.137E+11  Parms: SM  C   M1      
+    use Counter Mate  #    226  SI_Fract  vol(   0 ): 4.170E+11 integral 4.137E+11
+ Compute Stats, Diag. #    230  SI_Tice1  vol(   0 ): 4.137E+11  Parms: SM  C   M1      
+    use Counter Mate  #    226  SI_Fract  vol(   0 ): 4.170E+11 integral 4.137E+11
+ Compute Stats, Diag. #    231  SI_Tice2  vol(   0 ): 4.137E+11  Parms: SM  C   M1      
+    use Counter Mate  #    226  SI_Fract  vol(   0 ): 4.170E+11 integral 4.137E+11
+ Compute Stats, Diag. #    239  SIflx2oc  vol(   0 ): 4.170E+11  Parms: SM      M1      
+ Compute Stats, Diag. #    240  SIfrw2oc  vol(   0 ): 4.170E+11  Parms: SM      M1      
+ Compute Stats, Diag. #    241  SIsaltFx  vol(   0 ): 4.170E+11  Parms: SM      M1      
+ Compute Stats, Diag. #    237  SIflxAtm  vol(   0 ): 4.170E+11  Parms: SM      M1      
+ Compute Stats, Diag. #    238  SIfrwAtm  vol(   0 ): 4.170E+11  Parms: SM      M1      
+ Compute Stats, Diag. #    228  SI_SnowH  vol(   0 ): 4.137E+11  Parms: SM PC   M1      
+    use Counter Mate  #    226  SI_Fract  vol(   0 ): 4.170E+11 integral 4.137E+11
+ Compute Stats, Diag. #    165  SIuice    vol(   0 ): 4.140E+11  Parms: UU      M1      
+ Compute Stats, Diag. #    166  SIvice    vol(   0 ): 4.050E+11  Parms: VV      M1      
 (PID.TID 0000.0001) DIAGSTATS_CLOSE_IO: close file: iceStDiag.0000000000.txt , unit=     9
-(PID.TID 0000.0001) %CHECKPOINT        12 ckptA
+(PID.TID 0000.0001) %CHECKPOINT        24 ckptA
 (PID.TID 0000.0001)   Seconds in section "ALL                    [THE_MODEL_MAIN]":
-(PID.TID 0000.0001)           User time:   27.517810700461268
-(PID.TID 0000.0001)         System time:  0.32901701144874096
-(PID.TID 0000.0001)     Wall clock time:   28.529180049896240
+(PID.TID 0000.0001)           User time:   29.490306854248047
+(PID.TID 0000.0001)         System time:   4.6912000514566898E-002
+(PID.TID 0000.0001)     Wall clock time:   29.555981159210205
 (PID.TID 0000.0001)          No. starts:           1
 (PID.TID 0000.0001)           No. stops:           1
 (PID.TID 0000.0001)   Seconds in section "INITIALISE_FIXED       [THE_MODEL_MAIN]":
-(PID.TID 0000.0001)           User time:   5.4510000976733863E-002
-(PID.TID 0000.0001)         System time:   9.6690001664683223E-003
-(PID.TID 0000.0001)     Wall clock time:  0.13912606239318848
+(PID.TID 0000.0001)           User time:   5.6442998349666595E-002
+(PID.TID 0000.0001)         System time:   6.9960001856088638E-003
+(PID.TID 0000.0001)     Wall clock time:   7.2374105453491211E-002
 (PID.TID 0000.0001)          No. starts:           1
 (PID.TID 0000.0001)           No. stops:           1
 (PID.TID 0000.0001)   Seconds in section "THE_MAIN_LOOP          [THE_MODEL_MAIN]":
-(PID.TID 0000.0001)           User time:   27.463264070451260
-(PID.TID 0000.0001)         System time:  0.31933001149445772
-(PID.TID 0000.0001)     Wall clock time:   28.390015840530396
+(PID.TID 0000.0001)           User time:   29.433844223618507
+(PID.TID 0000.0001)         System time:   3.9837000891566277E-002
+(PID.TID 0000.0001)     Wall clock time:   29.483536958694458
 (PID.TID 0000.0001)          No. starts:           1
 (PID.TID 0000.0001)           No. stops:           1
 (PID.TID 0000.0001)   Seconds in section "INITIALISE_VARIA    [THE_MAIN_LOOP]":
-(PID.TID 0000.0001)           User time:   4.4278997927904129E-002
-(PID.TID 0000.0001)         System time:   2.3523000068962574E-002
-(PID.TID 0000.0001)     Wall clock time:  0.63800311088562012
+(PID.TID 0000.0001)           User time:   3.0333995819091797E-002
+(PID.TID 0000.0001)         System time:   1.9286999478936195E-002
+(PID.TID 0000.0001)     Wall clock time:   5.7332992553710938E-002
 (PID.TID 0000.0001)          No. starts:           1
 (PID.TID 0000.0001)           No. stops:           1
 (PID.TID 0000.0001)   Seconds in section "MAIN LOOP           [THE_MAIN_LOOP]":
-(PID.TID 0000.0001)           User time:   27.418954350054264
-(PID.TID 0000.0001)         System time:  0.29580001160502434
-(PID.TID 0000.0001)     Wall clock time:   27.751976966857910
+(PID.TID 0000.0001)           User time:   29.403482593595982
+(PID.TID 0000.0001)         System time:   2.0541001111268997E-002
+(PID.TID 0000.0001)     Wall clock time:   29.426170110702515
 (PID.TID 0000.0001)          No. starts:           1
 (PID.TID 0000.0001)           No. stops:           1
 (PID.TID 0000.0001)   Seconds in section "MAIN_DO_LOOP        [THE_MAIN_LOOP]":
-(PID.TID 0000.0001)           User time:   27.418856374919415
-(PID.TID 0000.0001)         System time:  0.29579701274633408
-(PID.TID 0000.0001)     Wall clock time:   27.751876354217529
-(PID.TID 0000.0001)          No. starts:          12
-(PID.TID 0000.0001)           No. stops:          12
-(PID.TID 0000.0001)   Seconds in section "FORWARD_STEP        [MAIN_DO_LOOP]":
-(PID.TID 0000.0001)           User time:   27.418624468147755
-(PID.TID 0000.0001)         System time:  0.29579001292586327
-(PID.TID 0000.0001)     Wall clock time:   27.751662969589233
-(PID.TID 0000.0001)          No. starts:          12
-(PID.TID 0000.0001)           No. stops:          12
-(PID.TID 0000.0001)   Seconds in section "DO_STATEVARS_DIAGS  [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:   2.5875084102153778E-002
-(PID.TID 0000.0001)         System time:   4.8980116844177246E-005
-(PID.TID 0000.0001)     Wall clock time:   2.5942802429199219E-002
-(PID.TID 0000.0001)          No. starts:          36
-(PID.TID 0000.0001)           No. stops:          36
-(PID.TID 0000.0001)   Seconds in section "LOAD_FIELDS_DRIVER  [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:   6.2516048550605774E-002
-(PID.TID 0000.0001)         System time:   2.9951333999633789E-006
-(PID.TID 0000.0001)     Wall clock time:   6.2519073486328125E-002
-(PID.TID 0000.0001)          No. starts:          12
-(PID.TID 0000.0001)           No. stops:          12
-(PID.TID 0000.0001)   Seconds in section "EXF_GETFORCING     [LOAD_FLDS_DRIVER]":
-(PID.TID 0000.0001)           User time:   6.2056280672550201E-002
-(PID.TID 0000.0001)         System time:   9.9837779998779297E-007
-(PID.TID 0000.0001)     Wall clock time:   6.2076330184936523E-002
-(PID.TID 0000.0001)          No. starts:          12
-(PID.TID 0000.0001)           No. stops:          12
-(PID.TID 0000.0001)   Seconds in section "EXTERNAL_FLDS_LOAD [LOAD_FLDS_DRIVER]":
-(PID.TID 0000.0001)           User time:   1.3104081153869629E-004
-(PID.TID 0000.0001)         System time:   9.8347663879394531E-007
-(PID.TID 0000.0001)     Wall clock time:   1.3065338134765625E-004
-(PID.TID 0000.0001)          No. starts:          12
-(PID.TID 0000.0001)           No. stops:          12
-(PID.TID 0000.0001)   Seconds in section "DO_ATMOSPHERIC_PHYS [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:   9.3780457973480225E-005
-(PID.TID 0000.0001)         System time:   9.9837779998779297E-007
-(PID.TID 0000.0001)     Wall clock time:   9.7036361694335938E-005
-(PID.TID 0000.0001)          No. starts:          12
-(PID.TID 0000.0001)           No. stops:          12
-(PID.TID 0000.0001)   Seconds in section "DO_OCEANIC_PHYS     [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:   27.235668644309044
-(PID.TID 0000.0001)         System time:  0.28765401989221573
-(PID.TID 0000.0001)     Wall clock time:   27.560529232025146
-(PID.TID 0000.0001)          No. starts:          12
-(PID.TID 0000.0001)           No. stops:          12
-(PID.TID 0000.0001)   Seconds in section "THSICE_MAIN     [DO_OCEANIC_PHYS]":
-(PID.TID 0000.0001)           User time:   8.6008898913860321E-002
-(PID.TID 0000.0001)         System time:   0.0000000000000000
-(PID.TID 0000.0001)     Wall clock time:   8.6033582687377930E-002
-(PID.TID 0000.0001)          No. starts:          12
-(PID.TID 0000.0001)           No. stops:          12
-(PID.TID 0000.0001)   Seconds in section "SEAICE_MODEL    [DO_OCEANIC_PHYS]":
-(PID.TID 0000.0001)           User time:   27.136534705758095
-(PID.TID 0000.0001)         System time:  0.28754898160696030
-(PID.TID 0000.0001)     Wall clock time:   27.461311578750610
-(PID.TID 0000.0001)          No. starts:          12
-(PID.TID 0000.0001)           No. stops:          12
-(PID.TID 0000.0001)   Seconds in section "SEAICE_DYNSOLVER   [SEAICE_MODEL]":
-(PID.TID 0000.0001)           User time:   27.045055508613586
-(PID.TID 0000.0001)         System time:  0.27949797362089157
-(PID.TID 0000.0001)     Wall clock time:   27.361209154129028
-(PID.TID 0000.0001)          No. starts:          12
-(PID.TID 0000.0001)           No. stops:          12
-(PID.TID 0000.0001)   Seconds in section "BLOCKING_EXCHANGES  [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:   2.6688575744628906E-003
-(PID.TID 0000.0001)         System time:   1.9997358322143555E-005
-(PID.TID 0000.0001)     Wall clock time:   2.6922225952148438E-003
+(PID.TID 0000.0001)           User time:   29.403270751237869
+(PID.TID 0000.0001)         System time:   2.0537000149488449E-002
+(PID.TID 0000.0001)     Wall clock time:   29.425958633422852
 (PID.TID 0000.0001)          No. starts:          24
 (PID.TID 0000.0001)           No. stops:          24
+(PID.TID 0000.0001)   Seconds in section "FORWARD_STEP        [MAIN_DO_LOOP]":
+(PID.TID 0000.0001)           User time:   29.402858443558216
+(PID.TID 0000.0001)         System time:   2.0532000809907913E-002
+(PID.TID 0000.0001)     Wall clock time:   29.425533771514893
+(PID.TID 0000.0001)          No. starts:          24
+(PID.TID 0000.0001)           No. stops:          24
+(PID.TID 0000.0001)   Seconds in section "DO_STATEVARS_DIAGS  [FORWARD_STEP]":
+(PID.TID 0000.0001)           User time:   5.5908352136611938E-002
+(PID.TID 0000.0001)         System time:   9.2500075697898865E-004
+(PID.TID 0000.0001)     Wall clock time:   5.6859493255615234E-002
+(PID.TID 0000.0001)          No. starts:          72
+(PID.TID 0000.0001)           No. stops:          72
+(PID.TID 0000.0001)   Seconds in section "LOAD_FIELDS_DRIVER  [FORWARD_STEP]":
+(PID.TID 0000.0001)           User time:  0.11140028387308121
+(PID.TID 0000.0001)         System time:   4.0009617805480957E-006
+(PID.TID 0000.0001)     Wall clock time:  0.11140465736389160
+(PID.TID 0000.0001)          No. starts:          24
+(PID.TID 0000.0001)           No. stops:          24
+(PID.TID 0000.0001)   Seconds in section "EXF_GETFORCING     [LOAD_FLDS_DRIVER]":
+(PID.TID 0000.0001)           User time:  0.11049450188875198
+(PID.TID 0000.0001)         System time:   0.0000000000000000
+(PID.TID 0000.0001)     Wall clock time:  0.11053156852722168
+(PID.TID 0000.0001)          No. starts:          24
+(PID.TID 0000.0001)           No. stops:          24
+(PID.TID 0000.0001)   Seconds in section "EXTERNAL_FLDS_LOAD [LOAD_FLDS_DRIVER]":
+(PID.TID 0000.0001)           User time:   2.2866576910018921E-004
+(PID.TID 0000.0001)         System time:   0.0000000000000000
+(PID.TID 0000.0001)     Wall clock time:   2.2768974304199219E-004
+(PID.TID 0000.0001)          No. starts:          24
+(PID.TID 0000.0001)           No. stops:          24
+(PID.TID 0000.0001)   Seconds in section "DO_ATMOSPHERIC_PHYS [FORWARD_STEP]":
+(PID.TID 0000.0001)           User time:   2.0912289619445801E-004
+(PID.TID 0000.0001)         System time:   0.0000000000000000
+(PID.TID 0000.0001)     Wall clock time:   2.1028518676757812E-004
+(PID.TID 0000.0001)          No. starts:          24
+(PID.TID 0000.0001)           No. stops:          24
+(PID.TID 0000.0001)   Seconds in section "DO_OCEANIC_PHYS     [FORWARD_STEP]":
+(PID.TID 0000.0001)           User time:   29.107003688812256
+(PID.TID 0000.0001)         System time:   3.6219991743564606E-003
+(PID.TID 0000.0001)     Wall clock time:   29.112549781799316
+(PID.TID 0000.0001)          No. starts:          24
+(PID.TID 0000.0001)           No. stops:          24
+(PID.TID 0000.0001)   Seconds in section "THSICE_MAIN     [DO_OCEANIC_PHYS]":
+(PID.TID 0000.0001)           User time:  0.17309726774692535
+(PID.TID 0000.0001)         System time:   3.3209994435310364E-003
+(PID.TID 0000.0001)     Wall clock time:  0.17644309997558594
+(PID.TID 0000.0001)          No. starts:          24
+(PID.TID 0000.0001)           No. stops:          24
+(PID.TID 0000.0001)   Seconds in section "SEAICE_MODEL    [DO_OCEANIC_PHYS]":
+(PID.TID 0000.0001)           User time:   28.906892687082291
+(PID.TID 0000.0001)         System time:   2.9800087213516235E-004
+(PID.TID 0000.0001)     Wall clock time:   28.909140110015869
+(PID.TID 0000.0001)          No. starts:          24
+(PID.TID 0000.0001)           No. stops:          24
+(PID.TID 0000.0001)   Seconds in section "SEAICE_DYNSOLVER   [SEAICE_MODEL]":
+(PID.TID 0000.0001)           User time:   28.699109189212322
+(PID.TID 0000.0001)         System time:   1.6999989748001099E-004
+(PID.TID 0000.0001)     Wall clock time:   28.701203107833862
+(PID.TID 0000.0001)          No. starts:          24
+(PID.TID 0000.0001)           No. stops:          24
+(PID.TID 0000.0001)   Seconds in section "BLOCKING_EXCHANGES  [FORWARD_STEP]":
+(PID.TID 0000.0001)           User time:   6.1080455780029297E-003
+(PID.TID 0000.0001)         System time:   0.0000000000000000
+(PID.TID 0000.0001)     Wall clock time:   6.1070919036865234E-003
+(PID.TID 0000.0001)          No. starts:          48
+(PID.TID 0000.0001)           No. stops:          48
 (PID.TID 0000.0001)   Seconds in section "THERMODYNAMICS      [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:   2.3661613464355469E-002
-(PID.TID 0000.0001)         System time:   6.4000487327575684E-005
-(PID.TID 0000.0001)     Wall clock time:   2.3738145828247070E-002
-(PID.TID 0000.0001)          No. starts:          12
-(PID.TID 0000.0001)           No. stops:          12
+(PID.TID 0000.0001)           User time:   5.0441265106201172E-002
+(PID.TID 0000.0001)         System time:   0.0000000000000000
+(PID.TID 0000.0001)     Wall clock time:   5.0444602966308594E-002
+(PID.TID 0000.0001)          No. starts:          24
+(PID.TID 0000.0001)           No. stops:          24
 (PID.TID 0000.0001)   Seconds in section "TRC_CORRECTION_STEP [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:   9.5605850219726562E-005
+(PID.TID 0000.0001)           User time:   2.4604797363281250E-004
 (PID.TID 0000.0001)         System time:   0.0000000000000000
-(PID.TID 0000.0001)     Wall clock time:   1.0061264038085938E-004
-(PID.TID 0000.0001)          No. starts:          12
-(PID.TID 0000.0001)           No. stops:          12
+(PID.TID 0000.0001)     Wall clock time:   2.4247169494628906E-004
+(PID.TID 0000.0001)          No. starts:          24
+(PID.TID 0000.0001)           No. stops:          24
 (PID.TID 0000.0001)   Seconds in section "MONITOR             [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:   5.2447319030761719E-003
+(PID.TID 0000.0001)           User time:   5.2111148834228516E-003
 (PID.TID 0000.0001)         System time:   0.0000000000000000
-(PID.TID 0000.0001)     Wall clock time:   5.2471160888671875E-003
-(PID.TID 0000.0001)          No. starts:          12
-(PID.TID 0000.0001)           No. stops:          12
+(PID.TID 0000.0001)     Wall clock time:   5.2146911621093750E-003
+(PID.TID 0000.0001)          No. starts:          24
+(PID.TID 0000.0001)           No. stops:          24
 (PID.TID 0000.0001)   Seconds in section "DO_THE_MODEL_IO     [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:   5.8943271636962891E-002
-(PID.TID 0000.0001)         System time:   4.0110200643539429E-003
-(PID.TID 0000.0001)     Wall clock time:   6.2996864318847656E-002
-(PID.TID 0000.0001)          No. starts:          12
-(PID.TID 0000.0001)           No. stops:          12
+(PID.TID 0000.0001)           User time:   6.1699151992797852E-002
+(PID.TID 0000.0001)         System time:   1.1969000101089478E-002
+(PID.TID 0000.0001)     Wall clock time:   7.3909282684326172E-002
+(PID.TID 0000.0001)          No. starts:          24
+(PID.TID 0000.0001)           No. stops:          24
 (PID.TID 0000.0001)   Seconds in section "DO_WRITE_PICKUP     [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:   2.4452209472656250E-003
-(PID.TID 0000.0001)         System time:   3.9770156145095825E-003
-(PID.TID 0000.0001)     Wall clock time:   6.4251422882080078E-003
-(PID.TID 0000.0001)          No. starts:          12
-(PID.TID 0000.0001)           No. stops:          12
+(PID.TID 0000.0001)           User time:   1.5356540679931641E-003
+(PID.TID 0000.0001)         System time:   4.0019974112510681E-003
+(PID.TID 0000.0001)     Wall clock time:   5.5356025695800781E-003
+(PID.TID 0000.0001)          No. starts:          24
+(PID.TID 0000.0001)           No. stops:          24
 (PID.TID 0000.0001) // ======================================================
 (PID.TID 0000.0001) // Tile <-> Tile communication statistics
 (PID.TID 0000.0001) // ======================================================
@@ -3566,9 +3586,9 @@ listId=   1 ; file name: iceStDiag
 (PID.TID 0000.0001) //          Total. Y spins =              0
 (PID.TID 0000.0001) //            Avg. Y spins =       0.00E+00
 (PID.TID 0000.0001) // o Thread number: 000001
-(PID.TID 0000.0001) //            No. barriers =          46950
+(PID.TID 0000.0001) //            No. barriers =          46960
 (PID.TID 0000.0001) //      Max. barrier spins =              1
 (PID.TID 0000.0001) //      Min. barrier spins =              1
-(PID.TID 0000.0001) //     Total barrier spins =          46950
+(PID.TID 0000.0001) //     Total barrier spins =          46960
 (PID.TID 0000.0001) //      Avg. barrier spins =       1.00E+00
 PROGRAM MAIN: Execution ended Normally

--- a/verification/tutorial_plume_on_slope/input.roughBot/eedata.mth
+++ b/verification/tutorial_plume_on_slope/input.roughBot/eedata.mth
@@ -1,0 +1,11 @@
+# Example "eedata" file  for multi-threaded test
+#   (copy "eedata.mth" to "eedata" to use it)
+# Lines beginning "#" are comments
+# nTx - No. threads per process in X
+# nTy - No. threads per process in Y
+ &EEPARMS
+ nTx=2,
+ nTy=1,
+ &
+# Note: Some systems use & as the namelist terminator (as shown here).
+#       Other systems use a / character.


### PR DESCRIPTION
## What changes does this PR introduce?
Bug fix and cleanup

## What is the current behaviour? 
- Compile error with `seaice_evp.F` when `ALLOW_AUTODIFF_TAMC` is not defined, issue #730
- there is an issue with using `ALLOW_AUTODIFF`, `useHB87stressCoupling`, and `SEAICE_deltaTdyn>deltaT`, also issue #730
- some code within `ifdef ALLOW_AUTODIFF_TAMC` is not specific to TAF/TAMC

## What is the new behaviour 
- fixes issues #730, second part by moving most computations into the `SEAICE_ALLOW_DYNAMICS`, except for S/R `seaice_get_dynforcing`, which is now called in every timestep to always have an valid local `TAUX/Y`.
- replace many `ALLOW_AUTODIFF_TAMC` by `ALLOW_AUTODIFF` where code is not specific to TAF/TAMC

## Does this PR introduce a breaking change? 
no

## Other information:
The cleanup is restricted to pkg/seaice, but there may be more in other places  where code within `ifdef ALLOW_AUTODIFF_TAMC` is not specific to TAF/TAMC.

## Suggested addition to `tag-index`
- pkg/seaice:
 o fix compile error in seaice_evp.F related to ALLOW_AUTODIFF_TAMC/ALLOW_AUTODIFF mix-up
 o move most of routine body of seaice_dynsolver.F in the SEAICE_ALLOW_DYNAMICS block
 o call S/R seaice_get_dynforcing every timestep to have TAUX/Y always available.
 o  replace many ALLOW_AUTODIFF_TAMC by ALLOW_AUTODIFF where code is not specific to TAF/TAMC
 