### PR TITLE
Add new required build options for readthedocs

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -5,7 +5,13 @@
 # Required
 version: 2
 
-# Build documentation in the docs/ directory with Sphinx
+# Set the OS and Python version (required)
+build:
+  os: ubuntu-22.04
+  tools:
+    python: "3.7"
+
+# Build documentation in the doc/ directory with Sphinx
 sphinx:
   configuration: doc/conf.py
   fail_on_warning: true


### PR DESCRIPTION
## What changes does this PR introduce?

Update readthedocs configuration

## What is the current behaviour? 

Failed readthedocs test on first brown-out day and will stop working 10/23/2023.

## What is the new behaviour 

Will continue working past October 2023.

## Does this PR introduce a breaking change? 

No

## Other information:

Should update to more recent python version soon.