### PR TITLE
Fix code for ALLOW_TAPENADE

### DIFF
--- a/model/src/initialise_varia.F
+++ b/model/src/initialise_varia.F
@@ -110,11 +110,11 @@ C     == Global variables ==
 #ifdef ALLOW_AUTODIFF
 # include "GRID.h"
 # include "FFIELDS.h"
-# if ( defined ALLOW_CTRL && defined ALLOW_GENTIM2D_CONTROL )
+# if ( defined ALLOW_CTRL && defined ALLOW_GENTIM2D_CONTROL && !defined ALLOW_TAPENADE )
 #  include "CTRL_SIZE.h"
 #  include "CTRL_DUMMY.h"
-# endif /* ALLOW_CTRL and ALLOW_GENTIM2D_CONTROL */
-#endif
+# endif
+#endif /* ALLOW_AUTODIFF */
 
 #ifdef ALLOW_TAPENADE
 # ifdef ALLOW_GMREDI


### PR DESCRIPTION
## What changes does this PR introduce?
Avoid including header files  CTRL_SIZE.h` and `CTRL_DUMMY.h` twice when ALLOW_TAPENADE is defined.
This is left from PR #740 and prevent to compile all except 1 Tapenade test experiments.

## What is the current behaviour? 
Fail to compile with Tapenade anytime `ALLOW_GENTIM2D_CONTROL` is defined

## What is the new behaviour 
fix

## Does this PR introduce a breaking change? 

## Other information:


## Suggested addition to `tag-index`
not needed if merged just after PR #740