### PR TITLE
Removing potential divide by zero error in Orlanski package

### DIFF
--- a/pkg/obcs/orlanski_east.F
+++ b/pkg/obcs/orlanski_east.F
@@ -90,6 +90,7 @@ C     == Routine arguments ==
 C     == Local variables ==
       INTEGER J, K, I_obc
       _RL CL, ab1, ab2, fracCVEL, f1, f2
+      _RL denom
 
       ab1   =  1.5 _d 0 + abEps /* Adams-Bashforth coefficients */
       ab2   = -0.5 _d 0 - abEps
@@ -106,16 +107,14 @@ C     Eastern OB (Orlanski Radiation Condition)
             I_obc=OB_Ie(J,bi,bj)
             IF ( I_obc.NE.OB_indexNone ) THEN
 C              uVel
-               IF ((UE_STORE_2(J,K,bi,bj).eq.0.).and.
-     &            (UE_STORE_3(J,K,bi,bj).eq.0.)) THEN
-                  CL=0.
-               ELSE
-                  CL=-(uVel(I_obc-1,J,K,bi,bj)-UE_STORE_1(J,K,bi,bj))/
+               denom = 
      &          (ab1*UE_STORE_2(J,K,bi,bj) + ab2*UE_STORE_3(J,K,bi,bj))
-               ENDIF
-               IF (CL.lt.0.) THEN
-                  CL=0.
-               ELSEIF (CL.gt.CMAX) THEN
+               IF ( denom .NE. 0 _d 0 ) THEN
+                  CL=-(uVel(I_obc-1,J,K,bi,bj)-UE_STORE_1(J,K,bi,bj))/
+     &          denom
+                  CL=MAX(CL, 0. _d 0)
+                  CL=MIN(CL, CMAX)
+               ELSE
                   CL=CMAX
                ENDIF
                IF (useFixedCEast) THEN
@@ -132,16 +131,14 @@ C              update OBC to next timestep
      &           (ab1*(uVel(I_obc,J,K,bi,bj)-uVel(I_obc-1,J,K,bi,bj)) +
      &           ab2*(UE_STORE_4(J,K,bi,bj)-UE_STORE_1(J,K,bi,bj)))
 C              vVel
-               IF ((VE_STORE_2(J,K,bi,bj).eq.0.).and.
-     &            (VE_STORE_3(J,K,bi,bj).eq.0.)) THEN
-                  CL=0.
-               ELSE
-                  CL=-(vVel(I_obc-1,J,K,bi,bj)-VE_STORE_1(J,K,bi,bj))/
+               denom =
      &          (ab1*VE_STORE_2(J,K,bi,bj) + ab2*VE_STORE_3(J,K,bi,bj))
-               ENDIF
-               IF (CL.lt.0.) THEN
-                  CL=0.
-               ELSEIF (CL.gt.CMAX) THEN
+               IF ( denom .NE. 0 _d 0 ) THEN
+                  CL=-(vVel(I_obc-1,J,K,bi,bj)-VE_STORE_1(J,K,bi,bj))/
+     &          denom
+                  CL=MAX(CL, 0. _d 0)
+                  CL=MIN(CL, CMAX)
+               ELSE
                   CL=CMAX
                ENDIF
                IF (useFixedCEast) THEN
@@ -158,16 +155,14 @@ C              update OBC to next timestep
      &           (ab1*(vVel(I_obc,J,K,bi,bj)-vVel(I_obc-1,J,K,bi,bj)) +
      &           ab2*(VE_STORE_4(J,K,bi,bj)-VE_STORE_1(J,K,bi,bj)))
 C              Temperature
-               IF ((TE_STORE_2(J,K,bi,bj).eq.0.).and.
-     &            (TE_STORE_3(J,K,bi,bj).eq.0.)) THEN
-                  CL=0.
-               ELSE
-                  CL=-(theta(I_obc-1,J,K,bi,bj)-TE_STORE_1(J,K,bi,bj))/
+               denom =
      &          (ab1*TE_STORE_2(J,K,bi,bj) + ab2*TE_STORE_3(J,K,bi,bj))
-               ENDIF
-               IF (CL.lt.0.) THEN
-                  CL=0.
-               ELSEIF (CL.gt.CMAX) THEN
+               IF ( denom .NE. 0 _d 0 ) THEN
+                  CL=-(theta(I_obc-1,J,K,bi,bj)-TE_STORE_1(J,K,bi,bj))/
+     &          denom
+                  CL=MAX(CL, 0. _d 0)
+                  CL=MIN(CL, CMAX)
+               ELSE
                   CL=CMAX
                ENDIF
                IF (useFixedCEast) THEN
@@ -184,18 +179,17 @@ C              update OBC to next timestep
      &           (ab1*(theta(I_obc,J,K,bi,bj)-theta(I_obc-1,J,K,bi,bj))+
      &           ab2*(TE_STORE_4(J,K,bi,bj)-TE_STORE_1(J,K,bi,bj)))
 C              Salinity
-               IF ((SE_STORE_2(J,K,bi,bj).eq.0.).and.
-     &            (SE_STORE_3(J,K,bi,bj).eq.0.)) THEN
-                  CL=0.
-               ELSE
-                  CL=-(salt(I_obc-1,J,K,bi,bj)-SE_STORE_1(J,K,bi,bj))/
+               denom =
      &          (ab1*SE_STORE_2(J,K,bi,bj) + ab2*SE_STORE_3(J,K,bi,bj))
-               ENDIF
-               IF (CL.lt.0.) THEN
-                  CL=0.
-               ELSEIF (CL.gt.CMAX) THEN
+               IF ( denom .NE. 0 _d 0 ) THEN
+                  CL=-(salt(I_obc-1,J,K,bi,bj)-SE_STORE_1(J,K,bi,bj))/
+     &          denom
+                  CL=MAX(CL, 0. _d 0)
+                  CL=MIN(CL, CMAX)
+               ELSE
                   CL=CMAX
                ENDIF
+
                IF (useFixedCEast) THEN
 C                Fixed phase speed (ignoring all of that painstakingly
 C                saved data...)

--- a/pkg/obcs/orlanski_north.F
+++ b/pkg/obcs/orlanski_north.F
@@ -80,6 +80,7 @@ C     == Routine arguments ==
 C     == Local variables ==
       INTEGER  I, K, J_obc
       _RL CL, ab1, ab2, fracCVEL, f1, f2
+      _RL denom
 
       ab1   =  1.5 _d 0 + abEps /* Adams-Bashforth coefficients */
       ab2   = -0.5 _d 0 - abEps
@@ -96,18 +97,18 @@ C     Northern OB (Orlanski Radiation Condition)
             J_obc=OB_Jn(I,bi,bj)
             IF ( J_obc.NE.OB_indexNone ) THEN
 C              uVel
-               IF ((UN_STORE_2(I,K,bi,bj).eq.0.).and.
-     &            (UN_STORE_3(I,K,bi,bj).eq.0.)) THEN
-                  CL=0.
-               ELSE
-                  CL=-(uVel(I,J_obc-1,K,bi,bj)-UN_STORE_1(I,K,bi,bj))/
+
+               denom = 
      &          (ab1*UN_STORE_2(I,K,bi,bj) + ab2*UN_STORE_3(I,K,bi,bj))
-               ENDIF
-               IF (CL.lt.0.) THEN
-                  CL=0.
-               ELSEIF (CL.gt.CMAX) THEN
+               IF ( denom .NE. 0 _d 0 ) THEN
+                  CL=-(uVel(I,J_obc-1,K,bi,bj)-UN_STORE_1(I,K,bi,bj))/
+     &          denom
+                  CL=MAX(CL, 0. _d 0)
+                  CL=MIN(CL, CMAX)
+               ELSE 
                   CL=CMAX
                ENDIF
+
                CVEL_UN(I,K,bi,bj) = f1*(CL*dyU(I,J_obc-1,bi,bj)/deltaT)+
      &                f2*CVEL_UN(I,K,bi,bj)
 C              update OBC to next timestep
@@ -116,18 +117,18 @@ C              update OBC to next timestep
      &           (ab1*(uVel(I,J_obc,K,bi,bj)-uVel(I,J_obc-1,K,bi,bj)) +
      &           ab2*(UN_STORE_4(I,K,bi,bj)-UN_STORE_1(I,K,bi,bj)))
 C              vVel
-               IF ((VN_STORE_2(I,K,bi,bj).eq.0.).and.
-     &            (VN_STORE_3(I,K,bi,bj).eq.0.)) THEN
-                  CL=0.
-               ELSE
-                  CL=-(vVel(I,J_obc-1,K,bi,bj)-VN_STORE_1(I,K,bi,bj))/
+
+               denom = 
      &          (ab1*VN_STORE_2(I,K,bi,bj) + ab2*VN_STORE_3(I,K,bi,bj))
-               ENDIF
-               IF (CL.lt.0.) THEN
-                  CL=0.
-               ELSEIF (CL.gt.CMAX) THEN
+               IF ( denom .NE. 0 _d 0 ) THEN
+                  CL=-(vVel(I,J_obc-1,K,bi,bj)-VN_STORE_1(I,K,bi,bj))/
+     &          denom
+                  CL=MAX(CL, 0. _d 0)
+                  CL=MIN(CL, CMAX)
+               ELSE
                   CL=CMAX
                ENDIF
+
                CVEL_VN(I,K,bi,bj) = f1*(CL*dyF(I,J_obc-2,bi,bj)/deltaT)+
      &                f2*CVEL_VN(I,K,bi,bj)
 C              update OBC to next timestep
@@ -136,16 +137,14 @@ C              update OBC to next timestep
      &           (ab1*(vVel(I,J_obc,K,bi,bj)-vVel(I,J_obc-1,K,bi,bj)) +
      &           ab2*(VN_STORE_4(I,K,bi,bj)-VN_STORE_1(I,K,bi,bj)))
 C              Temperature
-               IF ((TN_STORE_2(I,K,bi,bj).eq.0.).and.
-     &            (TN_STORE_3(I,K,bi,bj).eq.0.)) THEN
-                  CL=0.
-               ELSE
-                  CL=-(theta(I,J_obc-1,K,bi,bj)-TN_STORE_1(I,K,bi,bj))/
+               denom = 
      &          (ab1*TN_STORE_2(I,K,bi,bj) + ab2*TN_STORE_3(I,K,bi,bj))
-               ENDIF
-               IF (CL.lt.0.) THEN
-                  CL=0.
-               ELSEIF (CL.gt.CMAX) THEN
+               IF ( denom .NE. 0 _d 0 ) THEN
+                  CL=-(theta(I,J_obc-1,K,bi,bj)-TN_STORE_1(I,K,bi,bj))/
+     &          denom
+                  CL=MAX(CL, 0. _d 0)
+                  CL=MIN(CL, CMAX)
+               ELSE
                   CL=CMAX
                ENDIF
                CVEL_TN(I,K,bi,bj) = f1*(CL*dyC(I,J_obc-1,bi,bj)/deltaT)+
@@ -156,16 +155,14 @@ C              update OBC to next timestep
      &          (ab1*(theta(I,J_obc,K,bi,bj)-theta(I,J_obc-1,K,bi,bj))+
      &          ab2*(TN_STORE_4(I,K,bi,bj)-TN_STORE_1(I,K,bi,bj)))
 C              Salinity
-               IF ((SN_STORE_2(I,K,bi,bj).eq.0.).and.
-     &            (SN_STORE_3(I,K,bi,bj).eq.0.)) THEN
-                  CL=0.
-               ELSE
-                  CL=-(salt(I,J_obc-1,K,bi,bj)-SN_STORE_1(I,K,bi,bj))/
+               denom = 
      &          (ab1*SN_STORE_2(I,K,bi,bj) + ab2*SN_STORE_3(I,K,bi,bj))
-               ENDIF
-               IF (CL.lt.0.) THEN
-                  CL=0.
-               ELSEIF (CL.gt.CMAX) THEN
+               IF ( denom .NE. 0 _d 0 ) THEN
+                  CL=-(salt(I,J_obc-1,K,bi,bj)-SN_STORE_1(I,K,bi,bj))/
+     &          denom
+                  CL=MAX(CL, 0. _d 0)
+                  CL=MIN(CL, CMAX)
+               ELSE
                   CL=CMAX
                ENDIF
                CVEL_SN(I,K,bi,bj) = f1*(CL*dyC(I,J_obc-1,bi,bj)/deltaT)+

--- a/pkg/obcs/orlanski_south.F
+++ b/pkg/obcs/orlanski_south.F
@@ -80,6 +80,7 @@ C     == Routine arguments ==
 C     == Local variables ==
       INTEGER  I, K, J_obc
       _RL CL, ab1, ab2, fracCVEL, f1, f2
+      _RL denom
 
       ab1   =  1.5 _d 0 + abEps /* Adams-Bashforth coefficients */
       ab2   = -0.5 _d 0 - abEps
@@ -96,16 +97,14 @@ C     Southern OB (Orlanski Radiation Condition)
             J_obc=OB_Js(I,bi,bj)
             IF ( J_obc.NE.OB_indexNone ) THEN
 C              uVel
-               IF ((US_STORE_2(I,K,bi,bj).eq.0.).and.
-     &            (US_STORE_3(I,K,bi,bj).eq.0.)) THEN
-                  CL=0.
-               ELSE
-                  CL=(uVel(I,J_obc+1,K,bi,bj)-US_STORE_1(I,K,bi,bj))/
+                denom = 
      &          (ab1*US_STORE_2(I,K,bi,bj) + ab2*US_STORE_3(I,K,bi,bj))
-               ENDIF
-               IF (CL.lt.0.) THEN
-                  CL=0.
-               ELSEIF (CL.gt.CMAX) THEN
+               IF ( denom .NE. 0 _d 0 ) THEN
+                  CL=(uVel(I,J_obc+1,K,bi,bj)-US_STORE_1(I,K,bi,bj))/
+     &          denom
+                  CL=MAX(CL, 0. _d 0)
+                  CL=MIN(CL, CMAX)
+               ELSE
                   CL=CMAX
                ENDIF
                CVEL_US(I,K,bi,bj) = f1*(CL*dyU(I,J_obc+2,bi,bj)/deltaT)+
@@ -116,16 +115,14 @@ C              update OBC to next timestep
      &          (ab1*(uVel(I,J_obc+1,K,bi,bj)-uVel(I,J_obc,K,bi,bj)) +
      &         ab2*(US_STORE_1(I,K,bi,bj)-US_STORE_4(I,K,bi,bj)))
 C              vVel (to be applied at J_obc+1)
-               IF ((VS_STORE_2(I,K,bi,bj).eq.0.).and.
-     &            (VS_STORE_3(I,K,bi,bj).eq.0.)) THEN
-                  CL=0.
-               ELSE
-                  CL=(vVel(I,J_obc+2,K,bi,bj)-VS_STORE_1(I,K,bi,bj))/
+                denom = 
      &          (ab1*VS_STORE_2(I,K,bi,bj) + ab2*VS_STORE_3(I,K,bi,bj))
-               ENDIF
-               IF (CL.lt.0.) THEN
-                  CL=0.
-               ELSEIF (CL.gt.CMAX) THEN
+               IF ( denom .NE. 0 _d 0 ) THEN
+                  CL=(vVel(I,J_obc+2,K,bi,bj)-VS_STORE_1(I,K,bi,bj))/
+     &          denom
+                  CL=MAX(CL, 0. _d 0)
+                  CL=MIN(CL, CMAX)
+               ELSE
                   CL=CMAX
                ENDIF
                CVEL_VS(I,K,bi,bj) = f1*(CL*dyF(I,J_obc+2,bi,bj)/deltaT)+
@@ -136,16 +133,14 @@ C              update OBC to next timestep
      &          (ab1*(vVel(I,J_obc+2,K,bi,bj)-vVel(I,J_obc+1,K,bi,bj))+
      &          ab2*(VS_STORE_1(I,K,bi,bj)-VS_STORE_4(I,K,bi,bj)))
 C              Temperature
-               IF ((TS_STORE_2(I,K,bi,bj).eq.0.).and.
-     &            (TS_STORE_3(I,K,bi,bj).eq.0.)) THEN
-                  CL=0.
-               ELSE
-                  CL=(theta(I,J_obc+1,K,bi,bj)-TS_STORE_1(I,K,bi,bj))/
+                denom = 
      &          (ab1*TS_STORE_2(I,K,bi,bj) + ab2*TS_STORE_3(I,K,bi,bj))
-               ENDIF
-               IF (CL.lt.0.) THEN
-                  CL=0.
-               ELSEIF (CL.gt.CMAX) THEN
+               IF ( denom .NE. 0 _d 0 ) THEN
+                  CL=(theta(I,J_obc+1,K,bi,bj)-TS_STORE_1(I,K,bi,bj))/
+     &          denom
+                  CL=MAX(CL, 0. _d 0)
+                  CL=MIN(CL, CMAX)
+               ELSE
                   CL=CMAX
                ENDIF
                CVEL_TS(I,K,bi,bj) = f1*(CL*dyC(I,J_obc+2,bi,bj)/deltaT)+
@@ -156,16 +151,14 @@ C              update OBC to next timestep
      &          (ab1*(theta(I,J_obc+1,K,bi,bj)-theta(I,J_obc,K,bi,bj))+
      &          ab2*(TS_STORE_1(I,K,bi,bj)-TS_STORE_4(I,K,bi,bj)))
 C              Salinity
-               IF ((SS_STORE_2(I,K,bi,bj).eq.0.).and.
-     &            (SS_STORE_3(I,K,bi,bj).eq.0.)) THEN
-                  CL=0.
-               ELSE
-                  CL=(salt(I,J_obc+1,K,bi,bj)-SS_STORE_1(I,K,bi,bj))/
+                denom = 
      &          (ab1*SS_STORE_2(I,K,bi,bj) + ab2*SS_STORE_3(I,K,bi,bj))
-               ENDIF
-               IF (CL.lt.0.) THEN
-                  CL=0.
-               ELSEIF (CL.gt.CMAX) THEN
+               IF ( denom .NE. 0 _d 0 ) THEN
+                  CL=(salt(I,J_obc+1,K,bi,bj)-SS_STORE_1(I,K,bi,bj))/
+     &          denom
+                  CL=MAX(CL, 0. _d 0)
+                  CL=MIN(CL, CMAX)
+               ELSE
                   CL=CMAX
                ENDIF
                CVEL_SS(I,K,bi,bj) = f1*(CL*dyC(I,J_obc+2,bi,bj)/deltaT)+

--- a/pkg/obcs/orlanski_west.F
+++ b/pkg/obcs/orlanski_west.F
@@ -92,6 +92,7 @@ C     == Routine arguments ==
 C     == Local variables ==
       INTEGER J, K, I_obc
       _RL CL, ab1, ab2, fracCVEL, f1, f2
+      _RL denom
 
       ab1   =  1.5 _d 0 + abEps /* Adams-Bashforth coefficients */
       ab2   = -0.5 _d 0 - abEps
@@ -108,16 +109,14 @@ C      Western OB (Orlanski Radiation Condition)
             I_obc=OB_Iw(J,bi,bj)
             IF ( I_obc.NE.OB_indexNone ) THEN
 C              uVel (to be applied at I_obc+1)
-               IF ((UW_STORE_2(J,K,bi,bj).eq.0.).and.
-     &            (UW_STORE_3(J,K,bi,bj).eq.0.)) THEN
-                  CL=0.
-               ELSE
-                  CL=(uVel(I_obc+2,J,K,bi,bj)-UW_STORE_1(J,K,bi,bj))/
+                denom = 
      &          (ab1*UW_STORE_2(J,K,bi,bj) + ab2*UW_STORE_3(J,K,bi,bj))
-               ENDIF
-               IF (CL.lt.0.) THEN
-                  CL=0.
-               ELSEIF (CL.gt.CMAX) THEN
+               IF ( denom .NE. 0 _d 0 ) THEN
+                  CL=(uVel(I_obc+2,J,K,bi,bj)-UW_STORE_1(J,K,bi,bj))/
+     &          denom
+                  CL=MAX(CL, 0. _d 0)
+                  CL=MIN(CL, CMAX)
+               ELSE
                   CL=CMAX
                ENDIF
                IF (useFixedCWest) THEN
@@ -134,16 +133,14 @@ C              update OBC to next timestep
      &          (ab1*(uVel(I_obc+2,J,K,bi,bj)-uVel(I_obc+1,J,K,bi,bj))+
      &          ab2*(UW_STORE_1(J,K,bi,bj)-UW_STORE_4(J,K,bi,bj)))
 C              vVel
-               IF ((VW_STORE_2(J,K,bi,bj).eq.0.).and.
-     &            (VW_STORE_3(J,K,bi,bj).eq.0.)) THEN
-                  CL=0.
-               ELSE
-                  CL=(vVel(I_obc+1,J,K,bi,bj)-VW_STORE_1(J,K,bi,bj))/
+                denom = 
      &          (ab1*VW_STORE_2(J,K,bi,bj) + ab2*VW_STORE_3(J,K,bi,bj))
-               ENDIF
-               IF (CL.lt.0.) THEN
-                  CL=0.
-               ELSEIF (CL.gt.CMAX) THEN
+               IF ( denom .NE. 0 _d 0 ) THEN
+                  CL=(vVel(I_obc+1,J,K,bi,bj)-VW_STORE_1(J,K,bi,bj))/
+     &          denom
+                  CL=MAX(CL, 0. _d 0)
+                  CL=MIN(CL, CMAX)
+               ELSE
                   CL=CMAX
                ENDIF
                IF (useFixedCWest) THEN
@@ -160,16 +157,14 @@ C              update OBC to next timestep
      &           (ab1*(vVel(I_obc+1,J,K,bi,bj)-vVel(I_obc,J,K,bi,bj))+
      &           ab2*(VW_STORE_1(J,K,bi,bj)-VW_STORE_4(J,K,bi,bj)))
 C              Temperature
-               IF ((TW_STORE_2(J,K,bi,bj).eq.0.).and.
-     &            (TW_STORE_3(J,K,bi,bj).eq.0.)) THEN
-                  CL=0.
-               ELSE
-                  CL=(theta(I_obc+1,J,K,bi,bj)-TW_STORE_1(J,K,bi,bj))/
+                denom = 
      &          (ab1*TW_STORE_2(J,K,bi,bj) + ab2*TW_STORE_3(J,K,bi,bj))
-               ENDIF
-               IF (CL.lt.0.) THEN
-                  CL=0.
-               ELSEIF (CL.gt.CMAX) THEN
+               IF ( denom .NE. 0 _d 0 ) THEN
+                  CL=(theta(I_obc+1,J,K,bi,bj)-TW_STORE_1(J,K,bi,bj))/
+     &          denom
+                  CL=MAX(CL, 0. _d 0)
+                  CL=MIN(CL, CMAX)
+               ELSE
                   CL=CMAX
                ENDIF
                IF (useFixedCWest) THEN
@@ -186,16 +181,14 @@ C              update OBC to next timestep
      &          (ab1*(theta(I_obc+1,J,K,bi,bj)-theta(I_obc,J,K,bi,bj))+
      &          ab2*(TW_STORE_1(J,K,bi,bj)-TW_STORE_4(J,K,bi,bj)))
 C              Salinity
-               IF ((SW_STORE_2(J,K,bi,bj).eq.0.).and.
-     &            (SW_STORE_3(J,K,bi,bj).eq.0.)) THEN
-                  CL=0.
-               ELSE
-                  CL=(salt(I_obc+1,J,K,bi,bj)-SW_STORE_1(J,K,bi,bj))/
+                denom = 
      &          (ab1*SW_STORE_2(J,K,bi,bj) + ab2*SW_STORE_3(J,K,bi,bj))
-               ENDIF
-               IF (CL.lt.0.) THEN
-                  CL=0.
-               ELSEIF (CL.gt.CMAX) THEN
+               IF ( denom .NE. 0 _d 0 ) THEN
+                  CL=(salt(I_obc+1,J,K,bi,bj)-SW_STORE_1(J,K,bi,bj))/
+     &          denom
+                  CL=MAX(CL, 0. _d 0)
+                  CL=MIN(CL, CMAX)
+               ELSE
                   CL=CMAX
                ENDIF
                IF (useFixedCWest) THEN


### PR DESCRIPTION
This PR is a bug fix for issue #822 . It removes the possibility of a divide by zero error in the obcs/orlanski_[north,east,south,west].F files.

There is an ongoing discussion about whether when the denominator is zero, CL should be set to 0 or CMAX.

This pull request has not yet been tested in a set up with the orlanski condition enabled in each direction.