### PR TITLE
minor adjustment to Tapenade summary

### DIFF
--- a/verification/testreport
+++ b/verification/testreport
@@ -1868,8 +1868,8 @@ for dir in $TESTDIRS ; do
 	      if test -f $gmkLog ; then
 		ADtool=`grep '^Tapenade ' $gmkLog | tail -n 1`
 		echo "from '$gmkLog', get: $ADtool" >> $DRESULTS/genmake_state
-		ADvers=`echo $ADtool | awk '{print $1,$2,$3}'`
-		sed "s/ by Tapenade/ by $ADvers/" $SUMMARY > tmp.tr_log
+		ADvers=`echo $ADtool | awk '{print $2,$3}'`
+		sed "s/ by Tapenade/ by Tapenade $ADvers/" $SUMMARY > tmp.tr_log
 		mv -f tmp.tr_log $SUMMARY
 	      fi
 	    fi


### PR DESCRIPTION
## What changes does this PR introduce?
Minor adjustment to Tapenade testreport  summary

## What is the current behaviour? 
When testreport fails to find or run tapenade, no "Tapenade" output is found in `make.tr_log` and the type of test in the summary loses the recording of being a "Tapenade" test, like this:
> Adjoint generated by

## What is the new behaviour 
Always keeps "Tapenade" in the summary - type of test - being run, even when the tapenade command fails. This ensures that the testreport output will be correctly identified as a "tapenade test" when stored and compared in the archive.

## Does this PR introduce a breaking change?
No. And the summary remains identical when testreport is able to run the "tapenade" command.

## Other information:


## Suggested addition to `tag-index`
as this represents a very minor update, no need to be listed in tag-index.