### PR TITLE
Cleaning in pkg/diagnostics

### DIFF
--- a/doc/tag-index
+++ b/doc/tag-index
@@ -1,6 +1,13 @@
     Notes on tags used in MITgcmUV
     ==============================
 
+o pkg/diagnostics:
+  - new header file "DIAGNOSTICS_P2SHARE.h" (for now, just for useDiag4AdjOutp),
+    and remove DIAGNOSTICS.h in any src code outside pkg/diagnostics;
+  - new params "diag_dBugLevel" (default = main model "debugLevel");
+  - add new arg "seqFlag" to DIAGNOSTICS_SWITCH_ONOFF and DIAGNOSTICS_SUMMARY
+    and prevent "diagnostics_status" to be overwritten when using ADJ-diags.
+
 checkpoint68x (2024/04/30)
 o model/src:
   - more precise specific-volume anomaly expression for Ocean in P-coord;

--- a/model/src/forward_step.F
+++ b/model/src/forward_step.F
@@ -507,7 +507,7 @@ C--   Switch on/off individual tracer time-stepping
 C--   Switch on/off diagnostics for snap-shot output:
 #ifdef ALLOW_DIAGNOSTICS
       IF ( useDiagnostics ) THEN
-        CALL DIAGNOSTICS_SWITCH_ONOFF( myTime, myIter, myThid )
+        CALL DIAGNOSTICS_SWITCH_ONOFF( 1, myTime, myIter, myThid )
 C--   State-variables diagnostics
         CALL TIMER_START('DO_STATEVARS_DIAGS  [FORWARD_STEP]',myThid)
         CALL DO_STATEVARS_DIAGS( myTime, 0, myIter, myThid )

--- a/pkg/autodiff/addummy_in_stepping.F
+++ b/pkg/autodiff/addummy_in_stepping.F
@@ -5,9 +5,6 @@
 #ifdef ALLOW_CTRL
 # include "CTRL_OPTIONS.h"
 #endif
-#ifdef ALLOW_DIAGNOSTICS
-# include "DIAG_OPTIONS.h"
-#endif
 #ifdef ALLOW_GMREDI
 # include "GMREDI_OPTIONS.h"
 #endif
@@ -72,8 +69,7 @@ C- Note: Since OpenAD uses modules, the ordering of included headers matters
 #  include "MNC_PARAMS.h"
 # endif
 # ifdef ALLOW_DIAGNOSTICS
-#  include "DIAGNOSTICS_SIZE.h"
-#  include "DIAGNOSTICS.h"
+#  include "DIAGNOSTICS_P2SHARE.h"
 # endif
 #endif /* ALLOW_AUTODIFF_MONITOR */
 

--- a/pkg/autodiff/autodiff_check.F
+++ b/pkg/autodiff/autodiff_check.F
@@ -1,10 +1,5 @@
-C---+----1----+----2----+----3----+----4----+----5----+----6----+----7-|--+----|
-
 #include "AUTODIFF_OPTIONS.h"
 #include "AD_CONFIG.h"
-#ifdef ALLOW_DIAGNOSTICS
-# include "DIAG_OPTIONS.h"
-#endif
 
 CBOP
 C     !ROUTINE: AUTODIFF_CHECK
@@ -23,8 +18,7 @@ C     \ev
 # include "tamc.h"
 #endif
 #ifdef ALLOW_DIAGNOSTICS
-# include "DIAGNOSTICS_SIZE.h"
-# include "DIAGNOSTICS.h"
+# include "DIAGNOSTICS_P2SHARE.h"
 #endif
 
 C     !INPUT/OUTPUT PARAMETERS:
@@ -33,6 +27,8 @@ C     myThid -  Number of this instances
 C     msgBuf :: Informational/error message buffer
       CHARACTER*(MAX_LEN_MBUF) msgBuf
 CEOP
+
+C---+----1----+----2----+----3----+----4----+----5----+----6----+----7-|--+----|
 
 #ifdef ALLOW_AUTODIFF_TAMC
 

--- a/pkg/autodiff/autodiff_inadmode_set_ad.F
+++ b/pkg/autodiff/autodiff_inadmode_set_ad.F
@@ -30,8 +30,7 @@ C     == Global variables ===
 # include "CTRL.h"
 #endif
 #ifdef ALLOW_DIAGNOSTICS
-# include "DIAGNOSTICS_SIZE.h"
-# include "DIAGNOSTICS.h"
+# include "DIAGNOSTICS_P2SHARE.h"
 #endif /* ALLOW_DIAGNOSTICS */
 
 C     !INPUT/OUTPUT PARAMETERS:

--- a/pkg/autodiff/autodiff_inadmode_set_ad.F
+++ b/pkg/autodiff/autodiff_inadmode_set_ad.F
@@ -57,7 +57,7 @@ C--   Set backward-sweep switch:
 C-    Consistent with S/R DIAGNOSTICS_WRITE_ADJ and where both S/R are called:
         wrIter = myIter - 1
         wrTime = myTime - deltaTClock
-        CALL DIAGNOSTICS_SWITCH_ONOFF( wrTime, wrIter, myThid )
+        CALL DIAGNOSTICS_SWITCH_ONOFF( -1, wrTime, wrIter, myThid )
       ENDIF
 #endif /* ALLOW_DIAGNOSTICS */
 

--- a/pkg/autodiff/autodiff_inadmode_unset_ad.F
+++ b/pkg/autodiff/autodiff_inadmode_unset_ad.F
@@ -25,8 +25,7 @@ C     == Global variables ===
 #endif
 #ifdef ALLOW_AUTODIFF_MONITOR
 # ifdef ALLOW_DIAGNOSTICS
-#  include "DIAGNOSTICS_SIZE.h"
-#  include "DIAGNOSTICS.h"
+#  include "DIAGNOSTICS_P2SHARE.h"
 # endif
 #endif /* ALLOW_AUTODIFF_MONITOR */
 

--- a/pkg/autodiff/dump_adj_xy.F
+++ b/pkg/autodiff/dump_adj_xy.F
@@ -1,7 +1,4 @@
 #include "AUTODIFF_OPTIONS.h"
-#ifdef ALLOW_DIAGNOSTICS
-# include "DIAG_OPTIONS.h"
-#endif
 #include "AD_CONFIG.h"
 
 CBOP
@@ -25,8 +22,7 @@ C     == Global variables ===
 #include "AUTODIFF_PARAMS.h"
 #ifdef ALLOW_AUTODIFF_MONITOR
 # ifdef ALLOW_DIAGNOSTICS
-#  include "DIAGNOSTICS_SIZE.h"
-#  include "DIAGNOSTICS.h"
+#  include "DIAGNOSTICS_P2SHARE.h"
 # endif
 #endif /* ALLOW_AUTODIFF_MONITOR */
 

--- a/pkg/autodiff/dump_adj_xy_uv.F
+++ b/pkg/autodiff/dump_adj_xy_uv.F
@@ -1,7 +1,4 @@
 #include "AUTODIFF_OPTIONS.h"
-#ifdef ALLOW_DIAGNOSTICS
-# include "DIAG_OPTIONS.h"
-#endif
 #include "AD_CONFIG.h"
 
 CBOP
@@ -26,8 +23,7 @@ C     == Global variables ===
 #include "AUTODIFF_PARAMS.h"
 #ifdef ALLOW_AUTODIFF_MONITOR
 # ifdef ALLOW_DIAGNOSTICS
-#  include "DIAGNOSTICS_SIZE.h"
-#  include "DIAGNOSTICS.h"
+#  include "DIAGNOSTICS_P2SHARE.h"
 # endif
 #endif /* ALLOW_AUTODIFF_MONITOR */
 

--- a/pkg/autodiff/dump_adj_xyz.F
+++ b/pkg/autodiff/dump_adj_xyz.F
@@ -1,7 +1,4 @@
 #include "AUTODIFF_OPTIONS.h"
-#ifdef ALLOW_DIAGNOSTICS
-# include "DIAG_OPTIONS.h"
-#endif
 #include "AD_CONFIG.h"
 
 CBOP
@@ -26,8 +23,7 @@ C     == Global variables ===
 #include "AUTODIFF_PARAMS.h"
 #ifdef ALLOW_AUTODIFF_MONITOR
 # ifdef ALLOW_DIAGNOSTICS
-#  include "DIAGNOSTICS_SIZE.h"
-#  include "DIAGNOSTICS.h"
+#  include "DIAGNOSTICS_P2SHARE.h"
 # endif
 #endif /* ALLOW_AUTODIFF_MONITOR */
 

--- a/pkg/autodiff/dump_adj_xyz_uv.F
+++ b/pkg/autodiff/dump_adj_xyz_uv.F
@@ -1,7 +1,4 @@
 #include "AUTODIFF_OPTIONS.h"
-#ifdef ALLOW_DIAGNOSTICS
-# include "DIAG_OPTIONS.h"
-#endif
 #include "AD_CONFIG.h"
 
 CBOP
@@ -26,8 +23,7 @@ C     == Global variables ===
 #include "AUTODIFF_PARAMS.h"
 #ifdef ALLOW_AUTODIFF_MONITOR
 # ifdef ALLOW_DIAGNOSTICS
-#  include "DIAGNOSTICS_SIZE.h"
-#  include "DIAGNOSTICS.h"
+#  include "DIAGNOSTICS_P2SHARE.h"
 # endif
 #endif /* ALLOW_AUTODIFF_MONITOR */
 

--- a/pkg/diagnostics/DIAGNOSTICS.h
+++ b/pkg/diagnostics/DIAGNOSTICS.h
@@ -137,13 +137,11 @@ c    &   , misValInt
 C---+----1----+----2----+----3----+----4----+----5----+----6----+----7-|--+----|
 
 C  - DIAG_PARAMS common block:
-C    useDiag4AdjOutp :: use diagnostics pkg for Adjoint variables
 C    diagLoc_ioUnit :: internal parameter: I/O unit for local diagnostics output
 C    dumpAtLast :: always write time-ave (freq>0) diagnostics at the end of the run
 C    diagMdsDir :: directory where diagnostics will be written when using mds
 C    diagMdsDirCreate :: system call to mkdir to create diagMdsDir
       INTEGER diagLoc_ioUnit
-      LOGICAL useDiag4AdjOutp
       LOGICAL dumpAtLast,              diagMdsDirCreate
       LOGICAL diag_pickup_read,        diag_pickup_write
       LOGICAL diag_pickup_read_mdsio,  diag_pickup_write_mdsio
@@ -152,7 +150,7 @@ C    diagMdsDirCreate :: system call to mkdir to create diagMdsDir
 
       COMMON / DIAG_PARAMS_I /
      &     diagLoc_ioUnit
-      COMMON / DIAG_PARAMS_L /      useDiag4AdjOutp,
+      COMMON / DIAG_PARAMS_L /
      &     dumpAtLast,              diagMdsDirCreate,
      &     diag_pickup_read,        diag_pickup_write,
      &     diag_pickup_read_mdsio,  diag_pickup_write_mdsio,

--- a/pkg/diagnostics/DIAGNOSTICS.h
+++ b/pkg/diagnostics/DIAGNOSTICS.h
@@ -138,10 +138,11 @@ C---+----1----+----2----+----3----+----4----+----5----+----6----+----7-|--+----|
 
 C  - DIAG_PARAMS common block:
 C    diagLoc_ioUnit :: internal parameter: I/O unit for local diagnostics output
-C    dumpAtLast :: always write time-ave (freq>0) diagnostics at the end of the run
+C    diag_dBugLevel :: control debug print to STDOUT or log file, higher -> more
+C    dumpAtLast :: always write time-ave (freq>0) diagnostics at end of the run
 C    diagMdsDir :: directory where diagnostics will be written when using mds
 C    diagMdsDirCreate :: system call to mkdir to create diagMdsDir
-      INTEGER diagLoc_ioUnit
+      INTEGER diagLoc_ioUnit, diag_dBugLevel
       LOGICAL dumpAtLast,              diagMdsDirCreate
       LOGICAL diag_pickup_read,        diag_pickup_write
       LOGICAL diag_pickup_read_mdsio,  diag_pickup_write_mdsio
@@ -149,7 +150,7 @@ C    diagMdsDirCreate :: system call to mkdir to create diagMdsDir
       CHARACTER*(MAX_LEN_FNAM) diagMdsDir
 
       COMMON / DIAG_PARAMS_I /
-     &     diagLoc_ioUnit
+     &     diagLoc_ioUnit, diag_dBugLevel
       COMMON / DIAG_PARAMS_L /
      &     dumpAtLast,              diagMdsDirCreate,
      &     diag_pickup_read,        diag_pickup_write,

--- a/pkg/diagnostics/DIAGNOSTICS_P2SHARE.h
+++ b/pkg/diagnostics/DIAGNOSTICS_P2SHARE.h
@@ -1,0 +1,19 @@
+CBOP
+C     !ROUTINE: DIAGNOSTICS_P2SHARE.h
+C     !INTERFACE:
+C     #include "DIAGNOSTICS_P2SHARE.h"
+
+C     !DESCRIPTION:
+C     *================================================================*
+C     | DIAGNOSTICS_P2SHARE.h
+C     | o Header file for pkg "diagnostics" parameters that are used
+C     |   outside pkg/diagnostics (and need to be shared).
+C     *================================================================*
+CEOP
+
+C  - DIAG_PARAMS_TO_SHARE common block:
+C    useDiag4AdjOutp :: use diagnostics pkg for Adjoint variables
+      LOGICAL useDiag4AdjOutp
+      COMMON / DIAG_PARAMS_TO_SHARE_L / useDiag4AdjOutp
+
+C---+----1----+----2----+----3----+----4----+----5----+----6----+----7-|--+----|

--- a/pkg/diagnostics/diagnostics_calc_phivel.F
+++ b/pkg/diagnostics/diagnostics_calc_phivel.F
@@ -177,7 +177,7 @@ C-    Normalise Matrice & RHS :
           DO bi = myBxLo(myThid), myBxHi(myThid)
            DO j = 1,sNy
             DO i = 1,sNx
-              rhsMax = MAX(ABS(b2d(I,J,bi,bj)),rhsMax)
+              rhsMax = MAX(ABS(b2d(i,j,bi,bj)),rhsMax)
             ENDDO
            ENDDO
           ENDDO
@@ -217,7 +217,7 @@ c             x2d(i,j,bi,bj) =  x2d(i,j,bi,bj) /x2dNorm
           ENDDO
         ENDIF
 
-        IF ( debugLevel.GE.debLevA .AND. k.EQ.1 ) THEN
+        IF ( diag_dBugLevel.GE.debLevA .AND. k.EQ.1 ) THEN
           _BEGIN_MASTER( myThid )
           WRITE(standardMessageUnit,'(A,I9,2(A,1P1E13.6),A,1P1E9.2)')
      &     ' diag_cg2d (it=', myIter,') a2dNorm,x2dNorm=', a2dNorm,
@@ -234,7 +234,7 @@ c             x2d(i,j,bi,bj) =  x2d(i,j,bi,bj) /x2dNorm
      O                nIterMin,
      I                diagCG_prtResFrq, myThid )
 
-        IF ( debugLevel.GE.debLevA ) THEN
+        IF ( diag_dBugLevel.GE.debLevA ) THEN
           _BEGIN_MASTER( myThid )
           WRITE(standardMessageUnit,'(A,I4,A,2I6,A,1P3E14.7)')
      &    ' diag_cg2d : k=', k, ' , it=', nIterMin, numIters,

--- a/pkg/diagnostics/diagnostics_check.F
+++ b/pkg/diagnostics/diagnostics_check.F
@@ -17,6 +17,7 @@ C     !USES:
 #include "PARAMS.h"
 #include "GRID.h"
 #include "DIAGNOSTICS_SIZE.h"
+#include "DIAGNOSTICS_P2SHARE.h"
 #include "DIAGNOSTICS.h"
 
 C     !INPUT PARAMETERS:

--- a/pkg/diagnostics/diagnostics_init_varia.F
+++ b/pkg/diagnostics/diagnostics_init_varia.F
@@ -5,8 +5,7 @@ CBOP 0
 C     !ROUTINE: DIAGNOSTICS_INIT_VARIA
 
 C     !INTERFACE:
-      SUBROUTINE DIAGNOSTICS_INIT_VARIA(
-     I     myThid )
+      SUBROUTINE DIAGNOSTICS_INIT_VARIA( myThid )
 
 C     !DESCRIPTION:
 C     Initialize the qdiag array which accumulates during integration
@@ -68,7 +67,7 @@ C--   Zero out the qSdiag array (statistics) which accumulates during integratio
 
       CALL DIAGNOSTICS_READ_PICKUP( myThid )
 
-      CALL DIAGNOSTICS_SUMMARY( startTime, nIter0, myThid )
+      CALL DIAGNOSTICS_SUMMARY( 0, startTime, nIter0, myThid )
 
       RETURN
       END

--- a/pkg/diagnostics/diagnostics_out.F
+++ b/pkg/diagnostics/diagnostics_out.F
@@ -200,7 +200,7 @@ C--     Start processing 1 Fld :
 C-        Post-Processed diag from an other Post-Processed diag -and-
 C         both of them have just been calculated and are still stored in qtmp:
 C         => skip computation and just write qtmp2
-            IF ( debugLevel.GE.debLevB .AND. myThid.EQ.1 ) THEN
+            IF ( diag_dBugLevel.GE.debLevB .AND. myThid.EQ.1 ) THEN
                WRITE(ioUnit,'(A,I6,3A,I6)')
      &         '  get Post-Proc. Diag # ', ndId, '  ', cdiag(ndId),
      &         ' from previous computation of Diag # ', isComputed
@@ -252,7 +252,7 @@ C-        Empty diagnostics case :
 C-        diagnostics is not empty :
             isComputed = 0
 
-            IF ( debugLevel.GE.debLevB .AND. myThid.EQ.1 ) THEN
+            IF ( diag_dBugLevel.GE.debLevB .AND. myThid.EQ.1 ) THEN
               IF ( ppFld.GE.1 ) THEN
                WRITE(ioUnit,'(A,I6,7A,I8,2A)')
      &         ' Post-Processing Diag # ', ndId, '  ', cdiag(ndId),

--- a/pkg/diagnostics/diagnostics_readparms.F
+++ b/pkg/diagnostics/diagnostics_readparms.F
@@ -16,6 +16,7 @@ C     !USES:
 #include "EEPARAMS.h"
 #include "PARAMS.h"
 #include "DIAGNOSTICS_SIZE.h"
+#include "DIAGNOSTICS_P2SHARE.h"
 #include "DIAGNOSTICS.h"
 #include "DIAGNOSTICS_CALC.h"
 #include "DIAGSTATS_REGIONS.h"

--- a/pkg/diagnostics/diagnostics_readparms.F
+++ b/pkg/diagnostics/diagnostics_readparms.F
@@ -92,7 +92,7 @@ C--   full level output:
      &     averagingFreq, averagingPhase, repeatCycle,
      &     missing_value, missing_value_int,
      &     levels, fields, fileName, fileFlags,
-     &     dumpAtLast, diag_mnc, useMissingValue,
+     &     dumpAtLast, diag_dBugLevel, diag_mnc, useMissingValue,
      &     diagCG_maxIters, diagCG_resTarget,
      &     diagCG_pcOffDFac, diagCG_prtResFrq, xPsi0, yPsi0,
      &     diag_pickup_read,     diag_pickup_write,
@@ -149,6 +149,7 @@ c       missing_value(l)     = UNSET_RL
         ENDDO
       ENDDO
       diagLoc_ioUnit = 0
+      diag_dBugLevel = debugLevel
       dumpAtLast   = .FALSE.
       diag_mnc     = useMNC
       useMissingValue = .FALSE.
@@ -521,8 +522,13 @@ C---+----1----+----2----+----3----+----4----+----5----+----6----+----7-|--+----|
 C     Echo History List Data Structure
       stdUnit = standardMessageUnit
       WRITE(msgBuf,'(A)')
+     & '-----------------------------------------------------'
+      CALL PRINT_MESSAGE( msgBuf, stdUnit,SQUEEZE_RIGHT, myThid)
+      WRITE(msgBuf,'(A)')
      &     ' DIAGNOSTICS_READPARMS: global parameter summary:'
       CALL PRINT_MESSAGE( msgBuf, stdUnit,SQUEEZE_RIGHT, myThid)
+      CALL WRITE_0D_I( diag_dBugLevel, INDEX_NONE,
+     & ' diag_dBugLevel =', ' /* level of printed debug messages */')
       CALL WRITE_0D_L( dumpAtLast, INDEX_NONE,
      & ' dumpAtLast =',' /* always write time-ave diags at the end */')
       CALL WRITE_0D_L( diag_mnc,   INDEX_NONE,

--- a/pkg/diagnostics/diagnostics_set_levels.F
+++ b/pkg/diagnostics/diagnostics_set_levels.F
@@ -180,7 +180,7 @@ C--   Print to standard output
 
 C---+----1----+----2----+----3----+----4----+----5----+----6----+----7-|--+----|
 C     write a summary of the (long) list of all available diagnostics:
-      IF ( debugLevel.GE.debLevA .AND. myProcId.EQ.0 ) THEN
+      IF ( diag_dBugLevel.GE.debLevA .AND. myProcId.EQ.0 ) THEN
 
         WRITE(msgBuf,'(2A)')
      &   ' write list of available Diagnostics to file: ',

--- a/pkg/diagnostics/diagnostics_set_pointers.F
+++ b/pkg/diagnostics/diagnostics_set_pointers.F
@@ -19,6 +19,7 @@ C     == Global variables ===
 #include "EEPARAMS.h"
 #include "SIZE.h"
 #include "DIAGNOSTICS_SIZE.h"
+#include "DIAGNOSTICS_P2SHARE.h"
 #include "DIAGNOSTICS.h"
 
 C     !INPUT/OUTPUT PARAMETERS:

--- a/pkg/diagnostics/diagnostics_summary.F
+++ b/pkg/diagnostics/diagnostics_summary.F
@@ -44,7 +44,7 @@ C     !LOCAL VARIABLES:
 
 C---+----1----+----2----+----3----+----4----+----5----+----6----+----7-|--+----|
 
-      IF ( debugLevel.GE.debLevB ) THEN
+      IF ( diag_dBugLevel.GE.debLevB ) THEN
        IF ( myIter.EQ.nIter0 ) THEN
         outpSummary = .TRUE.
         dUnit = standardMessageUnit
@@ -67,7 +67,7 @@ C---+----1----+----2----+----3----+----4----+----5----+----6----+----7-|--+----|
        outpSummary = .FALSE.
       ENDIF
 
-      IF ( outpSummary .AND. debugLevel.GE.debLevB ) THEN
+      IF ( outpSummary .AND. diag_dBugLevel.GE.debLevB ) THEN
 C---+----1----+----2----+----3----+----4----+----5----+----6----+----7-|--+----|
 C     write a summary diagnostics state:
 

--- a/pkg/diagnostics/diagnostics_summary.F
+++ b/pkg/diagnostics/diagnostics_summary.F
@@ -4,7 +4,8 @@ CBOP 0
 C     !ROUTINE: DIAGNOSTICS_SUMMARY
 
 C     !INTERFACE:
-      SUBROUTINE DIAGNOSTICS_SUMMARY( myTime, myIter, myThid )
+      SUBROUTINE DIAGNOSTICS_SUMMARY(
+     I                       seqFlag, myTime, myIter, myThid )
 
 C     !DESCRIPTION:
 C     Write a summary of diagnostics state to ASCII file unit "dUnit"
@@ -21,10 +22,20 @@ C     !USES:
 #include "DIAGNOSTICS.h"
 
 C     !INPUT PARAMETERS:
-C     myThid :: my Thread Id number
+C     seqFlag  :: flag that indicates where this S/R is called from:
+C              :: = 0 : called from DIAGNOSTICS_INIT_VARIA
+C              :: = 1 : called from DIAGNOSTICS_WRITE, forward sweep
+C              :: =-1 : called from DIAGNOSTICS_WRITE_ADJ, backward sweep
+C     myTime   :: current Time of simulation ( s )
+C     myIter   :: current Iteration number
+C     myThid   :: my Thread Id number
+      INTEGER seqFlag
       _RL     myTime
       INTEGER myIter, myThid
-CEOP
+
+C     !FUNCTIONS:
+      INTEGER  ILNBLNK
+      EXTERNAL ILNBLNK
 
 C     !LOCAL VARIABLES:
       INTEGER md, ld, ndId, ipt, im
@@ -36,8 +47,10 @@ C     !LOCAL VARIABLES:
       CHARACTER*(MAX_LEN_FNAM) fn
       CHARACTER*(72) ccLine, ccFlds, ccList
       LOGICAL  outpSummary
-      INTEGER  ILNBLNK
-      EXTERNAL ILNBLNK
+#ifdef ALLOW_AUTODIFF
+      CHARACTER*(3) sfx3c
+#endif
+CEOP
 
       _BEGIN_MASTER( myThid )
       stdUnit = standardMessageUnit
@@ -45,7 +58,7 @@ C     !LOCAL VARIABLES:
 C---+----1----+----2----+----3----+----4----+----5----+----6----+----7-|--+----|
 
       IF ( diag_dBugLevel.GE.debLevB ) THEN
-       IF ( myIter.EQ.nIter0 ) THEN
+       IF ( seqFlag.EQ.0 ) THEN
         outpSummary = .TRUE.
         dUnit = standardMessageUnit
         WRITE(msgBuf,'(A,I6)')
@@ -54,7 +67,14 @@ C---+----1----+----2----+----3----+----4----+----5----+----6----+----7-|--+----|
        ELSE
         outpSummary = ( myXGlobalLo.EQ.1 .AND. myYGlobalLo.EQ.1 )
         IF ( outpSummary ) THEN
-         WRITE(fn,'(A,I10.10,A)') 'diagnostics_status.',myIter,'.txt'
+#ifdef ALLOW_AUTODIFF
+         sfx3c = 'fwd'
+         IF ( seqFlag.EQ.-1 ) sfx3c = 'adm'
+         WRITE(fn,'(3A,I10.10,A)') 'diagnostics_status.',
+     %                              sfx3c, '.', myIter, '.txt'
+#else /* ALLOW_AUTODIFF */
+         WRITE(fn,'(A,I10.10,A)') 'diagnostics_status.', myIter, '.txt'
+#endif /* ALLOW_AUTODIFF */
          iLen = ILNBLNK(fn)
          CALL MDSFINDUNIT( dUnit, myThid )
          OPEN(dUnit,file=fn(1:iLen),status='unknown',form='formatted')

--- a/pkg/diagnostics/diagnostics_switch_onoff.F
+++ b/pkg/diagnostics/diagnostics_switch_onoff.F
@@ -5,7 +5,8 @@ CBOP 0
 C     !ROUTINE: DIAGNOSTICS_SWITCH_ONOFF
 
 C     !INTERFACE:
-      SUBROUTINE DIAGNOSTICS_SWITCH_ONOFF( myTime, myIter, myThid )
+      SUBROUTINE DIAGNOSTICS_SWITCH_ONOFF( 
+     I                       seqFlag, myTime, myIter, myThid )
 
 C     !DESCRIPTION:
 C-----
@@ -27,9 +28,13 @@ C     !USES:
 #include "DIAGNOSTICS.h"
 
 C     !INPUT PARAMETERS:
-C     myTime     :: current Time of simulation ( s )
-C     myIter     :: current Iteration number
-C     myThid     :: my Thread Id number
+C     seqFlag  :: flag that indicates where this S/R is called from:
+C              :: = 1 : called from the top of FORWARD_STEP, forward sweep
+C              :: =-1 : called from AUTODIFF_INADMODE_SET_AD, backward sweep
+C     myTime   :: current Time of simulation ( s )
+C     myIter   :: current Iteration number
+C     myThid   :: my Thread Id number
+      INTEGER seqFlag
       _RL     myTime
       INTEGER myIter
       INTEGER myThid

--- a/pkg/diagnostics/diagnostics_switch_onoff.F
+++ b/pkg/diagnostics/diagnostics_switch_onoff.F
@@ -59,7 +59,7 @@ c     INTEGER newIter
 
 C---+----1----+----2----+----3----+----4----+----5----+----6----+----7-|--+----|
 
-      dBugFlag = debugLevel.GE.debLevE .AND. myThid.EQ.1
+      dBugFlag = diag_dBugLevel.GE.debLevE .AND. myThid.EQ.1
       dBugUnit = errorMessageUnit
 
 C--   Track diagnostics pkg activation status:
@@ -167,7 +167,7 @@ C---+----1----+----2----+----3----+----4----+----5----+----6----+----7-|--+----|
        IF ( diagSt_freq(n).LT.0. ) THEN
 C--    Select diagnostics list that uses instantaneous output
 
-        dBugFlag = debugLevel.GE.debLevE
+        dBugFlag = diag_dBugLevel.GE.debLevE
 
         freqSec = diagSt_freq(n)
         phiSec = diagSt_phase(n)

--- a/pkg/diagnostics/diagnostics_write.F
+++ b/pkg/diagnostics/diagnostics_write.F
@@ -18,8 +18,9 @@ C***********************************************************************
        IMPLICIT NONE
 #include "EEPARAMS.h"
 #include "SIZE.h"
-#include "DIAGNOSTICS_SIZE.h"
 #include "PARAMS.h"
+#include "DIAGNOSTICS_SIZE.h"
+#include "DIAGNOSTICS_P2SHARE.h"
 #include "DIAGNOSTICS.h"
 
 C     !INPUT PARAMETERS:

--- a/pkg/diagnostics/diagnostics_write.F
+++ b/pkg/diagnostics/diagnostics_write.F
@@ -148,7 +148,7 @@ C-      end loop on list id number n
 C---+----1----+----2----+----3----+----4----+----5----+----6----+----7-|--+----|
 
         IF ( write2file ) THEN
-          IF ( debugLevel.GE.debLevC ) THEN
+          IF ( diag_dBugLevel.GE.debLevC ) THEN
             CALL DIAGNOSTICS_SUMMARY( myTime, myIter, myThid )
           ENDIF
 C-      wait for everyone before setting arrays to zero:

--- a/pkg/diagnostics/diagnostics_write.F
+++ b/pkg/diagnostics/diagnostics_write.F
@@ -1,8 +1,8 @@
 #include "DIAG_OPTIONS.h"
 
-      SUBROUTINE DIAGNOSTICS_WRITE (
-     I                               modelEnd,
-     I                               myTime, myIter, myThid )
+      SUBROUTINE DIAGNOSTICS_WRITE(
+     I                              modelEnd,
+     I                              myTime, myIter, myThid )
 C***********************************************************************
 C  Purpose
 C  -------
@@ -149,7 +149,7 @@ C---+----1----+----2----+----3----+----4----+----5----+----6----+----7-|--+----|
 
         IF ( write2file ) THEN
           IF ( diag_dBugLevel.GE.debLevC ) THEN
-            CALL DIAGNOSTICS_SUMMARY( myTime, myIter, myThid )
+            CALL DIAGNOSTICS_SUMMARY( 1, myTime, myIter, myThid )
           ENDIF
 C-      wait for everyone before setting arrays to zero:
           _BARRIER

--- a/pkg/diagnostics/diagnostics_write_adj.F
+++ b/pkg/diagnostics/diagnostics_write_adj.F
@@ -103,7 +103,7 @@ C--- No Statistics Diag. Output for adjoint variables
 C---+----1----+----2----+----3----+----4----+----5----+----6----+----7-|--+----|
 
       IF ( write2file ) THEN
-        IF ( debugLevel.GE.debLevC ) THEN
+        IF ( diag_dBugLevel.GE.debLevC ) THEN
           CALL DIAGNOSTICS_SUMMARY( myTime, myIter, myThid )
         ENDIF
 C-    wait for everyone before setting arrays to zero:

--- a/pkg/diagnostics/diagnostics_write_adj.F
+++ b/pkg/diagnostics/diagnostics_write_adj.F
@@ -1,6 +1,6 @@
 #include "DIAG_OPTIONS.h"
 
-      SUBROUTINE DIAGNOSTICS_WRITE_ADJ (
+      SUBROUTINE DIAGNOSTICS_WRITE_ADJ(
      I                               modelStart,
      I                               myTime, myIter, myThid )
 C***********************************************************************
@@ -104,7 +104,7 @@ C---+----1----+----2----+----3----+----4----+----5----+----6----+----7-|--+----|
 
       IF ( write2file ) THEN
         IF ( diag_dBugLevel.GE.debLevC ) THEN
-          CALL DIAGNOSTICS_SUMMARY( myTime, myIter, myThid )
+          CALL DIAGNOSTICS_SUMMARY( -1, myTime, myIter, myThid )
         ENDIF
 C-    wait for everyone before setting arrays to zero:
         _BARRIER

--- a/pkg/diagnostics/diagstats_output.F
+++ b/pkg/diagnostics/diagstats_output.F
@@ -112,7 +112,7 @@ C-          Check for empty Diag (= not filled or using empty mask)
              _END_MASTER( myThid )
             ENDIF
 
-            IF ( debugLevel .GE. debLevB ) THEN
+            IF ( diag_dBugLevel .GE. debLevB ) THEN
              _BEGIN_MASTER( myThid )
               WRITE(ioUnit,'(A,I6,3A,I4,A,1PE10.3,2A)')
      &         ' Compute Stats, Diag. # ',ndId, '  ', cdiag(ndId),

--- a/pkg/diagnostics/diagstats_set_regions.F
+++ b/pkg/diagnostics/diagstats_set_regions.F
@@ -38,7 +38,7 @@ C     == Local variables ==
       CHARACTER*(MAX_LEN_MBUF) tmpBuf
       INTEGER ioUnit
       INTEGER k, nbReg
-      _RS     tmpVar(1-OLx:sNx+Olx,1-Oly:sNy+Oly,nSx,nSy)
+      _RS     tmpVar(1-OLx:sNx+OLx,1-OLy:sNy+OLy,nSx,nSy)
       COMMON / SET_REGIONS_LOCAL / tmpVar
 #else
       LOGICAL flag
@@ -52,8 +52,8 @@ C--   Initialize region-mask array to zero:
       DO bj = myByLo(myThid), myByHi(myThid)
        DO bi = myBxLo(myThid), myBxHi(myThid)
         DO k=1,sizRegMsk
-         DO j=1-Oly,sNy+Oly
-          DO i=1-Olx,sNx+Olx
+         DO j=1-OLy,sNy+OLy
+          DO i=1-OLx,sNx+OLx
            diagSt_regMask(i,j,k,bi,bj) = 0.
           ENDDO
          ENDDO
@@ -100,8 +100,8 @@ C       _END_MASTER( myThid )
         _EXCH_XY_RS( tmpVar, myThid )
         DO bj = myByLo(myThid), myByHi(myThid)
          DO bi = myBxLo(myThid), myBxHi(myThid)
-          DO j=1-Oly,sNy+Oly
-           DO i=1-Olx,sNx+Olx
+          DO j=1-OLy,sNy+OLy
+           DO i=1-OLx,sNx+OLx
             diagSt_regMask(i,j,k,bi,bj) = tmpVar(i,j,bi,bj)
            ENDDO
           ENDDO
@@ -150,7 +150,7 @@ c         ELSE
 c           tmpVar(i,j,bi,bj) = 0.
 c         ELSE
 C-      print region mask:
-c         IF ( debugLevel.GE.debLevA ) THEN
+c         IF ( diag_dBugLevel.GE.debLevA ) THEN
 c           WRITE(msgBuf,'(A,I3,A)') 'DIAGSTAT Region',j,' mask:'
 c           iLen = ILNBLNK(msgBuf)
 c           CALL PLOT_FIELD_XYRS( tmpVar, msgBuf(1:iLen), -1, myThid )
@@ -161,7 +161,6 @@ c         ENDIF
 C-    Global statistics (region # 0) <- done in diagnostics_readparams
 c     diagSt_kRegMsk(0) = 1
 c     diagSt_vRegMsk(0) = 0.
-
 
       WRITE(msgBuf,'(A,I4,A)') 'DIAGSTATS_SET_REGIONS: define',
      &                         nbReg,' regions:'
@@ -190,8 +189,8 @@ C--   Initialize region-mask array to zero:
        DO bi = myBxLo(myThid), myBxHi(myThid)
 c        DO j=1-Oly,sNy+Oly
 c         DO i=1-Olx,sNx+Olx
-         DO j=1-Oly,1-Oly
-          DO i=1-Olx,1-Olx
+         DO j=1-OLy,1-OLy
+          DO i=1-OLx,1-OLx
            diagSt_regMask(i,j,1,bi,bj) = 0.
           ENDDO
          ENDDO

--- a/pkg/exf/exf_adjoint_snapshots_ad.F
+++ b/pkg/exf/exf_adjoint_snapshots_ad.F
@@ -3,9 +3,6 @@
 #ifdef ALLOW_AUTODIFF
 # include "AUTODIFF_OPTIONS.h"
 #endif
-#ifdef ALLOW_DIAGNOSTICS
-# include "DIAG_OPTIONS.h"
-#endif
 
 CBOP
 C     !ROUTINE: ADEXF_ADJOINT_SNAPSHOTS
@@ -44,10 +41,6 @@ C     == Global variables ===
 # include "AUTODIFF_PARAMS.h"
 # include "AUTODIFF.h"
 # include "adcommon.h"
-# ifdef ALLOW_DIAGNOSTICS
-#  include "DIAGNOSTICS_SIZE.h"
-#  include "DIAGNOSTICS.h"
-# endif
 #endif
 #endif /* ALLOW_AUTODIFF */
 

--- a/pkg/fizhi/fizhi_driver.F
+++ b/pkg/fizhi/fizhi_driver.F
@@ -33,12 +33,6 @@ C***********************************************************************
 
 c Diagnostic Common
 c -----------------
-#ifdef ALLOW_DIAGNOSTICS
-#include "EEPARAMS.h"
-#include "SIZE.h"
-#include "DIAGNOSTICS_SIZE.h"
-#include "DIAGNOSTICS.h"
-#endif
 
 c Timers Common
 c -------------

--- a/pkg/ptracers/ptracers_ad_dump.F
+++ b/pkg/ptracers/ptracers_ad_dump.F
@@ -3,9 +3,6 @@
 #ifdef ALLOW_AUTODIFF
 # include "AUTODIFF_OPTIONS.h"
 #endif
-#ifdef ALLOW_DIAGNOSTICS
-# include "DIAG_OPTIONS.h"
-#endif
 
 CBOP
 C     !ROUTINE: ptracers_ad_dump
@@ -41,8 +38,7 @@ C     == Global variables ===
 # include "ptracers_adcommon.h"
 #endif
 #ifdef ALLOW_DIAGNOSTICS
-# include "DIAGNOSTICS_SIZE.h"
-# include "DIAGNOSTICS.h"
+# include "DIAGNOSTICS_P2SHARE.h"
 #endif
 
 C     !INPUT/OUTPUT PARAMETERS:

--- a/pkg/seaice/seaice_ad_dump.F
+++ b/pkg/seaice/seaice_ad_dump.F
@@ -3,9 +3,6 @@
 #ifdef ALLOW_AUTODIFF
 # include "AUTODIFF_OPTIONS.h"
 #endif
-#ifdef ALLOW_DIAGNOSTICS
-# include "DIAG_OPTIONS.h"
-#endif
 
 CBOP
 C     !ROUTINE: SEAICE_AD_DUMP
@@ -44,8 +41,7 @@ C     == Global variables ===
 # include "AUTODIFF.h"
 # include "adcommon.h"
 # ifdef ALLOW_DIAGNOSTICS
-#  include "DIAGNOSTICS_SIZE.h"
-#  include "DIAGNOSTICS.h"
+#  include "DIAGNOSTICS_P2SHARE.h"
 # endif
 #endif
 

--- a/pkg/seaice/seaice_ad_dump.F
+++ b/pkg/seaice/seaice_ad_dump.F
@@ -109,14 +109,7 @@ C--   need to all the correct OpenAD EXCH S/R ; left empty for now
 
 C-----------------------------------------------------------------------
 C--- Turn diagnostics on/off
-C-----------------------------------------------------------------------
-#ifdef ALLOW_DIAGNOSTICS
-C     This has already been done in addummy_in_stepping,
-C     from where this is called
-CML      IF ( useDiag4AdjOutp ) THEN
-CML        CALL DIAGNOSTICS_SWITCH_ONOFF( myTime, myIter, myThid )
-CML      ENDIF
-#endif
+C    <-- This has already been done in autodiff_inadmode_set_ad.F
 
 C-----------------------------------------------------------------------
 C--- do dump?


### PR DESCRIPTION
## What changes does this PR introduce?
1. Cleaner code where main `pkg/diagnostics` header file `DIAGNOSTICS.h` is never included outside `pkg/diagnostics` src files. This is also safer as many variables and storage arrays in `DIAGNOSTICS.h` are not named with specific `pkg/diagnostics` suffix.
2. Small updates to help in tracking issues: specific `pkg/diagnostics` "debugLevel" ; add new argument to 2 subroutines to identify where they have been called from: this allows to fix debug report to "diagnostics_status" that was overwritten when using ADJ-diags.

## What is the current behaviour? 
1. `DIAGNOSTICS.h` is included outside `pkg/diagnostics` as parameter  `useDiag4AdjOutp` is needed in several places. This also requires to include `DIAG_OPTIONS.h` and `DIAGNOSTICS_SIZE.h`
2. "diagnostics_status" files (written when `debugLevel` is set to 3 or higher) can be overwritten when using ADJ-diags (same file name in forward and backward sweep).

## What is the new behaviour?
1. New header file `DIAGNOSTICS_P2SHARE.h`, for now just holding `useDiag4AdjOutp`, intended to included anywhere (and not just inside pkg/diagnostics`).
2. new argument to S/R DIAGNOSTICS_SWITCH_ONOFF and S/R DIAGNOSTICS_SUMMARY that identifies where S/R is called from, allowing to fix "diagnostics_status" issue.
3. New parameter `diag_dBugLevel` (default value: `debugLevel`) enable to get more debug-print from `pkg/diagnostics` without all additional debug messages that would come if setting main model `debugLevel` to the same value. 

## Does this PR introduce a breaking change? 
no.

## Other information:
Note: Before the addition of Adj-Diags, `DIAGNOSTICS.h` was not included outside `pkg/diagnostics`. This PR restaures a clean separation.

## Suggested addition to `tag-index`
o pkg/diagnostics:
  - new header file "DIAGNOSTICS_P2SHARE.h" (for now, just for useDiag4AdjOutp),
    and remove DIAGNOSTICS.h in any src code outside pkg/diagnostics;
  - new params "diag_dBugLevel" (default = main model "debugLevel");
  - add new arg "seqFlag" to DIAGNOSTICS_SWITCH_ONOFF and DIAGNOSTICS_SUMMARY
    and prevent "diagnostics_status" to be overwritten when using ADJ-diags.
