### PR TITLE
fix combination of `calendarDumps` and `timePhase`

### DIFF
--- a/doc/outp_pkgs/outp_pkgs.rst
+++ b/doc/outp_pkgs/outp_pkgs.rst
@@ -357,17 +357,18 @@ time interval specified by :varlink:`frequency`; and to ``-0.5*`` \|
 written in the middle of the time interval specified by :varlink:`frequency`.
 
 There is a special case when :varlink:`calendarDumps` is ``.TRUE.``. In this
-case any value of :varlink:`frequency` between 2592000 and 2678400 seconds (30
+case, any value of :varlink:`frequency` between 2592000 and 2678400 seconds (30
 and 31 days) triggers monthly output according to the specified calendar and
 any value betweeen 31104000 and 31968000 seconds (360 and 370 days) triggers
-yearly output. In this case, the parameter :varlink:`timePhase` can be used to
-start the averaged or snapshot output put after ``N`` months or years, where
-the "unit" month or year is defined by the value of :varlink:`frequency`. For
+yearly output. The parameter :varlink:`timePhase` can still be used to start
+the averaged or snapshot output after ``N`` months or years, where now the
+"unit" month or year is defined by the value of :varlink:`frequency`. For
 example, if you specify :varlink:`frequency` = 31363217 seconds (363 days and
-17 seconds, we choose this example to make our point clear) for yearly output,
-:varlink:`timePhase` needs be ``50*31363217 = 1568160850`` to start writing
-averaged output to disk after 50 years, exactly (taking into account all
-possible leap years, etc.).
+17 seconds, this awkward example is deliberate to make our point clear) with
+:varlink:`calendarDumps` ``=.TRUE.``, the model will write yearly averages at
+the end of each calendar year exactly; to start writing averages only after
+``N=50``, :varlink:`timePhase` needs be ``50*31363217 = 1568160850`` (taking
+into account all possible leap years, etc.).
 
 The :varlink:`fileFlags` parameter is explained in
 :numref:`diagnostic_fileFlags`.  Only the first three characters matter.  The

--- a/doc/outp_pkgs/outp_pkgs.rst
+++ b/doc/outp_pkgs/outp_pkgs.rst
@@ -348,6 +348,27 @@ does time averaging every 3600. seconds and the names of diagnostics quantities
 are ``THETA`` and ``SALT``.  It interpolates vertically to the pressure levels
 100000 Pa, ..., 20000 Pa.
 
+The parameter :varlink:`timePhase` is used to specify the time of the first
+output (i.e., the phase): the output starts at :varlink:`timePhase` + multiple
+of \| :varlink:`frequency` \|. :varlink:`timePhase` defaults to zero for
+positive :varlink:`frequency` so that time averages are written at the of the
+time interval specified by :varlink:`frequency`; and to ``-0.5*`` \|
+:varlink:`frequency` \| for negative :varlink:`frequency` so that snapshots are
+written in the middle of the time interval specified by :varlink:`frequency`.
+
+There is a special case when :varlink:`calendarDumps` is ``.TRUE.``. In this
+case any value of :varlink:`frequency` between 2592000 and 2678400 seconds (30
+and 31 days) triggers monthly output according to the specified calendar and
+any value betweeen 31104000 and 31968000 seconds (360 and 370 days) triggers
+yearly output. In this case, the parameter :varlink:`timePhase` can be used to
+start the averaged or snapshot output put after ``N`` months or years, where
+the "unit" month or year is defined by the value of :varlink:`frequency`. For
+example, if you specify :varlink:`frequency` = 31363217 seconds (363 days and
+17 seconds, we choose this example to make our point clear) for yearly output,
+:varlink:`timePhase` needs be ``50*31363217 = 1568160850`` to start writing
+averaged output to disk after 50 years, exactly (taking into account all
+possible leap years, etc.).
+
 The :varlink:`fileFlags` parameter is explained in
 :numref:`diagnostic_fileFlags`.  Only the first three characters matter.  The
 first character determines the precision of the output files.  The default is
@@ -1426,7 +1447,7 @@ scripts to manipulate :filelink:`pkg/mnc` output are available at
 More general manipulations can be performed on `netCDF <http://www.unidata.ucar.edu/software/netcdf/>`_  files with
 the NetCDF Operators (“NCO”) at http://nco.sourceforge.net
 or with the Climate Data Operators (“CDO”) at https://code.mpimet.mpg.de/projects/cdo.
-See :ref:`gluemnc <gluemnc>` for post-processing NetCDF output via command line. 
+See :ref:`gluemnc <gluemnc>` for post-processing NetCDF output via command line.
 
 Unlike the older :filelink:`pkg/mdsio` routines, :filelink:`pkg/mnc` reads and writes variables on
 different “grids” depending upon their location in the
@@ -1535,7 +1556,7 @@ variables, and attributes.
 The two levels of :filelink:`pkg/mnc` are:
 
 Upper level
-     
+
 
     The upper level contains information about two kinds of
     associations:
@@ -1560,7 +1581,7 @@ Upper level
     re-used over multiple file reads and writes.
 
 Lower level
-     
+
 
     In the lower (or internal) level, associations are stored for `netCDF <http://www.unidata.ucar.edu/software/netcdf/>`_
     files and many of the entities that they contain including
@@ -1988,7 +2009,7 @@ and as yet are unpublished and undocumented.
 pkg/mnc utils
 ~~~~~~~~~~~~~
 
-The following scripts and utilities have been written to help manipulate 
+The following scripts and utilities have been written to help manipulate
 `netCDF <http://www.unidata.ucar.edu/software/netcdf/>`_ files:
 
 Tile Assembly:
@@ -1998,9 +2019,9 @@ Tile Assembly:
     called :filelink:`gluemnc.m <utils/matlab/gluemnc.m>` is also provided. Please use the
     `MATLAB <https://www.mathworks.com/>`_ help facility for more information.
 
-    A bash script :filelink:`gluemnc <utils/scripts/gluemnc>` is available for 
-    spatially “assembling” :filelink:`pkg/mnc` NetCDF output. Please see 
-    :numref:`gluemnc` for details. 
+    A bash script :filelink:`gluemnc <utils/scripts/gluemnc>` is available for
+    spatially “assembling” :filelink:`pkg/mnc` NetCDF output. Please see
+    :numref:`gluemnc` for details.
 
 gmt:
     As MITgcm evolves to handle more complicated domains and topologies,

--- a/pkg/cal/cal_time2dump.F
+++ b/pkg/cal/cal_time2dump.F
@@ -27,16 +27,19 @@ c     == local variables ==
       INTEGER thisDate(4), prevDate(4)
       _RL posFreq
       _RL shTime, prTime
+C     to avoid including EEPARAMS.h:
+      _RL halfRL
+      PARAMETER ( halfRL = 0.5 _d 0 )
 
       IF ( calendarDumps .AND. freq .NE. 0. ) THEN
 C-     Same as in FCT DIFF_PHASE_MULTIPLE:
 c      IF ( myTime+step .GE. phase+baseTime ) THEN
 C-     should compare to phase+baseTime (above), but would need PARAMS.h ;
+       posFreq = ABS(freq)
 C      choose to disable this condition for negative time:
-       IF ( myTime+step.GE.phase .OR. myTime.LT.0. ) THEN
-        posFreq = ABS(freq)
+       IF ( myTime+posFreq*halfRL.GE.phase .OR. myTime.LT.0. ) THEN
 C-    First determine calendar dates for this and previous time step.
-        shTime = myTime - phase
+        shTime = myTime - MOD(phase, posFreq)
         prTime = shTime - step
         CALL CAL_GETDATE( myIter, shTime, thisDate, myThid )
         CALL CAL_GETDATE( myIter, prTime, prevDate, myThid )


### PR DESCRIPTION
## What changes does this PR introduce?
Bug fix


## What is the current behaviour? 
In some special cases, the method of starting output only after `timePhase = n * |frequency|` does always not work for `calendarDumps=.TRUE.`, e.g. when `nIter0 = 0` corresponds to a date before Feb28 in a leap year (e.g. 1960), see issue #992

## What is the new behaviour 
Hopefully this PR fixes this bug. At the same time, the definition of "year" and "month" is tied to "frequency" for the sake of computing `timePhase` and the corresponding if-condition, see additional documentation.

## Does this PR introduce a breaking change? 
No

## Other information:


## Suggested addition to `tag-index`
o pkg/cal/cal_time2dump.F:
 - fix behaviour of calendarDumps=T when simulation starts in a leap year
 - for determining "time2write", the "unit" of "month" or "year" is tied to the value of "frequency"