### PR TITLE
Fix for Multi-threaded test

### DIFF
--- a/verification/global_with_exf/input.yearly/eedata.mth
+++ b/verification/global_with_exf/input.yearly/eedata.mth
@@ -1,11 +1,12 @@
 # Example "eedata" file  for multi-threaded test
 #   (copy "eedata.mth" to "eedata" to use it)
 # Lines beginning "#" are comments
-# nTx - No. threads per process in X
-# nTy - No. threads per process in Y
+#  nTx      :: No. threads per process in X
+#  nTy      :: No. threads per process in Y
+# debugMode :: print debug msg (sequence of S/R calls)
  &EEPARMS
- nTx=2,
- nTy=1,
+ nTx=1,
+ nTy=2,
  &
 # Note: Some systems use & as the namelist terminator (as shown here).
 #       Other systems use a / character.

--- a/verification/global_with_exf/input/eedata
+++ b/verification/global_with_exf/input/eedata
@@ -1,11 +1,11 @@
 # Example "eedata" file
 # Lines beginning "#" are comments
-# nTx - No. threads per process in X
-# nTy - No. threads per process in Y
+#  nTx      :: No. threads per process in X
+#  nTy      :: No. threads per process in Y
+# debugMode :: print debug msg (sequence of S/R calls)
  &EEPARMS
  nTx=1,
  nTy=1,
- & 
-# Note: Some systems use & as the
-# namelist terminator. Other systems
-# use a / character (as shown here).
+ &
+# Note: Some systems use & as the namelist terminator (as shown here).
+#       Other systems use a / character.

--- a/verification/global_with_exf/input/eedata.mth
+++ b/verification/global_with_exf/input/eedata.mth
@@ -1,11 +1,12 @@
 # Example "eedata" file  for multi-threaded test
 #   (copy "eedata.mth" to "eedata" to use it)
 # Lines beginning "#" are comments
-# nTx - No. threads per process in X
-# nTy - No. threads per process in Y
+#  nTx      :: No. threads per process in X
+#  nTy      :: No. threads per process in Y
+# debugMode :: print debug msg (sequence of S/R calls)
  &EEPARMS
- nTx=2,
- nTy=1,
+ nTx=1,
+ nTy=2,
  &
 # Note: Some systems use & as the namelist terminator (as shown here).
 #       Other systems use a / character.

--- a/verification/lab_sea/input.longstep/eedata.mth
+++ b/verification/lab_sea/input.longstep/eedata.mth
@@ -1,10 +1,12 @@
-# Example "eedata" file
+# Example "eedata" file  for multi-threaded test
+#   (copy "eedata.mth" to "eedata" to use it)
 # Lines beginning "#" are comments
-# nTx - No. threads per process in X
-# nTy - No. threads per process in Y
+#  nTx      :: No. threads per process in X
+#  nTy      :: No. threads per process in Y
+# debugMode :: print debug msg (sequence of S/R calls)
  &EEPARMS
- nTx=2,
- nTy=1,
+ nTx=1,
+ nTy=2,
  &
 # Note: Some systems use & as the namelist terminator (as shown here).
 #       Other systems use a / character.

--- a/verification/natl_box/input.longstep/eedata.mth
+++ b/verification/natl_box/input.longstep/eedata.mth
@@ -1,10 +1,12 @@
-# Example "eedata" file
+# Example "eedata" file  for multi-threaded test
+#   (copy "eedata.mth" to "eedata" to use it)
 # Lines beginning "#" are comments
-# nTx - No. threads per process in X
-# nTy - No. threads per process in Y
+#  nTx      :: No. threads per process in X
+#  nTy      :: No. threads per process in Y
+# debugMode :: print debug msg (sequence of S/R calls)
  &EEPARMS
- nTx=2,
- nTy=1,
+ nTx=1,
+ nTy=2,
  &
 # Note: Some systems use & as the namelist terminator (as shown here).
 #       Other systems use a / character.

--- a/verification/natl_box/input/eedata
+++ b/verification/natl_box/input/eedata
@@ -1,11 +1,11 @@
 # Example "eedata" file
 # Lines beginning "#" are comments
-# nTx - No. threads per process in X
-# nTy - No. threads per process in Y
+#  nTx      :: No. threads per process in X
+#  nTy      :: No. threads per process in Y
+# debugMode :: print debug msg (sequence of S/R calls)
  &EEPARMS
  nTx=1,
  nTy=1,
  &
-# Note: Some systems use & as the
-# namelist terminator. Other systems
-# use a / character (as shown here).
+# Note: Some systems use & as the namelist terminator (as shown here).
+#       Other systems use a / character.

--- a/verification/natl_box/input/eedata.mth
+++ b/verification/natl_box/input/eedata.mth
@@ -1,10 +1,12 @@
-# Example "eedata" file
+# Example "eedata" file  for multi-threaded test
+#   (copy "eedata.mth" to "eedata" to use it)
 # Lines beginning "#" are comments
-# nTx - No. threads per process in X
-# nTy - No. threads per process in Y
+#  nTx      :: No. threads per process in X
+#  nTy      :: No. threads per process in Y
+# debugMode :: print debug msg (sequence of S/R calls)
  &EEPARMS
- nTx=2,
- nTy=1,
+ nTx=1,
+ nTy=2,
  &
-# Note: Some systems use & as the namelist terminator (as shown here). 
+# Note: Some systems use & as the namelist terminator (as shown here).
 #       Other systems use a / character.

--- a/verification/natl_box/input/tr_checklist
+++ b/verification/natl_box/input/tr_checklist
@@ -1,0 +1,1 @@
+PS PS T+ S+ U+ V+


### PR DESCRIPTION
## What changes does this PR introduce?
Update Multi-threaded tests setting (left from PR #830)

## What is the current behaviour? 
In PR #830, experiments `global_with_exf` and `natl_box` were merged into new host exp. but "eedata.mth" was not updated.

## What is the new behaviour 

1. fix "eedata.mth" for experiment `global_with_exf` (to keep it compatible with updated "SIZE.h")
2. fix "eedata.mth" for experiment `natl_box` to allow to run this test as secondary test in exp. lab_sea when using MPI & multi-threads (for this case, nTx & nTy have to be the same as primary test). 

## Does this PR introduce a breaking change? 
no

## Other information:
also add a "tr_checklist" file (identical to default checklist) in `natl_box/input` to avoid using customized `lab_sea/input` version when run as secondary test.

## Suggested addition to `tag-index`
not needed if merged just after PR #830