### PR TITLE
modify streamice pickup write to ensure active variables are written correctly

### DIFF
--- a/doc/tag-index
+++ b/doc/tag-index
@@ -1,6 +1,9 @@
     Notes on tags used in MITgcmUV
     ==============================
 
+o pkg/streamice:
+  - for OpenAD, adjust streamice_write_pickup.F to only write the forward
+    components of state arrays to the binary pickups for later use.
 o verification:
   - remove all pkg/timeave params from all exp. and no longer compile this
     pkg in any exp. ; also skip pkg/mnc compilation in 4 fwd test exp ;

--- a/pkg/streamice/streamice_write_pickup.F
+++ b/pkg/streamice/streamice_write_pickup.F
@@ -71,8 +71,13 @@ C       Firstly, write 3-D fields as consecutive records,
 #ifdef STREAMICE_HYBRID_STRESS
 C     record number < 0 : a hack not to write meta files now:
         j = j + 1
+#ifndef ALLOW_OPENAD
         CALL WRITE_REC_3D_RL( fn, fp, Nr, visc_streamice_full,
      &                        -j, myIter, myThid )
+#else
+        CALL WRITE_REC_3D_RL( fn, fp, Nr, visc_streamice_full%v,
+     &                        -j, myIter, myThid )
+#endif
         IF (j.LE.listDim) wrFldList(j) = 'visc3d  '
 #endif /* STREAMICE_HYBRID_STRESS */
 
@@ -81,8 +86,13 @@ C-    switch to 2-D fields:
 
         j = j + 1
         nj = nj-1
+#ifndef ALLOW_OPENAD
         CALL WRITE_REC_3D_RL( fn, fp, 1, area_shelf_streamice,
      &                        nj, myIter, myThid )
+#else
+        CALL WRITE_REC_3D_RL( fn, fp, 1, area_shelf_streamice%v,
+     &                        nj, myIter, myThid )
+#endif
         IF (j.LE.listDim) wrFldList(j) = 'SI_area '
 
         j = j + 1
@@ -93,45 +103,80 @@ C-    switch to 2-D fields:
 
         j = j + 1
         nj = nj-1
+#ifndef ALLOW_OPENAD
         CALL WRITE_REC_3D_RL( fn, fp, 1, U_streamice,
      &                        nj, myIter, myThid )
+#else
+        CALL WRITE_REC_3D_RL( fn, fp, 1, U_streamice%v,
+     &                        nj, myIter, myThid )
+#endif
         IF (j.LE.listDim) wrFldList(j) = 'SI_uvel '
 
         j = j + 1
         nj = nj-1
+#ifndef ALLOW_OPENAD
         CALL WRITE_REC_3D_RL( fn, fp, 1, V_streamice,
      &                        nj, myIter, myThid )
+#else
+        CALL WRITE_REC_3D_RL( fn, fp, 1, V_streamice%v,
+     &                        nj, myIter, myThid )
+#endif
         IF (j.LE.listDim) wrFldList(j) = 'SI_vvel '
 
         j = j + 1
         nj = nj-1
+#ifndef ALLOW_OPENAD
         CALL WRITE_REC_3D_RL( fn, fp, 1, H_streamice,
      &                        nj, myIter, myThid )
+#else
+        CALL WRITE_REC_3D_RL( fn, fp, 1, H_streamice%v,
+     &                        nj, myIter, myThid )
+#endif
         IF (j.LE.listDim) wrFldList(j) = 'SI_thick'
 
         j = j + 1
         nj = nj-1
+#ifndef ALLOW_OPENAD
         CALL WRITE_REC_3D_RL( fn, fp, 1, tau_beta_eff_streamice,
      &                        nj, myIter, myThid )
+#else
+        CALL WRITE_REC_3D_RL( fn, fp, 1, tau_beta_eff_streamice%v,
+     &                        nj, myIter, myThid )
+#endif
         IF (j.LE.listDim) wrFldList(j) = 'SI_betaF'
 
         j = j + 1
         nj = nj-1
+#ifndef ALLOW_OPENAD
         CALL WRITE_REC_3D_RL( fn, fp, 1, visc_streamice,
      &                        nj, myIter, myThid )
+#else
+        CALL WRITE_REC_3D_RL( fn, fp, 1, visc_streamice%v,
+     &                        nj, myIter, myThid )
+#endif
         IF (j.LE.listDim) wrFldList(j) = 'SI_visc '
 
 #ifdef STREAMICE_HYBRID_STRESS
         j = j + 1
         nj = nj-1
+#ifndef ALLOW_OPENAD
         CALL WRITE_REC_3D_RL( fn, fp, 1, streamice_taubx,
      &                        nj, myIter, myThid )
+#else
+        CALL WRITE_REC_3D_RL( fn, fp, 1, streamice_taubx%v,
+     &                        nj, myIter, myThid )
+#endif
         IF (j.LE.listDim) wrFldList(j) = 'SI_taubx'
 
         j = j + 1
         nj = nj-1
+#ifndef ALLOW_OPENAD
         CALL WRITE_REC_3D_RL( fn, fp, 1, streamice_tauby,
      &                        nj, myIter, myThid )
+#else
+        CALL WRITE_REC_3D_RL( fn, fp, 1, streamice_tauby%v,
+     &                        nj, myIter, myThid )
+#endif
         IF (j.LE.listDim) wrFldList(j) = 'SI_tauby'
 #endif
 

--- a/pkg/streamice/streamice_write_pickup.F
+++ b/pkg/streamice/streamice_write_pickup.F
@@ -71,11 +71,11 @@ C       Firstly, write 3-D fields as consecutive records,
 #ifdef STREAMICE_HYBRID_STRESS
 C     record number < 0 : a hack not to write meta files now:
         j = j + 1
-#ifndef ALLOW_OPENAD
-        CALL WRITE_REC_3D_RL( fn, fp, Nr, visc_streamice_full,
+#ifdef ALLOW_OPENAD
+        CALL WRITE_REC_3D_RL( fn, fp, Nr, visc_streamice_full%v,
      &                        -j, myIter, myThid )
 #else
-        CALL WRITE_REC_3D_RL( fn, fp, Nr, visc_streamice_full%v,
+        CALL WRITE_REC_3D_RL( fn, fp, Nr, visc_streamice_full,
      &                        -j, myIter, myThid )
 #endif
         IF (j.LE.listDim) wrFldList(j) = 'visc3d  '
@@ -86,11 +86,11 @@ C-    switch to 2-D fields:
 
         j = j + 1
         nj = nj-1
-#ifndef ALLOW_OPENAD
-        CALL WRITE_REC_3D_RL( fn, fp, 1, area_shelf_streamice,
+#ifdef ALLOW_OPENAD
+        CALL WRITE_REC_3D_RL( fn, fp, 1, area_shelf_streamice%v,
      &                        nj, myIter, myThid )
 #else
-        CALL WRITE_REC_3D_RL( fn, fp, 1, area_shelf_streamice%v,
+        CALL WRITE_REC_3D_RL( fn, fp, 1, area_shelf_streamice,
      &                        nj, myIter, myThid )
 #endif
         IF (j.LE.listDim) wrFldList(j) = 'SI_area '
@@ -103,55 +103,55 @@ C-    switch to 2-D fields:
 
         j = j + 1
         nj = nj-1
-#ifndef ALLOW_OPENAD
-        CALL WRITE_REC_3D_RL( fn, fp, 1, U_streamice,
+#ifdef ALLOW_OPENAD
+        CALL WRITE_REC_3D_RL( fn, fp, 1, U_streamice%v,
      &                        nj, myIter, myThid )
 #else
-        CALL WRITE_REC_3D_RL( fn, fp, 1, U_streamice%v,
+        CALL WRITE_REC_3D_RL( fn, fp, 1, U_streamice,
      &                        nj, myIter, myThid )
 #endif
         IF (j.LE.listDim) wrFldList(j) = 'SI_uvel '
 
         j = j + 1
         nj = nj-1
-#ifndef ALLOW_OPENAD
-        CALL WRITE_REC_3D_RL( fn, fp, 1, V_streamice,
+#ifdef ALLOW_OPENAD
+        CALL WRITE_REC_3D_RL( fn, fp, 1, V_streamice%v,
      &                        nj, myIter, myThid )
 #else
-        CALL WRITE_REC_3D_RL( fn, fp, 1, V_streamice%v,
+        CALL WRITE_REC_3D_RL( fn, fp, 1, V_streamice,
      &                        nj, myIter, myThid )
 #endif
         IF (j.LE.listDim) wrFldList(j) = 'SI_vvel '
 
         j = j + 1
         nj = nj-1
-#ifndef ALLOW_OPENAD
-        CALL WRITE_REC_3D_RL( fn, fp, 1, H_streamice,
+#ifdef ALLOW_OPENAD
+        CALL WRITE_REC_3D_RL( fn, fp, 1, H_streamice%v,
      &                        nj, myIter, myThid )
 #else
-        CALL WRITE_REC_3D_RL( fn, fp, 1, H_streamice%v,
+        CALL WRITE_REC_3D_RL( fn, fp, 1, H_streamice,
      &                        nj, myIter, myThid )
 #endif
         IF (j.LE.listDim) wrFldList(j) = 'SI_thick'
 
         j = j + 1
         nj = nj-1
-#ifndef ALLOW_OPENAD
-        CALL WRITE_REC_3D_RL( fn, fp, 1, tau_beta_eff_streamice,
+#ifdef ALLOW_OPENAD
+        CALL WRITE_REC_3D_RL( fn, fp, 1, tau_beta_eff_streamice%v,
      &                        nj, myIter, myThid )
 #else
-        CALL WRITE_REC_3D_RL( fn, fp, 1, tau_beta_eff_streamice%v,
+        CALL WRITE_REC_3D_RL( fn, fp, 1, tau_beta_eff_streamice,
      &                        nj, myIter, myThid )
 #endif
         IF (j.LE.listDim) wrFldList(j) = 'SI_betaF'
 
         j = j + 1
         nj = nj-1
-#ifndef ALLOW_OPENAD
-        CALL WRITE_REC_3D_RL( fn, fp, 1, visc_streamice,
+#ifdef ALLOW_OPENAD
+        CALL WRITE_REC_3D_RL( fn, fp, 1, visc_streamice%v,
      &                        nj, myIter, myThid )
 #else
-        CALL WRITE_REC_3D_RL( fn, fp, 1, visc_streamice%v,
+        CALL WRITE_REC_3D_RL( fn, fp, 1, visc_streamice,
      &                        nj, myIter, myThid )
 #endif
         IF (j.LE.listDim) wrFldList(j) = 'SI_visc '
@@ -159,22 +159,22 @@ C-    switch to 2-D fields:
 #ifdef STREAMICE_HYBRID_STRESS
         j = j + 1
         nj = nj-1
-#ifndef ALLOW_OPENAD
-        CALL WRITE_REC_3D_RL( fn, fp, 1, streamice_taubx,
+#ifdef ALLOW_OPENAD
+        CALL WRITE_REC_3D_RL( fn, fp, 1, streamice_taubx%v,
      &                        nj, myIter, myThid )
 #else
-        CALL WRITE_REC_3D_RL( fn, fp, 1, streamice_taubx%v,
+        CALL WRITE_REC_3D_RL( fn, fp, 1, streamice_taubx,
      &                        nj, myIter, myThid )
 #endif
         IF (j.LE.listDim) wrFldList(j) = 'SI_taubx'
 
         j = j + 1
         nj = nj-1
-#ifndef ALLOW_OPENAD
-        CALL WRITE_REC_3D_RL( fn, fp, 1, streamice_tauby,
+#ifdef ALLOW_OPENAD
+        CALL WRITE_REC_3D_RL( fn, fp, 1, streamice_tauby%v,
      &                        nj, myIter, myThid )
 #else
-        CALL WRITE_REC_3D_RL( fn, fp, 1, streamice_tauby%v,
+        CALL WRITE_REC_3D_RL( fn, fp, 1, streamice_tauby,
      &                        nj, myIter, myThid )
 #endif
         IF (j.LE.listDim) wrFldList(j) = 'SI_tauby'


### PR DESCRIPTION
## What changes does this PR introduce?
This change allows pickups for the streamice package created by an OpenAD run to be read correctly

## What is the current behaviour? 
Due to the OpenAD approach to storing adjoint information, every array becomes an array of tuples, with the first of each tuple containing the "forward" value and the second containing the "adjoint" value. This structure is currently ignored by streamice/streamice_write_pickup, meaning the pickup files contain incorrect values.


## What is the new behaviour 
If OpenAD is allowed then certain state variables are "active". cpp directives then enable code which will write only the forward values of the array into the binary pickup file.


## Does this PR introduce a breaking change? 
No.

## Other information:

## Suggested addition to `tag-index`
o pkg/streamice:
   - modifiy streamice_write_pickup.F such that when OpenAD is used, only the forward components of state arrays are written to the binary pickups for later use