### PR TITLE
add date and time stamp to mdsio meta output

### DIFF
--- a/doc/tag-index
+++ b/doc/tag-index
@@ -1,6 +1,8 @@
     Notes on tags used in MITgcmUV
     ==============================
 
+o pkg/mdsio:
+  - when using pkg/cal, add date and time to ".meta" output file.
 o pkg/shelfice:
   - use alternative way to compute freshWaterFlux based on heat balance ;
     keep old code under CPP option SHI_SALTBAL_FWFLX, and define this option

--- a/model/src/write_grid.F
+++ b/model/src/write_grid.F
@@ -110,9 +110,9 @@ C     Write 3D geometry arrays
          CALL WRITE_FLD_XY_RS( 'rSurfW',' ',rSurfW, -1,myThid)
          CALL WRITE_FLD_XY_RS( 'rSurfS',' ',rSurfS, -1,myThid)
         ENDIF
-        CALL WRITE_FLD_XYZ_RS( 'hFacC',' ',hFacC, 0,myThid)
-        CALL WRITE_FLD_XYZ_RS( 'hFacW',' ',hFacW, 0,myThid)
-        CALL WRITE_FLD_XYZ_RS( 'hFacS',' ',hFacS, 0,myThid)
+        CALL WRITE_FLD_XYZ_RS( 'hFacC',' ',hFacC, -1, myThid )
+        CALL WRITE_FLD_XYZ_RS( 'hFacW',' ',hFacW, -1, myThid )
+        CALL WRITE_FLD_XYZ_RS( 'hFacS',' ',hFacS, -1, myThid )
         IF ( fluidIsAir )
      &    CALL WRITE_FLD_XY_RS( 'topo_P',' ',Ro_surf,-1,myThid)
         IF ( useOBCS ) THEN

--- a/pkg/mdsio/mdsio_write_meta.F
+++ b/pkg/mdsio/mdsio_write_meta.F
@@ -27,6 +27,10 @@ C     !USES:
 C     == Global variables / common blocks
 #include "SIZE.h"
 #include "EEPARAMS.h"
+#ifdef ALLOW_CAL
+# include "PARAMS.h"
+# include "cal.h"
+#endif
 
 C     !INPUT PARAMETERS:
 C     mFileName (string ) :: complete name of meta-file
@@ -75,6 +79,11 @@ C     !LOCAL VARIABLES:
       INTEGER mUnit
 c     LOGICAL exst
       CHARACTER*(MAX_LEN_MBUF) msgBuf
+#ifdef ALLOW_CAL
+      _RL     myTime
+      INTEGER myDate(4)
+      INTEGER year, month, day, hour, minute, second
+#endif
 
 C---+----1----+----2----+----3----+----4----+----5----+----6----+----7-|--+----|
 
@@ -165,6 +174,31 @@ C     keeping. If the timestep number is less than 0 then we assume
 C     that the information is superfluous and do not write it.
       IF ( myIter.GE.0 )
      & WRITE(mUnit,'(1X,A,I10,A)') 'timeStepNumber = [ ',myIter,' ];'
+
+#ifdef ALLOW_CAL
+      IF ( useCal .AND. myIter.GE.0 ) THEN
+C     add the date and time according to pkg/cal that corresponds to the
+C     current timestep myIter,
+C     First recover current time and get date in pkg/cal-format
+       myTime = modelStart + myIter*modelStep
+       CALL CAL_GETDATE( myIter, myTime, myDate, myThid )
+CMLC     this is simpler, but not so easy to read
+CML       WRITE(mUnit,'(1X,A,I8.8,A,I6.6,A)')
+CML     &      "timeStepDate (YYYYMMDDTHHmmss) = [ '",
+CML     &      myDate(1),"T",myDate(2),"' ];"
+C     Follow ISO 8601
+       day    = MOD(myDate(1),100)
+       month  = MOD(myDate(1)/100,100)
+       year   = myDate(1)/10000
+       second = MOD(myDate(2),100)
+       minute = MOD(myDate(2)/100,100)
+       hour   = myDate(2)/10000
+       WRITE(mUnit,'(1X,A,I4.4,A,I2.2,A,I2.2,A,I2.2,A,I2.2,A,I2.2,A)')
+     &      "timeStepDate = [ '",
+     &      year,"-",month,"-",day,"T",hour,":",minute,":",second,
+     &      "Z' ];"
+      ENDIf
+#endif
 
 C-    Write list of Time records
 C note: format might change once we have a better idea of what will

--- a/pkg/mdsio/mdsio_write_meta.F
+++ b/pkg/mdsio/mdsio_write_meta.F
@@ -29,7 +29,6 @@ C     == Global variables / common blocks
 #include "EEPARAMS.h"
 #ifdef ALLOW_CAL
 # include "PARAMS.h"
-# include "cal.h"
 #endif
 
 C     !INPUT PARAMETERS:
@@ -180,7 +179,7 @@ C     that the information is superfluous and do not write it.
 C     add the date and time according to pkg/cal that corresponds to the
 C     current timestep myIter,
 C     First recover current time and get date in pkg/cal-format
-       myTime = modelStart + myIter*modelStep
+       myTime = baseTime + myIter*deltaTClock
        CALL CAL_GETDATE( myIter, myTime, myDate, myThid )
 CMLC     this is simpler, but not so easy to read
 CML       WRITE(mUnit,'(1X,A,I8.8,A,I6.6,A)')

--- a/pkg/mdsio/mdsio_write_meta.F
+++ b/pkg/mdsio/mdsio_write_meta.F
@@ -192,7 +192,7 @@ C     Follow ISO 8601
        second = MOD(myDate(2),100)
        minute = MOD(myDate(2)/100,100)
        hour   = myDate(2)/10000
-       WRITE(mUnit,'(1X,A,I4.4,A,I2.2,A,I2.2,A,I2.2,A,I2.2,A,I2.2,A)')
+       WRITE(mUnit,'(1X,A,I4.4,A,5(I2.2,A))')
      &      "timeStepDate = [ '",
      &      year,"-",month,"-",day,"T",hour,":",minute,":",second,
      &      "Z' ];"

--- a/utils/python/MITgcmutils/MITgcmutils/mds.py
+++ b/utils/python/MITgcmutils/MITgcmutils/mds.py
@@ -181,10 +181,11 @@ def readmeta(f):
     # remove file-specific parameters
     timeInterval = meta.pop('timeInterval', None)
     timeStepNumber = meta.pop('timeStepNumber', None)
+    timeStepDate = meta.pop('timeStepDate', None)
     map2gl = meta.pop('map2glob', None)
     # put back only global dimensions
     meta['dimList'] = list(gdims[::-1])
-    return gdims,i0s,ies,timeStepNumber,timeInterval,map2gl,meta
+    return gdims,i0s,ies,timeStepNumber,timeStepDate,timeInterval,map2gl,meta
 
 
 _typeprefixes = {'ieee-be':'>',
@@ -336,6 +337,7 @@ def rdmds(fnamearg,itrs=-1,machineformat='b',rec=None,fill_value=0,
     arr = None
     metaref = {}
     timeStepNumbers = []
+    timeStepDates = []
     timeIntervals = []
     for iit,it in enumerate(itrs):
         if additrs:
@@ -352,7 +354,7 @@ def rdmds(fnamearg,itrs=-1,machineformat='b',rec=None,fill_value=0,
         if debug: warning('Found',len(metafiles),'metafiles for iteration',it)
 
         for metafile in metafiles:
-            gdims,i0s,ies,timestep,timeinterval,map2gl,meta = readmeta(metafile)
+            gdims,i0s,ies,timestep,tsdate,timeinterval,map2gl,meta = readmeta(metafile)
             if arr is None:
                 # initialize, allocate
                 try:
@@ -462,12 +464,18 @@ def rdmds(fnamearg,itrs=-1,machineformat='b',rec=None,fill_value=0,
         if timestep is not None:
             timeStepNumbers.extend(timestep)
 
+        if tsdate is not None:
+            timeStepDates.extend(tsdate)
+
         if timeinterval is not None:
             timeIntervals.append(timeinterval)
 
     # put list of iteration numbers back into metadata dictionary
     if len(timeStepNumbers):
         metaref['timeStepNumber'] = timeStepNumbers
+
+    if len(timeStepDates):
+        metaref['timeStepDate'] = timeStepDates
 
     if len(timeIntervals):
         metaref['timeInterval'] = timeIntervals
@@ -634,4 +642,3 @@ def wrmds(fbase, arr, itr=None, dataprec='float32', ndims=None, nrecords=None,
             f.write(" };\n")
 
     arr.astype(tp).tofile(fbase + '.data')
-

--- a/utils/python/MITgcmutils/MITgcmutils/mds.py
+++ b/utils/python/MITgcmutils/MITgcmutils/mds.py
@@ -467,7 +467,7 @@ def rdmds(fnamearg,itrs=-1,machineformat='b',rec=None,fill_value=0,
         if tsdate is not None:
             # np.datetime64 does not support timezones, so remove the
             # timezone Z (Zulu time) to avoid the warning
-            timeStepDates.append(np.datetime64(tsdate[0].replace("Z", "")))
+            timeStepDates.append(np.datetime64(tsdate[0].replace('Z','')))
 
         if timeinterval is not None:
             timeIntervals.append(timeinterval)
@@ -478,6 +478,8 @@ def rdmds(fnamearg,itrs=-1,machineformat='b',rec=None,fill_value=0,
 
     if len(timeStepDates):
         metaref['timeStepDate'] = timeStepDates
+        # hardwire time zone
+        metaref['timeZone'] = [ 'Z' ]
 
     if len(timeIntervals):
         metaref['timeInterval'] = timeIntervals

--- a/utils/python/MITgcmutils/MITgcmutils/mds.py
+++ b/utils/python/MITgcmutils/MITgcmutils/mds.py
@@ -465,7 +465,9 @@ def rdmds(fnamearg,itrs=-1,machineformat='b',rec=None,fill_value=0,
             timeStepNumbers.extend(timestep)
 
         if tsdate is not None:
-            timeStepDates.extend(tsdate)
+            # np.datetime64 does not support timezones, so remove the
+            # timezone Z (Zulu time) to avoid the warning
+            timeStepDates.append(np.datetime64(tsdate[0].replace("Z", "")))
 
         if timeinterval is not None:
             timeIntervals.append(timeinterval)


### PR DESCRIPTION
## What changes does this PR introduce?
new feature

## What is the current behaviour? 
meta files of mdsio output contain the current time step of the record, but no information about the date and timestamp. This makes it impossible to reconstruct the date without additional information (e.g. from `data.cal`, or `STDOUT`). For example, [xmitgcm](https://xmitgcm.readthedocs.io/en/latest) requires that one specifies the time step `deltaT` and a reference date to compute the current timestamp of a record.

## What is the new behaviour 
(Only!) If using `pkg/cal`, add a field `timeStepDate = [ 'YYYY-MM-DDTHH-mm-ssZ' ];` to the meta-files of the mdsio output that corresponds to the time step. The format follows the [ISO 8601 standard](https://en.wikipedia.org/wiki/ISO_8601), where `T` separates date and time fields and `Z` refers to "Zulu-time", i.e. UTC.

## Does this PR introduce a breaking change? 
No, but maybe the `rdmds.m` utility needs adjustment (no problems with python's `rdmds` and `xmitgcm.open_mdsdataset`), that's why it's a draft for now.

## Other information:
We can still discuss the format, or if we want to use a reference date and timestep instead.

## Suggested addition to `tag-index`
o add date and time to mdsio meta output if using pkg/cal.