### PR TITLE
add missing scaling for `GM_slipSqCutoff` and `GM_Small_Number`

### DIFF
--- a/pkg/gmredi/gmredi_slope_limit.F
+++ b/pkg/gmredi/gmredi_slope_limit.F
@@ -102,8 +102,8 @@ C     !LOCAL VARIABLES:
       PARAMETER( fpi = PI )
       INTEGER i, j
       _RL f1, Smod, f2, Rnondim
-      _RL maxSlopeSqr
-      _RL convSlopeUnit, loc_rMaxSlope
+      _RL maxSlopeSqr, smallNumberDr
+      _RL convSlopeUnit, loc_rMaxSlope, loc_sqCutoff
       _RL dSigmMod   (1-OLx:sNx+OLx,1-OLy:sNy+OLy)
       _RL dRdSigmaLtd(1-OLx:sNx+OLx,1-OLy:sNy+OLy)
       _RL tmpFld     (1-OLx:sNx+OLx,1-OLy:sNy+OLy)
@@ -126,13 +126,19 @@ C-   need to put this one in GM namelist :
 CEOP
 
       IF (kPos.EQ.3 ) THEN
+       smallNumberDr = GM_Small_Number*rVel2wUnit(k)
        GM_bigSlope   = GM_bigSlope*wUnit2rVel(k)
        maxSlopeSqr   = GM_maxSlope*GM_maxSlope
      &                *wUnit2rVel(k)*wUnit2rVel(k)
+       loc_sqCutoff  = GM_slopeSqCutoff
+     &                *wUnit2rVel(k)*wUnit2rVel(k)
        convSlopeUnit = rVel2wUnit(k)
       ELSE
+       smallNumberDr = GM_Small_Number*z2rUnit(k)
        GM_bigSlope   = GM_bigSlope*z2rUnit(k)
        maxSlopeSqr   = GM_maxSlope*GM_maxSlope
+     &                *z2rUnit(k)*z2rUnit(k)
+       loc_sqCutoff  = GM_slopeSqCutoff
      &                *z2rUnit(k)*z2rUnit(k)
        convSlopeUnit = rUnit2z(k)
       ENDIF
@@ -247,8 +253,8 @@ C-        Bottom or below:
             taperFct(i,j) = 0. _d 0
           ELSE
 C-        Above bottom:
-           IF ( dSigmaDr(i,j).LE. GM_Small_Number )
-     &          dSigmaDr(i,j) = GM_Small_Number
+           IF ( dSigmaDr(i,j).LE. smallNumberDr )
+     &          dSigmaDr(i,j) = smallNumberDr
            tmpFld(i,j) = dSigmaDx(i,j)*dSigmaDx(i,j)
      &                 + dSigmaDy(i,j)*dSigmaDy(i,j)
            IF ( tmpFld(i,j).GT.zeroRL ) THEN
@@ -427,9 +433,9 @@ C         but still neglect Kxy & Kyx (assumed to be zero)
 #ifndef ALLOW_AUTODIFF_TAMC
 cph-- this part does not adjoint well
           IF ( SlopeSqr(i,j) .GT. maxSlopeSqr .AND.
-     &         SlopeSqr(i,j) .LT. GM_slopeSqCutoff ) THEN
+     &         SlopeSqr(i,j) .LT. loc_sqCutoff ) THEN
            taperFct(i,j) = maxSlopeSqr/SlopeSqr(i,j)
-          ELSEIF ( SlopeSqr(i,j) .GE. GM_slopeSqCutoff ) THEN
+          ELSEIF ( SlopeSqr(i,j) .GE. loc_sqCutoff ) THEN
            taperFct(i,j) = 0. _d 0
           ENDIF
 #endif
@@ -461,8 +467,8 @@ CADJ STORE dSigmaDr = loctape_gm
         DO j=1-OLy+1,sNy+OLy-1
          DO i=1-OLx+1,sNx+OLx-1
           IF ( dSigmaDr(i,j) .NE. zeroRL ) THEN
-           IF ( dSigmaDr(i,j) .LE. GM_Small_Number )
-     &         dSigmaDr(i,j) = GM_Small_Number
+           IF ( dSigmaDr(i,j) .LE. smallNumberDr )
+     &         dSigmaDr(i,j) = smallNumberDr
           ENDIF
          ENDDO
         ENDDO
@@ -510,8 +516,8 @@ CADJ STORE SlopeSqr = loctape_gm
         DO j=1-OLy+1,sNy+OLy-1
          DO i=1-OLx+1,sNx+OLx-1
 #endif
-          IF ( SlopeSqr(i,j) .GE. GM_slopeSqCutoff ) THEN
-            slopeSqr(i,j) = GM_slopeSqCutoff
+          IF ( SlopeSqr(i,j) .GE. loc_sqCutoff ) THEN
+            slopeSqr(i,j) = loc_sqCutoff
             taperFct(i,j) = 0. _d 0
           ENDIF
          ENDDO
@@ -528,7 +534,7 @@ C-      Simplest adiabatic tapering = Smax/Slope (linear)
           IF ( SlopeSqr(i,j) .EQ. zeroRL ) THEN
            taperFct(i,j) = 1. _d 0
           ELSEIF ( SlopeSqr(i,j) .GT. maxSlopeSqr .AND.
-     &             SlopeSqr(i,j) .LT. GM_slopeSqCutoff )  THEN
+     &             SlopeSqr(i,j) .LT. loc_sqCutoff )  THEN
            taperFct(i,j) = SQRT(maxSlopeSqr / SlopeSqr(i,j))
            slopeSqr(i,j) = MIN( slopeSqr(i,j),GM_bigSlope*GM_bigSlope )
           ENDIF
@@ -545,7 +551,7 @@ C-      Gerdes, Koberle and Willebrand, Clim. Dyn. 1991
           IF ( SlopeSqr(i,j) .EQ. zeroRL ) THEN
            taperFct(i,j) = 1. _d 0
           ELSEIF ( SlopeSqr(i,j) .GT. maxSlopeSqr .AND.
-     &             SlopeSqr(i,j) .LT. GM_slopeSqCutoff ) THEN
+     &             SlopeSqr(i,j) .LT. loc_sqCutoff ) THEN
            taperFct(i,j) = maxSlopeSqr/SlopeSqr(i,j)
           ENDIF
 
@@ -560,7 +566,7 @@ C-      Danabasoglu and McWilliams, J. Clim. 1995
 
           IF ( SlopeSqr(i,j) .EQ. zeroRL ) THEN
            taperFct(i,j) = 1. _d 0
-          ELSEIF ( SlopeSqr(i,j) .LT. GM_slopeSqCutoff ) THEN
+          ELSEIF ( SlopeSqr(i,j) .LT. loc_sqCutoff ) THEN
            Smod = SQRT(SlopeSqr(i,j))*convSlopeUnit
            taperFct(i,j) = op5*( oneRL + TANH( (GM_Scrit-Smod)/GM_Sd ) )
           ENDIF
@@ -575,7 +581,7 @@ C-      Large, Danabasoglu and Doney, JPO 1997
 
           IF ( SlopeSqr(i,j) .EQ. zeroRL ) THEN
            taperFct(i,j) = 1. _d 0
-          ELSEIF ( SlopeSqr(i,j) .LT. GM_slopeSqCutoff ) THEN
+          ELSEIF ( SlopeSqr(i,j) .LT. loc_sqCutoff ) THEN
            Smod = SQRT(SlopeSqr(i,j))
            f1 = op5*( oneRL
      &              + TANH( (GM_Scrit-Smod*convSlopeUnit)/GM_Sd ) )

--- a/pkg/gmredi/gmredi_slope_psi.F
+++ b/pkg/gmredi/gmredi_slope_psi.F
@@ -63,6 +63,7 @@ C     !LOCAL VARIABLES:
       _RL maxSlopeSqr
       _RL slopeCutoff
       _RL loc_maxSlope, loc_rMaxSlope
+      _RL smallNumberSlp, smallNumberDr
       _RL fpi
       PARAMETER( fpi = PI )
       INTEGER i, j
@@ -77,15 +78,13 @@ CEOP
 
 C---+----1----+----2----+----3----+----4----+----5----+----6----+----7-|--+----|
 
-      slopeCutoff = SQRT( GM_slopeSqCutoff )
-C-    Note regarding slopeCutoff: current code by-passes the reduction of taper
-C     fct when slope is larger than "slopeCutoff", and this is not very safe !
-C     However, with default GM_Small_Number (=1.E-20) and default value of
-C     GM_slopeSqCutoff (=1.E+48), this is unlikely to occur as it would require
-C     |sigmaX/Y| > 1.e+4
-
+C     smallNumberSlp/Dr are only needed for comparability with between
+C     z- and p-coordinate simulations
+      smallNumberSlp= GM_Small_Number*wUnit2rVel(k)
+      smallNumberDr = GM_Small_Number*rVel2wUnit(k)
       loc_maxSlope  = GM_maxSlope*wUnit2rVel(k)
       loc_rMaxSlope = GM_rMaxSlope*rVel2wUnit(k)
+      slopeCutoff   = SQRT( GM_slopeSqCutoff )*wUnit2rVel(k)
 
 #ifdef ALLOW_AUTODIFF_TAMC
       kkey = bi + (bj-1)*nSx + (ikey_dynamics-1)*nSx*nSy
@@ -117,7 +116,7 @@ C-- X-comp
 C-      Cox 1987 "Slope clipping"
         DO j=1-OLy,sNy+OLy
          DO i=1-OLx+1,sNx+OLx
-          dSigmaDrLtd(i,j) = GM_Small_Number
+          dSigmaDrLtd(i,j) = smallNumberDr
      &     + ABS(SlopeX(i,j))*loc_rMaxSlope
          ENDDO
         ENDDO
@@ -152,7 +151,7 @@ C-- Y-comp
 #endif /* ALLOW_AUTODIFF */
         DO j=1-OLy+1,sNy+OLy
          DO i=1-OLx,sNx+OLx
-          dSigmaDrLtd(i,j) = GM_Small_Number
+          dSigmaDrLtd(i,j) = smallNumberDr
      &     + ABS(SlopeY(i,j))*loc_rMaxSlope
          ENDDO
         ENDDO
@@ -199,8 +198,8 @@ C- Compute the slope, no clipping, but avoid reverse slope in negatively
 C                                  stratified (dSigmaDr < 0) region :
         DO j=1-OLy,sNy+OLy
          DO i=1-OLx+1,sNx+OLx
-          IF (dSigmaDrW(i,j).LE.GM_Small_Number)
-     &        dSigmaDrW(i,j) = GM_Small_Number
+          IF (dSigmaDrW(i,j).LE.smallNumberDr)
+     &        dSigmaDrW(i,j) = smallNumberDr
          ENDDO
         ENDDO
 #ifdef ALLOW_AUTODIFF_TAMC
@@ -233,8 +232,8 @@ CADJ STORE dSigmaDrS(:,:)    = comlev1_bibj_k, key=kkey, byte=isbyte
 
         DO j=1-OLy+1,sNy+OLy
          DO i=1-OLx,sNx+OLx
-          IF (dSigmaDrS(i,j).LE.GM_Small_Number)
-     &        dSigmaDrS(i,j) = GM_Small_Number
+          IF (dSigmaDrS(i,j).LE.smallNumberDr)
+     &        dSigmaDrS(i,j) = smallNumberDr
          ENDDO
         ENDDO
 #ifdef ALLOW_AUTODIFF_TAMC
@@ -275,7 +274,7 @@ C-      Simplest adiabatic tapering = Smax/Slope (linear)
           Smod = ABS(SlopeX(i,j))
           IF ( Smod .GT. loc_maxSlope .AND.
      &         Smod .LT. slopeCutoff )
-     &      taperX(i,j) = loc_maxSlope/(Smod+GM_Small_Number)
+     &      taperX(i,j) = loc_maxSlope/(Smod+smallNumberSlp)
          ENDDO
         ENDDO
         DO j=1-OLy+1,sNy+OLy
@@ -283,7 +282,7 @@ C-      Simplest adiabatic tapering = Smax/Slope (linear)
           Smod = ABS(SlopeY(i,j))
           IF ( Smod .GT. loc_maxSlope .AND.
      &         Smod .LT. slopeCutoff )
-     &      taperY(i,j) = loc_maxSlope/(Smod+GM_Small_Number)
+     &      taperY(i,j) = loc_maxSlope/(Smod+smallNumberSlp)
          ENDDO
         ENDDO
 
@@ -298,7 +297,7 @@ C-      Gerdes, Koberle and Willebrand, Clim. Dyn. 1991
           IF ( Smod .GT. loc_maxSlope .AND.
      &         Smod .LT. slopeCutoff )
      &      taperX(i,j) = maxSlopeSqr/
-     &           ( SlopeX(i,j)*SlopeX(i,j) + GM_Small_Number )
+     &           ( SlopeX(i,j)*SlopeX(i,j) + smallNumberSlp )
          ENDDO
         ENDDO
         DO j=1-OLy+1,sNy+OLy
@@ -307,7 +306,7 @@ C-      Gerdes, Koberle and Willebrand, Clim. Dyn. 1991
           IF ( Smod .GT. loc_maxSlope .AND.
      &         Smod .LT. slopeCutoff )
      &      taperY(i,j) = maxSlopeSqr/
-     &           ( SlopeY(i,j)*SlopeY(i,j) + GM_Small_Number )
+     &           ( SlopeY(i,j)*SlopeY(i,j) + smallNumberSlp )
          ENDDO
         ENDDO
 


### PR DESCRIPTION
- for GM_Small_Number, the scaling changes according to usage: regularize dSigmaDr or SlopeX/Y (with dSigmaDr in the denominator)

## What changes does this PR introduce?
Bug fix


## What is the current behaviour? 
parameters `GM_slipSqCutoff` and `GM_Small_Number` where not properly scaled for the oceanic p-coordinate case

## What is the new behaviour 
parameters `GM_slipSqCutoff` and `GM_Small_Number` are properly scaled for the oceanic p-coordinate case. For `GM_Small_Number`, the scaling changes according to usage: regularize `dSigmaDr` or `SlopeX/Y` (where `dSigmaDr` is in the denominator).

## Does this PR introduce a breaking change? 
No, may change p-coordinate results a little in some cases.

## Other information:

## Suggested addition to `tag-index`
- pkg/gmredi: add missing scaling for GM_slipSqCutoff and GM_Small_Number