### PR TITLE
update darwin_arm64_gfortran opt-file

### DIFF
--- a/tools/build_options/darwin_arm64_gfortran
+++ b/tools/build_options/darwin_arm64_gfortran
@@ -42,8 +42,12 @@ NOOPTFLAGS='-O0'
 NOOPTFILES=''
 
 FFLAGS="$FFLAGS -fconvert=big-endian"
-# for big objects:
-#FFLAGS="$FFLAGS -fPIC"
+# needed for big objects (e.g., to compile and run TAF AD of
+# global_ocean.cs32x15), but requires larger stack sizes (set with
+# ulimit -s) in other cases, so we leave this commented out:
+# man gfortran: Allow indirect recursion by forcing all local arrays
+#               to be allocated on the stack.
+#FFLAGS="$FFLAGS -frecursive"
 #- might want to use '-fdefault-real-8' for fizhi pkg:
 #FFLAGS="$FFLAGS -fdefault-real-8 -fdefault-double-8"
 


### PR DESCRIPTION

## What changes does this PR introduce?
docs update (?)

## What is the current behaviour? 
without -frecursive I cannot run the TAF AD experiment global_ocean.cs32x15 because of memory issues,

## What is the new behaviour 
replace commented -fPIC by commented -frecursive, adjust comments; with -frecursive a few other experiments fail because segmentation faults (different memory issues), so this remains commented out.

## Does this PR introduce a breaking change? 
no, just a small change in an opt-file that is even commented out

## Other information:


## Suggested addition to `tag-index`
- in darwin_arm64_gfortran change instructions for applications with large objects (only comments)