### PR TITLE
DOC: more detail for input shapes and numpy

### DIFF
--- a/doc/getting_started/getting_started.rst
+++ b/doc/getting_started/getting_started.rst
@@ -3170,18 +3170,26 @@ MITgcm input files for grid-related data (e.g., :varlink:`delXFile`),
 forcing fields (e.g., :varlink:`tauThetaClimRelax`),
 parameter fields (e.g., :varlink:`viscAhZfile`), etc. are assumed to
 be in "flat" or "unblocked" `binary format <https://en.wikipedia.org/wiki/Binary_file>`_.
-For historical reasons, MITgcm files use big-endian
+
+Data is expected to be in
+`Fortran/column-major order <https://en.wikipedia.org/wiki/Row-_and_column-major_order>`_,
+in the order (:math:`x`, :math:`y`, :math:`z`, :math:`t`).  MATLAB typically
+uses F-order, while Python's numpy uses C-order (row-major order).
+
+For historical reasons, many large MITgcm projects use big-endian
 `byte ordering <https://en.wikipedia.org/wiki/Endianness>`_,
 **NOT** little-endian which is the more common default for today's computers.
-Thus, some care is required to create MITgcm-readable input files.
-
+Thus, some care is required to create MITgcm-readable input files.  However, if
+you prepare your own input files, it is perfectly fine to use little-endian so
+long as you also compile your executable to be little-endian compatible.
 
 - Using `MATLAB <https://www.mathworks.com/products/matlab.html>`_:
   When writing binary files, MATLAB's `fopen <https://www.mathworks.com/help/matlab/ref/fopen.html>`_
   command includes a MACHINEFORMAT option ``'b'`` which instructs MATLAB
   to read or write using big-endian byte ordering. 2-D arrays should be
-  index-ordered in MATLAB as (:math:`x`, :math:`y`) and 3-D arrays as
-  (:math:`x`, :math:`y`, :math:`z`); data is ordered from low to high in
+  index-ordered in MATLAB as (:math:`x`, :math:`y`), 3-D arrays as
+  (:math:`x`, :math:`y`, :math:`z`), and 4-D arrays as
+  (:math:`x`, :math:`y`, :math:`z`, :math:`t`); data is ordered from low to high in
   each index, with :math:`x` varying most rapidly.
 
   An example to create a bathymetry file of single-precision, floating
@@ -3217,9 +3225,17 @@ Thus, some care is required to create MITgcm-readable input files.
      h = reshape(fread(fid, Inf, accuracy), nx, ny);
      fclose(fid);
 
-- Using `Python <https://www.python.org/>`_:
+- Using Python's `numpy <https://numpy.org>`_:
 
-  A python version of the above script to create a bathymetry file is as follows:
+  The `tofile <https://numpy.org/doc/stable/reference/generated/numpy.ndarray.tofile.html>`_
+  method on a numpy array writes the data in
+  `row-major or C-order <https://en.wikipedia.org/wiki/Row-_and_column-major_order>`_,
+  so arrays should be shaped to take this into account for the MITgcm:
+  (:math:`y`, :math:`x`) for 2-D,  (:math:`z`, :math:`y`, :math:`x`) for 3-D, and
+  (:math:`t`, :math:`z`, :math:`y`, :math:`x`) for 4-D.
+
+  A python version of the above script can use numpy to create a bathymetry file is as
+  follows:
 
   ::
 
@@ -3239,23 +3255,19 @@ Thus, some care is required to create MITgcm-readable input files.
     # save as single-precision (NumPy type float32) with big-endian byte ordering
     h.astype('>f4').tofile('bathy.bin')
 
-  The dtype specification ``'>f4'`` above instructs Python to write the file with
+  The dtype specification ``'>f4'`` above instructs numpy to write the file with
   big-endian byte ordering (specifically, due to the '>') as single-precision real
   numbers (due to the 'f4' which is NumPy ``float32`` or equivalently,
   Fortran ``real*4`` format).
 
-  To read this bathymetry file back into Python, reshaped back to (ny, nx):
+  To read this bathymetry file back into numpy, reshaped back to (ny, nx):
 
   ::
 
     h = np.fromfile('bathy.bin', '>f4').reshape(ny, nx)
 
-  where again the dtype spec instructs Python to read a big-endian
+  where again the dtype spec instructs numpy to read a big-endian
   file of single-precision, floating point values.
-
-  Note that 2-D and 3-D arrays should be index-ordered as
-  (:math:`y`, :math:`x`) and (:math:`z`, :math:`y`, :math:`x`),
-  respectively, to be written in proper ordering for MITgcm.
 
   A more complicated example of using Python to generate input date is provided in
   :filelink:`verification/tutorial_baroclinic_gyre/input/gendata.py`.

--- a/doc/getting_started/getting_started.rst
+++ b/doc/getting_started/getting_started.rst
@@ -3173,8 +3173,9 @@ be in "flat" or "unblocked" `binary format <https://en.wikipedia.org/wiki/Binary
 
 Data is expected to be in
 `Fortran/column-major order <https://en.wikipedia.org/wiki/Row-_and_column-major_order>`_,
-in the order (:math:`x`, :math:`y`, :math:`z`, :math:`t`).  MATLAB typically
-uses F-order, while Python's numpy uses C-order (row-major order).
+in the order (:math:`x`, :math:`y`, :math:`z`, :math:`t`).
+`MATLAB <https://www.mathworks.com/products/matlab.html>`_ typically
+uses F-order, while Python's `NumPy <https://numpy.org>`_ uses C-order (row-major order).
 
 For historical reasons, many large MITgcm projects use big-endian
 `byte ordering <https://en.wikipedia.org/wiki/Endianness>`_,
@@ -3225,16 +3226,16 @@ long as you also compile your executable to be little-endian compatible.
      h = reshape(fread(fid, Inf, accuracy), nx, ny);
      fclose(fid);
 
-- Using Python's `numpy <https://numpy.org>`_:
+- Using Python's `NumPy <https://numpy.org>`_:
 
   The `tofile <https://numpy.org/doc/stable/reference/generated/numpy.ndarray.tofile.html>`_
-  method on a numpy array writes the data in
+  method on a NumPy array writes the data in
   `row-major or C-order <https://en.wikipedia.org/wiki/Row-_and_column-major_order>`_,
   so arrays should be shaped to take this into account for the MITgcm:
   (:math:`y`, :math:`x`) for 2-D,  (:math:`z`, :math:`y`, :math:`x`) for 3-D, and
   (:math:`t`, :math:`z`, :math:`y`, :math:`x`) for 4-D.
 
-  A python version of the above script can use numpy to create a bathymetry file is as
+  A python version of the above script can use NumPy to create a bathymetry file is as
   follows:
 
   ::
@@ -3255,18 +3256,18 @@ long as you also compile your executable to be little-endian compatible.
     # save as single-precision (NumPy type float32) with big-endian byte ordering
     h.astype('>f4').tofile('bathy.bin')
 
-  The dtype specification ``'>f4'`` above instructs numpy to write the file with
+  The dtype specification ``'>f4'`` above instructs NumPy to write the file with
   big-endian byte ordering (specifically, due to the '>') as single-precision real
   numbers (due to the 'f4' which is NumPy ``float32`` or equivalently,
   Fortran ``real*4`` format).
 
-  To read this bathymetry file back into numpy, reshaped back to (ny, nx):
+  To read this bathymetry file back into NumPy, reshaped back to (ny, nx):
 
   ::
 
     h = np.fromfile('bathy.bin', '>f4').reshape(ny, nx)
 
-  where again the dtype spec instructs numpy to read a big-endian
+  where again the dtype spec instructs NumPy to read a big-endian
   file of single-precision, floating point values.
 
   A more complicated example of using Python to generate input date is provided in


### PR DESCRIPTION
This is a small doc update to clarify the byte ordering and indexing of the input data files.  

Perhaps more controversial: I point out that unless you are running one of the configs where you need to share files, there is really no need to use big-endian.  I'm sure the performance hit is minimal, but swapping across 2read/write cycles isn't nothing, and it makes the analysis code more verbose than it needs to be. Happy to take that out, but I've run little-endian for 15 years with no actual issues.  