### PR TITLE
Fix loop limits in pkg/ggl90/ggl90_calc.F

### DIFF
--- a/doc/tag-index
+++ b/doc/tag-index
@@ -1,6 +1,9 @@
     Notes on tags used in MITgcmUV
     ==============================
 
+o pkg/ggl90 & obcs:
+  - fix loop limits in ggl90_calc.F, when getting BC from pkg/shelfice;
+  - fix OBCS indices in N & S OB-Eta field when applied to rStar factors.
 o pkg/ggl90:
   - langmuir code: save some computations for u/vStar (done once vs Nr times).
 o tools & testreport:

--- a/pkg/ggl90/ggl90_calc.F
+++ b/pkg/ggl90/ggl90_calc.F
@@ -847,7 +847,7 @@ C-     compute explicit stress
        ENDDO
 C
        DO j=jMin,jMax
-        DO i=jMin,jMax
+        DO i=iMin,iMax
          IF ( kTopC(i,j,bi,bj) .GT. 0 ) THEN
           uStarSquare(i,j) =
      &         ( stressU(i,j)*stressU(i,j)+stressU(i+1,j)*stressU(i+1,j)

--- a/pkg/obcs/obcs_apply_r_star.F
+++ b/pkg/obcs/obcs_apply_r_star.F
@@ -54,7 +54,7 @@ C     !LOCAL VARIABLES:
 C---+----1----+----2----+----3----+----4----+----5----+----6----+----7-|--+----|
 
 C-- Eta OB values corresponding to previous iteration are not available when
-C   calc_r_star is called for the 1rst time (myIter=-1) form initialise_varia.
+C   calc_r_star is called for the 1rst time (myIter=-1) from initialise_varia.
 C   Use current "etaFld" values instead, only for this 1rst call (myIter=-1).
       useOBeta = myIter.NE.-1
 
@@ -67,7 +67,7 @@ C  Northern boundary
          IF (kSurfS(i,j,bi,bj).LE.Nr) THEN
           IF ( useOBeta ) THEN
            rStarFldS(i,j,bi,bj) = 1. _d 0
-     &      + OBNeta(  j,bi,bj) / (rSurfS(i,j,bi,bj)-rLowS(i,j,bi,bj))
+     &      + OBNeta(i  ,bi,bj) / (rSurfS(i,j,bi,bj)-rLowS(i,j,bi,bj))
           ELSE
            rStarFldS(i,j,bi,bj) = 1. _d 0
      &      + etaFld(i,j,bi,bj) / (rSurfS(i,j,bi,bj)-rLowS(i,j,bi,bj))
@@ -84,7 +84,7 @@ C  Southern boundary
          IF (kSurfS(i,j,bi,bj).LE.Nr) THEN
           IF ( useOBeta ) THEN
            rStarFldS(i,j,bi,bj) = 1. _d 0
-     &      + OBSeta(  j,bi,bj) / (rSurfS(i,j,bi,bj)-rLowS(i,j,bi,bj))
+     &      + OBSeta(i  ,bi,bj) / (rSurfS(i,j,bi,bj)-rLowS(i,j,bi,bj))
           ELSE
            rStarFldS(i,j,bi,bj) = 1. _d 0
      &      + etaFld(i,j-1,bi,bj)/(rSurfS(i,j,bi,bj)-rLowS(i,j,bi,bj))


### PR DESCRIPTION
## What changes does this PR introduce?
Bugfix for the first copy-paste error in #1012 about wrong loop limits


## What is the current behaviour? 
#1012

## What is the new behaviour 
Correct loop limits used


## Does this PR introduce a breaking change? 
No, but may break bit-reproducibility 


## Other information:
Rebase after https://github.com/MITgcm/MITgcm/pull/1005 merges

## Suggested addition to `tag-index`
