### PR TITLE
Replace/extend 2 parameters and remove writeStatePrec

### DIFF
--- a/doc/tag-index
+++ b/doc/tag-index
@@ -1,6 +1,12 @@
     Notes on tags used in MITgcmUV
     ==============================
 
+o model/src:
+  - change param "metricTerms" to integer param "selectMetricTerms" and change
+    param "use3dCoriolis" to integer param "select3dCoriScheme" but keep former
+    parameters in namelist (backward compatible).
+  - remove un-used param "writeStatePrec" + also in experiment param file "data"
+  - rotateGrid: fix missing 3-D Coriolis term to gV ; adjust usage restriction.
 o pkg/ecco:
   - remove call to ECCO_CHECK from ecco_cost_init_fixed.F (but keep the other
     call from packages_check.F) and move ECCO_SUMMARY call to ecco_check.F

--- a/model/inc/PARAMS.h
+++ b/model/inc/PARAMS.h
@@ -1,5 +1,3 @@
-C
-
 CBOP
 C     !ROUTINE: PARAMS.h
 C     !INTERFACE:
@@ -202,7 +200,9 @@ C     saltAdvScheme       :: Salt. Horiz.advection scheme selector
 C     saltVertAdvScheme   :: Salt. Vert. Advection scheme selector
 C     selectKEscheme      :: Kinetic Energy scheme selector (Vector Inv.)
 C     selectVortScheme    :: Scheme selector for Vorticity term (Vector Inv.)
+C     selectMetricTerms   :: Scheme selector for Metric terms (Flux-Form)
 C     selectCoriScheme    :: Scheme selector for Coriolis term
+C     select3dCoriScheme  :: Scheme selector for 3-D Coriolis (in Omega.cos Phi)
 C     selectBotDragQuadr  :: quadratic bottom drag discretisation option:
 C                           =0: average KE from grid center to U & V location
 C                           =1: use local velocity norm @ U & V location
@@ -213,7 +213,6 @@ C                            with digit =0 : disable ;
 C                           = 1 : increases mixing linearly with recip_hFac
 C                           = 2,3,4 : increases mixing by recip_hFac^(2,3,4)
 C     readBinaryPrec      :: Precision used for reading binary files
-C     writeStatePrec      :: Precision used for writing model state.
 C     writeBinaryPrec     :: Precision used for writing binary files
 C     rwSuffixType        :: controls the format of the mds file suffix.
 C                          =0 (default): use iteration number (myIter, I10.10);
@@ -238,9 +237,10 @@ C-    plotLevel           :: controls printing of field maps ; higher -> more fl
      &        momForcingOutAB, tracForcingOutAB,
      &        tempAdvScheme, tempVertAdvScheme,
      &        saltAdvScheme, saltVertAdvScheme,
-     &        selectKEscheme, selectVortScheme, selectCoriScheme,
+     &        selectKEscheme, selectVortScheme, selectMetricTerms,
+     &        selectCoriScheme, select3dCoriScheme,
      &        selectBotDragQuadr, pCellMix_select,
-     &        readBinaryPrec, writeBinaryPrec, writeStatePrec,
+     &        readBinaryPrec, writeBinaryPrec,
      &        rwSuffixType, monitorSelect, debugLevel, plotLevel
       INTEGER cg2dMaxIters
       INTEGER cg2dMinItersNSA
@@ -266,11 +266,12 @@ C-    plotLevel           :: controls printing of field maps ; higher -> more fl
       INTEGER saltAdvScheme, saltVertAdvScheme
       INTEGER selectKEscheme
       INTEGER selectVortScheme
+      INTEGER selectMetricTerms
       INTEGER selectCoriScheme
+      INTEGER select3dCoriScheme
       INTEGER selectBotDragQuadr
       INTEGER pCellMix_select
       INTEGER readBinaryPrec
-      INTEGER writeStatePrec
       INTEGER writeBinaryPrec
       INTEGER rwSuffixType
       INTEGER monitorSelect
@@ -318,10 +319,8 @@ C     momForcing    :: Flag which turns external forcing of momentum on and off.
 C     momTidalForcing    :: Flag which turns tidal forcing on and off.
 C     momPressureForcing :: Flag which turns pressure term in momentum equation
 C                          on and off.
-C     metricTerms   :: Flag which turns metric terms on or off.
 C     useNHMTerms   :: If TRUE use non-hydrostatic metric terms.
 C     useCoriolis   :: Flag which turns the coriolis terms on and off.
-C     use3dCoriolis :: Turns the 3-D coriolis terms (in Omega.cos Phi) on - off
 C     useCDscheme   :: use CD-scheme to calculate Coriolis terms.
 C     vectorInvariantMomentum :: use Vector-Invariant form (mom_vecinv package)
 C                                (default = F = use mom_fluxform package)
@@ -429,9 +428,8 @@ C                        & Last iteration, in addition multiple of dumpFreq iter
      & no_slip_sides, no_slip_bottom, bottomVisc_pCell, useSmag3D,
      & useFullLeith, useStrainTensionVisc, useAreaViscLength,
      & momViscosity, momAdvection, momForcing, momTidalForcing,
-     & momPressureForcing, metricTerms, useNHMTerms,
-     & useCoriolis, use3dCoriolis,
-     & useCDscheme, vectorInvariantMomentum,
+     & momPressureForcing, useNHMTerms,
+     & useCoriolis, useCDscheme, vectorInvariantMomentum,
      & useJamartMomAdv, upwindVorticity, highOrderVorticity,
      & useAbsVorticity, upwindShear,
      & momStepping, calc_wVelocity, tempStepping, saltStepping,
@@ -489,11 +487,9 @@ C                        & Last iteration, in addition multiple of dumpFreq iter
       LOGICAL momForcing
       LOGICAL momTidalForcing
       LOGICAL momPressureForcing
-      LOGICAL metricTerms
       LOGICAL useNHMTerms
 
       LOGICAL useCoriolis
-      LOGICAL use3dCoriolis
       LOGICAL useCDscheme
       LOGICAL vectorInvariantMomentum
       LOGICAL useJamartMomAdv
@@ -765,12 +761,12 @@ C     dumpFreq      :: Frequency with which model state is written to
 C                      post-processing files ( s ).
 C     diagFreq      :: Frequency with which model writes diagnostic output
 C                      of intermediate quantities.
-C     afFacMom      :: Advection of momentum term tracer parameter
-C     vfFacMom      :: Momentum viscosity tracer parameter
-C     pfFacMom      :: Momentum pressure forcing tracer parameter
-C     cfFacMom      :: Coriolis term tracer parameter
-C     foFacMom      :: Momentum forcing tracer parameter
-C     mtFacMom      :: Metric terms tracer parameter
+C     afFacMom      :: Advection of momentum term multiplication factor
+C     vfFacMom      :: Momentum viscosity term    multiplication factor
+C     pfFacMom      :: Momentum pressure forcing  multiplication factor
+C     cfFacMom      :: Coriolis term              multiplication factor
+C     foFacMom      :: Momentum forcing           multiplication factor
+C     mtFacMom      :: Metric terms               multiplication factor
 C     cosPower      :: Power of cosine of latitude to multiply viscosity
 C     cAdjFreq      :: Frequency of convective adjustment
 C
@@ -791,8 +787,8 @@ C     convertFW2Salt :: salinity, used to convert Fresh-Water Flux to Salt Flux
 C                       (use model surface (local) value if set to -1)
 C     temp_EvPrRn :: temperature of Rain & Evap.
 C     salt_EvPrRn :: salinity of Rain & Evap.
-C     temp_addMass :: temperature of addMass array
-C     salt_addMass :: salinity of addMass array
+C     temp_addMass :: temperature of addMass field
+C     salt_addMass :: salinity of addMass field
 C        (notes: a) tracer content of Rain/Evap only used if both
 C                     NonLin_FrSurf & useRealFreshWater are set.
 C                b) use model surface (local) value if set to UNSET_RL)
@@ -1034,7 +1030,7 @@ C             derived from the orography. Implemented: 0,1 (see INI_P_GROUND)
       _RL atm_Po, atm_Cp, atm_Rd, atm_kappa, atm_Rq
       INTEGER integr_GeoPot, selectFindRoSurf
 
-C----------------------------------------
+C---+----1----+----2----+----3----+----4----+----5----+----6----+----7-|--+----|
 C-- Logical flags for selecting packages
       LOGICAL useGAD
       LOGICAL useOBCS
@@ -1097,11 +1093,9 @@ C-- Logical flags for selecting packages
      &        usePTRACERS, useGCHEM, useRBCS, useOffLine, useMATRIX,
      &        useFRAZIL, useSEAICE, useSALT_PLUME, useShelfIce,
      &        useStreamIce, useICEFRONT, useThSIce, useLand,
-     &        useATM2D, useAIM, useAtm_Phys, useFizhi, useGridAlt,
+     &        useATM2d, useAIM, useAtm_Phys, useFizhi, useGridAlt,
      &        useDiagnostics, useREGRID, useLayers, useMNC,
      &        useRunClock, useEMBED_FILES,
      &        useMYPACKAGE
 
-CEH3 ;;; Local Variables: ***
-CEH3 ;;; mode:fortran ***
-CEH3 ;;; End: ***
+C---+----1----+----2----+----3----+----4----+----5----+----6----+----7-|--+----|

--- a/model/src/calc_gw.F
+++ b/model/src/calc_gw.F
@@ -83,7 +83,7 @@ C     yA            :: W-Cell face area normal to Y
 C     rThickC_W     :: thickness (in r-units) of W-Cell at Western Edge
 C     rThickC_S     :: thickness (in r-units) of W-Cell at Southern Edge
 C     rThickC_C     :: thickness (in r-units) of W-Cell (centered on W pt)
-C     recip_rThickC :: reciprol thickness of W-Cell (centered on W-point)
+C     recip_rThickC :: reciprocal thickness of W-Cell (centered on W-point)
 C     flx_NS        :: vertical momentum flux, meridional direction
 C     flx_EW        :: vertical momentum flux, zonal direction
 C     flxAdvUp      :: vertical mom. advective   flux, vertical direction (@ level k-1)
@@ -614,7 +614,7 @@ C---+----1----+----2----+----3----+----4----+----5----+----6----+----7-|--+----|
            ENDDO
           ENDDO
         ENDIF
-        IF ( use3dCoriolis .AND. k.GT.1 ) THEN
+        IF ( select3dCoriScheme.GE.1 .AND. k.GT.1 ) THEN
           CALL MOM_W_CORIOLIS_NH(
      I               bi,bj,k,
      I               uVel, vVel,

--- a/model/src/config_check.F
+++ b/model/src/config_check.F
@@ -1084,12 +1084,11 @@ C--   Grid limitations:
         CALL PRINT_ERROR( msgBuf, myThid )
         errCount = errCount + 1
        ENDIF
-       IF ( useFLT .OR. useZonal_Filt .OR. useECCO ) THEN
-        WRITE(msgBuf,'(2A)')
-     &       'CONFIG_CHECK: specifying Euler angles will probably ',
-     &       'not work with pkgs FLT, ZONAL_FLT, ECCO'
-        CALL PRINT_ERROR( msgBuf, myThid )
-        errCount = errCount + 1
+       IF ( useFLT .OR. useECCO ) THEN
+        WRITE(msgBuf,'(2A)') '** WARNING ** CONFIG_CHECK: specifying',
+     &       ' Euler angles may not work with pkgs FLT, ECCO'
+        CALL PRINT_MESSAGE( msgBuf, errorMessageUnit,
+     &                      SQUEEZE_RIGHT, myThid )
        ENDIF
       ENDIF
 

--- a/model/src/config_summary.F
+++ b/model/src/config_summary.F
@@ -461,8 +461,8 @@ C-----
       CALL PRINT_MESSAGE( msgBuf, ioUnit, SQUEEZE_RIGHT, myThid )
       CALL PRINT_MESSAGE(endList, ioUnit, SQUEEZE_RIGHT, myThid )
 C-----
-      CALL WRITE_0D_L( metricTerms,  INDEX_NONE, 'metricTerms =',
-     &                '  /* metric-Terms on/off flag */')
+      CALL WRITE_0D_I( selectMetricTerms, INDEX_NONE,
+     & 'selectMetricTerms=', ' /* Metric-Terms on/off flag (=0/1) */')
       CALL WRITE_0D_L( useNHMTerms,  INDEX_NONE, 'useNHMTerms =',
      &              ' /* Non-Hydrostatic Metric-Terms on/off */')
       WRITE(msgBuf,'(2A)')
@@ -475,8 +475,8 @@ C-----
      &  ' 2= Spherical ; 3= read from file'
       CALL PRINT_MESSAGE( msgBuf, ioUnit, SQUEEZE_RIGHT, myThid )
       CALL PRINT_MESSAGE(endList, ioUnit, SQUEEZE_RIGHT, myThid )
-      CALL WRITE_0D_L( use3dCoriolis,  INDEX_NONE,
-     & 'use3dCoriolis =', ' /* 3-D Coriolis on/off flag */')
+      CALL WRITE_0D_I( select3dCoriScheme, INDEX_NONE,
+     & 'select3dCoriScheme=', ' /* 3-D Coriolis on/off flag (=0/1) */')
       CALL WRITE_0D_L( useCoriolis,  INDEX_NONE,
      & 'useCoriolis =', '  /* Coriolis on/off flag */')
       CALL WRITE_0D_L( useCDscheme,  INDEX_NONE,

--- a/model/src/ini_parms.F
+++ b/model/src/ini_parms.F
@@ -119,6 +119,8 @@ C     useSphereF    :: Coriolis = 2.omega.sin(phi)  (replaced by selectCoriMap=2
 C     useJamartWetPoints :: for backward compat. (replaced by selectCoriScheme=1)
 C                        :: Use wet-point method for Coriolis (Jamart & Ozer 1986)
 C     SadournyCoriolis :: for backward compat. (replaced by selectVortScheme=2)
+C     use3dCoriolis :: for backward compat. (=F,T same as select3dCoriScheme=0,1)
+C     metricTerms   :: for backward compat. (=F,T same as selectMetricTerms=0,1)
 C     tracerAdvScheme :: tracer advection scheme (old passive tracer code)
 C     trac_EvPrRn :: tracer conc. in Rain & Evap (old passive tracer code)
 C     saltDiffusion :: diffusion of salinity    on/off (flag not used)
@@ -138,6 +140,7 @@ C                              (replaced by pkg/frazil)
 C     useOldFreezing :: use the old version (before checkpoint52a_pre, 2003-11-12)
 C     balanceEmPmR   :: for backward compat. (replaced by selectBalanceEmPmR=1),
 C                    :: substract global mean of EmPmR at every time step
+C     writeStatePrec :: Precision used for writing model state (not used)
 C Namelist PARM02:
 C     cg2dChkResFreq :: Frequency with which to check 2-D con. grad solver
 C                         residual (was never coded)
@@ -161,9 +164,9 @@ C     dQdTfile     :: File containing thermal relaxation coefficient
 
       INTEGER nRetired
       LOGICAL useConstantF, useBetaPlaneF, useSphereF
-      LOGICAL useJamartWetPoints
-      LOGICAL useEnergyConservingCoriolis
+      LOGICAL useJamartWetPoints, useEnergyConservingCoriolis
       LOGICAL SadournyCoriolis
+      LOGICAL use3dCoriolis, metricTerms
       LOGICAL tempDiffusion, saltDiffusion
       INTEGER tracerAdvScheme
       _RL trac_EvPrRn
@@ -175,6 +178,7 @@ c     _RL gravitySign
       LOGICAL saveDebugMode
       LOGICAL allowInteriorFreezing, useOldFreezing
       LOGICAL balanceEmPmR
+      INTEGER writeStatePrec
 C-
       INTEGER cg2dChkResFreq, cg3dChkResFreq
 C-
@@ -204,17 +208,27 @@ C--   Continuous equation parameters
      & viscA4Max, viscA4Grid, viscA4GridMax, viscA4GridMin,
      & viscA4ReMax, viscAhReMax,
      & cosPower, viscAstrain, viscAtension,
+     & viscAz, diffKzT, diffKzS, viscAp, diffKpT, diffKpS,
+     & viscAr, diffKrT, diffKrS, viscArNr, diffKrNrT, diffKrNrS,
      & diffKhT, diffK4T, diffKhS, diffK4S, smag3D_diffCoeff,
+     & diffKr4T, diffKr4S, BL79LatVary,
+     & diffKrBL79surf, diffKrBL79deep, diffKrBL79scl, diffKrBL79Ho,
+     & diffKrBLEQsurf, diffKrBLEQdeep, diffKrBLEQscl, diffKrBLEQHo,
      & surf_pRef, tRef, sRef, tRefFile, sRefFile, rhoRefFile,
      & eosType, selectP_inEOS_Zc, integr_GeoPot, selectFindRoSurf,
      & HeatCapacity_Cp, celsius2K, atm_Cp, atm_Rd, atm_Rq, atm_Po,
      & no_slip_sides, sideDragFactor, no_slip_bottom, bottomVisc_pCell,
      & bottomDragLinear, bottomDragQuadratic,  zRoughBot,
      & selectBotDragQuadr,
-     & momViscosity,  momAdvection, momForcing, momTidalForcing,
-     & useCoriolis, useConstantF, useBetaPlaneF, useSphereF,
-     & use3dCoriolis, momPressureForcing,
-     & metricTerms, vectorInvariantMomentum, addFrictionHeating,
+     & momPressureForcing, momForcing, momTidalForcing,
+     & momViscosity, momAdvection, vectorInvariantMomentum,
+     & useConstantF, useBetaPlaneF, useSphereF, useCoriolis,
+     & use3dCoriolis, select3dCoriScheme, selectCoriScheme,
+     & useCDscheme, useJamartWetPoints, useEnergyConservingCoriolis,
+     & useAbsVorticity, selectVortScheme, SadournyCoriolis,
+     & useJamartMomAdv, upwindVorticity, highOrderVorticity,
+     & upwindShear, selectKEscheme,
+     & selectMetricTerms, metricTerms, useNHMTerms, addFrictionHeating,
      & tempDiffusion, tempAdvection, tempForcing, temp_stayPositive,
      & saltDiffusion, saltAdvection, saltForcing, salt_stayPositive,
      & implicSurfPress, implicDiv2DFlow, implicitNHPress,
@@ -227,30 +241,20 @@ C--   Continuous equation parameters
      & tempStepping, saltStepping, momStepping,
      & implicitDiffusion, implicitViscosity, selectImplicitDrag,
      & tempImplVertAdv, saltImplVertAdv, momImplVertAdv,
-     & viscAz, diffKzT, diffKzS, viscAp, diffKpT, diffKpS,
-     & viscAr, diffKrT, diffKrS, viscArNr, diffKrNrT, diffKrNrS,
-     & diffKr4T, diffKr4S, BL79LatVary,
-     & diffKrBL79surf, diffKrBL79deep, diffKrBL79scl, diffKrBL79Ho,
-     & diffKrBLEQsurf, diffKrBLEQdeep, diffKrBLEQscl, diffKrBLEQHo,
      & rhoConst, thetaConst, rhoConstFresh, buoyancyRelation,
-     & readBinaryPrec, writeBinaryPrec, writeStatePrec, globalFiles,
-     & useSingleCpuIO, useSingleCpuInput, usePickupBeforeC54,
-     & usePickupBeforeC35, debugMode, debugLevel, plotLevel,
      & allowFreezing, allowInteriorFreezing, useOldFreezing, ivdc_kappa,
      & hMixCriteria, dRhoSmall, hMixSmooth,
-     & tempAdvScheme, tempVertAdvScheme,
-     & saltAdvScheme, saltVertAdvScheme, tracerAdvScheme,
-     & multiDimAdvection, useNHMTerms, useCDscheme,
-     & useAbsVorticity, selectCoriScheme, useJamartWetPoints,
-     & useEnergyConservingCoriolis, selectVortScheme, SadournyCoriolis,
-     & useJamartMomAdv, upwindVorticity, highOrderVorticity,
-     & upwindShear, selectKEscheme,
+     & tempAdvScheme, tempVertAdvScheme, tracerAdvScheme,
+     & saltAdvScheme, saltVertAdvScheme, multiDimAdvection,
      & selectAddFluid, useRealFreshWaterFlux, convertFW2Salt,
      & temp_EvPrRn, salt_EvPrRn, trac_EvPrRn,
      & temp_addMass, salt_addMass, zonal_filt_lat,
      & smoothAbsFuncRange, sIceLoadFac,
      & selectBalanceEmPmR, balanceEmPmR, balanceQnet, balancePrintMean,
-     & balanceThetaClimRelax, balanceSaltClimRelax
+     & balanceThetaClimRelax, balanceSaltClimRelax,
+     & readBinaryPrec, writeBinaryPrec, writeStatePrec, globalFiles,
+     & useSingleCpuIO, useSingleCpuInput, usePickupBeforeC54,
+     & usePickupBeforeC35, debugMode, debugLevel, plotLevel
 
 C--   Elliptic solver parameters
       NAMELIST /PARM02/
@@ -329,9 +333,11 @@ C     Defaults values for input parameters
      O   hFacMinDrDefault, delRDefault,
      I   myThid )
 
-      useJamartWetPoints  = .FALSE.
+      useJamartWetPoints = .FALSE.
       useEnergyConservingCoriolis = .FALSE.
       SadournyCoriolis = .FALSE.
+      use3dCoriolis   = .TRUE.
+      metricTerms     = .TRUE.
       balanceEmPmR    = .FALSE.
 
 C--   Initialise "which vertical coordinate system used" flags.
@@ -358,6 +364,7 @@ C--   Initialise retired parameters to unlikely value
       saveDebugMode   = debugMode
       allowInteriorFreezing = .FALSE.
       useOldFreezing  = .FALSE.
+      writeStatePrec  = UNSET_I
       cg2dChkResFreq  = UNSET_I
       cg3dChkResFreq  = UNSET_I
       tauThetaClimRelax3Dim = UNSET_RL
@@ -681,6 +688,28 @@ C--   for backward compatibility :
           errCount = errCount + 1
         ENDIF
       ENDIF
+      IF ( select3dCoriScheme.EQ.UNSET_I ) THEN
+C--   for backward compatibility :
+        select3dCoriScheme = 0
+        IF ( use3dCoriolis ) select3dCoriScheme = 1
+      ELSEIF ( select3dCoriScheme.NE.0 .AND. .NOT.use3dCoriolis ) THEN
+        WRITE(msgBuf,'(A,I5,A)')
+     &     'S/R INI_PARMS: select3dCoriScheme=', select3dCoriScheme,
+     &     ' conflicts with "use3dCoriolis=F"'
+        CALL PRINT_ERROR( msgBuf, myThid )
+        errCount = errCount + 1
+      ENDIF
+      IF ( selectMetricTerms.EQ.UNSET_I ) THEN
+C--   for backward compatibility :
+        selectMetricTerms = 0
+        IF ( metricTerms ) selectMetricTerms = 1
+      ELSEIF ( selectMetricTerms.NE.0 .AND. .NOT.metricTerms ) THEN
+        WRITE(msgBuf,'(A,I5,A)')
+     &     'S/R INI_PARMS: selectMetricTerms=', selectMetricTerms,
+     &     ' conflicts with "metricTerms=F"'
+        CALL PRINT_ERROR( msgBuf, myThid )
+        errCount = errCount + 1
+      ENDIF
       IF ( selectBalanceEmPmR.EQ.UNSET_I ) THEN
         selectBalanceEmPmR = 0
         IF ( balanceEmPmR ) selectBalanceEmPmR = 1
@@ -878,6 +907,12 @@ C     Check for retired parameters still being used
        nRetired = nRetired+1
        WRITE(msgBuf,'(A,A)') 'S/R INI_PARMS: "useOldFreezing" ',
      &  'is no longer supported & not longer allowed in file "data"'
+       CALL PRINT_ERROR( msgBuf, myThid )
+      ENDIF
+      IF ( writeStatePrec .NE. UNSET_I ) THEN
+       nRetired = nRetired+1
+       WRITE(msgBuf,'(A,A)') 'S/R INI_PARMS: "writeStatePrec" ',
+     &  '(un-used) is no longer allowed in file "data"'
        CALL PRINT_ERROR( msgBuf, myThid )
       ENDIF
 
@@ -1299,6 +1334,10 @@ C-    Radius of the Planet:
       ELSE
        recip_rSphere = 0.
       ENDIF
+C--   Grid rotation
+      IF ( phiEuler .NE. 0. _d 0 .OR. thetaEuler .NE. 0. _d 0
+     &     .OR. psiEuler .NE. 0. _d 0 ) rotateGrid = .TRUE.
+
 C--   Default vertical axis origin
       IF ( Ro_SeaLevel .NE. UNSET_RL ) THEN
        IF ( usingPCoords .AND. top_Pres.NE.UNSET_RL ) THEN
@@ -1336,44 +1375,6 @@ C--   Default origin for  X & Y axis (longitude & latitude origin):
           CALL PRINT_ERROR( msgBuf, myThid )
           errCount = errCount + 1
         ENDIF
-      ENDIF
-C--   Make metric term & Coriolis settings consistent with underlying grid.
-      IF ( usingCartesianGrid ) THEN
-       metricTerms   = .FALSE.
-       useNHMTerms   = .FALSE.
-      ENDIF
-      IF ( usingCylindricalGrid ) THEN
-       useNHMTerms   = .FALSE.
-       WRITE(msgBuf,'(A)') 'S/R INI_PARMS ; Cylinder OK'
-       CALL PRINT_MESSAGE( msgBuf, standardMessageUnit,
-     &                     SQUEEZE_RIGHT, myThid )
-      ENDIF
-      IF ( usingCurvilinearGrid ) THEN
-       metricTerms   = .FALSE.
-      ENDIF
-      IF ( selectCoriMap.EQ.-1 ) THEN
-        IF ( usingCartesianGrid.OR.usingCylindricalGrid ) THEN
-C       default is to use Beta-Plane Coriolis
-          selectCoriMap = 1
-        ELSE
-C       default for other grids is to use Spherical Coriolis
-          selectCoriMap = 2
-        ENDIF
-      ENDIF
-      IF ( .NOT.(nonHydrostatic.OR.quasiHydrostatic) )
-     &                          use3dCoriolis = .FALSE.
-      IF ( (selectCoriMap.EQ.0 .OR.selectCoriMap.EQ.1)
-     &     .AND. fPrime.EQ.0. ) use3dCoriolis = .FALSE.
-
-C--   Grid rotation
-      IF ( phiEuler .NE. 0. _d 0 .OR. thetaEuler .NE. 0. _d 0
-     &     .OR. psiEuler .NE. 0. _d 0 ) rotateGrid = .TRUE.
-
-C--   Set default for latitude-band where relaxation to climatology applies
-C     note: done later (once domain size is known) if using CartesianGrid
-      IF ( latBandClimRelax .EQ. UNSET_RL) THEN
-        IF ( usingSphericalPolarGrid ) latBandClimRelax= 180. _d 0
-        IF ( usingCurvilinearGrid )    latBandClimRelax= 180. _d 0
       ENDIF
 
 C--   set cell Center depth and put Interface at the middle between 2 C

--- a/model/src/ini_parms.F
+++ b/model/src/ini_parms.F
@@ -6,11 +6,11 @@
 
 C---+----1----+----2----+----3----+----4----+----5----+----6----+----7-|--+----|
 CBOP
-C     !ROUTINE: INI_PARMS
-C     !INTERFACE:
+C !ROUTINE: INI_PARMS
+C !INTERFACE:
       SUBROUTINE INI_PARMS( myThid )
 
-C     !DESCRIPTION:
+C !DESCRIPTION:
 C     Routine to load model "parameters" from parameter file "data"
 
 C     !USES:
@@ -27,25 +27,24 @@ C- need GRID.h to save, in rF(1), half retired param Ro_SeaLevel value:
 #include "GRID.h"
 #include "SET_GRID.h"
 
-C     !INPUT/OUTPUT PARAMETERS:
-C     myThid :: Number of this instance of INI_PARMS
+C !INPUT/OUTPUT PARAMETERS:
+C   myThid :: Number of this instance of INI_PARMS
       INTEGER myThid
 
-C     !LOCAL VARIABLES:
-C     dxSpacing, dySpacing :: Default spacing in X and Y.
-C                          :: Units are that of coordinate system
-C                          :: i.e. cartesian => metres
-C                          ::       s. polar => degrees
-C     deltaTtracer  :: Timestep for tracer equations ( s )
-C     forcing_In_AB :: flag to put all forcings (Temp,Salt,Tracers,Momentum)
-C                   :: contribution in (or out of) Adams-Bashforth time stepping.
-C     goptCount  :: Used to count the nuber of grid options (only one is allowed!)
-C     msgBuf     :: Informational/error message buffer
-C     errIO      :: IO error flag
-C     errCount   :: error counter (inconsitent params and other errors)
-C     iUnit      :: Work variable for IO unit number
-C     k, i, j    :: Loop counters
-C     xxxDefault :: Default value for variable xxx
+C !LOCAL VARIABLES:
+C   dxSpacing, dySpacing :: Default spacing in X and Y.
+C                        :: Units are that of coordinate system
+C                        :: i.e. cartesian => metres ; s. polar => degrees
+C   deltaTtracer  :: Timestep for tracer equations ( s )
+C   forcing_In_AB :: flag to put all forcings (Temp,Salt,Tracers,Momentum)
+C                 :: contribution in (or out of) Adams-Bashforth time stepping.
+C   goptCount  :: Used to count the nuber of grid options (only one is allowed!)
+C   msgBuf     :: Informational/error message buffer
+C   errIO      :: IO error flag
+C   errCount   :: error counter (inconsitent params and other errors)
+C   iUnit      :: Work variable for IO unit number
+C   k, i, j    :: Loop counters
+C   xxxDefault :: Default value for variable xxx
       _RL  dxSpacing
       _RL  dySpacing
       _RL deltaTtracer
@@ -55,30 +54,30 @@ C     xxxDefault :: Default value for variable xxx
       INTEGER gridNx, gridNy
       INTEGER k, i, j, iUnit
       INTEGER errIO, errCount
-C     Default values for variables which have vertical coordinate system
-C     dependency.
+C   Default values for variables which have vertical coordinate system
+C   dependency.
       _RL viscArDefault
       _RL diffKrTDefault
       _RL diffKrSDefault
       _RL hFacMinDrDefault
       _RL delRDefault(Nr)
-C     zCoordInputData :: Variables used to select between different coordinate systems.
-C     pCoordInputData :: The vertical coordinate system in the rest of the model is
-C     rCoordInputData :: written in terms of r. In the model "data" file input data
-C     coordsSet       :: can be interms of z, p or r.
-C                     :: e.g. delZ or delP or delR for the vertical grid spacing.
-C                     :: The following rules apply:
-C                     :: All parameters must use the same vertical coordinate system.
-C                     ::  e.g. delZ and viscAz is legal but
-C                     ::       delZ and viscAr is an error.
-C                     :: Similarly specifying delZ and delP is an error.
-C                     :: zCoord..., pCoord..., rCoord... are used to flag when
-C                     :: z, p or r are used.
-C                     :: coordsSet counts how many vertical coordinate systems have
-C                     :: been used to specify variables. coordsSet > 1 is an error.
-C     vertSetCount    :: to count number of vertical array elements which are set.
-C    specifiedDiffKrT :: internal flag, true when any diffK[r,z,p,Nr]T is specified
-C    specifiedDiffKrS :: internal flag, true when any diffK[r,z,p,Nr]S is specified
+C-- Variables used to select between different coordinate systems:
+C   zCoordInputData :: The vertical coordinate system in the rest of the  model
+C   pCoordInputData :: is written in terms of r. In the model "data" file, 
+C   rCoordInputData :: input params can be in terms of z, p or r.
+C   coordsSet       :: e.g. delZ or delP or delR for the vertical grid spacing.
+C                   :: The following rules apply:
+C                   :: All parameters must use the same vertical coordinate
+C                   :: system.  e.g. delZ and viscAz is legal
+C                   ::           but delZ and viscAr is an error.
+C                   :: Similarly specifying delZ and delP is an error.
+C                   :: zCoord..., pCoord..., rCoord... are used to flag when
+C                   :: z, p or r are used.
+C                   :: coordsSet counts how many vertical coordinates have been
+C                   :: used to specify variables. coordsSet > 1 is an error.
+C   vertSetCount    :: to count number of vertical array elements which are set.
+C   specifiedDiffKrT :: internal flag, true if any diffK[r,z,p,Nr]T is specified
+C   specifiedDiffKrS :: internal flag, true if any diffK[r,z,p,Nr]S is specified
 
       LOGICAL zCoordInputData
       LOGICAL pCoordInputData
@@ -87,15 +86,15 @@ C    specifiedDiffKrS :: internal flag, true when any diffK[r,z,p,Nr]S is specif
       INTEGER vertSetCount
       LOGICAL specifiedDiffKrT, specifiedDiffKrS
 
-C     Variables which have vertical coordinate system dependency.
-C     delZ    :: Vertical grid spacing ( m  ).
-C     delP    :: Vertical grid spacing ( Pa ).
-C     viscAz  :: Eddy viscosity coeff. for mixing of momentum vertically ( m^2/s )
-C     viscAp  :: Eddy viscosity coeff. for mixing of momentum vertically ( Pa^2/s )
-C     diffKzT :: Laplacian diffusion coeff. for mixing of heat vertically ( m^2/s )
-C     diffKpT :: Laplacian diffusion coeff. for mixing of heat vertically ( Pa^2/s )
-C     diffKzS :: Laplacian diffusion coeff. for mixing of salt vertically ( m^2/s )
-C     diffKpS :: Laplacian diffusion coeff. for mixing of salt vertically ( Pa^2/s )
+C-- Variables which have vertical coordinate system dependency.
+C   delZ    :: Vertical grid spacing ( m  ).
+C   delP    :: Vertical grid spacing ( Pa ).
+C   viscAz  :: Eddy viscosity coeff. for mixing of momentum vertically (m^2/s)
+C   viscAp  :: Eddy viscosity coeff. for mixing of momentum vertically (Pa^2/s)
+C   diffKzT :: Laplacian diffusion coeff. for mixing of heat vertically (m^2/s)
+C   diffKpT :: Laplacian diffusion coeff. for mixing of heat vertically (Pa^2/s)
+C   diffKzS :: Laplacian diffusion coeff. for mixing of salt vertically (m^2/s)
+C   diffKpS :: Laplacian diffusion coeff. for mixing of salt vertically (Pa^2/s)
       _RL delZ(Nr)
       _RL delP(Nr)
       _RL viscAz
@@ -108,59 +107,60 @@ C     diffKpS :: Laplacian diffusion coeff. for mixing of salt vertically ( Pa^2
       _RL diffKpS
       _RL diffKrS
 
-C     Retired main data file parameters. Kept here to trap use of old data files.
-C     nRetired :: Counter used to trap gracefully namelists containing "retired"
-C              :: parameters. These are parameters that are either no-longer used
-C                 or that have moved to a different input file and/or namelist.
+C-- Retired main data file parameters. Kept here to trap use of old data files.
+C   nRetired :: Counter used to trap gracefully namelists containing "retired"
+C            :: parameters. These are parameters that are either no-longer used
+C            :: or that have moved to a different input file and/or namelist.
 C Namelist PARM01:
-C     useConstantF  :: Coriolis coeff set to f0     (replaced by selectCoriMap=0)
-C     useBetaPlaneF :: Coriolis coeff = f0 + beta.y (replaced by selectCoriMap=1)
-C     useSphereF    :: Coriolis = 2.omega.sin(phi)  (replaced by selectCoriMap=2)
-C     useJamartWetPoints :: for backward compat. (replaced by selectCoriScheme=1)
-C                        :: Use wet-point method for Coriolis (Jamart & Ozer 1986)
-C     SadournyCoriolis :: for backward compat. (replaced by selectVortScheme=2)
-C     use3dCoriolis :: for backward compat. (=F,T same as select3dCoriScheme=0,1)
-C     metricTerms   :: for backward compat. (=F,T same as selectMetricTerms=0,1)
-C     tracerAdvScheme :: tracer advection scheme (old passive tracer code)
-C     trac_EvPrRn :: tracer conc. in Rain & Evap (old passive tracer code)
-C     saltDiffusion :: diffusion of salinity    on/off (flag not used)
-C     tempDiffusion :: diffusion of temperature on/off (flag not used)
-C     zonal_filt_lat :: Moved to package "zonal_filt"
-C     gravitySign  :: direction of gravity relative to R direction
-C                  :: (removed from namelist and set according to z/p coordinate)
-C     viscAstrain  :: replaced by standard viscosity coeff & useStrainTensionVisc
-C     viscAtension :: replaced by standard viscosity coeff & useStrainTensionVisc
-C     useAnisotropicViscAgridMax :: Changed to be default behavior.  Can
-C                     use old method by setting useAreaViscLength=.true.
-C     usePickupBeforeC35 :: to restart from old-pickup files (generated with code
-C                   from before checkpoint-35, Feb 08, 2001): disabled (Jan 2007)
-C     debugMode    :: to print debug msg. now read from parameter file eedata
-C     allowInteriorFreezing :: Allow water at depth to freeze and rise to the surface
-C                              (replaced by pkg/frazil)
-C     useOldFreezing :: use the old version (before checkpoint52a_pre, 2003-11-12)
-C     balanceEmPmR   :: for backward compat. (replaced by selectBalanceEmPmR=1),
-C                    :: substract global mean of EmPmR at every time step
-C     writeStatePrec :: Precision used for writing model state (not used)
+C   useConstantF  :: Coriolis coeff set to f0     (replaced by selectCoriMap=0)
+C   useBetaPlaneF :: Coriolis coeff = f0 + beta.y (replaced by selectCoriMap=1)
+C   useSphereF    :: Coriolis = 2.omega.sin(phi)  (replaced by selectCoriMap=2)
+C   useJamartWetPoints :: for backward compat. (replaced by selectCoriScheme=1)
+C                      :: Use wet-point method for Coriolis (Jamart & Ozer 1986)
+C   SadournyCoriolis :: for backward compat. (replaced by selectVortScheme=2)
+C   use3dCoriolis :: for backward compat. (=F,T same as select3dCoriScheme=0,1)
+C   metricTerms   :: for backward compat. (=F,T same as selectMetricTerms=0,1)
+C   tracerAdvScheme :: tracer advection scheme (old passive tracer code)
+C   trac_EvPrRn :: tracer conc. in Rain & Evap (old passive tracer code)
+C   saltDiffusion :: diffusion of salinity    on/off (flag not used)
+C   tempDiffusion :: diffusion of temperature on/off (flag not used)
+C   zonal_filt_lat :: Moved to package "zonal_filt"
+C   gravitySign  :: direction of gravity relative to R direction
+C                :: (removed from namelist and set according to z/p coordinate)
+C   viscAstrain  :: replaced by standard viscosity coeff & useStrainTensionVisc
+C   viscAtension :: replaced by standard viscosity coeff & useStrainTensionVisc
+C   useAnisotropicViscAgridMax :: Changed to be default behavior.  Can
+C                   use old method by setting useAreaViscLength=.true.
+C   usePickupBeforeC35 :: to restart from old-pickup files (generated with code
+C                 from before checkpoint-35, Feb 08, 2001): disabled (Jan 2007)
+C   debugMode    :: to print debug msg. now read from parameter file eedata
+C   allowInteriorFreezing :: Allow water at depth to freeze
+C                            and rise to the surface (replaced by pkg/frazil)
+C   useOldFreezing :: use the old version (before checkpoint52a_pre, 2003-11-12)
+C   balanceEmPmR   :: for backward compat. (replaced by selectBalanceEmPmR=1),
+C                  :: substract global mean of EmPmR at every time step
+C   writeStatePrec :: Precision used for writing model state (not used)
 C Namelist PARM02:
-C     cg2dChkResFreq :: Frequency with which to check 2-D con. grad solver
-C                         residual (was never coded)
-C     cg3dChkResFreq :: Frequency with which to check 3-D con. grad solver
-C                         residual (was never coded)
+C   cg2dChkResFreq :: Frequency with which to check 2-D con. grad solver
+C                       residual (was never coded)
+C   cg3dChkResFreq :: Frequency with which to check 3-D con. grad solver
+C                       residual (was never coded)
 C Namelist PARM03:
-C     tauThetaClimRelax3Dim :: replaced by pkg/rbcs (3.D Relaxation B.Cs)
-C     tauSaltClimRelax3Dim  :: replaced by pkg/rbcs (3.D Relaxation B.Cs)
-C     calendarDumps  :: moved to package "cal" (calendar)
+C   tauThetaClimRelax3Dim :: replaced by pkg/rbcs (3.D Relaxation B.Cs)
+C   tauSaltClimRelax3Dim  :: replaced by pkg/rbcs (3.D Relaxation B.Cs)
+C   calendarDumps  :: moved to package "cal" (calendar)
 C Namelist PARM04:
-C     Ro_SeaLevel :: origin of the vertical R-coords axis ;
-C                 :: replaced by top_Pres or seaLev_Z setting
-C     groundAtK1 :: put the surface(k=1) at the ground (replaced by usingPCoords)
-C     rkFac      :: removed from namelist ; replaced by -rkSign
-C     thetaMin   :: unfortunate variable name ; replaced by xgOrigin
-C     phiMin     :: unfortunate variable name ; replaced by ygOrigin
+C   Ro_SeaLevel :: origin of the vertical R-coords axis ;
+C               :: replaced by top_Pres or seaLev_Z setting
+C   groundAtK1 :: put the surface(k=1) at the ground (replaced by usingPCoords)
+C   rkFac      :: removed from namelist ; replaced by -rkSign
+C   thetaMin   :: unfortunate variable name ; replaced by xgOrigin
+C   phiMin     :: unfortunate variable name ; replaced by ygOrigin
 C Namelist PARM05:
-C     shelfIceFile :: File containing the topography of the shelfice draught
-C                     (replaced by SHELFICEtopoFile in SHELFICE.h)
-C     dQdTfile     :: File containing thermal relaxation coefficient
+C   shelfIceFile :: File containing the topography of the shelfice draught
+C                   (replaced by SHELFICEtopoFile in SHELFICE.h)
+C   dQdTfile     :: File containing thermal relaxation coefficient
+C---+----1----+----2----+----3----+----4----+----5----+----6----+----7-|--+----|
 
       INTEGER nRetired
       LOGICAL useConstantF, useBetaPlaneF, useSphereF
@@ -1535,8 +1535,8 @@ C     Check vertical diffusivity setting:
 
 C--   Set Units conversion factor required to incorporate
 C     surface forcing into z-p isomorphic equations:
-C     mass2rUnit: from mass per unit area [kg/m2] to r-coordinate (z:=1/rho;p:=g)
-C     rUnit2mass: from r-coordinate to mass per unit area [kg/m2] (z:=rho;p:=1/g)
+C     mass2rUnit: from mass per unit area [kg/m2] to r-coordinate
+C     rUnit2mass: from r-coordinate to mass per unit area [kg/m2]
       IF ( usingPCoords ) THEN
          mass2rUnit = gravity
          rUnit2mass = recip_gravity

--- a/model/src/packages_boot.F
+++ b/model/src/packages_boot.F
@@ -82,7 +82,7 @@ C     data.pkg namelists
      &          useICEFRONT,
      &          useThSIce,
      &          useLand,
-     &          useATM2D,
+     &          useATM2d,
      &          useAIM,
      &          useAtm_Phys,
      &          useFizhi,
@@ -146,7 +146,7 @@ c     useGAD          =.FALSE.
       useICEFRONT     =.FALSE.
       useThSIce       =.FALSE.
       useLand         =.FALSE.
-      useATM2D        =.FALSE.
+      useATM2d        =.FALSE.
       useAIM          =.FALSE.
       useAtm_Phys     =.FALSE.
       useFizhi        =.FALSE.
@@ -369,7 +369,7 @@ C----- pkgs with a standard "usePKG" On/Off switch in "data.pkg":
       CALL PACKAGES_PRINT_MSG( useLand,       'Land',        ' ' )
 #endif
 #ifdef ALLOW_ATM2D
-      CALL PACKAGES_PRINT_MSG( useATM2D,      'ATM2D',       ' ' )
+      CALL PACKAGES_PRINT_MSG( useATM2d,      'ATM2d',       ' ' )
 #endif
 #ifdef ALLOW_AIM_V23
       CALL PACKAGES_PRINT_MSG( useAIM,        'aim_v23', 'useAIM' )

--- a/model/src/packages_check.F
+++ b/model/src/packages_check.F
@@ -379,7 +379,7 @@ C---  Continue with standard packages (with standard usePKG flag)
 #endif
 
 #ifndef ALLOW_ATM2D
-      IF (useATM2D) CALL PACKAGES_ERROR_MSG('ATM2D',' ',myThid)
+      IF (useATM2d) CALL PACKAGES_ERROR_MSG('ATM2d',' ',myThid)
 #endif
 
 #ifndef ALLOW_AIM

--- a/model/src/set_defaults.F
+++ b/model/src/set_defaults.F
@@ -90,7 +90,6 @@ C     General cylindrical coordinate system
       usingCylindricalGrid= .FALSE.
 C     Coriolis map:
       selectCoriMap       = -1
-      use3dCoriolis       = .TRUE.
 C     grid rotation
       rotateGrid          = .FALSE.
       phiEuler            = 0. _d 0
@@ -201,8 +200,8 @@ C-    viscosity and diffusivity default value:
       saltForcing         = .TRUE.
       salt_stayPositive   = .FALSE.
       addFrictionHeating  = .FALSE.
-      metricTerms         = .TRUE.
       useNHMTerms         = .FALSE.
+      selectMetricTerms   = UNSET_I
       useSmag3D           = .FALSE.
       useFullLeith        = .FALSE.
       useAreaViscLength   = .FALSE.
@@ -229,6 +228,7 @@ C-    viscosity and diffusivity default value:
       multiDimAdvection   = .TRUE.
       useMultiDimAdvec    = .FALSE.
       useCDscheme         = .FALSE.
+      select3dCoriScheme  = UNSET_I
       selectCoriScheme    = UNSET_I
       selectVortScheme    = UNSET_I
       useJamartMomAdv     = .FALSE.
@@ -355,7 +355,6 @@ C-    I/O params:
       tave_lastIter     = 0.5 _d 0
       readBinaryPrec    = precFloat32
       writeBinaryPrec   = precFloat32
-      writeStatePrec    = precFloat64
       rwSuffixType      = 0
 
 C--   Input files

--- a/model/src/set_parms.F
+++ b/model/src/set_parms.F
@@ -51,6 +51,34 @@ C-    For off-line calculation, switch off Momentum and Active-tracers (=T,S):
       _BEGIN_MASTER(myThid)
       errCount = 0
 
+C--   Make metric term & Coriolis settings consistent with underlying grid.
+      IF ( usingCartesianGrid ) THEN
+        selectMetricTerms = 0
+        useNHMTerms   = .FALSE.
+      ENDIF
+      IF ( usingCylindricalGrid ) THEN
+        useNHMTerms   = .FALSE.
+        WRITE(msgBuf,'(A)') 'S/R INI_PARMS ; Cylinder OK'
+        CALL PRINT_MESSAGE( msgBuf, standardMessageUnit,
+     &                     SQUEEZE_RIGHT, myThid )
+      ENDIF
+      IF ( usingCurvilinearGrid ) THEN
+        selectMetricTerms = 0
+      ENDIF
+      IF ( selectCoriMap.EQ.-1 ) THEN
+        IF ( usingCartesianGrid.OR.usingCylindricalGrid ) THEN
+C       default is to use Beta-Plane Coriolis
+          selectCoriMap = 1
+        ELSE
+C       default for other grids is to use Spherical Coriolis
+          selectCoriMap = 2
+        ENDIF
+      ENDIF
+      IF ( .NOT.(nonHydrostatic.OR.quasiHydrostatic) )
+     &                          select3dCoriScheme = 0
+      IF ( (selectCoriMap.EQ.0 .OR.selectCoriMap.EQ.1)
+     &     .AND. fPrime.EQ.0. ) select3dCoriScheme = 0
+
 C--   On/Off flags for each terms of the momentum equation
       nonHydrostatic   = momStepping .AND. nonHydrostatic
       quasiHydrostatic = momStepping .AND. quasiHydrostatic
@@ -59,7 +87,7 @@ C--   On/Off flags for each terms of the momentum equation
       momForcing       = momStepping .AND. momForcing
       momTidalForcing  = momForcing  .AND. momTidalForcing
       useCoriolis      = momStepping .AND. useCoriolis
-      use3dCoriolis    = useCoriolis .AND. use3dCoriolis
+      IF ( .NOT.useCoriolis ) select3dCoriScheme = 0
       useCDscheme      = momStepping .AND. useCDscheme
       momPressureForcing= momStepping .AND. momPressureForcing
       implicitIntGravWave=momPressureForcing .AND. implicitIntGravWave
@@ -191,7 +219,7 @@ C--   Pressure term on/off flag.
        pfFacMom = 0. _d 0
       ENDIF
 C--   Metric terms on/off flag.
-      IF ( metricTerms ) THEN
+      IF ( selectMetricTerms.GE.1 ) THEN
        mTFacMom = 1. _d 0
       ELSE
        mTFacMom = 0. _d 0
@@ -225,6 +253,13 @@ C--   Dynamically Active Tracers : set flags
       ELSEIF ( eosType.EQ.'LINEAR' ) THEN
         IF ( tAlpha.EQ.0. ) tempIsActiveTr = .FALSE.
         IF ( sBeta .EQ.0. ) saltIsActiveTr = .FALSE.
+      ENDIF
+
+C--   Set default for latitude-band where relaxation to climatology applies
+C     note: done later (once domain size is known) if using CartesianGrid
+      IF ( latBandClimRelax .EQ. UNSET_RL) THEN
+        IF ( usingSphericalPolarGrid ) latBandClimRelax= 180. _d 0
+        IF ( usingCurvilinearGrid )    latBandClimRelax= 180. _d 0
       ENDIF
 
       IF ( usingZCoords ) THEN

--- a/pkg/autodiff/addummy_in_dynamics.F
+++ b/pkg/autodiff/addummy_in_dynamics.F
@@ -97,11 +97,6 @@ C--     Set suffix for this set of data files.
         ELSE
           CALL RW_GET_SUFFIX( suff, myTime, myIter, myThid )
         ENDIF
-C ==>> Resetting run-time parameter writeBinaryPrec in the middle of a run
-C ==>>  is very very very nasty !!!
-c       writeBinaryPrec = writeStatePrec
-C <<==  If you really want to mess-up with this at your own risk,
-C <<==  uncomment the line above
 
 #ifdef ALLOW_AUTODIFF_MONITOR_DIAG
         IF ( dumpAdVarExch.NE.2 ) THEN

--- a/pkg/autodiff/g_dummy_in_dynamics.F
+++ b/pkg/autodiff/g_dummy_in_dynamics.F
@@ -71,11 +71,6 @@ C--     Set suffix for this set of data files.
         ELSE
           CALL RW_GET_SUFFIX( suff, myTime, myIter, myThid )
         ENDIF
-C ==>> Resetting run-time parameter writeBinaryPrec in the middle of a run
-C ==>>  is very very very nasty !!!
-c       writeBinaryPrec = writeStatePrec
-C <<==  If you really want to mess-up with this at your own risk,
-C <<==  uncomment the line above
 
 #ifdef ALLOW_AUTODIFF_MONITOR_DIAG
         CALL WRITE_FLD_XYZ_RL(

--- a/pkg/exf/exf_adjoint_snapshots__g.F
+++ b/pkg/exf/exf_adjoint_snapshots__g.F
@@ -73,11 +73,6 @@ C--     Set suffix for this set of data files.
         ELSE
           CALL RW_GET_SUFFIX( suff, myTime, myIter, myThid )
         ENDIF
-C ==>> Resetting run-time parameter writeBinaryPrec in the middle of a run
-C ==>>  is very very very nasty !!!
-c       writeBinaryPrec = writeStatePrec
-C <<==  If you really want to mess-up with this at your own risk,
-C <<==  uncomment the line above
 
         IF ( iwhen .EQ.1 ) THEN
 

--- a/pkg/mom_common/mom_quasihydrostatic.F
+++ b/pkg/mom_common/mom_quasihydrostatic.F
@@ -65,7 +65,7 @@ C  scalingFactor :: scaling factor (from acceleration to density)
       _RL scalingFactor
 CEOP
 
-      IF ( use3dCoriolis .OR. useNHMTerms ) THEN
+      IF ( select3dCoriScheme.GE.1 .OR. useNHMTerms ) THEN
 
         IF ( usingZCoords ) THEN
 C--   Z-coordinate case: Input is density anomaly
@@ -96,7 +96,7 @@ C     (see White & Bromley, QJRMS 1995)
          ENDDO
         ENDDO
 
-        IF ( use3dCoriolis ) THEN
+        IF ( select3dCoriScheme.GE.1 ) THEN
          DO j=jMin,jMax
           DO i=iMin,iMax
            gWinBuoy(i,j) = fCoriCos(i,j,bi,bj)*

--- a/pkg/mom_fluxform/mom_fluxform.F
+++ b/pkg/mom_fluxform/mom_fluxform.F
@@ -186,7 +186,7 @@ C     uDudxFac, AhDudxFac, etc ... individual term parameters for switching term
       _RL  mtFacV
       _RL  mtNHFacV
       _RL  sideMaskFac
-      LOGICAL bottomDragTerms
+      LOGICAL bottomDragTerms, metricTerms
 CEOP
 #ifdef MOM_BOUNDARY_CONSERVE
       COMMON / MOM_FLUXFORM_LOCAL / uBnd, vBnd
@@ -253,6 +253,7 @@ C     o V momentum equation
       mtNHFacV     = 1.
       fvFac        = cfFacMom*1.
 
+      metricTerms  = selectMetricTerms.GE.1
       IF (implicitViscosity) THEN
         ArDudrFac  = 0.
         ArDvdrFac  = 0.
@@ -378,7 +379,6 @@ C     them here.
 CADJ STORE hDiv(:,:)    = comlev1_bibj_k, key = kkey, byte = isbyte
 CADJ STORE vort3(:,:)   = comlev1_bibj_k, key = kkey, byte = isbyte
 #endif
-
 
 C---  First call (k=1): compute vertical adv. flux fVerUkm & fVerVkm
       IF (momAdvection.AND.k.EQ.1) THEN
@@ -1022,14 +1022,14 @@ C--   Coriolis term (call to CD_CODE_SCHEME has been moved to timestep.F)
       ENDIF
 
 C--   3.D Coriolis term (horizontal momentum, Eastward component: -fprime*w)
-      IF ( use3dCoriolis ) THEN
+      IF ( select3dCoriScheme.GE.1 ) THEN
         CALL MOM_U_CORIOLIS_NH( bi,bj,k,wVel,uCf,myThid )
         DO j=jMin,jMax
          DO i=iMin,iMax
           gU(i,j,k,bi,bj) = gU(i,j,k,bi,bj) + fuFac*uCf(i,j)
          ENDDO
         ENDDO
-       IF ( usingCurvilinearGrid ) THEN
+       IF ( usingCurvilinearGrid .OR. rotateGrid ) THEN
 C-     presently, non zero angleSinC array only supported with Curvilinear-Grid
         CALL MOM_V_CORIOLIS_NH( bi,bj,k,wVel,vCf,myThid )
         DO j=jMin,jMax

--- a/pkg/mom_vecinv/mom_vecinv.F
+++ b/pkg/mom_vecinv/mom_vecinv.F
@@ -837,14 +837,14 @@ C--   end if momAdvection
       ENDIF
 
 C--   3.D Coriolis term (horizontal momentum, Eastward component: -fprime*w)
-      IF ( use3dCoriolis ) THEN
+      IF ( select3dCoriScheme.GE.1 ) THEN
         CALL MOM_U_CORIOLIS_NH(bi,bj,k,wVel,uCf,myThid)
         DO j=jMin,jMax
          DO i=iMin,iMax
           gU(i,j,k,bi,bj) = gU(i,j,k,bi,bj)+uCf(i,j)
          ENDDO
         ENDDO
-       IF ( usingCurvilinearGrid ) THEN
+       IF ( usingCurvilinearGrid .OR. rotateGrid ) THEN
 C-     presently, non zero angleSinC array only supported with Curvilinear-Grid
         CALL MOM_V_CORIOLIS_NH(bi,bj,k,wVel,vCf,myThid)
         DO j=jMin,jMax

--- a/pkg/streamice/streamice_dump_ad.F
+++ b/pkg/streamice/streamice_dump_ad.F
@@ -7,7 +7,7 @@
 CBOP
 C     !ROUTINE: adstreamice_dump
 C     !INTERFACE:
-      subroutine adstreamice_dump( mytime, myiter, myThid )
+      subroutine adstreamice_dump( myTime, myIter, myThid )
 
 C     !DESCRIPTION: \bv
 C     *==========================================================*
@@ -23,7 +23,6 @@ C     \ev
 
 C     !USES:
       IMPLICIT NONE
-
 C     == Global variables ===
 #include "SIZE.h"
 #include "EEPARAMS.h"
@@ -40,18 +39,16 @@ C     == Global variables ===
       EXTERNAL IO_ERRCOUNT
 
 C     !INPUT/OUTPUT PARAMETERS:
-C     == Routine arguments ==
-C     myIter - iteration counter for this thread
 C     myTime - time counter for this thread
+C     myIter - iteration counter for this thread
 C     myThid - Thread number for this instance of the routine.
+      _RL     myTime
+      integer myIter
       integer myThid
-      integer myiter
-      _RL     mytime
 
 #if (defined (ALLOW_ADJOINT_RUN) || defined (ALLOW_ADMTLM))
 
 C     !LOCAL VARIABLES:
-c     == local variables ==
 C     suff - Hold suffix part of a filename
 C     beginIOErrCount - Begin and end IO error counts
 C     endIOErrCount
@@ -61,27 +58,27 @@ C     msgBuf - Error message buffer
       INTEGER endIOErrCount
       CHARACTER*(MAX_LEN_MBUF) msgBuf
 
-      double precision :: area_shelf_streamice_ad(1-olx:snx+olx,1-oly:
-     $sny+oly,nsx,nsy)
-      double precision :: b_glen_ad(1-olx:snx+olx,1-oly:sny+oly,nsx,nsy)
-      double precision :: bdot_streamice_ad(1-olx:snx+olx,1-oly:sny+oly,
-     $nsx,nsy)
-      double precision :: c_basal_friction_ad(1-olx:snx+olx,1-oly:sny+
-     $oly,nsx,nsy)
-      double precision :: float_frac_streamice_ad(1-olx:snx+olx,1-oly:
-     $sny+oly,nsx,nsy)
-      double precision :: h_streamice_ad(1-olx:snx+olx,1-oly:sny+oly,
-     $nsx,nsy)
-      double precision :: surf_el_streamice_ad(1-olx:snx+olx,1-oly:sny+
-     $oly,nsx,nsy)
-      double precision :: tau_beta_eff_streamice_ad(1-olx:snx+olx,1-oly:
-     $sny+oly,nsx,nsy)
-      double precision :: u_streamice_ad(1-olx:snx+olx,1-oly:sny+oly,
-     $nsx,nsy)
-      double precision :: v_streamice_ad(1-olx:snx+olx,1-oly:sny+oly,
-     $nsx,nsy)
-      double precision :: visc_streamice_ad(1-olx:snx+olx,1-oly:sny+oly,
-     $nsx,nsy)
+      double precision :: area_shelf_streamice_ad(1-OLx:sNx+OLx,1-OLy:
+     $sNy+OLy,nSx,nSy)
+      double precision :: b_glen_ad(1-OLx:sNx+OLx,1-OLy:sNy+OLy,nSx,nSy)
+      double precision :: bdot_streamice_ad(1-OLx:sNx+OLx,1-OLy:sNy+OLy,
+     $nSx,nSy)
+      double precision :: c_basal_friction_ad(1-OLx:sNx+OLx,1-OLy:sNy+
+     $OLy,nSx,nSy)
+      double precision :: float_frac_streamice_ad(1-OLx:sNx+OLx,1-OLy:
+     $sNy+OLy,nSx,nSy)
+      double precision :: h_streamice_ad(1-OLx:sNx+OLx,1-OLy:sNy+OLy,
+     $nSx,nSy)
+      double precision :: surf_el_streamice_ad(1-OLx:sNx+OLx,1-OLy:sNy+
+     $OLy,nSx,nSy)
+      double precision :: tau_beta_eff_streamice_ad(1-OLx:sNx+OLx,1-OLy:
+     $sNy+OLy,nSx,nSy)
+      double precision :: u_streamice_ad(1-OLx:sNx+OLx,1-OLy:sNy+OLy,
+     $nSx,nSy)
+      double precision :: v_streamice_ad(1-OLx:sNx+OLx,1-OLy:sNy+OLy,
+     $nSx,nSy)
+      double precision :: visc_streamice_ad(1-OLx:sNx+OLx,1-OLy:sNy+OLy,
+     $nSx,nSy)
       common /streamice_fields_rl_ad/ h_streamice_ad, u_streamice_ad,
      $v_streamice_ad, visc_streamice_ad, tau_beta_eff_streamice_ad,
      $float_frac_streamice_ad, surf_el_streamice_ad,
@@ -89,21 +86,18 @@ C     msgBuf - Error message buffer
      $bdot_streamice_ad
 
 #ifdef USE_ALT_RLOW
-      double precision :: r_low_si_ad(1-olx:snx+olx,1-oly:sny+oly,nsx,
-     $nsy)
+      double precision :: r_low_si_ad(1-OLx:sNx+OLx,1-OLy:sNy+OLy,nSx,
+     $nSy)
       common /streamice_rlow_ad/ r_low_si_ad
 #endif
-
-c     == end of interface ==
 CEOP
 
       IF (
-     &  DIFFERENT_MULTIPLE(streamice_adjDump,mytime,deltaTClock)
+     &  DIFFERENT_MULTIPLE(streamice_adjDump,myTime,deltaTClock)
      & ) THEN
 
 C--     Set suffix for this set of data files.
         WRITE(suff,'(I10.10)') myIter
-        writeBinaryPrec = writeStatePrec
 
 C--     Read IO error counter
         beginIOErrCount = IO_ERRCOUNT(myThid)

--- a/verification/bottom_ctrl_5x5/code_ad/dummy_in_hfac.F
+++ b/verification/bottom_ctrl_5x5/code_ad/dummy_in_hfac.F
@@ -102,7 +102,6 @@ CEOP
 
 C--     Set suffix for this set of data files.
         WRITE(suff,'(I10.10)') myIter
-c       writeBinaryPrec = writeStatePrec
 
 C--     Read IO error counter
         beginIOErrCount = IO_ERRCOUNT(myThid)

--- a/verification/bottom_ctrl_5x5/input_ad.facg2d/data
+++ b/verification/bottom_ctrl_5x5/input_ad.facg2d/data
@@ -23,7 +23,6 @@
  rigidLid=.FALSE.,
  implicitFreeSurface=.TRUE.,
  eosType='LINEAR',
- writeStatePrec=64,
  writeBinaryPrec=64,
  readBinaryPrec=64,
  hFacMin=.05,

--- a/verification/bottom_ctrl_5x5/input_ad/data
+++ b/verification/bottom_ctrl_5x5/input_ad/data
@@ -23,7 +23,6 @@
  rigidLid=.FALSE.,
  implicitFreeSurface=.TRUE.,
  eosType='LINEAR',
- writeStatePrec=64,
  writeBinaryPrec=64,
  readBinaryPrec=64,
  hFacMin=.05,

--- a/verification/dome/input/data
+++ b/verification/dome/input/data
@@ -41,7 +41,6 @@
  saltAdvScheme=77,
  readBinaryPrec=64,
  writeBinaryPrec=64,
- writeStatePrec=64,
 #- not safe to use globalFiles in multi-processors runs
 #globalFiles=.TRUE.,
  &

--- a/verification/global_ocean.cs32x15/input_ad.seaice_dynmix/data
+++ b/verification/global_ocean.cs32x15/input_ad.seaice_dynmix/data
@@ -61,7 +61,6 @@
  forcing_In_AB=.FALSE.,
  pChkptFreq  =311040000.,
  chkptFreq   = 31104000.,
-#taveFreq    =311040000.,
 #dumpFreq    = 31104000.,
 #adjDumpFreq = 31104000.,
 #monitorFreq = 31104000.,
@@ -77,7 +76,6 @@
  adjMonitorFreq=1.,
  dumpFreq    = 432000.,
  adjDumpFreq = 432000.,
- pickupStrictlyMatch=.FALSE.,
  &
 
 # Gridding parameters

--- a/verification/global_ocean.cs32x15/input_ad.thsice/data
+++ b/verification/global_ocean.cs32x15/input_ad.thsice/data
@@ -34,7 +34,6 @@
  hFacInf=0.2,
  hFacSup=2.0,
  useRealFreshWaterFlux=.TRUE.,
-### allowFreezing=.TRUE.,
  hFacMin=.1,
  hFacMinDr=20.,
  readBinaryPrec=64,
@@ -62,7 +61,6 @@
 #momDissip_In_AB=.FALSE.,
  pChkptFreq  =311040000.,
  chkptFreq   = 31104000.,
-#taveFreq    =311040000.,
 #dumpFreq    = 31104000.,
 #adjDumpFreq = 31104000.,
 #monitorFreq = 31104000.,
@@ -78,7 +76,6 @@
  adjMonitorFreq=1.,
  dumpFreq    = 432000.,
  adjDumpFreq = 432000.,
- pickupStrictlyMatch=.FALSE.,
  &
 
 # Gridding parameters

--- a/verification/internal_wave/input.kl10/data
+++ b/verification/internal_wave/input.kl10/data
@@ -38,7 +38,6 @@
 #globalFiles=.TRUE.,
  readBinaryPrec=64,
  writeBinaryPrec=64,
- writeStatePrec=64,
  &
 
 # Elliptic solver parameters

--- a/verification/internal_wave/input/data
+++ b/verification/internal_wave/input/data
@@ -36,7 +36,6 @@
 #globalFiles=.TRUE.,
  readBinaryPrec=64,
  writeBinaryPrec=64,
- writeStatePrec=64,
  &
 
 # Elliptic solver parameters


### PR DESCRIPTION
## What changes does this PR introduce?
This is in preparation for adding new discretisation options for Coriolis and momentum advection (including Metric-Terms):
1. upgrade boolean param `metricTerms` to integer param `selectMetricTerms` (for now, =0/1 matching F/T old setting)
2. upgrade boolean param `use3dCoriolis` to integer param `select3dCoriScheme` (for now, =0/1 matching F/T old setting)

Also remove un-used param `writeStatePrec` (see issue #117) and fix a missing term (3-D coriolis) with `rotateGrid`.

##  What is the current behaviour?
3-D corilolis term in V-component momentum is missing when using `rotateGrid`

## What is the new behaviour 
above is fixed. Also allows to use FFT filtering along X-dir (i.e., pkg/zonal_filt) with `rotategrid`.
And regarding the switch of 2 parameters,  fulll backward compatibility allows to leave user parameter file unchanged.

## Does this PR introduce a breaking change? 
un-used former parameter `writeStatePrec` is no longer allowed in main parameter file `data` (with clean error message)

## Other information:

## Suggested addition to `tag-index`
o model/src:
  - change param "metricTerms" to integer param "selectMetricTerms" and change
    param "use3dCoriolis" to integer param "select3dCoriScheme" but keep former
    parameters in namelist (backward compatible). 
  - remove un-used param "writeStatePrec" + also in experiment param file "data"
  - rotateGrid: fix missing 3-D Coriolis term to gV ; adjust usage restriction.

