### PR TITLE
f08 flag available for TAF

### DIFF
--- a/doc/tag-index
+++ b/doc/tag-index
@@ -1,6 +1,8 @@
     Notes on tags used in MITgcmUV
     ==============================
 
+o tools/adjoint_options:
+  - allow to pass -f08 flag to TAF by setting TAF_FORTRAN_VERS to "F08".
 o pkg/mom_vecinv:
   - add more 3-D momentum tendency diagnostics (originally from Helen Pillar)
     for harmonic/bi-harmonic dissipation and for bottom + top friction

--- a/tools/adjoint_options/adjoint_default
+++ b/tools/adjoint_options/adjoint_default
@@ -48,6 +48,8 @@ if test $TAF_FORTRAN_VERS = 'F77' ; then
     TAF_COMMON_FLAGS="-f77 $TAF_COMMON_FLAGS"
 elif test $TAF_FORTRAN_VERS = 'F90' ; then
     TAF_COMMON_FLAGS="-f90 $TAF_COMMON_FLAGS"
+elif test $TAF_FORTRAN_VERS = 'F08' ; then
+    TAF_COMMON_FLAGS="-f08 $TAF_COMMON_FLAGS"
 else
     #- after Jan 14, 2016, TAF default is "-f95"
     TAF_COMMON_FLAGS="-f95 $TAF_COMMON_FLAGS"

--- a/tools/adjoint_options/adjoint_default
+++ b/tools/adjoint_options/adjoint_default
@@ -7,15 +7,6 @@
 TAF=staf
 TAMC=stamc
 
-#- select which Fortran version to specify to TAF
-if test "x$TAF_FORTRAN_VERS" = x ; then
-    if test "x$ALWAYS_USE_F90" = "x1" ; then
-	TAF_FORTRAN_VERS='F90' ;
-    else
-	TAF_FORTRAN_VERS='F77' ;
-    fi
-fi
-
 if test "x$USE_DIVA" = "x1" ; then
     DIVA='true'
     DIVA_FLAG="-pure"
@@ -42,6 +33,15 @@ fi
 
 if test "x$USE_EXTENDED_SRC" = "xt"; then
     TAF_COMMON_FLAGS="-e $TAF_COMMON_FLAGS"
+fi
+
+#- select which Fortran version to specify to TAF
+if test "x$TAF_FORTRAN_VERS" = x ; then
+    if test "x$ALWAYS_USE_F90" = "x1" ; then
+	TAF_FORTRAN_VERS='F90' ;
+    else
+	TAF_FORTRAN_VERS='F77' ;
+    fi
 fi
 
 if test $TAF_FORTRAN_VERS = 'F77' ; then


### PR DESCRIPTION
## What changes does this PR introduce?
New feature to allow passing `-f08` flag to TAF


## What is the current behaviour? 
No `-f08` flag


## What is the new behaviour 
`-f08` flag available


## Does this PR introduce a breaking change? 
NA


## Other information:
Default float is still `-f95`

## Suggested addition to `tag-index`
Allow for `-f08` flag to be passed to TAF through `TAF_COMMON_FLAGS`