### PR TITLE
more bgc TAF store directives

### DIFF
--- a/doc/tag-index
+++ b/doc/tag-index
@@ -1,6 +1,8 @@
     Notes on tags used in MITgcmUV
     ==============================
 
+o pkg/bling, pkg/dic:
+  - additional store directives to avoid hidden recomputations.
 o pkg/longstep:
   - add remaining GM-Redi matrix coefficients (extra-diagonal & diagonal terms)
     and Bolus transport stream function for time-averaging in longstep pkg and

--- a/pkg/bling/bling_airseaflux.F
+++ b/pkg/bling/bling_airseaflux.F
@@ -232,6 +232,9 @@ C Use the original Follows et al. (2006) solver
 
         ENDDO
        ENDDO
+#ifdef ALLOW_AUTODIFF_TAMC
+CADJ STORE pCO2(:,:,bi,bj) = comlev1_bibj, key = tkey, kind = isbyte
+#endif
 
        DO j=jmin,jmax
         DO i=imin,imax

--- a/pkg/bling/bling_carbon_chem.F
+++ b/pkg/bling/bling_carbon_chem.F
@@ -31,11 +31,11 @@ C     =================================================================
 
 C     === Global variables ===
 #include "SIZE.h"
-#include "DYNVARS.h"
 #include "EEPARAMS.h"
-#include "PARAMS.h"
-#include "GRID.h"
-#include "FFIELDS.h"
+c#include "PARAMS.h"
+c#include "GRID.h"
+c#include "DYNVARS.h"
+c#include "FFIELDS.h"
 #include "BLING_VARS.h"
 
 C     == Routine arguments ==
@@ -345,11 +345,11 @@ C      Oct 2011: add CO3 extimation and pass out
 
 C     === Global variables ===
 #include "SIZE.h"
-#include "DYNVARS.h"
 #include "EEPARAMS.h"
-#include "PARAMS.h"
+c#include "PARAMS.h"
 #include "GRID.h"
-#include "FFIELDS.h"
+c#include "DYNVARS.h"
+c#include "FFIELDS.h"
 #include "BLING_VARS.h"
 
 C     == Routine arguments ==
@@ -523,11 +523,11 @@ C--------------------------------------------------------------------------
 
 C     === Global variables ===
 #include "SIZE.h"
-#include "DYNVARS.h"
 #include "EEPARAMS.h"
-#include "PARAMS.h"
+c#include "PARAMS.h"
 #include "GRID.h"
-#include "FFIELDS.h"
+c#include "DYNVARS.h"
+c#include "FFIELDS.h"
 #include "BLING_VARS.h"
 
 C     == Routine arguments ==
@@ -655,7 +655,7 @@ C------------------------------------------------------------------------
 C k1p = [H][H2PO4]/[H3PO4]
 C DOE(1994) eq 7.2.20 with footnote using data from Millero (1974)
 C The constant 115.525 is an approximation to convert to the total pH scale
-C  (Dickson et al., 2007). Use Millero's 115.540 constant to stay on the seawater
+C  (Dickson et al., 2007). Use Milleros 115.540 constant to stay on the seawater
 C  pH scale (everything else is the same).
            ak1p(i,j,bi,bj) = exp(-4576.752 _d 0*invtk + 115.525 _d 0 -
      &          18.453 _d 0*dlogtk +
@@ -665,7 +665,7 @@ C------------------------------------------------------------------------
 C k2p = [H][HPO4]/[H2PO4]
 C DOE(1994) eq 7.2.23 with footnote using data from Millero (1974))
 C The constant 172.0833 is an approximation to convert to the total pH scale
-C  (Dickson et al., 2007). Use Millero's 172.1033 constant to stay on the seawater
+C  (Dickson et al., 2007). Use Milleros 172.1033 constant to stay on the seawater
 C  pH scale (everything else is the same).
            ak2p(i,j,bi,bj) = exp(-8814.715 _d 0*invtk + 172.0883 _d 0 -
      &          27.927 _d 0*dlogtk +
@@ -675,7 +675,7 @@ C------------------------------------------------------------------------
 C k3p = [H][PO4]/[HPO4]
 C DOE(1994) eq 7.2.26 with footnote using data from Millero (1974)
 C The constant 18.141 is an approximation to convert to the total pH scale
-C  (Dickson et al., 2007). Use Millero's 18.126 constant to stay on the seawater
+C  (Dickson et al., 2007). Use Milleros 18.126 constant to stay on the seawater
 C  pH scale (everything else is the same).
            ak3p(i,j,bi,bj) = exp(-3070.75 _d 0*invtk - 18.141 _d 0 +
      &          (17.27039 _d 0*invtk + 2.81197 _d 0) *
@@ -684,7 +684,7 @@ C------------------------------------------------------------------------
 C ksi = [H][SiO(OH)3]/[Si(OH)4]
 C Millero p.671 (1995) using data from Yao and Millero (1995)
 C The constant 117.385 is an approximation to convert to the total pH scale
-C  (Dickson et al., 2007). Use Millero's 117.400 constant to stay on the seawater
+C  (Dickson et al., 2007). Use Milleros 117.400 constant to stay on the seawater
 C  pH scale (everything else is the same).
 C  Note: converted here from mol/kg-H2O to mol/kg-SW
            aksi(i,j,bi,bj) = exp(-8904.2 _d 0*invtk + 117.385 _d 0 -
@@ -697,7 +697,7 @@ C------------------------------------------------------------------------
 C kw = [H][OH]
 C Millero p.670 (1995) using composite data
 C The constant 148.9652 is an approximation to convert to the total pH scale
-C  (Dickson et al., 2007). Use Millero's 148.9802 constant to stay on the seawater
+C  (Dickson et al., 2007). Use Milleros 148.9802 constant to stay on the seawater
 C  pH scale (everything else is the same).
            akw(i,j,bi,bj) = exp(-13847.26 _d 0*invtk + 148.9652 _d 0 -
      &          23.6521 _d 0*dlogtk +
@@ -815,11 +815,11 @@ C--------------------------------------------------------------------------
 
 C     === Global variables ===
 #include "SIZE.h"
-#include "DYNVARS.h"
 #include "EEPARAMS.h"
-#include "PARAMS.h"
+c#include "PARAMS.h"
 #include "GRID.h"
-#include "FFIELDS.h"
+c#include "DYNVARS.h"
+c#include "FFIELDS.h"
 #include "BLING_VARS.h"
 
 C     == Routine arguments ==
@@ -1022,7 +1022,7 @@ C------------------------------------------------------------------------
 C k1p = [H][H2PO4]/[H3PO4]
 C DOE(1994) eq 7.2.20 with footnote using data from Millero (1974)
 C The constant 115.525 is an approximation to convert to the total pH scale
-C  (Dickson et al., 2007). Use Millero's 115.540 constant to stay on the seawater
+C  (Dickson et al., 2007). Use Milleros 115.540 constant to stay on the seawater
 C  pH scale (everything else is the same).
            ak1p(i,j,bi,bj) = exp(-4576.752*invtk + 115.525 -
      &          18.453*dlogtk +
@@ -1032,7 +1032,7 @@ C------------------------------------------------------------------------
 C k2p = [H][HPO4]/[H2PO4]
 C DOE(1994) eq 7.2.23 with footnote using data from Millero (1974))
 C The constant 172.0833 is an approximation to convert to the total pH scale
-C  (Dickson et al., 2007). Use Millero's 172.1033 constant to stay on the seawater
+C  (Dickson et al., 2007). Use Milleros 172.1033 constant to stay on the seawater
 C  pH scale (everything else is the same).
            ak2p(i,j,bi,bj) = exp(-8814.715*invtk + 172.0883 -
      &          27.927*dlogtk +
@@ -1042,7 +1042,7 @@ C------------------------------------------------------------------------
 C k3p = [H][PO4]/[HPO4]
 C DOE(1994) eq 7.2.26 with footnote using data from Millero (1974)
 C The constant 18.141 is an approximation to convert to the total pH scale
-C  (Dickson et al., 2007). Use Millero's 18.126 constant to stay on the seawater
+C  (Dickson et al., 2007). Use Milleros 18.126 constant to stay on the seawater
 C  pH scale (everything else is the same).
            ak3p(i,j,bi,bj) = exp(-3070.75*invtk - 18.141 +
      &          (17.27039*invtk + 2.81197) *
@@ -1051,7 +1051,7 @@ C------------------------------------------------------------------------
 C ksi = [H][SiO(OH)3]/[Si(OH)4]
 C Millero p.671 (1995) using data from Yao and Millero (1995)
 C The constant 117.385 is an approximation to convert to the total pH scale
-C  (Dickson et al., 2007). Use Millero's 117.400 constant to stay on the seawater
+C  (Dickson et al., 2007). Use Milleros 117.400 constant to stay on the seawater
 C  pH scale (everything else is the same).
 C Note: converted here from mol/kg-H2O to mol/kg-SW
            aksi(i,j,bi,bj) = exp(-8904.2*invtk + 117.385 -
@@ -1064,7 +1064,7 @@ C------------------------------------------------------------------------
 C kw = [H][OH]
 C Millero p.670 (1995) using composite data
 C The constant 148.9652 is an approximation to convert to the total pH scale
-C  (Dickson et al., 2007). Use Millero's 148.9802 constant to stay on the seawater
+C  (Dickson et al., 2007). Use Milleros 148.9802 constant to stay on the seawater
 C  pH scale (everything else is the same).
            akw(i,j,bi,bj) = exp(-13847.26*invtk + 148.9652 -
      &          23.6521*dlogtk +

--- a/pkg/bling/bling_carbonate_sys.F
+++ b/pkg/bling/bling_carbonate_sys.F
@@ -1,4 +1,7 @@
 #include "BLING_OPTIONS.h"
+#ifdef ALLOW_AUTODIFF
+# include "AUTODIFF_OPTIONS.h"
+#endif
 
 CBOP
       SUBROUTINE BLING_CARBONATE_SYS(
@@ -24,6 +27,9 @@ C     == GLobal variables ==
 #include "PARAMS.h"
 #include "GRID.h"
 #include "BLING_VARS.h"
+#ifdef ALLOW_AUTODIFF_TAMC
+# include "tamc.h"
+#endif
 
 C     == Routine arguments ==
 C     PTR_DIC              :: dissolved inorganic carbon
@@ -70,6 +76,12 @@ C     CO3iterMax        :: total number of iterations
 
 c      INTEGER CO3iter
 c      INTEGER CO3iterMax
+#ifdef ALLOW_AUTODIFF_TAMC
+C     tkey :: tape key (tile dependent)
+C     kkey :: tape key (level and tile dependent)
+C     ikey :: tape key (position, level, and tile dependent)
+      INTEGER tkey, kkey, ikey
+#endif
 CEOP
 
 C  Since pH is now a 3D field and is solved for at every time step
@@ -79,9 +91,15 @@ c      CO3iterMax = 1
 C determine carbonate ion concentration through full domain
 C determine calcite saturation state
 
+#ifdef ALLOW_AUTODIFF_TAMC
+      tkey = bi + (bj - 1)*nSx + (ikey_dynamics - 1)*nSx*nSy
+#endif
 C$TAF LOOP = parallel
        DO k=1,Nr
 
+#ifdef ALLOW_AUTODIFF_TAMC
+        kkey = k + (tkey - 1)*Nr
+#endif
         DO j=jMin,jMax
          DO i=iMin,iMax
           locTemp(i,j) = theta(i,j,k,bi,bj)
@@ -128,6 +146,9 @@ C$TAF LOOP = parallel
 
           IF ( hFacC(i,j,k,bi,bj) .GT. 0. _d 0) THEN
 
+#ifdef ALLOW_AUTODIFF_TAMC
+           ikey = i + (j - 1)*sNx + (kkey - 1)*sNx*sNy
+#endif
 #ifdef CARBONCHEM_SOLVESAPHE
            calcium = cat(i,j,bi,bj)
 #else
@@ -205,7 +226,9 @@ c           ENDDO
 #ifdef CARBONCHEM_SOLVESAPHE
            ENDIF
 #endif /* CARBONCHEM_SOLVESAPHE */
-
+#ifdef ALLOW_AUTODIFF_TAMC
+CADJ store carbonate = comlev1_bibj_ijk, key = ikey, kind = isbyte
+#endif
            pH(i,j,k,bi,bj) = pHlocal
 
 C  Calculate calcium carbonate (calcite and aragonite)

--- a/pkg/bling/bling_main.F
+++ b/pkg/bling/bling_main.F
@@ -117,6 +117,7 @@ C     runoff_PO4           :: tendency due to river runoff
 #endif
 #endif
 #ifdef ALLOW_AUTODIFF_TAMC
+C     tkey :: tape key (tile dependent)
       INTEGER tkey
 #endif
 CEOP
@@ -168,7 +169,8 @@ c  carbon and oxygen air-sea interaction
      I                       myTime, myIter, myThid)
 
 #ifdef ALLOW_AUTODIFF_TAMC
-CADJ STORE ph(:,:,:,bi,bj) = comlev1_bibj, key=tkey, kind=isbyte
+CADJ STORE ph(:,:,:,bi,bj), ak0(:,:,bi,bj), fugf(:,:,bi,bj)
+CADJ &     = comlev1_bibj, key = tkey, kind = isbyte
 #endif
 
 c-----------------------------------------------------------
@@ -180,6 +182,10 @@ c  determine calcite saturation for remineralization
 #endif
      I                         bi, bj, imin, imax, jmin, jmax,
      I                         myTime, myIter, myThid)
+
+#ifdef ALLOW_AUTODIFF_TAMC
+CADJ STORE omegaC(:,:,:,bi,bj) = comlev1_bibj, key=tkey, kind=isbyte
+#endif
 
 C-----------------------------------------------------------
 C  biological activity

--- a/pkg/dic/dic_biotic_forcing.F
+++ b/pkg/dic/dic_biotic_forcing.F
@@ -1,4 +1,7 @@
 #include "DIC_OPTIONS.h"
+#ifdef ALLOW_AUTODIFF
+# include "AUTODIFF_OPTIONS.h"
+#endif
 
 CBOP
 C !ROUTINE: DIC_BIOTIC_FORCING
@@ -29,6 +32,9 @@ C !USES: ===============================================================
 #include "DIC_VARS.h"
 #include "PTRACERS_SIZE.h"
 #include "PTRACERS_PARAMS.h"
+#ifdef ALLOW_AUTODIFF_TAMC
+# include "tamc.h"
+#endif
 
 C !INPUT/OUTPUT PARAMETERS: ===================================================
 C  PTR_DIC              :: dissolced inorganic carbon
@@ -105,12 +111,19 @@ C  freefe                 :: iron not bound to ligand
       INTEGER kBottom
 # endif
 #endif
+#ifdef ALLOW_AUTODIFF_TAMC
+C     tkey :: tape key TAF-AD simulations (depends on tiles)
+      INTEGER tkey
+#endif
 CEOP
 
 #ifdef ALLOW_DEBUG
       IF (debugMode) CALL DEBUG_ENTER('DIC_BIOTIC_FORCING',myThid)
 #endif
 
+#ifdef ALLOW_AUTODIFF_TAMC
+      tkey = bi + (bj-1)*nSx + (ikey_dynamics-1)*nSx*nSy
+#endif
       IF ( useThSIce .OR. useSEAICE .OR. useCoupler ) THEN
 #ifdef ALLOW_DEBUG
         IF (debugMode) CALL DEBUG_CALL('DIC_FIELDS_UPDATE',myThid)
@@ -162,6 +175,10 @@ C carbon air-sea interaction
      I                    bi, bj, iMin, iMax, jMin, jMax,
      I                    myTime, myIter, myThid )
 
+#ifdef ALLOW_AUTODIFF_TAMC
+CADJ STORE Kwexch_pre(:,:,bi,bj) = comlev1_bibj, key=tkey, kind=isbyte
+#endif
+
 C alkalinity air-sea interaction
 #ifdef ALLOW_DEBUG
        IF (debugMode) CALL DEBUG_CALL('ALK_SURFFORCING',myThid)
@@ -207,6 +224,9 @@ C biological activity
      O                    BIOac,
      I                    bi, bj, iMin, iMax, jMin, jMax,
      I                    myTime, myIter, myThid )
+#ifdef ALLOW_AUTODIFF_TAMC
+CADJ STORE BIOac = comlev1_bibj, key = tkey, kind = isbyte
+#endif
 
 C flux of po4 from layers with biological activity
 #ifdef ALLOW_DEBUG

--- a/pkg/dic/dic_surfforcing.F
+++ b/pkg/dic/dic_surfforcing.F
@@ -67,6 +67,7 @@ C local variables for carbon chem
       _RL VirtualFlux(1-OLx:sNx+OLx,1-OLy:sNy+OLy)
 #endif
 #ifdef ALLOW_AUTODIFF_TAMC
+C     tkey :: tape key (tile dependent)
       INTEGER tkey
 #endif
 CEOP
@@ -215,6 +216,9 @@ C Use the original Follows et al. (2006) solver
           ENDIF
         ENDDO
        ENDDO
+#ifdef ALLOW_AUTODIFF_TAMC
+CADJ STORE pCO2(:,:,bi,bj) = comlev1_bibj, key = tkey, kind = isbyte
+#endif
 
        DO j=jMin,jMax
         DO i=iMin,iMax


### PR DESCRIPTION
## What changes does this PR introduce?
update

## What is the current behaviour? 
some hidden recomputations in pkgs `dic` and `bling`

## What is the new behaviour 
A few store directives avoid most hidden recomputations in pkgs `dic` and `bling`.
What's left are routines that compute carbon chemistry coefficients. There are so many coefficients that even I think that recomputing them may be more economical than storing them.

## Does this PR introduce a breaking change? 
No

## Other information:
1. none of this is strictly necessary. It will increase memory overhead slight, and reduce runtime slightly (I didn't measure either)
2. I noticed that `dic/carbon_chem.F` and `bling/bling_carbon_chem.F` are nearly the same file. This means the four subroutines in each of these files have the same names, which is probably not problematic as long as `DIC` and `BLING` are never compiled together. I assume that `bling_carbon_chem.F` was originally a copy of `carbon_chem.F` and has been adjusted and now slowly diverges. Would it make sense to collect routines like this in `pkg/gchem`, and have both packages benefit from improvements and bug fixes? 

## Suggested addition to `tag-index`
- pkg/dic, pkg/bling: additional store directives to avoid hidden recomputations