### PR TITLE
Cleaning seaice cost test

### DIFF
--- a/doc/tag-index
+++ b/doc/tag-index
@@ -1,6 +1,9 @@
     Notes on tags used in MITgcmUV
     ==============================
 
+o pkg/seaice:
+  - comment out debug print in seaice_cost_test.F and reduce overlap size
+    (from 3 to 2) in experiment "1D_ocean_ice_column".
 o pkg/exf:
   - fix time-invariant exf field (fldPeriod=0) when used as ctrl variables
     (xx_gentim2d), by resetting it (ALLOW_GENTIM2D_CONTROL) from fld0,fld1 in

--- a/pkg/seaice/seaice_cost_test.F
+++ b/pkg/seaice/seaice_cost_test.F
@@ -86,8 +86,8 @@ c     == end of interface ==
      &             / deltaTClock )
 
 cph(
-      write(standardMessageUnit,*) 'ph-ice B ', myiter,
-     &        theta(4,4,kSrf,1,1), area(4,4,1,1), heff(4,4,1,1)
+c     write(standardMessageUnit,*) 'ph-ice B ', myiter,
+c    &        theta(4,4,kSrf,1,1), area(4,4,1,1), heff(4,4,1,1)
 cph)
          if ( cost_ice_flag .eq. 1 ) then
 c     sea-ice volume
@@ -228,7 +228,7 @@ c     assumed that measurements are AREA=0.5 at all times everywhere.
       endif
 
 cph(
-      write(standardMessageUnit,*) 'ph-ice C ', myiter, objf_ice(1,1)
+c     write(standardMessageUnit,*) 'ph-ice C ', myiter, objf_ice(1,1)
 cph)
 
 #endif /* ALLOW_COST & ALLOW_COST_ICE */

--- a/pkg/seaice/seaice_cost_test.F
+++ b/pkg/seaice/seaice_cost_test.F
@@ -1,51 +1,51 @@
 #include "SEAICE_OPTIONS.h"
 
-      subroutine seaice_cost_test( mytime, myiter, mythid )
+      SUBROUTINE SEAICE_COST_TEST( myTime, myIter, myThid )
 
-c     ==================================================================
-c     SUBROUTINE seaice_cost_test
-c     ==================================================================
-c
-c     o Compute sea-ice cost function.  The following options can be
-c       selected with data.seaice (SEAICE_PARM02) variable cost_ice_flag
-c
-c     cost_ice_flag = 1
-c     - compute mean sea-ice volume
-c       costIceStart < mytime < costIceEnd
-c
-c     cost_ice_flag = 2
-c     - compute mean sea-ice area
-c       costIceStart < mytime < costIceEnd
-c
-c     cost_ice_flag = 3
-c     - heat content of top level plus latent heat of sea-ice
-c       costIceStart < mytime < costIceEnd
-c
-c     cost_ice_flag = 4
-c     - heat content of top level
-c       costIceStart < mytime < costIceEnd
-c
-c     cost_ice_flag = 5
-c     - heat content of top level plus sea-ice plus latent heat of snow
-c       costIceStart < mytime < costIceEnd
-c
-c     cost_ice_flag = 6
-c     - quadratic cost function measuring difference between pkg/seaice
-c       AREA variable and simulated sea-ice measurements at every time
-c       step.
-c
-c     ==================================================================
-c
-c     started: menemenlis@jpl.nasa.gov 26-Feb-2003
-c
-c     ==================================================================
-c     SUBROUTINE seaice_cost_test
-c     ==================================================================
+C     ==================================================================
+C     SUBROUTINE seaice_cost_test
+C     ==================================================================
+C
+C     o Compute sea-ice cost function.  The following options can be
+C       selected with data.seaice (SEAICE_PARM02) variable cost_ice_flag
+C
+C     cost_ice_flag = 1
+C     - compute mean sea-ice volume
+C       costIceStart < myTime < costIceEnd
+C
+C     cost_ice_flag = 2
+C     - compute mean sea-ice area
+C       costIceStart < myTime < costIceEnd
+C
+C     cost_ice_flag = 3
+C     - heat content of top level plus latent heat of sea-ice
+C       costIceStart < myTime < costIceEnd
+C
+C     cost_ice_flag = 4
+C     - heat content of top level
+C       costIceStart < myTime < costIceEnd
+C
+C     cost_ice_flag = 5
+C     - heat content of top level plus sea-ice plus latent heat of snow
+C       costIceStart < myTime < costIceEnd
+C
+C     cost_ice_flag = 6
+C     - quadratic cost function measuring difference between pkg/seaice
+C       AREA variable and simulated sea-ice measurements at every time
+C       step.
+C
+C     ==================================================================
+C
+C     started: menemenlis@jpl.nasa.gov 26-Feb-2003
+C
+C     ==================================================================
+C     SUBROUTINE seaice_cost_test
+C     ==================================================================
 
       IMPLICIT NONE
 
 #if (defined ALLOW_COST && defined ALLOW_COST_ICE)
-c     == global variables ==
+C     == global variables ==
 #include "EEPARAMS.h"
 #include "SIZE.h"
 #include "GRID.h"
@@ -57,122 +57,118 @@ c     == global variables ==
 #include "cost.h"
 #endif /* ALLOW_COST & ALLOW_COST_ICE */
 
-c     == routine arguments ==
-      _RL     mytime
-      integer myiter
-      integer mythid
+C     == routine arguments ==
+      _RL     myTime
+      INTEGER myIter
+      INTEGER myThid
 
 #if (defined ALLOW_COST && defined ALLOW_COST_ICE)
-c     == external functions ==
-      integer  ilnblnk
-      external ilnblnk
-
-c     == local variables ==
-c     msgBuf      - Informational/error message buffer
+C     == local variables ==
+C     msgBuf      - Informational/error message buffer
       CHARACTER*(MAX_LEN_MBUF) msgBuf
-      integer bi,bj,i,j,kSrf
+      INTEGER bi,bj,i,j,kSrf
       _RL tempVar
 
-c     == end of interface ==
+C     == end of interface ==
 
-      if ( usingPCoords ) then
+      IF ( usingPCoords ) THEN
        kSrf = Nr
-      else
+      ELSE
        kSrf = 1
-      endif
-      if ( myTime .GT. (endTime - lastinterval) ) then
+      ENDIF
+      IF ( myTime .GT. (endTime - lastinterval) ) THEN
          tempVar = 1. _d 0/
      &             ( ( 1. _d 0 + min(endTime-startTime,lastinterval) )
      &             / deltaTClock )
 
 cph(
-c     write(standardMessageUnit,*) 'ph-ice B ', myiter,
+c     write(standardMessageUnit,*) 'ph-ice B ', myIter,
 c    &        theta(4,4,kSrf,1,1), area(4,4,1,1), heff(4,4,1,1)
 cph)
-         if ( cost_ice_flag .eq. 1 ) then
-c     sea-ice volume
-            do bj=myByLo(myThid),myByHi(myThid)
-               do bi=myBxLo(myThid),myBxHi(myThid)
-                  do j = 1,sny
-                     do i =  1,snx
+         IF ( cost_ice_flag .EQ. 1 ) THEN
+C     sea-ice volume
+            DO bj=myByLo(myThid),myByHi(myThid)
+               DO bi=myBxLo(myThid),myBxHi(myThid)
+                  DO j = 1,sNy
+                     DO i =  1,sNx
                         objf_ice(bi,bj) = objf_ice(bi,bj) +
      &                       tempVar * rA(i,j,bi,bj) * HEFF(i,j,bi,bj)
-                     enddo
-                  enddo
-               enddo
-            enddo
+                     ENDDO
+                  ENDDO
+               ENDDO
+            ENDDO
 
-         elseif ( cost_ice_flag .eq. 2 ) then
-c     sea-ice area
-            do bj=myByLo(myThid),myByHi(myThid)
-               do bi=myBxLo(myThid),myBxHi(myThid)
-                  do j = 1,sny
-                     do i =  1,snx
+         ELSEIF ( cost_ice_flag .EQ. 2 ) THEN
+C     sea-ice area
+            DO bj=myByLo(myThid),myByHi(myThid)
+               DO bi=myBxLo(myThid),myBxHi(myThid)
+                  DO j = 1,sNy
+                     DO i =  1,sNx
                         objf_ice(bi,bj) = objf_ice(bi,bj) +
      &                       tempVar * rA(i,j,bi,bj) * AREA(i,j,bi,bj)
-                     enddo
-                  enddo
-               enddo
-            enddo
+                     ENDDO
+                  ENDDO
+               ENDDO
+            ENDDO
 
-c     heat content of top level:
-c     theta * delZ * (sea water heat capacity = 3996 J/kg/K)
-c                  * (density of sea-water = 1026 kg/m^3)
-c
-c     heat content of sea-ice:
-c     tice * heff * (sea ice heat capacity = 2090 J/kg/K)
-c                 * (density of sea-ice = 910 kg/m^3)
-c
-c     note: to remove mass contribution to heat content,
-c     which is not properly accounted for by volume converving
-c     ocean model, theta and tice are referenced to freezing
-c     temperature of sea-ice, here -1.96 deg C
-c
-c     latent heat content of sea-ice:
-c     - heff * (latent heat of fusion = 334000 J/kg)
-c            * (density of sea-ice = 910 kg/m^3)
-c
-c     latent heat content of snow:
-c     - hsnow * (latent heat of fusion = 334000 J/kg)
-c             * (density of snow = 330 kg/m^3)
+C     heat content of top level:
+C     theta * delZ * (sea water heat capacity = 3996 J/kg/K)
+C                  * (density of sea-water = 1026 kg/m^3)
+C
+C     heat content of sea-ice:
+C     tice * heff * (sea ice heat capacity = 2090 J/kg/K)
+C                 * (density of sea-ice = 910 kg/m^3)
+C
+C     note: to remove mass contribution to heat content,
+C     which is not properly accounted for by volume converving
+C     ocean model, theta and tice are referenced to freezing
+C     temperature of sea-ice, here -1.96 deg C
+C
+C     latent heat content of sea-ice:
+C     - heff * (latent heat of fusion = 334000 J/kg)
+C            * (density of sea-ice = 910 kg/m^3)
+C
+C     latent heat content of snow:
+C     - hsnow * (latent heat of fusion = 334000 J/kg)
+C             * (density of snow = 330 kg/m^3)
 
-         elseif ( cost_ice_flag .eq. 3 ) then
-c     heat content of top level plus latent heat of sea-ice
-            do bj=myByLo(myThid),myByHi(myThid)
-             do bi=myBxLo(myThid),myBxHi(myThid)
-              do j = 1,sny
-               do i =  1,snx
+         ELSEIF ( cost_ice_flag .EQ. 3 ) THEN
+C     heat content of top level plus latent heat of sea-ice
+            DO bj=myByLo(myThid),myByHi(myThid)
+             DO bi=myBxLo(myThid),myBxHi(myThid)
+              DO j = 1,sNy
+               DO i =  1,sNx
                 objf_ice(bi,bj) = objf_ice(bi,bj) +
      &                 tempVar * rA(i,j,bi,bj) * (
      &                 (THETA(i,j,kSrf,bi,bj) + 1.96 _d 0 ) *
      &                 drF(kSrf) * 3996. _d 0 * 1026. _d 0 -
      &                 HEFF(i,j,bi,bj) * 334000. _d 0 * 910. _d 0 )
-               enddo
-              enddo
-             enddo
-            enddo
+               ENDDO
+              ENDDO
+             ENDDO
+            ENDDO
 
-         elseif ( cost_ice_flag .eq. 4 ) then
-c     heat content of top level
-            do bj=myByLo(myThid),myByHi(myThid)
-             do bi=myBxLo(myThid),myBxHi(myThid)
-              do j = 1,sny
-               do i =  1,snx
+         ELSEIF ( cost_ice_flag .EQ. 4 ) THEN
+C     heat content of top level
+            DO bj=myByLo(myThid),myByHi(myThid)
+             DO bi=myBxLo(myThid),myBxHi(myThid)
+              DO j = 1,sNy
+               DO i =  1,sNx
                 objf_ice(bi,bj) = objf_ice(bi,bj) +
      &                 tempVar * rA(i,j,bi,bj) * (
      &                 (THETA(i,j,kSrf,bi,bj) + 1.96 _d 0 ) *
      &                 drF(kSrf) * 3996. _d 0 * 1026. _d 0 )
-               enddo
-              enddo
-             enddo
-            enddo
+               ENDDO
+              ENDDO
+             ENDDO
+            ENDDO
 
-         elseif ( cost_ice_flag .eq. 5 ) then
-c     heat content of top level plus sea-ice plus latent heat of snow
-            do bj=myByLo(myThid),myByHi(myThid)
-             do bi=myBxLo(myThid),myBxHi(myThid)
-              do j = 1,sny
-               do i =  1,snx
+         ELSEIF ( cost_ice_flag .EQ. 5 ) THEN
+C     heat content of top level plus sea-ice plus latent heat of snow
+            DO bj=myByLo(myThid),myByHi(myThid)
+             DO bi=myBxLo(myThid),myBxHi(myThid)
+              DO j = 1,sNy
+               DO i =  1,sNx
                 objf_ice(bi,bj) = objf_ice(bi,bj) +
      &                 tempVar * rA(i,j,bi,bj) * (
      &                 (THETA(i,j,kSrf,bi,bj) + 1.96 _d 0 ) *
@@ -181,54 +177,53 @@ c     heat content of top level plus sea-ice plus latent heat of snow
      &                 HEFF(i,j,bi,bj) * 2090. _d 0 * 910. _d 0 -
      &                 HEFF(i,j,bi,bj) * 334000. _d 0 * 910. _d 0 -
      &                 HSNOW(i,j,bi,bj) * 334000. _d 0 * 330. _d 0 )
-               enddo
-              enddo
-             enddo
-            enddo
+               ENDDO
+              ENDDO
+             ENDDO
+            ENDDO
 
-         elseif ( cost_ice_flag .eq. 6 ) then
-c     Qadratic cost function measuring difference between pkg/seaice
-c     AREA variable and simulated sea-ice measurements at every time
-c     step.  For time being no measurements are read-in.  It is
-c     assumed that measurements are AREA=0.5 at all times everywhere.
-            do bj=myByLo(myThid),myByHi(myThid)
-               do bi=myBxLo(myThid),myBxHi(myThid)
-                  do j = 1,sny
-                     do i =  1,snx
+         ELSEIF ( cost_ice_flag .EQ. 6 ) THEN
+C     Qadratic cost function measuring difference between pkg/seaice
+C     AREA variable and simulated sea-ice measurements at every time
+C     step.  For time being no measurements are read-in.  It is
+C     assumed that measurements are AREA=0.5 at all times everywhere.
+            DO bj=myByLo(myThid),myByHi(myThid)
+               DO bi=myBxLo(myThid),myBxHi(myThid)
+                  DO j = 1,sNy
+                     DO i =  1,sNx
                         objf_ice(bi,bj) = objf_ice(bi,bj) +
      &                       ( AREA(i,j,bi,bj) - 0.5 _d 0 ) *
      &                       ( AREA(i,j,bi,bj) - 0.5 _d 0 )
-                     enddo
-                  enddo
-               enddo
-            enddo
+                     ENDDO
+                  ENDDO
+               ENDDO
+            ENDDO
 
-         elseif ( cost_ice_flag .eq. 7 ) then
+         ELSEIF ( cost_ice_flag .EQ. 7 ) THEN
 
-            do bj=myByLo(myThid),myByHi(myThid)
-               do bi=myBxLo(myThid),myBxHi(myThid)
-                  do j = 1,sny
-                     do i =  1,snx
+            DO bj=myByLo(myThid),myByHi(myThid)
+               DO bi=myBxLo(myThid),myBxHi(myThid)
+                  DO j = 1,sNy
+                     DO i =  1,sNx
                         objf_ice(bi,bj) = objf_ice(bi,bj) +
      &                       UICE(i,j,bi,bj) * UICE(i,j,bi,bj) +
      &                       VICE(i,j,bi,bj) * VICE(i,j,bi,bj)
 
-                     enddo
-                  enddo
-               enddo
-            enddo
+                     ENDDO
+                  ENDDO
+               ENDDO
+            ENDDO
 
-         else
+         ELSE
             WRITE(msgBuf,'(A)')
-     &           'COST_ICE: invalid cost_ice_flag'
-            CALL PRINT_MESSAGE( msgBuf, standardMessageUnit,
-     &           SQUEEZE_RIGHT , myThid )
-            STOP 'ABNORMAL END: S/R COST_ICE'
-         endif
-      endif
+     &           'SEAICE_COST_TEST: invalid cost_ice_flag'
+            CALL PRINT_ERROR( msgBuf, myThid )
+            STOP 'ABNORMAL END: S/R SEAICE_COST_TEST'
+         ENDIF
+      ENDIF
 
 cph(
-c     write(standardMessageUnit,*) 'ph-ice C ', myiter, objf_ice(1,1)
+c     write(standardMessageUnit,*) 'ph-ice C ', myIter, objf_ice(1,1)
 cph)
 
 #endif /* ALLOW_COST & ALLOW_COST_ICE */

--- a/verification/1D_ocean_ice_column/code/SIZE.h
+++ b/verification/1D_ocean_ice_column/code/SIZE.h
@@ -44,8 +44,8 @@ CEOP
       PARAMETER (
      &           sNx =   1,
      &           sNy =   1,
-     &           OLx =   3,
-     &           OLy =   3,
+     &           OLx =   2,
+     &           OLy =   2,
      &           nSx =   1,
      &           nSy =   1,
      &           nPx =   1,

--- a/verification/1D_ocean_ice_column/code_ad/SIZE.h
+++ b/verification/1D_ocean_ice_column/code_ad/SIZE.h
@@ -44,8 +44,8 @@ CEOP
       PARAMETER (
      &           sNx =   1,
      &           sNy =   1,
-     &           OLx =   3,
-     &           OLy =   3,
+     &           OLx =   2,
+     &           OLy =   2,
      &           nSx =   1,
      &           nSy =   1,
      &           nPx =   1,


### PR DESCRIPTION
## What changes does this PR introduce?
Comment out debug print in `seaice_cost_test.F` which were not clean.

## What is the current behaviour? 
2 lines printed each time this S/R is called:
1. no context/description, free-format print (machine and compiler dependent): not the most useful information (requires to grep in the code to see what this means)
2. no way to disable the print despite several `pkg/seaice` debug option (SEAICE_DEBUG, SEAICE_debugPointI, SEAICE_debugPointJ).
3. array index "out-of-bound" error when using a small domain.

## What is the new behaviour 
1. debug print are kept but commented out.
2. can now reduce the overlap size of verification experiment `1D_ocean_ice_column`, from 3 to 2, without getting "out of bounds" error.

## Does this PR introduce a breaking change? 
no

## Other information:
with this modification, the output of Adjoint test experiment "offline_exf_seaice" contains 2640 less lines.

## Suggested addition to `tag-index`
to be filled later