### PR TITLE
Make sure 'pass' option is always used

### DIFF
--- a/doc/requirements.txt
+++ b/doc/requirements.txt
@@ -3,4 +3,3 @@ sphinx_rtd_theme
 sphinxcontrib-bibtex>=2
 sphinxcontrib-programoutput
 numpy
-urllib3<2

--- a/tools/ci/runtr.sh
+++ b/tools/ci/runtr.sh
@@ -10,7 +10,7 @@
 #
 
 if [ -z "${MITGCM_TROPT}" ]; then
- export MITGCM_TROPT='-devel -of=../tools/build_options/linux_amd64_gfortran -match 14 -pass'
+ export MITGCM_TROPT='-devel -of=../tools/build_options/linux_amd64_gfortran -match 14'
 fi
 if [ -z "${MITGCM_DECMD}" ]; then
  export MITGCM_DECMD='docker exec -i ubuntu_18_04-testreport bash -c'
@@ -19,4 +19,4 @@ if [ -z "${MITGCM_INPUT_DIR_PAT}" ]; then
  export MITGCM_INPUT_DIR_PAT='/input.*'
 fi
 
-${MITGCM_DECMD} "cd /MITgcm/verification; ./testreport -t ${MITGCM_EXP} ${MITGCM_TROPT}"
+${MITGCM_DECMD} "cd /MITgcm/verification; ./testreport -pass -t ${MITGCM_EXP} ${MITGCM_TROPT}"


### PR DESCRIPTION
## What changes does this PR introduce?

bug fix

## What is the current behaviour? 

The "pass" option to testreport was dropped when MITGCM_TROPT was set in the workflow file, such as for OpenAD tests.

## What is the new behaviour 

The "pass" option is always given.

## Does this PR introduce a breaking change? 

No.