### PR TITLE
First attempt to send regression test output using sftp

### DIFF
--- a/doc/tag-index
+++ b/doc/tag-index
@@ -1,6 +1,10 @@
     Notes on tags used in MITgcmUV
     ==============================
 
+o tools & testreport:
+  - add a very short script and adjust testreport & do_tst_2+2 to enable to use
+   "sftp" to send output results.
+
 checkpoint69p (2026/07/24)
 o verification:
   - remove all OpenAD test dir and files (code_oad, input_oad*, output_oadm.*)

--- a/tools/do_tst_2+2
+++ b/tools/do_tst_2+2
@@ -271,12 +271,12 @@ if test "x$ADDRESS" != xNONE -a "x$ADDRESS" != x ; then
       fi
     fi
     if test "x$SENDCMD" != x ; then
-        sendOpt='' ; nb=`echo $SENDCMD | grep -c '\<scp\>'`
+        sendOpt='' ; nb=`echo $SENDCMD | grep -c '\<mpack\>'`
         if [ $nb -eq 0 ] ; then
+           tarFile="${SAVDIR}/${DRESULTS}.$$.tar"
+        else
            sendOpt='-s MITgcm-test -m 3555000'
            tarFile="${SAVDIR}/${DRESULTS}.tar"
-        else
-           tarFile="${SAVDIR}/${DRESULTS}.$$.tar"
         fi
         #echo " run: $SENDCMD $sendOpt ${tarFile}.gz $ADDRESSES"
         tar -cf ${tarFile} $DRESULTS > /dev/null 2>&1 \

--- a/tools/do_tst_2+2
+++ b/tools/do_tst_2+2
@@ -269,6 +269,8 @@ if test "x$ADDRESS" != xNONE -a "x$ADDRESS" != x ; then
         echo
         echo "Warning: $MPACK is not executable => no email was sent"
       fi
+    elif test "x$SENDCMD" = 'xupload_sftp' ; then
+      if test ! -x $SENDCMD ; then SENDCMD="../tools/$SENDCMD" ; fi
     fi
     if test "x$SENDCMD" != x ; then
         sendOpt='' ; nb=`echo $SENDCMD | grep -c '\<mpack\>'`

--- a/tools/do_tst_2+2
+++ b/tools/do_tst_2+2
@@ -270,7 +270,7 @@ if test "x$ADDRESS" != xNONE -a "x$ADDRESS" != x ; then
         echo "Warning: $MPACK is not executable => no email was sent"
       fi
     elif test "x$SENDCMD" = 'xupload_sftp' ; then
-      if test ! -x $SENDCMD ; then SENDCMD="../tools/$SENDCMD" ; fi
+      if test ! -x $SENDCMD -a -x ../tools/$SENDCMD ; then SENDCMD="../tools/$SENDCMD" ; fi
     fi
     if test "x$SENDCMD" != x ; then
         sendOpt='' ; nb=`echo $SENDCMD | grep -c '\<mpack\>'`

--- a/tools/upload_sftp
+++ b/tools/upload_sftp
@@ -1,0 +1,25 @@
+#! /usr/bin/env bash
+
+destDir='/uploads/'
+if [ $# -lt 2 ] ; then
+  echo
+  echo "Usage:  $0  this-file  this-remote-machine [destination-dir]"
+  echo
+#- description
+  echo " Send file 'this-file' to 'this-remote-machine' (User@Host type)"
+  echo "            in dir (on remote) 'destination-dir' (DEF='$destDir')"
+  echo "      using system 'sftp' command."
+  echo
+  exit 9
+fi
+file=$1
+remote=$2
+if [ $# -eq 3 ] ; then destDir=$3 ; fi
+
+sftp $remote <<EOF
+    put -p $file $destDir
+    bye
+EOF
+retVal=$?
+exit $retVal
+

--- a/verification/testreport
+++ b/verification/testreport
@@ -55,10 +55,10 @@ usage()
     echo "                             (DEF=\"hostname\")"
     echo "  (-addr|-a) STRING        list of email recipients"
     echo "                             (DEF=\"\" no email is sent)"
-    echo "  (-send)       STRING     sending command (instead of using mpack)"
+    echo "  (-send)       STRING     sending command (instead of locally built mpack)"
     echo "  (-savdir|-sd) STRING     location to save output tar file to send (DEF='$SAVDIR')"
     echo "  (-mpackdir|-mpd) DIR     location of the mpack utility"
-    echo "                             (DEF=\"../tools/mpack-1.6\")"
+    echo "                             (DEF='$MPACKDIR')"
     echo " -- do only some parts: --"
     echo "  (-clean)                 *ONLY* run \"make CLEAN\" & clean run-dir"
     echo "  (-norun|-nr)             skip the \"runmodel\" stage (stop after make)"
@@ -108,7 +108,7 @@ build_mpack()
 	RETVAL=$?
 	if test "x$RETVAL" != x0 ; then
 	    echo
-	    echo "Error building the mpack tools at: $MPACK_DIR"
+	    echo "Error building the mpack tools at: $MPACKDIR"
 	    echo
 	    HAVE_MPACK=f
 	else
@@ -1464,6 +1464,7 @@ fi
 #  build the mpack utility (if ADDRESSES = NONE, do it to test the build)
 if test "x$ADDRESSES" = x -o "x$SENDCMD" != x ; then
     echo "skipping mpack build"
+    if test "x$SENDCMD" = 'xupload_sftp' -a test ! -x $SENDCMD ; then SENDCMD="../tools/$SENDCMD" ; fi
 else
     build_mpack
     if test "x$HAVE_MPACK" = xt ; then SENDCMD=$MPACK ; fi
@@ -1907,12 +1908,12 @@ if test "x$ADDRESSES" = xNONE -o "x$ADDRESSES" = x ; then
     echo "No results email was sent."
 else
     if test "x$SENDCMD" != x ; then
-	sendOpt='' ; nb=`echo $SENDCMD | grep -c '\<scp\>'`
+	sendOpt='' ; nb=`echo $SENDCMD | grep -c '\<mpack\>'`
 	if [ $nb -eq 0 ] ; then
+	   tarFile="${SAVDIR}/${DRESULTS}.$$.tar"
+	else
 	   sendOpt='-s MITgcm-test -m 3555000'
 	   tarFile="${SAVDIR}/${DRESULTS}.tar"
-	else
-	   tarFile="${SAVDIR}/${DRESULTS}.$$.tar"
 	fi
 	if [ $verbose -gt 1 ]; then
 	   echo " run: $SENDCMD $sendOpt ${tarFile}.gz $ADDRESSES"

--- a/verification/testreport
+++ b/verification/testreport
@@ -1464,7 +1464,9 @@ fi
 #  build the mpack utility (if ADDRESSES = NONE, do it to test the build)
 if test "x$ADDRESSES" = x -o "x$SENDCMD" != x ; then
     echo "skipping mpack build"
-    if test "x$SENDCMD" = 'xupload_sftp' -a test ! -x $SENDCMD ; then SENDCMD="../tools/$SENDCMD" ; fi
+    if test "x$SENDCMD" = 'xupload_sftp' ; then
+      if test ! -x $SENDCMD -a -x ../tools/$SENDCMD ; then SENDCMD="../tools/$SENDCMD" ; fi
+    fi
 else
     build_mpack
     if test "x$HAVE_MPACK" = xt ; then SENDCMD=$MPACK ; fi


### PR DESCRIPTION
## What changes does this PR introduce?
Small changes to `testreport` and `do_tst_2+2` to enable to use "sftp" to send output results.

## What is the current behaviour? 
By default, `testreport` (and `do_tst_2+2`) uses `mpack` to send output, unless "-send" option include "scp"

## What is the new behaviour 
Continue to use `mpack`  by default, but allows other alternative than "scp".

## Does this PR introduce a breaking change? 
no

## Other information:
Also provide a short shell script to send output with "sftp" ; the purpose of  this script is mostly to have the right argument ordering to be used within `testreport`

## Suggested addition to `tag-index`
o tools & testreport:
  - add a very short script and adjust testreport & do_tst_2+2 to enable to use
   "sftp" to send output results.