### PR TITLE
Fix reading of diagstats output with more than one region in MITgcmutils 

### DIFF
--- a/utils/python/MITgcmutils/MITgcmutils/cs/pcol.py
+++ b/utils/python/MITgcmutils/MITgcmutils/cs/pcol.py
@@ -180,7 +180,7 @@ def pcol( x, y, data, projection=None, vmin=None, vmax=None, **kwargs):
         # add a reasonable colormap
         m = cm.ScalarMappable(cmap=colmap)
         m.set_array(data)
-        plt.colorbar(m)
+        plt.colorbar(m, ax=ax)
     elif mapit == 0:
         ax = fig.axes[-1]
         ax.axis('image')

--- a/utils/python/MITgcmutils/MITgcmutils/diagnostics.py
+++ b/utils/python/MITgcmutils/MITgcmutils/diagnostics.py
@@ -5,7 +5,7 @@ nstats = 5
 
 def readstats(fname):
     '''
-    locals,totals,itrs = readstats(fname)
+    statsPerLayer,statsVertInt,itrs = readstats(fname)
 
     Read a diagstats text file into record arrays (or dictionaries).
 
@@ -16,17 +16,19 @@ def readstats(fname):
 
     Returns
     -------
-    locals : record array or dict of arrays
-        local statistics, shape (len(itrs), Nr, 5)
-    totals : record array or dict of arrays
-        column integrals, shape (len(itrs), 5)
+    statsPerLayer : record array or dict of arrays
+        statistics per layer, shape (len(itrs), len(nReg), Nr, 5)
+    statsVertInt  : record array or dict of arrays
+        column integrals, shape (len(itrs), len(nReg), 5)
     itrs : list of int
         iteration numbers found in the file
 
     Notes
     -----
-    - The 5 columns of the resulting arrays are average, std.dev, min, max and total volume.
+    - The 5 columns of the resulting arrays are
+      average, std.dev, min, max and total volume.
     - There is a record (or dictionary key) for each field found in the file.
+    - Regional axis is omitted if nReg == 1
 
     '''
     flds = []
@@ -93,7 +95,8 @@ def readstats(fname):
     for fld in itrs:
         itrs[fld] = itrs[fld][0]
 
-    # if shapes differ between fields, we return dictionaries instead of record array
+    # if shapes differ between fields, we return dictionaries instead
+    # of record array
     asdict = False
     shp = None
     for fld in res:
@@ -116,11 +119,11 @@ def readstats(fname):
                 asdict = True
 
     if asdict:
-        tots = dict((fld,res[fld][...,0,:]) for fld in flds)
-        locs = dict((fld,res[fld][...,1:,:]) for fld in flds)
+        statsVertInt  = dict((fld,res[fld][...,0,:]) for fld in flds)
+        statsPerLayer = dict((fld,res[fld][...,1:,:]) for fld in flds)
     else:
         ra = np.rec.fromarrays([res[fld] for fld in flds], names=flds)
-        tots = ra[...,0,:]
-        locs = ra[...,1:,:]
+        statsVertInt  = ra[...,0,:]
+        statsPerLayer = ra[...,1:,:]
 
-    return locs,tots,itrs
+    return statsPerLayer,statsVertInt,itrs

--- a/utils/python/MITgcmutils/MITgcmutils/diagnostics.py
+++ b/utils/python/MITgcmutils/MITgcmutils/diagnostics.py
@@ -30,20 +30,25 @@ def readstats(fname):
 
     '''
     flds = []
+    regs = [0]
     with open(fname) as f:
         for line in f:
             if line.startswith('# end of header'):
                 break
 
-            m = re.match(r'^# ([^:]*) *: *(.*)$', line.rstrip())
+            m = re.match(r'^# ([^: ]*) *: *(.*)$', line.rstrip())
             if m:
                 var,val = m.groups()
                 if var.startswith('Fields'):
-                    flds = val.split()
+                    flds.extend(val.split())
+                elif var == 'Regions':
+                    regs = val.split()
 
-        res = dict((fld,[]) for fld in flds)
-        itrs = dict((fld,[]) for fld in flds)
+        nreg = len(regs)
+        res = dict((fld,[[] for reg in regs]) for fld in flds)
+        itrs = dict((fld,[[] for reg in regs]) for fld in flds)
 
+        fieldline = None
         for line in f:
             if line.strip() == '':
                 continue
@@ -51,11 +56,19 @@ def readstats(fname):
             if line.startswith('# records'):
                 break
 
+            if fieldline is not None:
+                assert line.startswith(' k')
+                # parse field information from saved line and discard 'k' line
+                line = fieldline
+
             m = re.match(r' field : *([^ ]*) *; Iter = *([0-9]*) *; region # *([0-9]*) ; nb\.Lev = *([0-9]*)', line)
             if m:
                 fld,itr,reg,nlev = m.groups()
-                itrs[fld].append(int(itr))
+                ireg = regs.index(reg)
+                itrs[fld][ireg].append(int(itr))
                 tmp = np.zeros((int(nlev)+1,nstats))
+                fieldline = None
+                kmax = 0
                 for line in f:
                     if line.startswith(' k'):
                         continue
@@ -63,20 +76,51 @@ def readstats(fname):
                     if line.strip() == '':
                         break
 
+                    if line.startswith(' field :'):
+                        fieldline = line
+                        break
+
                     cols = line.strip().split()
                     k = int(cols[0])
                     tmp[k] = [float(s) for s in cols[1:]]
+                    kmax = max(kmax, k)
 
-                res[fld].append(tmp)
-
+                res[fld][ireg].append(tmp[:kmax+1])
             else:
                 raise ValueError('readstats: parse error: ' + line)
 
-    try:
-        all = np.rec.fromarrays([np.array(res[fld]) for fld in flds], names=flds)
-        return all[:,1:],all[:,0],itrs
-    except:
-        totals = dict((fld,np.array(res[fld])[:,0]) for fld in flds)
-        locals = dict((fld,np.array(res[fld])[:,1:]) for fld in flds)
-        return locals,totals,itrs
+    # assume all regions have the same iteration numbers
+    for fld in itrs:
+        itrs[fld] = itrs[fld][0]
 
+    # if shapes differ between fields, we return dictionaries instead of record array
+    asdict = False
+    shp = None
+    for fld in res:
+        res[fld] = np.array(res[fld])
+        if nreg == 1:
+            # remove region axis
+            res[fld].shape = res[fld].shape[1:]
+        else:
+            # iteration axis first, then region
+            res[fld] = res[fld].swapaxes(0,1)
+
+        if res[fld].size == 0:
+            # avoid indexing error later
+            res[fld].shape = res[fld].shape + (1,5)
+
+        if shp is None:
+            shp = res[fld].shape
+        else:
+            if res[fld].shape != shp:
+                asdict = True
+
+    if asdict:
+        tots = dict((fld,res[fld][...,0,:]) for fld in flds)
+        locs = dict((fld,res[fld][...,1:,:]) for fld in flds)
+    else:
+        ra = np.rec.fromarrays([res[fld] for fld in flds], names=flds)
+        tots = ra[...,0,:]
+        locs = ra[...,1:,:]
+
+    return locs,tots,itrs


### PR DESCRIPTION
## What changes does this PR introduce?

Bug fix

## What is the current behaviour? 

Issue #818 and field lists over multiple lines in diagstats output are not supported.
cs.pcol throws an error with newer matplotlib.

## What is the new behaviour 

All mentioned bugs fixed.

## Does this PR introduce a breaking change? 

The depth-dependent diagstats of a 2-D variable are now empty rather than one level of zeros.

## Other information:

Tested against python 3.7 through 3.11.