### PR TITLE
Remove deprecated html theme path from sphinx conf

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -143,8 +143,6 @@ import sphinx_rtd_theme
 
 html_theme = "sphinx_rtd_theme"
 
-html_theme_path = [sphinx_rtd_theme.get_html_theme_path()]
-
 # Theme options are theme-specific and customize the look and feel of a theme
 # further.  For a list of options available for each theme, see the
 # documentation.


### PR DESCRIPTION
## What changes does this PR introduce?

Bug fix

## What is the current behaviour? 

html doc build fails because of deprecated API call

## What is the new behaviour 

html doc build succeeds

## Does this PR introduce a breaking change? 

No