### PR TITLE
report TAF/Tapenade version in main summary

### DIFF
--- a/verification/testreport
+++ b/verification/testreport
@@ -1851,6 +1851,28 @@ for dir in $TESTDIRS ; do
 		fi
 		grep ' set FC_CHECK=' $gmkLog	>> $DRESULTS/genmake_state
 	    fi
+	    if test $KIND = 1 -o  $KIND = 2 ; then
+	      gmkLog=$dir/$builddir/taf_ad.log
+	      if test $KIND = 1 ; then gmkLog=$dir/$builddir/taf_ftl.log ; fi
+	      if test -f $gmkLog ; then
+		echo -n "from '$gmkLog', get: " >> $DRESULTS/genmake_state
+		head -1 $gmkLog | sed 's/^.*Algorithms in Fortran //' \
+						>> $DRESULTS/genmake_state
+		ADvers=`head -1 $gmkLog | awk '{print $7,$8}'`
+		sed "s/ by TAF/ by TAF $ADvers/" $SUMMARY > tmp.tr_log
+		mv -f  tmp.tr_log $SUMMARY
+	      fi
+	    fi
+	    if test $KIND = 4 -o  $KIND = 5 ; then
+	      gmkLog=$dir/$builddir/make.tr_log
+	      if test -f $gmkLog ; then
+		ADtool=`grep '^Tapenade ' $gmkLog | tail -n 1`
+		echo "from '$gmkLog', get: $ADtool" >> $DRESULTS/genmake_state
+		ADvers=`echo $ADtool | awk '{print $1,$2,$3}'`
+		sed "s/ by Tapenade/ by $ADvers/" $SUMMARY > tmp.tr_log
+		mv -f  tmp.tr_log $SUMMARY
+	      fi
+	    fi
 	    gmkLog=$dir/$builddir/genmake_state
 	    if test -r $gmkLog ; then
 		echo -n "from '$gmkLog', "	>> $DRESULTS/genmake_state

--- a/verification/testreport
+++ b/verification/testreport
@@ -1860,7 +1860,7 @@ for dir in $TESTDIRS ; do
 						>> $DRESULTS/genmake_state
 		ADvers=`head -1 $gmkLog | awk '{print $7,$8}'`
 		sed "s/ by TAF/ by TAF $ADvers/" $SUMMARY > tmp.tr_log
-		mv -f  tmp.tr_log $SUMMARY
+		mv -f tmp.tr_log $SUMMARY
 	      fi
 	    fi
 	    if test $KIND = 4 -o  $KIND = 5 ; then
@@ -1870,7 +1870,7 @@ for dir in $TESTDIRS ; do
 		echo "from '$gmkLog', get: $ADtool" >> $DRESULTS/genmake_state
 		ADvers=`echo $ADtool | awk '{print $1,$2,$3}'`
 		sed "s/ by Tapenade/ by $ADvers/" $SUMMARY > tmp.tr_log
-		mv -f  tmp.tr_log $SUMMARY
+		mv -f tmp.tr_log $SUMMARY
 	      fi
 	    fi
 	    gmkLog=$dir/$builddir/genmake_state


### PR DESCRIPTION
For TAF and Tapenade ADM or TLM test, also report TAF/Tapenade version in main "genmake_state" file + a shorter version in main summary.

## What changes does this PR introduce?
Minor: only little addition to testreport output summary and "genmake_state" output-dir report

## What is the current behaviour? 
TAF and Tapenade version are reported in each experiment local summary.txt file but not in main summary.

## What is the new behaviour 
TAF and Tapenade version are also report in main summary & main genmake_state

## Does this PR introduce a breaking change? 
No

## Other information:

## Suggested addition to `tag-index`
no addition to tag-index since it's just a minor change that only affects particular (i.e., TAF & Tapenade) testreport output.