### PR TITLE
Add Process-Id Number to tar-file name

### DIFF
--- a/doc/tag-index
+++ b/doc/tag-index
@@ -1,6 +1,8 @@
     Notes on tags used in MITgcmUV
     ==============================
 
+o testreport:
+  - add process-id number to tar-file name when sending output with "scp".
 o pkg/obcs(sponge):
   - fix bug in sponge relaxation time-scale for Salinity at the Southern OB;
   - remove special condition (non zero T / S) for temp and salt relaxation.

--- a/tools/do_tst_2+2
+++ b/tools/do_tst_2+2
@@ -272,23 +272,27 @@ if test "x$ADDRESS" != xNONE -a "x$ADDRESS" != x ; then
     fi
     if test "x$SENDCMD" != x ; then
         sendOpt='' ; nb=`echo $SENDCMD | grep -c '\<scp\>'`
-        if [ $nb -eq 0 ] ; then sendOpt='-s MITgcm-test -m 3555000' ; fi
-        #echo " run: $SENDCMD $sendOpt ${SAVDIR}/${DRESULTS}".tar.gz" $ADDRESSES"
-        tar -cf  ${SAVDIR}/${DRESULTS}".tar" $DRESULTS > /dev/null 2>&1 \
-            && gzip  ${SAVDIR}/${DRESULTS}".tar" \
-            && $SENDCMD $sendOpt ${SAVDIR}/${DRESULTS}".tar.gz" $ADDRESS
+        if [ $nb -eq 0 ] ; then
+           sendOpt='-s MITgcm-test -m 3555000'
+           tarFile="${SAVDIR}/${DRESULTS}.tar"
+        else
+           tarFile="${SAVDIR}/${DRESULTS}.$$.tar"
+        fi
+        #echo " run: $SENDCMD $sendOpt ${tarFile}.gz $ADDRESSES"
+        tar -cf ${tarFile} $DRESULTS > /dev/null 2>&1 \
+            && gzip ${tarFile} \
+            && $SENDCMD $sendOpt ${tarFile}".gz" $ADDRESS
         out=$?
+        echo
         if test "x$out" != x0 ; then
-            echo
             echo "Warning: The tar, gzip, & mpack step failed.  Please send email"
             echo "  to <MITgcm-support@mitgcm.org> for help.  You may copy the "
             echo "  summary of results from the directory \"$DRESULTS\"."
         else
-            echo
             echo "An email containing results was sent to the following address:"
             echo "  \"$ADDRESS\""
-            test -f ${SAVDIR}/${DRESULTS}".tar" &&  rm -f ${SAVDIR}/${DRESULTS}".tar"
-            test -f ${SAVDIR}/${DRESULTS}".tar.gz" &&  rm -f ${SAVDIR}/${DRESULTS}".tar.gz"
+            test -f ${tarFile}      &&  rm -f ${tarFile}
+            test -f ${tarFile}".gz" &&  rm -f ${tarFile}".gz"
         fi
     fi
 fi

--- a/verification/testreport
+++ b/verification/testreport
@@ -1908,28 +1908,31 @@ if test "x$ADDRESSES" = xNONE -o "x$ADDRESSES" = x ; then
 else
     if test "x$SENDCMD" != x ; then
 	sendOpt='' ; nb=`echo $SENDCMD | grep -c '\<scp\>'`
-	if [ $nb -eq 0 ] ; then sendOpt='-s MITgcm-test -m 3555000' ; fi
-	if [ $verbose -gt 1 ]; then
-	   echo " run: $SENDCMD $sendOpt ${SAVDIR}/${DRESULTS}".tar.gz" $ADDRESSES"
+	if [ $nb -eq 0 ] ; then
+	   sendOpt='-s MITgcm-test -m 3555000'
+	   tarFile="${SAVDIR}/${DRESULTS}.tar"
+	else
+	   tarFile="${SAVDIR}/${DRESULTS}.$$.tar"
 	fi
-	tar -cf ${SAVDIR}/${DRESULTS}".tar" $DRESULTS > /dev/null 2>&1 \
-	    && gzip ${SAVDIR}/${DRESULTS}".tar" \
-	    && $SENDCMD $sendOpt ${SAVDIR}/${DRESULTS}".tar.gz" $ADDRESSES
+	if [ $verbose -gt 1 ]; then
+	   echo " run: $SENDCMD $sendOpt ${tarFile}.gz $ADDRESSES"
+	fi
+	tar -cf ${tarFile} $DRESULTS > /dev/null 2>&1 \
+	    && gzip ${tarFile} \
+	    && $SENDCMD $sendOpt ${tarFile}".gz" $ADDRESSES
 	RETVAL=$?
+	echo
 	if test "x$RETVAL" != x0 ; then
-	    echo
 	    echo "Warning: The tar, gzip, & $SENDCMD step failed.  Please send email"
 	    echo "  to <MITgcm-support@mitgcm.org> for help.  You may copy the "
 	    echo "  summary of results from the directory \"$DRESULTS\"."
-	    echo
 	else
-	    echo
 	    echo "An email containing results was sent to the following addresses:"
 	    echo "  \"$ADDRESSES\""
-	    echo
-	    test -f ${SAVDIR}/${DRESULTS}".tar" &&  rm -f ${SAVDIR}/${DRESULTS}".tar"
-	    test -f ${SAVDIR}/${DRESULTS}".tar.gz" &&  rm -f ${SAVDIR}/${DRESULTS}".tar.gz"
+	    test -f ${tarFile}      &&  rm -f ${tarFile}
+	    test -f ${tarFile}".gz" &&  rm -f ${tarFile}".gz"
 	fi
+	echo
     fi
 fi
 


### PR DESCRIPTION
## What changes does this PR introduce?
Minor update to sending testreport (and restart-test) output with "scp": to avoid 1 tar-file output to overwrite a previous one, add process-Id number to tar-file name.

## What is the current behaviour? 
Occasionally, one tar-file output could overwrite a previous one when: a) send from the same machine with same output-dir name and b) within less than 1/2 hour in between (since the place where tar-files are sent is cleaned up every 1/2 h). 

 ## What is the new behaviour 
Adding the testreport (or `do_tst_2+2`) process-Id number to the tar-file name eliminates any risk of overwriting.

## Does this PR introduce a breaking change? 
no

## Other information:
Note: this method (using "scp" instead of "mpack") is rarely used (requires write permission to where the file is sent to); and there is no risk of overwriting output when using "mpack" (if same tar-file name) as message file will be different.

## Suggested addition to `tag-index`
o testreport:
  - add process-Id -number to tar-file name when sending output with "scp".