### PR TITLE
update darwin_arm64_gfortran to be able to use free-format f90 files

### DIFF
--- a/doc/tag-index
+++ b/doc/tag-index
@@ -1,7 +1,9 @@
     Notes on tags used in MITgcmUV
     ==============================
 
-o pkg/seaice: 
+o tools/build_options:
+  - update darwin_arm64_gfortran to be able to compile free-format F90 files.
+o pkg/seaice:
   - add new lateral drag parameterisation for landfast ice (Liu etal 2022, JGR)
 o verification/*/results:
   - update 5 adm + 3 tlm ref. output affected by TAF new version 6.4.5 & 6.5.0

--- a/tools/build_options/darwin_arm64_gfortran
+++ b/tools/build_options/darwin_arm64_gfortran
@@ -73,7 +73,10 @@ else
     fi
 fi
 
-F90FLAGS=$FFLAGS
+# add undocumented flag -x f95 to force gfortran to interpret any
+# suffix as a f90-freeformat file, add -ffree-form to suppress the
+# associated warning
+F90FLAGS="$FFLAGS -x f95 -ffree-form"
 F90OPTIM=$FOPTIM
 
 INCLUDEDIRS=''


### PR DESCRIPTION
## What changes does this PR introduce?
bug fix

## What is the current behaviour? 
cannot compile free-format F90 files on MacOS with gfortran (because of non-standard file suffix in genmake2 process)

## What is the new behaviour 
can compile free-format F90 file

## Does this PR introduce a breaking change? 
no

## Other information:
This is really to avoid me having a customised version always being in the way.

## Suggested addition to `tag-index`
- update tools/build_options/darwin_arm64_gfortran to be able to compile free-format f90 files