### PR TITLE
modify tutorial_global_oce_optim to test f90-free format file

### DIFF
--- a/verification/tutorial_global_oce_optim/code_ad/code_ad_diff.list
+++ b/verification/tutorial_global_oce_optim/code_ad/code_ad_diff.list
@@ -1,2 +1,3 @@
 cost_temp.f
 cost_hflux.f
+cost_temp_fform.f90

--- a/verification/tutorial_global_oce_optim/code_ad/cost_temp.F
+++ b/verification/tutorial_global_oce_optim/code_ad/cost_temp.F
@@ -31,57 +31,18 @@ C     == Global variables ===
 C     !INPUT/OUTPUT PARAMETERS:
 C     myThid - Thread number for this instance of the routine.
       INTEGER myThid
-
-#ifdef ALLOW_COST_TEMP
-C     !LOCAL VARIABLES:
-      INTEGER i, j, k
-      INTEGER bi, bj
-      INTEGER Nk
-      _RL locfc,tmp
-      _RL thetalev(1-OLx:sNx+OLx,1-OLy:sNy+OLy,Nr,nSx,nSy)
 CEOP
 
-      Nk = 2
-C Read annual mean Levitus temperature
-
-      CALL READ_FLD_XYZ_RL('lev_t_an.bin',' ',thetalev,0,myThid)
-
-C  Total number of wet temperature point
-      tmp  = 0. _d 0
-      DO bj=myByLo(myThid),myByHi(myThid)
-       DO bi=myBxLo(myThid),myBxHi(myThid)
-         DO k=1, Nk
-          DO j=1,sNy
-           DO i=1,sNx
-             tmp = tmp + maskC(i,j,k,bi,bj)
-           ENDDO
-          ENDDO
-         ENDDO
-       ENDDO
-      ENDDO
-      _GLOBAL_SUM_RL( tmp , myThid )
-      IF ( tmp.GT.0. ) tmp = 1. _d 0 / tmp
-
-      DO bj=myByLo(myThid),myByHi(myThid)
-       DO bi=myBxLo(myThid),myBxHi(myThid)
-
-         locfc = 0. _d 0
-         DO k=1,Nk
-           DO j=1,sNy
-            DO i=1,sNx
-              locfc = locfc + tmp*maskC(i,j,k,bi,bj)*
-     &         wtheta(k,bi,bj)*
-     &         ( cMeanTheta(i,j,k,bi,bj) - thetalev(i,j,k,bi,bj) )**2
-            ENDDO
-           ENDDO
-         ENDDO
-
-         objf_temp_tut(bi,bj) = locfc
-c        print*,'objf_temp_tut =',locfc,startTime,endTime,tmp
-
-       ENDDO
-      ENDDO
-
+#ifdef ALLOW_COST_TEMP
+C     Abuse this routine as driver to call a free-format function
+      CALL COST_TEMP_FFORM(
+     I     sNx, sNy, nSx, nSy, OLx, OLy, Nr,
+     I     myByLo(myThid), myByHi(myThid),
+     I     myBxLo(myThid), myBxHi(myThid),
+     I     maskC, wtheta, cMeanTheta,
+     O     objf_temp_tut,
+     I     myThid )
 #endif /* ALLOW_COST_TEMP */
+
       RETURN
       END

--- a/verification/tutorial_global_oce_optim/code_ad/cost_temp_fform.F90
+++ b/verification/tutorial_global_oce_optim/code_ad/cost_temp_fform.F90
@@ -1,0 +1,104 @@
+#include "PACKAGES_CONFIG.h"
+! Copied from default CPP_EEMACROS.h
+! To avoid this, we need to find a way to include CPP_EEMACROS.h
+#define _RS Real*8
+#define _RL Real*8
+#define _GLOBAL_SUM_RL(a,b) CALL GLOBAL_SUM_R8 ( a, b )
+
+!BOP
+!     !ROUTINE: COST_TEMP_FFORM
+!     !INTERFACE:
+SUBROUTINE COST_TEMP_FFORM ( &
+     sNx, sNy, nSx, nSy, OLx, OLy, Nr, &
+     myByLo, myByHi, myBxLo, myBxHi, &
+     maskC, wtheta, cMeanTheta, &
+     objf_temp_tut, &
+     myThid )
+  !     *==========================================================*
+  !     | SUBROUTINE COST_TEMP_FFORM
+  !     | o the subroutine computes the sum of the squared errors
+  !     |   relatively to the Levitus climatology
+  !     *==========================================================*
+  !
+  !     !USES:
+  IMPLICIT NONE
+
+  !   !INPUT/OUTPUT PARAMETERS:
+  ! sNx,sNy,nSx,nSy,OLx,OLy,Nr  - array boundaries (set it SIZE.h)
+  ! myByLo,myByHi,myBxLo,myBxHi - bi/bj loop boundaries for myThid
+  ! myThid        - Thread number for this instance of the routine.
+  ! maskC         - 3D mask for C-points (defined in GRID.h)
+  ! wtheta        - 1D weights (defined in cost_local.h)
+  ! cMeanTheta    - mean temperature over time (defined in cost.h)
+  ! objf_temp_tut - contribution to objective function (defined in cost.h)
+  INTEGER sNx, sNy, nSx, nSy, OLx, OLy, Nr
+  INTEGER myByLo, myByHi, myBxLo, myBxHi
+  INTEGER myThid
+  _RS     maskC     (1-OLx:sNx+OLx,1-OLy:sNy+OLy,Nr,nSx,nSy)
+  _RL     wtheta                                (Nr,nSx,nSy)
+  _RL     cMeanTheta(1-OLx:sNx+OLx,1-OLy:sNy+OLy,Nr,nSx,nSy)
+  _RL     objf_temp_tut                            (nSx,nSy)
+  ! This only works with TAF if TAF_FORTRAN_VERS > F77
+  ! INTEGER, INTENT(in) :: sNx,sNy,nSx,nSy,OLx,OLy,Nr
+  ! INTEGER, INTENT(in) :: myByLo,myByHi,myBxLo,myBxHi,myThid
+  ! _RS, INTENT(in)     :: maskC     (1-OLx:sNx+OLx,1-OLy:sNy+OLy,Nr,nSx,nSy)
+  ! _RL, INTENT(in)     :: wtheta                                (Nr,nSx,nSy)
+  ! _RL, INTENT(in)     :: cMeanTheta(1-OLx:sNx+OLx,1-OLy:sNy+OLy,Nr,nSx,nSy)
+  ! _RL, INTENT(out)    :: objf_temp_tut(nSx,nSy)
+
+#ifdef ALLOW_COST
+  !   !LOCAL VARIABLES:
+  ! loop indices
+  INTEGER :: i, j, k
+  INTEGER :: bi, bj
+  INTEGER :: Nk
+  ! auxilliary variables
+  _RL :: locfc,tmp
+  ! theta/temperature data read from file
+  _RL :: thetalev(1-OLx:sNx+OLx,1-OLy:sNy+OLy,Nr,nSx,nSy)
+!EOP
+
+  Nk = 2 ! only loop over top Nk levels
+  ! Read annual mean Levitus temperature
+
+  CALL READ_FLD_XYZ_RL('lev_t_an.bin',' ',thetalev,0,myThid)
+
+  ! Total number of wet temperature points
+  tmp  = 0. _d 0
+  DO bj=myByLo,myByHi
+   DO bi=myBxLo,myBxHi
+    DO k=1,Nk
+     DO j=1,sNy
+      DO i=1,sNx
+       tmp = tmp + maskC(i,j,k,bi,bj)
+      ENDDO
+     ENDDO
+    ENDDO
+   ENDDO
+  ENDDO
+  _GLOBAL_SUM_RL( tmp , myThid )
+  IF ( tmp > 0. ) tmp = 1. _d 0 / tmp
+
+  DO bj=myByLo,myByHi
+   DO bi=myBxLo,myBxHi
+    locfc = 0.D0
+    DO k=1,Nk
+     DO j=1,sNy
+      DO i=1,sNx
+       locfc = locfc + tmp*maskC(i,j,k,bi,bj)* &
+            wtheta(k,bi,bj)* &
+            ( cMeanTheta(i,j,k,bi,bj) - thetalev(i,j,k,bi,bj) )**2
+      ENDDO
+     ENDDO
+    ENDDO
+
+    objf_temp_tut(bi,bj) = locfc
+    !print*,'objf_temp_tut =',locfc,startTime,endTime,tmp
+
+   ENDDO
+  ENDDO
+#endif /* ALLOW_COST */
+
+  RETURN
+  ! This only works with TAF if TAF_FORTRAN_VERS > F77
+END ! SUBROUTINE COST_TEMP_FFORM


### PR DESCRIPTION
## What changes does this PR introduce?
suggestion for a modified `verification/tutorial_global_oce_optim`

## What is the current behaviour? 
genmake2 functionality for f90-free format files are not testet


## What is the new behaviour 
- modified `verification/tutorial_global_oce_optim` uses f90-free format file `cost_temp_fform.F90` without any modules, etc.


## Does this PR introduce a breaking change? 
pure f77-compilers (e.g. g77) may not be able to compile `verification/tutorial_global_oce_optim`

## Other information:
- did not add "adjoint" label, because it does not affect OpenAD.
- additionally, one could enforce `TAF_FORTRAN_VERS > F77` and include more F90 features in new file `cost_temp_fform.F90`

## Suggested addition to `tag-index`
- modify tutorial_global_oce_optim to test f90-free format file