### PR TITLE
Attempt to include CPP header files in free-format F90 files

### DIFF
--- a/tools/genmake2
+++ b/tools/genmake2
@@ -3378,6 +3378,7 @@ cat >>$MAKEFILE <<EOF
 
 # C preprocessing and replacing the _d in constants:
 CPPCMD = cat \$< | ${CPP} \$(DEFINES) \$(INCLUDES) | ${S64}
+CPPcmd = cat \$< | ${CPP} \$(DEFINES) \$(INCLUDES) | ${S64} | \$(TOOLSDIR)/switch_comments2f90
 
 .F.$FS:
 	\$(CPPCMD)  > \$@
@@ -3386,7 +3387,7 @@ CPPCMD = cat \$< | ${CPP} \$(DEFINES) \$(INCLUDES) | ${S64}
 .F.o:
 	\$(FC) \$(FFLAGS) \$(FOPTIM) -c \$<
 .F90.$FS90:
-	\$(CPPCMD)  > \$@
+	\$(CPPcmd)  > \$@
 .FF90.f$FS90:
 	\$(CPPCMD)  > \$@
 .$FS90.o:

--- a/tools/switch_comments2f90
+++ b/tools/switch_comments2f90
@@ -1,0 +1,18 @@
+#! /usr/bin/env sh
+
+tmpFil=tmp.$$
+cat > $tmpFil
+
+  grep -q '^! End of included CPP Options files -- Do not delete or modify ' $tmpFil
+  retVal=$?
+  if [ $retVal -eq 0 ] ; then
+    #echo '-- Replace comments' 1>&2
+    sed '1,/^! End of included CPP Options files -- Do not delete or modify / s/^C/!/I' $tmpFil
+  else
+    #echo '-- Nothing done' 1>&2
+    cat $tmpFil
+  fi
+
+#ls -l $tmpFil 1>&2
+rm -f $tmpFil
+

--- a/verification/hs94.1x64x5/code_ad/cost_test_local.F90
+++ b/verification/hs94.1x64x5/code_ad/cost_test_local.F90
@@ -1,7 +1,6 @@
 #include "PACKAGES_CONFIG.h"
-! Copied from default CPP_EEMACROS.h
-! To avoid this, we need to find a way to include CPP_EEMACROS.h
-#define _RL Real*8
+#include "CPP_OPTIONS.h"
+! End of included CPP Options files -- Do not delete or modify <<
 
 !BOP
 !     !ROUTINE: COST_TEST_LOCAL
@@ -42,6 +41,8 @@ subroutine cost_test_local ( &
   ! loop indices
   integer :: i, j, k, ig, jg
   integer :: bi, bj
+character*(2) sfx
+CHARACTER*(128) msgBuf
 !EOP
 
   do bj=myByLo,myByHi


### PR DESCRIPTION
## What changes does this PR introduce?
Following discussion #998, propose a way to deal with traditional fixed-format comments in CPP header files when included in free-format F90 files.

## What is the current behaviour? 
(You can also link to an open issue here)

## What is the new behaviour 
provide an example with minimal changes in `hs94.1x64x5/code_ad/cost_test_local.F90`

## Does this PR introduce a breaking change? 
`pkg/atm_phys` contains many free-format F90 without CPP header file included. In this case, `switch_comments2f90` does nothing and test experiment `atm_gray` is left unaffected.

## Other information:
1. names (CPPcmd, switch_comments2f90, and key works to grep for) will likely be changed
2. processing in `switch_comments2f90` is very inefficient (uses a tmp file !).
3. not intended to be merged without significant improvements

## Suggested addition to `tag-index`
not ready yet