### PR TITLE
Fix bug in gluemncbig caused by new numpy casting rules

### DIFF
--- a/utils/python/MITgcmutils/scripts/gluemncbig
+++ b/utils/python/MITgcmutils/scripts/gluemncbig
@@ -194,7 +194,7 @@ class NetCDFError(Exception):
 
 class unmapped_array(object):
     def __init__(self, shape, dtype_):
-        self.shape = shape
+        self.shape = tuple(int(_) for _ in shape)
         self.dtype = dtype(dtype_)
 
     @property


### PR DESCRIPTION
## What changes does this PR introduce?

Bug fix

## What is the current behaviour? 

gluemncbig throws an integer overflow on large files

## What is the new behaviour 

Bug fixed (at least in some cases)

## Does this PR introduce a breaking change? 

No

## Other information:

This is caused by new integer casting rules in numpy 2.*.  Explicit casting to a python integer avoids the overflow.

Resolves #916 