### PR TITLE
remove f90-type syntax in subroutine for tapenade

### DIFF
--- a/doc/tag-index
+++ b/doc/tag-index
@@ -1,6 +1,8 @@
     Notes on tags used in MITgcmUV
     ==============================
 
+o pkg/streamice:
+  - fix "new_partial" initialisation in streamice_adv_front.f (helps Tapenade)
 o pkg/bling, pkg/dic:
   - additional store directives to avoid hidden recomputations.
 o pkg/longstep:

--- a/pkg/streamice/streamice_adv_front.F
+++ b/pkg/streamice/streamice_adv_front.F
@@ -220,7 +220,7 @@ CADJ STORE hflux_y_SI(i,j+1,bi,bj) = comlev1_stream_ij, key = ikey_1
 
                n_flux_2 = 0. _d 0 ;
                DO k=1,4
-                new_partial (:) = 0
+                new_partial (k) = 0
                ENDDO
 
                DO k=1,2


### PR DESCRIPTION
## What changes does this PR introduce?
Replaces single line containing f90 syntax with equivalent f77 syntax

## What is the current behaviour? 
when compiling the adjoint with Tapenade using the [latest Tapenade version](https://tapenade.gitlabpages.inria.fr/tapenade/distrib/tapenade_3.16.tar) the transformed version of streamice_adv_front.F is an f90 file, even though the Makefile looks for a f77 file. The build fails.

## What is the new behaviour 
the f90 syntax is replaced with f77 syntax and build succeeds. 

## Does this PR introduce a breaking change? 
No, it should not

## Other information:
I am unable to generate a results file for the halfpipe_streamice verification as it does not run on github actions, and Im not sure what server architecture is used

## Suggested addition to `tag-index`
o pkg/streamice:
  - remove f90 syntax from streamice_adv_front.f to address Tapenade build issues