### PR TITLE
Preformed Tracers

### DIFF
--- a/pkg/ptracers/PTRACERS_PARAMS.h
+++ b/pkg/ptracers/PTRACERS_PARAMS.h
@@ -22,7 +22,10 @@ C              b) use pTracer surface (local) value if = UNSET_RL (default)
 C     PTRACERS_startStepFwd :: time to start stepping forward this tracer
 C     PTRACERS_resetFreq    :: Frequency (s) to reset ptracers to original val
 C     PTRACERS_resetPhase   :: Phase (s) to reset ptracers
-
+C     PTRACERS_tauRelaxPreformed :: Relaxation timescale for preformed tracers
+C                                    in the upper ocean
+C     PTRACERS_preformedFixedValue :: Fixed value to relax a preformed tracer
+C                                      towards in the upper ocean.
       _RL PTRACERS_dTLev(Nr)
       _RL PTRACERS_dumpFreq
       _RL PTRACERS_taveFreq
@@ -35,6 +38,9 @@ C     PTRACERS_resetPhase   :: Phase (s) to reset ptracers
       _RL PTRACERS_startStepFwd(PTRACERS_num)
       _RL PTRACERS_resetFreq(PTRACERS_num)
       _RL PTRACERS_resetPhase(PTRACERS_num)
+      _RL PTRACERS_tauRelaxPreformed(PTRACERS_num)
+      _RL PTRACERS_preformedFixedValue(PTRACERS_num)
+
       COMMON /PTRACERS_PARAMS_R/
      &     PTRACERS_dTLev,
      &     PTRACERS_dumpFreq,
@@ -47,7 +53,9 @@ C     PTRACERS_resetPhase   :: Phase (s) to reset ptracers
      &     PTRACERS_EvPrRn,
      &     PTRACERS_startStepFwd,
      &     PTRACERS_resetFreq,
-     &     PTRACERS_resetPhase
+     &     PTRACERS_resetPhase,
+     &     PTRACERS_tauRelaxPreformed,
+     &     PTRACERS_preformedFixedValue
 
 #ifdef ALLOW_COST
 C     COMMON /PTRACERS_OLD_R/ Old (real type) PTRACERS parameters
@@ -60,13 +68,16 @@ C        (to be removed 1 day ...)
 C--   COMMON /PTRACERS_PARAMS_I/ PTRACERS integer-type parameters:
 C     PTRACERS_numInUse :: number of tracers to use
 C     PTRACERS_Iter0    :: timestep number when tracers are initialized
+C     PTRACERS_preformedMate :: Which ptracer to relax a preformed tracer towards
       INTEGER PTRACERS_Iter0
       INTEGER PTRACERS_numInUse
       INTEGER PTRACERS_advScheme(PTRACERS_num)
+      INTEGER PTRACERS_preformedMate(PTRACERS_num)
       COMMON /PTRACERS_PARAMS_I/
      &     PTRACERS_Iter0,
      &     PTRACERS_numInUse,
-     &     PTRACERS_advScheme
+     &     PTRACERS_advScheme,
+     &     PTRACERS_preformedMate
 
 C--   COMMON /PTRACERS_PARAMS_L/ PTRACERS logical-type parameters:
 C     PTRACERS_ImplVertAdv   :: use Implicit Vertical Advection for this tracer
@@ -90,6 +101,12 @@ C                               (set internally)
 C     PTRACERS_linFSConserve :: apply mean Free-Surf source/sink at surface
 C     PTRACERS_stayPositive  :: use Smolarkiewicz Hack to ensure Tracer stays >0
 C     PTRACERS_useRecords    :: snap-shot output: put all pTracers in one file
+C     PTRACERS_isPreformed   :: set as a preformed tracer reset in the upper ocean        
+C     PTRACERS_preformedUseMLD:: reset a preformed tracer throughout the mixed
+C                               layer depth, not just the surface level
+C     PTRACERS_preformedAgeTracer:: Is the preformed tracer an age-tracer, with
+C                               internal source
+
       LOGICAL PTRACERS_ImplVertAdv(PTRACERS_num)
       LOGICAL PTRACERS_MultiDimAdv(PTRACERS_num)
       LOGICAL PTRACERS_SOM_Advection(PTRACERS_num)
@@ -111,6 +128,10 @@ C     PTRACERS_useRecords    :: snap-shot output: put all pTracers in one file
      &     PTRACERS_pickup_write_mdsio, PTRACERS_pickup_read_mdsio,
      &     PTRACERS_timeave_mnc, PTRACERS_snapshot_mnc,
      &     PTRACERS_pickup_write_mnc, PTRACERS_pickup_read_mnc
+      LOGICAL PTRACERS_isPreformed(PTRACERS_num)
+      LOGICAL PTRACERS_preformedUseMLD(PTRACERS_num)    
+      LOGICAL PTRACERS_preformedAgeTracer(PTRACERS_num)
+
       COMMON /PTRACERS_PARAMS_L/
      &     PTRACERS_ImplVertAdv,
      &     PTRACERS_MultiDimAdv,
@@ -127,7 +148,10 @@ C     PTRACERS_useRecords    :: snap-shot output: put all pTracers in one file
      &     PTRACERS_pickup_write_mdsio, PTRACERS_pickup_read_mdsio,
      &     PTRACERS_monitor_stdio, PTRACERS_monitor_mnc,
      &     PTRACERS_timeave_mnc, PTRACERS_snapshot_mnc,
-     &     PTRACERS_pickup_write_mnc, PTRACERS_pickup_read_mnc
+     &     PTRACERS_pickup_write_mnc, PTRACERS_pickup_read_mnc,
+     &     PTRACERS_isPreformed, PTRACERS_preformedUseMLD,    
+     &     PTRACERS_preformedAgeTracer  
+
 
 C--   COMMON /PTRACERS_PARAMS_C/ PTRACERS character-type parameters:
       CHARACTER*(MAX_LEN_FNAM) PTRACERS_initialFile(PTRACERS_num)

--- a/pkg/ptracers/ptracers_apply_forcing.F
+++ b/pkg/ptracers/ptracers_apply_forcing.F
@@ -20,6 +20,7 @@ C !USES: ===============================================================
 #include "EEPARAMS.h"
 #include "PARAMS.h"
 #include "GRID.h"
+#include "DYNVARS.h"
 #include "PTRACERS_SIZE.h"
 #include "PTRACERS_PARAMS.h"
 #include "PTRACERS_FIELDS.h"
@@ -52,6 +53,7 @@ C  i,j            :: loop indices
       INTEGER i,j
 C     number of surface interface layer
       INTEGER kSurface
+      INTEGER kmld(1-OLx:sNx+OLx,1-OLy:sNy+OLy)
 CEOP
 
       IF ( fluidIsAir ) THEN
@@ -77,6 +79,19 @@ C     because it is needed by KPP_TRANSPORT_PTR.
       ENDIF
 #endif /* ALLOW_GCHEM */
 
+C get index of MLD for resetting 
+       DO j=0,sNy+1
+        DO i=0,sNx+1
+         kmld(i,j) = 0
+
+         IF ( maskC(i,j,k,bi,bj).NE.0. _d 0 
+     &               .AND. abs(RF(1+kmld(i,j))) 
+     &               .LT.hMixLayer(i,j,bi,bj) 
+     &               ) 
+     &               kmld(i,j)=kmld(i,j)+1
+        ENDDO
+       ENDDO
+
       IF ( k .EQ. kSurface ) THEN
 c      DO j=jMin,jMax
 c       DO i=iMin,iMax
@@ -97,6 +112,22 @@ c       DO i=iMin,iMax
          ENDIF
         ENDDO
        ENDDO
+C Internal ocean sources and sinks of ptracers       
+      ELSEIF ( k .NE. kSurface .AND. 
+     &                     PTRACERS_preformedAgeTracer(iTracer)) THEN
+          DO j=0,sNy+1
+            DO i=0,sNx+1
+              IF (PTRACERS_preformedUseMLD(iTracer)) THEN
+                IF ( k .GE. kmld(i,j) ) THEN
+                    gPtracer(i,j) = gPtracer(i,j)
+     &                          + 1. _d 0 * maskC(i,j,k,bi,bj)
+                ENDIF
+              ELSE
+                  gPtracer(i,j) = gPtracer(i,j)
+     &                          + 1. _d 0 * maskC(i,j,k,bi,bj)
+              ENDIF
+            ENDDO
+          ENDDO
       ENDIF
 
       IF (PTRACERS_linFSConserve(iTracer)) THEN

--- a/pkg/ptracers/ptracers_check.F
+++ b/pkg/ptracers/ptracers_check.F
@@ -38,6 +38,10 @@ C---+----1----+----2----+----3----+----4----+----5----+----6----+----7-|--+----|
 
       _BEGIN_MASTER(myThid)
       errCount = 0
+      WRITE(msgBuf,'(2A)') 'PTRACERS_CHECK ',
+     &                     ' --> Starts to check PTRACERS set-up'
+      CALL PRINT_MESSAGE( msgBuf, standardMessageUnit,
+     &                    SQUEEZE_RIGHT, myThid )
 
       WRITE(msgBuf,'(A)') 'PTRACERS_CHECK: #define ALLOW_PTRACERS'
       CALL PRINT_MESSAGE( msgBuf, standardMessageUnit,
@@ -140,6 +144,32 @@ C--   Print a summary of pTracer parameter values:
      &     'PTRACERS_stayPositive =',
      &     ' /* use Smolarkiewicz Hack for this tracer */')
 #endif
+        CALL WRITE_0D_L( PTRACERS_isPreformed(iTracer), INDEX_NONE,
+     &     'PTRACERS_isPreformed =', ' /* preformed tracer */')
+        IF ( PTRACERS_isPreformed(iTracer) ) THEN
+           CALL WRITE_0D_L( 
+     &        PTRACERS_preformedUseMLD(iTracer), INDEX_NONE,
+     &       'PTRACERS_preformedUseMLD =', 
+     &       ' /* reset tracer over MLD or just at the surface */')
+           CALL WRITE_0D_L( 
+     &        PTRACERS_preformedAgeTracer(iTracer), INDEX_NONE,
+     &       'PTRACERS_preformedAgeTracer =', 
+     &       ' /* Tracer ages in ocean interior */')
+           IF ( PTRACERS_preformedMate(iTracer).NE.UNSET_I ) 
+     &        CALL WRITE_0D_I( 
+     &            PTRACERS_preformedMate(iTracer), INDEX_NONE,
+     &           'PTRACERS_preformedMate =', 
+     &           ' /* Reset towards this tracer value */')
+           IF ( PTRACERS_preformedFixedValue(iTracer).NE.UNSET_RL ) 
+     &        CALL WRITE_0D_RL( 
+     &            PTRACERS_preformedFixedValue(iTracer), INDEX_NONE,
+     &           'PTRACERS_preformedFixedValue =', 
+     &           ' /* Reset towards this tracer value */')
+           CALL WRITE_0D_RL( 
+     &            PTRACERS_tauRelaxPreformed(iTracer), INDEX_NONE,
+     &           'PTRACERS_tauRelaxPreformed =', 
+     &           ' /* Reset timescale for preformed tracer */')
+        ENDIF
         CALL WRITE_1D_RL( PTRACERS_ref(1,iTracer), Nr, INDEX_K,
      &     'PTRACERS_ref =', ' /* Reference vertical profile */')
         CALL WRITE_0D_RL( PTRACERS_EvPrRn(iTracer), INDEX_NONE,
@@ -247,6 +277,66 @@ C---+----1----+----2----+----3----+----4----+----5----+----6----+----7-|--+----|
         errCount = errCount + 1
        ENDIF
 #endif
+C     Check preformed or age tracer parms that dont make sense
+        IF ( PTRACERS_isPreformed(iTracer) ) THEN
+C       Only set one of PTRACERS_preformedMate or PTRACERS_preformedFixedValue  
+           IF (
+     &         (PTRACERS_preformedMate(iTracer).EQ.UNSET_I .AND.
+     &         PTRACERS_preformedFixedValue(iTracer).EQ.UNSET_RL) .OR.
+     &         (PTRACERS_preformedMate(iTracer).NE.UNSET_I .AND.
+     &         PTRACERS_preformedFixedValue(iTracer).NE.UNSET_RL)
+     &          ) THEN   
+              WRITE(msgBuf,'(A,I4,A,A,I9,A,1PE23.14,A)')
+     &           ' PTRACERS_CHECK: You want ptracer ',
+     &           iTracer,
+     &           ' to be a preformed tracer,',
+     &           ' but PTRACERS_preformedMate is ', 
+     &           PTRACERS_preformedMate(iTracer),
+     &           ' and PTRACERS_preformedFixedValue is ',
+     &           PTRACERS_preformedFixedValue(iTracer),
+     &           '. You need to specify one or the other.'
+              CALL PRINT_ERROR( msgBuf, myThid )
+              errCount = errCount + 1
+C          Check that PTRACERS_preformedMate points to a real ptracer
+           ELSEIF (PTRACERS_preformedFixedValue(iTracer).EQ.UNSET_RL
+     &         .AND.PTRACERS_preformedMate(iTracer)
+     &                                       .GT.PTRACERS_numInUse) THEN
+              WRITE(msgBuf,'(A,I9,A,A,I9,A,I9,A)')
+     &           ' PTRACERS_CHECK: You want ptracer ',
+     &           iTracer,
+     &           ' to be a preformed tracer,',     
+     &           ' pointing to Ptr ' ,
+     &           PTRACERS_preformedMate(iTracer),
+     &           ' when only ',
+     &           PTRACERS_numInUse,
+     &           ' tracers are being used. '
+              CALL PRINT_ERROR( msgBuf, myThid )
+              errCount = errCount + 1
+           ENDIF
+C Soft warning for is the relaxation time is set to 1.234567e5. I mean,
+C   that could be a legitimate value
+           IF (PTRACERS_tauRelaxPreformed(iTracer).EQ.UNSET_RL) THEN
+              WRITE(msgBuf,'(A,I9,A,A,1PE23.14,A)')
+     &           ' PTRACERS_CHECK: You want ptracer ',
+     &           iTracer,
+     &           ' to be a preformed tracer,',
+     &           ' but the relaxation time is ',UNSET_RL,
+     &           ', are you sure?'
+              CALL PRINT_MESSAGE(msgBuf,errorMessageUnit,
+     &           SQUEEZE_RIGHT,myThid)
+C Soft warning for is the relaxation time is set to 0. I mean,
+C   could that be a legitimate value, probably not....
+           ELSEIF (PTRACERS_tauRelaxPreformed(iTracer).EQ.0. _d 0) THEN
+              WRITE(msgBuf,'(A,I9,A,A,1PE23.14,A)')
+     &           ' PTRACERS_CHECK: You want ptracer ',
+     &           iTracer,
+     &           ' to be a preformed tracer,',
+     &           ' but the relaxation time is set to ',0. _d 0,
+     &           ', are you sure?'
+              CALL PRINT_MESSAGE(msgBuf,errorMessageUnit,
+     &           SQUEEZE_RIGHT,myThid)
+           ENDIF
+        ENDIF
       ENDDO
 
       IF ( errCount.GE.1 ) THEN
@@ -255,8 +345,15 @@ C---+----1----+----2----+----3----+----4----+----5----+----6----+----7-|--+----|
         CALL PRINT_ERROR( msgBuf, myThid )
         CALL ALL_PROC_DIE( 0 )
         STOP 'ABNORMAL END: S/R PTRACERS_CHECK'
+      ELSE
+        WRITE(msgBuf,'(2A)') 'PTRACERS_CHECK ',
+     &                     ' <-- Ends Normally'
+        CALL PRINT_MESSAGE( msgBuf, standardMessageUnit,
+     &                    SQUEEZE_RIGHT, myThid )
+        WRITE(msgBuf,'(2A)') ' '
+        CALL PRINT_MESSAGE( msgBuf, standardMessageUnit,
+     &                    SQUEEZE_RIGHT, myThid )
       ENDIF
-
       _END_MASTER(myThid)
 C     Everyone else must wait for the parameters to be loaded
       _BARRIER

--- a/pkg/ptracers/ptracers_integrate.F
+++ b/pkg/ptracers/ptracers_integrate.F
@@ -508,6 +508,10 @@ C--   Update tracer fields:  pTr(n) = pTr**
      I               gTracer, myTime, myIter, myThid )
         ENDIF
 
+C-- Reset preformed tracers according to their different requirements
+        CALL PTRACERS_PREFORMED_RESET( bi, bj, 
+     &          myTime, myIter, myThid )
+
 #ifdef ALLOW_OBCS
 C--   Apply open boundary conditions for each passive tracer
         IF ( useOBCS ) THEN

--- a/pkg/ptracers/ptracers_preformed_reset.F
+++ b/pkg/ptracers/ptracers_preformed_reset.F
@@ -1,0 +1,169 @@
+#include "PTRACERS_OPTIONS.h"
+#ifdef ALLOW_AUTODIFF
+# include "AUTODIFF_OPTIONS.h"
+#endif
+
+CBOP
+C !ROUTINE: PTRACERS_PREFORMED_RESET
+C !INTERFACE: ==========================================================
+      SUBROUTINE PTRACERS_PREFORMED_RESET( bi, bj, 
+     &          myTime, myIter, myThid )
+
+C !DESCRIPTION:
+C     calls subroutine that will update passive preformed tracer values
+C     with a separate timestep. 
+
+C !USES: ===============================================================
+#include "PTRACERS_MOD.h"
+      IMPLICIT NONE
+#include "SIZE.h"
+#include "EEPARAMS.h"
+#include "PARAMS.h"
+#include "GRID.h"
+#include "DYNVARS.h"
+#ifdef ALLOW_LONGSTEP
+#include "LONGSTEP_PARAMS.h"
+#endif
+#include "PTRACERS_SIZE.h"
+#include "PTRACERS_PARAMS.h"
+#include "PTRACERS_START.h"
+#include "PTRACERS_FIELDS.h"
+#include "GAD.h"
+#ifdef ALLOW_AUTODIFF_TAMC
+# include "tamc.h"
+#endif
+
+C !INPUT PARAMETERS: ===================================================
+C  bi, bj           :: tile indices
+C  recip_hFac       :: reciprocal of cell open-depth factor (@ next iter)
+C  myTime           :: model time
+C  myIter           :: time-step number
+C  myThid           :: thread number
+CEOP
+
+      INTEGER bi, bj, iTracer
+      _RS recip_hFac(1-OLx:sNx+OLx,1-OLy:sNy+OLy,Nr)
+      _RL myTime
+      INTEGER myIter
+      INTEGER myThid
+
+C !OUTPUT PARAMETERS: ==================================================
+C  none
+
+#ifdef ALLOW_PTRACERS
+#ifdef ALLOW_DIAGNOSTICS
+C     !FUNCTIONS:
+      LOGICAL  DIAGNOSTICS_IS_ON
+      EXTERNAL DIAGNOSTICS_IS_ON
+      CHARACTER*4 GAD_DIAG_SUFX
+      EXTERNAL    GAD_DIAG_SUFX
+#endif /* ALLOW_DIAGNOSTICS */
+
+      CHARACTER*(MAX_LEN_MBUF) msgBuf
+      INTEGER iMin,iMax,jMin,jMax,i,j,k
+      INTEGER kmld(1-OLx:sNx+OLx,1-OLy:sNy+OLy)
+      INTEGER ktop(1-OLx:sNx+OLx,1-OLy:sNy+OLy)
+      INTEGER kind(1-OLx:sNx+OLx,1-OLy:sNy+OLy)
+
+#ifdef ALLOW_DEBUG
+      IF (debugMode) CALL DEBUG_ENTER('PTRACERS_PREFORMED_RESET',myThid)
+#endif
+
+      iMin=1-Olx
+      iMax=sNx+Olx
+      jMin=1-Oly
+      jMax=sNy+Oly
+
+C Get arrays of mixed layer depth for preformed tracers
+C     DO bj = myByLo(myThid), myByHi(myThid)
+C        DO bi = myBxLo(myThid), myBxHi(myThid)
+            DO j=jMin,jMax
+               DO i=iMin,iMax
+C Single surface          
+                  IF ( usingPCoords ) THEN
+                     ktop(i,j) = Nr
+                  ELSE
+                     ktop(i,j) = 1
+                  ENDIF
+C Entire mixed layer       
+                  kmld(i,j) = 0
+                  
+                  DO k=1,Nr
+                     IF ( maskC(i,j,k,bi,bj).NE.0. _d 0 
+     &                  .AND. abs(RF(1+kmld(i,j))) 
+     &                  .LT.hMixLayer(i,j,bi,bj) 
+     &                  ) 
+     &                  kmld(i,j)=kmld(i,j)+1
+                  ENDDO
+               ENDDO
+            ENDDO
+C        ENDDO
+C     ENDDO
+
+
+C--   Loop over tracers
+      DO iTracer=1,PTRACERS_numInUse
+         IF (PTRACERS_isPreformed(iTracer)) THEN
+#ifdef ALLOW_DEBUG
+            IF (debugMode) THEN
+               WRITE(msgBuf,'(A)')
+     &           'EVALUATING PASSIVE TRACER',PTRACERS_names(iTracer)
+               CALL DEBUG_MSG(msgBuf, myThid)
+            ENDIF
+#endif 
+
+            DO j=jMin,jMax
+               DO i=iMin,iMax
+                  IF (PTRACERS_preformedUseMLD(iTracer)) THEN
+                     kind(i,j) = kmld(i,j)
+                  ELSE
+                     kind(i,j) = ktop(i,j)
+                  ENDIF
+               ENDDO
+            ENDDO
+
+C Preformed tracer tracer set, or relaxed to a constant concentration at the surface
+            DO j=jMin,jMax
+               DO i=iMin,iMax
+                  DO k=1,kind(i,j)
+                     IF ( maskC(i,j,k,bi,bj).NE.0. _d 0 ) THEN
+                        IF (PTRACERS_preformedMate(iTracer)
+     &                                          .EQ.UNSET_I) THEN
+C Reset preformed tracer compared to a fixed value
+                           pTracer(i,j,k,bi,bj,iTracer) = 
+     &                          pTracer(i,j,k,bi,bj,iTracer)
+     &                        + (
+     &                           (PTRACERS_preformedFixedValue(iTracer)
+     &                         - pTracer(i,j,k,bi,bj,iTracer))     
+     &                         *_hFacC(i,j,k,bi,bj)
+     &                         * (PTRACERS_dTLev(k)
+     &                             /PTRACERS_tauRelaxPreformed(iTracer))
+     &                           )
+                        ELSEIF (PTRACERS_preformedMate(iTracer)
+     &                                         .EQ.UNSET_RL) THEN
+C Reset preformed tracer compared to another tracer carried by the model                    
+                           pTracer(i,j,k,bi,bj,iTracer) = 
+     &                          pTracer(i,j,k,bi,bj,iTracer)
+     &                        + (
+     &                           (pTracer(i,j,k,bi,bj,
+     &                                  PTRACERS_preformedMate(iTracer))
+     &                         - pTracer(i,j,k,bi,bj,iTracer))     
+     &                         *_hFacC(i,j,k,bi,bj)
+     &                         * (PTRACERS_dTLev(k)
+     &                             /PTRACERS_tauRelaxPreformed(iTracer))
+     &                           )
+                        ENDIF
+                     ELSE
+                        pTracer(i,j,k,bi,bj,iTracer)=0. _d 0
+                     ENDIF
+                  ENDDO
+               ENDDO
+            ENDDO
+         ENDIF
+      ENDDO
+#ifdef ALLOW_DEBUG
+      IF (debugMode) CALL DEBUG_LEAVE('PTRACERS_PREFORMED_RESET',myThid)
+#endif
+#endif /* ALLOW_PTRACERS */
+      RETURN
+      END

--- a/pkg/ptracers/ptracers_readparms.F
+++ b/pkg/ptracers/ptracers_readparms.F
@@ -78,7 +78,13 @@ C     tauTr1ClimRelax :: old parameter (will be removed 1 day)
      &     PTRACERS_snapshot_mnc,
      &     PTRACERS_monitor_mnc,
      &     PTRACERS_pickup_write_mnc,
-     &     PTRACERS_pickup_read_mnc
+     &     PTRACERS_pickup_read_mnc,
+     &     PTRACERS_isPreformed,
+     &     PTRACERS_preformedUseMLD,
+     &     PTRACERS_tauRelaxPreformed,
+     &     PTRACERS_preformedAgeTracer,
+     &     PTRACERS_preformedMate,
+     &     PTRACERS_preformedFixedValue
 
 C---+----1----+----2----+----3----+----4----+----5----+----6----+----7-|--+----|
 
@@ -134,6 +140,13 @@ C     Set defaults values for parameters in PTRACERS.h
           PTRACERS_long_names(iTracer)(ic:ic) = ' '
           PTRACERS_units(iTracer)(ic:ic) = ' '
         ENDDO
+        PTRACERS_isPreformed(iTracer)         = .FALSE.
+        PTRACERS_preformedUseMLD(iTracer)     = .FALSE.
+        PTRACERS_tauRelaxPreformed(iTracer)   = 1. _d 0
+        PTRACERS_preformedMate(iTracer)       = UNSET_I
+        PTRACERS_preformedFixedValue(iTracer) = UNSET_RL
+        PTRACERS_preformedAgeTracer(iTracer)  = .FALSE.
+
       ENDDO
       PTRACERS_doAB_onGpTr      = doAB_onGtGs
       PTRACERS_addSrelax2EmP    = .FALSE.


### PR DESCRIPTION
## What changes does this PR introduce?
Add the ability to reset (restore or relax) tracers towards other tracers or fixed values, at the surface or over the mixed layer.

## What is the new behavior 
define new options in `pkg/ptracers` and `data.ptracers`:
`PTRACERS_isPreformed`: logical, is this a preformed tracer?
`PTRACERS_preformedUseMLD`: logical, restore/relax tracer in the surface box (false), or over the spatially-varying mixed layer depth (true); 
`PTRACERS_preformedMate`: int, which other ptracer should the preformed tracer be restored/relaxed towards (e.g. preformed phosphate, oxygen, carbon, etc) 
`PTRACERS_preformedFixedValue`: real, may alternatively restore/relax towards a fixed value.
`PTRACERS_tauRelaxPreformed`: real, relaxation timescale for tracers resetting in the upper ocean (1.0 = restoring)
`PTRACERS_preformedAgeTracer`: logical, a preformed tracer could also be an Age tracer - reset at the surface with internal source of "time".

## Does this PR introduce a breaking change? 
Nope

## Suggested addition to `tag-index`
pkg/ptracers: preformed tracers