### PR TITLE
modify cost package for Tapenade with mpi

### DIFF
--- a/doc/tag-index
+++ b/doc/tag-index
@@ -1,6 +1,8 @@
     Notes on tags used in MITgcmUV
     ==============================
 
+o pkg/cost:
+  - fix multi-proc initialization of Tapenade adjoint cost-function.
 o pkg & model:
   - remove pkg/timeave ; remove all ALLOW_TIMEAVE code ; remove all timeave
     related parameters from common blocks (in header files) and from src code

--- a/pkg/cost/cost_dependent_init.F
+++ b/pkg/cost/cost_dependent_init.F
@@ -47,7 +47,7 @@ c     == end of interface ==
 #ifdef ALLOW_AUTODIFF
 
 #ifdef ALLOW_TAPENADE
-      fcb = 1.0
+      fcb = 0.0
 #endif
 
 #ifdef ALLOW_OPENAD
@@ -55,6 +55,9 @@ c     == end of interface ==
 #else
       if ( myProcId .EQ. 0 ) then
        adfc = 1. _d 0
+#ifdef ALLOW_TAPENADE
+       fcb = 1.0
+#endif
       endif
 #endif
 

--- a/pkg/cost/cost_dependent_init.F
+++ b/pkg/cost/cost_dependent_init.F
@@ -1,6 +1,6 @@
 #include "COST_OPTIONS.h"
 
-      subroutine cost_dependent_init( myThid )
+      SUBROUTINE COST_DEPENDENT_INIT( myThid )
 
 c     ==================================================================
 c     SUBROUTINE cost_dependent_init
@@ -26,16 +26,16 @@ c     == global variables ==
 #endif
 
 c     == routine arguments ==
-      integer myThid
+      INTEGER myThid
 
 c     == local variables ==
 #if ( defined ALLOW_COST_VECTOR || defined  ALLOW_COST_STATE_FINAL )
-      integer i
+      INTEGER i
 #endif
 #ifdef ALLOW_COST_STATE_FINAL
-      integer j, k
+      INTEGER j, k
 #endif
-      integer bi,bj
+      INTEGER bi,bj
 c     == end of interface ==
 
 #ifdef ALLOW_OPENAD
@@ -47,43 +47,40 @@ c     == end of interface ==
 #ifdef ALLOW_AUTODIFF
 
 #ifdef ALLOW_TAPENADE
-      fcb = 0.0
+      fcb = 0. _d 0
+      IF ( myProcId .EQ. 0 ) fcb = 1. _d 0
 #endif
 
 #ifdef ALLOW_OPENAD
       adfc = 1.0
 #else
-      if ( myProcId .EQ. 0 ) then
-       adfc = 1. _d 0
-#ifdef ALLOW_TAPENADE
-       fcb = 1.0
-#endif
-      endif
+      adfc = 0. _d 0
+      IF ( myProcId .EQ. 0 ) adfc = 1. _d 0
 #endif
 
-      do bj = myByLo(myThid), myByHi(myThid)
-       do bi = myBxLo(myThid), myBxHi(myThid)
+      DO bj = myByLo(myThid), myByHi(myThid)
+       DO bi = myBxLo(myThid), myBxHi(myThid)
 #ifdef ALLOW_COST_VECTOR
-         do i=1,sNx
+         DO i=1,sNx
           objf_vector(i,bi,bj) = 0. _d 0
           adobjf_vector(i,bi,bj) = 1. _d 0
-         enddo
+         ENDDO
 #endif
 #ifdef ALLOW_COST_STATE_FINAL
-         do k=1,4*Nr+1
-          do j=1,sNy
-           do i=1,sNx
+         DO k=1,4*Nr+1
+          DO j=1,sNy
+           DO i=1,sNx
             objf_state_final(i,j,bi,bj,k) = 0. _d 0
-           enddo
-          enddo
-         enddo
+           ENDDO
+          ENDDO
+         ENDDO
 cph No init. of cost_state_final here,
 cph because we need it in ADM*TLM
 #endif
-       enddo
-      enddo
+       ENDDO
+      ENDDO
 
 #endif /* ALLOW_AUTODIFF */
 
-      return
-      end
+      RETURN
+      END


### PR DESCRIPTION
## What changes does this PR introduce?
This provides a means of running the Tapenade adjoint with more than one mpi process.

## What is the current behaviour? 
`cost_dependent_init.F` provides the "seed" of the adjoint by setting an adjoint scalar to 1. If mpi is enabled then this "seed" is ensured to be nonzero on only one process (e.g. with TAF, `adfc` is set in this way). A similar setup was not implemented for tapenade, and so the adjoint breaks when run with more than one process.

## What is the new behaviour 
This change ensures that the variable `fcb` (the "primal" tapenade adjoint variable) is only nonzero on process 0.

## Does this PR introduce a breaking change? 
no, there are no parallel tapenade verification tests that I know of

## Other information:
- This particular issue was not highlighted in https://github.com/MITgcm/MITgcm/issues/735, even though it is a vital issue to resolve in the use of Tapenade
- This change was originally a part of PR [927](https://github.com/MITgcm/MITgcm/pull/927) but was split into a separate PR for streamlining

## Suggested addition to `tag-index`
o pkg/streamice
  - modify cost_dependent_init.F to ensure that with a tapenade mpi run, the final adjoint variable fcb is nonzero except on process 0