### PR TITLE
skip report of unused params

### DIFF
--- a/pkg/gchem/gchem_check.F
+++ b/pkg/gchem/gchem_check.F
@@ -41,18 +41,22 @@ C     myThid   :: My Thread Id number
 
 #ifdef ALLOW_GCHEM
 C     !FUNCTIONS:
+#ifdef ALLOW_CAL
       INTEGER  ILNBLNK
       EXTERNAL ILNBLNK
+#endif
 
 C     !LOCAL VARIABLES:
 C     msgBuf   :: Informational/error message buffer
       CHARACTER*(MAX_LEN_MBUF) msgBuf
       INTEGER errCount
       INTEGER nb_tendTr
-      INTEGER IL
-      INTEGER k
       INTEGER ioUnit
+#ifdef ALLOW_CAL
+      INTEGER IL
+#endif
 #ifdef GCHEM_REPORT_UNUSED_PARAMS
+      INTEGER k
       INTEGER gchem_int(5)
       _RL     gchem_rl(5)
       CHARACTER*(MAX_LEN_FNAM) gchem_fileName(5)


### PR DESCRIPTION
## What changes does this PR introduce?
fix so that `pkg/gchem` compiles with pgf77

## What is the current behaviour? 
F90 syntax was added in PR #948 to report some unsued params, and this does not compile with pgf77, see https://github.com/MITgcm/MITgcm/pull/948#discussion_r2676433822

## What is the new behaviour 
disable report of these 15 unused params, unless CPP option GCHEM_REPORT_UNUSED_PARAMS is defined

## Does this PR introduce a breaking change? 
no

## Other information:

## Suggested addition to `tag-index`
to be added later if needed.