### PR TITLE
Add full size initialisation of output var "cDrag"

### DIFF
--- a/pkg/mom_common/mom_u_botdrag_coeff.F
+++ b/pkg/mom_common/mom_u_botdrag_coeff.F
@@ -89,6 +89,15 @@ c       dragFac = wUnit2rVel(k)
         recDrC = recip_drC(kLowF)
        ENDIF
 
+#ifdef ALLOW_AUTODIFF
+C--   Initialise drag-coeff
+       DO j=1-OLy,sNy+OLy
+        DO i=1-OLx,sNx+OLx
+          cDrag(i,j) = 0. _d 0
+        ENDDO
+       ENDDO
+#endif
+
 C--   Linear bottom drag contribution to cDrag:
        DO j=1-OLy,sNy+OLy
         DO i=1-OLx+1,sNx+OLx

--- a/pkg/mom_common/mom_v_botdrag_coeff.F
+++ b/pkg/mom_common/mom_v_botdrag_coeff.F
@@ -89,6 +89,15 @@ c       dragFac = wUnit2rVel(k)
         recDrC = recip_drC(kLowF)
        ENDIF
 
+#ifdef ALLOW_AUTODIFF
+C--   Initialise drag-coeff
+       DO j=1-OLy,sNy+OLy
+        DO i=1-OLx,sNx+OLx
+          cDrag(i,j) = 0. _d 0
+        ENDDO
+       ENDDO
+#endif
+
 C--   Linear bottom drag contribution to cDrag:
        DO j=1-OLy+1,sNy+OLy
         DO i=1-OLx,sNx+OLx


### PR DESCRIPTION
While this does not seems necessary (all values that are used later on are currectly set), the (new, full size) storage dir of "cDrag" in `mon_vecinv.F` might access some overlap values that were not set before. For now, add full size initialisation of "cDrag" within #ifdef ALLOW_AUTODIFF

## What changes does this PR introduce?
Add initialisation of output var "cDrag" in S/R MOM_{U/V}_BOTDRAG_COEFF.

## What is the current behaviour? 
As a side effect of adding TAF storage dir for var "cDrag" in `mom_vecinv.F` (PR #723), experiment `obcs_ctrl` produces "floating point exception" with open64 compiler (and -devel), see:
http://mitgcm.org/testing/results/2023_09/tr_engaging-o64Adm_20230903_0/summary.txt

## What is the new behaviour 
Adding "cDrag" initialisation fix the problem.

## Does this PR introduce a breaking change? 
No

## Other information:
1. Moving "cDrag" initialisation into `mom_vecinv.F` does not fix the problem since TAF remove this addition in the "mom_vecinvmd" version (where the storage is done).
2. `shelfice_u/v_drag_coeff.F` already initialise over full size output var "cDrag".

## Suggested addition to `tag-index`
Not needed if merged jsut after PR #723