### PR TITLE
simplify file name handling in ctrl_map_ini_gentim2d.F to make both TAF and OpenAD happy

### DIFF
--- a/doc/tag-index
+++ b/doc/tag-index
@@ -1,6 +1,9 @@
     Notes on tags used in MITgcmUV
     ==============================
 
+o pkg/ctrl:
+  - simplify file name handling in ctrl_map_ini_gentim2d.F to please TAF (fixes
+    hs94.1x64x5 TL test) without upsetting Tapenade & OpenAD.
 o pkg/autodiff + ecco:
   - fix a typo in AD-var output file name (addummy_in_stepping.F);
   - fix and improve weight output in pkg/ecco/cost_generic.F

--- a/pkg/ctrl/ctrl_map_ini_gentim2d.F
+++ b/pkg/ctrl/ctrl_map_ini_gentim2d.F
@@ -57,7 +57,6 @@ C     temporary values in the do loop during reverse pass.
       CHARACTER*(MAX_LEN_FNAM) fnamegenIn(1:maxCtrlTim2D)
       CHARACTER*(MAX_LEN_FNAM) fnamegenOut(1:maxCtrlTim2D)
       CHARACTER*(MAX_LEN_FNAM) fnamegenTmp(1:maxCtrlTim2D)
-      CHARACTER*(MAX_LEN_FNAM) fnamebase(1:maxCtrlTim2D)
       CHARACTER*(MAX_LEN_FNAM) temp_genarr_fnamA
       CHARACTER*(MAX_LEN_FNAM) temp_genarr_fnamB
       integer startrec
@@ -121,9 +120,8 @@ C--   generic 2D control variables
 
         ilgen=ilnblnk( xx_gentim2d_file(iarr) )
         temp_genarr_fnamA = xx_gentim2d_file(iarr)
-        fnamebase(iarr) = temp_genarr_fnamA(1:ilgen)
 
-        call ctrl_init_rec ( fnamebase(iarr),
+        call ctrl_init_rec ( temp_genarr_fnamA(1:ilgen),
      I       xx_gentim2d_startdate1(iarr),
      I       xx_gentim2d_startdate2(iarr),
      I       xx_gentim2d_period(iarr),
@@ -165,9 +163,6 @@ C print statements are removed. See "Automatic Differentiation" chap. in the doc
          endif
         enddo
 
-        ilgen=ilnblnk( xx_gentim2d_file(iarr) )
-        temp_genarr_fnamA = xx_gentim2d_file(iarr)
-        fnamebase(iarr) = temp_genarr_fnamA(1:ilgen)
         write(temp_genarr_fnamB,'(2a,i10.10)')
      &   ctrlDir(1:ilDir)//temp_genarr_fnamA(1:ilgen),'.',optimcycle
         fnamegenIn(iarr) = temp_genarr_fnamB


### PR DESCRIPTION
## What changes does this PR introduce?
Bug fix

## What is the current behaviour? 
After PR #751, TAF swallows some lines in tangent linear version of `ctrl_map_ini_gentim2d`, breaking TL-test `hs94.1x64x5`

## What is the new behaviour 
tests pass again

## Does this PR introduce a breaking change? 
No

## Other information:

## Suggested addition to `tag-index`
(To avoid unnecessary merge conflicts, please don't update `tag-index`. One of the admins will do that when merging your pull request.)