### PR TITLE
Fix RS/RL type in pkg/steep_icecavity

### DIFF
--- a/pkg/autodiff/addummy_in_stepping.F
+++ b/pkg/autodiff/addummy_in_stepping.F
@@ -194,8 +194,8 @@ C     problem occurs
 #  endif
 # endif
 # if ( defined ALLOW_SHELFICE && defined ALLOW_SHITRANSCOEFF_3D )
-        CALL ADEXCH_3D_RL( adshiTransCoeffT3d, myThid )
-        CALL ADEXCH_3D_RL( adshiTransCoeffS3d, myThid )
+        CALL ADEXCH_3D_RL( adshiTransCoeffT3d, Nr, myThid )
+        CALL ADEXCH_3D_RL( adshiTransCoeffS3d, Nr, myThid )
 # endif
 
 #endif /* AUTODIFF_TAMC_COMPATIBILITY */

--- a/pkg/steep_icecavity/stic_thermodynamics.F
+++ b/pkg/steep_icecavity/stic_thermodynamics.F
@@ -23,7 +23,7 @@ C     |   shelf-ice ocean interface
 C     |
 C     | stresses at the ice/water interface are computed in separate
 C     | routines that are called from mom_fluxform/mom_vecinv
-
+C     |
 CIGF  | ASSUMES
 C---  |   * SHELFICEconserve = true
 C     *=============================================================*
@@ -59,8 +59,8 @@ C     === Global variables ===
 
 C     !INPUT/OUTPUT PARAMETERS:
 C     === Routine arguments ===
-C     myIter :: iteration counter for this thread
 C     myTime :: time counter for this thread
+C     myIter :: iteration counter for this thread
 C     myThid :: thread number for this instance of the routine.
       _RL  myTime
       INTEGER myIter
@@ -80,8 +80,8 @@ C                         column perpendicular to the ice front extended
 C                         to the far side of the tracer cell.
 C     iceFrontWidth    :: the width of the ice front.  unit meters.
 
-      INTEGER i,j,k
-      INTEGER bi,bj
+      INTEGER i, j, k
+      INTEGER bi, bj
       INTEGER CURI, CURJ, FRONT_K
 
       _RL tLoc
@@ -654,8 +654,8 @@ c     ENDIF
 #endif /* ndef ALLOW_AUTODIFF */
 
 #ifdef ALLOW_DIAGNOSTICS
-
       IF ( useDiagnostics ) THEN
+
 #ifdef NONLIN_FRSURF
        IF ( (nonlinFreeSurf.GT.0 .OR. usingPCoords)
      &         .AND. useRealFreshWaterFlux ) THEN
@@ -698,9 +698,9 @@ c     ENDIF
      &      0,1,0,1,1,myThid)
 
 #ifdef ALLOW_STEEP_ICECAVITY
-       CALL DIAGNOSTICS_FILL_RS(sticfFreshWaterFlux,'SHIICFfw',
+       CALL DIAGNOSTICS_FILL( sticfFreshWaterFlux, 'SHIICFfw',
      &      0,1,0,1,1,myThid)
-       CALL DIAGNOSTICS_FILL_RS(sticfHeatFlux,      'SHIICFht',
+       CALL DIAGNOSTICS_FILL( sticfHeatFlux,       'SHIICFht',
      &      0,1,0,1,1,myThid)
 #endif
 
@@ -746,7 +746,7 @@ C     Friction velocity
 #endif /* SHI_ALLOW_GAMMAFRICT */
 
       ENDIF
-#endif
+#endif /* ALLOW_DIAGNOSTICS */
 
       RETURN
       END

--- a/pkg/steep_icecavity/stic_thermodynamics.F
+++ b/pkg/steep_icecavity/stic_thermodynamics.F
@@ -188,7 +188,7 @@ C     (Holland and Jenkins, 1999, eq.21)
          ENDDO
         ENDDO
 #ifdef ALLOW_DIAGNOSTICS
-c       IF ( useDiagnostics ) THEN
+        IF ( useDiagnostics ) THEN
          DO j = 1-OLy,sNy+OLy
           DO i = 1-OLx,sNx+OLx
            tmpDiagShelficeForcingT(i,j,bi,bj) = 0. _d 0
@@ -207,7 +207,7 @@ c       IF ( useDiagnostics ) THEN
            ENDDO
           ENDDO
          ENDDO
-c       ENDIF
+        ENDIF
 #endif /* ALLOW_DIAGNOSTICS */
        ENDDO
       ENDDO
@@ -446,22 +446,26 @@ C     In units of K / s
      &                    tmpForcingT/iceFrontCellThickness*
      &                    iceFrontVertContactFrac*
      &                    _recip_hFacC(CURI,CURJ,k,bi,bj)
-                        tmpDiagIcfForcingT(CURI,CURJ,k,bi,bj) =
-     &                    tmpDiagIcfForcingT(CURI,CURJ,k,bi,bj) +
-     &                    tmpForcingT/iceFrontCellThickness*
-     &                    iceFrontVertContactFrac*
-     &                    drF(k)
 C     In units of psu /s
                         stic_gS(CURI,CURJ,k,bi,bj) =
      &                    stic_gS(CURI,CURJ,k,bi,bj) +
      &                    tmpForcingS/iceFrontCellThickness*
      &                    iceFrontVertContactFrac*
      &                    _recip_hFacC(CURI,CURJ,k,bi,bj)
-                        tmpDiagIcfForcingS(CURI,CURJ,k,bi,bj) =
-     &                    tmpDiagIcfForcingS(CURI,CURJ,k,bi,bj) +
-     &                    tmpForcingS/iceFrontCellThickness*
-     &                    iceFrontVertContactFrac*
-     &                    drF(k)
+#ifdef ALLOW_DIAGNOSTICS
+                        IF ( useDiagnostics ) THEN
+                         tmpDiagIcfForcingT(CURI,CURJ,k,bi,bj) =
+     &                     tmpDiagIcfForcingT(CURI,CURJ,k,bi,bj) +
+     &                     tmpForcingT/iceFrontCellThickness*
+     &                     iceFrontVertContactFrac*
+     &                     drF(k)
+                         tmpDiagIcfForcingS(CURI,CURJ,k,bi,bj) =
+     &                     tmpDiagIcfForcingS(CURI,CURJ,k,bi,bj) +
+     &                     tmpForcingS/iceFrontCellThickness*
+     &                     iceFrontVertContactFrac*
+     &                     drF(k)
+                        ENDIF
+#endif /* ALLOW_DIAGNOSTICS */
                        ENDIF /* iceFrontCellThickness */
 C     In units of kg /s
                          stic_addMass(CURI,CURJ,k,bi,bj) =
@@ -545,16 +549,16 @@ C ow - Now add shelfice heat and freshwater fluxes
 C     In units of K/s
                 stic_gT(i,j,k,bi,bj) = stic_gT(i,j,k,bi,bj) +
      &              tmpForcingT*recip_drF(k)* _recip_hFacC(i,j,k,bi,bj)
-                tmpDiagShelficeForcingT(i,j,bi,bj) = tmpForcingT
 C     In units of psu/s
                 stic_gS(i,j,k,bi,bj) = stic_gS(i,j,k,bi,bj) +
      &              tmpForcingS*recip_drF(k)* _recip_hFacC(i,j,k,bi,bj)
-                tmpDiagShelficeForcingS(i,j,bi,bj) = tmpForcingS
 C     In units of kg/s  -- multiplication of area required first
                 stic_addMass(i,j,k,bi,bj) = stic_addMass(i,j,k,bi,bj) -
      &              tmpFWFLX*RA(i,j,bi,bj)
 #ifdef ALLOW_DIAGNOSTICS
                 IF ( useDiagnostics ) THEN
+                 tmpDiagShelficeForcingT(i,j,bi,bj) = tmpForcingT
+                 tmpDiagShelficeForcingS(i,j,bi,bj) = tmpForcingS
 #ifdef NONLIN_FRSURF
                  IF ( (nonlinFreeSurf.GT.0 .OR. usingPCoords)
      &            .AND. useRealFreshWaterFlux ) THEN

--- a/pkg/steep_icecavity/stic_thermodynamics.F
+++ b/pkg/steep_icecavity/stic_thermodynamics.F
@@ -188,7 +188,7 @@ C     (Holland and Jenkins, 1999, eq.21)
          ENDDO
         ENDDO
 #ifdef ALLOW_DIAGNOSTICS
-        IF ( useDiagnostics ) THEN
+c       IF ( useDiagnostics ) THEN
          DO j = 1-OLy,sNy+OLy
           DO i = 1-OLx,sNx+OLx
            tmpDiagShelficeForcingT(i,j,bi,bj) = 0. _d 0
@@ -207,7 +207,7 @@ C     (Holland and Jenkins, 1999, eq.21)
            ENDDO
           ENDDO
          ENDDO
-        ENDIF
+c       ENDIF
 #endif /* ALLOW_DIAGNOSTICS */
        ENDDO
       ENDDO


### PR DESCRIPTION
## What changes does this PR introduce?
Fix few issues in recently added (PR #789) package `steep_icecavity`

## What is the current behaviour? 
1. variables `sticfFreshWaterFlux` and `sticfHeatFlux` are declared "_RL" but diagnostics 'SHIICFfw' and 'SHIICFht' are filled by calling `DIAGNOSTICS_FILL_RS` (i.e., wrong type).
This only matter when "_RS" is "real*4" and fail to compile with strict S/R argument check, e.g, intel compiler & -devel:
http://mitgcm.org/testing/results/2024_05/tr_engaging-ifcMpi_20240525_0/summary.txt
2. missing "Nr" argument when calling S/R ADEXCH_3D_RL in `addummy_in_stepping.F` prevents to compile AD exp. `isomip`, as seen here:
https://mitgcm.org/testing/results/2024_05/tr_svante-ifcAdm_20240526_0/summary.txt
3. few local arrays in `stic_thermodynamics.F` are only initialised when `useDiagnostics=T` but are used even when `useDiagnostics=F`; this produce a floating point error when checking for un-initialized vars with open64 compiler and "-devel", as here:
https://mitgcm.org/testing/results/2024_05/tr_engaging-o64Adm_20240526_0/summary.txt

## What is the new behaviour 
Fix all 3.

## Does this PR introduce a breaking change? 
no

## Other information:

## Suggested addition to `tag-index`
not needed if meged just after PR #789