### PR TITLE
Minor tweak to recently added exp. "atm_gray"

### DIFF
--- a/verification/atm_gray/input/data
+++ b/verification/atm_gray/input/data
@@ -63,7 +63,10 @@
 #endTime=311040000.,
  deltaT=384.,
  abEps=0.1,
- forcing_In_AB=.FALSE.,
+#forcing_In_AB=.FALSE.,
+#- uncommenting the line above would replace the 2 setting below
+ momForcingOutAB =1,
+ tracForcingOutAB=1,
  cAdjFreq=0.,
 #- long run (> 1.yr):
  chkptFreq =15552000.,


### PR DESCRIPTION
## What changes does this PR introduce?
No real change, keep same parameter setting but just change the way mom/tracForcingOutAB are set.

## What is the current behaviour? 
`mom/tracForcingOutAB`  are not set explicitly to 1 from main parameter file `data` but as  `forcing_In_AB` is set to False, this results ( in `ini_parms.F`) in the same setting (i..e., `mom/tracForcingOutAB `=1).

## What is the new behaviour 
set explicitly `mom/tracForcingOutAB` to 1 and comment out `forcing_In_AB`=F`

## Does this PR introduce a breaking change? 
No, even keep the same "config-summary" reported to STDOUT.

## Other information:

1. `forcing_In_AB=F` is already used in several verification experiments (counted 36 times) but `momForcingOutAB=1` is not found anywhere. This PR will diversify the tested setting (in tregression test) and will provide an example where `momForcingOutAB` is set in main parameter file `data`.
2. the PGI multi-threaded `atm_gray` tests on svante are currently not reliable (a compiler issue ?) as ``forcing_In_AB=F` is not read correctly in both primary test "atm_gray" and secondary test "atm_gray.ape". This should fix this issue.

## Suggested addition to `tag-index`
As this represent a very minor update, could skip addition to tag-index.