### PR TITLE
Import updates from SIZE.h into SIZE.h_mpi

### DIFF
--- a/verification/isomip/code_ad/SIZE.h_mpi
+++ b/verification/isomip/code_ad/SIZE.h_mpi
@@ -44,8 +44,8 @@ CEOP
       PARAMETER (
      &           sNx =  25,
      &           sNy =  25,
-     &           OLx =   3,
-     &           OLy =   3,
+     &           OLx =   4,
+     &           OLy =   4,
      &           nSx =   1,
      &           nSy =   2,
      &           nPx =   2,


### PR DESCRIPTION
This PR fix changes made in PR #814, where Overlap-size was increased from 3 to 4 in `code_ad/SIZE.h` but
`code_ad/SIZE.h_mpi` was missing this update.

## What changes does this PR introduce?
Fix AD-test experiment `isomip.htd` for MPI test

## What is the current behaviour? 
To use advScheme=7 (that  got changed in PR #814 in `isomip/input_ad,htd/data`)  need overlap-size of at least 4.
This got changes in SIZE.h but not in SIZE.h_mpi

## What is the new behaviour 
fix MPI test

## Does this PR introduce a breaking change? 

## Other information:

## Suggested addition to `tag-index`
not needed if merged just after PR #814 