### PR TITLE
Adding reference for Tapenade work. (On a separate branch, unlike #785)

### DIFF
--- a/doc/autodiff/autodiff.rst
+++ b/doc/autodiff/autodiff.rst
@@ -368,7 +368,7 @@ or
 Furthermore, the adjoint :math:`\delta v^{(\lambda) \, \ast}` of any
 intermediate state :math:`v^{(\lambda)}` may be obtained, using the
 intermediate Jacobian (an :math:`n_{\lambda+1} \times n_{\lambda}`
-matrix)
+matri for more details and a comparative analysis with TAF.)
 
 .. math::
    M_{\lambda} \, = \,
@@ -1750,8 +1750,11 @@ either absolute or relative to the build directory.
 Adjoint code generation using Tapenade
 ======================================
 
+Please refer to Gaikwad et. al 2024 :cite:`ssg:24` for more details and a comparative analysis with TAF. Feel free to reach out if you wish to use Tapenade and need help!
+
 Authors: Shreyas Gaikwad, Sri Hari Krishna Naryanan, Laurent Hascoet, Patrick
 Heimbach
+Contact: Shreyas Gaikwad (shreyas.gaikwad@utexas.edu)
 
 Introduction
 ------------

--- a/doc/manual_references.bib
+++ b/doc/manual_references.bib
@@ -2066,6 +2066,15 @@ and the influence of recent improvements in the parameterization of convection i
  pages        = {141-169}
 }
 
+@misc{ssg:24,
+ title={MITgcm-AD v2: Open source tangent linear and adjoint modeling framework for the oceans and atmosphere enabled by the Automatic Differentiation tool Tapenade}, 
+ author={Shreyas Sunil Gaikwad and Sri Hari Krishna Narayanan and Laurent Hascoet and Jean-Michel Campin and Helen Pillar and An Nguyen and Jan Hückelheim and Paul Hovland and Patrick Heimbach},
+ year={2024},
+ eprint={2401.11952},
+ archivePrefix={arXiv},
+ primaryClass={physics.ao-ph}
+}
+
 @techreport{taksz:96,
  author       = {Takacs, L. L. and M. J. Suarez},
  year         = {1996},


### PR DESCRIPTION
## What changes does this PR introduce?
A new AD capability for tutorial_barotropic_gyre and tutorial_baroclinic_gyre with Tapenade.


## What is the current behavior? 
No AD capability for tutorial_barotropic_gyre and tutorial_baroclinic_gyre.


## Does this PR introduce a breaking change? 
No, since the setup is independent of the rest of the code.


## Other information:
I might need @jm-c to assist with cleaning up to make it look like the structure of the other tutorials.