### PR TITLE
fix broken lxr link

### DIFF
--- a/doc/_extensions/mitgcm.py
+++ b/doc/_extensions/mitgcm.py
@@ -26,7 +26,7 @@ def setup(app):
         filelink('https://github.com/MITgcm/MITgcm/blob/master/%s'))
     app.add_role(
         'varlink',
-        autolink('http://mitgcm.org/lxr/ident/MITgcm?_i=%s'))
+        autolink('http://lxr.mitgcm.org/lxr2/ident/MITgcm?_i=%s'))
 
 def filelink(pattern):
     """


### PR DESCRIPTION
## What changes does this PR introduce?
doc fix

Previously there was a forward in place so that the lxr URL specified  in the doc (http://mitgcm.org/lxr) switched over to where it currently resides on the mitgcm server (http://lxr.mitgcm.org/lxr2/). This forward got broken recently, and rather than track down what happened it seemed more straightforward to simply change the doc to point directly.