### PR TITLE
Enable pkg/dic to use pkg/exf routines to read in BGC forcing.

### DIFF
--- a/pkg/dic/DIC_EXF.h
+++ b/pkg/dic/DIC_EXF.h
@@ -1,0 +1,232 @@
+CBOP
+C     !ROUTINE: DIC_EXF.h
+C     !INTERFACE:
+C #include DIC_EXF.h
+
+C     !DESCRIPTION:
+C Contains parameters for reading BGC forcing
+C with pkg/exf routines
+
+C Surface silica forcing parameters for exf
+      COMMON/dic_forcing_silica_c/
+     &    dic_silicaSurfMask
+      COMMON/dic_forcing_silica_i/
+     &    dic_silicaSurfStartDate1, dic_silicaSurfStartDate2
+      COMMON/dic_forcing_silica_r/
+     &    dic_silicaSurfStartTime,
+     &    dic_silicaSurfPeriod, dic_silicaSurfRepCycle,
+     &    dic_silicaSurf_exfremo_intercept, 
+     &    dic_silicaSurf_exfremo_slope,
+     &    dic_inscal_silicaSurf
+      CHARACTER*1 dic_silicaSurfMask
+      INTEGER dic_silicaSurfStartDate1
+      INTEGER dic_silicaSurfStartDate2
+      _RL dic_silicaSurfStartTime
+      _RL dic_silicaSurfPeriod
+      _RL dic_silicaSurfRepCycle
+      _RL dic_silicaSurf_exfremo_intercept
+      _RL dic_silicaSurf_exfremo_slope
+      _RL dic_inscal_silicaSurf
+
+      COMMON/dic_forcing_silicaDeep_c/
+     &    dic_silicaDeepMask
+      COMMON/dic_forcing_silicaDeep_i/
+     &    dic_silicaDeepStartDate1, dic_silicaDeepStartDate2
+      COMMON/dic_forcing_silicaDeep_r/
+     &    dic_silicaDeepStartTime,
+     &    dic_silicaDeepPeriod, dic_silicaDeepRepCycle,
+     &    dic_silicaDeep_exfremo_intercept, 
+     &    dic_silicaDeep_exfremo_slope,
+     &    dic_inscal_silicaDeep
+      CHARACTER*1 dic_silicaDeepMask
+      INTEGER dic_silicaDeepStartDate1
+      INTEGER dic_silicaDeepStartDate2
+      _RL dic_silicaDeepStartTime
+      _RL dic_silicaDeepPeriod
+      _RL dic_silicaDeepRepCycle
+      _RL dic_silicaDeep_exfremo_intercept
+      _RL dic_silicaDeep_exfremo_slope
+      _RL dic_inscal_silicaDeep
+
+C PAR forcing parameters for exf
+      COMMON/dic_forcing_PAR_c/
+     &    dic_parMask
+      COMMON/dic_forcing_PAR_i/
+     &    dic_parStartDate1, dic_parStartDate2
+      COMMON/dic_forcing_PAR_r/
+     &    dic_parStartTime,
+     &    dic_parPeriod, dic_parRepCycle,
+     &    dic_par_exfremo_intercept, dic_par_exfremo_slope,
+     &    dic_inscal_par
+      _RL dic_parStartTime
+      CHARACTER*1 dic_parMask
+      INTEGER dic_parStartDate1
+      INTEGER dic_parStartDate2
+      _RL dic_parPeriod
+      _RL dic_parRepCycle
+      _RL dic_par_exfremo_intercept
+      _RL dic_par_exfremo_slope
+      _RL dic_inscal_par
+
+C Iron dust forcing parameters for exf
+      COMMON/dic_forcing_iron_c/
+     &    dic_ironMask
+      COMMON/dic_forcing_iron_i/
+     &    dic_ironStartDate1, dic_ironStartDate2
+      COMMON/dic_forcing_iron_r/
+     &    dic_ironStartTime,
+     &    dic_ironPeriod, dic_ironRepCycle,
+     &    dic_iron_exfremo_intercept, dic_iron_exfremo_slope,
+     &    dic_inscal_iron
+      CHARACTER*1 dic_ironMask
+      INTEGER dic_ironStartDate1
+      INTEGER dic_ironStartDate2
+      _RL dic_ironStartTime
+      _RL dic_ironPeriod
+      _RL dic_ironRepCycle
+      _RL dic_iron_exfremo_intercept
+      _RL dic_iron_exfremo_slope
+      _RL dic_inscal_iron
+
+C Ice forcing parameters for exf
+      COMMON/dic_forcing_ice_c/
+     &    dic_iceMask
+      COMMON/dic_forcing_ice_i/
+     &    dic_iceStartDate1, dic_iceStartDate2
+      COMMON/dic_forcing_ice_r/
+     &    dic_iceStartTime,
+     &    dic_icePeriod, dic_iceRepCycle,
+     &    dic_ice_exfremo_intercept, dic_ice_exfremo_slope,
+     &    dic_inscal_ice
+      CHARACTER*1 dic_iceMask
+      INTEGER dic_iceStartDate1
+      INTEGER dic_iceStartDate2
+      _RL dic_iceStartTime
+      _RL dic_icePeriod
+      _RL dic_iceRepCycle
+      _RL dic_ice_exfremo_intercept
+      _RL dic_ice_exfremo_slope
+      _RL dic_inscal_ice
+
+C Wind forcing parameters for exf
+      COMMON/dic_forcing_wind_c/
+     &    dic_windMask
+      COMMON/dic_forcing_wind_i/
+     &    dic_windStartDate1, dic_windStartDate2
+      COMMON/dic_forcing_wind_r/
+     &    dic_windStartTime,
+     &    dic_windPeriod, dic_windRepCycle,
+     &    dic_wind_exfremo_intercept, dic_wind_exfremo_slope,
+     &    dic_inscal_wind
+      CHARACTER*1 dic_windMask
+      INTEGER dic_windStartDate1
+      INTEGER dic_windStartDate2
+      _RL dic_windStartTime
+      _RL dic_windPeriod
+      _RL dic_windRepCycle
+      _RL dic_wind_exfremo_intercept
+      _RL dic_wind_exfremo_slope
+      _RL dic_inscal_wind
+
+C Atmos pCO2 forcing parameters for exf
+      COMMON/dic_forcing_atmospCO2_c/
+     &    dic_atmospCO2Mask
+      COMMON/dic_forcing_atmospCO2_i/
+     &    dic_atmospCO2StartDate1, dic_atmospCO2StartDate2
+      COMMON/dic_forcing_atmospCO2_r/
+     &    dic_atmospCO2StartTime,
+     &    dic_atmospCO2Period, dic_atmospCO2RepCycle,
+     &    dic_atmospCO2_exfremo_intercept, 
+     &    dic_atmospCO2_exfremo_slope,
+     &    dic_inscal_atmospCO2
+      CHARACTER*1 dic_atmospCO2Mask
+      INTEGER dic_atmospCO2StartDate1
+      INTEGER dic_atmospCO2StartDate2
+      _RL dic_atmospCO2StartTime
+      _RL dic_atmospCO2Period
+      _RL dic_atmospCO2RepCycle
+      _RL dic_atmospCO2_exfremo_intercept
+      _RL dic_atmospCO2_exfremo_slope
+      _RL dic_inscal_atmospCO2
+
+C Atmos pressure forcing parameters for exf
+      COMMON/dic_forcing_atmosp_c/
+     &    dic_atmospMask
+      COMMON/dic_forcing_atmosp_i/
+     &    dic_atmospStartDate1, dic_atmospStartDate2
+      COMMON/dic_forcing_atmosp_r/
+     &    dic_atmospStartTime,
+     &    dic_atmospPeriod, dic_atmospRepCycle,
+     &    dic_atmosp_exfremo_intercept, 
+     &    dic_atmosp_exfremo_slope,
+     &    dic_inscal_atmosp
+      CHARACTER*1 dic_atmospMask
+      INTEGER dic_atmospStartDate1
+      INTEGER dic_atmospStartDate2
+      _RL dic_atmospStartTime
+      _RL dic_atmospPeriod
+      _RL dic_atmospRepCycle
+      _RL dic_atmosp_exfremo_intercept
+      _RL dic_atmosp_exfremo_slope
+      _RL dic_inscal_atmosp
+
+C Chlorophyll forcing parameters for exf
+      COMMON/dic_forcing_chl_c/
+     &    dic_chlMask
+      COMMON/dic_forcing_chl_i/
+     &    dic_chlStartDate1, dic_chlStartDate2
+      COMMON/dic_forcing_chl_r/
+     &    dic_chlStartTime,
+     &    dic_chlPeriod, dic_chlRepCycle,
+     &    dic_chl_exfremo_intercept, dic_chl_exfremo_slope,
+     &    dic_inscal_chl
+      CHARACTER*1 dic_chlMask
+      INTEGER dic_chlStartDate1
+      INTEGER dic_chlStartDate2
+      _RL dic_chlStartTime
+      _RL dic_chlPeriod
+      _RL dic_chlRepCycle
+      _RL dic_chl_exfremo_intercept
+      _RL dic_chl_exfremo_slope
+      _RL dic_inscal_chl
+
+C SST forcing parameters for exf
+      COMMON/dic_forcing_SST_c/
+     &    dic_SSTMask
+      COMMON/dic_forcing_SST_i/
+     &    dic_SSTStartDate1, dic_SSTStartDate2
+      COMMON/dic_forcing_SST_r/
+     &    dic_SSTStartTime,
+     &    dic_SSTPeriod, dic_SSTRepCycle,
+     &    dic_SST_exfremo_intercept, dic_SST_exfremo_slope,
+     &    dic_inscal_SST
+      CHARACTER*1 dic_SSTMask
+      INTEGER dic_SSTStartDate1
+      INTEGER dic_SSTStartDate2
+      _RL dic_SSTStartTime
+      _RL dic_SSTPeriod
+      _RL dic_SSTRepCycle
+      _RL dic_SST_exfremo_intercept
+      _RL dic_SST_exfremo_slope
+      _RL dic_inscal_SST
+
+C SSS forcing parameters for exf
+      COMMON/dic_forcing_SSS_c/
+     &    dic_SSSMask
+      COMMON/dic_forcing_SSS_i/
+     &    dic_SSSStartDate1, dic_SSSStartDate2
+      COMMON/dic_forcing_SSS_r/
+     &    dic_SSSStartTime,
+     &    dic_SSSPeriod, dic_SSSRepCycle,
+     &    dic_SSS_exfremo_intercept, dic_SSS_exfremo_slope,
+     &    dic_inscal_SSS
+      CHARACTER*1 dic_SSSMask
+      INTEGER dic_SSSStartDate1
+      INTEGER dic_SSSStartDate2
+      _RL dic_SSSStartTime
+      _RL dic_SSSPeriod
+      _RL dic_SSSRepCycle
+      _RL dic_SSS_exfremo_intercept
+      _RL dic_SSS_exfremo_slope
+      _RL dic_inscal_SSS
+      

--- a/pkg/dic/DIC_INTERP_PARAM.h
+++ b/pkg/dic/DIC_INTERP_PARAM.h
@@ -1,0 +1,147 @@
+CBOP
+C     !ROUTINE: DIC_INTERP_PARAM.h
+C     !INTERFACE:
+C #include DIC_INTERP_PARAM.h
+
+C     !DESCRIPTION:
+C Contains fields and parameters for interpolating
+C BGC forcing with pkg/exf interpolation routines.
+
+C Requires: EXF_INTERP_SIZE.h
+
+C Surface silica forcing parameters for exf
+
+      COMMON/dic_interp_Silicate_i/
+     &    Silicate_nlon, Silicate_nlat, Silicate_interpMethod
+      COMMON/dic_interp_Silicate_r/
+     &    Silicate_lon0, Silicate_lat0, Silicate_lon_inc,
+     &    Silicate_lat_inc
+      INTEGER Silicate_interpMethod, Silicate_nlon, Silicate_nlat
+      _RL Silicate_lon0
+      _RL Silicate_lat0
+      _RL Silicate_lon_inc
+      _RL Silicate_lat_inc(MAX_LAT_INC)
+
+C Three dimensional silica forcing parameters for exf (3D interp)
+#ifdef DIC_3D_SILICA
+      COMMON/dic_interp_SilicateDeep_i/
+     &    SilicateDeep_nlon, SilicateDeep_nlat, SilicateDeep_interpMethod, SilicateDeep_nzin
+      COMMON/dic_interp_SilicateDeep_r/
+     &    SilicateDeep_lon0, SilicateDeep_lat0, SilicateDeep_lon_inc,
+     &    SilicateDeep_lat_inc, SilicateDeep_dzin
+      INTEGER SilicateDeep_interpMethod, SilicateDeep_nlon, SilicateDeep_nlat
+      INTEGER SilicateDeep_nzin
+      _RL SilicateDeep_lon0
+      _RL SilicateDeep_lat0
+      _RL SilicateDeep_lon_inc
+      _RL SilicateDeep_lat_inc(MAX_LAT_INC)
+      _RL SilicateDeep_dzin(MAX_LEV_IN)
+#endif /* DIC_3D_SILICA */
+
+C PAR forcing parameters for exf
+      COMMON/dic_interp_PAR_i/
+     &    par_nlon, par_nlat, par_interpMethod
+      COMMON/dic_interp_PAR_r/
+     &    par_lon0, par_lat0, par_lon_inc,
+     &    par_lat_inc
+      INTEGER par_interpMethod, par_nlon, par_nlat
+      _RL  par_lon0
+      _RL  par_lat0
+      _RL  par_lon_inc
+      _RL  par_lat_inc(MAX_LAT_INC)
+
+C Iron dust forcing parameters for exf
+      COMMON/dic_interp_iron_i/
+     &    iron_nlon, iron_nlat, iron_interpMethod
+      COMMON/dic_interp_iron_r/
+     &    iron_lon0, iron_lat0, iron_lon_inc,
+     &    iron_lat_inc
+      INTEGER iron_interpMethod, iron_nlon, iron_nlat
+      _RL iron_lon0
+      _RL iron_lat0
+      _RL iron_lon_inc
+      _RL iron_lat_inc(MAX_LAT_INC)
+
+C Ice forcing parameters for exf
+      COMMON/dic_interp_ice_i/
+     &    ice_nlon, ice_nlat, ice_interpMethod
+      COMMON/dic_interp_ice_r/
+     &    ice_lon0, ice_lat0, ice_lon_inc,
+     &    ice_lat_inc
+      INTEGER ice_interpMethod, ice_nlon, ice_nlat
+      _RL ice_lon0
+      _RL ice_lat0
+      _RL ice_lon_inc
+      _RL ice_lat_inc(MAX_LAT_INC)
+
+C Wind forcing parameters for exf
+      COMMON/dic_interp_wind_i/
+     &    wind_nlon, wind_nlat, wind_interpMethod
+      COMMON/dic_interp_wind_r/
+     &    wind_lon0, wind_lat0, wind_lon_inc,
+     &    wind_lat_inc
+      INTEGER wind_interpMethod, wind_nlon, wind_nlat
+      _RL wind_lon0
+      _RL wind_lat0
+      _RL wind_lon_inc
+      _RL wind_lat_inc(MAX_LAT_INC)
+
+C Atmos pCO2 forcing parameters for exf
+      COMMON/dic_interp_atmpCO2_i/
+     &    atmospCO2_nlon, atmospCO2_nlat, atmospCO2_interpMethod
+      COMMON/dic_interp_atmpCO2_r/
+     &    atmospCO2_lon0, atmospCO2_lat0, atmospCO2_lon_inc,
+     &    atmospCO2_lat_inc
+      INTEGER atmospCO2_interpMethod, atmospCO2_nlon, atmospCO2_nlat
+      _RL atmospCO2_lon0
+      _RL atmospCO2_lat0
+      _RL atmospCO2_lon_inc
+      _RL atmospCO2_lat_inc(MAX_LAT_INC)
+
+C Atmos pressure forcing parameters for exf
+      COMMON/dic_interp_atmosp_i/
+     &    atmosp_nlon, atmosp_nlat, atmosp_interpMethod
+      COMMON/dic_interp_atmosp_r/
+     &    atmosp_lon0, atmosp_lat0, atmosp_lon_inc,
+     &    atmosp_lat_inc
+      INTEGER atmosp_interpMethod, atmosp_nlon, atmosp_nlat
+      _RL atmosp_lon0
+      _RL atmosp_lat0
+      _RL atmosp_lon_inc
+      _RL atmosp_lat_inc(MAX_LAT_INC)
+
+C Chlorophyll forcing parameters for exf
+      COMMON/dic_interp_chl_i/
+     &    chl_nlon, chl_nlat, chl_interpMethod
+      COMMON/dic_interp_chl_r/
+     &    chl_lon0, chl_lat0, chl_lon_inc,
+     &    chl_lat_inc
+      INTEGER chl_interpMethod, chl_nlon, chl_nlat
+      _RL chl_lon0
+      _RL chl_lat0
+      _RL chl_lon_inc
+      _RL chl_lat_inc(MAX_LAT_INC)
+
+C SST forcing parameters for exf
+      COMMON/dic_interp_SST_i/
+     &    SST_nlon, SST_nlat, SST_interpMethod
+      COMMON/dic_interp_SST_r/
+     &    SST_lon0, SST_lat0, SST_lon_inc,
+     &    SST_lat_inc
+      INTEGER SST_interpMethod, SST_nlon, SST_nlat
+      _RL SST_lon0
+      _RL SST_lat0
+      _RL SST_lon_inc
+      _RL SST_lat_inc(MAX_LAT_INC)
+
+C SSS forcing parameters for exf
+      COMMON/dic_interp_SSS_i/
+     &    SSS_nlon, SSS_nlat, SSS_interpMethod
+      COMMON/dic_interp_SSS_r/
+     &    SSS_lon0, SSS_lat0, SSS_lon_inc,
+     &    SSS_lat_inc  
+      INTEGER SSS_interpMethod, SSS_nlon, SSS_nlat
+      _RL SSS_lon0
+      _RL SSS_lat0
+      _RL SSS_lon_inc
+      _RL SSS_lat_inc(MAX_LAT_INC)

--- a/pkg/dic/DIC_LOAD.h
+++ b/pkg/dic/DIC_LOAD.h
@@ -3,9 +3,11 @@ C     DIC_ldRec     :: time-record currently loaded (in temp arrays *[1])
 C     chlinput      :: chlorophyll climatology input field [mg/m3]
 
       COMMON /DIC_LOAD_I/ DIC_ldRec
+      
       COMMON /DIC_LOAD_RS/
      &    dicwind0, dicwind1, ice0, ice1, atmosp0, atmosp1,
-     &    silicaSurf0, silicaSurf1
+     &    silicaSurf0, silicaSurf1, AtmospCO20, AtmospCO21,
+     &    dicSST0, dicSST1, dicSSS0, dicSSS1
 #ifdef DIC_CALCITE_SAT
      &  , silicaDeep0, silicaDeep1
 #endif
@@ -28,6 +30,12 @@ C     chlinput      :: chlorophyll climatology input field [mg/m3]
       _RS atmosp1    (1-OLx:sNx+OLx,1-OLy:sNy+OLy,nSx,nSy)
       _RS silicaSurf0(1-OLx:sNx+OLx,1-OLy:sNy+OLy,nSx,nSy)
       _RS silicaSurf1(1-OLx:sNx+OLx,1-OLy:sNy+OLy,nSx,nSy)
+      _RS AtmospCO20(1-OLx:sNx+OLx,1-OLy:sNy+OLy,nSx,nSy)
+      _RS AtmospCO21(1-OLx:sNx+OLx,1-OLy:sNy+OLy,nSx,nSy)
+      _RS dicSST0    (1-OLx:sNx+OLx,1-OLy:sNy+OLy,nSx,nSy)
+      _RS dicSST1    (1-OLx:sNx+OLx,1-OLy:sNy+OLy,nSx,nSy)
+      _RS dicSSS0    (1-OLx:sNx+OLx,1-OLy:sNy+OLy,nSx,nSy)
+      _RS dicSSS1    (1-OLx:sNx+OLx,1-OLy:sNy+OLy,nSx,nSy)
 #ifdef DIC_CALCITE_SAT
       _RS silicaDeep0(1-OLx:sNx+OLx,1-OLy:sNy+OLy,Nr,nSx,nSy)
       _RS silicaDeep1(1-OLx:sNx+OLx,1-OLy:sNy+OLy,Nr,nSx,nSy)

--- a/pkg/dic/DIC_OPTIONS.h
+++ b/pkg/dic/DIC_OPTIONS.h
@@ -38,6 +38,15 @@ C BIOTIC OPTIONS
 #undef MINFE
 #undef DIC_NO_NEG
 #undef DIC_BOUNDS
+C dissolution only below saturation horizon following method by Karsten Friis
+#undef DIC_CALCITE_SAT
+
+C Include self-shading effect by phytoplankton
+#undef LIGHT_CHL
+
+C Include iron sediment source using DOP flux
+#undef SEDFE
+
 C these all need to be defined for coupling to atmospheric model:
 #undef USE_QSW
 #undef USE_QSW_UNDERICE
@@ -48,15 +57,6 @@ C use surface salinity forcing (scaled by mean surf value) for DIC & ALK forcing
 
 C put back bugs related to Water-Vapour in carbonate chemistry & air-sea fluxes
 #undef WATERVAP_BUG
-
-C dissolution only below saturation horizon following method by Karsten Friis
-#undef DIC_CALCITE_SAT
-
-C Include self-shading effect by phytoplankton
-#undef LIGHT_CHL
-
-C Include iron sediment source using DOP flux
-#undef SEDFE
 
 C For Adjoint built
 #undef DIC_AD_SAFE

--- a/pkg/dic/DIC_VARS.h
+++ b/pkg/dic/DIC_VARS.h
@@ -44,6 +44,7 @@ C     pH_isLoaded(2) :: = T when   3-D   pH is loaded from pickup file
        COMMON /CARBON_NEEDS/
      &              AtmospCO2, AtmosP, pH, pCO2, FluxCO2,
      &              wind, fIce, Kwexch_Pre, silicaSurf,
+     &              dicSST, dicSSS,
      &              calciteDissolRate, calciteDissolExp,
      &              calcOmegaCalciteFreq, zca,
      &              WsinkPIC, selectCalciteBottomRemin,
@@ -59,6 +60,8 @@ C     pH_isLoaded(2) :: = T when   3-D   pH is loaded from pickup file
       _RL  fIce(1-OLx:sNx+OLx,1-OLy:sNy+OLy,nSx,nSy)
       _RL  Kwexch_Pre(1-OLx:sNx+OLx,1-OLy:sNy+OLy,nSx,nSy)
       _RL  silicaSurf(1-OLx:sNx+OLx,1-OLy:sNy+OLy,nSx,nSy)
+      _RL  dicSST(1-OLx:sNx+OLx,1-OLy:sNy+OLy,nSx,nSy)
+      _RL  dicSSS(1-OLx:sNx+OLx,1-OLy:sNy+OLy,nSx,nSy)
       _RL  calciteDissolRate(2), calciteDissolExp(2)
       _RL  calcOmegaCalciteFreq
       _RL  zca
@@ -243,7 +246,7 @@ C  DIC_atmospFile  :: file name of atmospheric pressure
 C  DIC_iceFile     :: file name of seaice fraction
 C  DIC_ironFile    :: file name of aeolian iron flux
 C  DIC_silicaFile  :: file name of surface silica
-C  DIC_deepSilicaFile  :: file name of 3D silica fields
+C  DIC_silicaDeepFile  :: file name of 3D silica fields
 C  DIC_parFile     :: file name of photosynthetically available radiation (PAR)
 C  DIC_chlaFile    :: file name of chlorophyll climatology
 C  DIC_forcingPeriod :: periodic forcing parameter specific for dic (seconds)
@@ -260,27 +263,55 @@ C  dic_int4          :: timestep between file entries
 C  dic_pCO2          :: atmospheric pCO2 to be read from data.dic
       COMMON /DIC_FILENAMES/
      &        DIC_windFile, DIC_atmospFile, DIC_silicaFile,
-     &        DIC_deepSilicaFile,
+     &        DIC_silicaDeepFile,
      &        DIC_iceFile, DIC_parFile,
      &        DIC_chlaFile, DIC_ironFile,
+     &        DIC_atmospCO2File, DIC_SSTFile, DIC_SSSFile,
      &        DIC_forcingPeriod, DIC_forcingCycle,
-     &        dic_pCO2, dic_int1, dic_int2, dic_int3, dic_int4
+     &        dic_pCO2, dic_int1, dic_int2, dic_int3, dic_int4,
+     &        dic_useEXF, dic_secondsPerYear
 
       CHARACTER*(MAX_LEN_FNAM) DIC_windFile
       CHARACTER*(MAX_LEN_FNAM) DIC_atmospFile
       CHARACTER*(MAX_LEN_FNAM) DIC_silicaFile
-      CHARACTER*(MAX_LEN_FNAM) DIC_deepSilicaFile
+      CHARACTER*(MAX_LEN_FNAM) DIC_silicaDeepFile
       CHARACTER*(MAX_LEN_FNAM) DIC_iceFile
       CHARACTER*(MAX_LEN_FNAM) DIC_parFile
       CHARACTER*(MAX_LEN_FNAM) DIC_chlaFile
       CHARACTER*(MAX_LEN_FNAM) DIC_ironFile
-      _RL     DIC_forcingPeriod
-      _RL     DIC_forcingCycle
-      _RL     dic_pCO2
+      CHARACTER*(MAX_LEN_FNAM) DIC_atmospCO2File
+      CHARACTER*(MAX_LEN_FNAM) DIC_SSTFile
+      CHARACTER*(MAX_LEN_FNAM) DIC_SSSFile
+
+      _RL  DIC_forcingPeriod
+      _RL  DIC_forcingCycle
+      _RL  dic_pCO2
+      _RL  dic_secondsPerYear
+      LOGICAL dic_useEXF
+
       INTEGER dic_int1
       INTEGER dic_int2
       INTEGER dic_int3
       INTEGER dic_int4
+
+C--   COMMON /DIC_FIELDS_CONST/
+      COMMON /DIC_FIELDS_CONST/
+     &     dic_SilicaSurf_const, dic_SilicaDeep_const, dic_par_const,
+     &     dic_iron_const, dic_atmospco2_const, dic_wind_const,
+     &     dic_atmosp_const, dic_chl_const, dic_ice_const,
+     &     dic_SST_const, dic_SSS_const
+
+      _RL dic_SilicaSurf_const
+      _RL dic_SilicaDeep_const
+      _RL dic_par_const
+      _RL dic_iron_const
+      _RL dic_atmospco2_const
+      _RL dic_wind_const
+      _RL dic_atmosp_const
+      _RL dic_chl_const
+      _RL dic_ice_const
+      _RL dic_SST_const
+      _RL dic_SSS_const
 
 #ifdef DIC_BIOTIC
 C     *==========================================================*

--- a/pkg/dic/calcite_saturation.F
+++ b/pkg/dic/calcite_saturation.F
@@ -119,7 +119,7 @@ C calcium concentration already calculated in S/R DIC_COEFFS_SURF
 #endif
 
 C SilicaDeep filled with constant value of 0.03 mol/m3 unless
-C     DIC_deepSilicaFile provided.
+C     DIC_silicaDeepFile provided.
            sitlocal = silicaDeep(i,j,k,bi,bj)
            po4local = PTR_PO4(i,j,k)
            diclocal = PTR_DIC(i,j,k)

--- a/pkg/dic/dic_biotic_forcing.F
+++ b/pkg/dic/dic_biotic_forcing.F
@@ -124,13 +124,14 @@ CEOP
 #ifdef ALLOW_AUTODIFF_TAMC
       tkey = bi + (bj-1)*nSx + (ikey_dynamics-1)*nSx*nSy
 #endif
-      IF ( useThSIce .OR. useSEAICE .OR. useCoupler ) THEN
+C      IF ( useThSIce .OR. useSEAICE .OR. useCoupler ) THEN
 #ifdef ALLOW_DEBUG
         IF (debugMode) CALL DEBUG_CALL('DIC_FIELDS_UPDATE',myThid)
 #endif
+        
         CALL DIC_FIELDS_UPDATE(
      I                    bi, bj, myTime, myIter, myThid )
-      ENDIF
+C      ENDIF
 
        DO k=1,Nr
          DO j=1-OLy,sNy+OLy

--- a/pkg/dic/dic_biotic_forcing.F
+++ b/pkg/dic/dic_biotic_forcing.F
@@ -124,14 +124,12 @@ CEOP
 #ifdef ALLOW_AUTODIFF_TAMC
       tkey = bi + (bj-1)*nSx + (ikey_dynamics-1)*nSx*nSy
 #endif
-C      IF ( useThSIce .OR. useSEAICE .OR. useCoupler ) THEN
 #ifdef ALLOW_DEBUG
         IF (debugMode) CALL DEBUG_CALL('DIC_FIELDS_UPDATE',myThid)
 #endif
         
         CALL DIC_FIELDS_UPDATE(
      I                    bi, bj, myTime, myIter, myThid )
-C      ENDIF
 
        DO k=1,Nr
          DO j=1-OLy,sNy+OLy

--- a/pkg/dic/dic_fields_load.F
+++ b/pkg/dic/dic_fields_load.F
@@ -352,7 +352,8 @@ C Otherwise get atmospheric pressure from PKG/EXF
          DO bi = myBxLo(myThid), myBxHi(myThid)
           DO j=1-OLy,sNy+OLy
            DO i=1-OLx,sNx+OLx
-            AtmosP(i,j,bi,bj) = apressure(i,j,bi,bj)
+C EXFs pressure is in Pa, convert to atm for DIC package.               
+            AtmosP(i,j,bi,bj) = apressure(i,j,bi,bj)/Pa2ATM
            ENDDO
           ENDDO
          ENDDO

--- a/pkg/dic/dic_fields_load.F
+++ b/pkg/dic/dic_fields_load.F
@@ -18,7 +18,15 @@ C !USES: ===============================================================
 #include "GRID.h"
 #include "DIC_VARS.h"
 #include "DIC_LOAD.h"
-
+#ifdef ALLOW_EXF
+# include "EXF_PARAM.h"
+# include "EXF_FIELDS.h"
+# include "DIC_EXF.h"
+# ifdef USE_EXF_INTERPOLATION
+#  include "EXF_INTERP_SIZE.h"
+#  include "DIC_INTERP_PARAM.h"
+# endif
+#endif
 C !INPUT PARAMETERS: ===================================================
 C  myTime               :: current time
 C  myIter               :: current timestep
@@ -37,26 +45,26 @@ c !LOCAL VARIABLES: ===================================================
       INTEGER k
 #endif
 CEOP
+      IF ( .NOT. dic_useEXF ) THEN
+       IF (  DIC_forcingCycle.GT.0. _d 0 ) THEN
 
-      IF (  DIC_forcingCycle.GT.0. _d 0 ) THEN
+C--    Now calculate whether it is time to update the forcing arrays
+        CALL GET_PERIODIC_INTERVAL(
+     O                    intimeP, intime0, intime1, bWght, aWght,
+     I                    DIC_forcingCycle, DIC_forcingPeriod,
+     I                    deltaTClock, myTime, myThid )
 
-C--   Now calculate whether it is time to update the forcing arrays
-       CALL GET_PERIODIC_INTERVAL(
-     O                   intimeP, intime0, intime1, bWght, aWght,
-     I                   DIC_forcingCycle, DIC_forcingPeriod,
-     I                   deltaTClock, myTime, myThid )
-
-       bi = myBxLo(myThid)
-       bj = myByLo(myThid)
+        bi = myBxLo(myThid)
+        bj = myByLo(myThid)
 #ifdef ALLOW_DEBUG
-       IF ( debugLevel.GE.debLevB ) THEN
-        _BEGIN_MASTER(myThid)
-        WRITE(standardMessageUnit,'(A,I10,A,4I5,A,2F14.10)')
-     &   ' DIC_FIELDS_LOAD,', myIter,
-     &   ' : iP,iLd,i0,i1=', intimeP,DIC_ldRec(bi,bj), intime0,intime1,
-     &   ' ; Wght=', bWght, aWght
-        _END_MASTER(myThid)
-       ENDIF
+        IF ( debugLevel.GE.debLevB ) THEN
+         _BEGIN_MASTER(myThid)
+         WRITE(standardMessageUnit,'(A,I10,A,4I5,A,2F14.10)')
+     &    ' DIC_FIELDS_LOAD,', myIter,
+     &    ' : iP,iLd,i0,i1=', intimeP,DIC_ldRec(bi,bj), intime0,intime1,
+     &    ' ; Wght=', bWght, aWght
+         _END_MASTER(myThid)
+        ENDIF
 #endif /* ALLOW_DEBUG */
 
 #ifdef ALLOW_AUTODIFF
@@ -64,224 +72,482 @@ C-    assuming that we call S/R DIC_FIELDS_LOAD at each time-step and
 C     with increasing time, this will catch when we need to load new records;
 C     But with Adjoint run, this is not always the case => might end-up using
 C     the wrong time-records
-       IF ( intime0.NE.intimeP .OR. myIter.EQ.nIter0 ) THEN
+        IF ( intime0.NE.intimeP .OR. myIter.EQ.nIter0 ) THEN
 #else /* ALLOW_AUTODIFF */
 C-    Make no assumption on sequence of calls to DIC_FIELDS_LOAD ;
 C     This is the correct formulation (works in Adjoint run).
 C     Unfortunatly, produces many recomputations <== not used until it is fixed
-       IF ( intime1.NE.DIC_ldRec(bi,bj) ) THEN
+        IF ( intime1.NE.DIC_ldRec(bi,bj) ) THEN
 #endif /* ALLOW_AUTODIFF */
 
 C--   If the above condition is met then we need to read in
 C     data for the period ahead and the period behind myTime.
-        IF ( debugLevel.GE.debLevZero ) THEN
-         _BEGIN_MASTER(myThid)
-         WRITE(standardMessageUnit,'(A,I10,A,2(2I5,A))')
-     &    ' DIC_FIELDS_LOAD, it=', myIter,
-     &    ' : Reading new data, i0,i1=', intime0, intime1,
-     &    ' (prev=', intimeP, DIC_ldRec(bi,bj), ' )'
-         _END_MASTER(myThid)
-        ENDIF
+         IF ( debugLevel.GE.debLevZero ) THEN
+          _BEGIN_MASTER(myThid)
+          WRITE(standardMessageUnit,'(A,I10,A,2(2I5,A))')
+     &     ' DIC_FIELDS_LOAD, it=', myIter,
+     &     ' : Reading new data, i0,i1=', intime0, intime1,
+     &     ' (prev=', intimeP, DIC_ldRec(bi,bj), ' )'
+          _END_MASTER(myThid)
+         ENDIF
 
-        _BARRIER
+         _BARRIER
 
-        IF ( DIC_windFile .NE. ' '  ) THEN
-         CALL READ_REC_XY_RS( DIC_windFile,dicwind0,intime0,
-     &        myIter,myThid )
-         CALL READ_REC_XY_RS( DIC_windFile,dicwind1,intime1,
-     &        myIter,myThid )
-        ENDIF
-        IF ( DIC_atmospFile .NE. ' '  ) THEN
-         CALL READ_REC_XY_RS( DIC_atmospFile,atmosp0,intime0,
-     &        myIter,myThid )
-         CALL READ_REC_XY_RS( DIC_atmospFile,atmosp1,intime1,
-     &        myIter,myThid )
-        ENDIF
-        IF ( DIC_silicaFile .NE. ' '  ) THEN
-         CALL READ_REC_XY_RS( DIC_silicaFile,silicaSurf0,intime0,
-     &        myIter,myThid )
-         CALL READ_REC_XY_RS( DIC_silicaFile,silicaSurf1,intime1,
-     &        myIter,myThid )
-        ENDIF
+         IF ( DIC_windFile .NE. ' '  ) THEN
+          CALL READ_REC_XY_RS( DIC_windFile,dicwind0,intime0,
+     &         myIter,myThid )
+          CALL READ_REC_XY_RS( DIC_windFile,dicwind1,intime1,
+     &         myIter,myThid )
+         ENDIF
+         IF ( DIC_atmospFile .NE. ' '  ) THEN
+          CALL READ_REC_XY_RS( DIC_atmospFile,atmosp0,intime0,
+     &         myIter,myThid )
+          CALL READ_REC_XY_RS( DIC_atmospFile,atmosp1,intime1,
+     &         myIter,myThid )
+         ENDIF
+         IF ( DIC_silicaFile .NE. ' '  ) THEN
+          CALL READ_REC_XY_RS( DIC_silicaFile,silicaSurf0,intime0,
+     &         myIter,myThid )
+          CALL READ_REC_XY_RS( DIC_silicaFile,silicaSurf1,intime1,
+     &         myIter,myThid )
+         ENDIF
 #ifdef DIC_CALCITE_SAT
-        IF ( DIC_deepSilicaFile .NE. ' '  ) THEN
-         CALL READ_REC_XYZ_RS( DIC_deepSilicaFile,silicaDeep0,intime0,
-     &        myIter,myThid )
-         CALL READ_REC_XYZ_RS( DIC_deepSilicaFile,silicaDeep1,intime1,
-     &        myIter,myThid )
-        ENDIF
+         IF ( DIC_silicaDeepFile .NE. ' '  ) THEN
+          CALL READ_REC_XYZ_RS( DIC_silicaDeepFile,silicaDeep0,intime0,
+     &         myIter,myThid )
+          CALL READ_REC_XYZ_RS( DIC_silicaDeepFile,silicaDeep1,intime1,
+     &         myIter,myThid )
+         ENDIF
 #endif
-        IF ( DIC_iceFile .NE. ' '  ) THEN
-         CALL READ_REC_XY_RS( DIC_iceFile,ice0,intime0,
-     &       myIter,myThid )
-         CALL READ_REC_XY_RS( DIC_iceFile,ice1,intime1,
-     &       myIter,myThid )
-        ENDIF
+         IF ( DIC_iceFile .NE. ' '  ) THEN
+          CALL READ_REC_XY_RS( DIC_iceFile,ice0,intime0,
+     &        myIter,myThid )
+          CALL READ_REC_XY_RS( DIC_iceFile,ice1,intime1,
+     &        myIter,myThid )
+         ENDIF
 #ifdef READ_PAR
-        IF ( DIC_parFile .NE. ' '  ) THEN
-         CALL READ_REC_XY_RS( DIC_parFile,par0,intime0,
-     &       myIter,myThid )
-         CALL READ_REC_XY_RS( DIC_parFile,par1,intime1,
-     &       myIter,myThid )
-        ENDIF
+         IF ( DIC_parFile .NE. ' '  ) THEN
+          CALL READ_REC_XY_RS( DIC_parFile,par0,intime0,
+     &        myIter,myThid )
+          CALL READ_REC_XY_RS( DIC_parFile,par1,intime1,
+     &        myIter,myThid )
+         ENDIF
 #endif
 #ifdef LIGHT_CHL
 C--   Load chlorophyll climatology data, unit for chlorophyll : mg/m3
-        IF ( DIC_chlaFile .NE. ' '  ) THEN
-         CALL READ_REC_XY_RS( DIC_chlaFile,chlinput,1,
-     &       myIter,myThid )
-        ENDIF
+         IF ( DIC_chlaFile .NE. ' '  ) THEN
+          CALL READ_REC_XY_RS( DIC_chlaFile,chlinput,1,
+     &        myIter,myThid )
+         ENDIF
 #endif
 #ifdef ALLOW_FE
-        IF ( DIC_ironFile .NE. ' '  ) THEN
-         CALL READ_REC_XY_RS( DIC_ironFile,feinput0,intime0,
-     &       myIter,myThid )
-         CALL READ_REC_XY_RS( DIC_ironFile,feinput1,intime1,
-     &       myIter,myThid )
-        ENDIF
+         IF ( DIC_ironFile .NE. ' '  ) THEN
+          CALL READ_REC_XY_RS( DIC_ironFile,feinput0,intime0,
+     &        myIter,myThid )
+          CALL READ_REC_XY_RS( DIC_ironFile,feinput1,intime1,
+     &        myIter,myThid )
+         ENDIF
 #endif
 
 C--   fill-in overlap after loading temp arrays:
-        _EXCH_XY_RS(dicwind0, myThid )
-        _EXCH_XY_RS(dicwind1, myThid )
-        _EXCH_XY_RS(atmosp0, myThid )
-        _EXCH_XY_RS(atmosp1, myThid )
-        _EXCH_XY_RS(silicaSurf0, myThid )
-        _EXCH_XY_RS(silicaSurf1, myThid )
+         _EXCH_XY_RS(dicwind0, myThid )
+         _EXCH_XY_RS(dicwind1, myThid )
+         _EXCH_XY_RS(atmosp0, myThid )
+         _EXCH_XY_RS(atmosp1, myThid )
+         _EXCH_XY_RS(silicaSurf0, myThid )
+         _EXCH_XY_RS(silicaSurf1, myThid )
 #ifdef DIC_CALCITE_SAT
-      IF ( DIC_deepSilicaFile .NE. ' '  ) THEN
-        _EXCH_XYZ_RS(silicaDeep0, myThid )
-        _EXCH_XYZ_RS(silicaDeep1, myThid )
-      ENDIF
+       IF ( DIC_silicaDeepFile .NE. ' '  ) THEN
+         _EXCH_XYZ_RS(silicaDeep0, myThid )
+         _EXCH_XYZ_RS(silicaDeep1, myThid )
+       ENDIF
 #endif
-        _EXCH_XY_RS(ice0, myThid )
-        _EXCH_XY_RS(ice1, myThid )
+         _EXCH_XY_RS(ice0, myThid )
+         _EXCH_XY_RS(ice1, myThid )
 #ifdef READ_PAR
-        _EXCH_XY_RS(par0, myThid )
-        _EXCH_XY_RS(par1, myThid )
+         _EXCH_XY_RS(par0, myThid )
+         _EXCH_XY_RS(par1, myThid )
 #endif
 #ifdef LIGHT_CHL
-        _EXCH_XY_RS(chlinput, myThid )
+         _EXCH_XY_RS(chlinput, myThid )
 #endif
 #ifdef ALLOW_FE
-        _EXCH_XY_RS(feinput0, myThid )
-        _EXCH_XY_RS(feinput1, myThid )
+         _EXCH_XY_RS(feinput0, myThid )
+         _EXCH_XY_RS(feinput1, myThid )
 #endif
 
 C-    save newly loaded time-record
-        DO bj = myByLo(myThid), myByHi(myThid)
-         DO bi = myBxLo(myThid), myBxHi(myThid)
-           DIC_ldRec(bi,bj) = intime1
+         DO bj = myByLo(myThid), myByHi(myThid)
+          DO bi = myBxLo(myThid), myBxHi(myThid)
+            DIC_ldRec(bi,bj) = intime1
+          ENDDO
          ENDDO
-        ENDDO
 
 C-     end if-bloc (time to load new fields)
-       ENDIF
+        ENDIF
 
-       DO bj = myByLo(myThid), myByHi(myThid)
-        DO bi = myBxLo(myThid), myBxHi(myThid)
-         IF ( DIC_windFile .NE. ' '  ) THEN
-           DO j=1-OLy,sNy+OLy
-            DO i=1-OLx,sNx+OLx
-             WIND(i,j,bi,bj) = bWght*dicwind0(i,j,bi,bj)
-     &                       + aWght*dicwind1(i,j,bi,bj)
+        DO bj = myByLo(myThid), myByHi(myThid)
+         DO bi = myBxLo(myThid), myBxHi(myThid)
+          IF ( DIC_windFile .NE. ' '  ) THEN
+            DO j=1-OLy,sNy+OLy
+             DO i=1-OLx,sNx+OLx
+              WIND(i,j,bi,bj) = bWght*dicwind0(i,j,bi,bj)
+     &                        + aWght*dicwind1(i,j,bi,bj)
+             ENDDO
             ENDDO
-           ENDDO
 
 C calculate piston velocity
 C QQ: note - we should have wind speed variance in here
 C QQ         also need to check units, and conversion factors
 c          pisvel(i,j,bi,bj)  =0.337*wind(i,j,bi,bj)**2/3.6d5    !QQQQ
-         ENDIF
+          ENDIF
 #ifndef USE_PLOAD
-         IF ( DIC_atmospFile .NE. ' '  ) THEN
-           DO j=1-OLy,sNy+OLy
-            DO i=1-OLx,sNx+OLx
-             AtmosP(i,j,bi,bj) = bWght*atmosp0(i,j,bi,bj)
-     &                         + aWght*atmosp1(i,j,bi,bj)
+          IF ( DIC_atmospFile .NE. ' '  ) THEN
+            DO j=1-OLy,sNy+OLy
+             DO i=1-OLx,sNx+OLx
+              AtmosP(i,j,bi,bj) = bWght*atmosp0(i,j,bi,bj)
+     &                          + aWght*atmosp1(i,j,bi,bj)
+             ENDDO
             ENDDO
-           ENDDO
-         ENDIF
+          ENDIF
 #endif
 #ifdef DIC_CALCITE_SAT
-         IF ( useCalciteSaturation .AND.
-     &        DIC_deepSilicaFile .NE. ' '  ) THEN
-          DO k=1,Nr
-           DO j=1-OLy,sNy+OLy
-            DO i=1-OLx,sNx+OLx
-             silicaDeep(i,j,k,bi,bj) = bWght*silicaDeep0(i,j,k,bi,bj)
-     &                               + aWght*silicaDeep1(i,j,k,bi,bj)
+          IF ( useCalciteSaturation .AND.
+     &         DIC_silicaDeepFile .NE. ' '  ) THEN
+           DO k=1,Nr
+            DO j=1-OLy,sNy+OLy
+             DO i=1-OLx,sNx+OLx
+              silicaDeep(i,j,k,bi,bj) = bWght*silicaDeep0(i,j,k,bi,bj)
+     &                                + aWght*silicaDeep1(i,j,k,bi,bj)
+             ENDDO
             ENDDO
            ENDDO
-          ENDDO
-         ENDIF
+          ENDIF
 #endif
-         IF ( DIC_silicaFile .NE. ' '  ) THEN
-           DO j=1-OLy,sNy+OLy
-            DO i=1-OLx,sNx+OLx
+          IF ( DIC_silicaFile .NE. ' '  ) THEN
+            DO j=1-OLy,sNy+OLy
+             DO i=1-OLx,sNx+OLx
 C If file provided for surface silicate, read it in
-             silicaSurf(i,j,bi,bj) = bWght*silicaSurf0(i,j,bi,bj)
-     &                             + aWght*silicaSurf1(i,j,bi,bj)
+              silicaSurf(i,j,bi,bj) = bWght*silicaSurf0(i,j,bi,bj)
+     &                              + aWght*silicaSurf1(i,j,bi,bj)
+             ENDDO
             ENDDO
-           ENDDO
 #ifndef ALLOW_AUTODIFF
 #ifdef DIC_CALCITE_SAT
-         ELSEIF ( DIC_deepSilicaFile .NE. ' '  ) THEN
-           DO j=1-OLy,sNy+OLy
-            DO i=1-OLx,sNx+OLx
+          ELSEIF ( DIC_silicaDeepFile .NE. ' '  ) THEN
+            DO j=1-OLy,sNy+OLy
+             DO i=1-OLx,sNx+OLx
 C If no surface silicate file but deep (3d) silicate provided, use top level
-             silicaSurf(i,j,bi,bj) = bWght*silicaDeep0(i,j,1,bi,bj)
-     &                             + aWght*silicaDeep1(i,j,1,bi,bj)
+              silicaSurf(i,j,bi,bj) = bWght*silicaDeep0(i,j,1,bi,bj)
+     &                              + aWght*silicaDeep1(i,j,1,bi,bj)
+             ENDDO
             ENDDO
-           ENDDO
 #endif /* DIC_CALCITE_SAT */
 #endif /* not ALLOW_AUTODIFF */
-         ENDIF
+          ENDIF
 
-         IF ( DIC_iceFile .NE. ' '  ) THEN
-           DO j=1-OLy,sNy+OLy
-            DO i=1-OLx,sNx+OLx
-             fIce(i,j,bi,bj) = bWght*ice0(i,j,bi,bj)
-     &                       + aWght*ice1(i,j,bi,bj)
+          IF ( DIC_iceFile .NE. ' '  ) THEN
+            DO j=1-OLy,sNy+OLy
+             DO i=1-OLx,sNx+OLx
+              fIce(i,j,bi,bj) = bWght*ice0(i,j,bi,bj)
+     &                        + aWght*ice1(i,j,bi,bj)
+             ENDDO
             ENDDO
-           ENDDO
-         ENDIF
+          ENDIF
 
 #ifdef READ_PAR
-         IF ( DIC_parFile .NE. ' '  ) THEN
-           DO j=1-OLy,sNy+OLy
-            DO i=1-OLx,sNx+OLx
-             PAR(i,j,bi,bj) = bWght*par0(i,j,bi,bj)
-     &                      + aWght*par1(i,j,bi,bj)
+          IF ( DIC_parFile .NE. ' '  ) THEN
+            DO j=1-OLy,sNy+OLy
+             DO i=1-OLx,sNx+OLx
+              PAR(i,j,bi,bj) = bWght*par0(i,j,bi,bj)
+     &                       + aWght*par1(i,j,bi,bj)
+             ENDDO
             ENDDO
-           ENDDO
-         ENDIF
+          ENDIF
 #endif
 #ifdef LIGHT_CHL
-         IF ( DIC_chlaFile .NE. ' '  ) THEN
-           DO j=1-OLy,sNy+OLy
-            DO i=1-OLx,sNx+OLx
-             CHL(i,j,bi,bj) = chlinput(i,j,bi,bj)
+          IF ( DIC_chlaFile .NE. ' '  ) THEN
+            DO j=1-OLy,sNy+OLy
+             DO i=1-OLx,sNx+OLx
+              CHL(i,j,bi,bj) = chlinput(i,j,bi,bj)
+             ENDDO
             ENDDO
-           ENDDO
-         ENDIF
+          ENDIF
 #endif
 #ifdef ALLOW_FE
-         IF ( DIC_ironFile .NE. ' '  ) THEN
-           DO j=1-OLy,sNy+OLy
-            DO i=1-OLx,sNx+OLx
-             InputFe(i,j,bi,bj) = bWght*feinput0(i,j,bi,bj)
-     &                          + aWght*feinput1(i,j,bi,bj)
+          IF ( DIC_ironFile .NE. ' '  ) THEN
+            DO j=1-OLy,sNy+OLy
+             DO i=1-OLx,sNx+OLx
+              InputFe(i,j,bi,bj) = bWght*feinput0(i,j,bi,bj)
+     &                           + aWght*feinput1(i,j,bi,bj)
+             ENDDO
             ENDDO
-           ENDDO
-         ENDIF
+          ENDIF
 #endif
+         ENDDO
         ENDDO
-       ENDDO
 
 C endif for DIC_forcingCycle
+       ENDIF
+C endif .not. dic_useEXF
       ENDIF
 
+C-----------------------------------------------------------
+#ifdef ALLOW_EXF
+C     forcing load fields with pkg/exf tools
+      IF ( dic_useEXF ) THEN
+
+C If a wind file is given in data.dic, read it
+       IF ( dic_WindFile .NE. ' ' ) THEN
+        CALL EXF_SET_FLD(
+     &     'dicWind', dic_windfile, dic_windMask,
+     &     dic_windStartTime, dic_windPeriod, dic_windRepCycle,
+     &     dic_inscal_wind,
+     &     dic_wind_exfremo_intercept, dic_wind_exfremo_slope,
+     &     Wind, dicWind0, dicWind1,
+# ifdef USE_EXF_INTERPOLATION
+     &     wind_lon0, wind_lon_inc,
+     &     wind_lat0, wind_lat_inc,
+     &     wind_nlon, wind_nlat, xC, yC,
+     &     wind_interpMethod,
+# endif
+     &     mytime, myiter, mythid )
+C Otherwise get winds from PKG/EXF (useEXF ensures physical model is actually using pkg/EXF)
+       ELSEIF ( useEXF
+     &   .AND. (( uwindfile .NE. ' ' .AND.
+     &           vwindfile .NE. ' ' )
+     &  .OR. ( ustressfile .NE. ' ' .AND.
+     &         vstressfile .NE. ' ' ))) THEN
+        DO bj = myByLo(myThid), myByHi(myThid)
+         DO bi = myBxLo(myThid), myBxHi(myThid)
+          DO j=1-OLy,sNy+OLy
+           DO i=1-OLx,sNx+OLx
+            Wind(i,j,bi,bj) = wspeed(i,j,bi,bj)
+           ENDDO
+          ENDDO
+         ENDDO
+        ENDDO
+       ENDIF
+
+#ifndef USE_PLOAD
+C If a pressure files is given in data.dic, read it
+       IF ( dic_atmospFile .NE. ' ' ) THEN
+        CALL EXF_SET_FLD(
+     &     'dicAtmosP', dic_atmospFile, dic_atmospMask,
+     &     dic_atmospStartTime, dic_atmospPeriod, dic_atmospRepCycle,
+     &     dic_inscal_atmosp,
+     &     dic_atmosp_exfremo_intercept, dic_atmosp_exfremo_slope,
+     &     AtmosP, atmosp0, atmosp1,
+# ifdef USE_EXF_INTERPOLATION
+     &     atmosp_lon0, atmosp_lon_inc,
+     &     atmosp_lat0, atmosp_lat_inc,
+     &     atmosp_nlon, atmosp_nlat, xC, yC,
+     &     atmosp_interpMethod,
+# endif
+     &     mytime, myiter, mythid )
+C Otherwise get atmospheric pressure from PKG/EXF
+       ELSEIF ( useEXF .AND. dic_atmospFile .NE. ' ' ) THEN
+        DO bj = myByLo(myThid), myByHi(myThid)
+         DO bi = myBxLo(myThid), myBxHi(myThid)
+          DO j=1-OLy,sNy+OLy
+           DO i=1-OLx,sNx+OLx
+            AtmosP(i,j,bi,bj) = apressure(i,j,bi,bj)
+           ENDDO
+          ENDDO
+         ENDDO
+        ENDDO
+       ENDIF
+#endif /* NOT USE_PLOAD */
+
+       IF ( dic_SilicaFile .NE. ' ' ) THEN
+        CALL EXF_SET_FLD(
+     &     'dicSilicaSurf', dic_SilicaFile, dic_SilicaSurfMask,
+     &     dic_SilicaSurfStartTime, dic_SilicaSurfPeriod, 
+     &     dic_SilicaSurfRepCycle, dic_inscal_SilicaSurf,
+     &     dic_SilicaSurf_exfremo_intercept, 
+     &     dic_SilicaSurf_exfremo_slope,
+     &     silicaSurf, silicaSurf0, silicaSurf1,
+# ifdef USE_EXF_INTERPOLATION
+     &     silicaSurfLon0, silicaSurfLonInc,
+     &     silicaSurfLat0, silicaSurfLatInc,
+     &     silicaSurfNlon, silicaSurfNlat, xC, yC,
+     &     silicaSurfInterpMethod,
+# endif
+     &     mytime, myiter, mythid )
+       ENDIF
+
+#ifdef DIC_3D_SILICA
+       IF ( useCalciteSaturation .AND.
+     &         DIC_silicaDeepFile .NE. ' '  ) THEN
+        CALL EXF_SET_FLD3D(
+     &      'dicSilicaDeep', dic_SilicaDeepFile, dic_SilicaDeepMask,
+     &      dic_SilicaDeepStartTime, dic_SilicaDeepPeriod,
+     &      dic_SilicaDeepRepCycle,
+     &      dic_inscal_SilicaDeep,
+     &      dic_SilicaDeep_exfremo_intercept,
+     &      dic_SilicaDeep_exfremo_slope,
+     &      silicaDeep, silicaDeep0, silicaDeep1,
+# ifdef USE_EXF_INTERPOLATION
+     &      SilicaDeep_lon0, SilicaDeep_lon_inc,
+     &      SilicaDeep_lat0, SilicaDeep_lat_inc,
+     &      SilicaDeep_nlon, SilicaDeep_nlat, xC, yC,
+     &      SilicaDeep_interpMethod,
+     &      SilicaDeep_nzin, SilicaDeep_dzin,
+# endif
+     &      mytime, myiter, mythid )
+#ifndef ALLOW_AUTODIFF
+        IF ( dic_SilicaFile .NE. ' ' ) THEN
+          DO j=1-OLy,sNy+OLy
+            DO i=1-OLx,sNx+OLx
+C If no surface silicate file but deep (3d) silicate provided, use top level
+              silicaSurf(i,j,bi,bj) = silicaDeep(i,j,1,bi,bj)
+            ENDDO
+          ENDDO
+        ENDIF
+#endif /* ALLOW_AUTODIFF */
+       ENDIF
+#endif
+
+#ifdef READ_PAR
+       IF ( dic_parFile .NE. ' '  ) THEN
+        CALL EXF_SET_FLD(
+     &     'dicPAR', dic_parFile, dic_parMask,
+     &     dic_parStartTime, dic_parPeriod, dic_parRepCycle,
+     &     dic_inscal_par,
+     &     dic_par_exfremo_intercept, dic_par_exfremo_slope,
+     &     PAR, PAR0, PAR1,
+# ifdef USE_EXF_INTERPOLATION
+     &     par_lon0, par_lon_inc,
+     &     par_lat0, par_lat_inc,
+     &     par_nlon, par_nlat, xC, yC,
+     &     par_interpMethod,
+# endif
+     &     mytime, myiter, mythid )
+       ENDIF
+#endif /* READ_PAR */
+
+#ifdef ALLOW_FE
+       IF ( dic_ironFile .NE. ' '  ) THEN
+        CALL EXF_SET_FLD(
+     &     'InputFe', dic_ironFile, dic_ironMask,
+     &     dic_ironStartTime, dic_ironPeriod, dic_ironRepCycle,
+     &     dic_inscal_iron,
+     &     dic_iron_exfremo_intercept, dic_iron_exfremo_slope,
+     &     InputFe, feinput0, feinput1,
+# ifdef USE_EXF_INTERPOLATION
+     &     iron_lon0, iron_lon_inc,
+     &     iron_lat0, iron_lat_inc,
+     &     iron_nlon, iron_nlat, xC, yC,
+     &     iron_interpMethod,
+# endif
+     &     mytime, myiter, mythid )
+       ENDIF
+#endif /* ALLOW_FE */
+
+       IF ( dic_atmospCO2file .NE. ' '  ) THEN
+        CALL EXF_SET_FLD(
+     &     'dicAtmosCO2', dic_atmospCO2file, dic_atmospCO2mask,
+     &     dic_atmospCO2StartTime, dic_atmospCO2Period, 
+     &     dic_atmospCO2RepCycle, dic_inscal_atmospCO2,
+     &     dic_atmospCO2_exfremo_intercept, 
+     &     dic_atmospCO2_exfremo_slope,
+     &     AtmospCO2, AtmospCO20, AtmospCO21,
+# ifdef USE_EXF_INTERPOLATION
+     &     atmospCO2_lon0, atmospCO2_lon_inc,
+     &     atmospCO2_lat0, atmospCO2_lat_inc,
+     &     atmospCO2_nlon, atmospCO2_nlat, xC, yC,
+     &     atmospCO2_interpMethod,
+# endif
+     &     mytime, myiter, mythid )
+       ENDIF
+
+       IF ( dic_IceFile .NE. ' ' ) THEN
+C     forcing load fields with pkg/exf tools
+        CALL EXF_SET_FLD(
+     &     'dicIce', dic_iceFile, dic_iceMask,
+     &     dic_iceStartTime, dic_icePeriod, dic_iceRepCycle,
+     &     dic_inscal_ice,
+     &     dic_ice_exfremo_intercept, dic_ice_exfremo_slope,
+     &     fIce, Ice0, Ice1,
+# ifdef USE_EXF_INTERPOLATION
+     &     ice_lon0, ice_lon_inc,
+     &     ice_lat0, ice_lat_inc,
+     &     ice_nlon, ice_nlat, xC, yC,
+     &     ice_interpMethod,
+# endif
+     &     mytime, myiter, mythid )
+#ifdef EXF_SEAICE_FRACTION
+C Otherwise get sea ice fraction from PKG/EXF
+       ELSEIF ( areamaskfile .NE. ' ' ) THEN
+        DO bj = myByLo(myThid), myByHi(myThid)
+         DO bi = myBxLo(myThid), myBxHi(myThid)
+          DO j=1-OLy,sNy+OLy
+           DO i=1-OLx,sNx+OLx
+            fIce(i,j,bi,bj) = areamask(i,j,bi,bj)
+           ENDDO
+          ENDDO
+         ENDDO
+        ENDDO
+#endif /* EXF_SEAICE_FRACTION */
+       ENDIF
+
+#ifdef LIGHT_CHL
+       IF ( dic_chlaFile .NE. ' ' ) THEN
+C     forcing load fields with pkg/exf tools
+        CALL EXF_SET_FLD(
+     &     'dicChl', dic_chlfile, dic_chlmask,
+     &     dic_chlStartTime, dic_chlperiod,
+     &     dic_chlRepCycle,
+     &     dic_inscal_chl,
+     &     dic_chl_exfremo_intercept,
+     &     dic_chl_exfremo_slope,
+     &     chl, chl0, chl1,
+# ifdef USE_EXF_INTERPOLATION
+     &     chl_lon0, chl_lon_inc,
+     &     chl_lat0, chl_lat_inc,
+     &     chl_nlon, chl_nlat, xC, yC,
+     &     chl_interpMethod,
+# endif
+     &     mytime, myiter, mythid )
+       ENDIF
+#endif /* LIGHT_CHL */
+
+       IF ( dic_SSTFile .NE. ' ' ) THEN
+C     forcing load fields with pkg/exf tools
+        CALL EXF_SET_FLD(
+     &     'dicSST', dic_SSTfile, dic_SSTmask,
+     &     dic_SSTStartTime, dic_SSTPeriod, dic_SSTRepCycle,
+     &     dic_inscal_SST,
+     &     dic_SST_exfremo_intercept, dic_SST_exfremo_slope,
+     &     dicSST, dicSST0, dicSST1,
+# ifdef USE_EXF_INTERPOLATION
+     &     SST_lon0, SST_lon_inc,
+     &     SST_lat0, SST_lat_inc,
+     &     SST_nlon, SST_nlat, xC, yC,
+     &     SST_interpMethod,
+# endif
+     &     mytime, myiter, mythid )
+       ENDIF
+
+       IF ( dic_SSSFile .NE. ' ' ) THEN
+C     forcing load fields with pkg/exf tools
+        CALL EXF_SET_FLD(
+     &     'dicSSS', dic_SSSfile, dic_SSSmask,
+     &     dic_SSSStartTime, dic_SSSPeriod, dic_SSSRepCycle,
+     &     dic_inscal_SSS,
+     &     dic_SSS_exfremo_intercept, dic_SSS_exfremo_slope,
+     &     dicSSS, dicSSS0, dicSSS1,
+# ifdef USE_EXF_INTERPOLATION
+     &     SSS_lon0, SSS_lon_inc,
+     &     SSS_lat0, SSS_lat_inc,
+     &     SSS_nlon, SSS_nlat, xC, yC,
+     &     SSS_interpMethod,
+# endif
+     &     mytime, myiter, mythid )
+       ENDIF
+C     endif dic_useEXF
+      ENDIF
+#endif /* ALLOW_EXF */
 #endif /* ALLOW_DIC */
       RETURN
       END

--- a/pkg/dic/dic_fields_load.F
+++ b/pkg/dic/dic_fields_load.F
@@ -19,6 +19,7 @@ C !USES: ===============================================================
 #include "DIC_VARS.h"
 #include "DIC_LOAD.h"
 #ifdef ALLOW_EXF
+# include "DYNVARS.h"
 # include "EXF_PARAM.h"
 # include "EXF_FIELDS.h"
 # include "DIC_EXF.h"
@@ -346,7 +347,7 @@ C If a pressure files is given in data.dic, read it
 # endif
      &     mytime, myiter, mythid )
 C Otherwise get atmospheric pressure from PKG/EXF
-       ELSEIF ( useEXF .AND. dic_atmospFile .NE. ' ' ) THEN
+       ELSEIF ( useEXF .AND. apressurefile .NE. ' ' ) THEN
         DO bj = myByLo(myThid), myByHi(myThid)
          DO bi = myBxLo(myThid), myBxHi(myThid)
           DO j=1-OLy,sNy+OLy
@@ -478,7 +479,7 @@ C     forcing load fields with pkg/exf tools
      &     mytime, myiter, mythid )
 #ifdef EXF_SEAICE_FRACTION
 C Otherwise get sea ice fraction from PKG/EXF
-       ELSEIF ( areamaskfile .NE. ' ' ) THEN
+       ELSEIF ( useEXF .AND. areamaskfile .NE. ' ' ) THEN
         DO bj = myByLo(myThid), myByHi(myThid)
          DO bi = myBxLo(myThid), myBxHi(myThid)
           DO j=1-OLy,sNy+OLy
@@ -527,6 +528,18 @@ C     forcing load fields with pkg/exf tools
      &     SST_interpMethod,
 # endif
      &     mytime, myiter, mythid )
+       ELSE
+C If there is no SST file given in data.dic, get fields from
+C  the main model.
+        DO bj = myByLo(myThid), myByHi(myThid)
+         DO bi = myBxLo(myThid), myBxHi(myThid)
+          DO j=1-OLy,sNy+OLy
+           DO i=1-OLx,sNx+OLx
+            dicSST(i,j,bi,bj) = theta(i,j,1,bi,bj)
+           ENDDO
+          ENDDO
+         ENDDO
+        ENDDO
        ENDIF
 
        IF ( dic_SSSFile .NE. ' ' ) THEN
@@ -544,6 +557,18 @@ C     forcing load fields with pkg/exf tools
      &     SSS_interpMethod,
 # endif
      &     mytime, myiter, mythid )
+       ELSE
+C If there is no SSS file given in data.dic, get fields from
+C  the main model.
+        DO bj = myByLo(myThid), myByHi(myThid)
+         DO bi = myBxLo(myThid), myBxHi(myThid)
+          DO j=1-OLy,sNy+OLy
+           DO i=1-OLx,sNx+OLx
+            dicSSS(i,j,bi,bj) = salt(i,j,1,bi,bj)
+           ENDDO
+          ENDDO
+         ENDDO
+        ENDDO          
        ENDIF
 C     endif dic_useEXF
       ENDIF

--- a/pkg/dic/dic_fields_load.F
+++ b/pkg/dic/dic_fields_load.F
@@ -529,18 +529,6 @@ C     forcing load fields with pkg/exf tools
      &     SST_interpMethod,
 # endif
      &     mytime, myiter, mythid )
-       ELSE
-C If there is no SST file given in data.dic, get fields from
-C  the main model.
-        DO bj = myByLo(myThid), myByHi(myThid)
-         DO bi = myBxLo(myThid), myBxHi(myThid)
-          DO j=1-OLy,sNy+OLy
-           DO i=1-OLx,sNx+OLx
-            dicSST(i,j,bi,bj) = theta(i,j,1,bi,bj)
-           ENDDO
-          ENDDO
-         ENDDO
-        ENDDO
        ENDIF
 
        IF ( dic_SSSFile .NE. ' ' ) THEN
@@ -557,19 +545,7 @@ C     forcing load fields with pkg/exf tools
      &     SSS_nlon, SSS_nlat, xC, yC,
      &     SSS_interpMethod,
 # endif
-     &     mytime, myiter, mythid )
-       ELSE
-C If there is no SSS file given in data.dic, get fields from
-C  the main model.
-        DO bj = myByLo(myThid), myByHi(myThid)
-         DO bi = myBxLo(myThid), myBxHi(myThid)
-          DO j=1-OLy,sNy+OLy
-           DO i=1-OLx,sNx+OLx
-            dicSSS(i,j,bi,bj) = salt(i,j,1,bi,bj)
-           ENDDO
-          ENDDO
-         ENDDO
-        ENDDO          
+     &     mytime, myiter, mythid )         
        ENDIF
 C     endif dic_useEXF
       ENDIF

--- a/pkg/dic/dic_fields_update.F
+++ b/pkg/dic/dic_fields_update.F
@@ -16,6 +16,7 @@ C !USES: ===============================================================
 #include "SIZE.h"
 #include "EEPARAMS.h"
 #include "PARAMS.h"
+#include "DYNVARS.h"
 #include "DIC_VARS.h"
 #ifdef ALLOW_THSICE
 # include "THSICE_VARS.h"
@@ -34,7 +35,7 @@ C     bi, bj       :: tile indices
 C     myTime       :: Current time in simulation
 C     myIter       :: Current timestep number
 C     myThid       :: my Thread Id number
-      INTEGER bi, bj
+      INTEGER bi, bj, k
       _RL myTime
       INTEGER myIter
       INTEGER myThid
@@ -42,9 +43,9 @@ C     myThid       :: my Thread Id number
 #ifdef ALLOW_DIC
 
 c !LOCAL VARIABLES: ===================================================
-#if defined(ALLOW_THSICE) || defined(ALLOW_SEAICE) || defined(COMPONENT_MODULE)
+C#if defined(ALLOW_THSICE) || defined(ALLOW_SEAICE) || defined(COMPONENT_MODULE)
       INTEGER i, j
-#endif
+C#endif
 c     CHARACTER*(MAX_LEN_MBUF) msgBuf
 CEOP
 
@@ -95,6 +96,17 @@ CEOP
         ENDIF
 #endif /* ALLOW_OCN_COMPON_INTERF */
 
+      IF ( .NOT. dic_useEXF ) THEN
+C  Get SST, SSS and ice fraction from the main model        
+        k = 1
+
+        DO j=1-OLy,sNy+OLy
+         DO i=1-OLx,sNx+OLx
+          dicSST(i,j,bi,bj) = theta(i,j,k,bi,bj)
+          dicSSS(i,j,bi,bj) = salt (i,j,k,bi,bj)
+         ENDDO
+        ENDDO
+      ENDIF /* NOT dic_useEXF */
 #endif /* ALLOW_DIC */
       RETURN
       END

--- a/pkg/dic/dic_fields_update.F
+++ b/pkg/dic/dic_fields_update.F
@@ -35,7 +35,7 @@ C     bi, bj       :: tile indices
 C     myTime       :: Current time in simulation
 C     myIter       :: Current timestep number
 C     myThid       :: my Thread Id number
-      INTEGER bi, bj, k
+      INTEGER bi, bj
       _RL myTime
       INTEGER myIter
       INTEGER myThid
@@ -44,7 +44,7 @@ C     myThid       :: my Thread Id number
 
 c !LOCAL VARIABLES: ===================================================
 C#if defined(ALLOW_THSICE) || defined(ALLOW_SEAICE) || defined(COMPONENT_MODULE)
-      INTEGER i, j
+      INTEGER i, j, k
 C#endif
 c     CHARACTER*(MAX_LEN_MBUF) msgBuf
 CEOP
@@ -96,17 +96,22 @@ CEOP
         ENDIF
 #endif /* ALLOW_OCN_COMPON_INTERF */
 
-      IF ( .NOT. dic_useEXF ) THEN
-C  Get SST, SSS and ice fraction from the main model        
+C  Get SST, SSS and ice fraction from the main model if not supplied      
         k = 1
-
-        DO j=1-OLy,sNy+OLy
-         DO i=1-OLx,sNx+OLx
-          dicSST(i,j,bi,bj) = theta(i,j,k,bi,bj)
-          dicSSS(i,j,bi,bj) = salt (i,j,k,bi,bj)
-         ENDDO
-        ENDDO
-      ENDIF /* NOT dic_useEXF */
+        IF ( dic_SSTFile .EQ. ' ' ) THEN
+          DO j=1-OLy,sNy+OLy
+           DO i=1-OLx,sNx+OLx
+            dicSST(i,j,bi,bj) = theta(i,j,k,bi,bj)
+           ENDDO
+          ENDDO
+        ENDIF
+        IF ( dic_SSSFile .EQ. ' ' ) THEN
+          DO j=1-OLy,sNy+OLy
+           DO i=1-OLx,sNx+OLx
+            dicSSS(i,j,bi,bj) = salt(i,j,k,bi,bj)
+           ENDDO
+          ENDDO
+        ENDIF
 #endif /* ALLOW_DIC */
       RETURN
       END

--- a/pkg/dic/dic_fields_update.F
+++ b/pkg/dic/dic_fields_update.F
@@ -49,7 +49,7 @@ C#endif
 c     CHARACTER*(MAX_LEN_MBUF) msgBuf
 CEOP
 
-        IF ( useThSIce ) THEN
+        IF ( useThSIce .AND. dic_iceFile .EQ. ' ' ) THEN
 #ifdef ALLOW_THSICE
           DO j=1-OLy,sNy+OLy
            DO i=1-OLx,sNx+OLx
@@ -57,7 +57,7 @@ CEOP
            ENDDO
           ENDDO
 #endif /* ALLOW_THSICE */
-        ELSEIF ( useSEAICE ) THEN
+        ELSEIF ( useSEAICE .AND. dic_iceFile .EQ. ' ' ) THEN
 #ifdef ALLOW_SEAICE
           DO j=1-OLy,sNy+OLy
            DO i=1-OLx,sNx+OLx
@@ -67,7 +67,7 @@ CEOP
 #endif /* ALLOW_SEAICE */
         ELSEIF ( useCoupler ) THEN
 #ifdef ALLOW_OCN_COMPON_INTERF
-         IF ( useImportFice ) THEN
+         IF ( useImportFice .AND. dic_iceFile .EQ. ' ' ) THEN
            DO j=1-OLy,sNy+OLy
             DO i=1-OLx,sNx+OLx
              fIce(i,j,bi,bj) = sIceFrac_cpl(i,j,bi,bj)
@@ -79,14 +79,14 @@ CEOP
 
 #ifdef ALLOW_OCN_COMPON_INTERF
         IF ( useCoupler ) THEN
-         IF ( useImportCO2 ) THEN
+         IF ( useImportCO2 .AND. dic_atmospCO2File .EQ. ' ' ) THEN
            DO j=1-OLy,sNy+OLy
             DO i=1-OLx,sNx+OLx
              AtmospCO2(i,j,bi,bj) = airCO2(i,j,bi,bj)
             ENDDO
            ENDDO
          ENDIF
-         IF ( useImportWSpd ) THEN
+         IF ( useImportWSpd .AND. dic_windFile .EQ. ' ' ) THEN
            DO j=1-OLy,sNy+OLy
             DO i=1-OLx,sNx+OLx
              wind(i,j,bi,bj) = surfWSpeed(i,j,bi,bj)

--- a/pkg/dic/dic_ini_forcing.F
+++ b/pkg/dic/dic_ini_forcing.F
@@ -256,6 +256,7 @@ c     &     mythid )
      &     SilicaSurf_interpMethod,
 # endif
      &     myLocTime, nIter0, mythid )
+        _EXCH_XY_RL( SilicaSurf, myThid )
        ENDIF
 
 #ifdef DIC_3D_SILICA
@@ -276,6 +277,7 @@ c     &     mythid )
      &      SilicaDeep_nzin, SilicaDeep_dzin,
 # endif
      &      myLocTime, nIter0, mythid )
+        _EXCH_XYZ_RL( SilicaDeep, myThid )
        ENDIF
 #endif /* DIC_3D_SILICA */
 
@@ -295,6 +297,7 @@ C    the first timestep to initialize pH/pCO2
      &     SST_interpMethod,
 # endif
      &     myLocTime, nIter0, mythid )
+        _EXCH_XY_RL( dicSST, myThid )
        ENDIF
        
        IF ( dic_SSSFile .NE. ' ' ) THEN
@@ -311,6 +314,7 @@ C    the first timestep to initialize pH/pCO2
      &     SSS_interpMethod,
 # endif
      &     myLocTime, nIter0, mythid )
+        _EXCH_XY_RL( dicSSS, myThid )
        ENDIF
 
        IF ( dic_WindFile .NE. ' ' ) THEN
@@ -325,6 +329,7 @@ C    the first timestep to initialize pH/pCO2
      &     wind_interpMethod,
 # endif
      &     mythid )
+        _EXCH_XY_RL( Wind, myThid )
        ENDIF
 
 #ifndef USE_PLOAD
@@ -340,6 +345,7 @@ C    the first timestep to initialize pH/pCO2
      &     atmosp_interpMethod,
 # endif
      &     mythid )
+        _EXCH_XY_RL( AtmosP, myThid )
        ENDIF
 #endif /* USE_PLOAD */
 
@@ -355,6 +361,7 @@ C    the first timestep to initialize pH/pCO2
      &     ice_interpMethod,
 # endif
      &     mythid )
+        _EXCH_XY_RL( fIce, myThid )
        ENDIF
 
 #ifdef READ_PAR
@@ -370,6 +377,7 @@ C    the first timestep to initialize pH/pCO2
      &     par_interpMethod,
 # endif
      &     mythid )
+        _EXCH_XY_RL( PAR, myThid )
        ENDIF
 #endif /* READ_PAR */
 
@@ -386,6 +394,7 @@ C    the first timestep to initialize pH/pCO2
      &     iron_interpMethod,
 # endif
      &     mythid )
+        _EXCH_XY_RL( inputFe, myThid )
        ENDIF
 #endif /* ALLOW_FE */
 
@@ -402,6 +411,7 @@ C    the first timestep to initialize pH/pCO2
      &     atmospCO2_interpMethod,
 # endif
      &     mythid )
+        _EXCH_XY_RL( atmospCO2, myThid )
        ENDIF
 
 #ifdef LIGHT_CHL
@@ -417,6 +427,7 @@ C    the first timestep to initialize pH/pCO2
      &     chl_interpMethod,
 # endif
      &     mythid )
+        _EXCH_XY_RL( CHL, myThid )
        ENDIF
 #endif /* LIGHT_CHL */
 C     dic_useEXF

--- a/pkg/dic/dic_ini_forcing.F
+++ b/pkg/dic/dic_ini_forcing.F
@@ -222,7 +222,7 @@ C     if not dic_useEXF
 
 #ifdef ALLOW_EXF
       IF ( dic_useEXF ) THEN
-
+       myLocTime = startTime + deltaTClock*nIter0
        IF ( dic_SilicaFile .NE. ' ' ) THEN
 C     This would be the exf-way to initialise a forcing field: just use
 C     a constant value. But, because in pkg/dic
@@ -242,7 +242,6 @@ c     &     SilicaSurf_nlon, SilicaSurf_nlat, xC, yC,
 c     &     SilicaSurf_interpMethod,
 c#endif
 c     &     mythid )
-        myLocTime = startTime + deltaTClock*nIter0
         CALL EXF_SET_FLD(
      &     'dicSilicaSurf', dic_SilicaFile, dic_SilicaSurfMask,
      &     dic_SilicaSurfStartTime, dic_SilicaSurfPeriod, 
@@ -260,7 +259,6 @@ c     &     mythid )
        ENDIF
 
 #ifdef DIC_3D_SILICA
-       myLocTime = startTime + deltaTClock*nIter0
        IF ( dic_SilicaDeepFile .NE. ' ' ) THEN
          CALL EXF_SET_FLD3D(
      &      'dicSilicaDeep', dic_SilicaDeepFile, dic_SilicaDeepMask,
@@ -284,7 +282,6 @@ c     &     mythid )
 C    Do the same for SST and SSS, which are also used before 
 C    the first timestep to initialize pH/pCO2
        IF ( dic_SSTFile .NE. ' ' ) THEN
-        myLocTime = startTime + deltaTClock*nIter0
         CALL EXF_SET_FLD(
      &     'dicSST', dic_SSTFile, dic_SSTMask,
      &     dic_SSTStartTime, dic_SSTPeriod, dic_SSTRepCycle,
@@ -301,7 +298,6 @@ C    the first timestep to initialize pH/pCO2
        ENDIF
        
        IF ( dic_SSSFile .NE. ' ' ) THEN
-        myLocTime = startTime + deltaTClock*nIter0
         CALL EXF_SET_FLD(
      &     'dicSSS', dic_SSSFile, dic_SSSMask,
      &     dic_SSSStartTime, dic_SSSPeriod, dic_SSSRepCycle,

--- a/pkg/dic/dic_ini_forcing.F
+++ b/pkg/dic/dic_ini_forcing.F
@@ -117,30 +117,30 @@ C--   Set reasonable values to those that need at least something
        DO bi = myBxLo(myThid), myBxHi(myThid)
          DO j=1-OLy,sNy+OLy
           DO i=1-OLx,sNx+OLx
-            wind(i,j,bi,bj)       = dic_wind_const
+           wind(i,j,bi,bj)       = dic_wind_const
      &                                  *maskC(i,j,1,bi,bj)
-            AtmosP(i,j,bi,bj)     = dic_atmosp_const/Pa2Atm
+           AtmosP(i,j,bi,bj)     = dic_atmosp_const/Pa2Atm
      &                                  *maskC(i,j,1,bi,bj)
-            silicaSurf(i,j,bi,bj) = dic_silicaSurf_const
+           silicaSurf(i,j,bi,bj) = dic_silicaSurf_const
      &                                  *maskC(i,j,1,bi,bj)
-            fIce(i,j,bi,bj)       = dic_ice_const
+           fIce(i,j,bi,bj)       = dic_ice_const
      &                                  *maskC(i,j,1,bi,bj)
 #ifdef READ_PAR
-            par(i,j,bi,bj)        = dic_par_const
+           par(i,j,bi,bj)        = dic_par_const
      &                                  *maskC(i,j,1,bi,bj)
 #endif
 #ifdef LIGHT_CHL
 C If the chlorophyll climatology is not provided, use this default value.
-            CHL(i,j,bi,bj)        = dic_chl_const
+           CHL(i,j,bi,bj)        = dic_chl_const
      &                                  *maskC(i,j,1,bi,bj)
 #endif
 #ifdef ALLOW_FE
-            InputFe(i,j,bi,bj)    = dic_iron_const
+           InputFe(i,j,bi,bj)    = dic_iron_const
      &                                  *maskC(i,j,1,bi,bj)
 #endif
-           dicSST(i,j,bi,bj)      = dic_SST_const
+           dicSST(i,j,bi,bj)     = dic_SST_const
      &                                  *maskC(i,j,1,bi,bj)
-           dicSSS(i,j,bi,bj)       = dic_SSS_const
+           dicSSS(i,j,bi,bj)     = dic_SSS_const
      &                                  *maskC(i,j,1,bi,bj)
           ENDDO
          ENDDO
@@ -149,7 +149,7 @@ C If the chlorophyll climatology is not provided, use this default value.
           DO k=1,Nr
            DO j=1-OLy,sNy+OLy
             DO i=1-OLx,sNx+OLx
-              silicaDeep(i,j,k,bi,bj) = dic_silicaDeep_const
+             silicaDeep(i,j,k,bi,bj) = dic_silicaDeep_const
      &                                  *maskC(i,j,k,bi,bj)
             ENDDO
            ENDDO
@@ -409,7 +409,7 @@ C    the first timestep to initialize pH/pCO2
         CALL EXF_INIT_FLD (
      &     'dicCHL', dic_chlaFile, dic_chlMask,
      &     dic_chlPeriod, dic_inscal_chl, dic_chl_const,
-     &     dicchl, dicchl0, dicchl1,
+     &     CHL, dicchl0, dicchl1,
 # ifdef USE_EXF_INTERPOLATION
      &     chl_lon0, chl_lon_inc,
      &     chl_lat0, chl_lat_inc,
@@ -422,6 +422,7 @@ C    the first timestep to initialize pH/pCO2
 C     dic_useEXF
       ENDIF
 # endif /* ALLOW_EXF */
+
 C If there is no SST file given in data.dic, get fields from
 C  the main model so we can initialize pH/pCO2 correctly.
       IF ( dic_SSTFile .EQ. ' ' ) THEN
@@ -434,8 +435,8 @@ C  the main model so we can initialize pH/pCO2 correctly.
           ENDDO
          ENDDO
         ENDDO
+      _EXCH_XY_RL( dicSST, myThid )
       ENDIF
-
 C If there is no SSS file given in data.dic, get fields from
 C  the main model so we can initialize pH/pCO2 correctly.
       IF ( dic_SSSFile .EQ. ' ' ) THEN
@@ -448,6 +449,7 @@ C  the main model so we can initialize pH/pCO2 correctly.
           ENDDO
          ENDDO
         ENDDO
+        _EXCH_XY_RL( dicSSS, myThid )
       ENDIF
 #endif /* ALLOW_DIC */
       RETURN

--- a/pkg/dic/dic_ini_forcing.F
+++ b/pkg/dic/dic_ini_forcing.F
@@ -60,6 +60,8 @@ C-    Initialise DIC_VARS.h forcing-field arrays:
            CHL       (i,j,bi,bj) = 0. _d 0
            InputFe   (i,j,bi,bj) = 0. _d 0
 #endif
+           dicSST    (i,j,bi,bj) = 0. _d 0
+           dicSSS    (i,j,bi,bj) = 0. _d 0
          ENDDO
         ENDDO
 #ifdef DIC_CALCITE_SAT
@@ -139,6 +141,10 @@ C If the chlorophyll climatology is not provided, use this default value.
             InputFe(i,j,bi,bj)    = dic_iron_const
      &                                  *maskC(i,j,1,bi,bj)
 #endif
+           dicSST(i,j,bi,bj)      = dic_SST_const
+     &                                  *maskC(i,j,1,bi,bj)
+           dicSSS(i,j,bi,bj)       = dic_SSS_const
+     &                                  *maskC(i,j,1,bi,bj)
           ENDDO
          ENDDO
 #ifdef DIC_CALCITE_SAT
@@ -488,7 +494,6 @@ C    the first timestep to initialize pH/pCO2
 C     dic_useEXF
       ENDIF
 # endif /* ALLOW_EXF */
-
 C If there is no SST file given in data.dic, get fields from
 C  the main model so we can initialize pH/pCO2 correctly.
       IF ( dic_SSTFile .EQ. ' ' ) THEN

--- a/pkg/dic/dic_ini_forcing.F
+++ b/pkg/dic/dic_ini_forcing.F
@@ -16,9 +16,18 @@ C !USES: ===============================================================
 #include "EEPARAMS.h"
 #include "PARAMS.h"
 #include "GRID.h"
+#include "DYNVARS.h"
 #include "DIC_VARS.h"
 #include "DIC_LOAD.h"
-
+#ifdef ALLOW_EXF
+# include "EXF_PARAM.h"
+# include "EXF_FIELDS.h"
+# include "DIC_EXF.h"
+# ifdef USE_EXF_INTERPOLATION
+#  include "EXF_INTERP_SIZE.h"
+#  include "DIC_INTERP_PARAM.h"
+# endif
+#endif
 C !INPUT PARAMETERS: ===================================================
 C  myThid               :: thread number
       INTEGER myThid
@@ -29,11 +38,12 @@ CEOP
 c !LOCAL VARIABLES: ====================================================
        INTEGER bi, bj, i, j
        INTEGER intimeP, intime0, intime1
-       _RL aWght, bWght
+       _RL aWght, bWght, myLocTime
 #ifdef DIC_CALCITE_SAT
       INTEGER k
 #endif
 
+      IF ( .NOT. dic_useEXF ) THEN
 C--   Initialise forcing arrays in common blocks
       DO bj = myByLo(myThid), myByHi(myThid)
        DO bi = myBxLo(myThid), myBxHi(myThid)
@@ -189,8 +199,8 @@ c#endif
 #endif /* DIC_BIOTIC */
 #ifdef DIC_CALCITE_SAT
        IF ( useCalciteSaturation .AND.
-     &      DIC_deepSilicaFile .NE. ' '  ) THEN
-         CALL READ_REC_XYZ_RL( DIC_deepSilicaFile, silicaDeep,
+     &      DIC_silicaDeepFile .NE. ' '  ) THEN
+         CALL READ_REC_XYZ_RL( DIC_silicaDeepFile, silicaDeep,
      &                        1, nIter0, myThid )
          _EXCH_XYZ_RL( silicaDeep, myThid )
        ENDIF
@@ -237,12 +247,12 @@ C-    If file provided for surface silicate, read it in
          ENDDO
 #ifndef ALLOW_AUTODIFF
 #ifdef DIC_CALCITE_SAT
-       ELSEIF ( DIC_deepSilicaFile .NE. ' '  ) THEN
+       ELSEIF ( DIC_silicaDeepFile .NE. ' '  ) THEN
 C-    If no surface silicate file but deep (3d) silicate provided, use top level
          k = 1
-         CALL READ_REC_XYZ_RS( DIC_deepSilicaFile, silicaDeep0,
+         CALL READ_REC_XYZ_RS( DIC_silicaDeepFile, silicaDeep0,
      &                         intime0, nIter0, myThid )
-         CALL READ_REC_XYZ_RS( DIC_deepSilicaFile, silicaDeep1,
+         CALL READ_REC_XYZ_RS( DIC_silicaDeepFile, silicaDeep1,
      &                         intime1, nIter0, myThid )
          DO bj = myByLo(myThid), myByHi(myThid)
           DO bi = myBxLo(myThid), myBxHi(myThid)
@@ -261,7 +271,243 @@ C-    If no surface silicate file but deep (3d) silicate provided, use top level
 
 C end if DIC_forcingCycle > 0
       ENDIF
+C     if not dic_useEXF
+      ENDIF
 
+#ifdef ALLOW_EXF
+      IF ( dic_useEXF ) THEN
+
+       IF ( dic_SilicaFile .NE. ' ' ) THEN
+C     This would be the exf-way to initialise a forcing field: just use
+C     a constant value. But, because in pkg/dic
+C     silica is already used before the first timestep (to initialize 
+C     pH/pCO2) and before dic_fields_load is called, silica needs 
+C     to have the correct value with respect to the current timestep 
+C     (nIter0) and myTime (startTime + deltaTClock*nIter0). Therefore, 
+C     we do not call exf_init_fld but exf_set_fld instead.
+c        CALL EXF_INIT_FLD (
+c     &     'dicSilicaSurf', dic_SilicaSurfFile, dic_SilicaSurfMask,
+c     &     dic_SilicaSurfPeriod, dic_inscal_SilicaSurf, dic_SilicaSurf_const,
+c     &     SilicaSurf, SilicaSurf0, SilicaSurf1,
+c#ifdef USE_EXF_INTERPOLATION
+c     &     SilicaSurf_lon0, SilicaSurf_lon_inc,
+c     &     SilicaSurf_lat0, SilicaSurf_lat_inc,
+c     &     SilicaSurf_nlon, SilicaSurf_nlat, xC, yC,
+c     &     SilicaSurf_interpMethod,
+c#endif
+c     &     mythid )
+        myLocTime = startTime + deltaTClock*nIter0
+        CALL EXF_SET_FLD(
+     &     'dicSilicaSurf', dic_SilicaFile, dic_SilicaSurfMask,
+     &     dic_SilicaSurfStartTime, dic_SilicaSurfPeriod, 
+     &     dic_SilicaSurfRepCycle,dic_inscal_SilicaSurf,
+     &     dic_SilicaSurf_exfremo_intercept, 
+     &     dic_SilicaSurf_exfremo_slope,
+     &     SilicaSurf, SilicaSurf0, SilicaSurf1,
+# ifdef USE_EXF_INTERPOLATION
+     &     SilicaSurf_lon0, SilicaSurf_lon_inc,
+     &     SilicaSurf_lat0, SilicaSurf_lat_inc,
+     &     SilicaSurf_nlon, SilicaSurf_nlat, xC, yC,
+     &     SilicaSurf_interpMethod,
+# endif
+     &     myLocTime, nIter0, mythid )
+       ENDIF
+
+#ifdef DIC_3D_SILICA
+       myLocTime = startTime + deltaTClock*nIter0
+       IF ( dic_SilicaDeepFile .NE. ' ' ) THEN
+         CALL EXF_SET_FLD3D(
+     &      'dicSilicaDeep', dic_SilicaDeepFile, dic_SilicaDeepMask,
+     &      dic_SilicaDeepStartTime, dic_SilicaDeepPeriod, 
+     &      dic_SilicaDeepRepCycle,
+     &      dic_inscal_SilicaDeep,
+     &      dic_SilicaDeep_exfremo_intercept, 
+     &      dic_SilicaDeep_exfremo_slope,
+     &      SilicaDeep, SilicaDeep0, SilicaDeep1,
+# ifdef USE_EXF_INTERPOLATION
+     &      SilicaDeep_lon0, SilicaDeep_lon_inc,
+     &      SilicaDeep_lat0, SilicaDeep_lat_inc,
+     &      SilicaDeep_nlon, SilicaDeep_nlat, xC, yC,
+     &      SilicaDeep_interpMethod,
+     &      SilicaDeep_nzin, SilicaDeep_dzin,
+# endif
+     &      myLocTime, nIter0, mythid )
+       ENDIF
+#endif /* DIC_3D_SILICA */
+
+C    Do the same for SST and SSS, which are also used before 
+C    the first timestep to initialize pH/pCO2
+       IF ( dic_SSTFile .NE. ' ' ) THEN
+        myLocTime = startTime + deltaTClock*nIter0
+        CALL EXF_SET_FLD(
+     &     'dicSST', dic_SSTFile, dic_SSTMask,
+     &     dic_SSTStartTime, dic_SSTPeriod, dic_SSTRepCycle,
+     &     dic_inscal_SST,
+     &     dic_SST_exfremo_intercept, dic_SST_exfremo_slope,
+     &     dicSST, dicSST0, dicSST1,
+# ifdef USE_EXF_INTERPOLATION
+     &     SST_lon0, SST_lon_inc,
+     &     SST_lat0, SST_lat_inc,
+     &     SST_nlon, SST_nlat, xC, yC,
+     &     SST_interpMethod,
+# endif
+     &     myLocTime, nIter0, mythid )
+       ENDIF
+       
+       IF ( dic_SSSFile .NE. ' ' ) THEN
+        myLocTime = startTime + deltaTClock*nIter0
+        CALL EXF_SET_FLD(
+     &     'dicSSS', dic_SSSFile, dic_SSSMask,
+     &     dic_SSSStartTime, dic_SSSPeriod, dic_SSSRepCycle,
+     &     dic_inscal_SSS,
+     &     dic_SSS_exfremo_intercept, dic_SSS_exfremo_slope,
+     &     dicSSS, dicSSS0, dicSSS1,
+# ifdef USE_EXF_INTERPOLATION
+     &     SSS_lon0, SSS_lon_inc,
+     &     SSS_lat0, SSS_lat_inc,
+     &     SSS_nlon, SSS_nlat, xC, yC,
+     &     SSS_interpMethod,
+# endif
+     &     myLocTime, nIter0, mythid )
+       ENDIF
+
+       IF ( dic_WindFile .NE. ' ' ) THEN
+        CALL EXF_INIT_FLD (
+     &     'dicWind', dic_WindFile, dic_WindMask,
+     &     dic_WindPeriod, dic_inscal_Wind, dic_wind_const,
+     &     Wind, dicWind0, dicWind1,
+# ifdef USE_EXF_INTERPOLATION
+     &     wind_lon0, wind_lon_inc,
+     &     wind_lat0, wind_lat_inc,
+     &     wind_nlon, wind_nlat, xC, yC,
+     &     wind_interpMethod,
+# endif
+     &     mythid )
+       ENDIF
+
+#ifndef USE_PLOAD
+       IF ( dic_atmospFile .NE. ' ' ) THEN
+        CALL EXF_INIT_FLD (
+     &     'dicAtmosP', dic_atmospFile, dic_atmospMask,
+     &     dic_atmospPeriod, dic_inscal_atmosp, dic_atmosp_const,
+     &     AtmosP, AtmosP0, AtmosP1,
+# ifdef USE_EXF_INTERPOLATION
+     &     atmosp_lon0, atmosp_lon_inc,
+     &     atmosp_lat0, atmosp_lat_inc,
+     &     atmosp_nlon, atmosp_nlat, xC, yC,
+     &     atmosp_interpMethod,
+# endif
+     &     mythid )
+       ENDIF
+#endif /* USE_PLOAD */
+
+       IF ( dic_iceFile .NE. ' ' ) THEN
+        CALL EXF_INIT_FLD (
+     &     'dicIce', dic_iceFile, dic_iceMask,
+     &     dic_icePeriod, dic_inscal_ice, dic_ice_const,
+     &     fIce, Ice0, Ice1,
+# ifdef USE_EXF_INTERPOLATION
+     &     ice_lon0, ice_lon_inc,
+     &     ice_lat0, ice_lat_inc,
+     &     ice_nlon, ice_nlat, xC, yC,
+     &     ice_interpMethod,
+# endif
+     &     mythid )
+       ENDIF
+
+#ifdef READ_PAR
+       IF ( dic_parFile .NE. ' ' ) THEN
+        CALL EXF_INIT_FLD (
+     &     'dicPAR', dic_parFile, dic_parMask,
+     &     dic_parPeriod, dic_inscal_par, dic_par_const,
+     &     PAR, PAR0, PAR1,
+# ifdef USE_EXF_INTERPOLATION
+     &     par_lon0, par_lon_inc,
+     &     par_lat0, par_lat_inc,
+     &     par_nlon, par_nlat, xC, yC,
+     &     par_interpMethod,
+# endif
+     &     mythid )
+       ENDIF
+#endif /* READ_PAR */
+
+#ifdef ALLOW_FE
+       IF ( dic_ironFile .NE. ' ' ) THEN
+        CALL EXF_INIT_FLD (
+     &     'dicIron', dic_ironFile, dic_ironMask,
+     &     dic_ironPeriod, dic_inscal_iron, dic_iron_const,
+     &     inputFe, feinput0, feinput1,
+# ifdef USE_EXF_INTERPOLATION
+     &     iron_lon0, iron_lon_inc,
+     &     iron_lat0, iron_lat_inc,
+     &     iron_nlon, iron_nlat, xC, yC,
+     &     iron_interpMethod,
+# endif
+     &     mythid )
+       ENDIF
+#endif /* ALLOW_FE */
+
+       IF ( dic_atmospCO2File .NE. ' ' ) THEN
+        CALL EXF_INIT_FLD (
+     &     'dicapCO2', dic_atmospCO2File, dic_atmospCO2Mask,
+     &     dic_atmospCO2Period, dic_inscal_atmospCO2, 
+     &     dic_atmospCO2_const,
+     &     atmospCO2, atmospCO20, atmospCO21,
+# ifdef USE_EXF_INTERPOLATION
+     &     atmospCO2_lon0, atmospCO2_lon_inc,
+     &     atmospCO2_lat0, atmospCO2_lat_inc,
+     &     atmospCO2_nlon, atmospCO2_nlat, xC, yC,
+     &     atmospCO2_interpMethod,
+# endif
+     &     mythid )
+       ENDIF
+
+#ifdef LIGHT_CHL
+       IF ( dic_chlaFile .NE. ' ' ) THEN
+        CALL EXF_INIT_FLD (
+     &     'dicCHL', dic_chlaFile, dic_chlMask,
+     &     dic_chlPeriod, dic_inscal_chl, dic_chl_const,
+     &     dicchl, dicchl0, dicchl1,
+# ifdef USE_EXF_INTERPOLATION
+     &     chl_lon0, chl_lon_inc,
+     &     chl_lat0, chl_lat_inc,
+     &     chl_nlon, chl_nlat, xC, yC,
+     &     chl_interpMethod,
+# endif
+     &     mythid )
+       ENDIF
+#endif /* LIGHT_CHL */
+C     dic_useEXF
+      ENDIF
+# endif /* ALLOW_EXF */
+
+C If there is no SST file given in data.dic, get fields from
+C  the main model so we can initialize pH/pCO2 correctly.
+      IF ( dic_SSTFile .EQ. ' ' ) THEN
+        DO bj = myByLo(myThid), myByHi(myThid)
+         DO bi = myBxLo(myThid), myBxHi(myThid)
+          DO j=1-OLy,sNy+OLy
+           DO i=1-OLx,sNx+OLx
+            dicSST(i,j,bi,bj) = theta(i,j,1,bi,bj)
+           ENDDO
+          ENDDO
+         ENDDO
+        ENDDO
+      ENDIF
+
+C If there is no SSS file given in data.dic, get fields from
+C  the main model so we can initialize pH/pCO2 correctly.
+      IF ( dic_SSSFile .EQ. ' ' ) THEN
+        DO bj = myByLo(myThid), myByHi(myThid)
+         DO bi = myBxLo(myThid), myBxHi(myThid)
+          DO j=1-OLy,sNy+OLy
+           DO i=1-OLx,sNx+OLx
+            dicSSS(i,j,bi,bj) = salt(i,j,1,bi,bj)
+           ENDDO
+          ENDDO
+         ENDDO
+        ENDDO
+      ENDIF
 #endif /* ALLOW_DIC */
       RETURN
       END

--- a/pkg/dic/dic_ini_forcing.F
+++ b/pkg/dic/dic_ini_forcing.F
@@ -43,11 +43,9 @@ c !LOCAL VARIABLES: ====================================================
       INTEGER k
 #endif
 
-      IF ( .NOT. dic_useEXF ) THEN
 C--   Initialise forcing arrays in common blocks
       DO bj = myByLo(myThid), myByHi(myThid)
        DO bi = myBxLo(myThid), myBxHi(myThid)
-
 C-    Initialise DIC_VARS.h forcing-field arrays:
         DO j=1-OLy,sNy+OLy
          DO i=1-OLx,sNx+OLx
@@ -114,7 +112,6 @@ C-   end bi,bj loops:
       ENDDO
 
 C ======================================================================
-
 C--   Set reasonable values to those that need at least something
       DO bj = myByLo(myThid), myByHi(myThid)
        DO bi = myBxLo(myThid), myBxHi(myThid)
@@ -164,7 +161,7 @@ C-    end bi,bj loops
       ENDDO
 
 C ======================================================================
-
+      IF ( .NOT. dic_useEXF ) THEN
 C--   Load constant forcing-file (used if DIC_forcingCycle=0 )
 c     IF ( DIC_forcingCycle .LE. zeroRL ) THEN
        IF ( DIC_windFile .NE. ' '  ) THEN
@@ -220,71 +217,6 @@ c#endif
        ENDIF
 #endif
 c     ENDIF
-
-C ======================================================================
-
-      IF ( DIC_forcingCycle .GT. zeroRL ) THEN
-C--   Load some initial forcing from file
-
-C-    Read in surface silica field (used to compute initial surf. pH)
-C     Note: For this purpose, might be accurate enough to use first record
-C           in silica file (already loaded) and skip all this block.
-
-C-    Get reccord number and weight for time interpolation:
-       CALL GET_PERIODIC_INTERVAL(
-     O                   intimeP, intime0, intime1, bWght, aWght,
-     I                   DIC_forcingCycle, DIC_forcingPeriod,
-     I                   deltaTClock, startTime, myThid )
-
-       _BARRIER
-       _BEGIN_MASTER(myThid)
-        WRITE(standardMessageUnit,'(A,I10,A,2(2I5,A))')
-     &   ' DIC_INI_FORCING, it=', nIter0,
-     &   ' : Reading new data, i0,i1=', intime0, intime1
-       _END_MASTER(myThid)
-
-       IF ( DIC_silicaFile .NE. ' '  ) THEN
-C-    If file provided for surface silicate, read it in
-         CALL READ_REC_XY_RS( DIC_silicaFile,silicaSurf0,intime0,
-     &        nIter0,myThid )
-         CALL READ_REC_XY_RS( DIC_silicaFile,silicaSurf1,intime1,
-     &        nIter0,myThid )
-         DO bj = myByLo(myThid), myByHi(myThid)
-          DO bi = myBxLo(myThid), myBxHi(myThid)
-           DO j=1-OLy,sNy+OLy
-            DO i=1-OLx,sNx+OLx
-              silicaSurf(i,j,bi,bj) = bWght*silicaSurf0(i,j,bi,bj)
-     &                              + aWght*silicaSurf1(i,j,bi,bj)
-            ENDDO
-           ENDDO
-          ENDDO
-         ENDDO
-#ifndef ALLOW_AUTODIFF
-#ifdef DIC_CALCITE_SAT
-       ELSEIF ( DIC_silicaDeepFile .NE. ' '  ) THEN
-C-    If no surface silicate file but deep (3d) silicate provided, use top level
-         k = 1
-         CALL READ_REC_XYZ_RS( DIC_silicaDeepFile, silicaDeep0,
-     &                         intime0, nIter0, myThid )
-         CALL READ_REC_XYZ_RS( DIC_silicaDeepFile, silicaDeep1,
-     &                         intime1, nIter0, myThid )
-         DO bj = myByLo(myThid), myByHi(myThid)
-          DO bi = myBxLo(myThid), myBxHi(myThid)
-           DO j=1-OLy,sNy+OLy
-            DO i=1-OLx,sNx+OLx
-              silicaSurf(i,j,bi,bj) = bWght*silicaDeep0(i,j,k,bi,bj)
-     &                              + aWght*silicaDeep1(i,j,k,bi,bj)
-            ENDDO
-           ENDDO
-          ENDDO
-         ENDDO
-#endif /* DIC_CALCITE_SAT */
-#endif /* ndef ALLOW_AUTODIFF */
-       ENDIF
-       _EXCH_XY_RL( silicaSurf, myThid )
-
-C end if DIC_forcingCycle > 0
-      ENDIF
 C     if not dic_useEXF
       ENDIF
 

--- a/pkg/dic/dic_ini_forcing.F
+++ b/pkg/dic/dic_ini_forcing.F
@@ -118,19 +118,26 @@ C--   Set reasonable values to those that need at least something
        DO bi = myBxLo(myThid), myBxHi(myThid)
          DO j=1-OLy,sNy+OLy
           DO i=1-OLx,sNx+OLx
-            wind(i,j,bi,bj)       = 5. _d 0*maskC(i,j,1,bi,bj)
-            AtmosP(i,j,bi,bj)     = 1. _d 0*maskC(i,j,1,bi,bj)
-            silicaSurf(i,j,bi,bj) = 7.6838 _d -3*maskC(i,j,1,bi,bj)
-            fIce(i,j,bi,bj)       = 0. _d 0
+            wind(i,j,bi,bj)       = dic_wind_const
+     &                                  *maskC(i,j,1,bi,bj)
+            AtmosP(i,j,bi,bj)     = dic_atmosp_const/Pa2Atm
+     &                                  *maskC(i,j,1,bi,bj)
+            silicaSurf(i,j,bi,bj) = dic_silicaSurf_const
+     &                                  *maskC(i,j,1,bi,bj)
+            fIce(i,j,bi,bj)       = dic_ice_const
+     &                                  *maskC(i,j,1,bi,bj)
 #ifdef READ_PAR
-            par(i,j,bi,bj)        = 100. _d 0*maskC(i,j,1,bi,bj)
+            par(i,j,bi,bj)        = dic_par_const
+     &                                  *maskC(i,j,1,bi,bj)
 #endif
 #ifdef LIGHT_CHL
 C If the chlorophyll climatology is not provided, use this default value.
-            CHL(i,j,bi,bj)        = 1. _d -2*maskC(i,j,1,bi,bj)
+            CHL(i,j,bi,bj)        = dic_chl_const
+     &                                  *maskC(i,j,1,bi,bj)
 #endif
 #ifdef ALLOW_FE
-            InputFe(i,j,bi,bj)    = 1. _d -11*maskC(i,j,1,bi,bj)
+            InputFe(i,j,bi,bj)    = dic_iron_const
+     &                                  *maskC(i,j,1,bi,bj)
 #endif
           ENDDO
          ENDDO
@@ -139,7 +146,8 @@ C If the chlorophyll climatology is not provided, use this default value.
           DO k=1,Nr
            DO j=1-OLy,sNy+OLy
             DO i=1-OLx,sNx+OLx
-              silicaDeep(i,j,k,bi,bj) = 3. _d -2*maskC(i,j,k,bi,bj)
+              silicaDeep(i,j,k,bi,bj) = dic_silicaDeep_const
+     &                                  *maskC(i,j,k,bi,bj)
             ENDDO
            ENDDO
           ENDDO

--- a/pkg/dic/dic_init_fixed.F
+++ b/pkg/dic/dic_init_fixed.F
@@ -55,7 +55,7 @@ C define Schmidt no. coefficients for CO2
 C define Schmidt no. coefficients for O2
 C based on Keeling et al [GBC, 12, 141, (1998)]
       sox1 = 1638.0 _d 0
-      sox2 = -81.83 _d 0
+      sox2 =  -81.83 _d 0
       sox3 =    1.483 _d 0
       sox4 =   -0.008004 _d 0
 

--- a/pkg/dic/dic_init_fixed.F
+++ b/pkg/dic/dic_init_fixed.F
@@ -269,7 +269,7 @@ C-      User set silicaDeep_nzin but not silicaDeep_dzin: fill from model grid
         IF (debugMode) CALL DEBUG_CALL('GETFFIELD_START SST',myThid)
 # endif
         CALL EXF_GETFFIELD_START( useExfYearlyFields,
-     I                   'dic', 'SST', dic_SSTPeriod,
+     I                   'dic', 'dicSST', dic_SSTPeriod,
      I                   dic_SSTStartDate1, dic_SSTStartDate2,
      U                   dic_SSTStartTime, errCount,
      I                   myThid )
@@ -280,12 +280,19 @@ C-      User set silicaDeep_nzin but not silicaDeep_dzin: fill from model grid
         IF (debugMode) CALL DEBUG_CALL('GETFFIELD_START SSS',myThid)
 # endif
         CALL EXF_GETFFIELD_START( useExfYearlyFields,
-     I                   'dic', 'SSS', dic_SSSPeriod,
+     I                   'dic', 'dicSSS', dic_SSSPeriod,
      I                   dic_SSSStartDate1, dic_SSSStartDate2,
      U                   dic_SSSStartTime, errCount,
      I                   myThid )
        ENDIF
        
+       IF ( errCount.GE.1 ) THEN
+        WRITE(msgBuf,'(A,I3,A)')
+     &       'DIC_INIT_FIXED: detected', errCount,' fatal error(s)'
+        CALL PRINT_ERROR( msgBuf, myThid )
+        CALL ALL_PROC_DIE( 0 )
+        STOP 'ABNORMAL END: S/R DIC_INIT_FIXED'
+       ENDIF
        _END_MASTER( myThid )
 
 C     endif dic_useEXF

--- a/pkg/dic/dic_init_fixed.F
+++ b/pkg/dic/dic_init_fixed.F
@@ -18,7 +18,14 @@ C     !USES:
 #include "GRID.h"
 #include "DIC_VARS.h"
 #include "DIC_ATMOS.h"
-
+#ifdef ALLOW_EXF
+# include "DIC_EXF.h"
+# include "EXF_PARAM.h"
+# ifdef USE_EXF_INTERPOLATION
+#  include "EXF_INTERP_SIZE.h"
+#  include "DIC_INTERP_PARAM.h"
+# endif
+#endif
 C     !INPUT PARAMETERS:
 C     myThid       :: my Thread Id number
       INTEGER myThid
@@ -29,6 +36,10 @@ CEOP
       INTEGER iUnit
 #if ( defined DIC_BIOTIC || defined READ_PAR )
       CHARACTER*(MAX_LEN_MBUF) msgBuf
+#endif
+#ifdef ALLOW_EXF
+C     errCount  :: error counter
+      INTEGER errCount
 #endif
 
 C---+----1----+----2----+----3----+----4----+----5----+----6----+----7-|--+----|
@@ -121,6 +132,167 @@ c       WRITE(msgBuf,'(2A)') ' DIC_FIELDS_LOAD: ',
       ENDIF
 #endif /* READ_PAR */
 
+#ifdef ALLOW_EXF
+      IF ( dic_useEXF ) THEN
+       _BEGIN_MASTER( myThid )
+       errCount = 0
+
+       IF ( dic_silicaFile .NE. ' ' ) THEN
+# ifdef ALLOW_DEBUG
+        IF (debugMode) CALL DEBUG_CALL(
+     &           'GETFFIELD_START silicaSurf',myThid)
+# endif
+        CALL EXF_GETFFIELD_START( useExfYearlyFields,
+     I               'dic', 'silicaSurf', dic_silicaSurfPeriod,
+     I               dic_silicaSurfStartDate1, dic_silicaSurfStartDate2,
+     U               dic_silicaSurfStartTime, errCount,
+     I               myThid )
+       ENDIF
+
+#ifdef DIC_3D_SILICA
+# ifdef USE_EXF_INTERPOLATION
+C-    Default silicaDeep vertical grid parameters if not set by user in namelist
+       IF ( silicaDeep_nzin .EQ. UNSET_I ) THEN
+         silicaDeep_nzin = Nr
+         DO k = 1, Nr
+           silicaDeep_dzin(k) = drF(k)
+         ENDDO
+       ELSEIF ( silicaDeep_dzin(1) .EQ. UNSET_RL ) THEN
+C-      User set silicaDeep_nzin but not silicaDeep_dzin: fill from model grid
+         DO k = 1, MIN(silicaDeep_nzin, Nr)
+           silicaDeep_dzin(k) = drF(k)
+         ENDDO
+       ENDIF
+# endif /* USE_EXF_INTERPOLATION */
+
+       IF ( dic_silicaDeepFile .NE. ' ' ) THEN
+# ifdef ALLOW_DEBUG
+        IF (debugMode) CALL DEBUG_CALL(
+     &           'GETFFIELD_START 3D silica',myThid)
+# endif
+        CALL EXF_GETFFIELD_START( useExfYearlyFields,
+     I                'dic', 'silicaDeep', dic_silicaDeepPeriod,
+     I                dic_silicaDeepStartDate1, dic_silicaDeepStartDate2,
+     U                dic_silicaDeepStartTime, errCount,
+     I                myThid )
+       ENDIF
+#endif /* DIC_3D_SILICA */
+
+#ifdef READ_PAR
+       IF ( dic_parFile .NE. ' ' ) THEN
+# ifdef ALLOW_DEBUG
+        IF (debugMode) CALL DEBUG_CALL('GETFFIELD_START PAR',myThid)
+# endif
+        CALL EXF_GETFFIELD_START( useExfYearlyFields,
+     I                    'dic', 'PAR', dic_parPeriod,
+     I                    dic_parStartDate1, dic_parStartDate2,
+     U                    dic_parStartTime, errCount,
+     I                    myThid )
+       ENDIF
+#endif /* READ_PAR */
+
+#ifndef USE_PLOAD
+       IF ( dic_atmospFile .NE. ' ' ) THEN
+# ifdef ALLOW_DEBUG
+        IF (debugMode) CALL DEBUG_CALL('GETFFIELD_START ATMOSP',myThid)
+# endif
+        CALL EXF_GETFFIELD_START( useExfYearlyFields,
+     I                    'dic', 'ATMOSP', dic_atmospPeriod,
+     I                    dic_atmospStartDate1, dic_atmospStartDate2,
+     U                    dic_atmospStartTime, errCount,
+     I                    myThid )
+       ENDIF
+#endif /* USE_PLOAD */
+
+       IF ( dic_windFile .NE. ' ' ) THEN
+# ifdef ALLOW_DEBUG
+        IF (debugMode) CALL DEBUG_CALL('GETFFIELD_START wind',myThid)
+# endif
+        CALL EXF_GETFFIELD_START( useExfYearlyFields,
+     I                    'dic', 'wind', dic_windPeriod,
+     I                    dic_windStartDate1, dic_windStartDate2,
+     U                    dic_windStartTime, errCount,
+     I                    myThid )
+       ENDIF
+       
+       IF ( dic_iceFile .NE. ' ' ) THEN
+# ifdef ALLOW_DEBUG
+        IF (debugMode) CALL DEBUG_CALL('GETFFIELD_START fIce',myThid)
+# endif
+        CALL EXF_GETFFIELD_START( useExfYearlyFields,
+     I                    'dic', 'fIce', dic_icePeriod,
+     I                    dic_iceStartDate1, dic_iceStartDate2,
+     U                    dic_iceStartTime, errCount,
+     I                    myThid )
+       ENDIF
+
+#ifdef ALLOW_FE
+       IF ( dic_ironFile .NE. ' ' ) THEN
+# ifdef ALLOW_DEBUG
+        IF (debugMode) CALL DEBUG_CALL('GETFFIELD_START inputFe',myThid)
+# endif
+        CALL EXF_GETFFIELD_START( useExfYearlyFields,
+     I                    'dic', 'inputFe', dic_ironPeriod,
+     I                    dic_ironStartDate1, dic_ironStartDate2,
+     U                    dic_ironStartTime, errCount,
+     I                    myThid )
+       ENDIF
+#endif /* ALLOW_FE */
+
+       IF ( dic_atmospCO2File .NE. ' ' ) THEN
+# ifdef ALLOW_DEBUG
+        IF (debugMode) CALL DEBUG_CALL('GETFFIELD_START atmpCO2',myThid)
+# endif
+        CALL EXF_GETFFIELD_START( useExfYearlyFields,
+     I                    'dic', 'atmospCO2', dic_atmospCO2Period,
+     I                    dic_atmospCO2StartDate1, 
+     I                    dic_atmospCO2StartDate2,
+     U                    dic_atmospCO2StartTime, errCount,
+     I                    myThid )
+       ENDIF
+
+#ifdef LIGHT_CHL
+       IF ( dic_chlfile .NE. ' ' ) THEN
+# ifdef ALLOW_DEBUG
+        IF (debugMode) CALL DEBUG_CALL('GETFFIELD_START CHL',myThid)
+# endif
+        CALL EXF_GETFFIELD_START( useExfYearlyFields,
+     I                   'dic', 'chl', dic_chlperiod,
+     I                   dic_chlstartdate1, dic_chlstartdate2,
+     U                   dic_chlStartTime, errCount,
+     I                   myThid )
+       ENDIF
+#endif /* LIGHT_CHL */
+
+       IF ( dic_SSTFile .NE. ' ' ) THEN
+# ifdef ALLOW_DEBUG
+        IF (debugMode) CALL DEBUG_CALL('GETFFIELD_START SST',myThid)
+# endif
+        CALL EXF_GETFFIELD_START( useExfYearlyFields,
+     I                   'dic', 'SST', dic_SSTPeriod,
+     I                   dic_SSTStartDate1, dic_SSTStartDate2,
+     U                   dic_SSTStartTime, errCount,
+     I                   myThid )
+       ENDIF
+
+            IF ( dic_SSSFile .NE. ' ' ) THEN
+# ifdef ALLOW_DEBUG
+        IF (debugMode) CALL DEBUG_CALL('GETFFIELD_START SSS',myThid)
+# endif
+        CALL EXF_GETFFIELD_START( useExfYearlyFields,
+     I                   'dic', 'SSS', dic_SSSPeriod,
+     I                   dic_SSSStartDate1, dic_SSSStartDate2,
+     U                   dic_SSSStartTime, errCount,
+     I                   myThid )
+       ENDIF
+       
+       _END_MASTER( myThid )
+
+C     endif dic_useEXF
+      ENDIF
+
+      _BARRIER
+#endif /* ALLOW_EXF */
 C---+----1----+----2----+----3----+----4----+----5----+----6----+----7-|--+----|
 
 #ifdef ALLOW_MNC

--- a/pkg/dic/dic_init_varia.F
+++ b/pkg/dic/dic_init_varia.F
@@ -24,6 +24,7 @@ C     !USES:
 #ifdef ALLOW_COST
 # include "DIC_COST.h"
 #endif
+
 C     !INPUT PARAMETERS:
 C     myThid               :: my Thread Id number
       INTEGER myThid

--- a/pkg/dic/dic_readparms.F
+++ b/pkg/dic/dic_readparms.F
@@ -997,22 +997,22 @@ C---+----1----+----2----+----3----+----4----+----5----+----6----+----7-|--+----|
 #ifdef ALLOW_EXF
       IF ( dic_useEXF ) THEN
 C--   Print general parameters:
-      WRITE(msgBuf,'(A)') ' dic_useEXF general parameters:'
-      CALL PRINT_MESSAGE( msgBuf, standardMessageUnit,
-     &                    SQUEEZE_RIGHT , myThid )
-      WRITE(msgBuf,'(A)') ' '
-      CALL PRINT_MESSAGE( msgBuf, standardMessageUnit,
-     &                    SQUEEZE_RIGHT , myThid )
+        WRITE(msgBuf,'(A)') ' dic_useEXF general parameters:'
+        CALL PRINT_MESSAGE( msgBuf, standardMessageUnit,
+     &                      SQUEEZE_RIGHT , myThid )
+        WRITE(msgBuf,'(A)') ' '
+        CALL PRINT_MESSAGE( msgBuf, standardMessageUnit,
+     &                      SQUEEZE_RIGHT , myThid )
 #ifdef USE_EXF_INTERPOLATION
-      WRITE(msgBuf,'(A)')
-     &'// USE_EXF_INTERPOLATION:              defined'
-      CALL PRINT_MESSAGE( msgBuf, standardMessageUnit,
-     &                    SQUEEZE_RIGHT , myThid)
+        WRITE(msgBuf,'(A)')
+     &  '// USE_EXF_INTERPOLATION:              defined'
+        CALL PRINT_MESSAGE( msgBuf, standardMessageUnit,
+     &                      SQUEEZE_RIGHT , myThid)
 #else
-      WRITE(msgBuf,'(A)')
-     &'// USE_EXF_INTERPOLATION:          NOT defined'
-      CALL PRINT_MESSAGE( msgBuf, standardMessageUnit,
-     &                    SQUEEZE_RIGHT , myThid)
+          WRITE(msgBuf,'(A)')
+     &  '// USE_EXF_INTERPOLATION:          NOT defined'
+        CALL PRINT_MESSAGE( msgBuf, standardMessageUnit,
+     &                      SQUEEZE_RIGHT , myThid)
 #endif
 C--   For each data set used the summary prints the calendar data
 C     and the corresponding file from which the data will be read.
@@ -1020,269 +1020,288 @@ C     and the corresponding file from which the data will be read.
       addBlkLn = .TRUE.
 
 C--   dic wind speed
-      IF ( dic_WindFile .NE. ' ' ) THEN
-       CALL EXF_FLD_SUMMARY( 'wind speed',
-     I      dic_windfile, 
-     I      dic_windRepCycle, 
-     I      dic_windperiod,
-     I      dic_windStartTime, 
-     I      useExfYearlyFields,
-     I      addBlkLn, 
-     I      myThid )
+        IF ( dic_WindFile .NE. ' ' ) THEN
+          CALL EXF_FLD_SUMMARY( 'wind speed',
+     I         dic_windfile, 
+     I         dic_windRepCycle, 
+     I         dic_windperiod,
+     I         dic_windStartTime, 
+     I         useExfYearlyFields,
+     I         addBlkLn, 
+     I         myThid )
 #ifdef USE_EXF_INTERPOLATION
-       CALL EXF_PRINT_INTERP( 'dicWind',
-     &  wind_lon0, 
-     I      wind_lon_inc, 
-     I      wind_lat0, 
-     I      wind_lat_inc,
-     &  wind_nlon, 
-     I      wind_nlat, 
-     I      wind_interpMethod, 
-     I      myThid )
-#endif
-       prtBlkLn = .TRUE.
-      ENDIF
+          CALL EXF_PRINT_INTERP( 'dicWind',
+     &     wind_lon0, 
+     I         wind_lon_inc, 
+     I         wind_lat0, 
+     I         wind_lat_inc,
+     &     wind_nlon, 
+     I         wind_nlat, 
+     I         wind_interpMethod, 
+     I         myThid )
+#endif   
+          prtBlkLn = .TRUE.
+        ENDIF
 
 C--   dic atmospheric pressure
-      IF ( dic_atmospFile .NE. ' ' ) THEN
-       CALL EXF_FLD_SUMMARY( 'atmospheric pressure',
-     I      dic_atmospfile, 
-     I      dic_atmospRepCycle, 
-     I      dic_atmospperiod,
-     I      dic_atmospStartTime, 
-     I      useExfYearlyFields, 
-     I      addBlkLn, 
-     I      myThid )
+        IF ( dic_atmospFile .NE. ' ' ) THEN
+          CALL EXF_FLD_SUMMARY( 'atmospheric pressure',
+     I         dic_atmospfile, 
+     I         dic_atmospRepCycle, 
+     I         dic_atmospperiod,
+     I         dic_atmospStartTime, 
+     I         useExfYearlyFields, 
+     I         addBlkLn, 
+     I         myThid )
 #ifdef USE_EXF_INTERPOLATION
-       CALL EXF_PRINT_INTERP( 'dicAtmosP',
-     &      atmosp_lon0, 
-     &      atmosp_lon_inc, 
-     &      atmosp_lat0, 
-     &      atmosp_lat_inc,
-     &      atmosp_nlon, 
-     &      atmosp_nlat, 
-     &      atmosp_interpMethod, 
-     &      myThid )
-#endif
-       prtBlkLn = .TRUE.
-      ENDIF 
+          CALL EXF_PRINT_INTERP( 'dicAtmosP',
+     &         atmosp_lon0, 
+     &         atmosp_lon_inc, 
+     &         atmosp_lat0, 
+     &         atmosp_lat_inc,
+     &         atmosp_nlon, 
+     &         atmosp_nlat, 
+     &         atmosp_interpMethod, 
+     &         myThid )
+#endif  
+         prtBlkLn = .TRUE.
+        ENDIF 
 
 C--   dic surface silica
-      IF ( dic_SilicaFile .NE. ' ' ) THEN
-       CALL EXF_FLD_SUMMARY( 'surface silica',
-     I      dic_SilicaFile, 
-     I      dic_SilicaSurfRepCycle, 
-     I      dic_SilicaSurfperiod,
-     I      dic_SilicaSurfStartTime, 
-     I      useExfYearlyFields, 
-     I      addBlkLn, 
-     I      myThid )
+        IF ( dic_SilicaFile .NE. ' ' ) THEN
+          CALL EXF_FLD_SUMMARY( 'surface silica',
+     I         dic_SilicaFile, 
+     I         dic_SilicaSurfRepCycle, 
+     I         dic_SilicaSurfperiod,
+     I         dic_SilicaSurfStartTime, 
+     I         useExfYearlyFields, 
+     I         addBlkLn, 
+     I         myThid )
 #ifdef USE_EXF_INTERPOLATION
-       CALL EXF_PRINT_INTERP( 'dicSilicaSurf',
-     I      silicaSurf_lon0, 
-     I      silicaSurf_lon_inc, 
-     I      silicaSurf_lat0, 
-     I      silicaSurf_lat_inc,
-     I      silicaSurf_nlon, 
-     I      silicaSurf_nlat, 
-     I      silicaSurf_interpMethod, 
-     I      myThid )
-#endif
-       prtBlkLn = .TRUE.
-      ENDIF
+          CALL EXF_PRINT_INTERP( 'dicSilicaSurf',
+     I         silicaSurf_lon0, 
+     I         silicaSurf_lon_inc, 
+     I         silicaSurf_lat0, 
+     I         silicaSurf_lat_inc,
+     I         silicaSurf_nlon, 
+     I         silicaSurf_nlat, 
+     I         silicaSurf_interpMethod, 
+     I         myThid )
+#endif   
+          prtBlkLn = .TRUE.
+        ENDIF
 
 C--  dic deep silica
-      IF ( dic_SilicaDeepFile .NE. ' ' ) THEN
-       CALL EXF_FLD_SUMMARY( 'deep silica',
-     I      dic_SilicaDeepFile, 
-     I      dic_SilicaDeepRepCycle, 
-     I      dic_SilicaDeepperiod,
-     I      dic_SilicaDeepStartTime, 
-     I      useExfYearlyFields, 
-     I      addBlkLn, 
-     I      myThid )
+        IF ( dic_SilicaDeepFile .NE. ' ' ) THEN
+          CALL EXF_FLD_SUMMARY( 'deep silica',
+     I         dic_SilicaDeepFile, 
+     I         dic_SilicaDeepRepCycle, 
+     I         dic_SilicaDeepperiod,
+     I         dic_SilicaDeepStartTime, 
+     I         useExfYearlyFields, 
+     I         addBlkLn, 
+     I         myThid )
 #ifdef USE_EXF_INTERPOLATION
-       CALL EXF_PRINT_INTERP( 'dicSilicaDeep',
-     &      silicaDeep_lon0, 
-     &      silicaDeep_lon_inc, 
-     &      silicaDeep_lat0, 
-     &      silicaDeep_lat_inc,
-     &      silicaDeep_nlon, 
-     &      silicaDeep_nlat, 
-     &      silicaDeep_interpMethod, 
-     &      myThid )
-#endif
-       prtBlkLn = .TRUE.
-      ENDIF
+          CALL EXF_PRINT_INTERP( 'dicSilicaDeep',
+     &         silicaDeep_lon0, 
+     &         silicaDeep_lon_inc, 
+     &         silicaDeep_lat0, 
+     &         silicaDeep_lat_inc,
+     &         silicaDeep_nlon, 
+     &         silicaDeep_nlat, 
+     &         silicaDeep_interpMethod, 
+     &         myThid )
+#endif   
+          prtBlkLn = .TRUE.
+        ENDIF
 
 C--   dic par
-      IF ( dic_parFile .NE. ' ' ) THEN
-       CALL EXF_FLD_SUMMARY( 'photosynthetically available radiation',
-     I      dic_parFile, 
-     I      dic_parRepCycle, 
-     I      dic_parperiod,
-     I      dic_parStartTime, 
-     I      useExfYearlyFields, 
-     I      addBlkLn, 
-     I      myThid )
+        IF ( dic_parFile .NE. ' ' ) THEN
+          CALL EXF_FLD_SUMMARY( 
+     I        'photosynthetically active radiation',
+     I         dic_parFile, 
+     I         dic_parRepCycle, 
+     I         dic_parperiod,
+     I         dic_parStartTime, 
+     I         useExfYearlyFields, 
+     I         addBlkLn, 
+     I         myThid )
 #ifdef USE_EXF_INTERPOLATION
-       CALL EXF_PRINT_INTERP( 'dicPAR',
-     &  par_lon0, 
-     &  par_lon_inc, 
-     &  par_lat0, 
-     &  par_lat_inc,
-     &  par_nlon, 
-     &  par_nlat, 
-     &  par_interpMethod, 
-     &  myThid )
-#endif
-       prtBlkLn = .TRUE.
-      ENDIF
+          CALL EXF_PRINT_INTERP( 'dicPAR',
+     &         par_lon0, 
+     &         par_lon_inc, 
+     &         par_lat0, 
+     &         par_lat_inc,
+     &         par_nlon, 
+     &         par_nlat, 
+     &         par_interpMethod, 
+     &         myThid )
+#endif   
+          prtBlkLn = .TRUE.
+        ENDIF
 
 C--   dic iron forcing
-      IF ( dic_ironFile .NE. ' ' ) THEN
-       CALL EXF_FLD_SUMMARY( 'aeolian iron flux',
-     I      dic_ironFile, 
-     I      dic_ironRepCycle, 
-     I      dic_ironperiod,
-     I      dic_ironStartTime, 
-     I      useExfYearlyFields, 
-     I      addBlkLn, 
-     I      myThid )
+        IF ( dic_ironFile .NE. ' ' ) THEN
+          CALL EXF_FLD_SUMMARY( 'aeolian iron flux',
+     I         dic_ironFile, 
+     I         dic_ironRepCycle, 
+     I         dic_ironperiod,
+     I         dic_ironStartTime, 
+     I         useExfYearlyFields, 
+     I         addBlkLn, 
+     I         myThid )
 #ifdef USE_EXF_INTERPOLATION
-       CALL EXF_PRINT_INTERP( 'InputFe',
-     &  iron_lon0, 
-     &  iron_lon_inc, 
-     &  iron_lat0, 
-     &  iron_lat_inc,
-     &  iron_nlon, 
-     &  iron_nlat, 
-     &  iron_interpMethod, 
-     &  myThid )
-#endif
-       prtBlkLn = .TRUE.
+          CALL EXF_PRINT_INTERP( 'InputFe',
+     &         iron_lon0, 
+     &         iron_lon_inc, 
+     &         iron_lat0, 
+     &         iron_lat_inc,
+     &         iron_nlon, 
+     &         iron_nlat, 
+     &         iron_interpMethod, 
+     &         myThid )
+#endif   
+          prtBlkLn = .TRUE.
       ENDIF
 
 C--   dic atmospheric CO2 forcing
-      IF ( dic_atmospCO2File .NE. ' ' ) THEN
-       CALL EXF_FLD_SUMMARY( 'atmospheric CO2',
-     I      dic_atmospCO2File, 
-     I      dic_atmospCO2RepCycle, 
-     I      dic_atmospCO2period,
-     I      dic_atmospCO2StartTime, 
-     I      useExfYearlyFields, 
-     I      addBlkLn, 
-     I      myThid)
+        IF ( dic_atmospCO2File .NE. ' ' ) THEN
+          CALL EXF_FLD_SUMMARY( 'atmospheric CO2',
+     I         dic_atmospCO2File, 
+     I         dic_atmospCO2RepCycle, 
+     I         dic_atmospCO2period,
+     I         dic_atmospCO2StartTime, 
+     I         useExfYearlyFields, 
+     I         addBlkLn, 
+     I         myThid)
 #ifdef USE_EXF_INTERPOLATION
-       CALL EXF_PRINT_INTERP( 'dicAtmosCO2',
-     &  atmospCO2_lon0, 
-     &  atmospCO2_lon_inc, 
-     &  atmospCO2_lat0, 
-     &  atmospCO2_lat_inc,
-     &  atmospCO2_nlon, 
-     &  atmospCO2_nlat, 
-     &  atmospCO2_interpMethod, 
-     &  myThid )
-#endif
-       prtBlkLn = .TRUE.
-      ENDIF
+          CALL EXF_PRINT_INTERP( 'dicAtmosCO2',
+     &         atmospCO2_lon0, 
+     &         atmospCO2_lon_inc, 
+     &         atmospCO2_lat0, 
+     &         atmospCO2_lat_inc,
+     &         atmospCO2_nlon, 
+     &         atmospCO2_nlat, 
+     &         atmospCO2_interpMethod, 
+     &         myThid )
+#endif  
+         prtBlkLn = .TRUE.
+        ENDIF
 
 C--  dic sea ice forcing
-      IF ( dic_iceFile .NE. ' ' ) THEN
-       CALL EXF_FLD_SUMMARY( 'sea ice fraction',
-     I      dic_iceFile, 
-     I      dic_iceRepCycle, 
-     I      dic_iceperiod,
-     I      dic_iceStartTime, 
-     I      useExfYearlyFields, 
-     I      addBlkLn, 
-     I      myThid ) 
+        IF ( dic_iceFile .NE. ' ' ) THEN
+          CALL EXF_FLD_SUMMARY( 'sea ice fraction',
+     I         dic_iceFile, 
+     I         dic_iceRepCycle, 
+     I         dic_iceperiod,
+     I         dic_iceStartTime, 
+     I         useExfYearlyFields, 
+     I         addBlkLn, 
+     I         myThid ) 
 #ifdef USE_EXF_INTERPOLATION
-       CALL EXF_PRINT_INTERP( 'dicIce',
-     &  ice_lon0, 
-     &  ice_lon_inc, 
-     &  ice_lat0, 
-     &  ice_lat_inc,
-     &  ice_nlon, 
-     &  ice_nlat, 
-     &  ice_interpMethod, 
-     &  myThid )
-#endif
-       prtBlkLn = .TRUE.
-      ENDIF
+          CALL EXF_PRINT_INTERP( 'dicIce',
+     &         ice_lon0, 
+     &         ice_lon_inc, 
+     &         ice_lat0, 
+     &         ice_lat_inc,
+     &         ice_nlon, 
+     &         ice_nlat, 
+     &         ice_interpMethod, 
+     &         myThid )
+#endif   
+          prtBlkLn = .TRUE.
+        ENDIF
 
 C-- dic chlorophyll forcing
-      IF ( dic_chlaFile .NE. ' ' ) THEN
-       CALL EXF_FLD_SUMMARY( 'chlorophyll',
-     I      dic_chlaFile, 
-     I      dic_chlRepCycle, 
-     I      dic_chlperiod,
-     I      dic_chlStartTime, 
-     I      useExfYearlyFields, 
-     I      addBlkLn, 
-     I      myThid )
+        IF ( dic_chlaFile .NE. ' ' ) THEN
+          CALL EXF_FLD_SUMMARY( 'chlorophyll',
+     I         dic_chlaFile, 
+     I         dic_chlRepCycle, 
+     I         dic_chlperiod,
+     I         dic_chlStartTime, 
+     I         useExfYearlyFields, 
+     I         addBlkLn, 
+     I         myThid )
 #ifdef USE_EXF_INTERPOLATION
-       CALL EXF_PRINT_INTERP( 'dicChl',
-     &  chl_lon0, 
-     &  chl_lon_inc, 
-     &  chl_lat0, 
-     &  chl_lat_inc,
-     &  chl_nlon, 
-     &  chl_nlat, 
-     &  chl_interpMethod, 
-     &  myThid )
-#endif
-       prtBlkLn = .TRUE.
-      ENDIF
+          CALL EXF_PRINT_INTERP( 'dicChl',
+     &         chl_lon0, 
+     &         chl_lon_inc, 
+     &         chl_lat0, 
+     &         chl_lat_inc,
+     &         chl_nlon, 
+     &         chl_nlat, 
+     &         chl_interpMethod, 
+     &         myThid )
+#endif   
+          prtBlkLn = .TRUE.
+        ENDIF
 
 C-- dic SST forcing
-      IF ( dic_SSTFile .NE. ' ' ) THEN
-       CALL EXF_FLD_SUMMARY( 'carbon chem sea surface temperature',
-     I      dic_SSTFile, 
-     I      dic_SSTRepCycle, 
-     I      dic_SSTperiod,
-     I      dic_SSTStartTime, 
-     I      useExfYearlyFields, 
-     I      addBlkLn, 
-     I      myThid )
+        IF ( dic_SSTFile .NE. ' ' ) THEN
+          CALL EXF_FLD_SUMMARY(
+     I        'carbon chem sea surface temperature',
+     I         dic_SSTFile, 
+     I         dic_SSTRepCycle, 
+     I         dic_SSTperiod,
+     I         dic_SSTStartTime, 
+     I         useExfYearlyFields, 
+     I         addBlkLn, 
+     I         myThid )
 #ifdef USE_EXF_INTERPOLATION
-       CALL EXF_PRINT_INTERP( 'dicSST',
-     &  SST_lon0, 
-     &  SST_lon_inc, 
-     &  SST_lat0, 
-     &  SST_lat_inc,
-     &  SST_nlon, 
-     &  SST_nlat, 
-     &  SST_interpMethod, 
-     &  myThid )
-#endif
-       prtBlkLn = .TRUE.
-      ENDIF
+          CALL EXF_PRINT_INTERP( 'dicSST',
+     &         SST_lon0, 
+     &         SST_lon_inc, 
+     &         SST_lat0, 
+     &         SST_lat_inc,
+     &         SST_nlon, 
+     &         SST_nlat, 
+     &         SST_interpMethod, 
+     &         myThid )
+#endif   
+          prtBlkLn = .TRUE.
+        ENDIF
 
 C-- dic SSS forcing
-      IF ( dic_SSSFile .NE. ' ' ) THEN
-       CALL EXF_FLD_SUMMARY( 'carbon chem sea surface salinity',
-     I      dic_SSSFile, 
-     I      dic_SSSRepCycle, 
-     I      dic_SSSperiod,
-     I      dic_SSSStartTime, 
-     I      useExfYearlyFields, 
-     I      addBlkLn, 
-     I      myThid )
+        IF ( dic_SSSFile .NE. ' ' ) THEN
+          CALL EXF_FLD_SUMMARY(
+     I        'carbon chem sea surface salinity',
+     I         dic_SSSFile, 
+     I         dic_SSSRepCycle, 
+     I         dic_SSSperiod,
+     I         dic_SSSStartTime, 
+     I         useExfYearlyFields, 
+     I         addBlkLn, 
+     I         myThid )
 #ifdef USE_EXF_INTERPOLATION
-       CALL EXF_PRINT_INTERP( 'dicSSS',
-     &  SSS_lon0, 
-     &  SSS_lon_inc, 
-     &  SSS_lat0, 
-     &  SSS_lat_inc,
-     &  SSS_nlon, 
-     &  SSS_nlat, 
-     &  SSS_interpMethod, 
-     &  myThid )
-#endif
-       prtBlkLn = .TRUE.
+          CALL EXF_PRINT_INTERP( 'dicSSS',
+     &         SSS_lon0, 
+     &         SSS_lon_inc, 
+     &         SSS_lat0, 
+     &         SSS_lat_inc,
+     &         SSS_nlon, 
+     &         SSS_nlat, 
+     &         SSS_interpMethod, 
+     &         myThid )
+#endif   
+           prtBlkLn = .TRUE.
+        ENDIF
+      ELSE
+        IF ( dic_SSSFile .NE. ' ' ) THEN
+         WRITE(msgBuf,'(2A)') 'DIC_READPARMS: The use of ',
+     &    'dic_SSSFile WITHOUT dic_useEXF',
+     &    'is not implemented'
+         CALL PRINT_ERROR( msgBuf, myThid )
+         errCount = errCount + 1
+        ENDIF
+        IF ( dic_SSTFile .NE. ' ' ) THEN
+         WRITE(msgBuf,'(2A)') 'DIC_READPARMS: The use of ',
+     &    'dic_SSTFile WITHOUT dic_useEXF',
+     &    'is not implemented'
+         CALL PRINT_ERROR( msgBuf, myThid )
+         errCount = errCount + 1
+        ENDIF
+C dic_useEXF
       ENDIF
-      ENDIF /* dic_useEXF */
 
 C     dic_useEXF and useExfYearlyFields
       IF ( dic_useEXF .AND. useExfYearlyFields ) THEN

--- a/pkg/dic/dic_readparms.F
+++ b/pkg/dic/dic_readparms.F
@@ -403,136 +403,134 @@ C---+----1----+----2----+----3----+----4----+----5----+----6----+----7-|--+----|
        ENDIF
 #endif
 
-# ifdef ALLOW_EXF
-      IF ( dic_useEXF ) THEN
+#ifdef ALLOW_EXF
 C     If useEXF=F, s/r exf_readparms is not called and exf-parameters
 C     are not initialiased properly. The following few exf-related
 C     parameters need to have a defined value to be used in s/r
 C     exf_set_fld.
-        dic_exf_iprec           = 32
-        dic_useExfYearlyFields  = .FALSE.
-        dic_twoDigitYear        = .FALSE.
-        dic_exf_debugLev        = debugLevel
-        dic_ForcingCycle        = repeatPeriod
-         
-        IF ( .NOT. useEXF ) THEN
-          repeatPeriod       = dic_ForcingCycle
-          exf_iprec          = dic_exf_iprec
-          useExfYearlyFields = dic_useExfYearlyFields
-          twoDigitYear       = dic_twoDigitYear
-          exf_debugLev       = dic_exf_debugLev
-        ENDIF
- 
-        dic_SilicaSurfPeriod               = 0.0 _d 0
-        dic_SilicaSurfRepCycle             = repeatPeriod
-        dic_SilicaSurfStartTime            = UNSET_RL
-        dic_SilicaSurfStartDate1           = 0
-        dic_SilicaSurfStartDate2           = 0
-        dic_SilicaSurf_exfremo_intercept   = 0.0 _d 0
-        dic_SilicaSurf_exfremo_slope       = 0.0 _d 0
-        dic_SilicaSurfMask                 = 'c'
-        dic_inscal_SilicaSurf              = 1. _d 0
- 
-        dic_SilicaDeepPeriod               = 0.0 _d 0
-        dic_SilicaDeepRepCycle             = repeatPeriod
-        dic_SilicaDeepStartTime            = UNSET_RL
-        dic_SilicaDeepStartDate1           = 0
-        dic_SilicaDeepStartDate2           = 0
-        dic_SilicaDeep_exfremo_intercept   = 0.0 _d 0
-        dic_SilicaDeep_exfremo_slope       = 0.0 _d 0
-        dic_SilicaDeepMask                 = 'c'
-        dic_inscal_SilicaDeep              = 1. _d 0
- 
-        dic_parPeriod                      = 0.0 _d 0
-        dic_parRepCycle                    = repeatPeriod
-        dic_parStartTime                   = UNSET_RL
-        dic_parStartDate1                  = 0
-        dic_parStartDate2                  = 0
-        dic_par_exfremo_intercept          = 0.0 _d 0
-        dic_par_exfremo_slope              = 0.0 _d 0
-        dic_parMask                        = 'c'
-        dic_inscal_par                     = 1. _d 0
- 
-        dic_ironPeriod                     = 0.0 _d 0
-        dic_ironRepCycle                   = repeatPeriod
-        dic_ironStartTime                  = UNSET_RL
-        dic_ironStartDate1                 = 0
-        dic_ironStartDate2                 = 0
-        dic_iron_exfremo_intercept         = 0.0 _d 0
-        dic_iron_exfremo_slope             = 0.0 _d 0
-        dic_ironMask                       = 'c'
-        dic_inscal_iron                    = 1. _d 0
- 
-        dic_atmospCO2Period                = 0.0 _d 0
-        dic_atmospCO2RepCycle              = repeatPeriod
-        dic_atmospCO2StartTime             = UNSET_RL
-        dic_atmospCO2StartDate1            = 0
-        dic_atmospCO2StartDate2            = 0
-        dic_atmospCO2_exfremo_intercept    = 0.0 _d 0
-        dic_atmospCO2_exfremo_slope        = 0.0 _d 0
-        dic_atmospCO2Mask                  = 'c'
-        dic_inscal_atmospCO2               = 1. _d 0
- 
-        dic_icePeriod                      = 0.0 _d 0
-        dic_iceRepCycle                    = repeatPeriod
-        dic_iceStartTime                   = UNSET_RL
-        dic_iceStartDate1                  = 0
-        dic_iceStartDate2                  = 0
-        dic_ice_exfremo_intercept          = 0.0 _d 0
-        dic_ice_exfremo_slope              = 0.0 _d 0
-        dic_iceMask                        = 'c'
-        dic_inscal_ice                     = 1. _d 0
- 
-        dic_windPeriod                     = 0.0 _d 0
-        dic_windRepCycle                   = repeatPeriod
-        dic_windStartTime                  = UNSET_RL
-        dic_windStartDate1                 = 0
-        dic_windStartDate2                 = 0
-        dic_wind_exfremo_intercept         = 0.0 _d 0
-        dic_wind_exfremo_slope             = 0.0 _d 0
-        dic_windMask                       = 'c'
-        dic_inscal_wind                    = 1. _d 0
- 
-        dic_atmospPeriod                   = 0.0 _d 0
-        dic_atmospRepCycle                 = repeatPeriod
-        dic_atmospStartTime                = UNSET_RL
-        dic_atmospStartDate1               = 0
-        dic_atmospStartDate2               = 0
-        dic_atmosp_exfremo_intercept       = 0.0 _d 0
-        dic_atmosp_exfremo_slope           = 0.0 _d 0
-        dic_atmospMask                     = 'c'
-        dic_inscal_atmosp                  = 1. _d 0
+       dic_exf_iprec           = 32
+       dic_useExfYearlyFields  = .FALSE.
+       dic_twoDigitYear        = .FALSE.
+       dic_exf_debugLev        = debugLevel
 
-        dic_chlPeriod                      = 0.0 _d 0
-        dic_chlRepCycle                    = repeatPeriod
-        dic_chlStartTime                   = UNSET_RL
-        dic_chlStartDate1                  = 0
-        dic_chlStartDate2                  = 0
-        dic_chl_exfremo_intercept          = 0.0 _d 0
-        dic_chl_exfremo_slope              = 0.0 _d 0
-        dic_chlMask                        = 'c'
-        dic_inscal_chl                     = 1. _d 0
+       IF ( .NOT. useEXF ) THEN
+         repeatPeriod       = dic_ForcingCycle
+         exf_iprec          = dic_exf_iprec
+         useExfYearlyFields = dic_useExfYearlyFields
+         twoDigitYear       = dic_twoDigitYear
+         exf_debugLev       = dic_exf_debugLev
+       ENDIF
+ 
+       dic_SilicaSurfPeriod               = 0.0 _d 0
+       dic_SilicaSurfRepCycle             = repeatPeriod
+       dic_SilicaSurfStartTime            = UNSET_RL
+       dic_SilicaSurfStartDate1           = 0
+       dic_SilicaSurfStartDate2           = 0
+       dic_SilicaSurf_exfremo_intercept   = 0.0 _d 0
+       dic_SilicaSurf_exfremo_slope       = 0.0 _d 0
+       dic_SilicaSurfMask                 = 'c'
+       dic_inscal_SilicaSurf              = 1. _d 0
+ 
+       dic_SilicaDeepPeriod               = 0.0 _d 0
+       dic_SilicaDeepRepCycle             = repeatPeriod
+       dic_SilicaDeepStartTime            = UNSET_RL
+       dic_SilicaDeepStartDate1           = 0
+       dic_SilicaDeepStartDate2           = 0
+       dic_SilicaDeep_exfremo_intercept   = 0.0 _d 0
+       dic_SilicaDeep_exfremo_slope       = 0.0 _d 0
+       dic_SilicaDeepMask                 = 'c'
+       dic_inscal_SilicaDeep              = 1. _d 0
+ 
+       dic_parPeriod                      = 0.0 _d 0
+       dic_parRepCycle                    = repeatPeriod
+       dic_parStartTime                   = UNSET_RL
+       dic_parStartDate1                  = 0
+       dic_parStartDate2                  = 0
+       dic_par_exfremo_intercept          = 0.0 _d 0
+       dic_par_exfremo_slope              = 0.0 _d 0
+       dic_parMask                        = 'c'
+       dic_inscal_par                     = 1. _d 0
+ 
+       dic_ironPeriod                     = 0.0 _d 0
+       dic_ironRepCycle                   = repeatPeriod
+       dic_ironStartTime                  = UNSET_RL
+       dic_ironStartDate1                 = 0
+       dic_ironStartDate2                 = 0
+       dic_iron_exfremo_intercept         = 0.0 _d 0
+       dic_iron_exfremo_slope             = 0.0 _d 0
+       dic_ironMask                       = 'c'
+       dic_inscal_iron                    = 1. _d 0
+ 
+       dic_atmospCO2Period                = 0.0 _d 0
+       dic_atmospCO2RepCycle              = repeatPeriod
+       dic_atmospCO2StartTime             = UNSET_RL
+       dic_atmospCO2StartDate1            = 0
+       dic_atmospCO2StartDate2            = 0
+       dic_atmospCO2_exfremo_intercept    = 0.0 _d 0
+       dic_atmospCO2_exfremo_slope        = 0.0 _d 0
+       dic_atmospCO2Mask                  = 'c'
+       dic_inscal_atmospCO2               = 1. _d 0
+ 
+       dic_icePeriod                      = 0.0 _d 0
+       dic_iceRepCycle                    = repeatPeriod
+       dic_iceStartTime                   = UNSET_RL
+       dic_iceStartDate1                  = 0
+       dic_iceStartDate2                  = 0
+       dic_ice_exfremo_intercept          = 0.0 _d 0
+       dic_ice_exfremo_slope              = 0.0 _d 0
+       dic_iceMask                        = 'c'
+       dic_inscal_ice                     = 1. _d 0
+ 
+       dic_windPeriod                     = 0.0 _d 0
+       dic_windRepCycle                   = repeatPeriod
+       dic_windStartTime                  = UNSET_RL
+       dic_windStartDate1                 = 0
+       dic_windStartDate2                 = 0
+       dic_wind_exfremo_intercept         = 0.0 _d 0
+       dic_wind_exfremo_slope             = 0.0 _d 0
+       dic_windMask                       = 'c'
+       dic_inscal_wind                    = 1. _d 0
+ 
+       dic_atmospPeriod                   = 0.0 _d 0
+       dic_atmospRepCycle                 = repeatPeriod
+       dic_atmospStartTime                = UNSET_RL
+       dic_atmospStartDate1               = 0
+       dic_atmospStartDate2               = 0
+       dic_atmosp_exfremo_intercept       = 0.0 _d 0
+       dic_atmosp_exfremo_slope           = 0.0 _d 0
+       dic_atmospMask                     = 'c'
+       dic_inscal_atmosp                  = 1. _d 0
 
-        dic_SSTPeriod                      = 0.0 _d 0
-        dic_SSTRepCycle                    = repeatPeriod
-        dic_SSTStartTime                   = UNSET_RL
-        dic_SSTStartDate1                  = 0
-        dic_SSTStartDate2                  = 0
-        dic_SST_exfremo_intercept          = 0.0 _d 0
-        dic_SST_exfremo_slope              = 0.0 _d 0
-        dic_SSTMask                        = 'c'
-        dic_inscal_SST                     = 1. _d 0
+       dic_chlPeriod                      = 0.0 _d 0
+       dic_chlRepCycle                    = repeatPeriod
+       dic_chlStartTime                   = UNSET_RL
+       dic_chlStartDate1                  = 0
+       dic_chlStartDate2                  = 0
+       dic_chl_exfremo_intercept          = 0.0 _d 0
+       dic_chl_exfremo_slope              = 0.0 _d 0
+       dic_chlMask                        = 'c'
+       dic_inscal_chl                     = 1. _d 0
 
-        dic_SSSPeriod                      = 0.0 _d 0
-        dic_SSSRepCycle                    = repeatPeriod
-        dic_SSSStartTime                   = UNSET_RL
-        dic_SSSStartDate1                  = 0
-        dic_SSSStartDate2                  = 0
-        dic_SSS_exfremo_intercept          = 0.0 _d 0
-        dic_SSS_exfremo_slope              = 0.0 _d 0
-        dic_SSSMask                        = 'c'
-        dic_inscal_SSS                     = 1. _d 0
-#  ifdef USE_EXF_INTERPOLATION
+       dic_SSTPeriod                      = 0.0 _d 0
+       dic_SSTRepCycle                    = repeatPeriod
+       dic_SSTStartTime                   = UNSET_RL
+       dic_SSTStartDate1                  = 0
+       dic_SSTStartDate2                  = 0
+       dic_SST_exfremo_intercept          = 0.0 _d 0
+       dic_SST_exfremo_slope              = 0.0 _d 0
+       dic_SSTMask                        = 'c'
+       dic_inscal_SST                     = 1. _d 0
+
+       dic_SSSPeriod                      = 0.0 _d 0
+       dic_SSSRepCycle                    = repeatPeriod
+       dic_SSSStartTime                   = UNSET_RL
+       dic_SSSStartDate1                  = 0
+       dic_SSSStartDate2                  = 0
+       dic_SSS_exfremo_intercept          = 0.0 _d 0
+       dic_SSS_exfremo_slope              = 0.0 _d 0
+       dic_SSSMask                        = 'c'
+       dic_inscal_SSS                     = 1. _d 0
+# ifdef USE_EXF_INTERPOLATION
 
        IF ( .NOT. useEXF ) THEN
 C     This is done in s/r exf_init_interp only if useEXF=T
@@ -550,9 +548,9 @@ C     This is done in s/r exf_init_interp only if useEXF=T
         inp_dLon = delX(1)
         DO j=1,MAX_LAT_INC
          IF (j.LT.inp_gNy) THEN
-          inp_dLat(j) = (delY(j) + delY(j+1))*halfRL
+           inp_dLat(j) = (delY(j) + delY(j+1))*halfRL
          ELSE
-          inp_dLat(j) = 0.
+           inp_dLat(j) = 0.
          ENDIF
         ENDDO
        ENDIF
@@ -653,10 +651,8 @@ C     This is done in s/r exf_init_interp only if useEXF=T
        IF ( .NOT. useEXF ) THEN
         exf_output_interp   = dic_exf_output_interp
        ENDIF
-#  endif /* USE_EXF_INTERPOLATION */
-C     dic_useEXF
-      ENDIF
-# endif /* ALLOW_EXF */
+# endif /* USE_EXF_INTERPOLATION */
+#endif /* ALLOW_EXF */
 
 C--   Open data file and read parameters from it:
       WRITE(msgBuf,'(A)') ' DIC_READPARMS: opening data.dic'

--- a/pkg/dic/dic_readparms.F
+++ b/pkg/dic/dic_readparms.F
@@ -405,134 +405,133 @@ C---+----1----+----2----+----3----+----4----+----5----+----6----+----7-|--+----|
 
 # ifdef ALLOW_EXF
       IF ( dic_useEXF ) THEN
-       dic_SilicaSurfPeriod               = 0.0 _d 0
-       dic_SilicaSurfRepCycle             = DIC_forcingPeriod
-       dic_SilicaSurfStartTime            = UNSET_RL
-       dic_SilicaSurfStartDate1           = 0
-       dic_SilicaSurfStartDate2           = 0
-       dic_SilicaSurf_exfremo_intercept   = 0.0 _d 0
-       dic_SilicaSurf_exfremo_slope       = 0.0 _d 0
-       dic_SilicaSurfMask                 = 'c'
-       dic_inscal_SilicaSurf              = 1. _d 0
-
-       dic_SilicaDeepPeriod               = 0.0 _d 0
-       dic_SilicaDeepRepCycle             = DIC_forcingPeriod
-       dic_SilicaDeepStartTime            = UNSET_RL
-       dic_SilicaDeepStartDate1           = 0
-       dic_SilicaDeepStartDate2           = 0
-       dic_SilicaDeep_exfremo_intercept   = 0.0 _d 0
-       dic_SilicaDeep_exfremo_slope       = 0.0 _d 0
-       dic_SilicaDeepMask                 = 'c'
-       dic_inscal_SilicaDeep              = 1. _d 0
-
-       dic_parPeriod                      = 0.0 _d 0
-       dic_parRepCycle                    = DIC_forcingPeriod
-       dic_parStartTime                   = UNSET_RL
-       dic_parStartDate1                  = 0
-       dic_parStartDate2                  = 0
-       dic_par_exfremo_intercept          = 0.0 _d 0
-       dic_par_exfremo_slope              = 0.0 _d 0
-       dic_parMask                        = 'c'
-       dic_inscal_par                     = 1. _d 0
-
-       dic_ironPeriod                     = 0.0 _d 0
-       dic_ironRepCycle                   = DIC_forcingPeriod
-       dic_ironStartTime                  = UNSET_RL
-       dic_ironStartDate1                 = 0
-       dic_ironStartDate2                 = 0
-       dic_iron_exfremo_intercept         = 0.0 _d 0
-       dic_iron_exfremo_slope             = 0.0 _d 0
-       dic_ironMask                       = 'c'
-       dic_inscal_iron                    = 1. _d 0
-
-       dic_atmospCO2Period                = 0.0 _d 0
-       dic_atmospCO2RepCycle              = DIC_forcingPeriod
-       dic_atmospCO2StartTime             = UNSET_RL
-       dic_atmospCO2StartDate1            = 0
-       dic_atmospCO2StartDate2            = 0
-       dic_atmospCO2_exfremo_intercept    = 0.0 _d 0
-       dic_atmospCO2_exfremo_slope        = 0.0 _d 0
-       dic_atmospCO2Mask                  = 'c'
-       dic_inscal_atmospCO2                 = 1. _d 0
-
-       dic_icePeriod                      = 0.0 _d 0
-       dic_iceRepCycle                    = DIC_forcingPeriod
-       dic_iceStartTime                   = UNSET_RL
-       dic_iceStartDate1                  = 0
-       dic_iceStartDate2                  = 0
-       dic_ice_exfremo_intercept          = 0.0 _d 0
-       dic_ice_exfremo_slope              = 0.0 _d 0
-       dic_iceMask                        = 'c'
-       dic_inscal_ice                     = 1. _d 0
-
-       dic_windPeriod                     = 0.0 _d 0
-       dic_windRepCycle                   = DIC_forcingPeriod
-       dic_windStartTime                  = UNSET_RL
-       dic_windStartDate1                 = 0
-       dic_windStartDate2                 = 0
-       dic_wind_exfremo_intercept         = 0.0 _d 0
-       dic_wind_exfremo_slope             = 0.0 _d 0
-       dic_windMask                       = 'c'
-       dic_inscal_wind                    = 1. _d 0
-
-       dic_atmospPeriod                   = 0.0 _d 0
-       dic_atmospRepCycle                 = DIC_forcingPeriod
-       dic_atmospStartTime                = UNSET_RL
-       dic_atmospStartDate1               = 0
-       dic_atmospStartDate2               = 0
-       dic_atmosp_exfremo_intercept       = 0.0 _d 0
-       dic_atmosp_exfremo_slope           = 0.0 _d 0
-       dic_atmospMask                     = 'c'
-C convert atmospheric pressure from Pa or mbar to Atm for use in dic_surfforcing
-       dic_inscal_atmosp                  = 1.01325 _d 5
-
-       dic_chlPeriod                      = 0.0 _d 0
-       dic_chlRepCycle                    = DIC_forcingPeriod
-       dic_chlStartTime                   = UNSET_RL
-       dic_chlStartDate1                  = 0
-       dic_chlStartDate2                  = 0
-       dic_chl_exfremo_intercept          = 0.0 _d 0
-       dic_chl_exfremo_slope              = 0.0 _d 0
-       dic_chlMask                        = 'c'
-       dic_inscal_chl                     = 1. _d 0
-
-       dic_SSTPeriod                      = 0.0 _d 0
-       dic_SSTRepCycle                    = DIC_forcingPeriod
-       dic_SSTStartTime                   = UNSET_RL
-       dic_SSTStartDate1                  = 0
-       dic_SSTStartDate2                  = 0
-       dic_SST_exfremo_intercept          = 0.0 _d 0
-       dic_SST_exfremo_slope              = 0.0 _d 0
-       dic_SSTMask                        = 'c'
-       dic_inscal_SST                     = 1. _d 0
-
-       dic_SSSPeriod                      = 0.0 _d 0
-       dic_SSSRepCycle                    = DIC_forcingPeriod
-       dic_SSSStartTime                   = UNSET_RL
-       dic_SSSStartDate1                  = 0
-       dic_SSSStartDate2                  = 0
-       dic_SSS_exfremo_intercept          = 0.0 _d 0
-       dic_SSS_exfremo_slope              = 0.0 _d 0
-       dic_SSSMask                        = 'c'
-       dic_inscal_SSS                     = 1. _d 0
-
 C     If useEXF=F, s/r exf_readparms is not called and exf-parameters
 C     are not initialiased properly. The following few exf-related
 C     parameters need to have a defined value to be used in s/r
 C     exf_set_fld.
-       dic_exf_iprec           = 32
-       dic_useExfYearlyFields  = .FALSE.
-       dic_twoDigitYear        = .FALSE.
-       dic_exf_debugLev        = debugLevel
+        dic_exf_iprec           = 32
+        dic_useExfYearlyFields  = .FALSE.
+        dic_twoDigitYear        = .FALSE.
+        dic_exf_debugLev        = debugLevel
+        dic_ForcingCycle        = repeatPeriod
+         
+        IF ( .NOT. useEXF ) THEN
+          repeatPeriod       = dic_ForcingCycle
+          exf_iprec          = dic_exf_iprec
+          useExfYearlyFields = dic_useExfYearlyFields
+          twoDigitYear       = dic_twoDigitYear
+          exf_debugLev       = dic_exf_debugLev
+        ENDIF
+ 
+        dic_SilicaSurfPeriod               = 0.0 _d 0
+        dic_SilicaSurfRepCycle             = repeatPeriod
+        dic_SilicaSurfStartTime            = UNSET_RL
+        dic_SilicaSurfStartDate1           = 0
+        dic_SilicaSurfStartDate2           = 0
+        dic_SilicaSurf_exfremo_intercept   = 0.0 _d 0
+        dic_SilicaSurf_exfremo_slope       = 0.0 _d 0
+        dic_SilicaSurfMask                 = 'c'
+        dic_inscal_SilicaSurf              = 1. _d 0
+ 
+        dic_SilicaDeepPeriod               = 0.0 _d 0
+        dic_SilicaDeepRepCycle             = repeatPeriod
+        dic_SilicaDeepStartTime            = UNSET_RL
+        dic_SilicaDeepStartDate1           = 0
+        dic_SilicaDeepStartDate2           = 0
+        dic_SilicaDeep_exfremo_intercept   = 0.0 _d 0
+        dic_SilicaDeep_exfremo_slope       = 0.0 _d 0
+        dic_SilicaDeepMask                 = 'c'
+        dic_inscal_SilicaDeep              = 1. _d 0
+ 
+        dic_parPeriod                      = 0.0 _d 0
+        dic_parRepCycle                    = repeatPeriod
+        dic_parStartTime                   = UNSET_RL
+        dic_parStartDate1                  = 0
+        dic_parStartDate2                  = 0
+        dic_par_exfremo_intercept          = 0.0 _d 0
+        dic_par_exfremo_slope              = 0.0 _d 0
+        dic_parMask                        = 'c'
+        dic_inscal_par                     = 1. _d 0
+ 
+        dic_ironPeriod                     = 0.0 _d 0
+        dic_ironRepCycle                   = repeatPeriod
+        dic_ironStartTime                  = UNSET_RL
+        dic_ironStartDate1                 = 0
+        dic_ironStartDate2                 = 0
+        dic_iron_exfremo_intercept         = 0.0 _d 0
+        dic_iron_exfremo_slope             = 0.0 _d 0
+        dic_ironMask                       = 'c'
+        dic_inscal_iron                    = 1. _d 0
+ 
+        dic_atmospCO2Period                = 0.0 _d 0
+        dic_atmospCO2RepCycle              = repeatPeriod
+        dic_atmospCO2StartTime             = UNSET_RL
+        dic_atmospCO2StartDate1            = 0
+        dic_atmospCO2StartDate2            = 0
+        dic_atmospCO2_exfremo_intercept    = 0.0 _d 0
+        dic_atmospCO2_exfremo_slope        = 0.0 _d 0
+        dic_atmospCO2Mask                  = 'c'
+        dic_inscal_atmospCO2               = 1. _d 0
+ 
+        dic_icePeriod                      = 0.0 _d 0
+        dic_iceRepCycle                    = repeatPeriod
+        dic_iceStartTime                   = UNSET_RL
+        dic_iceStartDate1                  = 0
+        dic_iceStartDate2                  = 0
+        dic_ice_exfremo_intercept          = 0.0 _d 0
+        dic_ice_exfremo_slope              = 0.0 _d 0
+        dic_iceMask                        = 'c'
+        dic_inscal_ice                     = 1. _d 0
+ 
+        dic_windPeriod                     = 0.0 _d 0
+        dic_windRepCycle                   = repeatPeriod
+        dic_windStartTime                  = UNSET_RL
+        dic_windStartDate1                 = 0
+        dic_windStartDate2                 = 0
+        dic_wind_exfremo_intercept         = 0.0 _d 0
+        dic_wind_exfremo_slope             = 0.0 _d 0
+        dic_windMask                       = 'c'
+        dic_inscal_wind                    = 1. _d 0
+ 
+        dic_atmospPeriod                   = 0.0 _d 0
+        dic_atmospRepCycle                 = repeatPeriod
+        dic_atmospStartTime                = UNSET_RL
+        dic_atmospStartDate1               = 0
+        dic_atmospStartDate2               = 0
+        dic_atmosp_exfremo_intercept       = 0.0 _d 0
+        dic_atmosp_exfremo_slope           = 0.0 _d 0
+        dic_atmospMask                     = 'c'
+        dic_inscal_atmosp                  = 1. _d 0
 
-       IF ( .NOT. useEXF ) THEN
-        repeatPeriod       = DIC_forcingPeriod
-        exf_iprec          = dic_exf_iprec
-        useExfYearlyFields = dic_useExfYearlyFields
-        twoDigitYear       = dic_twoDigitYear
-        exf_debugLev       = dic_exf_debugLev
-       ENDIF
+        dic_chlPeriod                      = 0.0 _d 0
+        dic_chlRepCycle                    = repeatPeriod
+        dic_chlStartTime                   = UNSET_RL
+        dic_chlStartDate1                  = 0
+        dic_chlStartDate2                  = 0
+        dic_chl_exfremo_intercept          = 0.0 _d 0
+        dic_chl_exfremo_slope              = 0.0 _d 0
+        dic_chlMask                        = 'c'
+        dic_inscal_chl                     = 1. _d 0
 
+        dic_SSTPeriod                      = 0.0 _d 0
+        dic_SSTRepCycle                    = repeatPeriod
+        dic_SSTStartTime                   = UNSET_RL
+        dic_SSTStartDate1                  = 0
+        dic_SSTStartDate2                  = 0
+        dic_SST_exfremo_intercept          = 0.0 _d 0
+        dic_SST_exfremo_slope              = 0.0 _d 0
+        dic_SSTMask                        = 'c'
+        dic_inscal_SST                     = 1. _d 0
+
+        dic_SSSPeriod                      = 0.0 _d 0
+        dic_SSSRepCycle                    = repeatPeriod
+        dic_SSSStartTime                   = UNSET_RL
+        dic_SSSStartDate1                  = 0
+        dic_SSSStartDate2                  = 0
+        dic_SSS_exfremo_intercept          = 0.0 _d 0
+        dic_SSS_exfremo_slope              = 0.0 _d 0
+        dic_SSSMask                        = 'c'
+        dic_inscal_SSS                     = 1. _d 0
 #  ifdef USE_EXF_INTERPOLATION
 
        IF ( .NOT. useEXF ) THEN

--- a/pkg/dic/dic_readparms.F
+++ b/pkg/dic/dic_readparms.F
@@ -37,7 +37,10 @@ C     === Global variables ===
 #  include "DIC_INTERP_PARAM.h"
 # endif
 #endif
-
+#ifdef ALLOW_OCN_COMPON_INTERF
+# include "CPL_PARAMS.h"
+# include "OCNCPL.h"
+#endif /* ALLOW_OCN_COMPON_INTERF */
 C     !INPUT/OUTPUT PARAMETERS:
 C     === Routine arguments ===
 C     myThid    :: My Thread Id. number
@@ -1560,6 +1563,80 @@ C  If USE_PLOAD is not defined, then dic_atmospFile may be used
         CALL ALL_PROC_DIE( 0 )
         STOP 'ABNORMAL END: S/R DIC_READPARMS'
       ENDIF
+
+C Warnings
+#ifdef DIC_CALCITE_SAT
+      IF ( useCalciteSaturation .AND. dic_SSTFile .NE. ' ' ) THEN
+        WRITE(msgBuf,'(2A)') 'DIC_READPARMS WARNING: ',
+     &      'using dic_SSTFile (SST input) only impacts gas exchange'
+        CALL PRINT_MESSAGE( msgBuf, standardMessageUnit,
+     I                    SQUEEZE_RIGHT, myThid )  
+        WRITE(msgBuf,'(2A)') 'DIC_READPARMS WARNING: ',
+     &      'prescribing 3D THETA field is not implemented.'
+        CALL PRINT_MESSAGE( msgBuf, standardMessageUnit,
+     I                    SQUEEZE_RIGHT, myThid )
+      ENDIF 
+
+      IF ( useCalciteSaturation .AND. dic_SSSFile .NE. ' ' ) THEN
+        WRITE(msgBuf,'(2A)') 'DIC_READPARMS WARNING: ',
+     &      'using dic_SSSFile (SSS input) only impacts gas exchange'
+        CALL PRINT_MESSAGE( msgBuf, standardMessageUnit,
+     I                    SQUEEZE_RIGHT, myThid )  
+        WRITE(msgBuf,'(2A)') 'DIC_READPARMS WARNING: ',
+     &      'prescribing 3D SALT field is not implemented.'
+        CALL PRINT_MESSAGE( msgBuf, standardMessageUnit,
+     I                    SQUEEZE_RIGHT, myThid )
+      ENDIF 
+#endif /* DIC_CALCITE_SAT */
+
+      IF ( useThSIce .AND. dic_iceFile .NE. ' ' ) THEN
+        WRITE(msgBuf,'(2A)') 'DIC_READPARMS WARNING: ',
+     &      'to use dynamic sea ice fraction from pkg/thice'
+        CALL PRINT_MESSAGE( msgBuf, standardMessageUnit,
+     I                    SQUEEZE_RIGHT, myThid )
+        WRITE(msgBuf,'(2A)') 'DIC_READPARMS WARNING: ',
+     &      'make sure to set dic_iceFile = " " in data.dic'
+        CALL PRINT_MESSAGE( msgBuf, standardMessageUnit,
+     I                    SQUEEZE_RIGHT, myThid )
+      ENDIF
+
+      IF ( useSEAICE .AND. dic_iceFile .NE. ' ' ) THEN
+        WRITE(msgBuf,'(2A)') 'DIC_READPARMS WARNING: ',
+     &      'to use dynamic sea ice fraction from pkg/seaice'
+        CALL PRINT_MESSAGE( msgBuf, standardMessageUnit,
+     I                    SQUEEZE_RIGHT, myThid )
+        WRITE(msgBuf,'(2A)') 'DIC_READPARMS WARNING: ',
+     &      'make sure to set dic_iceFile = " " in data.dic'
+        CALL PRINT_MESSAGE( msgBuf, standardMessageUnit,
+     I                    SQUEEZE_RIGHT, myThid )
+      ENDIF
+
+#ifdef ALLOW_OCN_COMPON_INTERF
+      IF ( useCoupler ) THEN
+        IF ( useImportCO2 .AND. dic_atmospCO2File .NE. ' ' ) THEN
+          WRITE(msgBuf,'(2A)') 'DIC_READPARMS WARNING: ',
+     &      'to use atmospheric pCO2 from the atmospheric model'
+          CALL PRINT_MESSAGE( msgBuf, standardMessageUnit,
+     I                    SQUEEZE_RIGHT, myThid )
+          WRITE(msgBuf,'(2A)') 'DIC_READPARMS WARNING: ',
+     &      'make sure to set dic_atmospCO2File = " " in data.dic'
+          CALL PRINT_MESSAGE( msgBuf, standardMessageUnit,
+     I                    SQUEEZE_RIGHT, myThid )
+        ENDIF
+
+        IF ( useImportWSpd .AND. dic_windFile .NE. ' ' ) THEN
+          WRITE(msgBuf,'(2A)') 'DIC_READPARMS WARNING: ',
+     &      'to use wind speed from the atmospheric model'
+          CALL PRINT_MESSAGE( msgBuf, standardMessageUnit,
+     I                    SQUEEZE_RIGHT, myThid )
+          WRITE(msgBuf,'(2A)') 'DIC_READPARMS WARNING: ',
+     &      'make sure to set dic_windFile = " " in data.dic'
+          CALL PRINT_MESSAGE( msgBuf, standardMessageUnit,
+     I                    SQUEEZE_RIGHT, myThid )
+        ENDIF
+      ENDIF
+#endif /* ALLOW_OCN_COMPON_INTERF */
+
       _END_MASTER(myThid)
 
 C--   Everyone else must wait for the parameters to be loaded

--- a/pkg/dic/dic_readparms.F
+++ b/pkg/dic/dic_readparms.F
@@ -371,14 +371,14 @@ C-- setting default values for Calcite Saturation params ends here.
 
 C     some sensible defaults
       dic_ice_const        = 0.      _d 0
-      dic_wind_const       = 0.      _d 0
       dic_atmosp_const     = 1.01325 _d 5
-      dic_silicaSurf_const = 7.6     _d -3
-      dic_Silicadeep_const = 3.      _d -2
-      dic_par_const        = 0.      _d 0
-      dic_iron_const       = 0.      _d 0
+      dic_silicaSurf_const = 7.6838  _d -3
+      dic_silicaDeep_const = 3.      _d -2
       dic_atmospCO2_const  = dic_pCO2
-      dic_chl_const        = 0.      _d 0
+      dic_wind_const       = 5.      _d 0
+      dic_par_const        = 100.    _d 0
+      dic_iron_const       = 1.      _d -11
+      dic_chl_const        = 1. _d -2
       dic_SST_const        = 24.     _d 0
       dic_SSS_const        = 34.5    _d 0
 

--- a/pkg/dic/dic_readparms.F
+++ b/pkg/dic/dic_readparms.F
@@ -391,6 +391,8 @@ C default periodic forcing to same as for physics
 
 C  default based on 360 day year or related to calendar settings
        dic_secondsPerYear   = 360. _d 0 * 86400. _d 0
+
+C---+----1----+----2----+----3----+----4----+----5----+----6----+----7-|--+----|
 #ifdef ALLOW_CAL
        IF ( useCAL ) THEN
         IF ( theCalendar .EQ. 'gregorian') THEN
@@ -401,39 +403,6 @@ C  default based on 360 day year or related to calendar settings
        ENDIF
 #endif
 
-      WRITE(msgBuf,'(A)') ' DIC_READPARMS: opening data.dic'
-      CALL PRINT_MESSAGE( msgBuf, standardMessageUnit,
-     I                    SQUEEZE_RIGHT, myThid )
-
-      CALL OPEN_COPY_DATA_FILE( 'data.dic', 'DIC_READPARMS',
-     O                          iUnit, myThid )
-
-C--   Read parameters from open data file:
-
-C-    Abiotic parameters
-      READ(UNIT=iUnit, NML=ABIOTIC_PARMS)
-
-#ifdef DIC_BIOTIC
-C-    Biotic parameters
-      READ(UNIT=iUnit, NML=BIOTIC_PARMS)
-#endif
-
-C-    forcing filenames and parameters
-      READ(UNIT=iUnit, NML=DIC_FORCING)
-
-      WRITE(msgBuf,'(A)')
-     &   ' DIC_READPARMS: finished reading data.dic'
-      CALL PRINT_MESSAGE( msgBuf, standardMessageUnit,
-     I                    SQUEEZE_RIGHT, myThid )
-
-C--   Close the open data file
-#ifdef SINGLE_DISK_IO
-      CLOSE(iUnit)
-#else
-      CLOSE(iUnit,STATUS='DELETE')
-#endif /* SINGLE_DISK_IO */
-
-C---+----1----+----2----+----3----+----4----+----5----+----6----+----7-|--+----|
 # ifdef ALLOW_EXF
       IF ( dic_useEXF ) THEN
        dic_SilicaSurfPeriod               = 0.0 _d 0
@@ -690,8 +659,38 @@ C     dic_useEXF
       ENDIF
 # endif /* ALLOW_EXF */
 
-C-    derive other parameters:
+C--   Open data file and read parameters from it:
+      WRITE(msgBuf,'(A)') ' DIC_READPARMS: opening data.dic'
+      CALL PRINT_MESSAGE( msgBuf, standardMessageUnit,
+     I                    SQUEEZE_RIGHT, myThid )
 
+      CALL OPEN_COPY_DATA_FILE( 'data.dic', 'DIC_READPARMS',
+     O                          iUnit, myThid )
+
+C-    Abiotic parameters
+      READ(UNIT=iUnit, NML=ABIOTIC_PARMS)
+
+#ifdef DIC_BIOTIC
+C-    Biotic parameters
+      READ(UNIT=iUnit, NML=BIOTIC_PARMS)
+#endif
+
+C-    forcing filenames and parameters
+      READ(UNIT=iUnit, NML=DIC_FORCING)
+
+      WRITE(msgBuf,'(A)')
+     &   ' DIC_READPARMS: finished reading data.dic'
+      CALL PRINT_MESSAGE( msgBuf, standardMessageUnit,
+     I                    SQUEEZE_RIGHT, myThid )
+
+C--   Close the open data file
+#ifdef SINGLE_DISK_IO
+      CLOSE(iUnit)
+#else
+      CLOSE(iUnit,STATUS='DELETE')
+#endif /* SINGLE_DISK_IO */
+
+C-    derive other parameters:
 C-    set parameter default values
       IF ( selectBTconst  .EQ.UNSET_I ) selectBTconst   = 1
       IF ( selectFTconst  .EQ.UNSET_I ) selectFTconst   = 1
@@ -1025,10 +1024,10 @@ C     and the corresponding file from which the data will be read.
 C--   dic wind speed
         IF ( dic_WindFile .NE. ' ' ) THEN
           CALL EXF_FLD_SUMMARY( 'wind speed',
-     I         dic_windfile, 
-     I         dic_windRepCycle, 
-     I         dic_windperiod,
-     I         dic_windStartTime, 
+     I         dic_WindFile, 
+     I         dic_WindRepCycle, 
+     I         dic_WindPeriod,
+     I         dic_WindStartTime, 
      I         useExfYearlyFields,
      I         addBlkLn, 
      I         myThid )
@@ -1049,9 +1048,9 @@ C--   dic wind speed
 C--   dic atmospheric pressure
         IF ( dic_atmospFile .NE. ' ' ) THEN
           CALL EXF_FLD_SUMMARY( 'atmospheric pressure',
-     I         dic_atmospfile, 
+     I         dic_atmospFile, 
      I         dic_atmospRepCycle, 
-     I         dic_atmospperiod,
+     I         dic_atmospPeriod,
      I         dic_atmospStartTime, 
      I         useExfYearlyFields, 
      I         addBlkLn, 
@@ -1075,7 +1074,7 @@ C--   dic surface silica
           CALL EXF_FLD_SUMMARY( 'surface silica',
      I         dic_SilicaFile, 
      I         dic_SilicaSurfRepCycle, 
-     I         dic_SilicaSurfperiod,
+     I         dic_SilicaSurfPeriod,
      I         dic_SilicaSurfStartTime, 
      I         useExfYearlyFields, 
      I         addBlkLn, 
@@ -1099,7 +1098,7 @@ C--  dic deep silica
           CALL EXF_FLD_SUMMARY( 'deep silica',
      I         dic_SilicaDeepFile, 
      I         dic_SilicaDeepRepCycle, 
-     I         dic_SilicaDeepperiod,
+     I         dic_SilicaDeepPeriod,
      I         dic_SilicaDeepStartTime, 
      I         useExfYearlyFields, 
      I         addBlkLn, 
@@ -1124,7 +1123,7 @@ C--   dic par
      I        'photosynthetically active radiation',
      I         dic_parFile, 
      I         dic_parRepCycle, 
-     I         dic_parperiod,
+     I         dic_parPeriod,
      I         dic_parStartTime, 
      I         useExfYearlyFields, 
      I         addBlkLn, 
@@ -1148,7 +1147,7 @@ C--   dic iron forcing
           CALL EXF_FLD_SUMMARY( 'aeolian iron flux',
      I         dic_ironFile, 
      I         dic_ironRepCycle, 
-     I         dic_ironperiod,
+     I         dic_ironPeriod,
      I         dic_ironStartTime, 
      I         useExfYearlyFields, 
      I         addBlkLn, 
@@ -1172,7 +1171,7 @@ C--   dic atmospheric CO2 forcing
           CALL EXF_FLD_SUMMARY( 'atmospheric CO2',
      I         dic_atmospCO2File, 
      I         dic_atmospCO2RepCycle, 
-     I         dic_atmospCO2period,
+     I         dic_atmospCO2Period,
      I         dic_atmospCO2StartTime, 
      I         useExfYearlyFields, 
      I         addBlkLn, 
@@ -1196,7 +1195,7 @@ C--  dic sea ice forcing
           CALL EXF_FLD_SUMMARY( 'sea ice fraction',
      I         dic_iceFile, 
      I         dic_iceRepCycle, 
-     I         dic_iceperiod,
+     I         dic_icePeriod,
      I         dic_iceStartTime, 
      I         useExfYearlyFields, 
      I         addBlkLn, 
@@ -1220,7 +1219,7 @@ C-- dic chlorophyll forcing
           CALL EXF_FLD_SUMMARY( 'chlorophyll',
      I         dic_chlaFile, 
      I         dic_chlRepCycle, 
-     I         dic_chlperiod,
+     I         dic_chlPeriod,
      I         dic_chlStartTime, 
      I         useExfYearlyFields, 
      I         addBlkLn, 
@@ -1245,7 +1244,7 @@ C-- dic SST forcing
      I        'carbon chem sea surface temperature',
      I         dic_SSTFile, 
      I         dic_SSTRepCycle, 
-     I         dic_SSTperiod,
+     I         dic_SSTPeriod,
      I         dic_SSTStartTime, 
      I         useExfYearlyFields, 
      I         addBlkLn, 
@@ -1270,7 +1269,7 @@ C-- dic SSS forcing
      I        'carbon chem sea surface salinity',
      I         dic_SSSFile, 
      I         dic_SSSRepCycle, 
-     I         dic_SSSperiod,
+     I         dic_SSSPeriod,
      I         dic_SSSStartTime, 
      I         useExfYearlyFields, 
      I         addBlkLn, 

--- a/pkg/dic/dic_readparms.F
+++ b/pkg/dic/dic_readparms.F
@@ -1,4 +1,7 @@
 #include "DIC_OPTIONS.h"
+#ifdef ALLOW_EXF
+# include "EXF_OPTIONS.h"
+#endif
 
 CBOP
 C !ROUTINE: DIC_READPARMS
@@ -22,6 +25,18 @@ C     === Global variables ===
 #include "DIC_VARS.h"
 #include "PTRACERS_SIZE.h"
 #include "PTRACERS_PARAMS.h"
+#ifdef ALLOW_CAL
+# include "cal.h"
+#endif
+#ifdef ALLOW_EXF
+# include "EXF_PARAM.h"
+# include "DIC_EXF.h"
+# ifdef USE_EXF_INTERPOLATION
+#  include "EXF_INTERP_SIZE.h"
+#  include "EXF_INTERP_PARAM.h"
+#  include "DIC_INTERP_PARAM.h"
+# endif
+#endif
 
 C     !INPUT/OUTPUT PARAMETERS:
 C     === Routine arguments ===
@@ -42,7 +57,19 @@ C     errCount  :: error counter
       INTEGER selectBTconst, selectFTconst, selectHFconst
       INTEGER selectK1K2const, selectPHsolver
 #endif
-
+#ifdef ALLOW_EXF
+C     Local helper parameters that can be set in case we want to use
+C       pkg/exf machinery for dic fields with dic_useEXF=T but useEXF=F 
+C.      (physical model not using pkg/exf)
+      INTEGER dic_exf_iprec, dic_exf_debugLev
+      LOGICAL dic_useExfYearlyFields, dic_twoDigitYear
+      LOGICAL prtBlkLn, addBlkLn
+# ifdef USE_EXF_INTERPOLATION
+      LOGICAL dic_exf_output_interp
+      INTEGER j
+# endif
+#endif
+CEOP
 C---+----1----+----2----+----3----+----4----+----5----+----6----+----7-|--+----|
 
 C-- Abiotic dic parameters:
@@ -148,12 +175,121 @@ C                  read in rainRatioUniform and filled in 2d array rain_ratio
 #endif
 
       NAMELIST /DIC_FORCING/
-     &          DIC_windFile, DIC_atmospFile, DIC_silicaFile,
-     &          DIC_deepSilicaFile, DIC_iceFile, DIC_parFile,
-     &          DIC_chlaFile, DIC_ironFile,
-     &          DIC_forcingPeriod, DIC_forcingCycle,
-     &          dic_int1, dic_int2, dic_int3, dic_int4, dic_pCO2
-
+     &     DIC_useEXF,
+     &     DIC_forcingPeriod, DIC_forcingCycle,
+     &     DIC_windFile, DIC_atmospFile, DIC_silicaFile,
+     &     DIC_silicaDeepFile, DIC_iceFile, DIC_parFile,
+     &     DIC_chlaFile, DIC_ironFile,
+     &     DIC_atmospCO2File, DIC_SSTFile, DIC_SSSFile,
+     &     dic_int1, dic_int2, dic_int3, dic_int4, dic_pCO2,
+     &     dic_SilicaSurf_const, dic_SilicaDeep_const, dic_par_const,
+     &     dic_Iron_const, dic_atmospCO2_const, dic_wind_const,
+     &     dic_atmosp_const, dic_ice_const, dic_chl_const,
+     &     dic_SST_const, dic_SSS_const
+# ifdef ALLOW_EXF
+     &     , dic_exf_iprec, dic_exf_debugLev,
+     &     dic_useExfYearlyFields, dic_twoDigitYear,
+C
+     &     dic_SilicaSurfPeriod, dic_SilicaSurfRepCycle, 
+     &     dic_SilicaSurfStartTime,
+     &     dic_SilicaSurfStartDate1, dic_SilicaSurfStartDate2,
+     &     dic_SilicaSurf_exfremo_intercept, 
+     &     dic_SilicaSurf_exfremo_slope,
+     &     dic_SilicaSurfMask, dic_inscal_SilicaSurf,
+C
+     &     dic_SilicaDeepPeriod, dic_SilicaDeepRepCycle, 
+     &     dic_SilicaDeepStartTime,
+     &     dic_SilicaDeepStartDate1, dic_SilicaDeepStartDate2,
+     &     dic_SilicaDeep_exfremo_intercept, 
+     &     dic_SilicaDeep_exfremo_slope,
+     &     dic_SilicaDeepMask, dic_inscal_SilicaDeep,
+C
+     &     dic_parPeriod, dic_parRepCycle, dic_parStartTime,
+     &     dic_parStartDate1, dic_parStartDate2,
+     &     dic_par_exfremo_intercept, dic_par_exfremo_slope,
+     &     dic_parMask, dic_inscal_par,
+C
+     &     dic_IronPeriod, dic_IronRepCycle, dic_IronStartTime,
+     &     dic_IronStartDate1, dic_IronStartDate2,
+     &     dic_Iron_exfremo_intercept, dic_Iron_exfremo_slope,
+     &     dic_IronMask, dic_inscal_Iron,
+C
+     &     dic_atmospCO2Period, dic_atmospCO2RepCycle, 
+     &     dic_atmospCO2StartTime,
+     &     dic_atmospCO2StartDate1, dic_atmospCO2StartDate2,
+     &     dic_atmospCO2_exfremo_intercept, dic_atmospCO2_exfremo_slope,
+     &     dic_atmospCO2Mask, dic_inscal_atmospCO2,
+C
+     &     dic_windPeriod, dic_windRepCycle, dic_windStartTime,
+     &     dic_windStartDate1, dic_windStartDate2,
+     &     dic_wind_exfremo_intercept, dic_wind_exfremo_slope,
+     &     dic_windMask, dic_inscal_wind,
+C
+     &     dic_icePeriod, dic_iceRepCycle, dic_iceStartTime,
+     &     dic_iceStartDate1, dic_iceStartDate2,
+     &     dic_ice_exfremo_intercept, dic_ice_exfremo_slope,
+     &     dic_iceMask, dic_inscal_ice,
+C
+     &     dic_atmospPeriod, dic_atmospRepCycle, dic_atmospStartTime,
+     &     dic_atmospStartDate1, dic_atmospStartDate2,
+     &     dic_atmosp_exfremo_intercept, dic_atmosp_exfremo_slope,
+     &     dic_atmospMask, dic_inscal_atmosp,
+C
+     &     dic_chlperiod, dic_chlRepCycle, dic_chlStartTime,
+     &     dic_chlstartdate1, dic_chlstartdate2,
+     &     dic_chl_exfremo_intercept, dic_chl_exfremo_slope,
+     &     dic_chlMask, dic_inscal_chl,
+C
+     &     dic_SSTPeriod, dic_SSTRepCycle, dic_SSTStartTime,
+     &     dic_SSTStartDate1, dic_SSTStartDate2,
+     &     dic_SST_exfremo_intercept, dic_SST_exfremo_slope,
+     &     dic_SSTMask, dic_inscal_SST,
+C
+     &     dic_SSSPeriod, dic_SSSRepCycle, dic_SSSStartTime,
+     &     dic_SSSStartDate1, dic_SSSStartDate2,
+     &     dic_SSS_exfremo_intercept, dic_SSS_exfremo_slope,
+     &     dic_SSSMask, dic_inscal_SSS
+#  ifdef USE_EXF_INTERPOLATION
+     &     , dic_exf_output_interp,
+C
+     &     SilicaSurf_lon0, SilicaSurf_lat0, SilicaSurf_nlon, 
+     &     SilicaSurf_nlat, SilicaSurf_lon_inc, 
+     &     SilicaSurf_lat_inc, SilicaSurf_interpMethod,
+C
+     &     SilicaDeep_lon0, SilicaDeep_lat0, SilicaDeep_nlon,
+     &     SilicaDeep_nlat, SilicaDeep_lon_inc, 
+     &     SilicaDeep_lat_inc, SilicaDeep_interpMethod,
+C Additional parameters for interpolation of 3D silica fields     
+     &     SilicaDeep_nzin, SilicaDeep_dzin,
+C
+     &     par_lon0, par_lat0, par_nlon, par_nlat,
+     &     par_lon_inc, par_lat_inc, par_interpMethod,
+C
+     &     Fe_lon0, Fe_lat0, Fe_nlon, Fe_nlat,
+     &     Fe_lon_inc, Fe_lat_inc, Fe_interpMethod,
+C
+     &     apco2_lon0, apco2_lat0, apco2_nlon, apco2_nlat,
+     &     apco2_lon_inc, apco2_lat_inc, apco2_interpMethod,
+C
+     &     wind_lon0, wind_lat0, wind_nlon, wind_nlat,
+     &     wind_lon_inc, wind_lat_inc, wind_interpMethod,
+C
+     &     ice_lon0, ice_lat0, ice_nlon, ice_nlat,
+     &     ice_lon_inc, ice_lat_inc, ice_interpMethod,
+C
+     &     atmosp_lon0, atmosp_lat0, atmosp_nlon, atmosp_nlat,
+     &     atmosp_lon_inc, atmosp_lat_inc, atmosp_interpMethod,
+C
+     &     chl_lon0, chl_lat0, chl_nlon, chl_nlat,
+     &     chl_lon_inc, chl_lat_inc, chl_interpMethod,
+C
+     &     SST_lon0, SST_lat0, SST_nlon, SST_nlat,
+     &     SST_lon_inc, SST_lat_inc, SST_interpMethod,
+C
+     &     SSS_lon0, SSS_lat0, SSS_nlon, SSS_nlat,
+     &     SSS_lon_inc, SSS_lat_inc, SSS_interpMethod
+#  endif
+# endif /* ALLOW_EXF */
 C---+----1----+----2----+----3----+----4----+----5----+----6----+----7-|--+----|
 
       _BEGIN_MASTER(myThid)
@@ -189,47 +325,78 @@ C-- setting default values for Calcite Saturation params ends here.
        zca                  = 3500. _d 0
 
 #ifdef DIC_BIOTIC
-       DOPfraction = 0.67 _d 0
-       KDOPRemin   = 1. _d 0/(6. _d 0*30. _d 0*86400. _d 0)
-       KRemin      = 0.9 _d 0
-       zcrit       = 500. _d 0
-       O2crit      = 4. _d -3
-       R_OP        =-170. _d 0
-       R_CP        = 117. _d 0
-       R_NP        = 16. _d 0
-       R_FeP       = 0.000468 _d 0
-       parfrac     = 0.4 _d 0
-       k0          = 0.02 _d 0
-       kchl        = 0.02 _d 0
-       lit0        = 30. _d 0
-       KPO4        = 5. _d -4
-       KFE         = 1.2 _d -7
-       alpfe       = 0.01 _d 0
+       DOPfraction   = 0.67 _d 0
+       KDOPRemin     = 1. _d 0/(6. _d 0*30. _d 0*86400. _d 0)
+       KRemin        = 0.9 _d 0
+       zcrit         = 500. _d 0
+       O2crit        = 4. _d -3
+       R_OP          =-170. _d 0
+       R_CP          = 117. _d 0
+       R_NP          = 16. _d 0
+       R_FeP         = 0.000468 _d 0
+       parfrac       = 0.4 _d 0
+       k0            = 0.02 _d 0
+       kchl          = 0.02 _d 0
+       lit0          = 30. _d 0
+       KPO4          = 5. _d -4
+       KFE           = 1.2 _d -7
+       alpfe         = 0.01 _d 0
        fesedflux_pcm = 6.8 _d -4 * 106. _d 0
-       FeIntSec    = 0.5 _d -6 / 86400. _d 0
-       freefemax   = 3. _d -7
-       KScav       = 0.19 _d 0/(360. _d 0*86400. _d 0)
-       ligand_stab = 1. _d 8
-       ligand_tot  = 1. _d -6
+       FeIntSec      = 0.5 _d -6 / 86400. _d 0
+       freefemax     = 3. _d -7
+       KScav         = 0.19 _d 0/(360. _d 0*86400. _d 0)
+       ligand_stab   = 1. _d 8
+       ligand_tot    = 1. _d -6
        alphaUniform     = 2. _d -3/(360. _d 0 * 86400. _d 0)
        rainRatioUniform = 7. _d -2
 #endif
-       DIC_windFile   = ' '
-       DIC_atmospFile = ' '
-       DIC_silicaFile = ' '
-       DIC_deepSilicaFile = ' '
-       DIC_iceFile    = ' '
-       DIC_parFile    = ' '
-       DIC_chlaFile   = ' '
-       DIC_ironFile   = ' '
-       dic_int1    = 0
-       dic_int2    = 0
-       dic_int3    = 0
-       dic_int4    = 0
-       dic_pCO2    = 278. _d -6
+       dic_useEXF         = .FALSE.
+       DIC_windFile       = ' '
+       DIC_atmospFile     = ' '
+       DIC_silicaFile     = ' '
+       DIC_silicaDeepFile = ' '
+       DIC_iceFile         = ' '
+       DIC_parFile         = ' '
+       DIC_atmospCO2File   = ' '
+       DIC_atmospFile      = ' '
+       DIC_chlaFile        = ' '
+       DIC_ironFile        = ' '
+       DIC_SSTFile         = ' '
+       DIC_SSSFile         = ' '
+       dic_int1            = 0
+       dic_int2            = 0
+       dic_int3            = 0
+       dic_int4            = 0
+       dic_pCO2            = 278. _d -6
+
+C     some sensible defaults
+      dic_ice_const        = 0.      _d 0
+      dic_wind_const       = 0.      _d 0
+      dic_atmosp_const     = 1.01325 _d 5
+      dic_silicaSurf_const = 7.6     _d -3
+      dic_Silicadeep_const = 3.      _d -2
+      dic_par_const        = 0.      _d 0
+      dic_iron_const       = 0.      _d 0
+      dic_atmospCO2_const  = dic_pCO2
+      dic_chl_const        = 0.      _d 0
+      dic_SST_const        = 24.     _d 0
+      dic_SSS_const        = 34.5    _d 0
+
 C default periodic forcing to same as for physics
        DIC_forcingPeriod = externForcingPeriod
        DIC_forcingCycle  = externForcingCycle
+
+C  default based on 360 day year or related to calendar settings
+       dic_secondsPerYear   = 360. _d 0 * 86400. _d 0
+#ifdef ALLOW_CAL
+       IF ( useCAL ) THEN
+        IF ( theCalendar .EQ. 'gregorian') THEN
+         dic_secondsPerYear = 365.25 _d 0*86400. _d 0
+        ELSEIF ( theCalendar .EQ. 'noLeapYear') THEN
+         dic_secondsPerYear = 365.00 _d 0*86400. _d 0
+        ENDIF
+       ENDIF
+#endif
 
       WRITE(msgBuf,'(A)') ' DIC_READPARMS: opening data.dic'
       CALL PRINT_MESSAGE( msgBuf, standardMessageUnit,
@@ -241,15 +408,15 @@ C default periodic forcing to same as for physics
 C--   Read parameters from open data file:
 
 C-    Abiotic parameters
-      READ(UNIT=iUnit,NML=ABIOTIC_PARMS)
+      READ(UNIT=iUnit, NML=ABIOTIC_PARMS)
 
 #ifdef DIC_BIOTIC
 C-    Biotic parameters
-      READ(UNIT=iUnit,NML=BIOTIC_PARMS)
+      READ(UNIT=iUnit, NML=BIOTIC_PARMS)
 #endif
 
 C-    forcing filenames and parameters
-      READ(UNIT=iUnit,NML=DIC_FORCING)
+      READ(UNIT=iUnit, NML=DIC_FORCING)
 
       WRITE(msgBuf,'(A)')
      &   ' DIC_READPARMS: finished reading data.dic'
@@ -264,6 +431,262 @@ C--   Close the open data file
 #endif /* SINGLE_DISK_IO */
 
 C---+----1----+----2----+----3----+----4----+----5----+----6----+----7-|--+----|
+# ifdef ALLOW_EXF
+      IF ( dic_useEXF ) THEN
+       dic_SilicaSurfPeriod               = 0.0 _d 0
+       dic_SilicaSurfRepCycle             = DIC_forcingPeriod
+       dic_SilicaSurfStartTime            = UNSET_RL
+       dic_SilicaSurfStartDate1           = 0
+       dic_SilicaSurfStartDate2           = 0
+       dic_SilicaSurf_exfremo_intercept   = 0.0 _d 0
+       dic_SilicaSurf_exfremo_slope       = 0.0 _d 0
+       dic_SilicaSurfMask                 = 'c'
+       dic_inscal_SilicaSurf              = 1. _d 0
+
+       dic_SilicaDeepPeriod               = 0.0 _d 0
+       dic_SilicaDeepRepCycle             = DIC_forcingPeriod
+       dic_SilicaDeepStartTime            = UNSET_RL
+       dic_SilicaDeepStartDate1           = 0
+       dic_SilicaDeepStartDate2           = 0
+       dic_SilicaDeep_exfremo_intercept   = 0.0 _d 0
+       dic_SilicaDeep_exfremo_slope       = 0.0 _d 0
+       dic_SilicaDeepMask                 = 'c'
+       dic_inscal_SilicaDeep              = 1. _d 0
+
+       dic_parPeriod                      = 0.0 _d 0
+       dic_parRepCycle                    = DIC_forcingPeriod
+       dic_parStartTime                   = UNSET_RL
+       dic_parStartDate1                  = 0
+       dic_parStartDate2                  = 0
+       dic_par_exfremo_intercept          = 0.0 _d 0
+       dic_par_exfremo_slope              = 0.0 _d 0
+       dic_parMask                        = 'c'
+       dic_inscal_par                     = 1. _d 0
+
+       dic_ironPeriod                     = 0.0 _d 0
+       dic_ironRepCycle                   = DIC_forcingPeriod
+       dic_ironStartTime                  = UNSET_RL
+       dic_ironStartDate1                 = 0
+       dic_ironStartDate2                 = 0
+       dic_iron_exfremo_intercept         = 0.0 _d 0
+       dic_iron_exfremo_slope             = 0.0 _d 0
+       dic_ironMask                       = 'c'
+       dic_inscal_iron                    = 1. _d 0
+
+       dic_atmospCO2Period                = 0.0 _d 0
+       dic_atmospCO2RepCycle              = DIC_forcingPeriod
+       dic_atmospCO2StartTime             = UNSET_RL
+       dic_atmospCO2StartDate1            = 0
+       dic_atmospCO2StartDate2            = 0
+       dic_atmospCO2_exfremo_intercept    = 0.0 _d 0
+       dic_atmospCO2_exfremo_slope        = 0.0 _d 0
+       dic_atmospCO2Mask                  = 'c'
+       dic_inscal_atmospCO2                 = 1. _d 0
+
+       dic_icePeriod                      = 0.0 _d 0
+       dic_iceRepCycle                    = DIC_forcingPeriod
+       dic_iceStartTime                   = UNSET_RL
+       dic_iceStartDate1                  = 0
+       dic_iceStartDate2                  = 0
+       dic_ice_exfremo_intercept          = 0.0 _d 0
+       dic_ice_exfremo_slope              = 0.0 _d 0
+       dic_iceMask                        = 'c'
+       dic_inscal_ice                     = 1. _d 0
+
+       dic_windPeriod                     = 0.0 _d 0
+       dic_windRepCycle                   = DIC_forcingPeriod
+       dic_windStartTime                  = UNSET_RL
+       dic_windStartDate1                 = 0
+       dic_windStartDate2                 = 0
+       dic_wind_exfremo_intercept         = 0.0 _d 0
+       dic_wind_exfremo_slope             = 0.0 _d 0
+       dic_windMask                       = 'c'
+       dic_inscal_wind                    = 1. _d 0
+
+       dic_atmospPeriod                   = 0.0 _d 0
+       dic_atmospRepCycle                 = DIC_forcingPeriod
+       dic_atmospStartTime                = UNSET_RL
+       dic_atmospStartDate1               = 0
+       dic_atmospStartDate2               = 0
+       dic_atmosp_exfremo_intercept       = 0.0 _d 0
+       dic_atmosp_exfremo_slope           = 0.0 _d 0
+       dic_atmospMask                     = 'c'
+C convert atmospheric pressure from Pa or mbar to Atm for use in dic_surfforcing
+       dic_inscal_atmosp                  = 1.01325 _d 5
+
+       dic_chlPeriod                      = 0.0 _d 0
+       dic_chlRepCycle                    = DIC_forcingPeriod
+       dic_chlStartTime                   = UNSET_RL
+       dic_chlStartDate1                  = 0
+       dic_chlStartDate2                  = 0
+       dic_chl_exfremo_intercept          = 0.0 _d 0
+       dic_chl_exfremo_slope              = 0.0 _d 0
+       dic_chlMask                        = 'c'
+       dic_inscal_chl                     = 1. _d 0
+
+       dic_SSTPeriod                      = 0.0 _d 0
+       dic_SSTRepCycle                    = DIC_forcingPeriod
+       dic_SSTStartTime                   = UNSET_RL
+       dic_SSTStartDate1                  = 0
+       dic_SSTStartDate2                  = 0
+       dic_SST_exfremo_intercept          = 0.0 _d 0
+       dic_SST_exfremo_slope              = 0.0 _d 0
+       dic_SSTMask                        = 'c'
+       dic_inscal_SST                     = 1. _d 0
+
+       dic_SSSPeriod                      = 0.0 _d 0
+       dic_SSSRepCycle                    = DIC_forcingPeriod
+       dic_SSSStartTime                   = UNSET_RL
+       dic_SSSStartDate1                  = 0
+       dic_SSSStartDate2                  = 0
+       dic_SSS_exfremo_intercept          = 0.0 _d 0
+       dic_SSS_exfremo_slope              = 0.0 _d 0
+       dic_SSSMask                        = 'c'
+       dic_inscal_SSS                     = 1. _d 0
+
+C     If useEXF=F, s/r exf_readparms is not called and exf-parameters
+C     are not initialiased properly. The following few exf-related
+C     parameters need to have a defined value to be used in s/r
+C     exf_set_fld.
+       dic_exf_iprec           = 32
+       dic_useExfYearlyFields  = .FALSE.
+       dic_twoDigitYear        = .FALSE.
+       dic_exf_debugLev        = debugLevel
+
+       IF ( .NOT. useEXF ) THEN
+        repeatPeriod       = DIC_forcingPeriod
+        exf_iprec          = dic_exf_iprec
+        useExfYearlyFields = dic_useExfYearlyFields
+        twoDigitYear       = dic_twoDigitYear
+        exf_debugLev       = dic_exf_debugLev
+       ENDIF
+
+#  ifdef USE_EXF_INTERPOLATION
+
+       IF ( .NOT. useEXF ) THEN
+C     This is done in s/r exf_init_interp only if useEXF=T
+# ifdef ALLOW_EXCH2
+        inp_gNx = exch2_mydNx(1)
+        inp_gNy = exch2_mydNy(1)
+# else /* ALLOW_EXCH2 */
+        inp_gNx = Nx
+        inp_gNy = Ny
+# endif /* ALLOW_EXCH2 */
+
+        inp_lon0 = xgOrigin + delX(1)*halfRL
+        inp_lat0 = ygOrigin + delY(1)*halfRL
+
+        inp_dLon = delX(1)
+        DO j=1,MAX_LAT_INC
+         IF (j.LT.inp_gNy) THEN
+          inp_dLat(j) = (delY(j) + delY(j+1))*halfRL
+         ELSE
+          inp_dLat(j) = 0.
+         ENDIF
+        ENDDO
+       ENDIF
+
+       Silicate_lon0              = inp_lon0
+       Silicate_lat0              = inp_lat0
+       Silicate_nlon              = inp_gNx
+       Silicate_nlat              = inp_gNy
+       Silicate_lon_inc           = inp_dLon
+       Silicate_interpMethod      = 1
+
+       SilicateDeep_lon0          = inp_lon0
+       SilicateDeep_lat0          = inp_lat0
+       SilicateDeep_nlon          = inp_gNx
+       SilicateDeep_nlat          = inp_gNy
+       SilicateDeep_lon_inc       = inp_dLon
+       SilicateDeep_interpMethod  = 1
+       SilicateDeep_nzin          = UNSET_I
+       DO j = 1, MAX_LEV_IN
+         SilicateDeep_dzin(j)     = UNSET_RL
+       ENDDO
+
+       par_lon0                   = inp_lon0
+       par_lat0                   = inp_lat0
+       par_nlon                   = inp_gNx
+       par_nlat                   = inp_gNy
+       par_lon_inc                = inp_dLon
+       par_interpMethod           = 1
+
+       iron_lon0                  = inp_lon0
+       iron_lat0                  = inp_lat0
+       iron_nlon                  = inp_gNx
+       iron_nlat                  = inp_gNy
+       iron_lon_inc               = inp_dLon
+       iron_interpMethod          = 1
+
+       atmospCO2_lat0               = inp_lat0
+       atmospCO2_lon0               = inp_lon0
+       atmospCO2_nlon               = inp_gNx
+       atmospCO2_nlat               = inp_gNy
+       atmospCO2_lon_inc            = inp_dLon
+       atmospCO2_interpMethod       = 1
+
+       wind_lon0                  = inp_lon0
+       wind_lat0                  = inp_lat0
+       wind_nlon                  = inp_gNx
+       wind_nlat                  = inp_gNy
+       wind_lon_inc               = inp_dLon
+       wind_interpMethod          = 1
+
+       ice_lon0                   = inp_lon0
+       ice_lat0                   = inp_lat0
+       ice_nlon                   = inp_gNx
+       ice_nlat                   = inp_gNy
+       ice_lon_inc                = inp_dLon
+       ice_interpMethod           = 1
+
+       atmosp_lat0                 = inp_lat0
+       atmosp_nlon                 = inp_gNx
+       atmosp_nlat                 = inp_gNy
+       atmosp_lon_inc              = inp_dLon
+       atmosp_interpMethod         = 1
+
+       chl_lat0                    = inp_lat0
+       chl_nlon                    = inp_gNx
+       chl_nlat                    = inp_gNy
+       chl_lon_inc                 = inp_dLon
+       chl_interpMethod            = 1
+
+       SST_lat0                    = inp_lat0
+       SST_nlon                    = inp_gNx
+       SST_nlat                    = inp_gNy
+       SST_lon_inc                 = inp_dLon
+       SST_interpMethod            = 1
+
+       SSS_lat0                    = inp_lat0
+       SSS_nlon                    = inp_gNx
+       SSS_nlat                    = inp_gNy
+       SSS_lon_inc                 = inp_dLon
+       SSS_interpMethod            = 1
+
+       DO j=1,MAX_LAT_INC
+        Silicate_lat_inc(j)        = inp_dLat(j)
+        SilicateDeep_lat_inc(j)    = inp_dLat(j)
+        par_lat_inc(j)             = inp_dLat(j)
+        iron_lat_inc(j)            = inp_dLat(j)
+        atmospCO2_lat_inc(j)         = inp_dLat(j)
+        wind_lat_inc(j)            = inp_dLat(j)
+        ice_lat_inc(j)             = inp_dLat(j)
+        atmosp_lat_inc(j)          = inp_dLat(j)
+        chl_lat_inc(j)             = inp_dLat(j)
+        SST_lat_inc(j)             = inp_dLat(j)
+        SSS_lat_inc(j)             = inp_dLat(j)
+       ENDDO
+
+       dic_exf_output_interp = .FALSE.
+
+       IF ( .NOT. useEXF ) THEN
+        exf_output_interp   = dic_exf_output_interp
+       ENDIF
+#  endif /* USE_EXF_INTERPOLATION */
+C     dic_useEXF
+      ENDIF
+# endif /* ALLOW_EXF */
+
 C-    derive other parameters:
 
 C-    set parameter default values
@@ -542,8 +965,8 @@ C- namelist DIC_FORCING
        CALL WRITE_0D_C( DIC_silicaFile, -1,INDEX_NONE,
      & 'DIC_silicaFile=','  /* File name of surface silica */')
       IF ( useCalciteSaturation ) THEN
-       CALL WRITE_0D_C( DIC_deepSilicaFile, -1,INDEX_NONE,
-     & 'DIC_deepSilicaFile=','  /* File name of 3d silica field */')
+       CALL WRITE_0D_C( DIC_silicaDeepFile, -1,INDEX_NONE,
+     & 'DIC_silicaDeepFile=','  /* File name of 3d silica field */')
       ENDIF
        CALL WRITE_0D_C( DIC_iceFile, -1, INDEX_NONE, 'DIC_iceFile =',
      & '  /* File name of seaice fraction */')
@@ -571,6 +994,378 @@ C- namelist DIC_FORCING
      &  ' /* Atmospheric pCO2 to be read in data.dic */')
 
 C---+----1----+----2----+----3----+----4----+----5----+----6----+----7-|--+----|
+#ifdef ALLOW_EXF
+      IF ( dic_useEXF ) THEN
+C--   Print general parameters:
+      WRITE(msgBuf,'(A)') ' dic_useEXF general parameters:'
+      CALL PRINT_MESSAGE( msgBuf, standardMessageUnit,
+     &                    SQUEEZE_RIGHT , myThid )
+      WRITE(msgBuf,'(A)') ' '
+      CALL PRINT_MESSAGE( msgBuf, standardMessageUnit,
+     &                    SQUEEZE_RIGHT , myThid )
+#ifdef USE_EXF_INTERPOLATION
+      WRITE(msgBuf,'(A)')
+     &'// USE_EXF_INTERPOLATION:              defined'
+      CALL PRINT_MESSAGE( msgBuf, standardMessageUnit,
+     &                    SQUEEZE_RIGHT , myThid)
+#else
+      WRITE(msgBuf,'(A)')
+     &'// USE_EXF_INTERPOLATION:          NOT defined'
+      CALL PRINT_MESSAGE( msgBuf, standardMessageUnit,
+     &                    SQUEEZE_RIGHT , myThid)
+#endif
+C--   For each data set used the summary prints the calendar data
+C     and the corresponding file from which the data will be read.
+      prtBlkLn = .FALSE.
+      addBlkLn = .TRUE.
+
+C--   dic wind speed
+      IF ( dic_WindFile .NE. ' ' ) THEN
+       CALL EXF_FLD_SUMMARY( 'wind speed',
+     I      dic_windfile, 
+     I      dic_windRepCycle, 
+     I      dic_windperiod,
+     I      dic_windStartTime, 
+     I      useExfYearlyFields,
+     I      addBlkLn, 
+     I      myThid )
+#ifdef USE_EXF_INTERPOLATION
+       CALL EXF_PRINT_INTERP( 'dicWind',
+     &  wind_lon0, 
+     I      wind_lon_inc, 
+     I      wind_lat0, 
+     I      wind_lat_inc,
+     &  wind_nlon, 
+     I      wind_nlat, 
+     I      wind_interpMethod, 
+     I      myThid )
+#endif
+       prtBlkLn = .TRUE.
+      ENDIF
+
+C--   dic atmospheric pressure
+      IF ( dic_atmospFile .NE. ' ' ) THEN
+       CALL EXF_FLD_SUMMARY( 'atmospheric pressure',
+     I      dic_atmospfile, 
+     I      dic_atmospRepCycle, 
+     I      dic_atmospperiod,
+     I      dic_atmospStartTime, 
+     I      useExfYearlyFields, 
+     I      addBlkLn, 
+     I      myThid )
+#ifdef USE_EXF_INTERPOLATION
+       CALL EXF_PRINT_INTERP( 'dicAtmosP',
+     &      atmosp_lon0, 
+     &      atmosp_lon_inc, 
+     &      atmosp_lat0, 
+     &      atmosp_lat_inc,
+     &      atmosp_nlon, 
+     &      atmosp_nlat, 
+     &      atmosp_interpMethod, 
+     &      myThid )
+#endif
+       prtBlkLn = .TRUE.
+      ENDIF 
+
+C--   dic surface silica
+      IF ( dic_SilicaFile .NE. ' ' ) THEN
+       CALL EXF_FLD_SUMMARY( 'surface silica',
+     I      dic_SilicaFile, 
+     I      dic_SilicaSurfRepCycle, 
+     I      dic_SilicaSurfperiod,
+     I      dic_SilicaSurfStartTime, 
+     I      useExfYearlyFields, 
+     I      addBlkLn, 
+     I      myThid )
+#ifdef USE_EXF_INTERPOLATION
+       CALL EXF_PRINT_INTERP( 'dicSilicaSurf',
+     I      silicaSurf_lon0, 
+     I      silicaSurf_lon_inc, 
+     I      silicaSurf_lat0, 
+     I      silicaSurf_lat_inc,
+     I      silicaSurf_nlon, 
+     I      silicaSurf_nlat, 
+     I      silicaSurf_interpMethod, 
+     I      myThid )
+#endif
+       prtBlkLn = .TRUE.
+      ENDIF
+
+C--  dic deep silica
+      IF ( dic_SilicaDeepFile .NE. ' ' ) THEN
+       CALL EXF_FLD_SUMMARY( 'deep silica',
+     I      dic_SilicaDeepFile, 
+     I      dic_SilicaDeepRepCycle, 
+     I      dic_SilicaDeepperiod,
+     I      dic_SilicaDeepStartTime, 
+     I      useExfYearlyFields, 
+     I      addBlkLn, 
+     I      myThid )
+#ifdef USE_EXF_INTERPOLATION
+       CALL EXF_PRINT_INTERP( 'dicSilicaDeep',
+     &      silicaDeep_lon0, 
+     &      silicaDeep_lon_inc, 
+     &      silicaDeep_lat0, 
+     &      silicaDeep_lat_inc,
+     &      silicaDeep_nlon, 
+     &      silicaDeep_nlat, 
+     &      silicaDeep_interpMethod, 
+     &      myThid )
+#endif
+       prtBlkLn = .TRUE.
+      ENDIF
+
+C--   dic par
+      IF ( dic_parFile .NE. ' ' ) THEN
+       CALL EXF_FLD_SUMMARY( 'photosynthetically available radiation',
+     I      dic_parFile, 
+     I      dic_parRepCycle, 
+     I      dic_parperiod,
+     I      dic_parStartTime, 
+     I      useExfYearlyFields, 
+     I      addBlkLn, 
+     I      myThid )
+#ifdef USE_EXF_INTERPOLATION
+       CALL EXF_PRINT_INTERP( 'dicPAR',
+     &  par_lon0, 
+     &  par_lon_inc, 
+     &  par_lat0, 
+     &  par_lat_inc,
+     &  par_nlon, 
+     &  par_nlat, 
+     &  par_interpMethod, 
+     &  myThid )
+#endif
+       prtBlkLn = .TRUE.
+      ENDIF
+
+C--   dic iron forcing
+      IF ( dic_ironFile .NE. ' ' ) THEN
+       CALL EXF_FLD_SUMMARY( 'aeolian iron flux',
+     I      dic_ironFile, 
+     I      dic_ironRepCycle, 
+     I      dic_ironperiod,
+     I      dic_ironStartTime, 
+     I      useExfYearlyFields, 
+     I      addBlkLn, 
+     I      myThid )
+#ifdef USE_EXF_INTERPOLATION
+       CALL EXF_PRINT_INTERP( 'InputFe',
+     &  iron_lon0, 
+     &  iron_lon_inc, 
+     &  iron_lat0, 
+     &  iron_lat_inc,
+     &  iron_nlon, 
+     &  iron_nlat, 
+     &  iron_interpMethod, 
+     &  myThid )
+#endif
+       prtBlkLn = .TRUE.
+      ENDIF
+
+C--   dic atmospheric CO2 forcing
+      IF ( dic_atmospCO2File .NE. ' ' ) THEN
+       CALL EXF_FLD_SUMMARY( 'atmospheric CO2',
+     I      dic_atmospCO2File, 
+     I      dic_atmospCO2RepCycle, 
+     I      dic_atmospCO2period,
+     I      dic_atmospCO2StartTime, 
+     I      useExfYearlyFields, 
+     I      addBlkLn, 
+     I      myThid)
+#ifdef USE_EXF_INTERPOLATION
+       CALL EXF_PRINT_INTERP( 'dicAtmosCO2',
+     &  atmospCO2_lon0, 
+     &  atmospCO2_lon_inc, 
+     &  atmospCO2_lat0, 
+     &  atmospCO2_lat_inc,
+     &  atmospCO2_nlon, 
+     &  atmospCO2_nlat, 
+     &  atmospCO2_interpMethod, 
+     &  myThid )
+#endif
+       prtBlkLn = .TRUE.
+      ENDIF
+
+C--  dic sea ice forcing
+      IF ( dic_iceFile .NE. ' ' ) THEN
+       CALL EXF_FLD_SUMMARY( 'sea ice fraction',
+     I      dic_iceFile, 
+     I      dic_iceRepCycle, 
+     I      dic_iceperiod,
+     I      dic_iceStartTime, 
+     I      useExfYearlyFields, 
+     I      addBlkLn, 
+     I      myThid ) 
+#ifdef USE_EXF_INTERPOLATION
+       CALL EXF_PRINT_INTERP( 'dicIce',
+     &  ice_lon0, 
+     &  ice_lon_inc, 
+     &  ice_lat0, 
+     &  ice_lat_inc,
+     &  ice_nlon, 
+     &  ice_nlat, 
+     &  ice_interpMethod, 
+     &  myThid )
+#endif
+       prtBlkLn = .TRUE.
+      ENDIF
+
+C-- dic chlorophyll forcing
+      IF ( dic_chlaFile .NE. ' ' ) THEN
+       CALL EXF_FLD_SUMMARY( 'chlorophyll',
+     I      dic_chlaFile, 
+     I      dic_chlRepCycle, 
+     I      dic_chlperiod,
+     I      dic_chlStartTime, 
+     I      useExfYearlyFields, 
+     I      addBlkLn, 
+     I      myThid )
+#ifdef USE_EXF_INTERPOLATION
+       CALL EXF_PRINT_INTERP( 'dicChl',
+     &  chl_lon0, 
+     &  chl_lon_inc, 
+     &  chl_lat0, 
+     &  chl_lat_inc,
+     &  chl_nlon, 
+     &  chl_nlat, 
+     &  chl_interpMethod, 
+     &  myThid )
+#endif
+       prtBlkLn = .TRUE.
+      ENDIF
+
+C-- dic SST forcing
+      IF ( dic_SSTFile .NE. ' ' ) THEN
+       CALL EXF_FLD_SUMMARY( 'carbon chem sea surface temperature',
+     I      dic_SSTFile, 
+     I      dic_SSTRepCycle, 
+     I      dic_SSTperiod,
+     I      dic_SSTStartTime, 
+     I      useExfYearlyFields, 
+     I      addBlkLn, 
+     I      myThid )
+#ifdef USE_EXF_INTERPOLATION
+       CALL EXF_PRINT_INTERP( 'dicSST',
+     &  SST_lon0, 
+     &  SST_lon_inc, 
+     &  SST_lat0, 
+     &  SST_lat_inc,
+     &  SST_nlon, 
+     &  SST_nlat, 
+     &  SST_interpMethod, 
+     &  myThid )
+#endif
+       prtBlkLn = .TRUE.
+      ENDIF
+
+C-- dic SSS forcing
+      IF ( dic_SSSFile .NE. ' ' ) THEN
+       CALL EXF_FLD_SUMMARY( 'carbon chem sea surface salinity',
+     I      dic_SSSFile, 
+     I      dic_SSSRepCycle, 
+     I      dic_SSSperiod,
+     I      dic_SSSStartTime, 
+     I      useExfYearlyFields, 
+     I      addBlkLn, 
+     I      myThid )
+#ifdef USE_EXF_INTERPOLATION
+       CALL EXF_PRINT_INTERP( 'dicSSS',
+     &  SSS_lon0, 
+     &  SSS_lon_inc, 
+     &  SSS_lat0, 
+     &  SSS_lat_inc,
+     &  SSS_nlon, 
+     &  SSS_nlat, 
+     &  SSS_interpMethod, 
+     &  myThid )
+#endif
+       prtBlkLn = .TRUE.
+      ENDIF
+      ENDIF /* dic_useEXF */
+
+C     dic_useEXF and useExfYearlyFields
+      IF ( dic_useEXF .AND. useExfYearlyFields ) THEN
+       IF ( dic_parRepCycle.NE.0. ) THEN
+        WRITE(msgBuf,'(2A)') 'DIC_READPARMS: The use of ',
+     &   'useExfYearlyFields AND dic_parRepCycle',
+     &   'is not implemented'
+        CALL PRINT_ERROR( msgBuf, myThid )
+        errCount = errCount + 1
+       ENDIF
+       IF ( dic_ironRepCycle.NE.0. ) THEN
+        WRITE(msgBuf,'(2A)') 'DIC_READPARMS: The use of ',
+     &   'useExfYearlyFields AND dic_ironRepCycle',
+     &   'is not implemented'
+        CALL PRINT_ERROR( msgBuf, myThid )
+        errCount = errCount + 1
+       ENDIF
+       IF ( dic_SilicaSurfRepCycle.NE.0. ) THEN
+        WRITE(msgBuf,'(2A)') 'DIC_READPARMS: The use of ',
+     &   'useExfYearlyFields AND dic_SilicaSurfRepCycle',
+     &   'is not implemented'
+        CALL PRINT_ERROR( msgBuf, myThid )
+        errCount = errCount + 1
+       ENDIF
+       IF ( dic_SilicaDeepRepCycle.NE.0. ) THEN
+        WRITE(msgBuf,'(2A)') 'DIC_READPARMS: The use of ',
+     &    'useExfYearlyFields AND dic_SilicaDeepRepCycle',
+     &    'is not implemented'
+        CALL PRINT_ERROR( msgBuf, myThid )
+        errCount = errCount + 1
+       ENDIF
+       IF ( dic_atmospCO2RepCycle.NE.0. ) THEN
+        WRITE(msgBuf,'(2A)') 'DIC_READPARMS: The use of ',
+     &   'useExfYearlyFields AND dic_atmospCO2RepCycle',
+     &   'is not implemented'
+        CALL PRINT_ERROR( msgBuf, myThid )
+        errCount = errCount + 1
+       ENDIF
+       IF ( dic_windRepCycle.NE.0. ) THEN
+        WRITE(msgBuf,'(2A)') 'DIC_READPARMS: The use of ',
+     &   'useExfYearlyFields AND dic_windRepCycle',
+     &   'is not implemented'
+        CALL PRINT_ERROR( msgBuf, myThid )
+        errCount = errCount + 1
+       ENDIF
+       IF ( dic_iceRepCycle.NE.0. ) THEN
+        WRITE(msgBuf,'(2A)') 'DIC_READPARMS: The use of ',
+     &   'useExfYearlyFields AND dic_iceRepCycle',
+     &   'is not implemented'
+        CALL PRINT_ERROR( msgBuf, myThid )
+        errCount = errCount + 1
+       ENDIF
+       IF ( dic_atmospRepCycle.NE.0. ) THEN
+        WRITE(msgBuf,'(2A)') 'DIC_READPARMS: The use of ',
+     &   'useExfYearlyFields AND dic_atmospRepCycle',
+     &   'is not implemented'
+        CALL PRINT_ERROR( msgBuf, myThid )
+        errCount = errCount + 1
+       ENDIF
+       IF ( dic_chlRepCycle.NE.0. ) THEN
+        WRITE(msgBuf,'(2A)') 'DIC_READPARMS: The use of ',
+     &    'useExfYearlyFields AND dic_chlRepCycle',
+     &    'is not implemented'
+        CALL PRINT_ERROR( msgBuf, myThid )
+        errCount = errCount + 1
+       ENDIF
+       IF ( dic_SSTRepCycle.NE.0. ) THEN
+        WRITE(msgBuf,'(2A)') 'DIC_READPARMS: The use of ',
+     &    'useExfYearlyFields AND dic_SSTRepCycle',
+     &    'is not implemented'
+        CALL PRINT_ERROR( msgBuf, myThid )
+        errCount = errCount + 1
+       ENDIF
+       IF ( dic_SSSRepCycle.NE.0. ) THEN
+        WRITE(msgBuf,'(2A)') 'DIC_READPARMS: The use of ',
+     &    'useExfYearlyFields AND dic_SSSRepCycle',
+     &    'is not implemented'
+        CALL PRINT_ERROR( msgBuf, myThid )
+        errCount = errCount + 1
+       ENDIF
+      ENDIF
+C     useEXF and useExfYearlyFields
+#endif /* ALLOW_EXF */
 
       IF ( dic_int1.EQ.0 .AND. dic_pCO2.NE.278. _d -6 ) THEN
         WRITE(msgBuf,'(A)')
@@ -652,12 +1447,12 @@ C Issue an error and stop for invalid selectCalciteDissolution
         CALL PRINT_ERROR( msgBuf, myThid )
         errCount = errCount + 1
       ENDIF
-C Issue a soft message if a deepSilicaFile is supplied
+C Issue a soft message if a silicaDeepFile is supplied
 C    but will not be used because useCalciteSaturation is FALSE
-      IF ( DIC_deepSilicaFile .NE. ' ' .AND.
+      IF ( DIC_silicaDeepFile .NE. ' ' .AND.
      &                        .NOT. useCalciteSaturation ) THEN
         WRITE(msgBuf,'(2A)') 'DIC_READPARMS: ',
-     &    'to use: DIC_deepSilicaFile (3d silicate input)'
+     &    'to use: DIC_silicaDeepFile (3d silicate input)'
          CALL PRINT_MESSAGE(msgBuf,iUnit,SQUEEZE_RIGHT,myThid)
         WRITE(msgBuf,'(2A)') 'DIC_READPARMS: ',
      &    'needs: "useCalciteSaturation=.TRUE." in "data.dic"'
@@ -676,11 +1471,11 @@ C    DIC_CALCITE_SATURATION code is not compiled
         errCount = errCount + 1
       ENDIF
 
-C Issue an error and stop if deepSilicaFile is supplied but
+C Issue an error and stop if silicaDeepFile is supplied but
 C    DIC_CALCITE_SATURATION code is not compiled
-      IF ( DIC_deepSilicaFile .NE. ' '  ) THEN
+      IF ( DIC_silicaDeepFile .NE. ' '  ) THEN
         WRITE(msgBuf,'(2A)') 'DIC_READPARMS: ',
-     &    'to use: DIC_deepSilicaFile (3d silicate input)'
+     &    'to use: DIC_silicaDeepFile (3d silicate input)'
         CALL PRINT_ERROR( msgBuf, myThid )
         WRITE(msgBuf,'(2A)') 'DIC_READPARMS: ',
      &    'needs: "#define DIC_CALCITE_SAT" in "DIC_OPTIONS.h"'
@@ -688,6 +1483,56 @@ C    DIC_CALCITE_SATURATION code is not compiled
         errCount = errCount + 1
       ENDIF
 #endif /* DIC_CALCITE_SAT */
+
+#ifndef ALLOW_FE
+      IF ( dic_ironFile .NE. ' ' ) THEN
+        WRITE(msgBuf,'(2A)') 'DIC_READPARMS: ',
+     &    'to use: dic_ironFile (aeolian iron flux input)'
+        CALL PRINT_ERROR( msgBuf, myThid )
+        WRITE(msgBuf,'(2A)') 'DIC_READPARMS: ',
+     &    'needs: "#define ALLOW_FE" in "DIC_OPTIONS.h"'
+        CALL PRINT_ERROR( msgBuf, myThid )
+        errCount = errCount + 1
+      ENDIF
+#endif /* ALLOW_FE */
+
+#ifndef READ_PAR
+      IF ( dic_parfile .NE. ' ' ) THEN
+        WRITE(msgBuf,'(2A)') 'DIC_READPARMS: ',
+     &    'to use: dic_parFile (PAR input)'
+        CALL PRINT_ERROR( msgBuf, myThid )
+        WRITE(msgBuf,'(2A)') 'DIC_READPARMS: ',
+     &    'needs: "#define READ_PAR" in "DIC_OPTIONS.h"'
+        CALL PRINT_ERROR( msgBuf, myThid )
+        errCount = errCount + 1
+      ENDIF
+#endif /* READ_PAR */
+
+#ifndef LIGHT_CHL
+      IF ( dic_chlaFile .NE. ' ' ) THEN
+        WRITE(msgBuf,'(2A)') 'DIC_READPARMS: ',
+     &    'to use: dic_chlaFile (chlorophyll input)'
+        CALL PRINT_ERROR( msgBuf, myThid )
+        WRITE(msgBuf,'(2A)') 'DIC_READPARMS: ',
+     &    'needs: "#define LIGHT_CHL" in "DIC_OPTIONS.h"'
+        CALL PRINT_ERROR( msgBuf, myThid )
+        errCount = errCount + 1
+      ENDIF
+#endif /* LIGHT_CHL */
+
+C USE_PLOAD invokes atmospheric presure from ATMOSPHERIC model
+C  If USE_PLOAD is not defined, then dic_atmospFile may be used
+#ifdef USE_PLOAD
+      IF ( dic_atmospFile .NE. ' ' ) THEN
+        WRITE(msgBuf,'(2A)') 'DIC_READPARMS: ',
+     &    'to use: dic_atmospFile (atmospheric pressure input)'
+        CALL PRINT_ERROR( msgBuf, myThid )
+        WRITE(msgBuf,'(2A)') 'DIC_READPARMS: ',
+     &    'needs: "#undef USE_PLOAD" in "DIC_OPTIONS.h"'
+        CALL PRINT_ERROR( msgBuf, myThid )
+        errCount = errCount + 1
+      ENDIF
+#endif /* USE_PLOAD */
 
       IF ( errCount.GE.1 ) THEN
         WRITE(msgBuf,'(A,I3,A)')

--- a/pkg/dic/dic_surfforcing.F
+++ b/pkg/dic/dic_surfforcing.F
@@ -103,7 +103,7 @@ cQQQQ check ptracer numbers
           surfphos(i,j) = PTR_PO4(i,j,klev)*maskC(i,j,kLev,bi,bj)
 #endif
 #else /* DIC_BIOTIC */
-          surfalk(i,j)  = 2.366595 _d 0 * salt(i,j,kLev,bi,bj)/gsm_s
+          surfalk(i,j)  = 2.366595 _d 0 * dicSSS(i,j,bi,bj)/gsm_s
      &                  * maskC(i,j,kLev,bi,bj)
           surfphos(i,j) = 5.1225 _d -4 * maskC(i,j,kLev,bi,bj)
 #endif /* DIC_BIOTIC */
@@ -111,14 +111,14 @@ C for non-interactive Si
           surfsi(i,j)   = silicaSurf(i,j,bi,bj)*maskC(i,j,kLev,bi,bj)
 #ifdef DIC_BOUNDS
           surftemp(i,j) = MAX( -4. _d 0,
-     &                         MIN( 50. _d 0, theta(i,j,kLev,bi,bj) ) )
+     &                         MIN( 50. _d 0, dicSST(i,j,bi,bj) ) )
           surfsalt(i,j) = MAX( 4. _d 0,
-     &                         MIN( 50. _d 0, salt(i,j,kLev,bi,bj) ) )
+     &                         MIN( 50. _d 0, dicSSS(i,j,bi,bj) ) )
           surfdic(i,j)  = MAX( 0.4 _d 0,
      &                         MIN( 10. _d 0, PTR_CO2(i,j,kLev) ) )
 #else
-          surftemp(i,j) = theta(i,j,kLev,bi,bj)
-          surfsalt(i,j) = salt(i,j,kLev,bi,bj)
+          surftemp(i,j) = dicSST(i,j,bi,bj)
+          surfsalt(i,j) = dicSSS(i,j,bi,bj)
           surfdic(i,j)  = PTR_CO2(i,j,kLev)
 #endif
         ENDDO
@@ -227,10 +227,10 @@ CADJ STORE pCO2(:,:,bi,bj) = comlev1_bibj, key = tkey, kind = isbyte
 C calculate SCHMIDT NO. for CO2
             SchmidtNoDIC(i,j) =
      &            sca1
-     &          + sca2 * theta(i,j,kLev,bi,bj)
-     &          + sca3 * theta(i,j,kLev,bi,bj)*theta(i,j,kLev,bi,bj)
-     &          + sca4 * theta(i,j,kLev,bi,bj)*theta(i,j,kLev,bi,bj)
-     &                *theta(i,j,kLev,bi,bj)
+     &          + sca2 * dicSST(i,j,bi,bj)
+     &          + sca3 * dicSST(i,j,bi,bj)*dicSST(i,j,bi,bj)
+     &          + sca4 * dicSST(i,j,bi,bj)*dicSST(i,j,bi,bj)
+     &                 * dicSST(i,j,bi,bj)
 C make sure Schmidt number is not negative (will happen if temp>39C)
             SchmidtNoDIC(i,j) = MAX( 1.0 _d -2, SchmidtNoDIC(i,j) )
 

--- a/pkg/dic/dic_surfforcing_init.F
+++ b/pkg/dic/dic_surfforcing_init.F
@@ -103,7 +103,7 @@ C determine inorganic carbon chem coefficients
      &                    * maskC(i,j,kLev,bi,bj)
 #endif
 #else /* DIC_BIOTIC */
-            surfalk(i,j)  = 2.366595 _d 0 *salt(i,j,kLev,bi,bj)/35. _d 0
+            surfalk(i,j)  = 2.366595 _d 0 *dicSSS(i,j,bi,bj)/35. _d 0
      &                    * maskC(i,j,kLev,bi,bj)
             surfphos(i,j) = 5.1225 _d -4 * maskC(i,j,kLev,bi,bj)
 #endif /* DIC_BIOTIC */
@@ -111,14 +111,14 @@ C for non-interactive Si
             surfsi(i,j)   = silicaSurf(i,j,bi,bj)*maskC(i,j,kLev,bi,bj)
 #ifdef DIC_BOUNDS
             surftemp(i,j) = MAX( -4. _d 0,
-     &                      MIN( 50. _d 0, theta(i,j,kLev,bi,bj) ) )
+     &                      MIN( 50. _d 0, dicSST(i,j,bi,bj) ) )
             surfsalt(i,j) = MAX( 4. _d 0,
-     &                      MIN( 50. _d 0, salt(i,j,kLev,bi,bj) ) )
+     &                      MIN( 50. _d 0, dicSSS(i,j,bi,bj) ) )
             surfdic(i,j)  = MAX( 0.4 _d 0,
      &                      MIN( 10. _d 0, PTRACER(i,j,kLev,bi,bj,1) ) )
 #else
-            surftemp(i,j) = theta(i,j,kLev,bi,bj)
-            surfsalt(i,j) = salt(i,j,kLev,bi,bj)
+            surftemp(i,j) = dicSST(i,j,bi,bj)
+            surfsalt(i,j) = dicSSS(i,j,bi,bj)
             surfdic(i,j)  = PTRACER(i,j,kLev,bi,bj,1)
      &                    * maskC(i,j,kLev,bi,bj)
 #endif
@@ -228,8 +228,8 @@ cC$TAF STORE surfalk(i,j), surfphos(i,j), surfsi(i,j)   = dic_surf
           jprt = MIN(20,sNy)
           WRITE(msgBuf,'(4(A,F9.6),2(A,F11.8),A,F9.6)')
      &        ' first guess pH=', pH(iprt,jprt,bi,bj),
-     &        ', Temp=',theta(iprt,jprt,1,bi,bj),
-     &        ', Salt=',salt(iprt,jprt,1,bi,bj),
+     &        ', Temp=',dicSST(iprt,jprt,bi,bj),
+     &        ', Salt=',dicSSS(iprt,jprt,bi,bj),
      &        ', DIC=', surfdic(iprt,jprt),
      &        ', PO4=', surfphos(iprt,jprt),
      &        ', SiT=', surfsi(iprt,jprt),

--- a/pkg/dic/o2_surfforcing.F
+++ b/pkg/dic/o2_surfforcing.F
@@ -66,8 +66,8 @@ C calculate SCHMIDT NO. for O2
         DO j=jmin,jmax
           DO i=imin,imax
             IF (maskC(i,j,k,bi,bj).NE.0.) THEN
-              ttemp = theta(i,j,k,bi,bj)
-              stemp = salt(i,j,k,bi,bj)
+              ttemp = dicSST(i,j,bi,bj)
+              stemp = dicSSS(i,j,bi,bj)
 
               SchmidtNoO2(i,j) =
      &            sox1

--- a/verification/darwin_arm64_gfortran
+++ b/verification/darwin_arm64_gfortran
@@ -1,0 +1,172 @@
+#!/bin/bash
+#
+# tested on MacBook Pro with macOS Monterey
+# uname -a
+# Darwin bkli04m056 21.3.0 Darwin Kernel Version 21.3.0: Wed Jan  5 21:37:58 PST 2022; root:xnu-8019.80.24~20/RELEASE_ARM64_T6000 arm64
+# gcc, gfortran, netcdf/netcdf-fortran, and openmpi obtained from
+# https://www.macports.org
+# sudo port install gcc11
+# sudo port select --set gcc mp-gcc11
+# similar results can be achieved using homebrew
+
+# Note: at the time of creating this file (Mar2022), the
+# gfortran-build of http://hpc.sourceforge.net does not work with
+# testreport (also: cannot compile like the "etime" test and leads to
+# multile warnings at the link step), because the model compiled with
+# this gfortran does not print the last line before the stop statement
+# without an additional flush-statement.
+
+if test "x$MPI" = xtrue ; then
+  CC=mpicc
+  FC=mpif77
+  F90C=mpif90
+  LINK=$F90C
+else
+  CC=/opt/homebrew/bin/gcc-16
+  FC=/opt/homebrew/bin/gfortran
+  F90C=/opt/homebrew/bin/gfortran
+  LINK=$F90C
+fi
+
+ABSOLUTE_ROOTDIR=$(cd $(dirname $0) && cd ../ && pwd)
+TAPENADECMD="docker container run --rm -u $(stat -f '%u:%g' ./) \
+ -v \${PWD}:\${PWD} -v ${ABSOLUTE_ROOTDIR}:${ABSOLUTE_ROOTDIR} -w \${PWD} \
+ registry.gitlab.inria.fr/tapenade/tapenade"
+
+FC_NAMEMANGLE="#define FC_NAMEMANGLE(X) X ## _"
+S64='$(TOOLSDIR)/set64bitConst.sh'
+DEFINES='-DWORDLENGTH=4 -DNML_TERMINATOR'
+CPP='/usr/bin/cpp -traditional -P'
+GET_FC_VERSION="--version"
+EXTENDED_SRC_FLAG='-ffixed-line-length-132'
+OMPFLAG='-fopenmp'
+
+#MAKEDEPEND=tools_xmakedepend
+
+NOOPTFLAGS='-O0'
+NOOPTFILES=''
+
+FFLAGS="$FFLAGS -fconvert=big-endian"
+# needed for big objects (e.g., to compile and run TAF AD of
+# global_ocean.cs32x15), but requires larger stack sizes (set with
+# ulimit -s) in other cases, so we leave this commented out:
+# man gfortran: Allow indirect recursion by forcing all local arrays
+#               to be allocated on the stack.
+#FFLAGS="$FFLAGS -frecursive"
+#- might want to use '-fdefault-real-8' for fizhi pkg:
+#FFLAGS="$FFLAGS -fdefault-real-8 -fdefault-double-8"
+
+#- for setting specific options, check compiler version:
+fcVers=`$FC -dumpversion | head -n 1 | sed 's/^[^0-9]* //;s/\..*$//'`
+if ! [[ $fcVers =~ ^[0-9]+$ ]] ; then
+  echo "    un-recognized Compiler-version '$fcVers' ; ignored (-> set to 0)" ; fcVers=0 ;
+else echo "    get Compiler-version: '$fcVers'" ; fi
+
+if [ $fcVers -ge 10 ] ; then
+  FFLAGS="$FFLAGS -fallow-argument-mismatch"
+fi
+
+#  For IEEE, use the "-ffloat-store" option
+if test "x$IEEE" = x ; then
+    FFLAGS="$FFLAGS -Wunused -Wuninitialized"
+    FOPTIM='-O3 -ftree-vectorize -funroll-loops'
+    NOOPTFLAGS='-O2 -funroll-loops'
+#    NOOPTFILES='gad_c4_adv_x.F gad_u3_adv_x.F'
+else
+    FFLAGS="$FFLAGS -Wall"
+    if test "x$DEVEL" = x ; then  #- no optimisation + IEEE :
+	FOPTIM='-O0'
+    else                          #- development/check options:
+	FOPTIM='-O0 -g -fbounds-check'
+	FOPTIM="$FOPTIM -ffpe-trap=invalid,zero,overflow -finit-real=inf"
+    fi
+fi
+
+# add undocumented flag -x f95 to force gfortran to interpret any
+# suffix as a f90-freeformat file, add -ffree-form to suppress the
+# associated warning
+F90FLAGS="$FFLAGS -x f95 -ffree-form"
+F90OPTIM=$FOPTIM
+
+INCLUDEDIRS=''
+INCLUDES=''
+LIBS=''
+
+if [ "x$NETCDF_ROOT" != x ] ; then
+    INCLUDEDIR="${NETCDF_ROOT}/include"
+    INCLUDES="-I${NETCDF_ROOT}/include"
+    LIBDIR="${NETCDF_ROOT}/lib"
+    LIBS="-L${NETCDF_ROOT}/lib -lnetcdf -lcurl"
+elif [ "x$NETCDF_HOME" != x ]; then
+    INCLUDEDIR="${NETCDF_HOME}/include"
+    INCLUDES="-I${NETCDF_HOME}/include"
+    LIBDIR="${NETCDF_HOME}/lib"
+    LIBS="-L${NETCDF_HOME}/lib"
+elif [ "x$NETCDF_INC" != x -a "x$NETCDF_LIB" != x ]; then
+    NETCDF_INC=`echo $NETCDF_INC | sed 's/-I//g'`
+    NETCDF_LIB=`echo $NETCDF_LIB | sed 's/-L//g'`
+    INCLUDEDIR="${NETCDF_INC}"
+    INCLUDES="-I${NETCDF_INC}"
+    LIBDIR="${NETCDF_LIB}"
+    LIBS="-L${NETCDF_LIB}"
+elif [ "x$NETCDF_INCDIR" != x -a "x$NETCDF_LIBDIR" != x ]; then
+    INCLUDEDIR="${NETCDF_INCDIR}"
+    INCLUDES="-I${NETCDF_INCDIR}"
+    LIBDIR="${NETCDF_LIBDIR}"
+    LIBS="-L${NETCDF_LIBDIR}"
+elif [[ -n $( nf-config --includedir ) && ($? == 0) ]] ; then
+    # NETCDF env variables are not set, trying nf-config instead
+    INCLUDEDIR=$( nf-config --includedir )
+    INCLUDES="-I$INCLUDEDIR"
+    # although this would is the best option, the resulting -arch arm64 is
+    # not supported by gfortran from hpc.sourceforge.net
+    LIBS=$( nf-config --flibs )
+    # if FC=gfortran from hpc.sourceforge.net, then this works:
+    # LIBDIR=$( nf-config --prefix )/lib
+    # LIBS="-L$LIBDIR"
+elif test -d /opt/local/include ; then
+    # if netcdf has been install by macports, this is where it is:
+    INCLUDES='-I/opt/local/include'
+    LIBS='-L/opt/local/lib'
+elif test -d /usr/include/netcdf-3 ; then
+    INCLUDES='-I/usr/include/netcdf-3'
+    LIBS='-L/usr/lib/netcdf-3 -L/usr/lib64/netcdf-3'
+elif test -d /usr/include/netcdf ; then
+    INCLUDES='-I/usr/include/netcdf'
+elif test -d /usr/local/netcdf ; then
+    INCLUDES='-I/usr/local/netcdf/include'
+    LIBS='-L/usr/local/netcdf/lib'
+elif test -d /usr/local/include/netcdf.inc ; then
+    INCLUDES='-I/usr/local/include'
+    LIBS='-L/usr/local/lib64'
+elif test -d /usr/include/netcdf.inc ; then
+    INCLUDES='-I/usr/include'
+    LIBS='-L/usr/lib64'
+fi
+
+if [ -n "$MPI_HOME" -a -z "$MPI_INC_DIR" ]; then
+    MPI_INC_DIR="$MPI_HOME/include"
+fi
+
+if [ "x$MPI" = xtrue ] ; then
+   if [ -z "$MPI_INC_DIR" ] ; then
+      # MPI env variables are not set, trying pkg-config insteal
+      # this works for macport installs of openmpi
+      if [[ -n $( pkg-config --cflags-only-I mpich ) && ($? == 0) ]] ; then
+         MPI_INC_DIR=$(pkg-config --cflags-only-I mpich | awk '{ print $1 }' | sed -e "s/-I//" )
+      else
+         echo MPI_HOME is not set and pkg-config not available, aborting
+         exit 1
+      fi
+   fi
+   if [ -n "$MPI_INC_DIR" ] ; then
+      # only fill this if we can find MPI, otherwise triggers netcdf error
+      INCLUDES+=" -I$MPI_INC_DIR"
+      INCLUDEDIRS+=" $MPI_INC_DIR"
+      #- used for parallel (MPI) DIVA
+      MPIINCLUDEDIR="$MPI_INC_DIR"
+   else
+      echo could not set MPI_INC_DIR, aborting
+      exit 1
+   fi
+fi

--- a/verification/tutorial_global_oce_biogeo/code/EXF_OPTIONS.h
+++ b/verification/tutorial_global_oce_biogeo/code/EXF_OPTIONS.h
@@ -1,0 +1,240 @@
+#ifndef EXF_OPTIONS_H
+#define EXF_OPTIONS_H
+#include "PACKAGES_CONFIG.h"
+#include "CPP_OPTIONS.h"
+
+CBOP
+C !ROUTINE: EXF_OPTIONS.h
+C !INTERFACE:
+C #include "EXF_OPTIONS.h"
+
+C !DESCRIPTION:
+C *==================================================================*
+C | CPP options file for EXternal Forcing (EXF) package:
+C | Control which optional features to compile in this package code.
+C *==================================================================*
+CEOP
+
+#ifdef ALLOW_EXF
+#ifdef ECCO_CPPOPTIONS_H
+
+C-- When multi-package option-file ECCO_CPPOPTIONS.h is used (directly included
+C    in CPP_OPTIONS.h), this option file is left empty since all options that
+C   are specific to this package are assumed to be set in ECCO_CPPOPTIONS.h
+
+#else /* ndef ECCO_CPPOPTIONS_H */
+
+C-- Package-specific Options & Macros go here
+
+C   --------------------
+C   pkg/exf CPP options:
+C   (see also table below on how to combine options)
+
+C   > ( EXF_VERBOSE ) < replaced with run-time integer parameter "exf_debugLev"
+C
+C   >>> ALLOW_ATM_WIND <<<
+C       If defined, set default value of run-time param. "useAtmWind" to True.
+C       If useAtmWind=True, read-in and use wind vector (uwind/vwind)
+C       to compute surface wind stress.
+C
+C   >>> ALLOW_ATM_TEMP <<<
+C       This is the main EXF option controlling air-sea buoyancy fluxes:
+C      If undefined, net heat flux (Qnet) and net fresh water flux
+C       (EmP or EmPmR) are set according to hfluxfile & sfluxfile setting.
+C      If defined, net heat flux and net fresh water flux are computed
+C       from sum of various components (radiative SW,LW + turbulent heat
+C       fluxes SH,LH ; Evap, Precip and optionally RunOff) thus ignoring
+C       hfluxfile & sfluxfile.
+C      In addition, it allows to read-in from files atmospheric temperature
+C       and specific humidity, net radiative fluxes, and precip.
+C       Also enable to read-in Evap (if EXF_READ_EVAP is defined) or
+C       turbulent heat fluxes (if ALLOW_READ_TURBFLUXES is defined).
+C
+C   >>> ALLOW_DOWNWARD_RADIATION <<<
+C       If defined, downward long-wave and short-wave radiation
+C       can be read-in form files to compute net lwflux and swflux.
+C
+C   >>> ALLOW_ZENITHANGLE <<<
+C       If defined, ocean albedo varies with the zenith angle, and
+C       incoming fluxes at the top of the atmosphere are computed
+C
+C   >>> ALLOW_BULKFORMULAE <<<
+C       Allows the use of bulk formulae in order to estimate
+C       turbulent fluxes (Sensible,Latent,Evap) at the ocean surface.
+C
+C   >>> EXF_CALC_ATMRHO
+C       Calculate the local air density as function of temp, humidity
+C       and pressure
+C
+C   >>> EXF_READ_EVAP <<<
+C       If defined, evaporation field is read-in from file;
+C     Note: if ALLOW_BULKFORMULAE is defined, evap that is computed from
+C       atmospheric state will be replaced by read-in evap but computed
+C       latent heat flux will be kept.
+C
+C   >>> ALLOW_READ_TURBFLUXES <<<
+C       If defined, turbulent heat fluxes (sensible and latent) can be read-in
+C       from files (but overwritten if ALLOW_BULKFORMULAE is defined).
+C
+C   >>> ALLOW_RUNOFF <<<
+C       If defined, river and glacier runoff can be read-in from files.
+C
+C   >>> ALLOW_SALTFLX <<<
+C       If defined, upward salt flux can be read-in from files.
+C
+C   >>> ALLOW_RUNOFTEMP <<<
+C       If defined, river and glacier runoff temperature
+C       can be read-in from files.
+C
+C   >>> ATMOSPHERIC_LOADING <<<
+C       If defined, atmospheric pressure can be read-in from files.
+C   WARNING: this flag is set (define/undef) in CPP_OPTIONS.h
+C            and cannot be changed here (in EXF_OPTIONS.h)
+C
+C   >>> EXF_ALLOW_TIDES <<<
+C       If defined, 2-D tidal geopotential can be read-in from files
+C
+C   >>> EXF_SEAICE_FRACTION <<<
+C       If defined, seaice fraction can be read-in from files (areaMaskFile)
+C
+C   >>> ALLOW_CLIMSST_RELAXATION <<<
+C       Allow the relaxation of surface level temperature to SST (climatology),
+C       e.g. the Reynolds climatology.
+C
+C   >>> ALLOW_CLIMSSS_RELAXATION <<<
+C       Allow the relaxation of surface level salinity to SSS (climatology),
+C       e.g. the Levitus climatology.
+C
+C   >>> USE_EXF_INTERPOLATION <<<
+C       Allows to provide input field on arbitrary Lat-Lon input grid
+C       (as specified in EXF_NML_04) and to interpolate to model grid.
+C     Note: default is to interpolate unless {FLD}_interpMethod is set to 0
+C
+C   ====================================================================
+C
+C    The following CPP options:
+C       ALLOW_ATM_WIND / useAtmWind (useWind)
+C       ALLOW_ATM_TEMP               (TEMP)
+C       ALLOW_DOWNWARD_RADIATION     (DOWN)
+C       ALLOW_BULKFORMULAE           (BULK)
+C       EXF_READ_EVAP                (EVAP)
+C       ALLOW_READ_TURBFLUXES        (TURB)
+C
+C    permit all ocean-model forcing configurations listed in the 2 tables below.
+C    The first configuration (A1,B1) is the flux-forced, ocean model.
+C    Configurations A2,B3 and A2,B4 use pkg/exf open-water bulk formulae
+C    to compute, from atmospheric variables, the missing surface fluxes.
+C    The forcing fields in the rightmost column are defined in EXF_FIELDS.h
+C    (ocean-model surface forcing field are defined in model/inc/FFIELDS.h)
+C
+C    (A) Surface momentum flux: [model: fu,fv ; exf: ustress,vstress]
+C
+C    # |useWind|        actions
+C   ---|-------|-------------------------------------------------------------
+C   (1)| False | Read-in ustress,vstress (if needed in B, compute wind-speed)
+C      |       |
+C   (2)| True  | Read-in uwind,vwind ; compute wind stress ustress,vstress.
+C   ---|-------|-------------------------------------------------------------
+C
+C    (B) Surface buoyancy flux:
+C        [ net heat flux: Qnet (exf: hflux), net short-wave: Qsw (exf: swflux)
+C          fresh-water flux: EmPmR (exf: sflux) and saltFlux (exf: saltflx) ]
+C
+C    # |TEMP |DOWN |BULK |EVAP |TURB |            actions
+C   ---|-----|-----|-----|-----|-----|-------------------------------------
+C   (1)|  -  |  -  |  -  |  -  |  -  | Read-in hflux, swflux and sflux.
+C      |     |     |     |     |     |
+C   (2)|  -  | def |  -  |  -  |  -  | Read-in hflux, swdown and sflux.
+C      |     |     |     |     |     | Compute swflux.
+C      |     |     |     |     |     |
+C   (3)| def | def | def |  -  |  -  | Read-in atemp, aqh, swdown, lwdown,
+C      |     |     |     |     |     |  precip, and runoff.
+C      |     |     |     |     |     | Compute hflux, swflux and sflux.
+C      |     |     |     |     |     |
+C   (4)| def |  -  | def |  -  |  -  | Read-in atemp, aqh, swflux, lwflux,
+C      |     |     |     |     |     |  precip, and runoff.
+C      |     |     |     |     |     | Compute hflux and sflux.
+C      |     |     |     |     |     |
+C   (5)| def | def |  -  | def | def | Read-in hs, hl, swdown, lwdown,
+C      |     |     |     |     |     |  evap, precip and runoff.
+C      |     |     |     |     |     | Compute hflux, swflux and sflux.
+C      |     |     |     |     |     |
+C   (6)| def |  -  |  -  | def | def | Read-in hs, hl, swflux, lwflux,
+C      |     |     |     |     |     |  evap, precip and runoff.
+C      |     |     |     |     |     | Compute  hflux and sflux.
+C
+C   =======================================================================
+
+C-  Bulk formulae related flags.
+#undef ALLOW_ATM_TEMP
+#undef ALLOW_ATM_WIND
+#undef ALLOW_DOWNWARD_RADIATION
+#ifdef ALLOW_ATM_TEMP
+C Note: To use ALLOW_BULKFORMULAE or EXF_READ_EVAP, needs #define ALLOW_ATM_TEMP
+# define ALLOW_BULKFORMULAE
+C use Large and Yeager (2004) modification to Large and Pond bulk formulae
+# undef  ALLOW_BULK_LARGEYEAGER04
+C use drag formulation of Large and Yeager (2009), Climate Dyn., 33, pp 341-364
+# undef  ALLOW_DRAG_LARGEYEAGER09
+# undef  EXF_READ_EVAP
+# ifndef ALLOW_BULKFORMULAE
+C  Note: To use ALLOW_READ_TURBFLUXES, ALLOW_ATM_TEMP needs to
+C        be defined but ALLOW_BULKFORMULAE needs to be undef
+#  define ALLOW_READ_TURBFLUXES
+# endif
+#endif /* ALLOW_ATM_TEMP */
+
+C-  Other forcing fields
+#undef  ALLOW_RUNOFF
+#undef  ALLOW_RUNOFTEMP
+#undef  ALLOW_SALTFLX
+
+#if (defined (ALLOW_BULKFORMULAE) && defined (ATMOSPHERIC_LOADING))
+C Note: To use EXF_CALC_ATMRHO, both ALLOW_BULKFORMULAE
+C       and ATMOSPHERIC_LOADING need to be defined
+# undef EXF_CALC_ATMRHO
+#endif
+
+C-  Zenith Angle/Albedo related flags.
+#ifdef ALLOW_DOWNWARD_RADIATION
+# undef ALLOW_ZENITHANGLE
+#endif
+
+C-  Use ocean_emissivity*lwdown in lwFlux. This flag should be defined
+C   unless to reproduce old results (obtained with inconsistent old code)
+#ifdef ALLOW_DOWNWARD_RADIATION
+# define EXF_LWDOWN_WITH_EMISSIVITY
+#endif
+
+C-  Surface level relaxation to prescribed fields (e.g., climatologies)
+#define ALLOW_CLIMSST_RELAXATION
+#define ALLOW_CLIMSSS_RELAXATION
+
+C-  Allows to read-in (2-d) tidal geopotential forcing
+#undef EXF_ALLOW_TIDES
+
+C-  Allows to read-in seaice fraction from files (areaMaskFile)
+#undef EXF_SEAICE_FRACTION
+
+C-  Use spatial interpolation to interpolate
+C   forcing files from input grid to model grid.
+#undef USE_EXF_INTERPOLATION
+C   for interpolated vector fields, rotate towards model-grid axis
+C   using old rotation formulae (instead of grid-angles)
+#undef EXF_USE_OLD_VEC_ROTATION
+C   for interpolation around N & S pole, use the old formulation
+C   (no pole symmetry, single vector-comp interp, reset to 0 zonal-comp @ N.pole)
+#undef EXF_USE_OLD_INTERP_POLE
+
+#define EXF_INTERP_USE_DYNALLOC
+#if ( defined USE_EXF_INTERPOLATION && defined EXF_INTERP_USE_DYNALLOC && defined USING_THREADS )
+# define EXF_IREAD_USE_GLOBAL_POINTER
+#endif
+
+C-  Not recommended (not tested nor maintained) and un-documented Options:
+#undef ALLOW_BULK_OFFLINE
+#undef ALLOW_CLIMSTRESS_RELAXATION
+
+#endif /* ndef ECCO_CPPOPTIONS_H */
+#endif /* ALLOW_EXF */
+#endif /* EXF_OPTIONS_H */

--- a/verification/tutorial_global_oce_biogeo/code/GCHEM_OPTIONS.h
+++ b/verification/tutorial_global_oce_biogeo/code/GCHEM_OPTIONS.h
@@ -1,0 +1,31 @@
+#ifndef GCHEM_OPTIONS_H
+#define GCHEM_OPTIONS_H
+#include "PACKAGES_CONFIG.h"
+#include "CPP_OPTIONS.h"
+
+CBOP
+C    !ROUTINE: GCHEM_OPTIONS.h
+C    !INTERFACE:
+
+C    !DESCRIPTION:
+C options for biogeochemistry package
+CEOP
+
+#ifdef ALLOW_GCHEM
+
+C o Allow separated update of Geo-Chemistry and Advect-Diff
+C    (fractional time-stepping type) for some gchem tracers
+#define GCHEM_SEPARATE_FORCING
+
+C o Allow single update of some gchem tracers, adding Geo-Chemistry
+C    tendency to Advect-Diff tendency
+#undef GCHEM_ADD2TR_TENDENCY
+#ifdef ALLOW_CFC
+# define GCHEM_ADD2TR_TENDENCY
+#endif
+#ifdef ALLOW_SPOIL
+# define GCHEM_ADD2TR_TENDENCY
+#endif
+
+#endif /* ALLOW_GCHEM */
+#endif /* GCHEM_OPTIONS_H */

--- a/verification/tutorial_global_oce_biogeo/code/packages.conf
+++ b/verification/tutorial_global_oce_biogeo/code/packages.conf
@@ -2,6 +2,8 @@
 gfd
 cd_code
 gmredi
+cal
+exf
 ptracers
 gchem
 dic

--- a/verification/tutorial_global_oce_biogeo/input.exf/data
+++ b/verification/tutorial_global_oce_biogeo/input.exf/data
@@ -1,0 +1,87 @@
+# ====================
+# | Model parameters |
+# ====================
+#
+# Continuous equation parameters
+ &PARM01
+ tRef=15*20.,
+ sRef=15*35.,
+ viscA4=0.,
+ viscAh=2.E5,
+ diffKhT=0.E3,
+ diffKhS=0.E3,
+ viscAz=1.E-3,
+#diffKzT=3.E-5,
+#diffKzS=3.E-5,
+ diffKrBL79surf= 3.E-5,
+ diffKrBL79deep= 13.E-5,
+ diffKrBL79Ho  = -2000.,
+ diffKrBL79scl = 150.,
+ gravity=9.81,
+ rhoConst=1035.,
+ rhoConstFresh=1000.,
+ implicitFreeSurface=.TRUE.,
+ eosType='JMD95Z',
+ implicitDiffusion=.TRUE.,
+ implicitViscosity=.TRUE.,
+ ivdc_kappa=100.,
+ tempAdvScheme       = 2,
+ saltAdvScheme       = 2,
+ allowFreezing=.TRUE.,
+# turn on looped cells
+ hFacMin=.1,
+ hFacMindz=50.,
+ useCDscheme=.TRUE.,
+ &
+
+# Elliptic solver parameters
+ &PARM02
+ cg2dMaxIters=1000,
+ cg2dTargetResidual=1.E-13,
+ &
+
+# Time stepping parameters
+ &PARM03
+ nIter0=5184000,
+ nTimeSteps = 4,
+ deltaTmom  = 900.,
+ tauCD =     321428.,
+ deltaTtracer= 43200.,
+ deltaTClock = 43200.,
+ abEps = 0.1,
+ pChkptFreq = 216000.,
+ chkptFreq  = 216000.,
+ dumpFreq   = 216000.,
+ monitorFreq= 86400.,
+# tauThetaClimRelax = 5184000.,
+# tauSaltClimRelax  = 7776000.,
+# periodicExternalForcing=.TRUE.,
+# externForcingPeriod=2592000.,
+# externForcingCycle=31104000.,
+ monitorFreq= 1.,
+ &
+
+# Gridding parameters
+ &PARM04
+ usingSphericalPolarGrid=.TRUE.,
+ delZ=  50., 70.,  100., 140., 190.,
+       240., 290., 340., 390., 440.,
+       490., 540., 590., 640., 690.,
+ ygOrigin=-90.,
+ delX=128*2.8125,
+ delY=64*2.8125,
+ &
+
+# Input datasets
+ &PARM05
+ bathyFile=      'bathy.bin',
+ hydrogThetaFile='lev_clim_temp.bin',
+ hydrogSaltFile= 'lev_clim_salt.bin',
+# zonalWindFile=  'tren_taux.bin',
+# meridWindFile=  'tren_tauy.bin',
+# thetaClimFile=  'lev_monthly_temp.bin',
+# saltClimFile=   'lev_monthly_salt.bin',
+# surfQnetFile=   'shi_qnet.bin',
+# EmPmRFile=      'shi_empmr_year.bin',
+ the_run_name=   'Tutorial Biogeo',
+ &

--- a/verification/tutorial_global_oce_biogeo/input.exf/data
+++ b/verification/tutorial_global_oce_biogeo/input.exf/data
@@ -28,6 +28,7 @@
  tempAdvScheme       = 2,
  saltAdvScheme       = 2,
  allowFreezing=.TRUE.,
+ debugLevel = 4,
 # turn on looped cells
  hFacMin=.1,
  hFacMindz=50.,

--- a/verification/tutorial_global_oce_biogeo/input.exf/data.cal
+++ b/verification/tutorial_global_oce_biogeo/input.exf/data.cal
@@ -1,0 +1,9 @@
+# *******************
+# Calendar Parameters
+# *******************
+ &CAL_NML
+# TheCalendar='gregorian',
+ TheCalendar='model',
+ startDate_1=00000101,
+ startDate_2= 000000,
+ &

--- a/verification/tutorial_global_oce_biogeo/input.exf/data.dic
+++ b/verification/tutorial_global_oce_biogeo/input.exf/data.dic
@@ -1,0 +1,27 @@
+# DIC parameters 
+ &ABIOTIC_PARMS
+ &
+
+ &BIOTIC_PARMS
+  alphaUniform = 0.97e-10,
+  rainRatioUniform = 5.e-2,
+  KRemin = 0.95,
+ &
+
+ &DIC_FORCING
+  DIC_useEXF          = .TRUE.,
+#
+  DIC_atmospco2_const = 278.e-6,
+  DIC_wind_const      = 5.,
+  DIC_atmosp_const     = 1.01325e5,
+  DIC_par_const       = 140.0,
+  DIC_silicaSurf_const= 7.6838e-3,
+#
+  DIC_iceFile         ='fice.bin',
+  DIC_windFile        ='tren_speed.bin',
+  DIC_silicaFile      ='sillev1.bin',
+#
+  DIC_windPeriod      = -12.,
+  DIC_icePeriod       = -12.,
+  DIC_SilicaSurfPeriod= -12.,
+ &

--- a/verification/tutorial_global_oce_biogeo/input.exf/data.exf
+++ b/verification/tutorial_global_oce_biogeo/input.exf/data.exf
@@ -1,0 +1,44 @@
+# *********************
+# External Forcing Data
+# *********************
+#
+ &EXF_NML_01
+ readStressOnCgrid = .TRUE.,
+ repeatPeriod      = 31104000.,
+# The coldest temperature in 'lev_monthly_temp.bin' is -2.9...degC.
+# avoid clipping of input data to maintain results relative to ../input
+ climtempfreeze    = -3.0,
+#
+ exf_iprec         = 32,
+ exf_yftype        = 'RL',
+ &
+#
+ &EXF_NML_02
+ hfluxfile         = 'shi_qnet.bin',
+ hfluxperiod       = -12.,
+#
+ sfluxfile         = 'shi_empmr_year.bin',
+ sfluxperiod       = -12.,
+#
+ ustressfile       = 'tren_taux.bin',
+ ustressperiod     = -12.,
+#
+ vstressfile       = 'tren_tauy.bin',
+ vstressperiod     = -12.,
+#
+ climsstfile  = 'lev_monthly_temp.bin',
+ climsstperiod     = -12.,
+# 2 months restoring timescale for temperature
+ climsstTauRelax   = 5184000.,
+#
+ climsssfile  = 'lev_monthly_salt.bin',
+ climsssperiod     = -12.,
+# 3 months restoring timescale for salinity
+ climsssTauRelax   = 7776000.,
+ &
+#
+ &EXF_NML_03
+ &
+#
+ &EXF_NML_04
+ &

--- a/verification/tutorial_global_oce_biogeo/input.exf/data.pkg
+++ b/verification/tutorial_global_oce_biogeo/input.exf/data.pkg
@@ -1,8 +1,8 @@
 # Packages
  &PACKAGES
+ useCAL=.TRUE.,
+ useEXF=.TRUE.,
  useGMRedi=.TRUE.,
- useCAL=.FALSE.,
- useEXF=.FALSE., 
  usePTRACERS=.TRUE.,
  useGCHEM=.TRUE.,
 #useMNC=.TRUE.,

--- a/verification/tutorial_global_oce_biogeo/input.nodicexf/data
+++ b/verification/tutorial_global_oce_biogeo/input.nodicexf/data
@@ -1,0 +1,87 @@
+# ====================
+# | Model parameters |
+# ====================
+#
+# Continuous equation parameters
+ &PARM01
+ tRef=15*20.,
+ sRef=15*35.,
+ viscA4=0.,
+ viscAh=2.E5,
+ diffKhT=0.E3,
+ diffKhS=0.E3,
+ viscAz=1.E-3,
+#diffKzT=3.E-5,
+#diffKzS=3.E-5,
+ diffKrBL79surf= 3.E-5,
+ diffKrBL79deep= 13.E-5,
+ diffKrBL79Ho  = -2000.,
+ diffKrBL79scl = 150.,
+ gravity=9.81,
+ rhoConst=1035.,
+ rhoConstFresh=1000.,
+ implicitFreeSurface=.TRUE.,
+ eosType='JMD95Z',
+ implicitDiffusion=.TRUE.,
+ implicitViscosity=.TRUE.,
+ ivdc_kappa=100.,
+ tempAdvScheme       = 2,
+ saltAdvScheme       = 2,
+ allowFreezing=.TRUE.,
+# turn on looped cells
+ hFacMin=.1,
+ hFacMindz=50.,
+ useCDscheme=.TRUE.,
+ &
+
+# Elliptic solver parameters
+ &PARM02
+ cg2dMaxIters=1000,
+ cg2dTargetResidual=1.E-13,
+ &
+
+# Time stepping parameters
+ &PARM03
+ nIter0=5184000,
+ nTimeSteps = 4,
+ deltaTmom  = 900.,
+ tauCD =     321428.,
+ deltaTtracer= 43200.,
+ deltaTClock = 43200.,
+ abEps = 0.1,
+ pChkptFreq = 216000.,
+ chkptFreq  = 216000.,
+ dumpFreq   = 216000.,
+ monitorFreq= 86400.,
+# tauThetaClimRelax = 5184000.,
+# tauSaltClimRelax  = 7776000.,
+# periodicExternalForcing=.TRUE.,
+# externForcingPeriod=2592000.,
+# externForcingCycle=31104000.,
+ monitorFreq= 1.,
+ &
+
+# Gridding parameters
+ &PARM04
+ usingSphericalPolarGrid=.TRUE.,
+ delZ=  50., 70.,  100., 140., 190.,
+       240., 290., 340., 390., 440.,
+       490., 540., 590., 640., 690.,
+ ygOrigin=-90.,
+ delX=128*2.8125,
+ delY=64*2.8125,
+ &
+
+# Input datasets
+ &PARM05
+ bathyFile=      'bathy.bin',
+ hydrogThetaFile='lev_clim_temp.bin',
+ hydrogSaltFile= 'lev_clim_salt.bin',
+# zonalWindFile=  'tren_taux.bin',
+# meridWindFile=  'tren_tauy.bin',
+# thetaClimFile=  'lev_monthly_temp.bin',
+# saltClimFile=   'lev_monthly_salt.bin',
+# surfQnetFile=   'shi_qnet.bin',
+# EmPmRFile=      'shi_empmr_year.bin',
+ the_run_name=   'Tutorial Biogeo',
+ &

--- a/verification/tutorial_global_oce_biogeo/input.nodicexf/data.cal
+++ b/verification/tutorial_global_oce_biogeo/input.nodicexf/data.cal
@@ -1,0 +1,9 @@
+# *******************
+# Calendar Parameters
+# *******************
+ &CAL_NML
+# TheCalendar='gregorian',
+ TheCalendar='model',
+ startDate_1=00000101,
+ startDate_2= 000000,
+ &

--- a/verification/tutorial_global_oce_biogeo/input.nodicexf/data.dic
+++ b/verification/tutorial_global_oce_biogeo/input.nodicexf/data.dic
@@ -9,13 +9,14 @@
  &
 
  &DIC_FORCING
-  DIC_useEXF          = .TRUE.,
+# use pkg/exf for physics but not bgc
+  DIC_useEXF          = .FALSE.,
+# Since externForcingPeriod and externForcingCycle will be 0
+#   have to provide a ForcingPeriod and ForcingCycle.
+  DIC_forcingPeriod   = 2592000.,
+  DIC_forcingCycle    = 31104000.,
 #
   DIC_iceFile         ='fice.bin',
   DIC_windFile        ='tren_speed.bin',
   DIC_silicaFile      ='sillev1.bin',
-#
-  DIC_icePeriod       = -12.,
-  DIC_windPeriod      = -12.,
-  DIC_SilicaSurfPeriod= -12.,
  &

--- a/verification/tutorial_global_oce_biogeo/input.nodicexf/data.exf
+++ b/verification/tutorial_global_oce_biogeo/input.nodicexf/data.exf
@@ -1,0 +1,44 @@
+# *********************
+# External Forcing Data
+# *********************
+#
+ &EXF_NML_01
+ readStressOnCgrid = .TRUE.,
+ repeatPeriod      = 31104000.,
+# The coldest temperature in 'lev_monthly_temp.bin' is -2.9...degC.
+# avoid clipping of input data to maintain results relative to ../input
+ climtempfreeze    = -3.0,
+#
+ exf_iprec         = 32,
+ exf_yftype        = 'RL',
+ &
+#
+ &EXF_NML_02
+ hfluxfile         = 'shi_qnet.bin',
+ hfluxperiod       = -12.,
+#
+ sfluxfile         = 'shi_empmr_year.bin',
+ sfluxperiod       = -12.,
+#
+ ustressfile       = 'tren_taux.bin',
+ ustressperiod     = -12.,
+#
+ vstressfile       = 'tren_tauy.bin',
+ vstressperiod     = -12.,
+#
+ climsstfile  = 'lev_monthly_temp.bin',
+ climsstperiod     = -12.,
+# 2 months restoring timescale for temperature
+ climsstTauRelax   = 5184000.,
+#
+ climsssfile  = 'lev_monthly_salt.bin',
+ climsssperiod     = -12.,
+# 3 months restoring timescale for salinity
+ climsssTauRelax   = 7776000.,
+ &
+#
+ &EXF_NML_03
+ &
+#
+ &EXF_NML_04
+ &

--- a/verification/tutorial_global_oce_biogeo/input.nodicexf/data.pkg
+++ b/verification/tutorial_global_oce_biogeo/input.nodicexf/data.pkg
@@ -1,0 +1,10 @@
+# Packages
+ &PACKAGES
+ useCAL=.TRUE.,
+ useEXF=.TRUE.,
+ useGMRedi=.TRUE.,
+ usePTRACERS=.TRUE.,
+ useGCHEM=.TRUE.,
+#useMNC=.TRUE.,
+ useDiagnostics=.TRUE.,
+ &

--- a/verification/tutorial_global_oce_biogeo/input/data
+++ b/verification/tutorial_global_oce_biogeo/input/data
@@ -28,6 +28,7 @@
  tempAdvScheme       = 2,
  saltAdvScheme       = 2,
  allowFreezing=.TRUE.,
+ debugLevel = 4,
 # turn on looped cells
  hFacMin=.1,
  hFacMindz=50.,

--- a/verification/tutorial_global_oce_biogeo/input/eedata
+++ b/verification/tutorial_global_oce_biogeo/input/eedata
@@ -3,6 +3,7 @@
 # nTx - No. threads per process in X
 # nTy - No. threads per process in Y
  &EEPARMS
+ debugMode=.True.,
  nTx=1,
  nTy=1,
  &

--- a/verification/tutorial_global_oce_biogeo/results/output.exf.txt
+++ b/verification/tutorial_global_oce_biogeo/results/output.exf.txt
@@ -1,0 +1,1 @@
+output.txt

--- a/verification/tutorial_global_oce_biogeo/results/output.nodicexf.txt
+++ b/verification/tutorial_global_oce_biogeo/results/output.nodicexf.txt
@@ -1,0 +1,1 @@
+output.txt


### PR DESCRIPTION
## What changes does this PR introduce?
Following on from #876, this P/R introduces `pkg/exf` routines that enable reading in BGC forcing from within `pkg/dic` (wind speed, silica concentration, sea ice cover, aeolian iron forcing, etc.)

## What is the current behaviour? 
Previous routines that use native read calls are kept in place, and used instead if `ALLOW_EXF` is not defined, or `dic_useEXF = .FALSE.`

## Does this PR introduce a breaking change? 
No

## Suggested addition to `tag-index`
Enable pkg/dic to use pkg/exf routines to read in BGC forcing.