### PR TITLE
Branch ci tapenade

### DIFF
--- a/.github/workflows/build_testing.yml
+++ b/.github/workflows/build_testing.yml
@@ -47,6 +47,35 @@ jobs:
        run: |
          . tools/ci/runtr.sh
 
+  tapenade:
+   runs-on: ubuntu-latest
+
+   strategy:
+     matrix:
+      include:
+        - exp: "halfpipe_streamice"
+
+   continue-on-error: true
+
+   steps:
+
+     - name: Checkout
+       uses: actions/checkout@v2.2.0
+
+     - name: Get a docker image and set it running
+       run: |
+         docker pull dngoldberg/tapenade_ubuntu:latest
+         docker run -i -t -v `pwd`:/MITgcm -d --name tapenade-testing --ulimit stack=-1:-1 --rm dngoldberg/tapenade_ubuntu:latest /bin/bash
+
+     - name: Run testreport
+       env:
+        MITGCM_EXP: ${{ matrix.exp }}
+        MITGCM_DECMD: "docker exec -i tapenade-testing bash -lc"
+        MITGCM_TROPT: "-oad -devel -of=../tools/build_options/linux_amd64_gfortran -match 10"
+        MITGCM_INPUT_DIR_PAT: '/input_oad.*'
+       run: |
+         . tools/ci/runtr.sh         
+
  openad:
    runs-on: ubuntu-latest
 

--- a/pkg/streamice/STREAMICE.h
+++ b/pkg/streamice/STREAMICE.h
@@ -184,7 +184,7 @@ C     -------------------------- INT PARAMS ------------------------------------
 C---+----1--+-+----2----+----3----+----4----+----5----+----6----+----7-|--+----|
 
 C--   COMMON /STREAMICE_PARMS_I/ int valued parameters.
-C     streamice_max_cg_iter             :: max CG iterations
+C     streamice_max_cg_iter             :: max conj gradient iterations
 C     streamice_max_nl_iter             :: max nonlin iterations in
 C                                          vel solve
 C     streamice_maxcgiter_cpl           :: max CG iters, coupled mode


### PR DESCRIPTION
## What changes does this PR introduce?
This branch introduces CI for tapenade verification, using a bespoke docker container


## What is the current behaviour? 
there is no tapenade test performed by a github runner


## What is the new behaviour 
A bespoke docker image (dngoldberg/tapenade_ubuntu) has been created that has an installationt of Tapenade, JRE and gfortran.


## Does this PR introduce a breaking change? 
I don't think so


## Other information:
The only material changes were to .github/workflows/build_testing.yml -- though images should be created under the mitgcm docker hub organisation and Dockerfile stored in tools/CI

## Suggested addition to `tag-index`
