### PR TITLE
[ENH] add eta to rbcs for nonlinear free surface

### DIFF
--- a/model/src/update_etah.F
+++ b/model/src/update_etah.F
@@ -80,6 +80,13 @@ C       depend on hFacZ which is not only function of boundary hFac values.
      &     CALL OBCS_APPLY_ETA( bi, bj, etaH, myThid )
 #endif /* ALLOW_OBCS */
 
+#ifdef ALLOW_RBCS
+C--    Apply RBCS to etaH
+        IF ( useRBCS.AND.nonlinFreeSurf.GT.0 )
+     &      CALL RBCS_APPLY_ETA( bi, bj, etaH, myTime, myIter, myThid )
+#endif
+
+
 C- end bi,bj loop.
        ENDDO
       ENDDO

--- a/pkg/rbcs/RBCS_FIELDS.h
+++ b/pkg/rbcs/RBCS_FIELDS.h
@@ -23,11 +23,13 @@ C---  RBCS 3-D Fields:
      &          RBCvVel
 #endif
       _RS RBC_mask(1-OLx:sNx+OLx,1-OLy:sNy+OLy,Nr,nSx,nSy,maskLEN)
+      _RS RBC_Etamask(1-OLx:sNx+OLx,1-OLy:sNy+OLy,nSx,nSy)
       _RL RBCtemp(1-OLx:sNx+OLx,1-OLy:sNy+OLy,Nr,nSx,nSy)
       _RL RBCsalt(1-OLx:sNx+OLx,1-OLy:sNy+OLy,Nr,nSx,nSy)
       _RL RBCeta(1-OLx:sNx+OLx,1-OLy:sNy+OLy,nSx,nSy)
       COMMON /RBCS_MASKS_TR/
-     &          RBC_mask
+     &          RBC_mask,
+     &          RBC_Etamask
       COMMON /RBCS_FIELDS_TS/
      &          RBCtemp,
      &          RBCsalt,

--- a/pkg/rbcs/RBCS_FIELDS.h
+++ b/pkg/rbcs/RBCS_FIELDS.h
@@ -25,11 +25,14 @@ C---  RBCS 3-D Fields:
       _RS RBC_mask(1-OLx:sNx+OLx,1-OLy:sNy+OLy,Nr,nSx,nSy,maskLEN)
       _RL RBCtemp(1-OLx:sNx+OLx,1-OLy:sNy+OLy,Nr,nSx,nSy)
       _RL RBCsalt(1-OLx:sNx+OLx,1-OLy:sNy+OLy,Nr,nSx,nSy)
+      _RL RBCeta(1-OLx:sNx+OLx,1-OLy:sNy+OLy,nSx,nSy)
       COMMON /RBCS_MASKS_TR/
      &          RBC_mask
       COMMON /RBCS_FIELDS_TS/
      &          RBCtemp,
-     &          RBCsalt
+     &          RBCsalt,
+     &          RBCeta
+
 
 #ifdef ALLOW_PTRACERS
       _RL RBC_ptracers(1-OLx:sNx+OLx,1-OLy:sNy+OLy,Nr,nSx,nSy,
@@ -52,11 +55,14 @@ C     rbcsLdRec     :: time-record currently loaded (in temp arrays *[1])
 #endif
       COMMON /RBCS_LOADED_TS/
      &                 rbct0, rbcs0,
-     &                 rbct1, rbcs1
+     &                 rbct1, rbcs1,
+     &                 rbceta0, rbceta1
       _RS  rbct0    (1-OLx:sNx+OLx,1-OLy:sNy+OLy,Nr,nSx,nSy)
       _RS  rbct1    (1-OLx:sNx+OLx,1-OLy:sNy+OLy,Nr,nSx,nSy)
       _RS  rbcs0    (1-OLx:sNx+OLx,1-OLy:sNy+OLy,Nr,nSx,nSy)
       _RS  rbcs1    (1-OLx:sNx+OLx,1-OLy:sNy+OLy,Nr,nSx,nSy)
+      _RS  rbceta0    (1-OLx:sNx+OLx,1-OLy:sNy+OLy,nSx,nSy)
+      _RS  rbceta1    (1-OLx:sNx+OLx,1-OLy:sNy+OLy,nSx,nSy)
 
 #ifdef ALLOW_PTRACERS
        COMMON /RBCS_LOADED_PTR/

--- a/pkg/rbcs/RBCS_PARAMS.h
+++ b/pkg/rbcs/RBCS_PARAMS.h
@@ -24,6 +24,7 @@ C
       _RL tauRelaxV
       _RL tauRelaxT
       _RL tauRelaxS
+      _RL tauRelaxEta
       _RL rbcsForcingPeriod
       _RL rbcsForcingCycle
       _RL rbcsForcingOffset
@@ -35,6 +36,8 @@ C
       LOGICAL useRBCvVel
       LOGICAL useRBCtemp
       LOGICAL useRBCsalt
+      LOGICAL useRBCeta
+      CHARACTER*(MAX_LEN_FNAM) relaxMaskEtaFile
       CHARACTER*(MAX_LEN_FNAM) relaxMaskUFile
       CHARACTER*(MAX_LEN_FNAM) relaxMaskVFile
       CHARACTER*(MAX_LEN_FNAM) relaxMaskTrFile(maskLEN)
@@ -42,12 +45,15 @@ C
       CHARACTER*(MAX_LEN_FNAM) relaxVFile
       CHARACTER*(MAX_LEN_FNAM) relaxTFile
       CHARACTER*(MAX_LEN_FNAM) relaxSFile
+      CHARACTER*(MAX_LEN_FNAM) relaxEtaFile
+
 
       COMMON /RBCS_PARM01_R/
      &          tauRelaxU,
      &          tauRelaxV,
      &          tauRelaxT,
      &          tauRelaxS,
+     &          tauRelaxEta,
      &          rbcsForcingPeriod,
      &          rbcsForcingCycle,
      &          rbcsForcingOffset,
@@ -59,16 +65,20 @@ C
      &          rbcsSingleTimeFiles,
      &          useRBCuVel,
      &          useRBCvVel,
+     &          useRBCeta,
      &          useRBCtemp,
      &          useRBCsalt
       COMMON /RBCS_PARM01_C/
      &          relaxMaskUFile,
      &          relaxMaskVFile,
      &          relaxMaskTrFile,
+     &          relaxMaskEtaFile,
      &          relaxUFile,
      &          relaxVFile,
      &          relaxTFile,
-     &          relaxSFile
+     &          relaxSFile,
+     &          relaxEtaFile
+
 
 #ifdef ALLOW_PTRACERS
       LOGICAL useRBCpTrNum(PTRACERS_num)

--- a/pkg/rbcs/rbcs_fields_load.F
+++ b/pkg/rbcs/rbcs_fields_load.F
@@ -182,6 +182,21 @@ C     for rbcsSingleTimeFiles=.TRUE.
         CALL EXCH_XYZ_RS( rbcs1 , myThid )
        ENDIF
 
+       IF (useRBCEeta .AND. nonlinFreeSurf.GT.0 .AND.
+     &     relaxEtaFile .NE. ' ' ) THEN
+        IF ( rbcsSingleTimeFiles ) THEN
+         IL=ILNBLNK( relaxEtaFile )
+         WRITE(fullName,'(2a,i10.10)') relaxEtaFile(1:IL),'.',initer0
+         CALL READ_REC_XY_RS(fullName, rbceta0, 1, myIter, myThid)
+         WRITE(fullName,'(2a,i10.10)') relaxEtaFile(1:IL),'.',initer1
+         CALL READ_REC_XY_RS(fullName, rbceta1, 1, myIter, myThid)
+        ELSE
+         CALL READ_REC_XY_RS(relaxEtaFile,rbceta0,intime0,myIter,myThid)
+         CALL READ_REC_XY_RS(relaxEtaFile,rbceta1,intime1,myIter,myThid)
+        ENDIF
+        CALL EXCH_XYZ_RS( rbceta0 , myThid )
+        CALL EXCH_XYZ_RS( rbceta1 , myThid )
+
 #ifdef ALLOW_PTRACERS
        IF ( usePTRACERS ) THEN
         DO iTracer = 1, PTRACERS_numInUse
@@ -251,6 +266,13 @@ C--   Interpolate
            ENDDO
           ENDDO
          ENDDO
+         DO j=1-Oly,sNy+Oly
+          DO i=1-Olx,sNx+Olx
+           RBCeta(i,j,bi,bj) = bWght*rbceta0(i,j,bi,bj)
+     &                        +aWght*rbceta1(i,j,bi,bj)
+          ENDDO
+         ENDDO
+
        ENDDO
       ENDDO
 

--- a/pkg/rbcs/rbcs_fields_load.F
+++ b/pkg/rbcs/rbcs_fields_load.F
@@ -182,7 +182,7 @@ C     for rbcsSingleTimeFiles=.TRUE.
         CALL EXCH_XYZ_RS( rbcs1 , myThid )
        ENDIF
 
-       IF (useRBCEeta .AND. nonlinFreeSurf.GT.0 .AND.
+       IF (useRBCeta .AND. nonlinFreeSurf.GT.0 .AND.
      &     relaxEtaFile .NE. ' ' ) THEN
         IF ( rbcsSingleTimeFiles ) THEN
          IL=ILNBLNK( relaxEtaFile )
@@ -196,7 +196,7 @@ C     for rbcsSingleTimeFiles=.TRUE.
         ENDIF
         CALL EXCH_XYZ_RS( rbceta0 , myThid )
         CALL EXCH_XYZ_RS( rbceta1 , myThid )
-
+       ENDIF
 #ifdef ALLOW_PTRACERS
        IF ( usePTRACERS ) THEN
         DO iTracer = 1, PTRACERS_numInUse

--- a/pkg/rbcs/rbcs_init_fixed.F
+++ b/pkg/rbcs/rbcs_init_fixed.F
@@ -149,6 +149,28 @@ C     Report RBCS mask setting
          CALL PRINT_MESSAGE( msgBuf, standardMessageUnit,
      &                       SQUEEZE_RIGHT, myThid )
       ENDIF
+      IF ( useRBCeta ) THEN
+        IF ( relaxMaskEtaFile.EQ. ' ' ) THEN
+         WRITE(msgBuf,'(2A)') '** WARNING ** RBCS_INIT_FIXED:',
+     &     ' relaxMaskEtaFile unset ==> use Temp mask instead'
+         CALL PRINT_MESSAGE( msgBuf, errorMessageUnit,
+     &                       SQUEEZE_RIGHT, myThid )
+         WRITE(msgBuf,'(2A)') 'Warning:',
+     &     ' relaxMaskEtaFile unset ==> use Temp mask instead'
+         CALL PRINT_MESSAGE( msgBuf, standardMessageUnit,
+     &                       SQUEEZE_RIGHT, myThid )
+        ELSE
+         iLen = ILNBLNK(relaxMaskEtaFile)
+         WRITE(msgBuf,'(A,3A)') 'Use relaxMaskEtaFile',
+     &     ' = "', relaxMaskEtaFile(1:iLen), '"'
+         CALL PRINT_MESSAGE( msgBuf, standardMessageUnit,
+     &                       SQUEEZE_RIGHT, myThid )
+        ENDIF
+         WRITE(msgBuf,'(A,1PE21.13)')
+     &     ' for Eta relaxation with tauRelaxEta =', tauRelaxEta
+         CALL PRINT_MESSAGE( msgBuf, standardMessageUnit,
+     &                       SQUEEZE_RIGHT, myThid )
+      ENDIF
 #ifdef ALLOW_PTRACERS
       IF ( usePTRACERS .AND. PTRACERS_numInUse.GE.1 ) THEN
        DO iTr=1,PTRACERS_numInUse
@@ -251,6 +273,25 @@ C--   Apply mask:
          ENDIF
        ENDIF
       ENDDO
+
+C--
+      IF ( relaxMaskEtaFile.NE. ' ' ) THEN
+        CALL READ_FLD_XY_RS( relaxMaskEtaFile, ' ',
+     &                 RBC_Etamask(1-OLx,1-OLy,1,1), 0, myThid )
+        CALL EXCH_XY_RS( RBC_Etamask(1-OLx,1-OLy,1,1), myThid )
+C--   Apply mask:
+        DO bj = myByLo(myThid), myByHi(myThid)
+          DO bi = myBxLo(myThid), myBxHi(myThid)
+             DO j=1-OLy,sNy+OLy
+              DO i=1-OLx,sNx+OLx
+                RBC_Etamask(i,j,bi,bj) = RBC_Etamask(i,j,bi,bj)
+     &                                       * maskC(i,j,1,bi,bj)
+              ENDDO
+             ENDDO
+          ENDDO
+        ENDDO
+      ENDIF
+
 
 #ifndef DISABLE_RBCS_MOM
       IF ( useRBCuVel .AND. relaxMaskUFile.NE. ' ' ) THEN

--- a/pkg/rbcs/rbcs_init_varia.F
+++ b/pkg/rbcs/rbcs_init_varia.F
@@ -51,8 +51,11 @@ C     i,j,k,bi,bj,iTracer  :: loop indices
                 rbcs0(i,j,k,bi,bj) = 0. _d 0
                 rbct1(i,j,k,bi,bj) = 0. _d 0
                 rbcs1(i,j,k,bi,bj) = 0. _d 0
+                rbceta0(i,j,k,bi,bj) = 0. _d 0
+                rbceta1(i,j,k,bi,bj) = 0. _d 0
                 RBCtemp(i,j,k,bi,bj) = 0. _d 0
                 RBCsalt(i,j,k,bi,bj) = 0. _d 0
+                RBCeta(i,j,k,bi,bj) = 0. _d 0
               ENDDO
             ENDDO
           ENDDO

--- a/pkg/rbcs/rbcs_init_varia.F
+++ b/pkg/rbcs/rbcs_init_varia.F
@@ -51,11 +51,11 @@ C     i,j,k,bi,bj,iTracer  :: loop indices
                 rbcs0(i,j,k,bi,bj) = 0. _d 0
                 rbct1(i,j,k,bi,bj) = 0. _d 0
                 rbcs1(i,j,k,bi,bj) = 0. _d 0
-                rbceta0(i,j,k,bi,bj) = 0. _d 0
-                rbceta1(i,j,k,bi,bj) = 0. _d 0
+                rbceta0(i,j,bi,bj) = 0. _d 0
+                rbceta1(i,j,bi,bj) = 0. _d 0
                 RBCtemp(i,j,k,bi,bj) = 0. _d 0
                 RBCsalt(i,j,k,bi,bj) = 0. _d 0
-                RBCeta(i,j,k,bi,bj) = 0. _d 0
+                RBCeta(i,j,bi,bj) = 0. _d 0
               ENDDO
             ENDDO
           ENDDO

--- a/pkg/rbcs/rbcs_readparms.F
+++ b/pkg/rbcs/rbcs_readparms.F
@@ -56,17 +56,21 @@ C--   RBCS parameters:
      &          tauRelaxV,
      &          tauRelaxT,
      &          tauRelaxS,
+     &          tauRelaxEta,
      &          relaxMaskUFile,
      &          relaxMaskVFile,
+     &          relaxMaskEtaFile,
      &          relaxMaskFile,
      &          relaxUFile,
      &          relaxVFile,
      &          relaxTFile,
      &          relaxSFile,
+     &          relaxEtaFile,
      &          useRBCuVel,
      &          useRBCvVel,
      &          useRBCtemp,
      &          useRBCsalt,
+     &          useRBCeta,
      &          useRBCptracers,
      &          rbcsIniter,
      &          rbcsForcingPeriod,
@@ -102,6 +106,7 @@ C--   Default values
       useRBCvVel =.FALSE.
       useRBCtemp =.FALSE.
       useRBCsalt =.FALSE.
+      useRBCeta =.FALSE.
       tauRelaxU = 0.
       tauRelaxV = 0.
       tauRelaxT = 0.
@@ -242,7 +247,7 @@ C---  Check RBCS config and params:
       ENDIF
       IF ( useRBCsalt .AND. tauRelaxS.LE.0. ) THEN
             WRITE(msgBuf,'(2A)') 'RBCS_READPARMS: ',
-         &    'tauRelaxS cannot be zero with useRBCsalt'
+     &    'tauRelaxS cannot be zero with useRBCsalt'
             CALL PRINT_ERROR( msgBuf, myThid )
             STOP 'ABNORMAL END: S/R RBCS_READPARMS'
           ENDIF

--- a/pkg/rbcs/rbcs_readparms.F
+++ b/pkg/rbcs/rbcs_readparms.F
@@ -106,8 +106,10 @@ C--   Default values
       tauRelaxV = 0.
       tauRelaxT = 0.
       tauRelaxS = 0.
+      tauRelaxEta = 0.
       relaxMaskUFile = ' '
       relaxMaskVFile = ' '
+      relaxMaskEtaFile = ' '
       DO irbc=1,locSize
         relaxMaskFile(irbc) = ' '
       ENDDO
@@ -115,6 +117,7 @@ C--   Default values
       relaxVFile = ' '
       relaxTFile = ' '
       relaxSFile = ' '
+      relaxEtaFile = ' '
       rbcsIniter = 0
       rbcsForcingPeriod = 0. _d 0
       rbcsForcingCycle  = 0. _d 0
@@ -238,8 +241,14 @@ C---  Check RBCS config and params:
         STOP 'ABNORMAL END: S/R RBCS_READPARMS'
       ENDIF
       IF ( useRBCsalt .AND. tauRelaxS.LE.0. ) THEN
+            WRITE(msgBuf,'(2A)') 'RBCS_READPARMS: ',
+         &    'tauRelaxS cannot be zero with useRBCsalt'
+            CALL PRINT_ERROR( msgBuf, myThid )
+            STOP 'ABNORMAL END: S/R RBCS_READPARMS'
+          ENDIF
+      IF ( useRBCeta .AND. tauRelaxEta.LE.0. ) THEN
         WRITE(msgBuf,'(2A)') 'RBCS_READPARMS: ',
-     &    'tauRelaxS cannot be zero with useRBCsalt'
+     &    'tauRelaxEta cannot be zero with useRBCeta'
         CALL PRINT_ERROR( msgBuf, myThid )
         STOP 'ABNORMAL END: S/R RBCS_READPARMS'
       ENDIF


### PR DESCRIPTION
## What changes does this PR introduce?

Draft for comment: `obcs` allows setting `etaH`, but I wanted an rbcs-type sponge, so I added this to rbcs.  

This is potentially valuable for fjords and other embayments where we want to force the tide via sea surface height in a large receiving basin.  I do this by adjusting the sponge in the receiving basin so that the surface wave is free in the fjord itself.  

## Does this PR introduce a breaking change? 

No

## Other information:

I have a simple version of a toy model that works with this at https://github.com/jklymak/FjordForce. That example could be simplified, its just a simulation I had that had a reasonable fjord with large receiving basin set up.

- [ ] Needs documentation
- [ ] Needs tests?