### PR TITLE
Fix potential compilation error when calling ctrl_getobcsn/s/w/e.F

### DIFF
--- a/pkg/ctrl/ctrl_getobcse.F
+++ b/pkg/ctrl/ctrl_getobcse.F
@@ -42,7 +42,7 @@ c     == routine arguments ==
       integer myIter
       integer myThid
 
-#ifdef ALLOW_OBCSE_CONTROL
+#if ( defined ALLOW_OBCS_EAST && defined ALLOW_OBCSE_CONTROL )
 c     == external functions ==
       integer  ilnblnk
       external ilnblnk
@@ -282,7 +282,7 @@ c--   Calculate mask for tracer cells (0 => land, 1 => water).
 C--   End over iobcs loop
       enddo
 
-#endif /* ALLOW_OBCSE_CONTROL */
+#endif /* ALLOW_OBCS_EAST && defined ALLOW_OBCSE_CONTROL */
 
       return
       end

--- a/pkg/ctrl/ctrl_getobcsn.F
+++ b/pkg/ctrl/ctrl_getobcsn.F
@@ -43,7 +43,7 @@ c     == routine arguments ==
       integer myIter
       integer myThid
 
-#ifdef ALLOW_OBCSN_CONTROL
+#if ( defined ALLOW_OBCS_NORTH && defined ALLOW_OBCSN_CONTROL )
 c     == external functions ==
       integer  ilnblnk
       external ilnblnk
@@ -285,7 +285,7 @@ c--   Calculate mask for tracer cells (0 => land, 1 => water).
 C--   End over iobcs loop
       enddo
 
-#endif /* ALLOW_OBCSN_CONTROL */
+#endif /* defined ALLOW_OBCS_NORTH && defined ALLOW_OBCSN_CONTROL */
 
       return
       end

--- a/pkg/ctrl/ctrl_getobcss.F
+++ b/pkg/ctrl/ctrl_getobcss.F
@@ -43,7 +43,7 @@ c     == routine arguments ==
       integer myIter
       integer myThid
 
-#ifdef ALLOW_OBCSS_CONTROL
+#if ( defined ALLOW_OBCS_SOUTH && defined ALLOW_OBCSS_CONTROL )
 c     == external functions ==
       integer  ilnblnk
       external ilnblnk
@@ -283,7 +283,7 @@ c--   Calculate mask for tracer cells (0 => land, 1 => water).
 C--   End over iobcs loop
       enddo
 
-#endif /* ALLOW_OBCSS_CONTROL */
+#endif /* defined ALLOW_OBCS_SOUTH && defined ALLOW_OBCSS_CONTROL */
 
       return
       end

--- a/pkg/ctrl/ctrl_getobcsw.F
+++ b/pkg/ctrl/ctrl_getobcsw.F
@@ -43,7 +43,7 @@ c     == routine arguments ==
       integer myIter
       integer myThid
 
-#ifdef ALLOW_OBCSW_CONTROL
+#if ( defined ALLOW_OBCS_WEST && defined ALLOW_OBCSW_CONTROL )
 c     == external functions ==
       integer  ilnblnk
       external ilnblnk
@@ -283,7 +283,7 @@ c--   Calculate mask for tracer cells (0 => land, 1 => water).
 C--   End over iobcs loop
       enddo
 
-#endif /* ALLOW_OBCSW_CONTROL */
+#endif /* defined ALLOW_OBCS_WEST && defined ALLOW_OBCSW_CONTROL */
 
       return
       end

--- a/pkg/obcs/obcs_calc.F
+++ b/pkg/obcs/obcs_calc.F
@@ -419,18 +419,10 @@ C     read control parameter contributions here to be independent of flags
 C     ALLOW_OBCS_PRESCRIBE and useOBCSprescribe
 #ifdef ALLOW_CTRL
       IF ( useCTRL ) THEN
-# ifdef ALLOW_OBCSN_CONTROL
        CALL CTRL_GETOBCSN ( futureTime, futureIter, myThid )
-# endif
-# ifdef ALLOW_OBCSS_CONTROL
        CALL CTRL_GETOBCSS ( futureTime, futureIter, myThid )
-# endif
-# ifdef ALLOW_OBCSW_CONTROL
        CALL CTRL_GETOBCSW ( futureTime, futureIter, myThid )
-# endif
-# ifdef ALLOW_OBCSE_CONTROL
        CALL CTRL_GETOBCSE ( futureTime, futureIter, myThid )
-# endif
       ENDIF
 #endif /* ALLOW_CTRL */
 


### PR DESCRIPTION
## What changes does this PR introduce?
Bug fix


## What is the current behaviour? 
The subroutines ctrl_getobcsn/s/w/e.F are currently called when ALLOW_CTRL_OBCSN/S/W/E are defined, even if some or all of ALLOW_OBCS_NORTH/SOUTH/WEST/EAST are not defined. This will generate a compilation error. See Issue #888. 


## What is the new behaviour 
The subroutines ctrl_getobcsn/s/w/e.F are active only when both ALLOW_OBCS_NORTH/SOUTH/WEST/EAST and ALLOW_CTRL_OBCSN/S/W/E are defined. 


## Does this PR introduce a breaking change? 
No.


## Other information:


## Suggested addition to `tag-index`
o Add open boundary controls to model states only when both ALLOW_OBCS_NORTH/SOUTH/WEST/EAST and ALLOW_CTRL_OBCSN/S/W/E are defined. 