### PR TITLE
Headers compatible with both free and fixed format fortran files

### DIFF
--- a/eesupp/inc/BAR2.h
+++ b/eesupp/inc/BAR2.h
@@ -1,49 +1,49 @@
-C
-CBOP
-C     !ROUTINE: BAR2.h
-C     !INTERFACE:
-C     include "BAR2.h"
-C     !DESCRIPTION:
-C     *==========================================================*
-C     | BAR2.h                                                    
-C     | o Globals used by BAR2 Fortran barrier routine.           
-C     |==========================================================*
-C     | These variables support a simple Fortran shared memory    
-C     | barrier routine. They do busy waiting, that is the        
-C     | thread that is waiting sits in a tight loop reading       
-C     | some memory location and waiting for all other threads.   
-C     | On some systems this is sometimes a good method to use.   
-C     | On the T3E memory is not shared so the routine should     
-C     | use the T3E "eureka" barriers. On CRAY and NEC there are  
-C     | hardware barriers that are accessed through a compiler    
-C     | directives. Finally proper multi-threading compilers      
-C     | support barrier compile directives - sometimes these      
-C     | are good, sometimes they are lousy.                       
-C     |  The barrier mechanism is used as follows                 
-C     |  1. In the single-threaded part of the code               
-C     |     CALL BAR2\_INIT                                        
-C     |     on CRAY, NEC this routine does nothing                
-C     |     on T3E there is no single-threaded code               
-C     |        but there may be barrier initialisation -          
-C     |        need to check.                                     
-C     |  2. When we need to synchronize everybody just            
-C     |     CALL BAR2( myThid )                                   
-C     |     where myThid is myThreadId                            
-C     |     on CRAY, NEC FBAR will just do C\$DIR BARRIER          
-C     |     or CALL BARRIER or the like.                          
-C     |     on T3E FBAR does CALL BARRIER(...) or something       
-C     |     need to check this.                                   
-C     *==========================================================*
-CEOP
-      COMMON /BAR2_BUFFER_I/
-     &  BAR2_level,
-     &  BAR2_barrierCount, 
-     &  BAR2_spinsCount, BAR2_spinsMax, BAR2_spinsMin
-      INTEGER BAR2_level(cacheLineSize/4,MAX_NO_THREADS)
-      INTEGER BAR2_barrierCount(cacheLineSize/4,MAX_NO_THREADS)
-      INTEGER BAR2_spinsCount(cacheLineSize/4,MAX_NO_THREADS)
-      INTEGER BAR2_spinsMax(cacheLineSize/4,MAX_NO_THREADS)
-      INTEGER BAR2_spinsMin(cacheLineSize/4,MAX_NO_THREADS)
+!
+!BOP
+! !ROUTINE: BAR2.h
+! !INTERFACE:
+! include "BAR2.h"
+! !DESCRIPTION:
+! *==========================================================*
+! | BAR2.h
+! | o Globals used by BAR2 Fortran barrier routine.
+! |==========================================================*
+! | These variables support a simple Fortran shared memory
+! | barrier routine. They do busy waiting, that is the
+! | thread that is waiting sits in a tight loop reading
+! | some memory location and waiting for all other threads.
+! | On some systems this is sometimes a good method to use.
+! | On the T3E memory is not shared so the routine should
+! | use the T3E "eureka" barriers. On CRAY and NEC there are
+! | hardware barriers that are accessed through a compiler
+! | directives. Finally proper multi-threading compilers
+! | support barrier compile directives - sometimes these
+! | are good, sometimes they are lousy.
+! |  The barrier mechanism is used as follows
+! |  1. In the single-threaded part of the code
+! |     CALL BAR2\_INIT
+! |     on CRAY, NEC this routine does nothing
+! |     on T3E there is no single-threaded code
+! |        but there may be barrier initialisation -
+! |        need to check.
+! |  2. When we need to synchronize everybody just
+! |     CALL BAR2( myThid )
+! |     where myThid is myThreadId
+! |     on CRAY, NEC FBAR will just do C\$DIR BARRIER
+! |     or CALL BARRIER or the like.
+! |     on T3E FBAR does CALL BARRIER(...) or something
+! |     need to check this.
+! *==========================================================*
+!EOP
+      COMMON /BAR2_BUFFER_I/                                                      &
+     &      BAR2_level,                                                           &
+     &      BAR2_barrierCount,                                                    &
+     &      BAR2_spinsCount, BAR2_spinsMax, BAR2_spinsMin
+      INTEGER :: BAR2_level(cacheLineSize/4,MAX_NO_THREADS)
+      INTEGER :: BAR2_barrierCount(cacheLineSize/4,MAX_NO_THREADS)
+      INTEGER :: BAR2_spinsCount(cacheLineSize/4,MAX_NO_THREADS)
+      INTEGER :: BAR2_spinsMax(cacheLineSize/4,MAX_NO_THREADS)
+      INTEGER :: BAR2_spinsMin(cacheLineSize/4,MAX_NO_THREADS)
 
       COMMON /BAR2_L/ bar2CollectStatistics
-      LOGICAL bar2CollectStatistics
+      LOGICAL :: bar2CollectStatistics

--- a/eesupp/inc/BARRIER.h
+++ b/eesupp/inc/BARRIER.h
@@ -1,55 +1,55 @@
-CBOP
-C     !ROUTINE: BARRIER.h
-C     !INTERFACE:
-C     include "BARRIER.h"
-C     !DESCRIPTION:
-C     *==========================================================*
-C     | BARRIER.h                                                 
-C     | o Globals used by Fortran barrier routine.                
-C     *==========================================================*
-C     | These variables support a simple Fortran shared memory    
-C     | barrier routine. They do busy waiting, that is the        
-C     | thread that is waiting sits in a tight loop reading       
-C     | some memory location and waiting for all other threads.   
-C     | On some systems this is sometimes a good method to use.   
-C     | On the T3E memory is not shared so the routine should     
-C     | use the T3E "eureka" barriers. On CRAY and NEC there are  
-C     | hardware barriers that are accessed through a compiler    
-C     | directives. Finally proper multi-threading compilers      
-C     | support barrier compile directives - sometimes these      
-C     | are good, sometimes they are lousy.                       
-C     |  The barrier mechanism is used as follows                 
-C     |  1. In the single-threaded part of the code               
-C     |     CALL FBAR\_INIT                                        
-C     |     on CRAY, NEC this routine does nothing                
-C     |     on T3E there is no single-threaded code               
-C     |        but there may be barrier initialisation -          
-C     |        need to check.                                     
-C     |  2. When we need to synchronize everybody just            
-C     |     CALL FBAR( myThid )                                   
-C     |     where myThid is myThreadId                            
-C     |     on CRAY, NEC FBAR will just do C\$DIR BARRIER          
-C     |     or the like.                                          
-C     |     on T3E FBAR does CALL BARRIER(...) or something       
-C     |     need to check this.                                   
-C     *==========================================================*
-CEOP
-      COMMON / BARRIER_COMMON / key1,  key2,  key3, 
-     &                          door1, door2, door3,
-     &                          bCount, masterSet
-      INTEGER key1(lShare4,MAX_NO_THREADS)
-      INTEGER key2(lShare4,MAX_NO_THREADS)
-      INTEGER key3(lShare4,MAX_NO_THREADS)
-      INTEGER door1
-      INTEGER door2
-      INTEGER door3
-      INTEGER VALID
+!BOP
+! !ROUTINE: BARRIER.h
+! !INTERFACE:
+! include "BARRIER.h"
+! !DESCRIPTION:
+! *==========================================================*
+! | BARRIER.h
+! | o Globals used by Fortran barrier routine.
+! *==========================================================*
+! | These variables support a simple Fortran shared memory
+! | barrier routine. They do busy waiting, that is the
+! | thread that is waiting sits in a tight loop reading
+! | some memory location and waiting for all other threads.
+! | On some systems this is sometimes a good method to use.
+! | On the T3E memory is not shared so the routine should
+! | use the T3E "eureka" barriers. On CRAY and NEC there are
+! | hardware barriers that are accessed through a compiler
+! | directives. Finally proper multi-threading compilers
+! | support barrier compile directives - sometimes these
+! | are good, sometimes they are lousy.
+! |  The barrier mechanism is used as follows
+! |  1. In the single-threaded part of the code
+! |     CALL FBAR\_INIT
+! |     on CRAY, NEC this routine does nothing
+! |     on T3E there is no single-threaded code
+! |        but there may be barrier initialisation -
+! |        need to check.
+! |  2. When we need to synchronize everybody just
+! |     CALL FBAR( myThid )
+! |     where myThid is myThreadId
+! |     on CRAY, NEC FBAR will just do C\$DIR BARRIER
+! |     or the like.
+! |     on T3E FBAR does CALL BARRIER(...) or something
+! |     need to check this.
+! *==========================================================*
+!EOP
+      COMMON / BARRIER_COMMON / key1,  key2,  key3,                               &
+     &      door1, door2, door3,                                                  &
+     &      bCount, masterSet
+      INTEGER :: key1(lShare4,MAX_NO_THREADS)
+      INTEGER :: key2(lShare4,MAX_NO_THREADS)
+      INTEGER :: key3(lShare4,MAX_NO_THREADS)
+      INTEGER :: door1
+      INTEGER :: door2
+      INTEGER :: door3
+      INTEGER :: VALID
       PARAMETER ( VALID = 1 )
-      INTEGER INVALID
+      INTEGER :: INVALID
       PARAMETER ( INVALID = 0 )
-      INTEGER OPEN
+      INTEGER :: OPEN
       PARAMETER ( OPEN = 1 )
-      INTEGER SHUT
+      INTEGER :: SHUT
       PARAMETER ( SHUT = 0 )
-      INTEGER bCount(MAX_NO_THREADS)
-      INTEGER masterSet(MAX_NO_THREADS)
+      INTEGER :: bCount(MAX_NO_THREADS)
+      INTEGER :: masterSet(MAX_NO_THREADS)

--- a/eesupp/inc/CPP_EEMACROS.h
+++ b/eesupp/inc/CPP_EEMACROS.h
@@ -1,46 +1,46 @@
-CBOP
-C     !ROUTINE: CPP_EEMACROS.h
-C     !INTERFACE:
-C     include "CPP_EEMACROS.h"
-C     !DESCRIPTION:
-C     *==========================================================*
-C     | CPP_EEMACROS.h
-C     *==========================================================*
-C     | C preprocessor "execution environment" supporting
-C     | macros. Use this file to define macros for  simplifying
-C     | execution environment in which a model runs - as opposed
-C     | to the dynamical problem the model solves.
-C     *==========================================================*
-CEOP
+!BOP
+! !ROUTINE: CPP_EEMACROS.h
+! !INTERFACE:
+! include "CPP_EEMACROS.h"
+! !DESCRIPTION:
+! *==========================================================*
+! | CPP_EEMACROS.h
+! *==========================================================*
+! | C preprocessor "execution environment" supporting
+! | macros. Use this file to define macros for  simplifying
+! | execution environment in which a model runs - as opposed
+! | to the dynamical problem the model solves.
+! *==========================================================*
+!EOP
 
 #ifndef _CPP_EEMACROS_H_
 #define _CPP_EEMACROS_H_
 
-C     In general the following convention applies:
-C     ALLOW  - indicates an feature will be included but it may
-C     CAN      have a run-time flag to allow it to be switched
-C              on and off.
-C              If ALLOW or CAN directives are "undef'd" this generally
-C              means that the feature will not be available i.e. it
-C              will not be included in the compiled code and so no
-C              run-time option to use the feature will be available.
-C
-C     ALWAYS - indicates the choice will be fixed at compile time
-C              so no run-time option will be present
+! In general the following convention applies:
+! ALLOW  - indicates an feature will be included but it may
+! CAN      have a run-time flag to allow it to be switched
+!          on and off.
+!          If ALLOW or CAN directives are "undef'd" this generally
+!          means that the feature will not be available i.e. it
+!          will not be included in the compiled code and so no
+!          run-time option to use the feature will be available.
+!
+! ALWAYS - indicates the choice will be fixed at compile time
+!          so no run-time option will be present
 
-C     Flag used to indicate which flavour of multi-threading
-C     compiler directives to use. Only set one of these.
-C     USE_SOLARIS_THREADING  - Takes directives for SUN Workshop
-C                              compiler.
-C     USE_KAP_THREADING      - Takes directives for Kuck and
-C                              Associates multi-threading compiler
-C                              ( used on Digital platforms ).
-C     USE_IRIX_THREADING     - Takes directives for SGI MIPS
-C                              Pro Fortran compiler.
-C     USE_EXEMPLAR_THREADING - Takes directives for HP SPP series
-C                              compiler.
-C     USE_C90_THREADING      - Takes directives for CRAY/SGI C90
-C                              system F90 compiler.
+! Flag used to indicate which flavour of multi-threading
+! compiler directives to use. Only set one of these.
+! USE_SOLARIS_THREADING  - Takes directives for SUN Workshop
+!                          compiler.
+! USE_KAP_THREADING      - Takes directives for Kuck and
+!                          Associates multi-threading compiler
+!                          ( used on Digital platforms ).
+! USE_IRIX_THREADING     - Takes directives for SGI MIPS
+!                          Pro Fortran compiler.
+! USE_EXEMPLAR_THREADING - Takes directives for HP SPP series
+!                          compiler.
+! USE_C90_THREADING      - Takes directives for CRAY/SGI C90
+!                          system F90 compiler.
 #ifdef TARGET_SUN
 #define USE_SOLARIS_THREADING
 #define USING_THREADS
@@ -70,55 +70,55 @@ C                              system F90 compiler.
 #define USING_THREADS
 #endif
 
-C--   Define the mapping for the _BARRIER macro
-C     On some systems low-level hardware support can be accessed through
-C     compiler directives here.
+!--   Define the mapping for the _BARRIER macro
+! On some systems low-level hardware support can be accessed through
+! compiler directives here.
 #define _BARRIER CALL BARRIER(myThid)
 
-C--   Define the mapping for the BEGIN_CRIT() and  END_CRIT() macros.
-C     On some systems we simply execute this section only using the
-C     master thread i.e. its not really a critical section. We can
-C     do this because we do not use critical sections in any critical
-C     sections of our code!
+!--   Define the mapping for the BEGIN_CRIT() and  END_CRIT() macros.
+! On some systems we simply execute this section only using the
+! master thread i.e. its not really a critical section. We can
+! do this because we do not use critical sections in any critical
+! sections of our code!
 #define _BEGIN_CRIT(a) _BEGIN_MASTER(a)
 #define _END_CRIT(a)   _END_MASTER(a)
 
-C--   Define the mapping for the BEGIN_MASTER_SECTION() and
-C     END_MASTER_SECTION() macros. These are generally implemented by
-C     simply choosing a particular thread to be "the master" and have
-C     it alone execute the BEGIN_MASTER..., END_MASTER.. sections.
+!--   Define the mapping for the BEGIN_MASTER_SECTION() and
+! END_MASTER_SECTION() macros. These are generally implemented by
+! simply choosing a particular thread to be "the master" and have
+! it alone execute the BEGIN_MASTER..., END_MASTER.. sections.
 
 #define _BEGIN_MASTER(a) IF ( a .EQ. 1 ) THEN
 #define _END_MASTER(a)   ENDIF
-CcnhDebugStarts
-C      Alternate form to the above macros that increments (decrements) a counter each
-C      time a MASTER section is entered (exited). This counter can then be checked in barrier
-C      to try and detect calls to BARRIER within single threaded sections.
-C      Using these macros requires two changes to Makefile - these changes are written
-C      below.
-C      1 - add a filter to the CPP command to kill off commented _MASTER lines
-C      2 - add a filter to the CPP output the converts the string N EWLINE to an actual newline.
-C      The N EWLINE needs to be changes to have no space when this macro and Makefile changes
-C      are used. Its in here with a space to stop it getting parsed by the CPP stage in these
-C      comments.
-C      #define _BEGIN_MASTER(a)  IF ( a .EQ. 1 ) THEN  N EWLINE      CALL BARRIER_MS(a)
-C      #define _END_MASTER(a)    CALL BARRIER_MU(a) N EWLINE        ENDIF
-C      'CPP = cat $< | $(TOOLSDIR)/set64bitConst.sh |  grep -v '^[cC].*_MASTER' | cpp  -traditional -P'
-C      .F.f:
-C      $(CPP) $(DEFINES) $(INCLUDES) |  sed 's/N EWLINE/\n/' > $@
-CcnhDebugEnds
+!cnhDebugStarts
+ ! Alternate form to the above macros that increments (decrements) a counter each
+ ! time a MASTER section is entered (exited). This counter can then be checked in barrier
+ ! to try and detect calls to BARRIER within single threaded sections.
+ ! Using these macros requires two changes to Makefile - these changes are written
+ ! below.
+ ! 1 - add a filter to the CPP command to kill off commented _MASTER lines
+ ! 2 - add a filter to the CPP output the converts the string N EWLINE to an actual newline.
+ ! The N EWLINE needs to be changes to have no space when this macro and Makefile changes
+ ! are used. Its in here with a space to stop it getting parsed by the CPP stage in these
+ ! comments.
+ ! #define _BEGIN_MASTER(a)  IF ( a .EQ. 1 ) THEN  N EWLINE      CALL BARRIER_MS(a)
+ ! #define _END_MASTER(a)    CALL BARRIER_MU(a) N EWLINE        ENDIF
+ ! 'CPP = cat $< | $(TOOLSDIR)/set64bitConst.sh |  grep -v '^[cC].*_MASTER' | cpp  -traditional -P'
+ ! .F.f:
+ ! $(CPP) $(DEFINES) $(INCLUDES) |  sed 's/N EWLINE/\n/' > $@
+!cnhDebugEnds
 
-C--   Control storage of floating point operands
-C     On many systems it improves performance only to use
-C     8-byte precision for time stepped variables.
-C     Constant in time terms ( geometric factors etc.. )
-C     can use 4-byte precision, reducing memory utilisation and
-C     boosting performance because of a smaller working
-C     set size. However, on vector CRAY systems this degrades
-C     performance.
-C- Note: global_sum/max macros were used to switch to  JAM routines (obsolete);
-C  in addition, since only the R4 & R8 S/R are coded, GLOBAL RS & RL macros
-C  enable to call the corresponding R4 or R8 S/R.
+!--   Control storage of floating point operands
+! On many systems it improves performance only to use
+! 8-byte precision for time stepped variables.
+! Constant in time terms ( geometric factors etc.. )
+! can use 4-byte precision, reducing memory utilisation and
+! boosting performance because of a smaller working
+! set size. However, on vector CRAY systems this degrades
+! performance.
+!- Note: global_sum/max macros were used to switch to  JAM routines (obsolete);
+!  in addition, since only the R4 & R8 S/R are coded, GLOBAL RS & RL macros
+!  enable to call the corresponding R4 or R8 S/R.
 #ifdef REAL4_IS_SLOW
 #define _RS Real*8
 #define RS_IS_REAL8
@@ -148,37 +148,37 @@ C  enable to call the corresponding R4 or R8 S/R.
 #define _R4 Real*4
 #define _R8 Real*8
 
-C- Note: a) exch macros were used to switch to  JAM routines (obsolete)
-C        b) exch R4 & R8 macros are not practically used ; if needed,
-C           will directly call the corrresponding S/R.
+!- Note: a) exch macros were used to switch to  JAM routines (obsolete)
+   ! b) exch R4 & R8 macros are not practically used ; if needed,
+   !    will directly call the corrresponding S/R.
 #define _EXCH_XY_RS(a,b) CALL EXCH_XY_RS ( a, b )
 #define _EXCH_XY_RL(a,b) CALL EXCH_XY_RL ( a, b )
 #define _EXCH_XYZ_RS(a,b) CALL EXCH_XYZ_RS ( a, b )
 #define _EXCH_XYZ_RL(a,b) CALL EXCH_XYZ_RL ( a, b )
 
-C--   Control use of JAM routines for Artic network (no longer supported)
-C     These invoke optimized versions of "exchange" and "sum" that
-C     utilize the programmable aspect of Artic cards.
-CXXX No longer supported ; started to remove JAM routines.
-CXXX #ifdef LETS_MAKE_JAM
-CXXX #define _GLOBAL_SUM_RS(a,b) CALL GLOBAL_SUM_R8_JAM ( a, b)
-CXXX #define _GLOBAL_SUM_RL(a,b) CALL GLOBAL_SUM_R8_JAM ( a, b )
-CXXX #define _EXCH_XY_RS(a,b) CALL EXCH_XY_R8_JAM ( a, b )
-CXXX #define _EXCH_XY_RL(a,b) CALL EXCH_XY_R8_JAM ( a, b )
-CXXX #define _EXCH_XYZ_RS(a,b) CALL EXCH_XYZ_R8_JAM ( a, b )
-CXXX #define _EXCH_XYZ_RL(a,b) CALL EXCH_XYZ_R8_JAM ( a, b )
-CXXX #endif
+!--   Control use of JAM routines for Artic network (no longer supported)
+! These invoke optimized versions of "exchange" and "sum" that
+! utilize the programmable aspect of Artic cards.
+!XXX No longer supported ; started to remove JAM routines.
+!XXX #ifdef LETS_MAKE_JAM
+!XXX #define _GLOBAL_SUM_RS(a,b) CALL GLOBAL_SUM_R8_JAM ( a, b)
+!XXX #define _GLOBAL_SUM_RL(a,b) CALL GLOBAL_SUM_R8_JAM ( a, b )
+!XXX #define _EXCH_XY_RS(a,b) CALL EXCH_XY_R8_JAM ( a, b )
+!XXX #define _EXCH_XY_RL(a,b) CALL EXCH_XY_R8_JAM ( a, b )
+!XXX #define _EXCH_XYZ_RS(a,b) CALL EXCH_XYZ_R8_JAM ( a, b )
+!XXX #define _EXCH_XYZ_RL(a,b) CALL EXCH_XYZ_R8_JAM ( a, b )
+!XXX #endif
 
-C--   Control use of "double" precision constants.
-C     Use D0 where it means REAL*8 but not where it means REAL*16
+!--   Control use of "double" precision constants.
+! Use D0 where it means REAL*8 but not where it means REAL*16
 #ifdef REAL_D0_IS_16BYTES
 #define D0
 #endif
 
-C--   Substitue for 1.D variables
-C     Sun compilers do not use 8-byte precision for literals
-C     unless .Dnn is specified. CRAY vector machines use 16-byte
-C     precision when they see .Dnn which runs very slowly!
+!--   Substitue for 1.D variables
+! Sun compilers do not use 8-byte precision for literals
+! unless .Dnn is specified. CRAY vector machines use 16-byte
+! precision when they see .Dnn which runs very slowly!
 #ifdef REAL_D0_IS_16BYTES
 #define _F64( a ) a
 #endif
@@ -186,17 +186,17 @@ C     precision when they see .Dnn which runs very slowly!
 #define _F64( a ) DFLOAT( a )
 #endif
 
-C--   Set the format for writing processor IDs, e.g. in S/R eeset_parms
-C     and S/R open_copy_data_file. The default of I9.9 should work for
-C     a long time (until we will use 10e10 processors and more)
+!--   Set the format for writing processor IDs, e.g. in S/R eeset_parms
+! and S/R open_copy_data_file. The default of I9.9 should work for
+! a long time (until we will use 10e10 processors and more)
 #define FMT_PROC_ID 'I9.9'
 
-C--   Set the format for writing ensemble task IDs in S/R eeset_parms
-C     and S/R open_copy_data_file.
+!--   Set the format for writing ensemble task IDs in S/R eeset_parms
+! and S/R open_copy_data_file.
 #define FMT_TSK_ID 'I6.6'
 
-C--   Set ACTION= in OPEN instruction for input file (before doing IO)
-C     leave it empty (if EXCLUDE_OPEN_ACTION) or set it to proper value
+!--   Set ACTION= in OPEN instruction for input file (before doing IO)
+! leave it empty (if EXCLUDE_OPEN_ACTION) or set it to proper value
 #ifdef EXCLUDE_OPEN_ACTION
 # define _READONLY_ACTION
 #else

--- a/eesupp/inc/CPP_EEOPTIONS.h
+++ b/eesupp/inc/CPP_EEOPTIONS.h
@@ -1,152 +1,152 @@
 #ifndef _CPP_EEOPTIONS_H_
 #define _CPP_EEOPTIONS_H_
 
-CBOP
-C     !ROUTINE: CPP_EEOPTIONS.h
-C     !INTERFACE:
-C     include "CPP_EEOPTIONS.h"
-C
-C     !DESCRIPTION:
-C     *==========================================================*
-C     | CPP\_EEOPTIONS.h                                         |
-C     *==========================================================*
-C     | C preprocessor "execution environment" supporting        |
-C     | flags. Use this file to set flags controlling the        |
-C     | execution environment in which a model runs - as opposed |
-C     | to the dynamical problem the model solves.               |
-C     | Note: Many options are implemented with both compile time|
-C     |       and run-time switches. This allows options to be   |
-C     |       removed altogether, made optional at run-time or   |
-C     |       to be permanently enabled. This convention helps   |
-C     |       with the data-dependence analysis performed by the |
-C     |       adjoint model compiler. This data dependency       |
-C     |       analysis can be upset by runtime switches that it  |
-C     |       is unable to recoginise as being fixed for the     |
-C     |       duration of an integration.                        |
-C     |       A reasonable way to use these flags is to          |
-C     |       set all options as selectable at runtime but then  |
-C     |       once an experimental configuration has been        |
-C     |       identified, rebuild the code with the appropriate  |
-C     |       options set at compile time.                       |
-C     *==========================================================*
-CEOP
+!BOP
+! !ROUTINE: CPP_EEOPTIONS.h
+! !INTERFACE:
+! include "CPP_EEOPTIONS.h"
+!
+! !DESCRIPTION:
+! *==========================================================*
+! | CPP\_EEOPTIONS.h                                         |
+! *==========================================================*
+! | C preprocessor "execution environment" supporting        |
+! | flags. Use this file to set flags controlling the        |
+! | execution environment in which a model runs - as opposed |
+! | to the dynamical problem the model solves.               |
+! | Note: Many options are implemented with both compile time|
+! |       and run-time switches. This allows options to be   |
+! |       removed altogether, made optional at run-time or   |
+! |       to be permanently enabled. This convention helps   |
+! |       with the data-dependence analysis performed by the |
+! |       adjoint model compiler. This data dependency       |
+! |       analysis can be upset by runtime switches that it  |
+! |       is unable to recoginise as being fixed for the     |
+! |       duration of an integration.                        |
+! |       A reasonable way to use these flags is to          |
+! |       set all options as selectable at runtime but then  |
+! |       once an experimental configuration has been        |
+! |       identified, rebuild the code with the appropriate  |
+! |       options set at compile time.                       |
+! *==========================================================*
+!EOP
 
-C     In general the following convention applies:
-C     ALLOW  - indicates an feature will be included but it may
-C     CAN      have a run-time flag to allow it to be switched
-C              on and off.
-C              If ALLOW or CAN directives are "undef'd" this generally
-C              means that the feature will not be available i.e. it
-C              will not be included in the compiled code and so no
-C              run-time option to use the feature will be available.
-C
-C     ALWAYS - indicates the choice will be fixed at compile time
-C              so no run-time option will be present
+! In general the following convention applies:
+! ALLOW  - indicates an feature will be included but it may
+! CAN      have a run-time flag to allow it to be switched
+!          on and off.
+!          If ALLOW or CAN directives are "undef'd" this generally
+!          means that the feature will not be available i.e. it
+!          will not be included in the compiled code and so no
+!          run-time option to use the feature will be available.
+!
+! ALWAYS - indicates the choice will be fixed at compile time
+!          so no run-time option will be present
 
-C=== Macro related options ===
-C--   Control storage of floating point operands
-C     On many systems it improves performance only to use
-C     8-byte precision for time stepped variables.
-C     Constant in time terms ( geometric factors etc.. )
-C     can use 4-byte precision, reducing memory utilisation and
-C     boosting performance because of a smaller working set size.
-C     However, on vector CRAY systems this degrades performance.
-C     Enable to switch REAL4_IS_SLOW from genmake2 (with LET_RS_BE_REAL4):
+!=== Macro related options ===
+!--   Control storage of floating point operands
+! On many systems it improves performance only to use
+! 8-byte precision for time stepped variables.
+! Constant in time terms ( geometric factors etc.. )
+! can use 4-byte precision, reducing memory utilisation and
+! boosting performance because of a smaller working set size.
+! However, on vector CRAY systems this degrades performance.
+! Enable to switch REAL4_IS_SLOW from genmake2 (with LET_RS_BE_REAL4):
 #ifdef LET_RS_BE_REAL4
 #undef REAL4_IS_SLOW
 #else /* LET_RS_BE_REAL4 */
 #define REAL4_IS_SLOW
 #endif /* LET_RS_BE_REAL4 */
 
-C--   Control use of "double" precision constants.
-C     Use D0 where it means REAL*8 but not where it means REAL*16
+!--   Control use of "double" precision constants.
+! Use D0 where it means REAL*8 but not where it means REAL*16
 #define D0 d0
 
-C=== IO related options ===
-C--   Flag used to indicate whether Fortran formatted write
-C     and read are threadsafe. On SGI the routines can be thread
-C     safe, on Sun it is not possible - if you are unsure then
-C     undef this option.
+!=== IO related options ===
+!--   Flag used to indicate whether Fortran formatted write
+! and read are threadsafe. On SGI the routines can be thread
+! safe, on Sun it is not possible - if you are unsure then
+! undef this option.
 #undef FMTFTN_IO_THREAD_SAFE
 
-C--   Flag used to indicate whether Binary write to Local file (i.e.,
-C     a different file for each tile) and read are thread-safe.
+!--   Flag used to indicate whether Binary write to Local file (i.e.,
+! a different file for each tile) and read are thread-safe.
 #undef LOCBIN_IO_THREAD_SAFE
 
-C--   Flag to turn off the writing of error message to ioUnit zero
+!--   Flag to turn off the writing of error message to ioUnit zero
 #undef DISABLE_WRITE_TO_UNIT_ZERO
 
-C--   Flag to turn on old default of opening scratch files with the
-C     STATUS='SCRATCH' option. This method, while perfectly FORTRAN-standard,
-C     caused filename conflicts on some multi-node/multi-processor platforms
-C     in the past and has been replace by something (hopefully) more robust.
+!--   Flag to turn on old default of opening scratch files with the
+! STATUS='SCRATCH' option. This method, while perfectly FORTRAN-standard,
+! caused filename conflicts on some multi-node/multi-processor platforms
+! in the past and has been replace by something (hopefully) more robust.
 #undef USE_FORTRAN_SCRATCH_FILES
 
-C--   Flag defined for eeboot_minimal.F, eeset_parms.F and open_copy_data_file.F
-C     to write STDOUT, STDERR and scratch files from process 0 only.
-C WARNING: to use only when absolutely confident that the setup is working
-C     since any message (error/warning/print) from any proc <> 0 will be lost.
+!--   Flag defined for eeboot_minimal.F, eeset_parms.F and open_copy_data_file.F
+! to write STDOUT, STDERR and scratch files from process 0 only.
+! WARNING: to use only when absolutely confident that the setup is working
+! since any message (error/warning/print) from any proc <> 0 will be lost.
 #undef SINGLE_DISK_IO
 
-C=== MPI, EXCH and GLOBAL_SUM related options ===
-C--   Flag turns off MPI_SEND ready_to_receive polling in the
-C     gather_* subroutines to speed up integrations.
+!=== MPI, EXCH and GLOBAL_SUM related options ===
+!--   Flag turns off MPI_SEND ready_to_receive polling in the
+! gather_* subroutines to speed up integrations.
 #undef DISABLE_MPI_READY_TO_RECEIVE
 
-C--   Control MPI based parallel processing
-CXXX We no longer select the use of MPI via this file (CPP_EEOPTIONS.h)
-CXXX To use MPI, use an appropriate genmake2 options file or use
-CXXX genmake2 -mpi .
-CXXX #undef  ALLOW_USE_MPI
+!--   Control MPI based parallel processing
+!XXX We no longer select the use of MPI via this file (CPP_EEOPTIONS.h)
+!XXX To use MPI, use an appropriate genmake2 options file or use
+!XXX genmake2 -mpi .
+!XXX #undef  ALLOW_USE_MPI
 
-C--   Control use of communication that might overlap computation.
-C     Under MPI selects/deselects "non-blocking" sends and receives.
+!--   Control use of communication that might overlap computation.
+! Under MPI selects/deselects "non-blocking" sends and receives.
 #undef  ALLOW_ASYNC_COMMUNICATION
 #undef  ALWAYS_USE_ASYNC_COMMUNICATION
-C--   Control use of communication that is atomic to computation.
-C     Under MPI selects/deselects "blocking" sends and receives.
+!--   Control use of communication that is atomic to computation.
+! Under MPI selects/deselects "blocking" sends and receives.
 #define ALLOW_SYNC_COMMUNICATION
 #undef  ALWAYS_USE_SYNC_COMMUNICATION
 
-C--   Control XY periodicity in processor to grid mappings
-C     Note: Model code does not need to know whether a domain is
-C           periodic because it has overlap regions for every box.
-C           Model assume that these values have been
-C           filled in some way.
+!--   Control XY periodicity in processor to grid mappings
+! Note: Model code does not need to know whether a domain is
+!       periodic because it has overlap regions for every box.
+!       Model assume that these values have been
+!       filled in some way.
 #undef  ALWAYS_PREVENT_X_PERIODICITY
 #undef  ALWAYS_PREVENT_Y_PERIODICITY
 #define CAN_PREVENT_X_PERIODICITY
 #define CAN_PREVENT_Y_PERIODICITY
 
-C--   disconnect tiles (no exchange between tiles, just fill-in edges
-C     assuming locally periodic subdomain)
+!--   disconnect tiles (no exchange between tiles, just fill-in edges
+! assuming locally periodic subdomain)
 #undef DISCONNECTED_TILES
 
-C--   Always cumulate tile local-sum in the same order by applying MPI allreduce
-C     to array of tiles ; can get slower with large number of tiles (big set-up)
+!--   Always cumulate tile local-sum in the same order by applying MPI allreduce
+! to array of tiles ; can get slower with large number of tiles (big set-up)
 #define GLOBAL_SUM_ORDER_TILES
 
-C--   Alternative way of doing global sum without MPI allreduce call
-C     but instead, explicit MPI send & recv calls. Expected to be slower.
+!--   Alternative way of doing global sum without MPI allreduce call
+! but instead, explicit MPI send & recv calls. Expected to be slower.
 #undef GLOBAL_SUM_SEND_RECV
 
-C--   Alternative way of doing global sum on a single CPU
-C     to eliminate tiling-dependent roundoff errors. Note: This is slow.
+!--   Alternative way of doing global sum on a single CPU
+! to eliminate tiling-dependent roundoff errors. Note: This is slow.
 #undef CG2D_SINGLECPU_SUM
 
-C=== Other options (to add/remove pieces of code) ===
-C--   Flag to turn on checking for errors from all threads and procs
-C     (calling S/R STOP_IF_ERROR) before stopping.
+!=== Other options (to add/remove pieces of code) ===
+!--   Flag to turn on checking for errors from all threads and procs
+! (calling S/R STOP_IF_ERROR) before stopping.
 #define USE_ERROR_STOP
 
-C--   Control use of communication with other component:
-C     allow to import and export from/to Coupler interface.
+!--   Control use of communication with other component:
+! allow to import and export from/to Coupler interface.
 #undef COMPONENT_MODULE
 
-C--   Activate some pieces of code for coupling to GEOS AGCM
+!--   Activate some pieces of code for coupling to GEOS AGCM
 #undef HACK_FOR_GMAO_CPL
 
-C=== And define Macros ===
+!=== And define Macros ===
 #include "CPP_EEMACROS.h"
 
 #endif /* _CPP_EEOPTIONS_H_ */

--- a/eesupp/inc/CUMULSUM.h
+++ b/eesupp/inc/CUMULSUM.h
@@ -1,22 +1,22 @@
-CBOP
-C     !ROUTINE: CUMULSUM.h
-C     !INTERFACE:
-C     include "CUMULSUM.h"
-C     !DESCRIPTION:
-C     *==========================================================*
-C     | CUMULSUM.h
-C     | o Globals used by Fortran CUMULSUM\_TILE routine.
-C     *==========================================================*
-C     *==========================================================*
-CEOP
+!BOP
+! !ROUTINE: CUMULSUM.h
+! !INTERFACE:
+! include "CUMULSUM.h"
+! !DESCRIPTION:
+! *==========================================================*
+! | CUMULSUM.h
+! | o Globals used by Fortran CUMULSUM\_TILE routine.
+! *==========================================================*
+! *==========================================================*
+!EOP
 
-C     shareBufCS2_R8 :: holds tile increment along X direction (1rst index=1)
-C                       and along Y direction (1rst index=2) (CUMULSUM input)
-C     shareBufCS1_R8 :: holds tile cumulated sum at tile origin (i,j)=1,1
+! shareBufCS2_R8 :: holds tile increment along X direction (1rst index=1)
+!                   and along Y direction (1rst index=2) (CUMULSUM input)
+! shareBufCS1_R8 :: holds tile cumulated sum at tile origin (i,j)=1,1
       COMMON  / CUMULSUM_R8 /  shareBufCS1_R8, shareBufCS2_R8
-      Real*8  shareBufCS1_R8  (nSx,nSy)
-      Real*8  shareBufCS2_R8(2,nSx,nSy)
+      Real(kind=8) :: shareBufCS1_R8  (nSx,nSy)
+      Real(kind=8) :: shareBufCS2_R8(2,nSx,nSy)
 
-CEH3 ;;; Local Variables: ***
-CEH3 ;;; mode:fortran ***
-CEH3 ;;; End: ***
+!EH3 ;;; Local Variables: ***
+!EH3 ;;; mode:fortran ***
+!EH3 ;;; End: ***

--- a/eesupp/inc/DEF_IN_MAKEFILE.h
+++ b/eesupp/inc/DEF_IN_MAKEFILE.h
@@ -1,14 +1,14 @@
-C=====  WARNING: DO NOT include this file in any source code =====
-CBOP
-C     !DESCRIPTION:
-C     *==========================================================*
-C     | This file provides a list of CPP-options that can be set
-C     | by the Makefile, through the variable $DEFINES which is
-C     | passed directly to the pre-processor command (CPP).
-C     *==========================================================*
-CEOP
+!=====  WARNING: DO NOT include this file in any source code =====
+!BOP
+! !DESCRIPTION:
+! *==========================================================*
+! | This file provides a list of CPP-options that can be set
+! | by the Makefile, through the variable $DEFINES which is
+! | passed directly to the pre-processor command (CPP).
+! *==========================================================*
+!EOP
 
-C-- options set in Makefile by genmake2:
+!-- options set in Makefile by genmake2:
 #undef ALLOW_AIM
 #undef IGNORE_TIME
 #undef ALLOW_USE_MPI
@@ -36,9 +36,9 @@ C-- options set in Makefile by genmake2:
 #undef HAVE_LAPACK
 #undef HAVE_FLUSH
 
-C-- options that can be set in Makefile by the OPTFILE
+!-- options that can be set in Makefile by the OPTFILE
 #undef HAVE_PTHREADS
-C-  platform specific options:
+!-  platform specific options:
 #undef TARGET_AIX
 #undef TARGET_BGL
 #undef TARGET_CRAY_VECTOR
@@ -51,13 +51,13 @@ C-  platform specific options:
 #undef TARGET_SGI
 #undef TARGET_SUN
 #undef TARGET_T3E
-C-  compiler/platform I/O specific options:
+!-  compiler/platform I/O specific options:
 #undef _BYTESWAPIO
 #undef EXCLUDE_OPEN_ACTION
 #undef NML_EXTENDED_F77
 #undef NML_TERMINATOR
 #undef WORDLENGTH
-C-  others options found in optfiles in dir tools/build_options:
+!-  others options found in optfiles in dir tools/build_options:
 #undef ALWAYS_USE_MPI
 #undef AUTODIFF_USE_MDSFINDUNITS
 #undef PROFILES_USE_MDSFINDUNITS
@@ -65,4 +65,4 @@ C-  others options found in optfiles in dir tools/build_options:
 #undef CG3D_OUTERLOOPITERS
 #undef INTEL_COMMITQQ
 
-C-----  WARNING: DO NOT include this file in any source code -----
+!-----  WARNING: DO NOT include this file in any source code -----

--- a/eesupp/inc/EEBUFF_SCPU.h
+++ b/eesupp/inc/EEBUFF_SCPU.h
@@ -1,45 +1,45 @@
-CBOP
-C     !ROUTINE: EEBUFF_SCPU.h
-C     !INTERFACE:
-C     include "EEBUFF_SCPU.h"
-C
-C     !DESCRIPTION:
-C     *==========================================================*
-C     | EEBUFF_SCPU.h
-C     | o Buffers used by S/R gather_2d and scatter_2d,
-C     |   in mapping 2-D local array from all processes to/from
-C     |   2-D Global (X,Y) array from Master-Proc (SingleCPU)
-C     | o Contain both 2-D Global (X,Y) buffers and
-C     |   Shared Local Buffer (for multi-threaded).
-C     *==========================================================*
-C     | presently used with:
-C     | - SingleCpu IO
-C     | - global-sum SingleCpu
-C     *==========================================================*
-CEOP
+!BOP
+! !ROUTINE: EEBUFF_SCPU.h
+! !INTERFACE:
+! include "EEBUFF_SCPU.h"
+!
+! !DESCRIPTION:
+! *==========================================================*
+! | EEBUFF_SCPU.h
+! | o Buffers used by S/R gather_2d and scatter_2d,
+! |   in mapping 2-D local array from all processes to/from
+! |   2-D Global (X,Y) array from Master-Proc (SingleCPU)
+! | o Contain both 2-D Global (X,Y) buffers and
+! |   Shared Local Buffer (for multi-threaded).
+! *==========================================================*
+! | presently used with:
+! | - SingleCpu IO
+! | - global-sum SingleCpu
+! *==========================================================*
+!EOP
 
-      INTEGER xyBuffer_size
+      INTEGER :: xyBuffer_size
 #ifdef ALLOW_EXCH2
       PARAMETER ( xyBuffer_size = W2_ioBufferSize )
 #else  /* ALLOW_EXCH2 */
       PARAMETER ( xyBuffer_size = Nx*Ny )
 #endif /* ALLOW_EXCH2 */
 
-C--   COMMON /EE_BUFFERS_GLOBAL/  2-D Global Buffers
-C     Those buffers are in common block to save some memory
-C     xy_buffer_r8 :: 2-D global Real*8 buffer.
-C     xy_buffer_r4 :: 2-D global Real*4 buffer.
+!--   COMMON /EE_BUFFERS_GLOBAL/  2-D Global Buffers
+! Those buffers are in common block to save some memory
+! xy_buffer_r8 :: 2-D global Real*8 buffer.
+! xy_buffer_r4 :: 2-D global Real*4 buffer.
       COMMON /EE_BUFFERS_GLOBAL/ xy_buffer_r8, xy_buffer_r4
-      Real*8 xy_buffer_r8(xyBuffer_size)
-      Real*4 xy_buffer_r4(xyBuffer_size)
+      Real(kind=8) :: xy_buffer_r8(xyBuffer_size)
+      Real(kind=4) :: xy_buffer_r4(xyBuffer_size)
 
-C--   COMMON /EE_BUFFERS_LOCAL/  2-D Shared Local Buffers
-C     Those buffers have be in common block to be shared by all threads
-C sharedLocBuf_rx :: Heap storage buffer to which master thread copies
-C                    data (during read) as part of a scatter/gather and
-C                    from which all threads read data (during read).
+!--   COMMON /EE_BUFFERS_LOCAL/  2-D Shared Local Buffers
+! Those buffers have be in common block to be shared by all threads
+! sharedLocBuf_rx :: Heap storage buffer to which master thread copies
+!                data (during read) as part of a scatter/gather and
+!                from which all threads read data (during read).
       COMMON /EE_BUFFERS_LOCAL/ sharedLocBuf_r8, sharedLocBuf_r4
-      Real*8 sharedLocBuf_r8(1:sNx,1:sNy,nSx,nSy)
-      Real*4 sharedLocBuf_r4(1:sNx,1:sNy,nSx,nSy)
+      Real(kind=8) :: sharedLocBuf_r8(1:sNx,1:sNy,nSx,nSy)
+      Real(kind=4) :: sharedLocBuf_r4(1:sNx,1:sNy,nSx,nSy)
 
-C---+----1----+----2----+----3----+----4----+----5----+----6----+----7-|--+----|
+!---+----1----+----2----+----3----+----4----+----5----+----6----+----7-|--+----|

--- a/eesupp/inc/EEPARAMS.h
+++ b/eesupp/inc/EEPARAMS.h
@@ -1,70 +1,70 @@
-CBOP
-C     !ROUTINE: EEPARAMS.h
-C     !INTERFACE:
-C     include "EEPARAMS.h"
-C
-C     !DESCRIPTION:
-C     *==========================================================*
-C     | EEPARAMS.h                                               |
-C     *==========================================================*
-C     | Parameters for "execution environemnt". These are used   |
-C     | by both the particular numerical model and the execution |
-C     | environment support routines.                            |
-C     *==========================================================*
-CEOP
+!BOP
+! !ROUTINE: EEPARAMS.h
+! !INTERFACE:
+! include "EEPARAMS.h"
+!
+! !DESCRIPTION:
+! *==========================================================*
+! | EEPARAMS.h                                               |
+! *==========================================================*
+! | Parameters for "execution environemnt". These are used   |
+! | by both the particular numerical model and the execution |
+! | environment support routines.                            |
+! *==========================================================*
+!EOP
 
-C     ========  EESIZE.h  ========================================
+! ========  EESIZE.h  ========================================
 
-C     MAX_LEN_MBUF  :: Default message buffer max. size
-C     MAX_LEN_FNAM  :: Default file name max. size
-C     MAX_LEN_PREC  :: Default rec len for reading "parameter" files
+! MAX_LEN_MBUF  :: Default message buffer max. size
+! MAX_LEN_FNAM  :: Default file name max. size
+! MAX_LEN_PREC  :: Default rec len for reading "parameter" files
 
-      INTEGER MAX_LEN_MBUF
+      INTEGER :: MAX_LEN_MBUF
       PARAMETER ( MAX_LEN_MBUF = 512 )
-      INTEGER MAX_LEN_FNAM
+      INTEGER :: MAX_LEN_FNAM
       PARAMETER ( MAX_LEN_FNAM = 512 )
-      INTEGER MAX_LEN_PREC
+      INTEGER :: MAX_LEN_PREC
       PARAMETER ( MAX_LEN_PREC = 200 )
 
-C     MAX_NO_THREADS  :: Maximum number of threads allowed.
-C     GSVec_size      :: Maximum buffer size for Global Sum Vector array
-      INTEGER MAX_NO_THREADS
+! MAX_NO_THREADS  :: Maximum number of threads allowed.
+! GSVec_size      :: Maximum buffer size for Global Sum Vector array
+      INTEGER :: MAX_NO_THREADS
       PARAMETER ( MAX_NO_THREADS =  4 )
-      INTEGER GSVec_size
+      INTEGER :: GSVec_size
       PARAMETER ( GSVec_size = 1024 )
 
-C     Particularly weird and obscure voodoo numbers
-C     lShare :: This wants to be the length in
-C               [148]-byte words of the size of
-C               the address "window" that is snooped
-C               on an SMP bus. By separating elements in
-C               the global sum buffer we can avoid generating
-C               extraneous invalidate traffic between
-C               processors. The length of this window is usually
-C               a cache line i.e. small O(64 bytes).
-C               The buffer arrays are usually short arrays
-C               and are declared REAL ARRA(lShare[148],LBUFF).
-C               Setting lShare[148] to 1 is like making these arrays
-C               one dimensional.
-      INTEGER cacheLineSize
-      INTEGER lShare1
-      INTEGER lShare4
-      INTEGER lShare8
+! Particularly weird and obscure voodoo numbers
+! lShare :: This wants to be the length in
+!           [148]-byte words of the size of
+!           the address "window" that is snooped
+!           on an SMP bus. By separating elements in
+!           the global sum buffer we can avoid generating
+!           extraneous invalidate traffic between
+!           processors. The length of this window is usually
+!           a cache line i.e. small O(64 bytes).
+!           The buffer arrays are usually short arrays
+!           and are declared REAL ARRA(lShare[148],LBUFF).
+!           Setting lShare[148] to 1 is like making these arrays
+!           one dimensional.
+      INTEGER :: cacheLineSize
+      INTEGER :: lShare1
+      INTEGER :: lShare4
+      INTEGER :: lShare8
       PARAMETER ( cacheLineSize = 256 )
       PARAMETER ( lShare1 =  cacheLineSize )
       PARAMETER ( lShare4 =  cacheLineSize/4 )
       PARAMETER ( lShare8 =  cacheLineSize/8 )
 
-C     ========  EESIZE.h  ========================================
+! ========  EESIZE.h  ========================================
 
-C     Symbolic values
-C     precXXXX :: precision used for I/O
-      INTEGER precFloat32
+! Symbolic values
+! precXXXX :: precision used for I/O
+      INTEGER :: precFloat32
       PARAMETER ( precFloat32 = 32 )
-      INTEGER precFloat64
+      INTEGER :: precFloat64
       PARAMETER ( precFloat64 = 64 )
 
-C     Real-type constant for some frequently used simple number (0,1,2,1/2):
+! Real-type constant for some frequently used simple number (0,1,2,1/2):
       _RS     zeroRS, oneRS, twoRS, halfRS
       PARAMETER ( zeroRS = 0.0 _d 0 , oneRS  = 1.0 _d 0 )
       PARAMETER ( twoRS  = 2.0 _d 0 , halfRS = 0.5 _d 0 )
@@ -72,21 +72,21 @@ C     Real-type constant for some frequently used simple number (0,1,2,1/2):
       PARAMETER ( zeroRL = 0.0 _d 0 , oneRL  = 1.0 _d 0 )
       PARAMETER ( twoRL  = 2.0 _d 0 , halfRL = 0.5 _d 0 )
 
-C     UNSET_xxx :: Used to indicate variables that have not been given a value
-      Real*8  UNSET_FLOAT8
+! UNSET_xxx :: Used to indicate variables that have not been given a value
+      Real(kind=8) :: UNSET_FLOAT8
       PARAMETER ( UNSET_FLOAT8 = 1.234567D5 )
-      Real*4  UNSET_FLOAT4
+      Real(kind=4) :: UNSET_FLOAT4
       PARAMETER ( UNSET_FLOAT4 = 1.234567E5 )
       _RL     UNSET_RL
       PARAMETER ( UNSET_RL     = 1.234567D5 )
       _RS     UNSET_RS
       PARAMETER ( UNSET_RS     = 1.234567D5 )
-      INTEGER UNSET_I
+      INTEGER :: UNSET_I
       PARAMETER ( UNSET_I      = 123456789  )
 
-C     debLevX  :: used to decide when to print debug messages
-      INTEGER debLevZero
-      INTEGER debLevA, debLevB,  debLevC, debLevD, debLevE
+! debLevX  :: used to decide when to print debug messages
+      INTEGER :: debLevZero
+      INTEGER :: debLevA, debLevB,  debLevC, debLevD, debLevE
       PARAMETER ( debLevZero=0 )
       PARAMETER ( debLevA=1 )
       PARAMETER ( debLevB=2 )
@@ -94,166 +94,166 @@ C     debLevX  :: used to decide when to print debug messages
       PARAMETER ( debLevD=4 )
       PARAMETER ( debLevE=5 )
 
-C     SQUEEZE_RIGHT      :: Flag indicating right blank space removal
-C                           from text field.
-C     SQUEEZE_LEFT       :: Flag indicating left blank space removal
-C                           from text field.
-C     SQUEEZE_BOTH       :: Flag indicating left and right blank
-C                           space removal from text field.
-C     PRINT_MAP_XY       :: Flag indicating to plot map as XY slices
-C     PRINT_MAP_XZ       :: Flag indicating to plot map as XZ slices
-C     PRINT_MAP_YZ       :: Flag indicating to plot map as YZ slices
-C     commentCharacter   :: Variable used in column 1 of parameter
-C                           files to indicate comments.
-C     INDEX_I            :: Variable used to select an index label
-C     INDEX_J               for formatted input parameters.
-C     INDEX_K
-C     INDEX_NONE
-      CHARACTER*(*) SQUEEZE_RIGHT
+! SQUEEZE_RIGHT      :: Flag indicating right blank space removal
+!                       from text field.
+! SQUEEZE_LEFT       :: Flag indicating left blank space removal
+!                       from text field.
+! SQUEEZE_BOTH       :: Flag indicating left and right blank
+!                       space removal from text field.
+! PRINT_MAP_XY       :: Flag indicating to plot map as XY slices
+! PRINT_MAP_XZ       :: Flag indicating to plot map as XZ slices
+! PRINT_MAP_YZ       :: Flag indicating to plot map as YZ slices
+! commentCharacter   :: Variable used in column 1 of parameter
+!                       files to indicate comments.
+! INDEX_I            :: Variable used to select an index label
+! INDEX_J               for formatted input parameters.
+! INDEX_K
+! INDEX_NONE
+      CHARACTER(len=*) :: SQUEEZE_RIGHT
       PARAMETER ( SQUEEZE_RIGHT = 'R' )
-      CHARACTER*(*) SQUEEZE_LEFT
+      CHARACTER(len=*) :: SQUEEZE_LEFT
       PARAMETER ( SQUEEZE_LEFT = 'L' )
-      CHARACTER*(*) SQUEEZE_BOTH
+      CHARACTER(len=*) :: SQUEEZE_BOTH
       PARAMETER ( SQUEEZE_BOTH = 'B' )
-      CHARACTER*(*) PRINT_MAP_XY
+      CHARACTER(len=*) :: PRINT_MAP_XY
       PARAMETER ( PRINT_MAP_XY = 'XY' )
-      CHARACTER*(*) PRINT_MAP_XZ
+      CHARACTER(len=*) :: PRINT_MAP_XZ
       PARAMETER ( PRINT_MAP_XZ = 'XZ' )
-      CHARACTER*(*) PRINT_MAP_YZ
+      CHARACTER(len=*) :: PRINT_MAP_YZ
       PARAMETER ( PRINT_MAP_YZ = 'YZ' )
-      CHARACTER*(*) commentCharacter
+      CHARACTER(len=*) :: commentCharacter
       PARAMETER ( commentCharacter = '#' )
-      INTEGER INDEX_I
-      INTEGER INDEX_J
-      INTEGER INDEX_K
-      INTEGER INDEX_NONE
-      PARAMETER ( INDEX_I    = 1,
-     &            INDEX_J    = 2,
-     &            INDEX_K    = 3,
-     &            INDEX_NONE = 4 )
+      INTEGER :: INDEX_I
+      INTEGER :: INDEX_J
+      INTEGER :: INDEX_K
+      INTEGER :: INDEX_NONE
+      PARAMETER ( INDEX_I    = 1,                                                 &
+     &      INDEX_J    = 2,                                                       &
+     &      INDEX_K    = 3,                                                       &
+     &      INDEX_NONE = 4 )
 
-C     EXCH_IGNORE_CORNERS :: Flag to select ignoring or
-C     EXCH_UPDATE_CORNERS    updating of corners during an edge exchange.
-      INTEGER EXCH_IGNORE_CORNERS
-      INTEGER EXCH_UPDATE_CORNERS
-      PARAMETER ( EXCH_IGNORE_CORNERS = 0,
-     &            EXCH_UPDATE_CORNERS = 1 )
+! EXCH_IGNORE_CORNERS :: Flag to select ignoring or
+! EXCH_UPDATE_CORNERS    updating of corners during an edge exchange.
+      INTEGER :: EXCH_IGNORE_CORNERS
+      INTEGER :: EXCH_UPDATE_CORNERS
+      PARAMETER ( EXCH_IGNORE_CORNERS = 0,                                        &
+     &      EXCH_UPDATE_CORNERS = 1 )
 
-C     FORWARD_SIMULATION
-C     REVERSE_SIMULATION
-C     TANGENT_SIMULATION
-      INTEGER FORWARD_SIMULATION
-      INTEGER REVERSE_SIMULATION
-      INTEGER TANGENT_SIMULATION
-      PARAMETER ( FORWARD_SIMULATION = 0,
-     &            REVERSE_SIMULATION = 1,
-     &            TANGENT_SIMULATION = 2 )
+! FORWARD_SIMULATION
+! REVERSE_SIMULATION
+! TANGENT_SIMULATION
+      INTEGER :: FORWARD_SIMULATION
+      INTEGER :: REVERSE_SIMULATION
+      INTEGER :: TANGENT_SIMULATION
+      PARAMETER ( FORWARD_SIMULATION = 0,                                         &
+     &      REVERSE_SIMULATION = 1,                                               &
+     &      TANGENT_SIMULATION = 2 )
 
-C--   COMMON /EEPARAMS_L/ Execution environment public logical variables.
-C     eeBootError    :: Flags indicating error during multi-processing
-C     eeEndError     :: initialisation and termination.
-C     fatalError     :: Flag used to indicate that the model is ended with an error
-C     debugMode      :: controls printing of debug msg (sequence of S/R calls).
-C     useSingleCpuIO :: When useSingleCpuIO is set, MDS_WRITE_FIELD outputs from
-C                       master MPI process only. -- NOTE: read from main parameter
-C                       file "data" and not set until call to INI_PARMS.
-C     useSingleCpuInput :: When useSingleCpuInput is set, EXF_INTERP_READ
-C                       reads forcing files from master MPI process only.
-C                       -- NOTE: read from main parameter file "data"
-C                          and defaults to useSingleCpuInput = useSingleCpuIO
-C     printMapIncludesZeros  :: Flag that controls whether character constant
-C                               map code ignores exact zero values.
-C     useCubedSphereExchange :: use Cubed-Sphere topology domain.
-C     useCoupler     :: use Coupler for a multi-components set-up.
-C     useNEST_PARENT :: use Parent Nesting interface (pkg/nest_parent)
-C     useNEST_CHILD  :: use Child  Nesting interface (pkg/nest_child)
-C     useNest2W_parent :: use Parent 2-W Nesting interface (pkg/nest2w_parent)
-C     useNest2W_child  :: use Child  2-W Nesting interface (pkg/nest2w_child)
-C     useOASIS       :: use OASIS-coupler for a multi-components set-up.
-      COMMON /EEPARAMS_L/
-c    &  eeBootError, fatalError, eeEndError,
-     &  eeBootError, eeEndError, fatalError, debugMode,
-     &  useSingleCpuIO, useSingleCpuInput, printMapIncludesZeros,
-     &  useCubedSphereExchange, useCoupler,
-     &  useNEST_PARENT, useNEST_CHILD,
-     &  useNest2W_parent, useNest2W_child, useOASIS,
-     &  useSETRLSTK, useSIGREG
-      LOGICAL eeBootError
-      LOGICAL eeEndError
-      LOGICAL fatalError
-      LOGICAL debugMode
-      LOGICAL useSingleCpuIO
-      LOGICAL useSingleCpuInput
-      LOGICAL printMapIncludesZeros
-      LOGICAL useCubedSphereExchange
-      LOGICAL useCoupler
-      LOGICAL useNEST_PARENT
-      LOGICAL useNEST_CHILD
-      LOGICAL useNest2W_parent
-      LOGICAL useNest2W_child
-      LOGICAL useOASIS
-      LOGICAL useSETRLSTK
-      LOGICAL useSIGREG
+!--   COMMON /EEPARAMS_L/ Execution environment public logical variables.
+! eeBootError    :: Flags indicating error during multi-processing
+! eeEndError     :: initialisation and termination.
+! fatalError     :: Flag used to indicate that the model is ended with an error
+! debugMode      :: controls printing of debug msg (sequence of S/R calls).
+! useSingleCpuIO :: When useSingleCpuIO is set, MDS_WRITE_FIELD outputs from
+!                   master MPI process only. -- NOTE: read from main parameter
+!                   file "data" and not set until call to INI_PARMS.
+! useSingleCpuInput :: When useSingleCpuInput is set, EXF_INTERP_READ
+!                   reads forcing files from master MPI process only.
+!                   -- NOTE: read from main parameter file "data"
+!                      and defaults to useSingleCpuInput = useSingleCpuIO
+! printMapIncludesZeros  :: Flag that controls whether character constant
+!                           map code ignores exact zero values.
+! useCubedSphereExchange :: use Cubed-Sphere topology domain.
+! useCoupler     :: use Coupler for a multi-components set-up.
+! useNEST_PARENT :: use Parent Nesting interface (pkg/nest_parent)
+! useNEST_CHILD  :: use Child  Nesting interface (pkg/nest_child)
+! useNest2W_parent :: use Parent 2-W Nesting interface (pkg/nest2w_parent)
+! useNest2W_child  :: use Child  2-W Nesting interface (pkg/nest2w_child)
+! useOASIS       :: use OASIS-coupler for a multi-components set-up.
+      COMMON /EEPARAMS_L/                                                         &
+!    &  eeBootError, fatalError, eeEndError,
+     &      eeBootError, eeEndError, fatalError, debugMode,                       &
+     &      useSingleCpuIO, useSingleCpuInput, printMapIncludesZeros,             &
+     &      useCubedSphereExchange, useCoupler,                                   &
+     &      useNEST_PARENT, useNEST_CHILD,                                        &
+     &      useNest2W_parent, useNest2W_child, useOASIS,                          &
+     &      useSETRLSTK, useSIGREG
+      LOGICAL :: eeBootError
+      LOGICAL :: eeEndError
+      LOGICAL :: fatalError
+      LOGICAL :: debugMode
+      LOGICAL :: useSingleCpuIO
+      LOGICAL :: useSingleCpuInput
+      LOGICAL :: printMapIncludesZeros
+      LOGICAL :: useCubedSphereExchange
+      LOGICAL :: useCoupler
+      LOGICAL :: useNEST_PARENT
+      LOGICAL :: useNEST_CHILD
+      LOGICAL :: useNest2W_parent
+      LOGICAL :: useNest2W_child
+      LOGICAL :: useOASIS
+      LOGICAL :: useSETRLSTK
+      LOGICAL :: useSIGREG
 
-C--   COMMON /EPARAMS_I/ Execution environment public integer variables.
-C     errorMessageUnit    :: Fortran IO unit for error messages
-C     standardMessageUnit :: Fortran IO unit for informational messages
-C     maxLengthPrt1D :: maximum length for printing (to Std-Msg-Unit) 1-D array
-C     scrUnit1      :: Scratch file 1 unit number
-C     scrUnit2      :: Scratch file 2 unit number
-C     eeDataUnit    :: Unit # for reading "execution environment" parameter file
-C     modelDataUnit :: Unit number for reading "model" parameter file.
-C     numberOfProcs :: Number of processes computing in parallel
-C     pidIO         :: Id of process to use for I/O.
-C     myBxLo, myBxHi :: Extents of domain in blocks in X and Y
-C     myByLo, myByHi :: that each threads is responsble for.
-C     myProcId      :: My own "process" id.
-C     myPx          :: My X coord on the proc. grid.
-C     myPy          :: My Y coord on the proc. grid.
-C     myXGlobalLo   :: My bottom-left (south-west) x-index global domain.
-C                      The x-coordinate of this point in for example m or
-C                      degrees is *not* specified here. A model needs to
-C                      provide a mechanism for deducing that information
-C                      if it is needed.
-C     myYGlobalLo   :: My bottom-left (south-west) y-index in global domain.
-C                      The y-coordinate of this point in for example m or
-C                      degrees is *not* specified here. A model needs to
-C                      provide a mechanism for deducing that information
-C                      if it is needed.
-C     nThreads      :: No. of threads
-C     nTx, nTy      :: No. of threads in X and in Y
-C                      This assumes a simple cartesian gridding of the threads
-C                      which is not required elsewhere but that makes it easier
-C     ioErrorCount  :: IO Error Counter. Set to zero initially and increased
-C                      by one every time an IO error occurs.
-      COMMON /EEPARAMS_I/
-     &  errorMessageUnit, standardMessageUnit, maxLengthPrt1D,
-     &  scrUnit1, scrUnit2, eeDataUnit, modelDataUnit,
-     &  numberOfProcs, pidIO, myProcId,
-     &  myPx, myPy, myXGlobalLo, myYGlobalLo, nThreads,
-     &  myBxLo, myBxHi, myByLo, myByHi,
-     &  nTx, nTy, ioErrorCount
-      INTEGER errorMessageUnit
-      INTEGER standardMessageUnit
-      INTEGER maxLengthPrt1D
-      INTEGER scrUnit1
-      INTEGER scrUnit2
-      INTEGER eeDataUnit
-      INTEGER modelDataUnit
-      INTEGER ioErrorCount(MAX_NO_THREADS)
-      INTEGER myBxLo(MAX_NO_THREADS)
-      INTEGER myBxHi(MAX_NO_THREADS)
-      INTEGER myByLo(MAX_NO_THREADS)
-      INTEGER myByHi(MAX_NO_THREADS)
-      INTEGER myProcId
-      INTEGER myPx
-      INTEGER myPy
-      INTEGER myXGlobalLo
-      INTEGER myYGlobalLo
-      INTEGER nThreads
-      INTEGER nTx
-      INTEGER nTy
-      INTEGER numberOfProcs
-      INTEGER pidIO
+!--   COMMON /EPARAMS_I/ Execution environment public integer variables.
+! errorMessageUnit    :: Fortran IO unit for error messages
+! standardMessageUnit :: Fortran IO unit for informational messages
+! maxLengthPrt1D :: maximum length for printing (to Std-Msg-Unit) 1-D array
+! scrUnit1      :: Scratch file 1 unit number
+! scrUnit2      :: Scratch file 2 unit number
+! eeDataUnit    :: Unit # for reading "execution environment" parameter file
+! modelDataUnit :: Unit number for reading "model" parameter file.
+! numberOfProcs :: Number of processes computing in parallel
+! pidIO         :: Id of process to use for I/O.
+! myBxLo, myBxHi :: Extents of domain in blocks in X and Y
+! myByLo, myByHi :: that each threads is responsble for.
+! myProcId      :: My own "process" id.
+! myPx          :: My X coord on the proc. grid.
+! myPy          :: My Y coord on the proc. grid.
+! myXGlobalLo   :: My bottom-left (south-west) x-index global domain.
+!                  The x-coordinate of this point in for example m or
+!                  degrees is *not* specified here. A model needs to
+!                  provide a mechanism for deducing that information
+!                  if it is needed.
+! myYGlobalLo   :: My bottom-left (south-west) y-index in global domain.
+!                  The y-coordinate of this point in for example m or
+!                  degrees is *not* specified here. A model needs to
+!                  provide a mechanism for deducing that information
+!                  if it is needed.
+! nThreads      :: No. of threads
+! nTx, nTy      :: No. of threads in X and in Y
+!                  This assumes a simple cartesian gridding of the threads
+!                  which is not required elsewhere but that makes it easier
+! ioErrorCount  :: IO Error Counter. Set to zero initially and increased
+!                  by one every time an IO error occurs.
+      COMMON /EEPARAMS_I/                                                         &
+     &      errorMessageUnit, standardMessageUnit, maxLengthPrt1D,                &
+     &      scrUnit1, scrUnit2, eeDataUnit, modelDataUnit,                        &
+     &      numberOfProcs, pidIO, myProcId,                                       &
+     &      myPx, myPy, myXGlobalLo, myYGlobalLo, nThreads,                       &
+     &      myBxLo, myBxHi, myByLo, myByHi,                                       &
+     &      nTx, nTy, ioErrorCount
+      INTEGER :: errorMessageUnit
+      INTEGER :: standardMessageUnit
+      INTEGER :: maxLengthPrt1D
+      INTEGER :: scrUnit1
+      INTEGER :: scrUnit2
+      INTEGER :: eeDataUnit
+      INTEGER :: modelDataUnit
+      INTEGER :: ioErrorCount(MAX_NO_THREADS)
+      INTEGER :: myBxLo(MAX_NO_THREADS)
+      INTEGER :: myBxHi(MAX_NO_THREADS)
+      INTEGER :: myByLo(MAX_NO_THREADS)
+      INTEGER :: myByHi(MAX_NO_THREADS)
+      INTEGER :: myProcId
+      INTEGER :: myPx
+      INTEGER :: myPy
+      INTEGER :: myXGlobalLo
+      INTEGER :: myYGlobalLo
+      INTEGER :: nThreads
+      INTEGER :: nTx
+      INTEGER :: nTy
+      INTEGER :: numberOfProcs
+      INTEGER :: pidIO
 
-C---+----1----+----2----+----3----+----4----+----5----+----6----+----7-|--+----|
+!---+----1----+----2----+----3----+----4----+----5----+----6----+----7-|--+----|

--- a/eesupp/inc/EESUPPORT.h
+++ b/eesupp/inc/EESUPPORT.h
@@ -1,296 +1,296 @@
-CBOP
-C     !ROUTINE: EESUPPORT.h
-C     !INTERFACE:
-C     include "EESUPPORT.h"
-C
-C     !DESCRIPTION:
-C     *==========================================================*
-C     | EESUPPORT.h                                              |
-C     *==========================================================*
-C     | Support data structures for the MITgcm UV                |
-C     | "execution environment" code. This data should be        |
-C     | private to the execution environment routines. Data      |
-C     | which needs to be accessed directly by a numerical model |
-C     | goes in EEPARAMS.h.                                      |
-C     *==========================================================*
-CEOP
+!BOP
+! !ROUTINE: EESUPPORT.h
+! !INTERFACE:
+! include "EESUPPORT.h"
+!
+! !DESCRIPTION:
+! *==========================================================*
+! | EESUPPORT.h                                              |
+! *==========================================================*
+! | Support data structures for the MITgcm UV                |
+! | "execution environment" code. This data should be        |
+! | private to the execution environment routines. Data      |
+! | which needs to be accessed directly by a numerical model |
+! | goes in EEPARAMS.h.                                      |
+! *==========================================================*
+!EOP
 
-C     ERROR_HEADER        - String which prefixes error messages
-      CHARACTER*(*) ERROR_HEADER
+! ERROR_HEADER        - String which prefixes error messages
+      CHARACTER(len=*) :: ERROR_HEADER
       PARAMETER ( ERROR_HEADER = ' *** ERROR ***' )
-C     PROCESS_HEADER      - String which prefixes processor number
-      CHARACTER*(*) PROCESS_HEADER
+! PROCESS_HEADER      - String which prefixes processor number
+      CHARACTER(len=*) :: PROCESS_HEADER
       PARAMETER ( PROCESS_HEADER = 'PID.TID' )
 
-C     MAX_NUM_COMM_MODES - Maximum number of communication modes
-C     COMM_NONE       - No edge communication
-C     COMM_MSG        - Use messages to communicate edges
-C     COMM_PUT        - Use put to communicate edges
-C     COMM_GET        - Use get to communicate edges
-C     Note - commName holds an identifying name for each communication
-C            mode. The COMM_ parameters are used to index commName
-C            so the COMM_ parameters need to be in the range
-C            1 : MAX_NUM_COMM_MODES.
-      INTEGER MAX_NUM_COMM_MODES
+! MAX_NUM_COMM_MODES - Maximum number of communication modes
+! COMM_NONE       - No edge communication
+! COMM_MSG        - Use messages to communicate edges
+! COMM_PUT        - Use put to communicate edges
+! COMM_GET        - Use get to communicate edges
+! Note - commName holds an identifying name for each communication
+!        mode. The COMM_ parameters are used to index commName
+!        so the COMM_ parameters need to be in the range
+!        1 : MAX_NUM_COMM_MODES.
+      INTEGER :: MAX_NUM_COMM_MODES
       PARAMETER ( MAX_NUM_COMM_MODES = 4 )
-      INTEGER COMM_NONE
+      INTEGER :: COMM_NONE
       PARAMETER ( COMM_NONE   =   1 )
-      INTEGER COMM_MSG
+      INTEGER :: COMM_MSG
       PARAMETER ( COMM_MSG    =   2 )
-      INTEGER COMM_PUT
+      INTEGER :: COMM_PUT
       PARAMETER ( COMM_PUT    =   3 )
-      INTEGER COMM_GET
+      INTEGER :: COMM_GET
       PARAMETER ( COMM_GET    =   4 )
       COMMON /EESUPP_COMMNAME/ commName
-      CHARACTER*10 commName(MAX_NUM_COMM_MODES)
+      CHARACTER(len=10) :: commName(MAX_NUM_COMM_MODES)
 
-C     Tile identifiers
-C     Tiles have a number that is unique over the global domain.
-C     A tile that is not there has its number set to NULL_TILE
-      INTEGER NULL_TILE
+! Tile identifiers
+! Tiles have a number that is unique over the global domain.
+! A tile that is not there has its number set to NULL_TILE
+      INTEGER :: NULL_TILE
       PARAMETER ( NULL_TILE = -1 )
 
 
-C--   COMMON /EESUPP_C/ Execution environment support character variables
-C     myProcessStr - String identifying my process number
+!--   COMMON /EESUPP_C/ Execution environment support character variables
+! myProcessStr - String identifying my process number
       COMMON /EESUPP_C/ myProcessStr
-      CHARACTER*128 myProcessStr
+      CHARACTER(len=128) :: myProcessStr
 
-C--   COMMON /EESUPP_L/ Execution environment support logical variables
-C     initMPError - Flag indicating error during multi-processing
-C                   initialisation.
-C     finMPError  - Flag indicating error during multi-processing
-C                   termination.
-C     ThError     - Thread detected an error.
-C     usingMPI    - Flag controlling use of MPI routines. This flag
-C                   allows either MPI or threads to be used in a
-C                   shared memory environment which can be a useful
-C                   debugging/performance analysis tool.
-C     usingSyncMessages - Flag that causes blocking communication to be used
-C                         if possible. When false non-blocking EXCH routines
-C                         will be used if possible.
-C     notUsingXPeriodicity - Flag indicating no X/Y boundary wrap around
-C     notUsingYPeriodicity   This affects the communication routines but
-C                            is generally ignored in the numerical model
-C                            code.
-C     threadIsRunning, threadIsComplete - Flags used to check for correct behaviour
-C                                         of multi-threaded code.
-C                                         threadIsRunning is used to check that the
-C                                         threads we need are running. This catches the
-C                                         situation where a program eedata file has nTthreads
-C                                         greater than the setenv PARALLEL or NCPUS variable.
-C                                         threadIsComplete is used to flag that a thread has
-C                                         reached the end of the model. This is used as a check to
-C                                         trap problems that might occur if one thread "escapes"
-C                                         the main.F master loop. This should not happen
-C                                         if the multi-threading compilation tools works right.
-C                                         But (see for example KAP) this is not always the case!
-      COMMON /EESUPP_L/ thError, threadIsRunning, threadIsComplete,
-     & allMyEdgesAreSharedMemory, usingMPI, usingSyncMessages,
-     & notUsingXPeriodicity, notUsingYPeriodicity
-      LOGICAL thError(MAX_NO_THREADS)
-      LOGICAL threadIsRunning(MAX_NO_THREADS)
-      LOGICAL threadIsComplete(MAX_NO_THREADS)
-      LOGICAL allMyEdgesAreSharedMemory(MAX_NO_THREADS)
-      LOGICAL usingMPI
-      LOGICAL usingSyncMessages
-      LOGICAL notUsingXPeriodicity
-      LOGICAL notUsingYPeriodicity
+!--   COMMON /EESUPP_L/ Execution environment support logical variables
+! initMPError - Flag indicating error during multi-processing
+!               initialisation.
+! finMPError  - Flag indicating error during multi-processing
+!               termination.
+! ThError     - Thread detected an error.
+! usingMPI    - Flag controlling use of MPI routines. This flag
+!               allows either MPI or threads to be used in a
+!               shared memory environment which can be a useful
+!               debugging/performance analysis tool.
+! usingSyncMessages - Flag that causes blocking communication to be used
+!                     if possible. When false non-blocking EXCH routines
+!                     will be used if possible.
+! notUsingXPeriodicity - Flag indicating no X/Y boundary wrap around
+! notUsingYPeriodicity   This affects the communication routines but
+!                        is generally ignored in the numerical model
+!                        code.
+! threadIsRunning, threadIsComplete - Flags used to check for correct behaviour
+!                                     of multi-threaded code.
+!                                     threadIsRunning is used to check that the
+!                                     threads we need are running. This catches the
+!                                     situation where a program eedata file has nTthreads
+!                                     greater than the setenv PARALLEL or NCPUS variable.
+!                                     threadIsComplete is used to flag that a thread has
+!                                     reached the end of the model. This is used as a check to
+!                                     trap problems that might occur if one thread "escapes"
+!                                     the main.F master loop. This should not happen
+!                                     if the multi-threading compilation tools works right.
+!                                     But (see for example KAP) this is not always the case!
+      COMMON /EESUPP_L/ thError, threadIsRunning, threadIsComplete,               &
+     &      allMyEdgesAreSharedMemory, usingMPI, usingSyncMessages,               &
+     &      notUsingXPeriodicity, notUsingYPeriodicity
+      LOGICAL :: thError(MAX_NO_THREADS)
+      LOGICAL :: threadIsRunning(MAX_NO_THREADS)
+      LOGICAL :: threadIsComplete(MAX_NO_THREADS)
+      LOGICAL :: allMyEdgesAreSharedMemory(MAX_NO_THREADS)
+      LOGICAL :: usingMPI
+      LOGICAL :: usingSyncMessages
+      LOGICAL :: notUsingXPeriodicity
+      LOGICAL :: notUsingYPeriodicity
 
-C--   COMMON /EESUPP_I/ Parallel support integer globals
-C     pidW   -  Process  ID of neighbor to West
-C     pidE   -           ditto             East
-C     pidN   -           ditto             North
-C     pidS   -           ditto             South
-C              Note: pid[XY] is not necessairily the UNIX
-C                    process id - it is just an identifying
-C                    number.
-C     myPid  - My own process id
-C     nProcs - Number of processes
-C     westCommunicationMode  - Mode of communication for each tile face
-C     eastCommunicationMode
-C     northCommunicationMode
-C     southCommunicationMode
-C     bi0   - Low cartesian tile index for this process
-C     bj0     Note - In a tile distribution with holes bi0 and bj0
-C                    are not useful. Neighboring tile indices must
-C                    be derived some other way.
-C     tileNo       - Tile identification number for my tile and
-C     tileNo[WENS]   my N,S,E,W neighbor tiles.
-C     tilePid[WENS] - Process identification number for
-C                     my N,S,E,W neighbor tiles.
-C     nTx, nTy    - No. threads in X and Y. This assumes a simple
-C                   cartesian gridding of the threads which is not
-C                   required elsewhere but that makes it easier.
-      COMMON /EESUPP_I/
-     & myPid, nProcs, pidW, pidE, pidN, pidS,
-     & tileCommModeW,  tileCommModeE,
-     & tileCommModeN,  tileCommModeS,
-     & tileNo, tileNoW, tileNoE, tileNoS, tileNoN,
-     &  tilePidW, tilePidE, tilePidS, tilePidN,
-     &  tileBiW, tileBiE, tileBiS, tileBiN,
-     & tileBjW, tileBjE, tileBjS, tileBjN,
-     & tileTagSendW, tileTagSendE, tileTagSendS, tileTagSendN,
-     & tileTagRecvW, tileTagRecvE, tileTagRecvS, tileTagRecvN
-      INTEGER myPid
-      INTEGER nProcs
-      INTEGER pidW
-      INTEGER pidE
-      INTEGER pidN
-      INTEGER pidS
-      INTEGER tileCommModeW ( nSx, nSy )
-      INTEGER tileCommModeE ( nSx, nSy )
-      INTEGER tileCommModeN ( nSx, nSy )
-      INTEGER tileCommModeS ( nSx, nSy )
-      INTEGER tileNo( nSx, nSy )
-      INTEGER tileNoW( nSx, nSy )
-      INTEGER tileNoE( nSx, nSy )
-      INTEGER tileNoN( nSx, nSy )
-      INTEGER tileNoS( nSx, nSy )
-      INTEGER tilePidW( nSx, nSy )
-      INTEGER tilePidE( nSx, nSy )
-      INTEGER tilePidN( nSx, nSy )
-      INTEGER tilePidS( nSx, nSy )
-      INTEGER tileBiW( nSx, nSy )
-      INTEGER tileBiE( nSx, nSy )
-      INTEGER tileBiN( nSx, nSy )
-      INTEGER tileBiS( nSx, nSy )
-      INTEGER tileBjW( nSx, nSy )
-      INTEGER tileBjE( nSx, nSy )
-      INTEGER tileBjN( nSx, nSy )
-      INTEGER tileBjS( nSx, nSy )
-      INTEGER tileTagSendW( nSx, nSy )
-      INTEGER tileTagSendE( nSx, nSy )
-      INTEGER tileTagSendN( nSx, nSy )
-      INTEGER tileTagSendS( nSx, nSy )
-      INTEGER tileTagRecvW( nSx, nSy )
-      INTEGER tileTagRecvE( nSx, nSy )
-      INTEGER tileTagRecvN( nSx, nSy )
-      INTEGER tileTagRecvS( nSx, nSy )
+!--   COMMON /EESUPP_I/ Parallel support integer globals
+! pidW   -  Process  ID of neighbor to West
+! pidE   -           ditto             East
+! pidN   -           ditto             North
+! pidS   -           ditto             South
+!          Note: pid[XY] is not necessairily the UNIX
+!                process id - it is just an identifying
+!                number.
+! myPid  - My own process id
+! nProcs - Number of processes
+! westCommunicationMode  - Mode of communication for each tile face
+! eastCommunicationMode
+! northCommunicationMode
+! southCommunicationMode
+! bi0   - Low cartesian tile index for this process
+! bj0     Note - In a tile distribution with holes bi0 and bj0
+!                are not useful. Neighboring tile indices must
+!                be derived some other way.
+! tileNo       - Tile identification number for my tile and
+! tileNo[WENS]   my N,S,E,W neighbor tiles.
+! tilePid[WENS] - Process identification number for
+!                 my N,S,E,W neighbor tiles.
+! nTx, nTy    - No. threads in X and Y. This assumes a simple
+!               cartesian gridding of the threads which is not
+!               required elsewhere but that makes it easier.
+      COMMON /EESUPP_I/                                                           &
+     &      myPid, nProcs, pidW, pidE, pidN, pidS,                                &
+     &      tileCommModeW,  tileCommModeE,                                        &
+     &      tileCommModeN,  tileCommModeS,                                        &
+     &      tileNo, tileNoW, tileNoE, tileNoS, tileNoN,                           &
+     &      tilePidW, tilePidE, tilePidS, tilePidN,                               &
+     &      tileBiW, tileBiE, tileBiS, tileBiN,                                   &
+     &      tileBjW, tileBjE, tileBjS, tileBjN,                                   &
+     &      tileTagSendW, tileTagSendE, tileTagSendS, tileTagSendN,               &
+     &      tileTagRecvW, tileTagRecvE, tileTagRecvS, tileTagRecvN
+      INTEGER :: myPid
+      INTEGER :: nProcs
+      INTEGER :: pidW
+      INTEGER :: pidE
+      INTEGER :: pidN
+      INTEGER :: pidS
+      INTEGER :: tileCommModeW ( nSx, nSy )
+      INTEGER :: tileCommModeE ( nSx, nSy )
+      INTEGER :: tileCommModeN ( nSx, nSy )
+      INTEGER :: tileCommModeS ( nSx, nSy )
+      INTEGER :: tileNo( nSx, nSy )
+      INTEGER :: tileNoW( nSx, nSy )
+      INTEGER :: tileNoE( nSx, nSy )
+      INTEGER :: tileNoN( nSx, nSy )
+      INTEGER :: tileNoS( nSx, nSy )
+      INTEGER :: tilePidW( nSx, nSy )
+      INTEGER :: tilePidE( nSx, nSy )
+      INTEGER :: tilePidN( nSx, nSy )
+      INTEGER :: tilePidS( nSx, nSy )
+      INTEGER :: tileBiW( nSx, nSy )
+      INTEGER :: tileBiE( nSx, nSy )
+      INTEGER :: tileBiN( nSx, nSy )
+      INTEGER :: tileBiS( nSx, nSy )
+      INTEGER :: tileBjW( nSx, nSy )
+      INTEGER :: tileBjE( nSx, nSy )
+      INTEGER :: tileBjN( nSx, nSy )
+      INTEGER :: tileBjS( nSx, nSy )
+      INTEGER :: tileTagSendW( nSx, nSy )
+      INTEGER :: tileTagSendE( nSx, nSy )
+      INTEGER :: tileTagSendN( nSx, nSy )
+      INTEGER :: tileTagSendS( nSx, nSy )
+      INTEGER :: tileTagRecvW( nSx, nSy )
+      INTEGER :: tileTagRecvE( nSx, nSy )
+      INTEGER :: tileTagRecvN( nSx, nSy )
+      INTEGER :: tileTagRecvS( nSx, nSy )
 
 #ifdef ALLOW_USE_MPI
-C--   Include MPI standard Fortran header file
+!--   Include MPI standard Fortran header file
 #include "mpif.h"
 #define _mpiTRUE_  1
 #define _mpiFALSE_ 0
 
-C--   COMMON /EESUPP_MPI_I/ MPI parallel support integer globals
-C     mpiPidW   - MPI process id for west neighbor.
-C     mpiPidE   - MPI process id for east neighbor.
-C     mpiPidN   - MPI process id for north neighbor.
-C     mpiPidS   - MPI process id for south neighbor.
-C     mpiPidNW  - MPI process id for northwest neighbor.
-C     mpiPidNE  - MPI process id for northeast neighbor.
-C     mpiPidSW  - MPI process id for southwest neighbor.
-C     mpiPidSE  - MPI process id for southeast neighbor.
-C     mpiPidIO  - MPI process to use for IO.
-C     mpiNprocs - No. of MPI processes.
-C     mpiMyId   - MPI process id of me.
-C     mpiComm   - MPI communicator to use.
-C     mpiPx     - My MPI proc. grid X coord
-C     mpiPy     - My MPI proc. grid Y coord
-C     mpiXGlobalLo - My bottom-left (south-west) x-coordinate in
-C                    global domain.
-C     mpiYGlobalLo - My bottom-left (south-west) y-coordinate in
-C                    global domain.
-C     mpiTypeXFaceBlock_xy_r4  - Primitives for communicating edge
-C     mpiTypeXFaceBlock_xy_r8    of a block.
-C     mpiTypeYFaceBlock_xy_r4    XFace is used in east-west transfer
-C     mpiTypeYFaceBlock_xy_r8    YFace is used in nrth-south transfer
-C     mpiTypeXFaceBlock_xyz_r4   xy is used in two-dimensional arrays
-C     mpiTypeXFaceBlock_xyz_r8   xyz is used with three-dimensional arrays
-C     mpiTypeYFaceBlock_xyz_r4   r4 is used for real*4 data
-C     mpiTypeYFaceBlock_xyz_r8   r8 is used for real*8 data
-C     mpiTypeXFaceThread_xy_r4  - Composites of the above primitives
-C     mpiTypeXFaceThread_xy_r8    for communicating edges of all blocks
-C     mpiTypeYFaceThread_xy_r4    owned by a thread.
-C     mpiTypeYFaceThread_xy_r8
-C     mpiTypeXFaceThread_xyz_r4
-C     mpiTypeXFaceThread_xyz_r8
-C     mpiTypeYFaceThread_xyz_r4
-C     mpiTypeYFaceBlock_xyz_r8
-C     mpiTagE       - Tags are needed to mark requests when MPI is running
-C     mpiTagW         between multithreaded processes or when the same process.
-C     mpiTagS         is a neighbor in more than one direction. The tags ensure that
-C     mpiTagN         a thread will get the message it is looking for.
-C     mpiTagSW        The scheme adopted is to tag messages according to
-C     mpiTagSE        the direction they are travelling. Thus a message
-C     mpiTagNW        travelling east is tagged mpiTagE. However, in a
-C     mpiTagNE        multi-threaded environemnt several messages could
-C                     be travelling east from the same process at the
-C                     same time. The tag is therefore modified to
-C                     be mpiTag[EWS...]*nThreads+myThid. This requires that
-C                     each thread also know the thread ids of its "neighbor"
-C                     threads.
-      COMMON /EESUPP_MPI_I/
-     & mpiPidW,  mpiPidE,  mpiPidS,  mpiPidN,
-     & mpiPidSE, mpiPidSW, mpiPidNE, mpiPidNW,
-     & mpiPidIo, mpiMyId, mpiNProcs, mpiComm,
-     & mpiPx, mpiPy, mpiXGlobalLo, mpiYGlobalLo,
-     & mpiTypeXFaceBlock_xy_r4, mpiTypeXFaceBlock_xy_r8,
-     & mpiTypeYFaceBlock_xy_r4, mpiTypeYFaceBlock_xy_r8,
-     & mpiTypeXFaceBlock_xyz_r4, mpiTypeXFaceBlock_xyz_r8,
-     & mpiTypeYFaceBlock_xyz_r4, mpiTypeYFaceBlock_xyz_r8,
-     & mpiTypeXFaceThread_xy_r4, mpiTypeXFaceThread_xy_r8,
-     & mpiTypeYFaceThread_xy_r4, mpiTypeYFaceThread_xy_r8,
-     & mpiTypeXFaceThread_xyz_r4, mpiTypeXFaceThread_xyz_r8,
-     & mpiTypeYFaceThread_xyz_r4, mpiTypeYFaceThread_xyz_r8,
-     & mpiTagE, mpiTagW, mpiTagN, mpiTagS,
-     & mpiTagSE, mpiTagSW, mpiTagNW, mpiTagNE
+!--   COMMON /EESUPP_MPI_I/ MPI parallel support integer globals
+! mpiPidW   - MPI process id for west neighbor.
+! mpiPidE   - MPI process id for east neighbor.
+! mpiPidN   - MPI process id for north neighbor.
+! mpiPidS   - MPI process id for south neighbor.
+! mpiPidNW  - MPI process id for northwest neighbor.
+! mpiPidNE  - MPI process id for northeast neighbor.
+! mpiPidSW  - MPI process id for southwest neighbor.
+! mpiPidSE  - MPI process id for southeast neighbor.
+! mpiPidIO  - MPI process to use for IO.
+! mpiNprocs - No. of MPI processes.
+! mpiMyId   - MPI process id of me.
+! mpiComm   - MPI communicator to use.
+! mpiPx     - My MPI proc. grid X coord
+! mpiPy     - My MPI proc. grid Y coord
+! mpiXGlobalLo - My bottom-left (south-west) x-coordinate in
+!                global domain.
+! mpiYGlobalLo - My bottom-left (south-west) y-coordinate in
+!                global domain.
+! mpiTypeXFaceBlock_xy_r4  - Primitives for communicating edge
+! mpiTypeXFaceBlock_xy_r8    of a block.
+! mpiTypeYFaceBlock_xy_r4    XFace is used in east-west transfer
+! mpiTypeYFaceBlock_xy_r8    YFace is used in nrth-south transfer
+! mpiTypeXFaceBlock_xyz_r4   xy is used in two-dimensional arrays
+! mpiTypeXFaceBlock_xyz_r8   xyz is used with three-dimensional arrays
+! mpiTypeYFaceBlock_xyz_r4   r4 is used for real*4 data
+! mpiTypeYFaceBlock_xyz_r8   r8 is used for real*8 data
+! mpiTypeXFaceThread_xy_r4  - Composites of the above primitives
+! mpiTypeXFaceThread_xy_r8    for communicating edges of all blocks
+! mpiTypeYFaceThread_xy_r4    owned by a thread.
+! mpiTypeYFaceThread_xy_r8
+! mpiTypeXFaceThread_xyz_r4
+! mpiTypeXFaceThread_xyz_r8
+! mpiTypeYFaceThread_xyz_r4
+! mpiTypeYFaceBlock_xyz_r8
+! mpiTagE       - Tags are needed to mark requests when MPI is running
+! mpiTagW         between multithreaded processes or when the same process.
+! mpiTagS         is a neighbor in more than one direction. The tags ensure that
+! mpiTagN         a thread will get the message it is looking for.
+! mpiTagSW        The scheme adopted is to tag messages according to
+! mpiTagSE        the direction they are travelling. Thus a message
+! mpiTagNW        travelling east is tagged mpiTagE. However, in a
+! mpiTagNE        multi-threaded environemnt several messages could
+!                 be travelling east from the same process at the
+!                 same time. The tag is therefore modified to
+!                 be mpiTag[EWS...]*nThreads+myThid. This requires that
+!                 each thread also know the thread ids of its "neighbor"
+!                 threads.
+      COMMON /EESUPP_MPI_I/                                                       &
+     &      mpiPidW,  mpiPidE,  mpiPidS,  mpiPidN,                                &
+     &      mpiPidSE, mpiPidSW, mpiPidNE, mpiPidNW,                               &
+     &      mpiPidIo, mpiMyId, mpiNProcs, mpiComm,                                &
+     &      mpiPx, mpiPy, mpiXGlobalLo, mpiYGlobalLo,                             &
+     &      mpiTypeXFaceBlock_xy_r4, mpiTypeXFaceBlock_xy_r8,                     &
+     &      mpiTypeYFaceBlock_xy_r4, mpiTypeYFaceBlock_xy_r8,                     &
+     &      mpiTypeXFaceBlock_xyz_r4, mpiTypeXFaceBlock_xyz_r8,                   &
+     &      mpiTypeYFaceBlock_xyz_r4, mpiTypeYFaceBlock_xyz_r8,                   &
+     &      mpiTypeXFaceThread_xy_r4, mpiTypeXFaceThread_xy_r8,                   &
+     &      mpiTypeYFaceThread_xy_r4, mpiTypeYFaceThread_xy_r8,                   &
+     &      mpiTypeXFaceThread_xyz_r4, mpiTypeXFaceThread_xyz_r8,                 &
+     &      mpiTypeYFaceThread_xyz_r4, mpiTypeYFaceThread_xyz_r8,                 &
+     &      mpiTagE, mpiTagW, mpiTagN, mpiTagS,                                   &
+     &      mpiTagSE, mpiTagSW, mpiTagNW, mpiTagNE
 
-      INTEGER mpiPidW
-      INTEGER mpiPidE
-      INTEGER mpiPidS
-      INTEGER mpiPidN
-      INTEGER mpiPidSW
-      INTEGER mpiPidSE
-      INTEGER mpiPidNW
-      INTEGER mpiPidNE
-      INTEGER mpiPidIO
-      INTEGER mpiMyId
-      INTEGER mpiNProcs
-      INTEGER mpiComm
-      INTEGER mpiPx
-      INTEGER mpiPy
-      INTEGER mpiXGlobalLo
-      INTEGER mpiYGlobalLo
-      INTEGER mpiTypeXFaceBlock_xy_r4
-      INTEGER mpiTypeXFaceBlock_xy_r8
-      INTEGER mpiTypeYFaceBlock_xy_r4
-      INTEGER mpiTypeYFaceBlock_xy_r8
-      INTEGER mpiTypeXFaceBlock_xyz_r4
-      INTEGER mpiTypeXFaceBlock_xyz_r8
-      INTEGER mpiTypeYFaceBlock_xyz_r4
-      INTEGER mpiTypeYFaceBlock_xyz_r8
-      INTEGER mpiTypeXFaceThread_xy_r4(MAX_NO_THREADS)
-      INTEGER mpiTypeXFaceThread_xy_r8(MAX_NO_THREADS)
-      INTEGER mpiTypeYFaceThread_xy_r4(MAX_NO_THREADS)
-      INTEGER mpiTypeYFaceThread_xy_r8(MAX_NO_THREADS)
-      INTEGER mpiTypeXFaceThread_xyz_r4(MAX_NO_THREADS)
-      INTEGER mpiTypeXFaceThread_xyz_r8(MAX_NO_THREADS)
-      INTEGER mpiTypeYFaceThread_xyz_r4(MAX_NO_THREADS)
-      INTEGER mpiTypeYFaceThread_xyz_r8(MAX_NO_THREADS)
-      INTEGER mpiTagNW
-      INTEGER mpiTagNE
-      INTEGER mpiTagSW
-      INTEGER mpiTagSE
-      INTEGER mpiTagW
-      INTEGER mpiTagE
-      INTEGER mpiTagN
-      INTEGER mpiTagS
+      INTEGER :: mpiPidW
+      INTEGER :: mpiPidE
+      INTEGER :: mpiPidS
+      INTEGER :: mpiPidN
+      INTEGER :: mpiPidSW
+      INTEGER :: mpiPidSE
+      INTEGER :: mpiPidNW
+      INTEGER :: mpiPidNE
+      INTEGER :: mpiPidIO
+      INTEGER :: mpiMyId
+      INTEGER :: mpiNProcs
+      INTEGER :: mpiComm
+      INTEGER :: mpiPx
+      INTEGER :: mpiPy
+      INTEGER :: mpiXGlobalLo
+      INTEGER :: mpiYGlobalLo
+      INTEGER :: mpiTypeXFaceBlock_xy_r4
+      INTEGER :: mpiTypeXFaceBlock_xy_r8
+      INTEGER :: mpiTypeYFaceBlock_xy_r4
+      INTEGER :: mpiTypeYFaceBlock_xy_r8
+      INTEGER :: mpiTypeXFaceBlock_xyz_r4
+      INTEGER :: mpiTypeXFaceBlock_xyz_r8
+      INTEGER :: mpiTypeYFaceBlock_xyz_r4
+      INTEGER :: mpiTypeYFaceBlock_xyz_r8
+      INTEGER :: mpiTypeXFaceThread_xy_r4(MAX_NO_THREADS)
+      INTEGER :: mpiTypeXFaceThread_xy_r8(MAX_NO_THREADS)
+      INTEGER :: mpiTypeYFaceThread_xy_r4(MAX_NO_THREADS)
+      INTEGER :: mpiTypeYFaceThread_xy_r8(MAX_NO_THREADS)
+      INTEGER :: mpiTypeXFaceThread_xyz_r4(MAX_NO_THREADS)
+      INTEGER :: mpiTypeXFaceThread_xyz_r8(MAX_NO_THREADS)
+      INTEGER :: mpiTypeYFaceThread_xyz_r4(MAX_NO_THREADS)
+      INTEGER :: mpiTypeYFaceThread_xyz_r8(MAX_NO_THREADS)
+      INTEGER :: mpiTagNW
+      INTEGER :: mpiTagNE
+      INTEGER :: mpiTagSW
+      INTEGER :: mpiTagSE
+      INTEGER :: mpiTagW
+      INTEGER :: mpiTagE
+      INTEGER :: mpiTagN
+      INTEGER :: mpiTagS
 
-C--   COMMON /MPI_FULLMAP_I/ holds integer arrays of the full list of MPI process
-C     mpi_myXGlobalLo :: List of all processors bottom-left X-index in global domain
-C     mpi_myYGlobalLo :: List of all processors bottom-left Y-index in global domain
-C                        Note: needed for mpi gather/scatter routines & singleCpuIO.
-      COMMON /MPI_FULLMAP_I/
-     &        mpi_myXGlobalLo, mpi_myYGlobalLo
-      INTEGER mpi_myXGlobalLo(nPx*nPy)
-      INTEGER mpi_myYGlobalLo(nPx*nPy)
+!--   COMMON /MPI_FULLMAP_I/ holds integer arrays of the full list of MPI process
+! mpi_myXGlobalLo :: List of all processors bottom-left X-index in global domain
+! mpi_myYGlobalLo :: List of all processors bottom-left Y-index in global domain
+!                    Note: needed for mpi gather/scatter routines & singleCpuIO.
+      COMMON /MPI_FULLMAP_I/                                                      &
+     &      mpi_myXGlobalLo, mpi_myYGlobalLo
+      INTEGER :: mpi_myXGlobalLo(nPx*nPy)
+      INTEGER :: mpi_myYGlobalLo(nPx*nPy)
 
-C MPI communicator describing this model realization
-      COMMON /MPI_COMMS/
-     &        MPI_COMM_MODEL
-      INTEGER MPI_COMM_MODEL
+! MPI communicator describing this model realization
+      COMMON /MPI_COMMS/                                                          &
+     &      MPI_COMM_MODEL
+      INTEGER :: MPI_COMM_MODEL
 
 #endif /* ALLOW_USE_MPI */

--- a/eesupp/inc/EXCH.h
+++ b/eesupp/inc/EXCH.h
@@ -1,18 +1,18 @@
-C
-CBOP
-C     !ROUTINE: EXCH.h
-C     !INTERFACE:
-C     include "EXCH.h"
-C
-C     !DESCRIPTION:
-C     *==========================================================*
-C     | EXCH.h
-C     *==========================================================*
-C     | Support data structures for
-C     | the MITgcm-UV "exchange routines" code. This data should
-C     | be private to the execution environment routines.
-C     *==========================================================*
-CEOP
+!
+!BOP
+! !ROUTINE: EXCH.h
+! !INTERFACE:
+! include "EXCH.h"
+!
+! !DESCRIPTION:
+! *==========================================================*
+! | EXCH.h
+! *==========================================================*
+! | Support data structures for
+! | the MITgcm-UV "exchange routines" code. This data should
+! | be private to the execution environment routines.
+! *==========================================================*
+!EOP
 
 #ifndef _RL
 #define _RL Real*8
@@ -134,194 +134,194 @@ CEOP
 #define _EXCH_SPIN_LIMIT EXCH_SPIN_LIMIT
 #endif
 
-C      MAX_OLX_EXCH - Maximum overlap region allowed in X
-C      MAX_OLY_EXCH - Maximum overlap region allowed in Y
-C      MAX_NR_EXCH  - Maximum number of vertical levels allowed
-C      NUMBER_OF_BUFFER_LEVELS - Number of levels of buffer allowed.
-C      EXCH_SPIN_LIMIT - Error trapping threshold for deadlocked exchange
-       INTEGER MAX_OLX_EXCH
+ ! MAX_OLX_EXCH - Maximum overlap region allowed in X
+ ! MAX_OLY_EXCH - Maximum overlap region allowed in Y
+ ! MAX_NR_EXCH  - Maximum number of vertical levels allowed
+ ! NUMBER_OF_BUFFER_LEVELS - Number of levels of buffer allowed.
+ ! EXCH_SPIN_LIMIT - Error trapping threshold for deadlocked exchange
+       INTEGER :: MAX_OLX_EXCH
        PARAMETER ( MAX_OLX_EXCH = MAX_OLX )
-       INTEGER MAX_OLY_EXCH
+       INTEGER :: MAX_OLY_EXCH
        PARAMETER ( MAX_OLY_EXCH = MAX_OLY )
-       INTEGER MAX_NR_EXCH
+       INTEGER :: MAX_NR_EXCH
        PARAMETER ( MAX_NR_EXCH  = nR + 1 )
-       INTEGER NUMBER_OF_BUFFER_LEVELS
+       INTEGER :: NUMBER_OF_BUFFER_LEVELS
        PARAMETER ( NUMBER_OF_BUFFER_LEVELS = 1 )
-       INTEGER EXCH_SPIN_LIMIT
+       INTEGER :: EXCH_SPIN_LIMIT
        PARAMETER ( EXCH_SPIN_LIMIT = 100000000 )
 
-C
-C      L_BUFFER[XY]  - Maximum size for exchange buffer in
-C      L_WBUFFER    west,
-C      L_EBUFFER    east,
-C      L_SBUFFER   south,
-C      L_NBUFFER   north.
-       INTEGER L_BUFFERX
-       PARAMETER ( L_BUFFERX =
-     &  (sNy+2*MAX_OLY_EXCH)*MAX_OLX_EXCH*MAX_NR_EXCH )
-       INTEGER L_BUFFERY
-       PARAMETER ( L_BUFFERY =
-     &  (sNx+2*MAX_OLX_EXCH)*MAX_OLY_EXCH*MAX_NR_EXCH )
-       INTEGER L_WBUFFER
-       INTEGER L_EBUFFER
-       INTEGER L_SBUFFER
-       INTEGER L_NBUFFER
-       PARAMETER ( L_WBUFFER = L_BUFFERX,
-     &             L_EBUFFER = L_BUFFERX,
-     &             L_SBUFFER = L_BUFFERY,
-     &             L_NBUFFER = L_BUFFERY )
+!
+!  L_BUFFER[XY]  - Maximum size for exchange buffer in
+!  L_WBUFFER    west,
+!  L_EBUFFER    east,
+!  L_SBUFFER   south,
+!  L_NBUFFER   north.
+       INTEGER :: L_BUFFERX
+       PARAMETER ( L_BUFFERX =                                                    &
+     &       (sNy+2*MAX_OLY_EXCH)*MAX_OLX_EXCH*MAX_NR_EXCH )
+       INTEGER :: L_BUFFERY
+       PARAMETER ( L_BUFFERY =                                                    &
+     &       (sNx+2*MAX_OLX_EXCH)*MAX_OLY_EXCH*MAX_NR_EXCH )
+       INTEGER :: L_WBUFFER
+       INTEGER :: L_EBUFFER
+       INTEGER :: L_SBUFFER
+       INTEGER :: L_NBUFFER
+       PARAMETER ( L_WBUFFER = L_BUFFERX,                                         &
+     &       L_EBUFFER = L_BUFFERX,                                               &
+     &       L_SBUFFER = L_BUFFERY,                                               &
+     &       L_NBUFFER = L_BUFFERY )
 
-C--    COMMON / EXCH_L / LOGICAL number common arrays for exchanges
-C      exchNeedsMemSync - TRUE if memory sync. required to ensure
-C                         memory consistency during exchange
-C      exchUsesBarrier  - TRUE if we use a call to BAR to do sync.
-C                         between processes. On some machines we wont
-C                         spin on the Ack setting ( the T90 ),
-C                         instead we will use s system barrier.
-C                         On the T90 the system barrier is very fast and
-C                         switches out the thread while it waits. On most
-C                         machines the system barrier is much too slow and if
-C                         we own the machine and have one thread per process
-C                         preemption is not a problem.
-C      exchCollectStatistics - Turns exchange statistics collecting on and off.
+!--    COMMON / EXCH_L / LOGICAL number common arrays for exchanges
+ ! exchNeedsMemSync - TRUE if memory sync. required to ensure
+ !                    memory consistency during exchange
+ ! exchUsesBarrier  - TRUE if we use a call to BAR to do sync.
+ !                    between processes. On some machines we wont
+ !                    spin on the Ack setting ( the T90 ),
+ !                    instead we will use s system barrier.
+ !                    On the T90 the system barrier is very fast and
+ !                    switches out the thread while it waits. On most
+ !                    machines the system barrier is much too slow and if
+ !                    we own the machine and have one thread per process
+ !                    preemption is not a problem.
+ ! exchCollectStatistics - Turns exchange statistics collecting on and off.
 
-       COMMON / EXCH_L / exchNeedsMemSync, exchUsesBarrier,
-     &                   exchCollectStatistics
-       LOGICAL exchNeedsMemSync
-       LOGICAL exchUsesBarrier
-       LOGICAL exchCollectStatistics
+       COMMON / EXCH_L / exchNeedsMemSync, exchUsesBarrier,                       &
+     &       exchCollectStatistics
+       LOGICAL :: exchNeedsMemSync
+       LOGICAL :: exchUsesBarrier
+       LOGICAL :: exchCollectStatistics
 
-C--    COMMON / EXCH_R / REAL number common arrays for exchanges
-C      xxxxSendBuf - Buffer used for sending data to another tile.
-C      xxxxRecvBuf - Buffer used for receiving data from another tile.
-       COMMON / EXCH_R /
-     &  westSendBuf_RL, eastSendBuf_RL,
-     &  southSendBuf_RL, northSendBuf_RL,
-     &  westRecvBuf_RL, eastRecvBuf_RL,
-     &  southRecvBuf_RL, northRecvBuf_RL,
-     &  westSendBuf_RS, eastSendBuf_RS,
-     &  southSendBuf_RS, northSendBuf_RS,
-     &  westRecvBuf_RS, eastRecvBuf_RS,
-     &  southRecvBuf_RS, northRecvBuf_RS,
-     &  westSendBuf_R8, eastSendBuf_R8,
-     &  southSendBuf_R8, northSendBuf_R8,
-     &  westRecvBuf_R8, eastRecvBuf_R8,
-     &  southRecvBuf_R8, northRecvBuf_R8,
-     &  westSendBuf_R4, eastSendBuf_R4,
-     &  southSendBuf_R4, northSendBuf_R4,
-     &  westRecvBuf_R4, eastRecvBuf_R4,
-     &  southRecvBuf_R4, northRecvBuf_R4
-       _RL   westSendBuf_RL( L_WBUFFER, NUMBER_OF_BUFFER_LEVELS,
-     &                       nSx, nSy )
-       _RL   eastSendBuf_RL( L_EBUFFER, NUMBER_OF_BUFFER_LEVELS,
-     &                       nSx, nSy )
-       _RL  southSendBuf_RL( L_SBUFFER, NUMBER_OF_BUFFER_LEVELS,
-     &                       nSx, nSy )
-       _RL  northSendBuf_RL( L_NBUFFER, NUMBER_OF_BUFFER_LEVELS,
-     &                       nSx, nSy )
-       _RL   westRecvBuf_RL( L_WBUFFER, NUMBER_OF_BUFFER_LEVELS,
-     &                       nSx, nSy )
-       _RL   eastRecvBuf_RL( L_EBUFFER, NUMBER_OF_BUFFER_LEVELS,
-     &                       nSx, nSy )
-       _RL  southRecvBuf_RL( L_SBUFFER, NUMBER_OF_BUFFER_LEVELS,
-     &                       nSx, nSy )
-       _RL  northRecvBuf_RL( L_NBUFFER, NUMBER_OF_BUFFER_LEVELS,
-     &                       nSx, nSy )
-       _RS   westSendBuf_RS( L_WBUFFER, NUMBER_OF_BUFFER_LEVELS,
-     &                       nSx, nSy )
-       _RS   eastSendBuf_RS( L_EBUFFER, NUMBER_OF_BUFFER_LEVELS,
-     &                       nSx, nSy )
-       _RS  southSendBuf_RS( L_SBUFFER, NUMBER_OF_BUFFER_LEVELS,
-     &                       nSx, nSy )
-       _RS  northSendBuf_RS( L_NBUFFER, NUMBER_OF_BUFFER_LEVELS,
-     &                       nSx, nSy )
-       _RS   westRecvBuf_RS( L_WBUFFER, NUMBER_OF_BUFFER_LEVELS,
-     &                       nSx, nSy )
-       _RS   eastRecvBuf_RS( L_EBUFFER, NUMBER_OF_BUFFER_LEVELS,
-     &                       nSx, nSy )
-       _RS  southRecvBuf_RS( L_SBUFFER, NUMBER_OF_BUFFER_LEVELS,
-     &                       nSx, nSy )
-       _RS  northRecvBuf_RS( L_NBUFFER, NUMBER_OF_BUFFER_LEVELS,
-     &                       nSx, nSy )
-       _R8   westSendBuf_R8( L_WBUFFER, NUMBER_OF_BUFFER_LEVELS,
-     &                       nSx, nSy )
-       _R8   eastSendBuf_R8( L_EBUFFER, NUMBER_OF_BUFFER_LEVELS,
-     &                       nSx, nSy )
-       _R8  southSendBuf_R8( L_SBUFFER, NUMBER_OF_BUFFER_LEVELS,
-     &                       nSx, nSy )
-       _R8  northSendBuf_R8( L_NBUFFER, NUMBER_OF_BUFFER_LEVELS,
-     &                       nSx, nSy )
-       _R8   westRecvBuf_R8( L_WBUFFER, NUMBER_OF_BUFFER_LEVELS,
-     &                       nSx, nSy )
-       _R8   eastRecvBuf_R8( L_EBUFFER, NUMBER_OF_BUFFER_LEVELS,
-     &                       nSx, nSy )
-       _R8  southRecvBuf_R8( L_SBUFFER, NUMBER_OF_BUFFER_LEVELS,
-     &                       nSx, nSy )
-       _R8  northRecvBuf_R8( L_NBUFFER, NUMBER_OF_BUFFER_LEVELS,
-     &                       nSx, nSy )
-       _R4   westSendBuf_R4( L_WBUFFER, NUMBER_OF_BUFFER_LEVELS,
-     &                       nSx, nSy )
-       _R4   eastSendBuf_R4( L_EBUFFER, NUMBER_OF_BUFFER_LEVELS,
-     &                       nSx, nSy )
-       _R4  southSendBuf_R4( L_SBUFFER, NUMBER_OF_BUFFER_LEVELS,
-     &                       nSx, nSy )
-       _R4  northSendBuf_R4( L_NBUFFER, NUMBER_OF_BUFFER_LEVELS,
-     &                       nSx, nSy )
-       _R4   westRecvBuf_R4( L_WBUFFER, NUMBER_OF_BUFFER_LEVELS,
-     &                       nSx, nSy )
-       _R4   eastRecvBuf_R4( L_EBUFFER, NUMBER_OF_BUFFER_LEVELS,
-     &                       nSx, nSy )
-       _R4  southRecvBuf_R4( L_SBUFFER, NUMBER_OF_BUFFER_LEVELS,
-     &                       nSx, nSy )
-       _R4  northRecvBuf_R4( L_NBUFFER, NUMBER_OF_BUFFER_LEVELS,
-     &                       nSx, nSy )
+!--    COMMON / EXCH_R / REAL number common arrays for exchanges
+ ! xxxxSendBuf - Buffer used for sending data to another tile.
+ ! xxxxRecvBuf - Buffer used for receiving data from another tile.
+       COMMON / EXCH_R /                                                          &
+     &       westSendBuf_RL, eastSendBuf_RL,                                      &
+     &       southSendBuf_RL, northSendBuf_RL,                                    &
+     &       westRecvBuf_RL, eastRecvBuf_RL,                                      &
+     &       southRecvBuf_RL, northRecvBuf_RL,                                    &
+     &       westSendBuf_RS, eastSendBuf_RS,                                      &
+     &       southSendBuf_RS, northSendBuf_RS,                                    &
+     &       westRecvBuf_RS, eastRecvBuf_RS,                                      &
+     &       southRecvBuf_RS, northRecvBuf_RS,                                    &
+     &       westSendBuf_R8, eastSendBuf_R8,                                      &
+     &       southSendBuf_R8, northSendBuf_R8,                                    &
+     &       westRecvBuf_R8, eastRecvBuf_R8,                                      &
+     &       southRecvBuf_R8, northRecvBuf_R8,                                    &
+     &       westSendBuf_R4, eastSendBuf_R4,                                      &
+     &       southSendBuf_R4, northSendBuf_R4,                                    &
+     &       westRecvBuf_R4, eastRecvBuf_R4,                                      &
+     &       southRecvBuf_R4, northRecvBuf_R4
+       _RL   westSendBuf_RL( L_WBUFFER, NUMBER_OF_BUFFER_LEVELS,                  &
+     &       nSx, nSy )
+       _RL   eastSendBuf_RL( L_EBUFFER, NUMBER_OF_BUFFER_LEVELS,                  &
+     &       nSx, nSy )
+       _RL  southSendBuf_RL( L_SBUFFER, NUMBER_OF_BUFFER_LEVELS,                  &
+     &       nSx, nSy )
+       _RL  northSendBuf_RL( L_NBUFFER, NUMBER_OF_BUFFER_LEVELS,                  &
+     &       nSx, nSy )
+       _RL   westRecvBuf_RL( L_WBUFFER, NUMBER_OF_BUFFER_LEVELS,                  &
+     &       nSx, nSy )
+       _RL   eastRecvBuf_RL( L_EBUFFER, NUMBER_OF_BUFFER_LEVELS,                  &
+     &       nSx, nSy )
+       _RL  southRecvBuf_RL( L_SBUFFER, NUMBER_OF_BUFFER_LEVELS,                  &
+     &       nSx, nSy )
+       _RL  northRecvBuf_RL( L_NBUFFER, NUMBER_OF_BUFFER_LEVELS,                  &
+     &       nSx, nSy )
+       _RS   westSendBuf_RS( L_WBUFFER, NUMBER_OF_BUFFER_LEVELS,                  &
+     &       nSx, nSy )
+       _RS   eastSendBuf_RS( L_EBUFFER, NUMBER_OF_BUFFER_LEVELS,                  &
+     &       nSx, nSy )
+       _RS  southSendBuf_RS( L_SBUFFER, NUMBER_OF_BUFFER_LEVELS,                  &
+     &       nSx, nSy )
+       _RS  northSendBuf_RS( L_NBUFFER, NUMBER_OF_BUFFER_LEVELS,                  &
+     &       nSx, nSy )
+       _RS   westRecvBuf_RS( L_WBUFFER, NUMBER_OF_BUFFER_LEVELS,                  &
+     &       nSx, nSy )
+       _RS   eastRecvBuf_RS( L_EBUFFER, NUMBER_OF_BUFFER_LEVELS,                  &
+     &       nSx, nSy )
+       _RS  southRecvBuf_RS( L_SBUFFER, NUMBER_OF_BUFFER_LEVELS,                  &
+     &       nSx, nSy )
+       _RS  northRecvBuf_RS( L_NBUFFER, NUMBER_OF_BUFFER_LEVELS,                  &
+     &       nSx, nSy )
+       _R8   westSendBuf_R8( L_WBUFFER, NUMBER_OF_BUFFER_LEVELS,                  &
+     &       nSx, nSy )
+       _R8   eastSendBuf_R8( L_EBUFFER, NUMBER_OF_BUFFER_LEVELS,                  &
+     &       nSx, nSy )
+       _R8  southSendBuf_R8( L_SBUFFER, NUMBER_OF_BUFFER_LEVELS,                  &
+     &       nSx, nSy )
+       _R8  northSendBuf_R8( L_NBUFFER, NUMBER_OF_BUFFER_LEVELS,                  &
+     &       nSx, nSy )
+       _R8   westRecvBuf_R8( L_WBUFFER, NUMBER_OF_BUFFER_LEVELS,                  &
+     &       nSx, nSy )
+       _R8   eastRecvBuf_R8( L_EBUFFER, NUMBER_OF_BUFFER_LEVELS,                  &
+     &       nSx, nSy )
+       _R8  southRecvBuf_R8( L_SBUFFER, NUMBER_OF_BUFFER_LEVELS,                  &
+     &       nSx, nSy )
+       _R8  northRecvBuf_R8( L_NBUFFER, NUMBER_OF_BUFFER_LEVELS,                  &
+     &       nSx, nSy )
+       _R4   westSendBuf_R4( L_WBUFFER, NUMBER_OF_BUFFER_LEVELS,                  &
+     &       nSx, nSy )
+       _R4   eastSendBuf_R4( L_EBUFFER, NUMBER_OF_BUFFER_LEVELS,                  &
+     &       nSx, nSy )
+       _R4  southSendBuf_R4( L_SBUFFER, NUMBER_OF_BUFFER_LEVELS,                  &
+     &       nSx, nSy )
+       _R4  northSendBuf_R4( L_NBUFFER, NUMBER_OF_BUFFER_LEVELS,                  &
+     &       nSx, nSy )
+       _R4   westRecvBuf_R4( L_WBUFFER, NUMBER_OF_BUFFER_LEVELS,                  &
+     &       nSx, nSy )
+       _R4   eastRecvBuf_R4( L_EBUFFER, NUMBER_OF_BUFFER_LEVELS,                  &
+     &       nSx, nSy )
+       _R4  southRecvBuf_R4( L_SBUFFER, NUMBER_OF_BUFFER_LEVELS,                  &
+     &       nSx, nSy )
+       _R4  northRecvBuf_R4( L_NBUFFER, NUMBER_OF_BUFFER_LEVELS,                  &
+     &       nSx, nSy )
 
-C--    COMMON / EXCH_I / INTEGER common arrays for exchanges
-C      xxxxSendAck - Flag indicating ready to send data.
-C      xxxxRecvAck - Falg indicating receive data is ready.
-C      exchBufferLevel - Current cyclic buffer level.
-C      exchNReqsX, exchNReqsY - Pending message counts
-C      exchReqIdX, exchReqIdY -Pending message identifiers
-C      *Spin* - Exchange statistics holder
-C       Count - No. spins for each thread
-C         Max - Maximum spins for an exchange
-C         Min - Minimum spins for an exchange
-       COMMON / EXCH_I /
-     &  westSendAck, eastSendAck, southSendAck, northSendAck,
-     &  westRecvAck, eastRecvAck, southRecvAck, northRecvAck,
-     &  exchangeBufLevel,
-     &  exchNReqsX, exchNReqsY, exchReqIdX, exchReqIdY,
-     &  exchRecvXSpinCount, exchRecvXSpinMax, exchRecvXSpinMin,
-     &  exchRecvXExchCount,
-     &  exchRecvYSpinCount, exchRecvYSpinMax, exchRecvYSpinMin,
-     &  exchRecvYExchCount
-       INTEGER  westSendAck(            NUMBER_OF_BUFFER_LEVELS,
-     &                       nSx, nSy )
-       INTEGER  eastSendAck(            NUMBER_OF_BUFFER_LEVELS,
-     &                       nSx, nSy )
-       INTEGER southSendAck(            NUMBER_OF_BUFFER_LEVELS,
-     &                       nSx, nSy )
-       INTEGER northSendAck(            NUMBER_OF_BUFFER_LEVELS,
-     &                       nSx, nSy )
-       INTEGER  westRecvAck(            NUMBER_OF_BUFFER_LEVELS,
-     &                       nSx, nSy )
-       INTEGER  eastRecvAck(            NUMBER_OF_BUFFER_LEVELS,
-     &                       nSx, nSy )
-       INTEGER southRecvAck(            NUMBER_OF_BUFFER_LEVELS,
-     &                       nSx, nSy )
-       INTEGER northRecvAck(            NUMBER_OF_BUFFER_LEVELS,
-     &                       nSx, nSy )
-       INTEGER exchangeBufLevel(  cacheLineSize/4, nSx, nSy )
-       INTEGER exchNReqsX(cacheLineSize/4,nSx,nSy)
-       INTEGER exchNReqsY(cacheLineSize/4,nSx,nSy)
-       INTEGER exchReqIdX(2*nSx+2*nSy,cacheLineSize/4,nSx,nSy)
-       INTEGER exchReqIdY(2*nSx+2*nSy,cacheLineSize/4,nSx,nSy)
-       INTEGER exchRecvXSpinCount(cacheLineSize/4, nSx, nSy)
-       INTEGER exchRecvXExchCount(cacheLineSize/4, nSx, nSy)
-       INTEGER exchRecvXSpinMax  (cacheLineSize/4, nSx, nSy)
-       INTEGER exchRecvXSpinMin  (cacheLineSize/4, nSx, nSy)
-       INTEGER exchRecvYSpinCount(cacheLineSize/4, nSx, nSy)
-       INTEGER exchRecvYExchCount(cacheLineSize/4, nSx, nSy)
-       INTEGER exchRecvYSpinMax  (cacheLineSize/4, nSx, nSy)
-       INTEGER exchRecvYSpinMin  (cacheLineSize/4, nSx, nSy)
+!--    COMMON / EXCH_I / INTEGER common arrays for exchanges
+ ! xxxxSendAck - Flag indicating ready to send data.
+ ! xxxxRecvAck - Falg indicating receive data is ready.
+ ! exchBufferLevel - Current cyclic buffer level.
+ ! exchNReqsX, exchNReqsY - Pending message counts
+ ! exchReqIdX, exchReqIdY -Pending message identifiers
+ ! *Spin* - Exchange statistics holder
+ !  Count - No. spins for each thread
+ !    Max - Maximum spins for an exchange
+ !    Min - Minimum spins for an exchange
+       COMMON / EXCH_I /                                                          &
+     &       westSendAck, eastSendAck, southSendAck, northSendAck,                &
+     &       westRecvAck, eastRecvAck, southRecvAck, northRecvAck,                &
+     &       exchangeBufLevel,                                                    &
+     &       exchNReqsX, exchNReqsY, exchReqIdX, exchReqIdY,                      &
+     &       exchRecvXSpinCount, exchRecvXSpinMax, exchRecvXSpinMin,              &
+     &       exchRecvXExchCount,                                                  &
+     &       exchRecvYSpinCount, exchRecvYSpinMax, exchRecvYSpinMin,              &
+     &       exchRecvYExchCount
+       INTEGER :: westSendAck(            NUMBER_OF_BUFFER_LEVELS,                  &
+     &       nSx, nSy )
+       INTEGER :: eastSendAck(            NUMBER_OF_BUFFER_LEVELS,                  &
+     &       nSx, nSy )
+       INTEGER :: southSendAck(            NUMBER_OF_BUFFER_LEVELS,                  &
+     &       nSx, nSy )
+       INTEGER :: northSendAck(            NUMBER_OF_BUFFER_LEVELS,                  &
+     &       nSx, nSy )
+       INTEGER :: westRecvAck(            NUMBER_OF_BUFFER_LEVELS,                  &
+     &       nSx, nSy )
+       INTEGER :: eastRecvAck(            NUMBER_OF_BUFFER_LEVELS,                  &
+     &       nSx, nSy )
+       INTEGER :: southRecvAck(            NUMBER_OF_BUFFER_LEVELS,                  &
+     &       nSx, nSy )
+       INTEGER :: northRecvAck(            NUMBER_OF_BUFFER_LEVELS,                  &
+     &       nSx, nSy )
+       INTEGER :: exchangeBufLevel(  cacheLineSize/4, nSx, nSy )
+       INTEGER :: exchNReqsX(cacheLineSize/4,nSx,nSy)
+       INTEGER :: exchNReqsY(cacheLineSize/4,nSx,nSy)
+       INTEGER :: exchReqIdX(2*nSx+2*nSy,cacheLineSize/4,nSx,nSy)
+       INTEGER :: exchReqIdY(2*nSx+2*nSy,cacheLineSize/4,nSx,nSy)
+       INTEGER :: exchRecvXSpinCount(cacheLineSize/4, nSx, nSy)
+       INTEGER :: exchRecvXExchCount(cacheLineSize/4, nSx, nSy)
+       INTEGER :: exchRecvXSpinMax  (cacheLineSize/4, nSx, nSy)
+       INTEGER :: exchRecvXSpinMin  (cacheLineSize/4, nSx, nSy)
+       INTEGER :: exchRecvYSpinCount(cacheLineSize/4, nSx, nSy)
+       INTEGER :: exchRecvYExchCount(cacheLineSize/4, nSx, nSy)
+       INTEGER :: exchRecvYSpinMax  (cacheLineSize/4, nSx, nSy)
+       INTEGER :: exchRecvYSpinMin  (cacheLineSize/4, nSx, nSy)
 

--- a/eesupp/inc/GLOBAL_MAX.h
+++ b/eesupp/inc/GLOBAL_MAX.h
@@ -1,36 +1,36 @@
-CBOP
-C     !ROUTINE: GLOBAL_MAX.h
-C     !INTERFACE:
-C     include "GLOBAL_MAX.h"
-C     !DESCRIPTION:
-C     *==========================================================*
-C     | GLOBAL\_MAX.h
-C     | o Globals used by Fortran global max routine.
-C     *==========================================================*
-C     | The global max shared memory scheme uses global heap data
-C     | structures (.i.e COMMON blocks ). Each thread writes to
-C     | an its own element of the shared memory array and then
-C     | one thread reads all the entries and maxs them. The max
-C     | result is then read by all threads.
-C     | Remember - you are working with regions of memory that
-C     | are being updated concurrently by different threads.
-C     | What happens, when it happens and who gets to see what
-C     | happens at what stage depends on the computer systems
-C     | memory model. Every computer has a different memory model
-C     | and they are never simple. In all current platforms it is
-C     | possible for one thread to see events happening in a
-C     | different order from the order they are written in the
-C     | code.
-C     | Unless you understand this it is not a good idea to
-C     | make modifications te way these header files are setup or
-C     | the way the global max routines work.
-C     *==========================================================*
-CEOP
+!BOP
+! !ROUTINE: GLOBAL_MAX.h
+! !INTERFACE:
+! include "GLOBAL_MAX.h"
+! !DESCRIPTION:
+! *==========================================================*
+! | GLOBAL\_MAX.h
+! | o Globals used by Fortran global max routine.
+! *==========================================================*
+! | The global max shared memory scheme uses global heap data
+! | structures (.i.e COMMON blocks ). Each thread writes to
+! | an its own element of the shared memory array and then
+! | one thread reads all the entries and maxs them. The max
+! | result is then read by all threads.
+! | Remember - you are working with regions of memory that
+! | are being updated concurrently by different threads.
+! | What happens, when it happens and who gets to see what
+! | happens at what stage depends on the computer systems
+! | memory model. Every computer has a different memory model
+! | and they are never simple. In all current platforms it is
+! | possible for one thread to see events happening in a
+! | different order from the order they are written in the
+! | code.
+! | Unless you understand this it is not a good idea to
+! | make modifications te way these header files are setup or
+! | the way the global max routines work.
+! *==========================================================*
+!EOP
       COMMON / GMAX_COMMON_R8 / phiGMR8
-      Real*8  phiGMR8(lShare8, 0:MAX_NO_THREADS )
+      Real(kind=8) :: phiGMR8(lShare8, 0:MAX_NO_THREADS )
 
       COMMON / GMAX_COMMON_R4 / phiGMR4
-      Real*4  phiGMR4(lShare4, 0:MAX_NO_THREADS )
+      Real(kind=4) :: phiGMR4(lShare4, 0:MAX_NO_THREADS )
 
       COMMON / GMAX_COMMON_I  / phiGMI
-      INTEGER phiGMI (lShare4, 0:MAX_NO_THREADS )
+      INTEGER :: phiGMI (lShare4, 0:MAX_NO_THREADS )

--- a/eesupp/inc/GLOBAL_SUM.h
+++ b/eesupp/inc/GLOBAL_SUM.h
@@ -1,47 +1,47 @@
-CBOP
-C     !ROUTINE: GLOBAL_SUM.h
-C     !INTERFACE:
-C     include "GLOBAL_SUM.h"
-C     !DESCRIPTION:
-C     *==========================================================*
-C     | GLOBAL\_SUM.h
-C     | o Globals used by Fortran global sum routine.
-C     *==========================================================*
-C     | The global sum shared memory scheme uses global heap data|
-C     | structures (.i.e COMMON blocks ). Each thread writes to  |
-C     | an its own element of the shared memory array and then   |
-C     | one thread reads all the entries and sums them. The sum  |
-C     | result is then read by all threads.                      |
-C     | Remember - you are working with regions of memory that   |
-C     | are being updated concurrently by different threads.     |
-C     | What happens, when it happens and who gets to see what   |
-C     | happens at what stage depends on the computer systems    |
-C     | memory model. Every computer has a different memory model|
-C     | and they are never simple. In all current platforms it is|
-C     | possible for one thread to see events happening in a     |
-C     | different order from the order they are written in the   |
-C     | code.                                                    |
-C     | Unless you understand this it is not a good idea to      |
-C     | make modifications te way these header files are setup or|
-C     | the way the global sum routines work.                    |
-C     *==========================================================*
-CEOP
+!BOP
+! !ROUTINE: GLOBAL_SUM.h
+! !INTERFACE:
+! include "GLOBAL_SUM.h"
+! !DESCRIPTION:
+! *==========================================================*
+! | GLOBAL\_SUM.h
+! | o Globals used by Fortran global sum routine.
+! *==========================================================*
+! | The global sum shared memory scheme uses global heap data|
+! | structures (.i.e COMMON blocks ). Each thread writes to  |
+! | an its own element of the shared memory array and then   |
+! | one thread reads all the entries and sums them. The sum  |
+! | result is then read by all threads.                      |
+! | Remember - you are working with regions of memory that   |
+! | are being updated concurrently by different threads.     |
+! | What happens, when it happens and who gets to see what   |
+! | happens at what stage depends on the computer systems    |
+! | memory model. Every computer has a different memory model|
+! | and they are never simple. In all current platforms it is|
+! | possible for one thread to see events happening in a     |
+! | different order from the order they are written in the   |
+! | code.                                                    |
+! | Unless you understand this it is not a good idea to      |
+! | make modifications te way these header files are setup or|
+! | the way the global sum routines work.                    |
+! *==========================================================*
+!EOP
 
       COMMON / GSUM_COMMON_R8 / phiGSR8, shareBufGSR8
-      Real*8  phiGSR8 (lShare8, 0:MAX_NO_THREADS )
-      Real*8  shareBufGSR8 ( nSx, nSy )
+      Real(kind=8) :: phiGSR8 (lShare8, 0:MAX_NO_THREADS )
+      Real(kind=8) :: shareBufGSR8 ( nSx, nSy )
 
       COMMON / GSUM_COMMON_R4 / phiGSR4
-      Real*4  phiGSR4 (lShare4, 0:MAX_NO_THREADS )
+      Real(kind=4) :: phiGSR4 (lShare4, 0:MAX_NO_THREADS )
 
       COMMON / GSUM_COMMON_I  / phiGSI
-      INTEGER phiGSI  (lShare4, 0:MAX_NO_THREADS )
+      INTEGER :: phiGSI  (lShare4, 0:MAX_NO_THREADS )
 
       COMMON / GLBSUM_VECTOR_RL / shareBufGSVec, shareGSVector
-      Real*8  shareBufGSVec( nSx, nSy, GSVec_size )
-      Real*8  shareGSVector( GSVec_size )
+      Real(kind=8) :: shareBufGSVec( nSx, nSy, GSVec_size )
+      Real(kind=8) :: shareGSVector( GSVec_size )
 
       COMMON / GLBSUM_VECTOR_I / shareBufGSVecI, shareGSVectInt
-      INTEGER shareBufGSVecI( nSx, nSy, GSVec_size )
-      INTEGER shareGSVectInt( GSVec_size )
-C---+----1----+----2----+----3----+----4----+----5----+----6----+----7-|--+----|
+      INTEGER :: shareBufGSVecI( nSx, nSy, GSVec_size )
+      INTEGER :: shareGSVectInt( GSVec_size )
+!---+----1----+----2----+----3----+----4----+----5----+----6----+----7-|--+----|

--- a/eesupp/inc/MAIN_PDIRECTIVES1.h
+++ b/eesupp/inc/MAIN_PDIRECTIVES1.h
@@ -1,76 +1,76 @@
-CBOP
-C     !ROUTINE: MAIN_PDIRECTIVES1.h
-C     !INTERFACE:
-C     include "MAIN_PDIRECTIVES1.h"
-C     !DESCRIPTION:
-C     *==========================================================*
-C     | MAIN\_PDIRECTIVES1.h                                       
-C     *==========================================================*
-C     | Parallel directives to generate multithreaded code for    
-C     | various different compilers. The master preprocessor      
-C     | file CPP\_OPTIONS is used to select which of these 
-C     | options is included in the code.
-C     *==========================================================*
-CEOP
+!BOP
+! !ROUTINE: MAIN_PDIRECTIVES1.h
+! !INTERFACE:
+! include "MAIN_PDIRECTIVES1.h"
+! !DESCRIPTION:
+! *==========================================================*
+! | MAIN\_PDIRECTIVES1.h
+! *==========================================================*
+! | Parallel directives to generate multithreaded code for
+! | various different compilers. The master preprocessor
+! | file CPP\_OPTIONS is used to select which of these
+! | options is included in the code.
+! *==========================================================*
+!EOP
 
 #ifdef USE_SOLARIS_THREADING
-C--
-C--  Parallel directives for SUN/Pro compiler.
-C--
-C     Parallel compiler directives for Solaris
-C$PAR  DOALL
-C$PAR& SHARED(nThreads)
-C$PAR& ,PRIVATE(myThid)
-C$PAR& ,SCHEDTYPE(SELF(1))
-C
+!--
+!--  Parallel directives for SUN/Pro compiler.
+!--
+! Parallel compiler directives for Solaris
+!$PAR  DOALL
+!$PAR& SHARED(nThreads)
+!$PAR& ,PRIVATE(myThid)
+!$PAR& ,SCHEDTYPE(SELF(1))
+!
 #endif
 
 #define USE_KAP_THREADING
 #ifdef USE_KAP_THREADING
-C--
-C--  Parallel directives for Kuck and Associates compiler.
-C--  This is used to generate multi-threaded code on Digital 
-C--  systems. It can also be used under NT.
-C--
-C      Parallel compiler directives for Digital with kap compiler.
-C*KAP* PARALLEL REGION
-C*KAP*& SHARED(nThreads,eeBootError,threadIsComplete)
-C*KAP*& LOCAL(myThid,I)
-C*KAP*  PARALLEL DO
-C*KAP*& BLOCKED(1)
-C
+!--
+!--  Parallel directives for Kuck and Associates compiler.
+!--  This is used to generate multi-threaded code on Digital
+!--  systems. It can also be used under NT.
+!--
+ ! Parallel compiler directives for Digital with kap compiler.
+!*KAP* PARALLEL REGION
+!*KAP*& SHARED(nThreads,eeBootError,threadIsComplete)
+!*KAP*& LOCAL(myThid,I)
+!*KAP*  PARALLEL DO
+!*KAP*& BLOCKED(1)
+!
 #endif
 
 #ifdef USE_IRIX_THREADING
-C--
-C--  Parallel directives for MIPS Pro Fortran compiler
-C--
-C      Parallel compiler directives for SGI with IRIX
-C$PAR  PARALLEL DO
-C$PAR&  CHUNK=1,MP_SCHEDTYPE=INTERLEAVE,
-C$PAR&  SHARE(nThreads),LOCAL(myThid,I)
-C
+!--
+!--  Parallel directives for MIPS Pro Fortran compiler
+!--
+ ! Parallel compiler directives for SGI with IRIX
+!$PAR  PARALLEL DO
+!$PAR&  CHUNK=1,MP_SCHEDTYPE=INTERLEAVE,
+!$PAR&  SHARE(nThreads),LOCAL(myThid,I)
+!
 #endif
 
 #ifdef USE_EXEMPLAR_THREADING
-C--
-C--  Parallel directives for HP Exemplar Fortran compiler
-C--
-C      Parallel compiler directives for HP Exemplar
-C$DIR loop_parallel
-C$DIR loop_private (I,myThid)
+!--
+!--  Parallel directives for HP Exemplar Fortran compiler
+!--
+ ! Parallel compiler directives for HP Exemplar
+!$DIR loop_parallel
+!$DIR loop_private (I,myThid)
 #endif
 
 #ifdef USE_C90_THREADING
-C--
-C--  Parallel directives for CRAY/SGI Fortan 90 compiler.
-C--
-CMIC$ DO ALL PRIVATE (I, myThid ) SHARED(nThreads)
-CMIC$& SINGLE
-#endif             
+!--
+!--  Parallel directives for CRAY/SGI Fortan 90 compiler.
+!--
+!MIC$ DO ALL PRIVATE (I, myThid ) SHARED(nThreads)
+!MIC$& SINGLE
+#endif
 
 
 #ifdef USE_OMP_THREADING
-C$OMP PARALLEL  SHARED(nThreads), PRIVATE(I,myThid)
+!$OMP PARALLEL  SHARED(nThreads), PRIVATE(I,myThid)
 #endif
 

--- a/eesupp/inc/MAIN_PDIRECTIVES2.h
+++ b/eesupp/inc/MAIN_PDIRECTIVES2.h
@@ -1,50 +1,50 @@
-CBOP
-C     !ROUTINE: MAIN_PDIRECTIVES2.h
-C     !INTERFACE:
-C     include "MAIN_PDIRECTIVES2.h"
-C     !DESCRIPTION:
-C     *==========================================================*
-C     | MAIN\_PDIRECTIVES2.h                                       
-C     *==========================================================*
-C     | Parallel directives to generate multithreaded code for    
-C     | various different compilers. The master preprocessor      
-C     | file CPP\_OPTIONS is used to select which of these 
-C     | options is included in the code.           
-C     | Note: Only some of the directives require end blocks.     
-C     |      For directives which do not require end blocks there 
-C     |      is no entry here.                                    
-C     *==========================================================*
-CEOP
+!BOP
+! !ROUTINE: MAIN_PDIRECTIVES2.h
+! !INTERFACE:
+! include "MAIN_PDIRECTIVES2.h"
+! !DESCRIPTION:
+! *==========================================================*
+! | MAIN\_PDIRECTIVES2.h
+! *==========================================================*
+! | Parallel directives to generate multithreaded code for
+! | various different compilers. The master preprocessor
+! | file CPP\_OPTIONS is used to select which of these
+! | options is included in the code.
+! | Note: Only some of the directives require end blocks.
+! |      For directives which do not require end blocks there
+! |      is no entry here.
+! *==========================================================*
+!EOP
 
 #if defined USE_KAP_THREADING
-C--
-C--  Parallel directives for Kuck and Associates compiler.
-C--  This is used to generate multi-threaded code on Digital
-C--  systems. It can also be used under NT. 
-C--  Note: The KAP parallel proceesing tool has several bugs
-C--        which means that if there are more threads (set via
-C--        setenv PARALLEL) than iterations in the parallel
-C--        loop the extra threads start on the section 
-C--        after the loop!
-C--        To work around this we could place an extra dummy
-C--        parallel section here. KAP places a barrier at the
-C--        start of each parallel region which ensures that 
-C--        the extra threads wait (note this wait is in a busy loop).
-C--        Without this feature the extra thread(s) will run on and may
-C--        halt the program by calling STOP! Unfortunately that seems
-C--        to cause a deadlock in a KAP library routine! Instead the
-C--        current solution is to check for a thread reaching the
-C--        shutdown part of main.F before other threads have
-C--        completed computation ( see eedie.F ).
-C
-C*KAP*  END PARALLEL REGION
-C   C*KAP*  PARALLEL REGION
-C           CALL FOOL_THE_COMPILER
-C   C*KAP*  END PARALLEL REGION
-C
+!--
+!--  Parallel directives for Kuck and Associates compiler.
+!--  This is used to generate multi-threaded code on Digital
+!--  systems. It can also be used under NT.
+!--  Note: The KAP parallel proceesing tool has several bugs
+!--        which means that if there are more threads (set via
+!--        setenv PARALLEL) than iterations in the parallel
+!--        loop the extra threads start on the section
+!--        after the loop!
+!--        To work around this we could place an extra dummy
+!--        parallel section here. KAP places a barrier at the
+!--        start of each parallel region which ensures that
+!--        the extra threads wait (note this wait is in a busy loop).
+!--        Without this feature the extra thread(s) will run on and may
+!--        halt the program by calling STOP! Unfortunately that seems
+!--        to cause a deadlock in a KAP library routine! Instead the
+!--        current solution is to check for a thread reaching the
+!--        shutdown part of main.F before other threads have
+!--        completed computation ( see eedie.F ).
+!
+!*KAP*  END PARALLEL REGION
+!   C*KAP*  PARALLEL REGION
+!       CALL FOOL_THE_COMPILER
+!   C*KAP*  END PARALLEL REGION
+!
 #endif
-C
+!
 
 #ifdef USE_OMP_THREADING
-C$OMP  END PARALLEL
-#endif 
+!$OMP  END PARALLEL
+#endif

--- a/eesupp/inc/MPI_INFO.h
+++ b/eesupp/inc/MPI_INFO.h
@@ -1,15 +1,15 @@
-CBOP
-C      !ROUTINE: MPI_INFO.h
-C      !INTERFACE:
-C      include "MPI_INFO.h"
-C      !DESCRIPTION:
-C      Parameters used with MPI.
-CEOP
+!BOP
+ ! !ROUTINE: MPI_INFO.h
+ ! !INTERFACE:
+ ! include "MPI_INFO.h"
+ ! !DESCRIPTION:
+ ! Parameters used with MPI.
+!EOP
 
-       COMMON /MPI_INFO/
-     &  mpi_pid,     mpi_np,
-     &  mpi_northId, mpi_southId
-       INTEGER mpi_pid
-       INTEGER mpi_np
-       INTEGER mpi_northId
-       INTEGER mpi_southId
+       COMMON /MPI_INFO/                                                          &
+     &       mpi_pid,     mpi_np,                                                 &
+     &       mpi_northId, mpi_southId
+       INTEGER :: mpi_pid
+       INTEGER :: mpi_np
+       INTEGER :: mpi_northId
+       INTEGER :: mpi_southId

--- a/eesupp/inc/SIGREG.h
+++ b/eesupp/inc/SIGREG.h
@@ -1,7 +1,7 @@
-      integer i_got_signal
+      integer :: i_got_signal
       common / sig_i / i_got_signal
 
-CEH3 ;;; Local Variables: ***
-CEH3 ;;; mode:fortran ***
-CEH3 ;;; End: ***
+!EH3 ;;; Local Variables: ***
+!EH3 ;;; mode:fortran ***
+!EH3 ;;; End: ***
 

--- a/model/inc/CG2D.h
+++ b/model/inc/CG2D.h
@@ -1,38 +1,38 @@
-CBOP
-C     !ROUTINE: CG2D.h
-C     !INTERFACE:
-C     include "CG2D.h"
-C
-C     !DESCRIPTION:
-C     \bv
-C     *==========================================================*
-C     | CG2D.h
-C     | o Two-dimensional conjugate gradient solver header.
-C     *==========================================================*
-C     | Internal (private) data structures.
-C     *==========================================================*
-C     \ev
-CEOP
+!BOP
+! !ROUTINE: CG2D.h
+! !INTERFACE:
+! include "CG2D.h"
+!
+! !DESCRIPTION:
+! \bv
+! *==========================================================*
+! | CG2D.h
+! | o Two-dimensional conjugate gradient solver header.
+! *==========================================================*
+! | Internal (private) data structures.
+! *==========================================================*
+! \ev
+!EOP
 
-C--   COMMON /CG2D_I_L/ cg2dNormaliseRHS
-C     cg2dNormaliseRHS :: flag set to TRUE if normalise RHS in the Solver
+!--   COMMON /CG2D_I_L/ cg2dNormaliseRHS
+! cg2dNormaliseRHS :: flag set to TRUE if normalise RHS in the Solver
       COMMON /CG2D_I_L/ cg2dNormaliseRHS
-      LOGICAL cg2dNormaliseRHS
+      LOGICAL :: cg2dNormaliseRHS
 
-C--   COMMON /CG2D_I_R/ DEL**2 Laplacian operators
-C     aW2d    :: East-west operator.
-C     aS2d    :: North-south operator.
-C     aC2d    :: 2D operator main diagonal term.
-C     pW      :: East-west off-diagonal term of preconditioner.
-C     pS      :: North-south off-diagonal term of preconditioner.
-C     pC      :: Main diagonal term of preconditioner.
-C     cg2dNorm :: A matrix normalisation factor.
-C     cg2dTolerance_sq :: square of cg2d solver Tolerance (units depends
-C                 on cg2dNormaliseRHS, solver-unit ^2 = (m2/s2)^2 or no unit)
-      COMMON /CG2D_I_RS/
-     &      aW2d, aS2d, aC2d,
+!--   COMMON /CG2D_I_R/ DEL**2 Laplacian operators
+! aW2d    :: East-west operator.
+! aS2d    :: North-south operator.
+! aC2d    :: 2D operator main diagonal term.
+! pW      :: East-west off-diagonal term of preconditioner.
+! pS      :: North-south off-diagonal term of preconditioner.
+! pC      :: Main diagonal term of preconditioner.
+! cg2dNorm :: A matrix normalisation factor.
+! cg2dTolerance_sq :: square of cg2d solver Tolerance (units depends
+!             on cg2dNormaliseRHS, solver-unit ^2 = (m2/s2)^2 or no unit)
+      COMMON /CG2D_I_RS/                                                          &
+     &      aW2d, aS2d, aC2d,                                                     &
      &      pW, pS, pC
-      COMMON /CG2D_I_RL/
+      COMMON /CG2D_I_RL/                                                          &
      &      cg2dNorm, cg2dTolerance_sq
       _RS  aW2d (1-OLx:sNx+OLx,1-OLy:sNy+OLy,nSx,nSy)
       _RS  aS2d (1-OLx:sNx+OLx,1-OLy:sNy+OLy,nSx,nSy)
@@ -42,4 +42,4 @@ C                 on cg2dNormaliseRHS, solver-unit ^2 = (m2/s2)^2 or no unit)
       _RS  pC   (1-OLx:sNx+OLx,1-OLy:sNy+OLy,nSx,nSy)
       _RL  cg2dNorm, cg2dTolerance_sq
 
-C---+----1----+----2----+----3----+----4----+----5----+----6----+----7-|--+----|
+!---+----1----+----2----+----3----+----4----+----5----+----6----+----7-|--+----|

--- a/model/inc/CG3D.h
+++ b/model/inc/CG3D.h
@@ -1,40 +1,40 @@
 #ifdef ALLOW_NONHYDROSTATIC
-CBOP
-C     !ROUTINE: CG3D.h
-C     !INTERFACE:
-C     include "CG3D.h"
-C     !DESCRIPTION: \bv
-C     *==========================================================*
-C     | CG3D.h
-C     | o Three-dimensional conjugate gradient solver header.
-C     *==========================================================*
-C     | The common blocks set up here are used in the elliptic
-C     | equation inversion. They are also used as the interface
-C     | to the rest of the model. To set the source term for the
-C     | solver set the appropriate array below. To read the
-C     | solution read from the appropriate array below.
-C     *==========================================================*
-C     \ev
-CEOP
+!BOP
+! !ROUTINE: CG3D.h
+! !INTERFACE:
+! include "CG3D.h"
+! !DESCRIPTION: \bv
+! *==========================================================*
+! | CG3D.h
+! | o Three-dimensional conjugate gradient solver header.
+! *==========================================================*
+! | The common blocks set up here are used in the elliptic
+! | equation inversion. They are also used as the interface
+! | to the rest of the model. To set the source term for the
+! | solver set the appropriate array below. To read the
+! | solution read from the appropriate array below.
+! *==========================================================*
+! \ev
+!EOP
 
-C--   COMMON /CG3D_L/ cg3dNormaliseRHS
-C     cg3dNormaliseRHS :: flag set to TRUE if normalise RHS in the Solver
+!--   COMMON /CG3D_L/ cg3dNormaliseRHS
+! cg3dNormaliseRHS :: flag set to TRUE if normalise RHS in the Solver
       COMMON /CG3D_L/ cg3dNormaliseRHS
-      LOGICAL cg3dNormaliseRHS
+      LOGICAL :: cg3dNormaliseRHS
 
-C--   COMMON /CG3D_R/ DEL**2 Laplacian operators
-C     aW3d :: East-west operator.
-C     aS3d :: North-south operator.
-C     aV3d :: Vertical operator.
-C     aC3d :: 3D operator main diagonal term.
-C     zMC, zML, zMU :: preconditioner 3D solver
-C     cg3dNorm :: A matrix normalisation factor.
-C     cg3dTolerance_sq :: square of cg3d solver Tolerance (units depends
-C                 on cg3dNormaliseRHS, solver-unit ^2 = (m2/s2)^2 or no unit)
-      COMMON /CG3D_RS/
-     &      aW3d, aS3d, aV3d, aC3d,
+!--   COMMON /CG3D_R/ DEL**2 Laplacian operators
+! aW3d :: East-west operator.
+! aS3d :: North-south operator.
+! aV3d :: Vertical operator.
+! aC3d :: 3D operator main diagonal term.
+! zMC, zML, zMU :: preconditioner 3D solver
+! cg3dNorm :: A matrix normalisation factor.
+! cg3dTolerance_sq :: square of cg3d solver Tolerance (units depends
+!             on cg3dNormaliseRHS, solver-unit ^2 = (m2/s2)^2 or no unit)
+      COMMON /CG3D_RS/                                                            &
+     &      aW3d, aS3d, aV3d, aC3d,                                               &
      &      zMC, zML, zMU
-      COMMON /CG3D_RL/
+      COMMON /CG3D_RL/                                                            &
      &      cg3dNorm, cg3dTolerance_sq
       _RS  aW3d (1-OLx:sNx+OLx,1-OLy:sNy+OLy,Nr,nSx,nSy)
       _RS  aS3d (1-OLx:sNx+OLx,1-OLy:sNy+OLy,Nr,nSx,nSy)
@@ -45,12 +45,12 @@ C                 on cg3dNormaliseRHS, solver-unit ^2 = (m2/s2)^2 or no unit)
       _RS  zMU  (1-OLx:sNx+OLx,1-OLy:sNy+OLy,Nr,nSx,nSy)
       _RL  cg3dNorm, cg3dTolerance_sq
 
-C--   COMMON /CG3D_WK_R/  Work array common block
-C     cg3d_q :: Intermediate matrix-vector product term
-C     cg3d_r ::   idem
-C     cg3d_s ::   idem
-      COMMON /CG3D_WK_R/
-     & cg3d_q, cg3d_r, cg3d_s
+!--   COMMON /CG3D_WK_R/  Work array common block
+! cg3d_q :: Intermediate matrix-vector product term
+! cg3d_r ::   idem
+! cg3d_s ::   idem
+      COMMON /CG3D_WK_R/                                                          &
+     &      cg3d_q, cg3d_r, cg3d_s
       _RL  cg3d_q( 0:sNx+1, 0:sNy+1, Nr,nSx,nSy)
       _RL  cg3d_r( 0:sNx+1, 0:sNy+1, Nr,nSx,nSy)
       _RL  cg3d_s( 0:sNx+1, 0:sNy+1, Nr,nSx,nSy)

--- a/model/inc/CPP_OPTIONS.h
+++ b/model/inc/CPP_OPTIONS.h
@@ -1,163 +1,163 @@
 #ifndef CPP_OPTIONS_H
 #define CPP_OPTIONS_H
 
-CBOP
-C !ROUTINE: CPP_OPTIONS.h
-C !INTERFACE:
-C #include "CPP_OPTIONS.h"
+!BOP
+! !ROUTINE: CPP_OPTIONS.h
+! !INTERFACE:
+! #include "CPP_OPTIONS.h"
 
-C !DESCRIPTION:
-C *==================================================================*
-C | main CPP options file for the model:
-C | Control which optional features to compile in model/src code.
-C *==================================================================*
-CEOP
+! !DESCRIPTION:
+! *==================================================================*
+! | main CPP options file for the model:
+! | Control which optional features to compile in model/src code.
+! *==================================================================*
+!EOP
 
-C CPP flags controlling particular source code features
+! CPP flags controlling particular source code features
 
-C-- Forcing code options:
+!-- Forcing code options:
 
-C o Shortwave heating as extra term in APPLY_FORCING_T (apply_forcing.F)
+! o Shortwave heating as extra term in APPLY_FORCING_T (apply_forcing.F)
 #undef SHORTWAVE_HEATING
 
-C o Include/exclude Geothermal Heat Flux at the bottom of the ocean
+! o Include/exclude Geothermal Heat Flux at the bottom of the ocean
 #undef ALLOW_GEOTHERMAL_FLUX
 
-C o Allow to account for heating due to friction (and momentum dissipation)
+! o Allow to account for heating due to friction (and momentum dissipation)
 #undef ALLOW_FRICTION_HEATING
 
-C o Allow mass source or sink of Fluid in the interior
-C   (3-D generalisation of oceanic real-fresh water flux)
+! o Allow mass source or sink of Fluid in the interior
+!   (3-D generalisation of oceanic real-fresh water flux)
 #undef ALLOW_ADDFLUID
 
-C o Include pressure loading code
+! o Include pressure loading code
 #define ATMOSPHERIC_LOADING
 
-C o Include/exclude balancing surface forcing fluxes code
+! o Include/exclude balancing surface forcing fluxes code
 #undef ALLOW_BALANCE_FLUXES
 
-C o Include/exclude balancing surface forcing relaxation code
+! o Include/exclude balancing surface forcing relaxation code
 #undef ALLOW_BALANCE_RELAX
 
-C o Include/exclude checking for negative salinity
+! o Include/exclude checking for negative salinity
 #undef CHECK_SALINITY_FOR_NEGATIVE_VALUES
 
-C-- Options to discard parts of the main code:
+!-- Options to discard parts of the main code:
 
-C o Exclude/allow external forcing-fields load
-C   this allows to read & do simple linear time interpolation of oceanic
-C   forcing fields, if no specific pkg (e.g., EXF) is used to compute them.
+! o Exclude/allow external forcing-fields load
+!   this allows to read & do simple linear time interpolation of oceanic
+!   forcing fields, if no specific pkg (e.g., EXF) is used to compute them.
 #undef EXCLUDE_FFIELDS_LOAD
-C   If defined, use same method (with pkg/autodiff compiled or not) for checking
-C   when to load new reccord ; by default, use simpler method with pkg/autodiff.
+!   If defined, use same method (with pkg/autodiff compiled or not) for checking
+!   when to load new reccord ; by default, use simpler method with pkg/autodiff.
 #undef STORE_LOADEDREC_TEST
 
-C o Include/exclude phi_hyd calculation code
+! o Include/exclude phi_hyd calculation code
 #define INCLUDE_PHIHYD_CALCULATION_CODE
 
-C o Include/exclude sound speed calculation code
-C o (Note that this is a diagnostic from Del Grasso algorithm, not derived
-C    from EOS)
+! o Include/exclude sound speed calculation code
+! o (Note that this is a diagnostic from Del Grasso algorithm, not derived
+!    from EOS)
 #undef INCLUDE_SOUNDSPEED_CALC_CODE
 
-C-- Vertical mixing code options:
+!-- Vertical mixing code options:
 
-C o Include/exclude calling S/R CONVECTIVE_ADJUSTMENT
+! o Include/exclude calling S/R CONVECTIVE_ADJUSTMENT
 #define INCLUDE_CONVECT_CALL
 
-C o Include/exclude calling S/R CONVECTIVE_ADJUSTMENT_INI, turned off by
-C   default because it is an unpopular historical left-over
+! o Include/exclude calling S/R CONVECTIVE_ADJUSTMENT_INI, turned off by
+!   default because it is an unpopular historical left-over
 #undef INCLUDE_CONVECT_INI_CALL
 
-C o Include/exclude call to S/R CALC_DIFFUSIVITY
+! o Include/exclude call to S/R CALC_DIFFUSIVITY
 #define INCLUDE_CALC_DIFFUSIVITY_CALL
 
-C o Allow full 3D specification of vertical diffusivity
+! o Allow full 3D specification of vertical diffusivity
 #undef ALLOW_3D_DIFFKR
 
-C o Allow latitudinally varying BryanLewis79 vertical diffusivity
+! o Allow latitudinally varying BryanLewis79 vertical diffusivity
 #undef ALLOW_BL79_LAT_VARY
 
-C o Exclude/allow partial-cell effect (physical or enhanced) in vertical mixing
-C   this allows to account for partial-cell in vertical viscosity and diffusion,
-C   either from grid-spacing reduction effect or as artificially enhanced mixing
-C   near surface & bottom for too thin grid-cell
+! o Exclude/allow partial-cell effect (physical or enhanced) in vertical mixing
+!   this allows to account for partial-cell in vertical viscosity and diffusion,
+!   either from grid-spacing reduction effect or as artificially enhanced mixing
+!   near surface & bottom for too thin grid-cell
 #undef EXCLUDE_PCELL_MIX_CODE
 
-C o Exclude/allow to use isotropic 3-D Smagorinsky viscosity as diffusivity
-C   for tracers (after scaling by constant Prandtl number)
+! o Exclude/allow to use isotropic 3-D Smagorinsky viscosity as diffusivity
+!   for tracers (after scaling by constant Prandtl number)
 #undef ALLOW_SMAG_3D_DIFFUSIVITY
 
-C-- Time-stepping code options:
+!-- Time-stepping code options:
 
-C o Include/exclude combined Surf.Pressure and Drag Implicit solver code
+! o Include/exclude combined Surf.Pressure and Drag Implicit solver code
 #undef ALLOW_SOLVE4_PS_AND_DRAG
 
-C o Include/exclude Implicit vertical advection code
+! o Include/exclude Implicit vertical advection code
 #define INCLUDE_IMPLVERTADV_CODE
 
-C o Include/exclude AdamsBashforth-3rd-Order code
+! o Include/exclude AdamsBashforth-3rd-Order code
 #undef ALLOW_ADAMSBASHFORTH_3
 
-C o Include/exclude Quasi-Hydrostatic Stagger Time-step AdamsBashforth code
+! o Include/exclude Quasi-Hydrostatic Stagger Time-step AdamsBashforth code
 #undef ALLOW_QHYD_STAGGER_TS
 
-C-- Model formulation options:
+!-- Model formulation options:
 
-C o Allow the use of Non-Linear Free-Surface formulation
-C   this implies that grid-cell thickness (hFactors) varies with time
+! o Allow the use of Non-Linear Free-Surface formulation
+!   this implies that grid-cell thickness (hFactors) varies with time
 #undef NONLIN_FRSURF
-C o Disable code for rStar coordinate and/or code for Sigma coordinate
-c#define DISABLE_RSTAR_CODE
-c#define DISABLE_SIGMA_CODE
+! o Disable code for rStar coordinate and/or code for Sigma coordinate
+!#define DISABLE_RSTAR_CODE
+!#define DISABLE_SIGMA_CODE
 
-C o Include/exclude nonHydrostatic code
+! o Include/exclude nonHydrostatic code
 #undef ALLOW_NONHYDROSTATIC
 
-C o Include/exclude GM-like eddy stress in momentum code
+! o Include/exclude GM-like eddy stress in momentum code
 #undef ALLOW_EDDYPSI
 
-C-- Algorithm options:
+!-- Algorithm options:
 
-C o Include/exclude code for Non Self-Adjoint (NSA) conjugate-gradient solver
+! o Include/exclude code for Non Self-Adjoint (NSA) conjugate-gradient solver
 #undef ALLOW_CG2D_NSA
 
-C o Include/exclude code for single reduction Conjugate-Gradient solver
+! o Include/exclude code for single reduction Conjugate-Gradient solver
 #define ALLOW_SRCG
 
-C o Choices for implicit solver routines solve_*diagonal.F
-C   The following has low memory footprint, but not suitable for AD
+! o Choices for implicit solver routines solve_*diagonal.F
+!   The following has low memory footprint, but not suitable for AD
 #undef SOLVE_DIAGONAL_LOWMEMORY
-C   The following one suitable for AD but does not vectorize
+!   The following one suitable for AD but does not vectorize
 #undef SOLVE_DIAGONAL_KINNER
 
-C   Implementation alternative (might be faster on some platforms ?)
+!   Implementation alternative (might be faster on some platforms ?)
 #undef USE_MASK_AND_NO_IF
 
-C-- Retired code options:
+!-- Retired code options:
 
-C-  These 2 flags: ISOTROPIC_COS_SCALING & COSINEMETH_III have no effect
-C   here as they are reset in GAD_OPTIONS.h and in MOM_COMMON_OPTIONS.h
-C   for tracer diffusivity and momentum viscosity respectively
+!-  These 2 flags: ISOTROPIC_COS_SCALING & COSINEMETH_III have no effect
+!   here as they are reset in GAD_OPTIONS.h and in MOM_COMMON_OPTIONS.h
+!   for tracer diffusivity and momentum viscosity respectively
 
-C o Use "OLD" UV discretisation near boundaries (*not* recommended)
-C   Note - only works with pkg/mom_fluxform and "no_slip_sides=.FALSE."
-C          because the old code did not have no-slip BCs
+! o Use "OLD" UV discretisation near boundaries (*not* recommended)
+!   Note - only works with pkg/mom_fluxform and "no_slip_sides=.FALSE."
+     ! because the old code did not have no-slip BCs
 #undef OLD_ADV_BCS
 
-C o Use LONG.bin, LATG.bin, etc., initialization for ini_curviliear_grid.F
-C   Default is to use "new" grid files (OLD_GRID_IO undef) but OLD_GRID_IO
-C   is still useful with, e.g., single-domain curvilinear configurations.
+! o Use LONG.bin, LATG.bin, etc., initialization for ini_curviliear_grid.F
+!   Default is to use "new" grid files (OLD_GRID_IO undef) but OLD_GRID_IO
+!   is still useful with, e.g., single-domain curvilinear configurations.
 #undef OLD_GRID_IO
 
-C o Use old EXTERNAL_FORCING_U,V,T,S subroutines (for backward compatibility)
+! o Use old EXTERNAL_FORCING_U,V,T,S subroutines (for backward compatibility)
 #undef USE_OLD_EXTERNAL_FORCING
 
-C-- Other option files:
+!-- Other option files:
 
-C o Execution environment support options
+! o Execution environment support options
 #include "CPP_EEOPTIONS.h"
 
-C-  Place where multi-pkg header file ECCO_CPPOPTIONS.h used to be included
+!-  Place where multi-pkg header file ECCO_CPPOPTIONS.h used to be included
 
 #endif /* CPP_OPTIONS_H */

--- a/model/inc/DXC_MACROS.h
+++ b/model/inc/DXC_MACROS.h
@@ -1,18 +1,18 @@
-C
-CBOP
-C    !ROUTINE: DXC_MACROS.h
-C    !INTERFACE:
-C    include DXC_MACROS.h
-C    !DESCRIPTION: \bv
-C     *==========================================================*
-C     | DXC_MACROS.h                                              
-C     *==========================================================*
-C     | These macros are used to reduce memory requirement and/or 
-C     | memory references when variables are fixed along a given  
-C     | axis or axes.                                             
-C     *==========================================================*
-C     \ev
-CEOP
+!
+!BOP
+!    !ROUTINE: DXC_MACROS.h
+!    !INTERFACE:
+!    include DXC_MACROS.h
+!    !DESCRIPTION: \bv
+! *==========================================================*
+! | DXC_MACROS.h
+! *==========================================================*
+! | These macros are used to reduce memory requirement and/or
+! | memory references when variables are fixed along a given
+! | axis or axes.
+! *==========================================================*
+! \ev
+!EOP
 
 #ifdef DXC_CONST
 #define  _dxC(i,j,bi,bj) dxC(1,1,1,1)

--- a/model/inc/DXF_MACROS.h
+++ b/model/inc/DXF_MACROS.h
@@ -1,18 +1,18 @@
-C
-CBOP
-C    !ROUTINE: DXF_MACROS.h
-C    !INTERFACE:
-C    include DXF_MACROS.h
-C    !DESCRIPTION: \bv
-C     *==========================================================*
-C     | DXF_MACROS.h                                              
-C     *==========================================================*
-C     | These macros are used to reduce memory requirement and/or 
-C     | memory references when variables are fixed along a given  
-C     | axis or axes.                                             
-C     *==========================================================*
-C     \ev
-CEOP
+!
+!BOP
+!    !ROUTINE: DXF_MACROS.h
+!    !INTERFACE:
+!    include DXF_MACROS.h
+!    !DESCRIPTION: \bv
+! *==========================================================*
+! | DXF_MACROS.h
+! *==========================================================*
+! | These macros are used to reduce memory requirement and/or
+! | memory references when variables are fixed along a given
+! | axis or axes.
+! *==========================================================*
+! \ev
+!EOP
 
 #ifdef DXF_CONST
 #define  _dxF(i,j,bi,bj) dxF(1,1,1,1)

--- a/model/inc/DXG_MACROS.h
+++ b/model/inc/DXG_MACROS.h
@@ -1,18 +1,18 @@
-C
-CBOP
-C    !ROUTINE: DXG_MACROS.h
-C    !INTERFACE:
-C    include DXG_MACROS.h
-C    !DESCRIPTION: \bv
-C     *==========================================================*
-C     | DXG_MACROS.h                                              
-C     *==========================================================*
-C     | These macros are used to reduce memory requirement and/or 
-C     | memory references when variables are fixed along a given  
-C     | axis or axes.                                             
-C     *==========================================================*
-C     \ev
-CEOP
+!
+!BOP
+!    !ROUTINE: DXG_MACROS.h
+!    !INTERFACE:
+!    include DXG_MACROS.h
+!    !DESCRIPTION: \bv
+! *==========================================================*
+! | DXG_MACROS.h
+! *==========================================================*
+! | These macros are used to reduce memory requirement and/or
+! | memory references when variables are fixed along a given
+! | axis or axes.
+! *==========================================================*
+! \ev
+!EOP
 
 #ifdef DXG_CONST
 #define  _dxG(i,j,bi,bj) dxG(1,1,1,1)

--- a/model/inc/DXV_MACROS.h
+++ b/model/inc/DXV_MACROS.h
@@ -1,18 +1,18 @@
-C
-CBOP
-C    !ROUTINE: DXV_MACROS.h
-C    !INTERFACE:
-C    include DXV_MACROS.h
-C    !DESCRIPTION: \bv
-C     *==========================================================*
-C     | DXV_MACROS.h                                              
-C     *==========================================================*
-C     | These macros are used to reduce memory requirement and/or 
-C     | memory references when variables are fixed along a given  
-C     | axis or axes.                                             
-C     *==========================================================*
-C     \ev
-CEOP
+!
+!BOP
+!    !ROUTINE: DXV_MACROS.h
+!    !INTERFACE:
+!    include DXV_MACROS.h
+!    !DESCRIPTION: \bv
+! *==========================================================*
+! | DXV_MACROS.h
+! *==========================================================*
+! | These macros are used to reduce memory requirement and/or
+! | memory references when variables are fixed along a given
+! | axis or axes.
+! *==========================================================*
+! \ev
+!EOP
 
 #ifdef DXV_CONST
 #define  _dxV(i,j,bi,bj) dxV(1,1,1,1)

--- a/model/inc/DYC_MACROS.h
+++ b/model/inc/DYC_MACROS.h
@@ -1,18 +1,18 @@
-C
-CBOP
-C    !ROUTINE: DYC_MACROS.h
-C    !INTERFACE:
-C    include DYC_MACROS.h
-C    !DESCRIPTION: \bv
-C     *==========================================================*
-C     | DYC_MACROS.h                                              
-C     *==========================================================*
-C     | These macros are used to reduce memory requirement and/or 
-C     | memory references when variables are fixed along a given  
-C     | axis or axes.                                             
-C     *==========================================================*
-C     \ev
-CEOP
+!
+!BOP
+!    !ROUTINE: DYC_MACROS.h
+!    !INTERFACE:
+!    include DYC_MACROS.h
+!    !DESCRIPTION: \bv
+! *==========================================================*
+! | DYC_MACROS.h
+! *==========================================================*
+! | These macros are used to reduce memory requirement and/or
+! | memory references when variables are fixed along a given
+! | axis or axes.
+! *==========================================================*
+! \ev
+!EOP
 
 #ifdef DYC_CONST
 #define  _dyC(i,j,bi,bj) dyC(1,1,1,1)

--- a/model/inc/DYF_MACROS.h
+++ b/model/inc/DYF_MACROS.h
@@ -1,18 +1,18 @@
-C
-CBOP
-C    !ROUTINE: DYF_MACROS.h
-C    !INTERFACE:
-C    include DYF_MACROS.h
-C    !DESCRIPTION: \bv
-C     *==========================================================*
-C     | DYF_MACROS.h                                              
-C     *==========================================================*
-C     | These macros are used to reduce memory requirement and/or 
-C     | memory references when variables are fixed along a given  
-C     | axis or axes.                                             
-C     *==========================================================*
-C     \ev
-CEOP
+!
+!BOP
+!    !ROUTINE: DYF_MACROS.h
+!    !INTERFACE:
+!    include DYF_MACROS.h
+!    !DESCRIPTION: \bv
+! *==========================================================*
+! | DYF_MACROS.h
+! *==========================================================*
+! | These macros are used to reduce memory requirement and/or
+! | memory references when variables are fixed along a given
+! | axis or axes.
+! *==========================================================*
+! \ev
+!EOP
 
 #ifdef DYF_CONST
 #define  _dyF(i,j,bi,bj) dyF(1,1,1,1)

--- a/model/inc/DYG_MACROS.h
+++ b/model/inc/DYG_MACROS.h
@@ -1,18 +1,18 @@
-C
-CBOP
-C    !ROUTINE: DYG_MACROS.h
-C    !INTERFACE:
-C    include DYG_MACROS.h
-C    !DESCRIPTION: \bv
-C     *==========================================================*
-C     | DYG_MACROS.h                                              
-C     *==========================================================*
-C     | These macros are used to reduce memory requirement and/or 
-C     | memory references when variables are fixed along a given  
-C     | axis or axes.                                             
-C     *==========================================================*
-C     \ev
-CEOP
+!
+!BOP
+!    !ROUTINE: DYG_MACROS.h
+!    !INTERFACE:
+!    include DYG_MACROS.h
+!    !DESCRIPTION: \bv
+! *==========================================================*
+! | DYG_MACROS.h
+! *==========================================================*
+! | These macros are used to reduce memory requirement and/or
+! | memory references when variables are fixed along a given
+! | axis or axes.
+! *==========================================================*
+! \ev
+!EOP
 
 #ifdef DYG_CONST
 #define  _dyG(i,j,bi,bj) dyG(1,1,1,1)

--- a/model/inc/DYNVARS.h
+++ b/model/inc/DYNVARS.h
@@ -1,49 +1,49 @@
-CBOP
-C     !ROUTINE: DYNVARS.h
-C     !INTERFACE:
-C     include "DYNVARS.h"
-C     !DESCRIPTION:
-C     \bv
-C     *==========================================================*
-C     | DYNVARS.h
-C     | o Dynamical model variables (common block DYNVARS_R)
-C     *==========================================================*
-C     | The value and two levels of time tendency are held for
-C     | each prognostic variable.
-C     *==========================================================*
-C     \ev
-CEOP
+!BOP
+! !ROUTINE: DYNVARS.h
+! !INTERFACE:
+! include "DYNVARS.h"
+! !DESCRIPTION:
+! \bv
+! *==========================================================*
+! | DYNVARS.h
+! | o Dynamical model variables (common block DYNVARS_R)
+! *==========================================================*
+! | The value and two levels of time tendency are held for
+! | each prognostic variable.
+! *==========================================================*
+! \ev
+!EOP
 
-C     State Variables:
-C     etaN  :: free-surface r-anomaly (r unit) at current time level
-C     uVel  :: zonal velocity (m/s, i=1 held at western face)
-C     vVel  :: meridional velocity (m/s, j=1 held at southern face)
-C     theta :: potential temperature (oC, held at pressure/tracer point)
-C     salt  :: salinity (g/kg, held at pressure/tracer point; note that
-C              salinity is either a conductivity ratio or, if using TEOS10,
-C              a mass ratio;here we assume it is a mass ratio even though
-C              it is only correct for TEOS10)
-C     gX, gxNm1 :: Time tendencies at current and previous time levels.
-C     etaH  :: surface r-anomaly, advanced in time consistently
-C              with 2.D flow divergence (Exact-Conservation):
-C                etaH^n+1 = etaH^n - delta_t*Div.(H^n U^n+1)
-C  note: a) used with "exactConserv", necessary for Non-Lin free-surf and mixed
-C           forward/backward free-surf time stepping (e.g., Crank-Nickelson)
-C        b) same as etaN but not necessarily at the same time, e.g.:
-C           implicDiv2DFlow=1 => etaH=etaN ; =0 => etaH=etaN^(n-1);
+! State Variables:
+! etaN  :: free-surface r-anomaly (r unit) at current time level
+! uVel  :: zonal velocity (m/s, i=1 held at western face)
+! vVel  :: meridional velocity (m/s, j=1 held at southern face)
+! theta :: potential temperature (oC, held at pressure/tracer point)
+! salt  :: salinity (g/kg, held at pressure/tracer point; note that
+!          salinity is either a conductivity ratio or, if using TEOS10,
+!          a mass ratio;here we assume it is a mass ratio even though
+!          it is only correct for TEOS10)
+! gX, gxNm1 :: Time tendencies at current and previous time levels.
+! etaH  :: surface r-anomaly, advanced in time consistently
+!          with 2.D flow divergence (Exact-Conservation):
+!            etaH^n+1 = etaH^n - delta_t*Div.(H^n U^n+1)
+!  note: a) used with "exactConserv", necessary for Non-Lin free-surf and mixed
+!       forward/backward free-surf time stepping (e.g., Crank-Nickelson)
+!    b) same as etaN but not necessarily at the same time, e.g.:
+!       implicDiv2DFlow=1 => etaH=etaN ; =0 => etaH=etaN^(n-1);
 
 #ifdef ALLOW_ADAMSBASHFORTH_3
-      COMMON /DYNVARS_R/
-     &                   etaN,
-     &                   uVel,vVel,wVel,theta,salt,
-     &                   gU,   gV,
-     &                   guNm, gvNm, gtNm, gsNm
+      COMMON /DYNVARS_R/                                                          &
+     &      etaN,                                                                 &
+     &      uVel,vVel,wVel,theta,salt,                                            &
+     &      gU,   gV,                                                             &
+     &      guNm, gvNm, gtNm, gsNm
 #else /* ALLOW_ADAMSBASHFORTH_3 */
-      COMMON /DYNVARS_R/
-     &                   etaN,
-     &                   uVel,vVel,wVel,theta,salt,
-     &                   gU,   gV,
-     &                   guNm1,gvNm1,gtNm1,gsNm1
+      COMMON /DYNVARS_R/                                                          &
+     &      etaN,                                                                 &
+     &      uVel,vVel,wVel,theta,salt,                                            &
+     &      gU,   gV,                                                             &
+     &      guNm1,gvNm1,gtNm1,gsNm1
 #endif /* ALLOW_ADAMSBASHFORTH_3 */
       _RL  etaN  (1-OLx:sNx+OLx,1-OLy:sNy+OLy,nSx,nSy)
       _RL  uVel (1-OLx:sNx+OLx,1-OLy:sNy+OLy,Nr,nSx,nSy)
@@ -66,58 +66,58 @@ C           implicDiv2DFlow=1 => etaH=etaN ; =0 => etaH=etaN^(n-1);
 #endif /* ALLOW_ADAMSBASHFORTH_3 */
 
 #ifdef USE_OLD_EXTERNAL_FORCING
-      COMMON /DYNVARS_OLD/
-     &                   gT,   gS
+      COMMON /DYNVARS_OLD/                                                        &
+     &      gT,   gS
       _RL  gT(1-OLx:sNx+OLx,1-OLy:sNy+OLy,Nr,nSx,nSy)
       _RL  gS(1-OLx:sNx+OLx,1-OLy:sNy+OLy,Nr,nSx,nSy)
 #endif
 
-      COMMON /DYNVARS_R_2/
-     &                   etaH
+      COMMON /DYNVARS_R_2/                                                        &
+     &      etaH
       _RL  etaH  (1-OLx:sNx+OLx,1-OLy:sNy+OLy,nSx,nSy)
 
 #if (defined (ALLOW_3D_DIFFKR) || defined (ALLOW_DIFFKR_CONTROL))
-C     diffKr :: full 3D specification of Laplacian diffusion coeff.
-C               for mixing of tracers vertically ( units of r^2/s )
-      COMMON /DYNVARS_DIFFKR/
-     &                       diffKr
+! diffKr :: full 3D specification of Laplacian diffusion coeff.
+!           for mixing of tracers vertically ( units of r^2/s )
+      COMMON /DYNVARS_DIFFKR/                                                     &
+     &      diffKr
       _RL  diffKr (1-OLx:sNx+OLx,1-OLy:sNy+OLy,Nr,nSx,nSy)
 #endif
 
 #ifdef ALLOW_SMAG_3D_DIFFUSIVITY
-C     smag3D_diffK :: isotropic 3D diffusivity from Smagorisky viscosity
-C                     at grid-cell center (units: m^2/s )
+! smag3D_diffK :: isotropic 3D diffusivity from Smagorisky viscosity
+!                 at grid-cell center (units: m^2/s )
       COMMON /DYNVARS_DIFFK_SMAG3D/ smag3D_diffK
       _RL smag3D_diffK(1-OLx:sNx+OLx,1-OLy:sNy+OLy,Nr,nSx,nSy)
 #endif
 
-C   The following blocks containing requires anomaly fields of control vars
-C   and related to Options:
-C   ALLOW_KAPGM_CONTROL , ALLOW_KAPREDI_CONTROL and ALLOW_BOTTOMDRAG_CONTROL
-C   have been moved to header file "CTRL_FIELDS.h"
+!   The following blocks containing requires anomaly fields of control vars
+!   and related to Options:
+!   ALLOW_KAPGM_CONTROL , ALLOW_KAPREDI_CONTROL and ALLOW_BOTTOMDRAG_CONTROL
+!   have been moved to header file "CTRL_FIELDS.h"
 
 #ifdef ALLOW_BL79_LAT_VARY
-C     BL79LatArray :: is used for latitudinal dependence of
-C                     BryanLewis79 vertical diffusivity
+! BL79LatArray :: is used for latitudinal dependence of
+!                 BryanLewis79 vertical diffusivity
       COMMON /DYNVARS_BL79LatArray/ BL79LatArray
       _RL BL79LatArray (1-OLx:sNx+OLx,1-OLy:sNy+OLy,nSx,nSy)
 #endif
 
-C     Diagnostic Variables:
-C     rhoInSitu    :: In-Situ density anomaly [kg/m^3] at cell center level.
-C     totPhiHyd    :: total hydrostatic Potential (anomaly, for now),
-C                     at cell center level ; includes surface contribution.
-C                     (for diagnostic + used in Z-coord with EOS_funct_P)
-C     phiHydLow    :: Phi-Hydrostatic at r-lower boundary
-C                     (bottom in z-coordinates, top in p-coordinates)
-C     hMixLayer    :: Mixed layer depth [m]
-C                     (for diagnostic + used GMRedi "fm07")
-C     IVDConvCount :: Impl.Vert.Diffusion convection counter:
-C                     = 0 (not convecting) or 1 (convecting)
-      COMMON /DYNVARS_DIAG/
-     &                rhoInSitu,
-     &                totPhiHyd, phiHydLow,
-     &                hMixLayer, IVDConvCount
+! Diagnostic Variables:
+! rhoInSitu    :: In-Situ density anomaly [kg/m^3] at cell center level.
+! totPhiHyd    :: total hydrostatic Potential (anomaly, for now),
+!                 at cell center level ; includes surface contribution.
+!                 (for diagnostic + used in Z-coord with EOS_funct_P)
+! phiHydLow    :: Phi-Hydrostatic at r-lower boundary
+!                 (bottom in z-coordinates, top in p-coordinates)
+! hMixLayer    :: Mixed layer depth [m]
+!                 (for diagnostic + used GMRedi "fm07")
+! IVDConvCount :: Impl.Vert.Diffusion convection counter:
+!                 = 0 (not convecting) or 1 (convecting)
+      COMMON /DYNVARS_DIAG/                                                       &
+     &      rhoInSitu,                                                            &
+     &      totPhiHyd, phiHydLow,                                                 &
+     &      hMixLayer, IVDConvCount
       _RL  rhoInSitu(1-OLx:sNx+OLx,1-OLy:sNy+OLy,Nr,nSx,nSy)
       _RL  totPhiHyd(1-OLx:sNx+OLx,1-OLy:sNy+OLy,Nr,nSx,nSy)
       _RL  phiHydLow(1-OLx:sNx+OLx,1-OLy:sNy+OLy,nSx,nSy)
@@ -125,30 +125,30 @@ C                     = 0 (not convecting) or 1 (convecting)
       _RL  IVDConvCount(1-OLx:sNx+OLx,1-OLy:sNy+OLy,Nr,nSx,nSy)
 
 #ifdef ALLOW_LEITH_QG
-C     Leith QG dynamic viscosity scheme requires buoyancy frequency.
-C     Store sigmaRfield to avoid computing density multiple times and give
-C     access to all levels during the k-loop
-C     sigmaRfield           :: vertical gradient of buoyancy.
+! Leith QG dynamic viscosity scheme requires buoyancy frequency.
+! Store sigmaRfield to avoid computing density multiple times and give
+! access to all levels during the k-loop
+! sigmaRfield           :: vertical gradient of buoyancy.
       COMMON /DYNVARS_sigmaR/ sigmaRfield
       _RL sigmaRfield  (1-OLx:sNx+OLx,1-OLy:sNy+OLy,Nr,nSx,nSy)
 #endif /* ALLOW_LEITH_QG */
 
 #ifdef ALLOW_SOLVE4_PS_AND_DRAG
-C     Variables for Implicit friction (& vert. visc) in 2-D pressure solver
-C     dU_psFacX    :: zonal velocity increment factor from (implicit) surf.
-C                     pressure gradient in X (no Units)
-C     dV_psFacY    :: merid velocity increment factor from (implicit) surf.
-C                     pressure gradient in Y (no Units)
+! Variables for Implicit friction (& vert. visc) in 2-D pressure solver
+! dU_psFacX    :: zonal velocity increment factor from (implicit) surf.
+!                 pressure gradient in X (no Units)
+! dV_psFacY    :: merid velocity increment factor from (implicit) surf.
+!                 pressure gradient in Y (no Units)
 
-      COMMON /DYNVARS_DRAG_IN_PS/
-     &                dU_psFacX, dV_psFacY
+      COMMON /DYNVARS_DRAG_IN_PS/                                                 &
+     &      dU_psFacX, dV_psFacY
       _RL  dU_psFacX(1-OLx:sNx+OLx,1-OLy:sNy+OLy,Nr,nSx,nSy)
       _RL  dV_psFacY(1-OLx:sNx+OLx,1-OLy:sNy+OLy,Nr,nSx,nSy)
 #endif /* ALLOW_SOLVE4_PS_AND_DRAG */
 
 #ifdef INCLUDE_SOUNDSPEED_CALC_CODE
-C     cSound       :: Speed of sound in seawater (m/s)
-C                     following Del Grosso (1974)
+! cSound       :: Speed of sound in seawater (m/s)
+!                 following Del Grosso (1974)
       COMMON /DYNVARS_cSound/ cSound
       _RL  cSound(1-OLx:sNx+OLx,1-OLy:sNy+OLy,Nr,nSx,nSy)
 #endif /* INCLUDE_SOUNDSPEED_CALC_CODE */

--- a/model/inc/DYU_MACROS.h
+++ b/model/inc/DYU_MACROS.h
@@ -1,18 +1,18 @@
-C
-CBOP
-C    !ROUTINE: DYU_MACROS.h
-C    !INTERFACE:
-C    include DYU_MACROS.h
-C    !DESCRIPTION: \bv
-C     *==========================================================*
-C     | DYU_MACROS.h                                              
-C     *==========================================================*
-C     | These macros are used to reduce memory requirement and/or 
-C     | memory references when variables are fixed along a given  
-C     | axis or axes.                                             
-C     *==========================================================*
-C     \ev
-CEOP
+!
+!BOP
+!    !ROUTINE: DYU_MACROS.h
+!    !INTERFACE:
+!    include DYU_MACROS.h
+!    !DESCRIPTION: \bv
+! *==========================================================*
+! | DYU_MACROS.h
+! *==========================================================*
+! | These macros are used to reduce memory requirement and/or
+! | memory references when variables are fixed along a given
+! | axis or axes.
+! *==========================================================*
+! \ev
+!EOP
 
 #ifdef DYU_CONST
 #define  _dyU(i,j,bi,bj) dyU(1,1,1,1)

--- a/model/inc/EOS.h
+++ b/model/inc/EOS.h
@@ -1,180 +1,180 @@
-CBOP
-C    !ROUTINE: EOS.h
-C    !INTERFACE:
-C    include EOS.h
-C    !DESCRIPTION: \bv
-C     *==========================================================*
-C     | EOS.h
-C     | o Header file defining coefficients for equation of state.
-C     *==========================================================*
-C     | The values from the model standard input file are
-C     | stored into the variables held here.
-C     *==========================================================*
-C     \ev
-CEOP
+!BOP
+!    !ROUTINE: EOS.h
+!    !INTERFACE:
+!    include EOS.h
+!    !DESCRIPTION: \bv
+! *==========================================================*
+! | EOS.h
+! | o Header file defining coefficients for equation of state.
+! *==========================================================*
+! | The values from the model standard input file are
+! | stored into the variables held here.
+! *==========================================================*
+! \ev
+!EOP
 
-C     SItoBar  :: conversion factor for pressure, from Pa (SI Unit) to Bar
-C     SItodBar :: conversion factor for pressure, from Pa (SI Unit) to deci Bar
+! SItoBar  :: conversion factor for pressure, from Pa (SI Unit) to Bar
+! SItodBar :: conversion factor for pressure, from Pa (SI Unit) to deci Bar
       _RL SItoBar, SItodBar
       PARAMETER ( SItoBar  = 1.D-05 )
       PARAMETER ( SItodBar = 1.D-04 )
 
-C Shared EOS Parameter
-C     eosRefP0  :: reference atmospheric pressure used in EOS formulation
+! Shared EOS Parameter
+! eosRefP0  :: reference atmospheric pressure used in EOS formulation
       COMMON /PARM_EOS_SHARED/ eosRefP0, equationOfState
       _RL eosRefP0
-      CHARACTER*(6) equationOfState
+      CHARACTER(len=6) :: equationOfState
 
-C Linear equation of state
-C     tAlpha    :: Linear EOS thermal expansion coefficient ( 1/degree ).
-C     sBeta     :: Linear EOS haline contraction coefficient.
+! Linear equation of state
+! tAlpha    :: Linear EOS thermal expansion coefficient ( 1/degree ).
+! sBeta     :: Linear EOS haline contraction coefficient.
       COMMON /PARM_EOS_LIN/ tAlpha, sBeta
       _RL tAlpha
       _RL sBeta
 
-C Equation of State (polynomial coeffients)
+! Equation of State (polynomial coeffients)
       COMMON /PARM_EOS_POLY3/ eosC,eosSig0,eosRefT,eosRefS
       _RL eosC(9,Nr+1),eosSig0(Nr+1),eosRefT(Nr+1),eosRefS(Nr+1)
 
-C Full Equation of State
-C     eosType = 'JMD95' (Jackett and McDougall 1995, JAOT)
-C     eosType = 'UNESCO' (Millero et al. 1980, DSR)
-C     COMMON /PARM_EOS_JMD95/
-C     eosJMDCFw  :: of fresh water at pressure 0
-C     eosJMDCSw  :: of sea water at pressure 0
-C     eosJMDCKFw :: of secant bulk modulus K of fresh water at pressure 0
-C     eosJMDCKSw :: of secant bulk modulus K of sea water at pressure 0
-C     eosJMDCKP  :: of secant bulk modulus K at pressure p
-C     eosType = 'MDJWF' (McDougall et al. 2003, JAOT)
-C     COMMON /PARM_EOS_MDJWF/
-C     eosMDJWFnum :: coefficients of numerator
-C     eosMDJWFden :: coefficients of denominator
-C     eosType = 'TEOS10' (McDougall et al. 2011, http://www.teos-10.org)
-C     Note: this eos implies that variables THETA and SALT are interpreted
-C     as conservative temperature and absolute salinity
-C     COMMON /PARM_TEOS10/
-C     teos        :: 48 coeffiencts of numerator and denominator
-C     end nonlinear equation of state
+! Full Equation of State
+! eosType = 'JMD95' (Jackett and McDougall 1995, JAOT)
+! eosType = 'UNESCO' (Millero et al. 1980, DSR)
+! COMMON /PARM_EOS_JMD95/
+! eosJMDCFw  :: of fresh water at pressure 0
+! eosJMDCSw  :: of sea water at pressure 0
+! eosJMDCKFw :: of secant bulk modulus K of fresh water at pressure 0
+! eosJMDCKSw :: of secant bulk modulus K of sea water at pressure 0
+! eosJMDCKP  :: of secant bulk modulus K at pressure p
+! eosType = 'MDJWF' (McDougall et al. 2003, JAOT)
+! COMMON /PARM_EOS_MDJWF/
+! eosMDJWFnum :: coefficients of numerator
+! eosMDJWFden :: coefficients of denominator
+! eosType = 'TEOS10' (McDougall et al. 2011, http://www.teos-10.org)
+! Note: this eos implies that variables THETA and SALT are interpreted
+! as conservative temperature and absolute salinity
+! COMMON /PARM_TEOS10/
+! teos        :: 48 coeffiencts of numerator and denominator
+! end nonlinear equation of state
       _RL eosJMDCFw(6), eosJMDCSw(9)
       _RL eosJMDCKFw(5), eosJMDCKSw(7), eosJMDCKP(14)
-      COMMON /PARM_EOS_JMD95/
-     &     eosJMDCFw, eosJMDCSw, eosJMDCKFw, eosJMDCKSw, eosJMDCKP
+      COMMON /PARM_EOS_JMD95/                                                     &
+     &      eosJMDCFw, eosJMDCSw, eosJMDCKFw, eosJMDCKSw, eosJMDCKP
       _RL eosMDJWFnum(0:11), eosMDJWFden(0:12)
-      COMMON /PARM_EOS_MDJWF/
-     &     eosMDJWFnum, eosMDJWFden
+      COMMON /PARM_EOS_MDJWF/                                                     &
+     &      eosMDJWFnum, eosMDJWFden
 
-C     TEOS10 coefficients
+! TEOS10 coefficients
       _RL teos(48)
 
-C     Parameters in the temperature conversion code for TEOS10
-C     The TEOS 10 conversion factor to go from reference salinity to
-C     practical salinity (nondim)
+! Parameters in the temperature conversion code for TEOS10
+! The TEOS 10 conversion factor to go from reference salinity to
+! practical salinity (nondim)
       _RL Sprac_Sref
-C     The inverse of a plausible range of oceanic salinities (kg g-1)
+! The inverse of a plausible range of oceanic salinities (kg g-1)
       _RL I_S0
-C     The inverse of a plausible range of oceanic temperatures (degC-1)
+! The inverse of a plausible range of oceanic temperatures (degC-1)
       _RL I_Ts
-C     The inverse of the "specific heat" for use
-C     with Conservative Temperature, as defined with TEOS10 (degC kg J-1)
+! The inverse of the "specific heat" for use
+! with Conservative Temperature, as defined with TEOS10 (degC kg J-1)
       _RL I_cp0
 
-C     The following are coefficients of contributions to conservative
-C     temperature as a function of the square root of normalized
-C     absolute salinity with an offset (zS) and potential temperature
-C     (T) with a contribution Hab * zS**a * T**b.  The numbers here are
-C     copied directly from the corresponding gsw module, but the
-C     expressions here do not use the same nondimensionalization for
-C     pressure or temperature as they do.
+! The following are coefficients of contributions to conservative
+! temperature as a function of the square root of normalized
+! absolute salinity with an offset (zS) and potential temperature
+! (T) with a contribution Hab * zS**a * T**b.  The numbers here are
+! copied directly from the corresponding gsw module, but the
+! expressions here do not use the same nondimensionalization for
+! pressure or temperature as they do.
 
-C     Tp to Tc fit constant (degC)
+! Tp to Tc fit constant (degC)
       _RL H00
-C     Tp to Tc fit T coef. (nondim)
+! Tp to Tc fit T coef. (nondim)
       _RL H01
-C     Tp to Tc fit T**2 coef. (degC-1)
+! Tp to Tc fit T**2 coef. (degC-1)
       _RL H02
-C     Tp to Tc fit T**3 coef. (degC-2)
+! Tp to Tc fit T**3 coef. (degC-2)
       _RL H03
-C     Tp to Tc fit T**4 coef. (degC-3)
+! Tp to Tc fit T**4 coef. (degC-3)
       _RL H04
-C     Tp to Tc fit T**5 coef. (degC-4)
+! Tp to Tc fit T**5 coef. (degC-4)
       _RL H05
-C     Tp to Tc fit T**6 coef. (degC-5)
+! Tp to Tc fit T**6 coef. (degC-5)
       _RL H06
-C     Tp to Tc fit T**7 coef. (degC-6)
+! Tp to Tc fit T**7 coef. (degC-6)
       _RL H07
-C     Tp to Tc fit zS**2 coef. (degC)
+! Tp to Tc fit zS**2 coef. (degC)
       _RL H20
-C     Tp to Tc fit zS**2 * T coef. (nondim)
+! Tp to Tc fit zS**2 * T coef. (nondim)
       _RL H21
-C     Tp to Tc fit zS**2 * T**2 coef. (degC-1)
+! Tp to Tc fit zS**2 * T**2 coef. (degC-1)
       _RL H22
-C     Tp to Tc fit zS**2 * T**3 coef. (degC-2)
+! Tp to Tc fit zS**2 * T**3 coef. (degC-2)
       _RL H23
-C     Tp to Tc fit zS**2 * T**4 coef. (degC-3)
+! Tp to Tc fit zS**2 * T**4 coef. (degC-3)
       _RL H24
-C     Tp to Tc fit zS**2 * T**5 coef. (degC-4)
+! Tp to Tc fit zS**2 * T**5 coef. (degC-4)
       _RL H25
-C     Tp to Tc fit zS**2 * T**6 coef. (degC-5)
+! Tp to Tc fit zS**2 * T**6 coef. (degC-5)
       _RL H26
-C     Tp to Tc fit zS**3 coef. (degC)
+! Tp to Tc fit zS**3 coef. (degC)
       _RL H30
-C     Tp to Tc fit zS** 3* T coef. (nondim)
+! Tp to Tc fit zS** 3* T coef. (nondim)
       _RL H31
-C     Tp to Tc fit zS**3 * T**2 coef. (degC-1)
+! Tp to Tc fit zS**3 * T**2 coef. (degC-1)
       _RL H32
-C     Tp to Tc fit zS**3 * T**3 coef. (degC-2)
+! Tp to Tc fit zS**3 * T**3 coef. (degC-2)
       _RL H33
-C     Tp to Tc fit zS**3 * T**4 coef. (degC-3)
+! Tp to Tc fit zS**3 * T**4 coef. (degC-3)
       _RL H34
-C     Tp to Tc fit zS**4 coef. (degC)
+! Tp to Tc fit zS**4 coef. (degC)
       _RL H40
-C     Tp to Tc fit zS**4 * T coef. (nondim)
+! Tp to Tc fit zS**4 * T coef. (nondim)
       _RL H41
-C     Tp to Tc fit zS**4 * T**2 coef. (degC-1)
+! Tp to Tc fit zS**4 * T**2 coef. (degC-1)
       _RL H42
-C     Tp to Tc fit zS**4 * T**3 coef. (degC-2)
+! Tp to Tc fit zS**4 * T**3 coef. (degC-2)
       _RL H43
-C     Tp to Tc fit zS**4 * T**4 coef. (degC-3)
+! Tp to Tc fit zS**4 * T**4 coef. (degC-3)
       _RL H44
-C     Tp to Tc fit zS**4 * T**5 coef. (degC-4)
+! Tp to Tc fit zS**4 * T**5 coef. (degC-4)
       _RL H45
-C     Tp to Tc fit zS**5 coef. (degC)
+! Tp to Tc fit zS**5 coef. (degC)
       _RL H50
-C     Tp to Tc fit zS**6 coef. (degC)
+! Tp to Tc fit zS**6 coef. (degC)
       _RL H60
-C     Tp to Tc fit zS**7 coef. (degC)
+! Tp to Tc fit zS**7 coef. (degC)
       _RL H70
 
-C     The following are coefficients in the nominator (TPNxx) or
-C     denominator (TPDxx) of a simple rational expression that
-C     approximately converts conservative temperature to potential
-C     temperature.
-C     Simple fit numerator constant (degC)
+! The following are coefficients in the nominator (TPNxx) or
+! denominator (TPDxx) of a simple rational expression that
+! approximately converts conservative temperature to potential
+! temperature.
+! Simple fit numerator constant (degC)
       _RL TPN00
-C     Simple fit numerator Sa coef. (degC ppt-1)
+! Simple fit numerator Sa coef. (degC ppt-1)
       _RL TPN10
-C     Simple fit numerator Sa**2 coef. (degC ppt-2)
+! Simple fit numerator Sa**2 coef. (degC ppt-2)
       _RL TPN20
-C     Simple fit numerator Tc coef. (nondim)
+! Simple fit numerator Tc coef. (nondim)
       _RL TPN01
-C     Simple fit numerator Sa * Tc coef. (ppt-1)
+! Simple fit numerator Sa * Tc coef. (ppt-1)
       _RL TPN11
-C     Simple fit numerator Tc**2 coef. (degC-1)
+! Simple fit numerator Tc**2 coef. (degC-1)
       _RL TPN02
-C     Simple fit denominator Sa coef. (ppt-1)
+! Simple fit denominator Sa coef. (ppt-1)
       _RL TPD10
-C     Simple fit denominator Tc coef. (degC-1)
+! Simple fit denominator Tc coef. (degC-1)
       _RL TPD01
-C     Simple fit denominator Tc**2 coef. (degC-2)
+! Simple fit denominator Tc**2 coef. (degC-2)
       _RL TPD02
 
-      COMMON /PARM_TEOS10/
-     &     teos,
-     &     Sprac_Sref, I_S0, I_Ts, I_cp0,
-     &     H00, H01, H02, H03, H04, H05, H06, H07,
-     &     H20, H21, H22, H23, H24, H25, H26,
-     &     H30, H31, H32, H33, H34,
-     &     H40, H41, H42, H43, H44, H45,
-     &     H50, H60, H70,
-     &     TPN00, TPN10, TPN20,
-     &     TPN01, TPN11, TPN02, TPD10, TPD01, TPD02
+      COMMON /PARM_TEOS10/                                                        &
+     &      teos,                                                                 &
+     &      Sprac_Sref, I_S0, I_Ts, I_cp0,                                        &
+     &      H00, H01, H02, H03, H04, H05, H06, H07,                               &
+     &      H20, H21, H22, H23, H24, H25, H26,                                    &
+     &      H30, H31, H32, H33, H34,                                              &
+     &      H40, H41, H42, H43, H44, H45,                                         &
+     &      H50, H60, H70,                                                        &
+     &      TPN00, TPN10, TPN20,                                                  &
+     &      TPN01, TPN11, TPN02, TPD10, TPD01, TPD02

--- a/model/inc/FCORI_MACROS.h
+++ b/model/inc/FCORI_MACROS.h
@@ -1,18 +1,18 @@
-C
-CBOP
-C    !ROUTINE: FCORI_MACROS.h
-C    !INTERFACE:
-C    include FCORI_MACROS.h
-C    !DESCRIPTION: \bv
-C     *==========================================================*
-C     | FCORI_MACROS.h                                            
-C     *==========================================================*
-C     | These macros are used to reduce memory requirement and/or 
-C     | memory references when variables are fixed along a given  
-C     | axis or axes.                                             
-C     *==========================================================*
-C     \ev
-CEOP
+!
+!BOP
+!    !ROUTINE: FCORI_MACROS.h
+!    !INTERFACE:
+!    include FCORI_MACROS.h
+!    !DESCRIPTION: \bv
+! *==========================================================*
+! | FCORI_MACROS.h
+! *==========================================================*
+! | These macros are used to reduce memory requirement and/or
+! | memory references when variables are fixed along a given
+! | axis or axes.
+! *==========================================================*
+! \ev
+!EOP
 
 #ifdef FCORI_CONST
 #define  _fCori(i,j,bi,bj) fCori(1,1,1,1)

--- a/model/inc/FFIELDS.h
+++ b/model/inc/FFIELDS.h
@@ -1,87 +1,87 @@
-CBOP
-C     !ROUTINE: FFIELDS.h
-C     !INTERFACE:
-C     include "FFIELDS.h"
-C     !DESCRIPTION:
-C     \bv
-C     *==========================================================*
-C     | FFIELDS.h
-C     | o Model forcing fields
-C     *==========================================================*
-C     | More flexible surface forcing configurations are
-C     | available via, e.g., pkg/exf
-C     *==========================================================*
-C     \ev
-CEOP
-C
-C     fu    :: Zonal surface wind stress in N/m^2
-C              > 0 for increase in uVel, which is west to
-C                  east for cartesian and spherical polar grids
-C              Typical range: -0.5 < fu < 0.5
-C              Southwest C-grid U point
-C
-C     fv    :: Meridional surface wind stress in N/m^2
-C              > 0 for increase in vVel, which is south to
-C                  north for cartesian and spherical polar grids
-C              Typical range: -0.5 < fv < 0.5
-C              Southwest C-grid V point
-C
-C     EmPmR :: Net upward freshwater flux in kg/m2/s
-C              EmPmR = Evaporation - precipitation - runoff
-C              > 0 for increase in salt (ocean salinity)
-C              Typical range: -1e-4 < EmPmR < 1e-4
-C              Southwest C-grid tracer point
-C           NOTE: for backward compatibility EmPmRfile is specified in
-C                 m/s when using external_fields_load.F.  It is converted
-C                 to kg/m2/s by multiplying by rhoConstFresh.
-C
-C  saltFlux :: Net upward salt flux in g/kg.kg/m^2/s = g/m^2/s
-C              flux of Salt taken out of the ocean per time unit (second).
-C              Note: only used when salty sea-ice forms or melts.
-C              > 0 for decrease in SSS.
-C              Southwest C-grid tracer point
-C
-C     Qnet  :: Net upward surface heat flux (including shortwave) in W/m^2
-C              Qnet = latent + sensible + net longwave + net shortwave
-C              > 0 for decrease in theta (ocean cooling)
-C              Typical range: -250 < Qnet < 600
-C              Southwest C-grid tracer point
-C
-C     Qsw   :: Net upward shortwave radiation in W/m^2
-C              Qsw = - ( downward - ice and snow absorption - reflected )
-C              > 0 for decrease in theta (ocean cooling)
-C              Typical range: -350 < Qsw < 0
-C              Southwest C-grid tracer point
-C
-C     SST   :: Sea surface temperature in degrees C for relaxation
-C              Southwest C-grid tracer point
-C
-C     SSS   :: Sea surface salinity in g/kg for relaxation
-C              Southwest C-grid tracer point
-C
-C     lambdaThetaClimRelax :: Inverse time scale for SST relaxation ( 1/s ).
-C
-C     lambdaSaltClimRelax  :: Inverse time scale for SSS relaxation ( 1/s ).
+!BOP
+! !ROUTINE: FFIELDS.h
+! !INTERFACE:
+! include "FFIELDS.h"
+! !DESCRIPTION:
+! \bv
+! *==========================================================*
+! | FFIELDS.h
+! | o Model forcing fields
+! *==========================================================*
+! | More flexible surface forcing configurations are
+! | available via, e.g., pkg/exf
+! *==========================================================*
+! \ev
+!EOP
+!
+! fu    :: Zonal surface wind stress in N/m^2
+!          > 0 for increase in uVel, which is west to
+!              east for cartesian and spherical polar grids
+!          Typical range: -0.5 < fu < 0.5
+!          Southwest C-grid U point
+!
+! fv    :: Meridional surface wind stress in N/m^2
+!          > 0 for increase in vVel, which is south to
+!              north for cartesian and spherical polar grids
+!          Typical range: -0.5 < fv < 0.5
+!          Southwest C-grid V point
+!
+! EmPmR :: Net upward freshwater flux in kg/m2/s
+!          EmPmR = Evaporation - precipitation - runoff
+!          > 0 for increase in salt (ocean salinity)
+!          Typical range: -1e-4 < EmPmR < 1e-4
+!          Southwest C-grid tracer point
+!       NOTE: for backward compatibility EmPmRfile is specified in
+!             m/s when using external_fields_load.F.  It is converted
+!             to kg/m2/s by multiplying by rhoConstFresh.
+!
+!  saltFlux :: Net upward salt flux in g/kg.kg/m^2/s = g/m^2/s
+!          flux of Salt taken out of the ocean per time unit (second).
+!          Note: only used when salty sea-ice forms or melts.
+!          > 0 for decrease in SSS.
+!          Southwest C-grid tracer point
+!
+! Qnet  :: Net upward surface heat flux (including shortwave) in W/m^2
+!          Qnet = latent + sensible + net longwave + net shortwave
+!          > 0 for decrease in theta (ocean cooling)
+!          Typical range: -250 < Qnet < 600
+!          Southwest C-grid tracer point
+!
+! Qsw   :: Net upward shortwave radiation in W/m^2
+!          Qsw = - ( downward - ice and snow absorption - reflected )
+!          > 0 for decrease in theta (ocean cooling)
+!          Typical range: -350 < Qsw < 0
+!          Southwest C-grid tracer point
+!
+! SST   :: Sea surface temperature in degrees C for relaxation
+!          Southwest C-grid tracer point
+!
+! SSS   :: Sea surface salinity in g/kg for relaxation
+!          Southwest C-grid tracer point
+!
+! lambdaThetaClimRelax :: Inverse time scale for SST relaxation ( 1/s ).
+!
+! lambdaSaltClimRelax  :: Inverse time scale for SSS relaxation ( 1/s ).
 
-C     phiTide2d :: vertically uniform (2d-map), time-dependent geopotential
-C                  anomaly (e.g., tidal forcing); Units are m^2/s^2
-C     pLoad :: for the ocean:      atmospheric pressure anomaly (relative to
-C                                   "surf_pRef") at z=eta
-C                Units are           Pa=N/m^2
-C              for the atmosphere (hack): geopotential anomaly of the orography
-C                Units are           m^2/s^2
-C     sIceLoad :: sea-ice loading, expressed in Mass of ice+snow / area unit
-C                Units are           kg/m^2
-C              Note: only used with Sea-Ice & RealFreshWater formulation
-C     addMass  :: source (<0: sink) of fluid in the domain interior
-C                 (generalisation of oceanic real fresh-water flux)
-C                Units are           kg/s  (mass per unit of time)
-C     frictionHeating :: heating caused by friction and momentum dissipation
-C                Units are           in W/m^2 (thickness integrated)
-C     eddyPsiX -Zonal Eddy Streamfunction in m^2/s used in taueddy_external_forcing.F
-C     eddyPsiY -Meridional Streamfunction in m^2/s used in taueddy_external_forcing.F
-C     EfluxY - y-component of Eliassen-Palm flux vector
-C     EfluxP - p-component of Eliassen-Palm flux vector
+! phiTide2d :: vertically uniform (2d-map), time-dependent geopotential
+!              anomaly (e.g., tidal forcing); Units are m^2/s^2
+! pLoad :: for the ocean:      atmospheric pressure anomaly (relative to
+!                               "surf_pRef") at z=eta
+!            Units are           Pa=N/m^2
+!          for the atmosphere (hack): geopotential anomaly of the orography
+!            Units are           m^2/s^2
+! sIceLoad :: sea-ice loading, expressed in Mass of ice+snow / area unit
+!            Units are           kg/m^2
+!          Note: only used with Sea-Ice & RealFreshWater formulation
+! addMass  :: source (<0: sink) of fluid in the domain interior
+!             (generalisation of oceanic real fresh-water flux)
+!            Units are           kg/s  (mass per unit of time)
+! frictionHeating :: heating caused by friction and momentum dissipation
+!            Units are           in W/m^2 (thickness integrated)
+! eddyPsiX -Zonal Eddy Streamfunction in m^2/s used in taueddy_external_forcing.F
+! eddyPsiY -Meridional Streamfunction in m^2/s used in taueddy_external_forcing.F
+! EfluxY - y-component of Eliassen-Palm flux vector
+! EfluxP - p-component of Eliassen-Palm flux vector
 
       COMMON /FFIELDS_fu/ fu
       COMMON /FFIELDS_fv/ fv
@@ -111,10 +111,10 @@ C     EfluxP - p-component of Eliassen-Palm flux vector
       _RS  pLoad    (1-OLx:sNx+OLx,1-OLy:sNy+OLy,nSx,nSy)
       _RS  sIceLoad (1-OLx:sNx+OLx,1-OLy:sNy+OLy,nSx,nSy)
 
-C     gcmSST :: model in-situ Sea Surface Temperature (SST); corresponds to
-C               surface-level model variable "theta", except if using TEOS-10 ;
-C               in that case a conversion from model Conservative Temperature
-C               "theta" is applied. Note: not defined under an ice-shelf
+! gcmSST :: model in-situ Sea Surface Temperature (SST); corresponds to
+!           surface-level model variable "theta", except if using TEOS-10 ;
+!           in that case a conversion from model Conservative Temperature
+!           "theta" is applied. Note: not defined under an ice-shelf
       COMMON /FFIELDS_INSITU_TEMP/ gcmSST
       _RL  gcmSST(1-OLx:sNx+OLx,1-OLy:sNy+OLy,nSx,nSy)
 
@@ -127,43 +127,43 @@ C               "theta" is applied. Note: not defined under an ice-shelf
       _RS frictionHeating(1-OLx:sNx+OLx,1-OLy:sNy+OLy,Nr,nSx,nSy)
 #endif
 #ifdef ALLOW_GEOTHERMAL_FLUX
-C  geothermalFlux :: Upward geothermal flux through bottom cell [W/m^2]
-C                    > 0 for increase in theta (ocean warming)
-C                    Typical range: 0 < geothermalFlux < 1.5 W/m^2
-C                    (global mean on the order 0.09 - 0.1 W/m^2)
+!  geothermalFlux :: Upward geothermal flux through bottom cell [W/m^2]
+               ! > 0 for increase in theta (ocean warming)
+               ! Typical range: 0 < geothermalFlux < 1.5 W/m^2
+               ! (global mean on the order 0.09 - 0.1 W/m^2)
       COMMON /FFIELDS_geothermal/ geothermalFlux
       _RS geothermalFlux(1-OLx:sNx+OLx,1-OLy:sNy+OLy,nSx,nSy)
 #endif
 #ifdef ALLOW_BALANCE_FLUXES
-C  weight2BalanceFlx :: weight used for applying weighted correction
-C                       to global-mean surf. flux imbalance ; no-units
+!  weight2BalanceFlx :: weight used for applying weighted correction
+                  ! to global-mean surf. flux imbalance ; no-units
       COMMON /FFIELDS_W2BALANCE/ weight2BalanceFlx
       _RS weight2BalanceFlx(1-OLx:sNx+OLx,1-OLy:sNy+OLy,nSx,nSy)
 #endif
 
 #ifdef SHORTWAVE_HEATING
-C     SWFrac3D :: fraction of solar short-wave flux penetrating the vertical
-C                 cell interfaces (no units), function of depth of cell
-C                 interface, potentially turbidity, cholorphyll concentration,
-C                 or other biogeochemical material;
-C                 the vertical dimension is Nr+1, because this makes it easier
-C                 to maintain the symmetry w.r.t. z vs. p-coordinates.
+! SWFrac3D :: fraction of solar short-wave flux penetrating the vertical
+!             cell interfaces (no units), function of depth of cell
+!             interface, potentially turbidity, cholorphyll concentration,
+!             or other biogeochemical material;
+!             the vertical dimension is Nr+1, because this makes it easier
+!             to maintain the symmetry w.r.t. z vs. p-coordinates.
       COMMON /FFIELDS_SWFRAC/ SWFrac3D
       _RS  SWFrac3D(1-OLx:sNx+OLx,1-OLy:sNy+OLy,Nr+1,nSx,nSy)
 #endif
 
 #ifdef ALLOW_EDDYPSI
-C     uEulerMean  :: The Eulerian mean Zonal  velocity (residual less bolus velocity)
-C     vEulerMean  :: The Eulerian mean Merid. velocity (residual less bolus velocity)
-C     tauxEddy    :: The eddy stress used in the momentum equation of a residual model
-C     tauyEddy    :: The eddy stress used in the momentum equation of a residual model
+! uEulerMean  :: The Eulerian mean Zonal  velocity (residual less bolus velocity)
+! vEulerMean  :: The Eulerian mean Merid. velocity (residual less bolus velocity)
+! tauxEddy    :: The eddy stress used in the momentum equation of a residual model
+! tauyEddy    :: The eddy stress used in the momentum equation of a residual model
 
       COMMON /FFIELDS_eddyPsi_RS/ eddyPsiX, eddyPsiY
       _RS  eddyPsiX (1-OLx:sNx+OLx,1-OLy:sNy+OLy,Nr,nSx,nSy)
       _RS  eddyPsiY (1-OLx:sNx+OLx,1-OLy:sNy+OLy,Nr,nSx,nSy)
 
-      COMMON /FFIELDS_eddyPsi_RL/
-     &                tauxEddy, tauyEddy, uEulerMean, vEulerMean
+      COMMON /FFIELDS_eddyPsi_RL/                                                 &
+     &      tauxEddy, tauyEddy, uEulerMean, vEulerMean
       _RL tauxEddy  (1-OLx:sNx+OLx,1-OLy:sNy+OLy,Nr,nSx,nSy)
       _RL tauyEddy  (1-OLx:sNx+OLx,1-OLy:sNy+OLy,Nr,nSx,nSy)
       _RL uEulerMean(1-OLx:sNx+OLx,1-OLy:sNy+OLy,Nr,nSx,nSy)
@@ -171,34 +171,34 @@ C     tauyEddy    :: The eddy stress used in the momentum equation of a residual
 #endif /* ALLOW_EDDYPSI */
 
 #ifndef EXCLUDE_FFIELDS_LOAD
-C     loadedRec     :: time-record currently loaded (in temp arrays *[1])
-C     taux[0,1]     :: Temp. for zonal wind stress
-C     tauy[0,1]     :: Temp. for merid. wind stress
-C     Qnet[0,1]     :: Temp. for heat flux
-C     EmPmR[0,1]    :: Temp. for fresh water flux
-C     saltFlux[0,1] :: Temp. for isurface salt flux
-C     SST[0,1]      :: Temp. for theta climatalogy
-C     SSS[0,1]      :: Temp. for theta climatalogy
-C     Qsw[0,1]      :: Temp. for short wave component of heat flux
-C     pLoad[0,1]    :: Temp. for atmospheric pressure at z=eta
-C     [0,1]         :: End points for interpolation
+! loadedRec     :: time-record currently loaded (in temp arrays *[1])
+! taux[0,1]     :: Temp. for zonal wind stress
+! tauy[0,1]     :: Temp. for merid. wind stress
+! Qnet[0,1]     :: Temp. for heat flux
+! EmPmR[0,1]    :: Temp. for fresh water flux
+! saltFlux[0,1] :: Temp. for isurface salt flux
+! SST[0,1]      :: Temp. for theta climatalogy
+! SSS[0,1]      :: Temp. for theta climatalogy
+! Qsw[0,1]      :: Temp. for short wave component of heat flux
+! pLoad[0,1]    :: Temp. for atmospheric pressure at z=eta
+! [0,1]         :: End points for interpolation
 
       COMMON /FFIELDS_I/ loadedRec
-      INTEGER loadedRec(nSx,nSy)
+      INTEGER :: loadedRec(nSx,nSy)
 
-      COMMON /TDFIELDS/
-     &                 taux0, tauy0, Qnet0, EmPmR0, SST0, SSS0,
-     &                 taux1, tauy1, Qnet1, EmPmR1, SST1, SSS1,
-     &                 saltFlux0, saltFlux1
-#ifdef SHORTWAVE_HEATING
-     &               , Qsw0, Qsw1
+      COMMON /TDFIELDS/                                                           &
+     &      taux0, tauy0, Qnet0, EmPmR0, SST0, SSS0,                              &
+     &      taux1, tauy1, Qnet1, EmPmR1, SST1, SSS1,                              &
+#ifdef SHORTWAVE_HEATING                                                          
+     &      Qsw0, Qsw1,                                                           &
 #endif
-#ifdef ALLOW_GEOTHERMAL_FLUX
-     &               , geothFlux0, geothFlux1
+#ifdef ALLOW_GEOTHERMAL_FLUX        
+     &      geothFlux0, geothFlux1,                                               &
 #endif
-#ifdef ATMOSPHERIC_LOADING
-     &               , pLoad0, pLoad1
+#ifdef ATMOSPHERIC_LOADING  
+     &      pLoad0, pLoad1,                                                       &
 #endif
+     &      saltFlux0, saltFlux1                                                  
 
       _RS  taux0    (1-OLx:sNx+OLx,1-OLy:sNy+OLy,nSx,nSy)
       _RS  tauy0    (1-OLx:sNx+OLx,1-OLy:sNy+OLy,nSx,nSy)
@@ -228,50 +228,50 @@ C     [0,1]         :: End points for interpolation
 #endif
 #endif /* EXCLUDE_FFIELDS_LOAD */
 
-C     surfaceForcingU     units are  r_unit.m/s^2 (=m^2/s^2 if r=z)
-C                -> usage in gU:     gU = gU + surfaceForcingU/drF [m/s^2]
-C     surfaceForcingV     units are  r_unit.m/s^2 (=m^2/s^-2 if r=z)
-C                -> usage in gU:     gV = gV + surfaceForcingV/drF [m/s^2]
-C
-C     surfaceForcingS     units are  r_unit.g/kg/s (=g/kg.m/s if r=z)
-C            - EmPmR * S_surf plus salinity relaxation*drF(1)
-C                -> usage in gS:     gS = gS + surfaceForcingS/drF [g/kg/s]
-C
-C     surfaceForcingT     units are  r_unit.Kelvin/s (=Kelvin.m/s if r=z)
-C            - Qnet (+Qsw) plus temp. relaxation*drF(1)
-C                -> calculate        -lambda*(T(model)-T(clim))
-C            Qnet assumed to be net heat flux including ShortWave rad.
-C                -> usage in gT:     gT = gT + surfaceforcingT/drF [K/s]
-C     adjustColdSST_diag :: diagnostic field for how much too cold (below
-C              Tfreezing) SST has been adjusted (with allowFreezing=T).
-C              > 0 for increase of SST (up to Tfreezing).
-C              Units are r_unit.K/s (=Kelvin.m/s if r=z).
-C        Note: 1) allowFreezing option is a crude hack to fix too cold SST that
-C              results from missing seaice component. It should never be used
-C              with any seaice component, neither current seaice pkg (pkg/seaice
-C              or pkg/thsice) nor a seaice component from atmos model when
-C              coupled to it.
-C              2) this diagnostic is currently used by KPP package (kpp_calc.F
-C              and kpp_transport_t.F) although it is not very clear it should.
+! surfaceForcingU     units are  r_unit.m/s^2 (=m^2/s^2 if r=z)
+!            -> usage in gU:     gU = gU + surfaceForcingU/drF [m/s^2]
+! surfaceForcingV     units are  r_unit.m/s^2 (=m^2/s^-2 if r=z)
+!            -> usage in gU:     gV = gV + surfaceForcingV/drF [m/s^2]
+!
+! surfaceForcingS     units are  r_unit.g/kg/s (=g/kg.m/s if r=z)
+!        - EmPmR * S_surf plus salinity relaxation*drF(1)
+!            -> usage in gS:     gS = gS + surfaceForcingS/drF [g/kg/s]
+!
+! surfaceForcingT     units are  r_unit.Kelvin/s (=Kelvin.m/s if r=z)
+!        - Qnet (+Qsw) plus temp. relaxation*drF(1)
+!            -> calculate        -lambda*(T(model)-T(clim))
+!        Qnet assumed to be net heat flux including ShortWave rad.
+!            -> usage in gT:     gT = gT + surfaceforcingT/drF [K/s]
+! adjustColdSST_diag :: diagnostic field for how much too cold (below
+!          Tfreezing) SST has been adjusted (with allowFreezing=T).
+!          > 0 for increase of SST (up to Tfreezing).
+!          Units are r_unit.K/s (=Kelvin.m/s if r=z).
+!    Note: 1) allowFreezing option is a crude hack to fix too cold SST that
+!          results from missing seaice component. It should never be used
+!          with any seaice component, neither current seaice pkg (pkg/seaice
+!          or pkg/thsice) nor a seaice component from atmos model when
+!          coupled to it.
+!          2) this diagnostic is currently used by KPP package (kpp_calc.F
+!          and kpp_transport_t.F) although it is not very clear it should.
 
-      COMMON /SURFACE_FORCING/
-     &                         surfaceForcingU,
-     &                         surfaceForcingV,
-     &                         surfaceForcingT,
-     &                         surfaceForcingS,
-     &                         adjustColdSST_diag
+      COMMON /SURFACE_FORCING/                                                    &
+     &      surfaceForcingU,                                                      &
+     &      surfaceForcingV,                                                      &
+     &      surfaceForcingT,                                                      &
+     &      surfaceForcingS,                                                      &
+     &      adjustColdSST_diag
       _RL  surfaceForcingU   (1-OLx:sNx+OLx,1-OLy:sNy+OLy,nSx,nSy)
       _RL  surfaceForcingV   (1-OLx:sNx+OLx,1-OLy:sNy+OLy,nSx,nSy)
       _RL  surfaceForcingT   (1-OLx:sNx+OLx,1-OLy:sNy+OLy,nSx,nSy)
       _RL  surfaceForcingS   (1-OLx:sNx+OLx,1-OLy:sNy+OLy,nSx,nSy)
       _RL  adjustColdSST_diag(1-OLx:sNx+OLx,1-OLy:sNy+OLy,nSx,nSy)
 
-C     botDragU :: bottom stress (for diagnostics), Zonal component
-C                Units are N/m^2 ;   > 0 increase uVel @ bottom
-C     botDragV :: bottom stress (for diagnostics), Merid. component
-C                Units are N/m^2 ;   > 0 increase vVel @ bottom
+! botDragU :: bottom stress (for diagnostics), Zonal component
+!            Units are N/m^2 ;   > 0 increase uVel @ bottom
+! botDragV :: bottom stress (for diagnostics), Merid. component
+!            Units are N/m^2 ;   > 0 increase vVel @ bottom
       COMMON /FFIELDS_bottomStress/ botDragU, botDragV
       _RS  botDragU (1-OLx:sNx+OLx,1-OLy:sNy+OLy,nSx,nSy)
       _RS  botDragV (1-OLx:sNx+OLx,1-OLy:sNy+OLy,nSx,nSy)
 
-C---+----1----+----2----+----3----+----4----+----5----+----6----+----7-|--+----|
+!---+----1----+----2----+----3----+----4----+----5----+----6----+----7-|--+----|

--- a/model/inc/GRID.h
+++ b/model/inc/GRID.h
@@ -1,322 +1,322 @@
-C
-CBOP
-C    !ROUTINE: GRID.h
-C    !INTERFACE:
-C    include GRID.h
-C    !DESCRIPTION: \bv
-C     *==========================================================*
-C     | GRID.h
-C     | o Header file defining model grid.
-C     *==========================================================*
-C     | Model grid is defined for each process by reference to
-C     | the arrays set here.
-C     | Notes
-C     | =====
-C     | The standard MITgcm convention of westmost, southern most
-C     | and upper most having the (1,1,1) index is used here.
-C     | i.e.
-C     |----------------------------------------------------------
-C     | (1)  Plan view schematic of model grid (top layer i.e. )
-C     |      ================================= ( ocean surface )
-C     |                                        ( or top of     )
-C     |                                        ( atmosphere    )
-C     |      This diagram shows the location of the model
-C     |      prognostic variables on the model grid. The "T"
-C     |      location is used for all tracers. The figure also
-C     |      shows the southern most, western most indexing
-C     |      convention that is used for all model variables.
-C     |
-C     |
-C     |             V(i=1,                     V(i=Nx,
-C     |               j=Ny+1,                    j=Ny+1,
-C     |               k=1)                       k=1)
-C     |                /|\                       /|\  "PWX"
-C     |       |---------|------------------etc..  |---- *---
-C     |       |                     |                   *  |
-C     |"PWY"*******************************etc..  **********"PWY"
-C     |       |                     |                   *  |
-C     |       |                     |                   *  |
-C     |       |                     |                   *  |
-C     |U(i=1, ==>       x           |             x     *==>U
-C     |  j=Ny,|      T(i=1,         |          T(i=Nx,  *(i=Nx+1,
-C     |  k=1) |        j=Ny,        |            j=Ny,  *  |j=Ny,
-C     |       |        k=1)         |            k=1)   *  |k=1)
-C     |
-C     |       .                     .                      .
-C     |       .                     .                      .
-C     |       .                     .                      .
-C     |       e                     e                   *  e
-C     |       t                     t                   *  t
-C     |       c                     c                   *  c
-C     |       |                     |                   *  |
-C     |       |                     |                   *  |
-C     |U(i=1, ==>       x           |             x     *  |
-C     |  j=2, |      T(i=1,         |          T(i=Nx,  *  |
-C     |  k=1) |        j=2,         |            j=2,   *  |
-C     |       |        k=1)         |            k=1)   *  |
-C     |       |                     |                   *  |
-C     |       |        /|\          |            /|\    *  |
-C     |      -----------|------------------etc..  |-----*---
-C     |       |       V(i=1,        |           V(i=Nx, *  |
-C     |       |         j=2,        |             j=2,  *  |
-C     |       |         k=1)        |             k=1)  *  |
-C     |       |                     |                   *  |
-C     |U(i=1, ==>       x         ==>U(i=2,       x     *==>U
-C     |  j=1, |      T(i=1,         |  j=1,    T(i=Nx,  *(i=Nx+1,
-C     |  k=1) |        j=1,         |  k=1)      j=1,   *  |j=1,
-C     |       |        k=1)         |            k=1)   *  |k=1)
-C     |       |                     |                   *  |
-C     |       |        /|\          |            /|\    *  |
-C     |"SB"++>|---------|------------------etc..  |-----*---
-C     |      /+\      V(i=1,                    V(i=Nx, *
-C     |       +         j=1,                      j=1,  *
-C     |       +         k=1)                      k=1)  *
-C     |     "WB"                                      "PWX"
-C     |
-C     |   N, y increasing northwards
-C     |  /|\ j increasing northwards
-C     |   |
-C     |   |
-C     |   ======>E, x increasing eastwards
-C     |             i increasing eastwards
-C     |
-C     |    i: East-west index
-C     |    j: North-south index
-C     |    k: up-down index
-C     |    U: x-velocity (m/s)
-C     |    V: y-velocity (m/s)
-C     |    T: potential temperature (oC)
-C     | "SB": Southern boundary
-C     | "WB": Western boundary
-C     |"PWX": Periodic wrap around in X.
-C     |"PWY": Periodic wrap around in Y.
-C     |----------------------------------------------------------
-C     | (2) South elevation schematic of model grid
-C     |     =======================================
-C     |     This diagram shows the location of the model
-C     |     prognostic variables on the model grid. The "T"
-C     |     location is used for all tracers. The figure also
-C     |     shows the upper most, western most indexing
-C     |     convention that is used for all model variables.
-C     |
-C     |      "WB"
-C     |       +
-C     |       +
-C     |      \+/       /|\                       /|\       .
-C     |"UB"++>|-------- | -----------------etc..  | ----*---
-C     |       |    rVel(i=1,        |        rVel(i=Nx, *  |
-C     |       |         j=1,        |             j=1,  *  |
-C     |       |         k=1)        |             k=1)  *  |
-C     |       |                     |                   *  |
-C     |U(i=1, ==>       x         ==>U(i=2,       x     *==>U
-C     |  j=1, |      T(i=1,         |  j=1,    T(i=Nx,  *(i=Nx+1,
-C     |  k=1) |        j=1,         |  k=1)      j=1,   *  |j=1,
-C     |       |        k=1)         |            k=1)   *  |k=1)
-C     |       |                     |                   *  |
-C     |       |        /|\          |            /|\    *  |
-C     |       |-------- | -----------------etc..  | ----*---
-C     |       |    rVel(i=1,        |        rVel(i=Nx, *  |
-C     |       |         j=1,        |             j=1,  *  |
-C     |       |         k=2)        |             k=2)  *  |
-C     |
-C     |       .                     .                      .
-C     |       .                     .                      .
-C     |       .                     .                      .
-C     |       e                     e                   *  e
-C     |       t                     t                   *  t
-C     |       c                     c                   *  c
-C     |       |                     |                   *  |
-C     |       |                     |                   *  |
-C     |       |                     |                   *  |
-C     |       |                     |                   *  |
-C     |       |        /|\          |            /|\    *  |
-C     |       |-------- | -----------------etc..  | ----*---
-C     |       |    rVel(i=1,        |        rVel(i=Nx, *  |
-C     |       |         j=1,        |             j=1,  *  |
-C     |       |         k=Nr)       |             k=Nr) *  |
-C     |U(i=1, ==>       x         ==>U(i=2,       x     *==>U
-C     |  j=1, |      T(i=1,         |  j=1,    T(i=Nx,  *(i=Nx+1,
-C     |  k=Nr)|        j=1,         |  k=Nr)     j=1,   *  |j=1,
-C     |       |        k=Nr)        |            k=Nr)  *  |k=Nr)
-C     |       |                     |                   *  |
-C     |"LB"++>==============================================
-C     |                                               "PWX"
-C     |
-C     | Up   increasing upwards.
-C     |/|\                                                       .
-C     | |
-C     | |
-C     | =====> E  i increasing eastwards
-C     | |         x increasing eastwards
-C     | |
-C     |\|/
-C     | Down,k increasing downwards.
-C     |
-C     | Note: r => height (m) => r increases upwards
-C     |       r => pressure (Pa) => r increases downwards
-C     |
-C     |
-C     |    i: East-west index
-C     |    j: North-south index
-C     |    k: up-down index
-C     |    U: x-velocity (m/s)
-C     | rVel: z-velocity ( units of r )
-C     |       The vertical velocity variable rVel is in units of
-C     |       "r" the vertical coordinate. r in m will give
-C     |       rVel m/s. r in Pa will give rVel Pa/s.
-C     |    T: potential temperature (oC)
-C     | "UB": Upper boundary.
-C     | "LB": Lower boundary (always solid - therefore om|w == 0)
-C     | "WB": Western boundary
-C     |"PWX": Periodic wrap around in X.
-C     |----------------------------------------------------------
-C     | (3) Views showing nomenclature and indexing
-C     |     for grid descriptor variables.
-C     |
-C     |      Fig 3a. shows the orientation, indexing and
-C     |      notation for the grid spacing terms used internally
-C     |      for the evaluation of gradient and averaging terms.
-C     |      These varaibles are set based on the model input
-C     |      parameters which define the model grid in terms of
-C     |      spacing in X, Y and Z.
-C     |
-C     |      Fig 3b. shows the orientation, indexing and
-C     |      notation for the variables that are used to define
-C     |      the model grid. These varaibles are set directly
-C     |      from the model input.
-C     |
-C     | Figure 3a
-C     | =========
-C     |       |------------------------------------
-C     |       |                       |
-C     |"PWY"********************************* etc...
-C     |       |                       |
-C     |       |                       |
-C     |       |                       |
-C     |       |                       |
-C     |       |                       |
-C     |       |                       |
-C     |       |                       |
-C     |
-C     |       .                       .
-C     |       .                       .
-C     |       .                       .
-C     |       e                       e
-C     |       t                       t
-C     |       c                       c
-C     |       |-----------v-----------|-----------v----------|-
-C     |       |                       |                      |
-C     |       |                       |                      |
-C     |       |                       |                      |
-C     |       |                       |                      |
-C     |       |                       |                      |
-C     |       u<--dxF(i=1,j=2,k=1)--->u           t          |
-C     |       |/|\       /|\          |                      |
-C     |       | |         |           |                      |
-C     |       | |         |           |                      |
-C     |       | |         |           |                      |
-C     |       |dyU(i=1,  dyC(i=1,     |                      |
-C     | ---  ---|--j=2,---|--j=2,-----------------v----------|-
-C     | /|\   | |  k=1)   |  k=1)     |          /|\         |
-C     |  |    | |         |           |          dyF(i=2,    |
-C     |  |    | |         |           |           |  j=1,    |
-C     |dyG(   |\|/       \|/          |           |  k=1)    |
-C     |   i=1,u---        t<---dxC(i=2,j=1,k=1)-->t          |
-C     |   j=1,|                       |           |          |
-C     |   k=1)|                       |           |          |
-C     |  |    |                       |           |          |
-C     |  |    |                       |           |          |
-C     | \|/   |           |<---dxV(i=2,j=1,k=1)--\|/         |
-C     |"SB"++>|___________v___________|___________v__________|_
-C     |       <--dxG(i=1,j=1,k=1)----->
-C     |      /+\                                              .
-C     |       +
-C     |       +
-C     |     "WB"
-C     |
-C     |   N, y increasing northwards
-C     |  /|\ j increasing northwards
-C     |   |
-C     |   |
-C     |   ======>E, x increasing eastwards
-C     |             i increasing eastwards
-C     |
-C     |    i: East-west index
-C     |    j: North-south index
-C     |    k: up-down index
-C     |    u: x-velocity point
-C     |    V: y-velocity point
-C     |    t: tracer point
-C     | "SB": Southern boundary
-C     | "WB": Western boundary
-C     |"PWX": Periodic wrap around in X.
-C     |"PWY": Periodic wrap around in Y.
-C     |
-C     | Figure 3b
-C     | =========
-C     |
-C     |       .                       .
-C     |       .                       .
-C     |       .                       .
-C     |       e                       e
-C     |       t                       t
-C     |       c                       c
-C     |       |-----------v-----------|-----------v--etc...
-C     |       |                       |
-C     |       |                       |
-C     |       |                       |
-C     |       |                       |
-C     |       |                       |
-C     |       u<--delX(i=1)---------->u           t
-C     |       |                       |
-C     |       |                       |
-C     |       |                       |
-C     |       |                       |
-C     |       |                       |
-C     |       |-----------v-----------------------v--etc...
-C     |       |          /|\          |
-C     |       |           |           |
-C     |       |           |           |
-C     |       |           |           |
-C     |       u        delY(j=1)      |           t
-C     |       |           |           |
-C     |       |           |           |
-C     |       |           |           |
-C     |       |           |           |
-C     |       |          \|/          |
-C     |"SB"++>|___________v___________|___________v__etc...
-C     |      /+\                                                 .
-C     |       +
-C     |       +
-C     |     "WB"
-C     |
-C     *==========================================================*
-C     \ev
-CEOP
+!
+!BOP
+!    !ROUTINE: GRID.h
+!    !INTERFACE:
+!    include GRID.h
+!    !DESCRIPTION: \bv
+! *==========================================================*
+! | GRID.h
+! | o Header file defining model grid.
+! *==========================================================*
+! | Model grid is defined for each process by reference to
+! | the arrays set here.
+! | Notes
+! | =====
+! | The standard MITgcm convention of westmost, southern most
+! | and upper most having the (1,1,1) index is used here.
+! | i.e.
+! |----------------------------------------------------------
+! | (1)  Plan view schematic of model grid (top layer i.e. )
+! |      ================================= ( ocean surface )
+! |                                        ( or top of     )
+! |                                        ( atmosphere    )
+! |      This diagram shows the location of the model
+! |      prognostic variables on the model grid. The "T"
+! |      location is used for all tracers. The figure also
+! |      shows the southern most, western most indexing
+! |      convention that is used for all model variables.
+! |
+! |
+! |             V(i=1,                     V(i=Nx,
+! |               j=Ny+1,                    j=Ny+1,
+! |               k=1)                       k=1)
+! |                /|\                       /|\  "PWX"
+! |       |---------|------------------etc..  |---- *---
+! |       |                     |                   *  |
+! |"PWY"*******************************etc..  **********"PWY"
+! |       |                     |                   *  |
+! |       |                     |                   *  |
+! |       |                     |                   *  |
+! |U(i=1, ==>       x           |             x     *==>U
+! |  j=Ny,|      T(i=1,         |          T(i=Nx,  *(i=Nx+1,
+! |  k=1) |        j=Ny,        |            j=Ny,  *  |j=Ny,
+! |       |        k=1)         |            k=1)   *  |k=1)
+! |
+! |       .                     .                      .
+! |       .                     .                      .
+! |       .                     .                      .
+! |       e                     e                   *  e
+! |       t                     t                   *  t
+! |       c                     c                   *  c
+! |       |                     |                   *  |
+! |       |                     |                   *  |
+! |U(i=1, ==>       x           |             x     *  |
+! |  j=2, |      T(i=1,         |          T(i=Nx,  *  |
+! |  k=1) |        j=2,         |            j=2,   *  |
+! |       |        k=1)         |            k=1)   *  |
+! |       |                     |                   *  |
+! |       |        /|\          |            /|\    *  |
+! |      -----------|------------------etc..  |-----*---
+! |       |       V(i=1,        |           V(i=Nx, *  |
+! |       |         j=2,        |             j=2,  *  |
+! |       |         k=1)        |             k=1)  *  |
+! |       |                     |                   *  |
+! |U(i=1, ==>       x         ==>U(i=2,       x     *==>U
+! |  j=1, |      T(i=1,         |  j=1,    T(i=Nx,  *(i=Nx+1,
+! |  k=1) |        j=1,         |  k=1)      j=1,   *  |j=1,
+! |       |        k=1)         |            k=1)   *  |k=1)
+! |       |                     |                   *  |
+! |       |        /|\          |            /|\    *  |
+! |"SB"++>|---------|------------------etc..  |-----*---
+! |      /+\      V(i=1,                    V(i=Nx, *
+! |       +         j=1,                      j=1,  *
+! |       +         k=1)                      k=1)  *
+! |     "WB"                                      "PWX"
+! |
+! |   N, y increasing northwards
+! |  /|\ j increasing northwards
+! |   |
+! |   |
+! |   ======>E, x increasing eastwards
+! |             i increasing eastwards
+! |
+! |    i: East-west index
+! |    j: North-south index
+!     |    k: up-down index
+! |    U: x-velocity (m/s)
+! |    V: y-velocity (m/s)
+! |    T: potential temperature (oC)
+! | "SB": Southern boundary
+! | "WB": Western boundary
+! |"PWX": Periodic wrap around in X.
+! |"PWY": Periodic wrap around in Y.
+! |----------------------------------------------------------
+! | (2) South elevation schematic of model grid
+! |     =======================================
+! |     This diagram shows the location of the model
+! |     prognostic variables on the model grid. The "T"
+! |     location is used for all tracers. The figure also
+! |     shows the upper most, western most indexing
+! |     convention that is used for all model variables.
+! |
+! |      "WB"
+! |       +
+! |       +
+! |      \+/       /|\                       /|\       .
+! |"UB"++>|-------- | -----------------etc..  | ----*---
+! |       |    rVel(i=1,        |        rVel(i=Nx, *  |
+! |       |         j=1,        |             j=1,  *  |
+! |       |         k=1)        |             k=1)  *  |
+! |       |                     |                   *  |
+! |U(i=1, ==>       x         ==>U(i=2,       x     *==>U
+! |  j=1, |      T(i=1,         |  j=1,    T(i=Nx,  *(i=Nx+1,
+! |  k=1) |        j=1,         |  k=1)      j=1,   *  |j=1,
+! |       |        k=1)         |            k=1)   *  |k=1)
+! |       |                     |                   *  |
+! |       |        /|\          |            /|\    *  |
+! |       |-------- | -----------------etc..  | ----*---
+! |       |    rVel(i=1,        |        rVel(i=Nx, *  |
+! |       |         j=1,        |             j=1,  *  |
+! |       |         k=2)        |             k=2)  *  |
+! |
+! |       .                     .                      .
+! |       .                     .                      .
+! |       .                     .                      .
+! |       e                     e                   *  e
+! |       t                     t                   *  t
+! |       c                     c                   *  c
+! |       |                     |                   *  |
+! |       |                     |                   *  |
+! |       |                     |                   *  |
+! |       |                     |                   *  |
+! |       |        /|\          |            /|\    *  |
+! |       |-------- | -----------------etc..  | ----*---
+! |       |    rVel(i=1,        |        rVel(i=Nx, *  |
+! |       |         j=1,        |             j=1,  *  |
+! |       |         k=Nr)       |             k=Nr) *  |
+! |U(i=1, ==>       x         ==>U(i=2,       x     *==>U
+! |  j=1, |      T(i=1,         |  j=1,    T(i=Nx,  *(i=Nx+1,
+! |  k=Nr)|        j=1,         |  k=Nr)     j=1,   *  |j=1,
+! |       |        k=Nr)        |            k=Nr)  *  |k=Nr)
+! |       |                     |                   *  |
+! |"LB"++>==============================================
+! |                                               "PWX"
+! |
+! | Up   increasing upwards.
+! |/|\                                                       .
+! | |
+! | |
+! | =====> E  i increasing eastwards
+! | |         x increasing eastwards
+! | |
+! |\|/
+! | Down,k increasing downwards.
+! |
+! | Note: r => height (m) => r increases upwards
+! |       r => pressure (Pa) => r increases downwards
+! |
+! |
+! |    i: East-west index
+! |    j: North-south index
+!     |    k: up-down index
+! |    U: x-velocity (m/s)
+! | rVel: z-velocity ( units of r )
+! |       The vertical velocity variable rVel is in units of
+! |       "r" the vertical coordinate. r in m will give
+! |       rVel m/s. r in Pa will give rVel Pa/s.
+! |    T: potential temperature (oC)
+! | "UB": Upper boundary.
+! | "LB": Lower boundary (always solid - therefore om|w == 0)
+! | "WB": Western boundary
+! |"PWX": Periodic wrap around in X.
+! |----------------------------------------------------------
+! | (3) Views showing nomenclature and indexing
+! |     for grid descriptor variables.
+! |
+! |      Fig 3a. shows the orientation, indexing and
+! |      notation for the grid spacing terms used internally
+! |      for the evaluation of gradient and averaging terms.
+! |      These varaibles are set based on the model input
+! |      parameters which define the model grid in terms of
+! |      spacing in X, Y and Z.
+! |
+! |      Fig 3b. shows the orientation, indexing and
+! |      notation for the variables that are used to define
+! |      the model grid. These varaibles are set directly
+! |      from the model input.
+! |
+! | Figure 3a
+! | =========
+! |       |------------------------------------
+! |       |                       |
+! |"PWY"********************************* etc...
+! |       |                       |
+! |       |                       |
+! |       |                       |
+! |       |                       |
+! |       |                       |
+! |       |                       |
+! |       |                       |
+! |
+! |       .                       .
+! |       .                       .
+! |       .                       .
+! |       e                       e
+! |       t                       t
+! |       c                       c
+! |       |-----------v-----------|-----------v----------|-
+! |       |                       |                      |
+! |       |                       |                      |
+! |       |                       |                      |
+! |       |                       |                      |
+! |       |                       |                      |
+! |       u<--dxF(i=1,j=2,k=1)--->u           t          |
+! |       |/|\       /|\          |                      |
+! |       | |         |           |                      |
+! |       | |         |           |                      |
+! |       | |         |           |                      |
+! |       |dyU(i=1,  dyC(i=1,     |                      |
+! | ---  ---|--j=2,---|--j=2,-----------------v----------|-
+! | /|\   | |  k=1)   |  k=1)     |          /|\         |
+! |  |    | |         |           |          dyF(i=2,    |
+! |  |    | |         |           |           |  j=1,    |
+! |dyG(   |\|/       \|/          |           |  k=1)    |
+! |   i=1,u---        t<---dxC(i=2,j=1,k=1)-->t          |
+! |   j=1,|                       |           |          |
+! |   k=1)|                       |           |          |
+! |  |    |                       |           |          |
+! |  |    |                       |           |          |
+! | \|/   |           |<---dxV(i=2,j=1,k=1)--\|/         |
+! |"SB"++>|___________v___________|___________v__________|_
+! |       <--dxG(i=1,j=1,k=1)----->
+! |      /+\                                              .
+! |       +
+! |       +
+! |     "WB"
+! |
+! |   N, y increasing northwards
+! |  /|\ j increasing northwards
+! |   |
+! |   |
+! |   ======>E, x increasing eastwards
+! |             i increasing eastwards
+! |
+! |    i: East-west index
+! |    j: North-south index
+!     |    k: up-down index
+! |    u: x-velocity point
+! |    V: y-velocity point
+!     |    t: tracer point
+! | "SB": Southern boundary
+! | "WB": Western boundary
+! |"PWX": Periodic wrap around in X.
+! |"PWY": Periodic wrap around in Y.
+! |
+! | Figure 3b
+! | =========
+! |
+! |       .                       .
+! |       .                       .
+! |       .                       .
+! |       e                       e
+! |       t                       t
+! |       c                       c
+! |       |-----------v-----------|-----------v--etc...
+! |       |                       |
+! |       |                       |
+! |       |                       |
+! |       |                       |
+! |       |                       |
+! |       u<--delX(i=1)---------->u           t
+! |       |                       |
+! |       |                       |
+! |       |                       |
+! |       |                       |
+! |       |                       |
+! |       |-----------v-----------------------v--etc...
+! |       |          /|\          |
+! |       |           |           |
+! |       |           |           |
+! |       |           |           |
+! |       u        delY(j=1)      |           t
+! |       |           |           |
+! |       |           |           |
+! |       |           |           |
+! |       |           |           |
+! |       |          \|/          |
+! |"SB"++>|___________v___________|___________v__etc...
+! |      /+\                                                 .
+! |       +
+! |       +
+! |     "WB"
+! |
+! *==========================================================*
+! \ev
+!EOP
 
-C     Macros that override/modify standard definitions
+! Macros that override/modify standard definitions
 #include "GRID_MACROS.h"
 
-C--   COMMON /GRID_RL/ RL valued grid defining variables.
-C     deepFacC  :: deep-model grid factor (fct of vertical only) for dx,dy
-C     deepFacF     at level-center (deepFacC)  and level interface (deepFacF)
-C     deepFac2C :: deep-model grid factor (fct of vertical only) for area dx*dy
-C     deepFac2F    at level-center (deepFac2C) and level interface (deepFac2F)
-C     gravitySign :: indicates the direction of gravity relative to R direction
-C                   (= -1 for R=Z (Z increases upward, -gravity direction  )
-C                   (= +1 for R=P (P increases downward, +gravity direction)
-C     rkSign     :: Vertical coordinate to vertical index orientation.
-C                   ( +1 same orientation, -1 opposite orientation )
-C     globalArea :: Domain Integrated horizontal Area ( m^2 )
-C     rAc_3dMean :: domain 3-d average of grid-cell horizontal area ( m^2 )
-C     n2dWetPts  :: number of non-empty columns (wet free-surface points)
-C     n3dWetPts  :: number of non-empty grid points (wet grid points)
-      COMMON /GRID_RL/
-     &  cosFacU, cosFacV, sqCosFacU, sqCosFacV,
-     &  deepFacC, deepFac2C, recip_deepFacC, recip_deepFac2C,
-     &  deepFacF, deepFac2F, recip_deepFacF, recip_deepFac2F,
-     &  gravitySign, rkSign,
-     &  globalArea, rAc_3dMean, n2dWetPts, n3dWetPts
+!--   COMMON /GRID_RL/ RL valued grid defining variables.
+! deepFacC  :: deep-model grid factor (fct of vertical only) for dx,dy
+! deepFacF     at level-center (deepFacC)  and level interface (deepFacF)
+! deepFac2C :: deep-model grid factor (fct of vertical only) for area dx*dy
+! deepFac2F    at level-center (deepFac2C) and level interface (deepFac2F)
+! gravitySign :: indicates the direction of gravity relative to R direction
+!               (= -1 for R=Z (Z increases upward, -gravity direction  )
+!               (= +1 for R=P (P increases downward, +gravity direction)
+! rkSign     :: Vertical coordinate to vertical index orientation.
+!               ( +1 same orientation, -1 opposite orientation )
+! globalArea :: Domain Integrated horizontal Area ( m^2 )
+! rAc_3dMean :: domain 3-d average of grid-cell horizontal area ( m^2 )
+! n2dWetPts  :: number of non-empty columns (wet free-surface points)
+!     n3dWetPts  :: number of non-empty grid points (wet grid points)
+      COMMON /GRID_RL/                                                            &
+     &      cosFacU, cosFacV, sqCosFacU, sqCosFacV,                               &
+     &      deepFacC, deepFac2C, recip_deepFacC, recip_deepFac2C,                 &
+     &      deepFacF, deepFac2F, recip_deepFacF, recip_deepFac2F,                 &
+     &      gravitySign, rkSign,                                                  &
+     &      globalArea, rAc_3dMean, n2dWetPts, n3dWetPts
       _RL cosFacU        (1-OLy:sNy+OLy,nSx,nSy)
       _RL cosFacV        (1-OLy:sNy+OLy,nSx,nSy)
       _RL sqCosFacU      (1-OLy:sNy+OLy,nSx,nSy)
@@ -334,101 +334,101 @@ C     n3dWetPts  :: number of non-empty grid points (wet grid points)
       _RL globalArea, rAc_3dMean
       _RL n2dWetPts, n3dWetPts
 
-C--   COMMON /GRID_RS/ RS valued grid defining variables.
-C     dxC     :: Cell center separation in X across western cell wall (m)
-C     dxG     :: Cell face separation in X along southern cell wall (m)
-C     dxF     :: Cell face separation in X thru cell center (m)
-C     dxV     :: V-point separation in X across south-west corner of cell (m)
-C     dyC     :: Cell center separation in Y across southern cell wall (m)
-C     dyG     :: Cell face separation in Y along western cell wall (m)
-C     dyF     :: Cell face separation in Y thru cell center (m)
-C     dyU     :: U-point separation in Y across south-west corner of cell (m)
-C     drC     :: Cell center separation along Z axis ( units of r ).
-C     drF     :: Cell face separation along Z axis ( units of r ).
-C     R_low   :: base of fluid in r_unit (Depth(m) / Pressure(Pa) at top Atmos.)
-C     rLowW   :: base of fluid column in r_unit at Western  edge location.
-C     rLowS   :: base of fluid column in r_unit at Southern edge location.
-C     Ro_surf :: surface reference (at rest) position, r_unit.
-C     rSurfW  :: surface reference position at Western  edge location [r_unit].
-C     rSurfS  :: surface reference position at Southern edge location [r_unit].
-C     hFac    :: Fraction of cell in vertical which is open i.e how
-C              "lopped" a cell is (dimensionless scale factor).
-C              Note: The code needs terms like MIN(hFac,hFac(I-1))
-C                    On some platforms it may be better to precompute
-C                    hFacW, hFacS, ... here than do MIN on the fly.
-C     maskInC :: Cell Center 2-D Interior mask (i.e., zero beyond OB)
-C     maskInW :: West  face 2-D Interior mask (i.e., zero on and beyond OB)
-C     maskInS :: South face 2-D Interior mask (i.e., zero on and beyond OB)
-C     maskC   :: cell Center land mask
-C     maskW   :: West face land mask
-C     maskS   :: South face land mask
-C     recip_dxC   :: Reciprocal of dxC
-C     recip_dxG   :: Reciprocal of dxG
-C     recip_dxF   :: Reciprocal of dxF
-C     recip_dxV   :: Reciprocal of dxV
-C     recip_dyC   :: Reciprocal of dxC
-C     recip_dyG   :: Reciprocal of dyG
-C     recip_dyF   :: Reciprocal of dyF
-C     recip_dyU   :: Reciprocal of dyU
-C     recip_drC   :: Reciprocal of drC
-C     recip_drF   :: Reciprocal of drF
-C     recip_Rcol  :: Inverse of cell center column thickness (1/r_unit)
-C     recip_hFacC :: Inverse of cell open-depth f[X,Y,Z] ( dimensionless ).
-C     recip_hFacW    rhFacC center, rhFacW west, rhFacS south.
-C     recip_hFacS   Note: This is precomputed here because it involves division.
-C     xC     :: X-coordinate of cell center f[X,Y]. The units of xc, yc
-C               depend on the grid. They are not used in differencing or
-C               averaging but are just a convient quantity for I/O,
-C               diagnostics etc.. As such xc is in m for cartesian
-C               coordinates but degrees for spherical polar.
-C     yC     :: Y-coordinate of center of cell f[X,Y].
-C     yG     :: Y-coordinate of corner of cell (c-grid vorticity point) f[X,Y].
-C     rA     :: R-face are f[X,Y] ( m^2 ).
-C               Note: In a cartesian framework rA is simply dx*dy,
-C                   however we use rA to allow for non-globally
-C                   orthogonal coordinate frames (with appropriate
-C                   metric terms).
-C     rC     :: R-coordinate of center of cell f[Z] (units of r).
-C     rF     :: R-coordinate of face of cell f[Z] (units of r).
-C - *HybSigm* - :: Hybrid-Sigma vert. Coord coefficients
-C     aHybSigmF    at level-interface (*HybSigmF) and level-center (*HybSigmC)
-C     aHybSigmC    aHybSigm* = constant r part, bHybSigm* = sigma part, such as
-C     bHybSigmF    r(ij,k,t) = rLow(ij) + aHybSigm(k)*[rF(1)-rF(Nr+1)]
-C     bHybSigmC              + bHybSigm(k)*[eta(ij,t)+Ro_surf(ij) - rLow(ij)]
-C     dAHybSigF :: vertical increment of Hybrid-Sigma coeff.: constant r part,
-C     dAHybSigC    between interface (dAHybSigF) and between center (dAHybSigC)
-C     dBHybSigF :: vertical increment of Hybrid-Sigma coefficient: sigma part,
-C     dBHybSigC    between interface (dBHybSigF) and between center (dBHybSigC)
-C     tanPhiAtU :: tan of the latitude at U point. Used for spherical polar
-C                  metric term in U equation.
-C     tanPhiAtV :: tan of the latitude at V point. Used for spherical polar
-C                  metric term in V equation.
-C     angleCosC :: cosine of grid orientation angle relative to Geographic
-C direction at cell center: alpha=(Eastward_dir,grid_uVel_dir)=(North_d,vVel_d)
-C     angleSinC :: sine   of grid orientation angle relative to Geographic
-C direction at cell center: alpha=(Eastward_dir,grid_uVel_dir)=(North_d,vVel_d)
-C     u2zonDir  :: cosine of grid orientation angle at U point location
-C     v2zonDir  :: minus sine of  orientation angle at V point location
-C     fCori     :: Coriolis parameter at grid Center point
-C     fCoriG    :: Coriolis parameter at grid Corner point
-C     fCoriCos  :: Coriolis Cos(phi) parameter at grid Center point (for NH)
+!--   COMMON /GRID_RS/ RS valued grid defining variables.
+! dxC     :: Cell center separation in X across western cell wall (m)
+! dxG     :: Cell face separation in X along southern cell wall (m)
+! dxF     :: Cell face separation in X thru cell center (m)
+! dxV     :: V-point separation in X across south-west corner of cell (m)
+! dyC     :: Cell center separation in Y across southern cell wall (m)
+!     dyG     :: Cell face separation in Y along western cell wall (m)
+! dyF     :: Cell face separation in Y thru cell center (m)
+! dyU     :: U-point separation in Y across south-west corner of cell (m)
+! drC     :: Cell center separation along Z axis ( units of r ).
+! drF     :: Cell face separation along Z axis ( units of r ).
+! R_low   :: base of fluid in r_unit (Depth(m) / Pressure(Pa) at top Atmos.)
+! rLowW   :: base of fluid column in r_unit at Western  edge location.
+! rLowS   :: base of fluid column in r_unit at Southern edge location.
+! Ro_surf :: surface reference (at rest) position, r_unit.
+! rSurfW  :: surface reference position at Western  edge location [r_unit].
+! rSurfS  :: surface reference position at Southern edge location [r_unit].
+! hFac    :: Fraction of cell in vertical which is open i.e how
+!          "lopped" a cell is (dimensionless scale factor).
+!          Note: The code needs terms like MIN(hFac,hFac(I-1))
+!                On some platforms it may be better to precompute
+!                hFacW, hFacS, ... here than do MIN on the fly.
+! maskInC :: Cell Center 2-D Interior mask (i.e., zero beyond OB)
+! maskInW :: West  face 2-D Interior mask (i.e., zero on and beyond OB)
+! maskInS :: South face 2-D Interior mask (i.e., zero on and beyond OB)
+! maskC   :: cell Center land mask
+! maskW   :: West face land mask
+! maskS   :: South face land mask
+! recip_dxC   :: Reciprocal of dxC
+! recip_dxG   :: Reciprocal of dxG
+! recip_dxF   :: Reciprocal of dxF
+! recip_dxV   :: Reciprocal of dxV
+! recip_dyC   :: Reciprocal of dxC
+! recip_dyG   :: Reciprocal of dyG
+! recip_dyF   :: Reciprocal of dyF
+! recip_dyU   :: Reciprocal of dyU
+! recip_drC   :: Reciprocal of drC
+! recip_drF   :: Reciprocal of drF
+! recip_Rcol  :: Inverse of cell center column thickness (1/r_unit)
+! recip_hFacC :: Inverse of cell open-depth f[X,Y,Z] ( dimensionless ).
+! recip_hFacW    rhFacC center, rhFacW west, rhFacS south.
+! recip_hFacS   Note: This is precomputed here because it involves division.
+! xC     :: X-coordinate of cell center f[X,Y]. The units of xc, yc
+!           depend on the grid. They are not used in differencing or
+!           averaging but are just a convient quantity for I/O,
+!           diagnostics etc.. As such xc is in m for cartesian
+!           coordinates but degrees for spherical polar.
+! yC     :: Y-coordinate of center of cell f[X,Y].
+! yG     :: Y-coordinate of corner of cell (c-grid vorticity point) f[X,Y].
+! rA     :: R-face are f[X,Y] ( m^2 ).
+!           Note: In a cartesian framework rA is simply dx*dy,
+!               however we use rA to allow for non-globally
+!               orthogonal coordinate frames (with appropriate
+!               metric terms).
+! rC     :: R-coordinate of center of cell f[Z] (units of r).
+! rF     :: R-coordinate of face of cell f[Z] (units of r).
+! - *HybSigm* - :: Hybrid-Sigma vert. Coord coefficients
+! aHybSigmF    at level-interface (*HybSigmF) and level-center (*HybSigmC)
+! aHybSigmC    aHybSigm* = constant r part, bHybSigm* = sigma part, such as
+! bHybSigmF    r(ij,k,t) = rLow(ij) + aHybSigm(k)*[rF(1)-rF(Nr+1)]
+! bHybSigmC              + bHybSigm(k)*[eta(ij,t)+Ro_surf(ij) - rLow(ij)]
+! dAHybSigF :: vertical increment of Hybrid-Sigma coeff.: constant r part,
+! dAHybSigC    between interface (dAHybSigF) and between center (dAHybSigC)
+! dBHybSigF :: vertical increment of Hybrid-Sigma coefficient: sigma part,
+! dBHybSigC    between interface (dBHybSigF) and between center (dBHybSigC)
+! tanPhiAtU :: tan of the latitude at U point. Used for spherical polar
+!              metric term in U equation.
+! tanPhiAtV :: tan of the latitude at V point. Used for spherical polar
+!              metric term in V equation.
+! angleCosC :: cosine of grid orientation angle relative to Geographic
+! direction at cell center: alpha=(Eastward_dir,grid_uVel_dir)=(North_d,vVel_d)
+! angleSinC :: sine   of grid orientation angle relative to Geographic
+! direction at cell center: alpha=(Eastward_dir,grid_uVel_dir)=(North_d,vVel_d)
+! u2zonDir  :: cosine of grid orientation angle at U point location
+! v2zonDir  :: minus sine of  orientation angle at V point location
+! fCori     :: Coriolis parameter at grid Center point
+! fCoriG    :: Coriolis parameter at grid Corner point
+! fCoriCos  :: Coriolis Cos(phi) parameter at grid Center point (for NH)
 
-      COMMON /GRID_RS/
-     &  dxC,dxF,dxG,dxV,dyC,dyF,dyG,dyU,
-     &  rLowW, rLowS,
-     &  Ro_surf, rSurfW, rSurfS,
-     &  recip_dxC,recip_dxF,recip_dxG,recip_dxV,
-     &  recip_dyC,recip_dyF,recip_dyG,recip_dyU,
-     &  xC,yC,rA,rAw,rAs,rAz,xG,yG,
-     &  maskInC, maskInW, maskInS,
-     &  maskC, maskW, maskS,
-     &  recip_rA,recip_rAw,recip_rAs,recip_rAz,
-     &  drC, drF, recip_drC, recip_drF, rC, rF,
-     &  aHybSigmF, bHybSigmF, aHybSigmC, bHybSigmC,
-     &  dAHybSigF, dBHybSigF, dBHybSigC, dAHybSigC,
-     &  tanPhiAtU, tanPhiAtV,
-     &  angleCosC, angleSinC, u2zonDir, v2zonDir,
-     &  fCori, fCoriG, fCoriCos
+      COMMON /GRID_RS/                                                            &
+     &      dxC,dxF,dxG,dxV,dyC,dyF,dyG,dyU,                                      &
+     &      rLowW, rLowS,                                                         &
+     &      Ro_surf, rSurfW, rSurfS,                                              &
+     &      recip_dxC,recip_dxF,recip_dxG,recip_dxV,                              &
+     &      recip_dyC,recip_dyF,recip_dyG,recip_dyU,                              &
+     &      xC,yC,rA,rAw,rAs,rAz,xG,yG,                                           &
+     &      maskInC, maskInW, maskInS,                                            &
+     &      maskC, maskW, maskS,                                                  &
+     &      recip_rA,recip_rAw,recip_rAs,recip_rAz,                               &
+     &      drC, drF, recip_drC, recip_drF, rC, rF,                               &
+     &      aHybSigmF, bHybSigmF, aHybSigmC, bHybSigmC,                           &
+     &      dAHybSigF, dBHybSigF, dBHybSigC, dAHybSigC,                           &
+     &      tanPhiAtU, tanPhiAtV,                                                 &
+     &      angleCosC, angleSinC, u2zonDir, v2zonDir,                             &
+     &      fCori, fCoriG, fCoriCos
       _RS dxC            (1-OLx:sNx+OLx,1-OLy:sNy+OLy,nSx,nSy)
       _RS dxF            (1-OLx:sNx+OLx,1-OLy:sNy+OLy,nSx,nSy)
       _RS dxG            (1-OLx:sNx+OLx,1-OLy:sNy+OLy,nSx,nSy)
@@ -492,15 +492,15 @@ C     fCoriCos  :: Coriolis Cos(phi) parameter at grid Center point (for NH)
       _RS fCoriG         (1-OLx:sNx+OLx,1-OLy:sNy+OLy,nSx,nSy)
       _RS fCoriCos       (1-OLx:sNx+OLx,1-OLy:sNy+OLy,nSx,nSy)
 
-C--   COMMON /GRID_VAR_RS/ potentially time-dependent or active RS
-C     valued grid defining variables. These grid defining variables are
-C     time-dependent when using a non-linear free surface, or they are
-C     active in an AD sense when using depth as a control parameter, or
-C     both.
-      COMMON /GRID_VAR_RS/
-     &  hFacC, hFacW, hFacS,
-     &  recip_hFacC,recip_hFacW,recip_hFacS,
-     &  R_low, recip_Rcol
+!--   COMMON /GRID_VAR_RS/ potentially time-dependent or active RS
+! valued grid defining variables. These grid defining variables are
+! time-dependent when using a non-linear free surface, or they are
+! active in an AD sense when using depth as a control parameter, or
+! both.
+      COMMON /GRID_VAR_RS/                                                        &
+     &      hFacC, hFacW, hFacS,                                                  &
+     &      recip_hFacC,recip_hFacW,recip_hFacS,                                  &
+     &      R_low, recip_Rcol
       _RS hFacC          (1-OLx:sNx+OLx,1-OLy:sNy+OLy,Nr,nSx,nSy)
       _RS hFacW          (1-OLx:sNx+OLx,1-OLy:sNy+OLy,Nr,nSx,nSy)
       _RS hFacS          (1-OLx:sNx+OLx,1-OLy:sNy+OLy,Nr,nSx,nSy)
@@ -511,26 +511,26 @@ C     both.
       _RS recip_Rcol     (1-OLx:sNx+OLx,1-OLy:sNy+OLy,nSx,nSy)
 
 #ifdef ALLOW_DEPTH_CONTROL
-C--   COMMON /GRID_DEPTH_CTRL/ grid defining variables for Depth Control code.
-C     xx_r_low  :: in TAF-sense active replacement of R_low
-      COMMON /GRID_DEPTH_CTRL/
-     &  xx_r_low
+!--   COMMON /GRID_DEPTH_CTRL/ grid defining variables for Depth Control code.
+! xx_r_low  :: in TAF-sense active replacement of R_low
+      COMMON /GRID_DEPTH_CTRL/                                                    &
+     &      xx_r_low
       _RL xx_r_low       (1-OLx:sNx+OLx,1-OLy:sNy+OLy,nSx,nSy)
 #endif /* ALLOW_DEPTH_CONTROL */
 
-C--   COMMON /GRID_I/ INTEGER valued grid defining variables.
-C     kSurfC  :: vertical index of the surface tracer cell
-C     kSurfW  :: vertical index of the surface U point
-C     kSurfS  :: vertical index of the surface V point
-C     kLowC   :: index of the r-lowest "wet cell" (2D)
-C IMPORTANT: kLowC = 0 and kSurfC,W,S = Nr+1 (or =Nr+2 on a thin-wall)
-C            where the fluid column is empty (continent)
-      COMMON /GRID_I/
-     &  kSurfC, kSurfW, kSurfS,
-     &  kLowC
-      INTEGER kSurfC(1-OLx:sNx+OLx,1-OLy:sNy+OLy,nSx,nSy)
-      INTEGER kSurfW(1-OLx:sNx+OLx,1-OLy:sNy+OLy,nSx,nSy)
-      INTEGER kSurfS(1-OLx:sNx+OLx,1-OLy:sNy+OLy,nSx,nSy)
-      INTEGER kLowC (1-OLx:sNx+OLx,1-OLy:sNy+OLy,nSx,nSy)
+!--   COMMON /GRID_I/ INTEGER valued grid defining variables.
+! kSurfC  :: vertical index of the surface tracer cell
+! kSurfW  :: vertical index of the surface U point
+! kSurfS  :: vertical index of the surface V point
+! kLowC   :: index of the r-lowest "wet cell" (2D)
+! IMPORTANT: kLowC = 0 and kSurfC,W,S = Nr+1 (or =Nr+2 on a thin-wall)
+!        where the fluid column is empty (continent)
+      COMMON /GRID_I/                                                             &
+     &      kSurfC, kSurfW, kSurfS,                                               &
+     &      kLowC
+      INTEGER :: kSurfC(1-OLx:sNx+OLx,1-OLy:sNy+OLy,nSx,nSy)
+      INTEGER :: kSurfW(1-OLx:sNx+OLx,1-OLy:sNy+OLy,nSx,nSy)
+      INTEGER :: kSurfS(1-OLx:sNx+OLx,1-OLy:sNy+OLy,nSx,nSy)
+      INTEGER :: kLowC (1-OLx:sNx+OLx,1-OLy:sNy+OLy,nSx,nSy)
 
-C---+----1----+----2----+----3----+----4----+----5----+----6----+----7-|--+----|
+!---+----1----+----2----+----3----+----4----+----5----+----6----+----7-|--+----|

--- a/model/inc/GRID_MACROS.h
+++ b/model/inc/GRID_MACROS.h
@@ -1,27 +1,27 @@
-C
-CBOP
-C    !ROUTINE: GRID_MACROS.h
-C    !INTERFACE:
-C    include GRID_MACROS.h
-C    !DESCRIPTION: \bv
-C     *==========================================================*
-C     | GRID_MACROS.h
-C     *==========================================================*
-C     | These macros are used to substitute definitions for
-C     | GRID.h variables for particular configurations.
-C     | In setting these variables the following convention
-C     | applies.
-C     | undef  phi_CONST   - Indicates the variable phi is fixed
-C     |                      in X, Y and Z.
-C     | undef  phi_FX      - Indicates the variable phi only
-C     |                      varies in X (i.e.not in X or Z).
-C     | undef  phi_FY      - Indicates the variable phi only
-C     |                      varies in Y (i.e.not in X or Z).
-C     | undef  phi_FXY     - Indicates the variable phi only
-C     |                      varies in X and Y ( i.e. not Z).
-C     *==========================================================*
-C     \ev
-CEOP
+!
+!BOP
+!    !ROUTINE: GRID_MACROS.h
+!    !INTERFACE:
+!    include GRID_MACROS.h
+!    !DESCRIPTION: \bv
+! *==========================================================*
+! | GRID_MACROS.h
+! *==========================================================*
+! | These macros are used to substitute definitions for
+! | GRID.h variables for particular configurations.
+! | In setting these variables the following convention
+! | applies.
+! | undef  phi_CONST   - Indicates the variable phi is fixed
+! |                      in X, Y and Z.
+! | undef  phi_FX      - Indicates the variable phi only
+! |                      varies in X (i.e.not in X or Z).
+! | undef  phi_FY      - Indicates the variable phi only
+! |                      varies in Y (i.e.not in X or Z).
+! | undef  phi_FXY     - Indicates the variable phi only
+! |                      varies in X and Y ( i.e. not Z).
+! *==========================================================*
+! \ev
+!EOP
 
 #undef    DXC_CONST
 #undef    DXC_FX

--- a/model/inc/HFACC_MACROS.h
+++ b/model/inc/HFACC_MACROS.h
@@ -1,18 +1,18 @@
-C
-CBOP
-C    !ROUTINE: HFACC_MACROS.h
-C    !INTERFACE:
-C    include HFACC_MACROS.h
-C    !DESCRIPTION: \bv
-C     *==========================================================*
-C     | HFACC_MACROS.h                                            
-C     *==========================================================*
-C     | These macros are used to reduce memory requirement and/or 
-C     | memory references when variables are fixed along a given  
-C     | axis or axes.                                             
-C     *==========================================================*
-C     \ev
-CEOP
+!
+!BOP
+!    !ROUTINE: HFACC_MACROS.h
+!    !INTERFACE:
+!    include HFACC_MACROS.h
+!    !DESCRIPTION: \bv
+! *==========================================================*
+! | HFACC_MACROS.h
+! *==========================================================*
+! | These macros are used to reduce memory requirement and/or
+! | memory references when variables are fixed along a given
+! | axis or axes.
+! *==========================================================*
+! \ev
+!EOP
 
 #ifdef HFACC_CONST
 #define  _hFacC(i,j,k,bi,bj) hFacC(1,1,1,1,1)

--- a/model/inc/HFACS_MACROS.h
+++ b/model/inc/HFACS_MACROS.h
@@ -1,18 +1,18 @@
-C
-CBOP
-C    !ROUTINE: HFACS_MACROS.h
-C    !INTERFACE:
-C    include HFACS_MACROS.h
-C    !DESCRIPTION: \bv
-C     *==========================================================*
-C     | HFACS_MACROS.h                                            
-C     *==========================================================*
-C     | These macros are used to reduce memory requirement and/or 
-C     | memory references when variables are fixed along a given  
-C     | axis or axes.                                             
-C     *==========================================================*
-C     \ev
-CEOP
+!
+!BOP
+!    !ROUTINE: HFACS_MACROS.h
+!    !INTERFACE:
+!    include HFACS_MACROS.h
+!    !DESCRIPTION: \bv
+! *==========================================================*
+! | HFACS_MACROS.h
+! *==========================================================*
+! | These macros are used to reduce memory requirement and/or
+! | memory references when variables are fixed along a given
+! | axis or axes.
+! *==========================================================*
+! \ev
+!EOP
 
 #ifdef HFACS_CONST
 #define  _hFacS(i,j,k,bi,bj) hFacS(1,1,1,1,1)

--- a/model/inc/HFACW_MACROS.h
+++ b/model/inc/HFACW_MACROS.h
@@ -1,18 +1,18 @@
-C
-CBOP
-C    !ROUTINE: HFACW_MACROS.h
-C    !INTERFACE:
-C    include HFACW_MACROS.h
-C    !DESCRIPTION: \bv
-C     *==========================================================*
-C     | HFACW_MACROS.h                                            
-C     *==========================================================*
-C     | These macros are used to reduce memory requirement and/or 
-C     | memory references when variables are fixed along a given  
-C     | axis or axes.                                             
-C     *==========================================================*
-C     \ev
-CEOP
+!
+!BOP
+!    !ROUTINE: HFACW_MACROS.h
+!    !INTERFACE:
+!    include HFACW_MACROS.h
+!    !DESCRIPTION: \bv
+! *==========================================================*
+! | HFACW_MACROS.h
+! *==========================================================*
+! | These macros are used to reduce memory requirement and/or
+! | memory references when variables are fixed along a given
+! | axis or axes.
+! *==========================================================*
+! \ev
+!EOP
 
 #ifdef HFACW_CONST
 #define  _hFacW(i,j,k,bi,bj) hFacW(1,1,1,1,1)

--- a/model/inc/MASKS_MACROS.h
+++ b/model/inc/MASKS_MACROS.h
@@ -1,18 +1,18 @@
-C
-CBOP
-C    !ROUTINE: MASKS_MACROS.h
-C    !INTERFACE:
-C    include MASKS_MACROS.h
-C    !DESCRIPTION: \bv
-C     *==========================================================*
-C     | MASKS_MACROS.h                                            
-C     *==========================================================*
-C     | These macros are used to reduce memory requirement and/or 
-C     | memory references when variables are fixed along a given  
-C     | axis or axes.                                             
-C     *==========================================================*
-C     \ev
-CEOP
+!
+!BOP
+!    !ROUTINE: MASKS_MACROS.h
+!    !INTERFACE:
+!    include MASKS_MACROS.h
+!    !DESCRIPTION: \bv
+! *==========================================================*
+! | MASKS_MACROS.h
+! *==========================================================*
+! | These macros are used to reduce memory requirement and/or
+! | memory references when variables are fixed along a given
+! | axis or axes.
+! *==========================================================*
+! \ev
+!EOP
 
 #ifdef MASKS_CONST
 #define  _maskS(i,j,k,bi,bj) maskS(1,1,1,1,1)

--- a/model/inc/MASKW_MACROS.h
+++ b/model/inc/MASKW_MACROS.h
@@ -1,18 +1,18 @@
-C
-CBOP
-C    !ROUTINE: MASKW_MACROS.h
-C    !INTERFACE:
-C    include MASKW_MACROS.h
-C    !DESCRIPTION: \bv
-C     *==========================================================*
-C     | MASKW_MACROS.h                                            
-C     *==========================================================*
-C     | These macros are used to reduce memory requirement and/or 
-C     | memory references when variables are fixed along a given  
-C     | axis or axes.                                             
-C     *==========================================================*
-C     \ev
-CEOP
+!
+!BOP
+!    !ROUTINE: MASKW_MACROS.h
+!    !INTERFACE:
+!    include MASKW_MACROS.h
+!    !DESCRIPTION: \bv
+! *==========================================================*
+! | MASKW_MACROS.h
+! *==========================================================*
+! | These macros are used to reduce memory requirement and/or
+! | memory references when variables are fixed along a given
+! | axis or axes.
+! *==========================================================*
+! \ev
+!EOP
 
 #ifdef MASKW_CONST
 #define  _maskW(i,j,k,bi,bj) maskW(1,1,1,1,1)

--- a/model/inc/NH_VARS.h
+++ b/model/inc/NH_VARS.h
@@ -1,35 +1,35 @@
-CBOP
-C     !ROUTINE: NH_VARS.h
-C     !INTERFACE:
-C     include "NH_VARS.h"
-C     !DESCRIPTION:
-C     \bv
-C     *==========================================================*
-C     | NH_VARS.h
-C     | o Additional state variables for non-hydrostatic model
-C     |   and Quasi-Hydrostatic time-stepping
-C     *==========================================================*
-C     | In N-H mode, wVel becomes a prognostic variable: need
-C     | to hold two levels of time tendency for w (for AB)
-C     *==========================================================*
-C     \ev
-CEOP
+!BOP
+! !ROUTINE: NH_VARS.h
+! !INTERFACE:
+! include "NH_VARS.h"
+! !DESCRIPTION:
+! \bv
+! *==========================================================*
+! | NH_VARS.h
+! | o Additional state variables for non-hydrostatic model
+! |   and Quasi-Hydrostatic time-stepping
+! *==========================================================*
+! | In N-H mode, wVel becomes a prognostic variable: need
+! | to hold two levels of time tendency for w (for AB)
+! *==========================================================*
+! \ev
+!EOP
 
 #ifdef ALLOW_NONHYDROSTATIC
-C--   COMMON /NH_VARS_R/ REAL NH state variables
-C     phi_nh    :: Non-hydrostatic potential (=NH-Pressure/rhoConst)
-C     dPhiNH    :: Surface-Hydrostatic correction to Non-hydrostatic Phi
-C     gW, gwNm1 :: Time tendencies at current and previous time levels.
-C     viscA?_W  :: Horizontal variable viscosities
+!--   COMMON /NH_VARS_R/ REAL NH state variables
+! phi_nh    :: Non-hydrostatic potential (=NH-Pressure/rhoConst)
+! dPhiNH    :: Surface-Hydrostatic correction to Non-hydrostatic Phi
+! gW, gwNm1 :: Time tendencies at current and previous time levels.
+! viscA?_W  :: Horizontal variable viscosities
 
 #ifdef ALLOW_ADAMSBASHFORTH_3
-      COMMON /NH_VARS_R/
-     &                   phi_nh, dPhiNH,
-     &                   gW, gwNm
+      COMMON /NH_VARS_R/                                                          &
+     &      phi_nh, dPhiNH,                                                       &
+     &      gW, gwNm
 #else /* ALLOW_ADAMSBASHFORTH_3 */
-      COMMON /NH_VARS_R/
-     &                   phi_nh, dPhiNH,
-     &                   gW, gwNm1
+      COMMON /NH_VARS_R/                                                          &
+     &      phi_nh, dPhiNH,                                                       &
+     &      gW, gwNm1
 #endif /* ALLOW_ADAMSBASHFORTH_3 */
       _RL  phi_nh(1-OLx:sNx+OLx,1-OLy:sNy+OLy,Nr,nSx,nSy)
       _RL  dPhiNH(1-OLx:sNx+OLx,1-OLy:sNy+OLy,   nSx,nSy)
@@ -43,11 +43,11 @@ C     viscA?_W  :: Horizontal variable viscosities
 #endif /* ALLOW_NONHYDROSTATIC */
 
 #ifdef ALLOW_QHYD_STAGGER_TS
-C--   COMMON /NH_VARS_QH_AB/ Quasi-Hydrostatic Adams-Bashforth variables
-C     QHydGwNm  :: QuasiHydrostatic vertical acceleration to add to Buoyancy at
-C                  previous time-step for AB with staggerTimeStep (units: m/s^2)
-      COMMON /NH_VARS_QH_AB/
-     &                   QHydGwNm
+!--   COMMON /NH_VARS_QH_AB/ Quasi-Hydrostatic Adams-Bashforth variables
+! QHydGwNm  :: QuasiHydrostatic vertical acceleration to add to Buoyancy at
+!              previous time-step for AB with staggerTimeStep (units: m/s^2)
+      COMMON /NH_VARS_QH_AB/                                                      &
+     &      QHydGwNm
 # ifdef ALLOW_ADAMSBASHFORTH_3
       _RL  QHydGwNm(1-OLx:sNx+OLx,1-OLy:sNy+OLy,Nr,nSx,nSy,2)
 # else /* ALLOW_ADAMSBASHFORTH_3 */

--- a/model/inc/PARAMS.h
+++ b/model/inc/PARAMS.h
@@ -1,109 +1,109 @@
-CBOP
-C     !ROUTINE: PARAMS.h
-C     !INTERFACE:
-C     #include PARAMS.h
+!BOP
+! !ROUTINE: PARAMS.h
+! !INTERFACE:
+! #include PARAMS.h
 
-C     !DESCRIPTION:
-C     Header file defining model "parameters".  The values from the
-C     model standard input file are stored into the variables held
-C     here. Notes describing the parameters can also be found here.
+! !DESCRIPTION:
+! Header file defining model "parameters".  The values from the
+! model standard input file are stored into the variables held
+! here. Notes describing the parameters can also be found here.
 
-CEOP
+!EOP
 
-C--   Contants
-C     Useful physical values
-      Real*8 PI
+!--   Contants
+! Useful physical values
+      Real(kind=8) :: PI
       PARAMETER ( PI    = 3.14159265358979323844D0   )
-      Real*8 deg2rad
+      Real(kind=8) :: deg2rad
       PARAMETER ( deg2rad = 2.D0*PI/360.D0           )
 
-C--   COMMON /PARM_C/ Character valued parameters used by the model.
-C     buoyancyRelation :: Flag used to indicate which relation to use to
-C                         get buoyancy.
-C     eosType         :: choose the equation of state:
-C                        LINEAR, POLY3, UNESCO, JMD95Z, JMD95P, MDJWF, IDEALGAS
-C     pickupSuff      :: force to start from pickup files (even if nIter0=0)
-C                        and read pickup files with this suffix (max 10 Char.)
-C     mdsioLocalDir   :: read-write tiled file from/to this directory name
-C                        (+ 4 digits Processor-Rank) instead of current dir.
-C     adTapeDir       :: read-write checkpointing tape files from/to this
-C                        directory name instead of current dir. Conflicts
-C                        mdsioLocalDir, so only one of the two can be set.
-C     tRefFile      :: File containing reference Potential Temperat.  tRef (1.D)
-C     sRefFile      :: File containing reference salinity/spec.humid. sRef (1.D)
-C     rhoRefFile    :: File containing reference density profile rhoRef (1.D)
-C     gravityFile   :: File containing gravity vertical profile (1.D)
-C     delRFile      :: File containing vertical grid spacing delR  (1.D array)
-C     delRcFile     :: File containing vertical grid spacing delRc (1.D array)
-C     hybSigmFile   :: File containing hybrid-sigma vertical coord. coeff. (2x 1.D)
-C     delXFile      :: File containing X-spacing grid definition (1.D array)
-C     delYFile      :: File containing Y-spacing grid definition (1.D array)
-C     horizGridFile :: File containing horizontal-grid definition
-C                        (only when using curvilinear_grid)
-C     bathyFile       :: File containing bathymetry. If not defined bathymetry
-C                        is taken from inline function.
-C     topoFile        :: File containing the topography of the surface (unit=m)
-C                        (mainly used for the atmosphere = ground height).
-C     addWwallFile    :: File containing 2-D additional Western  cell-edge wall
-C     addSwallFile    :: File containing 2-D additional Southern cell-edge wall
-C                        (e.g., to add "thin-wall" where it is =1)
-C     hydrogThetaFile :: File containing initial hydrographic data (3-D)
-C                        for potential temperature.
-C     hydrogSaltFile  :: File containing initial hydrographic data (3-D)
-C                        for salinity.
-C     diffKrFile      :: File containing 3D specification of vertical diffusivity
-C     viscAhDfile     :: File containing 3D specification of horizontal viscosity
-C     viscAhZfile     :: File containing 3D specification of horizontal viscosity
-C     viscA4Dfile     :: File containing 3D specification of horizontal viscosity
-C     viscA4Zfile     :: File containing 3D specification of horizontal viscosity
-C     zonalWindFile   :: File containing zonal wind data
-C     meridWindFile   :: File containing meridional wind data
-C     thetaClimFile   :: File containing surface theta climataology used
-C                        in relaxation term -lambda(theta-theta*)
-C     saltClimFile    :: File containing surface salt climataology used
-C                        in relaxation term -lambda(salt-salt*)
-C     surfQfile       :: File containing surface heat flux, excluding SW
-C                        (old version, kept for backward compatibility)
-C     surfQnetFile    :: File containing surface net heat flux
-C     surfQswFile     :: File containing surface shortwave radiation
-C     EmPmRfile       :: File containing surface fresh water flux
-C           NOTE: for backward compatibility EmPmRfile is specified in
-C                 m/s when using external_fields_load.F.  It is converted
-C                 to kg/m2/s by multiplying by rhoConstFresh.
-C     saltFluxFile    :: File containing surface salt flux
-C     pLoadFile       :: File containing pressure loading
-C     geoPotAnomFile  :: File containing constant geopotential anomaly due to
-C                        density structure
-C     addMassFile     :: File containing source/sink of fluid in the interior
-C     eddyPsiXFile    :: File containing zonal Eddy streamfunction data
-C     eddyPsiYFile    :: File containing meridional Eddy streamfunction data
-C     geothermalFile  :: File containing geothermal heat flux
-C     lambdaThetaFile :: File containing SST relaxation coefficient
-C     lambdaSaltFile  :: File containing SSS relaxation coefficient
-C     wghtBalanceFile :: File containing weight used in balancing net EmPmR
-C     the_run_name    :: string identifying the name of the model "run"
-      COMMON /PARM_C/
-     &                buoyancyRelation, eosType,
-     &                pickupSuff, mdsioLocalDir, adTapeDir,
-     &                tRefFile, sRefFile, rhoRefFile, gravityFile,
-     &                delRFile, delRcFile, hybSigmFile,
-     &                delXFile, delYFile, horizGridFile,
-     &                bathyFile, topoFile, addWwallFile, addSwallFile,
-     &                viscAhDfile, viscAhZfile,
-     &                viscA4Dfile, viscA4Zfile,
-     &                hydrogThetaFile, hydrogSaltFile, diffKrFile,
-     &                zonalWindFile, meridWindFile, thetaClimFile,
-     &                saltClimFile,
-     &                EmPmRfile, saltFluxFile,
-     &                surfQfile, surfQnetFile, surfQswFile,
-     &                uVelInitFile, vVelInitFile, pSurfInitFile,
-     &                pLoadFile, geoPotAnomFile, addMassFile,
-     &                eddyPsiXFile, eddyPsiYFile, geothermalFile,
-     &                lambdaThetaFile, lambdaSaltFile, wghtBalanceFile,
-     &                the_run_name
+!--   COMMON /PARM_C/ Character valued parameters used by the model.
+! buoyancyRelation :: Flag used to indicate which relation to use to
+!                     get buoyancy.
+! eosType         :: choose the equation of state:
+!                    LINEAR, POLY3, UNESCO, JMD95Z, JMD95P, MDJWF, IDEALGAS
+! pickupSuff      :: force to start from pickup files (even if nIter0=0)
+!                    and read pickup files with this suffix (max 10 Char.)
+! mdsioLocalDir   :: read-write tiled file from/to this directory name
+!                    (+ 4 digits Processor-Rank) instead of current dir.
+! adTapeDir       :: read-write checkpointing tape files from/to this
+!                    directory name instead of current dir. Conflicts
+!                    mdsioLocalDir, so only one of the two can be set.
+! tRefFile      :: File containing reference Potential Temperat.  tRef (1.D)
+! sRefFile      :: File containing reference salinity/spec.humid. sRef (1.D)
+! rhoRefFile    :: File containing reference density profile rhoRef (1.D)
+! gravityFile   :: File containing gravity vertical profile (1.D)
+! delRFile      :: File containing vertical grid spacing delR  (1.D array)
+! delRcFile     :: File containing vertical grid spacing delRc (1.D array)
+! hybSigmFile   :: File containing hybrid-sigma vertical coord. coeff. (2x 1.D)
+! delXFile      :: File containing X-spacing grid definition (1.D array)
+! delYFile      :: File containing Y-spacing grid definition (1.D array)
+! horizGridFile :: File containing horizontal-grid definition
+!                    (only when using curvilinear_grid)
+! bathyFile       :: File containing bathymetry. If not defined bathymetry
+!                    is taken from inline function.
+! topoFile        :: File containing the topography of the surface (unit=m)
+!                    (mainly used for the atmosphere = ground height).
+! addWwallFile    :: File containing 2-D additional Western  cell-edge wall
+! addSwallFile    :: File containing 2-D additional Southern cell-edge wall
+!                    (e.g., to add "thin-wall" where it is =1)
+! hydrogThetaFile :: File containing initial hydrographic data (3-D)
+!                    for potential temperature.
+! hydrogSaltFile  :: File containing initial hydrographic data (3-D)
+!                    for salinity.
+! diffKrFile      :: File containing 3D specification of vertical diffusivity
+! viscAhDfile     :: File containing 3D specification of horizontal viscosity
+! viscAhZfile     :: File containing 3D specification of horizontal viscosity
+! viscA4Dfile     :: File containing 3D specification of horizontal viscosity
+! viscA4Zfile     :: File containing 3D specification of horizontal viscosity
+! zonalWindFile   :: File containing zonal wind data
+! meridWindFile   :: File containing meridional wind data
+! thetaClimFile   :: File containing surface theta climataology used
+!                    in relaxation term -lambda(theta-theta*)
+! saltClimFile    :: File containing surface salt climataology used
+!                    in relaxation term -lambda(salt-salt*)
+! surfQfile       :: File containing surface heat flux, excluding SW
+!                    (old version, kept for backward compatibility)
+! surfQnetFile    :: File containing surface net heat flux
+! surfQswFile     :: File containing surface shortwave radiation
+! EmPmRfile       :: File containing surface fresh water flux
+!       NOTE: for backward compatibility EmPmRfile is specified in
+!             m/s when using external_fields_load.F.  It is converted
+!             to kg/m2/s by multiplying by rhoConstFresh.
+! saltFluxFile    :: File containing surface salt flux
+! pLoadFile       :: File containing pressure loading
+! geoPotAnomFile  :: File containing constant geopotential anomaly due to
+!                    density structure
+! addMassFile     :: File containing source/sink of fluid in the interior
+! eddyPsiXFile    :: File containing zonal Eddy streamfunction data
+! eddyPsiYFile    :: File containing meridional Eddy streamfunction data
+! geothermalFile  :: File containing geothermal heat flux
+! lambdaThetaFile :: File containing SST relaxation coefficient
+! lambdaSaltFile  :: File containing SSS relaxation coefficient
+! wghtBalanceFile :: File containing weight used in balancing net EmPmR
+! the_run_name    :: string identifying the name of the model "run"
+      COMMON /PARM_C/                                                             &
+     &      buoyancyRelation, eosType,                                            &
+     &      pickupSuff, mdsioLocalDir, adTapeDir,                                 &
+     &      tRefFile, sRefFile, rhoRefFile, gravityFile,                          &
+     &      delRFile, delRcFile, hybSigmFile,                                     &
+     &      delXFile, delYFile, horizGridFile,                                    &
+     &      bathyFile, topoFile, addWwallFile, addSwallFile,                      &
+     &      viscAhDfile, viscAhZfile,                                             &
+     &      viscA4Dfile, viscA4Zfile,                                             &
+     &      hydrogThetaFile, hydrogSaltFile, diffKrFile,                          &
+     &      zonalWindFile, meridWindFile, thetaClimFile,                          &
+     &      saltClimFile,                                                         &
+     &      EmPmRfile, saltFluxFile,                                              &
+     &      surfQfile, surfQnetFile, surfQswFile,                                 &
+     &      uVelInitFile, vVelInitFile, pSurfInitFile,                            &
+     &      pLoadFile, geoPotAnomFile, addMassFile,                               &
+     &      eddyPsiXFile, eddyPsiYFile, geothermalFile,                           &
+     &      lambdaThetaFile, lambdaSaltFile, wghtBalanceFile,                     &
+     &      the_run_name
       CHARACTER*(MAX_LEN_FNAM) buoyancyRelation
-      CHARACTER*(6)  eosType
-      CHARACTER*(10) pickupSuff
+      CHARACTER(len=6) :: eosType
+      CHARACTER(len=10) :: pickupSuff
       CHARACTER*(MAX_LEN_FNAM) mdsioLocalDir
       CHARACTER*(MAX_LEN_FNAM) adTapeDir
       CHARACTER*(MAX_LEN_FNAM) tRefFile
@@ -147,726 +147,726 @@ C     the_run_name    :: string identifying the name of the model "run"
       CHARACTER*(MAX_LEN_FNAM) wghtBalanceFile
       CHARACTER*(MAX_LEN_PREC/2) the_run_name
 
-C--   COMMON /PARM_I/ Integer valued parameters used by the model.
-C     cg2dMaxIters        :: Maximum number of iterations in the
-C                            two-dimensional con. grad solver.
-C     cg2dMinItersNSA     :: Minimum number of iterations in the
-C                            not-self-adjoint version (cg2d_nsa.F) of the
-C                            two-dimensional con. grad solver (default = 0).
-C     cg2dPreCondFreq     :: Frequency for updating cg2d preconditioner
-C                            (non-linear free-surf.)
-C     cg2dUseMinResSol    :: =0 : use last-iteration/converged solution
-C                            =1 : use solver minimum-residual solution
-C     cg3dMaxIters        :: Maximum number of iterations in the
-C                            three-dimensional con. grad solver.
-C     printResidualFreq   :: Frequency for printing residual in CG iterations
-C     nIter0              :: Start time-step number of for this run
-C     nTimeSteps          :: Number of timesteps to execute
-C     nTimeSteps_l2       :: Number of inner timesteps to execute per timestep
-C     selectCoriMap       :: select setting of Coriolis parameter map:
-C                           =0 f-Plane (Constant Coriolis, = f0)
-C                           =1 Beta-Plane Coriolis (= f0 + beta.y)
-C                           =2 Spherical Coriolis (= 2.omega.sin(phi))
-C                           =3 Read Coriolis 2-d fields from files.
-C     selectSigmaCoord    :: option related to sigma vertical coordinate
-C     nonlinFreeSurf      :: option related to non-linear free surface
-C                           =0 Linear free surface ; >0 Non-linear
-C     select_rStar        :: option related to r* vertical coordinate
-C                           =0 (default) use r coord. ; > 0 use r*
-C     selectNHfreeSurf    :: option for Non-Hydrostatic (free-)Surface formulation:
-C                           =0 (default) hydrostatic surf. ; > 0 add NH effects.
-C     selectP_inEOS_Zc    :: select which pressure to use in EOS (for z-coords)
-C                           =0: simply: -g*rhoConst*z
-C                           =1: use pRef = integral{-g*rho(Tref,Sref,pRef)*dz}
-C                           =2: use hydrostatic dynamical pressure
-C                           =3: use full (Hyd+NH) dynamical pressure
-C     selectAddFluid      :: option to add mass source/sink of fluid in the interior
-C                            (3-D generalisation of oceanic real-fresh water flux)
-C                           =0 off ; =1 add fluid ; =-1 virtual flux (no mass added)
-C     selectBalanceEmPmR  :: option to balance net surface fresh-water flux:
-C                           =0 off ; =1 uniform correction ; = 2 weighted correction
-C     selectImplicitDrag  :: select Implicit treatment of bottom/top drag
-C                           = 0: fully explicit
-C                           = 1: implicit on provisional velocity
-C                                (i.e., before grad.Eta increment)
-C                           = 2: fully implicit (combined with Impl Surf.Press)
-C     selectPenetratingSW :: select treatment of penetrating shortwave radiation
-C                            (requires to define SHORTWAVE_HEATING):
-C                           = 0: no shortwave penetration
-C                           = 1: constant in time and horizontally uniform
-C                                fraction of shortwave penetration (default)
-C                           = 2: constant in time, but non-uniform fraction of
-C                                shortwave penetration (not yet coded)
-C                           > 2: time varying fraction of shortwave penetration
-C                                according to external function (e.g. BGC model,
-C                                not yet coded)
-C     momForcingOutAB     :: =1: take momentum forcing contribution
-C                            out of (=0: in) Adams-Bashforth time stepping.
-C     tracForcingOutAB    :: =1: take tracer (Temp,Salt,pTracers) forcing contribution
-C                            out of (=0: in) Adams-Bashforth time stepping.
-C     tempAdvScheme       :: Temp. Horiz.Advection scheme selector
-C     tempVertAdvScheme   :: Temp. Vert. Advection scheme selector
-C     saltAdvScheme       :: Salt. Horiz.advection scheme selector
-C     saltVertAdvScheme   :: Salt. Vert. Advection scheme selector
-C     selectKEscheme      :: Kinetic Energy scheme selector (Vector Inv.)
-C     selectVortScheme    :: Scheme selector for Vorticity term (Vector Inv.)
-C     selectMetricTerms   :: Scheme selector for Metric terms (Flux-Form)
-C     selectCoriScheme    :: Scheme selector for Coriolis term
-C     select3dCoriScheme  :: Scheme selector for 3-D Coriolis (in Omega.cos Phi)
-C     selectBotDragQuadr  :: quadratic bottom drag discretisation option:
-C                           =0: average KE from grid center to U & V location
-C                           =1: use local velocity norm @ U & V location
-C                           =2: same with wet-point averaging of other component
-C     pCellMix_select     :: select option to enhance mixing near surface & bottom
-C                            unit digit: near bottom ; tens digit: near surface
-C                            with digit =0 : disable ;
-C                           = 1 : increases mixing linearly with recip_hFac
-C                           = 2,3,4 : increases mixing by recip_hFac^(2,3,4)
-C     readBinaryPrec      :: Precision used for reading binary files
-C     writeBinaryPrec     :: Precision used for writing binary files
-C     rwSuffixType        :: controls the format of the mds file suffix.
-C                          =0 (default): use iteration number (myIter, I10.10);
-C                          =1: 100*myTime (100th sec); =2: myTime (seconds);
-C                          =3: myTime/360 (10th of hr); =4: myTime/3600 (hours).
-C     monitorSelect       :: select group of variables to monitor
-C                            =1 : dynvars ; =2 : + vort ; =3 : + surface
-C-    debugLevel          :: controls printing of algorithm intermediate results
-C                            and statistics ; higher -> more writing
-C-    plotLevel           :: controls printing of field maps ; higher -> more flds
+!--   COMMON /PARM_I/ Integer valued parameters used by the model.
+! cg2dMaxIters        :: Maximum number of iterations in the
+!                        two-dimensional con. grad solver.
+! cg2dMinItersNSA     :: Minimum number of iterations in the
+!                        not-self-adjoint version (cg2d_nsa.F) of the
+!                        two-dimensional con. grad solver (default = 0).
+! cg2dPreCondFreq     :: Frequency for updating cg2d preconditioner
+!                        (non-linear free-surf.)
+! cg2dUseMinResSol    :: =0 : use last-iteration/converged solution
+!                        =1 : use solver minimum-residual solution
+! cg3dMaxIters        :: Maximum number of iterations in the
+!                        three-dimensional con. grad solver.
+! printResidualFreq   :: Frequency for printing residual in CG iterations
+! nIter0              :: Start time-step number of for this run
+! nTimeSteps          :: Number of timesteps to execute
+! nTimeSteps_l2       :: Number of inner timesteps to execute per timestep
+! selectCoriMap       :: select setting of Coriolis parameter map:
+!                       =0 f-Plane (Constant Coriolis, = f0)
+!                       =1 Beta-Plane Coriolis (= f0 + beta.y)
+!                       =2 Spherical Coriolis (= 2.omega.sin(phi))
+!                       =3 Read Coriolis 2-d fields from files.
+! selectSigmaCoord    :: option related to sigma vertical coordinate
+! nonlinFreeSurf      :: option related to non-linear free surface
+!                       =0 Linear free surface ; >0 Non-linear
+! select_rStar        :: option related to r* vertical coordinate
+!                       =0 (default) use r coord. ; > 0 use r*
+! selectNHfreeSurf    :: option for Non-Hydrostatic (free-)Surface formulation:
+!                       =0 (default) hydrostatic surf. ; > 0 add NH effects.
+! selectP_inEOS_Zc    :: select which pressure to use in EOS (for z-coords)
+!                       =0: simply: -g*rhoConst*z
+!                       =1: use pRef = integral{-g*rho(Tref,Sref,pRef)*dz}
+!                       =2: use hydrostatic dynamical pressure
+!                       =3: use full (Hyd+NH) dynamical pressure
+! selectAddFluid      :: option to add mass source/sink of fluid in the interior
+!                        (3-D generalisation of oceanic real-fresh water flux)
+!                       =0 off ; =1 add fluid ; =-1 virtual flux (no mass added)
+! selectBalanceEmPmR  :: option to balance net surface fresh-water flux:
+!                       =0 off ; =1 uniform correction ; = 2 weighted correction
+! selectImplicitDrag  :: select Implicit treatment of bottom/top drag
+!                       = 0: fully explicit
+!                       = 1: implicit on provisional velocity
+!                            (i.e., before grad.Eta increment)
+!                       = 2: fully implicit (combined with Impl Surf.Press)
+! selectPenetratingSW :: select treatment of penetrating shortwave radiation
+!                        (requires to define SHORTWAVE_HEATING):
+!                       = 0: no shortwave penetration
+!                       = 1: constant in time and horizontally uniform
+!                            fraction of shortwave penetration (default)
+!                       = 2: constant in time, but non-uniform fraction of
+!                            shortwave penetration (not yet coded)
+!                       > 2: time varying fraction of shortwave penetration
+!                            according to external function (e.g. BGC model,
+!                            not yet coded)
+! momForcingOutAB     :: =1: take momentum forcing contribution
+!                        out of (=0: in) Adams-Bashforth time stepping.
+! tracForcingOutAB    :: =1: take tracer (Temp,Salt,pTracers) forcing contribution
+!                        out of (=0: in) Adams-Bashforth time stepping.
+! tempAdvScheme       :: Temp. Horiz.Advection scheme selector
+! tempVertAdvScheme   :: Temp. Vert. Advection scheme selector
+! saltAdvScheme       :: Salt. Horiz.advection scheme selector
+! saltVertAdvScheme   :: Salt. Vert. Advection scheme selector
+! selectKEscheme      :: Kinetic Energy scheme selector (Vector Inv.)
+! selectVortScheme    :: Scheme selector for Vorticity term (Vector Inv.)
+!     selectMetricTerms   :: Scheme selector for Metric terms (Flux-Form)
+! selectCoriScheme    :: Scheme selector for Coriolis term
+! select3dCoriScheme  :: Scheme selector for 3-D Coriolis (in Omega.cos Phi)
+! selectBotDragQuadr  :: quadratic bottom drag discretisation option:
+!                       =0: average KE from grid center to U & V location
+!                       =1: use local velocity norm @ U & V location
+!                       =2: same with wet-point averaging of other component
+! pCellMix_select     :: select option to enhance mixing near surface & bottom
+!                        unit digit: near bottom ; tens digit: near surface
+!                        with digit =0 : disable ;
+!                       = 1 : increases mixing linearly with recip_hFac
+!                       = 2,3,4 : increases mixing by recip_hFac^(2,3,4)
+! readBinaryPrec      :: Precision used for reading binary files
+! writeBinaryPrec     :: Precision used for writing binary files
+! rwSuffixType        :: controls the format of the mds file suffix.
+!                      =0 (default): use iteration number (myIter, I10.10);
+!                      =1: 100*myTime (100th sec); =2: myTime (seconds);
+!                      =3: myTime/360 (10th of hr); =4: myTime/3600 (hours).
+! monitorSelect       :: select group of variables to monitor
+!                        =1 : dynvars ; =2 : + vort ; =3 : + surface
+!-    debugLevel          :: controls printing of algorithm intermediate results
+!                        and statistics ; higher -> more writing
+!-    plotLevel           :: controls printing of field maps ; higher -> more flds
 
-      COMMON /PARM_I/
-     &        cg2dMaxIters, cg2dMinItersNSA,
-     &        cg2dPreCondFreq, cg2dUseMinResSol,
-     &        cg3dMaxIters, printResidualFreq,
-     &        nIter0, nTimeSteps, nTimeSteps_l2, nEndIter,
-     &        selectCoriMap,
-     &        selectSigmaCoord,
-     &        nonlinFreeSurf, select_rStar,
-     &        selectNHfreeSurf, selectP_inEOS_Zc,
-     &        selectAddFluid, selectBalanceEmPmR, selectImplicitDrag,
-     &        momForcingOutAB, tracForcingOutAB,
-     &        tempAdvScheme, tempVertAdvScheme,
-     &        saltAdvScheme, saltVertAdvScheme,
-     &        selectKEscheme, selectVortScheme, selectMetricTerms,
-     &        selectCoriScheme, select3dCoriScheme,
-     &        selectBotDragQuadr, selectPenetratingSW, pCellMix_select,
-     &        readBinaryPrec, writeBinaryPrec,
-     &        rwSuffixType, monitorSelect, debugLevel, plotLevel
-      INTEGER cg2dMaxIters
-      INTEGER cg2dMinItersNSA
-      INTEGER cg2dPreCondFreq
-      INTEGER cg2dUseMinResSol
-      INTEGER cg3dMaxIters
-      INTEGER printResidualFreq
-      INTEGER nIter0
-      INTEGER nTimeSteps
-      INTEGER nTimeSteps_l2
-      INTEGER nEndIter
-      INTEGER selectCoriMap
-      INTEGER selectSigmaCoord
-      INTEGER nonlinFreeSurf
-      INTEGER select_rStar
-      INTEGER selectNHfreeSurf
-      INTEGER selectP_inEOS_Zc
-      INTEGER selectAddFluid
-      INTEGER selectBalanceEmPmR
-      INTEGER selectImplicitDrag
-      INTEGER momForcingOutAB, tracForcingOutAB
-      INTEGER tempAdvScheme, tempVertAdvScheme
-      INTEGER saltAdvScheme, saltVertAdvScheme
-      INTEGER selectKEscheme
-      INTEGER selectVortScheme
-      INTEGER selectMetricTerms
-      INTEGER selectCoriScheme
-      INTEGER select3dCoriScheme
-      INTEGER selectBotDragQuadr
-      INTEGER selectPenetratingSW
-      INTEGER pCellMix_select
-      INTEGER readBinaryPrec
-      INTEGER writeBinaryPrec
-      INTEGER rwSuffixType
-      INTEGER monitorSelect
-      INTEGER debugLevel
-      INTEGER plotLevel
+      COMMON /PARM_I/                                                             &
+     &      cg2dMaxIters, cg2dMinItersNSA,                                        &
+     &      cg2dPreCondFreq, cg2dUseMinResSol,                                    &
+     &      cg3dMaxIters, printResidualFreq,                                      &
+     &      nIter0, nTimeSteps, nTimeSteps_l2, nEndIter,                          &
+     &      selectCoriMap,                                                        &
+     &      selectSigmaCoord,                                                     &
+     &      nonlinFreeSurf, select_rStar,                                         &
+     &      selectNHfreeSurf, selectP_inEOS_Zc,                                   &
+     &      selectAddFluid, selectBalanceEmPmR, selectImplicitDrag,               &
+     &      momForcingOutAB, tracForcingOutAB,                                    &
+     &      tempAdvScheme, tempVertAdvScheme,                                     &
+     &      saltAdvScheme, saltVertAdvScheme,                                     &
+     &      selectKEscheme, selectVortScheme, selectMetricTerms,                  &
+     &      selectCoriScheme, select3dCoriScheme,                                 &
+     &      selectBotDragQuadr, selectPenetratingSW, pCellMix_select,             &
+     &      readBinaryPrec, writeBinaryPrec,                                      &
+     &      rwSuffixType, monitorSelect, debugLevel, plotLevel
+      INTEGER :: cg2dMaxIters
+      INTEGER :: cg2dMinItersNSA
+      INTEGER :: cg2dPreCondFreq
+      INTEGER :: cg2dUseMinResSol
+      INTEGER :: cg3dMaxIters
+      INTEGER :: printResidualFreq
+      INTEGER :: nIter0
+      INTEGER :: nTimeSteps
+      INTEGER :: nTimeSteps_l2
+      INTEGER :: nEndIter
+      INTEGER :: selectCoriMap
+      INTEGER :: selectSigmaCoord
+      INTEGER :: nonlinFreeSurf
+      INTEGER :: select_rStar
+      INTEGER :: selectNHfreeSurf
+      INTEGER :: selectP_inEOS_Zc
+      INTEGER :: selectAddFluid
+      INTEGER :: selectBalanceEmPmR
+      INTEGER :: selectImplicitDrag
+      INTEGER :: momForcingOutAB, tracForcingOutAB
+      INTEGER :: tempAdvScheme, tempVertAdvScheme
+      INTEGER :: saltAdvScheme, saltVertAdvScheme
+      INTEGER :: selectKEscheme
+      INTEGER :: selectVortScheme
+      INTEGER :: selectMetricTerms
+      INTEGER :: selectCoriScheme
+      INTEGER :: select3dCoriScheme
+      INTEGER :: selectBotDragQuadr
+      INTEGER :: selectPenetratingSW
+      INTEGER :: pCellMix_select
+      INTEGER :: readBinaryPrec
+      INTEGER :: writeBinaryPrec
+      INTEGER :: rwSuffixType
+      INTEGER :: monitorSelect
+      INTEGER :: debugLevel
+      INTEGER :: plotLevel
 
-C--   COMMON /PARM_L/ Logical valued parameters used by the model.
-C- Coordinate + Grid params:
-C     fluidIsAir       :: Set to indicate that the fluid major constituent
-C                         is air
-C     fluidIsWater     :: Set to indicate that the fluid major constituent
-C                         is water
-C     usingPCoords     :: Set to indicate that we are working in a pressure
-C                         type coordinate (p or p*).
-C     usingZCoords     :: Set to indicate that we are working in a height
-C                         type coordinate (z or z*)
-C     usingCartesianGrid :: If TRUE grid generation will be in a cartesian
-C                           coordinate frame.
-C     usingSphericalPolarGrid :: If TRUE grid generation will be in a
-C                                spherical polar frame.
-C     rotateGrid      :: rotate grid coordinates to geographical coordinates
-C                        according to Euler angles phiEuler, thetaEuler, psiEuler
-C     usingCylindricalGrid :: If TRUE grid generation will be Cylindrical
-C     usingCurvilinearGrid :: If TRUE, use a curvilinear grid (to be provided)
-C     hasWetCSCorners :: domain contains CS-type corners where dynamics is solved
-C     deepAtmosphere :: deep model (drop the shallow-atmosphere approximation)
-C     setInterFDr    :: set Interface depth (put cell-Center at the middle)
-C     setCenterDr    :: set cell-Center depth (put Interface at the middle)
-C     useMin4hFacEdges :: set hFacW,hFacS as minimum of adjacent hFacC factor
-C     interViscAr_pCell :: account for partial-cell in interior vert. viscosity
-C     interDiffKr_pCell :: account for partial-cell in interior vert. diffusion
-C- Momentum params:
-C     no_slip_sides  :: Impose "no-slip" at lateral boundaries.
-C     no_slip_bottom :: Impose "no-slip" at bottom boundary.
-C     bottomVisc_pCell :: account for partial-cell in bottom visc. (no-slip BC)
-C     useSmag3D      :: Use isotropic 3-D Smagorinsky
-C     useFullLeith   :: Set to true to use full Leith viscosity(may be unstable
-C                       on irregular grids)
-C     useStrainTensionVisc:: Set to true to use Strain-Tension viscous terms
-C     useAreaViscLength :: Set to true to use old scaling for viscous lengths,
-C                          e.g., L2=Raz.  May be preferable for cube sphere.
-C     momViscosity  :: Flag which turns momentum friction terms on and off.
-C     momAdvection  :: Flag which turns advection of momentum on and off.
-C     momForcing    :: Flag which turns external forcing of momentum on and off.
-C     momTidalForcing    :: Flag which turns tidal forcing on and off.
-C     momPressureForcing :: Flag which turns pressure term in momentum equation
-C                          on and off.
-C     useNHMTerms   :: If TRUE use non-hydrostatic metric terms.
-C     useCoriolis   :: Flag which turns the coriolis terms on and off.
-C     useCDscheme   :: use CD-scheme to calculate Coriolis terms.
-C     vectorInvariantMomentum :: use Vector-Invariant form (mom_vecinv package)
-C                                (default = F = use mom_fluxform package)
-C     useJamartMomAdv :: Use wet-point method for V.I. non-linear term
-C     upwindVorticity :: bias interpolation of vorticity in the Coriolis term
-C     highOrderVorticity :: use 3rd/4th order interp. of vorticity (V.I., advection)
-C     useAbsVorticity :: work with f+zeta in Coriolis terms
-C     upwindShear     :: use 1rst order upwind interp. (V.I., vertical advection)
-C     momStepping    :: Turns momentum equation time-stepping off
-C     calc_wVelocity :: Turns vertical velocity calculation off
-C- Temp. & Salt params:
-C     tempStepping   :: Turns temperature equation time-stepping on/off
-C     saltStepping   :: Turns salinity equation time-stepping on/off
-C     addFrictionHeating :: account for frictional heating
-C     temp_stayPositive :: use Smolarkiewicz Hack to ensure Temp stays positive
-C     salt_stayPositive :: use Smolarkiewicz Hack to ensure Salt stays positive
-C     tempAdvection  :: Flag which turns advection of temperature on and off.
-C     tempVertDiff4  :: use vertical bi-harmonic diffusion for temperature
-C     tempIsActiveTr :: Pot.Temp. is a dynamically active tracer
-C     tempForcing    :: Flag which turns external forcing of temperature on/off
-C     saltAdvection  :: Flag which turns advection of salinity on and off.
-C     saltVertDiff4  :: use vertical bi-harmonic diffusion for salinity
-C     saltIsActiveTr :: Salinity  is a dynamically active tracer
-C     saltForcing    :: Flag which turns external forcing of salinity on/off
-C     maskIniTemp    :: apply mask to initial Pot.Temp.
-C     maskIniSalt    :: apply mask to initial salinity
-C     checkIniTemp   :: check for points with identically zero initial Pot.Temp.
-C     checkIniSalt   :: check for points with identically zero initial salinity
-C- Pressure solver related parameters (PARM02)
-C     useNSACGSolver :: Set to true to use "not self-adjoint" conjugate
-C                       gradient solver that stores the iteration history
-C                       for an iterative adjoint as accuate as possible
-C     useSRCGSolver  :: Set to true to use conjugate gradient
-C                       solver with single reduction (only one call of
-C                       s/r mpi_allreduce), default is false
-C- Time-stepping & free-surface params:
-C     rigidLid            :: Set to true to use rigid lid
-C     implicitFreeSurface :: Set to true to use implicit free surface
-C     uniformLin_PhiSurf  :: Set to true to use a uniform Bo_surf in the
-C                            linear relation Phi_surf = Bo_surf*eta
-C     uniformFreeSurfLev  :: TRUE if free-surface level-index is uniform (=1)
-C     exactConserv        :: Set to true to conserve exactly the total Volume
-C     linFSConserveTr     :: Set to true to correct source/sink of tracer
-C                            at the surface due to Linear Free Surface
-C     useRealFreshWaterFlux :: if True (=Natural BCS), treats P+R-E flux
-C                         as a real Fresh Water (=> changes the Sea Level)
-C                         if F, converts P+R-E to salt flux (no SL effect)
-C     storePhiHyd4Phys :: store hydrostatic potential for use in Physics/EOS
-C                         this requires specific code for restart & exchange
-C     quasiHydrostatic :: Using non-hydrostatic terms in hydrostatic algorithm
-C     nonHydrostatic   :: Using non-hydrostatic algorithm
-C     use3Dsolver      :: set to true to use 3-D pressure solver
-C     implicitIntGravWave :: treat Internal Gravity Wave implicitly
-C     staggerTimeStep   :: enable a Stagger time stepping U,V (& W) then T,S
-C     applyExchUV_early :: Apply EXCH to U,V earlier, just before integr_continuity
-C     doResetHFactors   :: Do reset thickness factors @ beginning of each time-step
-C     implicitDiffusion :: Turns implicit vertical diffusion on
-C     implicitViscosity :: Turns implicit vertical viscosity on
-C     tempImplVertAdv   :: Turns on implicit vertical advection for Temperature
-C     saltImplVertAdv   :: Turns on implicit vertical advection for Salinity
-C     momImplVertAdv    :: Turns on implicit vertical advection for Momentum
-C     multiDimAdvection :: Flag that enable multi-dimension advection
-C     useMultiDimAdvec  :: True if multi-dim advection is used at least once
-C     momDissip_In_AB   :: if False, put Dissipation tendency contribution
-C                          out off Adams-Bashforth time stepping.
-C     doAB_onGtGs       :: if the Adams-Bashforth time stepping is used, always
-C                          apply AB on tracer tendencies (rather than on Tracer)
-C- Other forcing params -
-C     balanceQnet     :: substract global mean of Qnet at every time step
-C     balancePrintMean:: print substracted global means to STDOUT
-C     doThetaClimRelax :: Set true if relaxation to temperature
-C                        climatology is required.
-C     doSaltClimRelax  :: Set true if relaxation to salinity
-C                        climatology is required.
-C     balanceThetaClimRelax :: substract global mean effect at every time step
-C     balanceSaltClimRelax :: substract global mean effect at every time step
-C     allowFreezing  :: Allows surface water to freeze and form ice
-C     periodicExternalForcing :: Set true if forcing is time-dependant
-C- I/O parameters -
-C     globalFiles    :: Selects between "global" and "tiled" files.
-C                       On some platforms with MPI, option globalFiles is either
-C                       slow or does not work. Use useSingleCpuIO instead.
-C     useSingleCpuIO :: moved to EEPARAMS.h
-C     pickupStrictlyMatch :: check and stop if pickup-file do not stricly match
-C     startFromPickupAB2 :: with AB-3 code, start from an AB-2 pickup
-C     usePickupBeforeC54 :: start from old-pickup files, generated with code from
-C                           before checkpoint-54a, Jul 06, 2004.
-C     pickup_write_mdsio :: use mdsio to write pickups
-C     pickup_read_mdsio  :: use mdsio to read  pickups
-C     pickup_write_immed :: echo the pickup immediately (for conversion)
-C     writePickupAtEnd   :: write pickup at the last timestep
-C     snapshot_mdsio     :: use mdsio for "snapshot" (dumpfreq/diagfreq) output
-C     monitor_stdio      :: use stdio for monitor output
-C     dumpInitAndLast :: dumps model state to files at Initial (nIter0)
-C                        & Last iteration, in addition multiple of dumpFreq iter.
+!--   COMMON /PARM_L/ Logical valued parameters used by the model.
+!- Coordinate + Grid params:
+! fluidIsAir       :: Set to indicate that the fluid major constituent
+!                     is air
+! fluidIsWater     :: Set to indicate that the fluid major constituent
+!                     is water
+! usingPCoords     :: Set to indicate that we are working in a pressure
+!                     type coordinate (p or p*).
+! usingZCoords     :: Set to indicate that we are working in a height
+!                     type coordinate (z or z*)
+! usingCartesianGrid :: If TRUE grid generation will be in a cartesian
+!                       coordinate frame.
+! usingSphericalPolarGrid :: If TRUE grid generation will be in a
+!                            spherical polar frame.
+! rotateGrid      :: rotate grid coordinates to geographical coordinates
+!                    according to Euler angles phiEuler, thetaEuler, psiEuler
+! usingCylindricalGrid :: If TRUE grid generation will be Cylindrical
+! usingCurvilinearGrid :: If TRUE, use a curvilinear grid (to be provided)
+! hasWetCSCorners :: domain contains CS-type corners where dynamics is solved
+! deepAtmosphere :: deep model (drop the shallow-atmosphere approximation)
+! setInterFDr    :: set Interface depth (put cell-Center at the middle)
+! setCenterDr    :: set cell-Center depth (put Interface at the middle)
+! useMin4hFacEdges :: set hFacW,hFacS as minimum of adjacent hFacC factor
+! interViscAr_pCell :: account for partial-cell in interior vert. viscosity
+! interDiffKr_pCell :: account for partial-cell in interior vert. diffusion
+!- Momentum params:
+! no_slip_sides  :: Impose "no-slip" at lateral boundaries.
+! no_slip_bottom :: Impose "no-slip" at bottom boundary.
+! bottomVisc_pCell :: account for partial-cell in bottom visc. (no-slip BC)
+! useSmag3D      :: Use isotropic 3-D Smagorinsky
+! useFullLeith   :: Set to true to use full Leith viscosity(may be unstable
+!                   on irregular grids)
+! useStrainTensionVisc:: Set to true to use Strain-Tension viscous terms
+! useAreaViscLength :: Set to true to use old scaling for viscous lengths,
+!                      e.g., L2=Raz.  May be preferable for cube sphere.
+! momViscosity  :: Flag which turns momentum friction terms on and off.
+! momAdvection  :: Flag which turns advection of momentum on and off.
+! momForcing    :: Flag which turns external forcing of momentum on and off.
+! momTidalForcing    :: Flag which turns tidal forcing on and off.
+! momPressureForcing :: Flag which turns pressure term in momentum equation
+!                      on and off.
+! useNHMTerms   :: If TRUE use non-hydrostatic metric terms.
+! useCoriolis   :: Flag which turns the coriolis terms on and off.
+! useCDscheme   :: use CD-scheme to calculate Coriolis terms.
+! vectorInvariantMomentum :: use Vector-Invariant form (mom_vecinv package)
+!                            (default = F = use mom_fluxform package)
+! useJamartMomAdv :: Use wet-point method for V.I. non-linear term
+! upwindVorticity :: bias interpolation of vorticity in the Coriolis term
+! highOrderVorticity :: use 3rd/4th order interp. of vorticity (V.I., advection)
+! useAbsVorticity :: work with f+zeta in Coriolis terms
+! upwindShear     :: use 1rst order upwind interp. (V.I., vertical advection)
+! momStepping    :: Turns momentum equation time-stepping off
+! calc_wVelocity :: Turns vertical velocity calculation off
+!- Temp. & Salt params:
+! tempStepping   :: Turns temperature equation time-stepping on/off
+! saltStepping   :: Turns salinity equation time-stepping on/off
+! addFrictionHeating :: account for frictional heating
+! temp_stayPositive :: use Smolarkiewicz Hack to ensure Temp stays positive
+! salt_stayPositive :: use Smolarkiewicz Hack to ensure Salt stays positive
+! tempAdvection  :: Flag which turns advection of temperature on and off.
+! tempVertDiff4  :: use vertical bi-harmonic diffusion for temperature
+! tempIsActiveTr :: Pot.Temp. is a dynamically active tracer
+! tempForcing    :: Flag which turns external forcing of temperature on/off
+! saltAdvection  :: Flag which turns advection of salinity on and off.
+! saltVertDiff4  :: use vertical bi-harmonic diffusion for salinity
+! saltIsActiveTr :: Salinity  is a dynamically active tracer
+! saltForcing    :: Flag which turns external forcing of salinity on/off
+! maskIniTemp    :: apply mask to initial Pot.Temp.
+! maskIniSalt    :: apply mask to initial salinity
+! checkIniTemp   :: check for points with identically zero initial Pot.Temp.
+! checkIniSalt   :: check for points with identically zero initial salinity
+!- Pressure solver related parameters (PARM02)
+! useNSACGSolver :: Set to true to use "not self-adjoint" conjugate
+!                   gradient solver that stores the iteration history
+!                   for an iterative adjoint as accuate as possible
+! useSRCGSolver  :: Set to true to use conjugate gradient
+!                   solver with single reduction (only one call of
+!                   s/r mpi_allreduce), default is false
+!- Time-stepping & free-surface params:
+! rigidLid            :: Set to true to use rigid lid
+! implicitFreeSurface :: Set to true to use implicit free surface
+! uniformLin_PhiSurf  :: Set to true to use a uniform Bo_surf in the
+!                        linear relation Phi_surf = Bo_surf*eta
+! uniformFreeSurfLev  :: TRUE if free-surface level-index is uniform (=1)
+! exactConserv        :: Set to true to conserve exactly the total Volume
+! linFSConserveTr     :: Set to true to correct source/sink of tracer
+!                        at the surface due to Linear Free Surface
+! useRealFreshWaterFlux :: if True (=Natural BCS), treats P+R-E flux
+!                     as a real Fresh Water (=> changes the Sea Level)
+!                     if F, converts P+R-E to salt flux (no SL effect)
+! storePhiHyd4Phys :: store hydrostatic potential for use in Physics/EOS
+!                     this requires specific code for restart & exchange
+! quasiHydrostatic :: Using non-hydrostatic terms in hydrostatic algorithm
+! nonHydrostatic   :: Using non-hydrostatic algorithm
+! use3Dsolver      :: set to true to use 3-D pressure solver
+! implicitIntGravWave :: treat Internal Gravity Wave implicitly
+! staggerTimeStep   :: enable a Stagger time stepping U,V (& W) then T,S
+! applyExchUV_early :: Apply EXCH to U,V earlier, just before integr_continuity
+! doResetHFactors   :: Do reset thickness factors @ beginning of each time-step
+! implicitDiffusion :: Turns implicit vertical diffusion on
+! implicitViscosity :: Turns implicit vertical viscosity on
+! tempImplVertAdv   :: Turns on implicit vertical advection for Temperature
+! saltImplVertAdv   :: Turns on implicit vertical advection for Salinity
+! momImplVertAdv    :: Turns on implicit vertical advection for Momentum
+! multiDimAdvection :: Flag that enable multi-dimension advection
+! useMultiDimAdvec  :: True if multi-dim advection is used at least once
+! momDissip_In_AB   :: if False, put Dissipation tendency contribution
+!                      out off Adams-Bashforth time stepping.
+! doAB_onGtGs       :: if the Adams-Bashforth time stepping is used, always
+!                      apply AB on tracer tendencies (rather than on Tracer)
+!- Other forcing params -
+! balanceQnet     :: substract global mean of Qnet at every time step
+! balancePrintMean:: print substracted global means to STDOUT
+! doThetaClimRelax :: Set true if relaxation to temperature
+!                    climatology is required.
+! doSaltClimRelax  :: Set true if relaxation to salinity
+!                    climatology is required.
+! balanceThetaClimRelax :: substract global mean effect at every time step
+! balanceSaltClimRelax :: substract global mean effect at every time step
+! allowFreezing  :: Allows surface water to freeze and form ice
+! periodicExternalForcing :: Set true if forcing is time-dependant
+!- I/O parameters -
+! globalFiles    :: Selects between "global" and "tiled" files.
+!                   On some platforms with MPI, option globalFiles is either
+!                   slow or does not work. Use useSingleCpuIO instead.
+! useSingleCpuIO :: moved to EEPARAMS.h
+! pickupStrictlyMatch :: check and stop if pickup-file do not stricly match
+! startFromPickupAB2 :: with AB-3 code, start from an AB-2 pickup
+! usePickupBeforeC54 :: start from old-pickup files, generated with code from
+!                       before checkpoint-54a, Jul 06, 2004.
+! pickup_write_mdsio :: use mdsio to write pickups
+! pickup_read_mdsio  :: use mdsio to read  pickups
+! pickup_write_immed :: echo the pickup immediately (for conversion)
+! writePickupAtEnd   :: write pickup at the last timestep
+! snapshot_mdsio     :: use mdsio for "snapshot" (dumpfreq/diagfreq) output
+! monitor_stdio      :: use stdio for monitor output
+! dumpInitAndLast :: dumps model state to files at Initial (nIter0)
+!                    & Last iteration, in addition multiple of dumpFreq iter.
 
-      COMMON /PARM_L/
-     & fluidIsAir, fluidIsWater,
-     & usingPCoords, usingZCoords,
-     & usingCartesianGrid, usingSphericalPolarGrid, rotateGrid,
-     & usingCylindricalGrid, usingCurvilinearGrid, hasWetCSCorners,
-     & deepAtmosphere, setInterFDr, setCenterDr, useMin4hFacEdges,
-     & interViscAr_pCell, interDiffKr_pCell,
-     & no_slip_sides, no_slip_bottom, bottomVisc_pCell, useSmag3D,
-     & useFullLeith, useStrainTensionVisc, useAreaViscLength,
-     & momViscosity, momAdvection, momForcing, momTidalForcing,
-     & momPressureForcing, useNHMTerms,
-     & useCoriolis, useCDscheme, vectorInvariantMomentum,
-     & useJamartMomAdv, upwindVorticity, highOrderVorticity,
-     & useAbsVorticity, upwindShear,
-     & momStepping, calc_wVelocity, tempStepping, saltStepping,
-     & addFrictionHeating, temp_stayPositive, salt_stayPositive,
-     & tempAdvection, tempVertDiff4, tempIsActiveTr, tempForcing,
-     & saltAdvection, saltVertDiff4, saltIsActiveTr, saltForcing,
-     & maskIniTemp, maskIniSalt, checkIniTemp, checkIniSalt,
-     & useNSACGSolver, useSRCGSolver,
-     & rigidLid, implicitFreeSurface,
-     & uniformLin_PhiSurf, uniformFreeSurfLev,
-     & exactConserv, linFSConserveTr, useRealFreshWaterFlux,
-     & storePhiHyd4Phys, quasiHydrostatic, nonHydrostatic,
-     & use3Dsolver, implicitIntGravWave, staggerTimeStep,
-     & applyExchUV_early, doResetHFactors,
-     & implicitDiffusion, implicitViscosity,
-     & tempImplVertAdv, saltImplVertAdv, momImplVertAdv,
-     & multiDimAdvection, useMultiDimAdvec,
-     & momDissip_In_AB, doAB_onGtGs,
-     & balanceQnet, balancePrintMean,
-     & balanceThetaClimRelax, balanceSaltClimRelax,
-     & doThetaClimRelax, doSaltClimRelax,
-     & allowFreezing,
-     & periodicExternalForcing,
-     & globalFiles,
-     & pickupStrictlyMatch, usePickupBeforeC54, startFromPickupAB2,
-     & pickup_read_mdsio, pickup_write_mdsio, pickup_write_immed,
-     & writePickupAtEnd,
-     & snapshot_mdsio, monitor_stdio,
-     & outputTypesInclusive, dumpInitAndLast
+      COMMON /PARM_L/                                                             &
+     &      fluidIsAir, fluidIsWater,                                             &
+     &      usingPCoords, usingZCoords,                                           &
+     &      usingCartesianGrid, usingSphericalPolarGrid, rotateGrid,              &
+     &      usingCylindricalGrid, usingCurvilinearGrid, hasWetCSCorners,          &
+     &      deepAtmosphere, setInterFDr, setCenterDr, useMin4hFacEdges,           &
+     &      interViscAr_pCell, interDiffKr_pCell,                                 &
+     &      no_slip_sides, no_slip_bottom, bottomVisc_pCell, useSmag3D,           &
+     &      useFullLeith, useStrainTensionVisc, useAreaViscLength,                &
+     &      momViscosity, momAdvection, momForcing, momTidalForcing,              &
+     &      momPressureForcing, useNHMTerms,                                      &
+     &      useCoriolis, useCDscheme, vectorInvariantMomentum,                    &
+     &      useJamartMomAdv, upwindVorticity, highOrderVorticity,                 &
+     &      useAbsVorticity, upwindShear,                                         &
+     &      momStepping, calc_wVelocity, tempStepping, saltStepping,              &
+     &      addFrictionHeating, temp_stayPositive, salt_stayPositive,             &
+     &      tempAdvection, tempVertDiff4, tempIsActiveTr, tempForcing,            &
+     &      saltAdvection, saltVertDiff4, saltIsActiveTr, saltForcing,            &
+     &      maskIniTemp, maskIniSalt, checkIniTemp, checkIniSalt,                 &
+     &      useNSACGSolver, useSRCGSolver,                                        &
+     &      rigidLid, implicitFreeSurface,                                        &
+     &      uniformLin_PhiSurf, uniformFreeSurfLev,                               &
+     &      exactConserv, linFSConserveTr, useRealFreshWaterFlux,                 &
+     &      storePhiHyd4Phys, quasiHydrostatic, nonHydrostatic,                   &
+     &      use3Dsolver, implicitIntGravWave, staggerTimeStep,                    &
+     &      applyExchUV_early, doResetHFactors,                                   &
+     &      implicitDiffusion, implicitViscosity,                                 &
+     &      tempImplVertAdv, saltImplVertAdv, momImplVertAdv,                     &
+     &      multiDimAdvection, useMultiDimAdvec,                                  &
+     &      momDissip_In_AB, doAB_onGtGs,                                         &
+     &      balanceQnet, balancePrintMean,                                        &
+     &      balanceThetaClimRelax, balanceSaltClimRelax,                          &
+     &      doThetaClimRelax, doSaltClimRelax,                                    &
+     &      allowFreezing,                                                        &
+     &      periodicExternalForcing,                                              &
+     &      globalFiles,                                                          &
+     &      pickupStrictlyMatch, usePickupBeforeC54, startFromPickupAB2,          &
+     &      pickup_read_mdsio, pickup_write_mdsio, pickup_write_immed,            &
+     &      writePickupAtEnd,                                                     &
+     &      snapshot_mdsio, monitor_stdio,                                        &
+     &      outputTypesInclusive, dumpInitAndLast
 
-      LOGICAL fluidIsAir
-      LOGICAL fluidIsWater
-      LOGICAL usingPCoords
-      LOGICAL usingZCoords
-      LOGICAL usingCartesianGrid
-      LOGICAL usingSphericalPolarGrid, rotateGrid
-      LOGICAL usingCylindricalGrid
-      LOGICAL usingCurvilinearGrid, hasWetCSCorners
-      LOGICAL deepAtmosphere
-      LOGICAL setInterFDr
-      LOGICAL setCenterDr
-      LOGICAL useMin4hFacEdges
-      LOGICAL interViscAr_pCell
-      LOGICAL interDiffKr_pCell
+      LOGICAL :: fluidIsAir
+      LOGICAL :: fluidIsWater
+      LOGICAL :: usingPCoords
+      LOGICAL :: usingZCoords
+      LOGICAL :: usingCartesianGrid
+      LOGICAL :: usingSphericalPolarGrid, rotateGrid
+      LOGICAL :: usingCylindricalGrid
+      LOGICAL :: usingCurvilinearGrid, hasWetCSCorners
+      LOGICAL :: deepAtmosphere
+      LOGICAL :: setInterFDr
+      LOGICAL :: setCenterDr
+      LOGICAL :: useMin4hFacEdges
+      LOGICAL :: interViscAr_pCell
+      LOGICAL :: interDiffKr_pCell
 
-      LOGICAL no_slip_sides
-      LOGICAL no_slip_bottom
-      LOGICAL bottomVisc_pCell
-      LOGICAL useSmag3D
-      LOGICAL useFullLeith
-      LOGICAL useStrainTensionVisc
-      LOGICAL useAreaViscLength
-      LOGICAL momViscosity
-      LOGICAL momAdvection
-      LOGICAL momForcing
-      LOGICAL momTidalForcing
-      LOGICAL momPressureForcing
-      LOGICAL useNHMTerms
+      LOGICAL :: no_slip_sides
+      LOGICAL :: no_slip_bottom
+      LOGICAL :: bottomVisc_pCell
+      LOGICAL :: useSmag3D
+      LOGICAL :: useFullLeith
+      LOGICAL :: useStrainTensionVisc
+      LOGICAL :: useAreaViscLength
+      LOGICAL :: momViscosity
+      LOGICAL :: momAdvection
+      LOGICAL :: momForcing
+      LOGICAL :: momTidalForcing
+      LOGICAL :: momPressureForcing
+      LOGICAL :: useNHMTerms
 
-      LOGICAL useCoriolis
-      LOGICAL useCDscheme
-      LOGICAL vectorInvariantMomentum
-      LOGICAL useJamartMomAdv
-      LOGICAL upwindVorticity
-      LOGICAL highOrderVorticity
-      LOGICAL useAbsVorticity
-      LOGICAL upwindShear
-      LOGICAL momStepping
-      LOGICAL calc_wVelocity
-      LOGICAL tempStepping
-      LOGICAL saltStepping
-      LOGICAL addFrictionHeating
-      LOGICAL temp_stayPositive
-      LOGICAL salt_stayPositive
-      LOGICAL tempAdvection
-      LOGICAL tempVertDiff4
-      LOGICAL tempIsActiveTr
-      LOGICAL tempForcing
-      LOGICAL saltAdvection
-      LOGICAL saltVertDiff4
-      LOGICAL saltIsActiveTr
-      LOGICAL saltForcing
-      LOGICAL maskIniTemp
-      LOGICAL maskIniSalt
-      LOGICAL checkIniTemp
-      LOGICAL checkIniSalt
-      LOGICAL useNSACGSolver
-      LOGICAL useSRCGSolver
-      LOGICAL rigidLid
-      LOGICAL implicitFreeSurface
-      LOGICAL uniformLin_PhiSurf
-      LOGICAL uniformFreeSurfLev
-      LOGICAL exactConserv
-      LOGICAL linFSConserveTr
-      LOGICAL useRealFreshWaterFlux
-      LOGICAL storePhiHyd4Phys
-      LOGICAL quasiHydrostatic
-      LOGICAL nonHydrostatic
-      LOGICAL use3Dsolver
-      LOGICAL implicitIntGravWave
-      LOGICAL staggerTimeStep
-      LOGICAL applyExchUV_early
-      LOGICAL doResetHFactors
-      LOGICAL implicitDiffusion
-      LOGICAL implicitViscosity
-      LOGICAL tempImplVertAdv
-      LOGICAL saltImplVertAdv
-      LOGICAL momImplVertAdv
-      LOGICAL multiDimAdvection
-      LOGICAL useMultiDimAdvec
-      LOGICAL momDissip_In_AB
-      LOGICAL doAB_onGtGs
-      LOGICAL balanceQnet
-      LOGICAL balancePrintMean
-      LOGICAL doThetaClimRelax
-      LOGICAL doSaltClimRelax
-      LOGICAL balanceThetaClimRelax
-      LOGICAL balanceSaltClimRelax
-      LOGICAL allowFreezing
-      LOGICAL periodicExternalForcing
-      LOGICAL globalFiles
-      LOGICAL pickupStrictlyMatch
-      LOGICAL usePickupBeforeC54
-      LOGICAL startFromPickupAB2
-      LOGICAL pickup_read_mdsio, pickup_write_mdsio
-      LOGICAL pickup_write_immed, writePickupAtEnd
-      LOGICAL snapshot_mdsio, monitor_stdio
-      LOGICAL outputTypesInclusive
-      LOGICAL dumpInitAndLast
+      LOGICAL :: useCoriolis
+      LOGICAL :: useCDscheme
+      LOGICAL :: vectorInvariantMomentum
+      LOGICAL :: useJamartMomAdv
+      LOGICAL :: upwindVorticity
+      LOGICAL :: highOrderVorticity
+      LOGICAL :: useAbsVorticity
+      LOGICAL :: upwindShear
+      LOGICAL :: momStepping
+      LOGICAL :: calc_wVelocity
+      LOGICAL :: tempStepping
+      LOGICAL :: saltStepping
+      LOGICAL :: addFrictionHeating
+      LOGICAL :: temp_stayPositive
+      LOGICAL :: salt_stayPositive
+      LOGICAL :: tempAdvection
+      LOGICAL :: tempVertDiff4
+      LOGICAL :: tempIsActiveTr
+      LOGICAL :: tempForcing
+      LOGICAL :: saltAdvection
+      LOGICAL :: saltVertDiff4
+      LOGICAL :: saltIsActiveTr
+      LOGICAL :: saltForcing
+      LOGICAL :: maskIniTemp
+      LOGICAL :: maskIniSalt
+      LOGICAL :: checkIniTemp
+      LOGICAL :: checkIniSalt
+      LOGICAL :: useNSACGSolver
+      LOGICAL :: useSRCGSolver
+      LOGICAL :: rigidLid
+      LOGICAL :: implicitFreeSurface
+      LOGICAL :: uniformLin_PhiSurf
+      LOGICAL :: uniformFreeSurfLev
+      LOGICAL :: exactConserv
+      LOGICAL :: linFSConserveTr
+      LOGICAL :: useRealFreshWaterFlux
+      LOGICAL :: storePhiHyd4Phys
+      LOGICAL :: quasiHydrostatic
+      LOGICAL :: nonHydrostatic
+      LOGICAL :: use3Dsolver
+      LOGICAL :: implicitIntGravWave
+      LOGICAL :: staggerTimeStep
+      LOGICAL :: applyExchUV_early
+      LOGICAL :: doResetHFactors
+      LOGICAL :: implicitDiffusion
+      LOGICAL :: implicitViscosity
+      LOGICAL :: tempImplVertAdv
+      LOGICAL :: saltImplVertAdv
+      LOGICAL :: momImplVertAdv
+      LOGICAL :: multiDimAdvection
+      LOGICAL :: useMultiDimAdvec
+      LOGICAL :: momDissip_In_AB
+      LOGICAL :: doAB_onGtGs
+      LOGICAL :: balanceQnet
+      LOGICAL :: balancePrintMean
+      LOGICAL :: doThetaClimRelax
+      LOGICAL :: doSaltClimRelax
+      LOGICAL :: balanceThetaClimRelax
+      LOGICAL :: balanceSaltClimRelax
+      LOGICAL :: allowFreezing
+      LOGICAL :: periodicExternalForcing
+      LOGICAL :: globalFiles
+      LOGICAL :: pickupStrictlyMatch
+      LOGICAL :: usePickupBeforeC54
+      LOGICAL :: startFromPickupAB2
+      LOGICAL :: pickup_read_mdsio, pickup_write_mdsio
+      LOGICAL :: pickup_write_immed, writePickupAtEnd
+      LOGICAL :: snapshot_mdsio, monitor_stdio
+      LOGICAL :: outputTypesInclusive
+      LOGICAL :: dumpInitAndLast
 
-C--   COMMON /PARM_R/ "Real" valued parameters used by the model.
-C     cg2dTargetResidual
-C          :: Target residual for cg2d solver ; no unit (RHS normalisation)
-C     cg2dTargetResWunit
-C          :: Target residual for cg2d solver ; W unit (No RHS normalisation)
-C     cg3dTargetResidual
-C          :: Target residual for cg3d solver ; no unit (RHS normalisation)
-C     cg3dTargetResWunit
-C          :: Target residual for cg3d solver ; W unit (No RHS normalisation)
-C     cg2dpcOffDFac :: Averaging weight for preconditioner off-diagonal.
-C     Note. 20th May 1998
-C           I made a weird discovery! In the model paper we argue
-C           for the form of the preconditioner used here ( see
-C           A Finite-volume, Incompressible Navier-Stokes Model
-C           ...., Marshall et. al ). The algebra gives a simple
-C           0.5 factor for the averaging of ac and aCw to get a
-C           symmettric pre-conditioner. By using a factor of 0.51
-C           i.e. scaling the off-diagonal terms in the
-C           preconditioner down slightly I managed to get the
-C           number of iterations for convergence in a test case to
-C           drop form 192 -> 134! Need to investigate this further!
-C           For now I have introduced a parameter cg2dpcOffDFac which
-C           defaults to 0.51 but can be set at runtime.
-C     delR      :: Vertical grid spacing ( units of r ).
-C     delRc     :: Vertical grid spacing between cell centers (r unit).
-C     delX      :: Separation between cell faces (m) or (deg), depending
-C     delY         on input flags. Note: moved to header file SET_GRID.h
-C     xgOrigin   :: Origin of the X-axis (Cartesian Grid) / Longitude of Western
-C                :: most cell face (Lat-Lon grid) (Note: this is an "inert"
-C                :: parameter but it makes geographical references simple.)
-C     ygOrigin   :: Origin of the Y-axis (Cartesian Grid) / Latitude of Southern
-C                :: most face (Lat-Lon grid).
-C     rSphere    :: Radius of sphere for a spherical polar grid ( m ).
-C     recip_rSphere :: Reciprocal radius of sphere ( m^-1 ).
-C     radius_fromHorizGrid :: sphere Radius of input horiz. grid (Curvilinear Grid)
-C     seaLev_Z   :: the reference height of sea-level (usually zero)
-C     top_Pres   :: pressure (P-Coords) or reference pressure (Z-Coords) at the top
-C     rSigmaBnd  :: vertical position (in r-unit) of r/sigma transition (Hybrid-Sigma)
-C     gravity    :: Acceleration due to constant gravity ( m/s^2 )
-C     recip_gravity :: Reciprocal gravity acceleration ( s^2/m )
-C     gBaro      :: Accel. due to gravity used in barotropic equation ( m/s^2 )
-C     gravFacC   :: gravity factor (vs surf. gravity) vert. profile at cell-Center
-C     gravFacF   :: gravity factor (vs surf. gravity) vert. profile at cell-interF
-C     rhoNil     :: Reference density for the linear equation of state
-C     rhoConst   :: Vertically constant reference density (Boussinesq)
-C     rho1Ref    :: reference vertical profile for density (anelastic)
-C     rhoFacC    :: normalized (by rhoConst) reference density at cell-Center
-C     rhoFacF    :: normalized (by rhoConst) reference density at cell-interFace
-C     rhoConstFresh :: Constant reference density for fresh water (rain)
-C     thetaConst :: Constant reference for potential temperature
-C     tRef       :: reference vertical profile for potential temperature
-C     sRef       :: reference vertical profile for salinity/specific humidity
-C     rhoRef     :: density vertical profile from (tRef,sRef) [kg/m^3]
-C     dBdrRef    :: vertical gradient of reference buoyancy  [(m/s/r)^2]:
-C                :: z-coord: = N^2_ref = Brunt-Vaissala frequency [s^-2]
-C                :: p-coord: = -(d.alpha/dp)_ref          [(m^2.s/kg)^2]
-C     surf_pRef  :: surface reference pressure ( Pa )
-C     pRef4EOS   :: reference pressure used in EOS (case selectP_inEOS_Zc=1)
-C     phiRef     :: reference potential (press/rho, geopot) profile (m^2/s^2)
-C     rVel2wUnit :: units conversion factor (Non-Hydrostatic code),
-C                :: from r-coordinate vertical velocity to vertical velocity [m/s].
-C                :: z-coord: = 1 ; p-coord: wSpeed [m/s] = rVel [Pa/s] * rVel2wUnit
-C     wUnit2rVel :: units conversion factor (Non-Hydrostatic code),
-C                :: from vertical velocity [m/s] to r-coordinate vertical velocity.
-C                :: z-coord: = 1 ; p-coord: rVel [Pa/s] = wSpeed [m/s] * wUnit2rVel
-C     rUnit2z    :: units conversion factor (for ocean in P-coord, only fct of k),
-C                :: from r-coordinate to z [m] (at level center):
-C                :: z-coord: = 1 ; p-coord: dz [m] = dr [Pa] * rUnit2z
-C     z2rUnit    :: units conversion factor (for ocean in P-coord, only fct of k),
-C                :: from z [m] to r-coordinate (at level center):
-C                :: z-coord: = 1 ; p-coord: dr [Pa] = dz [m] * z2rUnit
-C     mass2rUnit :: units conversion factor (surface forcing),
-C                :: from mass per unit area [kg/m2] to vertical r-coordinate unit.
-C                :: z-coord: = 1/rhoConst ( [kg/m2] / rho = [m] ) ;
-C                :: p-coord: = gravity    ( [kg/m2] *  g = [Pa] ) ;
-C     rUnit2mass :: units conversion factor (surface forcing),
-C                :: from vertical r-coordinate unit to mass per unit area [kg/m2].
-C                :: z-coord: = rhoConst  ( [m] * rho = [kg/m2] ) ;
-C                :: p-coord: = 1/gravity ( [Pa] /  g = [kg/m2] ) ;
-C     sIceLoadFac:: factor to scale (and turn off) sIceLoad (sea-ice loading)
-C                   default = 1
-C     f0         :: Reference coriolis parameter ( 1/s )
-C                   ( Southern edge f for beta plane )
-C     beta       :: df/dy ( s^-1.m^-1 )
-C     fPrime     :: Second Coriolis parameter ( 1/s ), related to Y-component
-C                   of rotation (reference value = 2.Omega.Cos(Phi))
-C     omega      :: Angular velocity ( rad/s )
-C     rotationPeriod :: Rotation period (s) (= 2.pi/omega)
-C     viscArNr   :: vertical profile of Eddy viscosity coeff.
-C                   for vertical mixing of momentum ( units of r^2/s )
-C     viscAh     :: Eddy viscosity coeff. for mixing of
-C                   momentum laterally ( m^2/s )
-C     viscAhW    :: Eddy viscosity coeff. for mixing of vertical
-C                   momentum laterally, no effect for hydrostatic
-C                   model, defaults to viscAhD if unset ( m^2/s )
-C                   Not used if variable horiz. viscosity is used.
-C     viscA4     :: Biharmonic viscosity coeff. for mixing of
-C                   momentum laterally ( m^4/s )
-C     viscA4W    :: Biharmonic viscosity coeff. for mixing of vertical
-C                   momentum laterally, no effect for hydrostatic
-C                   model, defaults to viscA4D if unset ( m^2/s )
-C                   Not used if variable horiz. viscosity is used.
-C     viscAhD    :: Eddy viscosity coeff. for mixing of momentum laterally
-C                   (act on Divergence part) ( m^2/s )
-C     viscAhZ    :: Eddy viscosity coeff. for mixing of momentum laterally
-C                   (act on Vorticity  part) ( m^2/s )
-C     viscA4D    :: Biharmonic viscosity coeff. for mixing of momentum laterally
-C                   (act on Divergence part) ( m^4/s )
-C     viscA4Z    :: Biharmonic viscosity coeff. for mixing of momentum laterally
-C                   (act on Vorticity  part) ( m^4/s )
-C     smag3D_coeff     :: Isotropic 3-D Smagorinsky viscosity coefficient (-)
-C     smag3D_diffCoeff :: Isotropic 3-D Smagorinsky diffusivity coefficient (-)
-C     viscC2leith  :: Leith non-dimensional viscosity factor (grad(vort))
-C     viscC2leithD :: Modified Leith non-dimensional visc. factor (grad(div))
-C     viscC2LeithQG:: QG Leith non-dimensional viscosity factor
-C     viscC4leith  :: Leith non-dimensional viscosity factor (grad(vort))
-C     viscC4leithD :: Modified Leith non-dimensional viscosity factor (grad(div))
-C     viscC2smag   :: Smagorinsky non-dimensional viscosity factor (harmonic)
-C     viscC4smag   :: Smagorinsky non-dimensional viscosity factor (biharmonic)
-C     viscAhMax    :: Maximum eddy viscosity coeff. for mixing of
-C                    momentum laterally ( m^2/s )
-C     viscAhReMax  :: Maximum gridscale Reynolds number for eddy viscosity
-C                     coeff. for mixing of momentum laterally (non-dim)
-C     viscAhGrid   :: non-dimensional grid-size dependent viscosity
-C     viscAhGridMax:: maximum and minimum harmonic viscosity coefficients ...
-C     viscAhGridMin::  in terms of non-dimensional grid-size dependent visc.
-C     viscA4Max    :: Maximum biharmonic viscosity coeff. for mixing of
-C                     momentum laterally ( m^4/s )
-C     viscA4ReMax  :: Maximum Gridscale Reynolds number for
-C                     biharmonic viscosity coeff. momentum laterally (non-dim)
-C     viscA4Grid   :: non-dimensional grid-size dependent bi-harmonic viscosity
-C     viscA4GridMax:: maximum and minimum biharmonic viscosity coefficients ...
-C     viscA4GridMin::  in terms of non-dimensional grid-size dependent viscosity
-C     diffKhT   :: Laplacian diffusion coeff. for mixing of
-C                 heat laterally ( m^2/s )
-C     diffK4T   :: Biharmonic diffusion coeff. for mixing of
-C                 heat laterally ( m^4/s )
-C     diffKrNrT :: vertical profile of Laplacian diffusion coeff.
-C                 for mixing of heat vertically ( units of r^2/s )
-C     diffKr4T  :: vertical profile of Biharmonic diffusion coeff.
-C                 for mixing of heat vertically ( units of r^4/s )
-C     diffKhS  ::  Laplacian diffusion coeff. for mixing of
-C                 salt laterally ( m^2/s )
-C     diffK4S   :: Biharmonic diffusion coeff. for mixing of
-C                 salt laterally ( m^4/s )
-C     diffKrNrS :: vertical profile of Laplacian diffusion coeff.
-C                 for mixing of salt vertically ( units of r^2/s ),
-C     diffKr4S  :: vertical profile of Biharmonic diffusion coeff.
-C                 for mixing of salt vertically ( units of r^4/s )
-C     diffKrBL79surf :: T/S surface diffusivity (m^2/s) Bryan and Lewis, 1979
-C     diffKrBL79deep :: T/S deep diffusivity (m^2/s) Bryan and Lewis, 1979
-C     diffKrBL79scl  :: depth scale for arctan fn (m) Bryan and Lewis, 1979
-C     diffKrBL79Ho   :: depth offset for arctan fn (m) Bryan and Lewis, 1979
-C     BL79LatVary    :: polarwise of this latitude diffKrBL79 is applied with
-C                       gradual transition to diffKrBLEQ towards Equator
-C     diffKrBLEQsurf :: same as diffKrBL79surf but at Equator
-C     diffKrBLEQdeep :: same as diffKrBL79deep but at Equator
-C     diffKrBLEQscl  :: same as diffKrBL79scl but at Equator
-C     diffKrBLEQHo   :: same as diffKrBL79Ho but at Equator
-C     pCellMix_maxFac :: maximum enhanced mixing factor for thin partial-cell
-C     pCellMix_delR   :: thickness criteria   for too thin partial-cell
-C     pCellMix_viscAr :: vertical viscosity   for too thin partial-cell
-C     pCellMix_diffKr :: vertical diffusivity for too thin partial-cell
-C     deltaT    :: Default timestep ( s )
-C     deltaTClock  :: Timestep used as model "clock". This determines the
-C                    IO frequencies and is used in tagging output. It can
-C                    be totally different to the dynamical time. Typically
-C                    it will be the deep-water timestep for accelerated runs.
-C                    Frequency of checkpointing and dumping of the model state
-C                    are referenced to this clock. ( s )
-C     deltaTMom    :: Timestep for momemtum equations ( s )
-C     dTtracerLev  :: Timestep for tracer equations ( s ), function of level k
-C     deltaTFreeSurf :: Timestep for free-surface equation ( s )
-C     freeSurfFac  :: Parameter to turn implicit free surface term on or off
-C                     freeSurFac = 1. uses implicit free surface
-C                     freeSurFac = 0. uses rigid lid
-C     abEps        :: Adams-Bashforth-2 stabilizing weight
-C     alph_AB      :: Adams-Bashforth-3 primary factor
-C     beta_AB      :: Adams-Bashforth-3 secondary factor
-C     implicSurfPress :: parameter of the Crank-Nickelson time stepping :
-C                     Implicit part of Surface Pressure Gradient ( 0-1 )
-C     implicDiv2DFlow :: parameter of the Crank-Nickelson time stepping :
-C                     Implicit part of barotropic flow Divergence ( 0-1 )
-C     implicitNHPress :: parameter of the Crank-Nickelson time stepping :
-C                     Implicit part of Non-Hydrostatic Pressure Gradient ( 0-1 )
-C     hFacMin      :: Minimum fraction size of a cell (affects hFacC etc...)
-C     hFacMinDz    :: Minimum dimensional size of a cell (affects hFacC etc..., m)
-C     hFacMinDp    :: Minimum dimensional size of a cell (affects hFacC etc..., Pa)
-C     hFacMinDr    :: Minimum dimensional size of a cell (-> hFacC etc..., r units)
-C     hFacInf      :: Threshold (inf and sup) for fraction size of surface cell
-C     hFacSup          that control vanishing and creating levels
-C     tauCD         :: CD scheme coupling timescale ( s )
-C     rCD           :: CD scheme normalised coupling parameter (= 1 - deltaT/tauCD)
-C     epsAB_CD      :: Adams-Bashforth-2 stabilizing weight used in CD scheme
-C     baseTime      :: model base time (time origin) = time @ iteration zero
-C     startTime     :: Starting time for this integration ( s ).
-C     endTime       :: Ending time for this integration ( s ).
-C     chkPtFreq     :: Frequency of rolling check pointing ( s ).
-C     pChkPtFreq    :: Frequency of permanent check pointing ( s ).
-C     dumpFreq      :: Frequency with which model state is written to
-C                      post-processing files ( s ).
-C     diagFreq      :: Frequency with which model writes diagnostic output
-C                      of intermediate quantities.
-C     afFacMom      :: Advection of momentum term multiplication factor
-C     vfFacMom      :: Momentum viscosity term    multiplication factor
-C     pfFacMom      :: Momentum pressure forcing  multiplication factor
-C     cfFacMom      :: Coriolis term              multiplication factor
-C     foFacMom      :: Momentum forcing           multiplication factor
-C     mtFacMom      :: Metric terms               multiplication factor
-C     cosPower      :: Power of cosine of latitude to multiply viscosity
-C     cAdjFreq      :: Frequency of convective adjustment
-C
-C     tauThetaClimRelax :: Relaxation to climatology time scale ( s ).
-C     tauSaltClimRelax :: Relaxation to climatology time scale ( s ).
-C     latBandClimRelax :: latitude band where Relaxation to Clim. is applied,
-C                         i.e. where |yC| <= latBandClimRelax
-C     externForcingPeriod :: Is the period of which forcing varies (eg. 1 month)
-C     externForcingCycle :: Is the repeat time of the forcing (eg. 1 year)
-C                          (note: externForcingCycle must be an integer
-C                           number times externForcingPeriod)
-C     convertFW2Salt :: salinity, used to convert Fresh-Water Flux to Salt Flux
-C                       (use model surface (local) value if set to -1)
-C     temp_EvPrRn :: temperature of Rain & Evap.
-C     salt_EvPrRn :: salinity of Rain & Evap.
-C     temp_addMass :: temperature of addMass field
-C     salt_addMass :: salinity of addMass field
-C        (notes: a) tracer content of Rain/Evap only used if both
-C                     NonLin_FrSurf & useRealFreshWater are set.
-C                b) use model surface (local) value if set to UNSET_RL)
-C     hMixCriteria:: criteria for mixed-layer diagnostic
-C     dRhoSmall   :: parameter for mixed-layer diagnostic
-C     hMixSmooth  :: Smoothing parameter for mixed-layer diag
-C                    (default=0: no smoothing)
-C     ivdc_kappa  :: implicit vertical diffusivity for convection [m^2/s]
-C     sideDragFactor     :: side-drag scaling factor (used only if no_slip_sides)
-C                           (default=2: full drag ; =1: gives half-slip BC)
-C     bottomDragLinear    :: Linear    bottom-drag coefficient (units of [r]/s)
-C     bottomDragQuadratic :: Quadratic bottom-drag coefficient (units of [r]/m)
-C               (if using zcoordinate, units becomes linear: m/s, quadratic: [-])
-C     zRoughBot :: roughness length for quadratic bottom friction coefficient
-C                  (in m, typical values are order 0.01 m)
-C     smoothAbsFuncRange :: 1/2 of interval around zero, for which FORTRAN ABS
-C                           is to be replace by a smoother function
-C                           (affects myabs, mymin, mymax)
-C     nh_Am2        :: scales non-hydrostatic terms and changes internal scales
-C                      (i.e. allows convection at different Rayleigh numbers)
-C     tCylIn        :: Temperature of the cylinder inner boundary
-C     tCylOut       :: Temperature of the cylinder outer boundary
-C     phiEuler      :: Euler angle, rotation about original z-axis
-C     thetaEuler    :: Euler angle, rotation about new x-axis
-C     psiEuler      :: Euler angle, rotation about new z-axis
-      COMMON /PARM_R/ cg2dTargetResidual, cg2dTargetResWunit,
-     & cg2dpcOffDFac, cg3dTargetResidual, cg3dTargetResWunit,
-     & delR, delRc, xgOrigin, ygOrigin, rSphere, recip_rSphere,
-     & radius_fromHorizGrid, seaLev_Z, top_Pres, rSigmaBnd,
-     & deltaT, deltaTMom, dTtracerLev, deltaTFreeSurf, deltaTClock,
-     & abEps, alph_AB, beta_AB,
-     & f0, beta, fPrime, omega, rotationPeriod,
-     & viscFacAdj, viscAh, viscAhW, smag3D_coeff, smag3D_diffCoeff,
-     & viscAhMax, viscAhGrid, viscAhGridMax, viscAhGridMin,
-     & viscC2leith, viscC2leithD, viscC2LeithQG,
-     & viscC2smag, viscC4smag,
-     & viscAhD, viscAhZ, viscA4D, viscA4Z,
-     & viscA4, viscA4W, viscA4Max,
-     & viscA4Grid, viscA4GridMax, viscA4GridMin,
-     & viscAhReMax, viscA4ReMax,
-     & viscC4leith, viscC4leithD, viscArNr,
-     & diffKhT, diffK4T, diffKrNrT, diffKr4T,
-     & diffKhS, diffK4S, diffKrNrS, diffKr4S,
-     & diffKrBL79surf, diffKrBL79deep, diffKrBL79scl, diffKrBL79Ho,
-     & BL79LatVary,
-     & diffKrBLEQsurf, diffKrBLEQdeep, diffKrBLEQscl, diffKrBLEQHo,
-     & pCellMix_maxFac, pCellMix_delR, pCellMix_viscAr, pCellMix_diffKr,
-     & tauCD, rCD, epsAB_CD,
-     & freeSurfFac, implicSurfPress, implicDiv2DFlow, implicitNHPress,
-     & hFacMin, hFacMinDz, hFacInf, hFacSup,
-     & gravity, recip_gravity, gBaro,
-     & gravFacC, recip_gravFacC, gravFacF, recip_gravFacF,
-     & rhoNil, rhoConst, recip_rhoConst, rho1Ref,
-     & rhoFacC, recip_rhoFacC, rhoFacF, recip_rhoFacF, rhoConstFresh,
-     & thetaConst, tRef, sRef, rhoRef, dBdrRef,
-     & surf_pRef, pRef4EOS, phiRef,
-     & rVel2wUnit, wUnit2rVel, rUnit2z, z2rUnit, mass2rUnit, rUnit2mass,
-     & baseTime, startTime, endTime,
-     & chkPtFreq, pChkPtFreq, dumpFreq, adjDumpFreq,
-     & diagFreq, monitorFreq, adjMonitorFreq,
-     & afFacMom, vfFacMom, pfFacMom, cfFacMom, foFacMom, mtFacMom,
-     & cosPower, cAdjFreq,
-     & tauThetaClimRelax, tauSaltClimRelax, latBandClimRelax,
-     & externForcingCycle, externForcingPeriod,
-     & convertFW2Salt, temp_EvPrRn, salt_EvPrRn,
-     & temp_addMass, salt_addMass, hFacMinDr, hFacMinDp,
-     & ivdc_kappa, hMixCriteria, dRhoSmall, hMixSmooth,
-     & sideDragFactor, bottomDragLinear, bottomDragQuadratic,
-     & zRoughBot, nh_Am2, smoothAbsFuncRange, sIceLoadFac,
-     & tCylIn, tCylOut,
-     & phiEuler, thetaEuler, psiEuler
+!--   COMMON /PARM_R/ "Real" valued parameters used by the model.
+! cg2dTargetResidual
+!      :: Target residual for cg2d solver ; no unit (RHS normalisation)
+! cg2dTargetResWunit
+!      :: Target residual for cg2d solver ; W unit (No RHS normalisation)
+! cg3dTargetResidual
+!      :: Target residual for cg3d solver ; no unit (RHS normalisation)
+! cg3dTargetResWunit
+!      :: Target residual for cg3d solver ; W unit (No RHS normalisation)
+! cg2dpcOffDFac :: Averaging weight for preconditioner off-diagonal.
+! Note. 20th May 1998
+!       I made a weird discovery! In the model paper we argue
+!       for the form of the preconditioner used here ( see
+!       A Finite-volume, Incompressible Navier-Stokes Model
+!       ...., Marshall et. al ). The algebra gives a simple
+!       0.5 factor for the averaging of ac and aCw to get a
+!       symmettric pre-conditioner. By using a factor of 0.51
+!       i.e. scaling the off-diagonal terms in the
+!       preconditioner down slightly I managed to get the
+!       number of iterations for convergence in a test case to
+!       drop form 192 -> 134! Need to investigate this further!
+!       For now I have introduced a parameter cg2dpcOffDFac which
+!       defaults to 0.51 but can be set at runtime.
+! delR      :: Vertical grid spacing ( units of r ).
+! delRc     :: Vertical grid spacing between cell centers (r unit).
+! delX      :: Separation between cell faces (m) or (deg), depending
+! delY         on input flags. Note: moved to header file SET_GRID.h
+! xgOrigin   :: Origin of the X-axis (Cartesian Grid) / Longitude of Western
+!            :: most cell face (Lat-Lon grid) (Note: this is an "inert"
+!            :: parameter but it makes geographical references simple.)
+! ygOrigin   :: Origin of the Y-axis (Cartesian Grid) / Latitude of Southern
+!            :: most face (Lat-Lon grid).
+! rSphere    :: Radius of sphere for a spherical polar grid ( m ).
+! recip_rSphere :: Reciprocal radius of sphere ( m^-1 ).
+! radius_fromHorizGrid :: sphere Radius of input horiz. grid (Curvilinear Grid)
+! seaLev_Z   :: the reference height of sea-level (usually zero)
+! top_Pres   :: pressure (P-Coords) or reference pressure (Z-Coords) at the top
+! rSigmaBnd  :: vertical position (in r-unit) of r/sigma transition (Hybrid-Sigma)
+! gravity    :: Acceleration due to constant gravity ( m/s^2 )
+! recip_gravity :: Reciprocal gravity acceleration ( s^2/m )
+! gBaro      :: Accel. due to gravity used in barotropic equation ( m/s^2 )
+! gravFacC   :: gravity factor (vs surf. gravity) vert. profile at cell-Center
+! gravFacF   :: gravity factor (vs surf. gravity) vert. profile at cell-interF
+! rhoNil     :: Reference density for the linear equation of state
+! rhoConst   :: Vertically constant reference density (Boussinesq)
+! rho1Ref    :: reference vertical profile for density (anelastic)
+! rhoFacC    :: normalized (by rhoConst) reference density at cell-Center
+! rhoFacF    :: normalized (by rhoConst) reference density at cell-interFace
+! rhoConstFresh :: Constant reference density for fresh water (rain)
+! thetaConst :: Constant reference for potential temperature
+! tRef       :: reference vertical profile for potential temperature
+! sRef       :: reference vertical profile for salinity/specific humidity
+! rhoRef     :: density vertical profile from (tRef,sRef) [kg/m^3]
+! dBdrRef    :: vertical gradient of reference buoyancy  [(m/s/r)^2]:
+!            :: z-coord: = N^2_ref = Brunt-Vaissala frequency [s^-2]
+!            :: p-coord: = -(d.alpha/dp)_ref          [(m^2.s/kg)^2]
+! surf_pRef  :: surface reference pressure ( Pa )
+! pRef4EOS   :: reference pressure used in EOS (case selectP_inEOS_Zc=1)
+! phiRef     :: reference potential (press/rho, geopot) profile (m^2/s^2)
+! rVel2wUnit :: units conversion factor (Non-Hydrostatic code),
+!            :: from r-coordinate vertical velocity to vertical velocity [m/s].
+!            :: z-coord: = 1 ; p-coord: wSpeed [m/s] = rVel [Pa/s] * rVel2wUnit
+! wUnit2rVel :: units conversion factor (Non-Hydrostatic code),
+!            :: from vertical velocity [m/s] to r-coordinate vertical velocity.
+!            :: z-coord: = 1 ; p-coord: rVel [Pa/s] = wSpeed [m/s] * wUnit2rVel
+! rUnit2z    :: units conversion factor (for ocean in P-coord, only fct of k),
+!            :: from r-coordinate to z [m] (at level center):
+!            :: z-coord: = 1 ; p-coord: dz [m] = dr [Pa] * rUnit2z
+! z2rUnit    :: units conversion factor (for ocean in P-coord, only fct of k),
+!            :: from z [m] to r-coordinate (at level center):
+!            :: z-coord: = 1 ; p-coord: dr [Pa] = dz [m] * z2rUnit
+! mass2rUnit :: units conversion factor (surface forcing),
+!            :: from mass per unit area [kg/m2] to vertical r-coordinate unit.
+!            :: z-coord: = 1/rhoConst ( [kg/m2] / rho = [m] ) ;
+!            :: p-coord: = gravity    ( [kg/m2] *  g = [Pa] ) ;
+! rUnit2mass :: units conversion factor (surface forcing),
+!            :: from vertical r-coordinate unit to mass per unit area [kg/m2].
+!            :: z-coord: = rhoConst  ( [m] * rho = [kg/m2] ) ;
+!            :: p-coord: = 1/gravity ( [Pa] /  g = [kg/m2] ) ;
+! sIceLoadFac:: factor to scale (and turn off) sIceLoad (sea-ice loading)
+!               default = 1
+! f0         :: Reference coriolis parameter ( 1/s )
+!               ( Southern edge f for beta plane )
+! beta       :: df/dy ( s^-1.m^-1 )
+! fPrime     :: Second Coriolis parameter ( 1/s ), related to Y-component
+!               of rotation (reference value = 2.Omega.Cos(Phi))
+! omega      :: Angular velocity ( rad/s )
+! rotationPeriod :: Rotation period (s) (= 2.pi/omega)
+! viscArNr   :: vertical profile of Eddy viscosity coeff.
+!               for vertical mixing of momentum ( units of r^2/s )
+! viscAh     :: Eddy viscosity coeff. for mixing of
+!               momentum laterally ( m^2/s )
+! viscAhW    :: Eddy viscosity coeff. for mixing of vertical
+!               momentum laterally, no effect for hydrostatic
+!               model, defaults to viscAhD if unset ( m^2/s )
+!               Not used if variable horiz. viscosity is used.
+! viscA4     :: Biharmonic viscosity coeff. for mixing of
+!               momentum laterally ( m^4/s )
+! viscA4W    :: Biharmonic viscosity coeff. for mixing of vertical
+!               momentum laterally, no effect for hydrostatic
+!               model, defaults to viscA4D if unset ( m^2/s )
+!               Not used if variable horiz. viscosity is used.
+! viscAhD    :: Eddy viscosity coeff. for mixing of momentum laterally
+!               (act on Divergence part) ( m^2/s )
+! viscAhZ    :: Eddy viscosity coeff. for mixing of momentum laterally
+!               (act on Vorticity  part) ( m^2/s )
+! viscA4D    :: Biharmonic viscosity coeff. for mixing of momentum laterally
+!               (act on Divergence part) ( m^4/s )
+! viscA4Z    :: Biharmonic viscosity coeff. for mixing of momentum laterally
+!               (act on Vorticity  part) ( m^4/s )
+! smag3D_coeff     :: Isotropic 3-D Smagorinsky viscosity coefficient (-)
+! smag3D_diffCoeff :: Isotropic 3-D Smagorinsky diffusivity coefficient (-)
+! viscC2leith  :: Leith non-dimensional viscosity factor (grad(vort))
+! viscC2leithD :: Modified Leith non-dimensional visc. factor (grad(div))
+! viscC2LeithQG:: QG Leith non-dimensional viscosity factor
+! viscC4leith  :: Leith non-dimensional viscosity factor (grad(vort))
+! viscC4leithD :: Modified Leith non-dimensional viscosity factor (grad(div))
+!     viscC2smag   :: Smagorinsky non-dimensional viscosity factor (harmonic)
+! viscC4smag   :: Smagorinsky non-dimensional viscosity factor (biharmonic)
+! viscAhMax    :: Maximum eddy viscosity coeff. for mixing of
+!                momentum laterally ( m^2/s )
+! viscAhReMax  :: Maximum gridscale Reynolds number for eddy viscosity
+!                 coeff. for mixing of momentum laterally (non-dim)
+! viscAhGrid   :: non-dimensional grid-size dependent viscosity
+! viscAhGridMax:: maximum and minimum harmonic viscosity coefficients ...
+! viscAhGridMin::  in terms of non-dimensional grid-size dependent visc.
+! viscA4Max    :: Maximum biharmonic viscosity coeff. for mixing of
+!                 momentum laterally ( m^4/s )
+! viscA4ReMax  :: Maximum Gridscale Reynolds number for
+!                 biharmonic viscosity coeff. momentum laterally (non-dim)
+! viscA4Grid   :: non-dimensional grid-size dependent bi-harmonic viscosity
+! viscA4GridMax:: maximum and minimum biharmonic viscosity coefficients ...
+! viscA4GridMin::  in terms of non-dimensional grid-size dependent viscosity
+! diffKhT   :: Laplacian diffusion coeff. for mixing of
+!             heat laterally ( m^2/s )
+! diffK4T   :: Biharmonic diffusion coeff. for mixing of
+!             heat laterally ( m^4/s )
+! diffKrNrT :: vertical profile of Laplacian diffusion coeff.
+!             for mixing of heat vertically ( units of r^2/s )
+! diffKr4T  :: vertical profile of Biharmonic diffusion coeff.
+!             for mixing of heat vertically ( units of r^4/s )
+! diffKhS  ::  Laplacian diffusion coeff. for mixing of
+!             salt laterally ( m^2/s )
+! diffK4S   :: Biharmonic diffusion coeff. for mixing of
+!             salt laterally ( m^4/s )
+! diffKrNrS :: vertical profile of Laplacian diffusion coeff.
+!             for mixing of salt vertically ( units of r^2/s ),
+! diffKr4S  :: vertical profile of Biharmonic diffusion coeff.
+!             for mixing of salt vertically ( units of r^4/s )
+! diffKrBL79surf :: T/S surface diffusivity (m^2/s) Bryan and Lewis, 1979
+! diffKrBL79deep :: T/S deep diffusivity (m^2/s) Bryan and Lewis, 1979
+! diffKrBL79scl  :: depth scale for arctan fn (m) Bryan and Lewis, 1979
+! diffKrBL79Ho   :: depth offset for arctan fn (m) Bryan and Lewis, 1979
+! BL79LatVary    :: polarwise of this latitude diffKrBL79 is applied with
+!                   gradual transition to diffKrBLEQ towards Equator
+! diffKrBLEQsurf :: same as diffKrBL79surf but at Equator
+! diffKrBLEQdeep :: same as diffKrBL79deep but at Equator
+! diffKrBLEQscl  :: same as diffKrBL79scl but at Equator
+! diffKrBLEQHo   :: same as diffKrBL79Ho but at Equator
+! pCellMix_maxFac :: maximum enhanced mixing factor for thin partial-cell
+! pCellMix_delR   :: thickness criteria   for too thin partial-cell
+! pCellMix_viscAr :: vertical viscosity   for too thin partial-cell
+! pCellMix_diffKr :: vertical diffusivity for too thin partial-cell
+! deltaT    :: Default timestep ( s )
+! deltaTClock  :: Timestep used as model "clock". This determines the
+!                IO frequencies and is used in tagging output. It can
+!                be totally different to the dynamical time. Typically
+!                it will be the deep-water timestep for accelerated runs.
+!                Frequency of checkpointing and dumping of the model state
+!                are referenced to this clock. ( s )
+! deltaTMom    :: Timestep for momemtum equations ( s )
+! dTtracerLev  :: Timestep for tracer equations ( s ), function of level k
+! deltaTFreeSurf :: Timestep for free-surface equation ( s )
+! freeSurfFac  :: Parameter to turn implicit free surface term on or off
+!                 freeSurFac = 1. uses implicit free surface
+!                 freeSurFac = 0. uses rigid lid
+! abEps        :: Adams-Bashforth-2 stabilizing weight
+! alph_AB      :: Adams-Bashforth-3 primary factor
+! beta_AB      :: Adams-Bashforth-3 secondary factor
+! implicSurfPress :: parameter of the Crank-Nickelson time stepping :
+!                 Implicit part of Surface Pressure Gradient ( 0-1 )
+! implicDiv2DFlow :: parameter of the Crank-Nickelson time stepping :
+!                 Implicit part of barotropic flow Divergence ( 0-1 )
+! implicitNHPress :: parameter of the Crank-Nickelson time stepping :
+!                 Implicit part of Non-Hydrostatic Pressure Gradient ( 0-1 )
+!     hFacMin      :: Minimum fraction size of a cell (affects hFacC etc...)
+! hFacMinDz    :: Minimum dimensional size of a cell (affects hFacC etc..., m)
+! hFacMinDp    :: Minimum dimensional size of a cell (affects hFacC etc..., Pa)
+! hFacMinDr    :: Minimum dimensional size of a cell (-> hFacC etc..., r units)
+! hFacInf      :: Threshold (inf and sup) for fraction size of surface cell
+! hFacSup          that control vanishing and creating levels
+! tauCD         :: CD scheme coupling timescale ( s )
+! rCD           :: CD scheme normalised coupling parameter (= 1 - deltaT/tauCD)
+! epsAB_CD      :: Adams-Bashforth-2 stabilizing weight used in CD scheme
+! baseTime      :: model base time (time origin) = time @ iteration zero
+! startTime     :: Starting time for this integration ( s ).
+! endTime       :: Ending time for this integration ( s ).
+! chkPtFreq     :: Frequency of rolling check pointing ( s ).
+! pChkPtFreq    :: Frequency of permanent check pointing ( s ).
+! dumpFreq      :: Frequency with which model state is written to
+!                  post-processing files ( s ).
+! diagFreq      :: Frequency with which model writes diagnostic output
+!                  of intermediate quantities.
+! afFacMom      :: Advection of momentum term multiplication factor
+! vfFacMom      :: Momentum viscosity term    multiplication factor
+! pfFacMom      :: Momentum pressure forcing  multiplication factor
+! cfFacMom      :: Coriolis term              multiplication factor
+! foFacMom      :: Momentum forcing           multiplication factor
+! mtFacMom      :: Metric terms               multiplication factor
+! cosPower      :: Power of cosine of latitude to multiply viscosity
+! cAdjFreq      :: Frequency of convective adjustment
+!
+! tauThetaClimRelax :: Relaxation to climatology time scale ( s ).
+! tauSaltClimRelax :: Relaxation to climatology time scale ( s ).
+! latBandClimRelax :: latitude band where Relaxation to Clim. is applied,
+!                     i.e. where |yC| <= latBandClimRelax
+! externForcingPeriod :: Is the period of which forcing varies (eg. 1 month)
+! externForcingCycle :: Is the repeat time of the forcing (eg. 1 year)
+!                      (note: externForcingCycle must be an integer
+!                       number times externForcingPeriod)
+! convertFW2Salt :: salinity, used to convert Fresh-Water Flux to Salt Flux
+!                   (use model surface (local) value if set to -1)
+! temp_EvPrRn :: temperature of Rain & Evap.
+! salt_EvPrRn :: salinity of Rain & Evap.
+! temp_addMass :: temperature of addMass field
+! salt_addMass :: salinity of addMass field
+!    (notes: a) tracer content of Rain/Evap only used if both
+!                 NonLin_FrSurf & useRealFreshWater are set.
+!            b) use model surface (local) value if set to UNSET_RL)
+! hMixCriteria:: criteria for mixed-layer diagnostic
+! dRhoSmall   :: parameter for mixed-layer diagnostic
+! hMixSmooth  :: Smoothing parameter for mixed-layer diag
+!                (default=0: no smoothing)
+! ivdc_kappa  :: implicit vertical diffusivity for convection [m^2/s]
+! sideDragFactor     :: side-drag scaling factor (used only if no_slip_sides)
+!                       (default=2: full drag ; =1: gives half-slip BC)
+! bottomDragLinear    :: Linear    bottom-drag coefficient (units of [r]/s)
+! bottomDragQuadratic :: Quadratic bottom-drag coefficient (units of [r]/m)
+!           (if using zcoordinate, units becomes linear: m/s, quadratic: [-])
+! zRoughBot :: roughness length for quadratic bottom friction coefficient
+!              (in m, typical values are order 0.01 m)
+! smoothAbsFuncRange :: 1/2 of interval around zero, for which FORTRAN ABS
+!                       is to be replace by a smoother function
+!                       (affects myabs, mymin, mymax)
+! nh_Am2        :: scales non-hydrostatic terms and changes internal scales
+!                  (i.e. allows convection at different Rayleigh numbers)
+! tCylIn        :: Temperature of the cylinder inner boundary
+! tCylOut       :: Temperature of the cylinder outer boundary
+! phiEuler      :: Euler angle, rotation about original z-axis
+! thetaEuler    :: Euler angle, rotation about new x-axis
+! psiEuler      :: Euler angle, rotation about new z-axis
+      COMMON /PARM_R/ cg2dTargetResidual, cg2dTargetResWunit,                     &
+     &      cg2dpcOffDFac, cg3dTargetResidual, cg3dTargetResWunit,                &
+     &      delR, delRc, xgOrigin, ygOrigin, rSphere, recip_rSphere,              &
+     &      radius_fromHorizGrid, seaLev_Z, top_Pres, rSigmaBnd,                  &
+     &      deltaT, deltaTMom, dTtracerLev, deltaTFreeSurf, deltaTClock,          &
+     &      abEps, alph_AB, beta_AB,                                              &
+     &      f0, beta, fPrime, omega, rotationPeriod,                              &
+     &      viscFacAdj, viscAh, viscAhW, smag3D_coeff, smag3D_diffCoeff,          &
+     &      viscAhMax, viscAhGrid, viscAhGridMax, viscAhGridMin,                  &
+     &      viscC2leith, viscC2leithD, viscC2LeithQG,                             &
+     &      viscC2smag, viscC4smag,                                               &
+     &      viscAhD, viscAhZ, viscA4D, viscA4Z,                                   &
+     &      viscA4, viscA4W, viscA4Max,                                           &
+     &      viscA4Grid, viscA4GridMax, viscA4GridMin,                             &
+     &      viscAhReMax, viscA4ReMax,                                             &
+     &      viscC4leith, viscC4leithD, viscArNr,                                  &
+     &      diffKhT, diffK4T, diffKrNrT, diffKr4T,                                &
+     &      diffKhS, diffK4S, diffKrNrS, diffKr4S,                                &
+     &      diffKrBL79surf, diffKrBL79deep, diffKrBL79scl, diffKrBL79Ho,          &
+     &      BL79LatVary,                                                          &
+     &      diffKrBLEQsurf, diffKrBLEQdeep, diffKrBLEQscl, diffKrBLEQHo,          &
+     &      pCellMix_maxFac, pCellMix_delR, pCellMix_viscAr, pCellMix_diffKr,     &
+     &      tauCD, rCD, epsAB_CD,                                                 &
+     &      freeSurfFac, implicSurfPress, implicDiv2DFlow, implicitNHPress,       &
+     &      hFacMin, hFacMinDz, hFacInf, hFacSup,                                 &
+     &      gravity, recip_gravity, gBaro,                                        &
+     &      gravFacC, recip_gravFacC, gravFacF, recip_gravFacF,                   &
+     &      rhoNil, rhoConst, recip_rhoConst, rho1Ref,                            &
+     &      rhoFacC, recip_rhoFacC, rhoFacF, recip_rhoFacF, rhoConstFresh,        &
+     &      thetaConst, tRef, sRef, rhoRef, dBdrRef,                              &
+     &      surf_pRef, pRef4EOS, phiRef,                                          &
+     &      rVel2wUnit, wUnit2rVel, rUnit2z, z2rUnit, mass2rUnit, rUnit2mass,     &
+     &      baseTime, startTime, endTime,                                         &
+     &      chkPtFreq, pChkPtFreq, dumpFreq, adjDumpFreq,                         &
+     &      diagFreq, monitorFreq, adjMonitorFreq,                                &
+     &      afFacMom, vfFacMom, pfFacMom, cfFacMom, foFacMom, mtFacMom,           &
+     &      cosPower, cAdjFreq,                                                   &
+     &      tauThetaClimRelax, tauSaltClimRelax, latBandClimRelax,                &
+     &      externForcingCycle, externForcingPeriod,                              &
+     &      convertFW2Salt, temp_EvPrRn, salt_EvPrRn,                             &
+     &      temp_addMass, salt_addMass, hFacMinDr, hFacMinDp,                     &
+     &      ivdc_kappa, hMixCriteria, dRhoSmall, hMixSmooth,                      &
+     &      sideDragFactor, bottomDragLinear, bottomDragQuadratic,                &
+     &      zRoughBot, nh_Am2, smoothAbsFuncRange, sIceLoadFac,                   &
+     &      tCylIn, tCylOut,                                                      &
+     &      phiEuler, thetaEuler, psiEuler
 
       _RL cg2dTargetResidual
       _RL cg2dTargetResWunit
@@ -1012,99 +1012,99 @@ C     psiEuler      :: Euler angle, rotation about new z-axis
       _RL tCylIn, tCylOut
       _RL phiEuler, thetaEuler, psiEuler
 
-C--   COMMON /PARM_A/ Thermodynamics constants ?
+!--   COMMON /PARM_A/ Thermodynamics constants ?
       COMMON /PARM_A/ HeatCapacity_Cp
       _RL HeatCapacity_Cp
 
-C--   COMMON /PARM_ATM/ Atmospheric physical parameters (Ideal Gas EOS, ...)
-C     celsius2K :: convert centigrade (Celsius) degree to Kelvin
-C     atm_Po    :: standard reference pressure
-C     atm_Cp    :: specific heat (Cp) of the (dry) air at constant pressure
-C     atm_Rd    :: gas constant for dry air
-C     atm_kappa :: kappa = R/Cp (R: constant of Ideal Gas EOS)
-C     atm_Rq    :: water vapour specific volume anomaly relative to dry air
-C                  (e.g. typical value = (29/18 -1) 10^-3 with q [g/kg])
-C     integr_GeoPot :: option to select the way we integrate the geopotential
-C                     (still a subject of discussions ...)
-C     selectFindRoSurf :: select the way surf. ref. pressure (=Ro_surf) is
-C             derived from the orography. Implemented: 0,1 (see INI_P_GROUND)
-      COMMON /PARM_ATM/
-     &            celsius2K,
-     &            atm_Cp, atm_Rd, atm_kappa, atm_Rq, atm_Po,
-     &            integr_GeoPot, selectFindRoSurf
+!--   COMMON /PARM_ATM/ Atmospheric physical parameters (Ideal Gas EOS, ...)
+! celsius2K :: convert centigrade (Celsius) degree to Kelvin
+! atm_Po    :: standard reference pressure
+! atm_Cp    :: specific heat (Cp) of the (dry) air at constant pressure
+! atm_Rd    :: gas constant for dry air
+! atm_kappa :: kappa = R/Cp (R: constant of Ideal Gas EOS)
+! atm_Rq    :: water vapour specific volume anomaly relative to dry air
+!              (e.g. typical value = (29/18 -1) 10^-3 with q [g/kg])
+! integr_GeoPot :: option to select the way we integrate the geopotential
+!                 (still a subject of discussions ...)
+! selectFindRoSurf :: select the way surf. ref. pressure (=Ro_surf) is
+!         derived from the orography. Implemented: 0,1 (see INI_P_GROUND)
+      COMMON /PARM_ATM/                                                           &
+     &      celsius2K,                                                            &
+     &      atm_Cp, atm_Rd, atm_kappa, atm_Rq, atm_Po,                            &
+     &      integr_GeoPot, selectFindRoSurf
       _RL celsius2K
       _RL atm_Po, atm_Cp, atm_Rd, atm_kappa, atm_Rq
-      INTEGER integr_GeoPot, selectFindRoSurf
+      INTEGER :: integr_GeoPot, selectFindRoSurf
 
-C---+----1----+----2----+----3----+----4----+----5----+----6----+----7-|--+----|
-C-- Logical flags for selecting packages
-      LOGICAL useGAD
-      LOGICAL useOBCS
-      LOGICAL useSHAP_FILT
-      LOGICAL useZONAL_FILT
-      LOGICAL useOPPS
-      LOGICAL usePP81
-      LOGICAL useKL10
-      LOGICAL useMY82
-      LOGICAL useGGL90
-      LOGICAL useKPP
-      LOGICAL useGMRedi
-      LOGICAL useDOWN_SLOPE
-      LOGICAL useBBL
-      LOGICAL useCAL
-      LOGICAL useEXF
-      LOGICAL useBulkForce
-      LOGICAL useEBM
-      LOGICAL useCheapAML
-      LOGICAL useAUTODIFF
-      LOGICAL useGrdchk
-      LOGICAL useSMOOTH
-      LOGICAL usePROFILES
-      LOGICAL useOBSFIT
-      LOGICAL useECCO
-      LOGICAL useCTRL
-      LOGICAL useSBO
-      LOGICAL useFLT
-      LOGICAL usePTRACERS
-      LOGICAL useGCHEM
-      LOGICAL useRBCS
-      LOGICAL useOffLine
-      LOGICAL useMATRIX
-      LOGICAL useFRAZIL
-      LOGICAL useSEAICE
-      LOGICAL useSALT_PLUME
-      LOGICAL useShelfIce
-      LOGICAL useSTIC
-      LOGICAL useStreamIce
-      LOGICAL useICEFRONT
-      LOGICAL useThSIce
-      LOGICAL useLand
-      LOGICAL useATM2d
-      LOGICAL useAIM
-      LOGICAL useAtm_Phys
-      LOGICAL useFizhi
-      LOGICAL useGridAlt
-      LOGICAL useDiagnostics
-      LOGICAL useREGRID
-      LOGICAL useLayers
-      LOGICAL useMNC
-      LOGICAL useRunClock
-      LOGICAL useEMBED_FILES
-      LOGICAL useMYPACKAGE
-      COMMON /PARM_PACKAGES/
-     &        useGAD, useOBCS, useSHAP_FILT, useZONAL_FILT,
-     &        useOPPS, usePP81, useKL10, useMY82, useGGL90, useKPP,
-     &        useGMRedi, useBBL, useDOWN_SLOPE,
-     &        useCAL, useEXF, useBulkForce, useEBM, useCheapAML,
-     &        useGrdchk, useSMOOTH, usePROFILES, useOBSFIT,
-     &        useECCO, useCTRL,
-     &        useSBO, useFLT, useAUTODIFF,
-     &        usePTRACERS, useGCHEM, useRBCS, useOffLine, useMATRIX,
-     &        useFRAZIL, useSEAICE, useSALT_PLUME, useShelfIce, useSTIC,
-     &        useStreamIce, useICEFRONT, useThSIce, useLand,
-     &        useATM2d, useAIM, useAtm_Phys, useFizhi, useGridAlt,
-     &        useDiagnostics, useREGRID, useLayers, useMNC,
-     &        useRunClock, useEMBED_FILES,
-     &        useMYPACKAGE
+!---+----1----+----2----+----3----+----4----+----5----+----6----+----7-|--+----|
+!-- Logical flags for selecting packages
+      LOGICAL :: useGAD
+      LOGICAL :: useOBCS
+      LOGICAL :: useSHAP_FILT
+      LOGICAL :: useZONAL_FILT
+      LOGICAL :: useOPPS
+      LOGICAL :: usePP81
+      LOGICAL :: useKL10
+      LOGICAL :: useMY82
+      LOGICAL :: useGGL90
+      LOGICAL :: useKPP
+      LOGICAL :: useGMRedi
+      LOGICAL :: useDOWN_SLOPE
+      LOGICAL :: useBBL
+      LOGICAL :: useCAL
+      LOGICAL :: useEXF
+      LOGICAL :: useBulkForce
+      LOGICAL :: useEBM
+      LOGICAL :: useCheapAML
+      LOGICAL :: useAUTODIFF
+      LOGICAL :: useGrdchk
+      LOGICAL :: useSMOOTH
+      LOGICAL :: usePROFILES
+      LOGICAL :: useOBSFIT
+      LOGICAL :: useECCO
+      LOGICAL :: useCTRL
+      LOGICAL :: useSBO
+      LOGICAL :: useFLT
+      LOGICAL :: usePTRACERS
+      LOGICAL :: useGCHEM
+      LOGICAL :: useRBCS
+      LOGICAL :: useOffLine
+      LOGICAL :: useMATRIX
+      LOGICAL :: useFRAZIL
+      LOGICAL :: useSEAICE
+      LOGICAL :: useSALT_PLUME
+      LOGICAL :: useShelfIce
+      LOGICAL :: useSTIC
+      LOGICAL :: useStreamIce
+      LOGICAL :: useICEFRONT
+      LOGICAL :: useThSIce
+      LOGICAL :: useLand
+      LOGICAL :: useATM2d
+      LOGICAL :: useAIM
+      LOGICAL :: useAtm_Phys
+      LOGICAL :: useFizhi
+      LOGICAL :: useGridAlt
+      LOGICAL :: useDiagnostics
+      LOGICAL :: useREGRID
+      LOGICAL :: useLayers
+      LOGICAL :: useMNC
+      LOGICAL :: useRunClock
+      LOGICAL :: useEMBED_FILES
+      LOGICAL :: useMYPACKAGE
+      COMMON /PARM_PACKAGES/                                                      &
+     &      useGAD, useOBCS, useSHAP_FILT, useZONAL_FILT,                         &
+     &      useOPPS, usePP81, useKL10, useMY82, useGGL90, useKPP,                 &
+     &      useGMRedi, useBBL, useDOWN_SLOPE,                                     &
+     &      useCAL, useEXF, useBulkForce, useEBM, useCheapAML,                    &
+     &      useGrdchk, useSMOOTH, usePROFILES, useOBSFIT,                         &
+     &      useECCO, useCTRL,                                                     &
+     &      useSBO, useFLT, useAUTODIFF,                                          &
+     &      usePTRACERS, useGCHEM, useRBCS, useOffLine, useMATRIX,                &
+     &      useFRAZIL, useSEAICE, useSALT_PLUME, useShelfIce, useSTIC,            &
+     &      useStreamIce, useICEFRONT, useThSIce, useLand,                        &
+     &      useATM2d, useAIM, useAtm_Phys, useFizhi, useGridAlt,                  &
+     &      useDiagnostics, useREGRID, useLayers, useMNC,                         &
+     &      useRunClock, useEMBED_FILES,                                          &
+     &      useMYPACKAGE
 
-C---+----1----+----2----+----3----+----4----+----5----+----6----+----7-|--+----|
+!---+----1----+----2----+----3----+----4----+----5----+----6----+----7-|--+----|

--- a/model/inc/RAS_MACROS.h
+++ b/model/inc/RAS_MACROS.h
@@ -1,18 +1,18 @@
-C
-CBOP
-C    !ROUTINE: RAS_MACROS.h
-C    !INTERFACE:
-C    include RAS_MACROS.h
-C    !DESCRIPTION: \bv
-C     *==========================================================*
-C     | RAS_MACROS.h                                              
-C     *==========================================================*
-C     | These macros are used to reduce memory requirement and/or 
-C     | memory references when variables are fixed along a given  
-C     | axis or axes.                                             
-C     *==========================================================*
-C     \ev
-CEOP
+!
+!BOP
+!    !ROUTINE: RAS_MACROS.h
+!    !INTERFACE:
+!    include RAS_MACROS.h
+!    !DESCRIPTION: \bv
+! *==========================================================*
+! | RAS_MACROS.h
+! *==========================================================*
+! | These macros are used to reduce memory requirement and/or
+! | memory references when variables are fixed along a given
+! | axis or axes.
+! *==========================================================*
+! \ev
+!EOP
 
 #ifdef RA_CONST
 #define  _rAs(i,j,bi,bj) rAs(1,1,1,1)

--- a/model/inc/RAW_MACROS.h
+++ b/model/inc/RAW_MACROS.h
@@ -1,18 +1,18 @@
-C
-CBOP
-C    !ROUTINE: RAW_MACROS.h
-C    !INTERFACE:
-C    include RAW_MACROS.h
-C    !DESCRIPTION: \bv
-C     *==========================================================*
-C     | RAW_MACROS.h                                              
-C     *==========================================================*
-C     | These macros are used to reduce memory requirement and/or 
-C     | memory references when variables are fixed along a given  
-C     | axis or axes.                                             
-C     *==========================================================*
-C     \ev
-CEOP
+!
+!BOP
+!    !ROUTINE: RAW_MACROS.h
+!    !INTERFACE:
+!    include RAW_MACROS.h
+!    !DESCRIPTION: \bv
+! *==========================================================*
+! | RAW_MACROS.h
+! *==========================================================*
+! | These macros are used to reduce memory requirement and/or
+! | memory references when variables are fixed along a given
+! | axis or axes.
+! *==========================================================*
+! \ev
+!EOP
 
 #ifdef RA_CONST
 #define  _rAw(i,j,bi,bj) rAw(1,1,1,1)

--- a/model/inc/RA_MACROS.h
+++ b/model/inc/RA_MACROS.h
@@ -1,18 +1,18 @@
-C
-CBOP
-C    !ROUTINE: RA_MACROS.h
-C    !INTERFACE:
-C    include RA_MACROS.h
-C    !DESCRIPTION: \bv
-C     *==========================================================*
-C     | RA_MACROS.h                                               
-C     *==========================================================*
-C     | These macros are used to reduce memory requirement and/or 
-C     | memory references when variables are fixed along a given  
-C     | axis or axes.                                             
-C     *==========================================================*
-C     \ev
-CEOP
+!
+!BOP
+!    !ROUTINE: RA_MACROS.h
+!    !INTERFACE:
+!    include RA_MACROS.h
+!    !DESCRIPTION: \bv
+! *==========================================================*
+! | RA_MACROS.h
+! *==========================================================*
+! | These macros are used to reduce memory requirement and/or
+! | memory references when variables are fixed along a given
+! | axis or axes.
+! *==========================================================*
+! \ev
+!EOP
 
 #ifdef RA_CONST
 #define  _rA(i,j,bi,bj) rA(1,1,1,1)

--- a/model/inc/RECIP_DXC_MACROS.h
+++ b/model/inc/RECIP_DXC_MACROS.h
@@ -1,18 +1,18 @@
-C
-CBOP
-C    !ROUTINE: RECIP_DXC_MACROS.h
-C    !INTERFACE:
-C    include RECIP_DXC_MACROS.h
-C    !DESCRIPTION: \bv
-C     *==========================================================*
-C     | RECIP_DXC_MACROS.h                                        
-C     *==========================================================*
-C     | These macros are used to reduce memory requirement and/or 
-C     | memory references when variables are fixed along a given  
-C     | axis or axes.                                             
-C     *==========================================================*
-C     \ev
-CEOP
+!
+!BOP
+!    !ROUTINE: RECIP_DXC_MACROS.h
+!    !INTERFACE:
+!    include RECIP_DXC_MACROS.h
+!    !DESCRIPTION: \bv
+! *==========================================================*
+! | RECIP_DXC_MACROS.h
+! *==========================================================*
+! | These macros are used to reduce memory requirement and/or
+! | memory references when variables are fixed along a given
+! | axis or axes.
+! *==========================================================*
+! \ev
+!EOP
 
 #ifdef RECIP_DXC_CONST
 #define  _recip_dxC(i,j,bi,bj) recip_dxC(1,1,1,1)

--- a/model/inc/RECIP_DXF_MACROS.h
+++ b/model/inc/RECIP_DXF_MACROS.h
@@ -1,18 +1,18 @@
-C
-CBOP
-C    !ROUTINE: RECIP_DXF_MACROS.h
-C    !INTERFACE:
-C    include RECIP_DXF_MACROS.h
-C    !DESCRIPTION: \bv
-C     *==========================================================*
-C     | RECIP_DXF_MACROS.h                                        
-C     *==========================================================*
-C     | These macros are used to reduce memory requirement and/or 
-C     | memory references when variables are fixed along a given  
-C     | axis or axes.                                             
-C     *==========================================================*
-C     \ev
-CEOP
+!
+!BOP
+!    !ROUTINE: RECIP_DXF_MACROS.h
+!    !INTERFACE:
+!    include RECIP_DXF_MACROS.h
+!    !DESCRIPTION: \bv
+! *==========================================================*
+! | RECIP_DXF_MACROS.h
+! *==========================================================*
+! | These macros are used to reduce memory requirement and/or
+! | memory references when variables are fixed along a given
+! | axis or axes.
+! *==========================================================*
+! \ev
+!EOP
 
 #ifdef RECIP_DXF_CONST
 #define  _recip_dxF(i,j,bi,bj) recip_dxF(1,1,1,1)

--- a/model/inc/RECIP_DXG_MACROS.h
+++ b/model/inc/RECIP_DXG_MACROS.h
@@ -1,18 +1,18 @@
-C
-CBOP
-C    !ROUTINE: RECIP_DXG_MACROS.h
-C    !INTERFACE:
-C    include RECIP_DXG_MACROS.h
-C    !DESCRIPTION: \bv
-C     *==========================================================*
-C     | RECIP_DXG_MACROS.h                                        
-C     *==========================================================*
-C     | These macros are used to reduce memory requirement and/or 
-C     | memory references when variables are fixed along a given  
-C     | axis or axes.                                             
-C     *==========================================================*
-C     \ev
-CEOP
+!
+!BOP
+!    !ROUTINE: RECIP_DXG_MACROS.h
+!    !INTERFACE:
+!    include RECIP_DXG_MACROS.h
+!    !DESCRIPTION: \bv
+! *==========================================================*
+! | RECIP_DXG_MACROS.h
+! *==========================================================*
+! | These macros are used to reduce memory requirement and/or
+! | memory references when variables are fixed along a given
+! | axis or axes.
+! *==========================================================*
+! \ev
+!EOP
 
 #ifdef RECIP_DXG_CONST
 #define  _recip_dxG(i,j,bi,bj) recip_dxG(1,1,1,1)

--- a/model/inc/RECIP_DXV_MACROS.h
+++ b/model/inc/RECIP_DXV_MACROS.h
@@ -1,18 +1,18 @@
-C
-CBOP
-C    !ROUTINE: RECIP_DXV_MACROS.h
-C    !INTERFACE:
-C    include RECIP_DXV_MACROS.h
-C    !DESCRIPTION: \bv
-C     *==========================================================*
-C     | RECIP_DXV_MACROS.h                                        
-C     *==========================================================*
-C     | These macros are used to reduce memory requirement and/or 
-C     | memory references when variables are fixed along a given  
-C     | axis or axes.                                             
-C     *==========================================================*
-C     \ev
-CEOP
+!
+!BOP
+!    !ROUTINE: RECIP_DXV_MACROS.h
+!    !INTERFACE:
+!    include RECIP_DXV_MACROS.h
+!    !DESCRIPTION: \bv
+! *==========================================================*
+! | RECIP_DXV_MACROS.h
+! *==========================================================*
+! | These macros are used to reduce memory requirement and/or
+! | memory references when variables are fixed along a given
+! | axis or axes.
+! *==========================================================*
+! \ev
+!EOP
 
 #ifdef RECIP_DXV_CONST
 #define  _recip_dxV(i,j,bi,bj) recip_dxV(1,1,1,1)

--- a/model/inc/RECIP_DYC_MACROS.h
+++ b/model/inc/RECIP_DYC_MACROS.h
@@ -1,18 +1,18 @@
-C
-CBOP
-C    !ROUTINE: RECIP_DYC_MACROS.h
-C    !INTERFACE:
-C    include RECIP_DYC_MACROS.h
-C    !DESCRIPTION: \bv
-C     *==========================================================*
-C     | RECIP_DYC_MACROS.h                                        
-C     *==========================================================*
-C     | These macros are used to reduce memory requirement and/or 
-C     | memory references when variables are fixed along a given  
-C     | axis or axes.                                             
-C     *==========================================================*
-C     \ev
-CEOP
+!
+!BOP
+!    !ROUTINE: RECIP_DYC_MACROS.h
+!    !INTERFACE:
+!    include RECIP_DYC_MACROS.h
+!    !DESCRIPTION: \bv
+! *==========================================================*
+! | RECIP_DYC_MACROS.h
+! *==========================================================*
+! | These macros are used to reduce memory requirement and/or
+! | memory references when variables are fixed along a given
+! | axis or axes.
+! *==========================================================*
+! \ev
+!EOP
 
 #ifdef RECIP_DYC_CONST
 #define  _recip_dyC(i,j,bi,bj) recip_dyC(1,1,1,1)

--- a/model/inc/RECIP_DYF_MACROS.h
+++ b/model/inc/RECIP_DYF_MACROS.h
@@ -1,18 +1,18 @@
-C
-CBOP
-C    !ROUTINE: RECIP_DYF_MACROS.h
-C    !INTERFACE:
-C    include RECIP_DYF_MACROS.h
-C    !DESCRIPTION: \bv
-C     *==========================================================*
-C     | RECIP_DYF_MACROS.h                                        
-C     *==========================================================*
-C     | These macros are used to reduce memory requirement and/or 
-C     | memory references when variables are fixed along a given  
-C     | axis or axes.                                             
-C     *==========================================================*
-C     \ev
-CEOP
+!
+!BOP
+!    !ROUTINE: RECIP_DYF_MACROS.h
+!    !INTERFACE:
+!    include RECIP_DYF_MACROS.h
+!    !DESCRIPTION: \bv
+! *==========================================================*
+! | RECIP_DYF_MACROS.h
+! *==========================================================*
+! | These macros are used to reduce memory requirement and/or
+! | memory references when variables are fixed along a given
+! | axis or axes.
+! *==========================================================*
+! \ev
+!EOP
 
 #ifdef RECIP_DYF_CONST
 #define  _recip_dyF(i,j,bi,bj) recip_dyF(1,1,1,1)

--- a/model/inc/RECIP_DYG_MACROS.h
+++ b/model/inc/RECIP_DYG_MACROS.h
@@ -1,18 +1,18 @@
-C
-CBOP
-C    !ROUTINE: RECIP_DYG_MACROS.h
-C    !INTERFACE:
-C    include RECIP_DYG_MACROS.h
-C    !DESCRIPTION: \bv
-C     *==========================================================*
-C     | RECIP_DYG_MACROS.h                                        
-C     *==========================================================*
-C     | These macros are used to reduce memory requirement and/or 
-C     | memory references when variables are fixed along a given  
-C     | axis or axes.                                             
-C     *==========================================================*
-C     \ev
-CEOP
+!
+!BOP
+!    !ROUTINE: RECIP_DYG_MACROS.h
+!    !INTERFACE:
+!    include RECIP_DYG_MACROS.h
+!    !DESCRIPTION: \bv
+! *==========================================================*
+! | RECIP_DYG_MACROS.h
+! *==========================================================*
+! | These macros are used to reduce memory requirement and/or
+! | memory references when variables are fixed along a given
+! | axis or axes.
+! *==========================================================*
+! \ev
+!EOP
 
 #ifdef RECIP_DYG_CONST
 #define  _recip_dyG(i,j,bi,bj) recip_dyG(1,1,1,1)

--- a/model/inc/RECIP_DYU_MACROS.h
+++ b/model/inc/RECIP_DYU_MACROS.h
@@ -1,18 +1,18 @@
-C
-CBOP
-C    !ROUTINE: RECIP_DYU_MACROS.h
-C    !INTERFACE:
-C    include RECIP_DYU_MACROS.h
-C    !DESCRIPTION: \bv
-C     *==========================================================*
-C     | RECIP_DYU_MACROS.h                                        
-C     *==========================================================*
-C     | These macros are used to reduce memory requirement and/or 
-C     | memory references when variables are fixed along a given  
-C     | axis or axes.                                             
-C     *==========================================================*
-C     \ev
-CEOP
+!
+!BOP
+!    !ROUTINE: RECIP_DYU_MACROS.h
+!    !INTERFACE:
+!    include RECIP_DYU_MACROS.h
+!    !DESCRIPTION: \bv
+! *==========================================================*
+! | RECIP_DYU_MACROS.h
+! *==========================================================*
+! | These macros are used to reduce memory requirement and/or
+! | memory references when variables are fixed along a given
+! | axis or axes.
+! *==========================================================*
+! \ev
+!EOP
 
 #ifdef RECIP_DYU_CONST
 #define  _recip_dyU(i,j,bi,bj) recip_dyU(1,1,1,1)

--- a/model/inc/RECIP_HFACC_MACROS.h
+++ b/model/inc/RECIP_HFACC_MACROS.h
@@ -1,18 +1,18 @@
-C
-CBOP
-C    !ROUTINE: RECIP_HFACC_MACROS.h
-C    !INTERFACE:
-C    include RECIP_HFACC_MACROS.h
-C    !DESCRIPTION: \bv
-C     *==========================================================*
-C     | RECIP_HFACC_MACROS.h                                      
-C     *==========================================================*
-C     | These macros are used to reduce memory requirement and/or 
-C     | memory references when variables are fixed along a given  
-C     | axis or axes.                                             
-C     *==========================================================*
-C     \ev
-CEOP
+!
+!BOP
+!    !ROUTINE: RECIP_HFACC_MACROS.h
+!    !INTERFACE:
+!    include RECIP_HFACC_MACROS.h
+!    !DESCRIPTION: \bv
+! *==========================================================*
+! | RECIP_HFACC_MACROS.h
+! *==========================================================*
+! | These macros are used to reduce memory requirement and/or
+! | memory references when variables are fixed along a given
+! | axis or axes.
+! *==========================================================*
+! \ev
+!EOP
 
 #ifdef RECIP_HFACC_CONST
 #define  _recip_hFacC(i,j,k,bi,bj) recip_hFacC(1,1,1,1,1)

--- a/model/inc/RECIP_HFACS_MACROS.h
+++ b/model/inc/RECIP_HFACS_MACROS.h
@@ -1,18 +1,18 @@
-C
-CBOP
-C    !ROUTINE: RECIP_HFACS_MACROS.h
-C    !INTERFACE:
-C    include RECIP_HFACS_MACROS.h
-C    !DESCRIPTION: \bv
-C     *==========================================================*
-C     | RECIP_HFACS_MACROS.h                                      
-C     *==========================================================*
-C     | These macros are used to reduce memory requirement and/or 
-C     | memory references when variables are fixed along a given  
-C     | axis or axes.                                             
-C     *==========================================================*
-C     \ev
-CEOP
+!
+!BOP
+!    !ROUTINE: RECIP_HFACS_MACROS.h
+!    !INTERFACE:
+!    include RECIP_HFACS_MACROS.h
+!    !DESCRIPTION: \bv
+! *==========================================================*
+! | RECIP_HFACS_MACROS.h
+! *==========================================================*
+! | These macros are used to reduce memory requirement and/or
+! | memory references when variables are fixed along a given
+! | axis or axes.
+! *==========================================================*
+! \ev
+!EOP
 
 #ifdef RECIP_HFACS_CONST
 #define  _recip_hFacS(i,j,k,bi,bj) recip_hFacS(1,1,1,1,1)

--- a/model/inc/RECIP_HFACW_MACROS.h
+++ b/model/inc/RECIP_HFACW_MACROS.h
@@ -1,18 +1,18 @@
-C
-CBOP
-C    !ROUTINE: RECIP_HFACW_MACROS.h
-C    !INTERFACE:
-C    include RECIP_HFACW_MACROS.h
-C    !DESCRIPTION: \bv
-C     *==========================================================*
-C     | RECIP_HFACW_MACROS.h                                      
-C     *==========================================================*
-C     | These macros are used to reduce memory requirement and/or 
-C     | memory references when variables are fixed along a given  
-C     | axis or axes.                                             
-C     *==========================================================*
-C     \ev
-CEOP
+!
+!BOP
+!    !ROUTINE: RECIP_HFACW_MACROS.h
+!    !INTERFACE:
+!    include RECIP_HFACW_MACROS.h
+!    !DESCRIPTION: \bv
+! *==========================================================*
+! | RECIP_HFACW_MACROS.h
+! *==========================================================*
+! | These macros are used to reduce memory requirement and/or
+! | memory references when variables are fixed along a given
+! | axis or axes.
+! *==========================================================*
+! \ev
+!EOP
 
 #ifdef RECIP_HFACW_CONST
 #define  _recip_hFacW(i,j,k,bi,bj) recip_hFacW(1,1,1,1,1)

--- a/model/inc/RESTART.h
+++ b/model/inc/RESTART.h
@@ -1,57 +1,57 @@
-CBOP
-C     !ROUTINE: RESTART.h
-C     !INTERFACE:
-C     include "RESTART.h"
-C
-C     !DESCRIPTION:
-C     \bv
-C     *==========================================================*
-C     | RESTART.h
-C     | o Holds internal parameters related to restart process
-C     *==========================================================*
-C     | Model internal parameters/variables related to writing
-C     |  or reading pickup for a restart.
-C     | Note: external parameters (read from parameter file "data")
-C     |  stay in PARAMS.h and should not appear in RESTART.h ;
-C     |  therefore, this header file should not be included
-C     |  in S/R INI_PARMS.
-C     *==========================================================*
-C     \ev
-CEOP
+!BOP
+! !ROUTINE: RESTART.h
+! !INTERFACE:
+! include "RESTART.h"
+!
+! !DESCRIPTION:
+! \bv
+! *==========================================================*
+! | RESTART.h
+! | o Holds internal parameters related to restart process
+! *==========================================================*
+! | Model internal parameters/variables related to writing
+! |  or reading pickup for a restart.
+! | Note: external parameters (read from parameter file "data")
+! |  stay in PARAMS.h and should not appear in RESTART.h ;
+! |  therefore, this header file should not be included
+! |  in S/R INI_PARMS.
+! *==========================================================*
+! \ev
+!EOP
 
-C     Alternating pickup
-      INTEGER maxNoChkptLev
+! Alternating pickup
+      INTEGER :: maxNoChkptLev
       PARAMETER ( maxNoChkptLev = 2 )
 
-C--   COMMON / RESTART_I / Integer   valued parameters used for restart
-C     nCheckLev     :: Holds current checkpoint level (alternating pickup)
-C     tempStartAB   :: number of previous gT/Temp time levels which are
-C                      available to start (or restart) Adams-Bashforth.
-C     saltStartAB   :: number of previous gS/Salt time levels which are
-C                      available to start (or restart) Adams-Bashforth.
-C     mom_StartAB   :: number of previous gU,gV   time levels which are
-C                      available to start (or restart) Adams-Bashforth.
-C     nHydStartAB   :: number of previous gW      time levels which are
-C                      available to start (or restart) Adams-Bashforth.
-C     qHydStartAB   :: number of previous QH accel. time levels which are
-C                      available to start (or restart) Adams-Bashforth.
-C     dPhiNHstatus  :: status of field dPhiNH: 1= loaded from pickup
-C                      0= not available in pickup
-      COMMON / RESTART_I /
-     &  nCheckLev,
-     &  tempStartAB, saltStartAB,
-     &  mom_StartAB, nHydStartAB, qHydStartAB,
-     &  dPhiNHstatus
-      INTEGER nCheckLev
-      INTEGER tempStartAB
-      INTEGER saltStartAB
-      INTEGER mom_StartAB
-      INTEGER nHydStartAB
-      INTEGER qHydStartAB
-      INTEGER dPhiNHstatus
+!--   COMMON / RESTART_I / Integer   valued parameters used for restart
+! nCheckLev     :: Holds current checkpoint level (alternating pickup)
+! tempStartAB   :: number of previous gT/Temp time levels which are
+!                  available to start (or restart) Adams-Bashforth.
+! saltStartAB   :: number of previous gS/Salt time levels which are
+!                  available to start (or restart) Adams-Bashforth.
+! mom_StartAB   :: number of previous gU,gV   time levels which are
+!                  available to start (or restart) Adams-Bashforth.
+! nHydStartAB   :: number of previous gW      time levels which are
+!                  available to start (or restart) Adams-Bashforth.
+! qHydStartAB   :: number of previous QH accel. time levels which are
+!                  available to start (or restart) Adams-Bashforth.
+! dPhiNHstatus  :: status of field dPhiNH: 1= loaded from pickup
+!                  0= not available in pickup
+      COMMON / RESTART_I /                                                        &
+     &      nCheckLev,                                                            &
+     &      tempStartAB, saltStartAB,                                             &
+     &      mom_StartAB, nHydStartAB, qHydStartAB,                                &
+     &      dPhiNHstatus
+      INTEGER :: nCheckLev
+      INTEGER :: tempStartAB
+      INTEGER :: saltStartAB
+      INTEGER :: mom_StartAB
+      INTEGER :: nHydStartAB
+      INTEGER :: qHydStartAB
+      INTEGER :: dPhiNHstatus
 
-C--   COMMON / RESTART_C / Character valued parameters used for restart
-C     checkPtSuff   :: List of checkpoint file suffices
-      COMMON / RESTART_C /
-     &  checkPtSuff
-      CHARACTER*(5) checkPtSuff(maxNoChkptLev)
+!--   COMMON / RESTART_C / Character valued parameters used for restart
+! checkPtSuff   :: List of checkpoint file suffices
+      COMMON / RESTART_C /                                                        &
+     &      checkPtSuff
+      CHARACTER(len=5) :: checkPtSuff(maxNoChkptLev)

--- a/model/inc/SET_GRID.h
+++ b/model/inc/SET_GRID.h
@@ -1,22 +1,22 @@
-C
+!
 
-CBOP
-C     !ROUTINE: SET_GRID.h
-C     !INTERFACE:
-C     #include SET_GRID.h
+!BOP
+! !ROUTINE: SET_GRID.h
+! !INTERFACE:
+! #include SET_GRID.h
 
-C     !DESCRIPTION:
-C     Header file holding some 1-D arrays which are used to set-up the model grid.
-C==========================================================================
-C  IMPORTANT : This header file can only be included after the options
-C              file PACKAGES_CONFIG.h and the header file W2_EXCH2_SIZE.h
-C==========================================================================
+! !DESCRIPTION:
+! Header file holding some 1-D arrays which are used to set-up the model grid.
+!==========================================================================
+!  IMPORTANT : This header file can only be included after the options
+!          file PACKAGES_CONFIG.h and the header file W2_EXCH2_SIZE.h
+!==========================================================================
 
-CEOP
+!EOP
 
-C    grid_maxNx :: Maximum length of delX vector
-C    grid_maxNy :: Maximum length of delY vector
-      INTEGER grid_maxNx, grid_maxNy
+!    grid_maxNx :: Maximum length of delX vector
+!    grid_maxNy :: Maximum length of delY vector
+      INTEGER :: grid_maxNx, grid_maxNy
 #ifdef ALLOW_EXCH2
       PARAMETER( grid_maxNx = W2_maxXStackNx )
       PARAMETER( grid_maxNy = W2_maxYStackNy )
@@ -25,15 +25,15 @@ C    grid_maxNy :: Maximum length of delY vector
       PARAMETER( grid_maxNy = Ny )
 #endif /* ALLOW_EXCH2 */
 
-C--   COMMON /SET_GRID_R/ "Real" valued parameters used to set-up the model grid.
-C     delX      :: Separation between cell faces (m) or (deg), depending on type
-C     delY         type of horizontal grid choice (cartesian/spherical-polar ...)
-      COMMON /SET_GRID_R/
-     & delX, delY
+!--   COMMON /SET_GRID_R/ "Real" valued parameters used to set-up the model grid.
+! delX      :: Separation between cell faces (m) or (deg), depending on type
+! delY         type of horizontal grid choice (cartesian/spherical-polar ...)
+      COMMON /SET_GRID_R/                                                         &
+     &      delX, delY
 
       _RL delX(grid_maxNx)
       _RL delY(grid_maxNy)
 
-CEH3 ;;; Local Variables: ***
-CEH3 ;;; mode:fortran ***
-CEH3 ;;; End: ***
+!EH3 ;;; Local Variables: ***
+!EH3 ;;; mode:fortran ***
+!EH3 ;;; End: ***

--- a/model/inc/SIZE.h
+++ b/model/inc/SIZE.h
@@ -5,67 +5,67 @@
   You need to place you own copy of SIZE.h in the include
   path for the model, and comment out these lines.
 
-CBOP
-C    !ROUTINE: SIZE.h
-C    !INTERFACE:
-C    include SIZE.h
-C    !DESCRIPTION: \bv
-C     *==========================================================*
-C     | SIZE.h Declare size of underlying computational grid.
-C     *==========================================================*
-C     | The design here supports a three-dimensional model grid
-C     | with indices I,J and K. The three-dimensional domain
-C     | is comprised of nPx*nSx blocks (or tiles) of size sNx
-C     | along the first (left-most index) axis, nPy*nSy blocks
-C     | of size sNy along the second axis and one block of size
-C     | Nr along the vertical (third) axis.
-C     | Blocks/tiles have overlap regions of size OLx and OLy
-C     | along the dimensions that are subdivided.
-C     *==========================================================*
-C     \ev
-C
-C     Voodoo numbers controlling data layout:
-C     sNx :: Number of X points in tile.
-C     sNy :: Number of Y points in tile.
-C     OLx :: Tile overlap extent in X.
-C     OLy :: Tile overlap extent in Y.
-C     nSx :: Number of tiles per process in X.
-C     nSy :: Number of tiles per process in Y.
-C     nPx :: Number of processes to use in X.
-C     nPy :: Number of processes to use in Y.
-C     Nx  :: Number of points in X for the full domain.
-C     Ny  :: Number of points in Y for the full domain.
-C     Nr  :: Number of points in vertical direction.
-CEOP
-      INTEGER sNx
-      INTEGER sNy
-      INTEGER OLx
-      INTEGER OLy
-      INTEGER nSx
-      INTEGER nSy
-      INTEGER nPx
-      INTEGER nPy
-      INTEGER Nx
-      INTEGER Ny
-      INTEGER Nr
-      PARAMETER (
-     &           sNx =  30,
-     &           sNy =  15,
-     &           OLx =   2,
-     &           OLy =   2,
-     &           nSx =   2,
-     &           nSy =   4,
-     &           nPx =   1,
-     &           nPy =   1,
-     &           Nx  = sNx*nSx*nPx,
-     &           Ny  = sNy*nSy*nPy,
-     &           Nr  =   4)
+!BOP
+!    !ROUTINE: SIZE.h
+!    !INTERFACE:
+!    include SIZE.h
+!    !DESCRIPTION: \bv
+! *==========================================================*
+! | SIZE.h Declare size of underlying computational grid.
+! *==========================================================*
+! | The design here supports a three-dimensional model grid
+! | with indices I,J and K. The three-dimensional domain
+! | is comprised of nPx*nSx blocks (or tiles) of size sNx
+! | along the first (left-most index) axis, nPy*nSy blocks
+! | of size sNy along the second axis and one block of size
+! | Nr along the vertical (third) axis.
+! | Blocks/tiles have overlap regions of size OLx and OLy
+! | along the dimensions that are subdivided.
+! *==========================================================*
+! \ev
+!
+! Voodoo numbers controlling data layout:
+! sNx :: Number of X points in tile.
+! sNy :: Number of Y points in tile.
+! OLx :: Tile overlap extent in X.
+! OLy :: Tile overlap extent in Y.
+! nSx :: Number of tiles per process in X.
+! nSy :: Number of tiles per process in Y.
+! nPx :: Number of processes to use in X.
+! nPy :: Number of processes to use in Y.
+! Nx  :: Number of points in X for the full domain.
+! Ny  :: Number of points in Y for the full domain.
+! Nr  :: Number of points in vertical direction.
+!EOP
+      INTEGER :: sNx
+      INTEGER :: sNy
+      INTEGER :: OLx
+      INTEGER :: OLy
+      INTEGER :: nSx
+      INTEGER :: nSy
+      INTEGER :: nPx
+      INTEGER :: nPy
+      INTEGER :: Nx
+      INTEGER :: Ny
+      INTEGER :: Nr
+      PARAMETER (                                                                 &
+     &      sNx =  30,                                                            &
+     &      sNy =  15,                                                            &
+     &      OLx =   2,                                                            &
+     &      OLy =   2,                                                            &
+     &      nSx =   2,                                                            &
+     &      nSy =   4,                                                            &
+     &      nPx =   1,                                                            &
+     &      nPy =   1,                                                            &
+     &      Nx  = sNx*nSx*nPx,                                                    &
+     &      Ny  = sNy*nSy*nPy,                                                    &
+     &      Nr  =   4)
 
-C     MAX_OLX :: Set to the maximum overlap region size of any array
-C     MAX_OLY    that will be exchanged. Controls the sizing of exch
-C                routine buffers.
-      INTEGER MAX_OLX
-      INTEGER MAX_OLY
-      PARAMETER ( MAX_OLX = OLx,
-     &            MAX_OLY = OLy )
+! MAX_OLX :: Set to the maximum overlap region size of any array
+! MAX_OLY    that will be exchanged. Controls the sizing of exch
+!            routine buffers.
+      INTEGER :: MAX_OLX
+      INTEGER :: MAX_OLY
+      PARAMETER ( MAX_OLX = OLx,                                                  &
+     &      MAX_OLY = OLy )
 

--- a/model/inc/SURFACE.h
+++ b/model/inc/SURFACE.h
@@ -1,59 +1,59 @@
-C
-CBOP
-C    !ROUTINE: SURFACE.h
-C    !INTERFACE:
-C    include SURFACE.h
-C    !DESCRIPTION: \bv
-C     *==========================================================*
-C     | SURFACE.h
-C     | o Header file defining surface-related model variables
-C     *==========================================================*
-C     | Contains variables relative to the surface position
-C     | that are held fixed in linear free-surface formulation
-C     | but can vary with time with a non-linear free-surface.
-C     *==========================================================*
-C     \ev
-CEOP
+!
+!BOP
+!    !ROUTINE: SURFACE.h
+!    !INTERFACE:
+!    include SURFACE.h
+!    !DESCRIPTION: \bv
+! *==========================================================*
+! | SURFACE.h
+! | o Header file defining surface-related model variables
+! *==========================================================*
+! | Contains variables relative to the surface position
+! | that are held fixed in linear free-surface formulation
+! | but can vary with time with a non-linear free-surface.
+! *==========================================================*
+! \ev
+!EOP
 
-C--   COMMON /SURF_FIXED/  fixed surface arrays (Real)
-C     Bo_surf  :: Buoyancy|1/rho [ocean|atmos] at surface level [=g|alpha(p_o)]
-C     recip_Bo :: 1/Bo_surf
-C     topoZ    :: topographic height [m] (used mainly for atmosphere)
-C     phi0surf :: starting point for integrating phi_Hyd
+!--   COMMON /SURF_FIXED/  fixed surface arrays (Real)
+! Bo_surf  :: Buoyancy|1/rho [ocean|atmos] at surface level [=g|alpha(p_o)]
+! recip_Bo :: 1/Bo_surf
+! topoZ    :: topographic height [m] (used mainly for atmosphere)
+! phi0surf :: starting point for integrating phi_Hyd
       COMMON /SURF_FIXED/ Bo_surf, recip_Bo, topoZ, phi0surf
       _RL  Bo_surf (1-OLx:sNx+OLx,1-OLy:sNy+OLy,nSx,nSy)
       _RL  recip_Bo(1-OLx:sNx+OLx,1-OLy:sNy+OLy,nSx,nSy)
       _RS  topoZ   (1-OLx:sNx+OLx,1-OLy:sNy+OLy,nSx,nSy)
       _RS  phi0surf(1-OLx:sNx+OLx,1-OLy:sNy+OLy,nSx,nSy)
 
-C--   COMMON /SURF_CORREC/ Common block for correction of source/sink of
-C--                        Tracer due to W at the surface with Linear
-C--                        Free Surface
-C     TsurfCor :: Pot.Temp Linear-Free-Surface correction term [K.r_Unit/s]
-C     SsurfCor :: Salinity Linear-Free-Surface correction term [g/kg.r_Unit/s]
+!--   COMMON /SURF_CORREC/ Common block for correction of source/sink of
+!--                        Tracer due to W at the surface with Linear
+!--                        Free Surface
+! TsurfCor :: Pot.Temp Linear-Free-Surface correction term [K.r_Unit/s]
+! SsurfCor :: Salinity Linear-Free-Surface correction term [g/kg.r_Unit/s]
       COMMON /SURF_CORREC/ TsurfCor, SsurfCor
       _RL TsurfCor
       _RL SsurfCor
 
-C--   COMMON /ETA_UPDATES/ variables related to Eta updates (with exactConserv)
-C     etaHnm1 :: surface r-anomaly, etaH, at previous time level
-C     dEtaHdt :: time derivative of total column height [r_unit/s = w unit]
-C     PmEpR   :: keep the fresh water input (=-EmPmR) of the previous time step
+!--   COMMON /ETA_UPDATES/ variables related to Eta updates (with exactConserv)
+! etaHnm1 :: surface r-anomaly, etaH, at previous time level
+! dEtaHdt :: time derivative of total column height [r_unit/s = w unit]
+! PmEpR   :: keep the fresh water input (=-EmPmR) of the previous time step
       COMMON /ETA_UPDATES/ etaHnm1, dEtaHdt, PmEpR
       _RL etaHnm1(1-OLx:sNx+OLx,1-OLy:sNy+OLy,nSx,nSy)
       _RL dEtaHdt(1-OLx:sNx+OLx,1-OLy:sNy+OLy,nSx,nSy)
       _RL PmEpR  (1-OLx:sNx+OLx,1-OLy:sNy+OLy,nSx,nSy)
 
 #ifdef NONLIN_FRSURF
-C--   COMMON /SURF_CHANGE/ transient variables used for Non-Lin Free-Surf
-C     hFac_surfC ::  New thickness factor of the surface level
-C                        center (Tracer point)
-C     hFac_surfW ::  idem, West  interface (U point)
-C     hFac_surfS ::  idem, South interface (V point)
-C     hFac_surfNm1C, etc. :: prior values
-      COMMON /SURF_CHANGE/
-     &     hFac_surfC, hFac_surfW, hFac_surfS,
-     &     hFac_surfNm1C, hFac_surfNm1W, hFac_surfNm1S
+!--   COMMON /SURF_CHANGE/ transient variables used for Non-Lin Free-Surf
+! hFac_surfC ::  New thickness factor of the surface level
+!                    center (Tracer point)
+! hFac_surfW ::  idem, West  interface (U point)
+! hFac_surfS ::  idem, South interface (V point)
+! hFac_surfNm1C, etc. :: prior values
+      COMMON /SURF_CHANGE/                                                        &
+     &      hFac_surfC, hFac_surfW, hFac_surfS,                                   &
+     &      hFac_surfNm1C, hFac_surfNm1W, hFac_surfNm1S
       _RS  hFac_surfC(1-OLx:sNx+OLx,1-OLy:sNy+OLy,nSx,nSy)
       _RS  hFac_surfW(1-OLx:sNx+OLx,1-OLy:sNy+OLy,nSx,nSy)
       _RS  hFac_surfS(1-OLx:sNx+OLx,1-OLy:sNy+OLy,nSx,nSy)
@@ -61,29 +61,29 @@ C     hFac_surfNm1C, etc. :: prior values
       _RS  hFac_surfNm1W(1-OLx:sNx+OLx,1-OLy:sNy+OLy,nSx,nSy)
       _RS  hFac_surfNm1S(1-OLx:sNx+OLx,1-OLy:sNy+OLy,nSx,nSy)
 
-C     Local variables in common block
-C     Rmin_surf :: minimum r_value of the free surface position
-C                  that satisfy  the hFacInf criteria
+! Local variables in common block
+! Rmin_surf :: minimum r_value of the free surface position
+!              that satisfy  the hFacInf criteria
       COMMON /LOCAL_CALC_SURF_DR/ Rmin_surf
       _RL Rmin_surf(1-OLx:sNx+OLx,1-OLy:sNy+OLy,nSx,nSy)
 
-C--   COMMON /RSTAR_CHANGE/ transient variables used with r* Coordinate
-C     rStarFacC :: = dr/dr* = ratio of r-thickness / r*-thickness = h^n / H
-C     rStarFacW :: same but for West  face
-C     rStarFacS :: same but for South face
-C     pStarFacK :: rStarFacC**atm_kappa (for atmosphere in p* coords)
-C     rStarFacNm1C, etc. :: prior values
-C     rStarExpC :: column expansion factor = h^n+1/h^n , Centered
-C     rStarExpW :: column expansion factor = h^n+1/h^n , Western  face
-C     rStarExpS :: column expansion factor = h^n+1/h^n , Southern face
-C     rStarDhCDt:: relative time derivative of h_Center = d.eta/dt / H
-C     rStarDhWDt:: relative time derivative of h_West_face  (u.point)
-C     rStarDhSDt:: relative time derivative of h_South_face (v.point)
-      COMMON /RSTAR_CHANGE/
-     &     rStarFacC, rStarFacW, rStarFacS, pStarFacK,
-     &     rStarFacNm1C, rStarFacNm1W, rStarFacNm1S,
-     &     rStarExpC, rStarExpW, rStarExpS,
-     &     rStarDhCDt,rStarDhWDt,rStarDhSDt
+!--   COMMON /RSTAR_CHANGE/ transient variables used with r* Coordinate
+! rStarFacC :: = dr/dr* = ratio of r-thickness / r*-thickness = h^n / H
+! rStarFacW :: same but for West  face
+! rStarFacS :: same but for South face
+! pStarFacK :: rStarFacC**atm_kappa (for atmosphere in p* coords)
+! rStarFacNm1C, etc. :: prior values
+! rStarExpC :: column expansion factor = h^n+1/h^n , Centered
+! rStarExpW :: column expansion factor = h^n+1/h^n , Western  face
+! rStarExpS :: column expansion factor = h^n+1/h^n , Southern face
+! rStarDhCDt:: relative time derivative of h_Center = d.eta/dt / H
+! rStarDhWDt:: relative time derivative of h_West_face  (u.point)
+! rStarDhSDt:: relative time derivative of h_South_face (v.point)
+      COMMON /RSTAR_CHANGE/                                                       &
+     &      rStarFacC, rStarFacW, rStarFacS, pStarFacK,                           &
+     &      rStarFacNm1C, rStarFacNm1W, rStarFacNm1S,                             &
+     &      rStarExpC, rStarExpW, rStarExpS,                                      &
+     &      rStarDhCDt,rStarDhWDt,rStarDhSDt
       _RL  rStarFacC (1-OLx:sNx+OLx,1-OLy:sNy+OLy,nSx,nSy)
       _RL  rStarFacW (1-OLx:sNx+OLx,1-OLy:sNy+OLy,nSx,nSy)
       _RL  rStarFacS (1-OLx:sNx+OLx,1-OLy:sNy+OLy,nSx,nSy)
@@ -98,24 +98,24 @@ C     rStarDhSDt:: relative time derivative of h_South_face (v.point)
       _RL  rStarDhWDt(1-OLx:sNx+OLx,1-OLy:sNy+OLy,nSx,nSy)
       _RL  rStarDhSDt(1-OLx:sNx+OLx,1-OLy:sNy+OLy,nSx,nSy)
 
-C--   COMMON /RSTAR_FIXED/ fixed thickness ratio ( r* discretization )
-C     h0FacC :: initial (and fixed in time) hFacC factor
-C     h0FacW :: initial (and fixed in time) hFacW factor
-C     h0FacS :: initial (and fixed in time) hFacS factor
-      COMMON /RSTAR_FIXED/
-     & h0FacC, h0FacW, h0FacS
+!--   COMMON /RSTAR_FIXED/ fixed thickness ratio ( r* discretization )
+! h0FacC :: initial (and fixed in time) hFacC factor
+! h0FacW :: initial (and fixed in time) hFacW factor
+! h0FacS :: initial (and fixed in time) hFacS factor
+      COMMON /RSTAR_FIXED/                                                        &
+     &      h0FacC, h0FacW, h0FacS
       _RS h0FacC(1-OLx:sNx+OLx,1-OLy:sNy+OLy,Nr,nSx,nSy)
       _RS h0FacW(1-OLx:sNx+OLx,1-OLy:sNy+OLy,Nr,nSx,nSy)
       _RS h0FacS(1-OLx:sNx+OLx,1-OLy:sNy+OLy,Nr,nSx,nSy)
 
-C--   COMMON /SIGMA_CHANGE/ transient variables used with r* Coordinate
-C     etaHw    :: surface r-anomaly (etaH) at Western  edge (U location)
-C     etaHs    :: surface r-anomaly (etaH) at Southern edge (V location)
-C     dEtaWdt  :: time derivative of etaH at Western  edge (U location)
-C     dEtaSdt  :: time derivative of etaH at Southern edge (V location)
-      COMMON /SIGMA_CHANGE/
-     &  etaHw, etaHs,
-     &  dEtaWdt, dEtaSdt
+!--   COMMON /SIGMA_CHANGE/ transient variables used with r* Coordinate
+! etaHw    :: surface r-anomaly (etaH) at Western  edge (U location)
+! etaHs    :: surface r-anomaly (etaH) at Southern edge (V location)
+! dEtaWdt  :: time derivative of etaH at Western  edge (U location)
+! dEtaSdt  :: time derivative of etaH at Southern edge (V location)
+      COMMON /SIGMA_CHANGE/                                                       &
+     &      etaHw, etaHs,                                                         &
+     &      dEtaWdt, dEtaSdt
       _RL  etaHw  (1-OLx:sNx+OLx,1-OLy:sNy+OLy,nSx,nSy)
       _RL  etaHs  (1-OLx:sNx+OLx,1-OLy:sNy+OLy,nSx,nSy)
       _RL  dEtaWdt(1-OLx:sNx+OLx,1-OLy:sNy+OLy,nSx,nSy)

--- a/model/inc/TANPHIATU_MACROS.h
+++ b/model/inc/TANPHIATU_MACROS.h
@@ -1,18 +1,18 @@
-C
-CBOP
-C    !ROUTINE: TANPHIATU_MACROS.h
-C    !INTERFACE:
-C    include TANPHIATU_MACROS.h
-C    !DESCRIPTION: \bv
-C     *==========================================================*
-C     | TANPHIATU_MACROS.h                                        
-C     *==========================================================*
-C     | These macros are used to reduce memory requirement and/or 
-C     | memory references when variables are fixed along a given  
-C     | axis or axes.                                             
-C     *==========================================================*
-C     \ev
-CEOP
+!
+!BOP
+!    !ROUTINE: TANPHIATU_MACROS.h
+!    !INTERFACE:
+!    include TANPHIATU_MACROS.h
+!    !DESCRIPTION: \bv
+! *==========================================================*
+! | TANPHIATU_MACROS.h
+! *==========================================================*
+! | These macros are used to reduce memory requirement and/or
+! | memory references when variables are fixed along a given
+! | axis or axes.
+! *==========================================================*
+! \ev
+!EOP
 
 #ifdef TANPHIATU_CONST
 #define  _tanPhiAtU(i,j,bi,bj) tanPhiAtU(1,1,1,1)

--- a/model/inc/TANPHIATV_MACROS.h
+++ b/model/inc/TANPHIATV_MACROS.h
@@ -1,18 +1,18 @@
-C
-CBOP
-C    !ROUTINE: TANPHIATV_MACROS.h
-C    !INTERFACE:
-C    include TANPHIATV_MACROS.h
-C    !DESCRIPTION: \bv
-C     *==========================================================*
-C     | TANPHIATV_MACROS.h                                        
-C     *==========================================================*
-C     | These macros are used to reduce memory requirement and/or 
-C     | memory references when variables are fixed along a given  
-C     | axis or axes.                                             
-C     *==========================================================*
-C     \ev
-CEOP
+!
+!BOP
+!    !ROUTINE: TANPHIATV_MACROS.h
+!    !INTERFACE:
+!    include TANPHIATV_MACROS.h
+!    !DESCRIPTION: \bv
+! *==========================================================*
+! | TANPHIATV_MACROS.h
+! *==========================================================*
+! | These macros are used to reduce memory requirement and/or
+! | memory references when variables are fixed along a given
+! | axis or axes.
+! *==========================================================*
+! \ev
+!EOP
 
 #ifdef TANPHIATV_CONST
 #define  _tanPhiAtV(i,j,bi,bj) tanPhiAtV(1,1,1,1)

--- a/model/inc/XC_MACROS.h
+++ b/model/inc/XC_MACROS.h
@@ -1,18 +1,18 @@
-C
-CBOP
-C    !ROUTINE: XC_MACROS.h
-C    !INTERFACE:
-C    include XC_MACROS.h
-C    !DESCRIPTION: \bv
-C     *==========================================================*
-C     | XC_MACROS.h                                               
-C     *==========================================================*
-C     | These macros are used to reduce memory requirement and/or 
-C     | memory references when variables are fixed along a given  
-C     | axis or axes.                                             
-C     *==========================================================*
-C     \ev
-CEOP
+!
+!BOP
+!    !ROUTINE: XC_MACROS.h
+!    !INTERFACE:
+!    include XC_MACROS.h
+!    !DESCRIPTION: \bv
+! *==========================================================*
+! | XC_MACROS.h
+! *==========================================================*
+! | These macros are used to reduce memory requirement and/or
+! | memory references when variables are fixed along a given
+! | axis or axes.
+! *==========================================================*
+! \ev
+!EOP
 
 #ifdef XC_CONST
 #define  _xC(i,j,bi,bj) xC(1,1,1,1)

--- a/model/inc/YC_MACROS.h
+++ b/model/inc/YC_MACROS.h
@@ -1,18 +1,18 @@
-C
-CBOP
-C    !ROUTINE: YC_MACROS.h
-C    !INTERFACE:
-C    include YC_MACROS.h
-C    !DESCRIPTION: \bv
-C     *==========================================================*
-C     | YC_MACROS.h                                               
-C     *==========================================================*
-C     | These macros are used to reduce memory requirement and/or 
-C     | memory references when variables are fixed along a given  
-C     | axis or axes.                                             
-C     *==========================================================*
-C     \ev
-CEOP
+!
+!BOP
+!    !ROUTINE: YC_MACROS.h
+!    !INTERFACE:
+!    include YC_MACROS.h
+!    !DESCRIPTION: \bv
+! *==========================================================*
+! | YC_MACROS.h
+! *==========================================================*
+! | These macros are used to reduce memory requirement and/or
+! | memory references when variables are fixed along a given
+! | axis or axes.
+! *==========================================================*
+! \ev
+!EOP
 
 #ifdef YC_CONST
 #define  _yC(i,j,bi,bj) yC(1,1,1,1)

--- a/pkg/ptracers/PTRACERS_FIELDS.h
+++ b/pkg/ptracers/PTRACERS_FIELDS.h
@@ -1,27 +1,27 @@
 #ifdef ALLOW_PTRACERS
 
-CBOP
-C    !ROUTINE: PTRACERS_FIELDS.h
-C    !INTERFACE:
-C #include PTRACERS_FIELDS.h
+!BOP
+!    !ROUTINE: PTRACERS_FIELDS.h
+!    !INTERFACE:
+! #include PTRACERS_FIELDS.h
 
-C    !DESCRIPTION:
-C Contains passive tracer fields
+!    !DESCRIPTION:
+! Contains passive tracer fields
 
-CEOP
+!EOP
 
-C     COMMON /PTRACERS_FIELDS/
-C     pTracer  :: passive tracer concentration (tr per unit volume).
-C     gpTrNm1  :: work-space for time-stepping
-C     surfaceForcingPTr :: passive tracer surface forcing
-      _RL  pTracer (1-OLx:sNx+OLx,1-OLy:sNy+OLy,Nr,nSx,nSy,
-     &              PTRACERS_num)
-      _RL  gpTrNm1 (1-OLx:sNx+OLx,1-OLy:sNy+OLy,Nr,nSx,nSy,
-     &              PTRACERS_num)
-      _RL  surfaceForcingPTr (1-OLx:sNx+OLx,1-OLy:sNy+OLy,nSx,nSy,
-     &              PTRACERS_num)
-      COMMON /PTRACERS_FIELDS/
-     &              pTracer, gpTrNm1, surfaceForcingPTr
+! COMMON /PTRACERS_FIELDS/
+! pTracer  :: passive tracer concentration (tr per unit volume).
+! gpTrNm1  :: work-space for time-stepping
+! surfaceForcingPTr :: passive tracer surface forcing
+      _RL  pTracer (1-OLx:sNx+OLx,1-OLy:sNy+OLy,Nr,nSx,nSy,                       &
+     &      PTRACERS_num)
+      _RL  gpTrNm1 (1-OLx:sNx+OLx,1-OLy:sNy+OLy,Nr,nSx,nSy,                       &
+     &      PTRACERS_num)
+      _RL  surfaceForcingPTr (1-OLx:sNx+OLx,1-OLy:sNy+OLy,nSx,nSy,                &
+     &      PTRACERS_num)
+      COMMON /PTRACERS_FIELDS/                                                    &
+     &      pTracer, gpTrNm1, surfaceForcingPTr
 
       _RL totSurfCorPTr(PTRACERS_num)
       _RL meanSurfCorPTr(PTRACERS_num)
@@ -29,6 +29,6 @@ C     surfaceForcingPTr :: passive tracer surface forcing
 
 #endif /* ALLOW_PTRACERS */
 
-CEH3 ;;; Local Variables: ***
-CEH3 ;;; mode:fortran ***
-CEH3 ;;; End: ***
+!EH3 ;;; Local Variables: ***
+!EH3 ;;; mode:fortran ***
+!EH3 ;;; End: ***

--- a/pkg/ptracers/PTRACERS_MOD.h
+++ b/pkg/ptracers/PTRACERS_MOD.h
@@ -1,23 +1,23 @@
 #ifdef ALLOW_PTRACERS
 #ifdef PTRACERS_ALLOW_DYN_STATE
 
-CBOP
-C    !ROUTINE: PTRACERS_MOD.h
-C    !INTERFACE:
-C #include PTRACERS_MOD.h
+!BOP
+!    !ROUTINE: PTRACERS_MOD.h
+!    !INTERFACE:
+! #include PTRACERS_MOD.h
 
-C    !DESCRIPTION:
-C Contains passive tracer modules and associated macros
+!    !DESCRIPTION:
+! Contains passive tracer modules and associated macros
 
-CEOP
+!EOP
 
       use ptracers_dyn_state_mod
       use ptracers_dyn_state_data_mod
 
-C     This macro allows the second-order-moment member of the ptracers
-C     internal state data structure to be used like an simple array.
-C     Names are chosen such that macro expansion does not increase
-C     line length
+! This macro allows the second-order-moment member of the ptracers
+! internal state data structure to be used like an simple array.
+! Names are chosen such that macro expansion does not increase
+! line length
 #define _Ptracers_som(a,b,c,d,e,f,g) \
         PtrISt(g)%som_P(a,b,c,d,e,f)
 

--- a/pkg/ptracers/PTRACERS_OPTIONS.h
+++ b/pkg/ptracers/PTRACERS_OPTIONS.h
@@ -1,5 +1,5 @@
-C CPP options file for PTRACERS package
-C Use this file for selecting options within the PTRACERS package
+! CPP options file for PTRACERS package
+! Use this file for selecting options within the PTRACERS package
 
 #ifndef PTRACERS_OPTIONS_H
 #define PTRACERS_OPTIONS_H
@@ -7,25 +7,25 @@ C Use this file for selecting options within the PTRACERS package
 #include "CPP_OPTIONS.h"
 
 #ifdef ALLOW_PTRACERS
-C     Package-specific Options & Macros go here
+! Package-specific Options & Macros go here
 
-C NUMBER_OF_PTRACERS defines how many passive tracers are allocated/exist.
-C This CPP macro is *only* used in PTRACERS.h to set an integer parameter.
-C <Please> do not make use of it elsewhere.
-C   Note: this CPP macro has been removed to avoid confusion and risk of
-C    error resulting from multiple definitions (default + explicit) within
-C    the code.
-C    The maximum number of tracers is now defined within PTRACERS_SIZE.h
-C---
+! NUMBER_OF_PTRACERS defines how many passive tracers are allocated/exist.
+! This CPP macro is *only* used in PTRACERS.h to set an integer parameter.
+! <Please> do not make use of it elsewhere.
+!   Note: this CPP macro has been removed to avoid confusion and risk of
+!    error resulting from multiple definitions (default + explicit) within
+!    the code.
+!    The maximum number of tracers is now defined within PTRACERS_SIZE.h
+!---
 
-C     This enables the dynamically allocated internal state data structures
-C     for PTracers.  Needed for PTRACERS_SOM_Advection.
-C     This requires a Fortran 90 compiler!
+! This enables the dynamically allocated internal state data structures
+! for PTracers.  Needed for PTRACERS_SOM_Advection.
+! This requires a Fortran 90 compiler!
 #undef  PTRACERS_ALLOW_DYN_STATE
 
 #endif /* ALLOW_PTRACERS */
 #endif /* PTRACERS_OPTIONS_H */
 
-CEH3 ;;; Local Variables: ***
-CEH3 ;;; mode:fortran ***
-CEH3 ;;; End: ***
+!EH3 ;;; Local Variables: ***
+!EH3 ;;; mode:fortran ***
+!EH3 ;;; End: ***

--- a/pkg/ptracers/PTRACERS_PARAMS.h
+++ b/pkg/ptracers/PTRACERS_PARAMS.h
@@ -1,25 +1,25 @@
 #ifdef ALLOW_PTRACERS
 
-CBOP
-C    !ROUTINE: PTRACERS_PARAMS.h
-C    !INTERFACE:
-C #include PTRACERS_PARAMS.h
+!BOP
+!    !ROUTINE: PTRACERS_PARAMS.h
+!    !INTERFACE:
+! #include PTRACERS_PARAMS.h
 
-C    !DESCRIPTION:
-C Contains passive tracer parameters.
+!    !DESCRIPTION:
+! Contains passive tracer parameters.
 
-CEOP
+!EOP
 
-C--   COMMON /PTRACERS_PARAMS_R/ PTRACERS real-type parameters:
-C     PTRACERS_dTLev    :: Timestep for ptracers ( s ), function of level k
-C     PTRACERS_ref      :: vertical profile for passive tracers, in
-C                          analogy to tRef and sRef, hence the name
-C     PTRACERS_EvPrRn   :: tracer concentration in Rain, Evap & RunOff
-C       notes: a) used if both NonLin_FrSurf & useRealFreshWater are set.
-C              b) use pTracer surface (local) value if = UNSET_RL (default)
-C     PTRACERS_startStepFwd :: time to start stepping forward this tracer
-C     PTRACERS_resetFreq    :: Frequency (s) to reset ptracers to original val
-C     PTRACERS_resetPhase   :: Phase (s) to reset ptracers
+!--   COMMON /PTRACERS_PARAMS_R/ PTRACERS real-type parameters:
+! PTRACERS_dTLev    :: Timestep for ptracers ( s ), function of level k
+! PTRACERS_ref      :: vertical profile for passive tracers, in
+!                      analogy to tRef and sRef, hence the name
+! PTRACERS_EvPrRn   :: tracer concentration in Rain, Evap & RunOff
+!   notes: a) used if both NonLin_FrSurf & useRealFreshWater are set.
+!          b) use pTracer surface (local) value if = UNSET_RL (default)
+! PTRACERS_startStepFwd :: time to start stepping forward this tracer
+! PTRACERS_resetFreq    :: Frequency (s) to reset ptracers to original val
+! PTRACERS_resetPhase   :: Phase (s) to reset ptracers
 
       _RL PTRACERS_dTLev(Nr)
       _RL PTRACERS_dumpFreq
@@ -32,116 +32,116 @@ C     PTRACERS_resetPhase   :: Phase (s) to reset ptracers
       _RL PTRACERS_startStepFwd(PTRACERS_num)
       _RL PTRACERS_resetFreq(PTRACERS_num)
       _RL PTRACERS_resetPhase(PTRACERS_num)
-      COMMON /PTRACERS_PARAMS_R/
-     &     PTRACERS_dTLev,
-     &     PTRACERS_dumpFreq,
-     &     PTRACERS_monitorFreq,
-     &     PTRACERS_diffKh,
-     &     PTRACERS_diffK4,
-     &     PTRACERS_diffKrNr,
-     &     PTRACERS_ref,
-     &     PTRACERS_EvPrRn,
-     &     PTRACERS_startStepFwd,
-     &     PTRACERS_resetFreq,
-     &     PTRACERS_resetPhase
+      COMMON /PTRACERS_PARAMS_R/                                                  &
+     &      PTRACERS_dTLev,                                                       &
+     &      PTRACERS_dumpFreq,                                                    &
+     &      PTRACERS_monitorFreq,                                                 &
+     &      PTRACERS_diffKh,                                                      &
+     &      PTRACERS_diffK4,                                                      &
+     &      PTRACERS_diffKrNr,                                                    &
+     &      PTRACERS_ref,                                                         &
+     &      PTRACERS_EvPrRn,                                                      &
+     &      PTRACERS_startStepFwd,                                                &
+     &      PTRACERS_resetFreq,                                                   &
+     &      PTRACERS_resetPhase
 
 #ifdef ALLOW_COST
-C     COMMON /PTRACERS_OLD_R/ Old (real type) PTRACERS parameters
-C        (to be removed 1 day ...)
+! COMMON /PTRACERS_OLD_R/ Old (real type) PTRACERS parameters
+!    (to be removed 1 day ...)
       _RL lambdaTr1ClimRelax
-      COMMON /PTRACERS_OLD_R/
-     &     lambdaTr1ClimRelax
+      COMMON /PTRACERS_OLD_R/                                                     &
+     &      lambdaTr1ClimRelax
 #endif
 
-C--   COMMON /PTRACERS_PARAMS_I/ PTRACERS integer-type parameters:
-C     PTRACERS_numInUse :: number of tracers to use
-C     PTRACERS_Iter0    :: timestep number when tracers are initialized
-      INTEGER PTRACERS_Iter0
-      INTEGER PTRACERS_numInUse
-      INTEGER PTRACERS_advScheme(PTRACERS_num)
-      COMMON /PTRACERS_PARAMS_I/
-     &     PTRACERS_Iter0,
-     &     PTRACERS_numInUse,
-     &     PTRACERS_advScheme
+!--   COMMON /PTRACERS_PARAMS_I/ PTRACERS integer-type parameters:
+! PTRACERS_numInUse :: number of tracers to use
+! PTRACERS_Iter0    :: timestep number when tracers are initialized
+      INTEGER :: PTRACERS_Iter0
+      INTEGER :: PTRACERS_numInUse
+      INTEGER :: PTRACERS_advScheme(PTRACERS_num)
+      COMMON /PTRACERS_PARAMS_I/                                                  &
+     &      PTRACERS_Iter0,                                                       &
+     &      PTRACERS_numInUse,                                                    &
+     &      PTRACERS_advScheme
 
-C--   COMMON /PTRACERS_PARAMS_L/ PTRACERS logical-type parameters:
-C     PTRACERS_ImplVertAdv   :: use Implicit Vertical Advection for this tracer
-C     PTRACERS_MultiDimAdv   :: internal flag (depend on the advection scheme),
-C                               true if this tracer uses Multi-Dim advection
-C     PTRACERS_SOM_Advection :: internal flag (depend on the advection scheme),
-C                               true if this tracer uses 2nd-order moment advection
-C     PTRACERS_AdamsBashGtr  :: internal flag (depend on the advection scheme),
-C                               true if applies Adams-Bashforth on tracer tendency
-C     PTRACERS_AdamsBash_Tr  :: internal flag (depend on the advection scheme),
-C                               true if applies Adams-Bashforth on passive Tracer
-C     PTRACERS_useGMRedi(n)  :: true if GM-Redi applies to pTracer n
-C     PTRACERS_useDWNSLP(n)  :: true if Down-Sloping flow applies to pTracer n
-C     PTRACERS_useKPP(n)     :: true if KPP applies to pTracer n
-C     PTRACERS_doAB_onGpTr   :: if Adams-Bashforth time stepping is used, apply
-C                               AB on tracer tendencies (rather than on Tracers)
-C     PTRACERS_addSrelax2EmP :: add Salt relaxation to EmP
-C     PTRACERS_startAllTrc   :: internal flag, all tracers start at startTime
-C     PTRACERS_calcSurfCor   :: calculate Linear Free-Surf source/sink of tracer
-C                               (set internally)
-C     PTRACERS_linFSConserve :: apply mean Free-Surf source/sink at surface
-C     PTRACERS_stayPositive  :: use Smolarkiewicz Hack to ensure Tracer stays >0
-C     PTRACERS_useRecords    :: snap-shot output: put all pTracers in one file
-      LOGICAL PTRACERS_ImplVertAdv(PTRACERS_num)
-      LOGICAL PTRACERS_MultiDimAdv(PTRACERS_num)
-      LOGICAL PTRACERS_SOM_Advection(PTRACERS_num)
-      LOGICAL PTRACERS_AdamsBashGtr(PTRACERS_num)
-      LOGICAL PTRACERS_AdamsBash_Tr(PTRACERS_num)
-      LOGICAL PTRACERS_useGMRedi(PTRACERS_num)
-      LOGICAL PTRACERS_useDWNSLP(PTRACERS_num)
-      LOGICAL PTRACERS_useKPP(PTRACERS_num)
-      LOGICAL PTRACERS_linFSConserve(PTRACERS_num)
-      LOGICAL PTRACERS_stayPositive(PTRACERS_num)
-      LOGICAL PTRACERS_doAB_onGpTr
-      LOGICAL PTRACERS_addSrelax2EmP
-      LOGICAL PTRACERS_startAllTrc
-      LOGICAL PTRACERS_calcSurfCor
-      LOGICAL PTRACERS_useRecords
-      LOGICAL
-     &     PTRACERS_monitor_stdio, PTRACERS_monitor_mnc,
-     &     PTRACERS_snapshot_mdsio, PTRACERS_snapshot_mnc,
-     &     PTRACERS_pickup_write_mdsio, PTRACERS_pickup_read_mdsio,
-     &     PTRACERS_pickup_write_mnc, PTRACERS_pickup_read_mnc
-      COMMON /PTRACERS_PARAMS_L/
-     &     PTRACERS_ImplVertAdv,
-     &     PTRACERS_MultiDimAdv,
-     &     PTRACERS_SOM_Advection,
-     &     PTRACERS_AdamsBashGtr, PTRACERS_AdamsBash_Tr,
-     &     PTRACERS_useGMRedi, PTRACERS_useDWNSLP, PTRACERS_useKPP,
-     &     PTRACERS_linFSConserve, PTRACERS_stayPositive,
-     &     PTRACERS_doAB_onGpTr,
-     &     PTRACERS_addSrelax2EmP,
-     &     PTRACERS_startAllTrc,
-     &     PTRACERS_calcSurfCor,
-     &     PTRACERS_useRecords,
-     &     PTRACERS_snapshot_mdsio, PTRACERS_snapshot_mnc,
-     &     PTRACERS_monitor_stdio, PTRACERS_monitor_mnc,
-     &     PTRACERS_pickup_write_mdsio, PTRACERS_pickup_read_mdsio,
-     &     PTRACERS_pickup_write_mnc, PTRACERS_pickup_read_mnc
+!--   COMMON /PTRACERS_PARAMS_L/ PTRACERS logical-type parameters:
+! PTRACERS_ImplVertAdv   :: use Implicit Vertical Advection for this tracer
+! PTRACERS_MultiDimAdv   :: internal flag (depend on the advection scheme),
+!                           true if this tracer uses Multi-Dim advection
+! PTRACERS_SOM_Advection :: internal flag (depend on the advection scheme),
+!                           true if this tracer uses 2nd-order moment advection
+! PTRACERS_AdamsBashGtr  :: internal flag (depend on the advection scheme),
+!                           true if applies Adams-Bashforth on tracer tendency
+! PTRACERS_AdamsBash_Tr  :: internal flag (depend on the advection scheme),
+!                           true if applies Adams-Bashforth on passive Tracer
+! PTRACERS_useGMRedi(n)  :: true if GM-Redi applies to pTracer n
+! PTRACERS_useDWNSLP(n)  :: true if Down-Sloping flow applies to pTracer n
+! PTRACERS_useKPP(n)     :: true if KPP applies to pTracer n
+! PTRACERS_doAB_onGpTr   :: if Adams-Bashforth time stepping is used, apply
+!                           AB on tracer tendencies (rather than on Tracers)
+! PTRACERS_addSrelax2EmP :: add Salt relaxation to EmP
+! PTRACERS_startAllTrc   :: internal flag, all tracers start at startTime
+! PTRACERS_calcSurfCor   :: calculate Linear Free-Surf source/sink of tracer
+!                           (set internally)
+! PTRACERS_linFSConserve :: apply mean Free-Surf source/sink at surface
+! PTRACERS_stayPositive  :: use Smolarkiewicz Hack to ensure Tracer stays >0
+! PTRACERS_useRecords    :: snap-shot output: put all pTracers in one file
+      LOGICAL :: PTRACERS_ImplVertAdv(PTRACERS_num)
+      LOGICAL :: PTRACERS_MultiDimAdv(PTRACERS_num)
+      LOGICAL :: PTRACERS_SOM_Advection(PTRACERS_num)
+      LOGICAL :: PTRACERS_AdamsBashGtr(PTRACERS_num)
+      LOGICAL :: PTRACERS_AdamsBash_Tr(PTRACERS_num)
+      LOGICAL :: PTRACERS_useGMRedi(PTRACERS_num)
+      LOGICAL :: PTRACERS_useDWNSLP(PTRACERS_num)
+      LOGICAL :: PTRACERS_useKPP(PTRACERS_num)
+      LOGICAL :: PTRACERS_linFSConserve(PTRACERS_num)
+      LOGICAL :: PTRACERS_stayPositive(PTRACERS_num)
+      LOGICAL :: PTRACERS_doAB_onGpTr
+      LOGICAL :: PTRACERS_addSrelax2EmP
+      LOGICAL :: PTRACERS_startAllTrc
+      LOGICAL :: PTRACERS_calcSurfCor
+      LOGICAL :: PTRACERS_useRecords
+      LOGICAL ::                                                                  &
+     &      PTRACERS_monitor_stdio, PTRACERS_monitor_mnc,                         &
+     &      PTRACERS_snapshot_mdsio, PTRACERS_snapshot_mnc,                       &
+     &      PTRACERS_pickup_write_mdsio, PTRACERS_pickup_read_mdsio,              &
+     &      PTRACERS_pickup_write_mnc, PTRACERS_pickup_read_mnc
+      COMMON /PTRACERS_PARAMS_L/                                                  &
+     &      PTRACERS_ImplVertAdv,                                                 &
+     &      PTRACERS_MultiDimAdv,                                                 &
+     &      PTRACERS_SOM_Advection,                                               &
+     &      PTRACERS_AdamsBashGtr, PTRACERS_AdamsBash_Tr,                         &
+     &      PTRACERS_useGMRedi, PTRACERS_useDWNSLP, PTRACERS_useKPP,              &
+     &      PTRACERS_linFSConserve, PTRACERS_stayPositive,                        &
+     &      PTRACERS_doAB_onGpTr,                                                 &
+     &      PTRACERS_addSrelax2EmP,                                               &
+     &      PTRACERS_startAllTrc,                                                 &
+     &      PTRACERS_calcSurfCor,                                                 &
+     &      PTRACERS_useRecords,                                                  &
+     &      PTRACERS_snapshot_mdsio, PTRACERS_snapshot_mnc,                       &
+     &      PTRACERS_monitor_stdio, PTRACERS_monitor_mnc,                         &
+     &      PTRACERS_pickup_write_mdsio, PTRACERS_pickup_read_mdsio,              &
+     &      PTRACERS_pickup_write_mnc, PTRACERS_pickup_read_mnc
 
-C--   COMMON /PTRACERS_PARAMS_C/ PTRACERS character-type parameters:
+!--   COMMON /PTRACERS_PARAMS_C/ PTRACERS character-type parameters:
       CHARACTER*(MAX_LEN_FNAM) PTRACERS_initialFile(PTRACERS_num)
       CHARACTER*(MAX_LEN_FNAM) PTRACERS_names(PTRACERS_num)
       CHARACTER*(MAX_LEN_FNAM) PTRACERS_long_names(PTRACERS_num)
       CHARACTER*(MAX_LEN_FNAM) PTRACERS_units(PTRACERS_num)
-      COMMON /PTRACERS_PARAMS_C/
-     &     PTRACERS_initialFile,
-     &     PTRACERS_names,
-     &     PTRACERS_long_names,
-     &     PTRACERS_units
+      COMMON /PTRACERS_PARAMS_C/                                                  &
+     &      PTRACERS_initialFile,                                                 &
+     &      PTRACERS_names,                                                       &
+     &      PTRACERS_long_names,                                                  &
+     &      PTRACERS_units
 
-C     COMMON /PTRACERS_LABELS/ holds pTracers labels
-C     PTRACERS_ioLabel  :: pTracer I/O & diagnostics label (2 charecters long)
-      COMMON /PTRACERS_LABELS/
-     &     PTRACERS_ioLabel
-      CHARACTER*2              PTRACERS_ioLabel(PTRACERS_num)
+! COMMON /PTRACERS_LABELS/ holds pTracers labels
+! PTRACERS_ioLabel  :: pTracer I/O & diagnostics label (2 charecters long)
+      COMMON /PTRACERS_LABELS/                                                    &
+     &      PTRACERS_ioLabel
+      CHARACTER(len=2) :: PTRACERS_ioLabel(PTRACERS_num)
 
 #endif /* ALLOW_PTRACERS */
 
-CEH3 ;;; Local Variables: ***
-CEH3 ;;; mode:fortran ***
-CEH3 ;;; End: ***
+!EH3 ;;; Local Variables: ***
+!EH3 ;;; mode:fortran ***
+!EH3 ;;; End: ***

--- a/pkg/ptracers/PTRACERS_SIZE.h
+++ b/pkg/ptracers/PTRACERS_SIZE.h
@@ -1,28 +1,28 @@
 #ifdef ALLOW_PTRACERS
 
-CBOP
-C    !ROUTINE: PTRACERS_SIZE.h
-C    !INTERFACE:
-C #include PTRACERS_SIZE.h
+!BOP
+!    !ROUTINE: PTRACERS_SIZE.h
+!    !INTERFACE:
+! #include PTRACERS_SIZE.h
 
-C    !DESCRIPTION:
-C Contains passive tracer array size (number of tracers).
+!    !DESCRIPTION:
+! Contains passive tracer array size (number of tracers).
 
-C PTRACERS_num defines how many passive tracers are allocated/exist.
-C  and is set here (default 1)
-C
-C     Number of tracers
-      INTEGER PTRACERS_num
+! PTRACERS_num defines how many passive tracers are allocated/exist.
+!  and is set here (default 1)
+!
+! Number of tracers
+      INTEGER :: PTRACERS_num
       PARAMETER(PTRACERS_num = 1 )
 
 #ifdef ALLOW_AUTODIFF_TAMC
-      INTEGER    maxpass
+      INTEGER :: maxpass
       PARAMETER( maxpass     = PTRACERS_num + 2 )
 #endif
 
-CEOP
+!EOP
 #endif /* ALLOW_PTRACERS */
 
-CEH3 ;;; Local Variables: ***
-CEH3 ;;; mode:fortran ***
-CEH3 ;;; End: ***
+!EH3 ;;; Local Variables: ***
+!EH3 ;;; mode:fortran ***
+!EH3 ;;; End: ***

--- a/pkg/ptracers/PTRACERS_START.h
+++ b/pkg/ptracers/PTRACERS_START.h
@@ -1,37 +1,37 @@
-CBOP
-C     !ROUTINE: PTRACERS_START.h
-C     !INTERFACE:
-C     include "PTRACERS_START.h"
-C
-C     !DESCRIPTION:
-C     \bv
-C     *==========================================================*
-C     | PTRACERS_START.h
-C     | o Holds passive-tracer internal parameters related
-C     |   to start and restart process
-C     *==========================================================*
-C     | Passive-tracer internal parameters/variables related to
-C     | a) which tracer is stepped forward
-C     | b) writing or reading pickup for a restart.
-C     | Note:
-C     |  external parameters (read from parameter file "data.ptracers")
-C     |  stay in PTRACERS_PARAMS.h and should not appear here ;
-C     |  therefore, this header file should not be included
-C     |  in S/R PTRACERS_READPARMS.
-C     *==========================================================*
-C     \ev
-CEOP
+!BOP
+! !ROUTINE: PTRACERS_START.h
+! !INTERFACE:
+! include "PTRACERS_START.h"
+!
+! !DESCRIPTION:
+! \bv
+! *==========================================================*
+! | PTRACERS_START.h
+! | o Holds passive-tracer internal parameters related
+! |   to start and restart process
+! *==========================================================*
+! | Passive-tracer internal parameters/variables related to
+! | a) which tracer is stepped forward
+! | b) writing or reading pickup for a restart.
+! | Note:
+! |  external parameters (read from parameter file "data.ptracers")
+! |  stay in PTRACERS_PARAMS.h and should not appear here ;
+! |  therefore, this header file should not be included
+! |  in S/R PTRACERS_READPARMS.
+! *==========================================================*
+! \ev
+!EOP
 
-C--   COMMON / PTRACERS_START_I / Integer valued parameters used for (re)start
-C     PTRACERS_StartAB  :: number of gPtr previous time levels that are
-C                      available to start (or restart) Adams-Bashforth
-      COMMON / PTRACERS_START_I /
-     &  PTRACERS_StartAB
-      INTEGER PTRACERS_StartAB(PTRACERS_num)
+!--   COMMON / PTRACERS_START_I / Integer valued parameters used for (re)start
+! PTRACERS_StartAB  :: number of gPtr previous time levels that are
+!                  available to start (or restart) Adams-Bashforth
+      COMMON / PTRACERS_START_I /                                                 &
+     &      PTRACERS_StartAB
+      INTEGER :: PTRACERS_StartAB(PTRACERS_num)
 
-C--   COMMON / PTRACERS_START_L / Logical valued parameters used for (re)start
-C     PTRACERS_StepFwd  :: switch on/off this tracer time-stepping
-      COMMON / PTRACERS_START_L /
-     &  PTRACERS_StepFwd
-      LOGICAL PTRACERS_StepFwd(PTRACERS_num)
+!--   COMMON / PTRACERS_START_L / Logical valued parameters used for (re)start
+! PTRACERS_StepFwd  :: switch on/off this tracer time-stepping
+      COMMON / PTRACERS_START_L /                                                 &
+     &      PTRACERS_StepFwd
+      LOGICAL :: PTRACERS_StepFwd(PTRACERS_num)
 

--- a/pkg/ptracers/ptracers_ad_check_lev1_dir.h
+++ b/pkg/ptracers/ptracers_ad_check_lev1_dir.h
@@ -1,6 +1,6 @@
 #ifdef ALLOW_PTRACERS
 #if ( defined ALLOW_ECCO || defined NONLIN_FRSURF )
-CADJ STORE pTracer   = comlev1, key = ikey_dynamics, kind = isbyte
-CADJ STORE gpTrNm1   = comlev1, key = ikey_dynamics, kind = isbyte
+!ADJ STORE pTracer   = comlev1, key = ikey_dynamics, kind = isbyte
+!ADJ STORE gpTrNm1   = comlev1, key = ikey_dynamics, kind = isbyte
 #endif
 #endif /* ALLOW_PTRACERS */

--- a/pkg/ptracers/ptracers_ad_check_lev2_dir.h
+++ b/pkg/ptracers/ptracers_ad_check_lev2_dir.h
@@ -1,2 +1,3 @@
-CADJ STORE pTracer = tapelev2, key = ilev_2
-CADJ STORE gpTrNm1 = tapelev2, key = ilev_2
+#endif /* ALLOW_PTRACERS */
+!ADJ STORE pTracer = tapelev2, key = ilev_2
+!ADJ STORE gpTrNm1 = tapelev2, key = ilev_2

--- a/pkg/ptracers/ptracers_ad_check_lev3_dir.h
+++ b/pkg/ptracers/ptracers_ad_check_lev3_dir.h
@@ -1,2 +1,3 @@
-CADJ STORE pTracer = tapelev3, key = ilev_3
-CADJ STORE gpTrNm1 = tapelev3, key = ilev_3
+#endif /* ALLOW_PTRACERS */
+!ADJ STORE pTracer = tapelev3, key = ilev_3
+!ADJ STORE gpTrNm1 = tapelev3, key = ilev_3

--- a/pkg/ptracers/ptracers_ad_check_lev4_dir.h
+++ b/pkg/ptracers/ptracers_ad_check_lev4_dir.h
@@ -1,2 +1,3 @@
-CADJ STORE pTracer = tapelev4, key = ilev_4
-CADJ STORE gpTrNm1 = tapelev4, key = ilev_4
+#endif /* ALLOW_PTRACERS */
+!ADJ STORE pTracer = tapelev4, key = ilev_4
+!ADJ STORE gpTrNm1 = tapelev4, key = ilev_4

--- a/pkg/ptracers/ptracers_adcommon.h
+++ b/pkg/ptracers/ptracers_adcommon.h
@@ -1,10 +1,10 @@
-C--   These common blocks are extracted from the
-C--   automatically created tangent linear code.
-C--   You need to make sure that they are up-to-date
-C--   (i.e. in right order), and customize them
-C--   accordingly.
-C--
-C--   heimbach@mit.edu 11-Jan-2001
+!--   These common blocks are extracted from the
+!--   automatically created tangent linear code.
+!--   You need to make sure that they are up-to-date
+!--   (i.e. in right order), and customize them
+!--   accordingly.
+!--
+!--   heimbach@mit.edu 11-Jan-2001
 
 #ifdef ALLOW_AUTODIFF_MONITOR
 
@@ -15,16 +15,16 @@ C--   heimbach@mit.edu 11-Jan-2001
 #endif
 
 #ifdef ALLOW_PTRACERS
-      _RL adgptr(1-olx:snx+olx,1-oly:sny+oly,nr,nsx,nsy,
-     $ptracers_num)
-      _RL adgptrnm1(1-olx:snx+olx,1-oly:sny+oly,nr,nsx,nsy,
-     $ptracers_num)
-      _RL adptracer(1-olx:snx+olx,1-oly:sny+oly,nr,nsx,nsy,
-     $ptracers_num)
-      _RL adsurfaceforcingptr(1-olx:snx+olx,1-oly:sny+oly,
-     $nsx,nsy,ptracers_num)
-      common /adptracers_fields/ adptracer, adgptr, adgptrnm1, 
-     $adsurfaceforcingptr
+      _RL adgptr(1-olx:snx+olx,1-oly:sny+oly,nr,nsx,nsy,                          &
+     &      ptracers_num)
+      _RL adgptrnm1(1-olx:snx+olx,1-oly:sny+oly,nr,nsx,nsy,                       &
+     &      ptracers_num)
+      _RL adptracer(1-olx:snx+olx,1-oly:sny+oly,nr,nsx,nsy,                       &
+     &      ptracers_num)
+      _RL adsurfaceforcingptr(1-olx:snx+olx,1-oly:sny+oly,                        &
+     &      nsx,nsy,ptracers_num)
+      common /adptracers_fields/ adptracer, adgptr, adgptrnm1,                    &
+     &      adsurfaceforcingptr
 #endif
 
 #endif /* ALLOW_AUTODIFF_MONITOR */


### PR DESCRIPTION
## What changes does this PR introduce?

This enables the inclusion of header files (*.h) in free-format fortran files (F90+).


## What is the current behaviour? 

The headers are not compatible with free-format.


## What is the new behaviour 
(if this is a feature change)?

The new headers can be included in F90 files and compile using both intel and gfortran files.
They can still be included in F77 files.

I assumed a `-ffixed-line-length-80 ` to be included in the FFLAGS.

## Does this PR introduce a breaking change? 
(What changes might users need to make in their application due to this PR?)

The compilation will probably fail if `-ffixed-line-length-80 ` is not used.