### PR TITLE
More precise specific-vol. anomaly for ocean in P

### DIFF
--- a/doc/tag-index
+++ b/doc/tag-index
@@ -1,6 +1,9 @@
     Notes on tags used in MITgcmUV
     ==============================
 
+o model/src:
+  - more precise specific-volume anomaly expression for Ocean in P-coord;
+    update reference output of all 3 Ocean in P test experiments.
 o pkg/generic_advdiff:
   - adjust 2 SOM (Prather advection) store directives to reduce memory overhead
   - include OS7MP (advScheme 7) in AD code ; switch AD test experiment

--- a/model/src/calc_phi_hyd.F
+++ b/model/src/calc_phi_hyd.F
@@ -80,7 +80,7 @@ C     pKappaC    :: (p/Po)^kappa at cell center k
       _RL pKappaU (1-OLx:sNx+OLx,1-OLy:sNy+OLy)
       _RL pKappaC, locDepth, fullDepth
 #endif /* DISABLE_SIGMA_CODE */
-      _RL thetaRef, locAlpha
+      _RL thetaRef, locBuoy
       _RL dRlocM,dRlocP, ddRloc
       _RL ddPIm, ddPIp, rec_dRm, rec_dRp
       _RL surfPhiFac
@@ -322,12 +322,14 @@ CADJ STORE salt (:,:,k,bi,bj) = comlev1_bibj_k, key=kkey, kind = isbyte
 #ifdef ALLOW_AUTODIFF_TAMC
 CADJ STORE alphaRho = comlev1_bibj_k, key = kkey, kind = isbyte
 #endif
-C--     Calculate specific volume anomaly : alpha_prime = 1/rho - alpha_Cst
+C--     Calculate specific volume anomaly "alpha_prime":
+C       = 1/(rho_prime + rho_Cst) - 1/rho_Cst
+C       = - (rho_prime/rho_Cst) / ( 1 + rho_prime/rho_Cst ) / rho_Cst
         DO j=jMin,jMax
           DO i=iMin,iMax
-            locAlpha=alphaRho(i,j)+rhoConst
-            alphaRho(i,j)=maskC(i,j,k,bi,bj)*
-     &              (oneRL/locAlpha - recip_rhoConst)
+            locBuoy = -alphaRho(i,j)*recip_rhoConst
+            alphaRho(i,j) = maskC(i,j,k,bi,bj)*recip_rhoConst
+     &                    * locBuoy/( oneRL - locBuoy )
           ENDDO
         ENDDO
 

--- a/model/src/calc_phi_hyd.F
+++ b/model/src/calc_phi_hyd.F
@@ -327,9 +327,9 @@ C       = 1/(rho_prime + rho_Cst) - 1/rho_Cst
 C       = - (rho_prime/rho_Cst) / ( 1 + rho_prime/rho_Cst ) / rho_Cst
         DO j=jMin,jMax
           DO i=iMin,iMax
-            locBuoy = -alphaRho(i,j)*recip_rhoConst
-            alphaRho(i,j) = maskC(i,j,k,bi,bj)*recip_rhoConst
-     &                    * locBuoy/( oneRL - locBuoy )
+            locBuoy = alphaRho(i,j)*recip_rhoConst
+            alphaRho(i,j) = -maskC(i,j,k,bi,bj)*recip_rhoConst
+     &                    * locBuoy/( oneRL + locBuoy )
           ENDDO
         ENDDO
 

--- a/verification/front_relax/results/output.in_p.txt
+++ b/verification/front_relax/results/output.in_p.txt
@@ -5,10 +5,10 @@
 (PID.TID 0000.0001) // ======================================================
 (PID.TID 0000.0001) // execution environment starting up...
 (PID.TID 0000.0001) 
-(PID.TID 0000.0001) // MITgcmUV version:  checkpoint68j
+(PID.TID 0000.0001) // MITgcmUV version:  checkpoint68w
 (PID.TID 0000.0001) // Build user:        jm_c
 (PID.TID 0000.0001) // Build host:        villon
-(PID.TID 0000.0001) // Build date:        Thu Oct  6 17:23:06 EDT 2022
+(PID.TID 0000.0001) // Build date:        Tue Apr 16 13:08:47 EDT 2024
 (PID.TID 0000.0001) 
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // Execution Environment parameter file "eedata"
@@ -485,7 +485,7 @@
 (PID.TID 0000.0001) // ===================================
 (PID.TID 0000.0001) ------------------------------------------------------------
 (PID.TID 0000.0001) DIAGNOSTICS_SET_LEVELS: done
-(PID.TID 0000.0001)  Total Nb of available Diagnostics: ndiagt=   212
+(PID.TID 0000.0001)  Total Nb of available Diagnostics: ndiagt=   211
 (PID.TID 0000.0001)  write list of available Diagnostics to file: available_diagnostics.log
 (PID.TID 0000.0001) SETDIAG: Allocate  1 x  1 Levels for Diagnostic #    23 ETAN
 (PID.TID 0000.0001) SETDIAG: Allocate  1 x  1 Levels for Diagnostic #    25 DETADT2
@@ -494,11 +494,11 @@
 (PID.TID 0000.0001) SETDIAG: Allocate 25 x  1 Levels for Diagnostic #    77 DRHODR
 (PID.TID 0000.0001) SETDIAG: Allocate 25 x  1 Levels for Diagnostic #    64 RHOAnoma
 (PID.TID 0000.0001) SETDIAG: Allocate 25 x  1 Levels for Diagnostic #    26 THETA
-(PID.TID 0000.0001) SETDIAG: Allocate 25 x  1 Levels for Diagnostic #   202 GM_Kwy
-(PID.TID 0000.0001) SETDIAG: Allocate 25 x  1 Levels for Diagnostic #   203 GM_Kwz
-(PID.TID 0000.0001) SETDIAG: Allocate 25 x  1 Levels for Diagnostic #   198 GM_Kvy
-(PID.TID 0000.0001) SETDIAG: Allocate 25 x  1 Levels for Diagnostic #   200 GM_Kvz
-(PID.TID 0000.0001) SETDIAG: Allocate 25 x  1 Levels for Diagnostic #   205 GM_PsiY
+(PID.TID 0000.0001) SETDIAG: Allocate 25 x  1 Levels for Diagnostic #   201 GM_Kwy
+(PID.TID 0000.0001) SETDIAG: Allocate 25 x  1 Levels for Diagnostic #   202 GM_Kwz
+(PID.TID 0000.0001) SETDIAG: Allocate 25 x  1 Levels for Diagnostic #   197 GM_Kvy
+(PID.TID 0000.0001) SETDIAG: Allocate 25 x  1 Levels for Diagnostic #   199 GM_Kvz
+(PID.TID 0000.0001) SETDIAG: Allocate 25 x  1 Levels for Diagnostic #   204 GM_PsiY
 (PID.TID 0000.0001)   space allocated for all diagnostics:     204 levels
 (PID.TID 0000.0001) DIAGNOSTICS_SET_POINTERS: Set levels for Outp.Stream: oceDiag
 (PID.TID 0000.0001)  Levels:       1.   2.   3.   4.   5.   6.   7.   8.   9.  10.  11.  12.  13.  14.  15.  16.  17.  18.  19.  20.
@@ -515,11 +515,11 @@
 (PID.TID 0000.0001) SETDIAG: Allocate 25 Levels for Stats-Diag #    32 WVEL
 (PID.TID 0000.0001) SETDIAG: Allocate 25 Levels for Stats-Diag #    26 THETA
 (PID.TID 0000.0001) SETDIAG: Allocate 25 Levels for Stats-Diag #    27 SALT
-(PID.TID 0000.0001) SETDIAG: Allocate 25 Levels for Stats-Diag #   205 GM_PsiY
-(PID.TID 0000.0001) SETDIAG: Allocate 25 Levels for Stats-Diag #   198 GM_Kvy
-(PID.TID 0000.0001) SETDIAG: Allocate 25 Levels for Stats-Diag #   200 GM_Kvz
-(PID.TID 0000.0001) SETDIAG: Allocate 25 Levels for Stats-Diag #   202 GM_Kwy
-(PID.TID 0000.0001) SETDIAG: Allocate 25 Levels for Stats-Diag #   203 GM_Kwz
+(PID.TID 0000.0001) SETDIAG: Allocate 25 Levels for Stats-Diag #   204 GM_PsiY
+(PID.TID 0000.0001) SETDIAG: Allocate 25 Levels for Stats-Diag #   197 GM_Kvy
+(PID.TID 0000.0001) SETDIAG: Allocate 25 Levels for Stats-Diag #   199 GM_Kvz
+(PID.TID 0000.0001) SETDIAG: Allocate 25 Levels for Stats-Diag #   201 GM_Kwy
+(PID.TID 0000.0001) SETDIAG: Allocate 25 Levels for Stats-Diag #   202 GM_Kwz
 (PID.TID 0000.0001)   space allocated for all stats-diags:     253 levels
 (PID.TID 0000.0001) DIAGSTATS_SET_POINTERS: done
 (PID.TID 0000.0001) ------------------------------------------------------------
@@ -564,6 +564,12 @@
 (PID.TID 0000.0001)     ;
 (PID.TID 0000.0001) sRef =   /* Reference salinity profile ( g/kg ) */
 (PID.TID 0000.0001)    25 @  3.000000000000000E+01              /* K =  1: 25 */
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) rhoRef =   /* Density vertical profile from (Ref,sRef)( kg/m^3 ) */
+(PID.TID 0000.0001)    25 @  1.000000000000000E+03              /* K =  1: 25 */
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) dBdrRef = /* Vertical grad. of reference buoyancy [(m/s/r)^2] */
+(PID.TID 0000.0001)    25 @  0.000000000000000E+00              /* K =  1: 25 */
 (PID.TID 0000.0001)     ;
 (PID.TID 0000.0001) useStrainTensionVisc= /* Use StrainTension Form of Viscous Operator */
 (PID.TID 0000.0001)                   F
@@ -825,8 +831,8 @@
 (PID.TID 0000.0001)                       0
 (PID.TID 0000.0001)     0= Expl. ; 1= Impl. on provis. Vel ; 2= Fully Impl (with surf.P)
 (PID.TID 0000.0001)     ;
-(PID.TID 0000.0001) metricTerms =  /* metric-Terms on/off flag */
-(PID.TID 0000.0001)                   F
+(PID.TID 0000.0001) selectMetricTerms= /* Metric-Terms on/off flag (=0/1) */
+(PID.TID 0000.0001)                       0
 (PID.TID 0000.0001)     ;
 (PID.TID 0000.0001) useNHMTerms = /* Non-Hydrostatic Metric-Terms on/off */
 (PID.TID 0000.0001)                   F
@@ -835,8 +841,8 @@
 (PID.TID 0000.0001)                       1
 (PID.TID 0000.0001)     0= f-Plane ; 1= Beta-Plane ; 2= Spherical ; 3= read from file
 (PID.TID 0000.0001)     ;
-(PID.TID 0000.0001) use3dCoriolis = /* 3-D Coriolis on/off flag */
-(PID.TID 0000.0001)                   F
+(PID.TID 0000.0001) select3dCoriScheme= /* 3-D Coriolis on/off flag (=0/1) */
+(PID.TID 0000.0001)                       0
 (PID.TID 0000.0001)     ;
 (PID.TID 0000.0001) useCoriolis =  /* Coriolis on/off flag */
 (PID.TID 0000.0001)                   T
@@ -1320,14 +1326,17 @@
 (PID.TID 0000.0001) deepFacF = /* deep-model grid factor @ W-Interface (-) */
 (PID.TID 0000.0001)    26 @  1.000000000000000E+00              /* K =  1: 26 */
 (PID.TID 0000.0001)     ;
-(PID.TID 0000.0001) rVel2wUnit = /* convert units: rVel -> wSpeed (=1 if z-coord)*/
+(PID.TID 0000.0001) rVel2wUnit = /* convert units: rVel [Pa/s] -> wSpeed [m/s] */
 (PID.TID 0000.0001)    26 @  1.000000000000000E-04              /* K =  1: 26 */
 (PID.TID 0000.0001)     ;
-(PID.TID 0000.0001) wUnit2rVel = /* convert units: wSpeed -> rVel (=1 if z-coord)*/
+(PID.TID 0000.0001) wUnit2rVel = /* convert units: wSpeed [m/s] -> rVel [Pa/s] */
 (PID.TID 0000.0001)    26 @  1.000000000000000E+04              /* K =  1: 26 */
 (PID.TID 0000.0001)     ;
-(PID.TID 0000.0001) dBdrRef = /* Vertical grad. of reference buoyancy [(m/s/r)^2] */
-(PID.TID 0000.0001)    25 @  0.000000000000000E+00              /* K =  1: 25 */
+(PID.TID 0000.0001) rUnit2z = /* convert units (@ center): dr [Pa] -> dz [m] */
+(PID.TID 0000.0001)    25 @  1.000000000000000E-04              /* K =  1: 25 */
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) z2rUnit = /* convert units (@ center): dz [m] -> dr [Pa] */
+(PID.TID 0000.0001)    25 @  1.000000000000000E+04              /* K =  1: 25 */
 (PID.TID 0000.0001)     ;
 (PID.TID 0000.0001) rotateGrid = /* use rotated grid ( True/False ) */
 (PID.TID 0000.0001)                   F
@@ -1646,11 +1655,14 @@
 (PID.TID 0000.0001) GM_isopycK =    /* Background Isopyc. Diffusivity [m^2/s] */
 (PID.TID 0000.0001)                 1.000000000000000E+03
 (PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) GM_advec*K =    /* Backg. GM-Advec(=Bolus) Diffusivity [m^2/s] */
+(PID.TID 0000.0001)                 1.000000000000000E+03
+(PID.TID 0000.0001)     ;
 (PID.TID 0000.0001) GM_skewflx*K =  /* Background GM_SkewFlx Diffusivity [m^2/s] */
 (PID.TID 0000.0001)                 0.000000000000000E+00
 (PID.TID 0000.0001)     ;
-(PID.TID 0000.0001) GM_advec*K =    /* Backg. GM-Advec(=Bolus) Diffusivity [m^2/s]*/
-(PID.TID 0000.0001)                 1.000000000000000E+03
+(PID.TID 0000.0001) GM_isoFac_calcK = /* Fraction of dynamic K added to Redi tensor */
+(PID.TID 0000.0001)                 1.000000000000000E+00
 (PID.TID 0000.0001)     ;
 (PID.TID 0000.0001) GM_Kmin_horiz = /* Minimum Horizontal Diffusivity [m^2/s] */
 (PID.TID 0000.0001)                 0.000000000000000E+00
@@ -1706,6 +1718,9 @@
 (PID.TID 0000.0001) GM_useLeithQG = /* if TRUE => add QG Leith viscosity to GMRedi tensor */
 (PID.TID 0000.0001)                   F
 (PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) GM_useGEOM = /* using GEOMETRIC */
+(PID.TID 0000.0001)                   F
+(PID.TID 0000.0001)     ;
 (PID.TID 0000.0001) GAD_CHECK: #define ALLOW_GENERIC_ADVDIFF
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // Check Model config. (CONFIG_CHECK):
@@ -1740,11 +1755,11 @@ listId=    2 ; file name: oceDiag
     77 |DRHODR  |      5 |      0 |  25 |       0 |
     64 |RHOAnoma|     30 |      0 |  25 |       0 |
     26 |THETA   |     55 |      0 |  25 |       0 |
-   202 |GM_Kwy  |     80 |      0 |  25 |       0 |
-   203 |GM_Kwz  |    105 |      0 |  25 |       0 |
-   198 |GM_Kvy  |    130 |      0 |  25 |       0 |
-   200 |GM_Kvz  |    155 |      0 |  25 |       0 |
-   205 |GM_PsiY |    180 |      0 |  25 |       0 |
+   201 |GM_Kwy  |     80 |      0 |  25 |       0 |
+   202 |GM_Kwz  |    105 |      0 |  25 |       0 |
+   197 |GM_Kvy  |    130 |      0 |  25 |       0 |
+   199 |GM_Kvz  |    155 |      0 |  25 |       0 |
+   204 |GM_PsiY |    180 |      0 |  25 |       0 |
 ------------------------------------------------------------------------
 Global & Regional Statistics diagnostics: Number of lists:     1
 ------------------------------------------------------------------------
@@ -1761,11 +1776,11 @@ listId=   1 ; file name: dynStDiag
     32 |WVEL    |     54 |      0 | 0.00000E+00 |
     26 |THETA   |     79 |      0 | 0.00000E+00 |
     27 |SALT    |    104 |      0 | 0.00000E+00 |
-   205 |GM_PsiY |    129 |      0 | 0.00000E+00 |
-   198 |GM_Kvy  |    154 |      0 | 0.00000E+00 |
-   200 |GM_Kvz  |    179 |      0 | 0.00000E+00 |
-   202 |GM_Kwy  |    204 |      0 | 0.00000E+00 |
-   203 |GM_Kwz  |    229 |      0 | 0.00000E+00 |
+   204 |GM_PsiY |    129 |      0 | 0.00000E+00 |
+   197 |GM_Kvy  |    154 |      0 | 0.00000E+00 |
+   199 |GM_Kvz  |    179 |      0 | 0.00000E+00 |
+   201 |GM_Kwy  |    204 |      0 | 0.00000E+00 |
+   202 |GM_Kwz  |    229 |      0 | 0.00000E+00 |
 ------------------------------------------------------------------------
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // Model current state
@@ -1818,52 +1833,52 @@ listId=   1 ; file name: dynStDiag
 (PID.TID 0000.0001) // End MONITOR dynamic field statistics
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) SOLVE_FOR_PRESSURE: putPmEinXvector =    F
- cg2d: Sum(rhs),rhsMax =   0.00000000000000E+00  1.59001889464779E-03
-(PID.TID 0000.0001)      cg2d_init_res =   3.66943189311226E+00
+ cg2d: Sum(rhs),rhsMax =   1.77635683940025E-15  1.59001889435547E-03
+(PID.TID 0000.0001)      cg2d_init_res =   3.66943189378592E+00
 (PID.TID 0000.0001)      cg2d_iters(min,last) =      -1      29
-(PID.TID 0000.0001)      cg2d_last_res =   1.27208877247624E-14
+(PID.TID 0000.0001)      cg2d_last_res =   1.87856717661542E-14
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // Begin MONITOR dynamic field statistics
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) %MON time_tsnumber                =                     1
 (PID.TID 0000.0001) %MON time_secondsf                =   1.8000000000000E+03
-(PID.TID 0000.0001) %MON dynstat_eta_max              =   1.5577757061503E+02
-(PID.TID 0000.0001) %MON dynstat_eta_min              =  -1.5578802445227E+02
+(PID.TID 0000.0001) %MON dynstat_eta_max              =   1.5577757061499E+02
+(PID.TID 0000.0001) %MON dynstat_eta_min              =  -1.5578802445190E+02
 (PID.TID 0000.0001) %MON dynstat_eta_mean             =  -6.8817204301075E-15
 (PID.TID 0000.0001) %MON dynstat_eta_sd               =   1.1034790520489E+02
-(PID.TID 0000.0001) %MON dynstat_eta_del2             =   1.9396252918616E-01
+(PID.TID 0000.0001) %MON dynstat_eta_del2             =   1.9396252918331E-01
 (PID.TID 0000.0001) %MON dynstat_uvel_max             =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON dynstat_uvel_min             =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON dynstat_uvel_mean            =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON dynstat_uvel_sd              =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON dynstat_uvel_del2            =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON dynstat_vvel_max             =   1.3159304650597E-02
-(PID.TID 0000.0001) %MON dynstat_vvel_min             =  -2.8399192395328E-03
-(PID.TID 0000.0001) %MON dynstat_vvel_mean            =   2.2960740634924E-04
-(PID.TID 0000.0001) %MON dynstat_vvel_sd              =   3.2708413738132E-03
-(PID.TID 0000.0001) %MON dynstat_vvel_del2            =   2.6252515694238E-06
-(PID.TID 0000.0001) %MON dynstat_wvel_max             =   4.8044519469943E-01
-(PID.TID 0000.0001) %MON dynstat_wvel_min             =  -4.8057261799571E-01
-(PID.TID 0000.0001) %MON dynstat_wvel_mean            =  -6.0295447693699E-17
-(PID.TID 0000.0001) %MON dynstat_wvel_sd              =   2.3409514457713E-01
-(PID.TID 0000.0001) %MON dynstat_wvel_del2            =   1.0727456558643E-04
+(PID.TID 0000.0001) %MON dynstat_vvel_max             =   1.3159304650533E-02
+(PID.TID 0000.0001) %MON dynstat_vvel_min             =  -2.8399192395205E-03
+(PID.TID 0000.0001) %MON dynstat_vvel_mean            =   2.2960740634920E-04
+(PID.TID 0000.0001) %MON dynstat_vvel_sd              =   3.2708413738128E-03
+(PID.TID 0000.0001) %MON dynstat_vvel_del2            =   2.6252515693607E-06
+(PID.TID 0000.0001) %MON dynstat_wvel_max             =   4.8044519475064E-01
+(PID.TID 0000.0001) %MON dynstat_wvel_min             =  -4.8057261800746E-01
+(PID.TID 0000.0001) %MON dynstat_wvel_mean            =  -7.2354537232439E-17
+(PID.TID 0000.0001) %MON dynstat_wvel_sd              =   2.3409514457711E-01
+(PID.TID 0000.0001) %MON dynstat_wvel_del2            =   1.0727456523916E-04
 (PID.TID 0000.0001) %MON dynstat_theta_max            =   2.0568356979286E+01
 (PID.TID 0000.0001) %MON dynstat_theta_min            =   1.5559631949511E+01
 (PID.TID 0000.0001) %MON dynstat_theta_mean           =   1.7563160570396E+01
 (PID.TID 0000.0001) %MON dynstat_theta_sd             =   1.4157858227061E+00
-(PID.TID 0000.0001) %MON dynstat_theta_del2           =   1.3827375975960E-04
+(PID.TID 0000.0001) %MON dynstat_theta_del2           =   1.3827375975965E-04
 (PID.TID 0000.0001) %MON dynstat_salt_max             =   9.9984962322830E-01
 (PID.TID 0000.0001) %MON dynstat_salt_min             =   3.9573387965773E-01
 (PID.TID 0000.0001) %MON dynstat_salt_mean            =   7.4692405414469E-01
 (PID.TID 0000.0001) %MON dynstat_salt_sd              =   2.0049834950731E-01
 (PID.TID 0000.0001) %MON dynstat_salt_del2            =   2.2965688247240E-04
 (PID.TID 0000.0001) %MON advcfl_uvel_max              =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON advcfl_vvel_max              =   2.9970856915101E-03
-(PID.TID 0000.0001) %MON advcfl_wvel_max              =   8.4560392293359E-04
-(PID.TID 0000.0001) %MON advcfl_W_hf_max              =   8.9010939256167E-04
-(PID.TID 0000.0001) %MON pe_b_mean                    =   2.4749309315260E-07
-(PID.TID 0000.0001) %MON ke_max                       =   8.7029874315695E-05
-(PID.TID 0000.0001) %MON ke_mean                      =   5.1810275770367E-06
+(PID.TID 0000.0001) %MON advcfl_vvel_max              =   2.9970856914954E-03
+(PID.TID 0000.0001) %MON advcfl_wvel_max              =   8.4560392293614E-04
+(PID.TID 0000.0001) %MON advcfl_W_hf_max              =   8.9010939256436E-04
+(PID.TID 0000.0001) %MON pe_b_mean                    =   2.4749309315259E-07
+(PID.TID 0000.0001) %MON ke_max                       =   8.7029874315340E-05
+(PID.TID 0000.0001) %MON ke_mean                      =   5.1810275770356E-06
 (PID.TID 0000.0001) %MON ke_vol                       =   7.6260000000000E+16
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // End MONITOR dynamic field statistics
@@ -1875,561 +1890,561 @@ listId=   1 ; file name: dynStDiag
  Computing Diagnostic #     77  DRHODR       Counter:       1   Parms: SM      LR      
  Computing Diagnostic #     64  RHOAnoma     Counter:       1   Parms: SMR     MR      
  Computing Diagnostic #     26  THETA        Counter:       1   Parms: SMR     MR      
- Computing Diagnostic #    202  GM_Kwy       Counter:       1   Parms: VM      LR      
-           Vector  Mate for  GM_Kwy       Diagnostic #    201  GM_Kwx   not enabled
- Computing Diagnostic #    203  GM_Kwz       Counter:       1   Parms: WM P    LR      
- Computing Diagnostic #    198  GM_Kvy       Counter:       1   Parms: VV P    MR      
-           Vector  Mate for  GM_Kvy       Diagnostic #    197  GM_Kux   not enabled
- Computing Diagnostic #    200  GM_Kvz       Counter:       1   Parms: VV      MR      
-           Vector  Mate for  GM_Kvz       Diagnostic #    199  GM_Kuz   not enabled
- Computing Diagnostic #    205  GM_PsiY      Counter:       1   Parms: VV      LR      
-           Vector  Mate for  GM_PsiY      Diagnostic #    204  GM_PsiX  not enabled
- cg2d: Sum(rhs),rhsMax =   0.00000000000000E+00  1.93459627560502E-03
-(PID.TID 0000.0001)      cg2d_init_res =   6.52621796295528E-01
+ Computing Diagnostic #    201  GM_Kwy       Counter:       1   Parms: VM      LR      
+           Vector  Mate for  GM_Kwy       Diagnostic #    200  GM_Kwx   not enabled
+ Computing Diagnostic #    202  GM_Kwz       Counter:       1   Parms: WM P    LR      
+ Computing Diagnostic #    197  GM_Kvy       Counter:       1   Parms: VV P    MR      
+           Vector  Mate for  GM_Kvy       Diagnostic #    196  GM_Kux   not enabled
+ Computing Diagnostic #    199  GM_Kvz       Counter:       1   Parms: VV      MR      
+           Vector  Mate for  GM_Kvz       Diagnostic #    198  GM_Kuz   not enabled
+ Computing Diagnostic #    204  GM_PsiY      Counter:       1   Parms: VV      LR      
+           Vector  Mate for  GM_PsiY      Diagnostic #    203  GM_PsiX  not enabled
+ cg2d: Sum(rhs),rhsMax =   0.00000000000000E+00  1.93459627569848E-03
+(PID.TID 0000.0001)      cg2d_init_res =   6.52621796265662E-01
 (PID.TID 0000.0001)      cg2d_iters(min,last) =      -1      29
-(PID.TID 0000.0001)      cg2d_last_res =   4.18379565051472E-14
+(PID.TID 0000.0001)      cg2d_last_res =   4.10695060654865E-14
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // Begin MONITOR dynamic field statistics
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) %MON time_tsnumber                =                     2
 (PID.TID 0000.0001) %MON time_secondsf                =   3.6000000000000E+03
-(PID.TID 0000.0001) %MON dynstat_eta_max              =   1.8951386671227E+02
-(PID.TID 0000.0001) %MON dynstat_eta_min              =  -1.8947198904168E+02
-(PID.TID 0000.0001) %MON dynstat_eta_mean             =  -3.4408602150538E-14
-(PID.TID 0000.0001) %MON dynstat_eta_sd               =   1.3422563269427E+02
-(PID.TID 0000.0001) %MON dynstat_eta_del2             =   2.3595346114684E-01
-(PID.TID 0000.0001) %MON dynstat_uvel_max             =   3.7898523019000E-03
-(PID.TID 0000.0001) %MON dynstat_uvel_min             =  -8.1789232118577E-04
-(PID.TID 0000.0001) %MON dynstat_uvel_mean            =   6.4145241682961E-05
-(PID.TID 0000.0001) %MON dynstat_uvel_sd              =   9.2408534298956E-04
-(PID.TID 0000.0001) %MON dynstat_uvel_del2            =   1.4747871930024E-06
-(PID.TID 0000.0001) %MON dynstat_vvel_max             =   2.5689783464674E-02
-(PID.TID 0000.0001) %MON dynstat_vvel_min             =  -6.2949476488083E-03
-(PID.TID 0000.0001) %MON dynstat_vvel_mean            =   4.9684073564369E-05
-(PID.TID 0000.0001) %MON dynstat_vvel_sd              =   6.5357301546514E-03
-(PID.TID 0000.0001) %MON dynstat_vvel_del2            =   5.1105547707917E-06
-(PID.TID 0000.0001) %MON dynstat_wvel_max             =   9.0975978167577E-01
-(PID.TID 0000.0001) %MON dynstat_wvel_min             =  -9.0953932994991E-01
-(PID.TID 0000.0001) %MON dynstat_wvel_mean            =  -9.6472716309919E-17
-(PID.TID 0000.0001) %MON dynstat_wvel_sd              =   4.2486648959986E-01
-(PID.TID 0000.0001) %MON dynstat_wvel_del2            =   2.0066473132450E-04
+(PID.TID 0000.0001) %MON dynstat_eta_max              =   1.8951386671218E+02
+(PID.TID 0000.0001) %MON dynstat_eta_min              =  -1.8947198904209E+02
+(PID.TID 0000.0001) %MON dynstat_eta_mean             =  -6.8817204301075E-15
+(PID.TID 0000.0001) %MON dynstat_eta_sd               =   1.3422563269429E+02
+(PID.TID 0000.0001) %MON dynstat_eta_del2             =   2.3595346113716E-01
+(PID.TID 0000.0001) %MON dynstat_uvel_max             =   3.7898523018923E-03
+(PID.TID 0000.0001) %MON dynstat_uvel_min             =  -8.1789232119986E-04
+(PID.TID 0000.0001) %MON dynstat_uvel_mean            =   6.4145241682951E-05
+(PID.TID 0000.0001) %MON dynstat_uvel_sd              =   9.2408534298953E-04
+(PID.TID 0000.0001) %MON dynstat_uvel_del2            =   1.4747871930763E-06
+(PID.TID 0000.0001) %MON dynstat_vvel_max             =   2.5689783464562E-02
+(PID.TID 0000.0001) %MON dynstat_vvel_min             =  -6.2949476487963E-03
+(PID.TID 0000.0001) %MON dynstat_vvel_mean            =   4.9684073564462E-05
+(PID.TID 0000.0001) %MON dynstat_vvel_sd              =   6.5357301546508E-03
+(PID.TID 0000.0001) %MON dynstat_vvel_del2            =   5.1105547707492E-06
+(PID.TID 0000.0001) %MON dynstat_wvel_max             =   9.0975978172498E-01
+(PID.TID 0000.0001) %MON dynstat_wvel_min             =  -9.0953932995835E-01
+(PID.TID 0000.0001) %MON dynstat_wvel_mean            =  -2.4118179077480E-16
+(PID.TID 0000.0001) %MON dynstat_wvel_sd              =   4.2486648959984E-01
+(PID.TID 0000.0001) %MON dynstat_wvel_del2            =   2.0066473096772E-04
 (PID.TID 0000.0001) %MON dynstat_theta_max            =   2.0568279498456E+01
 (PID.TID 0000.0001) %MON dynstat_theta_min            =   1.5559685795808E+01
 (PID.TID 0000.0001) %MON dynstat_theta_mean           =   1.7563160570649E+01
 (PID.TID 0000.0001) %MON dynstat_theta_sd             =   1.4157856800178E+00
-(PID.TID 0000.0001) %MON dynstat_theta_del2           =   1.3820099290951E-04
+(PID.TID 0000.0001) %MON dynstat_theta_del2           =   1.3820099290959E-04
 (PID.TID 0000.0001) %MON dynstat_salt_max             =   9.9970129752384E-01
 (PID.TID 0000.0001) %MON dynstat_salt_min             =   3.9647383767943E-01
 (PID.TID 0000.0001) %MON dynstat_salt_mean            =   7.4692405430535E-01
 (PID.TID 0000.0001) %MON dynstat_salt_sd              =   2.0033380759074E-01
 (PID.TID 0000.0001) %MON dynstat_salt_del2            =   2.3124263697474E-04
-(PID.TID 0000.0001) %MON advcfl_uvel_max              =   6.8217341434200E-04
-(PID.TID 0000.0001) %MON advcfl_vvel_max              =   5.8509537155881E-03
-(PID.TID 0000.0001) %MON advcfl_wvel_max              =   1.6373566631726E-03
-(PID.TID 0000.0001) %MON advcfl_W_hf_max              =   1.7235333296554E-03
-(PID.TID 0000.0001) %MON pe_b_mean                    =   3.6618944049138E-07
-(PID.TID 0000.0001) %MON ke_max                       =   3.3886534174101E-04
-(PID.TID 0000.0001) %MON ke_mean                      =   2.1015186913333E-05
+(PID.TID 0000.0001) %MON advcfl_uvel_max              =   6.8217341434061E-04
+(PID.TID 0000.0001) %MON advcfl_vvel_max              =   5.8509537155625E-03
+(PID.TID 0000.0001) %MON advcfl_wvel_max              =   1.6373566632121E-03
+(PID.TID 0000.0001) %MON advcfl_W_hf_max              =   1.7235333296969E-03
+(PID.TID 0000.0001) %MON pe_b_mean                    =   3.6618944049152E-07
+(PID.TID 0000.0001) %MON ke_max                       =   3.3886534173858E-04
+(PID.TID 0000.0001) %MON ke_mean                      =   2.1015186913328E-05
 (PID.TID 0000.0001) %MON ke_vol                       =   7.6260000000000E+16
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // End MONITOR dynamic field statistics
 (PID.TID 0000.0001) // =======================================================
- cg2d: Sum(rhs),rhsMax =  -1.77635683940025E-15  1.81671856564536E-03
-(PID.TID 0000.0001)      cg2d_init_res =   2.35915529694195E-01
+ cg2d: Sum(rhs),rhsMax =   3.55271367880050E-15  1.81671856562929E-03
+(PID.TID 0000.0001)      cg2d_init_res =   2.35915529717665E-01
 (PID.TID 0000.0001)      cg2d_iters(min,last) =      -1      29
-(PID.TID 0000.0001)      cg2d_last_res =   4.11030209513667E-14
+(PID.TID 0000.0001)      cg2d_last_res =   4.10176620863997E-14
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // Begin MONITOR dynamic field statistics
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) %MON time_tsnumber                =                     3
 (PID.TID 0000.0001) %MON time_secondsf                =   5.4000000000000E+03
-(PID.TID 0000.0001) %MON dynstat_eta_max              =   1.7813647645883E+02
-(PID.TID 0000.0001) %MON dynstat_eta_min              =  -1.7796038826639E+02
-(PID.TID 0000.0001) %MON dynstat_eta_mean             =  -2.0645161290323E-14
-(PID.TID 0000.0001) %MON dynstat_eta_sd               =   1.2612273700473E+02
-(PID.TID 0000.0001) %MON dynstat_eta_del2             =   2.2181768636062E-01
-(PID.TID 0000.0001) %MON dynstat_uvel_max             =   9.7670092268924E-03
-(PID.TID 0000.0001) %MON dynstat_uvel_min             =  -2.3240702614386E-03
-(PID.TID 0000.0001) %MON dynstat_uvel_mean            =   5.3970978487014E-05
-(PID.TID 0000.0001) %MON dynstat_uvel_sd              =   2.4237151292893E-03
-(PID.TID 0000.0001) %MON dynstat_uvel_del2            =   3.7868677328205E-06
-(PID.TID 0000.0001) %MON dynstat_vvel_max             =   3.7318444927683E-02
-(PID.TID 0000.0001) %MON dynstat_vvel_min             =  -9.3065274578859E-03
-(PID.TID 0000.0001) %MON dynstat_vvel_mean            =  -1.6860568341409E-05
-(PID.TID 0000.0001) %MON dynstat_vvel_sd              =   9.5268504956582E-03
-(PID.TID 0000.0001) %MON dynstat_vvel_del2            =   7.4435939510965E-06
-(PID.TID 0000.0001) %MON dynstat_wvel_max             =   1.3080848728009E+00
-(PID.TID 0000.0001) %MON dynstat_wvel_min             =  -1.3064511831025E+00
-(PID.TID 0000.0001) %MON dynstat_wvel_mean            =   1.9294543261984E-16
-(PID.TID 0000.0001) %MON dynstat_wvel_sd              =   6.1072554185912E-01
-(PID.TID 0000.0001) %MON dynstat_wvel_del2            =   4.2968462413684E-04
+(PID.TID 0000.0001) %MON dynstat_eta_max              =   1.7813647645890E+02
+(PID.TID 0000.0001) %MON dynstat_eta_min              =  -1.7796038826565E+02
+(PID.TID 0000.0001) %MON dynstat_eta_mean             =  -5.5053763440860E-14
+(PID.TID 0000.0001) %MON dynstat_eta_sd               =   1.2612273700477E+02
+(PID.TID 0000.0001) %MON dynstat_eta_del2             =   2.2181768637673E-01
+(PID.TID 0000.0001) %MON dynstat_uvel_max             =   9.7670092268609E-03
+(PID.TID 0000.0001) %MON dynstat_uvel_min             =  -2.3240702614292E-03
+(PID.TID 0000.0001) %MON dynstat_uvel_mean            =   5.3970978487035E-05
+(PID.TID 0000.0001) %MON dynstat_uvel_sd              =   2.4237151292892E-03
+(PID.TID 0000.0001) %MON dynstat_uvel_del2            =   3.7868677329281E-06
+(PID.TID 0000.0001) %MON dynstat_vvel_max             =   3.7318444927517E-02
+(PID.TID 0000.0001) %MON dynstat_vvel_min             =  -9.3065274577109E-03
+(PID.TID 0000.0001) %MON dynstat_vvel_mean            =  -1.6860568341384E-05
+(PID.TID 0000.0001) %MON dynstat_vvel_sd              =   9.5268504956577E-03
+(PID.TID 0000.0001) %MON dynstat_vvel_del2            =   7.4435939512117E-06
+(PID.TID 0000.0001) %MON dynstat_wvel_max             =   1.3080848727624E+00
+(PID.TID 0000.0001) %MON dynstat_wvel_min             =  -1.3064511831978E+00
+(PID.TID 0000.0001) %MON dynstat_wvel_mean            =   2.8941814892976E-16
+(PID.TID 0000.0001) %MON dynstat_wvel_sd              =   6.1072554185916E-01
+(PID.TID 0000.0001) %MON dynstat_wvel_del2            =   4.2968462525523E-04
 (PID.TID 0000.0001) %MON dynstat_theta_max            =   2.0568192046944E+01
 (PID.TID 0000.0001) %MON dynstat_theta_min            =   1.5559758859725E+01
 (PID.TID 0000.0001) %MON dynstat_theta_mean           =   1.7563160570575E+01
 (PID.TID 0000.0001) %MON dynstat_theta_sd             =   1.4157855371630E+00
 (PID.TID 0000.0001) %MON dynstat_theta_del2           =   1.3808834136934E-04
 (PID.TID 0000.0001) %MON dynstat_salt_max             =   9.9955474002112E-01
-(PID.TID 0000.0001) %MON dynstat_salt_min             =   3.9719600058900E-01
+(PID.TID 0000.0001) %MON dynstat_salt_min             =   3.9719600058901E-01
 (PID.TID 0000.0001) %MON dynstat_salt_mean            =   7.4692405467938E-01
 (PID.TID 0000.0001) %MON dynstat_salt_sd              =   2.0016971128014E-01
 (PID.TID 0000.0001) %MON dynstat_salt_del2            =   2.3305103501236E-04
-(PID.TID 0000.0001) %MON advcfl_uvel_max              =   1.7580616608406E-03
-(PID.TID 0000.0001) %MON advcfl_vvel_max              =   8.4994291333691E-03
-(PID.TID 0000.0001) %MON advcfl_wvel_max              =   2.3630186087675E-03
-(PID.TID 0000.0001) %MON advcfl_W_hf_max              =   2.4873880092289E-03
-(PID.TID 0000.0001) %MON pe_b_mean                    =   3.2331188596674E-07
-(PID.TID 0000.0001) %MON ke_max                       =   7.4758468443072E-04
-(PID.TID 0000.0001) %MON ke_mean                      =   4.6676978153058E-05
+(PID.TID 0000.0001) %MON advcfl_uvel_max              =   1.7580616608350E-03
+(PID.TID 0000.0001) %MON advcfl_vvel_max              =   8.4994291333311E-03
+(PID.TID 0000.0001) %MON advcfl_wvel_max              =   2.3630186087662E-03
+(PID.TID 0000.0001) %MON advcfl_W_hf_max              =   2.4873880092276E-03
+(PID.TID 0000.0001) %MON pe_b_mean                    =   3.2331188596695E-07
+(PID.TID 0000.0001) %MON ke_max                       =   7.4758468442672E-04
+(PID.TID 0000.0001) %MON ke_mean                      =   4.6676978153054E-05
 (PID.TID 0000.0001) %MON ke_vol                       =   7.6260000000000E+16
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // End MONITOR dynamic field statistics
 (PID.TID 0000.0001) // =======================================================
- cg2d: Sum(rhs),rhsMax =  -3.55271367880050E-15  1.76617233379692E-03
-(PID.TID 0000.0001)      cg2d_init_res =   1.27484900375635E-01
+ cg2d: Sum(rhs),rhsMax =   1.77635683940025E-15  1.76617233312621E-03
+(PID.TID 0000.0001)      cg2d_init_res =   1.27484900433462E-01
 (PID.TID 0000.0001)      cg2d_iters(min,last) =      -1      29
-(PID.TID 0000.0001)      cg2d_last_res =   4.89315409919916E-14
+(PID.TID 0000.0001)      cg2d_last_res =   4.89288334599577E-14
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // Begin MONITOR dynamic field statistics
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) %MON time_tsnumber                =                     4
 (PID.TID 0000.0001) %MON time_secondsf                =   7.2000000000000E+03
-(PID.TID 0000.0001) %MON dynstat_eta_max              =   1.7225306824525E+02
-(PID.TID 0000.0001) %MON dynstat_eta_min              =  -1.7189516232448E+02
-(PID.TID 0000.0001) %MON dynstat_eta_mean             =  -5.5053763440860E-14
-(PID.TID 0000.0001) %MON dynstat_eta_sd               =   1.2188701823118E+02
-(PID.TID 0000.0001) %MON dynstat_eta_del2             =   2.1413228629240E-01
-(PID.TID 0000.0001) %MON dynstat_uvel_max             =   1.7739219648810E-02
-(PID.TID 0000.0001) %MON dynstat_uvel_min             =  -4.3242934807705E-03
-(PID.TID 0000.0001) %MON dynstat_uvel_mean            =   4.4055563364432E-05
-(PID.TID 0000.0001) %MON dynstat_uvel_sd              =   4.4224985332017E-03
-(PID.TID 0000.0001) %MON dynstat_uvel_del2            =   6.8669532466895E-06
-(PID.TID 0000.0001) %MON dynstat_vvel_max             =   4.7717704390784E-02
-(PID.TID 0000.0001) %MON dynstat_vvel_min             =  -1.1864767367945E-02
-(PID.TID 0000.0001) %MON dynstat_vvel_mean            =  -8.8136041219387E-06
+(PID.TID 0000.0001) %MON dynstat_eta_max              =   1.7225306824431E+02
+(PID.TID 0000.0001) %MON dynstat_eta_min              =  -1.7189516232454E+02
+(PID.TID 0000.0001) %MON dynstat_eta_mean             =  -8.2580645161290E-14
+(PID.TID 0000.0001) %MON dynstat_eta_sd               =   1.2188701823120E+02
+(PID.TID 0000.0001) %MON dynstat_eta_del2             =   2.1413228630461E-01
+(PID.TID 0000.0001) %MON dynstat_uvel_max             =   1.7739219648760E-02
+(PID.TID 0000.0001) %MON dynstat_uvel_min             =  -4.3242934807344E-03
+(PID.TID 0000.0001) %MON dynstat_uvel_mean            =   4.4055563364448E-05
+(PID.TID 0000.0001) %MON dynstat_uvel_sd              =   4.4224985332014E-03
+(PID.TID 0000.0001) %MON dynstat_uvel_del2            =   6.8669532466546E-06
+(PID.TID 0000.0001) %MON dynstat_vvel_max             =   4.7717704390654E-02
+(PID.TID 0000.0001) %MON dynstat_vvel_min             =  -1.1864767367827E-02
+(PID.TID 0000.0001) %MON dynstat_vvel_mean            =  -8.8136041220087E-06
 (PID.TID 0000.0001) %MON dynstat_vvel_sd              =   1.2173682125287E-02
-(PID.TID 0000.0001) %MON dynstat_vvel_del2            =   9.5698080075402E-06
-(PID.TID 0000.0001) %MON dynstat_wvel_max             =   1.6913772608246E+00
-(PID.TID 0000.0001) %MON dynstat_wvel_min             =  -1.6862409038171E+00
-(PID.TID 0000.0001) %MON dynstat_wvel_mean            =   1.4470907446488E-16
-(PID.TID 0000.0001) %MON dynstat_wvel_sd              =   7.8147590457918E-01
-(PID.TID 0000.0001) %MON dynstat_wvel_del2            =   9.2554807025706E-04
-(PID.TID 0000.0001) %MON dynstat_theta_max            =   2.0568095982110E+01
+(PID.TID 0000.0001) %MON dynstat_vvel_del2            =   9.5698080079483E-06
+(PID.TID 0000.0001) %MON dynstat_wvel_max             =   1.6913772609322E+00
+(PID.TID 0000.0001) %MON dynstat_wvel_min             =  -1.6862409039506E+00
+(PID.TID 0000.0001) %MON dynstat_wvel_mean            =  -1.4470907446488E-16
+(PID.TID 0000.0001) %MON dynstat_wvel_sd              =   7.8147590457949E-01
+(PID.TID 0000.0001) %MON dynstat_wvel_del2            =   9.2554807420752E-04
+(PID.TID 0000.0001) %MON dynstat_theta_max            =   2.0568095982111E+01
 (PID.TID 0000.0001) %MON dynstat_theta_min            =   1.5559851831857E+01
 (PID.TID 0000.0001) %MON dynstat_theta_mean           =   1.7563160570546E+01
 (PID.TID 0000.0001) %MON dynstat_theta_sd             =   1.4157853936001E+00
-(PID.TID 0000.0001) %MON dynstat_theta_del2           =   1.3791896326113E-04
+(PID.TID 0000.0001) %MON dynstat_theta_del2           =   1.3791896326095E-04
 (PID.TID 0000.0001) %MON dynstat_salt_max             =   9.9940957503145E-01
 (PID.TID 0000.0001) %MON dynstat_salt_min             =   3.9790151605071E-01
 (PID.TID 0000.0001) %MON dynstat_salt_mean            =   7.4692405519187E-01
 (PID.TID 0000.0001) %MON dynstat_salt_sd              =   2.0000605188286E-01
 (PID.TID 0000.0001) %MON dynstat_salt_del2            =   2.3504250848947E-04
-(PID.TID 0000.0001) %MON advcfl_uvel_max              =   3.1930595367857E-03
-(PID.TID 0000.0001) %MON advcfl_vvel_max              =   1.0867903195389E-02
-(PID.TID 0000.0001) %MON advcfl_wvel_max              =   3.0555661292913E-03
-(PID.TID 0000.0001) %MON advcfl_W_hf_max              =   3.2163853992540E-03
-(PID.TID 0000.0001) %MON pe_b_mean                    =   3.0196026856275E-07
-(PID.TID 0000.0001) %MON ke_max                       =   1.3015583308768E-03
-(PID.TID 0000.0001) %MON ke_mean                      =   8.1197976636338E-05
+(PID.TID 0000.0001) %MON advcfl_uvel_max              =   3.1930595367769E-03
+(PID.TID 0000.0001) %MON advcfl_vvel_max              =   1.0867903195360E-02
+(PID.TID 0000.0001) %MON advcfl_wvel_max              =   3.0555661294659E-03
+(PID.TID 0000.0001) %MON advcfl_W_hf_max              =   3.2163853994378E-03
+(PID.TID 0000.0001) %MON pe_b_mean                    =   3.0196026856285E-07
+(PID.TID 0000.0001) %MON ke_max                       =   1.3015583308727E-03
+(PID.TID 0000.0001) %MON ke_mean                      =   8.1197976636337E-05
 (PID.TID 0000.0001) %MON ke_vol                       =   7.6260000000000E+16
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // End MONITOR dynamic field statistics
 (PID.TID 0000.0001) // =======================================================
- cg2d: Sum(rhs),rhsMax =  -1.77635683940025E-15  1.77997396596381E-03
-(PID.TID 0000.0001)      cg2d_init_res =   3.15254817437705E-02
+ cg2d: Sum(rhs),rhsMax =  -1.77635683940025E-15  1.77997396537001E-03
+(PID.TID 0000.0001)      cg2d_init_res =   3.15254824372658E-02
 (PID.TID 0000.0001)      cg2d_iters(min,last) =      -1      30
-(PID.TID 0000.0001)      cg2d_last_res =   9.44359555167072E-17
+(PID.TID 0000.0001)      cg2d_last_res =   8.48751753647267E-17
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // Begin MONITOR dynamic field statistics
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) %MON time_tsnumber                =                     5
 (PID.TID 0000.0001) %MON time_secondsf                =   9.0000000000000E+03
-(PID.TID 0000.0001) %MON dynstat_eta_max              =   1.7173253468069E+02
-(PID.TID 0000.0001) %MON dynstat_eta_min              =  -1.7117084637893E+02
-(PID.TID 0000.0001) %MON dynstat_eta_mean             =   1.3763440860215E-14
-(PID.TID 0000.0001) %MON dynstat_eta_sd               =   1.2143687827519E+02
-(PID.TID 0000.0001) %MON dynstat_eta_del2             =   2.1278938746247E-01
-(PID.TID 0000.0001) %MON dynstat_uvel_max             =   2.7449463776479E-02
-(PID.TID 0000.0001) %MON dynstat_uvel_min             =  -6.7358205535301E-03
-(PID.TID 0000.0001) %MON dynstat_uvel_mean            =   4.3359699881121E-05
-(PID.TID 0000.0001) %MON dynstat_uvel_sd              =   6.8520706192121E-03
-(PID.TID 0000.0001) %MON dynstat_uvel_del2            =   1.0615168575963E-05
-(PID.TID 0000.0001) %MON dynstat_vvel_max             =   5.6445232582268E-02
-(PID.TID 0000.0001) %MON dynstat_vvel_min             =  -1.3999516497783E-02
-(PID.TID 0000.0001) %MON dynstat_vvel_mean            =  -9.3663246391295E-07
+(PID.TID 0000.0001) %MON dynstat_eta_max              =   1.7173253467977E+02
+(PID.TID 0000.0001) %MON dynstat_eta_min              =  -1.7117084637846E+02
+(PID.TID 0000.0001) %MON dynstat_eta_mean             =  -8.9462365591398E-14
+(PID.TID 0000.0001) %MON dynstat_eta_sd               =   1.2143687827513E+02
+(PID.TID 0000.0001) %MON dynstat_eta_del2             =   2.1278938747598E-01
+(PID.TID 0000.0001) %MON dynstat_uvel_max             =   2.7449463776422E-02
+(PID.TID 0000.0001) %MON dynstat_uvel_min             =  -6.7358205534779E-03
+(PID.TID 0000.0001) %MON dynstat_uvel_mean            =   4.3359699881115E-05
+(PID.TID 0000.0001) %MON dynstat_uvel_sd              =   6.8520706192116E-03
+(PID.TID 0000.0001) %MON dynstat_uvel_del2            =   1.0615168575760E-05
+(PID.TID 0000.0001) %MON dynstat_vvel_max             =   5.6445232582139E-02
+(PID.TID 0000.0001) %MON dynstat_vvel_min             =  -1.3999516497713E-02
+(PID.TID 0000.0001) %MON dynstat_vvel_mean            =  -9.3663246407623E-07
 (PID.TID 0000.0001) %MON dynstat_vvel_sd              =   1.4391823694628E-02
-(PID.TID 0000.0001) %MON dynstat_vvel_del2            =   1.1414981902800E-05
-(PID.TID 0000.0001) %MON dynstat_wvel_max             =   2.0273193473633E+00
-(PID.TID 0000.0001) %MON dynstat_wvel_min             =  -2.0152823980812E+00
-(PID.TID 0000.0001) %MON dynstat_wvel_mean            =  -2.8941814892976E-16
-(PID.TID 0000.0001) %MON dynstat_wvel_sd              =   9.2459912032048E-01
-(PID.TID 0000.0001) %MON dynstat_wvel_del2            =   1.6769765728509E-03
+(PID.TID 0000.0001) %MON dynstat_vvel_del2            =   1.1414981903241E-05
+(PID.TID 0000.0001) %MON dynstat_wvel_max             =   2.0273193474806E+00
+(PID.TID 0000.0001) %MON dynstat_wvel_min             =  -2.0152823981483E+00
+(PID.TID 0000.0001) %MON dynstat_wvel_mean            =   1.4470907446488E-16
+(PID.TID 0000.0001) %MON dynstat_wvel_sd              =   9.2459912032085E-01
+(PID.TID 0000.0001) %MON dynstat_wvel_del2            =   1.6769765758859E-03
 (PID.TID 0000.0001) %MON dynstat_theta_max            =   2.0567993072705E+01
 (PID.TID 0000.0001) %MON dynstat_theta_min            =   1.5559960866952E+01
 (PID.TID 0000.0001) %MON dynstat_theta_mean           =   1.7563160570544E+01
 (PID.TID 0000.0001) %MON dynstat_theta_sd             =   1.4157852493998E+00
-(PID.TID 0000.0001) %MON dynstat_theta_del2           =   1.3767837677996E-04
+(PID.TID 0000.0001) %MON dynstat_theta_del2           =   1.3767837677968E-04
 (PID.TID 0000.0001) %MON dynstat_salt_max             =   9.9926540750464E-01
 (PID.TID 0000.0001) %MON dynstat_salt_min             =   3.9859171484714E-01
 (PID.TID 0000.0001) %MON dynstat_salt_mean            =   7.4692405578210E-01
 (PID.TID 0000.0001) %MON dynstat_salt_sd              =   1.9984282093316E-01
 (PID.TID 0000.0001) %MON dynstat_salt_del2            =   2.3718198004315E-04
-(PID.TID 0000.0001) %MON advcfl_uvel_max              =   4.9409034797662E-03
-(PID.TID 0000.0001) %MON advcfl_vvel_max              =   1.2855633592965E-02
-(PID.TID 0000.0001) %MON advcfl_wvel_max              =   3.6650260952415E-03
-(PID.TID 0000.0001) %MON advcfl_W_hf_max              =   3.8579222055173E-03
-(PID.TID 0000.0001) %MON pe_b_mean                    =   2.9973405295168E-07
-(PID.TID 0000.0001) %MON ke_max                       =   1.9776387038036E-03
-(PID.TID 0000.0001) %MON ke_mean                      =   1.2329090022054E-04
+(PID.TID 0000.0001) %MON advcfl_uvel_max              =   4.9409034797559E-03
+(PID.TID 0000.0001) %MON advcfl_vvel_max              =   1.2855633592935E-02
+(PID.TID 0000.0001) %MON advcfl_wvel_max              =   3.6650260954242E-03
+(PID.TID 0000.0001) %MON advcfl_W_hf_max              =   3.8579222057097E-03
+(PID.TID 0000.0001) %MON pe_b_mean                    =   2.9973405295138E-07
+(PID.TID 0000.0001) %MON ke_max                       =   1.9776387038046E-03
+(PID.TID 0000.0001) %MON ke_mean                      =   1.2329090022053E-04
 (PID.TID 0000.0001) %MON ke_vol                       =   7.6260000000000E+16
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // End MONITOR dynamic field statistics
 (PID.TID 0000.0001) // =======================================================
- cg2d: Sum(rhs),rhsMax =  -8.88178419700125E-15  1.81176307340763E-03
-(PID.TID 0000.0001)      cg2d_init_res =   5.23921614352472E-02
+ cg2d: Sum(rhs),rhsMax =   5.32907051820075E-15  1.81176307304235E-03
+(PID.TID 0000.0001)      cg2d_init_res =   5.23921613587815E-02
 (PID.TID 0000.0001)      cg2d_iters(min,last) =      -1      30
-(PID.TID 0000.0001)      cg2d_last_res =   1.19330765506988E-16
+(PID.TID 0000.0001)      cg2d_last_res =   1.01754489727288E-16
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // Begin MONITOR dynamic field statistics
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) %MON time_tsnumber                =                     6
 (PID.TID 0000.0001) %MON time_secondsf                =   1.0800000000000E+04
-(PID.TID 0000.0001) %MON dynstat_eta_max              =   1.7146627038158E+02
-(PID.TID 0000.0001) %MON dynstat_eta_min              =  -1.7070705994005E+02
-(PID.TID 0000.0001) %MON dynstat_eta_mean             =  -3.4408602150538E-14
-(PID.TID 0000.0001) %MON dynstat_eta_sd               =   1.2115998069727E+02
-(PID.TID 0000.0001) %MON dynstat_eta_del2             =   2.1127772661787E-01
-(PID.TID 0000.0001) %MON dynstat_uvel_max             =   3.8548686424649E-02
-(PID.TID 0000.0001) %MON dynstat_uvel_min             =  -9.4855768081957E-03
-(PID.TID 0000.0001) %MON dynstat_uvel_mean            =   4.4021398808002E-05
-(PID.TID 0000.0001) %MON dynstat_uvel_sd              =   9.6277027250580E-03
-(PID.TID 0000.0001) %MON dynstat_uvel_del2            =   1.4897191801506E-05
-(PID.TID 0000.0001) %MON dynstat_vvel_max             =   6.3205903956828E-02
-(PID.TID 0000.0001) %MON dynstat_vvel_min             =  -1.5650388123760E-02
-(PID.TID 0000.0001) %MON dynstat_vvel_mean            =  -5.7599379409277E-07
+(PID.TID 0000.0001) %MON dynstat_eta_max              =   1.7146627038142E+02
+(PID.TID 0000.0001) %MON dynstat_eta_min              =  -1.7070705993964E+02
+(PID.TID 0000.0001) %MON dynstat_eta_mean             =  -1.1698924731183E-13
+(PID.TID 0000.0001) %MON dynstat_eta_sd               =   1.2115998069724E+02
+(PID.TID 0000.0001) %MON dynstat_eta_del2             =   2.1127772662977E-01
+(PID.TID 0000.0001) %MON dynstat_uvel_max             =   3.8548686424614E-02
+(PID.TID 0000.0001) %MON dynstat_uvel_min             =  -9.4855768081635E-03
+(PID.TID 0000.0001) %MON dynstat_uvel_mean            =   4.4021398807959E-05
+(PID.TID 0000.0001) %MON dynstat_uvel_sd              =   9.6277027250574E-03
+(PID.TID 0000.0001) %MON dynstat_uvel_del2            =   1.4897191801243E-05
+(PID.TID 0000.0001) %MON dynstat_vvel_max             =   6.3205903956842E-02
+(PID.TID 0000.0001) %MON dynstat_vvel_min             =  -1.5650388123762E-02
+(PID.TID 0000.0001) %MON dynstat_vvel_mean            =  -5.7599379397755E-07
 (PID.TID 0000.0001) %MON dynstat_vvel_sd              =   1.6108616068936E-02
-(PID.TID 0000.0001) %MON dynstat_vvel_del2            =   1.2931906104909E-05
-(PID.TID 0000.0001) %MON dynstat_wvel_max             =   2.3033407626881E+00
-(PID.TID 0000.0001) %MON dynstat_wvel_min             =  -2.2797137333380E+00
-(PID.TID 0000.0001) %MON dynstat_wvel_mean            =   2.4118179077480E-16
-(PID.TID 0000.0001) %MON dynstat_wvel_sd              =   1.0347459237761E+00
-(PID.TID 0000.0001) %MON dynstat_wvel_del2            =   2.6201766303851E-03
+(PID.TID 0000.0001) %MON dynstat_vvel_del2            =   1.2931906105416E-05
+(PID.TID 0000.0001) %MON dynstat_wvel_max             =   2.3033407628885E+00
+(PID.TID 0000.0001) %MON dynstat_wvel_min             =  -2.2797137333472E+00
+(PID.TID 0000.0001) %MON dynstat_wvel_mean            =  -2.4118179077480E-16
+(PID.TID 0000.0001) %MON dynstat_wvel_sd              =   1.0347459237769E+00
+(PID.TID 0000.0001) %MON dynstat_wvel_del2            =   2.6201766332857E-03
 (PID.TID 0000.0001) %MON dynstat_theta_max            =   2.0567885337322E+01
 (PID.TID 0000.0001) %MON dynstat_theta_min            =   1.5559899832434E+01
 (PID.TID 0000.0001) %MON dynstat_theta_mean           =   1.7563160570544E+01
 (PID.TID 0000.0001) %MON dynstat_theta_sd             =   1.4157851047000E+00
-(PID.TID 0000.0001) %MON dynstat_theta_del2           =   1.3735774454564E-04
+(PID.TID 0000.0001) %MON dynstat_theta_del2           =   1.3735774454526E-04
 (PID.TID 0000.0001) %MON dynstat_salt_max             =   9.9912187903509E-01
 (PID.TID 0000.0001) %MON dynstat_salt_min             =   3.9926801202539E-01
 (PID.TID 0000.0001) %MON dynstat_salt_mean            =   7.4692405636155E-01
 (PID.TID 0000.0001) %MON dynstat_salt_sd              =   1.9968001009305E-01
 (PID.TID 0000.0001) %MON dynstat_salt_del2            =   2.3943854694173E-04
-(PID.TID 0000.0001) %MON advcfl_uvel_max              =   6.9387635564368E-03
-(PID.TID 0000.0001) %MON advcfl_vvel_max              =   1.4395404270800E-02
-(PID.TID 0000.0001) %MON advcfl_wvel_max              =   4.1711751754145E-03
-(PID.TID 0000.0001) %MON advcfl_W_hf_max              =   4.3907107109627E-03
-(PID.TID 0000.0001) %MON pe_b_mean                    =   2.9836871793827E-07
-(PID.TID 0000.0001) %MON ke_max                       =   2.7501448182271E-03
-(PID.TID 0000.0001) %MON ke_mean                      =   1.7139581457341E-04
+(PID.TID 0000.0001) %MON advcfl_uvel_max              =   6.9387635564304E-03
+(PID.TID 0000.0001) %MON advcfl_vvel_max              =   1.4395404270803E-02
+(PID.TID 0000.0001) %MON advcfl_wvel_max              =   4.1711751756881E-03
+(PID.TID 0000.0001) %MON advcfl_W_hf_max              =   4.3907107112506E-03
+(PID.TID 0000.0001) %MON pe_b_mean                    =   2.9836871793814E-07
+(PID.TID 0000.0001) %MON ke_max                       =   2.7501448182359E-03
+(PID.TID 0000.0001) %MON ke_mean                      =   1.7139581457340E-04
 (PID.TID 0000.0001) %MON ke_vol                       =   7.6260000000000E+16
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // End MONITOR dynamic field statistics
 (PID.TID 0000.0001) // =======================================================
- cg2d: Sum(rhs),rhsMax =   8.88178419700125E-15  1.85702183009131E-03
-(PID.TID 0000.0001)      cg2d_init_res =   8.03104770693050E-02
+ cg2d: Sum(rhs),rhsMax =   3.55271367880050E-15  1.85702182981272E-03
+(PID.TID 0000.0001)      cg2d_init_res =   8.03104774335096E-02
 (PID.TID 0000.0001)      cg2d_iters(min,last) =      -1      30
-(PID.TID 0000.0001)      cg2d_last_res =   1.60174376287133E-16
+(PID.TID 0000.0001)      cg2d_last_res =   1.38897834018212E-16
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // Begin MONITOR dynamic field statistics
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) %MON time_tsnumber                =                     7
 (PID.TID 0000.0001) %MON time_secondsf                =   1.2600000000000E+04
-(PID.TID 0000.0001) %MON dynstat_eta_max              =   1.7062161562338E+02
-(PID.TID 0000.0001) %MON dynstat_eta_min              =  -1.6969719574321E+02
-(PID.TID 0000.0001) %MON dynstat_eta_mean             =   2.7526881720430E-14
-(PID.TID 0000.0001) %MON dynstat_eta_sd               =   1.2047294267605E+02
-(PID.TID 0000.0001) %MON dynstat_eta_del2             =   2.0853440784010E-01
-(PID.TID 0000.0001) %MON dynstat_uvel_max             =   5.0650649172463E-02
-(PID.TID 0000.0001) %MON dynstat_uvel_min             =  -1.2479886237547E-02
-(PID.TID 0000.0001) %MON dynstat_uvel_mean            =   4.3958654234800E-05
+(PID.TID 0000.0001) %MON dynstat_eta_max              =   1.7062161562346E+02
+(PID.TID 0000.0001) %MON dynstat_eta_min              =  -1.6969719574304E+02
+(PID.TID 0000.0001) %MON dynstat_eta_mean             =  -1.5139784946237E-13
+(PID.TID 0000.0001) %MON dynstat_eta_sd               =   1.2047294267594E+02
+(PID.TID 0000.0001) %MON dynstat_eta_del2             =   2.0853440784180E-01
+(PID.TID 0000.0001) %MON dynstat_uvel_max             =   5.0650649172470E-02
+(PID.TID 0000.0001) %MON dynstat_uvel_min             =  -1.2479886237546E-02
+(PID.TID 0000.0001) %MON dynstat_uvel_mean            =   4.3958654234808E-05
 (PID.TID 0000.0001) %MON dynstat_uvel_sd              =   1.2653132614702E-02
-(PID.TID 0000.0001) %MON dynstat_uvel_del2            =   1.9566475742194E-05
-(PID.TID 0000.0001) %MON dynstat_vvel_max             =   6.7793530656845E-02
-(PID.TID 0000.0001) %MON dynstat_vvel_min             =  -1.6754009045325E-02
-(PID.TID 0000.0001) %MON dynstat_vvel_mean            =  -1.4290957149651E-06
-(PID.TID 0000.0001) %MON dynstat_vvel_sd              =   1.7269027416414E-02
-(PID.TID 0000.0001) %MON dynstat_vvel_del2            =   1.4083381741666E-05
-(PID.TID 0000.0001) %MON dynstat_wvel_max             =   2.5092715588648E+00
-(PID.TID 0000.0001) %MON dynstat_wvel_min             =  -2.4684710354764E+00
-(PID.TID 0000.0001) %MON dynstat_wvel_mean            =   2.4118179077480E-16
-(PID.TID 0000.0001) %MON dynstat_wvel_sd              =   1.1089868827658E+00
-(PID.TID 0000.0001) %MON dynstat_wvel_del2            =   3.6637575379888E-03
+(PID.TID 0000.0001) %MON dynstat_uvel_del2            =   1.9566475741956E-05
+(PID.TID 0000.0001) %MON dynstat_vvel_max             =   6.7793530656857E-02
+(PID.TID 0000.0001) %MON dynstat_vvel_min             =  -1.6754009045463E-02
+(PID.TID 0000.0001) %MON dynstat_vvel_mean            =  -1.4290957151490E-06
+(PID.TID 0000.0001) %MON dynstat_vvel_sd              =   1.7269027416413E-02
+(PID.TID 0000.0001) %MON dynstat_vvel_del2            =   1.4083381741776E-05
+(PID.TID 0000.0001) %MON dynstat_wvel_max             =   2.5092715589465E+00
+(PID.TID 0000.0001) %MON dynstat_wvel_min             =  -2.4684710354547E+00
+(PID.TID 0000.0001) %MON dynstat_wvel_mean            =  -3.8589086523967E-16
+(PID.TID 0000.0001) %MON dynstat_wvel_sd              =   1.1089868827662E+00
+(PID.TID 0000.0001) %MON dynstat_wvel_del2            =   3.6637575386470E-03
 (PID.TID 0000.0001) %MON dynstat_theta_max            =   2.0567774932738E+01
 (PID.TID 0000.0001) %MON dynstat_theta_min            =   1.5559762606291E+01
 (PID.TID 0000.0001) %MON dynstat_theta_mean           =   1.7563160570546E+01
 (PID.TID 0000.0001) %MON dynstat_theta_sd             =   1.4157849596426E+00
-(PID.TID 0000.0001) %MON dynstat_theta_del2           =   1.3695645727560E-04
+(PID.TID 0000.0001) %MON dynstat_theta_del2           =   1.3695645727521E-04
 (PID.TID 0000.0001) %MON dynstat_salt_max             =   9.9897872228992E-01
 (PID.TID 0000.0001) %MON dynstat_salt_min             =   3.9993184206859E-01
 (PID.TID 0000.0001) %MON dynstat_salt_mean            =   7.4692405685115E-01
 (PID.TID 0000.0001) %MON dynstat_salt_sd              =   1.9951761106423E-01
 (PID.TID 0000.0001) %MON dynstat_salt_del2            =   2.4178513470016E-04
-(PID.TID 0000.0001) %MON advcfl_uvel_max              =   9.1171168510433E-03
-(PID.TID 0000.0001) %MON advcfl_vvel_max              =   1.5440255097321E-02
-(PID.TID 0000.0001) %MON advcfl_wvel_max              =   4.5570724670274E-03
-(PID.TID 0000.0001) %MON advcfl_W_hf_max              =   4.7969183863447E-03
-(PID.TID 0000.0001) %MON pe_b_mean                    =   2.9499451050869E-07
-(PID.TID 0000.0001) %MON ke_max                       =   3.5915437287049E-03
-(PID.TID 0000.0001) %MON ke_mean                      =   2.2376543931776E-04
+(PID.TID 0000.0001) %MON advcfl_uvel_max              =   9.1171168510445E-03
+(PID.TID 0000.0001) %MON advcfl_vvel_max              =   1.5440255097323E-02
+(PID.TID 0000.0001) %MON advcfl_wvel_max              =   4.5570724671361E-03
+(PID.TID 0000.0001) %MON advcfl_W_hf_max              =   4.7969183864590E-03
+(PID.TID 0000.0001) %MON pe_b_mean                    =   2.9499451050814E-07
+(PID.TID 0000.0001) %MON ke_max                       =   3.5915437287204E-03
+(PID.TID 0000.0001) %MON ke_mean                      =   2.2376543931773E-04
 (PID.TID 0000.0001) %MON ke_vol                       =   7.6260000000000E+16
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // End MONITOR dynamic field statistics
 (PID.TID 0000.0001) // =======================================================
- cg2d: Sum(rhs),rhsMax =   2.66453525910038E-15  1.92068363228977E-03
-(PID.TID 0000.0001)      cg2d_init_res =   1.03272271221930E-01
+ cg2d: Sum(rhs),rhsMax =   4.44089209850063E-15  1.92068363206234E-03
+(PID.TID 0000.0001)      cg2d_init_res =   1.03272271089706E-01
 (PID.TID 0000.0001)      cg2d_iters(min,last) =      -1      30
-(PID.TID 0000.0001)      cg2d_last_res =   1.46278461600160E-16
+(PID.TID 0000.0001)      cg2d_last_res =   1.01399611884223E-16
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // Begin MONITOR dynamic field statistics
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) %MON time_tsnumber                =                     8
 (PID.TID 0000.0001) %MON time_secondsf                =   1.4400000000000E+04
-(PID.TID 0000.0001) %MON dynstat_eta_max              =   1.6957890621084E+02
-(PID.TID 0000.0001) %MON dynstat_eta_min              =  -1.6854186760531E+02
-(PID.TID 0000.0001) %MON dynstat_eta_mean             =   4.1290322580645E-14
-(PID.TID 0000.0001) %MON dynstat_eta_sd               =   1.1965136905275E+02
-(PID.TID 0000.0001) %MON dynstat_eta_del2             =   2.0515677936450E-01
-(PID.TID 0000.0001) %MON dynstat_uvel_max             =   6.3341686974912E-02
-(PID.TID 0000.0001) %MON dynstat_uvel_min             =  -1.5613364457396E-02
-(PID.TID 0000.0001) %MON dynstat_uvel_mean            =   4.3619828205669E-05
-(PID.TID 0000.0001) %MON dynstat_uvel_sd              =   1.5824264445281E-02
-(PID.TID 0000.0001) %MON dynstat_uvel_del2            =   2.4467108016958E-05
-(PID.TID 0000.0001) %MON dynstat_vvel_max             =   7.0069671472203E-02
-(PID.TID 0000.0001) %MON dynstat_vvel_min             =  -1.7273113772034E-02
-(PID.TID 0000.0001) %MON dynstat_vvel_mean            =  -1.7086118511955E-06
-(PID.TID 0000.0001) %MON dynstat_vvel_sd              =   1.7837258747113E-02
-(PID.TID 0000.0001) %MON dynstat_vvel_del2            =   1.4837752413357E-05
-(PID.TID 0000.0001) %MON dynstat_wvel_max             =   2.6358793601630E+00
-(PID.TID 0000.0001) %MON dynstat_wvel_min             =  -2.5722210459860E+00
-(PID.TID 0000.0001) %MON dynstat_wvel_mean            =  -3.8589086523967E-16
-(PID.TID 0000.0001) %MON dynstat_wvel_sd              =   1.1451965170178E+00
-(PID.TID 0000.0001) %MON dynstat_wvel_del2            =   4.7065502137876E-03
+(PID.TID 0000.0001) %MON dynstat_eta_max              =   1.6957890621101E+02
+(PID.TID 0000.0001) %MON dynstat_eta_min              =  -1.6854186760580E+02
+(PID.TID 0000.0001) %MON dynstat_eta_mean             =  -1.2387096774194E-13
+(PID.TID 0000.0001) %MON dynstat_eta_sd               =   1.1965136905266E+02
+(PID.TID 0000.0001) %MON dynstat_eta_del2             =   2.0515677936079E-01
+(PID.TID 0000.0001) %MON dynstat_uvel_max             =   6.3341686974967E-02
+(PID.TID 0000.0001) %MON dynstat_uvel_min             =  -1.5613364457432E-02
+(PID.TID 0000.0001) %MON dynstat_uvel_mean            =   4.3619828205614E-05
+(PID.TID 0000.0001) %MON dynstat_uvel_sd              =   1.5824264445280E-02
+(PID.TID 0000.0001) %MON dynstat_uvel_del2            =   2.4467108016822E-05
+(PID.TID 0000.0001) %MON dynstat_vvel_max             =   7.0069671472459E-02
+(PID.TID 0000.0001) %MON dynstat_vvel_min             =  -1.7273113772338E-02
+(PID.TID 0000.0001) %MON dynstat_vvel_mean            =  -1.7086118511052E-06
+(PID.TID 0000.0001) %MON dynstat_vvel_sd              =   1.7837258747112E-02
+(PID.TID 0000.0001) %MON dynstat_vvel_del2            =   1.4837752413686E-05
+(PID.TID 0000.0001) %MON dynstat_wvel_max             =   2.6358793603304E+00
+(PID.TID 0000.0001) %MON dynstat_wvel_min             =  -2.5722210459131E+00
+(PID.TID 0000.0001) %MON dynstat_wvel_mean            =   9.6472716309919E-17
+(PID.TID 0000.0001) %MON dynstat_wvel_sd              =   1.1451965170185E+00
+(PID.TID 0000.0001) %MON dynstat_wvel_del2            =   4.7065502153293E-03
 (PID.TID 0000.0001) %MON dynstat_theta_max            =   2.0567664068042E+01
 (PID.TID 0000.0001) %MON dynstat_theta_min            =   1.5559621499641E+01
 (PID.TID 0000.0001) %MON dynstat_theta_mean           =   1.7563160570551E+01
 (PID.TID 0000.0001) %MON dynstat_theta_sd             =   1.4157848143980E+00
-(PID.TID 0000.0001) %MON dynstat_theta_del2           =   1.3648266930323E-04
+(PID.TID 0000.0001) %MON dynstat_theta_del2           =   1.3648266930283E-04
 (PID.TID 0000.0001) %MON dynstat_salt_max             =   9.9883580481001E-01
 (PID.TID 0000.0001) %MON dynstat_salt_min             =   4.0058461344134E-01
 (PID.TID 0000.0001) %MON dynstat_salt_mean            =   7.4692405719183E-01
 (PID.TID 0000.0001) %MON dynstat_salt_sd              =   1.9935561552451E-01
-(PID.TID 0000.0001) %MON dynstat_salt_del2            =   2.4419814121783E-04
-(PID.TID 0000.0001) %MON advcfl_uvel_max              =   1.1401503655484E-02
-(PID.TID 0000.0001) %MON advcfl_vvel_max              =   1.5958655518217E-02
-(PID.TID 0000.0001) %MON advcfl_wvel_max              =   4.8077796005404E-03
-(PID.TID 0000.0001) %MON advcfl_W_hf_max              =   5.0608206321478E-03
-(PID.TID 0000.0001) %MON pe_b_mean                    =   2.9098475845928E-07
-(PID.TID 0000.0001) %MON ke_max                       =   4.4721832105306E-03
-(PID.TID 0000.0001) %MON ke_mean                      =   2.7853150725290E-04
+(PID.TID 0000.0001) %MON dynstat_salt_del2            =   2.4419814121784E-04
+(PID.TID 0000.0001) %MON advcfl_uvel_max              =   1.1401503655494E-02
+(PID.TID 0000.0001) %MON advcfl_vvel_max              =   1.5958655518275E-02
+(PID.TID 0000.0001) %MON advcfl_wvel_max              =   4.8077796007409E-03
+(PID.TID 0000.0001) %MON advcfl_W_hf_max              =   5.0608206323588E-03
+(PID.TID 0000.0001) %MON pe_b_mean                    =   2.9098475845888E-07
+(PID.TID 0000.0001) %MON ke_max                       =   4.4721832105508E-03
+(PID.TID 0000.0001) %MON ke_mean                      =   2.7853150725286E-04
 (PID.TID 0000.0001) %MON ke_vol                       =   7.6260000000000E+16
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // End MONITOR dynamic field statistics
 (PID.TID 0000.0001) // =======================================================
- cg2d: Sum(rhs),rhsMax =   5.32907051820075E-15  2.00767794533427E-03
-(PID.TID 0000.0001)      cg2d_init_res =   1.17542337143664E-01
+ cg2d: Sum(rhs),rhsMax =  -8.88178419700125E-16  2.00767794590281E-03
+(PID.TID 0000.0001)      cg2d_init_res =   1.17542337640392E-01
 (PID.TID 0000.0001)      cg2d_iters(min,last) =      -1      30
-(PID.TID 0000.0001)      cg2d_last_res =   1.51047590988818E-16
+(PID.TID 0000.0001)      cg2d_last_res =   8.81798906100943E-17
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // Begin MONITOR dynamic field statistics
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) %MON time_tsnumber                =                     9
 (PID.TID 0000.0001) %MON time_secondsf                =   1.6200000000000E+04
-(PID.TID 0000.0001) %MON dynstat_eta_max              =   1.6851227221442E+02
-(PID.TID 0000.0001) %MON dynstat_eta_min              =  -1.6742761184911E+02
-(PID.TID 0000.0001) %MON dynstat_eta_mean             =  -6.8817204301075E-14
-(PID.TID 0000.0001) %MON dynstat_eta_sd               =   1.1882361550136E+02
-(PID.TID 0000.0001) %MON dynstat_eta_del2             =   2.0157514876939E-01
-(PID.TID 0000.0001) %MON dynstat_uvel_max             =   7.6190652891436E-02
-(PID.TID 0000.0001) %MON dynstat_uvel_min             =  -1.8776765248731E-02
-(PID.TID 0000.0001) %MON dynstat_uvel_mean            =   4.3292320814188E-05
-(PID.TID 0000.0001) %MON dynstat_uvel_sd              =   1.9032730139995E-02
-(PID.TID 0000.0001) %MON dynstat_uvel_del2            =   2.9436534210560E-05
-(PID.TID 0000.0001) %MON dynstat_vvel_max             =   6.9971441801809E-02
-(PID.TID 0000.0001) %MON dynstat_vvel_min             =  -1.7193906019946E-02
-(PID.TID 0000.0001) %MON dynstat_vvel_mean            =  -1.7209787468669E-06
-(PID.TID 0000.0001) %MON dynstat_vvel_sd              =   1.7797787767063E-02
-(PID.TID 0000.0001) %MON dynstat_vvel_del2            =   1.5174480465576E-05
-(PID.TID 0000.0001) %MON dynstat_wvel_max             =   2.6759947869248E+00
-(PID.TID 0000.0001) %MON dynstat_wvel_min             =  -2.5847676347134E+00
-(PID.TID 0000.0001) %MON dynstat_wvel_mean            =   1.4470907446488E-16
-(PID.TID 0000.0001) %MON dynstat_wvel_sd              =   1.1423498383565E+00
-(PID.TID 0000.0001) %MON dynstat_wvel_del2            =   5.6563430846361E-03
+(PID.TID 0000.0001) %MON dynstat_eta_max              =   1.6851227221377E+02
+(PID.TID 0000.0001) %MON dynstat_eta_min              =  -1.6742761184932E+02
+(PID.TID 0000.0001) %MON dynstat_eta_mean             =  -1.5827956989247E-13
+(PID.TID 0000.0001) %MON dynstat_eta_sd               =   1.1882361550129E+02
+(PID.TID 0000.0001) %MON dynstat_eta_del2             =   2.0157514876996E-01
+(PID.TID 0000.0001) %MON dynstat_uvel_max             =   7.6190652891535E-02
+(PID.TID 0000.0001) %MON dynstat_uvel_min             =  -1.8776765248781E-02
+(PID.TID 0000.0001) %MON dynstat_uvel_mean            =   4.3292320814175E-05
+(PID.TID 0000.0001) %MON dynstat_uvel_sd              =   1.9032730139994E-02
+(PID.TID 0000.0001) %MON dynstat_uvel_del2            =   2.9436534210399E-05
+(PID.TID 0000.0001) %MON dynstat_vvel_max             =   6.9971441802078E-02
+(PID.TID 0000.0001) %MON dynstat_vvel_min             =  -1.7193906020193E-02
+(PID.TID 0000.0001) %MON dynstat_vvel_mean            =  -1.7209787469041E-06
+(PID.TID 0000.0001) %MON dynstat_vvel_sd              =   1.7797787767062E-02
+(PID.TID 0000.0001) %MON dynstat_vvel_del2            =   1.5174480465819E-05
+(PID.TID 0000.0001) %MON dynstat_wvel_max             =   2.6759947871183E+00
+(PID.TID 0000.0001) %MON dynstat_wvel_min             =  -2.5847676345400E+00
+(PID.TID 0000.0001) %MON dynstat_wvel_mean            =  -2.8941814892976E-16
+(PID.TID 0000.0001) %MON dynstat_wvel_sd              =   1.1423498383570E+00
+(PID.TID 0000.0001) %MON dynstat_wvel_del2            =   5.6563430856278E-03
 (PID.TID 0000.0001) %MON dynstat_theta_max            =   2.0567554920852E+01
 (PID.TID 0000.0001) %MON dynstat_theta_min            =   1.5559482256640E+01
 (PID.TID 0000.0001) %MON dynstat_theta_mean           =   1.7563160570560E+01
 (PID.TID 0000.0001) %MON dynstat_theta_sd             =   1.4157846691534E+00
-(PID.TID 0000.0001) %MON dynstat_theta_del2           =   1.3595171243330E-04
+(PID.TID 0000.0001) %MON dynstat_theta_del2           =   1.3595171243295E-04
 (PID.TID 0000.0001) %MON dynstat_salt_max             =   9.9869315599510E-01
 (PID.TID 0000.0001) %MON dynstat_salt_min             =   4.0122766905873E-01
 (PID.TID 0000.0001) %MON dynstat_salt_mean            =   7.4692405734524E-01
 (PID.TID 0000.0001) %MON dynstat_salt_sd              =   1.9919401508671E-01
 (PID.TID 0000.0001) %MON dynstat_salt_del2            =   2.4665708669155E-04
-(PID.TID 0000.0001) %MON advcfl_uvel_max              =   1.3714317520458E-02
-(PID.TID 0000.0001) %MON advcfl_vvel_max              =   1.5936283307265E-02
-(PID.TID 0000.0001) %MON advcfl_wvel_max              =   4.9117896055709E-03
-(PID.TID 0000.0001) %MON advcfl_W_hf_max              =   5.1703048479693E-03
-(PID.TID 0000.0001) %MON pe_b_mean                    =   2.8697259351250E-07
-(PID.TID 0000.0001) %MON ke_max                       =   5.3613284217760E-03
-(PID.TID 0000.0001) %MON ke_mean                      =   3.3377240412627E-04
+(PID.TID 0000.0001) %MON advcfl_uvel_max              =   1.3714317520476E-02
+(PID.TID 0000.0001) %MON advcfl_vvel_max              =   1.5936283307327E-02
+(PID.TID 0000.0001) %MON advcfl_wvel_max              =   4.9117896057939E-03
+(PID.TID 0000.0001) %MON advcfl_W_hf_max              =   5.1703048482041E-03
+(PID.TID 0000.0001) %MON pe_b_mean                    =   2.8697259351217E-07
+(PID.TID 0000.0001) %MON ke_max                       =   5.3613284217963E-03
+(PID.TID 0000.0001) %MON ke_mean                      =   3.3377240412623E-04
 (PID.TID 0000.0001) %MON ke_vol                       =   7.6260000000000E+16
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // End MONITOR dynamic field statistics
 (PID.TID 0000.0001) // =======================================================
- cg2d: Sum(rhs),rhsMax =  -6.21724893790088E-15  2.10979449086484E-03
-(PID.TID 0000.0001)      cg2d_init_res =   1.21708886741114E-01
+ cg2d: Sum(rhs),rhsMax =   5.32907051820075E-15  2.10979449084994E-03
+(PID.TID 0000.0001)      cg2d_init_res =   1.21708886611215E-01
 (PID.TID 0000.0001)      cg2d_iters(min,last) =      -1      30
-(PID.TID 0000.0001)      cg2d_last_res =   9.70508069372864E-17
+(PID.TID 0000.0001)      cg2d_last_res =   3.06645805953272E-16
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // Begin MONITOR dynamic field statistics
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) %MON time_tsnumber                =                    10
 (PID.TID 0000.0001) %MON time_secondsf                =   1.8000000000000E+04
-(PID.TID 0000.0001) %MON dynstat_eta_max              =   1.6744604951625E+02
-(PID.TID 0000.0001) %MON dynstat_eta_min              =  -1.6638190324300E+02
-(PID.TID 0000.0001) %MON dynstat_eta_mean             =   2.7526881720430E-14
-(PID.TID 0000.0001) %MON dynstat_eta_sd               =   1.1801018986779E+02
-(PID.TID 0000.0001) %MON dynstat_eta_del2             =   1.9804043350106E-01
-(PID.TID 0000.0001) %MON dynstat_uvel_max             =   8.8763393351199E-02
-(PID.TID 0000.0001) %MON dynstat_uvel_min             =  -2.1860922145387E-02
-(PID.TID 0000.0001) %MON dynstat_uvel_mean            =   4.2990673472703E-05
-(PID.TID 0000.0001) %MON dynstat_uvel_sd              =   2.2169580158985E-02
-(PID.TID 0000.0001) %MON dynstat_uvel_del2            =   3.4310039854964E-05
-(PID.TID 0000.0001) %MON dynstat_vvel_max             =   6.7516461746005E-02
-(PID.TID 0000.0001) %MON dynstat_vvel_min             =  -1.6523138580768E-02
-(PID.TID 0000.0001) %MON dynstat_vvel_mean            =  -1.6906735003273E-06
-(PID.TID 0000.0001) %MON dynstat_vvel_sd              =   1.7155770154029E-02
-(PID.TID 0000.0001) %MON dynstat_vvel_del2            =   1.5091050542333E-05
-(PID.TID 0000.0001) %MON dynstat_wvel_max             =   2.6255446161573E+00
-(PID.TID 0000.0001) %MON dynstat_wvel_min             =  -2.5041423022774E+00
+(PID.TID 0000.0001) %MON dynstat_eta_max              =   1.6744604951669E+02
+(PID.TID 0000.0001) %MON dynstat_eta_min              =  -1.6638190324284E+02
+(PID.TID 0000.0001) %MON dynstat_eta_mean             =  -1.8580645161290E-13
+(PID.TID 0000.0001) %MON dynstat_eta_sd               =   1.1801018986774E+02
+(PID.TID 0000.0001) %MON dynstat_eta_del2             =   1.9804043349849E-01
+(PID.TID 0000.0001) %MON dynstat_uvel_max             =   8.8763393351323E-02
+(PID.TID 0000.0001) %MON dynstat_uvel_min             =  -2.1860922145448E-02
+(PID.TID 0000.0001) %MON dynstat_uvel_mean            =   4.2990673472668E-05
+(PID.TID 0000.0001) %MON dynstat_uvel_sd              =   2.2169580158984E-02
+(PID.TID 0000.0001) %MON dynstat_uvel_del2            =   3.4310039854824E-05
+(PID.TID 0000.0001) %MON dynstat_vvel_max             =   6.7516461746198E-02
+(PID.TID 0000.0001) %MON dynstat_vvel_min             =  -1.6523138580963E-02
+(PID.TID 0000.0001) %MON dynstat_vvel_mean            =  -1.6906735002500E-06
+(PID.TID 0000.0001) %MON dynstat_vvel_sd              =   1.7155770154028E-02
+(PID.TID 0000.0001) %MON dynstat_vvel_del2            =   1.5091050542365E-05
+(PID.TID 0000.0001) %MON dynstat_wvel_max             =   2.6255446162115E+00
+(PID.TID 0000.0001) %MON dynstat_wvel_min             =  -2.5041423021633E+00
 (PID.TID 0000.0001) %MON dynstat_wvel_mean            =  -1.4470907446488E-16
-(PID.TID 0000.0001) %MON dynstat_wvel_sd              =   1.1007607671130E+00
-(PID.TID 0000.0001) %MON dynstat_wvel_del2            =   6.4441684028818E-03
+(PID.TID 0000.0001) %MON dynstat_wvel_sd              =   1.1007607671129E+00
+(PID.TID 0000.0001) %MON dynstat_wvel_del2            =   6.4441684028683E-03
 (PID.TID 0000.0001) %MON dynstat_theta_max            =   2.0567449558545E+01
 (PID.TID 0000.0001) %MON dynstat_theta_min            =   1.5559350600078E+01
 (PID.TID 0000.0001) %MON dynstat_theta_mean           =   1.7563160570572E+01
 (PID.TID 0000.0001) %MON dynstat_theta_sd             =   1.4157845240931E+00
-(PID.TID 0000.0001) %MON dynstat_theta_del2           =   1.3538324712410E-04
-(PID.TID 0000.0001) %MON dynstat_salt_max             =   9.9855097341914E-01
-(PID.TID 0000.0001) %MON dynstat_salt_min             =   4.0186225341199E-01
+(PID.TID 0000.0001) %MON dynstat_theta_del2           =   1.3538324712382E-04
+(PID.TID 0000.0001) %MON dynstat_salt_max             =   9.9855097341913E-01
+(PID.TID 0000.0001) %MON dynstat_salt_min             =   4.0186225341200E-01
 (PID.TID 0000.0001) %MON dynstat_salt_mean            =   7.4692405729774E-01
 (PID.TID 0000.0001) %MON dynstat_salt_sd              =   1.9903280127770E-01
-(PID.TID 0000.0001) %MON dynstat_salt_del2            =   2.4914427913657E-04
-(PID.TID 0000.0001) %MON advcfl_uvel_max              =   1.5977410803216E-02
-(PID.TID 0000.0001) %MON advcfl_vvel_max              =   1.5377151514701E-02
-(PID.TID 0000.0001) %MON advcfl_wvel_max              =   4.8623407263266E-03
-(PID.TID 0000.0001) %MON advcfl_W_hf_max              =   5.1182533961332E-03
-(PID.TID 0000.0001) %MON pe_b_mean                    =   2.8305701041935E-07
-(PID.TID 0000.0001) %MON ke_max                       =   6.2284057106436E-03
-(PID.TID 0000.0001) %MON ke_mean                      =   3.8758077523562E-04
+(PID.TID 0000.0001) %MON dynstat_salt_del2            =   2.4914427913656E-04
+(PID.TID 0000.0001) %MON advcfl_uvel_max              =   1.5977410803238E-02
+(PID.TID 0000.0001) %MON advcfl_vvel_max              =   1.5377151514745E-02
+(PID.TID 0000.0001) %MON advcfl_wvel_max              =   4.8623407263880E-03
+(PID.TID 0000.0001) %MON advcfl_W_hf_max              =   5.1182533961979E-03
+(PID.TID 0000.0001) %MON pe_b_mean                    =   2.8305701041910E-07
+(PID.TID 0000.0001) %MON ke_max                       =   6.2284057106632E-03
+(PID.TID 0000.0001) %MON ke_mean                      =   3.8758077523558E-04
 (PID.TID 0000.0001) %MON ke_vol                       =   7.6260000000000E+16
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // End MONITOR dynamic field statistics
 (PID.TID 0000.0001) // =======================================================
- cg2d: Sum(rhs),rhsMax =  -5.32907051820075E-15  2.21470261040231E-03
-(PID.TID 0000.0001)      cg2d_init_res =   1.16126551392946E-01
+ cg2d: Sum(rhs),rhsMax =  -8.88178419700125E-16  2.21470261023342E-03
+(PID.TID 0000.0001)      cg2d_init_res =   1.16126551270310E-01
 (PID.TID 0000.0001)      cg2d_iters(min,last) =      -1      30
-(PID.TID 0000.0001)      cg2d_last_res =   2.05387146711161E-16
+(PID.TID 0000.0001)      cg2d_last_res =   2.04966487220742E-16
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // Begin MONITOR dynamic field statistics
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) %MON time_tsnumber                =                    11
 (PID.TID 0000.0001) %MON time_secondsf                =   1.9800000000000E+04
-(PID.TID 0000.0001) %MON dynstat_eta_max              =   1.6640115727114E+02
-(PID.TID 0000.0001) %MON dynstat_eta_min              =  -1.6541948970840E+02
-(PID.TID 0000.0001) %MON dynstat_eta_mean             =   8.2580645161290E-14
-(PID.TID 0000.0001) %MON dynstat_eta_sd               =   1.1722721289682E+02
-(PID.TID 0000.0001) %MON dynstat_eta_del2             =   1.9472599565584E-01
-(PID.TID 0000.0001) %MON dynstat_uvel_max             =   1.0063779015410E-01
-(PID.TID 0000.0001) %MON dynstat_uvel_min             =  -2.4760130851510E-02
-(PID.TID 0000.0001) %MON dynstat_uvel_mean            =   4.2698814891197E-05
-(PID.TID 0000.0001) %MON dynstat_uvel_sd              =   2.5128975579606E-02
-(PID.TID 0000.0001) %MON dynstat_uvel_del2            =   3.8925575334796E-05
-(PID.TID 0000.0001) %MON dynstat_vvel_max             =   6.2801988248762E-02
-(PID.TID 0000.0001) %MON dynstat_vvel_min             =  -1.5287569615254E-02
-(PID.TID 0000.0001) %MON dynstat_vvel_mean            =  -1.6269036116907E-06
+(PID.TID 0000.0001) %MON dynstat_eta_max              =   1.6640115727132E+02
+(PID.TID 0000.0001) %MON dynstat_eta_min              =  -1.6541948970819E+02
+(PID.TID 0000.0001) %MON dynstat_eta_mean             =  -5.5053763440860E-14
+(PID.TID 0000.0001) %MON dynstat_eta_sd               =   1.1722721289683E+02
+(PID.TID 0000.0001) %MON dynstat_eta_del2             =   1.9472599565271E-01
+(PID.TID 0000.0001) %MON dynstat_uvel_max             =   1.0063779015424E-01
+(PID.TID 0000.0001) %MON dynstat_uvel_min             =  -2.4760130851584E-02
+(PID.TID 0000.0001) %MON dynstat_uvel_mean            =   4.2698814891196E-05
+(PID.TID 0000.0001) %MON dynstat_uvel_sd              =   2.5128975579604E-02
+(PID.TID 0000.0001) %MON dynstat_uvel_del2            =   3.8925575334653E-05
+(PID.TID 0000.0001) %MON dynstat_vvel_max             =   6.2801988248861E-02
+(PID.TID 0000.0001) %MON dynstat_vvel_min             =  -1.5287569615317E-02
+(PID.TID 0000.0001) %MON dynstat_vvel_mean            =  -1.6269036115829E-06
 (PID.TID 0000.0001) %MON dynstat_vvel_sd              =   1.5936741433760E-02
-(PID.TID 0000.0001) %MON dynstat_vvel_del2            =   1.4608500232142E-05
-(PID.TID 0000.0001) %MON dynstat_wvel_max             =   2.4841541149112E+00
-(PID.TID 0000.0001) %MON dynstat_wvel_min             =  -2.3334098263994E+00
-(PID.TID 0000.0001) %MON dynstat_wvel_mean            =  -3.8589086523967E-16
-(PID.TID 0000.0001) %MON dynstat_wvel_sd              =   1.0220863819325E+00
-(PID.TID 0000.0001) %MON dynstat_wvel_del2            =   7.0310101190590E-03
+(PID.TID 0000.0001) %MON dynstat_vvel_del2            =   1.4608500232078E-05
+(PID.TID 0000.0001) %MON dynstat_wvel_max             =   2.4841541148262E+00
+(PID.TID 0000.0001) %MON dynstat_wvel_min             =  -2.3334098263497E+00
+(PID.TID 0000.0001) %MON dynstat_wvel_mean            =  -5.7883629785951E-16
+(PID.TID 0000.0001) %MON dynstat_wvel_sd              =   1.0220863819313E+00
+(PID.TID 0000.0001) %MON dynstat_wvel_del2            =   7.0310101183186E-03
 (PID.TID 0000.0001) %MON dynstat_theta_max            =   2.0567349868678E+01
-(PID.TID 0000.0001) %MON dynstat_theta_min            =   1.5559231851695E+01
+(PID.TID 0000.0001) %MON dynstat_theta_min            =   1.5559231851694E+01
 (PID.TID 0000.0001) %MON dynstat_theta_mean           =   1.7563160570586E+01
 (PID.TID 0000.0001) %MON dynstat_theta_sd             =   1.4157843793816E+00
-(PID.TID 0000.0001) %MON dynstat_theta_del2           =   1.3479833513296E-04
+(PID.TID 0000.0001) %MON dynstat_theta_del2           =   1.3479833513279E-04
 (PID.TID 0000.0001) %MON dynstat_salt_max             =   9.9840960769865E-01
 (PID.TID 0000.0001) %MON dynstat_salt_min             =   4.0248948739711E-01
 (PID.TID 0000.0001) %MON dynstat_salt_mean            =   7.4692405706245E-01
 (PID.TID 0000.0001) %MON dynstat_salt_sd              =   1.9887196553651E-01
 (PID.TID 0000.0001) %MON dynstat_salt_del2            =   2.5164450137979E-04
-(PID.TID 0000.0001) %MON advcfl_uvel_max              =   1.8114802227737E-02
-(PID.TID 0000.0001) %MON advcfl_vvel_max              =   1.4303410809036E-02
-(PID.TID 0000.0001) %MON advcfl_wvel_max              =   4.6582348299204E-03
-(PID.TID 0000.0001) %MON advcfl_W_hf_max              =   4.9034050841268E-03
-(PID.TID 0000.0001) %MON pe_b_mean                    =   2.7931340332433E-07
-(PID.TID 0000.0001) %MON ke_max                       =   7.0440623750368E-03
-(PID.TID 0000.0001) %MON ke_mean                      =   4.3812790263570E-04
+(PID.TID 0000.0001) %MON advcfl_uvel_max              =   1.8114802227762E-02
+(PID.TID 0000.0001) %MON advcfl_vvel_max              =   1.4303410809058E-02
+(PID.TID 0000.0001) %MON advcfl_wvel_max              =   4.6582348298416E-03
+(PID.TID 0000.0001) %MON advcfl_W_hf_max              =   4.9034050840438E-03
+(PID.TID 0000.0001) %MON pe_b_mean                    =   2.7931340332438E-07
+(PID.TID 0000.0001) %MON ke_max                       =   7.0440623750560E-03
+(PID.TID 0000.0001) %MON ke_mean                      =   4.3812790263566E-04
 (PID.TID 0000.0001) %MON ke_vol                       =   7.6260000000000E+16
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // End MONITOR dynamic field statistics
 (PID.TID 0000.0001) // =======================================================
- cg2d: Sum(rhs),rhsMax =   8.88178419700125E-16  2.31258381970829E-03
-(PID.TID 0000.0001)      cg2d_init_res =   1.02647610767646E-01
+ cg2d: Sum(rhs),rhsMax =  -2.66453525910038E-15  2.31258381938983E-03
+(PID.TID 0000.0001)      cg2d_init_res =   1.02647610616094E-01
 (PID.TID 0000.0001)      cg2d_iters(min,last) =      -1      30
-(PID.TID 0000.0001)      cg2d_last_res =   3.02024585361620E-16
+(PID.TID 0000.0001)      cg2d_last_res =   2.89123950323737E-16
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // Begin MONITOR dynamic field statistics
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) %MON time_tsnumber                =                    12
 (PID.TID 0000.0001) %MON time_secondsf                =   2.1600000000000E+04
-(PID.TID 0000.0001) %MON dynstat_eta_max              =   1.6541337291639E+02
-(PID.TID 0000.0001) %MON dynstat_eta_min              =  -1.6456195982533E+02
-(PID.TID 0000.0001) %MON dynstat_eta_mean             =   1.3075268817204E-13
-(PID.TID 0000.0001) %MON dynstat_eta_sd               =   1.1649939501851E+02
-(PID.TID 0000.0001) %MON dynstat_eta_del2             =   1.9171185917877E-01
-(PID.TID 0000.0001) %MON dynstat_uvel_max             =   1.1141799830391E-01
-(PID.TID 0000.0001) %MON dynstat_uvel_min             =  -2.7375687568538E-02
-(PID.TID 0000.0001) %MON dynstat_uvel_mean            =   4.2421614525171E-05
-(PID.TID 0000.0001) %MON dynstat_uvel_sd              =   2.7811751285446E-02
-(PID.TID 0000.0001) %MON dynstat_uvel_del2            =   4.3128594729693E-05
-(PID.TID 0000.0001) %MON dynstat_vvel_max             =   5.6000878517945E-02
-(PID.TID 0000.0001) %MON dynstat_vvel_min             =  -1.3533203385606E-02
-(PID.TID 0000.0001) %MON dynstat_vvel_mean            =  -1.5118575219017E-06
+(PID.TID 0000.0001) %MON dynstat_eta_max              =   1.6541337291637E+02
+(PID.TID 0000.0001) %MON dynstat_eta_min              =  -1.6456195982543E+02
+(PID.TID 0000.0001) %MON dynstat_eta_mean             =  -4.8172043010753E-14
+(PID.TID 0000.0001) %MON dynstat_eta_sd               =   1.1649939501852E+02
+(PID.TID 0000.0001) %MON dynstat_eta_del2             =   1.9171185917868E-01
+(PID.TID 0000.0001) %MON dynstat_uvel_max             =   1.1141799830406E-01
+(PID.TID 0000.0001) %MON dynstat_uvel_min             =  -2.7375687568624E-02
+(PID.TID 0000.0001) %MON dynstat_uvel_mean            =   4.2421614525175E-05
+(PID.TID 0000.0001) %MON dynstat_uvel_sd              =   2.7811751285445E-02
+(PID.TID 0000.0001) %MON dynstat_uvel_del2            =   4.3128594729383E-05
+(PID.TID 0000.0001) %MON dynstat_vvel_max             =   5.6000878517839E-02
+(PID.TID 0000.0001) %MON dynstat_vvel_min             =  -1.3533203385564E-02
+(PID.TID 0000.0001) %MON dynstat_vvel_mean            =  -1.5118575219013E-06
 (PID.TID 0000.0001) %MON dynstat_vvel_sd              =   1.4185635934458E-02
-(PID.TID 0000.0001) %MON dynstat_vvel_del2            =   1.3775257843970E-05
-(PID.TID 0000.0001) %MON dynstat_wvel_max             =   2.2668820021886E+00
-(PID.TID 0000.0001) %MON dynstat_wvel_min             =  -2.0932497591610E+00
-(PID.TID 0000.0001) %MON dynstat_wvel_mean            =   2.8941814892976E-16
-(PID.TID 0000.0001) %MON dynstat_wvel_sd              =   9.0925916462428E-01
-(PID.TID 0000.0001) %MON dynstat_wvel_del2            =   7.4064243242767E-03
+(PID.TID 0000.0001) %MON dynstat_vvel_del2            =   1.3775257843907E-05
+(PID.TID 0000.0001) %MON dynstat_wvel_max             =   2.2668820020923E+00
+(PID.TID 0000.0001) %MON dynstat_wvel_min             =  -2.0932497591153E+00
+(PID.TID 0000.0001) %MON dynstat_wvel_mean            =   9.6472716309919E-17
+(PID.TID 0000.0001) %MON dynstat_wvel_sd              =   9.0925916462316E-01
+(PID.TID 0000.0001) %MON dynstat_wvel_del2            =   7.4064243232272E-03
 (PID.TID 0000.0001) %MON dynstat_theta_max            =   2.0567257499447E+01
 (PID.TID 0000.0001) %MON dynstat_theta_min            =   1.5559130596301E+01
 (PID.TID 0000.0001) %MON dynstat_theta_mean           =   1.7563160570602E+01
 (PID.TID 0000.0001) %MON dynstat_theta_sd             =   1.4157842351496E+00
-(PID.TID 0000.0001) %MON dynstat_theta_del2           =   1.3421731646995E-04
+(PID.TID 0000.0001) %MON dynstat_theta_del2           =   1.3421731646985E-04
 (PID.TID 0000.0001) %MON dynstat_salt_max             =   9.9826952790306E-01
 (PID.TID 0000.0001) %MON dynstat_salt_min             =   4.0311035007238E-01
 (PID.TID 0000.0001) %MON dynstat_salt_mean            =   7.4692405667685E-01
 (PID.TID 0000.0001) %MON dynstat_salt_sd              =   1.9871149922967E-01
 (PID.TID 0000.0001) %MON dynstat_salt_del2            =   2.5414472297694E-04
-(PID.TID 0000.0001) %MON advcfl_uvel_max              =   2.0055239694704E-02
-(PID.TID 0000.0001) %MON advcfl_vvel_max              =   1.2754430129445E-02
-(PID.TID 0000.0001) %MON advcfl_wvel_max              =   4.3042680593479E-03
-(PID.TID 0000.0001) %MON advcfl_W_hf_max              =   4.5308084835241E-03
-(PID.TID 0000.0001) %MON pe_b_mean                    =   2.7585587479023E-07
-(PID.TID 0000.0001) %MON ke_max                       =   7.7810994049628E-03
-(PID.TID 0000.0001) %MON ke_mean                      =   4.8372263570806E-04
+(PID.TID 0000.0001) %MON advcfl_uvel_max              =   2.0055239694731E-02
+(PID.TID 0000.0001) %MON advcfl_vvel_max              =   1.2754430129421E-02
+(PID.TID 0000.0001) %MON advcfl_wvel_max              =   4.3042680592391E-03
+(PID.TID 0000.0001) %MON advcfl_W_hf_max              =   4.5308084834096E-03
+(PID.TID 0000.0001) %MON pe_b_mean                    =   2.7585587479029E-07
+(PID.TID 0000.0001) %MON ke_max                       =   7.7810994049784E-03
+(PID.TID 0000.0001) %MON ke_mean                      =   4.8372263570803E-04
 (PID.TID 0000.0001) %MON ke_vol                       =   7.6260000000000E+16
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // End MONITOR dynamic field statistics
@@ -2442,407 +2457,407 @@ listId=   1 ; file name: dynStDiag
  Compute Stats, Diag. #     32  WVEL      vol(   0 ): 9.951E+17  Parms: WM      LR      
  Compute Stats, Diag. #     26  THETA     vol(   0 ): 9.151E+17  Parms: SMR     MR      
  Compute Stats, Diag. #     27  SALT      vol(   0 ): 9.151E+17  Parms: SMR     MR      
- Compute Stats, Diag. #    205  GM_PsiY   vol(   0 ): 9.591E+17  Parms: VV      LR      
- Compute Stats, Diag. #    198  GM_Kvy    vol(   0 ): 8.820E+17  Parms: VV P    MR      
- Compute Stats, Diag. #    200  GM_Kvz    vol(   0 ): 8.820E+17  Parms: VV      MR      
- Compute Stats, Diag. #    202  GM_Kwy    vol(   0 ): 9.951E+17  Parms: VM      LR      
- Compute Stats, Diag. #    203  GM_Kwz    vol(   0 ): 9.951E+17  Parms: WM P    LR      
- cg2d: Sum(rhs),rhsMax =   0.00000000000000E+00  2.40403420907713E-03
-(PID.TID 0000.0001)      cg2d_init_res =   8.38454178017814E-02
+ Compute Stats, Diag. #    204  GM_PsiY   vol(   0 ): 9.591E+17  Parms: VV      LR      
+ Compute Stats, Diag. #    197  GM_Kvy    vol(   0 ): 8.820E+17  Parms: VV P    MR      
+ Compute Stats, Diag. #    199  GM_Kvz    vol(   0 ): 8.820E+17  Parms: VV      MR      
+ Compute Stats, Diag. #    201  GM_Kwy    vol(   0 ): 9.951E+17  Parms: VM      LR      
+ Compute Stats, Diag. #    202  GM_Kwz    vol(   0 ): 9.951E+17  Parms: WM P    LR      
+ cg2d: Sum(rhs),rhsMax =   1.06581410364015E-14  2.40403420945127E-03
+(PID.TID 0000.0001)      cg2d_init_res =   8.38454180981806E-02
 (PID.TID 0000.0001)      cg2d_iters(min,last) =      -1      29
-(PID.TID 0000.0001)      cg2d_last_res =   6.22539960830483E-14
+(PID.TID 0000.0001)      cg2d_last_res =   6.22622008209742E-14
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // Begin MONITOR dynamic field statistics
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) %MON time_tsnumber                =                    13
 (PID.TID 0000.0001) %MON time_secondsf                =   2.3400000000000E+04
-(PID.TID 0000.0001) %MON dynstat_eta_max              =   1.6452073903738E+02
-(PID.TID 0000.0001) %MON dynstat_eta_min              =  -1.6382746699186E+02
-(PID.TID 0000.0001) %MON dynstat_eta_mean             =   1.3075268817204E-13
-(PID.TID 0000.0001) %MON dynstat_eta_sd               =   1.1585139344040E+02
-(PID.TID 0000.0001) %MON dynstat_eta_del2             =   1.8899378262903E-01
-(PID.TID 0000.0001) %MON dynstat_uvel_max             =   1.2074759341972E-01
-(PID.TID 0000.0001) %MON dynstat_uvel_min             =  -2.9619265107767E-02
-(PID.TID 0000.0001) %MON dynstat_uvel_mean            =   4.2169879397600E-05
-(PID.TID 0000.0001) %MON dynstat_uvel_sd              =   3.0128730463964E-02
-(PID.TID 0000.0001) %MON dynstat_uvel_del2            =   4.6776956654115E-05
-(PID.TID 0000.0001) %MON dynstat_vvel_max             =   4.7355232379735E-02
-(PID.TID 0000.0001) %MON dynstat_vvel_min             =  -1.1323652873659E-02
-(PID.TID 0000.0001) %MON dynstat_vvel_mean            =  -1.3456724127575E-06
-(PID.TID 0000.0001) %MON dynstat_vvel_sd              =   1.1965171172206E-02
-(PID.TID 0000.0001) %MON dynstat_vvel_del2            =   1.2670379049987E-05
-(PID.TID 0000.0001) %MON dynstat_wvel_max             =   1.9758262860829E+00
-(PID.TID 0000.0001) %MON dynstat_wvel_min             =  -1.7814913683203E+00
-(PID.TID 0000.0001) %MON dynstat_wvel_mean            =   2.4118179077480E-16
-(PID.TID 0000.0001) %MON dynstat_wvel_sd              =   7.6639827165988E-01
-(PID.TID 0000.0001) %MON dynstat_wvel_del2            =   7.5809669936450E-03
+(PID.TID 0000.0001) %MON dynstat_eta_max              =   1.6452073903736E+02
+(PID.TID 0000.0001) %MON dynstat_eta_min              =  -1.6382746699204E+02
+(PID.TID 0000.0001) %MON dynstat_eta_mean             =   6.8817204301075E-15
+(PID.TID 0000.0001) %MON dynstat_eta_sd               =   1.1585139344039E+02
+(PID.TID 0000.0001) %MON dynstat_eta_del2             =   1.8899378263108E-01
+(PID.TID 0000.0001) %MON dynstat_uvel_max             =   1.2074759341985E-01
+(PID.TID 0000.0001) %MON dynstat_uvel_min             =  -2.9619265107845E-02
+(PID.TID 0000.0001) %MON dynstat_uvel_mean            =   4.2169879397606E-05
+(PID.TID 0000.0001) %MON dynstat_uvel_sd              =   3.0128730463963E-02
+(PID.TID 0000.0001) %MON dynstat_uvel_del2            =   4.6776956653756E-05
+(PID.TID 0000.0001) %MON dynstat_vvel_max             =   4.7355232379514E-02
+(PID.TID 0000.0001) %MON dynstat_vvel_min             =  -1.1323652873452E-02
+(PID.TID 0000.0001) %MON dynstat_vvel_mean            =  -1.3456724127886E-06
+(PID.TID 0000.0001) %MON dynstat_vvel_sd              =   1.1965171172207E-02
+(PID.TID 0000.0001) %MON dynstat_vvel_del2            =   1.2670379049738E-05
+(PID.TID 0000.0001) %MON dynstat_wvel_max             =   1.9758262858915E+00
+(PID.TID 0000.0001) %MON dynstat_wvel_min             =  -1.7814913683564E+00
+(PID.TID 0000.0001) %MON dynstat_wvel_mean            =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON dynstat_wvel_sd              =   7.6639827165810E-01
+(PID.TID 0000.0001) %MON dynstat_wvel_del2            =   7.5809669919368E-03
 (PID.TID 0000.0001) %MON dynstat_theta_max            =   2.0567173809872E+01
 (PID.TID 0000.0001) %MON dynstat_theta_min            =   1.5559050424887E+01
 (PID.TID 0000.0001) %MON dynstat_theta_mean           =   1.7563160570618E+01
 (PID.TID 0000.0001) %MON dynstat_theta_sd             =   1.4157840914841E+00
-(PID.TID 0000.0001) %MON dynstat_theta_del2           =   1.3365874273043E-04
+(PID.TID 0000.0001) %MON dynstat_theta_del2           =   1.3365874273041E-04
 (PID.TID 0000.0001) %MON dynstat_salt_max             =   9.9813127190471E-01
 (PID.TID 0000.0001) %MON dynstat_salt_min             =   4.0372566608474E-01
 (PID.TID 0000.0001) %MON dynstat_salt_mean            =   7.4692405619696E-01
 (PID.TID 0000.0001) %MON dynstat_salt_sd              =   1.9855139368136E-01
 (PID.TID 0000.0001) %MON dynstat_salt_del2            =   2.5663383908842E-04
-(PID.TID 0000.0001) %MON advcfl_uvel_max              =   2.1734566815549E-02
-(PID.TID 0000.0001) %MON advcfl_vvel_max              =   1.0785348705868E-02
-(PID.TID 0000.0001) %MON advcfl_wvel_max              =   3.8112685097357E-03
-(PID.TID 0000.0001) %MON advcfl_W_hf_max              =   4.0118615891955E-03
-(PID.TID 0000.0001) %MON pe_b_mean                    =   2.7279563744070E-07
-(PID.TID 0000.0001) %MON ke_max                       =   8.4153036656412E-03
-(PID.TID 0000.0001) %MON ke_mean                      =   5.2286327658877E-04
+(PID.TID 0000.0001) %MON advcfl_uvel_max              =   2.1734566815573E-02
+(PID.TID 0000.0001) %MON advcfl_vvel_max              =   1.0785348705817E-02
+(PID.TID 0000.0001) %MON advcfl_wvel_max              =   3.8112685094920E-03
+(PID.TID 0000.0001) %MON advcfl_W_hf_max              =   4.0118615889390E-03
+(PID.TID 0000.0001) %MON pe_b_mean                    =   2.7279563744064E-07
+(PID.TID 0000.0001) %MON ke_max                       =   8.4153036656532E-03
+(PID.TID 0000.0001) %MON ke_mean                      =   5.2286327658875E-04
 (PID.TID 0000.0001) %MON ke_vol                       =   7.6260000000000E+16
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // End MONITOR dynamic field statistics
 (PID.TID 0000.0001) // =======================================================
- cg2d: Sum(rhs),rhsMax =   0.00000000000000E+00  2.48359573347331E-03
-(PID.TID 0000.0001)      cg2d_init_res =   6.36229156299579E-02
+ cg2d: Sum(rhs),rhsMax =   0.00000000000000E+00  2.48359573378385E-03
+(PID.TID 0000.0001)      cg2d_init_res =   6.36229155830139E-02
 (PID.TID 0000.0001)      cg2d_iters(min,last) =      -1      29
-(PID.TID 0000.0001)      cg2d_last_res =   3.84734464094943E-14
+(PID.TID 0000.0001)      cg2d_last_res =   3.84806976022763E-14
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // Begin MONITOR dynamic field statistics
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) %MON time_tsnumber                =                    14
 (PID.TID 0000.0001) %MON time_secondsf                =   2.5200000000000E+04
-(PID.TID 0000.0001) %MON dynstat_eta_max              =   1.6375792947771E+02
-(PID.TID 0000.0001) %MON dynstat_eta_min              =  -1.6322806849355E+02
-(PID.TID 0000.0001) %MON dynstat_eta_mean             =   9.6344086021505E-14
-(PID.TID 0000.0001) %MON dynstat_eta_sd               =   1.1530432595485E+02
-(PID.TID 0000.0001) %MON dynstat_eta_del2             =   1.8654603946408E-01
-(PID.TID 0000.0001) %MON dynstat_uvel_max             =   1.2832130448013E-01
-(PID.TID 0000.0001) %MON dynstat_uvel_min             =  -3.1415898000407E-02
+(PID.TID 0000.0001) %MON dynstat_eta_max              =   1.6375792947783E+02
+(PID.TID 0000.0001) %MON dynstat_eta_min              =  -1.6322806849431E+02
+(PID.TID 0000.0001) %MON dynstat_eta_mean             =  -2.7526881720430E-14
+(PID.TID 0000.0001) %MON dynstat_eta_sd               =   1.1530432595497E+02
+(PID.TID 0000.0001) %MON dynstat_eta_del2             =   1.8654603946811E-01
+(PID.TID 0000.0001) %MON dynstat_uvel_max             =   1.2832130448024E-01
+(PID.TID 0000.0001) %MON dynstat_uvel_min             =  -3.1415898000478E-02
 (PID.TID 0000.0001) %MON dynstat_uvel_mean            =   4.1952510576992E-05
 (PID.TID 0000.0001) %MON dynstat_uvel_sd              =   3.2003680023232E-02
-(PID.TID 0000.0001) %MON dynstat_uvel_del2            =   4.9745811777493E-05
-(PID.TID 0000.0001) %MON dynstat_vvel_max             =   3.7167810688245E-02
-(PID.TID 0000.0001) %MON dynstat_vvel_min             =  -8.7736275306911E-03
-(PID.TID 0000.0001) %MON dynstat_vvel_mean            =  -1.1357017458718E-06
-(PID.TID 0000.0001) %MON dynstat_vvel_sd              =   9.3536931435436E-03
-(PID.TID 0000.0001) %MON dynstat_vvel_del2            =   1.1408445072756E-05
-(PID.TID 0000.0001) %MON dynstat_wvel_max             =   1.6173943763854E+00
-(PID.TID 0000.0001) %MON dynstat_wvel_min             =  -1.4109167679906E+00
-(PID.TID 0000.0001) %MON dynstat_wvel_mean            =   1.4470907446488E-16
-(PID.TID 0000.0001) %MON dynstat_wvel_sd              =   5.9872057159338E-01
-(PID.TID 0000.0001) %MON dynstat_wvel_del2            =   7.5758823029366E-03
+(PID.TID 0000.0001) %MON dynstat_uvel_del2            =   4.9745811777041E-05
+(PID.TID 0000.0001) %MON dynstat_vvel_max             =   3.7167810688031E-02
+(PID.TID 0000.0001) %MON dynstat_vvel_min             =  -8.7736275305688E-03
+(PID.TID 0000.0001) %MON dynstat_vvel_mean            =  -1.1357017456060E-06
+(PID.TID 0000.0001) %MON dynstat_vvel_sd              =   9.3536931435453E-03
+(PID.TID 0000.0001) %MON dynstat_vvel_del2            =   1.1408445071329E-05
+(PID.TID 0000.0001) %MON dynstat_wvel_max             =   1.6173943760722E+00
+(PID.TID 0000.0001) %MON dynstat_wvel_min             =  -1.4109167679736E+00
+(PID.TID 0000.0001) %MON dynstat_wvel_mean            =   1.9294543261984E-16
+(PID.TID 0000.0001) %MON dynstat_wvel_sd              =   5.9872057159026E-01
+(PID.TID 0000.0001) %MON dynstat_wvel_del2            =   7.5758822991340E-03
 (PID.TID 0000.0001) %MON dynstat_theta_max            =   2.0567099829517E+01
 (PID.TID 0000.0001) %MON dynstat_theta_min            =   1.5558981249349E+01
 (PID.TID 0000.0001) %MON dynstat_theta_mean           =   1.7563160570633E+01
 (PID.TID 0000.0001) %MON dynstat_theta_sd             =   1.4157839484231E+00
-(PID.TID 0000.0001) %MON dynstat_theta_del2           =   1.3313907514007E-04
+(PID.TID 0000.0001) %MON dynstat_theta_del2           =   1.3313907514013E-04
 (PID.TID 0000.0001) %MON dynstat_salt_max             =   9.9799538791025E-01
 (PID.TID 0000.0001) %MON dynstat_salt_min             =   4.0433609772149E-01
 (PID.TID 0000.0001) %MON dynstat_salt_mean            =   7.4692405568915E-01
 (PID.TID 0000.0001) %MON dynstat_salt_sd              =   1.9839164021578E-01
 (PID.TID 0000.0001) %MON dynstat_salt_del2            =   2.5910243737303E-04
-(PID.TID 0000.0001) %MON advcfl_uvel_max              =   2.3097834806423E-02
-(PID.TID 0000.0001) %MON advcfl_vvel_max              =   8.4651215665441E-03
-(PID.TID 0000.0001) %MON advcfl_wvel_max              =   3.1957187261247E-03
-(PID.TID 0000.0001) %MON advcfl_W_hf_max              =   3.3639144485523E-03
-(PID.TID 0000.0001) %MON pe_b_mean                    =   2.7022535739640E-07
-(PID.TID 0000.0001) %MON ke_max                       =   8.9261588042936E-03
-(PID.TID 0000.0001) %MON ke_mean                      =   5.5428133860752E-04
+(PID.TID 0000.0001) %MON advcfl_uvel_max              =   2.3097834806443E-02
+(PID.TID 0000.0001) %MON advcfl_vvel_max              =   8.4651215664954E-03
+(PID.TID 0000.0001) %MON advcfl_wvel_max              =   3.1957187257030E-03
+(PID.TID 0000.0001) %MON advcfl_W_hf_max              =   3.3639144481085E-03
+(PID.TID 0000.0001) %MON pe_b_mean                    =   2.7022535739693E-07
+(PID.TID 0000.0001) %MON ke_max                       =   8.9261588043026E-03
+(PID.TID 0000.0001) %MON ke_mean                      =   5.5428133860751E-04
 (PID.TID 0000.0001) %MON ke_vol                       =   7.6260000000000E+16
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // End MONITOR dynamic field statistics
 (PID.TID 0000.0001) // =======================================================
- cg2d: Sum(rhs),rhsMax =   4.44089209850063E-15  2.54025439429666E-03
-(PID.TID 0000.0001)      cg2d_init_res =   4.73771409811482E-02
+ cg2d: Sum(rhs),rhsMax =   6.21724893790088E-15  2.54025439444061E-03
+(PID.TID 0000.0001)      cg2d_init_res =   4.73771411929614E-02
 (PID.TID 0000.0001)      cg2d_iters(min,last) =      -1      30
-(PID.TID 0000.0001)      cg2d_last_res =   2.08343039018120E-16
+(PID.TID 0000.0001)      cg2d_last_res =   2.22847546083669E-16
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // Begin MONITOR dynamic field statistics
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) %MON time_tsnumber                =                    15
 (PID.TID 0000.0001) %MON time_secondsf                =   2.7000000000000E+04
-(PID.TID 0000.0001) %MON dynstat_eta_max              =   1.6315474393039E+02
-(PID.TID 0000.0001) %MON dynstat_eta_min              =  -1.6277142618090E+02
-(PID.TID 0000.0001) %MON dynstat_eta_mean             =   4.8172043010753E-14
-(PID.TID 0000.0001) %MON dynstat_eta_sd               =   1.1487537532913E+02
-(PID.TID 0000.0001) %MON dynstat_eta_del2             =   1.8439100921416E-01
-(PID.TID 0000.0001) %MON dynstat_uvel_max             =   1.3389494790862E-01
-(PID.TID 0000.0001) %MON dynstat_uvel_min             =  -3.2706475994924E-02
-(PID.TID 0000.0001) %MON dynstat_uvel_mean            =   4.1776369235183E-05
-(PID.TID 0000.0001) %MON dynstat_uvel_sd              =   3.3375809295653E-02
-(PID.TID 0000.0001) %MON dynstat_uvel_del2            =   5.1932268244594E-05
-(PID.TID 0000.0001) %MON dynstat_vvel_max             =   2.5791446902080E-02
-(PID.TID 0000.0001) %MON dynstat_vvel_min             =  -5.9587106321661E-03
-(PID.TID 0000.0001) %MON dynstat_vvel_mean            =  -8.9009729016613E-07
-(PID.TID 0000.0001) %MON dynstat_vvel_sd              =   6.4427374979395E-03
-(PID.TID 0000.0001) %MON dynstat_vvel_del2            =   1.0147666634319E-05
-(PID.TID 0000.0001) %MON dynstat_wvel_max             =   1.2047431897018E+00
-(PID.TID 0000.0001) %MON dynstat_wvel_min             =  -9.9618551927906E-01
-(PID.TID 0000.0001) %MON dynstat_wvel_mean            =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON dynstat_wvel_sd              =   4.1257724251322E-01
-(PID.TID 0000.0001) %MON dynstat_wvel_del2            =   7.4137027991422E-03
+(PID.TID 0000.0001) %MON dynstat_eta_max              =   1.6315474393026E+02
+(PID.TID 0000.0001) %MON dynstat_eta_min              =  -1.6277142618016E+02
+(PID.TID 0000.0001) %MON dynstat_eta_mean             =  -2.0645161290323E-14
+(PID.TID 0000.0001) %MON dynstat_eta_sd               =   1.1487537532904E+02
+(PID.TID 0000.0001) %MON dynstat_eta_del2             =   1.8439100921208E-01
+(PID.TID 0000.0001) %MON dynstat_uvel_max             =   1.3389494790870E-01
+(PID.TID 0000.0001) %MON dynstat_uvel_min             =  -3.2706475994968E-02
+(PID.TID 0000.0001) %MON dynstat_uvel_mean            =   4.1776369235255E-05
+(PID.TID 0000.0001) %MON dynstat_uvel_sd              =   3.3375809295654E-02
+(PID.TID 0000.0001) %MON dynstat_uvel_del2            =   5.1932268244224E-05
+(PID.TID 0000.0001) %MON dynstat_vvel_max             =   2.5791446901841E-02
+(PID.TID 0000.0001) %MON dynstat_vvel_min             =  -5.9587106320652E-03
+(PID.TID 0000.0001) %MON dynstat_vvel_mean            =  -8.9009729064297E-07
+(PID.TID 0000.0001) %MON dynstat_vvel_sd              =   6.4427374979410E-03
+(PID.TID 0000.0001) %MON dynstat_vvel_del2            =   1.0147666633647E-05
+(PID.TID 0000.0001) %MON dynstat_wvel_max             =   1.2047431894347E+00
+(PID.TID 0000.0001) %MON dynstat_wvel_min             =  -9.9618551934308E-01
+(PID.TID 0000.0001) %MON dynstat_wvel_mean            =  -4.8236358154959E-17
+(PID.TID 0000.0001) %MON dynstat_wvel_sd              =   4.1257724250995E-01
+(PID.TID 0000.0001) %MON dynstat_wvel_del2            =   7.4137027969735E-03
 (PID.TID 0000.0001) %MON dynstat_theta_max            =   2.0567036228008E+01
 (PID.TID 0000.0001) %MON dynstat_theta_min            =   1.5558934177926E+01
 (PID.TID 0000.0001) %MON dynstat_theta_mean           =   1.7563160570646E+01
 (PID.TID 0000.0001) %MON dynstat_theta_sd             =   1.4157838059570E+00
-(PID.TID 0000.0001) %MON dynstat_theta_del2           =   1.3267266024824E-04
+(PID.TID 0000.0001) %MON dynstat_theta_del2           =   1.3267266024838E-04
 (PID.TID 0000.0001) %MON dynstat_salt_max             =   9.9786237442035E-01
 (PID.TID 0000.0001) %MON dynstat_salt_min             =   4.0494214092942E-01
 (PID.TID 0000.0001) %MON dynstat_salt_mean            =   7.4692405522087E-01
 (PID.TID 0000.0001) %MON dynstat_salt_sd              =   1.9823223020904E-01
-(PID.TID 0000.0001) %MON dynstat_salt_del2            =   2.6154259300918E-04
-(PID.TID 0000.0001) %MON advcfl_uvel_max              =   2.4101090623551E-02
-(PID.TID 0000.0001) %MON advcfl_vvel_max              =   5.8741079810822E-03
-(PID.TID 0000.0001) %MON advcfl_wvel_max              =   2.4789962690252E-03
-(PID.TID 0000.0001) %MON advcfl_W_hf_max              =   2.6094697568686E-03
-(PID.TID 0000.0001) %MON pe_b_mean                    =   2.6821853367904E-07
-(PID.TID 0000.0001) %MON ke_max                       =   9.2974176191836E-03
-(PID.TID 0000.0001) %MON ke_mean                      =   5.7697655617837E-04
+(PID.TID 0000.0001) %MON dynstat_salt_del2            =   2.6154259300919E-04
+(PID.TID 0000.0001) %MON advcfl_uvel_max              =   2.4101090623565E-02
+(PID.TID 0000.0001) %MON advcfl_vvel_max              =   5.8741079810277E-03
+(PID.TID 0000.0001) %MON advcfl_wvel_max              =   2.4789962686707E-03
+(PID.TID 0000.0001) %MON advcfl_W_hf_max              =   2.6094697564955E-03
+(PID.TID 0000.0001) %MON pe_b_mean                    =   2.6821853367862E-07
+(PID.TID 0000.0001) %MON ke_max                       =   9.2974176191888E-03
+(PID.TID 0000.0001) %MON ke_mean                      =   5.7697655617838E-04
 (PID.TID 0000.0001) %MON ke_vol                       =   7.6260000000000E+16
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // End MONITOR dynamic field statistics
 (PID.TID 0000.0001) // =======================================================
- cg2d: Sum(rhs),rhsMax =  -8.88178419700125E-16  2.56964847736416E-03
-(PID.TID 0000.0001)      cg2d_init_res =   4.18093080515558E-02
+ cg2d: Sum(rhs),rhsMax =   6.21724893790088E-15  2.56964847752258E-03
+(PID.TID 0000.0001)      cg2d_init_res =   4.18093078196754E-02
 (PID.TID 0000.0001)      cg2d_iters(min,last) =      -1      30
-(PID.TID 0000.0001)      cg2d_last_res =   1.11146820915845E-16
+(PID.TID 0000.0001)      cg2d_last_res =   1.00146163800142E-16
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // Begin MONITOR dynamic field statistics
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) %MON time_tsnumber                =                    16
 (PID.TID 0000.0001) %MON time_secondsf                =   2.8800000000000E+04
-(PID.TID 0000.0001) %MON dynstat_eta_max              =   1.6273473343562E+02
-(PID.TID 0000.0001) %MON dynstat_eta_min              =  -1.6246243671672E+02
-(PID.TID 0000.0001) %MON dynstat_eta_mean             =   6.1935483870968E-14
-(PID.TID 0000.0001) %MON dynstat_eta_sd               =   1.1457755685760E+02
-(PID.TID 0000.0001) %MON dynstat_eta_del2             =   1.8263225285984E-01
-(PID.TID 0000.0001) %MON dynstat_uvel_max             =   1.3729323394927E-01
-(PID.TID 0000.0001) %MON dynstat_uvel_min             =  -3.3449674509197E-02
-(PID.TID 0000.0001) %MON dynstat_uvel_mean            =   4.1646811330775E-05
-(PID.TID 0000.0001) %MON dynstat_uvel_sd              =   3.4201730427973E-02
-(PID.TID 0000.0001) %MON dynstat_uvel_del2            =   5.3259559729221E-05
-(PID.TID 0000.0001) %MON dynstat_vvel_max             =   1.3616823541914E-02
-(PID.TID 0000.0001) %MON dynstat_vvel_min             =  -2.9914519337385E-03
-(PID.TID 0000.0001) %MON dynstat_vvel_mean            =  -6.1749064605436E-07
-(PID.TID 0000.0001) %MON dynstat_vvel_sd              =   3.3359267502462E-03
-(PID.TID 0000.0001) %MON dynstat_vvel_del2            =   9.0954684351323E-06
-(PID.TID 0000.0001) %MON dynstat_wvel_max             =   7.7485422520437E-01
-(PID.TID 0000.0001) %MON dynstat_wvel_min             =  -5.8074169178576E-01
-(PID.TID 0000.0001) %MON dynstat_wvel_mean            =  -1.3264998492614E-16
-(PID.TID 0000.0001) %MON dynstat_wvel_sd              =   2.1668411061276E-01
-(PID.TID 0000.0001) %MON dynstat_wvel_del2            =   7.1122812734851E-03
+(PID.TID 0000.0001) %MON dynstat_eta_max              =   1.6273473343592E+02
+(PID.TID 0000.0001) %MON dynstat_eta_min              =  -1.6246243671664E+02
+(PID.TID 0000.0001) %MON dynstat_eta_mean             =  -3.4408602150538E-14
+(PID.TID 0000.0001) %MON dynstat_eta_sd               =   1.1457755685758E+02
+(PID.TID 0000.0001) %MON dynstat_eta_del2             =   1.8263225285545E-01
+(PID.TID 0000.0001) %MON dynstat_uvel_max             =   1.3729323394930E-01
+(PID.TID 0000.0001) %MON dynstat_uvel_min             =  -3.3449674509205E-02
+(PID.TID 0000.0001) %MON dynstat_uvel_mean            =   4.1646811330684E-05
+(PID.TID 0000.0001) %MON dynstat_uvel_sd              =   3.4201730427974E-02
+(PID.TID 0000.0001) %MON dynstat_uvel_del2            =   5.3259559728732E-05
+(PID.TID 0000.0001) %MON dynstat_vvel_max             =   1.3616823541640E-02
+(PID.TID 0000.0001) %MON dynstat_vvel_min             =  -2.9914519337076E-03
+(PID.TID 0000.0001) %MON dynstat_vvel_mean            =  -6.1749064586330E-07
+(PID.TID 0000.0001) %MON dynstat_vvel_sd              =   3.3359267502478E-03
+(PID.TID 0000.0001) %MON dynstat_vvel_del2            =   9.0954684346329E-06
+(PID.TID 0000.0001) %MON dynstat_wvel_max             =   7.7485422499712E-01
+(PID.TID 0000.0001) %MON dynstat_wvel_min             =  -5.8074169186747E-01
+(PID.TID 0000.0001) %MON dynstat_wvel_mean            =   9.6472716309919E-17
+(PID.TID 0000.0001) %MON dynstat_wvel_sd              =   2.1668411060855E-01
+(PID.TID 0000.0001) %MON dynstat_wvel_del2            =   7.1122812719645E-03
 (PID.TID 0000.0001) %MON dynstat_theta_max            =   2.0566983295116E+01
 (PID.TID 0000.0001) %MON dynstat_theta_min            =   1.5558913276459E+01
 (PID.TID 0000.0001) %MON dynstat_theta_mean           =   1.7563160570655E+01
 (PID.TID 0000.0001) %MON dynstat_theta_sd             =   1.4157836640345E+00
-(PID.TID 0000.0001) %MON dynstat_theta_del2           =   1.3227163513690E-04
+(PID.TID 0000.0001) %MON dynstat_theta_del2           =   1.3227163513711E-04
 (PID.TID 0000.0001) %MON dynstat_salt_max             =   9.9773262590350E-01
 (PID.TID 0000.0001) %MON dynstat_salt_min             =   4.0554412503467E-01
 (PID.TID 0000.0001) %MON dynstat_salt_mean            =   7.4692405485138E-01
 (PID.TID 0000.0001) %MON dynstat_salt_sd              =   1.9807315514807E-01
-(PID.TID 0000.0001) %MON dynstat_salt_del2            =   2.6394769082205E-04
-(PID.TID 0000.0001) %MON advcfl_uvel_max              =   2.4712782110868E-02
-(PID.TID 0000.0001) %MON advcfl_vvel_max              =   3.1012874984573E-03
-(PID.TID 0000.0001) %MON advcfl_wvel_max              =   1.6863154801087E-03
-(PID.TID 0000.0001) %MON advcfl_W_hf_max              =   1.7750689264302E-03
-(PID.TID 0000.0001) %MON pe_b_mean                    =   2.6682960437918E-07
-(PID.TID 0000.0001) %MON ke_max                       =   9.5175298486562E-03
-(PID.TID 0000.0001) %MON ke_mean                      =   5.9024289264687E-04
+(PID.TID 0000.0001) %MON dynstat_salt_del2            =   2.6394769082206E-04
+(PID.TID 0000.0001) %MON advcfl_uvel_max              =   2.4712782110874E-02
+(PID.TID 0000.0001) %MON advcfl_vvel_max              =   3.1012874983948E-03
+(PID.TID 0000.0001) %MON advcfl_wvel_max              =   1.6863154797678E-03
+(PID.TID 0000.0001) %MON advcfl_W_hf_max              =   1.7750689260714E-03
+(PID.TID 0000.0001) %MON pe_b_mean                    =   2.6682960437912E-07
+(PID.TID 0000.0001) %MON ke_max                       =   9.5175298486566E-03
+(PID.TID 0000.0001) %MON ke_mean                      =   5.9024289264689E-04
 (PID.TID 0000.0001) %MON ke_vol                       =   7.6260000000000E+16
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // End MONITOR dynamic field statistics
 (PID.TID 0000.0001) // =======================================================
- cg2d: Sum(rhs),rhsMax =  -8.88178419700125E-16  2.56998741981951E-03
-(PID.TID 0000.0001)      cg2d_init_res =   4.83767145154183E-02
+ cg2d: Sum(rhs),rhsMax =   8.88178419700125E-16  2.56998741968326E-03
+(PID.TID 0000.0001)      cg2d_init_res =   4.83767146787147E-02
 (PID.TID 0000.0001)      cg2d_iters(min,last) =      -1      30
-(PID.TID 0000.0001)      cg2d_last_res =   1.37889400237758E-16
+(PID.TID 0000.0001)      cg2d_last_res =   1.07696356171444E-16
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // Begin MONITOR dynamic field statistics
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) %MON time_tsnumber                =                    17
 (PID.TID 0000.0001) %MON time_secondsf                =   3.0600000000000E+04
-(PID.TID 0000.0001) %MON dynstat_eta_max              =   1.6251370721725E+02
-(PID.TID 0000.0001) %MON dynstat_eta_min              =  -1.6230415715407E+02
-(PID.TID 0000.0001) %MON dynstat_eta_mean             =   5.5053763440860E-14
-(PID.TID 0000.0001) %MON dynstat_eta_sd               =   1.1441935875163E+02
-(PID.TID 0000.0001) %MON dynstat_eta_del2             =   1.8143759104171E-01
-(PID.TID 0000.0001) %MON dynstat_uvel_max             =   1.3841520107950E-01
-(PID.TID 0000.0001) %MON dynstat_uvel_min             =  -3.3623261573977E-02
-(PID.TID 0000.0001) %MON dynstat_uvel_mean            =   4.1567638618362E-05
-(PID.TID 0000.0001) %MON dynstat_uvel_sd              =   3.4456817545038E-02
-(PID.TID 0000.0001) %MON dynstat_uvel_del2            =   5.3680418929515E-05
-(PID.TID 0000.0001) %MON dynstat_vvel_max             =   1.2645502973224E-03
-(PID.TID 0000.0001) %MON dynstat_vvel_min             =  -1.8691648156106E-03
-(PID.TID 0000.0001) %MON dynstat_vvel_mean            =  -3.2727629209994E-07
-(PID.TID 0000.0001) %MON dynstat_vvel_sd              =   3.1738230462392E-04
-(PID.TID 0000.0001) %MON dynstat_vvel_del2            =   8.4842392015062E-06
-(PID.TID 0000.0001) %MON dynstat_wvel_max             =   3.5543094869743E-01
-(PID.TID 0000.0001) %MON dynstat_wvel_min             =  -3.7877295231943E-01
-(PID.TID 0000.0001) %MON dynstat_wvel_mean            =   1.8842327404281E-19
-(PID.TID 0000.0001) %MON dynstat_wvel_sd              =   6.2763699694492E-02
-(PID.TID 0000.0001) %MON dynstat_wvel_del2            =   6.6830845052903E-03
+(PID.TID 0000.0001) %MON dynstat_eta_max              =   1.6251370721772E+02
+(PID.TID 0000.0001) %MON dynstat_eta_min              =  -1.6230415715431E+02
+(PID.TID 0000.0001) %MON dynstat_eta_mean             =  -6.8817204301075E-15
+(PID.TID 0000.0001) %MON dynstat_eta_sd               =   1.1441935875185E+02
+(PID.TID 0000.0001) %MON dynstat_eta_del2             =   1.8143759103706E-01
+(PID.TID 0000.0001) %MON dynstat_uvel_max             =   1.3841520107947E-01
+(PID.TID 0000.0001) %MON dynstat_uvel_min             =  -3.3623261573932E-02
+(PID.TID 0000.0001) %MON dynstat_uvel_mean            =   4.1567638618372E-05
+(PID.TID 0000.0001) %MON dynstat_uvel_sd              =   3.4456817545039E-02
+(PID.TID 0000.0001) %MON dynstat_uvel_del2            =   5.3680418928927E-05
+(PID.TID 0000.0001) %MON dynstat_vvel_max             =   1.2645502973591E-03
+(PID.TID 0000.0001) %MON dynstat_vvel_min             =  -1.8691648153233E-03
+(PID.TID 0000.0001) %MON dynstat_vvel_mean            =  -3.2727629161960E-07
+(PID.TID 0000.0001) %MON dynstat_vvel_sd              =   3.1738230462167E-04
+(PID.TID 0000.0001) %MON dynstat_vvel_del2            =   8.4842392009777E-06
+(PID.TID 0000.0001) %MON dynstat_wvel_max             =   3.5543094859249E-01
+(PID.TID 0000.0001) %MON dynstat_wvel_min             =  -3.7877295219203E-01
+(PID.TID 0000.0001) %MON dynstat_wvel_mean            =   3.7684654808562E-18
+(PID.TID 0000.0001) %MON dynstat_wvel_sd              =   6.2763699687298E-02
+(PID.TID 0000.0001) %MON dynstat_wvel_del2            =   6.6830845044281E-03
 (PID.TID 0000.0001) %MON dynstat_theta_max            =   2.0566940932555E+01
 (PID.TID 0000.0001) %MON dynstat_theta_min            =   1.5558919520710E+01
 (PID.TID 0000.0001) %MON dynstat_theta_mean           =   1.7563160570660E+01
 (PID.TID 0000.0001) %MON dynstat_theta_sd             =   1.4157835225732E+00
-(PID.TID 0000.0001) %MON dynstat_theta_del2           =   1.3194569346398E-04
+(PID.TID 0000.0001) %MON dynstat_theta_del2           =   1.3194569346425E-04
 (PID.TID 0000.0001) %MON dynstat_salt_max             =   9.9760639056448E-01
 (PID.TID 0000.0001) %MON dynstat_salt_min             =   4.0614221620676E-01
 (PID.TID 0000.0001) %MON dynstat_salt_mean            =   7.4692405462387E-01
 (PID.TID 0000.0001) %MON dynstat_salt_sd              =   1.9791440669415E-01
-(PID.TID 0000.0001) %MON dynstat_salt_del2            =   2.6631227220828E-04
-(PID.TID 0000.0001) %MON advcfl_uvel_max              =   2.4914736194311E-02
-(PID.TID 0000.0001) %MON advcfl_vvel_max              =   3.0009832215104E-04
-(PID.TID 0000.0001) %MON advcfl_wvel_max              =   8.8084416441663E-04
-(PID.TID 0000.0001) %MON advcfl_W_hf_max              =   9.1472278612496E-04
-(PID.TID 0000.0001) %MON pe_b_mean                    =   2.6609328571413E-07
-(PID.TID 0000.0001) %MON ke_max                       =   9.5799250752323E-03
-(PID.TID 0000.0001) %MON ke_mean                      =   5.9368554475089E-04
+(PID.TID 0000.0001) %MON dynstat_salt_del2            =   2.6631227220829E-04
+(PID.TID 0000.0001) %MON advcfl_uvel_max              =   2.4914736194305E-02
+(PID.TID 0000.0001) %MON advcfl_vvel_max              =   3.0009832210493E-04
+(PID.TID 0000.0001) %MON advcfl_wvel_max              =   8.8084416422150E-04
+(PID.TID 0000.0001) %MON advcfl_W_hf_max              =   9.1472278592233E-04
+(PID.TID 0000.0001) %MON pe_b_mean                    =   2.6609328571514E-07
+(PID.TID 0000.0001) %MON ke_max                       =   9.5799250752278E-03
+(PID.TID 0000.0001) %MON ke_mean                      =   5.9368554475092E-04
 (PID.TID 0000.0001) %MON ke_vol                       =   7.6260000000000E+16
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // End MONITOR dynamic field statistics
 (PID.TID 0000.0001) // =======================================================
- cg2d: Sum(rhs),rhsMax =   1.77635683940025E-15  2.54211366997390E-03
-(PID.TID 0000.0001)      cg2d_init_res =   6.02779773024402E-02
+ cg2d: Sum(rhs),rhsMax =  -3.55271367880050E-15  2.54211366915320E-03
+(PID.TID 0000.0001)      cg2d_init_res =   6.02779774349597E-02
 (PID.TID 0000.0001)      cg2d_iters(min,last) =      -1      30
-(PID.TID 0000.0001)      cg2d_last_res =   2.71202172202042E-16
+(PID.TID 0000.0001)      cg2d_last_res =   2.71251803559455E-16
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // Begin MONITOR dynamic field statistics
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) %MON time_tsnumber                =                    18
 (PID.TID 0000.0001) %MON time_secondsf                =   3.2400000000000E+04
-(PID.TID 0000.0001) %MON dynstat_eta_max              =   1.6249861244843E+02
-(PID.TID 0000.0001) %MON dynstat_eta_min              =  -1.6229822941605E+02
-(PID.TID 0000.0001) %MON dynstat_eta_mean             =   6.8817204301075E-14
-(PID.TID 0000.0001) %MON dynstat_eta_sd               =   1.1440449032777E+02
-(PID.TID 0000.0001) %MON dynstat_eta_del2             =   1.8098583468795E-01
-(PID.TID 0000.0001) %MON dynstat_uvel_max             =   1.3723711846449E-01
-(PID.TID 0000.0001) %MON dynstat_uvel_min             =  -3.3224740030446E-02
-(PID.TID 0000.0001) %MON dynstat_uvel_mean            =   4.1540936702230E-05
-(PID.TID 0000.0001) %MON dynstat_uvel_sd              =   3.4135922464942E-02
-(PID.TID 0000.0001) %MON dynstat_uvel_del2            =   5.3179376777837E-05
-(PID.TID 0000.0001) %MON dynstat_vvel_max             =   3.4277586727208E-03
-(PID.TID 0000.0001) %MON dynstat_vvel_min             =  -1.1486782404002E-02
-(PID.TID 0000.0001) %MON dynstat_vvel_mean            =  -2.9394277626700E-08
-(PID.TID 0000.0001) %MON dynstat_vvel_sd              =   3.0887683830712E-03
-(PID.TID 0000.0001) %MON dynstat_vvel_del2            =   8.4766499317668E-06
-(PID.TID 0000.0001) %MON dynstat_wvel_max             =   6.1055392602860E-01
-(PID.TID 0000.0001) %MON dynstat_wvel_min             =  -7.4349679531383E-01
-(PID.TID 0000.0001) %MON dynstat_wvel_mean            =  -1.2059089538740E-16
-(PID.TID 0000.0001) %MON dynstat_wvel_sd              =   2.1323663540076E-01
-(PID.TID 0000.0001) %MON dynstat_wvel_del2            =   6.1334287129277E-03
+(PID.TID 0000.0001) %MON dynstat_eta_max              =   1.6249861244781E+02
+(PID.TID 0000.0001) %MON dynstat_eta_min              =  -1.6229822941607E+02
+(PID.TID 0000.0001) %MON dynstat_eta_mean             =  -2.0645161290323E-14
+(PID.TID 0000.0001) %MON dynstat_eta_sd               =   1.1440449032774E+02
+(PID.TID 0000.0001) %MON dynstat_eta_del2             =   1.8098583468987E-01
+(PID.TID 0000.0001) %MON dynstat_uvel_max             =   1.3723711846443E-01
+(PID.TID 0000.0001) %MON dynstat_uvel_min             =  -3.3224740030371E-02
+(PID.TID 0000.0001) %MON dynstat_uvel_mean            =   4.1540936702355E-05
+(PID.TID 0000.0001) %MON dynstat_uvel_sd              =   3.4135922464944E-02
+(PID.TID 0000.0001) %MON dynstat_uvel_del2            =   5.3179376777210E-05
+(PID.TID 0000.0001) %MON dynstat_vvel_max             =   3.4277586728647E-03
+(PID.TID 0000.0001) %MON dynstat_vvel_min             =  -1.1486782404111E-02
+(PID.TID 0000.0001) %MON dynstat_vvel_mean            =  -2.9394278148053E-08
+(PID.TID 0000.0001) %MON dynstat_vvel_sd              =   3.0887683830698E-03
+(PID.TID 0000.0001) %MON dynstat_vvel_del2            =   8.4766499306984E-06
+(PID.TID 0000.0001) %MON dynstat_wvel_max             =   6.1055392604785E-01
+(PID.TID 0000.0001) %MON dynstat_wvel_min             =  -7.4349679523724E-01
+(PID.TID 0000.0001) %MON dynstat_wvel_mean            =   1.2059089538740E-16
+(PID.TID 0000.0001) %MON dynstat_wvel_sd              =   2.1323663539948E-01
+(PID.TID 0000.0001) %MON dynstat_wvel_del2            =   6.1334287122090E-03
 (PID.TID 0000.0001) %MON dynstat_theta_max            =   2.0566908658756E+01
 (PID.TID 0000.0001) %MON dynstat_theta_min            =   1.5558952695106E+01
 (PID.TID 0000.0001) %MON dynstat_theta_mean           =   1.7563160570661E+01
 (PID.TID 0000.0001) %MON dynstat_theta_sd             =   1.4157833814725E+00
-(PID.TID 0000.0001) %MON dynstat_theta_del2           =   1.3170186975986E-04
+(PID.TID 0000.0001) %MON dynstat_theta_del2           =   1.3170186976014E-04
 (PID.TID 0000.0001) %MON dynstat_salt_max             =   9.9748374488876E-01
 (PID.TID 0000.0001) %MON dynstat_salt_min             =   4.0673642486540E-01
 (PID.TID 0000.0001) %MON dynstat_salt_mean            =   7.4692405455982E-01
 (PID.TID 0000.0001) %MON dynstat_salt_sd              =   1.9775597674871E-01
-(PID.TID 0000.0001) %MON dynstat_salt_del2            =   2.6863190332701E-04
-(PID.TID 0000.0001) %MON advcfl_uvel_max              =   2.4702681323609E-02
-(PID.TID 0000.0001) %MON advcfl_vvel_max              =   2.6161618792648E-03
-(PID.TID 0000.0001) %MON advcfl_wvel_max              =   1.5792924248295E-03
-(PID.TID 0000.0001) %MON advcfl_W_hf_max              =   1.6624130787679E-03
-(PID.TID 0000.0001) %MON pe_b_mean                    =   2.6602413429182E-07
-(PID.TID 0000.0001) %MON ke_max                       =   9.4831528244654E-03
-(PID.TID 0000.0001) %MON ke_mean                      =   5.8722908083385E-04
+(PID.TID 0000.0001) %MON dynstat_salt_del2            =   2.6863190332702E-04
+(PID.TID 0000.0001) %MON advcfl_uvel_max              =   2.4702681323597E-02
+(PID.TID 0000.0001) %MON advcfl_vvel_max              =   2.6161618792896E-03
+(PID.TID 0000.0001) %MON advcfl_wvel_max              =   1.5792924247090E-03
+(PID.TID 0000.0001) %MON advcfl_W_hf_max              =   1.6624130786411E-03
+(PID.TID 0000.0001) %MON pe_b_mean                    =   2.6602413429167E-07
+(PID.TID 0000.0001) %MON ke_max                       =   9.4831528244571E-03
+(PID.TID 0000.0001) %MON ke_mean                      =   5.8722908083389E-04
 (PID.TID 0000.0001) %MON ke_vol                       =   7.6260000000000E+16
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // End MONITOR dynamic field statistics
 (PID.TID 0000.0001) // =======================================================
- cg2d: Sum(rhs),rhsMax =   0.00000000000000E+00  2.48923711160982E-03
-(PID.TID 0000.0001)      cg2d_init_res =   7.21506564620145E-02
+ cg2d: Sum(rhs),rhsMax =  -6.21724893790088E-15  2.48923711098306E-03
+(PID.TID 0000.0001)      cg2d_init_res =   7.21506564797264E-02
 (PID.TID 0000.0001)      cg2d_iters(min,last) =      -1      30
-(PID.TID 0000.0001)      cg2d_last_res =   4.10733168783251E-16
+(PID.TID 0000.0001)      cg2d_last_res =   4.07792251450134E-16
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // Begin MONITOR dynamic field statistics
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) %MON time_tsnumber                =                    19
 (PID.TID 0000.0001) %MON time_secondsf                =   3.4200000000000E+04
-(PID.TID 0000.0001) %MON dynstat_eta_max              =   1.6268700954304E+02
-(PID.TID 0000.0001) %MON dynstat_eta_min              =  -1.6244486327861E+02
-(PID.TID 0000.0001) %MON dynstat_eta_mean             =   1.3763440860215E-14
-(PID.TID 0000.0001) %MON dynstat_eta_sd               =   1.1453180214954E+02
-(PID.TID 0000.0001) %MON dynstat_eta_del2             =   1.8140468890844E-01
-(PID.TID 0000.0001) %MON dynstat_uvel_max             =   1.3381278064464E-01
-(PID.TID 0000.0001) %MON dynstat_uvel_min             =  -3.2271307219731E-02
-(PID.TID 0000.0001) %MON dynstat_uvel_mean            =   4.1567002799208E-05
-(PID.TID 0000.0001) %MON dynstat_uvel_sd              =   3.3253426732124E-02
-(PID.TID 0000.0001) %MON dynstat_uvel_del2            =   5.1773766667940E-05
-(PID.TID 0000.0001) %MON dynstat_vvel_max             =   6.3903595513423E-03
-(PID.TID 0000.0001) %MON dynstat_vvel_min             =  -2.3525288097927E-02
-(PID.TID 0000.0001) %MON dynstat_vvel_mean            =   2.6603447969773E-07
-(PID.TID 0000.0001) %MON dynstat_vvel_sd              =   6.1489808816121E-03
-(PID.TID 0000.0001) %MON dynstat_vvel_del2            =   9.0506185328281E-06
-(PID.TID 0000.0001) %MON dynstat_wvel_max             =   9.5607357640973E-01
-(PID.TID 0000.0001) %MON dynstat_wvel_min             =  -1.0915692987347E+00
+(PID.TID 0000.0001) %MON dynstat_eta_max              =   1.6268700954291E+02
+(PID.TID 0000.0001) %MON dynstat_eta_min              =  -1.6244486327879E+02
+(PID.TID 0000.0001) %MON dynstat_eta_mean             =  -1.3763440860215E-14
+(PID.TID 0000.0001) %MON dynstat_eta_sd               =   1.1453180214963E+02
+(PID.TID 0000.0001) %MON dynstat_eta_del2             =   1.8140468891037E-01
+(PID.TID 0000.0001) %MON dynstat_uvel_max             =   1.3381278064459E-01
+(PID.TID 0000.0001) %MON dynstat_uvel_min             =  -3.2271307219665E-02
+(PID.TID 0000.0001) %MON dynstat_uvel_mean            =   4.1567002799145E-05
+(PID.TID 0000.0001) %MON dynstat_uvel_sd              =   3.3253426732126E-02
+(PID.TID 0000.0001) %MON dynstat_uvel_del2            =   5.1773766667368E-05
+(PID.TID 0000.0001) %MON dynstat_vvel_max             =   6.3903595513057E-03
+(PID.TID 0000.0001) %MON dynstat_vvel_min             =  -2.3525288097754E-02
+(PID.TID 0000.0001) %MON dynstat_vvel_mean            =   2.6603447996300E-07
+(PID.TID 0000.0001) %MON dynstat_vvel_sd              =   6.1489808816108E-03
+(PID.TID 0000.0001) %MON dynstat_vvel_del2            =   9.0506185318172E-06
+(PID.TID 0000.0001) %MON dynstat_wvel_max             =   9.5607357644448E-01
+(PID.TID 0000.0001) %MON dynstat_wvel_min             =  -1.0915692987115E+00
 (PID.TID 0000.0001) %MON dynstat_wvel_mean            =   7.2354537232439E-17
-(PID.TID 0000.0001) %MON dynstat_wvel_sd              =   4.0547333168653E-01
-(PID.TID 0000.0001) %MON dynstat_wvel_del2            =   5.4723768187489E-03
+(PID.TID 0000.0001) %MON dynstat_wvel_sd              =   4.0547333168589E-01
+(PID.TID 0000.0001) %MON dynstat_wvel_del2            =   5.4723768186793E-03
 (PID.TID 0000.0001) %MON dynstat_theta_max            =   2.0566885627517E+01
 (PID.TID 0000.0001) %MON dynstat_theta_min            =   1.5559011383492E+01
 (PID.TID 0000.0001) %MON dynstat_theta_mean           =   1.7563160570657E+01
 (PID.TID 0000.0001) %MON dynstat_theta_sd             =   1.4157832406275E+00
-(PID.TID 0000.0001) %MON dynstat_theta_del2           =   1.3154458239244E-04
+(PID.TID 0000.0001) %MON dynstat_theta_del2           =   1.3154458239271E-04
 (PID.TID 0000.0001) %MON dynstat_salt_max             =   9.9736458739071E-01
 (PID.TID 0000.0001) %MON dynstat_salt_min             =   4.0732661720278E-01
-(PID.TID 0000.0001) %MON dynstat_salt_mean            =   7.4692405465656E-01
+(PID.TID 0000.0001) %MON dynstat_salt_mean            =   7.4692405465655E-01
 (PID.TID 0000.0001) %MON dynstat_salt_sd              =   1.9759785751940E-01
 (PID.TID 0000.0001) %MON dynstat_salt_del2            =   2.7090306015436E-04
-(PID.TID 0000.0001) %MON advcfl_uvel_max              =   2.4086300516036E-02
-(PID.TID 0000.0001) %MON advcfl_vvel_max              =   5.3579810042431E-03
-(PID.TID 0000.0001) %MON advcfl_wvel_max              =   2.2390484704940E-03
-(PID.TID 0000.0001) %MON advcfl_W_hf_max              =   2.3568931268358E-03
-(PID.TID 0000.0001) %MON pe_b_mean                    =   2.6661653869149E-07
-(PID.TID 0000.0001) %MON ke_max                       =   9.2308826997103E-03
-(PID.TID 0000.0001) %MON ke_mean                      =   5.7111689740868E-04
+(PID.TID 0000.0001) %MON advcfl_uvel_max              =   2.4086300516026E-02
+(PID.TID 0000.0001) %MON advcfl_vvel_max              =   5.3579810042038E-03
+(PID.TID 0000.0001) %MON advcfl_wvel_max              =   2.2390484704719E-03
+(PID.TID 0000.0001) %MON advcfl_W_hf_max              =   2.3568931268126E-03
+(PID.TID 0000.0001) %MON pe_b_mean                    =   2.6661653869191E-07
+(PID.TID 0000.0001) %MON ke_max                       =   9.2308826996996E-03
+(PID.TID 0000.0001) %MON ke_mean                      =   5.7111689740872E-04
 (PID.TID 0000.0001) %MON ke_vol                       =   7.6260000000000E+16
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // End MONITOR dynamic field statistics
 (PID.TID 0000.0001) // =======================================================
- cg2d: Sum(rhs),rhsMax =   2.66453525910038E-15  2.41640990721626E-03
-(PID.TID 0000.0001)      cg2d_init_res =   8.17476564465451E-02
+ cg2d: Sum(rhs),rhsMax =   0.00000000000000E+00  2.41640990635804E-03
+(PID.TID 0000.0001)      cg2d_init_res =   8.17476564389256E-02
 (PID.TID 0000.0001)      cg2d_iters(min,last) =      -1      30
-(PID.TID 0000.0001)      cg2d_last_res =   4.86481047372312E-16
+(PID.TID 0000.0001)      cg2d_last_res =   4.88169197879869E-16
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // Begin MONITOR dynamic field statistics
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) %MON time_tsnumber                =                    20
 (PID.TID 0000.0001) %MON time_secondsf                =   3.6000000000000E+04
-(PID.TID 0000.0001) %MON dynstat_eta_max              =   1.6306719868322E+02
-(PID.TID 0000.0001) %MON dynstat_eta_min              =  -1.6274240666418E+02
-(PID.TID 0000.0001) %MON dynstat_eta_mean             =   6.8817204301075E-15
-(PID.TID 0000.0001) %MON dynstat_eta_sd               =   1.1479536153024E+02
-(PID.TID 0000.0001) %MON dynstat_eta_del2             =   1.8272625252058E-01
-(PID.TID 0000.0001) %MON dynstat_uvel_max             =   1.2827120361747E-01
-(PID.TID 0000.0001) %MON dynstat_uvel_min             =  -3.0799138160076E-02
-(PID.TID 0000.0001) %MON dynstat_uvel_mean            =   4.1644351963918E-05
-(PID.TID 0000.0001) %MON dynstat_uvel_sd              =   3.1842632279544E-02
-(PID.TID 0000.0001) %MON dynstat_uvel_del2            =   4.9513309902574E-05
-(PID.TID 0000.0001) %MON dynstat_vvel_max             =   9.1175332019243E-03
-(PID.TID 0000.0001) %MON dynstat_vvel_min             =  -3.4697613401750E-02
-(PID.TID 0000.0001) %MON dynstat_vvel_mean            =   5.4904721829999E-07
-(PID.TID 0000.0001) %MON dynstat_vvel_sd              =   8.9873474633343E-03
-(PID.TID 0000.0001) %MON dynstat_vvel_del2            =   1.0017278230077E-05
-(PID.TID 0000.0001) %MON dynstat_wvel_max             =   1.2764441993315E+00
-(PID.TID 0000.0001) %MON dynstat_wvel_min             =  -1.4041107804642E+00
-(PID.TID 0000.0001) %MON dynstat_wvel_mean            =  -4.8236358154959E-16
-(PID.TID 0000.0001) %MON dynstat_wvel_sd              =   5.8592318723884E-01
-(PID.TID 0000.0001) %MON dynstat_wvel_del2            =   4.7213196166886E-03
+(PID.TID 0000.0001) %MON dynstat_eta_max              =   1.6306719868289E+02
+(PID.TID 0000.0001) %MON dynstat_eta_min              =  -1.6274240666392E+02
+(PID.TID 0000.0001) %MON dynstat_eta_mean             =  -6.1935483870968E-14
+(PID.TID 0000.0001) %MON dynstat_eta_sd               =   1.1479536153029E+02
+(PID.TID 0000.0001) %MON dynstat_eta_del2             =   1.8272625252869E-01
+(PID.TID 0000.0001) %MON dynstat_uvel_max             =   1.2827120361746E-01
+(PID.TID 0000.0001) %MON dynstat_uvel_min             =  -3.0799138160037E-02
+(PID.TID 0000.0001) %MON dynstat_uvel_mean            =   4.1644351963983E-05
+(PID.TID 0000.0001) %MON dynstat_uvel_sd              =   3.1842632279546E-02
+(PID.TID 0000.0001) %MON dynstat_uvel_del2            =   4.9513309901989E-05
+(PID.TID 0000.0001) %MON dynstat_vvel_max             =   9.1175332018843E-03
+(PID.TID 0000.0001) %MON dynstat_vvel_min             =  -3.4697613401292E-02
+(PID.TID 0000.0001) %MON dynstat_vvel_mean            =   5.4904721820748E-07
+(PID.TID 0000.0001) %MON dynstat_vvel_sd              =   8.9873474633340E-03
+(PID.TID 0000.0001) %MON dynstat_vvel_del2            =   1.0017278229278E-05
+(PID.TID 0000.0001) %MON dynstat_wvel_max             =   1.2764441994277E+00
+(PID.TID 0000.0001) %MON dynstat_wvel_min             =  -1.4041107804807E+00
+(PID.TID 0000.0001) %MON dynstat_wvel_mean            =   4.8236358154959E-17
+(PID.TID 0000.0001) %MON dynstat_wvel_sd              =   5.8592318723829E-01
+(PID.TID 0000.0001) %MON dynstat_wvel_del2            =   4.7213196165339E-03
 (PID.TID 0000.0001) %MON dynstat_theta_max            =   2.0566870660733E+01
 (PID.TID 0000.0001) %MON dynstat_theta_min            =   1.5559081869525E+01
 (PID.TID 0000.0001) %MON dynstat_theta_mean           =   1.7563160570649E+01
 (PID.TID 0000.0001) %MON dynstat_theta_sd             =   1.4157830999419E+00
-(PID.TID 0000.0001) %MON dynstat_theta_del2           =   1.3147611667966E-04
+(PID.TID 0000.0001) %MON dynstat_theta_del2           =   1.3147611667990E-04
 (PID.TID 0000.0001) %MON dynstat_salt_max             =   9.9724865149694E-01
 (PID.TID 0000.0001) %MON dynstat_salt_min             =   4.0791253081147E-01
 (PID.TID 0000.0001) %MON dynstat_salt_mean            =   7.4692405488804E-01
 (PID.TID 0000.0001) %MON dynstat_salt_sd              =   1.9744004158435E-01
 (PID.TID 0000.0001) %MON dynstat_salt_del2            =   2.7312302571347E-04
-(PID.TID 0000.0001) %MON advcfl_uvel_max              =   2.3088816651145E-02
-(PID.TID 0000.0001) %MON advcfl_vvel_max              =   7.9025239871784E-03
-(PID.TID 0000.0001) %MON advcfl_wvel_max              =   2.8140710606366E-03
-(PID.TID 0000.0001) %MON advcfl_W_hf_max              =   2.9621800638280E-03
-(PID.TID 0000.0001) %MON pe_b_mean                    =   2.6784502091174E-07
-(PID.TID 0000.0001) %MON ke_max                       =   8.8317671476210E-03
-(PID.TID 0000.0001) %MON ke_mean                      =   5.4590217087720E-04
+(PID.TID 0000.0001) %MON advcfl_uvel_max              =   2.3088816651143E-02
+(PID.TID 0000.0001) %MON advcfl_vvel_max              =   7.9025239870740E-03
+(PID.TID 0000.0001) %MON advcfl_wvel_max              =   2.8140710606713E-03
+(PID.TID 0000.0001) %MON advcfl_W_hf_max              =   2.9621800638646E-03
+(PID.TID 0000.0001) %MON pe_b_mean                    =   2.6784502091197E-07
+(PID.TID 0000.0001) %MON ke_max                       =   8.8317671476108E-03
+(PID.TID 0000.0001) %MON ke_mean                      =   5.4590217087725E-04
 (PID.TID 0000.0001) %MON ke_vol                       =   7.6260000000000E+16
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // End MONITOR dynamic field statistics
@@ -2850,135 +2865,135 @@ listId=   1 ; file name: dynStDiag
 (PID.TID 0000.0001) DIAGSTATS_CLOSE_IO: close file: dynStDiag.0000000000.txt , unit=     9
 (PID.TID 0000.0001) %CHECKPOINT        20 ckptA
 (PID.TID 0000.0001)   Seconds in section "ALL                    [THE_MODEL_MAIN]":
-(PID.TID 0000.0001)           User time:   1.0028720302507281
-(PID.TID 0000.0001)         System time:   2.0136000588536263E-002
-(PID.TID 0000.0001)     Wall clock time:   1.0230331420898438
+(PID.TID 0000.0001)           User time:  0.95919099915772676
+(PID.TID 0000.0001)         System time:   1.8319999799132347E-002
+(PID.TID 0000.0001)     Wall clock time:  0.99366402626037598
 (PID.TID 0000.0001)          No. starts:           1
 (PID.TID 0000.0001)           No. stops:           1
 (PID.TID 0000.0001)   Seconds in section "INITIALISE_FIXED       [THE_MODEL_MAIN]":
-(PID.TID 0000.0001)           User time:   1.9035000354051590E-002
-(PID.TID 0000.0001)         System time:   1.5225999988615513E-002
-(PID.TID 0000.0001)     Wall clock time:   3.4264802932739258E-002
+(PID.TID 0000.0001)           User time:   2.6780999731272459E-002
+(PID.TID 0000.0001)         System time:   4.3759997934103012E-003
+(PID.TID 0000.0001)     Wall clock time:   3.9675951004028320E-002
 (PID.TID 0000.0001)          No. starts:           1
 (PID.TID 0000.0001)           No. stops:           1
 (PID.TID 0000.0001)   Seconds in section "THE_MAIN_LOOP          [THE_MODEL_MAIN]":
-(PID.TID 0000.0001)           User time:  0.98378197103738785
-(PID.TID 0000.0001)         System time:   4.9030007794499397E-003
-(PID.TID 0000.0001)     Wall clock time:  0.98872208595275879
+(PID.TID 0000.0001)           User time:  0.93233999982476234
+(PID.TID 0000.0001)         System time:   1.3936000410467386E-002
+(PID.TID 0000.0001)     Wall clock time:  0.95392322540283203
 (PID.TID 0000.0001)          No. starts:           1
 (PID.TID 0000.0001)           No. stops:           1
 (PID.TID 0000.0001)   Seconds in section "INITIALISE_VARIA    [THE_MAIN_LOOP]":
-(PID.TID 0000.0001)           User time:   1.3814000412821770E-002
-(PID.TID 0000.0001)         System time:   1.0599996894598007E-003
-(PID.TID 0000.0001)     Wall clock time:   1.4875888824462891E-002
+(PID.TID 0000.0001)           User time:   9.3890000134706497E-003
+(PID.TID 0000.0001)         System time:   8.9699998497962952E-003
+(PID.TID 0000.0001)     Wall clock time:   2.6005029678344727E-002
 (PID.TID 0000.0001)          No. starts:           1
 (PID.TID 0000.0001)           No. stops:           1
 (PID.TID 0000.0001)   Seconds in section "MAIN LOOP           [THE_MAIN_LOOP]":
-(PID.TID 0000.0001)           User time:  0.96994098275899887
-(PID.TID 0000.0001)         System time:   3.8330014795064926E-003
-(PID.TID 0000.0001)     Wall clock time:  0.97381091117858887
+(PID.TID 0000.0001)           User time:  0.92292400076985359
+(PID.TID 0000.0001)         System time:   4.9520004540681839E-003
+(PID.TID 0000.0001)     Wall clock time:  0.92788004875183105
 (PID.TID 0000.0001)          No. starts:           1
 (PID.TID 0000.0001)           No. stops:           1
 (PID.TID 0000.0001)   Seconds in section "MAIN_DO_LOOP        [THE_MAIN_LOOP]":
-(PID.TID 0000.0001)           User time:  0.96975402161478996
-(PID.TID 0000.0001)         System time:   3.8210004568099976E-003
-(PID.TID 0000.0001)     Wall clock time:  0.97360873222351074
+(PID.TID 0000.0001)           User time:  0.92274290695786476
+(PID.TID 0000.0001)         System time:   4.9400003626942635E-003
+(PID.TID 0000.0001)     Wall clock time:  0.92768740653991699
 (PID.TID 0000.0001)          No. starts:          20
 (PID.TID 0000.0001)           No. stops:          20
 (PID.TID 0000.0001)   Seconds in section "FORWARD_STEP        [MAIN_DO_LOOP]":
-(PID.TID 0000.0001)           User time:  0.96941695734858513
-(PID.TID 0000.0001)         System time:   3.8000009953975677E-003
-(PID.TID 0000.0001)     Wall clock time:  0.97325181961059570
+(PID.TID 0000.0001)           User time:  0.92238203436136246
+(PID.TID 0000.0001)         System time:   4.9250004813075066E-003
+(PID.TID 0000.0001)     Wall clock time:  0.92731118202209473
 (PID.TID 0000.0001)          No. starts:          20
 (PID.TID 0000.0001)           No. stops:          20
 (PID.TID 0000.0001)   Seconds in section "DO_STATEVARS_DIAGS  [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:   1.3085801154375076E-002
-(PID.TID 0000.0001)         System time:   2.7099996805191040E-004
-(PID.TID 0000.0001)     Wall clock time:   1.3364791870117188E-002
+(PID.TID 0000.0001)           User time:   8.9309327304363251E-003
+(PID.TID 0000.0001)         System time:   3.0799861997365952E-004
+(PID.TID 0000.0001)     Wall clock time:   9.2704296112060547E-003
 (PID.TID 0000.0001)          No. starts:          60
 (PID.TID 0000.0001)           No. stops:          60
 (PID.TID 0000.0001)   Seconds in section "LOAD_FIELDS_DRIVER  [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:   5.5001303553581238E-004
-(PID.TID 0000.0001)         System time:   2.6999041438102722E-005
+(PID.TID 0000.0001)           User time:   5.6392326951026917E-004
+(PID.TID 0000.0001)         System time:   1.4999881386756897E-005
 (PID.TID 0000.0001)     Wall clock time:   5.7673454284667969E-004
 (PID.TID 0000.0001)          No. starts:          20
 (PID.TID 0000.0001)           No. stops:          20
 (PID.TID 0000.0001)   Seconds in section "EXTERNAL_FLDS_LOAD [LOAD_FLDS_DRIVER]":
-(PID.TID 0000.0001)           User time:   1.9697844982147217E-004
-(PID.TID 0000.0001)         System time:   8.9984387159347534E-006
-(PID.TID 0000.0001)     Wall clock time:   2.0456314086914062E-004
+(PID.TID 0000.0001)           User time:   1.8992274999618530E-004
+(PID.TID 0000.0001)         System time:   5.9995800256729126E-006
+(PID.TID 0000.0001)     Wall clock time:   1.9860267639160156E-004
 (PID.TID 0000.0001)          No. starts:          20
 (PID.TID 0000.0001)           No. stops:          20
 (PID.TID 0000.0001)   Seconds in section "DO_ATMOSPHERIC_PHYS [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:   1.8109753727912903E-004
-(PID.TID 0000.0001)         System time:   9.0003013610839844E-006
-(PID.TID 0000.0001)     Wall clock time:   1.8882751464843750E-004
+(PID.TID 0000.0001)           User time:   1.8103048205375671E-004
+(PID.TID 0000.0001)         System time:   4.0000304579734802E-006
+(PID.TID 0000.0001)     Wall clock time:   1.8763542175292969E-004
 (PID.TID 0000.0001)          No. starts:          20
 (PID.TID 0000.0001)           No. stops:          20
 (PID.TID 0000.0001)   Seconds in section "DO_OCEANIC_PHYS     [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:  0.16328390687704086
-(PID.TID 0000.0001)         System time:   9.7899883985519409E-004
-(PID.TID 0000.0001)     Wall clock time:  0.16432261466979980
+(PID.TID 0000.0001)           User time:  0.15525800362229347
+(PID.TID 0000.0001)         System time:   0.0000000000000000
+(PID.TID 0000.0001)     Wall clock time:  0.15528273582458496
 (PID.TID 0000.0001)          No. starts:          20
 (PID.TID 0000.0001)           No. stops:          20
 (PID.TID 0000.0001)   Seconds in section "DYNAMICS            [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:  0.25551304221153259
-(PID.TID 0000.0001)         System time:   5.1999464631080627E-005
-(PID.TID 0000.0001)     Wall clock time:  0.25559163093566895
+(PID.TID 0000.0001)           User time:  0.24476902559399605
+(PID.TID 0000.0001)         System time:   0.0000000000000000
+(PID.TID 0000.0001)     Wall clock time:  0.24479484558105469
 (PID.TID 0000.0001)          No. starts:          20
 (PID.TID 0000.0001)           No. stops:          20
 (PID.TID 0000.0001)   Seconds in section "SOLVE_FOR_PRESSURE  [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:   1.8859110772609711E-002
-(PID.TID 0000.0001)         System time:   1.3400055468082428E-004
-(PID.TID 0000.0001)     Wall clock time:   1.9007205963134766E-002
+(PID.TID 0000.0001)           User time:   1.8468029797077179E-002
+(PID.TID 0000.0001)         System time:   0.0000000000000000
+(PID.TID 0000.0001)     Wall clock time:   1.8483400344848633E-002
 (PID.TID 0000.0001)          No. starts:          20
 (PID.TID 0000.0001)           No. stops:          20
 (PID.TID 0000.0001)   Seconds in section "MOM_CORRECTION_STEP [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:   1.2438006699085236E-002
-(PID.TID 0000.0001)         System time:   9.1999769210815430E-005
-(PID.TID 0000.0001)     Wall clock time:   1.2539148330688477E-002
+(PID.TID 0000.0001)           User time:   1.1836066842079163E-002
+(PID.TID 0000.0001)         System time:   0.0000000000000000
+(PID.TID 0000.0001)     Wall clock time:   1.1856555938720703E-002
 (PID.TID 0000.0001)          No. starts:          20
 (PID.TID 0000.0001)           No. stops:          20
 (PID.TID 0000.0001)   Seconds in section "INTEGR_CONTINUITY   [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:   7.6170340180397034E-003
-(PID.TID 0000.0001)         System time:   0.0000000000000000
-(PID.TID 0000.0001)     Wall clock time:   7.6241493225097656E-003
+(PID.TID 0000.0001)           User time:   7.2490051388740540E-003
+(PID.TID 0000.0001)         System time:   3.6999955773353577E-004
+(PID.TID 0000.0001)     Wall clock time:   7.6277256011962891E-003
 (PID.TID 0000.0001)          No. starts:          20
 (PID.TID 0000.0001)           No. stops:          20
 (PID.TID 0000.0001)   Seconds in section "BLOCKING_EXCHANGES  [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:   3.4835010766983032E-002
-(PID.TID 0000.0001)         System time:   0.0000000000000000
-(PID.TID 0000.0001)     Wall clock time:   3.4848213195800781E-002
+(PID.TID 0000.0001)           User time:   3.3607967197895050E-002
+(PID.TID 0000.0001)         System time:   1.0639997199177742E-003
+(PID.TID 0000.0001)     Wall clock time:   3.4691810607910156E-002
 (PID.TID 0000.0001)          No. starts:          40
 (PID.TID 0000.0001)           No. stops:          40
 (PID.TID 0000.0001)   Seconds in section "THERMODYNAMICS      [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:  0.42921089380979538
-(PID.TID 0000.0001)         System time:   0.0000000000000000
-(PID.TID 0000.0001)     Wall clock time:  0.42924094200134277
+(PID.TID 0000.0001)           User time:  0.40937489271163940
+(PID.TID 0000.0001)         System time:   1.0009994730353355E-003
+(PID.TID 0000.0001)     Wall clock time:  0.41040802001953125
 (PID.TID 0000.0001)          No. starts:          20
 (PID.TID 0000.0001)           No. stops:          20
 (PID.TID 0000.0001)   Seconds in section "TRC_CORRECTION_STEP [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:   2.0301342010498047E-004
+(PID.TID 0000.0001)           User time:   1.9409507513046265E-004
 (PID.TID 0000.0001)         System time:   0.0000000000000000
-(PID.TID 0000.0001)     Wall clock time:   2.0241737365722656E-004
+(PID.TID 0000.0001)     Wall clock time:   1.9955635070800781E-004
 (PID.TID 0000.0001)          No. starts:          20
 (PID.TID 0000.0001)           No. stops:          20
 (PID.TID 0000.0001)   Seconds in section "MONITOR             [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:   2.4965010583400726E-002
+(PID.TID 0000.0001)           User time:   2.3342072963714600E-002
 (PID.TID 0000.0001)         System time:   0.0000000000000000
-(PID.TID 0000.0001)     Wall clock time:   2.4986028671264648E-002
+(PID.TID 0000.0001)     Wall clock time:   2.3356676101684570E-002
 (PID.TID 0000.0001)          No. starts:          20
 (PID.TID 0000.0001)           No. stops:          20
 (PID.TID 0000.0001)   Seconds in section "DO_THE_MODEL_IO     [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:   4.1600167751312256E-003
-(PID.TID 0000.0001)         System time:   2.1560005843639374E-003
-(PID.TID 0000.0001)     Wall clock time:   6.3211917877197266E-003
+(PID.TID 0000.0001)           User time:   4.8660561442375183E-003
+(PID.TID 0000.0001)         System time:   1.3750009238719940E-003
+(PID.TID 0000.0001)     Wall clock time:   6.2468051910400391E-003
 (PID.TID 0000.0001)          No. starts:          20
 (PID.TID 0000.0001)           No. stops:          20
 (PID.TID 0000.0001)   Seconds in section "DO_WRITE_PICKUP     [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:   1.0680109262466431E-003
-(PID.TID 0000.0001)         System time:   1.0000541806221008E-005
-(PID.TID 0000.0001)     Wall clock time:   1.0797977447509766E-003
+(PID.TID 0000.0001)           User time:   1.7394125461578369E-004
+(PID.TID 0000.0001)         System time:   6.9699995219707489E-004
+(PID.TID 0000.0001)     Wall clock time:   8.6784362792968750E-004
 (PID.TID 0000.0001)          No. starts:          20
 (PID.TID 0000.0001)           No. stops:          20
 (PID.TID 0000.0001) // ======================================================

--- a/verification/global_ocean.cs32x15/results/output.in_p.txt
+++ b/verification/global_ocean.cs32x15/results/output.in_p.txt
@@ -5,10 +5,10 @@
 (PID.TID 0000.0001) // ======================================================
 (PID.TID 0000.0001) // execution environment starting up...
 (PID.TID 0000.0001) 
-(PID.TID 0000.0001) // MITgcmUV version:  checkpoint68q
+(PID.TID 0000.0001) // MITgcmUV version:  checkpoint68w
 (PID.TID 0000.0001) // Build user:        jm_c
 (PID.TID 0000.0001) // Build host:        villon
-(PID.TID 0000.0001) // Build date:        Tue Jul 18 11:59:26 EDT 2023
+(PID.TID 0000.0001) // Build date:        Tue Apr 16 13:10:34 EDT 2024
 (PID.TID 0000.0001) 
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // Execution Environment parameter file "eedata"
@@ -1271,6 +1271,9 @@
 (PID.TID 0000.0001) SEAICEuseLSR      = /* use default Picard-LSR solver */
 (PID.TID 0000.0001)                   T
 (PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) SEAICEuseLSRflex  = /* with residual norm criterion */
+(PID.TID 0000.0001)                   F
+(PID.TID 0000.0001)     ;
 (PID.TID 0000.0001) SEAICEuseKrylov   = /* use Picard-Krylov solver */
 (PID.TID 0000.0001)                   F
 (PID.TID 0000.0001)     ;
@@ -1685,7 +1688,7 @@
 (PID.TID 0000.0001) 
 (PID.TID 0000.0001) ------------------------------------------------------------
 (PID.TID 0000.0001) DIAGNOSTICS_SET_LEVELS: done
-(PID.TID 0000.0001)  Total Nb of available Diagnostics: ndiagt=   320
+(PID.TID 0000.0001)  Total Nb of available Diagnostics: ndiagt=   321
 (PID.TID 0000.0001)  write list of available Diagnostics to file: available_diagnostics.log
 (PID.TID 0000.0001) SETDIAG: Allocate  1 x  1 Levels for Diagnostic #    23 ETAN
 (PID.TID 0000.0001) SETDIAG: Allocate  1 x  1 Levels for Diagnostic #    24 ETANSQ
@@ -2086,8 +2089,8 @@
 (PID.TID 0000.0001)                       0
 (PID.TID 0000.0001)     0= Expl. ; 1= Impl. on provis. Vel ; 2= Fully Impl (with surf.P)
 (PID.TID 0000.0001)     ;
-(PID.TID 0000.0001) metricTerms =  /* metric-Terms on/off flag */
-(PID.TID 0000.0001)                   F
+(PID.TID 0000.0001) selectMetricTerms= /* Metric-Terms on/off flag (=0/1) */
+(PID.TID 0000.0001)                       0
 (PID.TID 0000.0001)     ;
 (PID.TID 0000.0001) useNHMTerms = /* Non-Hydrostatic Metric-Terms on/off */
 (PID.TID 0000.0001)                   F
@@ -2096,8 +2099,8 @@
 (PID.TID 0000.0001)                       2
 (PID.TID 0000.0001)     0= f-Plane ; 1= Beta-Plane ; 2= Spherical ; 3= read from file
 (PID.TID 0000.0001)     ;
-(PID.TID 0000.0001) use3dCoriolis = /* 3-D Coriolis on/off flag */
-(PID.TID 0000.0001)                   F
+(PID.TID 0000.0001) select3dCoriScheme= /* 3-D Coriolis on/off flag (=0/1) */
+(PID.TID 0000.0001)                       0
 (PID.TID 0000.0001)     ;
 (PID.TID 0000.0001) useCoriolis =  /* Coriolis on/off flag */
 (PID.TID 0000.0001)                   T
@@ -3468,37 +3471,37 @@ listId=   2 ; file name: seaiceStDiag
 (PID.TID 0000.0001) SOLVE_FOR_PRESSURE: putPmEinXvector =    F
 (PID.TID 0000.0001) SOLVE_FOR_PRESSURE: zeroPsNH=    F , zeroMeanPnh=    F
 (PID.TID 0000.0001) SOLVE_FOR_PRESSURE: oldFreeSurfTerm =    F
- cg2d: Sum(rhs),rhsMax =   2.40902106503411E-02  1.98075169506440E+01
-(PID.TID 0000.0001)      cg2d_init_res =   1.27331263107017E+01
+ cg2d: Sum(rhs),rhsMax =   2.40902106503424E-02  1.98075169506454E+01
+(PID.TID 0000.0001)      cg2d_init_res =   1.27331263107014E+01
 (PID.TID 0000.0001)      cg2d_iters(min,last) =      -1     113
-(PID.TID 0000.0001)      cg2d_last_res =   8.72799254104450E-10
+(PID.TID 0000.0001)      cg2d_last_res =   8.65511087418070E-10
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // Begin MONITOR dynamic field statistics
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) %MON time_tsnumber                =                     1
 (PID.TID 0000.0001) %MON time_secondsf                =   8.6400000000000E+04
-(PID.TID 0000.0001) %MON dynstat_eta_max              =   1.2901672457761E+04
-(PID.TID 0000.0001) %MON dynstat_eta_min              =  -1.5798236358394E+04
-(PID.TID 0000.0001) %MON dynstat_eta_mean             =  -7.2059481671931E+00
-(PID.TID 0000.0001) %MON dynstat_eta_sd               =   4.5633951462544E+03
-(PID.TID 0000.0001) %MON dynstat_eta_del2             =   9.3109699725817E+01
-(PID.TID 0000.0001) %MON dynstat_uvel_max             =   2.0853585897640E-02
-(PID.TID 0000.0001) %MON dynstat_uvel_min             =  -2.2891733236536E-02
-(PID.TID 0000.0001) %MON dynstat_uvel_mean            =  -1.4360005495116E-04
-(PID.TID 0000.0001) %MON dynstat_uvel_sd              =   1.4965613204064E-03
-(PID.TID 0000.0001) %MON dynstat_uvel_del2            =   7.4901818252572E-06
-(PID.TID 0000.0001) %MON dynstat_vvel_max             =   5.4246966594041E-02
-(PID.TID 0000.0001) %MON dynstat_vvel_min             =  -2.8660961010660E-02
-(PID.TID 0000.0001) %MON dynstat_vvel_mean            =  -2.5353611268934E-05
-(PID.TID 0000.0001) %MON dynstat_vvel_sd              =   1.5659498562017E-03
-(PID.TID 0000.0001) %MON dynstat_vvel_del2            =   7.6408656123503E-06
-(PID.TID 0000.0001) %MON dynstat_wvel_max             =   9.5462858742906E-01
-(PID.TID 0000.0001) %MON dynstat_wvel_min             =  -1.4950399588324E+00
-(PID.TID 0000.0001) %MON dynstat_wvel_mean            =   6.4640821697669E-03
-(PID.TID 0000.0001) %MON dynstat_wvel_sd              =   5.1233542361598E-02
-(PID.TID 0000.0001) %MON dynstat_wvel_del2            =   4.5450690937959E-04
+(PID.TID 0000.0001) %MON dynstat_eta_max              =   1.2901672458942E+04
+(PID.TID 0000.0001) %MON dynstat_eta_min              =  -1.5798236357109E+04
+(PID.TID 0000.0001) %MON dynstat_eta_mean             =  -7.2059481671934E+00
+(PID.TID 0000.0001) %MON dynstat_eta_sd               =   4.5633951463281E+03
+(PID.TID 0000.0001) %MON dynstat_eta_del2             =   9.3109699734973E+01
+(PID.TID 0000.0001) %MON dynstat_uvel_max             =   2.0853585897721E-02
+(PID.TID 0000.0001) %MON dynstat_uvel_min             =  -2.2891733236448E-02
+(PID.TID 0000.0001) %MON dynstat_uvel_mean            =  -1.4360005495222E-04
+(PID.TID 0000.0001) %MON dynstat_uvel_sd              =   1.4965613204076E-03
+(PID.TID 0000.0001) %MON dynstat_uvel_del2            =   7.4901818253273E-06
+(PID.TID 0000.0001) %MON dynstat_vvel_max             =   5.4246966589731E-02
+(PID.TID 0000.0001) %MON dynstat_vvel_min             =  -2.8660961010547E-02
+(PID.TID 0000.0001) %MON dynstat_vvel_mean            =  -2.5353611268101E-05
+(PID.TID 0000.0001) %MON dynstat_vvel_sd              =   1.5659498562020E-03
+(PID.TID 0000.0001) %MON dynstat_vvel_del2            =   7.6408656123618E-06
+(PID.TID 0000.0001) %MON dynstat_wvel_max             =   9.5462858742560E-01
+(PID.TID 0000.0001) %MON dynstat_wvel_min             =  -1.4950399588287E+00
+(PID.TID 0000.0001) %MON dynstat_wvel_mean            =   6.4640821699061E-03
+(PID.TID 0000.0001) %MON dynstat_wvel_sd              =   5.1233542361681E-02
+(PID.TID 0000.0001) %MON dynstat_wvel_del2            =   4.5450690938060E-04
 (PID.TID 0000.0001) %MON dynstat_theta_max            =   2.9392258707438E+01
-(PID.TID 0000.0001) %MON dynstat_theta_min            =  -1.8746172822183E+00
+(PID.TID 0000.0001) %MON dynstat_theta_min            =  -1.8746172822182E+00
 (PID.TID 0000.0001) %MON dynstat_theta_mean           =   3.5913319085257E+00
 (PID.TID 0000.0001) %MON dynstat_theta_sd             =   4.4271594928447E+00
 (PID.TID 0000.0001) %MON dynstat_theta_del2           =   2.1216005952791E-03
@@ -3506,7 +3509,7 @@ listId=   2 ; file name: seaiceStDiag
 (PID.TID 0000.0001) %MON dynstat_salt_min             =   1.8145258136301E+01
 (PID.TID 0000.0001) %MON dynstat_salt_mean            =   3.4721452713784E+01
 (PID.TID 0000.0001) %MON dynstat_salt_sd              =   4.8788469045420E-01
-(PID.TID 0000.0001) %MON dynstat_salt_del2            =   5.1443829693791E-04
+(PID.TID 0000.0001) %MON dynstat_salt_del2            =   5.1443829693773E-04
 (PID.TID 0000.0001) %MON forcing_qnet_max             =   7.0424222788353E+02
 (PID.TID 0000.0001) %MON forcing_qnet_min             =  -3.1743723293440E+02
 (PID.TID 0000.0001) %MON forcing_qnet_mean            =  -1.7570280474041E+01
@@ -3532,25 +3535,25 @@ listId=   2 ; file name: seaiceStDiag
 (PID.TID 0000.0001) %MON forcing_fv_mean              =  -1.3684501518858E-02
 (PID.TID 0000.0001) %MON forcing_fv_sd                =   7.5153512230531E-02
 (PID.TID 0000.0001) %MON forcing_fv_del2              =   2.3373863441584E-04
-(PID.TID 0000.0001) %MON trAdv_CFL_u_max              =   9.3906206996152E-03
-(PID.TID 0000.0001) %MON trAdv_CFL_v_max              =   1.8371368978856E-02
-(PID.TID 0000.0001) %MON trAdv_CFL_w_max              =   3.8688064937700E-02
-(PID.TID 0000.0001) %MON advcfl_uvel_max              =   6.7030426005249E-03
-(PID.TID 0000.0001) %MON advcfl_vvel_max              =   1.7701308101942E-02
-(PID.TID 0000.0001) %MON advcfl_wvel_max              =   4.2364454873478E-02
-(PID.TID 0000.0001) %MON advcfl_W_hf_max              =   4.6812921150028E-02
-(PID.TID 0000.0001) %MON pe_b_mean                    =   9.0238727205629E-03
-(PID.TID 0000.0001) %MON ke_max                       =   7.8068549276330E-04
-(PID.TID 0000.0001) %MON ke_mean                      =   2.1763151900607E-06
+(PID.TID 0000.0001) %MON trAdv_CFL_u_max              =   9.3906206995266E-03
+(PID.TID 0000.0001) %MON trAdv_CFL_v_max              =   1.8371368977397E-02
+(PID.TID 0000.0001) %MON trAdv_CFL_w_max              =   3.8688064937559E-02
+(PID.TID 0000.0001) %MON advcfl_uvel_max              =   6.7030426004639E-03
+(PID.TID 0000.0001) %MON advcfl_vvel_max              =   1.7701308100535E-02
+(PID.TID 0000.0001) %MON advcfl_wvel_max              =   4.2364454873324E-02
+(PID.TID 0000.0001) %MON advcfl_W_hf_max              =   4.6812921149858E-02
+(PID.TID 0000.0001) %MON pe_b_mean                    =   9.0238727206956E-03
+(PID.TID 0000.0001) %MON ke_max                       =   7.8068549268396E-04
+(PID.TID 0000.0001) %MON ke_mean                      =   2.1763151900629E-06
 (PID.TID 0000.0001) %MON ke_vol                       =   1.3604176684230E+22
-(PID.TID 0000.0001) %MON vort_r_min                   =  -2.1675335223380E-07
-(PID.TID 0000.0001) %MON vort_r_max                   =   2.6920810771400E-07
+(PID.TID 0000.0001) %MON vort_r_min                   =  -2.1675335221829E-07
+(PID.TID 0000.0001) %MON vort_r_max                   =   2.6920810771321E-07
 (PID.TID 0000.0001) %MON vort_a_mean                  =  -2.0556865257795E-05
 (PID.TID 0000.0001) %MON vort_a_sd                    =   7.5247378156126E-05
 (PID.TID 0000.0001) %MON vort_p_mean                  =  -2.4859393568698E-05
 (PID.TID 0000.0001) %MON vort_p_sd                    =   1.2919002127129E-04
-(PID.TID 0000.0001) %MON surfExpan_theta_mean         =  -2.2359492150247E-02
-(PID.TID 0000.0001) %MON surfExpan_salt_mean          =  -1.1897897151820E-03
+(PID.TID 0000.0001) %MON surfExpan_theta_mean         =  -2.2359492150728E-02
+(PID.TID 0000.0001) %MON surfExpan_salt_mean          =  -1.1897897152038E-03
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // End MONITOR dynamic field statistics
 (PID.TID 0000.0001) // =======================================================
@@ -3589,50 +3592,50 @@ listId=   2 ; file name: seaiceStDiag
 (PID.TID 0000.0001) // =======================================================
  EXTERNAL_FIELDS_LOAD,         1 : iP,iLd,i0,i1=   12    1   12    1 ; Wght=  0.4666666667  0.5333333333
  SEAICE_LSR: Residual Initial ipass,Uice,Vice=         1  5.13965689E-04  9.82437187E-04
- SEAICE_LSR (ipass=        1) iters,dU,Resid=       12  4.18221013E-13  1.50541546E-19
- SEAICE_LSR (ipass=        1) iters,dV,Resid=       12  2.81774604E-13  2.66616713E-19
+ SEAICE_LSR (ipass=        1) iters,dU,Resid=       12  4.18221013E-13  1.72766944E-19
+ SEAICE_LSR (ipass=        1) iters,dV,Resid=       12  2.81830115E-13  2.68610926E-19
  SEAICE_LSR: Residual Initial ipass,Uice,Vice=         2  2.91320933E-04  5.24466150E-04
- SEAICE_LSR (ipass=        2) iters,dU,Resid=       12  6.06459327E-14  9.14970337E-20
- SEAICE_LSR (ipass=        2) iters,dV,Resid=       12  4.21190860E-14  1.81575351E-19
- cg2d: Sum(rhs),rhsMax =   7.66661820774850E-02  2.00457239865342E+01
-(PID.TID 0000.0001)      cg2d_init_res =   4.84221893103093E-01
+ SEAICE_LSR (ipass=        2) iters,dU,Resid=       12  6.06736883E-14  8.65586393E-20
+ SEAICE_LSR (ipass=        2) iters,dV,Resid=       12  4.21329638E-14  1.74655402E-19
+ cg2d: Sum(rhs),rhsMax =   7.66661820772763E-02  2.00457239865908E+01
+(PID.TID 0000.0001)      cg2d_init_res =   4.84221892744953E-01
 (PID.TID 0000.0001)      cg2d_iters(min,last) =      -1     109
-(PID.TID 0000.0001)      cg2d_last_res =   8.72677277486335E-10
+(PID.TID 0000.0001)      cg2d_last_res =   8.71776742558140E-10
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // Begin MONITOR dynamic field statistics
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) %MON time_tsnumber                =                     2
 (PID.TID 0000.0001) %MON time_secondsf                =   1.7280000000000E+05
-(PID.TID 0000.0001) %MON dynstat_eta_max              =   1.4036965278188E+04
-(PID.TID 0000.0001) %MON dynstat_eta_min              =  -2.1104916363008E+04
-(PID.TID 0000.0001) %MON dynstat_eta_mean             =  -2.3208447105573E+01
-(PID.TID 0000.0001) %MON dynstat_eta_sd               =   6.2877655145156E+03
-(PID.TID 0000.0001) %MON dynstat_eta_del2             =   9.5570817526248E+01
-(PID.TID 0000.0001) %MON dynstat_uvel_max             =   3.8475392352578E-02
-(PID.TID 0000.0001) %MON dynstat_uvel_min             =  -4.4823815930171E-02
-(PID.TID 0000.0001) %MON dynstat_uvel_mean            =  -3.3193706807576E-04
-(PID.TID 0000.0001) %MON dynstat_uvel_sd              =   2.3399461644726E-03
-(PID.TID 0000.0001) %MON dynstat_uvel_del2            =   1.2333968631004E-05
-(PID.TID 0000.0001) %MON dynstat_vvel_max             =   7.3366327760999E-02
-(PID.TID 0000.0001) %MON dynstat_vvel_min             =  -5.6465928900613E-02
-(PID.TID 0000.0001) %MON dynstat_vvel_mean            =  -6.8051627585531E-05
-(PID.TID 0000.0001) %MON dynstat_vvel_sd              =   2.4524491996191E-03
-(PID.TID 0000.0001) %MON dynstat_vvel_del2            =   1.2959847032672E-05
-(PID.TID 0000.0001) %MON dynstat_wvel_max             =   1.8519222502982E+00
-(PID.TID 0000.0001) %MON dynstat_wvel_min             =  -2.9433441100239E+00
-(PID.TID 0000.0001) %MON dynstat_wvel_mean            =   2.4537896036600E-03
-(PID.TID 0000.0001) %MON dynstat_wvel_sd              =   8.9180896435905E-02
-(PID.TID 0000.0001) %MON dynstat_wvel_del2            =   7.6787559900243E-04
+(PID.TID 0000.0001) %MON dynstat_eta_max              =   1.4036965280473E+04
+(PID.TID 0000.0001) %MON dynstat_eta_min              =  -2.1104916363302E+04
+(PID.TID 0000.0001) %MON dynstat_eta_mean             =  -2.3208447105574E+01
+(PID.TID 0000.0001) %MON dynstat_eta_sd               =   6.2877655146377E+03
+(PID.TID 0000.0001) %MON dynstat_eta_del2             =   9.5570817540132E+01
+(PID.TID 0000.0001) %MON dynstat_uvel_max             =   3.8475392351844E-02
+(PID.TID 0000.0001) %MON dynstat_uvel_min             =  -4.4823815930194E-02
+(PID.TID 0000.0001) %MON dynstat_uvel_mean            =  -3.3193706807663E-04
+(PID.TID 0000.0001) %MON dynstat_uvel_sd              =   2.3399461644735E-03
+(PID.TID 0000.0001) %MON dynstat_uvel_del2            =   1.2333968630971E-05
+(PID.TID 0000.0001) %MON dynstat_vvel_max             =   7.3366327756240E-02
+(PID.TID 0000.0001) %MON dynstat_vvel_min             =  -5.6465928900794E-02
+(PID.TID 0000.0001) %MON dynstat_vvel_mean            =  -6.8051627584731E-05
+(PID.TID 0000.0001) %MON dynstat_vvel_sd              =   2.4524491996181E-03
+(PID.TID 0000.0001) %MON dynstat_vvel_del2            =   1.2959847032664E-05
+(PID.TID 0000.0001) %MON dynstat_wvel_max             =   1.8519222503037E+00
+(PID.TID 0000.0001) %MON dynstat_wvel_min             =  -2.9433441100238E+00
+(PID.TID 0000.0001) %MON dynstat_wvel_mean            =   2.4537896038018E-03
+(PID.TID 0000.0001) %MON dynstat_wvel_sd              =   8.9180896435766E-02
+(PID.TID 0000.0001) %MON dynstat_wvel_del2            =   7.6787559900145E-04
 (PID.TID 0000.0001) %MON dynstat_theta_max            =   2.9400728092453E+01
 (PID.TID 0000.0001) %MON dynstat_theta_min            =  -1.8772209402055E+00
 (PID.TID 0000.0001) %MON dynstat_theta_mean           =   3.5913487270807E+00
 (PID.TID 0000.0001) %MON dynstat_theta_sd             =   4.4274062489038E+00
 (PID.TID 0000.0001) %MON dynstat_theta_del2           =   2.1124454951578E-03
 (PID.TID 0000.0001) %MON dynstat_salt_max             =   4.0715790109972E+01
-(PID.TID 0000.0001) %MON dynstat_salt_min             =   1.8061466083992E+01
+(PID.TID 0000.0001) %MON dynstat_salt_min             =   1.8061466083960E+01
 (PID.TID 0000.0001) %MON dynstat_salt_mean            =   3.4721464665355E+01
-(PID.TID 0000.0001) %MON dynstat_salt_sd              =   4.8779450629029E-01
-(PID.TID 0000.0001) %MON dynstat_salt_del2            =   5.1533721863536E-04
+(PID.TID 0000.0001) %MON dynstat_salt_sd              =   4.8779450629030E-01
+(PID.TID 0000.0001) %MON dynstat_salt_del2            =   5.1533721863495E-04
 (PID.TID 0000.0001) %MON forcing_qnet_max             =   6.9568301659527E+02
 (PID.TID 0000.0001) %MON forcing_qnet_min             =  -3.1666111122704E+02
 (PID.TID 0000.0001) %MON forcing_qnet_mean            =  -2.1816693251500E+01
@@ -3643,11 +3646,11 @@ listId=   2 ; file name: seaiceStDiag
 (PID.TID 0000.0001) %MON forcing_qsw_mean             =  -1.8593263173938E+02
 (PID.TID 0000.0001) %MON forcing_qsw_sd               =   7.9196898015892E+01
 (PID.TID 0000.0001) %MON forcing_qsw_del2             =   1.1042682315688E-01
-(PID.TID 0000.0001) %MON forcing_empmr_max            =   1.7538245291051E-03
+(PID.TID 0000.0001) %MON forcing_empmr_max            =   1.7538245291048E-03
 (PID.TID 0000.0001) %MON forcing_empmr_min            =  -4.4649989994565E-04
 (PID.TID 0000.0001) %MON forcing_empmr_mean           =   1.8880133341804E-05
-(PID.TID 0000.0001) %MON forcing_empmr_sd             =   1.7400318919877E-04
-(PID.TID 0000.0001) %MON forcing_empmr_del2           =   2.4749984748073E-06
+(PID.TID 0000.0001) %MON forcing_empmr_sd             =   1.7400318919876E-04
+(PID.TID 0000.0001) %MON forcing_empmr_del2           =   2.4749984748071E-06
 (PID.TID 0000.0001) %MON forcing_fu_max               =   2.4755808644372E-01
 (PID.TID 0000.0001) %MON forcing_fu_min               =  -2.0607770640355E-01
 (PID.TID 0000.0001) %MON forcing_fu_mean              =  -4.4985339072935E-03
@@ -3658,25 +3661,25 @@ listId=   2 ; file name: seaiceStDiag
 (PID.TID 0000.0001) %MON forcing_fv_mean              =  -1.3688466828783E-02
 (PID.TID 0000.0001) %MON forcing_fv_sd                =   7.5192568394754E-02
 (PID.TID 0000.0001) %MON forcing_fv_del2              =   2.3387409827838E-04
-(PID.TID 0000.0001) %MON trAdv_CFL_u_max              =   1.5992061894299E-02
-(PID.TID 0000.0001) %MON trAdv_CFL_v_max              =   2.4917775183719E-02
-(PID.TID 0000.0001) %MON trAdv_CFL_w_max              =   7.6016943787404E-02
-(PID.TID 0000.0001) %MON advcfl_uvel_max              =   1.4235257677686E-02
-(PID.TID 0000.0001) %MON advcfl_vvel_max              =   2.3940139947809E-02
-(PID.TID 0000.0001) %MON advcfl_wvel_max              =   8.3246518013417E-02
-(PID.TID 0000.0001) %MON advcfl_W_hf_max              =   9.1981214395611E-02
-(PID.TID 0000.0001) %MON pe_b_mean                    =   1.2124608444944E-02
-(PID.TID 0000.0001) %MON ke_max                       =   1.6821389677623E-03
-(PID.TID 0000.0001) %MON ke_mean                      =   5.3584141389703E-06
+(PID.TID 0000.0001) %MON trAdv_CFL_u_max              =   1.5992061894228E-02
+(PID.TID 0000.0001) %MON trAdv_CFL_v_max              =   2.4917775182106E-02
+(PID.TID 0000.0001) %MON trAdv_CFL_w_max              =   7.6016943787393E-02
+(PID.TID 0000.0001) %MON advcfl_uvel_max              =   1.4235257677904E-02
+(PID.TID 0000.0001) %MON advcfl_vvel_max              =   2.3940139946257E-02
+(PID.TID 0000.0001) %MON advcfl_wvel_max              =   8.3246518013408E-02
+(PID.TID 0000.0001) %MON advcfl_W_hf_max              =   9.1981214395597E-02
+(PID.TID 0000.0001) %MON pe_b_mean                    =   1.2124608445203E-02
+(PID.TID 0000.0001) %MON ke_max                       =   1.6821389676977E-03
+(PID.TID 0000.0001) %MON ke_mean                      =   5.3584141389702E-06
 (PID.TID 0000.0001) %MON ke_vol                       =   1.3604174062081E+22
-(PID.TID 0000.0001) %MON vort_r_min                   =  -3.6133387797972E-07
-(PID.TID 0000.0001) %MON vort_r_max                   =   4.3008997581162E-07
+(PID.TID 0000.0001) %MON vort_r_min                   =  -3.6133387797630E-07
+(PID.TID 0000.0001) %MON vort_r_max                   =   4.3008997581284E-07
 (PID.TID 0000.0001) %MON vort_a_mean                  =  -2.0556865257795E-05
 (PID.TID 0000.0001) %MON vort_a_sd                    =   7.5247345870982E-05
 (PID.TID 0000.0001) %MON vort_p_mean                  =  -2.4859276343879E-05
-(PID.TID 0000.0001) %MON vort_p_sd                    =   1.2919529006779E-04
-(PID.TID 0000.0001) %MON surfExpan_theta_mean         =   7.0941750293490E-03
-(PID.TID 0000.0001) %MON surfExpan_salt_mean          =  -4.3489608523514E-03
+(PID.TID 0000.0001) %MON vort_p_sd                    =   1.2919529006778E-04
+(PID.TID 0000.0001) %MON surfExpan_theta_mean         =   7.0941750295316E-03
+(PID.TID 0000.0001) %MON surfExpan_salt_mean          =  -4.3489608523855E-03
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // End MONITOR dynamic field statistics
 (PID.TID 0000.0001) // =======================================================
@@ -3685,124 +3688,124 @@ listId=   2 ; file name: seaiceStDiag
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) %MON seaice_tsnumber              =                     2
 (PID.TID 0000.0001) %MON seaice_time_sec              =   1.7280000000000E+05
-(PID.TID 0000.0001) %MON seaice_uice_max              =   7.3890952399295E-02
-(PID.TID 0000.0001) %MON seaice_uice_min              =  -1.5290969918722E-01
-(PID.TID 0000.0001) %MON seaice_uice_mean             =  -2.4881484813002E-04
-(PID.TID 0000.0001) %MON seaice_uice_sd               =   7.3563029203112E-03
-(PID.TID 0000.0001) %MON seaice_uice_del2             =   1.4059024833203E-04
-(PID.TID 0000.0001) %MON seaice_vice_max              =   1.1358611117065E-01
-(PID.TID 0000.0001) %MON seaice_vice_min              =  -1.0853114929970E-01
-(PID.TID 0000.0001) %MON seaice_vice_mean             =   3.8472249052108E-04
-(PID.TID 0000.0001) %MON seaice_vice_sd               =   1.0695508673738E-02
-(PID.TID 0000.0001) %MON seaice_vice_del2             =   1.5150970671677E-04
+(PID.TID 0000.0001) %MON seaice_uice_max              =   7.3890952399299E-02
+(PID.TID 0000.0001) %MON seaice_uice_min              =  -1.5290969918710E-01
+(PID.TID 0000.0001) %MON seaice_uice_mean             =  -2.4881484812978E-04
+(PID.TID 0000.0001) %MON seaice_uice_sd               =   7.3563029203088E-03
+(PID.TID 0000.0001) %MON seaice_uice_del2             =   1.4059024833196E-04
+(PID.TID 0000.0001) %MON seaice_vice_max              =   1.1358611117095E-01
+(PID.TID 0000.0001) %MON seaice_vice_min              =  -1.0853114929980E-01
+(PID.TID 0000.0001) %MON seaice_vice_mean             =   3.8472249052129E-04
+(PID.TID 0000.0001) %MON seaice_vice_sd               =   1.0695508673742E-02
+(PID.TID 0000.0001) %MON seaice_vice_del2             =   1.5150970671692E-04
 (PID.TID 0000.0001) %MON seaice_area_max              =   5.2863391261661E-01
 (PID.TID 0000.0001) %MON seaice_area_min              =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON seaice_area_mean             =   5.7850301773832E-03
-(PID.TID 0000.0001) %MON seaice_area_sd               =   4.8215057294990E-02
-(PID.TID 0000.0001) %MON seaice_area_del2             =   5.1728804682532E-04
+(PID.TID 0000.0001) %MON seaice_area_mean             =   5.7850301773831E-03
+(PID.TID 0000.0001) %MON seaice_area_sd               =   4.8215057294989E-02
+(PID.TID 0000.0001) %MON seaice_area_del2             =   5.1728804682531E-04
 (PID.TID 0000.0001) %MON seaice_heff_max              =   2.8850295323282E-01
 (PID.TID 0000.0001) %MON seaice_heff_min              =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON seaice_heff_mean             =   2.9688901762534E-03
 (PID.TID 0000.0001) %MON seaice_heff_sd               =   2.4888776692042E-02
-(PID.TID 0000.0001) %MON seaice_heff_del2             =   2.6731814740289E-04
-(PID.TID 0000.0001) %MON seaice_hsnow_max             =   7.7350648682502E-04
+(PID.TID 0000.0001) %MON seaice_heff_del2             =   2.6731814740288E-04
+(PID.TID 0000.0001) %MON seaice_hsnow_max             =   7.7350648682493E-04
 (PID.TID 0000.0001) %MON seaice_hsnow_min             =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON seaice_hsnow_mean            =   4.4751292178649E-06
-(PID.TID 0000.0001) %MON seaice_hsnow_sd              =   4.8608571265505E-05
+(PID.TID 0000.0001) %MON seaice_hsnow_sd              =   4.8608571265504E-05
 (PID.TID 0000.0001) %MON seaice_hsnow_del2            =   8.0627621982811E-07
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // End MONITOR SEAICE statistics
 (PID.TID 0000.0001) // =======================================================
  EXTERNAL_FIELDS_LOAD,         2 : iP,iLd,i0,i1=   12    1   12    1 ; Wght=  0.4333333333  0.5666666667
  SEAICE_LSR: Residual Initial ipass,Uice,Vice=         1  5.59552591E-04  8.46157414E-04
- SEAICE_LSR (ipass=        1) iters,dU,Resid=       12  2.57960320E-13  2.34823094E-19
- SEAICE_LSR (ipass=        1) iters,dV,Resid=       12  1.46355150E-13  2.64692987E-19
+ SEAICE_LSR (ipass=        1) iters,dU,Resid=       12  2.57960320E-13  2.25984940E-19
+ SEAICE_LSR (ipass=        1) iters,dV,Resid=       12  1.46355150E-13  2.63755722E-19
  SEAICE_LSR: Residual Initial ipass,Uice,Vice=         2  1.59909245E-04  1.95870482E-04
- SEAICE_LSR (ipass=        2) iters,dU,Resid=       12  2.29677388E-14  1.76191580E-19
- SEAICE_LSR (ipass=        2) iters,dV,Resid=       12  3.57535182E-14  3.86110598E-19
- cg2d: Sum(rhs),rhsMax =   1.38049425831494E-01  1.98889658832412E+01
-(PID.TID 0000.0001)      cg2d_init_res =   1.91529690946784E-01
+ SEAICE_LSR (ipass=        2) iters,dU,Resid=       12  2.29677388E-14  1.37844250E-19
+ SEAICE_LSR (ipass=        2) iters,dV,Resid=       12  3.57535182E-14  2.54246415E-19
+ cg2d: Sum(rhs),rhsMax =   1.38049425831618E-01  1.98889658832225E+01
+(PID.TID 0000.0001)      cg2d_init_res =   1.91529691502481E-01
 (PID.TID 0000.0001)      cg2d_iters(min,last) =      -1     104
-(PID.TID 0000.0001)      cg2d_last_res =   9.56058000892377E-10
+(PID.TID 0000.0001)      cg2d_last_res =   9.59441042071305E-10
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // Begin MONITOR dynamic field statistics
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) %MON time_tsnumber                =                     3
 (PID.TID 0000.0001) %MON time_secondsf                =   2.5920000000000E+05
-(PID.TID 0000.0001) %MON dynstat_eta_max              =   1.3305516526985E+04
-(PID.TID 0000.0001) %MON dynstat_eta_min              =  -2.3897564836868E+04
-(PID.TID 0000.0001) %MON dynstat_eta_mean             =  -4.1463628767815E+01
-(PID.TID 0000.0001) %MON dynstat_eta_sd               =   7.0652247930115E+03
-(PID.TID 0000.0001) %MON dynstat_eta_del2             =   9.3851343154866E+01
-(PID.TID 0000.0001) %MON dynstat_uvel_max             =   5.4254244566545E-02
-(PID.TID 0000.0001) %MON dynstat_uvel_min             =  -6.4744466395562E-02
-(PID.TID 0000.0001) %MON dynstat_uvel_mean            =  -4.5171924061939E-04
-(PID.TID 0000.0001) %MON dynstat_uvel_sd              =   3.2106858601110E-03
-(PID.TID 0000.0001) %MON dynstat_uvel_del2            =   1.7239083075837E-05
-(PID.TID 0000.0001) %MON dynstat_vvel_max             =   8.8892296034718E-02
-(PID.TID 0000.0001) %MON dynstat_vvel_min             =  -8.2041441953303E-02
-(PID.TID 0000.0001) %MON dynstat_vvel_mean            =  -1.5754247872497E-04
-(PID.TID 0000.0001) %MON dynstat_vvel_sd              =   3.3125866737399E-03
-(PID.TID 0000.0001) %MON dynstat_vvel_del2            =   1.8229281068958E-05
-(PID.TID 0000.0001) %MON dynstat_wvel_max             =   2.6902867121102E+00
-(PID.TID 0000.0001) %MON dynstat_wvel_min             =  -4.3239209096397E+00
-(PID.TID 0000.0001) %MON dynstat_wvel_mean            =   8.8462872569652E-04
-(PID.TID 0000.0001) %MON dynstat_wvel_sd              =   1.2601871748436E-01
-(PID.TID 0000.0001) %MON dynstat_wvel_del2            =   1.0609038796059E-03
+(PID.TID 0000.0001) %MON dynstat_eta_max              =   1.3305516525891E+04
+(PID.TID 0000.0001) %MON dynstat_eta_min              =  -2.3897564836908E+04
+(PID.TID 0000.0001) %MON dynstat_eta_mean             =  -4.1463628767812E+01
+(PID.TID 0000.0001) %MON dynstat_eta_sd               =   7.0652247929834E+03
+(PID.TID 0000.0001) %MON dynstat_eta_del2             =   9.3851343151412E+01
+(PID.TID 0000.0001) %MON dynstat_uvel_max             =   5.4254244566495E-02
+(PID.TID 0000.0001) %MON dynstat_uvel_min             =  -6.4744466395582E-02
+(PID.TID 0000.0001) %MON dynstat_uvel_mean            =  -4.5171924061715E-04
+(PID.TID 0000.0001) %MON dynstat_uvel_sd              =   3.2106858601113E-03
+(PID.TID 0000.0001) %MON dynstat_uvel_del2            =   1.7239083075824E-05
+(PID.TID 0000.0001) %MON dynstat_vvel_max             =   8.8892296034768E-02
+(PID.TID 0000.0001) %MON dynstat_vvel_min             =  -8.2041441953317E-02
+(PID.TID 0000.0001) %MON dynstat_vvel_mean            =  -1.5754247872472E-04
+(PID.TID 0000.0001) %MON dynstat_vvel_sd              =   3.3125866737405E-03
+(PID.TID 0000.0001) %MON dynstat_vvel_del2            =   1.8229281068869E-05
+(PID.TID 0000.0001) %MON dynstat_wvel_max             =   2.6902867121119E+00
+(PID.TID 0000.0001) %MON dynstat_wvel_min             =  -4.3239209096422E+00
+(PID.TID 0000.0001) %MON dynstat_wvel_mean            =   8.8462872533439E-04
+(PID.TID 0000.0001) %MON dynstat_wvel_sd              =   1.2601871748442E-01
+(PID.TID 0000.0001) %MON dynstat_wvel_del2            =   1.0609038796076E-03
 (PID.TID 0000.0001) %MON dynstat_theta_max            =   2.9408480192321E+01
 (PID.TID 0000.0001) %MON dynstat_theta_min            =  -1.8865125950424E+00
 (PID.TID 0000.0001) %MON dynstat_theta_mean           =   3.5914740059489E+00
 (PID.TID 0000.0001) %MON dynstat_theta_sd             =   4.4277422829002E+00
 (PID.TID 0000.0001) %MON dynstat_theta_del2           =   2.0889810983395E-03
 (PID.TID 0000.0001) %MON dynstat_salt_max             =   4.0715813000502E+01
-(PID.TID 0000.0001) %MON dynstat_salt_min             =   1.7830036731087E+01
+(PID.TID 0000.0001) %MON dynstat_salt_min             =   1.7830036731091E+01
 (PID.TID 0000.0001) %MON dynstat_salt_mean            =   3.4721481368936E+01
 (PID.TID 0000.0001) %MON dynstat_salt_sd              =   4.8771643649436E-01
-(PID.TID 0000.0001) %MON dynstat_salt_del2            =   5.1199098268270E-04
+(PID.TID 0000.0001) %MON dynstat_salt_del2            =   5.1199098268277E-04
 (PID.TID 0000.0001) %MON forcing_qnet_max             =   6.8753323860620E+02
 (PID.TID 0000.0001) %MON forcing_qnet_min             =  -3.1582909723280E+02
-(PID.TID 0000.0001) %MON forcing_qnet_mean            =  -2.4471477074852E+01
+(PID.TID 0000.0001) %MON forcing_qnet_mean            =  -2.4471477074853E+01
 (PID.TID 0000.0001) %MON forcing_qnet_sd              =   1.6481294282837E+02
-(PID.TID 0000.0001) %MON forcing_qnet_del2            =   1.1176544376517E+00
+(PID.TID 0000.0001) %MON forcing_qnet_del2            =   1.1176544376518E+00
 (PID.TID 0000.0001) %MON forcing_qsw_max              =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON forcing_qsw_min              =  -3.0189127925792E+02
 (PID.TID 0000.0001) %MON forcing_qsw_mean             =  -1.8593879213095E+02
 (PID.TID 0000.0001) %MON forcing_qsw_sd               =   7.9086030762546E+01
 (PID.TID 0000.0001) %MON forcing_qsw_del2             =   1.1032203144530E-01
-(PID.TID 0000.0001) %MON forcing_empmr_max            =   1.7770026056383E-03
+(PID.TID 0000.0001) %MON forcing_empmr_max            =   1.7770026056385E-03
 (PID.TID 0000.0001) %MON forcing_empmr_min            =  -4.4823526083756E-04
 (PID.TID 0000.0001) %MON forcing_empmr_mean           =   2.1537902629404E-05
 (PID.TID 0000.0001) %MON forcing_empmr_sd             =   1.7644260801941E-04
-(PID.TID 0000.0001) %MON forcing_empmr_del2           =   2.7013953056429E-06
+(PID.TID 0000.0001) %MON forcing_empmr_del2           =   2.7013953056427E-06
 (PID.TID 0000.0001) %MON forcing_fu_max               =   2.4751003717351E-01
 (PID.TID 0000.0001) %MON forcing_fu_min               =  -2.0922350306190E-01
 (PID.TID 0000.0001) %MON forcing_fu_mean              =  -4.4451620525371E-03
-(PID.TID 0000.0001) %MON forcing_fu_sd                =   6.3963989757866E-02
-(PID.TID 0000.0001) %MON forcing_fu_del2              =   2.0566380553731E-04
+(PID.TID 0000.0001) %MON forcing_fu_sd                =   6.3963989757867E-02
+(PID.TID 0000.0001) %MON forcing_fu_del2              =   2.0566380553733E-04
 (PID.TID 0000.0001) %MON forcing_fv_max               =   2.5817746358114E-01
 (PID.TID 0000.0001) %MON forcing_fv_min               =  -3.2849573188785E-01
-(PID.TID 0000.0001) %MON forcing_fv_mean              =  -1.3688991868700E-02
+(PID.TID 0000.0001) %MON forcing_fv_mean              =  -1.3688991868701E-02
 (PID.TID 0000.0001) %MON forcing_fv_sd                =   7.5246627512406E-02
-(PID.TID 0000.0001) %MON forcing_fv_del2              =   2.3426168319918E-04
-(PID.TID 0000.0001) %MON trAdv_CFL_u_max              =   2.2399469630421E-02
-(PID.TID 0000.0001) %MON trAdv_CFL_v_max              =   3.1505566378534E-02
-(PID.TID 0000.0001) %MON trAdv_CFL_w_max              =   1.1159285137977E-01
-(PID.TID 0000.0001) %MON advcfl_uvel_max              =   2.0095832862162E-02
-(PID.TID 0000.0001) %MON advcfl_vvel_max              =   2.6274890318669E-02
-(PID.TID 0000.0001) %MON advcfl_wvel_max              =   1.2219895352134E-01
-(PID.TID 0000.0001) %MON advcfl_W_hf_max              =   1.3502839599138E-01
-(PID.TID 0000.0001) %MON pe_b_mean                    =   1.3156201526893E-02
-(PID.TID 0000.0001) %MON ke_max                       =   2.6260719230104E-03
-(PID.TID 0000.0001) %MON ke_mean                      =   9.9317944391177E-06
+(PID.TID 0000.0001) %MON forcing_fv_del2              =   2.3426168319917E-04
+(PID.TID 0000.0001) %MON trAdv_CFL_u_max              =   2.2399469630442E-02
+(PID.TID 0000.0001) %MON trAdv_CFL_v_max              =   3.1505566378583E-02
+(PID.TID 0000.0001) %MON trAdv_CFL_w_max              =   1.1159285137985E-01
+(PID.TID 0000.0001) %MON advcfl_uvel_max              =   2.0095832861967E-02
+(PID.TID 0000.0001) %MON advcfl_vvel_max              =   2.6274890318548E-02
+(PID.TID 0000.0001) %MON advcfl_wvel_max              =   1.2219895352143E-01
+(PID.TID 0000.0001) %MON advcfl_W_hf_max              =   1.3502839599147E-01
+(PID.TID 0000.0001) %MON pe_b_mean                    =   1.3156201526826E-02
+(PID.TID 0000.0001) %MON ke_max                       =   2.6260719230119E-03
+(PID.TID 0000.0001) %MON ke_mean                      =   9.9317944391192E-06
 (PID.TID 0000.0001) %MON ke_vol                       =   1.3604168238984E+22
-(PID.TID 0000.0001) %MON vort_r_min                   =  -4.9977030381728E-07
-(PID.TID 0000.0001) %MON vort_r_max                   =   5.2424367259793E-07
+(PID.TID 0000.0001) %MON vort_r_min                   =  -4.9977030381542E-07
+(PID.TID 0000.0001) %MON vort_r_max                   =   5.2424367260399E-07
 (PID.TID 0000.0001) %MON vort_a_mean                  =  -2.0556865257794E-05
 (PID.TID 0000.0001) %MON vort_a_sd                    =   7.5247335739735E-05
 (PID.TID 0000.0001) %MON vort_p_mean                  =  -2.4859228572286E-05
 (PID.TID 0000.0001) %MON vort_p_sd                    =   1.2920027960417E-04
-(PID.TID 0000.0001) %MON surfExpan_theta_mean         =   1.1500648556353E-02
-(PID.TID 0000.0001) %MON surfExpan_salt_mean          =  -5.7349990163425E-03
+(PID.TID 0000.0001) %MON surfExpan_theta_mean         =   1.1500648556883E-02
+(PID.TID 0000.0001) %MON surfExpan_salt_mean          =  -5.7349990162466E-03
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // End MONITOR dynamic field statistics
 (PID.TID 0000.0001) // =======================================================
@@ -3811,124 +3814,124 @@ listId=   2 ; file name: seaiceStDiag
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) %MON seaice_tsnumber              =                     3
 (PID.TID 0000.0001) %MON seaice_time_sec              =   2.5920000000000E+05
-(PID.TID 0000.0001) %MON seaice_uice_max              =   1.2724428033123E-01
-(PID.TID 0000.0001) %MON seaice_uice_min              =  -1.8208657069026E-01
-(PID.TID 0000.0001) %MON seaice_uice_mean             =  -3.0920738062971E-04
-(PID.TID 0000.0001) %MON seaice_uice_sd               =   9.5004997553721E-03
-(PID.TID 0000.0001) %MON seaice_uice_del2             =   2.0182969247114E-04
-(PID.TID 0000.0001) %MON seaice_vice_max              =   1.4349914736132E-01
-(PID.TID 0000.0001) %MON seaice_vice_min              =  -1.4748942214969E-01
-(PID.TID 0000.0001) %MON seaice_vice_mean             =   9.1149296699587E-04
-(PID.TID 0000.0001) %MON seaice_vice_sd               =   1.3507372646666E-02
-(PID.TID 0000.0001) %MON seaice_vice_del2             =   1.2915897524999E-04
-(PID.TID 0000.0001) %MON seaice_area_max              =   6.7874318643308E-01
+(PID.TID 0000.0001) %MON seaice_uice_max              =   1.2724428033188E-01
+(PID.TID 0000.0001) %MON seaice_uice_min              =  -1.8208657069302E-01
+(PID.TID 0000.0001) %MON seaice_uice_mean             =  -3.0920738063344E-04
+(PID.TID 0000.0001) %MON seaice_uice_sd               =   9.5004997553944E-03
+(PID.TID 0000.0001) %MON seaice_uice_del2             =   2.0182969247342E-04
+(PID.TID 0000.0001) %MON seaice_vice_max              =   1.4349914736051E-01
+(PID.TID 0000.0001) %MON seaice_vice_min              =  -1.4748942215034E-01
+(PID.TID 0000.0001) %MON seaice_vice_mean             =   9.1149296699422E-04
+(PID.TID 0000.0001) %MON seaice_vice_sd               =   1.3507372646654E-02
+(PID.TID 0000.0001) %MON seaice_vice_del2             =   1.2915897524930E-04
+(PID.TID 0000.0001) %MON seaice_area_max              =   6.7874318643202E-01
 (PID.TID 0000.0001) %MON seaice_area_min              =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON seaice_area_mean             =   9.8891559375926E-03
-(PID.TID 0000.0001) %MON seaice_area_sd               =   7.2978818783020E-02
+(PID.TID 0000.0001) %MON seaice_area_sd               =   7.2978818783021E-02
 (PID.TID 0000.0001) %MON seaice_area_del2             =   7.4107326270466E-04
-(PID.TID 0000.0001) %MON seaice_heff_max              =   3.7961498255969E-01
+(PID.TID 0000.0001) %MON seaice_heff_max              =   3.7961498255997E-01
 (PID.TID 0000.0001) %MON seaice_heff_min              =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON seaice_heff_mean             =   5.2116600148314E-03
 (PID.TID 0000.0001) %MON seaice_heff_sd               =   3.8744044652629E-02
 (PID.TID 0000.0001) %MON seaice_heff_del2             =   3.8870495211741E-04
-(PID.TID 0000.0001) %MON seaice_hsnow_max             =   1.8610648703187E-03
+(PID.TID 0000.0001) %MON seaice_hsnow_max             =   1.8610648703208E-03
 (PID.TID 0000.0001) %MON seaice_hsnow_min             =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON seaice_hsnow_mean            =   1.5451751934406E-05
 (PID.TID 0000.0001) %MON seaice_hsnow_sd              =   1.3298410683426E-04
-(PID.TID 0000.0001) %MON seaice_hsnow_del2            =   1.7228175798997E-06
+(PID.TID 0000.0001) %MON seaice_hsnow_del2            =   1.7228175798990E-06
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // End MONITOR SEAICE statistics
 (PID.TID 0000.0001) // =======================================================
  EXTERNAL_FIELDS_LOAD,         3 : iP,iLd,i0,i1=   12    1   12    1 ; Wght=  0.4000000000  0.6000000000
  SEAICE_LSR: Residual Initial ipass,Uice,Vice=         1  2.79845113E-04  3.78981856E-04
- SEAICE_LSR (ipass=        1) iters,dU,Resid=       12  3.15303339E-14  3.47479417E-19
- SEAICE_LSR (ipass=        1) iters,dV,Resid=       12  7.81041898E-14  5.12157796E-19
+ SEAICE_LSR (ipass=        1) iters,dU,Resid=       12  3.15580895E-14  3.18260475E-19
+ SEAICE_LSR (ipass=        1) iters,dV,Resid=       12  7.80903120E-14  5.22177534E-19
  SEAICE_LSR: Residual Initial ipass,Uice,Vice=         2  9.45419359E-05  8.82855237E-05
- SEAICE_LSR (ipass=        2) iters,dU,Resid=       12  1.88737914E-15  2.54720979E-19
- SEAICE_LSR (ipass=        2) iters,dV,Resid=       12  3.63615388E-14  4.18259268E-19
- cg2d: Sum(rhs),rhsMax =   1.97520473329250E-01  1.98884008061778E+01
-(PID.TID 0000.0001)      cg2d_init_res =   9.80683486677676E-02
+ SEAICE_LSR (ipass=        2) iters,dU,Resid=       12  1.88737914E-15  2.53029128E-19
+ SEAICE_LSR (ipass=        2) iters,dV,Resid=       12  3.63615388E-14  5.89740259E-19
+ cg2d: Sum(rhs),rhsMax =   1.97520473329181E-01  1.98884008061846E+01
+(PID.TID 0000.0001)      cg2d_init_res =   9.80683486728597E-02
 (PID.TID 0000.0001)      cg2d_iters(min,last) =      -1     103
-(PID.TID 0000.0001)      cg2d_last_res =   7.44319660156703E-10
+(PID.TID 0000.0001)      cg2d_last_res =   7.44319166625156E-10
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // Begin MONITOR dynamic field statistics
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) %MON time_tsnumber                =                     4
 (PID.TID 0000.0001) %MON time_secondsf                =   3.4560000000000E+05
-(PID.TID 0000.0001) %MON dynstat_eta_max              =   1.3102045225677E+04
-(PID.TID 0000.0001) %MON dynstat_eta_min              =  -2.3941781808318E+04
-(PID.TID 0000.0001) %MON dynstat_eta_mean             =  -5.9324280722999E+01
-(PID.TID 0000.0001) %MON dynstat_eta_sd               =   7.3741565115914E+03
-(PID.TID 0000.0001) %MON dynstat_eta_del2             =   9.3599179350555E+01
-(PID.TID 0000.0001) %MON dynstat_uvel_max             =   6.9734861389442E-02
-(PID.TID 0000.0001) %MON dynstat_uvel_min             =  -8.2795555183744E-02
-(PID.TID 0000.0001) %MON dynstat_uvel_mean            =  -4.6674385569669E-04
-(PID.TID 0000.0001) %MON dynstat_uvel_sd              =   4.1172564167209E-03
-(PID.TID 0000.0001) %MON dynstat_uvel_del2            =   2.2001267135032E-05
-(PID.TID 0000.0001) %MON dynstat_vvel_max             =   1.1498265105137E-01
-(PID.TID 0000.0001) %MON dynstat_vvel_min             =  -1.0576001484649E-01
-(PID.TID 0000.0001) %MON dynstat_vvel_mean            =  -2.7736446358358E-04
-(PID.TID 0000.0001) %MON dynstat_vvel_sd              =   4.2207540855216E-03
-(PID.TID 0000.0001) %MON dynstat_vvel_del2            =   2.3155903735472E-05
-(PID.TID 0000.0001) %MON dynstat_wvel_max             =   3.4523072949724E+00
-(PID.TID 0000.0001) %MON dynstat_wvel_min             =  -5.6353544455082E+00
-(PID.TID 0000.0001) %MON dynstat_wvel_mean            =   2.6323446727807E-04
-(PID.TID 0000.0001) %MON dynstat_wvel_sd              =   1.6024471722570E-01
-(PID.TID 0000.0001) %MON dynstat_wvel_del2            =   1.3202392812947E-03
+(PID.TID 0000.0001) %MON dynstat_eta_max              =   1.3102045225688E+04
+(PID.TID 0000.0001) %MON dynstat_eta_min              =  -2.3941781808325E+04
+(PID.TID 0000.0001) %MON dynstat_eta_mean             =  -5.9324280723000E+01
+(PID.TID 0000.0001) %MON dynstat_eta_sd               =   7.3741565115902E+03
+(PID.TID 0000.0001) %MON dynstat_eta_del2             =   9.3599179350316E+01
+(PID.TID 0000.0001) %MON dynstat_uvel_max             =   6.9734861389437E-02
+(PID.TID 0000.0001) %MON dynstat_uvel_min             =  -8.2795555183729E-02
+(PID.TID 0000.0001) %MON dynstat_uvel_mean            =  -4.6674385569711E-04
+(PID.TID 0000.0001) %MON dynstat_uvel_sd              =   4.1172564167206E-03
+(PID.TID 0000.0001) %MON dynstat_uvel_del2            =   2.2001267135038E-05
+(PID.TID 0000.0001) %MON dynstat_vvel_max             =   1.1498265105141E-01
+(PID.TID 0000.0001) %MON dynstat_vvel_min             =  -1.0576001484652E-01
+(PID.TID 0000.0001) %MON dynstat_vvel_mean            =  -2.7736446358439E-04
+(PID.TID 0000.0001) %MON dynstat_vvel_sd              =   4.2207540855218E-03
+(PID.TID 0000.0001) %MON dynstat_vvel_del2            =   2.3155903735473E-05
+(PID.TID 0000.0001) %MON dynstat_wvel_max             =   3.4523072949746E+00
+(PID.TID 0000.0001) %MON dynstat_wvel_min             =  -5.6353544455108E+00
+(PID.TID 0000.0001) %MON dynstat_wvel_mean            =   2.6323446735519E-04
+(PID.TID 0000.0001) %MON dynstat_wvel_sd              =   1.6024471722565E-01
+(PID.TID 0000.0001) %MON dynstat_wvel_del2            =   1.3202392812946E-03
 (PID.TID 0000.0001) %MON dynstat_theta_max            =   2.9415540454614E+01
 (PID.TID 0000.0001) %MON dynstat_theta_min            =  -1.8888212710790E+00
 (PID.TID 0000.0001) %MON dynstat_theta_mean           =   3.5916322316561E+00
 (PID.TID 0000.0001) %MON dynstat_theta_sd             =   4.4280392285594E+00
 (PID.TID 0000.0001) %MON dynstat_theta_del2           =   2.1044374499790E-03
 (PID.TID 0000.0001) %MON dynstat_salt_max             =   4.0715840180939E+01
-(PID.TID 0000.0001) %MON dynstat_salt_min             =   1.7561082639457E+01
+(PID.TID 0000.0001) %MON dynstat_salt_min             =   1.7561082639473E+01
 (PID.TID 0000.0001) %MON dynstat_salt_mean            =   3.4721498356130E+01
 (PID.TID 0000.0001) %MON dynstat_salt_sd              =   4.8760590309877E-01
-(PID.TID 0000.0001) %MON dynstat_salt_del2            =   5.1503408299080E-04
-(PID.TID 0000.0001) %MON forcing_qnet_max             =   6.8030478499597E+02
+(PID.TID 0000.0001) %MON dynstat_salt_del2            =   5.1503408299099E-04
+(PID.TID 0000.0001) %MON forcing_qnet_max             =   6.8030478499556E+02
 (PID.TID 0000.0001) %MON forcing_qnet_min             =  -3.1494449142178E+02
-(PID.TID 0000.0001) %MON forcing_qnet_mean            =  -2.5935127125962E+01
+(PID.TID 0000.0001) %MON forcing_qnet_mean            =  -2.5935127125963E+01
 (PID.TID 0000.0001) %MON forcing_qnet_sd              =   1.6015147957481E+02
-(PID.TID 0000.0001) %MON forcing_qnet_del2            =   9.6299152554354E-01
+(PID.TID 0000.0001) %MON forcing_qnet_del2            =   9.6299152554333E-01
 (PID.TID 0000.0001) %MON forcing_qsw_max              =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON forcing_qsw_min              =  -3.0187928232211E+02
 (PID.TID 0000.0001) %MON forcing_qsw_mean             =  -1.8594494413345E+02
 (PID.TID 0000.0001) %MON forcing_qsw_sd               =   7.8977862623784E+01
 (PID.TID 0000.0001) %MON forcing_qsw_del2             =   1.1028061737190E-01
-(PID.TID 0000.0001) %MON forcing_empmr_max            =   1.6292799959370E-03
+(PID.TID 0000.0001) %MON forcing_empmr_max            =   1.6292799959373E-03
 (PID.TID 0000.0001) %MON forcing_empmr_min            =  -4.4998185671542E-04
 (PID.TID 0000.0001) %MON forcing_empmr_mean           =   2.1072426986808E-05
-(PID.TID 0000.0001) %MON forcing_empmr_sd             =   1.6068845673359E-04
-(PID.TID 0000.0001) %MON forcing_empmr_del2           =   1.9615798835656E-06
+(PID.TID 0000.0001) %MON forcing_empmr_sd             =   1.6068845673358E-04
+(PID.TID 0000.0001) %MON forcing_empmr_del2           =   1.9615798835639E-06
 (PID.TID 0000.0001) %MON forcing_fu_max               =   2.4746198790331E-01
 (PID.TID 0000.0001) %MON forcing_fu_min               =  -2.1236929972025E-01
-(PID.TID 0000.0001) %MON forcing_fu_mean              =  -4.3916023190072E-03
+(PID.TID 0000.0001) %MON forcing_fu_mean              =  -4.3916023190069E-03
 (PID.TID 0000.0001) %MON forcing_fu_sd                =   6.3996063913045E-02
-(PID.TID 0000.0001) %MON forcing_fu_del2              =   2.0634347943575E-04
+(PID.TID 0000.0001) %MON forcing_fu_del2              =   2.0634347943578E-04
 (PID.TID 0000.0001) %MON forcing_fv_max               =   2.6086070515377E-01
 (PID.TID 0000.0001) %MON forcing_fv_min               =  -3.2928363582178E-01
-(PID.TID 0000.0001) %MON forcing_fv_mean              =  -1.3689822430126E-02
+(PID.TID 0000.0001) %MON forcing_fv_mean              =  -1.3689822430127E-02
 (PID.TID 0000.0001) %MON forcing_fv_sd                =   7.5311854584818E-02
-(PID.TID 0000.0001) %MON forcing_fv_del2              =   2.3488218439246E-04
-(PID.TID 0000.0001) %MON trAdv_CFL_u_max              =   2.9515021950012E-02
-(PID.TID 0000.0001) %MON trAdv_CFL_v_max              =   4.1207011141438E-02
-(PID.TID 0000.0001) %MON trAdv_CFL_w_max              =   1.4539945616148E-01
-(PID.TID 0000.0001) %MON advcfl_uvel_max              =   2.5031827627629E-02
-(PID.TID 0000.0001) %MON advcfl_vvel_max              =   3.2505790058442E-02
-(PID.TID 0000.0001) %MON advcfl_wvel_max              =   1.5921921607259E-01
-(PID.TID 0000.0001) %MON advcfl_W_hf_max              =   1.7593470460477E-01
-(PID.TID 0000.0001) %MON pe_b_mean                    =   1.3492776290119E-02
-(PID.TID 0000.0001) %MON ke_max                       =   4.4053273844921E-03
-(PID.TID 0000.0001) %MON ke_mean                      =   1.6188303210795E-05
+(PID.TID 0000.0001) %MON forcing_fv_del2              =   2.3488218439240E-04
+(PID.TID 0000.0001) %MON trAdv_CFL_u_max              =   2.9515021950090E-02
+(PID.TID 0000.0001) %MON trAdv_CFL_v_max              =   4.1207011141476E-02
+(PID.TID 0000.0001) %MON trAdv_CFL_w_max              =   1.4539945616156E-01
+(PID.TID 0000.0001) %MON advcfl_uvel_max              =   2.5031827627612E-02
+(PID.TID 0000.0001) %MON advcfl_vvel_max              =   3.2505790058454E-02
+(PID.TID 0000.0001) %MON advcfl_wvel_max              =   1.5921921607267E-01
+(PID.TID 0000.0001) %MON advcfl_W_hf_max              =   1.7593470460486E-01
+(PID.TID 0000.0001) %MON pe_b_mean                    =   1.3492776290115E-02
+(PID.TID 0000.0001) %MON ke_max                       =   4.4053273844953E-03
+(PID.TID 0000.0001) %MON ke_mean                      =   1.6188303210794E-05
 (PID.TID 0000.0001) %MON ke_vol                       =   1.3604161596165E+22
-(PID.TID 0000.0001) %MON vort_r_min                   =  -5.6816685197144E-07
-(PID.TID 0000.0001) %MON vort_r_max                   =   5.8099501587591E-07
+(PID.TID 0000.0001) %MON vort_r_min                   =  -5.6816685197097E-07
+(PID.TID 0000.0001) %MON vort_r_max                   =   5.8099501587492E-07
 (PID.TID 0000.0001) %MON vort_a_mean                  =  -2.0556865257795E-05
 (PID.TID 0000.0001) %MON vort_a_sd                    =   7.5247344302724E-05
 (PID.TID 0000.0001) %MON vort_p_mean                  =  -2.4859216047217E-05
 (PID.TID 0000.0001) %MON vort_p_sd                    =   1.2920357708264E-04
-(PID.TID 0000.0001) %MON surfExpan_theta_mean         =   9.2647810649243E-03
-(PID.TID 0000.0001) %MON surfExpan_salt_mean          =  -6.2711724529143E-03
+(PID.TID 0000.0001) %MON surfExpan_theta_mean         =   9.2647810646829E-03
+(PID.TID 0000.0001) %MON surfExpan_salt_mean          =  -6.2711724529366E-03
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // End MONITOR dynamic field statistics
 (PID.TID 0000.0001) // =======================================================
@@ -3937,124 +3940,124 @@ listId=   2 ; file name: seaiceStDiag
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) %MON seaice_tsnumber              =                     4
 (PID.TID 0000.0001) %MON seaice_time_sec              =   3.4560000000000E+05
-(PID.TID 0000.0001) %MON seaice_uice_max              =   1.0868746514753E-01
-(PID.TID 0000.0001) %MON seaice_uice_min              =  -1.9589701659280E-01
-(PID.TID 0000.0001) %MON seaice_uice_mean             =  -2.6880542883471E-04
-(PID.TID 0000.0001) %MON seaice_uice_sd               =   9.5683254973117E-03
-(PID.TID 0000.0001) %MON seaice_uice_del2             =   1.8684626426729E-04
-(PID.TID 0000.0001) %MON seaice_vice_max              =   1.5216495769080E-01
-(PID.TID 0000.0001) %MON seaice_vice_min              =  -1.6372542804929E-01
-(PID.TID 0000.0001) %MON seaice_vice_mean             =   9.6920164672684E-04
-(PID.TID 0000.0001) %MON seaice_vice_sd               =   1.4178977572970E-02
-(PID.TID 0000.0001) %MON seaice_vice_del2             =   1.1647709207839E-04
-(PID.TID 0000.0001) %MON seaice_area_max              =   7.8638727206046E-01
+(PID.TID 0000.0001) %MON seaice_uice_max              =   1.0868746514763E-01
+(PID.TID 0000.0001) %MON seaice_uice_min              =  -1.9589701659137E-01
+(PID.TID 0000.0001) %MON seaice_uice_mean             =  -2.6880542883981E-04
+(PID.TID 0000.0001) %MON seaice_uice_sd               =   9.5683254972598E-03
+(PID.TID 0000.0001) %MON seaice_uice_del2             =   1.8684626426586E-04
+(PID.TID 0000.0001) %MON seaice_vice_max              =   1.5216495769002E-01
+(PID.TID 0000.0001) %MON seaice_vice_min              =  -1.6372542805251E-01
+(PID.TID 0000.0001) %MON seaice_vice_mean             =   9.6920164672682E-04
+(PID.TID 0000.0001) %MON seaice_vice_sd               =   1.4178977572966E-02
+(PID.TID 0000.0001) %MON seaice_vice_del2             =   1.1647709207739E-04
+(PID.TID 0000.0001) %MON seaice_area_max              =   7.8638727205898E-01
 (PID.TID 0000.0001) %MON seaice_area_min              =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON seaice_area_mean             =   1.3619910803048E-02
+(PID.TID 0000.0001) %MON seaice_area_mean             =   1.3619910803047E-02
 (PID.TID 0000.0001) %MON seaice_area_sd               =   9.3179537950964E-02
-(PID.TID 0000.0001) %MON seaice_area_del2             =   8.1678459545111E-04
-(PID.TID 0000.0001) %MON seaice_heff_max              =   4.5246455815521E-01
+(PID.TID 0000.0001) %MON seaice_area_del2             =   8.1678459545170E-04
+(PID.TID 0000.0001) %MON seaice_heff_max              =   4.5246455815428E-01
 (PID.TID 0000.0001) %MON seaice_heff_min              =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON seaice_heff_mean             =   7.4166357200087E-03
-(PID.TID 0000.0001) %MON seaice_heff_sd               =   5.1242914446495E-02
-(PID.TID 0000.0001) %MON seaice_heff_del2             =   4.4909624856616E-04
-(PID.TID 0000.0001) %MON seaice_hsnow_max             =   3.6101802927263E-03
+(PID.TID 0000.0001) %MON seaice_heff_sd               =   5.1242914446497E-02
+(PID.TID 0000.0001) %MON seaice_heff_del2             =   4.4909624856642E-04
+(PID.TID 0000.0001) %MON seaice_hsnow_max             =   3.6101802927247E-03
 (PID.TID 0000.0001) %MON seaice_hsnow_min             =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON seaice_hsnow_mean            =   3.3613048323829E-05
-(PID.TID 0000.0001) %MON seaice_hsnow_sd              =   2.6980270903803E-04
-(PID.TID 0000.0001) %MON seaice_hsnow_del2            =   3.5048178653035E-06
+(PID.TID 0000.0001) %MON seaice_hsnow_mean            =   3.3613048323833E-05
+(PID.TID 0000.0001) %MON seaice_hsnow_sd              =   2.6980270903805E-04
+(PID.TID 0000.0001) %MON seaice_hsnow_del2            =   3.5048178653028E-06
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // End MONITOR SEAICE statistics
 (PID.TID 0000.0001) // =======================================================
  EXTERNAL_FIELDS_LOAD,         4 : iP,iLd,i0,i1=   12    1   12    1 ; Wght=  0.3666666667  0.6333333333
  SEAICE_LSR: Residual Initial ipass,Uice,Vice=         1  5.11121423E-04  3.80837163E-04
- SEAICE_LSR (ipass=        1) iters,dU,Resid=       12  6.04183370E-13  4.83848385E-19
- SEAICE_LSR (ipass=        1) iters,dV,Resid=       12  8.65557626E-14  7.30463566E-19
+ SEAICE_LSR (ipass=        1) iters,dU,Resid=       12  6.04294392E-13  5.60916929E-19
+ SEAICE_LSR (ipass=        1) iters,dV,Resid=       12  8.65418848E-14  9.28643768E-19
  SEAICE_LSR: Residual Initial ipass,Uice,Vice=         2  5.52067181E-04  1.19683702E-04
- SEAICE_LSR (ipass=        2) iters,dU,Resid=       12  9.30089339E-14  6.28346729E-19
- SEAICE_LSR (ipass=        2) iters,dV,Resid=       12  3.57908148E-14  5.74716075E-19
- cg2d: Sum(rhs),rhsMax =   2.46785490243518E-01  1.98977599419296E+01
-(PID.TID 0000.0001)      cg2d_init_res =   8.11890420112090E-02
+ SEAICE_LSR (ipass=        2) iters,dU,Resid=       12  9.29811783E-14  6.30577945E-19
+ SEAICE_LSR (ipass=        2) iters,dV,Resid=       12  3.57769370E-14  6.16917061E-19
+ cg2d: Sum(rhs),rhsMax =   2.46785490243507E-01  1.98977599419306E+01
+(PID.TID 0000.0001)      cg2d_init_res =   8.11890420153594E-02
 (PID.TID 0000.0001)      cg2d_iters(min,last) =      -1     102
-(PID.TID 0000.0001)      cg2d_last_res =   8.61221649154348E-10
+(PID.TID 0000.0001)      cg2d_last_res =   8.61217504481345E-10
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // Begin MONITOR dynamic field statistics
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) %MON time_tsnumber                =                     5
 (PID.TID 0000.0001) %MON time_secondsf                =   4.3200000000000E+05
-(PID.TID 0000.0001) %MON dynstat_eta_max              =   1.3206462383900E+04
-(PID.TID 0000.0001) %MON dynstat_eta_min              =  -2.3570667417394E+04
+(PID.TID 0000.0001) %MON dynstat_eta_max              =   1.3206462383883E+04
+(PID.TID 0000.0001) %MON dynstat_eta_min              =  -2.3570667417393E+04
 (PID.TID 0000.0001) %MON dynstat_eta_mean             =  -7.4155660722936E+01
-(PID.TID 0000.0001) %MON dynstat_eta_sd               =   7.4414202707482E+03
-(PID.TID 0000.0001) %MON dynstat_eta_del2             =   9.3713739732336E+01
-(PID.TID 0000.0001) %MON dynstat_uvel_max             =   8.4677444894757E-02
-(PID.TID 0000.0001) %MON dynstat_uvel_min             =  -1.0065273355756E-01
-(PID.TID 0000.0001) %MON dynstat_uvel_mean            =  -3.9406095868149E-04
+(PID.TID 0000.0001) %MON dynstat_eta_sd               =   7.4414202707508E+03
+(PID.TID 0000.0001) %MON dynstat_eta_del2             =   9.3713739732589E+01
+(PID.TID 0000.0001) %MON dynstat_uvel_max             =   8.4677444894752E-02
+(PID.TID 0000.0001) %MON dynstat_uvel_min             =  -1.0065273355754E-01
+(PID.TID 0000.0001) %MON dynstat_uvel_mean            =  -3.9406095868057E-04
 (PID.TID 0000.0001) %MON dynstat_uvel_sd              =   5.0200246736889E-03
-(PID.TID 0000.0001) %MON dynstat_uvel_del2            =   2.6355420136741E-05
-(PID.TID 0000.0001) %MON dynstat_vvel_max             =   1.3882053821738E-01
-(PID.TID 0000.0001) %MON dynstat_vvel_min             =  -1.2778211850343E-01
-(PID.TID 0000.0001) %MON dynstat_vvel_mean            =  -3.9213559157646E-04
-(PID.TID 0000.0001) %MON dynstat_vvel_sd              =   5.1500682925098E-03
-(PID.TID 0000.0001) %MON dynstat_vvel_del2            =   2.7546458492293E-05
-(PID.TID 0000.0001) %MON dynstat_wvel_max             =   4.1196970899106E+00
-(PID.TID 0000.0001) %MON dynstat_wvel_min             =  -6.8475989516363E+00
-(PID.TID 0000.0001) %MON dynstat_wvel_mean            =  -3.7021067397075E-06
-(PID.TID 0000.0001) %MON dynstat_wvel_sd              =   1.9087060788612E-01
-(PID.TID 0000.0001) %MON dynstat_wvel_del2            =   1.5405271630816E-03
+(PID.TID 0000.0001) %MON dynstat_uvel_del2            =   2.6355420136744E-05
+(PID.TID 0000.0001) %MON dynstat_vvel_max             =   1.3882053821743E-01
+(PID.TID 0000.0001) %MON dynstat_vvel_min             =  -1.2778211850345E-01
+(PID.TID 0000.0001) %MON dynstat_vvel_mean            =  -3.9213559157703E-04
+(PID.TID 0000.0001) %MON dynstat_vvel_sd              =   5.1500682925099E-03
+(PID.TID 0000.0001) %MON dynstat_vvel_del2            =   2.7546458492305E-05
+(PID.TID 0000.0001) %MON dynstat_wvel_max             =   4.1196970899125E+00
+(PID.TID 0000.0001) %MON dynstat_wvel_min             =  -6.8475989516382E+00
+(PID.TID 0000.0001) %MON dynstat_wvel_mean            =  -3.7021067283447E-06
+(PID.TID 0000.0001) %MON dynstat_wvel_sd              =   1.9087060788610E-01
+(PID.TID 0000.0001) %MON dynstat_wvel_del2            =   1.5405271630814E-03
 (PID.TID 0000.0001) %MON dynstat_theta_max            =   2.9421955886486E+01
 (PID.TID 0000.0001) %MON dynstat_theta_min            =  -1.8938198484307E+00
 (PID.TID 0000.0001) %MON dynstat_theta_mean           =   3.5917948791187E+00
 (PID.TID 0000.0001) %MON dynstat_theta_sd             =   4.4284275783065E+00
 (PID.TID 0000.0001) %MON dynstat_theta_del2           =   2.0808969497711E-03
 (PID.TID 0000.0001) %MON dynstat_salt_max             =   4.0715864194542E+01
-(PID.TID 0000.0001) %MON dynstat_salt_min             =   1.7267725868077E+01
+(PID.TID 0000.0001) %MON dynstat_salt_min             =   1.7267725868086E+01
 (PID.TID 0000.0001) %MON dynstat_salt_mean            =   3.4721512058069E+01
 (PID.TID 0000.0001) %MON dynstat_salt_sd              =   4.8754120089836E-01
-(PID.TID 0000.0001) %MON dynstat_salt_del2            =   5.1079892250705E-04
-(PID.TID 0000.0001) %MON forcing_qnet_max             =   1.4431065185424E+03
+(PID.TID 0000.0001) %MON dynstat_salt_del2            =   5.1079892250714E-04
+(PID.TID 0000.0001) %MON forcing_qnet_max             =   1.4431065185421E+03
 (PID.TID 0000.0001) %MON forcing_qnet_min             =  -3.1401884123695E+02
 (PID.TID 0000.0001) %MON forcing_qnet_mean            =  -2.6384321446065E+01
 (PID.TID 0000.0001) %MON forcing_qnet_sd              =   1.5898000061424E+02
-(PID.TID 0000.0001) %MON forcing_qnet_del2            =   1.3506060968992E+00
+(PID.TID 0000.0001) %MON forcing_qnet_del2            =   1.3506060968991E+00
 (PID.TID 0000.0001) %MON forcing_qsw_max              =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON forcing_qsw_min              =  -3.0186728538630E+02
 (PID.TID 0000.0001) %MON forcing_qsw_mean             =  -1.8595109427343E+02
 (PID.TID 0000.0001) %MON forcing_qsw_sd               =   7.8872389323802E+01
 (PID.TID 0000.0001) %MON forcing_qsw_del2             =   1.1030265382374E-01
 (PID.TID 0000.0001) %MON forcing_empmr_max            =   1.8663480840345E-03
-(PID.TID 0000.0001) %MON forcing_empmr_min            =  -3.5517475243565E-03
+(PID.TID 0000.0001) %MON forcing_empmr_min            =  -3.5517475243555E-03
 (PID.TID 0000.0001) %MON forcing_empmr_mean           =   1.7498419035679E-05
 (PID.TID 0000.0001) %MON forcing_empmr_sd             =   1.6171459666025E-04
-(PID.TID 0000.0001) %MON forcing_empmr_del2           =   3.7310390068556E-06
+(PID.TID 0000.0001) %MON forcing_empmr_del2           =   3.7310390068543E-06
 (PID.TID 0000.0001) %MON forcing_fu_max               =   2.4741393863310E-01
 (PID.TID 0000.0001) %MON forcing_fu_min               =  -2.1551509637860E-01
-(PID.TID 0000.0001) %MON forcing_fu_mean              =  -4.3387452455812E-03
+(PID.TID 0000.0001) %MON forcing_fu_mean              =  -4.3387452455813E-03
 (PID.TID 0000.0001) %MON forcing_fu_sd                =   6.4042641720765E-02
-(PID.TID 0000.0001) %MON forcing_fu_del2              =   2.0717909138390E-04
+(PID.TID 0000.0001) %MON forcing_fu_del2              =   2.0717909138391E-04
 (PID.TID 0000.0001) %MON forcing_fv_max               =   2.6354394672640E-01
 (PID.TID 0000.0001) %MON forcing_fv_min               =  -3.3007153975572E-01
 (PID.TID 0000.0001) %MON forcing_fv_mean              =  -1.3691530154093E-02
 (PID.TID 0000.0001) %MON forcing_fv_sd                =   7.5386108639045E-02
-(PID.TID 0000.0001) %MON forcing_fv_del2              =   2.3568412122218E-04
-(PID.TID 0000.0001) %MON trAdv_CFL_u_max              =   3.6219986029917E-02
-(PID.TID 0000.0001) %MON trAdv_CFL_v_max              =   5.0264969859844E-02
-(PID.TID 0000.0001) %MON trAdv_CFL_w_max              =   1.7658025459359E-01
-(PID.TID 0000.0001) %MON advcfl_uvel_max              =   3.0805944939303E-02
-(PID.TID 0000.0001) %MON advcfl_vvel_max              =   3.9244801105502E-02
-(PID.TID 0000.0001) %MON advcfl_wvel_max              =   1.9337410251953E-01
-(PID.TID 0000.0001) %MON advcfl_W_hf_max              =   2.1366376292670E-01
-(PID.TID 0000.0001) %MON pe_b_mean                    =   1.3558472527946E-02
-(PID.TID 0000.0001) %MON ke_max                       =   6.4891679787942E-03
+(PID.TID 0000.0001) %MON forcing_fv_del2              =   2.3568412122214E-04
+(PID.TID 0000.0001) %MON trAdv_CFL_u_max              =   3.6219986029975E-02
+(PID.TID 0000.0001) %MON trAdv_CFL_v_max              =   5.0264969859866E-02
+(PID.TID 0000.0001) %MON trAdv_CFL_w_max              =   1.7658025459364E-01
+(PID.TID 0000.0001) %MON advcfl_uvel_max              =   3.0805944939293E-02
+(PID.TID 0000.0001) %MON advcfl_vvel_max              =   3.9244801105516E-02
+(PID.TID 0000.0001) %MON advcfl_wvel_max              =   1.9337410251959E-01
+(PID.TID 0000.0001) %MON advcfl_W_hf_max              =   2.1366376292677E-01
+(PID.TID 0000.0001) %MON pe_b_mean                    =   1.3558472527950E-02
+(PID.TID 0000.0001) %MON ke_max                       =   6.4891679787964E-03
 (PID.TID 0000.0001) %MON ke_mean                      =   2.4024912782136E-05
 (PID.TID 0000.0001) %MON ke_vol                       =   1.3604155096911E+22
-(PID.TID 0000.0001) %MON vort_r_min                   =  -5.8241111880940E-07
-(PID.TID 0000.0001) %MON vort_r_max                   =   6.2816615104267E-07
+(PID.TID 0000.0001) %MON vort_r_min                   =  -5.8241111880946E-07
+(PID.TID 0000.0001) %MON vort_r_max                   =   6.2816615104759E-07
 (PID.TID 0000.0001) %MON vort_a_mean                  =  -2.0556865257795E-05
 (PID.TID 0000.0001) %MON vort_a_sd                    =   7.5247363992506E-05
 (PID.TID 0000.0001) %MON vort_p_mean                  =  -2.4859219133084E-05
 (PID.TID 0000.0001) %MON vort_p_sd                    =   1.2920535510748E-04
-(PID.TID 0000.0001) %MON surfExpan_theta_mean         =   6.4685598526527E-03
-(PID.TID 0000.0001) %MON surfExpan_salt_mean          =  -5.5496607994611E-03
+(PID.TID 0000.0001) %MON surfExpan_theta_mean         =   6.4685598526344E-03
+(PID.TID 0000.0001) %MON surfExpan_salt_mean          =  -5.5496607994824E-03
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // End MONITOR dynamic field statistics
 (PID.TID 0000.0001) // =======================================================
@@ -4063,70 +4066,70 @@ listId=   2 ; file name: seaiceStDiag
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) %MON seaice_tsnumber              =                     5
 (PID.TID 0000.0001) %MON seaice_time_sec              =   4.3200000000000E+05
-(PID.TID 0000.0001) %MON seaice_uice_max              =   1.2617171819746E-01
-(PID.TID 0000.0001) %MON seaice_uice_min              =  -2.1181211811266E-01
-(PID.TID 0000.0001) %MON seaice_uice_mean             =  -4.9064016689560E-04
-(PID.TID 0000.0001) %MON seaice_uice_sd               =   1.1923615152041E-02
-(PID.TID 0000.0001) %MON seaice_uice_del2             =   1.7675959383962E-04
-(PID.TID 0000.0001) %MON seaice_vice_max              =   1.5590231177344E-01
-(PID.TID 0000.0001) %MON seaice_vice_min              =  -1.5990044898495E-01
-(PID.TID 0000.0001) %MON seaice_vice_mean             =   1.0616438631590E-03
-(PID.TID 0000.0001) %MON seaice_vice_sd               =   1.5044616788990E-02
-(PID.TID 0000.0001) %MON seaice_vice_del2             =   1.1220654521856E-04
-(PID.TID 0000.0001) %MON seaice_area_max              =   8.6147191454222E-01
+(PID.TID 0000.0001) %MON seaice_uice_max              =   1.2617171819692E-01
+(PID.TID 0000.0001) %MON seaice_uice_min              =  -2.1181211811286E-01
+(PID.TID 0000.0001) %MON seaice_uice_mean             =  -4.9064016689570E-04
+(PID.TID 0000.0001) %MON seaice_uice_sd               =   1.1923615152032E-02
+(PID.TID 0000.0001) %MON seaice_uice_del2             =   1.7675959383958E-04
+(PID.TID 0000.0001) %MON seaice_vice_max              =   1.5590231177348E-01
+(PID.TID 0000.0001) %MON seaice_vice_min              =  -1.5990044898435E-01
+(PID.TID 0000.0001) %MON seaice_vice_mean             =   1.0616438631587E-03
+(PID.TID 0000.0001) %MON seaice_vice_sd               =   1.5044616788984E-02
+(PID.TID 0000.0001) %MON seaice_vice_del2             =   1.1220654521783E-04
+(PID.TID 0000.0001) %MON seaice_area_max              =   8.6147191454135E-01
 (PID.TID 0000.0001) %MON seaice_area_min              =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON seaice_area_mean             =   1.6715849032984E-02
+(PID.TID 0000.0001) %MON seaice_area_mean             =   1.6715849032983E-02
 (PID.TID 0000.0001) %MON seaice_area_sd               =   1.0882227581187E-01
-(PID.TID 0000.0001) %MON seaice_area_del2             =   9.8314239232652E-04
-(PID.TID 0000.0001) %MON seaice_heff_max              =   5.1951476138801E-01
+(PID.TID 0000.0001) %MON seaice_area_del2             =   9.8314239232692E-04
+(PID.TID 0000.0001) %MON seaice_heff_max              =   5.1951476138734E-01
 (PID.TID 0000.0001) %MON seaice_heff_min              =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON seaice_heff_mean             =   9.2920906691572E-03
-(PID.TID 0000.0001) %MON seaice_heff_sd               =   6.1489563913971E-02
-(PID.TID 0000.0001) %MON seaice_heff_del2             =   5.3052216117039E-04
-(PID.TID 0000.0001) %MON seaice_hsnow_max             =   6.0899358364476E-03
+(PID.TID 0000.0001) %MON seaice_heff_sd               =   6.1489563913972E-02
+(PID.TID 0000.0001) %MON seaice_heff_del2             =   5.3052216117063E-04
+(PID.TID 0000.0001) %MON seaice_hsnow_max             =   6.0899358364491E-03
 (PID.TID 0000.0001) %MON seaice_hsnow_min             =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON seaice_hsnow_mean            =   5.6966730245636E-05
-(PID.TID 0000.0001) %MON seaice_hsnow_sd              =   4.3979945907159E-04
-(PID.TID 0000.0001) %MON seaice_hsnow_del2            =   7.3370262382209E-06
+(PID.TID 0000.0001) %MON seaice_hsnow_mean            =   5.6966730245640E-05
+(PID.TID 0000.0001) %MON seaice_hsnow_sd              =   4.3979945907162E-04
+(PID.TID 0000.0001) %MON seaice_hsnow_del2            =   7.3370262382235E-06
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // End MONITOR SEAICE statistics
 (PID.TID 0000.0001) // =======================================================
  EXTERNAL_FIELDS_LOAD,         5 : iP,iLd,i0,i1=   12    1   12    1 ; Wght=  0.3333333333  0.6666666667
  SEAICE_LSR: Residual Initial ipass,Uice,Vice=         1  8.01714971E-04  3.65764625E-04
- SEAICE_LSR (ipass=        1) iters,dU,Resid=       12  2.82829316E-13  2.38271619E-16
- SEAICE_LSR (ipass=        1) iters,dV,Resid=       12  7.97951982E-13  2.04882826E-16
+ SEAICE_LSR (ipass=        1) iters,dU,Resid=       12  2.82829316E-13  2.38265690E-16
+ SEAICE_LSR (ipass=        1) iters,dV,Resid=       12  7.97938104E-13  2.04897953E-16
  SEAICE_LSR: Residual Initial ipass,Uice,Vice=         2  2.10637550E-04  8.21361721E-05
- SEAICE_LSR (ipass=        2) iters,dU,Resid=       12  6.96387392E-14  1.07652319E-16
- SEAICE_LSR (ipass=        2) iters,dV,Resid=       12  1.25531530E-13  4.40385391E-17
- cg2d: Sum(rhs),rhsMax =   2.98792882254336E-01  1.98998101744957E+01
-(PID.TID 0000.0001)      cg2d_init_res =   7.51561570499162E-02
+ SEAICE_LSR (ipass=        2) iters,dU,Resid=       12  6.96283309E-14  1.07617997E-16
+ SEAICE_LSR (ipass=        2) iters,dV,Resid=       12  1.25531530E-13  4.44187290E-17
+ cg2d: Sum(rhs),rhsMax =   2.98792882254294E-01  1.98998101744991E+01
+(PID.TID 0000.0001)      cg2d_init_res =   7.51561570466313E-02
 (PID.TID 0000.0001)      cg2d_iters(min,last) =      -1     102
-(PID.TID 0000.0001)      cg2d_last_res =   9.19136119751815E-10
+(PID.TID 0000.0001)      cg2d_last_res =   9.19138004753263E-10
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // Begin MONITOR dynamic field statistics
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) %MON time_tsnumber                =                     6
 (PID.TID 0000.0001) %MON time_secondsf                =   5.1840000000000E+05
-(PID.TID 0000.0001) %MON dynstat_eta_max              =   1.4047428544720E+04
-(PID.TID 0000.0001) %MON dynstat_eta_min              =  -2.3266855757677E+04
-(PID.TID 0000.0001) %MON dynstat_eta_mean             =  -8.9792421024797E+01
-(PID.TID 0000.0001) %MON dynstat_eta_sd               =   7.4065966385347E+03
-(PID.TID 0000.0001) %MON dynstat_eta_del2             =   9.3880911926134E+01
-(PID.TID 0000.0001) %MON dynstat_uvel_max             =   9.8471384207482E-02
-(PID.TID 0000.0001) %MON dynstat_uvel_min             =  -1.1753024834328E-01
-(PID.TID 0000.0001) %MON dynstat_uvel_mean            =  -2.7306867245297E-04
-(PID.TID 0000.0001) %MON dynstat_uvel_sd              =   5.8998186618449E-03
-(PID.TID 0000.0001) %MON dynstat_uvel_del2            =   3.0161759840123E-05
-(PID.TID 0000.0001) %MON dynstat_vvel_max             =   1.6007344712241E-01
-(PID.TID 0000.0001) %MON dynstat_vvel_min             =  -1.4764986710962E-01
-(PID.TID 0000.0001) %MON dynstat_vvel_mean            =  -4.7245164469995E-04
-(PID.TID 0000.0001) %MON dynstat_vvel_sd              =   6.0671457463028E-03
-(PID.TID 0000.0001) %MON dynstat_vvel_del2            =   3.1336304589756E-05
-(PID.TID 0000.0001) %MON dynstat_wvel_max             =   4.6784946947775E+00
-(PID.TID 0000.0001) %MON dynstat_wvel_min             =  -7.9345863777231E+00
-(PID.TID 0000.0001) %MON dynstat_wvel_mean            =  -8.8735601058804E-05
-(PID.TID 0000.0001) %MON dynstat_wvel_sd              =   2.1722460938934E-01
-(PID.TID 0000.0001) %MON dynstat_wvel_del2            =   1.7186802058517E-03
+(PID.TID 0000.0001) %MON dynstat_eta_max              =   1.4047428544726E+04
+(PID.TID 0000.0001) %MON dynstat_eta_min              =  -2.3266855757671E+04
+(PID.TID 0000.0001) %MON dynstat_eta_mean             =  -8.9792421024798E+01
+(PID.TID 0000.0001) %MON dynstat_eta_sd               =   7.4065966385351E+03
+(PID.TID 0000.0001) %MON dynstat_eta_del2             =   9.3880911926146E+01
+(PID.TID 0000.0001) %MON dynstat_uvel_max             =   9.8471384207477E-02
+(PID.TID 0000.0001) %MON dynstat_uvel_min             =  -1.1753024834327E-01
+(PID.TID 0000.0001) %MON dynstat_uvel_mean            =  -2.7306867245190E-04
+(PID.TID 0000.0001) %MON dynstat_uvel_sd              =   5.8998186618451E-03
+(PID.TID 0000.0001) %MON dynstat_uvel_del2            =   3.0161759840125E-05
+(PID.TID 0000.0001) %MON dynstat_vvel_max             =   1.6007344712245E-01
+(PID.TID 0000.0001) %MON dynstat_vvel_min             =  -1.4764986710963E-01
+(PID.TID 0000.0001) %MON dynstat_vvel_mean            =  -4.7245164470054E-04
+(PID.TID 0000.0001) %MON dynstat_vvel_sd              =   6.0671457463027E-03
+(PID.TID 0000.0001) %MON dynstat_vvel_del2            =   3.1336304589751E-05
+(PID.TID 0000.0001) %MON dynstat_wvel_max             =   4.6784946947791E+00
+(PID.TID 0000.0001) %MON dynstat_wvel_min             =  -7.9345863777242E+00
+(PID.TID 0000.0001) %MON dynstat_wvel_mean            =  -8.8735601065463E-05
+(PID.TID 0000.0001) %MON dynstat_wvel_sd              =   2.1722460938933E-01
+(PID.TID 0000.0001) %MON dynstat_wvel_del2            =   1.7186802058515E-03
 (PID.TID 0000.0001) %MON dynstat_theta_max            =   2.9427781655673E+01
 (PID.TID 0000.0001) %MON dynstat_theta_min            =  -1.8962389428750E+00
 (PID.TID 0000.0001) %MON dynstat_theta_mean           =   3.5919642088625E+00
@@ -4136,22 +4139,22 @@ listId=   2 ; file name: seaiceStDiag
 (PID.TID 0000.0001) %MON dynstat_salt_min             =   1.6954944932337E+01
 (PID.TID 0000.0001) %MON dynstat_salt_mean            =   3.4721525411307E+01
 (PID.TID 0000.0001) %MON dynstat_salt_sd              =   4.8747742516121E-01
-(PID.TID 0000.0001) %MON dynstat_salt_del2            =   5.0861379736728E-04
+(PID.TID 0000.0001) %MON dynstat_salt_del2            =   5.0861379736727E-04
 (PID.TID 0000.0001) %MON forcing_qnet_max             =   6.7026753827189E+02
 (PID.TID 0000.0001) %MON forcing_qnet_min             =  -3.1305243489962E+02
 (PID.TID 0000.0001) %MON forcing_qnet_mean            =  -2.7766078777346E+01
 (PID.TID 0000.0001) %MON forcing_qnet_sd              =   1.5329166545189E+02
-(PID.TID 0000.0001) %MON forcing_qnet_del2            =   8.6201992393132E-01
+(PID.TID 0000.0001) %MON forcing_qnet_del2            =   8.6201992393141E-01
 (PID.TID 0000.0001) %MON forcing_qsw_max              =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON forcing_qsw_min              =  -3.0185528845048E+02
 (PID.TID 0000.0001) %MON forcing_qsw_mean             =  -1.8595720283886E+02
 (PID.TID 0000.0001) %MON forcing_qsw_sd               =   7.8769715206083E+01
 (PID.TID 0000.0001) %MON forcing_qsw_del2             =   1.1038814370339E-01
-(PID.TID 0000.0001) %MON forcing_empmr_max            =   1.5956222433278E-03
+(PID.TID 0000.0001) %MON forcing_empmr_max            =   1.5956222433284E-03
 (PID.TID 0000.0001) %MON forcing_empmr_min            =  -4.5351270375881E-04
 (PID.TID 0000.0001) %MON forcing_empmr_mean           =   1.8448626097071E-05
-(PID.TID 0000.0001) %MON forcing_empmr_sd             =   1.3884084537191E-04
-(PID.TID 0000.0001) %MON forcing_empmr_del2           =   1.8045092190034E-06
+(PID.TID 0000.0001) %MON forcing_empmr_sd             =   1.3884084537192E-04
+(PID.TID 0000.0001) %MON forcing_empmr_del2           =   1.8045092190035E-06
 (PID.TID 0000.0001) %MON forcing_fu_max               =   2.4736588936290E-01
 (PID.TID 0000.0001) %MON forcing_fu_min               =  -2.1866089303695E-01
 (PID.TID 0000.0001) %MON forcing_fu_mean              =  -4.2896134025931E-03
@@ -4162,25 +4165,25 @@ listId=   2 ; file name: seaiceStDiag
 (PID.TID 0000.0001) %MON forcing_fv_mean              =  -1.3693659233558E-02
 (PID.TID 0000.0001) %MON forcing_fv_sd                =   7.5467638894608E-02
 (PID.TID 0000.0001) %MON forcing_fv_del2              =   2.3656544687444E-04
-(PID.TID 0000.0001) %MON trAdv_CFL_u_max              =   4.1293312179492E-02
-(PID.TID 0000.0001) %MON trAdv_CFL_v_max              =   5.8435120402238E-02
-(PID.TID 0000.0001) %MON trAdv_CFL_w_max              =   2.0436043995874E-01
-(PID.TID 0000.0001) %MON advcfl_uvel_max              =   3.6040663516923E-02
-(PID.TID 0000.0001) %MON advcfl_vvel_max              =   4.5253034423146E-02
-(PID.TID 0000.0001) %MON advcfl_wvel_max              =   2.2381177485807E-01
-(PID.TID 0000.0001) %MON advcfl_W_hf_max              =   2.4727804756787E-01
+(PID.TID 0000.0001) %MON trAdv_CFL_u_max              =   4.1293312179516E-02
+(PID.TID 0000.0001) %MON trAdv_CFL_v_max              =   5.8435120402252E-02
+(PID.TID 0000.0001) %MON trAdv_CFL_w_max              =   2.0436043995877E-01
+(PID.TID 0000.0001) %MON advcfl_uvel_max              =   3.6040663516914E-02
+(PID.TID 0000.0001) %MON advcfl_vvel_max              =   4.5253034423157E-02
+(PID.TID 0000.0001) %MON advcfl_wvel_max              =   2.2381177485810E-01
+(PID.TID 0000.0001) %MON advcfl_W_hf_max              =   2.4727804756791E-01
 (PID.TID 0000.0001) %MON pe_b_mean                    =   1.3538399324155E-02
-(PID.TID 0000.0001) %MON ke_max                       =   8.7302564675453E-03
+(PID.TID 0000.0001) %MON ke_max                       =   8.7302564675472E-03
 (PID.TID 0000.0001) %MON ke_mean                      =   3.3206156888219E-05
 (PID.TID 0000.0001) %MON ke_vol                       =   1.3604149699968E+22
-(PID.TID 0000.0001) %MON vort_r_min                   =  -5.8475017003732E-07
-(PID.TID 0000.0001) %MON vort_r_max                   =   6.8231180719063E-07
+(PID.TID 0000.0001) %MON vort_r_min                   =  -5.8475017003745E-07
+(PID.TID 0000.0001) %MON vort_r_max                   =   6.8231180719840E-07
 (PID.TID 0000.0001) %MON vort_a_mean                  =  -2.0556865257795E-05
 (PID.TID 0000.0001) %MON vort_a_sd                    =   7.5247389068702E-05
 (PID.TID 0000.0001) %MON vort_p_mean                  =  -2.4859227124463E-05
 (PID.TID 0000.0001) %MON vort_p_sd                    =   1.2920606859969E-04
-(PID.TID 0000.0001) %MON surfExpan_theta_mean         =   3.9318552814155E-03
-(PID.TID 0000.0001) %MON surfExpan_salt_mean          =  -6.0919114505183E-03
+(PID.TID 0000.0001) %MON surfExpan_theta_mean         =   3.9318552814312E-03
+(PID.TID 0000.0001) %MON surfExpan_salt_mean          =  -6.0919114505173E-03
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // End MONITOR dynamic field statistics
 (PID.TID 0000.0001) // =======================================================
@@ -4189,124 +4192,124 @@ listId=   2 ; file name: seaiceStDiag
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) %MON seaice_tsnumber              =                     6
 (PID.TID 0000.0001) %MON seaice_time_sec              =   5.1840000000000E+05
-(PID.TID 0000.0001) %MON seaice_uice_max              =   1.8248175407356E-01
+(PID.TID 0000.0001) %MON seaice_uice_max              =   1.8248175407364E-01
 (PID.TID 0000.0001) %MON seaice_uice_min              =  -2.5323899888556E-01
-(PID.TID 0000.0001) %MON seaice_uice_mean             =  -5.2877331489930E-04
-(PID.TID 0000.0001) %MON seaice_uice_sd               =   1.3089516131682E-02
-(PID.TID 0000.0001) %MON seaice_uice_del2             =   2.0073569552308E-04
+(PID.TID 0000.0001) %MON seaice_uice_mean             =  -5.2877331489875E-04
+(PID.TID 0000.0001) %MON seaice_uice_sd               =   1.3089516131681E-02
+(PID.TID 0000.0001) %MON seaice_uice_del2             =   2.0073569552289E-04
 (PID.TID 0000.0001) %MON seaice_vice_max              =   1.6272126750334E-01
-(PID.TID 0000.0001) %MON seaice_vice_min              =  -1.6617539863588E-01
-(PID.TID 0000.0001) %MON seaice_vice_mean             =   1.1141791133078E-03
-(PID.TID 0000.0001) %MON seaice_vice_sd               =   1.5454058702571E-02
-(PID.TID 0000.0001) %MON seaice_vice_del2             =   1.1458277983397E-04
-(PID.TID 0000.0001) %MON seaice_area_max              =   9.1248344090042E-01
+(PID.TID 0000.0001) %MON seaice_vice_min              =  -1.6617539863582E-01
+(PID.TID 0000.0001) %MON seaice_vice_mean             =   1.1141791133072E-03
+(PID.TID 0000.0001) %MON seaice_vice_sd               =   1.5454058702570E-02
+(PID.TID 0000.0001) %MON seaice_vice_del2             =   1.1458277983375E-04
+(PID.TID 0000.0001) %MON seaice_area_max              =   9.1248344089992E-01
 (PID.TID 0000.0001) %MON seaice_area_min              =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON seaice_area_mean             =   1.9559760897385E-02
 (PID.TID 0000.0001) %MON seaice_area_sd               =   1.2239016918156E-01
-(PID.TID 0000.0001) %MON seaice_area_del2             =   9.0043731598784E-04
-(PID.TID 0000.0001) %MON seaice_heff_max              =   5.7645858533563E-01
+(PID.TID 0000.0001) %MON seaice_area_del2             =   9.0043731598806E-04
+(PID.TID 0000.0001) %MON seaice_heff_max              =   5.7645858533514E-01
 (PID.TID 0000.0001) %MON seaice_heff_min              =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON seaice_heff_mean             =   1.1258524085242E-02
 (PID.TID 0000.0001) %MON seaice_heff_sd               =   7.1536090283364E-02
-(PID.TID 0000.0001) %MON seaice_heff_del2             =   5.1299119801228E-04
-(PID.TID 0000.0001) %MON seaice_hsnow_max             =   9.0823390152899E-03
+(PID.TID 0000.0001) %MON seaice_heff_del2             =   5.1299119801244E-04
+(PID.TID 0000.0001) %MON seaice_hsnow_max             =   9.0823390152916E-03
 (PID.TID 0000.0001) %MON seaice_hsnow_min             =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON seaice_hsnow_mean            =   8.6939830407747E-05
-(PID.TID 0000.0001) %MON seaice_hsnow_sd              =   6.5014900189110E-04
-(PID.TID 0000.0001) %MON seaice_hsnow_del2            =   1.0239344312577E-05
+(PID.TID 0000.0001) %MON seaice_hsnow_mean            =   8.6939830407750E-05
+(PID.TID 0000.0001) %MON seaice_hsnow_sd              =   6.5014900189113E-04
+(PID.TID 0000.0001) %MON seaice_hsnow_del2            =   1.0239344312581E-05
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // End MONITOR SEAICE statistics
 (PID.TID 0000.0001) // =======================================================
  EXTERNAL_FIELDS_LOAD,         6 : iP,iLd,i0,i1=   12    1   12    1 ; Wght=  0.3000000000  0.7000000000
  SEAICE_LSR: Residual Initial ipass,Uice,Vice=         1  7.24318685E-04  4.00795297E-04
- SEAICE_LSR (ipass=        1) iters,dU,Resid=       16  2.32395700E-13  9.00283995E-16
- SEAICE_LSR (ipass=        1) iters,dV,Resid=       16  3.18481352E-13  8.30405240E-16
+ SEAICE_LSR (ipass=        1) iters,dU,Resid=       16  2.32397435E-13  9.00285599E-16
+ SEAICE_LSR (ipass=        1) iters,dV,Resid=       16  3.18467475E-13  8.30700357E-16
  SEAICE_LSR: Residual Initial ipass,Uice,Vice=         2  5.52624500E-04  1.06269918E-04
- SEAICE_LSR (ipass=        2) iters,dU,Resid=       16  1.14741550E-13  4.71652237E-16
- SEAICE_LSR (ipass=        2) iters,dV,Resid=       16  7.69800890E-14  2.15828156E-16
- cg2d: Sum(rhs),rhsMax =   3.38474352249873E-01  1.99001901972720E+01
-(PID.TID 0000.0001)      cg2d_init_res =   7.38781098072774E-02
+ SEAICE_LSR (ipass=        2) iters,dU,Resid=       16  1.14741550E-13  4.71705768E-16
+ SEAICE_LSR (ipass=        2) iters,dV,Resid=       16  7.69523334E-14  2.15483574E-16
+ cg2d: Sum(rhs),rhsMax =   3.38474352249841E-01  1.99001901972741E+01
+(PID.TID 0000.0001)      cg2d_init_res =   7.38781098072248E-02
 (PID.TID 0000.0001)      cg2d_iters(min,last) =      -1      98
-(PID.TID 0000.0001)      cg2d_last_res =   9.08715143345150E-10
+(PID.TID 0000.0001)      cg2d_last_res =   9.08648264094665E-10
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // Begin MONITOR dynamic field statistics
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) %MON time_tsnumber                =                     7
 (PID.TID 0000.0001) %MON time_secondsf                =   6.0480000000000E+05
-(PID.TID 0000.0001) %MON dynstat_eta_max              =   1.4818626342338E+04
-(PID.TID 0000.0001) %MON dynstat_eta_min              =  -2.2989110769436E+04
+(PID.TID 0000.0001) %MON dynstat_eta_max              =   1.4818626342345E+04
+(PID.TID 0000.0001) %MON dynstat_eta_min              =  -2.2989110769431E+04
 (PID.TID 0000.0001) %MON dynstat_eta_mean             =  -1.0171933050184E+02
-(PID.TID 0000.0001) %MON dynstat_eta_sd               =   7.3400118656550E+03
-(PID.TID 0000.0001) %MON dynstat_eta_del2             =   9.4058627430415E+01
+(PID.TID 0000.0001) %MON dynstat_eta_sd               =   7.3400118656544E+03
+(PID.TID 0000.0001) %MON dynstat_eta_del2             =   9.4058627430337E+01
 (PID.TID 0000.0001) %MON dynstat_uvel_max             =   1.1104080571592E-01
-(PID.TID 0000.0001) %MON dynstat_uvel_min             =  -1.3231037996204E-01
-(PID.TID 0000.0001) %MON dynstat_uvel_mean            =  -1.4441420575379E-04
-(PID.TID 0000.0001) %MON dynstat_uvel_sd              =   6.7495910745534E-03
-(PID.TID 0000.0001) %MON dynstat_uvel_del2            =   3.3378579241523E-05
-(PID.TID 0000.0001) %MON dynstat_vvel_max             =   1.7851926060457E-01
-(PID.TID 0000.0001) %MON dynstat_vvel_min             =  -1.6521603522666E-01
-(PID.TID 0000.0001) %MON dynstat_vvel_mean            =  -5.0462584772291E-04
+(PID.TID 0000.0001) %MON dynstat_uvel_min             =  -1.3231037996202E-01
+(PID.TID 0000.0001) %MON dynstat_uvel_mean            =  -1.4441420575312E-04
+(PID.TID 0000.0001) %MON dynstat_uvel_sd              =   6.7495910745537E-03
+(PID.TID 0000.0001) %MON dynstat_uvel_del2            =   3.3378579241525E-05
+(PID.TID 0000.0001) %MON dynstat_vvel_max             =   1.7851926060461E-01
+(PID.TID 0000.0001) %MON dynstat_vvel_min             =  -1.6521603522668E-01
+(PID.TID 0000.0001) %MON dynstat_vvel_mean            =  -5.0462584772331E-04
 (PID.TID 0000.0001) %MON dynstat_vvel_sd              =   6.9514674919004E-03
-(PID.TID 0000.0001) %MON dynstat_vvel_del2            =   3.4532556841267E-05
-(PID.TID 0000.0001) %MON dynstat_wvel_max             =   5.1171112568101E+00
-(PID.TID 0000.0001) %MON dynstat_wvel_min             =  -8.8785787204448E+00
-(PID.TID 0000.0001) %MON dynstat_wvel_mean            =  -6.8279535438103E-05
+(PID.TID 0000.0001) %MON dynstat_vvel_del2            =   3.4532556841257E-05
+(PID.TID 0000.0001) %MON dynstat_wvel_max             =   5.1171112568114E+00
+(PID.TID 0000.0001) %MON dynstat_wvel_min             =  -8.8785787204454E+00
+(PID.TID 0000.0001) %MON dynstat_wvel_mean            =  -6.8279535439619E-05
 (PID.TID 0000.0001) %MON dynstat_wvel_sd              =   2.3891427086290E-01
-(PID.TID 0000.0001) %MON dynstat_wvel_del2            =   1.8534584429081E-03
+(PID.TID 0000.0001) %MON dynstat_wvel_del2            =   1.8534584429082E-03
 (PID.TID 0000.0001) %MON dynstat_theta_max            =   2.9433093675088E+01
 (PID.TID 0000.0001) %MON dynstat_theta_min            =  -1.8987898464377E+00
 (PID.TID 0000.0001) %MON dynstat_theta_mean           =   3.5921298086083E+00
 (PID.TID 0000.0001) %MON dynstat_theta_sd             =   4.4292045734119E+00
 (PID.TID 0000.0001) %MON dynstat_theta_del2           =   2.0663284299195E-03
 (PID.TID 0000.0001) %MON dynstat_salt_max             =   4.0715873150297E+01
-(PID.TID 0000.0001) %MON dynstat_salt_min             =   1.6626695315865E+01
+(PID.TID 0000.0001) %MON dynstat_salt_min             =   1.6626695315862E+01
 (PID.TID 0000.0001) %MON dynstat_salt_mean            =   3.4721534957498E+01
 (PID.TID 0000.0001) %MON dynstat_salt_sd              =   4.8743750202641E-01
-(PID.TID 0000.0001) %MON dynstat_salt_del2            =   5.0420397270037E-04
+(PID.TID 0000.0001) %MON dynstat_salt_del2            =   5.0420397270032E-04
 (PID.TID 0000.0001) %MON forcing_qnet_max             =   6.8177960035793E+02
 (PID.TID 0000.0001) %MON forcing_qnet_min             =  -3.1203737630998E+02
 (PID.TID 0000.0001) %MON forcing_qnet_mean            =  -2.7345393323586E+01
 (PID.TID 0000.0001) %MON forcing_qnet_sd              =   1.5227682162005E+02
-(PID.TID 0000.0001) %MON forcing_qnet_del2            =   9.2965453584834E-01
+(PID.TID 0000.0001) %MON forcing_qnet_del2            =   9.2965453584782E-01
 (PID.TID 0000.0001) %MON forcing_qsw_max              =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON forcing_qsw_min              =  -3.0184329151467E+02
 (PID.TID 0000.0001) %MON forcing_qsw_mean             =  -1.8596329455048E+02
 (PID.TID 0000.0001) %MON forcing_qsw_sd               =   7.8669793008696E+01
 (PID.TID 0000.0001) %MON forcing_qsw_del2             =   1.1053691825532E-01
-(PID.TID 0000.0001) %MON forcing_empmr_max            =   1.6400518306284E-03
-(PID.TID 0000.0001) %MON forcing_empmr_min            =  -9.9256215796157E-04
-(PID.TID 0000.0001) %MON forcing_empmr_mean           =   1.4071654817747E-05
+(PID.TID 0000.0001) %MON forcing_empmr_max            =   1.6400518306282E-03
+(PID.TID 0000.0001) %MON forcing_empmr_min            =  -9.9256215796121E-04
+(PID.TID 0000.0001) %MON forcing_empmr_mean           =   1.4071654817749E-05
 (PID.TID 0000.0001) %MON forcing_empmr_sd             =   1.1809520928432E-04
-(PID.TID 0000.0001) %MON forcing_empmr_del2           =   1.8986846986487E-06
+(PID.TID 0000.0001) %MON forcing_empmr_del2           =   1.8986846986477E-06
 (PID.TID 0000.0001) %MON forcing_fu_max               =   2.4731784009269E-01
 (PID.TID 0000.0001) %MON forcing_fu_min               =  -2.2180668969530E-01
-(PID.TID 0000.0001) %MON forcing_fu_mean              =  -4.2375913269599E-03
+(PID.TID 0000.0001) %MON forcing_fu_mean              =  -4.2375913269600E-03
 (PID.TID 0000.0001) %MON forcing_fu_sd                =   6.4177032037254E-02
 (PID.TID 0000.0001) %MON forcing_fu_del2              =   2.0948678176051E-04
 (PID.TID 0000.0001) %MON forcing_fv_max               =   2.6891042987167E-01
 (PID.TID 0000.0001) %MON forcing_fv_min               =  -3.3164734762358E-01
 (PID.TID 0000.0001) %MON forcing_fv_mean              =  -1.3693576287271E-02
 (PID.TID 0000.0001) %MON forcing_fv_sd                =   7.5556752224261E-02
-(PID.TID 0000.0001) %MON forcing_fv_del2              =   2.3758908332819E-04
-(PID.TID 0000.0001) %MON trAdv_CFL_u_max              =   4.4207081638690E-02
-(PID.TID 0000.0001) %MON trAdv_CFL_v_max              =   6.5549028646564E-02
-(PID.TID 0000.0001) %MON trAdv_CFL_w_max              =   2.2823573483499E-01
-(PID.TID 0000.0001) %MON advcfl_uvel_max              =   4.0648626269197E-02
-(PID.TID 0000.0001) %MON advcfl_vvel_max              =   5.0467697113786E-02
-(PID.TID 0000.0001) %MON advcfl_wvel_max              =   2.4997544118481E-01
-(PID.TID 0000.0001) %MON advcfl_W_hf_max              =   2.7616737812177E-01
-(PID.TID 0000.0001) %MON pe_b_mean                    =   1.3509189844066E-02
-(PID.TID 0000.0001) %MON ke_max                       =   1.0996425520018E-02
-(PID.TID 0000.0001) %MON ke_mean                      =   4.3475366911922E-05
+(PID.TID 0000.0001) %MON forcing_fv_del2              =   2.3758908332820E-04
+(PID.TID 0000.0001) %MON trAdv_CFL_u_max              =   4.4207081638689E-02
+(PID.TID 0000.0001) %MON trAdv_CFL_v_max              =   6.5549028646572E-02
+(PID.TID 0000.0001) %MON trAdv_CFL_w_max              =   2.2823573483501E-01
+(PID.TID 0000.0001) %MON advcfl_uvel_max              =   4.0648626269195E-02
+(PID.TID 0000.0001) %MON advcfl_vvel_max              =   5.0467697113795E-02
+(PID.TID 0000.0001) %MON advcfl_wvel_max              =   2.4997544118482E-01
+(PID.TID 0000.0001) %MON advcfl_W_hf_max              =   2.7616737812179E-01
+(PID.TID 0000.0001) %MON pe_b_mean                    =   1.3509189844065E-02
+(PID.TID 0000.0001) %MON ke_max                       =   1.0996425520020E-02
+(PID.TID 0000.0001) %MON ke_mean                      =   4.3475366911923E-05
 (PID.TID 0000.0001) %MON ke_vol                       =   1.3604144009959E+22
-(PID.TID 0000.0001) %MON vort_r_min                   =  -6.5506381517877E-07
-(PID.TID 0000.0001) %MON vort_r_max                   =   7.4440206864452E-07
+(PID.TID 0000.0001) %MON vort_r_min                   =  -6.5506381517887E-07
+(PID.TID 0000.0001) %MON vort_r_max                   =   7.4440206864961E-07
 (PID.TID 0000.0001) %MON vort_a_mean                  =  -2.0556865257795E-05
 (PID.TID 0000.0001) %MON vort_a_sd                    =   7.5247416046164E-05
 (PID.TID 0000.0001) %MON vort_p_mean                  =  -2.4859237123958E-05
 (PID.TID 0000.0001) %MON vort_p_sd                    =   1.2920621469863E-04
-(PID.TID 0000.0001) %MON surfExpan_theta_mean         =   1.6970908476267E-03
-(PID.TID 0000.0001) %MON surfExpan_salt_mean          =  -4.6258240064172E-03
+(PID.TID 0000.0001) %MON surfExpan_theta_mean         =   1.6970908476108E-03
+(PID.TID 0000.0001) %MON surfExpan_salt_mean          =  -4.6258240064067E-03
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // End MONITOR dynamic field statistics
 (PID.TID 0000.0001) // =======================================================
@@ -4315,80 +4318,80 @@ listId=   2 ; file name: seaiceStDiag
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) %MON seaice_tsnumber              =                     7
 (PID.TID 0000.0001) %MON seaice_time_sec              =   6.0480000000000E+05
-(PID.TID 0000.0001) %MON seaice_uice_max              =   1.2385498103103E-01
-(PID.TID 0000.0001) %MON seaice_uice_min              =  -2.0541045987206E-01
-(PID.TID 0000.0001) %MON seaice_uice_mean             =  -7.2010114229278E-04
-(PID.TID 0000.0001) %MON seaice_uice_sd               =   1.3630958401046E-02
-(PID.TID 0000.0001) %MON seaice_uice_del2             =   2.0514460206653E-04
-(PID.TID 0000.0001) %MON seaice_vice_max              =   1.6249559881675E-01
-(PID.TID 0000.0001) %MON seaice_vice_min              =  -1.7112762754801E-01
-(PID.TID 0000.0001) %MON seaice_vice_mean             =   1.1715074421800E-03
-(PID.TID 0000.0001) %MON seaice_vice_sd               =   1.5635432376430E-02
-(PID.TID 0000.0001) %MON seaice_vice_del2             =   1.1857864836990E-04
-(PID.TID 0000.0001) %MON seaice_area_max              =   9.4573687326239E-01
+(PID.TID 0000.0001) %MON seaice_uice_max              =   1.2385498103105E-01
+(PID.TID 0000.0001) %MON seaice_uice_min              =  -2.0541045987200E-01
+(PID.TID 0000.0001) %MON seaice_uice_mean             =  -7.2010114229267E-04
+(PID.TID 0000.0001) %MON seaice_uice_sd               =   1.3630958401043E-02
+(PID.TID 0000.0001) %MON seaice_uice_del2             =   2.0514460206633E-04
+(PID.TID 0000.0001) %MON seaice_vice_max              =   1.6249559881673E-01
+(PID.TID 0000.0001) %MON seaice_vice_min              =  -1.7112762754794E-01
+(PID.TID 0000.0001) %MON seaice_vice_mean             =   1.1715074421797E-03
+(PID.TID 0000.0001) %MON seaice_vice_sd               =   1.5635432376428E-02
+(PID.TID 0000.0001) %MON seaice_vice_del2             =   1.1857864836969E-04
+(PID.TID 0000.0001) %MON seaice_area_max              =   9.4573687326213E-01
 (PID.TID 0000.0001) %MON seaice_area_min              =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON seaice_area_mean             =   2.1673420902076E-02
 (PID.TID 0000.0001) %MON seaice_area_sd               =   1.3281511082544E-01
-(PID.TID 0000.0001) %MON seaice_area_del2             =   8.9683083952187E-04
-(PID.TID 0000.0001) %MON seaice_heff_max              =   6.2500069620512E-01
+(PID.TID 0000.0001) %MON seaice_area_del2             =   8.9683083952146E-04
+(PID.TID 0000.0001) %MON seaice_heff_max              =   6.2500069620475E-01
 (PID.TID 0000.0001) %MON seaice_heff_min              =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON seaice_heff_mean             =   1.2810384530582E-02
 (PID.TID 0000.0001) %MON seaice_heff_sd               =   7.9931742262457E-02
-(PID.TID 0000.0001) %MON seaice_heff_del2             =   5.5271062800608E-04
-(PID.TID 0000.0001) %MON seaice_hsnow_max             =   1.2340675823918E-02
+(PID.TID 0000.0001) %MON seaice_heff_del2             =   5.5271062800596E-04
+(PID.TID 0000.0001) %MON seaice_hsnow_max             =   1.2340675823920E-02
 (PID.TID 0000.0001) %MON seaice_hsnow_min             =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON seaice_hsnow_mean            =   1.2238437061201E-04
-(PID.TID 0000.0001) %MON seaice_hsnow_sd              =   8.9193765259388E-04
-(PID.TID 0000.0001) %MON seaice_hsnow_del2            =   1.3199478964234E-05
+(PID.TID 0000.0001) %MON seaice_hsnow_sd              =   8.9193765259390E-04
+(PID.TID 0000.0001) %MON seaice_hsnow_del2            =   1.3199478964238E-05
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // End MONITOR SEAICE statistics
 (PID.TID 0000.0001) // =======================================================
  EXTERNAL_FIELDS_LOAD,         7 : iP,iLd,i0,i1=   12    1   12    1 ; Wght=  0.2666666667  0.7333333333
  SEAICE_LSR: Residual Initial ipass,Uice,Vice=         1  5.56075834E-04  4.63897858E-04
- SEAICE_LSR (ipass=        1) iters,dU,Resid=       24  7.70754988E-14  9.71742717E-16
- SEAICE_LSR (ipass=        1) iters,dV,Resid=       24  1.24622535E-13  1.15399181E-15
+ SEAICE_LSR (ipass=        1) iters,dU,Resid=       24  7.70754988E-14  9.71801741E-16
+ SEAICE_LSR (ipass=        1) iters,dV,Resid=       24  1.24622535E-13  1.15451546E-15
  SEAICE_LSR: Residual Initial ipass,Uice,Vice=         2  2.63496080E-04  1.80461966E-04
- SEAICE_LSR (ipass=        2) iters,dU,Resid=       22  3.22592647E-13  4.30682043E-15
- SEAICE_LSR (ipass=        2) iters,dV,Resid=       22  3.07046055E-13  2.96126217E-15
- cg2d: Sum(rhs),rhsMax =   3.76892070776369E-01  1.99023261034168E+01
-(PID.TID 0000.0001)      cg2d_init_res =   7.47426784168787E-02
+ SEAICE_LSR (ipass=        2) iters,dU,Resid=       22  3.22597851E-13  4.30739179E-15
+ SEAICE_LSR (ipass=        2) iters,dV,Resid=       22  3.07059933E-13  2.96030191E-15
+ cg2d: Sum(rhs),rhsMax =   3.76892070776351E-01  1.99023261034188E+01
+(PID.TID 0000.0001)      cg2d_init_res =   7.47426784167069E-02
 (PID.TID 0000.0001)      cg2d_iters(min,last) =      -1     101
-(PID.TID 0000.0001)      cg2d_last_res =   7.99170911836764E-10
+(PID.TID 0000.0001)      cg2d_last_res =   7.99166535376064E-10
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // Begin MONITOR dynamic field statistics
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) %MON time_tsnumber                =                     8
 (PID.TID 0000.0001) %MON time_secondsf                =   6.9120000000000E+05
-(PID.TID 0000.0001) %MON dynstat_eta_max              =   1.5252788729400E+04
-(PID.TID 0000.0001) %MON dynstat_eta_min              =  -2.2591460027493E+04
+(PID.TID 0000.0001) %MON dynstat_eta_max              =   1.5252788729405E+04
+(PID.TID 0000.0001) %MON dynstat_eta_min              =  -2.2591460027489E+04
 (PID.TID 0000.0001) %MON dynstat_eta_mean             =  -1.1327689564868E+02
-(PID.TID 0000.0001) %MON dynstat_eta_sd               =   7.2867790125518E+03
-(PID.TID 0000.0001) %MON dynstat_eta_del2             =   9.4204273679903E+01
+(PID.TID 0000.0001) %MON dynstat_eta_sd               =   7.2867790125509E+03
+(PID.TID 0000.0001) %MON dynstat_eta_del2             =   9.4204273679797E+01
 (PID.TID 0000.0001) %MON dynstat_uvel_max             =   1.2227186274383E-01
-(PID.TID 0000.0001) %MON dynstat_uvel_min             =  -1.4483774389176E-01
-(PID.TID 0000.0001) %MON dynstat_uvel_mean            =  -3.9252120767158E-05
-(PID.TID 0000.0001) %MON dynstat_uvel_sd              =   7.5620703507753E-03
-(PID.TID 0000.0001) %MON dynstat_uvel_del2            =   3.6026312946907E-05
-(PID.TID 0000.0001) %MON dynstat_vvel_max             =   1.9402872841617E-01
-(PID.TID 0000.0001) %MON dynstat_vvel_min             =  -1.8029166281325E-01
-(PID.TID 0000.0001) %MON dynstat_vvel_mean            =  -4.9275706048279E-04
+(PID.TID 0000.0001) %MON dynstat_uvel_min             =  -1.4483774389174E-01
+(PID.TID 0000.0001) %MON dynstat_uvel_mean            =  -3.9252120766941E-05
+(PID.TID 0000.0001) %MON dynstat_uvel_sd              =   7.5620703507756E-03
+(PID.TID 0000.0001) %MON dynstat_uvel_del2            =   3.6026312946909E-05
+(PID.TID 0000.0001) %MON dynstat_vvel_max             =   1.9402872841620E-01
+(PID.TID 0000.0001) %MON dynstat_vvel_min             =  -1.8029166281327E-01
+(PID.TID 0000.0001) %MON dynstat_vvel_mean            =  -4.9275706048292E-04
 (PID.TID 0000.0001) %MON dynstat_vvel_sd              =   7.7914579870258E-03
-(PID.TID 0000.0001) %MON dynstat_vvel_del2            =   3.7171865485603E-05
-(PID.TID 0000.0001) %MON dynstat_wvel_max             =   5.4266255540353E+00
-(PID.TID 0000.0001) %MON dynstat_wvel_min             =  -9.6703679863634E+00
-(PID.TID 0000.0001) %MON dynstat_wvel_mean            =  -1.2680759269301E-05
-(PID.TID 0000.0001) %MON dynstat_wvel_sd              =   2.5577242736946E-01
-(PID.TID 0000.0001) %MON dynstat_wvel_del2            =   1.9455359429878E-03
+(PID.TID 0000.0001) %MON dynstat_vvel_del2            =   3.7171865485596E-05
+(PID.TID 0000.0001) %MON dynstat_wvel_max             =   5.4266255540368E+00
+(PID.TID 0000.0001) %MON dynstat_wvel_min             =  -9.6703679863639E+00
+(PID.TID 0000.0001) %MON dynstat_wvel_mean            =  -1.2680759269099E-05
+(PID.TID 0000.0001) %MON dynstat_wvel_sd              =   2.5577242736947E-01
+(PID.TID 0000.0001) %MON dynstat_wvel_del2            =   1.9455359429880E-03
 (PID.TID 0000.0001) %MON dynstat_theta_max            =   2.9437973417392E+01
 (PID.TID 0000.0001) %MON dynstat_theta_min            =  -1.8997353373336E+00
 (PID.TID 0000.0001) %MON dynstat_theta_mean           =   3.5922955544042E+00
 (PID.TID 0000.0001) %MON dynstat_theta_sd             =   4.4295985696579E+00
 (PID.TID 0000.0001) %MON dynstat_theta_del2           =   2.0700840449243E-03
 (PID.TID 0000.0001) %MON dynstat_salt_max             =   4.0715858077084E+01
-(PID.TID 0000.0001) %MON dynstat_salt_min             =   1.6289379365624E+01
+(PID.TID 0000.0001) %MON dynstat_salt_min             =   1.6289379365622E+01
 (PID.TID 0000.0001) %MON dynstat_salt_mean            =   3.4721543864524E+01
 (PID.TID 0000.0001) %MON dynstat_salt_sd              =   4.8739936514313E-01
-(PID.TID 0000.0001) %MON dynstat_salt_del2            =   5.0065319890512E-04
+(PID.TID 0000.0001) %MON dynstat_salt_del2            =   5.0065319890509E-04
 (PID.TID 0000.0001) %MON forcing_qnet_max             =   6.7731848354601E+02
 (PID.TID 0000.0001) %MON forcing_qnet_min             =  -3.1096788236390E+02
 (PID.TID 0000.0001) %MON forcing_qnet_mean            =  -2.7792171010370E+01
@@ -4403,7 +4406,7 @@ listId=   2 ; file name: seaiceStDiag
 (PID.TID 0000.0001) %MON forcing_empmr_min            =  -4.5708696955272E-04
 (PID.TID 0000.0001) %MON forcing_empmr_mean           =   1.3635893488834E-05
 (PID.TID 0000.0001) %MON forcing_empmr_sd             =   1.0639798724051E-04
-(PID.TID 0000.0001) %MON forcing_empmr_del2           =   1.4462122353090E-06
+(PID.TID 0000.0001) %MON forcing_empmr_del2           =   1.4462122353089E-06
 (PID.TID 0000.0001) %MON forcing_fu_max               =   2.4726979082249E-01
 (PID.TID 0000.0001) %MON forcing_fu_min               =  -2.2495248635365E-01
 (PID.TID 0000.0001) %MON forcing_fu_mean              =  -4.1868895666883E-03
@@ -4414,25 +4417,25 @@ listId=   2 ; file name: seaiceStDiag
 (PID.TID 0000.0001) %MON forcing_fv_mean              =  -1.3695653443005E-02
 (PID.TID 0000.0001) %MON forcing_fv_sd                =   7.5650804392343E-02
 (PID.TID 0000.0001) %MON forcing_fv_del2              =   2.3884684125073E-04
-(PID.TID 0000.0001) %MON trAdv_CFL_u_max              =   4.5060394658623E-02
-(PID.TID 0000.0001) %MON trAdv_CFL_v_max              =   7.1538725390497E-02
-(PID.TID 0000.0001) %MON trAdv_CFL_w_max              =   2.4798644053465E-01
-(PID.TID 0000.0001) %MON advcfl_uvel_max              =   4.4573733124983E-02
+(PID.TID 0000.0001) %MON trAdv_CFL_u_max              =   4.5060394658612E-02
+(PID.TID 0000.0001) %MON trAdv_CFL_v_max              =   7.1538725390502E-02
+(PID.TID 0000.0001) %MON trAdv_CFL_w_max              =   2.4798644053466E-01
+(PID.TID 0000.0001) %MON advcfl_uvel_max              =   4.4573733124989E-02
 (PID.TID 0000.0001) %MON advcfl_vvel_max              =   5.4948950921636E-02
-(PID.TID 0000.0001) %MON advcfl_wvel_max              =   2.7162132488981E-01
-(PID.TID 0000.0001) %MON advcfl_W_hf_max              =   3.0006591711731E-01
+(PID.TID 0000.0001) %MON advcfl_wvel_max              =   2.7162132488982E-01
+(PID.TID 0000.0001) %MON advcfl_W_hf_max              =   3.0006591711732E-01
 (PID.TID 0000.0001) %MON pe_b_mean                    =   1.3499614701467E-02
-(PID.TID 0000.0001) %MON ke_max                       =   1.3162064994150E-02
-(PID.TID 0000.0001) %MON ke_mean                      =   5.4548250402800E-05
+(PID.TID 0000.0001) %MON ke_max                       =   1.3162064994152E-02
+(PID.TID 0000.0001) %MON ke_mean                      =   5.4548250402802E-05
 (PID.TID 0000.0001) %MON ke_vol                       =   1.3604139669915E+22
-(PID.TID 0000.0001) %MON vort_r_min                   =  -7.1573686757882E-07
-(PID.TID 0000.0001) %MON vort_r_max                   =   8.0486198871888E-07
+(PID.TID 0000.0001) %MON vort_r_min                   =  -7.1573686757890E-07
+(PID.TID 0000.0001) %MON vort_r_max                   =   8.0486198871987E-07
 (PID.TID 0000.0001) %MON vort_a_mean                  =  -2.0556865257795E-05
 (PID.TID 0000.0001) %MON vort_a_sd                    =   7.5247442189326E-05
 (PID.TID 0000.0001) %MON vort_p_mean                  =  -2.4859243746094E-05
 (PID.TID 0000.0001) %MON vort_p_sd                    =   1.2920608579933E-04
-(PID.TID 0000.0001) %MON surfExpan_theta_mean         =   2.7736639479017E-05
-(PID.TID 0000.0001) %MON surfExpan_salt_mean          =  -4.3904597127385E-03
+(PID.TID 0000.0001) %MON surfExpan_theta_mean         =   2.7736639453850E-05
+(PID.TID 0000.0001) %MON surfExpan_salt_mean          =  -4.3904597127536E-03
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // End MONITOR dynamic field statistics
 (PID.TID 0000.0001) // =======================================================
@@ -4441,70 +4444,70 @@ listId=   2 ; file name: seaiceStDiag
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) %MON seaice_tsnumber              =                     8
 (PID.TID 0000.0001) %MON seaice_time_sec              =   6.9120000000000E+05
-(PID.TID 0000.0001) %MON seaice_uice_max              =   1.7785226951752E-01
-(PID.TID 0000.0001) %MON seaice_uice_min              =  -2.3406830043613E-01
-(PID.TID 0000.0001) %MON seaice_uice_mean             =  -6.3748188345084E-04
-(PID.TID 0000.0001) %MON seaice_uice_sd               =   1.4640140000246E-02
-(PID.TID 0000.0001) %MON seaice_uice_del2             =   2.3475381323829E-04
-(PID.TID 0000.0001) %MON seaice_vice_max              =   1.6462617043343E-01
-(PID.TID 0000.0001) %MON seaice_vice_min              =  -1.7711089349685E-01
-(PID.TID 0000.0001) %MON seaice_vice_mean             =   1.2477527197772E-03
-(PID.TID 0000.0001) %MON seaice_vice_sd               =   1.5759575117772E-02
-(PID.TID 0000.0001) %MON seaice_vice_del2             =   1.2204420568228E-04
-(PID.TID 0000.0001) %MON seaice_area_max              =   9.6723361167576E-01
+(PID.TID 0000.0001) %MON seaice_uice_max              =   1.7785226951754E-01
+(PID.TID 0000.0001) %MON seaice_uice_min              =  -2.3406830043610E-01
+(PID.TID 0000.0001) %MON seaice_uice_mean             =  -6.3748188345076E-04
+(PID.TID 0000.0001) %MON seaice_uice_sd               =   1.4640140000242E-02
+(PID.TID 0000.0001) %MON seaice_uice_del2             =   2.3475381323808E-04
+(PID.TID 0000.0001) %MON seaice_vice_max              =   1.6462617043342E-01
+(PID.TID 0000.0001) %MON seaice_vice_min              =  -1.7711089349680E-01
+(PID.TID 0000.0001) %MON seaice_vice_mean             =   1.2477527197771E-03
+(PID.TID 0000.0001) %MON seaice_vice_sd               =   1.5759575117770E-02
+(PID.TID 0000.0001) %MON seaice_vice_del2             =   1.2204420568208E-04
+(PID.TID 0000.0001) %MON seaice_area_max              =   9.6723361167565E-01
 (PID.TID 0000.0001) %MON seaice_area_min              =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON seaice_area_mean             =   2.3324809742672E-02
 (PID.TID 0000.0001) %MON seaice_area_sd               =   1.4099622174236E-01
-(PID.TID 0000.0001) %MON seaice_area_del2             =   8.7246823727736E-04
-(PID.TID 0000.0001) %MON seaice_heff_max              =   6.6744394584702E-01
+(PID.TID 0000.0001) %MON seaice_area_del2             =   8.7246823727717E-04
+(PID.TID 0000.0001) %MON seaice_heff_max              =   6.6744394584675E-01
 (PID.TID 0000.0001) %MON seaice_heff_min              =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON seaice_heff_mean             =   1.4317518835875E-02
-(PID.TID 0000.0001) %MON seaice_heff_sd               =   8.7838205600206E-02
-(PID.TID 0000.0001) %MON seaice_heff_del2             =   5.3782533633074E-04
-(PID.TID 0000.0001) %MON seaice_hsnow_max             =   1.5769512137398E-02
+(PID.TID 0000.0001) %MON seaice_heff_sd               =   8.7838205600207E-02
+(PID.TID 0000.0001) %MON seaice_heff_del2             =   5.3782533633067E-04
+(PID.TID 0000.0001) %MON seaice_hsnow_max             =   1.5769512137400E-02
 (PID.TID 0000.0001) %MON seaice_hsnow_min             =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON seaice_hsnow_mean            =   1.6232407800146E-04
+(PID.TID 0000.0001) %MON seaice_hsnow_mean            =   1.6232407800147E-04
 (PID.TID 0000.0001) %MON seaice_hsnow_sd              =   1.1589518318153E-03
-(PID.TID 0000.0001) %MON seaice_hsnow_del2            =   1.5368259823465E-05
+(PID.TID 0000.0001) %MON seaice_hsnow_del2            =   1.5368259823466E-05
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // End MONITOR SEAICE statistics
 (PID.TID 0000.0001) // =======================================================
  EXTERNAL_FIELDS_LOAD,         8 : iP,iLd,i0,i1=   12    1   12    1 ; Wght=  0.2333333333  0.7666666667
  SEAICE_LSR: Residual Initial ipass,Uice,Vice=         1  4.59994984E-04  5.32660375E-04
- SEAICE_LSR (ipass=        1) iters,dU,Resid=       32  1.69801673E-13  5.24838596E-15
- SEAICE_LSR (ipass=        1) iters,dV,Resid=       32  5.27022870E-13  1.33433570E-14
+ SEAICE_LSR (ipass=        1) iters,dU,Resid=       32  1.69794734E-13  5.24935362E-15
+ SEAICE_LSR (ipass=        1) iters,dV,Resid=       32  5.27036748E-13  1.33441871E-14
  SEAICE_LSR: Residual Initial ipass,Uice,Vice=         2  2.60183284E-04  2.27976418E-04
- SEAICE_LSR (ipass=        2) iters,dU,Resid=       30  4.16673640E-13  1.34158125E-14
- SEAICE_LSR (ipass=        2) iters,dV,Resid=       30  8.27060642E-13  2.20673325E-14
- cg2d: Sum(rhs),rhsMax =   4.06864674392303E-01  1.99064579812033E+01
-(PID.TID 0000.0001)      cg2d_init_res =   7.47337618866838E-02
+ SEAICE_LSR (ipass=        2) iters,dU,Resid=       30  4.16673640E-13  1.34154792E-14
+ SEAICE_LSR (ipass=        2) iters,dV,Resid=       30  8.27046764E-13  2.20686861E-14
+ cg2d: Sum(rhs),rhsMax =   4.06864674392298E-01  1.99064579812052E+01
+(PID.TID 0000.0001)      cg2d_init_res =   7.47337618865079E-02
 (PID.TID 0000.0001)      cg2d_iters(min,last) =      -1     101
-(PID.TID 0000.0001)      cg2d_last_res =   8.10101752007928E-10
+(PID.TID 0000.0001)      cg2d_last_res =   8.10107185800390E-10
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // Begin MONITOR dynamic field statistics
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) %MON time_tsnumber                =                     9
 (PID.TID 0000.0001) %MON time_secondsf                =   7.7760000000000E+05
-(PID.TID 0000.0001) %MON dynstat_eta_max              =   1.5332025207749E+04
-(PID.TID 0000.0001) %MON dynstat_eta_min              =  -2.2031687650270E+04
+(PID.TID 0000.0001) %MON dynstat_eta_max              =   1.5332025207729E+04
+(PID.TID 0000.0001) %MON dynstat_eta_min              =  -2.2031687650271E+04
 (PID.TID 0000.0001) %MON dynstat_eta_mean             =  -1.2231070681067E+02
-(PID.TID 0000.0001) %MON dynstat_eta_sd               =   7.2643185457068E+03
-(PID.TID 0000.0001) %MON dynstat_eta_del2             =   9.4299284617011E+01
+(PID.TID 0000.0001) %MON dynstat_eta_sd               =   7.2643185457037E+03
+(PID.TID 0000.0001) %MON dynstat_eta_del2             =   9.4299284616602E+01
 (PID.TID 0000.0001) %MON dynstat_uvel_max             =   1.3203474887445E-01
-(PID.TID 0000.0001) %MON dynstat_uvel_min             =  -1.5505833731601E-01
-(PID.TID 0000.0001) %MON dynstat_uvel_mean            =   2.6036268726553E-05
-(PID.TID 0000.0001) %MON dynstat_uvel_sd              =   8.3322892191111E-03
-(PID.TID 0000.0001) %MON dynstat_uvel_del2            =   3.8173461607176E-05
-(PID.TID 0000.0001) %MON dynstat_vvel_max             =   2.0658255280720E-01
-(PID.TID 0000.0001) %MON dynstat_vvel_min             =  -1.9267791284834E-01
-(PID.TID 0000.0001) %MON dynstat_vvel_mean            =  -4.5362587490827E-04
-(PID.TID 0000.0001) %MON dynstat_vvel_sd              =   8.5819611173273E-03
-(PID.TID 0000.0001) %MON dynstat_vvel_del2            =   3.9331148602638E-05
-(PID.TID 0000.0001) %MON dynstat_wvel_max             =   5.6008227629643E+00
+(PID.TID 0000.0001) %MON dynstat_uvel_min             =  -1.5505833731599E-01
+(PID.TID 0000.0001) %MON dynstat_uvel_mean            =   2.6036268726403E-05
+(PID.TID 0000.0001) %MON dynstat_uvel_sd              =   8.3322892191114E-03
+(PID.TID 0000.0001) %MON dynstat_uvel_del2            =   3.8173461607178E-05
+(PID.TID 0000.0001) %MON dynstat_vvel_max             =   2.0658255280722E-01
+(PID.TID 0000.0001) %MON dynstat_vvel_min             =  -1.9267791284835E-01
+(PID.TID 0000.0001) %MON dynstat_vvel_mean            =  -4.5362587490816E-04
+(PID.TID 0000.0001) %MON dynstat_vvel_sd              =   8.5819611173274E-03
+(PID.TID 0000.0001) %MON dynstat_vvel_del2            =   3.9331148602632E-05
+(PID.TID 0000.0001) %MON dynstat_wvel_max             =   5.6008227629649E+00
 (PID.TID 0000.0001) %MON dynstat_wvel_min             =  -1.0307413729394E+01
-(PID.TID 0000.0001) %MON dynstat_wvel_mean            =   5.5356304149184E-05
-(PID.TID 0000.0001) %MON dynstat_wvel_sd              =   2.6779907296973E-01
-(PID.TID 0000.0001) %MON dynstat_wvel_del2            =   1.9971502468267E-03
+(PID.TID 0000.0001) %MON dynstat_wvel_mean            =   5.5356304143370E-05
+(PID.TID 0000.0001) %MON dynstat_wvel_sd              =   2.6779907296975E-01
+(PID.TID 0000.0001) %MON dynstat_wvel_del2            =   1.9971502468270E-03
 (PID.TID 0000.0001) %MON dynstat_theta_max            =   2.9442503899786E+01
 (PID.TID 0000.0001) %MON dynstat_theta_min            =  -1.9011840429295E+00
 (PID.TID 0000.0001) %MON dynstat_theta_mean           =   3.5924557623694E+00
@@ -4519,46 +4522,46 @@ listId=   2 ; file name: seaiceStDiag
 (PID.TID 0000.0001) %MON forcing_qnet_min             =  -3.0984416529487E+02
 (PID.TID 0000.0001) %MON forcing_qnet_mean            =  -2.7219775222223E+01
 (PID.TID 0000.0001) %MON forcing_qnet_sd              =   1.4862335632547E+02
-(PID.TID 0000.0001) %MON forcing_qnet_del2            =   8.6249168604138E-01
+(PID.TID 0000.0001) %MON forcing_qnet_del2            =   8.6249168604131E-01
 (PID.TID 0000.0001) %MON forcing_qsw_max              =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON forcing_qsw_min              =  -3.0181929764305E+02
 (PID.TID 0000.0001) %MON forcing_qsw_mean             =  -1.8597516870272E+02
 (PID.TID 0000.0001) %MON forcing_qsw_sd               =   7.8478787234767E+01
 (PID.TID 0000.0001) %MON forcing_qsw_del2             =   1.1102171141631E-01
 (PID.TID 0000.0001) %MON forcing_empmr_max            =   1.1508436260847E-03
-(PID.TID 0000.0001) %MON forcing_empmr_min            =  -6.9111204329924E-04
+(PID.TID 0000.0001) %MON forcing_empmr_min            =  -6.9111204329946E-04
 (PID.TID 0000.0001) %MON forcing_empmr_mean           =   1.0658307804285E-05
 (PID.TID 0000.0001) %MON forcing_empmr_sd             =   9.1652023732460E-05
-(PID.TID 0000.0001) %MON forcing_empmr_del2           =   1.5873883030036E-06
+(PID.TID 0000.0001) %MON forcing_empmr_del2           =   1.5873883030031E-06
 (PID.TID 0000.0001) %MON forcing_fu_max               =   2.4722174155228E-01
 (PID.TID 0000.0001) %MON forcing_fu_min               =  -2.2809828301201E-01
 (PID.TID 0000.0001) %MON forcing_fu_mean              =  -4.1332457837451E-03
 (PID.TID 0000.0001) %MON forcing_fu_sd                =   6.4363309053029E-02
-(PID.TID 0000.0001) %MON forcing_fu_del2              =   2.1266108384821E-04
+(PID.TID 0000.0001) %MON forcing_fu_del2              =   2.1266108384820E-04
 (PID.TID 0000.0001) %MON forcing_fv_max               =   2.7427691301694E-01
 (PID.TID 0000.0001) %MON forcing_fv_min               =  -3.3322315549145E-01
 (PID.TID 0000.0001) %MON forcing_fv_mean              =  -1.3700059350252E-02
 (PID.TID 0000.0001) %MON forcing_fv_sd                =   7.5748370293256E-02
 (PID.TID 0000.0001) %MON forcing_fv_del2              =   2.4024308977182E-04
-(PID.TID 0000.0001) %MON trAdv_CFL_u_max              =   4.7688291930648E-02
-(PID.TID 0000.0001) %MON trAdv_CFL_v_max              =   7.6413473329455E-02
-(PID.TID 0000.0001) %MON trAdv_CFL_w_max              =   2.6359950676834E-01
-(PID.TID 0000.0001) %MON advcfl_uvel_max              =   4.7778845871482E-02
-(PID.TID 0000.0001) %MON advcfl_vvel_max              =   5.9252330582506E-02
+(PID.TID 0000.0001) %MON trAdv_CFL_u_max              =   4.7688291930658E-02
+(PID.TID 0000.0001) %MON trAdv_CFL_v_max              =   7.6413473329457E-02
+(PID.TID 0000.0001) %MON trAdv_CFL_w_max              =   2.6359950676833E-01
+(PID.TID 0000.0001) %MON advcfl_uvel_max              =   4.7778845871492E-02
+(PID.TID 0000.0001) %MON advcfl_vvel_max              =   5.9252330582510E-02
 (PID.TID 0000.0001) %MON advcfl_wvel_max              =   2.8873353121121E-01
 (PID.TID 0000.0001) %MON advcfl_W_hf_max              =   3.1895787358204E-01
-(PID.TID 0000.0001) %MON pe_b_mean                    =   1.3518705310077E-02
-(PID.TID 0000.0001) %MON ke_max                       =   1.5115992174465E-02
-(PID.TID 0000.0001) %MON ke_mean                      =   6.6159591389065E-05
+(PID.TID 0000.0001) %MON pe_b_mean                    =   1.3518705310072E-02
+(PID.TID 0000.0001) %MON ke_max                       =   1.5115992174466E-02
+(PID.TID 0000.0001) %MON ke_mean                      =   6.6159591389067E-05
 (PID.TID 0000.0001) %MON ke_vol                       =   1.3604135464270E+22
-(PID.TID 0000.0001) %MON vort_r_min                   =  -7.6693020057722E-07
-(PID.TID 0000.0001) %MON vort_r_max                   =   8.5174999441944E-07
+(PID.TID 0000.0001) %MON vort_r_min                   =  -7.6693020057728E-07
+(PID.TID 0000.0001) %MON vort_r_max                   =   8.5174999441785E-07
 (PID.TID 0000.0001) %MON vort_a_mean                  =  -2.0556865257795E-05
 (PID.TID 0000.0001) %MON vort_a_sd                    =   7.5247464798211E-05
 (PID.TID 0000.0001) %MON vort_p_mean                  =  -2.4859248134469E-05
 (PID.TID 0000.0001) %MON vort_p_sd                    =   1.2920593875699E-04
-(PID.TID 0000.0001) %MON surfExpan_theta_mean         =  -1.0875528093151E-03
-(PID.TID 0000.0001) %MON surfExpan_salt_mean          =  -3.2884692870013E-03
+(PID.TID 0000.0001) %MON surfExpan_theta_mean         =  -1.0875528093086E-03
+(PID.TID 0000.0001) %MON surfExpan_salt_mean          =  -3.2884692869341E-03
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // End MONITOR dynamic field statistics
 (PID.TID 0000.0001) // =======================================================
@@ -4567,70 +4570,70 @@ listId=   2 ; file name: seaiceStDiag
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) %MON seaice_tsnumber              =                     9
 (PID.TID 0000.0001) %MON seaice_time_sec              =   7.7760000000000E+05
-(PID.TID 0000.0001) %MON seaice_uice_max              =   1.7178312455828E-01
+(PID.TID 0000.0001) %MON seaice_uice_max              =   1.7178312455833E-01
 (PID.TID 0000.0001) %MON seaice_uice_min              =  -2.3107987833920E-01
 (PID.TID 0000.0001) %MON seaice_uice_mean             =  -6.7295013295837E-04
-(PID.TID 0000.0001) %MON seaice_uice_sd               =   1.4916014786676E-02
-(PID.TID 0000.0001) %MON seaice_uice_del2             =   2.3418237418142E-04
+(PID.TID 0000.0001) %MON seaice_uice_sd               =   1.4916014786672E-02
+(PID.TID 0000.0001) %MON seaice_uice_del2             =   2.3418237418107E-04
 (PID.TID 0000.0001) %MON seaice_vice_max              =   1.6590115587446E-01
-(PID.TID 0000.0001) %MON seaice_vice_min              =  -1.8429958827065E-01
-(PID.TID 0000.0001) %MON seaice_vice_mean             =   1.3463084028146E-03
+(PID.TID 0000.0001) %MON seaice_vice_min              =  -1.8429958827062E-01
+(PID.TID 0000.0001) %MON seaice_vice_mean             =   1.3463084028151E-03
 (PID.TID 0000.0001) %MON seaice_vice_sd               =   1.6013308772817E-02
-(PID.TID 0000.0001) %MON seaice_vice_del2             =   1.3887604597350E-04
-(PID.TID 0000.0001) %MON seaice_area_max              =   9.8169656819995E-01
+(PID.TID 0000.0001) %MON seaice_vice_del2             =   1.3887604597328E-04
+(PID.TID 0000.0001) %MON seaice_area_max              =   9.8169656819991E-01
 (PID.TID 0000.0001) %MON seaice_area_min              =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON seaice_area_mean             =   2.4525035954285E-02
 (PID.TID 0000.0001) %MON seaice_area_sd               =   1.4691129815273E-01
-(PID.TID 0000.0001) %MON seaice_area_del2             =   9.1773538746738E-04
-(PID.TID 0000.0001) %MON seaice_heff_max              =   7.0602655036361E-01
+(PID.TID 0000.0001) %MON seaice_area_del2             =   9.1773538746730E-04
+(PID.TID 0000.0001) %MON seaice_heff_max              =   7.0602655036341E-01
 (PID.TID 0000.0001) %MON seaice_heff_min              =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON seaice_heff_mean             =   1.5537145213670E-02
-(PID.TID 0000.0001) %MON seaice_heff_sd               =   9.4497695273164E-02
-(PID.TID 0000.0001) %MON seaice_heff_del2             =   5.6964259557398E-04
-(PID.TID 0000.0001) %MON seaice_hsnow_max             =   1.9311374557612E-02
+(PID.TID 0000.0001) %MON seaice_heff_mean             =   1.5537145213671E-02
+(PID.TID 0000.0001) %MON seaice_heff_sd               =   9.4497695273166E-02
+(PID.TID 0000.0001) %MON seaice_heff_del2             =   5.6964259557394E-04
+(PID.TID 0000.0001) %MON seaice_hsnow_max             =   1.9311374557614E-02
 (PID.TID 0000.0001) %MON seaice_hsnow_min             =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON seaice_hsnow_mean            =   2.0636560245866E-04
-(PID.TID 0000.0001) %MON seaice_hsnow_sd              =   1.4500521710013E-03
-(PID.TID 0000.0001) %MON seaice_hsnow_del2            =   1.7312533574946E-05
+(PID.TID 0000.0001) %MON seaice_hsnow_mean            =   2.0636560245867E-04
+(PID.TID 0000.0001) %MON seaice_hsnow_sd              =   1.4500521710014E-03
+(PID.TID 0000.0001) %MON seaice_hsnow_del2            =   1.7312533574945E-05
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // End MONITOR SEAICE statistics
 (PID.TID 0000.0001) // =======================================================
  EXTERNAL_FIELDS_LOAD,         9 : iP,iLd,i0,i1=   12    1   12    1 ; Wght=  0.2000000000  0.8000000000
  SEAICE_LSR: Residual Initial ipass,Uice,Vice=         1  4.69342011E-04  6.01972731E-04
- SEAICE_LSR (ipass=        1) iters,dU,Resid=       42  7.66470221E-14  4.41657482E-15
- SEAICE_LSR (ipass=        1) iters,dV,Resid=       42  7.37326866E-13  3.80276333E-14
+ SEAICE_LSR (ipass=        1) iters,dU,Resid=       42  7.66470221E-14  4.41600011E-15
+ SEAICE_LSR (ipass=        1) iters,dV,Resid=       42  7.37354622E-13  3.80284088E-14
  SEAICE_LSR: Residual Initial ipass,Uice,Vice=         2  2.94674969E-04  3.14255476E-04
- SEAICE_LSR (ipass=        2) iters,dU,Resid=       40  1.38639100E-13  8.18911394E-15
- SEAICE_LSR (ipass=        2) iters,dV,Resid=       40  8.14570633E-13  4.32800061E-14
- cg2d: Sum(rhs),rhsMax =   4.35683592553348E-01  1.99115674551300E+01
-(PID.TID 0000.0001)      cg2d_init_res =   7.43077818840119E-02
+ SEAICE_LSR (ipass=        2) iters,dU,Resid=       40  1.38639100E-13  8.19053272E-15
+ SEAICE_LSR (ipass=        2) iters,dV,Resid=       40  8.14570633E-13  4.32787315E-14
+ cg2d: Sum(rhs),rhsMax =   4.35683592553324E-01  1.99115674551319E+01
+(PID.TID 0000.0001)      cg2d_init_res =   7.43077818841340E-02
 (PID.TID 0000.0001)      cg2d_iters(min,last) =      -1     100
-(PID.TID 0000.0001)      cg2d_last_res =   8.64496746516316E-10
+(PID.TID 0000.0001)      cg2d_last_res =   8.64500456367144E-10
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // Begin MONITOR dynamic field statistics
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) %MON time_tsnumber                =                    10
 (PID.TID 0000.0001) %MON time_secondsf                =   8.6400000000000E+05
-(PID.TID 0000.0001) %MON dynstat_eta_max              =   1.5132456881304E+04
-(PID.TID 0000.0001) %MON dynstat_eta_min              =  -2.4252921894249E+04
-(PID.TID 0000.0001) %MON dynstat_eta_mean             =  -1.3100780027631E+02
-(PID.TID 0000.0001) %MON dynstat_eta_sd               =   7.2833751242446E+03
-(PID.TID 0000.0001) %MON dynstat_eta_del2             =   9.4347441065436E+01
-(PID.TID 0000.0001) %MON dynstat_uvel_max             =   1.4020151062671E-01
-(PID.TID 0000.0001) %MON dynstat_uvel_min             =  -1.6297128183070E-01
-(PID.TID 0000.0001) %MON dynstat_uvel_mean            =   4.9699670330466E-05
-(PID.TID 0000.0001) %MON dynstat_uvel_sd              =   9.0568796395779E-03
-(PID.TID 0000.0001) %MON dynstat_uvel_del2            =   3.9888961566981E-05
-(PID.TID 0000.0001) %MON dynstat_vvel_max             =   2.1625060139144E-01
-(PID.TID 0000.0001) %MON dynstat_vvel_min             =  -2.0221865377050E-01
-(PID.TID 0000.0001) %MON dynstat_vvel_mean            =  -4.0753962273884E-04
-(PID.TID 0000.0001) %MON dynstat_vvel_sd              =   9.3200252716606E-03
+(PID.TID 0000.0001) %MON dynstat_eta_max              =   1.5132456881303E+04
+(PID.TID 0000.0001) %MON dynstat_eta_min              =  -2.4252921894302E+04
+(PID.TID 0000.0001) %MON dynstat_eta_mean             =  -1.3100780027632E+02
+(PID.TID 0000.0001) %MON dynstat_eta_sd               =   7.2833751242443E+03
+(PID.TID 0000.0001) %MON dynstat_eta_del2             =   9.4347441065400E+01
+(PID.TID 0000.0001) %MON dynstat_uvel_max             =   1.4020151062672E-01
+(PID.TID 0000.0001) %MON dynstat_uvel_min             =  -1.6297128183068E-01
+(PID.TID 0000.0001) %MON dynstat_uvel_mean            =   4.9699670329931E-05
+(PID.TID 0000.0001) %MON dynstat_uvel_sd              =   9.0568796395782E-03
+(PID.TID 0000.0001) %MON dynstat_uvel_del2            =   3.9888961566985E-05
+(PID.TID 0000.0001) %MON dynstat_vvel_max             =   2.1625060139146E-01
+(PID.TID 0000.0001) %MON dynstat_vvel_min             =  -2.0221865377051E-01
+(PID.TID 0000.0001) %MON dynstat_vvel_mean            =  -4.0753962273860E-04
+(PID.TID 0000.0001) %MON dynstat_vvel_sd              =   9.3200252716607E-03
 (PID.TID 0000.0001) %MON dynstat_vvel_del2            =   4.1074315151666E-05
-(PID.TID 0000.0001) %MON dynstat_wvel_max             =   5.6379668363042E+00
+(PID.TID 0000.0001) %MON dynstat_wvel_max             =   5.6379668363047E+00
 (PID.TID 0000.0001) %MON dynstat_wvel_min             =  -1.0791390307844E+01
-(PID.TID 0000.0001) %MON dynstat_wvel_mean            =   1.1711994789904E-04
-(PID.TID 0000.0001) %MON dynstat_wvel_sd              =   2.7512928144233E-01
-(PID.TID 0000.0001) %MON dynstat_wvel_del2            =   2.0118377977045E-03
+(PID.TID 0000.0001) %MON dynstat_wvel_mean            =   1.1711994790678E-04
+(PID.TID 0000.0001) %MON dynstat_wvel_sd              =   2.7512928144235E-01
+(PID.TID 0000.0001) %MON dynstat_wvel_del2            =   2.0118377977047E-03
 (PID.TID 0000.0001) %MON dynstat_theta_max            =   2.9452368164193E+01
 (PID.TID 0000.0001) %MON dynstat_theta_min            =  -1.9013156465097E+00
 (PID.TID 0000.0001) %MON dynstat_theta_mean           =   3.5926142510922E+00
@@ -4645,7 +4648,7 @@ listId=   2 ; file name: seaiceStDiag
 (PID.TID 0000.0001) %MON forcing_qnet_min             =  -3.0866983038664E+02
 (PID.TID 0000.0001) %MON forcing_qnet_mean            =  -2.7236522023554E+01
 (PID.TID 0000.0001) %MON forcing_qnet_sd              =   1.4810006924452E+02
-(PID.TID 0000.0001) %MON forcing_qnet_del2            =   9.7758777749971E-01
+(PID.TID 0000.0001) %MON forcing_qnet_del2            =   9.7758777749968E-01
 (PID.TID 0000.0001) %MON forcing_qsw_max              =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON forcing_qsw_min              =  -3.0180730070724E+02
 (PID.TID 0000.0001) %MON forcing_qsw_mean             =  -1.8597957400326E+02
@@ -4654,11 +4657,11 @@ listId=   2 ; file name: seaiceStDiag
 (PID.TID 0000.0001) %MON forcing_empmr_max            =   1.3896871374541E-03
 (PID.TID 0000.0001) %MON forcing_empmr_min            =  -3.8522907870527E-03
 (PID.TID 0000.0001) %MON forcing_empmr_mean           =   1.0261040163152E-05
-(PID.TID 0000.0001) %MON forcing_empmr_sd             =   1.1207584314856E-04
-(PID.TID 0000.0001) %MON forcing_empmr_del2           =   1.9357132777592E-06
+(PID.TID 0000.0001) %MON forcing_empmr_sd             =   1.1207584314857E-04
+(PID.TID 0000.0001) %MON forcing_empmr_del2           =   1.9357132777591E-06
 (PID.TID 0000.0001) %MON forcing_fu_max               =   2.4734156444157E-01
 (PID.TID 0000.0001) %MON forcing_fu_min               =  -2.3124407967036E-01
-(PID.TID 0000.0001) %MON forcing_fu_mean              =  -4.0821717009627E-03
+(PID.TID 0000.0001) %MON forcing_fu_mean              =  -4.0821717009626E-03
 (PID.TID 0000.0001) %MON forcing_fu_sd                =   6.4475232469900E-02
 (PID.TID 0000.0001) %MON forcing_fu_del2              =   2.1461942425937E-04
 (PID.TID 0000.0001) %MON forcing_fv_max               =   2.7696015458957E-01
@@ -4666,25 +4669,25 @@ listId=   2 ; file name: seaiceStDiag
 (PID.TID 0000.0001) %MON forcing_fv_mean              =  -1.3712200084434E-02
 (PID.TID 0000.0001) %MON forcing_fv_sd                =   7.5847477327920E-02
 (PID.TID 0000.0001) %MON forcing_fv_del2              =   2.4173874757890E-04
-(PID.TID 0000.0001) %MON trAdv_CFL_u_max              =   5.0142974230716E-02
-(PID.TID 0000.0001) %MON trAdv_CFL_v_max              =   8.0221593181222E-02
+(PID.TID 0000.0001) %MON trAdv_CFL_u_max              =   5.0142974230730E-02
+(PID.TID 0000.0001) %MON trAdv_CFL_v_max              =   8.0221593181224E-02
 (PID.TID 0000.0001) %MON trAdv_CFL_w_max              =   2.7517122887883E-01
-(PID.TID 0000.0001) %MON advcfl_uvel_max              =   5.0238231288152E-02
-(PID.TID 0000.0001) %MON advcfl_vvel_max              =   6.2679804227775E-02
+(PID.TID 0000.0001) %MON advcfl_uvel_max              =   5.0238231288165E-02
+(PID.TID 0000.0001) %MON advcfl_vvel_max              =   6.2679804227785E-02
 (PID.TID 0000.0001) %MON advcfl_wvel_max              =   3.0141692423020E-01
-(PID.TID 0000.0001) %MON advcfl_W_hf_max              =   3.3295976578318E-01
-(PID.TID 0000.0001) %MON pe_b_mean                    =   1.3573143932004E-02
-(PID.TID 0000.0001) %MON ke_max                       =   1.6766040516652E-02
-(PID.TID 0000.0001) %MON ke_mean                      =   7.8060416579796E-05
+(PID.TID 0000.0001) %MON advcfl_W_hf_max              =   3.3295976578319E-01
+(PID.TID 0000.0001) %MON pe_b_mean                    =   1.3573143932006E-02
+(PID.TID 0000.0001) %MON ke_max                       =   1.6766040516654E-02
+(PID.TID 0000.0001) %MON ke_mean                      =   7.8060416579799E-05
 (PID.TID 0000.0001) %MON ke_vol                       =   1.3604132176986E+22
-(PID.TID 0000.0001) %MON vort_r_min                   =  -8.0901195079868E-07
-(PID.TID 0000.0001) %MON vort_r_max                   =   8.7666425960351E-07
+(PID.TID 0000.0001) %MON vort_r_min                   =  -8.0901195079874E-07
+(PID.TID 0000.0001) %MON vort_r_max                   =   8.7666425960099E-07
 (PID.TID 0000.0001) %MON vort_a_mean                  =  -2.0556865257795E-05
 (PID.TID 0000.0001) %MON vort_a_sd                    =   7.5247481433753E-05
 (PID.TID 0000.0001) %MON vort_p_mean                  =  -2.4859249105067E-05
 (PID.TID 0000.0001) %MON vort_p_sd                    =   1.2920585372202E-04
-(PID.TID 0000.0001) %MON surfExpan_theta_mean         =  -1.7677668454427E-03
-(PID.TID 0000.0001) %MON surfExpan_salt_mean          =  -3.0711711576389E-03
+(PID.TID 0000.0001) %MON surfExpan_theta_mean         =  -1.7677668454596E-03
+(PID.TID 0000.0001) %MON surfExpan_salt_mean          =  -3.0711711577136E-03
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // End MONITOR dynamic field statistics
 (PID.TID 0000.0001) // =======================================================
@@ -4693,31 +4696,31 @@ listId=   2 ; file name: seaiceStDiag
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) %MON seaice_tsnumber              =                    10
 (PID.TID 0000.0001) %MON seaice_time_sec              =   8.6400000000000E+05
-(PID.TID 0000.0001) %MON seaice_uice_max              =   1.7239342256629E-01
-(PID.TID 0000.0001) %MON seaice_uice_min              =  -2.3433433435930E-01
-(PID.TID 0000.0001) %MON seaice_uice_mean             =  -6.3110576510110E-04
-(PID.TID 0000.0001) %MON seaice_uice_sd               =   1.4989155675137E-02
-(PID.TID 0000.0001) %MON seaice_uice_del2             =   2.2256432939371E-04
+(PID.TID 0000.0001) %MON seaice_uice_max              =   1.7239342256630E-01
+(PID.TID 0000.0001) %MON seaice_uice_min              =  -2.3433433435931E-01
+(PID.TID 0000.0001) %MON seaice_uice_mean             =  -6.3110576510112E-04
+(PID.TID 0000.0001) %MON seaice_uice_sd               =   1.4989155675134E-02
+(PID.TID 0000.0001) %MON seaice_uice_del2             =   2.2256432939340E-04
 (PID.TID 0000.0001) %MON seaice_vice_max              =   1.6321150075165E-01
-(PID.TID 0000.0001) %MON seaice_vice_min              =  -1.9202532806798E-01
-(PID.TID 0000.0001) %MON seaice_vice_mean             =   1.4323430236226E-03
+(PID.TID 0000.0001) %MON seaice_vice_min              =  -1.9202532806794E-01
+(PID.TID 0000.0001) %MON seaice_vice_mean             =   1.4323430236230E-03
 (PID.TID 0000.0001) %MON seaice_vice_sd               =   1.6297073157974E-02
-(PID.TID 0000.0001) %MON seaice_vice_del2             =   1.3918049556538E-04
-(PID.TID 0000.0001) %MON seaice_area_max              =   9.9180396988276E-01
+(PID.TID 0000.0001) %MON seaice_vice_del2             =   1.3918049556512E-04
+(PID.TID 0000.0001) %MON seaice_area_max              =   9.9180396988275E-01
 (PID.TID 0000.0001) %MON seaice_area_min              =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON seaice_area_mean             =   2.5474429048911E-02
 (PID.TID 0000.0001) %MON seaice_area_sd               =   1.5104398912317E-01
 (PID.TID 0000.0001) %MON seaice_area_del2             =   1.0168244355572E-03
-(PID.TID 0000.0001) %MON seaice_heff_max              =   7.4206545134839E-01
+(PID.TID 0000.0001) %MON seaice_heff_max              =   7.4206545134822E-01
 (PID.TID 0000.0001) %MON seaice_heff_min              =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON seaice_heff_mean             =   1.6712367990083E-02
-(PID.TID 0000.0001) %MON seaice_heff_sd               =   1.0061645872488E-01
+(PID.TID 0000.0001) %MON seaice_heff_sd               =   1.0061645872489E-01
 (PID.TID 0000.0001) %MON seaice_heff_del2             =   6.2813990969497E-04
-(PID.TID 0000.0001) %MON seaice_hsnow_max             =   2.2923391376540E-02
+(PID.TID 0000.0001) %MON seaice_hsnow_max             =   2.2923391376541E-02
 (PID.TID 0000.0001) %MON seaice_hsnow_min             =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON seaice_hsnow_mean            =   2.5272736554573E-04
-(PID.TID 0000.0001) %MON seaice_hsnow_sd              =   1.7596882239845E-03
-(PID.TID 0000.0001) %MON seaice_hsnow_del2            =   1.9411939002926E-05
+(PID.TID 0000.0001) %MON seaice_hsnow_sd              =   1.7596882239846E-03
+(PID.TID 0000.0001) %MON seaice_hsnow_del2            =   1.9411939002924E-05
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // End MONITOR SEAICE statistics
 (PID.TID 0000.0001) // =======================================================
@@ -4748,183 +4751,183 @@ listId=   2 ; file name: seaiceStDiag
 (PID.TID 0000.0001) DIAGSTATS_CLOSE_IO: close file: seaiceStDiag.0000000000.txt , unit=    10
 (PID.TID 0000.0001) %CHECKPOINT        10 ckptA
 (PID.TID 0000.0001)   Seconds in section "ALL                    [THE_MODEL_MAIN]":
-(PID.TID 0000.0001)           User time:   16.303062244318426
-(PID.TID 0000.0001)         System time:  0.32427100441418588
-(PID.TID 0000.0001)     Wall clock time:   16.708030939102173
+(PID.TID 0000.0001)           User time:   17.153757787309587
+(PID.TID 0000.0001)         System time:  0.22694099275395274
+(PID.TID 0000.0001)     Wall clock time:   17.480443000793457
 (PID.TID 0000.0001)          No. starts:           1
 (PID.TID 0000.0001)           No. stops:           1
 (PID.TID 0000.0001)   Seconds in section "INITIALISE_FIXED       [THE_MODEL_MAIN]":
-(PID.TID 0000.0001)           User time:  0.17412000522017479
-(PID.TID 0000.0001)         System time:  0.10483799781650305
-(PID.TID 0000.0001)     Wall clock time:  0.33323621749877930
+(PID.TID 0000.0001)           User time:  0.22312200162559748
+(PID.TID 0000.0001)         System time:   7.6591000426560640E-002
+(PID.TID 0000.0001)     Wall clock time:  0.36021399497985840
 (PID.TID 0000.0001)          No. starts:           1
 (PID.TID 0000.0001)           No. stops:           1
 (PID.TID 0000.0001)   Seconds in section "THE_MAIN_LOOP          [THE_MODEL_MAIN]":
-(PID.TID 0000.0001)           User time:   16.128845527768135
-(PID.TID 0000.0001)         System time:  0.21940800547599792
-(PID.TID 0000.0001)     Wall clock time:   16.374683141708374
+(PID.TID 0000.0001)           User time:   16.930593252182007
+(PID.TID 0000.0001)         System time:  0.15033499151468277
+(PID.TID 0000.0001)     Wall clock time:   17.120187044143677
 (PID.TID 0000.0001)          No. starts:           1
 (PID.TID 0000.0001)           No. stops:           1
 (PID.TID 0000.0001)   Seconds in section "INITIALISE_VARIA    [THE_MAIN_LOOP]":
-(PID.TID 0000.0001)           User time:  0.38098300993442535
-(PID.TID 0000.0001)         System time:  0.15234299749135971
-(PID.TID 0000.0001)     Wall clock time:  0.55511999130249023
+(PID.TID 0000.0001)           User time:  0.35547700524330139
+(PID.TID 0000.0001)         System time:  0.11326200515031815
+(PID.TID 0000.0001)     Wall clock time:  0.50431394577026367
 (PID.TID 0000.0001)          No. starts:           1
 (PID.TID 0000.0001)           No. stops:           1
 (PID.TID 0000.0001)   Seconds in section "MAIN LOOP           [THE_MAIN_LOOP]":
-(PID.TID 0000.0001)           User time:   15.747840881347656
-(PID.TID 0000.0001)         System time:   6.7057996988296509E-002
-(PID.TID 0000.0001)     Wall clock time:   15.819536924362183
+(PID.TID 0000.0001)           User time:   16.575083613395691
+(PID.TID 0000.0001)         System time:   3.7064999341964722E-002
+(PID.TID 0000.0001)     Wall clock time:   16.615843772888184
 (PID.TID 0000.0001)          No. starts:           1
 (PID.TID 0000.0001)           No. stops:           1
 (PID.TID 0000.0001)   Seconds in section "MAIN_DO_LOOP        [THE_MAIN_LOOP]":
-(PID.TID 0000.0001)           User time:   15.747757852077484
-(PID.TID 0000.0001)         System time:   6.7055016756057739E-002
-(PID.TID 0000.0001)     Wall clock time:   15.819450378417969
+(PID.TID 0000.0001)           User time:   16.574999868869781
+(PID.TID 0000.0001)         System time:   3.7062987685203552E-002
+(PID.TID 0000.0001)     Wall clock time:   16.615760326385498
 (PID.TID 0000.0001)          No. starts:          10
 (PID.TID 0000.0001)           No. stops:          10
 (PID.TID 0000.0001)   Seconds in section "FORWARD_STEP        [MAIN_DO_LOOP]":
-(PID.TID 0000.0001)           User time:   15.747598946094513
-(PID.TID 0000.0001)         System time:   6.7052006721496582E-002
-(PID.TID 0000.0001)     Wall clock time:   15.819287061691284
+(PID.TID 0000.0001)           User time:   16.574819386005402
+(PID.TID 0000.0001)         System time:   3.7060990929603577E-002
+(PID.TID 0000.0001)     Wall clock time:   16.615572929382324
 (PID.TID 0000.0001)          No. starts:          10
 (PID.TID 0000.0001)           No. stops:          10
 (PID.TID 0000.0001)   Seconds in section "UPDATE_R_STAR       [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:  0.41088455915451050
-(PID.TID 0000.0001)         System time:   0.0000000000000000
-(PID.TID 0000.0001)     Wall clock time:  0.41095972061157227
+(PID.TID 0000.0001)           User time:  0.43289899826049805
+(PID.TID 0000.0001)         System time:   1.6701221466064453E-004
+(PID.TID 0000.0001)     Wall clock time:  0.43314099311828613
 (PID.TID 0000.0001)          No. starts:          20
 (PID.TID 0000.0001)           No. stops:          20
 (PID.TID 0000.0001)   Seconds in section "DO_STATEVARS_DIAGS  [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:  0.68178027868270874
-(PID.TID 0000.0001)         System time:   0.0000000000000000
-(PID.TID 0000.0001)     Wall clock time:  0.68185472488403320
+(PID.TID 0000.0001)           User time:  0.74683254957199097
+(PID.TID 0000.0001)         System time:   4.1007995605468750E-005
+(PID.TID 0000.0001)     Wall clock time:  0.74693894386291504
 (PID.TID 0000.0001)          No. starts:          30
 (PID.TID 0000.0001)           No. stops:          30
 (PID.TID 0000.0001)   Seconds in section "LOAD_FIELDS_DRIVER  [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:  0.14983320236206055
-(PID.TID 0000.0001)         System time:   2.7790367603302002E-003
-(PID.TID 0000.0001)     Wall clock time:  0.15527200698852539
+(PID.TID 0000.0001)           User time:  0.16053634881973267
+(PID.TID 0000.0001)         System time:   4.4649988412857056E-003
+(PID.TID 0000.0001)     Wall clock time:  0.16752433776855469
 (PID.TID 0000.0001)          No. starts:          10
 (PID.TID 0000.0001)           No. stops:          10
 (PID.TID 0000.0001)   Seconds in section "EXF_GETFORCING     [LOAD_FLDS_DRIVER]":
-(PID.TID 0000.0001)           User time:  0.14433693885803223
-(PID.TID 0000.0001)         System time:   2.5170147418975830E-003
-(PID.TID 0000.0001)     Wall clock time:  0.14952659606933594
+(PID.TID 0000.0001)           User time:  0.15441411733627319
+(PID.TID 0000.0001)         System time:   4.1100084781646729E-003
+(PID.TID 0000.0001)     Wall clock time:  0.16106867790222168
 (PID.TID 0000.0001)          No. starts:          10
 (PID.TID 0000.0001)           No. stops:          10
 (PID.TID 0000.0001)   Seconds in section "EXTERNAL_FLDS_LOAD [LOAD_FLDS_DRIVER]":
-(PID.TID 0000.0001)           User time:   5.2451491355895996E-003
-(PID.TID 0000.0001)         System time:   2.4998188018798828E-004
-(PID.TID 0000.0001)     Wall clock time:   5.5086612701416016E-003
+(PID.TID 0000.0001)           User time:   5.8397650718688965E-003
+(PID.TID 0000.0001)         System time:   3.4900009632110596E-004
+(PID.TID 0000.0001)     Wall clock time:   6.1919689178466797E-003
 (PID.TID 0000.0001)          No. starts:          10
 (PID.TID 0000.0001)           No. stops:          10
 (PID.TID 0000.0001)   Seconds in section "DO_ATMOSPHERIC_PHYS [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:   1.3369321823120117E-004
-(PID.TID 0000.0001)         System time:   1.7017126083374023E-005
-(PID.TID 0000.0001)     Wall clock time:   1.5234947204589844E-004
+(PID.TID 0000.0001)           User time:   9.9956989288330078E-005
+(PID.TID 0000.0001)         System time:   2.9951333999633789E-006
+(PID.TID 0000.0001)     Wall clock time:   1.0275840759277344E-004
 (PID.TID 0000.0001)          No. starts:          10
 (PID.TID 0000.0001)           No. stops:          10
 (PID.TID 0000.0001)   Seconds in section "DO_OCEANIC_PHYS     [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:   5.0551030039787292
-(PID.TID 0000.0001)         System time:   1.2644022703170776E-002
-(PID.TID 0000.0001)     Wall clock time:   5.0689678192138672
+(PID.TID 0000.0001)           User time:   5.2191948890686035
+(PID.TID 0000.0001)         System time:   1.2264981865882874E-002
+(PID.TID 0000.0001)     Wall clock time:   5.2318942546844482
 (PID.TID 0000.0001)          No. starts:          10
 (PID.TID 0000.0001)           No. stops:          10
 (PID.TID 0000.0001)   Seconds in section "SEAICE_MODEL    [DO_OCEANIC_PHYS]":
-(PID.TID 0000.0001)           User time:   2.0489403605461121
-(PID.TID 0000.0001)         System time:   8.6889863014221191E-003
-(PID.TID 0000.0001)     Wall clock time:   2.0577862262725830
+(PID.TID 0000.0001)           User time:   2.1493655443191528
+(PID.TID 0000.0001)         System time:   7.0005655288696289E-005
+(PID.TID 0000.0001)     Wall clock time:   2.1496622562408447
 (PID.TID 0000.0001)          No. starts:          10
 (PID.TID 0000.0001)           No. stops:          10
 (PID.TID 0000.0001)   Seconds in section "SEAICE_DYNSOLVER   [SEAICE_MODEL]":
-(PID.TID 0000.0001)           User time:   1.6883903145790100
-(PID.TID 0000.0001)         System time:   7.4400007724761963E-003
-(PID.TID 0000.0001)     Wall clock time:   1.6959919929504395
+(PID.TID 0000.0001)           User time:   1.7777440547943115
+(PID.TID 0000.0001)         System time:   0.0000000000000000
+(PID.TID 0000.0001)     Wall clock time:   1.7778308391571045
 (PID.TID 0000.0001)          No. starts:          10
 (PID.TID 0000.0001)           No. stops:          10
 (PID.TID 0000.0001)   Seconds in section "GGL90_CALC [DO_OCEANIC_PHYS]":
-(PID.TID 0000.0001)           User time:   2.2719463109970093
-(PID.TID 0000.0001)         System time:   3.7330090999603271E-003
-(PID.TID 0000.0001)     Wall clock time:   2.2767794132232666
+(PID.TID 0000.0001)           User time:   2.3259055614471436
+(PID.TID 0000.0001)         System time:   8.0539882183074951E-003
+(PID.TID 0000.0001)     Wall clock time:   2.3341028690338135
 (PID.TID 0000.0001)          No. starts:         120
 (PID.TID 0000.0001)           No. stops:         120
 (PID.TID 0000.0001)   Seconds in section "DYNAMICS            [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:   3.7342299222946167
-(PID.TID 0000.0001)         System time:   0.0000000000000000
-(PID.TID 0000.0001)     Wall clock time:   3.7344989776611328
+(PID.TID 0000.0001)           User time:   3.8396291732788086
+(PID.TID 0000.0001)         System time:   4.0150135755538940E-003
+(PID.TID 0000.0001)     Wall clock time:   3.8439230918884277
 (PID.TID 0000.0001)          No. starts:          10
 (PID.TID 0000.0001)           No. stops:          10
 (PID.TID 0000.0001)   Seconds in section "UPDATE_CG2D         [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:   7.4950098991394043E-002
-(PID.TID 0000.0001)         System time:   0.0000000000000000
-(PID.TID 0000.0001)     Wall clock time:   7.4960231781005859E-002
+(PID.TID 0000.0001)           User time:   8.0208301544189453E-002
+(PID.TID 0000.0001)         System time:   4.9918889999389648E-006
+(PID.TID 0000.0001)     Wall clock time:   8.0232143402099609E-002
 (PID.TID 0000.0001)          No. starts:          10
 (PID.TID 0000.0001)           No. stops:          10
 (PID.TID 0000.0001)   Seconds in section "SOLVE_FOR_PRESSURE  [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:   1.6909636259078979
+(PID.TID 0000.0001)           User time:   1.7629197835922241
 (PID.TID 0000.0001)         System time:   0.0000000000000000
-(PID.TID 0000.0001)     Wall clock time:   1.6911425590515137
+(PID.TID 0000.0001)     Wall clock time:   1.7630357742309570
 (PID.TID 0000.0001)          No. starts:          10
 (PID.TID 0000.0001)           No. stops:          10
 (PID.TID 0000.0001)   Seconds in section "MOM_CORRECTION_STEP [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:  0.11459147930145264
+(PID.TID 0000.0001)           User time:  0.12809753417968750
 (PID.TID 0000.0001)         System time:   0.0000000000000000
-(PID.TID 0000.0001)     Wall clock time:  0.11460232734680176
+(PID.TID 0000.0001)     Wall clock time:  0.12812471389770508
 (PID.TID 0000.0001)          No. starts:          10
 (PID.TID 0000.0001)           No. stops:          10
 (PID.TID 0000.0001)   Seconds in section "INTEGR_CONTINUITY   [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:  0.20623683929443359
+(PID.TID 0000.0001)           User time:  0.23323321342468262
 (PID.TID 0000.0001)         System time:   0.0000000000000000
-(PID.TID 0000.0001)     Wall clock time:  0.20625448226928711
+(PID.TID 0000.0001)     Wall clock time:  0.23333907127380371
 (PID.TID 0000.0001)          No. starts:          10
 (PID.TID 0000.0001)           No. stops:          10
 (PID.TID 0000.0001)   Seconds in section "CALC_R_STAR         [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:   3.8498401641845703E-002
-(PID.TID 0000.0001)         System time:   0.0000000000000000
-(PID.TID 0000.0001)     Wall clock time:   3.8507699966430664E-002
+(PID.TID 0000.0001)           User time:   4.1427612304687500E-002
+(PID.TID 0000.0001)         System time:   2.2009015083312988E-005
+(PID.TID 0000.0001)     Wall clock time:   4.1469097137451172E-002
 (PID.TID 0000.0001)          No. starts:          10
 (PID.TID 0000.0001)           No. stops:          10
 (PID.TID 0000.0001)   Seconds in section "BLOCKING_EXCHANGES  [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:  0.19944238662719727
-(PID.TID 0000.0001)         System time:   0.0000000000000000
-(PID.TID 0000.0001)     Wall clock time:  0.19949173927307129
+(PID.TID 0000.0001)           User time:  0.22202050685882568
+(PID.TID 0000.0001)         System time:   2.7999281883239746E-005
+(PID.TID 0000.0001)     Wall clock time:  0.22211074829101562
 (PID.TID 0000.0001)          No. starts:          20
 (PID.TID 0000.0001)           No. stops:          20
 (PID.TID 0000.0001)   Seconds in section "THERMODYNAMICS      [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:   2.2493703365325928
-(PID.TID 0000.0001)         System time:   3.7260055541992188E-003
-(PID.TID 0000.0001)     Wall clock time:   2.2532835006713867
+(PID.TID 0000.0001)           User time:   2.4533480405807495
+(PID.TID 0000.0001)         System time:   0.0000000000000000
+(PID.TID 0000.0001)     Wall clock time:   2.4536077976226807
 (PID.TID 0000.0001)          No. starts:          10
 (PID.TID 0000.0001)           No. stops:          10
 (PID.TID 0000.0001)   Seconds in section "TRC_CORRECTION_STEP [FORWARD_STEP]":
 (PID.TID 0000.0001)           User time:   9.8943710327148438E-005
-(PID.TID 0000.0001)         System time:   1.0132789611816406E-006
-(PID.TID 0000.0001)     Wall clock time:   1.0347366333007812E-004
+(PID.TID 0000.0001)         System time:   0.0000000000000000
+(PID.TID 0000.0001)     Wall clock time:   9.9897384643554688E-005
 (PID.TID 0000.0001)          No. starts:          10
 (PID.TID 0000.0001)           No. stops:          10
 (PID.TID 0000.0001)   Seconds in section "DO_STATEVARS_TAVE   [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:   7.5936317443847656E-005
+(PID.TID 0000.0001)           User time:   7.7486038208007812E-005
 (PID.TID 0000.0001)         System time:   0.0000000000000000
-(PID.TID 0000.0001)     Wall clock time:   7.5340270996093750E-005
+(PID.TID 0000.0001)     Wall clock time:   7.8201293945312500E-005
 (PID.TID 0000.0001)          No. starts:          10
 (PID.TID 0000.0001)           No. stops:          10
 (PID.TID 0000.0001)   Seconds in section "MONITOR             [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:   1.0475724935531616
+(PID.TID 0000.0001)           User time:   1.1115887165069580
 (PID.TID 0000.0001)         System time:   0.0000000000000000
-(PID.TID 0000.0001)     Wall clock time:   1.0476830005645752
+(PID.TID 0000.0001)     Wall clock time:   1.1117212772369385
 (PID.TID 0000.0001)          No. starts:          10
 (PID.TID 0000.0001)           No. stops:          10
 (PID.TID 0000.0001)   Seconds in section "DO_THE_MODEL_IO     [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:   6.6792488098144531E-002
-(PID.TID 0000.0001)         System time:   1.1833995580673218E-002
-(PID.TID 0000.0001)     Wall clock time:   7.8639030456542969E-002
+(PID.TID 0000.0001)           User time:   8.3825111389160156E-002
+(PID.TID 0000.0001)         System time:   0.0000000000000000
+(PID.TID 0000.0001)     Wall clock time:   8.3823919296264648E-002
 (PID.TID 0000.0001)          No. starts:          10
 (PID.TID 0000.0001)           No. stops:          10
 (PID.TID 0000.0001)   Seconds in section "DO_WRITE_PICKUP     [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:   2.3876905441284180E-002
-(PID.TID 0000.0001)         System time:   3.5991996526718140E-002
-(PID.TID 0000.0001)     Wall clock time:   5.9912681579589844E-002
+(PID.TID 0000.0001)           User time:   5.5401086807250977E-002
+(PID.TID 0000.0001)         System time:   1.5994995832443237E-002
+(PID.TID 0000.0001)     Wall clock time:   7.1397304534912109E-002
 (PID.TID 0000.0001)          No. starts:          10
 (PID.TID 0000.0001)           No. stops:          10
 (PID.TID 0000.0001) // ======================================================

--- a/verification/tutorial_global_oce_in_p/results/output.txt
+++ b/verification/tutorial_global_oce_in_p/results/output.txt
@@ -5,10 +5,10 @@
 (PID.TID 0000.0001) // ======================================================
 (PID.TID 0000.0001) // execution environment starting up...
 (PID.TID 0000.0001) 
-(PID.TID 0000.0001) // MITgcmUV version:  checkpoint67o
-(PID.TID 0000.0001) // Build user:        mlosch
-(PID.TID 0000.0001) // Build host:        bkli04l006
-(PID.TID 0000.0001) // Build date:        Thu May  7 11:02:00 CEST 2020
+(PID.TID 0000.0001) // MITgcmUV version:  checkpoint68w
+(PID.TID 0000.0001) // Build user:        jm_c
+(PID.TID 0000.0001) // Build host:        villon
+(PID.TID 0000.0001) // Build date:        Tue Apr 16 13:15:52 EDT 2024
 (PID.TID 0000.0001) 
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // Execution Environment parameter file "eedata"
@@ -50,7 +50,7 @@
 (PID.TID 0000.0001)                   /*  note: To execute a program with MPI calls */
 (PID.TID 0000.0001)                   /*  it must be launched appropriately e.g     */
 (PID.TID 0000.0001)                   /*  "mpirun -np 64 ......"                    */
-(PID.TID 0000.0001) useCoupler=    F ;/* Flag used to control communications with   */
+(PID.TID 0000.0001) useCoupler=   F ; /* Flag used to control communications with   */
 (PID.TID 0000.0001)                   /*  other model components, through a coupler */
 (PID.TID 0000.0001) useNest2W_parent =    F ;/* Control 2-W Nesting comm */
 (PID.TID 0000.0001) useNest2W_child  =    F ;/* Control 2-W Nesting comm */
@@ -300,21 +300,6 @@
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // Field Model R_low (ini_masks_etc)
 (PID.TID 0000.0001) // CMIN =          1.005828380584717E-06
-(PID.TID 0000.0001) // CMAX =          1.005828380584717E-06
-(PID.TID 0000.0001) // CINT =          0.000000000000000E+00
-(PID.TID 0000.0001) // SYMBOLS (CMIN->CMAX): -abcdefghijklmnopqrstuvwxyz+
-(PID.TID 0000.0001) //                  0.0: .
-(PID.TID 0000.0001) // RANGE I (Lo:Hi:Step):(    -1:    92:     1)
-(PID.TID 0000.0001) // RANGE J (Lo:Hi:Step):(    42:    -1:    -1)
-(PID.TID 0000.0001) // RANGE K (Lo:Hi:Step):(   1:   1:   1)
-(PID.TID 0000.0001) // =======================================================
-(PID.TID 0000.0001) // =======================================================
-(PID.TID 0000.0001) // END OF FIELD                                          =
-(PID.TID 0000.0001) // =======================================================
-(PID.TID 0000.0001) 
-(PID.TID 0000.0001) // =======================================================
-(PID.TID 0000.0001) // Field Model Ro_surf (ini_masks_etc)
-(PID.TID 0000.0001) // CMIN =          1.005828380584717E-06
 (PID.TID 0000.0001) // CMAX =          5.302312256608400E+07
 (PID.TID 0000.0001) // CINT =          1.963819354299370E+06
 (PID.TID 0000.0001) // SYMBOLS (CMIN->CMAX): -abcdefghijklmnopqrstuvwxyz+
@@ -326,54 +311,120 @@
 (PID.TID 0000.0001) K =   1
 (PID.TID 0000.0001) //                I=8       I=18      I=28      I=38      I=48      I=58      I=68      I=78      I=88
 (PID.TID 0000.0001) // |--J--|101234567|901234567|901234567|901234567|901234567|901234567|901234567|901234567|901234567|9012
-(PID.TID 0000.0001) //     42 --------------------------------------------bbcdnttwwwttttqnnlfddc--abcc-----ccbcltttttba-----
-(PID.TID 0000.0001) //     41 ----------------------------------------------------------------------------------------------
-(PID.TID 0000.0001) //     40 innllaa-aaaaaaaaaaaaa------------------------------------------------------------------aaainnl
-(PID.TID 0000.0001) //     39 gnnllibbaaaaaaaa---aa-----------------------------------------------------bdda--------abffgnnl
-(PID.TID 0000.0001) //     38 nllllibbaaaaaaa-----------------------------------------------------------bddca------bccfgnlll
-(PID.TID 0000.0001) //     37 nnnga------------------------------------------------------------------aa---bca---bggc--agnnng
-(PID.TID 0000.0001) //     36 fgga-----------------------------------------nnaa--------------------aaaaaaabnnn-bllfggffcfgga
-(PID.TID 0000.0001) //     35 aaaa---------------------------------aaaa--iinnqqa---atttn-----------aaa----annqqqnglllgddaaaa
-(PID.TID 0000.0001) //     34 -------------------------------------affc-tticcfab-wwwttttn------------------anqttqqqtttna----
-(PID.TID 0000.0001) //     33 a-------------------------------------ffa+++t+++++++++wwwtqna-----------------aifwwtnttttda---
-(PID.TID 0000.0001) //     32 a-------------------------------------ag++++t++++++++++wwttnn----------------aaatwttqltttna---
-(PID.TID 0000.0001) //     31 --------------------------------------++++++w++++++++++wwwtqn--------------iw++twwwtiltwwn----
-(PID.TID 0000.0001) //     30 -------------------------------------t++++w++w+++++++++++++ww------------at++++twwwlgqtwwq----
-(PID.TID 0000.0001) //     29 -----------------------------------gf++++t+++tqt+++++++++++wwt-----------w++w+++wtnqq++wtq----
-(PID.TID 0000.0001) //     28 ---------------------------------actn+++++++++++++++++++wwwwwtq---------iw++++++wntww++wqa----
-(PID.TID 0000.0001) //     27 ----------------cc--------------aftttlt++++++++w+nnw+++wwwwwwttt---aaac-iw++++++qt+++++t------
-(PID.TID 0000.0001) //     26 ----------------cnn-----------afw+++wl+++++++++++qwtn++++++wwtttqg-aa-ii-c++++++tw++++wq------
-(PID.TID 0000.0001) //     25 ----------------qttq---lla---atfw+++wl+++ww++qqtnt+++++++++wwtttqnn---iifnac+++wqw++wwqq------
-(PID.TID 0000.0001) //     24 --------------cntwwtg-qqqa---ftt-++twn+++++++++++++++++++wwwwwttqnqqqf-afnnddwwwtw++++wt------
-(PID.TID 0000.0001) //     23 --------------dttwwtl-ttqd---fff--tqtq++++ttw+++++w++++++wwwwwttqqqqqql----bbqwwwt++++ww------
-(PID.TID 0000.0001) //     22 gii-----------wwwqttgnttqq---bb-dlqwwlltwwwwt++++++wt+w++wwwwwwtttqqqqii------dwwwttwwtwwigii-
-(PID.TID 0000.0001) //     21 ++wqi--------nwwwwqtiwwwqqb-----dltwwqtttnwwt++++++wqwwwwwwwwwttttqnnill--------twwtqttwww++wq
-(PID.TID 0000.0001) //     20 ++wwi-------nwwwwwtqwwwwqww------b-fqqqgiltttt+++++++wwwwwwwwwwtttqttqqn---------ntt+++ttw++ww
-(PID.TID 0000.0001) //     19 ww++t-------qwwlittl+++qwwwwd---aba-----iannww++++t++++wwwwwwwwttqtttttt-----------w+++wqtww++
-(PID.TID 0000.0001) //     22 gii-----------wwwqttgnttqq---bb-dlqwwlltwwwwt++++++wt+w++wwwwwwtttqqqqii------dwwwttwwtwwigii-
-(PID.TID 0000.0001) //     21 ++wqi--------nwwwwqtiwwwqqb-----dltwwqtttnwwt++++++wqwwwwwwwwwttttqnnill--------twwtqttwww++wq
-(PID.TID 0000.0001) //     20 ++wwi-------nwwwwwtqwwwwqww------b-fqqqgiltttt+++++++wwwwwwwwwwtttqttqqn---------ntt+++ttw++ww
-(PID.TID 0000.0001) //     19 ww++t-------qwwlittl+++qwwwwd---aba-----iannww++++t++++wwwwwwwwttqtttttt-----------w+++wqtww++
-(PID.TID 0000.0001) //     18 w+++w-------qtnttfqq+++qwww++w+qfaa---iiblntwwwwtwtq+++wwtwwwwwtqtttttwwa----------w+++wqtw+++
-(PID.TID 0000.0001) //     17 w+++w-------q-twwdqt+++l+++++++qf-----iilnninnnltwww++wwwttttttnqttqtwwwq---------tw+++wqtw+++
-(PID.TID 0000.0001) //     16 w+++w------gn-wwtnntw++i++++++nf-------flnnfnnndf+++wwqflnttttqntttttwwwqt--------it+++wqtw+++
-(PID.TID 0000.0001) //     15 w++wlb----aqq-wwwttnwwwnw+++++f---------lggdllnf++++wwwwwtqtttqqtttttwwqttt------atw+++wqtw++w
-(PID.TID 0000.0001) //     14 w++nwn----dwwi+++tqqqtwnw++w+tb---------ttgglttg++++++wwtwttqqqnqttqqqqtttt-----aqtw+++wntw++n
-(PID.TID 0000.0001) //     13 wwn++t----nwwl+++qwwtqttliiw++n---------wwggittg++++++++wwwtttqqnqqttqttttl----aqttlwwwtntwwn+
-(PID.TID 0000.0001) //     12 tt+++wdaqttwwnwntwwwtntqttww++wt+++a----wwigiilw+++++++++wwqtttqqqqqtttttt-----qwwwwttttnttt++
-(PID.TID 0000.0001) //     11 tw+++w++qtwwwnnt++wwtlttttwww++++++++--wwwwng-nw+w+++++++++wwwtqntttqqtttt----n+++++wwtqnqtw++
-(PID.TID 0000.0001) //     10 tw++ww+w++wtiqqt++wwtqnnnqttwwww+++++w-wwwwtd-nbiw+++++++++wwwtqnttwwttqtq--ad++++++wwttnqtw++
-(PID.TID 0000.0001) //      9 ttwwwww+++llglntwtwtqqqttnnnttwwwwwwwwnwwwwt-fbt+++++++++++wwwtnqttwwwttqf-aad++++++wwwtqnttww
-(PID.TID 0000.0001) //      8 tttqqqw++twwttwwwwfblqttttttnqqqttqqqtwtwwticfw++++++wwwwwwwttqnttwwwwwwta-aacttn++wtwwwtntttq
-(PID.TID 0000.0001) //      7 ninnwwqqt++wnw++wwtgcqtwwwttwwwwwwwttnttwwntw++++++wwwwtttqtqnnttwww+++wwt-aaaintgfqtqwwwtninn
-(PID.TID 0000.0001) //      6 w++++++++++++++++wwwnggwwwwwwwwwwwwwwtqqqqttw++++wwwtqnnqnwtww+++w+w+++wwwtqqqqtilnniwtqtww+++
-(PID.TID 0000.0001) //      5 +++++++++++++++++wwwttttwwwwwwwwwwwwwtqqqlnlwwwwtttnnnqtwwww++++++++w+wwwwtqqqgitwwwwww+++++++
-(PID.TID 0000.0001) //      4 ++tw++++++wwwqttttqqqttqqlbdnnllqqlnqqqqqnnnlnqlnnntttwwwwww+++++++wwwwwttnb--cqtwwwwww+++++tw
-(PID.TID 0000.0001) //      3 ttttilqqqdcc----------------------------cclgnqqqqttwwwwwwwwwtttttwwwwttqqbb--ciqtwwwwwwwwttttt
-(PID.TID 0000.0001) //      2 --------------------------------------------bbcdnttwwwttttqnnlfddc--abcc-----ccbcltttttba-----
-(PID.TID 0000.0001) //      1 ----------------------------------------------------------------------------------------------
-(PID.TID 0000.0001) //      0 innllaa-aaaaaaaaaaaaa------------------------------------------------------------------aaainnl
-(PID.TID 0000.0001) //     -1 gnnllibbaaaaaaaa---aa-----------------------------------------------------bdda--------abffgnnl
+(PID.TID 0000.0001) //     42 ++++++++++++++++++++++++++++++++++++++++++++----------------------++----+++++------------+++++
+(PID.TID 0000.0001) //     41 ++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+(PID.TID 0000.0001) //     40 -------+-------------++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++-------
+(PID.TID 0000.0001) //     39 ----------------+++--+++++++++++++++++++++++++++++++++++++++++++++++++++++----++++++++--------
+(PID.TID 0000.0001) //     38 ---------------+++++++++++++++++++++++++++++++++++++++++++++++++++++++++++-----++++++---------
+(PID.TID 0000.0001) //     37 -----++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++--+++---+++----++------
+(PID.TID 0000.0001) //     36 ----+++++++++++++++++++++++++++++++++++++++++----++++++++++++++++++++-----------+-------------
+(PID.TID 0000.0001) //     35 ----+++++++++++++++++++++++++++++++++----++-------+++-----+++++++++++---++++------------------
+(PID.TID 0000.0001) //     34 +++++++++++++++++++++++++++++++++++++----+--------+--------++++++++++++++++++-------------++++
+(PID.TID 0000.0001) //     33 -+++++++++++++++++++++++++++++++++++++-----------------------+++++++++++++++++-------------+++
+(PID.TID 0000.0001) //     32 -+++++++++++++++++++++++++++++++++++++-----------------------++++++++++++++++--------------+++
+(PID.TID 0000.0001) //     31 ++++++++++++++++++++++++++++++++++++++-----------------------++++++++++++++---------------++++
+(PID.TID 0000.0001) //     30 +++++++++++++++++++++++++++++++++++++------------------------++++++++++++-----------------++++
+(PID.TID 0000.0001) //     29 +++++++++++++++++++++++++++++++++++---------------------------+++++++++++-----------------++++
+(PID.TID 0000.0001) //     28 +++++++++++++++++++++++++++++++++------------------------------+++++++++------------------++++
+(PID.TID 0000.0001) //     27 ++++++++++++++++--++++++++++++++--------------------------------+++----+----------------++++++
+(PID.TID 0000.0001) //     26 ++++++++++++++++---+++++++++++------------------------------------+--+--+---------------++++++
+(PID.TID 0000.0001) //     25 ++++++++++++++++----+++---+++--------------------------------------+++------------------++++++
+(PID.TID 0000.0001) //     24 ++++++++++++++-------+----+++---+-------------------------------------+-----------------++++++
+(PID.TID 0000.0001) //     23 ++++++++++++++-------+----+++---++-------------------------------------++++-------------++++++
+(PID.TID 0000.0001) //     22 ---+++++++++++------------+++--+----------------------------------------++++++---------------+
+(PID.TID 0000.0001) //     21 -----++++++++--------------+++++----------------------------------------++++++++--------------
+(PID.TID 0000.0001) //     20 -----+++++++---------------++++++-+-------------------------------------+++++++++-------------
+(PID.TID 0000.0001) //     19 -----+++++++-----------------+++---+++++--------------------------------+++++++++++-----------
+(PID.TID 0000.0001) //     22 ---+++++++++++------------+++--+----------------------------------------++++++---------------+
+(PID.TID 0000.0001) //     21 -----++++++++--------------+++++----------------------------------------++++++++--------------
+(PID.TID 0000.0001) //     20 -----+++++++---------------++++++-+-------------------------------------+++++++++-------------
+(PID.TID 0000.0001) //     19 -----+++++++-----------------+++---+++++--------------------------------+++++++++++-----------
+(PID.TID 0000.0001) //     18 -----+++++++-----------------------+++-----------------------------------++++++++++-----------
+(PID.TID 0000.0001) //     17 -----+++++++-+-------------------+++++-----------------------------------+++++++++------------
+(PID.TID 0000.0001) //     16 -----++++++--+------------------+++++++-----------------------------------++++++++------------
+(PID.TID 0000.0001) //     15 ------++++---+-----------------+++++++++-----------------------------------++++++-------------
+(PID.TID 0000.0001) //     14 ------++++---------------------+++++++++-----------------------------------+++++--------------
+(PID.TID 0000.0001) //     13 ------++++---------------------+++++++++-----------------------------------++++---------------
+(PID.TID 0000.0001) //     12 ------------------------------------++++----------------------------------+++++---------------
+(PID.TID 0000.0001) //     11 -------------------------------------++------+----------------------------++++----------------
+(PID.TID 0000.0001) //     10 --------------------------------------+------+----------------------------++------------------
+(PID.TID 0000.0001) //      9 --------------------------------------------+-----------------------------+-------------------
+(PID.TID 0000.0001) //      8 --------------------------------------------------------------------------+-------------------
+(PID.TID 0000.0001) //      7 --------------------------------------------------------------------------+-------------------
+(PID.TID 0000.0001) //      6 ----------------------------------------------------------------------------------------------
+(PID.TID 0000.0001) //      5 ----------------------------------------------------------------------------------------------
+(PID.TID 0000.0001) //      4 ----------------------------------------------------------------------------++----------------
+(PID.TID 0000.0001) //      3 ------------++++++++++++++++++++++++++++-----------------------------------++-----------------
+(PID.TID 0000.0001) //      2 ++++++++++++++++++++++++++++++++++++++++++++----------------------++----+++++------------+++++
+(PID.TID 0000.0001) //      1 ++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+(PID.TID 0000.0001) //      0 -------+-------------++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++-------
+(PID.TID 0000.0001) //     -1 ----------------+++--+++++++++++++++++++++++++++++++++++++++++++++++++++++----++++++++--------
+(PID.TID 0000.0001) // =======================================================
+(PID.TID 0000.0001) // END OF FIELD                                          =
+(PID.TID 0000.0001) // =======================================================
+(PID.TID 0000.0001) 
+(PID.TID 0000.0001) // =======================================================
+(PID.TID 0000.0001) // Field Model Ro_surf (ini_masks_etc)
+(PID.TID 0000.0001) // CMIN =          1.210008718981006E+06
+(PID.TID 0000.0001) // CMAX =          5.302312256608400E+07
+(PID.TID 0000.0001) // CINT =          1.919004216559370E+06
+(PID.TID 0000.0001) // SYMBOLS (CMIN->CMAX): -abcdefghijklmnopqrstuvwxyz+
+(PID.TID 0000.0001) //                  0.0: .
+(PID.TID 0000.0001) // RANGE I (Lo:Hi:Step):(    -1:    92:     1)
+(PID.TID 0000.0001) // RANGE J (Lo:Hi:Step):(    42:    -1:    -1)
+(PID.TID 0000.0001) // RANGE K (Lo:Hi:Step):(   1:   1:   1)
+(PID.TID 0000.0001) // =======================================================
+(PID.TID 0000.0001) K =   1
+(PID.TID 0000.0001) //                I=8       I=18      I=28      I=38      I=48      I=58      I=68      I=78      I=88
+(PID.TID 0000.0001) // |--J--|101234567|901234567|901234567|901234567|901234567|901234567|901234567|901234567|901234567|9012
+(PID.TID 0000.0001) //     42 ++++++++++++++++++++++++++++++++++++++++++++aabdnttwwwttttqnnkeddb++-abb+++++bbabkttttta-+++++
+(PID.TID 0000.0001) //     41 ++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+(PID.TID 0000.0001) //     40 innkkaa+-aaaaaa------++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++-aainnk
+(PID.TID 0000.0001) //     39 gnnkkiaaaaaaaaa-+++--+++++++++++++++++++++++++++++++++++++++++++++++++++++adda++++++++-aeegnnk
+(PID.TID 0000.0001) //     38 nkkkkiaaaaaaa--+++++++++++++++++++++++++++++++++++++++++++++++++++++++++++addb-++++++abbegnkkk
+(PID.TID 0000.0001) //     37 nnnga++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++--+++ab-+++aggb++agnnng
+(PID.TID 0000.0001) //     36 egga+++++++++++++++++++++++++++++++++++++++++nn--++++++++++++++++++++-------annn+akkeggeebegga
+(PID.TID 0000.0001) //     35 ----+++++++++++++++++++++++++++++++++-aaa++iinnqqa+++-tttn+++++++++++---++++-nnqqqngkkkgdd----
+(PID.TID 0000.0001) //     34 +++++++++++++++++++++++++++++++++++++-eeb+ttibbeaa+wwwttttn++++++++++++++++++-nqttqqqtttna++++
+(PID.TID 0000.0001) //     33 -+++++++++++++++++++++++++++++++++++++eea+++t+++++++++wwwtqn-+++++++++++++++++aiewwtnttttd-+++
+(PID.TID 0000.0001) //     32 -+++++++++++++++++++++++++++++++++++++-g++++t++++++++++wwttnn++++++++++++++++---twttqktttn-+++
+(PID.TID 0000.0001) //     31 ++++++++++++++++++++++++++++++++++++++++++++w++++++++++wwwtqn++++++++++++++iw++twwwtiktwwn++++
+(PID.TID 0000.0001) //     30 +++++++++++++++++++++++++++++++++++++t++++w++w+++++++++++++ww++++++++++++at++++twwwkgqtwwq++++
+(PID.TID 0000.0001) //     29 +++++++++++++++++++++++++++++++++++ge++++t+++tqt+++++++++++wwt+++++++++++w++w+++wtnqq++wtq++++
+(PID.TID 0000.0001) //     28 +++++++++++++++++++++++++++++++++-btn+++++++++++++++++++wwwwwtq+++++++++iw++++++wntww++wqa++++
+(PID.TID 0000.0001) //     27 ++++++++++++++++bb++++++++++++++-etttkt++++++++w+nnw+++wwwwwwttt+++---b+iw++++++qt+++++t++++++
+(PID.TID 0000.0001) //     26 ++++++++++++++++bnn+++++++++++-ew+++wk+++++++++++qwtn++++++wwtttqg+--+ii+b++++++tw++++wq++++++
+(PID.TID 0000.0001) //     25 ++++++++++++++++qttq+++kka+++-tew+++wk+++ww++qqtnt+++++++++wwtttqnn+++iienab+++wqw++wwqq++++++
+(PID.TID 0000.0001) //     24 ++++++++++++++bntwwtg+qqqa+++ett+++twn+++++++++++++++++++wwwwwttqnqqqe+aennddwwwtw++++wt++++++
+(PID.TID 0000.0001) //     23 ++++++++++++++dttwwtk+ttqd+++eee++tqtq++++ttw+++++w++++++wwwwwttqqqqqqk++++aaqwwwt++++ww++++++
+(PID.TID 0000.0001) //     22 gii+++++++++++wwwqttgnttqq+++aa+dkqwwkktwwwwt++++++wt+w++wwwwwwtttqqqqii++++++dwwwttwwtwwigii+
+(PID.TID 0000.0001) //     21 ++wqi++++++++nwwwwqtiwwwqqa+++++dktwwqtttnwwt++++++wqwwwwwwwwwttttqnnikk++++++++twwtqttwww++wq
+(PID.TID 0000.0001) //     20 ++wwi+++++++nwwwwwtqwwwwqww++++++a+eqqqgiktttt+++++++wwwwwwwwwwtttqttqqn+++++++++ntt+++ttw++ww
+(PID.TID 0000.0001) //     19 ww++t+++++++qwwkittk+++qwwwwd+++-a-+++++i-nnww++++t++++wwwwwwwwttqtttttt+++++++++++w+++wqtww++
+(PID.TID 0000.0001) //     22 gii+++++++++++wwwqttgnttqq+++aa+dkqwwkktwwwwt++++++wt+w++wwwwwwtttqqqqii++++++dwwwttwwtwwigii+
+(PID.TID 0000.0001) //     21 ++wqi++++++++nwwwwqtiwwwqqa+++++dktwwqtttnwwt++++++wqwwwwwwwwwttttqnnikk++++++++twwtqttwww++wq
+(PID.TID 0000.0001) //     20 ++wwi+++++++nwwwwwtqwwwwqww++++++a+eqqqgiktttt+++++++wwwwwwwwwwtttqttqqn+++++++++ntt+++ttw++ww
+(PID.TID 0000.0001) //     19 ww++t+++++++qwwkittk+++qwwwwd+++-a-+++++i-nnww++++t++++wwwwwwwwttqtttttt+++++++++++w+++wqtww++
+(PID.TID 0000.0001) //     18 w+++w+++++++qtntteqq+++qwww++w+qe--+++iiakntwwwwtwtq+++wwtwwwwwtqtttttww-++++++++++w+++wqtw+++
+(PID.TID 0000.0001) //     17 w+++w+++++++q+twwdqt+++k+++++++qe+++++iiknninnnktwww++wwwttttttnqttqtwwwq+++++++++tw+++wqtw+++
+(PID.TID 0000.0001) //     16 w+++w++++++gn+wwtnntw++i++++++ne+++++++eknnennnde+++wwqeknttttqntttttwwwqt++++++++it+++wqtw+++
+(PID.TID 0000.0001) //     15 w++wka++++-qq+wwwttnwwwnw+++++e+++++++++kggdkkne++++wwwwwtqtttqqtttttwwqttt++++++-tw+++wqtw++w
+(PID.TID 0000.0001) //     14 w++nwn++++dwwi+++tqqqtwnw++w+ta+++++++++ttggkttg++++++wwtwttqqqnqttqqqqtttt+++++aqtw+++wntw++n
+(PID.TID 0000.0001) //     13 wwn++t++++nwwk+++qwwtqttkiiw++n+++++++++wwggittg++++++++wwwtttqqnqqttqttttk++++-qttkwwwtntwwn+
+(PID.TID 0000.0001) //     12 tt+++wd-qttwwnwntwwwtntqttww++wt+++a++++wwigiikw+++++++++wwqtttqqqqqtttttt+++++qwwwwttttnttt++
+(PID.TID 0000.0001) //     11 tw+++w++qtwwwnnt++wwtkttttwww++++++++++wwwwng+nw+w+++++++++wwwtqntttqqtttt++++n+++++wwtqnqtw++
+(PID.TID 0000.0001) //     10 tw++ww+w++wtiqqt++wwtqnnnqttwwww+++++w+wwwwtd+naiw+++++++++wwwtqnttwwttqtq++-d++++++wwttnqtw++
+(PID.TID 0000.0001) //      9 ttwwwww+++kkgkntwtwtqqqttnnnttwwwwwwwwnwwwwt+eat+++++++++++wwwtnqttwwwttqe+--d++++++wwwtqnttww
+(PID.TID 0000.0001) //      8 tttqqqw++twwttwwwweakqttttttnqqqttqqqtwtwwtibew++++++wwwwwwwttqnttwwwwwwt-+-abttn++wtwwwtntttq
+(PID.TID 0000.0001) //      7 ninnwwqqt++wnw++wwtgbqtwwwttwwwwwwwttnttwwntw++++++wwwwtttqtqnnttwww+++wwt+-aaintgeqtqwwwtninn
+(PID.TID 0000.0001) //      6 w++++++++++++++++wwwnggwwwwwwwwwwwwwwtqqqqttw++++wwwtqnnqnwtww+++w+w+++wwwtqqqqtiknniwtqtww+++
+(PID.TID 0000.0001) //      5 +++++++++++++++++wwwttttwwwwwwwwwwwwwtqqqknkwwwwtttnnnqtwwww++++++++w+wwwwtqqqgitwwwwww+++++++
+(PID.TID 0000.0001) //      4 ++tw++++++wwwqttttqqqttqqkadnnkkqqknqqqqqnnnknqknnntttwwwwww+++++++wwwwwttna++bqtwwwwww+++++tw
+(PID.TID 0000.0001) //      3 ttttikqqqdbb++++++++++++++++++++++++++++bbkgnqqqqttwwwwwwwwwtttttwwwwttqqaa++biqtwwwwwwwwttttt
+(PID.TID 0000.0001) //      2 ++++++++++++++++++++++++++++++++++++++++++++aabdnttwwwttttqnnkeddb++-abb+++++bbabkttttta-+++++
+(PID.TID 0000.0001) //      1 ++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+(PID.TID 0000.0001) //      0 innkkaa+-aaaaaa------++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++-aainnk
+(PID.TID 0000.0001) //     -1 gnnkkiaaaaaaaaa-+++--+++++++++++++++++++++++++++++++++++++++++++++++++++++adda++++++++-aeegnnk
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // END OF FIELD                                          =
 (PID.TID 0000.0001) // =======================================================
@@ -504,8 +555,28 @@
 (PID.TID 0000.0001) tRef =   /* Reference temperature profile ( oC or K ) */
 (PID.TID 0000.0001)    15 @  2.000000000000000E+01              /* K =  1: 15 */
 (PID.TID 0000.0001)     ;
-(PID.TID 0000.0001) sRef =   /* Reference salinity profile ( psu ) */
+(PID.TID 0000.0001) sRef =   /* Reference salinity profile ( g/kg ) */
 (PID.TID 0000.0001)    15 @  3.500000000000000E+01              /* K =  1: 15 */
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) rhoRef =   /* Density vertical profile from (Ref,sRef)( kg/m^3 ) */
+(PID.TID 0000.0001)                 1.045007942990331E+03,      /* K =  1 */
+(PID.TID 0000.0001)                 1.042338200565522E+03,      /* K =  2 */
+(PID.TID 0000.0001)                 1.039840714386264E+03,      /* K =  3 */
+(PID.TID 0000.0001)                 1.037521858824433E+03,      /* K =  4 */
+(PID.TID 0000.0001)                 1.035387609408833E+03,      /* K =  5 */
+(PID.TID 0000.0001)                 1.033443513918912E+03,      /* K =  6 */
+(PID.TID 0000.0001)                 1.031694665399925E+03,      /* K =  7 */
+(PID.TID 0000.0001)                 1.030145677273144E+03,      /* K =  8 */
+(PID.TID 0000.0001)                 1.028800660699642E+03,      /* K =  9 */
+(PID.TID 0000.0001)                 1.027663204340393E+03,      /* K = 10 */
+(PID.TID 0000.0001)                 1.026736356639154E+03,      /* K = 11 */
+(PID.TID 0000.0001)                 1.026022610737867E+03,      /* K = 12 */
+(PID.TID 0000.0001)                 1.025502191119603E+03,      /* K = 13 */
+(PID.TID 0000.0001)                 1.025132881606050E+03,      /* K = 14 */
+(PID.TID 0000.0001)                 1.024871853843158E+03       /* K = 15 */
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) dBdrRef = /* Vertical grad. of reference buoyancy [(m/s/r)^2] */
+(PID.TID 0000.0001)    15 @  0.000000000000000E+00              /* K =  1: 15 */
 (PID.TID 0000.0001)     ;
 (PID.TID 0000.0001) useStrainTensionVisc= /* Use StrainTension Form of Viscous Operator */
 (PID.TID 0000.0001)                   F
@@ -596,6 +667,12 @@
 (PID.TID 0000.0001)     ;
 (PID.TID 0000.0001) eosType =  /* Type of Equation of State */
 (PID.TID 0000.0001)               'JMD95P'
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) eosRefP0 = /* Reference atmospheric pressure for EOS ( Pa ) */
+(PID.TID 0000.0001)                 1.013250000000000E+05
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) surf_pRef = /* Surface reference pressure ( Pa ) */
+(PID.TID 0000.0001)                 1.013250000000000E+05
 (PID.TID 0000.0001)     ;
 (PID.TID 0000.0001) HeatCapacity_Cp =  /* Specific heat capacity ( J/kg/K ) */
 (PID.TID 0000.0001)                 3.994000000000000E+03
@@ -697,7 +774,7 @@
 (PID.TID 0000.0001) temp_EvPrRn = /* Temp. of Evap/Prec/R (UNSET=use local T)(oC)*/
 (PID.TID 0000.0001)                 1.234567000000000E+05
 (PID.TID 0000.0001)     ;
-(PID.TID 0000.0001) salt_EvPrRn = /* Salin. of Evap/Prec/R (UNSET=use local S)(psu)*/
+(PID.TID 0000.0001) salt_EvPrRn = /* Salin. of Evap/Prec/R (UNSET=use local S)(g/kg)*/
 (PID.TID 0000.0001)                 0.000000000000000E+00
 (PID.TID 0000.0001)     ;
 (PID.TID 0000.0001) selectAddFluid = /* option for mass source/sink of fluid (=0: off) */
@@ -706,10 +783,10 @@
 (PID.TID 0000.0001) temp_addMass = /* Temp. of addMass array (UNSET=use local T)(oC)*/
 (PID.TID 0000.0001)                 1.234567000000000E+05
 (PID.TID 0000.0001)     ;
-(PID.TID 0000.0001) salt_addMass = /* Salin. of addMass array (UNSET=use local S)(psu)*/
+(PID.TID 0000.0001) salt_addMass = /* Salin. of addMass array (UNSET=use local S)(g/kg)*/
 (PID.TID 0000.0001)                 0.000000000000000E+00
 (PID.TID 0000.0001)     ;
-(PID.TID 0000.0001) convertFW2Salt = /* convert F.W. Flux to Salt Flux (-1=use local S)(psu)*/
+(PID.TID 0000.0001) convertFW2Salt = /* convert F.W. Flux to Salt Flux (-1=use local S)(g/kg)*/
 (PID.TID 0000.0001)                 3.500000000000000E+01
 (PID.TID 0000.0001)     ;
 (PID.TID 0000.0001) use3Dsolver = /* use 3-D pressure solver on/off flag */
@@ -755,8 +832,8 @@
 (PID.TID 0000.0001)                       0
 (PID.TID 0000.0001)     0= Expl. ; 1= Impl. on provis. Vel ; 2= Fully Impl (with surf.P)
 (PID.TID 0000.0001)     ;
-(PID.TID 0000.0001) metricTerms =  /* metric-Terms on/off flag */
-(PID.TID 0000.0001)                   T
+(PID.TID 0000.0001) selectMetricTerms= /* Metric-Terms on/off flag (=0/1) */
+(PID.TID 0000.0001)                       1
 (PID.TID 0000.0001)     ;
 (PID.TID 0000.0001) useNHMTerms = /* Non-Hydrostatic Metric-Terms on/off */
 (PID.TID 0000.0001)                   T
@@ -765,8 +842,8 @@
 (PID.TID 0000.0001)                       2
 (PID.TID 0000.0001)     0= f-Plane ; 1= Beta-Plane ; 2= Spherical ; 3= read from file
 (PID.TID 0000.0001)     ;
-(PID.TID 0000.0001) use3dCoriolis = /* 3-D Coriolis on/off flag */
-(PID.TID 0000.0001)                   F
+(PID.TID 0000.0001) select3dCoriScheme= /* 3-D Coriolis on/off flag (=0/1) */
+(PID.TID 0000.0001)                       0
 (PID.TID 0000.0001)     ;
 (PID.TID 0000.0001) useCoriolis =  /* Coriolis on/off flag */
 (PID.TID 0000.0001)                   T
@@ -884,8 +961,8 @@
 (PID.TID 0000.0001) cg2dMaxIters =   /* Upper limit on 2d con. grad iterations  */
 (PID.TID 0000.0001)                     200
 (PID.TID 0000.0001)     ;
-(PID.TID 0000.0001) cg2dChkResFreq =   /* 2d con. grad convergence test frequency */
-(PID.TID 0000.0001)                       1
+(PID.TID 0000.0001) cg2dMinItersNSA =   /* Minimum number of iterations of 2d con. grad solver  */
+(PID.TID 0000.0001)                       0
 (PID.TID 0000.0001)     ;
 (PID.TID 0000.0001) cg2dUseMinResSol= /* use cg2d last-iter(=0) / min-resid.(=1) solution */
 (PID.TID 0000.0001)                       0
@@ -900,6 +977,9 @@
 (PID.TID 0000.0001)                       1
 (PID.TID 0000.0001)     ;
 (PID.TID 0000.0001) useSRCGSolver =  /* use single reduction CG solver(s) */
+(PID.TID 0000.0001)                   F
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) useNSACGSolver =  /* use not-self-adjoint CG solver */
 (PID.TID 0000.0001)                   F
 (PID.TID 0000.0001)     ;
 (PID.TID 0000.0001) printResidualFreq = /* Freq. for printing CG residual */
@@ -1227,7 +1307,7 @@
 (PID.TID 0000.0001) deepFacF = /* deep-model grid factor @ W-Interface (-) */
 (PID.TID 0000.0001)    16 @  1.000000000000000E+00              /* K =  1: 16 */
 (PID.TID 0000.0001)     ;
-(PID.TID 0000.0001) rVel2wUnit = /* convert units: rVel -> wSpeed (=1 if z-coord)*/
+(PID.TID 0000.0001) rVel2wUnit = /* convert units: rVel [Pa/s] -> wSpeed [m/s] */
 (PID.TID 0000.0001)                 9.741857413830955E-05,      /* K =  1 */
 (PID.TID 0000.0001)                 9.767560854698387E-05,      /* K =  2 */
 (PID.TID 0000.0001)                 9.791810961961699E-05,      /* K =  3 */
@@ -1245,7 +1325,7 @@
 (PID.TID 0000.0001)                 9.945241412037006E-05,      /* K = 15 */
 (PID.TID 0000.0001)                 9.947353552744130E-05       /* K = 16 */
 (PID.TID 0000.0001)     ;
-(PID.TID 0000.0001) wUnit2rVel = /* convert units: wSpeed -> rVel (=1 if z-coord)*/
+(PID.TID 0000.0001) wUnit2rVel = /* convert units: wSpeed [m/s] -> rVel [Pa/s] */
 (PID.TID 0000.0001)                 1.026498292389555E+04,      /* K =  1 */
 (PID.TID 0000.0001)                 1.023797051153237E+04,      /* K =  2 */
 (PID.TID 0000.0001)                 1.021261545882274E+04,      /* K =  3 */
@@ -1263,8 +1343,39 @@
 (PID.TID 0000.0001)                 1.005506008923697E+04,      /* K = 15 */
 (PID.TID 0000.0001)                 1.005292507899385E+04       /* K = 16 */
 (PID.TID 0000.0001)     ;
-(PID.TID 0000.0001) dBdrRef = /* Vertical grad. of reference buoyancy [(m/s/r)^2] */
-(PID.TID 0000.0001)    15 @  0.000000000000000E+00              /* K =  1: 15 */
+(PID.TID 0000.0001) rUnit2z = /* convert units (@ center): dr [Pa] -> dz [m] */
+(PID.TID 0000.0001)                 9.754643480776761E-05,      /* K =  1 */
+(PID.TID 0000.0001)                 9.779628064019875E-05,      /* K =  2 */
+(PID.TID 0000.0001)                 9.803116744151615E-05,      /* K =  3 */
+(PID.TID 0000.0001)                 9.825026655342507E-05,      /* K =  4 */
+(PID.TID 0000.0001)                 9.845279029629072E-05,      /* K =  5 */
+(PID.TID 0000.0001)                 9.863799792787121E-05,      /* K =  6 */
+(PID.TID 0000.0001)                 9.880520138677945E-05,      /* K =  7 */
+(PID.TID 0000.0001)                 9.895377074661737E-05,      /* K =  8 */
+(PID.TID 0000.0001)                 9.908313930823379E-05,      /* K =  9 */
+(PID.TID 0000.0001)                 9.919280826049804E-05,      /* K = 10 */
+(PID.TID 0000.0001)                 9.928235084435727E-05,      /* K = 11 */
+(PID.TID 0000.0001)                 9.935141596070428E-05,      /* K = 12 */
+(PID.TID 0000.0001)                 9.940183460087493E-05,      /* K = 13 */
+(PID.TID 0000.0001)                 9.943764463471677E-05,      /* K = 14 */
+(PID.TID 0000.0001)                 9.946297071409826E-05       /* K = 15 */
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) z2rUnit = /* convert units (@ center): dz [m] -> dr [Pa] */
+(PID.TID 0000.0001)                 1.025152792073514E+04,      /* K =  1 */
+(PID.TID 0000.0001)                 1.022533774754778E+04,      /* K =  2 */
+(PID.TID 0000.0001)                 1.020083740812925E+04,      /* K =  3 */
+(PID.TID 0000.0001)                 1.017808943506769E+04,      /* K =  4 */
+(PID.TID 0000.0001)                 1.015715244830065E+04,      /* K =  5 */
+(PID.TID 0000.0001)                 1.013808087154453E+04,      /* K =  6 */
+(PID.TID 0000.0001)                 1.012092466757326E+04,      /* K =  7 */
+(PID.TID 0000.0001)                 1.010572909404955E+04,      /* K =  8 */
+(PID.TID 0000.0001)                 1.009253448146349E+04,      /* K =  9 */
+(PID.TID 0000.0001)                 1.008137603457925E+04,      /* K = 10 */
+(PID.TID 0000.0001)                 1.007228365863010E+04,      /* K = 11 */
+(PID.TID 0000.0001)                 1.006528181133848E+04,      /* K = 12 */
+(PID.TID 0000.0001)                 1.006017649488330E+04,      /* K = 13 */
+(PID.TID 0000.0001)                 1.005655356855535E+04,      /* K = 14 */
+(PID.TID 0000.0001)                 1.005399288620138E+04       /* K = 15 */
 (PID.TID 0000.0001)     ;
 (PID.TID 0000.0001) rotateGrid = /* use rotated grid ( True/False ) */
 (PID.TID 0000.0001)                   F
@@ -1737,33 +1848,33 @@
 (PID.TID 0000.0001)  MDS_READ_FIELD: opening global file: lev_sst.bin
 (PID.TID 0000.0001)  MDS_READ_FIELD: opening global file: lev_sst.bin
 (PID.TID 0000.0001) SOLVE_FOR_PRESSURE: putPmEinXvector =    F
- cg2d: Sum(rhs),rhsMax =  -2.91433543964104E-15  1.71163414373126E+02
-(PID.TID 0000.0001)      cg2d_init_res =   9.36692383621737E+00
+ cg2d: Sum(rhs),rhsMax =  -2.94209101525666E-15  1.71163414373127E+02
+(PID.TID 0000.0001)      cg2d_init_res =   9.36692383621733E+00
 (PID.TID 0000.0001)      cg2d_iters(min,last) =      -1     107
-(PID.TID 0000.0001)      cg2d_last_res =   9.62519078741551E-10
+(PID.TID 0000.0001)      cg2d_last_res =   9.62519078750575E-10
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // Begin MONITOR dynamic field statistics
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) %MON time_tsnumber                =                     1
 (PID.TID 0000.0001) %MON time_secondsf                =   1.7280000000000E+05
-(PID.TID 0000.0001) %MON dynstat_eta_max              =   4.1656786839423E+04
-(PID.TID 0000.0001) %MON dynstat_eta_min              =  -8.8276374725148E+04
-(PID.TID 0000.0001) %MON dynstat_eta_mean             =   6.5817908944932E-13
+(PID.TID 0000.0001) %MON dynstat_eta_max              =   4.1656786839422E+04
+(PID.TID 0000.0001) %MON dynstat_eta_min              =  -8.8276374725151E+04
+(PID.TID 0000.0001) %MON dynstat_eta_mean             =  -3.2908954472466E-13
 (PID.TID 0000.0001) %MON dynstat_eta_sd               =   3.6901397170278E+04
 (PID.TID 0000.0001) %MON dynstat_eta_del2             =   2.0856467227143E+03
-(PID.TID 0000.0001) %MON dynstat_uvel_max             =   3.5106109517859E-02
+(PID.TID 0000.0001) %MON dynstat_uvel_max             =   3.5106109517858E-02
 (PID.TID 0000.0001) %MON dynstat_uvel_min             =  -3.5372108944508E-02
 (PID.TID 0000.0001) %MON dynstat_uvel_mean            =  -8.4135916903908E-04
 (PID.TID 0000.0001) %MON dynstat_uvel_sd              =   2.2143004930635E-03
-(PID.TID 0000.0001) %MON dynstat_uvel_del2            =   2.3793586526362E-05
-(PID.TID 0000.0001) %MON dynstat_vvel_max             =   3.5008782265621E-02
+(PID.TID 0000.0001) %MON dynstat_uvel_del2            =   2.3793586526361E-05
+(PID.TID 0000.0001) %MON dynstat_vvel_max             =   3.5008782265620E-02
 (PID.TID 0000.0001) %MON dynstat_vvel_min             =  -2.4496142225806E-02
 (PID.TID 0000.0001) %MON dynstat_vvel_mean            =   1.0871733172810E-03
 (PID.TID 0000.0001) %MON dynstat_vvel_sd              =   2.2887791274522E-03
-(PID.TID 0000.0001) %MON dynstat_vvel_del2            =   2.5440556997751E-05
-(PID.TID 0000.0001) %MON dynstat_wvel_max             =   5.0250051231513E-01
-(PID.TID 0000.0001) %MON dynstat_wvel_min             =  -6.2689518742413E-01
-(PID.TID 0000.0001) %MON dynstat_wvel_mean            =  -6.6716894910155E-03
+(PID.TID 0000.0001) %MON dynstat_vvel_del2            =   2.5440556997750E-05
+(PID.TID 0000.0001) %MON dynstat_wvel_max             =   5.0250051231501E-01
+(PID.TID 0000.0001) %MON dynstat_wvel_min             =  -6.2689518742412E-01
+(PID.TID 0000.0001) %MON dynstat_wvel_mean            =  -6.6716894910150E-03
 (PID.TID 0000.0001) %MON dynstat_wvel_sd              =   1.5353611024476E-01
 (PID.TID 0000.0001) %MON dynstat_wvel_del2            =   1.7671817735107E-03
 (PID.TID 0000.0001) %MON dynstat_theta_max            =   2.9711296896544E+01
@@ -1804,54 +1915,54 @@
 (PID.TID 0000.0001) %MON trAdv_CFL_u_max              =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON trAdv_CFL_v_max              =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON trAdv_CFL_w_max              =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON advcfl_uvel_max              =   2.1979552871283E-02
+(PID.TID 0000.0001) %MON advcfl_uvel_max              =   2.1979552871282E-02
 (PID.TID 0000.0001) %MON advcfl_vvel_max              =   1.3603289841692E-02
-(PID.TID 0000.0001) %MON advcfl_wvel_max              =   4.1332940427638E-02
-(PID.TID 0000.0001) %MON advcfl_W_hf_max              =   5.0201445983040E-02
-(PID.TID 0000.0001) %MON pe_b_mean                    =  -6.4368668120800E-03
-(PID.TID 0000.0001) %MON ke_max                       =   5.7521020041948E-04
+(PID.TID 0000.0001) %MON advcfl_wvel_max              =   4.1332940427637E-02
+(PID.TID 0000.0001) %MON advcfl_W_hf_max              =   5.0201445983039E-02
+(PID.TID 0000.0001) %MON pe_b_mean                    =  -6.4368668120792E-03
+(PID.TID 0000.0001) %MON ke_max                       =   5.7521020041944E-04
 (PID.TID 0000.0001) %MON ke_mean                      =   5.4208464415534E-06
 (PID.TID 0000.0001) %MON ke_vol                       =   1.3442141716554E+22
-(PID.TID 0000.0001) %MON vort_r_min                   =  -1.1936131053982E-07
-(PID.TID 0000.0001) %MON vort_r_max                   =   1.5595297437961E-07
+(PID.TID 0000.0001) %MON vort_r_min                   =  -1.1936131053981E-07
+(PID.TID 0000.0001) %MON vort_r_max                   =   1.5595297437960E-07
 (PID.TID 0000.0001) %MON vort_a_mean                  =  -2.4598205433957E-05
 (PID.TID 0000.0001) %MON vort_a_sd                    =   7.3636984478817E-05
 (PID.TID 0000.0001) %MON vort_p_mean                  =  -2.9470763777015E-05
 (PID.TID 0000.0001) %MON vort_p_sd                    =   1.0360208227295E-04
-(PID.TID 0000.0001) %MON surfExpan_theta_mean         =   6.7314694837242E-02
-(PID.TID 0000.0001) %MON surfExpan_salt_mean          =  -2.2852742432940E-04
+(PID.TID 0000.0001) %MON surfExpan_theta_mean         =   6.7314694837239E-02
+(PID.TID 0000.0001) %MON surfExpan_salt_mean          =  -2.2852742432954E-04
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // End MONITOR dynamic field statistics
 (PID.TID 0000.0001) // =======================================================
  EXTERNAL_FIELDS_LOAD,         1 : iP,iLd,i0,i1=   12    1   12    1 ; Wght=  0.4333333333  0.5666666667
- cg2d: Sum(rhs),rhsMax =   2.09554595897998E-15  1.74491025527420E+02
-(PID.TID 0000.0001)      cg2d_init_res =   2.46961069563866E-01
+ cg2d: Sum(rhs),rhsMax =   7.35522753814166E-16  1.74491025527418E+02
+(PID.TID 0000.0001)      cg2d_init_res =   2.46961069563868E-01
 (PID.TID 0000.0001)      cg2d_iters(min,last) =      -1     100
-(PID.TID 0000.0001)      cg2d_last_res =   8.93944987923529E-10
+(PID.TID 0000.0001)      cg2d_last_res =   8.93944987925441E-10
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // Begin MONITOR dynamic field statistics
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) %MON time_tsnumber                =                     2
 (PID.TID 0000.0001) %MON time_secondsf                =   3.4560000000000E+05
-(PID.TID 0000.0001) %MON dynstat_eta_max              =   4.8731450536100E+04
-(PID.TID 0000.0001) %MON dynstat_eta_min              =  -8.9511245546204E+04
-(PID.TID 0000.0001) %MON dynstat_eta_mean             =  -1.0969651490822E-12
+(PID.TID 0000.0001) %MON dynstat_eta_max              =   4.8731450536099E+04
+(PID.TID 0000.0001) %MON dynstat_eta_min              =  -8.9511245546221E+04
+(PID.TID 0000.0001) %MON dynstat_eta_mean             =  -6.5817908944932E-13
 (PID.TID 0000.0001) %MON dynstat_eta_sd               =   3.9631566178494E+04
-(PID.TID 0000.0001) %MON dynstat_eta_del2             =   2.1451841533430E+03
-(PID.TID 0000.0001) %MON dynstat_uvel_max             =   6.3304193635929E-02
-(PID.TID 0000.0001) %MON dynstat_uvel_min             =  -4.0665562119323E-02
+(PID.TID 0000.0001) %MON dynstat_eta_del2             =   2.1451841533431E+03
+(PID.TID 0000.0001) %MON dynstat_uvel_max             =   6.3304193635927E-02
+(PID.TID 0000.0001) %MON dynstat_uvel_min             =  -4.0665562119321E-02
 (PID.TID 0000.0001) %MON dynstat_uvel_mean            =  -1.1812107812185E-03
 (PID.TID 0000.0001) %MON dynstat_uvel_sd              =   2.2830702491466E-03
-(PID.TID 0000.0001) %MON dynstat_uvel_del2            =   2.7762345632368E-05
-(PID.TID 0000.0001) %MON dynstat_vvel_max             =   5.1937726766173E-02
+(PID.TID 0000.0001) %MON dynstat_uvel_del2            =   2.7762345632367E-05
+(PID.TID 0000.0001) %MON dynstat_vvel_max             =   5.1937726766172E-02
 (PID.TID 0000.0001) %MON dynstat_vvel_min             =  -3.0731578950915E-02
 (PID.TID 0000.0001) %MON dynstat_vvel_mean            =   1.5489296654171E-03
 (PID.TID 0000.0001) %MON dynstat_vvel_sd              =   3.0000340554562E-03
 (PID.TID 0000.0001) %MON dynstat_vvel_del2            =   3.2859698065673E-05
-(PID.TID 0000.0001) %MON dynstat_wvel_max             =   6.3653971172248E-01
-(PID.TID 0000.0001) %MON dynstat_wvel_min             =  -7.9093004738051E-01
-(PID.TID 0000.0001) %MON dynstat_wvel_mean            =  -3.2535089381405E-03
-(PID.TID 0000.0001) %MON dynstat_wvel_sd              =   8.9444104945087E-02
+(PID.TID 0000.0001) %MON dynstat_wvel_max             =   6.3653971172243E-01
+(PID.TID 0000.0001) %MON dynstat_wvel_min             =  -7.9093004738040E-01
+(PID.TID 0000.0001) %MON dynstat_wvel_mean            =  -3.2535089381404E-03
+(PID.TID 0000.0001) %MON dynstat_wvel_sd              =   8.9444104945088E-02
 (PID.TID 0000.0001) %MON dynstat_wvel_del2            =   1.4669868692385E-03
 (PID.TID 0000.0001) %MON dynstat_theta_max            =   2.9684508324331E+01
 (PID.TID 0000.0001) %MON dynstat_theta_min            =  -2.6127577628499E+00
@@ -1888,45 +1999,45 @@
 (PID.TID 0000.0001) %MON forcing_fv_mean              =  -6.1647329254770E-03
 (PID.TID 0000.0001) %MON forcing_fv_sd                =   4.5369550755658E-02
 (PID.TID 0000.0001) %MON forcing_fv_del2              =   4.3066747124620E-04
-(PID.TID 0000.0001) %MON trAdv_CFL_u_max              =   2.1984017075671E-02
+(PID.TID 0000.0001) %MON trAdv_CFL_u_max              =   2.1984017075670E-02
 (PID.TID 0000.0001) %MON trAdv_CFL_v_max              =   1.7376324216851E-02
-(PID.TID 0000.0001) %MON trAdv_CFL_w_max              =   5.0201445983040E-02
-(PID.TID 0000.0001) %MON advcfl_uvel_max              =   3.3657700056190E-02
+(PID.TID 0000.0001) %MON trAdv_CFL_w_max              =   5.0201445983039E-02
+(PID.TID 0000.0001) %MON advcfl_uvel_max              =   3.3657700056188E-02
 (PID.TID 0000.0001) %MON advcfl_vvel_max              =   2.0181334659352E-02
-(PID.TID 0000.0001) %MON advcfl_wvel_max              =   5.3329973254368E-02
-(PID.TID 0000.0001) %MON advcfl_W_hf_max              =   6.4772594059531E-02
-(PID.TID 0000.0001) %MON pe_b_mean                    =  -7.1440395152752E-03
-(PID.TID 0000.0001) %MON ke_max                       =   1.6949296768474E-03
+(PID.TID 0000.0001) %MON advcfl_wvel_max              =   5.3329973254366E-02
+(PID.TID 0000.0001) %MON advcfl_W_hf_max              =   6.4772594059528E-02
+(PID.TID 0000.0001) %MON pe_b_mean                    =  -7.1440395152743E-03
+(PID.TID 0000.0001) %MON ke_max                       =   1.6949296768473E-03
 (PID.TID 0000.0001) %MON ke_mean                      =   8.1035640279376E-06
 (PID.TID 0000.0001) %MON ke_vol                       =   1.3442141716554E+22
 (PID.TID 0000.0001) %MON vort_r_min                   =  -1.7528959998915E-07
-(PID.TID 0000.0001) %MON vort_r_max                   =   1.8496218351050E-07
+(PID.TID 0000.0001) %MON vort_r_max                   =   1.8496218351049E-07
 (PID.TID 0000.0001) %MON vort_a_mean                  =  -2.4598205548451E-05
 (PID.TID 0000.0001) %MON vort_a_sd                    =   7.3636897957510E-05
 (PID.TID 0000.0001) %MON vort_p_mean                  =  -2.9475837120614E-05
 (PID.TID 0000.0001) %MON vort_p_sd                    =   1.0363025572138E-04
-(PID.TID 0000.0001) %MON surfExpan_theta_mean         =   3.6310067823676E-02
-(PID.TID 0000.0001) %MON surfExpan_salt_mean          =  -9.9763781564067E-05
+(PID.TID 0000.0001) %MON surfExpan_theta_mean         =   3.6310067823675E-02
+(PID.TID 0000.0001) %MON surfExpan_salt_mean          =  -9.9763781564203E-05
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // End MONITOR dynamic field statistics
 (PID.TID 0000.0001) // =======================================================
  EXTERNAL_FIELDS_LOAD,         2 : iP,iLd,i0,i1=   12    1   12    1 ; Wght=  0.3666666667  0.6333333333
- cg2d: Sum(rhs),rhsMax =   3.60822483003176E-16  1.72946927598947E+02
-(PID.TID 0000.0001)      cg2d_init_res =   1.05266927324619E-01
+ cg2d: Sum(rhs),rhsMax =  -4.16333634234434E-16  1.72946927598947E+02
+(PID.TID 0000.0001)      cg2d_init_res =   1.05266927324859E-01
 (PID.TID 0000.0001)      cg2d_iters(min,last) =      -1      99
-(PID.TID 0000.0001)      cg2d_last_res =   8.44864271507363E-10
+(PID.TID 0000.0001)      cg2d_last_res =   8.44864271508246E-10
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // Begin MONITOR dynamic field statistics
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) %MON time_tsnumber                =                     3
 (PID.TID 0000.0001) %MON time_secondsf                =   5.1840000000000E+05
-(PID.TID 0000.0001) %MON dynstat_eta_max              =   5.1187690644298E+04
-(PID.TID 0000.0001) %MON dynstat_eta_min              =  -9.1291812654994E+04
-(PID.TID 0000.0001) %MON dynstat_eta_mean             =  -3.5102884770630E-12
+(PID.TID 0000.0001) %MON dynstat_eta_max              =   5.1187690644297E+04
+(PID.TID 0000.0001) %MON dynstat_eta_min              =  -9.1291812654980E+04
+(PID.TID 0000.0001) %MON dynstat_eta_mean             =  -6.1430048348603E-12
 (PID.TID 0000.0001) %MON dynstat_eta_sd               =   3.9692824903823E+04
 (PID.TID 0000.0001) %MON dynstat_eta_del2             =   2.1203163413275E+03
-(PID.TID 0000.0001) %MON dynstat_uvel_max             =   7.1144492171942E-02
-(PID.TID 0000.0001) %MON dynstat_uvel_min             =  -5.1820176630174E-02
+(PID.TID 0000.0001) %MON dynstat_uvel_max             =   7.1144492171941E-02
+(PID.TID 0000.0001) %MON dynstat_uvel_min             =  -5.1820176630172E-02
 (PID.TID 0000.0001) %MON dynstat_uvel_mean            =  -1.1611745764352E-03
 (PID.TID 0000.0001) %MON dynstat_uvel_sd              =   2.7116173531614E-03
 (PID.TID 0000.0001) %MON dynstat_uvel_del2            =   3.6782278024847E-05
@@ -1935,9 +2046,9 @@
 (PID.TID 0000.0001) %MON dynstat_vvel_mean            =   1.5249385901560E-03
 (PID.TID 0000.0001) %MON dynstat_vvel_sd              =   4.1691709783510E-03
 (PID.TID 0000.0001) %MON dynstat_vvel_del2            =   4.5475874050495E-05
-(PID.TID 0000.0001) %MON dynstat_wvel_max             =   8.8722866015909E-01
-(PID.TID 0000.0001) %MON dynstat_wvel_min             =  -1.0866968237903E+00
-(PID.TID 0000.0001) %MON dynstat_wvel_mean            =  -1.5746951986405E-03
+(PID.TID 0000.0001) %MON dynstat_wvel_max             =   8.8722866015860E-01
+(PID.TID 0000.0001) %MON dynstat_wvel_min             =  -1.0866968237902E+00
+(PID.TID 0000.0001) %MON dynstat_wvel_mean            =  -1.5746951986404E-03
 (PID.TID 0000.0001) %MON dynstat_wvel_sd              =   1.2221960079329E-01
 (PID.TID 0000.0001) %MON dynstat_wvel_del2            =   1.9755405250569E-03
 (PID.TID 0000.0001) %MON dynstat_theta_max            =   2.9669020379124E+01
@@ -1975,56 +2086,56 @@
 (PID.TID 0000.0001) %MON forcing_fv_mean              =  -6.0182157576956E-03
 (PID.TID 0000.0001) %MON forcing_fv_sd                =   4.5652999799994E-02
 (PID.TID 0000.0001) %MON forcing_fv_del2              =   4.3302155748244E-04
-(PID.TID 0000.0001) %MON trAdv_CFL_u_max              =   3.4023610840839E-02
-(PID.TID 0000.0001) %MON trAdv_CFL_v_max              =   2.0553846395049E-02
-(PID.TID 0000.0001) %MON trAdv_CFL_w_max              =   4.5323243068243E-02
-(PID.TID 0000.0001) %MON advcfl_uvel_max              =   4.1883475207327E-02
+(PID.TID 0000.0001) %MON trAdv_CFL_u_max              =   3.4023610840838E-02
+(PID.TID 0000.0001) %MON trAdv_CFL_v_max              =   2.0553846395048E-02
+(PID.TID 0000.0001) %MON trAdv_CFL_w_max              =   4.5323243068241E-02
+(PID.TID 0000.0001) %MON advcfl_uvel_max              =   4.1883475207325E-02
 (PID.TID 0000.0001) %MON advcfl_vvel_max              =   2.0754760016190E-02
-(PID.TID 0000.0001) %MON advcfl_wvel_max              =   6.7849893495758E-02
-(PID.TID 0000.0001) %MON advcfl_W_hf_max              =   8.0000410885733E-02
-(PID.TID 0000.0001) %MON pe_b_mean                    =  -8.1381170042314E-03
+(PID.TID 0000.0001) %MON advcfl_wvel_max              =   6.7849893495764E-02
+(PID.TID 0000.0001) %MON advcfl_W_hf_max              =   8.0000410885740E-02
+(PID.TID 0000.0001) %MON pe_b_mean                    =  -8.1381170042305E-03
 (PID.TID 0000.0001) %MON ke_max                       =   1.9935661445800E-03
 (PID.TID 0000.0001) %MON ke_mean                      =   1.2776478266884E-05
 (PID.TID 0000.0001) %MON ke_vol                       =   1.3442141716554E+22
 (PID.TID 0000.0001) %MON vort_r_min                   =  -2.0870324390715E-07
-(PID.TID 0000.0001) %MON vort_r_max                   =   2.3948655295791E-07
+(PID.TID 0000.0001) %MON vort_r_max                   =   2.3948655295789E-07
 (PID.TID 0000.0001) %MON vort_a_mean                  =  -2.4598205699373E-05
 (PID.TID 0000.0001) %MON vort_a_sd                    =   7.3636896465367E-05
 (PID.TID 0000.0001) %MON vort_p_mean                  =  -2.9476057049540E-05
 (PID.TID 0000.0001) %MON vort_p_sd                    =   1.0363472713258E-04
 (PID.TID 0000.0001) %MON surfExpan_theta_mean         =   1.7738689832690E-02
-(PID.TID 0000.0001) %MON surfExpan_salt_mean          =  -2.9264460938167E-04
+(PID.TID 0000.0001) %MON surfExpan_salt_mean          =  -2.9264460938148E-04
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // End MONITOR dynamic field statistics
 (PID.TID 0000.0001) // =======================================================
  EXTERNAL_FIELDS_LOAD,         3 : iP,iLd,i0,i1=   12    1   12    1 ; Wght=  0.3000000000  0.7000000000
- cg2d: Sum(rhs),rhsMax =   2.08166817117217E-15  1.72906146268021E+02
-(PID.TID 0000.0001)      cg2d_init_res =   8.86299686343460E-03
+ cg2d: Sum(rhs),rhsMax =   2.22044604925031E-16  1.72906146268020E+02
+(PID.TID 0000.0001)      cg2d_init_res =   8.86299686349054E-03
 (PID.TID 0000.0001)      cg2d_iters(min,last) =      -1      91
-(PID.TID 0000.0001)      cg2d_last_res =   8.94396065771831E-10
+(PID.TID 0000.0001)      cg2d_last_res =   8.94396065773213E-10
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // Begin MONITOR dynamic field statistics
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) %MON time_tsnumber                =                     4
 (PID.TID 0000.0001) %MON time_secondsf                =   6.9120000000000E+05
-(PID.TID 0000.0001) %MON dynstat_eta_max              =   5.1022220432086E+04
-(PID.TID 0000.0001) %MON dynstat_eta_min              =  -9.2912034242294E+04
-(PID.TID 0000.0001) %MON dynstat_eta_mean             =   8.7757211926576E-13
+(PID.TID 0000.0001) %MON dynstat_eta_max              =   5.1022220432085E+04
+(PID.TID 0000.0001) %MON dynstat_eta_min              =  -9.2912034242181E+04
+(PID.TID 0000.0001) %MON dynstat_eta_mean             =   2.6327163577973E-12
 (PID.TID 0000.0001) %MON dynstat_eta_sd               =   4.0207364186275E+04
-(PID.TID 0000.0001) %MON dynstat_eta_del2             =   2.1191695433898E+03
-(PID.TID 0000.0001) %MON dynstat_uvel_max             =   6.0373181414721E-02
-(PID.TID 0000.0001) %MON dynstat_uvel_min             =  -7.7398832514350E-02
-(PID.TID 0000.0001) %MON dynstat_uvel_mean            =  -8.8738653325913E-04
-(PID.TID 0000.0001) %MON dynstat_uvel_sd              =   3.1068642425061E-03
+(PID.TID 0000.0001) %MON dynstat_eta_del2             =   2.1191695433897E+03
+(PID.TID 0000.0001) %MON dynstat_uvel_max             =   6.0373181414722E-02
+(PID.TID 0000.0001) %MON dynstat_uvel_min             =  -7.7398832514347E-02
+(PID.TID 0000.0001) %MON dynstat_uvel_mean            =  -8.8738653325912E-04
+(PID.TID 0000.0001) %MON dynstat_uvel_sd              =   3.1068642425060E-03
 (PID.TID 0000.0001) %MON dynstat_uvel_del2            =   4.4784025547006E-05
 (PID.TID 0000.0001) %MON dynstat_vvel_max             =   5.0445617437601E-02
-(PID.TID 0000.0001) %MON dynstat_vvel_min             =  -5.9541807417937E-02
+(PID.TID 0000.0001) %MON dynstat_vvel_min             =  -5.9541807417935E-02
 (PID.TID 0000.0001) %MON dynstat_vvel_mean            =   1.2051471104179E-03
 (PID.TID 0000.0001) %MON dynstat_vvel_sd              =   5.2732942351540E-03
-(PID.TID 0000.0001) %MON dynstat_vvel_del2            =   5.7684290203309E-05
-(PID.TID 0000.0001) %MON dynstat_wvel_max             =   1.1517920064735E+00
+(PID.TID 0000.0001) %MON dynstat_vvel_del2            =   5.7684290203308E-05
+(PID.TID 0000.0001) %MON dynstat_wvel_max             =   1.1517920064729E+00
 (PID.TID 0000.0001) %MON dynstat_wvel_min             =  -1.3332465646025E+00
-(PID.TID 0000.0001) %MON dynstat_wvel_mean            =  -9.9677632630542E-04
+(PID.TID 0000.0001) %MON dynstat_wvel_mean            =  -9.9677632630543E-04
 (PID.TID 0000.0001) %MON dynstat_wvel_sd              =   1.4929266822748E-01
 (PID.TID 0000.0001) %MON dynstat_wvel_del2            =   2.3613348919083E-03
 (PID.TID 0000.0001) %MON dynstat_theta_max            =   2.9656615937358E+01
@@ -2036,7 +2147,7 @@
 (PID.TID 0000.0001) %MON dynstat_salt_min             =   2.9775222928443E+01
 (PID.TID 0000.0001) %MON dynstat_salt_mean            =   3.4718001793435E+01
 (PID.TID 0000.0001) %MON dynstat_salt_sd              =   2.9441571236536E-01
-(PID.TID 0000.0001) %MON dynstat_salt_del2            =   1.0351907759711E-03
+(PID.TID 0000.0001) %MON dynstat_salt_del2            =   1.0351907759712E-03
 (PID.TID 0000.0001) %MON forcing_qnet_max             =   4.4001399113216E+02
 (PID.TID 0000.0001) %MON forcing_qnet_min             =  -2.1424176702723E+02
 (PID.TID 0000.0001) %MON forcing_qnet_mean            =  -1.5738238113315E+01
@@ -2062,63 +2173,63 @@
 (PID.TID 0000.0001) %MON forcing_fv_mean              =  -5.8716985899142E-03
 (PID.TID 0000.0001) %MON forcing_fv_sd                =   4.5996426990309E-02
 (PID.TID 0000.0001) %MON forcing_fv_del2              =   4.3761342904399E-04
-(PID.TID 0000.0001) %MON trAdv_CFL_u_max              =   4.2457458670588E-02
+(PID.TID 0000.0001) %MON trAdv_CFL_u_max              =   4.2457458670587E-02
 (PID.TID 0000.0001) %MON trAdv_CFL_v_max              =   2.1562663509242E-02
 (PID.TID 0000.0001) %MON trAdv_CFL_w_max              =   5.9777451267930E-02
-(PID.TID 0000.0001) %MON advcfl_uvel_max              =   4.9570840172367E-02
+(PID.TID 0000.0001) %MON advcfl_uvel_max              =   4.9570840172365E-02
 (PID.TID 0000.0001) %MON advcfl_vvel_max              =   2.3136036491044E-02
-(PID.TID 0000.0001) %MON advcfl_wvel_max              =   8.2672723383567E-02
-(PID.TID 0000.0001) %MON advcfl_W_hf_max              =   9.7087712611970E-02
-(PID.TID 0000.0001) %MON pe_b_mean                    =  -8.3953210342011E-03
-(PID.TID 0000.0001) %MON ke_max                       =   2.3924838775908E-03
+(PID.TID 0000.0001) %MON advcfl_wvel_max              =   8.2672723383564E-02
+(PID.TID 0000.0001) %MON advcfl_W_hf_max              =   9.7087712611943E-02
+(PID.TID 0000.0001) %MON pe_b_mean                    =  -8.3953210342001E-03
+(PID.TID 0000.0001) %MON ke_max                       =   2.3924838775907E-03
 (PID.TID 0000.0001) %MON ke_mean                      =   1.7846772698814E-05
 (PID.TID 0000.0001) %MON ke_vol                       =   1.3442141716554E+22
-(PID.TID 0000.0001) %MON vort_r_min                   =  -2.2444891367773E-07
-(PID.TID 0000.0001) %MON vort_r_max                   =   2.8703165171912E-07
+(PID.TID 0000.0001) %MON vort_r_min                   =  -2.2444891367772E-07
+(PID.TID 0000.0001) %MON vort_r_max                   =   2.8703165171911E-07
 (PID.TID 0000.0001) %MON vort_a_mean                  =  -2.4598205837176E-05
 (PID.TID 0000.0001) %MON vort_a_sd                    =   7.3636956691787E-05
 (PID.TID 0000.0001) %MON vort_p_mean                  =  -2.9476077386042E-05
 (PID.TID 0000.0001) %MON vort_p_sd                    =   1.0363703575158E-04
 (PID.TID 0000.0001) %MON surfExpan_theta_mean         =   1.0299907508857E-02
-(PID.TID 0000.0001) %MON surfExpan_salt_mean          =  -2.3121035246097E-04
+(PID.TID 0000.0001) %MON surfExpan_salt_mean          =  -2.3121035246127E-04
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // End MONITOR dynamic field statistics
 (PID.TID 0000.0001) // =======================================================
  EXTERNAL_FIELDS_LOAD,         4 : iP,iLd,i0,i1=   12    1   12    1 ; Wght=  0.2333333333  0.7666666667
- cg2d: Sum(rhs),rhsMax =   2.38697950294409E-15  1.72918766920360E+02
-(PID.TID 0000.0001)      cg2d_init_res =   4.67202668332594E-03
+ cg2d: Sum(rhs),rhsMax =  -1.66533453693773E-16  1.72918766920354E+02
+(PID.TID 0000.0001)      cg2d_init_res =   4.67202668334790E-03
 (PID.TID 0000.0001)      cg2d_iters(min,last) =      -1      94
-(PID.TID 0000.0001)      cg2d_last_res =   9.56783421109704E-10
+(PID.TID 0000.0001)      cg2d_last_res =   9.56783421118501E-10
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // Begin MONITOR dynamic field statistics
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) %MON time_tsnumber                =                     5
 (PID.TID 0000.0001) %MON time_secondsf                =   8.6400000000000E+05
-(PID.TID 0000.0001) %MON dynstat_eta_max              =   5.8777961990041E+04
-(PID.TID 0000.0001) %MON dynstat_eta_min              =  -9.4350849620728E+04
-(PID.TID 0000.0001) %MON dynstat_eta_mean             =   6.1430048348603E-12
+(PID.TID 0000.0001) %MON dynstat_eta_max              =   5.8777961990040E+04
+(PID.TID 0000.0001) %MON dynstat_eta_min              =  -9.4350849620742E+04
+(PID.TID 0000.0001) %MON dynstat_eta_mean             =  -5.2654327155946E-12
 (PID.TID 0000.0001) %MON dynstat_eta_sd               =   4.0654232830610E+04
 (PID.TID 0000.0001) %MON dynstat_eta_del2             =   2.1193252486699E+03
-(PID.TID 0000.0001) %MON dynstat_uvel_max             =   5.9431546259501E-02
-(PID.TID 0000.0001) %MON dynstat_uvel_min             =  -9.0095824957242E-02
-(PID.TID 0000.0001) %MON dynstat_uvel_mean            =  -4.7286298734172E-04
+(PID.TID 0000.0001) %MON dynstat_uvel_max             =   5.9431546259498E-02
+(PID.TID 0000.0001) %MON dynstat_uvel_min             =  -9.0095824957240E-02
+(PID.TID 0000.0001) %MON dynstat_uvel_mean            =  -4.7286298734173E-04
 (PID.TID 0000.0001) %MON dynstat_uvel_sd              =   3.5824348275364E-03
-(PID.TID 0000.0001) %MON dynstat_uvel_del2            =   5.1919006845905E-05
-(PID.TID 0000.0001) %MON dynstat_vvel_max             =   6.0201937207916E-02
-(PID.TID 0000.0001) %MON dynstat_vvel_min             =  -7.2312723148846E-02
-(PID.TID 0000.0001) %MON dynstat_vvel_mean            =   7.4567188833830E-04
+(PID.TID 0000.0001) %MON dynstat_uvel_del2            =   5.1919006845902E-05
+(PID.TID 0000.0001) %MON dynstat_vvel_max             =   6.0201937207918E-02
+(PID.TID 0000.0001) %MON dynstat_vvel_min             =  -7.2312723148845E-02
+(PID.TID 0000.0001) %MON dynstat_vvel_mean            =   7.4567188833831E-04
 (PID.TID 0000.0001) %MON dynstat_vvel_sd              =   6.3133399251076E-03
-(PID.TID 0000.0001) %MON dynstat_vvel_del2            =   6.9042652361022E-05
-(PID.TID 0000.0001) %MON dynstat_wvel_max             =   1.3999315034873E+00
-(PID.TID 0000.0001) %MON dynstat_wvel_min             =  -1.5271611397556E+00
-(PID.TID 0000.0001) %MON dynstat_wvel_mean            =  -6.9382859389008E-04
-(PID.TID 0000.0001) %MON dynstat_wvel_sd              =   1.7382735174086E-01
-(PID.TID 0000.0001) %MON dynstat_wvel_del2            =   2.6961383087031E-03
+(PID.TID 0000.0001) %MON dynstat_vvel_del2            =   6.9042652361021E-05
+(PID.TID 0000.0001) %MON dynstat_wvel_max             =   1.3999315034869E+00
+(PID.TID 0000.0001) %MON dynstat_wvel_min             =  -1.5271611397555E+00
+(PID.TID 0000.0001) %MON dynstat_wvel_mean            =  -6.9382859389012E-04
+(PID.TID 0000.0001) %MON dynstat_wvel_sd              =   1.7382735174085E-01
+(PID.TID 0000.0001) %MON dynstat_wvel_del2            =   2.6961383087027E-03
 (PID.TID 0000.0001) %MON dynstat_theta_max            =   2.9654525170064E+01
 (PID.TID 0000.0001) %MON dynstat_theta_min            =  -2.5894330677868E+00
 (PID.TID 0000.0001) %MON dynstat_theta_mean           =   3.6024836623626E+00
 (PID.TID 0000.0001) %MON dynstat_theta_sd             =   4.4013087405700E+00
-(PID.TID 0000.0001) %MON dynstat_theta_del2           =   5.4496680330636E-03
+(PID.TID 0000.0001) %MON dynstat_theta_del2           =   5.4496680330635E-03
 (PID.TID 0000.0001) %MON dynstat_salt_max             =   3.7435037703972E+01
 (PID.TID 0000.0001) %MON dynstat_salt_min             =   2.9777919241109E+01
 (PID.TID 0000.0001) %MON dynstat_salt_mean            =   3.4718001630196E+01
@@ -2149,58 +2260,58 @@
 (PID.TID 0000.0001) %MON forcing_fv_mean              =  -5.7251814221328E-03
 (PID.TID 0000.0001) %MON forcing_fv_sd                =   4.6398500527278E-02
 (PID.TID 0000.0001) %MON forcing_fv_del2              =   4.4437371985182E-04
-(PID.TID 0000.0001) %MON trAdv_CFL_u_max              =   4.9736919952016E-02
-(PID.TID 0000.0001) %MON trAdv_CFL_v_max              =   2.2164178643167E-02
-(PID.TID 0000.0001) %MON trAdv_CFL_w_max              =   7.8094117855154E-02
-(PID.TID 0000.0001) %MON advcfl_uvel_max              =   5.4004091544912E-02
+(PID.TID 0000.0001) %MON trAdv_CFL_u_max              =   4.9736919952014E-02
+(PID.TID 0000.0001) %MON trAdv_CFL_v_max              =   2.2164178643166E-02
+(PID.TID 0000.0001) %MON trAdv_CFL_w_max              =   7.8094117855145E-02
+(PID.TID 0000.0001) %MON advcfl_uvel_max              =   5.4004091544910E-02
 (PID.TID 0000.0001) %MON advcfl_vvel_max              =   2.8098404702348E-02
 (PID.TID 0000.0001) %MON advcfl_wvel_max              =   9.6078914474386E-02
-(PID.TID 0000.0001) %MON advcfl_W_hf_max              =   1.0908741646353E-01
-(PID.TID 0000.0001) %MON pe_b_mean                    =  -8.4417417547834E-03
-(PID.TID 0000.0001) %MON ke_max                       =   3.5715841762088E-03
+(PID.TID 0000.0001) %MON advcfl_W_hf_max              =   1.0908741646350E-01
+(PID.TID 0000.0001) %MON pe_b_mean                    =  -8.4417417547827E-03
+(PID.TID 0000.0001) %MON ke_max                       =   3.5715841762086E-03
 (PID.TID 0000.0001) %MON ke_mean                      =   2.4033004901197E-05
 (PID.TID 0000.0001) %MON ke_vol                       =   1.3442141716554E+22
-(PID.TID 0000.0001) %MON vort_r_min                   =  -2.5907671708790E-07
-(PID.TID 0000.0001) %MON vort_r_max                   =   2.9702778656968E-07
+(PID.TID 0000.0001) %MON vort_r_min                   =  -2.5907671708787E-07
+(PID.TID 0000.0001) %MON vort_r_max                   =   2.9702778656967E-07
 (PID.TID 0000.0001) %MON vort_a_mean                  =  -2.4598205917344E-05
 (PID.TID 0000.0001) %MON vort_a_sd                    =   7.3637051737867E-05
 (PID.TID 0000.0001) %MON vort_p_mean                  =  -2.9476147923768E-05
 (PID.TID 0000.0001) %MON vort_p_sd                    =   1.0363835084626E-04
 (PID.TID 0000.0001) %MON surfExpan_theta_mean         =   6.1418342497161E-03
-(PID.TID 0000.0001) %MON surfExpan_salt_mean          =  -1.0933568425280E-04
+(PID.TID 0000.0001) %MON surfExpan_salt_mean          =  -1.0933568425262E-04
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // End MONITOR dynamic field statistics
 (PID.TID 0000.0001) // =======================================================
  EXTERNAL_FIELDS_LOAD,         5 : iP,iLd,i0,i1=   12    1   12    1 ; Wght=  0.1666666667  0.8333333333
- cg2d: Sum(rhs),rhsMax =   1.11022302462516E-16  1.72928026396318E+02
-(PID.TID 0000.0001)      cg2d_init_res =   3.44720163719426E-03
+ cg2d: Sum(rhs),rhsMax =  -3.10862446895044E-15  1.72928026396326E+02
+(PID.TID 0000.0001)      cg2d_init_res =   3.44720163717163E-03
 (PID.TID 0000.0001)      cg2d_iters(min,last) =      -1      91
-(PID.TID 0000.0001)      cg2d_last_res =   9.88704297449990E-10
+(PID.TID 0000.0001)      cg2d_last_res =   9.88704297466584E-10
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // Begin MONITOR dynamic field statistics
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) %MON time_tsnumber                =                     6
 (PID.TID 0000.0001) %MON time_secondsf                =   1.0368000000000E+06
 (PID.TID 0000.0001) %MON dynstat_eta_max              =   6.2199514528760E+04
-(PID.TID 0000.0001) %MON dynstat_eta_min              =  -9.5076086806047E+04
-(PID.TID 0000.0001) %MON dynstat_eta_mean             =  -6.1430048348603E-12
+(PID.TID 0000.0001) %MON dynstat_eta_min              =  -9.5076086806072E+04
+(PID.TID 0000.0001) %MON dynstat_eta_mean             =   9.6532933119234E-12
 (PID.TID 0000.0001) %MON dynstat_eta_sd               =   4.0801704496365E+04
 (PID.TID 0000.0001) %MON dynstat_eta_del2             =   2.1193912540702E+03
-(PID.TID 0000.0001) %MON dynstat_uvel_max             =   7.3872645856155E-02
-(PID.TID 0000.0001) %MON dynstat_uvel_min             =  -8.7711994894124E-02
-(PID.TID 0000.0001) %MON dynstat_uvel_mean            =  -3.8391728420626E-05
-(PID.TID 0000.0001) %MON dynstat_uvel_sd              =   4.2190994927203E-03
-(PID.TID 0000.0001) %MON dynstat_uvel_del2            =   5.8219909841981E-05
-(PID.TID 0000.0001) %MON dynstat_vvel_max             =   6.8510011092932E-02
-(PID.TID 0000.0001) %MON dynstat_vvel_min             =  -8.3509538293638E-02
+(PID.TID 0000.0001) %MON dynstat_uvel_max             =   7.3872645856153E-02
+(PID.TID 0000.0001) %MON dynstat_uvel_min             =  -8.7711994894122E-02
+(PID.TID 0000.0001) %MON dynstat_uvel_mean            =  -3.8391728420624E-05
+(PID.TID 0000.0001) %MON dynstat_uvel_sd              =   4.2190994927202E-03
+(PID.TID 0000.0001) %MON dynstat_uvel_del2            =   5.8219909841980E-05
+(PID.TID 0000.0001) %MON dynstat_vvel_max             =   6.8510011092931E-02
+(PID.TID 0000.0001) %MON dynstat_vvel_min             =  -8.3509538293634E-02
 (PID.TID 0000.0001) %MON dynstat_vvel_mean            =   2.7716163547316E-04
 (PID.TID 0000.0001) %MON dynstat_vvel_sd              =   7.2905348043045E-03
 (PID.TID 0000.0001) %MON dynstat_vvel_del2            =   7.9319254713992E-05
-(PID.TID 0000.0001) %MON dynstat_wvel_max             =   1.6150474146068E+00
+(PID.TID 0000.0001) %MON dynstat_wvel_max             =   1.6150474146070E+00
 (PID.TID 0000.0001) %MON dynstat_wvel_min             =  -1.6581751720617E+00
-(PID.TID 0000.0001) %MON dynstat_wvel_mean            =  -3.9056482637718E-04
+(PID.TID 0000.0001) %MON dynstat_wvel_mean            =  -3.9056482637722E-04
 (PID.TID 0000.0001) %MON dynstat_wvel_sd              =   1.9515970060754E-01
-(PID.TID 0000.0001) %MON dynstat_wvel_del2            =   2.9650427992347E-03
+(PID.TID 0000.0001) %MON dynstat_wvel_del2            =   2.9650427992348E-03
 (PID.TID 0000.0001) %MON dynstat_theta_max            =   2.9697979591740E+01
 (PID.TID 0000.0001) %MON dynstat_theta_min            =  -2.5814274764938E+00
 (PID.TID 0000.0001) %MON dynstat_theta_mean           =   3.6026221481766E+00
@@ -2236,58 +2347,58 @@
 (PID.TID 0000.0001) %MON forcing_fv_mean              =  -5.5786642543514E-03
 (PID.TID 0000.0001) %MON forcing_fv_sd                =   4.6857710749175E-02
 (PID.TID 0000.0001) %MON forcing_fv_del2              =   4.5320540386280E-04
-(PID.TID 0000.0001) %MON trAdv_CFL_u_max              =   5.3920110932597E-02
+(PID.TID 0000.0001) %MON trAdv_CFL_u_max              =   5.3920110932594E-02
 (PID.TID 0000.0001) %MON trAdv_CFL_v_max              =   2.6918096435918E-02
-(PID.TID 0000.0001) %MON trAdv_CFL_w_max              =   9.4987033273592E-02
-(PID.TID 0000.0001) %MON advcfl_uvel_max              =   5.3934847350491E-02
-(PID.TID 0000.0001) %MON advcfl_vvel_max              =   3.2449127916964E-02
+(PID.TID 0000.0001) %MON trAdv_CFL_w_max              =   9.4987033273584E-02
+(PID.TID 0000.0001) %MON advcfl_uvel_max              =   5.3934847350488E-02
+(PID.TID 0000.0001) %MON advcfl_vvel_max              =   3.2449127916963E-02
 (PID.TID 0000.0001) %MON advcfl_wvel_max              =   1.0591083845440E-01
 (PID.TID 0000.0001) %MON advcfl_W_hf_max              =   1.1991144467440E-01
-(PID.TID 0000.0001) %MON pe_b_mean                    =  -8.5192963564499E-03
-(PID.TID 0000.0001) %MON ke_max                       =   3.8520477646275E-03
+(PID.TID 0000.0001) %MON pe_b_mean                    =  -8.5192963564492E-03
+(PID.TID 0000.0001) %MON ke_max                       =   3.8520477646276E-03
 (PID.TID 0000.0001) %MON ke_mean                      =   3.1927105193104E-05
 (PID.TID 0000.0001) %MON ke_vol                       =   1.3442141716554E+22
-(PID.TID 0000.0001) %MON vort_r_min                   =  -2.9393731111568E-07
-(PID.TID 0000.0001) %MON vort_r_max                   =   2.9638597146925E-07
+(PID.TID 0000.0001) %MON vort_r_min                   =  -2.9393731111564E-07
+(PID.TID 0000.0001) %MON vort_r_max                   =   2.9638597146924E-07
 (PID.TID 0000.0001) %MON vort_a_mean                  =  -2.4598205901929E-05
 (PID.TID 0000.0001) %MON vort_a_sd                    =   7.3637152869186E-05
 (PID.TID 0000.0001) %MON vort_p_mean                  =  -2.9476194533748E-05
 (PID.TID 0000.0001) %MON vort_p_sd                    =   1.0363871158538E-04
-(PID.TID 0000.0001) %MON surfExpan_theta_mean         =   2.1099872549432E-03
-(PID.TID 0000.0001) %MON surfExpan_salt_mean          =  -5.9579376030009E-05
+(PID.TID 0000.0001) %MON surfExpan_theta_mean         =   2.1099872549433E-03
+(PID.TID 0000.0001) %MON surfExpan_salt_mean          =  -5.9579376030015E-05
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // End MONITOR dynamic field statistics
 (PID.TID 0000.0001) // =======================================================
  EXTERNAL_FIELDS_LOAD,         6 : iP,iLd,i0,i1=   12    1   12    1 ; Wght=  0.1000000000  0.9000000000
- cg2d: Sum(rhs),rhsMax =  -3.16413562018170E-15  1.72940006374309E+02
-(PID.TID 0000.0001)      cg2d_init_res =   3.58866279382392E-03
+ cg2d: Sum(rhs),rhsMax =  -2.77555756156289E-16  1.72940006374306E+02
+(PID.TID 0000.0001)      cg2d_init_res =   3.58866279382681E-03
 (PID.TID 0000.0001)      cg2d_iters(min,last) =      -1      91
-(PID.TID 0000.0001)      cg2d_last_res =   8.94333226802885E-10
+(PID.TID 0000.0001)      cg2d_last_res =   8.94333226757442E-10
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // Begin MONITOR dynamic field statistics
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) %MON time_tsnumber                =                     7
 (PID.TID 0000.0001) %MON time_secondsf                =   1.2096000000000E+06
-(PID.TID 0000.0001) %MON dynstat_eta_max              =   6.1124867274111E+04
-(PID.TID 0000.0001) %MON dynstat_eta_min              =  -9.5056492024873E+04
-(PID.TID 0000.0001) %MON dynstat_eta_mean             =  -2.6327163577973E-12
+(PID.TID 0000.0001) %MON dynstat_eta_max              =   6.1124867274110E+04
+(PID.TID 0000.0001) %MON dynstat_eta_min              =  -9.5056492024920E+04
+(PID.TID 0000.0001) %MON dynstat_eta_mean             =  -3.5102884770630E-12
 (PID.TID 0000.0001) %MON dynstat_eta_sd               =   4.0658522838634E+04
 (PID.TID 0000.0001) %MON dynstat_eta_del2             =   2.1194804575949E+03
-(PID.TID 0000.0001) %MON dynstat_uvel_max             =   8.8124654697550E-02
-(PID.TID 0000.0001) %MON dynstat_uvel_min             =  -7.2707985717155E-02
-(PID.TID 0000.0001) %MON dynstat_uvel_mean            =   3.1961548860430E-04
+(PID.TID 0000.0001) %MON dynstat_uvel_max             =   8.8124654697546E-02
+(PID.TID 0000.0001) %MON dynstat_uvel_min             =  -7.2707985717153E-02
+(PID.TID 0000.0001) %MON dynstat_uvel_mean            =   3.1961548860431E-04
 (PID.TID 0000.0001) %MON dynstat_uvel_sd              =   4.9897499699937E-03
-(PID.TID 0000.0001) %MON dynstat_uvel_del2            =   6.3658695435690E-05
-(PID.TID 0000.0001) %MON dynstat_vvel_max             =   7.5321113116832E-02
-(PID.TID 0000.0001) %MON dynstat_vvel_min             =  -9.4848605905720E-02
-(PID.TID 0000.0001) %MON dynstat_vvel_mean            =  -1.0069652102899E-04
+(PID.TID 0000.0001) %MON dynstat_uvel_del2            =   6.3658695435689E-05
+(PID.TID 0000.0001) %MON dynstat_vvel_max             =   7.5321113116834E-02
+(PID.TID 0000.0001) %MON dynstat_vvel_min             =  -9.4848605905718E-02
+(PID.TID 0000.0001) %MON dynstat_vvel_mean            =  -1.0069652102902E-04
 (PID.TID 0000.0001) %MON dynstat_vvel_sd              =   8.1800417393895E-03
 (PID.TID 0000.0001) %MON dynstat_vvel_del2            =   8.8287955926494E-05
-(PID.TID 0000.0001) %MON dynstat_wvel_max             =   1.7882603424237E+00
-(PID.TID 0000.0001) %MON dynstat_wvel_min             =  -1.7284273274248E+00
-(PID.TID 0000.0001) %MON dynstat_wvel_mean            =  -8.0189997947282E-05
+(PID.TID 0000.0001) %MON dynstat_wvel_max             =   1.7882603424236E+00
+(PID.TID 0000.0001) %MON dynstat_wvel_min             =  -1.7284273274249E+00
+(PID.TID 0000.0001) %MON dynstat_wvel_mean            =  -8.0189997947106E-05
 (PID.TID 0000.0001) %MON dynstat_wvel_sd              =   2.1276998747193E-01
-(PID.TID 0000.0001) %MON dynstat_wvel_del2            =   3.1644583051033E-03
+(PID.TID 0000.0001) %MON dynstat_wvel_del2            =   3.1644583051034E-03
 (PID.TID 0000.0001) %MON dynstat_theta_max            =   2.9742919278628E+01
 (PID.TID 0000.0001) %MON dynstat_theta_min            =  -2.6576220656054E+00
 (PID.TID 0000.0001) %MON dynstat_theta_mean           =   3.6027577546461E+00
@@ -2323,58 +2434,58 @@
 (PID.TID 0000.0001) %MON forcing_fv_mean              =  -5.4321470865700E-03
 (PID.TID 0000.0001) %MON forcing_fv_sd                =   4.7372396100423E-02
 (PID.TID 0000.0001) %MON forcing_fv_del2              =   4.6399021419221E-04
-(PID.TID 0000.0001) %MON trAdv_CFL_u_max              =   5.3903135061249E-02
-(PID.TID 0000.0001) %MON trAdv_CFL_v_max              =   3.1086062137089E-02
+(PID.TID 0000.0001) %MON trAdv_CFL_u_max              =   5.3903135061246E-02
+(PID.TID 0000.0001) %MON trAdv_CFL_v_max              =   3.1086062137088E-02
 (PID.TID 0000.0001) %MON trAdv_CFL_w_max              =   1.1017941342647E-01
-(PID.TID 0000.0001) %MON advcfl_uvel_max              =   5.8256674496061E-02
-(PID.TID 0000.0001) %MON advcfl_vvel_max              =   3.6855125877458E-02
+(PID.TID 0000.0001) %MON advcfl_uvel_max              =   5.8256674496058E-02
+(PID.TID 0000.0001) %MON advcfl_vvel_max              =   3.6855125877457E-02
 (PID.TID 0000.0001) %MON advcfl_wvel_max              =   1.1219611001326E-01
-(PID.TID 0000.0001) %MON advcfl_W_hf_max              =   1.2702758126431E-01
-(PID.TID 0000.0001) %MON pe_b_mean                    =  -8.6494150929223E-03
-(PID.TID 0000.0001) %MON ke_max                       =   5.0805169932114E-03
+(PID.TID 0000.0001) %MON advcfl_W_hf_max              =   1.2702758126432E-01
+(PID.TID 0000.0001) %MON pe_b_mean                    =  -8.6494150929214E-03
+(PID.TID 0000.0001) %MON ke_max                       =   5.0805169932116E-03
 (PID.TID 0000.0001) %MON ke_mean                      =   4.1326652175479E-05
 (PID.TID 0000.0001) %MON ke_vol                       =   1.3442141716554E+22
-(PID.TID 0000.0001) %MON vort_r_min                   =  -2.7761818544160E-07
-(PID.TID 0000.0001) %MON vort_r_max                   =   2.6294212391517E-07
+(PID.TID 0000.0001) %MON vort_r_min                   =  -2.7761818544155E-07
+(PID.TID 0000.0001) %MON vort_r_max                   =   2.6294212391516E-07
 (PID.TID 0000.0001) %MON vort_a_mean                  =  -2.4598205783634E-05
 (PID.TID 0000.0001) %MON vort_a_sd                    =   7.3637237026630E-05
 (PID.TID 0000.0001) %MON vort_p_mean                  =  -2.9476210033395E-05
 (PID.TID 0000.0001) %MON vort_p_sd                    =   1.0363846082166E-04
-(PID.TID 0000.0001) %MON surfExpan_theta_mean         =  -1.7039274368721E-03
-(PID.TID 0000.0001) %MON surfExpan_salt_mean          =  -5.6851691934581E-05
+(PID.TID 0000.0001) %MON surfExpan_theta_mean         =  -1.7039274368724E-03
+(PID.TID 0000.0001) %MON surfExpan_salt_mean          =  -5.6851691934632E-05
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // End MONITOR dynamic field statistics
 (PID.TID 0000.0001) // =======================================================
  EXTERNAL_FIELDS_LOAD,         7 : iP,iLd,i0,i1=   12    1   12    1 ; Wght=  0.0333333333  0.9666666667
- cg2d: Sum(rhs),rhsMax =   2.22044604925031E-15  1.72953671010727E+02
-(PID.TID 0000.0001)      cg2d_init_res =   3.93758884622456E-03
+ cg2d: Sum(rhs),rhsMax =   5.55111512312578E-17  1.72953671010731E+02
+(PID.TID 0000.0001)      cg2d_init_res =   3.93758884629383E-03
 (PID.TID 0000.0001)      cg2d_iters(min,last) =      -1      90
-(PID.TID 0000.0001)      cg2d_last_res =   8.40984699644257E-10
+(PID.TID 0000.0001)      cg2d_last_res =   8.40984699646111E-10
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // Begin MONITOR dynamic field statistics
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) %MON time_tsnumber                =                     8
 (PID.TID 0000.0001) %MON time_secondsf                =   1.3824000000000E+06
-(PID.TID 0000.0001) %MON dynstat_eta_max              =   5.6571952283538E+04
-(PID.TID 0000.0001) %MON dynstat_eta_min              =  -9.4423302823414E+04
-(PID.TID 0000.0001) %MON dynstat_eta_mean             =  -9.2145072522905E-12
+(PID.TID 0000.0001) %MON dynstat_eta_max              =   5.6571952283537E+04
+(PID.TID 0000.0001) %MON dynstat_eta_min              =  -9.4423302823339E+04
+(PID.TID 0000.0001) %MON dynstat_eta_mean             =   3.5102884770630E-12
 (PID.TID 0000.0001) %MON dynstat_eta_sd               =   4.0354834070583E+04
 (PID.TID 0000.0001) %MON dynstat_eta_del2             =   2.1195693104036E+03
 (PID.TID 0000.0001) %MON dynstat_uvel_max             =   1.0170417651387E-01
-(PID.TID 0000.0001) %MON dynstat_uvel_min             =  -6.5317082788674E-02
-(PID.TID 0000.0001) %MON dynstat_uvel_mean            =   5.4612751709734E-04
+(PID.TID 0000.0001) %MON dynstat_uvel_min             =  -6.5317082788675E-02
+(PID.TID 0000.0001) %MON dynstat_uvel_mean            =   5.4612751709736E-04
 (PID.TID 0000.0001) %MON dynstat_uvel_sd              =   5.8329423829982E-03
-(PID.TID 0000.0001) %MON dynstat_uvel_del2            =   6.8255199265935E-05
-(PID.TID 0000.0001) %MON dynstat_vvel_max             =   8.0634665278281E-02
+(PID.TID 0000.0001) %MON dynstat_uvel_del2            =   6.8255199265934E-05
+(PID.TID 0000.0001) %MON dynstat_vvel_max             =   8.0634665278280E-02
 (PID.TID 0000.0001) %MON dynstat_vvel_min             =  -1.0472405198552E-01
-(PID.TID 0000.0001) %MON dynstat_vvel_mean            =  -3.3434228199018E-04
-(PID.TID 0000.0001) %MON dynstat_vvel_sd              =   8.9561927782301E-03
-(PID.TID 0000.0001) %MON dynstat_vvel_del2            =   9.5795802789150E-05
-(PID.TID 0000.0001) %MON dynstat_wvel_max             =   1.9132254038192E+00
-(PID.TID 0000.0001) %MON dynstat_wvel_min             =  -1.7438607313133E+00
-(PID.TID 0000.0001) %MON dynstat_wvel_mean            =   1.8250131035497E-04
-(PID.TID 0000.0001) %MON dynstat_wvel_sd              =   2.2628387981570E-01
-(PID.TID 0000.0001) %MON dynstat_wvel_del2            =   3.2962176593770E-03
+(PID.TID 0000.0001) %MON dynstat_vvel_mean            =  -3.3434228199017E-04
+(PID.TID 0000.0001) %MON dynstat_vvel_sd              =   8.9561927782300E-03
+(PID.TID 0000.0001) %MON dynstat_vvel_del2            =   9.5795802789149E-05
+(PID.TID 0000.0001) %MON dynstat_wvel_max             =   1.9132254038191E+00
+(PID.TID 0000.0001) %MON dynstat_wvel_min             =  -1.7438607313134E+00
+(PID.TID 0000.0001) %MON dynstat_wvel_mean            =   1.8250131035488E-04
+(PID.TID 0000.0001) %MON dynstat_wvel_sd              =   2.2628387981569E-01
+(PID.TID 0000.0001) %MON dynstat_wvel_del2            =   3.2962176593769E-03
 (PID.TID 0000.0001) %MON dynstat_theta_max            =   2.9791415849010E+01
 (PID.TID 0000.0001) %MON dynstat_theta_min            =  -2.7389994643564E+00
 (PID.TID 0000.0001) %MON dynstat_theta_mean           =   3.6028882566484E+00
@@ -2410,25 +2521,25 @@
 (PID.TID 0000.0001) %MON forcing_fv_mean              =  -5.2856299187887E-03
 (PID.TID 0000.0001) %MON forcing_fv_sd                =   4.7940769894797E-02
 (PID.TID 0000.0001) %MON forcing_fv_del2              =   4.7659557826527E-04
-(PID.TID 0000.0001) %MON trAdv_CFL_u_max              =   5.8268506843310E-02
-(PID.TID 0000.0001) %MON trAdv_CFL_v_max              =   3.5306980700025E-02
-(PID.TID 0000.0001) %MON trAdv_CFL_w_max              =   1.2343220108906E-01
-(PID.TID 0000.0001) %MON advcfl_uvel_max              =   6.7233705781806E-02
+(PID.TID 0000.0001) %MON trAdv_CFL_u_max              =   5.8268506843307E-02
+(PID.TID 0000.0001) %MON trAdv_CFL_v_max              =   3.5306980700024E-02
+(PID.TID 0000.0001) %MON trAdv_CFL_w_max              =   1.2343220108905E-01
+(PID.TID 0000.0001) %MON advcfl_uvel_max              =   6.7233705781804E-02
 (PID.TID 0000.0001) %MON advcfl_vvel_max              =   4.0692407457842E-02
-(PID.TID 0000.0001) %MON advcfl_wvel_max              =   1.1877388351612E-01
-(PID.TID 0000.0001) %MON advcfl_W_hf_max              =   1.3447889726578E-01
-(PID.TID 0000.0001) %MON pe_b_mean                    =  -8.7562681030090E-03
-(PID.TID 0000.0001) %MON ke_max                       =   6.3881973943752E-03
+(PID.TID 0000.0001) %MON advcfl_wvel_max              =   1.1877388351611E-01
+(PID.TID 0000.0001) %MON advcfl_W_hf_max              =   1.3447889726577E-01
+(PID.TID 0000.0001) %MON pe_b_mean                    =  -8.7562681030082E-03
+(PID.TID 0000.0001) %MON ke_max                       =   6.3881973943754E-03
 (PID.TID 0000.0001) %MON ke_mean                      =   5.1557184499732E-05
 (PID.TID 0000.0001) %MON ke_vol                       =   1.3442141716554E+22
-(PID.TID 0000.0001) %MON vort_r_min                   =  -2.3593673032253E-07
-(PID.TID 0000.0001) %MON vort_r_max                   =   2.1426490440916E-07
+(PID.TID 0000.0001) %MON vort_r_min                   =  -2.3593673032252E-07
+(PID.TID 0000.0001) %MON vort_r_max                   =   2.1426490440915E-07
 (PID.TID 0000.0001) %MON vort_a_mean                  =  -2.4598205581775E-05
 (PID.TID 0000.0001) %MON vort_a_sd                    =   7.3637290841549E-05
 (PID.TID 0000.0001) %MON vort_p_mean                  =  -2.9476203177460E-05
 (PID.TID 0000.0001) %MON vort_p_sd                    =   1.0363788603570E-04
-(PID.TID 0000.0001) %MON surfExpan_theta_mean         =  -4.3866513305754E-03
-(PID.TID 0000.0001) %MON surfExpan_salt_mean          =  -5.8894120105284E-05
+(PID.TID 0000.0001) %MON surfExpan_theta_mean         =  -4.3866513305752E-03
+(PID.TID 0000.0001) %MON surfExpan_salt_mean          =  -5.8894120105432E-05
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // End MONITOR dynamic field statistics
 (PID.TID 0000.0001) // =======================================================
@@ -2444,35 +2555,35 @@
 (PID.TID 0000.0001)  MDS_READ_FIELD: opening global file: shi_empmr.bin
 (PID.TID 0000.0001)  MDS_READ_FIELD: opening global file: lev_sst.bin
 (PID.TID 0000.0001)  MDS_READ_FIELD: opening global file: lev_sst.bin
- cg2d: Sum(rhs),rhsMax =  -1.16573417585641E-15  1.72967793887655E+02
-(PID.TID 0000.0001)      cg2d_init_res =   3.96296243677320E-03
+ cg2d: Sum(rhs),rhsMax =   4.99600361081320E-16  1.72967793887648E+02
+(PID.TID 0000.0001)      cg2d_init_res =   3.96296243689015E-03
 (PID.TID 0000.0001)      cg2d_iters(min,last) =      -1      92
-(PID.TID 0000.0001)      cg2d_last_res =   9.19042194740292E-10
+(PID.TID 0000.0001)      cg2d_last_res =   9.19042194796429E-10
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // Begin MONITOR dynamic field statistics
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) %MON time_tsnumber                =                     9
 (PID.TID 0000.0001) %MON time_secondsf                =   1.5552000000000E+06
-(PID.TID 0000.0001) %MON dynstat_eta_max              =   5.2422631605990E+04
-(PID.TID 0000.0001) %MON dynstat_eta_min              =  -9.3561906351974E+04
-(PID.TID 0000.0001) %MON dynstat_eta_mean             =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON dynstat_eta_max              =   5.2422631605988E+04
+(PID.TID 0000.0001) %MON dynstat_eta_min              =  -9.3561906351910E+04
+(PID.TID 0000.0001) %MON dynstat_eta_mean             =  -1.3163581788986E-12
 (PID.TID 0000.0001) %MON dynstat_eta_sd               =   4.0030034659454E+04
 (PID.TID 0000.0001) %MON dynstat_eta_del2             =   2.1196460035927E+03
 (PID.TID 0000.0001) %MON dynstat_uvel_max             =   1.1440962865726E-01
-(PID.TID 0000.0001) %MON dynstat_uvel_min             =  -6.6866662638843E-02
-(PID.TID 0000.0001) %MON dynstat_uvel_mean            =   6.2905266060538E-04
+(PID.TID 0000.0001) %MON dynstat_uvel_min             =  -6.6866662638842E-02
+(PID.TID 0000.0001) %MON dynstat_uvel_mean            =   6.2905266060540E-04
 (PID.TID 0000.0001) %MON dynstat_uvel_sd              =   6.7149966198494E-03
-(PID.TID 0000.0001) %MON dynstat_uvel_del2            =   7.2141975689059E-05
-(PID.TID 0000.0001) %MON dynstat_vvel_max             =   8.4192217576435E-02
-(PID.TID 0000.0001) %MON dynstat_vvel_min             =  -1.1289512949990E-01
-(PID.TID 0000.0001) %MON dynstat_vvel_mean            =  -4.1845496194416E-04
+(PID.TID 0000.0001) %MON dynstat_uvel_del2            =   7.2141975689058E-05
+(PID.TID 0000.0001) %MON dynstat_vvel_max             =   8.4192217576434E-02
+(PID.TID 0000.0001) %MON dynstat_vvel_min             =  -1.1289512949989E-01
+(PID.TID 0000.0001) %MON dynstat_vvel_mean            =  -4.1845496194415E-04
 (PID.TID 0000.0001) %MON dynstat_vvel_sd              =   9.6042199868459E-03
-(PID.TID 0000.0001) %MON dynstat_vvel_del2            =   1.0178964269095E-04
+(PID.TID 0000.0001) %MON dynstat_vvel_del2            =   1.0178964269094E-04
 (PID.TID 0000.0001) %MON dynstat_wvel_max             =   1.9865803434368E+00
 (PID.TID 0000.0001) %MON dynstat_wvel_min             =  -1.7098214031002E+00
-(PID.TID 0000.0001) %MON dynstat_wvel_mean            =   3.6138871723722E-04
+(PID.TID 0000.0001) %MON dynstat_wvel_mean            =   3.6138871723714E-04
 (PID.TID 0000.0001) %MON dynstat_wvel_sd              =   2.3564797018571E-01
-(PID.TID 0000.0001) %MON dynstat_wvel_del2            =   3.3669235612346E-03
+(PID.TID 0000.0001) %MON dynstat_wvel_del2            =   3.3669235612344E-03
 (PID.TID 0000.0001) %MON dynstat_theta_max            =   2.9837633195710E+01
 (PID.TID 0000.0001) %MON dynstat_theta_min            =  -2.8166604375319E+00
 (PID.TID 0000.0001) %MON dynstat_theta_mean           =   3.6030114415812E+00
@@ -2508,60 +2619,60 @@
 (PID.TID 0000.0001) %MON forcing_fv_mean              =  -5.2783813973473E-03
 (PID.TID 0000.0001) %MON forcing_fv_sd                =   4.7923548875222E-02
 (PID.TID 0000.0001) %MON forcing_fv_del2              =   4.7743132754674E-04
-(PID.TID 0000.0001) %MON trAdv_CFL_u_max              =   6.7247361428314E-02
-(PID.TID 0000.0001) %MON trAdv_CFL_v_max              =   3.8983072518289E-02
-(PID.TID 0000.0001) %MON trAdv_CFL_w_max              =   1.3447889726578E-01
-(PID.TID 0000.0001) %MON advcfl_uvel_max              =   7.5632914747597E-02
-(PID.TID 0000.0001) %MON advcfl_vvel_max              =   4.3867426083272E-02
+(PID.TID 0000.0001) %MON trAdv_CFL_u_max              =   6.7247361428312E-02
+(PID.TID 0000.0001) %MON trAdv_CFL_v_max              =   3.8983072518288E-02
+(PID.TID 0000.0001) %MON trAdv_CFL_w_max              =   1.3447889726577E-01
+(PID.TID 0000.0001) %MON advcfl_uvel_max              =   7.5632914747594E-02
+(PID.TID 0000.0001) %MON advcfl_vvel_max              =   4.3867426083271E-02
 (PID.TID 0000.0001) %MON advcfl_wvel_max              =   1.2680502432356E-01
-(PID.TID 0000.0001) %MON advcfl_W_hf_max              =   1.4356768278402E-01
-(PID.TID 0000.0001) %MON pe_b_mean                    =  -8.7681465669827E-03
-(PID.TID 0000.0001) %MON ke_max                       =   7.7543484731227E-03
-(PID.TID 0000.0001) %MON ke_mean                      =   6.2035061794874E-05
+(PID.TID 0000.0001) %MON advcfl_W_hf_max              =   1.4356768278401E-01
+(PID.TID 0000.0001) %MON pe_b_mean                    =  -8.7681465669819E-03
+(PID.TID 0000.0001) %MON ke_max                       =   7.7543484731229E-03
+(PID.TID 0000.0001) %MON ke_mean                      =   6.2035061794873E-05
 (PID.TID 0000.0001) %MON ke_vol                       =   1.3442141716554E+22
-(PID.TID 0000.0001) %MON vort_r_min                   =  -3.2649642331380E-07
-(PID.TID 0000.0001) %MON vort_r_max                   =   2.8529600336304E-07
+(PID.TID 0000.0001) %MON vort_r_min                   =  -3.2649642331379E-07
+(PID.TID 0000.0001) %MON vort_r_max                   =   2.8529600336303E-07
 (PID.TID 0000.0001) %MON vort_a_mean                  =  -2.4598205332190E-05
 (PID.TID 0000.0001) %MON vort_a_sd                    =   7.3637311025935E-05
 (PID.TID 0000.0001) %MON vort_p_mean                  =  -2.9476182117207E-05
 (PID.TID 0000.0001) %MON vort_p_sd                    =   1.0363716941496E-04
 (PID.TID 0000.0001) %MON surfExpan_theta_mean         =  -5.4714360175446E-03
-(PID.TID 0000.0001) %MON surfExpan_salt_mean          =  -5.5696504050601E-05
+(PID.TID 0000.0001) %MON surfExpan_salt_mean          =  -5.5696504050715E-05
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // End MONITOR dynamic field statistics
 (PID.TID 0000.0001) // =======================================================
  EXTERNAL_FIELDS_LOAD,         9 : iP,iLd,i0,i1=    1    2    1    2 ; Wght=  0.9000000000  0.1000000000
- cg2d: Sum(rhs),rhsMax =   1.58206781009085E-15  1.72980617066157E+02
-(PID.TID 0000.0001)      cg2d_init_res =   3.62564600273588E-03
+ cg2d: Sum(rhs),rhsMax =   8.32667268468867E-16  1.72980617066158E+02
+(PID.TID 0000.0001)      cg2d_init_res =   3.62564600278752E-03
 (PID.TID 0000.0001)      cg2d_iters(min,last) =      -1      93
-(PID.TID 0000.0001)      cg2d_last_res =   9.17033211318653E-10
+(PID.TID 0000.0001)      cg2d_last_res =   9.17033211368891E-10
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // Begin MONITOR dynamic field statistics
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) %MON time_tsnumber                =                    10
 (PID.TID 0000.0001) %MON time_secondsf                =   1.7280000000000E+06
-(PID.TID 0000.0001) %MON dynstat_eta_max              =   5.1401699513611E+04
-(PID.TID 0000.0001) %MON dynstat_eta_min              =  -9.2837442489328E+04
-(PID.TID 0000.0001) %MON dynstat_eta_mean             =  -6.5817908944932E-12
+(PID.TID 0000.0001) %MON dynstat_eta_max              =   5.1401699513609E+04
+(PID.TID 0000.0001) %MON dynstat_eta_min              =  -9.2837442489355E+04
+(PID.TID 0000.0001) %MON dynstat_eta_mean             =  -7.4593630137590E-12
 (PID.TID 0000.0001) %MON dynstat_eta_sd               =   3.9767814255778E+04
 (PID.TID 0000.0001) %MON dynstat_eta_del2             =   2.1197046037124E+03
 (PID.TID 0000.0001) %MON dynstat_uvel_max             =   1.2618422699242E-01
-(PID.TID 0000.0001) %MON dynstat_uvel_min             =  -6.6611116270546E-02
+(PID.TID 0000.0001) %MON dynstat_uvel_min             =  -6.6611116270544E-02
 (PID.TID 0000.0001) %MON dynstat_uvel_mean            =   5.9147209406564E-04
 (PID.TID 0000.0001) %MON dynstat_uvel_sd              =   7.6321560180890E-03
-(PID.TID 0000.0001) %MON dynstat_uvel_del2            =   7.5538431016370E-05
-(PID.TID 0000.0001) %MON dynstat_vvel_max             =   8.6814941939742E-02
+(PID.TID 0000.0001) %MON dynstat_uvel_del2            =   7.5538431016369E-05
+(PID.TID 0000.0001) %MON dynstat_vvel_max             =   8.6814941939741E-02
 (PID.TID 0000.0001) %MON dynstat_vvel_min             =  -1.1925785075757E-01
-(PID.TID 0000.0001) %MON dynstat_vvel_mean            =  -3.8389545210349E-04
+(PID.TID 0000.0001) %MON dynstat_vvel_mean            =  -3.8389545210348E-04
 (PID.TID 0000.0001) %MON dynstat_vvel_sd              =   1.0120134541948E-02
 (PID.TID 0000.0001) %MON dynstat_vvel_del2            =   1.0630661062933E-04
-(PID.TID 0000.0001) %MON dynstat_wvel_max             =   2.0202671302529E+00
-(PID.TID 0000.0001) %MON dynstat_wvel_min             =  -1.6386789000802E+00
-(PID.TID 0000.0001) %MON dynstat_wvel_mean            =   4.4780372612321E-04
-(PID.TID 0000.0001) %MON dynstat_wvel_sd              =   2.4115554204456E-01
-(PID.TID 0000.0001) %MON dynstat_wvel_del2            =   3.3869784010972E-03
-(PID.TID 0000.0001) %MON dynstat_theta_max            =   2.9875480820871E+01
-(PID.TID 0000.0001) %MON dynstat_theta_min            =  -2.8864415629255E+00
+(PID.TID 0000.0001) %MON dynstat_wvel_max             =   2.0202671302526E+00
+(PID.TID 0000.0001) %MON dynstat_wvel_min             =  -1.6386789000803E+00
+(PID.TID 0000.0001) %MON dynstat_wvel_mean            =   4.4780372612320E-04
+(PID.TID 0000.0001) %MON dynstat_wvel_sd              =   2.4115554204455E-01
+(PID.TID 0000.0001) %MON dynstat_wvel_del2            =   3.3869784010970E-03
+(PID.TID 0000.0001) %MON dynstat_theta_max            =   2.9875480820872E+01
+(PID.TID 0000.0001) %MON dynstat_theta_min            =  -2.8864415629254E+00
 (PID.TID 0000.0001) %MON dynstat_theta_mean           =   3.6031259674278E+00
 (PID.TID 0000.0001) %MON dynstat_theta_sd             =   4.4018678872004E+00
 (PID.TID 0000.0001) %MON dynstat_theta_del2           =   5.0609865784699E-03
@@ -2595,58 +2706,58 @@
 (PID.TID 0000.0001) %MON forcing_fv_mean              =  -5.4104015222459E-03
 (PID.TID 0000.0001) %MON forcing_fv_sd                =   4.7320622627559E-02
 (PID.TID 0000.0001) %MON forcing_fv_del2              =   4.6652458216358E-04
-(PID.TID 0000.0001) %MON trAdv_CFL_u_max              =   7.5648276333517E-02
-(PID.TID 0000.0001) %MON trAdv_CFL_v_max              =   4.2024720556692E-02
-(PID.TID 0000.0001) %MON trAdv_CFL_w_max              =   1.4356768278402E-01
-(PID.TID 0000.0001) %MON advcfl_uvel_max              =   8.3416763034860E-02
+(PID.TID 0000.0001) %MON trAdv_CFL_u_max              =   7.5648276333515E-02
+(PID.TID 0000.0001) %MON trAdv_CFL_v_max              =   4.2024720556690E-02
+(PID.TID 0000.0001) %MON trAdv_CFL_w_max              =   1.4356768278401E-01
+(PID.TID 0000.0001) %MON advcfl_uvel_max              =   8.3416763034858E-02
 (PID.TID 0000.0001) %MON advcfl_vvel_max              =   4.6339775472443E-02
-(PID.TID 0000.0001) %MON advcfl_wvel_max              =   1.3256694646766E-01
-(PID.TID 0000.0001) %MON advcfl_W_hf_max              =   1.5009128715240E-01
-(PID.TID 0000.0001) %MON pe_b_mean                    =  -8.6699411972418E-03
+(PID.TID 0000.0001) %MON advcfl_wvel_max              =   1.3256694646765E-01
+(PID.TID 0000.0001) %MON advcfl_W_hf_max              =   1.5009128715239E-01
+(PID.TID 0000.0001) %MON pe_b_mean                    =  -8.6699411972410E-03
 (PID.TID 0000.0001) %MON ke_max                       =   9.1650129779566E-03
 (PID.TID 0000.0001) %MON ke_mean                      =   7.2524040149959E-05
 (PID.TID 0000.0001) %MON ke_vol                       =   1.3442141716554E+22
-(PID.TID 0000.0001) %MON vort_r_min                   =  -4.0778034316645E-07
-(PID.TID 0000.0001) %MON vort_r_max                   =   3.6554917400191E-07
+(PID.TID 0000.0001) %MON vort_r_min                   =  -4.0778034316644E-07
+(PID.TID 0000.0001) %MON vort_r_max                   =   3.6554917400190E-07
 (PID.TID 0000.0001) %MON vort_a_mean                  =  -2.4598205077221E-05
 (PID.TID 0000.0001) %MON vort_a_sd                    =   7.3637302586975E-05
 (PID.TID 0000.0001) %MON vort_p_mean                  =  -2.9476155187799E-05
 (PID.TID 0000.0001) %MON vort_p_sd                    =   1.0363649507534E-04
 (PID.TID 0000.0001) %MON surfExpan_theta_mean         =  -5.1014181472546E-03
-(PID.TID 0000.0001) %MON surfExpan_salt_mean          =  -5.4152595126888E-05
+(PID.TID 0000.0001) %MON surfExpan_salt_mean          =  -5.4152595126729E-05
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // End MONITOR dynamic field statistics
 (PID.TID 0000.0001) // =======================================================
  EXTERNAL_FIELDS_LOAD,        10 : iP,iLd,i0,i1=    1    2    1    2 ; Wght=  0.8333333333  0.1666666667
- cg2d: Sum(rhs),rhsMax =   2.55351295663786E-15  1.72990547019250E+02
-(PID.TID 0000.0001)      cg2d_init_res =   3.12571289817249E-03
+ cg2d: Sum(rhs),rhsMax =   6.93889390390723E-16  1.72990547019250E+02
+(PID.TID 0000.0001)      cg2d_init_res =   3.12571289812649E-03
 (PID.TID 0000.0001)      cg2d_iters(min,last) =      -1      91
-(PID.TID 0000.0001)      cg2d_last_res =   9.05209555005341E-10
+(PID.TID 0000.0001)      cg2d_last_res =   9.05209554866004E-10
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // Begin MONITOR dynamic field statistics
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) %MON time_tsnumber                =                    11
 (PID.TID 0000.0001) %MON time_secondsf                =   1.9008000000000E+06
-(PID.TID 0000.0001) %MON dynstat_eta_max              =   4.7402122554422E+04
-(PID.TID 0000.0001) %MON dynstat_eta_min              =  -9.2588187791014E+04
-(PID.TID 0000.0001) %MON dynstat_eta_mean             =   6.1430048348603E-12
+(PID.TID 0000.0001) %MON dynstat_eta_max              =   4.7402122554421E+04
+(PID.TID 0000.0001) %MON dynstat_eta_min              =  -9.2588187791103E+04
+(PID.TID 0000.0001) %MON dynstat_eta_mean             =  -8.7757211926576E-13
 (PID.TID 0000.0001) %MON dynstat_eta_sd               =   3.9593342794899E+04
 (PID.TID 0000.0001) %MON dynstat_eta_del2             =   2.1197422969114E+03
 (PID.TID 0000.0001) %MON dynstat_uvel_max             =   1.3716009022150E-01
 (PID.TID 0000.0001) %MON dynstat_uvel_min             =  -6.5547866371825E-02
 (PID.TID 0000.0001) %MON dynstat_uvel_mean            =   4.7873540435330E-04
 (PID.TID 0000.0001) %MON dynstat_uvel_sd              =   8.5866626620562E-03
-(PID.TID 0000.0001) %MON dynstat_uvel_del2            =   7.8680595282236E-05
-(PID.TID 0000.0001) %MON dynstat_vvel_max             =   8.9396239252755E-02
+(PID.TID 0000.0001) %MON dynstat_uvel_del2            =   7.8680595282235E-05
+(PID.TID 0000.0001) %MON dynstat_vvel_max             =   8.9396239252749E-02
 (PID.TID 0000.0001) %MON dynstat_vvel_min             =  -1.2376669774763E-01
-(PID.TID 0000.0001) %MON dynstat_vvel_mean            =  -2.7966597686788E-04
+(PID.TID 0000.0001) %MON dynstat_vvel_mean            =  -2.7966597686789E-04
 (PID.TID 0000.0001) %MON dynstat_vvel_sd              =   1.0506318480149E-02
 (PID.TID 0000.0001) %MON dynstat_vvel_del2            =   1.0944064980930E-04
-(PID.TID 0000.0001) %MON dynstat_wvel_max             =   2.1381462941926E+00
-(PID.TID 0000.0001) %MON dynstat_wvel_min             =  -1.5528625926270E+00
-(PID.TID 0000.0001) %MON dynstat_wvel_mean            =   4.5198001939993E-04
-(PID.TID 0000.0001) %MON dynstat_wvel_sd              =   2.4331292052639E-01
-(PID.TID 0000.0001) %MON dynstat_wvel_del2            =   3.3681681781643E-03
+(PID.TID 0000.0001) %MON dynstat_wvel_max             =   2.1381462941928E+00
+(PID.TID 0000.0001) %MON dynstat_wvel_min             =  -1.5528625926266E+00
+(PID.TID 0000.0001) %MON dynstat_wvel_mean            =   4.5198001939988E-04
+(PID.TID 0000.0001) %MON dynstat_wvel_sd              =   2.4331292052638E-01
+(PID.TID 0000.0001) %MON dynstat_wvel_del2            =   3.3681681781640E-03
 (PID.TID 0000.0001) %MON dynstat_theta_max            =   2.9908059946309E+01
 (PID.TID 0000.0001) %MON dynstat_theta_min            =  -2.9512828485531E+00
 (PID.TID 0000.0001) %MON dynstat_theta_mean           =   3.6032325657136E+00
@@ -2682,58 +2793,58 @@
 (PID.TID 0000.0001) %MON forcing_fv_mean              =  -5.5424216471445E-03
 (PID.TID 0000.0001) %MON forcing_fv_sd                =   4.6771332121489E-02
 (PID.TID 0000.0001) %MON forcing_fv_del2              =   4.5745971542986E-04
-(PID.TID 0000.0001) %MON trAdv_CFL_u_max              =   8.3433705576039E-02
+(PID.TID 0000.0001) %MON trAdv_CFL_u_max              =   8.3433705576037E-02
 (PID.TID 0000.0001) %MON trAdv_CFL_v_max              =   4.4393215849787E-02
-(PID.TID 0000.0001) %MON trAdv_CFL_w_max              =   1.5009128715240E-01
-(PID.TID 0000.0001) %MON advcfl_uvel_max              =   9.0535560713407E-02
-(PID.TID 0000.0001) %MON advcfl_vvel_max              =   4.8091768786358E-02
-(PID.TID 0000.0001) %MON advcfl_wvel_max              =   1.3587529180559E-01
+(PID.TID 0000.0001) %MON trAdv_CFL_w_max              =   1.5009128715239E-01
+(PID.TID 0000.0001) %MON advcfl_uvel_max              =   9.0535560713408E-02
+(PID.TID 0000.0001) %MON advcfl_vvel_max              =   4.8091768786357E-02
+(PID.TID 0000.0001) %MON advcfl_wvel_max              =   1.3587529180560E-01
 (PID.TID 0000.0001) %MON advcfl_W_hf_max              =   1.5383697054744E-01
-(PID.TID 0000.0001) %MON pe_b_mean                    =  -8.4961425725624E-03
-(PID.TID 0000.0001) %MON ke_max                       =   1.0602787091885E-02
-(PID.TID 0000.0001) %MON ke_mean                      =   8.3021418183642E-05
+(PID.TID 0000.0001) %MON pe_b_mean                    =  -8.4961425725619E-03
+(PID.TID 0000.0001) %MON ke_max                       =   1.0602787091884E-02
+(PID.TID 0000.0001) %MON ke_mean                      =   8.3021418183641E-05
 (PID.TID 0000.0001) %MON ke_vol                       =   1.3442141716554E+22
-(PID.TID 0000.0001) %MON vort_r_min                   =  -4.6978574787137E-07
-(PID.TID 0000.0001) %MON vort_r_max                   =   4.2605322039884E-07
+(PID.TID 0000.0001) %MON vort_r_min                   =  -4.6978574787136E-07
+(PID.TID 0000.0001) %MON vort_r_max                   =   4.2605322039883E-07
 (PID.TID 0000.0001) %MON vort_a_mean                  =  -2.4598204856256E-05
 (PID.TID 0000.0001) %MON vort_a_sd                    =   7.3637275827345E-05
 (PID.TID 0000.0001) %MON vort_p_mean                  =  -2.9476129508998E-05
 (PID.TID 0000.0001) %MON vort_p_sd                    =   1.0363602292624E-04
-(PID.TID 0000.0001) %MON surfExpan_theta_mean         =  -3.7771788845284E-03
-(PID.TID 0000.0001) %MON surfExpan_salt_mean          =  -5.8044415398959E-05
+(PID.TID 0000.0001) %MON surfExpan_theta_mean         =  -3.7771788845285E-03
+(PID.TID 0000.0001) %MON surfExpan_salt_mean          =  -5.8044415398755E-05
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // End MONITOR dynamic field statistics
 (PID.TID 0000.0001) // =======================================================
  EXTERNAL_FIELDS_LOAD,        11 : iP,iLd,i0,i1=    1    2    1    2 ; Wght=  0.7666666667  0.2333333333
- cg2d: Sum(rhs),rhsMax =  -1.13797860024079E-15  1.72996802714390E+02
-(PID.TID 0000.0001)      cg2d_init_res =   2.73305186023690E-03
+ cg2d: Sum(rhs),rhsMax =  -1.55431223447522E-15  1.72996802714391E+02
+(PID.TID 0000.0001)      cg2d_init_res =   2.73305186016335E-03
 (PID.TID 0000.0001)      cg2d_iters(min,last) =      -1      83
-(PID.TID 0000.0001)      cg2d_last_res =   9.98035684153240E-10
+(PID.TID 0000.0001)      cg2d_last_res =   9.98035684134013E-10
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // Begin MONITOR dynamic field statistics
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) %MON time_tsnumber                =                    12
 (PID.TID 0000.0001) %MON time_secondsf                =   2.0736000000000E+06
-(PID.TID 0000.0001) %MON dynstat_eta_max              =   4.2927818965589E+04
-(PID.TID 0000.0001) %MON dynstat_eta_min              =  -9.2542317911141E+04
-(PID.TID 0000.0001) %MON dynstat_eta_mean             =  -2.1939302981644E-12
+(PID.TID 0000.0001) %MON dynstat_eta_max              =   4.2927818965588E+04
+(PID.TID 0000.0001) %MON dynstat_eta_min              =  -9.2542317911162E+04
+(PID.TID 0000.0001) %MON dynstat_eta_mean             =  -6.1430048348603E-12
 (PID.TID 0000.0001) %MON dynstat_eta_sd               =   3.9501885498860E+04
 (PID.TID 0000.0001) %MON dynstat_eta_del2             =   2.1197579250748E+03
-(PID.TID 0000.0001) %MON dynstat_uvel_max             =   1.4889619726010E-01
-(PID.TID 0000.0001) %MON dynstat_uvel_min             =  -7.0063863253466E-02
-(PID.TID 0000.0001) %MON dynstat_uvel_mean            =   3.4362315387815E-04
+(PID.TID 0000.0001) %MON dynstat_uvel_max             =   1.4889619726009E-01
+(PID.TID 0000.0001) %MON dynstat_uvel_min             =  -7.0063863253465E-02
+(PID.TID 0000.0001) %MON dynstat_uvel_mean            =   3.4362315387814E-04
 (PID.TID 0000.0001) %MON dynstat_uvel_sd              =   9.5690687602479E-03
 (PID.TID 0000.0001) %MON dynstat_uvel_del2            =   8.1757871701985E-05
-(PID.TID 0000.0001) %MON dynstat_vvel_max             =   9.0696926768294E-02
+(PID.TID 0000.0001) %MON dynstat_vvel_max             =   9.0696926768290E-02
 (PID.TID 0000.0001) %MON dynstat_vvel_min             =  -1.2706227278624E-01
 (PID.TID 0000.0001) %MON dynstat_vvel_mean            =  -1.5585156264017E-04
 (PID.TID 0000.0001) %MON dynstat_vvel_sd              =   1.0767581126489E-02
 (PID.TID 0000.0001) %MON dynstat_vvel_del2            =   1.1132035076320E-04
-(PID.TID 0000.0001) %MON dynstat_wvel_max             =   2.2833731057933E+00
-(PID.TID 0000.0001) %MON dynstat_wvel_min             =  -1.4708936747654E+00
-(PID.TID 0000.0001) %MON dynstat_wvel_mean            =   3.9628002648600E-04
+(PID.TID 0000.0001) %MON dynstat_wvel_max             =   2.2833731057931E+00
+(PID.TID 0000.0001) %MON dynstat_wvel_min             =  -1.4708936747652E+00
+(PID.TID 0000.0001) %MON dynstat_wvel_mean            =   3.9628002648619E-04
 (PID.TID 0000.0001) %MON dynstat_wvel_sd              =   2.4267945697921E-01
-(PID.TID 0000.0001) %MON dynstat_wvel_del2            =   3.3215917655210E-03
+(PID.TID 0000.0001) %MON dynstat_wvel_del2            =   3.3215917655208E-03
 (PID.TID 0000.0001) %MON dynstat_theta_max            =   2.9935564938161E+01
 (PID.TID 0000.0001) %MON dynstat_theta_min            =  -3.0112254286972E+00
 (PID.TID 0000.0001) %MON dynstat_theta_mean           =   3.6033327354346E+00
@@ -2769,58 +2880,58 @@
 (PID.TID 0000.0001) %MON forcing_fv_mean              =  -5.6744417720431E-03
 (PID.TID 0000.0001) %MON forcing_fv_sd                =   4.6277587280153E-02
 (PID.TID 0000.0001) %MON forcing_fv_del2              =   4.5034796430965E-04
-(PID.TID 0000.0001) %MON trAdv_CFL_u_max              =   9.0553949133309E-02
-(PID.TID 0000.0001) %MON trAdv_CFL_v_max              =   4.6071614516139E-02
+(PID.TID 0000.0001) %MON trAdv_CFL_u_max              =   9.0553949133310E-02
+(PID.TID 0000.0001) %MON trAdv_CFL_v_max              =   4.6071614516138E-02
 (PID.TID 0000.0001) %MON trAdv_CFL_w_max              =   1.5383697054744E-01
-(PID.TID 0000.0001) %MON advcfl_uvel_max              =   9.6966975399877E-02
-(PID.TID 0000.0001) %MON advcfl_vvel_max              =   4.9372323537024E-02
+(PID.TID 0000.0001) %MON advcfl_uvel_max              =   9.6966975399878E-02
+(PID.TID 0000.0001) %MON advcfl_vvel_max              =   4.9372323537023E-02
 (PID.TID 0000.0001) %MON advcfl_wvel_max              =   1.3658218905275E-01
 (PID.TID 0000.0001) %MON advcfl_W_hf_max              =   1.5463731422689E-01
-(PID.TID 0000.0001) %MON pe_b_mean                    =  -8.2948330943560E-03
-(PID.TID 0000.0001) %MON ke_max                       =   1.2028672775156E-02
+(PID.TID 0000.0001) %MON pe_b_mean                    =  -8.2948330943551E-03
+(PID.TID 0000.0001) %MON ke_max                       =   1.2028672775155E-02
 (PID.TID 0000.0001) %MON ke_mean                      =   9.3517378904218E-05
 (PID.TID 0000.0001) %MON ke_vol                       =   1.3442141716554E+22
 (PID.TID 0000.0001) %MON vort_r_min                   =  -5.0772019851498E-07
-(PID.TID 0000.0001) %MON vort_r_max                   =   4.6190586861040E-07
+(PID.TID 0000.0001) %MON vort_r_max                   =   4.6190586861039E-07
 (PID.TID 0000.0001) %MON vort_a_mean                  =  -2.4598204699154E-05
 (PID.TID 0000.0001) %MON vort_a_sd                    =   7.3637242859274E-05
 (PID.TID 0000.0001) %MON vort_p_mean                  =  -2.9476108627994E-05
 (PID.TID 0000.0001) %MON vort_p_sd                    =   1.0363584211432E-04
-(PID.TID 0000.0001) %MON surfExpan_theta_mean         =  -2.0971996953081E-03
-(PID.TID 0000.0001) %MON surfExpan_salt_mean          =  -6.3236738731959E-05
+(PID.TID 0000.0001) %MON surfExpan_theta_mean         =  -2.0971996953086E-03
+(PID.TID 0000.0001) %MON surfExpan_salt_mean          =  -6.3236738731837E-05
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // End MONITOR dynamic field statistics
 (PID.TID 0000.0001) // =======================================================
  EXTERNAL_FIELDS_LOAD,        12 : iP,iLd,i0,i1=    1    2    1    2 ; Wght=  0.7000000000  0.3000000000
- cg2d: Sum(rhs),rhsMax =   3.13638004456607E-15  1.72999553651185E+02
-(PID.TID 0000.0001)      cg2d_init_res =   2.58808844428129E-03
+ cg2d: Sum(rhs),rhsMax =  -1.99840144432528E-15  1.72999553651185E+02
+(PID.TID 0000.0001)      cg2d_init_res =   2.58808844440486E-03
 (PID.TID 0000.0001)      cg2d_iters(min,last) =      -1      88
-(PID.TID 0000.0001)      cg2d_last_res =   8.44926786497561E-10
+(PID.TID 0000.0001)      cg2d_last_res =   8.44926786649218E-10
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // Begin MONITOR dynamic field statistics
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) %MON time_tsnumber                =                    13
 (PID.TID 0000.0001) %MON time_secondsf                =   2.2464000000000E+06
 (PID.TID 0000.0001) %MON dynstat_eta_max              =   4.2917553730630E+04
-(PID.TID 0000.0001) %MON dynstat_eta_min              =  -9.2458918217067E+04
-(PID.TID 0000.0001) %MON dynstat_eta_mean             =   4.3878605963288E-12
+(PID.TID 0000.0001) %MON dynstat_eta_min              =  -9.2458918217054E+04
+(PID.TID 0000.0001) %MON dynstat_eta_mean             =  -8.7757211926576E-13
 (PID.TID 0000.0001) %MON dynstat_eta_sd               =   3.9481545649688E+04
 (PID.TID 0000.0001) %MON dynstat_eta_del2             =   2.1197530937070E+03
 (PID.TID 0000.0001) %MON dynstat_uvel_max             =   1.5947646288974E-01
 (PID.TID 0000.0001) %MON dynstat_uvel_min             =  -7.4480540822481E-02
 (PID.TID 0000.0001) %MON dynstat_uvel_mean            =   2.3254871749099E-04
 (PID.TID 0000.0001) %MON dynstat_uvel_sd              =   1.0557533078202E-02
-(PID.TID 0000.0001) %MON dynstat_uvel_del2            =   8.4894609841479E-05
-(PID.TID 0000.0001) %MON dynstat_vvel_max             =   9.0836368799295E-02
+(PID.TID 0000.0001) %MON dynstat_uvel_del2            =   8.4894609841480E-05
+(PID.TID 0000.0001) %MON dynstat_vvel_max             =   9.0836368799292E-02
 (PID.TID 0000.0001) %MON dynstat_vvel_min             =  -1.3042073859948E-01
-(PID.TID 0000.0001) %MON dynstat_vvel_mean            =  -5.1237081143452E-05
+(PID.TID 0000.0001) %MON dynstat_vvel_mean            =  -5.1237081143456E-05
 (PID.TID 0000.0001) %MON dynstat_vvel_sd              =   1.0909987288106E-02
 (PID.TID 0000.0001) %MON dynstat_vvel_del2            =   1.1209849306388E-04
-(PID.TID 0000.0001) %MON dynstat_wvel_max             =   2.4174595901056E+00
-(PID.TID 0000.0001) %MON dynstat_wvel_min             =  -1.4402942198368E+00
-(PID.TID 0000.0001) %MON dynstat_wvel_mean            =   3.0807346765360E-04
-(PID.TID 0000.0001) %MON dynstat_wvel_sd              =   2.3977726858664E-01
-(PID.TID 0000.0001) %MON dynstat_wvel_del2            =   3.2566876790548E-03
+(PID.TID 0000.0001) %MON dynstat_wvel_max             =   2.4174595901059E+00
+(PID.TID 0000.0001) %MON dynstat_wvel_min             =  -1.4402942198364E+00
+(PID.TID 0000.0001) %MON dynstat_wvel_mean            =   3.0807346765347E-04
+(PID.TID 0000.0001) %MON dynstat_wvel_sd              =   2.3977726858663E-01
+(PID.TID 0000.0001) %MON dynstat_wvel_del2            =   3.2566876790546E-03
 (PID.TID 0000.0001) %MON dynstat_theta_max            =   2.9958177879693E+01
 (PID.TID 0000.0001) %MON dynstat_theta_min            =  -3.0663450175066E+00
 (PID.TID 0000.0001) %MON dynstat_theta_mean           =   3.6034280763924E+00
@@ -2856,58 +2967,58 @@
 (PID.TID 0000.0001) %MON forcing_fv_mean              =  -5.8064618969417E-03
 (PID.TID 0000.0001) %MON forcing_fv_sd                =   4.5841182947436E-02
 (PID.TID 0000.0001) %MON forcing_fv_del2              =   4.4528292007770E-04
-(PID.TID 0000.0001) %MON trAdv_CFL_u_max              =   9.6986670086100E-02
-(PID.TID 0000.0001) %MON trAdv_CFL_v_max              =   4.7800495387989E-02
+(PID.TID 0000.0001) %MON trAdv_CFL_u_max              =   9.6986670086101E-02
+(PID.TID 0000.0001) %MON trAdv_CFL_v_max              =   4.7800495387987E-02
 (PID.TID 0000.0001) %MON trAdv_CFL_w_max              =   1.5463731422689E-01
-(PID.TID 0000.0001) %MON advcfl_uvel_max              =   1.0268833926036E-01
-(PID.TID 0000.0001) %MON advcfl_vvel_max              =   5.0677315625418E-02
-(PID.TID 0000.0001) %MON advcfl_wvel_max              =   1.3458746813602E-01
-(PID.TID 0000.0001) %MON advcfl_W_hf_max              =   1.5237890639690E-01
-(PID.TID 0000.0001) %MON pe_b_mean                    =  -8.1012326778976E-03
-(PID.TID 0000.0001) %MON ke_max                       =   1.3411840221296E-02
-(PID.TID 0000.0001) %MON ke_mean                      =   1.0387346493843E-04
+(PID.TID 0000.0001) %MON advcfl_uvel_max              =   1.0268833926037E-01
+(PID.TID 0000.0001) %MON advcfl_vvel_max              =   5.0677315625417E-02
+(PID.TID 0000.0001) %MON advcfl_wvel_max              =   1.3458746813606E-01
+(PID.TID 0000.0001) %MON advcfl_W_hf_max              =   1.5237890639694E-01
+(PID.TID 0000.0001) %MON pe_b_mean                    =  -8.1012326778967E-03
+(PID.TID 0000.0001) %MON ke_max                       =   1.3411840221295E-02
+(PID.TID 0000.0001) %MON ke_mean                      =   1.0387346493842E-04
 (PID.TID 0000.0001) %MON ke_vol                       =   1.3442141716554E+22
-(PID.TID 0000.0001) %MON vort_r_min                   =  -5.2097406484711E-07
-(PID.TID 0000.0001) %MON vort_r_max                   =   4.7253970103410E-07
+(PID.TID 0000.0001) %MON vort_r_min                   =  -5.2097406484710E-07
+(PID.TID 0000.0001) %MON vort_r_max                   =   4.7253970103409E-07
 (PID.TID 0000.0001) %MON vort_a_mean                  =  -2.4598204622524E-05
 (PID.TID 0000.0001) %MON vort_a_sd                    =   7.3637214395778E-05
 (PID.TID 0000.0001) %MON vort_p_mean                  =  -2.9476093773104E-05
 (PID.TID 0000.0001) %MON vort_p_sd                    =   1.0363595650660E-04
-(PID.TID 0000.0001) %MON surfExpan_theta_mean         =  -5.7117828482748E-04
-(PID.TID 0000.0001) %MON surfExpan_salt_mean          =  -6.1888230947213E-05
+(PID.TID 0000.0001) %MON surfExpan_theta_mean         =  -5.7117828482705E-04
+(PID.TID 0000.0001) %MON surfExpan_salt_mean          =  -6.1888230947125E-05
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // End MONITOR dynamic field statistics
 (PID.TID 0000.0001) // =======================================================
  EXTERNAL_FIELDS_LOAD,        13 : iP,iLd,i0,i1=    1    2    1    2 ; Wght=  0.6333333333  0.3666666667
- cg2d: Sum(rhs),rhsMax =   1.66533453693773E-15  1.72999587042744E+02
-(PID.TID 0000.0001)      cg2d_init_res =   2.58912943887929E-03
+ cg2d: Sum(rhs),rhsMax =  -1.27675647831893E-15  1.72999587042741E+02
+(PID.TID 0000.0001)      cg2d_init_res =   2.58912943910053E-03
 (PID.TID 0000.0001)      cg2d_iters(min,last) =      -1      88
-(PID.TID 0000.0001)      cg2d_last_res =   9.90963790117683E-10
+(PID.TID 0000.0001)      cg2d_last_res =   9.90963790233478E-10
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // Begin MONITOR dynamic field statistics
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) %MON time_tsnumber                =                    14
 (PID.TID 0000.0001) %MON time_secondsf                =   2.4192000000000E+06
-(PID.TID 0000.0001) %MON dynstat_eta_max              =   4.3098096779110E+04
-(PID.TID 0000.0001) %MON dynstat_eta_min              =  -9.2545876462794E+04
-(PID.TID 0000.0001) %MON dynstat_eta_mean             =   4.3878605963288E-13
+(PID.TID 0000.0001) %MON dynstat_eta_max              =   4.3098096779108E+04
+(PID.TID 0000.0001) %MON dynstat_eta_min              =  -9.2545876462921E+04
+(PID.TID 0000.0001) %MON dynstat_eta_mean             =   3.5102884770630E-12
 (PID.TID 0000.0001) %MON dynstat_eta_sd               =   3.9517136050476E+04
 (PID.TID 0000.0001) %MON dynstat_eta_del2             =   2.1197303168617E+03
 (PID.TID 0000.0001) %MON dynstat_uvel_max             =   1.6872403766365E-01
-(PID.TID 0000.0001) %MON dynstat_uvel_min             =  -7.9961644580613E-02
-(PID.TID 0000.0001) %MON dynstat_uvel_mean            =   1.7585963315777E-04
+(PID.TID 0000.0001) %MON dynstat_uvel_min             =  -7.9961644580612E-02
+(PID.TID 0000.0001) %MON dynstat_uvel_mean            =   1.7585963315775E-04
 (PID.TID 0000.0001) %MON dynstat_uvel_sd              =   1.1526662291912E-02
-(PID.TID 0000.0001) %MON dynstat_uvel_del2            =   8.8158630743723E-05
-(PID.TID 0000.0001) %MON dynstat_vvel_max             =   9.0027971199571E-02
+(PID.TID 0000.0001) %MON dynstat_uvel_del2            =   8.8158630743724E-05
+(PID.TID 0000.0001) %MON dynstat_vvel_max             =   9.0027971199566E-02
 (PID.TID 0000.0001) %MON dynstat_vvel_min             =  -1.3227618090051E-01
-(PID.TID 0000.0001) %MON dynstat_vvel_mean            =   1.2748018923345E-05
+(PID.TID 0000.0001) %MON dynstat_vvel_mean            =   1.2748018923346E-05
 (PID.TID 0000.0001) %MON dynstat_vvel_sd              =   1.0942035905529E-02
 (PID.TID 0000.0001) %MON dynstat_vvel_del2            =   1.1195140649970E-04
 (PID.TID 0000.0001) %MON dynstat_wvel_max             =   2.5417508950723E+00
-(PID.TID 0000.0001) %MON dynstat_wvel_min             =  -1.5090130095409E+00
-(PID.TID 0000.0001) %MON dynstat_wvel_mean            =   2.1326808266534E-04
-(PID.TID 0000.0001) %MON dynstat_wvel_sd              =   2.3509711693581E-01
-(PID.TID 0000.0001) %MON dynstat_wvel_del2            =   3.1813717252793E-03
+(PID.TID 0000.0001) %MON dynstat_wvel_min             =  -1.5090130095403E+00
+(PID.TID 0000.0001) %MON dynstat_wvel_mean            =   2.1326808266524E-04
+(PID.TID 0000.0001) %MON dynstat_wvel_sd              =   2.3509711693580E-01
+(PID.TID 0000.0001) %MON dynstat_wvel_del2            =   3.1813717252790E-03
 (PID.TID 0000.0001) %MON dynstat_theta_max            =   2.9976011782421E+01
 (PID.TID 0000.0001) %MON dynstat_theta_min            =  -3.1167056847970E+00
 (PID.TID 0000.0001) %MON dynstat_theta_mean           =   3.6035212672097E+00
@@ -2943,14 +3054,14 @@
 (PID.TID 0000.0001) %MON forcing_fv_mean              =  -5.9384820218404E-03
 (PID.TID 0000.0001) %MON forcing_fv_sd                =   4.5463770378877E-02
 (PID.TID 0000.0001) %MON forcing_fv_del2              =   4.4233489700273E-04
-(PID.TID 0000.0001) %MON trAdv_CFL_u_max              =   1.0270919599650E-01
+(PID.TID 0000.0001) %MON trAdv_CFL_u_max              =   1.0270919599651E-01
 (PID.TID 0000.0001) %MON trAdv_CFL_v_max              =   4.9063941461290E-02
-(PID.TID 0000.0001) %MON trAdv_CFL_w_max              =   1.5237890639690E-01
+(PID.TID 0000.0001) %MON trAdv_CFL_w_max              =   1.5237890639694E-01
 (PID.TID 0000.0001) %MON advcfl_uvel_max              =   1.0766326176730E-01
 (PID.TID 0000.0001) %MON advcfl_vvel_max              =   5.1398280988163E-02
-(PID.TID 0000.0001) %MON advcfl_wvel_max              =   1.2985135746429E-01
-(PID.TID 0000.0001) %MON advcfl_W_hf_max              =   1.4701671796488E-01
-(PID.TID 0000.0001) %MON pe_b_mean                    =  -7.9340062970494E-03
+(PID.TID 0000.0001) %MON advcfl_wvel_max              =   1.2985135746430E-01
+(PID.TID 0000.0001) %MON advcfl_W_hf_max              =   1.4701671796489E-01
+(PID.TID 0000.0001) %MON pe_b_mean                    =  -7.9340062970487E-03
 (PID.TID 0000.0001) %MON ke_max                       =   1.4723583659079E-02
 (PID.TID 0000.0001) %MON ke_mean                      =   1.1386963496352E-04
 (PID.TID 0000.0001) %MON ke_vol                       =   1.3442141716554E+22
@@ -2960,43 +3071,43 @@
 (PID.TID 0000.0001) %MON vort_a_sd                    =   7.3637197511444E-05
 (PID.TID 0000.0001) %MON vort_p_mean                  =  -2.9476085096091E-05
 (PID.TID 0000.0001) %MON vort_p_sd                    =   1.0363629907598E-04
-(PID.TID 0000.0001) %MON surfExpan_theta_mean         =   4.7298474677753E-04
-(PID.TID 0000.0001) %MON surfExpan_salt_mean          =  -4.8392308777012E-05
+(PID.TID 0000.0001) %MON surfExpan_theta_mean         =   4.7298474677790E-04
+(PID.TID 0000.0001) %MON surfExpan_salt_mean          =  -4.8392308777140E-05
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // End MONITOR dynamic field statistics
 (PID.TID 0000.0001) // =======================================================
  EXTERNAL_FIELDS_LOAD,        14 : iP,iLd,i0,i1=    1    2    1    2 ; Wght=  0.5666666667  0.4333333333
- cg2d: Sum(rhs),rhsMax =   1.72084568816899E-15  1.72997879294398E+02
-(PID.TID 0000.0001)      cg2d_init_res =   2.55393534973202E-03
+ cg2d: Sum(rhs),rhsMax =   3.52495810318487E-15  1.72997879294400E+02
+(PID.TID 0000.0001)      cg2d_init_res =   2.55393534955880E-03
 (PID.TID 0000.0001)      cg2d_iters(min,last) =      -1      89
-(PID.TID 0000.0001)      cg2d_last_res =   8.22634926779474E-10
+(PID.TID 0000.0001)      cg2d_last_res =   8.22634926741489E-10
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // Begin MONITOR dynamic field statistics
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) %MON time_tsnumber                =                    15
 (PID.TID 0000.0001) %MON time_secondsf                =   2.5920000000000E+06
-(PID.TID 0000.0001) %MON dynstat_eta_max              =   4.4307405417980E+04
-(PID.TID 0000.0001) %MON dynstat_eta_min              =  -9.2734807836939E+04
-(PID.TID 0000.0001) %MON dynstat_eta_mean             =  -3.5102884770630E-12
+(PID.TID 0000.0001) %MON dynstat_eta_max              =   4.4307405417979E+04
+(PID.TID 0000.0001) %MON dynstat_eta_min              =  -9.2734807836944E+04
+(PID.TID 0000.0001) %MON dynstat_eta_mean             =  -7.4593630137590E-12
 (PID.TID 0000.0001) %MON dynstat_eta_sd               =   3.9585907320650E+04
 (PID.TID 0000.0001) %MON dynstat_eta_del2             =   2.1196933838500E+03
 (PID.TID 0000.0001) %MON dynstat_uvel_max             =   1.7653272410717E-01
-(PID.TID 0000.0001) %MON dynstat_uvel_min             =  -8.4487739896563E-02
-(PID.TID 0000.0001) %MON dynstat_uvel_mean            =   1.8388850504784E-04
+(PID.TID 0000.0001) %MON dynstat_uvel_min             =  -8.4487739896561E-02
+(PID.TID 0000.0001) %MON dynstat_uvel_mean            =   1.8388850504782E-04
 (PID.TID 0000.0001) %MON dynstat_uvel_sd              =   1.2455323268157E-02
 (PID.TID 0000.0001) %MON dynstat_uvel_del2            =   9.1576102450193E-05
-(PID.TID 0000.0001) %MON dynstat_vvel_max             =   8.8300836045439E-02
+(PID.TID 0000.0001) %MON dynstat_vvel_max             =   8.8300836045436E-02
 (PID.TID 0000.0001) %MON dynstat_vvel_min             =  -1.3263445837931E-01
-(PID.TID 0000.0001) %MON dynstat_vvel_mean            =   3.2283057390865E-05
+(PID.TID 0000.0001) %MON dynstat_vvel_mean            =   3.2283057390864E-05
 (PID.TID 0000.0001) %MON dynstat_vvel_sd              =   1.0876195866328E-02
 (PID.TID 0000.0001) %MON dynstat_vvel_del2            =   1.1108194737941E-04
-(PID.TID 0000.0001) %MON dynstat_wvel_max             =   2.6566268401737E+00
-(PID.TID 0000.0001) %MON dynstat_wvel_min             =  -1.5534604932287E+00
-(PID.TID 0000.0001) %MON dynstat_wvel_mean            =   1.3002265934153E-04
+(PID.TID 0000.0001) %MON dynstat_wvel_max             =   2.6566268401740E+00
+(PID.TID 0000.0001) %MON dynstat_wvel_min             =  -1.5534604932283E+00
+(PID.TID 0000.0001) %MON dynstat_wvel_mean            =   1.3002265934165E-04
 (PID.TID 0000.0001) %MON dynstat_wvel_sd              =   2.2915511149120E-01
-(PID.TID 0000.0001) %MON dynstat_wvel_del2            =   3.1033063764742E-03
+(PID.TID 0000.0001) %MON dynstat_wvel_del2            =   3.1033063764740E-03
 (PID.TID 0000.0001) %MON dynstat_theta_max            =   2.9989122017326E+01
-(PID.TID 0000.0001) %MON dynstat_theta_min            =  -3.1623682619804E+00
+(PID.TID 0000.0001) %MON dynstat_theta_min            =  -3.1623682619803E+00
 (PID.TID 0000.0001) %MON dynstat_theta_mean           =   3.6036138498407E+00
 (PID.TID 0000.0001) %MON dynstat_theta_sd             =   4.4028219565429E+00
 (PID.TID 0000.0001) %MON dynstat_theta_del2           =   5.0180074354673E-03
@@ -3032,56 +3143,56 @@
 (PID.TID 0000.0001) %MON forcing_fv_del2              =   4.4154630056010E-04
 (PID.TID 0000.0001) %MON trAdv_CFL_u_max              =   1.0768512894578E-01
 (PID.TID 0000.0001) %MON trAdv_CFL_v_max              =   4.9761954012208E-02
-(PID.TID 0000.0001) %MON trAdv_CFL_w_max              =   1.4701671796488E-01
-(PID.TID 0000.0001) %MON advcfl_uvel_max              =   1.1184043717121E-01
-(PID.TID 0000.0001) %MON advcfl_vvel_max              =   5.1537496124263E-02
+(PID.TID 0000.0001) %MON trAdv_CFL_w_max              =   1.4701671796489E-01
+(PID.TID 0000.0001) %MON advcfl_uvel_max              =   1.1184043717122E-01
+(PID.TID 0000.0001) %MON advcfl_vvel_max              =   5.1537496124265E-02
 (PID.TID 0000.0001) %MON advcfl_wvel_max              =   1.2240516084365E-01
-(PID.TID 0000.0001) %MON advcfl_W_hf_max              =   1.3858619086169E-01
-(PID.TID 0000.0001) %MON pe_b_mean                    =  -7.8045187754898E-03
+(PID.TID 0000.0001) %MON advcfl_W_hf_max              =   1.3858619086170E-01
+(PID.TID 0000.0001) %MON pe_b_mean                    =  -7.8045187754891E-03
 (PID.TID 0000.0001) %MON ke_max                       =   1.5940426447385E-02
 (PID.TID 0000.0001) %MON ke_mean                      =   1.2331452107423E-04
 (PID.TID 0000.0001) %MON ke_vol                       =   1.3442141716554E+22
-(PID.TID 0000.0001) %MON vort_r_min                   =  -4.8925809873757E-07
+(PID.TID 0000.0001) %MON vort_r_min                   =  -4.8925809873756E-07
 (PID.TID 0000.0001) %MON vort_r_max                   =   5.0030040170823E-07
 (PID.TID 0000.0001) %MON vort_a_mean                  =  -2.4598204705360E-05
 (PID.TID 0000.0001) %MON vort_a_sd                    =   7.3637194740220E-05
 (PID.TID 0000.0001) %MON vort_p_mean                  =  -2.9476081821673E-05
 (PID.TID 0000.0001) %MON vort_p_sd                    =   1.0363675964763E-04
-(PID.TID 0000.0001) %MON surfExpan_theta_mean         =   9.2160626722193E-04
-(PID.TID 0000.0001) %MON surfExpan_salt_mean          =  -2.2164438603584E-05
+(PID.TID 0000.0001) %MON surfExpan_theta_mean         =   9.2160626722199E-04
+(PID.TID 0000.0001) %MON surfExpan_salt_mean          =  -2.2164438603640E-05
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // End MONITOR dynamic field statistics
 (PID.TID 0000.0001) // =======================================================
  EXTERNAL_FIELDS_LOAD,        15 : iP,iLd,i0,i1=    1    2    1    2 ; Wght=  0.5000000000  0.5000000000
- cg2d: Sum(rhs),rhsMax =   8.88178419700125E-16  1.72995258228741E+02
-(PID.TID 0000.0001)      cg2d_init_res =   2.44753173851391E-03
+ cg2d: Sum(rhs),rhsMax =   2.05391259555654E-15  1.72995258228738E+02
+(PID.TID 0000.0001)      cg2d_init_res =   2.44753173867869E-03
 (PID.TID 0000.0001)      cg2d_iters(min,last) =      -1      89
-(PID.TID 0000.0001)      cg2d_last_res =   7.72080159938727E-10
+(PID.TID 0000.0001)      cg2d_last_res =   7.72080160047317E-10
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // Begin MONITOR dynamic field statistics
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) %MON time_tsnumber                =                    16
 (PID.TID 0000.0001) %MON time_secondsf                =   2.7648000000000E+06
 (PID.TID 0000.0001) %MON dynstat_eta_max              =   4.6809622439001E+04
-(PID.TID 0000.0001) %MON dynstat_eta_min              =  -9.2852245565480E+04
-(PID.TID 0000.0001) %MON dynstat_eta_mean             =   2.1939302981644E-12
+(PID.TID 0000.0001) %MON dynstat_eta_min              =  -9.2852245565486E+04
+(PID.TID 0000.0001) %MON dynstat_eta_mean             =  -2.6327163577973E-12
 (PID.TID 0000.0001) %MON dynstat_eta_sd               =   3.9658699312391E+04
 (PID.TID 0000.0001) %MON dynstat_eta_del2             =   2.1196458902062E+03
 (PID.TID 0000.0001) %MON dynstat_uvel_max             =   1.8361428610375E-01
-(PID.TID 0000.0001) %MON dynstat_uvel_min             =  -8.7776569233698E-02
-(PID.TID 0000.0001) %MON dynstat_uvel_mean            =   2.4882043925916E-04
+(PID.TID 0000.0001) %MON dynstat_uvel_min             =  -8.7776569233695E-02
+(PID.TID 0000.0001) %MON dynstat_uvel_mean            =   2.4882043925915E-04
 (PID.TID 0000.0001) %MON dynstat_uvel_sd              =   1.3328797749521E-02
 (PID.TID 0000.0001) %MON dynstat_uvel_del2            =   9.5135660033349E-05
-(PID.TID 0000.0001) %MON dynstat_vvel_max             =   8.9032274232125E-02
-(PID.TID 0000.0001) %MON dynstat_vvel_min             =  -1.3150415368443E-01
-(PID.TID 0000.0001) %MON dynstat_vvel_mean            =   1.7161802847284E-05
+(PID.TID 0000.0001) %MON dynstat_vvel_max             =   8.9032274232122E-02
+(PID.TID 0000.0001) %MON dynstat_vvel_min             =  -1.3150415368444E-01
+(PID.TID 0000.0001) %MON dynstat_vvel_mean            =   1.7161802847313E-05
 (PID.TID 0000.0001) %MON dynstat_vvel_sd              =   1.0729503908365E-02
 (PID.TID 0000.0001) %MON dynstat_vvel_del2            =   1.0971380434599E-04
-(PID.TID 0000.0001) %MON dynstat_wvel_max             =   2.7616701480611E+00
-(PID.TID 0000.0001) %MON dynstat_wvel_min             =  -1.5752487767514E+00
-(PID.TID 0000.0001) %MON dynstat_wvel_mean            =   6.6535608071999E-05
+(PID.TID 0000.0001) %MON dynstat_wvel_max             =   2.7616701480613E+00
+(PID.TID 0000.0001) %MON dynstat_wvel_min             =  -1.5752487767510E+00
+(PID.TID 0000.0001) %MON dynstat_wvel_mean            =   6.6535608071965E-05
 (PID.TID 0000.0001) %MON dynstat_wvel_sd              =   2.2249590203018E-01
-(PID.TID 0000.0001) %MON dynstat_wvel_del2            =   3.0283553779470E-03
+(PID.TID 0000.0001) %MON dynstat_wvel_del2            =   3.0283553779469E-03
 (PID.TID 0000.0001) %MON dynstat_theta_max            =   2.9997520626705E+01
 (PID.TID 0000.0001) %MON dynstat_theta_min            =  -3.2033937961940E+00
 (PID.TID 0000.0001) %MON dynstat_theta_mean           =   3.6037068054970E+00
@@ -3118,57 +3229,57 @@
 (PID.TID 0000.0001) %MON forcing_fv_sd                =   4.4891639796661E-02
 (PID.TID 0000.0001) %MON forcing_fv_del2              =   4.4292866492091E-04
 (PID.TID 0000.0001) %MON trAdv_CFL_u_max              =   1.1186315276390E-01
-(PID.TID 0000.0001) %MON trAdv_CFL_v_max              =   4.9896737064622E-02
-(PID.TID 0000.0001) %MON trAdv_CFL_w_max              =   1.3858619086169E-01
+(PID.TID 0000.0001) %MON trAdv_CFL_v_max              =   4.9896737064624E-02
+(PID.TID 0000.0001) %MON trAdv_CFL_w_max              =   1.3858619086170E-01
 (PID.TID 0000.0001) %MON advcfl_uvel_max              =   1.1515808131522E-01
-(PID.TID 0000.0001) %MON advcfl_vvel_max              =   5.1098295975650E-02
-(PID.TID 0000.0001) %MON advcfl_wvel_max              =   1.1235875159479E-01
-(PID.TID 0000.0001) %MON advcfl_W_hf_max              =   1.2721172282423E-01
-(PID.TID 0000.0001) %MON pe_b_mean                    =  -7.7231349993650E-03
+(PID.TID 0000.0001) %MON advcfl_vvel_max              =   5.1098295975652E-02
+(PID.TID 0000.0001) %MON advcfl_wvel_max              =   1.1235875159478E-01
+(PID.TID 0000.0001) %MON advcfl_W_hf_max              =   1.2721172282422E-01
+(PID.TID 0000.0001) %MON pe_b_mean                    =  -7.7231349993642E-03
 (PID.TID 0000.0001) %MON ke_max                       =   1.7045657319536E-02
 (PID.TID 0000.0001) %MON ke_mean                      =   1.3210669542038E-04
 (PID.TID 0000.0001) %MON ke_vol                       =   1.3442141716554E+22
-(PID.TID 0000.0001) %MON vort_r_min                   =  -4.8628290426051E-07
+(PID.TID 0000.0001) %MON vort_r_min                   =  -4.8628290426049E-07
 (PID.TID 0000.0001) %MON vort_r_max                   =   5.2736704216995E-07
 (PID.TID 0000.0001) %MON vort_a_mean                  =  -2.4598204831015E-05
 (PID.TID 0000.0001) %MON vort_a_sd                    =   7.3637204502714E-05
 (PID.TID 0000.0001) %MON vort_p_mean                  =  -2.9476082711385E-05
 (PID.TID 0000.0001) %MON vort_p_sd                    =   1.0363722035264E-04
-(PID.TID 0000.0001) %MON surfExpan_theta_mean         =   8.5137050728461E-04
-(PID.TID 0000.0001) %MON surfExpan_salt_mean          =   1.3258805792013E-05
+(PID.TID 0000.0001) %MON surfExpan_theta_mean         =   8.5137050728457E-04
+(PID.TID 0000.0001) %MON surfExpan_salt_mean          =   1.3258805792021E-05
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // End MONITOR dynamic field statistics
 (PID.TID 0000.0001) // =======================================================
  EXTERNAL_FIELDS_LOAD,        16 : iP,iLd,i0,i1=    1    2    1    2 ; Wght=  0.4333333333  0.5666666667
- cg2d: Sum(rhs),rhsMax =   3.35842464949110E-15  1.72992219210637E+02
-(PID.TID 0000.0001)      cg2d_init_res =   2.30060670637421E-03
+ cg2d: Sum(rhs),rhsMax =  -1.69309011255336E-15  1.72992219210637E+02
+(PID.TID 0000.0001)      cg2d_init_res =   2.30060670654310E-03
 (PID.TID 0000.0001)      cg2d_iters(min,last) =      -1      86
-(PID.TID 0000.0001)      cg2d_last_res =   9.55048679137580E-10
+(PID.TID 0000.0001)      cg2d_last_res =   9.55048679187834E-10
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // Begin MONITOR dynamic field statistics
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) %MON time_tsnumber                =                    17
 (PID.TID 0000.0001) %MON time_secondsf                =   2.9376000000000E+06
 (PID.TID 0000.0001) %MON dynstat_eta_max              =   4.8395641838646E+04
-(PID.TID 0000.0001) %MON dynstat_eta_min              =  -9.2898575866328E+04
-(PID.TID 0000.0001) %MON dynstat_eta_mean             =  -5.7042187752274E-12
+(PID.TID 0000.0001) %MON dynstat_eta_min              =  -9.2898575866309E+04
+(PID.TID 0000.0001) %MON dynstat_eta_mean             =  -8.7757211926576E-13
 (PID.TID 0000.0001) %MON dynstat_eta_sd               =   3.9709002328558E+04
 (PID.TID 0000.0001) %MON dynstat_eta_del2             =   2.1195920957462E+03
 (PID.TID 0000.0001) %MON dynstat_uvel_max             =   1.9106602518602E-01
-(PID.TID 0000.0001) %MON dynstat_uvel_min             =  -9.1980509319738E-02
-(PID.TID 0000.0001) %MON dynstat_uvel_mean            =   3.5068930936359E-04
+(PID.TID 0000.0001) %MON dynstat_uvel_min             =  -9.1980509319737E-02
+(PID.TID 0000.0001) %MON dynstat_uvel_mean            =   3.5068930936358E-04
 (PID.TID 0000.0001) %MON dynstat_uvel_sd              =   1.4136731008253E-02
 (PID.TID 0000.0001) %MON dynstat_uvel_del2            =   9.8792246563050E-05
-(PID.TID 0000.0001) %MON dynstat_vvel_max             =   9.2081158841116E-02
+(PID.TID 0000.0001) %MON dynstat_vvel_max             =   9.2081158841114E-02
 (PID.TID 0000.0001) %MON dynstat_vvel_min             =  -1.2890435756313E-01
-(PID.TID 0000.0001) %MON dynstat_vvel_mean            =  -1.5383122957455E-05
+(PID.TID 0000.0001) %MON dynstat_vvel_mean            =  -1.5383122957456E-05
 (PID.TID 0000.0001) %MON dynstat_vvel_sd              =   1.0522927202626E-02
 (PID.TID 0000.0001) %MON dynstat_vvel_del2            =   1.0808313600200E-04
 (PID.TID 0000.0001) %MON dynstat_wvel_max             =   2.8560038149789E+00
-(PID.TID 0000.0001) %MON dynstat_wvel_min             =  -1.5787663580407E+00
-(PID.TID 0000.0001) %MON dynstat_wvel_mean            =   2.2025495971566E-05
+(PID.TID 0000.0001) %MON dynstat_wvel_min             =  -1.5787663580404E+00
+(PID.TID 0000.0001) %MON dynstat_wvel_mean            =   2.2025495971454E-05
 (PID.TID 0000.0001) %MON dynstat_wvel_sd              =   2.1569782188427E-01
-(PID.TID 0000.0001) %MON dynstat_wvel_del2            =   2.9623558969473E-03
+(PID.TID 0000.0001) %MON dynstat_wvel_del2            =   2.9623558969471E-03
 (PID.TID 0000.0001) %MON dynstat_theta_max            =   3.0001192195566E+01
 (PID.TID 0000.0001) %MON dynstat_theta_min            =  -3.2398429011316E+00
 (PID.TID 0000.0001) %MON dynstat_theta_mean           =   3.6038006223201E+00
@@ -3205,57 +3316,57 @@
 (PID.TID 0000.0001) %MON forcing_fv_sd                =   4.4699260252941E-02
 (PID.TID 0000.0001) %MON forcing_fv_del2              =   4.4646182492720E-04
 (PID.TID 0000.0001) %MON trAdv_CFL_u_max              =   1.1518147074516E-01
-(PID.TID 0000.0001) %MON trAdv_CFL_v_max              =   4.9471519388520E-02
-(PID.TID 0000.0001) %MON trAdv_CFL_w_max              =   1.2721172282423E-01
+(PID.TID 0000.0001) %MON trAdv_CFL_v_max              =   4.9471519388521E-02
+(PID.TID 0000.0001) %MON trAdv_CFL_w_max              =   1.2721172282422E-01
 (PID.TID 0000.0001) %MON advcfl_uvel_max              =   1.1854131243297E-01
-(PID.TID 0000.0001) %MON advcfl_vvel_max              =   5.0088098594346E-02
-(PID.TID 0000.0001) %MON advcfl_wvel_max              =   9.9903492707386E-02
+(PID.TID 0000.0001) %MON advcfl_vvel_max              =   5.0088098594348E-02
+(PID.TID 0000.0001) %MON advcfl_wvel_max              =   9.9903492707381E-02
 (PID.TID 0000.0001) %MON advcfl_W_hf_max              =   1.1310997357195E-01
-(PID.TID 0000.0001) %MON pe_b_mean                    =  -7.6975359580462E-03
-(PID.TID 0000.0001) %MON ke_max                       =   1.8029022448491E-02
+(PID.TID 0000.0001) %MON pe_b_mean                    =  -7.6975359580457E-03
+(PID.TID 0000.0001) %MON ke_max                       =   1.8029022448492E-02
 (PID.TID 0000.0001) %MON ke_mean                      =   1.4021661905947E-04
 (PID.TID 0000.0001) %MON ke_vol                       =   1.3442141716554E+22
-(PID.TID 0000.0001) %MON vort_r_min                   =  -5.1069751218749E-07
-(PID.TID 0000.0001) %MON vort_r_max                   =   5.4881809694649E-07
+(PID.TID 0000.0001) %MON vort_r_min                   =  -5.1069751218748E-07
+(PID.TID 0000.0001) %MON vort_r_max                   =   5.4881809694650E-07
 (PID.TID 0000.0001) %MON vort_a_mean                  =  -2.4598204977182E-05
 (PID.TID 0000.0001) %MON vort_a_sd                    =   7.3637222467504E-05
 (PID.TID 0000.0001) %MON vort_p_mean                  =  -2.9476085557080E-05
 (PID.TID 0000.0001) %MON vort_p_sd                    =   1.0363757702217E-04
-(PID.TID 0000.0001) %MON surfExpan_theta_mean         =   4.6348380869269E-04
-(PID.TID 0000.0001) %MON surfExpan_salt_mean          =   5.1989283664354E-05
+(PID.TID 0000.0001) %MON surfExpan_theta_mean         =   4.6348380869298E-04
+(PID.TID 0000.0001) %MON surfExpan_salt_mean          =   5.1989283664357E-05
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // End MONITOR dynamic field statistics
 (PID.TID 0000.0001) // =======================================================
  EXTERNAL_FIELDS_LOAD,        17 : iP,iLd,i0,i1=    1    2    1    2 ; Wght=  0.3666666667  0.6333333333
- cg2d: Sum(rhs),rhsMax =  -1.66533453693773E-15  1.72988889348094E+02
-(PID.TID 0000.0001)      cg2d_init_res =   2.20127537187626E-03
+ cg2d: Sum(rhs),rhsMax =   2.13717932240343E-15  1.72988889348102E+02
+(PID.TID 0000.0001)      cg2d_init_res =   2.20127537167479E-03
 (PID.TID 0000.0001)      cg2d_iters(min,last) =      -1      84
-(PID.TID 0000.0001)      cg2d_last_res =   8.58213327865022E-10
+(PID.TID 0000.0001)      cg2d_last_res =   8.58213327589358E-10
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // Begin MONITOR dynamic field statistics
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) %MON time_tsnumber                =                    18
 (PID.TID 0000.0001) %MON time_secondsf                =   3.1104000000000E+06
-(PID.TID 0000.0001) %MON dynstat_eta_max              =   4.8822224391389E+04
-(PID.TID 0000.0001) %MON dynstat_eta_min              =  -9.2836047989508E+04
-(PID.TID 0000.0001) %MON dynstat_eta_mean             =  -2.6327163577973E-12
+(PID.TID 0000.0001) %MON dynstat_eta_max              =   4.8822224391388E+04
+(PID.TID 0000.0001) %MON dynstat_eta_min              =  -9.2836047989595E+04
+(PID.TID 0000.0001) %MON dynstat_eta_mean             =  -8.3369351330247E-12
 (PID.TID 0000.0001) %MON dynstat_eta_sd               =   3.9722820150303E+04
 (PID.TID 0000.0001) %MON dynstat_eta_del2             =   2.1195365062540E+03
 (PID.TID 0000.0001) %MON dynstat_uvel_max             =   1.9697452292431E-01
-(PID.TID 0000.0001) %MON dynstat_uvel_min             =  -9.5821330521486E-02
-(PID.TID 0000.0001) %MON dynstat_uvel_mean            =   4.6509417069317E-04
+(PID.TID 0000.0001) %MON dynstat_uvel_min             =  -9.5821330521484E-02
+(PID.TID 0000.0001) %MON dynstat_uvel_mean            =   4.6509417069318E-04
 (PID.TID 0000.0001) %MON dynstat_uvel_sd              =   1.4870191153188E-02
 (PID.TID 0000.0001) %MON dynstat_uvel_del2            =   1.0246525343376E-04
-(PID.TID 0000.0001) %MON dynstat_vvel_max             =   9.4657823133187E-02
-(PID.TID 0000.0001) %MON dynstat_vvel_min             =  -1.2487336515077E-01
-(PID.TID 0000.0001) %MON dynstat_vvel_mean            =  -4.7047954709251E-05
+(PID.TID 0000.0001) %MON dynstat_vvel_max             =   9.4657823133183E-02
+(PID.TID 0000.0001) %MON dynstat_vvel_min             =  -1.2487336515078E-01
+(PID.TID 0000.0001) %MON dynstat_vvel_mean            =  -4.7047954709232E-05
 (PID.TID 0000.0001) %MON dynstat_vvel_sd              =   1.0280090767039E-02
-(PID.TID 0000.0001) %MON dynstat_vvel_del2            =   1.0641853781155E-04
-(PID.TID 0000.0001) %MON dynstat_wvel_max             =   2.9386406739359E+00
-(PID.TID 0000.0001) %MON dynstat_wvel_min             =  -1.6448078816023E+00
-(PID.TID 0000.0001) %MON dynstat_wvel_mean            =  -1.0051999717966E-05
-(PID.TID 0000.0001) %MON dynstat_wvel_sd              =   2.0930836013699E-01
-(PID.TID 0000.0001) %MON dynstat_wvel_del2            =   2.9096790367601E-03
+(PID.TID 0000.0001) %MON dynstat_vvel_del2            =   1.0641853781154E-04
+(PID.TID 0000.0001) %MON dynstat_wvel_max             =   2.9386406739358E+00
+(PID.TID 0000.0001) %MON dynstat_wvel_min             =  -1.6448078816019E+00
+(PID.TID 0000.0001) %MON dynstat_wvel_mean            =  -1.0051999717829E-05
+(PID.TID 0000.0001) %MON dynstat_wvel_sd              =   2.0930836013698E-01
+(PID.TID 0000.0001) %MON dynstat_wvel_del2            =   2.9096790367600E-03
 (PID.TID 0000.0001) %MON dynstat_theta_max            =   3.0000108898312E+01
 (PID.TID 0000.0001) %MON dynstat_theta_min            =  -3.2717729252062E+00
 (PID.TID 0000.0001) %MON dynstat_theta_mean           =   3.6038954592131E+00
@@ -3291,58 +3402,58 @@
 (PID.TID 0000.0001) %MON forcing_fv_mean              =  -6.4665625214348E-03
 (PID.TID 0000.0001) %MON forcing_fv_sd                =   4.4570503746109E-02
 (PID.TID 0000.0001) %MON forcing_fv_del2              =   4.5209535749048E-04
-(PID.TID 0000.0001) %MON trAdv_CFL_u_max              =   1.1856538902135E-01
-(PID.TID 0000.0001) %MON trAdv_CFL_v_max              =   4.8493482873188E-02
+(PID.TID 0000.0001) %MON trAdv_CFL_u_max              =   1.1856538902134E-01
+(PID.TID 0000.0001) %MON trAdv_CFL_v_max              =   4.8493482873190E-02
 (PID.TID 0000.0001) %MON trAdv_CFL_w_max              =   1.1310997357195E-01
 (PID.TID 0000.0001) %MON advcfl_uvel_max              =   1.2339988591671E-01
-(PID.TID 0000.0001) %MON advcfl_vvel_max              =   4.8521784241595E-02
-(PID.TID 0000.0001) %MON advcfl_wvel_max              =   9.8591264971531E-02
+(PID.TID 0000.0001) %MON advcfl_vvel_max              =   4.8521784241597E-02
+(PID.TID 0000.0001) %MON advcfl_wvel_max              =   9.8591264971596E-02
 (PID.TID 0000.0001) %MON advcfl_W_hf_max              =   1.0854403529869E-01
-(PID.TID 0000.0001) %MON pe_b_mean                    =  -7.7279676902974E-03
+(PID.TID 0000.0001) %MON pe_b_mean                    =  -7.7279676902966E-03
 (PID.TID 0000.0001) %MON ke_max                       =   1.8885197572972E-02
 (PID.TID 0000.0001) %MON ke_mean                      =   1.4763112470823E-04
 (PID.TID 0000.0001) %MON ke_vol                       =   1.3442141716554E+22
-(PID.TID 0000.0001) %MON vort_r_min                   =  -5.3039959255302E-07
-(PID.TID 0000.0001) %MON vort_r_max                   =   5.6530294281959E-07
+(PID.TID 0000.0001) %MON vort_r_min                   =  -5.3039959255301E-07
+(PID.TID 0000.0001) %MON vort_r_max                   =   5.6530294281960E-07
 (PID.TID 0000.0001) %MON vort_a_mean                  =  -2.4598205115405E-05
 (PID.TID 0000.0001) %MON vort_a_sd                    =   7.3637243292071E-05
 (PID.TID 0000.0001) %MON vort_p_mean                  =  -2.9476088325595E-05
 (PID.TID 0000.0001) %MON vort_p_sd                    =   1.0363776895249E-04
-(PID.TID 0000.0001) %MON surfExpan_theta_mean         =  -2.1762914814787E-06
-(PID.TID 0000.0001) %MON surfExpan_salt_mean          =   8.6734957934042E-05
+(PID.TID 0000.0001) %MON surfExpan_theta_mean         =  -2.1762914820826E-06
+(PID.TID 0000.0001) %MON surfExpan_salt_mean          =   8.6734957934004E-05
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // End MONITOR dynamic field statistics
 (PID.TID 0000.0001) // =======================================================
  EXTERNAL_FIELDS_LOAD,        18 : iP,iLd,i0,i1=    1    2    1    2 ; Wght=  0.3000000000  0.7000000000
- cg2d: Sum(rhs),rhsMax =  -2.05391259555654E-15  1.72985104115761E+02
-(PID.TID 0000.0001)      cg2d_init_res =   2.17881540609824E-03
+ cg2d: Sum(rhs),rhsMax =  -3.69149155687865E-15  1.72985104115761E+02
+(PID.TID 0000.0001)      cg2d_init_res =   2.17881540602634E-03
 (PID.TID 0000.0001)      cg2d_iters(min,last) =      -1      87
-(PID.TID 0000.0001)      cg2d_last_res =   8.60295546883345E-10
+(PID.TID 0000.0001)      cg2d_last_res =   8.60295546959189E-10
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // Begin MONITOR dynamic field statistics
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) %MON time_tsnumber                =                    19
 (PID.TID 0000.0001) %MON time_secondsf                =   3.2832000000000E+06
 (PID.TID 0000.0001) %MON dynstat_eta_max              =   4.8202056985269E+04
-(PID.TID 0000.0001) %MON dynstat_eta_min              =  -9.2714842932713E+04
-(PID.TID 0000.0001) %MON dynstat_eta_mean             =   3.0715024174302E-12
+(PID.TID 0000.0001) %MON dynstat_eta_min              =  -9.2714842932786E+04
+(PID.TID 0000.0001) %MON dynstat_eta_mean             =   6.5817908944932E-12
 (PID.TID 0000.0001) %MON dynstat_eta_sd               =   3.9702162452353E+04
 (PID.TID 0000.0001) %MON dynstat_eta_del2             =   2.1194832447090E+03
-(PID.TID 0000.0001) %MON dynstat_uvel_max             =   2.0126335778160E-01
-(PID.TID 0000.0001) %MON dynstat_uvel_min             =  -9.9142435658200E-02
-(PID.TID 0000.0001) %MON dynstat_uvel_mean            =   5.7029916306577E-04
+(PID.TID 0000.0001) %MON dynstat_uvel_max             =   2.0126335778161E-01
+(PID.TID 0000.0001) %MON dynstat_uvel_min             =  -9.9142435658199E-02
+(PID.TID 0000.0001) %MON dynstat_uvel_mean            =   5.7029916306578E-04
 (PID.TID 0000.0001) %MON dynstat_uvel_sd              =   1.5520216398854E-02
 (PID.TID 0000.0001) %MON dynstat_uvel_del2            =   1.0605139931047E-04
-(PID.TID 0000.0001) %MON dynstat_vvel_max             =   9.6785832059549E-02
+(PID.TID 0000.0001) %MON dynstat_vvel_max             =   9.6785832059547E-02
 (PID.TID 0000.0001) %MON dynstat_vvel_min             =  -1.1947557965342E-01
-(PID.TID 0000.0001) %MON dynstat_vvel_mean            =  -6.3553036657862E-05
+(PID.TID 0000.0001) %MON dynstat_vvel_mean            =  -6.3553036657865E-05
 (PID.TID 0000.0001) %MON dynstat_vvel_sd              =   1.0026039490886E-02
-(PID.TID 0000.0001) %MON dynstat_vvel_del2            =   1.0492768504607E-04
-(PID.TID 0000.0001) %MON dynstat_wvel_max             =   3.0087591960468E+00
-(PID.TID 0000.0001) %MON dynstat_wvel_min             =  -1.7743518013316E+00
-(PID.TID 0000.0001) %MON dynstat_wvel_mean            =  -3.7334023550820E-05
+(PID.TID 0000.0001) %MON dynstat_vvel_del2            =   1.0492768504606E-04
+(PID.TID 0000.0001) %MON dynstat_wvel_max             =   3.0087591960470E+00
+(PID.TID 0000.0001) %MON dynstat_wvel_min             =  -1.7743518013311E+00
+(PID.TID 0000.0001) %MON dynstat_wvel_mean            =  -3.7334023550806E-05
 (PID.TID 0000.0001) %MON dynstat_wvel_sd              =   2.0379000063777E-01
-(PID.TID 0000.0001) %MON dynstat_wvel_del2            =   2.8729468224158E-03
+(PID.TID 0000.0001) %MON dynstat_wvel_del2            =   2.8729468224157E-03
 (PID.TID 0000.0001) %MON dynstat_theta_max            =   2.9994243063431E+01
 (PID.TID 0000.0001) %MON dynstat_theta_min            =  -3.2992357030432E+00
 (PID.TID 0000.0001) %MON dynstat_theta_mean           =   3.6039914604690E+00
@@ -3379,58 +3490,58 @@
 (PID.TID 0000.0001) %MON forcing_fv_sd                =   4.4505922467671E-02
 (PID.TID 0000.0001) %MON forcing_fv_del2              =   4.5975205888607E-04
 (PID.TID 0000.0001) %MON trAdv_CFL_u_max              =   1.2342494931611E-01
-(PID.TID 0000.0001) %MON trAdv_CFL_v_max              =   4.6977034048601E-02
-(PID.TID 0000.0001) %MON trAdv_CFL_w_max              =   1.0593204047058E-01
-(PID.TID 0000.0001) %MON advcfl_uvel_max              =   1.2705959765176E-01
-(PID.TID 0000.0001) %MON advcfl_vvel_max              =   4.6424377937467E-02
-(PID.TID 0000.0001) %MON advcfl_wvel_max              =   9.8632129381405E-02
+(PID.TID 0000.0001) %MON trAdv_CFL_v_max              =   4.6977034048603E-02
+(PID.TID 0000.0001) %MON trAdv_CFL_w_max              =   1.0593204047065E-01
+(PID.TID 0000.0001) %MON advcfl_uvel_max              =   1.2705959765175E-01
+(PID.TID 0000.0001) %MON advcfl_vvel_max              =   4.6424377937468E-02
+(PID.TID 0000.0001) %MON advcfl_wvel_max              =   9.8632129381482E-02
 (PID.TID 0000.0001) %MON advcfl_W_hf_max              =   1.1403067338933E-01
-(PID.TID 0000.0001) %MON pe_b_mean                    =  -7.8050821305988E-03
-(PID.TID 0000.0001) %MON ke_max                       =   1.9611922062438E-02
+(PID.TID 0000.0001) %MON pe_b_mean                    =  -7.8050821305980E-03
+(PID.TID 0000.0001) %MON ke_max                       =   1.9611922062439E-02
 (PID.TID 0000.0001) %MON ke_mean                      =   1.5431578092480E-04
 (PID.TID 0000.0001) %MON ke_vol                       =   1.3442141716554E+22
-(PID.TID 0000.0001) %MON vort_r_min                   =  -5.4503138448807E-07
-(PID.TID 0000.0001) %MON vort_r_max                   =   5.7762101055352E-07
+(PID.TID 0000.0001) %MON vort_r_min                   =  -5.4503138448806E-07
+(PID.TID 0000.0001) %MON vort_r_max                   =   5.7762101055353E-07
 (PID.TID 0000.0001) %MON vort_a_mean                  =  -2.4598205221983E-05
 (PID.TID 0000.0001) %MON vort_a_sd                    =   7.3637262219765E-05
 (PID.TID 0000.0001) %MON vort_p_mean                  =  -2.9476089904906E-05
 (PID.TID 0000.0001) %MON vort_p_sd                    =   1.0363777174904E-04
-(PID.TID 0000.0001) %MON surfExpan_theta_mean         =  -3.3759404742142E-04
-(PID.TID 0000.0001) %MON surfExpan_salt_mean          =   1.1204859553691E-04
+(PID.TID 0000.0001) %MON surfExpan_theta_mean         =  -3.3759404742132E-04
+(PID.TID 0000.0001) %MON surfExpan_salt_mean          =   1.1204859553694E-04
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // End MONITOR dynamic field statistics
 (PID.TID 0000.0001) // =======================================================
  EXTERNAL_FIELDS_LOAD,        19 : iP,iLd,i0,i1=    1    2    1    2 ; Wght=  0.2333333333  0.7666666667
- cg2d: Sum(rhs),rhsMax =  -6.93889390390723E-16  1.72980544618336E+02
-(PID.TID 0000.0001)      cg2d_init_res =   2.20615081655230E-03
+ cg2d: Sum(rhs),rhsMax =  -1.72084568816899E-15  1.72980544618336E+02
+(PID.TID 0000.0001)      cg2d_init_res =   2.20615081629631E-03
 (PID.TID 0000.0001)      cg2d_iters(min,last) =      -1      88
-(PID.TID 0000.0001)      cg2d_last_res =   8.46568026182442E-10
+(PID.TID 0000.0001)      cg2d_last_res =   8.46568026214589E-10
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // Begin MONITOR dynamic field statistics
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) %MON time_tsnumber                =                    20
 (PID.TID 0000.0001) %MON time_secondsf                =   3.4560000000000E+06
-(PID.TID 0000.0001) %MON dynstat_eta_max              =   4.6894977797138E+04
-(PID.TID 0000.0001) %MON dynstat_eta_min              =  -9.2596637529397E+04
-(PID.TID 0000.0001) %MON dynstat_eta_mean             =   7.0205769541261E-12
+(PID.TID 0000.0001) %MON dynstat_eta_max              =   4.6894977797137E+04
+(PID.TID 0000.0001) %MON dynstat_eta_min              =  -9.2596637529402E+04
+(PID.TID 0000.0001) %MON dynstat_eta_mean             =  -3.0715024174302E-12
 (PID.TID 0000.0001) %MON dynstat_eta_sd               =   3.9661008558751E+04
 (PID.TID 0000.0001) %MON dynstat_eta_del2             =   2.1194357510854E+03
 (PID.TID 0000.0001) %MON dynstat_uvel_max             =   2.0387747086903E-01
 (PID.TID 0000.0001) %MON dynstat_uvel_min             =  -1.0181499071567E-01
-(PID.TID 0000.0001) %MON dynstat_uvel_mean            =   6.5203412947264E-04
+(PID.TID 0000.0001) %MON dynstat_uvel_mean            =   6.5203412947263E-04
 (PID.TID 0000.0001) %MON dynstat_uvel_sd              =   1.6078016870817E-02
 (PID.TID 0000.0001) %MON dynstat_uvel_del2            =   1.0944179146363E-04
-(PID.TID 0000.0001) %MON dynstat_vvel_max             =   9.8487061367507E-02
-(PID.TID 0000.0001) %MON dynstat_vvel_min             =  -1.1280494784155E-01
-(PID.TID 0000.0001) %MON dynstat_vvel_mean            =  -5.7597919063318E-05
-(PID.TID 0000.0001) %MON dynstat_vvel_sd              =   9.7860475155529E-03
+(PID.TID 0000.0001) %MON dynstat_vvel_max             =   9.8487061367505E-02
+(PID.TID 0000.0001) %MON dynstat_vvel_min             =  -1.1280494784156E-01
+(PID.TID 0000.0001) %MON dynstat_vvel_mean            =  -5.7597919063300E-05
+(PID.TID 0000.0001) %MON dynstat_vvel_sd              =   9.7860475155528E-03
 (PID.TID 0000.0001) %MON dynstat_vvel_del2            =   1.0377876566657E-04
-(PID.TID 0000.0001) %MON dynstat_wvel_max             =   3.0658672855623E+00
-(PID.TID 0000.0001) %MON dynstat_wvel_min             =  -1.8906981312982E+00
-(PID.TID 0000.0001) %MON dynstat_wvel_mean            =  -6.5307388253208E-05
-(PID.TID 0000.0001) %MON dynstat_wvel_sd              =   1.9947848504819E-01
-(PID.TID 0000.0001) %MON dynstat_wvel_del2            =   2.8528932021822E-03
-(PID.TID 0000.0001) %MON dynstat_theta_max            =   2.9983576585571E+01
+(PID.TID 0000.0001) %MON dynstat_wvel_max             =   3.0658672855622E+00
+(PID.TID 0000.0001) %MON dynstat_wvel_min             =  -1.8906981312981E+00
+(PID.TID 0000.0001) %MON dynstat_wvel_mean            =  -6.5307388253431E-05
+(PID.TID 0000.0001) %MON dynstat_wvel_sd              =   1.9947848504818E-01
+(PID.TID 0000.0001) %MON dynstat_wvel_del2            =   2.8528932021818E-03
+(PID.TID 0000.0001) %MON dynstat_theta_max            =   2.9983576585570E+01
 (PID.TID 0000.0001) %MON dynstat_theta_min            =  -3.3222780722174E+00
 (PID.TID 0000.0001) %MON dynstat_theta_mean           =   3.6040886526730E+00
 (PID.TID 0000.0001) %MON dynstat_theta_sd             =   4.4042268097648E+00
@@ -3465,177 +3576,177 @@
 (PID.TID 0000.0001) %MON forcing_fv_mean              =  -6.7306027712320E-03
 (PID.TID 0000.0001) %MON forcing_fv_sd                =   4.4505795787846E-02
 (PID.TID 0000.0001) %MON forcing_fv_del2              =   4.6933292157477E-04
-(PID.TID 0000.0001) %MON trAdv_CFL_u_max              =   1.2708540436479E-01
-(PID.TID 0000.0001) %MON trAdv_CFL_v_max              =   4.4946401232789E-02
-(PID.TID 0000.0001) %MON trAdv_CFL_w_max              =   1.0597594750759E-01
+(PID.TID 0000.0001) %MON trAdv_CFL_u_max              =   1.2708540436478E-01
+(PID.TID 0000.0001) %MON trAdv_CFL_v_max              =   4.4946401232790E-02
+(PID.TID 0000.0001) %MON trAdv_CFL_w_max              =   1.0597594750767E-01
 (PID.TID 0000.0001) %MON advcfl_uvel_max              =   1.2942303832233E-01
-(PID.TID 0000.0001) %MON advcfl_vvel_max              =   4.3832384383518E-02
-(PID.TID 0000.0001) %MON advcfl_wvel_max              =   9.7573814582797E-02
-(PID.TID 0000.0001) %MON advcfl_W_hf_max              =   1.1850951157741E-01
-(PID.TID 0000.0001) %MON pe_b_mean                    =  -7.9128324369026E-03
+(PID.TID 0000.0001) %MON advcfl_vvel_max              =   4.3832384383521E-02
+(PID.TID 0000.0001) %MON advcfl_wvel_max              =   9.7573814582793E-02
+(PID.TID 0000.0001) %MON advcfl_W_hf_max              =   1.1850951157740E-01
+(PID.TID 0000.0001) %MON pe_b_mean                    =  -7.9128324369021E-03
 (PID.TID 0000.0001) %MON ke_max                       =   2.0330618001007E-02
 (PID.TID 0000.0001) %MON ke_mean                      =   1.6021207766099E-04
 (PID.TID 0000.0001) %MON ke_vol                       =   1.3442141716554E+22
-(PID.TID 0000.0001) %MON vort_r_min                   =  -5.5434077858536E-07
-(PID.TID 0000.0001) %MON vort_r_max                   =   5.8652152649257E-07
+(PID.TID 0000.0001) %MON vort_r_min                   =  -5.5434077858535E-07
+(PID.TID 0000.0001) %MON vort_r_max                   =   5.8652152649258E-07
 (PID.TID 0000.0001) %MON vort_a_mean                  =  -2.4598205282204E-05
 (PID.TID 0000.0001) %MON vort_a_sd                    =   7.3637276146907E-05
 (PID.TID 0000.0001) %MON vort_p_mean                  =  -2.9476090357749E-05
 (PID.TID 0000.0001) %MON vort_p_sd                    =   1.0363761163573E-04
-(PID.TID 0000.0001) %MON surfExpan_theta_mean         =  -4.1875565650955E-04
+(PID.TID 0000.0001) %MON surfExpan_theta_mean         =  -4.1875565650887E-04
 (PID.TID 0000.0001) %MON surfExpan_salt_mean          =   1.2441096963517E-04
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // End MONITOR dynamic field statistics
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) %CHECKPOINT        20 ckptA
 (PID.TID 0000.0001)   Seconds in section "ALL                    [THE_MODEL_MAIN]":
-(PID.TID 0000.0001)           User time:   10.843999862670898
-(PID.TID 0000.0001)         System time:   1.9999999552965164E-002
-(PID.TID 0000.0001)     Wall clock time:   10.870580911636353
+(PID.TID 0000.0001)           User time:   9.0513353347778320
+(PID.TID 0000.0001)         System time:  0.17071699304506183
+(PID.TID 0000.0001)     Wall clock time:   9.4905159473419189
 (PID.TID 0000.0001)          No. starts:           1
 (PID.TID 0000.0001)           No. stops:           1
 (PID.TID 0000.0001)   Seconds in section "INITIALISE_FIXED       [THE_MODEL_MAIN]":
-(PID.TID 0000.0001)           User time:   7.5999997556209564E-002
-(PID.TID 0000.0001)         System time:   0.0000000000000000
-(PID.TID 0000.0001)     Wall clock time:   7.7105998992919922E-002
+(PID.TID 0000.0001)           User time:   6.6800996661186218E-002
+(PID.TID 0000.0001)         System time:   2.4294999428093433E-002
+(PID.TID 0000.0001)     Wall clock time:  0.10538220405578613
 (PID.TID 0000.0001)          No. starts:           1
 (PID.TID 0000.0001)           No. stops:           1
 (PID.TID 0000.0001)   Seconds in section "THE_MAIN_LOOP          [THE_MODEL_MAIN]":
-(PID.TID 0000.0001)           User time:   10.767999865114689
-(PID.TID 0000.0001)         System time:   1.9999999552965164E-002
-(PID.TID 0000.0001)     Wall clock time:   10.793437004089355
+(PID.TID 0000.0001)           User time:   8.9845177531242371
+(PID.TID 0000.0001)         System time:  0.14638199284672737
+(PID.TID 0000.0001)     Wall clock time:   9.3850920200347900
 (PID.TID 0000.0001)          No. starts:           1
 (PID.TID 0000.0001)           No. stops:           1
 (PID.TID 0000.0001)   Seconds in section "INITIALISE_VARIA    [THE_MAIN_LOOP]":
-(PID.TID 0000.0001)           User time:  0.16800000518560410
-(PID.TID 0000.0001)         System time:   1.2000000104308128E-002
-(PID.TID 0000.0001)     Wall clock time:  0.18038105964660645
+(PID.TID 0000.0001)           User time:  0.19687199592590332
+(PID.TID 0000.0001)         System time:   2.3650998249650002E-002
+(PID.TID 0000.0001)     Wall clock time:  0.42085599899291992
 (PID.TID 0000.0001)          No. starts:           1
 (PID.TID 0000.0001)           No. stops:           1
 (PID.TID 0000.0001)   Seconds in section "MAIN LOOP           [THE_MAIN_LOOP]":
-(PID.TID 0000.0001)           User time:   10.599999859929085
-(PID.TID 0000.0001)         System time:   7.9999994486570358E-003
-(PID.TID 0000.0001)     Wall clock time:   10.613031148910522
+(PID.TID 0000.0001)           User time:   8.7876201272010803
+(PID.TID 0000.0001)         System time:  0.12272599339485168
+(PID.TID 0000.0001)     Wall clock time:   8.9642069339752197
 (PID.TID 0000.0001)          No. starts:           1
 (PID.TID 0000.0001)           No. stops:           1
 (PID.TID 0000.0001)   Seconds in section "MAIN_DO_LOOP        [THE_MAIN_LOOP]":
-(PID.TID 0000.0001)           User time:   10.599999859929085
-(PID.TID 0000.0001)         System time:   7.9999994486570358E-003
-(PID.TID 0000.0001)     Wall clock time:   10.612872838973999
+(PID.TID 0000.0001)           User time:   8.7874453961849213
+(PID.TID 0000.0001)         System time:  0.12272299453616142
+(PID.TID 0000.0001)     Wall clock time:   8.9640357494354248
 (PID.TID 0000.0001)          No. starts:          20
 (PID.TID 0000.0001)           No. stops:          20
 (PID.TID 0000.0001)   Seconds in section "FORWARD_STEP        [MAIN_DO_LOOP]":
-(PID.TID 0000.0001)           User time:   10.599999859929085
-(PID.TID 0000.0001)         System time:   7.9999994486570358E-003
-(PID.TID 0000.0001)     Wall clock time:   10.612559795379639
+(PID.TID 0000.0001)           User time:   8.7871246635913849
+(PID.TID 0000.0001)         System time:  0.12271900102496147
+(PID.TID 0000.0001)     Wall clock time:   8.9637088775634766
 (PID.TID 0000.0001)          No. starts:          20
 (PID.TID 0000.0001)           No. stops:          20
 (PID.TID 0000.0001)   Seconds in section "UPDATE_SURF_DR      [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:   7.9997181892395020E-003
-(PID.TID 0000.0001)         System time:   0.0000000000000000
-(PID.TID 0000.0001)     Wall clock time:   1.3631820678710938E-002
+(PID.TID 0000.0001)           User time:   1.7560303211212158E-002
+(PID.TID 0000.0001)         System time:   3.1897053122520447E-004
+(PID.TID 0000.0001)     Wall clock time:   1.7915487289428711E-002
 (PID.TID 0000.0001)          No. starts:          40
 (PID.TID 0000.0001)           No. stops:          40
 (PID.TID 0000.0001)   Seconds in section "LOAD_FIELDS_DRIVER  [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:   2.4000570178031921E-002
-(PID.TID 0000.0001)         System time:   0.0000000000000000
-(PID.TID 0000.0001)     Wall clock time:   1.4940261840820312E-002
+(PID.TID 0000.0001)           User time:   1.3170301914215088E-002
+(PID.TID 0000.0001)         System time:   3.4760050475597382E-003
+(PID.TID 0000.0001)     Wall clock time:   2.2536516189575195E-002
 (PID.TID 0000.0001)          No. starts:          20
 (PID.TID 0000.0001)           No. stops:          20
 (PID.TID 0000.0001)   Seconds in section "EXTERNAL_FLDS_LOAD [LOAD_FLDS_DRIVER]":
-(PID.TID 0000.0001)           User time:   2.4000570178031921E-002
-(PID.TID 0000.0001)         System time:   0.0000000000000000
-(PID.TID 0000.0001)     Wall clock time:   1.4625310897827148E-002
+(PID.TID 0000.0001)           User time:   1.2793451547622681E-002
+(PID.TID 0000.0001)         System time:   3.4690089523792267E-003
+(PID.TID 0000.0001)     Wall clock time:   2.2160768508911133E-002
 (PID.TID 0000.0001)          No. starts:          20
 (PID.TID 0000.0001)           No. stops:          20
 (PID.TID 0000.0001)   Seconds in section "DO_ATMOSPHERIC_PHYS [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:   0.0000000000000000
-(PID.TID 0000.0001)         System time:   0.0000000000000000
-(PID.TID 0000.0001)     Wall clock time:   1.5640258789062500E-004
+(PID.TID 0000.0001)           User time:   1.6120076179504395E-004
+(PID.TID 0000.0001)         System time:   3.9972364902496338E-006
+(PID.TID 0000.0001)     Wall clock time:   1.5854835510253906E-004
 (PID.TID 0000.0001)          No. starts:          20
 (PID.TID 0000.0001)           No. stops:          20
 (PID.TID 0000.0001)   Seconds in section "DO_OCEANIC_PHYS     [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:  0.44000110030174255
-(PID.TID 0000.0001)         System time:   4.0000006556510925E-003
-(PID.TID 0000.0001)     Wall clock time:  0.44844770431518555
+(PID.TID 0000.0001)           User time:  0.36048457026481628
+(PID.TID 0000.0001)         System time:   1.2062985450029373E-002
+(PID.TID 0000.0001)     Wall clock time:  0.37321853637695312
 (PID.TID 0000.0001)          No. starts:          20
 (PID.TID 0000.0001)           No. stops:          20
 (PID.TID 0000.0001)   Seconds in section "THERMODYNAMICS      [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:   2.3359991312026978
-(PID.TID 0000.0001)         System time:   0.0000000000000000
-(PID.TID 0000.0001)     Wall clock time:   2.3343055248260498
+(PID.TID 0000.0001)           User time:   1.8280580341815948
+(PID.TID 0000.0001)         System time:   1.4155026525259018E-002
+(PID.TID 0000.0001)     Wall clock time:   1.8524205684661865
 (PID.TID 0000.0001)          No. starts:          20
 (PID.TID 0000.0001)           No. stops:          20
 (PID.TID 0000.0001)   Seconds in section "DYNAMICS            [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:   3.2999998927116394
-(PID.TID 0000.0001)         System time:   3.9999987930059433E-003
-(PID.TID 0000.0001)     Wall clock time:   3.3050475120544434
+(PID.TID 0000.0001)           User time:   2.7282088994979858
+(PID.TID 0000.0001)         System time:   3.2383989542722702E-002
+(PID.TID 0000.0001)     Wall clock time:   2.7808578014373779
 (PID.TID 0000.0001)          No. starts:          20
 (PID.TID 0000.0001)           No. stops:          20
 (PID.TID 0000.0001)   Seconds in section "UPDATE_CG2D         [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:   8.7999880313873291E-002
-(PID.TID 0000.0001)         System time:   0.0000000000000000
-(PID.TID 0000.0001)     Wall clock time:   9.2025518417358398E-002
+(PID.TID 0000.0001)           User time:   8.5258483886718750E-002
+(PID.TID 0000.0001)         System time:   4.1380152106285095E-003
+(PID.TID 0000.0001)     Wall clock time:   8.9411497116088867E-002
 (PID.TID 0000.0001)          No. starts:          20
 (PID.TID 0000.0001)           No. stops:          20
 (PID.TID 0000.0001)   Seconds in section "SOLVE_FOR_PRESSURE  [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:   1.9840012192726135
-(PID.TID 0000.0001)         System time:   0.0000000000000000
-(PID.TID 0000.0001)     Wall clock time:   1.9723703861236572
+(PID.TID 0000.0001)           User time:   1.6319247484207153
+(PID.TID 0000.0001)         System time:   1.9933998584747314E-002
+(PID.TID 0000.0001)     Wall clock time:   1.6665899753570557
 (PID.TID 0000.0001)          No. starts:          20
 (PID.TID 0000.0001)           No. stops:          20
 (PID.TID 0000.0001)   Seconds in section "MOM_CORRECTION_STEP [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:  0.11999756097793579
-(PID.TID 0000.0001)         System time:   0.0000000000000000
-(PID.TID 0000.0001)     Wall clock time:  0.12149858474731445
+(PID.TID 0000.0001)           User time:   9.0744018554687500E-002
+(PID.TID 0000.0001)         System time:   8.2001090049743652E-005
+(PID.TID 0000.0001)     Wall clock time:   9.0853691101074219E-002
 (PID.TID 0000.0001)          No. starts:          20
 (PID.TID 0000.0001)           No. stops:          20
 (PID.TID 0000.0001)   Seconds in section "INTEGR_CONTINUITY   [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:  0.25200194120407104
-(PID.TID 0000.0001)         System time:   0.0000000000000000
-(PID.TID 0000.0001)     Wall clock time:  0.25608181953430176
+(PID.TID 0000.0001)           User time:  0.20000219345092773
+(PID.TID 0000.0001)         System time:   2.4100020527839661E-004
+(PID.TID 0000.0001)     Wall clock time:  0.20027637481689453
 (PID.TID 0000.0001)          No. starts:          20
 (PID.TID 0000.0001)           No. stops:          20
 (PID.TID 0000.0001)   Seconds in section "CALC_SURF_DR      [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:   2.3998796939849854E-002
-(PID.TID 0000.0001)         System time:   0.0000000000000000
-(PID.TID 0000.0001)     Wall clock time:   1.9392728805541992E-002
+(PID.TID 0000.0001)           User time:   1.8716156482696533E-002
+(PID.TID 0000.0001)         System time:   1.0100752115249634E-004
+(PID.TID 0000.0001)     Wall clock time:   1.8847227096557617E-002
 (PID.TID 0000.0001)          No. starts:          20
 (PID.TID 0000.0001)           No. stops:          20
 (PID.TID 0000.0001)   Seconds in section "TRC_CORRECTION_STEP [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:   0.0000000000000000
-(PID.TID 0000.0001)         System time:   0.0000000000000000
-(PID.TID 0000.0001)     Wall clock time:   1.6331672668457031E-004
+(PID.TID 0000.0001)           User time:   1.7029047012329102E-004
+(PID.TID 0000.0001)         System time:   1.0021030902862549E-006
+(PID.TID 0000.0001)     Wall clock time:   1.7118453979492188E-004
 (PID.TID 0000.0001)          No. starts:          20
 (PID.TID 0000.0001)           No. stops:          20
 (PID.TID 0000.0001)   Seconds in section "BLOCKING_EXCHANGES  [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:   4.0000915527343750E-002
-(PID.TID 0000.0001)         System time:   0.0000000000000000
-(PID.TID 0000.0001)     Wall clock time:   4.5019865036010742E-002
+(PID.TID 0000.0001)           User time:   3.7310898303985596E-002
+(PID.TID 0000.0001)         System time:   3.9180070161819458E-003
+(PID.TID 0000.0001)     Wall clock time:   4.1269540786743164E-002
 (PID.TID 0000.0001)          No. starts:          20
 (PID.TID 0000.0001)           No. stops:          20
 (PID.TID 0000.0001)   Seconds in section "DO_STATEVARS_TAVE   [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:  0.76399862766265869
-(PID.TID 0000.0001)         System time:   0.0000000000000000
-(PID.TID 0000.0001)     Wall clock time:  0.75596880912780762
+(PID.TID 0000.0001)           User time:  0.57213658094406128
+(PID.TID 0000.0001)         System time:   5.5000185966491699E-005
+(PID.TID 0000.0001)     Wall clock time:  0.57243418693542480
 (PID.TID 0000.0001)          No. starts:          20
 (PID.TID 0000.0001)           No. stops:          20
 (PID.TID 0000.0001)   Seconds in section "MONITOR             [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:   1.1679999828338623
-(PID.TID 0000.0001)         System time:   0.0000000000000000
-(PID.TID 0000.0001)     Wall clock time:   1.1810512542724609
+(PID.TID 0000.0001)           User time:   1.1594575643539429
+(PID.TID 0000.0001)         System time:   1.5835002064704895E-002
+(PID.TID 0000.0001)     Wall clock time:   1.1774830818176270
 (PID.TID 0000.0001)          No. starts:          20
 (PID.TID 0000.0001)           No. stops:          20
 (PID.TID 0000.0001)   Seconds in section "DO_THE_MODEL_IO     [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:   2.8000831604003906E-002
-(PID.TID 0000.0001)         System time:   0.0000000000000000
-(PID.TID 0000.0001)     Wall clock time:   2.5872707366943359E-002
+(PID.TID 0000.0001)           User time:   1.3990402221679688E-002
+(PID.TID 0000.0001)         System time:   1.1943995952606201E-002
+(PID.TID 0000.0001)     Wall clock time:   2.5940895080566406E-002
 (PID.TID 0000.0001)          No. starts:          20
 (PID.TID 0000.0001)           No. stops:          20
 (PID.TID 0000.0001)   Seconds in section "DO_WRITE_PICKUP     [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:   1.9999504089355469E-002
-(PID.TID 0000.0001)         System time:   0.0000000000000000
-(PID.TID 0000.0001)     Wall clock time:   2.2850513458251953E-002
+(PID.TID 0000.0001)           User time:   2.5173962116241455E-002
+(PID.TID 0000.0001)         System time:   4.0159970521926880E-003
+(PID.TID 0000.0001)     Wall clock time:   2.9190063476562500E-002
 (PID.TID 0000.0001)          No. starts:          20
 (PID.TID 0000.0001)           No. stops:          20
 (PID.TID 0000.0001) // ======================================================
@@ -3664,9 +3775,9 @@
 (PID.TID 0000.0001) //          Total. Y spins =              0
 (PID.TID 0000.0001) //            Avg. Y spins =       0.00E+00
 (PID.TID 0000.0001) // o Thread number: 000001
-(PID.TID 0000.0001) //            No. barriers =          16106
+(PID.TID 0000.0001) //            No. barriers =          16114
 (PID.TID 0000.0001) //      Max. barrier spins =              1
 (PID.TID 0000.0001) //      Min. barrier spins =              1
-(PID.TID 0000.0001) //     Total barrier spins =          16106
+(PID.TID 0000.0001) //     Total barrier spins =          16114
 (PID.TID 0000.0001) //      Avg. barrier spins =       1.00E+00
 PROGRAM MAIN: Execution ended Normally


### PR DESCRIPTION
This is a minor change in Geopotential-Anomaly calculation for Ocean in P-coord: Use a more robust/precise (regarding floating point arithmetics) expression for specific-volume anomaly.

## What changes does this PR introduce?
single minor change, only relevant for Ocean in Pressure coordinate.

## What is the current behaviour? 
Specific volume anomaly $\alpha'$ is computed from density anomaly $\rho'$ by subtracting 2 numbers of similar magnitude: $\alpha' = 1/( \rho_c + \rho' ) - 1/\rho_c$

## What is the new behaviour 
Use more precise expression that does not involve this type of subtraction:
$\alpha' = - ( \rho'/\rho_c ) / ( 1 + \rho'/\rho_c ) / \rho_c $

## Does this PR introduce a breaking change? 
This affects results at  machine truncation level for all 3 Ocean in P-coord test experiments (updated here from reference machine & compiler).

## Other information:

## Suggested addition to `tag-index`
o model/src:
  - more precise specific-volume anomaly expression for Ocean in P-coord;
    update reference output of all 3 Ocean in P test experiments.
