### PR TITLE
another pkg/ctrl cleanup with implications for pkg/grdchk

### DIFF
--- a/pkg/ctrl/CTRL.h
+++ b/pkg/ctrl/CTRL.h
@@ -135,58 +135,6 @@ C                            (only used in pkg/autodiff ...)
       CHARACTER*(1) ncvargrd(maxcvars)
       CHARACTER*(2) yadprefix
 
-      COMMON /controlvec_header_i/
-     &        filenvartype,
-     &        filenvarlength,
-     &        fileOptimCycle,
-     &        filencbuffindex,
-     &        fileIg,
-     &        fileJg,
-     &        fileI,
-     &        fileJ,
-     &        filensx,
-     &        filensy,
-     &        filek,
-     &        filenWetcGlobal,
-     &        filenWetsGlobal,
-     &        filenWetwGlobal,
-     &        filenWetvGlobal,
-     &        filencvarindex,
-     &        filencvarrecs,
-     &        filencvarxmax,
-     &        filencvarymax,
-     &        filencvarnrmax
-      INTEGER filenvartype
-      INTEGER filenvarlength
-      INTEGER fileOptimCycle
-      INTEGER filencbuffindex
-      INTEGER fileIg
-      INTEGER fileJg
-      INTEGER fileI
-      INTEGER fileJ
-      INTEGER filensx
-      INTEGER filensy
-      INTEGER filek
-      INTEGER filenWetcGlobal(Nr)
-      INTEGER filenWetsGlobal(Nr)
-      INTEGER filenWetwGlobal(Nr)
-      INTEGER filenWetvGlobal(Nr)
-      INTEGER filencvarindex(maxcvars)
-      INTEGER filencvarrecs(maxcvars)
-      INTEGER filencvarxmax(maxcvars)
-      INTEGER filencvarymax(maxcvars)
-      INTEGER filencvarnrmax(maxcvars)
-
-      COMMON /controlvec_header_r/
-     &               filefc
-      _RL            filefc
-
-      COMMON /controlvec_header_c/
-     &        fileYctrlid,
-     &        filencvargrd
-      CHARACTER*(10) fileYctrlid
-      CHARACTER*( 1) filencvargrd(maxcvars)
-
 c     Define unit weight as a placeholder
       COMMON /ctrl_weights_unit_r/
      &                        wunit

--- a/pkg/ctrl/CTRL.h
+++ b/pkg/ctrl/CTRL.h
@@ -131,9 +131,13 @@ C                            (only used in pkg/autodiff ...)
 
       COMMON /controlvars_c/
      &                       ncvargrd
+     &                     , ncvartype
+     &                     , ncvarfname
      &                     , yadprefix
-      CHARACTER*(1) ncvargrd(maxcvars)
-      CHARACTER*(2) yadprefix
+      CHARACTER*(1)            ncvargrd  ( maxcvars )
+      CHARACTER*(2)            ncvartype ( maxcvars )
+      CHARACTER*(MAX_LEN_FNAM) ncvarfname( maxcvars )
+      CHARACTER*(2)            yadprefix
 
 c     Define unit weight as a placeholder
       COMMON /ctrl_weights_unit_r/

--- a/pkg/ctrl/ctrl_init.F
+++ b/pkg/ctrl/ctrl_init.F
@@ -85,6 +85,8 @@ c--     Set default values.
        ncvarymax(ivar)  =  0
        ncvarnrmax(ivar) =  0
        ncvargrd(ivar)   = '?'
+       ncvartype(ivar)  = '?'
+       ncvarfname(ivar) = ' '
       enddo
 
 c     Set unit weight to 1

--- a/pkg/ctrl/ctrl_init.F
+++ b/pkg/ctrl/ctrl_init.F
@@ -44,6 +44,7 @@ c     == local variables ==
       integer bi,bj
       integer i,j,k
       integer ivar
+      LOGICAL costfinal_exists
 
       _RL dummy
       _RL loctmp3d (1-OLx:sNx+OLx,1-OLy:sNy+OLy,Nr,nSx,nSy)
@@ -108,6 +109,17 @@ c
       CALL WRITE_REC_XYZ_RL( 'wunit', loctmp3d, 1, 1, myThid )
 #endif
 
+#ifdef CTRL_DO_PACK_UNPACK_ONLY
+      costfinal_exists=.FALSE.
+#else
+c     _BEGIN_MASTER( myThid )
+      inquire( file='costfinal', exist=costfinal_exists )
+c     _END_MASTER( myThid )
+
+c-- for DIVA, avoid forward-related output in adjoint part
+      IF ( costfinal_exists ) CALL TURNOFF_MODEL_IO( 1, myThid )
+#endif
+
       _BARRIER
 
 c--   ===========================
@@ -124,7 +136,7 @@ c--   Northern obc.
      I     myThid )
       call ctrl_init_ctrlvar (
      &     xx_obcsn_file, 11, 111, diffrec, startrec, endrec,
-     &     sNx, 1, Nr, 'm', 'xz', myThid )
+     &     sNx, 1, Nr, 'm', 'xz', costfinal_exists, myThid )
 #endif /* ALLOW_OBCSN_CONTROL */
 
 c----------------------------------------------------------------------
@@ -137,7 +149,7 @@ c--   Southern obc.
      I     myThid )
       call ctrl_init_ctrlvar (
      &     xx_obcss_file, 12, 112, diffrec, startrec, endrec,
-     &     sNx, 1, Nr, 'm', 'xz', myThid )
+     &     sNx, 1, Nr, 'm', 'xz', costfinal_exists, myThid )
 #endif /* ALLOW_OBCSS_CONTROL */
 
 c----------------------------------------------------------------------
@@ -150,7 +162,7 @@ c--   Western obc.
      I     myThid )
       call ctrl_init_ctrlvar (
      &     xx_obcsw_file, 13, 113, diffrec, startrec, endrec,
-     &     1, sNy, Nr, 'm', 'yz', myThid )
+     &     1, sNy, Nr, 'm', 'yz', costfinal_exists, myThid )
 #endif  /* ALLOW_OBCSW_CONTROL */
 
 c----------------------------------------------------------------------
@@ -163,7 +175,7 @@ c--   Eastern obc.
      I     myThid )
       call ctrl_init_ctrlvar (
      &     xx_obcse_file, 14, 114, diffrec, startrec, endrec,
-     &     1, sNy, Nr, 'm', 'yz', myThid )
+     &     1, sNy, Nr, 'm', 'yz', costfinal_exists, myThid )
 #endif /* ALLOW_OBCSE_CONTROL */
 
 c----------------------------------------------------------------------
@@ -217,7 +229,7 @@ C       Under iceshelf, use maskSHI for these
 # endif
      &       xx_genarr2d_file(iarr)(1:MAX_LEN_FNAM),
      &       100+iarr, 200+iarr, 1, 1, 1,
-     &       sNx, sNy, 1, ncvargrdtmp, 'xy', myThid )
+     &       sNx, sNy, 1, ncvargrdtmp, 'xy', costfinal_exists, myThid )
 
        enddo
 #endif /* ALLOW_GENARR2D_CONTROL */
@@ -235,7 +247,7 @@ c--
 #endif
      &       xx_genarr3d_file(iarr)(1:MAX_LEN_FNAM),
      &       200+iarr, 300+iarr, 1, 1, 1,
-     &       sNx, sNy, Nr, ncvargrdtmp, '3d', myThid )
+     &       sNx, sNy, Nr, ncvargrdtmp, '3d', costfinal_exists, myThid )
        enddo
 #endif /* ALLOW_GENARR3D_CONTROL */
 
@@ -301,7 +313,7 @@ C
      &       fnamegen(1:MAX_LEN_FNAM),
      &       300+iarr, 400+iarr,
      &       diffrecFull, startrec, endrecFull,
-     &       sNx, sNy, 1, ncvargrdtmp, 'xy', myThid )
+     &       sNx, sNy, 1, ncvargrdtmp, 'xy', costfinal_exists, myThid )
 C
         ilgen=ilnblnk( xx_gentim2d_file(iarr) )
         write(fnamegen(1:MAX_LEN_FNAM),'(2a)')
@@ -310,14 +322,14 @@ C
      &       fnamegen(1:MAX_LEN_FNAM),
      &       300+iarr, 400+iarr,
      &       diffrecFull, startrec, endrecFull,
-     &       sNx, sNy, 1, ncvargrdtmp, 'xy', myThid )
+     &       sNx, sNy, 1, ncvargrdtmp, 'xy', costfinal_exists, myThid )
 C
 C     The length of adxx-files needs to be 1:endrec
         call ctrl_init_ctrlvar (
      &       xx_gentim2d_file(iarr)(1:MAX_LEN_FNAM),
      &       300+iarr, 400+iarr,
      &       endrec, 1, endrec,
-     &       sNx, sNy, 1, ncvargrdtmp, 'xy', myThid )
+     &       sNx, sNy, 1, ncvargrdtmp, 'xy', costfinal_exists, myThid )
 C
 #ifndef ALLOW_OPENAD
        endif

--- a/pkg/ctrl/ctrl_init_ctrlvar.F
+++ b/pkg/ctrl/ctrl_init_ctrlvar.F
@@ -71,6 +71,8 @@ c     _BEGIN_MASTER( myThid )
       ncvarymax (ivarindex)    = ncvarymax_loc
       ncvarnrmax(ivarindex)    = ncvarnrmax_loc
       ncvargrd  (ivarindex)    = ncvargrd_loc
+      ncvartype (ivarindex)    = whichxyz
+      ncvarfname(ivarindex)    = xx_fname
 c     _END_MASTER( myThid )
 
 cph add following flag to make pack/unpack only less error-prone

--- a/pkg/ctrl/ctrl_init_ctrlvar.F
+++ b/pkg/ctrl/ctrl_init_ctrlvar.F
@@ -13,6 +13,7 @@
      &       ncvarnrmax_loc,
      &       ncvargrd_loc,
      &       whichxyz,
+     &       costfinal_exists,
      &       myThid )
 
 c     ==================================================================
@@ -47,6 +48,7 @@ c     == routine arguments ==
       integer ncvarnrmax_loc
       character*(1) ncvargrd_loc
       character*(2) whichxyz
+      logical  costfinal_exists
       integer myThid
 
 C     == external ==
@@ -57,7 +59,7 @@ c     == local variables ==
       integer il,ilDir
       character*(MAX_LEN_FNAM) fname(3), gfname
       character*(MAX_LEN_MBUF) msgBuf
-      logical  exst, g_exst
+      logical  g_exst
 C     == end of interface ==
 
 c     _BEGIN_MASTER( myThid )
@@ -78,7 +80,7 @@ cph add following flag to make pack/unpack only less error-prone
       call ctrl_set_fname( ctrlDir(1:ilDir)//xx_fname, fname, myThid )
 
 c     _BEGIN_MASTER( myThid )
-      inquire( file='costfinal', exist=exst )
+      inquire( file='costfinal', exist=costfinal_exists )
 c     _END_MASTER( myThid )
 
 C     In an adjoint run, adxx_ files should always be initialized with zeros
@@ -104,7 +106,7 @@ C     initialize to zero and warn user
         g_exst = .FALSE.
       endif
 
-      IF ( .NOT. exst) THEN
+      IF ( .NOT. costfinal_exists ) THEN
 
          if ( whichxyz .EQ. '3d') then
 #if (defined (ALLOW_ADJOINT_RUN) || defined (ALLOW_TANGENTLINEAR_RUN))
@@ -137,11 +139,6 @@ C     initialize to zero and warn user
          else
             STOP 'whichxyz option not implemented'
          end if
-
-      ELSE
-
-c-- for DIVA, avoid forward-related output in adjoint part
-         CALL TURNOFF_MODEL_IO( 1, myThid )
 
       ENDIF
 

--- a/pkg/ctrl/ctrl_set_unpack_xy.F
+++ b/pkg/ctrl/ctrl_set_unpack_xy.F
@@ -50,6 +50,14 @@ c     == local variables ==
       integer cbuffindex
       real*4 cbuff( sNx*nSx*nPx*sNy*nSy*nPy )
       character*(MAX_LEN_FNAM) cfile2, cfile3
+C     These are variables needed to read the header, but subsequently
+C     they are not used.
+      integer filencbuffindex
+      integer filei
+      integer filej
+      integer filek
+      integer filencvarindex(maxcvars)
+
 C========================================================================
 # ifndef ALLOW_PACKUNPACK_METHOD2
       integer ip,jp

--- a/pkg/ctrl/ctrl_set_unpack_xyz.F
+++ b/pkg/ctrl/ctrl_set_unpack_xyz.F
@@ -53,6 +53,13 @@ c     == local variables ==
       integer cbuffindex
       real*4 cbuff( sNx*nSx*nPx*sNy*nSy*nPy )
       character*(MAX_LEN_FNAM) cfile2, cfile3
+C     These are variables needed to read the header, but subsequently
+C     they are not used.
+      integer filencbuffindex
+      integer filei
+      integer filej
+      integer filek
+      integer filencvarindex(maxcvars)
 C========================================================================
 # ifndef ALLOW_PACKUNPACK_METHOD2
       integer ip,jp

--- a/pkg/ctrl/ctrl_set_unpack_xz.F
+++ b/pkg/ctrl/ctrl_set_unpack_xz.F
@@ -72,6 +72,14 @@ c     == local variables ==
       integer cunit2, cunit3
       character*(MAX_LEN_FNAM) cfile2, cfile3
 
+C     These are variables needed to read the header, but subsequently
+C     they are not used.
+      integer filencbuffindex
+      integer filei
+      integer filej
+      integer filek
+      integer filencvarindex(maxcvars)
+
 #ifdef CTRL_UNPACK_PRECISE
       integer il
       character*(MAX_LEN_FNAM) weightname
@@ -356,4 +364,3 @@ c     -- end of irec loop --
 
       return
       end
-

--- a/pkg/ctrl/ctrl_set_unpack_yz.F
+++ b/pkg/ctrl/ctrl_set_unpack_yz.F
@@ -72,6 +72,14 @@ c     == local variables ==
       integer cunit2, cunit3
       character*(MAX_LEN_FNAM) cfile2, cfile3
 
+C     These are variables needed to read the header, but subsequently
+C     they are not used.
+      integer filencbuffindex
+      integer filei
+      integer filej
+      integer filek
+      integer filencvarindex(maxcvars)
+
 #ifdef CTRL_UNPACK_PRECISE
       integer il
       character*(MAX_LEN_FNAM) weightname
@@ -350,4 +358,3 @@ c     -- end of irec loop --
 
       return
       end
-

--- a/pkg/ctrl/ctrl_unpack.F
+++ b/pkg/ctrl/ctrl_unpack.F
@@ -79,6 +79,30 @@ c     == local variables ==
       character*(128) cfile
       integer ilDir
 
+C     These are variables needed to read the header, but subsequently
+C     they are not used.
+      integer filenvartype
+      integer filenvarlength
+      integer fileOptimCycle
+      integer fileIg
+      integer fileJg
+      integer filensx
+      integer filensy
+      integer filenWetcGlobal(Nr)
+      integer filenWetsGlobal(Nr)
+      integer filenWetwGlobal(Nr)
+      integer filenWetvGlobal(Nr)
+      integer filencvarindex(maxcvars)
+      integer filencvarrecs(maxcvars)
+      integer filencvarxmax(maxcvars)
+      integer filencvarymax(maxcvars)
+      integer filencvarnrmax(maxcvars)
+
+      _RL            filefc
+
+      character*(10) fileYctrlid
+      character*( 1) filencvargrd(maxcvars)
+
 #if (defined ALLOW_GENARR2D_CONTROL) \
       || (defined ALLOW_GENARR3D_CONTROL) \
       || (defined ALLOW_GENTIM2D_CONTROL)

--- a/pkg/grdchk/grdchk_ctrl_fname.F
+++ b/pkg/grdchk/grdchk_ctrl_fname.F
@@ -51,50 +51,8 @@ CEOP
      &        'Invalid grdchk_index=', grdchk_index
         CALL PRINT_ERROR( msgBuf, myThid )
         STOP 'ABNORMAL END: S/R GRDCHK_CTRL_FNAME'
-
-#ifdef ALLOW_OBCSN_CONTROL
-      ELSEIF ( grdchk_index .EQ. 11 ) THEN
-        fName = xx_obcsn_file
-#endif /* ALLOW_OBCSN_CONTROL */
-
-#ifdef ALLOW_OBCSS_CONTROL
-      ELSEIF ( grdchk_index .EQ. 12 ) THEN
-        fName = xx_obcss_file
-#endif /* ALLOW_OBCSS_CONTROL */
-
-#ifdef ALLOW_OBCSW_CONTROL
-      ELSEIF ( grdchk_index .EQ. 13 ) THEN
-        fName = xx_obcsw_file
-#endif /* ALLOW_OBCSW_CONTROL */
-
-#ifdef ALLOW_OBCSE_CONTROL
-      ELSEIF ( grdchk_index .EQ. 14 ) THEN
-        fName = xx_obcse_file
-#endif /* ALLOW_OBCSE_CONTROL */
-
-#ifdef ALLOW_GENARR2D_CONTROL
-      ELSEIF ( grdchk_index .GE. 101 .AND.
-     &         grdchk_index .LE. 100+maxCtrlArr2D ) THEN
-        iarr = grdchk_index - 100
-        fName = xx_genarr2d_file(iarr)
-#endif /* ALLOW_GENARR2D_CONTROL */
-
-#ifdef ALLOW_GENARR3D_CONTROL
-      ELSEIF ( grdchk_index .GE. 201 .AND.
-     &         grdchk_index .LE. 200+maxCtrlArr3D ) THEN
-        iarr = grdchk_index - 200
-        fName = xx_genarr3d_file(iarr)
-#endif /* ALLOW_GENARR3D_CONTROL */
-
-#ifdef ALLOW_GENTIM2D_CONTROL
-      ELSEIF ( grdchk_index .GE. 301 .AND.
-     &         grdchk_index .LE. 300+maxCtrlTim2D ) THEN
-        iarr = grdchk_index - 300
-        fName = xx_gentim2d_file(iarr)
-#endif /* ALLOW_GENTIM2D_CONTROL */
-
       ELSE
-        WRITE(fName,'(A)') 'undefined'
+        fname = ncvarfname( grdchk_index )
       ENDIF
 
 #endif /* ALLOW_GRDCHK */

--- a/pkg/grdchk/grdchk_getadxx.F
+++ b/pkg/grdchk/grdchk_getadxx.F
@@ -82,8 +82,7 @@ C-    get the name of varIndex_gc corresponding CTRL:
      &           ctrl_name(1:iL), '.', optimcycle
 
 #ifdef ALLOW_GENARR3D_CONTROL
-      IF ( varIndex_gc .GE. 201 .AND.
-     &     varIndex_gc .LE. 200+maxCtrlArr3D ) THEN
+      IF ( ncvartype(varIndex_gc) .EQ. '3d' ) THEN
          CALL active_read_xyz( fName, loctmp3d, 1,
      &                         doglobalread, ladinit, optimcycle,
      &                         myThid, dummy )
@@ -94,7 +93,7 @@ C-    get the name of varIndex_gc corresponding CTRL:
 #endif
 
 #if (defined ALLOW_OBCSN_CONTROL || defined ALLOW_OBCSS_CONTROL)
-      ELSEIF ( varIndex_gc.EQ.11 .OR. varIndex_gc.EQ.12) THEN
+      ELSEIF ( ncvartype(varIndex_gc) .EQ. 'xz' ) THEN
          CALL active_read_xz( fName, tmpfldxz, icvrec,
      &                        doglobalread, ladinit, optimcycle,
      &                        myThid, dummy)
@@ -103,7 +102,7 @@ C-    get the name of varIndex_gc corresponding CTRL:
 #endif
 
 #if (defined ALLOW_OBCSE_CONTROL || defined ALLOW_OBCSW_CONTROL)
-      ELSEIF ( varIndex_gc.EQ.13 .OR. varIndex_gc.EQ.14) THEN
+      ELSEIF ( ncvartype(varIndex_gc) .EQ. 'yz' ) THEN
          CALL active_read_yz( fName, tmpfldyz, icvrec,
      &                        doglobalread, ladinit, optimcycle,
      &                        myThid, dummy )

--- a/pkg/grdchk/grdchk_getxx.F
+++ b/pkg/grdchk/grdchk_getxx.F
@@ -95,8 +95,7 @@ C-    get the name of varIndex_gc corresponding CTRL:
       ENDIF
 
 #ifdef ALLOW_GENARR3D_CONTROL
-      IF ( varIndex_gc .GE. 201 .AND.
-     &     varIndex_gc .LE. 200+maxCtrlArr3D ) THEN
+      IF ( ncvartype(varIndex_gc) .EQ. '3d' ) THEN
          CALL active_read_xyz( fName, loctmp3d, 1,
      &                         doglobalread, ladinit, optimcycle,
      &                         myThid, dummy )
@@ -114,7 +113,7 @@ C-    get the name of varIndex_gc corresponding CTRL:
 #endif
 
 #if (defined ALLOW_OBCSN_CONTROL || defined ALLOW_OBCSS_CONTROL)
-      ELSEIF ( varIndex_gc.EQ.11 .OR. varIndex_gc.EQ.12) THEN
+      ELSEIF ( ncvartype(varIndex_gc) .EQ. 'xz' ) THEN
          CALL active_read_xz( fName, tmpfldxz, icvrec,
      &                        doglobalread, ladinit, optimcycle,
      &                        myThid, dummy )
@@ -130,7 +129,7 @@ C-    get the name of varIndex_gc corresponding CTRL:
 #endif
 
 #if (defined ALLOW_OBCSE_CONTROL || defined ALLOW_OBCSW_CONTROL)
-      ELSEIF ( varIndex_gc.EQ.13 .OR. varIndex_gc.EQ.14) THEN
+      ELSEIF ( ncvartype(varIndex_gc) .EQ. 'yz' ) THEN
          CALL active_read_yz( fName, tmpfldyz, icvrec,
      &                        doglobalread, ladinit, optimcycle,
      &                        myThid, dummy )

--- a/pkg/grdchk/grdchk_setxx.F
+++ b/pkg/grdchk/grdchk_setxx.F
@@ -88,8 +88,7 @@ C-    get the name of varIndex_gc corresponding CTRL:
       ENDIF
 
 #ifdef ALLOW_GENARR3D_CONTROL
-      IF ( varIndex_gc .GE. 201 .AND.
-     &     varIndex_gc .LE. 200+maxCtrlArr3D ) THEN
+      IF ( ncvartype(varIndex_gc) .EQ. '3d' ) THEN
         CALL active_read_xyz( fName, loctmp3d, 1,
      &                        doglobalread, ladinit, optimcycle,
      &                        myThid, dummy )
@@ -103,7 +102,7 @@ C-    get the name of varIndex_gc corresponding CTRL:
 #endif
 
 #if (defined ALLOW_OBCSN_CONTROL || defined ALLOW_OBCSS_CONTROL)
-      ELSEIF ( varIndex_gc.EQ.11 .OR. varIndex_gc.EQ.12) THEN
+      ELSEIF ( ncvartype(varIndex_gc) .EQ. 'xz' ) THEN
         CALL active_read_xz( fName, tmpfldxz, icvrec,
      &                       doglobalread, ladinit, optimcycle,
      &                       myThid, dummy )
@@ -115,7 +114,7 @@ C-    get the name of varIndex_gc corresponding CTRL:
 #endif
 
 #if (defined ALLOW_OBCSE_CONTROL || defined ALLOW_OBCSW_CONTROL)
-      ELSEIF ( varIndex_gc.EQ.13 .OR. varIndex_gc.EQ.14) THEN
+      ELSEIF ( ncvartype(varIndex_gc) .EQ. 'yz' ) THEN
         CALL active_read_yz( fName, tmpfldyz, icvrec,
      &                       doglobalread, ladinit, optimcycle,
      &                       myThid, dummy )


### PR DESCRIPTION
## What changes does this PR introduce?
clean up and new feature

## What is the current behaviour? 
addresses most points in #786
- unnecessary common blocks
- unnecessary repetition 
- identification of ctrl variable in pkg/grdchk

## What is the new behaviour 
- unnecessary common blocks removed
- inquire for `cost final` and call `S/R TURNOFF_MODEL_IO` only once
- new character fields that store `xx_fname` and `whichxyz`, so that index (and `grdchkvarindex`) maps directly to the file and grid type of the control variable to be checked

## Does this PR introduce a breaking change? 
no, just internal

## Other information:
This is a draft so far, to decide, if the method of identifying the control variables via name and grid type is acceptable.
The new field `ncvarfilename` combines `xx_genarr3d_file`, `xx_genarr2d_file`, `xx_gentim2d_file`, and `xx_obcs[n,s,w,e]_file`, and hence is a duplication.
TBD: 
- change the value of `ncvarindex` to either `index` or just `1`. This variable is never used, except to identify if the variable has be activated as control variable. The current convention `ncvarindex = index + 100` causes confusion as to which value to use to access a specific variable.
- print all active control variables to stdout in the control-variable configuration section, currently, the obcs variables are missing.

## Suggested addition to `tag-index`
TBD. (To avoid unnecessary merge conflicts, please don't update `tag-index`. One of the admins will do that when merging your pull request.)