### PR TITLE
Update mdsio slice I/O routines

### DIFF
--- a/pkg/autodiff/active_file_control_slice.F
+++ b/pkg/autodiff/active_file_control_slice.F
@@ -102,7 +102,7 @@ C     >>>>>>>>>>>>>>>>>>> FORWARD RUN <<<<<<<<<<<<<<<<<<<
 C     Read the active variable from file.
         CALL MDS_READ_SEC_XZ(
      I                activeVar_file, prec, useCurrentDir,
-     I                'RL', myNr,
+     I                'RL', myNr, 1, myNr,
      O                active_var, dummyRS,
      I                iRec, myThid )
 
@@ -124,7 +124,7 @@ C     adjoint variable file. These files are tiled.
           CALL ADD_PREFIX( adpref, activeVar_file, adfname )
           CALL MDS_WRITE_SEC_XZ(
      I                adfname, prec, globalFile, useCurrentDir,
-     I                'RL', myNr,
+     I                'RL', myNr, 1, myNr,
      I                active_data_t, dummyRS,
      I                iRec, myOptimIter, myThid )
 
@@ -137,7 +137,7 @@ C     >>>>>>>>>>>>>>>>>>> ADJOINT RUN <<<<<<<<<<<<<<<<<<<
 
         CALL MDS_READ_SEC_XZ(
      I                activeVar_file, prec, useCurrentDir,
-     I                'RL', myNr,
+     I                'RL', myNr, 1, myNr,
      O                active_data_t, dummyRS,
      I                iRec, myThid )
 
@@ -157,7 +157,7 @@ C     Store the result on disk.
         w_globFile = .FALSE.
         CALL MDS_WRITE_SEC_XZ(
      I                activeVar_file, prec, w_globFile, useCurrentDir,
-     I                'RL', myNr,
+     I                'RL', myNr, 1, myNr,
      I                active_data_t, dummyRS,
      I                iRec, myOptimIter, myThid )
 
@@ -179,7 +179,7 @@ C     >>>>>>>>>>>>>>>>>>> TANGENT RUN <<<<<<<<<<<<<<<<<<<
 C     Read the active variable from file.
         CALL MDS_READ_SEC_XZ(
      I                activeVar_file, prec, useCurrentDir,
-     I                'RL', myNr,
+     I                'RL', myNr, 1, myNr,
      O                active_var, dummyRS,
      I                iRec, myThid )
       ENDIF
@@ -270,7 +270,7 @@ C     >>>>>>>>>>>>>>>>>>> FORWARD RUN <<<<<<<<<<<<<<<<<<<
 C     Read the active variable from file.
         CALL MDS_READ_SEC_XZ(
      I                activeVar_file, prec, useCurrentDir,
-     I                'RS', myNr,
+     I                'RS', myNr, 1, myNr,
      O                dummyRL, active_var,
      I                iRec, myThid )
 
@@ -292,7 +292,7 @@ C     adjoint variable file. These files are tiled.
           CALL ADD_PREFIX( adpref, activeVar_file, adfname )
           CALL MDS_WRITE_SEC_XZ(
      I                adfname, prec, globalFile, useCurrentDir,
-     I                'RS', myNr,
+     I                'RS', myNr, 1, myNr,
      I                dummyRL, active_data_t,
      I                iRec, myOptimIter, myThid )
 
@@ -305,7 +305,7 @@ C     >>>>>>>>>>>>>>>>>>> ADJOINT RUN <<<<<<<<<<<<<<<<<<<
 
         CALL MDS_READ_SEC_XZ(
      I                activeVar_file, prec, useCurrentDir,
-     I                'RS', myNr,
+     I                'RS', myNr, 1, myNr,
      O                dummyRL, active_data_t,
      I                iRec, myThid )
 
@@ -325,7 +325,7 @@ C     Store the result on disk.
         w_globFile = .FALSE.
         CALL MDS_WRITE_SEC_XZ(
      I                activeVar_file, prec, w_globFile, useCurrentDir,
-     I                'RS', myNr,
+     I                'RS', myNr, 1, myNr,
      I                dummyRL, active_data_t,
      I                iRec, myOptimIter, myThid )
 
@@ -347,7 +347,7 @@ C     >>>>>>>>>>>>>>>>>>> TANGENT RUN <<<<<<<<<<<<<<<<<<<
 C     Read the active variable from file.
         CALL MDS_READ_SEC_XZ(
      I                activeVar_file, prec, useCurrentDir,
-     I                'RS', myNr,
+     I                'RS', myNr, 1, myNr,
      O                dummyRL, active_var,
      I                iRec, myThid )
       ENDIF
@@ -437,7 +437,7 @@ C     >>>>>>>>>>>>>>>>>>> FORWARD RUN <<<<<<<<<<<<<<<<<<<
 C     Read the active variable from file.
         CALL MDS_READ_SEC_YZ(
      I                activeVar_file, prec, useCurrentDir,
-     I                'RL', myNr,
+     I                'RL', myNr, 1, myNr,
      O                active_var, dummyRS,
      I                iRec, myThid )
 
@@ -459,7 +459,7 @@ C     adjoint variable file. These files are tiled.
           CALL ADD_PREFIX( adpref, activeVar_file, adfname )
           CALL MDS_WRITE_SEC_YZ(
      I                adfname, prec, globalFile, useCurrentDir,
-     I                'RL', myNr,
+     I                'RL', myNr, 1, myNr,
      I                active_data_t, dummyRS,
      I                iRec, myOptimIter, myThid )
 
@@ -472,7 +472,7 @@ C     >>>>>>>>>>>>>>>>>>> ADJOINT RUN <<<<<<<<<<<<<<<<<<<
 
         CALL MDS_READ_SEC_YZ(
      I                activeVar_file, prec, useCurrentDir,
-     I                'RL', myNr,
+     I                'RL', myNr, 1, myNr,
      O                active_data_t, dummyRS,
      I                iRec, myThid )
 
@@ -492,7 +492,7 @@ C     Store the result on disk.
         w_globFile = .FALSE.
         CALL MDS_WRITE_SEC_YZ(
      I                activeVar_file, prec, w_globFile, useCurrentDir,
-     I                'RL', myNr,
+     I                'RL', myNr, 1, myNr,
      I                active_data_t, dummyRS,
      I                iRec, myOptimIter, myThid )
 
@@ -514,7 +514,7 @@ C     >>>>>>>>>>>>>>>>>>> TANGENT RUN <<<<<<<<<<<<<<<<<<<
 C     Read the active variable from file.
         CALL MDS_READ_SEC_YZ(
      I                activeVar_file, prec, useCurrentDir,
-     I                'RL', myNr,
+     I                'RL', myNr, 1, myNr,
      O                active_var, dummyRS,
      I                iRec, myThid )
       ENDIF
@@ -605,7 +605,7 @@ C     >>>>>>>>>>>>>>>>>>> FORWARD RUN <<<<<<<<<<<<<<<<<<<
 C     Read the active variable from file.
         CALL MDS_READ_SEC_YZ(
      I                activeVar_file, prec, useCurrentDir,
-     I                'RS', myNr,
+     I                'RS', myNr, 1, myNr,
      O                dummyRL, active_var,
      I                iRec, myThid )
 
@@ -627,7 +627,7 @@ C     adjoint variable file. These files are tiled.
           CALL ADD_PREFIX( adpref, activeVar_file, adfname )
           CALL MDS_WRITE_SEC_YZ(
      I                adfname, prec, globalFile, useCurrentDir,
-     I                'RS', myNr,
+     I                'RS', myNr, 1, myNr,
      I                dummyRL, active_data_t,
      I                iRec, myOptimIter, myThid )
 
@@ -640,7 +640,7 @@ C     >>>>>>>>>>>>>>>>>>> ADJOINT RUN <<<<<<<<<<<<<<<<<<<
 
         CALL MDS_READ_SEC_YZ(
      I                activeVar_file, prec, useCurrentDir,
-     I                'RS', myNr,
+     I                'RS', myNr, 1, myNr,
      O                dummyRL, active_data_t,
      I                iRec, myThid )
 
@@ -660,7 +660,7 @@ C     Store the result on disk.
         w_globFile = .FALSE.
         CALL MDS_WRITE_SEC_YZ(
      I                activeVar_file, prec, w_globFile, useCurrentDir,
-     I                'RS', myNr,
+     I                'RS', myNr, 1, myNr,
      I                dummyRL, active_data_t,
      I                iRec, myOptimIter, myThid )
 
@@ -682,7 +682,7 @@ C     >>>>>>>>>>>>>>>>>>> TANGENT RUN <<<<<<<<<<<<<<<<<<<
 C     Read the active variable from file.
         CALL MDS_READ_SEC_YZ(
      I                activeVar_file, prec, useCurrentDir,
-     I                'RS', myNr,
+     I                'RS', myNr, 1, myNr,
      O                dummyRL, active_var,
      I                iRec, myThid )
       ENDIF
@@ -761,7 +761,7 @@ C     >>>>>>>>>>>>>>>>>>> FORWARD RUN <<<<<<<<<<<<<<<<<<<
       IF (theSimulationMode .EQ. FORWARD_SIMULATION) THEN
         CALL MDS_WRITE_SEC_XZ(
      I                activeVar_file, prec, globalFile, useCurrentDir,
-     I                'RL', myNr,
+     I                'RL', myNr, 1, myNr,
      I                active_var, dummyRS,
      I                iRec, myOptimIter, myThid )
       ENDIF
@@ -771,7 +771,7 @@ C     >>>>>>>>>>>>>>>>>>> ADJOINT RUN <<<<<<<<<<<<<<<<<<<
 
         CALL MDS_READ_SEC_XZ(
      I                activeVar_file, prec, useCurrentDir,
-     I                'RL', myNr,
+     I                'RL', myNr, 1, myNr,
      O                active_data_t, dummyRS,
      I                iRec, myThid )
 
@@ -789,7 +789,7 @@ C     Add active_var from appropriate location to data.
         ENDDO
         CALL MDS_WRITE_SEC_XZ(
      I                activeVar_file, prec, globalFile, useCurrentDir,
-     I                'RL', myNr,
+     I                'RL', myNr, 1, myNr,
      I                active_data_t, dummyRS,
      I                iRec, myOptimIter, myThid )
 
@@ -799,7 +799,7 @@ C     >>>>>>>>>>>>>>>>>>> TANGENT RUN <<<<<<<<<<<<<<<<<<<
       IF (theSimulationMode .EQ. TANGENT_SIMULATION) THEN
         CALL MDS_WRITE_SEC_XZ(
      I                activeVar_file, prec, globalFile, useCurrentDir,
-     I                'RL', myNr,
+     I                'RL', myNr, 1, myNr,
      I                active_var, dummyRS,
      I                iRec, myOptimIter, myThid )
       ENDIF
@@ -878,7 +878,7 @@ C     >>>>>>>>>>>>>>>>>>> FORWARD RUN <<<<<<<<<<<<<<<<<<<
       IF (theSimulationMode .EQ. FORWARD_SIMULATION) THEN
         CALL MDS_WRITE_SEC_XZ(
      I                activeVar_file, prec, globalFile, useCurrentDir,
-     I                'RS', myNr,
+     I                'RS', myNr, 1, myNr,
      I                dummyRL, active_var,
      I                iRec, myOptimIter, myThid )
       ENDIF
@@ -888,7 +888,7 @@ C     >>>>>>>>>>>>>>>>>>> ADJOINT RUN <<<<<<<<<<<<<<<<<<<
 
         CALL MDS_READ_SEC_XZ(
      I                activeVar_file, prec, useCurrentDir,
-     I                'RS', myNr,
+     I                'RS', myNr, 1, myNr,
      O                dummyRL, active_data_t,
      I                iRec, myThid )
 
@@ -906,7 +906,7 @@ C     Add active_var from appropriate location to data.
         ENDDO
         CALL MDS_WRITE_SEC_XZ(
      I                activeVar_file, prec, globalFile, useCurrentDir,
-     I                'RS', myNr,
+     I                'RS', myNr, 1, myNr,
      I                dummyRL, active_data_t,
      I                iRec, myOptimIter, myThid )
 
@@ -916,7 +916,7 @@ C     >>>>>>>>>>>>>>>>>>> TANGENT RUN <<<<<<<<<<<<<<<<<<<
       IF (theSimulationMode .EQ. TANGENT_SIMULATION) THEN
         CALL MDS_WRITE_SEC_XZ(
      I                activeVar_file, prec, globalFile, useCurrentDir,
-     I                'RS', myNr,
+     I                'RS', myNr, 1, myNr,
      I                dummyRL, active_var,
      I                iRec, myOptimIter, myThid )
       ENDIF
@@ -995,7 +995,7 @@ C     >>>>>>>>>>>>>>>>>>> FORWARD RUN <<<<<<<<<<<<<<<<<<<
       IF (theSimulationMode .EQ. FORWARD_SIMULATION) THEN
         CALL MDS_WRITE_SEC_YZ(
      I                activeVar_file, prec, globalFile, useCurrentDir,
-     I                'RL', myNr,
+     I                'RL', myNr, 1, myNr,
      I                active_var, dummyRS,
      I                iRec, myOptimIter, myThid )
       ENDIF
@@ -1005,7 +1005,7 @@ C     >>>>>>>>>>>>>>>>>>> ADJOINT RUN <<<<<<<<<<<<<<<<<<<
 
         CALL MDS_READ_SEC_YZ(
      I                activeVar_file, prec, useCurrentDir,
-     I                'RL', myNr,
+     I                'RL', myNr, 1, myNr,
      O                active_data_t, dummyRS,
      I                iRec, myThid )
 
@@ -1023,7 +1023,7 @@ C     Add active_var from appropriate location to data.
         ENDDO
         CALL MDS_WRITE_SEC_YZ(
      I                activeVar_file, prec, globalFile, useCurrentDir,
-     I                'RL', myNr,
+     I                'RL', myNr, 1, myNr,
      I                active_data_t, dummyRS,
      I                iRec, myOptimIter, myThid )
 
@@ -1033,7 +1033,7 @@ C     >>>>>>>>>>>>>>>>>>> TANGENT RUN <<<<<<<<<<<<<<<<<<<
       IF (theSimulationMode .EQ. TANGENT_SIMULATION) THEN
         CALL MDS_WRITE_SEC_YZ(
      I                activeVar_file, prec, globalFile, useCurrentDir,
-     I                'RL', myNr,
+     I                'RL', myNr, 1, myNr,
      I                active_var, dummyRS,
      I                iRec, myOptimIter, myThid )
       ENDIF
@@ -1112,7 +1112,7 @@ C     >>>>>>>>>>>>>>>>>>> FORWARD RUN <<<<<<<<<<<<<<<<<<<
       IF (theSimulationMode .EQ. FORWARD_SIMULATION) THEN
         CALL MDS_WRITE_SEC_YZ(
      I                activeVar_file, prec, globalFile, useCurrentDir,
-     I                'RS', myNr,
+     I                'RS', myNr, 1, myNr,
      I                dummyRL, active_var,
      I                iRec, myOptimIter, myThid )
       ENDIF
@@ -1122,7 +1122,7 @@ C     >>>>>>>>>>>>>>>>>>> ADJOINT RUN <<<<<<<<<<<<<<<<<<<
 
         CALL MDS_READ_SEC_YZ(
      I                activeVar_file, prec, useCurrentDir,
-     I                'RS', myNr,
+     I                'RS', myNr, 1, myNr,
      O                dummyRL, active_data_t,
      I                iRec, myThid )
 
@@ -1140,7 +1140,7 @@ C     Add active_var from appropriate location to data.
         ENDDO
         CALL MDS_WRITE_SEC_YZ(
      I                activeVar_file, prec, globalFile, useCurrentDir,
-     I                'RS', myNr,
+     I                'RS', myNr, 1, myNr,
      I                dummyRL, active_data_t,
      I                iRec, myOptimIter, myThid )
 
@@ -1150,7 +1150,7 @@ C     >>>>>>>>>>>>>>>>>>> TANGENT RUN <<<<<<<<<<<<<<<<<<<
       IF (theSimulationMode .EQ. TANGENT_SIMULATION) THEN
         CALL MDS_WRITE_SEC_YZ(
      I                activeVar_file, prec, globalFile, useCurrentDir,
-     I                'RS', myNr,
+     I                'RS', myNr, 1, myNr,
      I                dummyRL, active_var,
      I                iRec, myOptimIter, myThid )
       ENDIF

--- a/pkg/mdsio/mdsio_ad.flow
+++ b/pkg/mdsio/mdsio_ad.flow
@@ -1,16 +1,16 @@
 C----------------------------------------
 C subroutine mds_read_field
 C----------------------------------------
-CADJ SUBROUTINE mds_read_field  INPUT  = 1,2,3,4,5,6,7,    10,11
-CADJ SUBROUTINE mds_read_field  OUTPUT =               8,9
-CADJ SUBROUTINE mds_read_field  DEPEND = 1,2,3,4,5,6,7,8,9,10,11
-CADJ SUBROUTINE mds_read_field  REQUIRED
+CADJ SUBROUTINE MDS_READ_FIELD  INPUT  = 1,2,3,4,5,6,7,    10,11
+CADJ SUBROUTINE MDS_READ_FIELD  OUTPUT =               8,9
+CADJ SUBROUTINE MDS_READ_FIELD  DEPEND = 1,2,3,4,5,6,7,8,9,10,11
+CADJ SUBROUTINE MDS_READ_FIELD  REQUIRED
 
 C----------------------------------------
 C subroutine mds_write_field
 C----------------------------------------
-CADJ SUBROUTINE mds_write_field  INPUT  = 1,2,3,4,5,6,7,8,9,10,11,12,13
-CADJ SUBROUTINE mds_write_field  OUTPUT =
+CADJ SUBROUTINE MDS_WRITE_FIELD  INPUT  = 1,2,3,4,5,6,7,8,9,10,11,12,13
+CADJ SUBROUTINE MDS_WRITE_FIELD  OUTPUT =
 
 C----------------------------------------
 C subroutine mds_read_rec_xz
@@ -31,30 +31,30 @@ cCADJ SUBROUTINE mds_read_rec_yz  REQUIRED
 C----------------------------------------
 C subroutine mds_read_sec_xz
 C----------------------------------------
-CADJ SUBROUTINE mds_read_sec_xz  INPUT  = 1,2,3,4,5,    8,9
-CADJ SUBROUTINE mds_read_sec_xz  OUTPUT =           6,7
-CADJ SUBROUTINE mds_read_sec_xz  DEPEND = 1,2,3,4,5,6,7,8,9
-CADJ SUBROUTINE mds_read_sec_xz  REQUIRED
+CADJ SUBROUTINE MDS_READ_SEC_XZ  INPUT  = 1,2,3,4,5,6,7,    10,11
+CADJ SUBROUTINE MDS_READ_SEC_XZ  OUTPUT =               8,9
+CADJ SUBROUTINE MDS_READ_SEC_XZ  DEPEND = 1,2,3,4,5,6,7,8,9,10,11
+CADJ SUBROUTINE MDS_READ_SEC_XZ  REQUIRED
 
 C----------------------------------------
 C subroutine mds_read_sec_yz
 C----------------------------------------
-CADJ SUBROUTINE mds_read_sec_yz  INPUT  = 1,2,3,4,5,    8,9
-CADJ SUBROUTINE mds_read_sec_yz  OUTPUT =           6,7
-CADJ SUBROUTINE mds_read_sec_yz  DEPEND = 1,2,3,4,5,6,7,8,9
-CADJ SUBROUTINE mds_read_sec_yz  REQUIRED
+CADJ SUBROUTINE MDS_READ_SEC_YZ  INPUT  = 1,2,3,4,5,6,7,    10,11
+CADJ SUBROUTINE MDS_READ_SEC_YZ  OUTPUT =               8,9
+CADJ SUBROUTINE MDS_READ_SEC_YZ  DEPEND = 1,2,3,4,5,6,7,8,9,10,11
+CADJ SUBROUTINE MDS_READ_SEC_YZ  REQUIRED
 
 C----------------------------------------
 C subroutine mds_write_sec_xz
 C----------------------------------------
-CADJ SUBROUTINE mds_write_sec_xz  INPUT  = 1,2,3,4,5,6,7,8,9,10,11
-CADJ SUBROUTINE mds_write_sec_xz  OUTPUT =
+CADJ SUBROUTINE MDS_WRITE_SEC_XZ  INPUT  = 1,2,3,4,5,6,7,8,9,10,11,12,13
+CADJ SUBROUTINE MDS_WRITE_SEC_XZ  OUTPUT =
 
 C----------------------------------------
 C subroutine mds_write_sec_yz
 C----------------------------------------
-CADJ SUBROUTINE mds_write_sec_yz  INPUT  = 1,2,3,4,5,6,7,8,9,10,11
-CADJ SUBROUTINE mds_write_sec_yz  OUTPUT =
+CADJ SUBROUTINE MDS_WRITE_SEC_YZ  INPUT  = 1,2,3,4,5,6,7,8,9,10,11,12,13
+CADJ SUBROUTINE MDS_WRITE_SEC_YZ  OUTPUT =
 
 C----------------------------------------
 C subroutine mdsreadfield

--- a/pkg/mdsio/mdsio_read_section.F
+++ b/pkg/mdsio/mdsio_read_section.F
@@ -15,7 +15,7 @@ C !INTERFACE:
      I   filePrec,
      I   useCurrentDir,
      I   arrType,
-     I   kSize,
+     I   kSize, kLo, kHi,
      O   fldRL, fldRS,
      I   irecord,
      I   myThid )
@@ -28,7 +28,9 @@ C filePrec    integer :: number of bits per word in file (32 or 64)
 C useCurrentDir(logic):: always read from the current directory (even if
 C                        "mdsioLocalDir" is set)
 C arrType     char(2) :: which array (fldRL/RS) to read into, either "RL" or "RS"
-C kSize       integer :: size of third dimension, normally either 1 or Nr
+C kSize       integer :: size of second dimension, normally either 1 or Nr
+C kLo         integer :: 1rst vertical level (of array fldRL/RS) to read-in
+C kHi         integer :: last vertical level (of array fldRL/RS) to read-in
 C fldRL         RL    :: array to read into if arrType="RL", fldRL(:,kSize,:,:)
 C fldRS         RS    :: array to read into if arrType="RS", fldRS(:,kSize,:,:)
 C irecord     integer :: record number to read
@@ -64,7 +66,7 @@ C !INPUT PARAMETERS:
       INTEGER filePrec
       LOGICAL useCurrentDir
       CHARACTER*(2) arrType
-      INTEGER kSize
+      INTEGER kSize, kLo, kHi
       INTEGER irecord
       INTEGER myThid
 C !OUTPUT PARAMETERS:
@@ -77,16 +79,17 @@ C !FUNCTIONS:
       EXTERNAL ILNBLNK, MDS_RECLEN
 
 C !LOCAL VARIABLES:
-      CHARACTER*(MAX_LEN_FNAM) dataFName,pfName
-      INTEGER iG,jG,irec,bi,bj,k,dUnit,IL,pIL
+      CHARACTER*(MAX_LEN_FNAM) dataFName, pfName
+      INTEGER IL, pIL, dUnit, nLev, irec
+      INTEGER iG, jG, bi, bj, k, kL
       LOGICAL exst
       Real*4 r4seg(sNx)
       Real*8 r8seg(sNx)
-      LOGICAL globalFile,fileIsOpen
+      LOGICAL globalFile, fileIsOpen
       INTEGER length_of_rec
-      CHARACTER*(max_len_mbuf) msgBuf
+      CHARACTER*(MAX_LEN_MBUF) msgBuf
 #ifdef ALLOW_EXCH2
-      INTEGER tGx,tNx,tN
+      INTEGER tGx, tNx, tN
 #endif /* ALLOW_EXCH2 */
 C     ------------------------------------------------------------------
 
@@ -118,6 +121,9 @@ C Assign special directory
        WRITE(pfName,'(2a)') mdsioLocalDir(1:pIL), fName(1:IL)
       ENDIF
       pIL=ILNBLNK( pfName )
+
+C Set number of levels to read:
+      nLev = kHi - kLo + 1
 
 C Assign a free unit number as the I/O channel for this routine
       CALL MDSFINDUNIT( dUnit, myThid )
@@ -201,23 +207,24 @@ C layout of global x-z section files is "xStack"
          tGx = exch2_txXStackLo(tN)
          tNx = exch2_tNx(tN)
 #endif /* ALLOW_EXCH2 */
-         DO k=1,kSize
+         DO k=1,nLev
+           kL = k + kLo - 1
            IF (globalFile) THEN
 #ifdef ALLOW_EXCH2
 C record length is sNx==tNx
             irec = 1 + ( tGx-1
-     &                   + ( k-1 + (irecord-1)*kSize )*exch2_xStack_Nx
+     &                   + ( k-1 + (irecord-1)*nLev )*exch2_xStack_Nx
      &                 )/tNx
 #else /* ALLOW_EXCH2 */
             iG = myXGlobalLo-1 + (bi-1)*sNx
             jG = (myYGlobalLo-1)/sNy + (bj-1)
-            irec=1 + INT(iG/sNx) + nSx*nPx*(k-1)
-     &           + nSx*nPx*kSize*(irecord-1)
+            irec = 1 + INT(iG/sNx) + nSx*nPx*(k-1)
+     &           + nSx*nPx*nLev*(irecord-1)
 #endif /* ALLOW_EXCH2 */
            ELSE
             iG = 0
             jG = 0
-            irec=k + kSize*(irecord-1)
+            irec = k + nLev*(irecord-1)
            ENDIF
            IF (filePrec .EQ. precFloat32) THEN
             READ(dUnit,rec=irec) r4seg
@@ -225,10 +232,10 @@ C record length is sNx==tNx
             CALL MDS_BYTESWAPR4(sNx,r4seg)
 #endif
             IF (arrType .EQ. 'RS') THEN
-             CALL MDS_SEG4toRS_2D( sNx,oLx,kSize,bi,bj,k,.TRUE.,
+             CALL MDS_SEG4toRS_2D( sNx,OLx,kSize,bi,bj,kL,.TRUE.,
      &                             r4seg,fldRS )
             ELSEIF (arrType .EQ. 'RL') THEN
-             CALL MDS_SEG4toRL_2D( sNx,oLx,kSize,bi,bj,k,.TRUE.,
+             CALL MDS_SEG4toRL_2D( sNx,OLx,kSize,bi,bj,kL,.TRUE.,
      &                             r4seg,fldRL )
             ELSE
              WRITE(msgBuf,'(A)')
@@ -242,10 +249,10 @@ C record length is sNx==tNx
             CALL MDS_BYTESWAPR8( sNx, r8seg )
 #endif
             IF (arrType .EQ. 'RS') THEN
-             CALL MDS_SEG8toRS_2D(sNx,oLx,kSize,bi,bj,k,.TRUE.,
+             CALL MDS_SEG8toRS_2D(sNx,OLx,kSize,bi,bj,kL,.TRUE.,
      &                             r8seg,fldRS )
             ELSEIF (arrType .EQ. 'RL') THEN
-             CALL MDS_SEG8toRL_2D(sNx,oLx,kSize,bi,bj,k,.TRUE.,
+             CALL MDS_SEG8toRL_2D(sNx,OLx,kSize,bi,bj,kL,.TRUE.,
      &                             r8seg,fldRL )
             ELSE
              WRITE(msgBuf,'(A)')
@@ -292,7 +299,7 @@ C !INTERFACE:
      I   filePrec,
      I   useCurrentDir,
      I   arrType,
-     I   kSize,
+     I   kSize, kLo, kHi,
      O   fldRL, fldRS,
      I   irecord,
      I   myThid )
@@ -305,7 +312,9 @@ C filePrec    integer :: number of bits per word in file (32 or 64)
 C useCurrentDir(logic):: always read from the current directory (even if
 C                        "mdsioLocalDir" is set)
 C arrType     char(2) :: which array (fldRL/RS) to read into, either "RL" or "RS"
-C kSize       integer :: size of third dimension, normally either 1 or Nr
+C kSize       integer :: size of second dimension, normally either 1 or Nr
+C kLo         integer :: 1rst vertical level (of array fldRL/RS) to read-in
+C kHi         integer :: last vertical level (of array fldRL/RS) to read-in
 C fldRL         RL    :: array to read into if arrType="RL", fldRL(:,kSize,:,:)
 C fldRS         RS    :: array to read into if arrType="RS", fldRS(:,kSize,:,:)
 C irecord     integer :: record number to read
@@ -341,7 +350,7 @@ C !INPUT PARAMETERS:
       INTEGER filePrec
       LOGICAL useCurrentDir
       CHARACTER*(2) arrType
-      INTEGER kSize
+      INTEGER kSize, kLo, kHi
       INTEGER irecord
       INTEGER myThid
 C !OUTPUT PARAMETERS:
@@ -354,16 +363,17 @@ C !FUNCTIONS:
       EXTERNAL ILNBLNK, MDS_RECLEN
 
 C !LOCAL VARIABLES:
-      CHARACTER*(MAX_LEN_FNAM) dataFName,pfName
-      INTEGER iG,jG,irec,bi,bj,k,dUnit,IL,pIL
+      CHARACTER*(MAX_LEN_FNAM) dataFName, pfName
+      INTEGER IL, pIL, dUnit, nLev, irec
+      INTEGER iG, jG, bi, bj, k, kL
       LOGICAL exst
       Real*4 r4seg(sNy)
       Real*8 r8seg(sNy)
-      LOGICAL globalFile,fileIsOpen
+      LOGICAL globalFile, fileIsOpen
       INTEGER length_of_rec
-      CHARACTER*(max_len_mbuf) msgBuf
+      CHARACTER*(MAX_LEN_MBUF) msgBuf
 #ifdef ALLOW_EXCH2
-      INTEGER tGy,tNy,tN
+      INTEGER tGy, tNy, tN
 #endif /* ALLOW_EXCH2 */
 
 C     ------------------------------------------------------------------
@@ -396,6 +406,9 @@ C Assign special directory
        WRITE(pfName,'(2A)') mdsioLocalDir(1:pIL), fName(1:IL)
       ENDIF
       pIL=ILNBLNK( pfName )
+
+C Set number of levels to read:
+      nLev = kHi - kLo + 1
 
 C Assign a free unit number as the I/O channel for this routine
       CALL MDSFINDUNIT( dUnit, myThid )
@@ -479,23 +492,24 @@ C layout of global y-z section files is "yStack"
          tGy = exch2_tyYStackLo(tN)
          tNy = exch2_tNy(tN)
 #endif /* ALLOW_EXCH2 */
-         DO k=1,kSize
+         DO k=1,nLev
+           kL = k + kLo - 1
            IF (globalFile) THEN
 #ifdef ALLOW_EXCH2
 C record length is sNy==tNy
             irec = 1 + ( tGy-1
-     &                   + ( k-1 + (irecord-1)*kSize )*exch2_yStack_Ny
+     &                   + ( k-1 + (irecord-1)*nLev )*exch2_yStack_Ny
      &                 )/tNy
 #else /* ALLOW_EXCH2 */
             iG = (myXGlobalLo-1)/sNx + (bi-1)
             jG = myYGlobalLo-1 + (bj-1)*sNy
-            irec=1 + INT(jG/sNy) + nSy*nPy*(k-1)
-     &           + nSy*nPy*kSize*(irecord-1)
+            irec = 1 + INT(jG/sNy) + nSy*nPy*(k-1)
+     &           + nSy*nPy*nLev*(irecord-1)
 #endif /* ALLOW_EXCH2 */
            ELSE
             iG = 0
             jG = 0
-            irec=k + kSize*(irecord-1)
+            irec = k + nLev*(irecord-1)
            ENDIF
            IF (filePrec .EQ. precFloat32) THEN
             READ(dUnit,rec=irec) r4seg
@@ -503,10 +517,10 @@ C record length is sNy==tNy
             CALL MDS_BYTESWAPR4(sNy,r4seg)
 #endif
             IF (arrType .EQ. 'RS') THEN
-             CALL MDS_SEG4toRS_2D( sNy,oLy,kSize,bi,bj,k,.TRUE.,
+             CALL MDS_SEG4toRS_2D( sNy,OLy,kSize,bi,bj,kL,.TRUE.,
      &                             r4seg,fldRS )
             ELSEIF (arrType .EQ. 'RL') THEN
-             CALL MDS_SEG4toRL_2D( sNy,oLy,kSize,bi,bj,k,.TRUE.,
+             CALL MDS_SEG4toRL_2D( sNy,OLy,kSize,bi,bj,kL,.TRUE.,
      &                             r4seg,fldRL )
             ELSE
              WRITE(msgBuf,'(A)')
@@ -520,10 +534,10 @@ C record length is sNy==tNy
             CALL MDS_BYTESWAPR8( sNy, r8seg )
 #endif
             IF (arrType .EQ. 'RS') THEN
-             CALL MDS_SEG8toRS_2D( sNy,oLy,kSize,bi,bj,k,.TRUE.,
+             CALL MDS_SEG8toRS_2D( sNy,OLy,kSize,bi,bj,kL,.TRUE.,
      &                             r8seg,fldRS )
             ELSEIF (arrType .EQ. 'RL') THEN
-             CALL MDS_SEG8toRL_2D( sNy,oLy,kSize,bi,bj,k,.TRUE.,
+             CALL MDS_SEG8toRL_2D( sNy,OLy,kSize,bi,bj,kL,.TRUE.,
      &                             r8seg,fldRL )
             ELSE
              WRITE(msgBuf,'(A)')

--- a/pkg/mdsio/mdsio_rw_slice.F
+++ b/pkg/mdsio/mdsio_rw_slice.F
@@ -62,12 +62,12 @@ C Local variables
 
       IF ( arrType.EQ.'RL' ) THEN
         CALL MDS_READ_SEC_XZ(
-     I                fName, filePrec, .FALSE., arrType, nNz,
+     I                fName, filePrec, .FALSE., arrType, nNz, 1, nNz,
      O                arr, dummyRS,
      I                irecord, myThid )
       ELSE
         CALL MDS_READ_SEC_XZ(
-     I                fName, filePrec, .FALSE., arrType, nNz,
+     I                fName, filePrec, .FALSE., arrType, nNz, 1, nNz,
      O                dummyRL, arr,
      I                irecord, myThid )
       ENDIF
@@ -127,12 +127,12 @@ C Local variables
 
       IF ( arrType.EQ.'RL' ) THEN
         CALL MDS_READ_SEC_YZ(
-     I                fName, filePrec, .FALSE., arrType, nNz,
+     I                fName, filePrec, .FALSE., arrType, nNz, 1, nNz,
      O                arr, dummyRS,
      I                irecord, myThid )
       ELSE
         CALL MDS_READ_SEC_YZ(
-     I                fName, filePrec, .FALSE., arrType, nNz,
+     I                fName, filePrec, .FALSE., arrType, nNz, 1, nNz,
      O                dummyRL, arr,
      I                irecord, myThid )
       ENDIF
@@ -192,12 +192,12 @@ C Local variables
 
       IF ( arrType.EQ.'RL' ) THEN
         CALL MDS_READ_SEC_XZ(
-     I                fName, filePrec, .TRUE., arrType, nNz,
+     I                fName, filePrec, .TRUE., arrType, nNz, 1, nNz,
      O                arr, dummyRS,
      I                irecord, myThid )
       ELSE
         CALL MDS_READ_SEC_XZ(
-     I                fName, filePrec, .TRUE., arrType, nNz,
+     I                fName, filePrec, .TRUE., arrType, nNz, 1, nNz,
      O                dummyRL, arr,
      I                irecord, myThid )
       ENDIF
@@ -257,12 +257,12 @@ C Local variables
 
       IF ( arrType.EQ.'RL' ) THEN
         CALL MDS_READ_SEC_YZ(
-     I                fName, filePrec, .TRUE., arrType, nNz,
+     I                fName, filePrec, .TRUE., arrType, nNz, 1, nNz,
      O                arr, dummyRS,
      I                irecord, myThid )
       ELSE
         CALL MDS_READ_SEC_YZ(
-     I                fName, filePrec, .TRUE., arrType, nNz,
+     I                fName, filePrec, .TRUE., arrType, nNz, 1, nNz,
      O                dummyRL, arr,
      I                irecord, myThid )
       ENDIF
@@ -329,12 +329,12 @@ C Local variables
       IF ( arrType.EQ.'RL' ) THEN
         CALL MDS_WRITE_SEC_XZ(
      I                 fName, filePrec, globalFile, .FALSE.,
-     I                 arrType, nNz, arr, dummyRS,
+     I                 arrType, nNz, 1, nNz, arr, dummyRS,
      I                 irecord, myIter, myThid )
       ELSE
         CALL MDS_WRITE_SEC_XZ(
      I                 fName, filePrec, globalFile, .FALSE.,
-     I                 arrType, nNz, dummyRL, arr,
+     I                 arrType, nNz, 1, nNz, dummyRL, arr,
      I                 irecord, myIter, myThid )
       ENDIF
 
@@ -400,12 +400,12 @@ C Local variables
       IF ( arrType.EQ.'RL' ) THEN
         CALL MDS_WRITE_SEC_YZ(
      I                 fName, filePrec, globalFile, .FALSE.,
-     I                 arrType, nNz, arr, dummyRS,
+     I                 arrType, nNz, 1, nNz, arr, dummyRS,
      I                 irecord, myIter, myThid )
       ELSE
         CALL MDS_WRITE_SEC_YZ(
      I                 fName, filePrec, globalFile, .FALSE.,
-     I                 arrType, nNz, dummyRL, arr,
+     I                 arrType, nNz, 1, nNz, dummyRL, arr,
      I                 irecord, myIter, myThid )
       ENDIF
 
@@ -471,12 +471,12 @@ C Local variables
       IF ( arrType.EQ.'RL' ) THEN
         CALL MDS_WRITE_SEC_XZ(
      I                 fName, filePrec, globalFile, .TRUE.,
-     I                 arrType, nNz, arr, dummyRS,
+     I                 arrType, nNz, 1, nNz, arr, dummyRS,
      I                 irecord, myIter, myThid )
       ELSE
         CALL MDS_WRITE_SEC_XZ(
      I                 fName, filePrec, globalFile, .TRUE.,
-     I                 arrType, nNz, dummyRL, arr,
+     I                 arrType, nNz, 1, nNz, dummyRL, arr,
      I                 irecord, myIter, myThid )
       ENDIF
 
@@ -542,12 +542,12 @@ C Local variables
       IF ( arrType.EQ.'RL' ) THEN
         CALL MDS_WRITE_SEC_YZ(
      I                 fName, filePrec, globalFile, .TRUE.,
-     I                 arrType, nNz, arr, dummyRS,
+     I                 arrType, nNz, 1, nNz, arr, dummyRS,
      I                 irecord, myIter, myThid )
       ELSE
         CALL MDS_WRITE_SEC_YZ(
      I                 fName, filePrec, globalFile, .TRUE.,
-     I                 arrType, nNz, dummyRL, arr,
+     I                 arrType, nNz, 1, nNz, dummyRL, arr,
      I                 irecord, myIter, myThid )
       ENDIF
 

--- a/pkg/mdsio/mdsio_write_section.F
+++ b/pkg/mdsio/mdsio_write_section.F
@@ -16,7 +16,7 @@ C !INTERFACE:
      I   globalFile,
      I   useCurrentDir,
      I   arrType,
-     I   kSize,
+     I   kSize, kLo, kHi,
      I   fldRL, fldRS,
      I   irecord,
      I   myIter,
@@ -31,7 +31,9 @@ C globalFile  logical :: selects between writing a global or tiled file
 C useCurrentDir logic :: always write to the current directory (even if
 C                        "mdsioLocalDir" is set)
 C arrType     char(2) :: which array (fldRL/RS) to write, either "RL" or "RS"
-C kSize       integer :: size of third dimension, normally either 1 or Nr
+C kSize       integer :: size of second dimension: normally either 1 or Nr
+C kLo         integer :: 1rst vertical level (of array fldRL/RS) to write
+C kHi         integer :: last vertical level (of array fldRL/RS) to write
 C fldRL         RL    :: array to write if arrType="RL", fldRL(:,kSize,:,:)
 C fldRS         RS    :: array to write if arrType="RS", fldRS(:,kSize,:,:)
 C irecord     integer :: record number to read
@@ -70,7 +72,7 @@ C !INPUT PARAMETERS:
       LOGICAL globalFile
       LOGICAL useCurrentDir
       CHARACTER*(2) arrType
-      INTEGER kSize
+      INTEGER kSize, kLo, kHi
       _RL  fldRL(*)
       _RS  fldRS(*)
       INTEGER irecord
@@ -84,15 +86,16 @@ C !FUNCTIONS:
       EXTERNAL ILNBLNK, MDS_RECLEN
 
 C !LOCAL VARIABLES:
-      CHARACTER*(MAX_LEN_FNAM) dataFName,pfName
-      INTEGER iG,jG,irec,bi,bj,k,dUnit,IL,pIL
+      CHARACTER*(MAX_LEN_FNAM) dataFName, pfName
+      INTEGER IL, pIL, dUnit, nLev, irec
+      INTEGER iG, jG, bi, bj, k, kL
       Real*4 r4seg(sNx)
       Real*8 r8seg(sNx)
       INTEGER length_of_rec
       LOGICAL fileIsOpen
-      CHARACTER*(max_len_mbuf) msgBuf
+      CHARACTER*(MAX_LEN_MBUF) msgBuf
 #ifdef ALLOW_EXCH2
-      INTEGER tGx,tNx,tN
+      INTEGER tGx, tNx, tN
 #endif /* ALLOW_EXCH2 */
 
 C     ------------------------------------------------------------------
@@ -124,6 +127,9 @@ C Assign special directory
        WRITE(pfName,'(2A)') mdsioLocalDir(1:pIL), fName(1:IL)
       ENDIF
       pIL=ILNBLNK( pfName )
+
+C Set number of levels to write:
+      nLev = kHi - kLo + 1
 
 C Assign a free unit number as the I/O channel for this routine
       CALL MDSFINDUNIT( dUnit, myThid )
@@ -172,30 +178,31 @@ C layout of global x-z section files is "xStack"
          tGx = exch2_txXStackLo(tN)
          tNx = exch2_tNx(tN)
 #endif /* ALLOW_EXCH2 */
-         DO k=1,kSize
+         DO k=1,nLev
+           kL = k + kLo - 1
            IF (globalFile) THEN
 #ifdef ALLOW_EXCH2
 C record length is sNx==tNx
             irec = 1 + ( tGx-1
-     &                   + ( k-1 + (irecord-1)*kSize )*exch2_xStack_Nx
+     &                   + ( k-1 + (irecord-1)*nLev )*exch2_xStack_Nx
      &                 )/tNx
 #else /* ALLOW_EXCH2 */
             iG = myXGlobalLo-1 + (bi-1)*sNx
             jG = (myYGlobalLo-1)/sNy + (bj-1)
-            irec=1 + INT(iG/sNx) + nSx*nPx*(k-1)
-     &           + nSx*nPx*kSize*(irecord-1)
+            irec = 1 + INT(iG/sNx) + nSx*nPx*(k-1)
+     &           + nSx*nPx*nLev*(irecord-1)
 #endif /* ALLOW_EXCH2 */
            ELSE
             iG = 0
             jG = 0
-            irec=k + kSize*(irecord-1)
+            irec = k + nLev*(irecord-1)
            ENDIF
            IF (filePrec .EQ. precFloat32) THEN
             IF (arrType .EQ. 'RS') THEN
-             CALL MDS_SEG4toRS_2D( sNx,oLx,kSize,bi,bj,k,.FALSE.,
+             CALL MDS_SEG4toRS_2D( sNx,OLx,kSize,bi,bj,kL,.FALSE.,
      &                             r4seg,fldRS )
             ELSEIF (arrType .EQ. 'RL') THEN
-             CALL MDS_SEG4toRL_2D( sNx,oLx,kSize,bi,bj,k,.FALSE.,
+             CALL MDS_SEG4toRL_2D( sNx,OLx,kSize,bi,bj,kL,.FALSE.,
      &                             r4seg,fldRL )
             ELSE
              WRITE(msgBuf,'(A)')
@@ -209,10 +216,10 @@ C record length is sNx==tNx
             WRITE(dUnit,rec=irec) r4seg
            ELSEIF (filePrec .EQ. precFloat64) THEN
             IF (arrType .EQ. 'RS') THEN
-             CALL MDS_SEG8toRS_2D( sNx,oLx,kSize,bi,bj,k,.FALSE.,
+             CALL MDS_SEG8toRS_2D( sNx,OLx,kSize,bi,bj,kL,.FALSE.,
      &                             r8seg,fldRS )
             ELSEIF (arrType .EQ. 'RL') THEN
-             CALL MDS_SEG8toRL_2D( sNx,oLx,kSize,bi,bj,k,.FALSE.,
+             CALL MDS_SEG8toRL_2D( sNx,OLx,kSize,bi,bj,kL,.FALSE.,
      &                             r8seg,fldRL )
             ELSE
              WRITE(msgBuf,'(A)')
@@ -270,7 +277,7 @@ C !INTERFACE:
      I   globalFile,
      I   useCurrentDir,
      I   arrType,
-     I   kSize,
+     I   kSize, kLo, kHi,
      I   fldRL, fldRS,
      I   irecord,
      I   myIter,
@@ -285,7 +292,9 @@ C globalFile  logical :: selects between writing a global or tiled file
 C useCurrentDir logic :: always write to the current directory (even if
 C                        "mdsioLocalDir" is set)
 C arrType     char(2) :: which array (fldRL/RS) to write, either "RL" or "RS"
-C kSize       integer :: size of third dimension, normally either 1 or Nr
+C kSize       integer :: size of second dimension: normally either 1 or Nr
+C kLo         integer :: 1rst vertical level (of array fldRL/RS) to write
+C kHi         integer :: last vertical level (of array fldRL/RS) to write
 C fldRL         RL    :: array to write if arrType="RL", fldRL(:,kSize,:,:)
 C fldRS         RS    :: array to write if arrType="RS", fldRS(:,kSize,:,:)
 C irecord     integer :: record number to read
@@ -324,7 +333,7 @@ C !INPUT PARAMETERS:
       LOGICAL globalFile
       LOGICAL useCurrentDir
       CHARACTER*(2) arrType
-      INTEGER kSize
+      INTEGER kSize, kLo, kHi
       _RL  fldRL(*)
       _RS  fldRS(*)
       INTEGER irecord
@@ -338,15 +347,16 @@ C !FUNCTIONS:
       EXTERNAL ILNBLNK, MDS_RECLEN
 
 C !LOCAL VARIABLES:
-      CHARACTER*(MAX_LEN_FNAM) dataFName,pfName
-      INTEGER iG,jG,irec,bi,bj,k,dUnit,IL,pIL
+      CHARACTER*(MAX_LEN_FNAM) dataFName, pfName
+      INTEGER IL, pIL, dUnit, nLev, irec
+      INTEGER iG, jG, bi, bj, k, kL
       Real*4 r4seg(sNy)
       Real*8 r8seg(sNy)
       INTEGER length_of_rec
       LOGICAL fileIsOpen
-      CHARACTER*(max_len_mbuf) msgBuf
+      CHARACTER*(MAX_LEN_MBUF) msgBuf
 #ifdef ALLOW_EXCH2
-      INTEGER tGy,tNy,tN
+      INTEGER tGy, tNy, tN
 #endif /* ALLOW_EXCH2 */
 C     ------------------------------------------------------------------
 
@@ -377,6 +387,9 @@ C Assign special directory
        WRITE(pfName,'(2a)') mdsioLocalDir(1:pIL), fName(1:IL)
       ENDIF
       pIL=ILNBLNK( pfName )
+
+C Set number of levels to write:
+      nLev = kHi - kLo + 1
 
 C Assign a free unit number as the I/O channel for this routine
       CALL MDSFINDUNIT( dUnit, myThid )
@@ -425,30 +438,31 @@ C layout of global y-z section files is "yStack"
          tGy = exch2_tyYStackLo(tN)
          tNy = exch2_tNy(tN)
 #endif /* ALLOW_EXCH2 */
-         DO k=1,kSize
+         DO k=1,nLev
+           kL = k + kLo - 1
            IF (globalFile) THEN
 #ifdef ALLOW_EXCH2
 C record length is sNy==tNy
             irec = 1 + ( tGy-1
-     &                   + ( k-1 + (irecord-1)*kSize )*exch2_yStack_Ny
+     &                   + ( k-1 + (irecord-1)*nLev )*exch2_yStack_Ny
      &                 )/tNy
 #else /* ALLOW_EXCH2 */
             iG = (myXGlobalLo-1)/sNx + (bi-1)
             jG = myYGlobalLo-1 + (bj-1)*sNy
-            irec=1 + INT(jG/sNy) + nSy*nPy*(k-1)
-     &           + nSy*nPy*kSize*(irecord-1)
+            irec = 1 + INT(jG/sNy) + nSy*nPy*(k-1)
+     &           + nSy*nPy*nLev*(irecord-1)
 #endif /* ALLOW_EXCH2 */
            ELSE
             iG = 0
             jG = 0
-            irec=k + kSize*(irecord-1)
+            irec = k + nLev*(irecord-1)
            ENDIF
            IF (filePrec .EQ. precFloat32) THEN
             IF (arrType .EQ. 'RS') THEN
-             CALL MDS_SEG4toRS_2D( sNy,oLy,kSize,bi,bj,k,.FALSE.,
+             CALL MDS_SEG4toRS_2D( sNy,OLy,kSize,bi,bj,kL,.FALSE.,
      &                             r4seg,fldRS )
             ELSEIF (arrType .EQ. 'RL') THEN
-             CALL MDS_SEG4toRL_2D( sNy,oLy,kSize,bi,bj,k,.FALSE.,
+             CALL MDS_SEG4toRL_2D( sNy,OLy,kSize,bi,bj,kL,.FALSE.,
      &                             r4seg,fldRL )
             ELSE
              WRITE(msgBuf,'(A)')
@@ -462,10 +476,10 @@ C record length is sNy==tNy
             WRITE(dUnit,rec=irec) r4seg
            ELSEIF (filePrec .EQ. precFloat64) THEN
             IF (arrType .EQ. 'RS') THEN
-             CALL MDS_SEG8toRS_2D( sNy,oLy,kSize,bi,bj,k,.FALSE.,
+             CALL MDS_SEG8toRS_2D( sNy,OLy,kSize,bi,bj,kL,.FALSE.,
      &                             r8seg,fldRS )
             ELSEIF (arrType .EQ. 'RL') THEN
-             CALL MDS_SEG8toRL_2D( sNy,oLy,kSize,bi,bj,k,.FALSE.,
+             CALL MDS_SEG8toRL_2D( sNy,OLy,kSize,bi,bj,kL,.FALSE.,
      &                             r8seg,fldRL )
             ELSE
              WRITE(msgBuf,'(A)')

--- a/pkg/rw/read_rec.F
+++ b/pkg/rw/read_rec.F
@@ -33,7 +33,7 @@ C Global
 C     !INPUT/OUTPUT PARAMETERS:
 C Arguments
       CHARACTER*(*) fName
-      _RS field(1-Olx:sNx+Olx,1-Oly:sNy+Oly,nSx,nSy)
+      _RS field(1-OLx:sNx+OLx,1-OLy:sNy+OLy,nSx,nSy)
       INTEGER iRec
       INTEGER myIter
       INTEGER myThid
@@ -92,7 +92,7 @@ C Global
 C     !INPUT/OUTPUT PARAMETERS:
 C Arguments
       CHARACTER*(*) fName
-      _RL field(1-Olx:sNx+Olx,1-Oly:sNy+Oly,nSx,nSy)
+      _RL field(1-OLx:sNx+OLx,1-OLy:sNy+OLy,nSx,nSy)
       INTEGER iRec
       INTEGER myIter
       INTEGER myThid
@@ -151,7 +151,7 @@ C Global
 C     !INPUT/OUTPUT PARAMETERS:
 C Arguments
       CHARACTER*(*) fName
-      _RS field(1-Olx:sNx+Olx,1-Oly:sNy+Oly,Nr,nSx,nSy)
+      _RS field(1-OLx:sNx+OLx,1-OLy:sNy+OLy,Nr,nSx,nSy)
       INTEGER iRec
       INTEGER myIter
       INTEGER myThid
@@ -168,7 +168,6 @@ C Local
 c     INTEGER IL
 c     CHARACTER*(MAX_LEN_FNAM) fullName
 CEOP
-
 
 c     IF (myIter.GE.0) THEN
 c      IL=ILNBLNK( fName )
@@ -211,7 +210,7 @@ C Global
 C     !INPUT/OUTPUT PARAMETERS:
 C Arguments
       CHARACTER*(*) fName
-      _RL field(1-Olx:sNx+Olx,1-Oly:sNy+Oly,Nr,nSx,nSy)
+      _RL field(1-OLx:sNx+OLx,1-OLy:sNy+OLy,Nr,nSx,nSy)
       INTEGER iRec
       INTEGER myIter
       INTEGER myThid
@@ -228,7 +227,6 @@ C Local
 c     INTEGER IL
 c     CHARACTER*(MAX_LEN_FNAM) fullName
 CEOP
-
 
 c     IF (myIter.GE.0) THEN
 c      IL=ILNBLNK( fName )
@@ -277,7 +275,7 @@ C Arguments
       CHARACTER*(*) fName
       INTEGER fPrec
       INTEGER nNz
-      _RS field(1-Olx:sNx+Olx,1-Oly:sNy+Oly,nNz,nSx,nSy)
+      _RS field(1-OLx:sNx+OLx,1-OLy:sNy+OLy,nNz,nSx,nSy)
       INTEGER iRec
       INTEGER myIter
       INTEGER myThid
@@ -293,7 +291,6 @@ C Local
 c     INTEGER IL
 c     CHARACTER*(MAX_LEN_FNAM) fullName
 CEOP
-
 
 c     IF (myIter.GE.0) THEN
 c      IL=ILNBLNK( fName )
@@ -341,7 +338,7 @@ C Arguments
       CHARACTER*(*) fName
       INTEGER fPrec
       INTEGER nNz
-      _RL field(1-Olx:sNx+Olx,1-Oly:sNy+Oly,nNz,nSx,nSy)
+      _RL field(1-OLx:sNx+OLx,1-OLy:sNy+OLy,nNz,nSx,nSy)
       INTEGER iRec
       INTEGER myIter
       INTEGER myThid
@@ -357,7 +354,6 @@ C Local
 c     INTEGER IL
 c     CHARACTER*(MAX_LEN_FNAM) fullName
 CEOP
-
 
 c     IF (myIter.GE.0) THEN
 c      IL=ILNBLNK( fName )
@@ -406,7 +402,7 @@ C Arguments
       CHARACTER*(*) fName
       INTEGER fPrec
       INTEGER kSiz, kLo, kHi
-      _RS field(1-Olx:sNx+Olx,1-Oly:sNy+Oly,kSiz,nSx,nSy)
+      _RS field(1-OLx:sNx+OLx,1-OLy:sNy+OLy,kSiz,nSx,nSy)
       INTEGER iRec
       INTEGER myIter
       INTEGER myThid
@@ -422,7 +418,6 @@ C Local
 c     INTEGER IL
 c     CHARACTER*(MAX_LEN_FNAM) fullName
 CEOP
-
 
 c     IF (myIter.GE.0) THEN
 c      IL=ILNBLNK( fName )
@@ -471,7 +466,7 @@ C Arguments
       CHARACTER*(*) fName
       INTEGER fPrec
       INTEGER kSiz, kLo, kHi
-      _RL field(1-Olx:sNx+Olx,1-Oly:sNy+Oly,kSiz,nSx,nSy)
+      _RL field(1-OLx:sNx+OLx,1-OLy:sNy+OLy,kSiz,nSx,nSy)
       INTEGER iRec
       INTEGER myIter
       INTEGER myThid
@@ -487,7 +482,6 @@ C Local
 c     INTEGER IL
 c     CHARACTER*(MAX_LEN_FNAM) fullName
 CEOP
-
 
 c     IF (myIter.GE.0) THEN
 c      IL=ILNBLNK( fName )
@@ -533,7 +527,7 @@ C Arguments
       CHARACTER*(*) fName
       INTEGER fPrec
       INTEGER nNz
-      _RS field(1-Olx:sNx+Olx,nNz,nSx,nSy)
+      _RS field(1-OLx:sNx+OLx,nNz,nSx,nSy)
       INTEGER iRec
       INTEGER myIter
       INTEGER myThid
@@ -562,7 +556,7 @@ c     ENDIF
 #ifdef ALLOW_MDSIO
       CALL MDS_READ_SEC_XZ(
      I                      fName, fPrec, useCurrentDir,
-     I                      fType, nNz,
+     I                      fType, nNz, 1, nNz,
      O                      dummyRL, field,
      I                      iRec, myThid )
 #endif
@@ -595,7 +589,7 @@ C Arguments
       CHARACTER*(*) fName
       INTEGER fPrec
       INTEGER nNz
-      _RL field(1-Olx:sNx+Olx,nNz,nSx,nSy)
+      _RL field(1-OLx:sNx+OLx,nNz,nSx,nSy)
       INTEGER iRec
       INTEGER myIter
       INTEGER myThid
@@ -624,7 +618,7 @@ c     ENDIF
 #ifdef ALLOW_MDSIO
       CALL MDS_READ_SEC_XZ(
      I                      fName, fPrec, useCurrentDir,
-     I                      fType, nNz,
+     I                      fType, nNz, 1, nNz,
      O                      field, dummyRS,
      I                      iRec, myThid )
 #endif
@@ -657,7 +651,7 @@ C Arguments
       CHARACTER*(*) fName
       INTEGER fPrec
       INTEGER nNz
-      _RS field(1-Oly:sNy+Oly,nNz,nSx,nSy)
+      _RS field(1-OLy:sNy+OLy,nNz,nSx,nSy)
       INTEGER iRec
       INTEGER myIter
       INTEGER myThid
@@ -674,7 +668,6 @@ c     INTEGER IL
 c     CHARACTER*(MAX_LEN_FNAM) fullName
 CEOP
 
-
 c     IF (myIter.GE.0) THEN
 c      IL=ILNBLNK( fName )
 c      WRITE(fullName,'(2a,i10.10)') fName(1:IL),'.',myIter
@@ -687,7 +680,7 @@ c     ENDIF
 #ifdef ALLOW_MDSIO
       CALL MDS_READ_SEC_YZ(
      I                      fName, fPrec, useCurrentDir,
-     I                      fType, nNz,
+     I                      fType, nNz, 1, nNz,
      O                      dummyRL, field,
      I                      iRec, myThid )
 #endif
@@ -720,7 +713,7 @@ C Arguments
       CHARACTER*(*) fName
       INTEGER fPrec
       INTEGER nNz
-      _RL field(1-Oly:sNy+Oly,nNz,nSx,nSy)
+      _RL field(1-OLy:sNy+OLy,nNz,nSx,nSy)
       INTEGER iRec
       INTEGER myIter
       INTEGER myThid
@@ -737,7 +730,6 @@ c     INTEGER IL
 c     CHARACTER*(MAX_LEN_FNAM) fullName
 CEOP
 
-
 c     IF (myIter.GE.0) THEN
 c      IL=ILNBLNK( fName )
 c      WRITE(fullName,'(2a,i10.10)') fName(1:IL),'.',myIter
@@ -750,7 +742,7 @@ c     ENDIF
 #ifdef ALLOW_MDSIO
       CALL MDS_READ_SEC_YZ(
      I                      fName, fPrec, useCurrentDir,
-     I                      fType, nNz,
+     I                      fType, nNz, 1, nNz,
      O                      field, dummyRS,
      I                      iRec, myThid )
 #endif

--- a/pkg/rw/write_rec.F
+++ b/pkg/rw/write_rec.F
@@ -96,7 +96,7 @@ C Global
 C     !INPUT/OUTPUT PARAMETERS:
 C Arguments
       CHARACTER*(*) fName
-      _RS field(1-Olx:sNx+Olx,1-Oly:sNy+Oly,nSx,nSy)
+      _RS field(1-OLx:sNx+OLx,1-OLy:sNy+OLy,nSx,nSy)
       INTEGER iRec
       INTEGER myIter
       INTEGER myThid
@@ -117,7 +117,6 @@ C Local
 c     INTEGER IL
 c     CHARACTER*(MAX_LEN_FNAM) fullName
 CEOP
-
 
 c     IF (myIter.GE.0) THEN
 c      IL=ILNBLNK( fName )
@@ -160,7 +159,7 @@ C Global
 C     !INPUT/OUTPUT PARAMETERS:
 C Arguments
       CHARACTER*(*) fName
-      _RL field(1-Olx:sNx+Olx,1-Oly:sNy+Oly,nSx,nSy)
+      _RL field(1-OLx:sNx+OLx,1-OLy:sNy+OLy,nSx,nSy)
       INTEGER iRec
       INTEGER myIter
       INTEGER myThid
@@ -181,7 +180,6 @@ C Local
 c     INTEGER IL
 c     CHARACTER*(MAX_LEN_FNAM) fullName
 CEOP
-
 
 c     IF (myIter.GE.0) THEN
 c      IL=ILNBLNK( fName )
@@ -224,7 +222,7 @@ C Global
 C     !INPUT/OUTPUT PARAMETERS:
 C Arguments
       CHARACTER*(*) fName
-      _RS field(1-Olx:sNx+Olx,1-Oly:sNy+Oly,Nr,nSx,nSy)
+      _RS field(1-OLx:sNx+OLx,1-OLy:sNy+OLy,Nr,nSx,nSy)
       INTEGER iRec
       INTEGER myIter
       INTEGER myThid
@@ -245,7 +243,6 @@ C Local
 c     INTEGER IL
 c     CHARACTER*(MAX_LEN_FNAM) fullName
 CEOP
-
 
 c     IF (myIter.GE.0) THEN
 c      IL=ILNBLNK( fName )
@@ -288,7 +285,7 @@ C Global
 C     !INPUT/OUTPUT PARAMETERS:
 C Arguments
       CHARACTER*(*) fName
-      _RL field(1-Olx:sNx+Olx,1-Oly:sNy+Oly,Nr,nSx,nSy)
+      _RL field(1-OLx:sNx+OLx,1-OLy:sNy+OLy,Nr,nSx,nSy)
       INTEGER iRec
       INTEGER myIter
       INTEGER myThid
@@ -309,7 +306,6 @@ C Local
 c     INTEGER IL
 c     CHARACTER*(MAX_LEN_FNAM) fullName
 CEOP
-
 
 c     IF (myIter.GE.0) THEN
 c      IL=ILNBLNK( fName )
@@ -357,7 +353,7 @@ C Arguments
       CHARACTER*(*) fName
       INTEGER fPrec
       INTEGER nNz
-      _RS field(1-Olx:sNx+Olx,1-Oly:sNy+Oly,nNz,nSx,nSy)
+      _RS field(1-OLx:sNx+OLx,1-OLy:sNy+OLy,nNz,nSx,nSy)
       INTEGER iRec
       INTEGER myIter
       INTEGER myThid
@@ -377,7 +373,6 @@ C Local
 c     INTEGER IL
 c     CHARACTER*(MAX_LEN_FNAM) fullName
 CEOP
-
 
 c     IF (myIter.GE.0) THEN
 c      IL=ILNBLNK( fName )
@@ -423,7 +418,7 @@ C Arguments
       CHARACTER*(*) fName
       INTEGER fPrec
       INTEGER nNz
-      _RL field(1-Olx:sNx+Olx,1-Oly:sNy+Oly,nNz,nSx,nSy)
+      _RL field(1-OLx:sNx+OLx,1-OLy:sNy+OLy,nNz,nSx,nSy)
       INTEGER iRec
       INTEGER myIter
       INTEGER myThid
@@ -443,7 +438,6 @@ C Local
 c     INTEGER IL
 c     CHARACTER*(MAX_LEN_FNAM) fullName
 CEOP
-
 
 c     IF (myIter.GE.0) THEN
 c      IL=ILNBLNK( fName )
@@ -490,7 +484,7 @@ C Arguments
       CHARACTER*(*) fName
       INTEGER fPrec
       INTEGER kSiz, kLo, kHi
-      _RS field(1-Olx:sNx+Olx,1-Oly:sNy+Oly,kSiz,nSx,nSy)
+      _RS field(1-OLx:sNx+OLx,1-OLy:sNy+OLy,kSiz,nSx,nSy)
       INTEGER iRec
       INTEGER myIter
       INTEGER myThid
@@ -510,7 +504,6 @@ C Local
 c     INTEGER IL
 c     CHARACTER*(MAX_LEN_FNAM) fullName
 CEOP
-
 
 c     IF (myIter.GE.0) THEN
 c      IL=ILNBLNK( fName )
@@ -557,7 +550,7 @@ C Arguments
       CHARACTER*(*) fName
       INTEGER fPrec
       INTEGER kSiz, kLo, kHi
-      _RL field(1-Olx:sNx+Olx,1-Oly:sNy+Oly,kSiz,nSx,nSy)
+      _RL field(1-OLx:sNx+OLx,1-OLy:sNy+OLy,kSiz,nSx,nSy)
       INTEGER iRec
       INTEGER myIter
       INTEGER myThid
@@ -577,7 +570,6 @@ C Local
 c     INTEGER IL
 c     CHARACTER*(MAX_LEN_FNAM) fullName
 CEOP
-
 
 c     IF (myIter.GE.0) THEN
 c      IL=ILNBLNK( fName )
@@ -622,7 +614,7 @@ C Arguments
       CHARACTER*(*) fName
       INTEGER fPrec
       INTEGER nNz
-      _RS field(1-Olx:sNx+Olx,nNz,nSx,nSy)
+      _RS field(1-OLx:sNx+OLx,nNz,nSx,nSy)
       INTEGER iRec
       INTEGER myIter
       INTEGER myThid
@@ -655,7 +647,7 @@ c     ENDIF
 #ifdef ALLOW_MDSIO
       CALL MDS_WRITE_SEC_XZ(
      I                       fName, fPrec, globalFile, useCurrentDir,
-     I                       fType, nNz,
+     I                       fType, nNz, 1, nNz,
      I                       dummyRL, field,
      I                       iRec, myIter, myThid )
 #endif
@@ -688,7 +680,7 @@ C Arguments
       CHARACTER*(*) fName
       INTEGER fPrec
       INTEGER nNz
-      _RL field(1-Olx:sNx+Olx,nNz,nSx,nSy)
+      _RL field(1-OLx:sNx+OLx,nNz,nSx,nSy)
       INTEGER iRec
       INTEGER myIter
       INTEGER myThid
@@ -721,7 +713,7 @@ c     ENDIF
 #ifdef ALLOW_MDSIO
       CALL MDS_WRITE_SEC_XZ(
      I                       fName, fPrec, globalFile, useCurrentDir,
-     I                       fType, nNz,
+     I                       fType, nNz, 1, nNz,
      I                       field, dummyRS,
      I                       iRec, myIter, myThid )
 #endif
@@ -754,7 +746,7 @@ C Arguments
       CHARACTER*(*) fName
       INTEGER fPrec
       INTEGER nNz
-      _RS field(1-Oly:sNy+Oly,nNz,nSx,nSy)
+      _RS field(1-OLy:sNy+OLy,nNz,nSx,nSy)
       INTEGER iRec
       INTEGER myIter
       INTEGER myThid
@@ -775,7 +767,6 @@ c     INTEGER IL
 c     CHARACTER*(MAX_LEN_FNAM) fullName
 CEOP
 
-
 c     IF (myIter.GE.0) THEN
 c      IL=ILNBLNK( fName )
 c      WRITE(fullName,'(2a,i10.10)') fName(1:IL),'.',myIter
@@ -788,7 +779,7 @@ c     ENDIF
 #ifdef ALLOW_MDSIO
       CALL MDS_WRITE_SEC_YZ(
      I                       fName, fPrec, globalFile, useCurrentDir,
-     I                       fType, nNz,
+     I                       fType, nNz, 1, nNz,
      I                       dummyRL, field,
      I                       iRec, myIter, myThid )
 #endif
@@ -821,7 +812,7 @@ C Arguments
       CHARACTER*(*) fName
       INTEGER fPrec
       INTEGER nNz
-      _RL field(1-Oly:sNy+Oly,nNz,nSx,nSy)
+      _RL field(1-OLy:sNy+OLy,nNz,nSx,nSy)
       INTEGER iRec
       INTEGER myIter
       INTEGER myThid
@@ -842,7 +833,6 @@ c     INTEGER IL
 c     CHARACTER*(MAX_LEN_FNAM) fullName
 CEOP
 
-
 c     IF (myIter.GE.0) THEN
 c      IL=ILNBLNK( fName )
 c      WRITE(fullName,'(2a,i10.10)') fName(1:IL),'.',myIter
@@ -855,7 +845,7 @@ c     ENDIF
 #ifdef ALLOW_MDSIO
       CALL MDS_WRITE_SEC_YZ(
      I                       fName, fPrec, globalFile, useCurrentDir,
-     I                       fType, nNz,
+     I                       fType, nNz, 1, nNz,
      I                       field, dummyRS,
      I                       iRec, myIter, myThid )
 #endif


### PR DESCRIPTION
## What changes does this PR introduce?
Add 2 new arguments (kLo & kHi) to S/R MDS\_[READ/WRITE]\_SEC\_[X/Y]Z that allow to select which levels in Slice-array to fill-in (read) or to write-out to file.

## What is the current behaviour? 
For 3-D fields (routines in mdsio_read_field.F and mdsio_write_field.F), this capability is already there
(3 arguments "kSize, kLo, kHi") but is currently missing for 2-D slice I/O, i.e., can only read-in or write-out all the levels of the slice-array.

## What is the new behaviour 
Add 2 new arguments (now similar to I/O routines in mdsio_read_field.F and mdsio_write_field.F) and adjust the calls to S/R MDS\_[READ/WRITE]\_SEC\_[X/Y]Z accordingly.

## Does this PR introduce a breaking change? 
No

## Other information:
This new capability will allow to address point (2) of issue #617 (Improve OBC Tidal forcing implementation)

## Suggested addition to `tag-index`
o pkg/mdsio:
   - Add 2 new arguments (kLo & kHi) to pkg/mdsio Slice I/O routines that allow 
    to select which levels in Slice-array to read-in or to write-out to file.
