### PR TITLE
Fix fortran output format + 1 prepare_run

### DIFF
--- a/doc/tag-index
+++ b/doc/tag-index
@@ -1,6 +1,9 @@
     Notes on tags used in MITgcmUV
     ==============================
 
+o pkg/seaice:
+  - fix 3 output formats to allow to run with gfortran v.15
+  - also add "deep_anelastic.vecinv" to multi-threaded tests.
 o pkg/mom_{common,fluxform,vecinv}:
   - mom_fluxform, new option, selectCoriScheme=4: use hFac averaged transport in
     Coriolis term so that column integral of tendency match Coriolis time

--- a/pkg/seaice/seaice_jfnk.F
+++ b/pkg/seaice/seaice_jfnk.F
@@ -291,7 +291,7 @@ C     some output diagnostics
          _BEGIN_MASTER( myThid )
          totalNewtonItersLoc =
      &        SEAICEnonLinIterMax*(myIter-nIter0)+newtonIter
-         WRITE(msgBuf,'(2A,2(1XI6),2E12.5)')
+         WRITE(msgBuf,'(2A,2(1X,I6),2E12.5)')
      &        ' S/R SEAICE_JFNK: Newton iterate / total, ',
      &        'JFNKgamma_lin, initial norm = ',
      &        newtonIter, totalNewtonItersLoc,
@@ -581,7 +581,7 @@ C     Only start a linesearch after some Newton iterations
 C     some output diagnostics
        IF ( debugLevel.GE.debLevA .AND. doLineSearch ) THEN
         _BEGIN_MASTER( myThid )
-        WRITE(msgBuf,'(2A,2(1XI6),1X,3E12.5)')
+        WRITE(msgBuf,'(2A,2(1X,I6),1X,3E12.5)')
      &       ' S/R SEAICE_JFNK_UPDATE: Newton iter, LSiter, ',
      &       'facLS, JFNKresidual, resLoc = ',
      &        newtonIter, l, facLS, JFNKresidual, resLoc

--- a/pkg/seaice/seaice_krylov.F
+++ b/pkg/seaice/seaice_krylov.F
@@ -376,7 +376,7 @@ C     some output diagnostics
          _BEGIN_MASTER( myThid )
          totalPicardItersLoc =
      &        picardIterMax*(myIter-nIter0)+picardIter
-         WRITE(msgBuf,'(2A,2(1XI6),2E12.5)')
+         WRITE(msgBuf,'(2A,2(1X,I6),2E12.5)')
      &        ' S/R SEAICE_KRYLOV: Picard iterate / total, ',
      &        'KRYLOVgamma_lin, initial norm = ',
      &        picardIter, totalPicardItersLoc,

--- a/verification/deep_anelastic/input.vecinv/eedata.mth
+++ b/verification/deep_anelastic/input.vecinv/eedata.mth
@@ -1,0 +1,12 @@
+# Example "eedata" file  for multi-threaded test
+#   (copy "eedata.mth" to "eedata" to use it)
+# Lines beginning "#" are comments
+#  nTx      :: No. threads per process in X
+#  nTy      :: No. threads per process in Y
+# debugMode :: print debug msg (sequence of S/R calls)
+ &EEPARMS
+ nTx=1,
+ nTy=2,
+ &
+# Note: Some systems use & as the namelist terminator (as shown here).
+#       Other systems use a / character.

--- a/verification/lab_sea/input.longstep/prepare_run
+++ b/verification/lab_sea/input.longstep/prepare_run
@@ -1,32 +1,6 @@
 #! /usr/bin/env bash
 
-#- Temporary solution (until all files got moved here): take parameter files
-#- from this dir:
-fromDir="../../natl_box/input.longstep"
-
-fileList=`( cd $fromDir ; echo data* eedata tr_checklist)`
-
-#echo 'fileList=' $fileList
-
-#- and do a symbolic link in the current directory
-#   (if the file does not already exist)
-if test -d $fromDir ; then
-  lnkList='files:'
-  for xx in $fileList
-  do
-    if test -r ${fromDir}/$xx ; then
-      if test ! -r $xx ; then
-        lnkList=${lnkList}" "$xx
-        ln -sf ${fromDir}/$xx .
-      fi
-    fi
-  done
-  echo ' link' $lnkList "from dir:" $fromDir
-else
-  echo " Error:" $fromDir "not a directory"
-fi
-
-#- And in order to save disc space, take binary input files
+#- In order to save disc space, take binary input files
 #- from this dir:
 fromDir="../input.natl_box"
 


### PR DESCRIPTION
## What changes does this PR introduce?
1. Fix 3 fortran format for output to STDOUT in pkg/seaice
2. Left from PR #885, fix `prepare_run` in `lab_sea/input/longstep`
3. Left from PR #809, fix missing "eedata.mth" in new test exp. `deep_anelastic/input.vecinv`

## What is the current behaviour? 
1. With recent gfortran compiler (version 15, with Fedora 42), missing separating comma in output format results in run-time error, as seen here:
 https://mitgcm.org/testing/results/2025_05/tr_baudelaire_20250517_0/offline_exf_seaice.dyn_jfnk/run.tr_log
2. Weak error in `lab_sea.longstep` from `prepare_run` (missing dir "../../natl_box/input.longstep")
   as this script has not been updated while cleaning merged test exp. (in PR #885). But this does not prevent to run this test.
3. New test exp. `deep_anelastic.vecinv` is skipped when running multi-threaded testreport.

## What is the new behaviour 
1. Can run run `offline_exf_seaice.dyn_jfnk`and `offline_exf_seaice.dyn_paralens` using gfortran version 15
2. No error when running `lab_sea.longstep`
3. Test `deep_anelastic.vecinv` is included in multi-threaded `testreport` (-mth).

## Does this PR introduce a breaking change? 
No

## Other information:

## Suggested addition to `tag-index`
o pkg/seaice:
  - fix 3 output formats to allow to run with gfortran v.15
  - also add "deep_anelastic.vecinv" to multi-threaded tests.
