### PR TITLE
Avoid readthedocs bug with urllib3 v2+

### DIFF
--- a/doc/requirements.txt
+++ b/doc/requirements.txt
@@ -3,3 +3,4 @@ sphinx_rtd_theme
 sphinxcontrib-bibtex>=2
 sphinxcontrib-programoutput
 numpy
+urllib3<2


### PR DESCRIPTION
## What changes does this PR introduce?

Temporary bug fix

## What is the current behaviour? 

Readthedocs build fails because of python library incompatibility.

## What is the new behaviour 

Succeeds.

## Does this PR introduce a breaking change? 

No.

## Other information:

Hopefully this will be fixed in RTD/Sphinx/... and this change can be reverted.
