### PR TITLE
Try to fix race condition in "make -j 2 adtaf" (non empty AD_F90FILES) 

### DIFF
--- a/doc/tag-index
+++ b/doc/tag-index
@@ -1,6 +1,9 @@
     Notes on tags used in MITgcmUV
     ==============================
 
+o tools/genmake2:
+  - use specific "ad_config.template{0,1,2}" in different stages of TAF
+    AD/TL built to avoid race condition issue with "make -jN".
 o model/src:
   - no "addMass" contribution to initial (iter=0) vertical velocity ;
   - with selectAddFluid=1, fix missing implDiv2DFlow factor in "addMass"

--- a/tools/do_tst_2+2
+++ b/tools/do_tst_2+2
@@ -161,7 +161,7 @@ echo 'P. Run  Result     experiment'  >> $SUMMARY
 echo '  1 2 3'  >> $SUMMARY
 
 #-- For MPI test:
-LOC_MFILE='tr_mpi_mfile'
+LOC_MFILE='mpi_mfile.loc'
 RUNOUTP="output.txt"
 if [ $mpi -ge 1 ] ; then
   SCRIPT="$SCRIPT -mpi"
@@ -186,14 +186,14 @@ do
     rCommand=`echo $COMMAND | sed "s/ TR_NPROC / $LOC_NPROC /"`
     if test "x$MPI_MFILE" != x ; then
       #- create new MPI machine-file with the right number of Procs
-      rm -f $LOC_MFILE
-      cat $MPI_MFILE | sort | uniq | head -$LOC_NPROC > $LOC_MFILE
-      nl=`wc -l $LOC_MFILE | awk '{print $1}'`
+      rm -f $xx/$LOC_MFILE
+      cat $MPI_MFILE | sort | uniq | head -$LOC_NPROC > $xx/$LOC_MFILE
+      nl=`wc -l $xx/$LOC_MFILE | awk '{print $1}'`
       if [ $nl -lt $LOC_NPROC ] ; then
-        rm -f $LOC_MFILE
-        cat $MPI_MFILE | head -$LOC_NPROC > $LOC_MFILE
+        rm -f $xx/$LOC_MFILE
+        cat $MPI_MFILE | head -$LOC_NPROC > $xx/$LOC_MFILE
       fi
-      rCommand=`echo $rCommand | sed "s/ TR_MFILE / ..\/..\/$LOC_MFILE /"`
+      rCommand=`echo $rCommand | sed "s/ TR_MFILE / ..\/$LOC_MFILE /"`
     fi
   fi
 
@@ -255,7 +255,7 @@ do
       )
     fi
   done
-  if test "x$mpi" != x0 -a "x$MPI_MFILE" != x ; then rm -f $LOC_MFILE ; fi
+  if test "x$mpi" != x0 -a "x$MPI_MFILE" != x ; then rm -f $xx/$LOC_MFILE ; fi
 done
 printf "End time:    " >> $SUMMARY
 date >> $SUMMARY

--- a/tools/genmake2
+++ b/tools/genmake2
@@ -3468,9 +3468,9 @@ adtaf: ad_taf_output.$FS
 
 ad_exe_target:
 	@echo Update AD_CONFIG.h and make \$(EXE_ADJ)
-	@$BASH\$(TOOLSDIR)/convert_cpp_cmd2defines "Adjoint version" -bAD_CONFIG_H -DALLOW_ADJOINT_RUN -UALLOW_TANGENTLINEAR_RUN > ad_config.template
-	@cmp ad_config.template AD_CONFIG.h || cat ad_config.template > AD_CONFIG.h
-	@-rm -f ad_config.template
+	@$BASH\$(TOOLSDIR)/convert_cpp_cmd2defines "Adjoint version" -bAD_CONFIG_H -DALLOW_ADJOINT_RUN -UALLOW_TANGENTLINEAR_RUN > ad_config.template0
+	@cmp ad_config.template0 AD_CONFIG.h || cat ad_config.template0 > AD_CONFIG.h
+	@-rm -f ad_config.template0
 	\$(MAKE) -f \$(MAKEFILE) \$(EXE_ADJ)
 
 EOF
@@ -3478,9 +3478,9 @@ EOF
 if test $CAT_SRC_FOR_TAF = 1 ; then
 cat >>$MAKEFILE <<EOF
 ad_input_code.$FS: \$(AD_FILES) \$(AD_FLOW_FILES)
-	@$BASH\$(TOOLSDIR)/convert_cpp_cmd2defines "Adjoint version" -bAD_CONFIG_H -DALLOW_ADJOINT_RUN -UALLOW_TANGENTLINEAR_RUN > ad_config.template
-	cmp ad_config.template AD_CONFIG.h || cat ad_config.template > AD_CONFIG.h
-	@-rm -f ad_config.template
+	@$BASH\$(TOOLSDIR)/convert_cpp_cmd2defines "Adjoint version" -bAD_CONFIG_H -DALLOW_ADJOINT_RUN -UALLOW_TANGENTLINEAR_RUN > ad_config.template1
+	cmp ad_config.template1 AD_CONFIG.h || cat ad_config.template1 > AD_CONFIG.h
+	@-rm -f ad_config.template1
 	@\$(MAKE) -f \$(MAKEFILE) \$(F77_PP_SRC_FILES)
 	cat \$(AD_FLOW_FILES) \$(AD_FILES) | sed -f \$(TOOLSDIR)/remove_comments_sed > ad_input_code.$FS
 
@@ -3504,9 +3504,9 @@ EOF
 else
 cat >>$MAKEFILE <<EOF
 ad_inpF90_code.$FS90: \$(AD_F90FILES) \$(AD_FLOW_FILES)
-	@$BASH\$(TOOLSDIR)/convert_cpp_cmd2defines "Adjoint version" -bAD_CONFIG_H -DALLOW_ADJOINT_RUN -UALLOW_TANGENTLINEAR_RUN > ad_config.template
-	cmp ad_config.template AD_CONFIG.h || cat ad_config.template > AD_CONFIG.h
-	@-rm -f ad_config.template
+	@$BASH\$(TOOLSDIR)/convert_cpp_cmd2defines "Adjoint version" -bAD_CONFIG_H -DALLOW_ADJOINT_RUN -UALLOW_TANGENTLINEAR_RUN > ad_config.template2
+	cmp ad_config.template2 AD_CONFIG.h || cat ad_config.template2 > AD_CONFIG.h
+	@-rm -f ad_config.template2
 	@\$(MAKE) -f \$(MAKEFILE) \$(F90_PP_SRC_FILES)
 	cat \$(AD_F90FILES) > ad_inpF90_code.$FS90
 
@@ -3536,9 +3536,9 @@ cat >>$MAKEFILE <<EOF
 adobjfiles: \$(AD_F90FILES:.$FS90=_ad.o) \$(AD_FILES:.$FS=_ad.o)
 
 ad_taf_output.$FS: \$(AD_FLOW_FILES) \$(AD_F90FILES) \$(AD_FILES)
-	@$BASH\$(TOOLSDIR)/convert_cpp_cmd2defines "Adjoint version" -bAD_CONFIG_H -DALLOW_ADJOINT_RUN -UALLOW_TANGENTLINEAR_RUN > ad_config.template
-	cmp ad_config.template AD_CONFIG.h || cat ad_config.template > AD_CONFIG.h
-	@-rm -f ad_config.template
+	@$BASH\$(TOOLSDIR)/convert_cpp_cmd2defines "Adjoint version" -bAD_CONFIG_H -DALLOW_ADJOINT_RUN -UALLOW_TANGENTLINEAR_RUN > ad_config.template1
+	cmp ad_config.template1 AD_CONFIG.h || cat ad_config.template1 > AD_CONFIG.h
+	@-rm -f ad_config.template1
 	@\$(MAKE) -f \$(MAKEFILE) \$(F90_PP_SRC_FILES) \$(F77_PP_SRC_FILES)
 	sed -i.bak -f \$(TOOLSDIR)/remove_comments_sed \$(AD_FILES)
 	@-rm -f \$(AD_F90FILES:.$FS90=_ad.$FS90) \$(AD_FILES:.$FS=_ad.$FS) \$(AD_FILES:.$FS=.$FS.bak); echo ''
@@ -3566,9 +3566,9 @@ ftltaf: ftl_taf_output.$FS
 
 ftl_exe_target:
 	@echo Update AD_CONFIG.h and make \$(EXE_TLM)
-	@$BASH\$(TOOLSDIR)/convert_cpp_cmd2defines "TangLin version" -bAD_CONFIG_H -UALLOW_ADJOINT_RUN -DALLOW_TANGENTLINEAR_RUN > ad_config.template
-	@cmp ad_config.template AD_CONFIG.h || cat ad_config.template > AD_CONFIG.h
-	@-rm -f ad_config.template
+	@$BASH\$(TOOLSDIR)/convert_cpp_cmd2defines "TangLin version" -bAD_CONFIG_H -UALLOW_ADJOINT_RUN -DALLOW_TANGENTLINEAR_RUN > ad_config.template0
+	@cmp ad_config.template0 AD_CONFIG.h || cat ad_config.template0 > AD_CONFIG.h
+	@-rm -f ad_config.template0
 	\$(MAKE) -f \$(MAKEFILE) \$(EXE_TLM)
 
 EOF
@@ -3576,9 +3576,9 @@ EOF
 if test $CAT_SRC_FOR_TAF = 1 ; then
 cat >>$MAKEFILE <<EOF
 ftl_input_code.$FS: \$(AD_FILES) \$(AD_FLOW_FILES)
-	@$BASH\$(TOOLSDIR)/convert_cpp_cmd2defines "TangLin version" -bAD_CONFIG_H -UALLOW_ADJOINT_RUN -DALLOW_TANGENTLINEAR_RUN > ad_config.template
-	cmp ad_config.template AD_CONFIG.h || cat ad_config.template > AD_CONFIG.h
-	@-rm -f ad_config.template
+	@$BASH\$(TOOLSDIR)/convert_cpp_cmd2defines "TangLin version" -bAD_CONFIG_H -UALLOW_ADJOINT_RUN -DALLOW_TANGENTLINEAR_RUN > ad_config.template1
+	cmp ad_config.template1 AD_CONFIG.h || cat ad_config.template1 > AD_CONFIG.h
+	@-rm -f ad_config.template1
 	@\$(MAKE) -f \$(MAKEFILE) \$(F77_PP_SRC_FILES)
 	cat \$(AD_FLOW_FILES) \$(AD_FILES) | sed -f \$(TOOLSDIR)/remove_comments_sed > ftl_input_code.$FS
 
@@ -3602,9 +3602,9 @@ EOF
 else
 cat >>$MAKEFILE <<EOF
 ftl_inpF90_code.$FS90: \$(AD_F90FILES) \$(AD_FLOW_FILES)
-	@$BASH\$(TOOLSDIR)/convert_cpp_cmd2defines "TangLin version" -bAD_CONFIG_H -UALLOW_ADJOINT_RUN -DALLOW_TANGENTLINEAR_RUN > ad_config.template
-	cmp ad_config.template AD_CONFIG.h || cat ad_config.template > AD_CONFIG.h
-	@-rm -f ad_config.template
+	@$BASH\$(TOOLSDIR)/convert_cpp_cmd2defines "TangLin version" -bAD_CONFIG_H -UALLOW_ADJOINT_RUN -DALLOW_TANGENTLINEAR_RUN > ad_config.template2
+	cmp ad_config.template2 AD_CONFIG.h || cat ad_config.template2 > AD_CONFIG.h
+	@-rm -f ad_config.template2
 	@\$(MAKE) -f \$(MAKEFILE) \$(F90_PP_SRC_FILES)
 	cat \$(AD_F90FILES) > ftl_inpF90_code.$FS90
 
@@ -3634,9 +3634,9 @@ cat >>$MAKEFILE <<EOF
 ftlobjfiles: \$(AD_F90FILES:.$FS90=_tl.o) \$(AD_FILES:.$FS=_tl.o)
 
 ftl_taf_output.$FS: \$(AD_FLOW_FILES) \$(AD_F90FILES) \$(AD_FILES)
-	@$BASH\$(TOOLSDIR)/convert_cpp_cmd2defines "TangLin version" -bAD_CONFIG_H -UALLOW_ADJOINT_RUN -DALLOW_TANGENTLINEAR_RUN > ad_config.template
-	cmp ad_config.template AD_CONFIG.h || cat ad_config.template > AD_CONFIG.h
-	@-rm -f ad_config.template
+	@$BASH\$(TOOLSDIR)/convert_cpp_cmd2defines "TangLin version" -bAD_CONFIG_H -UALLOW_ADJOINT_RUN -DALLOW_TANGENTLINEAR_RUN > ad_config.template1
+	cmp ad_config.template1 AD_CONFIG.h || cat ad_config.template1 > AD_CONFIG.h
+	@-rm -f ad_config.template1
 	@\$(MAKE) -f \$(MAKEFILE) \$(F90_PP_SRC_FILES) \$(F77_PP_SRC_FILES)
 	sed -i.bak -f \$(TOOLSDIR)/remove_comments_sed \$(AD_FILES)
 	@-rm -f \$(AD_F90FILES:.$FS90=_tl.$FS90) \$(AD_FILES:.$FS=_tl.$FS) \$(AD_FILES:.$FS=.$FS.bak); echo ''

--- a/verification/testreport
+++ b/verification/testreport
@@ -849,7 +849,7 @@ runmodel()
 	    #echo '' ; echo "  COMMAND='$COMMAND'"
 	    COMMAND=`echo $COMMAND | sed "s/ TR_NPROC/ $LOC_NPROC/"`
 	    if test "x$MPI_MFILE" != x ; then
-	      COMMAND=`echo $COMMAND | sed "s/ TR_MFILE / ..\/..\/$LOC_MFILE /"`
+	      COMMAND=`echo $COMMAND | sed "s/ TR_MFILE / ..\/$LOC_MFILE /"`
 	    fi
 	    #echo "  COMMAND='$COMMAND'"
 	fi
@@ -1411,7 +1411,7 @@ done
 if test $count = 1 ; then echo "" ; echo -n " ... " ; fi
 #echo 'TESTDIRS='${TESTDIRS}'<'
 
-LOC_MFILE='tr_mpi_mfile'
+LOC_MFILE='mpi_mfile.loc'
 RUNLOG="run.tr_log"
 if test "x$MPI" = x0 ; then
   OUTPUTFILE=$ref_outp
@@ -1677,17 +1677,17 @@ for dir in $TESTDIRS ; do
 	)
 	if test "x$MPI_MFILE" != x ; then
 	    #- create new MPI machine-file with the right number of Procs
-	    rm -f $LOC_MFILE
-	    cat $MPI_MFILE | sort | uniq | head -$LOC_NPROC > $LOC_MFILE
-	    nl=`wc -l $LOC_MFILE | awk '{print $1}'`
+	    rm -f $dir/$LOC_MFILE
+	    cat $MPI_MFILE | sort | uniq | head -$LOC_NPROC > $dir/$LOC_MFILE
+	    nl=`wc -l $dir/$LOC_MFILE | awk '{print $1}'`
 	    if [ $nl -lt $LOC_NPROC ] ; then
-		rm -f $LOC_MFILE
-		cat $MPI_MFILE | head -$LOC_NPROC > $LOC_MFILE
-		#sed -n "1,$LOC_NPROC p" $MPI_MFILE > $LOC_MFILE
+		rm -f $dir/$LOC_MFILE
+		cat $MPI_MFILE | head -$LOC_NPROC > $dir/$LOC_MFILE
+		#sed -n "1,$LOC_NPROC p" $MPI_MFILE > $dir/$LOC_MFILE
 	    fi
 	    if [ $verbose -gt 1 ]; then
 		nl=`wc -l $LOC_MFILE | awk '{print $1}'`
-		echo " new LOC_MFILE=$LOC_MFILE : $nl procs for LOC_NPROC=$LOC_NPROC"
+		echo " new LOC_MFILE=$dir/$LOC_MFILE : $nl procs for LOC_NPROC=$LOC_NPROC"
 	    fi
 	fi
 	if test "x$MULTI_THREAD" = "xt" ; then
@@ -1886,7 +1886,7 @@ for dir in $TESTDIRS ; do
 	makeclean $dir/$builddir \
 	    && run_clean $dir/$rundir
     fi
-    if test "x$MPI" != x0 -a "x$MPI_MFILE" != x ; then rm -f $LOC_MFILE ; fi
+    if test "x$MPI" != x0 -a "x$MPI_MFILE" != x ; then rm -f $dir/$LOC_MFILE ; fi
 
     echo "-------------------------------------------------------------------------------"
 

--- a/verification/testreport
+++ b/verification/testreport
@@ -876,6 +876,7 @@ runmodel()
 	    rm -f $OUTPUTFILE $RUNLOG ; touch $RUNLOG
 	    if test -f run.log_tmp ; then cat run.log_tmp >> $RUNLOG ; fi
 	#- Divided Adjoint Run:
+	    add_DIVA_runs=0
 	#  get the number of additional runs (add_DIVA_runs) from file "run_ADM_DIVA"
 	    if test $KIND = 2 -a -f run_ADM_DIVA ; then
 	      adm_diva_nb=`sed -n '/^ *add_DIVA_runs *=/p' run_ADM_DIVA | sed 's/ //g'`
@@ -1652,7 +1653,9 @@ for dir in $TESTDIRS ; do
 	continue
     fi
 
-    if test "x$MPI" != "x0" ; then
+    if test "x$MPI" = "x0" ; then
+	LOC_NPROC=1
+    else
 	ntx=1 ; nty=1
 	if test "x$MULTI_THREAD" = "xt" ; then
 	  ff=$dir"/input/eedata.mth"


### PR DESCRIPTION
## What changes does this PR introduce?

1. try a simple fix for issue #914 
2. testreport rarely used "-mfile/-mf" option: move local copy ($LOC_MFILE) to experiment directory.

## What is the current behaviour? 
1. see issue #914
2. processing of "-mfile" file involves an experiment specific local copy that is put where `testreport` is run (i..e., in `verification/).

## What is the new behaviour 
1. use a different file name (`ad_config.template{0,1,2}`) for each stage of the TAF processing. This should prevent one instance of `make` to remove the `ad_config.template` of an other instance before the comparison is completed.
2. local copy  $LOC_MFILE is kept in experiment directory.

## Does this PR introduce a breaking change? 
No.

## Other information:


## Suggested addition to `tag-index`
o tools/genmake2:
  - use specific "ad_config.template{0,1,2}" in different stages of TAF
    AD/TL built to avoid race condition issue with "make -jN".
