### PR TITLE
Fix missing output update from PR 959

### DIFF
--- a/verification/global_ocean.cs32x15/results/output_tap_adj.txt
+++ b/verification/global_ocean.cs32x15/results/output_tap_adj.txt
@@ -5,10 +5,10 @@
 (PID.TID 0000.0001) // ======================================================
 (PID.TID 0000.0001) // execution environment starting up...
 (PID.TID 0000.0001) 
-(PID.TID 0000.0001) // MITgcmUV version:  checkpoint68o
-(PID.TID 0000.0001) // Build user:        jmc
-(PID.TID 0000.0001) // Build host:        jaures.mit.edu
-(PID.TID 0000.0001) // Build date:        Thu May 18 05:19:43 PM EDT 2023
+(PID.TID 0000.0001) // MITgcmUV version:  checkpoint69j
+(PID.TID 0000.0001) // Build user:        jm_c
+(PID.TID 0000.0001) // Build host:        baudelaire.mit.edu
+(PID.TID 0000.0001) // Build date:        Tue Jan 20 11:11:49 AM EST 2026
 (PID.TID 0000.0001) 
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // Execution Environment parameter file "eedata"
@@ -126,8 +126,9 @@
 (PID.TID 0000.0001) ># Elliptic solver parameters
 (PID.TID 0000.0001) > &PARM02
 (PID.TID 0000.0001) > cg2dMaxIters=200,
-(PID.TID 0000.0001) >#cg2dTargetResidual=1.E-9,
-(PID.TID 0000.0001) > cg2dTargetResWunit=1.E-14,
+(PID.TID 0000.0001) > cg2dTargetResidual=1.E-9,
+(PID.TID 0000.0001) >#cg2dTargetResWunit=6.648E-13,
+(PID.TID 0000.0001) > printResidualFreq = 0,
 (PID.TID 0000.0001) > /
 (PID.TID 0000.0001) >
 (PID.TID 0000.0001) ># Time stepping parameters
@@ -143,7 +144,6 @@
 (PID.TID 0000.0001) > momDissip_In_AB=.FALSE.,
 (PID.TID 0000.0001) > pChkptFreq  =311040000.,
 (PID.TID 0000.0001) > chkptFreq   = 31104000.,
-(PID.TID 0000.0001) >#taveFreq    =311040000.,
 (PID.TID 0000.0001) >#dumpFreq    = 31104000.,
 (PID.TID 0000.0001) >#adjDumpFreq = 31104000.,
 (PID.TID 0000.0001) >#monitorFreq = 31104000.,
@@ -427,6 +427,19 @@
 (PID.TID 0000.0001) > /
 (PID.TID 0000.0001) 
 (PID.TID 0000.0001) COST_READPARMS: finished reading data.cost
+(PID.TID 0000.0001) // =======================================================
+(PID.TID 0000.0001) // cost configuration  >>> START <<<
+(PID.TID 0000.0001) // =======================================================
+(PID.TID 0000.0001) lastinterval =   /* cost interval over which to average ( s ). */
+(PID.TID 0000.0001)                 2.592000000000000E+06
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) cost_mask_file = /* file name of cost mask file */
+(PID.TID 0000.0001)               ''
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) // =======================================================
+(PID.TID 0000.0001) // cost configuration  >>> END <<<
+(PID.TID 0000.0001) // =======================================================
+(PID.TID 0000.0001) 
 (PID.TID 0000.0001) GRDCHK_READPARMS: opening data.grdchk
 (PID.TID 0000.0001)  OPEN_COPY_DATA_FILE: opening file data.grdchk
 (PID.TID 0000.0001) // =======================================================
@@ -443,29 +456,10 @@
 (PID.TID 0000.0001) > nbeg             = 1,
 (PID.TID 0000.0001) > nstep            = 1,
 (PID.TID 0000.0001) > nend             = 4,
-(PID.TID 0000.0001) ># this is xx_theta
-(PID.TID 0000.0001) >#grdchkvarindex   = 1,
-(PID.TID 0000.0001) > grdchkvarindex   =201,
+(PID.TID 0000.0001) > grdchkvarname    ="xx_theta",
 (PID.TID 0000.0001) > /
 (PID.TID 0000.0001) 
 (PID.TID 0000.0001) GRDCHK_READPARMS: finished reading data.grdchk
-(PID.TID 0000.0001) 
-(PID.TID 0000.0001) // =======================================================
-(PID.TID 0000.0001) // Gradient check configuration  >>> START <<<
-(PID.TID 0000.0001) // =======================================================
-(PID.TID 0000.0001) 
-(PID.TID 0000.0001)   grdchkvarindex :                        201
-(PID.TID 0000.0001)   eps:                              0.100E-01
-(PID.TID 0000.0001)   First location:                           1
-(PID.TID 0000.0001)   Last location:                            4
-(PID.TID 0000.0001)   Increment:                                1
-(PID.TID 0000.0001)   grdchkWhichProc:                          0
-(PID.TID 0000.0001)   iLocTile =       1  ,    jLocTile =       1
-(PID.TID 0000.0001) 
-(PID.TID 0000.0001) // =======================================================
-(PID.TID 0000.0001) // Gradient check configuration  >>> END <<<
-(PID.TID 0000.0001) // =======================================================
-(PID.TID 0000.0001) 
 (PID.TID 0000.0001)  DIAGNOSTICS_READPARMS: opening data.diagnostics
 (PID.TID 0000.0001)  OPEN_COPY_DATA_FILE: opening file data.diagnostics
 (PID.TID 0000.0001) // =======================================================
@@ -555,7 +549,11 @@
 (PID.TID 0000.0001) S/R DIAGNOSTICS_READPARMS, read namelist "diagnostics_list": OK
 (PID.TID 0000.0001) S/R DIAGNOSTICS_READPARMS, read namelist "DIAG_STATIS_PARMS": start
 (PID.TID 0000.0001) S/R DIAGNOSTICS_READPARMS, read namelist "DIAG_STATIS_PARMS": OK
+(PID.TID 0000.0001) -----------------------------------------------------
 (PID.TID 0000.0001)  DIAGNOSTICS_READPARMS: global parameter summary:
+(PID.TID 0000.0001)  diag_dBugLevel = /* level of printed debug messages */
+(PID.TID 0000.0001)                       1
+(PID.TID 0000.0001)     ;
 (PID.TID 0000.0001)  dumpAtLast = /* always write time-ave diags at the end */
 (PID.TID 0000.0001)                   F
 (PID.TID 0000.0001)     ;
@@ -569,7 +567,7 @@
 (PID.TID 0000.0001)                     200
 (PID.TID 0000.0001)     ;
 (PID.TID 0000.0001)  diagCG_resTarget = /* residual target for diag_cg2d */
-(PID.TID 0000.0001)                 1.000000000000000E-07
+(PID.TID 0000.0001)                 1.000000000000000E-09
 (PID.TID 0000.0001)     ;
 (PID.TID 0000.0001)  diagCG_pcOffDFac = /* preconditioner off-diagonal factor */
 (PID.TID 0000.0001)                 9.611687812379854E-01
@@ -750,434 +748,40 @@
 (PID.TID 0000.0001)                   F
 (PID.TID 0000.0001)     ;
 (PID.TID 0000.0001) // ===================================
+(PID.TID 0000.0001) CTRL_INIT_FIXED: ivar=   8 = number of CTRL variables defined
+(PID.TID 0000.0001) 
 (PID.TID 0000.0001) ctrl-wet 1:    nvarlength =       239366
 (PID.TID 0000.0001) ctrl-wet 2: surface wet C =          389
 (PID.TID 0000.0001) ctrl-wet 3: surface wet W =          367
 (PID.TID 0000.0001) ctrl-wet 4: surface wet S =          384
-(PID.TID 0000.0001) ctrl-wet 4a:surface wet V =            0
 (PID.TID 0000.0001) ctrl-wet 5: 3D wet points =         5204
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =     1           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =     2           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =     3           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =     4           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =     5           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =     6           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =     7           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =     8           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =     9           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =    10           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =    11           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =    12           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =    13           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =    14           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =    15           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =    16           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =    17           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =    18           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =    19           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =    20           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =    21           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =    22           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =    23           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =    24           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =    25           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =    26           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =    27           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =    28           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =    29           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =    30           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =    31           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =    32           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =    33           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =    34           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =    35           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =    36           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =    37           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =    38           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =    39           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =    40           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =    41           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =    42           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =    43           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =    44           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =    45           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =    46           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =    47           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =    48           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =    49           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =    50           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =    51           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =    52           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =    53           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =    54           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =    55           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =    56           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =    57           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =    58           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =    59           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =    60           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =    61           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =    62           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =    63           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =    64           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =    65           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =    66           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =    67           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =    68           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =    69           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =    70           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =    71           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =    72           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =    73           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =    74           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =    75           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =    76           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =    77           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =    78           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =    79           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =    80           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =    81           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =    82           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =    83           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =    84           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =    85           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =    86           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =    87           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =    88           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =    89           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =    90           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =    91           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =    92           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =    93           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =    94           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =    95           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =    96           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =    97           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =    98           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =    99           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   100           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   101           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   102           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   103           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   104           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   105           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   106           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   107           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   108           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   109           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   110           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   111           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   112           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   113           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   114           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   115           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   116           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   117           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   118           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   119           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   120           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   121           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   122           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   123           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   124           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   125           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   126           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   127           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   128           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   129           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   130           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   131           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   132           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   133           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   134           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   135           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   136           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   137           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   138           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   139           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   140           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   141           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   142           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   143           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   144           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   145           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   146           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   147           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   148           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   149           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   150           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   151           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   152           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   153           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   154           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   155           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   156           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   157           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   158           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   159           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   160           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   161           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   162           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   163           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   164           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   165           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   166           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   167           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   168           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   169           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   170           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   171           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   172           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   173           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   174           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   175           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   176           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   177           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   178           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   179           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   180           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   181           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   182           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   183           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   184           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   185           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   186           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   187           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   188           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   189           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   190           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   191           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   192           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   193           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   194           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   195           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   196           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   197           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   198           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   199           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   200           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   201           1
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   202           1
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   203           1
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   204           1
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   205           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   206           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   207           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   208           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   209           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   210           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   211           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   212           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   213           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   214           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   215           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   216           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   217           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   218           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   219           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   220           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   221           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   222           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   223           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   224           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   225           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   226           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   227           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   228           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   229           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   230           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   231           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   232           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   233           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   234           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   235           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   236           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   237           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   238           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   239           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   240           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   241           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   242           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   243           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   244           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   245           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   246           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   247           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   248           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   249           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   250           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   251           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   252           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   253           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   254           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   255           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   256           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   257           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   258           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   259           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   260           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   261           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   262           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   263           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   264           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   265           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   266           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   267           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   268           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   269           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   270           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   271           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   272           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   273           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   274           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   275           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   276           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   277           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   278           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   279           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   280           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   281           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   282           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   283           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   284           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   285           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   286           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   287           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   288           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   289           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   290           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   291           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   292           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   293           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   294           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   295           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   296           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   297           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   298           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   299           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   300           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   301           1
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   302           1
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   303           1
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   304           1
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   305           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   306           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   307           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   308           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   309           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   310           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   311           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   312           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   313           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   314           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   315           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   316           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   317           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   318           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   319           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   320           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   321           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   322           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   323           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   324           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   325           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   326           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   327           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   328           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   329           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   330           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   331           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   332           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   333           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   334           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   335           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   336           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   337           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   338           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   339           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   340           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   341           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   342           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   343           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   344           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   345           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   346           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   347           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   348           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   349           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   350           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   351           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   352           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   353           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   354           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   355           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   356           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   357           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   358           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   359           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   360           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   361           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   362           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   363           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   364           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   365           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   366           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   367           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   368           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   369           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   370           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   371           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   372           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   373           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   374           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   375           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   376           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   377           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   378           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   379           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   380           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   381           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   382           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   383           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   384           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   385           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   386           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   387           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   388           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   389           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   390           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   391           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   392           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   393           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   394           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   395           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   396           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   397           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   398           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   399           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   400           0
-(PID.TID 0000.0001) ctrl-wet 7: flux         10408
-(PID.TID 0000.0001) ctrl-wet 8: atmos        10408
+(PID.TID 0000.0001) ctrl-wet 6: no recs for ivar =     1           1
+(PID.TID 0000.0001) ctrl-wet 6: no recs for ivar =     2           1
+(PID.TID 0000.0001) ctrl-wet 6: no recs for ivar =     3           1
+(PID.TID 0000.0001) ctrl-wet 6: no recs for ivar =     4           1
+(PID.TID 0000.0001) ctrl-wet 6: no recs for ivar =     5           1
+(PID.TID 0000.0001) ctrl-wet 6: no recs for ivar =     6           1
+(PID.TID 0000.0001) ctrl-wet 6: no recs for ivar =     7           1
+(PID.TID 0000.0001) ctrl-wet 6: no recs for ivar =     8           1
+(PID.TID 0000.0001) ctrl-wet 6: no recs for ivar =     9           0
 (PID.TID 0000.0001) ctrl-wet -------------------------------------------------
 (PID.TID 0000.0001) ctrl-wet 13: global nvarlength for Nr =   15      239366
 (PID.TID 0000.0001) ctrl-wet -------------------------------------------------
-(PID.TID 0000.0001) ctrl-wet 14: global nWet C/S/W/V k=    1        4420        4232        4206           0
-(PID.TID 0000.0001) ctrl-wet 14: global nWet C/S/W/V k=    2        4299        4112        4096           0
-(PID.TID 0000.0001) ctrl-wet 14: global nWet C/S/W/V k=    3        4222        4038        4023           0
-(PID.TID 0000.0001) ctrl-wet 14: global nWet C/S/W/V k=    4        4140        3960        3939           0
-(PID.TID 0000.0001) ctrl-wet 14: global nWet C/S/W/V k=    5        4099        3919        3893           0
-(PID.TID 0000.0001) ctrl-wet 14: global nWet C/S/W/V k=    6        4038        3856        3839           0
-(PID.TID 0000.0001) ctrl-wet 14: global nWet C/S/W/V k=    7        3995        3814        3795           0
-(PID.TID 0000.0001) ctrl-wet 14: global nWet C/S/W/V k=    8        3944        3756        3737           0
-(PID.TID 0000.0001) ctrl-wet 14: global nWet C/S/W/V k=    9        3887        3699        3673           0
-(PID.TID 0000.0001) ctrl-wet 14: global nWet C/S/W/V k=   10        3799        3605        3585           0
-(PID.TID 0000.0001) ctrl-wet 14: global nWet C/S/W/V k=   11        3703        3502        3461           0
-(PID.TID 0000.0001) ctrl-wet 14: global nWet C/S/W/V k=   12        3554        3338        3303           0
-(PID.TID 0000.0001) ctrl-wet 14: global nWet C/S/W/V k=   13        3202        2910        2911           0
-(PID.TID 0000.0001) ctrl-wet 14: global nWet C/S/W/V k=   14        2599        2296        2276           0
-(PID.TID 0000.0001) ctrl-wet 14: global nWet C/S/W/V k=   15        1621        1368        1334           0
-(PID.TID 0000.0001) ctrl-wet -------------------------------------------------
-(PID.TID 0000.0001) ctrl-wet -------------------------------------------------
+(PID.TID 0000.0001) ctrl-wet 14: global nWet C/S/W k=    1        4420        4232        4206
+(PID.TID 0000.0001) ctrl-wet 14: global nWet C/S/W k=    2        4299        4112        4096
+(PID.TID 0000.0001) ctrl-wet 14: global nWet C/S/W k=    3        4222        4038        4023
+(PID.TID 0000.0001) ctrl-wet 14: global nWet C/S/W k=    4        4140        3960        3939
+(PID.TID 0000.0001) ctrl-wet 14: global nWet C/S/W k=    5        4099        3919        3893
+(PID.TID 0000.0001) ctrl-wet 14: global nWet C/S/W k=    6        4038        3856        3839
+(PID.TID 0000.0001) ctrl-wet 14: global nWet C/S/W k=    7        3995        3814        3795
+(PID.TID 0000.0001) ctrl-wet 14: global nWet C/S/W k=    8        3944        3756        3737
+(PID.TID 0000.0001) ctrl-wet 14: global nWet C/S/W k=    9        3887        3699        3673
+(PID.TID 0000.0001) ctrl-wet 14: global nWet C/S/W k=   10        3799        3605        3585
+(PID.TID 0000.0001) ctrl-wet 14: global nWet C/S/W k=   11        3703        3502        3461
+(PID.TID 0000.0001) ctrl-wet 14: global nWet C/S/W k=   12        3554        3338        3303
+(PID.TID 0000.0001) ctrl-wet 14: global nWet C/S/W k=   13        3202        2910        2911
+(PID.TID 0000.0001) ctrl-wet 14: global nWet C/S/W k=   14        2599        2296        2276
+(PID.TID 0000.0001) ctrl-wet 14: global nWet C/S/W k=   15        1621        1368        1334
 (PID.TID 0000.0001) ctrl-wet -------------------------------------------------
 (PID.TID 0000.0001) ctrl_init_wet: no. of control variables:            8
 (PID.TID 0000.0001) ctrl_init_wet: control vector length:          239366
@@ -1188,66 +792,78 @@
 (PID.TID 0000.0001) 
 (PID.TID 0000.0001)  Total number of ocean points per tile:
 (PID.TID 0000.0001)  --------------------------------------
-(PID.TID 0000.0001)  snx*sny*nr =     7680
+(PID.TID 0000.0001)  sNx*sNy*Nr =     7680
 (PID.TID 0000.0001) 
 (PID.TID 0000.0001)  Number of ocean points per tile:
 (PID.TID 0000.0001)  --------------------------------
-(PID.TID 0000.0001)  bi,bj,#(c/s/w): 0001 0001 005204 005084 004791
-(PID.TID 0000.0001)  bi,bj,#(c/s/w): 0002 0001 003115 002837 002945
-(PID.TID 0000.0001)  bi,bj,#(c/s/w): 0003 0001 005620 005386 005384
-(PID.TID 0000.0001)  bi,bj,#(c/s/w): 0004 0001 002470 002283 001983
-(PID.TID 0000.0001)  bi,bj,#(c/s/w): 0005 0001 001306 000952 000953
-(PID.TID 0000.0001)  bi,bj,#(c/s/w): 0006 0001 003476 003122 003082
-(PID.TID 0000.0001)  bi,bj,#(c/s/w): 0007 0001 005619 005222 005403
-(PID.TID 0000.0001)  bi,bj,#(c/s/w): 0008 0001 007482 007397 007429
-(PID.TID 0000.0001)  bi,bj,#(c/s/w): 0009 0001 005900 005825 005686
-(PID.TID 0000.0001)  bi,bj,#(c/s/w): 0010 0001 003678 003307 003317
-(PID.TID 0000.0001)  bi,bj,#(c/s/w): 0011 0001 006008 005782 005796
-(PID.TID 0000.0001)  bi,bj,#(c/s/w): 0012 0001 005644 005208 005302
-(PID.TID 0000.0001) 
-(PID.TID 0000.0001)  Settings of generic controls:
-(PID.TID 0000.0001)  -----------------------------
+(PID.TID 0000.0001)  bi,bj,#(c/s/w): 001 001    5204    5084    4791
+(PID.TID 0000.0001)  bi,bj,#(c/s/w): 002 001    3115    2837    2945
+(PID.TID 0000.0001)  bi,bj,#(c/s/w): 003 001    5620    5386    5384
+(PID.TID 0000.0001)  bi,bj,#(c/s/w): 004 001    2470    2283    1983
+(PID.TID 0000.0001)  bi,bj,#(c/s/w): 005 001    1306     952     953
+(PID.TID 0000.0001)  bi,bj,#(c/s/w): 006 001    3476    3122    3082
+(PID.TID 0000.0001)  bi,bj,#(c/s/w): 007 001    5619    5222    5403
+(PID.TID 0000.0001)  bi,bj,#(c/s/w): 008 001    7482    7397    7429
+(PID.TID 0000.0001)  bi,bj,#(c/s/w): 009 001    5900    5825    5686
+(PID.TID 0000.0001)  bi,bj,#(c/s/w): 010 001    3678    3307    3317
+(PID.TID 0000.0001)  bi,bj,#(c/s/w): 011 001    6008    5782    5796
+(PID.TID 0000.0001)  bi,bj,#(c/s/w): 012 001    5644    5208    5302
 (PID.TID 0000.0001) 
 (PID.TID 0000.0001)  -> 3d control, genarr3d no.  1 is in use
 (PID.TID 0000.0001)       file       = xx_theta
+(PID.TID 0000.0001)       ncvartype  = Arr3D
+(PID.TID 0000.0001)       index      =     1  (use this for pkg/grdchk)
+(PID.TID 0000.0001)       ncvarindex =     1
 (PID.TID 0000.0001)       weight     = ones_64b.bin
-(PID.TID 0000.0001)       index      =  0201
-(PID.TID 0000.0001)       ncvarindex =  0301
+(PID.TID 0000.0001) 
 (PID.TID 0000.0001)  -> 3d control, genarr3d no.  2 is in use
 (PID.TID 0000.0001)       file       = xx_salt
+(PID.TID 0000.0001)       ncvartype  = Arr3D
+(PID.TID 0000.0001)       index      =     2  (use this for pkg/grdchk)
+(PID.TID 0000.0001)       ncvarindex =     2
 (PID.TID 0000.0001)       weight     = ones_64b.bin
-(PID.TID 0000.0001)       index      =  0202
-(PID.TID 0000.0001)       ncvarindex =  0302
+(PID.TID 0000.0001) 
 (PID.TID 0000.0001)  -> 3d control, genarr3d no.  3 is in use
 (PID.TID 0000.0001)       file       = xx_ptr1
+(PID.TID 0000.0001)       ncvartype  = Arr3D
+(PID.TID 0000.0001)       index      =     3  (use this for pkg/grdchk)
+(PID.TID 0000.0001)       ncvarindex =     3
 (PID.TID 0000.0001)       weight     = ones_64b.bin
-(PID.TID 0000.0001)       index      =  0203
-(PID.TID 0000.0001)       ncvarindex =  0303
+(PID.TID 0000.0001) 
 (PID.TID 0000.0001)  -> 3d control, genarr3d no.  4 is in use
 (PID.TID 0000.0001)       file       = xx_diffkr
+(PID.TID 0000.0001)       ncvartype  = Arr3D
+(PID.TID 0000.0001)       index      =     4  (use this for pkg/grdchk)
+(PID.TID 0000.0001)       ncvarindex =     4
 (PID.TID 0000.0001)       weight     = ones_64b.bin
-(PID.TID 0000.0001)       index      =  0204
-(PID.TID 0000.0001)       ncvarindex =  0304
-(PID.TID 0000.0001)  -> time variable 2D control, gentim2d no.  1 is in use
+(PID.TID 0000.0001) 
+(PID.TID 0000.0001)  -> time variable 2d control, gentim2d no.  1 is in use
 (PID.TID 0000.0001)       file       = xx_qnet
+(PID.TID 0000.0001)       ncvartype  = Tim2D
+(PID.TID 0000.0001)       index      =     5  (use this for pkg/grdchk)
+(PID.TID 0000.0001)       ncvarindex =     1
 (PID.TID 0000.0001)       weight     = ones_64b.bin
-(PID.TID 0000.0001)       index      =  0301
-(PID.TID 0000.0001)       ncvarindex =  0401
-(PID.TID 0000.0001)  -> time variable 2D control, gentim2d no.  2 is in use
+(PID.TID 0000.0001) 
+(PID.TID 0000.0001)  -> time variable 2d control, gentim2d no.  2 is in use
 (PID.TID 0000.0001)       file       = xx_empmr
+(PID.TID 0000.0001)       ncvartype  = Tim2D
+(PID.TID 0000.0001)       index      =     6  (use this for pkg/grdchk)
+(PID.TID 0000.0001)       ncvarindex =     2
 (PID.TID 0000.0001)       weight     = ones_64b.bin
-(PID.TID 0000.0001)       index      =  0302
-(PID.TID 0000.0001)       ncvarindex =  0402
-(PID.TID 0000.0001)  -> time variable 2D control, gentim2d no.  3 is in use
+(PID.TID 0000.0001) 
+(PID.TID 0000.0001)  -> time variable 2d control, gentim2d no.  3 is in use
 (PID.TID 0000.0001)       file       = xx_fu
+(PID.TID 0000.0001)       ncvartype  = Tim2D
+(PID.TID 0000.0001)       index      =     7  (use this for pkg/grdchk)
+(PID.TID 0000.0001)       ncvarindex =     3
 (PID.TID 0000.0001)       weight     = ones_64b.bin
-(PID.TID 0000.0001)       index      =  0303
-(PID.TID 0000.0001)       ncvarindex =  0403
-(PID.TID 0000.0001)  -> time variable 2D control, gentim2d no.  4 is in use
+(PID.TID 0000.0001) 
+(PID.TID 0000.0001)  -> time variable 2d control, gentim2d no.  4 is in use
 (PID.TID 0000.0001)       file       = xx_fv
+(PID.TID 0000.0001)       ncvartype  = Tim2D
+(PID.TID 0000.0001)       index      =     8  (use this for pkg/grdchk)
+(PID.TID 0000.0001)       ncvarindex =     4
 (PID.TID 0000.0001)       weight     = ones_64b.bin
-(PID.TID 0000.0001)       index      =  0304
-(PID.TID 0000.0001)       ncvarindex =  0404
 (PID.TID 0000.0001) 
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // control vector configuration  >>> END <<<
@@ -1255,57 +871,57 @@
 (PID.TID 0000.0001) 
 (PID.TID 0000.0001) ------------------------------------------------------------
 (PID.TID 0000.0001) DIAGNOSTICS_SET_LEVELS: done
-(PID.TID 0000.0001)  Total Nb of available Diagnostics: ndiagt=   218
+(PID.TID 0000.0001)  Total Nb of available Diagnostics: ndiagt=   225
 (PID.TID 0000.0001)  write list of available Diagnostics to file: available_diagnostics.log
 (PID.TID 0000.0001) SETDIAG: Allocate  1 x  1 Levels for Diagnostic #    23 ETAN
 (PID.TID 0000.0001) SETDIAG: Allocate  1 x  1 Levels for Diagnostic #    24 ETANSQ
 (PID.TID 0000.0001) SETDIAG: Allocate  1 x  1 Levels for Diagnostic #    25 DETADT2
-(PID.TID 0000.0001) SETDIAG: Allocate  1 x  1 Levels for Diagnostic #    73 PHIBOT
-(PID.TID 0000.0001) SETDIAG: Allocate  1 x  1 Levels for Diagnostic #    74 PHIBOTSQ
-(PID.TID 0000.0001) SETDIAG: Allocate  1 x  1 Levels for Diagnostic #    80 oceTAUX
-(PID.TID 0000.0001) SETDIAG: Allocate  1 x  1 Levels for Diagnostic #    81 oceTAUY
-(PID.TID 0000.0001) SETDIAG: Allocate  1 x  1 Levels for Diagnostic #    93 TFLUX
-(PID.TID 0000.0001) SETDIAG: Allocate  1 x  1 Levels for Diagnostic #    94 SFLUX
-(PID.TID 0000.0001) SETDIAG: Allocate  1 x  1 Levels for Diagnostic #    88 oceFreez
-(PID.TID 0000.0001) SETDIAG: Allocate  1 x  1 Levels for Diagnostic #    89 TRELAX
-(PID.TID 0000.0001) SETDIAG: Allocate  1 x  1 Levels for Diagnostic #    90 SRELAX
+(PID.TID 0000.0001) SETDIAG: Allocate  1 x  1 Levels for Diagnostic #    74 PHIBOT
+(PID.TID 0000.0001) SETDIAG: Allocate  1 x  1 Levels for Diagnostic #    75 PHIBOTSQ
+(PID.TID 0000.0001) SETDIAG: Allocate  1 x  1 Levels for Diagnostic #    82 oceTAUX
+(PID.TID 0000.0001) SETDIAG: Allocate  1 x  1 Levels for Diagnostic #    83 oceTAUY
+(PID.TID 0000.0001) SETDIAG: Allocate  1 x  1 Levels for Diagnostic #    95 TFLUX
+(PID.TID 0000.0001) SETDIAG: Allocate  1 x  1 Levels for Diagnostic #    96 SFLUX
+(PID.TID 0000.0001) SETDIAG: Allocate  1 x  1 Levels for Diagnostic #    90 oceFreez
+(PID.TID 0000.0001) SETDIAG: Allocate  1 x  1 Levels for Diagnostic #    91 TRELAX
+(PID.TID 0000.0001) SETDIAG: Allocate  1 x  1 Levels for Diagnostic #    92 SRELAX
 (PID.TID 0000.0001) SETDIAG: Allocate 15 x  1 Levels for Diagnostic #    30 UVEL
 (PID.TID 0000.0001) SETDIAG: Allocate 15 x  1 Levels for Diagnostic #    31 VVEL
 (PID.TID 0000.0001) SETDIAG: Allocate 15 x  1 Levels for Diagnostic #    32 WVEL
-(PID.TID 0000.0001) SETDIAG: Allocate 15 x  1 Levels for Diagnostic #    71 PHIHYD
-(PID.TID 0000.0001) SETDIAG: Allocate 15 x  1 Levels for Diagnostic #    46 VVELMASS
-(PID.TID 0000.0001) SETDIAG: Allocate 15 x  1 Levels for Diagnostic #    45 UVELMASS
+(PID.TID 0000.0001) SETDIAG: Allocate 15 x  1 Levels for Diagnostic #    72 PHIHYD
+(PID.TID 0000.0001) SETDIAG: Allocate 15 x  1 Levels for Diagnostic #    47 VVELMASS
+(PID.TID 0000.0001) SETDIAG: Allocate 15 x  1 Levels for Diagnostic #    46 UVELMASS
 (PID.TID 0000.0001) SETDIAG: Allocate 15 x  1 Levels for Diagnostic #    38 WVELSQ
 (PID.TID 0000.0001) SETDIAG: Allocate 15 x  1 Levels for Diagnostic #    26 THETA
 (PID.TID 0000.0001) SETDIAG: Allocate 15 x  1 Levels for Diagnostic #    27 SALT
-(PID.TID 0000.0001) SETDIAG: Allocate 15 x  1 Levels for Diagnostic #   114 ADJuvel
-(PID.TID 0000.0001) SETDIAG: Allocate 15 x  1 Levels for Diagnostic #   115 ADJvvel
-(PID.TID 0000.0001) SETDIAG: Allocate 15 x  1 Levels for Diagnostic #   116 ADJwvel
-(PID.TID 0000.0001) SETDIAG: Allocate 15 x  1 Levels for Diagnostic #   117 ADJtheta
-(PID.TID 0000.0001) SETDIAG: Allocate 15 x  1 Levels for Diagnostic #   118 ADJsalt
-(PID.TID 0000.0001) SETDIAG: Allocate  1 x  1 Levels for Diagnostic #   113 ADJetan
-(PID.TID 0000.0001) SETDIAG: Allocate  1 x  1 Levels for Diagnostic #   122 ADJqnet
-(PID.TID 0000.0001) SETDIAG: Allocate  1 x  1 Levels for Diagnostic #   121 ADJempmr
-(PID.TID 0000.0001) SETDIAG: Allocate  1 x  1 Levels for Diagnostic #   119 ADJtaux
-(PID.TID 0000.0001) SETDIAG: Allocate  1 x  1 Levels for Diagnostic #   120 ADJtauy
+(PID.TID 0000.0001) SETDIAG: Allocate 15 x  1 Levels for Diagnostic #   116 ADJuvel
+(PID.TID 0000.0001) SETDIAG: Allocate 15 x  1 Levels for Diagnostic #   117 ADJvvel
+(PID.TID 0000.0001) SETDIAG: Allocate 15 x  1 Levels for Diagnostic #   118 ADJwvel
+(PID.TID 0000.0001) SETDIAG: Allocate 15 x  1 Levels for Diagnostic #   119 ADJtheta
+(PID.TID 0000.0001) SETDIAG: Allocate 15 x  1 Levels for Diagnostic #   120 ADJsalt
+(PID.TID 0000.0001) SETDIAG: Allocate  1 x  1 Levels for Diagnostic #   115 ADJetan
+(PID.TID 0000.0001) SETDIAG: Allocate  1 x  1 Levels for Diagnostic #   124 ADJqnet
+(PID.TID 0000.0001) SETDIAG: Allocate  1 x  1 Levels for Diagnostic #   123 ADJempmr
+(PID.TID 0000.0001) SETDIAG: Allocate  1 x  1 Levels for Diagnostic #   121 ADJtaux
+(PID.TID 0000.0001) SETDIAG: Allocate  1 x  1 Levels for Diagnostic #   122 ADJtauy
 (PID.TID 0000.0001)   space allocated for all diagnostics:     227 levels
-(PID.TID 0000.0001)   set mate pointer for diag #    80  oceTAUX  , Parms: UU      U1 , mate:    81
-(PID.TID 0000.0001)   set mate pointer for diag #    81  oceTAUY  , Parms: VV      U1 , mate:    80
+(PID.TID 0000.0001)   set mate pointer for diag #    82  oceTAUX  , Parms: UU      U1 , mate:    83
+(PID.TID 0000.0001)   set mate pointer for diag #    83  oceTAUY  , Parms: VV      U1 , mate:    82
 (PID.TID 0000.0001)   set mate pointer for diag #    30  UVEL     , Parms: UUR     MR , mate:    31
 (PID.TID 0000.0001)   set mate pointer for diag #    31  VVEL     , Parms: VVR     MR , mate:    30
-(PID.TID 0000.0001)   set mate pointer for diag #    46  VVELMASS , Parms: VVr     MR , mate:    45
-(PID.TID 0000.0001)   set mate pointer for diag #    45  UVELMASS , Parms: UUr     MR , mate:    46
-(PID.TID 0000.0001)   set mate pointer for diag #   114  ADJuvel  , Parms: UURA    MR , mate:   115
-(PID.TID 0000.0001)   set mate pointer for diag #   115  ADJvvel  , Parms: VVRA    MR , mate:   114
-(PID.TID 0000.0001)   set mate pointer for diag #   119  ADJtaux  , Parms: UU A    U1 , mate:   120
-(PID.TID 0000.0001)   set mate pointer for diag #   120  ADJtauy  , Parms: VV A    U1 , mate:   119
+(PID.TID 0000.0001)   set mate pointer for diag #    47  VVELMASS , Parms: VVr     MR , mate:    46
+(PID.TID 0000.0001)   set mate pointer for diag #    46  UVELMASS , Parms: UUr     MR , mate:    47
+(PID.TID 0000.0001)   set mate pointer for diag #   116  ADJuvel  , Parms: UURA    MR , mate:   117
+(PID.TID 0000.0001)   set mate pointer for diag #   117  ADJvvel  , Parms: VVRA    MR , mate:   116
+(PID.TID 0000.0001)   set mate pointer for diag #   121  ADJtaux  , Parms: UU A    U1 , mate:   122
+(PID.TID 0000.0001)   set mate pointer for diag #   122  ADJtauy  , Parms: VV A    U1 , mate:   121
 (PID.TID 0000.0001) DIAGNOSTICS_SET_POINTERS: Set levels for Outp.Stream: dynDiag
 (PID.TID 0000.0001)  Levels:       1.   2.   3.   4.   5.   6.   7.   8.   9.  10.  11.  12.  13.  14.  15.
 (PID.TID 0000.0001) DIAGNOSTICS_SET_POINTERS: Set levels for Outp.Stream: adjDiag
 (PID.TID 0000.0001)  Levels:       1.   2.   3.   4.   5.   6.   7.   8.   9.  10.  11.  12.  13.  14.  15.
 (PID.TID 0000.0001) DIAGNOSTICS_SET_POINTERS: Set levels for Outp.Stream: adjDiagSurf
 (PID.TID 0000.0001)  Levels:       1.
-(PID.TID 0000.0001) DIAGNOSTICS_SET_POINTERS: done
+(PID.TID 0000.0001) DIAGNOSTICS_SET_POINTERS: done, use     227 levels (numDiags =     600 )
 (PID.TID 0000.0001) ------------------------------------------------------------
 (PID.TID 0000.0001) DIAGSTATS_SET_REGIONS: define   0 regions:
 (PID.TID 0000.0001) ------------------------------------------------------------
@@ -1315,9 +931,8 @@
 (PID.TID 0000.0001) SETDIAG: Allocate 15 Levels for Stats-Diag #    32 WVEL
 (PID.TID 0000.0001) SETDIAG: Allocate 15 Levels for Stats-Diag #    26 THETA
 (PID.TID 0000.0001)   space allocated for all stats-diags:      61 levels
-(PID.TID 0000.0001) DIAGSTATS_SET_POINTERS: done
+(PID.TID 0000.0001) DIAGSTATS_SET_POINTERS: done, use      61 levels (diagSt_size=     150 )
 (PID.TID 0000.0001) ------------------------------------------------------------
-(PID.TID 0000.0001) DIAGSTATS_INI_IO: open file: dynStDiag.0000072000.txt , unit=     9
 (PID.TID 0000.0001) INI_GLOBAL_DOMAIN: Found  19 CS-corner Pts in the domain
 (PID.TID 0000.0001) %MON fCori_max                    =   1.4574827780704E-04
 (PID.TID 0000.0001) %MON fCori_min                    =  -1.4574827780704E-04
@@ -1332,7 +947,6 @@
 (PID.TID 0000.0001) %MON fCoriCos_mean                =   1.1514045869113E-04
 (PID.TID 0000.0001) %MON fCoriCos_sd                  =   3.0375849106513E-05
 (PID.TID 0000.0001) INI_CG2D: CG2D normalisation factor =  1.9156564154949553E-04
-(PID.TID 0000.0001) INI_CG2D: cg2dTolerance = 5.809016360175296E-07 (Area=3.6388673751E+14)
 (PID.TID 0000.0001) 
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // Model configuration
@@ -1556,7 +1170,7 @@
 (PID.TID 0000.0001) hFacMinDr = /* minimum partial cell thickness ( m) */
 (PID.TID 0000.0001)                 2.000000000000000E+01
 (PID.TID 0000.0001)     ;
-(PID.TID 0000.0001) exactConserv =  /* Exact Volume Conservation on/off flag */
+(PID.TID 0000.0001) exactConserv = /* Update etaN from continuity Eq on/off flag */
 (PID.TID 0000.0001)                   T
 (PID.TID 0000.0001)     ;
 (PID.TID 0000.0001) linFSConserveTr = /* Tracer correction for Lin Free Surface on/off flag */
@@ -1636,17 +1250,7 @@
 (PID.TID 0000.0001)                       0
 (PID.TID 0000.0001)     0= Expl. ; 1= Impl. on provis. Vel ; 2= Fully Impl (with surf.P)
 (PID.TID 0000.0001)     ;
-(PID.TID 0000.0001) metricTerms =  /* metric-Terms on/off flag */
-(PID.TID 0000.0001)                   F
-(PID.TID 0000.0001)     ;
 (PID.TID 0000.0001) useNHMTerms = /* Non-Hydrostatic Metric-Terms on/off */
-(PID.TID 0000.0001)                   F
-(PID.TID 0000.0001)     ;
-(PID.TID 0000.0001) selectCoriMap = /* Coriolis Map options (0,1,2,3)*/
-(PID.TID 0000.0001)                       2
-(PID.TID 0000.0001)     0= f-Plane ; 1= Beta-Plane ; 2= Spherical ; 3= read from file
-(PID.TID 0000.0001)     ;
-(PID.TID 0000.0001) use3dCoriolis = /* 3-D Coriolis on/off flag */
 (PID.TID 0000.0001)                   F
 (PID.TID 0000.0001)     ;
 (PID.TID 0000.0001) useCoriolis =  /* Coriolis on/off flag */
@@ -1654,6 +1258,16 @@
 (PID.TID 0000.0001)     ;
 (PID.TID 0000.0001) useCDscheme =  /* CD scheme on/off flag */
 (PID.TID 0000.0001)                   F
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) selectCoriMap = /* Coriolis Map options (0,1,2,3)*/
+(PID.TID 0000.0001)                       2
+(PID.TID 0000.0001)     0= f-Plane ; 1= Beta-Plane ; 2= Spherical ; 3= read from file
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) select3dCoriScheme= /* Scheme selector for 3-D Coriolis-Term */
+(PID.TID 0000.0001)                       0
+(PID.TID 0000.0001)    = 0 : Off (ignore 3-D Coriolis Terms in Omega.Cos(Lat) )
+(PID.TID 0000.0001)    = 1 : original discretization ; = 2 : using averaged Transport
+(PID.TID 0000.0001)    = 3 : same as 2 with hFac in gW_Cor
 (PID.TID 0000.0001)     ;
 (PID.TID 0000.0001) selectCoriScheme= /* Scheme selector for Coriolis-Term */
 (PID.TID 0000.0001)                       0
@@ -1672,6 +1286,7 @@
 (PID.TID 0000.0001)    = 2 : energy conserving scheme (used by Sadourny in JAS 75 paper)
 (PID.TID 0000.0001)    = 3 : energy (general) and enstrophy (2D, nonDiv.) conserving scheme
 (PID.TID 0000.0001)          from Sadourny (Burridge & Haseler, ECMWF Rep.4, 1977)
+(PID.TID 0000.0001)    = 4 : shift 1/hFac from Vorticity to gU,gV tend. (Ang.Mom. conserving)
 (PID.TID 0000.0001)     ;
 (PID.TID 0000.0001) useJamartMomAdv= /* V.I Non-linear terms Jamart flag */
 (PID.TID 0000.0001)                   F
@@ -1726,6 +1341,9 @@
 (PID.TID 0000.0001)     ;
 (PID.TID 0000.0001) tempForcing  =  /* Temperature forcing on/off flag */
 (PID.TID 0000.0001)                   T
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) selectPenetratingSW = /* short wave penetration selector */
+(PID.TID 0000.0001)                       1
 (PID.TID 0000.0001)     ;
 (PID.TID 0000.0001) balanceQnet  =  /* balance net heat-flux on/off flag */
 (PID.TID 0000.0001)                   F
@@ -1813,10 +1431,10 @@
 (PID.TID 0000.0001)                       0
 (PID.TID 0000.0001)     ;
 (PID.TID 0000.0001) cg2dTargetResidual =   /* 2d con. grad target residual  */
-(PID.TID 0000.0001)                 1.000000000000000E-07
+(PID.TID 0000.0001)                 1.000000000000000E-09
 (PID.TID 0000.0001)     ;
 (PID.TID 0000.0001) cg2dTargetResWunit =   /* CG2d target residual [W units] */
-(PID.TID 0000.0001)                 1.000000000000000E-14
+(PID.TID 0000.0001)                -1.000000000000000E+00
 (PID.TID 0000.0001)     ;
 (PID.TID 0000.0001) cg2dPreCondFreq =   /* Freq. for updating cg2d preconditioner */
 (PID.TID 0000.0001)                       1
@@ -2671,6 +2289,15 @@
 (PID.TID 0000.0001) globalArea = /* Integrated horizontal Area (m^2) */
 (PID.TID 0000.0001)                 3.638867375081599E+14
 (PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) rAc_3dMean = /* 3-D Averaged grid-cell Area (m^2) */
+(PID.TID 0000.0001)                 8.193292328209888E+10
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) n2dWetPts = /* Number of wet surface points (-) */
+(PID.TID 0000.0001)                 4.420000000000000E+03
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) n3dWetPts = /* Number of wet grid points (-) */
+(PID.TID 0000.0001)                 5.552200000000000E+04
+(PID.TID 0000.0001)     ;
 (PID.TID 0000.0001) hasWetCSCorners = /* Domain contains CS corners (True/False) */
 (PID.TID 0000.0001)                   T
 (PID.TID 0000.0001)     ;
@@ -2696,11 +2323,14 @@
 (PID.TID 0000.0001) GM_isopycK =    /* Background Isopyc. Diffusivity [m^2/s] */
 (PID.TID 0000.0001)                 1.000000000000000E+03
 (PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) GM_advec*K =    /* Backg. GM-Advec(=Bolus) Diffusivity [m^2/s] */
+(PID.TID 0000.0001)                 0.000000000000000E+00
+(PID.TID 0000.0001)     ;
 (PID.TID 0000.0001) GM_skewflx*K =  /* Background GM_SkewFlx Diffusivity [m^2/s] */
 (PID.TID 0000.0001)                 1.000000000000000E+03
 (PID.TID 0000.0001)     ;
-(PID.TID 0000.0001) GM_advec*K =    /* Backg. GM-Advec(=Bolus) Diffusivity [m^2/s]*/
-(PID.TID 0000.0001)                 0.000000000000000E+00
+(PID.TID 0000.0001) GM_isoFac_calcK = /* Fraction of dynamic K added to Redi tensor */
+(PID.TID 0000.0001)                 1.000000000000000E+00
 (PID.TID 0000.0001)     ;
 (PID.TID 0000.0001) GM_Kmin_horiz = /* Minimum Horizontal Diffusivity [m^2/s] */
 (PID.TID 0000.0001)                 5.000000000000000E+01
@@ -2756,11 +2386,32 @@
 (PID.TID 0000.0001) GM_useLeithQG = /* if TRUE => add QG Leith viscosity to GMRedi tensor */
 (PID.TID 0000.0001)                   F
 (PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) GM_useGEOM = /* using GEOMETRIC */
+(PID.TID 0000.0001)                   F
+(PID.TID 0000.0001)     ;
 (PID.TID 0000.0001) CTRL_CHECK:  --> Starts to check CTRL set-up
 (PID.TID 0000.0001) CTRL_CHECK:  <-- Ends Normally
 (PID.TID 0000.0001) 
 (PID.TID 0000.0001) COST_CHECK: #define ALLOW_COST
 (PID.TID 0000.0001) GRDCHK_CHECK: grdchk package
+(PID.TID 0000.0001) 
+(PID.TID 0000.0001) // =======================================================
+(PID.TID 0000.0001) // Gradient check configuration  >>> START <<<
+(PID.TID 0000.0001) // =======================================================
+(PID.TID 0000.0001) 
+(PID.TID 0000.0001)   grdchkvarindex :                      1
+(PID.TID 0000.0001)   matching CTRL xx_file:       "xx_theta"
+(PID.TID 0000.0001)   eps =                         1.000E-02
+(PID.TID 0000.0001)   First location:                       1
+(PID.TID 0000.0001)   Last location:                        4
+(PID.TID 0000.0001)   Increment:                            1
+(PID.TID 0000.0001)   grdchkWhichProc:                      0
+(PID.TID 0000.0001)   iLocTile =      1 ,   jLocTile =      1
+(PID.TID 0000.0001) 
+(PID.TID 0000.0001) // =======================================================
+(PID.TID 0000.0001) // Gradient check configuration  >>> END <<<
+(PID.TID 0000.0001) // =======================================================
+(PID.TID 0000.0001) 
 (PID.TID 0000.0001) GAD_CHECK: #define ALLOW_GENERIC_ADVDIFF
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // Check Model config. (CONFIG_CHECK):
@@ -2785,6 +2436,7 @@
 (PID.TID 0000.0001) READ_MFLDS_3D_RL: read field: "EtaN    ", #   9 in fldList, rec= 121
 (PID.TID 0000.0001) READ_MFLDS_3D_RL: read field: "dEtaHdt ", #  10 in fldList, rec= 122
 (PID.TID 0000.0001) READ_MFLDS_3D_RL: read field: "EtaH    ", #  11 in fldList, rec= 123
+(PID.TID 0000.0001) DIAGSTATS_INI_IO: open file: dynStDiag.0000072000.txt , unit=     9
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // Model current state
 (PID.TID 0000.0001) // =======================================================
@@ -2873,45 +2525,45 @@
 (PID.TID 0000.0001) // =======================================================
  EXTERNAL_FIELDS_LOAD, it=     72000 : Reading new data, i0,i1=   12    1 (prev=   12    0 )
 (PID.TID 0000.0001) SOLVE_FOR_PRESSURE: putPmEinXvector =    F
- cg2d: Sum(rhs),rhsMax =  -9.63495949690696E-12  4.28293538426452E+00
-(PID.TID 0000.0001)      cg2d_init_res =   1.68023878714095E-01
-(PID.TID 0000.0001)      cg2d_iters(min,last) =      -1      64
-(PID.TID 0000.0001)      cg2d_last_res =   5.58683552522706E-07
+ cg2d: Sum(rhs),rhsMax =  -2.21689333557151E-12  4.28293538426452E+00
+(PID.TID 0000.0001)      cg2d_init_res =   3.92310094920912E-02
+(PID.TID 0000.0001)      cg2d_iters(min,last) =      -1      91
+(PID.TID 0000.0001)      cg2d_last_res =   8.27294266102382E-10
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // Begin MONITOR dynamic field statistics
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) %MON time_tsnumber                =                 72001
 (PID.TID 0000.0001) %MON time_secondsf                =   6.2208864000000E+09
-(PID.TID 0000.0001) %MON dynstat_eta_max              =   9.2133655120996E-01
-(PID.TID 0000.0001) %MON dynstat_eta_min              =  -1.6190330502946E+00
-(PID.TID 0000.0001) %MON dynstat_eta_mean             =   1.4468787832318E-14
-(PID.TID 0000.0001) %MON dynstat_eta_sd               =   5.9917645600647E-01
-(PID.TID 0000.0001) %MON dynstat_eta_del2             =   7.8642723390166E-04
-(PID.TID 0000.0001) %MON dynstat_uvel_max             =   1.8614969421301E-01
-(PID.TID 0000.0001) %MON dynstat_uvel_min             =  -2.8756253548200E-01
-(PID.TID 0000.0001) %MON dynstat_uvel_mean            =  -4.8930781602901E-04
-(PID.TID 0000.0001) %MON dynstat_uvel_sd              =   1.2019850590904E-02
-(PID.TID 0000.0001) %MON dynstat_uvel_del2            =   5.1422826272405E-05
-(PID.TID 0000.0001) %MON dynstat_vvel_max             =   1.7424330934384E-01
-(PID.TID 0000.0001) %MON dynstat_vvel_min             =  -2.2484862162875E-01
-(PID.TID 0000.0001) %MON dynstat_vvel_mean            =  -4.0148993675111E-04
-(PID.TID 0000.0001) %MON dynstat_vvel_sd              =   1.2634847209014E-02
-(PID.TID 0000.0001) %MON dynstat_vvel_del2            =   5.0838534695572E-05
-(PID.TID 0000.0001) %MON dynstat_wvel_max             =   1.0470225922697E-04
-(PID.TID 0000.0001) %MON dynstat_wvel_min             =  -2.0629060515043E-04
-(PID.TID 0000.0001) %MON dynstat_wvel_mean            =  -3.1589699713370E-11
-(PID.TID 0000.0001) %MON dynstat_wvel_sd              =   3.8549171120240E-06
-(PID.TID 0000.0001) %MON dynstat_wvel_del2            =   2.6740462640007E-08
-(PID.TID 0000.0001) %MON dynstat_theta_max            =   3.0937492864893E+01
-(PID.TID 0000.0001) %MON dynstat_theta_min            =  -2.0051002156293E+00
-(PID.TID 0000.0001) %MON dynstat_theta_mean           =   3.9091886517348E+00
-(PID.TID 0000.0001) %MON dynstat_theta_sd             =   4.5710983067973E+00
-(PID.TID 0000.0001) %MON dynstat_theta_del2           =   2.6413868816426E-03
-(PID.TID 0000.0001) %MON dynstat_salt_max             =   4.1386656529517E+01
+(PID.TID 0000.0001) %MON dynstat_eta_max              =   9.2133626810671E-01
+(PID.TID 0000.0001) %MON dynstat_eta_min              =  -1.6190330884059E+00
+(PID.TID 0000.0001) %MON dynstat_eta_mean             =   1.4221458125783E-14
+(PID.TID 0000.0001) %MON dynstat_eta_sd               =   5.9917645742956E-01
+(PID.TID 0000.0001) %MON dynstat_eta_del2             =   7.8642722843297E-04
+(PID.TID 0000.0001) %MON dynstat_uvel_max             =   1.8614969430630E-01
+(PID.TID 0000.0001) %MON dynstat_uvel_min             =  -2.8756253546912E-01
+(PID.TID 0000.0001) %MON dynstat_uvel_mean            =  -4.8930782492438E-04
+(PID.TID 0000.0001) %MON dynstat_uvel_sd              =   1.2019850590499E-02
+(PID.TID 0000.0001) %MON dynstat_uvel_del2            =   5.1422826274059E-05
+(PID.TID 0000.0001) %MON dynstat_vvel_max             =   1.7424330938617E-01
+(PID.TID 0000.0001) %MON dynstat_vvel_min             =  -2.2484862167837E-01
+(PID.TID 0000.0001) %MON dynstat_vvel_mean            =  -4.0148993094680E-04
+(PID.TID 0000.0001) %MON dynstat_vvel_sd              =   1.2634847209242E-02
+(PID.TID 0000.0001) %MON dynstat_vvel_del2            =   5.0838534698515E-05
+(PID.TID 0000.0001) %MON dynstat_wvel_max             =   1.0470225922131E-04
+(PID.TID 0000.0001) %MON dynstat_wvel_min             =  -2.0629060542608E-04
+(PID.TID 0000.0001) %MON dynstat_wvel_mean            =  -3.1593559095091E-11
+(PID.TID 0000.0001) %MON dynstat_wvel_sd              =   3.8549171143017E-06
+(PID.TID 0000.0001) %MON dynstat_wvel_del2            =   2.6740462650446E-08
+(PID.TID 0000.0001) %MON dynstat_theta_max            =   3.0937492864933E+01
+(PID.TID 0000.0001) %MON dynstat_theta_min            =  -2.0051002160512E+00
+(PID.TID 0000.0001) %MON dynstat_theta_mean           =   3.9091886517352E+00
+(PID.TID 0000.0001) %MON dynstat_theta_sd             =   4.5710983067988E+00
+(PID.TID 0000.0001) %MON dynstat_theta_del2           =   2.6413868816405E-03
+(PID.TID 0000.0001) %MON dynstat_salt_max             =   4.1386656529612E+01
 (PID.TID 0000.0001) %MON dynstat_salt_min             =   1.8383740720343E+01
 (PID.TID 0000.0001) %MON dynstat_salt_mean            =   3.4772069023557E+01
-(PID.TID 0000.0001) %MON dynstat_salt_sd              =   5.3143476611334E-01
-(PID.TID 0000.0001) %MON dynstat_salt_del2            =   8.0251565841648E-04
+(PID.TID 0000.0001) %MON dynstat_salt_sd              =   5.3143476611350E-01
+(PID.TID 0000.0001) %MON dynstat_salt_del2            =   8.0251565841736E-04
 (PID.TID 0000.0001) %MON forcing_qnet_max             =   4.5344826813507E+02
 (PID.TID 0000.0001) %MON forcing_qnet_min             =  -2.1502574251756E+02
 (PID.TID 0000.0001) %MON forcing_qnet_mean            =  -1.2145822391644E+01
@@ -2937,67 +2589,67 @@
 (PID.TID 0000.0001) %MON forcing_fv_mean              =  -1.3684501518858E-02
 (PID.TID 0000.0001) %MON forcing_fv_sd                =   7.5153512230531E-02
 (PID.TID 0000.0001) %MON forcing_fv_del2              =   2.3373863441584E-04
-(PID.TID 0000.0001) %MON trAdv_CFL_u_max              =   8.1102262955735E-02
-(PID.TID 0000.0001) %MON trAdv_CFL_v_max              =   8.0812652325363E-02
-(PID.TID 0000.0001) %MON trAdv_CFL_w_max              =   7.4292349384178E-02
-(PID.TID 0000.0001) %MON advcfl_uvel_max              =   8.1558189746286E-02
-(PID.TID 0000.0001) %MON advcfl_vvel_max              =   7.5950203765915E-02
-(PID.TID 0000.0001) %MON advcfl_wvel_max              =   6.7258521830179E-02
-(PID.TID 0000.0001) %MON advcfl_W_hf_max              =   7.4292349384178E-02
-(PID.TID 0000.0001) %MON pe_b_mean                    =   4.7827089476881E-04
-(PID.TID 0000.0001) %MON ke_max                       =   4.0534798017586E-02
-(PID.TID 0000.0001) %MON ke_mean                      =   1.4061962891933E-04
+(PID.TID 0000.0001) %MON trAdv_CFL_u_max              =   8.1102262952101E-02
+(PID.TID 0000.0001) %MON trAdv_CFL_v_max              =   8.0812652344994E-02
+(PID.TID 0000.0001) %MON trAdv_CFL_w_max              =   7.4292349483446E-02
+(PID.TID 0000.0001) %MON advcfl_uvel_max              =   8.1558189742631E-02
+(PID.TID 0000.0001) %MON advcfl_vvel_max              =   7.5950203784365E-02
+(PID.TID 0000.0001) %MON advcfl_wvel_max              =   6.7258521920049E-02
+(PID.TID 0000.0001) %MON advcfl_W_hf_max              =   7.4292349483446E-02
+(PID.TID 0000.0001) %MON pe_b_mean                    =   4.7827089704068E-04
+(PID.TID 0000.0001) %MON ke_max                       =   4.0534798012729E-02
+(PID.TID 0000.0001) %MON ke_mean                      =   1.4061962891935E-04
 (PID.TID 0000.0001) %MON ke_vol                       =   1.3398024453628E+18
-(PID.TID 0000.0001) %MON vort_r_min                   =  -1.1961273457322E-06
-(PID.TID 0000.0001) %MON vort_r_max                   =   1.2248991447641E-06
+(PID.TID 0000.0001) %MON vort_r_min                   =  -1.1961273454270E-06
+(PID.TID 0000.0001) %MON vort_r_max                   =   1.2248991434525E-06
 (PID.TID 0000.0001) %MON vort_a_mean                  =  -2.0549865324846E-05
-(PID.TID 0000.0001) %MON vort_a_sd                    =   7.5259516806869E-05
+(PID.TID 0000.0001) %MON vort_a_sd                    =   7.5259516806868E-05
 (PID.TID 0000.0001) %MON vort_p_mean                  =  -2.4783469220072E-05
 (PID.TID 0000.0001) %MON vort_p_sd                    =   1.2812073162531E-04
-(PID.TID 0000.0001) %MON surfExpan_theta_mean         =   4.3139703452604E-08
-(PID.TID 0000.0001) %MON surfExpan_salt_mean          =   1.2483991774886E-08
+(PID.TID 0000.0001) %MON surfExpan_theta_mean         =   4.3139686620134E-08
+(PID.TID 0000.0001) %MON surfExpan_salt_mean          =   1.2483997845618E-08
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // End MONITOR dynamic field statistics
 (PID.TID 0000.0001) // =======================================================
- cg2d: Sum(rhs),rhsMax =  -9.54969436861575E-12  4.28169923847119E+00
-(PID.TID 0000.0001)      cg2d_init_res =   2.26182951652446E-01
-(PID.TID 0000.0001)      cg2d_iters(min,last) =      -1      64
-(PID.TID 0000.0001)      cg2d_last_res =   5.39325018591159E-07
+ cg2d: Sum(rhs),rhsMax =  -2.30926389122033E-12  4.28169922329599E+00
+(PID.TID 0000.0001)      cg2d_init_res =   5.28258186930844E-02
+(PID.TID 0000.0001)      cg2d_iters(min,last) =      -1      91
+(PID.TID 0000.0001)      cg2d_last_res =   7.97232337613538E-10
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // Begin MONITOR dynamic field statistics
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) %MON time_tsnumber                =                 72002
 (PID.TID 0000.0001) %MON time_secondsf                =   6.2209728000000E+09
-(PID.TID 0000.0001) %MON dynstat_eta_max              =   9.1899543513961E-01
-(PID.TID 0000.0001) %MON dynstat_eta_min              =  -1.6178232244521E+00
-(PID.TID 0000.0001) %MON dynstat_eta_mean             =   1.4386344596806E-14
-(PID.TID 0000.0001) %MON dynstat_eta_sd               =   5.9890083389511E-01
-(PID.TID 0000.0001) %MON dynstat_eta_del2             =   7.8619309107450E-04
-(PID.TID 0000.0001) %MON dynstat_uvel_max             =   1.8681676266081E-01
-(PID.TID 0000.0001) %MON dynstat_uvel_min             =  -2.8744599945261E-01
-(PID.TID 0000.0001) %MON dynstat_uvel_mean            =  -4.8865408201906E-04
-(PID.TID 0000.0001) %MON dynstat_uvel_sd              =   1.2016197449285E-02
-(PID.TID 0000.0001) %MON dynstat_uvel_del2            =   5.1210131724425E-05
-(PID.TID 0000.0001) %MON dynstat_vvel_max             =   1.7405826603062E-01
-(PID.TID 0000.0001) %MON dynstat_vvel_min             =  -2.2510217722701E-01
-(PID.TID 0000.0001) %MON dynstat_vvel_mean            =  -4.0366940269113E-04
-(PID.TID 0000.0001) %MON dynstat_vvel_sd              =   1.2639872138669E-02
-(PID.TID 0000.0001) %MON dynstat_vvel_del2            =   5.0605972538650E-05
-(PID.TID 0000.0001) %MON dynstat_wvel_max             =   1.0365488858011E-04
-(PID.TID 0000.0001) %MON dynstat_wvel_min             =  -2.0489391941864E-04
-(PID.TID 0000.0001) %MON dynstat_wvel_mean            =   2.7299861205590E-10
-(PID.TID 0000.0001) %MON dynstat_wvel_sd              =   3.8361815399456E-06
-(PID.TID 0000.0001) %MON dynstat_wvel_del2            =   2.6501884672292E-08
-(PID.TID 0000.0001) %MON dynstat_theta_max            =   3.0948569140590E+01
-(PID.TID 0000.0001) %MON dynstat_theta_min            =  -2.0092219769229E+00
-(PID.TID 0000.0001) %MON dynstat_theta_mean           =   3.9092460682667E+00
-(PID.TID 0000.0001) %MON dynstat_theta_sd             =   4.5710602606720E+00
-(PID.TID 0000.0001) %MON dynstat_theta_del2           =   2.6295808781658E-03
-(PID.TID 0000.0001) %MON dynstat_salt_max             =   4.1387060077504E+01
+(PID.TID 0000.0001) %MON dynstat_eta_max              =   9.1899547462415E-01
+(PID.TID 0000.0001) %MON dynstat_eta_min              =  -1.6178232127262E+00
+(PID.TID 0000.0001) %MON dynstat_eta_mean             =   1.4248939204287E-14
+(PID.TID 0000.0001) %MON dynstat_eta_sd               =   5.9890083509217E-01
+(PID.TID 0000.0001) %MON dynstat_eta_del2             =   7.8619305685641E-04
+(PID.TID 0000.0001) %MON dynstat_uvel_max             =   1.8681676263258E-01
+(PID.TID 0000.0001) %MON dynstat_uvel_min             =  -2.8744599936185E-01
+(PID.TID 0000.0001) %MON dynstat_uvel_mean            =  -4.8865408033750E-04
+(PID.TID 0000.0001) %MON dynstat_uvel_sd              =   1.2016197449287E-02
+(PID.TID 0000.0001) %MON dynstat_uvel_del2            =   5.1210131717510E-05
+(PID.TID 0000.0001) %MON dynstat_vvel_max             =   1.7405826584416E-01
+(PID.TID 0000.0001) %MON dynstat_vvel_min             =  -2.2510217720199E-01
+(PID.TID 0000.0001) %MON dynstat_vvel_mean            =  -4.0366941310382E-04
+(PID.TID 0000.0001) %MON dynstat_vvel_sd              =   1.2639872137015E-02
+(PID.TID 0000.0001) %MON dynstat_vvel_del2            =   5.0605972533207E-05
+(PID.TID 0000.0001) %MON dynstat_wvel_max             =   1.0365488865224E-04
+(PID.TID 0000.0001) %MON dynstat_wvel_min             =  -2.0489391946736E-04
+(PID.TID 0000.0001) %MON dynstat_wvel_mean            =   2.7299957784073E-10
+(PID.TID 0000.0001) %MON dynstat_wvel_sd              =   3.8361815407183E-06
+(PID.TID 0000.0001) %MON dynstat_wvel_del2            =   2.6501884713485E-08
+(PID.TID 0000.0001) %MON dynstat_theta_max            =   3.0948569140599E+01
+(PID.TID 0000.0001) %MON dynstat_theta_min            =  -2.0092219769523E+00
+(PID.TID 0000.0001) %MON dynstat_theta_mean           =   3.9092460682669E+00
+(PID.TID 0000.0001) %MON dynstat_theta_sd             =   4.5710602606719E+00
+(PID.TID 0000.0001) %MON dynstat_theta_del2           =   2.6295808781664E-03
+(PID.TID 0000.0001) %MON dynstat_salt_max             =   4.1387060077607E+01
 (PID.TID 0000.0001) %MON dynstat_salt_min             =   1.8384079578526E+01
 (PID.TID 0000.0001) %MON dynstat_salt_mean            =   3.4772069353871E+01
-(PID.TID 0000.0001) %MON dynstat_salt_sd              =   5.3141711854060E-01
-(PID.TID 0000.0001) %MON dynstat_salt_del2            =   7.9901339702912E-04
+(PID.TID 0000.0001) %MON dynstat_salt_sd              =   5.3141711854056E-01
+(PID.TID 0000.0001) %MON dynstat_salt_del2            =   7.9901339702992E-04
 (PID.TID 0000.0001) %MON forcing_qnet_max             =   4.5335380716717E+02
 (PID.TID 0000.0001) %MON forcing_qnet_min             =  -2.1405338853096E+02
 (PID.TID 0000.0001) %MON forcing_qnet_mean            =  -1.2158050760287E+01
@@ -3023,67 +2675,67 @@
 (PID.TID 0000.0001) %MON forcing_fv_mean              =  -1.3688427064785E-02
 (PID.TID 0000.0001) %MON forcing_fv_sd                =   7.5192943168452E-02
 (PID.TID 0000.0001) %MON forcing_fv_del2              =   2.3392164091250E-04
-(PID.TID 0000.0001) %MON trAdv_CFL_u_max              =   8.1069395163719E-02
-(PID.TID 0000.0001) %MON trAdv_CFL_v_max              =   8.0726800351923E-02
-(PID.TID 0000.0001) %MON trAdv_CFL_w_max              =   7.3789449428529E-02
-(PID.TID 0000.0001) %MON advcfl_uvel_max              =   8.1525137917814E-02
-(PID.TID 0000.0001) %MON advcfl_vvel_max              =   7.5869545992616E-02
-(PID.TID 0000.0001) %MON advcfl_wvel_max              =   6.6803149576492E-02
-(PID.TID 0000.0001) %MON advcfl_W_hf_max              =   7.3789449428529E-02
-(PID.TID 0000.0001) %MON pe_b_mean                    =   4.7783098524525E-04
-(PID.TID 0000.0001) %MON ke_max                       =   4.0487490178773E-02
-(PID.TID 0000.0001) %MON ke_mean                      =   1.4063874235253E-04
+(PID.TID 0000.0001) %MON trAdv_CFL_u_max              =   8.1069395138741E-02
+(PID.TID 0000.0001) %MON trAdv_CFL_v_max              =   8.0726800265604E-02
+(PID.TID 0000.0001) %MON trAdv_CFL_w_max              =   7.3789449445551E-02
+(PID.TID 0000.0001) %MON advcfl_uvel_max              =   8.1525137892072E-02
+(PID.TID 0000.0001) %MON advcfl_vvel_max              =   7.5869545911337E-02
+(PID.TID 0000.0001) %MON advcfl_wvel_max              =   6.6803149592376E-02
+(PID.TID 0000.0001) %MON advcfl_W_hf_max              =   7.3789449445551E-02
+(PID.TID 0000.0001) %MON pe_b_mean                    =   4.7783098715540E-04
+(PID.TID 0000.0001) %MON ke_max                       =   4.0487490151957E-02
+(PID.TID 0000.0001) %MON ke_mean                      =   1.4063874233632E-04
 (PID.TID 0000.0001) %MON ke_vol                       =   1.3398024453628E+18
-(PID.TID 0000.0001) %MON vort_r_min                   =  -1.1931492245839E-06
-(PID.TID 0000.0001) %MON vort_r_max                   =   1.2188021634864E-06
+(PID.TID 0000.0001) %MON vort_r_min                   =  -1.1931492246678E-06
+(PID.TID 0000.0001) %MON vort_r_max                   =   1.2188021638044E-06
 (PID.TID 0000.0001) %MON vort_a_mean                  =  -2.0549865324846E-05
-(PID.TID 0000.0001) %MON vort_a_sd                    =   7.5259516743743E-05
-(PID.TID 0000.0001) %MON vort_p_mean                  =  -2.4783469211163E-05
-(PID.TID 0000.0001) %MON vort_p_sd                    =   1.2812073652347E-04
-(PID.TID 0000.0001) %MON surfExpan_theta_mean         =   4.6957708387288E-08
-(PID.TID 0000.0001) %MON surfExpan_salt_mean          =   1.4613335922103E-08
+(PID.TID 0000.0001) %MON vort_a_sd                    =   7.5259516743742E-05
+(PID.TID 0000.0001) %MON vort_p_mean                  =  -2.4783469211161E-05
+(PID.TID 0000.0001) %MON vort_p_sd                    =   1.2812073652348E-04
+(PID.TID 0000.0001) %MON surfExpan_theta_mean         =   4.6957701867702E-08
+(PID.TID 0000.0001) %MON surfExpan_salt_mean          =   1.4613330189173E-08
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // End MONITOR dynamic field statistics
 (PID.TID 0000.0001) // =======================================================
- cg2d: Sum(rhs),rhsMax =  -9.80548975348938E-12  4.26963529004741E+00
-(PID.TID 0000.0001)      cg2d_init_res =   2.16204655988238E-01
-(PID.TID 0000.0001)      cg2d_iters(min,last) =      -1      62
-(PID.TID 0000.0001)      cg2d_last_res =   5.63275420217836E-07
+ cg2d: Sum(rhs),rhsMax =  -2.28794760914752E-12  4.26963528595225E+00
+(PID.TID 0000.0001)      cg2d_init_res =   5.06372034673015E-02
+(PID.TID 0000.0001)      cg2d_iters(min,last) =      -1      87
+(PID.TID 0000.0001)      cg2d_last_res =   9.43645596622753E-10
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // Begin MONITOR dynamic field statistics
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) %MON time_tsnumber                =                 72003
 (PID.TID 0000.0001) %MON time_secondsf                =   6.2210592000000E+09
-(PID.TID 0000.0001) %MON dynstat_eta_max              =   9.1716084923417E-01
-(PID.TID 0000.0001) %MON dynstat_eta_min              =  -1.6173450215665E+00
-(PID.TID 0000.0001) %MON dynstat_eta_mean             =   1.4400085136058E-14
-(PID.TID 0000.0001) %MON dynstat_eta_sd               =   5.9885647869818E-01
-(PID.TID 0000.0001) %MON dynstat_eta_del2             =   7.8462230692087E-04
-(PID.TID 0000.0001) %MON dynstat_uvel_max             =   1.8728728618647E-01
-(PID.TID 0000.0001) %MON dynstat_uvel_min             =  -2.8712408840580E-01
-(PID.TID 0000.0001) %MON dynstat_uvel_mean            =  -4.8819348948767E-04
-(PID.TID 0000.0001) %MON dynstat_uvel_sd              =   1.2017980722965E-02
-(PID.TID 0000.0001) %MON dynstat_uvel_del2            =   5.1189280944993E-05
-(PID.TID 0000.0001) %MON dynstat_vvel_max             =   1.7425549562990E-01
-(PID.TID 0000.0001) %MON dynstat_vvel_min             =  -2.2506893781164E-01
-(PID.TID 0000.0001) %MON dynstat_vvel_mean            =  -4.0361168984255E-04
-(PID.TID 0000.0001) %MON dynstat_vvel_sd              =   1.2644594893895E-02
-(PID.TID 0000.0001) %MON dynstat_vvel_del2            =   5.0573338554735E-05
-(PID.TID 0000.0001) %MON dynstat_wvel_max             =   1.0388197365466E-04
-(PID.TID 0000.0001) %MON dynstat_wvel_min             =  -2.0522690634202E-04
-(PID.TID 0000.0001) %MON dynstat_wvel_mean            =   1.8724296742724E-10
-(PID.TID 0000.0001) %MON dynstat_wvel_sd              =   3.8352222485647E-06
-(PID.TID 0000.0001) %MON dynstat_wvel_del2            =   2.6514535111421E-08
-(PID.TID 0000.0001) %MON dynstat_theta_max            =   3.0959186752849E+01
-(PID.TID 0000.0001) %MON dynstat_theta_min            =  -2.0136454252073E+00
-(PID.TID 0000.0001) %MON dynstat_theta_mean           =   3.9093036758847E+00
-(PID.TID 0000.0001) %MON dynstat_theta_sd             =   4.5710299886767E+00
-(PID.TID 0000.0001) %MON dynstat_theta_del2           =   2.6157541267114E-03
-(PID.TID 0000.0001) %MON dynstat_salt_max             =   4.1387452758909E+01
+(PID.TID 0000.0001) %MON dynstat_eta_max              =   9.1716091972922E-01
+(PID.TID 0000.0001) %MON dynstat_eta_min              =  -1.6173450374921E+00
+(PID.TID 0000.0001) %MON dynstat_eta_mean             =   1.4276420282791E-14
+(PID.TID 0000.0001) %MON dynstat_eta_sd               =   5.9885648051185E-01
+(PID.TID 0000.0001) %MON dynstat_eta_del2             =   7.8462234181728E-04
+(PID.TID 0000.0001) %MON dynstat_uvel_max             =   1.8728728618908E-01
+(PID.TID 0000.0001) %MON dynstat_uvel_min             =  -2.8712408836516E-01
+(PID.TID 0000.0001) %MON dynstat_uvel_mean            =  -4.8819349179429E-04
+(PID.TID 0000.0001) %MON dynstat_uvel_sd              =   1.2017980721303E-02
+(PID.TID 0000.0001) %MON dynstat_uvel_del2            =   5.1189280948542E-05
+(PID.TID 0000.0001) %MON dynstat_vvel_max             =   1.7425549573053E-01
+(PID.TID 0000.0001) %MON dynstat_vvel_min             =  -2.2506893782443E-01
+(PID.TID 0000.0001) %MON dynstat_vvel_mean            =  -4.0361170331964E-04
+(PID.TID 0000.0001) %MON dynstat_vvel_sd              =   1.2644594894710E-02
+(PID.TID 0000.0001) %MON dynstat_vvel_del2            =   5.0573338554304E-05
+(PID.TID 0000.0001) %MON dynstat_wvel_max             =   1.0388197362493E-04
+(PID.TID 0000.0001) %MON dynstat_wvel_min             =  -2.0522690578788E-04
+(PID.TID 0000.0001) %MON dynstat_wvel_mean            =   1.8724109112254E-10
+(PID.TID 0000.0001) %MON dynstat_wvel_sd              =   3.8352222476740E-06
+(PID.TID 0000.0001) %MON dynstat_wvel_del2            =   2.6514535133027E-08
+(PID.TID 0000.0001) %MON dynstat_theta_max            =   3.0959186752873E+01
+(PID.TID 0000.0001) %MON dynstat_theta_min            =  -2.0136454255590E+00
+(PID.TID 0000.0001) %MON dynstat_theta_mean           =   3.9093036758857E+00
+(PID.TID 0000.0001) %MON dynstat_theta_sd             =   4.5710299886782E+00
+(PID.TID 0000.0001) %MON dynstat_theta_del2           =   2.6157541267112E-03
+(PID.TID 0000.0001) %MON dynstat_salt_max             =   4.1387452759073E+01
 (PID.TID 0000.0001) %MON dynstat_salt_min             =   1.8384424559819E+01
-(PID.TID 0000.0001) %MON dynstat_salt_mean            =   3.4772069741443E+01
-(PID.TID 0000.0001) %MON dynstat_salt_sd              =   5.3139855654685E-01
-(PID.TID 0000.0001) %MON dynstat_salt_del2            =   7.9538894703908E-04
+(PID.TID 0000.0001) %MON dynstat_salt_mean            =   3.4772069741444E+01
+(PID.TID 0000.0001) %MON dynstat_salt_sd              =   5.3139855654692E-01
+(PID.TID 0000.0001) %MON dynstat_salt_del2            =   7.9538894704329E-04
 (PID.TID 0000.0001) %MON forcing_qnet_max             =   4.5325934619927E+02
 (PID.TID 0000.0001) %MON forcing_qnet_min             =  -2.1308103454435E+02
 (PID.TID 0000.0001) %MON forcing_qnet_mean            =  -1.2170279128930E+01
@@ -3109,67 +2761,67 @@
 (PID.TID 0000.0001) %MON forcing_fv_mean              =  -1.3692352610712E-02
 (PID.TID 0000.0001) %MON forcing_fv_sd                =   7.5242720295677E-02
 (PID.TID 0000.0001) %MON forcing_fv_del2              =   2.3430754301775E-04
-(PID.TID 0000.0001) %MON trAdv_CFL_u_max              =   8.0978614263626E-02
-(PID.TID 0000.0001) %MON trAdv_CFL_v_max              =   8.0818177952940E-02
-(PID.TID 0000.0001) %MON trAdv_CFL_w_max              =   7.3909343268016E-02
-(PID.TID 0000.0001) %MON advcfl_uvel_max              =   8.1433837838708E-02
-(PID.TID 0000.0001) %MON advcfl_vvel_max              =   7.5955515596326E-02
-(PID.TID 0000.0001) %MON advcfl_wvel_max              =   6.6911715879057E-02
-(PID.TID 0000.0001) %MON advcfl_W_hf_max              =   7.3909343268016E-02
-(PID.TID 0000.0001) %MON pe_b_mean                    =   4.7776021058134E-04
-(PID.TID 0000.0001) %MON ke_max                       =   4.0380603626313E-02
-(PID.TID 0000.0001) %MON ke_mean                      =   1.4071359914305E-04
+(PID.TID 0000.0001) %MON trAdv_CFL_u_max              =   8.0978614251685E-02
+(PID.TID 0000.0001) %MON trAdv_CFL_v_max              =   8.0818177998905E-02
+(PID.TID 0000.0001) %MON trAdv_CFL_w_max              =   7.3909343068704E-02
+(PID.TID 0000.0001) %MON advcfl_uvel_max              =   8.1433837827182E-02
+(PID.TID 0000.0001) %MON advcfl_vvel_max              =   7.5955515640190E-02
+(PID.TID 0000.0001) %MON advcfl_wvel_max              =   6.6911715698387E-02
+(PID.TID 0000.0001) %MON advcfl_W_hf_max              =   7.3909343068704E-02
+(PID.TID 0000.0001) %MON pe_b_mean                    =   4.7776021347520E-04
+(PID.TID 0000.0001) %MON ke_max                       =   4.0380603601165E-02
+(PID.TID 0000.0001) %MON ke_mean                      =   1.4071359914034E-04
 (PID.TID 0000.0001) %MON ke_vol                       =   1.3398024453628E+18
-(PID.TID 0000.0001) %MON vort_r_min                   =  -1.1970434092135E-06
-(PID.TID 0000.0001) %MON vort_r_max                   =   1.2200257391326E-06
+(PID.TID 0000.0001) %MON vort_r_min                   =  -1.1970434095799E-06
+(PID.TID 0000.0001) %MON vort_r_max                   =   1.2200257394203E-06
 (PID.TID 0000.0001) %MON vort_a_mean                  =  -2.0549865324846E-05
-(PID.TID 0000.0001) %MON vort_a_sd                    =   7.5259516612531E-05
+(PID.TID 0000.0001) %MON vort_a_sd                    =   7.5259516612530E-05
 (PID.TID 0000.0001) %MON vort_p_mean                  =  -2.4783469206482E-05
-(PID.TID 0000.0001) %MON vort_p_sd                    =   1.2812072816314E-04
-(PID.TID 0000.0001) %MON surfExpan_theta_mean         =   5.0263478196919E-08
-(PID.TID 0000.0001) %MON surfExpan_salt_mean          =   1.4850436420889E-08
+(PID.TID 0000.0001) %MON vort_p_sd                    =   1.2812072816312E-04
+(PID.TID 0000.0001) %MON surfExpan_theta_mean         =   5.0263438255875E-08
+(PID.TID 0000.0001) %MON surfExpan_salt_mean          =   1.4850434134044E-08
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // End MONITOR dynamic field statistics
 (PID.TID 0000.0001) // =======================================================
- cg2d: Sum(rhs),rhsMax =  -9.57811607804615E-12  4.26825643555341E+00
-(PID.TID 0000.0001)      cg2d_init_res =   1.96658865268473E-01
-(PID.TID 0000.0001)      cg2d_iters(min,last) =      -1      62
-(PID.TID 0000.0001)      cg2d_last_res =   4.90955559292357E-07
+ cg2d: Sum(rhs),rhsMax =  -2.27373675443232E-12  4.26825644232621E+00
+(PID.TID 0000.0001)      cg2d_init_res =   4.60751355447356E-02
+(PID.TID 0000.0001)      cg2d_iters(min,last) =      -1      86
+(PID.TID 0000.0001)      cg2d_last_res =   8.34781586999831E-10
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // Begin MONITOR dynamic field statistics
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) %MON time_tsnumber                =                 72004
 (PID.TID 0000.0001) %MON time_secondsf                =   6.2211456000000E+09
-(PID.TID 0000.0001) %MON dynstat_eta_max              =   9.1570007702562E-01
-(PID.TID 0000.0001) %MON dynstat_eta_min              =  -1.6168937448163E+00
-(PID.TID 0000.0001) %MON dynstat_eta_mean             =   1.4317641900547E-14
-(PID.TID 0000.0001) %MON dynstat_eta_sd               =   5.9879689894816E-01
-(PID.TID 0000.0001) %MON dynstat_eta_del2             =   7.8399835747975E-04
-(PID.TID 0000.0001) %MON dynstat_uvel_max             =   1.8746403549603E-01
-(PID.TID 0000.0001) %MON dynstat_uvel_min             =  -2.8677650418174E-01
-(PID.TID 0000.0001) %MON dynstat_uvel_mean            =  -4.8783424249094E-04
-(PID.TID 0000.0001) %MON dynstat_uvel_sd              =   1.2015633438107E-02
-(PID.TID 0000.0001) %MON dynstat_uvel_del2            =   5.1165791463594E-05
-(PID.TID 0000.0001) %MON dynstat_vvel_max             =   1.7442342151261E-01
-(PID.TID 0000.0001) %MON dynstat_vvel_min             =  -2.2502647213555E-01
-(PID.TID 0000.0001) %MON dynstat_vvel_mean            =  -4.0354301692567E-04
-(PID.TID 0000.0001) %MON dynstat_vvel_sd              =   1.2646088183848E-02
-(PID.TID 0000.0001) %MON dynstat_vvel_del2            =   5.0541127938387E-05
-(PID.TID 0000.0001) %MON dynstat_wvel_max             =   1.0425450194794E-04
-(PID.TID 0000.0001) %MON dynstat_wvel_min             =  -2.0548809237651E-04
-(PID.TID 0000.0001) %MON dynstat_wvel_mean            =   7.7133873663008E-11
-(PID.TID 0000.0001) %MON dynstat_wvel_sd              =   3.8337213006995E-06
-(PID.TID 0000.0001) %MON dynstat_wvel_del2            =   2.6532910787618E-08
-(PID.TID 0000.0001) %MON dynstat_theta_max            =   3.0969370038839E+01
-(PID.TID 0000.0001) %MON dynstat_theta_min            =  -2.0183541212217E+00
+(PID.TID 0000.0001) %MON dynstat_eta_max              =   9.1570011893738E-01
+(PID.TID 0000.0001) %MON dynstat_eta_min              =  -1.6168937484692E+00
+(PID.TID 0000.0001) %MON dynstat_eta_mean             =   1.4345122979050E-14
+(PID.TID 0000.0001) %MON dynstat_eta_sd               =   5.9879690003240E-01
+(PID.TID 0000.0001) %MON dynstat_eta_del2             =   7.8399837299963E-04
+(PID.TID 0000.0001) %MON dynstat_uvel_max             =   1.8746403561339E-01
+(PID.TID 0000.0001) %MON dynstat_uvel_min             =  -2.8677650407866E-01
+(PID.TID 0000.0001) %MON dynstat_uvel_mean            =  -4.8783424530797E-04
+(PID.TID 0000.0001) %MON dynstat_uvel_sd              =   1.2015633436201E-02
+(PID.TID 0000.0001) %MON dynstat_uvel_del2            =   5.1165791471021E-05
+(PID.TID 0000.0001) %MON dynstat_vvel_max             =   1.7442342157852E-01
+(PID.TID 0000.0001) %MON dynstat_vvel_min             =  -2.2502647215347E-01
+(PID.TID 0000.0001) %MON dynstat_vvel_mean            =  -4.0354303044061E-04
+(PID.TID 0000.0001) %MON dynstat_vvel_sd              =   1.2646088184185E-02
+(PID.TID 0000.0001) %MON dynstat_vvel_del2            =   5.0541127936694E-05
+(PID.TID 0000.0001) %MON dynstat_wvel_max             =   1.0425450193821E-04
+(PID.TID 0000.0001) %MON dynstat_wvel_min             =  -2.0548809195642E-04
+(PID.TID 0000.0001) %MON dynstat_wvel_mean            =   7.7134734139596E-11
+(PID.TID 0000.0001) %MON dynstat_wvel_sd              =   3.8337212994080E-06
+(PID.TID 0000.0001) %MON dynstat_wvel_del2            =   2.6532910781179E-08
+(PID.TID 0000.0001) %MON dynstat_theta_max            =   3.0969370038871E+01
+(PID.TID 0000.0001) %MON dynstat_theta_min            =  -2.0183541217090E+00
 (PID.TID 0000.0001) %MON dynstat_theta_mean           =   3.9093617574487E+00
-(PID.TID 0000.0001) %MON dynstat_theta_sd             =   4.5710069512675E+00
-(PID.TID 0000.0001) %MON dynstat_theta_del2           =   2.6094102831887E-03
-(PID.TID 0000.0001) %MON dynstat_salt_max             =   4.1387829995644E+01
-(PID.TID 0000.0001) %MON dynstat_salt_min             =   1.8384775698199E+01
+(PID.TID 0000.0001) %MON dynstat_theta_sd             =   4.5710069512674E+00
+(PID.TID 0000.0001) %MON dynstat_theta_del2           =   2.6094102831921E-03
+(PID.TID 0000.0001) %MON dynstat_salt_max             =   4.1387829995873E+01
+(PID.TID 0000.0001) %MON dynstat_salt_min             =   1.8384775698198E+01
 (PID.TID 0000.0001) %MON dynstat_salt_mean            =   3.4772070152259E+01
-(PID.TID 0000.0001) %MON dynstat_salt_sd              =   5.3137979133660E-01
-(PID.TID 0000.0001) %MON dynstat_salt_del2            =   7.9376593248892E-04
+(PID.TID 0000.0001) %MON dynstat_salt_sd              =   5.3137979133666E-01
+(PID.TID 0000.0001) %MON dynstat_salt_del2            =   7.9376593249285E-04
 (PID.TID 0000.0001) %MON forcing_qnet_max             =   4.5316488523137E+02
 (PID.TID 0000.0001) %MON forcing_qnet_min             =  -2.1210868055774E+02
 (PID.TID 0000.0001) %MON forcing_qnet_mean            =  -1.2182507497573E+01
@@ -3195,67 +2847,67 @@
 (PID.TID 0000.0001) %MON forcing_fv_mean              =  -1.3696278156640E-02
 (PID.TID 0000.0001) %MON forcing_fv_sd                =   7.5302823094907E-02
 (PID.TID 0000.0001) %MON forcing_fv_del2              =   2.3489534074143E-04
-(PID.TID 0000.0001) %MON trAdv_CFL_u_max              =   8.0880591304179E-02
-(PID.TID 0000.0001) %MON trAdv_CFL_v_max              =   8.0896001594586E-02
-(PID.TID 0000.0001) %MON trAdv_CFL_w_max              =   7.4003409669403E-02
-(PID.TID 0000.0001) %MON advcfl_uvel_max              =   8.1335256359550E-02
-(PID.TID 0000.0001) %MON advcfl_vvel_max              =   7.6028712122824E-02
-(PID.TID 0000.0001) %MON advcfl_wvel_max              =   6.6996872382378E-02
-(PID.TID 0000.0001) %MON advcfl_W_hf_max              =   7.4003409669403E-02
-(PID.TID 0000.0001) %MON pe_b_mean                    =   4.7766515135111E-04
-(PID.TID 0000.0001) %MON ke_max                       =   4.0270343994605E-02
-(PID.TID 0000.0001) %MON ke_mean                      =   1.4070501749942E-04
+(PID.TID 0000.0001) %MON trAdv_CFL_u_max              =   8.0880591275257E-02
+(PID.TID 0000.0001) %MON trAdv_CFL_v_max              =   8.0896001624667E-02
+(PID.TID 0000.0001) %MON trAdv_CFL_w_max              =   7.4003409517866E-02
+(PID.TID 0000.0001) %MON advcfl_uvel_max              =   8.1335256330315E-02
+(PID.TID 0000.0001) %MON advcfl_vvel_max              =   7.6028712151555E-02
+(PID.TID 0000.0001) %MON advcfl_wvel_max              =   6.6996872245413E-02
+(PID.TID 0000.0001) %MON advcfl_W_hf_max              =   7.4003409517866E-02
+(PID.TID 0000.0001) %MON pe_b_mean                    =   4.7766515308092E-04
+(PID.TID 0000.0001) %MON ke_max                       =   4.0270343957093E-02
+(PID.TID 0000.0001) %MON ke_mean                      =   1.4070501748866E-04
 (PID.TID 0000.0001) %MON ke_vol                       =   1.3398024453628E+18
-(PID.TID 0000.0001) %MON vort_r_min                   =  -1.2014015304671E-06
-(PID.TID 0000.0001) %MON vort_r_max                   =   1.2222297255627E-06
+(PID.TID 0000.0001) %MON vort_r_min                   =  -1.2014015304916E-06
+(PID.TID 0000.0001) %MON vort_r_max                   =   1.2222297237904E-06
 (PID.TID 0000.0001) %MON vort_a_mean                  =  -2.0549865324846E-05
-(PID.TID 0000.0001) %MON vort_a_sd                    =   7.5259516403386E-05
-(PID.TID 0000.0001) %MON vort_p_mean                  =  -2.4783469223252E-05
-(PID.TID 0000.0001) %MON vort_p_sd                    =   1.2812072565044E-04
-(PID.TID 0000.0001) %MON surfExpan_theta_mean         =   4.8538268792198E-08
-(PID.TID 0000.0001) %MON surfExpan_salt_mean          =   1.4766638303017E-08
+(PID.TID 0000.0001) %MON vort_a_sd                    =   7.5259516403385E-05
+(PID.TID 0000.0001) %MON vort_p_mean                  =  -2.4783469223251E-05
+(PID.TID 0000.0001) %MON vort_p_sd                    =   1.2812072565046E-04
+(PID.TID 0000.0001) %MON surfExpan_theta_mean         =   4.8538270072521E-08
+(PID.TID 0000.0001) %MON surfExpan_salt_mean          =   1.4766638898796E-08
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // End MONITOR dynamic field statistics
 (PID.TID 0000.0001) // =======================================================
- cg2d: Sum(rhs),rhsMax =  -9.74864633462857E-12  4.26314508307715E+00
-(PID.TID 0000.0001)      cg2d_init_res =   2.04010891451962E-01
-(PID.TID 0000.0001)      cg2d_iters(min,last) =      -1      62
-(PID.TID 0000.0001)      cg2d_last_res =   5.05624576832133E-07
+ cg2d: Sum(rhs),rhsMax =  -2.25952589971712E-12  4.26314509314259E+00
+(PID.TID 0000.0001)      cg2d_init_res =   4.78553539820498E-02
+(PID.TID 0000.0001)      cg2d_iters(min,last) =      -1      86
+(PID.TID 0000.0001)      cg2d_last_res =   8.93372250946448E-10
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // Begin MONITOR dynamic field statistics
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) %MON time_tsnumber                =                 72005
 (PID.TID 0000.0001) %MON time_secondsf                =   6.2212320000000E+09
-(PID.TID 0000.0001) %MON dynstat_eta_max              =   9.1425377205643E-01
-(PID.TID 0000.0001) %MON dynstat_eta_min              =  -1.6163081026433E+00
-(PID.TID 0000.0001) %MON dynstat_eta_mean             =   1.4290160822043E-14
-(PID.TID 0000.0001) %MON dynstat_eta_sd               =   5.9872262682672E-01
-(PID.TID 0000.0001) %MON dynstat_eta_del2             =   7.8312951231813E-04
-(PID.TID 0000.0001) %MON dynstat_uvel_max             =   1.8763539708194E-01
-(PID.TID 0000.0001) %MON dynstat_uvel_min             =  -2.8640511923386E-01
-(PID.TID 0000.0001) %MON dynstat_uvel_mean            =  -4.8754081495740E-04
-(PID.TID 0000.0001) %MON dynstat_uvel_sd              =   1.2013954659895E-02
-(PID.TID 0000.0001) %MON dynstat_uvel_del2            =   5.1138141319002E-05
-(PID.TID 0000.0001) %MON dynstat_vvel_max             =   1.7452974951525E-01
-(PID.TID 0000.0001) %MON dynstat_vvel_min             =  -2.2497580393048E-01
-(PID.TID 0000.0001) %MON dynstat_vvel_mean            =  -4.0340296087475E-04
-(PID.TID 0000.0001) %MON dynstat_vvel_sd              =   1.2648249095162E-02
-(PID.TID 0000.0001) %MON dynstat_vvel_del2            =   5.0506294776384E-05
-(PID.TID 0000.0001) %MON dynstat_wvel_max             =   1.0468577257698E-04
-(PID.TID 0000.0001) %MON dynstat_wvel_min             =  -2.0569267113831E-04
-(PID.TID 0000.0001) %MON dynstat_wvel_mean            =   6.1308612589859E-11
-(PID.TID 0000.0001) %MON dynstat_wvel_sd              =   3.8324712251396E-06
-(PID.TID 0000.0001) %MON dynstat_wvel_del2            =   2.6556156424327E-08
-(PID.TID 0000.0001) %MON dynstat_theta_max            =   3.0979141204939E+01
-(PID.TID 0000.0001) %MON dynstat_theta_min            =  -2.0233045989875E+00
-(PID.TID 0000.0001) %MON dynstat_theta_mean           =   3.9094200077766E+00
+(PID.TID 0000.0001) %MON dynstat_eta_max              =   9.1425379889565E-01
+(PID.TID 0000.0001) %MON dynstat_eta_min              =  -1.6163081167269E+00
+(PID.TID 0000.0001) %MON dynstat_eta_mean             =   1.4400085136058E-14
+(PID.TID 0000.0001) %MON dynstat_eta_sd               =   5.9872262673049E-01
+(PID.TID 0000.0001) %MON dynstat_eta_del2             =   7.8312952389670E-04
+(PID.TID 0000.0001) %MON dynstat_uvel_max             =   1.8763539717944E-01
+(PID.TID 0000.0001) %MON dynstat_uvel_min             =  -2.8640511913938E-01
+(PID.TID 0000.0001) %MON dynstat_uvel_mean            =  -4.8754081390371E-04
+(PID.TID 0000.0001) %MON dynstat_uvel_sd              =   1.2013954658189E-02
+(PID.TID 0000.0001) %MON dynstat_uvel_del2            =   5.1138141322368E-05
+(PID.TID 0000.0001) %MON dynstat_vvel_max             =   1.7452974953887E-01
+(PID.TID 0000.0001) %MON dynstat_vvel_min             =  -2.2497580395322E-01
+(PID.TID 0000.0001) %MON dynstat_vvel_mean            =  -4.0340297434027E-04
+(PID.TID 0000.0001) %MON dynstat_vvel_sd              =   1.2648249096089E-02
+(PID.TID 0000.0001) %MON dynstat_vvel_del2            =   5.0506294779145E-05
+(PID.TID 0000.0001) %MON dynstat_wvel_max             =   1.0468577258135E-04
+(PID.TID 0000.0001) %MON dynstat_wvel_min             =  -2.0569267085843E-04
+(PID.TID 0000.0001) %MON dynstat_wvel_mean            =   6.1309831698948E-11
+(PID.TID 0000.0001) %MON dynstat_wvel_sd              =   3.8324712257349E-06
+(PID.TID 0000.0001) %MON dynstat_wvel_del2            =   2.6556156420998E-08
+(PID.TID 0000.0001) %MON dynstat_theta_max            =   3.0979141204930E+01
+(PID.TID 0000.0001) %MON dynstat_theta_min            =  -2.0233045993227E+00
+(PID.TID 0000.0001) %MON dynstat_theta_mean           =   3.9094200077768E+00
 (PID.TID 0000.0001) %MON dynstat_theta_sd             =   4.5709949317998E+00
-(PID.TID 0000.0001) %MON dynstat_theta_del2           =   2.5984307053582E-03
-(PID.TID 0000.0001) %MON dynstat_salt_max             =   4.1388185924147E+01
+(PID.TID 0000.0001) %MON dynstat_theta_del2           =   2.5984307053668E-03
+(PID.TID 0000.0001) %MON dynstat_salt_max             =   4.1388185924417E+01
 (PID.TID 0000.0001) %MON dynstat_salt_min             =   1.8385132906266E+01
 (PID.TID 0000.0001) %MON dynstat_salt_mean            =   3.4772070576670E+01
 (PID.TID 0000.0001) %MON dynstat_salt_sd              =   5.3136309401449E-01
-(PID.TID 0000.0001) %MON dynstat_salt_del2            =   7.9027651596287E-04
+(PID.TID 0000.0001) %MON dynstat_salt_del2            =   7.9027651596557E-04
 (PID.TID 0000.0001) %MON forcing_qnet_max             =   4.5307042426348E+02
 (PID.TID 0000.0001) %MON forcing_qnet_min             =  -2.1113632657113E+02
 (PID.TID 0000.0001) %MON forcing_qnet_mean            =  -1.2194735866217E+01
@@ -3281,70 +2933,70 @@
 (PID.TID 0000.0001) %MON forcing_fv_mean              =  -1.3700203702567E-02
 (PID.TID 0000.0001) %MON forcing_fv_sd                =   7.5373226864996E-02
 (PID.TID 0000.0001) %MON forcing_fv_del2              =   2.3568352349763E-04
-(PID.TID 0000.0001) %MON trAdv_CFL_u_max              =   8.0775854379166E-02
-(PID.TID 0000.0001) %MON trAdv_CFL_v_max              =   8.0945274352149E-02
-(PID.TID 0000.0001) %MON trAdv_CFL_w_max              =   7.4077126133498E-02
-(PID.TID 0000.0001) %MON advcfl_uvel_max              =   8.1229924543645E-02
-(PID.TID 0000.0001) %MON advcfl_vvel_max              =   7.6075059001203E-02
-(PID.TID 0000.0001) %MON advcfl_wvel_max              =   6.7063572778678E-02
-(PID.TID 0000.0001) %MON advcfl_W_hf_max              =   7.4077126133498E-02
-(PID.TID 0000.0001) %MON pe_b_mean                    =   4.7754666375049E-04
-(PID.TID 0000.0001) %MON ke_max                       =   4.0156472604118E-02
-(PID.TID 0000.0001) %MON ke_mean                      =   1.4071166277397E-04
+(PID.TID 0000.0001) %MON trAdv_CFL_u_max              =   8.0775854352525E-02
+(PID.TID 0000.0001) %MON trAdv_CFL_v_max              =   8.0945274362434E-02
+(PID.TID 0000.0001) %MON trAdv_CFL_w_max              =   7.4077126032675E-02
+(PID.TID 0000.0001) %MON advcfl_uvel_max              =   8.1229924516850E-02
+(PID.TID 0000.0001) %MON advcfl_vvel_max              =   7.6075059011498E-02
+(PID.TID 0000.0001) %MON advcfl_wvel_max              =   6.7063572687427E-02
+(PID.TID 0000.0001) %MON advcfl_W_hf_max              =   7.4077126032675E-02
+(PID.TID 0000.0001) %MON pe_b_mean                    =   4.7754666359697E-04
+(PID.TID 0000.0001) %MON ke_max                       =   4.0156472569581E-02
+(PID.TID 0000.0001) %MON ke_mean                      =   1.4071166277060E-04
 (PID.TID 0000.0001) %MON ke_vol                       =   1.3398024453628E+18
-(PID.TID 0000.0001) %MON vort_r_min                   =  -1.2058369425432E-06
-(PID.TID 0000.0001) %MON vort_r_max                   =   1.2245058273221E-06
+(PID.TID 0000.0001) %MON vort_r_min                   =  -1.2058369420808E-06
+(PID.TID 0000.0001) %MON vort_r_max                   =   1.2245058281775E-06
 (PID.TID 0000.0001) %MON vort_a_mean                  =  -2.0549865324846E-05
-(PID.TID 0000.0001) %MON vort_a_sd                    =   7.5259516265911E-05
-(PID.TID 0000.0001) %MON vort_p_mean                  =  -2.4783469196317E-05
-(PID.TID 0000.0001) %MON vort_p_sd                    =   1.2812072400250E-04
-(PID.TID 0000.0001) %MON surfExpan_theta_mean         =   4.8333596078792E-08
-(PID.TID 0000.0001) %MON surfExpan_salt_mean          =   1.4621923210333E-08
+(PID.TID 0000.0001) %MON vort_a_sd                    =   7.5259516265910E-05
+(PID.TID 0000.0001) %MON vort_p_mean                  =  -2.4783469196316E-05
+(PID.TID 0000.0001) %MON vort_p_sd                    =   1.2812072400252E-04
+(PID.TID 0000.0001) %MON surfExpan_theta_mean         =   4.8333586991215E-08
+(PID.TID 0000.0001) %MON surfExpan_salt_mean          =   1.4621921176823E-08
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // End MONITOR dynamic field statistics
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) DIAGSTATS_CLOSE_IO: close file: dynStDiag.0000072000.txt , unit=     9
 (PID.TID 0000.0001) %CHECKPOINT     72005 ckptA
 (PID.TID 0000.0001)   early fc =  0.000000000000000D+00
- --> objf_test(bi,bj)        =  0.112642990319059D+05
- --> objf_test(bi,bj)        =  0.925748325923490D+04
- --> objf_test(bi,bj)        =  0.646782341064632D+04
- --> objf_test(bi,bj)        =  0.425114891594451D+04
- --> objf_test(bi,bj)        =  0.468651159947707D+04
- --> objf_test(bi,bj)        =  0.131971832117793D+05
- --> objf_test(bi,bj)        =  0.111682590494972D+05
- --> objf_test(bi,bj)        =  0.109410446656030D+05
- --> objf_test(bi,bj)        =  0.691550498455277D+04
- --> objf_test(bi,bj)        =  0.683247511182580D+04
- --> objf_test(bi,bj)        =  0.520040324668799D+04
- --> objf_test(bi,bj)        =  0.606296038321234D+04
-(PID.TID 0000.0001)   local fc =  0.962450968703671D+05
-(PID.TID 0000.0001)  global fc =  0.962450968703671D+05
- cg2d: Sum(rhs),rhsMax =  -9.74864633462857E-12  4.26314508307715E+00
+ --> objf_test(bi,bj)        =  0.112642990316523D+05
+ --> objf_test(bi,bj)        =  0.925748325913600D+04
+ --> objf_test(bi,bj)        =  0.646782341078077D+04
+ --> objf_test(bi,bj)        =  0.425114891600389D+04
+ --> objf_test(bi,bj)        =  0.468651159967385D+04
+ --> objf_test(bi,bj)        =  0.131971832121774D+05
+ --> objf_test(bi,bj)        =  0.111682590495046D+05
+ --> objf_test(bi,bj)        =  0.109410446654470D+05
+ --> objf_test(bi,bj)        =  0.691550498477741D+04
+ --> objf_test(bi,bj)        =  0.683247511169772D+04
+ --> objf_test(bi,bj)        =  0.520040324655723D+04
+ --> objf_test(bi,bj)        =  0.606296038320584D+04
+(PID.TID 0000.0001)   local fc =  0.962450968706140D+05
+(PID.TID 0000.0001)  global fc =  0.962450968706140D+05
+ cg2d: Sum(rhs),rhsMax =  -2.25952589971712E-12  4.26314509314259E+00
 (PID.TID 0000.0001) Did not write pickup because writePickupAtEnd = FALSE
- cg2d: Sum(rhs),rhsMax =  -9.74864633462857E-12  4.26314508307715E+00
- cg2d: Sum(rhs),rhsMax =  -9.74864633462857E-12  4.26314508307715E+00
- cg2d: Sum(rhs),rhsMax =   8.67361737988404E-19  1.78189962772662E-04
- cg2d: Sum(rhs),rhsMax =  -9.57811607804615E-12  4.26825643555341E+00
- cg2d: Sum(rhs),rhsMax =  -9.57811607804615E-12  4.26825643555341E+00
- cg2d: Sum(rhs),rhsMax =  -9.57811607804615E-12  4.26825643555341E+00
- cg2d: Sum(rhs),rhsMax =  -1.30104260698261E-18  1.55588377850507E-03
- cg2d: Sum(rhs),rhsMax =  -9.80548975348938E-12  4.26963529004741E+00
- cg2d: Sum(rhs),rhsMax =  -9.80548975348938E-12  4.26963529004741E+00
- cg2d: Sum(rhs),rhsMax =  -9.80548975348938E-12  4.26963529004741E+00
- cg2d: Sum(rhs),rhsMax =  -1.19262238973405E-18  2.60385267102966E-03
- cg2d: Sum(rhs),rhsMax =  -9.54969436861575E-12  4.28169923847119E+00
- cg2d: Sum(rhs),rhsMax =  -9.54969436861575E-12  4.28169923847119E+00
- cg2d: Sum(rhs),rhsMax =  -9.54969436861575E-12  4.28169923847119E+00
- cg2d: Sum(rhs),rhsMax =   2.81892564846231E-18  2.97812613610585E-03
+ cg2d: Sum(rhs),rhsMax =  -2.25952589971712E-12  4.26314509314259E+00
+ cg2d: Sum(rhs),rhsMax =  -2.25952589971712E-12  4.26314509314259E+00
+ cg2d: Sum(rhs),rhsMax =   4.44089209850063E-15  1.78189962678064E-04
+ cg2d: Sum(rhs),rhsMax =  -2.27373675443232E-12  4.26825644232621E+00
+ cg2d: Sum(rhs),rhsMax =  -2.27373675443232E-12  4.26825644232621E+00
+ cg2d: Sum(rhs),rhsMax =  -2.27373675443232E-12  4.26825644232621E+00
+ cg2d: Sum(rhs),rhsMax =  -4.44089209850063E-16  1.55590059698130E-03
+ cg2d: Sum(rhs),rhsMax =  -2.28794760914752E-12  4.26963528595225E+00
+ cg2d: Sum(rhs),rhsMax =  -2.28794760914752E-12  4.26963528595225E+00
+ cg2d: Sum(rhs),rhsMax =  -2.28794760914752E-12  4.26963528595225E+00
+ cg2d: Sum(rhs),rhsMax =   0.00000000000000E+00  2.60382966700569E-03
+ cg2d: Sum(rhs),rhsMax =  -2.30926389122033E-12  4.28169922329599E+00
+ cg2d: Sum(rhs),rhsMax =  -2.30926389122033E-12  4.28169922329599E+00
+ cg2d: Sum(rhs),rhsMax =  -2.30926389122033E-12  4.28169922329599E+00
+ cg2d: Sum(rhs),rhsMax =  -1.11022302462516E-16  2.97814750959357E-03
  EXTERNAL_FIELDS_LOAD, it=     72000 : Reading new data, i0,i1=   12    1 (prev=   12    0 )
 (PID.TID 0000.0001) SOLVE_FOR_PRESSURE: putPmEinXvector =    F
- cg2d: Sum(rhs),rhsMax =  -9.63495949690696E-12  4.28293538426452E+00
+ cg2d: Sum(rhs),rhsMax =  -2.21689333557151E-12  4.28293538426452E+00
  EXTERNAL_FIELDS_LOAD, it=     72000 : Reading new data, i0,i1=   12    1 (prev=   12    0 )
 (PID.TID 0000.0001) SOLVE_FOR_PRESSURE: putPmEinXvector =    F
- cg2d: Sum(rhs),rhsMax =  -9.63495949690696E-12  4.28293538426452E+00
- cg2d: Sum(rhs),rhsMax =  -9.63495949690696E-12  4.28293538426452E+00
- cg2d: Sum(rhs),rhsMax =  -8.67361737988404E-19  2.73831338873332E-03
+ cg2d: Sum(rhs),rhsMax =  -2.21689333557151E-12  4.28293538426452E+00
+ cg2d: Sum(rhs),rhsMax =  -2.21689333557151E-12  4.28293538426452E+00
+ cg2d: Sum(rhs),rhsMax =   3.33066907387547E-16  2.73841393781860E-03
  EXTERNAL_FIELDS_LOAD, it=     72000 : Reading new data, i0,i1=   12    1 (prev=   12    0 )
 (PID.TID 0000.0001)  nRecords = 123 ; filePrec =  64 ; fileIter =     72000
 (PID.TID 0000.0001)     nDims =   2 , dims:
@@ -3397,28 +3049,28 @@
 (PID.TID 0000.0001) 
  EXTERNAL_FIELDS_LOAD, it=     72000 : Reading new data, i0,i1=   12    1 (prev=   12    0 )
 (PID.TID 0000.0001) SOLVE_FOR_PRESSURE: putPmEinXvector =    F
- cg2d: Sum(rhs),rhsMax =  -9.63495949690696E-12  4.28293538426452E+00
- cg2d: Sum(rhs),rhsMax =  -9.54969436861575E-12  4.28169923847119E+00
- cg2d: Sum(rhs),rhsMax =  -9.80548975348938E-12  4.26963529004741E+00
- cg2d: Sum(rhs),rhsMax =  -9.57811607804615E-12  4.26825643555341E+00
- cg2d: Sum(rhs),rhsMax =  -9.74864633462857E-12  4.26314508307715E+00
+ cg2d: Sum(rhs),rhsMax =  -2.21689333557151E-12  4.28293538426452E+00
+ cg2d: Sum(rhs),rhsMax =  -2.30926389122033E-12  4.28169922329599E+00
+ cg2d: Sum(rhs),rhsMax =  -2.28794760914752E-12  4.26963528595225E+00
+ cg2d: Sum(rhs),rhsMax =  -2.27373675443232E-12  4.26825644232621E+00
+ cg2d: Sum(rhs),rhsMax =  -2.25952589971712E-12  4.26314509314259E+00
 (PID.TID 0000.0001) Did not write pickup because writePickupAtEnd = FALSE
 (PID.TID 0000.0001)   early fc =  0.000000000000000D+00
- --> objf_test(bi,bj)        =  0.112642990319059D+05
- --> objf_test(bi,bj)        =  0.925748325923490D+04
- --> objf_test(bi,bj)        =  0.646782341064632D+04
- --> objf_test(bi,bj)        =  0.425114891594451D+04
- --> objf_test(bi,bj)        =  0.468651159947707D+04
- --> objf_test(bi,bj)        =  0.131971832117793D+05
- --> objf_test(bi,bj)        =  0.111682590494972D+05
- --> objf_test(bi,bj)        =  0.109410446656030D+05
- --> objf_test(bi,bj)        =  0.691550498455277D+04
- --> objf_test(bi,bj)        =  0.683247511182580D+04
- --> objf_test(bi,bj)        =  0.520040324668799D+04
- --> objf_test(bi,bj)        =  0.606296038321234D+04
-(PID.TID 0000.0001)   local fc =  0.962450968703671D+05
-(PID.TID 0000.0001)  global fc =  0.962450968703671D+05
-(PID.TID 0000.0001) grdchk reference fc: fcref       =  9.62450968703671E+04
+ --> objf_test(bi,bj)        =  0.112642990316523D+05
+ --> objf_test(bi,bj)        =  0.925748325913600D+04
+ --> objf_test(bi,bj)        =  0.646782341078077D+04
+ --> objf_test(bi,bj)        =  0.425114891600389D+04
+ --> objf_test(bi,bj)        =  0.468651159967385D+04
+ --> objf_test(bi,bj)        =  0.131971832121774D+05
+ --> objf_test(bi,bj)        =  0.111682590495046D+05
+ --> objf_test(bi,bj)        =  0.109410446654470D+05
+ --> objf_test(bi,bj)        =  0.691550498477741D+04
+ --> objf_test(bi,bj)        =  0.683247511169772D+04
+ --> objf_test(bi,bj)        =  0.520040324655723D+04
+ --> objf_test(bi,bj)        =  0.606296038320584D+04
+(PID.TID 0000.0001)   local fc =  0.962450968706140D+05
+(PID.TID 0000.0001)  global fc =  0.962450968706140D+05
+(PID.TID 0000.0001) grdchk reference fc: fcref       =  9.62450968706140E+04
 grad-res -------------------------------
  grad-res  proc    #    i    j    k   bi   bj iobc       fc ref            fc + eps           fc - eps
  grad-res  proc    #    i    j    k   bi   bj iobc      adj grad            fd grad          1 - fd/adj
@@ -3451,28 +3103,28 @@ grad-res -------------------------------
 (PID.TID 0000.0001) 
  EXTERNAL_FIELDS_LOAD, it=     72000 : Reading new data, i0,i1=   12    1 (prev=   12    0 )
 (PID.TID 0000.0001) SOLVE_FOR_PRESSURE: putPmEinXvector =    F
- cg2d: Sum(rhs),rhsMax =  -9.66338120633736E-12  4.28293538426452E+00
- cg2d: Sum(rhs),rhsMax =  -9.57811607804615E-12  4.28169923834808E+00
- cg2d: Sum(rhs),rhsMax =  -9.46442924032453E-12  4.26963528989786E+00
- cg2d: Sum(rhs),rhsMax =  -9.89075488178059E-12  4.26825643505683E+00
- cg2d: Sum(rhs),rhsMax =  -9.83391146291979E-12  4.26314508222955E+00
+ cg2d: Sum(rhs),rhsMax =  -2.22399876292911E-12  4.28293538426452E+00
+ cg2d: Sum(rhs),rhsMax =  -2.25242047235952E-12  4.28169922325442E+00
+ cg2d: Sum(rhs),rhsMax =  -2.29505303650512E-12  4.26963528576028E+00
+ cg2d: Sum(rhs),rhsMax =  -2.33768560065073E-12  4.26825644185676E+00
+ cg2d: Sum(rhs),rhsMax =  -2.26663132707472E-12  4.26314509230660E+00
 (PID.TID 0000.0001) Did not write pickup because writePickupAtEnd = FALSE
 (PID.TID 0000.0001)   early fc =  0.000000000000000D+00
- --> objf_test(bi,bj)        =  0.112643372537197D+05
- --> objf_test(bi,bj)        =  0.925748325937274D+04
- --> objf_test(bi,bj)        =  0.646782341056008D+04
- --> objf_test(bi,bj)        =  0.425114891592850D+04
- --> objf_test(bi,bj)        =  0.468651159947307D+04
- --> objf_test(bi,bj)        =  0.131971832117306D+05
- --> objf_test(bi,bj)        =  0.111682590494812D+05
- --> objf_test(bi,bj)        =  0.109410446656234D+05
- --> objf_test(bi,bj)        =  0.691550498459337D+04
- --> objf_test(bi,bj)        =  0.683247680478209D+04
- --> objf_test(bi,bj)        =  0.520040324674087D+04
- --> objf_test(bi,bj)        =  0.606296259734182D+04
-(PID.TID 0000.0001)   local fc =  0.962451389993475D+05
-(PID.TID 0000.0001)  global fc =  0.962451389993475D+05
-(PID.TID 0000.0001) grdchk perturb(+)fc: fcpertplus  =  9.62451389993475E+04
+ --> objf_test(bi,bj)        =  0.112643372534519D+05
+ --> objf_test(bi,bj)        =  0.925748325927353D+04
+ --> objf_test(bi,bj)        =  0.646782341069408D+04
+ --> objf_test(bi,bj)        =  0.425114891598804D+04
+ --> objf_test(bi,bj)        =  0.468651159966980D+04
+ --> objf_test(bi,bj)        =  0.131971832121286D+05
+ --> objf_test(bi,bj)        =  0.111682590494886D+05
+ --> objf_test(bi,bj)        =  0.109410446654674D+05
+ --> objf_test(bi,bj)        =  0.691550498481766D+04
+ --> objf_test(bi,bj)        =  0.683247680465171D+04
+ --> objf_test(bi,bj)        =  0.520040324661009D+04
+ --> objf_test(bi,bj)        =  0.606296259735371D+04
+(PID.TID 0000.0001)   local fc =  0.962451389995951D+05
+(PID.TID 0000.0001)  global fc =  0.962451389995951D+05
+(PID.TID 0000.0001) grdchk perturb(+)fc: fcpertplus  =  9.62451389995951E+04
 (PID.TID 0000.0001)  nRecords = 123 ; filePrec =  64 ; fileIter =     72000
 (PID.TID 0000.0001)     nDims =   2 , dims:
 (PID.TID 0000.0001)    1: 192   1 192
@@ -3497,34 +3149,34 @@ grad-res -------------------------------
 (PID.TID 0000.0001) 
  EXTERNAL_FIELDS_LOAD, it=     72000 : Reading new data, i0,i1=   12    1 (prev=   12    0 )
 (PID.TID 0000.0001) SOLVE_FOR_PRESSURE: putPmEinXvector =    F
- cg2d: Sum(rhs),rhsMax =  -9.66338120633736E-12  4.28293538426452E+00
- cg2d: Sum(rhs),rhsMax =  -9.66338120633736E-12  4.28169923859646E+00
- cg2d: Sum(rhs),rhsMax =  -9.69180291576777E-12  4.26963529019077E+00
- cg2d: Sum(rhs),rhsMax =  -9.69180291576777E-12  4.26825643604795E+00
- cg2d: Sum(rhs),rhsMax =  -9.43600753089413E-12  4.26314508391993E+00
+ cg2d: Sum(rhs),rhsMax =  -2.21689333557151E-12  4.28293538426452E+00
+ cg2d: Sum(rhs),rhsMax =  -2.31636931857793E-12  4.28169922333961E+00
+ cg2d: Sum(rhs),rhsMax =  -2.27373675443232E-12  4.26963528614495E+00
+ cg2d: Sum(rhs),rhsMax =  -2.24531504500192E-12  4.26825644279558E+00
+ cg2d: Sum(rhs),rhsMax =  -2.23110419028671E-12  4.26314509397699E+00
 (PID.TID 0000.0001) Did not write pickup because writePickupAtEnd = FALSE
 (PID.TID 0000.0001)   early fc =  0.000000000000000D+00
- --> objf_test(bi,bj)        =  0.112642609186992D+05
- --> objf_test(bi,bj)        =  0.925748325909704D+04
- --> objf_test(bi,bj)        =  0.646782341073247D+04
- --> objf_test(bi,bj)        =  0.425114891596055D+04
- --> objf_test(bi,bj)        =  0.468651159948100D+04
- --> objf_test(bi,bj)        =  0.131971832118282D+05
- --> objf_test(bi,bj)        =  0.111682590495131D+05
- --> objf_test(bi,bj)        =  0.109410446655825D+05
- --> objf_test(bi,bj)        =  0.691550498451220D+04
- --> objf_test(bi,bj)        =  0.683247342113420D+04
- --> objf_test(bi,bj)        =  0.520040324663511D+04
- --> objf_test(bi,bj)        =  0.606295817145302D+04
-(PID.TID 0000.0001)   local fc =  0.962450548546287D+05
-(PID.TID 0000.0001)  global fc =  0.962450548546287D+05
-(PID.TID 0000.0001) grdchk perturb(-)fc: fcpertminus =  9.62450548546287E+04
+ --> objf_test(bi,bj)        =  0.112642609184597D+05
+ --> objf_test(bi,bj)        =  0.925748325899845D+04
+ --> objf_test(bi,bj)        =  0.646782341086739D+04
+ --> objf_test(bi,bj)        =  0.425114891601979D+04
+ --> objf_test(bi,bj)        =  0.468651159967785D+04
+ --> objf_test(bi,bj)        =  0.131971832122264D+05
+ --> objf_test(bi,bj)        =  0.111682590495205D+05
+ --> objf_test(bi,bj)        =  0.109410446654265D+05
+ --> objf_test(bi,bj)        =  0.691550498473716D+04
+ --> objf_test(bi,bj)        =  0.683247342100888D+04
+ --> objf_test(bi,bj)        =  0.520040324650437D+04
+ --> objf_test(bi,bj)        =  0.606295817142799D+04
+(PID.TID 0000.0001)   local fc =  0.962450548548750D+05
+(PID.TID 0000.0001)  global fc =  0.962450548548750D+05
+(PID.TID 0000.0001) grdchk perturb(-)fc: fcpertminus =  9.62450548548750E+04
 grad-res -------------------------------
- grad-res     0    1    1    1    1    1    1    1   9.62450968704E+04  9.62451389993E+04  9.62450548546E+04
- grad-res     0    1    1    1    0    1    1    1   4.20725615465E+00  4.20723593998E+00  4.80471770126E-06
-(PID.TID 0000.0001)  ADM  ref_cost_function      =  9.62450968703671E+04
-(PID.TID 0000.0001)  ADM  adjoint_gradient       =  4.20725615465348E+00
-(PID.TID 0000.0001)  ADM  finite-diff_grad       =  4.20723593997536E+00
+ grad-res     0    1    1    1    1    1    1    1   9.62450968706E+04  9.62451389996E+04  9.62450548549E+04
+ grad-res     0    1    1    1    0    1    1    1   4.20723634310E+00  4.20723600764E+00  7.97328384428E-08
+(PID.TID 0000.0001)  ADM  ref_cost_function      =  9.62450968706140E+04
+(PID.TID 0000.0001)  ADM  adjoint_gradient       =  4.20723634309666E+00
+(PID.TID 0000.0001)  ADM  finite-diff_grad       =  4.20723600764177E+00
 (PID.TID 0000.0001) ====== End of gradient-check number   1 (ierr=  0) =======
 (PID.TID 0000.0001) ====== Starts gradient-check number   2 (=ichknum) =======
  ph-test icomp, ncvarcomp, ichknum            2       55522           2
@@ -3555,28 +3207,28 @@ grad-res -------------------------------
 (PID.TID 0000.0001) 
  EXTERNAL_FIELDS_LOAD, it=     72000 : Reading new data, i0,i1=   12    1 (prev=   12    0 )
 (PID.TID 0000.0001) SOLVE_FOR_PRESSURE: putPmEinXvector =    F
- cg2d: Sum(rhs),rhsMax =  -9.69180291576777E-12  4.28293538426452E+00
- cg2d: Sum(rhs),rhsMax =  -9.63495949690696E-12  4.28169923848898E+00
- cg2d: Sum(rhs),rhsMax =  -9.69180291576777E-12  4.26963528967151E+00
- cg2d: Sum(rhs),rhsMax =  -9.49285094975494E-12  4.26825643475361E+00
- cg2d: Sum(rhs),rhsMax =  -9.72022462519817E-12  4.26314508164779E+00
+ cg2d: Sum(rhs),rhsMax =  -2.21689333557151E-12  4.28293538426452E+00
+ cg2d: Sum(rhs),rhsMax =  -2.26663132707472E-12  4.28169922322913E+00
+ cg2d: Sum(rhs),rhsMax =  -2.21689333557151E-12  4.26963528562166E+00
+ cg2d: Sum(rhs),rhsMax =  -2.22399876292911E-12  4.26825644151318E+00
+ cg2d: Sum(rhs),rhsMax =  -2.20978790821391E-12  4.26314509169905E+00
 (PID.TID 0000.0001) Did not write pickup because writePickupAtEnd = FALSE
 (PID.TID 0000.0001)   early fc =  0.000000000000000D+00
- --> objf_test(bi,bj)        =  0.112643378706429D+05
- --> objf_test(bi,bj)        =  0.925748325947092D+04
- --> objf_test(bi,bj)        =  0.646782341049779D+04
- --> objf_test(bi,bj)        =  0.425114891591706D+04
- --> objf_test(bi,bj)        =  0.468651159946984D+04
- --> objf_test(bi,bj)        =  0.131971832116948D+05
- --> objf_test(bi,bj)        =  0.111682590494701D+05
- --> objf_test(bi,bj)        =  0.109410446656374D+05
- --> objf_test(bi,bj)        =  0.691550498462186D+04
- --> objf_test(bi,bj)        =  0.683247522814915D+04
- --> objf_test(bi,bj)        =  0.520040324677840D+04
- --> objf_test(bi,bj)        =  0.606296159023752D+04
-(PID.TID 0000.0001)   local fc =  0.962451370325877D+05
-(PID.TID 0000.0001)  global fc =  0.962451370325877D+05
-(PID.TID 0000.0001) grdchk perturb(+)fc: fcpertplus  =  9.62451370325877E+04
+ --> objf_test(bi,bj)        =  0.112643378703818D+05
+ --> objf_test(bi,bj)        =  0.925748325937043D+04
+ --> objf_test(bi,bj)        =  0.646782341063206D+04
+ --> objf_test(bi,bj)        =  0.425114891597667D+04
+ --> objf_test(bi,bj)        =  0.468651159966679D+04
+ --> objf_test(bi,bj)        =  0.131971832120929D+05
+ --> objf_test(bi,bj)        =  0.111682590494772D+05
+ --> objf_test(bi,bj)        =  0.109410446654817D+05
+ --> objf_test(bi,bj)        =  0.691550498484629D+04
+ --> objf_test(bi,bj)        =  0.683247522802557D+04
+ --> objf_test(bi,bj)        =  0.520040324664761D+04
+ --> objf_test(bi,bj)        =  0.606296159023828D+04
+(PID.TID 0000.0001)   local fc =  0.962451370328374D+05
+(PID.TID 0000.0001)  global fc =  0.962451370328374D+05
+(PID.TID 0000.0001) grdchk perturb(+)fc: fcpertplus  =  9.62451370328374E+04
 (PID.TID 0000.0001)  nRecords = 123 ; filePrec =  64 ; fileIter =     72000
 (PID.TID 0000.0001)     nDims =   2 , dims:
 (PID.TID 0000.0001)    1: 192   1 192
@@ -3601,34 +3253,34 @@ grad-res -------------------------------
 (PID.TID 0000.0001) 
  EXTERNAL_FIELDS_LOAD, it=     72000 : Reading new data, i0,i1=   12    1 (prev=   12    0 )
 (PID.TID 0000.0001) SOLVE_FOR_PRESSURE: putPmEinXvector =    F
- cg2d: Sum(rhs),rhsMax =  -9.63495949690696E-12  4.28293538426452E+00
- cg2d: Sum(rhs),rhsMax =  -9.63495949690696E-12  4.28169923845654E+00
- cg2d: Sum(rhs),rhsMax =  -9.54969436861575E-12  4.26963529041537E+00
- cg2d: Sum(rhs),rhsMax =  -9.72022462519817E-12  4.26825643635290E+00
- cg2d: Sum(rhs),rhsMax =  -9.74864633462857E-12  4.26314508450758E+00
+ cg2d: Sum(rhs),rhsMax =  -2.21689333557151E-12  4.28293538426452E+00
+ cg2d: Sum(rhs),rhsMax =  -2.20268248085631E-12  4.28169922336588E+00
+ cg2d: Sum(rhs),rhsMax =  -2.28084218178992E-12  4.26963528628581E+00
+ cg2d: Sum(rhs),rhsMax =  -2.22399876292911E-12  4.26825644314091E+00
+ cg2d: Sum(rhs),rhsMax =  -2.25242047235952E-12  4.26314509458705E+00
 (PID.TID 0000.0001) Did not write pickup because writePickupAtEnd = FALSE
 (PID.TID 0000.0001)   early fc =  0.000000000000000D+00
- --> objf_test(bi,bj)        =  0.112642603170864D+05
- --> objf_test(bi,bj)        =  0.925748325899883D+04
- --> objf_test(bi,bj)        =  0.646782341079480D+04
- --> objf_test(bi,bj)        =  0.425114891597197D+04
- --> objf_test(bi,bj)        =  0.468651159948426D+04
- --> objf_test(bi,bj)        =  0.131971832118641D+05
- --> objf_test(bi,bj)        =  0.111682590495243D+05
- --> objf_test(bi,bj)        =  0.109410446655686D+05
- --> objf_test(bi,bj)        =  0.691550498448368D+04
- --> objf_test(bi,bj)        =  0.683247499554683D+04
- --> objf_test(bi,bj)        =  0.520040324659764D+04
- --> objf_test(bi,bj)        =  0.606295917753553D+04
-(PID.TID 0000.0001)   local fc =  0.962450568334570D+05
-(PID.TID 0000.0001)  global fc =  0.962450568334570D+05
-(PID.TID 0000.0001) grdchk perturb(-)fc: fcpertminus =  9.62450568334570E+04
+ --> objf_test(bi,bj)        =  0.112642603168408D+05
+ --> objf_test(bi,bj)        =  0.925748325890166D+04
+ --> objf_test(bi,bj)        =  0.646782341092942D+04
+ --> objf_test(bi,bj)        =  0.425114891603114D+04
+ --> objf_test(bi,bj)        =  0.468651159968083D+04
+ --> objf_test(bi,bj)        =  0.131971832122620D+05
+ --> objf_test(bi,bj)        =  0.111682590495320D+05
+ --> objf_test(bi,bj)        =  0.109410446654122D+05
+ --> objf_test(bi,bj)        =  0.691550498470853D+04
+ --> objf_test(bi,bj)        =  0.683247499541433D+04
+ --> objf_test(bi,bj)        =  0.520040324646685D+04
+ --> objf_test(bi,bj)        =  0.606295917752177D+04
+(PID.TID 0000.0001)   local fc =  0.962450568337015D+05
+(PID.TID 0000.0001)  global fc =  0.962450568337015D+05
+(PID.TID 0000.0001) grdchk perturb(-)fc: fcpertminus =  9.62450568337015E+04
 grad-res -------------------------------
- grad-res     0    2    2    1    1    1    1    1   9.62450968704E+04  9.62451370326E+04  9.62450568335E+04
- grad-res     0    2    2    2    0    1    1    1   4.00967431021E+00  4.00995653617E+00 -7.03862575169E-05
-(PID.TID 0000.0001)  ADM  ref_cost_function      =  9.62450968703671E+04
-(PID.TID 0000.0001)  ADM  adjoint_gradient       =  4.00967431020573E+00
-(PID.TID 0000.0001)  ADM  finite-diff_grad       =  4.00995653617429E+00
+ grad-res     0    2    2    1    1    1    1    1   9.62450968706E+04  9.62451370328E+04  9.62450568337E+04
+ grad-res     0    2    2    2    0    1    1    1   4.00969551982E+00  4.00995679374E+00 -6.51605395574E-05
+(PID.TID 0000.0001)  ADM  ref_cost_function      =  9.62450968706140E+04
+(PID.TID 0000.0001)  ADM  adjoint_gradient       =  4.00969551981965E+00
+(PID.TID 0000.0001)  ADM  finite-diff_grad       =  4.00995679374319E+00
 (PID.TID 0000.0001) ====== End of gradient-check number   2 (ierr=  0) =======
 (PID.TID 0000.0001) ====== Starts gradient-check number   3 (=ichknum) =======
  ph-test icomp, ncvarcomp, ichknum            3       55522           3
@@ -3659,28 +3311,28 @@ grad-res -------------------------------
 (PID.TID 0000.0001) 
  EXTERNAL_FIELDS_LOAD, it=     72000 : Reading new data, i0,i1=   12    1 (prev=   12    0 )
 (PID.TID 0000.0001) SOLVE_FOR_PRESSURE: putPmEinXvector =    F
- cg2d: Sum(rhs),rhsMax =  -9.63495949690696E-12  4.28293538426452E+00
- cg2d: Sum(rhs),rhsMax =  -9.57811607804615E-12  4.28169923834804E+00
- cg2d: Sum(rhs),rhsMax =  -9.80548975348938E-12  4.26963528960830E+00
- cg2d: Sum(rhs),rhsMax =  -9.89075488178059E-12  4.26825643444512E+00
- cg2d: Sum(rhs),rhsMax =  -9.74864633462857E-12  4.26314508111679E+00
+ cg2d: Sum(rhs),rhsMax =  -2.21689333557151E-12  4.28293538426452E+00
+ cg2d: Sum(rhs),rhsMax =  -2.30215846386272E-12  4.28169922320049E+00
+ cg2d: Sum(rhs),rhsMax =  -2.28794760914752E-12  4.26963528550473E+00
+ cg2d: Sum(rhs),rhsMax =  -2.29505303650512E-12  4.26825644122350E+00
+ cg2d: Sum(rhs),rhsMax =  -2.28794760914752E-12  4.26314509118641E+00
 (PID.TID 0000.0001) Did not write pickup because writePickupAtEnd = FALSE
 (PID.TID 0000.0001)   early fc =  0.000000000000000D+00
- --> objf_test(bi,bj)        =  0.112643321737231D+05
- --> objf_test(bi,bj)        =  0.925748325954393D+04
- --> objf_test(bi,bj)        =  0.646782341044705D+04
- --> objf_test(bi,bj)        =  0.425114891590794D+04
- --> objf_test(bi,bj)        =  0.468651159946771D+04
- --> objf_test(bi,bj)        =  0.131971832116658D+05
- --> objf_test(bi,bj)        =  0.111682590494606D+05
- --> objf_test(bi,bj)        =  0.109410446656495D+05
- --> objf_test(bi,bj)        =  0.691550498464398D+04
- --> objf_test(bi,bj)        =  0.683247511589005D+04
- --> objf_test(bi,bj)        =  0.520040324680865D+04
- --> objf_test(bi,bj)        =  0.606296088558872D+04
-(PID.TID 0000.0001)   local fc =  0.962451305187970D+05
-(PID.TID 0000.0001)  global fc =  0.962451305187970D+05
-(PID.TID 0000.0001) grdchk perturb(+)fc: fcpertplus  =  9.62451305187970E+04
+ --> objf_test(bi,bj)        =  0.112643321734692D+05
+ --> objf_test(bi,bj)        =  0.925748325944748D+04
+ --> objf_test(bi,bj)        =  0.646782341058179D+04
+ --> objf_test(bi,bj)        =  0.425114891596741D+04
+ --> objf_test(bi,bj)        =  0.468651159966445D+04
+ --> objf_test(bi,bj)        =  0.131971832120639D+05
+ --> objf_test(bi,bj)        =  0.111682590494679D+05
+ --> objf_test(bi,bj)        =  0.109410446654931D+05
+ --> objf_test(bi,bj)        =  0.691550498486921D+04
+ --> objf_test(bi,bj)        =  0.683247511576356D+04
+ --> objf_test(bi,bj)        =  0.520040324667783D+04
+ --> objf_test(bi,bj)        =  0.606296088557794D+04
+(PID.TID 0000.0001)   local fc =  0.962451305190438D+05
+(PID.TID 0000.0001)  global fc =  0.962451305190438D+05
+(PID.TID 0000.0001) grdchk perturb(+)fc: fcpertplus  =  9.62451305190438E+04
 (PID.TID 0000.0001)  nRecords = 123 ; filePrec =  64 ; fileIter =     72000
 (PID.TID 0000.0001)     nDims =   2 , dims:
 (PID.TID 0000.0001)    1: 192   1 192
@@ -3705,34 +3357,34 @@ grad-res -------------------------------
 (PID.TID 0000.0001) 
  EXTERNAL_FIELDS_LOAD, it=     72000 : Reading new data, i0,i1=   12    1 (prev=   12    0 )
 (PID.TID 0000.0001) SOLVE_FOR_PRESSURE: putPmEinXvector =    F
- cg2d: Sum(rhs),rhsMax =  -9.66338120633736E-12  4.28293538426452E+00
- cg2d: Sum(rhs),rhsMax =  -9.86233317235019E-12  4.28169923859372E+00
- cg2d: Sum(rhs),rhsMax =  -9.72022462519817E-12  4.26963529048258E+00
- cg2d: Sum(rhs),rhsMax =  -9.46442924032453E-12  4.26825643666237E+00
- cg2d: Sum(rhs),rhsMax =  -9.63495949690696E-12  4.26314508503709E+00
+ cg2d: Sum(rhs),rhsMax =  -2.20978790821391E-12  4.28293538426452E+00
+ cg2d: Sum(rhs),rhsMax =  -2.26663132707472E-12  4.28169922339221E+00
+ cg2d: Sum(rhs),rhsMax =  -2.25952589971712E-12  4.26963528640128E+00
+ cg2d: Sum(rhs),rhsMax =  -2.30215846386272E-12  4.26825644343336E+00
+ cg2d: Sum(rhs),rhsMax =  -2.30926389122033E-12  4.26314509509832E+00
 (PID.TID 0000.0001) Did not write pickup because writePickupAtEnd = FALSE
 (PID.TID 0000.0001)   early fc =  0.000000000000000D+00
- --> objf_test(bi,bj)        =  0.112642660210549D+05
- --> objf_test(bi,bj)        =  0.925748325892583D+04
- --> objf_test(bi,bj)        =  0.646782341084554D+04
- --> objf_test(bi,bj)        =  0.425114891598100D+04
- --> objf_test(bi,bj)        =  0.468651159948632D+04
- --> objf_test(bi,bj)        =  0.131971832118930D+05
- --> objf_test(bi,bj)        =  0.111682590495339D+05
- --> objf_test(bi,bj)        =  0.109410446655564D+05
- --> objf_test(bi,bj)        =  0.691550498446156D+04
- --> objf_test(bi,bj)        =  0.683247510776259D+04
- --> objf_test(bi,bj)        =  0.520040324656738D+04
- --> objf_test(bi,bj)        =  0.606295988160210D+04
-(PID.TID 0000.0001)   local fc =  0.962450633536705D+05
-(PID.TID 0000.0001)  global fc =  0.962450633536705D+05
-(PID.TID 0000.0001) grdchk perturb(-)fc: fcpertminus =  9.62450633536705E+04
+ --> objf_test(bi,bj)        =  0.112642660208022D+05
+ --> objf_test(bi,bj)        =  0.925748325882465D+04
+ --> objf_test(bi,bj)        =  0.646782341097970D+04
+ --> objf_test(bi,bj)        =  0.425114891604042D+04
+ --> objf_test(bi,bj)        =  0.468651159968322D+04
+ --> objf_test(bi,bj)        =  0.131971832122910D+05
+ --> objf_test(bi,bj)        =  0.111682590495412D+05
+ --> objf_test(bi,bj)        =  0.109410446654009D+05
+ --> objf_test(bi,bj)        =  0.691550498468562D+04
+ --> objf_test(bi,bj)        =  0.683247510763294D+04
+ --> objf_test(bi,bj)        =  0.520040324643669D+04
+ --> objf_test(bi,bj)        =  0.606295988159984D+04
+(PID.TID 0000.0001)   local fc =  0.962450633539184D+05
+(PID.TID 0000.0001)  global fc =  0.962450633539184D+05
+(PID.TID 0000.0001) grdchk perturb(-)fc: fcpertminus =  9.62450633539184E+04
 grad-res -------------------------------
- grad-res     0    3    3    1    1    1    1    1   9.62450968704E+04  9.62451305188E+04  9.62450633537E+04
- grad-res     0    3    3    3    0    1    1    1   3.35835980953E+00  3.35825632210E+00  3.08148726688E-05
-(PID.TID 0000.0001)  ADM  ref_cost_function      =  9.62450968703671E+04
-(PID.TID 0000.0001)  ADM  adjoint_gradient       =  3.35835980952880E+00
-(PID.TID 0000.0001)  ADM  finite-diff_grad       =  3.35825632209890E+00
+ grad-res     0    3    3    1    1    1    1    1   9.62450968706E+04  9.62451305190E+04  9.62450633539E+04
+ grad-res     0    3    3    3    0    1    1    1   3.35834410255E+00  3.35825627044E+00  2.61533990019E-05
+(PID.TID 0000.0001)  ADM  ref_cost_function      =  9.62450968706140E+04
+(PID.TID 0000.0001)  ADM  adjoint_gradient       =  3.35834410255290E+00
+(PID.TID 0000.0001)  ADM  finite-diff_grad       =  3.35825627043960E+00
 (PID.TID 0000.0001) ====== End of gradient-check number   3 (ierr=  0) =======
 (PID.TID 0000.0001) ====== Starts gradient-check number   4 (=ichknum) =======
  ph-test icomp, ncvarcomp, ichknum            4       55522           4
@@ -3763,28 +3415,28 @@ grad-res -------------------------------
 (PID.TID 0000.0001) 
  EXTERNAL_FIELDS_LOAD, it=     72000 : Reading new data, i0,i1=   12    1 (prev=   12    0 )
 (PID.TID 0000.0001) SOLVE_FOR_PRESSURE: putPmEinXvector =    F
- cg2d: Sum(rhs),rhsMax =  -9.66338120633736E-12  4.28293538426452E+00
- cg2d: Sum(rhs),rhsMax =  -9.77706804405898E-12  4.28169923829328E+00
- cg2d: Sum(rhs),rhsMax =  -9.52127265918534E-12  4.26963528952197E+00
- cg2d: Sum(rhs),rhsMax =  -9.37916411203332E-12  4.26825643418973E+00
- cg2d: Sum(rhs),rhsMax =  -9.66338120633736E-12  4.26314508067312E+00
+ cg2d: Sum(rhs),rhsMax =  -2.20978790821391E-12  4.28293538426452E+00
+ cg2d: Sum(rhs),rhsMax =  -2.18847162614111E-12  4.28169922318012E+00
+ cg2d: Sum(rhs),rhsMax =  -2.25242047235952E-12  4.26963528540275E+00
+ cg2d: Sum(rhs),rhsMax =  -2.18136619878351E-12  4.26825644096946E+00
+ cg2d: Sum(rhs),rhsMax =  -2.33058017329313E-12  4.26314509074228E+00
 (PID.TID 0000.0001) Did not write pickup because writePickupAtEnd = FALSE
 (PID.TID 0000.0001)   early fc =  0.000000000000000D+00
- --> objf_test(bi,bj)        =  0.112643265415474D+05
- --> objf_test(bi,bj)        =  0.925748325960757D+04
- --> objf_test(bi,bj)        =  0.646782341040589D+04
- --> objf_test(bi,bj)        =  0.425114891590007D+04
- --> objf_test(bi,bj)        =  0.468651159946554D+04
- --> objf_test(bi,bj)        =  0.131971832116433D+05
- --> objf_test(bi,bj)        =  0.111682590494530D+05
- --> objf_test(bi,bj)        =  0.109410446656582D+05
- --> objf_test(bi,bj)        =  0.691550498466291D+04
- --> objf_test(bi,bj)        =  0.683247511172393D+04
- --> objf_test(bi,bj)        =  0.520040324683352D+04
- --> objf_test(bi,bj)        =  0.606296053020935D+04
-(PID.TID 0000.0001)   local fc =  0.962451245271106D+05
-(PID.TID 0000.0001)  global fc =  0.962451245271106D+05
-(PID.TID 0000.0001) grdchk perturb(+)fc: fcpertplus  =  9.62451245271106E+04
+ --> objf_test(bi,bj)        =  0.112643265412939D+05
+ --> objf_test(bi,bj)        =  0.925748325950641D+04
+ --> objf_test(bi,bj)        =  0.646782341054113D+04
+ --> objf_test(bi,bj)        =  0.425114891595962D+04
+ --> objf_test(bi,bj)        =  0.468651159966253D+04
+ --> objf_test(bi,bj)        =  0.131971832120415D+05
+ --> objf_test(bi,bj)        =  0.111682590494601D+05
+ --> objf_test(bi,bj)        =  0.109410446655023D+05
+ --> objf_test(bi,bj)        =  0.691550498488761D+04
+ --> objf_test(bi,bj)        =  0.683247511159254D+04
+ --> objf_test(bi,bj)        =  0.520040324670281D+04
+ --> objf_test(bi,bj)        =  0.606296053020470D+04
+(PID.TID 0000.0001)   local fc =  0.962451245273551D+05
+(PID.TID 0000.0001)  global fc =  0.962451245273551D+05
+(PID.TID 0000.0001) grdchk perturb(+)fc: fcpertplus  =  9.62451245273551E+04
 (PID.TID 0000.0001)  nRecords = 123 ; filePrec =  64 ; fileIter =     72000
 (PID.TID 0000.0001)     nDims =   2 , dims:
 (PID.TID 0000.0001)    1: 192   1 192
@@ -3809,246 +3461,246 @@ grad-res -------------------------------
 (PID.TID 0000.0001) 
  EXTERNAL_FIELDS_LOAD, it=     72000 : Reading new data, i0,i1=   12    1 (prev=   12    0 )
 (PID.TID 0000.0001) SOLVE_FOR_PRESSURE: putPmEinXvector =    F
- cg2d: Sum(rhs),rhsMax =  -9.63495949690696E-12  4.28293538426452E+00
- cg2d: Sum(rhs),rhsMax =  -9.63495949690696E-12  4.28169923864340E+00
- cg2d: Sum(rhs),rhsMax =  -9.72022462519817E-12  4.26963529056705E+00
- cg2d: Sum(rhs),rhsMax =  -9.69180291576777E-12  4.26825643691576E+00
- cg2d: Sum(rhs),rhsMax =  -9.37916411203332E-12  4.26314508548041E+00
+ cg2d: Sum(rhs),rhsMax =  -2.21689333557151E-12  4.28293538426452E+00
+ cg2d: Sum(rhs),rhsMax =  -2.20978790821391E-12  4.28169922341550E+00
+ cg2d: Sum(rhs),rhsMax =  -2.24531504500192E-12  4.26963528650579E+00
+ cg2d: Sum(rhs),rhsMax =  -2.25952589971712E-12  4.26825644368494E+00
+ cg2d: Sum(rhs),rhsMax =  -2.30215846386272E-12  4.26314509554344E+00
 (PID.TID 0000.0001) Did not write pickup because writePickupAtEnd = FALSE
 (PID.TID 0000.0001)   early fc =  0.000000000000000D+00
- --> objf_test(bi,bj)        =  0.112642716549200D+05
- --> objf_test(bi,bj)        =  0.925748325886229D+04
- --> objf_test(bi,bj)        =  0.646782341088669D+04
- --> objf_test(bi,bj)        =  0.425114891598887D+04
- --> objf_test(bi,bj)        =  0.468651159948860D+04
- --> objf_test(bi,bj)        =  0.131971832119155D+05
- --> objf_test(bi,bj)        =  0.111682590495416D+05
- --> objf_test(bi,bj)        =  0.109410446655477D+05
- --> objf_test(bi,bj)        =  0.691550498444261D+04
- --> objf_test(bi,bj)        =  0.683247511192761D+04
- --> objf_test(bi,bj)        =  0.520040324654252D+04
- --> objf_test(bi,bj)        =  0.606296023664371D+04
-(PID.TID 0000.0001)   local fc =  0.962450693467077D+05
-(PID.TID 0000.0001)  global fc =  0.962450693467077D+05
-(PID.TID 0000.0001) grdchk perturb(-)fc: fcpertminus =  9.62450693467077E+04
+ --> objf_test(bi,bj)        =  0.112642716546664D+05
+ --> objf_test(bi,bj)        =  0.925748325876570D+04
+ --> objf_test(bi,bj)        =  0.646782341102032D+04
+ --> objf_test(bi,bj)        =  0.425114891604817D+04
+ --> objf_test(bi,bj)        =  0.468651159968515D+04
+ --> objf_test(bi,bj)        =  0.131971832123136D+05
+ --> objf_test(bi,bj)        =  0.111682590495491D+05
+ --> objf_test(bi,bj)        =  0.109410446653917D+05
+ --> objf_test(bi,bj)        =  0.691550498466722D+04
+ --> objf_test(bi,bj)        =  0.683247511180293D+04
+ --> objf_test(bi,bj)        =  0.520040324641172D+04
+ --> objf_test(bi,bj)        =  0.606296023663539D+04
+(PID.TID 0000.0001)   local fc =  0.962450693469574D+05
+(PID.TID 0000.0001)  global fc =  0.962450693469574D+05
+(PID.TID 0000.0001) grdchk perturb(-)fc: fcpertminus =  9.62450693469574E+04
 grad-res -------------------------------
- grad-res     0    4    4    1    1    1    1    1   9.62450968704E+04  9.62451245271E+04  9.62450693467E+04
- grad-res     0    4    4    4    0    1    1    1   2.75902173719E+00  2.75902014619E+00  5.76655439732E-07
-(PID.TID 0000.0001)  ADM  ref_cost_function      =  9.62450968703671E+04
-(PID.TID 0000.0001)  ADM  adjoint_gradient       =  2.75902173719112E+00
-(PID.TID 0000.0001)  ADM  finite-diff_grad       =  2.75902014618623E+00
+ grad-res     0    4    4    1    1    1    1    1   9.62450968706E+04  9.62451245274E+04  9.62450693470E+04
+ grad-res     0    4    4    4    0    1    1    1   2.75901943582E+00  2.75901988498E+00 -1.62797432646E-07
+(PID.TID 0000.0001)  ADM  ref_cost_function      =  9.62450968706140E+04
+(PID.TID 0000.0001)  ADM  adjoint_gradient       =  2.75901943581807E+00
+(PID.TID 0000.0001)  ADM  finite-diff_grad       =  2.75901988497935E+00
 (PID.TID 0000.0001) ====== End of gradient-check number   4 (ierr=  0) =======
 (PID.TID 0000.0001) 
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // Gradient check results  >>> START <<<
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) 
-(PID.TID 0000.0001)  EPS =   1.000000E-02
+(PID.TID 0000.0001)  EPS = 1.000000E-02 ; grdchk CTRL var/file name: "xx_theta"
 (PID.TID 0000.0001) 
 (PID.TID 0000.0001) grdchk output h.p:  Id Itile Jtile LAYER   bi   bj   X(Id)           X(Id)+/-EPS
 (PID.TID 0000.0001) grdchk output h.c:  Id  FC                   FC1                  FC2
 (PID.TID 0000.0001) grdchk output h.g:  Id     FC1-FC2/(2*EPS)      ADJ GRAD(FC)         1-FDGRD/ADGRD
 (PID.TID 0000.0001) 
 (PID.TID 0000.0001) grdchk output (p):   1     1     1     1    1    1   0.000000000E+00 -1.000000000E-02
-(PID.TID 0000.0001) grdchk output (c):   1  9.6245096870367E+04  9.6245138999347E+04  9.6245054854629E+04
-(PID.TID 0000.0001) grdchk output (g):   1     4.2072359399754E+00  4.2072561546535E+00  4.8047177012567E-06
+(PID.TID 0000.0001) grdchk output (c):   1  9.6245096870614E+04  9.6245138999595E+04  9.6245054854875E+04
+(PID.TID 0000.0001) grdchk output (g):   1     4.2072360076418E+00  4.2072363430967E+00  7.9732838442759E-08
 (PID.TID 0000.0001) 
 (PID.TID 0000.0001) grdchk output (p):   2     2     1     1    1    1   0.000000000E+00 -1.000000000E-02
-(PID.TID 0000.0001) grdchk output (c):   2  9.6245096870367E+04  9.6245137032588E+04  9.6245056833457E+04
-(PID.TID 0000.0001) grdchk output (g):   2     4.0099565361743E+00  4.0096743102057E+00 -7.0386257516875E-05
+(PID.TID 0000.0001) grdchk output (c):   2  9.6245096870614E+04  9.6245137032837E+04  9.6245056833701E+04
+(PID.TID 0000.0001) grdchk output (g):   2     4.0099567937432E+00  4.0096955198197E+00 -6.5160539557407E-05
 (PID.TID 0000.0001) 
 (PID.TID 0000.0001) grdchk output (p):   3     3     1     1    1    1   0.000000000E+00 -1.000000000E-02
-(PID.TID 0000.0001) grdchk output (c):   3  9.6245096870367E+04  9.6245130518797E+04  9.6245063353671E+04
-(PID.TID 0000.0001) grdchk output (g):   3     3.3582563220989E+00  3.3583598095288E+00  3.0814872668761E-05
+(PID.TID 0000.0001) grdchk output (c):   3  9.6245096870614E+04  9.6245130519044E+04  9.6245063353918E+04
+(PID.TID 0000.0001) grdchk output (g):   3     3.3582562704396E+00  3.3583441025529E+00  2.6153399001916E-05
 (PID.TID 0000.0001) 
 (PID.TID 0000.0001) grdchk output (p):   4     4     1     1    1    1   0.000000000E+00 -1.000000000E-02
-(PID.TID 0000.0001) grdchk output (c):   4  9.6245096870367E+04  9.6245124527111E+04  9.6245069346708E+04
-(PID.TID 0000.0001) grdchk output (g):   4     2.7590201461862E+00  2.7590217371911E+00  5.7665543973240E-07
+(PID.TID 0000.0001) grdchk output (c):   4  9.6245096870614E+04  9.6245124527355E+04  9.6245069346957E+04
+(PID.TID 0000.0001) grdchk output (g):   4     2.7590198849794E+00  2.7590194358181E+00 -1.6279743264569E-07
 (PID.TID 0000.0001) 
-(PID.TID 0000.0001) grdchk  summary  :  RMS of    4 ratios =  3.8494153674645E-05
+(PID.TID 0000.0001) grdchk  summary  :  RMS of    4 ratios =  3.5106726759609E-05
 (PID.TID 0000.0001) 
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // Gradient check results  >>> END <<<
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) 
 (PID.TID 0000.0001)   Seconds in section "ALL                    [THE_MODEL_MAIN]":
-(PID.TID 0000.0001)           User time:   44.271581887034699
-(PID.TID 0000.0001)         System time:   5.2107550103683025
-(PID.TID 0000.0001)     Wall clock time:   49.748782873153687
+(PID.TID 0000.0001)           User time:   36.647155846003443
+(PID.TID 0000.0001)         System time:   1.0460239944513887
+(PID.TID 0000.0001)     Wall clock time:   38.453982114791870
 (PID.TID 0000.0001)          No. starts:           1
 (PID.TID 0000.0001)           No. stops:           1
 (PID.TID 0000.0001)   Seconds in section "INITIALISE_FIXED       [THE_MODEL_MAIN]":
-(PID.TID 0000.0001)           User time:  0.13248999323695898
-(PID.TID 0000.0001)         System time:   3.8562999572604895E-002
-(PID.TID 0000.0001)     Wall clock time:  0.17261886596679688
+(PID.TID 0000.0001)           User time:  0.11545300250872970
+(PID.TID 0000.0001)         System time:   3.2693999819457531E-002
+(PID.TID 0000.0001)     Wall clock time:  0.15153098106384277
 (PID.TID 0000.0001)          No. starts:           1
 (PID.TID 0000.0001)           No. stops:           1
 (PID.TID 0000.0001)   Seconds in section "FORWARD_STEP        [MAIN_DO_LOOP]":
-(PID.TID 0000.0001)           User time:   23.874220162630081
-(PID.TID 0000.0001)         System time:   2.1126039326190948E-002
-(PID.TID 0000.0001)     Wall clock time:   23.961232662200928
+(PID.TID 0000.0001)           User time:   19.931664377450943
+(PID.TID 0000.0001)         System time:   1.4583051204681396E-002
+(PID.TID 0000.0001)     Wall clock time:   20.054046630859375
 (PID.TID 0000.0001)          No. starts:          50
 (PID.TID 0000.0001)           No. stops:          50
 (PID.TID 0000.0001)   Seconds in section "UPDATE_R_STAR       [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:  0.74604144692420959
-(PID.TID 0000.0001)         System time:   2.2652745246887207E-004
-(PID.TID 0000.0001)     Wall clock time:  0.74895954132080078
+(PID.TID 0000.0001)           User time:  0.55463027954101562
+(PID.TID 0000.0001)         System time:   2.8888881206512451E-004
+(PID.TID 0000.0001)     Wall clock time:  0.55870771408081055
 (PID.TID 0000.0001)          No. starts:         110
 (PID.TID 0000.0001)           No. stops:         110
 (PID.TID 0000.0001)   Seconds in section "DO_STATEVARS_DIAGS  [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:   5.0896644592285156E-002
-(PID.TID 0000.0001)         System time:   1.5005469322204590E-005
-(PID.TID 0000.0001)     Wall clock time:   5.1221370697021484E-002
+(PID.TID 0000.0001)           User time:   4.1595906019210815E-002
+(PID.TID 0000.0001)         System time:   4.7102570533752441E-004
+(PID.TID 0000.0001)     Wall clock time:   4.2325019836425781E-002
 (PID.TID 0000.0001)          No. starts:          15
 (PID.TID 0000.0001)           No. stops:          15
 (PID.TID 0000.0001)   Seconds in section "LOAD_FIELDS_DRIVER  [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:  0.12058961391448975
-(PID.TID 0000.0001)         System time:   3.7428736686706543E-003
-(PID.TID 0000.0001)     Wall clock time:  0.12490391731262207
+(PID.TID 0000.0001)           User time:   9.8501563072204590E-002
+(PID.TID 0000.0001)         System time:   3.8000643253326416E-003
+(PID.TID 0000.0001)     Wall clock time:  0.10381650924682617
 (PID.TID 0000.0001)          No. starts:          55
 (PID.TID 0000.0001)           No. stops:          55
 (PID.TID 0000.0001)   Seconds in section "EXTERNAL_FLDS_LOAD [LOAD_FLDS_DRIVER]":
-(PID.TID 0000.0001)           User time:   8.2373797893524170E-002
-(PID.TID 0000.0001)         System time:   2.6937946677207947E-003
-(PID.TID 0000.0001)     Wall clock time:   8.5491180419921875E-002
+(PID.TID 0000.0001)           User time:   6.4925074577331543E-002
+(PID.TID 0000.0001)         System time:   2.8409808874130249E-003
+(PID.TID 0000.0001)     Wall clock time:   6.9089412689208984E-002
 (PID.TID 0000.0001)          No. starts:          60
 (PID.TID 0000.0001)           No. stops:          60
 (PID.TID 0000.0001)   Seconds in section "CTRL_MAP_FORCING  [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:  0.17227721214294434
-(PID.TID 0000.0001)         System time:   6.2694400548934937E-004
-(PID.TID 0000.0001)     Wall clock time:  0.17349219322204590
+(PID.TID 0000.0001)           User time:  0.16588956117630005
+(PID.TID 0000.0001)         System time:   1.1108815670013428E-004
+(PID.TID 0000.0001)     Wall clock time:  0.16761445999145508
 (PID.TID 0000.0001)          No. starts:          55
 (PID.TID 0000.0001)           No. stops:          55
 (PID.TID 0000.0001)   Seconds in section "DO_ATMOSPHERIC_PHYS [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:   2.7062475681304932E-002
-(PID.TID 0000.0001)         System time:   2.5796890258789062E-004
-(PID.TID 0000.0001)     Wall clock time:   2.7425289154052734E-002
+(PID.TID 0000.0001)           User time:   2.4696111679077148E-002
+(PID.TID 0000.0001)         System time:   1.4498829841613770E-004
+(PID.TID 0000.0001)     Wall clock time:   2.4963855743408203E-002
 (PID.TID 0000.0001)          No. starts:          55
 (PID.TID 0000.0001)           No. stops:          55
 (PID.TID 0000.0001)   Seconds in section "DO_OCEANIC_PHYS     [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:   4.2508398592472076
-(PID.TID 0000.0001)         System time:   5.7697296142578125E-005
-(PID.TID 0000.0001)     Wall clock time:   4.2624669075012207
+(PID.TID 0000.0001)           User time:   3.3098242282867432
+(PID.TID 0000.0001)         System time:   9.3999505043029785E-004
+(PID.TID 0000.0001)     Wall clock time:   3.3272974491119385
 (PID.TID 0000.0001)          No. starts:          55
 (PID.TID 0000.0001)           No. stops:          55
 (PID.TID 0000.0001)   Seconds in section "DYNAMICS            [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:   7.0412757992744446
-(PID.TID 0000.0001)         System time:   1.0520219802856445E-004
-(PID.TID 0000.0001)     Wall clock time:   7.0604822635650635
+(PID.TID 0000.0001)           User time:   6.0496545135974884
+(PID.TID 0000.0001)         System time:   1.0060071945190430E-003
+(PID.TID 0000.0001)     Wall clock time:   6.0795021057128906
 (PID.TID 0000.0001)          No. starts:          55
 (PID.TID 0000.0001)           No. stops:          55
 (PID.TID 0000.0001)   Seconds in section "UPDATE_CG2D         [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:  0.14748656749725342
-(PID.TID 0000.0001)         System time:   9.7692012786865234E-005
-(PID.TID 0000.0001)     Wall clock time:  0.14807224273681641
+(PID.TID 0000.0001)           User time:  0.11468136310577393
+(PID.TID 0000.0001)         System time:   1.9997358322143555E-005
+(PID.TID 0000.0001)     Wall clock time:  0.11539578437805176
 (PID.TID 0000.0001)          No. starts:          55
 (PID.TID 0000.0001)           No. stops:          55
 (PID.TID 0000.0001)   Seconds in section "SOLVE_FOR_PRESSURE  [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:   1.8434599637985229
-(PID.TID 0000.0001)         System time:   9.1981887817382812E-004
-(PID.TID 0000.0001)     Wall clock time:   1.8493895530700684
+(PID.TID 0000.0001)           User time:   2.0044427812099457
+(PID.TID 0000.0001)         System time:   9.7101926803588867E-004
+(PID.TID 0000.0001)     Wall clock time:   2.0150942802429199
 (PID.TID 0000.0001)          No. starts:          55
 (PID.TID 0000.0001)           No. stops:          55
 (PID.TID 0000.0001)   Seconds in section "MOM_CORRECTION_STEP [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:  0.25158017873764038
-(PID.TID 0000.0001)         System time:   2.3508071899414062E-004
-(PID.TID 0000.0001)     Wall clock time:  0.25258588790893555
+(PID.TID 0000.0001)           User time:  0.19544827938079834
+(PID.TID 0000.0001)         System time:   0.0000000000000000
+(PID.TID 0000.0001)     Wall clock time:  0.19664359092712402
 (PID.TID 0000.0001)          No. starts:          55
 (PID.TID 0000.0001)           No. stops:          55
 (PID.TID 0000.0001)   Seconds in section "INTEGR_CONTINUITY   [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:  0.38866317272186279
-(PID.TID 0000.0001)         System time:   1.9073486328125000E-005
-(PID.TID 0000.0001)     Wall clock time:  0.39000082015991211
+(PID.TID 0000.0001)           User time:  0.31550377607345581
+(PID.TID 0000.0001)         System time:   1.2993812561035156E-005
+(PID.TID 0000.0001)     Wall clock time:  0.31794357299804688
 (PID.TID 0000.0001)          No. starts:          55
 (PID.TID 0000.0001)           No. stops:          55
 (PID.TID 0000.0001)   Seconds in section "CALC_R_STAR         [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:   8.9592933654785156E-002
-(PID.TID 0000.0001)         System time:   1.0967254638671875E-005
-(PID.TID 0000.0001)     Wall clock time:   8.9909076690673828E-002
+(PID.TID 0000.0001)           User time:   6.7476987838745117E-002
+(PID.TID 0000.0001)         System time:   1.3008713722229004E-005
+(PID.TID 0000.0001)     Wall clock time:   6.7948102951049805E-002
 (PID.TID 0000.0001)          No. starts:          55
 (PID.TID 0000.0001)           No. stops:          55
 (PID.TID 0000.0001)   Seconds in section "BLOCKING_EXCHANGES  [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:  0.55982273817062378
-(PID.TID 0000.0001)         System time:   8.5830688476562500E-005
-(PID.TID 0000.0001)     Wall clock time:  0.56173396110534668
+(PID.TID 0000.0001)           User time:  0.40071141719818115
+(PID.TID 0000.0001)         System time:   9.7799301147460938E-004
+(PID.TID 0000.0001)     Wall clock time:  0.40534830093383789
 (PID.TID 0000.0001)          No. starts:         110
 (PID.TID 0000.0001)           No. stops:         110
 (PID.TID 0000.0001)   Seconds in section "THERMODYNAMICS      [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:   9.9262729883193970
-(PID.TID 0000.0001)         System time:   9.8521262407302856E-004
-(PID.TID 0000.0001)     Wall clock time:   9.9534175395965576
+(PID.TID 0000.0001)           User time:   8.0868808031082153
+(PID.TID 0000.0001)         System time:   6.8199634552001953E-004
+(PID.TID 0000.0001)     Wall clock time:   8.1309418678283691
 (PID.TID 0000.0001)          No. starts:          55
 (PID.TID 0000.0001)           No. stops:          55
 (PID.TID 0000.0001)   Seconds in section "TRC_CORRECTION_STEP [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:   3.1703710556030273E-004
-(PID.TID 0000.0001)         System time:   1.0058283805847168E-006
-(PID.TID 0000.0001)     Wall clock time:   3.4689903259277344E-004
+(PID.TID 0000.0001)           User time:   3.1769275665283203E-004
+(PID.TID 0000.0001)         System time:   9.9837779998779297E-007
+(PID.TID 0000.0001)     Wall clock time:   3.1065940856933594E-004
 (PID.TID 0000.0001)          No. starts:          55
 (PID.TID 0000.0001)           No. stops:          55
 (PID.TID 0000.0001)   Seconds in section "MONITOR             [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:  0.17045646905899048
-(PID.TID 0000.0001)         System time:   4.7683715820312500E-006
-(PID.TID 0000.0001)     Wall clock time:  0.17105126380920410
+(PID.TID 0000.0001)           User time:  0.13870984315872192
+(PID.TID 0000.0001)         System time:   9.5367431640625000E-007
+(PID.TID 0000.0001)     Wall clock time:  0.13977313041687012
 (PID.TID 0000.0001)          No. starts:          55
 (PID.TID 0000.0001)           No. stops:          55
 (PID.TID 0000.0001)   Seconds in section "COST_TILE           [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:  0.35501581430435181
-(PID.TID 0000.0001)         System time:   1.8849968910217285E-005
-(PID.TID 0000.0001)     Wall clock time:  0.35613656044006348
+(PID.TID 0000.0001)           User time:  0.22105193138122559
+(PID.TID 0000.0001)         System time:   1.8000602722167969E-005
+(PID.TID 0000.0001)     Wall clock time:  0.22320532798767090
 (PID.TID 0000.0001)          No. starts:          55
 (PID.TID 0000.0001)           No. stops:          55
 (PID.TID 0000.0001)   Seconds in section "DO_THE_MODEL_IO     [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:   4.9590587615966797E-002
-(PID.TID 0000.0001)         System time:   7.8878104686737061E-003
-(PID.TID 0000.0001)     Wall clock time:   5.7955026626586914E-002
+(PID.TID 0000.0001)           User time:   4.5517206192016602E-002
+(PID.TID 0000.0001)         System time:   6.6649913787841797E-003
+(PID.TID 0000.0001)     Wall clock time:   5.2549362182617188E-002
 (PID.TID 0000.0001)          No. starts:          55
 (PID.TID 0000.0001)           No. stops:          55
 (PID.TID 0000.0001)   Seconds in section "DO_WRITE_PICKUP     [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:   1.6669929027557373E-002
-(PID.TID 0000.0001)         System time:   5.9709846973419189E-003
-(PID.TID 0000.0001)     Wall clock time:   2.2789955139160156E-002
+(PID.TID 0000.0001)           User time:   2.0747303962707520E-002
+(PID.TID 0000.0001)         System time:   1.5020370483398438E-005
+(PID.TID 0000.0001)     Wall clock time:   2.0855903625488281E-002
 (PID.TID 0000.0001)          No. starts:          55
 (PID.TID 0000.0001)           No. stops:          55
 (PID.TID 0000.0001)   Seconds in section "CTRL_PACK           [THE_MODEL_MAIN]":
-(PID.TID 0000.0001)           User time:   3.2903671264648438E-002
-(PID.TID 0000.0001)         System time:   3.9858818054199219E-003
-(PID.TID 0000.0001)     Wall clock time:   3.7142038345336914E-002
+(PID.TID 0000.0001)           User time:   2.7547836303710938E-002
+(PID.TID 0000.0001)         System time:   3.9640069007873535E-003
+(PID.TID 0000.0001)     Wall clock time:   3.1697034835815430E-002
 (PID.TID 0000.0001)          No. starts:           1
 (PID.TID 0000.0001)           No. stops:           1
 (PID.TID 0000.0001)   Seconds in section "CTRL_PACK     [THE_MODEL_MAIN]":
-(PID.TID 0000.0001)           User time:   3.2243728637695312E-002
-(PID.TID 0000.0001)         System time:   2.8729438781738281E-003
-(PID.TID 0000.0001)     Wall clock time:   3.5374879837036133E-002
+(PID.TID 0000.0001)           User time:   3.0572891235351562E-002
+(PID.TID 0000.0001)         System time:   0.0000000000000000
+(PID.TID 0000.0001)     Wall clock time:   3.0740022659301758E-002
 (PID.TID 0000.0001)          No. starts:           1
 (PID.TID 0000.0001)           No. stops:           1
 (PID.TID 0000.0001)   Seconds in section "GRDCHK_MAIN         [THE_MODEL_MAIN]":
-(PID.TID 0000.0001)           User time:   22.428234100341797
-(PID.TID 0000.0001)         System time:  0.10023927688598633
-(PID.TID 0000.0001)     Wall clock time:   22.626114130020142
+(PID.TID 0000.0001)           User time:   18.789325714111328
+(PID.TID 0000.0001)         System time:   6.6375017166137695E-002
+(PID.TID 0000.0001)     Wall clock time:   18.973006010055542
 (PID.TID 0000.0001)          No. starts:           1
 (PID.TID 0000.0001)           No. stops:           1
 (PID.TID 0000.0001)   Seconds in section "INITIALISE_VARIA    [THE_MAIN_LOOP]":
-(PID.TID 0000.0001)           User time:   1.1187477111816406
-(PID.TID 0000.0001)         System time:   7.3564529418945312E-002
-(PID.TID 0000.0001)     Wall clock time:   1.1992907524108887
+(PID.TID 0000.0001)           User time:  0.94584274291992188
+(PID.TID 0000.0001)         System time:   4.4694125652313232E-002
+(PID.TID 0000.0001)     Wall clock time:  0.99656295776367188
 (PID.TID 0000.0001)          No. starts:           9
 (PID.TID 0000.0001)           No. stops:           9
 (PID.TID 0000.0001)   Seconds in section "MAIN LOOP           [THE_MAIN_LOOP]":
-(PID.TID 0000.0001)           User time:   21.226501464843750
-(PID.TID 0000.0001)         System time:   9.7103118896484375E-003
-(PID.TID 0000.0001)     Wall clock time:   21.294141054153442
+(PID.TID 0000.0001)           User time:   17.769651412963867
+(PID.TID 0000.0001)         System time:   7.9108476638793945E-003
+(PID.TID 0000.0001)     Wall clock time:   17.868465185165405
 (PID.TID 0000.0001)          No. starts:           9
 (PID.TID 0000.0001)           No. stops:           9
 (PID.TID 0000.0001)   Seconds in section "MAIN_DO_LOOP        [THE_MAIN_LOOP]":
-(PID.TID 0000.0001)           User time:   21.197265625000000
-(PID.TID 0000.0001)         System time:   5.0683021545410156E-003
-(PID.TID 0000.0001)     Wall clock time:   21.260004997253418
+(PID.TID 0000.0001)           User time:   17.745054244995117
+(PID.TID 0000.0001)         System time:   3.1379461288452148E-003
+(PID.TID 0000.0001)     Wall clock time:   17.838849544525146
 (PID.TID 0000.0001)          No. starts:          45
 (PID.TID 0000.0001)           No. stops:          45
 (PID.TID 0000.0001)   Seconds in section "COST_FINAL         [ADJOINT SPIN-DOWN]":
-(PID.TID 0000.0001)           User time:   2.8877258300781250E-002
-(PID.TID 0000.0001)         System time:   4.6238899230957031E-003
-(PID.TID 0000.0001)     Wall clock time:   3.3768177032470703E-002
+(PID.TID 0000.0001)           User time:   2.4181365966796875E-002
+(PID.TID 0000.0001)         System time:   4.7689676284790039E-003
+(PID.TID 0000.0001)     Wall clock time:   2.9198408126831055E-002
 (PID.TID 0000.0001)          No. starts:           9
 (PID.TID 0000.0001)           No. stops:           9
 (PID.TID 0000.0001) // ======================================================
@@ -4187,9 +3839,9 @@ grad-res -------------------------------
 (PID.TID 0000.0001) //          Total. Y spins =              0
 (PID.TID 0000.0001) //            Avg. Y spins =       0.00E+00
 (PID.TID 0000.0001) // o Thread number: 000001
-(PID.TID 0000.0001) //            No. barriers =          56088
+(PID.TID 0000.0001) //            No. barriers =          76138
 (PID.TID 0000.0001) //      Max. barrier spins =              1
 (PID.TID 0000.0001) //      Min. barrier spins =              1
-(PID.TID 0000.0001) //     Total barrier spins =          56088
+(PID.TID 0000.0001) //     Total barrier spins =          76138
 (PID.TID 0000.0001) //      Avg. barrier spins =       1.00E+00
 PROGRAM MAIN: Execution ended Normally

--- a/verification/global_ocean.cs32x15/results/output_tap_tlm.txt
+++ b/verification/global_ocean.cs32x15/results/output_tap_tlm.txt
@@ -5,10 +5,10 @@
 (PID.TID 0000.0001) // ======================================================
 (PID.TID 0000.0001) // execution environment starting up...
 (PID.TID 0000.0001) 
-(PID.TID 0000.0001) // MITgcmUV version:  checkpoint68o
-(PID.TID 0000.0001) // Build user:        jmc
-(PID.TID 0000.0001) // Build host:        jaures.mit.edu
-(PID.TID 0000.0001) // Build date:        Thu May 18 02:44:33 PM EDT 2023
+(PID.TID 0000.0001) // MITgcmUV version:  checkpoint69j
+(PID.TID 0000.0001) // Build user:        jm_c
+(PID.TID 0000.0001) // Build host:        baudelaire.mit.edu
+(PID.TID 0000.0001) // Build date:        Tue Jan 20 11:52:43 AM EST 2026
 (PID.TID 0000.0001) 
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // Execution Environment parameter file "eedata"
@@ -126,8 +126,9 @@
 (PID.TID 0000.0001) ># Elliptic solver parameters
 (PID.TID 0000.0001) > &PARM02
 (PID.TID 0000.0001) > cg2dMaxIters=200,
-(PID.TID 0000.0001) >#cg2dTargetResidual=1.E-9,
-(PID.TID 0000.0001) > cg2dTargetResWunit=1.E-14,
+(PID.TID 0000.0001) > cg2dTargetResidual=1.E-9,
+(PID.TID 0000.0001) >#cg2dTargetResWunit=6.648E-13,
+(PID.TID 0000.0001) > printResidualFreq = 0,
 (PID.TID 0000.0001) > /
 (PID.TID 0000.0001) >
 (PID.TID 0000.0001) ># Time stepping parameters
@@ -143,7 +144,6 @@
 (PID.TID 0000.0001) > momDissip_In_AB=.FALSE.,
 (PID.TID 0000.0001) > pChkptFreq  =311040000.,
 (PID.TID 0000.0001) > chkptFreq   = 31104000.,
-(PID.TID 0000.0001) >#taveFreq    =311040000.,
 (PID.TID 0000.0001) >#dumpFreq    = 31104000.,
 (PID.TID 0000.0001) >#adjDumpFreq = 31104000.,
 (PID.TID 0000.0001) >#monitorFreq = 31104000.,
@@ -427,6 +427,19 @@
 (PID.TID 0000.0001) > /
 (PID.TID 0000.0001) 
 (PID.TID 0000.0001) COST_READPARMS: finished reading data.cost
+(PID.TID 0000.0001) // =======================================================
+(PID.TID 0000.0001) // cost configuration  >>> START <<<
+(PID.TID 0000.0001) // =======================================================
+(PID.TID 0000.0001) lastinterval =   /* cost interval over which to average ( s ). */
+(PID.TID 0000.0001)                 2.592000000000000E+06
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) cost_mask_file = /* file name of cost mask file */
+(PID.TID 0000.0001)               ''
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) // =======================================================
+(PID.TID 0000.0001) // cost configuration  >>> END <<<
+(PID.TID 0000.0001) // =======================================================
+(PID.TID 0000.0001) 
 (PID.TID 0000.0001) GRDCHK_READPARMS: opening data.grdchk
 (PID.TID 0000.0001)  OPEN_COPY_DATA_FILE: opening file data.grdchk
 (PID.TID 0000.0001) // =======================================================
@@ -443,29 +456,10 @@
 (PID.TID 0000.0001) > nbeg             = 1,
 (PID.TID 0000.0001) > nstep            = 1,
 (PID.TID 0000.0001) > nend             = 4,
-(PID.TID 0000.0001) ># this is xx_theta
-(PID.TID 0000.0001) >#grdchkvarindex   = 1,
-(PID.TID 0000.0001) > grdchkvarindex   =201,
+(PID.TID 0000.0001) > grdchkvarname    ="xx_theta",
 (PID.TID 0000.0001) > /
 (PID.TID 0000.0001) 
 (PID.TID 0000.0001) GRDCHK_READPARMS: finished reading data.grdchk
-(PID.TID 0000.0001) 
-(PID.TID 0000.0001) // =======================================================
-(PID.TID 0000.0001) // Gradient check configuration  >>> START <<<
-(PID.TID 0000.0001) // =======================================================
-(PID.TID 0000.0001) 
-(PID.TID 0000.0001)   grdchkvarindex :                        201
-(PID.TID 0000.0001)   eps:                              0.100E-01
-(PID.TID 0000.0001)   First location:                           1
-(PID.TID 0000.0001)   Last location:                            4
-(PID.TID 0000.0001)   Increment:                                1
-(PID.TID 0000.0001)   grdchkWhichProc:                          0
-(PID.TID 0000.0001)   iLocTile =       1  ,    jLocTile =       1
-(PID.TID 0000.0001) 
-(PID.TID 0000.0001) // =======================================================
-(PID.TID 0000.0001) // Gradient check configuration  >>> END <<<
-(PID.TID 0000.0001) // =======================================================
-(PID.TID 0000.0001) 
 (PID.TID 0000.0001)  DIAGNOSTICS_READPARMS: opening data.diagnostics
 (PID.TID 0000.0001)  OPEN_COPY_DATA_FILE: opening file data.diagnostics
 (PID.TID 0000.0001) // =======================================================
@@ -555,7 +549,11 @@
 (PID.TID 0000.0001) S/R DIAGNOSTICS_READPARMS, read namelist "diagnostics_list": OK
 (PID.TID 0000.0001) S/R DIAGNOSTICS_READPARMS, read namelist "DIAG_STATIS_PARMS": start
 (PID.TID 0000.0001) S/R DIAGNOSTICS_READPARMS, read namelist "DIAG_STATIS_PARMS": OK
+(PID.TID 0000.0001) -----------------------------------------------------
 (PID.TID 0000.0001)  DIAGNOSTICS_READPARMS: global parameter summary:
+(PID.TID 0000.0001)  diag_dBugLevel = /* level of printed debug messages */
+(PID.TID 0000.0001)                       1
+(PID.TID 0000.0001)     ;
 (PID.TID 0000.0001)  dumpAtLast = /* always write time-ave diags at the end */
 (PID.TID 0000.0001)                   F
 (PID.TID 0000.0001)     ;
@@ -569,7 +567,7 @@
 (PID.TID 0000.0001)                     200
 (PID.TID 0000.0001)     ;
 (PID.TID 0000.0001)  diagCG_resTarget = /* residual target for diag_cg2d */
-(PID.TID 0000.0001)                 1.000000000000000E-07
+(PID.TID 0000.0001)                 1.000000000000000E-09
 (PID.TID 0000.0001)     ;
 (PID.TID 0000.0001)  diagCG_pcOffDFac = /* preconditioner off-diagonal factor */
 (PID.TID 0000.0001)                 9.611687812379854E-01
@@ -750,434 +748,40 @@
 (PID.TID 0000.0001)                   F
 (PID.TID 0000.0001)     ;
 (PID.TID 0000.0001) // ===================================
+(PID.TID 0000.0001) CTRL_INIT_FIXED: ivar=   8 = number of CTRL variables defined
+(PID.TID 0000.0001) 
 (PID.TID 0000.0001) ctrl-wet 1:    nvarlength =       239366
 (PID.TID 0000.0001) ctrl-wet 2: surface wet C =          389
 (PID.TID 0000.0001) ctrl-wet 3: surface wet W =          367
 (PID.TID 0000.0001) ctrl-wet 4: surface wet S =          384
-(PID.TID 0000.0001) ctrl-wet 4a:surface wet V =            0
 (PID.TID 0000.0001) ctrl-wet 5: 3D wet points =         5204
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =     1           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =     2           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =     3           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =     4           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =     5           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =     6           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =     7           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =     8           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =     9           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =    10           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =    11           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =    12           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =    13           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =    14           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =    15           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =    16           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =    17           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =    18           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =    19           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =    20           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =    21           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =    22           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =    23           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =    24           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =    25           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =    26           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =    27           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =    28           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =    29           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =    30           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =    31           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =    32           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =    33           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =    34           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =    35           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =    36           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =    37           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =    38           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =    39           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =    40           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =    41           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =    42           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =    43           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =    44           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =    45           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =    46           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =    47           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =    48           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =    49           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =    50           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =    51           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =    52           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =    53           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =    54           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =    55           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =    56           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =    57           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =    58           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =    59           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =    60           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =    61           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =    62           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =    63           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =    64           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =    65           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =    66           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =    67           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =    68           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =    69           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =    70           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =    71           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =    72           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =    73           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =    74           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =    75           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =    76           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =    77           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =    78           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =    79           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =    80           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =    81           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =    82           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =    83           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =    84           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =    85           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =    86           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =    87           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =    88           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =    89           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =    90           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =    91           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =    92           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =    93           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =    94           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =    95           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =    96           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =    97           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =    98           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =    99           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   100           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   101           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   102           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   103           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   104           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   105           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   106           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   107           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   108           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   109           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   110           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   111           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   112           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   113           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   114           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   115           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   116           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   117           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   118           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   119           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   120           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   121           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   122           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   123           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   124           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   125           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   126           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   127           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   128           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   129           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   130           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   131           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   132           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   133           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   134           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   135           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   136           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   137           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   138           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   139           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   140           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   141           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   142           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   143           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   144           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   145           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   146           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   147           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   148           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   149           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   150           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   151           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   152           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   153           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   154           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   155           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   156           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   157           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   158           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   159           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   160           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   161           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   162           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   163           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   164           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   165           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   166           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   167           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   168           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   169           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   170           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   171           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   172           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   173           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   174           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   175           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   176           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   177           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   178           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   179           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   180           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   181           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   182           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   183           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   184           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   185           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   186           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   187           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   188           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   189           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   190           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   191           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   192           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   193           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   194           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   195           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   196           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   197           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   198           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   199           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   200           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   201           1
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   202           1
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   203           1
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   204           1
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   205           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   206           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   207           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   208           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   209           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   210           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   211           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   212           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   213           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   214           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   215           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   216           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   217           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   218           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   219           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   220           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   221           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   222           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   223           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   224           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   225           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   226           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   227           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   228           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   229           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   230           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   231           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   232           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   233           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   234           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   235           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   236           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   237           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   238           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   239           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   240           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   241           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   242           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   243           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   244           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   245           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   246           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   247           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   248           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   249           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   250           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   251           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   252           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   253           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   254           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   255           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   256           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   257           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   258           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   259           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   260           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   261           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   262           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   263           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   264           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   265           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   266           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   267           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   268           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   269           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   270           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   271           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   272           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   273           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   274           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   275           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   276           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   277           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   278           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   279           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   280           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   281           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   282           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   283           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   284           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   285           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   286           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   287           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   288           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   289           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   290           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   291           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   292           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   293           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   294           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   295           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   296           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   297           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   298           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   299           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   300           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   301           1
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   302           1
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   303           1
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   304           1
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   305           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   306           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   307           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   308           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   309           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   310           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   311           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   312           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   313           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   314           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   315           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   316           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   317           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   318           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   319           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   320           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   321           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   322           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   323           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   324           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   325           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   326           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   327           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   328           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   329           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   330           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   331           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   332           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   333           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   334           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   335           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   336           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   337           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   338           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   339           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   340           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   341           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   342           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   343           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   344           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   345           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   346           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   347           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   348           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   349           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   350           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   351           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   352           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   353           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   354           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   355           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   356           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   357           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   358           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   359           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   360           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   361           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   362           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   363           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   364           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   365           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   366           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   367           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   368           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   369           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   370           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   371           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   372           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   373           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   374           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   375           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   376           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   377           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   378           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   379           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   380           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   381           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   382           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   383           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   384           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   385           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   386           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   387           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   388           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   389           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   390           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   391           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   392           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   393           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   394           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   395           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   396           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   397           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   398           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   399           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   400           0
-(PID.TID 0000.0001) ctrl-wet 7: flux         10408
-(PID.TID 0000.0001) ctrl-wet 8: atmos        10408
+(PID.TID 0000.0001) ctrl-wet 6: no recs for ivar =     1           1
+(PID.TID 0000.0001) ctrl-wet 6: no recs for ivar =     2           1
+(PID.TID 0000.0001) ctrl-wet 6: no recs for ivar =     3           1
+(PID.TID 0000.0001) ctrl-wet 6: no recs for ivar =     4           1
+(PID.TID 0000.0001) ctrl-wet 6: no recs for ivar =     5           1
+(PID.TID 0000.0001) ctrl-wet 6: no recs for ivar =     6           1
+(PID.TID 0000.0001) ctrl-wet 6: no recs for ivar =     7           1
+(PID.TID 0000.0001) ctrl-wet 6: no recs for ivar =     8           1
+(PID.TID 0000.0001) ctrl-wet 6: no recs for ivar =     9           0
 (PID.TID 0000.0001) ctrl-wet -------------------------------------------------
 (PID.TID 0000.0001) ctrl-wet 13: global nvarlength for Nr =   15      239366
 (PID.TID 0000.0001) ctrl-wet -------------------------------------------------
-(PID.TID 0000.0001) ctrl-wet 14: global nWet C/S/W/V k=    1        4420        4232        4206           0
-(PID.TID 0000.0001) ctrl-wet 14: global nWet C/S/W/V k=    2        4299        4112        4096           0
-(PID.TID 0000.0001) ctrl-wet 14: global nWet C/S/W/V k=    3        4222        4038        4023           0
-(PID.TID 0000.0001) ctrl-wet 14: global nWet C/S/W/V k=    4        4140        3960        3939           0
-(PID.TID 0000.0001) ctrl-wet 14: global nWet C/S/W/V k=    5        4099        3919        3893           0
-(PID.TID 0000.0001) ctrl-wet 14: global nWet C/S/W/V k=    6        4038        3856        3839           0
-(PID.TID 0000.0001) ctrl-wet 14: global nWet C/S/W/V k=    7        3995        3814        3795           0
-(PID.TID 0000.0001) ctrl-wet 14: global nWet C/S/W/V k=    8        3944        3756        3737           0
-(PID.TID 0000.0001) ctrl-wet 14: global nWet C/S/W/V k=    9        3887        3699        3673           0
-(PID.TID 0000.0001) ctrl-wet 14: global nWet C/S/W/V k=   10        3799        3605        3585           0
-(PID.TID 0000.0001) ctrl-wet 14: global nWet C/S/W/V k=   11        3703        3502        3461           0
-(PID.TID 0000.0001) ctrl-wet 14: global nWet C/S/W/V k=   12        3554        3338        3303           0
-(PID.TID 0000.0001) ctrl-wet 14: global nWet C/S/W/V k=   13        3202        2910        2911           0
-(PID.TID 0000.0001) ctrl-wet 14: global nWet C/S/W/V k=   14        2599        2296        2276           0
-(PID.TID 0000.0001) ctrl-wet 14: global nWet C/S/W/V k=   15        1621        1368        1334           0
-(PID.TID 0000.0001) ctrl-wet -------------------------------------------------
-(PID.TID 0000.0001) ctrl-wet -------------------------------------------------
+(PID.TID 0000.0001) ctrl-wet 14: global nWet C/S/W k=    1        4420        4232        4206
+(PID.TID 0000.0001) ctrl-wet 14: global nWet C/S/W k=    2        4299        4112        4096
+(PID.TID 0000.0001) ctrl-wet 14: global nWet C/S/W k=    3        4222        4038        4023
+(PID.TID 0000.0001) ctrl-wet 14: global nWet C/S/W k=    4        4140        3960        3939
+(PID.TID 0000.0001) ctrl-wet 14: global nWet C/S/W k=    5        4099        3919        3893
+(PID.TID 0000.0001) ctrl-wet 14: global nWet C/S/W k=    6        4038        3856        3839
+(PID.TID 0000.0001) ctrl-wet 14: global nWet C/S/W k=    7        3995        3814        3795
+(PID.TID 0000.0001) ctrl-wet 14: global nWet C/S/W k=    8        3944        3756        3737
+(PID.TID 0000.0001) ctrl-wet 14: global nWet C/S/W k=    9        3887        3699        3673
+(PID.TID 0000.0001) ctrl-wet 14: global nWet C/S/W k=   10        3799        3605        3585
+(PID.TID 0000.0001) ctrl-wet 14: global nWet C/S/W k=   11        3703        3502        3461
+(PID.TID 0000.0001) ctrl-wet 14: global nWet C/S/W k=   12        3554        3338        3303
+(PID.TID 0000.0001) ctrl-wet 14: global nWet C/S/W k=   13        3202        2910        2911
+(PID.TID 0000.0001) ctrl-wet 14: global nWet C/S/W k=   14        2599        2296        2276
+(PID.TID 0000.0001) ctrl-wet 14: global nWet C/S/W k=   15        1621        1368        1334
 (PID.TID 0000.0001) ctrl-wet -------------------------------------------------
 (PID.TID 0000.0001) ctrl_init_wet: no. of control variables:            8
 (PID.TID 0000.0001) ctrl_init_wet: control vector length:          239366
@@ -1188,66 +792,78 @@
 (PID.TID 0000.0001) 
 (PID.TID 0000.0001)  Total number of ocean points per tile:
 (PID.TID 0000.0001)  --------------------------------------
-(PID.TID 0000.0001)  snx*sny*nr =     7680
+(PID.TID 0000.0001)  sNx*sNy*Nr =     7680
 (PID.TID 0000.0001) 
 (PID.TID 0000.0001)  Number of ocean points per tile:
 (PID.TID 0000.0001)  --------------------------------
-(PID.TID 0000.0001)  bi,bj,#(c/s/w): 0001 0001 005204 005084 004791
-(PID.TID 0000.0001)  bi,bj,#(c/s/w): 0002 0001 003115 002837 002945
-(PID.TID 0000.0001)  bi,bj,#(c/s/w): 0003 0001 005620 005386 005384
-(PID.TID 0000.0001)  bi,bj,#(c/s/w): 0004 0001 002470 002283 001983
-(PID.TID 0000.0001)  bi,bj,#(c/s/w): 0005 0001 001306 000952 000953
-(PID.TID 0000.0001)  bi,bj,#(c/s/w): 0006 0001 003476 003122 003082
-(PID.TID 0000.0001)  bi,bj,#(c/s/w): 0007 0001 005619 005222 005403
-(PID.TID 0000.0001)  bi,bj,#(c/s/w): 0008 0001 007482 007397 007429
-(PID.TID 0000.0001)  bi,bj,#(c/s/w): 0009 0001 005900 005825 005686
-(PID.TID 0000.0001)  bi,bj,#(c/s/w): 0010 0001 003678 003307 003317
-(PID.TID 0000.0001)  bi,bj,#(c/s/w): 0011 0001 006008 005782 005796
-(PID.TID 0000.0001)  bi,bj,#(c/s/w): 0012 0001 005644 005208 005302
-(PID.TID 0000.0001) 
-(PID.TID 0000.0001)  Settings of generic controls:
-(PID.TID 0000.0001)  -----------------------------
+(PID.TID 0000.0001)  bi,bj,#(c/s/w): 001 001    5204    5084    4791
+(PID.TID 0000.0001)  bi,bj,#(c/s/w): 002 001    3115    2837    2945
+(PID.TID 0000.0001)  bi,bj,#(c/s/w): 003 001    5620    5386    5384
+(PID.TID 0000.0001)  bi,bj,#(c/s/w): 004 001    2470    2283    1983
+(PID.TID 0000.0001)  bi,bj,#(c/s/w): 005 001    1306     952     953
+(PID.TID 0000.0001)  bi,bj,#(c/s/w): 006 001    3476    3122    3082
+(PID.TID 0000.0001)  bi,bj,#(c/s/w): 007 001    5619    5222    5403
+(PID.TID 0000.0001)  bi,bj,#(c/s/w): 008 001    7482    7397    7429
+(PID.TID 0000.0001)  bi,bj,#(c/s/w): 009 001    5900    5825    5686
+(PID.TID 0000.0001)  bi,bj,#(c/s/w): 010 001    3678    3307    3317
+(PID.TID 0000.0001)  bi,bj,#(c/s/w): 011 001    6008    5782    5796
+(PID.TID 0000.0001)  bi,bj,#(c/s/w): 012 001    5644    5208    5302
 (PID.TID 0000.0001) 
 (PID.TID 0000.0001)  -> 3d control, genarr3d no.  1 is in use
 (PID.TID 0000.0001)       file       = xx_theta
+(PID.TID 0000.0001)       ncvartype  = Arr3D
+(PID.TID 0000.0001)       index      =     1  (use this for pkg/grdchk)
+(PID.TID 0000.0001)       ncvarindex =     1
 (PID.TID 0000.0001)       weight     = ones_64b.bin
-(PID.TID 0000.0001)       index      =  0201
-(PID.TID 0000.0001)       ncvarindex =  0301
+(PID.TID 0000.0001) 
 (PID.TID 0000.0001)  -> 3d control, genarr3d no.  2 is in use
 (PID.TID 0000.0001)       file       = xx_salt
+(PID.TID 0000.0001)       ncvartype  = Arr3D
+(PID.TID 0000.0001)       index      =     2  (use this for pkg/grdchk)
+(PID.TID 0000.0001)       ncvarindex =     2
 (PID.TID 0000.0001)       weight     = ones_64b.bin
-(PID.TID 0000.0001)       index      =  0202
-(PID.TID 0000.0001)       ncvarindex =  0302
+(PID.TID 0000.0001) 
 (PID.TID 0000.0001)  -> 3d control, genarr3d no.  3 is in use
 (PID.TID 0000.0001)       file       = xx_ptr1
+(PID.TID 0000.0001)       ncvartype  = Arr3D
+(PID.TID 0000.0001)       index      =     3  (use this for pkg/grdchk)
+(PID.TID 0000.0001)       ncvarindex =     3
 (PID.TID 0000.0001)       weight     = ones_64b.bin
-(PID.TID 0000.0001)       index      =  0203
-(PID.TID 0000.0001)       ncvarindex =  0303
+(PID.TID 0000.0001) 
 (PID.TID 0000.0001)  -> 3d control, genarr3d no.  4 is in use
 (PID.TID 0000.0001)       file       = xx_diffkr
+(PID.TID 0000.0001)       ncvartype  = Arr3D
+(PID.TID 0000.0001)       index      =     4  (use this for pkg/grdchk)
+(PID.TID 0000.0001)       ncvarindex =     4
 (PID.TID 0000.0001)       weight     = ones_64b.bin
-(PID.TID 0000.0001)       index      =  0204
-(PID.TID 0000.0001)       ncvarindex =  0304
-(PID.TID 0000.0001)  -> time variable 2D control, gentim2d no.  1 is in use
+(PID.TID 0000.0001) 
+(PID.TID 0000.0001)  -> time variable 2d control, gentim2d no.  1 is in use
 (PID.TID 0000.0001)       file       = xx_qnet
+(PID.TID 0000.0001)       ncvartype  = Tim2D
+(PID.TID 0000.0001)       index      =     5  (use this for pkg/grdchk)
+(PID.TID 0000.0001)       ncvarindex =     1
 (PID.TID 0000.0001)       weight     = ones_64b.bin
-(PID.TID 0000.0001)       index      =  0301
-(PID.TID 0000.0001)       ncvarindex =  0401
-(PID.TID 0000.0001)  -> time variable 2D control, gentim2d no.  2 is in use
+(PID.TID 0000.0001) 
+(PID.TID 0000.0001)  -> time variable 2d control, gentim2d no.  2 is in use
 (PID.TID 0000.0001)       file       = xx_empmr
+(PID.TID 0000.0001)       ncvartype  = Tim2D
+(PID.TID 0000.0001)       index      =     6  (use this for pkg/grdchk)
+(PID.TID 0000.0001)       ncvarindex =     2
 (PID.TID 0000.0001)       weight     = ones_64b.bin
-(PID.TID 0000.0001)       index      =  0302
-(PID.TID 0000.0001)       ncvarindex =  0402
-(PID.TID 0000.0001)  -> time variable 2D control, gentim2d no.  3 is in use
+(PID.TID 0000.0001) 
+(PID.TID 0000.0001)  -> time variable 2d control, gentim2d no.  3 is in use
 (PID.TID 0000.0001)       file       = xx_fu
+(PID.TID 0000.0001)       ncvartype  = Tim2D
+(PID.TID 0000.0001)       index      =     7  (use this for pkg/grdchk)
+(PID.TID 0000.0001)       ncvarindex =     3
 (PID.TID 0000.0001)       weight     = ones_64b.bin
-(PID.TID 0000.0001)       index      =  0303
-(PID.TID 0000.0001)       ncvarindex =  0403
-(PID.TID 0000.0001)  -> time variable 2D control, gentim2d no.  4 is in use
+(PID.TID 0000.0001) 
+(PID.TID 0000.0001)  -> time variable 2d control, gentim2d no.  4 is in use
 (PID.TID 0000.0001)       file       = xx_fv
+(PID.TID 0000.0001)       ncvartype  = Tim2D
+(PID.TID 0000.0001)       index      =     8  (use this for pkg/grdchk)
+(PID.TID 0000.0001)       ncvarindex =     4
 (PID.TID 0000.0001)       weight     = ones_64b.bin
-(PID.TID 0000.0001)       index      =  0304
-(PID.TID 0000.0001)       ncvarindex =  0404
 (PID.TID 0000.0001) 
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // control vector configuration  >>> END <<<
@@ -1255,57 +871,57 @@
 (PID.TID 0000.0001) 
 (PID.TID 0000.0001) ------------------------------------------------------------
 (PID.TID 0000.0001) DIAGNOSTICS_SET_LEVELS: done
-(PID.TID 0000.0001)  Total Nb of available Diagnostics: ndiagt=   218
+(PID.TID 0000.0001)  Total Nb of available Diagnostics: ndiagt=   225
 (PID.TID 0000.0001)  write list of available Diagnostics to file: available_diagnostics.log
 (PID.TID 0000.0001) SETDIAG: Allocate  1 x  1 Levels for Diagnostic #    23 ETAN
 (PID.TID 0000.0001) SETDIAG: Allocate  1 x  1 Levels for Diagnostic #    24 ETANSQ
 (PID.TID 0000.0001) SETDIAG: Allocate  1 x  1 Levels for Diagnostic #    25 DETADT2
-(PID.TID 0000.0001) SETDIAG: Allocate  1 x  1 Levels for Diagnostic #    73 PHIBOT
-(PID.TID 0000.0001) SETDIAG: Allocate  1 x  1 Levels for Diagnostic #    74 PHIBOTSQ
-(PID.TID 0000.0001) SETDIAG: Allocate  1 x  1 Levels for Diagnostic #    80 oceTAUX
-(PID.TID 0000.0001) SETDIAG: Allocate  1 x  1 Levels for Diagnostic #    81 oceTAUY
-(PID.TID 0000.0001) SETDIAG: Allocate  1 x  1 Levels for Diagnostic #    93 TFLUX
-(PID.TID 0000.0001) SETDIAG: Allocate  1 x  1 Levels for Diagnostic #    94 SFLUX
-(PID.TID 0000.0001) SETDIAG: Allocate  1 x  1 Levels for Diagnostic #    88 oceFreez
-(PID.TID 0000.0001) SETDIAG: Allocate  1 x  1 Levels for Diagnostic #    89 TRELAX
-(PID.TID 0000.0001) SETDIAG: Allocate  1 x  1 Levels for Diagnostic #    90 SRELAX
+(PID.TID 0000.0001) SETDIAG: Allocate  1 x  1 Levels for Diagnostic #    74 PHIBOT
+(PID.TID 0000.0001) SETDIAG: Allocate  1 x  1 Levels for Diagnostic #    75 PHIBOTSQ
+(PID.TID 0000.0001) SETDIAG: Allocate  1 x  1 Levels for Diagnostic #    82 oceTAUX
+(PID.TID 0000.0001) SETDIAG: Allocate  1 x  1 Levels for Diagnostic #    83 oceTAUY
+(PID.TID 0000.0001) SETDIAG: Allocate  1 x  1 Levels for Diagnostic #    95 TFLUX
+(PID.TID 0000.0001) SETDIAG: Allocate  1 x  1 Levels for Diagnostic #    96 SFLUX
+(PID.TID 0000.0001) SETDIAG: Allocate  1 x  1 Levels for Diagnostic #    90 oceFreez
+(PID.TID 0000.0001) SETDIAG: Allocate  1 x  1 Levels for Diagnostic #    91 TRELAX
+(PID.TID 0000.0001) SETDIAG: Allocate  1 x  1 Levels for Diagnostic #    92 SRELAX
 (PID.TID 0000.0001) SETDIAG: Allocate 15 x  1 Levels for Diagnostic #    30 UVEL
 (PID.TID 0000.0001) SETDIAG: Allocate 15 x  1 Levels for Diagnostic #    31 VVEL
 (PID.TID 0000.0001) SETDIAG: Allocate 15 x  1 Levels for Diagnostic #    32 WVEL
-(PID.TID 0000.0001) SETDIAG: Allocate 15 x  1 Levels for Diagnostic #    71 PHIHYD
-(PID.TID 0000.0001) SETDIAG: Allocate 15 x  1 Levels for Diagnostic #    46 VVELMASS
-(PID.TID 0000.0001) SETDIAG: Allocate 15 x  1 Levels for Diagnostic #    45 UVELMASS
+(PID.TID 0000.0001) SETDIAG: Allocate 15 x  1 Levels for Diagnostic #    72 PHIHYD
+(PID.TID 0000.0001) SETDIAG: Allocate 15 x  1 Levels for Diagnostic #    47 VVELMASS
+(PID.TID 0000.0001) SETDIAG: Allocate 15 x  1 Levels for Diagnostic #    46 UVELMASS
 (PID.TID 0000.0001) SETDIAG: Allocate 15 x  1 Levels for Diagnostic #    38 WVELSQ
 (PID.TID 0000.0001) SETDIAG: Allocate 15 x  1 Levels for Diagnostic #    26 THETA
 (PID.TID 0000.0001) SETDIAG: Allocate 15 x  1 Levels for Diagnostic #    27 SALT
-(PID.TID 0000.0001) SETDIAG: Allocate 15 x  1 Levels for Diagnostic #   114 ADJuvel
-(PID.TID 0000.0001) SETDIAG: Allocate 15 x  1 Levels for Diagnostic #   115 ADJvvel
-(PID.TID 0000.0001) SETDIAG: Allocate 15 x  1 Levels for Diagnostic #   116 ADJwvel
-(PID.TID 0000.0001) SETDIAG: Allocate 15 x  1 Levels for Diagnostic #   117 ADJtheta
-(PID.TID 0000.0001) SETDIAG: Allocate 15 x  1 Levels for Diagnostic #   118 ADJsalt
-(PID.TID 0000.0001) SETDIAG: Allocate  1 x  1 Levels for Diagnostic #   113 ADJetan
-(PID.TID 0000.0001) SETDIAG: Allocate  1 x  1 Levels for Diagnostic #   122 ADJqnet
-(PID.TID 0000.0001) SETDIAG: Allocate  1 x  1 Levels for Diagnostic #   121 ADJempmr
-(PID.TID 0000.0001) SETDIAG: Allocate  1 x  1 Levels for Diagnostic #   119 ADJtaux
-(PID.TID 0000.0001) SETDIAG: Allocate  1 x  1 Levels for Diagnostic #   120 ADJtauy
+(PID.TID 0000.0001) SETDIAG: Allocate 15 x  1 Levels for Diagnostic #   116 ADJuvel
+(PID.TID 0000.0001) SETDIAG: Allocate 15 x  1 Levels for Diagnostic #   117 ADJvvel
+(PID.TID 0000.0001) SETDIAG: Allocate 15 x  1 Levels for Diagnostic #   118 ADJwvel
+(PID.TID 0000.0001) SETDIAG: Allocate 15 x  1 Levels for Diagnostic #   119 ADJtheta
+(PID.TID 0000.0001) SETDIAG: Allocate 15 x  1 Levels for Diagnostic #   120 ADJsalt
+(PID.TID 0000.0001) SETDIAG: Allocate  1 x  1 Levels for Diagnostic #   115 ADJetan
+(PID.TID 0000.0001) SETDIAG: Allocate  1 x  1 Levels for Diagnostic #   124 ADJqnet
+(PID.TID 0000.0001) SETDIAG: Allocate  1 x  1 Levels for Diagnostic #   123 ADJempmr
+(PID.TID 0000.0001) SETDIAG: Allocate  1 x  1 Levels for Diagnostic #   121 ADJtaux
+(PID.TID 0000.0001) SETDIAG: Allocate  1 x  1 Levels for Diagnostic #   122 ADJtauy
 (PID.TID 0000.0001)   space allocated for all diagnostics:     227 levels
-(PID.TID 0000.0001)   set mate pointer for diag #    80  oceTAUX  , Parms: UU      U1 , mate:    81
-(PID.TID 0000.0001)   set mate pointer for diag #    81  oceTAUY  , Parms: VV      U1 , mate:    80
+(PID.TID 0000.0001)   set mate pointer for diag #    82  oceTAUX  , Parms: UU      U1 , mate:    83
+(PID.TID 0000.0001)   set mate pointer for diag #    83  oceTAUY  , Parms: VV      U1 , mate:    82
 (PID.TID 0000.0001)   set mate pointer for diag #    30  UVEL     , Parms: UUR     MR , mate:    31
 (PID.TID 0000.0001)   set mate pointer for diag #    31  VVEL     , Parms: VVR     MR , mate:    30
-(PID.TID 0000.0001)   set mate pointer for diag #    46  VVELMASS , Parms: VVr     MR , mate:    45
-(PID.TID 0000.0001)   set mate pointer for diag #    45  UVELMASS , Parms: UUr     MR , mate:    46
-(PID.TID 0000.0001)   set mate pointer for diag #   114  ADJuvel  , Parms: UURA    MR , mate:   115
-(PID.TID 0000.0001)   set mate pointer for diag #   115  ADJvvel  , Parms: VVRA    MR , mate:   114
-(PID.TID 0000.0001)   set mate pointer for diag #   119  ADJtaux  , Parms: UU A    U1 , mate:   120
-(PID.TID 0000.0001)   set mate pointer for diag #   120  ADJtauy  , Parms: VV A    U1 , mate:   119
+(PID.TID 0000.0001)   set mate pointer for diag #    47  VVELMASS , Parms: VVr     MR , mate:    46
+(PID.TID 0000.0001)   set mate pointer for diag #    46  UVELMASS , Parms: UUr     MR , mate:    47
+(PID.TID 0000.0001)   set mate pointer for diag #   116  ADJuvel  , Parms: UURA    MR , mate:   117
+(PID.TID 0000.0001)   set mate pointer for diag #   117  ADJvvel  , Parms: VVRA    MR , mate:   116
+(PID.TID 0000.0001)   set mate pointer for diag #   121  ADJtaux  , Parms: UU A    U1 , mate:   122
+(PID.TID 0000.0001)   set mate pointer for diag #   122  ADJtauy  , Parms: VV A    U1 , mate:   121
 (PID.TID 0000.0001) DIAGNOSTICS_SET_POINTERS: Set levels for Outp.Stream: dynDiag
 (PID.TID 0000.0001)  Levels:       1.   2.   3.   4.   5.   6.   7.   8.   9.  10.  11.  12.  13.  14.  15.
 (PID.TID 0000.0001) DIAGNOSTICS_SET_POINTERS: Set levels for Outp.Stream: adjDiag
 (PID.TID 0000.0001)  Levels:       1.   2.   3.   4.   5.   6.   7.   8.   9.  10.  11.  12.  13.  14.  15.
 (PID.TID 0000.0001) DIAGNOSTICS_SET_POINTERS: Set levels for Outp.Stream: adjDiagSurf
 (PID.TID 0000.0001)  Levels:       1.
-(PID.TID 0000.0001) DIAGNOSTICS_SET_POINTERS: done
+(PID.TID 0000.0001) DIAGNOSTICS_SET_POINTERS: done, use     227 levels (numDiags =     600 )
 (PID.TID 0000.0001) ------------------------------------------------------------
 (PID.TID 0000.0001) DIAGSTATS_SET_REGIONS: define   0 regions:
 (PID.TID 0000.0001) ------------------------------------------------------------
@@ -1315,9 +931,8 @@
 (PID.TID 0000.0001) SETDIAG: Allocate 15 Levels for Stats-Diag #    32 WVEL
 (PID.TID 0000.0001) SETDIAG: Allocate 15 Levels for Stats-Diag #    26 THETA
 (PID.TID 0000.0001)   space allocated for all stats-diags:      61 levels
-(PID.TID 0000.0001) DIAGSTATS_SET_POINTERS: done
+(PID.TID 0000.0001) DIAGSTATS_SET_POINTERS: done, use      61 levels (diagSt_size=     150 )
 (PID.TID 0000.0001) ------------------------------------------------------------
-(PID.TID 0000.0001) DIAGSTATS_INI_IO: open file: dynStDiag.0000072000.txt , unit=     9
 (PID.TID 0000.0001) INI_GLOBAL_DOMAIN: Found  19 CS-corner Pts in the domain
 (PID.TID 0000.0001) %MON fCori_max                    =   1.4574827780704E-04
 (PID.TID 0000.0001) %MON fCori_min                    =  -1.4574827780704E-04
@@ -1332,7 +947,6 @@
 (PID.TID 0000.0001) %MON fCoriCos_mean                =   1.1514045869113E-04
 (PID.TID 0000.0001) %MON fCoriCos_sd                  =   3.0375849106513E-05
 (PID.TID 0000.0001) INI_CG2D: CG2D normalisation factor =  1.9156564154949553E-04
-(PID.TID 0000.0001) INI_CG2D: cg2dTolerance = 5.809016360175296E-07 (Area=3.6388673751E+14)
 (PID.TID 0000.0001) 
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // Model configuration
@@ -1556,7 +1170,7 @@
 (PID.TID 0000.0001) hFacMinDr = /* minimum partial cell thickness ( m) */
 (PID.TID 0000.0001)                 2.000000000000000E+01
 (PID.TID 0000.0001)     ;
-(PID.TID 0000.0001) exactConserv =  /* Exact Volume Conservation on/off flag */
+(PID.TID 0000.0001) exactConserv = /* Update etaN from continuity Eq on/off flag */
 (PID.TID 0000.0001)                   T
 (PID.TID 0000.0001)     ;
 (PID.TID 0000.0001) linFSConserveTr = /* Tracer correction for Lin Free Surface on/off flag */
@@ -1636,17 +1250,7 @@
 (PID.TID 0000.0001)                       0
 (PID.TID 0000.0001)     0= Expl. ; 1= Impl. on provis. Vel ; 2= Fully Impl (with surf.P)
 (PID.TID 0000.0001)     ;
-(PID.TID 0000.0001) metricTerms =  /* metric-Terms on/off flag */
-(PID.TID 0000.0001)                   F
-(PID.TID 0000.0001)     ;
 (PID.TID 0000.0001) useNHMTerms = /* Non-Hydrostatic Metric-Terms on/off */
-(PID.TID 0000.0001)                   F
-(PID.TID 0000.0001)     ;
-(PID.TID 0000.0001) selectCoriMap = /* Coriolis Map options (0,1,2,3)*/
-(PID.TID 0000.0001)                       2
-(PID.TID 0000.0001)     0= f-Plane ; 1= Beta-Plane ; 2= Spherical ; 3= read from file
-(PID.TID 0000.0001)     ;
-(PID.TID 0000.0001) use3dCoriolis = /* 3-D Coriolis on/off flag */
 (PID.TID 0000.0001)                   F
 (PID.TID 0000.0001)     ;
 (PID.TID 0000.0001) useCoriolis =  /* Coriolis on/off flag */
@@ -1654,6 +1258,16 @@
 (PID.TID 0000.0001)     ;
 (PID.TID 0000.0001) useCDscheme =  /* CD scheme on/off flag */
 (PID.TID 0000.0001)                   F
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) selectCoriMap = /* Coriolis Map options (0,1,2,3)*/
+(PID.TID 0000.0001)                       2
+(PID.TID 0000.0001)     0= f-Plane ; 1= Beta-Plane ; 2= Spherical ; 3= read from file
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) select3dCoriScheme= /* Scheme selector for 3-D Coriolis-Term */
+(PID.TID 0000.0001)                       0
+(PID.TID 0000.0001)    = 0 : Off (ignore 3-D Coriolis Terms in Omega.Cos(Lat) )
+(PID.TID 0000.0001)    = 1 : original discretization ; = 2 : using averaged Transport
+(PID.TID 0000.0001)    = 3 : same as 2 with hFac in gW_Cor
 (PID.TID 0000.0001)     ;
 (PID.TID 0000.0001) selectCoriScheme= /* Scheme selector for Coriolis-Term */
 (PID.TID 0000.0001)                       0
@@ -1672,6 +1286,7 @@
 (PID.TID 0000.0001)    = 2 : energy conserving scheme (used by Sadourny in JAS 75 paper)
 (PID.TID 0000.0001)    = 3 : energy (general) and enstrophy (2D, nonDiv.) conserving scheme
 (PID.TID 0000.0001)          from Sadourny (Burridge & Haseler, ECMWF Rep.4, 1977)
+(PID.TID 0000.0001)    = 4 : shift 1/hFac from Vorticity to gU,gV tend. (Ang.Mom. conserving)
 (PID.TID 0000.0001)     ;
 (PID.TID 0000.0001) useJamartMomAdv= /* V.I Non-linear terms Jamart flag */
 (PID.TID 0000.0001)                   F
@@ -1726,6 +1341,9 @@
 (PID.TID 0000.0001)     ;
 (PID.TID 0000.0001) tempForcing  =  /* Temperature forcing on/off flag */
 (PID.TID 0000.0001)                   T
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) selectPenetratingSW = /* short wave penetration selector */
+(PID.TID 0000.0001)                       1
 (PID.TID 0000.0001)     ;
 (PID.TID 0000.0001) balanceQnet  =  /* balance net heat-flux on/off flag */
 (PID.TID 0000.0001)                   F
@@ -1813,10 +1431,10 @@
 (PID.TID 0000.0001)                       0
 (PID.TID 0000.0001)     ;
 (PID.TID 0000.0001) cg2dTargetResidual =   /* 2d con. grad target residual  */
-(PID.TID 0000.0001)                 1.000000000000000E-07
+(PID.TID 0000.0001)                 1.000000000000000E-09
 (PID.TID 0000.0001)     ;
 (PID.TID 0000.0001) cg2dTargetResWunit =   /* CG2d target residual [W units] */
-(PID.TID 0000.0001)                 1.000000000000000E-14
+(PID.TID 0000.0001)                -1.000000000000000E+00
 (PID.TID 0000.0001)     ;
 (PID.TID 0000.0001) cg2dPreCondFreq =   /* Freq. for updating cg2d preconditioner */
 (PID.TID 0000.0001)                       1
@@ -2671,6 +2289,15 @@
 (PID.TID 0000.0001) globalArea = /* Integrated horizontal Area (m^2) */
 (PID.TID 0000.0001)                 3.638867375081599E+14
 (PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) rAc_3dMean = /* 3-D Averaged grid-cell Area (m^2) */
+(PID.TID 0000.0001)                 8.193292328209888E+10
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) n2dWetPts = /* Number of wet surface points (-) */
+(PID.TID 0000.0001)                 4.420000000000000E+03
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) n3dWetPts = /* Number of wet grid points (-) */
+(PID.TID 0000.0001)                 5.552200000000000E+04
+(PID.TID 0000.0001)     ;
 (PID.TID 0000.0001) hasWetCSCorners = /* Domain contains CS corners (True/False) */
 (PID.TID 0000.0001)                   T
 (PID.TID 0000.0001)     ;
@@ -2696,11 +2323,14 @@
 (PID.TID 0000.0001) GM_isopycK =    /* Background Isopyc. Diffusivity [m^2/s] */
 (PID.TID 0000.0001)                 1.000000000000000E+03
 (PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) GM_advec*K =    /* Backg. GM-Advec(=Bolus) Diffusivity [m^2/s] */
+(PID.TID 0000.0001)                 0.000000000000000E+00
+(PID.TID 0000.0001)     ;
 (PID.TID 0000.0001) GM_skewflx*K =  /* Background GM_SkewFlx Diffusivity [m^2/s] */
 (PID.TID 0000.0001)                 1.000000000000000E+03
 (PID.TID 0000.0001)     ;
-(PID.TID 0000.0001) GM_advec*K =    /* Backg. GM-Advec(=Bolus) Diffusivity [m^2/s]*/
-(PID.TID 0000.0001)                 0.000000000000000E+00
+(PID.TID 0000.0001) GM_isoFac_calcK = /* Fraction of dynamic K added to Redi tensor */
+(PID.TID 0000.0001)                 1.000000000000000E+00
 (PID.TID 0000.0001)     ;
 (PID.TID 0000.0001) GM_Kmin_horiz = /* Minimum Horizontal Diffusivity [m^2/s] */
 (PID.TID 0000.0001)                 5.000000000000000E+01
@@ -2756,11 +2386,32 @@
 (PID.TID 0000.0001) GM_useLeithQG = /* if TRUE => add QG Leith viscosity to GMRedi tensor */
 (PID.TID 0000.0001)                   F
 (PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) GM_useGEOM = /* using GEOMETRIC */
+(PID.TID 0000.0001)                   F
+(PID.TID 0000.0001)     ;
 (PID.TID 0000.0001) CTRL_CHECK:  --> Starts to check CTRL set-up
 (PID.TID 0000.0001) CTRL_CHECK:  <-- Ends Normally
 (PID.TID 0000.0001) 
 (PID.TID 0000.0001) COST_CHECK: #define ALLOW_COST
 (PID.TID 0000.0001) GRDCHK_CHECK: grdchk package
+(PID.TID 0000.0001) 
+(PID.TID 0000.0001) // =======================================================
+(PID.TID 0000.0001) // Gradient check configuration  >>> START <<<
+(PID.TID 0000.0001) // =======================================================
+(PID.TID 0000.0001) 
+(PID.TID 0000.0001)   grdchkvarindex :                      1
+(PID.TID 0000.0001)   matching CTRL xx_file:       "xx_theta"
+(PID.TID 0000.0001)   eps =                         1.000E-02
+(PID.TID 0000.0001)   First location:                       1
+(PID.TID 0000.0001)   Last location:                        4
+(PID.TID 0000.0001)   Increment:                            1
+(PID.TID 0000.0001)   grdchkWhichProc:                      0
+(PID.TID 0000.0001)   iLocTile =      1 ,   jLocTile =      1
+(PID.TID 0000.0001) 
+(PID.TID 0000.0001) // =======================================================
+(PID.TID 0000.0001) // Gradient check configuration  >>> END <<<
+(PID.TID 0000.0001) // =======================================================
+(PID.TID 0000.0001) 
 (PID.TID 0000.0001) GAD_CHECK: #define ALLOW_GENERIC_ADVDIFF
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // Check Model config. (CONFIG_CHECK):
@@ -2796,28 +2447,28 @@
 (PID.TID 0000.0001) 
  EXTERNAL_FIELDS_LOAD, it=     72000 : Reading new data, i0,i1=   12    1 (prev=   12    0 )
 (PID.TID 0000.0001) SOLVE_FOR_PRESSURE: putPmEinXvector =    F
- cg2d: Sum(rhs),rhsMax =  -9.63495949690696E-12  4.28293538426452E+00
- cg2d: Sum(rhs),rhsMax =  -9.54969436861575E-12  4.28169923847119E+00
- cg2d: Sum(rhs),rhsMax =  -9.80548975348938E-12  4.26963529004741E+00
- cg2d: Sum(rhs),rhsMax =  -9.57811607804615E-12  4.26825643555341E+00
- cg2d: Sum(rhs),rhsMax =  -9.74864633462857E-12  4.26314508307715E+00
+ cg2d: Sum(rhs),rhsMax =  -2.21689333557151E-12  4.28293538426452E+00
+ cg2d: Sum(rhs),rhsMax =  -2.30926389122033E-12  4.28169922329599E+00
+ cg2d: Sum(rhs),rhsMax =  -2.28794760914752E-12  4.26963528595225E+00
+ cg2d: Sum(rhs),rhsMax =  -2.27373675443232E-12  4.26825644232621E+00
+ cg2d: Sum(rhs),rhsMax =  -2.25952589971712E-12  4.26314509314259E+00
 (PID.TID 0000.0001) Did not write pickup because writePickupAtEnd = FALSE
 (PID.TID 0000.0001)   early fc =  0.000000000000000D+00
- --> objf_test(bi,bj)        =  0.112642990319059D+05
- --> objf_test(bi,bj)        =  0.925748325923490D+04
- --> objf_test(bi,bj)        =  0.646782341064632D+04
- --> objf_test(bi,bj)        =  0.425114891594451D+04
- --> objf_test(bi,bj)        =  0.468651159947707D+04
- --> objf_test(bi,bj)        =  0.131971832117793D+05
- --> objf_test(bi,bj)        =  0.111682590494972D+05
- --> objf_test(bi,bj)        =  0.109410446656030D+05
- --> objf_test(bi,bj)        =  0.691550498455277D+04
- --> objf_test(bi,bj)        =  0.683247511182580D+04
- --> objf_test(bi,bj)        =  0.520040324668799D+04
- --> objf_test(bi,bj)        =  0.606296038321234D+04
-(PID.TID 0000.0001)   local fc =  0.962450968703671D+05
-(PID.TID 0000.0001)  global fc =  0.962450968703671D+05
-(PID.TID 0000.0001) grdchk reference fc: fcref       =  9.62450968703671E+04
+ --> objf_test(bi,bj)        =  0.112642990316523D+05
+ --> objf_test(bi,bj)        =  0.925748325913600D+04
+ --> objf_test(bi,bj)        =  0.646782341078077D+04
+ --> objf_test(bi,bj)        =  0.425114891600389D+04
+ --> objf_test(bi,bj)        =  0.468651159967385D+04
+ --> objf_test(bi,bj)        =  0.131971832121774D+05
+ --> objf_test(bi,bj)        =  0.111682590495046D+05
+ --> objf_test(bi,bj)        =  0.109410446654470D+05
+ --> objf_test(bi,bj)        =  0.691550498477741D+04
+ --> objf_test(bi,bj)        =  0.683247511169772D+04
+ --> objf_test(bi,bj)        =  0.520040324655723D+04
+ --> objf_test(bi,bj)        =  0.606296038320584D+04
+(PID.TID 0000.0001)   local fc =  0.962450968706140D+05
+(PID.TID 0000.0001)  global fc =  0.962450968706140D+05
+(PID.TID 0000.0001) grdchk reference fc: fcref       =  9.62450968706140E+04
 grad-res -------------------------------
  grad-res  proc    #    i    j    k   bi   bj iobc       fc ref            fc + eps           fc - eps
  grad-res  proc    #    i    j    k   bi   bj iobc      tlm grad            fd grad          1 - fd/tlm
@@ -2850,32 +2501,32 @@ grad-res -------------------------------
 (PID.TID 0000.0001) 
  EXTERNAL_FIELDS_LOAD, it=     72000 : Reading new data, i0,i1=   12    1 (prev=   12    0 )
 (PID.TID 0000.0001) SOLVE_FOR_PRESSURE: putPmEinXvector =    F
- cg2d: Sum(rhs),rhsMax =  -2.08166817117217E-16  4.97083349095585E-01
- cg2d: Sum(rhs),rhsMax =  -9.63495949690696E-12  4.28293538426480E+00
- cg2d: Sum(rhs),rhsMax =   1.52655665885959E-16  4.61544119515300E-01
- cg2d: Sum(rhs),rhsMax =  -9.89075488178059E-12  4.28169923847316E+00
- cg2d: Sum(rhs),rhsMax =  -6.10622663543836E-16  4.22135511776206E-01
- cg2d: Sum(rhs),rhsMax =  -9.46442924032453E-12  4.26963529004743E+00
- cg2d: Sum(rhs),rhsMax =  -1.66533453693773E-16  3.83666267133075E-01
- cg2d: Sum(rhs),rhsMax =  -9.83391146291979E-12  4.26825643555305E+00
- cg2d: Sum(rhs),rhsMax =   2.35922392732846E-16  3.48096288899501E-01
- cg2d: Sum(rhs),rhsMax =  -9.60653778747655E-12  4.26314508307816E+00
+ cg2d: Sum(rhs),rhsMax =  -4.16333634234434E-16  4.97083349095585E-01
+ cg2d: Sum(rhs),rhsMax =  -2.28794760914752E-12  4.28293538426480E+00
+ cg2d: Sum(rhs),rhsMax =   1.66533453693773E-16  4.61544116304199E-01
+ cg2d: Sum(rhs),rhsMax =  -2.23820961764432E-12  4.28169922329472E+00
+ cg2d: Sum(rhs),rhsMax =   2.77555756156289E-16  4.22135495352740E-01
+ cg2d: Sum(rhs),rhsMax =  -2.26663132707472E-12  4.26963528595195E+00
+ cg2d: Sum(rhs),rhsMax =  -2.22044604925031E-16  3.83666257182794E-01
+ cg2d: Sum(rhs),rhsMax =  -2.26663132707472E-12  4.26825644232617E+00
+ cg2d: Sum(rhs),rhsMax =  -2.77555756156289E-16  3.48096301026668E-01
+ cg2d: Sum(rhs),rhsMax =  -2.24531504500192E-12  4.26314509314283E+00
 (PID.TID 0000.0001) Did not write pickup because writePickupAtEnd = FALSE
 (PID.TID 0000.0001)   early fc =  0.000000000000000D+00
- --> objf_test(bi,bj)        =  0.112642990319058D+05
- --> objf_test(bi,bj)        =  0.925748325923488D+04
- --> objf_test(bi,bj)        =  0.646782341064632D+04
- --> objf_test(bi,bj)        =  0.425114891594450D+04
- --> objf_test(bi,bj)        =  0.468651159947707D+04
- --> objf_test(bi,bj)        =  0.131971832117794D+05
- --> objf_test(bi,bj)        =  0.111682590494972D+05
- --> objf_test(bi,bj)        =  0.109410446656030D+05
- --> objf_test(bi,bj)        =  0.691550498455276D+04
- --> objf_test(bi,bj)        =  0.683247511182581D+04
- --> objf_test(bi,bj)        =  0.520040324668799D+04
- --> objf_test(bi,bj)        =  0.606296038321233D+04
-(PID.TID 0000.0001)   local fc =  0.962450968703671D+05
-(PID.TID 0000.0001)  global fc =  0.962450968703671D+05
+ --> objf_test(bi,bj)        =  0.112642990316523D+05
+ --> objf_test(bi,bj)        =  0.925748325913598D+04
+ --> objf_test(bi,bj)        =  0.646782341078077D+04
+ --> objf_test(bi,bj)        =  0.425114891600389D+04
+ --> objf_test(bi,bj)        =  0.468651159967384D+04
+ --> objf_test(bi,bj)        =  0.131971832121775D+05
+ --> objf_test(bi,bj)        =  0.111682590495045D+05
+ --> objf_test(bi,bj)        =  0.109410446654470D+05
+ --> objf_test(bi,bj)        =  0.691550498477740D+04
+ --> objf_test(bi,bj)        =  0.683247511169771D+04
+ --> objf_test(bi,bj)        =  0.520040324655724D+04
+ --> objf_test(bi,bj)        =  0.606296038320583D+04
+(PID.TID 0000.0001)   local fc =  0.962450968706140D+05
+(PID.TID 0000.0001)  global fc =  0.962450968706140D+05
 (PID.TID 0000.0001)  nRecords = 123 ; filePrec =  64 ; fileIter =     72000
 (PID.TID 0000.0001)     nDims =   2 , dims:
 (PID.TID 0000.0001)    1: 192   1 192
@@ -2900,28 +2551,28 @@ grad-res -------------------------------
 (PID.TID 0000.0001) 
  EXTERNAL_FIELDS_LOAD, it=     72000 : Reading new data, i0,i1=   12    1 (prev=   12    0 )
 (PID.TID 0000.0001) SOLVE_FOR_PRESSURE: putPmEinXvector =    F
- cg2d: Sum(rhs),rhsMax =  -9.66338120633736E-12  4.28293538426452E+00
- cg2d: Sum(rhs),rhsMax =  -9.57811607804615E-12  4.28169923834808E+00
- cg2d: Sum(rhs),rhsMax =  -9.46442924032453E-12  4.26963528989786E+00
- cg2d: Sum(rhs),rhsMax =  -9.89075488178059E-12  4.26825643505683E+00
- cg2d: Sum(rhs),rhsMax =  -9.83391146291979E-12  4.26314508222955E+00
+ cg2d: Sum(rhs),rhsMax =  -2.22399876292911E-12  4.28293538426452E+00
+ cg2d: Sum(rhs),rhsMax =  -2.25242047235952E-12  4.28169922325442E+00
+ cg2d: Sum(rhs),rhsMax =  -2.29505303650512E-12  4.26963528576028E+00
+ cg2d: Sum(rhs),rhsMax =  -2.33768560065073E-12  4.26825644185676E+00
+ cg2d: Sum(rhs),rhsMax =  -2.26663132707472E-12  4.26314509230660E+00
 (PID.TID 0000.0001) Did not write pickup because writePickupAtEnd = FALSE
 (PID.TID 0000.0001)   early fc =  0.000000000000000D+00
- --> objf_test(bi,bj)        =  0.112643372537197D+05
- --> objf_test(bi,bj)        =  0.925748325937274D+04
- --> objf_test(bi,bj)        =  0.646782341056008D+04
- --> objf_test(bi,bj)        =  0.425114891592850D+04
- --> objf_test(bi,bj)        =  0.468651159947307D+04
- --> objf_test(bi,bj)        =  0.131971832117306D+05
- --> objf_test(bi,bj)        =  0.111682590494812D+05
- --> objf_test(bi,bj)        =  0.109410446656234D+05
- --> objf_test(bi,bj)        =  0.691550498459337D+04
- --> objf_test(bi,bj)        =  0.683247680478209D+04
- --> objf_test(bi,bj)        =  0.520040324674087D+04
- --> objf_test(bi,bj)        =  0.606296259734182D+04
-(PID.TID 0000.0001)   local fc =  0.962451389993475D+05
-(PID.TID 0000.0001)  global fc =  0.962451389993475D+05
-(PID.TID 0000.0001) grdchk perturb(+)fc: fcpertplus  =  9.62451389993475E+04
+ --> objf_test(bi,bj)        =  0.112643372534519D+05
+ --> objf_test(bi,bj)        =  0.925748325927353D+04
+ --> objf_test(bi,bj)        =  0.646782341069408D+04
+ --> objf_test(bi,bj)        =  0.425114891598804D+04
+ --> objf_test(bi,bj)        =  0.468651159966980D+04
+ --> objf_test(bi,bj)        =  0.131971832121286D+05
+ --> objf_test(bi,bj)        =  0.111682590494886D+05
+ --> objf_test(bi,bj)        =  0.109410446654674D+05
+ --> objf_test(bi,bj)        =  0.691550498481766D+04
+ --> objf_test(bi,bj)        =  0.683247680465171D+04
+ --> objf_test(bi,bj)        =  0.520040324661009D+04
+ --> objf_test(bi,bj)        =  0.606296259735371D+04
+(PID.TID 0000.0001)   local fc =  0.962451389995951D+05
+(PID.TID 0000.0001)  global fc =  0.962451389995951D+05
+(PID.TID 0000.0001) grdchk perturb(+)fc: fcpertplus  =  9.62451389995951E+04
 (PID.TID 0000.0001)  nRecords = 123 ; filePrec =  64 ; fileIter =     72000
 (PID.TID 0000.0001)     nDims =   2 , dims:
 (PID.TID 0000.0001)    1: 192   1 192
@@ -2946,34 +2597,34 @@ grad-res -------------------------------
 (PID.TID 0000.0001) 
  EXTERNAL_FIELDS_LOAD, it=     72000 : Reading new data, i0,i1=   12    1 (prev=   12    0 )
 (PID.TID 0000.0001) SOLVE_FOR_PRESSURE: putPmEinXvector =    F
- cg2d: Sum(rhs),rhsMax =  -9.66338120633736E-12  4.28293538426452E+00
- cg2d: Sum(rhs),rhsMax =  -9.66338120633736E-12  4.28169923859646E+00
- cg2d: Sum(rhs),rhsMax =  -9.69180291576777E-12  4.26963529019077E+00
- cg2d: Sum(rhs),rhsMax =  -9.69180291576777E-12  4.26825643604795E+00
- cg2d: Sum(rhs),rhsMax =  -9.43600753089413E-12  4.26314508391993E+00
+ cg2d: Sum(rhs),rhsMax =  -2.21689333557151E-12  4.28293538426452E+00
+ cg2d: Sum(rhs),rhsMax =  -2.31636931857793E-12  4.28169922333961E+00
+ cg2d: Sum(rhs),rhsMax =  -2.27373675443232E-12  4.26963528614495E+00
+ cg2d: Sum(rhs),rhsMax =  -2.24531504500192E-12  4.26825644279558E+00
+ cg2d: Sum(rhs),rhsMax =  -2.23110419028671E-12  4.26314509397699E+00
 (PID.TID 0000.0001) Did not write pickup because writePickupAtEnd = FALSE
 (PID.TID 0000.0001)   early fc =  0.000000000000000D+00
- --> objf_test(bi,bj)        =  0.112642609186992D+05
- --> objf_test(bi,bj)        =  0.925748325909704D+04
- --> objf_test(bi,bj)        =  0.646782341073247D+04
- --> objf_test(bi,bj)        =  0.425114891596055D+04
- --> objf_test(bi,bj)        =  0.468651159948100D+04
- --> objf_test(bi,bj)        =  0.131971832118282D+05
- --> objf_test(bi,bj)        =  0.111682590495131D+05
- --> objf_test(bi,bj)        =  0.109410446655825D+05
- --> objf_test(bi,bj)        =  0.691550498451220D+04
- --> objf_test(bi,bj)        =  0.683247342113420D+04
- --> objf_test(bi,bj)        =  0.520040324663511D+04
- --> objf_test(bi,bj)        =  0.606295817145302D+04
-(PID.TID 0000.0001)   local fc =  0.962450548546287D+05
-(PID.TID 0000.0001)  global fc =  0.962450548546287D+05
-(PID.TID 0000.0001) grdchk perturb(-)fc: fcpertminus =  9.62450548546287E+04
+ --> objf_test(bi,bj)        =  0.112642609184597D+05
+ --> objf_test(bi,bj)        =  0.925748325899845D+04
+ --> objf_test(bi,bj)        =  0.646782341086739D+04
+ --> objf_test(bi,bj)        =  0.425114891601979D+04
+ --> objf_test(bi,bj)        =  0.468651159967785D+04
+ --> objf_test(bi,bj)        =  0.131971832122264D+05
+ --> objf_test(bi,bj)        =  0.111682590495205D+05
+ --> objf_test(bi,bj)        =  0.109410446654265D+05
+ --> objf_test(bi,bj)        =  0.691550498473716D+04
+ --> objf_test(bi,bj)        =  0.683247342100888D+04
+ --> objf_test(bi,bj)        =  0.520040324650437D+04
+ --> objf_test(bi,bj)        =  0.606295817142799D+04
+(PID.TID 0000.0001)   local fc =  0.962450548548750D+05
+(PID.TID 0000.0001)  global fc =  0.962450548548750D+05
+(PID.TID 0000.0001) grdchk perturb(-)fc: fcpertminus =  9.62450548548750E+04
 grad-res -------------------------------
- grad-res     0    1    1    1    1    1    1    1   9.62450968704E+04  9.62451389993E+04  9.62450548546E+04
- grad-res     0    1    1    1    0    1    1    1   4.20723620988E+00  4.20723593998E+00  6.41516283428E-08
-(PID.TID 0000.0001)  TLM  ref_cost_function      =  9.62450968703671E+04
-(PID.TID 0000.0001)  TLM  tangent-lin_grad       =  4.20723620987642E+00
-(PID.TID 0000.0001)  TLM  finite-diff_grad       =  4.20723593997536E+00
+ grad-res     0    1    1    1    1    1    1    1   9.62450968706E+04  9.62451389996E+04  9.62450548549E+04
+ grad-res     0    1    1    1    0    1    1    1   4.20723634324E+00  4.20723600764E+00  7.97665681285E-08
+(PID.TID 0000.0001)  TLM  ref_cost_function      =  9.62450968706140E+04
+(PID.TID 0000.0001)  TLM  tangent-lin_grad       =  4.20723634323857E+00
+(PID.TID 0000.0001)  TLM  finite-diff_grad       =  4.20723600764177E+00
 (PID.TID 0000.0001) ====== End of gradient-check number   1 (ierr=  0) =======
 (PID.TID 0000.0001) ====== Starts gradient-check number   2 (=ichknum) =======
  ph-test icomp, ncvarcomp, ichknum            2       55522           2
@@ -3005,31 +2656,31 @@ grad-res -------------------------------
  EXTERNAL_FIELDS_LOAD, it=     72000 : Reading new data, i0,i1=   12    1 (prev=   12    0 )
 (PID.TID 0000.0001) SOLVE_FOR_PRESSURE: putPmEinXvector =    F
  cg2d: Sum(rhs),rhsMax =   5.55111512312578E-17  5.21328928551239E-01
- cg2d: Sum(rhs),rhsMax =  -9.63495949690696E-12  4.28293538426480E+00
- cg2d: Sum(rhs),rhsMax =   2.77555756156289E-16  4.94127340983262E-01
- cg2d: Sum(rhs),rhsMax =  -9.89075488178059E-12  4.28169923847316E+00
- cg2d: Sum(rhs),rhsMax =  -2.35922392732846E-16  4.62627002996203E-01
- cg2d: Sum(rhs),rhsMax =  -9.46442924032453E-12  4.26963529004743E+00
- cg2d: Sum(rhs),rhsMax =  -8.32667268468867E-17  4.30994943752776E-01
- cg2d: Sum(rhs),rhsMax =  -9.83391146291979E-12  4.26825643555305E+00
- cg2d: Sum(rhs),rhsMax =  -6.93889390390723E-17  3.99981649106928E-01
- cg2d: Sum(rhs),rhsMax =  -9.60653778747655E-12  4.26314508307816E+00
+ cg2d: Sum(rhs),rhsMax =  -2.28794760914752E-12  4.28293538426480E+00
+ cg2d: Sum(rhs),rhsMax =  -7.77156117237610E-16  4.94127340224313E-01
+ cg2d: Sum(rhs),rhsMax =  -2.23820961764432E-12  4.28169922329472E+00
+ cg2d: Sum(rhs),rhsMax =   3.33066907387547E-16  4.62626997528516E-01
+ cg2d: Sum(rhs),rhsMax =  -2.26663132707472E-12  4.26963528595195E+00
+ cg2d: Sum(rhs),rhsMax =  -3.88578058618805E-16  4.30994935773940E-01
+ cg2d: Sum(rhs),rhsMax =  -2.26663132707472E-12  4.26825644232617E+00
+ cg2d: Sum(rhs),rhsMax =   4.44089209850063E-16  3.99981641086419E-01
+ cg2d: Sum(rhs),rhsMax =  -2.24531504500192E-12  4.26314509314283E+00
 (PID.TID 0000.0001) Did not write pickup because writePickupAtEnd = FALSE
 (PID.TID 0000.0001)   early fc =  0.000000000000000D+00
- --> objf_test(bi,bj)        =  0.112642990319058D+05
- --> objf_test(bi,bj)        =  0.925748325923488D+04
- --> objf_test(bi,bj)        =  0.646782341064632D+04
- --> objf_test(bi,bj)        =  0.425114891594450D+04
- --> objf_test(bi,bj)        =  0.468651159947707D+04
- --> objf_test(bi,bj)        =  0.131971832117794D+05
- --> objf_test(bi,bj)        =  0.111682590494972D+05
- --> objf_test(bi,bj)        =  0.109410446656030D+05
- --> objf_test(bi,bj)        =  0.691550498455276D+04
- --> objf_test(bi,bj)        =  0.683247511182581D+04
- --> objf_test(bi,bj)        =  0.520040324668799D+04
- --> objf_test(bi,bj)        =  0.606296038321233D+04
-(PID.TID 0000.0001)   local fc =  0.962450968703671D+05
-(PID.TID 0000.0001)  global fc =  0.962450968703671D+05
+ --> objf_test(bi,bj)        =  0.112642990316523D+05
+ --> objf_test(bi,bj)        =  0.925748325913598D+04
+ --> objf_test(bi,bj)        =  0.646782341078077D+04
+ --> objf_test(bi,bj)        =  0.425114891600389D+04
+ --> objf_test(bi,bj)        =  0.468651159967384D+04
+ --> objf_test(bi,bj)        =  0.131971832121775D+05
+ --> objf_test(bi,bj)        =  0.111682590495045D+05
+ --> objf_test(bi,bj)        =  0.109410446654470D+05
+ --> objf_test(bi,bj)        =  0.691550498477740D+04
+ --> objf_test(bi,bj)        =  0.683247511169771D+04
+ --> objf_test(bi,bj)        =  0.520040324655724D+04
+ --> objf_test(bi,bj)        =  0.606296038320583D+04
+(PID.TID 0000.0001)   local fc =  0.962450968706140D+05
+(PID.TID 0000.0001)  global fc =  0.962450968706140D+05
 (PID.TID 0000.0001)  nRecords = 123 ; filePrec =  64 ; fileIter =     72000
 (PID.TID 0000.0001)     nDims =   2 , dims:
 (PID.TID 0000.0001)    1: 192   1 192
@@ -3054,28 +2705,28 @@ grad-res -------------------------------
 (PID.TID 0000.0001) 
  EXTERNAL_FIELDS_LOAD, it=     72000 : Reading new data, i0,i1=   12    1 (prev=   12    0 )
 (PID.TID 0000.0001) SOLVE_FOR_PRESSURE: putPmEinXvector =    F
- cg2d: Sum(rhs),rhsMax =  -9.69180291576777E-12  4.28293538426452E+00
- cg2d: Sum(rhs),rhsMax =  -9.63495949690696E-12  4.28169923848898E+00
- cg2d: Sum(rhs),rhsMax =  -9.69180291576777E-12  4.26963528967151E+00
- cg2d: Sum(rhs),rhsMax =  -9.49285094975494E-12  4.26825643475361E+00
- cg2d: Sum(rhs),rhsMax =  -9.72022462519817E-12  4.26314508164779E+00
+ cg2d: Sum(rhs),rhsMax =  -2.21689333557151E-12  4.28293538426452E+00
+ cg2d: Sum(rhs),rhsMax =  -2.26663132707472E-12  4.28169922322913E+00
+ cg2d: Sum(rhs),rhsMax =  -2.21689333557151E-12  4.26963528562166E+00
+ cg2d: Sum(rhs),rhsMax =  -2.22399876292911E-12  4.26825644151318E+00
+ cg2d: Sum(rhs),rhsMax =  -2.20978790821391E-12  4.26314509169905E+00
 (PID.TID 0000.0001) Did not write pickup because writePickupAtEnd = FALSE
 (PID.TID 0000.0001)   early fc =  0.000000000000000D+00
- --> objf_test(bi,bj)        =  0.112643378706429D+05
- --> objf_test(bi,bj)        =  0.925748325947092D+04
- --> objf_test(bi,bj)        =  0.646782341049779D+04
- --> objf_test(bi,bj)        =  0.425114891591706D+04
- --> objf_test(bi,bj)        =  0.468651159946984D+04
- --> objf_test(bi,bj)        =  0.131971832116948D+05
- --> objf_test(bi,bj)        =  0.111682590494701D+05
- --> objf_test(bi,bj)        =  0.109410446656374D+05
- --> objf_test(bi,bj)        =  0.691550498462186D+04
- --> objf_test(bi,bj)        =  0.683247522814915D+04
- --> objf_test(bi,bj)        =  0.520040324677840D+04
- --> objf_test(bi,bj)        =  0.606296159023752D+04
-(PID.TID 0000.0001)   local fc =  0.962451370325877D+05
-(PID.TID 0000.0001)  global fc =  0.962451370325877D+05
-(PID.TID 0000.0001) grdchk perturb(+)fc: fcpertplus  =  9.62451370325877E+04
+ --> objf_test(bi,bj)        =  0.112643378703818D+05
+ --> objf_test(bi,bj)        =  0.925748325937043D+04
+ --> objf_test(bi,bj)        =  0.646782341063206D+04
+ --> objf_test(bi,bj)        =  0.425114891597667D+04
+ --> objf_test(bi,bj)        =  0.468651159966679D+04
+ --> objf_test(bi,bj)        =  0.131971832120929D+05
+ --> objf_test(bi,bj)        =  0.111682590494772D+05
+ --> objf_test(bi,bj)        =  0.109410446654817D+05
+ --> objf_test(bi,bj)        =  0.691550498484629D+04
+ --> objf_test(bi,bj)        =  0.683247522802557D+04
+ --> objf_test(bi,bj)        =  0.520040324664761D+04
+ --> objf_test(bi,bj)        =  0.606296159023828D+04
+(PID.TID 0000.0001)   local fc =  0.962451370328374D+05
+(PID.TID 0000.0001)  global fc =  0.962451370328374D+05
+(PID.TID 0000.0001) grdchk perturb(+)fc: fcpertplus  =  9.62451370328374E+04
 (PID.TID 0000.0001)  nRecords = 123 ; filePrec =  64 ; fileIter =     72000
 (PID.TID 0000.0001)     nDims =   2 , dims:
 (PID.TID 0000.0001)    1: 192   1 192
@@ -3100,34 +2751,34 @@ grad-res -------------------------------
 (PID.TID 0000.0001) 
  EXTERNAL_FIELDS_LOAD, it=     72000 : Reading new data, i0,i1=   12    1 (prev=   12    0 )
 (PID.TID 0000.0001) SOLVE_FOR_PRESSURE: putPmEinXvector =    F
- cg2d: Sum(rhs),rhsMax =  -9.63495949690696E-12  4.28293538426452E+00
- cg2d: Sum(rhs),rhsMax =  -9.63495949690696E-12  4.28169923845654E+00
- cg2d: Sum(rhs),rhsMax =  -9.54969436861575E-12  4.26963529041537E+00
- cg2d: Sum(rhs),rhsMax =  -9.72022462519817E-12  4.26825643635290E+00
- cg2d: Sum(rhs),rhsMax =  -9.74864633462857E-12  4.26314508450758E+00
+ cg2d: Sum(rhs),rhsMax =  -2.21689333557151E-12  4.28293538426452E+00
+ cg2d: Sum(rhs),rhsMax =  -2.20268248085631E-12  4.28169922336588E+00
+ cg2d: Sum(rhs),rhsMax =  -2.28084218178992E-12  4.26963528628581E+00
+ cg2d: Sum(rhs),rhsMax =  -2.22399876292911E-12  4.26825644314091E+00
+ cg2d: Sum(rhs),rhsMax =  -2.25242047235952E-12  4.26314509458705E+00
 (PID.TID 0000.0001) Did not write pickup because writePickupAtEnd = FALSE
 (PID.TID 0000.0001)   early fc =  0.000000000000000D+00
- --> objf_test(bi,bj)        =  0.112642603170864D+05
- --> objf_test(bi,bj)        =  0.925748325899883D+04
- --> objf_test(bi,bj)        =  0.646782341079480D+04
- --> objf_test(bi,bj)        =  0.425114891597197D+04
- --> objf_test(bi,bj)        =  0.468651159948426D+04
- --> objf_test(bi,bj)        =  0.131971832118641D+05
- --> objf_test(bi,bj)        =  0.111682590495243D+05
- --> objf_test(bi,bj)        =  0.109410446655686D+05
- --> objf_test(bi,bj)        =  0.691550498448368D+04
- --> objf_test(bi,bj)        =  0.683247499554683D+04
- --> objf_test(bi,bj)        =  0.520040324659764D+04
- --> objf_test(bi,bj)        =  0.606295917753553D+04
-(PID.TID 0000.0001)   local fc =  0.962450568334570D+05
-(PID.TID 0000.0001)  global fc =  0.962450568334570D+05
-(PID.TID 0000.0001) grdchk perturb(-)fc: fcpertminus =  9.62450568334570E+04
+ --> objf_test(bi,bj)        =  0.112642603168408D+05
+ --> objf_test(bi,bj)        =  0.925748325890166D+04
+ --> objf_test(bi,bj)        =  0.646782341092942D+04
+ --> objf_test(bi,bj)        =  0.425114891603114D+04
+ --> objf_test(bi,bj)        =  0.468651159968083D+04
+ --> objf_test(bi,bj)        =  0.131971832122620D+05
+ --> objf_test(bi,bj)        =  0.111682590495320D+05
+ --> objf_test(bi,bj)        =  0.109410446654122D+05
+ --> objf_test(bi,bj)        =  0.691550498470853D+04
+ --> objf_test(bi,bj)        =  0.683247499541433D+04
+ --> objf_test(bi,bj)        =  0.520040324646685D+04
+ --> objf_test(bi,bj)        =  0.606295917752177D+04
+(PID.TID 0000.0001)   local fc =  0.962450568337015D+05
+(PID.TID 0000.0001)  global fc =  0.962450568337015D+05
+(PID.TID 0000.0001) grdchk perturb(-)fc: fcpertminus =  9.62450568337015E+04
 grad-res -------------------------------
- grad-res     0    2    2    1    1    1    1    1   9.62450968704E+04  9.62451370326E+04  9.62450568335E+04
- grad-res     0    2    2    2    0    1    1    1   4.00969523493E+00  4.00995653617E+00 -6.51673570315E-05
-(PID.TID 0000.0001)  TLM  ref_cost_function      =  9.62450968703671E+04
-(PID.TID 0000.0001)  TLM  tangent-lin_grad       =  4.00969523493332E+00
-(PID.TID 0000.0001)  TLM  finite-diff_grad       =  4.00995653617429E+00
+ grad-res     0    2    2    1    1    1    1    1   9.62450968706E+04  9.62451370328E+04  9.62450568337E+04
+ grad-res     0    2    2    2    0    1    1    1   4.00969551983E+00  4.00995679374E+00 -6.51605369553E-05
+(PID.TID 0000.0001)  TLM  ref_cost_function      =  9.62450968706140E+04
+(PID.TID 0000.0001)  TLM  tangent-lin_grad       =  4.00969551983009E+00
+(PID.TID 0000.0001)  TLM  finite-diff_grad       =  4.00995679374319E+00
 (PID.TID 0000.0001) ====== End of gradient-check number   2 (ierr=  0) =======
 (PID.TID 0000.0001) ====== Starts gradient-check number   3 (=ichknum) =======
  ph-test icomp, ncvarcomp, ichknum            3       55522           3
@@ -3158,32 +2809,32 @@ grad-res -------------------------------
 (PID.TID 0000.0001) 
  EXTERNAL_FIELDS_LOAD, it=     72000 : Reading new data, i0,i1=   12    1 (prev=   12    0 )
 (PID.TID 0000.0001) SOLVE_FOR_PRESSURE: putPmEinXvector =    F
- cg2d: Sum(rhs),rhsMax =   2.77555756156289E-17  5.14783382156190E-01
- cg2d: Sum(rhs),rhsMax =  -9.63495949690696E-12  4.28293538426480E+00
- cg2d: Sum(rhs),rhsMax =  -1.38777878078145E-16  4.91304295893306E-01
- cg2d: Sum(rhs),rhsMax =  -9.89075488178059E-12  4.28169923847316E+00
- cg2d: Sum(rhs),rhsMax =   4.16333634234434E-17  4.63551401247431E-01
- cg2d: Sum(rhs),rhsMax =  -9.46442924032453E-12  4.26963529004743E+00
- cg2d: Sum(rhs),rhsMax =   6.93889390390723E-17  4.35782778985409E-01
- cg2d: Sum(rhs),rhsMax =  -9.83391146291979E-12  4.26825643555305E+00
- cg2d: Sum(rhs),rhsMax =   2.63677968348475E-16  4.07970706211293E-01
- cg2d: Sum(rhs),rhsMax =  -9.60653778747655E-12  4.26314508307816E+00
+ cg2d: Sum(rhs),rhsMax =   0.00000000000000E+00  5.14783382156190E-01
+ cg2d: Sum(rhs),rhsMax =  -2.28794760914752E-12  4.28293538426480E+00
+ cg2d: Sum(rhs),rhsMax =  -5.55111512312578E-17  4.91304295310166E-01
+ cg2d: Sum(rhs),rhsMax =  -2.23820961764432E-12  4.28169922329472E+00
+ cg2d: Sum(rhs),rhsMax =   5.55111512312578E-16  4.63551399733279E-01
+ cg2d: Sum(rhs),rhsMax =  -2.26663132707472E-12  4.26963528595195E+00
+ cg2d: Sum(rhs),rhsMax =   0.00000000000000E+00  4.35782774450503E-01
+ cg2d: Sum(rhs),rhsMax =  -2.26663132707472E-12  4.26825644232617E+00
+ cg2d: Sum(rhs),rhsMax =  -1.66533453693773E-16  4.07970693739567E-01
+ cg2d: Sum(rhs),rhsMax =  -2.24531504500192E-12  4.26314509314283E+00
 (PID.TID 0000.0001) Did not write pickup because writePickupAtEnd = FALSE
 (PID.TID 0000.0001)   early fc =  0.000000000000000D+00
- --> objf_test(bi,bj)        =  0.112642990319058D+05
- --> objf_test(bi,bj)        =  0.925748325923488D+04
- --> objf_test(bi,bj)        =  0.646782341064632D+04
- --> objf_test(bi,bj)        =  0.425114891594450D+04
- --> objf_test(bi,bj)        =  0.468651159947707D+04
- --> objf_test(bi,bj)        =  0.131971832117794D+05
- --> objf_test(bi,bj)        =  0.111682590494972D+05
- --> objf_test(bi,bj)        =  0.109410446656030D+05
- --> objf_test(bi,bj)        =  0.691550498455276D+04
- --> objf_test(bi,bj)        =  0.683247511182581D+04
- --> objf_test(bi,bj)        =  0.520040324668799D+04
- --> objf_test(bi,bj)        =  0.606296038321233D+04
-(PID.TID 0000.0001)   local fc =  0.962450968703671D+05
-(PID.TID 0000.0001)  global fc =  0.962450968703671D+05
+ --> objf_test(bi,bj)        =  0.112642990316523D+05
+ --> objf_test(bi,bj)        =  0.925748325913598D+04
+ --> objf_test(bi,bj)        =  0.646782341078077D+04
+ --> objf_test(bi,bj)        =  0.425114891600389D+04
+ --> objf_test(bi,bj)        =  0.468651159967384D+04
+ --> objf_test(bi,bj)        =  0.131971832121775D+05
+ --> objf_test(bi,bj)        =  0.111682590495045D+05
+ --> objf_test(bi,bj)        =  0.109410446654470D+05
+ --> objf_test(bi,bj)        =  0.691550498477740D+04
+ --> objf_test(bi,bj)        =  0.683247511169771D+04
+ --> objf_test(bi,bj)        =  0.520040324655724D+04
+ --> objf_test(bi,bj)        =  0.606296038320583D+04
+(PID.TID 0000.0001)   local fc =  0.962450968706140D+05
+(PID.TID 0000.0001)  global fc =  0.962450968706140D+05
 (PID.TID 0000.0001)  nRecords = 123 ; filePrec =  64 ; fileIter =     72000
 (PID.TID 0000.0001)     nDims =   2 , dims:
 (PID.TID 0000.0001)    1: 192   1 192
@@ -3208,28 +2859,28 @@ grad-res -------------------------------
 (PID.TID 0000.0001) 
  EXTERNAL_FIELDS_LOAD, it=     72000 : Reading new data, i0,i1=   12    1 (prev=   12    0 )
 (PID.TID 0000.0001) SOLVE_FOR_PRESSURE: putPmEinXvector =    F
- cg2d: Sum(rhs),rhsMax =  -9.63495949690696E-12  4.28293538426452E+00
- cg2d: Sum(rhs),rhsMax =  -9.57811607804615E-12  4.28169923834804E+00
- cg2d: Sum(rhs),rhsMax =  -9.80548975348938E-12  4.26963528960830E+00
- cg2d: Sum(rhs),rhsMax =  -9.89075488178059E-12  4.26825643444512E+00
- cg2d: Sum(rhs),rhsMax =  -9.74864633462857E-12  4.26314508111679E+00
+ cg2d: Sum(rhs),rhsMax =  -2.21689333557151E-12  4.28293538426452E+00
+ cg2d: Sum(rhs),rhsMax =  -2.30215846386272E-12  4.28169922320049E+00
+ cg2d: Sum(rhs),rhsMax =  -2.28794760914752E-12  4.26963528550473E+00
+ cg2d: Sum(rhs),rhsMax =  -2.29505303650512E-12  4.26825644122350E+00
+ cg2d: Sum(rhs),rhsMax =  -2.28794760914752E-12  4.26314509118641E+00
 (PID.TID 0000.0001) Did not write pickup because writePickupAtEnd = FALSE
 (PID.TID 0000.0001)   early fc =  0.000000000000000D+00
- --> objf_test(bi,bj)        =  0.112643321737231D+05
- --> objf_test(bi,bj)        =  0.925748325954393D+04
- --> objf_test(bi,bj)        =  0.646782341044705D+04
- --> objf_test(bi,bj)        =  0.425114891590794D+04
- --> objf_test(bi,bj)        =  0.468651159946771D+04
- --> objf_test(bi,bj)        =  0.131971832116658D+05
- --> objf_test(bi,bj)        =  0.111682590494606D+05
- --> objf_test(bi,bj)        =  0.109410446656495D+05
- --> objf_test(bi,bj)        =  0.691550498464398D+04
- --> objf_test(bi,bj)        =  0.683247511589005D+04
- --> objf_test(bi,bj)        =  0.520040324680865D+04
- --> objf_test(bi,bj)        =  0.606296088558872D+04
-(PID.TID 0000.0001)   local fc =  0.962451305187970D+05
-(PID.TID 0000.0001)  global fc =  0.962451305187970D+05
-(PID.TID 0000.0001) grdchk perturb(+)fc: fcpertplus  =  9.62451305187970E+04
+ --> objf_test(bi,bj)        =  0.112643321734692D+05
+ --> objf_test(bi,bj)        =  0.925748325944748D+04
+ --> objf_test(bi,bj)        =  0.646782341058179D+04
+ --> objf_test(bi,bj)        =  0.425114891596741D+04
+ --> objf_test(bi,bj)        =  0.468651159966445D+04
+ --> objf_test(bi,bj)        =  0.131971832120639D+05
+ --> objf_test(bi,bj)        =  0.111682590494679D+05
+ --> objf_test(bi,bj)        =  0.109410446654931D+05
+ --> objf_test(bi,bj)        =  0.691550498486921D+04
+ --> objf_test(bi,bj)        =  0.683247511576356D+04
+ --> objf_test(bi,bj)        =  0.520040324667783D+04
+ --> objf_test(bi,bj)        =  0.606296088557794D+04
+(PID.TID 0000.0001)   local fc =  0.962451305190438D+05
+(PID.TID 0000.0001)  global fc =  0.962451305190438D+05
+(PID.TID 0000.0001) grdchk perturb(+)fc: fcpertplus  =  9.62451305190438E+04
 (PID.TID 0000.0001)  nRecords = 123 ; filePrec =  64 ; fileIter =     72000
 (PID.TID 0000.0001)     nDims =   2 , dims:
 (PID.TID 0000.0001)    1: 192   1 192
@@ -3254,34 +2905,34 @@ grad-res -------------------------------
 (PID.TID 0000.0001) 
  EXTERNAL_FIELDS_LOAD, it=     72000 : Reading new data, i0,i1=   12    1 (prev=   12    0 )
 (PID.TID 0000.0001) SOLVE_FOR_PRESSURE: putPmEinXvector =    F
- cg2d: Sum(rhs),rhsMax =  -9.66338120633736E-12  4.28293538426452E+00
- cg2d: Sum(rhs),rhsMax =  -9.86233317235019E-12  4.28169923859372E+00
- cg2d: Sum(rhs),rhsMax =  -9.72022462519817E-12  4.26963529048258E+00
- cg2d: Sum(rhs),rhsMax =  -9.46442924032453E-12  4.26825643666237E+00
- cg2d: Sum(rhs),rhsMax =  -9.63495949690696E-12  4.26314508503709E+00
+ cg2d: Sum(rhs),rhsMax =  -2.20978790821391E-12  4.28293538426452E+00
+ cg2d: Sum(rhs),rhsMax =  -2.26663132707472E-12  4.28169922339221E+00
+ cg2d: Sum(rhs),rhsMax =  -2.25952589971712E-12  4.26963528640128E+00
+ cg2d: Sum(rhs),rhsMax =  -2.30215846386272E-12  4.26825644343336E+00
+ cg2d: Sum(rhs),rhsMax =  -2.30926389122033E-12  4.26314509509832E+00
 (PID.TID 0000.0001) Did not write pickup because writePickupAtEnd = FALSE
 (PID.TID 0000.0001)   early fc =  0.000000000000000D+00
- --> objf_test(bi,bj)        =  0.112642660210549D+05
- --> objf_test(bi,bj)        =  0.925748325892583D+04
- --> objf_test(bi,bj)        =  0.646782341084554D+04
- --> objf_test(bi,bj)        =  0.425114891598100D+04
- --> objf_test(bi,bj)        =  0.468651159948632D+04
- --> objf_test(bi,bj)        =  0.131971832118930D+05
- --> objf_test(bi,bj)        =  0.111682590495339D+05
- --> objf_test(bi,bj)        =  0.109410446655564D+05
- --> objf_test(bi,bj)        =  0.691550498446156D+04
- --> objf_test(bi,bj)        =  0.683247510776259D+04
- --> objf_test(bi,bj)        =  0.520040324656738D+04
- --> objf_test(bi,bj)        =  0.606295988160210D+04
-(PID.TID 0000.0001)   local fc =  0.962450633536705D+05
-(PID.TID 0000.0001)  global fc =  0.962450633536705D+05
-(PID.TID 0000.0001) grdchk perturb(-)fc: fcpertminus =  9.62450633536705E+04
+ --> objf_test(bi,bj)        =  0.112642660208022D+05
+ --> objf_test(bi,bj)        =  0.925748325882465D+04
+ --> objf_test(bi,bj)        =  0.646782341097970D+04
+ --> objf_test(bi,bj)        =  0.425114891604042D+04
+ --> objf_test(bi,bj)        =  0.468651159968322D+04
+ --> objf_test(bi,bj)        =  0.131971832122910D+05
+ --> objf_test(bi,bj)        =  0.111682590495412D+05
+ --> objf_test(bi,bj)        =  0.109410446654009D+05
+ --> objf_test(bi,bj)        =  0.691550498468562D+04
+ --> objf_test(bi,bj)        =  0.683247510763294D+04
+ --> objf_test(bi,bj)        =  0.520040324643669D+04
+ --> objf_test(bi,bj)        =  0.606295988159984D+04
+(PID.TID 0000.0001)   local fc =  0.962450633539184D+05
+(PID.TID 0000.0001)  global fc =  0.962450633539184D+05
+(PID.TID 0000.0001) grdchk perturb(-)fc: fcpertminus =  9.62450633539184E+04
 grad-res -------------------------------
- grad-res     0    3    3    1    1    1    1    1   9.62450968704E+04  9.62451305188E+04  9.62450633537E+04
- grad-res     0    3    3    3    0    1    1    1   3.35834369199E+00  3.35825632210E+00  2.60157694189E-05
-(PID.TID 0000.0001)  TLM  ref_cost_function      =  9.62450968703671E+04
-(PID.TID 0000.0001)  TLM  tangent-lin_grad       =  3.35834369199402E+00
-(PID.TID 0000.0001)  TLM  finite-diff_grad       =  3.35825632209890E+00
+ grad-res     0    3    3    1    1    1    1    1   9.62450968706E+04  9.62451305190E+04  9.62450633539E+04
+ grad-res     0    3    3    3    0    1    1    1   3.35834410266E+00  3.35825627044E+00  2.61534304243E-05
+(PID.TID 0000.0001)  TLM  ref_cost_function      =  9.62450968706140E+04
+(PID.TID 0000.0001)  TLM  tangent-lin_grad       =  3.35834410265843E+00
+(PID.TID 0000.0001)  TLM  finite-diff_grad       =  3.35825627043960E+00
 (PID.TID 0000.0001) ====== End of gradient-check number   3 (ierr=  0) =======
 (PID.TID 0000.0001) ====== Starts gradient-check number   4 (=ichknum) =======
  ph-test icomp, ncvarcomp, ichknum            4       55522           4
@@ -3312,32 +2963,32 @@ grad-res -------------------------------
 (PID.TID 0000.0001) 
  EXTERNAL_FIELDS_LOAD, it=     72000 : Reading new data, i0,i1=   12    1 (prev=   12    0 )
 (PID.TID 0000.0001) SOLVE_FOR_PRESSURE: putPmEinXvector =    F
- cg2d: Sum(rhs),rhsMax =  -2.77555756156289E-17  4.97549420720442E-01
- cg2d: Sum(rhs),rhsMax =  -9.63495949690696E-12  4.28293538426480E+00
- cg2d: Sum(rhs),rhsMax =  -1.11022302462516E-16  4.75651995220081E-01
- cg2d: Sum(rhs),rhsMax =  -9.89075488178059E-12  4.28169923847316E+00
- cg2d: Sum(rhs),rhsMax =  -1.80411241501588E-16  4.49477956093374E-01
- cg2d: Sum(rhs),rhsMax =  -9.46442924032453E-12  4.26963529004743E+00
- cg2d: Sum(rhs),rhsMax =   2.35922392732846E-16  4.23649160367470E-01
- cg2d: Sum(rhs),rhsMax =  -9.83391146291979E-12  4.26825643555305E+00
- cg2d: Sum(rhs),rhsMax =   8.32667268468867E-17  3.97676637341900E-01
- cg2d: Sum(rhs),rhsMax =  -9.60653778747655E-12  4.26314508307816E+00
+ cg2d: Sum(rhs),rhsMax =  -5.55111512312578E-17  4.97549420720442E-01
+ cg2d: Sum(rhs),rhsMax =  -2.28794760914752E-12  4.28293538426480E+00
+ cg2d: Sum(rhs),rhsMax =   2.77555756156289E-16  4.75651995106623E-01
+ cg2d: Sum(rhs),rhsMax =  -2.23820961764432E-12  4.28169922329472E+00
+ cg2d: Sum(rhs),rhsMax =  -3.33066907387547E-16  4.49477957703178E-01
+ cg2d: Sum(rhs),rhsMax =  -2.26663132707472E-12  4.26963528595195E+00
+ cg2d: Sum(rhs),rhsMax =  -2.22044604925031E-16  4.23649157762545E-01
+ cg2d: Sum(rhs),rhsMax =  -2.26663132707472E-12  4.26825644232617E+00
+ cg2d: Sum(rhs),rhsMax =  -1.66533453693773E-16  3.97676627166592E-01
+ cg2d: Sum(rhs),rhsMax =  -2.24531504500192E-12  4.26314509314283E+00
 (PID.TID 0000.0001) Did not write pickup because writePickupAtEnd = FALSE
 (PID.TID 0000.0001)   early fc =  0.000000000000000D+00
- --> objf_test(bi,bj)        =  0.112642990319058D+05
- --> objf_test(bi,bj)        =  0.925748325923488D+04
- --> objf_test(bi,bj)        =  0.646782341064632D+04
- --> objf_test(bi,bj)        =  0.425114891594450D+04
- --> objf_test(bi,bj)        =  0.468651159947707D+04
- --> objf_test(bi,bj)        =  0.131971832117794D+05
- --> objf_test(bi,bj)        =  0.111682590494972D+05
- --> objf_test(bi,bj)        =  0.109410446656030D+05
- --> objf_test(bi,bj)        =  0.691550498455276D+04
- --> objf_test(bi,bj)        =  0.683247511182581D+04
- --> objf_test(bi,bj)        =  0.520040324668799D+04
- --> objf_test(bi,bj)        =  0.606296038321233D+04
-(PID.TID 0000.0001)   local fc =  0.962450968703671D+05
-(PID.TID 0000.0001)  global fc =  0.962450968703671D+05
+ --> objf_test(bi,bj)        =  0.112642990316523D+05
+ --> objf_test(bi,bj)        =  0.925748325913598D+04
+ --> objf_test(bi,bj)        =  0.646782341078077D+04
+ --> objf_test(bi,bj)        =  0.425114891600389D+04
+ --> objf_test(bi,bj)        =  0.468651159967384D+04
+ --> objf_test(bi,bj)        =  0.131971832121775D+05
+ --> objf_test(bi,bj)        =  0.111682590495045D+05
+ --> objf_test(bi,bj)        =  0.109410446654470D+05
+ --> objf_test(bi,bj)        =  0.691550498477740D+04
+ --> objf_test(bi,bj)        =  0.683247511169771D+04
+ --> objf_test(bi,bj)        =  0.520040324655724D+04
+ --> objf_test(bi,bj)        =  0.606296038320583D+04
+(PID.TID 0000.0001)   local fc =  0.962450968706140D+05
+(PID.TID 0000.0001)  global fc =  0.962450968706140D+05
 (PID.TID 0000.0001)  nRecords = 123 ; filePrec =  64 ; fileIter =     72000
 (PID.TID 0000.0001)     nDims =   2 , dims:
 (PID.TID 0000.0001)    1: 192   1 192
@@ -3362,28 +3013,28 @@ grad-res -------------------------------
 (PID.TID 0000.0001) 
  EXTERNAL_FIELDS_LOAD, it=     72000 : Reading new data, i0,i1=   12    1 (prev=   12    0 )
 (PID.TID 0000.0001) SOLVE_FOR_PRESSURE: putPmEinXvector =    F
- cg2d: Sum(rhs),rhsMax =  -9.66338120633736E-12  4.28293538426452E+00
- cg2d: Sum(rhs),rhsMax =  -9.77706804405898E-12  4.28169923829328E+00
- cg2d: Sum(rhs),rhsMax =  -9.52127265918534E-12  4.26963528952197E+00
- cg2d: Sum(rhs),rhsMax =  -9.37916411203332E-12  4.26825643418973E+00
- cg2d: Sum(rhs),rhsMax =  -9.66338120633736E-12  4.26314508067312E+00
+ cg2d: Sum(rhs),rhsMax =  -2.20978790821391E-12  4.28293538426452E+00
+ cg2d: Sum(rhs),rhsMax =  -2.18847162614111E-12  4.28169922318012E+00
+ cg2d: Sum(rhs),rhsMax =  -2.25242047235952E-12  4.26963528540275E+00
+ cg2d: Sum(rhs),rhsMax =  -2.18136619878351E-12  4.26825644096946E+00
+ cg2d: Sum(rhs),rhsMax =  -2.33058017329313E-12  4.26314509074228E+00
 (PID.TID 0000.0001) Did not write pickup because writePickupAtEnd = FALSE
 (PID.TID 0000.0001)   early fc =  0.000000000000000D+00
- --> objf_test(bi,bj)        =  0.112643265415474D+05
- --> objf_test(bi,bj)        =  0.925748325960757D+04
- --> objf_test(bi,bj)        =  0.646782341040589D+04
- --> objf_test(bi,bj)        =  0.425114891590007D+04
- --> objf_test(bi,bj)        =  0.468651159946554D+04
- --> objf_test(bi,bj)        =  0.131971832116433D+05
- --> objf_test(bi,bj)        =  0.111682590494530D+05
- --> objf_test(bi,bj)        =  0.109410446656582D+05
- --> objf_test(bi,bj)        =  0.691550498466291D+04
- --> objf_test(bi,bj)        =  0.683247511172393D+04
- --> objf_test(bi,bj)        =  0.520040324683352D+04
- --> objf_test(bi,bj)        =  0.606296053020935D+04
-(PID.TID 0000.0001)   local fc =  0.962451245271106D+05
-(PID.TID 0000.0001)  global fc =  0.962451245271106D+05
-(PID.TID 0000.0001) grdchk perturb(+)fc: fcpertplus  =  9.62451245271106E+04
+ --> objf_test(bi,bj)        =  0.112643265412939D+05
+ --> objf_test(bi,bj)        =  0.925748325950641D+04
+ --> objf_test(bi,bj)        =  0.646782341054113D+04
+ --> objf_test(bi,bj)        =  0.425114891595962D+04
+ --> objf_test(bi,bj)        =  0.468651159966253D+04
+ --> objf_test(bi,bj)        =  0.131971832120415D+05
+ --> objf_test(bi,bj)        =  0.111682590494601D+05
+ --> objf_test(bi,bj)        =  0.109410446655023D+05
+ --> objf_test(bi,bj)        =  0.691550498488761D+04
+ --> objf_test(bi,bj)        =  0.683247511159254D+04
+ --> objf_test(bi,bj)        =  0.520040324670281D+04
+ --> objf_test(bi,bj)        =  0.606296053020470D+04
+(PID.TID 0000.0001)   local fc =  0.962451245273551D+05
+(PID.TID 0000.0001)  global fc =  0.962451245273551D+05
+(PID.TID 0000.0001) grdchk perturb(+)fc: fcpertplus  =  9.62451245273551E+04
 (PID.TID 0000.0001)  nRecords = 123 ; filePrec =  64 ; fileIter =     72000
 (PID.TID 0000.0001)     nDims =   2 , dims:
 (PID.TID 0000.0001)    1: 192   1 192
@@ -3408,240 +3059,240 @@ grad-res -------------------------------
 (PID.TID 0000.0001) 
  EXTERNAL_FIELDS_LOAD, it=     72000 : Reading new data, i0,i1=   12    1 (prev=   12    0 )
 (PID.TID 0000.0001) SOLVE_FOR_PRESSURE: putPmEinXvector =    F
- cg2d: Sum(rhs),rhsMax =  -9.63495949690696E-12  4.28293538426452E+00
- cg2d: Sum(rhs),rhsMax =  -9.63495949690696E-12  4.28169923864340E+00
- cg2d: Sum(rhs),rhsMax =  -9.72022462519817E-12  4.26963529056705E+00
- cg2d: Sum(rhs),rhsMax =  -9.69180291576777E-12  4.26825643691576E+00
- cg2d: Sum(rhs),rhsMax =  -9.37916411203332E-12  4.26314508548041E+00
+ cg2d: Sum(rhs),rhsMax =  -2.21689333557151E-12  4.28293538426452E+00
+ cg2d: Sum(rhs),rhsMax =  -2.20978790821391E-12  4.28169922341550E+00
+ cg2d: Sum(rhs),rhsMax =  -2.24531504500192E-12  4.26963528650579E+00
+ cg2d: Sum(rhs),rhsMax =  -2.25952589971712E-12  4.26825644368494E+00
+ cg2d: Sum(rhs),rhsMax =  -2.30215846386272E-12  4.26314509554344E+00
 (PID.TID 0000.0001) Did not write pickup because writePickupAtEnd = FALSE
 (PID.TID 0000.0001)   early fc =  0.000000000000000D+00
- --> objf_test(bi,bj)        =  0.112642716549200D+05
- --> objf_test(bi,bj)        =  0.925748325886229D+04
- --> objf_test(bi,bj)        =  0.646782341088669D+04
- --> objf_test(bi,bj)        =  0.425114891598887D+04
- --> objf_test(bi,bj)        =  0.468651159948860D+04
- --> objf_test(bi,bj)        =  0.131971832119155D+05
- --> objf_test(bi,bj)        =  0.111682590495416D+05
- --> objf_test(bi,bj)        =  0.109410446655477D+05
- --> objf_test(bi,bj)        =  0.691550498444261D+04
- --> objf_test(bi,bj)        =  0.683247511192761D+04
- --> objf_test(bi,bj)        =  0.520040324654252D+04
- --> objf_test(bi,bj)        =  0.606296023664371D+04
-(PID.TID 0000.0001)   local fc =  0.962450693467077D+05
-(PID.TID 0000.0001)  global fc =  0.962450693467077D+05
-(PID.TID 0000.0001) grdchk perturb(-)fc: fcpertminus =  9.62450693467077E+04
+ --> objf_test(bi,bj)        =  0.112642716546664D+05
+ --> objf_test(bi,bj)        =  0.925748325876570D+04
+ --> objf_test(bi,bj)        =  0.646782341102032D+04
+ --> objf_test(bi,bj)        =  0.425114891604817D+04
+ --> objf_test(bi,bj)        =  0.468651159968515D+04
+ --> objf_test(bi,bj)        =  0.131971832123136D+05
+ --> objf_test(bi,bj)        =  0.111682590495491D+05
+ --> objf_test(bi,bj)        =  0.109410446653917D+05
+ --> objf_test(bi,bj)        =  0.691550498466722D+04
+ --> objf_test(bi,bj)        =  0.683247511180293D+04
+ --> objf_test(bi,bj)        =  0.520040324641172D+04
+ --> objf_test(bi,bj)        =  0.606296023663539D+04
+(PID.TID 0000.0001)   local fc =  0.962450693469574D+05
+(PID.TID 0000.0001)  global fc =  0.962450693469574D+05
+(PID.TID 0000.0001) grdchk perturb(-)fc: fcpertminus =  9.62450693469574E+04
 grad-res -------------------------------
- grad-res     0    4    4    1    1    1    1    1   9.62450968704E+04  9.62451245271E+04  9.62450693467E+04
- grad-res     0    4    4    4    0    1    1    1   2.75901910607E+00  2.75902014619E+00 -3.76988921413E-07
-(PID.TID 0000.0001)  TLM  ref_cost_function      =  9.62450968703671E+04
-(PID.TID 0000.0001)  TLM  tangent-lin_grad       =  2.75901910606659E+00
-(PID.TID 0000.0001)  TLM  finite-diff_grad       =  2.75902014618623E+00
+ grad-res     0    4    4    1    1    1    1    1   9.62450968706E+04  9.62451245274E+04  9.62450693470E+04
+ grad-res     0    4    4    4    0    1    1    1   2.75901943551E+00  2.75901988498E+00 -1.62910552381E-07
+(PID.TID 0000.0001)  TLM  ref_cost_function      =  9.62450968706140E+04
+(PID.TID 0000.0001)  TLM  tangent-lin_grad       =  2.75901943550597E+00
+(PID.TID 0000.0001)  TLM  finite-diff_grad       =  2.75901988497935E+00
 (PID.TID 0000.0001) ====== End of gradient-check number   4 (ierr=  0) =======
 (PID.TID 0000.0001) 
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // Gradient check results  >>> START <<<
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) 
-(PID.TID 0000.0001)  EPS =   1.000000E-02
+(PID.TID 0000.0001)  EPS = 1.000000E-02 ; grdchk CTRL var/file name: "xx_theta"
 (PID.TID 0000.0001) 
 (PID.TID 0000.0001) grdchk output h.p:  Id Itile Jtile LAYER   bi   bj   X(Id)           X(Id)+/-EPS
 (PID.TID 0000.0001) grdchk output h.c:  Id  FC                   FC1                  FC2
 (PID.TID 0000.0001) grdchk output h.g:  Id     FC1-FC2/(2*EPS)      TLM GRAD(FC)        1-FDGRD/TLMGRD
 (PID.TID 0000.0001) 
 (PID.TID 0000.0001) grdchk output (p):   1     1     1     1    1    1   0.000000000E+00 -1.000000000E-02
-(PID.TID 0000.0001) grdchk output (c):   1  9.6245096870367E+04  9.6245138999347E+04  9.6245054854629E+04
-(PID.TID 0000.0001) grdchk output (g):   1     4.2072359399754E+00  4.2072362098764E+00  6.4151628342834E-08
+(PID.TID 0000.0001) grdchk output (c):   1  9.6245096870614E+04  9.6245138999595E+04  9.6245054854875E+04
+(PID.TID 0000.0001) grdchk output (g):   1     4.2072360076418E+00  4.2072363432386E+00  7.9766568128470E-08
 (PID.TID 0000.0001) 
 (PID.TID 0000.0001) grdchk output (p):   2     2     1     1    1    1   0.000000000E+00 -1.000000000E-02
-(PID.TID 0000.0001) grdchk output (c):   2  9.6245096870367E+04  9.6245137032588E+04  9.6245056833457E+04
-(PID.TID 0000.0001) grdchk output (g):   2     4.0099565361743E+00  4.0096952349333E+00 -6.5167357031548E-05
+(PID.TID 0000.0001) grdchk output (c):   2  9.6245096870614E+04  9.6245137032837E+04  9.6245056833701E+04
+(PID.TID 0000.0001) grdchk output (g):   2     4.0099567937432E+00  4.0096955198301E+00 -6.5160536955267E-05
 (PID.TID 0000.0001) 
 (PID.TID 0000.0001) grdchk output (p):   3     3     1     1    1    1   0.000000000E+00 -1.000000000E-02
-(PID.TID 0000.0001) grdchk output (c):   3  9.6245096870367E+04  9.6245130518797E+04  9.6245063353671E+04
-(PID.TID 0000.0001) grdchk output (g):   3     3.3582563220989E+00  3.3583436919940E+00  2.6015769418852E-05
+(PID.TID 0000.0001) grdchk output (c):   3  9.6245096870614E+04  9.6245130519044E+04  9.6245063353918E+04
+(PID.TID 0000.0001) grdchk output (g):   3     3.3582562704396E+00  3.3583441026584E+00  2.6153430424336E-05
 (PID.TID 0000.0001) 
 (PID.TID 0000.0001) grdchk output (p):   4     4     1     1    1    1   0.000000000E+00 -1.000000000E-02
-(PID.TID 0000.0001) grdchk output (c):   4  9.6245096870367E+04  9.6245124527111E+04  9.6245069346708E+04
-(PID.TID 0000.0001) grdchk output (g):   4     2.7590201461862E+00  2.7590191060666E+00 -3.7698892141336E-07
+(PID.TID 0000.0001) grdchk output (c):   4  9.6245096870614E+04  9.6245124527355E+04  9.6245069346957E+04
+(PID.TID 0000.0001) grdchk output (g):   4     2.7590198849794E+00  2.7590194355060E+00 -1.6291055238149E-07
 (PID.TID 0000.0001) 
-(PID.TID 0000.0001) grdchk  summary  :  RMS of    4 ratios =  3.5084722162967E-05
+(PID.TID 0000.0001) grdchk  summary  :  RMS of    4 ratios =  3.5106731554692E-05
 (PID.TID 0000.0001) 
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // Gradient check results  >>> END <<<
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) 
 (PID.TID 0000.0001)   Seconds in section "ALL                    [THE_MODEL_MAIN]":
-(PID.TID 0000.0001)           User time:   40.206356358830817
-(PID.TID 0000.0001)         System time:  0.24327100627124310
-(PID.TID 0000.0001)     Wall clock time:   40.686790943145752
+(PID.TID 0000.0001)           User time:   33.347145212814212
+(PID.TID 0000.0001)         System time:  0.20824199961498380
+(PID.TID 0000.0001)     Wall clock time:   33.815146923065186
 (PID.TID 0000.0001)          No. starts:           1
 (PID.TID 0000.0001)           No. stops:           1
 (PID.TID 0000.0001)   Seconds in section "INITIALISE_FIXED       [THE_MODEL_MAIN]":
-(PID.TID 0000.0001)           User time:  0.12342000263743103
-(PID.TID 0000.0001)         System time:   5.3247001487761736E-002
-(PID.TID 0000.0001)     Wall clock time:  0.18475914001464844
+(PID.TID 0000.0001)           User time:  0.11976800579577684
+(PID.TID 0000.0001)         System time:   3.8450000807642937E-002
+(PID.TID 0000.0001)     Wall clock time:  0.16053390502929688
 (PID.TID 0000.0001)          No. starts:           1
 (PID.TID 0000.0001)           No. stops:           1
 (PID.TID 0000.0001)   Seconds in section "CTRL_PACK           [THE_MODEL_MAIN]":
-(PID.TID 0000.0001)           User time:   3.3298999071121216E-002
-(PID.TID 0000.0001)         System time:   3.8309991359710693E-003
-(PID.TID 0000.0001)     Wall clock time:   3.7326097488403320E-002
+(PID.TID 0000.0001)           User time:   2.8836011886596680E-002
+(PID.TID 0000.0001)         System time:   2.9610022902488708E-003
+(PID.TID 0000.0001)     Wall clock time:   3.1934022903442383E-002
 (PID.TID 0000.0001)          No. starts:           1
 (PID.TID 0000.0001)           No. stops:           1
 (PID.TID 0000.0001)   Seconds in section "CTRL_PACK     [THE_MODEL_MAIN]":
-(PID.TID 0000.0001)           User time:   3.4125000238418579E-002
-(PID.TID 0000.0001)         System time:   1.1729970574378967E-003
-(PID.TID 0000.0001)     Wall clock time:   3.5461902618408203E-002
+(PID.TID 0000.0001)           User time:   2.8793007135391235E-002
+(PID.TID 0000.0001)         System time:   1.9560009241104126E-003
+(PID.TID 0000.0001)     Wall clock time:   3.0877113342285156E-002
 (PID.TID 0000.0001)          No. starts:           1
 (PID.TID 0000.0001)           No. stops:           1
 (PID.TID 0000.0001)   Seconds in section "GRDCHK_MAIN         [THE_MODEL_MAIN]":
-(PID.TID 0000.0001)           User time:   40.015483543276787
-(PID.TID 0000.0001)         System time:  0.18499600887298584
-(PID.TID 0000.0001)     Wall clock time:   40.429206132888794
+(PID.TID 0000.0001)           User time:   33.169707402586937
+(PID.TID 0000.0001)         System time:  0.16485599800944328
+(PID.TID 0000.0001)     Wall clock time:   33.591753959655762
 (PID.TID 0000.0001)          No. starts:           1
 (PID.TID 0000.0001)           No. stops:           1
 (PID.TID 0000.0001)   Seconds in section "INITIALISE_VARIA    [THE_MAIN_LOOP]":
-(PID.TID 0000.0001)           User time:   1.7731812000274658
-(PID.TID 0000.0001)         System time:  0.13040903955698013
-(PID.TID 0000.0001)     Wall clock time:   1.9557299613952637
+(PID.TID 0000.0001)           User time:   1.4461263716220856
+(PID.TID 0000.0001)         System time:  0.12471399828791618
+(PID.TID 0000.0001)     Wall clock time:   1.6493825912475586
 (PID.TID 0000.0001)          No. starts:          13
 (PID.TID 0000.0001)           No. stops:          13
 (PID.TID 0000.0001)   Seconds in section "MAIN LOOP           [THE_MAIN_LOOP]":
-(PID.TID 0000.0001)           User time:   38.121696561574936
-(PID.TID 0000.0001)         System time:   4.2658977210521698E-002
-(PID.TID 0000.0001)     Wall clock time:   38.339935779571533
+(PID.TID 0000.0001)           User time:   31.614011526107788
+(PID.TID 0000.0001)         System time:   2.7188010513782501E-002
+(PID.TID 0000.0001)     Wall clock time:   31.797343969345093
 (PID.TID 0000.0001)          No. starts:          13
 (PID.TID 0000.0001)           No. stops:          13
 (PID.TID 0000.0001)   Seconds in section "MAIN_DO_LOOP        [THE_MAIN_LOOP]":
-(PID.TID 0000.0001)           User time:   37.998867660760880
-(PID.TID 0000.0001)         System time:   1.9846968352794647E-002
-(PID.TID 0000.0001)     Wall clock time:   38.188557386398315
+(PID.TID 0000.0001)           User time:   31.507507383823395
+(PID.TID 0000.0001)         System time:   1.0324008762836456E-002
+(PID.TID 0000.0001)     Wall clock time:   31.673102617263794
 (PID.TID 0000.0001)          No. starts:          65
 (PID.TID 0000.0001)           No. stops:          65
 (PID.TID 0000.0001)   Seconds in section "FORWARD_STEP        [MAIN_DO_LOOP]":
-(PID.TID 0000.0001)           User time:   37.998126775026321
-(PID.TID 0000.0001)         System time:   1.9836977124214172E-002
-(PID.TID 0000.0001)     Wall clock time:   38.187809467315674
+(PID.TID 0000.0001)           User time:   31.506717592477798
+(PID.TID 0000.0001)         System time:   1.0321013629436493E-002
+(PID.TID 0000.0001)     Wall clock time:   31.672291040420532
 (PID.TID 0000.0001)          No. starts:          65
 (PID.TID 0000.0001)           No. stops:          65
 (PID.TID 0000.0001)   Seconds in section "UPDATE_R_STAR       [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:   1.0579997003078461
-(PID.TID 0000.0001)         System time:   3.9994716644287109E-005
-(PID.TID 0000.0001)     Wall clock time:   1.0628192424774170
+(PID.TID 0000.0001)           User time:  0.79012447595596313
+(PID.TID 0000.0001)         System time:   1.6002357006072998E-004
+(PID.TID 0000.0001)     Wall clock time:  0.79503130912780762
 (PID.TID 0000.0001)          No. starts:         130
 (PID.TID 0000.0001)           No. stops:         130
 (PID.TID 0000.0001)   Seconds in section "LOAD_FIELDS_DRIVER  [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:  0.15644040703773499
-(PID.TID 0000.0001)         System time:   3.4209936857223511E-003
-(PID.TID 0000.0001)     Wall clock time:  0.16633129119873047
+(PID.TID 0000.0001)           User time:  0.12670576572418213
+(PID.TID 0000.0001)         System time:   3.9890184998512268E-003
+(PID.TID 0000.0001)     Wall clock time:  0.13204407691955566
 (PID.TID 0000.0001)          No. starts:          65
 (PID.TID 0000.0001)           No. stops:          65
 (PID.TID 0000.0001)   Seconds in section "EXTERNAL_FLDS_LOAD [LOAD_FLDS_DRIVER]":
-(PID.TID 0000.0001)           User time:   9.2814803123474121E-002
-(PID.TID 0000.0001)         System time:   3.3799782395362854E-003
-(PID.TID 0000.0001)     Wall clock time:  0.10239243507385254
+(PID.TID 0000.0001)           User time:   7.5269162654876709E-002
+(PID.TID 0000.0001)         System time:   1.9900053739547729E-003
+(PID.TID 0000.0001)     Wall clock time:   7.8135013580322266E-002
 (PID.TID 0000.0001)          No. starts:          65
 (PID.TID 0000.0001)           No. stops:          65
 (PID.TID 0000.0001)   Seconds in section "CTRL_MAP_FORCING  [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:  0.24798536300659180
-(PID.TID 0000.0001)         System time:   1.1800229549407959E-004
-(PID.TID 0000.0001)     Wall clock time:  0.24912428855895996
+(PID.TID 0000.0001)           User time:  0.23768559098243713
+(PID.TID 0000.0001)         System time:   8.9497864246368408E-004
+(PID.TID 0000.0001)     Wall clock time:  0.23974967002868652
 (PID.TID 0000.0001)          No. starts:          65
 (PID.TID 0000.0001)           No. stops:          65
 (PID.TID 0000.0001)   Seconds in section "DO_ATMOSPHERIC_PHYS [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:   3.9493799209594727E-002
-(PID.TID 0000.0001)         System time:   1.2298673391342163E-004
-(PID.TID 0000.0001)     Wall clock time:   3.9821386337280273E-002
+(PID.TID 0000.0001)           User time:   3.2780796289443970E-002
+(PID.TID 0000.0001)         System time:   9.9994242191314697E-005
+(PID.TID 0000.0001)     Wall clock time:   3.3066511154174805E-002
 (PID.TID 0000.0001)          No. starts:          65
 (PID.TID 0000.0001)           No. stops:          65
 (PID.TID 0000.0001)   Seconds in section "DO_OCEANIC_PHYS     [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:   6.3224565088748932
-(PID.TID 0000.0001)         System time:   3.2570064067840576E-003
-(PID.TID 0000.0001)     Wall clock time:   6.3540885448455811
+(PID.TID 0000.0001)           User time:   4.8327147364616394
+(PID.TID 0000.0001)         System time:   2.9951333999633789E-006
+(PID.TID 0000.0001)     Wall clock time:   4.8565225601196289
 (PID.TID 0000.0001)          No. starts:          65
 (PID.TID 0000.0001)           No. stops:          65
 (PID.TID 0000.0001)   Seconds in section "DYNAMICS            [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:   10.072610348463058
-(PID.TID 0000.0001)         System time:   4.2519941926002502E-003
-(PID.TID 0000.0001)     Wall clock time:   10.122623682022095
+(PID.TID 0000.0001)           User time:   8.6595039069652557
+(PID.TID 0000.0001)         System time:   2.5004148483276367E-005
+(PID.TID 0000.0001)     Wall clock time:   8.6980988979339600
 (PID.TID 0000.0001)          No. starts:          65
 (PID.TID 0000.0001)           No. stops:          65
 (PID.TID 0000.0001)   Seconds in section "UPDATE_CG2D         [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:  0.17359256744384766
-(PID.TID 0000.0001)         System time:   1.3900548219680786E-004
-(PID.TID 0000.0001)     Wall clock time:  0.17445921897888184
+(PID.TID 0000.0001)           User time:  0.13106200098991394
+(PID.TID 0000.0001)         System time:   4.9993395805358887E-005
+(PID.TID 0000.0001)     Wall clock time:  0.13179874420166016
 (PID.TID 0000.0001)          No. starts:          65
 (PID.TID 0000.0001)           No. stops:          65
 (PID.TID 0000.0001)   Seconds in section "SOLVE_FOR_PRESSURE  [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:   2.7317029833793640
-(PID.TID 0000.0001)         System time:   1.0859742760658264E-003
-(PID.TID 0000.0001)     Wall clock time:   2.7444832324981689
+(PID.TID 0000.0001)           User time:   3.0562464892864227
+(PID.TID 0000.0001)         System time:   2.1003186702728271E-005
+(PID.TID 0000.0001)     Wall clock time:   3.0742759704589844
 (PID.TID 0000.0001)          No. starts:          65
 (PID.TID 0000.0001)           No. stops:          65
 (PID.TID 0000.0001)   Seconds in section "MOM_CORRECTION_STEP [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:  0.35401082038879395
-(PID.TID 0000.0001)         System time:   1.0060220956802368E-003
-(PID.TID 0000.0001)     Wall clock time:  0.35664987564086914
+(PID.TID 0000.0001)           User time:  0.27108615636825562
+(PID.TID 0000.0001)         System time:   2.7015805244445801E-005
+(PID.TID 0000.0001)     Wall clock time:  0.27263951301574707
 (PID.TID 0000.0001)          No. starts:          65
 (PID.TID 0000.0001)           No. stops:          65
 (PID.TID 0000.0001)   Seconds in section "INTEGR_CONTINUITY   [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:  0.56992280483245850
-(PID.TID 0000.0001)         System time:   3.0025839805603027E-006
-(PID.TID 0000.0001)     Wall clock time:  0.57256388664245605
+(PID.TID 0000.0001)           User time:  0.46682393550872803
+(PID.TID 0000.0001)         System time:   2.0988285541534424E-005
+(PID.TID 0000.0001)     Wall clock time:  0.46917033195495605
 (PID.TID 0000.0001)          No. starts:          65
 (PID.TID 0000.0001)           No. stops:          65
 (PID.TID 0000.0001)   Seconds in section "CALC_R_STAR         [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:  0.12684553861618042
-(PID.TID 0000.0001)         System time:   1.0209828615188599E-003
-(PID.TID 0000.0001)     Wall clock time:  0.12846922874450684
+(PID.TID 0000.0001)           User time:   9.3448877334594727E-002
+(PID.TID 0000.0001)         System time:   7.9944729804992676E-006
+(PID.TID 0000.0001)     Wall clock time:   9.5045566558837891E-002
 (PID.TID 0000.0001)          No. starts:          65
 (PID.TID 0000.0001)           No. stops:          65
 (PID.TID 0000.0001)   Seconds in section "BLOCKING_EXCHANGES  [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:  0.86558473110198975
-(PID.TID 0000.0001)         System time:   1.1602044105529785E-004
-(PID.TID 0000.0001)     Wall clock time:  0.86928749084472656
+(PID.TID 0000.0001)           User time:  0.61692464351654053
+(PID.TID 0000.0001)         System time:   1.0030046105384827E-003
+(PID.TID 0000.0001)     Wall clock time:  0.62162089347839355
 (PID.TID 0000.0001)          No. starts:         130
 (PID.TID 0000.0001)           No. stops:         130
 (PID.TID 0000.0001)   Seconds in section "THERMODYNAMICS      [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:   14.845510184764862
-(PID.TID 0000.0001)         System time:   5.1080062985420227E-003
-(PID.TID 0000.0001)     Wall clock time:   14.911704540252686
+(PID.TID 0000.0001)           User time:   11.925002336502075
+(PID.TID 0000.0001)         System time:   3.0060037970542908E-003
+(PID.TID 0000.0001)     Wall clock time:   11.984825611114502
 (PID.TID 0000.0001)          No. starts:          65
 (PID.TID 0000.0001)           No. stops:          65
 (PID.TID 0000.0001)   Seconds in section "TRC_CORRECTION_STEP [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:   3.7711858749389648E-004
-(PID.TID 0000.0001)         System time:   2.9951333999633789E-006
-(PID.TID 0000.0001)     Wall clock time:   3.9172172546386719E-004
+(PID.TID 0000.0001)           User time:   3.9821863174438477E-004
+(PID.TID 0000.0001)         System time:   0.0000000000000000
+(PID.TID 0000.0001)     Wall clock time:   3.9649009704589844E-004
 (PID.TID 0000.0001)          No. starts:          65
 (PID.TID 0000.0001)           No. stops:          65
 (PID.TID 0000.0001)   Seconds in section "MONITOR             [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:   4.0560960769653320E-004
-(PID.TID 0000.0001)         System time:   2.0116567611694336E-006
-(PID.TID 0000.0001)     Wall clock time:   3.9553642272949219E-004
+(PID.TID 0000.0001)           User time:   3.8766860961914062E-004
+(PID.TID 0000.0001)         System time:   0.0000000000000000
+(PID.TID 0000.0001)     Wall clock time:   3.9267539978027344E-004
 (PID.TID 0000.0001)          No. starts:          65
 (PID.TID 0000.0001)           No. stops:          65
 (PID.TID 0000.0001)   Seconds in section "COST_TILE           [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:  0.42074972391128540
-(PID.TID 0000.0001)         System time:   7.1018934249877930E-005
-(PID.TID 0000.0001)     Wall clock time:  0.42273426055908203
+(PID.TID 0000.0001)           User time:  0.25369894504547119
+(PID.TID 0000.0001)         System time:   9.5602124929428101E-004
+(PID.TID 0000.0001)     Wall clock time:  0.25605583190917969
 (PID.TID 0000.0001)          No. starts:          65
 (PID.TID 0000.0001)           No. stops:          65
 (PID.TID 0000.0001)   Seconds in section "DO_THE_MODEL_IO     [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:   4.2402744293212891E-004
-(PID.TID 0000.0001)         System time:   1.9967555999755859E-006
-(PID.TID 0000.0001)     Wall clock time:   4.3559074401855469E-004
+(PID.TID 0000.0001)           User time:   4.5931339263916016E-004
+(PID.TID 0000.0001)         System time:   9.9837779998779297E-007
+(PID.TID 0000.0001)     Wall clock time:   4.6634674072265625E-004
 (PID.TID 0000.0001)          No. starts:          65
 (PID.TID 0000.0001)           No. stops:          65
 (PID.TID 0000.0001)   Seconds in section "DO_WRITE_PICKUP     [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:   6.8616867065429688E-004
-(PID.TID 0000.0001)         System time:   5.9902667999267578E-006
-(PID.TID 0000.0001)     Wall clock time:   6.9260597229003906E-004
+(PID.TID 0000.0001)           User time:   8.1610679626464844E-004
+(PID.TID 0000.0001)         System time:   9.9837779998779297E-007
+(PID.TID 0000.0001)     Wall clock time:   8.1682205200195312E-004
 (PID.TID 0000.0001)          No. starts:          65
 (PID.TID 0000.0001)           No. stops:          65
 (PID.TID 0000.0001)   Seconds in section "COST_FINAL         [ADJOINT SPIN-DOWN]":
-(PID.TID 0000.0001)           User time:   4.2591094970703125E-002
-(PID.TID 0000.0001)         System time:   1.0864011943340302E-002
-(PID.TID 0000.0001)     Wall clock time:   5.8847427368164062E-002
+(PID.TID 0000.0001)           User time:   3.7463188171386719E-002
+(PID.TID 0000.0001)         System time:   4.9310028553009033E-003
+(PID.TID 0000.0001)     Wall clock time:   4.2909860610961914E-002
 (PID.TID 0000.0001)          No. starts:          13
 (PID.TID 0000.0001)           No. stops:          13
 (PID.TID 0000.0001) // ======================================================
@@ -3780,9 +3431,9 @@ grad-res -------------------------------
 (PID.TID 0000.0001) //          Total. Y spins =              0
 (PID.TID 0000.0001) //            Avg. Y spins =       0.00E+00
 (PID.TID 0000.0001) // o Thread number: 000001
-(PID.TID 0000.0001) //            No. barriers =          63418
+(PID.TID 0000.0001) //            No. barriers =          87480
 (PID.TID 0000.0001) //      Max. barrier spins =              1
 (PID.TID 0000.0001) //      Min. barrier spins =              1
-(PID.TID 0000.0001) //     Total barrier spins =          63418
+(PID.TID 0000.0001) //     Total barrier spins =          87480
 (PID.TID 0000.0001) //      Avg. barrier spins =       1.00E+00
 PROGRAM MAIN: Execution ended Normally


### PR DESCRIPTION
## What changes does this PR introduce?
Update the reference Tapenade output from experiment `global_ocean.cs32x15`

## What is the current behaviour? 
Adjoint and Tang-Lin output should have been updated in PR #959, following the switch to normalize the cg2d RHS.
As a results, the Adjoint and Tang-Lin tests are currently failing for this experiment:
https://mitgcm.org/testing/results/2026_01/tr_baudelaire_20260120_5/summary.txt
https://mitgcm.org/testing/results/2026_01/tr_baudelaire_20260120_6/summary.txt

## What is the new behaviour 
Get updated reference output from the reference platform (i.e., for Tapenade, baudelaire Fedora-12 VM).

## Does this PR introduce a breaking change? 
no

## Other information:

## Suggested addition to `tag-index`
none if merged just after 959.