### PR TITLE
Strain rate metrics

### DIFF
--- a/pkg/streamice/streamice_cg_functions.F
+++ b/pkg/streamice/streamice_cg_functions.F
@@ -111,10 +111,10 @@ C     == Local variables ==
      &       v(i+1,j,bi,bj) * DPhi(i,j,bi,bj,2,n,2) +
      &       v(i,j+1,bi,bj) * DPhi(i,j,bi,bj,3,n,2) +
      &       v(i+1,j+1,bi,bj) * DPhi(i,j,bi,bj,4,n,2)
-            exx = ux + k1AtC_str(i,j,bi,bj)*vq
-            eyy = vy + k2AtC_str(i,j,bi,bj)*uq
-            exy = .5*(uy+vx) +
-     &       k1AtC_str(i,j,bi,bj)*uq + k2AtC_str(i,j,bi,bj)*vq
+            exx = ux + k2AtC_str(i,j,bi,bj)*vq
+            eyy = vy + k1AtC_str(i,j,bi,bj)*uq
+            exy = .5*(uy+vx) - .5 * (
+     &       k2AtC_str(i,j,bi,bj)*uq + k1AtC_str(i,j,bi,bj)*vq)
 
             do inode = 1,2
              do jnode = 1,2
@@ -139,8 +139,8 @@ C     == Local variables ==
      &         uret(i-1+inode,j-1+jnode,bi,bj) + .25 *
      &         grid_jacq_streamice(i,j,bi,bj,n) *
      &         visc_streamice(i,j,bi,bj) * phival(inode,jnode) *
-     &         (4*k2AtC_str(i,j,bi,bj)*eyy+2*k2AtC_str(i,j,bi,bj)*exx+
-     &          4*0.5*k1AtC_str(i,j,bi,bj)*exy)
+     &         (4*k1AtC_str(i,j,bi,bj)*eyy+2*k1AtC_str(i,j,bi,bj)*exx-
+     &          2*k2AtC_str(i,j,bi,bj)*exy)
 
               uret(i-1+inode,j-1+jnode,bi,bj) =
      &         uret(i-1+inode,j-1+jnode,bi,bj) + .25 *
@@ -157,12 +157,14 @@ C     == Local variables ==
      &         visc_streamice(i,j,bi,bj) * (
      &          DPhi(i,j,bi,bj,m,n,2)*(4*eyy+2*exx) +
      &          DPhi(i,j,bi,bj,m,n,1)*(2*exy))
+
               vret(i-1+inode,j-1+jnode,bi,bj) =
      &         vret(i-1+inode,j-1+jnode,bi,bj) + .25 *
      &         grid_jacq_streamice(i,j,bi,bj,n) *
      &         visc_streamice(i,j,bi,bj) * phival(inode,jnode) *
-     &         (4*k1AtC_str(i,j,bi,bj)*exx+2*k1AtC_str(i,j,bi,bj)*eyy+
-     &          4*0.5*k2AtC_str(i,j,bi,bj)*exy)
+     &         (4*k2AtC_str(i,j,bi,bj)*exx+2*k2AtC_str(i,j,bi,bj)*eyy-
+     &          2*k1AtC_str(i,j,bi,bj)*exy)
+
               vret(i-1+inode,j-1+jnode,bi,bj) =
      &         vret(i-1+inode,j-1+jnode,bi,bj) + .25 *
      &         phival(inode,jnode) *
@@ -330,10 +332,10 @@ c
                    uq = Xquad(ilqx) * Xquad(ilqy)
                    vq = 0
 
-                   exx = ux + k1AtC_str(i,j,bi,bj)*vq
-                   eyy = vy + k2AtC_str(i,j,bi,bj)*uq
-                   exy = .5*(uy+vx) +
-     &              k1AtC_str(i,j,bi,bj)*uq + k2AtC_str(i,j,bi,bj)*vq
+                   exx = ux + k2AtC_str(i,j,bi,bj)*vq
+                   eyy = vy + k1AtC_str(i,j,bi,bj)*uq
+                   exy = .5*(uy+vx) - .5 * (
+     &              k2AtC_str(i,j,bi,bj)*uq + k1AtC_str(i,j,bi,bj)*vq)
 
                     tmpval = .25 *
      &              grid_jacq_streamice(i,j,bi,bj,n) *
@@ -388,8 +390,8 @@ c!!
                     tmpval = .25 *
      &              grid_jacq_streamice(i,j,bi,bj,n) *
      &              visc_streamice(i,j,bi,bj) * phival(inodx,inody) *
-     &             (4*k2AtC_str(i,j,bi,bj)*eyy+2*k2AtC_str(i,j,bi,bj)*
-     &              exx+4*0.5*k1AtC_str(i,j,bi,bj)*exy)
+     &             (4*k1AtC_str(i,j,bi,bj)*eyy+2*k1AtC_str(i,j,bi,bj)*
+     &              exx-2*k2AtC_str(i,j,bi,bj)*exy)
 
                    streamice_cg_A1
      &                 (i-1+inodx,j-1+inody,bi,bj,mod(inodx,2)+jnodx-2,
@@ -413,8 +415,8 @@ c!!
                    tmpval = .25 *
      &              grid_jacq_streamice(i,j,bi,bj,n) *
      &              visc_streamice(i,j,bi,bj) * phival(inodx,inody) *
-     &             (4*k1AtC_str(i,j,bi,bj)*exx+2*k1AtC_str(i,j,bi,bj)*
-     &              eyy+4*0.5*k2AtC_str(i,j,bi,bj)*exy)
+     &             (4*k2AtC_str(i,j,bi,bj)*exx+2*k2AtC_str(i,j,bi,bj)*
+     &              eyy-2*k1AtC_str(i,j,bi,bj)*exy)
 
                    streamice_cg_A3
      &                 (i-1+inodx,j-1+inody,bi,bj,mod(inodx,2)+jnodx-2,
@@ -487,10 +489,10 @@ c!!
                    vq = Xquad(ilqx) * Xquad(ilqy)
                    uq = 0
 
-                   exx = ux + k1AtC_str(i,j,bi,bj)*vq
-                   eyy = vy + k2AtC_str(i,j,bi,bj)*uq
-                   exy = .5*(uy+vx) +
-     &              k1AtC_str(i,j,bi,bj)*uq + k2AtC_str(i,j,bi,bj)*vq
+                   exx = ux + k2AtC_str(i,j,bi,bj)*vq
+                   eyy = vy + k1AtC_str(i,j,bi,bj)*uq
+                   exy = .5*(uy+vx) - .5 * (
+     &              k2AtC_str(i,j,bi,bj)*uq + k1AtC_str(i,j,bi,bj)*vq)
 
                     tmpval = .25 *
      &              grid_jacq_streamice(i,j,bi,bj,n) *
@@ -541,8 +543,8 @@ c!!
                    tmpval = .25 *
      &              grid_jacq_streamice(i,j,bi,bj,n) *
      &              visc_streamice(i,j,bi,bj) * phival(inodx,inody) *
-     &             (4*k2AtC_str(i,j,bi,bj)*eyy+2*k2AtC_str(i,j,bi,bj)*
-     &              exx+4*0.5*k1AtC_str(i,j,bi,bj)*exy)
+     &             (4*k1AtC_str(i,j,bi,bj)*eyy+2*k1AtC_str(i,j,bi,bj)*
+     &              exx-2*k2AtC_str(i,j,bi,bj)*exy)
 
                    streamice_cg_A2
      &                 (i-1+inodx,j-1+inody,bi,bj,mod(inodx,2)+jnodx-2,
@@ -564,8 +566,8 @@ c!!
                    tmpval = .25 *
      &              grid_jacq_streamice(i,j,bi,bj,n) *
      &              visc_streamice(i,j,bi,bj) * phival(inodx,inody) *
-     &             (4*k1AtC_str(i,j,bi,bj)*exx+2*k1AtC_str(i,j,bi,bj)*
-     &              eyy+4*0.5*k2AtC_str(i,j,bi,bj)*exy)
+     &             (4*k2AtC_str(i,j,bi,bj)*exx+2*k2AtC_str(i,j,bi,bj)*
+     &              eyy-2*k1AtC_str(i,j,bi,bj)*exy)
 
                    streamice_cg_A4
      &                 (i-1+inodx,j-1+inody,bi,bj,mod(inodx,2)+jnodx-2,
@@ -738,10 +740,10 @@ C     == Local variables ==
               uq = Xquad(ilq) * Xquad(jlq)
               vq = 0
 
-              exx = ux + k1AtC_str(i,j,bi,bj)*vq
-              eyy = vy + k2AtC_str(i,j,bi,bj)*uq
-              exy = .5*(uy+vx) +
-     &         k1AtC_str(i,j,bi,bj)*uq + k2AtC_str(i,j,bi,bj)*vq
+              exx = ux + k2AtC_str(i,j,bi,bj)*vq
+              eyy = vy + k1AtC_str(i,j,bi,bj)*uq
+              exy = .5*(uy+vx) - .5 * (
+     &         k2AtC_str(i,j,bi,bj)*uq + k1AtC_str(i,j,bi,bj)*vq)
 
               uret(i-1+inode,j-1+jnode,bi,bj) =
      &         uret(i-1+inode,j-1+jnode,bi,bj) + .25 *
@@ -754,8 +756,8 @@ C     == Local variables ==
      &         uret(i-1+inode,j-1+jnode,bi,bj) + .25 *
      &         grid_jacq_streamice(i,j,bi,bj,n) *
      &         visc_streamice(i,j,bi,bj) * phival(inode,jnode) *
-     &         (4*k2AtC_str(i,j,bi,bj)*eyy+2*k2AtC_str(i,j,bi,bj)*exx+
-     &          4*0.5*k1AtC_str(i,j,bi,bj)*exy)
+     &         (4*k1AtC_str(i,j,bi,bj)*eyy+2*k1AtC_str(i,j,bi,bj)*exx-
+     &          2*k2AtC_str(i,j,bi,bj)*exy)
 
               uret(i-1+inode,j-1+jnode,bi,bj) =
      &         uret(i-1+inode,j-1+jnode,bi,bj) + .25 *
@@ -769,10 +771,10 @@ C     == Local variables ==
               vq = Xquad(ilq) * Xquad(jlq)
               uq = 0
 
-              exx = ux + k1AtC_str(i,j,bi,bj)*vq
-              eyy = vy + k2AtC_str(i,j,bi,bj)*uq
-              exy = .5*(uy+vx) +
-     &         k1AtC_str(i,j,bi,bj)*uq + k2AtC_str(i,j,bi,bj)*vq
+              exx = ux + k2AtC_str(i,j,bi,bj)*vq
+              eyy = vy + k1AtC_str(i,j,bi,bj)*uq
+              exy = .5*(uy+vx) - .5 * (
+     &         k2AtC_str(i,j,bi,bj)*uq + k1AtC_str(i,j,bi,bj)*vq)
 
               vret(i-1+inode,j-1+jnode,bi,bj) =
      &         vret(i-1+inode,j-1+jnode,bi,bj) + .25 *
@@ -784,8 +786,8 @@ C     == Local variables ==
      &         vret(i-1+inode,j-1+jnode,bi,bj) + .25 *
      &         grid_jacq_streamice(i,j,bi,bj,n) *
      &         visc_streamice(i,j,bi,bj) * phival(inode,jnode) *
-     &         (4*k1AtC_str(i,j,bi,bj)*exx+2*k1AtC_str(i,j,bi,bj)*eyy+
-     &          4*0.5*k2AtC_str(i,j,bi,bj)*exy)
+     &         (4*k2AtC_str(i,j,bi,bj)*exx+2*k2AtC_str(i,j,bi,bj)*eyy-
+     &          2*k1AtC_str(i,j,bi,bj)*exy)
 
               vret(i-1+inode,j-1+jnode,bi,bj) =
      &         vret(i-1+inode,j-1+jnode,bi,bj) + .25 *
@@ -908,10 +910,10 @@ C     == Local variables ==
      &       v_bdry_values_SI(i+1,j,bi,bj) * DPhi(i,j,bi,bj,2,n,2) +
      &       v_bdry_values_SI(i,j+1,bi,bj) * DPhi(i,j,bi,bj,3,n,2) +
      &       v_bdry_values_SI(i+1,j+1,bi,bj) * DPhi(i,j,bi,bj,4,n,2)
-            exx = ux + k1AtC_str(i,j,bi,bj)*vq
-            eyy = vy + k2AtC_str(i,j,bi,bj)*uq
-            exy = .5*(uy+vx) +
-     &       k1AtC_str(i,j,bi,bj)*uq + k2AtC_str(i,j,bi,bj)*vq
+            exx = ux + k2AtC_str(i,j,bi,bj)*vq
+            eyy = vy + k1AtC_str(i,j,bi,bj)*uq
+            exy = .5*(uy+vx) - .5 * (
+     &       k2AtC_str(i,j,bi,bj)*uq + k1AtC_str(i,j,bi,bj)*vq)
 
             do inode = 1,2
              do jnode = 1,2
@@ -936,8 +938,8 @@ C     == Local variables ==
      &         uret(i-1+inode,j-1+jnode,bi,bj) + .25 *
      &         grid_jacq_streamice(i,j,bi,bj,n) *
      &         visc_streamice(i,j,bi,bj) * phival(inode,jnode) *
-     &         (4*k2AtC_str(i,j,bi,bj)*eyy+2*k2AtC_str(i,j,bi,bj)*exx+
-     &          4*0.5*k1AtC_str(i,j,bi,bj)*exy)
+     &         (4*k1AtC_str(i,j,bi,bj)*eyy+2*k1AtC_str(i,j,bi,bj)*exx-
+     &          2*k2AtC_str(i,j,bi,bj)*exy)
 
 c               if (STREAMICE_float_cond(i,j,bi,bj) .eq. 1) then
               uret(i-1+inode,j-1+jnode,bi,bj) =
@@ -958,8 +960,8 @@ c               endif
      &         vret(i-1+inode,j-1+jnode,bi,bj) + .25 *
      &         grid_jacq_streamice(i,j,bi,bj,n) *
      &         visc_streamice(i,j,bi,bj) * phival(inode,jnode) *
-     &         (4*k1AtC_str(i,j,bi,bj)*exx+2*k1AtC_str(i,j,bi,bj)*eyy+
-     &          4*0.5*k2AtC_str(i,j,bi,bj)*exy)
+     &         (4*k2AtC_str(i,j,bi,bj)*exx+2*k2AtC_str(i,j,bi,bj)*eyy-
+     &          2*k1AtC_str(i,j,bi,bj)*exy)
               vret(i-1+inode,j-1+jnode,bi,bj) =
      &         vret(i-1+inode,j-1+jnode,bi,bj) + .25 *
      &         phival(inode,jnode) * grid_jacq_streamice(i,j,bi,bj,n) *

--- a/pkg/streamice/streamice_init_fixed.F
+++ b/pkg/streamice/streamice_init_fixed.F
@@ -325,9 +325,9 @@ C         INIT VALUES FOR METRIC TERMS
           IF (.not.usingCartesianGrid) THEN
 
            k1AtC_str(i,j,bi,bj) = recip_rA(i,j,bi,bj) *
-     &      (dxG(i,j+1,bi,bj)-dxG(i,j,bi,bj))
-           k2AtC_str(i,j,bi,bj) = recip_rA(i,j,bi,bj) *
      &      (dyG(i+1,j,bi,bj)-dyG(i,j,bi,bj))
+           k2AtC_str(i,j,bi,bj) = recip_rA(i,j,bi,bj) *
+     &      (dxG(i,j+1,bi,bj)-dxG(i,j,bi,bj))
 
           ELSE
 

--- a/pkg/streamice/streamice_init_fixed.F
+++ b/pkg/streamice/streamice_init_fixed.F
@@ -325,9 +325,9 @@ C         INIT VALUES FOR METRIC TERMS
           IF (.not.usingCartesianGrid) THEN
 
            k1AtC_str(i,j,bi,bj) = recip_rA(i,j,bi,bj) *
-     &      (dxG(i+1,j,bi,bj)-dxG(i,j,bi,bj))
+     &      (dxG(i,j+1,bi,bj)-dxG(i,j,bi,bj))
            k2AtC_str(i,j,bi,bj) = recip_rA(i,j,bi,bj) *
-     &      (dyG(i,j+1,bi,bj)-dyG(i,j,bi,bj))
+     &      (dyG(i+1,j,bi,bj)-dyG(i,j,bi,bj))
 
           ELSE
 

--- a/pkg/streamice/streamice_visc_beta.F
+++ b/pkg/streamice/streamice_visc_beta.F
@@ -76,10 +76,10 @@ C     LOCAL VARIABLES
      &           V_streamice(i,j,bi,bj)) /
      &           (2. * dyF(i,j,bi,bj))
 
-           exx = ux + k1AtC_str(i,j,bi,bj)*vmid
-           eyy = vy + k2AtC_str(i,j,bi,bj)*umid
-           exy = .5*(uy+vx) +
-     &      k1AtC_str(i,j,bi,bj)*umid + k2AtC_str(i,j,bi,bj)*vmid
+           exx = ux + k2AtC_str(i,j,bi,bj)*vmid
+           eyy = vy + k1AtC_str(i,j,bi,bj)*umid
+           exy = .5*(uy+vx) - .5 * 
+     &      (k2AtC_str(i,j,bi,bj)*umid + k1AtC_str(i,j,bi,bj)*vmid)
 
 !A_glen_isothermal, n_glen, eps_glen_min,
 

--- a/pkg/streamice/streamice_visc_beta_hybrid.F
+++ b/pkg/streamice/streamice_visc_beta_hybrid.F
@@ -109,10 +109,10 @@ c       _RL total_vol_out
      &           V_streamice(i,j,bi,bj)) /
      &           (2. * dyF(i,j,bi,bj))
 
-           exx = ux + k1AtC_str(i,j,bi,bj)*vmid
-           eyy = vy + k2AtC_str(i,j,bi,bj)*umid
-           exy = .5*(uy+vx) +
-     &      k1AtC_str(i,j,bi,bj)*umid + k2AtC_str(i,j,bi,bj)*vmid
+           exx = ux + k2AtC_str(i,j,bi,bj)*vmid
+           eyy = vy + k1AtC_str(i,j,bi,bj)*umid
+           exy = .5*(uy+vx) - .5 * (
+     &      k2AtC_str(i,j,bi,bj)*umid + k1AtC_str(i,j,bi,bj)*vmid)
 
            visc_streamice (i,j,bi,bj) = 0.0
            streamice_omega(i,j,bi,bj) = 0.0


### PR DESCRIPTION
## What changes does this PR introduce?
This corrects the implementation of the metric terms $k_1^C$ and $k_2^C$ (as defined [here](https://mitgcm.readthedocs.io/en/latest/phys_pkgs/seaice.html#finite-volume-discretization-of-the-stress-tensor-divergence)) in the STREAMICE representation of the strain rate tensor
 
## What is the current behaviour? 
The STREAMICE package defines a nonlinear viscosity using the elements of the horizontal strain rate tensor. As in the SEAICE package, where there is a noncartesian grid, ["metric terms"](https://mitgcm.readthedocs.io/en/latest/phys_pkgs/seaice.html#finite-volume-discretization-of-the-stress-tensor-divergence) are needed (only at cell centers in the STREAMICE code). `streamice_init_fixed.F` defines these terms on the grid. There was an indexing error in the initial implementation.

## What is the new behaviour 
The indexing error is addressed and the STREAMICE velocity solver is tested in an idealised situation on a lat/lon grid with varying latitude and longitude spacing, no verification is done but the solution is physically sensible and there is good nonlinear convergence.

## Does this PR introduce a breaking change? 
No


## Other information:
None

## Suggested addition to `tag-index`
o pkg/streamice:
- in STREAMICE_INIT_FIXED, fix indexing error in metric terms k1AtC_str and k2AtC_str