### PR TITLE
`pkg/layers`: turn `layers_useThermo` into runtime parameter

### DIFF
--- a/pkg/layers/layers_check.F
+++ b/pkg/layers/layers_check.F
@@ -106,6 +106,14 @@ C-     Check for valid density reference level:
 
       ENDDO
 
+#ifndef LAYERS_THERMODYNAMICS
+      IF ( layers_useThermo ) THEN
+        WRITE(msgBuf,'(2A)') 'LAYERS_CHECK: ',
+     &    'layers_useTherm=T requires LAYERS_THERMODYNAMICS'
+        CALL PRINT_ERROR( msgBuf, myThid )
+        errCount = errCount + 1
+      ENDIF
+#endif
       IF ( layers_useThermo .AND. .NOT. useDiagnostics ) THEN
         WRITE(msgBuf,'(2A)') 'LAYERS_CHECK: ',
      &    'layers-thermodynamics part requires useDiagnostics=T'

--- a/pkg/layers/layers_readparms.F
+++ b/pkg/layers/layers_readparms.F
@@ -40,6 +40,7 @@ C---+----1----+----2----+----3----+----4----+----5----+----6----+----7-|--+----|
       NAMELIST /LAYERS_PARM01/
      &       layers_G, layers_taveFreq, layers_diagFreq,
      &       LAYER_nb, layers_kref, useBOLUS, layers_bolus,
+     &       layers_useThermo,
      &       layers_name, layers_bounds, layers_krho
 
        _BEGIN_MASTER(myThid)


### PR DESCRIPTION
## What changes does this PR introduce?
new feature


## What is the current behaviour? 
in `pkg/layers`, "thermodynamic" layers code is turned on with CPP flag, which sets parameter `layers_useThermo`, see 6th point of issue #987 

## What is the new behaviour 
`layers_useThermo` can now be set in namelist `LAYERS_PARM01` (`data.layers`), but still requires CPP-flag `LAYERS_THERMODYNAMICS` 

## Does this PR introduce a breaking change? 
Nope

## Other information:
- documentation is still missing, to be added in #995

## Suggested addition to `tag-index`
- pkg/layers: turn layers_useThermo into runtime parameter.