### PR TITLE
Remove egrep

### DIFF
--- a/tools/do_tst_2+2
+++ b/tools/do_tst_2+2
@@ -90,7 +90,7 @@ if test -x $SCRIPT ; then
  fi
  echo " $LIST"
  echo ""
- yy=`echo $SCRIPT | grep -c '^\/'`
+ yy=`echo $SCRIPT | grep -c '^/'`
  if test $yy = 0 ; then SCRIPT="../../$SCRIPT" ; fi
 else
  echo "ERROR: script '$SCRIPT' not found or not executable"

--- a/tools/genmake2
+++ b/tools/genmake2
@@ -3026,9 +3026,9 @@ for d in $alldirs ; do
 
 			if test "x$TAPENADE" != x ; then
 			    basename=${sf%%.F}
-			    isAD=`egrep ^$basename.f'[ 	]*' $TMP.adSrcFiles`
+			    isAD=`grep -E ^$basename.f'[ 	]*' $TMP.adSrcFiles`
 			    if test -z "$isAD" ; then
-				toBeIgnored=`egrep ^$basename'[      ]*' ${TAP_DONT_COMPILE}`
+				toBeIgnored=`grep -E ^$basename'[      ]*' ${TAP_DONT_COMPILE}`
 				if test -z "$toBeIgnored" ; then
 				    echo    " \\"  >> $TMP.nonADF77srclist
 				    printf " $sf" >> $TMP.nonADF77srclist
@@ -3037,8 +3037,8 @@ for d in $alldirs ; do
 				fi
 			    else # file is initially listed as an AD file we want to exclude it
 				 # or we want to retain the untransformed version
-				notToBeTransformed=`egrep ^$basename'[      ]*' ${TAP_DONT_TRANSFORM}`
-				untransformedVersionToBeKept=`egrep ^$basename'[      ]*' ${TAP_KEEP_ORIGINAL}`
+				notToBeTransformed=`grep -E ^$basename'[      ]*' ${TAP_DONT_TRANSFORM}`
+				untransformedVersionToBeKept=`grep -E ^$basename'[      ]*' ${TAP_KEEP_ORIGINAL}`
 				if test -n "$notToBeTransformed"; then
 				    echo "    not to be transformed:  $sf"
 				fi
@@ -3054,16 +3054,16 @@ for d in $alldirs ; do
 
 			if test "x$OPENAD" = x ; then
 			    basename=${sf%%.F}
-			    isAD=`egrep ^$basename.f'[ 	]*' $TMP.adSrcFiles`
+			    isAD=`grep -E ^$basename.f'[ 	]*' $TMP.adSrcFiles`
 			    if test -z "$isAD" ; then
 				echo    " \\"  >> $TMP.nonADF77srclist
 				printf " $sf" >> $TMP.nonADF77srclist
 			    fi
 			else #- OpenAD case:
 			    basename=${sf%%.F}
-			    isAD=`egrep ^$basename.f'[ 	]*' $TMP.adSrcFiles`
+			    isAD=`grep -E ^$basename.f'[ 	]*' $TMP.adSrcFiles`
 			    if test -z "$isAD" ; then
-				toBeIgnored=`egrep ^$basename'[      ]*' ${OAD_DONT_COMPILE}`
+				toBeIgnored=`grep -E ^$basename'[      ]*' ${OAD_DONT_COMPILE}`
 				if test -z "$toBeIgnored" ; then
 				    echo    " \\"  >> $TMP.nonADF77srclist
 				    printf " $sf" >> $TMP.nonADF77srclist
@@ -3072,8 +3072,8 @@ for d in $alldirs ; do
 				fi
 			    else # file is initially listed as an AD file we want to exclude it
 				 # or we want to retain the untransformed version
-				notToBeTransformed=`egrep ^$basename'[      ]*' ${OAD_DONT_TRANSFORM}`
-				untransformedVersionToBeKept=`egrep ^$basename'[      ]*' ${OAD_KEEP_ORIGINAL}`
+				notToBeTransformed=`grep -E ^$basename'[      ]*' ${OAD_DONT_TRANSFORM}`
+				untransformedVersionToBeKept=`grep -E ^$basename'[      ]*' ${OAD_KEEP_ORIGINAL}`
 				if test -n "$notToBeTransformed"; then
 				    echo "    not to be transformed:  $sf"
 				fi
@@ -3092,7 +3092,7 @@ for d in $alldirs ; do
 			printf " $sf" >> $TMP.F90srclist
 			if ( test "x$OPENAD" = x && test "x$TAPENADE" = x ) ; then
 			    basename=${sf%%.F90}
-			    isAD=`egrep ^$basename.f90'[ 	]*' $TMP.adF90Files`
+			    isAD=`grep -E ^$basename.f90'[ 	]*' $TMP.adF90Files`
 			    if test -z "$isAD" ; then
 				echo    " \\" >> $TMP.nonADF90srclist
 				printf " $sf" >> $TMP.nonADF90srclist
@@ -3764,7 +3764,7 @@ printf "AD_FILES = " >> $MAKEFILE
 AD_FILES=`cat $TMP.adSrcFiles`
 for i in $AD_FILES ; do
   basename=${i%%.f}
-  toBeIgnored=`egrep ^$basename'[      ]*' ${TAP_DONT_COMPILE} ${TAP_DONT_TRANSFORM}`
+  toBeIgnored=`grep -E ^$basename'[      ]*' ${TAP_DONT_COMPILE} ${TAP_DONT_TRANSFORM}`
   if test -z "$toBeIgnored" ; then
     echo    " \\" >> $MAKEFILE
     printf " $i" >> $MAKEFILE
@@ -3901,7 +3901,7 @@ done
 AD_FILES=`cat $TMP.adSrcFiles`
 for i in $AD_FILES ; do
   basename=${i%%.f}
-  toBeIgnored=`egrep ^$basename'[      ]*' ${OAD_DONT_COMPILE} ${OAD_DONT_TRANSFORM}`
+  toBeIgnored=`grep -E ^$basename'[      ]*' ${OAD_DONT_COMPILE} ${OAD_DONT_TRANSFORM}`
   if test -z "$toBeIgnored" ; then
     echo    " \\" >> $MAKEFILE
     printf " $i" >> $MAKEFILE

--- a/tools/tst_2+2
+++ b/tools/tst_2+2
@@ -299,7 +299,7 @@ fi
 if test ! -s std_outp.2it
 then echo "empty or no output file: 'std_outp.2it' => exit" ; exit 1 ; fi
 mv STDERR.0000 std__err.2it
-out=`egrep -c 'STOP ABNORMAL END' std_outp.2it`
+out=`grep -c 'STOP ABNORMAL END' std_outp.2it`
 if test $out != 0
 then echo "==> RUN 2 x $Nit it : ABNORMAL END => exit" ; exit 1 ; fi
 listF=`ls -1 $pref.ckptA*.data 2> /dev/null`
@@ -328,7 +328,7 @@ fi
 if test ! -s std_outp.1iA
 then echo "empty or no output file: 'std_outp.1iA' => exit" ; exit 2 ; fi
 mv STDERR.0000 std__err.1iA
-out=`egrep -c 'STOP ABNORMAL END' std_outp.1iA`
+out=`grep -c 'STOP ABNORMAL END' std_outp.1iA`
 if test $out != 0
 then echo "==> RUN 1iA : ABNORMAL END => exit" ; exit 2 ; fi
 listF=`ls -1 $pref.ckptA*.data 2> /dev/null`
@@ -356,7 +356,7 @@ fi
 if test ! -s std_outp.1iB
 then echo "empty or no output file: 'std_outp.1iB' => exit" ; exit 3 ; fi
 mv STDERR.0000 std__err.1iB
-out=`egrep -c 'STOP ABNORMAL END' std_outp.1iB`
+out=`grep -c 'STOP ABNORMAL END' std_outp.1iB`
 if test $out != 0
 then echo "==> RUN 1iB : ABNORMAL END => exit" ; exit 3 ; fi
 listF=`ls -1 $pref.ckptA*.data 2> /dev/null`

--- a/tools/xmakedepend
+++ b/tools/xmakedepend
@@ -218,7 +218,7 @@ done   | sed -e 's|/[^/.][^/]*/\.\.||g' -e 's|/\.[^.][^/]*/\.\.||g'     -e 's|"|
 
 	    if (rec != "")
 		print rec
-	    }'   | egrep -v '^[^:]*:[ 	]*$' >> $DEPENDLINES
+	    }'   | grep -E -v '^[^:]*:[ 	]*$' >> $DEPENDLINES
 
 trap "" 1 2 13 15	# Now we are committed
 case "$makefile" in

--- a/utils/scripts/gluemnc
+++ b/utils/scripts/gluemnc
@@ -375,7 +375,7 @@ echo    ncpdq $DEBUG -O -a Xp1,$recname -F -d Xp1,1,$Xp1len $somegloy $somegloy 
 #  varsz=$( ncdump -h $somepre.t001.nc | sed -n 's/^\s*\(double\|float\).* \(\w*\)(Z\w*).*/\2/p' )
   # The OR ("\|") and "\s", "\w" only work for GNU-sed, but not for
   # BSD-sed or SunOS-sed, therefore we need to use some work-arounds:
-  varsz=$( ncdump -h $somepre.t001.nc | egrep "double|float" \
+  varsz=$( ncdump -h $somepre.t001.nc | grep -E "double|float" \
            | grep -v , | sed -n 's/.* \(.*\)(Z.*).*/\1/p' )
   fixed=
   for varz in $varsz
@@ -391,7 +391,6 @@ echo    ncpdq $DEBUG -O -a Xp1,$recname -F -d Xp1,1,$Xp1len $somegloy $somegloy 
 
   cp $somepre.glob.nc $DIRORIG
 done
-
 
 cd $DIRORIG
 rm -rf $DIRNAME

--- a/utils/scripts/xplodemnc
+++ b/utils/scripts/xplodemnc
@@ -1,7 +1,7 @@
 #! /usr/bin/env bash
 #
 # This is a shell script to separate an MITgcm mnc output file into
-# one file per multi-dimensional variable. 
+# one file per multi-dimensional variable.
 # The file should be in one directory, where this script is run.
 # The resulting files will be in the same directory.
 
@@ -19,7 +19,7 @@ do
   fi
 
 # Finding all the multidimensional variables
-  varls=$(ncdump -h $somefile | egrep "double|float" | egrep , )
+  varls=$(ncdump -h $somefile | grep -E "double|float" | grep -E , )
   IFS=';'
   vars=
   for somevar in ${varls}


### PR DESCRIPTION
## What changes does this PR introduce?
replace "egrep" with "grep -E", following issue #905

## What is the current behaviour? 
getting this warning from the use of "egrep" with grep version 3.11:
> egrep: warning: egrep is obsolescent; using grep -E

## What is the new behaviour 
only use "grep" and "grep -E", no warning anymore.

## Does this PR introduce a breaking change? 
no

## Other information:

## Suggested addition to `tag-index`
o tools:
  - replace (obsolete) "egrep" with "grep -E".